### PR TITLE
Clip loop length constant

### DIFF
--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -319,7 +319,7 @@ void ClipManager::setClipLoopEnabled(ClipId clipId, bool enabled) {
 
 void ClipManager::setClipLoopLength(ClipId clipId, double lengthBeats) {
     if (auto* clip = getClip(clipId)) {
-        clip->internalLoopLength = juce::jmax(0.25, lengthBeats);
+        clip->internalLoopLength = juce::jmax(ClipOperations::MIN_LOOP_LENGTH_BEATS, lengthBeats);
         notifyClipPropertyChanged(clipId);
     }
 }

--- a/magda/daw/core/ClipOperations.hpp
+++ b/magda/daw/core/ClipOperations.hpp
@@ -25,6 +25,7 @@ class ClipOperations {
 
     static constexpr double MIN_CLIP_LENGTH = 0.1;
     static constexpr double MIN_SOURCE_LENGTH = 0.1;
+    static constexpr double MIN_LOOP_LENGTH_BEATS = 0.25;
     static constexpr double MIN_STRETCH_FACTOR = 0.25;
     static constexpr double MAX_STRETCH_FACTOR = 4.0;
 


### PR DESCRIPTION
Extract magic number `0.25` to `MIN_LOOP_LENGTH_BEATS` constant to improve readability and maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-799e669c-a3c6-4539-968b-d9182a32c82e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-799e669c-a3c6-4539-968b-d9182a32c82e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small readability refactor that keeps the same minimum loop length behavior while centralizing the value in `ClipOperations`.
> 
> **Overview**
> Replaces the hardcoded minimum loop length clamp (`0.25` beats) in `ClipManager::setClipLoopLength` with a named constant.
> 
> Adds `ClipOperations::MIN_LOOP_LENGTH_BEATS` to centralize the loop-length constraint and improve maintainability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 464cfe3ef0612c368f0968f7ce9fe1c313c71b6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->