### PR TITLE
fix: resolve lang/ via /proc/self/exe so AppImages find translations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,8 +318,9 @@ jobs:
       env:
         VERSION: ${{ steps.version.outputs.version }}
       run: |
-        # /FS serialises PDB writes across parallel cl.exe workers so we keep
-        # /Zi (separate PDB shipped with the binary) and can build in parallel.
+        # /FS (required for parallel MSVC builds with /Zi) is applied in
+        # CMakeLists.txt via add_compile_options, so it composes with the
+        # default MSVC init flags instead of clobbering them.
         # sccache is deliberately NOT used here: release builds rarely hit the
         # cache (cold after most merges) and sccache's .obj interposition
         # bypasses /FS coordination, reintroducing C1041 PDB races.
@@ -327,9 +328,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release `
           -DCMAKE_SYSTEM_PROCESSOR=x64 `
           -DMAGDA_BUILD_TESTS=OFF `
-          -DMAGDA_FULL_VERSION="$env:VERSION" `
-          -DCMAKE_C_FLAGS="/FS" `
-          -DCMAKE_CXX_FLAGS="/FS"
+          -DMAGDA_FULL_VERSION="$env:VERSION"
 
     - name: Build
       shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,50 +313,27 @@ jobs:
         }
         echo "$nsisDir" >> $env:GITHUB_PATH
 
-    - name: Install sccache
-      shell: powershell
-      run: |
-        $sccacheDir = "$env:USERPROFILE\.sccache\bin"
-        if (-not (Test-Path "$sccacheDir\sccache.exe")) {
-          Write-Output "Installing sccache..."
-          New-Item -ItemType Directory -Force -Path $sccacheDir | Out-Null
-          Invoke-WebRequest -Uri "https://github.com/mozilla/sccache/releases/download/v0.8.1/sccache-v0.8.1-x86_64-pc-windows-msvc.zip" -OutFile "$env:TEMP\sccache.zip"
-          Expand-Archive "$env:TEMP\sccache.zip" -DestinationPath "$env:TEMP\sccache" -Force
-          Copy-Item "$env:TEMP\sccache\sccache-v0.8.1-x86_64-pc-windows-msvc\sccache.exe" "$sccacheDir\"
-        }
-        echo "$sccacheDir" >> $env:GITHUB_PATH
-        & "$sccacheDir\sccache.exe" --version
-
-    - name: Cache sccache
-      uses: actions/cache@v5
-      with:
-        path: ~\AppData\Local\Mozilla\sccache
-        key: sccache-windows-release-${{ hashFiles('CMakeLists.txt', 'magda/daw/CMakeLists.txt') }}
-        restore-keys: |
-          sccache-windows-release-
-
     - name: Configure CMake
       shell: powershell
       env:
         VERSION: ${{ steps.version.outputs.version }}
       run: |
+        # /FS serialises PDB writes across parallel cl.exe workers so we keep
+        # /Zi (separate PDB shipped with the binary) and can build in parallel.
+        # sccache is deliberately NOT used here: release builds rarely hit the
+        # cache (cold after most merges) and sccache's .obj interposition
+        # bypasses /FS coordination, reintroducing C1041 PDB races.
         cmake -B build -G Ninja `
           -DCMAKE_BUILD_TYPE=Release `
           -DCMAKE_SYSTEM_PROCESSOR=x64 `
           -DMAGDA_BUILD_TESTS=OFF `
           -DMAGDA_FULL_VERSION="$env:VERSION" `
-          -DCMAKE_C_COMPILER_LAUNCHER=sccache `
-          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          -DCMAKE_C_FLAGS="/FS" `
+          -DCMAKE_CXX_FLAGS="/FS"
 
     - name: Build
       shell: powershell
-      run: |
-        # Serial build (-j 1) to avoid C1041 PDB write conflicts with /Zi + sccache
-        cmake --build build --config Release -j 1
-
-    - name: Print sccache stats
-      shell: powershell
-      run: sccache --show-stats
+      run: cmake --build build --config Release
 
     - name: Locate MAGDA.exe
       id: locate

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,11 @@ endif()
 if(MSVC)
     set(CMAKE_CXX_FLAGS_DEBUG "/Zi /Od /W3")
     set(CMAKE_CXX_FLAGS_RELEASE "/O2 /DNDEBUG")
+    # /FS serialises PDB writes across parallel cl.exe workers (required with
+    # /Zi when the build runs with -j >1). Added via add_compile_options so it
+    # composes with CMake's default MSVC init flags (/DWIN32 /_WINDOWS /EHsc etc.)
+    # instead of replacing them like a top-level -DCMAKE_CXX_FLAGS would.
+    add_compile_options(/FS)
     # /OPT:REF,ICF preserve release dead-stripping; /Zi + /DEBUG applied per-target (see magda/daw/CMakeLists.txt)
     string(APPEND CMAKE_EXE_LINKER_FLAGS_RELEASE " /OPT:REF /OPT:ICF")
 else()

--- a/magda/daw/core/StringTable.cpp
+++ b/magda/daw/core/StringTable.cpp
@@ -29,11 +29,12 @@ juce::File StringTable::findLangDirectory() {
 #if JUCE_MAC
     candidates.add(appFile.getChildFile("Contents/Resources/lang"));
 #endif
-#if JUCE_LINUX || JUCE_BSD
+#if JUCE_LINUX
     // Under an AppImage, JUCE's currentApplicationFile returns the outer
     // .AppImage launcher path (via argv[0]/dladdr), so `lang` ends up looked
     // for next to the launcher instead of inside the mount. /proc/self/exe
     // always resolves to the real binary inside the AppImage mount.
+    // Linux-only: BSD would need /proc/curproc/file and procfs isn't guaranteed.
     if (auto real = juce::File("/proc/self/exe").getLinkedTarget(); real.exists())
         candidates.add(real.getParentDirectory().getChildFile("lang"));
 #endif

--- a/magda/daw/core/StringTable.cpp
+++ b/magda/daw/core/StringTable.cpp
@@ -29,6 +29,14 @@ juce::File StringTable::findLangDirectory() {
 #if JUCE_MAC
     candidates.add(appFile.getChildFile("Contents/Resources/lang"));
 #endif
+#if JUCE_LINUX || JUCE_BSD
+    // Under an AppImage, JUCE's currentApplicationFile returns the outer
+    // .AppImage launcher path (via argv[0]/dladdr), so `lang` ends up looked
+    // for next to the launcher instead of inside the mount. /proc/self/exe
+    // always resolves to the real binary inside the AppImage mount.
+    if (auto real = juce::File("/proc/self/exe").getLinkedTarget(); real.exists())
+        candidates.add(real.getParentDirectory().getChildFile("lang"));
+#endif
     // Next to the binary (Windows/Linux, and macOS portable layout).
     candidates.add(appFile.getParentDirectory().getChildFile("lang"));
 


### PR DESCRIPTION
JUCE's File::getSpecialLocation(currentApplicationFile) uses dladdr/argv[0] on Linux, which under an AppImage returns the outer .AppImage launcher path rather than the mounted binary inside /tmp/.mount_*/usr/bin/. StringTable then stats lang/ next to the launcher (e.g. /root/lang), finds nothing, and falls back to raw localisation keys even though the bundle contains lang/en.json at the correct usr/bin/lang/ location.

/proc/self/exe always resolves to the real binary, so add it as a Linux lookup candidate ahead of the argv[0]-derived path. Confirmed empirically via strace on a v0.5.1-rc1 AppImage: the binary reads /proc/self/exe correctly to the mount path, but the existing lookup still stats /root/lang because it uses the JUCE-provided appFile.