### PR TITLE
Fix #982: repaint MainView during drag resize to clear artifacts

### DIFF
--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -1362,7 +1362,8 @@ void MainView::mouseDrag(const juce::MouseEvent& event) {
 
         if (newWidth != trackHeaderWidth) {
             trackHeaderWidth = newWidth;
-            resized();  // Trigger layout update
+            resized();
+            repaint();
         }
 
         lastMouseX = event.x;  // Update for next drag event
@@ -1376,7 +1377,8 @@ void MainView::mouseDrag(const juce::MouseEvent& event) {
 
         if (newHeight != masterStripHeight) {
             masterStripHeight = newHeight;
-            resized();  // Trigger layout update
+            resized();
+            repaint();
         }
     }
 }


### PR DESCRIPTION
resized() repositions child components but does not invalidate the paint buffer, leaving stale pixels visible on the left side when dragging the master strip or header column edge.