### PR TITLE
Publish release with artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -437,9 +437,10 @@ jobs:
       with:
         tag_name: v${{ needs.build-macos.outputs.version }}
         name: MAGDA v${{ needs.build-macos.outputs.version }}
-        draft: true
+        draft: false
         prerelease: ${{ contains(needs.build-macos.outputs.version, '-') }}
         generate_release_notes: true
+        fail_on_unmatched_files: true
         files: |
           macos-release/*
           windows-release/*


### PR DESCRIPTION
## Summary
- Change release from draft to published so artifacts are immediately available
- Add `fail_on_unmatched_files: true` to catch missing artifacts early

## Test plan
- Merge and tag `v0.1.0-rc2` to verify release is created with all platform artifacts