### PR TITLE
ci(crowdin): drop export_only_approved gate

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -27,7 +27,7 @@ jobs:
           upload_sources: true
           upload_translations: false
           download_translations: true
-          export_only_approved: true
+          export_only_approved: false
           skip_untranslated_strings: true
           localization_branch_name: l10n_crowdin_${{ github.ref_name }}
           create_pull_request: true


### PR DESCRIPTION
## Summary
- Flips `export_only_approved` from `true` to `false` in the Crowdin sync workflow.
- The approval gate keeps wiping good translations from sync PRs whenever an English source string changes (Crowdin invalidates approval on source edits). For a solo dev who can't proofread non-English locales, the gate adds friction without adding quality.
- After this lands, future sync PRs will include any translation that exists on Crowdin, regardless of approval status.

## Test plan
- [ ] Merge, then re-dispatch the workflow on `dev/0.6.0` and confirm PR #1072 stops trying to revert the existing zh translations.