### PR TITLE
fix: switch /Zi to /Z7 on magda_daw_app for sccache compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,11 +50,9 @@ endif()
 # Compiler flags
 if(MSVC)
     set(CMAKE_CXX_FLAGS_DEBUG "/Zi /Od /W3")
-    set(CMAKE_CXX_FLAGS_RELEASE "/O2 /Z7 /DNDEBUG")
-    # /Z7 embeds debug info in .obj files (avoids parallel PDB write conflicts with sccache)
-    # /DEBUG tells the linker to produce a .pdb from the embedded debug info
-    # /OPT:REF,ICF preserve release dead-stripping
-    string(APPEND CMAKE_EXE_LINKER_FLAGS_RELEASE " /DEBUG /OPT:REF /OPT:ICF")
+    set(CMAKE_CXX_FLAGS_RELEASE "/O2 /DNDEBUG")
+    # /OPT:REF,ICF preserve release dead-stripping; /Zi + /DEBUG applied per-target (see magda/daw/CMakeLists.txt)
+    string(APPEND CMAKE_EXE_LINKER_FLAGS_RELEASE " /OPT:REF /OPT:ICF")
 else()
     set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wextra")
     set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,10 @@ endif()
 # Compiler flags
 if(MSVC)
     set(CMAKE_CXX_FLAGS_DEBUG "/Zi /Od /W3")
-    set(CMAKE_CXX_FLAGS_RELEASE "/O2 /Zi /DNDEBUG")
-    # /DEBUG keeps the PDB reference in the EXE; /OPT:REF,ICF preserve release dead-stripping
+    set(CMAKE_CXX_FLAGS_RELEASE "/O2 /Z7 /DNDEBUG")
+    # /Z7 embeds debug info in .obj files (avoids parallel PDB write conflicts with sccache)
+    # /DEBUG tells the linker to produce a .pdb from the embedded debug info
+    # /OPT:REF,ICF preserve release dead-stripping
     string(APPEND CMAKE_EXE_LINKER_FLAGS_RELEASE " /DEBUG /OPT:REF /OPT:ICF")
 else()
     set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall -Wextra")

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -836,6 +836,14 @@ target_include_directories(magda_daw_app
     ${CMAKE_SOURCE_DIR}
 )
 
+# On MSVC Release builds, generate a PDB for crash symbolization.
+# /Zi is applied here (not globally) so llama.cpp and other third-party targets
+# are not affected and don't hit parallel PDB write conflicts when using sccache.
+if(MSVC)
+    target_compile_options(magda_daw_app PRIVATE $<$<CONFIG:Release>:/Zi>)
+    target_link_options(magda_daw_app PRIVATE $<$<CONFIG:Release>:/DEBUG /OPT:REF /OPT:ICF>)
+endif()
+
 # Install targets
 install(TARGETS magda_daw_app DESTINATION bin)
 install(FILES ${DAW_HEADERS} DESTINATION include/magda/daw)

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -837,10 +837,12 @@ target_include_directories(magda_daw_app
 )
 
 # On MSVC Release builds, generate a PDB for crash symbolization.
-# /Zi is applied here (not globally) so llama.cpp and other third-party targets
-# are not affected and don't hit parallel PDB write conflicts when using sccache.
+# /Z7 embeds debug info in .obj files rather than a shared intermediate .pdb,
+# avoiding C1041 parallel-write conflicts when sccache intercepts cl.exe (/FS
+# serialization doesn't survive the sccache proxy). The linker /DEBUG flag
+# extracts the debug info into a final MAGDA.pdb; the .exe itself is not larger.
 if(MSVC)
-    target_compile_options(magda_daw_app PRIVATE $<$<CONFIG:Release>:/Zi>)
+    target_compile_options(magda_daw_app PRIVATE $<$<CONFIG:Release>:/Z7>)
     target_link_options(magda_daw_app PRIVATE $<$<CONFIG:Release>:/DEBUG /OPT:REF /OPT:ICF>)
 endif()
 


### PR DESCRIPTION
## Problem
`/Zi` writes debug info to a shared intermediate `.pdb` per directory. `/FS` is supposed to serialize those writes, but sccache proxies `cl.exe` and breaks the synchronisation — causing C1041 on parallel builds.

## Fix
Use `/Z7` instead: debug info is embedded in each `.obj` file, so there is no shared intermediate PDB and no race condition. The linker `/DEBUG` flag extracts the debug info into a final `MAGDA.pdb`; the `.exe` itself is not larger.

## Test plan
- [ ] Windows CI build passes without C1041
- [ ] `MAGDA-*-Windows-x86_64.pdb` present in release artifacts