### PR TITLE
feat(scripting): embed Lua 5.4 runtime + sandbox (#29)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,10 +147,22 @@ if(MAGDA_BUILD_TESTS)
     FetchContent_MakeAvailable(Catch2)
 endif()
 
+# Lua 5.4 — embedded scripting runtime (issue #29).
+# Lua's official source distribution ships no CMakeLists.txt, so
+# FetchContent_MakeAvailable just populates lua_SOURCE_DIR; the actual
+# static library is built by magda/scripting/CMakeLists.txt.
+FetchContent_Declare(
+    lua
+    URL https://www.lua.org/ftp/lua-5.4.7.tar.gz
+    URL_HASH SHA256=9fbf5e28ef86c69858f6d3d34eccc32e911c1a28b4120ff3e84aaa70cfbf1e30
+)
+FetchContent_MakeAvailable(lua)
+
 # Simple agent system - no external dependencies needed
 
 # Product-based subdirectories
 add_subdirectory(magda/daw)
+add_subdirectory(magda/scripting)
 add_subdirectory(magda/agents)
 
 # Examples

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,23 @@
-# Examples will be added here later
-# For now, this is just a placeholder to satisfy CMake
+# Examples - small standalone binaries that exercise individual modules.
 
-message(STATUS "Examples directory - placeholder for future examples")
+# lua_smoke — interactive REPL / script runner for issue #29 verification.
+# Useful for poking at the sandbox and print()-redirect before bindings (#30)
+# and controller scripting (#592) land.
+add_executable(lua_smoke lua_smoke.cpp)
+
+target_link_libraries(lua_smoke
+    PRIVATE
+    magda_scripting
+    juce::juce_core
+)
+
+target_include_directories(lua_smoke
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}
+)
+
+set_target_properties(lua_smoke PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+)

--- a/examples/lua_smoke.cpp
+++ b/examples/lua_smoke.cpp
@@ -1,0 +1,62 @@
+// lua_smoke — interactive smoke test for the embedded Lua runtime (#29).
+//
+// Usage:
+//   lua_smoke                  → REPL on stdin (blank line / EOF to quit)
+//   lua_smoke script.lua       → run script.lua and exit
+//
+// Verifies end-to-end: stdlib opened, sandbox applied, print() routed to
+// juce::Logger, errors carry tracebacks. No DAW dependencies.
+
+#include "magda/scripting/LuaRuntime.hpp"
+
+#include <juce_core/juce_core.h>
+
+#include <iostream>
+#include <string>
+
+namespace {
+
+class StdoutLogger : public juce::Logger {
+public:
+    void logMessage(const juce::String& message) override {
+        std::cout << message.toRawUTF8() << '\n';
+    }
+};
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    StdoutLogger logger;
+    juce::Logger::setCurrentLogger(&logger);
+
+    magda::scripting::LuaRuntime rt;
+
+    if (argc == 2) {
+        juce::File scriptFile(juce::String::fromUTF8(argv[1]));
+        bool ok = rt.evalFile(scriptFile);
+        if (!ok)
+            std::cerr << "! " << rt.lastError().toRawUTF8() << '\n';
+        juce::Logger::setCurrentLogger(nullptr);
+        return ok ? 0 : 1;
+    }
+
+    std::cout << "MAGDA Lua smoke REPL — Lua 5.4 with sandbox.\n"
+                 "  print(os.execute('ls'))   -- sandboxed away\n"
+                 "  print(math.floor(3.7))    -- stdlib stays\n"
+                 "  Blank line or EOF to quit.\n";
+
+    std::string line;
+    for (;;) {
+        std::cout << "> " << std::flush;
+        if (!std::getline(std::cin, line))
+            break;
+        if (line.empty())
+            break;
+        juce::String chunk = juce::String::fromUTF8(line.c_str());
+        if (!rt.eval(chunk, "=stdin"))
+            std::cerr << "! " << rt.lastError().toRawUTF8() << '\n';
+    }
+
+    juce::Logger::setCurrentLogger(nullptr);
+    return 0;
+}

--- a/magda/scripting/CMakeLists.txt
+++ b/magda/scripting/CMakeLists.txt
@@ -1,0 +1,115 @@
+# Scripting - Embedded Lua runtime for MAGDA
+#
+# This module owns the embedded Lua VM. It is intentionally free of any
+# MagdaApi / DAW dependencies in this branch — issue #29 only.
+# The MagdaApi bindings (#30) and MIDI controller scripting (#592)
+# will land in follow-up branches that can depend on this lib.
+
+# ---------------------------------------------------------------------------
+# Lua 5.4 static library — fetched in the root CMakeLists.txt.
+# Lua's official source distribution does not ship a CMake build, so we
+# compile the .c files directly.
+# ---------------------------------------------------------------------------
+
+set(LUA_SRC_DIR "${lua_SOURCE_DIR}/src")
+
+set(LUA_CORE_SOURCES
+    ${LUA_SRC_DIR}/lapi.c
+    ${LUA_SRC_DIR}/lauxlib.c
+    ${LUA_SRC_DIR}/lbaselib.c
+    ${LUA_SRC_DIR}/lcode.c
+    ${LUA_SRC_DIR}/lcorolib.c
+    ${LUA_SRC_DIR}/lctype.c
+    ${LUA_SRC_DIR}/ldblib.c
+    ${LUA_SRC_DIR}/ldebug.c
+    ${LUA_SRC_DIR}/ldo.c
+    ${LUA_SRC_DIR}/ldump.c
+    ${LUA_SRC_DIR}/lfunc.c
+    ${LUA_SRC_DIR}/lgc.c
+    ${LUA_SRC_DIR}/linit.c
+    ${LUA_SRC_DIR}/liolib.c
+    ${LUA_SRC_DIR}/llex.c
+    ${LUA_SRC_DIR}/lmathlib.c
+    ${LUA_SRC_DIR}/lmem.c
+    ${LUA_SRC_DIR}/loadlib.c
+    ${LUA_SRC_DIR}/lobject.c
+    ${LUA_SRC_DIR}/lopcodes.c
+    ${LUA_SRC_DIR}/loslib.c
+    ${LUA_SRC_DIR}/lparser.c
+    ${LUA_SRC_DIR}/lstate.c
+    ${LUA_SRC_DIR}/lstring.c
+    ${LUA_SRC_DIR}/lstrlib.c
+    ${LUA_SRC_DIR}/ltable.c
+    ${LUA_SRC_DIR}/ltablib.c
+    ${LUA_SRC_DIR}/ltm.c
+    ${LUA_SRC_DIR}/lundump.c
+    ${LUA_SRC_DIR}/lutf8lib.c
+    ${LUA_SRC_DIR}/lvm.c
+    ${LUA_SRC_DIR}/lzio.c
+)
+
+add_library(lua_static STATIC ${LUA_CORE_SOURCES})
+
+target_include_directories(lua_static
+    PUBLIC
+    ${LUA_SRC_DIR}
+)
+
+# Lua compiles as C; tell it which platform features are available so the
+# stdlib (loadlib, os.execute, etc.) link properly. We will sandbox these at
+# runtime, but the symbols still need to resolve.
+if(APPLE)
+    target_compile_definitions(lua_static PRIVATE LUA_USE_MACOSX)
+elseif(UNIX)
+    target_compile_definitions(lua_static PRIVATE LUA_USE_LINUX)
+endif()
+
+# Suppress warnings from Lua's source; this is third-party code and the
+# project's -Wall -Wextra -Wpedantic flags trigger many false positives in it.
+if(MSVC)
+    target_compile_options(lua_static PRIVATE /w)
+else()
+    target_compile_options(lua_static PRIVATE -w)
+endif()
+
+set_target_properties(lua_static PROPERTIES
+    C_STANDARD 99
+    C_STANDARD_REQUIRED ON
+    POSITION_INDEPENDENT_CODE ON
+)
+
+# ---------------------------------------------------------------------------
+# magda_scripting — thin C++ wrapper exposing LuaRuntime + LuaSandbox.
+# ---------------------------------------------------------------------------
+
+set(MAGDA_SCRIPTING_SOURCES
+    LuaRuntime.hpp
+    LuaRuntime.cpp
+    LuaSandbox.hpp
+    LuaSandbox.cpp
+)
+
+add_library(magda_scripting STATIC ${MAGDA_SCRIPTING_SOURCES})
+
+target_link_libraries(magda_scripting
+    PUBLIC
+    lua_static
+    juce::juce_core
+)
+
+target_include_directories(magda_scripting
+    PUBLIC
+    ${CMAKE_SOURCE_DIR}
+)
+
+set_target_properties(magda_scripting PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+)
+
+if(MSVC)
+    target_compile_options(magda_scripting PRIVATE /W4)
+else()
+    target_compile_options(magda_scripting PRIVATE -Wall -Wextra -Wpedantic)
+endif()

--- a/magda/scripting/LuaRuntime.cpp
+++ b/magda/scripting/LuaRuntime.cpp
@@ -1,0 +1,225 @@
+#include "magda/scripting/LuaRuntime.hpp"
+
+#include "magda/scripting/LuaSandbox.hpp"
+
+extern "C" {
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+}
+
+#include <cstddef>
+#include <utility>
+
+namespace magda::scripting {
+
+namespace {
+
+// Replacement for Lua's default print(): forwards to juce::Logger.
+// Mirrors the formatting of the stock implementation in lbaselib.c — coerces
+// each argument with tostring(), separates with tabs, and emits a single line.
+int luaPrintToLogger(lua_State* L) {
+    int n = lua_gettop(L);
+    juce::String line;
+    for (int i = 1; i <= n; ++i) {
+        size_t len = 0;
+        const char* s = luaL_tolstring(L, i, &len);  // pushes converted string
+        if (i > 1)
+            line << '\t';
+        line << juce::String::fromUTF8(s, static_cast<int>(len));
+        lua_pop(L, 1);  // pop converted string
+    }
+    juce::Logger::writeToLog(line);
+    return 0;
+}
+
+// Message handler installed for lua_pcall — appends a traceback so error
+// messages report the exact line in user code instead of just the bottom of
+// the call stack.
+int errorMessageHandler(lua_State* L) {
+    const char* msg = lua_tostring(L, 1);
+    if (msg == nullptr) {
+        if (luaL_callmeta(L, 1, "__tostring") && lua_type(L, -1) == LUA_TSTRING)
+            return 1;
+        msg = lua_pushfstring(L, "(error object is a %s value)", luaL_typename(L, 1));
+    }
+    luaL_traceback(L, L, msg, 1);
+    return 1;
+}
+
+bool runChunk(lua_State* L, juce::String& errorOut) {
+    // Stack: [ ..., chunk ]
+    int base = lua_gettop(L);                 // index of the chunk function
+    lua_pushcfunction(L, errorMessageHandler);
+    lua_insert(L, base);                      // move handler below the chunk
+    int rc = lua_pcall(L, 0, 0, base);        // 0 args, 0 results, handler at `base`
+    lua_remove(L, base);                      // remove handler
+    if (rc != LUA_OK) {
+        size_t len = 0;
+        const char* msg = lua_tolstring(L, -1, &len);
+        errorOut = msg ? juce::String::fromUTF8(msg, static_cast<int>(len))
+                       : juce::String("(unknown Lua error)");
+        lua_pop(L, 1);
+        return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+LuaRuntime::LuaRuntime()
+    : L_(luaL_newstate()) {
+    if (L_ == nullptr) {
+        // Out of memory at startup — extremely unlikely. Leave L_ null;
+        // every subsequent call short-circuits via the null check.
+        lastError_ = "luaL_newstate returned null";
+        return;
+    }
+
+    luaL_openlibs(L_);
+    applySandbox(L_);
+
+    // Replace print() with our logger-forwarding version.
+    lua_pushcfunction(L_, luaPrintToLogger);
+    lua_setglobal(L_, "print");
+}
+
+LuaRuntime::~LuaRuntime() {
+    if (L_ != nullptr)
+        lua_close(L_);
+}
+
+LuaRuntime::LuaRuntime(LuaRuntime&& other) noexcept
+    : L_(std::exchange(other.L_, nullptr)),
+      lastError_(std::move(other.lastError_)) {}
+
+LuaRuntime& LuaRuntime::operator=(LuaRuntime&& other) noexcept {
+    if (this != &other) {
+        if (L_ != nullptr)
+            lua_close(L_);
+        L_ = std::exchange(other.L_, nullptr);
+        lastError_ = std::move(other.lastError_);
+    }
+    return *this;
+}
+
+bool LuaRuntime::eval(const juce::String& chunk, const juce::String& chunkName) {
+    if (L_ == nullptr)
+        return false;
+
+    lastError_ = {};
+    auto chunkUtf8 = chunk.toRawUTF8();
+    auto nameUtf8 = chunkName.toRawUTF8();
+    auto chunkLen = static_cast<std::size_t>(chunk.getNumBytesAsUTF8());
+
+    int rc = luaL_loadbuffer(L_, chunkUtf8, chunkLen, nameUtf8);
+    if (rc != LUA_OK) {
+        size_t len = 0;
+        const char* msg = lua_tolstring(L_, -1, &len);
+        lastError_ = msg ? juce::String::fromUTF8(msg, static_cast<int>(len))
+                         : juce::String("(unknown Lua load error)");
+        lua_pop(L_, 1);
+        return false;
+    }
+
+    return runChunk(L_, lastError_);
+}
+
+bool LuaRuntime::evalFile(const juce::File& file) {
+    if (!file.existsAsFile()) {
+        lastError_ = "File does not exist: " + file.getFullPathName();
+        return false;
+    }
+    juce::String contents = file.loadFileAsString();
+    juce::String chunkName = "@" + file.getFullPathName();
+    return eval(contents, chunkName);
+}
+
+std::optional<long long> LuaRuntime::evalToInt(const juce::String& chunk) {
+    if (L_ == nullptr)
+        return std::nullopt;
+
+    // Wrap as `return (chunk)` so the value lands on the stack.
+    juce::String wrapped = "return (" + chunk + ")";
+    lastError_ = {};
+
+    auto src = wrapped.toRawUTF8();
+    auto srcLen = static_cast<std::size_t>(wrapped.getNumBytesAsUTF8());
+    if (luaL_loadbuffer(L_, src, srcLen, "=eval") != LUA_OK) {
+        size_t len = 0;
+        const char* msg = lua_tolstring(L_, -1, &len);
+        lastError_ = msg ? juce::String::fromUTF8(msg, static_cast<int>(len))
+                         : juce::String("(unknown Lua load error)");
+        lua_pop(L_, 1);
+        return std::nullopt;
+    }
+
+    int base = lua_gettop(L_);
+    lua_pushcfunction(L_, errorMessageHandler);
+    lua_insert(L_, base);
+    int rc = lua_pcall(L_, 0, 1, base);
+    lua_remove(L_, base);
+    if (rc != LUA_OK) {
+        size_t len = 0;
+        const char* msg = lua_tolstring(L_, -1, &len);
+        lastError_ = msg ? juce::String::fromUTF8(msg, static_cast<int>(len))
+                         : juce::String("(unknown Lua runtime error)");
+        lua_pop(L_, 1);
+        return std::nullopt;
+    }
+
+    if (!lua_isinteger(L_, -1)) {
+        lua_pop(L_, 1);
+        lastError_ = "result is not an integer";
+        return std::nullopt;
+    }
+    long long result = static_cast<long long>(lua_tointeger(L_, -1));
+    lua_pop(L_, 1);
+    return result;
+}
+
+std::optional<juce::String> LuaRuntime::evalToString(const juce::String& chunk) {
+    if (L_ == nullptr)
+        return std::nullopt;
+
+    juce::String wrapped = "return (" + chunk + ")";
+    lastError_ = {};
+
+    auto src = wrapped.toRawUTF8();
+    auto srcLen = static_cast<std::size_t>(wrapped.getNumBytesAsUTF8());
+    if (luaL_loadbuffer(L_, src, srcLen, "=eval") != LUA_OK) {
+        size_t len = 0;
+        const char* msg = lua_tolstring(L_, -1, &len);
+        lastError_ = msg ? juce::String::fromUTF8(msg, static_cast<int>(len))
+                         : juce::String("(unknown Lua load error)");
+        lua_pop(L_, 1);
+        return std::nullopt;
+    }
+
+    int base = lua_gettop(L_);
+    lua_pushcfunction(L_, errorMessageHandler);
+    lua_insert(L_, base);
+    int rc = lua_pcall(L_, 0, 1, base);
+    lua_remove(L_, base);
+    if (rc != LUA_OK) {
+        size_t len = 0;
+        const char* msg = lua_tolstring(L_, -1, &len);
+        lastError_ = msg ? juce::String::fromUTF8(msg, static_cast<int>(len))
+                         : juce::String("(unknown Lua runtime error)");
+        lua_pop(L_, 1);
+        return std::nullopt;
+    }
+
+    if (lua_type(L_, -1) != LUA_TSTRING) {
+        lua_pop(L_, 1);
+        lastError_ = "result is not a string";
+        return std::nullopt;
+    }
+    size_t len = 0;
+    const char* s = lua_tolstring(L_, -1, &len);
+    juce::String result = juce::String::fromUTF8(s, static_cast<int>(len));
+    lua_pop(L_, 1);
+    return result;
+}
+
+}  // namespace magda::scripting

--- a/magda/scripting/LuaRuntime.hpp
+++ b/magda/scripting/LuaRuntime.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <optional>
+#include <string>
+
+extern "C" {
+struct lua_State;
+}
+
+namespace magda::scripting {
+
+/**
+ * Owns a Lua 5.4 VM. RAII: constructor opens stdlib + applies the sandbox +
+ * redirects print() to juce::Logger; destructor closes the state.
+ *
+ * Threading: not thread-safe. A LuaRuntime instance must be used from a single
+ * thread (typically the JUCE message thread). #592 will rely on this when
+ * draining MIDI events on the message thread before calling into Lua.
+ */
+class LuaRuntime {
+public:
+    LuaRuntime();
+    ~LuaRuntime();
+
+    LuaRuntime(const LuaRuntime&) = delete;
+    LuaRuntime& operator=(const LuaRuntime&) = delete;
+    LuaRuntime(LuaRuntime&&) noexcept;
+    LuaRuntime& operator=(LuaRuntime&&) noexcept;
+
+    /** Compile and execute `chunk`. Returns true on success.
+     *  On failure, lastError() returns the message (with line numbers).
+     *  `chunkName` is the source label used in error messages — pass a path
+     *  like "@/path/to/script.lua" when evaluating from a file. */
+    bool eval(const juce::String& chunk, const juce::String& chunkName = "=chunk");
+
+    /** Read `file` and evaluate its contents. */
+    bool evalFile(const juce::File& file);
+
+    /** Evaluate `chunk` and return the first result coerced to integer.
+     *  Returns std::nullopt on eval failure or if the result is not an integer. */
+    std::optional<long long> evalToInt(const juce::String& chunk);
+
+    /** Evaluate `chunk` and return the first result coerced to string.
+     *  Returns std::nullopt on eval failure or if the result is not a string. */
+    std::optional<juce::String> evalToString(const juce::String& chunk);
+
+    /** Last error message captured by eval/evalFile, or empty if the last call
+     *  succeeded (or no call has been made). */
+    const juce::String& lastError() const noexcept { return lastError_; }
+
+    /** Raw VM access — for binding code in #30 and beyond.
+     *  Returns nullptr only if this instance has been moved-from. */
+    lua_State* state() noexcept { return L_; }
+
+private:
+    lua_State* L_ = nullptr;
+    juce::String lastError_;
+};
+
+}  // namespace magda::scripting

--- a/magda/scripting/LuaSandbox.cpp
+++ b/magda/scripting/LuaSandbox.cpp
@@ -1,0 +1,97 @@
+#include "magda/scripting/LuaSandbox.hpp"
+
+extern "C" {
+#include <lauxlib.h>
+#include <lua.h>
+}
+
+#include <string>
+
+namespace magda::scripting {
+
+namespace {
+
+// C closure: raises a descriptive error using the name passed as upvalue 1.
+// Used both as a stand-in for blocked function globals (dofile, os.execute)
+// and as the __index/__newindex/__call handler on blocked global tables (io,
+// package, debug) — so any access to a blocked thing produces a clear
+// message instead of "attempt to call/index a nil value".
+int sandboxBlocker(lua_State* L) {
+    const char* name = lua_tostring(L, lua_upvalueindex(1));
+    return luaL_error(L,
+                      "'%s' is disabled in the MAGDA Lua sandbox",
+                      name != nullptr ? name : "(unknown)");
+}
+
+// _G[name] = function() error("...") end
+void blockGlobalCall(lua_State* L, const char* name) {
+    lua_pushstring(L, name);
+    lua_pushcclosure(L, sandboxBlocker, 1);
+    lua_setglobal(L, name);
+}
+
+// os[field] = function() error("...") end  (with name "os.field")
+void blockOsField(lua_State* L, const char* field) {
+    lua_getglobal(L, "os");
+    if (lua_type(L, -1) != LUA_TTABLE) {
+        lua_pop(L, 1);
+        return;
+    }
+    std::string full = std::string("os.") + field;
+    lua_pushstring(L, full.c_str());
+    lua_pushcclosure(L, sandboxBlocker, 1);
+    lua_setfield(L, -2, field);
+    lua_pop(L, 1);
+}
+
+// _G[name] = setmetatable({}, { __index = blocker, __newindex = blocker,
+//                                __call = blocker, __metatable = false })
+// Any read, write, or call on the table errors with a sandbox message.
+// The metatable is locked so user code can't strip it via setmetatable.
+void blockGlobalTable(lua_State* L, const char* name) {
+    lua_newtable(L);  // the empty stub table
+    lua_newtable(L);  // its metatable
+
+    // Stack on entry: [stub_table, metatable]. After pushstring + pushcclosure
+    // we have [stub_table, metatable, closure] so the metatable is at -2.
+    for (const char* meta : {"__index", "__newindex", "__call"}) {
+        lua_pushstring(L, name);
+        lua_pushcclosure(L, sandboxBlocker, 1);
+        lua_setfield(L, -2, meta);
+    }
+
+    lua_pushboolean(L, 0);
+    lua_setfield(L, -2, "__metatable");
+
+    lua_setmetatable(L, -2);
+    lua_setglobal(L, name);
+}
+
+}  // namespace
+
+void applySandbox(lua_State* L) {
+    // Chunk loaders — the host loads scripts via the C API directly; user
+    // code has no business compiling more code at runtime.
+    blockGlobalCall(L, "dofile");
+    blockGlobalCall(L, "loadfile");
+    blockGlobalCall(L, "load");
+    blockGlobalCall(L, "loadstring");
+    blockGlobalCall(L, "require");
+
+    // Whole-table removals.
+    blockGlobalTable(L, "io");
+    blockGlobalTable(L, "package");
+    blockGlobalTable(L, "debug");
+
+    // os: keep only read-only timing helpers; block process / filesystem
+    // effects.
+    blockOsField(L, "execute");
+    blockOsField(L, "remove");
+    blockOsField(L, "rename");
+    blockOsField(L, "exit");
+    blockOsField(L, "tmpname");
+    blockOsField(L, "getenv");
+    blockOsField(L, "setlocale");
+}
+
+}  // namespace magda::scripting

--- a/magda/scripting/LuaSandbox.hpp
+++ b/magda/scripting/LuaSandbox.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+extern "C" {
+struct lua_State;
+}
+
+namespace magda::scripting {
+
+/**
+ * Strip globals that would let untrusted Lua code escape the host process —
+ * arbitrary file I/O, shell execution, dynamic library loading, raw bytecode
+ * loading. Call after luaL_openlibs(); must be applied to every fresh state
+ * before user code runs.
+ *
+ * What is removed:
+ *   - dofile, loadfile, load, loadstring  (no chunk loading from Lua side;
+ *                                          host loads via lua_load directly)
+ *   - io                                  (full stdio table dropped)
+ *   - package, require                    (no C library loading or module fs lookup)
+ *   - debug                               (introspection / stack rewriting)
+ *   - os.execute, os.remove, os.rename,
+ *     os.exit, os.tmpname, os.getenv,
+ *     os.setlocale                        (process / filesystem effects)
+ *
+ * What stays usable:
+ *   - string, math, table, utf8, coroutine
+ *   - print  (redirected to juce::Logger by LuaRuntime)
+ *   - os.date, os.time, os.difftime, os.clock  (read-only timing)
+ */
+void applySandbox(lua_State* L);
+
+}  // namespace magda::scripting

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,6 +79,8 @@ set(TEST_SOURCES
     test_midi_learn.cpp
     # Controller profile tests (issue #1052)
     test_controller_profile.cpp
+    # Lua runtime tests (issue #29)
+    test_lua_runtime.cpp
 )
 
 # Create test executable
@@ -89,6 +91,7 @@ target_link_libraries(magda_tests
     PRIVATE
     magda_daw
     magda_agents
+    magda_scripting
     Catch2::Catch2WithMain
     juce::juce_core
     juce::juce_gui_basics

--- a/tests/test_lua_runtime.cpp
+++ b/tests/test_lua_runtime.cpp
@@ -1,0 +1,187 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <juce_core/juce_core.h>
+
+#include "magda/scripting/LuaRuntime.hpp"
+
+using magda::scripting::LuaRuntime;
+
+namespace {
+
+// Captures every line passed to juce::Logger::writeToLog while installed.
+// Restores the previous logger on destruction.
+class CapturingLogger : public juce::Logger {
+public:
+    CapturingLogger() : previous_(juce::Logger::getCurrentLogger()) {
+        juce::Logger::setCurrentLogger(this);
+    }
+    ~CapturingLogger() override { juce::Logger::setCurrentLogger(previous_); }
+
+    void logMessage(const juce::String& message) override { lines_.add(message); }
+
+    const juce::StringArray& lines() const noexcept { return lines_; }
+
+private:
+    juce::Logger* previous_;
+    juce::StringArray lines_;
+};
+
+}  // namespace
+
+TEST_CASE("LuaRuntime evaluates an integer expression", "[lua_runtime]") {
+    LuaRuntime rt;
+    auto result = rt.evalToInt("2 + 2");
+    REQUIRE(result.has_value());
+    REQUIRE(*result == 4);
+    REQUIRE(rt.lastError().isEmpty());
+}
+
+TEST_CASE("LuaRuntime evaluates a string expression", "[lua_runtime]") {
+    LuaRuntime rt;
+    auto result = rt.evalToString("'hello ' .. 'world'");
+    REQUIRE(result.has_value());
+    REQUIRE(*result == "hello world");
+}
+
+TEST_CASE("LuaRuntime reports syntax errors with line numbers", "[lua_runtime]") {
+    LuaRuntime rt;
+    REQUIRE_FALSE(rt.eval("if then"));
+    // Lua's load error format is `[chunkname]:LINE: message`.
+    REQUIRE(rt.lastError().contains(":1:"));
+}
+
+TEST_CASE("LuaRuntime reports runtime errors with the original message", "[lua_runtime]") {
+    LuaRuntime rt;
+    REQUIRE_FALSE(rt.eval("error('oops')"));
+    REQUIRE(rt.lastError().contains("oops"));
+    // Traceback is appended by the message handler.
+    REQUIRE(rt.lastError().contains("stack traceback"));
+}
+
+TEST_CASE("LuaRuntime print() forwards to juce::Logger", "[lua_runtime]") {
+    CapturingLogger capture;
+    LuaRuntime rt;
+    REQUIRE(rt.eval("print('hi from lua')"));
+    REQUIRE(capture.lines().size() >= 1);
+    REQUIRE(capture.lines().joinIntoString("\n").contains("hi from lua"));
+}
+
+TEST_CASE("LuaRuntime print() joins arguments with tabs", "[lua_runtime]") {
+    CapturingLogger capture;
+    LuaRuntime rt;
+    REQUIRE(rt.eval("print('a', 1, true)"));
+    REQUIRE(capture.lines().size() >= 1);
+    auto joined = capture.lines().joinIntoString("\n");
+    REQUIRE(joined.contains("a\t1\ttrue"));
+}
+
+TEST_CASE("LuaRuntime sandbox: calling os.execute errors with a descriptive message",
+          "[lua_runtime][sandbox]") {
+    LuaRuntime rt;
+    REQUIRE_FALSE(rt.eval("os.execute('ls')"));
+    REQUIRE(rt.lastError().contains("os.execute"));
+    REQUIRE(rt.lastError().contains("sandbox"));
+}
+
+TEST_CASE("LuaRuntime sandbox: blocked os.* fields error with their name",
+          "[lua_runtime][sandbox]") {
+    for (const char* field : {"execute", "remove", "rename", "exit", "tmpname", "getenv"}) {
+        LuaRuntime rt;
+        auto chunk = juce::String("os.") + field + "('x')";
+        REQUIRE_FALSE(rt.eval(chunk));
+        REQUIRE(rt.lastError().contains(juce::String("os.") + field));
+        REQUIRE(rt.lastError().contains("sandbox"));
+    }
+}
+
+TEST_CASE("LuaRuntime sandbox: read-only os timing helpers stay available",
+          "[lua_runtime][sandbox]") {
+    LuaRuntime rt;
+    REQUIRE(rt.evalToString("type(os.time)") == std::optional<juce::String>{"function"});
+    REQUIRE(rt.evalToString("type(os.date)") == std::optional<juce::String>{"function"});
+    REQUIRE(rt.evalToString("type(os.clock)") == std::optional<juce::String>{"function"});
+    REQUIRE(rt.evalToString("type(os.difftime)") == std::optional<juce::String>{"function"});
+}
+
+TEST_CASE("LuaRuntime sandbox: io.open errors with a sandbox message",
+          "[lua_runtime][sandbox]") {
+    LuaRuntime rt;
+    REQUIRE_FALSE(rt.eval("io.open('/tmp/x', 'w')"));
+    REQUIRE(rt.lastError().contains("'io'"));
+    REQUIRE(rt.lastError().contains("sandbox"));
+}
+
+TEST_CASE("LuaRuntime sandbox: blocked tables error on read, write, and call",
+          "[lua_runtime][sandbox]") {
+    for (const char* tbl : {"io", "package", "debug"}) {
+        LuaRuntime rt;
+        // Read access
+        auto readChunk = juce::String("local _ = ") + tbl + ".x";
+        REQUIRE_FALSE(rt.eval(readChunk));
+        REQUIRE(rt.lastError().contains(juce::String("'") + tbl + "'"));
+
+        // Write access
+        auto writeChunk = juce::String(tbl) + ".x = 1";
+        REQUIRE_FALSE(rt.eval(writeChunk));
+        REQUIRE(rt.lastError().contains(juce::String("'") + tbl + "'"));
+
+        // setmetatable() can't strip our locked metatable
+        auto mtChunk = juce::String("setmetatable(") + tbl + ", {})";
+        REQUIRE_FALSE(rt.eval(mtChunk));
+    }
+}
+
+TEST_CASE("LuaRuntime sandbox: chunk loaders error with their name",
+          "[lua_runtime][sandbox]") {
+    for (const char* name : {"dofile", "loadfile", "load", "loadstring", "require"}) {
+        LuaRuntime rt;
+        auto chunk = juce::String(name) + "('x')";
+        REQUIRE_FALSE(rt.eval(chunk));
+        REQUIRE(rt.lastError().contains(juce::String("'") + name + "'"));
+        REQUIRE(rt.lastError().contains("sandbox"));
+    }
+}
+
+TEST_CASE("LuaRuntime sandbox: stdlib that should remain works", "[lua_runtime][sandbox]") {
+    LuaRuntime rt;
+    REQUIRE(rt.evalToInt("string.len('abc')") == std::optional<long long>{3});
+    REQUIRE(rt.evalToInt("math.floor(3.7)") == std::optional<long long>{3});
+    REQUIRE(rt.evalToInt("#({10, 20, 30})") == std::optional<long long>{3});
+}
+
+TEST_CASE("LuaRuntime instances are isolated", "[lua_runtime]") {
+    LuaRuntime a;
+    LuaRuntime b;
+    REQUIRE(a.eval("magda_test_global = 42"));
+    auto seen_in_b = b.evalToString("type(magda_test_global)");
+    REQUIRE(seen_in_b.has_value());
+    REQUIRE(*seen_in_b == "nil");
+}
+
+TEST_CASE("LuaRuntime evalFile loads a file and reports its filename on error",
+          "[lua_runtime]") {
+    // Lua truncates the chunk source name to LUA_IDSIZE (60) chars and keeps
+    // the tail when the name starts with '@', so the bare filename always
+    // survives even on long temp-directory paths.
+    auto tempDir = juce::File::getSpecialLocation(juce::File::tempDirectory);
+    auto scriptFile = tempDir.getChildFile("magda_test_lua_runtime.lua");
+    scriptFile.replaceWithText("error('intentional')\n");
+
+    LuaRuntime rt;
+    REQUIRE_FALSE(rt.evalFile(scriptFile));
+    REQUIRE(rt.lastError().contains(scriptFile.getFileName()));
+    REQUIRE(rt.lastError().contains("intentional"));
+
+    scriptFile.deleteFile();
+}
+
+TEST_CASE("LuaRuntime survives a runtime error and remains usable", "[lua_runtime]") {
+    LuaRuntime rt;
+    REQUIRE_FALSE(rt.eval("error('first')"));
+    REQUIRE(rt.lastError().contains("first"));
+
+    auto ok = rt.evalToInt("1 + 1");
+    REQUIRE(ok.has_value());
+    REQUIRE(*ok == 2);
+    REQUIRE(rt.lastError().isEmpty());
+}


### PR DESCRIPTION
## Summary

Foundation for the Lua scripting epic. **This PR covers issue #29 only** — the embedded Lua VM. Bindings to `MagdaApi` (#30) and the MIDI controller scripting use case (#592) land in follow-up branches off this one.

- Vendor **Lua 5.4.7** via `FetchContent` (PUC-Rio, ~250 KB compiled). No LuaJIT, to avoid Apple Silicon W^X friction.
- `magda/scripting/LuaRuntime` — RAII over `lua_State*`, `eval` / `evalFile` / typed `evalTo{Int,String}` helpers, errors carry a stack traceback. `print()` is rerouted to `juce::Logger`.
- `magda/scripting/LuaSandbox` — blocks chunk loaders (`dofile`, `loadfile`, `load`, `loadstring`, `require`), wholesale tables (`io`, `package`, `debug`), and dangerous `os.*` fields. Each blocked thing is replaced with a stub function or metatable-protected stub table that errors with a descriptive `"'X' is disabled in the MAGDA Lua sandbox"` message instead of Lua's generic "attempt to call a nil value".
- `examples/lua_smoke` — tiny REPL / file-runner for manual verification.

No `MagdaApi`, MIDI, or UI dependencies in this branch — by design.

## Test plan

- [x] `make configure` clean on macOS arm64
- [x] `make test-build` clean
- [x] `cmake-build-debug/tests/magda_tests "[lua_runtime]"` — 16 cases, 88 assertions, all pass
- [x] Full suite `cmake-build-debug/tests/magda_tests` — 800/800 cases, 26,755 assertions, no regressions
- [x] Manual smoke via `cmake-build-debug/examples/lua_smoke`:
  - [x] `print(2+2)` → `4` via `juce::Logger`
  - [x] `print(math.floor(3.7))` → `3` (stdlib stays)
  - [x] `os.execute('ls')` → `'os.execute' is disabled in the MAGDA Lua sandbox`
  - [x] `io.open('x','w')` → `'io' is disabled in the MAGDA Lua sandbox`
  - [x] `require('foo')` → `'require' is disabled in the MAGDA Lua sandbox`
  - [x] `error('boom')` → traceback pointing at `stdin:1`
- [ ] Linux + Windows CI (will be exercised when the PR opens for review)

## Follow-ups (separate branches)

- **#30** — `MagdaApiLuaBindings`: bind the 7 `MagdaApi` sub-interfaces + a `magda.transport` / `magda.log` namespace using LuaBridge3.
- **#592** — `LuaController`: hook into `MidiBridge::RawMidiListener`, lock-free SPSC queue from MIDI thread → message-thread drain → user `on_midi(event)` Lua callback. Plus `LuaScriptStore` (global `~/MAGDA/Scripts/Controllers/`) and a Scripts dialog with a manual Reload button.
- **#34** — file-watcher hot-reload (the manual button arrives with #592).