### PR TITLE
Feat/magda api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ rebuild: clean debug
 format:
 	@echo "🎨 Formatting code..."
 	@if command -v clang-format >/dev/null 2>&1; then \
-		find . -name "*.cpp" -o -name "*.hpp" -o -name "*.h" | grep -E "(daw|agents|tests)" | xargs clang-format -i; \
+		find magda tests \( -name "*.cpp" -o -name "*.hpp" -o -name "*.h" \) | xargs clang-format -i; \
 		echo "✅ Code formatting complete"; \
 	else \
 		echo "❌ clang-format not found. Please install it first."; \

--- a/magda/agents/CMakeLists.txt
+++ b/magda/agents/CMakeLists.txt
@@ -12,6 +12,7 @@ dsl_grammar.hpp
     dsl_interpreter.hpp
     dsl_interpreter.cpp
     music_helpers.hpp
+    internal_plugins.hpp
     compact_parser.hpp
     compact_parser.cpp
     compact_executor.hpp

--- a/magda/agents/automation_agent.cpp
+++ b/magda/agents/automation_agent.cpp
@@ -1,10 +1,13 @@
 #include "automation_agent.hpp"
 
-#include "../daw/core/AutomationManager.hpp"
+#include "../daw/api/automation_api.hpp"
+#include "../daw/api/magda_api.hpp"
+#include "../daw/api/selection_api.hpp"
+#include "../daw/api/track_api.hpp"
+#include "../daw/core/AutomationInfo.hpp"
 #include "../daw/core/Config.hpp"
 #include "../daw/core/ParameterInfo.hpp"
-#include "../daw/core/SelectionManager.hpp"
-#include "../daw/core/TrackManager.hpp"
+#include "../daw/core/TrackInfo.hpp"
 #include "llm_client_factory.hpp"
 
 namespace magda {
@@ -76,16 +79,17 @@ AUTO freeform points=(0,0.1)(2,0.9)(8,0) target=selected)PROMPT";
 namespace {
 
 /** Multi-line selection context appended to the system prompt. */
-juce::String buildSelectionContext() {
-    auto& sel = SelectionManager::getInstance();
-    auto& amgr = AutomationManager::getInstance();
-    auto& tmgr = TrackManager::getInstance();
+juce::String buildSelectionContext(MagdaApi& api) {
+    auto& sel = api.selection();
+    auto& amgr = api.automation();
+    auto& tmgr = api.tracks();
     juce::String out;
 
     TrackId contextTrackId = sel.getSelectedTrack();
 
-    if (sel.hasAutomationLaneSelection()) {
-        auto laneId = sel.getAutomationLaneSelection().laneId;
+    auto selLaneId = sel.getSelectedAutomationLaneId();
+    if (selLaneId != INVALID_AUTOMATION_LANE_ID) {
+        auto laneId = selLaneId;
         if (auto* lane = amgr.getLane(laneId)) {
             auto info = lane->target.getParameterInfo();
             out << "Selected lane: \"" << lane->getDisplayName() << "\" (laneId=" << laneId
@@ -129,9 +133,9 @@ std::string cleanOutput(const juce::String& raw) {
     return text.toStdString();
 }
 
-llm::Request buildRequest(const std::string& message) {
+llm::Request buildRequest(MagdaApi& api, const std::string& message) {
     auto systemPrompt = juce::String::fromUTF8(AutomationAgent::getSystemPrompt());
-    auto ctx = buildSelectionContext();
+    auto ctx = buildSelectionContext(api);
     if (ctx.isNotEmpty())
         systemPrompt += "\n\nContext:\n" + ctx;
 
@@ -166,7 +170,7 @@ AutomationAgent::GenerateResult AutomationAgent::generate(const std::string& mes
     }
 
     auto client = createLLMClient(agentConfig, "automation");
-    auto request = buildRequest(message);
+    auto request = buildRequest(api_, message);
 
     auto response = client->sendRequest(request);
 
@@ -214,7 +218,7 @@ AutomationAgent::GenerateResult AutomationAgent::generateStreaming(const std::st
     }
 
     auto client = createLLMClient(agentConfig, "automation");
-    auto request = buildRequest(message);
+    auto request = buildRequest(api_, message);
 
     auto response = client->sendStreamingRequest(request, [&](const juce::String& token) {
         if (shouldStop_.load())

--- a/magda/agents/automation_agent.hpp
+++ b/magda/agents/automation_agent.hpp
@@ -27,7 +27,7 @@ class MagdaApi;
  */
 class AutomationAgent {
   public:
-    explicit AutomationAgent(MagdaApi& api) : executor_(api) {}
+    explicit AutomationAgent(MagdaApi& api) : api_(api), executor_(api) {}
 
     struct GenerateResult {
         std::string rawOutput;
@@ -57,6 +57,7 @@ class AutomationAgent {
     static const char* getSystemPrompt();
 
   private:
+    MagdaApi& api_;
     AutomationParser parser_;
     AutomationExecutor executor_;
     std::atomic<bool> shouldStop_{false};

--- a/magda/agents/automation_agent.hpp
+++ b/magda/agents/automation_agent.hpp
@@ -11,6 +11,8 @@
 
 namespace magda {
 
+class MagdaApi;
+
 /**
  * @brief Automation agent — emits automation curves on a selected lane.
  *
@@ -21,10 +23,12 @@ namespace magda {
  *   1. Call LLM with system prompt describing AUTO grammar + current
  *      selection context
  *   2. Parse response into AutoInstruction IR
- *   3. Execute against AutomationManager (must be on message thread)
+ *   3. Execute against the MagdaApi automation surface (message thread)
  */
 class AutomationAgent {
   public:
+    explicit AutomationAgent(MagdaApi& api) : executor_(api) {}
+
     struct GenerateResult {
         std::string rawOutput;
         std::vector<AutoInstruction> instructions;

--- a/magda/agents/automation_executor.cpp
+++ b/magda/agents/automation_executor.cpp
@@ -2,8 +2,10 @@
 
 #include <cmath>
 
-#include "../daw/core/AutomationManager.hpp"
-#include "../daw/core/SelectionManager.hpp"
+#include "../daw/api/alias_api.hpp"
+#include "../daw/api/automation_api.hpp"
+#include "../daw/api/magda_api.hpp"
+#include "../daw/api/selection_api.hpp"
 #include "../daw/core/aliases/AliasRegistry.hpp"
 #include "../daw/core/aliases/ChainContext.hpp"
 #include "../daw/core/aliases/ParamSigilParser.hpp"
@@ -26,15 +28,15 @@ double clampNorm(double v) {
 }
 
 /** Get selected track id, or INVALID if none. */
-TrackId getSelectedTrack(juce::String& err) {
-    auto& sel = SelectionManager::getInstance();
+TrackId getSelectedTrack(MagdaApi& api, juce::String& err) {
+    auto& sel = api.selection();
     auto trackId = sel.getSelectedTrack();
     if (trackId == INVALID_TRACK_ID) {
         // Also consult the automation-lane selection for its track, so that
         // clicking a lane counts as "having a track context" too.
-        if (sel.hasAutomationLaneSelection()) {
-            auto laneId = sel.getAutomationLaneSelection().laneId;
-            if (auto* lane = AutomationManager::getInstance().getLane(laneId))
+        auto laneId = sel.getSelectedAutomationLaneId();
+        if (laneId != INVALID_AUTOMATION_LANE_ID) {
+            if (auto* lane = api.automation().getLane(laneId))
                 return lane->target.trackId;
         }
         err = "No track is selected. Click a track first.";
@@ -44,8 +46,8 @@ TrackId getSelectedTrack(juce::String& err) {
 }
 
 /** Look up an existing lane for a target, creating it if needed. */
-AutomationLaneId ensureLaneForTarget(const AutomationTarget& target) {
-    auto& mgr = AutomationManager::getInstance();
+AutomationLaneId ensureLaneForTarget(MagdaApi& api, const AutomationTarget& target) {
+    auto& mgr = api.automation();
     auto existing = mgr.getLaneForTarget(target);
     if (existing != INVALID_AUTOMATION_LANE_ID)
         return existing;
@@ -53,10 +55,10 @@ AutomationLaneId ensureLaneForTarget(const AutomationTarget& target) {
 }
 
 /** Resolve an AutoTarget into a concrete lane id, or INVALID. */
-AutomationLaneId resolveTarget(const AutoTarget& target, juce::String& err) {
+AutomationLaneId resolveTarget(MagdaApi& api, const AutoTarget& target, juce::String& err) {
     switch (target.kind) {
         case AutoTarget::Kind::LaneId: {
-            auto* lane = AutomationManager::getInstance().getLane(target.laneId);
+            auto* lane = api.automation().getLane(target.laneId);
             if (lane == nullptr) {
                 err = "Lane " + juce::String(target.laneId) + " does not exist";
                 return INVALID_AUTOMATION_LANE_ID;
@@ -64,36 +66,37 @@ AutomationLaneId resolveTarget(const AutoTarget& target, juce::String& err) {
             return target.laneId;
         }
         case AutoTarget::Kind::Selected: {
-            auto& sel = SelectionManager::getInstance();
-            if (sel.hasAutomationLaneSelection())
-                return sel.getAutomationLaneSelection().laneId;
+            auto& sel = api.selection();
+            auto laneId = sel.getSelectedAutomationLaneId();
+            if (laneId != INVALID_AUTOMATION_LANE_ID)
+                return laneId;
             // Fall back to trackVolume on the selected track — the most
             // common default for "automate this track".
-            auto trackId = getSelectedTrack(err);
+            auto trackId = getSelectedTrack(api, err);
             if (trackId == INVALID_TRACK_ID)
                 return INVALID_AUTOMATION_LANE_ID;
             AutomationTarget t;
             t.type = AutomationTargetType::TrackVolume;
             t.trackId = trackId;
-            return ensureLaneForTarget(t);
+            return ensureLaneForTarget(api, t);
         }
         case AutoTarget::Kind::TrackVolume: {
-            auto trackId = getSelectedTrack(err);
+            auto trackId = getSelectedTrack(api, err);
             if (trackId == INVALID_TRACK_ID)
                 return INVALID_AUTOMATION_LANE_ID;
             AutomationTarget t;
             t.type = AutomationTargetType::TrackVolume;
             t.trackId = trackId;
-            return ensureLaneForTarget(t);
+            return ensureLaneForTarget(api, t);
         }
         case AutoTarget::Kind::TrackPan: {
-            auto trackId = getSelectedTrack(err);
+            auto trackId = getSelectedTrack(api, err);
             if (trackId == INVALID_TRACK_ID)
                 return INVALID_AUTOMATION_LANE_ID;
             AutomationTarget t;
             t.type = AutomationTargetType::TrackPan;
             t.trackId = trackId;
-            return ensureLaneForTarget(t);
+            return ensureLaneForTarget(api, t);
         }
         case AutoTarget::Kind::Alias: {
             auto sigil = tryParse(target.aliasToken);
@@ -102,7 +105,7 @@ AutomationLaneId resolveTarget(const AutoTarget& target, juce::String& err) {
                 return INVALID_AUTOMATION_LANE_ID;
             }
             DefaultChainContext ctx;
-            TargetResolver resolver(AliasRegistry::getInstance(), ResolverRegistry::getInstance(),
+            TargetResolver resolver(api.aliases().aliasRegistry(), api.aliases().resolverRegistry(),
                                     ctx);
             auto resolved = resolver.resolveSigil(*sigil);
             if (!resolved.ok()) {
@@ -116,7 +119,7 @@ AutomationLaneId resolveTarget(const AutoTarget& target, juce::String& err) {
             t.paramIndex = resolved.paramIndex;
             // Derive track id from device path
             t.trackId = resolved.devicePath.trackId;
-            return ensureLaneForTarget(t);
+            return ensureLaneForTarget(api, t);
         }
     }
     err = "Unknown target kind";
@@ -124,9 +127,7 @@ AutomationLaneId resolveTarget(const AutoTarget& target, juce::String& err) {
 }
 
 /** Emit points into a lane for a given shape op. Values already normalized. */
-void emitShapePoints(AutomationLaneId laneId, const AutoShapeOp& op) {
-    auto& mgr = AutomationManager::getInstance();
-
+void emitShapePoints(AutomationApi& mgr, AutomationLaneId laneId, const AutoShapeOp& op) {
     const double minV = clampNorm(op.minV);
     const double maxV = clampNorm(op.maxV);
     const double center = 0.5 * (minV + maxV);
@@ -227,7 +228,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
     error_.clear();
     results_.clear();
 
-    auto& mgr = AutomationManager::getInstance();
+    auto& mgr = api_.automation();
     int laneCount = 0;
     int pointCount = 0;
 
@@ -236,14 +237,14 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
     // AutomationPlaybackEngine answers with a full bakeLane() — producing
     // O(n) bakes for an n-point curve and a visible stall between the agent
     // completing and the curve appearing.
-    AutomationManager::BatchScope batchScope;
+    AutomationApi::BatchScope batchScope(mgr);
 
     for (const auto& inst : instructions) {
         juce::String err;
 
         if (std::holds_alternative<AutoClearOp>(inst.payload)) {
             auto& op = std::get<AutoClearOp>(inst.payload);
-            auto laneId = resolveTarget(op.target, err);
+            auto laneId = resolveTarget(api_, op.target, err);
             if (laneId == INVALID_AUTOMATION_LANE_ID) {
                 error_ = err;
                 return false;
@@ -255,7 +256,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
 
         if (std::holds_alternative<AutoFreeformOp>(inst.payload)) {
             auto& op = std::get<AutoFreeformOp>(inst.payload);
-            auto laneId = resolveTarget(op.target, err);
+            auto laneId = resolveTarget(api_, op.target, err);
             if (laneId == INVALID_AUTOMATION_LANE_ID) {
                 error_ = err;
                 return false;
@@ -270,7 +271,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
 
         if (std::holds_alternative<AutoShapeOp>(inst.payload)) {
             auto& op = std::get<AutoShapeOp>(inst.payload);
-            auto laneId = resolveTarget(op.target, err);
+            auto laneId = resolveTarget(api_, op.target, err);
             if (laneId == INVALID_AUTOMATION_LANE_ID) {
                 error_ = err;
                 return false;
@@ -278,7 +279,7 @@ bool AutomationExecutor::execute(const std::vector<AutoInstruction>& instruction
             int before = 0;
             if (auto* lane = mgr.getLane(laneId))
                 before = static_cast<int>(lane->absolutePoints.size());
-            emitShapePoints(laneId, op);
+            emitShapePoints(mgr, laneId, op);
             int after = 0;
             if (auto* lane = mgr.getLane(laneId))
                 after = static_cast<int>(lane->absolutePoints.size());

--- a/magda/agents/automation_executor.hpp
+++ b/magda/agents/automation_executor.hpp
@@ -8,17 +8,21 @@
 
 namespace magda {
 
+class MagdaApi;
+
 /**
- * @brief Executes AutomationAgent IR against AutomationManager.
+ * @brief Executes AutomationAgent IR against the MagdaApi automation surface.
  *
- * Resolves the "selected" target from SelectionManager, generates shape
- * points in beats, and writes them via AutomationManager::addPoint.
+ * Resolves the "selected" target via the host's selection state, generates
+ * shape points in beats, and writes them through MagdaApi::automation().
  *
- * MUST be called on the message thread (touches AutomationManager which
- * notifies UI listeners).
+ * MUST be called on the message thread (host writes ultimately notify UI
+ * listeners).
  */
 class AutomationExecutor {
   public:
+    explicit AutomationExecutor(MagdaApi& api) : api_(api) {}
+
     /** Run all instructions. Returns true on success. */
     bool execute(const std::vector<AutoInstruction>& instructions);
 
@@ -30,6 +34,7 @@ class AutomationExecutor {
     }
 
   private:
+    MagdaApi& api_;
     juce::String error_;
     juce::String results_;
 };

--- a/magda/agents/command_agent.cpp
+++ b/magda/agents/command_agent.cpp
@@ -45,8 +45,8 @@ static std::unique_ptr<llm::LLMClient> createCommandClient(const Config::AgentLL
 }
 
 /** Build the LLM request, adding CFG grammar when supported. */
-static llm::Request buildRequest(const std::string& message, bool cfg) {
-    auto stateJson = dsl::Interpreter::buildStateSnapshot();
+static llm::Request buildRequest(MagdaApi& api, const std::string& message, bool cfg) {
+    auto stateJson = dsl::Interpreter::buildStateSnapshot(api);
     auto systemPrompt = juce::String::fromUTF8(CommandAgent::getSystemPrompt());
     if (stateJson.isNotEmpty())
         systemPrompt += "\n\nCurrent DAW state:\n" + stateJson;
@@ -87,7 +87,7 @@ CommandAgent::GenerateResult CommandAgent::generate(const std::string& message) 
 
     bool cfg = usesCFG(agentConfig);
     auto client = createCommandClient(agentConfig);
-    auto request = buildRequest(message, cfg);
+    auto request = buildRequest(api_, message, cfg);
 
     auto response = client->sendRequest(request);
 
@@ -130,7 +130,7 @@ CommandAgent::GenerateResult CommandAgent::generateStreaming(const std::string& 
 
     bool cfg = usesCFG(agentConfig);
     auto client = createCommandClient(agentConfig);
-    auto request = buildRequest(message, cfg);
+    auto request = buildRequest(api_, message, cfg);
 
     // CFG via Responses API doesn't support streaming — fall back to sync
     if (cfg) {

--- a/magda/agents/command_agent.hpp
+++ b/magda/agents/command_agent.hpp
@@ -7,6 +7,8 @@
 
 namespace magda {
 
+class MagdaApi;
+
 /**
  * @brief Command agent — handles DAW operations via DSL generation.
  *
@@ -16,6 +18,8 @@ namespace magda {
  */
 class CommandAgent {
   public:
+    explicit CommandAgent(MagdaApi& api) : api_(api) {}
+
     struct GenerateResult {
         std::string dslOutput;  // raw DSL text from the LLM
         std::string error;
@@ -40,6 +44,7 @@ class CommandAgent {
     static const char* getSystemPrompt();
 
   private:
+    MagdaApi& api_;
     std::atomic<bool> shouldStop_{false};
 };
 

--- a/magda/agents/compact_executor.cpp
+++ b/magda/agents/compact_executor.cpp
@@ -16,6 +16,7 @@
 #include "../daw/core/TrackTypes.hpp"
 #include "../daw/engine/AudioEngine.hpp"
 #include "../daw/engine/TracktionEngineWrapper.hpp"
+#include "internal_plugins.hpp"
 #include "music_helpers.hpp"
 
 namespace magda {
@@ -488,41 +489,22 @@ bool CompactExecutor::executeFx(const FxOp& op) {
     if (trackId < 0)
         return false;
 
-    // Internal plugin alias lookup (mirrors DSL interpreter)
-    static const std::map<juce::String, juce::String> internalAliases = {
-        {"eq", "eq"},
-        {"equaliser", "eq"},
-        {"equalizer", "eq"},
-        {"compressor", "compressor"},
-        {"reverb", "reverb"},
-        {"delay", "delay"},
-        {"chorus", "chorus"},
-        {"phaser", "phaser"},
-        {"filter", "lowpass"},
-        {"lowpass", "lowpass"},
-        {"utility", "utility"},
-        {"pitch shift", "pitchshift"},
-        {"pitchshift", "pitchshift"},
-        {"ir reverb", "impulseresponse"},
-        {"impulse response", "impulseresponse"},
-    };
-
-    auto lowerName = op.fxName.toLowerCase();
-    auto aliasIt = internalAliases.find(lowerName);
-
-    if (aliasIt != internalAliases.end()) {
+    // Internal plugin lookup — shares internal_plugins.hpp with the DSL
+    // interpreter so a single canonical alias per plugin is accepted by both.
+    if (const auto* match = lookupInternalPluginByAlias(op.fxName)) {
         DeviceInfo device;
-        device.name = op.fxName;
-        device.pluginId = aliasIt->second;
+        device.name = match->displayName;
+        device.pluginId = match->pluginId;
         device.format = PluginFormat::Internal;
-        device.isInstrument = false;
+        device.deviceType = match->deviceType;
+        device.isInstrument = (match->deviceType == DeviceType::Instrument);
 
         auto deviceId = api_.tracks().addDeviceToTrack(trackId, device);
         if (deviceId == INVALID_DEVICE_ID) {
             error_ = "Failed to add FX '" + op.fxName + "'";
             return false;
         }
-        results_.add("Added FX '" + op.fxName + "'");
+        results_.add("Added FX '" + match->displayName + "'");
         return true;
     }
 

--- a/magda/agents/compact_executor.cpp
+++ b/magda/agents/compact_executor.cpp
@@ -4,17 +4,18 @@
 #include <cmath>
 #include <limits>
 
-#include "../daw/core/ClipManager.hpp"
+#include "../daw/api/clip_api.hpp"
+#include "../daw/api/magda_api.hpp"
+#include "../daw/api/project_api.hpp"
+#include "../daw/api/selection_api.hpp"
+#include "../daw/api/track_api.hpp"
+#include "../daw/api/undo_api.hpp"
 #include "../daw/core/DeviceInfo.hpp"
 #include "../daw/core/MidiNoteCommands.hpp"
 #include "../daw/core/PluginAlias.hpp"
-#include "../daw/core/SelectionManager.hpp"
-#include "../daw/core/TrackManager.hpp"
 #include "../daw/core/TrackTypes.hpp"
-#include "../daw/core/UndoManager.hpp"
 #include "../daw/engine/AudioEngine.hpp"
 #include "../daw/engine/TracktionEngineWrapper.hpp"
-#include "../daw/project/ProjectManager.hpp"
 #include "music_helpers.hpp"
 
 namespace magda {
@@ -24,8 +25,7 @@ namespace magda {
 // ============================================================================
 
 int CompactExecutor::findTrackByName(const juce::String& name) const {
-    auto& tm = TrackManager::getInstance();
-    for (const auto& track : tm.getTracks())
+    for (const auto& track : api_.tracks().getTracks())
         if (track.name.equalsIgnoreCase(name))
             return track.id;
     return -1;
@@ -40,7 +40,7 @@ int CompactExecutor::resolveTrackRef(const TrackRef& ref) {
         return currentTrackId_;
     }
 
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
     if (ref.isById()) {
         int index = ref.id - 1;
         if (index < 0 || index >= tm.getNumTracks()) {
@@ -57,7 +57,7 @@ int CompactExecutor::resolveTrackRef(const TrackRef& ref) {
 
 double CompactExecutor::barsToTime(double bar) const {
     double bpm = 120.0;
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     if (engine)
         bpm = engine->getTempo();
     return (bar - 1.0) * 4.0 * 60.0 / bpm;
@@ -65,7 +65,7 @@ double CompactExecutor::barsToTime(double bar) const {
 
 double CompactExecutor::barsToLength(double bars) const {
     double bpm = 120.0;
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     if (engine)
         bpm = engine->getTempo();
     return bars * 4.0 * 60.0 / bpm;
@@ -74,7 +74,7 @@ double CompactExecutor::barsToLength(double bars) const {
 double CompactExecutor::barsToBeats(double bars) const {
     // Use the project's time-signature numerator. Hard-coding 4 here was
     // the source of the seconds↔beats round-trip drift under non-4/4 sigs.
-    int beatsPerBar = ProjectManager::getInstance().getCurrentProjectInfo().timeSignatureNumerator;
+    int beatsPerBar = api_.project().getCurrentProjectInfo().timeSignatureNumerator;
     if (beatsPerBar <= 0)
         beatsPerBar = 4;
     return bars * static_cast<double>(beatsPerBar);
@@ -98,7 +98,7 @@ bool CompactExecutor::execute(const std::vector<Instruction>& instructions) {
     // command agent's clip.new). Using SelectionManager for agent-to-agent
     // handoff would silently fill whichever clip the user happened to have
     // selected in the UI.
-    auto& sm = SelectionManager::getInstance();
+    auto& sm = api_.selection();
     auto selectedTrack = sm.getSelectedTrack();
 
     // Ignore master track as implicit target — it's not a user track
@@ -110,7 +110,7 @@ bool CompactExecutor::execute(const std::vector<Instruction>& instructions) {
     // auto-creation and cause note commands to silently no-op on a missing
     // clip while still reporting success.
     if (seedClipId_ >= 0) {
-        auto* clipInfo = ClipManager::getInstance().getClip(seedClipId_);
+        auto* clipInfo = api_.clips().getClip(seedClipId_);
         if (clipInfo) {
             currentClipId_ = seedClipId_;
             if (clipInfo->trackId != INVALID_TRACK_ID)
@@ -129,7 +129,7 @@ bool CompactExecutor::execute(const std::vector<Instruction>& instructions) {
         // Derive track from first clip if no track selected
         if (currentTrackId_ < 0) {
             for (auto cid : uiClips) {
-                auto* clipInfo = ClipManager::getInstance().getClip(cid);
+                auto* clipInfo = api_.clips().getClip(cid);
                 if (clipInfo && clipInfo->trackId != INVALID_TRACK_ID) {
                     currentTrackId_ = clipInfo->trackId;
                     break;
@@ -222,8 +222,7 @@ bool CompactExecutor::autoCreateClip() {
         juce::String(currentTrackId_) + " startBeats=" + juce::String(startBeats, 3) +
         " lenBeats=" + juce::String(lengthBeats, 3));
 
-    auto clipId =
-        ClipManager::getInstance().createMidiClipBeats(currentTrackId_, startBeats, lengthBeats);
+    auto clipId = api_.clips().createMidiClipBeats(currentTrackId_, startBeats, lengthBeats);
     if (clipId < 0) {
         error_ = "Failed to auto-create clip";
         DBG("CompactExecutor::autoCreateClip FAIL: createMidiClip returned -1 for track " +
@@ -244,7 +243,7 @@ bool CompactExecutor::autoCreateClip() {
 // ============================================================================
 
 bool CompactExecutor::executeTrack(const TrackOp& op) {
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
 
     // TRACK FX <alias> — resolve plugin, name track after it, add plugin
     if (op.fxAlias.isNotEmpty()) {
@@ -292,8 +291,8 @@ bool CompactExecutor::executeTrack(const TrackOp& op) {
 bool CompactExecutor::executeDel(const DelOp& op) {
     // If active selection from SELECT, delete all selected items
     if (op.target.isImplicit() && hasActiveSelection()) {
-        auto& tm = TrackManager::getInstance();
-        auto& cm = ClipManager::getInstance();
+        auto& tm = api_.tracks();
+        auto& cm = api_.clips();
         int count = 0;
 
         if (!selectedClips_.empty()) {
@@ -318,13 +317,13 @@ bool CompactExecutor::executeDel(const DelOp& op) {
     int trackId = resolveTrackRef(op.target);
     if (trackId < 0)
         return false;
-    TrackManager::getInstance().deleteTrack(trackId);
+    api_.tracks().deleteTrack(trackId);
     results_.add("Deleted track");
     return true;
 }
 
 bool CompactExecutor::executeMute(const MuteOp& op) {
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
 
     // If an active track selection from SELECT is present, mute all selected
     // (unless the caller gave an explicit target, in which case honour that).
@@ -361,7 +360,7 @@ bool CompactExecutor::executeMute(const MuteOp& op) {
 }
 
 bool CompactExecutor::executeSolo(const SoloOp& op) {
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
 
     if (!selectedTracks_.empty() && op.target.isImplicit()) {
         for (auto trackId : selectedTracks_)
@@ -392,7 +391,7 @@ bool CompactExecutor::executeSolo(const SoloOp& op) {
 }
 
 void CompactExecutor::applySetProps(int trackId, const juce::StringPairArray& props) {
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
     for (const auto& key : props.getAllKeys()) {
         auto val = props.getValue(key, "");
         if (key == "vol" || key == "volume_db") {
@@ -424,7 +423,7 @@ bool CompactExecutor::executeSet(const SetOp& op) {
     // If active clip selection, apply track props to each clip's parent track
     // and apply clip-specific props (name) to the clips
     if (op.target.isImplicit() && !selectedClips_.empty()) {
-        auto& cm = ClipManager::getInstance();
+        auto& cm = api_.clips();
         int count = 0;
         for (auto clipId : selectedClips_) {
             auto* clip = cm.getClip(clipId);
@@ -463,7 +462,7 @@ bool CompactExecutor::executeClip(const ClipOp& op) {
     double startBeats = barsToBeats(op.bar - 1.0);
     double lengthBeats = barsToBeats(op.lengthBars);
 
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api_.clips();
     auto clipId = cm.createMidiClipBeats(trackId, startBeats, lengthBeats);
 
     if (clipId < 0) {
@@ -518,7 +517,7 @@ bool CompactExecutor::executeFx(const FxOp& op) {
         device.format = PluginFormat::Internal;
         device.isInstrument = false;
 
-        auto deviceId = TrackManager::getInstance().addDeviceToTrack(trackId, device);
+        auto deviceId = api_.tracks().addDeviceToTrack(trackId, device);
         if (deviceId == INVALID_DEVICE_ID) {
             error_ = "Failed to add FX '" + op.fxName + "'";
             return false;
@@ -528,7 +527,7 @@ bool CompactExecutor::executeFx(const FxOp& op) {
     }
 
     // External plugin lookup via alias matching
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     if (!engine) {
         error_ = "Audio engine not available";
         return false;
@@ -577,7 +576,7 @@ bool CompactExecutor::executeFx(const FxOp& op) {
     else
         device.format = PluginFormat::VST3;
 
-    auto deviceId = TrackManager::getInstance().addDeviceToTrack(trackId, device);
+    auto deviceId = api_.tracks().addDeviceToTrack(trackId, device);
     if (deviceId == INVALID_DEVICE_ID) {
         error_ = "Failed to add plugin '" + op.fxName + "'";
         return false;
@@ -588,10 +587,10 @@ bool CompactExecutor::executeFx(const FxOp& op) {
 }
 
 bool CompactExecutor::executeSelect(const SelectOp& op) {
-    auto& sm = SelectionManager::getInstance();
+    auto& sm = api_.selection();
 
     if (op.target == SelectOp::Target::Tracks) {
-        auto& tm = TrackManager::getInstance();
+        auto& tm = api_.tracks();
         std::unordered_set<TrackId> matches;
 
         for (const auto& track : tm.getTracks()) {
@@ -638,7 +637,7 @@ bool CompactExecutor::executeSelect(const SelectOp& op) {
     }
 
     // SELECT CLIPS
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api_.clips();
     std::unordered_set<ClipId> matches;
 
     for (const auto& clip : cm.getArrangementClips()) {
@@ -680,8 +679,7 @@ bool CompactExecutor::executeSelect(const SelectOp& op) {
                 match = std::abs(clipBar - numVal) < 0.01;
         } else if (op.field == "track") {
             // Filter by parent track name
-            auto& tm = TrackManager::getInstance();
-            for (const auto& track : tm.getTracks()) {
+            for (const auto& track : api_.tracks().getTracks()) {
                 if (track.id == clip.trackId) {
                     auto trackName = track.name.toLowerCase();
                     auto val = op.value.toLowerCase();
@@ -787,7 +785,7 @@ bool CompactExecutor::executeArp(const ArpOp& op) {
         idx++;
     }
 
-    UndoManager::getInstance().executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
+    api_.undo().executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
         currentClipId_, std::move(notes),
         "Add " + op.quality + " arpeggio at beat " + juce::String(op.beat, 2)));
 
@@ -821,7 +819,7 @@ bool CompactExecutor::executeChord(const ChordOp& op) {
         notes.push_back(mn);
     }
 
-    UndoManager::getInstance().executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
+    api_.undo().executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
         currentClipId_, std::move(notes),
         "Add " + op.quality + " chord at beat " + juce::String(op.beat, 2)));
 
@@ -843,7 +841,7 @@ bool CompactExecutor::executeNote(const NoteOp& op) {
 
     int velocity = op.velocity >= 0 ? op.velocity : 100;
 
-    UndoManager::getInstance().executeCommand(std::make_unique<AddMidiNoteCommand>(
+    api_.undo().executeCommand(std::make_unique<AddMidiNoteCommand>(
         currentClipId_, op.beat, noteNumber, op.length, velocity));
 
     results_.add("Added note " + op.pitch);

--- a/magda/agents/compact_executor.hpp
+++ b/magda/agents/compact_executor.hpp
@@ -11,14 +11,18 @@
 
 namespace magda {
 
+class MagdaApi;
+
 /**
- * @brief Executes IR instructions against TrackManager/ClipManager.
+ * @brief Executes IR instructions against the MagdaApi facade.
  *
- * Skips the DSL text round-trip: compact LLM output → IR → direct API calls.
- * Must be called on the message thread (same as DSL Interpreter).
+ * Skips the DSL text round-trip: compact LLM output → IR → MagdaApi calls.
+ * Must be called on the message thread (host writes notify UI listeners).
  */
 class CompactExecutor {
   public:
+    explicit CompactExecutor(MagdaApi& api) : api_(api) {}
+
     /**
      * @brief Execute a list of IR instructions.
      * @return true if all instructions succeeded
@@ -89,6 +93,7 @@ class CompactExecutor {
     /** Convert bar count to duration in beats (uses project time signature). */
     double barsToBeats(double bars) const;
 
+    MagdaApi& api_;
     int currentTrackId_ = -1;
     int currentClipId_ = -1;
     int seedClipId_ = -1;

--- a/magda/agents/daw_agent.cpp
+++ b/magda/agents/daw_agent.cpp
@@ -6,7 +6,7 @@
 
 namespace magda {
 
-DAWAgent::DAWAgent(MagdaApi& api) : api_(api), executor_(api) {}
+DAWAgent::DAWAgent(MagdaApi& api) : api_(api), executor_(api), interpreter_(api) {}
 DAWAgent::~DAWAgent() = default;
 
 std::map<std::string, std::string> DAWAgent::getCapabilities() const {

--- a/magda/agents/daw_agent.cpp
+++ b/magda/agents/daw_agent.cpp
@@ -122,7 +122,7 @@ DAWAgent::GenerateResult DAWAgent::generate(const std::string& message) {
     auto client = createLLMClient(agentConfig, "music");
 
     // Build state snapshot for context
-    auto stateJson = dsl::Interpreter::buildStateSnapshot();
+    auto stateJson = dsl::Interpreter::buildStateSnapshot(api_);
 
     // Build the full prompt with system prompt + state
     auto systemPrompt = juce::String::fromUTF8(getCompactSystemPrompt());
@@ -202,7 +202,7 @@ DAWAgent::DSLResult DAWAgent::generateDSL(const std::string& message) {
     pc.provider = llm::Provider::OpenAIResponses;
     auto client = llm::LLMClientFactory::create(pc);
 
-    auto stateJson = dsl::Interpreter::buildStateSnapshot();
+    auto stateJson = dsl::Interpreter::buildStateSnapshot(api_);
     auto systemPrompt = juce::String::fromUTF8(dsl::getToolDescription());
     if (stateJson.isNotEmpty())
         systemPrompt += "\n\nCurrent DAW state:\n" + stateJson;

--- a/magda/agents/daw_agent.cpp
+++ b/magda/agents/daw_agent.cpp
@@ -6,7 +6,7 @@
 
 namespace magda {
 
-DAWAgent::DAWAgent() = default;
+DAWAgent::DAWAgent(MagdaApi& api) : api_(api), executor_(api) {}
 DAWAgent::~DAWAgent() = default;
 
 std::map<std::string, std::string> DAWAgent::getCapabilities() const {

--- a/magda/agents/daw_agent.hpp
+++ b/magda/agents/daw_agent.hpp
@@ -12,6 +12,8 @@
 
 namespace magda {
 
+class MagdaApi;
+
 /**
  * @brief Concrete DAW agent that wires LLM → compact IR → execution.
  *
@@ -26,7 +28,7 @@ namespace magda {
  */
 class DAWAgent : public AgentInterface {
   public:
-    DAWAgent();
+    explicit DAWAgent(MagdaApi& api);
     ~DAWAgent() override;
 
     // AgentInterface
@@ -91,6 +93,7 @@ class DAWAgent : public AgentInterface {
     /** Get the compact system prompt with instruction set. */
     static const char* getCompactSystemPrompt();
 
+    MagdaApi& api_;
     CompactParser parser_;
     CompactExecutor executor_;
     dsl::Interpreter interpreter_;

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -7,6 +7,12 @@
 #include <cstdlib>
 #include <random>
 
+#include "../daw/api/clip_api.hpp"
+#include "../daw/api/magda_api.hpp"
+#include "../daw/api/project_api.hpp"
+#include "../daw/api/selection_api.hpp"
+#include "../daw/api/track_api.hpp"
+#include "../daw/api/undo_api.hpp"
 #include "../daw/audio/AudioThumbnailManager.hpp"
 #include "../daw/core/ClipManager.hpp"
 #include "../daw/core/ClipPropertyCommands.hpp"
@@ -325,7 +331,7 @@ bool Params::getBool(const std::string& key, bool def) const {
 // Interpreter Implementation
 // ============================================================================
 
-Interpreter::Interpreter() {}
+Interpreter::Interpreter(MagdaApi& api) : api_(api) {}
 
 bool Interpreter::execute(const char* dslCode) {
     // Interpreter mutates TrackManager/ClipManager/SelectionManager, all of
@@ -344,7 +350,7 @@ bool Interpreter::execute(const char* dslCode) {
     // `fx("reverb")` or `note(...)` targets the selected track/clip. Matches
     // CompactExecutor's behaviour — the two paths must stay in sync or the
     // same request succeeds in one and fails in the other.
-    auto& sm = SelectionManager::getInstance();
+    auto& sm = api_.selection();
     auto selectedTrack = sm.getSelectedTrack();
     if (selectedTrack != INVALID_TRACK_ID && selectedTrack != MASTER_TRACK_ID)
         ctx_.currentTrackId = selectedTrack;
@@ -435,7 +441,7 @@ bool Interpreter::parseTrackStatement(Tokenizer& tok) {
         return false;
     }
 
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
 
     if (params.has("id")) {
         // Reference existing track by 1-based index
@@ -459,7 +465,7 @@ bool Interpreter::parseTrackStatement(Tokenizer& tok) {
             auto trackType = parseTrackType(params);
             auto trackId = tm.createTrack(name, trackType);
             ctx_.currentTrackId = trackId;
-            SelectionManager::getInstance().selectTrack(trackId);
+            api_.selection().selectTrack(trackId);
             ctx_.addResult("Created track '" + name + "'");
         }
     } else {
@@ -467,7 +473,7 @@ bool Interpreter::parseTrackStatement(Tokenizer& tok) {
         auto trackType = parseTrackType(params);
         auto trackId = tm.createTrack("", trackType);
         ctx_.currentTrackId = trackId;
-        SelectionManager::getInstance().selectTrack(trackId);
+        api_.selection().selectTrack(trackId);
         ctx_.addResult("Created track");
     }
 
@@ -529,7 +535,7 @@ bool Interpreter::parseFilterStatement(Tokenizer& tok) {
     }
 
     // Execute filter: find matching tracks
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
     ctx_.filteredTrackIds.clear();
 
     if (field.value == "name") {
@@ -798,12 +804,12 @@ bool Interpreter::executeNewClip(const Params& params) {
         // No position specified — place after the last clip on this track
         bar = 1.0;
         double bpm = 120.0;
-        auto* engine = TrackManager::getInstance().getAudioEngine();
+        auto* engine = api_.tracks().getAudioEngine();
         if (engine)
             bpm = engine->getTempo();
         double secondsPerBar = 4.0 * 60.0 / bpm;
 
-        auto& cm = ClipManager::getInstance();
+        auto& cm = api_.clips();
         for (auto cid : cm.getClipsOnTrack(ctx_.currentTrackId)) {
             auto* clip = cm.getClip(cid);
             if (!clip)
@@ -830,7 +836,7 @@ bool Interpreter::executeNewClip(const Params& params) {
     double startBeats = barsToBeats(bar - 1.0);
     double lengthBeats = barsToBeats(lengthBars);
 
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api_.clips();
     auto clipId = cm.createMidiClipBeats(ctx_.currentTrackId, startBeats, lengthBeats);
 
     if (clipId < 0) {
@@ -839,14 +845,14 @@ bool Interpreter::executeNewClip(const Params& params) {
     }
 
     ctx_.currentClipId = clipId;
-    SelectionManager::getInstance().selectClip(clipId);
+    api_.selection().selectClip(clipId);
     ctx_.addResult("Created MIDI clip at bar " + juce::String(bar, 2) + ", length " +
                    juce::String(lengthBars, 2) + " bars");
     return true;
 }
 
 bool Interpreter::executeSetTrack(const Params& params) {
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
 
     auto applyToTrack = [&](int trackId) {
         if (params.has("name"))
@@ -898,7 +904,7 @@ bool Interpreter::executeSetTrack(const Params& params) {
 }
 
 bool Interpreter::executeDelete() {
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
 
     if (ctx_.inFilterContext) {
         // Delete in reverse order to avoid index shifting issues
@@ -925,7 +931,7 @@ bool Interpreter::executeDeleteClip(const Params& params) {
         return false;
     }
 
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api_.clips();
     auto clipIds = cm.getClipsOnTrack(ctx_.currentTrackId);
 
     int index = params.getInt("index", 0);
@@ -947,7 +953,7 @@ bool Interpreter::executeRenameClip(const Params& params) {
     }
 
     juce::String newName(params.get("name"));
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api_.clips();
 
     if (params.has("index")) {
         // Rename a specific clip by index on the current track
@@ -965,7 +971,7 @@ bool Interpreter::executeRenameClip(const Params& params) {
         ctx_.addResult("Renamed clip at index " + juce::String(index) + " to '" + newName + "'");
     } else {
         // Rename all currently selected clips
-        auto& sm = SelectionManager::getInstance();
+        auto& sm = api_.selection();
         const auto& selected = sm.getSelectedClips();
         auto singleClip = sm.getSelectedClip();
 
@@ -1070,7 +1076,7 @@ bool Interpreter::executeAddFx(const Params& params) {
         device.deviceType = aliasIt->second.deviceType;
         device.isInstrument = (aliasIt->second.deviceType == DeviceType::Instrument);
 
-        auto deviceId = TrackManager::getInstance().addDeviceToTrack(ctx_.currentTrackId, device);
+        auto deviceId = api_.tracks().addDeviceToTrack(ctx_.currentTrackId, device);
         if (deviceId == INVALID_DEVICE_ID) {
             ctx_.setError("Failed to add internal FX '" + fxName + "' to track");
             return false;
@@ -1080,7 +1086,7 @@ bool Interpreter::executeAddFx(const Params& params) {
     }
 
     // --- External plugin lookup via KnownPluginList ---
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     if (!engine) {
         ctx_.setError("Audio engine not available");
         return false;
@@ -1144,14 +1150,14 @@ bool Interpreter::executeAddFx(const Params& params) {
 
     bestMatch = nullptr;  // no longer safe to dereference
 
-    auto deviceId = TrackManager::getInstance().addDeviceToTrack(ctx_.currentTrackId, device);
+    auto deviceId = api_.tracks().addDeviceToTrack(ctx_.currentTrackId, device);
     if (deviceId == INVALID_DEVICE_ID) {
         ctx_.setError("Failed to add FX '" + fxName + "' to track");
         return false;
     }
 
     // If the track was named with the alias form, rename it to the real plugin name.
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
     if (auto* trackInfo = tm.getTrack(ctx_.currentTrackId)) {
         if (trackInfo->name.equalsIgnoreCase(fxName) && !fxName.equalsIgnoreCase(matchedName))
             tm.setTrackName(ctx_.currentTrackId, matchedName);
@@ -1234,13 +1240,13 @@ bool Interpreter::executeSelect() {
     if (ctx_.inFilterContext) {
         // Select first matching track
         if (!ctx_.filteredTrackIds.empty()) {
-            SelectionManager::getInstance().selectTrack(ctx_.filteredTrackIds.front());
+            api_.selection().selectTrack(ctx_.filteredTrackIds.front());
             ctx_.addResult("Selected track");
         } else {
             ctx_.addResult("No tracks matched filter");
         }
     } else if (ctx_.currentTrackId >= 0) {
-        SelectionManager::getInstance().selectTrack(ctx_.currentTrackId);
+        api_.selection().selectTrack(ctx_.currentTrackId);
         ctx_.addResult("Selected track");
     } else {
         ctx_.setError("No track context for select");
@@ -1293,7 +1299,7 @@ bool Interpreter::executeSelectClips(Tokenizer& tok) {
 
     // Get tempo for bar/time conversions
     double bpm = 120.0;
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     if (engine)
         bpm = engine->getTempo();
     double secondsPerBar = 4.0 * 60.0 / bpm;
@@ -1326,7 +1332,7 @@ bool Interpreter::executeSelectClips(Tokenizer& tok) {
         return false;
     };
 
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api_.clips();
 
     // Resolve a clip field to either a numeric or string match
     auto matchClip = [&](const ClipInfo* clip) -> bool {
@@ -1386,7 +1392,7 @@ bool Interpreter::executeSelectClips(Tokenizer& tok) {
     } else if (ctx_.currentTrackId >= 0) {
         allMatched = matchOnTrack(ctx_.currentTrackId);
     } else {
-        auto& tm = TrackManager::getInstance();
+        auto& tm = api_.tracks();
         for (const auto& track : tm.getTracks()) {
             auto m = matchOnTrack(track.id);
             allMatched.insert(m.begin(), m.end());
@@ -1399,10 +1405,10 @@ bool Interpreter::executeSelectClips(Tokenizer& tok) {
     if (allMatched.empty()) {
         ctx_.addResult("No clips matched the criteria");
     } else if (allMatched.size() == 1) {
-        SelectionManager::getInstance().selectClip(*allMatched.begin());
+        api_.selection().selectClip(*allMatched.begin());
         ctx_.addResult("Selected 1 clip");
     } else {
-        SelectionManager::getInstance().selectClips(allMatched);
+        api_.selection().selectClips(allMatched);
         ctx_.addResult("Selected " + juce::String(static_cast<int>(allMatched.size())) + " clips");
     }
 
@@ -1422,7 +1428,7 @@ TrackType Interpreter::parseTrackType(const Params& params) {
 }
 
 int Interpreter::findTrackByName(const juce::String& name) const {
-    auto& tm = TrackManager::getInstance();
+    auto& tm = api_.tracks();
     for (const auto& track : tm.getTracks()) {
         if (track.name.equalsIgnoreCase(name))
             return track.id;
@@ -1433,7 +1439,7 @@ int Interpreter::findTrackByName(const juce::String& name) const {
 double Interpreter::barsToTime(double bar) const {
     // Convert 1-based bar number to seconds
     double bpm = 120.0;  // fallback
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     if (engine)
         bpm = engine->getTempo();
 
@@ -1444,7 +1450,7 @@ double Interpreter::barsToTime(double bar) const {
 double Interpreter::barsToBeats(double bars) const {
     // Use project time signature; never assume 4/4 here — the seconds round
     // trip is what got us into trouble under non-4/4 sigs.
-    int beatsPerBar = ProjectManager::getInstance().getCurrentProjectInfo().timeSignatureNumerator;
+    int beatsPerBar = api_.project().getCurrentProjectInfo().timeSignatureNumerator;
     if (beatsPerBar <= 0)
         beatsPerBar = 4;
     return bars * static_cast<double>(beatsPerBar);
@@ -1549,7 +1555,7 @@ ClipId Interpreter::getSelectedClipId() const {
         return ctx_.currentClipId;
 
     // Fall back to UI selection
-    auto& sm = SelectionManager::getInstance();
+    auto& sm = api_.selection();
     auto clipId = sm.getSelectedClip();
     if (clipId != INVALID_CLIP_ID)
         return clipId;
@@ -1561,7 +1567,7 @@ ClipId Interpreter::getSelectedClipId() const {
 
     // Fall back to the first clip on the current track
     if (ctx_.currentTrackId >= 0) {
-        auto& cm = ClipManager::getInstance();
+        auto& cm = api_.clips();
         auto clips = cm.getClipsOnTrack(ctx_.currentTrackId);
         if (!clips.empty())
             return clips.front();
@@ -1575,8 +1581,8 @@ ClipId Interpreter::getSelectedClipId() const {
 // ============================================================================
 
 bool Interpreter::ensureNoteSelection() {
-    auto& sm = SelectionManager::getInstance();
-    if (sm.getNoteSelection().isValid())
+    auto& sm = api_.selection();
+    if (sm.hasNoteSelection())
         return true;
 
     // No notes selected — try to auto-select all notes in the current clip
@@ -1584,7 +1590,7 @@ bool Interpreter::ensureNoteSelection() {
     if (clipId == INVALID_CLIP_ID)
         return false;
 
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api_.clips();
     auto* clip = cm.getClip(clipId);
     if (!clip || clip->midiNotes.empty())
         return false;
@@ -1595,7 +1601,7 @@ bool Interpreter::ensureNoteSelection() {
         allIndices.push_back(i);
 
     sm.selectNotes(clipId, allIndices);
-    return sm.getNoteSelection().isValid();
+    return sm.hasNoteSelection();
 }
 
 // ============================================================================
@@ -1651,7 +1657,7 @@ bool Interpreter::executeSelectNotes(Tokenizer& tok) {
         return false;
     }
 
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api_.clips();
     auto* clip = cm.getClip(clipId);
     if (!clip) {
         ctx_.setError("Selected clip not found");
@@ -1711,7 +1717,7 @@ bool Interpreter::executeSelectNotes(Tokenizer& tok) {
             matched.push_back(i);
     }
 
-    auto& sm = SelectionManager::getInstance();
+    auto& sm = api_.selection();
     if (matched.empty()) {
         sm.clearNoteSelection();
         ctx_.addResult("No notes matched the criteria");
@@ -1746,7 +1752,7 @@ bool Interpreter::executeAddNote(const Params& params) {
     double length = params.getFloat("length", 1.0);
     int velocity = params.getInt("velocity", 100);
 
-    UndoManager::getInstance().executeCommand(
+    api_.undo().executeCommand(
         std::make_unique<AddMidiNoteCommand>(clipId, beat, noteNumber, length, velocity));
 
     ctx_.addResult("Added note (pitch=" + juce::String(noteNumber) +
@@ -1803,7 +1809,7 @@ bool Interpreter::executeAddChord(const Params& params) {
         noteNames.add(juce::MidiMessage::getMidiNoteName(n, true, true, 4));
     }
 
-    UndoManager::getInstance().executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
+    api_.undo().executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
         clipId, std::move(notes),
         "Add " + juce::String(quality) + " chord at beat " + juce::String(beat, 2)));
 
@@ -1870,10 +1876,10 @@ bool Interpreter::executeAddArpeggio(const Params& params) {
     if (params.has("beats")) {
         fillBeats = beat + params.getFloat("beats");
     } else if (fill) {
-        auto* clip = ClipManager::getInstance().getClip(clipId);
+        auto* clip = api_.clips().getClip(clipId);
         if (clip) {
             double bpm = 120.0;
-            auto* engine = TrackManager::getInstance().getAudioEngine();
+            auto* engine = api_.tracks().getAudioEngine();
             if (engine)
                 bpm = engine->getTempo();
             fillBeats = clip->length * bpm / 60.0;
@@ -1901,7 +1907,7 @@ bool Interpreter::executeAddArpeggio(const Params& params) {
         idx++;
     }
 
-    UndoManager::getInstance().executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
+    api_.undo().executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
         clipId, std::move(notes),
         "Add " + juce::String(quality) + " arpeggio at beat " + juce::String(beat, 2)));
 
@@ -1916,13 +1922,14 @@ bool Interpreter::executeDeleteNotes() {
         return false;
     }
 
-    auto& sm = SelectionManager::getInstance();
-    const auto& noteSel = sm.getNoteSelection();
+    auto& sm = api_.selection();
+    auto noteSelClipId = sm.getNoteSelectionClipId();
+    const auto& noteSelIndices = sm.getNoteSelectionIndices();
 
-    UndoManager::getInstance().executeCommand(
-        std::make_unique<DeleteMultipleMidiNotesCommand>(noteSel.clipId, noteSel.noteIndices));
+    api_.undo().executeCommand(
+        std::make_unique<DeleteMultipleMidiNotesCommand>(noteSelClipId, noteSelIndices));
 
-    int count = static_cast<int>(noteSel.noteIndices.size());
+    int count = static_cast<int>(noteSelIndices.size());
     sm.clearNoteSelection();
     ctx_.addResult("Deleted " + juce::String(count) + " note(s)");
     return true;
@@ -1940,18 +1947,19 @@ bool Interpreter::executeTranspose(const Params& params) {
         return false;
     }
 
-    auto& sm = SelectionManager::getInstance();
-    const auto& noteSel = sm.getNoteSelection();
+    auto& sm = api_.selection();
+    auto noteSelClipId = sm.getNoteSelectionClipId();
+    const auto& noteSelIndices = sm.getNoteSelectionIndices();
 
-    auto& cm = ClipManager::getInstance();
-    auto* clip = cm.getClip(noteSel.clipId);
+    auto& cm = api_.clips();
+    auto* clip = cm.getClip(noteSelClipId);
     if (!clip) {
         ctx_.setError("Clip not found for notes.transpose");
         return false;
     }
 
     std::vector<MoveMultipleMidiNotesCommand::NoteMove> moves;
-    for (auto idx : noteSel.noteIndices) {
+    for (auto idx : noteSelIndices) {
         if (idx < clip->midiNotes.size()) {
             const auto& note = clip->midiNotes[idx];
             int newNote = juce::jlimit(0, 127, note.noteNumber + semitones);
@@ -1960,11 +1968,11 @@ bool Interpreter::executeTranspose(const Params& params) {
     }
 
     if (!moves.empty()) {
-        UndoManager::getInstance().executeCommand(
-            std::make_unique<MoveMultipleMidiNotesCommand>(noteSel.clipId, std::move(moves)));
+        api_.undo().executeCommand(
+            std::make_unique<MoveMultipleMidiNotesCommand>(noteSelClipId, std::move(moves)));
     }
 
-    ctx_.addResult("Transposed " + juce::String(static_cast<int>(noteSel.noteIndices.size())) +
+    ctx_.addResult("Transposed " + juce::String(static_cast<int>(noteSelIndices.size())) +
                    " note(s) by " + juce::String(semitones) + " semitones");
     return true;
 }
@@ -1986,18 +1994,19 @@ bool Interpreter::executeSetPitch(const Params& params) {
         return false;
     }
 
-    auto& sm = SelectionManager::getInstance();
-    const auto& noteSel = sm.getNoteSelection();
+    auto& sm = api_.selection();
+    auto noteSelClipId = sm.getNoteSelectionClipId();
+    const auto& noteSelIndices = sm.getNoteSelectionIndices();
 
-    auto& cm = ClipManager::getInstance();
-    auto* clip = cm.getClip(noteSel.clipId);
+    auto& cm = api_.clips();
+    auto* clip = cm.getClip(noteSelClipId);
     if (!clip) {
         ctx_.setError("Clip not found for notes.set_pitch");
         return false;
     }
 
     std::vector<MoveMultipleMidiNotesCommand::NoteMove> moves;
-    for (auto idx : noteSel.noteIndices) {
+    for (auto idx : noteSelIndices) {
         if (idx < clip->midiNotes.size()) {
             const auto& note = clip->midiNotes[idx];
             moves.push_back({idx, note.startBeat, targetPitch});
@@ -2005,12 +2014,12 @@ bool Interpreter::executeSetPitch(const Params& params) {
     }
 
     if (!moves.empty()) {
-        UndoManager::getInstance().executeCommand(
-            std::make_unique<MoveMultipleMidiNotesCommand>(noteSel.clipId, std::move(moves)));
+        api_.undo().executeCommand(
+            std::make_unique<MoveMultipleMidiNotesCommand>(noteSelClipId, std::move(moves)));
     }
 
     ctx_.addResult("Set pitch to " + juce::String(params.get("pitch")) + " on " +
-                   juce::String(static_cast<int>(noteSel.noteIndices.size())) + " note(s)");
+                   juce::String(static_cast<int>(noteSelIndices.size())) + " note(s)");
     return true;
 }
 
@@ -2023,18 +2032,19 @@ bool Interpreter::executeSetVelocity(const Params& params) {
         return false;
     }
 
-    auto& sm = SelectionManager::getInstance();
-    const auto& noteSel = sm.getNoteSelection();
+    auto& sm = api_.selection();
+    auto noteSelClipId = sm.getNoteSelectionClipId();
+    const auto& noteSelIndices = sm.getNoteSelectionIndices();
 
     std::vector<std::pair<size_t, int>> noteVelocities;
-    for (auto idx : noteSel.noteIndices)
+    for (auto idx : noteSelIndices)
         noteVelocities.emplace_back(idx, velocity);
 
-    UndoManager::getInstance().executeCommand(std::make_unique<SetMultipleNoteVelocitiesCommand>(
-        noteSel.clipId, std::move(noteVelocities)));
+    api_.undo().executeCommand(std::make_unique<SetMultipleNoteVelocitiesCommand>(
+        noteSelClipId, std::move(noteVelocities)));
 
     ctx_.addResult("Set velocity to " + juce::String(velocity) + " on " +
-                   juce::String(static_cast<int>(noteSel.noteIndices.size())) + " note(s)");
+                   juce::String(static_cast<int>(noteSelIndices.size())) + " note(s)");
     return true;
 }
 
@@ -2046,11 +2056,12 @@ bool Interpreter::executeQuantize(const Params& params) {
         return false;
     }
 
-    auto& sm = SelectionManager::getInstance();
-    const auto& noteSel = sm.getNoteSelection();
+    auto& sm = api_.selection();
+    auto noteSelClipId = sm.getNoteSelectionClipId();
+    const auto& noteSelIndices = sm.getNoteSelectionIndices();
 
-    UndoManager::getInstance().executeCommand(std::make_unique<QuantizeMidiNotesCommand>(
-        noteSel.clipId, noteSel.noteIndices, grid, QuantizeMode::StartOnly));
+    api_.undo().executeCommand(std::make_unique<QuantizeMidiNotesCommand>(
+        noteSelClipId, noteSelIndices, grid, QuantizeMode::StartOnly));
 
     juce::String gridName;
     if (std::abs(grid - 0.25) < 0.001)
@@ -2062,7 +2073,7 @@ bool Interpreter::executeQuantize(const Params& params) {
     else
         gridName = juce::String(grid, 2) + " beats";
 
-    ctx_.addResult("Quantized " + juce::String(static_cast<int>(noteSel.noteIndices.size())) +
+    ctx_.addResult("Quantized " + juce::String(static_cast<int>(noteSelIndices.size())) +
                    " note(s) to " + gridName);
     return true;
 }
@@ -2079,17 +2090,18 @@ bool Interpreter::executeResizeNotes(const Params& params) {
         return false;
     }
 
-    auto& sm = SelectionManager::getInstance();
-    const auto& noteSel = sm.getNoteSelection();
+    auto& sm = api_.selection();
+    auto noteSelClipId = sm.getNoteSelectionClipId();
+    const auto& noteSelIndices = sm.getNoteSelectionIndices();
 
     std::vector<std::pair<size_t, double>> noteLengths;
-    for (auto idx : noteSel.noteIndices)
+    for (auto idx : noteSelIndices)
         noteLengths.emplace_back(idx, length);
 
-    UndoManager::getInstance().executeCommand(
-        std::make_unique<ResizeMultipleMidiNotesCommand>(noteSel.clipId, std::move(noteLengths)));
+    api_.undo().executeCommand(
+        std::make_unique<ResizeMultipleMidiNotesCommand>(noteSelClipId, std::move(noteLengths)));
 
-    ctx_.addResult("Resized " + juce::String(static_cast<int>(noteSel.noteIndices.size())) +
+    ctx_.addResult("Resized " + juce::String(static_cast<int>(noteSelIndices.size())) +
                    " note(s) to " + juce::String(length, 2) + " beats");
     return true;
 }
@@ -2175,7 +2187,7 @@ bool Interpreter::executeGrooveNew(const Params& params) {
     }
 
     // Get TE engine
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     auto* teWrapper = dynamic_cast<TracktionEngineWrapper*>(engine);
     if (!teWrapper || !teWrapper->getEngine()) {
         ctx_.setError("Audio engine not available");
@@ -2221,9 +2233,9 @@ bool Interpreter::executeGrooveNew(const Params& params) {
     // Refresh clip inspector so new template appears in dropdown immediately
     auto clipId = getSelectedClipId();
     if (clipId != INVALID_CLIP_ID) {
-        auto* clip = ClipManager::getInstance().getClip(clipId);
+        auto* clip = api_.clips().getClip(clipId);
         if (clip && clip->type == ClipType::MIDI)
-            ClipManager::getInstance().setGrooveTemplate(clipId, clip->grooveTemplate);
+            api_.clips().setGrooveTemplate(clipId, clip->grooveTemplate);
     }
 
     return true;
@@ -2244,7 +2256,7 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
                 "groove.extract: no track in context. Use track(...).groove.extract(...)");
             return false;
         }
-        auto& cm = ClipManager::getInstance();
+        auto& cm = api_.clips();
         auto trackClips = cm.getClipsOnTrack(ctx_.currentTrackId);
         if (clipIndex < 0 || clipIndex >= static_cast<int>(trackClips.size())) {
             ctx_.setError("groove.extract: clip index " + juce::String(clipIndex) +
@@ -2261,7 +2273,7 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
         return false;
     }
 
-    const auto* clip = ClipManager::getInstance().getClip(clipId);
+    const auto* clip = api_.clips().getClip(clipId);
     if (!clip || clip->type != ClipType::Audio) {
         ctx_.setError("groove.extract: clip must be an audio clip");
         return false;
@@ -2321,7 +2333,7 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
     int patternLength = (numSteps >= stepsPerBar) ? stepsPerBar : numSteps;
 
     // Build GrooveTemplate
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     auto* teWrapper = dynamic_cast<TracktionEngineWrapper*>(engine);
     if (!teWrapper || !teWrapper->getEngine()) {
         ctx_.setError("Audio engine not available");
@@ -2356,9 +2368,9 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
     // Refresh clip inspector so new template appears in dropdown immediately
     auto selClipId = getSelectedClipId();
     if (selClipId != INVALID_CLIP_ID) {
-        auto* selClip = ClipManager::getInstance().getClip(selClipId);
+        auto* selClip = api_.clips().getClip(selClipId);
         if (selClip && selClip->type == ClipType::MIDI)
-            ClipManager::getInstance().setGrooveTemplate(selClipId, selClip->grooveTemplate);
+            api_.clips().setGrooveTemplate(selClipId, selClip->grooveTemplate);
     }
     return true;
 }
@@ -2375,20 +2387,20 @@ bool Interpreter::executeGrooveSet(const Params& params) {
         return false;
     }
 
-    const auto* clip = ClipManager::getInstance().getClip(clipId);
+    const auto* clip = api_.clips().getClip(clipId);
     if (!clip || clip->type != ClipType::MIDI) {
         ctx_.setError("groove.set: clip must be a MIDI clip");
         return false;
     }
 
     if (params.has("template")) {
-        UndoManager::getInstance().executeCommand(
+        api_.undo().executeCommand(
             std::make_unique<SetClipGrooveTemplateCommand>(clipId, juce::String(templateName)));
     }
 
     if (params.has("strength")) {
         float strength = static_cast<float>(params.getFloat("strength", 0.5));
-        UndoManager::getInstance().executeCommand(
+        api_.undo().executeCommand(
             std::make_unique<SetClipGrooveStrengthCommand>(clipId, strength));
     }
 
@@ -2400,7 +2412,7 @@ bool Interpreter::executeGrooveSet(const Params& params) {
 
 // groove.list() — show all available groove templates
 bool Interpreter::executeGrooveList() {
-    auto* engine = TrackManager::getInstance().getAudioEngine();
+    auto* engine = api_.tracks().getAudioEngine();
     auto* teWrapper = dynamic_cast<TracktionEngineWrapper*>(engine);
     if (!teWrapper || !teWrapper->getEngine()) {
         ctx_.setError("Audio engine not available");

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -1024,64 +1024,59 @@ bool Interpreter::executeAddFx(const Params& params) {
     if (fxName.startsWith("<") && fxName.endsWith(">"))
         fxName = fxName.substring(1, fxName.length() - 1);
 
-    // --- Internal plugin lookup (case-insensitive alias map) ---
+    // --- Internal plugin lookup ---
+    // Single canonical alias per plugin, matching the autocomplete dropdown
+    // (see AIChatConsoleContent::buildAliasList). Both lists feed off
+    // pluginNameToAlias(displayName) so what autocomplete suggests is exactly
+    // what the DSL accepts. To add a built-in here, also add the same display
+    // name to buildAliasList — never invent variants.
     struct InternalAlias {
+        juce::String displayName;
         juce::String pluginId;
         DeviceType deviceType;
     };
-    static const std::map<juce::String, InternalAlias> internalAliases = {
+    static const InternalAlias internalAliases[] = {
         // Effects
-        {"eq", {"eq", DeviceType::Effect}},
-        {"equaliser", {"eq", DeviceType::Effect}},
-        {"equalizer", {"eq", DeviceType::Effect}},
-        {"compressor", {"compressor", DeviceType::Effect}},
-        {"reverb", {"reverb", DeviceType::Effect}},
-        {"delay", {"delay", DeviceType::Effect}},
-        {"chorus", {"chorus", DeviceType::Effect}},
-        {"phaser", {"phaser", DeviceType::Effect}},
-        {"filter", {"lowpass", DeviceType::Effect}},
-        {"lowpass", {"lowpass", DeviceType::Effect}},
-        {"utility", {"utility", DeviceType::Effect}},
-        {"pitch shift", {"pitchshift", DeviceType::Effect}},
-        {"pitchshift", {"pitchshift", DeviceType::Effect}},
-        {"ir reverb", {"impulseresponse", DeviceType::Effect}},
-        {"impulse response", {"impulseresponse", DeviceType::Effect}},
+        {"Equaliser", "eq", DeviceType::Effect},
+        {"Compressor", "compressor", DeviceType::Effect},
+        {"Reverb", "reverb", DeviceType::Effect},
+        {"Delay", "delay", DeviceType::Effect},
+        {"Chorus", "chorus", DeviceType::Effect},
+        {"Phaser", "phaser", DeviceType::Effect},
+        {"Filter", "lowpass", DeviceType::Effect},
+        {"Utility", "utility", DeviceType::Effect},
+        {"Pitch Shift", "pitchshift", DeviceType::Effect},
+        {"IR Reverb", "impulseresponse", DeviceType::Effect},
+        {"Test Tone", "tone", DeviceType::Effect},
         // Instruments
-        {"4osc", {"4osc", DeviceType::Instrument}},
-        {"4osc synth", {"4osc", DeviceType::Instrument}},
-        {"fourosc", {"4osc", DeviceType::Instrument}},
-        {"sampler", {"magdasampler", DeviceType::Instrument}},
-        {"magda sampler", {"magdasampler", DeviceType::Instrument}},
-        {"drum grid", {"drumgrid", DeviceType::Instrument}},
-        {"drumgrid", {"drumgrid", DeviceType::Instrument}},
-        {"drum machine", {"drumgrid", DeviceType::Instrument}},
-        // MIDI devices
-        {"chord engine", {"midichordengine", DeviceType::MIDI}},
-        {"chord", {"midichordengine", DeviceType::MIDI}},
-        {"midichordengine", {"midichordengine", DeviceType::MIDI}},
-        {"arpeggiator", {"arpeggiator", DeviceType::MIDI}},
-        {"arp", {"arpeggiator", DeviceType::MIDI}},
-        // Tone generator
-        {"test tone", {"tone", DeviceType::Effect}},
-        {"tone", {"tone", DeviceType::Effect}},
+        {"4OSC Synth", "4osc", DeviceType::Instrument},
+        {"MAGDA Sampler", "magdasampler", DeviceType::Instrument},
+        {"Drum Grid", "drumgrid", DeviceType::Instrument},
     };
 
     auto lowerName = fxName.toLowerCase();
-    auto aliasIt = internalAliases.find(lowerName);
-    if (aliasIt != internalAliases.end()) {
+    const InternalAlias* internalMatch = nullptr;
+    for (const auto& entry : internalAliases) {
+        if (pluginNameToAlias(entry.displayName).equalsIgnoreCase(lowerName)) {
+            internalMatch = &entry;
+            break;
+        }
+    }
+
+    if (internalMatch != nullptr) {
         DeviceInfo device;
-        device.name = fxName;
-        device.pluginId = aliasIt->second.pluginId;
+        device.name = internalMatch->displayName;
+        device.pluginId = internalMatch->pluginId;
         device.format = PluginFormat::Internal;
-        device.deviceType = aliasIt->second.deviceType;
-        device.isInstrument = (aliasIt->second.deviceType == DeviceType::Instrument);
+        device.deviceType = internalMatch->deviceType;
+        device.isInstrument = (internalMatch->deviceType == DeviceType::Instrument);
 
         auto deviceId = api_.tracks().addDeviceToTrack(ctx_.currentTrackId, device);
         if (deviceId == INVALID_DEVICE_ID) {
             ctx_.setError("Failed to add internal FX '" + fxName + "' to track");
             return false;
         }
-        ctx_.addResult("Added internal FX '" + fxName + "'");
+        ctx_.addResult("Added internal FX '" + internalMatch->displayName + "'");
         return true;
     }
 
@@ -1472,8 +1467,8 @@ bool Interpreter::isContextEnabled() {
     return g_contextEnabled.load(std::memory_order_relaxed);
 }
 
-juce::String Interpreter::buildStateSnapshot() {
-    auto& tm = TrackManager::getInstance();
+juce::String Interpreter::buildStateSnapshot(MagdaApi& api) {
+    auto& tm = api.tracks();
 
     auto* root = new juce::DynamicObject();
 
@@ -1497,7 +1492,7 @@ juce::String Interpreter::buildStateSnapshot() {
     if (!g_contextEnabled.load(std::memory_order_relaxed))
         return juce::JSON::toString(juce::var(root), true);
 
-    auto& sm = SelectionManager::getInstance();
+    auto& sm = api.selection();
     auto selTrack = sm.getSelectedTrack();
     if (selTrack != INVALID_TRACK_ID) {
         // Find 1-based index for the selected track
@@ -1511,7 +1506,7 @@ juce::String Interpreter::buildStateSnapshot() {
     }
 
     // Selected clip context
-    auto& cm = ClipManager::getInstance();
+    auto& cm = api.clips();
     auto selClip = sm.getSelectedClip();
     if (selClip != INVALID_CLIP_ID) {
         auto* clip = cm.getClip(selClip);
@@ -2279,9 +2274,8 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
         return false;
     }
 
-    // Get cached transients
-    auto& thumbnailManager = AudioThumbnailManager::getInstance();
-    const auto* transients = thumbnailManager.getCachedTransients(clip->audioFilePath);
+    // Get cached transients via the api
+    const auto* transients = api_.clips().getCachedTransients(clip->audioFilePath);
     if (!transients || transients->isEmpty()) {
         ctx_.setError("groove.extract: no transients detected for this clip. "
                       "Enable warp or detect transients first.");

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -25,6 +25,7 @@
 #include "../daw/engine/AudioEngine.hpp"
 #include "../daw/engine/TracktionEngineWrapper.hpp"
 #include "../daw/project/ProjectManager.hpp"
+#include "internal_plugins.hpp"
 #include "music_helpers.hpp"
 
 namespace magda::dsl {
@@ -1025,58 +1026,22 @@ bool Interpreter::executeAddFx(const Params& params) {
         fxName = fxName.substring(1, fxName.length() - 1);
 
     // --- Internal plugin lookup ---
-    // Single canonical alias per plugin, matching the autocomplete dropdown
-    // (see AIChatConsoleContent::buildAliasList). Both lists feed off
-    // pluginNameToAlias(displayName) so what autocomplete suggests is exactly
-    // what the DSL accepts. To add a built-in here, also add the same display
-    // name to buildAliasList — never invent variants.
-    struct InternalAlias {
-        juce::String displayName;
-        juce::String pluginId;
-        DeviceType deviceType;
-    };
-    static const InternalAlias internalAliases[] = {
-        // Effects
-        {"Equaliser", "eq", DeviceType::Effect},
-        {"Compressor", "compressor", DeviceType::Effect},
-        {"Reverb", "reverb", DeviceType::Effect},
-        {"Delay", "delay", DeviceType::Effect},
-        {"Chorus", "chorus", DeviceType::Effect},
-        {"Phaser", "phaser", DeviceType::Effect},
-        {"Filter", "lowpass", DeviceType::Effect},
-        {"Utility", "utility", DeviceType::Effect},
-        {"Pitch Shift", "pitchshift", DeviceType::Effect},
-        {"IR Reverb", "impulseresponse", DeviceType::Effect},
-        {"Test Tone", "tone", DeviceType::Effect},
-        // Instruments
-        {"4OSC Synth", "4osc", DeviceType::Instrument},
-        {"MAGDA Sampler", "magdasampler", DeviceType::Instrument},
-        {"Drum Grid", "drumgrid", DeviceType::Instrument},
-    };
-
-    auto lowerName = fxName.toLowerCase();
-    const InternalAlias* internalMatch = nullptr;
-    for (const auto& entry : internalAliases) {
-        if (pluginNameToAlias(entry.displayName).equalsIgnoreCase(lowerName)) {
-            internalMatch = &entry;
-            break;
-        }
-    }
-
-    if (internalMatch != nullptr) {
+    // Built-in plugins are listed in internal_plugins.hpp — single canonical
+    // alias per plugin, matching the autocomplete dropdown.
+    if (const auto* match = lookupInternalPluginByAlias(fxName)) {
         DeviceInfo device;
-        device.name = internalMatch->displayName;
-        device.pluginId = internalMatch->pluginId;
+        device.name = match->displayName;
+        device.pluginId = match->pluginId;
         device.format = PluginFormat::Internal;
-        device.deviceType = internalMatch->deviceType;
-        device.isInstrument = (internalMatch->deviceType == DeviceType::Instrument);
+        device.deviceType = match->deviceType;
+        device.isInstrument = (match->deviceType == DeviceType::Instrument);
 
         auto deviceId = api_.tracks().addDeviceToTrack(ctx_.currentTrackId, device);
         if (deviceId == INVALID_DEVICE_ID) {
             ctx_.setError("Failed to add internal FX '" + fxName + "' to track");
             return false;
         }
-        ctx_.addResult("Added internal FX '" + internalMatch->displayName + "'");
+        ctx_.addResult("Added internal FX '" + match->displayName + "'");
         return true;
     }
 

--- a/magda/agents/dsl_interpreter.hpp
+++ b/magda/agents/dsl_interpreter.hpp
@@ -178,13 +178,8 @@ class Interpreter {
      * Includes the user's current track/clip selection by default so the LLM
      * can target it. Controlled by setContextEnabled(): when false, the
      * snapshot omits selection info so the LLM has no bias signal.
-     *
-     * NOTE: still reads MAGDA singletons internally — migration to
-     * MagdaApi is deferred to a follow-up PR (touches CommandAgent which
-     * doesn't yet hold a MagdaApi&). The instance Interpreter migrated
-     * in this PR doesn't depend on this static helper.
      */
-    static juce::String buildStateSnapshot();
+    static juce::String buildStateSnapshot(MagdaApi& api);
 
     /** Toggle whether the state snapshot exposes the UI selection to the LLM. */
     static void setContextEnabled(bool enabled);

--- a/magda/agents/dsl_interpreter.hpp
+++ b/magda/agents/dsl_interpreter.hpp
@@ -9,6 +9,10 @@
 #include "../daw/core/ClipTypes.hpp"
 #include "../daw/core/TrackTypes.hpp"
 
+namespace magda {
+class MagdaApi;
+}
+
 namespace magda::dsl {
 
 // ============================================================================
@@ -144,10 +148,10 @@ struct InterpreterContext {
 // ============================================================================
 class Interpreter {
   public:
-    Interpreter();
+    explicit Interpreter(MagdaApi& api);
 
     /**
-     * @brief Execute DSL code against TrackManager/ClipManager
+     * @brief Execute DSL code against the MagdaApi facade.
      * @return true on success, false on error (check getError())
      */
     bool execute(const char* dslCode);
@@ -174,6 +178,11 @@ class Interpreter {
      * Includes the user's current track/clip selection by default so the LLM
      * can target it. Controlled by setContextEnabled(): when false, the
      * snapshot omits selection info so the LLM has no bias signal.
+     *
+     * NOTE: still reads MAGDA singletons internally — migration to
+     * MagdaApi is deferred to a follow-up PR (touches CommandAgent which
+     * doesn't yet hold a MagdaApi&). The instance Interpreter migrated
+     * in this PR doesn't depend on this static helper.
      */
     static juce::String buildStateSnapshot();
 
@@ -233,6 +242,7 @@ class Interpreter {
     double barsToTime(double bar) const;
     double barsToBeats(double bars) const;
 
+    MagdaApi& api_;
     InterpreterContext ctx_;
 };
 

--- a/magda/agents/internal_plugins.hpp
+++ b/magda/agents/internal_plugins.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <vector>
+
+#include "../daw/core/DeviceInfo.hpp"
+#include "../daw/core/PluginAlias.hpp"
+
+namespace magda {
+
+/**
+ * @brief Single source of truth for MAGDA's built-in (non-scanned) plugins
+ *        addressable from agent code and the autocomplete dropdown.
+ *
+ * The canonical alias for each entry is `pluginNameToAlias(displayName)`,
+ * matching what the plugin browser / autocomplete UI suggests for external
+ * plugins. Don't add variants — when the user types an alias, autocomplete
+ * already steers them to the canonical form.
+ */
+struct InternalPluginInfo {
+    juce::String displayName;
+    juce::String pluginId;
+    DeviceType deviceType;
+};
+
+/// Built-in MAGDA + Tracktion plugins exposed to the agent layer + autocomplete.
+inline const std::vector<InternalPluginInfo>& getInternalPlugins() {
+    static const std::vector<InternalPluginInfo> kPlugins = {
+        // Effects
+        {"Equaliser", "eq", DeviceType::Effect},
+        {"Compressor", "compressor", DeviceType::Effect},
+        {"Reverb", "reverb", DeviceType::Effect},
+        {"Delay", "delay", DeviceType::Effect},
+        {"Chorus", "chorus", DeviceType::Effect},
+        {"Phaser", "phaser", DeviceType::Effect},
+        {"Filter", "lowpass", DeviceType::Effect},
+        {"Utility", "utility", DeviceType::Effect},
+        {"Pitch Shift", "pitchshift", DeviceType::Effect},
+        {"IR Reverb", "impulseresponse", DeviceType::Effect},
+        {"Test Tone", "tone", DeviceType::Effect},
+        // Instruments
+        {"4OSC Synth", "4osc", DeviceType::Instrument},
+        {"MAGDA Sampler", "magdasampler", DeviceType::Instrument},
+        {"Drum Grid", "drumgrid", DeviceType::Instrument},
+    };
+    return kPlugins;
+}
+
+/**
+ * @brief Look an internal plugin up by its canonical alias.
+ *
+ * The match is case-insensitive against `pluginNameToAlias(displayName)`
+ * for each registered plugin. Returns nullptr when no plugin matches —
+ * caller should fall through to the external KnownPluginList lookup.
+ */
+inline const InternalPluginInfo* lookupInternalPluginByAlias(const juce::String& alias) {
+    for (const auto& entry : getInternalPlugins()) {
+        if (pluginNameToAlias(entry.displayName).equalsIgnoreCase(alias))
+            return &entry;
+    }
+    return nullptr;
+}
+
+}  // namespace magda

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -267,6 +267,10 @@ set(DAW_CORE_SOURCES
     api/selection_api_live.cpp
     api/automation_api_live.cpp
     api/alias_api_live.cpp
+    api/track_api_live.cpp
+    api/clip_api_live.cpp
+    api/project_api_live.cpp
+    api/undo_api_live.cpp
     # Controller data model (issue #1050 -- Phase A)
     core/controllers/Controller.cpp
     core/controllers/Binding.cpp
@@ -572,10 +576,18 @@ set(DAW_HEADERS
     api/selection_api.hpp
     api/automation_api.hpp
     api/alias_api.hpp
+    api/track_api.hpp
+    api/clip_api.hpp
+    api/project_api.hpp
+    api/undo_api.hpp
     api/magda_api_live.hpp
     api/selection_api_live.hpp
     api/automation_api_live.hpp
     api/alias_api_live.hpp
+    api/track_api_live.hpp
+    api/clip_api_live.hpp
+    api/project_api_live.hpp
+    api/undo_api_live.hpp
     # Themes
     ui/themes/DarkTheme.hpp
     ui/themes/FontManager.hpp

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -263,6 +263,10 @@ set(DAW_CORE_SOURCES
     core/aliases/AutoAliasGenerator.cpp
     # Parameter alias system (PR 5 -- CuratedAliasLoader)
     core/aliases/CuratedAliasLoader.cpp
+    # MagdaApi -- programmatic facade for the agent layer (issue #1113)
+    api/selection_api_live.cpp
+    api/automation_api_live.cpp
+    api/alias_api_live.cpp
     # Controller data model (issue #1050 -- Phase A)
     core/controllers/Controller.cpp
     core/controllers/Binding.cpp
@@ -563,6 +567,15 @@ set(DAW_HEADERS
     interfaces/prompt_interface.hpp
     interfaces/track_interface.hpp
     interfaces/transport_interface.hpp
+    # MagdaApi (issue #1113)
+    api/magda_api.hpp
+    api/selection_api.hpp
+    api/automation_api.hpp
+    api/alias_api.hpp
+    api/magda_api_live.hpp
+    api/selection_api_live.hpp
+    api/automation_api_live.hpp
+    api/alias_api_live.hpp
     # Themes
     ui/themes/DarkTheme.hpp
     ui/themes/FontManager.hpp

--- a/magda/daw/api/alias_api.hpp
+++ b/magda/daw/api/alias_api.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace magda {
+
+class AliasRegistry;
+class ResolverRegistry;
+
+/**
+ * Abstract view onto the alias / resolver registries.
+ *
+ * PR1 just exposes the two registry references — TargetResolver consumes
+ * them by reference and isn't worth wrapping further at this stage. If
+ * a future MagdaApiPlugin needs different alias semantics we'll factor
+ * resolveSigil into this interface, but for now this preserves the
+ * existing call shape.
+ */
+class AliasApi {
+  public:
+    virtual ~AliasApi() = default;
+
+    virtual AliasRegistry& aliasRegistry() = 0;
+    virtual ResolverRegistry& resolverRegistry() = 0;
+};
+
+}  // namespace magda

--- a/magda/daw/api/alias_api_live.cpp
+++ b/magda/daw/api/alias_api_live.cpp
@@ -1,0 +1,16 @@
+#include "alias_api_live.hpp"
+
+#include "../core/aliases/AliasRegistry.hpp"
+#include "../core/aliases/ResolverRegistry.hpp"
+
+namespace magda {
+
+AliasRegistry& AliasApiLive::aliasRegistry() {
+    return AliasRegistry::getInstance();
+}
+
+ResolverRegistry& AliasApiLive::resolverRegistry() {
+    return ResolverRegistry::getInstance();
+}
+
+}  // namespace magda

--- a/magda/daw/api/alias_api_live.hpp
+++ b/magda/daw/api/alias_api_live.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "alias_api.hpp"
+
+namespace magda {
+
+/// Forwards every AliasApi call to the live alias / resolver registry singletons.
+class AliasApiLive : public AliasApi {
+  public:
+    AliasRegistry& aliasRegistry() override;
+    ResolverRegistry& resolverRegistry() override;
+};
+
+}  // namespace magda

--- a/magda/daw/api/automation_api.hpp
+++ b/magda/daw/api/automation_api.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "../core/AutomationInfo.hpp"
+#include "../core/AutomationTypes.hpp"
+#include "../core/TypeIds.hpp"
+
+namespace magda {
+
+/**
+ * Abstract view onto AutomationManager — the subset the agent layer uses.
+ *
+ * PR1 exposes what AutomationExecutor needs (lane lookup, lane creation,
+ * point writes, batch coalescing). Subsequent PRs grow the surface.
+ */
+class AutomationApi {
+  public:
+    virtual ~AutomationApi() = default;
+
+    virtual AutomationLaneId createLane(const AutomationTarget& target,
+                                        AutomationLaneType type) = 0;
+    virtual AutomationLaneId getLaneForTarget(const AutomationTarget& target) const = 0;
+
+    virtual AutomationLaneInfo* getLane(AutomationLaneId laneId) = 0;
+    virtual const AutomationLaneInfo* getLane(AutomationLaneId laneId) const = 0;
+
+    virtual AutomationPointId addPoint(AutomationLaneId laneId, double time, double value,
+                                       AutomationCurveType curveType) = 0;
+    virtual void clearLanePoints(AutomationLaneId laneId) = 0;
+
+    virtual void beginNotificationBatch() = 0;
+    virtual void endNotificationBatch() = 0;
+
+    /// RAII helper that brackets a write batch on this AutomationApi.
+    /// Replaces direct use of AutomationManager::BatchScope so callers
+    /// don't reach back to the singleton.
+    class BatchScope {
+      public:
+        explicit BatchScope(AutomationApi& api) : api_(api) {
+            api_.beginNotificationBatch();
+        }
+        ~BatchScope() {
+            api_.endNotificationBatch();
+        }
+        BatchScope(const BatchScope&) = delete;
+        BatchScope& operator=(const BatchScope&) = delete;
+
+      private:
+        AutomationApi& api_;
+    };
+};
+
+}  // namespace magda

--- a/magda/daw/api/automation_api_live.cpp
+++ b/magda/daw/api/automation_api_live.cpp
@@ -1,0 +1,41 @@
+#include "automation_api_live.hpp"
+
+#include "../core/AutomationManager.hpp"
+
+namespace magda {
+
+AutomationLaneId AutomationApiLive::createLane(const AutomationTarget& target,
+                                               AutomationLaneType type) {
+    return AutomationManager::getInstance().createLane(target, type);
+}
+
+AutomationLaneId AutomationApiLive::getLaneForTarget(const AutomationTarget& target) const {
+    return AutomationManager::getInstance().getLaneForTarget(target);
+}
+
+AutomationLaneInfo* AutomationApiLive::getLane(AutomationLaneId laneId) {
+    return AutomationManager::getInstance().getLane(laneId);
+}
+
+const AutomationLaneInfo* AutomationApiLive::getLane(AutomationLaneId laneId) const {
+    return AutomationManager::getInstance().getLane(laneId);
+}
+
+AutomationPointId AutomationApiLive::addPoint(AutomationLaneId laneId, double time, double value,
+                                              AutomationCurveType curveType) {
+    return AutomationManager::getInstance().addPoint(laneId, time, value, curveType);
+}
+
+void AutomationApiLive::clearLanePoints(AutomationLaneId laneId) {
+    AutomationManager::getInstance().clearLanePoints(laneId);
+}
+
+void AutomationApiLive::beginNotificationBatch() {
+    AutomationManager::getInstance().beginNotificationBatch();
+}
+
+void AutomationApiLive::endNotificationBatch() {
+    AutomationManager::getInstance().endNotificationBatch();
+}
+
+}  // namespace magda

--- a/magda/daw/api/automation_api_live.hpp
+++ b/magda/daw/api/automation_api_live.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "automation_api.hpp"
+
+namespace magda {
+
+/// Forwards every AutomationApi call to AutomationManager::getInstance().
+class AutomationApiLive : public AutomationApi {
+  public:
+    AutomationLaneId createLane(const AutomationTarget& target, AutomationLaneType type) override;
+    AutomationLaneId getLaneForTarget(const AutomationTarget& target) const override;
+
+    AutomationLaneInfo* getLane(AutomationLaneId laneId) override;
+    const AutomationLaneInfo* getLane(AutomationLaneId laneId) const override;
+
+    AutomationPointId addPoint(AutomationLaneId laneId, double time, double value,
+                               AutomationCurveType curveType) override;
+    void clearLanePoints(AutomationLaneId laneId) override;
+
+    void beginNotificationBatch() override;
+    void endNotificationBatch() override;
+};
+
+}  // namespace magda

--- a/magda/daw/api/clip_api.hpp
+++ b/magda/daw/api/clip_api.hpp
@@ -15,12 +15,14 @@ class ClipApi {
 
     virtual ClipInfo* getClip(ClipId clipId) = 0;
     virtual std::vector<ClipInfo> getArrangementClips() const = 0;
+    virtual std::vector<ClipId> getClipsOnTrack(TrackId trackId) const = 0;
 
     virtual ClipId createMidiClipBeats(TrackId trackId, double startBeats, double lengthBeats,
                                        ClipView view = ClipView::Arrangement) = 0;
     virtual void deleteClip(ClipId clipId) = 0;
 
     virtual void setClipName(ClipId clipId, const juce::String& name) = 0;
+    virtual void setGrooveTemplate(ClipId clipId, const juce::String& templateName) = 0;
 };
 
 }  // namespace magda

--- a/magda/daw/api/clip_api.hpp
+++ b/magda/daw/api/clip_api.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <vector>
+
+#include "../core/ClipInfo.hpp"
+#include "../core/ClipTypes.hpp"
+#include "../core/TypeIds.hpp"
+
+namespace magda {
+
+/// Abstract view onto ClipManager — what the agent layer reads and writes.
+class ClipApi {
+  public:
+    virtual ~ClipApi() = default;
+
+    virtual ClipInfo* getClip(ClipId clipId) = 0;
+    virtual std::vector<ClipInfo> getArrangementClips() const = 0;
+
+    virtual ClipId createMidiClipBeats(TrackId trackId, double startBeats, double lengthBeats,
+                                       ClipView view = ClipView::Arrangement) = 0;
+    virtual void deleteClip(ClipId clipId) = 0;
+
+    virtual void setClipName(ClipId clipId, const juce::String& name) = 0;
+};
+
+}  // namespace magda

--- a/magda/daw/api/clip_api.hpp
+++ b/magda/daw/api/clip_api.hpp
@@ -23,6 +23,15 @@ class ClipApi {
 
     virtual void setClipName(ClipId clipId, const juce::String& name) = 0;
     virtual void setGrooveTemplate(ClipId clipId, const juce::String& templateName) = 0;
+
+    /**
+     * @brief Cached transient times for an audio clip's source file.
+     *
+     * Looks the file path up in the audio thumbnail / transient cache.
+     * @return Array of transient times in seconds, or nullptr if no
+     *         transients have been detected for this file.
+     */
+    virtual const juce::Array<double>* getCachedTransients(const juce::String& filePath) const = 0;
 };
 
 }  // namespace magda

--- a/magda/daw/api/clip_api_live.cpp
+++ b/magda/daw/api/clip_api_live.cpp
@@ -12,6 +12,10 @@ std::vector<ClipInfo> ClipApiLive::getArrangementClips() const {
     return ClipManager::getInstance().getArrangementClips();
 }
 
+std::vector<ClipId> ClipApiLive::getClipsOnTrack(TrackId trackId) const {
+    return ClipManager::getInstance().getClipsOnTrack(trackId);
+}
+
 ClipId ClipApiLive::createMidiClipBeats(TrackId trackId, double startBeats, double lengthBeats,
                                         ClipView view) {
     return ClipManager::getInstance().createMidiClipBeats(trackId, startBeats, lengthBeats, view);
@@ -23,6 +27,10 @@ void ClipApiLive::deleteClip(ClipId clipId) {
 
 void ClipApiLive::setClipName(ClipId clipId, const juce::String& name) {
     ClipManager::getInstance().setClipName(clipId, name);
+}
+
+void ClipApiLive::setGrooveTemplate(ClipId clipId, const juce::String& templateName) {
+    ClipManager::getInstance().setGrooveTemplate(clipId, templateName);
 }
 
 }  // namespace magda

--- a/magda/daw/api/clip_api_live.cpp
+++ b/magda/daw/api/clip_api_live.cpp
@@ -1,5 +1,6 @@
 #include "clip_api_live.hpp"
 
+#include "../audio/AudioThumbnailManager.hpp"
 #include "../core/ClipManager.hpp"
 
 namespace magda {
@@ -31,6 +32,10 @@ void ClipApiLive::setClipName(ClipId clipId, const juce::String& name) {
 
 void ClipApiLive::setGrooveTemplate(ClipId clipId, const juce::String& templateName) {
     ClipManager::getInstance().setGrooveTemplate(clipId, templateName);
+}
+
+const juce::Array<double>* ClipApiLive::getCachedTransients(const juce::String& filePath) const {
+    return AudioThumbnailManager::getInstance().getCachedTransients(filePath);
 }
 
 }  // namespace magda

--- a/magda/daw/api/clip_api_live.cpp
+++ b/magda/daw/api/clip_api_live.cpp
@@ -1,0 +1,28 @@
+#include "clip_api_live.hpp"
+
+#include "../core/ClipManager.hpp"
+
+namespace magda {
+
+ClipInfo* ClipApiLive::getClip(ClipId clipId) {
+    return ClipManager::getInstance().getClip(clipId);
+}
+
+std::vector<ClipInfo> ClipApiLive::getArrangementClips() const {
+    return ClipManager::getInstance().getArrangementClips();
+}
+
+ClipId ClipApiLive::createMidiClipBeats(TrackId trackId, double startBeats, double lengthBeats,
+                                        ClipView view) {
+    return ClipManager::getInstance().createMidiClipBeats(trackId, startBeats, lengthBeats, view);
+}
+
+void ClipApiLive::deleteClip(ClipId clipId) {
+    ClipManager::getInstance().deleteClip(clipId);
+}
+
+void ClipApiLive::setClipName(ClipId clipId, const juce::String& name) {
+    ClipManager::getInstance().setClipName(clipId, name);
+}
+
+}  // namespace magda

--- a/magda/daw/api/clip_api_live.hpp
+++ b/magda/daw/api/clip_api_live.hpp
@@ -9,12 +9,14 @@ class ClipApiLive : public ClipApi {
   public:
     ClipInfo* getClip(ClipId clipId) override;
     std::vector<ClipInfo> getArrangementClips() const override;
+    std::vector<ClipId> getClipsOnTrack(TrackId trackId) const override;
 
     ClipId createMidiClipBeats(TrackId trackId, double startBeats, double lengthBeats,
                                ClipView view) override;
     void deleteClip(ClipId clipId) override;
 
     void setClipName(ClipId clipId, const juce::String& name) override;
+    void setGrooveTemplate(ClipId clipId, const juce::String& templateName) override;
 };
 
 }  // namespace magda

--- a/magda/daw/api/clip_api_live.hpp
+++ b/magda/daw/api/clip_api_live.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "clip_api.hpp"
+
+namespace magda {
+
+/// Forwards every ClipApi call to ClipManager::getInstance().
+class ClipApiLive : public ClipApi {
+  public:
+    ClipInfo* getClip(ClipId clipId) override;
+    std::vector<ClipInfo> getArrangementClips() const override;
+
+    ClipId createMidiClipBeats(TrackId trackId, double startBeats, double lengthBeats,
+                               ClipView view) override;
+    void deleteClip(ClipId clipId) override;
+
+    void setClipName(ClipId clipId, const juce::String& name) override;
+};
+
+}  // namespace magda

--- a/magda/daw/api/clip_api_live.hpp
+++ b/magda/daw/api/clip_api_live.hpp
@@ -17,6 +17,8 @@ class ClipApiLive : public ClipApi {
 
     void setClipName(ClipId clipId, const juce::String& name) override;
     void setGrooveTemplate(ClipId clipId, const juce::String& templateName) override;
+
+    const juce::Array<double>* getCachedTransients(const juce::String& filePath) const override;
 };
 
 }  // namespace magda

--- a/magda/daw/api/magda_api.hpp
+++ b/magda/daw/api/magda_api.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+namespace magda {
+
+class SelectionApi;
+class AutomationApi;
+class AliasApi;
+
+/**
+ * Programmatic facade for MAGDA's DAW state.
+ *
+ * Composed of focused sub-interfaces, one per DAW concept. Consumers
+ * (the agent layer today; Lua / controllers / CLI in future) take a
+ * MagdaApi& and route every state read or mutation through these
+ * accessors instead of reaching into singletons.
+ *
+ * The live implementation (MagdaApiLive) forwards every call to the
+ * existing TrackManager/ClipManager/etc. singletons — this is the
+ * abstraction boundary, not a behavioural change.
+ *
+ * PR1 wires only the three sub-interfaces AutomationExecutor needs.
+ * Track/Clip/Project/Undo land in subsequent PRs as the matching
+ * call sites migrate.
+ */
+class MagdaApi {
+  public:
+    virtual ~MagdaApi() = default;
+
+    virtual SelectionApi& selection() = 0;
+    virtual AutomationApi& automation() = 0;
+    virtual AliasApi& aliases() = 0;
+};
+
+}  // namespace magda

--- a/magda/daw/api/magda_api.hpp
+++ b/magda/daw/api/magda_api.hpp
@@ -5,6 +5,10 @@ namespace magda {
 class SelectionApi;
 class AutomationApi;
 class AliasApi;
+class TrackApi;
+class ClipApi;
+class ProjectApi;
+class UndoApi;
 
 /**
  * Programmatic facade for MAGDA's DAW state.
@@ -17,10 +21,6 @@ class AliasApi;
  * The live implementation (MagdaApiLive) forwards every call to the
  * existing TrackManager/ClipManager/etc. singletons — this is the
  * abstraction boundary, not a behavioural change.
- *
- * PR1 wires only the three sub-interfaces AutomationExecutor needs.
- * Track/Clip/Project/Undo land in subsequent PRs as the matching
- * call sites migrate.
  */
 class MagdaApi {
   public:
@@ -29,6 +29,10 @@ class MagdaApi {
     virtual SelectionApi& selection() = 0;
     virtual AutomationApi& automation() = 0;
     virtual AliasApi& aliases() = 0;
+    virtual TrackApi& tracks() = 0;
+    virtual ClipApi& clips() = 0;
+    virtual ProjectApi& project() = 0;
+    virtual UndoApi& undo() = 0;
 };
 
 }  // namespace magda

--- a/magda/daw/api/magda_api_live.hpp
+++ b/magda/daw/api/magda_api_live.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "alias_api_live.hpp"
+#include "automation_api_live.hpp"
+#include "magda_api.hpp"
+#include "selection_api_live.hpp"
+
+namespace magda {
+
+/// Live implementation: every sub-interface forwards to the matching MAGDA singleton.
+class MagdaApiLive : public MagdaApi {
+  public:
+    SelectionApi& selection() override {
+        return selection_;
+    }
+    AutomationApi& automation() override {
+        return automation_;
+    }
+    AliasApi& aliases() override {
+        return aliases_;
+    }
+
+  private:
+    SelectionApiLive selection_;
+    AutomationApiLive automation_;
+    AliasApiLive aliases_;
+};
+
+}  // namespace magda

--- a/magda/daw/api/magda_api_live.hpp
+++ b/magda/daw/api/magda_api_live.hpp
@@ -2,8 +2,12 @@
 
 #include "alias_api_live.hpp"
 #include "automation_api_live.hpp"
+#include "clip_api_live.hpp"
 #include "magda_api.hpp"
+#include "project_api_live.hpp"
 #include "selection_api_live.hpp"
+#include "track_api_live.hpp"
+#include "undo_api_live.hpp"
 
 namespace magda {
 
@@ -19,11 +23,27 @@ class MagdaApiLive : public MagdaApi {
     AliasApi& aliases() override {
         return aliases_;
     }
+    TrackApi& tracks() override {
+        return tracks_;
+    }
+    ClipApi& clips() override {
+        return clips_;
+    }
+    ProjectApi& project() override {
+        return project_;
+    }
+    UndoApi& undo() override {
+        return undo_;
+    }
 
   private:
     SelectionApiLive selection_;
     AutomationApiLive automation_;
     AliasApiLive aliases_;
+    TrackApiLive tracks_;
+    ClipApiLive clips_;
+    ProjectApiLive project_;
+    UndoApiLive undo_;
 };
 
 }  // namespace magda

--- a/magda/daw/api/project_api.hpp
+++ b/magda/daw/api/project_api.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "../project/ProjectInfo.hpp"
+
+namespace magda {
+
+/// Abstract view onto ProjectManager — read-only project info today.
+class ProjectApi {
+  public:
+    virtual ~ProjectApi() = default;
+
+    virtual const ProjectInfo& getCurrentProjectInfo() const = 0;
+};
+
+}  // namespace magda

--- a/magda/daw/api/project_api_live.cpp
+++ b/magda/daw/api/project_api_live.cpp
@@ -1,0 +1,11 @@
+#include "project_api_live.hpp"
+
+#include "../project/ProjectManager.hpp"
+
+namespace magda {
+
+const ProjectInfo& ProjectApiLive::getCurrentProjectInfo() const {
+    return ProjectManager::getInstance().getCurrentProjectInfo();
+}
+
+}  // namespace magda

--- a/magda/daw/api/project_api_live.hpp
+++ b/magda/daw/api/project_api_live.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "project_api.hpp"
+
+namespace magda {
+
+/// Forwards every ProjectApi call to ProjectManager::getInstance().
+class ProjectApiLive : public ProjectApi {
+  public:
+    const ProjectInfo& getCurrentProjectInfo() const override;
+};
+
+}  // namespace magda

--- a/magda/daw/api/selection_api.hpp
+++ b/magda/daw/api/selection_api.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstddef>
 #include <unordered_set>
+#include <vector>
 
 #include "../core/ClipTypes.hpp"
 #include "../core/TypeIds.hpp"
@@ -15,18 +17,22 @@ namespace magda {
  * the SelectionManager singleton directly. Kept lightweight on purpose:
  * the abstract header pulls in only TypeIds, not the full singleton +
  * UI-listener machinery from SelectionManager.hpp. Concrete struct types
- * (e.g. AutomationLaneSelection) are deliberately not exposed here —
- * their members are surfaced as primitive accessors instead.
+ * (NoteSelection, AutomationLaneSelection, ...) are deliberately not
+ * exposed here — their members are surfaced as primitive accessors
+ * instead.
  *
- * PR1 added the read paths AutomationExecutor needs; PR2 adds the
- * multi-selection read/write surface CompactExecutor uses.
+ * PR1 added automation-selection reads; PR2 added multi-track / clip
+ * reads + writes; PR3 adds note-selection + single-target setters used
+ * by the DSL interpreter.
  */
 class SelectionApi {
   public:
     virtual ~SelectionApi() = default;
 
-    // Reads
+    // ---- Reads ----------------------------------------------------------
+
     virtual TrackId getSelectedTrack() const = 0;
+    virtual ClipId getSelectedClip() const = 0;
     virtual const std::unordered_set<ClipId>& getSelectedClips() const = 0;
 
     /**
@@ -37,9 +43,22 @@ class SelectionApi {
      */
     virtual AutomationLaneId getSelectedAutomationLaneId() const = 0;
 
-    // Writes
+    /// True iff there is a valid note selection (clip set, indices non-empty).
+    virtual bool hasNoteSelection() const = 0;
+    /// Clip the selected notes belong to, or INVALID_CLIP_ID if none.
+    virtual ClipId getNoteSelectionClipId() const = 0;
+    /// Indices of the selected notes within their clip's MIDI sequence.
+    /// Empty if there is no note selection.
+    virtual const std::vector<size_t>& getNoteSelectionIndices() const = 0;
+
+    // ---- Writes ---------------------------------------------------------
+
+    virtual void selectTrack(TrackId trackId) = 0;
     virtual void selectTracks(const std::unordered_set<TrackId>& trackIds) = 0;
+    virtual void selectClip(ClipId clipId) = 0;
     virtual void selectClips(const std::unordered_set<ClipId>& clipIds) = 0;
+    virtual void selectNotes(ClipId clipId, const std::vector<size_t>& noteIndices) = 0;
+    virtual void clearNoteSelection() = 0;
 };
 
 }  // namespace magda

--- a/magda/daw/api/selection_api.hpp
+++ b/magda/daw/api/selection_api.hpp
@@ -1,11 +1,15 @@
 #pragma once
 
+#include <unordered_set>
+
+#include "../core/ClipTypes.hpp"
 #include "../core/TypeIds.hpp"
 
 namespace magda {
 
 /**
- * Abstract view onto SelectionManager — the subset the agent layer reads.
+ * Abstract view onto SelectionManager — the subset the agent layer reads
+ * and writes.
  *
  * Lives behind MagdaApi so agents/scripting/CLI consumers don't depend on
  * the SelectionManager singleton directly. Kept lightweight on purpose:
@@ -14,14 +18,16 @@ namespace magda {
  * (e.g. AutomationLaneSelection) are deliberately not exposed here —
  * their members are surfaced as primitive accessors instead.
  *
- * PR1 only exposes what AutomationExecutor needs; subsequent PRs grow
- * the surface as more call sites migrate.
+ * PR1 added the read paths AutomationExecutor needs; PR2 adds the
+ * multi-selection read/write surface CompactExecutor uses.
  */
 class SelectionApi {
   public:
     virtual ~SelectionApi() = default;
 
+    // Reads
     virtual TrackId getSelectedTrack() const = 0;
+    virtual const std::unordered_set<ClipId>& getSelectedClips() const = 0;
 
     /**
      * @return The lane id of the currently selected automation lane, or
@@ -30,6 +36,10 @@ class SelectionApi {
      *         nothing is selected).
      */
     virtual AutomationLaneId getSelectedAutomationLaneId() const = 0;
+
+    // Writes
+    virtual void selectTracks(const std::unordered_set<TrackId>& trackIds) = 0;
+    virtual void selectClips(const std::unordered_set<ClipId>& clipIds) = 0;
 };
 
 }  // namespace magda

--- a/magda/daw/api/selection_api.hpp
+++ b/magda/daw/api/selection_api.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "../core/TypeIds.hpp"
+
+namespace magda {
+
+/**
+ * Abstract view onto SelectionManager — the subset the agent layer reads.
+ *
+ * Lives behind MagdaApi so agents/scripting/CLI consumers don't depend on
+ * the SelectionManager singleton directly. Kept lightweight on purpose:
+ * the abstract header pulls in only TypeIds, not the full singleton +
+ * UI-listener machinery from SelectionManager.hpp. Concrete struct types
+ * (e.g. AutomationLaneSelection) are deliberately not exposed here —
+ * their members are surfaced as primitive accessors instead.
+ *
+ * PR1 only exposes what AutomationExecutor needs; subsequent PRs grow
+ * the surface as more call sites migrate.
+ */
+class SelectionApi {
+  public:
+    virtual ~SelectionApi() = default;
+
+    virtual TrackId getSelectedTrack() const = 0;
+
+    /**
+     * @return The lane id of the currently selected automation lane, or
+     *         INVALID_AUTOMATION_LANE_ID if no automation lane is
+     *         selected (e.g. another selection type is active, or
+     *         nothing is selected).
+     */
+    virtual AutomationLaneId getSelectedAutomationLaneId() const = 0;
+};
+
+}  // namespace magda

--- a/magda/daw/api/selection_api_live.cpp
+++ b/magda/daw/api/selection_api_live.cpp
@@ -4,8 +4,14 @@
 
 namespace magda {
 
+// ---- Reads ----------------------------------------------------------
+
 TrackId SelectionApiLive::getSelectedTrack() const {
     return SelectionManager::getInstance().getSelectedTrack();
+}
+
+ClipId SelectionApiLive::getSelectedClip() const {
+    return SelectionManager::getInstance().getSelectedClip();
 }
 
 const std::unordered_set<ClipId>& SelectionApiLive::getSelectedClips() const {
@@ -19,12 +25,42 @@ AutomationLaneId SelectionApiLive::getSelectedAutomationLaneId() const {
     return sel.getAutomationLaneSelection().laneId;
 }
 
+bool SelectionApiLive::hasNoteSelection() const {
+    return SelectionManager::getInstance().hasNoteSelection();
+}
+
+ClipId SelectionApiLive::getNoteSelectionClipId() const {
+    return SelectionManager::getInstance().getNoteSelection().clipId;
+}
+
+const std::vector<size_t>& SelectionApiLive::getNoteSelectionIndices() const {
+    return SelectionManager::getInstance().getNoteSelection().noteIndices;
+}
+
+// ---- Writes ---------------------------------------------------------
+
+void SelectionApiLive::selectTrack(TrackId trackId) {
+    SelectionManager::getInstance().selectTrack(trackId);
+}
+
 void SelectionApiLive::selectTracks(const std::unordered_set<TrackId>& trackIds) {
     SelectionManager::getInstance().selectTracks(trackIds);
 }
 
+void SelectionApiLive::selectClip(ClipId clipId) {
+    SelectionManager::getInstance().selectClip(clipId);
+}
+
 void SelectionApiLive::selectClips(const std::unordered_set<ClipId>& clipIds) {
     SelectionManager::getInstance().selectClips(clipIds);
+}
+
+void SelectionApiLive::selectNotes(ClipId clipId, const std::vector<size_t>& noteIndices) {
+    SelectionManager::getInstance().selectNotes(clipId, noteIndices);
+}
+
+void SelectionApiLive::clearNoteSelection() {
+    SelectionManager::getInstance().clearNoteSelection();
 }
 
 }  // namespace magda

--- a/magda/daw/api/selection_api_live.cpp
+++ b/magda/daw/api/selection_api_live.cpp
@@ -8,11 +8,23 @@ TrackId SelectionApiLive::getSelectedTrack() const {
     return SelectionManager::getInstance().getSelectedTrack();
 }
 
+const std::unordered_set<ClipId>& SelectionApiLive::getSelectedClips() const {
+    return SelectionManager::getInstance().getSelectedClips();
+}
+
 AutomationLaneId SelectionApiLive::getSelectedAutomationLaneId() const {
     auto& sel = SelectionManager::getInstance();
     if (!sel.hasAutomationLaneSelection())
         return INVALID_AUTOMATION_LANE_ID;
     return sel.getAutomationLaneSelection().laneId;
+}
+
+void SelectionApiLive::selectTracks(const std::unordered_set<TrackId>& trackIds) {
+    SelectionManager::getInstance().selectTracks(trackIds);
+}
+
+void SelectionApiLive::selectClips(const std::unordered_set<ClipId>& clipIds) {
+    SelectionManager::getInstance().selectClips(clipIds);
 }
 
 }  // namespace magda

--- a/magda/daw/api/selection_api_live.cpp
+++ b/magda/daw/api/selection_api_live.cpp
@@ -1,0 +1,18 @@
+#include "selection_api_live.hpp"
+
+#include "../core/SelectionManager.hpp"
+
+namespace magda {
+
+TrackId SelectionApiLive::getSelectedTrack() const {
+    return SelectionManager::getInstance().getSelectedTrack();
+}
+
+AutomationLaneId SelectionApiLive::getSelectedAutomationLaneId() const {
+    auto& sel = SelectionManager::getInstance();
+    if (!sel.hasAutomationLaneSelection())
+        return INVALID_AUTOMATION_LANE_ID;
+    return sel.getAutomationLaneSelection().laneId;
+}
+
+}  // namespace magda

--- a/magda/daw/api/selection_api_live.hpp
+++ b/magda/daw/api/selection_api_live.hpp
@@ -8,7 +8,12 @@ namespace magda {
 class SelectionApiLive : public SelectionApi {
   public:
     TrackId getSelectedTrack() const override;
+    const std::unordered_set<ClipId>& getSelectedClips() const override;
+
     AutomationLaneId getSelectedAutomationLaneId() const override;
+
+    void selectTracks(const std::unordered_set<TrackId>& trackIds) override;
+    void selectClips(const std::unordered_set<ClipId>& clipIds) override;
 };
 
 }  // namespace magda

--- a/magda/daw/api/selection_api_live.hpp
+++ b/magda/daw/api/selection_api_live.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "selection_api.hpp"
+
+namespace magda {
+
+/// Forwards every SelectionApi call to SelectionManager::getInstance().
+class SelectionApiLive : public SelectionApi {
+  public:
+    TrackId getSelectedTrack() const override;
+    AutomationLaneId getSelectedAutomationLaneId() const override;
+};
+
+}  // namespace magda

--- a/magda/daw/api/selection_api_live.hpp
+++ b/magda/daw/api/selection_api_live.hpp
@@ -8,12 +8,21 @@ namespace magda {
 class SelectionApiLive : public SelectionApi {
   public:
     TrackId getSelectedTrack() const override;
+    ClipId getSelectedClip() const override;
     const std::unordered_set<ClipId>& getSelectedClips() const override;
 
     AutomationLaneId getSelectedAutomationLaneId() const override;
 
+    bool hasNoteSelection() const override;
+    ClipId getNoteSelectionClipId() const override;
+    const std::vector<size_t>& getNoteSelectionIndices() const override;
+
+    void selectTrack(TrackId trackId) override;
     void selectTracks(const std::unordered_set<TrackId>& trackIds) override;
+    void selectClip(ClipId clipId) override;
     void selectClips(const std::unordered_set<ClipId>& clipIds) override;
+    void selectNotes(ClipId clipId, const std::vector<size_t>& noteIndices) override;
+    void clearNoteSelection() override;
 };
 
 }  // namespace magda

--- a/magda/daw/api/track_api.hpp
+++ b/magda/daw/api/track_api.hpp
@@ -29,6 +29,8 @@ class TrackApi {
 
     virtual int getNumTracks() const = 0;
     virtual const std::vector<TrackInfo>& getTracks() const = 0;
+    virtual TrackInfo* getTrack(TrackId trackId) = 0;
+    virtual const TrackInfo* getTrack(TrackId trackId) const = 0;
 
     virtual void setTrackName(TrackId trackId, const juce::String& name) = 0;
     virtual void setTrackVolume(TrackId trackId, float volume, bool fromAutomation = false) = 0;

--- a/magda/daw/api/track_api.hpp
+++ b/magda/daw/api/track_api.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <vector>
+
+#include "../core/DeviceInfo.hpp"
+#include "../core/TrackInfo.hpp"
+#include "../core/TrackTypes.hpp"
+#include "../core/TypeIds.hpp"
+
+namespace magda {
+
+class AudioEngine;
+
+/**
+ * Abstract view onto TrackManager — the track-level surface the agent
+ * layer needs.
+ *
+ * NOTE: getAudioEngine() returns te::Engine*-equivalent and leaks the
+ * engine into the API surface. Acceptable for now (executors need it
+ * for groove/bpm + plugin scanning), but flagged: a future
+ * MagdaApiPlugin variant probably won't return a real engine here.
+ */
+class TrackApi {
+  public:
+    virtual ~TrackApi() = default;
+
+    virtual TrackId createTrack(const juce::String& name, TrackType type) = 0;
+    virtual void deleteTrack(TrackId trackId) = 0;
+
+    virtual int getNumTracks() const = 0;
+    virtual const std::vector<TrackInfo>& getTracks() const = 0;
+
+    virtual void setTrackName(TrackId trackId, const juce::String& name) = 0;
+    virtual void setTrackVolume(TrackId trackId, float volume, bool fromAutomation = false) = 0;
+    virtual void setTrackPan(TrackId trackId, float pan, bool fromAutomation = false) = 0;
+    virtual void setTrackMuted(TrackId trackId, bool muted) = 0;
+    virtual void setTrackSoloed(TrackId trackId, bool soloed) = 0;
+
+    virtual DeviceId addDeviceToTrack(TrackId trackId, const DeviceInfo& device) = 0;
+
+    virtual AudioEngine* getAudioEngine() const = 0;
+};
+
+}  // namespace magda

--- a/magda/daw/api/track_api_live.cpp
+++ b/magda/daw/api/track_api_live.cpp
@@ -20,6 +20,14 @@ const std::vector<TrackInfo>& TrackApiLive::getTracks() const {
     return TrackManager::getInstance().getTracks();
 }
 
+TrackInfo* TrackApiLive::getTrack(TrackId trackId) {
+    return TrackManager::getInstance().getTrack(trackId);
+}
+
+const TrackInfo* TrackApiLive::getTrack(TrackId trackId) const {
+    return TrackManager::getInstance().getTrack(trackId);
+}
+
 void TrackApiLive::setTrackName(TrackId trackId, const juce::String& name) {
     TrackManager::getInstance().setTrackName(trackId, name);
 }

--- a/magda/daw/api/track_api_live.cpp
+++ b/magda/daw/api/track_api_live.cpp
@@ -1,0 +1,51 @@
+#include "track_api_live.hpp"
+
+#include "../core/TrackManager.hpp"
+
+namespace magda {
+
+TrackId TrackApiLive::createTrack(const juce::String& name, TrackType type) {
+    return TrackManager::getInstance().createTrack(name, type);
+}
+
+void TrackApiLive::deleteTrack(TrackId trackId) {
+    TrackManager::getInstance().deleteTrack(trackId);
+}
+
+int TrackApiLive::getNumTracks() const {
+    return TrackManager::getInstance().getNumTracks();
+}
+
+const std::vector<TrackInfo>& TrackApiLive::getTracks() const {
+    return TrackManager::getInstance().getTracks();
+}
+
+void TrackApiLive::setTrackName(TrackId trackId, const juce::String& name) {
+    TrackManager::getInstance().setTrackName(trackId, name);
+}
+
+void TrackApiLive::setTrackVolume(TrackId trackId, float volume, bool fromAutomation) {
+    TrackManager::getInstance().setTrackVolume(trackId, volume, fromAutomation);
+}
+
+void TrackApiLive::setTrackPan(TrackId trackId, float pan, bool fromAutomation) {
+    TrackManager::getInstance().setTrackPan(trackId, pan, fromAutomation);
+}
+
+void TrackApiLive::setTrackMuted(TrackId trackId, bool muted) {
+    TrackManager::getInstance().setTrackMuted(trackId, muted);
+}
+
+void TrackApiLive::setTrackSoloed(TrackId trackId, bool soloed) {
+    TrackManager::getInstance().setTrackSoloed(trackId, soloed);
+}
+
+DeviceId TrackApiLive::addDeviceToTrack(TrackId trackId, const DeviceInfo& device) {
+    return TrackManager::getInstance().addDeviceToTrack(trackId, device);
+}
+
+AudioEngine* TrackApiLive::getAudioEngine() const {
+    return TrackManager::getInstance().getAudioEngine();
+}
+
+}  // namespace magda

--- a/magda/daw/api/track_api_live.hpp
+++ b/magda/daw/api/track_api_live.hpp
@@ -12,6 +12,8 @@ class TrackApiLive : public TrackApi {
 
     int getNumTracks() const override;
     const std::vector<TrackInfo>& getTracks() const override;
+    TrackInfo* getTrack(TrackId trackId) override;
+    const TrackInfo* getTrack(TrackId trackId) const override;
 
     void setTrackName(TrackId trackId, const juce::String& name) override;
     void setTrackVolume(TrackId trackId, float volume, bool fromAutomation) override;

--- a/magda/daw/api/track_api_live.hpp
+++ b/magda/daw/api/track_api_live.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "track_api.hpp"
+
+namespace magda {
+
+/// Forwards every TrackApi call to TrackManager::getInstance().
+class TrackApiLive : public TrackApi {
+  public:
+    TrackId createTrack(const juce::String& name, TrackType type) override;
+    void deleteTrack(TrackId trackId) override;
+
+    int getNumTracks() const override;
+    const std::vector<TrackInfo>& getTracks() const override;
+
+    void setTrackName(TrackId trackId, const juce::String& name) override;
+    void setTrackVolume(TrackId trackId, float volume, bool fromAutomation) override;
+    void setTrackPan(TrackId trackId, float pan, bool fromAutomation) override;
+    void setTrackMuted(TrackId trackId, bool muted) override;
+    void setTrackSoloed(TrackId trackId, bool soloed) override;
+
+    DeviceId addDeviceToTrack(TrackId trackId, const DeviceInfo& device) override;
+
+    AudioEngine* getAudioEngine() const override;
+};
+
+}  // namespace magda

--- a/magda/daw/api/undo_api.hpp
+++ b/magda/daw/api/undo_api.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <memory>
+
+namespace magda {
+
+class UndoableCommand;
+
+/// Abstract view onto UndoManager — agent code only enqueues commands.
+class UndoApi {
+  public:
+    virtual ~UndoApi() = default;
+
+    virtual void executeCommand(std::unique_ptr<UndoableCommand> command) = 0;
+};
+
+}  // namespace magda

--- a/magda/daw/api/undo_api_live.cpp
+++ b/magda/daw/api/undo_api_live.cpp
@@ -1,0 +1,11 @@
+#include "undo_api_live.hpp"
+
+#include "../core/UndoManager.hpp"
+
+namespace magda {
+
+void UndoApiLive::executeCommand(std::unique_ptr<UndoableCommand> command) {
+    UndoManager::getInstance().executeCommand(std::move(command));
+}
+
+}  // namespace magda

--- a/magda/daw/api/undo_api_live.hpp
+++ b/magda/daw/api/undo_api_live.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "undo_api.hpp"
+
+namespace magda {
+
+/// Forwards every UndoApi call to UndoManager::getInstance().
+class UndoApiLive : public UndoApi {
+  public:
+    void executeCommand(std::unique_ptr<UndoableCommand> command) override;
+};
+
+}  // namespace magda

--- a/magda/daw/audio/AutomationPlaybackEngine.cpp
+++ b/magda/daw/audio/AutomationPlaybackEngine.cpp
@@ -35,9 +35,8 @@ AutomationPlaybackEngine::AutomationPlaybackEngine(AudioBridge& bridge, te::Edit
         auto* lane = AutomationManager::getInstance().getLane(laneId);
         if (!lane)
             return;
-        DBG("[AutoPb] touchSuppressionListener lane=" << laneId
-                                                       << " suppressed=" << (int)suppressed
-                                                       << " bypass=" << (int)lane->bypass);
+        DBG("[AutoPb] touchSuppressionListener lane=" << laneId << " suppressed=" << (int)suppressed
+                                                      << " bypass=" << (int)lane->bypass);
         if (suppressed) {
             clearLane(*lane);
             if (auto* param = resolveParameter(lane->target))

--- a/magda/daw/audio/ClipSynchronizer.cpp
+++ b/magda/daw/audio/ClipSynchronizer.cpp
@@ -293,8 +293,8 @@ void ClipSynchronizer::clipPropertyChanged(ClipId clipId) {
                     }
 
                 }  // if (teClip)
-            }      // else (already synced)
-        }          // if (sceneIndex >= 0)
+            }  // else (already synced)
+        }  // if (sceneIndex >= 0)
         return;
     }
 

--- a/magda/daw/audio/DeviceProcessor.hpp
+++ b/magda/daw/audio/DeviceProcessor.hpp
@@ -187,7 +187,8 @@ class ToneGeneratorProcessor : public DeviceProcessor {
     int getParameterCount() const override;
     ParameterInfo getParameterInfo(int index) const override;
 
-    // Single-parameter sync from DeviceInfo (values in real units: TE osc enum / bandLimit / Hz / dB)
+    // Single-parameter sync from DeviceInfo (values in real units: TE osc enum / bandLimit / Hz /
+    // dB)
     void setParameterByIndex(int paramIndex, float value);
 
     // Initialize with default values - call after processor is fully set up

--- a/magda/daw/core/AutomationManager.cpp
+++ b/magda/daw/core/AutomationManager.cpp
@@ -397,12 +397,11 @@ std::optional<double> AutomationManager::getTouchBaseline(const AutomationTarget
 }
 
 void AutomationManager::clearTouchBaseline(const AutomationTarget& target) {
-    touchBaselines_.erase(
-        std::remove_if(touchBaselines_.begin(), touchBaselines_.end(),
-                       [&](const std::pair<AutomationTarget, double>& e) {
-                           return e.first == target;
-                       }),
-        touchBaselines_.end());
+    touchBaselines_.erase(std::remove_if(touchBaselines_.begin(), touchBaselines_.end(),
+                                         [&](const std::pair<AutomationTarget, double>& e) {
+                                             return e.first == target;
+                                         }),
+                          touchBaselines_.end());
 }
 
 AutomationVisualState AutomationManager::getVisualState(const AutomationTarget& target) const {

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -403,12 +403,18 @@ class UIPage : public juce::Component {
 
     static double scaleValueForId(int id) {
         switch (id) {
-            case 2: return 1.0;
-            case 3: return 1.25;
-            case 4: return 1.5;
-            case 5: return 1.75;
-            case 6: return 2.0;
-            default: return 0.0;  // Auto
+            case 2:
+                return 1.0;
+            case 3:
+                return 1.25;
+            case 4:
+                return 1.5;
+            case 5:
+                return 1.75;
+            case 6:
+                return 2.0;
+            default:
+                return 0.0;  // Auto
         }
     }
 

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -485,7 +485,7 @@ void AIChatConsoleContent::RequestThread::run() {
                 // Execute DSL from command agent
                 int commandClipId = -1;
                 if (!dsl.empty()) {
-                    magda::dsl::Interpreter interpreter;
+                    magda::dsl::Interpreter interpreter(*safeThis->magdaApi_);
                     if (interpreter.execute(dsl.c_str())) {
                         auto results = interpreter.getResults().toStdString();
                         response = results.empty() ? "OK" : results;
@@ -984,7 +984,7 @@ void AIChatConsoleContent::sendMessage(const juce::String& text) {
         auto dslCode = text.trimStart().substring(5).trim();
         appendToChat(juce::String::charToString(0x25CF) + " " + text);
 
-        magda::dsl::Interpreter interpreter;
+        magda::dsl::Interpreter interpreter(*magdaApi_);
         bool success = interpreter.execute(dslCode.toRawUTF8());
 
         if (success) {
@@ -1382,7 +1382,7 @@ void AIChatConsoleContent::executeDSL() {
     }
 
     // Execute
-    magda::dsl::Interpreter interpreter;
+    magda::dsl::Interpreter interpreter(*magdaApi_);
     bool success = interpreter.execute(code.toRawUTF8());
 
     if (success) {

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -13,6 +13,7 @@
 #include "../../../../agents/controller_profile_agent.hpp"
 #include "../../../../agents/daw_agent.hpp"
 #include "../../../../agents/dsl_interpreter.hpp"
+#include "../../../../agents/internal_plugins.hpp"
 #include "../../../../agents/llama_model_manager.hpp"
 #include "../../../../agents/llm_presets.hpp"
 #include "../../../../agents/music_agent.hpp"
@@ -1562,24 +1563,13 @@ void AIChatConsoleContent::mouseUp(const juce::MouseEvent& event) {
 void AIChatConsoleContent::buildAliasList() {
     allAliases_.clear();
 
-    // Internal plugins
-    auto addInternal = [this](const juce::String& name) {
-        allAliases_.push_back({PluginBrowserInfo::generateAlias(name), name});
-    };
-    addInternal("Test Tone");
-    addInternal("4OSC Synth");
-    addInternal("Equaliser");
-    addInternal("Compressor");
-    addInternal("Reverb");
-    addInternal("Delay");
-    addInternal("Chorus");
-    addInternal("Phaser");
-    addInternal("Filter");
-    addInternal("Pitch Shift");
-    addInternal("IR Reverb");
-    addInternal("Utility");
-    addInternal(juce::String(audio::MagdaSamplerPlugin::getPluginName()));
-    addInternal(juce::String(audio::DrumGridPlugin::getPluginName()));
+    // Internal plugins — single source of truth in internal_plugins.hpp,
+    // shared with the DSL interpreter and CompactExecutor so the autocomplete
+    // dropdown lists exactly the aliases the agent layer accepts.
+    for (const auto& entry : magda::getInternalPlugins()) {
+        allAliases_.push_back(
+            {PluginBrowserInfo::generateAlias(entry.displayName), entry.displayName});
+    }
 
     // External plugins from KnownPluginList
     if (auto* engine = dynamic_cast<magda::TracktionEngineWrapper*>(

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -891,7 +891,7 @@ AIChatConsoleContent::AIChatConsoleContent() {
     agent_ = std::make_unique<magda::DAWAgent>(*magdaApi_);  // legacy DSL REPL
     agent_->start();
     routerAgent_ = std::make_unique<magda::RouterAgent>();
-    commandAgent_ = std::make_unique<magda::CommandAgent>();
+    commandAgent_ = std::make_unique<magda::CommandAgent>(*magdaApi_);
     musicAgent_ = std::make_unique<magda::MusicAgent>();
     automationAgent_ = std::make_unique<magda::AutomationAgent>(*magdaApi_);
     controllerAgent_ = std::make_unique<magda::ControllerProfileAgent>();

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -502,7 +502,7 @@ void AIChatConsoleContent::RequestThread::run() {
                             response += "\n";
                         response += musicDesc;
                     }
-                    magda::CompactExecutor executor;
+                    magda::CompactExecutor executor(*safeThis->magdaApi_);
                     // Hand the command agent's freshly-created clip (if any)
                     // explicitly to the music executor. Otherwise it will
                     // auto-create a new clip — we never want it to silently
@@ -888,7 +888,7 @@ AIChatConsoleContent::AIChatConsoleContent() {
     magdaApi_ = std::make_unique<magda::MagdaApiLive>();
 
     // Create agents
-    agent_ = std::make_unique<magda::DAWAgent>();  // legacy DSL REPL
+    agent_ = std::make_unique<magda::DAWAgent>(*magdaApi_);  // legacy DSL REPL
     agent_->start();
     routerAgent_ = std::make_unique<magda::RouterAgent>();
     commandAgent_ = std::make_unique<magda::CommandAgent>();

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -17,6 +17,7 @@
 #include "../../../../agents/llm_presets.hpp"
 #include "../../../../agents/music_agent.hpp"
 #include "../../../../agents/router_agent.hpp"
+#include "../../../api/magda_api_live.hpp"
 #include "../../../core/ClipManager.hpp"
 #include "../../../core/Config.hpp"
 #include "../../../core/SelectionManager.hpp"
@@ -541,7 +542,7 @@ void AIChatConsoleContent::RequestThread::run() {
 
                 // Execute IR from automation agent
                 if (!autoIR.empty()) {
-                    magda::AutomationExecutor autoExec;
+                    magda::AutomationExecutor autoExec(*safeThis->magdaApi_);
                     if (autoExec.execute(autoIR)) {
                         auto results = autoExec.getResults().toStdString();
                         if (!response.empty())
@@ -881,13 +882,18 @@ AIChatConsoleContent::AIChatConsoleContent() {
     // Register for config changes (e.g. preset changed in settings dialog)
     magda::Config::getInstance().addListener(this);
 
+    // Create the live MagdaApi facade once. Agents take a MagdaApi& and
+    // route DAW reads/writes through it instead of the singletons; the
+    // facade outlives every agent because it's a member of this panel.
+    magdaApi_ = std::make_unique<magda::MagdaApiLive>();
+
     // Create agents
     agent_ = std::make_unique<magda::DAWAgent>();  // legacy DSL REPL
     agent_->start();
     routerAgent_ = std::make_unique<magda::RouterAgent>();
     commandAgent_ = std::make_unique<magda::CommandAgent>();
     musicAgent_ = std::make_unique<magda::MusicAgent>();
-    automationAgent_ = std::make_unique<magda::AutomationAgent>();
+    automationAgent_ = std::make_unique<magda::AutomationAgent>(*magdaApi_);
     controllerAgent_ = std::make_unique<magda::ControllerProfileAgent>();
 }
 

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
@@ -20,6 +20,7 @@ class AutomationAgent;
 class CommandAgent;
 class ControllerProfileAgent;
 class DAWAgent;
+class MagdaApiLive;
 class MusicAgent;
 class RouterAgent;
 class SvgButton;
@@ -111,6 +112,11 @@ class AIChatConsoleContent : public PanelContent,
     // KeyListener — intercept arrow keys for autocomplete navigation
     using juce::Component::keyPressed;  // unhide 1-param overload
     bool keyPressed(const juce::KeyPress& key, juce::Component* originatingComponent) override;
+
+    // Live MagdaApi backing the agent layer. Owned by this panel so it
+    // outlives every agent we hand it to. PR1 wires only AutomationAgent;
+    // the other agents will take it in subsequent migration PRs.
+    std::unique_ptr<magda::MagdaApiLive> magdaApi_;
 
     std::unique_ptr<magda::DAWAgent> agent_;  // kept for legacy DSL REPL
     std::unique_ptr<magda::RouterAgent> routerAgent_;

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
@@ -114,8 +114,11 @@ class AIChatConsoleContent : public PanelContent,
     bool keyPressed(const juce::KeyPress& key, juce::Component* originatingComponent) override;
 
     // Live MagdaApi backing the agent layer. Owned by this panel so it
-    // outlives every agent we hand it to. PR1 wires only AutomationAgent;
-    // the other agents will take it in subsequent migration PRs.
+    // outlives every agent we hand it to. Every agent the chat creates
+    // (DAWAgent, CommandAgent, MusicAgent, AutomationAgent, ...) is
+    // constructed with this api as its DAW backend; the inline executors
+    // used in the request-thread lambda do the same via
+    // *safeThis->magdaApi_.
     std::unique_ptr<magda::MagdaApiLive> magdaApi_;
 
     std::unique_ptr<magda::DAWAgent> agent_;  // kept for legacy DSL REPL

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -191,13 +191,13 @@ void MainWindow::MainComponent::getCommandInfo(juce::CommandID commandID,
             result.setInfo("Increase UI Scale", "Make the UI larger", "View", 0);
             result.addDefaultKeypress('=', juce::ModifierKeys::commandModifier);
             result.addDefaultKeypress('+', juce::ModifierKeys::commandModifier |
-                                              juce::ModifierKeys::shiftModifier);
+                                               juce::ModifierKeys::shiftModifier);
             break;
         case uiScaleDown:
             result.setInfo("Decrease UI Scale", "Make the UI smaller", "View", 0);
             result.addDefaultKeypress('-', juce::ModifierKeys::commandModifier);
             result.addDefaultKeypress('_', juce::ModifierKeys::commandModifier |
-                                              juce::ModifierKeys::shiftModifier);
+                                               juce::ModifierKeys::shiftModifier);
             break;
 
         // Help

--- a/tests/test_automation_agent.cpp
+++ b/tests/test_automation_agent.cpp
@@ -4,6 +4,7 @@
 #include "magda/agents/automation_agent.hpp"
 #include "magda/agents/automation_executor.hpp"
 #include "magda/agents/automation_parser.hpp"
+#include "magda/daw/api/magda_api_live.hpp"
 #include "magda/daw/core/AutomationManager.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/SelectionManager.hpp"
@@ -161,7 +162,8 @@ TEST_CASE("AutomationExecutor: target=volume creates TrackVolume lane on selecte
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     auto ir = parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=volume");
     REQUIRE(exec.execute(ir));
 
@@ -191,7 +193,8 @@ TEST_CASE("AutomationExecutor: target=pan creates a separate TrackPan lane",
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE(exec.execute(parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=volume")));
     REQUIRE(exec.execute(parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=pan")));
 
@@ -217,7 +220,8 @@ TEST_CASE("AutomationExecutor: target=volume is a singleton (two runs = one lane
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE(exec.execute(parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=volume")));
     REQUIRE(exec.execute(parseOrFail(parser, "AUTO line start=4 end=8 from=1 to=0 target=volume")));
 
@@ -232,7 +236,8 @@ TEST_CASE("AutomationExecutor: target=selected falls back to TrackVolume with no
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE(
         exec.execute(parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=selected")));
 
@@ -247,7 +252,8 @@ TEST_CASE("AutomationExecutor: target=volume with no track selected fails",
     resetState();
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE_FALSE(
         exec.execute(parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=volume")));
     REQUIRE(exec.getError().isNotEmpty());
@@ -263,7 +269,8 @@ TEST_CASE("AutomationExecutor: target=laneId:N writes to that exact lane",
     auto laneId = AutomationManager::getInstance().createLane(t, AutomationLaneType::Absolute);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     auto ir = parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=laneId:" +
                                       juce::String(laneId));
     REQUIRE(exec.execute(ir));
@@ -280,7 +287,8 @@ TEST_CASE("AutomationExecutor: target=laneId:INVALID fails", "[automation][execu
     resetState();
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE_FALSE(exec.execute(
         parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=laneId:9999")));
     REQUIRE(exec.getError().isNotEmpty());
@@ -297,7 +305,8 @@ TEST_CASE("AutomationExecutor: line writes exactly 2 endpoints with correct valu
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE(
         exec.execute(parseOrFail(parser, "AUTO line start=0 end=8 from=0.2 to=0.8 target=volume")));
 
@@ -321,7 +330,8 @@ TEST_CASE("AutomationExecutor: sin writes many points bounded by [min,max]",
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE(exec.execute(
         parseOrFail(parser, "AUTO sin start=0 end=8 min=0.1 max=0.9 cycles=2 target=volume")));
 
@@ -343,7 +353,8 @@ TEST_CASE("AutomationExecutor: freeform writes the exact provided points",
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE(exec.execute(
         parseOrFail(parser, "AUTO freeform points=(0,0.1)(2,0.5)(4,0.9) target=volume")));
 
@@ -369,7 +380,8 @@ TEST_CASE("AutomationExecutor: clear empties the lane", "[automation][executor][
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE(exec.execute(
         parseOrFail(parser, "AUTO sin start=0 end=8 min=0 max=1 cycles=2 target=volume")));
 
@@ -389,7 +401,8 @@ TEST_CASE("AutomationExecutor: values are clamped into [0, 1]", "[automation][ex
     SelectionManager::getInstance().selectTrack(trackId);
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
     REQUIRE(exec.execute(
         parseOrFail(parser, "AUTO freeform points=(0,-0.5)(2,1.5)(4,0.5) target=volume")));
 

--- a/tests/test_automation_alias_targets.cpp
+++ b/tests/test_automation_alias_targets.cpp
@@ -2,6 +2,7 @@
 
 #include "magda/agents/automation_executor.hpp"
 #include "magda/agents/automation_parser.hpp"
+#include "magda/daw/api/magda_api_live.hpp"
 #include "magda/daw/core/AutomationManager.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/SelectionManager.hpp"
@@ -106,7 +107,8 @@ TEST_CASE("AutomationExecutor: unresolvable @alias target fails gracefully",
     resetState();
 
     AutomationParser parser;
-    AutomationExecutor exec;
+    MagdaApiLive api;
+    AutomationExecutor exec(api);
 
     // No registry entry for @ghost.param, no chain context — resolution fails.
     auto ir = parseOrFail(parser, "AUTO sin start=0 end=4 min=0 max=1 target=@ghost.param");

--- a/tests/test_compact_executor_context.cpp
+++ b/tests/test_compact_executor_context.cpp
@@ -2,6 +2,7 @@
 
 #include "magda/agents/compact_executor.hpp"
 #include "magda/agents/compact_parser.hpp"
+#include "magda/daw/api/magda_api_live.hpp"
 #include "magda/daw/core/AutomationManager.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/SelectionManager.hpp"
@@ -56,7 +57,8 @@ TEST_CASE("CompactExecutor: bare MUTE mutes the selected track", "[compact][cont
     SelectionManager::getInstance().selectTrack(bass);
 
     CompactParser parser;
-    CompactExecutor exec;
+    MagdaApiLive api;
+    CompactExecutor exec(api);
     REQUIRE(exec.execute(parseOrFail(parser, "MUTE")));
 
     auto& tm = TrackManager::getInstance();
@@ -71,7 +73,8 @@ TEST_CASE("CompactExecutor: bare SOLO solos the selected track", "[compact][cont
     SelectionManager::getInstance().selectTrack(lead);
 
     CompactParser parser;
-    CompactExecutor exec;
+    MagdaApiLive api;
+    CompactExecutor exec(api);
     REQUIRE(exec.execute(parseOrFail(parser, "SOLO")));
 
     auto& tm = TrackManager::getInstance();
@@ -85,7 +88,8 @@ TEST_CASE("CompactExecutor: bare MUTE with no selection fails with a helpful err
     makeTrack("Anything");
 
     CompactParser parser;
-    CompactExecutor exec;
+    MagdaApiLive api;
+    CompactExecutor exec(api);
     REQUIRE_FALSE(exec.execute(parseOrFail(parser, "MUTE")));
     REQUIRE(exec.getError().isNotEmpty());
 }
@@ -101,7 +105,8 @@ TEST_CASE("CompactExecutor: MUTE 2 mutes the second track by 1-based index", "[c
     auto t3 = makeTrack("C");
 
     CompactParser parser;
-    CompactExecutor exec;
+    MagdaApiLive api;
+    CompactExecutor exec(api);
     REQUIRE(exec.execute(parseOrFail(parser, "MUTE 2")));
 
     auto& tm = TrackManager::getInstance();
@@ -122,7 +127,8 @@ TEST_CASE("CompactExecutor: MUTE <name> mutes every track with matching name",
     auto bass = makeTrack("Bass");
 
     CompactParser parser;
-    CompactExecutor exec;
+    MagdaApiLive api;
+    CompactExecutor exec(api);
     REQUIRE(exec.execute(parseOrFail(parser, "MUTE Drums")));
 
     auto& tm = TrackManager::getInstance();
@@ -143,7 +149,8 @@ TEST_CASE("CompactExecutor: SELECT TRACKS advances currentTrackId for follow-up 
     auto bass = makeTrack("Bass");
 
     CompactParser parser;
-    CompactExecutor exec;
+    MagdaApiLive api;
+    CompactExecutor exec(api);
 
     // After SELECT, bare MUTE mutes every selected track via the
     // SELECT-driven bulk path (no implicit single-track resolution needed).
@@ -161,7 +168,8 @@ TEST_CASE("CompactExecutor: SELECT with empty match does not crash follow-up MUT
     makeTrack("Bass");
 
     CompactParser parser;
-    CompactExecutor exec;
+    MagdaApiLive api;
+    CompactExecutor exec(api);
     // Predicate matches nothing. SELECT succeeds with an empty set; the
     // follow-up bare MUTE has no implicit track context and fails. The
     // batch executor still returns true when at least one instruction
@@ -184,7 +192,8 @@ TEST_CASE("CompactExecutor: bare SET targets the selected track", "[compact][con
     SelectionManager::getInstance().selectTrack(bass);
 
     CompactParser parser;
-    CompactExecutor exec;
+    MagdaApiLive api;
+    CompactExecutor exec(api);
     REQUIRE(exec.execute(parseOrFail(parser, "SET mute=true")));
 
     auto& tm = TrackManager::getInstance();

--- a/tests/test_dsl_add_arpeggio.cpp
+++ b/tests/test_dsl_add_arpeggio.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "magda/agents/dsl_interpreter.hpp"
+#include "magda/daw/api/magda_api_live.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/SelectionManager.hpp"
 #include "magda/daw/core/TrackManager.hpp"
@@ -50,7 +51,8 @@ static std::vector<std::pair<int, double>> getNotesByBeat(const ClipInfo* clip) 
 
 TEST_CASE("add_arpeggio - up pattern (default)", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -77,7 +79,8 @@ TEST_CASE("add_arpeggio - up pattern (default)", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - down pattern", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute(
         "track(name=\"Test\", type=\"midi\")"
@@ -101,7 +104,8 @@ TEST_CASE("add_arpeggio - down pattern", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - updown pattern", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // C min7 = C4(60), Eb4(63), G4(67), Bb4(70)
     // updown skips endpoints: C Eb G Bb G Eb → 6 notes
@@ -130,7 +134,8 @@ TEST_CASE("add_arpeggio - updown pattern", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - first inversion", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // C major first inversion: E4(64), G4(67), C5(72)
     REQUIRE(interp.execute(
@@ -155,7 +160,8 @@ TEST_CASE("add_arpeggio - first inversion", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - second inversion down", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // C major second inversion: G4(67), C5(72), E5(76) — down: E5, C5, G4
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
@@ -180,7 +186,8 @@ TEST_CASE("add_arpeggio - second inversion down", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - custom note_length", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute(
         "track(name=\"Test\", type=\"midi\")"
@@ -199,7 +206,8 @@ TEST_CASE("add_arpeggio - custom note_length", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - staccato (note_length < step)", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute(
         "track(name=\"Test\", type=\"midi\")"
@@ -226,7 +234,8 @@ TEST_CASE("add_arpeggio - staccato (note_length < step)", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - beat offset and velocity", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute(
         "track(name=\"Test\", type=\"midi\")"
@@ -257,7 +266,8 @@ TEST_CASE("add_arpeggio - beat offset and velocity", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - fill covers entire clip", "[dsl][arpeggio][fill]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // 2-bar clip at 120 BPM = 8 beats, step=0.5 → 16 notes cycling C E G
     REQUIRE(
@@ -283,7 +293,8 @@ TEST_CASE("add_arpeggio - fill covers entire clip", "[dsl][arpeggio][fill]") {
 
 TEST_CASE("add_arpeggio - fill with updown pattern", "[dsl][arpeggio][fill]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // C major updown = C E G E (4 notes per cycle), 1-bar clip = 4 beats, step=0.5 → 8 notes
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
@@ -305,7 +316,8 @@ TEST_CASE("add_arpeggio - fill with updown pattern", "[dsl][arpeggio][fill]") {
 
 TEST_CASE("add_arpeggio - fill with down pattern", "[dsl][arpeggio][fill]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // 1-bar clip = 4 beats, step=0.5, down: G E C → 8 notes cycling
     REQUIRE(interp.execute(
@@ -330,7 +342,8 @@ TEST_CASE("add_arpeggio - fill with down pattern", "[dsl][arpeggio][fill]") {
 
 TEST_CASE("add_arpeggio - beats parameter for exact duration", "[dsl][arpeggio][fill]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // Fill only 2 beats of a 4-bar clip — step=0.5 → 4 notes
     REQUIRE(
@@ -350,7 +363,8 @@ TEST_CASE("add_arpeggio - beats parameter for exact duration", "[dsl][arpeggio][
 
 TEST_CASE("add_arpeggio - chord progression with beats", "[dsl][arpeggio][progression]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // E minor for 4 beats, then C major for 4 beats in a 2-bar clip
     REQUIRE(
@@ -385,7 +399,8 @@ TEST_CASE("add_arpeggio - chord progression with beats", "[dsl][arpeggio][progre
 
 TEST_CASE("add_arpeggio - four-chord progression", "[dsl][arpeggio][progression]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // Em - C - G - D, each for 4 beats in a 4-bar clip
     REQUIRE(
@@ -428,7 +443,8 @@ TEST_CASE("add_arpeggio - four-chord progression", "[dsl][arpeggio][progression]
 
 TEST_CASE("add_arpeggio - 9th chord", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // C dom9 = C4(60), E4(64), G4(67), Bb4(70), D5(74) — 5 notes
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
@@ -450,7 +466,8 @@ TEST_CASE("add_arpeggio - 9th chord", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - min7b5 (half diminished)", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // B half-dim = B3(59), D4(62), F4(65), A4(69)
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
@@ -475,7 +492,8 @@ TEST_CASE("add_arpeggio - min7b5 (half diminished)", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - undo removes all notes", "[dsl][arpeggio][undo]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -495,7 +513,8 @@ TEST_CASE("add_arpeggio - undo removes all notes", "[dsl][arpeggio][undo]") {
 
 TEST_CASE("add_arpeggio - undo progression removes last chord only", "[dsl][arpeggio][undo]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(
         interp.execute("track(name=\"Test\", type=\"midi\")"
@@ -529,7 +548,8 @@ TEST_CASE("add_arpeggio - undo progression removes last chord only", "[dsl][arpe
 
 TEST_CASE("add_arpeggio - missing root", "[dsl][arpeggio][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
                                  ".clip.new(bar=1, length_bars=4)"
@@ -539,7 +559,8 @@ TEST_CASE("add_arpeggio - missing root", "[dsl][arpeggio][error]") {
 
 TEST_CASE("add_arpeggio - missing quality", "[dsl][arpeggio][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
                                  ".clip.new(bar=1, length_bars=4)"
@@ -549,7 +570,8 @@ TEST_CASE("add_arpeggio - missing quality", "[dsl][arpeggio][error]") {
 
 TEST_CASE("add_arpeggio - unknown quality", "[dsl][arpeggio][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
                                  ".clip.new(bar=1, length_bars=4)"
@@ -559,7 +581,8 @@ TEST_CASE("add_arpeggio - unknown quality", "[dsl][arpeggio][error]") {
 
 TEST_CASE("add_arpeggio - zero step rejected", "[dsl][arpeggio][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
                                  ".clip.new(bar=1, length_bars=4)"
@@ -569,7 +592,8 @@ TEST_CASE("add_arpeggio - zero step rejected", "[dsl][arpeggio][error]") {
 
 TEST_CASE("add_arpeggio - negative step rejected", "[dsl][arpeggio][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
                                  ".clip.new(bar=1, length_bars=4)"
@@ -579,7 +603,8 @@ TEST_CASE("add_arpeggio - negative step rejected", "[dsl][arpeggio][error]") {
 
 TEST_CASE("add_arpeggio - negative note_length rejected", "[dsl][arpeggio][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute(
         "track(name=\"Test\", type=\"midi\")"
@@ -590,7 +615,8 @@ TEST_CASE("add_arpeggio - negative note_length rejected", "[dsl][arpeggio][error
 
 TEST_CASE("add_arpeggio - negative beats rejected", "[dsl][arpeggio][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result =
         interp.execute("track(name=\"Test\", type=\"midi\")"
@@ -601,7 +627,8 @@ TEST_CASE("add_arpeggio - negative beats rejected", "[dsl][arpeggio][error]") {
 
 TEST_CASE("add_arpeggio - no clip context", "[dsl][arpeggio][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // Create track but no clip — arpeggio should fail
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
@@ -615,7 +642,8 @@ TEST_CASE("add_arpeggio - no clip context", "[dsl][arpeggio][error]") {
 
 TEST_CASE("add_arpeggio - power chord (2 notes)", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=2)"
@@ -633,7 +661,8 @@ TEST_CASE("add_arpeggio - power chord (2 notes)", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - fill with beat offset", "[dsl][arpeggio][fill]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // Start at beat 2 and fill to end of 1-bar (4-beat) clip
     // Available space: beats 2-4, step=0.5 → 4 notes
@@ -654,7 +683,8 @@ TEST_CASE("add_arpeggio - fill with beat offset", "[dsl][arpeggio][fill]") {
 
 TEST_CASE("add_arpeggio - updown with triad (3 notes)", "[dsl][arpeggio]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // updown with 3-note chord: C E G E → 4 notes (skip top and bottom on way down)
     REQUIRE(interp.execute(
@@ -681,7 +711,8 @@ TEST_CASE("add_arpeggio - updown with triad (3 notes)", "[dsl][arpeggio]") {
 
 TEST_CASE("add_arpeggio - new=true creates separate track", "[dsl][arpeggio][track]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // Create first track
     REQUIRE(

--- a/tests/test_dsl_add_chord.cpp
+++ b/tests/test_dsl_add_chord.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "magda/agents/dsl_interpreter.hpp"
+#include "magda/daw/api/magda_api_live.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/SelectionManager.hpp"
 #include "magda/daw/core/TrackManager.hpp"
@@ -47,7 +48,8 @@ static std::vector<int> getSortedPitches(const ClipInfo* clip) {
 
 TEST_CASE("notes.add_chord - C major triad", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -69,7 +71,8 @@ TEST_CASE("notes.add_chord - C major triad", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - minor triad", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -89,7 +92,8 @@ TEST_CASE("notes.add_chord - minor triad", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - min7 four-note chord", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -114,7 +118,8 @@ TEST_CASE("notes.add_chord - min7 four-note chord", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - dom7", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -135,7 +140,8 @@ TEST_CASE("notes.add_chord - dom7", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - diminished", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -155,7 +161,8 @@ TEST_CASE("notes.add_chord - diminished", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - augmented", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -175,7 +182,8 @@ TEST_CASE("notes.add_chord - augmented", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - sus2", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -195,7 +203,8 @@ TEST_CASE("notes.add_chord - sus2", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - sus4", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -215,7 +224,8 @@ TEST_CASE("notes.add_chord - sus4", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - power chord", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"
@@ -238,7 +248,8 @@ TEST_CASE("notes.add_chord - power chord", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - quality aliases", "[dsl][chord][alias]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     SECTION("maj alias") {
         REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
@@ -294,7 +305,8 @@ TEST_CASE("notes.add_chord - quality aliases", "[dsl][chord][alias]") {
 
 TEST_CASE("notes.add_chord - first inversion", "[dsl][chord][inversion]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // C major first inversion: E4, G4, C5
     REQUIRE(
@@ -316,7 +328,8 @@ TEST_CASE("notes.add_chord - first inversion", "[dsl][chord][inversion]") {
 
 TEST_CASE("notes.add_chord - second inversion", "[dsl][chord][inversion]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // C major second inversion: G4, C5, E5
     REQUIRE(
@@ -342,7 +355,8 @@ TEST_CASE("notes.add_chord - second inversion", "[dsl][chord][inversion]") {
 
 TEST_CASE("notes.add_chord - beat position and velocity", "[dsl][chord]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute(
         "track(name=\"Test\", type=\"midi\")"
@@ -367,7 +381,8 @@ TEST_CASE("notes.add_chord - beat position and velocity", "[dsl][chord]") {
 
 TEST_CASE("notes.add_chord - multiple chords (progression)", "[dsl][chord][progression]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // Em - C - G - D progression
     REQUIRE(interp.execute(
@@ -391,7 +406,8 @@ TEST_CASE("notes.add_chord - multiple chords (progression)", "[dsl][chord][progr
 
 TEST_CASE("clip.new without bar places after last clip", "[dsl][chord][autoplace]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // Create first clip at bar 1, 4 bars long (ends at bar 5)
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\").clip.new(bar=1, length_bars=4)"));
@@ -418,7 +434,8 @@ TEST_CASE("clip.new without bar places after last clip", "[dsl][chord][autoplace
 
 TEST_CASE("clip.new without bar on empty track places at bar 1", "[dsl][chord][autoplace]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\").clip.new(length_bars=4)"));
 
@@ -439,7 +456,8 @@ TEST_CASE("clip.new without bar on empty track places at bar 1", "[dsl][chord][a
 
 TEST_CASE("notes.add_chord - missing root", "[dsl][chord][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
                                  ".clip.new(bar=1, length_bars=4)"
@@ -449,7 +467,8 @@ TEST_CASE("notes.add_chord - missing root", "[dsl][chord][error]") {
 
 TEST_CASE("notes.add_chord - missing quality", "[dsl][chord][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
                                  ".clip.new(bar=1, length_bars=4)"
@@ -459,7 +478,8 @@ TEST_CASE("notes.add_chord - missing quality", "[dsl][chord][error]") {
 
 TEST_CASE("notes.add_chord - unknown quality", "[dsl][chord][error]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     bool result = interp.execute("track(name=\"Test\", type=\"midi\")"
                                  ".clip.new(bar=1, length_bars=4)"
@@ -473,7 +493,8 @@ TEST_CASE("notes.add_chord - unknown quality", "[dsl][chord][error]") {
 
 TEST_CASE("notes.add_chord - continues after failed statement", "[dsl][chord][recovery]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     // First statement fails (bad FX), but track is created.
     // Second statement should still add chords to the clip.
@@ -498,7 +519,8 @@ TEST_CASE("notes.add_chord - continues after failed statement", "[dsl][chord][re
 
 TEST_CASE("notes.add_chord - undo removes all chord notes", "[dsl][chord][undo]") {
     resetState();
-    dsl::Interpreter interp;
+    magda::MagdaApiLive api;
+    dsl::Interpreter interp(api);
 
     REQUIRE(interp.execute("track(name=\"Test\", type=\"midi\")"
                            ".clip.new(bar=1, length_bars=4)"

--- a/tests/test_ui_scale.cpp
+++ b/tests/test_ui_scale.cpp
@@ -59,8 +59,7 @@ TEST_CASE("stepUIScale - up from 2.0 clamps to 2.0", "[ui_scale]") {
 // Out-of-range current values — snap to nearest in-range step, then move.
 // ---------------------------------------------------------------------------
 
-TEST_CASE("stepUIScale - up from 0.5 (below range) snaps to 1.0 then to 1.25",
-          "[ui_scale]") {
+TEST_CASE("stepUIScale - up from 0.5 (below range) snaps to 1.0 then to 1.25", "[ui_scale]") {
     REQUIRE(stepUIScale(0.5, +1) == Approx(1.25));
 }
 
@@ -68,8 +67,7 @@ TEST_CASE("stepUIScale - down from 0.5 (below range) snaps to 1.0 and clamps", "
     REQUIRE(stepUIScale(0.5, -1) == Approx(1.0));
 }
 
-TEST_CASE("stepUIScale - down from 3.0 (above range) snaps to 2.0 then to 1.75",
-          "[ui_scale]") {
+TEST_CASE("stepUIScale - down from 3.0 (above range) snaps to 2.0 then to 1.75", "[ui_scale]") {
     REQUIRE(stepUIScale(3.0, -1) == Approx(1.75));
 }
 


### PR DESCRIPTION
## Summary

Closes #1113. Integration PR for the MagdaApi epic — merges \`feat/magda-api\` into \`dev/0.7.0\`. The agent layer (\`magda/agents/\`) no longer reaches into MAGDA's DAW state singletons; every read and write now routes through a programmatic facade (\`magda::MagdaApi\`) under \`magda/daw/api/\`. Same DAW behaviour, swappable backend.

The diff is the squashed result of four already-reviewed PRs that landed on the integration branch:

| PR | Scope |
|---|---|
| #1114 (PR1) | Abstract \`MagdaApi\` facade + \`SelectionApi\` / \`AutomationApi\` / \`AliasApi\` sub-interfaces, \`MagdaApiLive\` singleton-forwarding impl, \`automation_executor.cpp\` migrated, DI wired through \`AutomationAgent\` and \`AIChatConsoleContent\` |
| #1115 (PR2) | \`TrackApi\` / \`ClipApi\` / \`ProjectApi\` / \`UndoApi\` added, \`SelectionApi\` extended for multi-selection, \`compact_executor.cpp\` migrated, \`DAWAgent\` plumbed |
| #1116 (PR3) | \`SelectionApi\`/\`ClipApi\`/\`TrackApi\` extended for the DSL-side surface (note-selection primitives, getTrack, setGrooveTemplate, getClipsOnTrack), \`dsl_interpreter.cpp\` migrated (65/69 sites) |
| #1117 (PR4) | \`buildSelectionContext\`, \`buildStateSnapshot\`, \`groove.extract\` migrated; \`CommandAgent\` constructor takes \`MagdaApi&\`; FX alias map collapsed to one canonical alias per plugin (matches the autocomplete dropdown) |

## What lives where

\`magda/daw/api/\` (new):
- \`magda_api.hpp\` — abstract facade (7 sub-interfaces)
- \`{selection,automation,alias,track,clip,project,undo}_api.hpp\` — abstract per-concept interfaces
- \`*_api_live.{hpp,cpp}\` — singleton-forwarding live impl, one per sub-interface
- \`magda_api_live.hpp\` — composed live facade

The abstract headers are kept lightweight on purpose — they pull in only \`TypeIds.hpp\` / \`ClipTypes.hpp\`, not the singleton + listener machinery. Concrete struct types like \`NoteSelection\` and \`AutomationLaneSelection\` are surfaced via primitive accessors (e.g. \`getSelectedAutomationLaneId()\` returns an id, not a struct ref).

## Final state of the agent layer

\`grep \"::getInstance\" magda/agents/\` after merge returns:
- \`Config::getInstance().getAgentLLMConfig(...)\` — LLM provider config-loader. Not DAW state, intentionally out of scope per the original plan.
- \`LlamaModelManager::getInstance()\` — LLM-internal singleton, also intentionally out of scope.

**Zero DAW-state singleton calls remain.** Issue #1113's stated goal is met: an alternative \`MagdaApi\` backend (e.g. \`MagdaApiPlugin\` for a future plugin distribution, or \`MagdaApiFake\` for unit tests) can be dropped in without touching agent code.

## Test plan

- [x] \`make debug\` clean
- [x] \`make test\` — 26694 assertions / 783 cases pass on the integration branch tip
- [x] \`grep \"::getInstance\" magda/agents/\` shows only the documented carve-outs (Config, LlamaModelManager)
- [x] Manual smoke (per-PR, against \`feat/magda-api\` tip): AI chat path (router → command + music + automation, BOTH-intent), DSL console (chained track + clip + chord + add_fx), automation lane prompts, groove.extract on an audio clip
- [ ] Full smoke pass against \`dev/0.7.0\` after merge — same flows, plus any 0.7-specific behaviour added on \`dev/0.7.0\` since the branch was cut

## Follow-ups (out of scope here, separate PRs)

- \`AgentManager\` is dead code (never instantiated outside its own file); can be deleted in a follow-up.
- \`MagdaApiFake\` for the agent unit tests — currently they construct \`MagdaApiLive\` and reset the underlying singletons in fixtures. A pure-in-memory fake would make the tests independent of MAGDA singleton state.
- \`MagdaApiPlugin\` whenever the plugin distribution lands. The composed-sub-class facade lets that happen per-concept (e.g. plugin variant only needs to override \`TrackApi\`/\`ClipApi\`, can keep \`MagdaApiLive\` for the rest).