### PR TITLE
i18n: CJK font fallback + Preferences/dialog localization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+assets/fonts/NotoSansCJKsc-Regular.otf filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+        lfs: true
 
     - name: Cache apt packages
       uses: actions/cache@v5
@@ -148,6 +149,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+        lfs: true
 
     - name: Cache apt packages
       uses: actions/cache@v5
@@ -300,6 +302,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        lfs: true
 
     - name: Init submodules
       run: git submodule update --init --recursive
@@ -361,6 +365,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+        lfs: true
 
     - name: Setup MSVC x64
       uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         submodules: recursive
+        lfs: true
 
     - name: Install dependencies (Linux)
       run: |

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -27,6 +27,8 @@ jobs:
           upload_sources: true
           upload_translations: false
           download_translations: true
+          export_only_approved: true
+          skip_untranslated_strings: true
           localization_branch_name: l10n_crowdin_${{ github.ref_name }}
           create_pull_request: true
           pull_request_title: 'i18n: sync translations from Crowdin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+        lfs: true
 
     - name: Install dependencies
       run: |
@@ -252,6 +253,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+        lfs: true
 
     - name: Extract version
       id: version
@@ -403,6 +405,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         submodules: recursive
+        lfs: true
 
     - name: Extract version
       id: version

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <a href="https://github.com/Conceptual-Machines/magda-core/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/Conceptual-Machines/magda-core/ci.yml?label=Windows&logo=windows" alt="Windows Build"></a>
   <a href="https://github.com/Conceptual-Machines/magda-core/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-GPL--3.0-blue.svg" alt="License"></a>
   <img src="https://img.shields.io/badge/C%2B%2B-20-blue.svg" alt="C++20">
+  <a href="https://crowdin.com/project/magda"><img src="https://badges.crowdin.net/magda/localized.svg" alt="Crowdin"></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -49,13 +49,18 @@ See [Issues](https://github.com/Conceptual-Machines/magda-core/issues) for known
 
 - C++20 compiler (GCC 10+, Clang 12+, or Xcode)
 - CMake 3.20+
+- [Git LFS](https://git-lfs.com/) — required to fetch bundled binary assets
+  (CJK font, etc.). Install with `brew install git-lfs` (macOS),
+  `apt install git-lfs` (Debian/Ubuntu), or `choco install git-lfs` (Windows),
+  then run `git lfs install` once per machine.
 
 ### Quick Start
 
 ```bash
-# Clone with submodules
+# Clone with submodules and LFS assets
 git clone --recursive https://github.com/Conceptual-Machines/magda-core.git
 cd magda-core
+git lfs pull  # safety net if git-lfs wasn't installed at clone time
 
 # Setup and build
 make setup

--- a/assets/fonts/NotoSansCJKsc-Regular.otf
+++ b/assets/fonts/NotoSansCJKsc-Regular.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c76254f6fc379fddfce0a7e84fb5385bb135d3e399294f6eeb6680d0365b74b
+size 16437364

--- a/lang/en.json
+++ b/lang/en.json
@@ -218,6 +218,135 @@
     "success.import": "audio file(s) imported successfully"
   },
 
+  "about": {
+    "subtitle": "Multi-Agent Digital Audio",
+    "version_prefix": "Version ",
+    "credits.powered_by": "powered by",
+    "credits.tracktion_engine": "Tracktion Engine",
+    "credits.made_with": "made with",
+    "credits.juce": "JUCE"
+  },
+
+  "splash": {
+    "subtitle": "Multi-Agent Digital Audio",
+    "version_prefix": "Version ",
+    "credits.powered_by": "powered by",
+    "credits.tracktion_engine": "Tracktion Engine",
+    "credits.made_with": "made with",
+    "credits.juce": "JUCE"
+  },
+
+  "chain_tree": {
+    "label.click_hint": "Click an item to select it in the chain view"
+  },
+
+  "track_manager": {
+    "column.track": "Track",
+    "column.live": "Live",
+    "column.arrange": "Arrange",
+    "column.mix": "Mix",
+    "label.hint": "Click checkboxes to toggle track visibility per view mode"
+  },
+
+  "export_audio": {
+    "label.format": "Format:",
+    "label.sample_rate": "Sample Rate:",
+    "label.bit_depth": "Bit Depth:",
+    "label.lead_in_silence": "Lead-in Silence:",
+    "label.export_range": "Export Range:",
+    "option.wav_16": "WAV 16-bit",
+    "option.wav_24": "WAV 24-bit",
+    "option.wav_32_float": "WAV 32-bit Float",
+    "option.flac": "FLAC",
+    "option.entire_song": "Entire Song",
+    "option.time_selection": "Time Selection",
+    "option.loop_region": "Loop Region",
+    "toggle.normalize": "Normalize to 0 dB (peak)",
+    "toggle.realtime_render": "Real-time render (slower, avoids plugin glitches)",
+    "button.export": "Export",
+    "bit_depth.16": "16-bit",
+    "bit_depth.24": "24-bit",
+    "bit_depth.32_float": "32-bit Float",
+    "bit_depth.24_flac": "24-bit (FLAC)"
+  },
+
+  "export_midi": {
+    "label.midi_format": "MIDI Format:",
+    "label.export_range": "Export Range:",
+    "option.type_0": "Type 0 (Single Track)",
+    "option.type_1": "Type 1 (Multi-Track)",
+    "option.entire_song": "Entire Song",
+    "option.time_selection": "Time Selection",
+    "option.loop_region": "Loop Region",
+    "button.export": "Export",
+    "dialog.title": "Export MIDI"
+  },
+
+  "plugin_settings": {
+    "section.system_directories": "System Plugin Directories",
+    "section.custom_directories": "Custom Plugin Directories",
+    "section.excluded": "Excluded Plugins",
+    "button.add": "Add...",
+    "button.remove": "Remove",
+    "button.scan": "Scan for Plugins",
+    "button.view_report": "View Scan Report",
+    "button.remove_selected": "Remove Selected",
+    "button.reset_all": "Reset All",
+    "toggle.scan_on_startup": "Scan for new plugins on startup",
+    "dialog.select_directory": "Select Plugin Directory",
+    "column.plugin": "Plugin",
+    "column.reason": "Reason",
+    "column.date": "Date",
+    "status.starting": "Starting scan...",
+    "status.scanning": "Scanning:",
+    "status.failed": "Plugin scan failed",
+    "status.found_before_error": "found before error",
+    "status.plugins_failed": "plugin(s) failed",
+    "status.found": "Found",
+    "status.plugins": "plugins",
+    "status.failed_short": "failed",
+    "status.plugins_available": "plugins available",
+    "status.excluded": "excluded",
+    "status.none_scanned": "No plugins scanned yet"
+  },
+
+  "footer": {
+    "tooltip.session": "Session",
+    "tooltip.arrangement": "Arrangement",
+    "tooltip.mix": "Mix"
+  },
+
+  "main_window": {
+    "loading.initializing": "Initializing...",
+    "loading.scanning_devices": "Scanning audio & MIDI devices...",
+    "undo.render_clips": "Render Clips"
+  },
+
+  "export": {
+    "progress.exporting_audio": "Exporting Audio...",
+    "progress.preparing": "Preparing to export...",
+    "progress.rendering": "Rendering:",
+    "progress.trimming": "Trimming preroll...",
+    "progress.complete": "Export complete!",
+    "progress.failed": "Export failed",
+    "alert.cancelled_title": "Export Cancelled",
+    "alert.cancelled_body": "Export was cancelled.",
+    "alert.complete_title": "Export Complete",
+    "alert.failed_title": "Export Failed",
+    "alert.midi_title": "Export MIDI",
+    "alert.audio_success_prefix": "Audio exported successfully to:",
+    "alert.midi_success_prefix": "MIDI exported successfully to:",
+    "error.trim_failed": "Render succeeded but failed to trim preroll.",
+    "error.file_not_created": "Render completed but file was not created. The project may be empty or contain no audio.",
+    "error.render_failed": "Render job failed",
+    "error.cancelled": "Export cancelled by user",
+    "error.unknown": "Unknown error occurred during export",
+    "error.no_midi_clips": "No MIDI clips to export.",
+    "error.no_midi_notes": "No MIDI clips with notes to export.",
+    "error.midi_write_failed": "Failed to write MIDI file.",
+    "error.cannot_create_file": "Could not create output file:"
+  },
+
   "common": {
     "on": "On",
     "off": "Off",
@@ -234,6 +363,75 @@
   "preferences": {
     "language.header": "Language",
     "language.label": "UI Language",
-    "language.restart_required": "Restart required for language change to fully apply."
+    "language.restart_required": "Restart required for language change to fully apply.",
+
+    "tab.general": "General",
+    "tab.ui": "UI",
+    "tab.colours": "Colours",
+    "tab.rendering": "Rendering",
+    "tab.shortcuts": "Shortcuts",
+
+    "section.zoom": "Zoom",
+    "section.timeline": "Timeline",
+    "section.autosave": "Auto-Save",
+    "section.panels": "Panels",
+    "section.layout": "Layout",
+    "section.behavior": "Behavior",
+    "section.track_colour_palette": "Track Colour Palette",
+    "section.clip_colours": "Clip Colours",
+    "section.output": "Output",
+    "section.format": "Format",
+    "section.file_naming": "File Naming",
+    "section.keyboard_shortcuts": "Keyboard Shortcuts",
+
+    "slider.zoom_in_sensitivity": "Zoom In Sensitivity",
+    "slider.zoom_out_sensitivity": "Zoom Out Sensitivity",
+    "slider.zoom_shift_sensitivity": "Shift+Zoom Sensitivity",
+    "slider.default_length": "Default Length",
+    "slider.default_view": "Default View",
+    "slider.interval": "Interval",
+
+    "toggle.enable_autosave": "Enable auto-save",
+    "toggle.expand_left_panel": "Expand Left Panel (Browser)",
+    "toggle.expand_right_panel": "Expand Right Panel (Inspector)",
+    "toggle.expand_bottom_panel": "Expand Bottom Panel (Mixer)",
+    "toggle.headers_on_right": "Headers on the Right",
+    "toggle.confirm_track_delete": "Confirm before deleting tracks",
+    "toggle.auto_monitor": "Auto-monitor selected track",
+    "toggle.show_tooltips": "Show tooltips",
+
+    "button.add_colour": "+ Add Colour",
+    "button.browse": "Browse...",
+    "button.clear": "Clear",
+
+    "colours.colour": "Colour",
+    "colours.hex_rgb": "Hex (RGB)",
+    "colours.name": "Name",
+    "colours.new_default_name": "New",
+    "colours.default_name_prefix": "Colour",
+
+    "label.new_clip_colour": "New clip colour",
+    "label.render_output_folder": "Render Output Folder",
+    "label.default_beside_source": "Default (beside source file)",
+    "label.sample_rate": "Sample Rate",
+    "label.export_bit_depth": "Export Bit Depth",
+    "label.bounce_bit_depth": "Bounce Bit Depth",
+    "label.export_pattern": "Export Pattern",
+    "label.bounce_pattern": "Bounce Pattern",
+    "label.pattern_tokens_hint": "Tokens: <clip-name> <track-name> <project-name> <date-time>",
+
+    "option.inherit_from_track": "Inherit from track",
+    "option.cycle_palette": "Cycle through palette",
+    "option.bit_depth_16": "16-bit",
+    "option.bit_depth_24": "24-bit",
+    "option.bit_depth_32_float": "32-bit float",
+
+    "dialog.select_render_output_folder": "Select Render Output Folder",
+
+    "shortcut.add_track": "Add Track",
+    "shortcut.delete_track": "Delete Track",
+    "shortcut.duplicate_track": "Duplicate Track",
+    "shortcut.mute_track": "Mute Track",
+    "shortcut.solo_track": "Solo Track"
   }
 }

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -14,6 +14,8 @@ juce_add_binary_data(MagdaAssets
     ../../assets/fonts/Inter-Bold.ttf
     "../../assets/fonts/Microgramma D Extended Bold.otf"
     ../../assets/fonts/JetBrainsMono-Regular.ttf
+    # CJK fallback — covers Simplified/Traditional Chinese, Japanese, Korean
+    ../../assets/fonts/NotoSansCJKsc-Regular.otf
     # General UI icons
     ../../assets/icons/general/enter.svg
     ../../assets/icons/general/track.svg

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -4,6 +4,28 @@
 # Generate version header from project version
 configure_file(version.hpp.in "${CMAKE_CURRENT_BINARY_DIR}/generated/version.hpp" @ONLY)
 
+# Safety net: detect git-lfs pointer files before juce_add_binary_data embeds
+# them. Without this, a clone without git-lfs would build successfully but
+# silently ship a ~130-byte pointer in place of the real font, and CJK text
+# would render as tofu at runtime.
+set(LFS_TRACKED_FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../assets/fonts/NotoSansCJKsc-Regular.otf"
+)
+foreach(LFS_FILE ${LFS_TRACKED_FILES})
+    if(EXISTS "${LFS_FILE}")
+        file(READ "${LFS_FILE}" _lfs_head LIMIT 64)
+        if(_lfs_head MATCHES "^version https://git-lfs\\.github\\.com/spec/")
+            message(FATAL_ERROR
+                "\n"
+                "Git LFS file not fetched: ${LFS_FILE}\n"
+                "This file is tracked by git-lfs but was checked out as a pointer.\n"
+                "Install git-lfs and pull the real content:\n"
+                "    git lfs install\n"
+                "    git lfs pull\n")
+        endif()
+    endif()
+endforeach()
+
 # Create binary data for fonts and icons
 juce_add_binary_data(MagdaAssets
     SOURCES

--- a/magda/daw/core/StringTable.cpp
+++ b/magda/daw/core/StringTable.cpp
@@ -103,8 +103,14 @@ juce::String StringTable::get(const juce::String& key) const {
 
 bool StringTable::loadLanguage(const juce::String& languageCode) {
     if (languageCode == "en") {
-        // Reset to English: alias localized_ onto english_ so get() only hits
-        // the master table.
+        // Reset to English: alias localized_ onto the master table. Returns
+        // false if the English master never loaded (e.g. packaging error),
+        // so callers can surface the failure rather than silently using an
+        // empty string table.
+        if (english_.empty()) {
+            DBG("StringTable::loadLanguage(\"en\"): english_ is empty — en.json not loaded");
+            return false;
+        }
         localized_ = english_;
         language_ = "en";
         return true;

--- a/magda/daw/core/StringTable.cpp
+++ b/magda/daw/core/StringTable.cpp
@@ -51,7 +51,7 @@ bool StringTable::load(const juce::File& jsonFile) {
         return false;
     bool ok = loadFromString(text);
     if (ok)
-        DBG("StringTable: loaded " << strings_.size() << " strings from "
+        DBG("StringTable: loaded " << localized_.size() << " strings from "
                                    << jsonFile.getFileName());
     return ok;
 }
@@ -66,7 +66,12 @@ bool StringTable::loadFromString(const juce::String& json) {
     if (parsedStrings.empty())
         return false;
 
-    strings_ = std::move(parsedStrings);
+    // Treat the first successful load as the English master (the constructor
+    // loads en.json this way). Subsequent loadLanguage() calls overwrite only
+    // the localized_ map, keeping english_ as the fallback source.
+    if (english_.empty())
+        english_ = parsedStrings;
+    localized_ = std::move(parsedStrings);
     return true;
 }
 
@@ -86,13 +91,25 @@ void StringTable::parseObject(const juce::var& obj, const juce::String& prefix,
 }
 
 juce::String StringTable::get(const juce::String& key) const {
-    auto it = strings_.find(key);
-    if (it != strings_.end())
+    // Prefer the active locale, then fall back to English, then finally to the
+    // key itself. That way missing translations stay readable as English rather
+    // than surfacing the raw dotted key to users.
+    if (auto it = localized_.find(key); it != localized_.end())
         return it->second;
-    return key;  // Fallback: return the key itself so missing translations are visible
+    if (auto it = english_.find(key); it != english_.end())
+        return it->second;
+    return key;
 }
 
 bool StringTable::loadLanguage(const juce::String& languageCode) {
+    if (languageCode == "en") {
+        // Reset to English: alias localized_ onto english_ so get() only hits
+        // the master table.
+        localized_ = english_;
+        language_ = "en";
+        return true;
+    }
+
     auto langDir = findLangDirectory();
     if (langDir.isDirectory()) {
         auto file = langDir.getChildFile(languageCode + ".json");

--- a/magda/daw/core/StringTable.hpp
+++ b/magda/daw/core/StringTable.hpp
@@ -50,9 +50,9 @@ class StringTable {
     /** Return the first existing lang/ directory searched by the loader. */
     static juce::File findLangDirectory();
 
-    /** Get the number of loaded strings. */
+    /** Get the number of loaded strings in the active locale map. */
     int size() const {
-        return static_cast<int>(strings_.size());
+        return static_cast<int>(localized_.size());
     }
 
   private:
@@ -61,7 +61,12 @@ class StringTable {
     static void parseObject(const juce::var& obj, const juce::String& prefix,
                             std::unordered_map<juce::String, juce::String>& out);
 
-    std::unordered_map<juce::String, juce::String> strings_;
+    // `english_` is the master table, loaded from lang/en.json at construction
+    // and never modified afterwards — it's the fallback for any key missing in
+    // the current locale. `localized_` holds the active non-English locale (or
+    // aliases `english_` when the active language is English).
+    std::unordered_map<juce::String, juce::String> english_;
+    std::unordered_map<juce::String, juce::String> localized_;
     juce::String language_ = "en";
 };
 

--- a/magda/daw/ui/dialogs/AboutDialog.cpp
+++ b/magda/daw/ui/dialogs/AboutDialog.cpp
@@ -1,6 +1,7 @@
 #include "AboutDialog.hpp"
 
 #include "BinaryData.h"
+#include "core/StringTable.hpp"
 #include "magda.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
@@ -75,13 +76,12 @@ class AboutDialog::ContentComponent : public juce::Component {
         // Subtitle
         g.setFont(fm.getUIFont(14.0f));
         g.setColour(juce::Colour(DarkTheme::TEXT_SECONDARY));
-        g.drawText("Multi-Agent Digital Audio", bounds.removeFromTop(24),
-                   juce::Justification::centred);
+        g.drawText(tr("about.subtitle"), bounds.removeFromTop(24), juce::Justification::centred);
 
         // Version
         g.setFont(fm.getUIFont(12.0f));
         g.setColour(juce::Colour(DarkTheme::TEXT_DIM));
-        g.drawText(juce::String("Version ") + MAGDA_VERSION, bounds.removeFromTop(20),
+        g.drawText(tr("about.version_prefix") + MAGDA_VERSION, bounds.removeFromTop(20),
                    juce::Justification::centred);
 
         // Credits line
@@ -108,19 +108,24 @@ class AboutDialog::ContentComponent : public juce::Component {
             return juce::roundToInt(ga.getBoundingBox(0, -1, false).getWidth()) + 1;
         };
 
-        int powW = measure("powered by");
-        int teW = measure("Tracktion Engine");
+        const juce::String poweredBy = tr("about.credits.powered_by");
+        const juce::String tracktionName = tr("about.credits.tracktion_engine");
+        const juce::String madeWith = tr("about.credits.made_with");
+        const juce::String juceName = tr("about.credits.juce");
+
+        int powW = measure(poweredBy);
+        int teW = measure(tracktionName);
         int dotW = measure("|");
-        int madeW = measure("made with");
-        int juceW = measure("JUCE");
+        int madeW = measure(madeWith);
+        int juceW = measure(juceName);
 
         int totalW = powW + gap + teW + gap + logoSize + dotGap + dotW + dotGap + madeW + gap +
                      juceW + gap + logoSize;
         auto centred = row.withSizeKeepingCentre(totalW, 20);
 
-        g.drawText("powered by", centred.removeFromLeft(powW), juce::Justification::centred);
+        g.drawText(poweredBy, centred.removeFromLeft(powW), juce::Justification::centred);
         centred.removeFromLeft(gap);
-        g.drawText("Tracktion Engine", centred.removeFromLeft(teW), juce::Justification::centred);
+        g.drawText(tracktionName, centred.removeFromLeft(teW), juce::Justification::centred);
         centred.removeFromLeft(gap);
         if (teLogo_)
             teLogo_->drawWithin(g, centred.removeFromLeft(logoSize).toFloat(),
@@ -128,9 +133,9 @@ class AboutDialog::ContentComponent : public juce::Component {
         centred.removeFromLeft(dotGap);
         g.drawText("|", centred.removeFromLeft(dotW), juce::Justification::centred);
         centred.removeFromLeft(dotGap);
-        g.drawText("made with", centred.removeFromLeft(madeW), juce::Justification::centred);
+        g.drawText(madeWith, centred.removeFromLeft(madeW), juce::Justification::centred);
         centred.removeFromLeft(gap);
-        g.drawText("JUCE", centred.removeFromLeft(juceW), juce::Justification::centred);
+        g.drawText(juceName, centred.removeFromLeft(juceW), juce::Justification::centred);
         centred.removeFromLeft(gap);
         if (juceLogo_)
             juceLogo_->drawWithin(g, centred.removeFromLeft(logoSize).toFloat(),
@@ -171,7 +176,7 @@ class AboutDialog::ContentComponent : public juce::Component {
 // =============================================================================
 
 AboutDialog::AboutDialog()
-    : DialogWindow("About MAGDA", juce::Colour(DarkTheme::PANEL_BACKGROUND), true) {
+    : DialogWindow(tr("dialogs.about"), juce::Colour(DarkTheme::PANEL_BACKGROUND), true) {
     setContentOwned(new ContentComponent(), true);
     setUsingNativeTitleBar(false);
     setResizable(false, false);

--- a/magda/daw/ui/dialogs/ChainTreeDialog.cpp
+++ b/magda/daw/ui/dialogs/ChainTreeDialog.cpp
@@ -3,6 +3,7 @@
 #include "../themes/DarkTheme.hpp"
 #include "../themes/FontManager.hpp"
 #include "core/SelectionManager.hpp"
+#include "core/StringTable.hpp"
 
 namespace magda {
 
@@ -222,8 +223,7 @@ class ChainTreeDialog::ContentComponent : public juce::Component,
         addAndMakeVisible(treeView_);
 
         // Info label
-        infoLabel_.setText("Click an item to select it in the chain view",
-                           juce::dontSendNotification);
+        infoLabel_.setText(tr("chain_tree.label.click_hint"), juce::dontSendNotification);
         infoLabel_.setColour(juce::Label::textColourId,
                              DarkTheme::getColour(DarkTheme::TEXT_SECONDARY));
         infoLabel_.setJustificationType(juce::Justification::centred);
@@ -410,7 +410,8 @@ class ChainTreeDialog::ContentComponent : public juce::Component,
 juce::Component::SafePointer<ChainTreeDialog> ChainTreeDialog::currentInstance_;
 
 ChainTreeDialog::ChainTreeDialog(TrackId trackId)
-    : DialogWindow("Chain Tree", DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND), true),
+    : DialogWindow(tr("dialogs.chain_tree"), DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND),
+                   true),
       trackId_(trackId) {
     content_ = std::make_unique<ContentComponent>(trackId);
     setContentOwned(content_.release(), true);
@@ -450,7 +451,7 @@ void ChainTreeDialog::show(TrackId trackId) {
     }
 
     auto* dialog = new ChainTreeDialog(trackId);
-    dialog->setName("Chain Tree - " + track->name);
+    dialog->setName(tr("dialogs.chain_tree") + " - " + track->name);
     dialog->setVisible(true);
     dialog->toFront(true);
     currentInstance_ = dialog;

--- a/magda/daw/ui/dialogs/ExportAudioDialog.cpp
+++ b/magda/daw/ui/dialogs/ExportAudioDialog.cpp
@@ -4,6 +4,7 @@
 #include "../themes/DarkTheme.hpp"
 #include "../themes/DialogLookAndFeel.hpp"
 #include "../themes/FontManager.hpp"
+#include "core/StringTable.hpp"
 
 namespace magda {
 
@@ -11,14 +12,14 @@ ExportAudioDialog::ExportAudioDialog() {
     setLookAndFeel(&daw::ui::DialogLookAndFeel::getInstance());
 
     // Format selection
-    formatLabel_.setText("Format:", juce::dontSendNotification);
+    formatLabel_.setText(tr("export_audio.label.format"), juce::dontSendNotification);
     formatLabel_.setFont(FontManager::getInstance().getUIFontBold(14.0f));
     addAndMakeVisible(formatLabel_);
 
-    formatComboBox_.addItem("WAV 16-bit", 1);
-    formatComboBox_.addItem("WAV 24-bit", 2);
-    formatComboBox_.addItem("WAV 32-bit Float", 3);
-    formatComboBox_.addItem("FLAC", 4);
+    formatComboBox_.addItem(tr("export_audio.option.wav_16"), 1);
+    formatComboBox_.addItem(tr("export_audio.option.wav_24"), 2);
+    formatComboBox_.addItem(tr("export_audio.option.wav_32_float"), 3);
+    formatComboBox_.addItem(tr("export_audio.option.flac"), 4);
     // Initialise format from render bit depth preference
     auto& config = Config::getInstance();
     int bd = config.getRenderBitDepth();
@@ -34,7 +35,7 @@ ExportAudioDialog::ExportAudioDialog() {
     addAndMakeVisible(formatComboBox_);
 
     // Sample rate selection
-    sampleRateLabel_.setText("Sample Rate:", juce::dontSendNotification);
+    sampleRateLabel_.setText(tr("export_audio.label.sample_rate"), juce::dontSendNotification);
     sampleRateLabel_.setFont(FontManager::getInstance().getUIFontBold(14.0f));
     addAndMakeVisible(sampleRateLabel_);
 
@@ -55,7 +56,7 @@ ExportAudioDialog::ExportAudioDialog() {
     addAndMakeVisible(sampleRateComboBox_);
 
     // Bit depth (read-only, updates based on format)
-    bitDepthLabel_.setText("Bit Depth:", juce::dontSendNotification);
+    bitDepthLabel_.setText(tr("export_audio.label.bit_depth"), juce::dontSendNotification);
     bitDepthLabel_.setFont(FontManager::getInstance().getUIFontBold(14.0f));
     addAndMakeVisible(bitDepthLabel_);
 
@@ -64,17 +65,18 @@ ExportAudioDialog::ExportAudioDialog() {
     updateBitDepthOptions();  // Set label based on restored format
 
     // Normalization option
-    normalizeCheckbox_.setButtonText("Normalize to 0 dB (peak)");
+    normalizeCheckbox_.setButtonText(tr("export_audio.toggle.normalize"));
     normalizeCheckbox_.setToggleState(false, juce::dontSendNotification);
     addAndMakeVisible(normalizeCheckbox_);
 
     // Real-time render option
-    realTimeRenderCheckbox_.setButtonText("Real-time render (slower, avoids plugin glitches)");
+    realTimeRenderCheckbox_.setButtonText(tr("export_audio.toggle.realtime_render"));
     realTimeRenderCheckbox_.setToggleState(false, juce::dontSendNotification);
     addAndMakeVisible(realTimeRenderCheckbox_);
 
     // Lead-in silence
-    leadInSilenceLabel_.setText("Lead-in Silence:", juce::dontSendNotification);
+    leadInSilenceLabel_.setText(tr("export_audio.label.lead_in_silence"),
+                                juce::dontSendNotification);
     leadInSilenceLabel_.setFont(FontManager::getInstance().getUIFontBold(14.0f));
     addAndMakeVisible(leadInSilenceLabel_);
 
@@ -85,27 +87,27 @@ ExportAudioDialog::ExportAudioDialog() {
     addAndMakeVisible(leadInSilenceSlider_);
 
     // Time range selection
-    timeRangeLabel_.setText("Export Range:", juce::dontSendNotification);
+    timeRangeLabel_.setText(tr("export_audio.label.export_range"), juce::dontSendNotification);
     timeRangeLabel_.setFont(FontManager::getInstance().getUIFontBold(14.0f));
     addAndMakeVisible(timeRangeLabel_);
 
-    exportEntireSongButton_.setButtonText("Entire Song");
+    exportEntireSongButton_.setButtonText(tr("export_audio.option.entire_song"));
     exportEntireSongButton_.setRadioGroupId(1);
     exportEntireSongButton_.setToggleState(true, juce::dontSendNotification);
     addAndMakeVisible(exportEntireSongButton_);
 
-    exportTimeSelectionButton_.setButtonText("Time Selection");
+    exportTimeSelectionButton_.setButtonText(tr("export_audio.option.time_selection"));
     exportTimeSelectionButton_.setRadioGroupId(1);
     exportTimeSelectionButton_.setEnabled(false);  // Disabled by default
     addAndMakeVisible(exportTimeSelectionButton_);
 
-    exportLoopRegionButton_.setButtonText("Loop Region");
+    exportLoopRegionButton_.setButtonText(tr("export_audio.option.loop_region"));
     exportLoopRegionButton_.setRadioGroupId(1);
     exportLoopRegionButton_.setEnabled(false);  // Disabled by default
     addAndMakeVisible(exportLoopRegionButton_);
 
     // Export button
-    exportButton_.setButtonText("Export");
+    exportButton_.setButtonText(tr("export_audio.button.export"));
     exportButton_.onClick = [this]() {
         if (onExport) {
             auto settings = getSettings();
@@ -128,7 +130,7 @@ ExportAudioDialog::ExportAudioDialog() {
     addAndMakeVisible(exportButton_);
 
     // Cancel button
-    cancelButton_.setButtonText("Cancel");
+    cancelButton_.setButtonText(tr("dialogs.cancel"));
     cancelButton_.onClick = [this]() {
         if (auto* dw = findParentComponentOfClass<juce::DialogWindow>()) {
             dw->exitModalState(0);
@@ -294,19 +296,19 @@ void ExportAudioDialog::updateBitDepthOptions() {
 
     switch (formatId) {
         case 1:  // WAV 16-bit
-            bitDepthText = "16-bit";
+            bitDepthText = tr("export_audio.bit_depth.16");
             break;
         case 2:  // WAV 24-bit
-            bitDepthText = "24-bit";
+            bitDepthText = tr("export_audio.bit_depth.24");
             break;
         case 3:  // WAV 32-bit Float
-            bitDepthText = "32-bit Float";
+            bitDepthText = tr("export_audio.bit_depth.32_float");
             break;
         case 4:  // FLAC
-            bitDepthText = "24-bit (FLAC)";
+            bitDepthText = tr("export_audio.bit_depth.24_flac");
             break;
         default:
-            bitDepthText = "24-bit";
+            bitDepthText = tr("export_audio.bit_depth.24");
             break;
     }
 
@@ -322,7 +324,7 @@ void ExportAudioDialog::showDialog(juce::Component* parent,
     dialog->onExport = exportCallback;
 
     juce::DialogWindow::LaunchOptions options;
-    options.dialogTitle = "Export Audio";
+    options.dialogTitle = tr("dialogs.export_audio");
     options.dialogBackgroundColour = DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND);
     options.content.setOwned(dialog);
     options.escapeKeyTriggersCloseButton = true;

--- a/magda/daw/ui/dialogs/ExportMidiDialog.cpp
+++ b/magda/daw/ui/dialogs/ExportMidiDialog.cpp
@@ -3,6 +3,7 @@
 #include "../themes/DarkTheme.hpp"
 #include "../themes/DialogLookAndFeel.hpp"
 #include "../themes/FontManager.hpp"
+#include "core/StringTable.hpp"
 
 namespace magda {
 
@@ -10,37 +11,37 @@ ExportMidiDialog::ExportMidiDialog() {
     setLookAndFeel(&daw::ui::DialogLookAndFeel::getInstance());
 
     // MIDI format selection
-    formatLabel_.setText("MIDI Format:", juce::dontSendNotification);
+    formatLabel_.setText(tr("export_midi.label.midi_format"), juce::dontSendNotification);
     formatLabel_.setFont(FontManager::getInstance().getUIFontBold(14.0f));
     addAndMakeVisible(formatLabel_);
 
-    formatComboBox_.addItem("Type 0 (Single Track)", 1);
-    formatComboBox_.addItem("Type 1 (Multi-Track)", 2);
+    formatComboBox_.addItem(tr("export_midi.option.type_0"), 1);
+    formatComboBox_.addItem(tr("export_midi.option.type_1"), 2);
     formatComboBox_.setSelectedId(2, juce::dontSendNotification);
     addAndMakeVisible(formatComboBox_);
 
     // Export range
-    rangeLabel_.setText("Export Range:", juce::dontSendNotification);
+    rangeLabel_.setText(tr("export_midi.label.export_range"), juce::dontSendNotification);
     rangeLabel_.setFont(FontManager::getInstance().getUIFontBold(14.0f));
     addAndMakeVisible(rangeLabel_);
 
-    exportEntireSongButton_.setButtonText("Entire Song");
+    exportEntireSongButton_.setButtonText(tr("export_midi.option.entire_song"));
     exportEntireSongButton_.setRadioGroupId(1);
     exportEntireSongButton_.setToggleState(true, juce::dontSendNotification);
     addAndMakeVisible(exportEntireSongButton_);
 
-    exportTimeSelectionButton_.setButtonText("Time Selection");
+    exportTimeSelectionButton_.setButtonText(tr("export_midi.option.time_selection"));
     exportTimeSelectionButton_.setRadioGroupId(1);
     exportTimeSelectionButton_.setEnabled(false);
     addAndMakeVisible(exportTimeSelectionButton_);
 
-    exportLoopRegionButton_.setButtonText("Loop Region");
+    exportLoopRegionButton_.setButtonText(tr("export_midi.option.loop_region"));
     exportLoopRegionButton_.setRadioGroupId(1);
     exportLoopRegionButton_.setEnabled(false);
     addAndMakeVisible(exportLoopRegionButton_);
 
     // Export button
-    exportButton_.setButtonText("Export");
+    exportButton_.setButtonText(tr("export_midi.button.export"));
     exportButton_.onClick = [this]() {
         if (onExport)
             onExport(getSettings());
@@ -50,7 +51,7 @@ ExportMidiDialog::ExportMidiDialog() {
     addAndMakeVisible(exportButton_);
 
     // Cancel button
-    cancelButton_.setButtonText("Cancel");
+    cancelButton_.setButtonText(tr("dialogs.cancel"));
     cancelButton_.onClick = [this]() {
         if (auto* dw = findParentComponentOfClass<juce::DialogWindow>())
             dw->exitModalState(0);
@@ -133,7 +134,7 @@ void ExportMidiDialog::showDialog(juce::Component* parent,
     dialog->onExport = exportCallback;
 
     juce::DialogWindow::LaunchOptions options;
-    options.dialogTitle = "Export MIDI";
+    options.dialogTitle = tr("export_midi.dialog.title");
     options.dialogBackgroundColour = DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND);
     options.content.setOwned(dialog);
     options.escapeKeyTriggersCloseButton = true;

--- a/magda/daw/ui/dialogs/PluginSettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/PluginSettingsDialog.cpp
@@ -6,6 +6,7 @@
 #include "../themes/DialogLookAndFeel.hpp"
 #include "../themes/FontManager.hpp"
 #include "core/Config.hpp"
+#include "core/StringTable.hpp"
 #include "engine/PluginScanCoordinator.hpp"
 #include "engine/TracktionEngineWrapper.hpp"
 
@@ -133,7 +134,7 @@ PluginSettingsDialog::PluginSettingsDialog(TracktionEngineWrapper* engine)
     excludedTableModel_.entries = &excludedPlugins_;
 
     // System directories section (read-only)
-    setupSectionHeader(systemDirsHeader_, "System Plugin Directories");
+    setupSectionHeader(systemDirsHeader_, tr("plugin_settings.section.system_directories"));
 
     systemDirsList_.setModel(&systemDirListModel_);
     systemDirsList_.setColour(juce::ListBox::backgroundColourId,
@@ -144,7 +145,7 @@ PluginSettingsDialog::PluginSettingsDialog(TracktionEngineWrapper* engine)
     addAndMakeVisible(systemDirsList_);
 
     // Custom directories section
-    setupSectionHeader(directoriesHeader_, "Custom Plugin Directories");
+    setupSectionHeader(directoriesHeader_, tr("plugin_settings.section.custom_directories"));
 
     directoriesList_.setModel(&dirListModel_);
     directoriesList_.setColour(juce::ListBox::backgroundColourId,
@@ -154,9 +155,10 @@ PluginSettingsDialog::PluginSettingsDialog(TracktionEngineWrapper* engine)
     directoriesList_.setRowHeight(22);
     addAndMakeVisible(directoriesList_);
 
-    addDirButton_.setButtonText("Add...");
+    addDirButton_.setButtonText(tr("plugin_settings.button.add"));
     addDirButton_.onClick = [this]() {
-        fileChooser_ = std::make_unique<juce::FileChooser>("Select Plugin Directory");
+        fileChooser_ =
+            std::make_unique<juce::FileChooser>(tr("plugin_settings.dialog.select_directory"));
         fileChooser_->launchAsync(
             juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectDirectories,
             [this](const juce::FileChooser& fc) {
@@ -170,7 +172,7 @@ PluginSettingsDialog::PluginSettingsDialog(TracktionEngineWrapper* engine)
     };
     addAndMakeVisible(addDirButton_);
 
-    removeDirButton_.setButtonText("Remove");
+    removeDirButton_.setButtonText(tr("plugin_settings.button.remove"));
     removeDirButton_.onClick = [this]() {
         int selected = directoriesList_.getSelectedRow();
         if (selected >= 0 && selected < static_cast<int>(customPaths_.size())) {
@@ -182,7 +184,7 @@ PluginSettingsDialog::PluginSettingsDialog(TracktionEngineWrapper* engine)
     addAndMakeVisible(removeDirButton_);
 
     // Scan section
-    scanButton_.setButtonText("Scan for Plugins");
+    scanButton_.setButtonText(tr("plugin_settings.button.scan"));
     scanButton_.onClick = [this]() {
         if (!engine_)
             return;
@@ -191,7 +193,7 @@ PluginSettingsDialog::PluginSettingsDialog(TracktionEngineWrapper* engine)
 
         setScanningUIEnabled(false);
         scanProgress_ = 0.0;
-        scanStatusLabel_.setText("Starting scan...", juce::dontSendNotification);
+        scanStatusLabel_.setText(tr("plugin_settings.status.starting"), juce::dontSendNotification);
         scanProgressBar_.setVisible(true);
         scanStatusLabel_.setVisible(true);
 
@@ -203,7 +205,8 @@ PluginSettingsDialog::PluginSettingsDialog(TracktionEngineWrapper* engine)
                     return;
                 safeThis->scanProgress_ = static_cast<double>(progress);
                 juce::File f(pluginName);
-                safeThis->scanStatusLabel_.setText("Scanning: " + f.getFileName(),
+                safeThis->scanStatusLabel_.setText(tr("plugin_settings.status.scanning") + " " +
+                                                       f.getFileName(),
                                                    juce::dontSendNotification);
             });
         });
@@ -217,17 +220,21 @@ PluginSettingsDialog::PluginSettingsDialog(TracktionEngineWrapper* engine)
                 safeThis->scanProgress_ = -1.0;
                 safeThis->scanProgressBar_.setVisible(false);
                 if (!success) {
-                    juce::String message = "Plugin scan failed";
+                    juce::String message = tr("plugin_settings.status.failed");
                     if (numPlugins > 0)
-                        message += " (" + juce::String(numPlugins) + " found before error)";
+                        message += " (" + juce::String(numPlugins) + " " +
+                                   tr("plugin_settings.status.found_before_error") + ")";
                     if (failedPlugins.size() > 0)
-                        message += ", " + juce::String(failedPlugins.size()) + " plugin(s) failed";
+                        message += ", " + juce::String(failedPlugins.size()) + " " +
+                                   tr("plugin_settings.status.plugins_failed");
                     safeThis->scanStatusLabel_.setText(message, juce::dontSendNotification);
                 } else {
                     safeThis->scanStatusLabel_.setText(
-                        "Found " + juce::String(numPlugins) + " plugins" +
+                        tr("plugin_settings.status.found") + " " + juce::String(numPlugins) + " " +
+                            tr("plugin_settings.status.plugins") +
                             (failedPlugins.size() > 0
-                                 ? ", " + juce::String(failedPlugins.size()) + " failed"
+                                 ? ", " + juce::String(failedPlugins.size()) + " " +
+                                       tr("plugin_settings.status.failed_short")
                                  : ""),
                         juce::dontSendNotification);
                 }
@@ -247,7 +254,7 @@ PluginSettingsDialog::PluginSettingsDialog(TracktionEngineWrapper* engine)
     };
     addAndMakeVisible(scanButton_);
 
-    viewReportButton_.setButtonText("View Scan Report");
+    viewReportButton_.setButtonText(tr("plugin_settings.button.view_report"));
     viewReportButton_.onClick = [this]() {
         if (engine_) {
             auto* coordinator = engine_->getPluginScanCoordinator();
@@ -260,7 +267,7 @@ PluginSettingsDialog::PluginSettingsDialog(TracktionEngineWrapper* engine)
     };
     addAndMakeVisible(viewReportButton_);
 
-    scanOnStartupToggle_.setButtonText("Scan for new plugins on startup");
+    scanOnStartupToggle_.setButtonText(tr("plugin_settings.toggle.scan_on_startup"));
     scanOnStartupToggle_.setToggleState(Config::getInstance().getScanPluginsOnStartup(),
                                         juce::dontSendNotification);
     scanOnStartupToggle_.setColour(juce::ToggleButton::textColourId,
@@ -284,16 +291,16 @@ PluginSettingsDialog::PluginSettingsDialog(TracktionEngineWrapper* engine)
     addAndMakeVisible(pluginCountLabel_);
 
     // Excluded plugins section
-    setupSectionHeader(excludedHeader_, "Excluded Plugins");
+    setupSectionHeader(excludedHeader_, tr("plugin_settings.section.excluded"));
 
     excludedTable_.setModel(&excludedTableModel_);
     excludedTable_.setColour(juce::ListBox::backgroundColourId,
                              DarkTheme::getColour(DarkTheme::SURFACE));
     excludedTable_.setColour(juce::ListBox::outlineColourId, DarkTheme::getBorderColour());
     excludedTable_.setOutlineThickness(1);
-    excludedTable_.getHeader().addColumn("Plugin", 1, 250, 100, 400);
-    excludedTable_.getHeader().addColumn("Reason", 2, 80, 60, 150);
-    excludedTable_.getHeader().addColumn("Date", 3, 150, 80, 250);
+    excludedTable_.getHeader().addColumn(tr("plugin_settings.column.plugin"), 1, 250, 100, 400);
+    excludedTable_.getHeader().addColumn(tr("plugin_settings.column.reason"), 2, 80, 60, 150);
+    excludedTable_.getHeader().addColumn(tr("plugin_settings.column.date"), 3, 150, 80, 250);
     excludedTable_.getHeader().setColour(juce::TableHeaderComponent::backgroundColourId,
                                          DarkTheme::getColour(DarkTheme::SURFACE));
     excludedTable_.getHeader().setColour(juce::TableHeaderComponent::textColourId,
@@ -301,7 +308,7 @@ PluginSettingsDialog::PluginSettingsDialog(TracktionEngineWrapper* engine)
     excludedTable_.setMultipleSelectionEnabled(true);
     addAndMakeVisible(excludedTable_);
 
-    removeSelectedButton_.setButtonText("Remove Selected");
+    removeSelectedButton_.setButtonText(tr("plugin_settings.button.remove_selected"));
     removeSelectedButton_.onClick = [this]() {
         auto selectedRows = excludedTable_.getSelectedRows();
         std::vector<int> indices;
@@ -319,7 +326,7 @@ PluginSettingsDialog::PluginSettingsDialog(TracktionEngineWrapper* engine)
     };
     addAndMakeVisible(removeSelectedButton_);
 
-    resetAllButton_.setButtonText("Reset All");
+    resetAllButton_.setButtonText(tr("plugin_settings.button.reset_all"));
     resetAllButton_.onClick = [this]() {
         excludedPlugins_.clear();
         excludedTable_.updateContent();
@@ -328,7 +335,7 @@ PluginSettingsDialog::PluginSettingsDialog(TracktionEngineWrapper* engine)
     addAndMakeVisible(resetAllButton_);
 
     // OK / Cancel
-    okButton_.setButtonText("OK");
+    okButton_.setButtonText(tr("dialogs.ok"));
     okButton_.onClick = [this]() {
         if (isScanRunning())
             return;
@@ -338,7 +345,7 @@ PluginSettingsDialog::PluginSettingsDialog(TracktionEngineWrapper* engine)
     };
     addAndMakeVisible(okButton_);
 
-    cancelButton_.setButtonText("Cancel");
+    cancelButton_.setButtonText(tr("dialogs.cancel"));
     cancelButton_.onClick = [this]() {
         if (isScanRunning())
             return;
@@ -493,7 +500,7 @@ void PluginSettingsDialog::showDialog(TracktionEngineWrapper* engine, juce::Comp
     auto* dialog = new PluginSettingsDialog(engine);
     auto bg = DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND);
 
-    auto* window = new PluginSettingsDialogWindow("Plugin Settings", bg, false, dialog);
+    auto* window = new PluginSettingsDialogWindow(tr("dialogs.plugin_settings"), bg, false, dialog);
     window->setContentOwned(dialog, true);
     window->setUsingNativeTitleBar(true);
     window->setResizable(false, false);
@@ -507,12 +514,14 @@ void PluginSettingsDialog::updatePluginCountLabel() {
     int excluded = static_cast<int>(excludedPlugins_.size());
 
     if (count > 0) {
-        juce::String text = juce::String(count) + " plugins available";
+        juce::String text =
+            juce::String(count) + " " + tr("plugin_settings.status.plugins_available");
         if (excluded > 0)
-            text += ", " + juce::String(excluded) + " excluded";
+            text += ", " + juce::String(excluded) + " " + tr("plugin_settings.status.excluded");
         pluginCountLabel_.setText(text, juce::dontSendNotification);
     } else {
-        pluginCountLabel_.setText("No plugins scanned yet", juce::dontSendNotification);
+        pluginCountLabel_.setText(tr("plugin_settings.status.none_scanned"),
+                                  juce::dontSendNotification);
     }
 }
 

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -86,25 +86,25 @@ namespace magda {
 class GeneralPage : public juce::Component {
   public:
     GeneralPage() {
-        setupSectionHeader(*this, zoomHeader, "Zoom");
-        setupSlider(*this, zoomInSensitivitySlider, zoomInLabel, "Zoom In Sensitivity", 5.0, 100.0,
-                    1.0);
-        setupSlider(*this, zoomOutSensitivitySlider, zoomOutLabel, "Zoom Out Sensitivity", 5.0,
-                    100.0, 1.0);
-        setupSlider(*this, zoomShiftSensitivitySlider, zoomShiftLabel, "Shift+Zoom Sensitivity",
-                    1.0, 50.0, 0.5);
+        setupSectionHeader(*this, zoomHeader, tr("preferences.section.zoom"));
+        setupSlider(*this, zoomInSensitivitySlider, zoomInLabel,
+                    tr("preferences.slider.zoom_in_sensitivity"), 5.0, 100.0, 1.0);
+        setupSlider(*this, zoomOutSensitivitySlider, zoomOutLabel,
+                    tr("preferences.slider.zoom_out_sensitivity"), 5.0, 100.0, 1.0);
+        setupSlider(*this, zoomShiftSensitivitySlider, zoomShiftLabel,
+                    tr("preferences.slider.zoom_shift_sensitivity"), 1.0, 50.0, 0.5);
 
-        setupSectionHeader(*this, timelineHeader, "Timeline");
-        setupSlider(*this, timelineLengthSlider, timelineLengthLabel, "Default Length", 16.0,
-                    4096.0, 1.0, " bars");
+        setupSectionHeader(*this, timelineHeader, tr("preferences.section.timeline"));
+        setupSlider(*this, timelineLengthSlider, timelineLengthLabel,
+                    tr("preferences.slider.default_length"), 16.0, 4096.0, 1.0, " bars");
         timelineLengthSlider.setSkewFactorFromMidPoint(256.0);
-        setupSlider(*this, viewDurationSlider, viewDurationLabel, "Default View", 4.0, 128.0, 1.0,
-                    " bars");
+        setupSlider(*this, viewDurationSlider, viewDurationLabel,
+                    tr("preferences.slider.default_view"), 4.0, 128.0, 1.0, " bars");
 
-        setupSectionHeader(*this, autoSaveHeader, "Auto-Save");
-        setupToggle(*this, autoSaveToggle, "Enable auto-save");
-        setupSlider(*this, autoSaveIntervalSlider, autoSaveIntervalLabel, "Interval", 10.0, 300.0,
-                    10.0, " sec");
+        setupSectionHeader(*this, autoSaveHeader, tr("preferences.section.autosave"));
+        setupToggle(*this, autoSaveToggle, tr("preferences.toggle.enable_autosave"));
+        setupSlider(*this, autoSaveIntervalSlider, autoSaveIntervalLabel,
+                    tr("preferences.slider.interval"), 10.0, 300.0, 10.0, " sec");
     }
 
     void resized() override {
@@ -190,18 +190,18 @@ class GeneralPage : public juce::Component {
 class UIPage : public juce::Component {
   public:
     UIPage() {
-        setupSectionHeader(*this, panelsHeader, "Panels");
-        setupToggle(*this, showLeftPanelToggle, "Expand Left Panel (Browser)");
-        setupToggle(*this, showRightPanelToggle, "Expand Right Panel (Inspector)");
-        setupToggle(*this, showBottomPanelToggle, "Expand Bottom Panel (Mixer)");
+        setupSectionHeader(*this, panelsHeader, tr("preferences.section.panels"));
+        setupToggle(*this, showLeftPanelToggle, tr("preferences.toggle.expand_left_panel"));
+        setupToggle(*this, showRightPanelToggle, tr("preferences.toggle.expand_right_panel"));
+        setupToggle(*this, showBottomPanelToggle, tr("preferences.toggle.expand_bottom_panel"));
 
-        setupSectionHeader(*this, layoutHeader, "Layout");
-        setupToggle(*this, headersOnRightToggle, "Headers on the Right");
+        setupSectionHeader(*this, layoutHeader, tr("preferences.section.layout"));
+        setupToggle(*this, headersOnRightToggle, tr("preferences.toggle.headers_on_right"));
 
-        setupSectionHeader(*this, behaviorHeader, "Behavior");
-        setupToggle(*this, confirmTrackDeleteToggle, "Confirm before deleting tracks");
-        setupToggle(*this, autoMonitorToggle, "Auto-monitor selected track");
-        setupToggle(*this, showTooltipsToggle, "Show tooltips");
+        setupSectionHeader(*this, behaviorHeader, tr("preferences.section.behavior"));
+        setupToggle(*this, confirmTrackDeleteToggle, tr("preferences.toggle.confirm_track_delete"));
+        setupToggle(*this, autoMonitorToggle, tr("preferences.toggle.auto_monitor"));
+        setupToggle(*this, showTooltipsToggle, tr("preferences.toggle.show_tooltips"));
 
         // Language section
         setupSectionHeader(*this, languageHeader, tr("preferences.language.header"));
@@ -366,42 +366,45 @@ class ColoursPage : public juce::Component {
     static constexpr int MAX_PALETTE_SIZE = 16;
 
     ColoursPage() {
-        setupSectionHeader(*this, coloursHeader, "Track Colour Palette");
+        setupSectionHeader(*this, coloursHeader, tr("preferences.section.track_colour_palette"));
 
-        colourHeaderLabel.setText("Colour", juce::dontSendNotification);
+        colourHeaderLabel.setText(tr("preferences.colours.colour"), juce::dontSendNotification);
         colourHeaderLabel.setFont(FontManager::getInstance().getUIFont(11.0f));
         colourHeaderLabel.setColour(juce::Label::textColourId,
                                     DarkTheme::getColour(DarkTheme::TEXT_SECONDARY));
         addAndMakeVisible(colourHeaderLabel);
 
-        hexHeaderLabel.setText("Hex (RGB)", juce::dontSendNotification);
+        hexHeaderLabel.setText(tr("preferences.colours.hex_rgb"), juce::dontSendNotification);
         hexHeaderLabel.setFont(FontManager::getInstance().getUIFont(11.0f));
         hexHeaderLabel.setColour(juce::Label::textColourId,
                                  DarkTheme::getColour(DarkTheme::TEXT_SECONDARY));
         addAndMakeVisible(hexHeaderLabel);
 
-        nameHeaderLabel.setText("Name", juce::dontSendNotification);
+        nameHeaderLabel.setText(tr("preferences.colours.name"), juce::dontSendNotification);
         nameHeaderLabel.setFont(FontManager::getInstance().getUIFont(11.0f));
         nameHeaderLabel.setColour(juce::Label::textColourId,
                                   DarkTheme::getColour(DarkTheme::TEXT_SECONDARY));
         addAndMakeVisible(nameHeaderLabel);
 
-        addColourButton.setButtonText("+ Add Colour");
-        addColourButton.onClick = [this]() { addColourRow(0xFF808080, "New"); };
+        addColourButton.setButtonText(tr("preferences.button.add_colour"));
+        addColourButton.onClick = [this]() {
+            addColourRow(0xFF808080, tr("preferences.colours.new_default_name").toStdString());
+        };
         addAndMakeVisible(addColourButton);
 
         // Clip colour mode
-        setupSectionHeader(*this, clipColourHeader, "Clip Colours");
+        setupSectionHeader(*this, clipColourHeader, tr("preferences.section.clip_colours"));
 
-        clipColourModeLabel.setText("New clip colour", juce::dontSendNotification);
+        clipColourModeLabel.setText(tr("preferences.label.new_clip_colour"),
+                                    juce::dontSendNotification);
         clipColourModeLabel.setFont(FontManager::getInstance().getUIFont(12.0f));
         clipColourModeLabel.setColour(juce::Label::textColourId,
                                       DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
         clipColourModeLabel.setJustificationType(juce::Justification::centredLeft);
         addAndMakeVisible(clipColourModeLabel);
 
-        clipColourModeCombo.addItem("Inherit from track", 1);
-        clipColourModeCombo.addItem("Cycle through palette", 2);
+        clipColourModeCombo.addItem(tr("preferences.option.inherit_from_track"), 1);
+        clipColourModeCombo.addItem(tr("preferences.option.cycle_palette"), 2);
         clipColourModeCombo.setColour(juce::ComboBox::backgroundColourId,
                                       DarkTheme::getColour(DarkTheme::SURFACE));
         clipColourModeCombo.setColour(juce::ComboBox::textColourId,
@@ -481,7 +484,8 @@ class ColoursPage : public juce::Component {
                 static_cast<uint32_t>(hexEditors_[i]->getText().getHexValue64() | 0xFF000000ULL);
             entry.name = nameEditors_[i]->getText().toStdString();
             if (entry.name.empty())
-                entry.name = "Colour " + std::to_string(i + 1);
+                entry.name = tr("preferences.colours.default_name_prefix").toStdString() + " " +
+                             std::to_string(i + 1);
             palette.push_back(entry);
         }
         config.setTrackColourPalette(palette);
@@ -621,25 +625,28 @@ class RenderingPage : public juce::Component {
   public:
     RenderingPage() {
         // --- Output Folder ---
-        setupSectionHeader(*this, renderHeader, "Output");
+        setupSectionHeader(*this, renderHeader, tr("preferences.section.output"));
 
-        renderFolderLabel.setText("Render Output Folder", juce::dontSendNotification);
+        renderFolderLabel.setText(tr("preferences.label.render_output_folder"),
+                                  juce::dontSendNotification);
         renderFolderLabel.setFont(FontManager::getInstance().getUIFont(12.0f));
         renderFolderLabel.setColour(juce::Label::textColourId,
                                     DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
         renderFolderLabel.setJustificationType(juce::Justification::centredLeft);
         addAndMakeVisible(renderFolderLabel);
 
-        renderFolderValue.setText("Default (beside source file)", juce::dontSendNotification);
+        renderFolderValue.setText(tr("preferences.label.default_beside_source"),
+                                  juce::dontSendNotification);
         renderFolderValue.setFont(FontManager::getInstance().getUIFont(12.0f));
         renderFolderValue.setColour(juce::Label::textColourId,
                                     DarkTheme::getColour(DarkTheme::TEXT_SECONDARY));
         renderFolderValue.setJustificationType(juce::Justification::centredLeft);
         addAndMakeVisible(renderFolderValue);
 
-        renderFolderBrowseButton.setButtonText("Browse...");
+        renderFolderBrowseButton.setButtonText(tr("preferences.button.browse"));
         renderFolderBrowseButton.onClick = [this]() {
-            fileChooser_ = std::make_unique<juce::FileChooser>("Select Render Output Folder");
+            fileChooser_ = std::make_unique<juce::FileChooser>(
+                tr("preferences.dialog.select_render_output_folder"));
             fileChooser_->launchAsync(juce::FileBrowserComponent::openMode |
                                           juce::FileBrowserComponent::canSelectDirectories,
                                       [this](const juce::FileChooser& fc) {
@@ -654,17 +661,18 @@ class RenderingPage : public juce::Component {
         };
         addAndMakeVisible(renderFolderBrowseButton);
 
-        renderFolderClearButton.setButtonText("Clear");
+        renderFolderClearButton.setButtonText(tr("preferences.button.clear"));
         renderFolderClearButton.onClick = [this]() {
             renderFolderPath_.clear();
-            renderFolderValue.setText("Default (beside source file)", juce::dontSendNotification);
+            renderFolderValue.setText(tr("preferences.label.default_beside_source"),
+                                      juce::dontSendNotification);
         };
         addAndMakeVisible(renderFolderClearButton);
 
         // --- Format ---
-        setupSectionHeader(*this, formatHeader, "Format");
+        setupSectionHeader(*this, formatHeader, tr("preferences.section.format"));
 
-        setupComboLabel(sampleRateLabel, "Sample Rate");
+        setupComboLabel(sampleRateLabel, tr("preferences.label.sample_rate"));
         sampleRateCombo.addItem("44100 Hz", 1);
         sampleRateCombo.addItem("48000 Hz", 2);
         sampleRateCombo.addItem("96000 Hz", 3);
@@ -672,24 +680,24 @@ class RenderingPage : public juce::Component {
         styleCombo(sampleRateCombo);
         addAndMakeVisible(sampleRateCombo);
 
-        setupComboLabel(bitDepthLabel, "Export Bit Depth");
-        bitDepthCombo.addItem("16-bit", 1);
-        bitDepthCombo.addItem("24-bit", 2);
-        bitDepthCombo.addItem("32-bit float", 3);
+        setupComboLabel(bitDepthLabel, tr("preferences.label.export_bit_depth"));
+        bitDepthCombo.addItem(tr("preferences.option.bit_depth_16"), 1);
+        bitDepthCombo.addItem(tr("preferences.option.bit_depth_24"), 2);
+        bitDepthCombo.addItem(tr("preferences.option.bit_depth_32_float"), 3);
         styleCombo(bitDepthCombo);
         addAndMakeVisible(bitDepthCombo);
 
-        setupComboLabel(bounceBitDepthLabel, "Bounce Bit Depth");
-        bounceBitDepthCombo.addItem("16-bit", 1);
-        bounceBitDepthCombo.addItem("24-bit", 2);
-        bounceBitDepthCombo.addItem("32-bit float", 3);
+        setupComboLabel(bounceBitDepthLabel, tr("preferences.label.bounce_bit_depth"));
+        bounceBitDepthCombo.addItem(tr("preferences.option.bit_depth_16"), 1);
+        bounceBitDepthCombo.addItem(tr("preferences.option.bit_depth_24"), 2);
+        bounceBitDepthCombo.addItem(tr("preferences.option.bit_depth_32_float"), 3);
         styleCombo(bounceBitDepthCombo);
         addAndMakeVisible(bounceBitDepthCombo);
 
         // --- File Naming ---
-        setupSectionHeader(*this, namingHeader, "File Naming");
+        setupSectionHeader(*this, namingHeader, tr("preferences.section.file_naming"));
 
-        setupComboLabel(patternLabel, "Export Pattern");
+        setupComboLabel(patternLabel, tr("preferences.label.export_pattern"));
         patternEditor.setFont(FontManager::getInstance().getUIFont(12.0f));
         patternEditor.setColour(juce::TextEditor::backgroundColourId,
                                 DarkTheme::getColour(DarkTheme::SURFACE));
@@ -699,7 +707,7 @@ class RenderingPage : public juce::Component {
                                 DarkTheme::getColour(DarkTheme::BORDER));
         addAndMakeVisible(patternEditor);
 
-        setupComboLabel(bouncePatternLabel, "Bounce Pattern");
+        setupComboLabel(bouncePatternLabel, tr("preferences.label.bounce_pattern"));
         bouncePatternEditor.setFont(FontManager::getInstance().getUIFont(12.0f));
         bouncePatternEditor.setColour(juce::TextEditor::backgroundColourId,
                                       DarkTheme::getColour(DarkTheme::SURFACE));
@@ -709,7 +717,7 @@ class RenderingPage : public juce::Component {
                                       DarkTheme::getColour(DarkTheme::BORDER));
         addAndMakeVisible(bouncePatternEditor);
 
-        patternHint.setText("Tokens: <clip-name> <track-name> <project-name> <date-time>",
+        patternHint.setText(tr("preferences.label.pattern_tokens_hint"),
                             juce::dontSendNotification);
         patternHint.setFont(FontManager::getInstance().getUIFont(10.0f));
         patternHint.setColour(juce::Label::textColourId, DarkTheme::getColour(DarkTheme::TEXT_DIM));
@@ -771,7 +779,8 @@ class RenderingPage : public juce::Component {
         // Folder
         renderFolderPath_ = config.getRenderFolder();
         if (renderFolderPath_.empty()) {
-            renderFolderValue.setText("Default (beside source file)", juce::dontSendNotification);
+            renderFolderValue.setText(tr("preferences.label.default_beside_source"),
+                                      juce::dontSendNotification);
         } else {
             renderFolderValue.setText(juce::String(renderFolderPath_), juce::dontSendNotification);
         }
@@ -885,20 +894,24 @@ class RenderingPage : public juce::Component {
 class ShortcutsPage : public juce::Component {
   public:
     ShortcutsPage() {
-        setupSectionHeader(*this, shortcutsHeader, "Keyboard Shortcuts");
+        setupSectionHeader(*this, shortcutsHeader, tr("preferences.section.keyboard_shortcuts"));
 #if JUCE_MAC
-        setupShortcutLabel(*this, addTrackShortcut, "Add Track", juce::String::fromUTF8("\u2318T"));
-        setupShortcutLabel(*this, deleteTrackShortcut, "Delete Track",
+        setupShortcutLabel(*this, addTrackShortcut, tr("preferences.shortcut.add_track"),
+                           juce::String::fromUTF8("\u2318T"));
+        setupShortcutLabel(*this, deleteTrackShortcut, tr("preferences.shortcut.delete_track"),
                            juce::String::fromUTF8("\u232B"));
-        setupShortcutLabel(*this, duplicateTrackShortcut, "Duplicate Track",
+        setupShortcutLabel(*this, duplicateTrackShortcut,
+                           tr("preferences.shortcut.duplicate_track"),
                            juce::String::fromUTF8("\u2318D"));
 #else
-        setupShortcutLabel(*this, addTrackShortcut, "Add Track", "Ctrl+T");
-        setupShortcutLabel(*this, deleteTrackShortcut, "Delete Track", "Delete");
-        setupShortcutLabel(*this, duplicateTrackShortcut, "Duplicate Track", "Ctrl+D");
+        setupShortcutLabel(*this, addTrackShortcut, tr("preferences.shortcut.add_track"), "Ctrl+T");
+        setupShortcutLabel(*this, deleteTrackShortcut, tr("preferences.shortcut.delete_track"),
+                           "Delete");
+        setupShortcutLabel(*this, duplicateTrackShortcut,
+                           tr("preferences.shortcut.duplicate_track"), "Ctrl+D");
 #endif
-        setupShortcutLabel(*this, muteTrackShortcut, "Mute Track", "M");
-        setupShortcutLabel(*this, soloTrackShortcut, "Solo Track", "S");
+        setupShortcutLabel(*this, muteTrackShortcut, tr("preferences.shortcut.mute_track"), "M");
+        setupShortcutLabel(*this, soloTrackShortcut, tr("preferences.shortcut.solo_track"), "S");
     }
 
     void resized() override {
@@ -943,14 +956,14 @@ PreferencesDialog::PreferencesDialog() {
     shortcutsPage = std::make_unique<ShortcutsPage>();
 
     auto tabBg = DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND);
-    tabbedComponent.addTab("General", tabBg, generalPage.get(), false);
-    tabbedComponent.addTab("UI", tabBg, uiPage.get(), false);
-    tabbedComponent.addTab("Colours", tabBg, coloursPage.get(), false);
-    tabbedComponent.addTab("Rendering", tabBg, renderingPage.get(), false);
-    tabbedComponent.addTab("Shortcuts", tabBg, shortcutsPage.get(), false);
+    tabbedComponent.addTab(tr("preferences.tab.general"), tabBg, generalPage.get(), false);
+    tabbedComponent.addTab(tr("preferences.tab.ui"), tabBg, uiPage.get(), false);
+    tabbedComponent.addTab(tr("preferences.tab.colours"), tabBg, coloursPage.get(), false);
+    tabbedComponent.addTab(tr("preferences.tab.rendering"), tabBg, renderingPage.get(), false);
+    tabbedComponent.addTab(tr("preferences.tab.shortcuts"), tabBg, shortcutsPage.get(), false);
     addAndMakeVisible(tabbedComponent);
 
-    okButton.setButtonText("OK");
+    okButton.setButtonText(tr("dialogs.ok"));
     okButton.onClick = [this]() {
         applySettings();
         if (auto* dw = findParentComponentOfClass<juce::DialogWindow>())
@@ -958,14 +971,14 @@ PreferencesDialog::PreferencesDialog() {
     };
     addAndMakeVisible(okButton);
 
-    cancelButton.setButtonText("Cancel");
+    cancelButton.setButtonText(tr("dialogs.cancel"));
     cancelButton.onClick = [this]() {
         if (auto* dw = findParentComponentOfClass<juce::DialogWindow>())
             dw->exitModalState(0);
     };
     addAndMakeVisible(cancelButton);
 
-    applyButton.setButtonText("Apply");
+    applyButton.setButtonText(tr("dialogs.apply"));
     applyButton.onClick = [this]() { applySettings(); };
     addAndMakeVisible(applyButton);
 
@@ -1048,7 +1061,7 @@ void PreferencesDialog::showDialog(juce::Component* parent) {
     auto* dialog = new PreferencesDialog();
 
     juce::DialogWindow::LaunchOptions options;
-    options.dialogTitle = "Preferences";
+    options.dialogTitle = tr("dialogs.preferences");
     options.dialogBackgroundColour = DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND);
     options.content.setOwned(dialog);
     options.escapeKeyTriggersCloseButton = true;

--- a/magda/daw/ui/dialogs/SplashScreen.cpp
+++ b/magda/daw/ui/dialogs/SplashScreen.cpp
@@ -1,6 +1,7 @@
 #include "SplashScreen.hpp"
 
 #include "BinaryData.h"
+#include "core/StringTable.hpp"
 #include "magda.hpp"
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
@@ -73,13 +74,12 @@ class SplashScreen::ContentComponent : public juce::Component {
         // Subtitle
         g.setFont(fm.getUIFont(14.0f));
         g.setColour(juce::Colour(DarkTheme::TEXT_SECONDARY));
-        g.drawText("Multi-Agent Digital Audio", bounds.removeFromTop(24),
-                   juce::Justification::centred);
+        g.drawText(tr("splash.subtitle"), bounds.removeFromTop(24), juce::Justification::centred);
 
         // Version
         g.setFont(fm.getUIFont(12.0f));
         g.setColour(juce::Colour(DarkTheme::TEXT_DIM));
-        g.drawText(juce::String("Version ") + MAGDA_VERSION, bounds.removeFromTop(20),
+        g.drawText(tr("splash.version_prefix") + MAGDA_VERSION, bounds.removeFromTop(20),
                    juce::Justification::centred);
 
         // Status text
@@ -112,19 +112,24 @@ class SplashScreen::ContentComponent : public juce::Component {
             return juce::roundToInt(ga.getBoundingBox(0, -1, false).getWidth()) + 1;
         };
 
-        int powW = measure("powered by");
-        int teW = measure("Tracktion Engine");
+        const juce::String poweredBy = tr("splash.credits.powered_by");
+        const juce::String tracktionName = tr("splash.credits.tracktion_engine");
+        const juce::String madeWith = tr("splash.credits.made_with");
+        const juce::String juceName = tr("splash.credits.juce");
+
+        int powW = measure(poweredBy);
+        int teW = measure(tracktionName);
         int dotW = measure("|");
-        int madeW = measure("made with");
-        int juceW = measure("JUCE");
+        int madeW = measure(madeWith);
+        int juceW = measure(juceName);
 
         int totalW = powW + gap + teW + gap + logoSize + dotGap + dotW + dotGap + madeW + gap +
                      juceW + gap + logoSize;
         auto centred = row.withSizeKeepingCentre(totalW, 20);
 
-        g.drawText("powered by", centred.removeFromLeft(powW), juce::Justification::centred);
+        g.drawText(poweredBy, centred.removeFromLeft(powW), juce::Justification::centred);
         centred.removeFromLeft(gap);
-        g.drawText("Tracktion Engine", centred.removeFromLeft(teW), juce::Justification::centred);
+        g.drawText(tracktionName, centred.removeFromLeft(teW), juce::Justification::centred);
         centred.removeFromLeft(gap);
         if (teLogo_)
             teLogo_->drawWithin(g, centred.removeFromLeft(logoSize).toFloat(),
@@ -132,9 +137,9 @@ class SplashScreen::ContentComponent : public juce::Component {
         centred.removeFromLeft(dotGap);
         g.drawText("|", centred.removeFromLeft(dotW), juce::Justification::centred);
         centred.removeFromLeft(dotGap);
-        g.drawText("made with", centred.removeFromLeft(madeW), juce::Justification::centred);
+        g.drawText(madeWith, centred.removeFromLeft(madeW), juce::Justification::centred);
         centred.removeFromLeft(gap);
-        g.drawText("JUCE", centred.removeFromLeft(juceW), juce::Justification::centred);
+        g.drawText(juceName, centred.removeFromLeft(juceW), juce::Justification::centred);
         centred.removeFromLeft(gap);
         if (juceLogo_)
             juceLogo_->drawWithin(g, centred.removeFromLeft(logoSize).toFloat(),

--- a/magda/daw/ui/dialogs/TrackManagerDialog.cpp
+++ b/magda/daw/ui/dialogs/TrackManagerDialog.cpp
@@ -1,6 +1,7 @@
 #include "TrackManagerDialog.hpp"
 
 #include "../themes/DarkTheme.hpp"
+#include "core/StringTable.hpp"
 
 namespace magda {
 
@@ -24,12 +25,14 @@ class TrackManagerDialog::ContentComponent : public juce::Component,
         table_.setHeaderHeight(28);
 
         auto& header = table_.getHeader();
-        header.addColumn("Track", TrackName, 180, 100, 300,
+        header.addColumn(tr("track_manager.column.track"), TrackName, 180, 100, 300,
                          juce::TableHeaderComponent::defaultFlags);
-        header.addColumn("Live", LiveCol, 60, 50, 80, juce::TableHeaderComponent::defaultFlags);
-        header.addColumn("Arrange", ArrangeCol, 60, 50, 80,
+        header.addColumn(tr("track_manager.column.live"), LiveCol, 60, 50, 80,
                          juce::TableHeaderComponent::defaultFlags);
-        header.addColumn("Mix", MixCol, 60, 50, 80, juce::TableHeaderComponent::defaultFlags);
+        header.addColumn(tr("track_manager.column.arrange"), ArrangeCol, 60, 50, 80,
+                         juce::TableHeaderComponent::defaultFlags);
+        header.addColumn(tr("track_manager.column.mix"), MixCol, 60, 50, 80,
+                         juce::TableHeaderComponent::defaultFlags);
 
         // Style the header
         header.setColour(juce::TableHeaderComponent::backgroundColourId,
@@ -40,8 +43,7 @@ class TrackManagerDialog::ContentComponent : public juce::Component,
         addAndMakeVisible(table_);
 
         // Info label
-        infoLabel_.setText("Click checkboxes to toggle track visibility per view mode",
-                           juce::dontSendNotification);
+        infoLabel_.setText(tr("track_manager.label.hint"), juce::dontSendNotification);
         infoLabel_.setColour(juce::Label::textColourId,
                              DarkTheme::getColour(DarkTheme::TEXT_SECONDARY));
         infoLabel_.setJustificationType(juce::Justification::centred);
@@ -100,7 +102,8 @@ class TrackManagerDialog::ContentComponent : public juce::Component,
             if (columnId == TrackName) {
                 // Draw master track name with special styling
                 g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_ORANGE));
-                g.drawText("Master", 5, 0, width - 10, height, juce::Justification::centredLeft);
+                g.drawText(tr("common.master"), 5, 0, width - 10, height,
+                           juce::Justification::centredLeft);
             } else {
                 // Draw checkbox for view mode columns
                 ViewMode mode = columnIdToViewMode(columnId);
@@ -232,8 +235,7 @@ class TrackManagerDialog::ContentComponent : public juce::Component,
         table_.updateContent();
         table_.repaint();
 
-        infoLabel_.setText("Click checkboxes to toggle track visibility per view mode",
-                           juce::dontSendNotification);
+        infoLabel_.setText(tr("track_manager.label.hint"), juce::dontSendNotification);
     }
 
     static ViewMode columnIdToViewMode(int columnId) {
@@ -261,7 +263,8 @@ class TrackManagerDialog::ContentComponent : public juce::Component,
 // ============================================================================
 
 TrackManagerDialog::TrackManagerDialog()
-    : DialogWindow("Track Manager", DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND), true) {
+    : DialogWindow(tr("dialogs.track_manager"), DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND),
+                   true) {
     content_ = std::make_unique<ContentComponent>();
     setContentOwned(content_.release(), true);
     centreWithSize(500, 400);

--- a/magda/daw/ui/panels/FooterBar.cpp
+++ b/magda/daw/ui/panels/FooterBar.cpp
@@ -3,6 +3,7 @@
 #include <BinaryData.h>
 
 #include "../themes/DarkTheme.hpp"
+#include "core/StringTable.hpp"
 
 namespace magda {
 
@@ -60,13 +61,15 @@ void FooterBar::setupButtons() {
         int size;
         ViewMode mode;
         const char* name;
+        const char* tooltipKey;
     };
 
     const std::array<IconData, NUM_MODES> icons = {{
-        {BinaryData::Session_svg, BinaryData::Session_svgSize, ViewMode::Live, "Session"},
+        {BinaryData::Session_svg, BinaryData::Session_svgSize, ViewMode::Live, "Session",
+         "footer.tooltip.session"},
         {BinaryData::Arrangement_svg, BinaryData::Arrangement_svgSize, ViewMode::Arrange,
-         "Arrangement"},
-        {BinaryData::Mix_svg, BinaryData::Mix_svgSize, ViewMode::Mix, "Mix"},
+         "Arrangement", "footer.tooltip.arrangement"},
+        {BinaryData::Mix_svg, BinaryData::Mix_svgSize, ViewMode::Mix, "Mix", "footer.tooltip.mix"},
     }};
 
     for (size_t i = 0; i < NUM_MODES; ++i) {
@@ -74,7 +77,7 @@ void FooterBar::setupButtons() {
         modeButtons[i] = magda::ManagedChild<SvgButton>::create(icons[i].name, icons[i].data,
                                                                 static_cast<size_t>(icons[i].size));
 
-        modeButtons[i]->setTooltip(icons[i].name);
+        modeButtons[i]->setTooltip(tr(icons[i].tooltipKey));
         modeButtons[i]->setClickingTogglesState(false);
         modeButtons[i]->onClick = [mode = icons[i].mode]() {
             ViewModeController::getInstance().setViewMode(mode);

--- a/magda/daw/ui/themes/FontManager.cpp
+++ b/magda/daw/ui/themes/FontManager.cpp
@@ -63,6 +63,18 @@ bool FontManager::initialize() {
         success = false;
     }
 
+    // Load Noto Sans CJK SC Regular — fallback for CJK glyphs that Inter doesn't cover.
+    // Missing here is non-fatal; Chinese/Japanese/Korean text will fall back to OS
+    // fonts instead (or render as tofu on systems without any CJK font installed).
+    notoSansCJK = juce::Typeface::createSystemTypefaceFor(BinaryData::NotoSansCJKscRegular_otf,
+                                                          BinaryData::NotoSansCJKscRegular_otfSize);
+    if (notoSansCJK) {
+        notoSansCJKFamily = notoSansCJK->getName();
+        DBG("Noto Sans CJK loaded, family=" << notoSansCJKFamily);
+    } else {
+        DBG("Failed to load Noto Sans CJK — CJK glyphs will use OS fallback");
+    }
+
     initialized = success;
 
     if (initialized) {
@@ -82,7 +94,15 @@ void FontManager::shutdown() {
     interBold = nullptr;
     microgrammaBold = nullptr;
     jetBrainsMonoRegular = nullptr;
+    notoSansCJK = nullptr;
+    notoSansCJKFamily = {};
     initialized = false;
+}
+
+juce::Font FontManager::withCJKFallback(juce::Font font) const {
+    if (notoSansCJKFamily.isNotEmpty())
+        font.setPreferredFallbackFamilies({notoSansCJKFamily});
+    return font;
 }
 
 juce::Font FontManager::getInterFont(float size, Weight weight) const {
@@ -104,7 +124,7 @@ juce::Font FontManager::getInterFont(float size, Weight weight) const {
     }
 
     if (typeface) {
-        return juce::Font(typeface).withHeight(size);
+        return withCJKFallback(juce::Font(typeface).withHeight(size));
     }
 
     // Fallback to system font
@@ -118,7 +138,7 @@ juce::Font FontManager::getInterFont(float size, Weight weight) const {
             break;
     }
 
-    return juce::Font(FALLBACK_FONT, size, style);
+    return withCJKFallback(juce::Font(FALLBACK_FONT, size, style));
 }
 
 juce::Font FontManager::getUIFont(float size) const {
@@ -147,19 +167,21 @@ juce::Font FontManager::getTimeFont(float size) const {
 
 juce::Font FontManager::getMicrogrammaFont(float size) const {
     if (microgrammaBold) {
-        return juce::Font(microgrammaBold).withHeight(size);
+        return withCJKFallback(juce::Font(microgrammaBold).withHeight(size));
     }
 
     // Fallback to monospace font if Microgramma isn't loaded
-    return juce::Font(juce::Font::getDefaultMonospacedFontName(), size, juce::Font::bold);
+    return withCJKFallback(
+        juce::Font(juce::Font::getDefaultMonospacedFontName(), size, juce::Font::bold));
 }
 
 juce::Font FontManager::getMonoFont(float size) const {
     if (jetBrainsMonoRegular) {
-        return juce::Font(jetBrainsMonoRegular).withHeight(size);
+        return withCJKFallback(juce::Font(jetBrainsMonoRegular).withHeight(size));
     }
 
-    return juce::Font(juce::Font::getDefaultMonospacedFontName(), size, juce::Font::plain);
+    return withCJKFallback(
+        juce::Font(juce::Font::getDefaultMonospacedFontName(), size, juce::Font::plain));
 }
 
 }  // namespace magda

--- a/magda/daw/ui/themes/FontManager.hpp
+++ b/magda/daw/ui/themes/FontManager.hpp
@@ -60,6 +60,15 @@ class FontManager {
     juce::Typeface::Ptr microgrammaBold;
     juce::Typeface::Ptr jetBrainsMonoRegular;
 
+    // CJK fallback (Noto Sans CJK SC Regular — covers zh, ja, ko glyphs that
+    // Inter, Microgramma, and JetBrains Mono all lack).
+    juce::Typeface::Ptr notoSansCJK;
+    juce::String notoSansCJKFamily;
+
+    // Apply the CJK family as a fallback on the given font so characters not
+    // covered by the primary typeface are resolved via Noto Sans CJK.
+    juce::Font withCJKFallback(juce::Font font) const;
+
     // Fallback system font name
     static constexpr const char* FALLBACK_FONT = "Helvetica";
 };

--- a/magda/daw/ui/windows/MainWindow.cpp
+++ b/magda/daw/ui/windows/MainWindow.cpp
@@ -27,6 +27,7 @@
 #include "core/Config.hpp"
 #include "core/LinkModeManager.hpp"
 #include "core/ModulatorEngine.hpp"
+#include "core/StringTable.hpp"
 #include "core/TrackCommands.hpp"
 #include "core/TrackManager.hpp"
 #include "core/UndoManager.hpp"
@@ -98,7 +99,7 @@ class MainWindow::MainComponent::LoadingOverlay : public juce::Component, privat
     }
 
   private:
-    juce::String message_ = "Initializing...";
+    juce::String message_ = tr("main_window.loading.initializing");
     float alpha_ = 1.0f;
     int spinnerFrame_ = 0;
 
@@ -586,7 +587,7 @@ MainWindow::MainComponent::MainComponent(AudioEngine* externalEngine) {
             if (audioClips.empty())
                 return;
 
-            UndoManager::getInstance().beginCompoundOperation("Render Clips");
+            UndoManager::getInstance().beginCompoundOperation(tr("main_window.undo.render_clips"));
             std::vector<ClipId> newClips;
             for (auto cid : audioClips) {
                 auto cmd = std::make_unique<RenderClipCommand>(cid, engine);
@@ -914,7 +915,7 @@ void MainWindow::MainComponent::setupDeviceLoadingCallback() {
     if (teWrapper) {
         // Show notification and disable transport if devices are still loading
         if (teWrapper->isDevicesLoading()) {
-            loadingOverlay_->setMessage("Scanning audio & MIDI devices...");
+            loadingOverlay_->setMessage(tr("main_window.loading.scanning_devices"));
             loadingOverlay_->showWithFade();
             loadingOverlay_->toFront(false);
             transportPanel->setTransportEnabled(false);

--- a/magda/daw/ui/windows/MainWindowExport.cpp
+++ b/magda/daw/ui/windows/MainWindowExport.cpp
@@ -6,6 +6,7 @@
 #include "audio/AudioBridge.hpp"
 #include "core/ClipManager.hpp"
 #include "core/Config.hpp"
+#include "core/StringTable.hpp"
 #include "core/TrackManager.hpp"
 #include "engine/TracktionEngineWrapper.hpp"
 #include "project/ProjectManager.hpp"
@@ -28,14 +29,14 @@ class ExportProgressWindow : public juce::ThreadWithProgressWindow {
                          tracktion::engine::TransportControl& transport,
                          std::function<void()> onComplete, double prerollSeconds = 0.0,
                          double leadInSilence = 0.0)
-        : ThreadWithProgressWindow("Exporting Audio...", true, true),
+        : ThreadWithProgressWindow(tr("export.progress.exporting_audio"), true, true),
           params_(params),
           outputFile_(outputFile),
           reallocationInhibitor_(transport),
           onComplete_(std::move(onComplete)),
           prerollSeconds_(prerollSeconds),
           leadInSilence_(leadInSilence) {
-        setStatusMessage("Preparing to export...");
+        setStatusMessage(tr("export.progress.preparing"));
     }
 
     void run() override {
@@ -43,7 +44,7 @@ class ExportProgressWindow : public juce::ThreadWithProgressWindow {
         renderTask_ = std::make_unique<tracktion::Renderer::RenderTask>("Export", params_,
                                                                         &progress, nullptr);
 
-        setStatusMessage("Rendering: " + outputFile_.getFileName());
+        setStatusMessage(tr("export.progress.rendering") + " " + outputFile_.getFileName());
 
         while (!threadShouldExit()) {
             auto status = renderTask_->runJob();
@@ -55,21 +56,20 @@ class ExportProgressWindow : public juce::ThreadWithProgressWindow {
                 // Verify the file was actually created
                 if (outputFile_.existsAsFile()) {
                     if (prerollSeconds_ > 0.0) {
-                        setStatusMessage("Trimming preroll...");
+                        setStatusMessage(tr("export.progress.trimming"));
                         if (!trimPreroll()) {
                             success_ = false;
-                            errorMessage_ = "Render succeeded but failed to trim preroll.";
+                            errorMessage_ = tr("export.error.trim_failed");
                             break;
                         }
                     }
                     success_ = true;
-                    setStatusMessage("Export complete!");
+                    setStatusMessage(tr("export.progress.complete"));
                     setProgress(1.0);
                 } else {
                     success_ = false;
-                    errorMessage_ = "Render completed but file was not created. The project may be "
-                                    "empty or contain no audio.";
-                    setStatusMessage("Export failed");
+                    errorMessage_ = tr("export.error.file_not_created");
+                    setStatusMessage(tr("export.progress.failed"));
                 }
                 break;
             }
@@ -81,13 +81,13 @@ class ExportProgressWindow : public juce::ThreadWithProgressWindow {
             }
 
             // Error occurred
-            errorMessage_ = "Render job failed";
-            setStatusMessage("Export failed");
+            errorMessage_ = tr("export.error.render_failed");
+            setStatusMessage(tr("export.progress.failed"));
             break;
         }
 
         if (threadShouldExit() && !success_) {
-            errorMessage_ = "Export cancelled by user";
+            errorMessage_ = tr("export.error.cancelled");
         }
     }
 
@@ -111,15 +111,16 @@ class ExportProgressWindow : public juce::ThreadWithProgressWindow {
                 onComplete();
             if (userPressedCancel) {
                 juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::InfoIcon,
-                                                       "Export Cancelled", "Export was cancelled.");
+                                                       tr("export.alert.cancelled_title"),
+                                                       tr("export.alert.cancelled_body"));
             } else if (success) {
                 juce::AlertWindow::showMessageBoxAsync(
-                    juce::AlertWindow::InfoIcon, "Export Complete",
-                    "Audio exported successfully to:\n" + outputFile.getFullPathName());
+                    juce::AlertWindow::InfoIcon, tr("export.alert.complete_title"),
+                    tr("export.alert.audio_success_prefix") + "\n" + outputFile.getFullPathName());
             } else {
                 juce::AlertWindow::showMessageBoxAsync(
-                    juce::AlertWindow::WarningIcon, "Export Failed",
-                    errorMessage.isEmpty() ? "Unknown error occurred during export" : errorMessage);
+                    juce::AlertWindow::WarningIcon, tr("export.alert.failed_title"),
+                    errorMessage.isEmpty() ? tr("export.error.unknown") : errorMessage);
             }
         });
     }
@@ -197,8 +198,9 @@ void MainWindow::performExport(const ExportAudioDialog::Settings& settings,
     namespace te = tracktion;
 
     if (!engine || !engine->getEdit()) {
-        juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon, "Export Audio",
-                                               "Cannot export: no Edit loaded");
+        juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon,
+                                               tr("dialogs.export_audio"),
+                                               tr("dialogs.error.export_no_edit"));
         return;
     }
 
@@ -236,8 +238,8 @@ void MainWindow::performExport(const ExportAudioDialog::Settings& settings,
     juce::File defaultFile = defaultDir.getChildFile(pattern + extension);
 
     // Launch file chooser
-    fileChooser_ =
-        std::make_unique<juce::FileChooser>("Export Audio", defaultFile, "*" + extension, true);
+    fileChooser_ = std::make_unique<juce::FileChooser>(tr("dialogs.export_audio"), defaultFile,
+                                                       "*" + extension, true);
 
     auto flags = juce::FileBrowserComponent::saveMode | juce::FileBrowserComponent::canSelectFiles |
                  juce::FileBrowserComponent::warnAboutOverwriting;
@@ -436,8 +438,9 @@ void MainWindow::performMidiExport(const ExportMidiDialog::Settings& settings) {
 
     if (rangeEnd <= rangeStart) {
         DBG("No MIDI clips found - rangeEnd <= rangeStart");
-        juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon, "Export MIDI",
-                                               "No MIDI clips to export.");
+        juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon,
+                                               tr("export.alert.midi_title"),
+                                               tr("export.error.no_midi_clips"));
         return;
     }
 
@@ -478,8 +481,9 @@ void MainWindow::performMidiExport(const ExportMidiDialog::Settings& settings) {
     DBG("Track data count: " << trackData.size());
     if (trackData.empty()) {
         DBG("No MIDI clips with notes found");
-        juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon, "Export MIDI",
-                                               "No MIDI clips with notes to export.");
+        juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon,
+                                               tr("export.alert.midi_title"),
+                                               tr("export.error.no_midi_notes"));
         return;
     }
 
@@ -493,7 +497,8 @@ void MainWindow::performMidiExport(const ExportMidiDialog::Settings& settings) {
     auto defaultFile = defaultDir.getChildFile(projName + ".mid");
 
     // Launch file chooser
-    fileChooser_ = std::make_unique<juce::FileChooser>("Export MIDI", defaultFile, "*.mid", true);
+    fileChooser_ = std::make_unique<juce::FileChooser>(tr("export.alert.midi_title"), defaultFile,
+                                                       "*.mid", true);
 
     auto flags = juce::FileBrowserComponent::saveMode | juce::FileBrowserComponent::canSelectFiles |
                  juce::FileBrowserComponent::warnAboutOverwriting;
@@ -653,17 +658,18 @@ void MainWindow::performMidiExport(const ExportMidiDialog::Settings& settings) {
 
             if (written) {
                 juce::AlertWindow::showMessageBoxAsync(
-                    juce::AlertWindow::InfoIcon, "Export Complete",
-                    "MIDI exported successfully to:\n" + file.getFullPathName());
+                    juce::AlertWindow::InfoIcon, tr("export.alert.complete_title"),
+                    tr("export.alert.midi_success_prefix") + "\n" + file.getFullPathName());
             } else {
-                juce::AlertWindow::showMessageBoxAsync(
-                    juce::AlertWindow::WarningIcon, "Export Failed", "Failed to write MIDI file.");
+                juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon,
+                                                       tr("export.alert.failed_title"),
+                                                       tr("export.error.midi_write_failed"));
             }
         } else {
             DBG("Failed to open output stream for: " << file.getFullPathName());
-            juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon, "Export Failed",
-                                                   "Could not create output file:\n" +
-                                                       file.getFullPathName());
+            juce::AlertWindow::showMessageBoxAsync(
+                juce::AlertWindow::WarningIcon, tr("export.alert.failed_title"),
+                tr("export.error.cannot_create_file") + "\n" + file.getFullPathName());
         }
     });
 }

--- a/magda/daw/ui/windows/MainWindowExport.cpp
+++ b/magda/daw/ui/windows/MainWindowExport.cpp
@@ -35,7 +35,18 @@ class ExportProgressWindow : public juce::ThreadWithProgressWindow {
           reallocationInhibitor_(transport),
           onComplete_(std::move(onComplete)),
           prerollSeconds_(prerollSeconds),
-          leadInSilence_(leadInSilence) {
+          leadInSilence_(leadInSilence),
+          // Snapshot every string run() needs on the message thread. StringTable
+          // isn't thread-safe and the user can change language mid-export, so
+          // reading it from the background thread would data-race.
+          strRendering_(tr("export.progress.rendering")),
+          strTrimming_(tr("export.progress.trimming")),
+          strComplete_(tr("export.progress.complete")),
+          strFailed_(tr("export.progress.failed")),
+          errTrimFailed_(tr("export.error.trim_failed")),
+          errFileNotCreated_(tr("export.error.file_not_created")),
+          errRenderFailed_(tr("export.error.render_failed")),
+          errCancelled_(tr("export.error.cancelled")) {
         setStatusMessage(tr("export.progress.preparing"));
     }
 
@@ -44,7 +55,7 @@ class ExportProgressWindow : public juce::ThreadWithProgressWindow {
         renderTask_ = std::make_unique<tracktion::Renderer::RenderTask>("Export", params_,
                                                                         &progress, nullptr);
 
-        setStatusMessage(tr("export.progress.rendering") + " " + outputFile_.getFileName());
+        setStatusMessage(strRendering_ + " " + outputFile_.getFileName());
 
         while (!threadShouldExit()) {
             auto status = renderTask_->runJob();
@@ -56,20 +67,20 @@ class ExportProgressWindow : public juce::ThreadWithProgressWindow {
                 // Verify the file was actually created
                 if (outputFile_.existsAsFile()) {
                     if (prerollSeconds_ > 0.0) {
-                        setStatusMessage(tr("export.progress.trimming"));
+                        setStatusMessage(strTrimming_);
                         if (!trimPreroll()) {
                             success_ = false;
-                            errorMessage_ = tr("export.error.trim_failed");
+                            errorMessage_ = errTrimFailed_;
                             break;
                         }
                     }
                     success_ = true;
-                    setStatusMessage(tr("export.progress.complete"));
+                    setStatusMessage(strComplete_);
                     setProgress(1.0);
                 } else {
                     success_ = false;
-                    errorMessage_ = tr("export.error.file_not_created");
-                    setStatusMessage(tr("export.progress.failed"));
+                    errorMessage_ = errFileNotCreated_;
+                    setStatusMessage(strFailed_);
                 }
                 break;
             }
@@ -81,13 +92,13 @@ class ExportProgressWindow : public juce::ThreadWithProgressWindow {
             }
 
             // Error occurred
-            errorMessage_ = tr("export.error.render_failed");
-            setStatusMessage(tr("export.progress.failed"));
+            errorMessage_ = errRenderFailed_;
+            setStatusMessage(strFailed_);
             break;
         }
 
         if (threadShouldExit() && !success_) {
-            errorMessage_ = tr("export.error.cancelled");
+            errorMessage_ = errCancelled_;
         }
     }
 
@@ -189,6 +200,17 @@ class ExportProgressWindow : public juce::ThreadWithProgressWindow {
     double leadInSilence_ = 0.0;
     bool success_ = false;
     juce::String errorMessage_;
+
+    // Translated strings snapshotted at construction — safe for run() to read
+    // from the background thread while the message thread may mutate StringTable.
+    const juce::String strRendering_;
+    const juce::String strTrimming_;
+    const juce::String strComplete_;
+    const juce::String strFailed_;
+    const juce::String errTrimFailed_;
+    const juce::String errFileNotCreated_;
+    const juce::String errRenderFailed_;
+    const juce::String errCancelled_;
 };
 
 }  // namespace


### PR DESCRIPTION
## Summary
Three related changes that together make zh-CN (and future CJK locales) actually ship:

1. **Bundle Noto Sans CJK SC Regular** as a font fallback via git-lfs. Every font \`FontManager\` returns now carries Noto as a \`setPreferredFallbackFamilies\` entry, so Chinese/Japanese/Korean glyphs render under Inter, Microgramma, and JetBrains Mono without relying on per-OS system font fallback.
2. **Localize Preferences + 11 additional UI files** through \`tr(...)\` — About, ChainTree, ExportAudio, ExportMidi, PluginSettings, Splash, TrackManager, FooterBar, MainWindow (core + export). ~150 new keys added to \`lang/en.json\`.
3. **Fix StringTable fallback**: untranslated keys now surface as English instead of the raw dotted key (\`active locale → English master → key\`).

Plus CI/docs plumbing for git-lfs: \`lfs: true\` on build-job checkouts, \`git-lfs\` listed as a prerequisite, and a Crowdin badge in the README.

## What's in it
- \`assets/fonts/NotoSansCJKsc-Regular.otf\` (~15 MB, tracked by LFS)
- \`FontManager\` loads Noto and exposes \`withCJKFallback(font)\` applied by every getter
- \`StringTable\` keeps an English master map separate from the active locale, so missing keys fall through cleanly
- \`tr(...)\` wiring across the full set of dialogs and windows listed above
- \`ci.yml\` / \`release.yml\` / \`codeql.yml\`: \`lfs: true\` on every build-type checkout; analysis-only jobs (security-checks, secret-scanning, etc.) left untouched to save bandwidth
- \`README\`: git-lfs prerequisite, \`git lfs pull\` note, Crowdin badge
- \`.gitattributes\`: tracks the one new OTF file; existing Microgramma font left as a regular git blob

## Test plan
- [ ] Build locally with git-lfs, confirm MAGDA launches and logs \`Noto Sans CJK loaded, family=...\` at startup
- [ ] Switch Preferences → Language to Simplified Chinese, verify every tab (General, UI, Colours, Rendering, Shortcuts) renders Chinese where translations exist and English elsewhere — **no raw dotted keys**
- [ ] Walk through About, Export Audio, Export MIDI, Plugin Settings, Track Manager, Splash, Footer tooltips, and MainWindow dialogs in zh-CN — confirm glyphs render and strings show up
- [ ] Confirm CI passes on Linux, macOS, Windows with LFS fetch
- [ ] Pull a fresh clone without git-lfs installed → build should fail with a clear error; \`git lfs install && git lfs pull\` should unblock