### PR TITLE
Device header redesign + MAGDA presets (.mps)

### DIFF
--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -759,6 +759,50 @@ DeviceProcessor* AudioBridge::getDeviceProcessor(DeviceId deviceId) const {
     return pluginManager_.getDeviceProcessor(deviceId);
 }
 
+namespace {
+te::ExternalPlugin* asExternalPlugin(te::Plugin::Ptr plugin) {
+    return dynamic_cast<te::ExternalPlugin*>(plugin.get());
+}
+}  // namespace
+
+int AudioBridge::getPluginNumPrograms(DeviceId deviceId) const {
+    if (auto* ext = asExternalPlugin(pluginManager_.getPlugin(deviceId))) {
+        if (auto* pi = ext->getAudioPluginInstance())
+            return pi->getNumPrograms();
+    }
+    return 0;
+}
+
+int AudioBridge::getPluginCurrentProgram(DeviceId deviceId) const {
+    if (auto* ext = asExternalPlugin(pluginManager_.getPlugin(deviceId))) {
+        if (auto* pi = ext->getAudioPluginInstance())
+            return pi->getCurrentProgram();
+    }
+    return 0;
+}
+
+juce::String AudioBridge::getPluginProgramName(DeviceId deviceId, int programIndex) const {
+    if (auto* ext = asExternalPlugin(pluginManager_.getPlugin(deviceId))) {
+        if (auto* pi = ext->getAudioPluginInstance()) {
+            if (programIndex >= 0 && programIndex < pi->getNumPrograms())
+                return pi->getProgramName(programIndex);
+        }
+    }
+    return {};
+}
+
+bool AudioBridge::setPluginCurrentProgram(DeviceId deviceId, int programIndex) {
+    if (auto* ext = asExternalPlugin(pluginManager_.getPlugin(deviceId))) {
+        if (auto* pi = ext->getAudioPluginInstance()) {
+            if (programIndex >= 0 && programIndex < pi->getNumPrograms()) {
+                pi->setCurrentProgram(programIndex);
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 te::VirtualMidiInputDevice* AudioBridge::getQwertyMidiDevice() {
     if (!qwertyMidiDevice_) {
         // Check if it already exists (persisted from a previous session).

--- a/magda/daw/audio/AudioBridge.hpp
+++ b/magda/daw/audio/AudioBridge.hpp
@@ -310,6 +310,16 @@ class AudioBridge : public TrackManagerListener, public ClipManagerListener, pub
      */
     DeviceProcessor* getDeviceProcessor(DeviceId deviceId) const;
 
+    // ------------------------------------------------------------------------
+    // VST/AU plugin program (factory preset) access for hosted external plugins.
+    // All return zero/empty for non-external (internal/MAGDA) devices.
+    // ------------------------------------------------------------------------
+    int getPluginNumPrograms(DeviceId deviceId) const;
+    int getPluginCurrentProgram(DeviceId deviceId) const;
+    juce::String getPluginProgramName(DeviceId deviceId, int programIndex) const;
+    /** Switch the plugin's current program. Returns true on success. */
+    bool setPluginCurrentProgram(DeviceId deviceId, int programIndex);
+
     /**
      * @brief Get (or lazily create) the virtual MIDI input device used by
      *        the QWERTY keyboard. Returns nullptr if creation fails.

--- a/magda/daw/core/PresetManager.cpp
+++ b/magda/daw/core/PresetManager.cpp
@@ -19,6 +19,40 @@ juce::String sanitizeName(const juce::String& name) {
     return sanitized;
 }
 
+// Sanitize each segment of a slash-separated relative path so the user can
+// nest presets in subfolders ("Bass/Reese 808" → "Bass/Reese 808.mps").
+juce::String sanitizeRelativePath(const juce::String& relativePath) {
+    juce::StringArray parts;
+    parts.addTokens(relativePath, "/", "");
+    juce::StringArray cleaned;
+    for (const auto& part : parts) {
+        auto trimmed = part.trim();
+        if (trimmed.isEmpty())
+            continue;
+        cleaned.add(juce::File::createLegalFileName(trimmed));
+    }
+    if (cleaned.isEmpty())
+        cleaned.add("Untitled");
+    return cleaned.joinIntoString("/");
+}
+
+// Walk a preset directory tree, appending forward-slash relative paths
+// (no extension) for every .mps file encountered. Directories first then
+// files, alphabetical within each, so the menu order is predictable.
+void collectPresetsRecursive(const juce::File& root, const juce::String& prefix,
+                             juce::StringArray& out) {
+    if (!root.isDirectory())
+        return;
+    auto subdirs = root.findChildFiles(juce::File::findDirectories, false);
+    auto files = root.findChildFiles(juce::File::findFiles, false, "*.mps");
+    subdirs.sort();
+    files.sort();
+    for (const auto& sub : subdirs)
+        collectPresetsRecursive(sub, prefix + sub.getFileName() + "/", out);
+    for (const auto& f : files)
+        out.add(prefix + f.getFileNameWithoutExtension());
+}
+
 // Wrap payload in the standard envelope and write pretty JSON.
 bool writePresetFile(const juce::File& target, const juce::String& kind, const juce::var& payload,
                      juce::String& outError) {
@@ -182,14 +216,22 @@ juce::StringArray PresetManager::getRackPresets() const {
 // Device Presets
 // ============================================================================
 
+juce::File PresetManager::getDevicePluginDirectory(const juce::String& pluginFolder) const {
+    return getDevicesDirectory().getChildFile(sanitizeName(pluginFolder));
+}
+
 bool PresetManager::saveDevicePreset(const DeviceInfo& device, const juce::String& presetName) {
     auto payload = ProjectSerializer::serializeDeviceInfo(device);
-    auto target = getDevicesDirectory().getChildFile(sanitizeName(presetName) + kPresetExtension);
+    auto pluginDir = getDevicePluginDirectory(device.name);
+    auto target = pluginDir.getChildFile(sanitizeRelativePath(presetName) + kPresetExtension);
     return writePresetFile(target, kKindDevice, payload, lastError_);
 }
 
-bool PresetManager::loadDevicePreset(const juce::String& presetName, DeviceInfo& outDevice) {
-    auto source = getDevicesDirectory().getChildFile(sanitizeName(presetName) + kPresetExtension);
+bool PresetManager::loadDevicePreset(const juce::String& pluginFolder,
+                                     const juce::String& presetRelativePath,
+                                     DeviceInfo& outDevice) {
+    auto source = getDevicePluginDirectory(pluginFolder)
+                      .getChildFile(sanitizeRelativePath(presetRelativePath) + kPresetExtension);
     juce::var payload;
     if (!readPresetFile(source, kKindDevice, payload, lastError_))
         return false;
@@ -201,8 +243,10 @@ bool PresetManager::loadDevicePreset(const juce::String& presetName, DeviceInfo&
     return true;
 }
 
-juce::StringArray PresetManager::getDevicePresets() const {
-    return getPresetList(getDevicesDirectory());
+juce::StringArray PresetManager::getDevicePresets(const juce::String& pluginFolder) const {
+    juce::StringArray out;
+    collectPresetsRecursive(getDevicePluginDirectory(pluginFolder), "", out);
+    return out;
 }
 
 // ============================================================================

--- a/magda/daw/core/PresetManager.cpp
+++ b/magda/daw/core/PresetManager.cpp
@@ -1,6 +1,70 @@
 #include "PresetManager.hpp"
 
+#include "../project/serialization/ProjectSerializer.hpp"
+#include "version.hpp"
+
 namespace magda {
+
+namespace {
+constexpr const char* kPresetExtension = ".mps";
+constexpr const char* kKindChain = "chain";
+constexpr const char* kKindRack = "rack";
+constexpr const char* kKindDevice = "device";
+
+// Sanitize a user-supplied preset name into something filesystem-safe.
+juce::String sanitizeName(const juce::String& name) {
+    auto sanitized = juce::File::createLegalFileName(name.trim());
+    if (sanitized.isEmpty())
+        sanitized = "Untitled";
+    return sanitized;
+}
+
+// Wrap payload in the standard envelope and write pretty JSON.
+bool writePresetFile(const juce::File& target, const juce::String& kind, const juce::var& payload,
+                     juce::String& outError) {
+    auto* envelope = new juce::DynamicObject();
+    envelope->setProperty("magdaVersion", juce::String(MAGDA_VERSION));
+    envelope->setProperty("kind", kind);
+    envelope->setProperty("payload", payload);
+
+    juce::var root(envelope);
+    auto json = juce::JSON::toString(root, /*allOnOneLine*/ false);
+
+    target.getParentDirectory().createDirectory();
+    if (!target.replaceWithText(json)) {
+        outError = "Failed to write preset file: " + target.getFullPathName();
+        return false;
+    }
+    return true;
+}
+
+// Parse a preset file, validate the envelope, and return the payload.
+bool readPresetFile(const juce::File& source, const juce::String& expectedKind,
+                    juce::var& outPayload, juce::String& outError) {
+    if (!source.existsAsFile()) {
+        outError = "Preset file not found: " + source.getFullPathName();
+        return false;
+    }
+
+    auto text = source.loadFileAsString();
+    auto root = juce::JSON::parse(text);
+    if (!root.isObject()) {
+        outError = "Preset file is not a JSON object: " + source.getFullPathName();
+        return false;
+    }
+
+    auto* obj = root.getDynamicObject();
+    auto kind = obj->getProperty("kind").toString();
+    if (kind != expectedKind) {
+        outError = "Preset kind mismatch (expected '" + expectedKind + "', got '" + kind + "')";
+        return false;
+    }
+
+    outPayload = obj->getProperty("payload");
+    return true;
+}
+
+}  // namespace
 
 PresetManager& PresetManager::getInstance() {
     static PresetManager instance;
@@ -41,19 +105,46 @@ juce::File PresetManager::getDevicesDirectory() const {
 
 bool PresetManager::saveChainPreset(const std::vector<ChainElement>& chainElements,
                                     const juce::String& presetName) {
-    // TODO: Implement chain preset serialization
-    // For now, just return placeholder error
-    juce::ignoreUnused(chainElements, presetName);
-    lastError_ = "Chain preset saving not yet implemented";
-    return false;
+    juce::Array<juce::var> elementsArray;
+    for (const auto& element : chainElements)
+        elementsArray.add(ProjectSerializer::serializeChainElement(element));
+
+    auto* payload = new juce::DynamicObject();
+    payload->setProperty("elements", juce::var(elementsArray));
+
+    auto target = getChainsDirectory().getChildFile(sanitizeName(presetName) + kPresetExtension);
+    return writePresetFile(target, kKindChain, juce::var(payload), lastError_);
 }
 
 bool PresetManager::loadChainPreset(const juce::String& presetName,
                                     std::vector<ChainElement>& outChainElements) {
-    // TODO: Implement chain preset deserialization
-    juce::ignoreUnused(presetName, outChainElements);
-    lastError_ = "Chain preset loading not yet implemented";
-    return false;
+    auto source = getChainsDirectory().getChildFile(sanitizeName(presetName) + kPresetExtension);
+    juce::var payload;
+    if (!readPresetFile(source, kKindChain, payload, lastError_))
+        return false;
+
+    if (!payload.isObject()) {
+        lastError_ = "Chain preset payload is not an object";
+        return false;
+    }
+    auto elementsVar = payload.getDynamicObject()->getProperty("elements");
+    if (!elementsVar.isArray()) {
+        lastError_ = "Chain preset 'elements' is not an array";
+        return false;
+    }
+
+    outChainElements.clear();
+    for (const auto& elementVar : *elementsVar.getArray()) {
+        ChainElement element;
+        if (!ProjectSerializer::deserializeChainElement(elementVar, element)) {
+            lastError_ =
+                "Failed to deserialize chain element: " + ProjectSerializer::getLastError();
+            outChainElements.clear();
+            return false;
+        }
+        outChainElements.push_back(std::move(element));
+    }
+    return true;
 }
 
 juce::StringArray PresetManager::getChainPresets() const {
@@ -65,17 +156,22 @@ juce::StringArray PresetManager::getChainPresets() const {
 // ============================================================================
 
 bool PresetManager::saveRackPreset(const RackInfo& rack, const juce::String& presetName) {
-    // TODO: Implement rack preset serialization
-    juce::ignoreUnused(rack, presetName);
-    lastError_ = "Rack preset saving not yet implemented";
-    return false;
+    auto payload = ProjectSerializer::serializeRackInfo(rack);
+    auto target = getRacksDirectory().getChildFile(sanitizeName(presetName) + kPresetExtension);
+    return writePresetFile(target, kKindRack, payload, lastError_);
 }
 
 bool PresetManager::loadRackPreset(const juce::String& presetName, RackInfo& outRack) {
-    // TODO: Implement rack preset deserialization
-    juce::ignoreUnused(presetName, outRack);
-    lastError_ = "Rack preset loading not yet implemented";
-    return false;
+    auto source = getRacksDirectory().getChildFile(sanitizeName(presetName) + kPresetExtension);
+    juce::var payload;
+    if (!readPresetFile(source, kKindRack, payload, lastError_))
+        return false;
+
+    if (!ProjectSerializer::deserializeRackInfo(payload, outRack)) {
+        lastError_ = "Failed to deserialize rack: " + ProjectSerializer::getLastError();
+        return false;
+    }
+    return true;
 }
 
 juce::StringArray PresetManager::getRackPresets() const {
@@ -87,17 +183,22 @@ juce::StringArray PresetManager::getRackPresets() const {
 // ============================================================================
 
 bool PresetManager::saveDevicePreset(const DeviceInfo& device, const juce::String& presetName) {
-    // TODO: Implement device preset serialization
-    juce::ignoreUnused(device, presetName);
-    lastError_ = "Device preset saving not yet implemented";
-    return false;
+    auto payload = ProjectSerializer::serializeDeviceInfo(device);
+    auto target = getDevicesDirectory().getChildFile(sanitizeName(presetName) + kPresetExtension);
+    return writePresetFile(target, kKindDevice, payload, lastError_);
 }
 
 bool PresetManager::loadDevicePreset(const juce::String& presetName, DeviceInfo& outDevice) {
-    // TODO: Implement device preset deserialization
-    juce::ignoreUnused(presetName, outDevice);
-    lastError_ = "Device preset loading not yet implemented";
-    return false;
+    auto source = getDevicesDirectory().getChildFile(sanitizeName(presetName) + kPresetExtension);
+    juce::var payload;
+    if (!readPresetFile(source, kKindDevice, payload, lastError_))
+        return false;
+
+    if (!ProjectSerializer::deserializeDeviceInfo(payload, outDevice)) {
+        lastError_ = "Failed to deserialize device: " + ProjectSerializer::getLastError();
+        return false;
+    }
+    return true;
 }
 
 juce::StringArray PresetManager::getDevicePresets() const {
@@ -126,11 +227,11 @@ juce::StringArray PresetManager::getPresetList(const juce::File& directory) cons
     if (!directory.exists())
         return presets;
 
-    auto files = directory.findChildFiles(juce::File::findFiles, false, "*.preset");
+    auto files = directory.findChildFiles(juce::File::findFiles, false,
+                                          juce::String("*") + kPresetExtension);
 
-    for (const auto& file : files) {
+    for (const auto& file : files)
         presets.add(file.getFileNameWithoutExtension());
-    }
 
     presets.sort(true);  // Case-insensitive alphabetical sort
     return presets;

--- a/magda/daw/core/PresetManager.hpp
+++ b/magda/daw/core/PresetManager.hpp
@@ -102,25 +102,33 @@ class PresetManager {
     // ========================================================================
 
     /**
-     * @brief Save a device configuration as a preset
-     * @param device The device to save
-     * @param presetName Name for the preset file
-     * @return true on success, false on error
+     * @brief Save a device configuration as a preset.
+     *
+     * Saved into Devices/<plugin folder>/<presetName>.mps. The plugin folder
+     * is derived from device.name. presetName may contain forward slashes to
+     * place the preset in a subfolder (e.g. "Bass/Reese 808").
      */
     bool saveDevicePreset(const DeviceInfo& device, const juce::String& presetName);
 
     /**
-     * @brief Load a device preset
-     * @param presetName Name of the preset file
-     * @param outDevice Output device info
-     * @return true on success, false on error
+     * @brief Load a device preset by plugin folder + relative preset path.
+     *
+     * @param pluginFolder The plugin's folder name (typically device.name)
+     * @param presetRelativePath Relative path within that folder, no extension
+     *                           (e.g. "Init Patch" or "Bass/Reese 808")
      */
-    bool loadDevicePreset(const juce::String& presetName, DeviceInfo& outDevice);
+    bool loadDevicePreset(const juce::String& pluginFolder, const juce::String& presetRelativePath,
+                          DeviceInfo& outDevice);
 
     /**
-     * @brief Get list of available device presets
+     * @brief List device presets for a single plugin, returned as forward-slash
+     *        relative paths sans extension (e.g. ["Init Patch", "Bass/Reese 808"]).
+     *        Sorted: directories first, then files, alphabetical.
      */
-    juce::StringArray getDevicePresets() const;
+    juce::StringArray getDevicePresets(const juce::String& pluginFolder) const;
+
+    /** @brief The Devices/<pluginFolder>/ directory. Created lazily on save. */
+    juce::File getDevicePluginDirectory(const juce::String& pluginFolder) const;
 
     // ========================================================================
     // Error Handling

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -333,6 +333,19 @@ class TrackManager {
     void setDeviceParameterValue(const ChainNodePath& devicePath, int paramIndex, float value);
 
     /**
+     * @brief Apply a deserialized DeviceInfo (from a .mps preset) to a live device.
+     *
+     * Copies the state-y fields (parameters, macros, mods, gainDb, pluginState)
+     * onto the existing device at devicePath; preserves identity (id, name,
+     * pluginId, format, etc.). Pushes the plugin state to the running plugin
+     * and notifies UI listeners.
+     *
+     * Returns false if the path doesn't resolve to a device or the preset's
+     * plugin identity doesn't match the live device.
+     */
+    bool applyDevicePreset(const ChainNodePath& devicePath, const DeviceInfo& presetDevice);
+
+    /**
      * @brief Set a device parameter value from the plugin's native UI
      *
      * This method is called when the plugin's native UI changes a parameter.

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -545,6 +545,58 @@ void TrackManager::setDeviceParameterValue(const ChainNodePath& devicePath, int 
     }
 }
 
+bool TrackManager::applyDevicePreset(const ChainNodePath& devicePath,
+                                     const DeviceInfo& presetDevice) {
+    auto* live = getDeviceInChainByPath(devicePath);
+    if (!live) {
+        DBG("applyDevicePreset: no live device at path");
+        return false;
+    }
+
+    // Don't load a preset captured from a different plugin onto this slot.
+    if (live->pluginId != presetDevice.pluginId) {
+        DBG("applyDevicePreset: pluginId mismatch (live='" << live->pluginId << "', preset='"
+                                                           << presetDevice.pluginId << "')");
+        return false;
+    }
+
+    // Copy state-y fields; preserve identity (id, name, format, fileOrIdentifier,
+    // capabilities, sidechain wiring, current track placement).
+    live->parameters = presetDevice.parameters;
+    live->macros = presetDevice.macros;
+    live->mods = presetDevice.mods;
+    live->gainDb = presetDevice.gainDb;
+    live->gainValue = std::pow(10.0f, presetDevice.gainDb / 20.0f);
+    live->pluginState = presetDevice.pluginState;
+
+    // Push the new pluginState into the running plugin.
+    if (audioEngine_) {
+        if (auto* bridge = audioEngine_->getAudioBridge()) {
+            if (auto plugin = bridge->getPlugin(live->id)) {
+                if (auto* ext = dynamic_cast<tracktion::engine::ExternalPlugin*>(plugin.get())) {
+                    ext->state.setProperty(tracktion::engine::IDs::state, live->pluginState,
+                                           nullptr);
+                    ext->restorePluginStateFromValueTree(ext->state);
+                } else if (auto xml = juce::parseXML(live->pluginState)) {
+                    auto savedState = juce::ValueTree::fromXml(*xml);
+                    if (savedState.isValid())
+                        plugin->restorePluginStateFromValueTree(savedState);
+                }
+            }
+        }
+    }
+
+    // Notify listeners — devicePropertyChanged covers gain/macros/mods refresh
+    // via the AudioBridge sync path, then push each parameter individually so
+    // the UI's ParamGrid pickup matches what the preset captured.
+    notifyDevicePropertyChanged(live->id);
+    for (size_t i = 0; i < live->parameters.size(); ++i) {
+        notifyDeviceParameterChanged(live->id, static_cast<int>(i),
+                                     live->parameters[i].currentValue);
+    }
+    return true;
+}
+
 void TrackManager::setDeviceParameterValueFromPlugin(const ChainNodePath& devicePath,
                                                      int paramIndex, float value) {
     // This method is called when the plugin's native UI changes a parameter.

--- a/magda/daw/project/serialization/ProjectSerializer.hpp
+++ b/magda/daw/project/serialization/ProjectSerializer.hpp
@@ -111,6 +111,24 @@ class ProjectSerializer {
         return lastError_;
     }
 
+    // ========================================================================
+    // Per-element (de)serialization helpers — public so PresetManager and
+    // other clients can build sub-document JSON for chain / rack / device
+    // presets without re-implementing the schema.
+    // ========================================================================
+
+    static juce::var serializeChainElement(const ChainElement& element);
+    static bool deserializeChainElement(const juce::var& json, ChainElement& outElement);
+
+    static juce::var serializeDeviceInfo(const DeviceInfo& device);
+    static bool deserializeDeviceInfo(const juce::var& json, DeviceInfo& outDevice);
+
+    static juce::var serializeRackInfo(const RackInfo& rack);
+    static bool deserializeRackInfo(const juce::var& json, RackInfo& outRack);
+
+    static juce::var serializeChainInfo(const ChainInfo& chain);
+    static bool deserializeChainInfo(const juce::var& json, ChainInfo& outChain);
+
   private:
     // ========================================================================
     // Atomic deserialization helpers
@@ -167,17 +185,8 @@ class ProjectSerializer {
     static juce::var serializeTrackInfo(const TrackInfo& track);
     static bool deserializeTrackInfo(const juce::var& json, TrackInfo& outTrack);
 
-    static juce::var serializeChainElement(const ChainElement& element);
-    static bool deserializeChainElement(const juce::var& json, ChainElement& outElement);
-
-    static juce::var serializeDeviceInfo(const DeviceInfo& device);
-    static bool deserializeDeviceInfo(const juce::var& json, DeviceInfo& outDevice);
-
-    static juce::var serializeRackInfo(const RackInfo& rack);
-    static bool deserializeRackInfo(const juce::var& json, RackInfo& outRack);
-
-    static juce::var serializeChainInfo(const ChainInfo& chain);
-    static bool deserializeChainInfo(const juce::var& json, ChainInfo& outChain);
+    // serializeChainElement / DeviceInfo / RackInfo / ChainInfo are declared
+    // public above so PresetManager can use them.
 
     // ========================================================================
     // Clip serialization helpers

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -1349,7 +1349,8 @@ void DeviceSlotComponent::showSaveMagdaPresetDialog() {
                     self->currentPresetName_ = name;
             };
 
-            if (magda::PresetManager::getInstance().getDevicePresets().contains(name)) {
+            const auto pluginFolder = self->device_.name;
+            if (magda::PresetManager::getInstance().getDevicePresets(pluginFolder).contains(name)) {
                 juce::AlertWindow::showAsync(
                     juce::MessageBoxOptions()
                         .withIconType(juce::MessageBoxIconType::QuestionIcon)

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -257,19 +257,27 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     };
     addAndMakeVisible(*presetButton_);
 
-    // ----- MOCK UI (no wiring): Native plugin programs dropdown (second header) -----
+    // Native plugin programs (factory presets) dropdown — populated lazily once
+    // the plugin instance is loaded (see refreshProgramsCombo).
     programsCombo_ = std::make_unique<juce::ComboBox>("Programs");
-    programsCombo_->addItem("Init Patch", 1);
-    programsCombo_->addItem("Bass Lead", 2);
-    programsCombo_->addItem("Pad", 3);
-    programsCombo_->addItem("Bell", 4);
-    programsCombo_->setSelectedId(1, juce::dontSendNotification);
     programsCombo_->setLookAndFeel(&SmallComboBoxLookAndFeel::getInstance());
     programsCombo_->setColour(juce::ComboBox::backgroundColourId,
                               DarkTheme::getColour(DarkTheme::SURFACE));
     programsCombo_->setColour(juce::ComboBox::outlineColourId,
                               DarkTheme::getColour(DarkTheme::BORDER));
     programsCombo_->setColour(juce::ComboBox::textColourId, DarkTheme::getTextColour());
+    programsCombo_->setTextWhenNothingSelected({});
+    programsCombo_->onChange = [this]() {
+        auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine();
+        if (!audioEngine)
+            return;
+        auto* bridge = audioEngine->getAudioBridge();
+        if (!bridge)
+            return;
+        const int programIndex = programsCombo_->getSelectedId() - 1;
+        if (programIndex >= 0)
+            bridge->setPluginCurrentProgram(device_.id, programIndex);
+    };
     addAndMakeVisible(*programsCombo_);
 
     // Vertical gain slider overlaid on the meter, with a tooltip that reports
@@ -788,6 +796,10 @@ void DeviceSlotComponent::timerCallback() {
     if (!bridge)
         return;
 
+    // Keep the plugin programs combo selection in sync with the underlying
+    // plugin (program may have been changed via the plugin's native UI).
+    syncProgramsComboSelection();
+
     // Update UI button state to match actual plugin window state
     if (uiButton_) {
         bool isOpen = bridge->isPluginWindowOpen(device_.id);
@@ -1194,6 +1206,59 @@ int DeviceSlotComponent::getPreferredWidth() const {
     return getTotalWidth(getDynamicSlotWidth()) + meterExtra;
 }
 
+void DeviceSlotComponent::refreshProgramsCombo() {
+    if (!programsCombo_)
+        return;
+    auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine();
+    if (!audioEngine)
+        return;
+    auto* bridge = audioEngine->getAudioBridge();
+    if (!bridge)
+        return;
+
+    const int numPrograms = bridge->getPluginNumPrograms(device_.id);
+    // Hide the combo for plugins that don't expose meaningful programs
+    // (most modern VST3s return 1 because presets live as .vstpreset files).
+    if (numPrograms <= 1) {
+        programsCombo_->clear(juce::dontSendNotification);
+        programsCombo_->setVisible(false);
+        return;
+    }
+
+    programsCombo_->clear(juce::dontSendNotification);
+    for (int i = 0; i < numPrograms; ++i) {
+        auto name = bridge->getPluginProgramName(device_.id, i);
+        if (name.isEmpty())
+            name = "Program " + juce::String(i + 1);
+        programsCombo_->addItem(name, i + 1);
+    }
+    const int current = bridge->getPluginCurrentProgram(device_.id);
+    programsCombo_->setSelectedId(current + 1, juce::dontSendNotification);
+}
+
+void DeviceSlotComponent::syncProgramsComboSelection() {
+    if (!programsCombo_ || isInternalDevice() ||
+        device_.loadState != magda::DeviceLoadState::Loaded)
+        return;
+    auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine();
+    if (!audioEngine)
+        return;
+    auto* bridge = audioEngine->getAudioBridge();
+    if (!bridge)
+        return;
+
+    // First-time population: combo is empty but the plugin is now ready.
+    if (programsCombo_->getNumItems() == 0) {
+        if (bridge->getPluginNumPrograms(device_.id) > 1)
+            refreshProgramsCombo();
+        return;
+    }
+
+    const int current = bridge->getPluginCurrentProgram(device_.id);
+    if (current + 1 != programsCombo_->getSelectedId())
+        programsCombo_->setSelectedId(current + 1, juce::dontSendNotification);
+}
+
 void DeviceSlotComponent::updateFromDevice(const magda::DeviceInfo& device) {
     device_ = device;
     // Custom name and font for drum grid (MPC-style with Microgramma)
@@ -1211,6 +1276,11 @@ void DeviceSlotComponent::updateFromDevice(const magda::DeviceInfo& device) {
     gainLabel_.setValue(device.gainDb, juce::dontSendNotification);
     if (gainSlider_)
         gainSlider_->setValue(device.gainDb, juce::dontSendNotification);
+
+    // Plugin instance may have just become available (or its program list changed
+    // due to a state restore) — repopulate.
+    if (device_.loadState == magda::DeviceLoadState::Loaded && !isInternalDevice())
+        refreshProgramsCombo();
 
     // Update sidechain button visibility and state
     if (scButton_) {

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -12,6 +12,7 @@
 #include "audio/DrumGridPlugin.hpp"
 #include "audio/MagdaSamplerPlugin.hpp"
 #include "audio/MidiChordEnginePlugin.hpp"
+#include "audio/PluginManager.hpp"
 #include "audio/StepClock.hpp"
 #include "core/ClipManager.hpp"
 #include "core/MacroInfo.hpp"
@@ -257,35 +258,7 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     // full button size.
     presetButton_->setIconPadding(4.5f);
     presetButton_->setTooltip("MAGDA Presets");
-    presetButton_->onClick = [this]() {
-        auto& pm = magda::PresetManager::getInstance();
-        const auto presets = pm.getDevicePresets();
-
-        juce::PopupMenu menu;
-        menu.addSectionHeader("MAGDA Presets");
-        if (presets.isEmpty()) {
-            menu.addItem(1, "(no presets yet)", /*isActive*/ false);
-        } else {
-            // Load is wired in task 3 — for now items are visible-only so the
-            // user can confirm saves landed on disk.
-            int id = 100;
-            for (const auto& name : presets)
-                menu.addItem(id++, name, /*isActive*/ false);
-        }
-        menu.addSeparator();
-        menu.addItem(2, "Save as MAGDA Preset...");
-        menu.addItem(3, "Reveal in Finder");
-
-        menu.showMenuAsync(
-            juce::PopupMenu::Options().withTargetComponent(presetButton_.get()),
-            [this](int chosen) {
-                if (chosen == 2) {
-                    showSaveMagdaPresetDialog();
-                } else if (chosen == 3) {
-                    magda::PresetManager::getInstance().getDevicesDirectory().revealToUser();
-                }
-            });
-    };
+    presetButton_->onClick = [this]() { showPresetMenu(); };
     addAndMakeVisible(*presetButton_);
 
     // Native plugin programs (factory presets) dropdown — populated lazily once
@@ -1237,32 +1210,191 @@ int DeviceSlotComponent::getPreferredWidth() const {
     return getTotalWidth(getDynamicSlotWidth()) + meterExtra;
 }
 
+namespace {
+void showPresetErrorAsync(const juce::String& title, const juce::String& message) {
+    juce::AlertWindow::showAsync(juce::MessageBoxOptions()
+                                     .withIconType(juce::MessageBoxIconType::WarningIcon)
+                                     .withTitle(title)
+                                     .withMessage(message)
+                                     .withButton("OK"),
+                                 nullptr);
+}
+}  // namespace
+
+namespace {
+
+// Recursively walk a preset directory and append items / submenus to `menu`.
+// `outIndex` collects the relative path of every preset file in click order
+// so the chosen menu id can be resolved back to a path.
+void buildPresetSubmenu(juce::PopupMenu& menu, const juce::File& dir, const juce::String& prefix,
+                        int idBase, int& nextId, const juce::String& currentLoaded,
+                        juce::StringArray& outIndex) {
+    if (!dir.isDirectory())
+        return;
+    auto subdirs = dir.findChildFiles(juce::File::findDirectories, false);
+    auto files = dir.findChildFiles(juce::File::findFiles, false, "*.mps");
+    subdirs.sort();
+    files.sort();
+
+    for (const auto& sub : subdirs) {
+        juce::PopupMenu submenu;
+        buildPresetSubmenu(submenu, sub, prefix + sub.getFileName() + "/", idBase, nextId,
+                           currentLoaded, outIndex);
+        menu.addSubMenu(sub.getFileName(), submenu);
+    }
+    for (const auto& f : files) {
+        const auto displayName = f.getFileNameWithoutExtension();
+        const auto relPath = prefix + displayName;
+        outIndex.add(relPath);
+        const bool ticked = (relPath == currentLoaded);
+        menu.addItem(idBase + outIndex.size() - 1, displayName, /*isActive*/ true, ticked);
+    }
+}
+
+}  // namespace
+
+void DeviceSlotComponent::showPresetMenu() {
+    auto& pm = magda::PresetManager::getInstance();
+    const auto pluginFolder = device_.name;
+
+    constexpr int kSaveOverwrite = 1;
+    constexpr int kSaveAs = 2;
+    constexpr int kRevealInFinder = 3;
+    constexpr int kPresetIdBase = 1000;
+
+    juce::PopupMenu menu;
+    menu.addSectionHeader("MAGDA Presets");
+
+    juce::StringArray index;  // relative paths, indexed by chosen-id - kPresetIdBase
+    int nextId = 0;
+    auto pluginDir = pm.getDevicePluginDirectory(pluginFolder);
+    buildPresetSubmenu(menu, pluginDir, "", kPresetIdBase, nextId, currentPresetName_, index);
+
+    if (index.isEmpty())
+        menu.addItem(kPresetIdBase, "(no presets yet)", /*isActive*/ false);
+
+    menu.addSeparator();
+    if (currentPresetName_.isNotEmpty())
+        menu.addItem(kSaveOverwrite, "Save \"" + currentPresetName_ + "\"");
+    menu.addItem(kSaveAs, "Save as MAGDA Preset...");
+    menu.addItem(kRevealInFinder, "Reveal in Finder");
+
+    const auto indexCopy = index;
+    menu.showMenuAsync(juce::PopupMenu::Options().withTargetComponent(presetButton_.get()),
+                       [this, indexCopy](int chosen) {
+                           if (chosen == 0)
+                               return;
+                           if (chosen == kSaveAs) {
+                               showSaveMagdaPresetDialog();
+                           } else if (chosen == kSaveOverwrite) {
+                               saveCurrentMagdaPreset();
+                           } else if (chosen == kRevealInFinder) {
+                               auto& pm = magda::PresetManager::getInstance();
+                               auto dir = pm.getDevicePluginDirectory(device_.name);
+                               if (!dir.exists())
+                                   dir = pm.getDevicesDirectory();
+                               dir.revealToUser();
+                           } else if (chosen >= kPresetIdBase) {
+                               const int idx = chosen - kPresetIdBase;
+                               if (idx >= 0 && idx < indexCopy.size())
+                                   loadMagdaPreset(indexCopy[idx]);
+                           }
+                       });
+}
+
+magda::DeviceInfo DeviceSlotComponent::snapshotForPreset() {
+    // Force the plugin's current state into DeviceInfo before we snapshot,
+    // otherwise device_.pluginState reflects only the last project-save /
+    // capture point and recent edits would be silently dropped.
+    auto& tm = magda::TrackManager::getInstance();
+    if (auto* engine = tm.getAudioEngine()) {
+        if (auto* bridge = engine->getAudioBridge())
+            bridge->getPluginManager().capturePluginState(device_.id);
+    }
+    if (auto* live = tm.getDeviceInChainByPath(nodePath_))
+        return *live;
+    return device_;
+}
+
 void DeviceSlotComponent::showSaveMagdaPresetDialog() {
     auto* aw = new juce::AlertWindow("Save MAGDA Preset", "Enter a name for this device preset:",
                                      juce::MessageBoxIconType::NoIcon);
-    aw->addTextEditor("name", device_.name, "Name:");
+    aw->addTextEditor("name", currentPresetName_.isNotEmpty() ? currentPresetName_ : device_.name,
+                      "Name:");
     aw->addButton("Save", 1, juce::KeyPress(juce::KeyPress::returnKey));
     aw->addButton("Cancel", 0, juce::KeyPress(juce::KeyPress::escapeKey));
 
-    const auto deviceCopy = device_;  // capture by value — async callback
-    aw->enterModalState(true, juce::ModalCallbackFunction::create([aw, deviceCopy](int result) {
-                            if (result == 1) {
-                                auto name = aw->getTextEditorContents("name").trim();
-                                if (name.isNotEmpty()) {
-                                    auto& pm = magda::PresetManager::getInstance();
-                                    if (!pm.saveDevicePreset(deviceCopy, name)) {
-                                        juce::AlertWindow::showAsync(
-                                            juce::MessageBoxOptions()
-                                                .withIconType(juce::MessageBoxIconType::WarningIcon)
-                                                .withTitle("Save Preset Failed")
-                                                .withMessage(pm.getLastError())
-                                                .withButton("OK"),
-                                            nullptr);
-                                    }
-                                }
-                            }
-                            delete aw;
-                        }));
+    juce::Component::SafePointer<DeviceSlotComponent> self(this);
+    aw->enterModalState(
+        true, juce::ModalCallbackFunction::create([aw, self](int result) {
+            if (result != 1) {
+                delete aw;
+                return;
+            }
+            auto name = aw->getTextEditorContents("name").trim();
+            delete aw;
+            if (name.isEmpty() || self == nullptr)
+                return;
+
+            auto doSave = [name, self]() {
+                if (self == nullptr)
+                    return;
+                auto fresh = self->snapshotForPreset();
+                auto& mgr = magda::PresetManager::getInstance();
+                if (!mgr.saveDevicePreset(fresh, name)) {
+                    showPresetErrorAsync("Save Preset Failed", mgr.getLastError());
+                    return;
+                }
+                if (self != nullptr)
+                    self->currentPresetName_ = name;
+            };
+
+            if (magda::PresetManager::getInstance().getDevicePresets().contains(name)) {
+                juce::AlertWindow::showAsync(
+                    juce::MessageBoxOptions()
+                        .withIconType(juce::MessageBoxIconType::QuestionIcon)
+                        .withTitle("Overwrite Preset?")
+                        .withMessage("\"" + name + "\" already exists. Overwrite?")
+                        .withButton("Overwrite")
+                        .withButton("Cancel"),
+                    [doSave](int r) {
+                        if (r == 1)
+                            doSave();
+                    });
+            } else {
+                doSave();
+            }
+        }));
+}
+
+void DeviceSlotComponent::saveCurrentMagdaPreset() {
+    if (currentPresetName_.isEmpty())
+        return;
+    auto& pm = magda::PresetManager::getInstance();
+    auto fresh = snapshotForPreset();
+    if (!pm.saveDevicePreset(fresh, currentPresetName_))
+        showPresetErrorAsync("Save Preset Failed", pm.getLastError());
+}
+
+void DeviceSlotComponent::loadMagdaPreset(const juce::String& presetRelativePath) {
+    magda::DeviceInfo preset;
+    auto& pm = magda::PresetManager::getInstance();
+    if (!pm.loadDevicePreset(device_.name, presetRelativePath, preset)) {
+        showPresetErrorAsync("Load Preset Failed", pm.getLastError());
+        return;
+    }
+    auto& tm = magda::TrackManager::getInstance();
+    if (!tm.applyDevicePreset(nodePath_, preset)) {
+        showPresetErrorAsync("Load Preset Failed",
+                             "Preset is for a different plugin (\"" + preset.pluginId + "\").");
+        return;
+    }
+    // Refresh this slot's UI from the now-mutated live DeviceInfo. The
+    // applyDevicePreset path notifies via devicePropertyChanged (AudioBridge),
+    // but DeviceSlotComponent's custom-UI refresh sits in updateFromDevice().
+    if (auto* live = tm.getDeviceInChainByPath(nodePath_))
+        updateFromDevice(*live);
+    currentPresetName_ = presetRelativePath;
 }
 
 void DeviceSlotComponent::refreshProgramsCombo() {
@@ -1319,6 +1451,11 @@ void DeviceSlotComponent::syncProgramsComboSelection() {
 }
 
 void DeviceSlotComponent::updateFromDevice(const magda::DeviceInfo& device) {
+    // Detect plugin replacement BEFORE assignment so we can drop a stale
+    // currentPresetName_ reference (a preset is tied to one plugin).
+    if (currentPresetName_.isNotEmpty() && device.pluginId != device_.pluginId)
+        currentPresetName_.clear();
+
     device_ = device;
     // Custom name and font for drum grid (MPC-style with Microgramma)
     isDrumGrid_ = device.pluginId.containsIgnoreCase(daw::audio::DrumGridPlugin::xmlTypeName);

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -60,6 +60,28 @@ class FlatGainSliderLookAndFeel : public juce::LookAndFeel_V4 {
     }
 };
 
+// Slider subclass that returns a dynamic tooltip showing both the current
+// gain value and the meter's peak-hold dB level.
+class GainSliderWithMeterTooltip : public juce::Slider {
+  public:
+    GainSliderWithMeterTooltip(juce::Slider::SliderStyle style,
+                               juce::Slider::TextEntryBoxPosition textPos,
+                               const magda::LevelMeter& meter)
+        : juce::Slider(style, textPos), meter_(meter) {}
+
+    juce::String getTooltip() override {
+        const double gainDb = getValue();
+        const float peakDb = meter_.getPeakDb();
+        const juce::String peakStr =
+            peakDb <= -59.5f ? juce::String("-inf") : juce::String::formatted("%+.1f", peakDb);
+        return juce::String::formatted("Gain: %+.1f dB    Peak: ", gainDb) + peakStr +
+               juce::String(" dB");
+    }
+
+  private:
+    const magda::LevelMeter& meter_;
+};
+
 // Unified visual recipe for all device-header SvgButtons. Pass the accent
 // colour used as the active-state pill background. Set toggling=false for
 // stateless buttons (menus, one-shots).
@@ -250,9 +272,10 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     programsCombo_->setColour(juce::ComboBox::textColourId, DarkTheme::getTextColour());
     addAndMakeVisible(*programsCombo_);
 
-    // ----- MOCK UI (no wiring): Vertical gain slider (above meter) + chevron toggle -----
-    gainSlider_ =
-        std::make_unique<juce::Slider>(juce::Slider::LinearVertical, juce::Slider::NoTextBox);
+    // Vertical gain slider overlaid on the meter, with a tooltip that reports
+    // both the current gain and the meter's peak-hold dB.
+    gainSlider_ = std::make_unique<GainSliderWithMeterTooltip>(
+        juce::Slider::LinearVertical, juce::Slider::NoTextBox, levelMeter_);
     gainSlider_->setRange(-60.0, 12.0, 0.1);
     gainSlider_->setValue(device_.gainDb, juce::dontSendNotification);
     gainSlider_->setTooltip("Device Gain (dB)");
@@ -261,6 +284,11 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     gainSlider_->setLookAndFeel(&FlatGainSliderLookAndFeel::getInstance());
     gainSlider_->setColour(juce::Slider::backgroundColourId, juce::Colours::transparentBlack);
     gainSlider_->setColour(juce::Slider::trackColourId, juce::Colours::transparentBlack);
+    gainSlider_->setDoubleClickReturnValue(true, 0.0);
+    gainSlider_->onValueChange = [this]() {
+        magda::TrackManager::getInstance().setDeviceGainDb(
+            nodePath_, static_cast<float>(gainSlider_->getValue()));
+    };
     addAndMakeVisible(*gainSlider_);
 
     // Sidechain button (only visible when plugin supports sidechain)
@@ -1181,6 +1209,8 @@ void DeviceSlotComponent::updateFromDevice(const magda::DeviceInfo& device) {
     onButton_->setToggleState(!device.bypassed, juce::dontSendNotification);
     onButton_->setActive(!device.bypassed);
     gainLabel_.setValue(device.gainDb, juce::dontSendNotification);
+    if (gainSlider_)
+        gainSlider_->setValue(device.gainDb, juce::dontSendNotification);
 
     // Update sidechain button visibility and state
     if (scButton_) {

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -30,8 +30,51 @@
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
 #include "ui/themes/SmallButtonLookAndFeel.hpp"
+#include "ui/themes/SmallComboBoxLookAndFeel.hpp"
 
 namespace magda::daw::ui {
+
+namespace {
+
+// Minimal flat-thumb LookAndFeel for the device gain slider: draws no track,
+// just a thin horizontal bar at the slider position.
+class FlatGainSliderLookAndFeel : public juce::LookAndFeel_V4 {
+  public:
+    void drawLinearSlider(juce::Graphics& g, int x, int /*y*/, int width, int /*height*/,
+                          float sliderPos, float /*minSliderPos*/, float /*maxSliderPos*/,
+                          const juce::Slider::SliderStyle /*style*/,
+                          juce::Slider& /*slider*/) override {
+        constexpr float thumbHeight = 2.0f;
+        const float thumbY = sliderPos - thumbHeight * 0.5f;
+        g.setColour(DarkTheme::getSecondaryTextColour());
+        g.fillRect((float)x, thumbY, (float)width, thumbHeight);
+    }
+
+    int getSliderThumbRadius(juce::Slider&) override {
+        return 1;
+    }
+
+    static FlatGainSliderLookAndFeel& getInstance() {
+        static FlatGainSliderLookAndFeel instance;
+        return instance;
+    }
+};
+
+// Unified visual recipe for all device-header SvgButtons. Pass the accent
+// colour used as the active-state pill background. Set toggling=false for
+// stateless buttons (menus, one-shots).
+inline void applyHeaderIconStyle(magda::SvgButton& btn, juce::Colour activeBg,
+                                 bool toggling = true) {
+    btn.setIconPadding(2.0f);
+    btn.setOriginalColor(juce::Colour(0xFFB3B3B3));
+    btn.setNormalColor(juce::Colour(0xFFB3B3B3).withAlpha(0.5f));
+    btn.setActiveColor(juce::Colours::white);
+    btn.setActiveBackgroundColor(activeBg);
+    if (toggling)
+        btn.setClickingTogglesState(true);
+}
+
+}  // namespace
 
 DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : device_(device) {
     // Register as TrackManager listener for parameter updates from plugin
@@ -139,11 +182,8 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     // Mod button (toggle mod panel) - bare sine icon
     modButton_ = std::make_unique<magda::SvgButton>("Mod", BinaryData::bare_sine_svg,
                                                     BinaryData::bare_sine_svgSize);
-    modButton_->setClickingTogglesState(true);
+    applyHeaderIconStyle(*modButton_, DarkTheme::getColour(DarkTheme::ACCENT_ORANGE));
     modButton_->setToggleState(modPanelVisible_, juce::dontSendNotification);
-    modButton_->setNormalColor(DarkTheme::getSecondaryTextColour());
-    modButton_->setActiveColor(juce::Colours::white);
-    modButton_->setActiveBackgroundColor(DarkTheme::getColour(DarkTheme::ACCENT_ORANGE));
     modButton_->setActive(modPanelVisible_);
     modButton_->onClick = [this]() {
         modButton_->setActive(modButton_->getToggleState());
@@ -154,11 +194,8 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     // Macro button (toggle macro panel) - knob icon
     macroButton_ =
         std::make_unique<magda::SvgButton>("Macro", BinaryData::knob_svg, BinaryData::knob_svgSize);
-    macroButton_->setClickingTogglesState(true);
+    applyHeaderIconStyle(*macroButton_, DarkTheme::getColour(DarkTheme::ACCENT_PURPLE));
     macroButton_->setToggleState(paramPanelVisible_, juce::dontSendNotification);
-    macroButton_->setNormalColor(DarkTheme::getSecondaryTextColour());
-    macroButton_->setActiveColor(juce::Colours::white);
-    macroButton_->setActiveBackgroundColor(DarkTheme::getColour(DarkTheme::ACCENT_PURPLE));
     macroButton_->setActive(paramPanelVisible_);
     macroButton_->onClick = [this]() {
         macroButton_->setActive(macroButton_->getToggleState());
@@ -181,6 +218,51 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     };
     addAndMakeVisible(gainLabel_);
 
+    // ----- MOCK UI (no wiring): MAGDA preset menu button (top header) -----
+    presetButton_ = std::make_unique<magda::SvgButton>("Presets", BinaryData::preset_svg,
+                                                       BinaryData::preset_svgSize);
+    applyHeaderIconStyle(*presetButton_, DarkTheme::getColour(DarkTheme::ACCENT_PURPLE),
+                         /*toggling*/ false);
+    presetButton_->setTooltip("MAGDA Presets");
+    presetButton_->onClick = [this]() {
+        juce::PopupMenu menu;
+        menu.addSectionHeader("MAGDA Presets");
+        menu.addItem(1, "(no presets yet)", false);
+        menu.addSeparator();
+        menu.addItem(2, "Save as MAGDA Preset...");
+        menu.addItem(3, "Reveal in Finder");
+        menu.showMenuAsync(juce::PopupMenu::Options().withTargetComponent(presetButton_.get()));
+    };
+    addAndMakeVisible(*presetButton_);
+
+    // ----- MOCK UI (no wiring): Native plugin programs dropdown (second header) -----
+    programsCombo_ = std::make_unique<juce::ComboBox>("Programs");
+    programsCombo_->addItem("Init Patch", 1);
+    programsCombo_->addItem("Bass Lead", 2);
+    programsCombo_->addItem("Pad", 3);
+    programsCombo_->addItem("Bell", 4);
+    programsCombo_->setSelectedId(1, juce::dontSendNotification);
+    programsCombo_->setLookAndFeel(&SmallComboBoxLookAndFeel::getInstance());
+    programsCombo_->setColour(juce::ComboBox::backgroundColourId,
+                              DarkTheme::getColour(DarkTheme::SURFACE));
+    programsCombo_->setColour(juce::ComboBox::outlineColourId,
+                              DarkTheme::getColour(DarkTheme::BORDER));
+    programsCombo_->setColour(juce::ComboBox::textColourId, DarkTheme::getTextColour());
+    addAndMakeVisible(*programsCombo_);
+
+    // ----- MOCK UI (no wiring): Vertical gain slider (above meter) + chevron toggle -----
+    gainSlider_ =
+        std::make_unique<juce::Slider>(juce::Slider::LinearVertical, juce::Slider::NoTextBox);
+    gainSlider_->setRange(-60.0, 12.0, 0.1);
+    gainSlider_->setValue(device_.gainDb, juce::dontSendNotification);
+    gainSlider_->setTooltip("Device Gain (dB)");
+    // Overlay slider on top of the meter — keep track/background transparent so
+    // the meter shows through; only the thumb is drawn.
+    gainSlider_->setLookAndFeel(&FlatGainSliderLookAndFeel::getInstance());
+    gainSlider_->setColour(juce::Slider::backgroundColourId, juce::Colours::transparentBlack);
+    gainSlider_->setColour(juce::Slider::trackColourId, juce::Colours::transparentBlack);
+    addAndMakeVisible(*gainSlider_);
+
     // Sidechain button (only visible when plugin supports sidechain)
     scButton_ = std::make_unique<juce::TextButton>("SC");
     scButton_->setColour(juce::TextButton::buttonColourId,
@@ -195,10 +277,8 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     // Multi-output routing button (only visible for multi-out plugins)
     multiOutButton_ = std::make_unique<magda::SvgButton>("MultiOut", BinaryData::multiout_svg,
                                                          BinaryData::multiout_svgSize);
-    multiOutButton_->setIconPadding(2.0f);
-    multiOutButton_->setOriginalColor(juce::Colour(0xFFB3B3B3));
-    multiOutButton_->setNormalColor(juce::Colour(0xFFB3B3B3).withAlpha(0.5f));
-    multiOutButton_->setActiveColor(juce::Colours::white);
+    applyHeaderIconStyle(*multiOutButton_, DarkTheme::getColour(DarkTheme::ACCENT_BLUE),
+                         /*toggling*/ false);
     multiOutButton_->onClick = [this]() { showMultiOutMenu(); };
     multiOutButton_->setVisible(device_.multiOut.isMultiOut);
     addAndMakeVisible(*multiOutButton_);
@@ -206,12 +286,7 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     // UI button (toggle plugin window) - open in new icon
     uiButton_ = std::make_unique<magda::SvgButton>("UI", BinaryData::open_in_new_svg,
                                                    BinaryData::open_in_new_svgSize);
-    uiButton_->setIconPadding(2.0f);
-    uiButton_->setOriginalColor(juce::Colour(0xFFB3B3B3));
-    uiButton_->setClickingTogglesState(true);
-    uiButton_->setNormalColor(juce::Colour(0xFFB3B3B3).withAlpha(0.5f));
-    uiButton_->setActiveColor(juce::Colours::white);
-    uiButton_->setActiveBackgroundColor(DarkTheme::getColour(DarkTheme::ACCENT_BLUE));
+    applyHeaderIconStyle(*uiButton_, DarkTheme::getColour(DarkTheme::ACCENT_BLUE));
     uiButton_->onClick = [this]() {
         // Get the audio bridge and toggle plugin window
         auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine();
@@ -234,12 +309,7 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     // Learn button (parameter pick mode)
     learnButton_ = std::make_unique<magda::SvgButton>("Learn", BinaryData::learn_svg,
                                                       BinaryData::learn_svgSize);
-    learnButton_->setIconPadding(2.0f);
-    learnButton_->setOriginalColor(juce::Colour(0xFFB3B3B3));
-    learnButton_->setClickingTogglesState(true);
-    learnButton_->setNormalColor(juce::Colour(0xFFB3B3B3).withAlpha(0.5f));
-    learnButton_->setActiveColor(juce::Colours::white);
-    learnButton_->setActiveBackgroundColor(DarkTheme::getColour(DarkTheme::ACCENT_ORANGE));
+    applyHeaderIconStyle(*learnButton_, DarkTheme::getColour(DarkTheme::ACCENT_ORANGE));
     learnButton_->setEnabled(false);
     learnButton_->onClick = [this]() {
         bool active = learnButton_->getToggleState();
@@ -277,11 +347,8 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     if (isStepSequencer_) {
         exportClipButton_ = std::make_unique<magda::SvgButton>("ExportClip", BinaryData::copy_svg,
                                                                BinaryData::copy_svgSize);
-        // Match the muted styling of multiOut / open-in-external buttons so it
-        // blends into the header instead of popping.
-        exportClipButton_->setOriginalColor(juce::Colour(0xFFB3B3B3));
-        exportClipButton_->setNormalColor(juce::Colour(0xFFB3B3B3).withAlpha(0.5f));
-        exportClipButton_->setActiveColor(juce::Colours::white);
+        applyHeaderIconStyle(*exportClipButton_, DarkTheme::getColour(DarkTheme::ACCENT_GREEN),
+                             /*toggling*/ false);
         exportClipButton_->setTooltip("Click to copy pattern, drag to timeline");
         exportClipButton_->addMouseListener(this, false);
         exportClipButton_->onClick = [this]() {
@@ -1422,15 +1489,39 @@ void DeviceSlotComponent::resizedContent(juce::Rectangle<int> contentArea) {
     // When collapsed, NodeComponent calls resizedCollapsed() first then resizedContent()
     // with an empty rect — so we must not touch meter visibility when collapsed.
     if (!collapsed_) {
-        auto meterBounds = contentArea.removeFromRight(METER_STRIP_WIDTH)
-                               .withTrimmedTop(CONTENT_HEADER_HEIGHT)
-                               .reduced(1, 3);
+        // Carve the FULL-width second header first so the programs dropdown
+        // can sit flush against the right edge of the panel.
+        auto secondHeaderArea = contentArea.removeFromTop(CONTENT_HEADER_HEIGHT);
+        if (programsCombo_) {
+            const bool showCombo = device_.loadState == magda::DeviceLoadState::Loaded &&
+                                   !isInternalDevice() && !isChordEngine_ && !isArpeggiator_ &&
+                                   !isStepSequencer_;
+            if (showCombo) {
+                const int comboWidth = juce::jmin(140, secondHeaderArea.getWidth() / 2);
+                programsCombo_->setBounds(
+                    secondHeaderArea.removeFromRight(comboWidth).reduced(2, 3));
+                programsCombo_->setVisible(true);
+            } else {
+                programsCombo_->setVisible(false);
+            }
+        }
+
+        // Then the meter strip lives in the area BELOW the second header.
+        auto stripBounds = contentArea.removeFromRight(METER_STRIP_WIDTH).reduced(1, 3);
         contentArea.removeFromRight(4);  // Padding between content and meter
+
         bool usesNoteStrip = isArpeggiator_ || isChordEngine_ || isStepSequencer_;
-        levelMeter_.setBounds(meterBounds);
+        levelMeter_.setBounds(stripBounds);
         levelMeter_.setVisible(!usesNoteStrip);
-        midiNoteStrip_.setBounds(meterBounds);
+        midiNoteStrip_.setBounds(stripBounds);
         midiNoteStrip_.setVisible(usesNoteStrip);
+
+        // Slider overlaid on the meter — same bounds, drawn on top, always visible.
+        if (gainSlider_) {
+            gainSlider_->setBounds(stripBounds);
+            gainSlider_->setVisible(true);
+            gainSlider_->toFront(false);
+        }
     }
 
     // Bottom padding
@@ -1440,6 +1531,13 @@ void DeviceSlotComponent::resizedContent(juce::Rectangle<int> contentArea) {
     if (collapsed_ || device_.loadState != magda::DeviceLoadState::Loaded) {
         paramGrid_->setVisible(false);
         gainLabel_.setVisible(false);
+        if (programsCombo_)
+            programsCombo_->setVisible(false);
+        if (gainSlider_)
+            gainSlider_->setVisible(false);
+        if (presetButton_)
+            presetButton_->setVisible(
+                !collapsed_);  // preset button stays in header even while loading
         if (toneGeneratorUI_)
             toneGeneratorUI_->setVisible(false);
         if (samplerUI_)
@@ -1488,8 +1586,8 @@ void DeviceSlotComponent::resizedContent(juce::Rectangle<int> contentArea) {
     onButton_->setVisible(true);
     gainLabel_.setVisible(!isChordEngine_ && !isArpeggiator_ && !isStepSequencer_);
 
-    // Content header subtitle area (all devices)
-    contentArea.removeFromTop(CONTENT_HEADER_HEIGHT);
+    // (Second header carve + programs combo placement happen in the
+    //  `if (!collapsed_)` block above so the dropdown can sit flush right.)
 
     // Check if this is an internal device with custom UI
     if (isInternalDevice() &&
@@ -1620,11 +1718,17 @@ void DeviceSlotComponent::resizedContent(juce::Rectangle<int> contentArea) {
 }
 
 void DeviceSlotComponent::resizedHeaderExtra(juce::Rectangle<int>& headerArea) {
-    // Header layout: [Macro] [M] [Name] [UI] [gain slider] [SC] [MO] [on] [X]
-    // Note: delete (X) is handled by NodeComponent on the right
+    // Header layout (visual L→R):
+    //   Plugin-hosted: [macro] [mod] [name ...]  [learn] [ui] [multiOut] [sc] [preset] [power] [X]
+    //   MIDI:          [macro] [mod?] [name ...]                       [preset] [exportClip]
+    //   [power] [X] X (delete) is owned by NodeComponent.
+    //
+    // Right→left removal order is the reverse of the visual order above.
 
-    bool isDrumGrid = drumGridUI_ != nullptr;
+    const bool isDrumGrid = drumGridUI_ != nullptr;
+    gainLabel_.setVisible(false);  // gain has moved to the meter-strip slider
 
+    // Left side: macro, mod
     if (device_.deviceType != magda::DeviceType::MIDI || isDrumGrid) {
         macroButton_->setBounds(headerArea.removeFromLeft(BUTTON_SIZE));
         headerArea.removeFromLeft(4);
@@ -1639,56 +1743,53 @@ void DeviceSlotComponent::resizedHeaderExtra(juce::Rectangle<int>& headerArea) {
         modButton_->setVisible(false);
     }
 
-    // MIDI devices: no volume/SC
-    // Right-edge order (left → right): [export clip] [power] [delete X (NodeComponent)]
-    // Power must sit immediately to the left of the delete X — clip lives to its left.
+    // place(): right→left removal of one button, with gap, only if visible.
+    auto place = [&](juce::Component* c) {
+        if (c == nullptr || !c->isVisible())
+            return;
+        c->setBounds(headerArea.removeFromRight(BUTTON_SIZE));
+        headerArea.removeFromRight(4);
+    };
+
+    // MIDI branch: preset, exportClip, power, X
     if (isChordEngine_ || isArpeggiator_ || isStepSequencer_) {
-        gainLabel_.setVisible(false);
         learnButton_->setVisible(false);
         if (scButton_)
             scButton_->setVisible(false);
-        onButton_->setBounds(headerArea.removeFromRight(BUTTON_SIZE));
-        if (exportClipButton_) {
+        if (multiOutButton_)
+            multiOutButton_->setVisible(false);
+        onButton_->setVisible(true);
+        if (presetButton_)
+            presetButton_->setVisible(true);
+        if (exportClipButton_)
             exportClipButton_->setVisible(true);
-            headerArea.removeFromRight(4);
-            exportClipButton_->setBounds(headerArea.removeFromRight(BUTTON_SIZE));
-        }
+
+        place(onButton_.get());
+        place(exportClipButton_ ? exportClipButton_.get() : nullptr);
+        place(presetButton_ ? presetButton_.get() : nullptr);
         return;
     }
 
-    // Non-MIDI devices with export clip (none currently, but keep symmetric)
-    if (exportClipButton_) {
-        exportClipButton_->setVisible(true);
-        exportClipButton_->setBounds(headerArea.removeFromRight(BUTTON_SIZE));
-        headerArea.removeFromRight(4);
-    }
+    // Non-MIDI: ui, learn, sc, multiOut, preset, power, X
+    if (exportClipButton_)
+        exportClipButton_->setVisible(false);
 
-    // Set conditional button visibility before calling shared layout
-    // DrumGrid: hide SC button (manages its own MIDI internally) and gain slider (per-pad level)
     if (scButton_)
         scButton_->setVisible(!isDrumGrid && (device_.canSidechain || device_.canReceiveMidi));
     if (multiOutButton_)
         multiOutButton_->setVisible(device_.multiOut.isMultiOut);
-    if (isDrumGrid)
-        gainLabel_.setVisible(false);
-
-    // Learn button: visible only for external plugins (not internal/MIDI devices)
     learnButton_->setVisible(!isInternalDevice());
+    onButton_->setVisible(true);
+    uiButton_->setVisible(!isInternalDevice());
+    if (presetButton_)
+        presetButton_->setVisible(true);
 
-    layoutDeviceSlotHeaderRight(headerArea, BUTTON_SIZE, 4,
-                                /*delete*/ nullptr,
-                                /*power*/ onButton_.get(),
-                                /*multiOut*/ multiOutButton_ ? multiOutButton_.get() : nullptr,
-                                /*sc*/ scButton_ ? scButton_.get() : nullptr,
-                                /*slider*/ isDrumGrid ? nullptr : &gainLabel_, 70,
-                                /*ui*/ uiButton_.get());
-
-    // Place learn button to the left of the UI button (headerArea still has remaining central
-    // space)
-    if (learnButton_->isVisible()) {
-        learnButton_->setBounds(headerArea.removeFromRight(BUTTON_SIZE));
-        headerArea.removeFromRight(4);
-    }
+    place(onButton_.get());
+    place(presetButton_ ? presetButton_.get() : nullptr);
+    place(scButton_ ? scButton_.get() : nullptr);
+    place(multiOutButton_ ? multiOutButton_.get() : nullptr);
+    place(uiButton_.get());
+    place(learnButton_.get());
 }
 
 void DeviceSlotComponent::mouseDrag(const juce::MouseEvent& e) {

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -18,6 +18,7 @@
 #include "core/MidiFileWriter.hpp"
 #include "core/ModInfo.hpp"
 #include "core/ParameterUtils.hpp"
+#include "core/PresetManager.hpp"
 #include "core/SelectionManager.hpp"
 #include "core/TrackCommands.hpp"
 #include "core/TrackManager.hpp"
@@ -243,17 +244,47 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     // ----- MOCK UI (no wiring): MAGDA preset menu button (top header) -----
     presetButton_ = std::make_unique<magda::SvgButton>("Presets", BinaryData::preset_svg,
                                                        BinaryData::preset_svgSize);
-    applyHeaderIconStyle(*presetButton_, DarkTheme::getColour(DarkTheme::ACCENT_PURPLE),
+    // Indigo sits between ACCENT_BLUE and ACCENT_PURPLE — distinct from both
+    // utility blue (ui/multiOut) and macro purple, signals "MAGDA presets".
+    constexpr juce::uint32 PRESET_INDIGO = 0xFF5577CC;
+    applyHeaderIconStyle(*presetButton_, juce::Colour(PRESET_INDIGO),
                          /*toggling*/ false);
+    // Permanent "active" treatment: indigo pill + white icon. Using setActive()
+    // (not normalBackgroundColor) so hover/pressed don't wipe out the pill —
+    // the active branch wins first in SvgButton's paint priority.
+    presetButton_->setActive(true);
+    // Larger inner padding shrinks the icon glyph while leaving the pill at
+    // full button size.
+    presetButton_->setIconPadding(4.5f);
     presetButton_->setTooltip("MAGDA Presets");
     presetButton_->onClick = [this]() {
+        auto& pm = magda::PresetManager::getInstance();
+        const auto presets = pm.getDevicePresets();
+
         juce::PopupMenu menu;
         menu.addSectionHeader("MAGDA Presets");
-        menu.addItem(1, "(no presets yet)", false);
+        if (presets.isEmpty()) {
+            menu.addItem(1, "(no presets yet)", /*isActive*/ false);
+        } else {
+            // Load is wired in task 3 — for now items are visible-only so the
+            // user can confirm saves landed on disk.
+            int id = 100;
+            for (const auto& name : presets)
+                menu.addItem(id++, name, /*isActive*/ false);
+        }
         menu.addSeparator();
         menu.addItem(2, "Save as MAGDA Preset...");
         menu.addItem(3, "Reveal in Finder");
-        menu.showMenuAsync(juce::PopupMenu::Options().withTargetComponent(presetButton_.get()));
+
+        menu.showMenuAsync(
+            juce::PopupMenu::Options().withTargetComponent(presetButton_.get()),
+            [this](int chosen) {
+                if (chosen == 2) {
+                    showSaveMagdaPresetDialog();
+                } else if (chosen == 3) {
+                    magda::PresetManager::getInstance().getDevicesDirectory().revealToUser();
+                }
+            });
     };
     addAndMakeVisible(*presetButton_);
 
@@ -1204,6 +1235,34 @@ int DeviceSlotComponent::getPreferredWidth() const {
         return getTotalWidth(drumGridUI_->getPreferredContentWidth()) + meterExtra;
     }
     return getTotalWidth(getDynamicSlotWidth()) + meterExtra;
+}
+
+void DeviceSlotComponent::showSaveMagdaPresetDialog() {
+    auto* aw = new juce::AlertWindow("Save MAGDA Preset", "Enter a name for this device preset:",
+                                     juce::MessageBoxIconType::NoIcon);
+    aw->addTextEditor("name", device_.name, "Name:");
+    aw->addButton("Save", 1, juce::KeyPress(juce::KeyPress::returnKey));
+    aw->addButton("Cancel", 0, juce::KeyPress(juce::KeyPress::escapeKey));
+
+    const auto deviceCopy = device_;  // capture by value — async callback
+    aw->enterModalState(true, juce::ModalCallbackFunction::create([aw, deviceCopy](int result) {
+                            if (result == 1) {
+                                auto name = aw->getTextEditorContents("name").trim();
+                                if (name.isNotEmpty()) {
+                                    auto& pm = magda::PresetManager::getInstance();
+                                    if (!pm.saveDevicePreset(deviceCopy, name)) {
+                                        juce::AlertWindow::showAsync(
+                                            juce::MessageBoxOptions()
+                                                .withIconType(juce::MessageBoxIconType::WarningIcon)
+                                                .withTitle("Save Preset Failed")
+                                                .withMessage(pm.getLastError())
+                                                .withButton("OK"),
+                                            nullptr);
+                                    }
+                                }
+                            }
+                            delete aw;
+                        }));
 }
 
 void DeviceSlotComponent::refreshProgramsCombo() {

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
@@ -288,6 +288,10 @@ class DeviceSlotComponent : public NodeComponent,
     bool hasAutomapBindings_ = false;  // Any DeviceMacro binding targets this device
     void refreshControllerIndicators();
 
+    // Plugin programs combo helpers
+    void refreshProgramsCombo();        // full re-populate (item list + selection)
+    void syncProgramsComboSelection();  // selection-only, cheap, called from timer
+
     void updateParamModulation();  // Update mod/macro pointers for params
     void updateParameterSlots();   // Reload parameter data for current page
     void updateParameterValues();  // Update only parameter values (for polling)

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
@@ -292,6 +292,9 @@ class DeviceSlotComponent : public NodeComponent,
     void refreshProgramsCombo();        // full re-populate (item list + selection)
     void syncProgramsComboSelection();  // selection-only, cheap, called from timer
 
+    // MAGDA preset dialogs
+    void showSaveMagdaPresetDialog();
+
     void updateParamModulation();  // Update mod/macro pointers for params
     void updateParameterSlots();   // Reload parameter data for current page
     void updateParameterValues();  // Update only parameter values (for polling)

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
@@ -68,10 +68,10 @@ class DeviceSlotComponent : public NodeComponent,
     static constexpr int BASE_SLOT_WIDTH = 450;  // Maximum width (8 columns)
     static constexpr int NUM_PARAMS_PER_PAGE = 32;
     static constexpr int PARAMS_PER_ROW = 8;  // Maximum columns
-    static constexpr int PARAM_CELL_WIDTH = 48;
+    static constexpr int PARAM_CELL_WIDTH = 54;
     static constexpr int PARAM_CELL_HEIGHT = 24;
     static constexpr int PAGINATION_HEIGHT = 18;
-    static constexpr int CONTENT_HEADER_HEIGHT = 18;
+    static constexpr int CONTENT_HEADER_HEIGHT = 26;
     DeviceSlotComponent(const magda::DeviceInfo& device);
     ~DeviceSlotComponent() override;
 
@@ -266,9 +266,16 @@ class DeviceSlotComponent : public NodeComponent,
     std::unique_ptr<ArpeggiatorUI> arpeggiatorUI_;
     std::unique_ptr<StepSequencerUI> stepSequencerUI_;
 
-    static constexpr int METER_STRIP_WIDTH = 10;
+    static constexpr int METER_STRIP_WIDTH = 18;  // wide enough for slider thumb overlay
     magda::LevelMeter levelMeter_;
     magda::MidiNoteStrip midiNoteStrip_;
+
+    // MAGDA preset menu button (lives in top header, replaces gainLabel_ slot)
+    std::unique_ptr<magda::SvgButton> presetButton_;
+    // Native plugin programs dropdown (lives in second/content header, plugin-hosted only)
+    std::unique_ptr<juce::ComboBox> programsCombo_;
+    // Vertical gain slider overlaid on the meter
+    std::unique_ptr<juce::Slider> gainSlider_;
     daw::audio::ArpeggiatorPlugin* arpPlugin_ = nullptr;
     daw::audio::StepSequencerPlugin* stepSeqPlugin_ = nullptr;
     int lastArpNote_ = -1;

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
@@ -292,8 +292,19 @@ class DeviceSlotComponent : public NodeComponent,
     void refreshProgramsCombo();        // full re-populate (item list + selection)
     void syncProgramsComboSelection();  // selection-only, cheap, called from timer
 
-    // MAGDA preset dialogs
+    // MAGDA preset dialogs / actions
+    void showPresetMenu();
     void showSaveMagdaPresetDialog();
+    void saveCurrentMagdaPreset();  // overwrite currentPresetName_
+    void loadMagdaPreset(const juce::String& presetRelativePath);
+    // Trigger PluginManager::capturePluginState and return a fresh DeviceInfo
+    // copy from TrackManager — used as the source-of-truth for a save.
+    magda::DeviceInfo snapshotForPreset();
+
+    // Name of the .mps file last loaded (or saved-as) on this device.
+    // Empty until the user touches the preset surface; cleared when the
+    // device's pluginId changes (different plugin loaded into the slot).
+    juce::String currentPresetName_;
 
     void updateParamModulation();  // Update mod/macro pointers for params
     void updateParameterSlots();   // Reload parameter data for current page

--- a/magda/daw/ui/components/mixer/LevelMeter.hpp
+++ b/magda/daw/ui/components/mixer/LevelMeter.hpp
@@ -55,6 +55,12 @@ class LevelMeter : public juce::Component, private juce::Timer {
         return std::max(displayLeftLevel_, displayRightLevel_);
     }
 
+    /** Highest peak-hold value across L/R channels, in dB.
+     *  Returns MIN_DB (~-60) when there has been no signal. */
+    float getPeakDb() const {
+        return std::max(peakLeftDb_, peakRightDb_);
+    }
+
     void paint(juce::Graphics& g) override {
         auto effectiveBounds = getLocalBounds().toFloat();
 


### PR DESCRIPTION
## Summary
- Closes the save/load half of #182 — `.mps` device preset format with per-plugin folders and nested submenus
- Device header redesign: gain moves to a vertical fader overlaid on the meter, second header bumped + plugin-programs dropdown, MAGDA preset menu in the freed top-header slot
- Harmonised all device-header SvgButtons via shared style helper; reordered to `[learn] [ui] [multiOut] [sc] [preset] [power] [X]`

## What's wired
- **Save** as `.mps` (pretty JSON, `{ magdaVersion, kind, payload }` envelope, `serializeDeviceInfo` payload). Captures fresh plugin state before snapshot via `PluginManager::capturePluginState`.
- **Save / Save as / overwrite confirmation** — "Save" overwrites the currently-loaded preset; "Save as" prompts and asks before overwriting an existing name.
- **Load** via `TrackManager::applyDevicePreset` — copies state-y fields onto the live `DeviceInfo`, pushes `pluginState` to the running plugin (external via `ext->state` + restore; internal via `parseXML` + `restorePluginStateFromValueTree`), notifies per-param listeners, and triggers `updateFromDevice` on the slot so custom UIs (FourOscUI etc.) re-read plugin state.
- **Per-plugin folders** — presets live at `Devices/<plugin name>/[<subfolder>/]<preset>.mps`. Cross-plugin contamination eliminated. Forward slashes in the name nest immediately.
- **Recursive submenu** in the preset popup — directories first then files, alphabetical within each.
- **Gain slider** wired to `setDeviceGainDb`; double-click resets to 0 dB; tooltip shows live `Gain` + meter peak (`Gain: -3.0 dB    Peak: -12.4 dB`).
- **Plugin programs combo** wired to `juce::AudioPluginInstance::getProgramName / setCurrentProgram` via new `AudioBridge::getPluginNumPrograms / getPluginProgramName / setPluginCurrentProgram`. Auto-hidden when `numPrograms <= 1` (most modern VST3s).

## Visual changes
- `CONTENT_HEADER_HEIGHT` 18 → 26 (room for the programs combo)
- `PARAM_CELL_WIDTH` 48 → 54 (more room for the parameter values)
- `METER_STRIP_WIDTH` 10 → 18 with the slider thumb overlaid (transparent track, flat thin bar in `DarkTheme::getSecondaryTextColour`)
- Preset button: indigo (`#5577CC`) pill with white folder icon, permanently `setActive(true)` so hover/press don't strip the colour

## Known limitations
- Plugin programs combo works for plugins that expose meaningful programs; modern VST3s mostly don't — #1118 tracks disk-based `.vstpreset` scanning as the real fix
- Macros and mods aren't currently re-applied through `applyDevicePreset` — only the params/state/gain. Loaded preset's modulation links restore via `pluginState` only if the plugin owns them; MAGDA-side macros/mods need explicit handling — follow-up.
- Old flat `.mps` files in `Devices/` (top-level, no plugin folder) become invisible in the menu under the new structure. Move them into the matching plugin folder or trash them.

## Related
- #1120 — AI device-preset agent (consumes `.mps`; will benefit from per-plugin folders for organising generated output)
- #1121 — Wire plugin-parameter aliases end-to-end in the AI Console
- #1118 — Disk-based plugin preset scanning (`.vstpreset` / `.aupreset`)

## Test plan
- [ ] Save a device preset (4-OSC and a VST plugin), verify `.mps` lands at `~/Documents/MAGDA/Presets/Devices/<plugin>/<name>.mps`
- [ ] Open the JSON, confirm envelope + payload shape
- [ ] Load the preset back: sound restores AND UI (waveform pickers, params) reflects the saved state
- [ ] "Save" overwrites the loaded preset silently; "Save as" with existing name asks to overwrite
- [ ] Forward slashes in save name nest into subfolders; menu shows them as nested submenus
- [ ] Loading a preset for plugin A onto a slot now holding plugin B is rejected with a clear error
- [ ] Replace a device's plugin → loaded-preset reference clears
- [ ] Gain slider drags update the audio; double-click resets; tooltip reads gain + peak
- [ ] Plugin programs combo: loads a program when the plugin exposes >1; hidden otherwise
- [ ] Reveal in Finder opens the plugin's folder
- [ ] No regressions on MIDI devices (chord engine / arpeggiator / step sequencer header order)