### PR TITLE
fix(release): bundle lang/ in installers and pin splash version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,6 +381,13 @@ jobs:
         Copy-Item -Recurse "lang" "$stage\lang"
         Write-Output "Staged lang/ for installer"
 
+        # Guard against a regression where lang/ stops being bundled - 0.5
+        # shipped with missing translations because staging silently dropped it.
+        if (-not (Test-Path "$stage\lang\en.json")) {
+          Write-Error "lang/en.json missing from installer staging"
+          exit 1
+        }
+
         & "${env:ProgramFiles(x86)}\NSIS\makensis.exe" /DVERSION=$env:VERSION "$stage\magda-installer.nsi"
 
         $installerName = "MAGDA-$env:VERSION-Windows-x86_64-Setup.exe"
@@ -521,8 +528,13 @@ jobs:
           echo "Warning: magda_plugin_scanner not found"
         fi
 
-        # Localization JSON — StringTable looks for lang/ next to the binary
+        # Localization JSON - StringTable looks for lang/ next to the binary
         cp -r lang "$APPDIR/usr/bin/lang"
+
+        # Guard against a regression where lang/ stops being bundled - 0.5
+        # shipped with missing translations because staging silently dropped it.
+        test -f "$APPDIR/usr/bin/lang/en.json" \
+          || { echo "lang/en.json missing from AppDir staging"; exit 1; }
 
         # Copy icon
         cp assets/app_icon.png "$APPDIR/usr/share/icons/hicolor/256x256/apps/magda.png"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,15 @@ jobs:
         echo "Version: $VERSION"
 
     - name: Configure CMake (Universal Binary)
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
       run: |
         cmake -B build -G Ninja \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
           -DCMAKE_OSX_DEPLOYMENT_TARGET="11.0" \
           -DMAGDA_BUILD_TESTS=OFF \
+          -DMAGDA_FULL_VERSION="$VERSION" \
           -DCMAKE_C_COMPILER_LAUNCHER=sccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
@@ -302,11 +305,14 @@ jobs:
 
     - name: Configure CMake
       shell: powershell
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
       run: |
         cmake -B build -G Ninja `
           -DCMAKE_BUILD_TYPE=Release `
           -DCMAKE_SYSTEM_PROCESSOR=x64 `
           -DMAGDA_BUILD_TESTS=OFF `
+          -DMAGDA_FULL_VERSION="$env:VERSION" `
           -DCMAKE_C_COMPILER_LAUNCHER=sccache `
           -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
@@ -365,6 +371,12 @@ jobs:
           Write-Warning "magda_plugin_scanner.exe not found at $scanner"
         }
 
+        # Stage lang/ so NSIS can bundle it into the installer
+        $langStaging = Join-Path $stagingDir "lang"
+        if (Test-Path $langStaging) { Remove-Item -Recurse -Force $langStaging }
+        Copy-Item -Recurse "lang" $langStaging
+        Write-Output "Staged lang/ for installer"
+
         & "${env:ProgramFiles(x86)}\NSIS\makensis.exe" /DVERSION=$env:VERSION "$stagingDir\magda-installer.nsi"
 
         $installerName = "MAGDA-$env:VERSION-Windows-x86_64-Setup.exe"
@@ -398,6 +410,8 @@ jobs:
       run: |
         Remove-Item -Recurse -Force build -ErrorAction SilentlyContinue
         Remove-Item -Force "packaging\windows\MAGDA.exe" -ErrorAction SilentlyContinue
+        Remove-Item -Force "packaging\windows\magda_plugin_scanner.exe" -ErrorAction SilentlyContinue
+        Remove-Item -Recurse -Force "packaging\windows\lang" -ErrorAction SilentlyContinue
 
   build-linux:
     runs-on: ubuntu-latest
@@ -460,11 +474,14 @@ jobs:
         sccache --version
 
     - name: Configure CMake
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
       run: |
         cmake -B build -G Ninja \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=/usr \
           -DMAGDA_BUILD_TESTS=OFF \
+          -DMAGDA_FULL_VERSION="$VERSION" \
           -DCMAKE_C_COMPILER_LAUNCHER=sccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
@@ -501,6 +518,9 @@ jobs:
         else
           echo "Warning: magda_plugin_scanner not found"
         fi
+
+        # Localization JSON — StringTable looks for lang/ next to the binary
+        cp -r lang "$APPDIR/usr/bin/lang"
 
         # Copy icon
         cp assets/app_icon.png "$APPDIR/usr/share/icons/hicolor/256x256/apps/magda.png"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,29 +358,33 @@ jobs:
       env:
         VERSION: ${{ steps.version.outputs.version }}
       run: |
-        $stagingDir = "packaging\windows"
-        Copy-Item "${{ steps.locate.outputs.exe_path }}" "$stagingDir\MAGDA.exe"
+        # Stage installer inputs into an ephemeral directory outside the source
+        # tree so the checkout stays clean and every shipped artifact appears
+        # here explicitly. The .nsi uses ${__FILEDIR__} and finds files next to
+        # itself, so staging and makensis invocation agree without chdir.
+        $stage = Join-Path $env:RUNNER_TEMP "magda-installer-stage"
+        if (Test-Path $stage) { Remove-Item -Recurse -Force $stage }
+        New-Item -ItemType Directory -Path $stage | Out-Null
 
-        # Copy plugin scanner executable alongside MAGDA.exe
+        Copy-Item "packaging\windows\magda-installer.nsi" "$stage\"
+        Copy-Item "${{ steps.locate.outputs.exe_path }}" "$stage\MAGDA.exe"
+
         $exeDir = Split-Path "${{ steps.locate.outputs.exe_path }}"
         $scanner = Join-Path $exeDir "magda_plugin_scanner.exe"
         if (Test-Path $scanner) {
-          Copy-Item $scanner "$stagingDir\magda_plugin_scanner.exe"
+          Copy-Item $scanner "$stage\magda_plugin_scanner.exe"
           Write-Output "Copied plugin scanner to staging"
         } else {
           Write-Warning "magda_plugin_scanner.exe not found at $scanner"
         }
 
-        # Stage lang/ so NSIS can bundle it into the installer
-        $langStaging = Join-Path $stagingDir "lang"
-        if (Test-Path $langStaging) { Remove-Item -Recurse -Force $langStaging }
-        Copy-Item -Recurse "lang" $langStaging
+        Copy-Item -Recurse "lang" "$stage\lang"
         Write-Output "Staged lang/ for installer"
 
-        & "${env:ProgramFiles(x86)}\NSIS\makensis.exe" /DVERSION=$env:VERSION "$stagingDir\magda-installer.nsi"
+        & "${env:ProgramFiles(x86)}\NSIS\makensis.exe" /DVERSION=$env:VERSION "$stage\magda-installer.nsi"
 
         $installerName = "MAGDA-$env:VERSION-Windows-x86_64-Setup.exe"
-        Move-Item "$stagingDir\MAGDA-$env:VERSION-Windows-Setup.exe" $installerName
+        Move-Item "$stage\MAGDA-$env:VERSION-Windows-Setup.exe" $installerName
 
         Write-Output "Installer created: $installerName"
         Get-ChildItem $installerName
@@ -409,9 +413,7 @@ jobs:
       shell: powershell
       run: |
         Remove-Item -Recurse -Force build -ErrorAction SilentlyContinue
-        Remove-Item -Force "packaging\windows\MAGDA.exe" -ErrorAction SilentlyContinue
-        Remove-Item -Force "packaging\windows\magda_plugin_scanner.exe" -ErrorAction SilentlyContinue
-        Remove-Item -Recurse -Force "packaging\windows\lang" -ErrorAction SilentlyContinue
+        Remove-Item -Recurse -Force (Join-Path $env:RUNNER_TEMP "magda-installer-stage") -ErrorAction SilentlyContinue
 
   build-linux:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ cmake-build-*/
 build/
 Build/
 
+# Windows installer staging (populated by release CI or local install tests)
+packaging/windows/lang/
+
 # IDE files
 .vscode/
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,6 @@ cmake-build-*/
 build/
 Build/
 
-# Windows installer staging (populated by release CI or local install tests)
-packaging/windows/lang/
-
 # IDE files
 .vscode/
 .idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,19 +7,22 @@ endif()
 
 project(Magda VERSION 0.1.0 LANGUAGES C CXX)
 
-# Derive display version from git tags (e.g. "0.1.0-rc2" or "0.1.0-rc2-15-g1391223")
-execute_process(
-    COMMAND git describe --tags --always
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    OUTPUT_VARIABLE MAGDA_GIT_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET
-    RESULT_VARIABLE GIT_DESCRIBE_RESULT
-)
-if(GIT_DESCRIBE_RESULT EQUAL 0 AND MAGDA_GIT_VERSION MATCHES "^v?(.+)$")
-    set(MAGDA_FULL_VERSION "${CMAKE_MATCH_1}")
-else()
-    set(MAGDA_FULL_VERSION "${PROJECT_VERSION}")
+# Display version: prefer explicit -DMAGDA_FULL_VERSION (set by release CI), else
+# derive from git tags (e.g. "0.1.0-rc2" or "0.1.0-rc2-15-g1391223").
+if(NOT DEFINED MAGDA_FULL_VERSION OR MAGDA_FULL_VERSION STREQUAL "")
+    execute_process(
+        COMMAND git describe --tags --always
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE MAGDA_GIT_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE GIT_DESCRIBE_RESULT
+    )
+    if(GIT_DESCRIBE_RESULT EQUAL 0 AND MAGDA_GIT_VERSION MATCHES "^v?(.+)$")
+        set(MAGDA_FULL_VERSION "${CMAKE_MATCH_1}")
+    else()
+        set(MAGDA_FULL_VERSION "${PROJECT_VERSION}")
+    endif()
 endif()
 
 # ccache disabled - causes unnecessary rebuilds with Ninja

--- a/magda/daw/core/StringTable.cpp
+++ b/magda/daw/core/StringTable.cpp
@@ -11,10 +11,14 @@ StringTable::StringTable() {
     auto langDir = findLangDirectory();
     if (langDir.isDirectory()) {
         auto en = langDir.getChildFile("en.json");
-        if (en.existsAsFile() && load(en))
+        if (en.existsAsFile() && load(en)) {
+            DBG("StringTable: loaded en.json from " << langDir.getFullPathName());
             return;
+        }
     }
-    DBG("StringTable: no lang/en.json found, using key fallback");
+    auto appFile = juce::File::getSpecialLocation(juce::File::currentApplicationFile);
+    DBG("StringTable: no lang/en.json found near " << appFile.getFullPathName()
+                                                   << ", using key fallback");
 }
 
 juce::File StringTable::findLangDirectory() {

--- a/packaging/windows/magda-installer.nsi
+++ b/packaging/windows/magda-installer.nsi
@@ -31,6 +31,11 @@ Section "Install"
     File "MAGDA.exe"
     File /nonfatal "magda_plugin_scanner.exe"
 
+    ; Localization JSON files — StringTable looks for them next to MAGDA.exe
+    SetOutPath "$INSTDIR\lang"
+    File /r "lang\*.*"
+    SetOutPath $INSTDIR
+
     ; Create uninstaller
     WriteUninstaller "$INSTDIR\Uninstall.exe"
 
@@ -66,6 +71,7 @@ Section "Uninstall"
     Delete "$INSTDIR\MAGDA.exe"
     Delete "$INSTDIR\magda_plugin_scanner.exe"
     Delete "$INSTDIR\Uninstall.exe"
+    RMDir /r "$INSTDIR\lang"
     RMDir "$INSTDIR"
 
     Delete "$SMPROGRAMS\MAGDA\*.*"

--- a/packaging/windows/magda-installer.nsi
+++ b/packaging/windows/magda-installer.nsi
@@ -28,12 +28,14 @@ Unicode True
 
 Section "Install"
     SetOutPath $INSTDIR
-    File "MAGDA.exe"
-    File /nonfatal "magda_plugin_scanner.exe"
+    ; ${__FILEDIR__} resolves to the directory of this .nsi at compile time, so
+    ; the installer builds correctly regardless of makensis's working directory.
+    File "${__FILEDIR__}\MAGDA.exe"
+    File /nonfatal "${__FILEDIR__}\magda_plugin_scanner.exe"
 
-    ; Localization JSON files — StringTable looks for them next to MAGDA.exe
+    ; Localization JSON files - StringTable looks for them next to MAGDA.exe
     SetOutPath "$INSTDIR\lang"
-    File /r "lang\*.*"
+    File /r "${__FILEDIR__}\lang\*.*"
     SetOutPath $INSTDIR
 
     ; Create uninstaller


### PR DESCRIPTION
The 0.5 release shipped broken packaged builds on Windows and Linux: localisation keys rendered instead of translated strings, and the splash showed a stale/fallback version.

Root causes:
- Windows NSIS installer only staged MAGDA.exe and the scanner, never lang/. PR #1040 added a cmake install() rule for lang, but CI hand-stages files and never runs cmake --install, so it was inert.
- Linux AppImage staging copied only the two binaries into usr/bin/; lang/ was never copied into the AppDir.
- MAGDA_FULL_VERSION was derived purely from `git describe --tags`, which can return a SHA or wrong-nearest-tag when actions/checkout does its default shallow fetch without tags, so the splash showed the wrong version.

Fix:
- NSIS: install lang/ next to MAGDA.exe, remove on uninstall. CI stages the directory before running makensis and cleans it up after.
- Linux CI: cp -r lang "$APPDIR/usr/bin/lang" so StringTable finds it at runtime next to the binary.
- CMakeLists.txt: honour an explicit -DMAGDA_FULL_VERSION override, falling back to git describe only when not provided. Release CI passes the workflow-computed VERSION on all three platforms.
- Gitignore the Windows staging lang/ dir so local installer tests do not dirty the tree.