### PR TITLE
Skip CI on tag pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [ '**' ]
+    tags-ignore: [ '**' ]
   workflow_dispatch:
     inputs:
       skip-cpp-build:


### PR DESCRIPTION
## Summary
- Add `tags-ignore: ['**']` to CI workflow so tag pushes only trigger the release workflow, not CI

## Test plan
- Next tag push should only trigger release.yml, not ci.yml