### PR TITLE
refactor(agents): introduce MagdaApi, migrate automation_executor (#1113) [PR1/N]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ rebuild: clean debug
 format:
 	@echo "🎨 Formatting code..."
 	@if command -v clang-format >/dev/null 2>&1; then \
-		find . -name "*.cpp" -o -name "*.hpp" -o -name "*.h" | grep -E "(daw|agents|tests)" | xargs clang-format -i; \
+		find magda tests \( -name "*.cpp" -o -name "*.hpp" -o -name "*.h" \) | xargs clang-format -i; \
 		echo "✅ Code formatting complete"; \
 	else \
 		echo "❌ clang-format not found. Please install it first."; \

--- a/magda/agents/automation_agent.hpp
+++ b/magda/agents/automation_agent.hpp
@@ -11,6 +11,8 @@
 
 namespace magda {
 
+class MagdaApi;
+
 /**
  * @brief Automation agent — emits automation curves on a selected lane.
  *
@@ -21,10 +23,12 @@ namespace magda {
  *   1. Call LLM with system prompt describing AUTO grammar + current
  *      selection context
  *   2. Parse response into AutoInstruction IR
- *   3. Execute against AutomationManager (must be on message thread)
+ *   3. Execute against the MagdaApi automation surface (message thread)
  */
 class AutomationAgent {
   public:
+    explicit AutomationAgent(MagdaApi& api) : executor_(api) {}
+
     struct GenerateResult {
         std::string rawOutput;
         std::vector<AutoInstruction> instructions;

--- a/magda/agents/automation_executor.cpp
+++ b/magda/agents/automation_executor.cpp
@@ -34,8 +34,8 @@ TrackId getSelectedTrack(MagdaApi& api, juce::String& err) {
     if (trackId == INVALID_TRACK_ID) {
         // Also consult the automation-lane selection for its track, so that
         // clicking a lane counts as "having a track context" too.
-        if (sel.hasAutomationLaneSelection()) {
-            auto laneId = sel.getAutomationLaneSelection().laneId;
+        auto laneId = sel.getSelectedAutomationLaneId();
+        if (laneId != INVALID_AUTOMATION_LANE_ID) {
             if (auto* lane = api.automation().getLane(laneId))
                 return lane->target.trackId;
         }
@@ -67,8 +67,9 @@ AutomationLaneId resolveTarget(MagdaApi& api, const AutoTarget& target, juce::St
         }
         case AutoTarget::Kind::Selected: {
             auto& sel = api.selection();
-            if (sel.hasAutomationLaneSelection())
-                return sel.getAutomationLaneSelection().laneId;
+            auto laneId = sel.getSelectedAutomationLaneId();
+            if (laneId != INVALID_AUTOMATION_LANE_ID)
+                return laneId;
             // Fall back to trackVolume on the selected track — the most
             // common default for "automate this track".
             auto trackId = getSelectedTrack(api, err);

--- a/magda/agents/automation_executor.cpp
+++ b/magda/agents/automation_executor.cpp
@@ -2,8 +2,10 @@
 
 #include <cmath>
 
-#include "../daw/core/AutomationManager.hpp"
-#include "../daw/core/SelectionManager.hpp"
+#include "../daw/api/alias_api.hpp"
+#include "../daw/api/automation_api.hpp"
+#include "../daw/api/magda_api.hpp"
+#include "../daw/api/selection_api.hpp"
 #include "../daw/core/aliases/AliasRegistry.hpp"
 #include "../daw/core/aliases/ChainContext.hpp"
 #include "../daw/core/aliases/ParamSigilParser.hpp"
@@ -26,15 +28,15 @@ double clampNorm(double v) {
 }
 
 /** Get selected track id, or INVALID if none. */
-TrackId getSelectedTrack(juce::String& err) {
-    auto& sel = SelectionManager::getInstance();
+TrackId getSelectedTrack(MagdaApi& api, juce::String& err) {
+    auto& sel = api.selection();
     auto trackId = sel.getSelectedTrack();
     if (trackId == INVALID_TRACK_ID) {
         // Also consult the automation-lane selection for its track, so that
         // clicking a lane counts as "having a track context" too.
         if (sel.hasAutomationLaneSelection()) {
             auto laneId = sel.getAutomationLaneSelection().laneId;
-            if (auto* lane = AutomationManager::getInstance().getLane(laneId))
+            if (auto* lane = api.automation().getLane(laneId))
                 return lane->target.trackId;
         }
         err = "No track is selected. Click a track first.";
@@ -44,8 +46,8 @@ TrackId getSelectedTrack(juce::String& err) {
 }
 
 /** Look up an existing lane for a target, creating it if needed. */
-AutomationLaneId ensureLaneForTarget(const AutomationTarget& target) {
-    auto& mgr = AutomationManager::getInstance();
+AutomationLaneId ensureLaneForTarget(MagdaApi& api, const AutomationTarget& target) {
+    auto& mgr = api.automation();
     auto existing = mgr.getLaneForTarget(target);
     if (existing != INVALID_AUTOMATION_LANE_ID)
         return existing;
@@ -53,10 +55,10 @@ AutomationLaneId ensureLaneForTarget(const AutomationTarget& target) {
 }
 
 /** Resolve an AutoTarget into a concrete lane id, or INVALID. */
-AutomationLaneId resolveTarget(const AutoTarget& target, juce::String& err) {
+AutomationLaneId resolveTarget(MagdaApi& api, const AutoTarget& target, juce::String& err) {
     switch (target.kind) {
         case AutoTarget::Kind::LaneId: {
-            auto* lane = AutomationManager::getInstance().getLane(target.laneId);
+            auto* lane = api.automation().getLane(target.laneId);
             if (lane == nullptr) {
                 err = "Lane " + juce::String(target.laneId) + " does not exist";
                 return INVALID_AUTOMATION_LANE_ID;
@@ -64,36 +66,36 @@ AutomationLaneId resolveTarget(const AutoTarget& target, juce::String& err) {
             return target.laneId;
         }
         case AutoTarget::Kind::Selected: {
-            auto& sel = SelectionManager::getInstance();
+            auto& sel = api.selection();
             if (sel.hasAutomationLaneSelection())
                 return sel.getAutomationLaneSelection().laneId;
             // Fall back to trackVolume on the selected track — the most
             // common default for "automate this track".
-            auto trackId = getSelectedTrack(err);
+            auto trackId = getSelectedTrack(api, err);
             if (trackId == INVALID_TRACK_ID)
                 return INVALID_AUTOMATION_LANE_ID;
             AutomationTarget t;
             t.type = AutomationTargetType::TrackVolume;
             t.trackId = trackId;
-            return ensureLaneForTarget(t);
+            return ensureLaneForTarget(api, t);
         }
         case AutoTarget::Kind::TrackVolume: {
-            auto trackId = getSelectedTrack(err);
+            auto trackId = getSelectedTrack(api, err);
             if (trackId == INVALID_TRACK_ID)
                 return INVALID_AUTOMATION_LANE_ID;
             AutomationTarget t;
             t.type = AutomationTargetType::TrackVolume;
             t.trackId = trackId;
-            return ensureLaneForTarget(t);
+            return ensureLaneForTarget(api, t);
         }
         case AutoTarget::Kind::TrackPan: {
-            auto trackId = getSelectedTrack(err);
+            auto trackId = getSelectedTrack(api, err);
             if (trackId == INVALID_TRACK_ID)
                 return INVALID_AUTOMATION_LANE_ID;
             AutomationTarget t;
             t.type = AutomationTargetType::TrackPan;
             t.trackId = trackId;
-            return ensureLaneForTarget(t);
+            return ensureLaneForTarget(api, t);
         }
         case AutoTarget::Kind::Alias: {
             auto sigil = tryParse(target.aliasToken);
@@ -102,7 +104,7 @@ AutomationLaneId resolveTarget(const AutoTarget& target, juce::String& err) {
                 return INVALID_AUTOMATION_LANE_ID;
             }
             DefaultChainContext ctx;
-            TargetResolver resolver(AliasRegistry::getInstance(), ResolverRegistry::getInstance(),
+            TargetResolver resolver(api.aliases().aliasRegistry(), api.aliases().resolverRegistry(),
                                     ctx);
             auto resolved = resolver.resolveSigil(*sigil);
             if (!resolved.ok()) {
@@ -116,7 +118,7 @@ AutomationLaneId resolveTarget(const AutoTarget& target, juce::String& err) {
             t.paramIndex = resolved.paramIndex;
             // Derive track id from device path
             t.trackId = resolved.devicePath.trackId;
-            return ensureLaneForTarget(t);
+            return ensureLaneForTarget(api, t);
         }
     }
     err = "Unknown target kind";
@@ -124,9 +126,7 @@ AutomationLaneId resolveTarget(const AutoTarget& target, juce::String& err) {
 }
 
 /** Emit points into a lane for a given shape op. Values already normalized. */
-void emitShapePoints(AutomationLaneId laneId, const AutoShapeOp& op) {
-    auto& mgr = AutomationManager::getInstance();
-
+void emitShapePoints(AutomationApi& mgr, AutomationLaneId laneId, const AutoShapeOp& op) {
     const double minV = clampNorm(op.minV);
     const double maxV = clampNorm(op.maxV);
     const double center = 0.5 * (minV + maxV);
@@ -227,7 +227,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
     error_.clear();
     results_.clear();
 
-    auto& mgr = AutomationManager::getInstance();
+    auto& mgr = api_.automation();
     int laneCount = 0;
     int pointCount = 0;
 
@@ -236,14 +236,14 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
     // AutomationPlaybackEngine answers with a full bakeLane() — producing
     // O(n) bakes for an n-point curve and a visible stall between the agent
     // completing and the curve appearing.
-    AutomationManager::BatchScope batchScope;
+    AutomationApi::BatchScope batchScope(mgr);
 
     for (const auto& inst : instructions) {
         juce::String err;
 
         if (std::holds_alternative<AutoClearOp>(inst.payload)) {
             auto& op = std::get<AutoClearOp>(inst.payload);
-            auto laneId = resolveTarget(op.target, err);
+            auto laneId = resolveTarget(api_, op.target, err);
             if (laneId == INVALID_AUTOMATION_LANE_ID) {
                 error_ = err;
                 return false;
@@ -255,7 +255,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
 
         if (std::holds_alternative<AutoFreeformOp>(inst.payload)) {
             auto& op = std::get<AutoFreeformOp>(inst.payload);
-            auto laneId = resolveTarget(op.target, err);
+            auto laneId = resolveTarget(api_, op.target, err);
             if (laneId == INVALID_AUTOMATION_LANE_ID) {
                 error_ = err;
                 return false;
@@ -270,7 +270,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
 
         if (std::holds_alternative<AutoShapeOp>(inst.payload)) {
             auto& op = std::get<AutoShapeOp>(inst.payload);
-            auto laneId = resolveTarget(op.target, err);
+            auto laneId = resolveTarget(api_, op.target, err);
             if (laneId == INVALID_AUTOMATION_LANE_ID) {
                 error_ = err;
                 return false;
@@ -278,7 +278,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
             int before = 0;
             if (auto* lane = mgr.getLane(laneId))
                 before = static_cast<int>(lane->absolutePoints.size());
-            emitShapePoints(laneId, op);
+            emitShapePoints(mgr, laneId, op);
             int after = 0;
             if (auto* lane = mgr.getLane(laneId))
                 after = static_cast<int>(lane->absolutePoints.size());

--- a/magda/agents/automation_executor.hpp
+++ b/magda/agents/automation_executor.hpp
@@ -8,17 +8,21 @@
 
 namespace magda {
 
+class MagdaApi;
+
 /**
- * @brief Executes AutomationAgent IR against AutomationManager.
+ * @brief Executes AutomationAgent IR against the MagdaApi automation surface.
  *
- * Resolves the "selected" target from SelectionManager, generates shape
- * points in beats, and writes them via AutomationManager::addPoint.
+ * Resolves the "selected" target via the host's selection state, generates
+ * shape points in beats, and writes them through MagdaApi::automation().
  *
- * MUST be called on the message thread (touches AutomationManager which
- * notifies UI listeners).
+ * MUST be called on the message thread (host writes ultimately notify UI
+ * listeners).
  */
 class AutomationExecutor {
   public:
+    explicit AutomationExecutor(MagdaApi& api) : api_(api) {}
+
     /** Run all instructions. Returns true on success. */
     bool execute(const std::vector<AutoInstruction>& instructions);
 
@@ -30,6 +34,7 @@ class AutomationExecutor {
     }
 
   private:
+    MagdaApi& api_;
     juce::String error_;
     juce::String results_;
 };

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -263,6 +263,10 @@ set(DAW_CORE_SOURCES
     core/aliases/AutoAliasGenerator.cpp
     # Parameter alias system (PR 5 -- CuratedAliasLoader)
     core/aliases/CuratedAliasLoader.cpp
+    # MagdaApi -- programmatic facade for the agent layer (issue #1113)
+    api/selection_api_live.cpp
+    api/automation_api_live.cpp
+    api/alias_api_live.cpp
     # Controller data model (issue #1050 -- Phase A)
     core/controllers/Controller.cpp
     core/controllers/Binding.cpp
@@ -563,6 +567,15 @@ set(DAW_HEADERS
     interfaces/prompt_interface.hpp
     interfaces/track_interface.hpp
     interfaces/transport_interface.hpp
+    # MagdaApi (issue #1113)
+    api/magda_api.hpp
+    api/selection_api.hpp
+    api/automation_api.hpp
+    api/alias_api.hpp
+    api/magda_api_live.hpp
+    api/selection_api_live.hpp
+    api/automation_api_live.hpp
+    api/alias_api_live.hpp
     # Themes
     ui/themes/DarkTheme.hpp
     ui/themes/FontManager.hpp

--- a/magda/daw/api/alias_api.hpp
+++ b/magda/daw/api/alias_api.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace magda {
+
+class AliasRegistry;
+class ResolverRegistry;
+
+/**
+ * Abstract view onto the alias / resolver registries.
+ *
+ * PR1 just exposes the two registry references — TargetResolver consumes
+ * them by reference and isn't worth wrapping further at this stage. If
+ * a future MagdaApiPlugin needs different alias semantics we'll factor
+ * resolveSigil into this interface, but for now this preserves the
+ * existing call shape.
+ */
+class AliasApi {
+  public:
+    virtual ~AliasApi() = default;
+
+    virtual AliasRegistry& aliasRegistry() = 0;
+    virtual ResolverRegistry& resolverRegistry() = 0;
+};
+
+}  // namespace magda

--- a/magda/daw/api/alias_api_live.cpp
+++ b/magda/daw/api/alias_api_live.cpp
@@ -1,0 +1,16 @@
+#include "alias_api_live.hpp"
+
+#include "../core/aliases/AliasRegistry.hpp"
+#include "../core/aliases/ResolverRegistry.hpp"
+
+namespace magda {
+
+AliasRegistry& AliasApiLive::aliasRegistry() {
+    return AliasRegistry::getInstance();
+}
+
+ResolverRegistry& AliasApiLive::resolverRegistry() {
+    return ResolverRegistry::getInstance();
+}
+
+}  // namespace magda

--- a/magda/daw/api/alias_api_live.hpp
+++ b/magda/daw/api/alias_api_live.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "alias_api.hpp"
+
+namespace magda {
+
+/// Forwards every AliasApi call to the live alias / resolver registry singletons.
+class AliasApiLive : public AliasApi {
+  public:
+    AliasRegistry& aliasRegistry() override;
+    ResolverRegistry& resolverRegistry() override;
+};
+
+}  // namespace magda

--- a/magda/daw/api/automation_api.hpp
+++ b/magda/daw/api/automation_api.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "../core/AutomationInfo.hpp"
+#include "../core/AutomationTypes.hpp"
+#include "../core/TypeIds.hpp"
+
+namespace magda {
+
+/**
+ * Abstract view onto AutomationManager — the subset the agent layer uses.
+ *
+ * PR1 exposes what AutomationExecutor needs (lane lookup, lane creation,
+ * point writes, batch coalescing). Subsequent PRs grow the surface.
+ */
+class AutomationApi {
+  public:
+    virtual ~AutomationApi() = default;
+
+    virtual AutomationLaneId createLane(const AutomationTarget& target,
+                                        AutomationLaneType type) = 0;
+    virtual AutomationLaneId getLaneForTarget(const AutomationTarget& target) const = 0;
+
+    virtual AutomationLaneInfo* getLane(AutomationLaneId laneId) = 0;
+    virtual const AutomationLaneInfo* getLane(AutomationLaneId laneId) const = 0;
+
+    virtual AutomationPointId addPoint(AutomationLaneId laneId, double time, double value,
+                                       AutomationCurveType curveType) = 0;
+    virtual void clearLanePoints(AutomationLaneId laneId) = 0;
+
+    virtual void beginNotificationBatch() = 0;
+    virtual void endNotificationBatch() = 0;
+
+    /// RAII helper that brackets a write batch on this AutomationApi.
+    /// Replaces direct use of AutomationManager::BatchScope so callers
+    /// don't reach back to the singleton.
+    class BatchScope {
+      public:
+        explicit BatchScope(AutomationApi& api) : api_(api) {
+            api_.beginNotificationBatch();
+        }
+        ~BatchScope() {
+            api_.endNotificationBatch();
+        }
+        BatchScope(const BatchScope&) = delete;
+        BatchScope& operator=(const BatchScope&) = delete;
+
+      private:
+        AutomationApi& api_;
+    };
+};
+
+}  // namespace magda

--- a/magda/daw/api/automation_api_live.cpp
+++ b/magda/daw/api/automation_api_live.cpp
@@ -1,0 +1,41 @@
+#include "automation_api_live.hpp"
+
+#include "../core/AutomationManager.hpp"
+
+namespace magda {
+
+AutomationLaneId AutomationApiLive::createLane(const AutomationTarget& target,
+                                               AutomationLaneType type) {
+    return AutomationManager::getInstance().createLane(target, type);
+}
+
+AutomationLaneId AutomationApiLive::getLaneForTarget(const AutomationTarget& target) const {
+    return AutomationManager::getInstance().getLaneForTarget(target);
+}
+
+AutomationLaneInfo* AutomationApiLive::getLane(AutomationLaneId laneId) {
+    return AutomationManager::getInstance().getLane(laneId);
+}
+
+const AutomationLaneInfo* AutomationApiLive::getLane(AutomationLaneId laneId) const {
+    return AutomationManager::getInstance().getLane(laneId);
+}
+
+AutomationPointId AutomationApiLive::addPoint(AutomationLaneId laneId, double time, double value,
+                                              AutomationCurveType curveType) {
+    return AutomationManager::getInstance().addPoint(laneId, time, value, curveType);
+}
+
+void AutomationApiLive::clearLanePoints(AutomationLaneId laneId) {
+    AutomationManager::getInstance().clearLanePoints(laneId);
+}
+
+void AutomationApiLive::beginNotificationBatch() {
+    AutomationManager::getInstance().beginNotificationBatch();
+}
+
+void AutomationApiLive::endNotificationBatch() {
+    AutomationManager::getInstance().endNotificationBatch();
+}
+
+}  // namespace magda

--- a/magda/daw/api/automation_api_live.hpp
+++ b/magda/daw/api/automation_api_live.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "automation_api.hpp"
+
+namespace magda {
+
+/// Forwards every AutomationApi call to AutomationManager::getInstance().
+class AutomationApiLive : public AutomationApi {
+  public:
+    AutomationLaneId createLane(const AutomationTarget& target, AutomationLaneType type) override;
+    AutomationLaneId getLaneForTarget(const AutomationTarget& target) const override;
+
+    AutomationLaneInfo* getLane(AutomationLaneId laneId) override;
+    const AutomationLaneInfo* getLane(AutomationLaneId laneId) const override;
+
+    AutomationPointId addPoint(AutomationLaneId laneId, double time, double value,
+                               AutomationCurveType curveType) override;
+    void clearLanePoints(AutomationLaneId laneId) override;
+
+    void beginNotificationBatch() override;
+    void endNotificationBatch() override;
+};
+
+}  // namespace magda

--- a/magda/daw/api/magda_api.hpp
+++ b/magda/daw/api/magda_api.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+namespace magda {
+
+class SelectionApi;
+class AutomationApi;
+class AliasApi;
+
+/**
+ * Programmatic facade for MAGDA's DAW state.
+ *
+ * Composed of focused sub-interfaces, one per DAW concept. Consumers
+ * (the agent layer today; Lua / controllers / CLI in future) take a
+ * MagdaApi& and route every state read or mutation through these
+ * accessors instead of reaching into singletons.
+ *
+ * The live implementation (MagdaApiLive) forwards every call to the
+ * existing TrackManager/ClipManager/etc. singletons — this is the
+ * abstraction boundary, not a behavioural change.
+ *
+ * PR1 wires only the three sub-interfaces AutomationExecutor needs.
+ * Track/Clip/Project/Undo land in subsequent PRs as the matching
+ * call sites migrate.
+ */
+class MagdaApi {
+  public:
+    virtual ~MagdaApi() = default;
+
+    virtual SelectionApi& selection() = 0;
+    virtual AutomationApi& automation() = 0;
+    virtual AliasApi& aliases() = 0;
+};
+
+}  // namespace magda

--- a/magda/daw/api/magda_api_live.hpp
+++ b/magda/daw/api/magda_api_live.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "alias_api_live.hpp"
+#include "automation_api_live.hpp"
+#include "magda_api.hpp"
+#include "selection_api_live.hpp"
+
+namespace magda {
+
+/// Live implementation: every sub-interface forwards to the matching MAGDA singleton.
+class MagdaApiLive : public MagdaApi {
+  public:
+    SelectionApi& selection() override {
+        return selection_;
+    }
+    AutomationApi& automation() override {
+        return automation_;
+    }
+    AliasApi& aliases() override {
+        return aliases_;
+    }
+
+  private:
+    SelectionApiLive selection_;
+    AutomationApiLive automation_;
+    AliasApiLive aliases_;
+};
+
+}  // namespace magda

--- a/magda/daw/api/selection_api.hpp
+++ b/magda/daw/api/selection_api.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "../core/SelectionManager.hpp"
+#include "../core/TypeIds.hpp"
+
+namespace magda {
+
+/**
+ * Abstract view onto SelectionManager — the subset the agent layer reads.
+ *
+ * Lives behind MagdaApi so agents/scripting/CLI consumers don't depend on
+ * the SelectionManager singleton directly. PR1 only exposes what
+ * AutomationExecutor needs; subsequent PRs grow the surface as more
+ * call sites migrate.
+ */
+class SelectionApi {
+  public:
+    virtual ~SelectionApi() = default;
+
+    virtual TrackId getSelectedTrack() const = 0;
+
+    virtual bool hasAutomationLaneSelection() const = 0;
+    virtual const AutomationLaneSelection& getAutomationLaneSelection() const = 0;
+};
+
+}  // namespace magda

--- a/magda/daw/api/selection_api.hpp
+++ b/magda/daw/api/selection_api.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "../core/SelectionManager.hpp"
 #include "../core/TypeIds.hpp"
 
 namespace magda {
@@ -9,9 +8,14 @@ namespace magda {
  * Abstract view onto SelectionManager — the subset the agent layer reads.
  *
  * Lives behind MagdaApi so agents/scripting/CLI consumers don't depend on
- * the SelectionManager singleton directly. PR1 only exposes what
- * AutomationExecutor needs; subsequent PRs grow the surface as more
- * call sites migrate.
+ * the SelectionManager singleton directly. Kept lightweight on purpose:
+ * the abstract header pulls in only TypeIds, not the full singleton +
+ * UI-listener machinery from SelectionManager.hpp. Concrete struct types
+ * (e.g. AutomationLaneSelection) are deliberately not exposed here —
+ * their members are surfaced as primitive accessors instead.
+ *
+ * PR1 only exposes what AutomationExecutor needs; subsequent PRs grow
+ * the surface as more call sites migrate.
  */
 class SelectionApi {
   public:
@@ -19,8 +23,13 @@ class SelectionApi {
 
     virtual TrackId getSelectedTrack() const = 0;
 
-    virtual bool hasAutomationLaneSelection() const = 0;
-    virtual const AutomationLaneSelection& getAutomationLaneSelection() const = 0;
+    /**
+     * @return The lane id of the currently selected automation lane, or
+     *         INVALID_AUTOMATION_LANE_ID if no automation lane is
+     *         selected (e.g. another selection type is active, or
+     *         nothing is selected).
+     */
+    virtual AutomationLaneId getSelectedAutomationLaneId() const = 0;
 };
 
 }  // namespace magda

--- a/magda/daw/api/selection_api_live.cpp
+++ b/magda/daw/api/selection_api_live.cpp
@@ -1,0 +1,17 @@
+#include "selection_api_live.hpp"
+
+namespace magda {
+
+TrackId SelectionApiLive::getSelectedTrack() const {
+    return SelectionManager::getInstance().getSelectedTrack();
+}
+
+bool SelectionApiLive::hasAutomationLaneSelection() const {
+    return SelectionManager::getInstance().hasAutomationLaneSelection();
+}
+
+const AutomationLaneSelection& SelectionApiLive::getAutomationLaneSelection() const {
+    return SelectionManager::getInstance().getAutomationLaneSelection();
+}
+
+}  // namespace magda

--- a/magda/daw/api/selection_api_live.cpp
+++ b/magda/daw/api/selection_api_live.cpp
@@ -1,17 +1,18 @@
 #include "selection_api_live.hpp"
 
+#include "../core/SelectionManager.hpp"
+
 namespace magda {
 
 TrackId SelectionApiLive::getSelectedTrack() const {
     return SelectionManager::getInstance().getSelectedTrack();
 }
 
-bool SelectionApiLive::hasAutomationLaneSelection() const {
-    return SelectionManager::getInstance().hasAutomationLaneSelection();
-}
-
-const AutomationLaneSelection& SelectionApiLive::getAutomationLaneSelection() const {
-    return SelectionManager::getInstance().getAutomationLaneSelection();
+AutomationLaneId SelectionApiLive::getSelectedAutomationLaneId() const {
+    auto& sel = SelectionManager::getInstance();
+    if (!sel.hasAutomationLaneSelection())
+        return INVALID_AUTOMATION_LANE_ID;
+    return sel.getAutomationLaneSelection().laneId;
 }
 
 }  // namespace magda

--- a/magda/daw/api/selection_api_live.hpp
+++ b/magda/daw/api/selection_api_live.hpp
@@ -8,8 +8,7 @@ namespace magda {
 class SelectionApiLive : public SelectionApi {
   public:
     TrackId getSelectedTrack() const override;
-    bool hasAutomationLaneSelection() const override;
-    const AutomationLaneSelection& getAutomationLaneSelection() const override;
+    AutomationLaneId getSelectedAutomationLaneId() const override;
 };
 
 }  // namespace magda

--- a/magda/daw/api/selection_api_live.hpp
+++ b/magda/daw/api/selection_api_live.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "selection_api.hpp"
+
+namespace magda {
+
+/// Forwards every SelectionApi call to SelectionManager::getInstance().
+class SelectionApiLive : public SelectionApi {
+  public:
+    TrackId getSelectedTrack() const override;
+    bool hasAutomationLaneSelection() const override;
+    const AutomationLaneSelection& getAutomationLaneSelection() const override;
+};
+
+}  // namespace magda

--- a/magda/daw/audio/AutomationPlaybackEngine.cpp
+++ b/magda/daw/audio/AutomationPlaybackEngine.cpp
@@ -35,9 +35,8 @@ AutomationPlaybackEngine::AutomationPlaybackEngine(AudioBridge& bridge, te::Edit
         auto* lane = AutomationManager::getInstance().getLane(laneId);
         if (!lane)
             return;
-        DBG("[AutoPb] touchSuppressionListener lane=" << laneId
-                                                       << " suppressed=" << (int)suppressed
-                                                       << " bypass=" << (int)lane->bypass);
+        DBG("[AutoPb] touchSuppressionListener lane=" << laneId << " suppressed=" << (int)suppressed
+                                                      << " bypass=" << (int)lane->bypass);
         if (suppressed) {
             clearLane(*lane);
             if (auto* param = resolveParameter(lane->target))

--- a/magda/daw/audio/ClipSynchronizer.cpp
+++ b/magda/daw/audio/ClipSynchronizer.cpp
@@ -293,8 +293,8 @@ void ClipSynchronizer::clipPropertyChanged(ClipId clipId) {
                     }
 
                 }  // if (teClip)
-            }      // else (already synced)
-        }          // if (sceneIndex >= 0)
+            }  // else (already synced)
+        }  // if (sceneIndex >= 0)
         return;
     }
 

--- a/magda/daw/audio/DeviceProcessor.hpp
+++ b/magda/daw/audio/DeviceProcessor.hpp
@@ -187,7 +187,8 @@ class ToneGeneratorProcessor : public DeviceProcessor {
     int getParameterCount() const override;
     ParameterInfo getParameterInfo(int index) const override;
 
-    // Single-parameter sync from DeviceInfo (values in real units: TE osc enum / bandLimit / Hz / dB)
+    // Single-parameter sync from DeviceInfo (values in real units: TE osc enum / bandLimit / Hz /
+    // dB)
     void setParameterByIndex(int paramIndex, float value);
 
     // Initialize with default values - call after processor is fully set up

--- a/magda/daw/core/AutomationManager.cpp
+++ b/magda/daw/core/AutomationManager.cpp
@@ -397,12 +397,11 @@ std::optional<double> AutomationManager::getTouchBaseline(const AutomationTarget
 }
 
 void AutomationManager::clearTouchBaseline(const AutomationTarget& target) {
-    touchBaselines_.erase(
-        std::remove_if(touchBaselines_.begin(), touchBaselines_.end(),
-                       [&](const std::pair<AutomationTarget, double>& e) {
-                           return e.first == target;
-                       }),
-        touchBaselines_.end());
+    touchBaselines_.erase(std::remove_if(touchBaselines_.begin(), touchBaselines_.end(),
+                                         [&](const std::pair<AutomationTarget, double>& e) {
+                                             return e.first == target;
+                                         }),
+                          touchBaselines_.end());
 }
 
 AutomationVisualState AutomationManager::getVisualState(const AutomationTarget& target) const {

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -403,12 +403,18 @@ class UIPage : public juce::Component {
 
     static double scaleValueForId(int id) {
         switch (id) {
-            case 2: return 1.0;
-            case 3: return 1.25;
-            case 4: return 1.5;
-            case 5: return 1.75;
-            case 6: return 2.0;
-            default: return 0.0;  // Auto
+            case 2:
+                return 1.0;
+            case 3:
+                return 1.25;
+            case 4:
+                return 1.5;
+            case 5:
+                return 1.75;
+            case 6:
+                return 2.0;
+            default:
+                return 0.0;  // Auto
         }
     }
 

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -17,6 +17,7 @@
 #include "../../../../agents/llm_presets.hpp"
 #include "../../../../agents/music_agent.hpp"
 #include "../../../../agents/router_agent.hpp"
+#include "../../../api/magda_api_live.hpp"
 #include "../../../core/ClipManager.hpp"
 #include "../../../core/Config.hpp"
 #include "../../../core/SelectionManager.hpp"
@@ -541,7 +542,7 @@ void AIChatConsoleContent::RequestThread::run() {
 
                 // Execute IR from automation agent
                 if (!autoIR.empty()) {
-                    magda::AutomationExecutor autoExec;
+                    magda::AutomationExecutor autoExec(*safeThis->magdaApi_);
                     if (autoExec.execute(autoIR)) {
                         auto results = autoExec.getResults().toStdString();
                         if (!response.empty())
@@ -881,13 +882,18 @@ AIChatConsoleContent::AIChatConsoleContent() {
     // Register for config changes (e.g. preset changed in settings dialog)
     magda::Config::getInstance().addListener(this);
 
+    // Create the live MagdaApi facade once. Agents take a MagdaApi& and
+    // route DAW reads/writes through it instead of the singletons; the
+    // facade outlives every agent because it's a member of this panel.
+    magdaApi_ = std::make_unique<magda::MagdaApiLive>();
+
     // Create agents
     agent_ = std::make_unique<magda::DAWAgent>();  // legacy DSL REPL
     agent_->start();
     routerAgent_ = std::make_unique<magda::RouterAgent>();
     commandAgent_ = std::make_unique<magda::CommandAgent>();
     musicAgent_ = std::make_unique<magda::MusicAgent>();
-    automationAgent_ = std::make_unique<magda::AutomationAgent>();
+    automationAgent_ = std::make_unique<magda::AutomationAgent>(*magdaApi_);
     controllerAgent_ = std::make_unique<magda::ControllerProfileAgent>();
 }
 

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
@@ -20,6 +20,7 @@ class AutomationAgent;
 class CommandAgent;
 class ControllerProfileAgent;
 class DAWAgent;
+class MagdaApiLive;
 class MusicAgent;
 class RouterAgent;
 class SvgButton;
@@ -111,6 +112,11 @@ class AIChatConsoleContent : public PanelContent,
     // KeyListener — intercept arrow keys for autocomplete navigation
     using juce::Component::keyPressed;  // unhide 1-param overload
     bool keyPressed(const juce::KeyPress& key, juce::Component* originatingComponent) override;
+
+    // Live MagdaApi backing the agent layer. Owned by this panel so it
+    // outlives every agent we hand it to. PR1 wires only AutomationAgent;
+    // the other agents will take it in subsequent migration PRs.
+    std::unique_ptr<magda::MagdaApiLive> magdaApi_;
 
     std::unique_ptr<magda::DAWAgent> agent_;  // kept for legacy DSL REPL
     std::unique_ptr<magda::RouterAgent> routerAgent_;

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -191,13 +191,13 @@ void MainWindow::MainComponent::getCommandInfo(juce::CommandID commandID,
             result.setInfo("Increase UI Scale", "Make the UI larger", "View", 0);
             result.addDefaultKeypress('=', juce::ModifierKeys::commandModifier);
             result.addDefaultKeypress('+', juce::ModifierKeys::commandModifier |
-                                              juce::ModifierKeys::shiftModifier);
+                                               juce::ModifierKeys::shiftModifier);
             break;
         case uiScaleDown:
             result.setInfo("Decrease UI Scale", "Make the UI smaller", "View", 0);
             result.addDefaultKeypress('-', juce::ModifierKeys::commandModifier);
             result.addDefaultKeypress('_', juce::ModifierKeys::commandModifier |
-                                              juce::ModifierKeys::shiftModifier);
+                                               juce::ModifierKeys::shiftModifier);
             break;
 
         // Help

--- a/tests/test_automation_agent.cpp
+++ b/tests/test_automation_agent.cpp
@@ -4,6 +4,7 @@
 #include "magda/agents/automation_agent.hpp"
 #include "magda/agents/automation_executor.hpp"
 #include "magda/agents/automation_parser.hpp"
+#include "magda/daw/api/magda_api_live.hpp"
 #include "magda/daw/core/AutomationManager.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/SelectionManager.hpp"
@@ -161,7 +162,8 @@ TEST_CASE("AutomationExecutor: target=volume creates TrackVolume lane on selecte
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     auto ir = parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=volume");
     REQUIRE(exec.execute(ir));
 
@@ -191,7 +193,8 @@ TEST_CASE("AutomationExecutor: target=pan creates a separate TrackPan lane",
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE(exec.execute(parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=volume")));
     REQUIRE(exec.execute(parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=pan")));
 
@@ -217,7 +220,8 @@ TEST_CASE("AutomationExecutor: target=volume is a singleton (two runs = one lane
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE(exec.execute(parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=volume")));
     REQUIRE(exec.execute(parseOrFail(parser, "AUTO line start=4 end=8 from=1 to=0 target=volume")));
 
@@ -232,7 +236,8 @@ TEST_CASE("AutomationExecutor: target=selected falls back to TrackVolume with no
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE(
         exec.execute(parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=selected")));
 
@@ -247,7 +252,8 @@ TEST_CASE("AutomationExecutor: target=volume with no track selected fails",
     resetState();
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE_FALSE(
         exec.execute(parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=volume")));
     REQUIRE(exec.getError().isNotEmpty());
@@ -263,7 +269,8 @@ TEST_CASE("AutomationExecutor: target=laneId:N writes to that exact lane",
     auto laneId = AutomationManager::getInstance().createLane(t, AutomationLaneType::Absolute);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     auto ir = parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=laneId:" +
                                       juce::String(laneId));
     REQUIRE(exec.execute(ir));
@@ -280,7 +287,8 @@ TEST_CASE("AutomationExecutor: target=laneId:INVALID fails", "[automation][execu
     resetState();
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE_FALSE(exec.execute(
         parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=laneId:9999")));
     REQUIRE(exec.getError().isNotEmpty());
@@ -297,7 +305,8 @@ TEST_CASE("AutomationExecutor: line writes exactly 2 endpoints with correct valu
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE(
         exec.execute(parseOrFail(parser, "AUTO line start=0 end=8 from=0.2 to=0.8 target=volume")));
 
@@ -321,7 +330,8 @@ TEST_CASE("AutomationExecutor: sin writes many points bounded by [min,max]",
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE(exec.execute(
         parseOrFail(parser, "AUTO sin start=0 end=8 min=0.1 max=0.9 cycles=2 target=volume")));
 
@@ -343,7 +353,8 @@ TEST_CASE("AutomationExecutor: freeform writes the exact provided points",
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE(exec.execute(
         parseOrFail(parser, "AUTO freeform points=(0,0.1)(2,0.5)(4,0.9) target=volume")));
 
@@ -369,7 +380,8 @@ TEST_CASE("AutomationExecutor: clear empties the lane", "[automation][executor][
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE(exec.execute(
         parseOrFail(parser, "AUTO sin start=0 end=8 min=0 max=1 cycles=2 target=volume")));
 
@@ -389,7 +401,8 @@ TEST_CASE("AutomationExecutor: values are clamped into [0, 1]", "[automation][ex
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE(exec.execute(
         parseOrFail(parser, "AUTO freeform points=(0,-0.5)(2,1.5)(4,0.5) target=volume")));
 

--- a/tests/test_automation_alias_targets.cpp
+++ b/tests/test_automation_alias_targets.cpp
@@ -2,6 +2,7 @@
 
 #include "magda/agents/automation_executor.hpp"
 #include "magda/agents/automation_parser.hpp"
+#include "magda/daw/api/magda_api_live.hpp"
 #include "magda/daw/core/AutomationManager.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/SelectionManager.hpp"
@@ -106,7 +107,8 @@ TEST_CASE("AutomationExecutor: unresolvable @alias target fails gracefully",
     resetState();
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
 
     // No registry entry for @ghost.param, no chain context — resolution fails.
     auto ir = parseOrFail(parser, "AUTO sin start=0 end=4 min=0 max=1 target=@ghost.param");

--- a/tests/test_ui_scale.cpp
+++ b/tests/test_ui_scale.cpp
@@ -59,8 +59,7 @@ TEST_CASE("stepUIScale - up from 2.0 clamps to 2.0", "[ui_scale]") {
 // Out-of-range current values — snap to nearest in-range step, then move.
 // ---------------------------------------------------------------------------
 
-TEST_CASE("stepUIScale - up from 0.5 (below range) snaps to 1.0 then to 1.25",
-          "[ui_scale]") {
+TEST_CASE("stepUIScale - up from 0.5 (below range) snaps to 1.0 then to 1.25", "[ui_scale]") {
     REQUIRE(stepUIScale(0.5, +1) == Approx(1.25));
 }
 
@@ -68,8 +67,7 @@ TEST_CASE("stepUIScale - down from 0.5 (below range) snaps to 1.0 and clamps", "
     REQUIRE(stepUIScale(0.5, -1) == Approx(1.0));
 }
 
-TEST_CASE("stepUIScale - down from 3.0 (above range) snaps to 2.0 then to 1.75",
-          "[ui_scale]") {
+TEST_CASE("stepUIScale - down from 3.0 (above range) snaps to 2.0 then to 1.75", "[ui_scale]") {
     REQUIRE(stepUIScale(3.0, -1) == Approx(1.75));
 }
 


### PR DESCRIPTION
## Summary

PR1 of the issue #1113 epic. Lands the abstract `MagdaApi` facade and three sub-interfaces (`SelectionApi`, `AutomationApi`, `AliasApi`) under `magda/daw/api/`, plus the live singleton-forwarding implementation `MagdaApiLive`. Migrates `automation_executor.cpp` onto the new API — zero `::getInstance()` calls remain in the file.

`AutomationAgent`'s constructor now takes `MagdaApi&` and forwards it to its `AutomationExecutor`. `AIChatConsoleContent` owns one `MagdaApiLive` and hands it down. The other agents (DAWAgent, RouterAgent, CommandAgent, MusicAgent, ControllerProfileAgent) keep their default constructors — they take a `MagdaApi&` in subsequent migration PRs when their internal executors actually need it.

This PR targets the long-lived integration branch `feat/magda-api`, not `main`. PR2 migrates `compact_executor.cpp`, PR3 `dsl_interpreter.cpp`, PR4 the small agent classes, PR5 merges everything to `main`.

## Design notes

- **Composed sub-interfaces** rather than one fat `MagdaApi` — each consumer can depend on just what it needs; mirrors `magda/daw/interfaces/` precedent.
- **Abstract base + Live impl** so `MagdaApiPlugin` (plugin distribution) and `MagdaApiFake` (unit tests) can drop in later without changing call sites.
- **Typed `TrackId`/`ClipId`** from `TypeIds.hpp`, not the string IDs `magda/daw/interfaces/` uses — agent code already uses the typed form.
- **`AutomationApi::BatchScope`** RAII helper replaces `AutomationManager::BatchScope` so the executor doesn't reach back to the singleton.
- **PR1 surface tightened to what `automation_executor.cpp` needs.** Track/Clip/Project/Undo land in their respective migration PRs (no busywork forwarders nobody calls).

## Test plan

- [x] `make debug` clean
- [x] `make test` — 26694 assertions / 783 cases pass
- [x] `grep "::getInstance" magda/agents/automation_executor.cpp` returns zero matches
- [ ] Manual smoke in app: AI chat automation prompts (volume fade, sin LFO, saw, freeform, alias-targeted)
- [ ] Verify command/music/controller agents still work (untouched paths)