### PR TITLE
refactor(agents): remove remaining DAW-state singletons (#1113) [PR4/N]

### DIFF
--- a/magda/agents/automation_agent.cpp
+++ b/magda/agents/automation_agent.cpp
@@ -1,10 +1,13 @@
 #include "automation_agent.hpp"
 
-#include "../daw/core/AutomationManager.hpp"
+#include "../daw/api/automation_api.hpp"
+#include "../daw/api/magda_api.hpp"
+#include "../daw/api/selection_api.hpp"
+#include "../daw/api/track_api.hpp"
+#include "../daw/core/AutomationInfo.hpp"
 #include "../daw/core/Config.hpp"
 #include "../daw/core/ParameterInfo.hpp"
-#include "../daw/core/SelectionManager.hpp"
-#include "../daw/core/TrackManager.hpp"
+#include "../daw/core/TrackInfo.hpp"
 #include "llm_client_factory.hpp"
 
 namespace magda {
@@ -76,16 +79,17 @@ AUTO freeform points=(0,0.1)(2,0.9)(8,0) target=selected)PROMPT";
 namespace {
 
 /** Multi-line selection context appended to the system prompt. */
-juce::String buildSelectionContext() {
-    auto& sel = SelectionManager::getInstance();
-    auto& amgr = AutomationManager::getInstance();
-    auto& tmgr = TrackManager::getInstance();
+juce::String buildSelectionContext(MagdaApi& api) {
+    auto& sel = api.selection();
+    auto& amgr = api.automation();
+    auto& tmgr = api.tracks();
     juce::String out;
 
     TrackId contextTrackId = sel.getSelectedTrack();
 
-    if (sel.hasAutomationLaneSelection()) {
-        auto laneId = sel.getAutomationLaneSelection().laneId;
+    auto selLaneId = sel.getSelectedAutomationLaneId();
+    if (selLaneId != INVALID_AUTOMATION_LANE_ID) {
+        auto laneId = selLaneId;
         if (auto* lane = amgr.getLane(laneId)) {
             auto info = lane->target.getParameterInfo();
             out << "Selected lane: \"" << lane->getDisplayName() << "\" (laneId=" << laneId
@@ -129,9 +133,9 @@ std::string cleanOutput(const juce::String& raw) {
     return text.toStdString();
 }
 
-llm::Request buildRequest(const std::string& message) {
+llm::Request buildRequest(MagdaApi& api, const std::string& message) {
     auto systemPrompt = juce::String::fromUTF8(AutomationAgent::getSystemPrompt());
-    auto ctx = buildSelectionContext();
+    auto ctx = buildSelectionContext(api);
     if (ctx.isNotEmpty())
         systemPrompt += "\n\nContext:\n" + ctx;
 
@@ -166,7 +170,7 @@ AutomationAgent::GenerateResult AutomationAgent::generate(const std::string& mes
     }
 
     auto client = createLLMClient(agentConfig, "automation");
-    auto request = buildRequest(message);
+    auto request = buildRequest(api_, message);
 
     auto response = client->sendRequest(request);
 
@@ -214,7 +218,7 @@ AutomationAgent::GenerateResult AutomationAgent::generateStreaming(const std::st
     }
 
     auto client = createLLMClient(agentConfig, "automation");
-    auto request = buildRequest(message);
+    auto request = buildRequest(api_, message);
 
     auto response = client->sendStreamingRequest(request, [&](const juce::String& token) {
         if (shouldStop_.load())

--- a/magda/agents/automation_agent.hpp
+++ b/magda/agents/automation_agent.hpp
@@ -27,7 +27,7 @@ class MagdaApi;
  */
 class AutomationAgent {
   public:
-    explicit AutomationAgent(MagdaApi& api) : executor_(api) {}
+    explicit AutomationAgent(MagdaApi& api) : api_(api), executor_(api) {}
 
     struct GenerateResult {
         std::string rawOutput;
@@ -57,6 +57,7 @@ class AutomationAgent {
     static const char* getSystemPrompt();
 
   private:
+    MagdaApi& api_;
     AutomationParser parser_;
     AutomationExecutor executor_;
     std::atomic<bool> shouldStop_{false};

--- a/magda/agents/command_agent.cpp
+++ b/magda/agents/command_agent.cpp
@@ -45,8 +45,8 @@ static std::unique_ptr<llm::LLMClient> createCommandClient(const Config::AgentLL
 }
 
 /** Build the LLM request, adding CFG grammar when supported. */
-static llm::Request buildRequest(const std::string& message, bool cfg) {
-    auto stateJson = dsl::Interpreter::buildStateSnapshot();
+static llm::Request buildRequest(MagdaApi& api, const std::string& message, bool cfg) {
+    auto stateJson = dsl::Interpreter::buildStateSnapshot(api);
     auto systemPrompt = juce::String::fromUTF8(CommandAgent::getSystemPrompt());
     if (stateJson.isNotEmpty())
         systemPrompt += "\n\nCurrent DAW state:\n" + stateJson;
@@ -87,7 +87,7 @@ CommandAgent::GenerateResult CommandAgent::generate(const std::string& message) 
 
     bool cfg = usesCFG(agentConfig);
     auto client = createCommandClient(agentConfig);
-    auto request = buildRequest(message, cfg);
+    auto request = buildRequest(api_, message, cfg);
 
     auto response = client->sendRequest(request);
 
@@ -130,7 +130,7 @@ CommandAgent::GenerateResult CommandAgent::generateStreaming(const std::string& 
 
     bool cfg = usesCFG(agentConfig);
     auto client = createCommandClient(agentConfig);
-    auto request = buildRequest(message, cfg);
+    auto request = buildRequest(api_, message, cfg);
 
     // CFG via Responses API doesn't support streaming — fall back to sync
     if (cfg) {

--- a/magda/agents/command_agent.hpp
+++ b/magda/agents/command_agent.hpp
@@ -7,6 +7,8 @@
 
 namespace magda {
 
+class MagdaApi;
+
 /**
  * @brief Command agent — handles DAW operations via DSL generation.
  *
@@ -16,6 +18,8 @@ namespace magda {
  */
 class CommandAgent {
   public:
+    explicit CommandAgent(MagdaApi& api) : api_(api) {}
+
     struct GenerateResult {
         std::string dslOutput;  // raw DSL text from the LLM
         std::string error;
@@ -40,6 +44,7 @@ class CommandAgent {
     static const char* getSystemPrompt();
 
   private:
+    MagdaApi& api_;
     std::atomic<bool> shouldStop_{false};
 };
 

--- a/magda/agents/daw_agent.cpp
+++ b/magda/agents/daw_agent.cpp
@@ -122,7 +122,7 @@ DAWAgent::GenerateResult DAWAgent::generate(const std::string& message) {
     auto client = createLLMClient(agentConfig, "music");
 
     // Build state snapshot for context
-    auto stateJson = dsl::Interpreter::buildStateSnapshot();
+    auto stateJson = dsl::Interpreter::buildStateSnapshot(api_);
 
     // Build the full prompt with system prompt + state
     auto systemPrompt = juce::String::fromUTF8(getCompactSystemPrompt());
@@ -202,7 +202,7 @@ DAWAgent::DSLResult DAWAgent::generateDSL(const std::string& message) {
     pc.provider = llm::Provider::OpenAIResponses;
     auto client = llm::LLMClientFactory::create(pc);
 
-    auto stateJson = dsl::Interpreter::buildStateSnapshot();
+    auto stateJson = dsl::Interpreter::buildStateSnapshot(api_);
     auto systemPrompt = juce::String::fromUTF8(dsl::getToolDescription());
     if (stateJson.isNotEmpty())
         systemPrompt += "\n\nCurrent DAW state:\n" + stateJson;

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -1024,64 +1024,59 @@ bool Interpreter::executeAddFx(const Params& params) {
     if (fxName.startsWith("<") && fxName.endsWith(">"))
         fxName = fxName.substring(1, fxName.length() - 1);
 
-    // --- Internal plugin lookup (case-insensitive alias map) ---
+    // --- Internal plugin lookup ---
+    // Single canonical alias per plugin, matching the autocomplete dropdown
+    // (see AIChatConsoleContent::buildAliasList). Both lists feed off
+    // pluginNameToAlias(displayName) so what autocomplete suggests is exactly
+    // what the DSL accepts. To add a built-in here, also add the same display
+    // name to buildAliasList — never invent variants.
     struct InternalAlias {
+        juce::String displayName;
         juce::String pluginId;
         DeviceType deviceType;
     };
-    static const std::map<juce::String, InternalAlias> internalAliases = {
+    static const InternalAlias internalAliases[] = {
         // Effects
-        {"eq", {"eq", DeviceType::Effect}},
-        {"equaliser", {"eq", DeviceType::Effect}},
-        {"equalizer", {"eq", DeviceType::Effect}},
-        {"compressor", {"compressor", DeviceType::Effect}},
-        {"reverb", {"reverb", DeviceType::Effect}},
-        {"delay", {"delay", DeviceType::Effect}},
-        {"chorus", {"chorus", DeviceType::Effect}},
-        {"phaser", {"phaser", DeviceType::Effect}},
-        {"filter", {"lowpass", DeviceType::Effect}},
-        {"lowpass", {"lowpass", DeviceType::Effect}},
-        {"utility", {"utility", DeviceType::Effect}},
-        {"pitch shift", {"pitchshift", DeviceType::Effect}},
-        {"pitchshift", {"pitchshift", DeviceType::Effect}},
-        {"ir reverb", {"impulseresponse", DeviceType::Effect}},
-        {"impulse response", {"impulseresponse", DeviceType::Effect}},
+        {"Equaliser", "eq", DeviceType::Effect},
+        {"Compressor", "compressor", DeviceType::Effect},
+        {"Reverb", "reverb", DeviceType::Effect},
+        {"Delay", "delay", DeviceType::Effect},
+        {"Chorus", "chorus", DeviceType::Effect},
+        {"Phaser", "phaser", DeviceType::Effect},
+        {"Filter", "lowpass", DeviceType::Effect},
+        {"Utility", "utility", DeviceType::Effect},
+        {"Pitch Shift", "pitchshift", DeviceType::Effect},
+        {"IR Reverb", "impulseresponse", DeviceType::Effect},
+        {"Test Tone", "tone", DeviceType::Effect},
         // Instruments
-        {"4osc", {"4osc", DeviceType::Instrument}},
-        {"4osc synth", {"4osc", DeviceType::Instrument}},
-        {"fourosc", {"4osc", DeviceType::Instrument}},
-        {"sampler", {"magdasampler", DeviceType::Instrument}},
-        {"magda sampler", {"magdasampler", DeviceType::Instrument}},
-        {"drum grid", {"drumgrid", DeviceType::Instrument}},
-        {"drumgrid", {"drumgrid", DeviceType::Instrument}},
-        {"drum machine", {"drumgrid", DeviceType::Instrument}},
-        // MIDI devices
-        {"chord engine", {"midichordengine", DeviceType::MIDI}},
-        {"chord", {"midichordengine", DeviceType::MIDI}},
-        {"midichordengine", {"midichordengine", DeviceType::MIDI}},
-        {"arpeggiator", {"arpeggiator", DeviceType::MIDI}},
-        {"arp", {"arpeggiator", DeviceType::MIDI}},
-        // Tone generator
-        {"test tone", {"tone", DeviceType::Effect}},
-        {"tone", {"tone", DeviceType::Effect}},
+        {"4OSC Synth", "4osc", DeviceType::Instrument},
+        {"MAGDA Sampler", "magdasampler", DeviceType::Instrument},
+        {"Drum Grid", "drumgrid", DeviceType::Instrument},
     };
 
     auto lowerName = fxName.toLowerCase();
-    auto aliasIt = internalAliases.find(lowerName);
-    if (aliasIt != internalAliases.end()) {
+    const InternalAlias* internalMatch = nullptr;
+    for (const auto& entry : internalAliases) {
+        if (pluginNameToAlias(entry.displayName).equalsIgnoreCase(lowerName)) {
+            internalMatch = &entry;
+            break;
+        }
+    }
+
+    if (internalMatch != nullptr) {
         DeviceInfo device;
-        device.name = fxName;
-        device.pluginId = aliasIt->second.pluginId;
+        device.name = internalMatch->displayName;
+        device.pluginId = internalMatch->pluginId;
         device.format = PluginFormat::Internal;
-        device.deviceType = aliasIt->second.deviceType;
-        device.isInstrument = (aliasIt->second.deviceType == DeviceType::Instrument);
+        device.deviceType = internalMatch->deviceType;
+        device.isInstrument = (internalMatch->deviceType == DeviceType::Instrument);
 
         auto deviceId = api_.tracks().addDeviceToTrack(ctx_.currentTrackId, device);
         if (deviceId == INVALID_DEVICE_ID) {
             ctx_.setError("Failed to add internal FX '" + fxName + "' to track");
             return false;
         }
-        ctx_.addResult("Added internal FX '" + fxName + "'");
+        ctx_.addResult("Added internal FX '" + internalMatch->displayName + "'");
         return true;
     }
 
@@ -1472,8 +1467,8 @@ bool Interpreter::isContextEnabled() {
     return g_contextEnabled.load(std::memory_order_relaxed);
 }
 
-juce::String Interpreter::buildStateSnapshot() {
-    auto& tm = TrackManager::getInstance();
+juce::String Interpreter::buildStateSnapshot(MagdaApi& api) {
+    auto& tm = api.tracks();
 
     auto* root = new juce::DynamicObject();
 
@@ -1497,7 +1492,7 @@ juce::String Interpreter::buildStateSnapshot() {
     if (!g_contextEnabled.load(std::memory_order_relaxed))
         return juce::JSON::toString(juce::var(root), true);
 
-    auto& sm = SelectionManager::getInstance();
+    auto& sm = api.selection();
     auto selTrack = sm.getSelectedTrack();
     if (selTrack != INVALID_TRACK_ID) {
         // Find 1-based index for the selected track
@@ -1511,7 +1506,7 @@ juce::String Interpreter::buildStateSnapshot() {
     }
 
     // Selected clip context
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api.clips();
     auto selClip = sm.getSelectedClip();
     if (selClip != INVALID_CLIP_ID) {
         auto* clip = cm.getClip(selClip);
@@ -2279,9 +2274,8 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
         return false;
     }
 
-    // Get cached transients
-    auto& thumbnailManager = AudioThumbnailManager::getInstance();
-    const auto* transients = thumbnailManager.getCachedTransients(clip->audioFilePath);
+    // Get cached transients via the api
+    const auto* transients = api_.clips().getCachedTransients(clip->audioFilePath);
     if (!transients || transients->isEmpty()) {
         ctx_.setError("groove.extract: no transients detected for this clip. "
                       "Enable warp or detect transients first.");

--- a/magda/agents/dsl_interpreter.hpp
+++ b/magda/agents/dsl_interpreter.hpp
@@ -178,13 +178,8 @@ class Interpreter {
      * Includes the user's current track/clip selection by default so the LLM
      * can target it. Controlled by setContextEnabled(): when false, the
      * snapshot omits selection info so the LLM has no bias signal.
-     *
-     * NOTE: still reads MAGDA singletons internally — migration to
-     * MagdaApi is deferred to a follow-up PR (touches CommandAgent which
-     * doesn't yet hold a MagdaApi&). The instance Interpreter migrated
-     * in this PR doesn't depend on this static helper.
      */
-    static juce::String buildStateSnapshot();
+    static juce::String buildStateSnapshot(MagdaApi& api);
 
     /** Toggle whether the state snapshot exposes the UI selection to the LLM. */
     static void setContextEnabled(bool enabled);

--- a/magda/daw/api/clip_api.hpp
+++ b/magda/daw/api/clip_api.hpp
@@ -23,6 +23,15 @@ class ClipApi {
 
     virtual void setClipName(ClipId clipId, const juce::String& name) = 0;
     virtual void setGrooveTemplate(ClipId clipId, const juce::String& templateName) = 0;
+
+    /**
+     * @brief Cached transient times for an audio clip's source file.
+     *
+     * Looks the file path up in the audio thumbnail / transient cache.
+     * @return Array of transient times in seconds, or nullptr if no
+     *         transients have been detected for this file.
+     */
+    virtual const juce::Array<double>* getCachedTransients(const juce::String& filePath) const = 0;
 };
 
 }  // namespace magda

--- a/magda/daw/api/clip_api_live.cpp
+++ b/magda/daw/api/clip_api_live.cpp
@@ -1,5 +1,6 @@
 #include "clip_api_live.hpp"
 
+#include "../audio/AudioThumbnailManager.hpp"
 #include "../core/ClipManager.hpp"
 
 namespace magda {
@@ -31,6 +32,10 @@ void ClipApiLive::setClipName(ClipId clipId, const juce::String& name) {
 
 void ClipApiLive::setGrooveTemplate(ClipId clipId, const juce::String& templateName) {
     ClipManager::getInstance().setGrooveTemplate(clipId, templateName);
+}
+
+const juce::Array<double>* ClipApiLive::getCachedTransients(const juce::String& filePath) const {
+    return AudioThumbnailManager::getInstance().getCachedTransients(filePath);
 }
 
 }  // namespace magda

--- a/magda/daw/api/clip_api_live.hpp
+++ b/magda/daw/api/clip_api_live.hpp
@@ -17,6 +17,8 @@ class ClipApiLive : public ClipApi {
 
     void setClipName(ClipId clipId, const juce::String& name) override;
     void setGrooveTemplate(ClipId clipId, const juce::String& templateName) override;
+
+    const juce::Array<double>* getCachedTransients(const juce::String& filePath) const override;
 };
 
 }  // namespace magda

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -891,7 +891,7 @@ AIChatConsoleContent::AIChatConsoleContent() {
     agent_ = std::make_unique<magda::DAWAgent>(*magdaApi_);  // legacy DSL REPL
     agent_->start();
     routerAgent_ = std::make_unique<magda::RouterAgent>();
-    commandAgent_ = std::make_unique<magda::CommandAgent>();
+    commandAgent_ = std::make_unique<magda::CommandAgent>(*magdaApi_);
     musicAgent_ = std::make_unique<magda::MusicAgent>();
     automationAgent_ = std::make_unique<magda::AutomationAgent>(*magdaApi_);
     controllerAgent_ = std::make_unique<magda::ControllerProfileAgent>();


### PR DESCRIPTION
## Summary

PR4 of the issue #1113 epic, stacked on PR3 (#1116). Closes the carve-outs PR3 left behind.

**Migrations:**
- \`automation_agent::buildSelectionContext\` now takes \`MagdaApi&\`. \`AutomationAgent\` stores \`api_\` to pass through.
- \`dsl::Interpreter::buildStateSnapshot\` is now \`static(MagdaApi&)\` instead of singleton-reading. Callers (DAWAgent x2, CommandAgent x1) pass their own \`api_\`.
- \`CommandAgent\` constructor takes \`MagdaApi&\` (matching the other agents). \`AIChatConsoleContent\` constructs it with \`magdaApi_\`.
- \`ClipApi\` gains \`getCachedTransients(filePath) -> const juce::Array<double>*\` so \`groove.extract\` no longer hits \`AudioThumbnailManager::getInstance()\` directly.

## Final state of the agent layer

\`grep \"::getInstance\" magda/agents/\` after this PR returns only:
- \`Config::getInstance().getAgentLLMConfig(role)\` — LLM provider configuration. Not DAW state; the original plan deliberately scoped this out (\"it's a config-loader, not DAW state\").
- \`LlamaModelManager\` — LLM-internal singleton, also intentionally out of scope.

The agent layer no longer touches DAW state singletons through any code path. Issue #1113's stated goal is met: the agent code is reusable outside the standalone DAW (e.g. as a separate plugin distribution) by swapping the \`MagdaApiLive\` implementation for an alternative without changing any agent code.

## Test plan

- [x] \`make debug\` clean
- [x] \`make test\` — 26694 assertions / 783 cases pass
- [x] Final singleton audit:
      \`grep \"::getInstance\" magda/agents/\` shows only \`Config::getInstance\` + \`LlamaModelManager\` (intentional)
- [ ] Manual smoke: AI chat (router → command + music + automation, BOTH-intent), DSL console (\`/dsl\` + DSL tab), automation lane prompts, groove.extract

## Stack

- PR1 #1114 — merged
- PR2 #1115 — merged
- PR3 #1116 — open, base \`feat/magda-api\`
- PR4 (this) — open, base PR3's branch (will retarget to \`feat/magda-api\` after PR3 merges)