### PR TITLE
fix(release): bundle controllers/ in Windows + Linux installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -451,12 +451,16 @@ jobs:
           Write-Error "controllers/ missing next to MAGDA.exe at $controllersSrc"
           exit 1
         }
-        New-Item -ItemType Directory -Path $controllersDst | Out-Null
-        Copy-Item -Recurse "$controllersSrc\*" $controllersDst
+        New-Item -ItemType Directory -Path $controllersDst -ErrorAction Stop | Out-Null
+        Copy-Item -Recurse "$controllersSrc\*" $controllersDst -ErrorAction Stop
         Write-Output "Staged controllers/ for installer"
 
         if (-not (Test-Path "$controllersDst\profiles")) {
           Write-Error "controllers/profiles missing from installer staging"
+          exit 1
+        }
+        if (-not (Test-Path "$controllersDst\scripts")) {
+          Write-Error "controllers/scripts missing from installer staging"
           exit 1
         }
 
@@ -621,6 +625,8 @@ jobs:
 
         test -d "$APPDIR/usr/bin/controllers/profiles" \
           || { echo "controllers/profiles missing from AppDir staging"; exit 1; }
+        test -d "$APPDIR/usr/bin/controllers/scripts" \
+          || { echo "controllers/scripts missing from AppDir staging"; exit 1; }
 
         # Copy icon
         cp assets/app_icon.png "$APPDIR/usr/share/icons/hicolor/256x256/apps/magda.png"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -441,6 +441,25 @@ jobs:
           exit 1
         }
 
+        # Controller profiles + Lua scripts. POST_BUILD already places
+        # controllers/ next to MAGDA.exe; mirror that exact layout into
+        # staging so runtime probes (<exe>/controllers/{profiles,scripts})
+        # find them after install.
+        $controllersSrc = Join-Path $exeDir "controllers"
+        $controllersDst = Join-Path $stage "controllers"
+        if (-not (Test-Path $controllersSrc)) {
+          Write-Error "controllers/ missing next to MAGDA.exe at $controllersSrc"
+          exit 1
+        }
+        New-Item -ItemType Directory -Path $controllersDst | Out-Null
+        Copy-Item -Recurse "$controllersSrc\*" $controllersDst
+        Write-Output "Staged controllers/ for installer"
+
+        if (-not (Test-Path "$controllersDst\profiles")) {
+          Write-Error "controllers/profiles missing from installer staging"
+          exit 1
+        }
+
         & $env:MAKENSIS /DVERSION=$env:VERSION "$stage\magda-installer.nsi"
 
         $installerName = "MAGDA-$env:VERSION-Windows-x86_64-Setup.exe"
@@ -588,6 +607,20 @@ jobs:
         # shipped with missing translations because staging silently dropped it.
         test -f "$APPDIR/usr/bin/lang/en.json" \
           || { echo "lang/en.json missing from AppDir staging"; exit 1; }
+
+        # Controller profiles + Lua scripts. POST_BUILD already places
+        # controllers/ next to the binary; mirror that exact layout into
+        # the AppDir so runtime probes (<exe>/controllers/{profiles,scripts})
+        # find them after install.
+        CONTROLLERS_SRC="$(dirname "$BINARY")/controllers"
+        if [ ! -d "$CONTROLLERS_SRC" ]; then
+          echo "controllers/ missing next to MAGDA binary at $CONTROLLERS_SRC"
+          exit 1
+        fi
+        cp -r "$CONTROLLERS_SRC" "$APPDIR/usr/bin/controllers"
+
+        test -d "$APPDIR/usr/bin/controllers/profiles" \
+          || { echo "controllers/profiles missing from AppDir staging"; exit 1; }
 
         # Copy icon
         cp assets/app_icon.png "$APPDIR/usr/share/icons/hicolor/256x256/apps/magda.png"

--- a/packaging/windows/magda-installer.nsi
+++ b/packaging/windows/magda-installer.nsi
@@ -38,6 +38,11 @@ Section "Install"
     File /r "${__FILEDIR__}\lang\*.*"
     SetOutPath $INSTDIR
 
+    ; Controller profiles + Lua scripts - registry probes <exe>/controllers/
+    SetOutPath "$INSTDIR\controllers"
+    File /r "${__FILEDIR__}\controllers\*.*"
+    SetOutPath $INSTDIR
+
     ; Create uninstaller
     WriteUninstaller "$INSTDIR\Uninstall.exe"
 
@@ -74,6 +79,7 @@ Section "Uninstall"
     Delete "$INSTDIR\magda_plugin_scanner.exe"
     Delete "$INSTDIR\Uninstall.exe"
     RMDir /r "$INSTDIR\lang"
+    RMDir /r "$INSTDIR\controllers"
     RMDir "$INSTDIR"
 
     Delete "$SMPROGRAMS\MAGDA\*.*"

--- a/packaging/windows/magda-installer.nsi
+++ b/packaging/windows/magda-installer.nsi
@@ -38,7 +38,9 @@ Section "Install"
     File /r "${__FILEDIR__}\lang\*.*"
     SetOutPath $INSTDIR
 
-    ; Controller profiles + Lua scripts - registry probes <exe>/controllers/
+    ; Controller profiles + Lua scripts - registry probes
+    ; <exe>/controllers/profiles and LuaScriptStore probes
+    ; <exe>/controllers/scripts. File /r preserves both subdirs.
     SetOutPath "$INSTDIR\controllers"
     File /r "${__FILEDIR__}\controllers\*.*"
     SetOutPath $INSTDIR


### PR DESCRIPTION
## Summary
- Windows NSIS installer and Linux AppImage shipped without `controllers/` (factory profiles + Lua scripts), so users on those platforms got an empty Controllers Settings dialog despite the resources being present in the source tree
- macOS was unaffected — `.app` bundle POST_BUILD copy + `create-dmg` already wrap controllers
- Stage `controllers/` from next to the built binary (where POST_BUILD puts it) into both installer flows, mirror the existing `lang/` staging pattern, and add the same presence guards
- Add `File /r` + `RMDir` entries in `magda-installer.nsi` so install and uninstall round-trip cleanly

Same shape of fix as #1044 (lang/) — controllers landed in 0.6 and the release pipelines were never updated.

## Test plan
- [ ] CI release workflow builds Windows installer without erroring on the new staging guard
- [ ] CI release workflow builds Linux AppImage without erroring on the new staging guard
- [ ] Install Windows .exe, confirm `%ProgramFiles%\MAGDA\controllers\profiles\*.json` and `controllers\scripts\*.lua` present, launch app, confirm Launchkey/Launchpad/foot pedal/8-knob profiles appear in Controllers Settings
- [ ] Run Linux AppImage, confirm same factory profiles appear in Controllers Settings
- [ ] Smoke-check macOS DMG still works after the post-786c3dec layout (no code changed but worth confirming `Contents/Resources/controllers/{profiles,scripts}/` populated)
- [ ] Uninstall on Windows removes `controllers/` directory cleanly