### PR TITLE
fix: prune uninstalled AU plugins from known list (#1005)

### DIFF
--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -326,15 +326,16 @@ class TracktionEngineWrapper : public AudioEngine,
     void detectNewPlugins(std::function<void(const juce::String&)> statusCallback = nullptr);
 
     /**
-     * @brief Remove entries from the given known-plugin list whose absolute
-     * fileOrIdentifier no longer exists on disk. Cheap (stat-only, no plugin
-     * scanning, no disk writes). Returns the number of entries removed so the
-     * caller can decide whether to persist and update Config.
-     *
-     * Static and self-contained so it can be unit-tested without spinning up
-     * an Engine.
+     * @brief Remove entries from the given known-plugin list whose plugins
+     * are no longer installed. Delegates per-entry to
+     * AudioPluginFormatManager::doesPluginStillExist so each format decides
+     * correctly — VST/VST3 stat the file path, AU queries AudioComponentFindNext
+     * on the identifier (a plain File::exists() skips every AU entry because
+     * their fileOrIdentifier is "AudioUnit:..." and not an absolute path).
+     * Returns the number of entries removed.
      */
-    static int pruneMissingPlugins(juce::KnownPluginList& knownPlugins);
+    static int pruneMissingPlugins(juce::KnownPluginList& knownPlugins,
+                                   juce::AudioPluginFormatManager& formatManager);
 
     /**
      * @brief Clear the plugin list and delete the saved file

--- a/magda/daw/engine/TracktionEngineWrapperInit.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperInit.cpp
@@ -38,7 +38,7 @@ void TracktionEngineWrapper::initializePluginFormats() {
     // Persist + resync the cached count so PluginSettingsDialog doesn't
     // show a stale total after the prune.
     auto& knownPlugins = pluginManager.knownPluginList;
-    if (pruneMissingPlugins(knownPlugins) > 0) {
+    if (pruneMissingPlugins(knownPlugins, pluginManager.pluginFormatManager) > 0) {
         savePluginList();
         Config::getInstance().setTotalPluginCount(knownPlugins.getNumTypes());
         Config::getInstance().save();

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -95,19 +95,20 @@ void TracktionEngineWrapper::startPluginScan(
             }
         },
         // Completion callback
-        [this, &knownPlugins](bool success, const juce::Array<juce::PluginDescription>& plugins,
-                              const juce::StringArray& failedPlugins) {
+        [this, &knownPlugins, &formatManager](bool success,
+                                              const juce::Array<juce::PluginDescription>& plugins,
+                                              const juce::StringArray& failedPlugins) {
             // Add found plugins to KnownPluginList
             for (const auto& desc : plugins) {
                 knownPlugins.addType(desc);
             }
 
-            // Remove entries whose files are no longer on disk (e.g. the
+            // Remove entries whose plugins are no longer installed (e.g. the
             // plugin was uninstalled between the last scan and this one).
             // The unconditional savePluginList() + Config update below covers
             // persistence for both the additions and the pruning, so we
             // don't pay for an extra save here.
-            pruneMissingPlugins(knownPlugins);
+            pruneMissingPlugins(knownPlugins, formatManager);
 
             int numPlugins = knownPlugins.getNumTypes();
             DBG("Plugin scan complete. Found " << numPlugins << " plugins.");
@@ -230,14 +231,14 @@ void TracktionEngineWrapper::loadPluginList() {
     }
 }
 
-int TracktionEngineWrapper::pruneMissingPlugins(juce::KnownPluginList& knownPlugins) {
+int TracktionEngineWrapper::pruneMissingPlugins(juce::KnownPluginList& knownPlugins,
+                                                juce::AudioPluginFormatManager& formatManager) {
     juce::Array<juce::PluginDescription> stalePlugins;
     for (int i = 0; i < knownPlugins.getNumTypes(); ++i) {
         auto* desc = knownPlugins.getType(i);
-        if (!desc || !juce::File::isAbsolutePath(desc->fileOrIdentifier))
+        if (!desc)
             continue;
-        juce::File pluginFile(desc->fileOrIdentifier);
-        if (!pluginFile.exists())
+        if (!formatManager.doesPluginStillExist(*desc))
             stalePlugins.add(*desc);
     }
 

--- a/tests/test_prune_missing_plugins.cpp
+++ b/tests/test_prune_missing_plugins.cpp
@@ -11,8 +11,8 @@ namespace {
 // Build a platform-correct absolute path that is guaranteed not to exist.
 // Hard-coded "/foo/bar" style paths are NOT absolute on Windows
 // (juce::File::isAbsolutePath needs a drive letter or leading backslash),
-// so the prune helper would skip them and the test would falsely pass on
-// Unix while reporting 0 removals on Windows.
+// so a path-based existence check would skip them and the test would
+// falsely pass on Unix while reporting 0 removals on Windows.
 juce::String makeAbsentAbsolutePath(const juce::String& filename) {
     auto path = juce::File::getSpecialLocation(juce::File::tempDirectory)
                     .getChildFile("magda_prune_test_does_not_exist")
@@ -42,45 +42,67 @@ bool listContainsName(const juce::KnownPluginList& list, const juce::String& nam
     return false;
 }
 
+// Build a format manager with the formats we actually ship. The tracktion
+// fork deletes addDefaultFormats(), so each format is registered explicitly.
+void registerTestFormats(juce::AudioPluginFormatManager& fm) {
+#if JUCE_PLUGINHOST_VST3
+    fm.addFormat(std::make_unique<juce::VST3PluginFormat>());
+#endif
+#if JUCE_PLUGINHOST_AU && JUCE_MAC
+    fm.addFormat(std::make_unique<juce::AudioUnitPluginFormat>());
+#endif
+}
+
 }  // namespace
 
-TEST_CASE("pruneMissingPlugins removes only missing absolute-path entries", "[plugin][prune]") {
-    // Create a real temp file to stand in for an existing plugin.
+TEST_CASE("pruneMissingPlugins removes stale entries across formats", "[plugin][prune]") {
+    // Real temp file stands in for an installed VST3.
     juce::TemporaryFile temp(".vst3");
     REQUIRE(temp.getFile().create().wasOk());
 
+    juce::AudioPluginFormatManager formatManager;
+    registerTestFormats(formatManager);
+
     juce::KnownPluginList list;
-    list.addType(makeDesc("Existing", temp.getFile().getFullPathName()));
-    list.addType(makeDesc("Missing", makeAbsentAbsolutePath("Missing.vst3")));
-    list.addType(makeDesc("AURelative", "AudioUnit:Apple:fooo,fooo,fooo", "AudioUnit"));
+    list.addType(makeDesc("ExistingVST3", temp.getFile().getFullPathName()));
+    list.addType(makeDesc("MissingVST3", makeAbsentAbsolutePath("Missing.vst3")));
+    // Bogus AU identifier: AudioComponentFindNext returns null for
+    // unregistered OSTypes, so this must be pruned on macOS. On platforms
+    // without AU support the format isn't registered and the entry is
+    // treated as missing, which is the correct outcome either way.
+    list.addType(makeDesc("MissingAU", "AudioUnit:Effects/fooo,fooo,fooo", "AudioUnit"));
 
     REQUIRE(list.getNumTypes() == 3);
 
-    const int removed = TracktionEngineWrapper::pruneMissingPlugins(list);
+    const int removed = TracktionEngineWrapper::pruneMissingPlugins(list, formatManager);
 
-    CHECK(removed == 1);
-    CHECK(list.getNumTypes() == 2);
-    CHECK(listContainsName(list, "Existing"));
-    CHECK_FALSE(listContainsName(list, "Missing"));
-    CHECK(listContainsName(list, "AURelative"));
+    CHECK(removed == 2);
+    CHECK(list.getNumTypes() == 1);
+    CHECK(listContainsName(list, "ExistingVST3"));
+    CHECK_FALSE(listContainsName(list, "MissingVST3"));
+    CHECK_FALSE(listContainsName(list, "MissingAU"));
 }
 
 TEST_CASE("pruneMissingPlugins is a no-op when nothing is stale", "[plugin][prune]") {
     juce::TemporaryFile temp(".vst3");
     REQUIRE(temp.getFile().create().wasOk());
 
+    juce::AudioPluginFormatManager formatManager;
+    registerTestFormats(formatManager);
+
     juce::KnownPluginList list;
     list.addType(makeDesc("Existing", temp.getFile().getFullPathName()));
-    list.addType(makeDesc("AURelative", "AudioUnit:Apple:fooo,fooo,fooo", "AudioUnit"));
 
-    const int removed = TracktionEngineWrapper::pruneMissingPlugins(list);
+    const int removed = TracktionEngineWrapper::pruneMissingPlugins(list, formatManager);
 
     CHECK(removed == 0);
-    CHECK(list.getNumTypes() == 2);
+    CHECK(list.getNumTypes() == 1);
 }
 
 TEST_CASE("pruneMissingPlugins handles an empty list", "[plugin][prune]") {
+    juce::AudioPluginFormatManager formatManager;
+    registerTestFormats(formatManager);
     juce::KnownPluginList list;
-    CHECK(TracktionEngineWrapper::pruneMissingPlugins(list) == 0);
+    CHECK(TracktionEngineWrapper::pruneMissingPlugins(list, formatManager) == 0);
     CHECK(list.getNumTypes() == 0);
 }

--- a/tests/test_prune_missing_plugins.cpp
+++ b/tests/test_prune_missing_plugins.cpp
@@ -15,7 +15,7 @@ namespace {
 // falsely pass on Unix while reporting 0 removals on Windows.
 juce::String makeAbsentAbsolutePath(const juce::String& filename) {
     auto path = juce::File::getSpecialLocation(juce::File::tempDirectory)
-                    .getChildFile("magda_prune_test_does_not_exist")
+                    .getChildFile("magda_prune_test_does_not_exist_" + juce::Uuid().toString())
                     .getChildFile(filename);
     REQUIRE(juce::File::isAbsolutePath(path.getFullPathName()));
     REQUIRE_FALSE(path.exists());


### PR DESCRIPTION
The prune added in #1066 used juce::File::isAbsolutePath + File::exists to decide whether an entry was stale. That check covers VST/VST3 (whose fileOrIdentifier is an absolute path) but skips every Audio Unit — AU entries store a "AudioUnit:Effects/aumu,Ampl,appl" style identifier, so isAbsolutePath returns false and the loop continues past them. Result: on macOS uninstalled AUs are never pruned.

Delegate per-entry to AudioPluginFormatManager::doesPluginStillExist so each format decides correctly. VST/VST3 still stat the file path, AU queries AudioComponentFindNext on the identifier, and the callers pass the same pluginFormatManager Tracktion has populated already.

The existing test asserted the broken behaviour (the AU entry had to survive the prune); it now builds a real AudioPluginFormatManager with the formats we ship and expects a bogus AU id to be pruned alongside a missing VST3 path.