### PR TITLE
ci(release): drop Chocolatey for NSIS, fetch a pinned zip directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,7 +279,7 @@ jobs:
 
     # Ninja is shipped with the Visual Studio install on windows-latest, so
     # we only need to provision NSIS. We pin a known version and download
-    # the zip directly — Chocolatey's community feed historically flakes
+    # the zip directly: Chocolatey's community feed historically flakes
     # (5xx, rate limits) and was blocking the release as recently as the
     # rc0 attempt.
     - name: Cache NSIS
@@ -304,7 +304,7 @@ jobs:
         }
 
         # NSIS: portable zip from SourceForge, pinned + hash-checked.
-        # Two mirrors and an in-attempt retry loop — Windows PowerShell 5.1
+        # Two mirrors and an in-attempt retry loop. Windows PowerShell 5.1
         # doesn't support Invoke-WebRequest's -MaximumRetryCount, so retries
         # are spelled out here.
         $nsisDir = "$env:RUNNER_TEMP\nsis-$env:NSIS_VERSION"
@@ -344,7 +344,7 @@ jobs:
           $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLower()
           $expected = $env:NSIS_SHA256.ToLower()
           if ($actual -ne $expected) {
-            Write-Error "NSIS zip hash mismatch — expected $expected, got $actual"
+            Write-Error "NSIS zip hash mismatch - expected $expected, got $actual"
             exit 1
           }
           Write-Output "NSIS zip hash OK ($actual)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,8 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
+    env:
+      NSIS_VERSION: "3.10"
     steps:
     - uses: actions/checkout@v4
       with:
@@ -275,43 +277,60 @@ jobs:
       with:
         arch: x64
 
+    # Ninja is shipped with the Visual Studio install on windows-latest, so
+    # we only need to provision NSIS. We pin a known version and download
+    # the zip directly — Chocolatey's community feed historically flakes
+    # (5xx, rate limits) and was blocking the release as recently as the
+    # rc0 attempt.
+    - name: Cache NSIS
+      uses: actions/cache@v4
+      id: cache-nsis
+      with:
+        path: ${{ runner.temp }}\nsis-${{ env.NSIS_VERSION }}
+        key: nsis-${{ env.NSIS_VERSION }}
+
     - name: Install Ninja and NSIS
       shell: powershell
       run: |
-        # Both tools are typically pre-installed on windows-latest runners;
-        # only fall back to Chocolatey if missing, since the community feed
-        # flakes (HTTP 499) intermittently and blocks the release otherwise.
-        $nsisPath = "${env:ProgramFiles(x86)}\NSIS\makensis.exe"
-        $needNinja = -not (Get-Command ninja -ErrorAction SilentlyContinue)
-        $needNsis  = -not (Test-Path $nsisPath) `
-                     -and -not (Get-Command makensis -ErrorAction SilentlyContinue)
-
-        if ($needNinja -or $needNsis) {
-          $packages = @()
-          if ($needNinja) { $packages += "ninja" }
-          if ($needNsis)  { $packages += "nsis" }
-          Write-Output "Installing via Chocolatey: $($packages -join ', ')"
-          choco install $packages -y
-          if ($LASTEXITCODE -ne 0) {
-            Write-Error "Chocolatey install failed with exit code $LASTEXITCODE"
-            exit $LASTEXITCODE
-          }
-        } else {
-          Write-Output "Ninja and NSIS already present; skipping Chocolatey"
-        }
-
-        # Export the resolved NSIS directory so later steps find makensis
-        # regardless of whether ProgramFiles(x86) is on C: or elsewhere.
-        $makensis = Get-Command makensis -ErrorAction SilentlyContinue
-        if ($makensis) {
-          $nsisDir = Split-Path -Parent $makensis.Source
-        } elseif (Test-Path $nsisPath) {
-          $nsisDir = Split-Path -Parent $nsisPath
-        } else {
-          Write-Error "NSIS not found after install attempt"
+        # Ninja: prefer whatever the VS install ships; only bail if missing.
+        if (-not (Get-Command ninja -ErrorAction SilentlyContinue)) {
+          Write-Error "ninja not found on PATH (expected via Visual Studio install)"
           exit 1
         }
-        echo "$nsisDir" >> $env:GITHUB_PATH
+
+        # NSIS: portable zip from SourceForge, pinned. Two mirrors with a
+        # small backoff so a transient 5xx on one doesn't kill the build.
+        $nsisDir = "$env:RUNNER_TEMP\nsis-$env:NSIS_VERSION"
+        $makensis = Join-Path $nsisDir "nsis-$env:NSIS_VERSION\makensis.exe"
+        if (-not (Test-Path $makensis)) {
+          $zip = "$env:RUNNER_TEMP\nsis-$env:NSIS_VERSION.zip"
+          $urls = @(
+            "https://prdownloads.sourceforge.net/nsis/nsis-$env:NSIS_VERSION.zip",
+            "https://sourceforge.net/projects/nsis/files/NSIS%203/$env:NSIS_VERSION/nsis-$env:NSIS_VERSION.zip/download"
+          )
+          $ok = $false
+          foreach ($u in $urls) {
+            try {
+              Write-Output "Downloading NSIS $env:NSIS_VERSION from $u"
+              Invoke-WebRequest -Uri $u -OutFile $zip -MaximumRetryCount 3 -RetryIntervalSec 5
+              if ((Get-Item $zip).Length -gt 1MB) { $ok = $true; break }
+            } catch {
+              Write-Output "Mirror failed: $($_.Exception.Message)"
+              Start-Sleep -Seconds 5
+            }
+          }
+          if (-not $ok) {
+            Write-Error "All NSIS mirrors failed"
+            exit 1
+          }
+          Expand-Archive -Path $zip -DestinationPath $nsisDir -Force
+        } else {
+          Write-Output "NSIS $env:NSIS_VERSION already cached"
+        }
+
+        $bin = Split-Path -Parent $makensis
+        echo "$bin" >> $env:GITHUB_PATH
+        Write-Output "NSIS on PATH: $bin"
 
     - name: Configure CMake
       shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,8 +289,13 @@ jobs:
         path: ${{ runner.temp }}\nsis-${{ env.NSIS_VERSION }}
         key: nsis-${{ env.NSIS_VERSION }}
 
-    - name: Install Ninja and NSIS
+    - name: Verify Ninja and provision NSIS
       shell: powershell
+      env:
+        # Pinned hash matches the contents of the Sourceforge release for
+        # NSIS_VERSION above. Bumping the version means computing a fresh
+        # hash with `Get-FileHash -Algorithm SHA256` (or `shasum -a 256`).
+        NSIS_SHA256: "fcdce3229717a2a148e7cda0ab5bdb667f39d8fb33ede1da8dabc336bd5ad110"
       run: |
         # Ninja: prefer whatever the VS install ships; only bail if missing.
         if (-not (Get-Command ninja -ErrorAction SilentlyContinue)) {
@@ -298,8 +303,10 @@ jobs:
           exit 1
         }
 
-        # NSIS: portable zip from SourceForge, pinned. Two mirrors with a
-        # small backoff so a transient 5xx on one doesn't kill the build.
+        # NSIS: portable zip from SourceForge, pinned + hash-checked.
+        # Two mirrors and an in-attempt retry loop — Windows PowerShell 5.1
+        # doesn't support Invoke-WebRequest's -MaximumRetryCount, so retries
+        # are spelled out here.
         $nsisDir = "$env:RUNNER_TEMP\nsis-$env:NSIS_VERSION"
         $makensis = Join-Path $nsisDir "nsis-$env:NSIS_VERSION\makensis.exe"
         if (-not (Test-Path $makensis)) {
@@ -308,29 +315,55 @@ jobs:
             "https://prdownloads.sourceforge.net/nsis/nsis-$env:NSIS_VERSION.zip",
             "https://sourceforge.net/projects/nsis/files/NSIS%203/$env:NSIS_VERSION/nsis-$env:NSIS_VERSION.zip/download"
           )
-          $ok = $false
+          $downloaded = $false
           foreach ($u in $urls) {
-            try {
-              Write-Output "Downloading NSIS $env:NSIS_VERSION from $u"
-              Invoke-WebRequest -Uri $u -OutFile $zip -MaximumRetryCount 3 -RetryIntervalSec 5
-              if ((Get-Item $zip).Length -gt 1MB) { $ok = $true; break }
-            } catch {
-              Write-Output "Mirror failed: $($_.Exception.Message)"
-              Start-Sleep -Seconds 5
+            for ($attempt = 1; $attempt -le 3; $attempt++) {
+              try {
+                Write-Output "Downloading NSIS $env:NSIS_VERSION from $u (attempt $attempt/3)"
+                Invoke-WebRequest -Uri $u -OutFile $zip
+                if ((Test-Path $zip) -and ((Get-Item $zip).Length -gt 1MB)) {
+                  $downloaded = $true
+                  break
+                }
+                Write-Output "Downloaded file from $u was missing or too small"
+              } catch {
+                Write-Output "Download attempt $attempt failed: $($_.Exception.Message)"
+              }
+              if ($attempt -lt 3) { Start-Sleep -Seconds 5 }
             }
+            if ($downloaded) { break }
+            Write-Output "Mirror failed: $u"
           }
-          if (-not $ok) {
+          if (-not $downloaded) {
             Write-Error "All NSIS mirrors failed"
             exit 1
           }
+
+          # Supply-chain check: refuse to extract if the zip doesn't match
+          # the pinned hash for this version.
+          $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLower()
+          $expected = $env:NSIS_SHA256.ToLower()
+          if ($actual -ne $expected) {
+            Write-Error "NSIS zip hash mismatch — expected $expected, got $actual"
+            exit 1
+          }
+          Write-Output "NSIS zip hash OK ($actual)"
+
           Expand-Archive -Path $zip -DestinationPath $nsisDir -Force
         } else {
           Write-Output "NSIS $env:NSIS_VERSION already cached"
         }
 
+        if (-not (Test-Path $makensis)) {
+          Write-Error "makensis.exe missing after extraction at $makensis"
+          exit 1
+        }
+
         $bin = Split-Path -Parent $makensis
         echo "$bin" >> $env:GITHUB_PATH
+        echo "MAKENSIS=$makensis" >> $env:GITHUB_ENV
         Write-Output "NSIS on PATH: $bin"
+        Write-Output "Resolved makensis: $makensis"
 
     - name: Configure CMake
       shell: powershell
@@ -415,7 +448,7 @@ jobs:
           exit 1
         }
 
-        & "${env:ProgramFiles(x86)}\NSIS\makensis.exe" /DVERSION=$env:VERSION "$stage\magda-installer.nsi"
+        & $env:MAKENSIS /DVERSION=$env:VERSION "$stage\magda-installer.nsi"
 
         $installerName = "MAGDA-$env:VERSION-Windows-x86_64-Setup.exe"
         Move-Item "$stage\MAGDA-$env:VERSION-Windows-Setup.exe" $installerName

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,10 +278,10 @@ jobs:
         arch: x64
 
     # Ninja is shipped with the Visual Studio install on windows-latest, so
-    # we only need to provision NSIS. We pin a known version and download
-    # the zip directly: Chocolatey's community feed historically flakes
-    # (5xx, rate limits) and was blocking the release as recently as the
-    # rc0 attempt.
+    # we only need to provision NSIS. The zip is hosted as a release asset
+    # on this repo's "vendor/nsis-X.Y" tag - GitHub-hosted, rock-solid, no
+    # third-party CDN flakes. Bumping NSIS_VERSION means uploading the new
+    # zip to a new vendor/nsis-X.Y release tag and refreshing NSIS_SHA256.
     - name: Cache NSIS
       uses: actions/cache@v4
       id: cache-nsis
@@ -303,39 +303,32 @@ jobs:
           exit 1
         }
 
-        # NSIS: portable zip from SourceForge, pinned + hash-checked.
-        # Two mirrors and an in-attempt retry loop. Windows PowerShell 5.1
-        # doesn't support Invoke-WebRequest's -MaximumRetryCount, so retries
-        # are spelled out here.
+        # NSIS: vendored as a GitHub release asset on this repo. Three
+        # attempts with a small backoff covers any transient blip; PS 5.1
+        # doesn't support Invoke-WebRequest's -MaximumRetryCount so retries
+        # are spelled out.
         $nsisDir = "$env:RUNNER_TEMP\nsis-$env:NSIS_VERSION"
         $makensis = Join-Path $nsisDir "nsis-$env:NSIS_VERSION\makensis.exe"
         if (-not (Test-Path $makensis)) {
           $zip = "$env:RUNNER_TEMP\nsis-$env:NSIS_VERSION.zip"
-          $urls = @(
-            "https://prdownloads.sourceforge.net/nsis/nsis-$env:NSIS_VERSION.zip",
-            "https://sourceforge.net/projects/nsis/files/NSIS%203/$env:NSIS_VERSION/nsis-$env:NSIS_VERSION.zip/download"
-          )
+          $url = "https://github.com/${env:GITHUB_REPOSITORY}/releases/download/vendor/nsis-$env:NSIS_VERSION/nsis-$env:NSIS_VERSION.zip"
           $downloaded = $false
-          foreach ($u in $urls) {
-            for ($attempt = 1; $attempt -le 3; $attempt++) {
-              try {
-                Write-Output "Downloading NSIS $env:NSIS_VERSION from $u (attempt $attempt/3)"
-                Invoke-WebRequest -Uri $u -OutFile $zip
-                if ((Test-Path $zip) -and ((Get-Item $zip).Length -gt 1MB)) {
-                  $downloaded = $true
-                  break
-                }
-                Write-Output "Downloaded file from $u was missing or too small"
-              } catch {
-                Write-Output "Download attempt $attempt failed: $($_.Exception.Message)"
+          for ($attempt = 1; $attempt -le 3; $attempt++) {
+            try {
+              Write-Output "Downloading NSIS $env:NSIS_VERSION from $url (attempt $attempt/3)"
+              Invoke-WebRequest -Uri $url -OutFile $zip
+              if ((Test-Path $zip) -and ((Get-Item $zip).Length -gt 1MB)) {
+                $downloaded = $true
+                break
               }
-              if ($attempt -lt 3) { Start-Sleep -Seconds 5 }
+              Write-Output "Downloaded file was missing or too small"
+            } catch {
+              Write-Output "Download attempt $attempt failed: $($_.Exception.Message)"
             }
-            if ($downloaded) { break }
-            Write-Output "Mirror failed: $u"
+            if ($attempt -lt 3) { Start-Sleep -Seconds 5 }
           }
           if (-not $downloaded) {
-            Write-Error "All NSIS mirrors failed"
+            Write-Error "NSIS download failed after 3 attempts"
             exit 1
           }
 


### PR DESCRIPTION
The Windows release leg has been failing on transient 5xx errors from community.chocolatey.org while resolving nsis.install — the v0.6.0-rc0 build hit a 503 mid-pull. Choco's community feed has a long history of this; the existing comment already acknowledged 499s.

Ninja already comes from the Visual Studio install on windows-latest, so the only thing we needed Choco for was NSIS. Replace it with a direct download of the pinned NSIS portable zip from SourceForge, plus a second SourceForge mirror as fallback and actions/cache so subsequent runs skip the fetch entirely.

Removes the single biggest external-dependency flake in the Windows release pipeline.