### PR TITLE
Fix #965: prevent duplicate Chain Tree windows and close leak

### DIFF
--- a/magda/daw/ui/dialogs/ChainTreeDialog.cpp
+++ b/magda/daw/ui/dialogs/ChainTreeDialog.cpp
@@ -258,10 +258,15 @@ class ChainTreeDialog::ContentComponent : public juce::Component,
     void tracksChanged() override {
         // Check if our track still exists
         if (!TrackManager::getInstance().getTrack(trackId_)) {
-            // Track was deleted, close the dialog
-            if (auto* parent = findParentComponentOfClass<ChainTreeDialog>()) {
-                parent->closeButtonPressed();
-            }
+            // Track was deleted — defer the close so we don't delete the
+            // dialog (and this component) while TrackManager is still
+            // iterating its listener list.
+            juce::Component::SafePointer<ChainTreeDialog> dialog{
+                findParentComponentOfClass<ChainTreeDialog>()};
+            juce::MessageManager::callAsync([dialog]() mutable {
+                if (dialog != nullptr)
+                    dialog->closeButtonPressed();
+            });
             return;
         }
         buildTree();
@@ -402,8 +407,11 @@ class ChainTreeDialog::ContentComponent : public juce::Component,
 // ChainTreeDialog
 // ============================================================================
 
+juce::Component::SafePointer<ChainTreeDialog> ChainTreeDialog::currentInstance_;
+
 ChainTreeDialog::ChainTreeDialog(TrackId trackId)
-    : DialogWindow("Chain Tree", DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND), true) {
+    : DialogWindow("Chain Tree", DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND), true),
+      trackId_(trackId) {
     content_ = std::make_unique<ContentComponent>(trackId);
     setContentOwned(content_.release(), true);
     centreWithSize(400, 500);
@@ -415,7 +423,7 @@ ChainTreeDialog::ChainTreeDialog(TrackId trackId)
 ChainTreeDialog::~ChainTreeDialog() = default;
 
 void ChainTreeDialog::closeButtonPressed() {
-    setVisible(false);
+    delete this;
 }
 
 void ChainTreeDialog::show(TrackId trackId) {
@@ -429,10 +437,21 @@ void ChainTreeDialog::show(TrackId trackId) {
         return;
     }
 
+    // Re-focus existing instance instead of spawning a duplicate
+    if (currentInstance_ != nullptr) {
+        if (currentInstance_->getTrackId() == trackId) {
+            currentInstance_->toFront(true);
+            return;
+        }
+        // Different track — close the existing dialog and open a fresh one
+        delete currentInstance_.getComponent();
+    }
+
     auto* dialog = new ChainTreeDialog(trackId);
     dialog->setName("Chain Tree - " + track->name);
     dialog->setVisible(true);
     dialog->toFront(true);
+    currentInstance_ = dialog;
 }
 
 }  // namespace magda

--- a/magda/daw/ui/dialogs/ChainTreeDialog.cpp
+++ b/magda/daw/ui/dialogs/ChainTreeDialog.cpp
@@ -443,8 +443,10 @@ void ChainTreeDialog::show(TrackId trackId) {
             currentInstance_->toFront(true);
             return;
         }
-        // Different track — close the existing dialog and open a fresh one
-        delete currentInstance_.getComponent();
+        // Different track — close the existing dialog and open a fresh one.
+        // Route through closeButtonPressed so any future cleanup stays in
+        // one place.
+        currentInstance_->closeButtonPressed();
     }
 
     auto* dialog = new ChainTreeDialog(trackId);

--- a/magda/daw/ui/dialogs/ChainTreeDialog.hpp
+++ b/magda/daw/ui/dialogs/ChainTreeDialog.hpp
@@ -25,6 +25,10 @@ class ChainTreeDialog : public juce::DialogWindow {
 
     void closeButtonPressed() override;
 
+    TrackId getTrackId() const {
+        return trackId_;
+    }
+
     /**
      * @brief Show the dialog for a given track
      * @param trackId The track whose chain to display
@@ -34,6 +38,11 @@ class ChainTreeDialog : public juce::DialogWindow {
   private:
     class ContentComponent;
     std::unique_ptr<ContentComponent> content_;
+    TrackId trackId_;
+
+    // Tracks the currently-open instance so repeat clicks re-focus instead
+    // of spawning duplicate windows.
+    static juce::Component::SafePointer<ChainTreeDialog> currentInstance_;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ChainTreeDialog)
 };


### PR DESCRIPTION
## Summary
- `ChainTreeDialog::show()` now re-focuses an existing instance for the same track (or closes+reopens when the track changes) via a static `Component::SafePointer`, instead of `new`-ing a fresh dialog on every click.
- `closeButtonPressed()` deletes the dialog — standard JUCE idiom for self-owned non-modal `DialogWindow`s — fixing a pre-existing leak where the dialog and its `TrackManager`/`SelectionManager` listeners outlived every close.
- `ContentComponent::tracksChanged()` defers the close-on-track-deleted path through `MessageManager::callAsync`, so the dialog isn't destroyed while `TrackManager` is still iterating its listener list.

Fixes Conceptual-Machines/magda-core#965.

## Test plan
- [ ] Click the Chain Tree icon repeatedly on a single track — only one window should be present, subsequent clicks re-focus it.
- [ ] Open the Chain Tree for track A, then click the Chain Tree icon on track B — window should switch to track B, no stacking.
- [ ] Open the Chain Tree, then delete the track it's showing — dialog should close cleanly without crash.
- [ ] Open, close, reopen the Chain Tree — no leaks under `LEAK_DETECTOR` asserts.