### PR TITLE
fix: prune uninstalled plugins from known list on startup (#1005)

### DIFF
--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -326,13 +326,15 @@ class TracktionEngineWrapper : public AudioEngine,
     void detectNewPlugins(std::function<void(const juce::String&)> statusCallback = nullptr);
 
     /**
-     * @brief Remove entries from the known plugin list whose file no longer
-     * exists on disk. Cheap (stat-only, no plugin scanning) and safe to call
-     * unconditionally — e.g. on every startup, regardless of the
-     * scan-plugins-on-startup config flag. Saves the list if anything was
-     * pruned.
+     * @brief Remove entries from the given known-plugin list whose absolute
+     * fileOrIdentifier no longer exists on disk. Cheap (stat-only, no plugin
+     * scanning, no disk writes). Returns the number of entries removed so the
+     * caller can decide whether to persist and update Config.
+     *
+     * Static and self-contained so it can be unit-tested without spinning up
+     * an Engine.
      */
-    void pruneMissingPlugins();
+    static int pruneMissingPlugins(juce::KnownPluginList& knownPlugins);
 
     /**
      * @brief Clear the plugin list and delete the saved file

--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -326,6 +326,15 @@ class TracktionEngineWrapper : public AudioEngine,
     void detectNewPlugins(std::function<void(const juce::String&)> statusCallback = nullptr);
 
     /**
+     * @brief Remove entries from the known plugin list whose file no longer
+     * exists on disk. Cheap (stat-only, no plugin scanning) and safe to call
+     * unconditionally — e.g. on every startup, regardless of the
+     * scan-plugins-on-startup config flag. Saves the list if anything was
+     * pruned.
+     */
+    void pruneMissingPlugins();
+
+    /**
      * @brief Clear the plugin list and delete the saved file
      * Use this before a fresh rescan
      */

--- a/magda/daw/engine/TracktionEngineWrapperInit.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperInit.cpp
@@ -33,7 +33,11 @@ void TracktionEngineWrapper::initializePluginFormats() {
     // Load saved plugin list from persistent storage
     loadPluginList();
 
-    // Auto-detect newly installed (or removed) plugins (if enabled)
+    // Drop entries whose files have been uninstalled. Unconditional —
+    // the scan-on-startup flag only governs detecting *new* plugins.
+    pruneMissingPlugins();
+
+    // Auto-detect newly installed plugins (if enabled)
     if (Config::getInstance().getScanPluginsOnStartup())
         detectNewPlugins(onPluginScanStatus);
 

--- a/magda/daw/engine/TracktionEngineWrapperInit.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperInit.cpp
@@ -35,7 +35,14 @@ void TracktionEngineWrapper::initializePluginFormats() {
 
     // Drop entries whose files have been uninstalled. Unconditional —
     // the scan-on-startup flag only governs detecting *new* plugins.
-    pruneMissingPlugins();
+    // Persist + resync the cached count so PluginSettingsDialog doesn't
+    // show a stale total after the prune.
+    auto& knownPlugins = pluginManager.knownPluginList;
+    if (pruneMissingPlugins(knownPlugins) > 0) {
+        savePluginList();
+        Config::getInstance().setTotalPluginCount(knownPlugins.getNumTypes());
+        Config::getInstance().save();
+    }
 
     // Auto-detect newly installed plugins (if enabled)
     if (Config::getInstance().getScanPluginsOnStartup())

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -104,7 +104,10 @@ void TracktionEngineWrapper::startPluginScan(
 
             // Remove entries whose files are no longer on disk (e.g. the
             // plugin was uninstalled between the last scan and this one).
-            pruneMissingPlugins();
+            // The unconditional savePluginList() + Config update below covers
+            // persistence for both the additions and the pruning, so we
+            // don't pay for an extra save here.
+            pruneMissingPlugins(knownPlugins);
 
             int numPlugins = knownPlugins.getNumTypes();
             DBG("Plugin scan complete. Found " << numPlugins << " plugins.");
@@ -227,12 +230,7 @@ void TracktionEngineWrapper::loadPluginList() {
     }
 }
 
-void TracktionEngineWrapper::pruneMissingPlugins() {
-    if (!engine_)
-        return;
-
-    auto& knownPlugins = engine_->getPluginManager().knownPluginList;
-
+int TracktionEngineWrapper::pruneMissingPlugins(juce::KnownPluginList& knownPlugins) {
     juce::Array<juce::PluginDescription> stalePlugins;
     for (int i = 0; i < knownPlugins.getNumTypes(); ++i) {
         auto* desc = knownPlugins.getType(i);
@@ -248,10 +246,10 @@ void TracktionEngineWrapper::pruneMissingPlugins() {
         knownPlugins.removeType(desc);
     }
 
-    if (!stalePlugins.isEmpty()) {
+    if (!stalePlugins.isEmpty())
         DBG("Pruned " << stalePlugins.size() << " stale plugin(s) from known list");
-        savePluginList();
-    }
+
+    return stalePlugins.size();
 }
 
 void TracktionEngineWrapper::clearPluginList() {
@@ -331,62 +329,61 @@ void TracktionEngineWrapper::detectNewPlugins(
             return;
 
         juce::WeakReference<TracktionEngineWrapper> weakThis(this);
-        juce::MessageManager::callAsync([weakThis, alive, newPlugins = std::move(newPlugins),
-                                         statusCallback]() mutable {
-            auto* self = weakThis.get();
-            if (!self || !*alive || !self->engine_)
-                return;
+        juce::MessageManager::callAsync(
+            [weakThis, alive, newPlugins = std::move(newPlugins), statusCallback]() mutable {
+                auto* self = weakThis.get();
+                if (!self || !*alive || !self->engine_)
+                    return;
 
-            auto& pm = self->engine_->getPluginManager();
-            auto& kp = pm.knownPluginList;
-            auto& fm = pm.pluginFormatManager;
+                auto& pm = self->engine_->getPluginManager();
+                auto& kp = pm.knownPluginList;
+                auto& fm = pm.pluginFormatManager;
 
-            if (newPlugins.empty()) {
-                auto msg = "Plugins up to date (" + juce::String(kp.getNumTypes()) + " loaded)";
+                if (newPlugins.empty()) {
+                    auto msg = "Plugins up to date (" + juce::String(kp.getNumTypes()) + " loaded)";
+                    juce::Logger::writeToLog("[AutoDetect] " + msg);
+                    if (statusCallback)
+                        statusCallback(msg);
+                    return;
+                }
+
+                auto msg = "Scanning " + juce::String(static_cast<int>(newPlugins.size())) +
+                           " new plugin(s)...";
                 juce::Logger::writeToLog("[AutoDetect] " + msg);
                 if (statusCallback)
                     statusCallback(msg);
-                return;
-            }
 
-            auto msg = "Scanning " + juce::String(static_cast<int>(newPlugins.size())) +
-                       " new plugin(s)...";
-            juce::Logger::writeToLog("[AutoDetect] " + msg);
-            if (statusCallback)
-                statusCallback(msg);
+                self->isScanning_ = true;
 
-            self->isScanning_ = true;
+                self->pluginScanCoordinator_->startIncrementalScan(
+                    fm, newPlugins,
+                    [statusCallback](float, const juce::String& currentPlugin) {
+                        if (statusCallback) {
+                            auto name = juce::File(currentPlugin).getFileNameWithoutExtension();
+                            statusCallback("Scanning: " + name + "...");
+                        }
+                    },
+                    [weakThis, alive](bool /*success*/,
+                                      const juce::Array<juce::PluginDescription>& plugins,
+                                      const juce::StringArray& failedPlugins) {
+                        auto* s = weakThis.get();
+                        if (!s || !*alive || !s->engine_)
+                            return;
+                        auto& kpl = s->engine_->getPluginManager().knownPluginList;
+                        for (const auto& desc : plugins)
+                            kpl.addType(desc);
 
-            self->pluginScanCoordinator_->startIncrementalScan(
-                fm, newPlugins,
-                [statusCallback](float, const juce::String& currentPlugin) {
-                    if (statusCallback) {
-                        auto name = juce::File(currentPlugin).getFileNameWithoutExtension();
-                        statusCallback("Scanning: " + name + "...");
-                    }
-                },
-                [weakThis, alive](bool /*success*/,
-                                  const juce::Array<juce::PluginDescription>& plugins,
-                                  const juce::StringArray& failedPlugins) {
-                    auto* s = weakThis.get();
-                    if (!s || !*alive || !s->engine_)
-                        return;
-                    auto& kpl = s->engine_->getPluginManager().knownPluginList;
-                    for (const auto& desc : plugins)
-                        kpl.addType(desc);
-
-                    auto msg =
-                        "[AutoDetect] Incremental scan complete: " + juce::String(plugins.size()) +
-                        " new plugin(s) added" +
-                        (failedPlugins.size() > 0
-                             ? ", " + juce::String(failedPlugins.size()) + " failed"
-                             : "");
-                    DBG(msg);
-                    juce::Logger::writeToLog(msg);
-                    s->savePluginList();
-                    s->isScanning_ = false;
-                });
-        });
+                        auto msg = "[AutoDetect] Incremental scan complete: " +
+                                   juce::String(plugins.size()) + " new plugin(s) added" +
+                                   (failedPlugins.size() > 0
+                                        ? ", " + juce::String(failedPlugins.size()) + " failed"
+                                        : "");
+                        DBG(msg);
+                        juce::Logger::writeToLog(msg);
+                        s->savePluginList();
+                        s->isScanning_ = false;
+                    });
+            });
     });
 }
 

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -102,32 +102,9 @@ void TracktionEngineWrapper::startPluginScan(
                 knownPlugins.addType(desc);
             }
 
-            // Remove stale plugins whose files no longer exist on disk
-            {
-                std::unordered_set<std::string> scannedPaths;
-                for (const auto& desc : plugins)
-                    scannedPaths.insert(desc.fileOrIdentifier.toStdString());
-
-                juce::Array<juce::PluginDescription> stalePlugins;
-                for (int i = 0; i < knownPlugins.getNumTypes(); ++i) {
-                    auto* desc = knownPlugins.getType(i);
-                    if (desc && scannedPaths.find(desc->fileOrIdentifier.toStdString()) ==
-                                    scannedPaths.end()) {
-                        juce::File pluginFile(desc->fileOrIdentifier);
-                        if (juce::File::isAbsolutePath(desc->fileOrIdentifier) &&
-                            !pluginFile.exists()) {
-                            DBG("Removing stale plugin: " << desc->name << " ("
-                                                          << desc->fileOrIdentifier << ")");
-                            stalePlugins.add(*desc);
-                        }
-                    }
-                }
-                for (const auto& desc : stalePlugins)
-                    knownPlugins.removeType(desc);
-
-                if (!stalePlugins.isEmpty())
-                    DBG("Removed " << stalePlugins.size() << " stale plugin(s)");
-            }
+            // Remove entries whose files are no longer on disk (e.g. the
+            // plugin was uninstalled between the last scan and this one).
+            pruneMissingPlugins();
 
             int numPlugins = knownPlugins.getNumTypes();
             DBG("Plugin scan complete. Found " << numPlugins << " plugins.");
@@ -250,6 +227,33 @@ void TracktionEngineWrapper::loadPluginList() {
     }
 }
 
+void TracktionEngineWrapper::pruneMissingPlugins() {
+    if (!engine_)
+        return;
+
+    auto& knownPlugins = engine_->getPluginManager().knownPluginList;
+
+    juce::Array<juce::PluginDescription> stalePlugins;
+    for (int i = 0; i < knownPlugins.getNumTypes(); ++i) {
+        auto* desc = knownPlugins.getType(i);
+        if (!desc || !juce::File::isAbsolutePath(desc->fileOrIdentifier))
+            continue;
+        juce::File pluginFile(desc->fileOrIdentifier);
+        if (!pluginFile.exists())
+            stalePlugins.add(*desc);
+    }
+
+    for (const auto& desc : stalePlugins) {
+        DBG("Removing stale plugin: " << desc.name << " (" << desc.fileOrIdentifier << ")");
+        knownPlugins.removeType(desc);
+    }
+
+    if (!stalePlugins.isEmpty()) {
+        DBG("Pruned " << stalePlugins.size() << " stale plugin(s) from known list");
+        savePluginList();
+    }
+}
+
 void TracktionEngineWrapper::clearPluginList() {
     if (!engine_) {
         DBG("Cannot clear plugin list: engine not initialized");
@@ -321,11 +325,6 @@ void TracktionEngineWrapper::detectNewPlugins(
                 newPlugins.push_back(plugin);
         }
 
-        // Build disk paths set for stale detection
-        juce::StringArray diskPaths;
-        for (const auto& plugin : allPlugins)
-            diskPaths.add(plugin.pluginPath);
-
         // Switch back to message thread for UI updates and scan dispatch
         auto alive = aliveFlag_;
         if (!*alive)
@@ -333,7 +332,6 @@ void TracktionEngineWrapper::detectNewPlugins(
 
         juce::WeakReference<TracktionEngineWrapper> weakThis(this);
         juce::MessageManager::callAsync([weakThis, alive, newPlugins = std::move(newPlugins),
-                                         diskPaths = std::move(diskPaths),
                                          statusCallback]() mutable {
             auto* self = weakThis.get();
             if (!self || !*alive || !self->engine_)
@@ -343,40 +341,13 @@ void TracktionEngineWrapper::detectNewPlugins(
             auto& kp = pm.knownPluginList;
             auto& fm = pm.pluginFormatManager;
 
-            // Remove stale plugins
-            juce::Array<juce::PluginDescription> stalePlugins;
-            for (int i = 0; i < kp.getNumTypes(); ++i) {
-                auto* desc = kp.getType(i);
-                if (desc && !diskPaths.contains(desc->fileOrIdentifier)) {
-                    juce::File pluginFile(desc->fileOrIdentifier);
-                    if (pluginFile.getFullPathName().isNotEmpty() && !pluginFile.exists()) {
-                        DBG("[AutoDetect] Removing stale plugin: "
-                            << desc->name << " (" << desc->fileOrIdentifier << ")");
-                        stalePlugins.add(*desc);
-                    }
-                }
-            }
-            for (const auto& desc : stalePlugins)
-                kp.removeType(desc);
-
-            if (newPlugins.empty() && stalePlugins.isEmpty()) {
+            if (newPlugins.empty()) {
                 auto msg = "Plugins up to date (" + juce::String(kp.getNumTypes()) + " loaded)";
                 juce::Logger::writeToLog("[AutoDetect] " + msg);
                 if (statusCallback)
                     statusCallback(msg);
                 return;
             }
-
-            if (!stalePlugins.isEmpty()) {
-                auto msg = "Removed " + juce::String(stalePlugins.size()) + " stale plugin(s)";
-                juce::Logger::writeToLog("[AutoDetect] " + msg);
-                if (statusCallback)
-                    statusCallback(msg);
-                self->savePluginList();
-            }
-
-            if (newPlugins.empty())
-                return;
 
             auto msg = "Scanning " + juce::String(static_cast<int>(newPlugins.size())) +
                        " new plugin(s)...";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TEST_SOURCES
     test_plugin_loading.cpp
     test_plugin_format.cpp
     test_plugin_window_manager.cpp
+    test_prune_missing_plugins.cpp
     test_device_parameter_pagination.cpp
     test_waveform_editor_absolute_mode.cpp
     test_clip_commands.cpp

--- a/tests/test_prune_missing_plugins.cpp
+++ b/tests/test_prune_missing_plugins.cpp
@@ -1,0 +1,72 @@
+#include <juce_audio_processors/juce_audio_processors.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/engine/TracktionEngineWrapper.hpp"
+
+using magda::TracktionEngineWrapper;
+
+namespace {
+
+juce::PluginDescription makeDesc(const juce::String& name, const juce::String& fileOrId,
+                                 const juce::String& format = "VST3") {
+    juce::PluginDescription d;
+    d.name = name;
+    d.fileOrIdentifier = fileOrId;
+    d.pluginFormatName = format;
+    d.manufacturerName = "Test";
+    d.uniqueId = name.hashCode();
+    d.deprecatedUid = d.uniqueId;
+    return d;
+}
+
+bool listContainsName(const juce::KnownPluginList& list, const juce::String& name) {
+    for (int i = 0; i < list.getNumTypes(); ++i) {
+        if (auto* d = list.getType(i); d && d->name == name)
+            return true;
+    }
+    return false;
+}
+
+}  // namespace
+
+TEST_CASE("pruneMissingPlugins removes only missing absolute-path entries", "[plugin][prune]") {
+    // Create a real temp file to stand in for an existing plugin.
+    juce::TemporaryFile temp(".vst3");
+    REQUIRE(temp.getFile().create().wasOk());
+
+    juce::KnownPluginList list;
+    list.addType(makeDesc("Existing", temp.getFile().getFullPathName()));
+    list.addType(makeDesc("Missing", "/definitely/not/a/real/path/Missing.vst3"));
+    list.addType(makeDesc("AURelative", "AudioUnit:Apple:fooo,fooo,fooo", "AudioUnit"));
+
+    REQUIRE(list.getNumTypes() == 3);
+
+    const int removed = TracktionEngineWrapper::pruneMissingPlugins(list);
+
+    CHECK(removed == 1);
+    CHECK(list.getNumTypes() == 2);
+    CHECK(listContainsName(list, "Existing"));
+    CHECK_FALSE(listContainsName(list, "Missing"));
+    CHECK(listContainsName(list, "AURelative"));
+}
+
+TEST_CASE("pruneMissingPlugins is a no-op when nothing is stale", "[plugin][prune]") {
+    juce::TemporaryFile temp(".vst3");
+    REQUIRE(temp.getFile().create().wasOk());
+
+    juce::KnownPluginList list;
+    list.addType(makeDesc("Existing", temp.getFile().getFullPathName()));
+    list.addType(makeDesc("AURelative", "AudioUnit:Apple:fooo,fooo,fooo", "AudioUnit"));
+
+    const int removed = TracktionEngineWrapper::pruneMissingPlugins(list);
+
+    CHECK(removed == 0);
+    CHECK(list.getNumTypes() == 2);
+}
+
+TEST_CASE("pruneMissingPlugins handles an empty list", "[plugin][prune]") {
+    juce::KnownPluginList list;
+    CHECK(TracktionEngineWrapper::pruneMissingPlugins(list) == 0);
+    CHECK(list.getNumTypes() == 0);
+}

--- a/tests/test_prune_missing_plugins.cpp
+++ b/tests/test_prune_missing_plugins.cpp
@@ -8,6 +8,20 @@ using magda::TracktionEngineWrapper;
 
 namespace {
 
+// Build a platform-correct absolute path that is guaranteed not to exist.
+// Hard-coded "/foo/bar" style paths are NOT absolute on Windows
+// (juce::File::isAbsolutePath needs a drive letter or leading backslash),
+// so the prune helper would skip them and the test would falsely pass on
+// Unix while reporting 0 removals on Windows.
+juce::String makeAbsentAbsolutePath(const juce::String& filename) {
+    auto path = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                    .getChildFile("magda_prune_test_does_not_exist")
+                    .getChildFile(filename);
+    REQUIRE(juce::File::isAbsolutePath(path.getFullPathName()));
+    REQUIRE_FALSE(path.exists());
+    return path.getFullPathName();
+}
+
 juce::PluginDescription makeDesc(const juce::String& name, const juce::String& fileOrId,
                                  const juce::String& format = "VST3") {
     juce::PluginDescription d;
@@ -37,7 +51,7 @@ TEST_CASE("pruneMissingPlugins removes only missing absolute-path entries", "[pl
 
     juce::KnownPluginList list;
     list.addType(makeDesc("Existing", temp.getFile().getFullPathName()));
-    list.addType(makeDesc("Missing", "/definitely/not/a/real/path/Missing.vst3"));
+    list.addType(makeDesc("Missing", makeAbsentAbsolutePath("Missing.vst3")));
     list.addType(makeDesc("AURelative", "AudioUnit:Apple:fooo,fooo,fooo", "AudioUnit"));
 
     REQUIRE(list.getNumTypes() == 3);


### PR DESCRIPTION
When a VST/VST3 was uninstalled, its entry stayed in MAGDA's plugin list until the user manually triggered a full rescan — on Windows users mostly never do, so stale entries accumulated in the plugin browser. The flag that could have caught it (scanPluginsOnStartup) defaults off and was also responsible for detecting newly installed plugins; users who didn't want an expensive startup scan lost the cleanup too.

Split the two concerns:

- New pruneMissingPlugins() — stat-only, no plugin scanning. Iterates the KnownPluginList, drops entries whose fileOrIdentifier no longer exists on disk, and persists the result.
- Called unconditionally after loadPluginList() on every startup, so uninstalled plugins disappear without any user action or config.
- scanPluginsOnStartup now genuinely means "detect new plugins on startup" — detectNewPlugins no longer handles stale removal.
- startPluginScan's duplicated prune block now just calls the new method.