### PR TITLE
Add ccache to Docker build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     cmake \
     ninja-build \
+    ccache \
     pkg-config \
     git \
     python3 \


### PR DESCRIPTION
## Summary
- Add `ccache` to the Dockerfile so the `hendrikmuhs/ccache-action` step works inside the container

## Test plan
- [ ] Docker image builds successfully
- [ ] Linux CI passes with ccache step

Co-authored-by: CM Claude