### PR TITLE
chore(0.6): theme polish on JUCE-drawn title bars + controller learn fix

### DIFF
--- a/magda/daw/audio/ControllerRouter.cpp
+++ b/magda/daw/audio/ControllerRouter.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 
-#include "../core/SelectionManager.hpp"
 #include "../core/aliases/AliasRegistry.hpp"
 #include "../core/aliases/ChainContext.hpp"
 #include "../core/aliases/ResolverRegistry.hpp"
@@ -384,19 +383,6 @@ void ControllerRouter::executeWrite(const BindingId& bindingId, int rawValue, in
         DBG("ControllerRouter: target resolve FAILED (" << resolved.sourceLabel << ") for binding "
                                                         << bindingId.toDashedString());
         return;
-    }
-
-    // Contextual firing: if the resolved target is pinned to a specific track,
-    // the binding only fires while that track is the selected track. Targets
-    // without a track pin (master, @focused.*, @selected.*) fire regardless.
-    const TrackId targetTrackId = resolved.devicePath.trackId;
-    if (targetTrackId != INVALID_TRACK_ID) {
-        const TrackId selected = SelectionManager::getInstance().getSelectedTrack();
-        if (selected != targetTrackId) {
-            DBG("ControllerRouter: gated — binding target is on track "
-                << targetTrackId << " but selected is " << selected);
-            return;
-        }
     }
 
     DBG("ControllerRouter: WRITE value=" << finalValue << " to " << resolved.sourceLabel);

--- a/magda/daw/engine/MagdaUIBehaviour.cpp
+++ b/magda/daw/engine/MagdaUIBehaviour.cpp
@@ -3,6 +3,8 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <tracktion_engine/tracktion_engine.h>
 
+#include "../ui/themes/MainLookAndFeel.hpp"
+
 namespace magda {
 
 // =============================================================================
@@ -107,6 +109,7 @@ PluginEditorWindow::PluginEditorWindow(tracktion::Plugin& plugin,
     // with Tracktion's window ownership. Using JUCE's title bar gives us
     // complete control - nothing happens after closeButtonPressed() unless we do it.
     setUsingNativeTitleBar(false);
+    setTitleBarHeight(MainLookAndFeel::kTitleBarHeight);
 
     // Keep plugin window always on top so it doesn't go behind main window when user interacts with
     // parameters

--- a/magda/daw/ui/themes/DarkTheme.cpp
+++ b/magda/daw/ui/themes/DarkTheme.cpp
@@ -28,6 +28,7 @@ void DarkTheme::applyToLookAndFeel(juce::LookAndFeel_V4& laf) {
     laf.setColour(juce::TextEditor::backgroundColourId, getColour(SURFACE));
     laf.setColour(juce::TextEditor::outlineColourId, getColour(BORDER));
     laf.setColour(juce::TextEditor::focusedOutlineColourId, getColour(ACCENT_BLUE));
+    laf.setColour(juce::CaretComponent::caretColourId, getColour(TEXT_PRIMARY));
 
     // Button colors
     laf.setColour(juce::TextButton::buttonColourId, getColour(BUTTON_NORMAL));

--- a/magda/daw/ui/themes/MainLookAndFeel.hpp
+++ b/magda/daw/ui/themes/MainLookAndFeel.hpp
@@ -9,6 +9,8 @@ namespace magda {
 
 class MainLookAndFeel : public juce::LookAndFeel_V4 {
   public:
+    static constexpr int kTitleBarHeight = 22;
+
     MainLookAndFeel() = default;
     ~MainLookAndFeel() override = default;
 

--- a/magda/daw/ui/themes/MainLookAndFeel.hpp
+++ b/magda/daw/ui/themes/MainLookAndFeel.hpp
@@ -43,13 +43,17 @@ class MainLookAndFeel : public juce::LookAndFeel_V4 {
             textX = titleSpaceX + titleSpaceW - textW;
 
         if (icon != nullptr) {
-            g.setOpacity(isActive ? 1.0f : 0.6f);
-            g.drawImageWithin(*icon, textX, (h - iconH) / 2, iconW, iconH,
-                              juce::RectanglePlacement::centred, false);
-            textX += iconW;
-            textW -= iconW;
+            const auto drawnIconW = juce::jmin(iconW, textW);
+            if (drawnIconW > 0) {
+                g.setOpacity(isActive ? 1.0f : 0.6f);
+                g.drawImageWithin(*icon, textX, (h - iconH) / 2, drawnIconW, iconH,
+                                  juce::RectanglePlacement::centred, false);
+                textX += drawnIconW;
+            }
+            textW = juce::jmax(0, textW - drawnIconW);
         }
 
+        g.setOpacity(isActive ? 1.0f : 0.6f);
         if (window.isColourSpecified(juce::DocumentWindow::textColourId) ||
             isColourSpecified(juce::DocumentWindow::textColourId))
             g.setColour(window.findColour(juce::DocumentWindow::textColourId));

--- a/magda/daw/ui/themes/MainLookAndFeel.hpp
+++ b/magda/daw/ui/themes/MainLookAndFeel.hpp
@@ -3,6 +3,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include "DarkTheme.hpp"
+#include "FontManager.hpp"
 
 namespace magda {
 
@@ -10,6 +11,52 @@ class MainLookAndFeel : public juce::LookAndFeel_V4 {
   public:
     MainLookAndFeel() = default;
     ~MainLookAndFeel() override = default;
+
+    void drawDocumentWindowTitleBar(juce::DocumentWindow& window, juce::Graphics& g, int w, int h,
+                                    int titleSpaceX, int titleSpaceW, const juce::Image* icon,
+                                    bool drawTitleTextOnLeft) override {
+        if (w * h == 0)
+            return;
+
+        const bool isActive = window.isActiveWindow();
+
+        g.setColour(getCurrentColourScheme().getUIColour(
+            juce::LookAndFeel_V4::ColourScheme::widgetBackground));
+        g.fillAll();
+
+        auto font = FontManager::getInstance().getUIFontMedium(static_cast<float>(h) * 0.55f);
+        g.setFont(font);
+
+        auto textW = juce::GlyphArrangement::getStringWidthInt(font, window.getName());
+        int iconW = 0;
+        int iconH = 0;
+        if (icon != nullptr) {
+            iconH = static_cast<int>(font.getHeight());
+            iconW = icon->getWidth() * iconH / icon->getHeight() + 4;
+        }
+
+        textW = juce::jmin(titleSpaceW, textW + iconW);
+        int textX = drawTitleTextOnLeft ? titleSpaceX : juce::jmax(titleSpaceX, (w - textW) / 2);
+        if (textX + textW > titleSpaceX + titleSpaceW)
+            textX = titleSpaceX + titleSpaceW - textW;
+
+        if (icon != nullptr) {
+            g.setOpacity(isActive ? 1.0f : 0.6f);
+            g.drawImageWithin(*icon, textX, (h - iconH) / 2, iconW, iconH,
+                              juce::RectanglePlacement::centred, false);
+            textX += iconW;
+            textW -= iconW;
+        }
+
+        if (window.isColourSpecified(juce::DocumentWindow::textColourId) ||
+            isColourSpecified(juce::DocumentWindow::textColourId))
+            g.setColour(window.findColour(juce::DocumentWindow::textColourId));
+        else
+            g.setColour(getCurrentColourScheme().getUIColour(
+                juce::LookAndFeel_V4::ColourScheme::defaultText));
+
+        g.drawText(window.getName(), textX, 0, textW, h, juce::Justification::centredLeft, true);
+    }
 
     juce::Button* createDocumentWindowButton(int buttonType) override {
         juce::Path shape;

--- a/magda/daw/ui/windows/MainWindow.cpp
+++ b/magda/daw/ui/windows/MainWindow.cpp
@@ -19,6 +19,7 @@
 #include "../state/TimelineController.hpp"
 #include "../state/TimelineEvents.hpp"
 #include "../themes/DarkTheme.hpp"
+#include "../themes/MainLookAndFeel.hpp"
 #include "../views/MainView.hpp"
 #include "../views/MixerView.hpp"
 #include "../views/SessionView.hpp"
@@ -188,6 +189,7 @@ MainWindow::MainWindow(AudioEngine* audioEngine)
     // request native decorations, hiding the menu bar. JUCE-drawn decorations
     // lay out the menu correctly on every WM.
     setUsingNativeTitleBar(false);
+    setTitleBarHeight(MainLookAndFeel::kTitleBarHeight);
 #else
     setUsingNativeTitleBar(true);
 #endif


### PR DESCRIPTION
Bundled 0.6-RC follow-ups.

## Theme — JUCE-drawn title bars
The Linux/Wayland fix flipped the main window to a JUCE-drawn title bar and added a V4 ColourScheme to style it. That left a few rough edges:

- The V4 ColourScheme left \`juce::CaretComponent::caretColourId\` at the JUCE default — effectively black on dark TextEditor surfaces, so the blinking caret was invisible in the search box, AI console, inspector text fields, etc. Set to \`TEXT_PRIMARY\`.
- \`MainLookAndFeel::drawDocumentWindowTitleBar\` now renders titles with \`FontManager::getUIFontMedium\` instead of JUCE's default typeface. Affects every JUCE-drawn title bar — plugin editor windows on every OS, plus the main window on Linux.
- \`MainLookAndFeel::kTitleBarHeight = 22\` (down from JUCE's 26), applied to plugin editor windows on every OS and the main window on Linux. Single tunable knob.
- Copilot review fixes: clamped icon width so it can't drive \`textW\` negative on tiny windows, and the title text now follows active/inactive opacity instead of leaking the icon-block opacity.

## Controllers — gate fix
\`ControllerRouter::dispatch\` had a contextual-firing gate: if a binding's resolved devicePath had a trackId, it would only fire when that track was the \`SelectionManager\`'s selected track. Intent was per-track context, but it silently killed every explicit instance-pinned binding the moment selection moved off that track — e.g. opening Serum's plugin window flipped selection to \`MASTER_TRACK_ID\` (-2), and every subsequent MIDI move on a learned controller was dropped. Dynamic-resolver targets like \`@focused.macro\` self-gate via the resolver, so removing this block doesn't change their behaviour.

Repro: bind a controller knob to \`serum_2.macro_1\`, open Serum's plugin window, wiggle the knob — pre-fix every dispatch logged \`gated — binding target is on track 1 but selected is -2\` and the VST param never moved.

## Test plan
- [x] Caret visible in TextEditor fields
- [x] Plugin editor window title bar uses Inter
- [x] Plugin editor window title bar height is 22
- [x] Bound controller drives a VST macro regardless of current track selection
- [ ] Verify caret + title bar on Linux