### PR TITLE
Fetch notarization log on failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,9 +175,17 @@ jobs:
           --wait 2>&1) || true
         echo "$SUBMIT_OUTPUT"
 
-        # Extract submission ID and check status
-        SUBMISSION_ID=$(echo "$SUBMIT_OUTPUT" | grep "id:" | head -1 | awk '{print $2}')
-        STATUS=$(echo "$SUBMIT_OUTPUT" | grep "status:" | tail -1 | awk '{print $2}')
+        # Extract submission ID and check status (disable pipefail for grep)
+        set +o pipefail
+        SUBMISSION_ID=$(echo "$SUBMIT_OUTPUT" | grep "id:" | head -1 | awk '{print $2}') || true
+        STATUS=$(echo "$SUBMIT_OUTPUT" | grep "status:" | tail -1 | awk '{print $2}') || true
+        set -o pipefail
+
+        if [ -z "$SUBMISSION_ID" ] || [ -z "$STATUS" ]; then
+          echo "Failed to parse notarization output:"
+          echo "$SUBMIT_OUTPUT"
+          exit 1
+        fi
 
         if [ "$STATUS" != "Accepted" ]; then
           echo "Notarization failed with status: $STATUS"


### PR DESCRIPTION
## Summary
- Capture notarization submission output and check status before stapling
- On failure, fetch and print the full notarization log for debugging
- Previous rc4 build failed with `status: Invalid` but gave no details

## Test plan
- [ ] Retag rc4 after merge and verify log is printed if notarization fails