### PR TITLE
Extract shared routing sync logic into RoutingSyncHelper (#651)

### DIFF
--- a/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
+++ b/magda/daw/ui/components/mixer/RoutingSyncHelper.hpp
@@ -82,6 +82,7 @@ inline void populateAudioOutputOptions(RoutingSelector* selector, TrackId curren
 
     std::vector<RoutingSelector::RoutingOption> options;
     options.push_back({1, "Master"});
+    options.push_back({2, "None"});
 
     auto& trackManager = TrackManager::getInstance();
     const auto& allTracks = trackManager.getTracks();

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -522,6 +522,9 @@ void TrackHeadersPanel::setupRoutingCallbacks(TrackHeader& header, TrackId track
         if (selectedId == 1) {
             // Master
             TrackManager::getInstance().setTrackAudioOutput(trackId, "master");
+        } else if (selectedId == 2) {
+            // None
+            TrackManager::getInstance().setTrackAudioOutput(trackId, "");
         } else if (selectedId >= 200 && selectedId < 400) {
             // Group or Aux track destination
             auto it = mapping.find(selectedId);

--- a/magda/daw/ui/panels/content/inspector/TrackInspector.cpp
+++ b/magda/daw/ui/panels/content/inspector/TrackInspector.cpp
@@ -679,6 +679,9 @@ void TrackInspector::populateRoutingSelectors() {
         if (selectedId == 1) {
             // Master
             magda::TrackManager::getInstance().setTrackAudioOutput(selectedTrackId_, "master");
+        } else if (selectedId == 2) {
+            // None
+            magda::TrackManager::getInstance().setTrackAudioOutput(selectedTrackId_, "");
         } else if (selectedId >= 200 && selectedId < 400) {
             // Group or Aux track destination
             auto it = outputTrackMapping_.find(selectedId);


### PR DESCRIPTION
Both TrackHeadersPanel and TrackInspector independently implemented ~200 lines of near-identical routing sync logic. Extract into free functions in RoutingSyncHelper.hpp that both panels delegate to.