### PR TITLE
Fix bypass overlay not repainting on deactivation

### DIFF
--- a/magda/daw/ui/components/chain/NodeComponent.cpp
+++ b/magda/daw/ui/components/chain/NodeComponent.cpp
@@ -478,6 +478,7 @@ juce::String NodeComponent::getNodeName() const {
 void NodeComponent::setBypassed(bool bypassed) {
     bypassButton_->setToggleState(!bypassed, juce::dontSendNotification);  // Active = not bypassed
     bypassButton_->setActive(!bypassed);
+    repaint();  // Redraw bypass overlay in paintOverChildren
 }
 
 bool NodeComponent::isBypassed() const {


### PR DESCRIPTION
## Summary
- Add `repaint()` call to `NodeComponent::setBypassed()` so the dimming overlay in `paintOverChildren` redraws immediately when a device is toggled on/off

## Test plan
- [ ] Deactivate a device via its power button — should grey out immediately
- [ ] Reactivate — grey overlay should disappear immediately
- [ ] Verify bypass state persists across project save/load