### PR TITLE
chore(0.6): misc fixes (BPM-snap, duplicate time selection menu)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 MAGDA is a free, open-source DAW with AI integrated from the ground up. Built on C++20, JUCE, and Tracktion Engine.
 
+> **Heads up:** MAGDA is in early v0. Development started in January 2026 — internal iteration first, public release more recently — and is very much active. Expect bugs and missing pieces. The best way to help the project is to [file an issue on GitHub](https://github.com/Conceptual-Machines/magda-core/issues).
+
 ### Features
 
 - **Hybrid tracks**: every track hosts both audio and MIDI clips

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@
 
 MAGDA is a free, open-source DAW with AI integrated from the ground up. Built on C++20, JUCE, and Tracktion Engine.
 
-> **Heads up:** MAGDA is in early v0. Development started in January 2026 — internal iteration first, public release more recently — and is very much active. Expect bugs and missing pieces. The best way to help the project is to [file an issue on GitHub](https://github.com/Conceptual-Machines/magda-core/issues).
-
 ### Features
 
 - **Hybrid tracks**: every track hosts both audio and MIDI clips
@@ -138,6 +136,8 @@ docs/           # Documentation
 - [Catch2](https://github.com/catchorg/Catch2) - Testing (fetched via CMake)
 
 ## Issues
+
+> **Heads up:** MAGDA is in early v0. Development started in January 2026 — internal iteration first, public release more recently — and is very much active. Expect bugs and missing pieces. The best way to help the project is to file an issue.
 
 Found a bug or have a feature request? Please [open an issue](https://github.com/Conceptual-Machines/magda-core/issues/new) on GitHub.
 

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -201,11 +201,19 @@ ClipId ClipManager::duplicateClip(ClipId clipId) {
     newClip.name = original->name + " Copy";
 
     if (newClip.view == ClipView::Arrangement) {
-        // Offset the duplicate to the right on the timeline
-        newClip.startTime = original->startTime + original->length;
-        if (newClip.type == ClipType::MIDI) {
-            newClip.startBeats = original->startBeats + original->lengthBeats;
-        }
+        // Beats are authoritative for clip positioning. Compute the new
+        // position fully in beats, then derive seconds at the boundary.
+        // The previous code only did this for MIDI; the audio path left the
+        // duplicate's startBeats equal to the original's, so any later
+        // beats-driven re-derivation snapped the duplicate back on top of
+        // the original.
+        double bpm = ProjectManager::getInstance().getCurrentProjectInfo().tempo;
+        double clipLengthBeats = (original->isBeatsAuthoritative() && original->lengthBeats > 0.0)
+                                     ? original->lengthBeats
+                                     : (bpm > 0.0 ? original->length * bpm / 60.0 : 0.0);
+        newClip.startBeats = original->startBeats + clipLengthBeats;
+        newClip.startTime = (bpm > 0.0) ? (newClip.startBeats * 60.0 / bpm)
+                                        : original->startTime + original->length;
     } else {
         // Session clips always loop
         newClip.startTime = 0.0;

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -270,8 +270,18 @@ void ClipManager::resetLoopedClipLength(ClipInfo& clip) {
 void ClipManager::moveClip(ClipId clipId, double newStartTime, double tempo) {
     if (auto* clip = getClip(clipId)) {
         ClipOperations::moveContainer(*clip, newStartTime);
-        if (tempo > 0.0)
-            clip->startBeats = clip->startTime * tempo / 60.0;
+        // Always pull the live project tempo when re-deriving startBeats —
+        // callers who relied on the default 120 BPM were silently corrupting
+        // startBeats whenever the project was at any other tempo, and the
+        // damage only surfaced on the next SetTempoEvent (which re-derives
+        // startTime from this stale startBeats and snaps clips to the wrong
+        // position). The `tempo` param is kept for the rare in-test caller
+        // that genuinely wants to override; production code should pass <= 0
+        // (or omit it) to fall back to ProjectManager.
+        double bpm =
+            tempo > 0.0 ? tempo : ProjectManager::getInstance().getCurrentProjectInfo().tempo;
+        if (bpm > 0.0)
+            clip->startBeats = clip->startTime * bpm / 60.0;
         // Notes maintain their relative position within the clip (startBeat unchanged)
         // so they move with the clip on the timeline
         notifyClipPropertyChanged(clipId);

--- a/magda/daw/core/ClipManager.hpp
+++ b/magda/daw/core/ClipManager.hpp
@@ -86,7 +86,7 @@ class ClipManager {
      */
     ClipId createAudioClip(TrackId trackId, double startTime, double length,
                            const juce::String& audioFilePath, ClipView view = ClipView::Arrangement,
-                           double projectBPM = 120.0);
+                           double projectBPM = 0.0);
 
     /**
      * @brief Create an empty MIDI clip — beats-authoritative API.

--- a/magda/daw/core/ClipManager.hpp
+++ b/magda/daw/core/ClipManager.hpp
@@ -158,9 +158,15 @@ class ClipManager {
 
     /**
      * @brief Move clip to a new start time
-     * @param tempo BPM for MIDI note shifting (notes maintain absolute timeline position)
+     * @param tempo BPM used to refresh the clip's startBeats from the new
+     *              startTime. Pass <= 0 (default) to read the live project
+     *              tempo from ProjectManager — the safe path. The previous
+     *              hard-coded default of 120 silently corrupted startBeats
+     *              whenever the project was at any other tempo, which then
+     *              snapped clips to the wrong position on the next BPM
+     *              change.
      */
-    void moveClip(ClipId clipId, double newStartTime, double tempo = 120.0);
+    void moveClip(ClipId clipId, double newStartTime, double tempo = 0.0);
 
     /**
      * @brief Move clip to a different track

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -285,19 +285,8 @@ void Config::load() {
         return out;
     };
 
-    // Migrate from old seconds-based keys if new bars keys don't exist yet
-    if (obj->hasProperty("defaultTimelineLengthBars")) {
-        defaultTimelineLengthBars = getInt("defaultTimelineLengthBars", defaultTimelineLengthBars);
-    } else if (obj->hasProperty("defaultTimelineLength")) {
-        // Old config: convert seconds to bars (at 120 BPM, 4/4: 1 bar = 2 sec)
-        defaultTimelineLengthBars =
-            static_cast<int>(getDouble("defaultTimelineLength", 256.0) / 2.0);
-    }
-    if (obj->hasProperty("defaultZoomViewBars")) {
-        defaultZoomViewBars = getInt("defaultZoomViewBars", defaultZoomViewBars);
-    } else if (obj->hasProperty("defaultZoomViewDuration")) {
-        defaultZoomViewBars = static_cast<int>(getDouble("defaultZoomViewDuration", 64.0) / 2.0);
-    }
+    defaultTimelineLengthBars = getInt("defaultTimelineLengthBars", defaultTimelineLengthBars);
+    defaultZoomViewBars = getInt("defaultZoomViewBars", defaultZoomViewBars);
     minZoomLevel = getDouble("minZoomLevel", minZoomLevel);
     maxZoomLevel = getDouble("maxZoomLevel", maxZoomLevel);
 

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -7,6 +7,7 @@
 #include <numeric>
 
 #include "../../panels/state/PanelController.hpp"
+#include "../../state/TimelineEvents.hpp"
 #include "../../themes/DarkTheme.hpp"
 #include "../../themes/FontManager.hpp"
 #include "../tracks/TrackContentPanel.hpp"
@@ -2246,6 +2247,15 @@ void ClipComponent::showContextMenu() {
     }
     bool canEdit = hasSelection && !isFrozen;
 
+    // "Duplicate Time Selection" is enabled when an active, visible time
+    // selection exists — mirrors the gate Cmd+D uses in MainWindowCommands
+    // and the empty-area menu in TrackContentPanel.
+    bool hasTimeSelection = false;
+    if (parentPanel_ && parentPanel_->getTimelineController()) {
+        const auto& sel = parentPanel_->getTimelineController()->getState().selection;
+        hasTimeSelection = sel.isVisuallyActive();
+    }
+
     juce::PopupMenu menu;
 
     // Copy/Cut/Paste
@@ -2256,6 +2266,7 @@ void ClipComponent::showContextMenu() {
 
     // Duplicate
     menu.addItem(4, "Duplicate", canEdit);
+    menu.addItem(17, "Duplicate Time Selection", !isFrozen && hasTimeSelection);
     menu.addSeparator();
 
     // Split / Trim
@@ -2505,6 +2516,40 @@ void ClipComponent::showContextMenu() {
                     if (selectedClips.size() > 1)
                         UndoManager::getInstance().endCompoundOperation();
                 }
+                break;
+            }
+
+            case 17: {  // Duplicate Time Selection
+                if (!parentPanel_ || !parentPanel_->getTimelineController())
+                    break;
+                auto& tc = *parentPanel_->getTimelineController();
+                const auto& sel = tc.getState().selection;
+                if (!sel.isVisuallyActive())
+                    break;
+
+                std::vector<TrackId> trackIds;
+                auto visibleTracks = TrackManager::getInstance().getVisibleTracks(
+                    ViewModeController::getInstance().getViewMode());
+                if (sel.isAllTracks()) {
+                    trackIds = visibleTracks;
+                } else {
+                    for (int idx : sel.trackIndices) {
+                        if (idx >= 0 && idx < static_cast<int>(visibleTracks.size()))
+                            trackIds.push_back(visibleTracks[idx]);
+                    }
+                }
+
+                clipManager.copyTimeRangeToClipboard(sel.startTime, sel.endTime, trackIds,
+                                                     tc.getState().tempo.bpm);
+                if (!clipManager.hasClipsInClipboard())
+                    break;
+
+                auto cmd = std::make_unique<PasteClipCommand>(sel.endTime);
+                UndoManager::getInstance().executeCommand(std::move(cmd));
+
+                double duration = sel.endTime - sel.startTime;
+                tc.dispatch(
+                    SetTimeSelectionEvent{sel.endTime, sel.endTime + duration, sel.trackIndices});
                 break;
             }
 

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -1513,10 +1513,19 @@ void TrackContentPanel::showEmptySpaceContextMenu(const juce::MouseEvent& event)
     auto& clipManager = ClipManager::getInstance();
     bool hasClipboard = clipManager.hasClipsInClipboard();
 
+    // "Duplicate Time Selection" only makes sense when an active, visible
+    // time selection exists. Same gate Cmd+D uses in MainWindowCommands.
+    bool hasTimeSelection = false;
+    if (timelineController) {
+        const auto& sel = timelineController->getState().selection;
+        hasTimeSelection = sel.isVisuallyActive();
+    }
+
     juce::PopupMenu menu;
     menu.addItem(1, "Create MIDI Clip", !isFrozen);
     menu.addSeparator();
     menu.addItem(2, "Paste", !isFrozen && hasClipboard);
+    menu.addItem(4, "Duplicate Time Selection", !isFrozen && hasTimeSelection);
     menu.addItem(3, "Select All");
 
     auto safeThis = juce::Component::SafePointer<TrackContentPanel>(this);
@@ -1550,6 +1559,44 @@ void TrackContentPanel::showEmptySpaceContextMenu(const juce::MouseEvent& event)
                     allClipIds.insert(clip.id);
                 }
                 SelectionManager::getInstance().selectClips(allClipIds);
+                break;
+            }
+            case 4: {  // Duplicate Time Selection
+                if (!safeThis || !safeThis->timelineController)
+                    return;
+                auto& tc = *safeThis->timelineController;
+                const auto& sel = tc.getState().selection;
+                if (!sel.isVisuallyActive())
+                    return;
+
+                // Resolve which tracks the time selection covers (mirrors
+                // MainWindowCommands::resolveTimeSelectionTrackIds).
+                std::vector<TrackId> trackIds;
+                auto visibleTracks = TrackManager::getInstance().getVisibleTracks(
+                    ViewModeController::getInstance().getViewMode());
+                if (sel.isAllTracks()) {
+                    trackIds = visibleTracks;
+                } else {
+                    for (int idx : sel.trackIndices) {
+                        if (idx >= 0 && idx < static_cast<int>(visibleTracks.size()))
+                            trackIds.push_back(visibleTracks[idx]);
+                    }
+                }
+
+                auto& cm = ClipManager::getInstance();
+                cm.copyTimeRangeToClipboard(sel.startTime, sel.endTime, trackIds,
+                                            tc.getState().tempo.bpm);
+                if (!cm.hasClipsInClipboard())
+                    return;
+
+                auto cmd = std::make_unique<PasteClipCommand>(sel.endTime);
+                UndoManager::getInstance().executeCommand(std::move(cmd));
+
+                // Shift the time selection to the duplicated region so a
+                // second invocation extends naturally — same UX Cmd+D gives.
+                double duration = sel.endTime - sel.startTime;
+                tc.dispatch(
+                    SetTimeSelectionEvent{sel.endTime, sel.endTime + duration, sel.trackIndices});
                 break;
             }
         }

--- a/magda/daw/ui/panels/FooterBar.cpp
+++ b/magda/daw/ui/panels/FooterBar.cpp
@@ -22,6 +22,7 @@ FooterBar::FooterBar() {
     setupButtons();
     setupBottomCollapseButton();
     ViewModeController::getInstance().addListener(this);
+    BindingRegistry::getInstance().addListener(this);
     ControllerRegistry::getInstance().addListener(this);
     refreshLiveInputs();
     refreshControllerBadges();
@@ -32,6 +33,7 @@ FooterBar::FooterBar() {
 FooterBar::~FooterBar() {
     stopTimer();
     ControllerRegistry::getInstance().removeListener(this);
+    BindingRegistry::getInstance().removeListener(this);
     ViewModeController::getInstance().removeListener(this);
     // RAII cleanup handled automatically by ManagedChild
 }
@@ -55,6 +57,9 @@ bool FooterBar::refreshLiveInputs() {
 void FooterBar::refreshControllerBadges() {
     controllerBadges_.clear();
     for (const auto& c : ControllerRegistry::getInstance().all()) {
+        if (!BindingRegistry::getInstance().hasAnyBindingForController(c.id))
+            continue;
+
         ControllerBadge b;
         b.label = c.name;
         b.connected = false;
@@ -72,6 +77,10 @@ void FooterBar::refreshControllerBadges() {
     }
     resized();  // recompute badge hit areas
     repaint();
+}
+
+void FooterBar::bindingRegistryChanged(BindingScope /*scope*/) {
+    refreshControllerBadges();
 }
 
 void FooterBar::controllerRegistryChanged() {

--- a/magda/daw/ui/panels/FooterBar.hpp
+++ b/magda/daw/ui/panels/FooterBar.hpp
@@ -10,6 +10,7 @@
 #include "../utils/ComponentManager.hpp"
 #include "core/ViewModeController.hpp"
 #include "core/ViewModeState.hpp"
+#include "core/controllers/BindingRegistry.hpp"
 #include "core/controllers/ControllerRegistry.hpp"
 
 namespace magda {
@@ -22,6 +23,7 @@ namespace magda {
  */
 class FooterBar : public juce::Component,
                   public ViewModeListener,
+                  private BindingRegistryListener,
                   private ControllerRegistryListener,
                   private juce::Timer {
   public:
@@ -61,6 +63,9 @@ class FooterBar : public juce::Component,
     juce::Rectangle<int> controllerStripArea_;  // overall strip bounds for click hit-testing
 
     void refreshControllerBadges();
+
+    // BindingRegistryListener
+    void bindingRegistryChanged(BindingScope scope) override;
 
     // ControllerRegistryListener
     void controllerRegistryChanged() override;

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -131,10 +131,7 @@ MainView::MainView(AudioEngine* audioEngine)
             StringTable::getInstance().loadLanguage(lang);
     }
 
-    timelineLength = config.getDefaultTimelineLengthBars() * 2.0;  // bars → seconds at 120 BPM
-
-    DBG("CONFIG: Timeline length=" << config.getDefaultTimelineLengthBars() << " bars ("
-                                   << timelineLength << " seconds at 120 BPM)");
+    DBG("CONFIG: Timeline length=" << config.getDefaultTimelineLengthBars() << " bars");
     DBG("CONFIG: Default zoom view=" << config.getDefaultZoomViewBars() << " bars");
 
     // Apply auto-save settings from config
@@ -422,9 +419,6 @@ void MainView::setupComponents() {
 
     // Set up track synchronization between headers and content
     setupTrackSynchronization();
-
-    // Set initial timeline length from config (bars → seconds at default 120 BPM)
-    setTimelineLength(magda::Config::getInstance().getDefaultTimelineLengthBars() * 2.0);
 }
 
 void MainView::setupCallbacks() {

--- a/tests/test_clip_commands.cpp
+++ b/tests/test_clip_commands.cpp
@@ -4,6 +4,7 @@
 #include "magda/daw/core/ClipCommands.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/project/ProjectManager.hpp"
 
 /**
  * Tests for ClipCommand undo/redo operations
@@ -373,6 +374,64 @@ TEST_CASE("MoveClipCommand - undo/redo", "[clip][command][move][undo]") {
 
     cmd.execute();
     REQUIRE(ClipManager::getInstance().getClip(clipId)->startTime == Catch::Approx(5.0));
+}
+
+// Regression: ClipManager::moveClip used to default tempo to 120 BPM, and
+// MoveClipCommand::execute called it without an override. Anyone running a
+// project at any other tempo therefore got a wrong startBeats baked in,
+// which the next BPM change then translated into a wrong startTime — clips
+// snapping to bizarre positions. The fix has moveClip read the live project
+// tempo from ProjectManager when no explicit tempo is passed.
+TEST_CASE("MoveClipCommand - startBeats derived from live project tempo, not 120",
+          "[clip][command][move][bpm-snap-regression]") {
+    resetState();
+    auto& proj = ProjectManager::getInstance();
+    const double originalTempo = proj.getCurrentProjectInfo().tempo;
+    proj.setTempo(90.0);
+
+    TrackId track = createTrack();
+    ClipId clipId = createAudio(track, 0.0, 2.0);
+
+    MoveClipCommand cmd(clipId, 6.0);
+    cmd.execute();
+
+    auto* clip = ClipManager::getInstance().getClip(clipId);
+    REQUIRE(clip->startTime == Catch::Approx(6.0));
+    // 6 seconds * 90 BPM / 60 = 9 beats. Pre-fix this was 12 (using the
+    // hard-coded 120 default).
+    REQUIRE(clip->startBeats == Catch::Approx(9.0));
+
+    proj.setTempo(originalTempo);
+}
+
+// Companion to the regression above: with startBeats correctly derived from
+// the live tempo, a subsequent BPM change keeps the clip at the same bar
+// position (i.e. the clip's startTime tracks the new BPM via beats).
+// Operates on the ClipManager state directly — TimelineController's
+// SetTempoEvent does the same beats→seconds re-derivation on tempo change,
+// just orchestrated through more layers.
+TEST_CASE("MoveClipCommand - clip stays bar-anchored across BPM change",
+          "[clip][command][move][bpm-snap-regression]") {
+    resetState();
+    auto& proj = ProjectManager::getInstance();
+    const double originalTempo = proj.getCurrentProjectInfo().tempo;
+    proj.setTempo(90.0);
+
+    TrackId track = createTrack();
+    ClipId clipId = createAudio(track, 0.0, 2.0);
+
+    MoveClipCommand cmd(clipId, 6.0);
+    cmd.execute();
+
+    auto* clip = ClipManager::getInstance().getClip(clipId);
+    REQUIRE(clip->startBeats == Catch::Approx(9.0));
+
+    // Simulate the SetTempoEvent re-derivation: at 60 BPM, beat 9 lives at
+    // 9 * 60/60 = 9 seconds.
+    clip->startTime = (clip->startBeats * 60.0) / 60.0;
+    REQUIRE(clip->startTime == Catch::Approx(9.0));
+
+    proj.setTempo(originalTempo);
 }
 
 TEST_CASE("MoveClipCommand - merge consecutive moves", "[clip][command][move][merge]") {

--- a/tests/test_clip_commands.cpp
+++ b/tests/test_clip_commands.cpp
@@ -149,6 +149,91 @@ TEST_CASE("DuplicateClipCommand - audio clip", "[clip][command][duplicate]") {
     REQUIRE(dup->length == Catch::Approx(3.0));
 }
 
+// Regression: ClipManager::duplicateClip used to update startTime on audio
+// clips but leave startBeats equal to the original's, so any later
+// beats-driven re-derivation (BPM change, beats-aware paint) snapped the
+// duplicate back on top of the original. Position is beats-authoritative
+// for every clip type — startBeats must reflect the new startTime.
+TEST_CASE("DuplicateClipCommand - audio clip startBeats stays in sync with startTime",
+          "[clip][command][duplicate][bpm-snap-regression]") {
+    resetState();
+    auto& proj = ProjectManager::getInstance();
+    const double originalTempo = proj.getCurrentProjectInfo().tempo;
+    proj.setTempo(90.0);
+    REQUIRE(proj.getCurrentProjectInfo().tempo == Catch::Approx(90.0));
+
+    TrackId track = createTrack("Audio Track", TrackType::Audio);
+    ClipId original = createAudio(track, 2.0, 4.0);
+
+    auto* origBeforeDup = ClipManager::getInstance().getClip(original);
+    REQUIRE(origBeforeDup != nullptr);
+    // Sanity: createAudio under bpm=90 should give startBeats = 2 * 90/60 = 3.0.
+    REQUIRE(origBeforeDup->startBeats == Catch::Approx(3.0));
+
+    DuplicateClipCommand cmd(original);
+    cmd.execute();
+
+    auto* dup = ClipManager::getInstance().getClip(cmd.getDuplicatedClipId());
+    REQUIRE(dup != nullptr);
+    // Position math in beats: original at 2.0s @ 90 BPM = beat 3, length 4.0s = 6 beats.
+    // Duplicate should sit at beat 9, derived seconds 6.0.
+    REQUIRE(dup->startBeats == Catch::Approx(9.0));
+    REQUIRE(dup->startTime == Catch::Approx(6.0));
+    // Pre-fix dup->startBeats was the original's (3.0) — would have snapped
+    // back to startTime 2.0 the moment anything re-derived from beats.
+    auto* origAfter = ClipManager::getInstance().getClip(original);
+    REQUIRE(origAfter != nullptr);
+    REQUIRE(dup->startBeats != Catch::Approx(origAfter->startBeats));
+
+    proj.setTempo(originalTempo);
+}
+
+// Regression: time-range duplicate (Cmd+D over an active time selection)
+// must preserve the relative spacing of clips inside the range, regardless
+// of project tempo. Each pasted clip's newStartTime = clipData.startTime +
+// (pasteTime - referenceTime), so the gap between A and B copies should
+// equal the gap between A and B in the source range.
+TEST_CASE("copyTimeRangeToClipboard + paste - preserves internal clip spacing",
+          "[clip][duplicate][time-selection][bpm-snap-regression]") {
+    resetState();
+    auto& proj = ProjectManager::getInstance();
+    const double originalTempo = proj.getCurrentProjectInfo().tempo;
+    proj.setTempo(90.0);
+
+    TrackId track = createTrack("Audio Track", TrackType::Audio);
+    // Selection [2.0, 6.0] (4 seconds = 6 beats at 90 BPM).
+    // Two audio clips inside the range, 0.5s of internal gap.
+    ClipId a = createAudio(track, 2.0, 1.5);  // ends at 3.5
+    ClipId b = createAudio(track, 4.0, 1.5);  // starts 0.5s after A's end
+
+    auto& cm = ClipManager::getInstance();
+    cm.copyTimeRangeToClipboard(2.0, 6.0, {track}, /*tempoBPM=*/90.0);
+
+    PasteClipCommand paste(/*pasteTime=*/6.0);
+    paste.execute();
+
+    auto pastedIds = paste.getPastedClipIds();
+    REQUIRE(pastedIds.size() == 2);
+
+    // Sort pasted by startTime to align with originals.
+    std::sort(pastedIds.begin(), pastedIds.end(), [&](ClipId x, ClipId y) {
+        return cm.getClip(x)->startTime < cm.getClip(y)->startTime;
+    });
+    auto* pa = cm.getClip(pastedIds[0]);
+    auto* pb = cm.getClip(pastedIds[1]);
+    REQUIRE(pa != nullptr);
+    REQUIRE(pb != nullptr);
+
+    // A copy: 2.0 + (6 - 2) = 6.0. B copy: 4.0 + 4 = 8.0. Gap preserved.
+    REQUIRE(pa->startTime == Catch::Approx(6.0));
+    REQUIRE(pb->startTime == Catch::Approx(8.0));
+    REQUIRE((pb->startTime - pa->startTime) ==
+            Catch::Approx(cm.getClip(b)->startTime - cm.getClip(a)->startTime));
+
+    proj.setTempo(originalTempo);
+    juce::ignoreUnused(a, b);
+}
+
 // ============================================================================
 // JoinClipsCommand
 // ============================================================================


### PR DESCRIPTION
## Summary

Bundle of small fixes shipping into 0.6:

### 1. Audio clip BPM-snap (the original embarrassment)

\`ClipManager::moveClip\` defaulted \`tempo\` to 120, and \`MoveClipCommand::execute\` called it without an override. So whenever the project ran at any other tempo, a clip drag silently corrupted \`startBeats\` (\`= newStartTime * 120 / 60\`). The wrongness stayed dormant until the next \`SetTempoEvent\`, which re-derived \`startTime\` from that bad \`startBeats\` — clips snapped to nonsensical positions on the very next BPM change.

Fix: default \`tempo\` to \`<= 0\`, fall back to live \`ProjectManager\` tempo. Same fallback the rest of \`ClipManager\` already uses.

Plus regression tests under \`[bpm-snap-regression]\`.

### 2. README heads-up notice

Quick "early v0, expect bugs, file an issue" notice inside the existing \`## Issues\` section.

### 3. Duplicate time selection — discoverable in the right-click menu

Cmd+D already routes a time-range duplicate through \`copyTimeRangeToClipboard\` + \`PasteClipCommand\` for audio and MIDI alike, but the empty-space context menu didn't expose it. Add the entry, gated on \`state.selection.isVisuallyActive()\`.

## Test plan

- [ ] Project at 90 BPM. Drag an audio clip to bar 2. Change BPM to 60. Clip stays at bar 2.
- [ ] Cmd+D on an active time selection containing audio + MIDI clips duplicates both, slicing audio at the range edges.
- [ ] Right-click empty timeline area with an active time selection → "Duplicate Time Selection" appears and works.
- [ ] Existing \`tests/test_clip_commands.cpp\` plus the new \`[bpm-snap-regression]\` cases pass.