### PR TITLE
feat(drag-drop): multi-sample drag-and-drop across arrangement, sessi…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [ '**' ]
     tags-ignore: [ '**' ]
+    # Skip CI when a push only touches translation files. Crowdin sync PRs
+    # only ever modify lang/**, so they no longer burn a full matrix build.
+    # Any push that mixes lang changes with real code still runs CI because
+    # paths-ignore is AND across all modified files.
+    paths-ignore:
+      - 'lang/**'
   workflow_dispatch:
     inputs:
       skip-cpp-build:

--- a/lang/en.json
+++ b/lang/en.json
@@ -62,6 +62,7 @@
     "track.delete": "Delete Track",
     "track.duplicate": "Duplicate Track",
     "track.duplicate_no_content": "Duplicate Track Without Content",
+    "track.duplicate_content_only": "Duplicate Track Content Only",
     "track.mute": "Mute Track",
     "track.solo": "Solo Track",
 
@@ -111,6 +112,7 @@
     "unfreeze": "Unfreeze Track",
     "duplicate": "Duplicate Track",
     "duplicate_no_content": "Duplicate Track Without Content",
+    "duplicate_content_only": "Duplicate Track Content Only",
     "delete": "Delete Track",
     "show_io_routing": "Show I/O Routing",
     "hide_io_routing": "Hide I/O Routing",

--- a/magda/agents/dsl_grammar.hpp
+++ b/magda/agents/dsl_grammar.hpp
@@ -197,9 +197,21 @@ BUILT-IN FUNCTIONS:
 - random(min, max) - Returns a random value between min and max (inclusive). Integer if both args are integers, float otherwise.
   Example: .clip.new(length_bars=random(1, 4)) - Create a clip with random length between 1 and 4 bars
 
-NOTE: The DAW state JSON includes "selected_track_id" when a track is selected, and "selected_clip_index" / "selected_clip_track_id" when a clip is selected.
-Use track(id=N) to reference any track. When the user says "this track" or implies the current selection, use the selected_track_id from the state.
-For note operations, use the selected_clip_track_id to reference the track owning the selected clip.
+SELECTED-TRACK TARGETING (IMPORTANT):
+The DAW state JSON includes "selected_track_id" when a track is selected, and
+"selected_clip_index" / "selected_clip_track_id" when a clip is selected.
+
+When "selected_track_id" is present in the state, target that track BY DEFAULT
+for every content operation — clip.new, note.add, fx.add, track.set_*, etc. —
+even if the user does not explicitly say "this track". A verb like "add",
+"put", "write", or "generate" with no explicit target MUST target the selected
+track. Only emit track.new(...) when the user explicitly asks for a NEW track
+(phrases like "new track", "another track", "create a track", "on a new
+track", "on its own track"). When "selected_track_id" is absent, it is
+acceptable to create a new track as needed.
+
+For note operations on the selected clip, target "selected_clip_track_id"
+instead of "selected_track_id".
 
 **CRITICAL: Always generate DSL code. Never generate plain text responses.**
 )DESC";

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -1,6 +1,7 @@
 #include "dsl_interpreter.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <cctype>
 #include <cmath>
 #include <cstdlib>
@@ -1422,6 +1423,18 @@ double Interpreter::barsToTime(double bar) const {
 // State Snapshot
 // ============================================================================
 
+namespace {
+std::atomic<bool> g_contextEnabled{true};
+}
+
+void Interpreter::setContextEnabled(bool enabled) {
+    g_contextEnabled.store(enabled, std::memory_order_relaxed);
+}
+
+bool Interpreter::isContextEnabled() {
+    return g_contextEnabled.load(std::memory_order_relaxed);
+}
+
 juce::String Interpreter::buildStateSnapshot() {
     auto& tm = TrackManager::getInstance();
 
@@ -1441,7 +1454,12 @@ juce::String Interpreter::buildStateSnapshot() {
     root->setProperty("tracks", tracksArray);
     root->setProperty("track_count", tm.getNumTracks());
 
-    // Current selection context
+    // Selection context — only exposed to the LLM when the UI's context
+    // toggle is enabled. When disabled, the snapshot still lists the tracks
+    // but omits the selection so the LLM has no bias signal.
+    if (!g_contextEnabled.load(std::memory_order_relaxed))
+        return juce::JSON::toString(juce::var(root), true);
+
     auto& sm = SelectionManager::getInstance();
     auto selTrack = sm.getSelectedTrack();
     if (selTrack != INVALID_TRACK_ID) {

--- a/magda/agents/dsl_interpreter.hpp
+++ b/magda/agents/dsl_interpreter.hpp
@@ -169,9 +169,17 @@ class Interpreter {
     }
 
     /**
-     * @brief Build a JSON snapshot of current project state for LLM context
+     * @brief Build a JSON snapshot of current project state for LLM context.
+     *
+     * Includes the user's current track/clip selection by default so the LLM
+     * can target it. Controlled by setContextEnabled(): when false, the
+     * snapshot omits selection info so the LLM has no bias signal.
      */
     static juce::String buildStateSnapshot();
+
+    /** Toggle whether the state snapshot exposes the UI selection to the LLM. */
+    static void setContextEnabled(bool enabled);
+    static bool isContextEnabled();
 
   private:
     // Statement parsing

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -123,20 +123,26 @@ void DeleteTrackCommand::undo() {
 // DuplicateTrackCommand
 // ============================================================================
 
-DuplicateTrackCommand::DuplicateTrackCommand(TrackId sourceTrackId, bool duplicateContent)
-    : sourceTrackId_(sourceTrackId), duplicateContent_(duplicateContent) {}
+DuplicateTrackCommand::DuplicateTrackCommand(TrackId sourceTrackId, bool duplicateContent,
+                                             bool duplicateDevices)
+    : sourceTrackId_(sourceTrackId),
+      duplicateContent_(duplicateContent),
+      duplicateDevices_(duplicateDevices) {}
 
 void DuplicateTrackCommand::execute() {
     auto& trackManager = TrackManager::getInstance();
 
-    // Capture current plugin state so the duplicate gets the source's live settings
-    if (auto* engine = trackManager.getAudioEngine()) {
-        if (auto* bridge = engine->getAudioBridge()) {
-            bridge->captureAllPluginStates();
+    // Capture current plugin state so the duplicate gets the source's live settings.
+    // Skipped when we're stripping the FX chain anyway — nothing to carry over.
+    if (duplicateDevices_) {
+        if (auto* engine = trackManager.getAudioEngine()) {
+            if (auto* bridge = engine->getAudioBridge()) {
+                bridge->captureAllPluginStates();
+            }
         }
     }
 
-    duplicatedTrackId_ = trackManager.duplicateTrack(sourceTrackId_);
+    duplicatedTrackId_ = trackManager.duplicateTrack(sourceTrackId_, duplicateDevices_);
 
     if (duplicateContent_ && duplicatedTrackId_ != INVALID_TRACK_ID) {
         auto& clipManager = ClipManager::getInstance();

--- a/magda/daw/core/TrackCommands.hpp
+++ b/magda/daw/core/TrackCommands.hpp
@@ -56,12 +56,19 @@ class DeleteTrackCommand : public UndoableCommand {
  */
 class DuplicateTrackCommand : public UndoableCommand {
   public:
-    explicit DuplicateTrackCommand(TrackId sourceTrackId, bool duplicateContent = true);
+    explicit DuplicateTrackCommand(TrackId sourceTrackId, bool duplicateContent = true,
+                                   bool duplicateDevices = true);
 
     void execute() override;
     void undo() override;
     juce::String getDescription() const override {
-        return duplicateContent_ ? "Duplicate Track" : "Duplicate Track Without Content";
+        if (duplicateContent_ && duplicateDevices_)
+            return "Duplicate Track";
+        if (!duplicateContent_ && duplicateDevices_)
+            return "Duplicate Track Without Content";
+        if (duplicateContent_ && !duplicateDevices_)
+            return "Duplicate Track Content Only";
+        return "Duplicate Track (Empty)";
     }
 
     TrackId getDuplicatedTrackId() const {
@@ -71,6 +78,7 @@ class DuplicateTrackCommand : public UndoableCommand {
   private:
     TrackId sourceTrackId_;
     bool duplicateContent_;
+    bool duplicateDevices_;
     TrackId duplicatedTrackId_ = INVALID_TRACK_ID;
     bool executed_ = false;
 };

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -350,7 +350,7 @@ void TrackManager::restoreTrack(const TrackInfo& trackInfo) {
     DBG("Restored track: " << trackInfo.name << " (id=" << trackInfo.id << ")");
 }
 
-TrackId TrackManager::duplicateTrack(TrackId trackId) {
+TrackId TrackManager::duplicateTrack(TrackId trackId, bool includeDevices) {
     auto it = std::find_if(tracks_.begin(), tracks_.end(),
                            [trackId](const TrackInfo& t) { return t.id == trackId; });
 
@@ -362,6 +362,11 @@ TrackId TrackManager::duplicateTrack(TrackId trackId) {
     newTrack.id = nextTrackId_++;
     newTrack.name = it->name + " Copy";
     newTrack.childIds.clear();  // Don't duplicate children references
+
+    // Content-only duplication: strip the FX chain so the duplicate starts clean.
+    if (!includeDevices) {
+        newTrack.chainElements.clear();
+    }
 
     // Reassign all device/rack/chain IDs so the duplicate gets its own
     // plugin instances in the audio engine (sharing IDs = no audio).

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -159,7 +159,12 @@ class TrackManager {
     TrackId createTrack(const juce::String& name = "", TrackType type = TrackType::Audio);
     TrackId createGroupTrack(const juce::String& name = "");
     void deleteTrack(TrackId trackId);
-    TrackId duplicateTrack(TrackId trackId);
+    /**
+     * Duplicate a track. When `includeDevices` is false, the new track is
+     * created empty (no plugins / racks / chain elements), giving a clean
+     * slate for workflows that want content-only duplication.
+     */
+    TrackId duplicateTrack(TrackId trackId, bool includeDevices = true);
     void restoreTrack(const TrackInfo& trackInfo);  // Used by undo system
     void moveTrack(TrackId trackId, int newIndex);
 

--- a/magda/daw/ui/components/chain/DrumGridUI.cpp
+++ b/magda/daw/ui/components/chain/DrumGridUI.cpp
@@ -556,22 +556,66 @@ bool DrumGridUI::isInterestedInFileDrag(const juce::StringArray& files) {
     return false;
 }
 
-void DrumGridUI::filesDropped(const juce::StringArray& files, int x, int y) {
-    // Find which pad the file was dropped on
+static int countAudioFilesDG(const juce::StringArray& files) {
+    int n = 0;
+    for (const auto& f : files) {
+        if (f.endsWithIgnoreCase(".wav") || f.endsWithIgnoreCase(".aif") ||
+            f.endsWithIgnoreCase(".aiff") || f.endsWithIgnoreCase(".flac") ||
+            f.endsWithIgnoreCase(".ogg") || f.endsWithIgnoreCase(".mp3"))
+            ++n;
+    }
+    return n;
+}
+
+void DrumGridUI::fileDragEnter(const juce::StringArray& files, int x, int y) {
+    fileDropCount_ = countAudioFilesDG(files);
     int btnIdx = padButtonIndexAtPoint({x, y});
-    if (btnIdx < 0)
+    fileDropStartPad_ = (btnIdx >= 0) ? currentPage_ * kPadsPerPage + btnIdx : -1;
+    repaint();
+}
+
+void DrumGridUI::fileDragMove(const juce::StringArray& /*files*/, int x, int y) {
+    int btnIdx = padButtonIndexAtPoint({x, y});
+    int newStart = (btnIdx >= 0) ? currentPage_ * kPadsPerPage + btnIdx : -1;
+    if (newStart != fileDropStartPad_) {
+        fileDropStartPad_ = newStart;
+        repaint();
+    }
+}
+
+void DrumGridUI::fileDragExit(const juce::StringArray& /*files*/) {
+    fileDropStartPad_ = -1;
+    fileDropCount_ = 0;
+    repaint();
+}
+
+void DrumGridUI::filesDropped(const juce::StringArray& files, int x, int y) {
+    fileDropStartPad_ = -1;
+    fileDropCount_ = 0;
+    repaint();
+
+    int btnIdx = padButtonIndexAtPoint({x, y});
+    if (btnIdx < 0 || !onSampleDropped)
         return;
 
     int padIndex = currentPage_ * kPadsPerPage + btnIdx;
+    int lastAssigned = -1;
 
     for (const auto& f : files) {
-        juce::File file(f);
-        if (file.existsAsFile() && onSampleDropped) {
-            setSelectedPad(padIndex);
-            onSampleDropped(padIndex, file);
+        if (padIndex >= kTotalPads)
             break;
-        }
+
+        juce::File file(f);
+        if (!file.existsAsFile())
+            continue;
+
+        onSampleDropped(padIndex, file);
+        lastAssigned = padIndex;
+        ++padIndex;
     }
+
+    if (lastAssigned >= 0)
+        setSelectedPad(lastAssigned);
 }
 
 // =============================================================================
@@ -637,16 +681,32 @@ void DrumGridUI::PaginationStripBg::paint(juce::Graphics& g) {
 }
 
 void DrumGridUI::paintOverChildren(juce::Graphics& g) {
-    // Drop highlight on pad (painted over children so it's visible on top of PadButton)
-    if (dropHighlightPad_ >= 0) {
+    auto highlightPad = [&](int absolutePadIndex, float alphaFill, float alphaStroke) {
         int pageStart = currentPage_ * kPadsPerPage;
-        int btnIdx = dropHighlightPad_ - pageStart;
-        if (btnIdx >= 0 && btnIdx < kPadsPerPage) {
-            auto padBounds = padButtons_[static_cast<size_t>(btnIdx)].getBounds();
-            g.setColour(juce::Colours::yellow.withAlpha(0.4f));
-            g.fillRoundedRectangle(padBounds.toFloat(), 3.0f);
-            g.setColour(juce::Colours::yellow.withAlpha(0.8f));
-            g.drawRoundedRectangle(padBounds.toFloat().reduced(1.0f), 3.0f, 1.5f);
+        int btnIdx = absolutePadIndex - pageStart;
+        if (btnIdx < 0 || btnIdx >= kPadsPerPage)
+            return;
+        auto padBounds = padButtons_[static_cast<size_t>(btnIdx)].getBounds();
+        g.setColour(juce::Colours::yellow.withAlpha(alphaFill));
+        g.fillRoundedRectangle(padBounds.toFloat(), 3.0f);
+        g.setColour(juce::Colours::yellow.withAlpha(alphaStroke));
+        g.drawRoundedRectangle(padBounds.toFloat().reduced(1.0f), 3.0f, 1.5f);
+    };
+
+    // Plugin/pad drop highlight — single pad under cursor.
+    if (dropHighlightPad_ >= 0)
+        highlightPad(dropHighlightPad_, 0.4f, 0.8f);
+
+    // File-drag preview — every pad that will receive a sample on drop.
+    if (fileDropStartPad_ >= 0 && fileDropCount_ > 0) {
+        for (int i = 0; i < fileDropCount_; ++i) {
+            int pad = fileDropStartPad_ + i;
+            if (pad >= kTotalPads)
+                break;
+            // First pad bright, the rest slightly dimmer so the origin reads.
+            const float f = (i == 0) ? 0.4f : 0.25f;
+            const float s = (i == 0) ? 0.8f : 0.55f;
+            highlightPad(pad, f, s);
         }
     }
 }

--- a/magda/daw/ui/components/chain/DrumGridUI.hpp
+++ b/magda/daw/ui/components/chain/DrumGridUI.hpp
@@ -166,6 +166,9 @@ class DrumGridUI : public juce::Component,
 
     // FileDragAndDropTarget
     bool isInterestedInFileDrag(const juce::StringArray& files) override;
+    void fileDragEnter(const juce::StringArray& files, int x, int y) override;
+    void fileDragMove(const juce::StringArray& files, int x, int y) override;
+    void fileDragExit(const juce::StringArray& files) override;
     void filesDropped(const juce::StringArray& files, int x, int y) override;
 
     // DragAndDropTarget (for plugin drops)
@@ -284,6 +287,10 @@ class DrumGridUI : public juce::Component,
 
     // Plugin drop highlight
     int dropHighlightPad_ = -1;
+    // File-drag hover preview: first absolute pad + number of audio files
+    // being dragged, so we can highlight every pad that will receive a sample.
+    int fileDropStartPad_ = -1;
+    int fileDropCount_ = 0;
 
     // DrumGridPlugin pointer for trigger polling
     daw::audio::DrumGridPlugin* drumGridPlugin_ = nullptr;

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -311,12 +311,12 @@ void TrackContentPanel::paintOverChildren(juce::Graphics& g) {
             g.setColour(juce::Colours::yellow.withAlpha(0.8f));
             g.drawLine(static_cast<float>(dropX), static_cast<float>(trackY),
                        static_cast<float>(dropX), static_cast<float>(trackY + trackHeight), 2.0f);
-        } else {
-            // Dropping on empty area — ghost one clip preview per audio file, each
-            // on its own phantom track row below the existing tracks. The ghost
-            // starts at the drop insertion time (never before it) and its width
-            // matches the sample duration so the user can judge layout.
-            const int numGhosts = juce::jmax(1, draggedAudioFiles_.size());
+        } else if (!draggedAudioFiles_.isEmpty()) {
+            // Dropping audio on empty area — ghost one clip preview per audio
+            // file, each on its own phantom track row below the existing tracks.
+            // The ghost starts at the drop insertion time (never before it) and
+            // its width matches the sample duration so the user can judge layout.
+            const int numGhosts = draggedAudioFiles_.size();
             const int topY = getTotalTracksHeight();
             const int ghostHeight = DEFAULT_TRACK_HEIGHT;
             const int baseIndex = TrackManager::getInstance().getNumTracks();
@@ -340,20 +340,24 @@ void TrackContentPanel::paintOverChildren(juce::Graphics& g) {
                 g.setColour(tint.withAlpha(0.9f));
                 g.drawRect(clipRect, 1);
 
-                // Filename inside the clip (left-aligned, with padding).
-                if (i < draggedAudioFiles_.size()) {
-                    auto name = juce::File(draggedAudioFiles_[i]).getFileNameWithoutExtension();
-                    g.setColour(tint.brighter(0.3f));
-                    g.setFont(juce::Font(juce::FontOptions(12.0f).withStyle("Bold")));
-                    g.drawFittedText(name, clipRect.reduced(6, 4), juce::Justification::centredLeft,
-                                     1);
-                }
+                auto name = juce::File(draggedAudioFiles_[i]).getFileNameWithoutExtension();
+                g.setColour(tint.brighter(0.3f));
+                g.setFont(juce::Font(juce::FontOptions(12.0f).withStyle("Bold")));
+                g.drawFittedText(name, clipRect.reduced(6, 4), juce::Justification::centredLeft, 1);
 
                 // Insertion marker (left edge of the clip).
                 g.setColour(tint.withAlpha(0.9f));
                 g.drawLine(static_cast<float>(dropX), static_cast<float>(y0),
                            static_cast<float>(dropX), static_cast<float>(y1), 2.0f);
             }
+        } else {
+            // Non-audio drop on empty area (e.g. MIDI-only) — simple insertion
+            // line only, no clip-shaped ghosts.
+            const int topY = getTotalTracksHeight();
+            const int bottomY = topY + DEFAULT_TRACK_HEIGHT;
+            g.setColour(juce::Colours::yellow.withAlpha(0.8f));
+            g.drawLine(static_cast<float>(dropX), static_cast<float>(topY),
+                       static_cast<float>(dropX), static_cast<float>(bottomY), 2.0f);
         }
     }
 }

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -304,7 +304,7 @@ void TrackContentPanel::paintOverChildren(juce::Graphics& g) {
 
         if (dropTargetTrackIndex_ >= 0 &&
             dropTargetTrackIndex_ < static_cast<int>(trackLanes.size())) {
-            // Dropping on an existing track — line spans that track
+            // Dropping on an existing track — line spans that track (append mode).
             int trackY = getTrackYPosition(dropTargetTrackIndex_);
             int trackHeight = getTrackHeight(dropTargetTrackIndex_);
 
@@ -312,13 +312,48 @@ void TrackContentPanel::paintOverChildren(juce::Graphics& g) {
             g.drawLine(static_cast<float>(dropX), static_cast<float>(trackY),
                        static_cast<float>(dropX), static_cast<float>(trackY + trackHeight), 2.0f);
         } else {
-            // Dropping on empty area — show drop line spanning a phantom track region
-            int topY = getTotalTracksHeight();
-            int bottomY = topY + DEFAULT_TRACK_HEIGHT;
+            // Dropping on empty area — ghost one clip preview per audio file, each
+            // on its own phantom track row below the existing tracks. The ghost
+            // starts at the drop insertion time (never before it) and its width
+            // matches the sample duration so the user can judge layout.
+            const int numGhosts = juce::jmax(1, draggedAudioFiles_.size());
+            const int topY = getTotalTracksHeight();
+            const int ghostHeight = DEFAULT_TRACK_HEIGHT;
+            const int baseIndex = TrackManager::getInstance().getNumTracks();
 
-            g.setColour(juce::Colours::yellow.withAlpha(0.8f));
-            g.drawLine(static_cast<float>(dropX), static_cast<float>(topY),
-                       static_cast<float>(dropX), static_cast<float>(bottomY), 2.0f);
+            for (int i = 0; i < numGhosts; ++i) {
+                const int y0 = topY + i * ghostHeight;
+                const int y1 = y0 + ghostHeight;
+
+                const auto tint = juce::Colour(Config::getDefaultColour(baseIndex + i));
+
+                // Ghost clip: starts at dropX, width derived from sample duration.
+                double duration = (i < static_cast<int>(draggedAudioDurations_.size()))
+                                      ? draggedAudioDurations_[i]
+                                      : 4.0;
+                int clipEndX = timeToPixel(dropInsertTime_ + duration);
+                int clipW = juce::jmax(4, clipEndX - dropX);
+
+                juce::Rectangle<int> clipRect(dropX, y0 + 2, clipW, ghostHeight - 4);
+                g.setColour(tint.withAlpha(0.25f));
+                g.fillRect(clipRect);
+                g.setColour(tint.withAlpha(0.9f));
+                g.drawRect(clipRect, 1);
+
+                // Filename inside the clip (left-aligned, with padding).
+                if (i < draggedAudioFiles_.size()) {
+                    auto name = juce::File(draggedAudioFiles_[i]).getFileNameWithoutExtension();
+                    g.setColour(tint.brighter(0.3f));
+                    g.setFont(juce::Font(juce::FontOptions(12.0f).withStyle("Bold")));
+                    g.drawFittedText(name, clipRect.reduced(6, 4), juce::Justification::centredLeft,
+                                     1);
+                }
+
+                // Insertion marker (left edge of the clip).
+                g.setColour(tint.withAlpha(0.9f));
+                g.drawLine(static_cast<float>(dropX), static_cast<float>(y0),
+                           static_cast<float>(dropX), static_cast<float>(y1), 2.0f);
+            }
         }
     }
 }
@@ -2409,13 +2444,47 @@ bool TrackContentPanel::isInterestedInFileDrag(const juce::StringArray& files) {
     return false;
 }
 
-void TrackContentPanel::fileDragEnter(const juce::StringArray& /*files*/, int x, int y) {
+void TrackContentPanel::fileDragEnter(const juce::StringArray& files, int x, int y) {
     dropInsertTime_ = juce::jmax(0.0, pixelToTime(x));
     if (snapTimeToGrid) {
         dropInsertTime_ = snapTimeToGrid(dropInsertTime_);
     }
     dropTargetTrackIndex_ = getTrackIndexAtY(y);
+
+    draggedAudioFiles_.clear();
+    draggedAudioDurations_.clear();
+    juce::AudioFormatManager formatMgr;
+    formatMgr.registerBasicFormats();
+    for (const auto& f : files) {
+        if (f.endsWithIgnoreCase(".wav") || f.endsWithIgnoreCase(".aiff") ||
+            f.endsWithIgnoreCase(".aif") || f.endsWithIgnoreCase(".mp3") ||
+            f.endsWithIgnoreCase(".ogg") || f.endsWithIgnoreCase(".flac")) {
+            draggedAudioFiles_.add(f);
+
+            double duration = 4.0;
+            juce::File audioFile(f);
+            if (auto reader = std::unique_ptr<juce::AudioFormatReader>(
+                    formatMgr.createReaderFor(audioFile))) {
+                if (reader->sampleRate > 0.0)
+                    duration = static_cast<double>(reader->lengthInSamples) / reader->sampleRate;
+            }
+            draggedAudioDurations_.push_back(duration);
+        }
+    }
+
     showDropIndicator_ = true;
+
+    // Fire ghost-header callback: one phantom header per audio file when the
+    // drop would spawn new tracks (i.e. empty area).
+    if (onGhostHeadersChanged) {
+        juce::StringArray labels;
+        if (dropTargetTrackIndex_ < 0) {
+            for (const auto& f : draggedAudioFiles_)
+                labels.add(juce::File(f).getFileNameWithoutExtension());
+        }
+        onGhostHeadersChanged(labels);
+    }
+
     repaintVisible();
 }
 
@@ -2424,17 +2493,37 @@ void TrackContentPanel::fileDragMove(const juce::StringArray& /*files*/, int x, 
     if (snapTimeToGrid) {
         dropInsertTime_ = snapTimeToGrid(dropInsertTime_);
     }
+    const int prevTarget = dropTargetTrackIndex_;
     dropTargetTrackIndex_ = getTrackIndexAtY(y);
+
+    // Update ghost headers when we cross the empty-area / existing-track boundary.
+    if (onGhostHeadersChanged && (prevTarget < 0) != (dropTargetTrackIndex_ < 0)) {
+        juce::StringArray labels;
+        if (dropTargetTrackIndex_ < 0) {
+            for (const auto& f : draggedAudioFiles_)
+                labels.add(juce::File(f).getFileNameWithoutExtension());
+        }
+        onGhostHeadersChanged(labels);
+    }
+
     repaintVisible();
 }
 
 void TrackContentPanel::fileDragExit(const juce::StringArray& /*files*/) {
     showDropIndicator_ = false;
+    draggedAudioFiles_.clear();
+    draggedAudioDurations_.clear();
+    if (onGhostHeadersChanged)
+        onGhostHeadersChanged({});
     repaintVisible();
 }
 
 void TrackContentPanel::filesDropped(const juce::StringArray& files, int x, int y) {
     showDropIndicator_ = false;
+    draggedAudioFiles_.clear();
+    draggedAudioDurations_.clear();
+    if (onGhostHeadersChanged)
+        onGhostHeadersChanged({});
     repaintVisible();
 
     // Determine drop position (clamp to timeline start, snap if enabled)
@@ -2486,43 +2575,74 @@ void TrackContentPanel::filesDropped(const juce::StringArray& files, int x, int 
 
     int importedCount = 0;
 
-    // Import audio files
+    // Import audio files.
+    // Drop target decides the mode:
+    //   * on existing track  → append clips sequentially to that track
+    //   * on empty area      → one new track per sample
     if (!audioFiles.isEmpty()) {
         juce::AudioFormatManager formatManager;
         formatManager.registerBasicFormats();
 
-        double currentTime = dropTime;
+        const bool expand = (targetTrackId == INVALID_TRACK_ID);
         CompoundOperationScope scope("Import Audio Files");
 
-        for (const auto& filePath : audioFiles) {
-            juce::File audioFile(filePath);
-            if (!audioFile.existsAsFile())
-                continue;
+        if (expand) {
+            TrackId insertAfter = INVALID_TRACK_ID;
 
-            if (targetTrackId == INVALID_TRACK_ID) {
+            for (const auto& filePath : audioFiles) {
+                juce::File audioFile(filePath);
+                if (!audioFile.existsAsFile())
+                    continue;
+
                 juce::String trackName = audioFile.getFileNameWithoutExtension();
                 auto createTrackCmd =
-                    std::make_unique<CreateTrackCommand>(TrackType::Audio, trackName);
+                    std::make_unique<CreateTrackCommand>(TrackType::Audio, trackName, insertAfter);
                 auto* createTrackPtr = createTrackCmd.get();
                 UndoManager::getInstance().executeCommand(std::move(createTrackCmd));
-                targetTrackId = createTrackPtr->getCreatedTrackId();
-                if (targetTrackId == INVALID_TRACK_ID)
-                    return;
-                TrackManager::getInstance().setSelectedTrack(targetTrackId);
+                TrackId clipTrackId = createTrackPtr->getCreatedTrackId();
+                if (clipTrackId == INVALID_TRACK_ID)
+                    continue;
+                insertAfter = clipTrackId;
+
+                double fileDuration = 4.0;
+                if (auto reader = std::unique_ptr<juce::AudioFormatReader>(
+                        formatManager.createReaderFor(audioFile))) {
+                    fileDuration =
+                        static_cast<double>(reader->lengthInSamples) / reader->sampleRate;
+                }
+
+                auto cmd = std::make_unique<CreateClipCommand>(
+                    ClipType::Audio, clipTrackId, dropTime, fileDuration, filePath.toStdString());
+                UndoManager::getInstance().executeCommand(std::move(cmd));
+                importedCount++;
             }
 
-            double fileDuration = 4.0;
-            if (auto reader = std::unique_ptr<juce::AudioFormatReader>(
-                    formatManager.createReaderFor(audioFile))) {
-                fileDuration = static_cast<double>(reader->lengthInSamples) / reader->sampleRate;
+            if (importedCount > 0 && insertAfter != INVALID_TRACK_ID)
+                TrackManager::getInstance().setSelectedTrack(insertAfter);
+        } else {
+            // Append to the hovered track: stack clips sequentially on the timeline.
+            double currentTime = dropTime;
+
+            for (const auto& filePath : audioFiles) {
+                juce::File audioFile(filePath);
+                if (!audioFile.existsAsFile())
+                    continue;
+
+                double fileDuration = 4.0;
+                if (auto reader = std::unique_ptr<juce::AudioFormatReader>(
+                        formatManager.createReaderFor(audioFile))) {
+                    fileDuration =
+                        static_cast<double>(reader->lengthInSamples) / reader->sampleRate;
+                }
+
+                auto cmd =
+                    std::make_unique<CreateClipCommand>(ClipType::Audio, targetTrackId, currentTime,
+                                                        fileDuration, filePath.toStdString());
+                UndoManager::getInstance().executeCommand(std::move(cmd));
+
+                currentTime += fileDuration + 0.5;
+                importedCount++;
             }
-
-            auto cmd = std::make_unique<CreateClipCommand>(
-                ClipType::Audio, targetTrackId, currentTime, fileDuration, filePath.toStdString());
-            UndoManager::getInstance().executeCommand(std::move(cmd));
-
-            currentTime += fileDuration + 0.5;
-            importedCount++;
         }
     }
 

--- a/magda/daw/ui/components/tracks/TrackContentPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.hpp
@@ -149,6 +149,11 @@ class TrackContentPanel : public juce::Component,
 
     // Callbacks
     std::function<void(int)> onTrackSelected;
+
+    // Fires during file-drag with the list of audio filenames that are about
+    // to spawn new tracks (empty = clear ghost). Wired by MainView to push
+    // ghost-header previews into TrackHeadersPanel.
+    std::function<void(const juce::StringArray&)> onGhostHeadersChanged;
     std::function<void(int, int)> onTrackHeightChanged;
     std::function<void(double, double, std::set<int>)>
         onTimeSelectionChanged;                             // startTime, endTime, trackIndices
@@ -391,6 +396,8 @@ class TrackContentPanel : public juce::Component,
     bool showDropIndicator_ = false;
     double dropInsertTime_ = 0.0;
     int dropTargetTrackIndex_ = -1;
+    juce::StringArray draggedAudioFiles_;        // Audio files currently being dragged over
+    std::vector<double> draggedAudioDurations_;  // Parallel to draggedAudioFiles_
 
     // Group track extent cache — avoids walking all descendants every paint
     struct GroupExtent {

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -1310,22 +1310,68 @@ void TrackHeadersPanel::paint(juce::Graphics& g) {
     // Draw drag-and-drop feedback on top
     paintDragFeedback(g);
 
-    // Draw plugin drop highlight
-    if (pluginDragActive_) {
-        // Always draw a thick yellow border between the last track and
-        // master to show where a "new track" drop will land.
-        int lineY = 0;
+    // Ghost-header preview (drag-to-create flows — files or devices).
+    // Colours match what TrackManager::createTrack will assign (Config palette
+    // indexed by track count), so the preview is a faithful prediction.
+    if (!ghostHeaderLabels_.isEmpty()) {
+        int topY = 0;
         for (int i = static_cast<int>(trackHeaders.size()) - 1; i >= 0; --i) {
             if (!trackHeaders[i]->isMaster) {
-                lineY = getTrackHeaderArea(i).getBottom();
+                topY = getTrackHeaderArea(i).getBottom();
                 break;
             }
         }
-        g.setColour(juce::Colours::yellow.withAlpha(pluginDropTrackIndex_ < 0 ? 0.9f : 0.4f));
-        g.fillRect(0, lineY, getWidth(), 3);
+        const int ghostHeight = DEFAULT_TRACK_HEIGHT;
+        const int w = getWidth();
+        const int baseIndex = static_cast<int>(trackHeaders.size());
 
-        if (pluginDropTrackIndex_ >= 0 &&
-            pluginDropTrackIndex_ < static_cast<int>(trackHeaders.size())) {
+        for (int i = 0; i < ghostHeaderLabels_.size(); ++i) {
+            const int y0 = topY + i * ghostHeight;
+            const auto tint = juce::Colour(Config::getDefaultColour(baseIndex + i));
+
+            juce::Rectangle<int> headerRect(0, y0, w, ghostHeight);
+            g.setColour(tint.withAlpha(0.18f));
+            g.fillRect(headerRect);
+            g.setColour(tint.withAlpha(0.7f));
+            g.drawRect(headerRect, 1);
+
+            // Accent stripe on the left so it reads as a track header.
+            g.setColour(tint);
+            g.fillRect(0, y0, 4, ghostHeight);
+
+            g.setColour(tint.brighter(0.4f));
+            g.setFont(juce::Font(juce::FontOptions(13.0f).withStyle("Bold")));
+            g.drawFittedText(ghostHeaderLabels_[i], headerRect.reduced(12, 4),
+                             juce::Justification::centredLeft, 1);
+        }
+    }
+
+    // Draw plugin drop highlight
+    if (pluginDragActive_) {
+        if (pluginDropTrackIndex_ < 0) {
+            // Targeting empty area: ghost header(s) show where the new track
+            // will land. Only fall back to a "line at the bottom" when the
+            // ghost is scrolled out of the visible viewport.
+            int lineY = 0;
+            for (int i = static_cast<int>(trackHeaders.size()) - 1; i >= 0; --i) {
+                if (!trackHeaders[i]->isMaster) {
+                    lineY = getTrackHeaderArea(i).getBottom();
+                    break;
+                }
+            }
+
+            auto* vp = findParentComponentOfClass<juce::Viewport>();
+            const int visibleBottom = vp ? (vp->getViewPositionY() + vp->getHeight()) : getHeight();
+            const bool ghostVisible = !ghostHeaderLabels_.isEmpty() && lineY < visibleBottom;
+
+            if (!ghostVisible) {
+                const int drawY = juce::jmax(0, visibleBottom - 3);
+                g.setColour(juce::Colours::yellow.withAlpha(0.9f));
+                g.fillRect(0, drawY, getWidth(), 3);
+            }
+        } else if (pluginDropTrackIndex_ < static_cast<int>(trackHeaders.size())) {
+            // Targeting an existing track: highlight it. The hovered-track
+            // rectangle is the only indicator — no redundant horizontal line.
             auto area = getTrackHeaderArea(pluginDropTrackIndex_);
             g.setColour(juce::Colours::yellow.withAlpha(0.12f));
             g.fillRect(area);
@@ -1337,6 +1383,13 @@ void TrackHeadersPanel::paint(juce::Graphics& g) {
 
 void TrackHeadersPanel::resized() {
     updateTrackHeaderLayout();
+}
+
+void TrackHeadersPanel::setGhostHeaders(const juce::StringArray& labels) {
+    if (ghostHeaderLabels_ == labels)
+        return;
+    ghostHeaderLabels_ = labels;
+    repaint();
 }
 
 void TrackHeadersPanel::selectTrack(int index) {
@@ -3591,6 +3644,20 @@ void TrackHeadersPanel::itemDragEnter(const SourceDetails& details) {
             break;
         }
     }
+
+    // Ghost header for the new track that a drop on empty area would create.
+    if (pluginDropTrackIndex_ < 0) {
+        juce::String label = "New Track";
+        if (auto* obj = details.description.getDynamicObject()) {
+            auto name = obj->getProperty("name").toString();
+            if (name.isNotEmpty())
+                label = name;
+        }
+        setGhostHeaders({label});
+    } else {
+        setGhostHeaders({});
+    }
+
     repaint();
 }
 
@@ -3605,6 +3672,21 @@ void TrackHeadersPanel::itemDragMove(const SourceDetails& details) {
             break;
         }
     }
+
+    if ((prev < 0) != (pluginDropTrackIndex_ < 0)) {
+        if (pluginDropTrackIndex_ < 0) {
+            juce::String label = "New Track";
+            if (auto* obj = details.description.getDynamicObject()) {
+                auto name = obj->getProperty("name").toString();
+                if (name.isNotEmpty())
+                    label = name;
+            }
+            setGhostHeaders({label});
+        } else {
+            setGhostHeaders({});
+        }
+    }
+
     if (pluginDropTrackIndex_ != prev)
         repaint();
 }
@@ -3612,11 +3694,13 @@ void TrackHeadersPanel::itemDragMove(const SourceDetails& details) {
 void TrackHeadersPanel::itemDragExit(const SourceDetails& /*details*/) {
     pluginDragActive_ = false;
     pluginDropTrackIndex_ = -1;
+    setGhostHeaders({});
     repaint();
 }
 
 void TrackHeadersPanel::itemDropped(const SourceDetails& details) {
     pluginDragActive_ = false;
+    setGhostHeaders({});
     auto* obj = details.description.getDynamicObject();
     if (!obj) {
         pluginDropTrackIndex_ = -1;

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -1323,7 +1323,10 @@ void TrackHeadersPanel::paint(juce::Graphics& g) {
         }
         const int ghostHeight = DEFAULT_TRACK_HEIGHT;
         const int w = getWidth();
-        const int baseIndex = static_cast<int>(trackHeaders.size());
+        // Master is stored separately in TrackManager, so `trackHeaders.size()`
+        // would include it and drift by one from the colour index used in
+        // `TrackManager::createTrack`. Use `getNumTracks()` for a faithful match.
+        const int baseIndex = TrackManager::getInstance().getNumTracks();
 
         for (int i = 0; i < ghostHeaderLabels_.size(); ++i) {
             const int y0 = topY + i * ghostHeight;

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -2714,6 +2714,7 @@ void TrackHeadersPanel::showContextMenu(int trackIndex, juce::Point<int> positio
     // Duplicate track
     menu.addItem(4, tr("tracks.duplicate"));
     menu.addItem(5, tr("tracks.duplicate_no_content"));
+    menu.addItem(7, tr("tracks.duplicate_content_only"));
 
     // Delete track
     menu.addItem(3, tr("tracks.delete"));
@@ -2725,56 +2726,66 @@ void TrackHeadersPanel::showContextMenu(int trackIndex, juce::Point<int> positio
                                          : tr("tracks.show_io_routing"));
 
     // Show menu and handle result
-    menu.showMenuAsync(juce::PopupMenu::Options().withTargetScreenArea(
-                           localAreaToGlobal(juce::Rectangle<int>(position.x, position.y, 1, 1))),
-                       [this, trackId = header.trackId, trackIndex](int result) {
-                           if (result == 1) {
-                               // Toggle collapse
-                               handleCollapseToggle(trackId);
-                           } else if (result == 2) {
-                               // Remove from group
-                               TrackManager::getInstance().removeTrackFromGroup(trackId);
-                           } else if (result == 3) {
-                               // Delete track (through undo system)
-                               auto cmd = std::make_unique<DeleteTrackCommand>(trackId);
-                               UndoManager::getInstance().executeCommand(std::move(cmd));
-                           } else if (result == 4) {
-                               // Duplicate track with content
-                               auto cmd = std::make_unique<DuplicateTrackCommand>(trackId, true);
-                               UndoManager::getInstance().executeCommand(std::move(cmd));
-                           } else if (result == 5) {
-                               // Duplicate track without content
-                               auto cmd = std::make_unique<DuplicateTrackCommand>(trackId, false);
-                               UndoManager::getInstance().executeCommand(std::move(cmd));
-                           } else if (result == 6) {
-                               // Toggle I/O routing visibility (per-track)
-                               if (trackIndex >= 0 &&
-                                   trackIndex < static_cast<int>(trackHeaders.size())) {
-                                   trackHeaders[trackIndex]->showIORouting =
-                                       !trackHeaders[trackIndex]->showIORouting;
-                                   resized();
-                               }
-                           } else if (result == 7) {
-                               // Toggle freeze
-                               auto* t = TrackManager::getInstance().getTrack(trackId);
-                               if (t) {
-                                   TrackManager::getInstance().setTrackFrozen(trackId, !t->frozen);
-                               }
-                           } else if (result >= 600) {
-                               // Remove send (busIndex = result - 600)
-                               int busIndex = result - 600;
-                               TrackManager::getInstance().removeSend(trackId, busIndex);
-                           } else if (result >= 500) {
-                               // Add send (aux trackId = result - 500)
-                               // Note: checked after >= 600 to avoid collision when trackId >= 100
-                               TrackId auxId = result - 500;
-                               TrackManager::getInstance().addSend(trackId, auxId);
-                           } else if (result >= 100) {
-                               // Move to group
-                               TrackId groupId = result - 100;
-                               TrackManager::getInstance().addTrackToGroup(trackId, groupId);
-                           }
-                       });
+    menu.showMenuAsync(
+        juce::PopupMenu::Options().withTargetScreenArea(
+            localAreaToGlobal(juce::Rectangle<int>(position.x, position.y, 1, 1))),
+        [this, trackId = header.trackId, trackIndex](int result) {
+            if (result == 1) {
+                // Toggle collapse
+                handleCollapseToggle(trackId);
+            } else if (result == 2) {
+                // Remove from group
+                TrackManager::getInstance().removeTrackFromGroup(trackId);
+            } else if (result == 3) {
+                // Delete track (through undo system)
+                auto cmd = std::make_unique<DeleteTrackCommand>(trackId);
+                UndoManager::getInstance().executeCommand(std::move(cmd));
+            } else if (result == 4) {
+                // Duplicate track with content + FX chain
+                auto cmd =
+                    std::make_unique<DuplicateTrackCommand>(trackId, /*duplicateContent=*/true,
+                                                            /*duplicateDevices=*/true);
+                UndoManager::getInstance().executeCommand(std::move(cmd));
+            } else if (result == 5) {
+                // Duplicate track without content (FX chain only)
+                auto cmd =
+                    std::make_unique<DuplicateTrackCommand>(trackId, /*duplicateContent=*/false,
+                                                            /*duplicateDevices=*/true);
+                UndoManager::getInstance().executeCommand(std::move(cmd));
+            } else if (result == 7) {
+                // Duplicate track content only (clips, no FX chain)
+                auto cmd =
+                    std::make_unique<DuplicateTrackCommand>(trackId, /*duplicateContent=*/true,
+                                                            /*duplicateDevices=*/false);
+                UndoManager::getInstance().executeCommand(std::move(cmd));
+            } else if (result == 6) {
+                // Toggle I/O routing visibility (per-track)
+                if (trackIndex >= 0 && trackIndex < static_cast<int>(trackHeaders.size())) {
+                    trackHeaders[trackIndex]->showIORouting =
+                        !trackHeaders[trackIndex]->showIORouting;
+                    resized();
+                }
+            } else if (result == 7) {
+                // Toggle freeze
+                auto* t = TrackManager::getInstance().getTrack(trackId);
+                if (t) {
+                    TrackManager::getInstance().setTrackFrozen(trackId, !t->frozen);
+                }
+            } else if (result >= 600) {
+                // Remove send (busIndex = result - 600)
+                int busIndex = result - 600;
+                TrackManager::getInstance().removeSend(trackId, busIndex);
+            } else if (result >= 500) {
+                // Add send (aux trackId = result - 500)
+                // Note: checked after >= 600 to avoid collision when trackId >= 100
+                TrackId auxId = result - 500;
+                TrackManager::getInstance().addSend(trackId, auxId);
+            } else if (result >= 100) {
+                // Move to group
+                TrackId groupId = result - 100;
+                TrackManager::getInstance().addTrackToGroup(trackId, groupId);
+            }
+        });
 }
 
 void TrackHeadersPanel::toggleRouting(int trackIndex, RoutingType type) {

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.hpp
@@ -83,6 +83,11 @@ class TrackHeadersPanel : public juce::Component,
         scrollTarget_ = viewport;
     }
 
+    // Ghost-header preview: paints one phantom track-header row per label below
+    // the last real (non-master) track. Called during drag-to-create flows from
+    // both file drops and device drops. Pass an empty StringArray to clear.
+    void setGhostHeaders(const juce::StringArray& labels);
+
     // Track management
     void selectTrack(int index);
     int getNumTracks() const;
@@ -260,6 +265,9 @@ class TrackHeadersPanel : public juce::Component,
     // Plugin drop state
     bool pluginDragActive_ = false;
     int pluginDropTrackIndex_ = -1;  // -1 = empty area (new track), >= 0 = existing track
+
+    // Ghost-header preview (file/device drags that will spawn new tracks)
+    juce::StringArray ghostHeaderLabels_;
 
     // Routing device management
     void populateAudioInputOptions(RoutingSelector* selector, TrackId trackId = INVALID_TRACK_ID);

--- a/magda/daw/ui/panels/TransportPanel.cpp
+++ b/magda/daw/ui/panels/TransportPanel.cpp
@@ -98,8 +98,9 @@ void TransportPanel::paint(juce::Graphics& g) {
     drawGroupWrapper(autoGridButton->getBounds().getUnion(snapButton->getBounds()), "",
                      DarkTheme::getColour(DarkTheme::ACCENT_PURPLE));
 
-    // CPU frame — rounded rectangle matching transport group wrapper style
-    {
+    // CPU frame — rounded rectangle matching transport group wrapper style.
+    // Skipped entirely when the panel is too narrow to host the meter.
+    if (cpuVisible_) {
         auto cpuArea = getCpuArea().reduced(4, 3);
         auto frameBounds = cpuArea.toFloat();
         g.setColour(DarkTheme::getColour(DarkTheme::SURFACE));
@@ -146,6 +147,21 @@ void TransportPanel::paint(juce::Graphics& g) {
 void TransportPanel::resized() {
     auto transportArea = getTransportControlsArea();
     auto timeArea = getTimeDisplayArea();
+
+    // Decide whether the CPU meter fits before any area that depends on
+    // getCpuArea() is computed. It reserves 70px on the right when visible;
+    // we hide it entirely (and reclaim that slot) once the grid-quantize
+    // cluster on the left would otherwise overlap it.
+    {
+        const int fixedLeftWidth = getTransportControlsArea().getWidth() + 106 + 440;
+        const int gridMinWidth = 6 + 30 + 4 + 44;  // pad + numDen + gap + btn
+        const int cpuWidth = 70;
+        const int minGap = 8;
+        cpuVisible_ = getWidth() >= fixedLeftWidth + gridMinWidth + minGap + cpuWidth;
+    }
+    cpuTitleLabel->setVisible(cpuVisible_);
+    cpuValueLabel->setVisible(cpuVisible_);
+
     auto tempoArea = getTempoQuantizeArea();
 
     // Transport controls layout — order: Home, Prev, Next, Play, Stop, Rec, AutoWrite, Loop,
@@ -273,15 +289,29 @@ void TransportPanel::resized() {
     gridSlashLabel->setBounds(0, 0, 0, 0);
     gridSlashLabel->setVisible(false);
 
-    // QWERTY keyboard toggle — just left of CPU
+    // QWERTY keyboard toggle — just left of CPU (or the panel's right edge
+    // when CPU is hidden). Hidden itself when the window is narrow enough
+    // that it would overlap the grid-quantize cluster on the left.
     auto cpuBounds = getCpuArea();
-    int qwertyX = cpuBounds.getX() - buttonSize - 4;
-    qwertyKeyboardButton->setBounds(qwertyX, buttonY, buttonSize, buttonSize);
+    const int rightAnchor = cpuVisible_ ? cpuBounds.getX() : getWidth();
+    const int qwertyX = rightAnchor - buttonSize - 4;
+    const int gridRight = gridBtnX + btnWidth;
+    const int minGapToQwerty = 8;
+    const bool qwertyFits = qwertyX >= gridRight + minGapToQwerty;
 
-    // Automation write indicator — fills the gap between grid quantize and QWERTY button
-    int autoWriteLeft = gridBtnX + btnWidth + 8;
-    int autoWriteRight = qwertyX - 4;
-    if (autoWriteRight > autoWriteLeft) {
+    qwertyKeyboardButton->setVisible(qwertyFits);
+    if (qwertyFits) {
+        qwertyKeyboardButton->setBounds(qwertyX, buttonY, buttonSize, buttonSize);
+    }
+
+    // Automation write indicator — fills whatever gap is left between the grid
+    // quantize cluster and whichever right-side control is currently visible.
+    // Only shown while write mode is actually on.
+    const int autoWriteLeft = gridRight + minGapToQwerty;
+    const int autoWriteRight = (qwertyFits ? qwertyX : rightAnchor) - 4;
+    const bool autoWriteFits = autoWriteRight > autoWriteLeft;
+    automationWriteLabel->setVisible(isAutomationWriteEnabled && autoWriteFits);
+    if (autoWriteFits) {
         automationWriteLabel->setBounds(autoWriteLeft, 0, autoWriteRight - autoWriteLeft,
                                         getHeight());
     }
@@ -322,6 +352,8 @@ juce::Rectangle<int> TransportPanel::getTempoQuantizeArea() const {
 }
 
 juce::Rectangle<int> TransportPanel::getCpuArea() const {
+    if (!cpuVisible_)
+        return {};
     return getLocalBounds().removeFromRight(70);
 }
 

--- a/magda/daw/ui/panels/TransportPanel.hpp
+++ b/magda/daw/ui/panels/TransportPanel.hpp
@@ -150,6 +150,11 @@ class TransportPanel : public juce::Component {
     juce::Rectangle<int> getTempoQuantizeArea() const;
     juce::Rectangle<int> getCpuArea() const;
 
+    // CPU meter is hidden (and its right-edge slot reclaimed) when the panel
+    // is too narrow to fit it without overlapping the grid-quantize cluster.
+    // Updated in resized() before any area-dependent layout runs.
+    bool cpuVisible_ = true;
+
     // Button styling
     void styleTransportButton(SvgButton& button, juce::Colour accentColor);
     void setupTransportButtons();

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -857,8 +857,19 @@ AIChatConsoleContent::AIChatConsoleContent() {
 
     updateConfigStatus();
 
-    // Register for selection changes
-    magda::SelectionManager::getInstance().addListener(this);
+    // Register for selection changes and seed the context bar from the
+    // currently-selected track/clip. Without this, opening the panel after
+    // an existing selection leaves the context bar empty until the next
+    // selection event fires.
+    {
+        auto& sm = magda::SelectionManager::getInstance();
+        sm.addListener(this);
+        if (auto clipId = sm.getSelectedClip(); clipId != magda::INVALID_CLIP_ID) {
+            clipSelectionChanged(clipId);
+        } else if (auto trackId = sm.getSelectedTrack(); trackId != magda::INVALID_TRACK_ID) {
+            trackSelectionChanged(trackId);
+        }
+    }
 
     // Register for project lifecycle events
     magda::ProjectManager::getInstance().addListener(this);
@@ -1502,6 +1513,7 @@ void AIChatConsoleContent::mouseUp(const juce::MouseEvent& event) {
     if (event.originalComponent == &contextLabel_ ||
         (event.originalComponent == this && contextIconBounds_.contains(event.getPosition()))) {
         contextEnabled_ = !contextEnabled_;
+        magda::dsl::Interpreter::setContextEnabled(contextEnabled_);
         updateContextBar();
     }
 }

--- a/magda/daw/ui/panels/content/MediaExplorerContent.cpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.cpp
@@ -693,6 +693,21 @@ MediaExplorerContent::MediaExplorerContent() {
     fileBrowser_->addMouseListener(this, true);
     addAndMakeVisible(*fileBrowser_);
 
+    // Belt-and-braces: ensure the underlying list honours shift/cmd multi-select and
+    // paints with our theme's highlight colour (FileListComponent::findColour does not
+    // inherit from the parent FileBrowserComponent, so colours must be set here too).
+    if (auto* listComp =
+            dynamic_cast<juce::FileListComponent*>(fileBrowser_->getDisplayComponent())) {
+        listComp->setMultipleSelectionEnabled(true);
+        listComp->setRowSelectedOnMouseDown(true);
+        listComp->setColour(juce::DirectoryContentsDisplayComponent::highlightColourId,
+                            DarkTheme::getColour(DarkTheme::ACCENT_BLUE).withAlpha(0.3f));
+        listComp->setColour(juce::DirectoryContentsDisplayComponent::textColourId,
+                            DarkTheme::getTextColour());
+        listComp->setColour(juce::DirectoryContentsDisplayComponent::highlightedTextColourId,
+                            DarkTheme::getTextColour());
+    }
+
     // Apply LookAndFeel to ComboBox child and hide the filename editor
     for (int i = 0; i < fileBrowser_->getNumChildComponents(); ++i) {
         auto* child = fileBrowser_->getChildComponent(i);
@@ -1096,8 +1111,55 @@ void MediaExplorerContent::onDeactivated() {
 
 // FileBrowserListener implementation
 void MediaExplorerContent::selectionChanged() {
-    // When selection changes, handle preview based on file type
-    auto selectedFile = fileBrowser_->getSelectedFile(0);
+    // Read selection from the underlying list directly (more reliable than
+    // FileBrowserComponent's cached chosenFiles).
+    auto* listComp = dynamic_cast<juce::FileListComponent*>(fileBrowser_->getDisplayComponent());
+    const int numSelected = listComp ? listComp->getNumSelectedFiles() : 0;
+
+    // Maintain sticky selection for drag. Rules:
+    //   * selection size >= 2 → remember this set as the new sticky selection
+    //   * size == 1 AND that single file was in the prior sticky set → keep sticky
+    //     (user clicked within a multi-selection, presumably to drag it out)
+    //   * otherwise → replace sticky with the current selection
+    if (listComp != nullptr) {
+        juce::Array<juce::File> current;
+        for (int i = 0; i < numSelected; ++i)
+            current.add(listComp->getSelectedFile(i));
+
+        if (current.size() >= 2) {
+            stickySelection_ = current;
+            stickyRowSelection_ = listComp->getSelectedRows();
+        } else if (current.size() == 1 && stickySelection_.size() >= 2 &&
+                   stickySelection_.contains(current[0])) {
+            // Keep sticky — user may be about to drag.
+        } else {
+            stickySelection_ = current;
+            stickyRowSelection_ = listComp->getSelectedRows();
+        }
+    }
+
+    // Multi-selection: show a summary in the preview area and stop any ongoing preview.
+    if (numSelected > 1) {
+        stopPreview();
+        transportSource_->setSource(nullptr);
+        readerSource_.reset();
+        playButton_->setEnabled(false);
+
+        juce::int64 totalBytes = 0;
+        for (int i = 0; i < numSelected; ++i)
+            totalBytes += listComp->getSelectedFile(i).getSize();
+
+        fileInfoLabel_.setText(juce::String(numSelected) + " files selected",
+                               juce::dontSendNotification);
+        formatLabel_.setText("Multiple files", juce::dontSendNotification);
+        propertiesLabel_.setText("Total size: " + formatFileSize(totalBytes),
+                                 juce::dontSendNotification);
+        if (thumbnailComponent_)
+            thumbnailComponent_->setFile(juce::File());
+        return;
+    }
+
+    auto selectedFile = listComp ? listComp->getSelectedFile(0) : fileBrowser_->getSelectedFile(0);
 
     if (!selectedFile.existsAsFile()) {
         // No valid file selected - stop preview
@@ -1244,15 +1306,41 @@ void MediaExplorerContent::changeListenerCallback(juce::ChangeBroadcaster* sourc
 
 // MouseListener implementation for drag detection
 void MediaExplorerContent::mouseDrag(const juce::MouseEvent& e) {
-    // Start drag if mouse moved beyond threshold
-    if (!isDraggingFile_ && fileForDrag_.existsAsFile() && e.getDistanceFromDragStart() > 5) {
-        isDraggingFile_ = true;
+    if (isDraggingFile_ || !fileForDrag_.existsAsFile() || e.getDistanceFromDragStart() <= 5)
+        return;
 
-        // Start drag operation (all media types are draggable)
-        if (mediaFileFilter_->isFileSuitable(fileForDrag_)) {
-            juce::DragAndDropContainer::performExternalDragDropOfFiles(
-                juce::StringArray{fileForDrag_.getFullPathName()}, false, this);
+    isDraggingFile_ = true;
+
+    auto* listComp = dynamic_cast<juce::FileListComponent*>(fileBrowser_->getDisplayComponent());
+
+    juce::StringArray paths;
+
+    // Prefer the sticky selection if the drag started from one of its files.
+    if (stickySelection_.size() >= 2 && stickySelection_.contains(fileForDrag_)) {
+        for (const auto& f : stickySelection_) {
+            if (f.existsAsFile() && mediaFileFilter_->isFileSuitable(f))
+                paths.addIfNotAlreadyThere(f.getFullPathName());
         }
+    } else if (listComp != nullptr) {
+        const int numSelected = listComp->getNumSelectedFiles();
+        for (int i = 0; i < numSelected; ++i) {
+            auto f = listComp->getSelectedFile(i);
+            if (f.existsAsFile() && mediaFileFilter_->isFileSuitable(f))
+                paths.addIfNotAlreadyThere(f.getFullPathName());
+        }
+    }
+
+    if (paths.isEmpty() && mediaFileFilter_->isFileSuitable(fileForDrag_))
+        paths.add(fileForDrag_.getFullPathName());
+
+    if (!paths.isEmpty()) {
+        juce::DragAndDropContainer::performExternalDragDropOfFiles(paths, false, this);
+
+        // The ListBox collapsed the visual selection to the clicked row when
+        // the drag started. Restore the sticky multi-selection now that the
+        // external drag has finished so the user keeps their selection.
+        if (stickyRowSelection_.size() >= 2 && listComp != nullptr)
+            listComp->setSelectedRows(stickyRowSelection_);
     }
 }
 

--- a/magda/daw/ui/panels/content/MediaExplorerContent.hpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.hpp
@@ -123,6 +123,15 @@ class MediaExplorerContent : public PanelContent,
     juce::Point<int> mouseDownPosition_;
     bool isDraggingFile_ = false;
 
+    // Sticky multi-selection: JUCE's FileListComponent collapses the selection to
+    // the clicked row on plain mouseDown, which makes it impossible to drag a
+    // multi-selection out without a modifier. We remember the last ≥2-file
+    // selection and keep it as the drag payload as long as the user keeps
+    // clicking within that set. We also snapshot the row indices so we can
+    // restore the visual multi-selection after an external drag completes.
+    juce::Array<juce::File> stickySelection_;
+    juce::SparseSet<int> stickyRowSelection_;
+
     // Helper methods
     void timerCallback() override;
     void setupAudioPreview();

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -166,6 +166,12 @@ void MainView::setupComponents() {
     // Wire track headers scroll to content viewport
     trackHeadersPanel->setScrollTarget(trackContentViewport.get());
 
+    // Wire file-drag ghost-header previews from content panel → headers panel.
+    trackContentPanel->onGhostHeadersChanged = [this](const juce::StringArray& labels) {
+        if (trackHeadersPanel)
+            trackHeadersPanel->setGhostHeaders(labels);
+    };
+
     // Create grid overlay component (vertical time grid lines - below selection and playhead)
     gridOverlay = std::make_unique<GridOverlayComponent>();
     gridOverlay->setController(timelineController.get());

--- a/magda/daw/ui/views/SessionView.cpp
+++ b/magda/daw/ui/views/SessionView.cpp
@@ -2923,26 +2923,18 @@ void SessionView::filesDropped(const juce::StringArray& files, int x, int y) {
     };
 
     if (expand) {
-        // First sample goes to hovered track (if any); remaining samples each spawn a new track.
-        TrackId insertAfter = hoveredTrackId;
-        bool useHoveredForFirst = (hoveredTrackId != INVALID_TRACK_ID);
+        // Empty-area drop: one new track per sample, inserted in order.
+        TrackId insertAfter = INVALID_TRACK_ID;
 
-        for (int i = 0; i < audioFiles.size(); ++i) {
-            const auto& filePath = audioFiles[i];
-
-            TrackId trackId;
-            if (i == 0 && useHoveredForFirst) {
-                trackId = hoveredTrackId;
-            } else {
-                juce::String trackName = juce::File(filePath).getFileNameWithoutExtension();
-                auto cmd =
-                    std::make_unique<CreateTrackCommand>(TrackType::Audio, trackName, insertAfter);
-                auto* cmdPtr = cmd.get();
-                UndoManager::getInstance().executeCommand(std::move(cmd));
-                trackId = cmdPtr->getCreatedTrackId();
-                if (trackId == INVALID_TRACK_ID)
-                    break;
-            }
+        for (const auto& filePath : audioFiles) {
+            juce::String trackName = juce::File(filePath).getFileNameWithoutExtension();
+            auto cmd =
+                std::make_unique<CreateTrackCommand>(TrackType::Audio, trackName, insertAfter);
+            auto* cmdPtr = cmd.get();
+            UndoManager::getInstance().executeCommand(std::move(cmd));
+            TrackId trackId = cmdPtr->getCreatedTrackId();
+            if (trackId == INVALID_TRACK_ID)
+                break;
 
             int slot = nextEmptySlot(trackId, sceneIndex);
             if (slot < numScenes_)
@@ -2951,25 +2943,14 @@ void SessionView::filesDropped(const juce::StringArray& files, int x, int y) {
             insertAfter = trackId;
         }
     } else {
-        // Append mode: stack all clips down the scenes of a single target track.
-        TrackId targetTrackId = hoveredTrackId;
-        if (targetTrackId == INVALID_TRACK_ID) {
-            juce::String trackName = juce::File(audioFiles[0]).getFileNameWithoutExtension();
-            auto cmd = std::make_unique<CreateTrackCommand>(TrackType::Audio, trackName);
-            auto* cmdPtr = cmd.get();
-            UndoManager::getInstance().executeCommand(std::move(cmd));
-            targetTrackId = cmdPtr->getCreatedTrackId();
-            if (targetTrackId == INVALID_TRACK_ID)
-                return;
-        }
-
+        // Append mode: stack all clips down the scenes of the hovered track.
         int slot = sceneIndex;
         for (const auto& filePath : audioFiles) {
-            slot = nextEmptySlot(targetTrackId, slot);
+            slot = nextEmptySlot(hoveredTrackId, slot);
             if (slot >= numScenes_)
                 break;
 
-            createClipOnTrack(targetTrackId, slot, filePath);
+            createClipOnTrack(hoveredTrackId, slot, filePath);
             ++slot;
         }
     }

--- a/magda/daw/ui/views/SessionView.cpp
+++ b/magda/daw/ui/views/SessionView.cpp
@@ -2857,99 +2857,121 @@ void SessionView::filesDropped(const juce::StringArray& files, int x, int y) {
     clearDragHighlight();
     clearDragGhost();
 
-    // Convert screen coordinates to grid viewport coordinates
     auto gridLocalPoint = gridViewport->getLocalPoint(this, juce::Point<int>(x, y));
-
-    // Add viewport scroll offset
     gridLocalPoint +=
         juce::Point<int>(gridViewport->getViewPositionX(), gridViewport->getViewPositionY());
 
-    // Calculate which slot was dropped on
     int sceneRowHeight = CLIP_SLOT_HEIGHT + CLIP_SLOT_MARGIN;
-
     int trackIndex = getTrackIndexAtX(gridLocalPoint.getX());
     int sceneIndex = gridLocalPoint.getY() / sceneRowHeight;
 
-    // Validate scene index
     if (sceneIndex < 0 || sceneIndex >= numScenes_)
         return;
 
-    TrackId targetTrackId = INVALID_TRACK_ID;
-
-    if (trackIndex >= 0 && trackIndex < static_cast<int>(visibleTrackIds_.size())) {
-        targetTrackId = visibleTrackIds_[trackIndex];
-    } else {
-        // Dropped past last track — create a new audio track
-        // Derive name from first audio file
-        juce::String trackName = "Audio";
-        for (const auto& f : files) {
-            if (isAudioFile(f)) {
-                trackName = juce::File(f).getFileNameWithoutExtension();
-                break;
-            }
-        }
-        auto cmd = std::make_unique<CreateTrackCommand>(TrackType::Audio, trackName);
-        auto* cmdPtr = cmd.get();
-        UndoManager::getInstance().executeCommand(std::move(cmd));
-        targetTrackId = cmdPtr->getCreatedTrackId();
-        if (targetTrackId == INVALID_TRACK_ID)
-            return;
+    juce::StringArray audioFiles;
+    for (const auto& f : files) {
+        if (isAudioFile(f))
+            audioFiles.add(f);
     }
+    if (audioFiles.isEmpty())
+        return;
 
-    // Create clips for each audio file dropped
+    TrackId hoveredTrackId = INVALID_TRACK_ID;
+    if (trackIndex >= 0 && trackIndex < static_cast<int>(visibleTrackIds_.size()))
+        hoveredTrackId = visibleTrackIds_[trackIndex];
+
+    // Drop target decides: empty area → one new track per sample, existing
+    // track → stack clips down the scene slots of that track.
+    const bool expand = (hoveredTrackId == INVALID_TRACK_ID);
+
     auto& clipManager = ClipManager::getInstance();
-    int currentSceneIndex = sceneIndex;
 
-    // Create format manager once for all dropped files
     juce::AudioFormatManager formatManager;
     formatManager.registerBasicFormats();
 
-    for (const auto& filePath : files) {
-        if (!isAudioFile(filePath))
-            continue;
+    double bpm = 120.0;
+    if (timelineController_)
+        bpm = timelineController_->getState().tempo.bpm;
 
-        // Skip to next empty slot
-        while (currentSceneIndex < numScenes_ &&
-               clipManager.getClipInSlot(targetTrackId, currentSceneIndex) != INVALID_CLIP_ID) {
-            currentSceneIndex++;
-        }
-
-        // Don't exceed scene bounds
-        if (currentSceneIndex >= numScenes_)
-            break;
-
-        // Get audio file duration
+    auto createClipOnTrack = [&](TrackId trackId, int sceneSlot, const juce::String& filePath) {
         juce::File audioFile(filePath);
-        double fileDuration = 4.0;  // fallback
+        double fileDuration = 4.0;
         {
             std::unique_ptr<juce::AudioFormatReader> reader(
                 formatManager.createReaderFor(audioFile));
-            if (reader) {
+            if (reader)
                 fileDuration = static_cast<double>(reader->lengthInSamples) / reader->sampleRate;
-            }
         }
 
-        // Create audio clip for session view (not arrangement)
-        double bpm = 120.0;
-        if (timelineController_) {
-            bpm = timelineController_->getState().tempo.bpm;
-        }
-        ClipId newClipId = clipManager.createAudioClip(targetTrackId, 0.0, fileDuration, filePath,
+        ClipId newClipId = clipManager.createAudioClip(trackId, 0.0, fileDuration, filePath,
                                                        ClipView::Session, bpm);
         if (newClipId != INVALID_CLIP_ID) {
             UndoManager::getInstance().executeCommand(std::make_unique<SetClipNameCommand>(
                 newClipId, audioFile.getFileNameWithoutExtension()));
-
-            // Session clips default to looping, with source end matching clip duration
             clipManager.setClipLoopEnabled(newClipId, true, bpm);
-            // Set loopLength to match file duration (source region = entire file)
             clipManager.setLoopLength(newClipId, fileDuration);
+            clipManager.setClipSceneIndex(newClipId, sceneSlot);
+        }
+    };
 
-            // Assign to session view slot (triggers proper notification)
-            clipManager.setClipSceneIndex(newClipId, currentSceneIndex);
+    auto nextEmptySlot = [&](TrackId trackId, int startSlot) {
+        while (startSlot < numScenes_ &&
+               clipManager.getClipInSlot(trackId, startSlot) != INVALID_CLIP_ID) {
+            ++startSlot;
+        }
+        return startSlot;
+    };
+
+    if (expand) {
+        // First sample goes to hovered track (if any); remaining samples each spawn a new track.
+        TrackId insertAfter = hoveredTrackId;
+        bool useHoveredForFirst = (hoveredTrackId != INVALID_TRACK_ID);
+
+        for (int i = 0; i < audioFiles.size(); ++i) {
+            const auto& filePath = audioFiles[i];
+
+            TrackId trackId;
+            if (i == 0 && useHoveredForFirst) {
+                trackId = hoveredTrackId;
+            } else {
+                juce::String trackName = juce::File(filePath).getFileNameWithoutExtension();
+                auto cmd =
+                    std::make_unique<CreateTrackCommand>(TrackType::Audio, trackName, insertAfter);
+                auto* cmdPtr = cmd.get();
+                UndoManager::getInstance().executeCommand(std::move(cmd));
+                trackId = cmdPtr->getCreatedTrackId();
+                if (trackId == INVALID_TRACK_ID)
+                    break;
+            }
+
+            int slot = nextEmptySlot(trackId, sceneIndex);
+            if (slot < numScenes_)
+                createClipOnTrack(trackId, slot, filePath);
+
+            insertAfter = trackId;
+        }
+    } else {
+        // Append mode: stack all clips down the scenes of a single target track.
+        TrackId targetTrackId = hoveredTrackId;
+        if (targetTrackId == INVALID_TRACK_ID) {
+            juce::String trackName = juce::File(audioFiles[0]).getFileNameWithoutExtension();
+            auto cmd = std::make_unique<CreateTrackCommand>(TrackType::Audio, trackName);
+            auto* cmdPtr = cmd.get();
+            UndoManager::getInstance().executeCommand(std::move(cmd));
+            targetTrackId = cmdPtr->getCreatedTrackId();
+            if (targetTrackId == INVALID_TRACK_ID)
+                return;
         }
 
-        currentSceneIndex++;  // Move to next scene for multi-file drop
+        int slot = sceneIndex;
+        for (const auto& filePath : audioFiles) {
+            slot = nextEmptySlot(targetTrackId, slot);
+            if (slot >= numScenes_)
+                break;
+
+            createClipOnTrack(targetTrackId, slot, filePath);
+            ++slot;
+        }
     }
 }
 

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -939,7 +939,23 @@ bool MainWindow::MainComponent::keyPressed(const juce::KeyPress& key) {
                        0)) {
         TrackId selectedTrack = SelectionManager::getInstance().getSelectedTrack();
         if (selectedTrack != INVALID_TRACK_ID) {
-            auto cmd = std::make_unique<DuplicateTrackCommand>(selectedTrack, false);
+            auto cmd = std::make_unique<DuplicateTrackCommand>(selectedTrack,
+                                                               /*duplicateContent=*/false,
+                                                               /*duplicateDevices=*/true);
+            UndoManager::getInstance().executeCommand(std::move(cmd));
+            return true;
+        }
+        return false;
+    }
+
+    // Cmd/Ctrl+Alt+D: Duplicate selected track content only (clips, no FX chain)
+    if (key == juce::KeyPress(
+                   'd', juce::ModifierKeys::commandModifier | juce::ModifierKeys::altModifier, 0)) {
+        TrackId selectedTrack = SelectionManager::getInstance().getSelectedTrack();
+        if (selectedTrack != INVALID_TRACK_ID) {
+            auto cmd = std::make_unique<DuplicateTrackCommand>(selectedTrack,
+                                                               /*duplicateContent=*/true,
+                                                               /*duplicateDevices=*/false);
             UndoManager::getInstance().executeCommand(std::move(cmd));
             return true;
         }

--- a/magda/daw/ui/windows/MainWindowMenus.cpp
+++ b/magda/daw/ui/windows/MainWindowMenus.cpp
@@ -670,7 +670,19 @@ void MainWindow::setupMenuCallbacks() {
     callbacks.onDuplicateTrackNoContent = []() {
         TrackId selectedTrack = SelectionManager::getInstance().getSelectedTrack();
         if (selectedTrack != INVALID_TRACK_ID) {
-            auto cmd = std::make_unique<DuplicateTrackCommand>(selectedTrack, false);
+            auto cmd = std::make_unique<DuplicateTrackCommand>(selectedTrack,
+                                                               /*duplicateContent=*/false,
+                                                               /*duplicateDevices=*/true);
+            UndoManager::getInstance().executeCommand(std::move(cmd));
+        }
+    };
+
+    callbacks.onDuplicateTrackContentOnly = []() {
+        TrackId selectedTrack = SelectionManager::getInstance().getSelectedTrack();
+        if (selectedTrack != INVALID_TRACK_ID) {
+            auto cmd = std::make_unique<DuplicateTrackCommand>(selectedTrack,
+                                                               /*duplicateContent=*/true,
+                                                               /*duplicateDevices=*/false);
             UndoManager::getInstance().executeCommand(std::move(cmd));
         }
     };

--- a/magda/daw/ui/windows/MenuManager.cpp
+++ b/magda/daw/ui/windows/MenuManager.cpp
@@ -233,6 +233,10 @@ juce::PopupMenu MenuManager::getMenuForIndex(int topLevelMenuIndex,
                          tr("menu.track.duplicate_no_content") +
                              juce::String::fromUTF8("\t\u21E7\u2318D"),
                          true, false);
+            menu.addItem(DuplicateTrackContentOnly,
+                         tr("menu.track.duplicate_content_only") +
+                             juce::String::fromUTF8("\t\u2325\u2318D"),
+                         true, false);
 #else
             menu.addItem(AddTrack, tr("menu.track.add_track") + "\tCtrl+T", true, false);
             menu.addItem(AddGroupTrack, tr("menu.track.add_group") + "\tCtrl+Shift+T", true, false);
@@ -242,6 +246,8 @@ juce::PopupMenu MenuManager::getMenuForIndex(int topLevelMenuIndex,
             menu.addItem(DuplicateTrack, tr("menu.track.duplicate") + "\tCtrl+D", true, false);
             menu.addItem(DuplicateTrackNoContent,
                          tr("menu.track.duplicate_no_content") + "\tCtrl+Shift+D", true, false);
+            menu.addItem(DuplicateTrackContentOnly,
+                         tr("menu.track.duplicate_content_only") + "\tCtrl+Alt+D", true, false);
 #endif
             menu.addSeparator();
             menu.addItem(MuteTrack, tr("menu.track.mute") + "\tM", true, false);
@@ -488,6 +494,10 @@ void MenuManager::menuItemSelected(int menuItemID, int topLevelMenuIndex) {
         case DuplicateTrackNoContent:
             if (callbacks_.onDuplicateTrackNoContent)
                 callbacks_.onDuplicateTrackNoContent();
+            break;
+        case DuplicateTrackContentOnly:
+            if (callbacks_.onDuplicateTrackContentOnly)
+                callbacks_.onDuplicateTrackContentOnly();
             break;
         case MuteTrack:
             if (callbacks_.onMuteTrack)

--- a/magda/daw/ui/windows/MenuManager.hpp
+++ b/magda/daw/ui/windows/MenuManager.hpp
@@ -71,6 +71,7 @@ class MenuManager : public juce::MenuBarModel, public UndoManagerListener {
         std::function<void()> onDeleteTrack;
         std::function<void()> onDuplicateTrack;
         std::function<void()> onDuplicateTrackNoContent;
+        std::function<void()> onDuplicateTrackContentOnly;
         std::function<void()> onMuteTrack;
         std::function<void()> onSoloTrack;
 
@@ -184,6 +185,7 @@ class MenuManager : public juce::MenuBarModel, public UndoManagerListener {
         DeleteTrack = 510,
         DuplicateTrack,
         DuplicateTrackNoContent,
+        DuplicateTrackContentOnly,
         MuteTrack = 520,
         SoloTrack,
 


### PR DESCRIPTION
## Summary
Implements #1011 — drag multiple samples from the media browser in one gesture and have them land correctly across the arrangement, session, and drum grid.

The drop target decides how the samples fan out — no modifier keys to remember:
- **Empty area** → one new track per sample
- **Existing track** → clips appended to that track
- **Drum grid** → samples fill consecutive pads from the drop target

## What's in it
- **Media browser**: sticky multi-selection survives the mouseDown that collapses JUCE's ListBox selection when a drag starts; highlight colour propagated to the list component; preview panel summarises multi-file selections (\`N files selected\`); visual selection restored after the external drop completes.
- **Arrangement** (\`TrackContentPanel\`): expand-vs-append routing on drop; during drag-over-empty, clip-shaped ghosts start at the drop time and span each sample's actual duration, tinted with the palette colour each new track will be assigned.
- **Track headers** (\`TrackHeadersPanel\`): phantom header rows with matching palette colours and filename/device labels during file and device drags. The plugin-drop horizontal line now only appears when targeting the empty area **and** the ghost is scrolled out of the viewport.
- **Session view** (\`SessionView\`): same expand-vs-append rule; dropping on empty stacks into new tracks, dropping on a track stacks down scene slots.
- **Drum grid** (\`DrumGridUI\`): file drag highlights every pad that will receive a sample, not just the one under the cursor.

## Test plan
- [ ] Shift/cmd-click multiple samples in the media browser, confirm visual multi-select
- [ ] Drag multi-selection over empty arrangement area — ghost headers + clip ghosts appear with correct colours/lengths, drop creates one new track per sample
- [ ] Drag multi-selection onto an existing track — clips appended sequentially on the hovered track
- [ ] Drag multi-selection onto the drum grid — all target pads light up, drop fills consecutive pads
- [ ] Drag onto session grid empty area (new tracks) vs existing track (scenes stack)
- [ ] Drag a single plugin onto empty headers area — ghost header shows plugin name
- [ ] Drag a plugin onto an existing track — only the hovered-track highlight appears, no redundant bottom line
- [ ] After dropping multi-selection, browser still shows all files highlighted
- [ ] Single-file drops still behave as before

Closes #1011