### PR TITLE
fix: install lang/ directory on Windows and Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,3 +167,8 @@ install(TARGETS magda_daw_app
     BUNDLE DESTINATION .
     RUNTIME DESTINATION bin
 )
+if(NOT APPLE)
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/lang"
+        DESTINATION bin
+    )
+endif()


### PR DESCRIPTION
The POST_BUILD command copies lang/ next to the binary during dev builds but there was no install() rule for it on non-Apple platforms, so packaged releases never shipped the directory and StringTable fell back to returning raw localisation keys.