### PR TITLE
Fix loop region calculation in SessionClipEditor

### DIFF
--- a/magda/daw/ui/views/SessionClipEditor.cpp
+++ b/magda/daw/ui/views/SessionClipEditor.cpp
@@ -55,16 +55,12 @@ class SessionClipEditor::WaveformDisplay : public juce::Component {
                 double loopEndTime = startTime + loopLengthSeconds;
 
                 if (loopEndTime <= endTime) {
-                    // Calculate loop region bounds
-                    double loopStart = startTime;
-                    double loopEnd = loopEndTime;
+                    // Calculate loop region bounds (loop starts at clip beginning)
                     double visibleDuration = endTime - startTime;
 
-                    int loopStartX = waveformBounds.getX() +
-                                     static_cast<int>((loopStart - startTime) / visibleDuration *
-                                                      waveformBounds.getWidth());
+                    int loopStartX = waveformBounds.getX();
                     int loopEndX = waveformBounds.getX() +
-                                   static_cast<int>((loopEnd - startTime) / visibleDuration *
+                                   static_cast<int>(loopLengthSeconds / visibleDuration *
                                                     waveformBounds.getWidth());
 
                     // Draw loop region overlay


### PR DESCRIPTION
Simplify loop region bounds calculation — the loop always starts at the left edge of the visible waveform (clip beginning), so compute loopStartX directly and derive loopEndX from loopLengthSeconds rather than using redundant intermediate variables.

Fixes #198