### PR TITLE
ci: skip JUCE integration tests on macOS until sandboxed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,16 +333,12 @@ jobs:
           exit 1
         fi
 
-    - name: Run JUCE integration tests
-      run: |
-        JUCE_TEST_BIN=$(find build-debug -name "magda_juce_tests" -type f | head -1)
-        if [ -n "$JUCE_TEST_BIN" ]; then
-          echo "Running JUCE integration tests..."
-          "$JUCE_TEST_BIN"
-        else
-          echo "❌ magda_juce_tests executable not found"
-          exit 1
-        fi
+    # JUCE integration tests are intentionally skipped on the macOS
+    # self-hosted runner: SharedTestEngine calls the production
+    # TracktionEngineWrapper::initialize(), which loads the runner host's
+    # real ~/Library/MAGDA settings, opens real CoreAudio + MIDI devices,
+    # and hangs on async playback-graph reallocation. Re-enable once the
+    # engine has a sandboxed test-init path. Tracking: #1172.
 
     - name: Configure CMake (Release)
       run: |


### PR DESCRIPTION
## Summary
- macOS self-hosted runner hangs on `TracktionEngineWrapper Refactoring Tests / Transport operations` because `SharedTestEngine::getSharedEngine()` calls the production `TracktionEngineWrapper::initialize()`, which loads the runner host's real `~/Library/MAGDA` state, opens real CoreAudio + MIDI devices, and stalls on async playback-graph reallocation when the device change callback fires
- The JUCE-tests-on-macOS step from #1165 (`8204824a`) was the trigger — Linux had been running the same suite without issue because xvfb hosted runners have no real audio/MIDI hardware to grab
- This PR comments out the macOS step with a tracking reference to #1172, where the proper fix (sandboxed test-init: tmp user-data dir, null audio device, no MIDI, empty `KnownPluginList`) is described
- Linux + Windows keep running the JUCE integration tests

## Test plan
- [ ] CI runs to completion on macOS without the integration-test step (build still succeeds)
- [ ] Linux integration test step still runs (regression coverage stays for non-engine-init tests)
- [ ] Windows integration test step still runs