### PR TITLE
ci(release): skip Chocolatey when Ninja/NSIS are already installed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,7 +283,8 @@ jobs:
         # flakes (HTTP 499) intermittently and blocks the release otherwise.
         $nsisPath = "${env:ProgramFiles(x86)}\NSIS\makensis.exe"
         $needNinja = -not (Get-Command ninja -ErrorAction SilentlyContinue)
-        $needNsis  = -not (Test-Path $nsisPath)
+        $needNsis  = -not (Test-Path $nsisPath) `
+                     -and -not (Get-Command makensis -ErrorAction SilentlyContinue)
 
         if ($needNinja -or $needNsis) {
           $packages = @()
@@ -291,11 +292,26 @@ jobs:
           if ($needNsis)  { $packages += "nsis" }
           Write-Output "Installing via Chocolatey: $($packages -join ', ')"
           choco install $packages -y
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Chocolatey install failed with exit code $LASTEXITCODE"
+            exit $LASTEXITCODE
+          }
         } else {
           Write-Output "Ninja and NSIS already present; skipping Chocolatey"
         }
 
-        echo "C:\Program Files (x86)\NSIS" >> $env:GITHUB_PATH
+        # Export the resolved NSIS directory so later steps find makensis
+        # regardless of whether ProgramFiles(x86) is on C: or elsewhere.
+        $makensis = Get-Command makensis -ErrorAction SilentlyContinue
+        if ($makensis) {
+          $nsisDir = Split-Path -Parent $makensis.Source
+        } elseif (Test-Path $nsisPath) {
+          $nsisDir = Split-Path -Parent $nsisPath
+        } else {
+          Write-Error "NSIS not found after install attempt"
+          exit 1
+        }
+        echo "$nsisDir" >> $env:GITHUB_PATH
 
     - name: Install sccache
       shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,7 +278,23 @@ jobs:
     - name: Install Ninja and NSIS
       shell: powershell
       run: |
-        choco install ninja nsis -y
+        # Both tools are typically pre-installed on windows-latest runners;
+        # only fall back to Chocolatey if missing, since the community feed
+        # flakes (HTTP 499) intermittently and blocks the release otherwise.
+        $nsisPath = "${env:ProgramFiles(x86)}\NSIS\makensis.exe"
+        $needNinja = -not (Get-Command ninja -ErrorAction SilentlyContinue)
+        $needNsis  = -not (Test-Path $nsisPath)
+
+        if ($needNinja -or $needNsis) {
+          $packages = @()
+          if ($needNinja) { $packages += "ninja" }
+          if ($needNsis)  { $packages += "nsis" }
+          Write-Output "Installing via Chocolatey: $($packages -join ', ')"
+          choco install $packages -y
+        } else {
+          Write-Output "Ninja and NSIS already present; skipping Chocolatey"
+        }
+
         echo "C:\Program Files (x86)\NSIS" >> $env:GITHUB_PATH
 
     - name: Install sccache


### PR DESCRIPTION
The Windows release build just failed because Chocolatey's community feed returned HTTP 499:

> Unable to connect to source 'https://community.chocolatey.org/api/v2/'
> Failed to fetch results ... 499 (<none>)

Both Ninja and NSIS are pre-installed on `windows-latest` runners (NSIS at `C:\Program Files (x86)\NSIS\makensis.exe`, Ninja via VS build tools). The `choco install` step is defensive but gates the release on Chocolatey's uptime — which, as just demonstrated, is not something we should depend on.

This change:
- Checks for Ninja on PATH and NSIS at the standard install path.
- Only calls `choco install` for whichever is actually missing.
- If both are present (the common case), skips Chocolatey entirely.
- If both are missing AND Chocolatey is flaky, fails loudly — which is the correct behavior.

## Test plan

- [ ] Trigger a Windows release build from this branch and confirm the "Install Ninja and NSIS" step logs "Ninja and NSIS already present; skipping Chocolatey".
- [ ] Confirm the subsequent installer build step still finds `makensis.exe` on PATH via the `GITHUB_PATH` export.