### PR TITLE
fix: track selection propagation and macro link amount sync

### DIFF
--- a/magda/daw/audio/PluginManager.cpp
+++ b/magda/daw/audio/PluginManager.cpp
@@ -1283,11 +1283,11 @@ void PluginManager::updateDeviceModifierProperties(TrackId trackId) {
         }
     }
 
-    // Update device-level macro assignment values in-place. The in-place path
-    // exists because fingerprint-based rebuild skips "value-only" changes (amount
-    // / bipolar), and a full rebuild destroys TE's modifier graph. Without this
-    // macro loop, adjusting a macro link amount silently kept the old modifier
-    // assignment value.
+    // Update device-level macro assignment values in-place. The structural
+    // fingerprint (mod count, link count, bipolar count) covers add/remove
+    // and bipolar flips, but amount is NOT in it — so amount-only edits take
+    // the in-place branch instead of a rebuild, and without this macro loop
+    // they silently kept the previous TE modifier assignment value.
     for (const auto& element : trackInfo->chainElements) {
         if (!isDevice(element))
             continue;

--- a/magda/daw/audio/PluginManager.cpp
+++ b/magda/daw/audio/PluginManager.cpp
@@ -1330,26 +1330,14 @@ void PluginManager::updateDeviceModifierProperties(TrackId trackId) {
                 if (!param)
                     continue;
 
-                bool matched = false;
                 for (auto* assignment : param->getAssignments()) {
                     if (assignment->isForModifierSource(*macroParam)) {
                         const float offset = link.bipolar ? -link.amount : 0.0f;
                         const float value = link.bipolar ? link.amount * 2.0f : link.amount;
-                        DBG("[MACRO-ASSIGN] update (device): devId="
-                            << device.id << " macroIdx=" << macroIdx << " paramIdx="
-                            << link.target.paramIndex << " linkAmount=" << link.amount
-                            << " bipolar=" << (link.bipolar ? "yes" : "no")
-                            << " prevValue=" << assignment->value << " newValue=" << value);
                         assignment->value = value;
                         assignment->offset = offset;
-                        matched = true;
                         break;
                     }
-                }
-                if (!matched) {
-                    DBG("[MACRO-ASSIGN] no assignment found (device): devId="
-                        << device.id << " macroIdx=" << macroIdx << " paramIdx="
-                        << link.target.paramIndex << " — macro amount change will NOT take effect");
                 }
             }
         }
@@ -1457,28 +1445,14 @@ void PluginManager::updateDeviceModifierProperties(TrackId trackId) {
                 if (!param)
                     continue;
 
-                bool matched = false;
                 for (auto* assignment : param->getAssignments()) {
                     if (assignment->isForModifierSource(*macroParam)) {
                         const float offset = link.bipolar ? -link.amount : 0.0f;
                         const float value = link.bipolar ? link.amount * 2.0f : link.amount;
-                        DBG("[MACRO-ASSIGN] update (track): trackId="
-                            << trackId << " macroIdx=" << macroIdx << " targetDevId="
-                            << link.target.deviceId << " paramIdx=" << link.target.paramIndex
-                            << " linkAmount=" << link.amount
-                            << " bipolar=" << (link.bipolar ? "yes" : "no")
-                            << " prevValue=" << assignment->value << " newValue=" << value);
                         assignment->value = value;
                         assignment->offset = offset;
-                        matched = true;
                         break;
                     }
-                }
-                if (!matched) {
-                    DBG("[MACRO-ASSIGN] no assignment found (track): trackId="
-                        << trackId << " macroIdx=" << macroIdx << " targetDevId="
-                        << link.target.deviceId << " paramIdx=" << link.target.paramIndex
-                        << " — macro amount change will NOT take effect");
                 }
             }
         }

--- a/magda/daw/audio/PluginManager.cpp
+++ b/magda/daw/audio/PluginManager.cpp
@@ -1283,6 +1283,66 @@ void PluginManager::updateDeviceModifierProperties(TrackId trackId) {
         }
     }
 
+    // Update device-level macro assignment values in-place. The in-place path
+    // exists because fingerprint-based rebuild skips "value-only" changes (amount
+    // / bipolar), and a full rebuild destroys TE's modifier graph. Without this
+    // macro loop, adjusting a macro link amount silently kept the old modifier
+    // assignment value.
+    for (const auto& element : trackInfo->chainElements) {
+        if (!isDevice(element))
+            continue;
+        const auto& device = getDevice(element);
+        auto sdIt = syncedDevices_.find(device.id);
+        if (sdIt == syncedDevices_.end())
+            continue;
+
+        for (int macroIdx = 0; macroIdx < static_cast<int>(device.macros.size()); ++macroIdx) {
+            auto mpIt = sdIt->second.macroParams.find(macroIdx);
+            if (mpIt == sdIt->second.macroParams.end() || mpIt->second == nullptr)
+                continue;
+            auto* macroParam = mpIt->second;
+
+            const auto& macroInfo = device.macros[static_cast<size_t>(macroIdx)];
+            for (const auto& link : macroInfo.links) {
+                if (!link.target.isValid())
+                    continue;
+
+                te::Plugin::Ptr linkTarget;
+                {
+                    juce::ScopedLock lock(pluginLock_);
+                    auto pit = syncedDevices_.find(link.target.deviceId);
+                    if (pit != syncedDevices_.end())
+                        linkTarget = pit->second.plugin;
+                }
+                if (!linkTarget) {
+                    auto* inner = instrumentRackManager_.getInnerPlugin(link.target.deviceId);
+                    if (inner)
+                        linkTarget = inner;
+                }
+                if (!linkTarget)
+                    continue;
+
+                auto params = linkTarget->getAutomatableParameters();
+                if (link.target.paramIndex < 0 ||
+                    link.target.paramIndex >= static_cast<int>(params.size()))
+                    continue;
+                auto* param = params[static_cast<size_t>(link.target.paramIndex)];
+                if (!param)
+                    continue;
+
+                for (auto* assignment : param->getAssignments()) {
+                    if (assignment->isForModifierSource(*macroParam)) {
+                        const float offset = link.bipolar ? -link.amount : 0.0f;
+                        const float value = link.bipolar ? link.amount * 2.0f : link.amount;
+                        assignment->value = value;
+                        assignment->offset = offset;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
     // Update track-level mod properties in-place
     auto tmIt = trackModStates_.find(trackId);
     if (tmIt != trackModStates_.end()) {
@@ -1344,6 +1404,57 @@ void PluginManager::updateDeviceModifierProperties(TrackId trackId) {
             }
 
             ++modIdx;
+        }
+    }
+
+    // Track-level macro assignment values — mirror of the device-macro loop
+    // above, but walks trackMacroParams_ keyed by (trackId, macroIdx).
+    auto trackMacroIt = trackMacroParams_.find(trackId);
+    if (trackMacroIt != trackMacroParams_.end()) {
+        for (int macroIdx = 0; macroIdx < static_cast<int>(trackInfo->macros.size()); ++macroIdx) {
+            auto pIt = trackMacroIt->second.find(macroIdx);
+            if (pIt == trackMacroIt->second.end() || pIt->second == nullptr)
+                continue;
+            auto* macroParam = pIt->second;
+
+            const auto& macroInfo = trackInfo->macros[static_cast<size_t>(macroIdx)];
+            for (const auto& link : macroInfo.links) {
+                if (!link.target.isValid())
+                    continue;
+
+                te::Plugin::Ptr linkTarget;
+                {
+                    juce::ScopedLock lock(pluginLock_);
+                    auto pit = syncedDevices_.find(link.target.deviceId);
+                    if (pit != syncedDevices_.end())
+                        linkTarget = pit->second.plugin;
+                }
+                if (!linkTarget) {
+                    auto* inner = instrumentRackManager_.getInnerPlugin(link.target.deviceId);
+                    if (inner)
+                        linkTarget = inner;
+                }
+                if (!linkTarget)
+                    continue;
+
+                auto params = linkTarget->getAutomatableParameters();
+                if (link.target.paramIndex < 0 ||
+                    link.target.paramIndex >= static_cast<int>(params.size()))
+                    continue;
+                auto* param = params[static_cast<size_t>(link.target.paramIndex)];
+                if (!param)
+                    continue;
+
+                for (auto* assignment : param->getAssignments()) {
+                    if (assignment->isForModifierSource(*macroParam)) {
+                        const float offset = link.bipolar ? -link.amount : 0.0f;
+                        const float value = link.bipolar ? link.amount * 2.0f : link.amount;
+                        assignment->value = value;
+                        assignment->offset = offset;
+                        break;
+                    }
+                }
+            }
         }
     }
 }

--- a/magda/daw/audio/PluginManager.cpp
+++ b/magda/daw/audio/PluginManager.cpp
@@ -1330,14 +1330,26 @@ void PluginManager::updateDeviceModifierProperties(TrackId trackId) {
                 if (!param)
                     continue;
 
+                bool matched = false;
                 for (auto* assignment : param->getAssignments()) {
                     if (assignment->isForModifierSource(*macroParam)) {
                         const float offset = link.bipolar ? -link.amount : 0.0f;
                         const float value = link.bipolar ? link.amount * 2.0f : link.amount;
+                        DBG("[MACRO-ASSIGN] update (device): devId="
+                            << device.id << " macroIdx=" << macroIdx << " paramIdx="
+                            << link.target.paramIndex << " linkAmount=" << link.amount
+                            << " bipolar=" << (link.bipolar ? "yes" : "no")
+                            << " prevValue=" << assignment->value << " newValue=" << value);
                         assignment->value = value;
                         assignment->offset = offset;
+                        matched = true;
                         break;
                     }
+                }
+                if (!matched) {
+                    DBG("[MACRO-ASSIGN] no assignment found (device): devId="
+                        << device.id << " macroIdx=" << macroIdx << " paramIdx="
+                        << link.target.paramIndex << " — macro amount change will NOT take effect");
                 }
             }
         }
@@ -1445,14 +1457,28 @@ void PluginManager::updateDeviceModifierProperties(TrackId trackId) {
                 if (!param)
                     continue;
 
+                bool matched = false;
                 for (auto* assignment : param->getAssignments()) {
                     if (assignment->isForModifierSource(*macroParam)) {
                         const float offset = link.bipolar ? -link.amount : 0.0f;
                         const float value = link.bipolar ? link.amount * 2.0f : link.amount;
+                        DBG("[MACRO-ASSIGN] update (track): trackId="
+                            << trackId << " macroIdx=" << macroIdx << " targetDevId="
+                            << link.target.deviceId << " paramIdx=" << link.target.paramIndex
+                            << " linkAmount=" << link.amount
+                            << " bipolar=" << (link.bipolar ? "yes" : "no")
+                            << " prevValue=" << assignment->value << " newValue=" << value);
                         assignment->value = value;
                         assignment->offset = offset;
+                        matched = true;
                         break;
                     }
+                }
+                if (!matched) {
+                    DBG("[MACRO-ASSIGN] no assignment found (track): trackId="
+                        << trackId << " macroIdx=" << macroIdx << " targetDevId="
+                        << link.target.deviceId << " paramIdx=" << link.target.paramIndex
+                        << " — macro amount change will NOT take effect");
                 }
             }
         }

--- a/magda/daw/core/SelectionManager.cpp
+++ b/magda/daw/core/SelectionManager.cpp
@@ -542,6 +542,20 @@ void SelectionManager::selectDevice(TrackId trackId, RackId rackId, ChainId chai
     deviceSelection_.chainId = chainId;
     deviceSelection_.deviceId = deviceId;
 
+    // Align primary track selection with the device's owning track. Without
+    // this the track stays at whatever was last selected (often the master,
+    // which is the startup default) and downstream consumers like the
+    // ControllerRouter contextual-firing gate see a stale selection.
+    bool trackChanged = false;
+    if (trackId != INVALID_TRACK_ID && selectedTrackId_ != trackId) {
+        selectedTrackId_ = trackId;
+        anchorTrackId_ = trackId;
+        selectedTrackIds_.clear();
+        selectedTrackIds_.insert(trackId);
+        TrackManager::getInstance().setSelectedTrack(trackId);
+        trackChanged = true;
+    }
+
     // Sync with managers (clear clip selection)
     ClipManager::getInstance().clearClipSelection();
 
@@ -550,6 +564,9 @@ void SelectionManager::selectDevice(TrackId trackId, RackId rackId, ChainId chai
     }
     if (deviceChanged) {
         notifyDeviceSelectionChanged(deviceSelection_);
+    }
+    if (trackChanged) {
+        notifyTrackSelectionChanged(selectedTrackId_);
     }
 }
 
@@ -739,6 +756,20 @@ void SelectionManager::selectChainNode(const ChainNodePath& path, const juce::St
     chainNodeDisplayName_ = displayName;
     chainNodeDisplayType_ = displayType;
 
+    // Align primary track selection with the chain node's owning track, for
+    // the same reason as selectDevice(): downstream consumers read
+    // getSelectedTrack() to decide whether the user is "on" this track.
+    bool trackChanged = false;
+    const TrackId pathTrackId = path.trackId;
+    if (pathTrackId != INVALID_TRACK_ID && selectedTrackId_ != pathTrackId) {
+        selectedTrackId_ = pathTrackId;
+        anchorTrackId_ = pathTrackId;
+        selectedTrackIds_.clear();
+        selectedTrackIds_.insert(pathTrackId);
+        TrackManager::getInstance().setSelectedTrack(pathTrackId);
+        trackChanged = true;
+    }
+
     // Sync with managers
     ClipManager::getInstance().clearClipSelection();
 
@@ -747,6 +778,9 @@ void SelectionManager::selectChainNode(const ChainNodePath& path, const juce::St
     }
     // Always notify so all components can update their visual state
     notifyChainNodeSelectionChanged(selectedChainNode_);
+    if (trackChanged) {
+        notifyTrackSelectionChanged(selectedTrackId_);
+    }
 }
 
 void SelectionManager::clearChainNodeSelection() {

--- a/magda/daw/core/SelectionManager.cpp
+++ b/magda/daw/core/SelectionManager.cpp
@@ -19,6 +19,44 @@ SelectionManager::SelectionManager() {
 }
 
 // ============================================================================
+// Primary-track alignment helper (shared by selectDevice / selectChainNode)
+// ============================================================================
+
+bool SelectionManager::alignPrimaryTrackToOwner(TrackId trackId) {
+    if (trackId == INVALID_TRACK_ID)
+        return false;
+
+    const bool needsCollapse =
+        (selectedTrackIds_.size() != 1 || selectedTrackIds_.count(trackId) == 0);
+    const bool primaryChanged = (selectedTrackId_ != trackId);
+
+    if (!primaryChanged && !needsCollapse)
+        return false;
+
+    const TrackId oldTrackId = selectedTrackId_;
+
+    selectedTrackId_ = trackId;
+    anchorTrackId_ = trackId;
+    selectedTrackIds_.clear();
+    selectedTrackIds_.insert(trackId);
+    TrackManager::getInstance().setSelectedTrack(trackId);
+
+    // Mirror selectTrack()'s auto-monitor bookkeeping when the primary track
+    // id actually changed. Collapsing an already-primary track's set doesn't
+    // move monitoring off anything, so skip it in that case.
+    if (primaryChanged && Config::getInstance().getAutoMonitorSelectedTrack()) {
+        if (oldTrackId != INVALID_TRACK_ID) {
+            TrackManager::getInstance().setTrackInputMonitor(oldTrackId, InputMonitorMode::Off);
+        }
+        if (trackId != MASTER_TRACK_ID) {
+            TrackManager::getInstance().setTrackInputMonitor(trackId, InputMonitorMode::Auto);
+        }
+    }
+
+    return primaryChanged;
+}
+
+// ============================================================================
 // Track Selection
 // ============================================================================
 
@@ -542,19 +580,12 @@ void SelectionManager::selectDevice(TrackId trackId, RackId rackId, ChainId chai
     deviceSelection_.chainId = chainId;
     deviceSelection_.deviceId = deviceId;
 
-    // Align primary track selection with the device's owning track. Without
-    // this the track stays at whatever was last selected (often the master,
-    // which is the startup default) and downstream consumers like the
-    // ControllerRouter contextual-firing gate see a stale selection.
-    bool trackChanged = false;
-    if (trackId != INVALID_TRACK_ID && selectedTrackId_ != trackId) {
-        selectedTrackId_ = trackId;
-        anchorTrackId_ = trackId;
-        selectedTrackIds_.clear();
-        selectedTrackIds_.insert(trackId);
-        TrackManager::getInstance().setSelectedTrack(trackId);
-        trackChanged = true;
-    }
+    // Align primary track selection with the device's owning track. Handles
+    // collapsing multi-track sets, anchor reset, TrackManager sync, and
+    // auto-monitor bookkeeping. Without this, downstream consumers like the
+    // ControllerRouter contextual-firing gate or multi-track commands see
+    // stale state after clicking a device.
+    const bool trackChanged = alignPrimaryTrackToOwner(trackId);
 
     // Sync with managers (clear clip selection)
     ClipManager::getInstance().clearClipSelection();
@@ -756,19 +787,10 @@ void SelectionManager::selectChainNode(const ChainNodePath& path, const juce::St
     chainNodeDisplayName_ = displayName;
     chainNodeDisplayType_ = displayType;
 
-    // Align primary track selection with the chain node's owning track, for
-    // the same reason as selectDevice(): downstream consumers read
-    // getSelectedTrack() to decide whether the user is "on" this track.
-    bool trackChanged = false;
-    const TrackId pathTrackId = path.trackId;
-    if (pathTrackId != INVALID_TRACK_ID && selectedTrackId_ != pathTrackId) {
-        selectedTrackId_ = pathTrackId;
-        anchorTrackId_ = pathTrackId;
-        selectedTrackIds_.clear();
-        selectedTrackIds_.insert(pathTrackId);
-        TrackManager::getInstance().setSelectedTrack(pathTrackId);
-        trackChanged = true;
-    }
+    // Align primary track selection with the chain node's owning track; see
+    // alignPrimaryTrackToOwner() for the full rationale (collapses multi-
+    // track sets, runs auto-monitor, keeps TrackManager in sync).
+    const bool trackChanged = alignPrimaryTrackToOwner(path.trackId);
 
     // Sync with managers
     ClipManager::getInstance().clearClipSelection();

--- a/magda/daw/core/SelectionManager.hpp
+++ b/magda/daw/core/SelectionManager.hpp
@@ -1182,6 +1182,13 @@ class SelectionManager {
     SelectionManager();
     ~SelectionManager() = default;
 
+    // Collapse any prior multi-track selection to the given single track,
+    // align anchor and TrackManager, and mirror selectTrack's auto-monitor
+    // handling when the primary id actually changes. Returns true iff the
+    // primary track id changed (caller uses this to decide whether to
+    // notifyTrackSelectionChanged). No-op for INVALID_TRACK_ID.
+    bool alignPrimaryTrackToOwner(TrackId trackId);
+
     SelectionType selectionType_ = SelectionType::None;
     TrackId selectedTrackId_ = INVALID_TRACK_ID;
     std::unordered_set<TrackId> selectedTrackIds_;  // For multi-track selection


### PR DESCRIPTION
## Summary
Two pre-existing bugs that surfaced while testing MIDI Learn and macro
linking on `feat/controller-data-model` but which live on `main`.

## Selection: clicking a device/chain-node didn't select its owning track
`SelectionManager::selectDevice()` / `selectChainNode()` flipped
`selectionType_` to Device/ChainNode and populated their own fields,
but never touched `selectedTrackId_`. After startup (which selects
`MASTER_TRACK_ID` as the default), clicking into track 1's chain left
`getSelectedTrack()` stuck on master. Downstream consumers that reason
about "which track is the user on" (controller contextual firing,
focus-aware resolvers, automation recording) saw stale selection.

Fix aligns `selectedTrackId_` + `anchorTrackId_` + `selectedTrackIds_`
with the owning track on `selectDevice` / `selectChainNode`.

## Macros: amount edits didn't reach the live TE modifier
`resyncDeviceModifiers` rebuilds on structural fingerprint change
(count, bipolar flags). Amount isn't in the fingerprint, so amount-only
edits went down the in-place `updateDeviceModifierProperties` path.
That path updated mod assignment values but skipped macros, leaving the
TE `MacroParameter` assignment at whatever value it had when the link
was first created.

Fix mirrors the mod-amount update loop for device-level and
track-level macros.

## Test plan
- [x] `make test` — 585/585 pass locally
- [ ] Manual: click into a device's chain → `SelectionManager::getSelectedTrack()` returns that track's id
- [ ] Manual: link a macro to 4OSC Filter Freq, move the amount overlay to 100%, move the macro → full-range filter sweep audible