### PR TITLE
Tighten refactoring scanner and add Copilot agent guidelines

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,6 +43,34 @@ This document defines code review guidelines for the Magda project, a JUCE/C++ a
 - **Trivial Issues**: Skip commenting on very minor issues that don't affect functionality or maintainability
 - **Pre-existing Issues**: Focus on the code being changed, not unrelated existing code
 
+## Refactoring Guidelines (for Copilot Coding Agent)
+
+When assigned refactoring issues, follow these rules strictly:
+
+### Do NOT
+- **Extract constants from obvious values** — `0.0`, `0.5`, `1.0`, `2.0`, `60.0`, `PI`, pixel padding values (4, 8, 12, 20), font sizes, etc. are not magic numbers. They are clearer inline than as `FULL_RANGE`, `HALF_CYCLE`, `SECONDS_PER_MINUTE`, or `kOuterPadding`.
+- **Split functions under 50 NLOC** — Small functions don't need decomposition regardless of CCN.
+- **Create PRs that only rename magic numbers or extract constants** — This is busywork, not refactoring.
+- **Split one-liner expressions into separate functions** — `return 1.0f - phase;` does not need a `generateReverseSawWave()` wrapper.
+- **Add `using namespace` indirection** — Creating a constants namespace and then `using namespace` in every method adds complexity, not clarity.
+- **Make internal rendering constants public** — Paint parameters, timer intervals, and layout values are private implementation details.
+- **Couple unrelated timers or constants** — Independent components should not share constants just because the values happen to be the same.
+- **Redefine standard constants** — Use `juce::MathConstants<float>::pi`, not a custom `PI` constant.
+
+### DO
+- **Split God Objects** — Classes with 40+ methods or 1000+ lines need structural decomposition into smaller classes with distinct responsibilities.
+- **Extract state machines** — Complex mouse handlers (`mouseDrag`/`mouseUp` with CCN > 20) benefit from strategy/state pattern extraction.
+- **Break up monolithic constructors** — Constructors over 150 NLOC should be split into logical initialization helpers (e.g., `setupControls()`, `setupCallbacks()`, `setupLayout()`).
+- **Decompose functions over 100 NLOC with CCN > 15** — These have genuine structural problems. Split along logical boundaries, not arbitrary line counts.
+- **Focus on structural refactoring** — Move responsibilities to new classes, extract reusable components, simplify inheritance hierarchies.
+
+### Thresholds for Action
+Only refactor when a function meets **both** criteria:
+- CCN > 15 **AND** NLOC > 50
+- OR the file exceeds 1000 lines with clear God Object characteristics (40+ methods, mixed responsibilities)
+
+Files under 300 lines, header files with only declarations, and test files should **never** be refactored.
+
 ## Project-Specific Context
 
 ### Architecture

--- a/.github/workflows/refactoring-scanner.yml
+++ b/.github/workflows/refactoring-scanner.yml
@@ -36,8 +36,16 @@ jobs:
 
     - name: List Code Files
       run: |
-        find magda/ tests/ \( -name "*.cpp" -o -name "*.hpp" -o -name "*.h" \) > file_list.txt
-        echo "Found $(wc -l < file_list.txt) files to analyze"
+        # Only scan .cpp source files over 300 lines — skip headers, tests, and small files
+        find magda/ \( -name "*.cpp" \) > file_candidates.txt
+        > file_list.txt
+        while IFS= read -r file; do
+          LINES=$(wc -l < "$file")
+          if [ "$LINES" -gt 300 ]; then
+            echo "$file" >> file_list.txt
+          fi
+        done < file_candidates.txt
+        echo "Found $(wc -l < file_list.txt) files to analyze (filtered from $(wc -l < file_candidates.txt) candidates)"
 
     - name: Process Each File
       id: analyze_files
@@ -45,98 +53,80 @@ jobs:
         # Initialize summary file
         echo "=== Refactoring Analysis Summary ===" > refactoring-results-summary.txt
         echo "" >> refactoring-results-summary.txt
-        
+
         TOTAL_FILES=$(wc -l < file_list.txt)
         COMPLEX_COUNT=0
         LARGE_FILE_COUNT=0
         COUPLING_COUNT=0
-        
+
         echo "Processing $TOTAL_FILES files..." >> refactoring-results-summary.txt
         echo "" >> refactoring-results-summary.txt
-        
+
         # Process each file
         while IFS= read -r file; do
           echo "Analyzing $file..."
-          
+
           # Create sanitized filename for per-file results
           SAFE_FILENAME=$(echo "$file" | sed 's/[\/\.]/-/g')
           RESULT_FILE="results/refactoring-report-${SAFE_FILENAME}.txt"
-          
+
           echo "=== Analysis Report for: $file ===" > "$RESULT_FILE"
           echo "" >> "$RESULT_FILE"
-          
+
           # 1. Analyze complexity with lizard
           echo "--- Complexity Analysis ---" >> "$RESULT_FILE"
-          LIZARD_OUTPUT=$(lizard "$file" -l cpp -C 10 2>&1 || echo "No high complexity functions found")
+          LIZARD_OUTPUT=$(lizard "$file" -l cpp -C 15 2>&1 || echo "No high complexity functions found")
           echo "$LIZARD_OUTPUT" >> "$RESULT_FILE"
-          
+
           # Check if file has high complexity
           if echo "$LIZARD_OUTPUT" | grep -q "^[[:space:]]*[0-9]"; then
             COMPLEX_COUNT=$((COMPLEX_COUNT + 1))
             echo "⚠️  $file: High complexity detected" >> refactoring-results-summary.txt
           fi
-          
+
           echo "" >> "$RESULT_FILE"
-          
+
           # 2. Check file size
           LINES=$(wc -l < "$file")
           echo "--- File Size ---" >> "$RESULT_FILE"
           echo "Lines of code: $LINES" >> "$RESULT_FILE"
-          
-          if [ "$LINES" -gt 500 ]; then
+
+          if [ "$LINES" -gt 800 ]; then
             LARGE_FILE_COUNT=$((LARGE_FILE_COUNT + 1))
             echo "⚠️  $file: Large file ($LINES lines)" >> refactoring-results-summary.txt
           fi
-          
+
           echo "" >> "$RESULT_FILE"
-          
+
           # 3. Check for tight coupling (internal includes)
           echo "--- Coupling Analysis ---" >> "$RESULT_FILE"
           INTERNAL_INCLUDES=$(grep -c "#include.*magda" "$file" 2>/dev/null || echo "0")
           echo "Internal includes: $INTERNAL_INCLUDES" >> "$RESULT_FILE"
-          
+
           if [ "$INTERNAL_INCLUDES" -gt 10 ]; then
             COUPLING_COUNT=$((COUPLING_COUNT + 1))
             echo "⚠️  $file: High coupling ($INTERNAL_INCLUDES internal includes)" >> refactoring-results-summary.txt
           fi
-          
+
           echo "" >> "$RESULT_FILE"
-          
-          # 4. Check for magic numbers
-          echo "--- Magic Numbers ---" >> "$RESULT_FILE"
-          grep -n "[^a-zA-Z0-9_][0-9]\{2,\}[^a-zA-Z0-9_]" "$file" | \
-            grep -v "\.0\|1000\|2000\|255" | head -10 >> "$RESULT_FILE" || echo "None found" >> "$RESULT_FILE"
-          
-          echo "" >> "$RESULT_FILE"
-          
-          # 5. For header files, check for god objects
-          if [[ "$file" == *.hpp || "$file" == *.h ]]; then
-            echo "--- Class Analysis ---" >> "$RESULT_FILE"
-            CLASS_NAME=$(grep "^class\|^struct" "$file" | head -1 | awk '{print $2}' | sed 's/[:{]//g')
-            if [ -n "$CLASS_NAME" ]; then
-              METHOD_COUNT=$(awk '/^public:/,/^(private:|protected:)/ {if (/^\s*[a-zA-Z_][a-zA-Z0-9_]*\s*\(/) count++} END {print count+0}' "$file")
-              echo "Class: $CLASS_NAME" >> "$RESULT_FILE"
-              echo "Public methods: ~$METHOD_COUNT" >> "$RESULT_FILE"
-              
-              if [ "$METHOD_COUNT" -gt 20 ]; then
-                echo "⚠️  $file ($CLASS_NAME): Potential god object (~$METHOD_COUNT public methods)" >> refactoring-results-summary.txt
-              fi
-            fi
-          fi
-          
+
+          # 4. (Magic number scanning removed — produces too many false positives)
+
+          # 5. (Header-only God Object scanning removed — headers are excluded from file list)
+
           echo "" >> "$RESULT_FILE"
           echo "File: $file processed" >> "$RESULT_FILE"
-          
+
         done < file_list.txt
-        
+
         # Add summary statistics
         echo "" >> refactoring-results-summary.txt
         echo "=== Summary Statistics ===" >> refactoring-results-summary.txt
         echo "Total files analyzed: $TOTAL_FILES" >> refactoring-results-summary.txt
         echo "Files with high complexity: $COMPLEX_COUNT" >> refactoring-results-summary.txt
-        echo "Large files (>500 lines): $LARGE_FILE_COUNT" >> refactoring-results-summary.txt
+        echo "Large files (>800 lines): $LARGE_FILE_COUNT" >> refactoring-results-summary.txt
         echo "Files with tight coupling (>10 includes): $COUPLING_COUNT" >> refactoring-results-summary.txt
-        
+
         # Save metrics for later steps
         echo "complex_count=$COMPLEX_COUNT" >> $GITHUB_OUTPUT
         echo "large_file_count=$LARGE_FILE_COUNT" >> $GITHUB_OUTPUT
@@ -155,28 +145,28 @@ jobs:
         # Truncate summary to 65000 bytes to avoid GitHub API limits
         # Note: This truncates by bytes, not characters, to ensure we stay under the limit
         head -c 65000 refactoring-results-summary.txt > results/summary-truncated.txt || true
-        
+
         # Also copy full summary
         cp refactoring-results-summary.txt results/summary-full.txt
-        
+
         # Create a summary of per-file results
         echo "=== Per-File Analysis Reports ===" > results/file-index.txt
         echo "Individual file reports available in artifacts:" >> results/file-index.txt
         ls -1 results/refactoring-report-*.txt 2>/dev/null | while read -r report; do
           echo "  - $(basename "$report")" >> results/file-index.txt
         done || echo "No per-file reports generated" >> results/file-index.txt
-        
+
         # Create a detailed findings report for GitHub issue (with size limit)
         echo "=== Detailed Per-File Findings ===" > results/detailed-findings.txt
         echo "" >> results/detailed-findings.txt
-        
+
         # Only include files with issues (from the summary)
         grep "⚠️" refactoring-results-summary.txt | while read -r line; do
           # Extract filename from the warning line
           FILE=$(echo "$line" | sed 's/⚠️  \([^:]*\):.*/\1/')
           SAFE_FILENAME=$(echo "$FILE" | sed 's/[\/\.]/-/g')
           REPORT_FILE="results/refactoring-report-${SAFE_FILENAME}.txt"
-          
+
           if [ -f "$REPORT_FILE" ]; then
             echo "<details>" >> results/detailed-findings.txt
             echo "<summary>📄 $FILE</summary>" >> results/detailed-findings.txt
@@ -189,7 +179,7 @@ jobs:
             echo "" >> results/detailed-findings.txt
           fi
         done
-        
+
         # Truncate detailed findings if too large (keep under 60KB for the issue body)
         head -c 60000 results/detailed-findings.txt > results/detailed-findings-truncated.txt || true
 
@@ -217,7 +207,7 @@ jobs:
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Analysis Results" >> $GITHUB_STEP_SUMMARY
         echo "- **Files with high complexity**: ${{ steps.analyze_files.outputs.complex_count }}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Large files (>500 lines)**: ${{ steps.analyze_files.outputs.large_file_count }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Large files (>800 lines)**: ${{ steps.analyze_files.outputs.large_file_count }}" >> $GITHUB_STEP_SUMMARY
         echo "- **Files with tight coupling**: ${{ steps.analyze_files.outputs.coupling_count }}" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Review the full report in workflow artifacts for detailed per-file findings." >> $GITHUB_STEP_SUMMARY

--- a/scripts/create_refactoring_issues.py
+++ b/scripts/create_refactoring_issues.py
@@ -29,7 +29,7 @@ class IssueStats:
     skipped: int = 0
     failed: int = 0
     errors: List[Tuple[str, str]] = None
-    
+
     def __post_init__(self):
         if self.errors is None:
             self.errors = []
@@ -47,12 +47,12 @@ class RateLimitError(GitHubAPIError):
 
 class GitHubIssueCreator:
     """Handle GitHub issue creation with rate limiting and retries."""
-    
-    def __init__(self, token: str, owner: str, repo: str, 
+
+    def __init__(self, token: str, owner: str, repo: str,
                  delay_seconds: float = 2.0, max_retries: int = 3):
         """
         Initialize the issue creator.
-        
+
         Args:
             token: GitHub personal access token
             owner: Repository owner
@@ -73,26 +73,26 @@ class GitHubIssueCreator:
             "User-Agent": f"{owner}/{repo} refactoring-scanner"
         })
         self.stats = IssueStats()
-    
+
     def _sleep(self, seconds: Optional[float] = None):
         """Sleep for the specified duration."""
         delay = seconds if seconds is not None else self.delay_seconds
         if delay > 0:
             print(f"⏳ Waiting {delay:.1f}s before next request...")
             time.sleep(delay)
-    
+
     def _retry_with_backoff(self, func, *args, **kwargs):
         """
         Retry a function with exponential backoff.
-        
+
         Args:
             func: Function to retry
             *args: Positional arguments for the function
             **kwargs: Keyword arguments for the function
-            
+
         Returns:
             The return value of the function
-            
+
         Raises:
             GitHubAPIError: If all retries are exhausted
         """
@@ -116,36 +116,36 @@ class GitHubIssueCreator:
                     time.sleep(delay)
                 else:
                     raise GitHubAPIError(f"Request failed after {self.max_retries} attempts") from e
-    
+
     def _make_request(self, method: str, url: str, **kwargs) -> requests.Response:
         """
         Make an API request with error handling.
-        
+
         Args:
             method: HTTP method (GET, POST, etc.)
             url: URL to request
             **kwargs: Additional arguments for requests
-            
+
         Returns:
             Response object
-            
+
         Raises:
             RateLimitError: If rate limit is hit
             GitHubAPIError: For other API errors
         """
         try:
             response = self.session.request(method, url, **kwargs)
-            
+
             # Check for rate limit errors
             if response.status_code == 429 or response.status_code == 403:
                 error_msg = response.json().get('message', '') if response.headers.get('content-type', '').startswith('application/json') else response.text
                 if 'rate limit' in error_msg.lower() or 'secondary rate limit' in error_msg.lower():
                     raise RateLimitError(f"Rate limit exceeded: {error_msg}")
-            
+
             # Raise for other HTTP errors
             response.raise_for_status()
             return response
-            
+
         except requests.exceptions.HTTPError as e:
             # Check if it's a rate limit error in the exception
             if e.response.status_code in [403, 429]:
@@ -153,21 +153,21 @@ class GitHubIssueCreator:
             raise GitHubAPIError(f"HTTP error: {str(e)}") from e
         except requests.exceptions.RequestException as e:
             raise GitHubAPIError(f"Request error: {str(e)}") from e
-    
+
     def search_existing_issue(self, file_path: str) -> Optional[int]:
         """
         Search for an existing issue for the given file.
-        
+
         Args:
             file_path: Path to the file
-            
+
         Returns:
             Issue number if found, None otherwise
         """
         # Search for issues with the file path in the title
         query = f'repo:{self.owner}/{self.repo} is:issue is:open label:refactoring label:automated in:title "{file_path}"'
         url = f"{self.base_url}/search/issues"
-        
+
         try:
             response = self._retry_with_backoff(
                 self._make_request,
@@ -175,34 +175,34 @@ class GitHubIssueCreator:
                 url,
                 params={"q": query}
             )
-            
+
             data = response.json()
             items = data.get('items', [])
-            
+
             # Filter for exact title match
             issue_title = f"[Refactoring] {file_path}"
             for item in items:
                 if item.get('title') == issue_title:
                     return item.get('number')
-            
+
             return None
-            
+
         except Exception as e:
             print(f"⚠️  Search failed for {file_path}: {str(e)}")
             return None
-    
+
     def create_issue(self, title: str, body: str, labels: List[str]) -> int:
         """
         Create a new GitHub issue.
-        
+
         Args:
             title: Issue title
             body: Issue body
             labels: List of labels
-            
+
         Returns:
             Issue number
-            
+
         Raises:
             GitHubAPIError: If issue creation fails
         """
@@ -212,52 +212,52 @@ class GitHubIssueCreator:
             "body": body,
             "labels": labels
         }
-        
+
         response = self._retry_with_backoff(
             self._make_request,
             "POST",
             url,
             json=data
         )
-        
+
         return response.json().get('number')
-    
+
     def add_comment(self, issue_number: int, body: str):
         """
         Add a comment to an existing issue.
-        
+
         Args:
             issue_number: Issue number
             body: Comment body
-            
+
         Raises:
             GitHubAPIError: If comment creation fails
         """
         url = f"{self.base_url}/repos/{self.owner}/{self.repo}/issues/{issue_number}/comments"
         data = {"body": body}
-        
+
         self._retry_with_backoff(
             self._make_request,
             "POST",
             url,
             json=data
         )
-    
-    def process_file(self, file_path: str, issue_description: str, 
+
+    def process_file(self, file_path: str, issue_description: str,
                      report_content: str) -> bool:
         """
         Process a single file and create or update its issue.
-        
+
         Args:
             file_path: Path to the file
             issue_description: Description of the issue
             report_content: Full report content
-            
+
         Returns:
             True if successful, False otherwise
         """
         print(f"\n📄 Processing: {file_path}")
-        
+
         try:
             # Create issue title and body
             issue_title = f"[Refactoring] {file_path}"
@@ -279,27 +279,23 @@ This issue was automatically created by the refactoring scanner workflow.
 
 ### Recommended Actions
 
-Based on the issue type:
-- **High Complexity**: Break down complex functions (cyclomatic complexity > 10) into smaller, more focused functions
-- **Large File**: Consider splitting file over 500 lines into smaller, focused modules
-- **High Coupling**: Review and reduce files with many internal dependencies (>10 includes)
-- **Magic Numbers**: Replace literal numbers with named constants
-- **God Object**: Consider splitting classes with 20+ methods into smaller, more focused classes
+Focus on **structural** refactoring only:
+- **High Complexity (CCN > 15)**: Extract state machines, split along logical boundaries. Do NOT just extract constants or split one-liners.
+- **Large File (> 800 lines)**: Split God Objects into smaller classes with distinct responsibilities.
+- **High Coupling**: Review and reduce files with many internal dependencies (>10 includes).
+- **Monolithic constructors (> 150 NLOC)**: Split into `setupControls()`, `setupCallbacks()`, `setupLayout()` etc.
 
-### Next Steps
+Do NOT:
+- Extract magic numbers into named constants (e.g., `FULL_RANGE = 1.0f` is worse than `1.0f`)
+- Split functions under 50 NLOC
+- Create PRs that only rename values or add wrapper functions for one-liners
 
-1. Review the detailed analysis above
-2. Plan refactoring approach
-3. Create a branch for the refactoring work
-4. Submit a PR with the improvements
-5. Close this issue when complete
-
-**Note**: This is an automated issue. Feel free to add comments, assign it, or close it if not applicable.
+**Note**: This is an automated issue. Close if not applicable.
 """
-            
+
             # Check if issue already exists
             existing_issue = self.search_existing_issue(file_path)
-            
+
             if existing_issue:
                 # Update existing issue with a comment
                 comment_body = f"""## Updated Analysis - {time.strftime('%Y-%m-%d')}
@@ -314,7 +310,7 @@ Based on the issue type:
 ```
 
 </details>"""
-                
+
                 self.add_comment(existing_issue, comment_body)
                 print(f"✅ Updated existing issue #{existing_issue} for {file_path}")
                 self.stats.updated += 1
@@ -327,21 +323,21 @@ Based on the issue type:
                 )
                 print(f"✅ Created new issue #{issue_number} for {file_path}")
                 self.stats.created += 1
-            
+
             return True
-            
+
         except Exception as e:
             print(f"❌ Failed to process {file_path}: {str(e)}")
             self.stats.failed += 1
             self.stats.errors.append((file_path, str(e)))
-            
+
             # If it's a persistent rate limit, wait longer
             if isinstance(e, (RateLimitError, GitHubAPIError)) and 'rate limit' in str(e).lower():
                 print(f"⏳ Rate limit persists, waiting 30s before continuing...")
                 time.sleep(30)
-            
+
             return False
-    
+
     def print_summary(self):
         """Print a summary of the processing results."""
         print("\n" + "=" * 60)
@@ -352,7 +348,7 @@ Based on the issue type:
         print(f"⚠️  Skipped: {self.stats.skipped}")
         print(f"❌ Failed: {self.stats.failed}")
         print(f"📝 Total: {self.stats.total}")
-        
+
         if self.stats.errors:
             print(f"\n❌ Errors encountered ({len(self.stats.errors)}):")
             for idx, (file_path, error) in enumerate(self.stats.errors, 1):
@@ -363,45 +359,45 @@ Based on the issue type:
 def parse_summary_file(summary_path: str) -> List[Tuple[str, str]]:
     """
     Parse the refactoring summary file to extract files with issues.
-    
+
     Args:
         summary_path: Path to the summary file
-        
+
     Returns:
         List of tuples (file_path, issue_description)
     """
     with open(summary_path, 'r') as f:
         content = f.read()
-    
+
     # Extract lines starting with ⚠️
     warning_pattern = re.compile(r'⚠️\s+([^:]+):\s*(.+)')
     warnings = []
-    
+
     for line in content.split('\n'):
         match = warning_pattern.match(line)
         if match:
             file_path = match.group(1).strip()
             description = match.group(2).strip()
             warnings.append((file_path, description))
-    
+
     return warnings
 
 
 def read_report_file(file_path: str, results_dir: str = "./results") -> Optional[str]:
     """
     Read the detailed report file for a given source file.
-    
+
     Args:
         file_path: Path to the source file
         results_dir: Directory containing the report files
-        
+
     Returns:
         Report content or None if file not found
     """
     # Sanitize filename (must match the shell script sanitization)
     safe_filename = file_path.replace('/', '-').replace('.', '-')
     report_path = os.path.join(results_dir, f"refactoring-report-{safe_filename}.txt")
-    
+
     try:
         with open(report_path, 'r') as f:
             return f.read()
@@ -442,42 +438,42 @@ def main():
         action='store_true',
         help='Dry run mode - do not actually create issues'
     )
-    
+
     args = parser.parse_args()
-    
+
     # Get GitHub credentials from environment
     token = os.environ.get('GITHUB_TOKEN')
     if not token:
         print("❌ Error: GITHUB_TOKEN environment variable not set")
         sys.exit(1)
-    
+
     repo_full = os.environ.get('GITHUB_REPOSITORY')
     if not repo_full:
         print("❌ Error: GITHUB_REPOSITORY environment variable not set")
         sys.exit(1)
-    
+
     try:
         owner, repo = repo_full.split('/')
     except ValueError:
         print(f"❌ Error: Invalid GITHUB_REPOSITORY format: {repo_full}")
         sys.exit(1)
-    
+
     # Parse the summary file
     print(f"📖 Reading summary from: {args.summary}")
     warnings = parse_summary_file(args.summary)
-    
+
     if not warnings:
         print("✅ No files with refactoring opportunities found")
         return
-    
+
     print(f"Found {len(warnings)} files with refactoring opportunities")
-    
+
     if args.dry_run:
         print("\n🔍 DRY RUN MODE - No issues will be created\n")
         for file_path, description in warnings:
             print(f"  - {file_path}: {description}")
         return
-    
+
     # Create the issue creator
     creator = GitHubIssueCreator(
         token=token,
@@ -486,30 +482,30 @@ def main():
         delay_seconds=args.delay,
         max_retries=args.max_retries
     )
-    
+
     creator.stats.total = len(warnings)
-    
+
     # Process each file
     for idx, (file_path, description) in enumerate(warnings, 1):
         print(f"\nProcessing file {idx}/{len(warnings)}...")
-        
+
         # Read the detailed report
         report_content = read_report_file(file_path, args.results_dir)
         if not report_content:
             print(f"⚠️  Skipping {file_path} - no report file found")
             creator.stats.skipped += 1
             continue
-        
+
         # Process the file
         success = creator.process_file(file_path, description, report_content)
-        
+
         # Throttle between files (except for the last one)
         if success and idx < len(warnings):
             creator._sleep()
-    
+
     # Print summary
     creator.print_summary()
-    
+
     # Exit with error code if there were failures
     if creator.stats.failed > 0:
         sys.exit(1)


### PR DESCRIPTION
Scanner: only scan .cpp files over 300 lines in magda/, raise CCN threshold to 15, file size to 800, remove magic number scanning. Copilot instructions: add explicit refactoring rules to prevent constant extraction busywork and one-liner splitting.