### PR TITLE
fix: tone generator UI controls and mod links bound to wrong TE params

### DIFF
--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -455,6 +455,8 @@ void AudioBridge::deviceParameterChanged(DeviceId deviceId, int paramIndex, floa
     // Use setParameterByIndex for efficient single-param sync
     if (auto* extProcessor = dynamic_cast<ExternalPluginProcessor*>(processor)) {
         extProcessor->setParameterByIndex(paramIndex, newValue);
+    } else if (auto* toneProc = dynamic_cast<ToneGeneratorProcessor*>(processor)) {
+        toneProc->setParameterByIndex(paramIndex, newValue);
     } else if (auto* samplerProc = dynamic_cast<MagdaSamplerProcessor*>(processor)) {
         samplerProc->setParameterByIndex(paramIndex, newValue);
     } else if (auto* fourOscProc = dynamic_cast<FourOscProcessor*>(processor)) {

--- a/magda/daw/audio/DeviceProcessor.cpp
+++ b/magda/daw/audio/DeviceProcessor.cpp
@@ -247,6 +247,8 @@ ParameterInfo ToneGeneratorProcessor::getParameterInfo(int index) const {
             info.unit = "";
             info.minValue = 0.0f;
             info.maxValue = 5.0f;
+            info.teMinValue = 0.0f;
+            info.teMaxValue = 5.0f;
             info.defaultValue = 0.0f;
             info.currentValue = static_cast<float>(getOscType());
             info.scale = ParameterScale::Discrete;
@@ -258,30 +260,39 @@ ParameterInfo ToneGeneratorProcessor::getParameterInfo(int index) const {
             info.unit = "";
             info.minValue = 0.0f;
             info.maxValue = 1.0f;
+            info.teMinValue = 0.0f;
+            info.teMaxValue = 1.0f;
             info.defaultValue = 0.0f;
             info.currentValue = getBandLimit() ? 1.0f : 0.0f;
-            info.scale = ParameterScale::Discrete;
+            info.scale = ParameterScale::Boolean;
+            info.modulatable = false;
             info.choices = {"Aliased", "Band Limited"};
             break;
 
-        case 2: {  // Frequency
+        case 2: {  // Frequency (log sweep, 1 kHz at visual midpoint)
             info.name = "Frequency";
             info.unit = "Hz";
             info.minValue = 20.0f;
             info.maxValue = 20000.0f;
+            info.teMinValue = 20.0f;
+            info.teMaxValue = 20000.0f;
             info.defaultValue = 440.0f;
             info.scale = ParameterScale::Logarithmic;
+            info.scaleAnchor = 1000.0f;
             info.currentValue = juce::jlimit(20.0f, 20000.0f, getFrequency());
             break;
         }
 
-        case 3: {  // Level - display as dB
+        case 3: {  // Level — UI is in dB; plugin-native is linear, converted at the bridge
             info.name = "Level";
             info.unit = "dB";
             info.minValue = -60.0f;
             info.maxValue = 0.0f;
+            info.teMinValue = -60.0f;
+            info.teMaxValue = 0.0f;
             info.defaultValue = -12.0f;  // 0.25 linear ≈ -12 dB
             info.scale = ParameterScale::Linear;
+            info.displayFormat = DisplayFormat::Decibels;
             float level = getLevel();
             float db = level > 0.0f ? juce::Decibels::gainToDecibels(level, -60.0f) : -60.0f;
             info.currentValue = juce::jlimit(-60.0f, 0.0f, db);

--- a/magda/daw/audio/DeviceProcessor.cpp
+++ b/magda/daw/audio/DeviceProcessor.cpp
@@ -184,9 +184,10 @@ void ToneGeneratorProcessor::initializeDefaults() {
         return;
 
     // Set default values using the proper setters (they handle null checks internally)
+    setOscType(0);  // TE sine
+    setBandLimit(false);
     setFrequency(440.0f);
     setLevel(0.25f);
-    setOscType(0);  // Sine wave
 
     initialized_ = true;
 }
@@ -196,45 +197,44 @@ te::ToneGeneratorPlugin* ToneGeneratorProcessor::getTonePlugin() const {
 }
 
 void ToneGeneratorProcessor::setParameter(const juce::String& paramName, float value) {
-    if (paramName.equalsIgnoreCase("frequency") || paramName.equalsIgnoreCase("freq")) {
-        // Value is actual Hz (20-20000)
+    if (paramName.equalsIgnoreCase("oscType") || paramName.equalsIgnoreCase("type") ||
+        paramName.equalsIgnoreCase("waveform")) {
+        setOscType(static_cast<int>(std::round(value)));
+    } else if (paramName.equalsIgnoreCase("bandLimit")) {
+        setBandLimit(value >= 0.5f);
+    } else if (paramName.equalsIgnoreCase("frequency") || paramName.equalsIgnoreCase("freq")) {
         setFrequency(value);
     } else if (paramName.equalsIgnoreCase("level") || paramName.equalsIgnoreCase("gain") ||
                paramName.equalsIgnoreCase("volume")) {
-        // Value is actual dB (-60 to +6)
-        float level = juce::Decibels::decibelsToGain(value, -60.0f);
-        setLevel(level);
-    } else if (paramName.equalsIgnoreCase("oscType") || paramName.equalsIgnoreCase("type") ||
-               paramName.equalsIgnoreCase("waveform")) {
-        // Value is actual choice index (0 or 1)
-        int type = static_cast<int>(std::round(value));
-        setOscType(type);
+        // Value is dB; convert to linear for the plugin
+        setLevel(juce::Decibels::decibelsToGain(value, -60.0f));
     }
 }
 
 float ToneGeneratorProcessor::getParameter(const juce::String& paramName) const {
-    if (paramName.equalsIgnoreCase("frequency") || paramName.equalsIgnoreCase("freq")) {
-        // Return actual Hz (20-20000)
+    if (paramName.equalsIgnoreCase("oscType") || paramName.equalsIgnoreCase("type") ||
+        paramName.equalsIgnoreCase("waveform")) {
+        return static_cast<float>(getOscType());
+    } else if (paramName.equalsIgnoreCase("bandLimit")) {
+        return getBandLimit() ? 1.0f : 0.0f;
+    } else if (paramName.equalsIgnoreCase("frequency") || paramName.equalsIgnoreCase("freq")) {
         return getFrequency();
     } else if (paramName.equalsIgnoreCase("level") || paramName.equalsIgnoreCase("gain") ||
                paramName.equalsIgnoreCase("volume")) {
-        // Return actual dB (-60 to 0)
         float level = getLevel();
         return juce::Decibels::gainToDecibels(level, -60.0f);
-    } else if (paramName.equalsIgnoreCase("oscType") || paramName.equalsIgnoreCase("type") ||
-               paramName.equalsIgnoreCase("waveform")) {
-        // Return actual choice index (0 or 1)
-        return static_cast<float>(getOscType());
     }
     return 0.0f;
 }
 
 std::vector<juce::String> ToneGeneratorProcessor::getParameterNames() const {
-    return {"frequency", "level", "oscType"};
+    // Order matches te::ToneGeneratorPlugin::getAutomatableParameters() so
+    // mod/macro links resolve to the correct TE parameter.
+    return {"oscType", "bandLimit", "frequency", "level"};
 }
 
 int ToneGeneratorProcessor::getParameterCount() const {
-    return 3;  // frequency, level, oscType
+    return 4;
 }
 
 ParameterInfo ToneGeneratorProcessor::getParameterInfo(int index) const {
@@ -242,49 +242,76 @@ ParameterInfo ToneGeneratorProcessor::getParameterInfo(int index) const {
     info.paramIndex = index;
 
     switch (index) {
-        case 0: {  // Frequency
+        case 0:  // Oscillator Type (TE enum 0-5)
+            info.name = "Waveform";
+            info.unit = "";
+            info.minValue = 0.0f;
+            info.maxValue = 5.0f;
+            info.defaultValue = 0.0f;
+            info.currentValue = static_cast<float>(getOscType());
+            info.scale = ParameterScale::Discrete;
+            info.choices = {"Sine", "Triangle", "Saw Up", "Saw Down", "Square", "Noise"};
+            break;
+
+        case 1:  // Band Limit
+            info.name = "Band Limit";
+            info.unit = "";
+            info.minValue = 0.0f;
+            info.maxValue = 1.0f;
+            info.defaultValue = 0.0f;
+            info.currentValue = getBandLimit() ? 1.0f : 0.0f;
+            info.scale = ParameterScale::Discrete;
+            info.choices = {"Aliased", "Band Limited"};
+            break;
+
+        case 2: {  // Frequency
             info.name = "Frequency";
             info.unit = "Hz";
             info.minValue = 20.0f;
             info.maxValue = 20000.0f;
             info.defaultValue = 440.0f;
             info.scale = ParameterScale::Logarithmic;
-            // Store actual value in Hz
             info.currentValue = juce::jlimit(20.0f, 20000.0f, getFrequency());
             break;
         }
 
-        case 1: {  // Level - display as dB
+        case 3: {  // Level - display as dB
             info.name = "Level";
             info.unit = "dB";
             info.minValue = -60.0f;
             info.maxValue = 0.0f;
             info.defaultValue = -12.0f;  // 0.25 linear ≈ -12 dB
             info.scale = ParameterScale::Linear;
-            // Store actual value in dB
             float level = getLevel();
             float db = level > 0.0f ? juce::Decibels::gainToDecibels(level, -60.0f) : -60.0f;
             info.currentValue = juce::jlimit(-60.0f, 0.0f, db);
             break;
         }
 
-        case 2:  // Oscillator Type
-            info.name = "Waveform";
-            info.unit = "";
-            info.minValue = 0.0f;
-            info.maxValue = 1.0f;
-            info.defaultValue = 0.0f;
-            // Store actual value (choice index)
-            info.currentValue = static_cast<float>(getOscType());  // 0 or 1
-            info.scale = ParameterScale::Discrete;
-            info.choices = {"Sine", "Noise"};
-            break;
-
         default:
             break;
     }
 
     return info;
+}
+
+void ToneGeneratorProcessor::setParameterByIndex(int paramIndex, float value) {
+    switch (paramIndex) {
+        case 0:  // Oscillator type (TE enum 0-5)
+            setOscType(static_cast<int>(std::round(value)));
+            break;
+        case 1:  // Band limit
+            setBandLimit(value >= 0.5f);
+            break;
+        case 2:  // Frequency (Hz)
+            setFrequency(value);
+            break;
+        case 3:  // Level (dB from UI, convert to linear for plugin)
+            setLevel(juce::Decibels::decibelsToGain(value, -60.0f));
+            break;
+        default:
+            break;
+    }
 }
 
 void ToneGeneratorProcessor::setFrequency(float hz) {
@@ -323,13 +350,10 @@ float ToneGeneratorProcessor::getLevel() const {
     return 0.25f;
 }
 
-void ToneGeneratorProcessor::setOscType(int type) {
+void ToneGeneratorProcessor::setOscType(int teOscType) {
     if (auto* tone = getTonePlugin()) {
-        // Map our 0/1 (sine/noise) to TE's 0/5 (sin/noise)
         // TE enum: 0=sin, 1=triangle, 2=sawUp, 3=sawDown, 4=square, 5=noise
-        float teType = (type == 0) ? 0.0f : 5.0f;  // 0→sin, 1→noise
-
-        // Set via AutomatableParameter - proper Tracktion Engine way
+        float teType = static_cast<float>(juce::jlimit(0, 5, teOscType));
         if (tone->oscTypeParam) {
             tone->oscTypeParam->setParameter(teType, juce::dontSendNotification);
         }
@@ -338,11 +362,25 @@ void ToneGeneratorProcessor::setOscType(int type) {
 
 int ToneGeneratorProcessor::getOscType() const {
     if (auto* tone = getTonePlugin()) {
-        // Map TE's 0/5 back to our 0/1
-        int teType = static_cast<int>(tone->oscType);
-        return (teType == 5) ? 1 : 0;  // noise→1, everything else→0 (sine)
+        return juce::jlimit(0, 5, static_cast<int>(tone->oscType));
     }
-    return 0;  // Sine
+    return 0;
+}
+
+void ToneGeneratorProcessor::setBandLimit(bool bandLimited) {
+    if (auto* tone = getTonePlugin()) {
+        if (tone->bandLimitParam) {
+            tone->bandLimitParam->setParameter(bandLimited ? 1.0f : 0.0f,
+                                               juce::dontSendNotification);
+        }
+    }
+}
+
+bool ToneGeneratorProcessor::getBandLimit() const {
+    if (auto* tone = getTonePlugin()) {
+        return static_cast<float>(tone->bandLimit) >= 0.5f;
+    }
+    return false;
 }
 
 void ToneGeneratorProcessor::applyGain() {

--- a/magda/daw/audio/DeviceProcessor.hpp
+++ b/magda/daw/audio/DeviceProcessor.hpp
@@ -170,10 +170,12 @@ class DeviceProcessor {
 /**
  * @brief Processor for the built-in Tone Generator device
  *
- * Parameters:
- * - frequency: Tone frequency in Hz (20-20000)
- * - level: Output level (0-1 linear, maps to amplitude)
- * - oscType: Oscillator type (0=sine, 1=square, 2=saw, 3=noise)
+ * Parameter indexing matches TE's ToneGeneratorPlugin::getAutomatableParameters()
+ * so that mod/macro links resolve to the correct TE parameter:
+ * - 0: oscType  (discrete, 0=Sine .. 5=Noise — matches te::ToneGeneratorPlugin::OscType)
+ * - 1: bandLimit (discrete, 0=Aliased, 1=Band Limited — not shown in MAGDA UI)
+ * - 2: frequency (Hz, 20-20000, logarithmic)
+ * - 3: level     (dB in UI, linear 0-1 on the plugin)
  */
 class ToneGeneratorProcessor : public DeviceProcessor {
   public:
@@ -185,6 +187,9 @@ class ToneGeneratorProcessor : public DeviceProcessor {
     int getParameterCount() const override;
     ParameterInfo getParameterInfo(int index) const override;
 
+    // Single-parameter sync from DeviceInfo (values in real units: TE osc enum / bandLimit / Hz / dB)
+    void setParameterByIndex(int paramIndex, float value);
+
     // Initialize with default values - call after processor is fully set up
     void initializeDefaults();
 
@@ -195,8 +200,11 @@ class ToneGeneratorProcessor : public DeviceProcessor {
     void setLevel(float level);  // 0-1 linear
     float getLevel() const;
 
-    void setOscType(int type);  // 0=sine, 1=noise
+    void setOscType(int teOscType);  // TE enum: 0=sin,1=triangle,2=sawUp,3=sawDown,4=square,5=noise
     int getOscType() const;
+
+    void setBandLimit(bool bandLimited);
+    bool getBandLimit() const;
 
   protected:
     void applyGain() override;

--- a/magda/daw/ui/components/chain/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/DeviceCustomUIManager.cpp
@@ -990,10 +990,12 @@ void DeviceCustomUIManager::update(const magda::DeviceInfo& device) {
         float level = -12.0f;
         int waveform = 0;
 
-        if (device.parameters.size() >= 3) {
-            frequency = device.parameters[0].currentValue;
-            level = device.parameters[1].currentValue;
-            waveform = static_cast<int>(device.parameters[2].currentValue);
+        // ToneGeneratorProcessor exposes params in TE order: 0=oscType, 1=bandLimit,
+        // 2=frequency, 3=level. Match that here.
+        if (device.parameters.size() >= 4) {
+            waveform = static_cast<int>(device.parameters[0].currentValue);
+            frequency = device.parameters[2].currentValue;
+            level = device.parameters[3].currentValue;
         }
 
         toneGeneratorUI_->updateParameters(frequency, level, waveform);

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -3195,21 +3195,16 @@ void DeviceSlotComponent::refreshCustomUIParameterValues() {
 
 void DeviceSlotComponent::updateCustomUI() {
     if (toneGeneratorUI_ && device_.pluginId.containsIgnoreCase("tone")) {
-        // Extract parameters from device (stored as actual values)
         float frequency = 440.0f;
         float level = -12.0f;
         int waveform = 0;
 
-        // Read from device parameters if available
-        if (device_.parameters.size() >= 3) {
-            // Param 0: Frequency (actual Hz)
-            frequency = device_.parameters[0].currentValue;
-
-            // Param 1: Level (actual dB)
-            level = device_.parameters[1].currentValue;
-
-            // Param 2: Waveform (actual choice index: 0 or 1)
-            waveform = static_cast<int>(device_.parameters[2].currentValue);
+        // ToneGeneratorProcessor exposes params in TE order:
+        // 0=oscType (TE enum 0-5), 1=bandLimit, 2=frequency (Hz), 3=level (dB).
+        if (device_.parameters.size() >= 4) {
+            waveform = static_cast<int>(device_.parameters[0].currentValue);
+            frequency = device_.parameters[2].currentValue;
+            level = device_.parameters[3].currentValue;
         }
 
         toneGeneratorUI_->updateParameters(frequency, level, waveform);

--- a/magda/daw/ui/components/chain/ToneGeneratorUI.cpp
+++ b/magda/daw/ui/components/chain/ToneGeneratorUI.cpp
@@ -6,30 +6,32 @@
 namespace magda::daw::ui {
 
 ToneGeneratorUI::ToneGeneratorUI() {
-    // Waveform selector
+    // Waveform selector — IDs are TE oscType + 1 so (selectedId - 1) is the TE enum value.
+    // TE enum: 0=Sine, 1=Triangle, 2=Saw Up, 3=Saw Down, 4=Square, 5=Noise
     waveformSelector_.addItem("Sine", 1);
-    waveformSelector_.addItem("Noise", 2);
+    waveformSelector_.addItem("Triangle", 2);
+    waveformSelector_.addItem("Saw Up", 3);
+    waveformSelector_.addItem("Saw Down", 4);
+    waveformSelector_.addItem("Square", 5);
+    waveformSelector_.addItem("Noise", 6);
     waveformSelector_.setSelectedId(1, juce::dontSendNotification);
     waveformSelector_.onChange = [this]() {
-        int waveform = waveformSelector_.getSelectedId() - 1;  // 0=Sine, 1=Noise
+        int teValue = waveformSelector_.getSelectedId() - 1;
         if (onParameterChanged) {
-            // Send actual choice index (0 or 1)
-            onParameterChanged(2, static_cast<float>(waveform));
+            onParameterChanged(0, static_cast<float>(teValue));  // Param 0 = oscType (TE enum)
         }
     };
     addAndMakeVisible(waveformSelector_);
 
-    // Frequency slider (20 Hz - 20 kHz, log-scaled drag)
+    // Frequency slider (20 Hz - 20 kHz, log-scaled drag). Param index 2 in TE's ordering.
+    frequencySlider_.setParamIndex(2);
     frequencySlider_.setRange(20.0, 20000.0, 0.1);
     frequencySlider_.setSkewForCentre(1000.0);
     frequencySlider_.setValue(440.0, juce::dontSendNotification);
-    // Custom formatter to display Hz/kHz
     frequencySlider_.setValueFormatter(
         [this](double value) { return formatFrequency(static_cast<float>(value)); });
-    // Custom parser to read Hz/kHz input
     frequencySlider_.setValueParser([](const juce::String& text) {
         juce::String trimmed = text.trim();
-        // Remove "Hz" or "kHz" suffix
         if (trimmed.endsWithIgnoreCase("khz")) {
             float kHz = trimmed.dropLastCharacters(3).trim().getFloatValue();
             return static_cast<double>(kHz * 1000.0f);
@@ -40,32 +42,29 @@ ToneGeneratorUI::ToneGeneratorUI() {
     });
     frequencySlider_.onValueChanged = [this](double value) {
         if (onParameterChanged) {
-            // Send actual Hz value (20-20000)
-            onParameterChanged(0, static_cast<float>(value));  // Param 0 = frequency
+            onParameterChanged(2, static_cast<float>(value));
         }
     };
     addAndMakeVisible(frequencySlider_);
 
-    // Level slider (-60 to 0 dB)
+    // Level slider (-60 to 0 dB). Param index 3 in TE's ordering.
+    levelSlider_.setParamIndex(3);
     levelSlider_.setRange(-60.0, 0.0, 0.1);
     levelSlider_.setValue(-12.0, juce::dontSendNotification);
     levelSlider_.onValueChanged = [this](double value) {
         if (onParameterChanged) {
-            // Send actual dB value (-60 to 0)
-            onParameterChanged(1, static_cast<float>(value));  // Param 1 = level
+            onParameterChanged(3, static_cast<float>(value));
         }
     };
     addAndMakeVisible(levelSlider_);
 }
 
 void ToneGeneratorUI::updateParameters(float frequency, float level, int waveform) {
-    // Update waveform selector
-    waveformSelector_.setSelectedId(waveform + 1, juce::dontSendNotification);
+    // waveform is the TE enum value (0-5); combo IDs are TE value + 1
+    int teValue = juce::jlimit(0, 5, waveform);
+    waveformSelector_.setSelectedId(teValue + 1, juce::dontSendNotification);
 
-    // Update frequency slider
     frequencySlider_.setValue(frequency, juce::dontSendNotification);
-
-    // Update level slider
     levelSlider_.setValue(level, juce::dontSendNotification);
 }
 

--- a/magda/daw/ui/components/chain/ToneGeneratorUI.cpp
+++ b/magda/daw/ui/components/chain/ToneGeneratorUI.cpp
@@ -23,23 +23,10 @@ ToneGeneratorUI::ToneGeneratorUI() {
     };
     addAndMakeVisible(waveformSelector_);
 
-    // Frequency slider (20 Hz - 20 kHz, log-scaled drag). Param index 2 in TE's ordering.
+    // Frequency slider — range, skew, and Hz/kHz format/parse are populated by
+    // DeviceSlotComponent via setParameterInfo() from the processor's ParameterInfo
+    // (unit="Hz", scale=Logarithmic, scaleAnchor=1000). Param index 2 in TE's ordering.
     frequencySlider_.setParamIndex(2);
-    frequencySlider_.setRange(20.0, 20000.0, 0.1);
-    frequencySlider_.setSkewForCentre(1000.0);
-    frequencySlider_.setValue(440.0, juce::dontSendNotification);
-    frequencySlider_.setValueFormatter(
-        [this](double value) { return formatFrequency(static_cast<float>(value)); });
-    frequencySlider_.setValueParser([](const juce::String& text) {
-        juce::String trimmed = text.trim();
-        if (trimmed.endsWithIgnoreCase("khz")) {
-            float kHz = trimmed.dropLastCharacters(3).trim().getFloatValue();
-            return static_cast<double>(kHz * 1000.0f);
-        } else if (trimmed.endsWithIgnoreCase("hz")) {
-            return static_cast<double>(trimmed.dropLastCharacters(2).trim().getFloatValue());
-        }
-        return static_cast<double>(trimmed.getFloatValue());
-    });
     frequencySlider_.onValueChanged = [this](double value) {
         if (onParameterChanged) {
             onParameterChanged(2, static_cast<float>(value));
@@ -47,10 +34,9 @@ ToneGeneratorUI::ToneGeneratorUI() {
     };
     addAndMakeVisible(frequencySlider_);
 
-    // Level slider (-60 to 0 dB). Param index 3 in TE's ordering.
+    // Level slider — range and dB formatting come from the processor's ParameterInfo
+    // via setParameterInfo(). Param index 3 in TE's ordering.
     levelSlider_.setParamIndex(3);
-    levelSlider_.setRange(-60.0, 0.0, 0.1);
-    levelSlider_.setValue(-12.0, juce::dontSendNotification);
     levelSlider_.onValueChanged = [this](double value) {
         if (onParameterChanged) {
             onParameterChanged(3, static_cast<float>(value));
@@ -97,22 +83,8 @@ void ToneGeneratorUI::resized() {
 }
 
 std::vector<LinkableTextSlider*> ToneGeneratorUI::getLinkableSliders() {
-    // ParamIndex: 0=frequency, 1=level (waveform is a combo, not a slider)
+    // Sliders carry their TE param index via setParamIndex (2 = frequency, 3 = level).
     return {&frequencySlider_, &levelSlider_};
-}
-
-juce::String ToneGeneratorUI::formatFrequency(float hz) const {
-    if (hz >= 1000.0f) {
-        float kHz = hz / 1000.0f;
-        if (kHz >= 10.0f) {
-            return juce::String(kHz, 1) + " kHz";
-        }
-        return juce::String(kHz, 2) + " kHz";
-    }
-    if (hz >= 100.0f) {
-        return juce::String(static_cast<int>(hz)) + " Hz";
-    }
-    return juce::String(hz, 1) + " Hz";
 }
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/ToneGeneratorUI.hpp
+++ b/magda/daw/ui/components/chain/ToneGeneratorUI.hpp
@@ -53,9 +53,6 @@ class ToneGeneratorUI : public juce::Component {
     // Level slider (-60 to 0 dB)
     LinkableTextSlider levelSlider_{TextSlider::Format::Decibels};
 
-    // Convert frequency to display string (for formatter)
-    juce::String formatFrequency(float hz) const;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ToneGeneratorUI)
 };
 

--- a/magda/daw/ui/components/chain/ToneGeneratorUI.hpp
+++ b/magda/daw/ui/components/chain/ToneGeneratorUI.hpp
@@ -25,14 +25,15 @@ class ToneGeneratorUI : public juce::Component {
      * @brief Update UI from device parameters
      * @param frequency Frequency in Hz (20-20000)
      * @param level Level in dB (-60 to 0)
-     * @param waveform Waveform type (0=Sine, 1=Noise)
+     * @param waveform TE oscType enum (0=Sine, 1=Triangle, 2=Saw Up, 3=Saw Down, 4=Square, 5=Noise)
      */
     void updateParameters(float frequency, float level, int waveform);
 
     /**
      * @brief Callback when a parameter changes (paramIndex, actualValue)
-     * ParamIndex: 0=frequency, 1=level, 2=waveform
-     * Values are in real units (Hz, dB, choice index)
+     * ParamIndex matches TE's ToneGeneratorPlugin ordering:
+     *   0=oscType (TE enum 0-5), 2=frequency (Hz), 3=level (dB)
+     * bandLimit (index 1) is not exposed in this UI.
      */
     std::function<void(int paramIndex, float actualValue)> onParameterChanged;
 

--- a/magda/daw/ui/components/common/LinkableTextSlider.cpp
+++ b/magda/daw/ui/components/common/LinkableTextSlider.cpp
@@ -193,6 +193,10 @@ bool LinkableTextSlider::isBeingDragged() const {
 // Linking context setters
 // ============================================================================
 
+void LinkableTextSlider::setParamIndex(int paramIndex) {
+    paramIndex_ = paramIndex;
+}
+
 void LinkableTextSlider::setLinkContext(magda::DeviceId deviceId, int paramIndex,
                                         const magda::ChainNodePath& devicePath) {
     deviceId_ = deviceId;

--- a/magda/daw/ui/components/common/LinkableTextSlider.hpp
+++ b/magda/daw/ui/components/common/LinkableTextSlider.hpp
@@ -44,6 +44,10 @@ class LinkableTextSlider : public juce::Component,
     // === Linking context (set by parent custom UI) ===
     void setLinkContext(magda::DeviceId deviceId, int paramIndex,
                         const magda::ChainNodePath& devicePath);
+    // Pre-set paramIndex before setLinkContext runs. Use when the processor's
+    // parameter ordering (e.g. TE's oscType/bandLimit/freq/level for the Tone
+    // Generator) doesn't match the slider's position in getLinkableSliders().
+    void setParamIndex(int paramIndex);
     void setAvailableMods(const magda::ModArray* mods);
     void setAvailableMacros(const magda::MacroArray* macros);
     void setAvailableRackMods(const magda::ModArray* rackMods);


### PR DESCRIPTION
The Tone Generator's frequency, level, and waveform controls had no effect beyond the initial defaults because AudioBridge::deviceParameterChanged had no dispatch branch for ToneGeneratorProcessor. Worse, mod/macro links resolved via plugin->getAutomatableParameters()[paramIndex], but ToneGeneratorProcessor exposed params in a different order than TE's [oscType, bandLimit, frequency, level] — so an LFO linked to the "frequency" slider was actually modulating oscType, which is why switching to Noise got stuck on Sine after adding modulation (#1065).

- ToneGeneratorProcessor: reorder param indexing to match TE's native ordering (0=oscType, 1=bandLimit, 2=frequency, 3=level). setOscType now takes the TE enum directly (0-5). Added setBandLimit.
- AudioBridge: add ToneGeneratorProcessor branch in deviceParameterChanged.
- ToneGeneratorUI: expose all six TE shapes (Sine/Triangle/Saw Up/Saw Down/ Square/Noise); sliders explicitly set paramIdx to their TE index.
- LinkableTextSlider: add setParamIndex() so a UI can pre-declare a slider's paramIdx when TE's ordering has gaps (bandLimit between the two visible sliders).
- DeviceCustomUIManager, DeviceSlotComponent: read tone params from the new indices 0/2/3.