### PR TITLE
Introduce clip content variant

### DIFF
--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -1301,7 +1301,7 @@ bool Interpreter::executeSelectClips(Tokenizer& tok) {
             if (field.value == "name")
                 strVal = clip->name;
             else if (field.value == "type")
-                strVal = (clip->type == ClipType::Audio) ? "audio" : "midi";
+                strVal = (clip->isAudio()) ? "audio" : "midi";
             return compareStr(strVal);
         }
 
@@ -2194,7 +2194,7 @@ bool Interpreter::executeGrooveNew(const Params& params) {
     auto clipId = getSelectedClipId();
     if (clipId != INVALID_CLIP_ID) {
         auto* clip = api_.clips().getClip(clipId);
-        if (clip && clip->type == ClipType::MIDI)
+        if (clip && clip->isMidi())
             api_.clips().setGrooveTemplate(clipId, clip->grooveTemplate);
     }
 
@@ -2234,7 +2234,7 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
     }
 
     const auto* clip = api_.clips().getClip(clipId);
-    if (!clip || clip->type != ClipType::Audio) {
+    if (!clip || !clip->isAudio()) {
         ctx_.setError("groove.extract: clip must be an audio clip");
         return false;
     }
@@ -2328,7 +2328,7 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
     auto selClipId = getSelectedClipId();
     if (selClipId != INVALID_CLIP_ID) {
         auto* selClip = api_.clips().getClip(selClipId);
-        if (selClip && selClip->type == ClipType::MIDI)
+        if (selClip && selClip->isMidi())
             api_.clips().setGrooveTemplate(selClipId, selClip->grooveTemplate);
     }
     return true;
@@ -2347,7 +2347,7 @@ bool Interpreter::executeGrooveSet(const Params& params) {
     }
 
     const auto* clip = api_.clips().getClip(clipId);
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         ctx_.setError("groove.set: clip must be a MIDI clip");
         return false;
     }

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -708,7 +708,7 @@ void AudioBridge::captureAllPluginStates() {
 void AudioBridge::captureWarpMarkerStates() {
     auto& cm = ClipManager::getInstance();
     for (auto& clip : cm.getArrangementClips()) {
-        if (clip.type == ClipType::Audio && clip.warpEnabled) {
+        if (clip.isAudio() && clip.warpEnabled) {
             auto markers = clipSynchronizer_.getWarpMarkers(clip.id);
             DBG("captureWarpMarkerStates: clip " << clip.id
                                                  << " warpEnabled=" << (int)clip.warpEnabled

--- a/magda/daw/audio/WarpMarkerManager.cpp
+++ b/magda/daw/audio/WarpMarkerManager.cpp
@@ -40,7 +40,7 @@ void WarpMarkerManager::setTransientSensitivity(
     te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId, ClipId clipId,
     float sensitivity) {
     const auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (!clip || clip->type != ClipType::Audio || clip->audioFilePath.isEmpty())
+    if (!clip || !clip->isAudio() || clip->audioFilePath.isEmpty())
         return;
 
     te::WaveAudioClip* audioClipPtr = findWaveAudioClip(edit, clipIdToEngineId, clipId);
@@ -64,7 +64,7 @@ bool WarpMarkerManager::getTransientTimes(te::Edit& edit,
                                           ClipId clipId) {
     // Get clip info for file path
     const auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (!clip || clip->type != ClipType::Audio || clip->audioFilePath.isEmpty()) {
+    if (!clip || !clip->isAudio() || clip->audioFilePath.isEmpty()) {
         return false;
     }
 

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -174,7 +174,7 @@ void ClipSynchronizer::clipPropertyChanged(ClipId clipId) {
                     }
 
                     // AutoTempo handling for audio clips
-                    bool isAutoTempoAudio = clip->type == ClipType::Audio && clip->autoTempo;
+                    bool isAutoTempoAudio = clip->isAudio() && clip->autoTempo;
 
                     if (isAutoTempoAudio) {
                         auto* audioClip = dynamic_cast<te::WaveAudioClip*>(teClip);
@@ -199,7 +199,7 @@ void ClipSynchronizer::clipPropertyChanged(ClipId clipId) {
                         // Neutralize embedded tempo metadata: set source BPM =
                         // project BPM so the auto-enabled autoTempo doesn't cause
                         // unwanted speed changes.
-                        if (clip->type == ClipType::Audio) {
+                        if (clip->isAudio()) {
                             if (auto* audioClip = dynamic_cast<te::WaveAudioClip*>(teClip)) {
                                 double projectBpm =
                                     edit_.tempoSequence.getBpmAt(te::TimePosition());
@@ -237,7 +237,7 @@ void ClipSynchronizer::clipPropertyChanged(ClipId clipId) {
                     }
 
                     // Sync session-applicable audio clip properties
-                    if (clip->type == ClipType::Audio) {
+                    if (clip->isAudio()) {
                         auto* audioClip = dynamic_cast<te::WaveAudioClip*>(teClip);
                         if (audioClip) {
                             // Pitch
@@ -272,7 +272,7 @@ void ClipSynchronizer::clipPropertyChanged(ClipId clipId) {
                     }
 
                     // Re-sync MIDI notes from ClipManager to the TE MidiClip
-                    if (clip->type == ClipType::MIDI) {
+                    if (clip->isMidi()) {
                         if (auto* midiClip = dynamic_cast<te::MidiClip*>(teClip)) {
                             auto& sequence = midiClip->getSequence();
                             sequence.clear(nullptr);
@@ -302,8 +302,8 @@ void ClipSynchronizer::clipPropertyChanged(ClipId clipId) {
                     }
 
                 }  // if (teClip)
-            }  // else (already synced)
-        }  // if (sceneIndex >= 0)
+            }      // else (already synced)
+        }          // if (sceneIndex >= 0)
         return;
     }
 
@@ -333,9 +333,9 @@ void ClipSynchronizer::syncClipToEngine(ClipId clipId) {
     }
 
     // Route to appropriate sync method by type
-    if (clip->type == ClipType::MIDI) {
+    if (clip->isMidi()) {
         syncMidiClipToEngine(clipId, clip);
-    } else if (clip->type == ClipType::Audio) {
+    } else if (clip->isAudio()) {
         syncAudioClipToEngine(clipId, clip);
     } else {
         DBG("syncClipToEngine: Unknown clip type for clip " << clipId);
@@ -449,7 +449,7 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
     // Create the TE clip directly in the slot (NOT on the track then moved).
     // TE's free functions insertWaveClip(ClipOwner&, ...) and insertMIDIClip(ClipOwner&, ...)
     // accept ClipSlot as a ClipOwner, creating the clip's ValueTree directly in the slot.
-    if (clip->type == ClipType::Audio) {
+    if (clip->isAudio()) {
         if (clip->audioFilePath.isEmpty())
             return false;
 
@@ -609,7 +609,7 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
 
         return true;
 
-    } else if (clip->type == ClipType::MIDI) {
+    } else if (clip->isMidi()) {
         // Create MIDI clip directly in the slot
         double clipDuration = clip->length;
         auto timeRange = te::TimeRange(te::TimePosition::fromSeconds(0.0),
@@ -715,14 +715,14 @@ void ClipSynchronizer::launchSessionClip(ClipId clipId, bool forceImmediate) {
     if (clip) {
         if (clip->loopEnabled) {
             double srcLength = clip->getSourceLength();
-            if (clip->type == ClipType::Audio && clip->autoTempo) {
+            if (clip->isAudio() && clip->autoTempo) {
                 double bpm = edit_.tempoSequence.getBpmAt(te::TimePosition());
                 auto [loopStartBeats, loopLengthBeats] =
                     ClipOperations::getAutoTempoBeatRange(*clip, bpm);
                 if (loopLengthBeats > 0.0) {
                     launchHandle->setLooping(te::BeatDuration::fromBeats(loopLengthBeats));
                 }
-            } else if (clip->type == ClipType::Audio && srcLength > 0.0) {
+            } else if (clip->isAudio() && srcLength > 0.0) {
                 double bpm = edit_.tempoSequence.getBpmAt(te::TimePosition());
                 double loopDurationBeats = (srcLength / clip->speedRatio) * (bpm / 60.0);
                 launchHandle->setLooping(te::BeatDuration::fromBeats(loopDurationBeats));
@@ -849,7 +849,7 @@ void ClipSynchronizer::stopSessionClipQueued(ClipId clipId, LaunchQuantize quant
     if (!clip)
         return;
 
-    if (clip->type == ClipType::MIDI) {
+    if (clip->isMidi()) {
         auto* audioTrack = trackController_.getAudioTrack(clip->trackId);
         if (audioTrack) {
             for (auto* plugin : audioTrack->pluginList) {
@@ -878,7 +878,7 @@ void ClipSynchronizer::stopSessionClip(ClipId clipId) {
     if (!clip)
         return;
 
-    if (clip->type == ClipType::MIDI) {
+    if (clip->isMidi()) {
         auto* audioTrack = trackController_.getAudioTrack(clip->trackId);
         if (audioTrack) {
             for (auto* plugin : audioTrack->pluginList) {

--- a/magda/daw/audio/session/SessionClipScheduler.cpp
+++ b/magda/daw/audio/session/SessionClipScheduler.cpp
@@ -403,11 +403,11 @@ void SessionClipScheduler::updateLaunchTimings(ClipId clipId, const ClipInfo* cl
     if (bpm <= 0.0)
         bpm = 120.0;
 
-    if (clip->type == ClipType::Audio && clip->autoTempo) {
+    if (clip->isAudio() && clip->autoTempo) {
         data.clipLengthBeats = clip->lengthBeats;
         data.loopLengthBeats =
             (clip->loopLengthBeats > 0.0) ? clip->loopLengthBeats : clip->lengthBeats;
-    } else if (clip->type == ClipType::Audio) {
+    } else if (clip->isAudio()) {
         double srcLength =
             clip->loopLength > 0.0 ? clip->loopLength : clip->length * clip->speedRatio;
         double durationSeconds = srcLength / clip->speedRatio;

--- a/magda/daw/audio/session/SessionRecorder.cpp
+++ b/magda/daw/audio/session/SessionRecorder.cpp
@@ -50,7 +50,7 @@ void SessionRecorder::setArmed(bool armed) {
                     preview.trackId = clip.trackId;
                     preview.startTime = launchTime;
                     preview.currentLength = 0.0;
-                    preview.isAudioRecording = (clip.type == ClipType::Audio);
+                    preview.isAudioRecording = (clip.isAudio());
                     (*recordingPreviews_)[clip.trackId] = preview;
                 }
             }
@@ -76,7 +76,7 @@ void SessionRecorder::updatePreviews() {
 
         // Populate preview notes from the session clip's MIDI data
         const auto* sessionClip = clipManager.getClip(rec.sessionClipId);
-        if (!sessionClip || sessionClip->type != ClipType::MIDI || sessionClip->midiNotes.empty())
+        if (!sessionClip || !sessionClip->isMidi() || sessionClip->midiNotes.empty())
             continue;
 
         double clipLengthBeats = sessionClip->lengthBeats;
@@ -175,7 +175,7 @@ void SessionRecorder::clipPlaybackStateChanged(ClipId clipId) {
             preview.trackId = clip->trackId;
             preview.startTime = launchTime;
             preview.currentLength = 0.0;
-            preview.isAudioRecording = (clip->type == ClipType::Audio);
+            preview.isAudioRecording = (clip->isAudio());
             (*recordingPreviews_)[clip->trackId] = preview;
         }
     } else if (state == SessionClipPlayState::Stopped) {
@@ -203,7 +203,7 @@ void SessionRecorder::finalizeRecording(const ActiveRecording& rec, double stopT
     // Create arrangement clip with the session clip's content
     ClipId newClipId = INVALID_CLIP_ID;
 
-    if (sessionClip->type == ClipType::Audio) {
+    if (sessionClip->isAudio()) {
         if (sessionClip->audioFilePath.isNotEmpty()) {
             newClipId =
                 clipManager.createAudioClip(rec.trackId, rec.arrangementStartTime, duration,
@@ -225,7 +225,7 @@ void SessionRecorder::finalizeRecording(const ActiveRecording& rec, double stopT
     newClip->name = sessionClip->name;
     newClip->colour = sessionClip->colour;
 
-    if (sessionClip->type == ClipType::Audio) {
+    if (sessionClip->isAudio()) {
         newClip->offset = sessionClip->offset;
         newClip->loopStart = sessionClip->loopStart;
         newClip->loopLength = sessionClip->loopLength;
@@ -259,7 +259,7 @@ void SessionRecorder::finalizeRecording(const ActiveRecording& rec, double stopT
         if (sessionClip->loopEnabled && duration > onePassDuration) {
             newClip->loopEnabled = true;
         }
-    } else if (sessionClip->type == ClipType::MIDI) {
+    } else if (sessionClip->isMidi()) {
         // For MIDI: tile notes across the played duration if looping
         double clipLengthBeats = sessionClip->lengthBeats;
         if (clipLengthBeats <= 0.0)

--- a/magda/daw/core/ClipCommands.cpp
+++ b/magda/daw/core/ClipCommands.cpp
@@ -638,7 +638,7 @@ bool JoinClipsCommand::canExecute() const {
     // Must be same track, same type
     if (left->trackId != right->trackId)
         return false;
-    if (left->type != right->type)
+    if (left->getType() != right->getType())
         return false;
 
     // Must be adjacent (left ends where right starts)
@@ -687,7 +687,7 @@ void JoinClipsCommand::performAction() {
     if (!left || !right)
         return;
 
-    if (left->type == ClipType::MIDI) {
+    if (left->isMidi()) {
         // MIDI join: copy right clip's notes into left, adjusting beat positions
         const double beatsPerSecond = tempo_ / 60.0;
         double beatOffset = (right->startTime - left->startTime) * beatsPerSecond;
@@ -697,7 +697,7 @@ void JoinClipsCommand::performAction() {
             adjustedNote.startBeat += beatOffset;
             left->midiNotes.push_back(adjustedNote);
         }
-    } else if (left->type == ClipType::Audio) {
+    } else if (left->isAudio()) {
         // Audio join: extend left clip length to cover both clips
         // (offset and speedRatio remain from left clip)
     }
@@ -828,7 +828,7 @@ RenderClipCommand::RenderClipCommand(ClipId clipId, TracktionEngineWrapper* engi
 void RenderClipCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::Audio || !engine_) {
+    if (!clip || !clip->isAudio() || !engine_) {
         DBG("RenderClipCommand: invalid clip or engine");
         return;
     }
@@ -1053,7 +1053,7 @@ void RenderTimeSelectionCommand::execute() {
         bool allAudio = true;
         for (auto cid : overlappingIds) {
             auto* c = clipManager.getClip(cid);
-            if (!c || c->type != ClipType::Audio) {
+            if (!c || !c->isAudio()) {
                 allAudio = false;
                 break;
             }
@@ -1235,7 +1235,7 @@ static bool trimLoopedClip(ClipManager& clipManager, const ClipInfo& clip, doubl
         liveClip->length -= trimAmount;
 
         // Adjust midiOffset (phase) for the trimmed portion
-        if (clip.type == ClipType::MIDI && clip.loopLength > 0.0) {
+        if (clip.isMidi() && clip.loopLength > 0.0) {
             double bpm = 120.0;
             if (auto* controller = magda::TimelineController::getCurrent()) {
                 bpm = controller->getState().tempo.bpm;
@@ -1498,7 +1498,7 @@ BounceInPlaceCommand::BounceInPlaceCommand(ClipId clipId, TracktionEngineWrapper
 void BounceInPlaceCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI || !engine_) {
+    if (!clip || !clip->isMidi() || !engine_) {
         DBG("BounceInPlaceCommand: invalid clip (must be MIDI) or engine");
         return;
     }
@@ -1880,7 +1880,7 @@ FlattenMidiClipCommand::FlattenMidiClipCommand(ClipId clipId) : clipId_(clipId) 
 void FlattenMidiClipCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI)
+    if (!clip || !clip->isMidi())
         return;
 
     beforeSnapshot_ = *clip;
@@ -1976,7 +1976,7 @@ void sliceClipAtWarpMarkers(ClipId clipId, double tempo, AudioBridge* bridge) {
         return;
 
     auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (!clip || clip->type != ClipType::Audio)
+    if (!clip || !clip->isAudio())
         return;
 
     auto markers = bridge->getWarpMarkers(clipId);
@@ -2179,7 +2179,7 @@ void sliceWarpMarkersToDrumGrid(ClipId clipId, double tempo, AudioBridge* bridge
         return;
 
     auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (!clip || clip->type != ClipType::Audio || clip->audioFilePath.isEmpty())
+    if (!clip || !clip->isAudio() || clip->audioFilePath.isEmpty())
         return;
 
     auto markers = bridge->getWarpMarkers(clipId);
@@ -2241,7 +2241,7 @@ void sliceAtGridToDrumGrid(ClipId clipId, double gridInterval, double tempo, Aud
         return;
 
     auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (!clip || clip->type != ClipType::Audio || clip->audioFilePath.isEmpty())
+    if (!clip || !clip->isAudio() || clip->audioFilePath.isEmpty())
         return;
 
     juce::File audioFile(clip->audioFilePath);

--- a/magda/daw/core/ClipInfo.hpp
+++ b/magda/daw/core/ClipInfo.hpp
@@ -3,6 +3,7 @@
 #include <juce_core/juce_core.h>
 #include <juce_graphics/juce_graphics.h>
 
+#include <variant>
 #include <vector>
 
 #include "ClipTypes.hpp"
@@ -90,6 +91,12 @@ struct ClipPlacement {
     }
 };
 
+struct AudioClipModel {};
+
+struct MidiClipModel {};
+
+using ClipContent = std::variant<MidiClipModel, AudioClipModel>;
+
 /**
  * @brief Clip data structure containing all clip properties
  */
@@ -98,11 +105,31 @@ struct ClipInfo {
     TrackId trackId = INVALID_TRACK_ID;
     juce::String name;
     juce::Colour colour;
-    ClipType type = ClipType::MIDI;
     ClipView view = ClipView::Arrangement;  // Which view this clip belongs to
+    ClipContent content = MidiClipModel{};
 
     // Timeline position. This is the canonical placement model for every clip type.
     ClipPlacement placement;
+
+    ClipType getType() const {
+        return std::holds_alternative<AudioClipModel>(content) ? ClipType::Audio : ClipType::MIDI;
+    }
+
+    bool isAudio() const {
+        return std::holds_alternative<AudioClipModel>(content);
+    }
+
+    bool isMidi() const {
+        return std::holds_alternative<MidiClipModel>(content);
+    }
+
+    void setAudioContent() {
+        content = AudioClipModel{};
+    }
+
+    void setMidiContent() {
+        content = MidiClipModel{};
+    }
 
     // Derived timeline seconds cache. Kept only for bridge/UI call sites that
     // have not moved to beats yet; do not treat these as model authority.

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -21,7 +21,7 @@ bool sourceBpmLooksDefaulted(const ClipInfo& clip, double projectBPM) {
 }
 
 bool seedSourceMetadataFromCachedDetection(ClipInfo& clip, double projectBPM) {
-    if (clip.type != ClipType::Audio || clip.audioFilePath.isEmpty() ||
+    if (!clip.isAudio() || clip.audioFilePath.isEmpty() ||
         !sourceBpmLooksDefaulted(clip, projectBPM)) {
         return false;
     }
@@ -63,7 +63,7 @@ ClipId ClipManager::createAudioClip(TrackId trackId, double startTime, double le
     ClipInfo clip;
     clip.id = nextClipId_++;
     clip.trackId = trackId;
-    clip.type = ClipType::Audio;
+    clip.setAudioContent();
     clip.view = view;
     if (audioFilePath.isNotEmpty()) {
         clip.name = juce::File(audioFilePath).getFileNameWithoutExtension();
@@ -164,7 +164,7 @@ ClipId ClipManager::createMidiClipBeats(TrackId trackId, double startBeats, doub
     ClipInfo clip;
     clip.id = nextClipId_++;
     clip.trackId = trackId;
-    clip.type = ClipType::MIDI;
+    clip.setMidiContent();
     clip.view = view;
     clip.name = generateClipName(ClipType::MIDI);
     if (Config::getInstance().getClipColourMode() == 0) {
@@ -395,14 +395,14 @@ void ClipManager::resizeClip(ClipId clipId, double newLength, bool fromStart, do
         if (fromStart) {
             ClipOperations::resizeContainerFromLeft(*clip, newLength, tempo);
             // Non-loop mode: keep loopStart synced to offset
-            if (!clip->loopEnabled && clip->type == ClipType::Audio) {
+            if (!clip->loopEnabled && clip->isAudio()) {
                 clip->loopStart = clip->offset;
             }
         } else {
             ClipOperations::resizeContainerFromRight(*clip, newLength, tempo);
 
             // In non-loop mode, clip length defines the source region — keep loopLength in sync
-            if (!clip->loopEnabled && clip->type == ClipType::Audio) {
+            if (!clip->loopEnabled && clip->isAudio()) {
                 clip->loopLength = clip->timelineToSource(clip->length);
                 if (clip->autoTempo && clip->sourceBPM > 0.0) {
                     clip->loopLengthBeats = clip->loopLength * clip->sourceBPM / 60.0;
@@ -436,7 +436,7 @@ ClipId ClipManager::splitClip(ClipId clipId, double splitTime, double tempo) {
     rightClip.length = rightLength;
 
     // Adjust offset for right clip (TE-aligned: offset is start position in source)
-    if (rightClip.type == ClipType::Audio) {
+    if (rightClip.isAudio()) {
         // In autoTempo/warp mode, speedRatio is 1.0 but actual stretch is projectBPM/sourceBPM.
         // Use the tempo ratio to convert timeline seconds to source seconds.
         if (clip->isBeatsAuthoritative() && clip->sourceBPM > 0.0 && tempo > 0.0) {
@@ -449,7 +449,7 @@ ClipId ClipManager::splitClip(ClipId clipId, double splitTime, double tempo) {
     }
 
     // Handle MIDI clip splitting
-    if (rightClip.type == ClipType::MIDI && !rightClip.midiNotes.empty()) {
+    if (rightClip.isMidi() && !rightClip.midiNotes.empty()) {
         if (clip->loopEnabled && clip->loopLengthBeats > 0.0) {
             // Looped MIDI: both halves keep the same notes.
             // If the split falls mid-loop, adjust the right clip's midiOffset
@@ -509,7 +509,7 @@ ClipId ClipManager::splitClip(ClipId clipId, double splitTime, double tempo) {
         double leftLenBeats = leftLength * beatsPerSecond;
         if (clip->loopLengthBeats > leftLenBeats) {
             clip->loopLengthBeats = leftLenBeats;
-            if (clip->type == ClipType::Audio) {
+            if (clip->isAudio()) {
                 double srcBpm = clip->sourceBPM > 0.0 ? clip->sourceBPM : tempo;
                 clip->loopLength = clip->loopLengthBeats / srcBpm * 60.0;
             }
@@ -519,7 +519,7 @@ ClipId ClipManager::splitClip(ClipId clipId, double splitTime, double tempo) {
         double rightLenBeats = rightLength * beatsPerSecond;
         if (rightClip.loopLengthBeats > rightLenBeats) {
             rightClip.loopLengthBeats = rightLenBeats;
-            if (rightClip.type == ClipType::Audio) {
+            if (rightClip.isAudio()) {
                 double srcBpm = rightClip.sourceBPM > 0.0 ? rightClip.sourceBPM : tempo;
                 if (rightClip.autoTempo && rightClip.sourceBPM > 0.0) {
                     rightClip.loopStartBeats = rightClip.offsetBeats;
@@ -531,7 +531,7 @@ ClipId ClipManager::splitClip(ClipId clipId, double splitTime, double tempo) {
                 rightClip.loopLength = rightClip.loopLengthBeats / srcBpm * 60.0;
             }
         }
-    } else if (clip->type == ClipType::Audio) {
+    } else if (clip->isAudio()) {
         // Non-looped audio: sync loopStart/loopLength to actual source extent
         // Left clip: loopStart stays at original value, loopLength shrinks
         clip->loopLength = clip->timelineToSource(clip->length);
@@ -562,7 +562,7 @@ ClipId ClipManager::splitClip(ClipId clipId, double splitTime, double tempo) {
     // split boundary.  The stretcher's overlapping analysis windows bleed audio
     // from beyond the boundary, which sounds like a doubled transient.  A short
     // fade masks this startup/shutdown artifact without being audible.
-    if (clip->type == ClipType::Audio && clip->isBeatsAuthoritative()) {
+    if (clip->isAudio() && clip->isBeatsAuthoritative()) {
         constexpr double kSplitFadeSeconds = 0.005;  // 5 ms
         clip->fadeOut = kSplitFadeSeconds;
         rightClip.fadeIn = kSplitFadeSeconds;
@@ -613,7 +613,7 @@ void ClipManager::setClipLoopEnabled(ClipId clipId, bool enabled, double project
 
         // When enabling loop on MIDI clips, capture current length as loop region
         // Populate both beat and seconds fields so all existing code paths work
-        if (enabled && clip->type == ClipType::MIDI) {
+        if (enabled && clip->isMidi()) {
             double bpm = juce::jmax(1.0, projectBPM);
             if (clip->loopLengthBeats <= 0.0) {
                 clip->loopLengthBeats =
@@ -624,7 +624,7 @@ void ClipManager::setClipLoopEnabled(ClipId clipId, bool enabled, double project
 
         // When enabling loop on audio clips, transfer offset → loopStart
         // The user's current offset becomes the loop start point (phase resets to 0)
-        if (enabled && clip->type == ClipType::Audio && clip->audioFilePath.isNotEmpty()) {
+        if (enabled && clip->isAudio() && clip->audioFilePath.isNotEmpty()) {
             clip->loopStart = clip->offset;
 
             // Ensure loopLength is set (preserves source extent in loop mode)
@@ -637,13 +637,13 @@ void ClipManager::setClipLoopEnabled(ClipId clipId, bool enabled, double project
 
         // When disabling loop on MIDI clips, reset midiOffset — the looped
         // phase value has no meaning in non-looped mode.
-        if (!enabled && clip->type == ClipType::MIDI) {
+        if (!enabled && clip->isMidi()) {
             clip->midiOffset = 0.0;
         }
 
         // When disabling loop on audio clips, sync loopStart and clamp length to actual file
         // content
-        if (!enabled && clip->type == ClipType::Audio && clip->audioFilePath.isNotEmpty()) {
+        if (!enabled && clip->isAudio() && clip->audioFilePath.isNotEmpty()) {
             clip->loopStart = clip->offset;
             auto* thumbnail =
                 AudioThumbnailManager::getInstance().getThumbnail(clip->audioFilePath);
@@ -658,7 +658,7 @@ void ClipManager::setClipLoopEnabled(ClipId clipId, bool enabled, double project
 
 void ClipManager::setClipMidiOffset(ClipId clipId, double offsetBeats) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type != ClipType::MIDI) {
+        if (!clip->isMidi()) {
             return;
         }
         clip->midiOffset = juce::jmax(0.0, offsetBeats);
@@ -682,7 +682,7 @@ void ClipManager::setClipLaunchQuantize(ClipId clipId, LaunchQuantize quantize) 
 
 void ClipManager::setClipWarpEnabled(ClipId clipId, bool enabled) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio && clip->warpEnabled != enabled) {
+        if (clip->isAudio() && clip->warpEnabled != enabled) {
             clip->warpEnabled = enabled;
             if (enabled)
                 clip->analogPitch = false;  // Analog pitch is incompatible with warp
@@ -693,7 +693,7 @@ void ClipManager::setClipWarpEnabled(ClipId clipId, bool enabled) {
 
 void ClipManager::setAutoTempo(ClipId clipId, bool enabled, double bpm) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             if (enabled)
                 seedSourceMetadataFromCachedDetection(*clip, bpm);
 
@@ -717,7 +717,7 @@ void ClipManager::setAutoTempo(ClipId clipId, bool enabled, double bpm) {
 
 void ClipManager::setOffset(ClipId clipId, double offset) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::MIDI) {
+        if (clip->isMidi()) {
             // MIDI phase lives in midiOffset (beats) — caller passes beats directly
             clip->midiOffset = juce::jmax(0.0, offset);
         } else {
@@ -732,7 +732,7 @@ void ClipManager::setOffset(ClipId clipId, double offset) {
 
 void ClipManager::setLoopPhase(ClipId clipId, double phase) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio && clip->loopEnabled) {
+        if (clip->isAudio() && clip->loopEnabled) {
             clip->offset = clip->loopStart + phase;
             if (clip->autoTempo && clip->sourceBPM > 0.0)
                 clip->offsetBeats = clip->offset * clip->sourceBPM / 60.0;
@@ -745,7 +745,7 @@ void ClipManager::setLoopPhase(ClipId clipId, double phase) {
 void ClipManager::setLoopStart(ClipId clipId, double loopStart, double bpm) {
     if (auto* clip = getClip(clipId)) {
         clip->loopStart = juce::jmax(0.0, loopStart);
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             if (clip->autoTempo) {
                 // Use sourceBPM for beat conversion — loopStartBeats is in source-beat domain
                 double convBpm = (clip->sourceBPM > 0.0) ? clip->sourceBPM : bpm;
@@ -760,10 +760,10 @@ void ClipManager::setLoopStart(ClipId clipId, double loopStart, double bpm) {
 void ClipManager::setLoopLength(ClipId clipId, double loopLength, double bpm) {
     if (auto* clip = getClip(clipId)) {
         clip->loopLength = juce::jmax(0.0, loopLength);
-        if (clip->type == ClipType::MIDI) {
+        if (clip->isMidi()) {
             // MIDI: keep loopLengthBeats in sync using project BPM
             clip->loopLengthBeats = (clip->loopLength * juce::jmax(1.0, bpm)) / 60.0;
-        } else if (clip->type == ClipType::Audio) {
+        } else if (clip->isAudio()) {
             if (clip->autoTempo) {
                 // Use sourceBPM for beat conversion — loopLengthBeats is in source-beat domain
                 double convBpm = (clip->sourceBPM > 0.0) ? clip->sourceBPM : bpm;
@@ -782,7 +782,7 @@ void ClipManager::setLoopStartAndLength(ClipId clipId, double loopStart, double 
         clip->loopStart = juce::jmax(0.0, loopStart);
         clip->loopLength = juce::jmax(0.0, loopLength);
 
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             // Moving the loop START snaps the phase (clip.offset relative to loopStart) back to 0
             // — the user's drag intent is to relocate the loop, not to compensate for a stale
             // phase. Loop END moves don't touch the phase.
@@ -798,7 +798,7 @@ void ClipManager::setLoopStartAndLength(ClipId clipId, double loopStart, double 
                     clip->offsetBeats = clip->offset * clip->sourceBPM / 60.0;
             }
             sanitizeAudioClip(*clip);
-        } else if (clip->type == ClipType::MIDI) {
+        } else if (clip->isMidi()) {
             clip->loopLengthBeats = (clip->loopLength * juce::jmax(1.0, bpm)) / 60.0;
         }
 
@@ -808,7 +808,7 @@ void ClipManager::setLoopStartAndLength(ClipId clipId, double loopStart, double 
 
 void ClipManager::setLengthBeats(ClipId clipId, double newBeats, double bpm) {
     auto* clip = getClip(clipId);
-    if (!clip || clip->type != ClipType::Audio || !clip->autoTempo || bpm <= 0.0)
+    if (!clip || !clip->isAudio() || !clip->autoTempo || bpm <= 0.0)
         return;
 
     // Issue #1157: the beat-length slider edits USER INTENT only — how many
@@ -832,7 +832,7 @@ void ClipManager::setLengthBeats(ClipId clipId, double newBeats, double bpm) {
 void ClipManager::applyAudioClipBeats(ClipId clipId, const AudioClipBeatsUpdate& update,
                                       double projectBPM) {
     auto* clip = getClip(clipId);
-    if (!clip || clip->type != ClipType::Audio || !clip->autoTempo)
+    if (!clip || !clip->isAudio() || !clip->autoTempo)
         return;
 
     // (1) Detected metadata — write-only role. Inspector "BPM" corrections
@@ -888,19 +888,19 @@ void ClipManager::refreshDerivedSeconds(ClipId clipId, double projectBPM) {
     // loopLength uses projectBPM. When sourceBPM is unknown (detection
     // pending), leave the source-domain seconds alone — readers fall back to
     // the lengthBeats × 60 / projectBPM path.
-    if (clip->type == ClipType::Audio && clip->autoTempo && clip->sourceBPM > 0.0) {
+    if (clip->isAudio() && clip->autoTempo && clip->sourceBPM > 0.0) {
         clip->offset = clip->offsetBeats * 60.0 / clip->sourceBPM;
         clip->loopStart = clip->loopStartBeats * 60.0 / clip->sourceBPM;
         if (clip->loopLengthBeats > 0.0)
             clip->loopLength = clip->loopLengthBeats * 60.0 / clip->sourceBPM;
-    } else if (clip->type == ClipType::MIDI && projectBPM > 0.0 && clip->loopLengthBeats > 0.0) {
+    } else if (clip->isMidi() && projectBPM > 0.0 && clip->loopLengthBeats > 0.0) {
         clip->loopLength = clip->loopLengthBeats * 60.0 / projectBPM;
     }
 }
 
 void ClipManager::setSpeedRatio(ClipId clipId, double speedRatio) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             double oldSourceExtent = clip->timelineToSource(clip->length);
             clip->speedRatio = juce::jlimit(ClipOperations::MIN_SPEED_RATIO,
                                             ClipOperations::MAX_SPEED_RATIO, speedRatio);
@@ -918,7 +918,7 @@ void ClipManager::setSpeedRatio(ClipId clipId, double speedRatio) {
 
 void ClipManager::setTimeStretchMode(ClipId clipId, int mode) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->timeStretchMode = mode;
             notifyClipPropertyChanged(clipId);
         }
@@ -931,7 +931,7 @@ void ClipManager::setTimeStretchMode(ClipId clipId, int mode) {
 
 void ClipManager::setAutoPitch(ClipId clipId, bool enabled) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->autoPitch = enabled;
             notifyClipPropertyChanged(clipId);
         }
@@ -940,7 +940,7 @@ void ClipManager::setAutoPitch(ClipId clipId, bool enabled) {
 
 void ClipManager::setAnalogPitch(ClipId clipId, bool enabled) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->analogPitch = enabled;
             if (enabled && !clip->autoTempo && !clip->warpEnabled) {
                 // Recompute speedRatio from current pitchChange
@@ -956,7 +956,7 @@ void ClipManager::setAnalogPitch(ClipId clipId, bool enabled) {
 
 void ClipManager::setAutoPitchMode(ClipId clipId, int mode) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->autoPitchMode = juce::jlimit(0, 2, mode);
             notifyClipPropertyChanged(clipId);
         }
@@ -965,7 +965,7 @@ void ClipManager::setAutoPitchMode(ClipId clipId, int mode) {
 
 void ClipManager::setPitchChange(ClipId clipId, float semitones) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             float old = clip->pitchChange;
             clip->pitchChange = juce::jlimit(-48.0f, 48.0f, semitones);
 
@@ -984,7 +984,7 @@ void ClipManager::setPitchChange(ClipId clipId, float semitones) {
 
 void ClipManager::setTranspose(ClipId clipId, int semitones) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->transpose = juce::jlimit(-24, 24, semitones);
             notifyClipPropertyChanged(clipId);
         }
@@ -997,7 +997,7 @@ void ClipManager::setTranspose(ClipId clipId, int semitones) {
 
 void ClipManager::setAutoDetectBeats(ClipId clipId, bool enabled) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->autoDetectBeats = enabled;
             notifyClipPropertyChanged(clipId);
         }
@@ -1006,7 +1006,7 @@ void ClipManager::setAutoDetectBeats(ClipId clipId, bool enabled) {
 
 void ClipManager::setBeatSensitivity(ClipId clipId, float sensitivity) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->beatSensitivity = juce::jlimit(0.0f, 1.0f, sensitivity);
             notifyClipPropertyChanged(clipId);
         }
@@ -1019,7 +1019,7 @@ void ClipManager::setBeatSensitivity(ClipId clipId, float sensitivity) {
 
 void ClipManager::setIsReversed(ClipId clipId, bool reversed) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->isReversed = reversed;
             notifyClipPropertyChanged(clipId);
         }
@@ -1032,7 +1032,7 @@ void ClipManager::setIsReversed(ClipId clipId, bool reversed) {
 
 void ClipManager::setGrooveTemplate(ClipId clipId, const juce::String& templateName) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::MIDI) {
+        if (clip->isMidi()) {
             clip->grooveTemplate = templateName;
             notifyClipPropertyChanged(clipId);
         }
@@ -1041,7 +1041,7 @@ void ClipManager::setGrooveTemplate(ClipId clipId, const juce::String& templateN
 
 void ClipManager::setGrooveStrength(ClipId clipId, float strength) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::MIDI) {
+        if (clip->isMidi()) {
             clip->grooveStrength = juce::jlimit(0.0f, 1.0f, strength);
             notifyClipPropertyChanged(clipId);
         }
@@ -1054,7 +1054,7 @@ void ClipManager::setGrooveStrength(ClipId clipId, float strength) {
 
 void ClipManager::setClipVolumeDB(ClipId clipId, float dB) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->volumeDB = juce::jlimit(-100.0f, 0.0f, dB);
             notifyClipPropertyChanged(clipId);
         }
@@ -1063,7 +1063,7 @@ void ClipManager::setClipVolumeDB(ClipId clipId, float dB) {
 
 void ClipManager::setClipGainDB(ClipId clipId, float dB) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->gainDB = juce::jlimit(0.0f, 24.0f, dB);
             notifyClipPropertyChanged(clipId);
         }
@@ -1072,7 +1072,7 @@ void ClipManager::setClipGainDB(ClipId clipId, float dB) {
 
 void ClipManager::setClipPan(ClipId clipId, float pan) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->pan = juce::jlimit(-1.0f, 1.0f, pan);
             notifyClipPropertyChanged(clipId);
         }
@@ -1085,7 +1085,7 @@ void ClipManager::setClipPan(ClipId clipId, float pan) {
 
 void ClipManager::setFadeIn(ClipId clipId, double seconds) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->fadeIn = juce::jmax(0.0, seconds);
             notifyClipPropertyChanged(clipId);
         }
@@ -1094,7 +1094,7 @@ void ClipManager::setFadeIn(ClipId clipId, double seconds) {
 
 void ClipManager::setFadeOut(ClipId clipId, double seconds) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->fadeOut = juce::jmax(0.0, seconds);
             notifyClipPropertyChanged(clipId);
         }
@@ -1103,7 +1103,7 @@ void ClipManager::setFadeOut(ClipId clipId, double seconds) {
 
 void ClipManager::setFadeInType(ClipId clipId, int type) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->fadeInType = juce::jlimit(1, 4, type);
             notifyClipPropertyChanged(clipId);
         }
@@ -1112,7 +1112,7 @@ void ClipManager::setFadeInType(ClipId clipId, int type) {
 
 void ClipManager::setFadeOutType(ClipId clipId, int type) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->fadeOutType = juce::jlimit(1, 4, type);
             notifyClipPropertyChanged(clipId);
         }
@@ -1121,7 +1121,7 @@ void ClipManager::setFadeOutType(ClipId clipId, int type) {
 
 void ClipManager::setFadeInBehaviour(ClipId clipId, int behaviour) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->fadeInBehaviour = juce::jlimit(0, 1, behaviour);
             notifyClipPropertyChanged(clipId);
         }
@@ -1130,7 +1130,7 @@ void ClipManager::setFadeInBehaviour(ClipId clipId, int behaviour) {
 
 void ClipManager::setFadeOutBehaviour(ClipId clipId, int behaviour) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->fadeOutBehaviour = juce::jlimit(0, 1, behaviour);
             notifyClipPropertyChanged(clipId);
         }
@@ -1139,7 +1139,7 @@ void ClipManager::setFadeOutBehaviour(ClipId clipId, int behaviour) {
 
 void ClipManager::setAutoCrossfade(ClipId clipId, bool enabled) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->autoCrossfade = enabled;
             notifyClipPropertyChanged(clipId);
         }
@@ -1148,7 +1148,7 @@ void ClipManager::setAutoCrossfade(ClipId clipId, bool enabled) {
 
 void ClipManager::setLaunchFadeSamples(ClipId clipId, int samples) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->launchFadeSamples = juce::jlimit(0, 16384, samples);
             notifyClipPropertyChanged(clipId);
         }
@@ -1161,7 +1161,7 @@ void ClipManager::setLaunchFadeSamples(ClipId clipId, int samples) {
 
 void ClipManager::setLeftChannelActive(ClipId clipId, bool active) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->leftChannelActive = active;
             notifyClipPropertyChanged(clipId);
         }
@@ -1170,7 +1170,7 @@ void ClipManager::setLeftChannelActive(ClipId clipId, bool active) {
 
 void ClipManager::setRightChannelActive(ClipId clipId, bool active) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             clip->rightChannelActive = active;
             notifyClipPropertyChanged(clipId);
         }
@@ -1204,7 +1204,7 @@ void ClipManager::setClipSnapEnabled(ClipId clipId, bool enabled) {
 
 void ClipManager::trimAudioLeft(ClipId clipId, double trimAmount, double fileDuration) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             ClipOperations::trimAudioFromLeft(*clip, trimAmount, fileDuration);
             notifyClipPropertyChanged(clipId);
         }
@@ -1213,7 +1213,7 @@ void ClipManager::trimAudioLeft(ClipId clipId, double trimAmount, double fileDur
 
 void ClipManager::trimAudioRight(ClipId clipId, double trimAmount, double fileDuration) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             ClipOperations::trimAudioFromRight(*clip, trimAmount, fileDuration);
             notifyClipPropertyChanged(clipId);
         }
@@ -1223,7 +1223,7 @@ void ClipManager::trimAudioRight(ClipId clipId, double trimAmount, double fileDu
 void ClipManager::stretchAudioLeft(ClipId clipId, double newLength, double oldLength,
                                    double originalSpeedRatio, double bpm) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             ClipOperations::stretchAudioFromLeft(*clip, newLength, oldLength, originalSpeedRatio);
             if (bpm > 0.0)
                 clip->startBeats = clip->startTime * bpm / 60.0;
@@ -1238,7 +1238,7 @@ void ClipManager::stretchAudioLeft(ClipId clipId, double newLength, double oldLe
 void ClipManager::stretchAudioRight(ClipId clipId, double newLength, double oldLength,
                                     double originalSpeedRatio, double bpm) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             ClipOperations::stretchAudioFromRight(*clip, newLength, oldLength, originalSpeedRatio);
             if (clip->isBeatsAuthoritative() && bpm > 0.0) {
                 clip->lengthBeats = clip->length * bpm / 60.0;
@@ -1250,7 +1250,7 @@ void ClipManager::stretchAudioRight(ClipId clipId, double newLength, double oldL
 
 void ClipManager::addMidiNote(ClipId clipId, const MidiNote& note) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::MIDI) {
+        if (clip->isMidi()) {
             clip->midiNotes.push_back(note);
             notifyClipPropertyChanged(clipId);
         }
@@ -1259,7 +1259,7 @@ void ClipManager::addMidiNote(ClipId clipId, const MidiNote& note) {
 
 void ClipManager::removeMidiNote(ClipId clipId, int noteIndex) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::MIDI && noteIndex >= 0 &&
+        if (clip->isMidi() && noteIndex >= 0 &&
             noteIndex < static_cast<int>(clip->midiNotes.size())) {
             clip->midiNotes.erase(clip->midiNotes.begin() + noteIndex);
             notifyClipPropertyChanged(clipId);
@@ -1269,7 +1269,7 @@ void ClipManager::removeMidiNote(ClipId clipId, int noteIndex) {
 
 void ClipManager::clearMidiNotes(ClipId clipId) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::MIDI) {
+        if (clip->isMidi()) {
             clip->midiNotes.clear();
             notifyClipPropertyChanged(clipId);
         }
@@ -1278,7 +1278,7 @@ void ClipManager::clearMidiNotes(ClipId clipId) {
 
 void ClipManager::addChordAnnotation(ClipId clipId, const ClipInfo::ChordAnnotation& annotation) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::MIDI) {
+        if (clip->isMidi()) {
             clip->chordAnnotations.push_back(annotation);
             notifyClipPropertyChanged(clipId);
         }
@@ -1287,7 +1287,7 @@ void ClipManager::addChordAnnotation(ClipId clipId, const ClipInfo::ChordAnnotat
 
 void ClipManager::removeChordAnnotation(ClipId clipId, size_t index) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::MIDI && index < clip->chordAnnotations.size()) {
+        if (clip->isMidi() && index < clip->chordAnnotations.size()) {
             clip->chordAnnotations.erase(clip->chordAnnotations.begin() +
                                          static_cast<ptrdiff_t>(index));
             notifyClipPropertyChanged(clipId);
@@ -1297,7 +1297,7 @@ void ClipManager::removeChordAnnotation(ClipId clipId, size_t index) {
 
 void ClipManager::clearChordAnnotations(ClipId clipId) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->type == ClipType::MIDI) {
+        if (clip->isMidi()) {
             clip->chordAnnotations.clear();
             notifyClipPropertyChanged(clipId);
         }
@@ -1706,7 +1706,7 @@ void ClipManager::notifyClipDragPreview(ClipId clipId, double previewStartTime,
 juce::String ClipManager::generateClipName(ClipType type) const {
     int count = 1;
     for (const auto& [id, clip] : clips_) {
-        if (clip.type == type)
+        if (clip.getType() == type)
             count++;
     }
 
@@ -1718,7 +1718,7 @@ juce::String ClipManager::generateClipName(ClipType type) const {
 }
 
 void ClipManager::sanitizeAudioClip(ClipInfo& clip) {
-    if (clip.type != ClipType::Audio || clip.audioFilePath.isEmpty())
+    if (!clip.isAudio() || clip.audioFilePath.isEmpty())
         return;
 
     auto* thumbnail = AudioThumbnailManager::getInstance().getThumbnail(clip.audioFilePath);
@@ -1812,7 +1812,7 @@ void ClipManager::copyTimeRangeToClipboard(double startTime, double endTime,
         trimmed.length = overlapEnd - overlapStart;
         trimmed.startTime = overlapStart;
 
-        if (clip.type == ClipType::Audio) {
+        if (clip.isAudio()) {
             // Adjust offset for the trimmed start position
             double trimFromLeft = overlapStart - clip.startTime;
             if (clip.isBeatsAuthoritative() && clip.sourceBPM > 0.0 && tempoBPM > 0.0) {
@@ -1833,7 +1833,7 @@ void ClipManager::copyTimeRangeToClipboard(double startTime, double endTime,
                 }
                 trimmed.loopLength = trimmed.timelineToSource(trimmed.length);
             }
-        } else if (clip.type == ClipType::MIDI && !clip.midiNotes.empty()) {
+        } else if (clip.isMidi() && !clip.midiNotes.empty()) {
             // Filter MIDI notes to those within the overlap range
             double bps = tempoBPM / 60.0;
             // Notes are in beats relative to clip start. Convert overlap bounds to beats.
@@ -1878,7 +1878,7 @@ std::vector<ClipId> ClipManager::pasteFromClipboard(double pasteTime, TrackId ta
 
         // Create new clip based on type, using targetView instead of clipData.view
         ClipId newClipId = INVALID_CLIP_ID;
-        if (clipData.type == ClipType::Audio) {
+        if (clipData.isAudio()) {
             if (clipData.audioFilePath.isNotEmpty()) {
                 newClipId = createAudioClip(newTrackId, newStartTime, clipData.length,
                                             clipData.audioFilePath, targetView);
@@ -1897,7 +1897,7 @@ std::vector<ClipId> ClipManager::pasteFromClipboard(double pasteTime, TrackId ta
                 newClip->loopEnabled = clipData.loopEnabled;
 
                 // Copy MIDI data
-                if (clipData.type == ClipType::MIDI) {
+                if (clipData.isMidi()) {
                     newClip->midiNotes = clipData.midiNotes;
                     newClip->midiOffset = clipData.midiOffset;
                     newClip->midiCCData = clipData.midiCCData;
@@ -1910,7 +1910,7 @@ std::vector<ClipId> ClipManager::pasteFromClipboard(double pasteTime, TrackId ta
                 bool crossViewToSession =
                     (targetView == ClipView::Session && clipData.view == ClipView::Arrangement);
 
-                if (clipData.type == ClipType::Audio && !crossViewToSession) {
+                if (clipData.isAudio() && !crossViewToSession) {
                     newClip->offset = clipData.offset;
                     newClip->loopStart = clipData.loopStart;
                     newClip->loopLength = clipData.loopLength;
@@ -2042,7 +2042,7 @@ void ClipManager::copyNotesToClipboard(ClipId clipId, const std::vector<size_t>&
     noteClipboardMinBeat_ = 0.0;
 
     const auto* clip = getClip(clipId);
-    if (!clip || clip->type != ClipType::MIDI || noteIndices.empty()) {
+    if (!clip || !clip->isMidi() || noteIndices.empty()) {
         return;
     }
 

--- a/magda/daw/core/ClipOperations.hpp
+++ b/magda/daw/core/ClipOperations.hpp
@@ -77,7 +77,7 @@ class ClipOperations {
         // loopLengthBeats is the authoritative source of truth and should only
         // be updated when the user explicitly changes it, not during tempo-driven resizes.
 
-        if (clip.type == ClipType::Audio && !clip.audioFilePath.isEmpty()) {
+        if (clip.isAudio() && !clip.audioFilePath.isEmpty()) {
             bool isAutoTempo = clip.autoTempo && clip.sourceBPM > 0.0 && bpm > 0.0;
 
             if (isAutoTempo) {
@@ -112,7 +112,7 @@ class ClipOperations {
                     }
                 }
             }
-        } else if (clip.type == ClipType::MIDI) {
+        } else if (clip.isMidi()) {
             // MIDI phase lives in midiOffset (beats). Do NOT touch clip.offset.
             double beatsPerSecond = bpm / 60.0;
             double deltaBeat = actualDelta * beatsPerSecond;
@@ -286,7 +286,7 @@ class ClipOperations {
      * @param newLength New clip length
      */
     static inline void stretchClipFromLeft(ClipInfo& clip, double newLength) {
-        if (clip.type != ClipType::Audio || clip.audioFilePath.isEmpty()) {
+        if (!clip.isAudio() || clip.audioFilePath.isEmpty()) {
             resizeContainerFromLeft(clip, newLength);
             return;
         }
@@ -310,7 +310,7 @@ class ClipOperations {
      * @param newLength New clip length
      */
     static inline void stretchClipFromRight(ClipInfo& clip, double newLength) {
-        if (clip.type != ClipType::Audio || clip.audioFilePath.isEmpty()) {
+        if (!clip.isAudio() || clip.audioFilePath.isEmpty()) {
             resizeContainerFromRight(clip, newLength);
             return;
         }
@@ -742,7 +742,7 @@ class ClipOperations {
      * After flattening, looping is disabled and offsets are reset to 0.
      */
     static inline void flattenMidiClip(ClipInfo& clip) {
-        if (clip.type != ClipType::MIDI)
+        if (!clip.isMidi())
             return;
 
         std::vector<MidiNote> flatNotes;

--- a/magda/daw/core/ClipPropertyCommands.hpp
+++ b/magda/daw/core/ClipPropertyCommands.hpp
@@ -40,7 +40,7 @@ class SetClipOffsetCommand : public UndoableCommand {
     SetClipOffsetCommand(ClipId clipId, double newOffset) : clipId_(clipId), newOffset_(newOffset) {
         auto* clip = ClipManager::getInstance().getClip(clipId);
         if (clip)
-            oldOffset_ = (clip->type == ClipType::MIDI) ? clip->midiOffset : clip->offset;
+            oldOffset_ = (clip->isMidi()) ? clip->midiOffset : clip->offset;
     }
 
     void execute() override {
@@ -162,7 +162,7 @@ class SetClipLoopRangeCommand : public UndoableCommand {
         if (auto* clip = ClipManager::getInstance().getClip(clipId)) {
             oldLoopStart_ = clip->loopStart;
             oldLoopLength_ = clip->loopLength;
-            oldOffset_ = (clip->type == ClipType::MIDI) ? clip->midiOffset : clip->offset;
+            oldOffset_ = (clip->isMidi()) ? clip->midiOffset : clip->offset;
         }
     }
 

--- a/magda/daw/core/MidiNoteCommands.cpp
+++ b/magda/daw/core/MidiNoteCommands.cpp
@@ -28,9 +28,9 @@ void AddMidiNoteCommand::execute() {
         DBG("AddMidiNoteCommand: clip " + juce::String(clipId_) + " NOT FOUND — note dropped");
         return;
     }
-    if (clip->type != ClipType::MIDI) {
+    if (!clip->isMidi()) {
         DBG("AddMidiNoteCommand: clip " + juce::String(clipId_) +
-            " type=" + juce::String(static_cast<int>(clip->type)) + " != MIDI — note dropped");
+            " type=" + juce::String(static_cast<int>(clip->getType())) + " != MIDI — note dropped");
         return;
     }
 
@@ -73,7 +73,7 @@ void MoveMidiNoteCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI || noteIndex_ >= clip->midiNotes.size()) {
+    if (!clip || !clip->isMidi() || noteIndex_ >= clip->midiNotes.size()) {
         return;
     }
 
@@ -92,7 +92,7 @@ void MoveMidiNoteCommand::undo() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI || noteIndex_ >= clip->midiNotes.size()) {
+    if (!clip || !clip->isMidi() || noteIndex_ >= clip->midiNotes.size()) {
         return;
     }
 
@@ -132,7 +132,7 @@ void ResizeMidiNoteCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI || noteIndex_ >= clip->midiNotes.size()) {
+    if (!clip || !clip->isMidi() || noteIndex_ >= clip->midiNotes.size()) {
         return;
     }
 
@@ -150,7 +150,7 @@ void ResizeMidiNoteCommand::undo() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI || noteIndex_ >= clip->midiNotes.size()) {
+    if (!clip || !clip->isMidi() || noteIndex_ >= clip->midiNotes.size()) {
         return;
     }
 
@@ -198,7 +198,7 @@ void DeleteMidiNoteCommand::undo() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         return;
     }
 
@@ -228,7 +228,7 @@ void SetMidiNoteVelocityCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI || noteIndex_ >= clip->midiNotes.size()) {
+    if (!clip || !clip->isMidi() || noteIndex_ >= clip->midiNotes.size()) {
         return;
     }
 
@@ -246,7 +246,7 @@ void SetMidiNoteVelocityCommand::undo() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI || noteIndex_ >= clip->midiNotes.size()) {
+    if (!clip || !clip->isMidi() || noteIndex_ >= clip->midiNotes.size()) {
         return;
     }
 
@@ -280,7 +280,7 @@ void SetMultipleNoteVelocitiesCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         return;
     }
 
@@ -314,7 +314,7 @@ void SetMultipleNoteVelocitiesCommand::undo() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         return;
     }
 
@@ -340,7 +340,7 @@ void MoveMultipleMidiNotesCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         return;
     }
 
@@ -376,7 +376,7 @@ void MoveMultipleMidiNotesCommand::undo() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         return;
     }
 
@@ -404,7 +404,7 @@ void ResizeMultipleMidiNotesCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         return;
     }
 
@@ -438,7 +438,7 @@ void ResizeMultipleMidiNotesCommand::undo() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         return;
     }
 
@@ -478,15 +478,14 @@ void MoveMidiNoteBetweenClipsCommand::execute() {
 
     // Get source clip
     auto* sourceClip = clipManager.getClip(sourceClipId_);
-    if (!sourceClip || sourceClip->type != ClipType::MIDI ||
-        sourceNoteIndex_ >= sourceClip->midiNotes.size()) {
+    if (!sourceClip || !sourceClip->isMidi() || sourceNoteIndex_ >= sourceClip->midiNotes.size()) {
         DBG("MoveMidiNoteBetweenClipsCommand::execute() - validation failed");
         return;
     }
 
     // Get destination clip
     auto* destClip = clipManager.getClip(destClipId_);
-    if (!destClip || destClip->type != ClipType::MIDI) {
+    if (!destClip || !destClip->isMidi()) {
         DBG("MoveMidiNoteBetweenClipsCommand::execute() - dest clip validation failed");
         return;
     }
@@ -524,7 +523,7 @@ void MoveMidiNoteBetweenClipsCommand::undo() {
 
     // Re-add to source clip at original position
     auto* sourceClip = clipManager.getClip(sourceClipId_);
-    if (!sourceClip || sourceClip->type != ClipType::MIDI) {
+    if (!sourceClip || !sourceClip->isMidi()) {
         return;
     }
 
@@ -550,7 +549,7 @@ void QuantizeMidiNotesCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         return;
     }
 
@@ -598,7 +597,7 @@ void QuantizeMidiNotesCommand::undo() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         return;
     }
 
@@ -626,7 +625,7 @@ DeleteMultipleMidiNotesCommand::DeleteMultipleMidiNotesCommand(ClipId clipId,
 
     // Capture note data for undo
     const auto* clip = ClipManager::getInstance().getClip(clipId_);
-    if (clip && clip->type == ClipType::MIDI) {
+    if (clip && clip->isMidi()) {
         for (size_t idx : noteIndices_) {
             if (idx < clip->midiNotes.size()) {
                 deleted_.emplace_back(idx, clip->midiNotes[idx]);
@@ -639,7 +638,7 @@ void DeleteMultipleMidiNotesCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         return;
     }
 
@@ -662,7 +661,7 @@ void DeleteMultipleMidiNotesCommand::undo() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         return;
     }
 
@@ -688,7 +687,7 @@ void AddMultipleMidiNotesCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         return;
     }
 
@@ -711,7 +710,7 @@ void AddMultipleMidiNotesCommand::undo() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         return;
     }
 
@@ -738,7 +737,7 @@ void TransposeMidiClipCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI || clip->midiNotes.empty()) {
+    if (!clip || !clip->isMidi() || clip->midiNotes.empty()) {
         return;
     }
 
@@ -768,7 +767,7 @@ void TransposeMidiClipCommand::undo() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         return;
     }
 
@@ -802,7 +801,7 @@ AddMidiCCEventCommand::AddMidiCCEventCommand(ClipId clipId, MidiCCData event)
 void AddMidiCCEventCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI)
+    if (!clip || !clip->isMidi())
         return;
 
     clip->midiCCData.push_back(event_);
@@ -815,7 +814,7 @@ void AddMidiCCEventCommand::undo() {
         return;
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI || clip->midiCCData.empty())
+    if (!clip || !clip->isMidi() || clip->midiCCData.empty())
         return;
 
     clip->midiCCData.pop_back();
@@ -837,7 +836,7 @@ EditMidiCCEventCommand::EditMidiCCEventCommand(ClipId clipId, size_t eventIndex,
 void EditMidiCCEventCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI || eventIndex_ >= clip->midiCCData.size())
+    if (!clip || !clip->isMidi() || eventIndex_ >= clip->midiCCData.size())
         return;
 
     clip->midiCCData[eventIndex_].value = newValue_;
@@ -850,7 +849,7 @@ void EditMidiCCEventCommand::undo() {
         return;
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI || eventIndex_ >= clip->midiCCData.size())
+    if (!clip || !clip->isMidi() || eventIndex_ >= clip->midiCCData.size())
         return;
 
     clip->midiCCData[eventIndex_].value = oldValue_;
@@ -883,7 +882,7 @@ DeleteMidiCCEventCommand::DeleteMidiCCEventCommand(ClipId clipId, size_t eventIn
 void DeleteMidiCCEventCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI || eventIndex_ >= clip->midiCCData.size())
+    if (!clip || !clip->isMidi() || eventIndex_ >= clip->midiCCData.size())
         return;
 
     clip->midiCCData.erase(clip->midiCCData.begin() + static_cast<std::ptrdiff_t>(eventIndex_));
@@ -896,7 +895,7 @@ void DeleteMidiCCEventCommand::undo() {
         return;
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI)
+    if (!clip || !clip->isMidi())
         return;
 
     size_t insertPos = std::min(eventIndex_, clip->midiCCData.size());
@@ -915,7 +914,7 @@ DrawMidiCCEventsCommand::DrawMidiCCEventsCommand(ClipId clipId, std::vector<Midi
 void DrawMidiCCEventsCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI)
+    if (!clip || !clip->isMidi())
         return;
 
     insertStartIndex_ = clip->midiCCData.size();
@@ -931,7 +930,7 @@ void DrawMidiCCEventsCommand::undo() {
         return;
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI)
+    if (!clip || !clip->isMidi())
         return;
 
     if (insertStartIndex_ <= clip->midiCCData.size()) {
@@ -962,7 +961,7 @@ MoveMidiCCEventCommand::MoveMidiCCEventCommand(ClipId clipId, size_t eventIndex,
 void MoveMidiCCEventCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI || eventIndex_ >= clip->midiCCData.size())
+    if (!clip || !clip->isMidi() || eventIndex_ >= clip->midiCCData.size())
         return;
 
     clip->midiCCData[eventIndex_].beatPosition = newBeatPosition_;
@@ -976,7 +975,7 @@ void MoveMidiCCEventCommand::undo() {
         return;
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI || eventIndex_ >= clip->midiCCData.size())
+    if (!clip || !clip->isMidi() || eventIndex_ >= clip->midiCCData.size())
         return;
 
     clip->midiCCData[eventIndex_].beatPosition = oldBeatPosition_;
@@ -1017,7 +1016,7 @@ MoveMidiPitchBendEventCommand::MoveMidiPitchBendEventCommand(ClipId clipId, size
 void MoveMidiPitchBendEventCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI || eventIndex_ >= clip->midiPitchBendData.size())
+    if (!clip || !clip->isMidi() || eventIndex_ >= clip->midiPitchBendData.size())
         return;
 
     clip->midiPitchBendData[eventIndex_].beatPosition = newBeatPosition_;
@@ -1031,7 +1030,7 @@ void MoveMidiPitchBendEventCommand::undo() {
         return;
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI || eventIndex_ >= clip->midiPitchBendData.size())
+    if (!clip || !clip->isMidi() || eventIndex_ >= clip->midiPitchBendData.size())
         return;
 
     clip->midiPitchBendData[eventIndex_].beatPosition = oldBeatPosition_;
@@ -1064,7 +1063,7 @@ DeleteMultipleMidiCCEventsCommand::DeleteMultipleMidiCCEventsCommand(
 
     // Capture event data for undo
     const auto* clip = ClipManager::getInstance().getClip(clipId_);
-    if (clip && clip->type == ClipType::MIDI) {
+    if (clip && clip->isMidi()) {
         for (size_t idx : eventIndices_) {
             if (idx < clip->midiCCData.size()) {
                 deleted_.emplace_back(idx, clip->midiCCData[idx]);
@@ -1076,7 +1075,7 @@ DeleteMultipleMidiCCEventsCommand::DeleteMultipleMidiCCEventsCommand(
 void DeleteMultipleMidiCCEventsCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI)
+    if (!clip || !clip->isMidi())
         return;
 
     for (size_t idx : eventIndices_) {
@@ -1094,7 +1093,7 @@ void DeleteMultipleMidiCCEventsCommand::undo() {
         return;
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI)
+    if (!clip || !clip->isMidi())
         return;
 
     // Re-insert in reverse order (ascending index) to restore original positions
@@ -1117,7 +1116,7 @@ AddMidiPitchBendEventCommand::AddMidiPitchBendEventCommand(ClipId clipId, MidiPi
 void AddMidiPitchBendEventCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI)
+    if (!clip || !clip->isMidi())
         return;
 
     clip->midiPitchBendData.push_back(event_);
@@ -1130,7 +1129,7 @@ void AddMidiPitchBendEventCommand::undo() {
         return;
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI || clip->midiPitchBendData.empty())
+    if (!clip || !clip->isMidi() || clip->midiPitchBendData.empty())
         return;
 
     clip->midiPitchBendData.pop_back();
@@ -1153,7 +1152,7 @@ EditMidiPitchBendEventCommand::EditMidiPitchBendEventCommand(ClipId clipId, size
 void EditMidiPitchBendEventCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI || eventIndex_ >= clip->midiPitchBendData.size())
+    if (!clip || !clip->isMidi() || eventIndex_ >= clip->midiPitchBendData.size())
         return;
 
     clip->midiPitchBendData[eventIndex_].value = newValue_;
@@ -1166,7 +1165,7 @@ void EditMidiPitchBendEventCommand::undo() {
         return;
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI || eventIndex_ >= clip->midiPitchBendData.size())
+    if (!clip || !clip->isMidi() || eventIndex_ >= clip->midiPitchBendData.size())
         return;
 
     clip->midiPitchBendData[eventIndex_].value = oldValue_;
@@ -1199,7 +1198,7 @@ DeleteMidiPitchBendEventCommand::DeleteMidiPitchBendEventCommand(ClipId clipId, 
 void DeleteMidiPitchBendEventCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI || eventIndex_ >= clip->midiPitchBendData.size())
+    if (!clip || !clip->isMidi() || eventIndex_ >= clip->midiPitchBendData.size())
         return;
 
     clip->midiPitchBendData.erase(clip->midiPitchBendData.begin() +
@@ -1213,7 +1212,7 @@ void DeleteMidiPitchBendEventCommand::undo() {
         return;
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI)
+    if (!clip || !clip->isMidi())
         return;
 
     size_t insertPos = std::min(eventIndex_, clip->midiPitchBendData.size());
@@ -1233,7 +1232,7 @@ DrawMidiPitchBendEventsCommand::DrawMidiPitchBendEventsCommand(
 void DrawMidiPitchBendEventsCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI)
+    if (!clip || !clip->isMidi())
         return;
 
     insertStartIndex_ = clip->midiPitchBendData.size();
@@ -1249,7 +1248,7 @@ void DrawMidiPitchBendEventsCommand::undo() {
         return;
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI)
+    if (!clip || !clip->isMidi())
         return;
 
     if (insertStartIndex_ <= clip->midiPitchBendData.size()) {
@@ -1272,7 +1271,7 @@ DeleteMultipleMidiPitchBendEventsCommand::DeleteMultipleMidiPitchBendEventsComma
 
     // Capture event data for undo
     const auto* clip = ClipManager::getInstance().getClip(clipId_);
-    if (clip && clip->type == ClipType::MIDI) {
+    if (clip && clip->isMidi()) {
         for (size_t idx : eventIndices_) {
             if (idx < clip->midiPitchBendData.size()) {
                 deleted_.emplace_back(idx, clip->midiPitchBendData[idx]);
@@ -1284,7 +1283,7 @@ DeleteMultipleMidiPitchBendEventsCommand::DeleteMultipleMidiPitchBendEventsComma
 void DeleteMultipleMidiPitchBendEventsCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI)
+    if (!clip || !clip->isMidi())
         return;
 
     for (size_t idx : eventIndices_) {
@@ -1303,7 +1302,7 @@ void DeleteMultipleMidiPitchBendEventsCommand::undo() {
         return;
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI)
+    if (!clip || !clip->isMidi())
         return;
 
     // Re-insert in reverse order (ascending index) to restore original positions
@@ -1478,7 +1477,7 @@ void BendNoteTimingCommand::execute() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI || noteIndices_.size() < 2)
+    if (!clip || !clip->isMidi() || noteIndices_.size() < 2)
         return;
 
     // Capture old values on first execute
@@ -1544,7 +1543,7 @@ void BendNoteTimingCommand::undo() {
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
 
-    if (!clip || clip->type != ClipType::MIDI)
+    if (!clip || !clip->isMidi())
         return;
 
     for (size_t i = 0; i < noteIndices_.size() && i < oldStartBeats_.size(); ++i) {

--- a/magda/daw/project/serialization/ClipSerializer.cpp
+++ b/magda/daw/project/serialization/ClipSerializer.cpp
@@ -14,7 +14,7 @@ juce::var ProjectSerializer::serializeClipInfo(const ClipInfo& clip) {
     obj->setProperty("trackId", clip.trackId);
     obj->setProperty("name", clip.name);
     obj->setProperty("colour", colourToString(clip.colour));
-    obj->setProperty("type", static_cast<int>(clip.type));
+    obj->setProperty("type", static_cast<int>(clip.getType()));
     obj->setProperty("view", static_cast<int>(clip.view));
     obj->setProperty("loopEnabled", clip.loopEnabled);
     obj->setProperty("sceneIndex", clip.sceneIndex);
@@ -178,7 +178,11 @@ bool ProjectSerializer::deserializeClipInfo(const juce::var& json, ClipInfo& out
     outClip.trackId = obj->getProperty("trackId");
     outClip.name = obj->getProperty("name").toString();
     outClip.colour = stringToColour(obj->getProperty("colour").toString());
-    outClip.type = static_cast<ClipType>(static_cast<int>(obj->getProperty("type")));
+    auto clipType = static_cast<ClipType>(static_cast<int>(obj->getProperty("type")));
+    if (clipType == ClipType::Audio)
+        outClip.setAudioContent();
+    else
+        outClip.setMidiContent();
     outClip.view = static_cast<ClipView>(static_cast<int>(obj->getProperty("view")));
 
     auto* placementObj = obj->getProperty("placement").getDynamicObject();

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -72,7 +72,7 @@ void ClipComponent::paint(juce::Graphics& g) {
     auto bounds = getLocalBounds();
 
     // Draw based on clip type
-    if (clip->type == ClipType::Audio) {
+    if (clip->isAudio()) {
         paintAudioClip(g, *clip, bounds);
     } else {
         paintMidiClip(g, *clip, bounds);
@@ -159,13 +159,13 @@ void ClipComponent::paint(juce::Graphics& g) {
     }
 
     // Draw fade handles (selected audio clips only)
-    if (isSelected_ && clip->type == ClipType::Audio) {
+    if (isSelected_ && clip->isAudio()) {
         paintFadeHandles(g, *clip, getLocalBounds());
     }
 
     // Draw volume line (audio clips with non-zero volume, or when hovering/dragging)
-    if (clip->type == ClipType::Audio && (std::abs(clip->volumeDB) > 0.01f || hoverVolumeHandle_ ||
-                                          dragMode_ == DragMode::VolumeDrag)) {
+    if (clip->isAudio() && (std::abs(clip->volumeDB) > 0.01f || hoverVolumeHandle_ ||
+                            dragMode_ == DragMode::VolumeDrag)) {
         auto wfArea = bounds.reduced(2, 0).withTrimmedTop(HEADER_HEIGHT + 2).withTrimmedBottom(2);
         paintVolumeLine(g, *clip, wfArea);
     }
@@ -575,7 +575,7 @@ void ClipComponent::paintClipHeader(juce::Graphics& g, const ClipInfo& clip,
     }
 
     // Musical mode indicator (auto-tempo)
-    if (clip.autoTempo && clip.type == ClipType::Audio && headerArea.getWidth() > 16) {
+    if (clip.autoTempo && clip.isAudio() && headerArea.getWidth() > 16) {
         auto musicalArea = headerArea.removeFromRight(14).reduced(2);
         g.setColour(headerForeground);
         g.setFont(FontManager::getInstance().getUIFont(12.0f));
@@ -861,7 +861,7 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
         pc.setCollapsed(daw::ui::PanelLocation::Bottom, false);
         // Don't force a specific MIDI editor tab — BottomPanel's clipSelectionChanged
         // handles the PianoRoll vs DrumGrid choice, respecting the user's preference.
-        if (c->type == ClipType::Audio) {
+        if (c->isAudio()) {
             pc.setActiveTabByType(daw::ui::PanelLocation::Bottom,
                                   daw::ui::PanelContentType::WaveformEditor);
         }
@@ -960,7 +960,7 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
 
     // Cache file duration for resize clamping
     dragStartFileDuration_ = 0.0;
-    if (clip->type == ClipType::Audio && clip->audioFilePath.isNotEmpty()) {
+    if (clip->isAudio() && clip->audioFilePath.isNotEmpty()) {
         auto* thumbnail = AudioThumbnailManager::getInstance().getThumbnail(clip->audioFilePath);
         if (thumbnail)
             dragStartFileDuration_ = thumbnail->getTotalLength();
@@ -995,7 +995,7 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
                 if (cid == clipId_)
                     continue;
                 const auto* c = cm.getClip(cid);
-                if (c && c->type == ClipType::Audio)
+                if (c && c->isAudio())
                     dragStartSelectedFadeSnapshots_[cid] = *c;
             }
         }
@@ -1024,7 +1024,7 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
                 if (cid == clipId_)
                     continue;
                 const auto* c = cm.getClip(cid);
-                if (c && c->type == ClipType::Audio)
+                if (c && c->isAudio())
                     dragStartSelectedFadeSnapshots_[cid] = *c;
             }
         }
@@ -1046,7 +1046,7 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
                 if (cid == clipId_)
                     continue;
                 const auto* c = cm.getClip(cid);
-                if (c && c->type == ClipType::Audio)
+                if (c && c->isAudio())
                     dragStartSelectedFadeSnapshots_[cid] = *c;
             }
         }
@@ -1057,8 +1057,7 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
     // Shift+edge = stretch mode (time-stretches audio source or scales MIDI notes)
     if (isOnLeftEdge(e.x)) {
         if (e.mods.isShiftDown() &&
-            ((clip->type == ClipType::Audio && clip->audioFilePath.isNotEmpty()) ||
-             clip->type == ClipType::MIDI)) {
+            ((clip->isAudio() && clip->audioFilePath.isNotEmpty()) || clip->isMidi())) {
             dragMode_ = DragMode::StretchLeft;
             dragStartSpeedRatio_ = clip->speedRatio;
             dragStartClipSnapshot_ = *clip;
@@ -1069,8 +1068,7 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
         }
     } else if (isOnRightEdge(e.x)) {
         if (e.mods.isShiftDown() &&
-            ((clip->type == ClipType::Audio && clip->audioFilePath.isNotEmpty()) ||
-             clip->type == ClipType::MIDI)) {
+            ((clip->isAudio() && clip->audioFilePath.isNotEmpty()) || clip->isMidi())) {
             dragMode_ = DragMode::StretchRight;
             dragStartSpeedRatio_ = clip->speedRatio;
             dragStartClipSnapshot_ = *clip;
@@ -1290,7 +1288,7 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
             // Compute preview clip from scratch (single source of truth)
             resizePreviewClip_ = dragStartClipSnapshot_;
             ClipOperations::resizeContainerFromLeft(resizePreviewClip_, finalLength, tempoBPM);
-            if (!resizePreviewClip_.loopEnabled && resizePreviewClip_.type == ClipType::Audio) {
+            if (!resizePreviewClip_.loopEnabled && resizePreviewClip_.isAudio()) {
                 resizePreviewClip_.loopStart = resizePreviewClip_.offset;
             }
 
@@ -1418,7 +1416,7 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
             if (stretchThrottle_.check()) {
                 auto& cm = ClipManager::getInstance();
                 if (auto* mutableClip = cm.getClip(clipId_)) {
-                    if (mutableClip->type == ClipType::MIDI) {
+                    if (mutableClip->isMidi()) {
                         // Scale MIDI notes from original snapshot
                         mutableClip->midiNotes = dragStartClipSnapshot_.midiNotes;
                         ClipOperations::stretchMidiNotes(*mutableClip, stretchRatio);
@@ -1545,7 +1543,7 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
                 auto& cm = ClipManager::getInstance();
                 if (auto* mutableClip = cm.getClip(clipId_)) {
                     double rightEdge = dragStartTime_ + dragStartLength_;
-                    if (mutableClip->type == ClipType::MIDI) {
+                    if (mutableClip->isMidi()) {
                         mutableClip->midiNotes = dragStartClipSnapshot_.midiNotes;
                         ClipOperations::stretchMidiNotes(*mutableClip, stretchRatio);
                         mutableClip->length = finalLength;
@@ -1904,7 +1902,7 @@ void ClipComponent::mouseUp(const juce::MouseEvent& e) {
                 double tempo = parentPanel_ ? parentPanel_->getTempo() : 120.0;
                 auto& cm = ClipManager::getInstance();
                 if (auto* clip = cm.getClip(clipId_)) {
-                    if (clip->type == ClipType::MIDI) {
+                    if (clip->isMidi()) {
                         clip->midiNotes = dragStartClipSnapshot_.midiNotes;
                         ClipOperations::stretchMidiNotes(*clip, stretchRatio);
                         ClipOperations::resizeContainerFromRight(*clip, finalLength, tempo);
@@ -1943,7 +1941,7 @@ void ClipComponent::mouseUp(const juce::MouseEvent& e) {
                 double tempoLeft = parentPanel_ ? parentPanel_->getTempo() : 120.0;
                 auto& cm = ClipManager::getInstance();
                 if (auto* clip = cm.getClip(clipId_)) {
-                    if (clip->type == ClipType::MIDI) {
+                    if (clip->isMidi()) {
                         clip->midiNotes = dragStartClipSnapshot_.midiNotes;
                         ClipOperations::stretchMidiNotes(*clip, stretchRatio);
                         clip->length = finalLength;
@@ -2116,7 +2114,7 @@ bool ClipComponent::isOnRightEdge(int x) const {
 
 bool ClipComponent::isOnFadeInHandle(int x, int y) const {
     const auto* clip = getClipInfo();
-    if (!clip || clip->type != ClipType::Audio)
+    if (!clip || !clip->isAudio())
         return false;
 
     auto waveformArea = getLocalBounds().reduced(2, HEADER_HEIGHT + 2);
@@ -2139,7 +2137,7 @@ bool ClipComponent::isOnFadeInHandle(int x, int y) const {
 
 bool ClipComponent::isOnFadeOutHandle(int x, int y) const {
     const auto* clip = getClipInfo();
-    if (!clip || clip->type != ClipType::Audio)
+    if (!clip || !clip->isAudio())
         return false;
 
     auto waveformArea = getLocalBounds().reduced(2, HEADER_HEIGHT + 2);
@@ -2162,7 +2160,7 @@ bool ClipComponent::isOnFadeOutHandle(int x, int y) const {
 bool ClipComponent::isOnVolumeHandle(int x, int y) const {
     juce::ignoreUnused(x);
     const auto* clip = getClipInfo();
-    if (!clip || clip->type != ClipType::Audio)
+    if (!clip || !clip->isAudio())
         return false;
 
     auto waveformArea = getLocalBounds().reduced(2, HEADER_HEIGHT + 2);
@@ -2276,7 +2274,7 @@ void ClipComponent::showContextMenu() {
     bool canSliceAtGrid = false;
     if (!isMultiSelection && canEdit) {
         const auto* singleClip = getClipInfo();
-        if (singleClip && singleClip->type == ClipType::Audio) {
+        if (singleClip && singleClip->isAudio()) {
             // Check for warp markers
             if (singleClip->warpEnabled) {
                 auto* audioEngine = TrackManager::getInstance().getAudioEngine();
@@ -2333,14 +2331,14 @@ void ClipComponent::showContextMenu() {
         if (isMultiSelection) {
             for (auto cid : selectionManager.getSelectedClips()) {
                 auto* c = clipManager.getClip(cid);
-                if (c && c->type == ClipType::MIDI && !c->midiNotes.empty()) {
+                if (c && c->isMidi() && !c->midiNotes.empty()) {
                     hasMidi = true;
                     break;
                 }
             }
         } else {
             const auto* ci = getClipInfo();
-            hasMidi = ci && ci->type == ClipType::MIDI && !ci->midiNotes.empty();
+            hasMidi = ci && ci->isMidi() && !ci->midiNotes.empty();
         }
 
         if (hasMidi) {
@@ -2403,14 +2401,14 @@ void ClipComponent::showContextMenu() {
         if (isMultiSelection) {
             for (auto cid : selectionManager.getSelectedClips()) {
                 auto* c = clipManager.getClip(cid);
-                if (!c || c->type != ClipType::Audio) {
+                if (!c || !c->isAudio()) {
                     allAudio = false;
                     break;
                 }
             }
         } else {
             const auto* clipInfo = getClipInfo();
-            allAudio = clipInfo && clipInfo->type == ClipType::Audio;
+            allAudio = clipInfo && clipInfo->isAudio();
         }
         if (allAudio) {
             menu.addSeparator();
@@ -2436,7 +2434,7 @@ void ClipComponent::showContextMenu() {
         bool canBounceInPlace = false;
         if (!isMultiSelection) {
             const auto* clipInfo = getClipInfo();
-            if (clipInfo && clipInfo->type == ClipType::MIDI) {
+            if (clipInfo && clipInfo->isMidi()) {
                 auto* trackInfo = TrackManager::getInstance().getTrack(clipInfo->trackId);
                 canBounceInPlace = trackInfo && trackInfo->hasInstrument();
             }
@@ -2737,7 +2735,7 @@ void ClipComponent::showContextMenu() {
                     std::vector<ClipId> midiClips;
                     for (auto cid : selectedClips) {
                         auto* c = clipManager.getClip(cid);
-                        if (c && c->type == ClipType::MIDI && !c->midiNotes.empty()) {
+                        if (c && c->isMidi() && !c->midiNotes.empty()) {
                             midiClips.push_back(cid);
                         }
                     }
@@ -2781,7 +2779,7 @@ void ClipComponent::showContextMenu() {
                     std::vector<ClipId> midiClips;
                     for (auto cid : selectedClips) {
                         auto* c = clipManager.getClip(cid);
-                        if (c && c->type == ClipType::MIDI && !c->midiNotes.empty()) {
+                        if (c && c->isMidi() && !c->midiNotes.empty()) {
                             midiClips.push_back(cid);
                         }
                     }

--- a/magda/daw/ui/components/common/TimeBendPopup.cpp
+++ b/magda/daw/ui/components/common/TimeBendPopup.cpp
@@ -24,7 +24,7 @@ TimeBendPopup::TimeBendPopup(magda::ClipId clipId, std::vector<size_t> noteIndic
     : clipId_(clipId), noteIndices_(std::move(noteIndices)) {
     // Capture original positions for preview/restore
     auto* clip = magda::ClipManager::getInstance().getClip(clipId_);
-    if (clip && clip->type == magda::ClipType::MIDI) {
+    if (clip && clip->isMidi()) {
         originalStartBeats_.reserve(noteIndices_.size());
         for (size_t index : noteIndices_) {
             if (index < clip->midiNotes.size())
@@ -198,7 +198,7 @@ TimeBendPopup::~TimeBendPopup() {
 void TimeBendPopup::applyPreview(float depth, float skew, int cycles, float quantize,
                                  int quantizeSub, bool hardAngle) {
     auto* clip = magda::ClipManager::getInstance().getClip(clipId_);
-    if (!clip || clip->type != magda::ClipType::MIDI || originalStartBeats_.size() < 2)
+    if (!clip || !clip->isMidi() || originalStartBeats_.size() < 2)
         return;
 
     // Identity curve with no quantize — restore exact originals to avoid float drift
@@ -243,7 +243,7 @@ void TimeBendPopup::applyPreview(float depth, float skew, int cycles, float quan
 
 void TimeBendPopup::restoreOriginals() {
     auto* clip = magda::ClipManager::getInstance().getClip(clipId_);
-    if (!clip || clip->type != magda::ClipType::MIDI)
+    if (!clip || !clip->isMidi())
         return;
 
     for (size_t i = 0; i < noteIndices_.size() && i < originalStartBeats_.size(); ++i) {

--- a/magda/daw/ui/components/pianoroll/CCLaneComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/CCLaneComponent.cpp
@@ -233,7 +233,7 @@ void CCLaneComponent::updatePointsCache() const {
     cachedPoints_.clear();
 
     const auto* clip = ClipManager::getInstance().getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         pointsCacheDirty_ = false;
         return;
     }

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -853,7 +853,7 @@ bool PianoRollGridComponent::keyPressed(const juce::KeyPress& key) {
             delta *= 12;
 
         const auto* clip = ClipManager::getInstance().getClip(noteSel.clipId);
-        if (!clip || clip->type != ClipType::MIDI)
+        if (!clip || !clip->isMidi())
             return false;
 
         // Check all notes stay within valid range
@@ -889,7 +889,7 @@ bool PianoRollGridComponent::keyPressed(const juce::KeyPress& key) {
             return false;
 
         const auto* clip = ClipManager::getInstance().getClip(noteSel.clipId);
-        if (!clip || clip->type != ClipType::MIDI)
+        if (!clip || !clip->isMidi())
             return false;
 
         double nudge = gridResolutionBeats_;
@@ -1078,7 +1078,7 @@ void PianoRollGridComponent::updateNotePosition(NoteComponent* note, double beat
                 tempo = controller->getState().tempo.bpm;
             }
             double clipStartBeats = clip->startTime * (tempo / 60.0);
-            double trimCompensation = (clip->type == ClipType::MIDI) ? clip->midiTrimOffset : 0.0;
+            double trimCompensation = (clip->isMidi()) ? clip->midiTrimOffset : 0.0;
             displayBeat = clipStartBeats + beat - trimCompensation;
         } else {
             displayBeat = clipStartBeats_ + beat;
@@ -1391,7 +1391,7 @@ void PianoRollGridComponent::createNoteComponents() {
     // Iterate through all clips
     for (ClipId clipId : clipIds_) {
         const auto* clip = clipManager.getClip(clipId);
-        if (!clip || clip->type != ClipType::MIDI) {
+        if (!clip || !clip->isMidi()) {
             continue;
         }
 
@@ -1771,7 +1771,7 @@ void PianoRollGridComponent::updateNoteComponentBounds() {
             } else {
                 clipOffsetBeats = clipStartBeats_;
             }
-            double trimCompensation = (clip->type == ClipType::MIDI) ? clip->midiTrimOffset : 0.0;
+            double trimCompensation = (clip->isMidi()) ? clip->midiTrimOffset : 0.0;
             displayBeat = clipOffsetBeats + note.startBeat - trimCompensation;
         }
 

--- a/magda/daw/ui/components/pianoroll/VelocityLaneComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/VelocityLaneComponent.cpp
@@ -117,7 +117,7 @@ int VelocityLaneComponent::yToVelocity(int y) const {
 
 size_t VelocityLaneComponent::findNoteAtX(int x) const {
     const auto* clip = ClipManager::getInstance().getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         return SIZE_MAX;
     }
 
@@ -170,7 +170,7 @@ std::vector<std::pair<size_t, int>> VelocityLaneComponent::computeRampVelocities
     }
 
     const auto* clip = ClipManager::getInstance().getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         return result;
     }
 
@@ -213,7 +213,7 @@ void VelocityLaneComponent::updateCurveHandle() {
     }
 
     const auto* clip = ClipManager::getInstance().getClip(clipId_);
-    if (!clip || clip->type != ClipType::MIDI) {
+    if (!clip || !clip->isMidi()) {
         isCurveHandleVisible_ = false;
         return;
     }
@@ -323,7 +323,7 @@ void VelocityLaneComponent::paint(juce::Graphics& g) {
 
     for (ClipId renderClipId : clipsToRender) {
         const auto* clip = clipManager.getClip(renderClipId);
-        if (!clip || clip->type != ClipType::MIDI) {
+        if (!clip || !clip->isMidi()) {
             continue;
         }
 
@@ -415,7 +415,7 @@ void VelocityLaneComponent::paint(juce::Graphics& g) {
     if ((isRampDragging_ || isCurveHandleVisible_) && sortedSelectedIndices_.size() >= 2 &&
         clipId_ != INVALID_CLIP_ID) {
         const auto* curveClip = clipManager.getClip(clipId_);
-        if (curveClip && curveClip->type == ClipType::MIDI) {
+        if (curveClip && curveClip->isMidi()) {
             // Compute absolute offset for beat->pixel
             double clipAbsOffset = 0.0;
             if (!relativeMode_) {
@@ -496,7 +496,7 @@ void VelocityLaneComponent::mouseDown(const juce::MouseEvent& e) {
     // Alt+click with 2+ selected notes: start ramp drag
     if (e.mods.isAltDown() && selectedNoteIndices_.size() >= 2) {
         const auto* clip = ClipManager::getInstance().getClip(clipId_);
-        if (clip && clip->type == ClipType::MIDI) {
+        if (clip && clip->isMidi()) {
             // Filter out stale indices and sort by beat position
             sortedSelectedIndices_.clear();
             for (size_t idx : selectedNoteIndices_) {

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -1844,7 +1844,7 @@ void TrackContentPanel::rebuildClipComponents() {
             // Open bottom panel — BottomPanel's clipSelectionChanged handles
             // the PianoRoll vs DrumGrid choice, respecting the user's preference.
             panelController.setCollapsed(daw::ui::PanelLocation::Bottom, false);
-            if (clip->type == ClipType::Audio) {
+            if (clip->isAudio()) {
                 panelController.setActiveTabByType(daw::ui::PanelLocation::Bottom,
                                                    daw::ui::PanelContentType::WaveformEditor);
             }
@@ -1862,7 +1862,7 @@ void TrackContentPanel::rebuildClipComponents() {
             if (isCollapsed) {
                 // If somehow collapsed, open it
                 panelController.setCollapsed(daw::ui::PanelLocation::Bottom, false);
-                if (clip->type == ClipType::Audio) {
+                if (clip->isAudio()) {
                     panelController.setActiveTabByType(daw::ui::PanelLocation::Bottom,
                                                        daw::ui::PanelContentType::WaveformEditor);
                 }
@@ -2027,7 +2027,7 @@ void TrackContentPanel::finishMarqueeSelection(bool addToSelection) {
             if (clip) {
                 auto& panelController = daw::ui::PanelController::getInstance();
                 panelController.setCollapsed(daw::ui::PanelLocation::Bottom, false);
-                if (clip->type == ClipType::Audio) {
+                if (clip->isAudio()) {
                     panelController.setActiveTabByType(daw::ui::PanelLocation::Bottom,
                                                        daw::ui::PanelContentType::WaveformEditor);
                 }

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -48,7 +48,7 @@ void WaveformGridComponent::paint(juce::Graphics& g) {
 
     if (editingClipId_ != magda::INVALID_CLIP_ID) {
         const auto* clip = getClip();
-        if (clip && clip->type == magda::ClipType::Audio) {
+        if (clip && clip->isAudio()) {
             paintWaveform(g, *clip);
             paintClipBoundaries(g);
         } else {
@@ -1024,7 +1024,7 @@ void WaveformGridComponent::mouseDown(const juce::MouseEvent& event) {
     }
 
     auto* clip = magda::ClipManager::getInstance().getClip(editingClipId_);
-    if (!clip || clip->type != magda::ClipType::Audio || clip->audioFilePath.isEmpty()) {
+    if (!clip || !clip->isAudio() || clip->audioFilePath.isEmpty()) {
         return;
     }
 

--- a/magda/daw/ui/panels/BottomPanel.cpp
+++ b/magda/daw/ui/panels/BottomPanel.cpp
@@ -766,7 +766,7 @@ void BottomPanel::updateContentBasedOnSelection() {
             return;
         }
         if (clip) {
-            if (clip->type == ClipType::MIDI) {
+            if (clip->isMidi()) {
                 needsTabs = true;
 
                 // Auto-default to Drum Grid for DrumGrid tracks (on first selection)
@@ -781,7 +781,7 @@ void BottomPanel::updateContentBasedOnSelection() {
                 targetContent = (lastEditorTabChoice_ == 1)
                                     ? daw::ui::PanelContentType::DrumGridClipView
                                     : daw::ui::PanelContentType::PianoRoll;
-            } else if (clip->type == ClipType::Audio) {
+            } else if (clip->isAudio()) {
                 targetContent = daw::ui::PanelContentType::WaveformEditor;
             }
         }

--- a/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
+++ b/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
@@ -148,7 +148,7 @@ void AudioClipPropertiesContent::createControls() {
 
         const bool sourceBpmLooksDefaulted =
             clip->sourceBPM <= 0.0 || (bpm > 0.0 && std::abs(clip->sourceBPM - bpm) < 0.1);
-        if (enable && clip->type == magda::ClipType::Audio && sourceBpmLooksDefaulted) {
+        if (enable && clip->isAudio() && sourceBpmLooksDefaulted) {
             // Issue #1157: only seed from AudioThumbnailManager when the
             // file didn't carry tempo metadata. setSourceMetadata (from TE's
             // loopInfo) is authoritative when present.
@@ -443,7 +443,7 @@ void AudioClipPropertiesContent::createControls() {
 
 void AudioClipPropertiesContent::updateFromClip() {
     const auto* clip = magda::ClipManager::getInstance().getClip(clipId_);
-    bool hasClip = clip != nullptr && clip->type == magda::ClipType::Audio;
+    bool hasClip = clip != nullptr && clip->isAudio();
 
     warpToggle_->setToggleState(hasClip && clip->warpEnabled, juce::dontSendNotification);
     autoTempoToggle_->setToggleState(hasClip && clip->autoTempo, juce::dontSendNotification);

--- a/magda/daw/ui/panels/content/DrumGridClipContent.cpp
+++ b/magda/daw/ui/panels/content/DrumGridClipContent.cpp
@@ -848,7 +848,7 @@ class DrumGridClipGrid : public juce::Component,
                 delta *= 12;
 
             const auto* clip = magda::ClipManager::getInstance().getClip(noteSel.clipId);
-            if (!clip || clip->type != magda::ClipType::MIDI)
+            if (!clip || !clip->isMidi())
                 return false;
 
             for (size_t idx : noteSel.noteIndices) {
@@ -1026,7 +1026,7 @@ class DrumGridClipGrid : public juce::Component,
 
     void createNoteComponents() {
         const auto* clip = magda::ClipManager::getInstance().getClip(clipId_);
-        if (!clip || clip->type != magda::ClipType::MIDI || !padRows_)
+        if (!clip || !clip->isMidi() || !padRows_)
             return;
 
         auto noteColour = DarkTheme::getColour(DarkTheme::ACCENT_BLUE);
@@ -1539,7 +1539,7 @@ DrumGridClipContent::DrumGridClipContent() {
             return;
 
         const auto* clip = clipManager.getClip(clipId);
-        if (!clip || clip->type != magda::ClipType::MIDI)
+        if (!clip || !clip->isMidi())
             return;
 
         double pasteOffset = clipManager.getNoteClipboardMinBeat();
@@ -1569,7 +1569,7 @@ DrumGridClipContent::DrumGridClipContent() {
                                               std::vector<size_t> noteIndices) {
         auto& clipManager = magda::ClipManager::getInstance();
         const auto* clip = clipManager.getClip(clipId);
-        if (!clip || clip->type != magda::ClipType::MIDI)
+        if (!clip || !clip->isMidi())
             return;
 
         double minStart = std::numeric_limits<double>::max();
@@ -1769,7 +1769,7 @@ void DrumGridClipContent::onActivated() {
     magda::ClipId selectedClip = magda::ClipManager::getInstance().getSelectedClip();
     if (selectedClip != magda::INVALID_CLIP_ID) {
         const auto* clip = magda::ClipManager::getInstance().getClip(selectedClip);
-        if (clip && clip->type == magda::ClipType::MIDI) {
+        if (clip && clip->isMidi()) {
             setClip(selectedClip);
         }
     }
@@ -1811,7 +1811,7 @@ void DrumGridClipContent::clipSelectionChanged(magda::ClipId clipId) {
     }
 
     const auto* clip = magda::ClipManager::getInstance().getClip(clipId);
-    if (clip && clip->type == magda::ClipType::MIDI) {
+    if (clip && clip->isMidi()) {
         setClip(clipId);
     }
 }

--- a/magda/daw/ui/panels/content/MidiEditorContent.cpp
+++ b/magda/daw/ui/panels/content/MidiEditorContent.cpp
@@ -169,7 +169,7 @@ MidiEditorContent::MidiEditorContent() {
     magda::ClipId selectedClip = magda::ClipManager::getInstance().getSelectedClip();
     if (selectedClip != magda::INVALID_CLIP_ID) {
         const auto* clip = magda::ClipManager::getInstance().getClip(selectedClip);
-        if (clip && clip->type == magda::ClipType::MIDI) {
+        if (clip && clip->isMidi()) {
             editingClipId_ = selectedClip;
         }
     }

--- a/magda/daw/ui/panels/content/PianoRollContent.cpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.cpp
@@ -186,7 +186,7 @@ void PianoRollContent::setupGridCallbacks() {
 
         // After moving, check if note is still visible in this clip (considering offset)
         auto* clip = magda::ClipManager::getInstance().getClip(clipId);
-        if (clip && clip->type == magda::ClipType::MIDI && noteIndex < clip->midiNotes.size()) {
+        if (clip && clip->isMidi() && noteIndex < clip->midiNotes.size()) {
             const auto& note = clip->midiNotes[noteIndex];
             double tempo = 120.0;
             if (auto* controller = magda::TimelineController::getCurrent()) {
@@ -218,7 +218,7 @@ void PianoRollContent::setupGridCallbacks() {
                 if (destClipId != magda::INVALID_CLIP_ID && destClipId != clipId) {
                     DBG("  -> Would be visible in clip " << destClipId << ", moving it there");
                     auto* destClip = magda::ClipManager::getInstance().getClip(destClipId);
-                    if (destClip && destClip->type == magda::ClipType::MIDI) {
+                    if (destClip && destClip->isMidi()) {
                         // Calculate position in destination clip's content coordinates
                         // absoluteBeat is timeline position, convert to content position
                         double destClipStartBeats = destClip->placement.startBeat;
@@ -363,7 +363,7 @@ void PianoRollContent::setupGridCallbacks() {
             return;
 
         const auto* clip = clipManager.getClip(clipId);
-        if (!clip || clip->type != magda::ClipType::MIDI)
+        if (!clip || !clip->isMidi())
             return;
 
         double pasteOffset = clipManager.getNoteClipboardMinBeat();
@@ -393,7 +393,7 @@ void PianoRollContent::setupGridCallbacks() {
                                               std::vector<size_t> noteIndices) {
         auto& clipManager = magda::ClipManager::getInstance();
         const auto* clip = clipManager.getClip(clipId);
-        if (!clip || clip->type != magda::ClipType::MIDI)
+        if (!clip || !clip->isMidi())
             return;
 
         double minStart = std::numeric_limits<double>::max();
@@ -841,7 +841,7 @@ void PianoRollContent::setRelativeTimeMode(bool relative) {
             auto& clipManager = magda::ClipManager::getInstance();
             auto& selectionManager = magda::SelectionManager::getInstance();
             const auto* clip = clipManager.getClip(editingClipId_);
-            if (clip && clip->type == magda::ClipType::MIDI) {
+            if (clip && clip->isMidi()) {
                 magda::TrackId trackId = clip->trackId;
 
                 // Get all selected clips
@@ -851,7 +851,7 @@ void PianoRollContent::setRelativeTimeMode(bool relative) {
                 // Filter selected clips to only MIDI clips on this track
                 for (magda::ClipId id : selectedClipsSet) {
                     auto* c = clipManager.getClip(id);
-                    if (c && c->type == magda::ClipType::MIDI && c->trackId == trackId) {
+                    if (c && c->isMidi() && c->trackId == trackId) {
                         selectedMidiClips.push_back(id);
                     }
                 }
@@ -873,7 +873,7 @@ void PianoRollContent::setRelativeTimeMode(bool relative) {
                     std::vector<magda::ClipId> allMidiClips;
                     for (magda::ClipId id : allClipsOnTrack) {
                         auto* c = clipManager.getClip(id);
-                        if (c && c->type == magda::ClipType::MIDI) {
+                        if (c && c->isMidi()) {
                             allMidiClips.push_back(id);
                         }
                     }
@@ -909,7 +909,7 @@ void PianoRollContent::onActivated() {
     magda::ClipId selectedClip = magda::ClipManager::getInstance().getSelectedClip();
     if (selectedClip != magda::INVALID_CLIP_ID) {
         const auto* clip = magda::ClipManager::getInstance().getClip(selectedClip);
-        if (clip && clip->type == magda::ClipType::MIDI) {
+        if (clip && clip->isMidi()) {
             editingClipId_ = selectedClip;
             gridComponent_->setClip(selectedClip);
 
@@ -972,7 +972,7 @@ void PianoRollContent::clipsChanged() {
             std::vector<magda::ClipId> selectedMidiClips;
             for (magda::ClipId id : selectedClipsSet) {
                 auto* c = clipManager.getClip(id);
-                if (c && c->type == magda::ClipType::MIDI && c->trackId == trackId) {
+                if (c && c->isMidi() && c->trackId == trackId) {
                     selectedMidiClips.push_back(id);
                 }
             }
@@ -988,7 +988,7 @@ void PianoRollContent::clipsChanged() {
                 std::vector<magda::ClipId> allMidiClips;
                 for (magda::ClipId id : allClipsOnTrack) {
                     auto* c = clipManager.getClip(id);
-                    if (c && c->type == magda::ClipType::MIDI) {
+                    if (c && c->isMidi()) {
                         allMidiClips.push_back(id);
                     }
                 }
@@ -1018,7 +1018,7 @@ void PianoRollContent::clipPropertyChanged(magda::ClipId clipId) {
             if (auto* self = safeThis.getComponent()) {
                 // Re-evaluate force-relative mode (loop may have been toggled)
                 const auto* clip = magda::ClipManager::getInstance().getClip(clipId);
-                if (clip && clip->type == magda::ClipType::MIDI) {
+                if (clip && clip->isMidi()) {
                     bool forceRelative =
                         (clip->view == magda::ClipView::Session) || clip->loopEnabled;
                     if (forceRelative) {
@@ -1067,7 +1067,7 @@ void PianoRollContent::clipSelectionChanged(magda::ClipId clipId) {
         auto& clipManager = magda::ClipManager::getInstance();
         auto& selectionManager = magda::SelectionManager::getInstance();
         const auto* clip = clipManager.getClip(clipId);
-        if (clip && clip->type == magda::ClipType::MIDI) {
+        if (clip && clip->isMidi()) {
             editingClipId_ = clipId;
 
             magda::TrackId trackId = clip->trackId;
@@ -1081,7 +1081,7 @@ void PianoRollContent::clipSelectionChanged(magda::ClipId clipId) {
             // Filter selected clips to only MIDI clips on this track
             for (magda::ClipId id : selectedClipsSet) {
                 auto* c = clipManager.getClip(id);
-                if (c && c->type == magda::ClipType::MIDI && c->trackId == trackId) {
+                if (c && c->isMidi() && c->trackId == trackId) {
                     selectedMidiClips.push_back(id);
                     DBG("  - Selected MIDI clip on track: " << id);
                 }
@@ -1106,7 +1106,7 @@ void PianoRollContent::clipSelectionChanged(magda::ClipId clipId) {
                 std::vector<magda::ClipId> allMidiClips;
                 for (magda::ClipId id : allClipsOnTrack) {
                     auto* c = clipManager.getClip(id);
-                    if (c && c->type == magda::ClipType::MIDI) {
+                    if (c && c->isMidi()) {
                         allMidiClips.push_back(id);
                     }
                 }
@@ -1176,7 +1176,7 @@ void PianoRollContent::multiClipSelectionChanged(const std::unordered_set<magda:
     // Get the first clip to determine the track
     magda::ClipId firstClipId = *clipIds.begin();
     const auto* firstClip = clipManager.getClip(firstClipId);
-    if (!firstClip || firstClip->type != magda::ClipType::MIDI) {
+    if (!firstClip || !firstClip->isMidi()) {
         return;
     }
 
@@ -1186,7 +1186,7 @@ void PianoRollContent::multiClipSelectionChanged(const std::unordered_set<magda:
     std::vector<magda::ClipId> selectedMidiClips;
     for (magda::ClipId id : clipIds) {
         auto* c = clipManager.getClip(id);
-        if (c && c->type == magda::ClipType::MIDI && c->trackId == trackId) {
+        if (c && c->isMidi() && c->trackId == trackId) {
             selectedMidiClips.push_back(id);
         }
     }

--- a/magda/daw/ui/panels/content/WaveformEditorContent.cpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.cpp
@@ -559,7 +559,7 @@ WaveformEditorContent::WaveformEditorContent() {
     magda::ClipId selectedClip = magda::ClipManager::getInstance().getSelectedClip();
     if (selectedClip != magda::INVALID_CLIP_ID) {
         const auto* clip = magda::ClipManager::getInstance().getClip(selectedClip);
-        if (clip && clip->type == magda::ClipType::Audio) {
+        if (clip && clip->isAudio()) {
             setClip(selectedClip);
         }
     }
@@ -648,7 +648,7 @@ void WaveformEditorContent::onActivated() {
     magda::ClipId selectedClip = magda::ClipManager::getInstance().getSelectedClip();
     if (selectedClip != magda::INVALID_CLIP_ID) {
         const auto* clip = magda::ClipManager::getInstance().getClip(selectedClip);
-        if (clip && clip->type == magda::ClipType::Audio) {
+        if (clip && clip->isAudio()) {
             setClip(selectedClip);
         }
     }
@@ -832,8 +832,7 @@ void WaveformEditorContent::clipPropertyChanged(magda::ClipId clipId) {
         }
 
         // Check if cached transients were invalidated (e.g. sensitivity changed)
-        if (transientsCached_ && clip->type == magda::ClipType::Audio &&
-            !clip->audioFilePath.isEmpty()) {
+        if (transientsCached_ && clip->isAudio() && !clip->audioFilePath.isEmpty()) {
             auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
                 clip->audioFilePath);
             if (!cached) {
@@ -855,7 +854,7 @@ void WaveformEditorContent::clipSelectionChanged(magda::ClipId clipId) {
     // Auto-switch to the selected clip if it's an audio clip
     if (clipId != magda::INVALID_CLIP_ID) {
         const auto* clip = magda::ClipManager::getInstance().getClip(clipId);
-        if (clip && clip->type == magda::ClipType::Audio) {
+        if (clip && clip->isAudio()) {
             setClip(clipId);
         }
     }
@@ -1009,7 +1008,7 @@ void WaveformEditorContent::setClip(magda::ClipId clipId) {
         }
 
         // Check for cached transients or start polling
-        if (clip && clip->type == magda::ClipType::Audio && !clip->audioFilePath.isEmpty()) {
+        if (clip && clip->isAudio() && !clip->audioFilePath.isEmpty()) {
             auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
                 clip->audioFilePath);
             if (cached) {

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -357,7 +357,7 @@ void ClipInspector::initClipPropertiesSection() {
     clipBpmValue_.setEditable(true);
     clipBpmValue_.onTextChange = [this]() {
         auto* clip = magda::ClipManager::getInstance().getClip(primaryClipId());
-        if (!clip || clip->type != magda::ClipType::Audio)
+        if (!clip || !clip->isAudio())
             return;
 
         // Parse BPM from text (strip " BPM" suffix if present)
@@ -523,10 +523,10 @@ void ClipInspector::initClipPropertiesSection() {
         if (!clip)
             return;
 
-        if (clip->type == magda::ClipType::MIDI) {
+        if (clip->isMidi()) {
             double newOffsetBeats = clipContentOffsetValue_->getValue();
             magda::ClipManager::getInstance().setClipMidiOffset(primaryClipId(), newOffsetBeats);
-        } else if (clip->type == magda::ClipType::Audio) {
+        } else if (clip->isAudio()) {
             double bpm = 120.0;
             if (timelineController_) {
                 bpm = timelineController_->getState().tempo.bpm;
@@ -651,7 +651,7 @@ void ClipInspector::initClipPropertiesSection() {
         // applyAudioClipBeats once autoTempo is on.
         const bool sourceBpmLooksDefaulted =
             clip->sourceBPM <= 0.0 || (bpm > 0.0 && std::abs(clip->sourceBPM - bpm) < 0.1);
-        if (enable && clip->type == magda::ClipType::Audio && sourceBpmLooksDefaulted) {
+        if (enable && clip->isAudio() && sourceBpmLooksDefaulted) {
             // Issue #1157: only seed from AudioThumbnailManager when the file
             // didn't carry tempo metadata. setSourceMetadata (from TE's
             // loopInfo) is authoritative when present; TempoDetect can be
@@ -746,7 +746,7 @@ void ClipInspector::initClipPropertiesSection() {
         double delta = currentValue - multiSpeedRatioDragStart_;
         for (auto cid : selectedClipIds_) {
             const auto* c = magda::ClipManager::getInstance().getClip(cid);
-            if (c && c->type == magda::ClipType::Audio) {
+            if (c && c->isAudio()) {
                 double newVal = juce::jlimit(0.25, 4.0, c->speedRatio + delta);
                 magda::UndoManager::getInstance().executeCommand(
                     std::make_unique<magda::SetClipSpeedRatioCommand>(cid, newVal));
@@ -808,8 +808,7 @@ void ClipInspector::initClipPropertiesSection() {
         }
         // Preserve current phase when moving loop start
         // Use sourceBPM for audio source-file positions
-        double loopBpm =
-            (clip->type == magda::ClipType::Audio && clip->sourceBPM > 0.0) ? clip->sourceBPM : bpm;
+        double loopBpm = (clip->isAudio() && clip->sourceBPM > 0.0) ? clip->sourceBPM : bpm;
         double currentPhase = clip->offset - clip->loopStart;
         double newLoopStartBeats = clipLoopStartValue_->getValue();
         double newLoopStartSeconds =
@@ -851,8 +850,7 @@ void ClipInspector::initClipPropertiesSection() {
 
         // Compute new loop length from loop end - loop start
         // Use sourceBPM for audio source-file positions
-        double loopBpm =
-            (clip->type == magda::ClipType::Audio && clip->sourceBPM > 0.0) ? clip->sourceBPM : bpm;
+        double loopBpm = (clip->isAudio() && clip->sourceBPM > 0.0) ? clip->sourceBPM : bpm;
         double newLoopEndBeats = clipLoopEndValue_->getValue();
         double loopStartBeats = magda::TimelineUtils::secondsToBeats(clip->loopStart, loopBpm);
         double newLoopLengthBeats = newLoopEndBeats - loopStartBeats;
@@ -907,7 +905,7 @@ void ClipInspector::initClipPropertiesSection() {
             return;
 
         double newPhaseBeats = std::max(0.0, clipLoopPhaseValue_->getValue());
-        if (clip->type == magda::ClipType::MIDI) {
+        if (clip->isMidi()) {
             // MIDI phase lives in midiOffset (beats)
             magda::UndoManager::getInstance().executeCommand(
                 std::make_unique<magda::SetClipOffsetCommand>(primaryClipId(), newPhaseBeats));
@@ -1077,7 +1075,7 @@ void ClipInspector::initPitchSection() {
             magda::UndoManager::getInstance().beginCompoundOperation("Transpose MIDI Clips");
         for (auto cid : selectedClipIds_) {
             const auto* c = magda::ClipManager::getInstance().getClip(cid);
-            if (c && c->type == magda::ClipType::MIDI) {
+            if (c && c->isMidi()) {
                 magda::UndoManager::getInstance().executeCommand(
                     std::make_unique<magda::TransposeMidiClipCommand>(cid, semitones));
             }
@@ -1127,7 +1125,7 @@ void ClipInspector::initPitchSection() {
         double delta = currentValue - multiPitchChangeDragStart_;
         for (auto cid : selectedClipIds_) {
             const auto* c = magda::ClipManager::getInstance().getClip(cid);
-            if (c && c->type == magda::ClipType::Audio) {
+            if (c && c->isAudio()) {
                 float newVal =
                     juce::jlimit(-48.0f, 48.0f, c->pitchChange + static_cast<float>(delta));
                 magda::UndoManager::getInstance().executeCommand(
@@ -1177,7 +1175,7 @@ void ClipInspector::initGrooveSection() {
         float newStrength = static_cast<float>(grooveStrengthValue_->getValue());
         for (auto cid : selectedClipIds_) {
             const auto* c = magda::ClipManager::getInstance().getClip(cid);
-            if (c && c->type == magda::ClipType::MIDI) {
+            if (c && c->isMidi()) {
                 magda::UndoManager::getInstance().executeCommand(
                     std::make_unique<magda::SetClipGrooveStrengthCommand>(cid, newStrength));
             }
@@ -1259,7 +1257,7 @@ void ClipInspector::onGrooveTemplateSelected(const juce::String& templateName) {
 
     for (auto cid : selectedClipIds_) {
         const auto* c = magda::ClipManager::getInstance().getClip(cid);
-        if (c && c->type == magda::ClipType::MIDI) {
+        if (c && c->isMidi()) {
             magda::UndoManager::getInstance().executeCommand(
                 std::make_unique<magda::SetClipGrooveTemplateCommand>(cid, name));
         }
@@ -1287,7 +1285,7 @@ void ClipInspector::initMixSection() {
         double delta = currentValue - multiVolumeDragStart_;
         for (auto cid : selectedClipIds_) {
             const auto* c = magda::ClipManager::getInstance().getClip(cid);
-            if (c && c->type == magda::ClipType::Audio) {
+            if (c && c->isAudio()) {
                 float newVal = juce::jlimit(-100.0f, 0.0f, c->volumeDB + static_cast<float>(delta));
                 magda::UndoManager::getInstance().executeCommand(
                     std::make_unique<magda::SetClipVolumeDBCommand>(cid, newVal));
@@ -1308,7 +1306,7 @@ void ClipInspector::initMixSection() {
         double delta = currentValue - multiPanDragStart_;
         for (auto cid : selectedClipIds_) {
             const auto* c = magda::ClipManager::getInstance().getClip(cid);
-            if (c && c->type == magda::ClipType::Audio) {
+            if (c && c->isAudio()) {
                 float newVal = juce::jlimit(-1.0f, 1.0f, c->pan + static_cast<float>(delta));
                 magda::UndoManager::getInstance().executeCommand(
                     std::make_unique<magda::SetClipPanCommand>(cid, newVal));
@@ -1330,7 +1328,7 @@ void ClipInspector::initMixSection() {
         double delta = currentValue - multiGainDragStart_;
         for (auto cid : selectedClipIds_) {
             const auto* c = magda::ClipManager::getInstance().getClip(cid);
-            if (c && c->type == magda::ClipType::Audio) {
+            if (c && c->isAudio()) {
                 float newVal = juce::jlimit(0.0f, 24.0f, c->gainDB + static_cast<float>(delta));
                 magda::UndoManager::getInstance().executeCommand(
                     std::make_unique<magda::SetClipGainDBCommand>(cid, newVal));

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSelection.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSelection.cpp
@@ -45,7 +45,7 @@ void ClipInspector::clipPropertyChanged(magda::ClipId clipId) {
         // Still update stretch mode combo during drag — pitchChange affects effective mode
         auto pid = primaryClipId();
         const auto* clip = magda::ClipManager::getInstance().getClip(pid);
-        if (clip && clip->type == magda::ClipType::Audio) {
+        if (clip && clip->isAudio()) {
             int effectiveMode = clip->timeStretchMode;
             bool isAnalog = clip->isAnalogPitchActive();
             if (!isAnalog && effectiveMode == 0 &&

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
@@ -38,8 +38,7 @@ void ClipInspector::updateFromSelectedClip() {
     // Only for single-clip selection to avoid sanitization conflicts
     if (!isMulti) {
         auto* mutableClip = magda::ClipManager::getInstance().getClip(pid);
-        if (mutableClip && mutableClip->type == magda::ClipType::Audio &&
-            !mutableClip->audioFilePath.isEmpty()) {
+        if (mutableClip && mutableClip->isAudio() && !mutableClip->audioFilePath.isEmpty()) {
             auto* thumbnail = magda::AudioThumbnailManager::getInstance().getThumbnail(
                 mutableClip->audioFilePath);
             if (thumbnail) {
@@ -101,7 +100,7 @@ void ClipInspector::updateFromSelectedClip() {
             swatch->setColour(clip->colour);
 
         // File path label: show audio filename for arrangement audio clips only.
-        if (clip->type == magda::ClipType::Audio && clip->audioFilePath.isNotEmpty() &&
+        if (clip->isAudio() && clip->audioFilePath.isNotEmpty() &&
             clip->view != magda::ClipView::Session && !isMulti) {
             juce::File audioFile(clip->audioFilePath);
             clipFilePathLabel_.setText(audioFile.getFileName(), juce::dontSendNotification);
@@ -112,7 +111,7 @@ void ClipInspector::updateFromSelectedClip() {
         }
 
         // Update type icon based on clip type
-        bool isAudioClip = (clip->type == magda::ClipType::Audio);
+        bool isAudioClip = (clip->isAudio());
         bool showAudioProps = isAudioClip && !audioPropsCollapsed_;
         audioPropsCollapseToggle_.setVisible(isAudioClip);
         audioPropsLabel_.setVisible(isAudioClip);
@@ -226,9 +225,9 @@ void ClipInspector::updateFromSelectedClip() {
             clipEndValue_->setValue(clip->getEndBeats(bpm), juce::dontSendNotification);
 
             // Offset value
-            if (clip->type == magda::ClipType::MIDI) {
+            if (clip->isMidi()) {
                 clipContentOffsetValue_->setValue(clip->midiOffset, juce::dontSendNotification);
-            } else if (clip->type == magda::ClipType::Audio) {
+            } else if (clip->isAudio()) {
                 // Use sourceBPM for source-file positions when available
                 double displayBpm = clip->sourceBPM > 0.0 ? clip->sourceBPM : bpm;
                 double offsetBeats = magda::TimelineUtils::secondsToBeats(clip->offset, displayBpm);
@@ -253,9 +252,7 @@ void ClipInspector::updateFromSelectedClip() {
             clipLoopStartValue_->setVisible(true);
             clipLoopStartValue_->setBeatsPerBar(beatsPerBar);
             // For audio clips, loop start/end are source-file positions — use sourceBPM
-            double loopBpm = (clip->type == magda::ClipType::Audio && clip->sourceBPM > 0.0)
-                                 ? clip->sourceBPM
-                                 : bpm;
+            double loopBpm = (clip->isAudio() && clip->sourceBPM > 0.0) ? clip->sourceBPM : bpm;
             double loopStartBeats = magda::TimelineUtils::secondsToBeats(clip->loopStart, loopBpm);
             clipLoopStartValue_->setValue(loopStartBeats, juce::dontSendNotification);
             clipLoopStartValue_->setEnabled(true);
@@ -283,7 +280,7 @@ void ClipInspector::updateFromSelectedClip() {
             clipLoopPhaseLabel_.setVisible(true);
             clipLoopPhaseValue_->setVisible(true);
             clipLoopPhaseValue_->setBeatsPerBar(beatsPerBar);
-            if (clip->type == magda::ClipType::MIDI) {
+            if (clip->isMidi()) {
                 clipLoopPhaseValue_->setValue(clip->midiOffset, juce::dontSendNotification);
             } else {
                 double phaseSeconds = clip->offset - clip->loopStart;
@@ -374,7 +371,7 @@ void ClipInspector::updateFromSelectedClip() {
         // ====================================================================
 
         // Pitch/Transpose section (audio + MIDI clips)
-        bool isMidiClip = (clip->type == magda::ClipType::MIDI);
+        bool isMidiClip = (clip->isMidi());
         pitchSectionLabel_.setVisible(showAudioProps);
         autoPitchToggle_.setVisible(false);     // hidden for now
         autoPitchModeCombo_.setVisible(false);  // hidden for now
@@ -597,9 +594,9 @@ void ClipInspector::computeClipRange() {
         if (!c)
             continue;
 
-        if (c->type != magda::ClipType::Audio)
+        if (!c->isAudio())
             clipRange_.allAudio = false;
-        if (c->type != magda::ClipType::MIDI)
+        if (!c->isMidi())
             clipRange_.allMidi = false;
         if (c->view != magda::ClipView::Arrangement)
             clipRange_.allArrangement = false;

--- a/magda/daw/ui/panels/content/inspector/clip/sections/ClipFadesSection.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/sections/ClipFadesSection.cpp
@@ -54,7 +54,7 @@ void ClipFadesSection::initControls() {
         double delta = current - multiFadeInDragStart_;
         for (auto cid : selectedClipIds_) {
             const auto* c = magda::ClipManager::getInstance().getClip(cid);
-            if (c && c->type == magda::ClipType::Audio && c->view != magda::ClipView::Session) {
+            if (c && c->isAudio() && c->view != magda::ClipView::Session) {
                 double newVal = juce::jmax(0.0, c->fadeIn + delta);
                 magda::UndoManager::getInstance().executeCommand(
                     std::make_unique<magda::SetClipFadeInCommand>(cid, newVal));
@@ -78,7 +78,7 @@ void ClipFadesSection::initControls() {
         double delta = current - multiFadeOutDragStart_;
         for (auto cid : selectedClipIds_) {
             const auto* c = magda::ClipManager::getInstance().getClip(cid);
-            if (c && c->type == magda::ClipType::Audio && c->view != magda::ClipView::Session) {
+            if (c && c->isAudio() && c->view != magda::ClipView::Session) {
                 double newVal = juce::jmax(0.0, c->fadeOut + delta);
                 magda::UndoManager::getInstance().executeCommand(
                     std::make_unique<magda::SetClipFadeOutCommand>(cid, newVal));
@@ -220,7 +220,7 @@ void ClipFadesSection::initControls() {
         int samples = msToSamples(launchFadeValue_->getValue());
         for (auto cid : selectedClipIds_) {
             const auto* c = magda::ClipManager::getInstance().getClip(cid);
-            if (c && c->type == magda::ClipType::Audio && c->view == magda::ClipView::Session)
+            if (c && c->isAudio() && c->view == magda::ClipView::Session)
                 magda::UndoManager::getInstance().executeCommand(
                     std::make_unique<magda::SetClipLaunchFadeSamplesCommand>(cid, samples));
         }
@@ -252,7 +252,7 @@ void ClipFadesSection::update() {
     }
 
     const auto* clip = magda::ClipManager::getInstance().getClip(pid);
-    if (!clip || clip->type != magda::ClipType::Audio) {
+    if (!clip || !clip->isAudio()) {
         setVisible(false);
         return;
     }
@@ -292,7 +292,7 @@ void ClipFadesSection::update() {
                 if (cid == pid)
                     continue;
                 const auto* c = magda::ClipManager::getInstance().getClip(cid);
-                if (c && c->type == magda::ClipType::Audio) {
+                if (c && c->isAudio()) {
                     minIn = juce::jmin(minIn, (double)c->fadeIn);
                     maxIn = juce::jmax(maxIn, (double)c->fadeIn);
                     minOut = juce::jmin(minOut, (double)c->fadeOut);
@@ -351,7 +351,7 @@ int ClipFadesSection::getPreferredHeight() const {
 
     auto pid = primaryClipId();
     const auto* clip = magda::ClipManager::getInstance().getClip(pid);
-    if (!clip || clip->type != magda::ClipType::Audio)
+    if (!clip || !clip->isAudio())
         return 0;
 
     bool isSession = (clip->view == magda::ClipView::Session);

--- a/magda/daw/ui/views/SessionClipEditor.cpp
+++ b/magda/daw/ui/views/SessionClipEditor.cpp
@@ -31,7 +31,7 @@ class SessionClipEditor::WaveformDisplay : public juce::Component {
 
         // Get clip info
         const auto* clip = ClipManager::getInstance().getClip(clipId_);
-        if (!clip || clip->type != ClipType::Audio || clip->audioFilePath.isEmpty()) {
+        if (!clip || !clip->isAudio() || clip->audioFilePath.isEmpty()) {
             // No waveform to show
             g.setColour(DarkTheme::getSecondaryTextColour());
             g.setFont(FontManager::getInstance().getUIFont(14.0f));

--- a/magda/daw/ui/views/SessionView.cpp
+++ b/magda/daw/ui/views/SessionView.cpp
@@ -2698,7 +2698,7 @@ void SessionView::openClipEditor(int trackIndex, int sceneIndex) {
         // For audio clips, explicitly switch to waveform editor.
         // For MIDI clips, BottomPanel's clipSelectionChanged handles the
         // PianoRoll vs DrumGrid choice, respecting the user's preference.
-        if (clip->type == ClipType::Audio) {
+        if (clip->isAudio()) {
             panelController.setActiveTabByType(daw::ui::PanelLocation::Bottom,
                                                daw::ui::PanelContentType::WaveformEditor);
         }

--- a/magda/daw/ui/windows/MainWindow.cpp
+++ b/magda/daw/ui/windows/MainWindow.cpp
@@ -597,7 +597,7 @@ MainWindow::MainComponent::MainComponent(AudioEngine* externalEngine) {
             std::vector<ClipId> audioClips;
             for (auto cid : selectedClips) {
                 auto* c = clipManager.getClip(cid);
-                if (c && c->type == ClipType::Audio)
+                if (c && c->isAudio())
                     audioClips.push_back(cid);
             }
             if (audioClips.empty())

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -317,7 +317,7 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
                     }
                 }
                 const auto* targetClip = clipManager.getClip(targetClipId);
-                if (targetClip && targetClip->type == ClipType::MIDI) {
+                if (targetClip && targetClip->isMidi()) {
                     // Determine paste position: use edit cursor if available, else original
                     // position
                     double pasteOffset = clipManager.getNoteClipboardMinBeat();
@@ -443,7 +443,7 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
             const auto& noteSel = selectionManager.getNoteSelection();
             if (noteSel.isValid()) {
                 const auto* clip = clipManager.getClip(noteSel.clipId);
-                if (clip && clip->type == ClipType::MIDI) {
+                if (clip && clip->isMidi()) {
                     // Read selected notes and compute offset (place duplicates right after
                     // originals)
                     double minStart = std::numeric_limits<double>::max();
@@ -603,7 +603,7 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
             if (selectionManager.hasNoteSelection()) {
                 auto clipId = selectionManager.getNoteSelection().clipId;
                 const auto* clip = clipManager.getClip(clipId);
-                if (clip && clip->type == ClipType::MIDI) {
+                if (clip && clip->isMidi()) {
                     std::vector<size_t> allIndices;
                     for (size_t i = 0; i < clip->midiNotes.size(); ++i)
                         allIndices.push_back(i);
@@ -792,7 +792,7 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
             std::vector<ClipId> audioClips;
             for (auto cid : selectedClips) {
                 auto* c = clipManager.getClip(cid);
-                if (c && c->type == ClipType::Audio)
+                if (c && c->isAudio())
                     audioClips.push_back(cid);
             }
 

--- a/magda/daw/ui/windows/MainWindowExport.cpp
+++ b/magda/daw/ui/windows/MainWindowExport.cpp
@@ -440,7 +440,7 @@ void MainWindow::performMidiExport(const ExportMidiDialog::Settings& settings) {
 
     // Find the extent of all MIDI clips
     for (const auto& clip : clips) {
-        if (clip.type == ClipType::MIDI) {
+        if (clip.isMidi()) {
             double end = clip.startTime + clip.length;
             if (end > rangeEnd)
                 rangeEnd = end;
@@ -481,7 +481,7 @@ void MainWindow::performMidiExport(const ExportMidiDialog::Settings& settings) {
     std::map<TrackId, TrackMidiData> trackData;
 
     for (const auto& clip : clips) {
-        if (clip.type != ClipType::MIDI)
+        if (!clip.isMidi())
             continue;
         if (clip.midiNotes.empty() && clip.midiCCData.empty() && clip.midiPitchBendData.empty())
             continue;

--- a/tests/test_audio_clip_stretch.cpp
+++ b/tests/test_audio_clip_stretch.cpp
@@ -281,7 +281,7 @@ TEST_CASE("ClipOperations - stretchAudioFromLeft right edge anchoring",
 
     SECTION("Multiple stretch events maintain fixed right edge") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.startTime = 10.0;
@@ -336,7 +336,7 @@ TEST_CASE("ClipOperations - stretchAudioFromLeft right edge anchoring",
 
     SECTION("Stretch factor clamping doesn't break right edge anchoring") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.startTime = 5.0;
@@ -364,7 +364,7 @@ TEST_CASE("ClipOperations - stretchAudioFromLeft right edge anchoring",
 
     SECTION("Stretch with pre-stretched audio maintains correct calculations") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.startTime = 20.0;

--- a/tests/test_audio_source_length.cpp
+++ b/tests/test_audio_source_length.cpp
@@ -135,7 +135,7 @@ TEST_CASE("ClipDisplayInfo - sourceLength in loop mode uses loopLength",
 
     SECTION("Loop mode with loopLength set: uses loopLength directly") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 16.0;  // Long clip (multiple loop cycles)
         clip.offset = 0.0;
@@ -155,7 +155,7 @@ TEST_CASE("ClipDisplayInfo - sourceLength in loop mode uses loopLength",
 
     SECTION("Loop mode with loopLength=0: falls back to clip.length * speedRatio") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.offset = 0.0;
@@ -174,7 +174,7 @@ TEST_CASE("ClipDisplayInfo - sourceLength in loop mode uses loopLength",
 
     SECTION("Loop mode with speed ratio: sourceExtentSeconds = sourceLength / speedRatio") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 16.0;
         clip.offset = 0.0;
@@ -198,7 +198,7 @@ TEST_CASE("ClipDisplayInfo - sourceLength in non-loop mode derives from clip.len
 
     SECTION("Non-loop mode: sourceLength = clip.length * speedRatio") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.offset = 0.0;
@@ -216,7 +216,7 @@ TEST_CASE("ClipDisplayInfo - sourceLength in non-loop mode derives from clip.len
 
     SECTION("Non-loop mode with speed ratio: sourceLength = clip.length * speedRatio") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.offset = 0.0;
@@ -238,7 +238,7 @@ TEST_CASE("ClipDisplayInfo - sourceFileEnd in non-loop mode", "[clip][display][s
 
     SECTION("Non-loop mode: sourceFileEnd = offset + sourceLength") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.offset = 1.0;
@@ -257,7 +257,7 @@ TEST_CASE("ClipDisplayInfo - sourceFileEnd in non-loop mode", "[clip][display][s
 
     SECTION("Non-loop mode with speed ratio: sourceFileEnd accounts for speed") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 8.0;  // 8s on timeline
         clip.offset = 0.5;
@@ -285,7 +285,7 @@ TEST_CASE("ClipDisplayInfo - sourceExtentSeconds and loopEndPositionSeconds for 
 
     SECTION("Source extent controls waveform editor visible region") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 16.0;  // Long clip
         clip.offset = 0.0;
@@ -305,7 +305,7 @@ TEST_CASE("ClipDisplayInfo - sourceExtentSeconds and loopEndPositionSeconds for 
 
     SECTION("Source extent equals loop - loopEndPositionSeconds matches") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 16.0;
         clip.offset = 0.0;

--- a/tests/test_auto_tempo.cpp
+++ b/tests/test_auto_tempo.cpp
@@ -32,7 +32,7 @@ static constexpr double PROJECT_BPM = 69.0;
 
 static ClipInfo makeAmenClip(double startTime = 0.0) {
     ClipInfo clip;
-    clip.type = ClipType::Audio;
+    clip.setAudioContent();
     clip.audioFilePath = "amen_break.wav";
     clip.startTime = startTime;
     clip.length = AMEN_DURATION;  // original duration before stretching
@@ -46,7 +46,7 @@ static ClipInfo makeAmenClip(double startTime = 0.0) {
 // Helper: make a clip where sourceBPM matches projectBPM (defaulted/calibrated case)
 static ClipInfo makeCalibratedClip(double projectBPM = 120.0) {
     ClipInfo clip;
-    clip.type = ClipType::Audio;
+    clip.setAudioContent();
     clip.audioFilePath = "sample.wav";
     clip.startTime = 0.0;
     clip.length = 2.0;
@@ -394,7 +394,7 @@ TEST_CASE("Regression: loop wrapping past file end", "[clip][auto-tempo][regress
     static constexpr double FILE_BEATS = FILE_DURATION * FILE_BPM / 60.0;  // 13.8 beats
 
     ClipInfo clip;
-    clip.type = ClipType::Audio;
+    clip.setAudioContent();
     clip.audioFilePath = "long_loop.wav";
     clip.length = FILE_DURATION;
     clip.offset = 5.0;  // near end of file

--- a/tests/test_clip_bpm_invariant.cpp
+++ b/tests/test_clip_bpm_invariant.cpp
@@ -27,7 +27,7 @@ ClipInfo makeSessionAutoTempoClip(ClipId id = 1) {
     ClipInfo clip;
     clip.id = id;
     clip.trackId = 1;
-    clip.type = ClipType::Audio;
+    clip.setAudioContent();
     clip.view = ClipView::Session;
     clip.audioFilePath = "fake.wav";
     clip.autoTempo = true;
@@ -210,7 +210,7 @@ TEST_CASE("setAutoTempo adopts cached detected BPM when clip BPM is project defa
     ClipInfo seed;
     seed.id = 77;
     seed.trackId = 1;
-    seed.type = ClipType::Audio;
+    seed.setAudioContent();
     seed.view = ClipView::Arrangement;
     seed.audioFilePath = path;
     seed.loopEnabled = false;

--- a/tests/test_clip_commands.cpp
+++ b/tests/test_clip_commands.cpp
@@ -82,7 +82,7 @@ TEST_CASE("DuplicateClipCommand - basic duplicate", "[clip][command][duplicate]"
         REQUIRE(dup->startTime == Catch::Approx(orig->startTime + orig->length));
         REQUIRE(dup->length == Catch::Approx(orig->length));
         REQUIRE(dup->trackId == orig->trackId);
-        REQUIRE(dup->type == orig->type);
+        REQUIRE(dup->getType() == orig->getType());
 
         // MIDI notes copied
         REQUIRE(dup->midiNotes.size() == orig->midiNotes.size());
@@ -174,7 +174,7 @@ TEST_CASE("DuplicateClipCommand - audio clip", "[clip][command][duplicate]") {
 
     auto* dup = ClipManager::getInstance().getClip(cmd.getDuplicatedClipId());
     REQUIRE(dup != nullptr);
-    REQUIRE(dup->type == ClipType::Audio);
+    REQUIRE(dup->isAudio());
     REQUIRE(dup->startTime == Catch::Approx(4.0));  // 1.0 + 3.0
     REQUIRE(dup->length == Catch::Approx(3.0));
 }
@@ -718,7 +718,7 @@ TEST_CASE("CreateClipCommand - create MIDI clip", "[clip][command][create]") {
 
     auto* clip = ClipManager::getInstance().getClip(created);
     REQUIRE(clip != nullptr);
-    REQUIRE(clip->type == ClipType::MIDI);
+    REQUIRE(clip->isMidi());
     REQUIRE(clip->startTime == Catch::Approx(1.0));
     REQUIRE(clip->length == Catch::Approx(3.0));
     REQUIRE(clip->trackId == track);

--- a/tests/test_clip_resize_operations.cpp
+++ b/tests/test_clip_resize_operations.cpp
@@ -26,7 +26,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         ClipInfo clip;
         clip.startTime = 0.0;
         clip.length = 4.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.speedRatio = 1.0;
@@ -45,7 +45,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         ClipInfo clip;
         clip.startTime = 0.0;
         clip.length = 8.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.speedRatio = 2.0;  // 2x faster (speedRatio = speed factor semantics)
@@ -65,7 +65,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         ClipInfo clip;
         clip.startTime = 2.0;
         clip.length = 4.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 2.0;  // Previously trimmed
         clip.speedRatio = 1.0;
@@ -84,7 +84,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         ClipInfo clip;
         clip.startTime = 2.0;
         clip.length = 4.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.5;  // Only 0.5s of offset available
         clip.speedRatio = 1.0;
@@ -103,7 +103,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         ClipInfo clip;
         clip.startTime = 1.0;
         clip.length = 4.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.speedRatio = 1.0;
@@ -126,7 +126,7 @@ TEST_CASE("ClipOperations::resizeContainerFromRight - audio data unchanged",
         ClipInfo clip;
         clip.startTime = 0.0;
         clip.length = 4.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 1.0;
         clip.speedRatio = 1.5;
@@ -145,7 +145,7 @@ TEST_CASE("ClipOperations::resizeContainerFromRight - audio data unchanged",
         ClipInfo clip;
         clip.startTime = 2.0;
         clip.length = 4.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.speedRatio = 1.0;
@@ -179,7 +179,7 @@ TEST_CASE("ClipOperations - Sequential resizes maintain correct audio offset",
         ClipInfo clip;
         clip.startTime = 0.0;
         clip.length = 8.0;  // 2 bars at 120 BPM = 8 beats
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "kick_loop.wav";
         clip.offset = 0.0;
         clip.speedRatio = 1.0;
@@ -210,7 +210,7 @@ TEST_CASE("ClipOperations - Sequential resizes maintain correct audio offset",
         ClipInfo clip;
         clip.startTime = 2.0;
         clip.length = 6.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.speedRatio = 1.0;
@@ -398,7 +398,7 @@ TEST_CASE("Left resize with throttled drag updates - offset must use original st
         ClipInfo originalState;
         originalState.startTime = 0.0;
         originalState.length = 4.0;
-        originalState.type = ClipType::Audio;
+        originalState.setAudioContent();
         originalState.audioFilePath = "test.wav";
         originalState.offset = 0.0;
         originalState.speedRatio = 1.0;
@@ -435,7 +435,7 @@ TEST_CASE("Left resize with throttled drag updates - offset must use original st
         ClipInfo originalState;
         originalState.startTime = 0.0;
         originalState.length = 8.0;
-        originalState.type = ClipType::Audio;
+        originalState.setAudioContent();
         originalState.audioFilePath = "test.wav";
         originalState.offset = 0.0;
         originalState.speedRatio = 2.0;  // 2x slower (speedRatio = stretchFactor semantics)
@@ -456,7 +456,7 @@ TEST_CASE("Left resize with throttled drag updates - offset must use original st
         ClipInfo originalState;
         originalState.startTime = 0.0;
         originalState.length = 8.0;
-        originalState.type = ClipType::Audio;
+        originalState.setAudioContent();
         originalState.audioFilePath = "test.wav";
         originalState.offset = 0.0;
         originalState.speedRatio = 1.0;
@@ -490,7 +490,7 @@ TEST_CASE("Left resize with throttled drag updates - offset must use original st
         ClipInfo originalState;
         originalState.startTime = 2.0;
         originalState.length = 4.0;
-        originalState.type = ClipType::Audio;
+        originalState.setAudioContent();
         originalState.audioFilePath = "test.wav";
         originalState.offset = 2.0;  // Previously trimmed
         originalState.speedRatio = 1.0;
@@ -595,7 +595,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart tracks offset for
         ClipInfo clip;
         clip.startTime = 0.0;
         clip.length = 4.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.loopStart = 0.0;
@@ -612,7 +612,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart tracks offset for
         ClipInfo clip;
         clip.startTime = 2.0;
         clip.length = 4.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 2.0;
         clip.loopStart = 2.0;
@@ -629,7 +629,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart tracks offset for
         ClipInfo clip;
         clip.startTime = 0.0;
         clip.length = 8.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.loopStart = 0.0;
@@ -646,7 +646,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart tracks offset for
         ClipInfo clip;
         clip.startTime = 0.0;
         clip.length = 8.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.loopStart = 0.0;
@@ -671,7 +671,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart unchanged for loo
         ClipInfo clip;
         clip.startTime = 0.0;
         clip.length = 8.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 1.0;
         clip.loopStart = 0.5;
@@ -694,7 +694,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart unchanged for loo
         ClipInfo clip;
         clip.startTime = 4.0;
         clip.length = 4.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 1.5;
         clip.loopStart = 0.5;
@@ -713,7 +713,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart unchanged for loo
         ClipInfo clip;
         clip.startTime = 0.0;
         clip.length = 8.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 1.0;
         clip.loopStart = 0.5;
@@ -740,7 +740,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart unchanged for loo
         ClipInfo clip;
         clip.startTime = 0.0;
         clip.length = 8.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 1.0;
         clip.loopStart = 0.0;
@@ -769,7 +769,7 @@ TEST_CASE("ClipOperations::trimAudioFromLeft - loopStart tracks offset",
         ClipInfo clip;
         clip.startTime = 0.0;
         clip.length = 4.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.loopStart = 0.0;
@@ -785,7 +785,7 @@ TEST_CASE("ClipOperations::trimAudioFromLeft - loopStart tracks offset",
         ClipInfo clip;
         clip.startTime = 2.0;
         clip.length = 4.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 2.0;
         clip.loopStart = 2.0;
@@ -801,7 +801,7 @@ TEST_CASE("ClipOperations::trimAudioFromLeft - loopStart tracks offset",
         ClipInfo clip;
         clip.startTime = 0.0;
         clip.length = 8.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.loopStart = 0.0;
@@ -818,7 +818,7 @@ TEST_CASE("ClipOperations::trimAudioFromLeft - loopStart tracks offset",
         ClipInfo clip;
         clip.startTime = 1.0;
         clip.length = 4.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.5;
         clip.loopStart = 0.5;
@@ -842,7 +842,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - auto-tempo offset uses BPM 
         ClipInfo clip;
         clip.startTime = 0.0;
         clip.length = 4.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.offsetBeats = 0.0;
@@ -864,7 +864,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - auto-tempo offset uses BPM 
         ClipInfo clip;
         clip.startTime = 0.0;
         clip.length = 8.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.offsetBeats = 0.0;
@@ -891,7 +891,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - auto-tempo offset uses BPM 
         ClipInfo clip;
         clip.startTime = 0.0;
         clip.length = 4.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.speedRatio = 2.0;
@@ -908,7 +908,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - auto-tempo offset uses BPM 
         ClipInfo clip;
         clip.startTime = 0.0;
         clip.length = 4.0;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.audioFilePath = "test.wav";
         clip.offset = 0.0;
         clip.speedRatio = 1.0;

--- a/tests/test_looped_waveform_tile.cpp
+++ b/tests/test_looped_waveform_tile.cpp
@@ -64,7 +64,7 @@ TEST_CASE("ClipDisplayInfo - looped source file ranges", "[clip][display][loop]"
 
     SECTION("Non-looped clip: source range spans full clip") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.offset = 1.0;
@@ -83,7 +83,7 @@ TEST_CASE("ClipDisplayInfo - looped source file ranges", "[clip][display][loop]"
 
     SECTION("Looped clip: source range covers one loop cycle") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 8.0;  // clip is 8s long
         clip.speedRatio = 1.0;
@@ -108,7 +108,7 @@ TEST_CASE("ClipDisplayInfo - looped source file ranges", "[clip][display][loop]"
 
     SECTION("Looped clip with stretch: source range accounts for stretch") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 16.0;     // stretched clip
         clip.speedRatio = 2.0;  // 2x faster
@@ -132,7 +132,7 @@ TEST_CASE("ClipDisplayInfo - looped source file ranges", "[clip][display][loop]"
 
     SECTION("Loop active when loopLength is zero but loopEnabled is true") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 1.0;
         clip.offset = 0.0;
@@ -152,7 +152,7 @@ TEST_CASE("ClipDisplayInfo - looped source file ranges", "[clip][display][loop]"
 
     SECTION("Clip shorter than loop cycle: source range covers full loop region") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 1.0;  // 1s clip, shorter than 2s loop cycle
         clip.speedRatio = 1.0;
@@ -172,7 +172,7 @@ TEST_CASE("ClipDisplayInfo - looped source file ranges", "[clip][display][loop]"
 
     SECTION("Looped clip with stretch: clip covers multiple cycles") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 1.0;  // 1s on timeline
         clip.offset = 0.0;
@@ -193,7 +193,7 @@ TEST_CASE("ClipDisplayInfo - looped source file ranges", "[clip][display][loop]"
 
     SECTION("Clip equal to loop cycle: source range not clamped") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 2.0;  // exactly one loop cycle on timeline
         clip.offset = 0.0;
@@ -213,7 +213,7 @@ TEST_CASE("ClipDisplayInfo - looped source file ranges", "[clip][display][loop]"
 
     SECTION("Clip longer than loop cycle: source range not clamped") {
         ClipInfo clip;
-        clip.type = ClipType::Audio;
+        clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 6.0;  // 3x the loop cycle
         clip.offset = 0.0;

--- a/tests/test_midi_clip_resize_left.cpp
+++ b/tests/test_midi_clip_resize_left.cpp
@@ -21,7 +21,7 @@ using namespace magda;
 static ClipInfo makeMidiClip(double startTime, double length, bool looped = false,
                              double loopLengthBeats = 0.0) {
     ClipInfo clip;
-    clip.type = ClipType::MIDI;
+    clip.setMidiContent();
     clip.startTime = startTime;
     clip.length = length;
     clip.midiOffset = 0.0;

--- a/tests/test_midi_clip_sync.cpp
+++ b/tests/test_midi_clip_sync.cpp
@@ -21,7 +21,7 @@ TEST_CASE("MidiNote - Clip-relative storage", "[midi][clip][storage]") {
 
     SECTION("Notes are stored relative to clip start") {
         ClipInfo clip;
-        clip.type = ClipType::MIDI;
+        clip.setMidiContent();
         clip.startTime = 4.0;  // Clip at 4 seconds (bar 2 at 120 BPM)
         clip.length = 8.0;     // 4 bars
 
@@ -44,7 +44,7 @@ TEST_CASE("MidiNote - Clip-relative storage", "[midi][clip][storage]") {
 
     SECTION("Multiple notes at different clip-relative positions") {
         ClipInfo clip;
-        clip.type = ClipType::MIDI;
+        clip.setMidiContent();
         clip.startTime = 0.0;
         clip.length = 8.0;
 
@@ -71,7 +71,7 @@ TEST_CASE("MidiClip - Position changes don't affect notes", "[midi][clip][positi
 
     SECTION("Moving clip preserves note positions") {
         ClipInfo clip;
-        clip.type = ClipType::MIDI;
+        clip.setMidiContent();
         clip.startTime = 0.0;
         clip.length = 8.0;
 
@@ -94,7 +94,7 @@ TEST_CASE("MidiClip - Position changes don't affect notes", "[midi][clip][positi
 
     SECTION("Moving clip multiple times preserves notes") {
         ClipInfo clip;
-        clip.type = ClipType::MIDI;
+        clip.setMidiContent();
         clip.startTime = 0.0;
         clip.length = 4.0;
 
@@ -122,7 +122,7 @@ TEST_CASE("MidiClip - Length changes preserve note positions", "[midi][clip][len
 
     SECTION("Shortening clip from end preserves notes at start") {
         ClipInfo clip;
-        clip.type = ClipType::MIDI;
+        clip.setMidiContent();
         clip.startTime = 0.0;
         clip.length = 16.0;  // 16 seconds = 32 beats = 8 bars at 120 BPM
 
@@ -154,7 +154,7 @@ TEST_CASE("MidiClip - Length changes preserve note positions", "[midi][clip][len
 
     SECTION("Extending clip doesn't shift existing notes") {
         ClipInfo clip;
-        clip.type = ClipType::MIDI;
+        clip.setMidiContent();
         clip.startTime = 2.0;
         clip.length = 2.0;  // 2 seconds = 4 beats = 1 bar at 120 BPM
 
@@ -181,7 +181,7 @@ TEST_CASE("MidiClip - Notes beyond clip boundary", "[midi][clip][boundary]") {
 
     SECTION("Identify notes within clip length") {
         ClipInfo clip;
-        clip.type = ClipType::MIDI;
+        clip.setMidiContent();
         clip.startTime = 0.0;
         clip.length = 4.0;  // 4 seconds = 8 beats = 2 bars at 120 BPM
 
@@ -214,7 +214,7 @@ TEST_CASE("MidiClip - Notes beyond clip boundary", "[midi][clip][boundary]") {
 
     SECTION("Notes at clip boundaries") {
         ClipInfo clip;
-        clip.type = ClipType::MIDI;
+        clip.setMidiContent();
         clip.startTime = 0.0;
         clip.length = 2.0;  // Exactly 1 bar = 4 beats at 120 BPM
 
@@ -280,7 +280,7 @@ TEST_CASE("MidiClip - Real-world scenario", "[midi][clip][integration]") {
         // - Notes should still play
 
         ClipInfo clip;
-        clip.type = ClipType::MIDI;
+        clip.setMidiContent();
         clip.startTime = 0.0;  // Bar 1
         clip.length = 8.0;     // 8 seconds = 16 beats = 4 bars at 120 BPM
 

--- a/tests/test_midi_offset.cpp
+++ b/tests/test_midi_offset.cpp
@@ -19,7 +19,7 @@ TEST_CASE("MidiOffset - Basic offset behavior", "[midi][offset]") {
 
     SECTION("Offset shifts visible note window") {
         ClipInfo clip;
-        clip.type = ClipType::MIDI;
+        clip.setMidiContent();
         clip.startTime = 0.0;
         clip.length = 4.0;  // 4 seconds = 8 beats at 120 BPM
         clip.midiOffset = 0.0;
@@ -61,7 +61,7 @@ TEST_CASE("MidiOffset - Basic offset behavior", "[midi][offset]") {
 
     SECTION("Offset doesn't modify note data") {
         ClipInfo clip;
-        clip.type = ClipType::MIDI;
+        clip.setMidiContent();
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.midiOffset = 0.0;
@@ -140,7 +140,7 @@ TEST_CASE("MidiOffset - Display position calculation", "[midi][offset][display]"
 
     SECTION("Notes shift left by offset amount in display") {
         ClipInfo clip;
-        clip.type = ClipType::MIDI;
+        clip.setMidiContent();
         clip.startTime = 10.0;  // Timeline position
         clip.length = 4.0;
         clip.midiOffset = 2.0;  // Skip first 2 beats
@@ -164,7 +164,7 @@ TEST_CASE("MidiOffset - Display position calculation", "[midi][offset][display]"
 
     SECTION("Note before offset should be identified") {
         ClipInfo clip;
-        clip.type = ClipType::MIDI;
+        clip.setMidiContent();
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.midiOffset = 3.0;
@@ -197,7 +197,7 @@ TEST_CASE("MidiOffset - Arrangement preview with offset", "[midi][offset][previe
 
     SECTION("Preview shows only visible notes within offset range") {
         ClipInfo clip;
-        clip.type = ClipType::MIDI;
+        clip.setMidiContent();
         clip.startTime = 0.0;
         clip.length = 2.0;  // 2 seconds = 4 beats at 120 BPM
         clip.midiOffset = 2.0;
@@ -240,7 +240,7 @@ TEST_CASE("MidiOffset - Arrangement preview with offset", "[midi][offset][previe
     SECTION("Split clips show different content in preview") {
         // Simulate split scenario: L, C, R clips from same source
         ClipInfo sourceClip;
-        sourceClip.type = ClipType::MIDI;
+        sourceClip.setMidiContent();
         sourceClip.startTime = 0.0;
         sourceClip.length = 6.0;  // 6 seconds = 12 beats
         sourceClip.midiOffset = 0.0;
@@ -327,7 +327,7 @@ TEST_CASE("MidiOffset - Edge cases", "[midi][offset][edge]") {
 
     SECTION("Offset equals clip length shows no notes") {
         ClipInfo clip;
-        clip.type = ClipType::MIDI;
+        clip.setMidiContent();
         clip.startTime = 0.0;
         clip.length = 2.0;      // 4 beats
         clip.midiOffset = 4.0;  // Same as clip length in beats
@@ -371,7 +371,7 @@ TEST_CASE("MidiOffset - Edge cases", "[midi][offset][edge]") {
 
     SECTION("Partial note visibility at offset boundary") {
         ClipInfo clip;
-        clip.type = ClipType::MIDI;
+        clip.setMidiContent();
         clip.startTime = 0.0;
         clip.length = 2.0;  // 4 beats
         clip.midiOffset = 2.0;

--- a/tests/test_midi_recording_juce.cpp
+++ b/tests/test_midi_recording_juce.cpp
@@ -500,7 +500,7 @@ class ProjectSerializerMidiRoundtripTest final : public juce::UnitTest {
 
         // Verify that a clip with no CC/pitchbend data stays empty after roundtrip
         ClipInfo emptyClip;
-        emptyClip.type = ClipType::MIDI;
+        emptyClip.setMidiContent();
         expect(emptyClip.midiCCData.empty(), "New clip CC data should be empty");
         expect(emptyClip.midiPitchBendData.empty(), "New clip PitchBend data should be empty");
 

--- a/tests/test_project_serialization.cpp
+++ b/tests/test_project_serialization.cpp
@@ -391,7 +391,7 @@ TEST_CASE("Comprehensive Project Serialization", "[project][serialization][compr
         const auto& clips = clipManager.getClips();
         REQUIRE(clips.size() == 1);
         REQUIRE(clips[0].name == "MIDI 1");  // Default name from createMidiClip
-        REQUIRE(clips[0].type == ClipType::MIDI);
+        REQUIRE(clips[0].getType() == ClipType::MIDI);
         REQUIRE(clips[0].midiNotes.size() == 2);
         REQUIRE(clips[0].midiNotes[0].noteNumber == 60);
         REQUIRE(clips[0].midiNotes[1].noteNumber == 64);

--- a/tests/test_session_clip_playback.cpp
+++ b/tests/test_session_clip_playback.cpp
@@ -310,7 +310,7 @@ TEST_CASE("CreateMidiClip — create via ClipManager and verify type", "[session
 
     const auto* clip = ClipManager::getInstance().getClip(clipId);
     REQUIRE(clip != nullptr);
-    REQUIRE(clip->type == ClipType::MIDI);
+    REQUIRE(clip->isMidi());
     REQUIRE(clip->view == ClipView::Session);
     REQUIRE(clip->trackId == 1);
     REQUIRE(clip->length == Catch::Approx(4.0));
@@ -371,7 +371,7 @@ TEST_CASE("SyncMidiClipToSlot — verify ClipManager state for MIDI session clip
     const auto* clip = ClipManager::getInstance().getClip(clipId);
     REQUIRE(clip != nullptr);
     REQUIRE(clip->sceneIndex == 0);
-    REQUIRE(clip->type == ClipType::MIDI);
+    REQUIRE(clip->isMidi());
     REQUIRE(clip->midiNotes.size() == 2);
 
     // Verify the clip is retrievable by slot
@@ -425,12 +425,12 @@ TEST_CASE("StopMidiClipSendsAllNotesOff — verify MIDI clip type is detectable 
     REQUIRE(audioClip != nullptr);
 
     // Only MIDI clips should trigger all-notes-off
-    REQUIRE(midiClip->type == ClipType::MIDI);
-    REQUIRE(audioClip->type == ClipType::Audio);
+    REQUIRE(midiClip->isMidi());
+    REQUIRE(audioClip->isAudio());
 
     // Verify the type check used in AudioBridge::stopSessionClip
-    REQUIRE((midiClip->type == ClipType::MIDI) == true);
-    REQUIRE((audioClip->type == ClipType::MIDI) == false);
+    REQUIRE((midiClip->isMidi()) == true);
+    REQUIRE((audioClip->isMidi()) == false);
 }
 
 TEST_CASE("MidiClipSlotAppearance — clip slot shows as occupied after MIDI clip creation",
@@ -455,7 +455,7 @@ TEST_CASE("MidiClipSlotAppearance — clip slot shows as occupied after MIDI cli
     // Clip should be identifiable as MIDI
     const auto* clip = ClipManager::getInstance().getClip(slotClipId);
     REQUIRE(clip != nullptr);
-    REQUIRE(clip->type == ClipType::MIDI);
+    REQUIRE(clip->isMidi());
 }
 
 TEST_CASE("getClipInSlot stays correct across mutation paths",
@@ -960,7 +960,7 @@ TEST_CASE("AutoTempo session clip timing: 172bpm clip in 120bpm project",
           "[session][auto-tempo][playhead]") {
     // Scenario from the bug report: 2-bar loop at 172bpm, project at 120bpm
     ClipInfo clip;
-    clip.type = ClipType::Audio;
+    clip.setAudioContent();
     clip.audioFilePath = "loop_172bpm.wav";
     clip.sourceBPM = 172.0;
     clip.sourceNumBeats = 8.0;         // 2 bars = 8 beats
@@ -1017,7 +1017,7 @@ TEST_CASE("AutoTempo session clip timing: sub-loop region",
           "[session][auto-tempo][playhead][sub-loop]") {
     // 8-beat source, but only looping 4 beats
     ClipInfo clip;
-    clip.type = ClipType::Audio;
+    clip.setAudioContent();
     clip.audioFilePath = "sample.wav";
     clip.sourceBPM = 140.0;
     clip.sourceNumBeats = 8.0;
@@ -1048,7 +1048,7 @@ TEST_CASE("AutoTempo session clip timing: sub-loop region",
 TEST_CASE("AutoTempo session clip timing: BPM edge cases",
           "[session][auto-tempo][playhead][edge]") {
     ClipInfo clip;
-    clip.type = ClipType::Audio;
+    clip.setAudioContent();
     clip.audioFilePath = "sample.wav";
     clip.sourceBPM = 120.0;
     clip.sourceNumBeats = 4.0;
@@ -1088,7 +1088,7 @@ TEST_CASE("AutoTempo session clip timing: BPM edge cases",
 TEST_CASE("AutoTempo session clip: getAutoTempoBeatRange for session loop",
           "[session][auto-tempo][beat-range]") {
     ClipInfo clip;
-    clip.type = ClipType::Audio;
+    clip.setAudioContent();
     clip.audioFilePath = "loop.wav";
     clip.sourceBPM = 172.0;
     clip.sourceNumBeats = 8.0;


### PR DESCRIPTION
## Summary

This is the first stacked PR for the definitive ClipInfo model refactor.

It removes the mutable ClipInfo::type field and makes clip kind derive from a new ClipContent variant:

- adds AudioClipModel, MidiClipModel, and ClipContent
- adds ClipInfo::getType(), isAudio(), isMidi(), setAudioContent(), and setMidiContent()
- updates clip creation, serialization, UI, audio sync, commands, and tests to use the content-derived API instead of direct clip.type access

This PR intentionally does not move source BPM, source beat count, audio loop region, or MIDI loop data yet. Those are the next stacked PRs. The goal here is to remove the free-floating mutable clip type before moving content-specific state behind the variant.

## Validation

- make test-build
- ./cmake-build-debug/tests/magda_tests "[clip][command][duplicate]"
- ./cmake-build-debug/tests/magda_tests "[serialization]"
- ./cmake-build-debug/tests/magda_tests "[bpm][clip][issue-1157]"
- git diff --check

Known test runner noise: existing JUCE shutdown assertions/leak detector messages appear after some focused tests, but the selected Catch2 tests passed.