### PR TITLE
fix(automation): batch notifications during agent-driven curve writes

### DIFF
--- a/magda/agents/automation_executor.cpp
+++ b/magda/agents/automation_executor.cpp
@@ -203,6 +203,13 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
     int laneCount = 0;
     int pointCount = 0;
 
+    // Coalesce listener callbacks across the whole batch. Without this, every
+    // per-point addPoint fires automationPointsChanged synchronously, which
+    // AutomationPlaybackEngine answers with a full bakeLane() — producing
+    // O(n) bakes for an n-point curve and a visible stall between the agent
+    // completing and the curve appearing.
+    AutomationManager::BatchScope batchScope;
+
     for (const auto& inst : instructions) {
         juce::String err;
 

--- a/magda/daw/core/AutomationManager.hpp
+++ b/magda/daw/core/AutomationManager.hpp
@@ -356,6 +356,19 @@ class AutomationManager : public TrackManagerListener {
     void beginNotificationBatch();
     void endNotificationBatch();
 
+    /// RAII helper for beginNotificationBatch/endNotificationBatch.
+    class BatchScope {
+      public:
+        BatchScope() {
+            AutomationManager::getInstance().beginNotificationBatch();
+        }
+        ~BatchScope() {
+            AutomationManager::getInstance().endNotificationBatch();
+        }
+        BatchScope(const BatchScope&) = delete;
+        BatchScope& operator=(const BatchScope&) = delete;
+    };
+
     /**
      * @brief Broadcast point drag preview event
      */


### PR DESCRIPTION
## Summary

- `AutomationExecutor::execute` calls `AutomationManager::addPoint` in a loop (~33 points for a typical exp curve). Each `addPoint` fires `automationPointsChanged` synchronously, which `AutomationPlaybackEngine::automationPointsChanged` answers with a full `bakeLane()` — clearing the TE `AutomationCurve` and re-sampling the entire edit at ~10ms intervals.
- For an n-point curve on a multi-bar edit, that's O(n) bakes — tens of thousands of TE ops on the message thread before the UI refreshes. Visible stall between the agent reporting completion and the curve appearing on the lane (observed ~seconds of wall-clock gap after `Timing: total=8786ms`).
- Fix: introduce `AutomationManager::BatchScope` (RAII mirror of `ClipManager::BatchScope`) and wrap the executor body. `notifyPointsChanged` already supports batching — just wasn't used by the executor. One coalesced notification per lane at scope exit instead of per point.

Same O(n²) pattern already documented and fixed for bulk MIDI insertion in `AIChatConsoleContent.cpp:473-478`.

## Test plan

- [x] Local debug build green
- [ ] In-app: ask the AI for an automation curve ('fade volume in over 4 bars') and confirm the curve appears immediately after the streaming log finishes (no multi-second UI gap)
- [ ] Scrub the transport and confirm baked TE automation drives the parameter correctly (no stuck / stale values)
- [ ] Drawing a single point still works (scope only added to the bulk executor path)