### PR TITLE
feat(paths): configurable user-data folders (Data / Presets / Render)

### DIFF
--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -222,6 +222,7 @@ set(DAW_CORE_SOURCES
     command.cpp
     magda.cpp
     core/Config.cpp
+    core/AppPaths.cpp
     core/UIScale.cpp
     core/UpdateChecker.cpp
     core/ViewModeController.cpp
@@ -540,6 +541,7 @@ set(DAW_HEADERS
     profiling/PerformanceProfiler.hpp
     profiling/BenchmarkSuite.hpp
     core/Config.hpp
+    core/AppPaths.hpp
     core/UIScale.hpp
     core/DeviceInfo.hpp
     core/ViewModeState.hpp

--- a/magda/daw/core/AppPaths.cpp
+++ b/magda/daw/core/AppPaths.cpp
@@ -1,0 +1,216 @@
+#include "AppPaths.hpp"
+
+#include "Config.hpp"
+
+#include <atomic>
+#include <mutex>
+
+namespace magda::paths {
+
+namespace {
+
+// Resolved roots are stored as lazy holders behind a mutex so resolve() can
+// update them safely from the message thread while readers (potentially on
+// other threads — e.g. plugin scanner subprocess controller) take a stable
+// snapshot. Reads happen vastly more often than resolve() runs, so the
+// shared_ptr swap is cheaper than copying juce::String into atomics.
+struct Resolved {
+    juce::File data;
+    juce::File presets;
+    juce::File render;
+    bool dataFromEnv = false;
+    bool presetsFromEnv = false;
+    bool renderFromEnv = false;
+};
+
+std::mutex& cacheMutex() {
+    static std::mutex m;
+    return m;
+}
+
+std::shared_ptr<const Resolved>& cachedSlot() {
+    static std::shared_ptr<const Resolved> ptr;
+    return ptr;
+}
+
+std::shared_ptr<const Resolved> snapshot() {
+    std::lock_guard<std::mutex> lock(cacheMutex());
+    if (cachedSlot() == nullptr) {
+        // Bootstrap: first reader before resolve() ran. Compute defaults
+        // on demand so paths remain useful even if a consumer touches them
+        // before MagdaDAWApplication::initialise() reaches its resolve()
+        // call (e.g. unit tests that don't run a JUCE app).
+        auto fresh = std::make_shared<Resolved>();
+        fresh->data = alwaysOSDefault();
+        fresh->presets = juce::File::getSpecialLocation(juce::File::userDocumentsDirectory)
+                             .getChildFile("MAGDA")
+                             .getChildFile("Presets");
+        fresh->render = juce::File::getSpecialLocation(juce::File::userDocumentsDirectory)
+                            .getChildFile("MAGDA")
+                            .getChildFile("Renders");
+        cachedSlot() = fresh;
+    }
+    return cachedSlot();
+}
+
+// JUCE doesn't expose getEnvironmentVariable on every platform via the
+// SystemStats subset we link; use std::getenv directly.
+juce::String envVar(const char* name) {
+    if (const char* v = std::getenv(name); v != nullptr && v[0] != '\0')
+        return juce::String::fromUTF8(v);
+    return {};
+}
+
+juce::File defaultPresets() {
+    return juce::File::getSpecialLocation(juce::File::userDocumentsDirectory)
+        .getChildFile("MAGDA")
+        .getChildFile("Presets");
+}
+
+juce::File defaultRender() {
+    return juce::File::getSpecialLocation(juce::File::userDocumentsDirectory)
+        .getChildFile("MAGDA")
+        .getChildFile("Renders");
+}
+
+// Combine override with default. Returns {file, fromEnv}: env wins over
+// configured, configured wins over default. fromEnv is true only when the
+// env var was used.
+struct ResolveOne {
+    juce::File file;
+    bool fromEnv;
+};
+
+ResolveOne resolveOne(const juce::String& envVal,
+                      const std::string& configVal,
+                      const juce::File& fallback) {
+    if (envVal.isNotEmpty())
+        return {juce::File(envVal), true};
+    if (!configVal.empty())
+        return {juce::File(juce::String::fromUTF8(configVal.c_str(),
+                                                   static_cast<int>(configVal.size()))),
+                false};
+    return {fallback, false};
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Resolved roots
+// ---------------------------------------------------------------------------
+
+juce::File dataDir() {
+    return snapshot()->data;
+}
+
+juce::File presetsDir() {
+    return snapshot()->presets;
+}
+
+juce::File renderDir() {
+    return snapshot()->render;
+}
+
+juce::File alwaysOSDefault() {
+    return juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
+        .getChildFile("MAGDA");
+}
+
+// ---------------------------------------------------------------------------
+// Computed subpaths
+// ---------------------------------------------------------------------------
+
+juce::File logsDir() {
+    return dataDir().getChildFile("Logs");
+}
+
+juce::File controllerScriptsDir() {
+    return dataDir().getChildFile("Scripts").getChildFile("Controllers");
+}
+
+juce::File controllerProfilesDir() {
+    return dataDir().getChildFile("controllers");
+}
+
+juce::File pluginConfigsDir() {
+    return dataDir().getChildFile("PluginConfigs");
+}
+
+juce::File configFile() {
+    return alwaysOSDefault().getChildFile("config.json");
+}
+
+juce::File pluginListFile() {
+    return dataDir().getChildFile("PluginList.xml");
+}
+
+juce::File pluginCacheFile() {
+    return dataDir().getChildFile("PluginCache.json");
+}
+
+juce::File pluginExclusionsFile() {
+    return dataDir().getChildFile("plugin_exclusions.txt");
+}
+
+juce::File pluginScanMarkerFile(const juce::String& format) {
+    return dataDir().getChildFile("scanning_" + format + ".txt");
+}
+
+juce::File lastScanReportFile() {
+    return dataDir().getChildFile("last_scan_report.txt");
+}
+
+juce::File pluginFavoritesFile() {
+    return dataDir().getChildFile("plugin_favorites.xml");
+}
+
+juce::File pluginAliasesFile() {
+    return dataDir().getChildFile("plugin_aliases.xml");
+}
+
+juce::File parameterDetectorLog() {
+    return dataDir().getChildFile("param_detector.log");
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+void resolve() {
+    auto fresh = std::make_shared<Resolved>();
+
+    // Config may not be loaded yet on the first call; getInstance() returns
+    // a default-initialised instance whose path getters return empty strings,
+    // which the resolveOne fallback handles correctly.
+    auto& cfg = Config::getInstance();
+
+    auto data = resolveOne(envVar("MAGDA_DATA_DIR"), cfg.getDataDir(), alwaysOSDefault());
+    auto presets = resolveOne(envVar("MAGDA_PRESETS_DIR"), cfg.getPresetsDir(), defaultPresets());
+    auto render = resolveOne(envVar("MAGDA_RENDER_DIR"), cfg.getRenderFolder(), defaultRender());
+
+    fresh->data = data.file;
+    fresh->presets = presets.file;
+    fresh->render = render.file;
+    fresh->dataFromEnv = data.fromEnv;
+    fresh->presetsFromEnv = presets.fromEnv;
+    fresh->renderFromEnv = render.fromEnv;
+
+    {
+        std::lock_guard<std::mutex> lock(cacheMutex());
+        cachedSlot() = fresh;
+    }
+}
+
+bool dataDirOverriddenByEnv() {
+    return snapshot()->dataFromEnv;
+}
+
+bool presetsDirOverriddenByEnv() {
+    return snapshot()->presetsFromEnv;
+}
+
+bool renderDirOverriddenByEnv() {
+    return snapshot()->renderFromEnv;
+}
+
+}  // namespace magda::paths

--- a/magda/daw/core/AppPaths.hpp
+++ b/magda/daw/core/AppPaths.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+// Centralised filesystem path resolution for MAGDA's per-user files.
+//
+// Three configurable roots (resolved in this order — first non-empty wins):
+//   1. Environment variable (MAGDA_DATA_DIR / MAGDA_PRESETS_DIR / MAGDA_RENDER_DIR)
+//   2. magda::Config (Preferences → Paths)
+//   3. OS-default (juce::File::getSpecialLocation)
+//
+// Resolution happens at startup via resolve(); for the hot-swappable knobs
+// (presets, render) it can be re-run after Config changes. Once resolved,
+// every path consumer goes through one of the named accessors below — no
+// caller should bake juce::File::getSpecialLocation(...) into its own logic.
+//
+// The CONFIG FILE itself stays at alwaysOSDefault() / "config.json", because
+// Config has to be loaded BEFORE the configured data dir is known.
+
+namespace magda::paths {
+
+// ---------------------------------------------------------------------------
+// Resolved roots
+// ---------------------------------------------------------------------------
+
+/** Per-user data: logs, config, scripts, plugin caches, controller profiles. */
+juce::File dataDir();
+
+/** Per-user user-facing presets (Chains, Racks, Devices). */
+juce::File presetsDir();
+
+/** Default destination for rendered audio. */
+juce::File renderDir();
+
+/** OS-default appdata root (`~/Library/Application Support/MAGDA` on macOS).
+ *  Returned regardless of override — needed because the config file itself
+ *  is anchored here so the override can be read from it. */
+juce::File alwaysOSDefault();
+
+// ---------------------------------------------------------------------------
+// Computed subpaths under dataDir()
+// ---------------------------------------------------------------------------
+
+juce::File logsDir();                 // dataDir() / "Logs"
+juce::File controllerScriptsDir();    // dataDir() / "Scripts" / "Controllers"
+juce::File controllerProfilesDir();   // dataDir() / "controllers"
+juce::File pluginConfigsDir();        // dataDir() / "PluginConfigs"
+
+juce::File configFile();              // alwaysOSDefault() / "config.json"
+juce::File pluginListFile();          // dataDir() / "PluginList.xml"
+juce::File pluginCacheFile();         // dataDir() / "PluginCache.json"
+juce::File pluginExclusionsFile();    // dataDir() / "plugin_exclusions.txt"
+juce::File pluginScanMarkerFile(const juce::String& format);  // dataDir() / "scanning_<format>.txt"
+juce::File lastScanReportFile();      // dataDir() / "last_scan_report.txt"
+juce::File pluginFavoritesFile();     // dataDir() / "plugin_favorites.xml"
+juce::File pluginAliasesFile();       // dataDir() / "plugin_aliases.xml"
+juce::File parameterDetectorLog();    // dataDir() / "param_detector.log"
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/** Read env vars + (if loaded) Config and update the cached resolved roots.
+ *
+ *  Safe to call from anywhere; cheap. Called twice during startup:
+ *    1. Before the file logger is created (Config not yet loaded — env vars
+ *       and OS defaults take effect).
+ *    2. After Config::load() — picks up persisted user overrides.
+ *
+ *  Also safe to call after Config::set{Data,Presets,Render}Dir at runtime to
+ *  apply the change to subsequent path queries (the data-dir knob still
+ *  requires a restart for full effect because file handles are already open;
+ *  that's a UX choice, not a technical limit of resolve()).
+ */
+void resolve();
+
+/** True iff MAGDA_DATA_DIR / MAGDA_PRESETS_DIR / MAGDA_RENDER_DIR is currently
+ *  in effect for the corresponding root. Used by the Paths preferences page
+ *  to mark a knob as "overridden by env var — Config setting is ignored". */
+bool dataDirOverriddenByEnv();
+bool presetsDirOverriddenByEnv();
+bool renderDirOverriddenByEnv();
+
+}  // namespace magda::paths

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -4,17 +4,15 @@
 
 #include <algorithm>
 
+#include "AppPaths.hpp"
+
 // ---------------------------------------------------------------------------
 // Path helper
 // ---------------------------------------------------------------------------
-
-namespace {
-juce::File getConfigFile() {
-    return juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-        .getChildFile("MAGDA")
-        .getChildFile("config.json");
-}
-}  // namespace
+// config.json itself is anchored to the OS default location (paths::configFile
+// returns alwaysOSDefault() / "config.json"). It cannot move with the
+// configurable data dir override — Config has to be loaded BEFORE the
+// override is known.
 
 namespace {
 // Use fromUTF8 to avoid juce_String.cpp:327 assertion when std::string contains non-ASCII bytes
@@ -99,6 +97,11 @@ void Config::save() {
     // Export audio
     root->setProperty("exportFormat", toJuceString(exportFormat));
     root->setProperty("exportSampleRate", exportSampleRate);
+
+    // Configurable user-data paths (empty string = OS default; resolved by
+    // magda::paths::resolve()). Render folder uses the same field as before.
+    root->setProperty("dataDir", toJuceString(dataDir));
+    root->setProperty("presetsDir", toJuceString(presetsDir));
 
     // Render
     root->setProperty("renderFolder", toJuceString(renderFolder));
@@ -214,7 +217,7 @@ void Config::save() {
     }
 
     // Write to disk
-    auto configFile = getConfigFile();
+    auto configFile = magda::paths::configFile();
     configFile.getParentDirectory().createDirectory();
 
     auto json = juce::JSON::toString(juce::var(root.get()));
@@ -234,7 +237,7 @@ void Config::save() {
 // ---------------------------------------------------------------------------
 
 void Config::load() {
-    auto configFile = getConfigFile();
+    auto configFile = magda::paths::configFile();
     if (!configFile.existsAsFile()) {
         DBG("Config::load - file not found, using defaults: " + configFile.getFullPathName());
         return;
@@ -324,6 +327,8 @@ void Config::load() {
     exportFormat = getString("exportFormat", exportFormat);
     exportSampleRate = getDouble("exportSampleRate", exportSampleRate);
 
+    dataDir = getString("dataDir", dataDir);
+    presetsDir = getString("presetsDir", presetsDir);
     renderFolder = getString("renderFolder", renderFolder);
     renderSampleRate = getDouble("renderSampleRate", renderSampleRate);
     renderBitDepth = getInt("renderBitDepth", renderBitDepth);

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -333,6 +333,31 @@ class Config {
         renderFolder = folder;
     }
 
+    // ----- Configurable user-data paths --------------------------------
+    // Empty string means "use OS default". Resolution + env-var override
+    // happens in magda::paths (AppPaths.hpp); these are just the persisted
+    // override strings.
+
+    /** Override for `userApplicationDataDirectory/MAGDA/` — logs, scripts,
+     *  controller profiles, plugin caches. Empty = OS default. Changes
+     *  require a restart to fully apply (file logger + plugin scanner
+     *  hold open file handles). */
+    std::string getDataDir() const {
+        return dataDir;
+    }
+    void setDataDir(const std::string& d) {
+        dataDir = d;
+    }
+
+    /** Override for `userDocumentsDirectory/MAGDA/Presets/` — Chains, Racks,
+     *  Devices. Empty = OS default. Hot-swappable via Config listeners. */
+    std::string getPresetsDir() const {
+        return presetsDir;
+    }
+    void setPresetsDir(const std::string& d) {
+        presetsDir = d;
+    }
+
     double getRenderSampleRate() const {
         return renderSampleRate;
     }
@@ -741,6 +766,11 @@ class Config {
     // Export audio settings
     std::string exportFormat = "WAV24";  // WAV16, WAV24, WAV32, FLAC
     double exportSampleRate = 48000.0;   // 44100, 48000, 96000, 192000
+
+    // Configurable user-data path overrides (resolved by magda::paths).
+    // Empty = OS default. Persisted in config.json.
+    std::string dataDir = "";     // userApplicationDataDirectory/MAGDA/
+    std::string presetsDir = "";  // userDocumentsDirectory/MAGDA/Presets/
 
     // Render settings
     std::string renderFolder = "";  // Custom render output folder (empty = renders/ beside source)

--- a/magda/daw/core/ParameterDetector.cpp
+++ b/magda/daw/core/ParameterDetector.cpp
@@ -1,5 +1,7 @@
 #include "ParameterDetector.hpp"
 
+#include "AppPaths.hpp"
+
 #include <juce_events/juce_events.h>
 #include <juce_llm/juce_llm.h>
 
@@ -15,10 +17,13 @@
 namespace magda {
 namespace {
 
-// File-based logging for parameter detection (avoids flooding console)
+// File-based logging for parameter detection (avoids flooding console).
+// Lives under the configurable data dir alongside the main MAGDA log.
+// Pre-refactor this lived at ~/Library/MAGDA/ (macOS only) which was a
+// stray location — folded into the standard data dir as part of the
+// configurable-paths refactor.
 juce::File getDetectorLogFile() {
-    return juce::File::getSpecialLocation(juce::File::userHomeDirectory)
-        .getChildFile("Library/MAGDA/param_detector.log");
+    return magda::paths::parameterDetectorLog();
 }
 
 void logDetector(const juce::String& msg) {

--- a/magda/daw/core/PresetManager.cpp
+++ b/magda/daw/core/PresetManager.cpp
@@ -1,6 +1,7 @@
 #include "PresetManager.hpp"
 
 #include "../project/serialization/ProjectSerializer.hpp"
+#include "AppPaths.hpp"
 #include "version.hpp"
 
 namespace magda {
@@ -117,8 +118,7 @@ PresetManager::PresetManager() {
 // ============================================================================
 
 juce::File PresetManager::getPresetsDirectory() const {
-    auto docsDir = juce::File::getSpecialLocation(juce::File::userDocumentsDirectory);
-    return docsDir.getChildFile("MAGDA").getChildFile("Presets");
+    return magda::paths::presetsDir();
 }
 
 juce::File PresetManager::getChainsDirectory() const {

--- a/magda/daw/core/controllers/ControllerProfileRegistry.cpp
+++ b/magda/daw/core/controllers/ControllerProfileRegistry.cpp
@@ -1,5 +1,7 @@
 #include "ControllerProfileRegistry.hpp"
 
+#include "../AppPaths.hpp"
+
 #include <algorithm>
 
 namespace magda {
@@ -49,9 +51,7 @@ juce::File ControllerProfileRegistry::findBundledControllersDirectory() {
 }
 
 juce::File ControllerProfileRegistry::userControllersDirectory() {
-    return juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-        .getChildFile("MAGDA")
-        .getChildFile("controllers");
+    return magda::paths::controllerProfilesDir();
 }
 
 juce::String ControllerProfileRegistry::filenameForProfileId(const juce::String& id) {

--- a/magda/daw/engine/PluginScanCoordinator.cpp
+++ b/magda/daw/engine/PluginScanCoordinator.cpp
@@ -1,5 +1,6 @@
 #include "PluginScanCoordinator.hpp"
 
+#include "core/AppPaths.hpp"
 #include "core/Config.hpp"
 
 #if JUCE_LINUX
@@ -462,9 +463,7 @@ void PluginScanCoordinator::killOrphanScannerProcesses() {
 
 // Exclusion management
 juce::File PluginScanCoordinator::getExclusionFile() const {
-    return juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-        .getChildFile("MAGDA")
-        .getChildFile("plugin_exclusions.txt");
+    return magda::paths::pluginExclusionsFile();
 }
 
 const std::vector<ExcludedPlugin>& PluginScanCoordinator::getExcludedPlugins() const {
@@ -501,9 +500,7 @@ void PluginScanCoordinator::saveExclusions() {
 }
 
 juce::File PluginScanCoordinator::getScanReportFile() const {
-    return juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-        .getChildFile("MAGDA")
-        .getChildFile("last_scan_report.txt");
+    return magda::paths::lastScanReportFile();
 }
 
 void PluginScanCoordinator::writeScanReport() {

--- a/magda/daw/engine/PluginScanner.cpp
+++ b/magda/daw/engine/PluginScanner.cpp
@@ -1,5 +1,7 @@
 #include "PluginScanner.hpp"
 
+#include "../core/AppPaths.hpp"
+
 namespace magda {
 
 PluginScanner::PluginScanner() : juce::Thread("Plugin Scanner") {
@@ -73,10 +75,7 @@ void PluginScanner::run() {
         auto searchPath = format->getDefaultLocationsToSearch();
 
         // Dead man's pedal - if we crash, this file tells us which plugin was being scanned
-        juce::File deadMansPedal =
-            juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-                .getChildFile("MAGDA")
-                .getChildFile("scanning_" + formatName + ".txt");
+        juce::File deadMansPedal = magda::paths::pluginScanMarkerFile(formatName);
         (void)deadMansPedal.getParentDirectory().createDirectory();
 
         // Check if there's a dead man's pedal from a previous crash
@@ -182,9 +181,7 @@ void PluginScanner::excludePlugin(const juce::String& pluginPath, const juce::St
 }
 
 juce::File PluginScanner::getExclusionFile() const {
-    return juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-        .getChildFile("MAGDA")
-        .getChildFile("plugin_exclusions.txt");
+    return magda::paths::pluginExclusionsFile();
 }
 
 void PluginScanner::loadExclusions() {

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -3,6 +3,7 @@
 #include <thread>
 #include <utility>
 
+#include "../core/AppPaths.hpp"
 #include "PluginScanCoordinator.hpp"
 #include "TracktionEngineWrapper.hpp"
 #include "core/Config.hpp"
@@ -189,19 +190,11 @@ const juce::KnownPluginList& TracktionEngineWrapper::getKnownPluginList() const 
 }
 
 juce::File TracktionEngineWrapper::getPluginListFile() const {
-    // Store plugin list in app data directory
-    // macOS: ~/Library/Application Support/MAGDA/
-    // Windows: %APPDATA%/MAGDA/
-    // Linux: ~/.config/MAGDA/
-    auto appDataDir = juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-                          .getChildFile("MAGDA");
-
-    // Create directory if it doesn't exist
-    if (!appDataDir.exists()) {
-        appDataDir.createDirectory();
-    }
-
-    return appDataDir.getChildFile("PluginList.xml");
+    // Routed via paths::pluginListFile() — respects MAGDA_DATA_DIR /
+    // Config::getDataDir() override. Defaults to userApplicationDataDirectory.
+    auto file = magda::paths::pluginListFile();
+    file.getParentDirectory().createDirectory();
+    return file;
 }
 
 void TracktionEngineWrapper::savePluginList() {

--- a/magda/daw/magda_daw_main.cpp
+++ b/magda/daw/magda_daw_main.cpp
@@ -8,6 +8,7 @@
 #include "../../magda/agents/llama_model_manager.hpp"
 #include "../../magda/agents/llm_presets.hpp"
 #include "audio/AudioThumbnailManager.hpp"
+#include "core/AppPaths.hpp"
 #include "core/ClipManager.hpp"
 #include "core/Config.hpp"
 #include "core/ModulatorEngine.hpp"
@@ -83,12 +84,28 @@ class MagdaDAWApplication : public JUCEApplication {
             return;
         }
 
-        // Set up file logger early so all startup activity is captured
-        auto logDir = juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-                          .getChildFile("MAGDA")
-                          .getChildFile("Logs");
+        // 0. Configurable user-data paths. Two-phase resolution (issue:
+        //    custom data dir).
+        //    Phase 1: env vars only — Config not yet loaded. Lets MAGDA_DATA_DIR
+        //    redirect even before config.json is read. Files created by font
+        //    init / look-and-feel / etc. land in the right place.
+        magda::paths::resolve();
+
+        // 1. Load Config from its always-OS-default path. config.json itself
+        //    cannot move with the data dir override (chicken-and-egg: we
+        //    have to read it to know where to redirect to).
+        magda::Config::getInstance().load();
+
+        //    Phase 2: re-resolve now that Config has provided any persisted
+        //    path overrides.
+        magda::paths::resolve();
+
+        // 2. File logger — set up only NOW so it lands in the configured
+        //    data dir / Logs. The 4-5 ms of pre-logger init below this
+        //    runs without logging, which is fine; nothing of substance
+        //    logged there pre-refactor either.
+        auto logDir = magda::paths::logsDir();
         if (!logDir.createDirectory()) {
-            // Fall back to temp directory if APPDATA is not writable
             logDir = juce::File::getSpecialLocation(juce::File::tempDirectory)
                          .getChildFile("MAGDA-Logs");
             logDir.createDirectory();
@@ -99,19 +116,22 @@ class MagdaDAWApplication : public JUCEApplication {
         juce::Logger::writeToLog("=== MAGDA " + getApplicationVersion() + " starting ===");
         juce::Logger::writeToLog("OS: " + juce::SystemStats::getOperatingSystemName());
         juce::Logger::writeToLog("Command line: " + commandLine);
+        juce::Logger::writeToLog("Data dir: " + magda::paths::dataDir().getFullPathName() +
+                                 (magda::paths::dataDirOverriddenByEnv()
+                                      ? " (MAGDA_DATA_DIR override)"
+                                      : ""));
 
-        // 1. Initialize fonts
+        // 3. Initialize fonts
         magda::FontManager::getInstance().initialize();
 
-        // 2. Set up dark theme
+        // 4. Set up dark theme
         lookAndFeel_ = std::make_unique<magda::MainLookAndFeel>();
         magda::DarkTheme::applyToLookAndFeel(*lookAndFeel_);
         juce::LookAndFeel::setDefaultLookAndFeel(lookAndFeel_.get());
 
-        // 2a. Apply HiDPI scale before any window is created.
+        // 5. Apply HiDPI scale before any window is created.
         // setGlobalScaleFactor must run before TopLevelWindows exist for clean
         // sizing; see juce_TopLevelWindow.cpp.
-        magda::Config::getInstance().load();
         const double uiScale = magda::resolveStartupScale();
         juce::Desktop::getInstance().setGlobalScaleFactor(static_cast<float>(uiScale));
         juce::Logger::writeToLog("UI scale: " + juce::String(uiScale, 2) + "x");

--- a/magda/daw/magda_daw_main.cpp
+++ b/magda/daw/magda_daw_main.cpp
@@ -11,6 +11,8 @@
 #include "core/AppPaths.hpp"
 #include "core/ClipManager.hpp"
 #include "core/Config.hpp"
+#include "core/PresetManager.hpp"
+#include "magda/scripting/LuaScriptStore.hpp"
 #include "core/ModulatorEngine.hpp"
 #include "core/TrackManager.hpp"
 #include "core/UIScale.hpp"
@@ -120,6 +122,15 @@ class MagdaDAWApplication : public JUCEApplication {
                                  (magda::paths::dataDirOverriddenByEnv()
                                       ? " (MAGDA_DATA_DIR override)"
                                       : ""));
+
+        // Eagerly create the configured per-user folders so they exist on
+        // disk immediately after launch — users expect to find them when
+        // they look at the paths shown in Preferences. PresetManager is a
+        // singleton whose ctor mkdir's Chains/Racks/Devices; touching it
+        // here forces that. LuaScriptStore::ensureExists() does the same
+        // for Scripts/Controllers/.
+        magda::PresetManager::getInstance();
+        magda::scripting::LuaScriptStore{}.ensureExists();
 
         // 3. Initialize fonts
         magda::FontManager::getInstance().initialize();

--- a/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
+++ b/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
@@ -5,6 +5,7 @@
 #include "../themes/DarkTheme.hpp"
 #include "../themes/DialogLookAndFeel.hpp"
 #include "../themes/FontManager.hpp"
+#include "core/AppPaths.hpp"
 #include "core/Config.hpp"
 #include "core/TrackManager.hpp"
 #include "engine/TracktionEngineWrapper.hpp"
@@ -855,11 +856,8 @@ void ParameterConfigDialog::resetParameterConfiguration() {
     // reloads this plugin) applyConfigToDevice finds nothing and the plugin
     // keeps its native metadata.
     if (!pluginUniqueId_.isEmpty()) {
-        auto configFile =
-            juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-                .getChildFile("MAGDA")
-                .getChildFile("PluginConfigs")
-                .getChildFile(pluginUniqueId_.replaceCharacters(":/\\,; ", "______") + ".xml");
+        auto configFile = magda::paths::pluginConfigsDir().getChildFile(
+            pluginUniqueId_.replaceCharacters(":/\\,; ", "______") + ".xml");
         if (configFile.existsAsFile()) {
             configFile.deleteFile();
             DBG("Deleted parameter config: " << configFile.getFullPathName());
@@ -1102,9 +1100,7 @@ void ParameterConfigDialog::saveParameterConfiguration() {
     }
 
     // Get the config directory
-    auto configDir = juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-                         .getChildFile("MAGDA")
-                         .getChildFile("PluginConfigs");
+    auto configDir = magda::paths::pluginConfigsDir();
 
     if (!configDir.exists()) {
         configDir.createDirectory();
@@ -1167,9 +1163,7 @@ void ParameterConfigDialog::loadParameterConfiguration() {
         return;
     }
 
-    auto configDir = juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-                         .getChildFile("MAGDA")
-                         .getChildFile("PluginConfigs");
+    auto configDir = magda::paths::pluginConfigsDir();
 
     auto configFile =
         configDir.getChildFile(pluginUniqueId_.replaceCharacters(":/\\,; ", "______") + ".xml");
@@ -1250,9 +1244,7 @@ bool ParameterConfigDialog::applyConfigToDevice(const juce::String& uniqueId,
         return false;
     }
 
-    auto configDir = juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-                         .getChildFile("MAGDA")
-                         .getChildFile("PluginConfigs");
+    auto configDir = magda::paths::pluginConfigsDir();
 
     auto configFile =
         configDir.getChildFile(uniqueId.replaceCharacters(":/\\,; ", "______") + ".xml");

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -1051,7 +1051,7 @@ class PathsPage : public juce::Component {
                                DarkTheme::getColour(DarkTheme::TEXT_DIM));
         presetsNote_.setJustificationType(juce::Justification::centredLeft);
         presetsNote_.setText(
-            "Applies immediately — preset browsers re-scan on next open.",
+            "Applies immediately. Preset browsers re-scan on next open.",
             juce::dontSendNotification);
         addAndMakeVisible(presetsNote_);
 

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -9,6 +9,7 @@
 #include "../themes/DialogLookAndFeel.hpp"
 #include "../themes/FontManager.hpp"
 #include "../windows/MainWindow.hpp"
+#include "core/AppPaths.hpp"
 #include "core/Config.hpp"
 #include "core/StringTable.hpp"
 #include "core/UIScale.hpp"
@@ -961,6 +962,230 @@ class RenderingPage : public juce::Component {
     std::unique_ptr<juce::FileChooser> fileChooser_;
 };
 
+// ---- Paths tab (configurable user-data locations) -------------------------
+//
+// Two pickers: Data Folder (logs, config, scripts, plugin caches) and
+// Presets Folder (Chains, Racks, Devices). Render Folder lives on the
+// Rendering tab — kept there to avoid duplication.
+//
+// Render + Presets apply hot via Config listeners. Data Folder triggers a
+// migration confirmation in PreferencesDialog::applySettings() because file
+// handles (logger, plugin scanner) are open at the old path; the actual
+// move + restart happens there.
+
+class PathsPage : public juce::Component {
+  public:
+    PathsPage() {
+        // --- Data Folder ---
+        setupSectionHeader(*this, dataHeader_,
+                           "Data folder (logs, scripts, plugin caches)");
+
+        dataLabel_.setText("Folder:", juce::dontSendNotification);
+        dataLabel_.setFont(FontManager::getInstance().getUIFont(12.0f));
+        dataLabel_.setColour(juce::Label::textColourId,
+                             DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
+        dataLabel_.setJustificationType(juce::Justification::centredLeft);
+        addAndMakeVisible(dataLabel_);
+
+        dataValue_.setFont(FontManager::getInstance().getUIFont(12.0f));
+        dataValue_.setColour(juce::Label::textColourId,
+                             DarkTheme::getColour(DarkTheme::TEXT_SECONDARY));
+        dataValue_.setJustificationType(juce::Justification::centredLeft);
+        addAndMakeVisible(dataValue_);
+
+        dataBrowse_.setButtonText("Browse...");
+        dataBrowse_.onClick = [this]() {
+            pickFolder("Choose data folder", dataPath_, dataValue_, true);
+        };
+        addAndMakeVisible(dataBrowse_);
+
+        dataReset_.setButtonText("Reset");
+        dataReset_.onClick = [this]() {
+            dataPath_.clear();
+            updateDisplay();
+        };
+        addAndMakeVisible(dataReset_);
+
+        dataNote_.setFont(FontManager::getInstance().getUIFont(11.0f));
+        dataNote_.setColour(juce::Label::textColourId,
+                            DarkTheme::getColour(DarkTheme::TEXT_DIM));
+        dataNote_.setJustificationType(juce::Justification::centredLeft);
+        dataNote_.setText(
+            "Changes require a restart. Existing files can be copied to the "
+            "new location.",
+            juce::dontSendNotification);
+        addAndMakeVisible(dataNote_);
+
+        // --- Presets Folder ---
+        setupSectionHeader(*this, presetsHeader_,
+                           "Presets folder (Chains, Racks, Devices)");
+
+        presetsLabel_.setText("Folder:", juce::dontSendNotification);
+        presetsLabel_.setFont(FontManager::getInstance().getUIFont(12.0f));
+        presetsLabel_.setColour(juce::Label::textColourId,
+                                DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
+        presetsLabel_.setJustificationType(juce::Justification::centredLeft);
+        addAndMakeVisible(presetsLabel_);
+
+        presetsValue_.setFont(FontManager::getInstance().getUIFont(12.0f));
+        presetsValue_.setColour(juce::Label::textColourId,
+                                DarkTheme::getColour(DarkTheme::TEXT_SECONDARY));
+        presetsValue_.setJustificationType(juce::Justification::centredLeft);
+        addAndMakeVisible(presetsValue_);
+
+        presetsBrowse_.setButtonText("Browse...");
+        presetsBrowse_.onClick = [this]() {
+            pickFolder("Choose presets folder", presetsPath_, presetsValue_, false);
+        };
+        addAndMakeVisible(presetsBrowse_);
+
+        presetsReset_.setButtonText("Reset");
+        presetsReset_.onClick = [this]() {
+            presetsPath_.clear();
+            updateDisplay();
+        };
+        addAndMakeVisible(presetsReset_);
+
+        presetsNote_.setFont(FontManager::getInstance().getUIFont(11.0f));
+        presetsNote_.setColour(juce::Label::textColourId,
+                               DarkTheme::getColour(DarkTheme::TEXT_DIM));
+        presetsNote_.setJustificationType(juce::Justification::centredLeft);
+        presetsNote_.setText(
+            "Applies immediately — preset browsers re-scan on next open.",
+            juce::dontSendNotification);
+        addAndMakeVisible(presetsNote_);
+
+        // --- Hint about Render Folder ---
+        renderHint_.setFont(FontManager::getInstance().getUIFont(11.0f));
+        renderHint_.setColour(juce::Label::textColourId,
+                              DarkTheme::getColour(DarkTheme::TEXT_DIM));
+        renderHint_.setJustificationType(juce::Justification::centredLeft);
+        renderHint_.setText(
+            "Render output folder is configured on the Rendering tab.",
+            juce::dontSendNotification);
+        addAndMakeVisible(renderHint_);
+    }
+
+    void resized() override {
+        auto bounds = getLocalBounds().reduced(20);
+        const int rowH = 28;
+        const int gap = 6;
+        const int sectionGap = 18;
+
+        // Data section
+        dataHeader_.setBounds(bounds.removeFromTop(rowH));
+        bounds.removeFromTop(gap);
+        auto dataRow = bounds.removeFromTop(rowH);
+        dataLabel_.setBounds(dataRow.removeFromLeft(60));
+        dataReset_.setBounds(dataRow.removeFromRight(80));
+        dataRow.removeFromRight(gap);
+        dataBrowse_.setBounds(dataRow.removeFromRight(100));
+        dataRow.removeFromRight(gap);
+        dataValue_.setBounds(dataRow);
+        bounds.removeFromTop(gap);
+        dataNote_.setBounds(bounds.removeFromTop(rowH));
+
+        bounds.removeFromTop(sectionGap);
+
+        // Presets section
+        presetsHeader_.setBounds(bounds.removeFromTop(rowH));
+        bounds.removeFromTop(gap);
+        auto pRow = bounds.removeFromTop(rowH);
+        presetsLabel_.setBounds(pRow.removeFromLeft(60));
+        presetsReset_.setBounds(pRow.removeFromRight(80));
+        pRow.removeFromRight(gap);
+        presetsBrowse_.setBounds(pRow.removeFromRight(100));
+        pRow.removeFromRight(gap);
+        presetsValue_.setBounds(pRow);
+        bounds.removeFromTop(gap);
+        presetsNote_.setBounds(bounds.removeFromTop(rowH));
+
+        bounds.removeFromTop(sectionGap);
+
+        renderHint_.setBounds(bounds.removeFromTop(rowH));
+    }
+
+    void loadSettings(Config& config) {
+        dataPath_ = config.getDataDir();
+        presetsPath_ = config.getPresetsDir();
+        // Snapshot the original Data path for change detection in
+        // applySettings — used to decide whether to trigger the migration
+        // dialog.
+        originalDataPath_ = dataPath_;
+        updateDisplay();
+    }
+
+    void applySettings(Config& config) {
+        config.setDataDir(dataPath_);
+        config.setPresetsDir(presetsPath_);
+        // Re-resolve so paths::presetsDir() picks up the change immediately
+        // (Render is also re-resolved here for free). The data dir part
+        // doesn't take full effect until restart — see PreferencesDialog
+        // applySettings for the migration prompt.
+        magda::paths::resolve();
+    }
+
+    /** Returns true if the data dir has been changed in this dialog session.
+     *  PreferencesDialog uses this to gate the migration confirmation. */
+    bool dataDirChanged() const {
+        return dataPath_ != originalDataPath_;
+    }
+    std::string getOriginalDataPath() const { return originalDataPath_; }
+    std::string getNewDataPath() const { return dataPath_; }
+
+  private:
+    void pickFolder(const juce::String& title,
+                    std::string& target,
+                    juce::Label& display,
+                    bool isDataDir) {
+        (void)isDataDir;  // no migration here — applied in PreferencesDialog
+        fileChooser_ = std::make_unique<juce::FileChooser>(title);
+        fileChooser_->launchAsync(juce::FileBrowserComponent::openMode |
+                                      juce::FileBrowserComponent::canSelectDirectories,
+                                  [&target, &display](const juce::FileChooser& fc) {
+                                      auto result = fc.getResult();
+                                      if (result.exists() && result.isDirectory()) {
+                                          target = result.getFullPathName().toStdString();
+                                          display.setText(result.getFullPathName(),
+                                                          juce::dontSendNotification);
+                                      }
+                                  });
+    }
+
+    void updateDisplay() {
+        if (dataPath_.empty()) {
+            dataValue_.setText("(default: " +
+                                   magda::paths::alwaysOSDefault().getFullPathName() + ")",
+                               juce::dontSendNotification);
+        } else {
+            dataValue_.setText(juce::String(dataPath_), juce::dontSendNotification);
+        }
+
+        if (presetsPath_.empty()) {
+            auto def = juce::File::getSpecialLocation(juce::File::userDocumentsDirectory)
+                           .getChildFile("MAGDA")
+                           .getChildFile("Presets");
+            presetsValue_.setText("(default: " + def.getFullPathName() + ")",
+                                  juce::dontSendNotification);
+        } else {
+            presetsValue_.setText(juce::String(presetsPath_), juce::dontSendNotification);
+        }
+    }
+
+    juce::Label dataHeader_, dataLabel_, dataValue_, dataNote_;
+    juce::TextButton dataBrowse_, dataReset_;
+    std::string dataPath_;
+    std::string originalDataPath_;
+
+    juce::Label presetsHeader_, presetsLabel_, presetsValue_, presetsNote_;
+    juce::TextButton presetsBrowse_, presetsReset_;
+    std::string presetsPath_;
+
+    juce::Label renderHint_;
+
+    std::unique_ptr<juce::FileChooser> fileChooser_;
+};
+
 // ---- Shortcuts tab (read-only) --------------------------------------------
 
 class ShortcutsPage : public juce::Component {
@@ -1025,6 +1250,7 @@ PreferencesDialog::PreferencesDialog() {
     uiPage = std::make_unique<UIPage>();
     coloursPage = std::make_unique<ColoursPage>();
     renderingPage = std::make_unique<RenderingPage>();
+    pathsPage = std::make_unique<PathsPage>();
     shortcutsPage = std::make_unique<ShortcutsPage>();
 
     auto tabBg = DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND);
@@ -1032,6 +1258,7 @@ PreferencesDialog::PreferencesDialog() {
     tabbedComponent.addTab(tr("preferences.tab.ui"), tabBg, uiPage.get(), false);
     tabbedComponent.addTab(tr("preferences.tab.colours"), tabBg, coloursPage.get(), false);
     tabbedComponent.addTab(tr("preferences.tab.rendering"), tabBg, renderingPage.get(), false);
+    tabbedComponent.addTab("Paths", tabBg, pathsPage.get(), false);
     tabbedComponent.addTab(tr("preferences.tab.shortcuts"), tabBg, shortcutsPage.get(), false);
     addAndMakeVisible(tabbedComponent);
 
@@ -1096,17 +1323,84 @@ void PreferencesDialog::loadCurrentSettings() {
     uiPage->loadSettings(config);
     coloursPage->loadSettings(config);
     renderingPage->loadSettings(config);
+    pathsPage->loadSettings(config);
     shortcutsPage->loadSettings(config);
 }
 
 void PreferencesDialog::applySettings() {
     auto& config = Config::getInstance();
+
+    // Capture data-dir change BEFORE pathsPage.applySettings writes to Config
+    // — we use the snapshot to gate the migration dialog.
+    bool dataDirChange = pathsPage->dataDirChanged();
+    juce::String oldDataPath =
+        juce::String(pathsPage->getOriginalDataPath()).isEmpty()
+            ? magda::paths::alwaysOSDefault().getFullPathName()
+            : juce::String(pathsPage->getOriginalDataPath());
+    juce::String newDataPath =
+        juce::String(pathsPage->getNewDataPath()).isEmpty()
+            ? magda::paths::alwaysOSDefault().getFullPathName()
+            : juce::String(pathsPage->getNewDataPath());
+
     generalPage->applySettings(config);
     uiPage->applySettings(config);
     coloursPage->applySettings(config);
     renderingPage->applySettings(config);
+    pathsPage->applySettings(config);
     shortcutsPage->applySettings(config);
     config.save();
+
+    // If the user changed the data dir, prompt for optional migration +
+    // restart. The save above persists the new path so the prompt can
+    // be backed out by reverting Config if user cancels — but we're
+    // committed by this point; cancel just means "don't migrate now,
+    // restart later".
+    if (dataDirChange) {
+        juce::AlertWindow::showAsync(
+            juce::MessageBoxOptions()
+                .withIconType(juce::MessageBoxIconType::QuestionIcon)
+                .withTitle("Move MAGDA data folder")
+                .withMessage(
+                    "MAGDA's data folder is changing.\n\nFrom: " + oldDataPath +
+                    "\nTo:    " + newDataPath +
+                    "\n\nCopy existing files to the new location now? "
+                    "MAGDA will restart afterwards.\n\n"
+                    "If you choose No, the new path takes effect on next "
+                    "launch but existing files stay where they are.")
+                .withButton("Copy and restart")
+                .withButton("Restart only")
+                .withButton("Later"),
+            [oldDataPath, newDataPath](int result) {
+                if (result == 0)
+                    return;  // "Later" — no action
+                if (result == 1) {
+                    juce::File from(oldDataPath);
+                    juce::File to(newDataPath);
+                    if (from.isDirectory() &&
+                        from.getFullPathName() != to.getFullPathName()) {
+                        to.createDirectory();
+                        if (!from.copyDirectoryTo(to)) {
+                            juce::AlertWindow::showAsync(
+                                juce::MessageBoxOptions()
+                                    .withIconType(juce::MessageBoxIconType::WarningIcon)
+                                    .withTitle("Migration failed")
+                                    .withMessage(
+                                        "Could not copy all files from\n" +
+                                        from.getFullPathName() + "\nto\n" +
+                                        to.getFullPathName() +
+                                        "\n\nFiles in the old location are "
+                                        "untouched. You can copy them "
+                                        "manually and restart.")
+                                    .withButton("OK"),
+                                nullptr);
+                            return;
+                        }
+                    }
+                }
+                // Both "Copy and restart" (1) and "Restart only" (2) end here.
+                juce::JUCEApplication::quit();  // Caller responsible for relaunch.
+            });
+    }
 
     // Apply auto-save settings
     ProjectManager::getInstance().setAutoSaveEnabled(config.getAutoSaveEnabled(),

--- a/magda/daw/ui/dialogs/PreferencesDialog.hpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.hpp
@@ -9,6 +9,7 @@ class GeneralPage;
 class UIPage;
 class ColoursPage;
 class RenderingPage;
+class PathsPage;
 class ShortcutsPage;
 
 /**
@@ -36,6 +37,7 @@ class PreferencesDialog : public juce::Component {
     std::unique_ptr<UIPage> uiPage;
     std::unique_ptr<ColoursPage> coloursPage;
     std::unique_ptr<RenderingPage> renderingPage;
+    std::unique_ptr<PathsPage> pathsPage;
     std::unique_ptr<ShortcutsPage> shortcutsPage;
 
     juce::TextButton okButton;

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -20,6 +20,7 @@
 #include "../../../../agents/music_agent.hpp"
 #include "../../../../agents/router_agent.hpp"
 #include "../../../api/magda_api_live.hpp"
+#include "../../../core/AppPaths.hpp"
 #include "../../../core/ClipManager.hpp"
 #include "../../../core/Config.hpp"
 #include "../../../core/SelectionManager.hpp"
@@ -1619,9 +1620,7 @@ void AIChatConsoleContent::buildAliasList() {
     }
 
     // Load custom alias overrides
-    auto aliasFile = juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-                         .getChildFile("MAGDA")
-                         .getChildFile("plugin_aliases.xml");
+    auto aliasFile = magda::paths::pluginAliasesFile();
 
     if (aliasFile.existsAsFile()) {
         if (auto xml = juce::parseXML(aliasFile)) {

--- a/magda/daw/ui/panels/content/PluginBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.cpp
@@ -11,6 +11,7 @@
 #include "audio/MagdaSamplerPlugin.hpp"
 #include "audio/MidiChordEnginePlugin.hpp"
 #include "audio/StepSequencerPlugin.hpp"
+#include "core/AppPaths.hpp"
 #include "core/DeviceInfo.hpp"
 #include "core/PluginAlias.hpp"
 #include "core/TrackManager.hpp"
@@ -666,9 +667,7 @@ void PluginBrowserContent::toggleFavorite(const PluginBrowserInfo& plugin) {
 }
 
 juce::File PluginBrowserContent::getFavoritesFile() const {
-    return juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-        .getChildFile("MAGDA")
-        .getChildFile("plugin_favorites.xml");
+    return magda::paths::pluginFavoritesFile();
 }
 
 void PluginBrowserContent::saveFavorites() {
@@ -710,9 +709,7 @@ void PluginBrowserContent::loadFavorites() {
 }
 
 juce::File PluginBrowserContent::getAliasesFile() const {
-    return juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-        .getChildFile("MAGDA")
-        .getChildFile("plugin_aliases.xml");
+    return magda::paths::pluginAliasesFile();
 }
 
 void PluginBrowserContent::saveAliases() {

--- a/magda/scripting/LuaScriptStore.cpp
+++ b/magda/scripting/LuaScriptStore.cpp
@@ -1,21 +1,12 @@
 #include "magda/scripting/LuaScriptStore.hpp"
 
+#include "magda/daw/core/AppPaths.hpp"
+
 #include <algorithm>
 
 namespace magda::scripting {
 
-namespace {
-
-juce::File defaultControllerScriptsDir() {
-    return juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
-        .getChildFile("MAGDA")
-        .getChildFile("Scripts")
-        .getChildFile("Controllers");
-}
-
-}  // namespace
-
-LuaScriptStore::LuaScriptStore() : root_(defaultControllerScriptsDir()) {}
+LuaScriptStore::LuaScriptStore() : root_(magda::paths::controllerScriptsDir()) {}
 
 LuaScriptStore::LuaScriptStore(const juce::File& root) : root_(root) {}
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -85,6 +85,8 @@ set(TEST_SOURCES
     test_magda_api_lua_bindings.cpp
     # Lua controller tests (issue #592 — MIDI dispatch)
     test_lua_controller.cpp
+    # Configurable user data paths
+    test_app_paths.cpp
 )
 
 # Create test executable

--- a/tests/test_app_paths.cpp
+++ b/tests/test_app_paths.cpp
@@ -1,0 +1,180 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <juce_core/juce_core.h>
+
+#include <cstdlib>
+
+#include "magda/daw/core/AppPaths.hpp"
+#include "magda/daw/core/Config.hpp"
+
+namespace paths = magda::paths;
+
+namespace {
+
+// Setenv helpers — cross-platform-ish; portable tests.
+void setEnv(const char* name, const char* value) {
+#if defined(_WIN32)
+    _putenv_s(name, value);
+#else
+    setenv(name, value, 1);
+#endif
+}
+
+void unsetEnv(const char* name) {
+#if defined(_WIN32)
+    _putenv_s(name, "");
+#else
+    unsetenv(name);
+#endif
+}
+
+struct EnvScope {
+    EnvScope() {
+        // Snapshot the three knobs and restore on dtor so tests don't leak.
+        snapshot("MAGDA_DATA_DIR", dataPrev);
+        snapshot("MAGDA_PRESETS_DIR", presetsPrev);
+        snapshot("MAGDA_RENDER_DIR", renderPrev);
+    }
+    ~EnvScope() {
+        restore("MAGDA_DATA_DIR", dataPrev);
+        restore("MAGDA_PRESETS_DIR", presetsPrev);
+        restore("MAGDA_RENDER_DIR", renderPrev);
+        // Also reset Config overrides so the next test starts clean.
+        magda::Config::getInstance().setDataDir({});
+        magda::Config::getInstance().setPresetsDir({});
+        magda::Config::getInstance().setRenderFolder({});
+        paths::resolve();
+    }
+
+    static void snapshot(const char* name, juce::String& out) {
+        if (const char* v = std::getenv(name); v != nullptr)
+            out = juce::String::fromUTF8(v);
+    }
+    static void restore(const char* name, const juce::String& prev) {
+        if (prev.isEmpty())
+            unsetEnv(name);
+        else
+            setEnv(name, prev.toRawUTF8());
+    }
+
+    juce::String dataPrev;
+    juce::String presetsPrev;
+    juce::String renderPrev;
+};
+
+}  // namespace
+
+TEST_CASE("paths::dataDir defaults to OS appdata/MAGDA", "[app_paths]") {
+    EnvScope scope;
+    unsetEnv("MAGDA_DATA_DIR");
+    magda::Config::getInstance().setDataDir({});
+    paths::resolve();
+
+    auto expected =
+        juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
+            .getChildFile("MAGDA");
+    REQUIRE(paths::dataDir() == expected);
+    REQUIRE_FALSE(paths::dataDirOverriddenByEnv());
+}
+
+TEST_CASE("paths::dataDir env var beats default", "[app_paths]") {
+    EnvScope scope;
+    setEnv("MAGDA_DATA_DIR", "/tmp/magda-env-test/data");
+    paths::resolve();
+
+    REQUIRE(paths::dataDir() == juce::File("/tmp/magda-env-test/data"));
+    REQUIRE(paths::dataDirOverriddenByEnv());
+}
+
+TEST_CASE("paths::dataDir env var beats Config", "[app_paths]") {
+    EnvScope scope;
+    setEnv("MAGDA_DATA_DIR", "/tmp/magda-env-wins/data");
+    magda::Config::getInstance().setDataDir("/tmp/magda-config-loses/data");
+    paths::resolve();
+
+    REQUIRE(paths::dataDir() == juce::File("/tmp/magda-env-wins/data"));
+    REQUIRE(paths::dataDirOverriddenByEnv());
+}
+
+TEST_CASE("paths::dataDir Config beats default", "[app_paths]") {
+    EnvScope scope;
+    unsetEnv("MAGDA_DATA_DIR");
+    magda::Config::getInstance().setDataDir("/tmp/magda-config-test/data");
+    paths::resolve();
+
+    REQUIRE(paths::dataDir() == juce::File("/tmp/magda-config-test/data"));
+    REQUIRE_FALSE(paths::dataDirOverriddenByEnv());
+}
+
+TEST_CASE("paths subpaths compose under dataDir", "[app_paths]") {
+    EnvScope scope;
+    setEnv("MAGDA_DATA_DIR", "/tmp/magda-subpath-test");
+    paths::resolve();
+
+    REQUIRE(paths::logsDir() ==
+            juce::File("/tmp/magda-subpath-test/Logs"));
+    REQUIRE(paths::controllerScriptsDir() ==
+            juce::File("/tmp/magda-subpath-test/Scripts/Controllers"));
+    REQUIRE(paths::controllerProfilesDir() ==
+            juce::File("/tmp/magda-subpath-test/controllers"));
+    REQUIRE(paths::pluginConfigsDir() ==
+            juce::File("/tmp/magda-subpath-test/PluginConfigs"));
+    REQUIRE(paths::pluginListFile() ==
+            juce::File("/tmp/magda-subpath-test/PluginList.xml"));
+    REQUIRE(paths::pluginExclusionsFile() ==
+            juce::File("/tmp/magda-subpath-test/plugin_exclusions.txt"));
+    REQUIRE(paths::lastScanReportFile() ==
+            juce::File("/tmp/magda-subpath-test/last_scan_report.txt"));
+    REQUIRE(paths::pluginFavoritesFile() ==
+            juce::File("/tmp/magda-subpath-test/plugin_favorites.xml"));
+    REQUIRE(paths::pluginAliasesFile() ==
+            juce::File("/tmp/magda-subpath-test/plugin_aliases.xml"));
+    REQUIRE(paths::pluginScanMarkerFile("VST3") ==
+            juce::File("/tmp/magda-subpath-test/scanning_VST3.txt"));
+    REQUIRE(paths::parameterDetectorLog() ==
+            juce::File("/tmp/magda-subpath-test/param_detector.log"));
+}
+
+TEST_CASE("paths::configFile is anchored to OS default regardless of override",
+          "[app_paths]") {
+    EnvScope scope;
+    setEnv("MAGDA_DATA_DIR", "/tmp/magda-anchor-test/data");
+    paths::resolve();
+
+    auto expected = paths::alwaysOSDefault().getChildFile("config.json");
+    REQUIRE(paths::configFile() == expected);
+    REQUIRE_FALSE(paths::configFile().getFullPathName().contains("magda-anchor-test"));
+}
+
+TEST_CASE("paths::resolve picks up Config changes between calls", "[app_paths]") {
+    EnvScope scope;
+    unsetEnv("MAGDA_DATA_DIR");
+    magda::Config::getInstance().setDataDir("/tmp/magda-rev1");
+    paths::resolve();
+    REQUIRE(paths::dataDir() == juce::File("/tmp/magda-rev1"));
+
+    magda::Config::getInstance().setDataDir("/tmp/magda-rev2");
+    paths::resolve();
+    REQUIRE(paths::dataDir() == juce::File("/tmp/magda-rev2"));
+}
+
+TEST_CASE("paths::presetsDir / renderDir resolution chain works", "[app_paths]") {
+    EnvScope scope;
+    unsetEnv("MAGDA_PRESETS_DIR");
+    unsetEnv("MAGDA_RENDER_DIR");
+    magda::Config::getInstance().setPresetsDir("/tmp/magda-presets");
+    magda::Config::getInstance().setRenderFolder("/tmp/magda-renders");
+    paths::resolve();
+
+    REQUIRE(paths::presetsDir() == juce::File("/tmp/magda-presets"));
+    REQUIRE(paths::renderDir() == juce::File("/tmp/magda-renders"));
+
+    setEnv("MAGDA_PRESETS_DIR", "/tmp/env-presets");
+    setEnv("MAGDA_RENDER_DIR", "/tmp/env-renders");
+    paths::resolve();
+
+    REQUIRE(paths::presetsDir() == juce::File("/tmp/env-presets"));
+    REQUIRE(paths::renderDir() == juce::File("/tmp/env-renders"));
+    REQUIRE(paths::presetsDirOverriddenByEnv());
+    REQUIRE(paths::renderDirOverriddenByEnv());
+}


### PR DESCRIPTION
## Summary

Lets users redirect MAGDA's per-user files to a custom volume via Preferences → Paths. No more symlinks for users on small system drives or shared studio rigs.

Three independent knobs:

| Knob | Default | Apply | Reasoning |
|---|---|---|---|
| **Data dir** | `userApplicationDataDirectory/MAGDA/` | restart | logger has `magda.log` open; plugin scanner subprocess holds files; live recording auto-saves there |
| **Presets dir** | `userDocumentsDirectory/MAGDA/Presets/` | hot | re-scanned on next browse |
| **Render dir** | (existing `Config::renderFolder`) | hot | already trivial |

Each knob can be overridden three ways, in this order: `MAGDA_DATA_DIR` / `MAGDA_PRESETS_DIR` / `MAGDA_RENDER_DIR` env var → Preferences → OS default.

### Architecture decision: no virtual interface

I deliberately did **not** create a `UserPathService` virtual interface mirroring `MagdaApi`. There's only one filesystem; tests use temp dirs. The right level is a small `magda::paths` free-function module (~20 named accessors) that funnels every formerly-hardcoded `juce::File::getSpecialLocation(...)` call through one resolution point. ~13 call-site changes, no DI plumbing.

### Bootstrap reorder

The file logger used to start before `Config::load()`, which would have made it impossible to redirect logs to the configured path. Reordered to:

```
paths::resolve()         → env vars only; Config not loaded yet
Config::load()           → reads config.json from alwaysOSDefault()
paths::resolve()         → re-resolve with Config overrides
file logger setup        → uses configured dataDir/Logs
… rest of init unchanged
```

### Migration UX

Changing the data dir prompts:
- **Copy and restart** — `juce::File::copyDirectoryTo` from old → new, then quit
- **Restart only** — quit (next launch uses new path; old folder left as backup)
- **Later** — persist setting; takes effect on next launch

Old folder is never deleted — explicit user choice.

## Test plan

- [x] `make build` clean on macOS arm64 (full app + tests)
- [x] `cmake-build-debug/tests/magda_tests "[app_paths]"` — 8 cases, 29 assertions
- [x] Full suite — **835 cases / 26,971 assertions, no regressions**
- [ ] Manual end-to-end (post-merge):
  1. Fresh launch → files land in OS default as today.
  2. Preferences → Paths → set Data Folder to `/Volumes/Studio/MAGDA`. Apply → choose "Copy and restart".
  3. After relaunch, verify `magda.log`, `Scripts/Controllers/`, `controllers/`, `PluginList.xml` all live under `/Volumes/Studio/MAGDA`. (`config.json` stays at OS default by design.)
  4. `MAGDA_DATA_DIR=/tmp/override` → relaunch → first log line says env-var override is active; files land under `/tmp/override`.
  5. Set Presets Folder to `/Volumes/Shared/Presets`. No restart prompt; preset browser shows new content.
  6. Render folder via Rendering tab still works as before.
- [ ] Linux + Windows CI

## Out of scope (explicit follow-ups)

- Hot-swap for the **Data dir** knob — needs gating (no active recording, no scan in progress, project closed) + re-init choreography across `juce::FileLogger`, `Config`, `PluginScanCoordinator`, `LuaScriptStore`, `ControllerProfileRegistry`. v2.
- Per-knob "Reveal in Finder/Explorer" buttons on the Paths tab.
- "Portable mode" sentinel in the app bundle for USB-stick installs.