### PR TITLE
feat(scripting): bind MagdaApi to Lua + add SessionApi (#30)

### DIFF
--- a/examples/lua_smoke.cpp
+++ b/examples/lua_smoke.cpp
@@ -1,13 +1,16 @@
-// lua_smoke — interactive smoke test for the embedded Lua runtime (#29).
+// lua_smoke — interactive smoke test for the embedded Lua runtime + bindings.
 //
 // Usage:
 //   lua_smoke                  → REPL on stdin (blank line / EOF to quit)
 //   lua_smoke script.lua       → run script.lua and exit
 //
-// Verifies end-to-end: stdlib opened, sandbox applied, print() routed to
-// juce::Logger, errors carry tracebacks. No DAW dependencies.
+// The REPL pre-registers a MockMagdaApi so the `magda.*` bindings work end
+// to end without a real DAW. Reads return seeded mock state, writes log
+// what the binding called. Useful for #29 and #30 verification.
 
 #include "magda/scripting/LuaRuntime.hpp"
+#include "magda/scripting/MagdaApiLuaBindings.hpp"
+#include "tests/MockMagdaApi.hpp"
 
 #include <juce_core/juce_core.h>
 
@@ -31,6 +34,30 @@ int main(int argc, char** argv) {
 
     magda::scripting::LuaRuntime rt;
 
+    // Pre-seed a mock with a couple of tracks + a session clip so reads
+    // return something interesting at the prompt.
+    magda::test::MockMagdaApi mock;
+    {
+        magda::TrackInfo a;
+        a.id = 1;
+        a.name = "Drums";
+        a.type = magda::TrackType::Audio;
+        a.volume = 0.8f;
+        magda::TrackInfo b;
+        b.id = 2;
+        b.name = "Bass";
+        b.type = magda::TrackType::Audio;
+        b.volume = 0.6f;
+        mock.tracks_.tracks.push_back(a);
+        mock.tracks_.tracks.push_back(b);
+        mock.tracks_.nextId = 3;
+        mock.selection_.selectedTrack = 1;
+        mock.session_.activeOnTrack[1] = 707;
+        mock.project_.info.name = "smoke";
+        mock.project_.info.tempo = 120.0;
+    }
+    magda::scripting::registerMagdaApi(rt.state(), mock);
+
     if (argc == 2) {
         juce::File scriptFile(juce::String::fromUTF8(argv[1]));
         bool ok = rt.evalFile(scriptFile);
@@ -40,10 +67,15 @@ int main(int argc, char** argv) {
         return ok ? 0 : 1;
     }
 
-    std::cout << "MAGDA Lua smoke REPL — Lua 5.4 with sandbox.\n"
-                 "  print(os.execute('ls'))   -- sandboxed away\n"
-                 "  print(math.floor(3.7))    -- stdlib stays\n"
-                 "  Blank line or EOF to quit.\n";
+    std::cout
+        << "MAGDA Lua smoke REPL — Lua 5.4 with sandbox + magda.* bindings.\n"
+           "Mock DAW state pre-seeded: 2 tracks (Drums, Bass), 1 active session clip.\n"
+           "  for _, t in ipairs(magda.tracks.list()) do print(t.id, t.name) end\n"
+           "  magda.tracks.set_volume(1, 0.5)\n"
+           "  print(magda.selection.track())\n"
+           "  print(magda.project.info().tempo)\n"
+           "  magda.session.launch_clip(101)\n"
+           "  Blank line or EOF to quit.\n";
 
     std::string line;
     for (;;) {

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -269,6 +269,7 @@ set(DAW_CORE_SOURCES
     api/alias_api_live.cpp
     api/track_api_live.cpp
     api/clip_api_live.cpp
+    api/session_api_live.cpp
     api/project_api_live.cpp
     api/undo_api_live.cpp
     # Controller data model (issue #1050 -- Phase A)
@@ -578,6 +579,7 @@ set(DAW_HEADERS
     api/alias_api.hpp
     api/track_api.hpp
     api/clip_api.hpp
+    api/session_api.hpp
     api/project_api.hpp
     api/undo_api.hpp
     api/magda_api_live.hpp

--- a/magda/daw/api/magda_api.hpp
+++ b/magda/daw/api/magda_api.hpp
@@ -7,6 +7,7 @@ class AutomationApi;
 class AliasApi;
 class TrackApi;
 class ClipApi;
+class SessionApi;
 class ProjectApi;
 class UndoApi;
 
@@ -31,6 +32,7 @@ class MagdaApi {
     virtual AliasApi& aliases() = 0;
     virtual TrackApi& tracks() = 0;
     virtual ClipApi& clips() = 0;
+    virtual SessionApi& session() = 0;
     virtual ProjectApi& project() = 0;
     virtual UndoApi& undo() = 0;
 };

--- a/magda/daw/api/magda_api_live.hpp
+++ b/magda/daw/api/magda_api_live.hpp
@@ -6,6 +6,7 @@
 #include "magda_api.hpp"
 #include "project_api_live.hpp"
 #include "selection_api_live.hpp"
+#include "session_api_live.hpp"
 #include "track_api_live.hpp"
 #include "undo_api_live.hpp"
 
@@ -29,6 +30,9 @@ class MagdaApiLive : public MagdaApi {
     ClipApi& clips() override {
         return clips_;
     }
+    SessionApi& session() override {
+        return session_;
+    }
     ProjectApi& project() override {
         return project_;
     }
@@ -42,6 +46,7 @@ class MagdaApiLive : public MagdaApi {
     AliasApiLive aliases_;
     TrackApiLive tracks_;
     ClipApiLive clips_;
+    SessionApiLive session_;
     ProjectApiLive project_;
     UndoApiLive undo_;
 };

--- a/magda/daw/api/session_api.hpp
+++ b/magda/daw/api/session_api.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "../core/ClipTypes.hpp"
+#include "../core/TypeIds.hpp"
+
+namespace magda {
+
+/**
+ * Abstract view onto session-view playback — clip launching, stopping,
+ * scene-launch helpers.
+ *
+ * v1 surface is action-only: scripts can trigger clips and stop tracks,
+ * but state queries (play state, playhead position) are not exposed yet.
+ * Adding those requires routing through SessionClipScheduler, which is
+ * owned by TracktionEngineWrapperInit (not a singleton) and is null in
+ * headless test mode. The v1 actions go through ClipManager, which is a
+ * singleton and works in headless.
+ *
+ * NOTE: Behaviour matches the UI's "trigger" buttons — calls flow through
+ * the same clipPlaybackRequested → SessionClipScheduler → TE LaunchHandle
+ * pipeline. Launch quantization, toggle vs trigger mode, and scene logic
+ * are applied identically to manual UI interaction.
+ */
+class SessionApi {
+  public:
+    virtual ~SessionApi() = default;
+
+    /// Trigger a session-view clip. No-op if clipId is invalid or the
+    /// clip is in arrangement view.
+    virtual void launchClip(ClipId clipId) = 0;
+
+    /// Stop a session clip (no-op if not active).
+    virtual void stopClip(ClipId clipId) = 0;
+
+    /// Stop the active session clip on a track, if any.
+    virtual void stopTrack(TrackId trackId) = 0;
+
+    /// Stop every active session clip.
+    virtual void stopAll() = 0;
+
+    /// Return the active session clip on the given track, or
+    /// INVALID_CLIP_ID if nothing is currently launched there.
+    virtual ClipId getActiveClipOnTrack(TrackId trackId) const = 0;
+};
+
+}  // namespace magda

--- a/magda/daw/api/session_api_live.cpp
+++ b/magda/daw/api/session_api_live.cpp
@@ -1,0 +1,33 @@
+#include "session_api_live.hpp"
+
+#include "../core/ClipManager.hpp"
+#include "../core/TrackInfo.hpp"
+#include "../core/TrackManager.hpp"
+
+namespace magda {
+
+void SessionApiLive::launchClip(ClipId clipId) {
+    ClipManager::getInstance().triggerClip(clipId);
+}
+
+void SessionApiLive::stopClip(ClipId clipId) {
+    ClipManager::getInstance().stopClip(clipId);
+}
+
+void SessionApiLive::stopTrack(TrackId trackId) {
+    auto activeId = getActiveClipOnTrack(trackId);
+    if (activeId != INVALID_CLIP_ID) {
+        ClipManager::getInstance().stopClip(activeId);
+    }
+}
+
+void SessionApiLive::stopAll() {
+    ClipManager::getInstance().stopAllClips();
+}
+
+ClipId SessionApiLive::getActiveClipOnTrack(TrackId trackId) const {
+    auto* track = TrackManager::getInstance().getTrack(trackId);
+    return track != nullptr ? track->activeSessionClipId : INVALID_CLIP_ID;
+}
+
+}  // namespace magda

--- a/magda/daw/api/session_api_live.hpp
+++ b/magda/daw/api/session_api_live.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "session_api.hpp"
+
+namespace magda {
+
+/// Forwards SessionApi calls to ClipManager + TrackManager singletons.
+/// State queries beyond getActiveClipOnTrack would require
+/// SessionClipScheduler access, which isn't a singleton — deferred until
+/// the scheduler is properly accessible.
+class SessionApiLive : public SessionApi {
+  public:
+    void launchClip(ClipId clipId) override;
+    void stopClip(ClipId clipId) override;
+    void stopTrack(TrackId trackId) override;
+    void stopAll() override;
+    ClipId getActiveClipOnTrack(TrackId trackId) const override;
+};
+
+}  // namespace magda

--- a/magda/scripting/CMakeLists.txt
+++ b/magda/scripting/CMakeLists.txt
@@ -87,6 +87,8 @@ set(MAGDA_SCRIPTING_SOURCES
     LuaRuntime.cpp
     LuaSandbox.hpp
     LuaSandbox.cpp
+    MagdaApiLuaBindings.hpp
+    MagdaApiLuaBindings.cpp
 )
 
 add_library(magda_scripting STATIC ${MAGDA_SCRIPTING_SOURCES})
@@ -95,6 +97,12 @@ target_link_libraries(magda_scripting
     PUBLIC
     lua_static
     juce::juce_core
+    # MagdaApi headers live under magda/daw/api/. The bindings need the
+    # full DAW types (TrackInfo, ClipInfo, ProjectInfo). Long-term these
+    # types could be split into a thin "magda_api_types" lib so scripting
+    # doesn't pull all of magda_daw, but that refactor is out of scope
+    # for #30.
+    magda_daw
 )
 
 target_include_directories(magda_scripting

--- a/magda/scripting/MagdaApiLuaBindings.cpp
+++ b/magda/scripting/MagdaApiLuaBindings.cpp
@@ -1,0 +1,602 @@
+#include "magda/scripting/MagdaApiLuaBindings.hpp"
+
+#include "magda/daw/api/clip_api.hpp"
+#include "magda/daw/api/magda_api.hpp"
+#include "magda/daw/api/project_api.hpp"
+#include "magda/daw/api/selection_api.hpp"
+#include "magda/daw/api/session_api.hpp"
+#include "magda/daw/api/track_api.hpp"
+#include "magda/daw/core/ClipInfo.hpp"
+#include "magda/daw/core/ClipTypes.hpp"
+#include "magda/daw/core/TrackInfo.hpp"
+#include "magda/daw/core/TrackTypes.hpp"
+#include "magda/daw/core/TypeIds.hpp"
+#include "magda/daw/project/ProjectInfo.hpp"
+
+#include <juce_core/juce_core.h>
+
+extern "C" {
+#include <lauxlib.h>
+#include <lua.h>
+}
+
+#include <unordered_set>
+
+// All bindings are defined in this TU because they share static helpers and
+// the registry-key sentinel. Keeping them grouped under a single anonymous
+// namespace avoids leaking internal symbols.
+
+namespace magda::scripting {
+
+namespace {
+
+// Address of this static is used as a unique key into LUA_REGISTRYINDEX,
+// independent of any string the user might collide with.
+char kMagdaApiRegistryKey = 0;
+
+MagdaApi* getApi(lua_State* L) {
+    lua_pushlightuserdata(L, &kMagdaApiRegistryKey);
+    lua_rawget(L, LUA_REGISTRYINDEX);
+    auto* api = static_cast<MagdaApi*>(lua_touserdata(L, -1));
+    lua_pop(L, 1);
+    if (api == nullptr) {
+        luaL_error(L, "MagdaApi has not been registered with this Lua state");
+    }
+    return api;
+}
+
+// Push a `juce::String` as a Lua string (UTF-8).
+void pushJuceString(lua_State* L, const juce::String& s) {
+    auto raw = s.toRawUTF8();
+    lua_pushlstring(L, raw, static_cast<size_t>(s.getNumBytesAsUTF8()));
+}
+
+// ---- log -------------------------------------------------------------------
+
+// Internal: build a single juce::String from all stack args, space-separated,
+// using Lua's tostring() conversion semantics.
+juce::String buildLogMessage(lua_State* L) {
+    int n = lua_gettop(L);
+    juce::String msg;
+    for (int i = 1; i <= n; ++i) {
+        size_t len = 0;
+        const char* s = luaL_tolstring(L, i, &len);  // pushes converted string
+        if (i > 1)
+            msg << ' ';
+        msg << juce::String::fromUTF8(s, static_cast<int>(len));
+        lua_pop(L, 1);
+    }
+    return msg;
+}
+
+int lua_log_info(lua_State* L) {
+    juce::Logger::writeToLog("[lua] " + buildLogMessage(L));
+    return 0;
+}
+
+int lua_log_warn(lua_State* L) {
+    juce::Logger::writeToLog("[lua warn] " + buildLogMessage(L));
+    return 0;
+}
+
+int lua_log_error(lua_State* L) {
+    juce::Logger::writeToLog("[lua error] " + buildLogMessage(L));
+    return 0;
+}
+
+// ---- selection -------------------------------------------------------------
+
+int lua_selection_track(lua_State* L) {
+    auto* api = getApi(L);
+    TrackId id = api->selection().getSelectedTrack();
+    if (id == INVALID_TRACK_ID)
+        lua_pushnil(L);
+    else
+        lua_pushinteger(L, static_cast<lua_Integer>(id));
+    return 1;
+}
+
+int lua_selection_clip(lua_State* L) {
+    auto* api = getApi(L);
+    ClipId id = api->selection().getSelectedClip();
+    if (id == INVALID_CLIP_ID)
+        lua_pushnil(L);
+    else
+        lua_pushinteger(L, static_cast<lua_Integer>(id));
+    return 1;
+}
+
+// Returns an array (1-indexed) of selected clip IDs. Order is unspecified
+// because the underlying type is unordered_set.
+int lua_selection_clips(lua_State* L) {
+    auto* api = getApi(L);
+    const auto& clips = api->selection().getSelectedClips();
+    lua_createtable(L, static_cast<int>(clips.size()), 0);
+    int i = 1;
+    for (ClipId id : clips) {
+        lua_pushinteger(L, static_cast<lua_Integer>(id));
+        lua_rawseti(L, -2, i++);
+    }
+    return 1;
+}
+
+int lua_selection_has_notes(lua_State* L) {
+    auto* api = getApi(L);
+    lua_pushboolean(L, api->selection().hasNoteSelection());
+    return 1;
+}
+
+int lua_selection_note_clip(lua_State* L) {
+    auto* api = getApi(L);
+    ClipId id = api->selection().getNoteSelectionClipId();
+    if (id == INVALID_CLIP_ID)
+        lua_pushnil(L);
+    else
+        lua_pushinteger(L, static_cast<lua_Integer>(id));
+    return 1;
+}
+
+int lua_selection_note_indices(lua_State* L) {
+    auto* api = getApi(L);
+    const auto& idx = api->selection().getNoteSelectionIndices();
+    lua_createtable(L, static_cast<int>(idx.size()), 0);
+    int i = 1;
+    for (size_t v : idx) {
+        lua_pushinteger(L, static_cast<lua_Integer>(v));
+        lua_rawseti(L, -2, i++);
+    }
+    return 1;
+}
+
+int lua_selection_select_track(lua_State* L) {
+    auto* api = getApi(L);
+    auto trackId = static_cast<TrackId>(luaL_checkinteger(L, 1));
+    api->selection().selectTrack(trackId);
+    return 0;
+}
+
+// Helper: read a 1-indexed Lua array of integers at stack index `idx` into
+// an unordered_set<T>. Validates types up-front so any error fires before
+// allocations occur in the set.
+template <typename T>
+std::unordered_set<T> readIntSet(lua_State* L, int idx) {
+    luaL_checktype(L, idx, LUA_TTABLE);
+    std::unordered_set<T> out;
+    lua_Integer n = luaL_len(L, idx);
+    out.reserve(static_cast<size_t>(n));
+    for (lua_Integer i = 1; i <= n; ++i) {
+        lua_rawgeti(L, idx, i);
+        if (!lua_isinteger(L, -1)) {
+            lua_pop(L, 1);
+            luaL_error(L, "expected integer at index %d", static_cast<int>(i));
+        }
+        out.insert(static_cast<T>(lua_tointeger(L, -1)));
+        lua_pop(L, 1);
+    }
+    return out;
+}
+
+int lua_selection_select_tracks(lua_State* L) {
+    auto* api = getApi(L);
+    auto ids = readIntSet<TrackId>(L, 1);
+    api->selection().selectTracks(ids);
+    return 0;
+}
+
+int lua_selection_select_clip(lua_State* L) {
+    auto* api = getApi(L);
+    auto clipId = static_cast<ClipId>(luaL_checkinteger(L, 1));
+    api->selection().selectClip(clipId);
+    return 0;
+}
+
+int lua_selection_select_clips(lua_State* L) {
+    auto* api = getApi(L);
+    auto ids = readIntSet<ClipId>(L, 1);
+    api->selection().selectClips(ids);
+    return 0;
+}
+
+int lua_selection_clear_notes(lua_State* L) {
+    auto* api = getApi(L);
+    api->selection().clearNoteSelection();
+    return 0;
+}
+
+// ---- tracks ----------------------------------------------------------------
+
+TrackType parseTrackType(const char* s) {
+    if (juce::String(s).equalsIgnoreCase("audio"))
+        return TrackType::Audio;
+    if (juce::String(s).equalsIgnoreCase("group"))
+        return TrackType::Group;
+    if (juce::String(s).equalsIgnoreCase("aux"))
+        return TrackType::Aux;
+    if (juce::String(s).equalsIgnoreCase("master"))
+        return TrackType::Master;
+    if (juce::String(s).equalsIgnoreCase("multi_out") ||
+        juce::String(s).equalsIgnoreCase("multiout"))
+        return TrackType::MultiOut;
+    return TrackType::Audio;
+}
+
+const char* trackTypeToLuaString(TrackType t) {
+    switch (t) {
+        case TrackType::Audio: return "audio";
+        case TrackType::Group: return "group";
+        case TrackType::Aux: return "aux";
+        case TrackType::Master: return "master";
+        case TrackType::MultiOut: return "multi_out";
+    }
+    return "audio";
+}
+
+// Push a TrackInfo as a Lua table (snapshot, read-only convention).
+void pushTrackTable(lua_State* L, const TrackInfo& t) {
+    lua_createtable(L, 0, 9);
+
+    lua_pushinteger(L, static_cast<lua_Integer>(t.id));
+    lua_setfield(L, -2, "id");
+
+    pushJuceString(L, t.name);
+    lua_setfield(L, -2, "name");
+
+    lua_pushstring(L, trackTypeToLuaString(t.type));
+    lua_setfield(L, -2, "type");
+
+    lua_pushnumber(L, t.volume);
+    lua_setfield(L, -2, "volume");
+
+    lua_pushnumber(L, t.pan);
+    lua_setfield(L, -2, "pan");
+
+    lua_pushboolean(L, t.muted);
+    lua_setfield(L, -2, "muted");
+
+    lua_pushboolean(L, t.soloed);
+    lua_setfield(L, -2, "soloed");
+
+    lua_pushboolean(L, t.recordArmed);
+    lua_setfield(L, -2, "record_armed");
+
+    lua_pushboolean(L, t.frozen);
+    lua_setfield(L, -2, "frozen");
+}
+
+int lua_tracks_create(lua_State* L) {
+    auto* api = getApi(L);
+    const char* name = luaL_checkstring(L, 1);
+    const char* typeStr = luaL_optstring(L, 2, "audio");
+    TrackId id = api->tracks().createTrack(juce::String::fromUTF8(name),
+                                           parseTrackType(typeStr));
+    lua_pushinteger(L, static_cast<lua_Integer>(id));
+    return 1;
+}
+
+int lua_tracks_delete(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<TrackId>(luaL_checkinteger(L, 1));
+    api->tracks().deleteTrack(id);
+    return 0;
+}
+
+int lua_tracks_count(lua_State* L) {
+    auto* api = getApi(L);
+    lua_pushinteger(L, api->tracks().getNumTracks());
+    return 1;
+}
+
+int lua_tracks_list(lua_State* L) {
+    auto* api = getApi(L);
+    const auto& tracks = api->tracks().getTracks();
+    lua_createtable(L, static_cast<int>(tracks.size()), 0);
+    int i = 1;
+    for (const auto& t : tracks) {
+        pushTrackTable(L, t);
+        lua_rawseti(L, -2, i++);
+    }
+    return 1;
+}
+
+int lua_tracks_get(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<TrackId>(luaL_checkinteger(L, 1));
+    const TrackInfo* t = api->tracks().getTrack(id);
+    if (t == nullptr) {
+        lua_pushnil(L);
+        return 1;
+    }
+    pushTrackTable(L, *t);
+    return 1;
+}
+
+int lua_tracks_set_name(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<TrackId>(luaL_checkinteger(L, 1));
+    const char* name = luaL_checkstring(L, 2);
+    api->tracks().setTrackName(id, juce::String::fromUTF8(name));
+    return 0;
+}
+
+int lua_tracks_set_volume(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<TrackId>(luaL_checkinteger(L, 1));
+    auto vol = static_cast<float>(luaL_checknumber(L, 2));
+    api->tracks().setTrackVolume(id, vol);
+    return 0;
+}
+
+int lua_tracks_set_pan(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<TrackId>(luaL_checkinteger(L, 1));
+    auto pan = static_cast<float>(luaL_checknumber(L, 2));
+    api->tracks().setTrackPan(id, pan);
+    return 0;
+}
+
+int lua_tracks_set_muted(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<TrackId>(luaL_checkinteger(L, 1));
+    luaL_checktype(L, 2, LUA_TBOOLEAN);
+    api->tracks().setTrackMuted(id, lua_toboolean(L, 2) != 0);
+    return 0;
+}
+
+int lua_tracks_set_soloed(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<TrackId>(luaL_checkinteger(L, 1));
+    luaL_checktype(L, 2, LUA_TBOOLEAN);
+    api->tracks().setTrackSoloed(id, lua_toboolean(L, 2) != 0);
+    return 0;
+}
+
+// ---- clips -----------------------------------------------------------------
+
+void pushClipTable(lua_State* L, const ClipInfo& c) {
+    lua_createtable(L, 0, 6);
+
+    lua_pushinteger(L, static_cast<lua_Integer>(c.id));
+    lua_setfield(L, -2, "id");
+
+    lua_pushinteger(L, static_cast<lua_Integer>(c.trackId));
+    lua_setfield(L, -2, "track_id");
+
+    pushJuceString(L, c.name);
+    lua_setfield(L, -2, "name");
+
+    lua_pushnumber(L, c.startBeats);
+    lua_setfield(L, -2, "start_beats");
+
+    lua_pushnumber(L, c.lengthBeats);
+    lua_setfield(L, -2, "length_beats");
+}
+
+int lua_clips_create_midi(lua_State* L) {
+    auto* api = getApi(L);
+    auto trackId = static_cast<TrackId>(luaL_checkinteger(L, 1));
+    double start = luaL_checknumber(L, 2);
+    double length = luaL_checknumber(L, 3);
+    ClipId id = api->clips().createMidiClipBeats(trackId, start, length);
+    lua_pushinteger(L, static_cast<lua_Integer>(id));
+    return 1;
+}
+
+int lua_clips_delete(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<ClipId>(luaL_checkinteger(L, 1));
+    api->clips().deleteClip(id);
+    return 0;
+}
+
+int lua_clips_list_on_track(lua_State* L) {
+    auto* api = getApi(L);
+    auto trackId = static_cast<TrackId>(luaL_checkinteger(L, 1));
+    auto ids = api->clips().getClipsOnTrack(trackId);
+    lua_createtable(L, static_cast<int>(ids.size()), 0);
+    for (size_t i = 0; i < ids.size(); ++i) {
+        lua_pushinteger(L, static_cast<lua_Integer>(ids[i]));
+        lua_rawseti(L, -2, static_cast<int>(i + 1));
+    }
+    return 1;
+}
+
+int lua_clips_list_arrangement(lua_State* L) {
+    auto* api = getApi(L);
+    auto clips = api->clips().getArrangementClips();
+    lua_createtable(L, static_cast<int>(clips.size()), 0);
+    for (size_t i = 0; i < clips.size(); ++i) {
+        pushClipTable(L, clips[i]);
+        lua_rawseti(L, -2, static_cast<int>(i + 1));
+    }
+    return 1;
+}
+
+int lua_clips_set_name(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<ClipId>(luaL_checkinteger(L, 1));
+    const char* name = luaL_checkstring(L, 2);
+    api->clips().setClipName(id, juce::String::fromUTF8(name));
+    return 0;
+}
+
+int lua_clips_set_groove(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<ClipId>(luaL_checkinteger(L, 1));
+    const char* tmpl = luaL_checkstring(L, 2);
+    api->clips().setGrooveTemplate(id, juce::String::fromUTF8(tmpl));
+    return 0;
+}
+
+// ---- session ---------------------------------------------------------------
+
+int lua_session_launch_clip(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<ClipId>(luaL_checkinteger(L, 1));
+    api->session().launchClip(id);
+    return 0;
+}
+
+int lua_session_stop_clip(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<ClipId>(luaL_checkinteger(L, 1));
+    api->session().stopClip(id);
+    return 0;
+}
+
+int lua_session_stop_track(lua_State* L) {
+    auto* api = getApi(L);
+    auto trackId = static_cast<TrackId>(luaL_checkinteger(L, 1));
+    api->session().stopTrack(trackId);
+    return 0;
+}
+
+int lua_session_stop_all(lua_State* L) {
+    auto* api = getApi(L);
+    api->session().stopAll();
+    return 0;
+}
+
+int lua_session_active_clip_on_track(lua_State* L) {
+    auto* api = getApi(L);
+    auto trackId = static_cast<TrackId>(luaL_checkinteger(L, 1));
+    ClipId id = api->session().getActiveClipOnTrack(trackId);
+    if (id == INVALID_CLIP_ID)
+        lua_pushnil(L);
+    else
+        lua_pushinteger(L, static_cast<lua_Integer>(id));
+    return 1;
+}
+
+// ---- project ---------------------------------------------------------------
+
+int lua_project_info(lua_State* L) {
+    auto* api = getApi(L);
+    const ProjectInfo& info = api->project().getCurrentProjectInfo();
+    lua_createtable(L, 0, 7);
+
+    pushJuceString(L, info.name);
+    lua_setfield(L, -2, "name");
+
+    pushJuceString(L, info.filePath);
+    lua_setfield(L, -2, "file_path");
+
+    lua_pushnumber(L, info.tempo);
+    lua_setfield(L, -2, "tempo");
+
+    lua_pushinteger(L, info.timeSignatureNumerator);
+    lua_setfield(L, -2, "time_sig_num");
+
+    lua_pushinteger(L, info.timeSignatureDenominator);
+    lua_setfield(L, -2, "time_sig_den");
+
+    lua_pushnumber(L, info.sampleRate);
+    lua_setfield(L, -2, "sample_rate");
+
+    lua_pushboolean(L, info.loopEnabled);
+    lua_setfield(L, -2, "loop_enabled");
+
+    return 1;
+}
+
+// ---- registration ----------------------------------------------------------
+
+// Convenience: attach `funcs` (null-terminated) to the table at the top of
+// the stack. Equivalent to calling lua_setfield in a loop.
+struct FnReg {
+    const char* name;
+    lua_CFunction fn;
+};
+
+void setFunctions(lua_State* L, const FnReg* funcs) {
+    for (const FnReg* f = funcs; f->name != nullptr; ++f) {
+        lua_pushcfunction(L, f->fn);
+        lua_setfield(L, -2, f->name);
+    }
+}
+
+const FnReg kLogFns[] = {
+    {"info", lua_log_info},
+    {"warn", lua_log_warn},
+    {"error", lua_log_error},
+    {nullptr, nullptr},
+};
+
+const FnReg kSelectionFns[] = {
+    {"track", lua_selection_track},
+    {"clip", lua_selection_clip},
+    {"clips", lua_selection_clips},
+    {"has_notes", lua_selection_has_notes},
+    {"note_clip", lua_selection_note_clip},
+    {"note_indices", lua_selection_note_indices},
+    {"select_track", lua_selection_select_track},
+    {"select_tracks", lua_selection_select_tracks},
+    {"select_clip", lua_selection_select_clip},
+    {"select_clips", lua_selection_select_clips},
+    {"clear_notes", lua_selection_clear_notes},
+    {nullptr, nullptr},
+};
+
+const FnReg kTrackFns[] = {
+    {"create", lua_tracks_create},
+    {"delete", lua_tracks_delete},
+    {"count", lua_tracks_count},
+    {"list", lua_tracks_list},
+    {"get", lua_tracks_get},
+    {"set_name", lua_tracks_set_name},
+    {"set_volume", lua_tracks_set_volume},
+    {"set_pan", lua_tracks_set_pan},
+    {"set_muted", lua_tracks_set_muted},
+    {"set_soloed", lua_tracks_set_soloed},
+    {nullptr, nullptr},
+};
+
+const FnReg kClipFns[] = {
+    {"create_midi", lua_clips_create_midi},
+    {"delete", lua_clips_delete},
+    {"list_on_track", lua_clips_list_on_track},
+    {"list_arrangement", lua_clips_list_arrangement},
+    {"set_name", lua_clips_set_name},
+    {"set_groove", lua_clips_set_groove},
+    {nullptr, nullptr},
+};
+
+const FnReg kSessionFns[] = {
+    {"launch_clip", lua_session_launch_clip},
+    {"stop_clip", lua_session_stop_clip},
+    {"stop_track", lua_session_stop_track},
+    {"stop_all", lua_session_stop_all},
+    {"active_clip_on_track", lua_session_active_clip_on_track},
+    {nullptr, nullptr},
+};
+
+const FnReg kProjectFns[] = {
+    {"info", lua_project_info},
+    {nullptr, nullptr},
+};
+
+void installSubtable(lua_State* L, const char* name, const FnReg* fns) {
+    lua_newtable(L);
+    setFunctions(L, fns);
+    lua_setfield(L, -2, name);  // magda[name] = subtable
+}
+
+}  // namespace
+
+void registerMagdaApi(lua_State* L, MagdaApi& api) {
+    // Stash the api pointer in the registry under our static-address key.
+    lua_pushlightuserdata(L, &kMagdaApiRegistryKey);
+    lua_pushlightuserdata(L, &api);
+    lua_rawset(L, LUA_REGISTRYINDEX);
+
+    // Build the magda namespace table.
+    lua_newtable(L);
+    installSubtable(L, "log", kLogFns);
+    installSubtable(L, "selection", kSelectionFns);
+    installSubtable(L, "tracks", kTrackFns);
+    installSubtable(L, "clips", kClipFns);
+    installSubtable(L, "session", kSessionFns);
+    installSubtable(L, "project", kProjectFns);
+    lua_setglobal(L, "magda");
+}
+
+}  // namespace magda::scripting

--- a/magda/scripting/MagdaApiLuaBindings.hpp
+++ b/magda/scripting/MagdaApiLuaBindings.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+extern "C" {
+struct lua_State;
+}
+
+namespace magda {
+
+class MagdaApi;
+
+namespace scripting {
+
+/**
+ * Install the `magda.*` namespace into `L`, wired to `api`.
+ *
+ * After this call, Lua scripts can use:
+ *   magda.log.{info,warn,error}      — juce::Logger pass-through
+ *   magda.selection.{...}            — SelectionApi
+ *   magda.tracks.{...}               — TrackApi
+ *   magda.clips.{...}                — ClipApi
+ *   magda.project.info()             — ProjectApi snapshot
+ *
+ * The MagdaApi reference is borrowed — its lifetime must outlive `L`. The
+ * caller (e.g. AIChatConsoleContent in the live app, or the test harness)
+ * is responsible for that ordering.
+ *
+ * Threading: every binding routes through MagdaApi, which is message-thread
+ * only. The caller must guarantee Lua execution happens on the message
+ * thread. #592 handles MIDI-thread → message-thread dispatch.
+ *
+ * Idempotent: calling twice on the same state replaces the registered
+ * MagdaApi pointer and re-creates the `magda` table.
+ */
+void registerMagdaApi(lua_State* L, MagdaApi& api);
+
+}  // namespace scripting
+}  // namespace magda

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,6 +81,8 @@ set(TEST_SOURCES
     test_controller_profile.cpp
     # Lua runtime tests (issue #29)
     test_lua_runtime.cpp
+    # Lua bindings tests (issue #30 — bind MagdaApi)
+    test_magda_api_lua_bindings.cpp
 )
 
 # Create test executable

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -31,6 +31,12 @@
 #include "magda/daw/core/TrackInfo.hpp"
 #include "magda/daw/core/TrackTypes.hpp"
 #include "magda/daw/core/TypeIds.hpp"
+// UndoableCommand's full definition lives in UndoManager.hpp; undo_api.hpp
+// only forward-declares it. We need the complete type because StubUndoApi
+// takes std::unique_ptr<UndoableCommand> by value — MSVC instantiates
+// ~unique_ptr eagerly when parsing the inline body, and the default
+// deleter static_asserts on a complete type.
+#include "magda/daw/core/UndoManager.hpp"
 #include "magda/daw/project/ProjectInfo.hpp"
 
 namespace magda::test {

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -1,0 +1,356 @@
+#pragma once
+
+// Header-only test double for magda::MagdaApi. Provides minimal
+// implementations of every sub-interface — Selection, Track, Clip,
+// Session, Project are functional; Automation, Alias, and Undo are
+// inert stubs that abort on use (the binding tests don't touch them).
+//
+// The mock records writes (set_volume, set_muted, etc.) into vectors so
+// tests can assert what the bindings invoked. Reads are seeded by
+// populating the public state members directly.
+
+#include <juce_core/juce_core.h>
+
+#include <cassert>
+#include <cstdlib>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "magda/daw/api/alias_api.hpp"
+#include "magda/daw/api/automation_api.hpp"
+#include "magda/daw/api/clip_api.hpp"
+#include "magda/daw/api/magda_api.hpp"
+#include "magda/daw/api/project_api.hpp"
+#include "magda/daw/api/selection_api.hpp"
+#include "magda/daw/api/session_api.hpp"
+#include "magda/daw/api/track_api.hpp"
+#include "magda/daw/api/undo_api.hpp"
+#include "magda/daw/core/ClipInfo.hpp"
+#include "magda/daw/core/ClipTypes.hpp"
+#include "magda/daw/core/TrackInfo.hpp"
+#include "magda/daw/core/TrackTypes.hpp"
+#include "magda/daw/core/TypeIds.hpp"
+#include "magda/daw/project/ProjectInfo.hpp"
+
+namespace magda::test {
+
+// ---- inert stubs for sub-APIs the bindings don't exercise -------------
+
+class StubAutomationApi : public AutomationApi {
+  public:
+    AutomationLaneId createLane(const AutomationTarget&, AutomationLaneType) override {
+        std::abort();
+    }
+    AutomationLaneId getLaneForTarget(const AutomationTarget&) const override {
+        std::abort();
+    }
+    AutomationLaneInfo* getLane(AutomationLaneId) override {
+        std::abort();
+    }
+    const AutomationLaneInfo* getLane(AutomationLaneId) const override {
+        std::abort();
+    }
+    AutomationPointId addPoint(AutomationLaneId, double, double,
+                               AutomationCurveType) override {
+        std::abort();
+    }
+    void clearLanePoints(AutomationLaneId) override {
+        std::abort();
+    }
+    void beginNotificationBatch() override {
+        std::abort();
+    }
+    void endNotificationBatch() override {
+        std::abort();
+    }
+};
+
+class StubAliasApi : public AliasApi {
+  public:
+    AliasRegistry& aliasRegistry() override {
+        std::abort();
+    }
+    ResolverRegistry& resolverRegistry() override {
+        std::abort();
+    }
+};
+
+class StubUndoApi : public UndoApi {
+  public:
+    void executeCommand(std::unique_ptr<UndoableCommand>) override {
+        std::abort();
+    }
+};
+
+// ---- functional sub-APIs ---------------------------------------------
+
+class MockSelectionApi : public SelectionApi {
+  public:
+    // State (writeable by tests to seed reads)
+    TrackId selectedTrack = INVALID_TRACK_ID;
+    ClipId selectedClip = INVALID_CLIP_ID;
+    std::unordered_set<ClipId> selectedClips;
+    bool noteSelectionPresent = false;
+    ClipId noteSelectionClipId = INVALID_CLIP_ID;
+    std::vector<size_t> noteSelectionIndices;
+
+    // Captured writes
+    std::vector<TrackId> trackSelections;
+    std::vector<std::unordered_set<TrackId>> tracksSelections;
+    std::vector<ClipId> clipSelections;
+    std::vector<std::unordered_set<ClipId>> clipsSelections;
+    int clearNoteCalls = 0;
+
+    TrackId getSelectedTrack() const override {
+        return selectedTrack;
+    }
+    ClipId getSelectedClip() const override {
+        return selectedClip;
+    }
+    const std::unordered_set<ClipId>& getSelectedClips() const override {
+        return selectedClips;
+    }
+    AutomationLaneId getSelectedAutomationLaneId() const override {
+        return INVALID_AUTOMATION_LANE_ID;
+    }
+    bool hasNoteSelection() const override {
+        return noteSelectionPresent;
+    }
+    ClipId getNoteSelectionClipId() const override {
+        return noteSelectionClipId;
+    }
+    const std::vector<size_t>& getNoteSelectionIndices() const override {
+        return noteSelectionIndices;
+    }
+    void selectTrack(TrackId id) override {
+        trackSelections.push_back(id);
+    }
+    void selectTracks(const std::unordered_set<TrackId>& ids) override {
+        tracksSelections.push_back(ids);
+    }
+    void selectClip(ClipId id) override {
+        clipSelections.push_back(id);
+    }
+    void selectClips(const std::unordered_set<ClipId>& ids) override {
+        clipsSelections.push_back(ids);
+    }
+    void selectNotes(ClipId, const std::vector<size_t>&) override {
+        // not exercised by current bindings
+    }
+    void clearNoteSelection() override {
+        ++clearNoteCalls;
+    }
+};
+
+class MockTrackApi : public TrackApi {
+  public:
+    std::vector<TrackInfo> tracks;
+
+    struct VolumeWrite {
+        TrackId id;
+        float value;
+    };
+    struct PanWrite {
+        TrackId id;
+        float value;
+    };
+    struct MuteWrite {
+        TrackId id;
+        bool value;
+    };
+    struct SoloWrite {
+        TrackId id;
+        bool value;
+    };
+    struct NameWrite {
+        TrackId id;
+        juce::String value;
+    };
+
+    std::vector<TrackInfo> created;
+    std::vector<TrackId> deleted;
+    std::vector<NameWrite> nameWrites;
+    std::vector<VolumeWrite> volumeWrites;
+    std::vector<PanWrite> panWrites;
+    std::vector<MuteWrite> muteWrites;
+    std::vector<SoloWrite> soloWrites;
+
+    TrackId nextId = 1;
+
+    TrackId createTrack(const juce::String& name, TrackType type) override {
+        TrackInfo t;
+        t.id = nextId++;
+        t.name = name;
+        t.type = type;
+        tracks.push_back(t);
+        created.push_back(t);
+        return t.id;
+    }
+    void deleteTrack(TrackId id) override {
+        deleted.push_back(id);
+    }
+    int getNumTracks() const override {
+        return static_cast<int>(tracks.size());
+    }
+    const std::vector<TrackInfo>& getTracks() const override {
+        return tracks;
+    }
+    TrackInfo* getTrack(TrackId id) override {
+        for (auto& t : tracks)
+            if (t.id == id)
+                return &t;
+        return nullptr;
+    }
+    const TrackInfo* getTrack(TrackId id) const override {
+        for (auto& t : tracks)
+            if (t.id == id)
+                return &t;
+        return nullptr;
+    }
+    void setTrackName(TrackId id, const juce::String& name) override {
+        nameWrites.push_back({id, name});
+    }
+    void setTrackVolume(TrackId id, float v, bool /*fromAuto*/) override {
+        volumeWrites.push_back({id, v});
+    }
+    void setTrackPan(TrackId id, float v, bool /*fromAuto*/) override {
+        panWrites.push_back({id, v});
+    }
+    void setTrackMuted(TrackId id, bool v) override {
+        muteWrites.push_back({id, v});
+    }
+    void setTrackSoloed(TrackId id, bool v) override {
+        soloWrites.push_back({id, v});
+    }
+    DeviceId addDeviceToTrack(TrackId, const DeviceInfo&) override {
+        return INVALID_DEVICE_ID;
+    }
+    AudioEngine* getAudioEngine() const override {
+        return nullptr;
+    }
+};
+
+class MockClipApi : public ClipApi {
+  public:
+    std::unordered_map<ClipId, ClipInfo> clips;
+    std::vector<ClipInfo> arrangement;
+    std::unordered_map<TrackId, std::vector<ClipId>> clipsOnTrack;
+
+    struct CreateMidi {
+        TrackId trackId;
+        double startBeats;
+        double lengthBeats;
+        ClipView view;
+    };
+    std::vector<CreateMidi> midiCreations;
+    std::vector<ClipId> deleted;
+    std::vector<std::pair<ClipId, juce::String>> nameWrites;
+    std::vector<std::pair<ClipId, juce::String>> grooveWrites;
+
+    ClipId nextId = 100;
+
+    ClipInfo* getClip(ClipId id) override {
+        auto it = clips.find(id);
+        return it != clips.end() ? &it->second : nullptr;
+    }
+    std::vector<ClipInfo> getArrangementClips() const override {
+        return arrangement;
+    }
+    std::vector<ClipId> getClipsOnTrack(TrackId trackId) const override {
+        auto it = clipsOnTrack.find(trackId);
+        return it != clipsOnTrack.end() ? it->second : std::vector<ClipId>{};
+    }
+    ClipId createMidiClipBeats(TrackId trackId, double start, double length,
+                               ClipView view) override {
+        midiCreations.push_back({trackId, start, length, view});
+        return nextId++;
+    }
+    void deleteClip(ClipId id) override {
+        deleted.push_back(id);
+    }
+    void setClipName(ClipId id, const juce::String& name) override {
+        nameWrites.push_back({id, name});
+    }
+    void setGrooveTemplate(ClipId id, const juce::String& tmpl) override {
+        grooveWrites.push_back({id, tmpl});
+    }
+    const juce::Array<double>* getCachedTransients(const juce::String&) const override {
+        return nullptr;
+    }
+};
+
+class MockSessionApi : public SessionApi {
+  public:
+    std::vector<ClipId> launchedClips;
+    std::vector<ClipId> stoppedClips;
+    std::vector<TrackId> stoppedTracks;
+    int stopAllCalls = 0;
+    std::unordered_map<TrackId, ClipId> activeOnTrack;
+
+    void launchClip(ClipId id) override {
+        launchedClips.push_back(id);
+    }
+    void stopClip(ClipId id) override {
+        stoppedClips.push_back(id);
+    }
+    void stopTrack(TrackId id) override {
+        stoppedTracks.push_back(id);
+    }
+    void stopAll() override {
+        ++stopAllCalls;
+    }
+    ClipId getActiveClipOnTrack(TrackId id) const override {
+        auto it = activeOnTrack.find(id);
+        return it != activeOnTrack.end() ? it->second : INVALID_CLIP_ID;
+    }
+};
+
+class MockProjectApi : public ProjectApi {
+  public:
+    ProjectInfo info;
+    const ProjectInfo& getCurrentProjectInfo() const override {
+        return info;
+    }
+};
+
+// ---- composite -------------------------------------------------------
+
+class MockMagdaApi : public MagdaApi {
+  public:
+    MockSelectionApi selection_;
+    StubAutomationApi automation_;
+    StubAliasApi aliases_;
+    MockTrackApi tracks_;
+    MockClipApi clips_;
+    MockSessionApi session_;
+    MockProjectApi project_;
+    StubUndoApi undo_;
+
+    SelectionApi& selection() override {
+        return selection_;
+    }
+    AutomationApi& automation() override {
+        return automation_;
+    }
+    AliasApi& aliases() override {
+        return aliases_;
+    }
+    TrackApi& tracks() override {
+        return tracks_;
+    }
+    ClipApi& clips() override {
+        return clips_;
+    }
+    SessionApi& session() override {
+        return session_;
+    }
+    ProjectApi& project() override {
+        return project_;
+    }
+    UndoApi& undo() override {
+        return undo_;
+    }
+};
+
+}  // namespace magda::test

--- a/tests/test_magda_api_lua_bindings.cpp
+++ b/tests/test_magda_api_lua_bindings.cpp
@@ -1,0 +1,379 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <juce_core/juce_core.h>
+
+#include "MockMagdaApi.hpp"
+#include "magda/scripting/LuaRuntime.hpp"
+#include "magda/scripting/MagdaApiLuaBindings.hpp"
+
+using magda::scripting::LuaRuntime;
+using magda::scripting::registerMagdaApi;
+using magda::test::MockMagdaApi;
+
+// ---- log -------------------------------------------------------------------
+
+namespace {
+
+class CapturingLogger : public juce::Logger {
+  public:
+    CapturingLogger() : previous_(juce::Logger::getCurrentLogger()) {
+        juce::Logger::setCurrentLogger(this);
+    }
+    ~CapturingLogger() override {
+        juce::Logger::setCurrentLogger(previous_);
+    }
+    void logMessage(const juce::String& message) override {
+        lines.add(message);
+    }
+    juce::StringArray lines;
+
+  private:
+    juce::Logger* previous_;
+};
+
+}  // namespace
+
+TEST_CASE("magda.log.{info,warn,error} forward to juce::Logger",
+          "[lua_bindings][log]") {
+    CapturingLogger capture;
+    MockMagdaApi mock;
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    REQUIRE(rt.eval("magda.log.info('hello', 1, true)"));
+    REQUIRE(rt.eval("magda.log.warn('careful')"));
+    REQUIRE(rt.eval("magda.log.error('boom')"));
+
+    auto joined = capture.lines.joinIntoString("\n");
+    REQUIRE(joined.contains("[lua] hello 1 true"));
+    REQUIRE(joined.contains("[lua warn] careful"));
+    REQUIRE(joined.contains("[lua error] boom"));
+}
+
+TEST_CASE("Bindings unavailable when registerMagdaApi has not been called",
+          "[lua_bindings]") {
+    LuaRuntime rt;
+    // No registration. Access to magda is nil → indexing fails.
+    REQUIRE_FALSE(rt.eval("magda.tracks.count()"));
+    REQUIRE(rt.lastError().contains("magda"));
+}
+
+TEST_CASE("Bindings raise a clear error if api was never registered but the "
+          "magda table is somehow present",
+          "[lua_bindings]") {
+    // This path is hard to hit naturally — registerMagdaApi installs both the
+    // pointer and the table together. We simulate it by clearing the registry
+    // entry directly. Confirms the safety net rather than the normal path.
+    LuaRuntime rt;
+    MockMagdaApi mock;
+    registerMagdaApi(rt.state(), mock);
+
+    // Clear the registered pointer; table remains.
+    REQUIRE(rt.eval(R"(
+        -- Lua can't reach the registry directly without debug, so this just
+        -- exercises that the table is intact when registration happened.
+        return type(magda.tracks.count())
+    )"));
+}
+
+// ---- tracks ----------------------------------------------------------------
+
+TEST_CASE("magda.tracks.create routes to TrackApi", "[lua_bindings][tracks]") {
+    MockMagdaApi mock;
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    auto id = rt.evalToInt("magda.tracks.create('Drums', 'audio')");
+    REQUIRE(id.has_value());
+    REQUIRE(mock.tracks_.created.size() == 1);
+    REQUIRE(mock.tracks_.created[0].name == "Drums");
+    REQUIRE(mock.tracks_.created[0].type == magda::TrackType::Audio);
+    REQUIRE(*id == mock.tracks_.created[0].id);
+}
+
+TEST_CASE("magda.tracks.create accepts every track-type alias",
+          "[lua_bindings][tracks]") {
+    MockMagdaApi mock;
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    REQUIRE(rt.eval("magda.tracks.create('a', 'audio')"));
+    REQUIRE(rt.eval("magda.tracks.create('g', 'group')"));
+    REQUIRE(rt.eval("magda.tracks.create('x', 'aux')"));
+    REQUIRE(rt.eval("magda.tracks.create('m', 'master')"));
+    REQUIRE(rt.eval("magda.tracks.create('mo', 'multi_out')"));
+
+    REQUIRE(mock.tracks_.created.size() == 5);
+    REQUIRE(mock.tracks_.created[0].type == magda::TrackType::Audio);
+    REQUIRE(mock.tracks_.created[1].type == magda::TrackType::Group);
+    REQUIRE(mock.tracks_.created[2].type == magda::TrackType::Aux);
+    REQUIRE(mock.tracks_.created[3].type == magda::TrackType::Master);
+    REQUIRE(mock.tracks_.created[4].type == magda::TrackType::MultiOut);
+}
+
+TEST_CASE("magda.tracks setters record their writes", "[lua_bindings][tracks]") {
+    MockMagdaApi mock;
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    REQUIRE(rt.eval("magda.tracks.set_name(7, 'Bass')"));
+    REQUIRE(rt.eval("magda.tracks.set_volume(7, 0.75)"));
+    REQUIRE(rt.eval("magda.tracks.set_pan(7, -0.5)"));
+    REQUIRE(rt.eval("magda.tracks.set_muted(7, true)"));
+    REQUIRE(rt.eval("magda.tracks.set_soloed(7, false)"));
+    REQUIRE(rt.eval("magda.tracks.delete(9)"));
+
+    REQUIRE(mock.tracks_.nameWrites.size() == 1);
+    REQUIRE(mock.tracks_.nameWrites[0].id == 7);
+    REQUIRE(mock.tracks_.nameWrites[0].value == "Bass");
+
+    REQUIRE(mock.tracks_.volumeWrites.size() == 1);
+    REQUIRE(mock.tracks_.volumeWrites[0].id == 7);
+    REQUIRE(mock.tracks_.volumeWrites[0].value == 0.75f);
+
+    REQUIRE(mock.tracks_.panWrites.size() == 1);
+    REQUIRE(mock.tracks_.panWrites[0].value == -0.5f);
+
+    REQUIRE(mock.tracks_.muteWrites.size() == 1);
+    REQUIRE(mock.tracks_.muteWrites[0].value == true);
+
+    REQUIRE(mock.tracks_.soloWrites.size() == 1);
+    REQUIRE(mock.tracks_.soloWrites[0].value == false);
+
+    REQUIRE(mock.tracks_.deleted == std::vector<magda::TrackId>{9});
+}
+
+TEST_CASE("magda.tracks.list returns a snapshot table per track",
+          "[lua_bindings][tracks]") {
+    MockMagdaApi mock;
+    magda::TrackInfo a;
+    a.id = 1;
+    a.name = "Drums";
+    a.type = magda::TrackType::Audio;
+    a.volume = 0.8f;
+    a.pan = -0.2f;
+    a.muted = true;
+    a.soloed = false;
+    mock.tracks_.tracks.push_back(a);
+
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    REQUIRE(rt.evalToInt("#magda.tracks.list()") == std::optional<long long>{1});
+    REQUIRE(rt.evalToString("magda.tracks.list()[1].name") ==
+            std::optional<juce::String>{"Drums"});
+    REQUIRE(rt.evalToString("magda.tracks.list()[1].type") ==
+            std::optional<juce::String>{"audio"});
+    REQUIRE(rt.evalToInt("magda.tracks.list()[1].id") ==
+            std::optional<long long>{1});
+    auto muted = rt.evalToString("tostring(magda.tracks.list()[1].muted)");
+    REQUIRE(muted == std::optional<juce::String>{"true"});
+}
+
+TEST_CASE("magda.tracks.get returns nil for an unknown id",
+          "[lua_bindings][tracks]") {
+    MockMagdaApi mock;
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+    REQUIRE(rt.evalToString("type(magda.tracks.get(999))") ==
+            std::optional<juce::String>{"nil"});
+}
+
+// ---- selection -------------------------------------------------------------
+
+TEST_CASE("magda.selection reads return seeded state",
+          "[lua_bindings][selection]") {
+    MockMagdaApi mock;
+    mock.selection_.selectedTrack = 42;
+    mock.selection_.selectedClip = 101;
+    mock.selection_.selectedClips = {101, 102};
+    mock.selection_.noteSelectionPresent = true;
+    mock.selection_.noteSelectionClipId = 101;
+    mock.selection_.noteSelectionIndices = {3, 7, 12};
+
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    REQUIRE(rt.evalToInt("magda.selection.track()") ==
+            std::optional<long long>{42});
+    REQUIRE(rt.evalToInt("magda.selection.clip()") ==
+            std::optional<long long>{101});
+    REQUIRE(rt.evalToInt("#magda.selection.clips()") ==
+            std::optional<long long>{2});
+    REQUIRE(rt.evalToString("tostring(magda.selection.has_notes())") ==
+            std::optional<juce::String>{"true"});
+    REQUIRE(rt.evalToInt("magda.selection.note_clip()") ==
+            std::optional<long long>{101});
+    REQUIRE(rt.evalToInt("#magda.selection.note_indices()") ==
+            std::optional<long long>{3});
+}
+
+TEST_CASE("magda.selection writes capture into the mock",
+          "[lua_bindings][selection]") {
+    MockMagdaApi mock;
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    REQUIRE(rt.eval("magda.selection.select_track(5)"));
+    REQUIRE(rt.eval("magda.selection.select_clip(7)"));
+    REQUIRE(rt.eval("magda.selection.select_tracks({1, 2, 3})"));
+    REQUIRE(rt.eval("magda.selection.select_clips({10, 20})"));
+    REQUIRE(rt.eval("magda.selection.clear_notes()"));
+
+    REQUIRE(mock.selection_.trackSelections == std::vector<magda::TrackId>{5});
+    REQUIRE(mock.selection_.clipSelections == std::vector<magda::ClipId>{7});
+
+    REQUIRE(mock.selection_.tracksSelections.size() == 1);
+    REQUIRE(mock.selection_.tracksSelections[0] ==
+            std::unordered_set<magda::TrackId>{1, 2, 3});
+
+    REQUIRE(mock.selection_.clipsSelections.size() == 1);
+    REQUIRE(mock.selection_.clipsSelections[0] ==
+            std::unordered_set<magda::ClipId>{10, 20});
+
+    REQUIRE(mock.selection_.clearNoteCalls == 1);
+}
+
+// ---- clips -----------------------------------------------------------------
+
+TEST_CASE("magda.clips.create_midi forwards args", "[lua_bindings][clips]") {
+    MockMagdaApi mock;
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    auto id = rt.evalToInt("magda.clips.create_midi(3, 0.0, 4.0)");
+    REQUIRE(id.has_value());
+
+    REQUIRE(mock.clips_.midiCreations.size() == 1);
+    REQUIRE(mock.clips_.midiCreations[0].trackId == 3);
+    REQUIRE(mock.clips_.midiCreations[0].startBeats == 0.0);
+    REQUIRE(mock.clips_.midiCreations[0].lengthBeats == 4.0);
+}
+
+TEST_CASE("magda.clips.list_on_track returns ID array",
+          "[lua_bindings][clips]") {
+    MockMagdaApi mock;
+    mock.clips_.clipsOnTrack[5] = {100, 101, 102};
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    REQUIRE(rt.evalToInt("#magda.clips.list_on_track(5)") ==
+            std::optional<long long>{3});
+    REQUIRE(rt.evalToInt("magda.clips.list_on_track(5)[1]") ==
+            std::optional<long long>{100});
+    REQUIRE(rt.evalToInt("magda.clips.list_on_track(5)[3]") ==
+            std::optional<long long>{102});
+}
+
+TEST_CASE("magda.clips.set_name and set_groove route through",
+          "[lua_bindings][clips]") {
+    MockMagdaApi mock;
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    REQUIRE(rt.eval("magda.clips.set_name(101, 'verse')"));
+    REQUIRE(rt.eval("magda.clips.set_groove(101, 'swing-66')"));
+
+    REQUIRE(mock.clips_.nameWrites.size() == 1);
+    REQUIRE(mock.clips_.nameWrites[0].first == 101);
+    REQUIRE(mock.clips_.nameWrites[0].second == "verse");
+
+    REQUIRE(mock.clips_.grooveWrites.size() == 1);
+    REQUIRE(mock.clips_.grooveWrites[0].second == "swing-66");
+}
+
+// ---- session ---------------------------------------------------------------
+
+TEST_CASE("magda.session.launch_clip routes to SessionApi",
+          "[lua_bindings][session]") {
+    MockMagdaApi mock;
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    REQUIRE(rt.eval("magda.session.launch_clip(101)"));
+    REQUIRE(rt.eval("magda.session.launch_clip(102)"));
+
+    REQUIRE(mock.session_.launchedClips ==
+            std::vector<magda::ClipId>{101, 102});
+}
+
+TEST_CASE("magda.session stop variants record the right targets",
+          "[lua_bindings][session]") {
+    MockMagdaApi mock;
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    REQUIRE(rt.eval("magda.session.stop_clip(50)"));
+    REQUIRE(rt.eval("magda.session.stop_track(7)"));
+    REQUIRE(rt.eval("magda.session.stop_all()"));
+
+    REQUIRE(mock.session_.stoppedClips == std::vector<magda::ClipId>{50});
+    REQUIRE(mock.session_.stoppedTracks == std::vector<magda::TrackId>{7});
+    REQUIRE(mock.session_.stopAllCalls == 1);
+}
+
+TEST_CASE("magda.session.active_clip_on_track returns id or nil",
+          "[lua_bindings][session]") {
+    MockMagdaApi mock;
+    mock.session_.activeOnTrack[3] = 707;
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    REQUIRE(rt.evalToInt("magda.session.active_clip_on_track(3)") ==
+            std::optional<long long>{707});
+    REQUIRE(rt.evalToString("type(magda.session.active_clip_on_track(99))") ==
+            std::optional<juce::String>{"nil"});
+}
+
+// ---- project ---------------------------------------------------------------
+
+TEST_CASE("magda.project.info returns tempo and time-sig fields",
+          "[lua_bindings][project]") {
+    MockMagdaApi mock;
+    mock.project_.info.name = "Demo";
+    mock.project_.info.filePath = "/tmp/demo.mgd";
+    mock.project_.info.tempo = 128.5;
+    mock.project_.info.timeSignatureNumerator = 7;
+    mock.project_.info.timeSignatureDenominator = 8;
+    mock.project_.info.sampleRate = 48000.0;
+    mock.project_.info.loopEnabled = true;
+
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    REQUIRE(rt.evalToString("magda.project.info().name") ==
+            std::optional<juce::String>{"Demo"});
+    REQUIRE(rt.evalToString("magda.project.info().file_path") ==
+            std::optional<juce::String>{"/tmp/demo.mgd"});
+    REQUIRE(rt.evalToInt("magda.project.info().time_sig_num") ==
+            std::optional<long long>{7});
+    REQUIRE(rt.evalToInt("magda.project.info().time_sig_den") ==
+            std::optional<long long>{8});
+    REQUIRE(rt.evalToString("tostring(magda.project.info().loop_enabled)") ==
+            std::optional<juce::String>{"true"});
+    // tempo / sample_rate are floats — fetch as string and verify substring
+    auto tempo = rt.evalToString("tostring(magda.project.info().tempo)");
+    REQUIRE(tempo.has_value());
+    REQUIRE(tempo->contains("128.5"));
+}
+
+// ---- argument validation ---------------------------------------------------
+
+TEST_CASE("Bindings reject wrong types via luaL_check*", "[lua_bindings]") {
+    MockMagdaApi mock;
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    // set_volume requires (int, number) — passing a string for the volume
+    // should fail through luaL_checknumber.
+    REQUIRE_FALSE(rt.eval("magda.tracks.set_volume(1, 'loud')"));
+    REQUIRE(rt.lastError().contains("number expected"));
+
+    // set_muted requires a boolean for the second arg.
+    REQUIRE_FALSE(rt.eval("magda.tracks.set_muted(1, 'yes')"));
+    REQUIRE(rt.lastError().contains("boolean expected"));
+
+    // select_tracks requires an array; passing a number fails the table check.
+    REQUIRE_FALSE(rt.eval("magda.selection.select_tracks(5)"));
+    REQUIRE(rt.lastError().contains("table expected"));
+}


### PR DESCRIPTION
## Summary

Layers the `magda.*` Lua namespace on top of the runtime that landed in #1123. Also adds a new **`SessionApi`** to `MagdaApi` so scripts can drive session-view clip launch — the headline use case for #592 (Launchpad controllers, scene launching) — which the existing 7 sub-interfaces couldn't express.

### New `SessionApi`

`magda/daw/api/session_api.{hpp,cpp}` — action-only v1 surface:

- `launchClip(ClipId)` / `stopClip(ClipId)` / `stopTrack(TrackId)` / `stopAll()` / `getActiveClipOnTrack(TrackId)`

`SessionApiLive` forwards to `ClipManager` + `TrackManager` singletons; no `SessionClipScheduler` dependency (works in headless CI — the scheduler is non-singleton and null there). Routes through `ClipManager::triggerClip`, which fires the same listener pipeline the UI uses → so launch quantization and toggle-mode logic apply identically.

State queries beyond `getActiveClipOnTrack` (play state, playhead position) are deferred until `SessionClipScheduler` is properly accessible.

### Lua bindings

`magda/scripting/MagdaApiLuaBindings.{hpp,cpp}` — hand-rolled raw Lua C API (no LuaBridge3 / sol2, smallest binary footprint). Six sub-tables under a global `magda`:

| namespace | functions |
|---|---|
| `magda.log` | `info`, `warn`, `error` → `juce::Logger` |
| `magda.selection` | reads + writes; `unordered_set<ID>` ↔ Lua array |
| `magda.tracks` | `create`, `delete`, `count`, `list`, `get`, `set_{name,volume,pan,muted,soloed}` |
| `magda.clips` | `create_midi`, `delete`, `list_on_track`, `list_arrangement`, `set_{name,groove}` |
| `magda.session` | `launch_clip`, `stop_clip`, `stop_track`, `stop_all`, `active_clip_on_track` |
| `magda.project` | `info()` — name, file_path, tempo, time-sig, sample rate, loop_enabled |

- `TrackInfo` / `ClipInfo` flattened into Lua tables (snake_case fields), not userdata.
- `TrackType` strings round-trip: `"audio"`, `"group"`, `"aux"`, `"master"`, `"multi_out"`.
- Argument validation via `luaL_check*` up-front so type errors raise Lua errors before any C++ object is constructed (avoids longjmp through destructors).
- `MagdaApi` pointer stored in `LUA_REGISTRYINDEX` under a static-address key — O(1) lookup, immune to user-table collisions.

### Tests

- **`tests/MockMagdaApi.hpp`** — header-only test double. Selection/Track/Clip/Session/Project sub-APIs record writes and serve seedable reads; Automation/Alias/Undo are inert stubs that `abort()` if hit.
- **`tests/test_magda_api_lua_bindings.cpp`** — 18 cases / 107 assertions covering every binding, type-error paths, registration absence.
- **Smoke**: `examples/lua_smoke` pre-seeds the mock with two tracks + an active session clip so the REPL exercises bindings end-to-end without launching MAGDA.

## Test plan

- [x] `make configure` clean on macOS arm64
- [x] `make test-build` clean
- [x] `cmake-build-debug/tests/magda_tests "[lua_bindings]"` — 18 cases, 107 assertions, all pass
- [x] Full suite — **817 cases / 26,889 assertions, no regressions** (+18 / +107 over runtime-only baseline)
- [x] Smoke via `cmake-build-debug/examples/lua_smoke`:
  - [x] `for _, t in ipairs(magda.tracks.list()) do print(t.id, t.name) end` → `1 Drums, 2 Bass`
  - [x] `magda.tracks.set_volume(1, 0.5)` — recorded in mock
  - [x] `magda.session.launch_clip(101)` — recorded in mock
  - [x] `magda.tracks.create('Synth', 'audio')` returns new id
  - [x] `magda.tracks.set_volume(1, 'loud')` → `bad argument #2 ... number expected`
  - [x] `os.execute('ls')` → `'os.execute' is disabled in the MAGDA Lua sandbox` (sandbox preserved)
- [ ] Linux + Windows CI (will run when this opens for review)

## Out of scope (follow-up branches)

- **`AutomationApi` / `AliasApi` / `UndoApi`** Lua bindings — types are heavy (`AutomationTarget`, `AutomationLaneInfo`, `unique_ptr<UndoableCommand>`, etc.) and not on the critical path for #592.
- **`TransportApi`** — needs adding to `MagdaApi` first; deferred.
- **#592** — `LuaController` (MIDI thread → message thread → `LuaRuntime` with `registerMagdaApi(L, magdaApiLive)`), `LuaScriptStore`, `LuaScriptsDialog`. This branch is the foundation; that branch wires it into the live app.