### PR TITLE
Fix bugs for 0.4.2

### DIFF
--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -658,7 +658,7 @@ set(DAW_HEADERS
     core/AutomationManager.hpp
     # Project serialization
     project/ProjectInfo.hpp
-    project/ProjectSerializer.hpp
+    project/serialization/ProjectSerializer.hpp
     project/ProjectManager.hpp
     # Preset management
     core/PresetManager.hpp

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -8,6 +8,7 @@
 #include "../profiling/PerformanceProfiler.hpp"
 #include "AudioThumbnailManager.hpp"
 #include "MagdaSamplerPlugin.hpp"
+#include "MidiChordEnginePlugin.hpp"
 #include "SessionMonitorPlugin.hpp"
 #include "SidechainTriggerBus.hpp"
 
@@ -289,6 +290,10 @@ void AudioBridge::updateMidiRoutingForSelection() {
                     const auto& device = getDevice(element);
                     if (device.isInstrument)
                         return true;
+                    // Chord Engine needs live MIDI input for real-time detection
+                    if (device.pluginId.containsIgnoreCase(
+                            daw::audio::MidiChordEnginePlugin::xmlTypeName))
+                        return true;
                     for (const auto& mod : device.mods) {
                         if (mod.enabled && mod.triggerMode == LFOTriggerMode::MIDI)
                             return true;
@@ -453,8 +458,6 @@ void AudioBridge::deviceParameterChanged(DeviceId deviceId, int paramIndex, floa
 void AudioBridge::devicePropertyChanged(DeviceId deviceId) {
     // A device property changed (gain, bypass, etc.) - sync to processor
     auto* processor = getDeviceProcessor(deviceId);
-    if (!processor)
-        return;
 
     // Find the DeviceInfo to get updated values
     // Search through all tracks, recursing into racks
@@ -462,7 +465,14 @@ void AudioBridge::devicePropertyChanged(DeviceId deviceId) {
     for (const auto& track : tm.getTracks()) {
         auto* device = findDeviceRecursive(track.chainElements, deviceId);
         if (device) {
-            processor->syncFromDeviceInfo(*device);
+            if (processor) {
+                processor->syncFromDeviceInfo(*device);
+            } else {
+                // For plugins without a processor (e.g. Chord Engine), sync bypass directly
+                auto tePlugin = pluginManager_.getPlugin(deviceId);
+                if (tePlugin)
+                    tePlugin->setEnabled(!device->bypassed);
+            }
 
             // Push gain to the audio-graph atomic so DeviceGainNode picks it up
             deviceMetering_.setGain(deviceId, device->gainValue);

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -177,6 +177,9 @@ void AudioBridge::trackPropertyChanged(int trackId) {
             // Sync audio output routing
             trackController_.setTrackAudioOutput(trackId, trackInfo->audioOutputDevice);
 
+            // Sync rack/chain volume and pan
+            pluginManager_.syncRackProperties(trackId);
+
             // Sync send levels to AuxSendPlugins
             for (const auto& send : trackInfo->sends) {
                 if (auto* auxSend = track->getAuxSendPlugin(send.busIndex)) {

--- a/magda/daw/audio/MidiChordEnginePlugin.cpp
+++ b/magda/daw/audio/MidiChordEnginePlugin.cpp
@@ -103,8 +103,8 @@ void MidiChordEnginePlugin::applyToBuffer(const te::PluginRenderContext& fc) {
 
 void MidiChordEnginePlugin::timerCallback() {
     if (!isEnabled()) {
-        // Clear held notes so detection doesn't resume with stale data
-        heldNoteCount_.store(0, std::memory_order_relaxed);
+        // Clear held notes and FIFO so detection doesn't resume with stale data
+        reset();
         return;
     }
 

--- a/magda/daw/audio/MidiChordEnginePlugin.cpp
+++ b/magda/daw/audio/MidiChordEnginePlugin.cpp
@@ -103,8 +103,12 @@ void MidiChordEnginePlugin::applyToBuffer(const te::PluginRenderContext& fc) {
 
 void MidiChordEnginePlugin::timerCallback() {
     if (!isEnabled()) {
-        // Clear held notes and FIFO so detection doesn't resume with stale data
-        reset();
+        // Flush stale FIFO events by consuming them (safe — we're the reader).
+        // Don't call reset() here as it races with the audio thread writer.
+        int start1, size1, start2, size2;
+        noteFifo_.prepareToRead(noteFifo_.getNumReady(), start1, size1, start2, size2);
+        noteFifo_.finishedRead(size1 + size2);
+        heldNoteCount_.store(0, std::memory_order_relaxed);
         return;
     }
 

--- a/magda/daw/audio/MidiChordEnginePlugin.cpp
+++ b/magda/daw/audio/MidiChordEnginePlugin.cpp
@@ -42,8 +42,8 @@ void MidiChordEnginePlugin::applyToBuffer(const te::PluginRenderContext& fc) {
     if (!fc.bufferForMidiMessages)
         return;
 
-    // Skip recording during preview playback
-    if (detectionSuppressed_.load(std::memory_order_relaxed))
+    // Skip recording during preview playback or when plugin is bypassed/disabled
+    if (detectionSuppressed_.load(std::memory_order_relaxed) || !isEnabled())
         return;
 
     const double blockTimeSeconds = static_cast<double>(fc.bufferStartSample) / sampleRate_;
@@ -102,6 +102,12 @@ void MidiChordEnginePlugin::applyToBuffer(const te::PluginRenderContext& fc) {
 // =============================================================================
 
 void MidiChordEnginePlugin::timerCallback() {
+    if (!isEnabled()) {
+        // Clear held notes so detection doesn't resume with stale data
+        heldNoteCount_.store(0, std::memory_order_relaxed);
+        return;
+    }
+
     processNoteEvents();
 
     // Debounce: if held note count changed since last detection, wait

--- a/magda/daw/audio/PluginManager.cpp
+++ b/magda/daw/audio/PluginManager.cpp
@@ -2000,6 +2000,18 @@ void PluginManager::resyncDeviceModifiers(TrackId trackId) {
     rebuildSidechainLFOCache();
 }
 
+void PluginManager::syncRackProperties(TrackId trackId) {
+    auto* trackInfo = TrackManager::getInstance().getTrack(trackId);
+    if (!trackInfo)
+        return;
+
+    for (const auto& element : trackInfo->chainElements) {
+        if (isRack(element)) {
+            rackSyncManager_.updateRackProperties(getRack(element));
+        }
+    }
+}
+
 // =============================================================================
 // Macro Value Routing
 // =============================================================================

--- a/magda/daw/audio/PluginManager.hpp
+++ b/magda/daw/audio/PluginManager.hpp
@@ -322,6 +322,13 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener {
     void resyncDeviceModifiers(TrackId trackId);
 
     /**
+     * @brief Update rack/chain volume, pan, and mute/solo without structural resync
+     *
+     * Lighter than syncTrackPlugins — only pushes property values to existing TE plugins.
+     */
+    void syncRackProperties(TrackId trackId);
+
+    /**
      * @brief Trigger note-on resync on all TE LFO modifiers for a track
      *
      * Thread-safe: can be called from MIDI thread. The actual resync happens

--- a/magda/daw/audio/RackSyncManager.cpp
+++ b/magda/daw/audio/RackSyncManager.cpp
@@ -136,6 +136,13 @@ void RackSyncManager::resyncRack(TrackId trackId, const RackInfo& rackInfo) {
     DBG("RackSyncManager: Resynced rack " << rackInfo.id);
 }
 
+void RackSyncManager::updateRackProperties(const RackInfo& rackInfo) {
+    auto it = syncedRacks_.find(rackInfo.id);
+    if (it == syncedRacks_.end())
+        return;
+    updateProperties(it->second, rackInfo);
+}
+
 void RackSyncManager::removeRack(RackId rackId) {
     auto it = syncedRacks_.find(rackId);
     if (it == syncedRacks_.end())

--- a/magda/daw/audio/RackSyncManager.cpp
+++ b/magda/daw/audio/RackSyncManager.cpp
@@ -721,18 +721,14 @@ void RackSyncManager::applyBypassState(SyncedRack& synced, const RackInfo& rackI
     }
 
     // Apply rack output volume/pan via the RackInstance's output level parameters
-    if (rackInfo.volume != 0.0f) {
-        rackInstance->leftOutDb->setParameter(
-            static_cast<float>(juce::jlimit(te::RackInstance::rackMinDb,
-                                            te::RackInstance::rackMaxDb,
-                                            static_cast<double>(rackInfo.volume))),
-            juce::dontSendNotification);
-        rackInstance->rightOutDb->setParameter(
-            static_cast<float>(juce::jlimit(te::RackInstance::rackMinDb,
-                                            te::RackInstance::rackMaxDb,
-                                            static_cast<double>(rackInfo.volume))),
-            juce::dontSendNotification);
-    }
+    rackInstance->leftOutDb->setParameter(
+        static_cast<float>(juce::jlimit(te::RackInstance::rackMinDb, te::RackInstance::rackMaxDb,
+                                        static_cast<double>(rackInfo.volume))),
+        juce::dontSendNotification);
+    rackInstance->rightOutDb->setParameter(
+        static_cast<float>(juce::jlimit(te::RackInstance::rackMinDb, te::RackInstance::rackMaxDb,
+                                        static_cast<double>(rackInfo.volume))),
+        juce::dontSendNotification);
 }
 
 // =============================================================================

--- a/magda/daw/audio/RackSyncManager.hpp
+++ b/magda/daw/audio/RackSyncManager.hpp
@@ -52,6 +52,12 @@ class RackSyncManager {
     void resyncRack(TrackId trackId, const RackInfo& rackInfo);
 
     /**
+     * @brief Lightweight update of rack/chain volume, pan, mute/solo without structural resync
+     * @param rackInfo Updated rack data model
+     */
+    void updateRackProperties(const RackInfo& rackInfo);
+
+    /**
      * @brief Clean up RackType, RackInstance, and inner plugins for a rack
      * @param rackId The MAGDA rack ID to remove
      */

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -1313,6 +1313,13 @@ void TrackManager::setRackVolume(TrackId trackId, RackId rackId, float volume) {
     }
 }
 
+void TrackManager::setRackVolume(const ChainNodePath& rackPath, float volume) {
+    if (auto* rack = getRackByPath(rackPath)) {
+        rack->volume = juce::jlimit(-60.0f, 6.0f, volume);
+        notifyTrackPropertyChanged(rackPath.trackId);
+    }
+}
+
 void TrackManager::setChainExpanded(TrackId trackId, RackId rackId, ChainId chainId,
                                     bool expanded) {
     if (auto* chain = getChain(trackId, rackId, chainId)) {

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -172,6 +172,15 @@ void TrackManager::deleteTrack(TrackId trackId) {
         }
     }
 
+    // Remove sends targeting this track from all other tracks
+    for (auto& t : tracks_) {
+        auto& sends = t.sends;
+        sends.erase(
+            std::remove_if(sends.begin(), sends.end(),
+                           [trackId](const SendInfo& s) { return s.destTrackId == trackId; }),
+            sends.end());
+    }
+
     // Remove the track itself
     auto it = std::find_if(tracks_.begin(), tracks_.end(),
                            [trackId](const TrackInfo& t) { return t.id == trackId; });
@@ -819,6 +828,12 @@ void TrackManager::addSend(TrackId sourceTrackId, TrackId destTrackId) {
         return;
     }
 
+    // Tracktion Engine supports a limited number of aux buses
+    if (static_cast<int>(source->sends.size()) >= MAX_SENDS_PER_TRACK) {
+        DBG("addSend failed: maximum number of sends (" << MAX_SENDS_PER_TRACK << ") reached");
+        return;
+    }
+
     // Auto-assign auxBusIndex for non-Aux tracks that don't have one yet
     if (dest->auxBusIndex < 0) {
         dest->auxBusIndex = nextAuxBusIndex_++;
@@ -1280,14 +1295,21 @@ void TrackManager::setChainSolo(TrackId trackId, RackId rackId, ChainId chainId,
 void TrackManager::setChainVolume(TrackId trackId, RackId rackId, ChainId chainId, float volume) {
     if (auto* chain = getChain(trackId, rackId, chainId)) {
         chain->volume = juce::jlimit(-60.0f, 6.0f, volume);  // dB range
-        notifyTrackDevicesChanged(trackId);
+        notifyTrackPropertyChanged(trackId);
     }
 }
 
 void TrackManager::setChainPan(TrackId trackId, RackId rackId, ChainId chainId, float pan) {
     if (auto* chain = getChain(trackId, rackId, chainId)) {
         chain->pan = juce::jlimit(-1.0f, 1.0f, pan);
-        notifyTrackDevicesChanged(trackId);
+        notifyTrackPropertyChanged(trackId);
+    }
+}
+
+void TrackManager::setRackVolume(TrackId trackId, RackId rackId, float volume) {
+    if (auto* rack = getRack(trackId, rackId)) {
+        rack->volume = juce::jlimit(-60.0f, 6.0f, volume);
+        notifyTrackPropertyChanged(trackId);
     }
 }
 

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -91,6 +91,8 @@ class TrackManagerListener {
  */
 class TrackManager {
   public:
+    static constexpr int MAX_SENDS_PER_TRACK = 8;  // Tracktion Engine aux bus limit
+
     static TrackManager& getInstance();
 
     // Prevent copying
@@ -265,6 +267,7 @@ class TrackManager {
     void setChainVolume(TrackId trackId, RackId rackId, ChainId chainId, float volume);
     void setChainPan(TrackId trackId, RackId rackId, ChainId chainId, float pan);
     void setChainExpanded(TrackId trackId, RackId rackId, ChainId chainId, bool expanded);
+    void setRackVolume(TrackId trackId, RackId rackId, float volume);
 
     // Device management within chains
     DeviceId addDeviceToChain(TrackId trackId, RackId rackId, ChainId chainId,

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -268,6 +268,7 @@ class TrackManager {
     void setChainPan(TrackId trackId, RackId rackId, ChainId chainId, float pan);
     void setChainExpanded(TrackId trackId, RackId rackId, ChainId chainId, bool expanded);
     void setRackVolume(TrackId trackId, RackId rackId, float volume);
+    void setRackVolume(const ChainNodePath& rackPath, float volume);
 
     // Device management within chains
     DeviceId addDeviceToChain(TrackId trackId, RackId rackId, ChainId chainId,

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -219,9 +219,17 @@ void ProjectSerializer::commitStaged(StagedProjectData& data) {
 
     // Restore master track chain elements (plugins on the master bus)
     if (data.masterTrack) {
-        auto* masterTrack = TrackManager::getInstance().getTrack(MASTER_TRACK_ID);
+        auto& tm = TrackManager::getInstance();
+        auto* masterTrack = tm.getTrack(MASTER_TRACK_ID);
         if (masterTrack) {
             masterTrack->chainElements = std::move(data.masterTrack->chainElements);
+            // Update device ID counter to include master chain devices
+            for (const auto& element : masterTrack->chainElements) {
+                if (isDevice(element))
+                    tm.ensureDeviceIdAbove(getDevice(element).id);
+            }
+            // Notify listeners so audio bridge creates TE plugins for master devices
+            tm.notifyTrackDevicesChanged(MASTER_TRACK_ID);
         }
     }
 }
@@ -409,9 +417,15 @@ bool ProjectSerializer::deserializeProject(const juce::var& json, ProjectInfo& o
     if (masterTrackVar.isObject()) {
         TrackInfo masterTrackData;
         if (deserializeTrackInfo(masterTrackVar, masterTrackData)) {
-            auto* masterTrack = TrackManager::getInstance().getTrack(MASTER_TRACK_ID);
+            auto& tm = TrackManager::getInstance();
+            auto* masterTrack = tm.getTrack(MASTER_TRACK_ID);
             if (masterTrack) {
                 masterTrack->chainElements = std::move(masterTrackData.chainElements);
+                for (const auto& element : masterTrack->chainElements) {
+                    if (isDevice(element))
+                        tm.ensureDeviceIdAbove(getDevice(element).id);
+                }
+                tm.notifyTrackDevicesChanged(MASTER_TRACK_ID);
             }
         }
     }

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -31,8 +31,8 @@ bool ProjectSerializer::saveToFile(const juce::File& file, const ProjectInfo& in
         {
             juce::FileOutputStream outputStream(tempFile.getFile());
             if (!outputStream.openedOk()) {
-                lastError_ =
-                    "Failed to open temporary file for writing: " + tempFile.getFile().getFullPathName();
+                lastError_ = "Failed to open temporary file for writing: " +
+                             tempFile.getFile().getFullPathName();
                 return false;
             }
 
@@ -194,6 +194,15 @@ bool ProjectSerializer::loadAndStage(const juce::File& file, StagedProjectData& 
             return false;
         }
 
+        // Deserialize master track if present (backward-compatible: old projects won't have it)
+        auto masterTrackVar = obj->getProperty("masterTrack");
+        if (masterTrackVar.isObject()) {
+            auto mt = std::make_unique<TrackInfo>();
+            if (deserializeTrackInfo(masterTrackVar, *mt)) {
+                outData.masterTrack = std::move(mt);
+            }
+        }
+
         return true;
 
     } catch (const std::exception& e) {
@@ -207,6 +216,14 @@ bool ProjectSerializer::loadAndStage(const juce::File& file, StagedProjectData& 
 
 void ProjectSerializer::commitStaged(StagedProjectData& data) {
     commitStagedData(data.tracks, data.clips, data.automationLanes, data.automationClips);
+
+    // Restore master track chain elements (plugins on the master bus)
+    if (data.masterTrack) {
+        auto* masterTrack = TrackManager::getInstance().getTrack(MASTER_TRACK_ID);
+        if (masterTrack) {
+            masterTrack->chainElements = std::move(data.masterTrack->chainElements);
+        }
+    }
 }
 
 // ============================================================================
@@ -268,6 +285,12 @@ juce::var ProjectSerializer::serializeProject(const ProjectInfo& info) {
     obj->setProperty("tracks", serializeTracks());
     obj->setProperty("clips", serializeClips());
     obj->setProperty("automation", serializeAutomation());
+
+    // Serialize master track separately (its chain elements hold master bus plugins)
+    auto* masterTrack = TrackManager::getInstance().getTrack(MASTER_TRACK_ID);
+    if (masterTrack && !masterTrack->chainElements.empty()) {
+        obj->setProperty("masterTrack", serializeTrackInfo(*masterTrack));
+    }
 
     return juce::var(obj);
 }
@@ -380,6 +403,18 @@ bool ProjectSerializer::deserializeProject(const juce::var& json, ProjectInfo& o
 
     // Stage 2: All components validated successfully - now commit to managers atomically
     commitStagedData(stagedTracks, stagedClips, stagedAutomation, stagedAutomationClips);
+
+    // Restore master track chain elements (plugins on the master bus)
+    auto masterTrackVar = obj->getProperty("masterTrack");
+    if (masterTrackVar.isObject()) {
+        TrackInfo masterTrackData;
+        if (deserializeTrackInfo(masterTrackVar, masterTrackData)) {
+            auto* masterTrack = TrackManager::getInstance().getTrack(MASTER_TRACK_ID);
+            if (masterTrack) {
+                masterTrack->chainElements = std::move(masterTrackData.chainElements);
+            }
+        }
+    }
 
     return true;
 }

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -200,6 +200,9 @@ bool ProjectSerializer::loadAndStage(const juce::File& file, StagedProjectData& 
             auto mt = std::make_unique<TrackInfo>();
             if (deserializeTrackInfo(masterTrackVar, *mt)) {
                 outData.masterTrack = std::move(mt);
+            } else {
+                DBG("WARNING: Failed to deserialize masterTrack data - master plugins will be "
+                    "lost");
             }
         }
 

--- a/magda/daw/project/serialization/ProjectSerializer.hpp
+++ b/magda/daw/project/serialization/ProjectSerializer.hpp
@@ -18,6 +18,7 @@ namespace magda {
 struct StagedProjectData {
     ProjectInfo info;
     std::vector<TrackInfo> tracks;
+    std::unique_ptr<TrackInfo> masterTrack;  // Master track (id=MASTER_TRACK_ID)
     std::vector<ClipInfo> clips;
     std::vector<AutomationLaneInfo> automationLanes;
     std::vector<AutomationClipInfo> automationClips;

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -60,7 +60,6 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
         setNodeName(device.name);
     }
     setBypassed(device.bypassed);
-    setCollapsed(!device.expanded);
 
     // Restore panel visibility from device state
     modPanelVisible_ = device.modPanelOpen;
@@ -603,6 +602,10 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
 
     // Populate macro panel with parameter names
     updateMacroPanel();
+
+    // Restore collapsed state AFTER all child components are created, because
+    // setCollapsed triggers resized() which accesses onButton_, uiButton_, etc.
+    setCollapsed(!device.expanded);
 
     // Start timer for UI button state sync and meter updates (~30 FPS)
     startTimerHz(30);

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -60,6 +60,7 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
         setNodeName(device.name);
     }
     setBypassed(device.bypassed);
+    setCollapsed(!device.expanded);
 
     // Restore panel visibility from device state
     modPanelVisible_ = device.modPanelOpen;
@@ -108,6 +109,12 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
         }
         if (onDeviceLayoutChanged) {
             onDeviceLayoutChanged();
+        }
+    };
+
+    onCollapsedChanged = [this](bool collapsed) {
+        if (auto* dev = magda::TrackManager::getInstance().getDeviceInChainByPath(nodePath_)) {
+            dev->expanded = !collapsed;
         }
     };
 

--- a/magda/daw/ui/components/chain/NodeComponent.cpp
+++ b/magda/daw/ui/components/chain/NodeComponent.cpp
@@ -879,8 +879,9 @@ void NodeComponent::mouseUp(const juce::MouseEvent& e) {
 
                 magda::SelectionManager::getInstance().selectChainNode(nodePath_);
 
-                // If was already selected, toggle collapse using captured state
-                if (wasAlreadySelected) {
+                // If was already selected, toggle collapse — but only when collapsed
+                // (to expand) or when the click is on the header bar (to collapse)
+                if (wasAlreadySelected && (wasCollapsed || e.getPosition().y < getHeaderHeight())) {
                     setCollapsed(!wasCollapsed);
                 }
             }

--- a/magda/daw/ui/components/chain/RackComponent.cpp
+++ b/magda/daw/ui/components/chain/RackComponent.cpp
@@ -103,9 +103,8 @@ void RackComponent::initializeCommon(const magda::RackInfo& rack) {
     // Volume slider (dB format)
     volumeSlider_.setRange(-60.0, 6.0, 0.1);
     volumeSlider_.setValue(rack.volume, juce::dontSendNotification);
-    volumeSlider_.onValueChanged = [](double db) {
-        // TODO: Add TrackManager method to set rack volume
-        DBG("Rack volume changed to " << db << " dB");
+    volumeSlider_.onValueChanged = [this](double db) {
+        magda::TrackManager::getInstance().setRackVolume(trackId_, rackId_, static_cast<float>(db));
     };
     addAndMakeVisible(volumeSlider_);
     addAndMakeVisible(levelMeter_);

--- a/magda/daw/ui/components/chain/RackComponent.cpp
+++ b/magda/daw/ui/components/chain/RackComponent.cpp
@@ -104,7 +104,7 @@ void RackComponent::initializeCommon(const magda::RackInfo& rack) {
     volumeSlider_.setRange(-60.0, 6.0, 0.1);
     volumeSlider_.setValue(rack.volume, juce::dontSendNotification);
     volumeSlider_.onValueChanged = [this](double db) {
-        magda::TrackManager::getInstance().setRackVolume(trackId_, rackId_, static_cast<float>(db));
+        magda::TrackManager::getInstance().setRackVolume(rackPath_, static_cast<float>(db));
     };
     addAndMakeVisible(volumeSlider_);
     addAndMakeVisible(levelMeter_);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,8 @@ set(TEST_SOURCES
     test_scale_detection.cpp
     test_step_clock.cpp
     test_mono_note_processor.cpp
+    test_sends_and_track_deletion.cpp
+    test_master_track_serialization.cpp
 )
 
 # Create test executable

--- a/tests/test_master_track_serialization.cpp
+++ b/tests/test_master_track_serialization.cpp
@@ -15,6 +15,7 @@ using namespace magda;
 // ============================================================================
 
 struct MasterSerializationFixture {
+    std::vector<juce::File> tempFiles;
     std::vector<juce::File> tempDirs;
 
     MasterSerializationFixture() {
@@ -28,6 +29,10 @@ struct MasterSerializationFixture {
             if (dir.isDirectory())
                 dir.deleteRecursively();
         }
+        for (auto& file : tempFiles) {
+            if (file.existsAsFile())
+                file.deleteFile();
+        }
         TrackManager::getInstance().clearAllTracks();
         ClipManager::getInstance().clearAllClips();
         AutomationManager::getInstance().clearAll();
@@ -35,6 +40,7 @@ struct MasterSerializationFixture {
 
     juce::File createTempProjectFile(const juce::String& suffix) {
         auto file = juce::File::createTempFile(suffix);
+        tempFiles.push_back(file);
         auto wrapperDir =
             file.getParentDirectory().getChildFile(file.getFileNameWithoutExtension());
         tempDirs.push_back(wrapperDir);

--- a/tests/test_master_track_serialization.cpp
+++ b/tests/test_master_track_serialization.cpp
@@ -1,0 +1,138 @@
+#include <juce_core/juce_core.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/core/AutomationManager.hpp"
+#include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/project/ProjectManager.hpp"
+#include "magda/daw/project/serialization/ProjectSerializer.hpp"
+
+using namespace magda;
+
+// ============================================================================
+// Test Fixture
+// ============================================================================
+
+struct MasterSerializationFixture {
+    std::vector<juce::File> tempDirs;
+
+    MasterSerializationFixture() {
+        TrackManager::getInstance().clearAllTracks();
+        ClipManager::getInstance().clearAllClips();
+        AutomationManager::getInstance().clearAll();
+    }
+
+    ~MasterSerializationFixture() {
+        for (auto& dir : tempDirs) {
+            if (dir.isDirectory())
+                dir.deleteRecursively();
+        }
+        TrackManager::getInstance().clearAllTracks();
+        ClipManager::getInstance().clearAllClips();
+        AutomationManager::getInstance().clearAll();
+    }
+
+    juce::File createTempProjectFile(const juce::String& suffix) {
+        auto file = juce::File::createTempFile(suffix);
+        auto wrapperDir =
+            file.getParentDirectory().getChildFile(file.getFileNameWithoutExtension());
+        tempDirs.push_back(wrapperDir);
+        return file;
+    }
+
+    static juce::File wrappedPath(const juce::File& file) {
+        auto projectName = file.getFileNameWithoutExtension();
+        auto parentDir = file.getParentDirectory();
+        if (parentDir.getFileName() != projectName) {
+            auto wrapperDir = parentDir.getChildFile(projectName);
+            return wrapperDir.getChildFile(file.getFileName());
+        }
+        return file;
+    }
+};
+
+// ============================================================================
+// Master Track Chain Serialization (#959)
+// ============================================================================
+
+TEST_CASE("Master track chain elements survive save/load", "[project][serialization][master]") {
+    MasterSerializationFixture fixture;
+
+    auto& tm = TrackManager::getInstance();
+    auto& pm = ProjectManager::getInstance();
+
+    // Add a device to the master track
+    DeviceInfo eqDevice;
+    eqDevice.name = "EQ";
+    eqDevice.pluginId = "eq";
+    eqDevice.format = PluginFormat::Internal;
+    auto eqId = tm.addDeviceToTrack(MASTER_TRACK_ID, eqDevice);
+    REQUIRE(eqId != INVALID_DEVICE_ID);
+
+    // Verify it's on the master track
+    auto* master = tm.getTrack(MASTER_TRACK_ID);
+    REQUIRE(master != nullptr);
+    REQUIRE(master->chainElements.size() == 1);
+
+    // Save
+    auto tempFile = fixture.createTempProjectFile(".mgd");
+    auto actualFile = MasterSerializationFixture::wrappedPath(tempFile);
+    bool saved = pm.saveProjectAs(tempFile);
+    INFO("saveProjectAs error: " << pm.getLastError());
+    REQUIRE(saved);
+
+    // Clear state
+    tm.clearAllTracks();
+    master = tm.getTrack(MASTER_TRACK_ID);
+    REQUIRE(master->chainElements.empty());
+
+    // Load back
+    bool loaded = pm.loadProject(actualFile);
+    REQUIRE(loaded);
+
+    // Verify master chain was restored
+    master = tm.getTrack(MASTER_TRACK_ID);
+    REQUIRE(master != nullptr);
+    REQUIRE(master->chainElements.size() == 1);
+
+    auto& element = master->chainElements[0];
+    REQUIRE(isDevice(element));
+    REQUIRE(getDevice(element).pluginId == "eq");
+}
+
+TEST_CASE("Master track chain with multiple devices roundtrips",
+          "[project][serialization][master]") {
+    MasterSerializationFixture fixture;
+
+    auto& tm = TrackManager::getInstance();
+    auto& pm = ProjectManager::getInstance();
+
+    // Add multiple devices to master
+    DeviceInfo eq;
+    eq.name = "EQ";
+    eq.pluginId = "eq";
+    eq.format = PluginFormat::Internal;
+    tm.addDeviceToTrack(MASTER_TRACK_ID, eq);
+
+    DeviceInfo comp;
+    comp.name = "Compressor";
+    comp.pluginId = "compressor";
+    comp.format = PluginFormat::Internal;
+    tm.addDeviceToTrack(MASTER_TRACK_ID, comp);
+
+    auto* master = tm.getTrack(MASTER_TRACK_ID);
+    REQUIRE(master->chainElements.size() == 2);
+
+    // Save and reload
+    auto tempFile = fixture.createTempProjectFile(".mgd");
+    auto actualFile = MasterSerializationFixture::wrappedPath(tempFile);
+    REQUIRE(pm.saveProjectAs(tempFile));
+    tm.clearAllTracks();
+    REQUIRE(pm.loadProject(actualFile));
+
+    master = tm.getTrack(MASTER_TRACK_ID);
+    REQUIRE(master->chainElements.size() == 2);
+    REQUIRE(getDevice(master->chainElements[0]).pluginId == "eq");
+    REQUIRE(getDevice(master->chainElements[1]).pluginId == "compressor");
+}

--- a/tests/test_sends_and_track_deletion.cpp
+++ b/tests/test_sends_and_track_deletion.cpp
@@ -1,0 +1,121 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/core/TrackManager.hpp"
+
+using namespace magda;
+
+// ============================================================================
+// Test Fixture
+// ============================================================================
+
+struct SendsTestFixture {
+    SendsTestFixture() {
+        TrackManager::getInstance().clearAllTracks();
+    }
+
+    ~SendsTestFixture() {
+        TrackManager::getInstance().clearAllTracks();
+    }
+
+    TrackManager& tm() {
+        return TrackManager::getInstance();
+    }
+
+    TrackId createTrack(const juce::String& name = "Track") {
+        return tm().createTrack(name, TrackType::Audio);
+    }
+};
+
+// ============================================================================
+// Send Cap (#961)
+// ============================================================================
+
+TEST_CASE("Sends are capped at MAX_SENDS_PER_TRACK", "[sends][cap]") {
+    SendsTestFixture fixture;
+
+    auto source = fixture.createTrack("Source");
+
+    // Create enough destination tracks to exceed the cap
+    std::vector<TrackId> dests;
+    for (int i = 0; i < TrackManager::MAX_SENDS_PER_TRACK + 4; ++i) {
+        dests.push_back(fixture.createTrack("Dest " + juce::String(i)));
+    }
+
+    // Add sends up to the cap
+    for (int i = 0; i < TrackManager::MAX_SENDS_PER_TRACK; ++i) {
+        fixture.tm().addSend(source, dests[static_cast<size_t>(i)]);
+    }
+
+    auto* track = fixture.tm().getTrack(source);
+    REQUIRE(track != nullptr);
+    REQUIRE(static_cast<int>(track->sends.size()) == TrackManager::MAX_SENDS_PER_TRACK);
+
+    // Trying to add more sends should be silently ignored
+    for (int i = TrackManager::MAX_SENDS_PER_TRACK; i < TrackManager::MAX_SENDS_PER_TRACK + 4;
+         ++i) {
+        fixture.tm().addSend(source, dests[static_cast<size_t>(i)]);
+    }
+
+    REQUIRE(static_cast<int>(track->sends.size()) == TrackManager::MAX_SENDS_PER_TRACK);
+}
+
+TEST_CASE("Duplicate sends are not added", "[sends]") {
+    SendsTestFixture fixture;
+
+    auto source = fixture.createTrack("Source");
+    auto dest = fixture.createTrack("Dest");
+
+    fixture.tm().addSend(source, dest);
+    fixture.tm().addSend(source, dest);  // duplicate
+
+    auto* track = fixture.tm().getTrack(source);
+    REQUIRE(track != nullptr);
+    REQUIRE(track->sends.size() == 1);
+}
+
+// ============================================================================
+// Sends cleaned up on track deletion (#960)
+// ============================================================================
+
+TEST_CASE("Sends targeting deleted track are removed", "[sends][delete]") {
+    SendsTestFixture fixture;
+
+    auto trackA = fixture.createTrack("A");
+    auto trackB = fixture.createTrack("B");
+    auto trackC = fixture.createTrack("C");
+
+    // A sends to B and C
+    fixture.tm().addSend(trackA, trackB);
+    fixture.tm().addSend(trackA, trackC);
+
+    auto* a = fixture.tm().getTrack(trackA);
+    REQUIRE(a->sends.size() == 2);
+
+    // Delete B — send from A to B should be removed
+    fixture.tm().deleteTrack(trackB);
+
+    a = fixture.tm().getTrack(trackA);
+    REQUIRE(a != nullptr);
+    REQUIRE(a->sends.size() == 1);
+    REQUIRE(a->sends[0].destTrackId == trackC);
+}
+
+TEST_CASE("Sends from multiple tracks to deleted track are all removed", "[sends][delete]") {
+    SendsTestFixture fixture;
+
+    auto trackA = fixture.createTrack("A");
+    auto trackB = fixture.createTrack("B");
+    auto dest = fixture.createTrack("Dest");
+
+    fixture.tm().addSend(trackA, dest);
+    fixture.tm().addSend(trackB, dest);
+
+    REQUIRE(fixture.tm().getTrack(trackA)->sends.size() == 1);
+    REQUIRE(fixture.tm().getTrack(trackB)->sends.size() == 1);
+
+    // Delete dest — sends from both A and B should be cleaned up
+    fixture.tm().deleteTrack(dest);
+
+    REQUIRE(fixture.tm().getTrack(trackA)->sends.empty());
+    REQUIRE(fixture.tm().getTrack(trackB)->sends.empty());
+}


### PR DESCRIPTION
## Summary
- Fix crash when creating track with collapsed device slots (null deref in `resizedCollapsed`)
- Only toggle device collapse when clicking the header bar, not the content area
- Fix bugs #953, #955, #957, #958, #959, #960, #961 (sends cap, chord engine, rack serialization, etc.)

## Test plan
- [ ] Create new track — no crash
- [ ] Click content area of selected device — should not collapse
- [ ] Click header bar of selected device — should collapse
- [ ] Click collapsed device — should expand
- [ ] Verify fixes for #953, #955, #957, #958, #959, #960, #961