### PR TITLE
refactor(agents): migrate compact_executor onto MagdaApi (#1113) [PR2/N]

### DIFF
--- a/magda/agents/compact_executor.cpp
+++ b/magda/agents/compact_executor.cpp
@@ -4,17 +4,18 @@
 #include <cmath>
 #include <limits>
 
-#include "../daw/core/ClipManager.hpp"
+#include "../daw/api/clip_api.hpp"
+#include "../daw/api/magda_api.hpp"
+#include "../daw/api/project_api.hpp"
+#include "../daw/api/selection_api.hpp"
+#include "../daw/api/track_api.hpp"
+#include "../daw/api/undo_api.hpp"
 #include "../daw/core/DeviceInfo.hpp"
 #include "../daw/core/MidiNoteCommands.hpp"
 #include "../daw/core/PluginAlias.hpp"
-#include "../daw/core/SelectionManager.hpp"
-#include "../daw/core/TrackManager.hpp"
 #include "../daw/core/TrackTypes.hpp"
-#include "../daw/core/UndoManager.hpp"
 #include "../daw/engine/AudioEngine.hpp"
 #include "../daw/engine/TracktionEngineWrapper.hpp"
-#include "../daw/project/ProjectManager.hpp"
 #include "music_helpers.hpp"
 
 namespace magda {
@@ -24,8 +25,7 @@ namespace magda {
 // ============================================================================
 
 int CompactExecutor::findTrackByName(const juce::String& name) const {
-    auto& tm = TrackManager::getInstance();
-    for (const auto& track : tm.getTracks())
+    for (const auto& track : api_.tracks().getTracks())
         if (track.name.equalsIgnoreCase(name))
             return track.id;
     return -1;
@@ -40,7 +40,7 @@ int CompactExecutor::resolveTrackRef(const TrackRef& ref) {
         return currentTrackId_;
     }
 
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
     if (ref.isById()) {
         int index = ref.id - 1;
         if (index < 0 || index >= tm.getNumTracks()) {
@@ -57,7 +57,7 @@ int CompactExecutor::resolveTrackRef(const TrackRef& ref) {
 
 double CompactExecutor::barsToTime(double bar) const {
     double bpm = 120.0;
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     if (engine)
         bpm = engine->getTempo();
     return (bar - 1.0) * 4.0 * 60.0 / bpm;
@@ -65,7 +65,7 @@ double CompactExecutor::barsToTime(double bar) const {
 
 double CompactExecutor::barsToLength(double bars) const {
     double bpm = 120.0;
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     if (engine)
         bpm = engine->getTempo();
     return bars * 4.0 * 60.0 / bpm;
@@ -74,7 +74,7 @@ double CompactExecutor::barsToLength(double bars) const {
 double CompactExecutor::barsToBeats(double bars) const {
     // Use the project's time-signature numerator. Hard-coding 4 here was
     // the source of the seconds↔beats round-trip drift under non-4/4 sigs.
-    int beatsPerBar = ProjectManager::getInstance().getCurrentProjectInfo().timeSignatureNumerator;
+    int beatsPerBar = api_.project().getCurrentProjectInfo().timeSignatureNumerator;
     if (beatsPerBar <= 0)
         beatsPerBar = 4;
     return bars * static_cast<double>(beatsPerBar);
@@ -98,7 +98,7 @@ bool CompactExecutor::execute(const std::vector<Instruction>& instructions) {
     // command agent's clip.new). Using SelectionManager for agent-to-agent
     // handoff would silently fill whichever clip the user happened to have
     // selected in the UI.
-    auto& sm = SelectionManager::getInstance();
+    auto& sm = api_.selection();
     auto selectedTrack = sm.getSelectedTrack();
 
     // Ignore master track as implicit target — it's not a user track
@@ -110,7 +110,7 @@ bool CompactExecutor::execute(const std::vector<Instruction>& instructions) {
     // auto-creation and cause note commands to silently no-op on a missing
     // clip while still reporting success.
     if (seedClipId_ >= 0) {
-        auto* clipInfo = ClipManager::getInstance().getClip(seedClipId_);
+        auto* clipInfo = api_.clips().getClip(seedClipId_);
         if (clipInfo) {
             currentClipId_ = seedClipId_;
             if (clipInfo->trackId != INVALID_TRACK_ID)
@@ -129,7 +129,7 @@ bool CompactExecutor::execute(const std::vector<Instruction>& instructions) {
         // Derive track from first clip if no track selected
         if (currentTrackId_ < 0) {
             for (auto cid : uiClips) {
-                auto* clipInfo = ClipManager::getInstance().getClip(cid);
+                auto* clipInfo = api_.clips().getClip(cid);
                 if (clipInfo && clipInfo->trackId != INVALID_TRACK_ID) {
                     currentTrackId_ = clipInfo->trackId;
                     break;
@@ -222,8 +222,7 @@ bool CompactExecutor::autoCreateClip() {
         juce::String(currentTrackId_) + " startBeats=" + juce::String(startBeats, 3) +
         " lenBeats=" + juce::String(lengthBeats, 3));
 
-    auto clipId =
-        ClipManager::getInstance().createMidiClipBeats(currentTrackId_, startBeats, lengthBeats);
+    auto clipId = api_.clips().createMidiClipBeats(currentTrackId_, startBeats, lengthBeats);
     if (clipId < 0) {
         error_ = "Failed to auto-create clip";
         DBG("CompactExecutor::autoCreateClip FAIL: createMidiClip returned -1 for track " +
@@ -244,7 +243,7 @@ bool CompactExecutor::autoCreateClip() {
 // ============================================================================
 
 bool CompactExecutor::executeTrack(const TrackOp& op) {
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
 
     // TRACK FX <alias> — resolve plugin, name track after it, add plugin
     if (op.fxAlias.isNotEmpty()) {
@@ -292,8 +291,8 @@ bool CompactExecutor::executeTrack(const TrackOp& op) {
 bool CompactExecutor::executeDel(const DelOp& op) {
     // If active selection from SELECT, delete all selected items
     if (op.target.isImplicit() && hasActiveSelection()) {
-        auto& tm = TrackManager::getInstance();
-        auto& cm = ClipManager::getInstance();
+        auto& tm = api_.tracks();
+        auto& cm = api_.clips();
         int count = 0;
 
         if (!selectedClips_.empty()) {
@@ -318,13 +317,13 @@ bool CompactExecutor::executeDel(const DelOp& op) {
     int trackId = resolveTrackRef(op.target);
     if (trackId < 0)
         return false;
-    TrackManager::getInstance().deleteTrack(trackId);
+    api_.tracks().deleteTrack(trackId);
     results_.add("Deleted track");
     return true;
 }
 
 bool CompactExecutor::executeMute(const MuteOp& op) {
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
 
     // If an active track selection from SELECT is present, mute all selected
     // (unless the caller gave an explicit target, in which case honour that).
@@ -361,7 +360,7 @@ bool CompactExecutor::executeMute(const MuteOp& op) {
 }
 
 bool CompactExecutor::executeSolo(const SoloOp& op) {
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
 
     if (!selectedTracks_.empty() && op.target.isImplicit()) {
         for (auto trackId : selectedTracks_)
@@ -392,7 +391,7 @@ bool CompactExecutor::executeSolo(const SoloOp& op) {
 }
 
 void CompactExecutor::applySetProps(int trackId, const juce::StringPairArray& props) {
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
     for (const auto& key : props.getAllKeys()) {
         auto val = props.getValue(key, "");
         if (key == "vol" || key == "volume_db") {
@@ -424,7 +423,7 @@ bool CompactExecutor::executeSet(const SetOp& op) {
     // If active clip selection, apply track props to each clip's parent track
     // and apply clip-specific props (name) to the clips
     if (op.target.isImplicit() && !selectedClips_.empty()) {
-        auto& cm = ClipManager::getInstance();
+        auto& cm = api_.clips();
         int count = 0;
         for (auto clipId : selectedClips_) {
             auto* clip = cm.getClip(clipId);
@@ -463,7 +462,7 @@ bool CompactExecutor::executeClip(const ClipOp& op) {
     double startBeats = barsToBeats(op.bar - 1.0);
     double lengthBeats = barsToBeats(op.lengthBars);
 
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api_.clips();
     auto clipId = cm.createMidiClipBeats(trackId, startBeats, lengthBeats);
 
     if (clipId < 0) {
@@ -518,7 +517,7 @@ bool CompactExecutor::executeFx(const FxOp& op) {
         device.format = PluginFormat::Internal;
         device.isInstrument = false;
 
-        auto deviceId = TrackManager::getInstance().addDeviceToTrack(trackId, device);
+        auto deviceId = api_.tracks().addDeviceToTrack(trackId, device);
         if (deviceId == INVALID_DEVICE_ID) {
             error_ = "Failed to add FX '" + op.fxName + "'";
             return false;
@@ -528,7 +527,7 @@ bool CompactExecutor::executeFx(const FxOp& op) {
     }
 
     // External plugin lookup via alias matching
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     if (!engine) {
         error_ = "Audio engine not available";
         return false;
@@ -577,7 +576,7 @@ bool CompactExecutor::executeFx(const FxOp& op) {
     else
         device.format = PluginFormat::VST3;
 
-    auto deviceId = TrackManager::getInstance().addDeviceToTrack(trackId, device);
+    auto deviceId = api_.tracks().addDeviceToTrack(trackId, device);
     if (deviceId == INVALID_DEVICE_ID) {
         error_ = "Failed to add plugin '" + op.fxName + "'";
         return false;
@@ -588,10 +587,10 @@ bool CompactExecutor::executeFx(const FxOp& op) {
 }
 
 bool CompactExecutor::executeSelect(const SelectOp& op) {
-    auto& sm = SelectionManager::getInstance();
+    auto& sm = api_.selection();
 
     if (op.target == SelectOp::Target::Tracks) {
-        auto& tm = TrackManager::getInstance();
+        auto& tm = api_.tracks();
         std::unordered_set<TrackId> matches;
 
         for (const auto& track : tm.getTracks()) {
@@ -638,7 +637,7 @@ bool CompactExecutor::executeSelect(const SelectOp& op) {
     }
 
     // SELECT CLIPS
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api_.clips();
     std::unordered_set<ClipId> matches;
 
     for (const auto& clip : cm.getArrangementClips()) {
@@ -680,8 +679,7 @@ bool CompactExecutor::executeSelect(const SelectOp& op) {
                 match = std::abs(clipBar - numVal) < 0.01;
         } else if (op.field == "track") {
             // Filter by parent track name
-            auto& tm = TrackManager::getInstance();
-            for (const auto& track : tm.getTracks()) {
+            for (const auto& track : api_.tracks().getTracks()) {
                 if (track.id == clip.trackId) {
                     auto trackName = track.name.toLowerCase();
                     auto val = op.value.toLowerCase();
@@ -787,7 +785,7 @@ bool CompactExecutor::executeArp(const ArpOp& op) {
         idx++;
     }
 
-    UndoManager::getInstance().executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
+    api_.undo().executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
         currentClipId_, std::move(notes),
         "Add " + op.quality + " arpeggio at beat " + juce::String(op.beat, 2)));
 
@@ -821,7 +819,7 @@ bool CompactExecutor::executeChord(const ChordOp& op) {
         notes.push_back(mn);
     }
 
-    UndoManager::getInstance().executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
+    api_.undo().executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
         currentClipId_, std::move(notes),
         "Add " + op.quality + " chord at beat " + juce::String(op.beat, 2)));
 
@@ -843,7 +841,7 @@ bool CompactExecutor::executeNote(const NoteOp& op) {
 
     int velocity = op.velocity >= 0 ? op.velocity : 100;
 
-    UndoManager::getInstance().executeCommand(std::make_unique<AddMidiNoteCommand>(
+    api_.undo().executeCommand(std::make_unique<AddMidiNoteCommand>(
         currentClipId_, op.beat, noteNumber, op.length, velocity));
 
     results_.add("Added note " + op.pitch);

--- a/magda/agents/compact_executor.hpp
+++ b/magda/agents/compact_executor.hpp
@@ -11,14 +11,18 @@
 
 namespace magda {
 
+class MagdaApi;
+
 /**
- * @brief Executes IR instructions against TrackManager/ClipManager.
+ * @brief Executes IR instructions against the MagdaApi facade.
  *
- * Skips the DSL text round-trip: compact LLM output → IR → direct API calls.
- * Must be called on the message thread (same as DSL Interpreter).
+ * Skips the DSL text round-trip: compact LLM output → IR → MagdaApi calls.
+ * Must be called on the message thread (host writes notify UI listeners).
  */
 class CompactExecutor {
   public:
+    explicit CompactExecutor(MagdaApi& api) : api_(api) {}
+
     /**
      * @brief Execute a list of IR instructions.
      * @return true if all instructions succeeded
@@ -89,6 +93,7 @@ class CompactExecutor {
     /** Convert bar count to duration in beats (uses project time signature). */
     double barsToBeats(double bars) const;
 
+    MagdaApi& api_;
     int currentTrackId_ = -1;
     int currentClipId_ = -1;
     int seedClipId_ = -1;

--- a/magda/agents/daw_agent.cpp
+++ b/magda/agents/daw_agent.cpp
@@ -6,7 +6,7 @@
 
 namespace magda {
 
-DAWAgent::DAWAgent() = default;
+DAWAgent::DAWAgent(MagdaApi& api) : api_(api), executor_(api) {}
 DAWAgent::~DAWAgent() = default;
 
 std::map<std::string, std::string> DAWAgent::getCapabilities() const {

--- a/magda/agents/daw_agent.hpp
+++ b/magda/agents/daw_agent.hpp
@@ -12,6 +12,8 @@
 
 namespace magda {
 
+class MagdaApi;
+
 /**
  * @brief Concrete DAW agent that wires LLM → compact IR → execution.
  *
@@ -26,7 +28,7 @@ namespace magda {
  */
 class DAWAgent : public AgentInterface {
   public:
-    DAWAgent();
+    explicit DAWAgent(MagdaApi& api);
     ~DAWAgent() override;
 
     // AgentInterface
@@ -91,6 +93,7 @@ class DAWAgent : public AgentInterface {
     /** Get the compact system prompt with instruction set. */
     static const char* getCompactSystemPrompt();
 
+    MagdaApi& api_;
     CompactParser parser_;
     CompactExecutor executor_;
     dsl::Interpreter interpreter_;

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -267,6 +267,10 @@ set(DAW_CORE_SOURCES
     api/selection_api_live.cpp
     api/automation_api_live.cpp
     api/alias_api_live.cpp
+    api/track_api_live.cpp
+    api/clip_api_live.cpp
+    api/project_api_live.cpp
+    api/undo_api_live.cpp
     # Controller data model (issue #1050 -- Phase A)
     core/controllers/Controller.cpp
     core/controllers/Binding.cpp
@@ -572,10 +576,18 @@ set(DAW_HEADERS
     api/selection_api.hpp
     api/automation_api.hpp
     api/alias_api.hpp
+    api/track_api.hpp
+    api/clip_api.hpp
+    api/project_api.hpp
+    api/undo_api.hpp
     api/magda_api_live.hpp
     api/selection_api_live.hpp
     api/automation_api_live.hpp
     api/alias_api_live.hpp
+    api/track_api_live.hpp
+    api/clip_api_live.hpp
+    api/project_api_live.hpp
+    api/undo_api_live.hpp
     # Themes
     ui/themes/DarkTheme.hpp
     ui/themes/FontManager.hpp

--- a/magda/daw/api/clip_api.hpp
+++ b/magda/daw/api/clip_api.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <vector>
+
+#include "../core/ClipInfo.hpp"
+#include "../core/ClipTypes.hpp"
+#include "../core/TypeIds.hpp"
+
+namespace magda {
+
+/// Abstract view onto ClipManager — what the agent layer reads and writes.
+class ClipApi {
+  public:
+    virtual ~ClipApi() = default;
+
+    virtual ClipInfo* getClip(ClipId clipId) = 0;
+    virtual std::vector<ClipInfo> getArrangementClips() const = 0;
+
+    virtual ClipId createMidiClipBeats(TrackId trackId, double startBeats, double lengthBeats,
+                                       ClipView view = ClipView::Arrangement) = 0;
+    virtual void deleteClip(ClipId clipId) = 0;
+
+    virtual void setClipName(ClipId clipId, const juce::String& name) = 0;
+};
+
+}  // namespace magda

--- a/magda/daw/api/clip_api_live.cpp
+++ b/magda/daw/api/clip_api_live.cpp
@@ -1,0 +1,28 @@
+#include "clip_api_live.hpp"
+
+#include "../core/ClipManager.hpp"
+
+namespace magda {
+
+ClipInfo* ClipApiLive::getClip(ClipId clipId) {
+    return ClipManager::getInstance().getClip(clipId);
+}
+
+std::vector<ClipInfo> ClipApiLive::getArrangementClips() const {
+    return ClipManager::getInstance().getArrangementClips();
+}
+
+ClipId ClipApiLive::createMidiClipBeats(TrackId trackId, double startBeats, double lengthBeats,
+                                        ClipView view) {
+    return ClipManager::getInstance().createMidiClipBeats(trackId, startBeats, lengthBeats, view);
+}
+
+void ClipApiLive::deleteClip(ClipId clipId) {
+    ClipManager::getInstance().deleteClip(clipId);
+}
+
+void ClipApiLive::setClipName(ClipId clipId, const juce::String& name) {
+    ClipManager::getInstance().setClipName(clipId, name);
+}
+
+}  // namespace magda

--- a/magda/daw/api/clip_api_live.hpp
+++ b/magda/daw/api/clip_api_live.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "clip_api.hpp"
+
+namespace magda {
+
+/// Forwards every ClipApi call to ClipManager::getInstance().
+class ClipApiLive : public ClipApi {
+  public:
+    ClipInfo* getClip(ClipId clipId) override;
+    std::vector<ClipInfo> getArrangementClips() const override;
+
+    ClipId createMidiClipBeats(TrackId trackId, double startBeats, double lengthBeats,
+                               ClipView view) override;
+    void deleteClip(ClipId clipId) override;
+
+    void setClipName(ClipId clipId, const juce::String& name) override;
+};
+
+}  // namespace magda

--- a/magda/daw/api/magda_api.hpp
+++ b/magda/daw/api/magda_api.hpp
@@ -5,6 +5,10 @@ namespace magda {
 class SelectionApi;
 class AutomationApi;
 class AliasApi;
+class TrackApi;
+class ClipApi;
+class ProjectApi;
+class UndoApi;
 
 /**
  * Programmatic facade for MAGDA's DAW state.
@@ -17,10 +21,6 @@ class AliasApi;
  * The live implementation (MagdaApiLive) forwards every call to the
  * existing TrackManager/ClipManager/etc. singletons — this is the
  * abstraction boundary, not a behavioural change.
- *
- * PR1 wires only the three sub-interfaces AutomationExecutor needs.
- * Track/Clip/Project/Undo land in subsequent PRs as the matching
- * call sites migrate.
  */
 class MagdaApi {
   public:
@@ -29,6 +29,10 @@ class MagdaApi {
     virtual SelectionApi& selection() = 0;
     virtual AutomationApi& automation() = 0;
     virtual AliasApi& aliases() = 0;
+    virtual TrackApi& tracks() = 0;
+    virtual ClipApi& clips() = 0;
+    virtual ProjectApi& project() = 0;
+    virtual UndoApi& undo() = 0;
 };
 
 }  // namespace magda

--- a/magda/daw/api/magda_api_live.hpp
+++ b/magda/daw/api/magda_api_live.hpp
@@ -2,8 +2,12 @@
 
 #include "alias_api_live.hpp"
 #include "automation_api_live.hpp"
+#include "clip_api_live.hpp"
 #include "magda_api.hpp"
+#include "project_api_live.hpp"
 #include "selection_api_live.hpp"
+#include "track_api_live.hpp"
+#include "undo_api_live.hpp"
 
 namespace magda {
 
@@ -19,11 +23,27 @@ class MagdaApiLive : public MagdaApi {
     AliasApi& aliases() override {
         return aliases_;
     }
+    TrackApi& tracks() override {
+        return tracks_;
+    }
+    ClipApi& clips() override {
+        return clips_;
+    }
+    ProjectApi& project() override {
+        return project_;
+    }
+    UndoApi& undo() override {
+        return undo_;
+    }
 
   private:
     SelectionApiLive selection_;
     AutomationApiLive automation_;
     AliasApiLive aliases_;
+    TrackApiLive tracks_;
+    ClipApiLive clips_;
+    ProjectApiLive project_;
+    UndoApiLive undo_;
 };
 
 }  // namespace magda

--- a/magda/daw/api/project_api.hpp
+++ b/magda/daw/api/project_api.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "../project/ProjectInfo.hpp"
+
+namespace magda {
+
+/// Abstract view onto ProjectManager — read-only project info today.
+class ProjectApi {
+  public:
+    virtual ~ProjectApi() = default;
+
+    virtual const ProjectInfo& getCurrentProjectInfo() const = 0;
+};
+
+}  // namespace magda

--- a/magda/daw/api/project_api_live.cpp
+++ b/magda/daw/api/project_api_live.cpp
@@ -1,0 +1,11 @@
+#include "project_api_live.hpp"
+
+#include "../project/ProjectManager.hpp"
+
+namespace magda {
+
+const ProjectInfo& ProjectApiLive::getCurrentProjectInfo() const {
+    return ProjectManager::getInstance().getCurrentProjectInfo();
+}
+
+}  // namespace magda

--- a/magda/daw/api/project_api_live.hpp
+++ b/magda/daw/api/project_api_live.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "project_api.hpp"
+
+namespace magda {
+
+/// Forwards every ProjectApi call to ProjectManager::getInstance().
+class ProjectApiLive : public ProjectApi {
+  public:
+    const ProjectInfo& getCurrentProjectInfo() const override;
+};
+
+}  // namespace magda

--- a/magda/daw/api/selection_api.hpp
+++ b/magda/daw/api/selection_api.hpp
@@ -1,11 +1,15 @@
 #pragma once
 
+#include <unordered_set>
+
+#include "../core/ClipTypes.hpp"
 #include "../core/TypeIds.hpp"
 
 namespace magda {
 
 /**
- * Abstract view onto SelectionManager — the subset the agent layer reads.
+ * Abstract view onto SelectionManager — the subset the agent layer reads
+ * and writes.
  *
  * Lives behind MagdaApi so agents/scripting/CLI consumers don't depend on
  * the SelectionManager singleton directly. Kept lightweight on purpose:
@@ -14,14 +18,16 @@ namespace magda {
  * (e.g. AutomationLaneSelection) are deliberately not exposed here —
  * their members are surfaced as primitive accessors instead.
  *
- * PR1 only exposes what AutomationExecutor needs; subsequent PRs grow
- * the surface as more call sites migrate.
+ * PR1 added the read paths AutomationExecutor needs; PR2 adds the
+ * multi-selection read/write surface CompactExecutor uses.
  */
 class SelectionApi {
   public:
     virtual ~SelectionApi() = default;
 
+    // Reads
     virtual TrackId getSelectedTrack() const = 0;
+    virtual const std::unordered_set<ClipId>& getSelectedClips() const = 0;
 
     /**
      * @return The lane id of the currently selected automation lane, or
@@ -30,6 +36,10 @@ class SelectionApi {
      *         nothing is selected).
      */
     virtual AutomationLaneId getSelectedAutomationLaneId() const = 0;
+
+    // Writes
+    virtual void selectTracks(const std::unordered_set<TrackId>& trackIds) = 0;
+    virtual void selectClips(const std::unordered_set<ClipId>& clipIds) = 0;
 };
 
 }  // namespace magda

--- a/magda/daw/api/selection_api_live.cpp
+++ b/magda/daw/api/selection_api_live.cpp
@@ -8,11 +8,23 @@ TrackId SelectionApiLive::getSelectedTrack() const {
     return SelectionManager::getInstance().getSelectedTrack();
 }
 
+const std::unordered_set<ClipId>& SelectionApiLive::getSelectedClips() const {
+    return SelectionManager::getInstance().getSelectedClips();
+}
+
 AutomationLaneId SelectionApiLive::getSelectedAutomationLaneId() const {
     auto& sel = SelectionManager::getInstance();
     if (!sel.hasAutomationLaneSelection())
         return INVALID_AUTOMATION_LANE_ID;
     return sel.getAutomationLaneSelection().laneId;
+}
+
+void SelectionApiLive::selectTracks(const std::unordered_set<TrackId>& trackIds) {
+    SelectionManager::getInstance().selectTracks(trackIds);
+}
+
+void SelectionApiLive::selectClips(const std::unordered_set<ClipId>& clipIds) {
+    SelectionManager::getInstance().selectClips(clipIds);
 }
 
 }  // namespace magda

--- a/magda/daw/api/selection_api_live.hpp
+++ b/magda/daw/api/selection_api_live.hpp
@@ -8,7 +8,12 @@ namespace magda {
 class SelectionApiLive : public SelectionApi {
   public:
     TrackId getSelectedTrack() const override;
+    const std::unordered_set<ClipId>& getSelectedClips() const override;
+
     AutomationLaneId getSelectedAutomationLaneId() const override;
+
+    void selectTracks(const std::unordered_set<TrackId>& trackIds) override;
+    void selectClips(const std::unordered_set<ClipId>& clipIds) override;
 };
 
 }  // namespace magda

--- a/magda/daw/api/track_api.hpp
+++ b/magda/daw/api/track_api.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <vector>
+
+#include "../core/DeviceInfo.hpp"
+#include "../core/TrackInfo.hpp"
+#include "../core/TrackTypes.hpp"
+#include "../core/TypeIds.hpp"
+
+namespace magda {
+
+class AudioEngine;
+
+/**
+ * Abstract view onto TrackManager — the track-level surface the agent
+ * layer needs.
+ *
+ * NOTE: getAudioEngine() returns te::Engine*-equivalent and leaks the
+ * engine into the API surface. Acceptable for now (executors need it
+ * for groove/bpm + plugin scanning), but flagged: a future
+ * MagdaApiPlugin variant probably won't return a real engine here.
+ */
+class TrackApi {
+  public:
+    virtual ~TrackApi() = default;
+
+    virtual TrackId createTrack(const juce::String& name, TrackType type) = 0;
+    virtual void deleteTrack(TrackId trackId) = 0;
+
+    virtual int getNumTracks() const = 0;
+    virtual const std::vector<TrackInfo>& getTracks() const = 0;
+
+    virtual void setTrackName(TrackId trackId, const juce::String& name) = 0;
+    virtual void setTrackVolume(TrackId trackId, float volume, bool fromAutomation = false) = 0;
+    virtual void setTrackPan(TrackId trackId, float pan, bool fromAutomation = false) = 0;
+    virtual void setTrackMuted(TrackId trackId, bool muted) = 0;
+    virtual void setTrackSoloed(TrackId trackId, bool soloed) = 0;
+
+    virtual DeviceId addDeviceToTrack(TrackId trackId, const DeviceInfo& device) = 0;
+
+    virtual AudioEngine* getAudioEngine() const = 0;
+};
+
+}  // namespace magda

--- a/magda/daw/api/track_api_live.cpp
+++ b/magda/daw/api/track_api_live.cpp
@@ -1,0 +1,51 @@
+#include "track_api_live.hpp"
+
+#include "../core/TrackManager.hpp"
+
+namespace magda {
+
+TrackId TrackApiLive::createTrack(const juce::String& name, TrackType type) {
+    return TrackManager::getInstance().createTrack(name, type);
+}
+
+void TrackApiLive::deleteTrack(TrackId trackId) {
+    TrackManager::getInstance().deleteTrack(trackId);
+}
+
+int TrackApiLive::getNumTracks() const {
+    return TrackManager::getInstance().getNumTracks();
+}
+
+const std::vector<TrackInfo>& TrackApiLive::getTracks() const {
+    return TrackManager::getInstance().getTracks();
+}
+
+void TrackApiLive::setTrackName(TrackId trackId, const juce::String& name) {
+    TrackManager::getInstance().setTrackName(trackId, name);
+}
+
+void TrackApiLive::setTrackVolume(TrackId trackId, float volume, bool fromAutomation) {
+    TrackManager::getInstance().setTrackVolume(trackId, volume, fromAutomation);
+}
+
+void TrackApiLive::setTrackPan(TrackId trackId, float pan, bool fromAutomation) {
+    TrackManager::getInstance().setTrackPan(trackId, pan, fromAutomation);
+}
+
+void TrackApiLive::setTrackMuted(TrackId trackId, bool muted) {
+    TrackManager::getInstance().setTrackMuted(trackId, muted);
+}
+
+void TrackApiLive::setTrackSoloed(TrackId trackId, bool soloed) {
+    TrackManager::getInstance().setTrackSoloed(trackId, soloed);
+}
+
+DeviceId TrackApiLive::addDeviceToTrack(TrackId trackId, const DeviceInfo& device) {
+    return TrackManager::getInstance().addDeviceToTrack(trackId, device);
+}
+
+AudioEngine* TrackApiLive::getAudioEngine() const {
+    return TrackManager::getInstance().getAudioEngine();
+}
+
+}  // namespace magda

--- a/magda/daw/api/track_api_live.hpp
+++ b/magda/daw/api/track_api_live.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "track_api.hpp"
+
+namespace magda {
+
+/// Forwards every TrackApi call to TrackManager::getInstance().
+class TrackApiLive : public TrackApi {
+  public:
+    TrackId createTrack(const juce::String& name, TrackType type) override;
+    void deleteTrack(TrackId trackId) override;
+
+    int getNumTracks() const override;
+    const std::vector<TrackInfo>& getTracks() const override;
+
+    void setTrackName(TrackId trackId, const juce::String& name) override;
+    void setTrackVolume(TrackId trackId, float volume, bool fromAutomation) override;
+    void setTrackPan(TrackId trackId, float pan, bool fromAutomation) override;
+    void setTrackMuted(TrackId trackId, bool muted) override;
+    void setTrackSoloed(TrackId trackId, bool soloed) override;
+
+    DeviceId addDeviceToTrack(TrackId trackId, const DeviceInfo& device) override;
+
+    AudioEngine* getAudioEngine() const override;
+};
+
+}  // namespace magda

--- a/magda/daw/api/undo_api.hpp
+++ b/magda/daw/api/undo_api.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <memory>
+
+namespace magda {
+
+class UndoableCommand;
+
+/// Abstract view onto UndoManager — agent code only enqueues commands.
+class UndoApi {
+  public:
+    virtual ~UndoApi() = default;
+
+    virtual void executeCommand(std::unique_ptr<UndoableCommand> command) = 0;
+};
+
+}  // namespace magda

--- a/magda/daw/api/undo_api_live.cpp
+++ b/magda/daw/api/undo_api_live.cpp
@@ -1,0 +1,11 @@
+#include "undo_api_live.hpp"
+
+#include "../core/UndoManager.hpp"
+
+namespace magda {
+
+void UndoApiLive::executeCommand(std::unique_ptr<UndoableCommand> command) {
+    UndoManager::getInstance().executeCommand(std::move(command));
+}
+
+}  // namespace magda

--- a/magda/daw/api/undo_api_live.hpp
+++ b/magda/daw/api/undo_api_live.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "undo_api.hpp"
+
+namespace magda {
+
+/// Forwards every UndoApi call to UndoManager::getInstance().
+class UndoApiLive : public UndoApi {
+  public:
+    void executeCommand(std::unique_ptr<UndoableCommand> command) override;
+};
+
+}  // namespace magda

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -502,7 +502,7 @@ void AIChatConsoleContent::RequestThread::run() {
                             response += "\n";
                         response += musicDesc;
                     }
-                    magda::CompactExecutor executor;
+                    magda::CompactExecutor executor(*safeThis->magdaApi_);
                     // Hand the command agent's freshly-created clip (if any)
                     // explicitly to the music executor. Otherwise it will
                     // auto-create a new clip — we never want it to silently
@@ -888,7 +888,7 @@ AIChatConsoleContent::AIChatConsoleContent() {
     magdaApi_ = std::make_unique<magda::MagdaApiLive>();
 
     // Create agents
-    agent_ = std::make_unique<magda::DAWAgent>();  // legacy DSL REPL
+    agent_ = std::make_unique<magda::DAWAgent>(*magdaApi_);  // legacy DSL REPL
     agent_->start();
     routerAgent_ = std::make_unique<magda::RouterAgent>();
     commandAgent_ = std::make_unique<magda::CommandAgent>();

--- a/tests/test_compact_executor_context.cpp
+++ b/tests/test_compact_executor_context.cpp
@@ -2,6 +2,7 @@
 
 #include "magda/agents/compact_executor.hpp"
 #include "magda/agents/compact_parser.hpp"
+#include "magda/daw/api/magda_api_live.hpp"
 #include "magda/daw/core/AutomationManager.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/SelectionManager.hpp"
@@ -56,7 +57,8 @@ TEST_CASE("CompactExecutor: bare MUTE mutes the selected track", "[compact][cont
     SelectionManager::getInstance().selectTrack(bass);
 
     CompactParser parser;
-    CompactExecutor exec;
+    MagdaApiLive api;
+    CompactExecutor exec(api);
     REQUIRE(exec.execute(parseOrFail(parser, "MUTE")));
 
     auto& tm = TrackManager::getInstance();
@@ -71,7 +73,8 @@ TEST_CASE("CompactExecutor: bare SOLO solos the selected track", "[compact][cont
     SelectionManager::getInstance().selectTrack(lead);
 
     CompactParser parser;
-    CompactExecutor exec;
+    MagdaApiLive api;
+    CompactExecutor exec(api);
     REQUIRE(exec.execute(parseOrFail(parser, "SOLO")));
 
     auto& tm = TrackManager::getInstance();
@@ -85,7 +88,8 @@ TEST_CASE("CompactExecutor: bare MUTE with no selection fails with a helpful err
     makeTrack("Anything");
 
     CompactParser parser;
-    CompactExecutor exec;
+    MagdaApiLive api;
+    CompactExecutor exec(api);
     REQUIRE_FALSE(exec.execute(parseOrFail(parser, "MUTE")));
     REQUIRE(exec.getError().isNotEmpty());
 }
@@ -101,7 +105,8 @@ TEST_CASE("CompactExecutor: MUTE 2 mutes the second track by 1-based index", "[c
     auto t3 = makeTrack("C");
 
     CompactParser parser;
-    CompactExecutor exec;
+    MagdaApiLive api;
+    CompactExecutor exec(api);
     REQUIRE(exec.execute(parseOrFail(parser, "MUTE 2")));
 
     auto& tm = TrackManager::getInstance();
@@ -122,7 +127,8 @@ TEST_CASE("CompactExecutor: MUTE <name> mutes every track with matching name",
     auto bass = makeTrack("Bass");
 
     CompactParser parser;
-    CompactExecutor exec;
+    MagdaApiLive api;
+    CompactExecutor exec(api);
     REQUIRE(exec.execute(parseOrFail(parser, "MUTE Drums")));
 
     auto& tm = TrackManager::getInstance();
@@ -143,7 +149,8 @@ TEST_CASE("CompactExecutor: SELECT TRACKS advances currentTrackId for follow-up 
     auto bass = makeTrack("Bass");
 
     CompactParser parser;
-    CompactExecutor exec;
+    MagdaApiLive api;
+    CompactExecutor exec(api);
 
     // After SELECT, bare MUTE mutes every selected track via the
     // SELECT-driven bulk path (no implicit single-track resolution needed).
@@ -161,7 +168,8 @@ TEST_CASE("CompactExecutor: SELECT with empty match does not crash follow-up MUT
     makeTrack("Bass");
 
     CompactParser parser;
-    CompactExecutor exec;
+    MagdaApiLive api;
+    CompactExecutor exec(api);
     // Predicate matches nothing. SELECT succeeds with an empty set; the
     // follow-up bare MUTE has no implicit track context and fails. The
     // batch executor still returns true when at least one instruction
@@ -184,7 +192,8 @@ TEST_CASE("CompactExecutor: bare SET targets the selected track", "[compact][con
     SelectionManager::getInstance().selectTrack(bass);
 
     CompactParser parser;
-    CompactExecutor exec;
+    MagdaApiLive api;
+    CompactExecutor exec(api);
     REQUIRE(exec.execute(parseOrFail(parser, "SET mute=true")));
 
     auto& tm = TrackManager::getInstance();


### PR DESCRIPTION
## Summary

PR2 of the issue #1113 epic, stacked on top of PR1 (#1114). Migrates \`compact_executor.cpp\` (28 singleton calls → 0) and adds the four sub-interfaces it needs.

**New sub-interfaces** (all under \`magda/daw/api/\`):
- \`TrackApi\` — track CRUD, getNumTracks, getTracks, set{Volume,Pan,Muted,Soloed,Name}, addDeviceToTrack, getAudioEngine
- \`ClipApi\` — getClip, getArrangementClips, createMidiClipBeats, deleteClip, setClipName
- \`ProjectApi\` — getCurrentProjectInfo (read-only)
- \`UndoApi\` — executeCommand

Plus extensions to \`SelectionApi\`: getSelectedClips, selectTracks, selectClips.

**Plumbing:**
- \`CompactExecutor\` constructor now takes \`MagdaApi&\`
- \`DAWAgent\` constructor takes \`MagdaApi&\`, forwards to its \`CompactExecutor\` member (and to \`dsl::Interpreter\` in PR3)
- \`AIChatConsoleContent\` updated: \`make_unique<DAWAgent>(*magdaApi_)\` and the inline lambda's \`CompactExecutor\`

This PR targets PR1's branch (\`feat/magda-api-skeleton\`) so it stacks. When PR1 merges to \`feat/magda-api\`, this rebases automatically.

## Test plan

- [x] \`make debug\` clean
- [x] \`make test\` — 26694 assertions / 783 cases pass (same as PR1)
- [x] \`grep \"::getInstance\" magda/agents/compact_executor.cpp\` — zero matches
- [ ] Manual smoke: command-agent prompts (track create, set props, mute/solo, FX add); music-agent prompts (chord, note, arpeggio); BOTH-intent flow with command + music
- [ ] Verify command/music agents still produce identical output to PR1