### PR TITLE
Scan disk plugin presets (.vstpreset / .aupreset)

### DIFF
--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -347,6 +347,7 @@ set(DAW_CORE_SOURCES
     project/ProjectManager.cpp
     # Preset management
     core/PresetManager.cpp
+    core/PluginPresetScanner.cpp
     # Music theory (chord detection, suggestion, scales)
     music/ChordEngine.cpp
     music/ChordSuggestionEngine.cpp
@@ -776,6 +777,7 @@ set(DAW_HEADERS
     project/ProjectManager.hpp
     # Preset management
     core/PresetManager.hpp
+    core/PluginPresetScanner.hpp
     # Components - Common Curve Editor
     ui/components/common/curve/CurveTypes.hpp
     ui/components/common/curve/CurveEditorBase.hpp

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -803,6 +803,104 @@ bool AudioBridge::setPluginCurrentProgram(DeviceId deviceId, int programIndex) {
     return false;
 }
 
+namespace {
+
+// Loads / saves a .vstpreset blob via JUCE's VST3Client extension. Two-mode
+// visitor: when `dataIn` is non-empty we apply it as a preset; otherwise we
+// pull the current state into `dataOut`.
+struct Vst3PresetVisitor : juce::ExtensionsVisitor {
+    juce::MemoryBlock dataIn;
+    juce::MemoryBlock dataOut;
+    bool ok = false;
+    bool save = false;
+
+    void visitVST3Client(const VST3Client& client) override {
+        if (save) {
+            dataOut = client.getPreset();
+            ok = dataOut.getSize() > 0;
+        } else {
+            ok = client.setPreset(dataIn);
+        }
+    }
+};
+
+}  // namespace
+
+bool AudioBridge::loadPluginPresetFile(DeviceId deviceId, const juce::File& presetFile) {
+    if (!presetFile.existsAsFile())
+        return false;
+
+    auto* ext = asExternalPlugin(pluginManager_.getPlugin(deviceId));
+    if (ext == nullptr)
+        return false;
+    auto* pi = ext->getAudioPluginInstance();
+    if (pi == nullptr)
+        return false;
+
+    const auto extension = presetFile.getFileExtension().toLowerCase();
+    bool applied = false;
+
+    if (extension == ".vstpreset") {
+        juce::MemoryBlock raw;
+        if (!presetFile.loadFileAsData(raw))
+            return false;
+        Vst3PresetVisitor visitor;
+        visitor.save = false;
+        visitor.dataIn = std::move(raw);
+        pi->getExtensions(visitor);
+        applied = visitor.ok;
+    } else if (extension == ".aupreset") {
+        juce::MemoryBlock raw;
+        if (!presetFile.loadFileAsData(raw))
+            return false;
+        // JUCE's AU wrapper reads the plist directly and pushes it to the
+        // unit via kAudioUnitProperty_ClassInfo. Note: setStateInformation
+        // is NOT what we want — that's JUCE's own state envelope, which
+        // wraps the AU class-info plist and would not match a bare .aupreset.
+        pi->setCurrentProgramStateInformation(raw.getData(), (int)raw.getSize());
+        applied = true;  // AU API doesn't report success; assume ok.
+    }
+
+    if (applied) {
+        // Persist the new state into TE's ValueTree so project save / undo
+        // / param refresh sees it. Mirrors PluginManager::capturePluginState.
+        ext->flushPluginStateToValueTree();
+    }
+    return applied;
+}
+
+bool AudioBridge::savePluginPresetFile(DeviceId deviceId, const juce::File& presetFile) {
+    auto* ext = asExternalPlugin(pluginManager_.getPlugin(deviceId));
+    if (ext == nullptr)
+        return false;
+    auto* pi = ext->getAudioPluginInstance();
+    if (pi == nullptr)
+        return false;
+
+    const auto extension = presetFile.getFileExtension().toLowerCase();
+
+    if (extension == ".vstpreset") {
+        Vst3PresetVisitor visitor;
+        visitor.save = true;
+        pi->getExtensions(visitor);
+        if (!visitor.ok)
+            return false;
+        presetFile.getParentDirectory().createDirectory();
+        return presetFile.replaceWithData(visitor.dataOut.getData(), visitor.dataOut.getSize());
+    }
+
+    if (extension == ".aupreset") {
+        juce::MemoryBlock raw;
+        pi->getCurrentProgramStateInformation(raw);
+        if (raw.getSize() == 0)
+            return false;
+        presetFile.getParentDirectory().createDirectory();
+        return presetFile.replaceWithData(raw.getData(), raw.getSize());
+    }
+
+    return false;
+}
+
 te::VirtualMidiInputDevice* AudioBridge::getQwertyMidiDevice() {
     if (!qwertyMidiDevice_) {
         // Check if it already exists (persisted from a previous session).

--- a/magda/daw/audio/AudioBridge.hpp
+++ b/magda/daw/audio/AudioBridge.hpp
@@ -320,6 +320,18 @@ class AudioBridge : public TrackManagerListener, public ClipManagerListener, pub
     /** Switch the plugin's current program. Returns true on success. */
     bool setPluginCurrentProgram(DeviceId deviceId, int programIndex);
 
+    // ------------------------------------------------------------------------
+    // Disk-based plugin preset loading / saving (.vstpreset / .aupreset).
+    //
+    // VST3: routed through JUCE's ExtensionsVisitor::VST3Client which feeds
+    //       raw .vstpreset bytes to IComponent::setState / IEditController::setState.
+    // AU:   uses AudioPluginInstance::setCurrentProgramStateInformation, which
+    //       parses the .aupreset plist and calls
+    //       AudioUnitSetProperty(kAudioUnitProperty_ClassInfo).
+    // ------------------------------------------------------------------------
+    bool loadPluginPresetFile(DeviceId deviceId, const juce::File& presetFile);
+    bool savePluginPresetFile(DeviceId deviceId, const juce::File& presetFile);
+
     /**
      * @brief Get (or lazily create) the virtual MIDI input device used by
      *        the QWERTY keyboard. Returns nullptr if creation fails.

--- a/magda/daw/core/PluginPresetScanner.cpp
+++ b/magda/daw/core/PluginPresetScanner.cpp
@@ -1,0 +1,195 @@
+#include "PluginPresetScanner.hpp"
+
+#include <algorithm>
+
+namespace magda {
+
+namespace {
+
+juce::String sanitiseFolderName(const juce::String& name) {
+    return juce::File::createLegalFileName(name.trim());
+}
+
+juce::String extensionFor(PluginFormat format) {
+    switch (format) {
+        case PluginFormat::VST3:
+            return ".vstpreset";
+        case PluginFormat::AU:
+            return ".aupreset";
+        default:
+            return {};
+    }
+}
+
+// User-writable preset roots, per plugin format and OS.
+// Issue #1118 spec — these are the canonical locations that hosts and
+// installers use when writing presets.
+std::vector<juce::File> userRootsFor(PluginFormat format) {
+    std::vector<juce::File> roots;
+#if JUCE_MAC
+    auto home = juce::File::getSpecialLocation(juce::File::userHomeDirectory);
+    if (format == PluginFormat::VST3 || format == PluginFormat::AU)
+        roots.push_back(home.getChildFile("Library/Audio/Presets"));
+#elif JUCE_WINDOWS
+    if (format == PluginFormat::VST3) {
+        auto local = juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory);
+        roots.push_back(local.getChildFile("VST3 Presets"));
+    }
+#elif JUCE_LINUX
+    if (format == PluginFormat::VST3) {
+        auto home = juce::File::getSpecialLocation(juce::File::userHomeDirectory);
+        roots.push_back(home.getChildFile(".vst3/presets"));
+    }
+#endif
+    return roots;
+}
+
+// System / shared preset roots for installed factory content.
+std::vector<juce::File> systemRootsFor(PluginFormat format) {
+    std::vector<juce::File> roots;
+#if JUCE_MAC
+    if (format == PluginFormat::VST3 || format == PluginFormat::AU)
+        roots.push_back(juce::File("/Library/Audio/Presets"));
+#elif JUCE_WINDOWS
+    if (format == PluginFormat::VST3) {
+        auto common = juce::File::getSpecialLocation(juce::File::commonApplicationDataDirectory);
+        roots.push_back(common.getChildFile("VST3 Presets"));
+        // Some installers use Program Files\Common Files\VST3 Presets
+        if (auto programFilesCommon = []() -> juce::File {
+                auto* p = std::getenv("CommonProgramFiles");
+                return p != nullptr ? juce::File(juce::String::fromUTF8(p)) : juce::File();
+            }();
+            programFilesCommon != juce::File()) {
+            roots.push_back(programFilesCommon.getChildFile("VST3 Presets"));
+        }
+    }
+#elif JUCE_LINUX
+    if (format == PluginFormat::VST3) {
+        roots.push_back(juce::File("/usr/share/vst3/presets"));
+        roots.push_back(juce::File("/usr/local/share/vst3/presets"));
+    }
+#endif
+    return roots;
+}
+
+// Scan a directory for preset files matching `extension`, recursing into
+// subfolders. Files become leaf entries; folders become Entry with children.
+// Sorted: folders first, then files, alphabetical within each group.
+PluginPresetScanner::Entry scanDir(const juce::File& dir, const juce::String& extension) {
+    PluginPresetScanner::Entry node;
+    node.name = dir.getFileName();
+    node.isFolder = true;
+
+    auto subdirs = dir.findChildFiles(juce::File::findDirectories, false);
+    auto files = dir.findChildFiles(juce::File::findFiles, false, "*" + extension);
+    subdirs.sort();
+    files.sort();
+
+    for (const auto& sub : subdirs) {
+        auto child = scanDir(sub, extension);
+        if (!child.children.empty())
+            node.children.push_back(std::move(child));
+    }
+    for (const auto& f : files) {
+        PluginPresetScanner::Entry leaf;
+        leaf.name = f.getFileNameWithoutExtension();
+        leaf.file = f;
+        node.children.push_back(std::move(leaf));
+    }
+    return node;
+}
+
+// Merge another root's children into target, collapsing folders by name so
+// presets in `~/Library/Audio/Presets/Vendor/Plugin/Bass` and
+// `/Library/Audio/Presets/Vendor/Plugin/Bass` end up in one "Bass" submenu.
+void mergeInto(std::vector<PluginPresetScanner::Entry>& target,
+               std::vector<PluginPresetScanner::Entry>&& source) {
+    for (auto& src : source) {
+        if (src.isFolder) {
+            auto it = std::find_if(target.begin(), target.end(),
+                                   [&](const PluginPresetScanner::Entry& e) {
+                                       return e.isFolder && e.name == src.name;
+                                   });
+            if (it != target.end()) {
+                mergeInto(it->children, std::move(src.children));
+                continue;
+            }
+        }
+        target.push_back(std::move(src));
+    }
+}
+
+}  // namespace
+
+PluginPresetScanner& PluginPresetScanner::getInstance() {
+    static PluginPresetScanner instance;
+    return instance;
+}
+
+juce::String PluginPresetScanner::makeCacheKey(const DeviceInfo& device) const {
+    return device.getFormatString() + "|" + device.manufacturer + "|" + device.name;
+}
+
+juce::String PluginPresetScanner::getPresetExtension(const DeviceInfo& device) const {
+    return extensionFor(device.format);
+}
+
+std::vector<juce::File> PluginPresetScanner::getScanRoots(const DeviceInfo& device) const {
+    std::vector<juce::File> out;
+    auto vendor = sanitiseFolderName(device.manufacturer);
+    auto plugin = sanitiseFolderName(device.name);
+    if (vendor.isEmpty() || plugin.isEmpty())
+        return out;
+
+    auto roots = userRootsFor(device.format);
+    auto sysRoots = systemRootsFor(device.format);
+    roots.insert(roots.end(), sysRoots.begin(), sysRoots.end());
+
+    for (const auto& root : roots) {
+        auto pluginDir = root.getChildFile(vendor).getChildFile(plugin);
+        if (pluginDir.isDirectory())
+            out.push_back(pluginDir);
+    }
+    return out;
+}
+
+juce::File PluginPresetScanner::getUserPresetDirectory(const DeviceInfo& device) const {
+    auto vendor = sanitiseFolderName(device.manufacturer);
+    auto plugin = sanitiseFolderName(device.name);
+    if (vendor.isEmpty() || plugin.isEmpty())
+        return {};
+    auto roots = userRootsFor(device.format);
+    if (roots.empty())
+        return {};
+    return roots.front().getChildFile(vendor).getChildFile(plugin);
+}
+
+PluginPresetScanner::PresetTree PluginPresetScanner::scanPlugin(const DeviceInfo& device) const {
+    PresetTree tree;
+    auto extension = extensionFor(device.format);
+    if (extension.isEmpty())
+        return tree;
+
+    for (const auto& dir : getScanRoots(device)) {
+        auto rootEntry = scanDir(dir, extension);
+        if (!rootEntry.children.empty())
+            mergeInto(tree.roots, std::move(rootEntry.children));
+    }
+    return tree;
+}
+
+const PluginPresetScanner::PresetTree& PluginPresetScanner::getPresets(const DeviceInfo& device) {
+    auto key = makeCacheKey(device).toStdString();
+    auto it = cache_.find(key);
+    if (it != cache_.end())
+        return it->second;
+    auto [inserted, _] = cache_.emplace(key, scanPlugin(device));
+    return inserted->second;
+}
+
+void PluginPresetScanner::rescan(const DeviceInfo& device) {
+    auto key = makeCacheKey(device).toStdString();
+    cache_[key] = scanPlugin(device);
+}
+
+}  // namespace magda

--- a/magda/daw/core/PluginPresetScanner.hpp
+++ b/magda/daw/core/PluginPresetScanner.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "DeviceInfo.hpp"
+
+namespace magda {
+
+/**
+ * @brief Scans disk-based plugin presets (.vstpreset, .aupreset) per plugin.
+ *
+ * Modern VST3 / AU plugins store their factory and user presets as files on
+ * disk rather than exposing them through the legacy Programs API. This class
+ * walks the OS-defined preset locations for a given plugin and returns a tree
+ * suitable for building a PopupMenu.
+ *
+ * Results are cached per (format, vendor, plugin) and stay valid until
+ * `rescan()` is called. The user-writable directory (returned from
+ * `getUserPresetDirectory()`) is where new presets saved from MAGDA land.
+ */
+class PluginPresetScanner {
+  public:
+    static PluginPresetScanner& getInstance();
+
+    /** Single preset entry (directory or file). */
+    struct Entry {
+        juce::String name;  // Display name (file basename or folder name)
+        juce::File file;    // Empty for folders
+        bool isFolder = false;
+        std::vector<Entry> children;  // Populated when isFolder
+    };
+
+    /** Tree of presets. Top-level entries are direct children of all scan roots
+     *  merged together — folders coming from any root with the same name are
+     *  collapsed into one entry. */
+    struct PresetTree {
+        std::vector<Entry> roots;
+        bool empty() const {
+            return roots.empty();
+        }
+    };
+
+    /**
+     * @brief Returns a cached scan result for the given device.
+     *
+     * @param device A loaded external plugin device. Internal devices return
+     *        an empty tree.
+     * @return Tree of presets discovered on disk. Empty if no presets exist.
+     */
+    const PresetTree& getPresets(const DeviceInfo& device);
+
+    /**
+     * @brief Force a rescan for the given plugin identity. Cheap (a few
+     *        directory listings); safe to call from the message thread.
+     */
+    void rescan(const DeviceInfo& device);
+
+    /**
+     * @brief The user-writable directory where MAGDA writes new presets for
+     *        this plugin. Created on demand (only when actually written to).
+     */
+    juce::File getUserPresetDirectory(const DeviceInfo& device) const;
+
+    /**
+     * @brief Filesystem extension expected for the device's plugin format
+     *        (".vstpreset", ".aupreset", or empty for unsupported formats).
+     */
+    juce::String getPresetExtension(const DeviceInfo& device) const;
+
+    /**
+     * @brief All directories (user + system) scanned for the device. Useful
+     *        for exposing a "Reveal in Finder" action for the user dir.
+     */
+    std::vector<juce::File> getScanRoots(const DeviceInfo& device) const;
+
+  private:
+    PluginPresetScanner() = default;
+
+    juce::String makeCacheKey(const DeviceInfo& device) const;
+    PresetTree scanPlugin(const DeviceInfo& device) const;
+
+    std::unordered_map<std::string, PresetTree> cache_;
+};
+
+}  // namespace magda

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -19,6 +19,7 @@
 #include "core/MidiFileWriter.hpp"
 #include "core/ModInfo.hpp"
 #include "core/ParameterUtils.hpp"
+#include "core/PluginPresetScanner.hpp"
 #include "core/PresetManager.hpp"
 #include "core/SelectionManager.hpp"
 #include "core/TrackCommands.hpp"
@@ -32,7 +33,6 @@
 #include "ui/themes/DarkTheme.hpp"
 #include "ui/themes/FontManager.hpp"
 #include "ui/themes/SmallButtonLookAndFeel.hpp"
-#include "ui/themes/SmallComboBoxLookAndFeel.hpp"
 
 namespace magda::daw::ui {
 
@@ -97,6 +97,57 @@ inline void applyHeaderIconStyle(magda::SvgButton& btn, juce::Colour activeBg,
     if (toggling)
         btn.setClickingTogglesState(true);
 }
+
+// LookAndFeel for the plugin-presets header button. Visually a flat label
+// with a chevron on the right, so it reads as a menu trigger rather than a
+// "select one of these values" combo.
+class PluginPresetsButtonLookAndFeel : public juce::LookAndFeel_V4 {
+  public:
+    void drawButtonBackground(juce::Graphics& g, juce::Button& button,
+                              const juce::Colour& /*bgColour*/, bool isHighlighted,
+                              bool isDown) override {
+        auto bounds = button.getLocalBounds().toFloat().reduced(0.5f);
+        auto bg = DarkTheme::getColour(DarkTheme::SURFACE);
+        if (isDown)
+            bg = bg.darker(0.2f);
+        else if (isHighlighted)
+            bg = bg.brighter(0.1f);
+        g.setColour(bg);
+        g.fillRoundedRectangle(bounds, 3.0f);
+        g.setColour(DarkTheme::getColour(DarkTheme::BORDER));
+        g.drawRoundedRectangle(bounds, 3.0f, 1.0f);
+    }
+
+    void drawButtonText(juce::Graphics& g, juce::TextButton& button, bool /*highlighted*/,
+                        bool /*down*/) override {
+        auto bounds = button.getLocalBounds().reduced(6, 0);
+        constexpr float chevronW = 10.0f;
+        auto chevronArea = bounds.removeFromRight((int)chevronW).toFloat();
+
+        g.setFont(FontManager::getInstance().getUIFont(10.0f));
+        g.setColour(
+            DarkTheme::getTextColour().withMultipliedAlpha(button.isEnabled() ? 1.0f : 0.5f));
+        g.drawText(button.getButtonText(), bounds.toFloat(), juce::Justification::centredLeft,
+                   /*useEllipses*/ true);
+
+        // Down-pointing chevron, two strokes from the centre.
+        const float cx = chevronArea.getCentreX();
+        const float cy = chevronArea.getCentreY() + 1.0f;
+        constexpr float halfSize = 2.5f;
+        juce::Path chevron;
+        chevron.startNewSubPath(cx - halfSize, cy - 1.0f);
+        chevron.lineTo(cx, cy + 1.5f);
+        chevron.lineTo(cx + halfSize, cy - 1.0f);
+        g.setColour(DarkTheme::getSecondaryTextColour());
+        g.strokePath(chevron, juce::PathStrokeType(1.0f, juce::PathStrokeType::curved,
+                                                   juce::PathStrokeType::rounded));
+    }
+
+    static PluginPresetsButtonLookAndFeel& getInstance() {
+        static PluginPresetsButtonLookAndFeel instance;
+        return instance;
+    }
+};
 
 }  // namespace
 
@@ -261,28 +312,15 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     presetButton_->onClick = [this]() { showPresetMenu(); };
     addAndMakeVisible(*presetButton_);
 
-    // Native plugin programs (factory presets) dropdown — populated lazily once
-    // the plugin instance is loaded (see refreshProgramsCombo).
-    programsCombo_ = std::make_unique<juce::ComboBox>("Programs");
-    programsCombo_->setLookAndFeel(&SmallComboBoxLookAndFeel::getInstance());
-    programsCombo_->setColour(juce::ComboBox::backgroundColourId,
-                              DarkTheme::getColour(DarkTheme::SURFACE));
-    programsCombo_->setColour(juce::ComboBox::outlineColourId,
-                              DarkTheme::getColour(DarkTheme::BORDER));
-    programsCombo_->setColour(juce::ComboBox::textColourId, DarkTheme::getTextColour());
-    programsCombo_->setTextWhenNothingSelected({});
-    programsCombo_->onChange = [this]() {
-        auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine();
-        if (!audioEngine)
-            return;
-        auto* bridge = audioEngine->getAudioBridge();
-        if (!bridge)
-            return;
-        const int programIndex = programsCombo_->getSelectedId() - 1;
-        if (programIndex >= 0)
-            bridge->setPluginCurrentProgram(device_.id, programIndex);
-    };
-    addAndMakeVisible(*programsCombo_);
+    // Plugin presets menu button — opens a hierarchical popup of disk-scanned
+    // presets (.vstpreset / .aupreset). Hidden when neither disk presets nor
+    // built-in programs are available so plugins with proprietary preset
+    // systems (Vital, Serum 2, etc.) don't show a dead control.
+    presetsButton_ = std::make_unique<juce::TextButton>("Presets");
+    presetsButton_->setLookAndFeel(&PluginPresetsButtonLookAndFeel::getInstance());
+    presetsButton_->setTooltip("Plugin Presets");
+    presetsButton_->onClick = [this]() { showPluginPresetMenu(); };
+    addChildComponent(*presetsButton_);  // hidden by default; shown by refreshPresetsButton
 
     // Vertical gain slider overlaid on the meter, with a tooltip that reports
     // both the current gain and the meter's peak-hold dB.
@@ -799,10 +837,6 @@ void DeviceSlotComponent::timerCallback() {
     auto* bridge = audioEngine->getAudioBridge();
     if (!bridge)
         return;
-
-    // Keep the plugin programs combo selection in sync with the underlying
-    // plugin (program may have been changed via the plugin's native UI).
-    syncProgramsComboSelection();
 
     // Update UI button state to match actual plugin window state
     if (uiButton_) {
@@ -1398,64 +1432,243 @@ void DeviceSlotComponent::loadMagdaPreset(const juce::String& presetRelativePath
     currentPresetName_ = presetRelativePath;
 }
 
-void DeviceSlotComponent::refreshProgramsCombo() {
-    if (!programsCombo_)
+void DeviceSlotComponent::refreshPresetsButton() {
+    if (!presetsButton_)
         return;
-    auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine();
-    if (!audioEngine)
-        return;
-    auto* bridge = audioEngine->getAudioBridge();
-    if (!bridge)
-        return;
-
-    const int numPrograms = bridge->getPluginNumPrograms(device_.id);
-    // Hide the combo for plugins that don't expose meaningful programs
-    // (most modern VST3s return 1 because presets live as .vstpreset files).
-    if (numPrograms <= 1) {
-        programsCombo_->clear(juce::dontSendNotification);
-        programsCombo_->setVisible(false);
-        return;
-    }
-
-    programsCombo_->clear(juce::dontSendNotification);
-    for (int i = 0; i < numPrograms; ++i) {
-        auto name = bridge->getPluginProgramName(device_.id, i);
-        if (name.isEmpty())
-            name = "Program " + juce::String(i + 1);
-        programsCombo_->addItem(name, i + 1);
-    }
-    const int current = bridge->getPluginCurrentProgram(device_.id);
-    programsCombo_->setSelectedId(current + 1, juce::dontSendNotification);
+    const auto label = pluginPresetName_.isNotEmpty() ? pluginPresetName_ : juce::String("Presets");
+    presetsButton_->setButtonText(label);
 }
 
-void DeviceSlotComponent::syncProgramsComboSelection() {
-    if (!programsCombo_ || isInternalDevice() ||
-        device_.loadState != magda::DeviceLoadState::Loaded)
-        return;
+bool DeviceSlotComponent::hasPluginPresetsAvailable() const {
+    // Disk presets only. The legacy getNumPrograms / getProgramName API is
+    // effectively useless on modern VST3s (Serum, Vital, etc. report 128
+    // generic "Program N" entries that resolve to identical state) so we
+    // don't fall back to it — that's exactly the lie #1118 set out to remove.
+    if (isInternalDevice() || device_.loadState != magda::DeviceLoadState::Loaded)
+        return false;
+    return !magda::PluginPresetScanner::getInstance().getPresets(device_).empty();
+}
+
+namespace {
+
+// Walk a PluginPresetScanner tree, append items / submenus to `menu`,
+// and accumulate every leaf preset's File so the chosen menu id can be
+// resolved back to a path. Items matching `currentLoaded` are ticked.
+void buildPluginPresetSubmenu(juce::PopupMenu& menu,
+                              const std::vector<magda::PluginPresetScanner::Entry>& entries,
+                              int idBase, juce::Array<juce::File>& outFiles,
+                              const juce::File& currentLoaded) {
+    for (const auto& entry : entries) {
+        if (entry.isFolder) {
+            juce::PopupMenu submenu;
+            buildPluginPresetSubmenu(submenu, entry.children, idBase, outFiles, currentLoaded);
+            if (submenu.getNumItems() > 0)
+                menu.addSubMenu(entry.name, submenu);
+        } else {
+            outFiles.add(entry.file);
+            const bool ticked = currentLoaded == entry.file;
+            menu.addItem(idBase + outFiles.size() - 1, entry.name, /*isActive*/ true, ticked);
+        }
+    }
+}
+
+}  // namespace
+
+void DeviceSlotComponent::showPluginPresetMenu() {
     auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine();
-    if (!audioEngine)
-        return;
-    auto* bridge = audioEngine->getAudioBridge();
-    if (!bridge)
+    auto* bridge = audioEngine != nullptr ? audioEngine->getAudioBridge() : nullptr;
+    if (bridge == nullptr || isInternalDevice())
         return;
 
-    // First-time population: combo is empty but the plugin is now ready.
-    if (programsCombo_->getNumItems() == 0) {
-        if (bridge->getPluginNumPrograms(device_.id) > 1)
-            refreshProgramsCombo();
+    auto& scanner = magda::PluginPresetScanner::getInstance();
+    const auto extension = scanner.getPresetExtension(device_);
+    const bool diskPresetsSupported = extension.isNotEmpty();
+
+    constexpr int kPresetIdBase = 1000;
+    constexpr int kProgramIdBase = 5000;
+    constexpr int kSavePresetAs = 1;
+    constexpr int kRevealUserDir = 2;
+    constexpr int kRescan = 3;
+
+    juce::PopupMenu menu;
+    juce::Array<juce::File> indexed;
+
+    if (diskPresetsSupported) {
+        const auto& tree = scanner.getPresets(device_);
+        if (!tree.empty()) {
+            buildPluginPresetSubmenu(menu, tree.roots, kPresetIdBase, indexed,
+                                     currentPluginPresetFile_);
+        } else {
+            menu.addItem(kPresetIdBase, "(no presets installed)", /*isActive*/ false);
+        }
+    }
+
+    // Legacy program API as a fallback / supplementary entry. Plugins like
+    // older VSTs and a handful of VST3s still expose meaningful program lists
+    // through getNumPrograms — keep them reachable.
+    const int numPrograms = bridge->getPluginNumPrograms(device_.id);
+    if (numPrograms > 1) {
+        juce::PopupMenu programsSubmenu;
+        const int currentProgram = bridge->getPluginCurrentProgram(device_.id);
+        for (int i = 0; i < numPrograms; ++i) {
+            auto name = bridge->getPluginProgramName(device_.id, i);
+            if (name.isEmpty())
+                name = "Program " + juce::String(i + 1);
+            programsSubmenu.addItem(kProgramIdBase + i, name, /*isActive*/ true,
+                                    /*isTicked*/ i == currentProgram);
+        }
+        if (menu.getNumItems() > 0)
+            menu.addSeparator();
+        menu.addSubMenu("Built-in Programs", programsSubmenu);
+    }
+
+    if (diskPresetsSupported) {
+        menu.addSeparator();
+        menu.addItem(kSavePresetAs, "Save Preset As...");
+        const auto userDir = scanner.getUserPresetDirectory(device_);
+        menu.addItem(kRevealUserDir, "Reveal User Preset Folder",
+                     /*isActive*/ !userDir.getFullPathName().isEmpty());
+        menu.addItem(kRescan, "Rescan");
+    } else if (numPrograms <= 1) {
+        // Nothing to show at all (e.g. a legacy VST with one program and no
+        // disk presets). Don't show the menu.
         return;
     }
 
-    const int current = bridge->getPluginCurrentProgram(device_.id);
-    if (current + 1 != programsCombo_->getSelectedId())
-        programsCombo_->setSelectedId(current + 1, juce::dontSendNotification);
+    juce::Component::SafePointer<DeviceSlotComponent> self(this);
+    menu.showMenuAsync(
+        juce::PopupMenu::Options().withTargetComponent(presetsButton_.get()),
+        [self, indexed](int chosen) {
+            if (self == nullptr || chosen == 0)
+                return;
+            if (chosen == kSavePresetAs) {
+                self->showSavePluginPresetDialog();
+            } else if (chosen == kRevealUserDir) {
+                auto dir =
+                    magda::PluginPresetScanner::getInstance().getUserPresetDirectory(self->device_);
+                if (!dir.exists())
+                    dir.createDirectory();
+                if (dir.exists())
+                    dir.revealToUser();
+            } else if (chosen == kRescan) {
+                magda::PluginPresetScanner::getInstance().rescan(self->device_);
+            } else if (chosen >= kProgramIdBase) {
+                const int programIndex = chosen - kProgramIdBase;
+                auto* engine = magda::TrackManager::getInstance().getAudioEngine();
+                if (auto* bridge = engine != nullptr ? engine->getAudioBridge() : nullptr) {
+                    if (bridge->setPluginCurrentProgram(self->device_.id, programIndex)) {
+                        auto name = bridge->getPluginProgramName(self->device_.id, programIndex);
+                        self->pluginPresetName_ =
+                            name.isNotEmpty() ? name
+                                              : ("Program " + juce::String(programIndex + 1));
+                        self->currentPluginPresetFile_ = juce::File();
+                        self->refreshPresetsButton();
+                    }
+                }
+            } else if (chosen >= kPresetIdBase) {
+                const int idx = chosen - kPresetIdBase;
+                if (idx >= 0 && idx < indexed.size())
+                    self->loadPluginPresetFile(indexed[idx]);
+            }
+        });
+}
+
+void DeviceSlotComponent::loadPluginPresetFile(const juce::File& file) {
+    auto* engine = magda::TrackManager::getInstance().getAudioEngine();
+    auto* bridge = engine != nullptr ? engine->getAudioBridge() : nullptr;
+    if (bridge == nullptr)
+        return;
+    if (!bridge->loadPluginPresetFile(device_.id, file)) {
+        showPresetErrorAsync("Load Preset Failed",
+                             "Could not load \"" + file.getFileName() + "\".");
+        return;
+    }
+    currentPluginPresetFile_ = file;
+    pluginPresetName_ = file.getFileNameWithoutExtension();
+    refreshPresetsButton();
+}
+
+void DeviceSlotComponent::showSavePluginPresetDialog() {
+    auto& scanner = magda::PluginPresetScanner::getInstance();
+    const auto extension = scanner.getPresetExtension(device_);
+    if (extension.isEmpty())
+        return;
+    const auto userDir = scanner.getUserPresetDirectory(device_);
+    if (userDir.getFullPathName().isEmpty()) {
+        showPresetErrorAsync("Save Preset Failed",
+                             "No writable preset directory for this plugin format.");
+        return;
+    }
+
+    auto* aw = new juce::AlertWindow("Save Plugin Preset",
+                                     "Enter a name for this " + extension.substring(1) + " preset:",
+                                     juce::MessageBoxIconType::NoIcon);
+    aw->addTextEditor("name", pluginPresetName_.isNotEmpty() ? pluginPresetName_ : device_.name,
+                      "Name:");
+    aw->addButton("Save", 1, juce::KeyPress(juce::KeyPress::returnKey));
+    aw->addButton("Cancel", 0, juce::KeyPress(juce::KeyPress::escapeKey));
+
+    juce::Component::SafePointer<DeviceSlotComponent> self(this);
+    aw->enterModalState(
+        true, juce::ModalCallbackFunction::create([aw, self, userDir, extension](int result) {
+            if (result != 1) {
+                delete aw;
+                return;
+            }
+            auto rawName = aw->getTextEditorContents("name").trim();
+            delete aw;
+            if (rawName.isEmpty() || self == nullptr)
+                return;
+            auto safeName = juce::File::createLegalFileName(rawName);
+            if (safeName.isEmpty())
+                return;
+
+            auto target = userDir.getChildFile(safeName + extension);
+
+            auto doSave = [self, target]() {
+                if (self == nullptr)
+                    return;
+                auto* engine = magda::TrackManager::getInstance().getAudioEngine();
+                auto* bridge = engine != nullptr ? engine->getAudioBridge() : nullptr;
+                if (bridge == nullptr)
+                    return;
+                if (!bridge->savePluginPresetFile(self->device_.id, target)) {
+                    showPresetErrorAsync("Save Preset Failed",
+                                         "Could not write \"" + target.getFileName() + "\".");
+                    return;
+                }
+                magda::PluginPresetScanner::getInstance().rescan(self->device_);
+                self->currentPluginPresetFile_ = target;
+                self->pluginPresetName_ = target.getFileNameWithoutExtension();
+                self->refreshPresetsButton();
+            };
+
+            if (target.existsAsFile()) {
+                juce::AlertWindow::showAsync(
+                    juce::MessageBoxOptions()
+                        .withIconType(juce::MessageBoxIconType::QuestionIcon)
+                        .withTitle("Overwrite Preset?")
+                        .withMessage("\"" + target.getFileName() + "\" already exists. Overwrite?")
+                        .withButton("Overwrite")
+                        .withButton("Cancel"),
+                    [doSave](int r) {
+                        if (r == 1)
+                            doSave();
+                    });
+            } else {
+                doSave();
+            }
+        }));
 }
 
 void DeviceSlotComponent::updateFromDevice(const magda::DeviceInfo& device) {
     // Detect plugin replacement BEFORE assignment so we can drop a stale
     // currentPresetName_ reference (a preset is tied to one plugin).
-    if (currentPresetName_.isNotEmpty() && device.pluginId != device_.pluginId)
+    if (device.pluginId != device_.pluginId) {
         currentPresetName_.clear();
+        pluginPresetName_.clear();
+        currentPluginPresetFile_ = juce::File();
+    }
 
     device_ = device;
     // Custom name and font for drum grid (MPC-style with Microgramma)
@@ -1477,7 +1690,7 @@ void DeviceSlotComponent::updateFromDevice(const magda::DeviceInfo& device) {
     // Plugin instance may have just become available (or its program list changed
     // due to a state restore) — repopulate.
     if (device_.loadState == magda::DeviceLoadState::Loaded && !isInternalDevice())
-        refreshProgramsCombo();
+        refreshPresetsButton();
 
     // Update sidechain button visibility and state
     if (scButton_) {
@@ -1786,20 +1999,18 @@ void DeviceSlotComponent::resizedContent(juce::Rectangle<int> contentArea) {
     // When collapsed, NodeComponent calls resizedCollapsed() first then resizedContent()
     // with an empty rect — so we must not touch meter visibility when collapsed.
     if (!collapsed_) {
-        // Carve the FULL-width second header first so the programs dropdown
-        // can sit flush against the right edge of the panel.
+        // Carve the FULL-width second header first so the presets button can
+        // sit flush against the right edge of the panel.
         auto secondHeaderArea = contentArea.removeFromTop(CONTENT_HEADER_HEIGHT);
-        if (programsCombo_) {
-            const bool showCombo = device_.loadState == magda::DeviceLoadState::Loaded &&
-                                   !isInternalDevice() && !isChordEngine_ && !isArpeggiator_ &&
-                                   !isStepSequencer_;
-            if (showCombo) {
-                const int comboWidth = juce::jmin(140, secondHeaderArea.getWidth() / 2);
-                programsCombo_->setBounds(
-                    secondHeaderArea.removeFromRight(comboWidth).reduced(2, 3));
-                programsCombo_->setVisible(true);
+        if (presetsButton_) {
+            const bool eligible = !isChordEngine_ && !isArpeggiator_ && !isStepSequencer_;
+            const bool show = eligible && hasPluginPresetsAvailable();
+            if (show) {
+                const int btnWidth = juce::jmin(140, secondHeaderArea.getWidth() / 2);
+                presetsButton_->setBounds(secondHeaderArea.removeFromRight(btnWidth).reduced(2, 3));
+                presetsButton_->setVisible(true);
             } else {
-                programsCombo_->setVisible(false);
+                presetsButton_->setVisible(false);
             }
         }
 
@@ -1828,8 +2039,8 @@ void DeviceSlotComponent::resizedContent(juce::Rectangle<int> contentArea) {
     if (collapsed_ || device_.loadState != magda::DeviceLoadState::Loaded) {
         paramGrid_->setVisible(false);
         gainLabel_.setVisible(false);
-        if (programsCombo_)
-            programsCombo_->setVisible(false);
+        if (presetsButton_)
+            presetsButton_->setVisible(false);
         if (gainSlider_)
             gainSlider_->setVisible(false);
         if (presetButton_)

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
@@ -272,8 +272,11 @@ class DeviceSlotComponent : public NodeComponent,
 
     // MAGDA preset menu button (lives in top header, replaces gainLabel_ slot)
     std::unique_ptr<magda::SvgButton> presetButton_;
-    // Native plugin programs dropdown (lives in second/content header, plugin-hosted only)
-    std::unique_ptr<juce::ComboBox> programsCombo_;
+    // Plugin preset menu button (second/content header, plugin-hosted only).
+    // Hidden when neither disk presets nor built-in programs are available so
+    // plugins with proprietary preset systems (Vital, Serum 2, etc.) don't
+    // show a dead control.
+    std::unique_ptr<juce::TextButton> presetsButton_;
     // Vertical gain slider overlaid on the meter
     std::unique_ptr<juce::Slider> gainSlider_;
     daw::audio::ArpeggiatorPlugin* arpPlugin_ = nullptr;
@@ -288,9 +291,18 @@ class DeviceSlotComponent : public NodeComponent,
     bool hasAutomapBindings_ = false;  // Any DeviceMacro binding targets this device
     void refreshControllerIndicators();
 
-    // Plugin programs combo helpers
-    void refreshProgramsCombo();        // full re-populate (item list + selection)
-    void syncProgramsComboSelection();  // selection-only, cheap, called from timer
+    // Plugin presets button helpers (disk-scanned .vstpreset / .aupreset).
+    void refreshPresetsButton();             // re-paint label + recompute visibility
+    bool hasPluginPresetsAvailable() const;  // disk presets OR >1 built-in programs
+    void showPluginPresetMenu();
+    void loadPluginPresetFile(const juce::File& file);
+    void showSavePluginPresetDialog();
+
+    // Most-recently loaded plugin preset (cleared when the device's pluginId
+    // changes). pluginPresetName_ is the display label; currentPluginPresetFile_
+    // is the source file used to tick the entry in the popup menu.
+    juce::File currentPluginPresetFile_;
+    juce::String pluginPresetName_;
 
     // MAGDA preset dialogs / actions
     void showPresetMenu();


### PR DESCRIPTION
## Summary
- New `PluginPresetScanner` walks the OS-defined preset roots (macOS user/system `~/Library/Audio/Presets`, Windows `VST3 Presets`, Linux `~/.vst3/presets`) and returns a hierarchical tree of `.vstpreset` / `.aupreset` files for the loaded plugin, cached per-(format, vendor, plugin).
- Device slot's stale "Programs" combo (which exposed the legacy JUCE `getProgramName` API — useless for modern VST3s that report 1 generic program) becomes a hierarchical popup of disk presets, behind a button that hides itself when the plugin has no `.vstpreset` / `.aupreset` files. Plugins with proprietary preset systems (Vital, Serum 2, Diva, Massive — `.vital`, `.serumpreset`, `.h2p`, `.nmsv`) get no button at all, since the legacy program API on those reports 128 useless generic entries.
- VST3 load/save routed through JUCE's `ExtensionsVisitor::VST3Client::setPreset/getPreset` (real chunk file → `IComponent::setState` / `IEditController::setState`). AU load/save routes through `setCurrentProgramStateInformation` (raw plist → `kAudioUnitProperty_ClassInfo`).
- Save Preset As… writes the plugin's current state into the user-writable root in the format the plugin expects; Reveal User Preset Folder + Rescan close the loop.

Closes #1118

## Test plan
- [x] Drop a Plugin Alliance VST3 with installed `.vstpreset` files (e.g. bx_saturator V2). Presets button shows, menu lists every preset, selection audibly changes the sound, label updates.
- [x] Save Preset As… writes a `.vstpreset` into `~/Library/Audio/Presets/<vendor>/<plugin>/`, rescan picks it up, the plugin's own UI can re-load it later.
- [x] Drop Vital / Serum 2 / Diva — Presets button is absent (proprietary formats, scanner correctly returns empty).
- [x] Drop a MAGDA internal device — no Presets button (only the existing `.mps` MAGDA preset button).
- [ ] Windows / Linux scan paths (only macOS verified locally).
- [ ] AU plugin save/load smoke test.