### PR TITLE
Fix crash on project reopen with non-ASCII file paths (Windows)

### DIFF
--- a/.claude/skills/crash-analysis/SKILL.md
+++ b/.claude/skills/crash-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crash-analysis
-description: Analyze macOS crash logs for MAGDA. Use when the user reports a crash, provides a crash log, or asks to investigate a crash. Parses .ips and .crash files to extract only the relevant thread.
+description: Analyze MAGDA crash logs and Windows minidumps. Use when the user reports a crash, provides a crash log or .dmp file, or asks to investigate a crash.
 ---
 
 # Crash Analysis
@@ -57,3 +57,64 @@ Crashes in `juce::Timer::TimerThread::callTimers()` often mean a component was d
 
 ### Audio thread crashes
 Crashes in threads named "JUCE Audio" or "Tracktion" are audio-thread issues. Common causes: allocating memory, locking mutexes, or accessing deleted objects from the audio callback.
+
+---
+
+## Windows Crash Analysis (.dmp files)
+
+Windows users send `.dmp` minidump files. Use the scripts below — **never read .dmp files directly**.
+
+### Quick parse (no symbols)
+
+```bash
+python3 .claude/skills/crash-analysis/parse-minidump.py /path/to/file.dmp
+```
+
+### With PDB symbolization (function names + offsets)
+
+From v0.4.6 onwards, each release includes `MAGDA-X.Y.Z-Windows-x86_64.pdb`.
+Download it from the GitHub release assets, then:
+
+```bash
+python3 .claude/skills/crash-analysis/parse-minidump.py file.dmp --pdb MAGDA-X.Y.Z-Windows-x86_64.pdb
+```
+
+### Semi-automated analysis (parse + Claude + optional Linear issue)
+
+Requires: `pip install anthropic`
+
+```bash
+# Parse + Claude analysis (downloads PDB automatically for known versions)
+ANTHROPIC_API_KEY=... GITHUB_TOKEN=... \
+  python3 .claude/skills/crash-analysis/analyze-crash.py \
+    --dump file.dmp --version 0.4.6
+
+# Also create a Linear issue
+ANTHROPIC_API_KEY=... GITHUB_TOKEN=... LINEAR_API_KEY=... LINEAR_TEAM_ID=... \
+  python3 .claude/skills/crash-analysis/analyze-crash.py \
+    --dump file.dmp --version 0.4.6 --create-issue
+
+# With a local PDB (skips download)
+ANTHROPIC_API_KEY=... \
+  python3 .claude/skills/crash-analysis/analyze-crash.py \
+    --dump file.dmp --pdb MAGDA.pdb
+```
+
+### Reading the output
+
+| Field | What to look for |
+|-------|-----------------|
+| Exception code | `0xC0000005` = access violation (most common) |
+| AV address | `0x0` = null deref; `0xFFFFFFFFFFFFFFFF` = sentinel/corruption |
+| Rcx register | In x64, this is `this` — garbage here means the object is corrupt/freed |
+| Stack scan | MAGDA.exe offsets narrow the subsystem; with PDB they resolve to function names |
+
+### Common Windows crash patterns
+
+| Pattern | Likely cause |
+|---------|-------------|
+| AV read at 0x0 | Null pointer dereference |
+| AV read at 0xFFFFFFFFFFFFFFFF | Dangling `std::list` iterator or sentinel value used as pointer |
+| Rcx = ASCII/UTF bytes | String buffer being used as `this` pointer — memory corruption or bad cast |
+| Rbp = small integer (0, 1, 2) | Stack frame pointer corrupted — look for buffer overflows |
+| Crash on project reopen | Serialization/deserialization bug, often with non-ASCII paths on Windows |

--- a/.claude/skills/crash-analysis/analyze-crash.py
+++ b/.claude/skills/crash-analysis/analyze-crash.py
@@ -22,12 +22,10 @@ Environment variables required for full automation:
 """
 
 import argparse
-import io
 import os
 import sys
 import subprocess
 import tempfile
-import contextlib
 
 REPO = "Conceptual-Machines/magda-core"
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/.claude/skills/crash-analysis/analyze-crash.py
+++ b/.claude/skills/crash-analysis/analyze-crash.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+MAGDA semi-automated Windows crash analyser.
+
+Workflow:
+  1. Parse the .dmp with parse-minidump.py
+  2. Optionally download the matching PDB from GitHub releases and symbolize
+  3. Feed the report to Claude for root-cause analysis
+  4. Optionally create a Linear issue with the findings
+
+Usage:
+  analyze-crash.py --dump FILE.dmp
+  analyze-crash.py --dump FILE.dmp --version 0.4.5
+  analyze-crash.py --dump FILE.dmp --pdb MAGDA.pdb
+  analyze-crash.py --dump FILE.dmp --version 0.4.5 --create-issue
+
+Environment variables required for full automation:
+  ANTHROPIC_API_KEY   Claude API key
+  GITHUB_TOKEN        GitHub PAT with repo read access (for PDB download)
+  LINEAR_API_KEY      Linear API key (only needed with --create-issue)
+  LINEAR_TEAM_ID      Linear team ID  (only needed with --create-issue)
+"""
+
+import argparse
+import io
+import os
+import sys
+import subprocess
+import tempfile
+import contextlib
+
+REPO = "Conceptual-Machines/magda-core"
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PARSE_SCRIPT = os.path.join(SCRIPT_DIR, "parse-minidump.py")
+
+
+# ── PDB download ──────────────────────────────────────────────────────────────
+
+def download_pdb(version, dest_dir):
+    """Download MAGDA-{version}-Windows-x86_64.pdb from GitHub releases."""
+    try:
+        import urllib.request, urllib.error
+    except ImportError:
+        print("[warn] urllib not available — skipping PDB download")
+        return None
+
+    token = os.environ.get("GITHUB_TOKEN")
+    pdb_name = f"MAGDA-{version}-Windows-x86_64.pdb"
+    url = f"https://github.com/{REPO}/releases/download/v{version}/{pdb_name}"
+    dest = os.path.join(dest_dir, pdb_name)
+
+    headers = {"Accept": "application/octet-stream"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    print(f"Downloading PDB for v{version}...")
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=60) as resp, open(dest, "wb") as f:
+            while chunk := resp.read(65536):
+                f.write(chunk)
+        print(f"  → saved to {dest}")
+        return dest
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            print(f"  [warn] PDB not found in v{version} release assets — "
+                  "was this version built before PDB upload was added?")
+        else:
+            print(f"  [warn] HTTP {e.code} downloading PDB: {e}")
+        return None
+    except Exception as e:
+        print(f"  [warn] could not download PDB: {e}")
+        return None
+
+
+# ── Parse dump → text report ──────────────────────────────────────────────────
+
+def run_parse(dump_path, pdb_path=None):
+    """Run parse-minidump.py and capture its stdout."""
+    cmd = [sys.executable, PARSE_SCRIPT, dump_path]
+    if pdb_path:
+        cmd += ["--pdb", pdb_path]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    output = result.stdout
+    if result.returncode != 0:
+        output += f"\n[stderr]\n{result.stderr}"
+    return output
+
+
+# ── Claude analysis ───────────────────────────────────────────────────────────
+
+SYSTEM_PROMPT = """\
+You are an expert C++/JUCE crash analyst for MAGDA, a DAW built on JUCE and Tracktion Engine.
+When given a Windows minidump analysis, your job is to:
+1. Identify the most likely root cause (null pointer, dangling reference, use-after-free, etc.)
+2. Pinpoint the specific function or subsystem responsible
+3. Suggest a concrete fix or investigation path
+4. Rate your confidence (high/medium/low) given the available symbol information
+
+Be concise. Lead with the most actionable finding. If symbols are absent, focus on the
+exception type, register state, and the pattern of stack addresses to narrow down the subsystem.
+"""
+
+def analyse_with_claude(report_text):
+    """Send the parsed report to Claude and return its analysis."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("[warn] ANTHROPIC_API_KEY not set — skipping Claude analysis")
+        return None
+
+    try:
+        import anthropic
+    except ImportError:
+        print("[warn] anthropic package not installed — run: pip install anthropic")
+        return None
+
+    client = anthropic.Anthropic(api_key=api_key)
+    print("Sending to Claude for analysis...")
+
+    message = client.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=1024,
+        system=SYSTEM_PROMPT,
+        messages=[
+            {
+                "role": "user",
+                "content": f"Analyse this MAGDA crash dump:\n\n```\n{report_text}\n```",
+            }
+        ],
+    )
+    return message.content[0].text
+
+
+# ── Linear issue creation ─────────────────────────────────────────────────────
+
+def create_linear_issue(title, body):
+    """Create a Linear issue and return its URL."""
+    api_key = os.environ.get("LINEAR_API_KEY")
+    team_id = os.environ.get("LINEAR_TEAM_ID")
+    if not api_key or not team_id:
+        print("[warn] LINEAR_API_KEY / LINEAR_TEAM_ID not set — skipping issue creation")
+        return None
+
+    try:
+        import urllib.request, urllib.error, json
+    except ImportError:
+        return None
+
+    mutation = """
+    mutation IssueCreate($input: IssueCreateInput!) {
+      issueCreate(input: $input) {
+        success
+        issue { identifier url title }
+      }
+    }
+    """
+    variables = {
+        "input": {
+            "teamId": team_id,
+            "title": title,
+            "description": body,
+            "labelIds": [],
+        }
+    }
+    payload = json.dumps({"query": mutation, "variables": variables}).encode()
+    req = urllib.request.Request(
+        "https://api.linear.app/graphql",
+        data=payload,
+        headers={
+            "Authorization": api_key,
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+        issue = data["data"]["issueCreate"]["issue"]
+        print(f"Linear issue created: {issue['identifier']} — {issue['url']}")
+        return issue["url"]
+    except Exception as e:
+        print(f"[warn] Linear issue creation failed: {e}")
+        return None
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    ap = argparse.ArgumentParser(description="MAGDA Windows crash analyser")
+    ap.add_argument("--dump", required=True, help=".dmp file path")
+    ap.add_argument("--version", help="MAGDA version (e.g. 0.4.5) — downloads matching PDB")
+    ap.add_argument("--pdb", help="Local path to MAGDA.pdb (skips download)")
+    ap.add_argument("--create-issue", action="store_true",
+                    help="Create a Linear issue with the analysis")
+    ap.add_argument("--no-claude", action="store_true",
+                    help="Skip Claude analysis (just parse and print)")
+    args = ap.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        pdb_path = args.pdb
+
+        # Download PDB if version given and no local PDB
+        if args.version and not pdb_path:
+            pdb_path = download_pdb(args.version, tmp)
+
+        # Parse the dump
+        print(f"\nParsing {args.dump}...\n")
+        report = run_parse(args.dump, pdb_path)
+        print(report)
+
+        # Claude analysis
+        analysis = None
+        if not args.no_claude:
+            analysis = analyse_with_claude(report)
+            if analysis:
+                print("\n" + "="*70)
+                print("CLAUDE ANALYSIS")
+                print("="*70)
+                print(analysis)
+
+        # Linear issue
+        if args.create_issue and analysis:
+            version_tag = f"v{args.version}" if args.version else "unknown version"
+            title = f"Windows crash ({version_tag}) — {_extract_exc_code(report)}"
+            body = (
+                f"## Crash report ({version_tag})\n\n"
+                f"```\n{report[:3000]}{'...' if len(report) > 3000 else ''}\n```\n\n"
+                f"## Analysis\n\n{analysis}"
+            )
+            create_linear_issue(title, body)
+
+
+def _extract_exc_code(report):
+    """Pull the exception description from the report for the issue title."""
+    for line in report.splitlines():
+        if "Code:" in line:
+            return line.strip().split("Code:", 1)[1].strip()
+    return "ACCESS_VIOLATION"
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/crash-analysis/parse-minidump.py
+++ b/.claude/skills/crash-analysis/parse-minidump.py
@@ -191,7 +191,7 @@ def build_symbol_map(pdb_path):
                 if section == 1:          # .text section → offset ≈ RVA
                     symbols.append((offset, current_name))
             except ValueError:
-                pass
+                pass  # ignore malformed addr lines in llvm-pdbutil output
             current_name = None
 
     symbols.sort(key=lambda x: x[0])

--- a/.claude/skills/crash-analysis/parse-minidump.py
+++ b/.claude/skills/crash-analysis/parse-minidump.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""
+Windows Minidump (.dmp) parser for MAGDA crash analysis.
+Extracts: exception info, crashing thread registers, module list, heuristic stack trace.
+"""
+
+import struct
+import sys
+import os
+
+# Stream types
+THREAD_LIST_STREAM      = 3
+MODULE_LIST_STREAM      = 4
+EXCEPTION_STREAM        = 6
+SYSTEM_INFO_STREAM      = 7
+MISC_INFO_STREAM        = 15
+
+# Exception codes
+EXCEPTION_CODES = {
+    0xC0000005: "ACCESS_VIOLATION (null/dangling pointer)",
+    0xC0000094: "INTEGER_DIVIDE_BY_ZERO",
+    0xC0000096: "PRIVILEGED_INSTRUCTION",
+    0xC000001D: "ILLEGAL_INSTRUCTION",
+    0xC0000025: "NONCONTINUABLE_EXCEPTION",
+    0xC0000026: "INVALID_DISPOSITION",
+    0xC0000374: "HEAP_CORRUPTION",
+    0x80000003: "BREAKPOINT",
+    0x80000004: "SINGLE_STEP",
+    0xC0000409: "STACK_BUFFER_OVERRUN",
+}
+
+ACCESS_VIOLATION_TYPE = {0: "read", 1: "write", 8: "DEP execute"}
+
+
+def read_struct(data, offset, fmt):
+    size = struct.calcsize(fmt)
+    return struct.unpack_from(fmt, data, offset), offset + size
+
+
+def read_minidump_string(data, rva):
+    length = struct.unpack_from("<I", data, rva)[0]
+    raw = data[rva + 4: rva + 4 + length]
+    return raw.decode("utf-16-le", errors="replace")
+
+
+def parse_header(data):
+    sig = data[0:4]
+    if sig != b"MDMP":
+        raise ValueError(f"Not a minidump file (signature: {sig!r})")
+    # MINIDUMP_HEADER: sig(4), version(4), num_streams(4), dir_rva(4), checksum(4), timestamp(4), flags(8)
+    (version, num_streams, dir_rva, checksum, timestamp), _ = read_struct(data, 4, "<IIIII")
+    flags = struct.unpack_from("<Q", data, 24)[0]
+    return {
+        "version": version,
+        "num_streams": num_streams,
+        "dir_rva": dir_rva,
+        "timestamp": timestamp,
+        "flags": flags,
+    }
+
+
+def parse_stream_directory(data, header):
+    streams = {}
+    offset = header["dir_rva"]
+    for _ in range(header["num_streams"]):
+        (stream_type, data_size, rva), offset = read_struct(data, offset, "<III")
+        streams[stream_type] = {"size": data_size, "rva": rva}
+    return streams
+
+
+def parse_exception_stream(data, stream):
+    off = stream["rva"]
+    # MINIDUMP_EXCEPTION_STREAM: thread_id(4), alignment(4), then MINIDUMP_EXCEPTION
+    (thread_id, _align), off = read_struct(data, off, "<II")
+
+    # MINIDUMP_EXCEPTION:
+    #   ExceptionCode(4), ExceptionFlags(4), ExceptionRecord(8), ExceptionAddress(8),
+    #   NumberParameters(4), __unusedAlignment(4), ExceptionInformation[15](8*15=120)
+    (exc_code, exc_flags), off = read_struct(data, off, "<II")
+    exc_record_ptr = struct.unpack_from("<Q", data, off)[0]; off += 8
+    exc_address   = struct.unpack_from("<Q", data, off)[0]; off += 8
+    (num_params, _), off = read_struct(data, off, "<II")
+    exc_info = list(struct.unpack_from("<15Q", data, off)); off += 120
+
+    # MINIDUMP_LOCATION_DESCRIPTOR for thread context: DataSize(4), Rva(4)
+    (ctx_size, ctx_rva), off = read_struct(data, off, "<II")
+
+    return {
+        "thread_id": thread_id,
+        "exc_code": exc_code,
+        "exc_flags": exc_flags,
+        "exc_address": exc_address,
+        "num_params": num_params,
+        "exc_info": exc_info[:num_params],
+        "ctx_size": ctx_size,
+        "ctx_rva": ctx_rva,
+    }
+
+
+def parse_x64_context(data, rva, size):
+    """Parse AMD64 CONTEXT structure, return dict of registers."""
+    if size < 0x100:
+        return {}
+    # Offsets in AMD64 CONTEXT:
+    # 0x030 ContextFlags, 0x034 MxCsr
+    # 0x078 Rax, 0x080 Rcx, 0x088 Rdx, 0x090 Rbx, 0x098 Rsp, 0x0a0 Rbp
+    # 0x0a8 Rsi, 0x0b0 Rdi, 0x0b8 R8..R15(8 regs), 0x0f8 Rip
+    base = rva
+    regs = {}
+    names_offsets = [
+        ("Rax", 0x078), ("Rcx", 0x080), ("Rdx", 0x088), ("Rbx", 0x090),
+        ("Rsp", 0x098), ("Rbp", 0x0a0), ("Rsi", 0x0a8), ("Rdi", 0x0b0),
+        ("R8",  0x0b8), ("R9",  0x0c0), ("R10", 0x0c8), ("R11", 0x0d0),
+        ("R12", 0x0d8), ("R13", 0x0e0), ("R14", 0x0e8), ("R15", 0x0f0),
+        ("Rip", 0x0f8),
+    ]
+    for name, off in names_offsets:
+        if base + off + 8 <= len(data):
+            regs[name] = struct.unpack_from("<Q", data, base + off)[0]
+    return regs
+
+
+def parse_module_list(data, stream):
+    off = stream["rva"]
+    (num_modules,), off = read_struct(data, off, "<I")
+    modules = []
+    # MINIDUMP_MODULE size = 108 bytes
+    # BaseOfImage(8), SizeOfImage(4), CheckSum(4), TimeDateStamp(4), ModuleNameRva(4),
+    # VS_FIXEDFILEINFO(52), CvRecord(8), MiscRecord(8), Reserved0(8), Reserved1(8)
+    for _ in range(num_modules):
+        base_addr = struct.unpack_from("<Q", data, off)[0]
+        size      = struct.unpack_from("<I", data, off + 8)[0]
+        timestamp = struct.unpack_from("<I", data, off + 16)[0]
+        name_rva  = struct.unpack_from("<I", data, off + 20)[0]
+        name = read_minidump_string(data, name_rva)
+        modules.append({
+            "base": base_addr,
+            "size": size,
+            "end":  base_addr + size,
+            "name": os.path.basename(name),
+            "path": name,
+        })
+        off += 108
+    modules.sort(key=lambda m: m["base"])
+    return modules
+
+
+def parse_thread_list(data, stream):
+    off = stream["rva"]
+    (num_threads,), off = read_struct(data, off, "<I")
+    threads = []
+    # MINIDUMP_THREAD:
+    #   ThreadId(4), SuspendCount(4), PriorityClass(4), Priority(4), Teb(8)
+    #   Stack: StartOfMemoryRange(8), Memory.DataSize(4), Memory.Rva(4) = 16
+    #   ThreadContext: DataSize(4), Rva(4) = 8
+    for _ in range(num_threads):
+        (tid, suspend, pclass, priority), off = read_struct(data, off, "<IIII")
+        teb = struct.unpack_from("<Q", data, off)[0]; off += 8
+        stack_start = struct.unpack_from("<Q", data, off)[0]; off += 8
+        (stack_data_size, stack_rva), off = read_struct(data, off, "<II")
+        (ctx_size, ctx_rva), off = read_struct(data, off, "<II")
+        threads.append({
+            "tid": tid,
+            "suspend": suspend,
+            "teb": teb,
+            "stack_start": stack_start,
+            "stack_data_size": stack_data_size,
+            "stack_rva": stack_rva,
+            "ctx_size": ctx_size,
+            "ctx_rva": ctx_rva,
+        })
+    return threads
+
+
+def addr_to_module(addr, modules):
+    for m in modules:
+        if m["base"] <= addr < m["end"]:
+            return m["name"], addr - m["base"]
+    return None, None
+
+
+def scan_stack_for_addresses(data, thread, modules):
+    """Heuristic: scan stack memory for 8-byte values that fall within known modules."""
+    rva  = thread["stack_rva"]
+    size = thread["stack_data_size"]
+    if rva == 0 or size == 0:
+        return []
+
+    hits = []
+    stack_bytes = data[rva: rva + size]
+    for i in range(0, len(stack_bytes) - 8, 8):
+        val = struct.unpack_from("<Q", stack_bytes, i)[0]
+        mod_name, offset = addr_to_module(val, modules)
+        if mod_name:
+            hits.append((val, mod_name, offset))
+    return hits
+
+
+def parse_system_info(data, stream):
+    off = stream["rva"]
+    # ProcessorArchitecture(2), ProcessorLevel(2), ProcessorRevision(2), NumberOfProcessors(1), ProductType(1)
+    (arch, level, rev, num_cpus, prod_type), off = read_struct(data, off, "<HHHBB")
+    arch_names = {0: "x86", 5: "ARM", 6: "IA64", 9: "AMD64", 12: "ARM64"}
+    return {
+        "arch": arch_names.get(arch, f"unknown({arch})"),
+        "num_cpus": num_cpus,
+    }
+
+
+def main(path):
+    with open(path, "rb") as f:
+        data = f.read()
+
+    print(f"Minidump: {path}  ({len(data):,} bytes)\n")
+
+    header  = parse_header(data)
+    streams = parse_stream_directory(data, header)
+
+    # System info
+    if SYSTEM_INFO_STREAM in streams:
+        si = parse_system_info(data, streams[SYSTEM_INFO_STREAM])
+        print(f"Architecture: {si['arch']}  CPUs: {si['num_cpus']}")
+
+    # Module list
+    modules = []
+    if MODULE_LIST_STREAM in streams:
+        modules = parse_module_list(data, streams[MODULE_LIST_STREAM])
+
+    # Exception
+    print("\n" + "="*70)
+    print("EXCEPTION")
+    print("="*70)
+    if EXCEPTION_STREAM not in streams:
+        print("  No exception stream found.")
+    else:
+        exc = parse_exception_stream(data, streams[EXCEPTION_STREAM])
+        code_desc = EXCEPTION_CODES.get(exc["exc_code"], f"0x{exc['exc_code']:08X}")
+        print(f"  Thread ID:   0x{exc['thread_id']:X}")
+        print(f"  Code:        0x{exc['exc_code']:08X}  {code_desc}")
+        print(f"  Address:     0x{exc['exc_address']:016X}")
+
+        mod_name, mod_off = addr_to_module(exc["exc_address"], modules)
+        if mod_name:
+            print(f"               → {mod_name} + 0x{mod_off:X}")
+
+        if exc["exc_code"] == 0xC0000005 and exc["num_params"] >= 2:
+            av_type = ACCESS_VIOLATION_TYPE.get(exc["exc_info"][0], f"type={exc['exc_info'][0]}")
+            av_addr = exc["exc_info"][1]
+            print(f"  AV type:     {av_type} at 0x{av_addr:016X}")
+            if av_addr == 0:
+                print("               → NULL pointer dereference")
+            elif av_addr < 0x10000:
+                print(f"               → Small offset from NULL (offset={av_addr}) — likely vtable/member of null object")
+
+        # Crashing thread context (from exception stream)
+        if exc["ctx_rva"] and exc["ctx_size"]:
+            regs = parse_x64_context(data, exc["ctx_rva"], exc["ctx_size"])
+            if regs:
+                print("\n  Registers:")
+                key_regs = ["Rip", "Rsp", "Rbp", "Rax", "Rcx", "Rdx", "Rbx",
+                            "Rsi", "Rdi", "R8", "R9", "R10", "R11", "R12", "R13", "R14", "R15"]
+                for name in key_regs:
+                    if name in regs:
+                        val = regs[name]
+                        mn, mo = addr_to_module(val, modules)
+                        suffix = f"  → {mn}+0x{mo:X}" if mn else ""
+                        print(f"    {name:>4} = 0x{val:016X}{suffix}")
+
+    # Thread list + stack scan
+    print("\n" + "="*70)
+    print("THREADS")
+    print("="*70)
+    threads = []
+    if THREAD_LIST_STREAM in streams:
+        threads = parse_thread_list(data, streams[THREAD_LIST_STREAM])
+        crashing_tid = exc["thread_id"] if EXCEPTION_STREAM in streams else None
+
+        for t in threads:
+            marker = " *** CRASHING ***" if t["tid"] == crashing_tid else ""
+            regs = parse_x64_context(data, t["ctx_rva"], t["ctx_size"]) if t["ctx_rva"] else {}
+            rip = regs.get("Rip", 0)
+            mn, mo = addr_to_module(rip, modules)
+            rip_str = f"  RIP=0x{rip:016X}" + (f" → {mn}+0x{mo:X}" if mn else "")
+            print(f"\n  TID=0x{t['tid']:X}{marker}{rip_str}")
+
+    # Stack trace for crashing thread
+    print("\n" + "="*70)
+    print("STACK SCAN (crashing thread)")
+    print("="*70)
+    if EXCEPTION_STREAM in streams and threads:
+        crashing_tid = exc["thread_id"]
+        ct = next((t for t in threads if t["tid"] == crashing_tid), None)
+        if ct:
+            hits = scan_stack_for_addresses(data, ct, modules)
+            # Deduplicate consecutive same-module hits
+            seen = set()
+            count = 0
+            for addr, mod_name, offset in hits:
+                key = (mod_name, offset)
+                if key in seen:
+                    continue
+                seen.add(key)
+                print(f"  0x{addr:016X}  {mod_name}+0x{offset:X}")
+                count += 1
+                if count >= 60:
+                    print(f"  ... ({len(hits) - count} more)")
+                    break
+        else:
+            print("  Could not find crashing thread in thread list.")
+
+    # Module list
+    print("\n" + "="*70)
+    print("MODULES")
+    print("="*70)
+    for m in modules:
+        print(f"  0x{m['base']:016X} - 0x{m['end']:016X}  {m['name']}")
+
+    print()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <file.dmp>")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/.claude/skills/crash-analysis/parse-minidump.py
+++ b/.claude/skills/crash-analysis/parse-minidump.py
@@ -1,63 +1,56 @@
 #!/usr/bin/env python3
 """
 Windows Minidump (.dmp) parser for MAGDA crash analysis.
-Extracts: exception info, crashing thread registers, module list, heuristic stack trace.
+
+Usage:
+  parse-minidump.py <file.dmp>
+  parse-minidump.py <file.dmp> --pdb <MAGDA.pdb>
+
+With --pdb: stack addresses are resolved to function names using
+llvm-pdbutil (installed at /opt/homebrew/opt/llvm/bin/ on macOS).
 """
 
 import struct
 import sys
 import os
+import subprocess
 
-# Stream types
-THREAD_LIST_STREAM      = 3
-MODULE_LIST_STREAM      = 4
-EXCEPTION_STREAM        = 6
-SYSTEM_INFO_STREAM      = 7
-MISC_INFO_STREAM        = 15
+# ── Stream types ─────────────────────────────────────────────────────────────
+THREAD_LIST_STREAM  = 3
+MODULE_LIST_STREAM  = 4
+EXCEPTION_STREAM    = 6
+SYSTEM_INFO_STREAM  = 7
 
-# Exception codes
+# ── Exception codes ───────────────────────────────────────────────────────────
 EXCEPTION_CODES = {
     0xC0000005: "ACCESS_VIOLATION (null/dangling pointer)",
     0xC0000094: "INTEGER_DIVIDE_BY_ZERO",
     0xC0000096: "PRIVILEGED_INSTRUCTION",
     0xC000001D: "ILLEGAL_INSTRUCTION",
-    0xC0000025: "NONCONTINUABLE_EXCEPTION",
-    0xC0000026: "INVALID_DISPOSITION",
     0xC0000374: "HEAP_CORRUPTION",
     0x80000003: "BREAKPOINT",
-    0x80000004: "SINGLE_STEP",
     0xC0000409: "STACK_BUFFER_OVERRUN",
 }
-
 ACCESS_VIOLATION_TYPE = {0: "read", 1: "write", 8: "DEP execute"}
 
+# ── Binary helpers ────────────────────────────────────────────────────────────
 
 def read_struct(data, offset, fmt):
     size = struct.calcsize(fmt)
     return struct.unpack_from(fmt, data, offset), offset + size
-
 
 def read_minidump_string(data, rva):
     length = struct.unpack_from("<I", data, rva)[0]
     raw = data[rva + 4: rva + 4 + length]
     return raw.decode("utf-16-le", errors="replace")
 
+# ── Stream parsers ────────────────────────────────────────────────────────────
 
 def parse_header(data):
-    sig = data[0:4]
-    if sig != b"MDMP":
-        raise ValueError(f"Not a minidump file (signature: {sig!r})")
-    # MINIDUMP_HEADER: sig(4), version(4), num_streams(4), dir_rva(4), checksum(4), timestamp(4), flags(8)
+    if data[0:4] != b"MDMP":
+        raise ValueError(f"Not a minidump (signature: {data[0:4]!r})")
     (version, num_streams, dir_rva, checksum, timestamp), _ = read_struct(data, 4, "<IIIII")
-    flags = struct.unpack_from("<Q", data, 24)[0]
-    return {
-        "version": version,
-        "num_streams": num_streams,
-        "dir_rva": dir_rva,
-        "timestamp": timestamp,
-        "flags": flags,
-    }
-
+    return {"num_streams": num_streams, "dir_rva": dir_rva}
 
 def parse_stream_directory(data, header):
     streams = {}
@@ -67,46 +60,31 @@ def parse_stream_directory(data, header):
         streams[stream_type] = {"size": data_size, "rva": rva}
     return streams
 
+def parse_system_info(data, stream):
+    off = stream["rva"]
+    (arch, level, rev, num_cpus, prod_type), _ = read_struct(data, off, "<HHHBB")
+    arch_names = {0: "x86", 5: "ARM", 6: "IA64", 9: "AMD64", 12: "ARM64"}
+    return {"arch": arch_names.get(arch, f"unknown({arch})"), "num_cpus": num_cpus}
 
 def parse_exception_stream(data, stream):
     off = stream["rva"]
-    # MINIDUMP_EXCEPTION_STREAM: thread_id(4), alignment(4), then MINIDUMP_EXCEPTION
     (thread_id, _align), off = read_struct(data, off, "<II")
-
-    # MINIDUMP_EXCEPTION:
-    #   ExceptionCode(4), ExceptionFlags(4), ExceptionRecord(8), ExceptionAddress(8),
-    #   NumberParameters(4), __unusedAlignment(4), ExceptionInformation[15](8*15=120)
     (exc_code, exc_flags), off = read_struct(data, off, "<II")
-    exc_record_ptr = struct.unpack_from("<Q", data, off)[0]; off += 8
-    exc_address   = struct.unpack_from("<Q", data, off)[0]; off += 8
+    off += 8  # ExceptionRecord ptr
+    exc_address = struct.unpack_from("<Q", data, off)[0]; off += 8
     (num_params, _), off = read_struct(data, off, "<II")
     exc_info = list(struct.unpack_from("<15Q", data, off)); off += 120
-
-    # MINIDUMP_LOCATION_DESCRIPTOR for thread context: DataSize(4), Rva(4)
-    (ctx_size, ctx_rva), off = read_struct(data, off, "<II")
-
+    (ctx_size, ctx_rva), _ = read_struct(data, off, "<II")
     return {
-        "thread_id": thread_id,
-        "exc_code": exc_code,
-        "exc_flags": exc_flags,
-        "exc_address": exc_address,
-        "num_params": num_params,
-        "exc_info": exc_info[:num_params],
-        "ctx_size": ctx_size,
-        "ctx_rva": ctx_rva,
+        "thread_id": thread_id, "exc_code": exc_code,
+        "exc_address": exc_address, "num_params": num_params,
+        "exc_info": exc_info[:num_params], "ctx_size": ctx_size, "ctx_rva": ctx_rva,
     }
 
-
 def parse_x64_context(data, rva, size):
-    """Parse AMD64 CONTEXT structure, return dict of registers."""
     if size < 0x100:
         return {}
-    # Offsets in AMD64 CONTEXT:
-    # 0x030 ContextFlags, 0x034 MxCsr
-    # 0x078 Rax, 0x080 Rcx, 0x088 Rdx, 0x090 Rbx, 0x098 Rsp, 0x0a0 Rbp
-    # 0x0a8 Rsi, 0x0b0 Rdi, 0x0b8 R8..R15(8 regs), 0x0f8 Rip
     base = rva
-    regs = {}
     names_offsets = [
         ("Rax", 0x078), ("Rcx", 0x080), ("Rdx", 0x088), ("Rbx", 0x090),
         ("Rsp", 0x098), ("Rbp", 0x0a0), ("Rsi", 0x0a8), ("Rdi", 0x0b0),
@@ -114,63 +92,47 @@ def parse_x64_context(data, rva, size):
         ("R12", 0x0d8), ("R13", 0x0e0), ("R14", 0x0e8), ("R15", 0x0f0),
         ("Rip", 0x0f8),
     ]
+    regs = {}
     for name, off in names_offsets:
         if base + off + 8 <= len(data):
             regs[name] = struct.unpack_from("<Q", data, base + off)[0]
     return regs
 
-
 def parse_module_list(data, stream):
     off = stream["rva"]
     (num_modules,), off = read_struct(data, off, "<I")
     modules = []
-    # MINIDUMP_MODULE size = 108 bytes
-    # BaseOfImage(8), SizeOfImage(4), CheckSum(4), TimeDateStamp(4), ModuleNameRva(4),
-    # VS_FIXEDFILEINFO(52), CvRecord(8), MiscRecord(8), Reserved0(8), Reserved1(8)
     for _ in range(num_modules):
         base_addr = struct.unpack_from("<Q", data, off)[0]
         size      = struct.unpack_from("<I", data, off + 8)[0]
-        timestamp = struct.unpack_from("<I", data, off + 16)[0]
         name_rva  = struct.unpack_from("<I", data, off + 20)[0]
         name = read_minidump_string(data, name_rva)
         modules.append({
-            "base": base_addr,
-            "size": size,
-            "end":  base_addr + size,
-            "name": os.path.basename(name),
-            "path": name,
+            "base": base_addr, "size": size, "end": base_addr + size,
+            "name": os.path.basename(name), "path": name,
         })
         off += 108
     modules.sort(key=lambda m: m["base"])
     return modules
 
-
 def parse_thread_list(data, stream):
     off = stream["rva"]
     (num_threads,), off = read_struct(data, off, "<I")
     threads = []
-    # MINIDUMP_THREAD:
-    #   ThreadId(4), SuspendCount(4), PriorityClass(4), Priority(4), Teb(8)
-    #   Stack: StartOfMemoryRange(8), Memory.DataSize(4), Memory.Rva(4) = 16
-    #   ThreadContext: DataSize(4), Rva(4) = 8
     for _ in range(num_threads):
         (tid, suspend, pclass, priority), off = read_struct(data, off, "<IIII")
-        teb = struct.unpack_from("<Q", data, off)[0]; off += 8
+        off += 8  # teb
         stack_start = struct.unpack_from("<Q", data, off)[0]; off += 8
-        (stack_data_size, stack_rva), off = read_struct(data, off, "<II")
+        (stack_size, stack_rva), off = read_struct(data, off, "<II")
         (ctx_size, ctx_rva), off = read_struct(data, off, "<II")
         threads.append({
-            "tid": tid,
-            "suspend": suspend,
-            "teb": teb,
-            "stack_start": stack_start,
-            "stack_data_size": stack_data_size,
-            "stack_rva": stack_rva,
-            "ctx_size": ctx_size,
-            "ctx_rva": ctx_rva,
+            "tid": tid, "stack_start": stack_start,
+            "stack_data_size": stack_size, "stack_rva": stack_rva,
+            "ctx_size": ctx_size, "ctx_rva": ctx_rva,
         })
     return threads
 
+# ── Address / module helpers ──────────────────────────────────────────────────
 
 def addr_to_module(addr, modules):
     for m in modules:
@@ -178,148 +140,210 @@ def addr_to_module(addr, modules):
             return m["name"], addr - m["base"]
     return None, None
 
-
-def scan_stack_for_addresses(data, thread, modules):
-    """Heuristic: scan stack memory for 8-byte values that fall within known modules."""
-    rva  = thread["stack_rva"]
-    size = thread["stack_data_size"]
-    if rva == 0 or size == 0:
+def scan_stack(data, thread, modules):
+    rva, size = thread["stack_rva"], thread["stack_data_size"]
+    if not rva or not size:
         return []
-
     hits = []
     stack_bytes = data[rva: rva + size]
     for i in range(0, len(stack_bytes) - 8, 8):
         val = struct.unpack_from("<Q", stack_bytes, i)[0]
-        mod_name, offset = addr_to_module(val, modules)
-        if mod_name:
-            hits.append((val, mod_name, offset))
+        mn, mo = addr_to_module(val, modules)
+        if mn:
+            hits.append((val, mn, mo))
     return hits
 
+# ── PDB symbolization ─────────────────────────────────────────────────────────
 
-def parse_system_info(data, stream):
-    off = stream["rva"]
-    # ProcessorArchitecture(2), ProcessorLevel(2), ProcessorRevision(2), NumberOfProcessors(1), ProductType(1)
-    (arch, level, rev, num_cpus, prod_type), off = read_struct(data, off, "<HHHBB")
-    arch_names = {0: "x86", 5: "ARM", 6: "IA64", 9: "AMD64", 12: "ARM64"}
-    return {
-        "arch": arch_names.get(arch, f"unknown({arch})"),
-        "num_cpus": num_cpus,
-    }
+def _find_tool(name):
+    homebrew = f"/opt/homebrew/opt/llvm/bin/{name}"
+    return homebrew if os.path.exists(homebrew) else name
 
+def build_symbol_map(pdb_path):
+    """
+    Dump public symbols from PDB via llvm-pdbutil and return a sorted list of
+    (rva, name) pairs. Section 1 (.text) offsets are used as RVA approximations.
+    """
+    tool = _find_tool("llvm-pdbutil")
+    try:
+        result = subprocess.run(
+            [tool, "dump", "--publics", pdb_path],
+            capture_output=True, text=True, timeout=60
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        print(f"  [warn] {tool}: {e}", file=sys.stderr)
+        return []
 
-def main(path):
+    symbols = []
+    current_name = None
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("demangled ="):
+            current_name = line.split("=", 1)[1].strip()
+        elif line.startswith("mangled =") and not current_name:
+            current_name = line.split("=", 1)[1].strip()
+        elif line.startswith("addr =") and current_name:
+            addr_str = line.split("=", 1)[1].strip()
+            try:
+                section_str, offset_str = addr_str.split(":")
+                section = int(section_str, 16)
+                offset  = int(offset_str, 16)
+                if section == 1:          # .text section → offset ≈ RVA
+                    symbols.append((offset, current_name))
+            except ValueError:
+                pass
+            current_name = None
+
+    symbols.sort(key=lambda x: x[0])
+    return symbols
+
+def lookup_symbol(rva, symbol_map):
+    """Binary search: nearest symbol at or before rva."""
+    if not symbol_map:
+        return None, None
+    lo, hi = 0, len(symbol_map) - 1
+    idx = -1
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        if symbol_map[mid][0] <= rva:
+            idx = mid
+            lo = mid + 1
+        else:
+            hi = mid - 1
+    if idx < 0:
+        return None, None
+    sym_rva, sym_name = symbol_map[idx]
+    return sym_name, rva - sym_rva
+
+# ── Formatted address label ───────────────────────────────────────────────────
+
+def fmt_addr(addr, modules, symbol_map):
+    mn, mo = addr_to_module(addr, modules)
+    if not mn:
+        return f"0x{addr:016X}"
+    if mn.lower() == "magda.exe" and symbol_map:
+        sym, fn_off = lookup_symbol(mo, symbol_map)
+        if sym:
+            return f"0x{addr:016X}  {sym}+0x{fn_off:X}"
+    return f"0x{addr:016X}  {mn}+0x{mo:X}"
+
+# ── Top-level parse ───────────────────────────────────────────────────────────
+
+def parse(path, pdb_path=None):
     with open(path, "rb") as f:
         data = f.read()
 
-    print(f"Minidump: {path}  ({len(data):,} bytes)\n")
+    print(f"Minidump: {path}  ({len(data):,} bytes)")
+    if pdb_path:
+        print(f"PDB:      {pdb_path}")
 
     header  = parse_header(data)
     streams = parse_stream_directory(data, header)
 
-    # System info
     if SYSTEM_INFO_STREAM in streams:
         si = parse_system_info(data, streams[SYSTEM_INFO_STREAM])
-        print(f"Architecture: {si['arch']}  CPUs: {si['num_cpus']}")
+        print(f"Arch: {si['arch']}  CPUs: {si['num_cpus']}")
 
-    # Module list
-    modules = []
-    if MODULE_LIST_STREAM in streams:
-        modules = parse_module_list(data, streams[MODULE_LIST_STREAM])
+    modules = parse_module_list(data, streams[MODULE_LIST_STREAM]) if MODULE_LIST_STREAM in streams else []
 
-    # Exception
+    symbol_map = []
+    if pdb_path:
+        symbol_map = build_symbol_map(pdb_path)
+        if symbol_map:
+            print(f"Symbols:  {len(symbol_map):,} public symbols loaded from PDB")
+        else:
+            print("Symbols:  [failed — check llvm-pdbutil is installed]")
+
+    # ── Exception ────────────────────────────────────────────────────────────
     print("\n" + "="*70)
     print("EXCEPTION")
     print("="*70)
-    if EXCEPTION_STREAM not in streams:
-        print("  No exception stream found.")
-    else:
+    exc = None
+    if EXCEPTION_STREAM in streams:
         exc = parse_exception_stream(data, streams[EXCEPTION_STREAM])
         code_desc = EXCEPTION_CODES.get(exc["exc_code"], f"0x{exc['exc_code']:08X}")
-        print(f"  Thread ID:   0x{exc['thread_id']:X}")
-        print(f"  Code:        0x{exc['exc_code']:08X}  {code_desc}")
-        print(f"  Address:     0x{exc['exc_address']:016X}")
-
-        mod_name, mod_off = addr_to_module(exc["exc_address"], modules)
-        if mod_name:
-            print(f"               → {mod_name} + 0x{mod_off:X}")
+        print(f"  Thread:  0x{exc['thread_id']:X}")
+        print(f"  Code:    0x{exc['exc_code']:08X}  {code_desc}")
+        print(f"  Address: {fmt_addr(exc['exc_address'], modules, symbol_map)}")
 
         if exc["exc_code"] == 0xC0000005 and exc["num_params"] >= 2:
             av_type = ACCESS_VIOLATION_TYPE.get(exc["exc_info"][0], f"type={exc['exc_info'][0]}")
             av_addr = exc["exc_info"][1]
-            print(f"  AV type:     {av_type} at 0x{av_addr:016X}")
-            if av_addr == 0:
-                print("               → NULL pointer dereference")
-            elif av_addr < 0x10000:
-                print(f"               → Small offset from NULL (offset={av_addr}) — likely vtable/member of null object")
+            note = ""
+            if av_addr == 0:                    note = "  ← NULL dereference"
+            elif av_addr < 0x10000:             note = f"  ← small offset from NULL ({av_addr})"
+            elif av_addr == 0xFFFFFFFFFFFFFFFF: note = "  ← sentinel/corruption (-1)"
+            print(f"  AV:      {av_type} at 0x{av_addr:016X}{note}")
 
-        # Crashing thread context (from exception stream)
         if exc["ctx_rva"] and exc["ctx_size"]:
             regs = parse_x64_context(data, exc["ctx_rva"], exc["ctx_size"])
             if regs:
                 print("\n  Registers:")
-                key_regs = ["Rip", "Rsp", "Rbp", "Rax", "Rcx", "Rdx", "Rbx",
-                            "Rsi", "Rdi", "R8", "R9", "R10", "R11", "R12", "R13", "R14", "R15"]
-                for name in key_regs:
+                for name in ["Rip","Rsp","Rbp","Rax","Rcx","Rdx","Rbx","Rsi","Rdi",
+                             "R8","R9","R10","R11","R12","R13","R14","R15"]:
                     if name in regs:
-                        val = regs[name]
-                        mn, mo = addr_to_module(val, modules)
-                        suffix = f"  → {mn}+0x{mo:X}" if mn else ""
-                        print(f"    {name:>4} = 0x{val:016X}{suffix}")
+                        print(f"    {name:>4} = {fmt_addr(regs[name], modules, symbol_map)}")
+    else:
+        print("  No exception stream found.")
 
-    # Thread list + stack scan
+    # ── Threads (summary) ────────────────────────────────────────────────────
+    threads = parse_thread_list(data, streams[THREAD_LIST_STREAM]) if THREAD_LIST_STREAM in streams else []
     print("\n" + "="*70)
     print("THREADS")
     print("="*70)
-    threads = []
-    if THREAD_LIST_STREAM in streams:
-        threads = parse_thread_list(data, streams[THREAD_LIST_STREAM])
-        crashing_tid = exc["thread_id"] if EXCEPTION_STREAM in streams else None
+    for t in threads:
+        marker = " *** CRASHING ***" if exc and t["tid"] == exc["thread_id"] else ""
+        regs = parse_x64_context(data, t["ctx_rva"], t["ctx_size"]) if t["ctx_rva"] else {}
+        rip  = regs.get("Rip", 0)
+        print(f"  TID=0x{t['tid']:X}{marker}  RIP={fmt_addr(rip, modules, symbol_map)}")
 
-        for t in threads:
-            marker = " *** CRASHING ***" if t["tid"] == crashing_tid else ""
-            regs = parse_x64_context(data, t["ctx_rva"], t["ctx_size"]) if t["ctx_rva"] else {}
-            rip = regs.get("Rip", 0)
-            mn, mo = addr_to_module(rip, modules)
-            rip_str = f"  RIP=0x{rip:016X}" + (f" → {mn}+0x{mo:X}" if mn else "")
-            print(f"\n  TID=0x{t['tid']:X}{marker}{rip_str}")
-
-    # Stack trace for crashing thread
+    # ── Stack scan (crashing thread) ─────────────────────────────────────────
     print("\n" + "="*70)
     print("STACK SCAN (crashing thread)")
     print("="*70)
-    if EXCEPTION_STREAM in streams and threads:
-        crashing_tid = exc["thread_id"]
-        ct = next((t for t in threads if t["tid"] == crashing_tid), None)
+    if exc and threads:
+        ct = next((t for t in threads if t["tid"] == exc["thread_id"]), None)
         if ct:
-            hits = scan_stack_for_addresses(data, ct, modules)
-            # Deduplicate consecutive same-module hits
+            hits = scan_stack(data, ct, modules)
             seen = set()
             count = 0
-            for addr, mod_name, offset in hits:
-                key = (mod_name, offset)
+            for addr, mn, mo in hits:
+                key = (mn, mo)
                 if key in seen:
                     continue
                 seen.add(key)
-                print(f"  0x{addr:016X}  {mod_name}+0x{offset:X}")
+                if mn.lower() == "magda.exe" and symbol_map:
+                    sym, fn_off = lookup_symbol(mo, symbol_map)
+                    label = f"{sym}+0x{fn_off:X}" if sym else f"{mn}+0x{mo:X}"
+                else:
+                    label = f"{mn}+0x{mo:X}"
+                print(f"  0x{addr:016X}  {label}")
                 count += 1
                 if count >= 60:
                     print(f"  ... ({len(hits) - count} more)")
                     break
-        else:
-            print("  Could not find crashing thread in thread list.")
 
-    # Module list
+    # ── Module list ──────────────────────────────────────────────────────────
     print("\n" + "="*70)
     print("MODULES")
     print("="*70)
     for m in modules:
-        print(f"  0x{m['base']:016X} - 0x{m['end']:016X}  {m['name']}")
+        print(f"  0x{m['base']:016X}  {m['name']}")
 
     print()
 
+    # Return structured data for programmatic use (analyze-crash.py)
+    return {
+        "exc": exc,
+        "modules": modules,
+        "symbol_map": symbol_map,
+    }
+
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        print(f"Usage: {sys.argv[0]} <file.dmp>")
-        sys.exit(1)
-    main(sys.argv[1])
+    import argparse
+    ap = argparse.ArgumentParser(description="Parse a Windows minidump file")
+    ap.add_argument("dump", help="Path to .dmp file")
+    ap.add_argument("--pdb", help="Path to MAGDA.pdb for symbol resolution")
+    args = ap.parse_args()
+    parse(args.dump, pdb_path=args.pdb)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,6 +332,20 @@ jobs:
           exit 1
         }
 
+    - name: Locate and stage PDB
+      shell: powershell
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        $pdb = Get-ChildItem -Path build -Recurse -Filter "MAGDA.pdb" | Select-Object -First 1
+        if ($pdb) {
+          $pdbName = "MAGDA-$env:VERSION-Windows-x86_64.pdb"
+          Copy-Item $pdb.FullName $pdbName
+          Write-Output "Staged PDB: $pdbName"
+        } else {
+          Write-Warning "MAGDA.pdb not found — crash symbolization unavailable for this release"
+        }
+
     - name: Create installer
       shell: powershell
       env:
@@ -375,6 +389,7 @@ jobs:
         path: |
           MAGDA-*-Windows-x86_64-Setup.exe
           MAGDA-*-Windows-x86_64-Setup.exe.sha256
+          MAGDA-*-Windows-x86_64.pdb
 
     - name: Clean up
       if: always()
@@ -586,5 +601,7 @@ jobs:
         fail_on_unmatched_files: true
         files: |
           macos-release/*
-          windows-x86_64-release/*
+          windows-x86_64-release/MAGDA-*-Windows-x86_64-Setup.exe
+          windows-x86_64-release/MAGDA-*-Windows-x86_64-Setup.exe.sha256
+          windows-x86_64-release/MAGDA-*-Windows-x86_64.pdb
           linux-release/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,9 @@ endif()
 # Compiler flags
 if(MSVC)
     set(CMAKE_CXX_FLAGS_DEBUG "/Zi /Od /W3")
-    set(CMAKE_CXX_FLAGS_RELEASE "/O2 /DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELEASE "/O2 /Zi /DNDEBUG")
+    # /DEBUG keeps the PDB reference in the EXE; /OPT:REF,ICF preserve release dead-stripping
+    string(APPEND CMAKE_EXE_LINKER_FLAGS_RELEASE " /DEBUG /OPT:REF /OPT:ICF")
 else()
     set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wextra")
     set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")

--- a/TRUST.md
+++ b/TRUST.md
@@ -1,0 +1,84 @@
+# Project Commitments
+
+*Last updated: 2026-04-15*
+
+This document describes the commitments I make as the maintainer of magda-core to users and contributors. These are promises about how the project is run, beyond what the license itself requires.
+
+## Licensing
+
+magda-core is licensed under GPL-3.0.
+
+I commit to the following:
+
+- Any version of magda-core released under GPL-3.0 will remain available under GPL-3.0 in perpetuity. No future licensing decision can retroactively remove the GPL-licensed version from circulation.
+- The main branch and tagged releases of this repository will continue to be published under GPL-3.0 for the foreseeable future.
+- If the project is ever sold, transferred, or undergoes a major governance change, the GPL-licensed codebase as of that date will remain available for community forking, and I will support that transition in good faith.
+
+If magda-core ever adopts a dual-licensing or commercial offering in addition to the GPL track (for example, to fund development or offer commercial support), this will be announced openly with reasoning, and the GPL track will continue in parallel.
+
+## Contributor License Agreement
+
+magda-core currently uses a CLA for external contributions. I want to be transparent about why it exists and what it does.
+
+The CLA grants me, as maintainer, the right to relicense contributed code under alternative licenses. In practice, this exists to preserve the option of offering a commercial license alongside the GPL version in the future, and to resolve potential license-compatibility issues with upstream dependencies.
+
+What the CLA does **not** mean:
+
+- It does not remove any contributor's rights to their own work. Contributors retain copyright and can use their contributions however they like elsewhere.
+- It does not allow me to retroactively un-GPL any released version of magda-core (see the Licensing section above).
+- It does not give me ownership of contributors' work — only a broad license to use it.
+
+I am open to revisiting the CLA structure (including moving to a DCO-based model) based on contributor feedback. If you are considering contributing and the CLA is a blocker, please open a discussion.
+
+## Engineering Practices
+
+magda-core is built with deliberate attention to software engineering discipline. Regardless of whether code is written by hand or with AI assistance, the same standards apply:
+
+- **Design patterns.** The codebase follows established design patterns appropriate to a DAW architecture — clear separation of concerns between audio engine, UI, plugin hosting, and project persistence.
+- **Modularity.** Components are built to be testable, replaceable, and independently reasoned about. I resist shortcuts that create hidden coupling.
+- **Change discipline.** Changes go through pull requests with a clear description of intent. AI-assisted contributions are held to the same standard as any other code.
+- **Testing.** Critical paths (audio rendering, project save/load, plugin state) are covered by automated tests. Bug fixes come with regression tests where practical.
+- **Readability.** Code is written to be read. Naming, structure, and comments are treated as part of the product, not an afterthought.
+
+These are not claims of perfection — bugs will still happen and architecture will still evolve. They are commitments about how I approach the work.
+
+## AI-Assisted Development
+
+magda-core is developed with AI-assisted tooling as part of the workflow. I believe in being transparent about this rather than hiding it, since it is increasingly common across the industry.
+
+My practices:
+
+- All code, whether human-written or AI-assisted, is reviewed and integrated by me. I am the author of record for the project and take responsibility for what ships.
+- AI tools are used as assistance for implementation, refactoring, test generation, and debugging — not as unreviewed code generators.
+- I review AI-assisted output for structural originality before integration. I do not accept large verbatim suggestions that appear to reproduce identifiable third-party code.
+- The project does not knowingly incorporate code from licenses incompatible with GPL-3.0.
+
+If any user identifies code in magda-core that appears to reproduce copyrighted material from another source, please open an issue with the label `license-concern` and I will investigate and remediate promptly.
+
+The copyright position of magda-core is standard for AI-assisted projects: the creative direction, architecture, integration, and authorship decisions are human-made, and the project as a whole is a copyrightable human-authored work. This aligns with current guidance from the U.S. Copyright Office and similar bodies.
+
+## Maintainer Commitments
+
+- **Bug triage.** I aim to triage new issues within a reasonable window and prioritize reproducible bugs on supported platforms. Issues that cannot be reproduced or that lack sufficient information may be labeled `needs-info` and closed if they remain inactive.
+- **Breaking changes.** Breaking changes are documented in the changelog with migration notes.
+- **Telemetry.** magda-core does not include telemetry, analytics, or phone-home behavior. Your project files, settings, and usage stay on your machine.
+- **Data locality.** All user data (projects, settings, plugin state) is stored locally. The project has no cloud dependency.
+- **Deprecation.** If I ever need to stop maintaining magda-core, I will post a clear deprecation notice well in advance and, where possible, help transition to a community fork.
+
+## Scope of Support
+
+magda-core targets the following platforms as primary support tier:
+
+- Windows 10 / 11
+- macOS (recent versions)
+- Major Linux distributions with PipeWire
+
+Bugs on supported platforms are prioritized. Bugs on other configurations (older distros, exotic audio stacks, specific hardware combinations) are accepted and investigated as time permits, but may not be fixed on the same timeline.
+
+## Reporting Concerns
+
+If you have a concern about any commitment in this document, or believe the project is not living up to it, please open an issue or start a discussion. I would rather hear about a concern directly than have it go unaddressed.
+
+---
+
+*These commitments are written in good faith. They will evolve as the project grows, but any change will be visible in the commit history of this file.*

--- a/magda/daw/audio/AudioThumbnailManager.cpp
+++ b/magda/daw/audio/AudioThumbnailManager.cpp
@@ -241,8 +241,7 @@ void AudioThumbnailManager::clearCachedTransients(const juce::String& filePath) 
 
 juce::AudioFormatReader* AudioThumbnailManager::getOrCreateReader(
     const juce::String& audioFilePath) {
-    auto key = audioFilePath.toStdString();
-    auto it = readerIndex_.find(key);
+    auto it = readerIndex_.find(audioFilePath);
 
     if (it != readerIndex_.end()) {
         // Move to front (most recently used)
@@ -262,12 +261,12 @@ juce::AudioFormatReader* AudioThumbnailManager::getOrCreateReader(
 
     // Insert at front
     readerLru_.push_front({audioFilePath, std::move(reader)});
-    readerIndex_[key] = readerLru_.begin();
+    readerIndex_[audioFilePath] = readerLru_.begin();
 
     // Evict LRU entries if over limit
     while (readerLru_.size() > MAX_CACHED_READERS) {
         auto& back = readerLru_.back();
-        readerIndex_.erase(back.path.toStdString());
+        readerIndex_.erase(back.path);
         readerLru_.pop_back();
     }
 

--- a/magda/daw/audio/AudioThumbnailManager.hpp
+++ b/magda/daw/audio/AudioThumbnailManager.hpp
@@ -145,7 +145,7 @@ class AudioThumbnailManager {
 
     // LRU list: front = most recently used, back = least recently used
     std::list<ReaderEntry> readerLru_;
-    // Map path -> iterator into readerLru_ for O(1) lookup
+    // Map path -> iterator into readerLru_ for O(log N) lookup
     std::map<juce::String, std::list<ReaderEntry>::iterator> readerIndex_;
 
     juce::AudioFormatReader* getOrCreateReader(const juce::String& audioFilePath);

--- a/magda/daw/audio/AudioThumbnailManager.hpp
+++ b/magda/daw/audio/AudioThumbnailManager.hpp
@@ -8,8 +8,6 @@
 #include <list>
 #include <map>
 #include <memory>
-#include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace magda {
@@ -148,7 +146,7 @@ class AudioThumbnailManager {
     // LRU list: front = most recently used, back = least recently used
     std::list<ReaderEntry> readerLru_;
     // Map path -> iterator into readerLru_ for O(1) lookup
-    std::unordered_map<std::string, std::list<ReaderEntry>::iterator> readerIndex_;
+    std::map<juce::String, std::list<ReaderEntry>::iterator> readerIndex_;
 
     juce::AudioFormatReader* getOrCreateReader(const juce::String& audioFilePath);
 


### PR DESCRIPTION
## Summary

- `AudioThumbnailManager::readerIndex_` used `std::unordered_map<std::string, ...>` with keys built via `juce::String::toStdString()`
- On Windows with non-ASCII paths (e.g. Chinese characters), NFC/NFD normalization differences between call sites could cause the LRU eviction `erase()` to silently no-op, leaving a **dangling `std::list` iterator** in the map
- The next `getOrCreateReader()` call would `splice`/dereference the freed node → access violation reading from `0xFFFFFFFFFFFFFFFF`

Fix: switch to `std::map<juce::String, ...>` so keys use JUCE's own string comparison throughout, with no lossy `toStdString()` conversion.

## Test plan

- [ ] Build passes on macOS
- [ ] Windows build with a project containing audio files in a path with non-ASCII (Chinese/Japanese/etc.) characters no longer crashes on reopen