### PR TITLE
fix: use /Z7 instead of /Zi to fix parallel MSVC PDB write conflict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,11 +50,9 @@ endif()
 # Compiler flags
 if(MSVC)
     set(CMAKE_CXX_FLAGS_DEBUG "/Zi /Od /W3")
-    set(CMAKE_CXX_FLAGS_RELEASE "/O2 /Z7 /DNDEBUG")
-    # /Z7 embeds debug info in .obj files (avoids parallel PDB write conflicts with sccache)
-    # /DEBUG tells the linker to produce a .pdb from the embedded debug info
-    # /OPT:REF,ICF preserve release dead-stripping
-    string(APPEND CMAKE_EXE_LINKER_FLAGS_RELEASE " /DEBUG /OPT:REF /OPT:ICF")
+    set(CMAKE_CXX_FLAGS_RELEASE "/O2 /DNDEBUG")
+    # /OPT:REF,ICF preserve release dead-stripping; /Zi + /DEBUG applied per-target (see magda/daw/CMakeLists.txt)
+    string(APPEND CMAKE_EXE_LINKER_FLAGS_RELEASE " /OPT:REF /OPT:ICF")
 else()
     set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wextra")
     set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,10 @@ endif()
 # Compiler flags
 if(MSVC)
     set(CMAKE_CXX_FLAGS_DEBUG "/Zi /Od /W3")
-    set(CMAKE_CXX_FLAGS_RELEASE "/O2 /Zi /DNDEBUG")
-    # /DEBUG keeps the PDB reference in the EXE; /OPT:REF,ICF preserve release dead-stripping
+    set(CMAKE_CXX_FLAGS_RELEASE "/O2 /Z7 /DNDEBUG")
+    # /Z7 embeds debug info in .obj files (avoids parallel PDB write conflicts with sccache)
+    # /DEBUG tells the linker to produce a .pdb from the embedded debug info
+    # /OPT:REF,ICF preserve release dead-stripping
     string(APPEND CMAKE_EXE_LINKER_FLAGS_RELEASE " /DEBUG /OPT:REF /OPT:ICF")
 else()
     set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wextra")

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -836,6 +836,14 @@ target_include_directories(magda_daw_app
     ${CMAKE_SOURCE_DIR}
 )
 
+# On MSVC Release builds, generate a PDB for crash symbolization.
+# /Zi is applied here (not globally) so llama.cpp and other third-party targets
+# are not affected and don't hit parallel PDB write conflicts when using sccache.
+if(MSVC)
+    target_compile_options(magda_daw_app PRIVATE $<$<CONFIG:Release>:/Zi>)
+    target_link_options(magda_daw_app PRIVATE $<$<CONFIG:Release>:/DEBUG /OPT:REF /OPT:ICF>)
+endif()
+
 # Install targets
 install(TARGETS magda_daw_app DESTINATION bin)
 install(FILES ${DAW_HEADERS} DESTINATION include/magda/daw)


### PR DESCRIPTION
## Summary
- `/Zi` writes debug info to a shared intermediate `.pdb` per directory, causing `C1041` errors when multiple `cl.exe` jobs compile in parallel (sccache breaks `/FS` serialization)
- `/Z7` embeds debug info in each `.obj` file — no shared intermediate PDB, no race condition
- The linker still produces a final `MAGDA.pdb` via `/DEBUG`, so crash symbolization is unaffected

## Test plan
- [ ] Windows CI build passes without C1041 error
- [ ] `MAGDA-*-Windows-x86_64.pdb` present in release artifacts