### PR TITLE
i18n: un-localize brand names and file-format designators

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -135,7 +135,6 @@
     "track_name": "Track Name",
     "routing": "Routing",
     "audio": "Audio",
-    "midi": "MIDI",
     "input": "Input",
     "output": "Output",
     "sends": "Sends / Receives",
@@ -219,21 +218,15 @@
   },
 
   "about": {
-    "subtitle": "Multi-Agent Digital Audio",
     "version_prefix": "Version ",
     "credits.powered_by": "powered by",
-    "credits.tracktion_engine": "Tracktion Engine",
-    "credits.made_with": "made with",
-    "credits.juce": "JUCE"
+    "credits.made_with": "made with"
   },
 
   "splash": {
-    "subtitle": "Multi-Agent Digital Audio",
     "version_prefix": "Version ",
     "credits.powered_by": "powered by",
-    "credits.tracktion_engine": "Tracktion Engine",
-    "credits.made_with": "made with",
-    "credits.juce": "JUCE"
+    "credits.made_with": "made with"
   },
 
   "chain_tree": {
@@ -254,10 +247,6 @@
     "label.bit_depth": "Bit Depth:",
     "label.lead_in_silence": "Lead-in Silence:",
     "label.export_range": "Export Range:",
-    "option.wav_16": "WAV 16-bit",
-    "option.wav_24": "WAV 24-bit",
-    "option.wav_32_float": "WAV 32-bit Float",
-    "option.flac": "FLAC",
     "option.entire_song": "Entire Song",
     "option.time_selection": "Time Selection",
     "option.loop_region": "Loop Region",

--- a/magda/daw/ui/dialogs/AboutDialog.cpp
+++ b/magda/daw/ui/dialogs/AboutDialog.cpp
@@ -76,7 +76,9 @@ class AboutDialog::ContentComponent : public juce::Component {
         // Subtitle
         g.setFont(fm.getUIFont(14.0f));
         g.setColour(juce::Colour(DarkTheme::TEXT_SECONDARY));
-        g.drawText(tr("about.subtitle"), bounds.removeFromTop(24), juce::Justification::centred);
+        // Brand tagline — MAGDA acronym expansion, do not translate.
+        g.drawText("Multi-Agent Digital Audio", bounds.removeFromTop(24),
+                   juce::Justification::centred);
 
         // Version
         g.setFont(fm.getUIFont(12.0f));
@@ -109,9 +111,9 @@ class AboutDialog::ContentComponent : public juce::Component {
         };
 
         const juce::String poweredBy = tr("about.credits.powered_by");
-        const juce::String tracktionName = tr("about.credits.tracktion_engine");
+        const juce::String tracktionName = "Tracktion Engine";  // brand — do not translate
         const juce::String madeWith = tr("about.credits.made_with");
-        const juce::String juceName = tr("about.credits.juce");
+        const juce::String juceName = "JUCE";  // brand — do not translate
 
         int powW = measure(poweredBy);
         int teW = measure(tracktionName);

--- a/magda/daw/ui/dialogs/ExportAudioDialog.cpp
+++ b/magda/daw/ui/dialogs/ExportAudioDialog.cpp
@@ -16,10 +16,11 @@ ExportAudioDialog::ExportAudioDialog() {
     formatLabel_.setFont(FontManager::getInstance().getUIFontBold(14.0f));
     addAndMakeVisible(formatLabel_);
 
-    formatComboBox_.addItem(tr("export_audio.option.wav_16"), 1);
-    formatComboBox_.addItem(tr("export_audio.option.wav_24"), 2);
-    formatComboBox_.addItem(tr("export_audio.option.wav_32_float"), 3);
-    formatComboBox_.addItem(tr("export_audio.option.flac"), 4);
+    // File-format designators — do not translate.
+    formatComboBox_.addItem("WAV 16-bit", 1);
+    formatComboBox_.addItem("WAV 24-bit", 2);
+    formatComboBox_.addItem("WAV 32-bit Float", 3);
+    formatComboBox_.addItem("FLAC", 4);
     // Initialise format from render bit depth preference
     auto& config = Config::getInstance();
     int bd = config.getRenderBitDepth();

--- a/magda/daw/ui/dialogs/SplashScreen.cpp
+++ b/magda/daw/ui/dialogs/SplashScreen.cpp
@@ -74,7 +74,9 @@ class SplashScreen::ContentComponent : public juce::Component {
         // Subtitle
         g.setFont(fm.getUIFont(14.0f));
         g.setColour(juce::Colour(DarkTheme::TEXT_SECONDARY));
-        g.drawText(tr("splash.subtitle"), bounds.removeFromTop(24), juce::Justification::centred);
+        // Brand tagline — MAGDA acronym expansion, do not translate.
+        g.drawText("Multi-Agent Digital Audio", bounds.removeFromTop(24),
+                   juce::Justification::centred);
 
         // Version
         g.setFont(fm.getUIFont(12.0f));
@@ -113,9 +115,9 @@ class SplashScreen::ContentComponent : public juce::Component {
         };
 
         const juce::String poweredBy = tr("splash.credits.powered_by");
-        const juce::String tracktionName = tr("splash.credits.tracktion_engine");
+        const juce::String tracktionName = "Tracktion Engine";  // brand — do not translate
         const juce::String madeWith = tr("splash.credits.made_with");
-        const juce::String juceName = tr("splash.credits.juce");
+        const juce::String juceName = "JUCE";  // brand — do not translate
 
         int powW = measure(poweredBy);
         int teW = measure(tracktionName);

--- a/magda/daw/ui/panels/content/inspector/TrackInspector.cpp
+++ b/magda/daw/ui/panels/content/inspector/TrackInspector.cpp
@@ -345,7 +345,8 @@ TrackInspector::TrackInspector() {
     audioColumnLabel_.setJustificationType(juce::Justification::centred);
     addAndMakeVisible(audioColumnLabel_);
 
-    midiColumnLabel_.setText(tr("inspector.midi"), juce::dontSendNotification);
+    // "MIDI" is a universal technical acronym — do not translate.
+    midiColumnLabel_.setText("MIDI", juce::dontSendNotification);
     midiColumnLabel_.setFont(FontManager::getInstance().getUIFont(9.0f));
     midiColumnLabel_.setColour(juce::Label::textColourId, DarkTheme::getSecondaryTextColour());
     midiColumnLabel_.setJustificationType(juce::Justification::centred);


### PR DESCRIPTION
## Summary
The mechanical localization pass in #1023 was too greedy: it wrapped brand names and file-format tokens in \`tr(...)\` calls, so they'd get translated per-locale. That's wrong for two reasons — they're proper nouns, and translating "Multi-Agent Digital Audio" breaks the **M**AGDA acronym mnemonic.

Restores the following as literals in source and removes their keys from \`lang/en.json\`:

- **AboutDialog / SplashScreen**: "Tracktion Engine", "JUCE", and the subtitle "Multi-Agent Digital Audio".
- **ExportAudioDialog**: "WAV 16-bit", "WAV 24-bit", "WAV 32-bit Float", "FLAC".
- **TrackInspector**: "MIDI" column label.

## Side effects on translators
Existing zh-CN translations for these specific keys (if any) will disappear from the next Crowdin sync because the keys no longer exist in the source. That's intended — the strings should never have been translatable in the first place.

## Test plan
- [ ] Launch MAGDA, switch language to zh-CN, confirm the About dialog still reads "Tracktion Engine" / "JUCE" / "Multi-Agent Digital Audio" in English.
- [ ] Splash screen same.
- [ ] Export Audio dialog: format dropdown shows "WAV 16-bit" etc. verbatim.
- [ ] Track Inspector: "MIDI" column header in English.
- [ ] Remainder of UI still picks up zh-CN translations.