### PR TITLE
Fix #970: route MIDI through instrument rack wrappers and chain ends

### DIFF
--- a/magda/daw/audio/InstrumentRackManager.cpp
+++ b/magda/daw/audio/InstrumentRackManager.cpp
@@ -43,6 +43,32 @@ te::Plugin::Ptr InstrumentRackManager::wrapInstrument(te::Plugin::Ptr instrument
     // MIDI: rack input pin 0 --> synth pin 0
     rackType->addConnection(rackIOId, 0, synthId, 0);
 
+    // MIDI at the rack output: depends on what kind of plugin we wrap.
+    //
+    // - Zero audio outputs => MIDI-only plugin (Cthulhu, chord engines, arps).
+    //   Forward the plugin's transformed MIDI to the rack output so downstream
+    //   sees its events.
+    //
+    // - Has audio outputs => synth (Serum, Surge, 4osc, samplers...). Pass the
+    //   raw clip MIDI around the synth so downstream audio effects that sync
+    //   from note events (SerumFX LFO, sidechain envelopes) still see the
+    //   clip's MIDI after the instrument. We deliberately ignore the plugin's
+    //   own MIDI output here even if it claims producesMidi() — synths often
+    //   lie about that and emit nothing, which would silently kill MIDI flow.
+    //
+    // Exactly one of these edges is added so MIDI is never duplicated.
+    const bool isMidiOnly = [&] {
+        if (auto* ext = dynamic_cast<te::ExternalPlugin*>(instrument.get()))
+            if (auto* api = ext->getAudioPluginInstance())
+                return api->getTotalNumOutputChannels() == 0;
+        return false;
+    }();
+
+    if (isMidiOnly)
+        rackType->addConnection(synthId, 0, rackIOId, 0);  // plugin MIDI out --> rack output
+    else
+        rackType->addConnection(rackIOId, 0, rackIOId, 0);  // raw MIDI passthrough
+
     // Audio passthrough: rack input pin 1 --> rack output pin 1 (left)
     rackType->addConnection(rackIOId, 1, rackIOId, 1);
     // Audio passthrough: rack input pin 2 --> rack output pin 2 (right)
@@ -109,6 +135,22 @@ te::Plugin::Ptr InstrumentRackManager::wrapMultiOutInstrument(te::Plugin::Ptr in
 
     // MIDI: rack input pin 0 --> synth pin 0
     rackType->addConnection(rackIOId, 0, synthId, 0);
+
+    // MIDI at the rack output: plugin-dependent (see wrapInstrument for rationale).
+    // A multi-out instrument always has audio outputs, so this branch will
+    // almost always be raw passthrough — kept symmetric with wrapInstrument
+    // for clarity.
+    const bool isMidiOnly = [&] {
+        if (auto* ext = dynamic_cast<te::ExternalPlugin*>(instrument.get()))
+            if (auto* api = ext->getAudioPluginInstance())
+                return api->getTotalNumOutputChannels() == 0;
+        return false;
+    }();
+
+    if (isMidiOnly)
+        rackType->addConnection(synthId, 0, rackIOId, 0);  // plugin MIDI out --> rack output
+    else
+        rackType->addConnection(rackIOId, 0, rackIOId, 0);  // raw MIDI passthrough
 
     // Audio passthrough: rack input pin 1 --> rack output pin 1 (left)
     rackType->addConnection(rackIOId, 1, rackIOId, 1);

--- a/magda/daw/audio/RackSyncManager.cpp
+++ b/magda/daw/audio/RackSyncManager.cpp
@@ -590,7 +590,13 @@ void RackSyncManager::buildConnections(SyncedRack& synced, const RackInfo& rackI
             rackType->addConnection(src, 0, dst, 0);  // MIDI
         }
 
-        // Connect last plugin to rack output (only if chain is active)
+        // Connect last plugin to rack output.
+        // Audio L/R is only wired when the chain is active (mute/solo gating),
+        // but MIDI pin 0 is wired unconditionally so a MIDI plugin at the end
+        // of the chain can still feed downstream MIDI plugins / instruments
+        // when the chain is bypassed — matching TE's standard bypass semantics
+        // (a bypassed plugin passes MIDI through unchanged).
+        rackType->addConnection(lastPlugin, 0, rackIOId, 0);  // MIDI — always
         if (chainActive) {
             rackType->addConnection(lastPlugin, 1, rackIOId, 1);  // Left
             rackType->addConnection(lastPlugin, 2, rackIOId, 2);  // Right
@@ -598,11 +604,13 @@ void RackSyncManager::buildConnections(SyncedRack& synced, const RackInfo& rackI
         }
     }
 
-    // If no chains exist at all, pass audio straight through so the rack is transparent.
-    // When chains exist but are all muted/inactive, leave output disconnected for silence.
+    // If no chains exist at all, pass audio and MIDI straight through so the
+    // rack is transparent. When chains exist but are all muted/inactive, leave
+    // audio disconnected for silence (MIDI is already wired per-chain above).
     if (!anyChainConnectedToOutput && rackInfo.chains.empty()) {
-        rackType->addConnection(rackIOId, 1, rackIOId, 1);
-        rackType->addConnection(rackIOId, 2, rackIOId, 2);
+        rackType->addConnection(rackIOId, 1, rackIOId, 1);  // Audio L
+        rackType->addConnection(rackIOId, 2, rackIOId, 2);  // Audio R
+        rackType->addConnection(rackIOId, 0, rackIOId, 0);  // MIDI
     }
 }
 


### PR DESCRIPTION
InstrumentRackManager dropped MIDI at the rack output pin (only audio pins 1/2 were wired), so any plugin chain ending in a wrapped instrument silently lost its MIDI stream. RackSyncManager had the same omission at the last-plugin->rack-output and empty-rack passthrough boundaries.

InstrumentRackManager now adds one MIDI edge at the rack output, picked by audio output channel count: zero outputs (Cthulhu, chord engines, arps) forward the plugin's transformed MIDI; non-zero outputs (Serum, Surge, 4osc, samplers) pass the raw clip MIDI around the synth so downstream sidechain effects and SerumFX-style LFOs still see note events. Using output count instead of producesMidi() avoids synths that lie about emitting MIDI.

RackSyncManager wires pin 0 unconditionally at the chain-end and empty-rack boundaries so a MIDI plugin at the end of a chain still feeds downstream when the chain is bypassed and an empty rack is fully transparent.