### PR TITLE
Fix DMG creation failing on CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,8 +138,7 @@ jobs:
 
         create-dmg \
           --volname "MAGDA" \
-          --window-pos 200 120 \
-          --window-size 600 400 \
+          --sandbox-safe \
           --icon-size 100 \
           --icon "MAGDA.app" 150 190 \
           --app-drop-link 450 190 \


### PR DESCRIPTION
## Summary
- Use `--sandbox-safe` flag in `create-dmg` to skip AppleScript Finder window styling
- Fixes `Can't set statusbar visible of container window` error on headless CI runner
- DMG still gets app + Applications symlink, just without Finder window cosmetics

## Test plan
- [ ] Re-run release workflow and verify DMG is created successfully