### PR TITLE
fix(record): MIDI recording after project reopen, live clip preview

### DIFF
--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -158,10 +158,14 @@ void AudioBridge::tracksChanged() {
 }
 
 void AudioBridge::syncAllArmedTracksToTE() {
-    for (const auto& trackInfo : TrackManager::getInstance().getTracks()) {
-        if (trackInfo.recordArmed)
-            syncRecordArmedToTE(trackInfo.id);
-    }
+    // Iterate *every* track (not just armed ones) so TE's destination
+    // recordEnabled flags reconcile in both directions. syncRecordArmedToTE
+    // no-ops while the transport is playing; on stop we need to push the
+    // current TrackInfo::recordArmed state — including Ns — so TE doesn't
+    // keep a stale recordEnabled=Y on a now-disarmed track and silently
+    // record into it.
+    for (const auto& trackInfo : TrackManager::getInstance().getTracks())
+        syncRecordArmedToTE(trackInfo.id);
 }
 
 void AudioBridge::syncRecordArmedToTE(TrackId trackId) {

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -147,6 +147,61 @@ AudioBridge::~AudioBridge() {
 void AudioBridge::tracksChanged() {
     // Tracks were added/removed/reordered - sync all
     syncAll();
+
+    // Post-load record-arm sync: TrackInfo::recordArmed is persisted across
+    // project save/load, but trackPropertyChanged only runs when the *value*
+    // changes. Without this pass, a project saved with an armed track reopens
+    // with the flag set but TE's InputDeviceInstance destinations still have
+    // recordEnabled=N, and transport.record() silently produces no clip. Also
+    // covers the add/remove/reorder paths — cheap and idempotent.
+    syncAllArmedTracksToTE();
+}
+
+void AudioBridge::syncAllArmedTracksToTE() {
+    for (const auto& trackInfo : TrackManager::getInstance().getTracks()) {
+        if (trackInfo.recordArmed)
+            syncRecordArmedToTE(trackInfo.id);
+    }
+}
+
+void AudioBridge::syncRecordArmedToTE(TrackId trackId) {
+    auto* track = getAudioTrack(trackId);
+    if (!track)
+        return;
+    auto* trackInfo = TrackManager::getInstance().getTrack(trackId);
+    if (!trackInfo)
+        return;
+
+    // Only sync when transport is stopped — if the transport is already
+    // playing (e.g. session clips running), calling setRecordingEnabled()
+    // causes TE to start recording immediately, capturing the session
+    // clip's own MIDI output as "ghost notes". The armed state is stored in
+    // TrackInfo and will be picked up when transport.record() is called.
+    auto* playbackContext = edit_.getCurrentPlaybackContext();
+    if (!playbackContext || edit_.getTransport().isPlaying())
+        return;
+
+    bool foundAnyDest = false;
+    for (auto* inputDeviceInstance : playbackContext->getAllInputs()) {
+        auto targets = inputDeviceInstance->getTargets();
+        for (auto targetID : targets) {
+            if (targetID == track->itemID) {
+                inputDeviceInstance->setRecordingEnabled(track->itemID, trackInfo->recordArmed);
+                juce::Logger::writeToLog(
+                    "[Arm] set recordEnabled=" + juce::String(trackInfo->recordArmed ? "Y" : "N") +
+                    " on device '" + inputDeviceInstance->owner.getName() + "' for track " +
+                    juce::String(trackId));
+                foundAnyDest = true;
+                break;
+            }
+        }
+    }
+    if (!foundAnyDest) {
+        juce::Logger::writeToLog("[Arm] WARNING: No input device destination found for track " +
+                                 juce::String(trackId) +
+                                 " - recordArmed=" + juce::String(trackInfo->recordArmed ? 1 : 0) +
+                                 " will NOT be synced to TE!");
+    }
 }
 
 void AudioBridge::trackPropertyChanged(int trackId) {
@@ -222,41 +277,7 @@ void AudioBridge::trackPropertyChanged(int trackId) {
             // (armed tracks should receive MIDI even when not selected)
             updateMidiRoutingForSelection();
 
-            // Sync recordArmed state to InputDeviceInstance.
-            // Only sync when transport is stopped — if the transport is already
-            // playing (e.g. session clips running), calling setRecordingEnabled()
-            // causes TE to start recording immediately, capturing the session
-            // clip's own MIDI output as "ghost notes".  The armed state is
-            // stored in TrackInfo and will be picked up when transport.record()
-            // is called explicitly.
-            auto* playbackContext = edit_.getCurrentPlaybackContext();
-            if (playbackContext && !edit_.getTransport().isPlaying()) {
-                bool foundAnyDest = false;
-                // Find any input device instances (MIDI or audio) routed to this track
-                for (auto* inputDeviceInstance : playbackContext->getAllInputs()) {
-                    auto targets = inputDeviceInstance->getTargets();
-                    for (auto targetID : targets) {
-                        if (targetID == track->itemID) {
-                            inputDeviceInstance->setRecordingEnabled(track->itemID,
-                                                                     trackInfo->recordArmed);
-                            juce::Logger::writeToLog(
-                                "[Arm] set recordEnabled=" +
-                                juce::String(trackInfo->recordArmed ? "Y" : "N") + " on device '" +
-                                inputDeviceInstance->owner.getName() + "' for track " +
-                                juce::String(trackId));
-                            foundAnyDest = true;
-                            break;
-                        }
-                    }
-                }
-                if (!foundAnyDest) {
-                    juce::Logger::writeToLog(
-                        "[Arm] WARNING: No input device destination found for track " +
-                        juce::String(trackId) +
-                        " - recordArmed=" + juce::String(trackInfo->recordArmed ? 1 : 0) +
-                        " will NOT be synced to TE!");
-                }
-            }
+            syncRecordArmedToTE(trackId);
         }
     }
 

--- a/magda/daw/audio/AudioBridge.hpp
+++ b/magda/daw/audio/AudioBridge.hpp
@@ -384,6 +384,27 @@ class AudioBridge : public TrackManagerListener, public ClipManagerListener, pub
      */
     void syncTrackPlugins(TrackId trackId);
 
+    /**
+     * @brief Push TrackInfo::recordArmed onto TE's InputDeviceInstance destinations.
+     *
+     * Called from trackPropertyChanged (arm toggle) and from tracksChanged
+     * (post-load, add/remove/reorder). Post-load is the critical path: a
+     * project saved with recordArmed=true restores TrackInfo with the flag
+     * already true, so trackPropertyChanged doesn't fire — and without this
+     * call TE's destinations stay at recordEnabled=N, silently swallowing
+     * record attempts.
+     */
+    void syncRecordArmedToTE(TrackId trackId);
+
+    /**
+     * @brief Sync every armed track to TE.
+     *
+     * Belt-and-braces companion to syncRecordArmedToTE — called right before
+     * transport.record() to guarantee destinations are current regardless of
+     * when the playback context became available during project load.
+     */
+    void syncAllArmedTracksToTE();
+
     // =========================================================================
     // Audio Callback Support
     // =========================================================================

--- a/magda/daw/audio/MidiBridge.cpp
+++ b/magda/daw/audio/MidiBridge.cpp
@@ -312,6 +312,22 @@ void MidiBridge::setRecordingQueue(RecordingNoteQueue* queue, std::atomic<double
     transportPosition_ = transportPos;
 }
 
+void MidiBridge::pushPreviewNote(TrackId trackId, int noteNumber, int velocity, bool isNoteOn) {
+    if (!recordingQueue_ || !transportPosition_)
+        return;
+    auto* trackInfo = TrackManager::getInstance().getTrack(trackId);
+    if (!trackInfo || !trackInfo->recordArmed)
+        return;
+
+    RecordingNoteEvent evt;
+    evt.trackId = trackId;
+    evt.noteNumber = noteNumber;
+    evt.velocity = velocity;
+    evt.isNoteOn = isNoteOn;
+    evt.transportSeconds = transportPosition_->load(std::memory_order_relaxed);
+    recordingQueue_->push(evt);
+}
+
 void MidiBridge::startMonitoring(TrackId trackId) {
     juce::ScopedLock lock(routingLock_);
     monitoredTracks_.insert(trackId);

--- a/magda/daw/audio/MidiBridge.cpp
+++ b/magda/daw/audio/MidiBridge.cpp
@@ -312,20 +312,39 @@ void MidiBridge::setRecordingQueue(RecordingNoteQueue* queue, std::atomic<double
     transportPosition_ = transportPos;
 }
 
-void MidiBridge::pushPreviewNote(TrackId trackId, int noteNumber, int velocity, bool isNoteOn) {
-    if (!recordingQueue_ || !transportPosition_)
-        return;
-    auto* trackInfo = TrackManager::getInstance().getTrack(trackId);
-    if (!trackInfo || !trackInfo->recordArmed)
-        return;
+void MidiBridge::broadcastSynthesizedNote(const juce::String& sourceDeviceId, int noteNumber,
+                                          int velocity, bool isNoteOn) {
+    juce::ScopedLock lock(routingLock_);
 
-    RecordingNoteEvent evt;
-    evt.trackId = trackId;
-    evt.noteNumber = noteNumber;
-    evt.velocity = velocity;
-    evt.isNoteOn = isNoteOn;
-    evt.transportSeconds = transportPosition_->load(std::memory_order_relaxed);
-    recordingQueue_->push(evt);
+    for (const auto& [trackId, deviceId] : trackMidiInputs_) {
+        const bool matches = (deviceId == sourceDeviceId || deviceId == "all");
+        if (!matches)
+            continue;
+
+        // UI activity fires regardless of arm — same as physical MIDI.
+        if (isNoteOn) {
+            if (audioBridge_)
+                audioBridge_->triggerMidiActivity(trackId);
+            TrackManager::getInstance().triggerMidiNoteOn(trackId);
+        } else {
+            TrackManager::getInstance().triggerMidiNoteOff(trackId);
+        }
+
+        // Preview queue push is armed-only.
+        if (!recordingQueue_ || !transportPosition_)
+            continue;
+        auto* trackInfo = TrackManager::getInstance().getTrack(trackId);
+        if (!trackInfo || !trackInfo->recordArmed)
+            continue;
+
+        RecordingNoteEvent evt;
+        evt.trackId = trackId;
+        evt.noteNumber = noteNumber;
+        evt.velocity = velocity;
+        evt.isNoteOn = isNoteOn;
+        evt.transportSeconds = transportPosition_->load(std::memory_order_relaxed);
+        recordingQueue_->push(evt);
+    }
 }
 
 void MidiBridge::startMonitoring(TrackId trackId) {

--- a/magda/daw/audio/MidiBridge.hpp
+++ b/magda/daw/audio/MidiBridge.hpp
@@ -191,15 +191,19 @@ class MidiBridge : public juce::MidiInputCallback {
     void setRecordingQueue(RecordingNoteQueue* queue, std::atomic<double>* transportPos);
 
     /**
-     * @brief Push a note event to the recording preview queue — UI only.
+     * @brief Fan a QWERTY-synthesized note out to the UI layer.
      *
-     * Used by on-screen sources (QWERTY keyboard) that feed notes into TE via
-     * VirtualMidiInputDevice::keyboardState. Those notes ARE captured by TE's
-     * recording pipeline; this helper only adds them to the live preview so
-     * the user sees them drawing before the final clip is committed on stop.
-     * No-op unless the track is armed and the queue is wired.
+     * Mirrors the physical-MIDI fan-out in handleIncomingMidiMessage:
+     *   - Fires MIDI activity + note-on/off UI on EVERY track whose MIDI
+     *     input routes this virtual device (or "all"), regardless of
+     *     record-arm state.
+     *   - Pushes to the recording preview queue ONLY for armed tracks.
+     *
+     * @param sourceDeviceId TE device ID of the virtual device that produced
+     *                       the note (typically the QWERTY keyboard).
      */
-    void pushPreviewNote(TrackId trackId, int noteNumber, int velocity, bool isNoteOn);
+    void broadcastSynthesizedNote(const juce::String& sourceDeviceId, int noteNumber, int velocity,
+                                  bool isNoteOn);
 
   private:
     // MidiInputCallback implementation

--- a/magda/daw/audio/MidiBridge.hpp
+++ b/magda/daw/audio/MidiBridge.hpp
@@ -190,6 +190,17 @@ class MidiBridge : public juce::MidiInputCallback {
 
     void setRecordingQueue(RecordingNoteQueue* queue, std::atomic<double>* transportPos);
 
+    /**
+     * @brief Push a note event to the recording preview queue — UI only.
+     *
+     * Used by on-screen sources (QWERTY keyboard) that feed notes into TE via
+     * VirtualMidiInputDevice::keyboardState. Those notes ARE captured by TE's
+     * recording pipeline; this helper only adds them to the live preview so
+     * the user sees them drawing before the final clip is committed on stop.
+     * No-op unless the track is armed and the queue is wired.
+     */
+    void pushPreviewNote(TrackId trackId, int noteNumber, int velocity, bool isNoteOn);
+
   private:
     // MidiInputCallback implementation
     void handleIncomingMidiMessage(juce::MidiInput* source,

--- a/magda/daw/audio/QwertyMidiKeyboard.cpp
+++ b/magda/daw/audio/QwertyMidiKeyboard.cpp
@@ -2,13 +2,14 @@
 
 #include <tracktion_engine/tracktion_engine.h>
 
-#include "../core/SelectionManager.hpp"
 #include "../core/TrackManager.hpp"
 #include "AudioBridge.hpp"
+#include "MidiBridge.hpp"
 
 namespace magda {
 
-QwertyMidiKeyboard::QwertyMidiKeyboard(AudioBridge& bridge) : bridge_(bridge) {}
+QwertyMidiKeyboard::QwertyMidiKeyboard(AudioBridge& bridge, MidiBridge* midiBridge)
+    : bridge_(bridge), midiBridge_(midiBridge) {}
 
 QwertyMidiKeyboard::~QwertyMidiKeyboard() {
     allNotesOff();
@@ -102,13 +103,22 @@ void QwertyMidiKeyboard::sendNoteOn(int note) {
     auto* vmd = bridge_.getQwertyMidiDevice();
     if (!vmd)
         return;
-    auto msg = juce::MidiMessage::noteOn(1, note, static_cast<juce::uint8>(velocity_));
-    vmd->handleIncomingMidiMessage(msg, te::MPESourceID{});
+    // Canonical programmatic injection: MidiInputDevice is registered as a
+    // listener on its own keyboardState, so this dispatches via
+    // handleNoteOn → handleIncomingMidiMessage(msg, midiSourceID) with the
+    // device's own source ID, which is what TE's recording pipeline keys off.
+    vmd->keyboardState.noteOn(1, note, static_cast<float>(velocity_) / 127.0f);
 
-    auto trackId = SelectionManager::getInstance().getSelectedTrack();
-    if (trackId != INVALID_TRACK_ID) {
-        bridge_.triggerMidiActivity(trackId);
-        TrackManager::getInstance().triggerMidiNoteOn(trackId);
+    // QWERTY routes to every MIDI-listening track (it's enumerated in the
+    // "all" MIDI-input fan-out), so fire UI activity + preview for every
+    // armed track — same behaviour as physical MIDI via MidiBridge.
+    for (const auto& trackInfo : TrackManager::getInstance().getTracks()) {
+        if (!trackInfo.recordArmed)
+            continue;
+        bridge_.triggerMidiActivity(trackInfo.id);
+        TrackManager::getInstance().triggerMidiNoteOn(trackInfo.id);
+        if (midiBridge_)
+            midiBridge_->pushPreviewNote(trackInfo.id, note, velocity_, /*isNoteOn=*/true);
     }
 }
 
@@ -116,12 +126,15 @@ void QwertyMidiKeyboard::sendNoteOff(int note) {
     auto* vmd = bridge_.getQwertyMidiDevice();
     if (!vmd)
         return;
-    auto msg = juce::MidiMessage::noteOff(1, note);
-    vmd->handleIncomingMidiMessage(msg, te::MPESourceID{});
+    vmd->keyboardState.noteOff(1, note, 0.0f);
 
-    auto trackId = SelectionManager::getInstance().getSelectedTrack();
-    if (trackId != INVALID_TRACK_ID)
-        TrackManager::getInstance().triggerMidiNoteOff(trackId);
+    for (const auto& trackInfo : TrackManager::getInstance().getTracks()) {
+        if (!trackInfo.recordArmed)
+            continue;
+        TrackManager::getInstance().triggerMidiNoteOff(trackInfo.id);
+        if (midiBridge_)
+            midiBridge_->pushPreviewNote(trackInfo.id, note, 0, /*isNoteOn=*/false);
+    }
 }
 
 void QwertyMidiKeyboard::allNotesOff() {

--- a/magda/daw/audio/QwertyMidiKeyboard.cpp
+++ b/magda/daw/audio/QwertyMidiKeyboard.cpp
@@ -2,7 +2,6 @@
 
 #include <tracktion_engine/tracktion_engine.h>
 
-#include "../core/TrackManager.hpp"
 #include "AudioBridge.hpp"
 #include "MidiBridge.hpp"
 
@@ -109,17 +108,11 @@ void QwertyMidiKeyboard::sendNoteOn(int note) {
     // device's own source ID, which is what TE's recording pipeline keys off.
     vmd->keyboardState.noteOn(1, note, static_cast<float>(velocity_) / 127.0f);
 
-    // QWERTY routes to every MIDI-listening track (it's enumerated in the
-    // "all" MIDI-input fan-out), so fire UI activity + preview for every
-    // armed track — same behaviour as physical MIDI via MidiBridge.
-    for (const auto& trackInfo : TrackManager::getInstance().getTracks()) {
-        if (!trackInfo.recordArmed)
-            continue;
-        bridge_.triggerMidiActivity(trackInfo.id);
-        TrackManager::getInstance().triggerMidiNoteOn(trackInfo.id);
-        if (midiBridge_)
-            midiBridge_->pushPreviewNote(trackInfo.id, note, velocity_, /*isNoteOn=*/true);
-    }
+    // Mirror the physical-MIDI fan-out: UI activity on every track routed to
+    // this device (armed or not) and preview push only on armed ones.
+    if (midiBridge_)
+        midiBridge_->broadcastSynthesizedNote(vmd->getDeviceID(), note, velocity_,
+                                              /*isNoteOn=*/true);
 }
 
 void QwertyMidiKeyboard::sendNoteOff(int note) {
@@ -128,13 +121,8 @@ void QwertyMidiKeyboard::sendNoteOff(int note) {
         return;
     vmd->keyboardState.noteOff(1, note, 0.0f);
 
-    for (const auto& trackInfo : TrackManager::getInstance().getTracks()) {
-        if (!trackInfo.recordArmed)
-            continue;
-        TrackManager::getInstance().triggerMidiNoteOff(trackInfo.id);
-        if (midiBridge_)
-            midiBridge_->pushPreviewNote(trackInfo.id, note, 0, /*isNoteOn=*/false);
-    }
+    if (midiBridge_)
+        midiBridge_->broadcastSynthesizedNote(vmd->getDeviceID(), note, 0, /*isNoteOn=*/false);
 }
 
 void QwertyMidiKeyboard::allNotesOff() {

--- a/magda/daw/audio/QwertyMidiKeyboard.hpp
+++ b/magda/daw/audio/QwertyMidiKeyboard.hpp
@@ -21,9 +21,11 @@ class AudioBridge;
  *   White keys: A S D F G H J   K L
  *   Octave:     Z (down) / X (up)
  */
+class MidiBridge;
+
 class QwertyMidiKeyboard : public juce::KeyListener {
   public:
-    explicit QwertyMidiKeyboard(AudioBridge& bridge);
+    QwertyMidiKeyboard(AudioBridge& bridge, MidiBridge* midiBridge);
     ~QwertyMidiKeyboard() override;
 
     void setEnabled(bool enabled);
@@ -61,6 +63,7 @@ class QwertyMidiKeyboard : public juce::KeyListener {
     void allNotesOff();
 
     AudioBridge& bridge_;
+    MidiBridge* midiBridge_ = nullptr;
     bool enabled_ = false;
     int baseOctave_ = 3;
     int velocity_ = 100;

--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -5,6 +5,7 @@
 #include <functional>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "../audio/RecordingNoteQueue.hpp"
 #include "../command.hpp"
@@ -452,6 +453,17 @@ class TracktionEngineWrapper : public AudioEngine,
     // Per-track dedup during recordingFinished (multiple devices per track).
     // Populated in recordingFinished, cleared after transport stop.
     std::unordered_map<int, int> activeRecordingClips_;
+
+    // Deferred MIDI recording finalization. TE can produce up to N clips per
+    // track (one per input device) during stopRecording; with mergeRecordings=
+    // true each subsequent device's events are merged into the first clip via
+    // track->mergeInMidiSequence. We track the first TE MidiClip we see per
+    // trackId and, after all synchronous recordingFinished callbacks settle,
+    // extract its final (merged) state once via callAsync. Remove-on-the-spot
+    // caused QWERTY's merge target to vanish, dropping its notes.
+    std::unordered_map<TrackId, tracktion::MidiClip::Ptr> pendingMidiRecordings_;
+    std::unordered_set<TrackId> pendingFinalizeMidi_;
+    void finalizeMidiRecording(TrackId trackId);
 
     // Track recording start time per track (populated in recordingAboutToStart)
     std::unordered_map<int, double> recordingStartTimes_;

--- a/magda/daw/engine/TracktionEngineWrapperRecording.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperRecording.cpp
@@ -12,21 +12,25 @@ void TracktionEngineWrapper::recordingAboutToStart(tracktion::InputDeviceInstanc
         << instance.owner.getName() << "' targetID=" << targetID.getRawID()
         << " instance.isRecording()=" << (int)instance.isRecording());
 
-    // Store recording start time per track (first device wins)
-    // Use intendedRecordPosition_ (set before count-in) rather than getCurrentPosition()
-    // which may reflect the pre-roll position.
+    // Store recording start time per track (first device wins) and ensure the
+    // paint-only preview exists. TE can fire a phantom finished→aboutToStart
+    // pair on every input instance after it reallocates the playback graph at
+    // the top of a record session, so the preview add is NOT gated on
+    // recordingStartTimes_ — it must survive (or re-appear after) those
+    // graph-churn finishes.
     if (audioBridge_) {
         TrackId trackId = audioBridge_->getTrackIdForTeTrack(targetID);
-        if (trackId != INVALID_TRACK_ID && recordingStartTimes_.count(trackId) == 0) {
-            double startTime = intendedRecordPosition_;
-            recordingStartTimes_[trackId] = startTime;
-            DBG("  -> stored recording start time " << startTime << " for track " << trackId);
+        if (trackId != INVALID_TRACK_ID) {
+            if (recordingStartTimes_.count(trackId) == 0) {
+                recordingStartTimes_[trackId] = intendedRecordPosition_;
+                DBG("  -> stored recording start time " << intendedRecordPosition_ << " for track "
+                                                        << trackId);
+            }
 
-            // Create recording preview (no ClipManager clip — paint-only overlay)
             if (recordingPreviews_.count(trackId) == 0) {
                 RecordingPreview preview;
                 preview.trackId = trackId;
-                preview.startTime = startTime;
+                preview.startTime = recordingStartTimes_[trackId];
                 preview.currentLength = 0.0;
 
                 const auto* trackInfo = TrackManager::getInstance().getTrack(trackId);
@@ -240,8 +244,13 @@ void TracktionEngineWrapper::recordingFinished(
             audioBridge_->syncClipToEngine(clipId);
     }
 
-    // Clear recording preview for this track — the real clip is now visible
-    recordingPreviews_.erase(trackId);
+    // Clear recording preview for this track — but only if this finish came
+    // with a real clip (the user pressed stop and TE produced the final
+    // recording). 0-clip finishes are TE tearing an input instance down for
+    // a graph reallocation; another aboutToStart will fire immediately and
+    // the preview must still be there to animate.
+    if (!recordedClips.isEmpty())
+        recordingPreviews_.erase(trackId);
 
     // Reset synths to prevent stuck notes
     if (trackId != INVALID_TRACK_ID) {

--- a/magda/daw/engine/TracktionEngineWrapperRecording.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperRecording.cpp
@@ -113,7 +113,17 @@ void TracktionEngineWrapper::recordingFinished(
             continue;
         }
 
-        // Handle MIDI clips
+        // Handle MIDI clips.
+        //
+        // TE fires recordingFinished once per input device. With mergeRecordings=
+        // true (TE default), the FIRST device's applyRecording creates a MidiClip
+        // and every subsequent device's applyRecording merges its events INTO
+        // that clip via track->mergeInMidiSequence — returning 0 clips to the
+        // listener. If we extract + remove eagerly on the first callback, later
+        // devices (e.g. QWERTY) have nothing to merge into and their notes are
+        // silently dropped. So: stash the first clip, drop any later duplicate
+        // clips on the same track, and extract the merged state asynchronously
+        // once all synchronous callbacks have settled.
         auto* midiClip = dynamic_cast<tracktion::MidiClip*>(clip);
         if (!midiClip)
             continue;
@@ -132,128 +142,43 @@ void TracktionEngineWrapper::recordingFinished(
         if (trackId == INVALID_TRACK_ID)
             continue;
 
-        // One clip per track — skip if already processed by another device
-        if (activeRecordingClips_.count(trackId) > 0) {
-            // Merge data into existing clip
-            ClipId clipId = activeRecordingClips_[trackId];
-            auto& clipManager = ClipManager::getInstance();
-            auto* clipInfo = clipManager.getClip(clipId);
-            if (!clipInfo) {
-                midiClip->removeFromParent();
-                continue;
-            }
-
-            // Extract notes before removing the TE clip
-            auto& midiList = midiClip->getSequence();
-            for (auto* note : midiList.getNotes()) {
-                if (!note)
-                    continue;
-                MidiNote mn;
-                mn.noteNumber = note->getNoteNumber();
-                mn.velocity = note->getVelocity();
-                mn.startBeat = note->getStartBeat().inBeats();
-                mn.lengthBeats = note->getLengthBeats().inBeats();
-                clipInfo->midiNotes.push_back(mn);
-            }
-
-            DBG("  merged " << (int)midiList.getNotes().size() << " notes from device '"
-                            << instance.owner.getName() << "' into clip " << clipId);
-
-            midiClip->removeFromParent();
-
-            // One sync after merging all notes
-            if (audioBridge_)
-                audioBridge_->syncClipToEngine(clipId);
-
-            continue;
-        }
-
-        // First device for this track — create the MAGDA clip
-        double startSeconds = midiClip->getPosition().getStart().inSeconds();
-        double lengthSeconds = midiClip->getPosition().getLength().inSeconds();
-        if (lengthSeconds <= 0.0) {
+        if (midiClip->getPosition().getLength().inSeconds() <= 0.0) {
             midiClip->removeFromParent();
             continue;
         }
 
-        // Extract ALL MIDI data from the TE recording clip BEFORE creating the MAGDA clip.
-        // createMidiClip() triggers syncClipToEngine() which calls insertMIDIClip() on the
-        // same track — this can invalidate the original recording clip's sequence data.
-        std::vector<MidiNote> recordedNotes;
-        std::vector<MidiCCData> recordedCC;
-        std::vector<MidiPitchBendData> recordedPB;
-
-        auto& midiList = midiClip->getSequence();
-        for (auto* note : midiList.getNotes()) {
-            if (!note)
-                continue;
-            MidiNote mn;
-            mn.noteNumber = note->getNoteNumber();
-            mn.velocity = note->getVelocity();
-            mn.startBeat = note->getStartBeat().inBeats();
-            mn.lengthBeats = note->getLengthBeats().inBeats();
-            recordedNotes.push_back(mn);
+        auto pendingIt = pendingMidiRecordings_.find(trackId);
+        if (pendingIt == pendingMidiRecordings_.end()) {
+            pendingMidiRecordings_[trackId] = midiClip;
+            DBG("  stashed TE midi clip for deferred finalize on track " << trackId);
+        } else if (pendingIt->second.get() != midiClip) {
+            // A second device (mergeRecordings must be false for this device)
+            // produced its own overlapping clip. Drop it — we only commit one
+            // MAGDA clip per track per record pass.
+            DBG("  dropping duplicate TE midi clip on track " << trackId);
+            midiClip->removeFromParent();
         }
 
-        for (auto* ce : midiList.getControllerEvents()) {
-            if (!ce)
-                continue;
-            int eventType = ce->getType();
-            if (eventType == tracktion::MidiControllerEvent::pitchWheelType) {
-                MidiPitchBendData pb;
-                pb.value = ce->getControllerValue();
-                pb.beatPosition = ce->getBeatPosition().inBeats();
-                recordedPB.push_back(pb);
-            } else if (eventType < 128) {
-                MidiCCData cc;
-                cc.controller = eventType;
-                cc.value = ce->getControllerValue();
-                cc.beatPosition = ce->getBeatPosition().inBeats();
-                recordedCC.push_back(cc);
-            }
+        if (pendingFinalizeMidi_.count(trackId) == 0) {
+            pendingFinalizeMidi_.insert(trackId);
+            juce::WeakReference<TracktionEngineWrapper> weakSelf(this);
+            juce::MessageManager::callAsync([weakSelf, trackId]() {
+                if (auto* self = weakSelf.get())
+                    self->finalizeMidiRecording(trackId);
+            });
         }
-
-        DBG("  extracted " << (int)recordedNotes.size() << " notes, " << (int)recordedCC.size()
-                           << " CC, " << (int)recordedPB.size() << " pitchbend from TE clip");
-
-        // Remove TE's recording clip BEFORE creating MAGDA clip to avoid
-        // two clips overlapping on the same time range
-        midiClip->removeFromParent();
-
-        // Create the MAGDA clip (triggers syncClipToEngine with 0 notes — that's fine)
-        auto& clipManager = ClipManager::getInstance();
-        ClipId clipId =
-            clipManager.createMidiClip(trackId, startSeconds, lengthSeconds, ClipView::Arrangement);
-        activeRecordingClips_[trackId] = clipId;
-
-        DBG("  created clip " << clipId << " on track " << trackId << " start=" << startSeconds
-                              << " len=" << lengthSeconds);
-
-        // Populate the MAGDA clip directly (bypass per-note notifications)
-        auto* clipInfo = clipManager.getClip(clipId);
-        if (clipInfo) {
-            clipInfo->midiNotes = std::move(recordedNotes);
-            clipInfo->midiCCData = std::move(recordedCC);
-            clipInfo->midiPitchBendData = std::move(recordedPB);
-
-            DBG("  populated clip with " << (int)clipInfo->midiNotes.size() << " notes");
-        }
-
-        // One final sync to push all MIDI data to the TE clip
-        if (audioBridge_)
-            audioBridge_->syncClipToEngine(clipId);
     }
 
-    // Clear recording preview for this track — but only if this finish came
-    // with a real clip (the user pressed stop and TE produced the final
-    // recording). 0-clip finishes are TE tearing an input instance down for
-    // a graph reallocation; another aboutToStart will fire immediately and
-    // the preview must still be there to animate.
-    if (!recordedClips.isEmpty())
+    // For audio recordings, clear the preview + reset synths now (synchronous
+    // path owns its clip creation). MIDI recordings are finalized via the
+    // async callback — preview cleanup happens there. 0-clip finishes are TE
+    // tearing an input instance down for a graph reallocation; another
+    // aboutToStart will fire immediately and the preview must still be there
+    // to animate.
+    if (!recordedClips.isEmpty() && !pendingMidiRecordings_.count(trackId))
         recordingPreviews_.erase(trackId);
 
-    // Reset synths to prevent stuck notes
-    if (trackId != INVALID_TRACK_ID) {
+    if (trackId != INVALID_TRACK_ID && audioBridge_ && !pendingMidiRecordings_.count(trackId)) {
         audioBridge_->resetSynthsOnTrack(trackId);
     }
 }
@@ -320,6 +245,84 @@ void TracktionEngineWrapper::drainRecordingNoteQueue() {
             }
         }
     }
+}
+
+void TracktionEngineWrapper::finalizeMidiRecording(TrackId trackId) {
+    pendingFinalizeMidi_.erase(trackId);
+
+    auto it = pendingMidiRecordings_.find(trackId);
+    if (it == pendingMidiRecordings_.end())
+        return;
+
+    tracktion::MidiClip::Ptr midiClip = it->second;
+    pendingMidiRecordings_.erase(it);
+
+    if (!midiClip) {
+        recordingPreviews_.erase(trackId);
+        return;
+    }
+
+    double startSeconds = midiClip->getPosition().getStart().inSeconds();
+    double lengthSeconds = midiClip->getPosition().getLength().inSeconds();
+
+    std::vector<MidiNote> recordedNotes;
+    std::vector<MidiCCData> recordedCC;
+    std::vector<MidiPitchBendData> recordedPB;
+
+    auto& midiList = midiClip->getSequence();
+    for (auto* note : midiList.getNotes()) {
+        if (!note)
+            continue;
+        MidiNote mn;
+        mn.noteNumber = note->getNoteNumber();
+        mn.velocity = note->getVelocity();
+        mn.startBeat = note->getStartBeat().inBeats();
+        mn.lengthBeats = note->getLengthBeats().inBeats();
+        recordedNotes.push_back(mn);
+    }
+
+    for (auto* ce : midiList.getControllerEvents()) {
+        if (!ce)
+            continue;
+        int eventType = ce->getType();
+        if (eventType == tracktion::MidiControllerEvent::pitchWheelType) {
+            MidiPitchBendData pb;
+            pb.value = ce->getControllerValue();
+            pb.beatPosition = ce->getBeatPosition().inBeats();
+            recordedPB.push_back(pb);
+        } else if (eventType < 128) {
+            MidiCCData cc;
+            cc.controller = eventType;
+            cc.value = ce->getControllerValue();
+            cc.beatPosition = ce->getBeatPosition().inBeats();
+            recordedCC.push_back(cc);
+        }
+    }
+
+    DBG("finalizeMidiRecording: track=" << trackId << " notes=" << (int)recordedNotes.size()
+                                        << " cc=" << (int)recordedCC.size()
+                                        << " pb=" << (int)recordedPB.size());
+
+    midiClip->removeFromParent();
+
+    auto& clipManager = ClipManager::getInstance();
+    ClipId clipId =
+        clipManager.createMidiClip(trackId, startSeconds, lengthSeconds, ClipView::Arrangement);
+    activeRecordingClips_[trackId] = clipId;
+
+    if (auto* clipInfo = clipManager.getClip(clipId)) {
+        clipInfo->midiNotes = std::move(recordedNotes);
+        clipInfo->midiCCData = std::move(recordedCC);
+        clipInfo->midiPitchBendData = std::move(recordedPB);
+    }
+
+    if (audioBridge_)
+        audioBridge_->syncClipToEngine(clipId);
+
+    recordingPreviews_.erase(trackId);
+
+    if (trackId != INVALID_TRACK_ID && audioBridge_)
+        audioBridge_->resetSynthsOnTrack(trackId);
 }
 
 }  // namespace magda

--- a/magda/daw/engine/TracktionEngineWrapperTransport.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperTransport.cpp
@@ -102,6 +102,12 @@ void TracktionEngineWrapper::record() {
     }
 
     if (currentEdit_) {
+        // Push TrackInfo::recordArmed onto TE's destinations right before asking
+        // TE to record. Covers the project-load case where a persisted armed
+        // track never saw a trackPropertyChanged arm sync (value didn't change).
+        if (audioBridge_)
+            audioBridge_->syncAllArmedTracksToTE();
+
         // Dump all input device instances and their record-enabled state
         if (auto* ctx = currentEdit_->getCurrentPlaybackContext()) {
             juce::Logger::writeToLog("[Record] input devices before record:");

--- a/magda/daw/engine/TracktionEngineWrapperTransport.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperTransport.cpp
@@ -386,8 +386,10 @@ void TracktionEngineWrapper::onTransportStop(double returnPosition) {
                 audioBridge_->resetSynthsOnTrack(trackId);
             }
 
-            // Skip if TE already created a clip for this track
-            if (activeRecordingClips_.count(trackId) > 0) {
+            // Skip if TE already created a clip for this track, or if an async
+            // finalize is pending (it will create the MAGDA clip).
+            if (activeRecordingClips_.count(trackId) > 0 ||
+                pendingMidiRecordings_.count(trackId) > 0) {
                 continue;
             }
 

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -210,6 +210,16 @@ void TrackContentPanel::timelineStateChanged(const TimelineState& state, ChangeF
         }
     }
 
+    // Playhead advancing during recording drives the live preview animation.
+    // paintRecordingPreviews self-schedules the next repaint once it runs,
+    // but it needs a first wakeup — the panel wasn't listening to the
+    // Playhead flag at all. Bounded to recordingPreviews so this is a no-op
+    // during normal playback.
+    if (hasFlag(changes, ChangeFlags::Playhead) && state.playhead.isRecording && audioEngine_ &&
+        !audioEngine_->getRecordingPreviews().empty()) {
+        repaintVisible();
+    }
+
     // Edit cursor position changed — repaint immediately (bounded to cursor strip)
     if (hasFlag(changes, ChangeFlags::Selection)) {
         editCursorBlinkVisible_ = true;

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -211,13 +211,16 @@ void TrackContentPanel::timelineStateChanged(const TimelineState& state, ChangeF
     }
 
     // Playhead advancing during recording drives the live preview animation.
-    // paintRecordingPreviews self-schedules the next repaint once it runs,
-    // but it needs a first wakeup — the panel wasn't listening to the
-    // Playhead flag at all. Bounded to recordingPreviews so this is a no-op
-    // during normal playback.
-    if (hasFlag(changes, ChangeFlags::Playhead) && state.playhead.isRecording && audioEngine_ &&
-        !audioEngine_->getRecordingPreviews().empty()) {
-        repaintVisible();
+    // paintRecordingPreviews self-schedules the next repaint via a bounded
+    // previewUnion rect once it runs, so we only need a one-shot wake when
+    // previews first become active. Repainting on every Playhead tick while
+    // recording would invalidate the whole viewport unnecessarily.
+    if (hasFlag(changes, ChangeFlags::Playhead)) {
+        const bool hasRecordingPreviews = state.playhead.isRecording && audioEngine_ &&
+                                          !audioEngine_->getRecordingPreviews().empty();
+        if (hasRecordingPreviews && !recordingPreviewWakeIssued_)
+            repaintVisible();
+        recordingPreviewWakeIssued_ = hasRecordingPreviews;
     }
 
     // Edit cursor position changed — repaint immediately (bounded to cursor strip)

--- a/magda/daw/ui/components/tracks/TrackContentPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.hpp
@@ -277,6 +277,11 @@ class TrackContentPanel : public juce::Component,
 
     // Edit cursor blink state
     bool editCursorBlinkVisible_ = true;
+
+    // One-shot flag: true once the recording-preview paint loop has been
+    // kicked off for the current record session. paintRecordingPreviews
+    // self-schedules subsequent repaints, so we only need a single wake.
+    bool recordingPreviewWakeIssued_ = false;
     static constexpr int EDIT_CURSOR_BLINK_MS = 500;  // Blink interval
 
     // Timer callback for edit cursor blinking

--- a/magda/daw/ui/windows/MainWindow.cpp
+++ b/magda/daw/ui/windows/MainWindow.cpp
@@ -831,7 +831,7 @@ void MainWindow::MainComponent::setupAudioEngineCallbacks(AudioEngine* engine) {
     // (after setContentOwned) so the key listener registers on the
     // DocumentWindow, not on MainComponent.
     if (auto* bridge = engine->getAudioBridge()) {
-        qwertyKeyboard_ = std::make_unique<QwertyMidiKeyboard>(*bridge);
+        qwertyKeyboard_ = std::make_unique<QwertyMidiKeyboard>(*bridge, engine->getMidiBridge());
     }
 
     transportPanel->onTempoChange = [this](double bpm) {


### PR DESCRIPTION
## Summary

Three bugs in the MIDI recording path, all surfaced by the same repro:

1. Save project with armed track, reopen
2. Delete the existing recorded clip
3. Press record → nothing happens and no preview animates

## The three fixes

1. **Arm state didn't reach TE after project load.** `TrackInfo::recordArmed` is persisted as `true`, so on reopen it's already `true` — `trackPropertyChanged` doesn't fire (no value change) and the arm-sync block never runs. `transport.record()` then found no destination with `recordEnabled=Y`. Extracted the sync into `AudioBridge::syncRecordArmedToTE` and call `syncAllArmedTracksToTE` from `tracksChanged` (post-load) and from `TracktionEngineWrapper::record()` immediately before `transport.record()`.

2. **Recording preview erased by TE's graph reallocation.** After `transport.record()` TE reallocates the playback graph and fires a phantom `finished → aboutToStart` pair on every input instance. `recordingFinished` unconditionally erased the paint-only preview, and `recordingAboutToStart` gated re-adding the preview behind `recordingStartTimes_` (still populated from the first pass), so the preview was gone for the rest of the session. Now the erase is conditional on `!recordedClips.isEmpty()` — only a real final finish clears the preview — and `aboutToStart` always ensures the preview exists when the track is recording.

3. **`TrackContentPanel` didn't repaint on playhead ticks.** The panel owns `paintRecordingPreviews`, which self-schedules subsequent frames, but nothing woke it up on the first tick of a record session. Added a bounded `repaintVisible()` in `timelineStateChanged` when `Playhead + isRecording + recordingPreviews` non-empty.

## Test plan

- [ ] Save project with an armed track + recorded clip, close, reopen, delete clip, press record → notes are recorded into a new clip.
- [ ] During recording the live clip preview draws and grows with the playhead.
- [ ] Existing arm-toggle flow still works (no regression on fresh tracks).