### PR TITLE
feat: HiDPI / UI scaling support (#1061)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -364,6 +364,9 @@
     "language.label": "UI Language",
     "language.restart_required": "Restart required for language change to fully apply.",
 
+    "scale.label": "UI Scale",
+    "scale.auto": "Auto (from display DPI)",
+
     "tab.general": "General",
     "tab.ui": "UI",
     "tab.colours": "Colours",
@@ -376,6 +379,7 @@
     "section.panels": "Panels",
     "section.layout": "Layout",
     "section.behavior": "Behavior",
+    "section.scale": "Display Scale",
     "section.track_colour_palette": "Track Colour Palette",
     "section.clip_colours": "Clip Colours",
     "section.output": "Output",

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -218,6 +218,7 @@ set(DAW_CORE_SOURCES
     command.cpp
     magda.cpp
     core/Config.cpp
+    core/UIScale.cpp
     core/UpdateChecker.cpp
     core/ViewModeController.cpp
     core/TrackManager.cpp
@@ -488,6 +489,7 @@ set(DAW_HEADERS
     profiling/PerformanceProfiler.hpp
     profiling/BenchmarkSuite.hpp
     core/Config.hpp
+    core/UIScale.hpp
     core/DeviceInfo.hpp
     core/ViewModeState.hpp
     core/ViewModeEvents.hpp

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -86,6 +86,7 @@ void Config::save() {
 
     // UI / behaviour
     root->setProperty("scrollbarOnLeft", scrollbarOnLeft);
+    root->setProperty("uiScale", uiScale);
     root->setProperty("confirmTrackDelete", confirmTrackDelete);
     root->setProperty("showTooltips", showTooltips);
     root->setProperty("autoMonitorSelectedTrack", autoMonitorSelectedTrack);
@@ -302,6 +303,7 @@ void Config::load() {
 
     language = getString("language", language);
     scrollbarOnLeft = getBool("scrollbarOnLeft", scrollbarOnLeft);
+    uiScale = getDouble("uiScale", uiScale);
     confirmTrackDelete = getBool("confirmTrackDelete", confirmTrackDelete);
     showTooltips = getBool("showTooltips", showTooltips);
     autoMonitorSelectedTrack = getBool("autoMonitorSelectedTrack", autoMonitorSelectedTrack);

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -178,6 +178,15 @@ class Config {
         scrollbarOnLeft = onLeft;
     }
 
+    // UI scale factor for HiDPI displays.
+    // 0 = Auto (pick from primary display DPI at startup); >0 = explicit factor (e.g. 1.5).
+    double getUIScale() const {
+        return uiScale;
+    }
+    void setUIScale(double scale) {
+        uiScale = scale;
+    }
+
     // Audio Device Configuration
     std::string getPreferredAudioDevice() const {
         return preferredAudioDevice;
@@ -661,6 +670,9 @@ class Config {
 
     // Layout settings
     bool scrollbarOnLeft = false;  // Scrollbar on right by default
+
+    // UI scale: 0 = Auto (pick from display DPI), otherwise an explicit factor (1.0, 1.25, …)
+    double uiScale = 0.0;
 
     // Recent projects (most recent first, max 10)
     std::vector<std::string> recentProjects;

--- a/magda/daw/core/UIScale.cpp
+++ b/magda/daw/core/UIScale.cpp
@@ -2,6 +2,7 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
+#include <cmath>
 #include <cstdlib>
 
 #include "Config.hpp"
@@ -28,6 +29,12 @@ double autoScaleForDpi(double dpi) {
 
 }  // namespace
 
+double dpiOnlyAutoScale() {
+    if (auto* d = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay())
+        return autoScaleForDpi(d->dpi);
+    return 1.0;
+}
+
 double resolveStartupScale() {
     if (const char* env = std::getenv("MAGDA_UI_SCALE")) {
         char* end = nullptr;
@@ -39,16 +46,16 @@ double resolveStartupScale() {
     if (configured > 0.0)
         return clampScale(configured);
 
-    if (auto* d = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay())
-        return autoScaleForDpi(d->dpi);
-    return 1.0;
+    return dpiOnlyAutoScale();
 }
 
-void applyUIScale(double scale) {
+void applyUIScale(double scale, bool persist) {
     scale = clampScale(scale);
     juce::Desktop::getInstance().setGlobalScaleFactor(static_cast<float>(scale));
-    Config::getInstance().setUIScale(scale);
-    Config::getInstance().save();
+    if (persist) {
+        Config::getInstance().setUIScale(scale);
+        Config::getInstance().save();
+    }
 
     // Force every top-level window to re-lay-out and repaint. setGlobalScaleFactor
     // updates the peer's scale, but cached child layouts won't reflect it until

--- a/magda/daw/core/UIScale.cpp
+++ b/magda/daw/core/UIScale.cpp
@@ -1,0 +1,88 @@
+#include "UIScale.hpp"
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <cstdlib>
+
+#include "Config.hpp"
+
+namespace magda {
+
+namespace {
+
+double clampScale(double s) {
+    if (s < kMinUIScale)
+        return kMinUIScale;
+    if (s > kMaxUIScale)
+        return kMaxUIScale;
+    return s;
+}
+
+double autoScaleForDpi(double dpi) {
+    if (dpi < 140.0)
+        return 1.0;
+    if (dpi <= 180.0)
+        return 1.5;
+    return 2.0;
+}
+
+}  // namespace
+
+double resolveStartupScale() {
+    if (const char* env = std::getenv("MAGDA_UI_SCALE")) {
+        char* end = nullptr;
+        double v = std::strtod(env, &end);
+        if (end != env && v > 0.0)
+            return clampScale(v);
+    }
+    double configured = Config::getInstance().getUIScale();
+    if (configured > 0.0)
+        return clampScale(configured);
+
+    if (auto* d = juce::Desktop::getInstance().getDisplays().getPrimaryDisplay())
+        return autoScaleForDpi(d->dpi);
+    return 1.0;
+}
+
+void applyUIScale(double scale) {
+    scale = clampScale(scale);
+    juce::Desktop::getInstance().setGlobalScaleFactor(static_cast<float>(scale));
+    Config::getInstance().setUIScale(scale);
+    Config::getInstance().save();
+
+    // Force every top-level window to re-lay-out and repaint. setGlobalScaleFactor
+    // updates the peer's scale, but cached child layouts won't reflect it until
+    // we kick a resize.
+    auto& desktop = juce::Desktop::getInstance();
+    for (int i = 0; i < desktop.getNumComponents(); ++i) {
+        if (auto* c = desktop.getComponent(i)) {
+            c->resized();
+            c->repaint();
+        }
+    }
+}
+
+double stepUIScale(double current, int direction) {
+    if (kUIScaleSteps.empty())
+        return current;
+
+    // Find index of the step nearest to `current`.
+    size_t nearest = 0;
+    double bestDiff = std::abs(current - kUIScaleSteps[0]);
+    for (size_t i = 1; i < kUIScaleSteps.size(); ++i) {
+        double d = std::abs(current - kUIScaleSteps[i]);
+        if (d < bestDiff) {
+            bestDiff = d;
+            nearest = i;
+        }
+    }
+
+    long next = static_cast<long>(nearest) + (direction > 0 ? 1 : -1);
+    if (next < 0)
+        next = 0;
+    if (next >= static_cast<long>(kUIScaleSteps.size()))
+        next = static_cast<long>(kUIScaleSteps.size()) - 1;
+    return kUIScaleSteps[static_cast<size_t>(next)];
+}
+
+}  // namespace magda

--- a/magda/daw/core/UIScale.hpp
+++ b/magda/daw/core/UIScale.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <array>
+
+namespace magda {
+
+// Allowed scale factors for keyboard cycling. The Preferences combo offers the
+// same set plus "Auto" (resolved at startup from display DPI).
+inline constexpr std::array<double, 5> kUIScaleSteps = {1.0, 1.25, 1.5, 1.75, 2.0};
+
+// Sane bounds for any scale factor we apply — guards against a fat-fingered
+// env var or stale config locking the user out by making everything microscopic
+// or huge.
+inline constexpr double kMinUIScale = 0.5;
+inline constexpr double kMaxUIScale = 4.0;
+
+// Resolve the scale to use at app startup.
+// Precedence: MAGDA_UI_SCALE env var > Config::getUIScale() > auto from DPI.
+// Returns a value in [kMinUIScale, kMaxUIScale]. Safe to call before any window
+// exists (will fall back to 1.0 if no display is queryable).
+double resolveStartupScale();
+
+// Apply a scale factor at runtime. Calls juce::Desktop::setGlobalScaleFactor,
+// persists to Config, and triggers a top-level repaint so existing components
+// pick up the new scale immediately.
+void applyUIScale(double scale);
+
+// Pick the next/previous step from kUIScaleSteps relative to the current
+// global scale factor. direction = +1 increases, -1 decreases. Clamped to the
+// ends of the table.
+double stepUIScale(double current, int direction);
+
+}  // namespace magda

--- a/magda/daw/core/UIScale.hpp
+++ b/magda/daw/core/UIScale.hpp
@@ -20,10 +20,18 @@ inline constexpr double kMaxUIScale = 4.0;
 // exists (will fall back to 1.0 if no display is queryable).
 double resolveStartupScale();
 
-// Apply a scale factor at runtime. Calls juce::Desktop::setGlobalScaleFactor,
-// persists to Config, and triggers a top-level repaint so existing components
-// pick up the new scale immediately.
-void applyUIScale(double scale);
+// Auto scale derived purely from the primary display's DPI — ignores env var
+// and Config. Use when the user explicitly picked "Auto" in the UI and expects
+// DPI-based behavior, not the startup precedence chain.
+double dpiOnlyAutoScale();
+
+// Apply a scale factor at runtime. Calls juce::Desktop::setGlobalScaleFactor
+// and triggers a top-level repaint so existing components pick up the new
+// scale immediately. When `persist` is true (default), also writes the value
+// to Config and saves. Pass `persist=false` when the caller wants to manage
+// Config writes itself (e.g. the "Auto" path that needs to store 0 as a
+// sentinel rather than the resolved value).
+void applyUIScale(double scale, bool persist = true);
 
 // Pick the next/previous step from kUIScaleSteps relative to the current
 // global scale factor. direction = +1 increases, -1 decreases. Clamped to the

--- a/magda/daw/magda_daw_main.cpp
+++ b/magda/daw/magda_daw_main.cpp
@@ -12,6 +12,7 @@
 #include "core/Config.hpp"
 #include "core/ModulatorEngine.hpp"
 #include "core/TrackManager.hpp"
+#include "core/UIScale.hpp"
 #include "core/UpdateChecker.hpp"
 #include "engine/TracktionEngineWrapper.hpp"
 #include "project/ProjectManager.hpp"
@@ -85,6 +86,14 @@ class MagdaDAWApplication : public JUCEApplication {
         lookAndFeel_ = std::make_unique<juce::LookAndFeel_V4>();
         magda::DarkTheme::applyToLookAndFeel(*lookAndFeel_);
         juce::LookAndFeel::setDefaultLookAndFeel(lookAndFeel_.get());
+
+        // 2a. Apply HiDPI scale before any window is created.
+        // setGlobalScaleFactor must run before TopLevelWindows exist for clean
+        // sizing; see juce_TopLevelWindow.cpp.
+        magda::Config::getInstance().load();
+        const double uiScale = magda::resolveStartupScale();
+        juce::Desktop::getInstance().setGlobalScaleFactor(static_cast<float>(uiScale));
+        juce::Logger::writeToLog("UI scale: " + juce::String(uiScale, 2) + "x");
 
         // 2b. Show splash screen
         splashScreen_ = magda::SplashScreen::create();

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -1,5 +1,7 @@
 #include "PreferencesDialog.hpp"
 
+#include <cmath>
+
 #include "../../project/ProjectManager.hpp"
 #include "../state/TimelineController.hpp"
 #include "../state/TimelineEvents.hpp"
@@ -9,6 +11,7 @@
 #include "../windows/MainWindow.hpp"
 #include "core/Config.hpp"
 #include "core/StringTable.hpp"
+#include "core/UIScale.hpp"
 
 // ---------------------------------------------------------------------------
 // Setup helpers — internal linkage, shared by all page classes
@@ -222,6 +225,18 @@ class UIPage : public juce::Component {
             if (idx >= 0 && idx < static_cast<int>(availableLanguages_.size()))
                 restartHint.setVisible(availableLanguages_[idx] != initialLanguage_);
         };
+
+        // UI scale section (HiDPI / accessibility)
+        setupSectionHeader(*this, scaleHeader, tr("preferences.section.scale"));
+        setupComboLabel(scaleLabel, tr("preferences.scale.label"));
+        styleCombo(scaleCombo);
+        scaleCombo.addItem(tr("preferences.scale.auto"), 1);
+        scaleCombo.addItem("100%", 2);
+        scaleCombo.addItem("125%", 3);
+        scaleCombo.addItem("150%", 4);
+        scaleCombo.addItem("175%", 5);
+        scaleCombo.addItem("200%", 6);
+        addAndMakeVisible(scaleCombo);
     }
 
     void resized() override {
@@ -262,6 +277,12 @@ class UIPage : public juce::Component {
         bounds.removeFromTop(4);
         layoutComboRow(bounds, languageLabel, languageCombo, toggleH + 8, labelW);
         restartHint.setBounds(bounds.removeFromTop(18));
+        bounds.removeFromTop(secGap);
+
+        // UI scale
+        scaleHeader.setBounds(bounds.removeFromTop(headerH));
+        bounds.removeFromTop(4);
+        layoutComboRow(bounds, scaleLabel, scaleCombo, toggleH + 8, labelW);
     }
 
     void loadSettings(Config& config) {
@@ -302,6 +323,8 @@ class UIPage : public juce::Component {
         }
         languageCombo.setSelectedId(selectedId, juce::dontSendNotification);
         restartHint.setVisible(false);
+
+        scaleCombo.setSelectedId(scaleIdForValue(config.getUIScale()), juce::dontSendNotification);
     }
 
     void applySettings(Config& config) {
@@ -321,6 +344,20 @@ class UIPage : public juce::Component {
                 config.setLanguage(newLang.toStdString());
                 StringTable::getInstance().loadLanguage(newLang);
             }
+        }
+
+        // Apply UI scale live. For "Auto", resolve from DPI now so something
+        // visible happens; the stored config value stays 0 so the next launch
+        // re-resolves automatically.
+        double newScale = scaleValueForId(scaleCombo.getSelectedId());
+        if (newScale > 0.0) {
+            applyUIScale(newScale);
+        } else {
+            config.setUIScale(0.0);
+            applyUIScale(resolveStartupScale());
+            // applyUIScale persisted the resolved value — restore the Auto sentinel.
+            config.setUIScale(0.0);
+            config.save();
         }
     }
 
@@ -348,7 +385,36 @@ class UIPage : public juce::Component {
         combo.setBounds(row.reduced(0, 4));
     }
 
-    juce::Label panelsHeader, layoutHeader, behaviorHeader, languageHeader;
+    // UI-scale combo: ID 1=Auto(0), 2=100%(1.0), 3=125%(1.25), 4=150%(1.5),
+    // 5=175%(1.75), 6=200%(2.0). Anything else falls back to Auto.
+    static int scaleIdForValue(double v) {
+        if (v <= 0.0)
+            return 1;
+        if (std::abs(v - 1.0) < 0.01)
+            return 2;
+        if (std::abs(v - 1.25) < 0.01)
+            return 3;
+        if (std::abs(v - 1.5) < 0.01)
+            return 4;
+        if (std::abs(v - 1.75) < 0.01)
+            return 5;
+        if (std::abs(v - 2.0) < 0.01)
+            return 6;
+        return 1;
+    }
+
+    static double scaleValueForId(int id) {
+        switch (id) {
+            case 2: return 1.0;
+            case 3: return 1.25;
+            case 4: return 1.5;
+            case 5: return 1.75;
+            case 6: return 2.0;
+            default: return 0.0;  // Auto
+        }
+    }
+
+    juce::Label panelsHeader, layoutHeader, behaviorHeader, languageHeader, scaleHeader;
     juce::ToggleButton showLeftPanelToggle, showRightPanelToggle, showBottomPanelToggle;
     juce::ToggleButton headersOnRightToggle;
     juce::ToggleButton confirmTrackDeleteToggle, autoMonitorToggle, showTooltipsToggle;
@@ -357,6 +423,8 @@ class UIPage : public juce::Component {
     juce::Label restartHint;
     std::vector<juce::String> availableLanguages_;
     juce::String initialLanguage_;
+    juce::Label scaleLabel;
+    juce::ComboBox scaleCombo;
 };
 
 // ---- Colours tab: Track colour palette ------------------------------------

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -346,16 +346,14 @@ class UIPage : public juce::Component {
             }
         }
 
-        // Apply UI scale live. For "Auto", resolve from DPI now so something
-        // visible happens; the stored config value stays 0 so the next launch
-        // re-resolves automatically.
+        // Apply UI scale live. "Auto" resolves from display DPI only (ignoring
+        // env var / config) so the user sees the actual auto-detected value,
+        // and we persist 0 as the Auto sentinel in a single config write.
         double newScale = scaleValueForId(scaleCombo.getSelectedId());
         if (newScale > 0.0) {
             applyUIScale(newScale);
         } else {
-            config.setUIScale(0.0);
-            applyUIScale(resolveStartupScale());
-            // applyUIScale persisted the resolved value — restore the Auto sentinel.
+            applyUIScale(dpiOnlyAutoScale(), /*persist=*/false);
             config.setUIScale(0.0);
             config.save();
         }

--- a/magda/daw/ui/windows/CommandIDs.hpp
+++ b/magda/daw/ui/windows/CommandIDs.hpp
@@ -42,6 +42,8 @@ enum {
     // View menu
     zoom = 0x4000,
     toggleArrangeSession = 0x4001,
+    uiScaleUp = 0x4002,    // Cmd+= / Cmd++: increase global UI scale
+    uiScaleDown = 0x4003,  // Cmd+- / Cmd+_: decrease global UI scale
 
     // Help menu
     showHelp = 0x5000,

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -6,6 +6,7 @@
 #include "../../core/TrackCommands.hpp"
 #include "../../core/TrackManager.hpp"
 #include "../../core/TrackPropertyCommands.hpp"
+#include "../../core/UIScale.hpp"
 #include "../../core/UndoManager.hpp"
 #include "../debug/DebugDialog.hpp"
 #include "../state/TimelineController.hpp"
@@ -38,7 +39,7 @@ void MainWindow::MainComponent::getAllCommands(juce::Array<juce::CommandID>& com
         // Track
         newAudioTrack, newMidiTrack, deleteTrack,
         // View
-        zoom, toggleArrangeSession,
+        zoom, toggleArrangeSession, uiScaleUp, uiScaleDown,
         // Help
         showHelp, about};
 
@@ -185,6 +186,18 @@ void MainWindow::MainComponent::getCommandInfo(juce::CommandID commandID,
         case toggleArrangeSession:
             result.setInfo("Toggle Arrange/Session", "Switch between arrange and session view",
                            "View", 0);
+            break;
+        case uiScaleUp:
+            result.setInfo("Increase UI Scale", "Make the UI larger", "View", 0);
+            result.addDefaultKeypress('=', juce::ModifierKeys::commandModifier);
+            result.addDefaultKeypress('+', juce::ModifierKeys::commandModifier |
+                                              juce::ModifierKeys::shiftModifier);
+            break;
+        case uiScaleDown:
+            result.setInfo("Decrease UI Scale", "Make the UI smaller", "View", 0);
+            result.addDefaultKeypress('-', juce::ModifierKeys::commandModifier);
+            result.addDefaultKeypress('_', juce::ModifierKeys::commandModifier |
+                                              juce::ModifierKeys::shiftModifier);
             break;
 
         // Help
@@ -886,6 +899,15 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
             auto cmd = std::make_unique<CreateTrackCommand>(TrackType::Group, juce::String(),
                                                             selectedTrack);
             UndoManager::getInstance().executeCommand(std::move(cmd));
+            return true;
+        }
+
+        case uiScaleUp:
+        case uiScaleDown: {
+            const double current =
+                static_cast<double>(juce::Desktop::getInstance().getGlobalScaleFactor());
+            const int direction = (info.commandID == uiScaleUp) ? +1 : -1;
+            applyUIScale(stepUIScale(current, direction));
             return true;
         }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ set(TEST_SOURCES
     test_drum_grid_plugin.cpp
     test_velocity_lane_utils.cpp
     test_grid_constants.cpp
+    test_ui_scale.cpp
     test_multi_out_tracks.cpp
     test_freeze_track.cpp
     test_dsl_add_chord.cpp

--- a/tests/test_ui_scale.cpp
+++ b/tests/test_ui_scale.cpp
@@ -1,0 +1,89 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/core/UIScale.hpp"
+
+using Catch::Approx;
+using magda::kUIScaleSteps;
+using magda::stepUIScale;
+
+// ---------------------------------------------------------------------------
+// Exact step values — stepping moves to the adjacent table entry.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("stepUIScale - up from exact 1.0 lands on 1.25", "[ui_scale]") {
+    REQUIRE(stepUIScale(1.0, +1) == Approx(1.25));
+}
+
+TEST_CASE("stepUIScale - up from exact 1.5 lands on 1.75", "[ui_scale]") {
+    REQUIRE(stepUIScale(1.5, +1) == Approx(1.75));
+}
+
+TEST_CASE("stepUIScale - down from exact 1.5 lands on 1.25", "[ui_scale]") {
+    REQUIRE(stepUIScale(1.5, -1) == Approx(1.25));
+}
+
+TEST_CASE("stepUIScale - down from exact 2.0 lands on 1.75", "[ui_scale]") {
+    REQUIRE(stepUIScale(2.0, -1) == Approx(1.75));
+}
+
+// ---------------------------------------------------------------------------
+// Between-step values snap to the nearest, then move from there.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("stepUIScale - up from 1.3 (nearest 1.25) lands on 1.5", "[ui_scale]") {
+    REQUIRE(stepUIScale(1.3, +1) == Approx(1.5));
+}
+
+TEST_CASE("stepUIScale - up from 1.4 (nearest 1.5) lands on 1.75", "[ui_scale]") {
+    REQUIRE(stepUIScale(1.4, +1) == Approx(1.75));
+}
+
+TEST_CASE("stepUIScale - down from 1.4 (nearest 1.5) lands on 1.25", "[ui_scale]") {
+    REQUIRE(stepUIScale(1.4, -1) == Approx(1.25));
+}
+
+// ---------------------------------------------------------------------------
+// Boundary clamping — stepping past the ends of the table stays put.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("stepUIScale - down from 1.0 clamps to 1.0", "[ui_scale]") {
+    REQUIRE(stepUIScale(1.0, -1) == Approx(1.0));
+}
+
+TEST_CASE("stepUIScale - up from 2.0 clamps to 2.0", "[ui_scale]") {
+    REQUIRE(stepUIScale(2.0, +1) == Approx(2.0));
+}
+
+// ---------------------------------------------------------------------------
+// Out-of-range current values — snap to nearest in-range step, then move.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("stepUIScale - up from 0.5 (below range) snaps to 1.0 then to 1.25",
+          "[ui_scale]") {
+    REQUIRE(stepUIScale(0.5, +1) == Approx(1.25));
+}
+
+TEST_CASE("stepUIScale - down from 0.5 (below range) snaps to 1.0 and clamps", "[ui_scale]") {
+    REQUIRE(stepUIScale(0.5, -1) == Approx(1.0));
+}
+
+TEST_CASE("stepUIScale - down from 3.0 (above range) snaps to 2.0 then to 1.75",
+          "[ui_scale]") {
+    REQUIRE(stepUIScale(3.0, -1) == Approx(1.75));
+}
+
+TEST_CASE("stepUIScale - up from 3.0 (above range) snaps to 2.0 and clamps", "[ui_scale]") {
+    REQUIRE(stepUIScale(3.0, +1) == Approx(2.0));
+}
+
+// ---------------------------------------------------------------------------
+// Sanity: the step table itself.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("kUIScaleSteps is monotonically increasing and non-empty", "[ui_scale]") {
+    REQUIRE_FALSE(kUIScaleSteps.empty());
+    for (size_t i = 1; i < kUIScaleSteps.size(); ++i) {
+        REQUIRE(kUIScaleSteps[i] > kUIScaleSteps[i - 1]);
+    }
+}


### PR DESCRIPTION
Closes #1061.

## Summary
- New `uiScale` setting (default `0` = Auto) wired through `juce::Desktop::setGlobalScaleFactor`. Resolution at startup: `MAGDA_UI_SCALE` env var > `Config::getUIScale()` > auto from primary display DPI (`<140 → 1.0`, `140-180 → 1.5`, `>180 → 2.0`). Clamped to `[0.5, 4.0]`. Applied before splash so the splash itself scales.
- Live runtime control via `Cmd/Ctrl + =` / `+` (step up) and `Cmd/Ctrl + -` / `_` (step down) cycling through `{1.0, 1.25, 1.5, 1.75, 2.0}`. Registered as `ApplicationCommandManager` commands so the global key listener at `MainWindow.cpp:198` dispatches them regardless of focus.
- Preferences → UI → **Display Scale** combo (Auto / 100-200%) applies live via the same `applyUIScale()` helper.

## Notes
- New `magda/daw/core/UIScale.{hpp,cpp}` houses `resolveStartupScale()`, `applyUIScale()`, and `stepUIScale()`.
- Localization: only `lang/en.json` updated; `zh.json` will pick up the new keys via Crowdin.
- Suggest releasing as a **minor** bump — new user-visible feature, no breaking changes.

## Caveats
- The OS window keeps its pixel dimensions when scale changes live, so the logical content area shrinks/grows. Users may want to manually resize the window after a big jump.
- Plugin-host child windows aren't part of `Desktop::getNumComponents()` iteration, so any open plugin GUIs keep their old scale until reopened.

## Test plan
- [ ] Launch with no env var on the current display: verify the picked Auto scale is sensible.
- [ ] `MAGDA_UI_SCALE=1.5 make run`: verify the env var override beats Auto.
- [ ] Set Preferences → UI → Display Scale to 150%, click Apply: verify it applies live (no restart).
- [ ] Press `Ctrl + =` / `Ctrl + -` from various focus contexts (timeline, mixer, chat panel, with no clicks): verify both fire globally.
- [ ] Restart app with config left at 150%: verify it persists.
- [ ] Spot-check tracks / mixer / transport / device slots / popups at 1.0x and 2.0x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)