### PR TITLE
refactor(agents): migrate dsl_interpreter onto MagdaApi (#1113) [PR3/N]

### DIFF
--- a/magda/agents/daw_agent.cpp
+++ b/magda/agents/daw_agent.cpp
@@ -6,7 +6,7 @@
 
 namespace magda {
 
-DAWAgent::DAWAgent(MagdaApi& api) : api_(api), executor_(api) {}
+DAWAgent::DAWAgent(MagdaApi& api) : api_(api), executor_(api), interpreter_(api) {}
 DAWAgent::~DAWAgent() = default;
 
 std::map<std::string, std::string> DAWAgent::getCapabilities() const {

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -7,6 +7,12 @@
 #include <cstdlib>
 #include <random>
 
+#include "../daw/api/clip_api.hpp"
+#include "../daw/api/magda_api.hpp"
+#include "../daw/api/project_api.hpp"
+#include "../daw/api/selection_api.hpp"
+#include "../daw/api/track_api.hpp"
+#include "../daw/api/undo_api.hpp"
 #include "../daw/audio/AudioThumbnailManager.hpp"
 #include "../daw/core/ClipManager.hpp"
 #include "../daw/core/ClipPropertyCommands.hpp"
@@ -325,7 +331,7 @@ bool Params::getBool(const std::string& key, bool def) const {
 // Interpreter Implementation
 // ============================================================================
 
-Interpreter::Interpreter() {}
+Interpreter::Interpreter(MagdaApi& api) : api_(api) {}
 
 bool Interpreter::execute(const char* dslCode) {
     // Interpreter mutates TrackManager/ClipManager/SelectionManager, all of
@@ -344,7 +350,7 @@ bool Interpreter::execute(const char* dslCode) {
     // `fx("reverb")` or `note(...)` targets the selected track/clip. Matches
     // CompactExecutor's behaviour — the two paths must stay in sync or the
     // same request succeeds in one and fails in the other.
-    auto& sm = SelectionManager::getInstance();
+    auto& sm = api_.selection();
     auto selectedTrack = sm.getSelectedTrack();
     if (selectedTrack != INVALID_TRACK_ID && selectedTrack != MASTER_TRACK_ID)
         ctx_.currentTrackId = selectedTrack;
@@ -435,7 +441,7 @@ bool Interpreter::parseTrackStatement(Tokenizer& tok) {
         return false;
     }
 
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
 
     if (params.has("id")) {
         // Reference existing track by 1-based index
@@ -459,7 +465,7 @@ bool Interpreter::parseTrackStatement(Tokenizer& tok) {
             auto trackType = parseTrackType(params);
             auto trackId = tm.createTrack(name, trackType);
             ctx_.currentTrackId = trackId;
-            SelectionManager::getInstance().selectTrack(trackId);
+            api_.selection().selectTrack(trackId);
             ctx_.addResult("Created track '" + name + "'");
         }
     } else {
@@ -467,7 +473,7 @@ bool Interpreter::parseTrackStatement(Tokenizer& tok) {
         auto trackType = parseTrackType(params);
         auto trackId = tm.createTrack("", trackType);
         ctx_.currentTrackId = trackId;
-        SelectionManager::getInstance().selectTrack(trackId);
+        api_.selection().selectTrack(trackId);
         ctx_.addResult("Created track");
     }
 
@@ -529,7 +535,7 @@ bool Interpreter::parseFilterStatement(Tokenizer& tok) {
     }
 
     // Execute filter: find matching tracks
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
     ctx_.filteredTrackIds.clear();
 
     if (field.value == "name") {
@@ -798,12 +804,12 @@ bool Interpreter::executeNewClip(const Params& params) {
         // No position specified — place after the last clip on this track
         bar = 1.0;
         double bpm = 120.0;
-        auto* engine = TrackManager::getInstance().getAudioEngine();
+        auto* engine = api_.tracks().getAudioEngine();
         if (engine)
             bpm = engine->getTempo();
         double secondsPerBar = 4.0 * 60.0 / bpm;
 
-        auto& cm = ClipManager::getInstance();
+        auto& cm = api_.clips();
         for (auto cid : cm.getClipsOnTrack(ctx_.currentTrackId)) {
             auto* clip = cm.getClip(cid);
             if (!clip)
@@ -830,7 +836,7 @@ bool Interpreter::executeNewClip(const Params& params) {
     double startBeats = barsToBeats(bar - 1.0);
     double lengthBeats = barsToBeats(lengthBars);
 
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api_.clips();
     auto clipId = cm.createMidiClipBeats(ctx_.currentTrackId, startBeats, lengthBeats);
 
     if (clipId < 0) {
@@ -839,14 +845,14 @@ bool Interpreter::executeNewClip(const Params& params) {
     }
 
     ctx_.currentClipId = clipId;
-    SelectionManager::getInstance().selectClip(clipId);
+    api_.selection().selectClip(clipId);
     ctx_.addResult("Created MIDI clip at bar " + juce::String(bar, 2) + ", length " +
                    juce::String(lengthBars, 2) + " bars");
     return true;
 }
 
 bool Interpreter::executeSetTrack(const Params& params) {
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
 
     auto applyToTrack = [&](int trackId) {
         if (params.has("name"))
@@ -898,7 +904,7 @@ bool Interpreter::executeSetTrack(const Params& params) {
 }
 
 bool Interpreter::executeDelete() {
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
 
     if (ctx_.inFilterContext) {
         // Delete in reverse order to avoid index shifting issues
@@ -925,7 +931,7 @@ bool Interpreter::executeDeleteClip(const Params& params) {
         return false;
     }
 
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api_.clips();
     auto clipIds = cm.getClipsOnTrack(ctx_.currentTrackId);
 
     int index = params.getInt("index", 0);
@@ -947,7 +953,7 @@ bool Interpreter::executeRenameClip(const Params& params) {
     }
 
     juce::String newName(params.get("name"));
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api_.clips();
 
     if (params.has("index")) {
         // Rename a specific clip by index on the current track
@@ -965,7 +971,7 @@ bool Interpreter::executeRenameClip(const Params& params) {
         ctx_.addResult("Renamed clip at index " + juce::String(index) + " to '" + newName + "'");
     } else {
         // Rename all currently selected clips
-        auto& sm = SelectionManager::getInstance();
+        auto& sm = api_.selection();
         const auto& selected = sm.getSelectedClips();
         auto singleClip = sm.getSelectedClip();
 
@@ -1070,7 +1076,7 @@ bool Interpreter::executeAddFx(const Params& params) {
         device.deviceType = aliasIt->second.deviceType;
         device.isInstrument = (aliasIt->second.deviceType == DeviceType::Instrument);
 
-        auto deviceId = TrackManager::getInstance().addDeviceToTrack(ctx_.currentTrackId, device);
+        auto deviceId = api_.tracks().addDeviceToTrack(ctx_.currentTrackId, device);
         if (deviceId == INVALID_DEVICE_ID) {
             ctx_.setError("Failed to add internal FX '" + fxName + "' to track");
             return false;
@@ -1080,7 +1086,7 @@ bool Interpreter::executeAddFx(const Params& params) {
     }
 
     // --- External plugin lookup via KnownPluginList ---
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     if (!engine) {
         ctx_.setError("Audio engine not available");
         return false;
@@ -1144,14 +1150,14 @@ bool Interpreter::executeAddFx(const Params& params) {
 
     bestMatch = nullptr;  // no longer safe to dereference
 
-    auto deviceId = TrackManager::getInstance().addDeviceToTrack(ctx_.currentTrackId, device);
+    auto deviceId = api_.tracks().addDeviceToTrack(ctx_.currentTrackId, device);
     if (deviceId == INVALID_DEVICE_ID) {
         ctx_.setError("Failed to add FX '" + fxName + "' to track");
         return false;
     }
 
     // If the track was named with the alias form, rename it to the real plugin name.
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
     if (auto* trackInfo = tm.getTrack(ctx_.currentTrackId)) {
         if (trackInfo->name.equalsIgnoreCase(fxName) && !fxName.equalsIgnoreCase(matchedName))
             tm.setTrackName(ctx_.currentTrackId, matchedName);
@@ -1234,13 +1240,13 @@ bool Interpreter::executeSelect() {
     if (ctx_.inFilterContext) {
         // Select first matching track
         if (!ctx_.filteredTrackIds.empty()) {
-            SelectionManager::getInstance().selectTrack(ctx_.filteredTrackIds.front());
+            api_.selection().selectTrack(ctx_.filteredTrackIds.front());
             ctx_.addResult("Selected track");
         } else {
             ctx_.addResult("No tracks matched filter");
         }
     } else if (ctx_.currentTrackId >= 0) {
-        SelectionManager::getInstance().selectTrack(ctx_.currentTrackId);
+        api_.selection().selectTrack(ctx_.currentTrackId);
         ctx_.addResult("Selected track");
     } else {
         ctx_.setError("No track context for select");
@@ -1293,7 +1299,7 @@ bool Interpreter::executeSelectClips(Tokenizer& tok) {
 
     // Get tempo for bar/time conversions
     double bpm = 120.0;
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     if (engine)
         bpm = engine->getTempo();
     double secondsPerBar = 4.0 * 60.0 / bpm;
@@ -1326,7 +1332,7 @@ bool Interpreter::executeSelectClips(Tokenizer& tok) {
         return false;
     };
 
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api_.clips();
 
     // Resolve a clip field to either a numeric or string match
     auto matchClip = [&](const ClipInfo* clip) -> bool {
@@ -1386,7 +1392,7 @@ bool Interpreter::executeSelectClips(Tokenizer& tok) {
     } else if (ctx_.currentTrackId >= 0) {
         allMatched = matchOnTrack(ctx_.currentTrackId);
     } else {
-        auto& tm = TrackManager::getInstance();
+        auto& tm = api_.tracks();
         for (const auto& track : tm.getTracks()) {
             auto m = matchOnTrack(track.id);
             allMatched.insert(m.begin(), m.end());
@@ -1399,10 +1405,10 @@ bool Interpreter::executeSelectClips(Tokenizer& tok) {
     if (allMatched.empty()) {
         ctx_.addResult("No clips matched the criteria");
     } else if (allMatched.size() == 1) {
-        SelectionManager::getInstance().selectClip(*allMatched.begin());
+        api_.selection().selectClip(*allMatched.begin());
         ctx_.addResult("Selected 1 clip");
     } else {
-        SelectionManager::getInstance().selectClips(allMatched);
+        api_.selection().selectClips(allMatched);
         ctx_.addResult("Selected " + juce::String(static_cast<int>(allMatched.size())) + " clips");
     }
 
@@ -1422,7 +1428,7 @@ TrackType Interpreter::parseTrackType(const Params& params) {
 }
 
 int Interpreter::findTrackByName(const juce::String& name) const {
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
     for (const auto& track : tm.getTracks()) {
         if (track.name.equalsIgnoreCase(name))
             return track.id;
@@ -1433,7 +1439,7 @@ int Interpreter::findTrackByName(const juce::String& name) const {
 double Interpreter::barsToTime(double bar) const {
     // Convert 1-based bar number to seconds
     double bpm = 120.0;  // fallback
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     if (engine)
         bpm = engine->getTempo();
 
@@ -1444,7 +1450,7 @@ double Interpreter::barsToTime(double bar) const {
 double Interpreter::barsToBeats(double bars) const {
     // Use project time signature; never assume 4/4 here — the seconds round
     // trip is what got us into trouble under non-4/4 sigs.
-    int beatsPerBar = ProjectManager::getInstance().getCurrentProjectInfo().timeSignatureNumerator;
+    int beatsPerBar = api_.project().getCurrentProjectInfo().timeSignatureNumerator;
     if (beatsPerBar <= 0)
         beatsPerBar = 4;
     return bars * static_cast<double>(beatsPerBar);
@@ -1549,7 +1555,7 @@ ClipId Interpreter::getSelectedClipId() const {
         return ctx_.currentClipId;
 
     // Fall back to UI selection
-    auto& sm = SelectionManager::getInstance();
+    auto& sm = api_.selection();
     auto clipId = sm.getSelectedClip();
     if (clipId != INVALID_CLIP_ID)
         return clipId;
@@ -1561,7 +1567,7 @@ ClipId Interpreter::getSelectedClipId() const {
 
     // Fall back to the first clip on the current track
     if (ctx_.currentTrackId >= 0) {
-        auto& cm = ClipManager::getInstance();
+        auto& cm = api_.clips();
         auto clips = cm.getClipsOnTrack(ctx_.currentTrackId);
         if (!clips.empty())
             return clips.front();
@@ -1575,8 +1581,8 @@ ClipId Interpreter::getSelectedClipId() const {
 // ============================================================================
 
 bool Interpreter::ensureNoteSelection() {
-    auto& sm = SelectionManager::getInstance();
-    if (sm.getNoteSelection().isValid())
+    auto& sm = api_.selection();
+    if (sm.hasNoteSelection())
         return true;
 
     // No notes selected — try to auto-select all notes in the current clip
@@ -1584,7 +1590,7 @@ bool Interpreter::ensureNoteSelection() {
     if (clipId == INVALID_CLIP_ID)
         return false;
 
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api_.clips();
     auto* clip = cm.getClip(clipId);
     if (!clip || clip->midiNotes.empty())
         return false;
@@ -1595,7 +1601,7 @@ bool Interpreter::ensureNoteSelection() {
         allIndices.push_back(i);
 
     sm.selectNotes(clipId, allIndices);
-    return sm.getNoteSelection().isValid();
+    return sm.hasNoteSelection();
 }
 
 // ============================================================================
@@ -1651,7 +1657,7 @@ bool Interpreter::executeSelectNotes(Tokenizer& tok) {
         return false;
     }
 
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api_.clips();
     auto* clip = cm.getClip(clipId);
     if (!clip) {
         ctx_.setError("Selected clip not found");
@@ -1711,7 +1717,7 @@ bool Interpreter::executeSelectNotes(Tokenizer& tok) {
             matched.push_back(i);
     }
 
-    auto& sm = SelectionManager::getInstance();
+    auto& sm = api_.selection();
     if (matched.empty()) {
         sm.clearNoteSelection();
         ctx_.addResult("No notes matched the criteria");
@@ -1746,7 +1752,7 @@ bool Interpreter::executeAddNote(const Params& params) {
     double length = params.getFloat("length", 1.0);
     int velocity = params.getInt("velocity", 100);
 
-    UndoManager::getInstance().executeCommand(
+    api_.undo().executeCommand(
         std::make_unique<AddMidiNoteCommand>(clipId, beat, noteNumber, length, velocity));
 
     ctx_.addResult("Added note (pitch=" + juce::String(noteNumber) +
@@ -1803,7 +1809,7 @@ bool Interpreter::executeAddChord(const Params& params) {
         noteNames.add(juce::MidiMessage::getMidiNoteName(n, true, true, 4));
     }
 
-    UndoManager::getInstance().executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
+    api_.undo().executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
         clipId, std::move(notes),
         "Add " + juce::String(quality) + " chord at beat " + juce::String(beat, 2)));
 
@@ -1870,10 +1876,10 @@ bool Interpreter::executeAddArpeggio(const Params& params) {
     if (params.has("beats")) {
         fillBeats = beat + params.getFloat("beats");
     } else if (fill) {
-        auto* clip = ClipManager::getInstance().getClip(clipId);
+        auto* clip = api_.clips().getClip(clipId);
         if (clip) {
             double bpm = 120.0;
-            auto* engine = TrackManager::getInstance().getAudioEngine();
+            auto* engine = api_.tracks().getAudioEngine();
             if (engine)
                 bpm = engine->getTempo();
             fillBeats = clip->length * bpm / 60.0;
@@ -1901,7 +1907,7 @@ bool Interpreter::executeAddArpeggio(const Params& params) {
         idx++;
     }
 
-    UndoManager::getInstance().executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
+    api_.undo().executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
         clipId, std::move(notes),
         "Add " + juce::String(quality) + " arpeggio at beat " + juce::String(beat, 2)));
 
@@ -1916,13 +1922,14 @@ bool Interpreter::executeDeleteNotes() {
         return false;
     }
 
-    auto& sm = SelectionManager::getInstance();
-    const auto& noteSel = sm.getNoteSelection();
+    auto& sm = api_.selection();
+    auto noteSelClipId = sm.getNoteSelectionClipId();
+    const auto& noteSelIndices = sm.getNoteSelectionIndices();
 
-    UndoManager::getInstance().executeCommand(
-        std::make_unique<DeleteMultipleMidiNotesCommand>(noteSel.clipId, noteSel.noteIndices));
+    api_.undo().executeCommand(
+        std::make_unique<DeleteMultipleMidiNotesCommand>(noteSelClipId, noteSelIndices));
 
-    int count = static_cast<int>(noteSel.noteIndices.size());
+    int count = static_cast<int>(noteSelIndices.size());
     sm.clearNoteSelection();
     ctx_.addResult("Deleted " + juce::String(count) + " note(s)");
     return true;
@@ -1940,18 +1947,19 @@ bool Interpreter::executeTranspose(const Params& params) {
         return false;
     }
 
-    auto& sm = SelectionManager::getInstance();
-    const auto& noteSel = sm.getNoteSelection();
+    auto& sm = api_.selection();
+    auto noteSelClipId = sm.getNoteSelectionClipId();
+    const auto& noteSelIndices = sm.getNoteSelectionIndices();
 
-    auto& cm = ClipManager::getInstance();
-    auto* clip = cm.getClip(noteSel.clipId);
+    auto& cm = api_.clips();
+    auto* clip = cm.getClip(noteSelClipId);
     if (!clip) {
         ctx_.setError("Clip not found for notes.transpose");
         return false;
     }
 
     std::vector<MoveMultipleMidiNotesCommand::NoteMove> moves;
-    for (auto idx : noteSel.noteIndices) {
+    for (auto idx : noteSelIndices) {
         if (idx < clip->midiNotes.size()) {
             const auto& note = clip->midiNotes[idx];
             int newNote = juce::jlimit(0, 127, note.noteNumber + semitones);
@@ -1960,11 +1968,11 @@ bool Interpreter::executeTranspose(const Params& params) {
     }
 
     if (!moves.empty()) {
-        UndoManager::getInstance().executeCommand(
-            std::make_unique<MoveMultipleMidiNotesCommand>(noteSel.clipId, std::move(moves)));
+        api_.undo().executeCommand(
+            std::make_unique<MoveMultipleMidiNotesCommand>(noteSelClipId, std::move(moves)));
     }
 
-    ctx_.addResult("Transposed " + juce::String(static_cast<int>(noteSel.noteIndices.size())) +
+    ctx_.addResult("Transposed " + juce::String(static_cast<int>(noteSelIndices.size())) +
                    " note(s) by " + juce::String(semitones) + " semitones");
     return true;
 }
@@ -1986,18 +1994,19 @@ bool Interpreter::executeSetPitch(const Params& params) {
         return false;
     }
 
-    auto& sm = SelectionManager::getInstance();
-    const auto& noteSel = sm.getNoteSelection();
+    auto& sm = api_.selection();
+    auto noteSelClipId = sm.getNoteSelectionClipId();
+    const auto& noteSelIndices = sm.getNoteSelectionIndices();
 
-    auto& cm = ClipManager::getInstance();
-    auto* clip = cm.getClip(noteSel.clipId);
+    auto& cm = api_.clips();
+    auto* clip = cm.getClip(noteSelClipId);
     if (!clip) {
         ctx_.setError("Clip not found for notes.set_pitch");
         return false;
     }
 
     std::vector<MoveMultipleMidiNotesCommand::NoteMove> moves;
-    for (auto idx : noteSel.noteIndices) {
+    for (auto idx : noteSelIndices) {
         if (idx < clip->midiNotes.size()) {
             const auto& note = clip->midiNotes[idx];
             moves.push_back({idx, note.startBeat, targetPitch});
@@ -2005,12 +2014,12 @@ bool Interpreter::executeSetPitch(const Params& params) {
     }
 
     if (!moves.empty()) {
-        UndoManager::getInstance().executeCommand(
-            std::make_unique<MoveMultipleMidiNotesCommand>(noteSel.clipId, std::move(moves)));
+        api_.undo().executeCommand(
+            std::make_unique<MoveMultipleMidiNotesCommand>(noteSelClipId, std::move(moves)));
     }
 
     ctx_.addResult("Set pitch to " + juce::String(params.get("pitch")) + " on " +
-                   juce::String(static_cast<int>(noteSel.noteIndices.size())) + " note(s)");
+                   juce::String(static_cast<int>(noteSelIndices.size())) + " note(s)");
     return true;
 }
 
@@ -2023,18 +2032,19 @@ bool Interpreter::executeSetVelocity(const Params& params) {
         return false;
     }
 
-    auto& sm = SelectionManager::getInstance();
-    const auto& noteSel = sm.getNoteSelection();
+    auto& sm = api_.selection();
+    auto noteSelClipId = sm.getNoteSelectionClipId();
+    const auto& noteSelIndices = sm.getNoteSelectionIndices();
 
     std::vector<std::pair<size_t, int>> noteVelocities;
-    for (auto idx : noteSel.noteIndices)
+    for (auto idx : noteSelIndices)
         noteVelocities.emplace_back(idx, velocity);
 
-    UndoManager::getInstance().executeCommand(std::make_unique<SetMultipleNoteVelocitiesCommand>(
-        noteSel.clipId, std::move(noteVelocities)));
+    api_.undo().executeCommand(std::make_unique<SetMultipleNoteVelocitiesCommand>(
+        noteSelClipId, std::move(noteVelocities)));
 
     ctx_.addResult("Set velocity to " + juce::String(velocity) + " on " +
-                   juce::String(static_cast<int>(noteSel.noteIndices.size())) + " note(s)");
+                   juce::String(static_cast<int>(noteSelIndices.size())) + " note(s)");
     return true;
 }
 
@@ -2046,11 +2056,12 @@ bool Interpreter::executeQuantize(const Params& params) {
         return false;
     }
 
-    auto& sm = SelectionManager::getInstance();
-    const auto& noteSel = sm.getNoteSelection();
+    auto& sm = api_.selection();
+    auto noteSelClipId = sm.getNoteSelectionClipId();
+    const auto& noteSelIndices = sm.getNoteSelectionIndices();
 
-    UndoManager::getInstance().executeCommand(std::make_unique<QuantizeMidiNotesCommand>(
-        noteSel.clipId, noteSel.noteIndices, grid, QuantizeMode::StartOnly));
+    api_.undo().executeCommand(std::make_unique<QuantizeMidiNotesCommand>(
+        noteSelClipId, noteSelIndices, grid, QuantizeMode::StartOnly));
 
     juce::String gridName;
     if (std::abs(grid - 0.25) < 0.001)
@@ -2062,7 +2073,7 @@ bool Interpreter::executeQuantize(const Params& params) {
     else
         gridName = juce::String(grid, 2) + " beats";
 
-    ctx_.addResult("Quantized " + juce::String(static_cast<int>(noteSel.noteIndices.size())) +
+    ctx_.addResult("Quantized " + juce::String(static_cast<int>(noteSelIndices.size())) +
                    " note(s) to " + gridName);
     return true;
 }
@@ -2079,17 +2090,18 @@ bool Interpreter::executeResizeNotes(const Params& params) {
         return false;
     }
 
-    auto& sm = SelectionManager::getInstance();
-    const auto& noteSel = sm.getNoteSelection();
+    auto& sm = api_.selection();
+    auto noteSelClipId = sm.getNoteSelectionClipId();
+    const auto& noteSelIndices = sm.getNoteSelectionIndices();
 
     std::vector<std::pair<size_t, double>> noteLengths;
-    for (auto idx : noteSel.noteIndices)
+    for (auto idx : noteSelIndices)
         noteLengths.emplace_back(idx, length);
 
-    UndoManager::getInstance().executeCommand(
-        std::make_unique<ResizeMultipleMidiNotesCommand>(noteSel.clipId, std::move(noteLengths)));
+    api_.undo().executeCommand(
+        std::make_unique<ResizeMultipleMidiNotesCommand>(noteSelClipId, std::move(noteLengths)));
 
-    ctx_.addResult("Resized " + juce::String(static_cast<int>(noteSel.noteIndices.size())) +
+    ctx_.addResult("Resized " + juce::String(static_cast<int>(noteSelIndices.size())) +
                    " note(s) to " + juce::String(length, 2) + " beats");
     return true;
 }
@@ -2175,7 +2187,7 @@ bool Interpreter::executeGrooveNew(const Params& params) {
     }
 
     // Get TE engine
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     auto* teWrapper = dynamic_cast<TracktionEngineWrapper*>(engine);
     if (!teWrapper || !teWrapper->getEngine()) {
         ctx_.setError("Audio engine not available");
@@ -2221,9 +2233,9 @@ bool Interpreter::executeGrooveNew(const Params& params) {
     // Refresh clip inspector so new template appears in dropdown immediately
     auto clipId = getSelectedClipId();
     if (clipId != INVALID_CLIP_ID) {
-        auto* clip = ClipManager::getInstance().getClip(clipId);
+        auto* clip = api_.clips().getClip(clipId);
         if (clip && clip->type == ClipType::MIDI)
-            ClipManager::getInstance().setGrooveTemplate(clipId, clip->grooveTemplate);
+            api_.clips().setGrooveTemplate(clipId, clip->grooveTemplate);
     }
 
     return true;
@@ -2244,7 +2256,7 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
                 "groove.extract: no track in context. Use track(...).groove.extract(...)");
             return false;
         }
-        auto& cm = ClipManager::getInstance();
+        auto& cm = api_.clips();
         auto trackClips = cm.getClipsOnTrack(ctx_.currentTrackId);
         if (clipIndex < 0 || clipIndex >= static_cast<int>(trackClips.size())) {
             ctx_.setError("groove.extract: clip index " + juce::String(clipIndex) +
@@ -2261,7 +2273,7 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
         return false;
     }
 
-    const auto* clip = ClipManager::getInstance().getClip(clipId);
+    const auto* clip = api_.clips().getClip(clipId);
     if (!clip || clip->type != ClipType::Audio) {
         ctx_.setError("groove.extract: clip must be an audio clip");
         return false;
@@ -2321,7 +2333,7 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
     int patternLength = (numSteps >= stepsPerBar) ? stepsPerBar : numSteps;
 
     // Build GrooveTemplate
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     auto* teWrapper = dynamic_cast<TracktionEngineWrapper*>(engine);
     if (!teWrapper || !teWrapper->getEngine()) {
         ctx_.setError("Audio engine not available");
@@ -2356,9 +2368,9 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
     // Refresh clip inspector so new template appears in dropdown immediately
     auto selClipId = getSelectedClipId();
     if (selClipId != INVALID_CLIP_ID) {
-        auto* selClip = ClipManager::getInstance().getClip(selClipId);
+        auto* selClip = api_.clips().getClip(selClipId);
         if (selClip && selClip->type == ClipType::MIDI)
-            ClipManager::getInstance().setGrooveTemplate(selClipId, selClip->grooveTemplate);
+            api_.clips().setGrooveTemplate(selClipId, selClip->grooveTemplate);
     }
     return true;
 }
@@ -2375,20 +2387,20 @@ bool Interpreter::executeGrooveSet(const Params& params) {
         return false;
     }
 
-    const auto* clip = ClipManager::getInstance().getClip(clipId);
+    const auto* clip = api_.clips().getClip(clipId);
     if (!clip || clip->type != ClipType::MIDI) {
         ctx_.setError("groove.set: clip must be a MIDI clip");
         return false;
     }
 
     if (params.has("template")) {
-        UndoManager::getInstance().executeCommand(
+        api_.undo().executeCommand(
             std::make_unique<SetClipGrooveTemplateCommand>(clipId, juce::String(templateName)));
     }
 
     if (params.has("strength")) {
         float strength = static_cast<float>(params.getFloat("strength", 0.5));
-        UndoManager::getInstance().executeCommand(
+        api_.undo().executeCommand(
             std::make_unique<SetClipGrooveStrengthCommand>(clipId, strength));
     }
 
@@ -2400,7 +2412,7 @@ bool Interpreter::executeGrooveSet(const Params& params) {
 
 // groove.list() — show all available groove templates
 bool Interpreter::executeGrooveList() {
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     auto* teWrapper = dynamic_cast<TracktionEngineWrapper*>(engine);
     if (!teWrapper || !teWrapper->getEngine()) {
         ctx_.setError("Audio engine not available");

--- a/magda/agents/dsl_interpreter.hpp
+++ b/magda/agents/dsl_interpreter.hpp
@@ -9,6 +9,10 @@
 #include "../daw/core/ClipTypes.hpp"
 #include "../daw/core/TrackTypes.hpp"
 
+namespace magda {
+class MagdaApi;
+}
+
 namespace magda::dsl {
 
 // ============================================================================
@@ -144,10 +148,10 @@ struct InterpreterContext {
 // ============================================================================
 class Interpreter {
   public:
-    Interpreter();
+    explicit Interpreter(MagdaApi& api);
 
     /**
-     * @brief Execute DSL code against TrackManager/ClipManager
+     * @brief Execute DSL code against the MagdaApi facade.
      * @return true on success, false on error (check getError())
      */
     bool execute(const char* dslCode);
@@ -174,6 +178,11 @@ class Interpreter {
      * Includes the user's current track/clip selection by default so the LLM
      * can target it. Controlled by setContextEnabled(): when false, the
      * snapshot omits selection info so the LLM has no bias signal.
+     *
+     * NOTE: still reads MAGDA singletons internally — migration to
+     * MagdaApi is deferred to a follow-up PR (touches CommandAgent which
+     * doesn't yet hold a MagdaApi&). The instance Interpreter migrated
+     * in this PR doesn't depend on this static helper.
      */
     static juce::String buildStateSnapshot();
 
@@ -233,6 +242,7 @@ class Interpreter {
     double barsToTime(double bar) const;
     double barsToBeats(double bars) const;
 
+    MagdaApi& api_;
     InterpreterContext ctx_;
 };
 

--- a/magda/daw/api/clip_api.hpp
+++ b/magda/daw/api/clip_api.hpp
@@ -15,12 +15,14 @@ class ClipApi {
 
     virtual ClipInfo* getClip(ClipId clipId) = 0;
     virtual std::vector<ClipInfo> getArrangementClips() const = 0;
+    virtual std::vector<ClipId> getClipsOnTrack(TrackId trackId) const = 0;
 
     virtual ClipId createMidiClipBeats(TrackId trackId, double startBeats, double lengthBeats,
                                        ClipView view = ClipView::Arrangement) = 0;
     virtual void deleteClip(ClipId clipId) = 0;
 
     virtual void setClipName(ClipId clipId, const juce::String& name) = 0;
+    virtual void setGrooveTemplate(ClipId clipId, const juce::String& templateName) = 0;
 };
 
 }  // namespace magda

--- a/magda/daw/api/clip_api_live.cpp
+++ b/magda/daw/api/clip_api_live.cpp
@@ -12,6 +12,10 @@ std::vector<ClipInfo> ClipApiLive::getArrangementClips() const {
     return ClipManager::getInstance().getArrangementClips();
 }
 
+std::vector<ClipId> ClipApiLive::getClipsOnTrack(TrackId trackId) const {
+    return ClipManager::getInstance().getClipsOnTrack(trackId);
+}
+
 ClipId ClipApiLive::createMidiClipBeats(TrackId trackId, double startBeats, double lengthBeats,
                                         ClipView view) {
     return ClipManager::getInstance().createMidiClipBeats(trackId, startBeats, lengthBeats, view);
@@ -23,6 +27,10 @@ void ClipApiLive::deleteClip(ClipId clipId) {
 
 void ClipApiLive::setClipName(ClipId clipId, const juce::String& name) {
     ClipManager::getInstance().setClipName(clipId, name);
+}
+
+void ClipApiLive::setGrooveTemplate(ClipId clipId, const juce::String& templateName) {
+    ClipManager::getInstance().setGrooveTemplate(clipId, templateName);
 }
 
 }  // namespace magda

--- a/magda/daw/api/clip_api_live.hpp
+++ b/magda/daw/api/clip_api_live.hpp
@@ -9,12 +9,14 @@ class ClipApiLive : public ClipApi {
   public:
     ClipInfo* getClip(ClipId clipId) override;
     std::vector<ClipInfo> getArrangementClips() const override;
+    std::vector<ClipId> getClipsOnTrack(TrackId trackId) const override;
 
     ClipId createMidiClipBeats(TrackId trackId, double startBeats, double lengthBeats,
                                ClipView view) override;
     void deleteClip(ClipId clipId) override;
 
     void setClipName(ClipId clipId, const juce::String& name) override;
+    void setGrooveTemplate(ClipId clipId, const juce::String& templateName) override;
 };
 
 }  // namespace magda

--- a/magda/daw/api/selection_api.hpp
+++ b/magda/daw/api/selection_api.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstddef>
 #include <unordered_set>
+#include <vector>
 
 #include "../core/ClipTypes.hpp"
 #include "../core/TypeIds.hpp"
@@ -15,18 +17,22 @@ namespace magda {
  * the SelectionManager singleton directly. Kept lightweight on purpose:
  * the abstract header pulls in only TypeIds, not the full singleton +
  * UI-listener machinery from SelectionManager.hpp. Concrete struct types
- * (e.g. AutomationLaneSelection) are deliberately not exposed here —
- * their members are surfaced as primitive accessors instead.
+ * (NoteSelection, AutomationLaneSelection, ...) are deliberately not
+ * exposed here — their members are surfaced as primitive accessors
+ * instead.
  *
- * PR1 added the read paths AutomationExecutor needs; PR2 adds the
- * multi-selection read/write surface CompactExecutor uses.
+ * PR1 added automation-selection reads; PR2 added multi-track / clip
+ * reads + writes; PR3 adds note-selection + single-target setters used
+ * by the DSL interpreter.
  */
 class SelectionApi {
   public:
     virtual ~SelectionApi() = default;
 
-    // Reads
+    // ---- Reads ----------------------------------------------------------
+
     virtual TrackId getSelectedTrack() const = 0;
+    virtual ClipId getSelectedClip() const = 0;
     virtual const std::unordered_set<ClipId>& getSelectedClips() const = 0;
 
     /**
@@ -37,9 +43,22 @@ class SelectionApi {
      */
     virtual AutomationLaneId getSelectedAutomationLaneId() const = 0;
 
-    // Writes
+    /// True iff there is a valid note selection (clip set, indices non-empty).
+    virtual bool hasNoteSelection() const = 0;
+    /// Clip the selected notes belong to, or INVALID_CLIP_ID if none.
+    virtual ClipId getNoteSelectionClipId() const = 0;
+    /// Indices of the selected notes within their clip's MIDI sequence.
+    /// Empty if there is no note selection.
+    virtual const std::vector<size_t>& getNoteSelectionIndices() const = 0;
+
+    // ---- Writes ---------------------------------------------------------
+
+    virtual void selectTrack(TrackId trackId) = 0;
     virtual void selectTracks(const std::unordered_set<TrackId>& trackIds) = 0;
+    virtual void selectClip(ClipId clipId) = 0;
     virtual void selectClips(const std::unordered_set<ClipId>& clipIds) = 0;
+    virtual void selectNotes(ClipId clipId, const std::vector<size_t>& noteIndices) = 0;
+    virtual void clearNoteSelection() = 0;
 };
 
 }  // namespace magda

--- a/magda/daw/api/selection_api_live.cpp
+++ b/magda/daw/api/selection_api_live.cpp
@@ -4,8 +4,14 @@
 
 namespace magda {
 
+// ---- Reads ----------------------------------------------------------
+
 TrackId SelectionApiLive::getSelectedTrack() const {
     return SelectionManager::getInstance().getSelectedTrack();
+}
+
+ClipId SelectionApiLive::getSelectedClip() const {
+    return SelectionManager::getInstance().getSelectedClip();
 }
 
 const std::unordered_set<ClipId>& SelectionApiLive::getSelectedClips() const {
@@ -19,12 +25,42 @@ AutomationLaneId SelectionApiLive::getSelectedAutomationLaneId() const {
     return sel.getAutomationLaneSelection().laneId;
 }
 
+bool SelectionApiLive::hasNoteSelection() const {
+    return SelectionManager::getInstance().hasNoteSelection();
+}
+
+ClipId SelectionApiLive::getNoteSelectionClipId() const {
+    return SelectionManager::getInstance().getNoteSelection().clipId;
+}
+
+const std::vector<size_t>& SelectionApiLive::getNoteSelectionIndices() const {
+    return SelectionManager::getInstance().getNoteSelection().noteIndices;
+}
+
+// ---- Writes ---------------------------------------------------------
+
+void SelectionApiLive::selectTrack(TrackId trackId) {
+    SelectionManager::getInstance().selectTrack(trackId);
+}
+
 void SelectionApiLive::selectTracks(const std::unordered_set<TrackId>& trackIds) {
     SelectionManager::getInstance().selectTracks(trackIds);
 }
 
+void SelectionApiLive::selectClip(ClipId clipId) {
+    SelectionManager::getInstance().selectClip(clipId);
+}
+
 void SelectionApiLive::selectClips(const std::unordered_set<ClipId>& clipIds) {
     SelectionManager::getInstance().selectClips(clipIds);
+}
+
+void SelectionApiLive::selectNotes(ClipId clipId, const std::vector<size_t>& noteIndices) {
+    SelectionManager::getInstance().selectNotes(clipId, noteIndices);
+}
+
+void SelectionApiLive::clearNoteSelection() {
+    SelectionManager::getInstance().clearNoteSelection();
 }
 
 }  // namespace magda

--- a/magda/daw/api/selection_api_live.hpp
+++ b/magda/daw/api/selection_api_live.hpp
@@ -8,12 +8,21 @@ namespace magda {
 class SelectionApiLive : public SelectionApi {
   public:
     TrackId getSelectedTrack() const override;
+    ClipId getSelectedClip() const override;
     const std::unordered_set<ClipId>& getSelectedClips() const override;
 
     AutomationLaneId getSelectedAutomationLaneId() const override;
 
+    bool hasNoteSelection() const override;
+    ClipId getNoteSelectionClipId() const override;
+    const std::vector<size_t>& getNoteSelectionIndices() const override;
+
+    void selectTrack(TrackId trackId) override;
     void selectTracks(const std::unordered_set<TrackId>& trackIds) override;
+    void selectClip(ClipId clipId) override;
     void selectClips(const std::unordered_set<ClipId>& clipIds) override;
+    void selectNotes(ClipId clipId, const std::vector<size_t>& noteIndices) override;
+    void clearNoteSelection() override;
 };
 
 }  // namespace magda

--- a/magda/daw/api/track_api.hpp
+++ b/magda/daw/api/track_api.hpp
@@ -29,6 +29,8 @@ class TrackApi {
 
     virtual int getNumTracks() const = 0;
     virtual const std::vector<TrackInfo>& getTracks() const = 0;
+    virtual TrackInfo* getTrack(TrackId trackId) = 0;
+    virtual const TrackInfo* getTrack(TrackId trackId) const = 0;
 
     virtual void setTrackName(TrackId trackId, const juce::String& name) = 0;
     virtual void setTrackVolume(TrackId trackId, float volume, bool fromAutomation = false) = 0;

--- a/magda/daw/api/track_api_live.cpp
+++ b/magda/daw/api/track_api_live.cpp
@@ -20,6 +20,14 @@ const std::vector<TrackInfo>& TrackApiLive::getTracks() const {
     return TrackManager::getInstance().getTracks();
 }
 
+TrackInfo* TrackApiLive::getTrack(TrackId trackId) {
+    return TrackManager::getInstance().getTrack(trackId);
+}
+
+const TrackInfo* TrackApiLive::getTrack(TrackId trackId) const {
+    return TrackManager::getInstance().getTrack(trackId);
+}
+
 void TrackApiLive::setTrackName(TrackId trackId, const juce::String& name) {
     TrackManager::getInstance().setTrackName(trackId, name);
 }

--- a/magda/daw/api/track_api_live.hpp
+++ b/magda/daw/api/track_api_live.hpp
@@ -12,6 +12,8 @@ class TrackApiLive : public TrackApi {
 
     int getNumTracks() const override;
     const std::vector<TrackInfo>& getTracks() const override;
+    TrackInfo* getTrack(TrackId trackId) override;
+    const TrackInfo* getTrack(TrackId trackId) const override;
 
     void setTrackName(TrackId trackId, const juce::String& name) override;
     void setTrackVolume(TrackId trackId, float volume, bool fromAutomation) override;

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -485,7 +485,7 @@ void AIChatConsoleContent::RequestThread::run() {
                 // Execute DSL from command agent
                 int commandClipId = -1;
                 if (!dsl.empty()) {
-                    magda::dsl::Interpreter interpreter;
+                    magda::dsl::Interpreter interpreter(*safeThis->magdaApi_);
                     if (interpreter.execute(dsl.c_str())) {
                         auto results = interpreter.getResults().toStdString();
                         response = results.empty() ? "OK" : results;
@@ -984,7 +984,7 @@ void AIChatConsoleContent::sendMessage(const juce::String& text) {
         auto dslCode = text.trimStart().substring(5).trim();
         appendToChat(juce::String::charToString(0x25CF) + " " + text);
 
-        magda::dsl::Interpreter interpreter;
+        magda::dsl::Interpreter interpreter(*magdaApi_);
         bool success = interpreter.execute(dslCode.toRawUTF8());
 
         if (success) {
@@ -1382,7 +1382,7 @@ void AIChatConsoleContent::executeDSL() {
     }
 
     // Execute
-    magda::dsl::Interpreter interpreter;
+    magda::dsl::Interpreter interpreter(*magdaApi_);
     bool success = interpreter.execute(code.toRawUTF8());
 
     if (success) {

--- a/tests/test_dsl_add_arpeggio.cpp
+++ b/tests/test_dsl_add_arpeggio.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "magda/agents/dsl_interpreter.hpp"
+#include "magda/daw/api/magda_api_live.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/SelectionManager.hpp"
 #include "magda/daw/core/TrackManager.hpp"
@@ -50,7 +51,8 @@ static std::vector<std::pair<int, double>> getNotesByBeat(const ClipInfo* clip) 
 
 TEST_CASE("add_arpeggio - up pattern (default)", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -77,7 +79,8 @@ TEST_CASE("add_arpeggio - up pattern (default)", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - down pattern", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute(
         "track(name=\"Test\", type=\"midi\")"
@@ -101,7 +104,8 @@ TEST_CASE("add_arpeggio - down pattern", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - updown pattern", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // C min7 = C4(60), Eb4(63), G4(67), Bb4(70)
     // updown skips endpoints: C Eb G Bb G Eb → 6 notes
@@ -130,7 +134,8 @@ TEST_CASE("add_arpeggio - updown pattern", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - first inversion", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // C major first inversion: E4(64), G4(67), C5(72)
     REQUIRE(interp.execute(
@@ -155,7 +160,8 @@ TEST_CASE("add_arpeggio - first inversion", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - second inversion down", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // C major second inversion: G4(67), C5(72), E5(76) — down: E5, C5, G4
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
@@ -180,7 +186,8 @@ TEST_CASE("add_arpeggio - second inversion down", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - custom note_length", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute(
         "track(name=\"Test\", type=\"midi\")"
@@ -199,7 +206,8 @@ TEST_CASE("add_arpeggio - custom note_length", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - staccato (note_length < step)", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute(
         "track(name=\"Test\", type=\"midi\")"
@@ -226,7 +234,8 @@ TEST_CASE("add_arpeggio - staccato (note_length < step)", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - beat offset and velocity", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute(
         "track(name=\"Test\", type=\"midi\")"
@@ -257,7 +266,8 @@ TEST_CASE("add_arpeggio - beat offset and velocity", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - fill covers entire clip", "[dsl][arpeggio][fill]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // 2-bar clip at 120 BPM = 8 beats, step=0.5 → 16 notes cycling C E G
     REQUIRE(
@@ -283,7 +293,8 @@ TEST_CASE("add_arpeggio - fill covers entire clip", "[dsl][arpeggio][fill]") {
 
 TEST_CASE("add_arpeggio - fill with updown pattern", "[dsl][arpeggio][fill]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // C major updown = C E G E (4 notes per cycle), 1-bar clip = 4 beats, step=0.5 → 8 notes
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
@@ -305,7 +316,8 @@ TEST_CASE("add_arpeggio - fill with updown pattern", "[dsl][arpeggio][fill]") {
 
 TEST_CASE("add_arpeggio - fill with down pattern", "[dsl][arpeggio][fill]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // 1-bar clip = 4 beats, step=0.5, down: G E C → 8 notes cycling
     REQUIRE(interp.execute(
@@ -330,7 +342,8 @@ TEST_CASE("add_arpeggio - fill with down pattern", "[dsl][arpeggio][fill]") {
 
 TEST_CASE("add_arpeggio - beats parameter for exact duration", "[dsl][arpeggio][fill]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // Fill only 2 beats of a 4-bar clip — step=0.5 → 4 notes
     REQUIRE(
@@ -350,7 +363,8 @@ TEST_CASE("add_arpeggio - beats parameter for exact duration", "[dsl][arpeggio][
 
 TEST_CASE("add_arpeggio - chord progression with beats", "[dsl][arpeggio][progression]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // E minor for 4 beats, then C major for 4 beats in a 2-bar clip
     REQUIRE(
@@ -385,7 +399,8 @@ TEST_CASE("add_arpeggio - chord progression with beats", "[dsl][arpeggio][progre
 
 TEST_CASE("add_arpeggio - four-chord progression", "[dsl][arpeggio][progression]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // Em - C - G - D, each for 4 beats in a 4-bar clip
     REQUIRE(
@@ -428,7 +443,8 @@ TEST_CASE("add_arpeggio - four-chord progression", "[dsl][arpeggio][progression]
 
 TEST_CASE("add_arpeggio - 9th chord", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // C dom9 = C4(60), E4(64), G4(67), Bb4(70), D5(74) — 5 notes
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
@@ -450,7 +466,8 @@ TEST_CASE("add_arpeggio - 9th chord", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - min7b5 (half diminished)", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // B half-dim = B3(59), D4(62), F4(65), A4(69)
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
@@ -475,7 +492,8 @@ TEST_CASE("add_arpeggio - min7b5 (half diminished)", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - undo removes all notes", "[dsl][arpeggio][undo]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -495,7 +513,8 @@ TEST_CASE("add_arpeggio - undo removes all notes", "[dsl][arpeggio][undo]") {
 
 TEST_CASE("add_arpeggio - undo progression removes last chord only", "[dsl][arpeggio][undo]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(
         interp.execute("track(name=\"Test\", type=\"midi\")"
@@ -529,7 +548,8 @@ TEST_CASE("add_arpeggio - undo progression removes last chord only", "[dsl][arpe
 
 TEST_CASE("add_arpeggio - missing root", "[dsl][arpeggio][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
                                  ".clip.new(bar=1, length_bars=4)"
@@ -539,7 +559,8 @@ TEST_CASE("add_arpeggio - missing root", "[dsl][arpeggio][error]") {
 
 TEST_CASE("add_arpeggio - missing quality", "[dsl][arpeggio][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
                                  ".clip.new(bar=1, length_bars=4)"
@@ -549,7 +570,8 @@ TEST_CASE("add_arpeggio - missing quality", "[dsl][arpeggio][error]") {
 
 TEST_CASE("add_arpeggio - unknown quality", "[dsl][arpeggio][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
                                  ".clip.new(bar=1, length_bars=4)"
@@ -559,7 +581,8 @@ TEST_CASE("add_arpeggio - unknown quality", "[dsl][arpeggio][error]") {
 
 TEST_CASE("add_arpeggio - zero step rejected", "[dsl][arpeggio][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
                                  ".clip.new(bar=1, length_bars=4)"
@@ -569,7 +592,8 @@ TEST_CASE("add_arpeggio - zero step rejected", "[dsl][arpeggio][error]") {
 
 TEST_CASE("add_arpeggio - negative step rejected", "[dsl][arpeggio][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
                                  ".clip.new(bar=1, length_bars=4)"
@@ -579,7 +603,8 @@ TEST_CASE("add_arpeggio - negative step rejected", "[dsl][arpeggio][error]") {
 
 TEST_CASE("add_arpeggio - negative note_length rejected", "[dsl][arpeggio][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute(
         "track(name=\"Test\", type=\"midi\")"
@@ -590,7 +615,8 @@ TEST_CASE("add_arpeggio - negative note_length rejected", "[dsl][arpeggio][error
 
 TEST_CASE("add_arpeggio - negative beats rejected", "[dsl][arpeggio][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result =
         interp.execute("track(name=\"Test\", type=\"midi\")"
@@ -601,7 +627,8 @@ TEST_CASE("add_arpeggio - negative beats rejected", "[dsl][arpeggio][error]") {
 
 TEST_CASE("add_arpeggio - no clip context", "[dsl][arpeggio][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // Create track but no clip — arpeggio should fail
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
@@ -615,7 +642,8 @@ TEST_CASE("add_arpeggio - no clip context", "[dsl][arpeggio][error]") {
 
 TEST_CASE("add_arpeggio - power chord (2 notes)", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=2)"
@@ -633,7 +661,8 @@ TEST_CASE("add_arpeggio - power chord (2 notes)", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - fill with beat offset", "[dsl][arpeggio][fill]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // Start at beat 2 and fill to end of 1-bar (4-beat) clip
     // Available space: beats 2-4, step=0.5 → 4 notes
@@ -654,7 +683,8 @@ TEST_CASE("add_arpeggio - fill with beat offset", "[dsl][arpeggio][fill]") {
 
 TEST_CASE("add_arpeggio - updown with triad (3 notes)", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // updown with 3-note chord: C E G E → 4 notes (skip top and bottom on way down)
     REQUIRE(interp.execute(
@@ -681,7 +711,8 @@ TEST_CASE("add_arpeggio - updown with triad (3 notes)", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - new=true creates separate track", "[dsl][arpeggio][track]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // Create first track
     REQUIRE(

--- a/tests/test_dsl_add_chord.cpp
+++ b/tests/test_dsl_add_chord.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "magda/agents/dsl_interpreter.hpp"
+#include "magda/daw/api/magda_api_live.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/SelectionManager.hpp"
 #include "magda/daw/core/TrackManager.hpp"
@@ -47,7 +48,8 @@ static std::vector<int> getSortedPitches(const ClipInfo* clip) {
 
 TEST_CASE("notes.add_chord - C major triad", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -69,7 +71,8 @@ TEST_CASE("notes.add_chord - C major triad", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - minor triad", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -89,7 +92,8 @@ TEST_CASE("notes.add_chord - minor triad", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - min7 four-note chord", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -114,7 +118,8 @@ TEST_CASE("notes.add_chord - min7 four-note chord", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - dom7", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -135,7 +140,8 @@ TEST_CASE("notes.add_chord - dom7", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - diminished", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -155,7 +161,8 @@ TEST_CASE("notes.add_chord - diminished", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - augmented", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -175,7 +182,8 @@ TEST_CASE("notes.add_chord - augmented", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - sus2", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -195,7 +203,8 @@ TEST_CASE("notes.add_chord - sus2", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - sus4", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -215,7 +224,8 @@ TEST_CASE("notes.add_chord - sus4", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - power chord", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -238,7 +248,8 @@ TEST_CASE("notes.add_chord - power chord", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - quality aliases", "[dsl][chord][alias]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     SECTION("maj alias") {
         REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
@@ -294,7 +305,8 @@ TEST_CASE("notes.add_chord - quality aliases", "[dsl][chord][alias]") {
 
 TEST_CASE("notes.add_chord - first inversion", "[dsl][chord][inversion]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // C major first inversion: E4, G4, C5
     REQUIRE(
@@ -316,7 +328,8 @@ TEST_CASE("notes.add_chord - first inversion", "[dsl][chord][inversion]") {
 
 TEST_CASE("notes.add_chord - second inversion", "[dsl][chord][inversion]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // C major second inversion: G4, C5, E5
     REQUIRE(
@@ -342,7 +355,8 @@ TEST_CASE("notes.add_chord - second inversion", "[dsl][chord][inversion]") {
 
 TEST_CASE("notes.add_chord - beat position and velocity", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute(
         "track(name=\"Test\", type=\"midi\")"
@@ -367,7 +381,8 @@ TEST_CASE("notes.add_chord - beat position and velocity", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - multiple chords (progression)", "[dsl][chord][progression]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // Em - C - G - D progression
     REQUIRE(interp.execute(
@@ -391,7 +406,8 @@ TEST_CASE("notes.add_chord - multiple chords (progression)", "[dsl][chord][progr
 
 TEST_CASE("clip.new without bar places after last clip", "[dsl][chord][autoplace]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // Create first clip at bar 1, 4 bars long (ends at bar 5)
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\").clip.new(bar=1, length_bars=4)"));
@@ -418,7 +434,8 @@ TEST_CASE("clip.new without bar places after last clip", "[dsl][chord][autoplace
 
 TEST_CASE("clip.new without bar on empty track places at bar 1", "[dsl][chord][autoplace]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\").clip.new(length_bars=4)"));
 
@@ -439,7 +456,8 @@ TEST_CASE("clip.new without bar on empty track places at bar 1", "[dsl][chord][a
 
 TEST_CASE("notes.add_chord - missing root", "[dsl][chord][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
                                  ".clip.new(bar=1, length_bars=4)"
@@ -449,7 +467,8 @@ TEST_CASE("notes.add_chord - missing root", "[dsl][chord][error]") {
 
 TEST_CASE("notes.add_chord - missing quality", "[dsl][chord][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
                                  ".clip.new(bar=1, length_bars=4)"
@@ -459,7 +478,8 @@ TEST_CASE("notes.add_chord - missing quality", "[dsl][chord][error]") {
 
 TEST_CASE("notes.add_chord - unknown quality", "[dsl][chord][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
                                  ".clip.new(bar=1, length_bars=4)"
@@ -473,7 +493,8 @@ TEST_CASE("notes.add_chord - unknown quality", "[dsl][chord][error]") {
 
 TEST_CASE("notes.add_chord - continues after failed statement", "[dsl][chord][recovery]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // First statement fails (bad FX), but track is created.
     // Second statement should still add chords to the clip.
@@ -498,7 +519,8 @@ TEST_CASE("notes.add_chord - continues after failed statement", "[dsl][chord][re
 
 TEST_CASE("notes.add_chord - undo removes all chord notes", "[dsl][chord][undo]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"


### PR DESCRIPTION
## Summary

PR3 of the issue #1113 epic, stacked on PR2 (#1115). Migrates \`dsl_interpreter.cpp\` (65 of 69 singleton call sites) and grows the API surface for the methods it needed.

**API surface added** (under \`magda/daw/api/\`):
- \`ClipApi\`: \`setGrooveTemplate\`, \`getClipsOnTrack\`
- \`TrackApi\`: \`getTrack\` (const + non-const overloads)
- \`SelectionApi\`: \`selectTrack\`, \`selectClip\`, \`selectNotes\`, \`clearNoteSelection\`, \`getSelectedClip\` + note-selection primitives (\`hasNoteSelection\`, \`getNoteSelectionClipId\`, \`getNoteSelectionIndices\`). Primitives keep the abstract header free of \`NoteSelection\`/\`AutomationLaneSelection\` struct dependencies (continues PR1's review-feedback pattern).

**Plumbing:**
- \`dsl::Interpreter\` constructor takes \`MagdaApi&\` and stores it as a member
- \`DAWAgent\` constructor (already taking \`MagdaApi&\` from PR2) now constructs \`interpreter_\` with the api too
- 3 inline \`dsl::Interpreter\` sites in \`AIChatConsoleContent.cpp\` updated (lambda-captured \`safeThis->magdaApi_\` for the message-thread one, \`*magdaApi_\` for the two member-function ones)
- \`tests/test_dsl_add_chord.cpp\` and \`tests/test_dsl_add_arpeggio.cpp\` construct the interpreter with \`MagdaApiLive\`

## Carve-outs (deferred to PR4)

Two known \`::getInstance\` calls remain in \`dsl_interpreter.cpp\` and are intentional:

1. **\`static buildStateSnapshot()\`** still calls \`TrackManager::getInstance()\` / \`ClipManager::getInstance()\` / \`SelectionManager::getInstance()\` for its JSON snapshot. Moving it onto MagdaApi requires \`CommandAgent\` (one of its callers) to also take \`MagdaApi&\` — that's exactly PR4's scope.
2. **\`AudioThumbnailManager::getInstance()\`** inside \`executeGrooveExtract\` — not DAW state, more of a thumbnail/transient cache. Will fold into PR4 cleanup.

\`grep \"::getInstance\" magda/agents/dsl_interpreter.cpp\` returns 4 matches — all expected and documented.

## Test plan

- [x] \`make debug\` clean
- [x] \`make test\` — 26694 assertions / 783 cases pass (same as PR1+PR2)
- [x] \`grep \"::getInstance\" magda/agents/dsl_interpreter.cpp\` — only the 4 documented carve-outs remain
- [ ] Manual smoke: legacy DSL REPL (\`/dsl track.new(name=\"x\")\` etc.); BOTH-intent prompts (router → command → music); note-editing DSL ops (transpose, set_velocity, quantize, resize) which exercise the new note-selection primitives