### PR TITLE
fix(controllers): drop track-pinned binding gate that killed VST learn

### DIFF
--- a/magda/daw/audio/ControllerRouter.cpp
+++ b/magda/daw/audio/ControllerRouter.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 
-#include "../core/SelectionManager.hpp"
 #include "../core/aliases/AliasRegistry.hpp"
 #include "../core/aliases/ChainContext.hpp"
 #include "../core/aliases/ResolverRegistry.hpp"
@@ -384,19 +383,6 @@ void ControllerRouter::executeWrite(const BindingId& bindingId, int rawValue, in
         DBG("ControllerRouter: target resolve FAILED (" << resolved.sourceLabel << ") for binding "
                                                         << bindingId.toDashedString());
         return;
-    }
-
-    // Contextual firing: if the resolved target is pinned to a specific track,
-    // the binding only fires while that track is the selected track. Targets
-    // without a track pin (master, @focused.*, @selected.*) fire regardless.
-    const TrackId targetTrackId = resolved.devicePath.trackId;
-    if (targetTrackId != INVALID_TRACK_ID) {
-        const TrackId selected = SelectionManager::getInstance().getSelectedTrack();
-        if (selected != targetTrackId) {
-            DBG("ControllerRouter: gated — binding target is on track "
-                << targetTrackId << " but selected is " << selected);
-            return;
-        }
     }
 
     DBG("ControllerRouter: WRITE value=" << finalValue << " to " << resolved.sourceLabel);


### PR DESCRIPTION
## Summary

`ControllerRouter::dispatch` had a contextual-firing gate: if the resolved target's devicePath had a trackId, it would only fire when that exact trackId was the `SelectionManager`'s selected track. The intent was to make alias/static bindings track-sensitive, but it silently killed every explicit instance-pinned binding the moment selection moved off that track — e.g. opening the VST's plugin window flipped selection to \`MASTER_TRACK_ID\` (-2), and every subsequent MIDI move from a learned controller hit the gate and was dropped.

Dynamic-resolver targets like \`@focused.macro\` / \`@selected.macro\` self-gate naturally — when no track is focused/selected, the resolver fails and the binding doesn't fire — so removing this block doesn't change their behaviour. What it does fix is the user's mental model: when I bind knob 21 to "Serum 2 Macro 1", that knob controls Serum 2 Macro 1 regardless of which track is currently selected.

## Repro from the log
1. Add a Serum 2 instance on track 1
2. Right-click Macro 1 → MIDI Learn
3. Wiggle knob 21 — alias \`serum_2.macro_1\` is bound, "project binding created"
4. Open Serum's plugin window — selection flips to MASTER_TRACK_ID (-2)
5. Wiggle the knob — every dispatch logged \`gated — binding target is on track 1 but selected is -2\` and the VST param never moved

## Test plan
- [x] Bind a controller to a VST macro, switch tracks, controller still drives the macro
- [x] \`@focused.macro_1\` style bindings still self-gate (resolver fails when nothing focused)