### PR TITLE
build(cmake): default MAGDA_BUILD_EXAMPLES to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 
 # Options
 option(MAGDA_BUILD_TESTS "Build tests" ON)
-option(MAGDA_BUILD_EXAMPLES "Build examples" ON)
+option(MAGDA_BUILD_EXAMPLES "Build developer example tools (e.g. lua_smoke REPL)" OFF)
 option(MAGDA_BUILD_JUCE_ADAPTER "Build JUCE/Tracktion adapter" OFF)
 
 # Find packages


### PR DESCRIPTION
examples/ contains lua_smoke — a stdin REPL for the embedded Lua runtime, used during sandbox/binding bring-up. It's not user-facing and not shipped, but its dependency on magda_scripting transitively pulls in JUCE and tracktion_engine modules, bloating release builds on every platform.

Defaults to OFF; opt in with -DMAGDA_BUILD_EXAMPLES=ON when working on Lua bindings.