### PR TITLE
ci: match dev/** branches for Crowdin auto-sync

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -2,7 +2,7 @@ name: Crowdin Sync
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, 'dev/**']
     paths: ['lang/en.json']
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Crowdin workflow push filter was `[main, dev]`, but the actual development branch convention is `dev/<version>` (e.g. `dev/0.6.0`), so the automatic sync on `lang/en.json` changes never fired for the 0.6.0 line.
- Changed to `[main, 'dev/**']` so any `dev/*` branch now triggers the sync.

## Test plan
- [ ] Next push touching `lang/en.json` on `dev/0.6.0` triggers the Crowdin Sync workflow.