### PR TITLE
Move audio source data into AudioClipModel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,17 +125,6 @@ jobs:
           exit 1
         fi
 
-    - name: Run JUCE integration tests
-      run: |
-        JUCE_TEST_BIN=$(find build -name "magda_juce_tests" -type f | head -1)
-        if [ -n "$JUCE_TEST_BIN" ]; then
-          echo "Running JUCE integration tests..."
-          xvfb-run -a "$JUCE_TEST_BIN"
-        else
-          echo "❌ magda_juce_tests executable not found"
-          exit 1
-        fi
-
     - name: Show ccache statistics
       run: ccache -s
 
@@ -403,19 +392,6 @@ jobs:
           & $testExe.FullName --abort
         } else {
           Write-Error "Tests executable not found"
-          exit 1
-        }
-
-    - name: Run JUCE integration tests
-      timeout-minutes: 10
-      run: |
-        $juceExe = Get-ChildItem -Path build-debug -Recurse -Filter "magda_juce_tests.exe" | Select-Object -First 1
-        if ($juceExe) {
-          Write-Output "Running JUCE integration tests..."
-          & $juceExe.FullName
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-        } else {
-          Write-Error "magda_juce_tests executable not found"
           exit 1
         }
 

--- a/.github/workflows/juce-tests-linux.yml
+++ b/.github/workflows/juce-tests-linux.yml
@@ -1,0 +1,83 @@
+name: JUCE Tests (Linux)
+
+on:
+  push:
+    branches: [ '**' ]
+    tags-ignore: [ '**' ]
+    paths-ignore:
+      - 'lang/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  juce-tests-linux:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        lfs: true
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          build-essential \
+          cmake \
+          ninja-build \
+          pkg-config \
+          libgtk-3-dev \
+          libasound2-dev \
+          libjack-jackd2-dev \
+          ladspa-sdk \
+          libcurl4-openssl-dev \
+          libfreetype6-dev \
+          libx11-dev \
+          libxcomposite-dev \
+          libxcursor-dev \
+          libxext-dev \
+          libxinerama-dev \
+          libxrandr-dev \
+          libxrender-dev \
+          libwebkit2gtk-4.1-dev \
+          libglu1-mesa-dev \
+          mesa-common-dev \
+          xvfb
+
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ runner.os }}-juce-ccache-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-juce-ccache-
+          ${{ runner.os }}-ccache-
+
+    - name: Configure CMake
+      run: |
+        cmake -B build-juce -G Ninja \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+          -DMAGDA_BUILD_TESTS=ON \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+    - name: Build JUCE tests
+      run: cmake --build build-juce --target magda_juce_tests --config Debug -j$(nproc)
+
+    - name: Run JUCE tests
+      run: |
+        JUCE_TEST_BIN=$(find build-juce -name "magda_juce_tests" -type f | head -1)
+        if [ -z "$JUCE_TEST_BIN" ]; then
+          echo "magda_juce_tests executable not found"
+          exit 1
+        fi
+
+        xvfb-run -a "$JUCE_TEST_BIN"
+
+    - name: Show ccache statistics
+      run: ccache -s

--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -2240,7 +2240,7 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
     }
 
     // Get cached transients via the api
-    const auto* transients = api_.clips().getCachedTransients(clip->audioFilePath);
+    const auto* transients = api_.clips().getCachedTransients(clip->audio().source.filePath);
     if (!transients || transients->isEmpty()) {
         ctx_.setError("groove.extract: no transients detected for this clip. "
                       "Enable warp or detect transients first.");
@@ -2248,7 +2248,8 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
     }
 
     // Determine clip parameters
-    double clipBPM = clip->sourceBPM > 0.0 ? clip->sourceBPM : 120.0;
+    double clipBPM =
+        clip->audio().interpretation.bpm > 0.0 ? clip->audio().interpretation.bpm : 120.0;
     double beatDuration = 60.0 / clipBPM;  // seconds per beat
     double clipStartSec = clip->offset;    // source offset
 

--- a/magda/daw/audio/AudioThumbnailManager.cpp
+++ b/magda/daw/audio/AudioThumbnailManager.cpp
@@ -38,7 +38,6 @@ juce::AudioThumbnail* AudioThumbnailManager::createThumbnail(const juce::String&
     // Validate file exists
     juce::File audioFile(audioFilePath);
     if (!audioFile.existsAsFile()) {
-        DBG("AudioThumbnailManager: File not found: " << audioFilePath);
         return nullptr;
     }
 
@@ -53,7 +52,6 @@ juce::AudioThumbnail* AudioThumbnailManager::createThumbnail(const juce::String&
     // Load the audio file into the thumbnail
     auto* reader = formatManager_.createReaderFor(audioFile);
     if (reader == nullptr) {
-        DBG("AudioThumbnailManager: Could not create reader for: " << audioFilePath);
         return nullptr;
     }
 
@@ -64,10 +62,7 @@ juce::AudioThumbnail* AudioThumbnailManager::createThumbnail(const juce::String&
     // Store in cache
     auto* thumbnailPtr = thumbnail.get();
     thumbnails_[audioFilePath] = std::move(thumbnail);
-
-    DBG("AudioThumbnailManager: Created thumbnail for "
-        << audioFilePath << " (channels: " << thumbnailPtr->getNumChannels()
-        << ", length: " << thumbnailPtr->getTotalLength() << "s)");
+    juce::ignoreUnused(thumbnailPtr);
 
     // First time we've seen this file in this session — load (or compute and
     // persist) its high-resolution peak cache off the message thread. The
@@ -113,18 +108,10 @@ void AudioThumbnailManager::drawWaveform(juce::Graphics& g, const juce::Rectangl
             // ~8192 samples/pixel ≈ 186 ms/pixel at 44.1k — keeps the smooth
             // path active at most realistic arrangement-view zooms; only true
             // multi-minute overviews drop to the thumbnail.
-            // Log mode transitions per-file so the dev console reflects when
-            // zoom crosses the smooth/thumbnail boundary — without spamming
-            // every paint frame.
             static std::unordered_map<juce::String, bool> lastWasLowResByFile;
             bool& last = lastWasLowResByFile[audioFilePath];
             if (samplesPerPixel < 8192.0) {
-                if (last) {
-                    DBG("AudioThumbnailManager: smooth (samples) for "
-                        << audioFilePath << " — samplesPerPixel=" << samplesPerPixel
-                        << " (threshold 8192, " << bounds.getWidth() << "px wide)");
-                    last = false;
-                }
+                last = false;
                 const WaveformPeakCache* peakCache = nullptr;
                 auto pcIt = peakCaches_.find(audioFilePath);
                 if (pcIt != peakCaches_.end())
@@ -134,12 +121,7 @@ void AudioThumbnailManager::drawWaveform(juce::Graphics& g, const juce::Rectangl
                                         verticalZoom, thick);
                 return;
             }
-            if (!last) {
-                DBG("AudioThumbnailManager: low-res (thumbnail) for "
-                    << audioFilePath << " — samplesPerPixel=" << samplesPerPixel
-                    << " (threshold 8192, " << bounds.getWidth() << "px wide)");
-                last = true;
-            }
+            last = true;
         }
     }
 
@@ -195,7 +177,6 @@ double AudioThumbnailManager::detectBPM(const juce::String& filePath) {
 
     double result = runBpmDetection(filePath);
     bpmCache_[filePath] = result;
-    DBG("AudioThumbnailManager: Detected BPM for " << filePath << ": " << result);
     return result;
 }
 
@@ -238,7 +219,6 @@ void AudioThumbnailManager::requestBPMDetection(const juce::String& filePath,
 
     getOrCreateBackgroundPool().addJob([filePath]() {
         const double result = runBpmDetection(filePath);
-        DBG("AudioThumbnailManager: Detected BPM for " << filePath << ": " << result);
 
         juce::MessageManager::callAsync([filePath, result]() {
             auto& self = AudioThumbnailManager::getInstance();
@@ -518,7 +498,6 @@ void AudioThumbnailManager::clearCache() {
     readerLru_.clear();
     peakCaches_.clear();
     pendingPeakComputes_.clear();
-    DBG("AudioThumbnailManager: Cache cleared");
 }
 
 juce::ThreadPool& AudioThumbnailManager::getOrCreateBackgroundPool() {

--- a/magda/daw/audio/WarpMarkerManager.cpp
+++ b/magda/daw/audio/WarpMarkerManager.cpp
@@ -40,7 +40,7 @@ void WarpMarkerManager::setTransientSensitivity(
     te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId, ClipId clipId,
     float sensitivity) {
     const auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (!clip || !clip->isAudio() || clip->audioFilePath.isEmpty())
+    if (!clip || !clip->isAudio() || clip->audio().source.filePath.isEmpty())
         return;
 
     te::WaveAudioClip* audioClipPtr = findWaveAudioClip(edit, clipIdToEngineId, clipId);
@@ -53,10 +53,11 @@ void WarpMarkerManager::setTransientSensitivity(
 
     // Clear cache so the next poll picks up fresh results.
     // Keep clipId in detectionStarted_ since detectTransients() already started the job.
-    AudioThumbnailManager::getInstance().clearCachedTransients(clip->audioFilePath);
+    AudioThumbnailManager::getInstance().clearCachedTransients(clip->audio().source.filePath);
     detectionStarted_.insert(clipId);
 
-    DBG("WarpMarkerManager: set sensitivity=" << sensitivity << " for " << clip->audioFilePath);
+    DBG("WarpMarkerManager: set sensitivity=" << sensitivity << " for "
+                                              << clip->audio().source.filePath);
 }
 
 bool WarpMarkerManager::getTransientTimes(te::Edit& edit,
@@ -64,13 +65,13 @@ bool WarpMarkerManager::getTransientTimes(te::Edit& edit,
                                           ClipId clipId) {
     // Get clip info for file path
     const auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (!clip || !clip->isAudio() || clip->audioFilePath.isEmpty()) {
+    if (!clip || !clip->isAudio() || clip->audio().source.filePath.isEmpty()) {
         return false;
     }
 
     // Check cache first
     auto& thumbnailManager = AudioThumbnailManager::getInstance();
-    if (thumbnailManager.getCachedTransients(clip->audioFilePath) != nullptr) {
+    if (thumbnailManager.getCachedTransients(clip->audio().source.filePath) != nullptr) {
         return true;
     }
 
@@ -103,9 +104,9 @@ bool WarpMarkerManager::getTransientTimes(te::Edit& edit,
             times.add(tp.inSeconds());
         }
 
-        thumbnailManager.cacheTransients(clip->audioFilePath, times);
+        thumbnailManager.cacheTransients(clip->audio().source.filePath, times);
         DBG("WarpMarkerManager: Cached " << times.size() << " transients for "
-                                         << clip->audioFilePath);
+                                         << clip->audio().source.filePath);
         return true;
     }
 
@@ -134,10 +135,10 @@ void WarpMarkerManager::enableWarp(te::Edit& edit,
 
     // Get cached transients from AudioThumbnailManager
     auto* cachedTransients =
-        AudioThumbnailManager::getInstance().getCachedTransients(clip->audioFilePath);
+        AudioThumbnailManager::getInstance().getCachedTransients(clip->audio().source.filePath);
     DBG("WarpMarkerManager::enableWarp cachedTransients="
         << (cachedTransients ? juce::String(cachedTransients->size()) : "null")
-        << " file=" << clip->audioFilePath << " offset=" << clipOffset);
+        << " file=" << clip->audio().source.filePath << " offset=" << clipOffset);
     if (cachedTransients) {
         // Insert identity-mapped markers at each transient position within the visible range
         double visibleEnd = clipOffset + clip->length * clip->speedRatio;

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -450,13 +450,13 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
     // TE's free functions insertWaveClip(ClipOwner&, ...) and insertMIDIClip(ClipOwner&, ...)
     // accept ClipSlot as a ClipOwner, creating the clip's ValueTree directly in the slot.
     if (clip->isAudio()) {
-        if (clip->audioFilePath.isEmpty())
+        if (clip->audio().source.filePath.isEmpty())
             return false;
 
-        juce::File audioFile(clip->audioFilePath);
+        juce::File audioFile(clip->audio().source.filePath);
         if (!audioFile.existsAsFile()) {
             DBG("ClipSynchronizer::syncSessionClipToSlot: Audio file not found: "
-                << clip->audioFilePath);
+                << clip->audio().source.filePath);
             return false;
         }
 
@@ -473,20 +473,17 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
 
         auto* audioClipPtr = clipRef.get();
 
-        // Populate source file metadata from TE's loopInfo. Issue #1157:
-        // when this is the first time metadata lands on an autoTempo clip,
-        // setSourceMetadata also snaps lengthBeats/loopLengthBeats to the
-        // file's natural beat count (instead of the project-tempo guess seeded
-        // by createAudioClip Session). Refresh the seconds cache from the new
-        // beat values so renderers reading clip->length see the right number.
+        // Populate source file metadata from TE's loopInfo. This is source-domain data only;
+        // clip placement and source loop region are never changed by metadata arrival.
         {
             auto& loopInfoRef = audioClipPtr->getLoopInfo();
             auto waveInfo = audioClipPtr->getWaveInfo();
             if (auto* mutableClip = cm.getClip(clipId)) {
-                bool sourceBpmWasUnset = mutableClip->sourceBPM <= 0.0;
+                bool sourceInterpretationBpmWasUnset =
+                    mutableClip->audio().interpretation.bpm <= 0.0;
                 mutableClip->setSourceMetadata(loopInfoRef.getNumBeats(),
                                                loopInfoRef.getBpm(waveInfo));
-                if (sourceBpmWasUnset && mutableClip->autoTempo) {
+                if (sourceInterpretationBpmWasUnset && mutableClip->autoTempo) {
                     double projectBpm = edit_.tempoSequence.getBpmAt(te::TimePosition());
                     cm.refreshDerivedSeconds(clipId, projectBpm);
                     cm.forceNotifyClipPropertyChanged(clipId);
@@ -919,11 +916,11 @@ te::Clip* ClipSynchronizer::getSessionTeClip(ClipId clipId) {
 
 void ClipSynchronizer::configureSessionAutoTempo(te::WaveAudioClip* audioClip,
                                                  const ClipInfo* clip) {
-    // Sync sourceBPM to TE's loopInfo
-    if (clip->sourceBPM > 0.0) {
+    // Sync source interpretation BPM to TE's loopInfo
+    if (clip->audio().interpretation.bpm > 0.0) {
         auto waveInfo = audioClip->getWaveInfo();
         auto& li = audioClip->getLoopInfo();
-        li.setBpm(clip->sourceBPM, waveInfo);
+        li.setBpm(clip->audio().interpretation.bpm, waveInfo);
     }
 
     // Ensure valid stretch mode (autoTempo requires time-stretching)
@@ -1380,13 +1377,13 @@ void ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
 
     // 3. CREATE new clip if doesn't exist
     if (!audioClipPtr) {
-        if (clip->audioFilePath.isEmpty()) {
+        if (clip->audio().source.filePath.isEmpty()) {
             DBG("ClipSynchronizer: No audio file for clip " << clipId);
             return;
         }
-        juce::File audioFile(clip->audioFilePath);
+        juce::File audioFile(clip->audio().source.filePath);
         if (!audioFile.existsAsFile()) {
-            DBG("ClipSynchronizer: Audio file not found: " << clip->audioFilePath);
+            DBG("ClipSynchronizer: Audio file not found: " << clip->audio().source.filePath);
             return;
         }
 
@@ -1424,18 +1421,18 @@ void ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
         }
         audioClipPtr->setUsesProxy(false);
 
-        // Populate source file metadata from TE's loopInfo. Issue #1157: see
-        // matching block in the session-clip path above — when metadata first
-        // lands on an autoTempo clip, refresh seconds + notify.
+        // Populate source file metadata from TE's loopInfo. See the matching
+        // session-clip path above.
         {
             auto& loopInfoRef = audioClipPtr->getLoopInfo();
             auto waveInfo = audioClipPtr->getWaveInfo();
             auto& cm = ClipManager::getInstance();
             if (auto* mutableClip = cm.getClip(clipId)) {
-                bool sourceBpmWasUnset = mutableClip->sourceBPM <= 0.0;
+                bool sourceInterpretationBpmWasUnset =
+                    mutableClip->audio().interpretation.bpm <= 0.0;
                 mutableClip->setSourceMetadata(loopInfoRef.getNumBeats(),
                                                loopInfoRef.getBpm(waveInfo));
-                if (sourceBpmWasUnset && mutableClip->autoTempo) {
+                if (sourceInterpretationBpmWasUnset && mutableClip->autoTempo) {
                     double projectBpm = edit_.tempoSequence.getBpmAt(te::TimePosition());
                     cm.refreshDerivedSeconds(clipId, projectBpm);
                     cm.forceNotifyClipPropertyChanged(clipId);
@@ -1611,16 +1608,16 @@ void ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
             // Get tempo for beat calculations
             double bpm = edit_.tempoSequence.getTempo(0)->getBpm();
 
-            // Override TE's loopInfo BPM to match our calibrated sourceBPM.
-            // setAutoTempo calibrates sourceBPM = projectBPM / speedRatio so that
+            // Override TE's loopInfo BPM to match our calibrated source interpretation BPM.
+            // setAutoTempo calibrates source interpretation BPM = projectBPM / speedRatio so that
             // enabling autoTempo doesn't change playback speed.  TE uses loopInfo
             // to map source beats ↔ source time, so the two must agree.
-            if (clip->sourceBPM > 0.0) {
+            if (clip->audio().interpretation.bpm > 0.0) {
                 auto waveInfo = audioClipPtr->getWaveInfo();
                 auto& li = audioClipPtr->getLoopInfo();
                 double currentLoopInfoBpm = li.getBpm(waveInfo);
-                if (std::abs(currentLoopInfoBpm - clip->sourceBPM) > 0.1) {
-                    li.setBpm(clip->sourceBPM, waveInfo);
+                if (std::abs(currentLoopInfoBpm - clip->audio().interpretation.bpm) > 0.1) {
+                    li.setBpm(clip->audio().interpretation.bpm, waveInfo);
                 }
             }
 

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -1339,6 +1339,13 @@ void ClipSynchronizer::syncMidiClipToEngine(ClipId clipId, const ClipInfo* clip)
 void ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip) {
     namespace te = tracktion;
 
+    DBG("[ClipLengthTrace] syncAudioClipToEngine:entry id="
+        << clipId << " placement.lengthBeats=" << clip->placement.lengthBeats
+        << " mirror.lengthBeats=" << clip->lengthBeats << " timeline.lengthSeconds=" << clip->length
+        << " loopLengthBeats=" << clip->loopLengthBeats << " loopLengthSeconds=" << clip->loopLength
+        << " interpretation.bpm=" << clip->audio().interpretation.bpm
+        << " interpretation.totalBeats=" << clip->audio().interpretation.totalBeats);
+
     // 1. Get Tracktion track
     auto* audioTrack = trackController_.getAudioTrack(clip->trackId);
     if (!audioTrack) {
@@ -1504,6 +1511,10 @@ void ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
         std::abs(currentStart - engineStart) > 0.001 || std::abs(currentEnd - engineEnd) > 0.001;
 
     if (needsPositionUpdate) {
+        DBG("[ClipLengthTrace] syncAudioClipToEngine:setPosition id="
+            << clipId << " engineStart=" << engineStart << " engineEnd=" << engineEnd
+            << " placement.lengthBeats=" << clip->placement.lengthBeats
+            << " interpretation.totalBeats=" << clip->audio().interpretation.totalBeats);
         auto newTimeRange = te::TimeRange(te::TimePosition::fromSeconds(engineStart),
                                           te::TimePosition::fromSeconds(engineEnd));
         audioClipPtr->setPosition(te::ClipPosition{newTimeRange, currentPos.getOffset()});
@@ -1616,14 +1627,29 @@ void ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
                 auto waveInfo = audioClipPtr->getWaveInfo();
                 auto& li = audioClipPtr->getLoopInfo();
                 double currentLoopInfoBpm = li.getBpm(waveInfo);
+                DBG("[ClipLengthTrace] syncAudioClipToEngine:loopInfoBefore id="
+                    << clipId << " teLoopInfo.bpm=" << currentLoopInfoBpm
+                    << " teLoopInfo.numBeats=" << li.getNumBeats() << " model.interpretation.bpm="
+                    << clip->audio().interpretation.bpm << " model.interpretation.totalBeats="
+                    << clip->audio().interpretation.totalBeats);
                 if (std::abs(currentLoopInfoBpm - clip->audio().interpretation.bpm) > 0.1) {
                     li.setBpm(clip->audio().interpretation.bpm, waveInfo);
                 }
+                DBG("[ClipLengthTrace] syncAudioClipToEngine:loopInfoAfter id="
+                    << clipId << " teLoopInfo.bpm=" << li.getBpm(waveInfo)
+                    << " teLoopInfo.numBeats=" << li.getNumBeats()
+                    << " model.interpretation.totalBeats="
+                    << clip->audio().interpretation.totalBeats);
             }
 
             auto [loopStartBeats, loopLengthBeats] =
                 ClipOperations::getAutoTempoBeatRange(*clip, bpm);
 
+            DBG("[ClipLengthTrace] syncAudioClipToEngine:setLoopRangeBeats id="
+                << clipId << " loopStartBeats=" << loopStartBeats << " loopLengthBeats="
+                << loopLengthBeats << " placement.lengthBeats=" << clip->placement.lengthBeats
+                << " model.loopLengthBeats=" << clip->loopLengthBeats
+                << " model.interpretation.totalBeats=" << clip->audio().interpretation.totalBeats);
             auto loopRange = te::BeatRange(te::BeatPosition::fromBeats(loopStartBeats),
                                            te::BeatDuration::fromBeats(loopLengthBeats));
             audioClipPtr->setLoopRangeBeats(loopRange);

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -46,6 +46,22 @@ static te::LaunchQType toTELaunchQType(LaunchQuantize q) {
     return te::LaunchQType::none;
 }
 
+static void syncAudioSourceInterpretationToLoopInfo(te::WaveAudioClip& audioClip,
+                                                    const ClipInfo& clip) {
+    auto waveInfo = audioClip.getWaveInfo();
+    auto& li = audioClip.getLoopInfo();
+
+    if (clip.audio().interpretation.bpm > 0.0 &&
+        std::abs(li.getBpm(waveInfo) - clip.audio().interpretation.bpm) > 0.1) {
+        li.setBpm(clip.audio().interpretation.bpm, waveInfo);
+    }
+
+    if (clip.audio().interpretation.totalBeats > 0.0 &&
+        std::abs(li.getNumBeats() - clip.audio().interpretation.totalBeats) > 0.001) {
+        li.setNumBeats(clip.audio().interpretation.totalBeats);
+    }
+}
+
 ClipSynchronizer::ClipSynchronizer(te::Edit& edit, TrackController& trackController,
                                    WarpMarkerManager& warpMarkerManager)
     : edit_(edit), trackController_(trackController), warpMarkerManager_(warpMarkerManager) {
@@ -916,12 +932,9 @@ te::Clip* ClipSynchronizer::getSessionTeClip(ClipId clipId) {
 
 void ClipSynchronizer::configureSessionAutoTempo(te::WaveAudioClip* audioClip,
                                                  const ClipInfo* clip) {
-    // Sync source interpretation BPM to TE's loopInfo
-    if (clip->audio().interpretation.bpm > 0.0) {
-        auto waveInfo = audioClip->getWaveInfo();
-        auto& li = audioClip->getLoopInfo();
-        li.setBpm(clip->audio().interpretation.bpm, waveInfo);
-    }
+    // Sync source interpretation to TE's loopInfo. AutoTempo playback uses both BPM and
+    // source beat count to map source time to timeline beats.
+    syncAudioSourceInterpretationToLoopInfo(*audioClip, *clip);
 
     // Ensure valid stretch mode (autoTempo requires time-stretching)
     if (audioClip->getTimeStretchMode() == te::TimeStretcher::disabled)
@@ -1619,11 +1632,12 @@ void ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
             // Get tempo for beat calculations
             double bpm = edit_.tempoSequence.getTempo(0)->getBpm();
 
-            // Override TE's loopInfo BPM to match our calibrated source interpretation BPM.
+            // Override TE's loopInfo to match our calibrated source interpretation.
             // setAutoTempo calibrates source interpretation BPM = projectBPM / speedRatio so that
-            // enabling autoTempo doesn't change playback speed.  TE uses loopInfo
-            // to map source beats ↔ source time, so the two must agree.
-            if (clip->audio().interpretation.bpm > 0.0) {
+            // enabling autoTempo doesn't change playback speed. TE uses loopInfo to map source
+            // beats to source time, so BPM and source beat count must both agree.
+            if (clip->audio().interpretation.bpm > 0.0 ||
+                clip->audio().interpretation.totalBeats > 0.0) {
                 auto waveInfo = audioClipPtr->getWaveInfo();
                 auto& li = audioClipPtr->getLoopInfo();
                 double currentLoopInfoBpm = li.getBpm(waveInfo);
@@ -1632,9 +1646,7 @@ void ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
                     << " teLoopInfo.numBeats=" << li.getNumBeats() << " model.interpretation.bpm="
                     << clip->audio().interpretation.bpm << " model.interpretation.totalBeats="
                     << clip->audio().interpretation.totalBeats);
-                if (std::abs(currentLoopInfoBpm - clip->audio().interpretation.bpm) > 0.1) {
-                    li.setBpm(clip->audio().interpretation.bpm, waveInfo);
-                }
+                syncAudioSourceInterpretationToLoopInfo(*audioClipPtr, *clip);
                 DBG("[ClipLengthTrace] syncAudioClipToEngine:loopInfoAfter id="
                     << clipId << " teLoopInfo.bpm=" << li.getBpm(waveInfo)
                     << " teLoopInfo.numBeats=" << li.getNumBeats()

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -62,6 +62,27 @@ static void syncAudioSourceInterpretationToLoopInfo(te::WaveAudioClip& audioClip
     }
 }
 
+static void initialiseSourceLoopBeatsFromMetadata(ClipInfo& clip) {
+    if (!clip.isAudio() || !clip.autoTempo || clip.loopLengthBeats > 0.0)
+        return;
+
+    const double sourceBpm = clip.audio().interpretation.bpm;
+    if (sourceBpm <= 0.0)
+        return;
+
+    const double sourceTotalBeats = clip.audio().interpretation.totalBeats;
+    clip.loopStartBeats = juce::jmax(0.0, clip.loopStart * sourceBpm / 60.0);
+
+    double loopBeats =
+        clip.loopLength > 0.0 ? clip.loopLength * sourceBpm / 60.0 : sourceTotalBeats;
+    if (sourceTotalBeats > 0.0) {
+        clip.loopStartBeats = juce::jmin(clip.loopStartBeats, sourceTotalBeats);
+        loopBeats = juce::jmin(loopBeats, sourceTotalBeats - clip.loopStartBeats);
+    }
+
+    clip.loopLengthBeats = juce::jmax(0.0, loopBeats);
+}
+
 ClipSynchronizer::ClipSynchronizer(te::Edit& edit, TrackController& trackController,
                                    WarpMarkerManager& warpMarkerManager)
     : edit_(edit), trackController_(trackController), warpMarkerManager_(warpMarkerManager) {
@@ -489,8 +510,10 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
 
         auto* audioClipPtr = clipRef.get();
 
-        // Populate source file metadata from TE's loopInfo. This is source-domain data only;
-        // clip placement and source loop region are never changed by metadata arrival.
+        // Populate source file metadata from TE's loopInfo. For a freshly
+        // imported session clip, loopLengthBeats starts as a sentinel and is
+        // initialised from the already-stored source loop seconds once the
+        // source beat domain is known.
         {
             auto& loopInfoRef = audioClipPtr->getLoopInfo();
             auto waveInfo = audioClipPtr->getWaveInfo();
@@ -499,6 +522,7 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
                     mutableClip->audio().interpretation.bpm <= 0.0;
                 mutableClip->setSourceMetadata(loopInfoRef.getNumBeats(),
                                                loopInfoRef.getBpm(waveInfo));
+                initialiseSourceLoopBeatsFromMetadata(*mutableClip);
                 if (sourceInterpretationBpmWasUnset && mutableClip->autoTempo) {
                     double projectBpm = edit_.tempoSequence.getBpmAt(te::TimePosition());
                     cm.refreshDerivedSeconds(clipId, projectBpm);
@@ -1452,6 +1476,7 @@ void ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
                     mutableClip->audio().interpretation.bpm <= 0.0;
                 mutableClip->setSourceMetadata(loopInfoRef.getNumBeats(),
                                                loopInfoRef.getBpm(waveInfo));
+                initialiseSourceLoopBeatsFromMetadata(*mutableClip);
                 if (sourceInterpretationBpmWasUnset && mutableClip->autoTempo) {
                     double projectBpm = edit_.tempoSequence.getBpmAt(te::TimePosition());
                     cm.refreshDerivedSeconds(clipId, projectBpm);

--- a/magda/daw/audio/session/ClipSynchronizer.hpp
+++ b/magda/daw/audio/session/ClipSynchronizer.hpp
@@ -302,7 +302,7 @@ class ClipSynchronizer : public ClipManagerListener, public TrackManagerListener
      * @param clip The ClipInfo model data
      *
      * Shared by syncSessionClipToSlot() and clipPropertyChanged().
-     * Syncs sourceBPM, stretch mode, speedRatio, autoTempo flag,
+     * Syncs source interpretation BPM, stretch mode, speedRatio, autoTempo flag,
      * offset, and beat-based loop range.
      */
     void configureSessionAutoTempo(te::WaveAudioClip* audioClip, const ClipInfo* clip);

--- a/magda/daw/audio/session/SessionRecorder.cpp
+++ b/magda/daw/audio/session/SessionRecorder.cpp
@@ -204,10 +204,10 @@ void SessionRecorder::finalizeRecording(const ActiveRecording& rec, double stopT
     ClipId newClipId = INVALID_CLIP_ID;
 
     if (sessionClip->isAudio()) {
-        if (sessionClip->audioFilePath.isNotEmpty()) {
-            newClipId =
-                clipManager.createAudioClip(rec.trackId, rec.arrangementStartTime, duration,
-                                            sessionClip->audioFilePath, ClipView::Arrangement);
+        if (sessionClip->audio().source.filePath.isNotEmpty()) {
+            newClipId = clipManager.createAudioClip(rec.trackId, rec.arrangementStartTime, duration,
+                                                    sessionClip->audio().source.filePath,
+                                                    ClipView::Arrangement);
         }
     } else {
         newClipId = clipManager.createMidiClip(rec.trackId, rec.arrangementStartTime, duration,
@@ -233,8 +233,8 @@ void SessionRecorder::finalizeRecording(const ActiveRecording& rec, double stopT
 
         // Copy beat-mode / auto-tempo properties so the arrangement clip
         // stays in the same time-stretch mode as the session clip.
-        newClip->sourceBPM = sessionClip->sourceBPM;
-        newClip->sourceNumBeats = sessionClip->sourceNumBeats;
+        newClip->audio().interpretation.bpm = sessionClip->audio().interpretation.bpm;
+        newClip->audio().interpretation.totalBeats = sessionClip->audio().interpretation.totalBeats;
         newClip->timeStretchMode = sessionClip->timeStretchMode;
         newClip->loopStartBeats = sessionClip->loopStartBeats;
         newClip->loopLengthBeats = sessionClip->loopLengthBeats;

--- a/magda/daw/core/ClipCommands.cpp
+++ b/magda/daw/core/ClipCommands.cpp
@@ -333,10 +333,24 @@ ResizeClipCommand::ResizeClipCommand(ClipId clipId, double newLength, bool fromS
 
 ClipInfo ResizeClipCommand::captureState() {
     auto* clip = ClipManager::getInstance().getClip(clipId_);
+    if (clip && clip->isAudio()) {
+        DBG("[ClipLengthTrace] ResizeClipCommand::captureState id="
+            << clipId_ << " placement.lengthBeats=" << clip->placement.lengthBeats
+            << " mirror.lengthBeats=" << clip->lengthBeats << " loopLengthBeats="
+            << clip->loopLengthBeats << " interpretation.bpm=" << clip->audio().interpretation.bpm
+            << " interpretation.totalBeats=" << clip->audio().interpretation.totalBeats);
+    }
     return clip ? *clip : ClipInfo{};
 }
 
 void ResizeClipCommand::restoreState(const ClipInfo& state) {
+    if (state.isAudio()) {
+        DBG("[ClipLengthTrace] ResizeClipCommand::restoreState id="
+            << clipId_ << " placement.lengthBeats=" << state.placement.lengthBeats
+            << " mirror.lengthBeats=" << state.lengthBeats << " loopLengthBeats="
+            << state.loopLengthBeats << " interpretation.bpm=" << state.audio().interpretation.bpm
+            << " interpretation.totalBeats=" << state.audio().interpretation.totalBeats);
+    }
     auto& clipManager = ClipManager::getInstance();
     if (auto* clip = clipManager.getClip(clipId_)) {
         *clip = state;

--- a/magda/daw/core/ClipCommands.cpp
+++ b/magda/daw/core/ClipCommands.cpp
@@ -851,7 +851,7 @@ void RenderClipCommand::execute() {
     }
 
     // Determine output file path — always use the project's renders directory
-    juce::File sourceFile(clip->audioFilePath);
+    juce::File sourceFile(clip->audio().source.filePath);
     auto rendersDir = ProjectManager::getInstance().getRendersDirectory();
     if (rendersDir == juce::File())
         rendersDir = sourceFile.getParentDirectory().getChildFile("renders");
@@ -1072,7 +1072,7 @@ void RenderTimeSelectionCommand::execute() {
 
         // Determine output file path from first overlapping clip's source
         auto* firstClip = clipManager.getClip(overlappingIds[0]);
-        juce::File sourceFile(firstClip->audioFilePath);
+        juce::File sourceFile(firstClip->audio().source.filePath);
         auto rendersDir = ProjectManager::getInstance().getRendersDirectory();
         if (rendersDir == juce::File())
             rendersDir = sourceFile.getParentDirectory().getChildFile("renders");
@@ -1984,7 +1984,7 @@ void sliceClipAtWarpMarkers(ClipId clipId, double tempo, AudioBridge* bridge) {
         return;  // Only boundary markers
 
     // Disable warp before splitting — splitClip uses a linear formula
-    // (tempo/sourceBPM or speedRatio) to compute source offsets, but warp
+    // (tempo/source interpretation BPM or speedRatio) to compute source offsets, but warp
     // markers define a non-linear mapping.  With warp off the linear formula
     // is correct, so we convert marker sourceTime values to the linear
     // timeline domain.
@@ -2004,8 +2004,8 @@ void sliceClipAtWarpMarkers(ClipId clipId, double tempo, AudioBridge* bridge) {
     for (size_t i = 1; i + 1 < markers.size(); ++i) {
         double sourceDelta = markers[i].sourceTime - clipOffset;
         double splitTime;
-        if (clip->autoTempo && clip->sourceBPM > 0.0 && tempo > 0.0) {
-            splitTime = clipStart + sourceDelta * clip->sourceBPM / tempo;
+        if (clip->autoTempo && clip->audio().interpretation.bpm > 0.0 && tempo > 0.0) {
+            splitTime = clipStart + sourceDelta * clip->audio().interpretation.bpm / tempo;
         } else {
             splitTime = clipStart + sourceDelta / clip->speedRatio;
         }
@@ -2179,14 +2179,14 @@ void sliceWarpMarkersToDrumGrid(ClipId clipId, double tempo, AudioBridge* bridge
         return;
 
     auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (!clip || !clip->isAudio() || clip->audioFilePath.isEmpty())
+    if (!clip || !clip->isAudio() || clip->audio().source.filePath.isEmpty())
         return;
 
     auto markers = bridge->getWarpMarkers(clipId);
     if (markers.size() <= 2)
         return;
 
-    juce::File audioFile(clip->audioFilePath);
+    juce::File audioFile(clip->audio().source.filePath);
     if (!audioFile.existsAsFile())
         return;
 
@@ -2216,8 +2216,8 @@ void sliceWarpMarkersToDrumGrid(ClipId clipId, double tempo, AudioBridge* bridge
 
     auto sourceToTimeline = [&](double sourceTime) -> double {
         double sourceDelta = sourceTime - clipOffset;
-        if (clip->autoTempo && clip->sourceBPM > 0.0 && tempo > 0.0)
-            return clipStart + sourceDelta * clip->sourceBPM / tempo;
+        if (clip->autoTempo && clip->audio().interpretation.bpm > 0.0 && tempo > 0.0)
+            return clipStart + sourceDelta * clip->audio().interpretation.bpm / tempo;
         else
             return clipStart + sourceDelta / clip->speedRatio;
     };
@@ -2241,10 +2241,10 @@ void sliceAtGridToDrumGrid(ClipId clipId, double gridInterval, double tempo, Aud
         return;
 
     auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (!clip || !clip->isAudio() || clip->audioFilePath.isEmpty())
+    if (!clip || !clip->isAudio() || clip->audio().source.filePath.isEmpty())
         return;
 
-    juce::File audioFile(clip->audioFilePath);
+    juce::File audioFile(clip->audio().source.filePath);
     if (!audioFile.existsAsFile())
         return;
 
@@ -2255,8 +2255,8 @@ void sliceAtGridToDrumGrid(ClipId clipId, double gridInterval, double tempo, Aud
     // Convert timeline grid lines to source-file boundaries
     auto timelineToSource = [&](double timelinePos) -> double {
         double delta = timelinePos - clipStart;
-        if (clip->autoTempo && clip->sourceBPM > 0.0 && tempo > 0.0)
-            return clipOffset + delta * tempo / clip->sourceBPM;
+        if (clip->autoTempo && clip->audio().interpretation.bpm > 0.0 && tempo > 0.0)
+            return clipOffset + delta * tempo / clip->audio().interpretation.bpm;
         else
             return clipOffset + delta * clip->speedRatio;
     };

--- a/magda/daw/core/ClipDisplayInfo.hpp
+++ b/magda/daw/core/ClipDisplayInfo.hpp
@@ -98,6 +98,22 @@ struct ClipDisplayInfo {
         return loopEnabled && sourceLength > 0.0;
     }
 
+    double sessionPlayheadToDisplayPosition(double sessionPlayheadSeconds) const {
+        if (sessionPlayheadSeconds < 0.0)
+            return -1.0;
+
+        if (isLooped() && loopLengthSeconds > 0.0) {
+            const double phaseDisplay = loopPhasePositionSeconds - loopStartPositionSeconds;
+            double wrappedDisplay =
+                std::fmod(phaseDisplay + sessionPlayheadSeconds, loopLengthSeconds);
+            if (wrappedDisplay < 0.0)
+                wrappedDisplay += loopLengthSeconds;
+            return loopStartPositionSeconds + wrappedDisplay;
+        }
+
+        return offsetPositionSeconds + sessionPlayheadSeconds;
+    }
+
     // Convert a timeline position (relative to display anchor = file start) to absolute source file
     // time
     double displayPositionToSourceTime(double timelinePos) const {

--- a/magda/daw/core/ClipDisplayInfo.hpp
+++ b/magda/daw/core/ClipDisplayInfo.hpp
@@ -130,7 +130,7 @@ struct ClipDisplayInfo {
 
         // Auto-tempo display info (using centralized ClipInfo methods)
         d.autoTempo = clip.autoTempo;
-        d.lengthBeats = clip.lengthBeats;
+        d.lengthBeats = clip.placement.lengthBeats;
         d.loopLengthBeats = clip.loopLengthBeats;
         d.startBeats = clip.getStartBeats(bpm);
         d.endBeats = clip.getEndBeats(bpm);
@@ -162,16 +162,16 @@ struct ClipDisplayInfo {
         //
         // AutoTempo invariant: TE stretches the source so 1 source beat == 1
         // timeline beat. Therefore
-        //     timelineSeconds = sourceSeconds × (sourceBPM / projectBPM)
+        //     timelineSeconds = sourceSeconds × (source interpretation BPM / projectBPM)
         // The earlier branch I added used the inverted ratio (projectBPM /
-        // sourceBPM), which is what made the green loop bracket span ~9
+        // source interpretation BPM), which is what made the green loop bracket span ~9
         // bars in the user's screenshot when lengthBeats said 4 bars.
         // Issue #1157.
         //
         // For manual stretch: timelineSeconds = sourceSeconds / speedRatio.
         auto srcToTimeline = [&](double sourceDelta) -> double {
-            if (clip.autoTempo && clip.sourceBPM > 0.0 && bpm > 0.0) {
-                return sourceDelta * clip.sourceBPM / bpm;
+            if (clip.autoTempo && clip.audio().interpretation.bpm > 0.0 && bpm > 0.0) {
+                return sourceDelta * clip.audio().interpretation.bpm / bpm;
             }
             if (clip.autoTempo && clipLoopLength > 0.0 && clip.loopLengthBeats > 0.0 && bpm > 0.0) {
                 return sourceDelta * (clip.loopLengthBeats * 60.0 / bpm) / clipLoopLength;

--- a/magda/daw/core/ClipInfo.hpp
+++ b/magda/daw/core/ClipInfo.hpp
@@ -99,6 +99,7 @@ struct AudioSourceFacts {
 struct AudioSourceInterpretation {
     double bpm = 0.0;
     double totalBeats = 0.0;
+    bool totalBeatsLocked = false;
 };
 
 struct AudioClipModel {

--- a/magda/daw/core/ClipInfo.hpp
+++ b/magda/daw/core/ClipInfo.hpp
@@ -175,6 +175,12 @@ struct ClipInfo {
     /// source loop region state.
     void setSourceMetadata(double numBeats, double bpm) {
         auto& source = audio();
+        DBG("[ClipLengthTrace] setSourceMetadata:before id="
+            << id << " incoming.numBeats=" << numBeats << " incoming.bpm=" << bpm
+            << " placement.lengthBeats=" << placement.lengthBeats
+            << " mirror.lengthBeats=" << lengthBeats << " loopLengthBeats=" << loopLengthBeats
+            << " interpretation.bpm=" << source.interpretation.bpm
+            << " interpretation.totalBeats=" << source.interpretation.totalBeats);
         if (numBeats > 0.0 && source.interpretation.totalBeats <= 0.0)
             source.interpretation.totalBeats = numBeats;
         if (bpm > 0.0 && source.interpretation.bpm <= 0.0)
@@ -184,6 +190,12 @@ struct ClipInfo {
             source.source.durationSeconds =
                 source.interpretation.totalBeats * 60.0 / source.interpretation.bpm;
         }
+        DBG("[ClipLengthTrace] setSourceMetadata:after id="
+            << id << " placement.lengthBeats=" << placement.lengthBeats
+            << " mirror.lengthBeats=" << lengthBeats << " loopLengthBeats=" << loopLengthBeats
+            << " source.durationSeconds=" << source.source.durationSeconds
+            << " interpretation.bpm=" << source.interpretation.bpm
+            << " interpretation.totalBeats=" << source.interpretation.totalBeats);
     }
 
     // =========================================================================

--- a/magda/daw/core/ClipInfo.hpp
+++ b/magda/daw/core/ClipInfo.hpp
@@ -91,7 +91,20 @@ struct ClipPlacement {
     }
 };
 
-struct AudioClipModel {};
+struct AudioSourceFacts {
+    juce::String filePath;
+    double durationSeconds = 0.0;
+};
+
+struct AudioSourceInterpretation {
+    double bpm = 0.0;
+    double totalBeats = 0.0;
+};
+
+struct AudioClipModel {
+    AudioSourceFacts source;
+    AudioSourceInterpretation interpretation;
+};
 
 struct MidiClipModel {};
 
@@ -123,6 +136,22 @@ struct ClipInfo {
         return std::holds_alternative<MidiClipModel>(content);
     }
 
+    AudioClipModel& audio() {
+        return std::get<AudioClipModel>(content);
+    }
+
+    const AudioClipModel& audio() const {
+        return std::get<AudioClipModel>(content);
+    }
+
+    MidiClipModel& midi() {
+        return std::get<MidiClipModel>(content);
+    }
+
+    const MidiClipModel& midi() const {
+        return std::get<MidiClipModel>(content);
+    }
+
     void setAudioContent() {
         content = AudioClipModel{};
     }
@@ -141,29 +170,19 @@ struct ClipInfo {
     // removes direct field access.
     double startBeats = 0.0;
 
-    // Audio-specific properties (flat model: one clip = one file reference)
-    juce::String audioFilePath;   // Path to audio file
-    double sourceNumBeats = 0.0;  // Beat count from source file metadata (TE loopInfo)
-    double sourceBPM = 0.0;       // Source file BPM (from TE loopInfo, 0 = unknown)
-
     /// Populate source metadata from engine (only sets if not already populated).
-    ///
-    /// Issue #1157: when the file's tempo metadata first lands on an autoTempo
-    /// clip, also snap the beat-domain canonicals to the file's natural beat
-    /// count. createAudioClip(Session) seeded lengthBeats from project tempo
-    /// as a best-guess (no metadata yet); metadata wins. After this call, the
-    /// caller should refreshDerivedSeconds and notify so renderers re-read.
+    /// This is source-domain data only; it must never edit clip placement or
+    /// source loop region state.
     void setSourceMetadata(double numBeats, double bpm) {
-        bool wasUnset = sourceNumBeats <= 0.0 && sourceBPM <= 0.0;
-        if (numBeats > 0.0 && sourceNumBeats <= 0.0)
-            sourceNumBeats = numBeats;
-        if (bpm > 0.0 && sourceBPM <= 0.0)
-            sourceBPM = bpm;
-
-        if (wasUnset && autoTempo && sourceNumBeats > 0.0) {
-            lengthBeats = sourceNumBeats;
-            if (loopLengthBeats <= 0.0)
-                loopLengthBeats = sourceNumBeats;
+        auto& source = audio();
+        if (numBeats > 0.0 && source.interpretation.totalBeats <= 0.0)
+            source.interpretation.totalBeats = numBeats;
+        if (bpm > 0.0 && source.interpretation.bpm <= 0.0)
+            source.interpretation.bpm = bpm;
+        if (source.source.durationSeconds <= 0.0 && source.interpretation.totalBeats > 0.0 &&
+            source.interpretation.bpm > 0.0) {
+            source.source.durationSeconds =
+                source.interpretation.totalBeats * 60.0 / source.interpretation.bpm;
         }
     }
 
@@ -176,7 +195,8 @@ struct ClipInfo {
     double offset = 0.0;  // Start position in source file (source-time seconds)
 
     // Beat-based offset (authoritative for autoTempo clips)
-    // Source beats from file start. offset (seconds) is derived: offsetBeats * 60/sourceBPM
+    // Source beats from file start. offset (seconds) is derived: offsetBeats * 60/source
+    // interpretation BPM
     double offsetBeats = 0.0;
 
     // Looping - defines the region that loops
@@ -469,7 +489,7 @@ struct ClipInfo {
     //
     // For autoTempo audio clips and MIDI clips, beats are AUTHORITATIVE — the
     // seconds fields (length, startTime, offset, loopStart, loopLength) are
-    // derived caches that go stale every time projectBPM or sourceBPM changes.
+    // derived caches that go stale every time projectBPM or source interpretation BPM changes.
     // Renderers, sync code, and inspector readouts that go through these
     // accessors compute the live value from beats and never depend on cache
     // freshness. The cached fields are still maintained (so non-migrated
@@ -498,27 +518,27 @@ struct ClipInfo {
     }
 
     /// Source-domain seconds for the loop start. For autoTempo clips, computed
-    /// live from loopStartBeats × 60 / sourceBPM. For non-autoTempo clips,
+    /// live from loopStartBeats × 60 / source interpretation BPM. For non-autoTempo clips,
     /// returns the stored field.
     double getSourceLoopStart() const {
-        if (autoTempo && sourceBPM > 0.0) {
-            return loopStartBeats * 60.0 / sourceBPM;
+        if (autoTempo && audio().interpretation.bpm > 0.0) {
+            return loopStartBeats * 60.0 / audio().interpretation.bpm;
         }
         return loopStart;
     }
 
     /// Source-domain seconds for the loop length.
     double getSourceLoopLength() const {
-        if (autoTempo && sourceBPM > 0.0 && loopLengthBeats > 0.0) {
-            return loopLengthBeats * 60.0 / sourceBPM;
+        if (autoTempo && audio().interpretation.bpm > 0.0 && loopLengthBeats > 0.0) {
+            return loopLengthBeats * 60.0 / audio().interpretation.bpm;
         }
         return loopLength;
     }
 
     /// Source-domain seconds for the read-position offset.
     double getSourceOffset() const {
-        if (autoTempo && sourceBPM > 0.0) {
-            return offsetBeats * 60.0 / sourceBPM;
+        if (autoTempo && audio().interpretation.bpm > 0.0) {
+            return offsetBeats * 60.0 / audio().interpretation.bpm;
         }
         return offset;
     }

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -929,6 +929,20 @@ void ClipManager::applyAudioClipBeats(ClipId clipId, const AudioClipBeatsUpdate&
     if (update.startBeats)
         clip->setPlacementBeats(juce::jmax(0.0, *update.startBeats), clip->placement.lengthBeats);
 
+    // If the source interpretation changed, preserve the selected source region in seconds.
+    // loopStartBeats/loopLengthBeats/offsetBeats are derived from source seconds unless the
+    // current update explicitly edits those beat-domain fields.
+    if ((update.interpretationBpm || update.interpretationTotalBeats) &&
+        clip->audio().interpretation.bpm > 0.0) {
+        double sourceBpm = clip->audio().interpretation.bpm;
+        if (!update.loopStartBeats)
+            clip->loopStartBeats = clip->loopStart * sourceBpm / 60.0;
+        if (!update.loopLengthBeats && clip->loopLength > 0.0)
+            clip->loopLengthBeats = clip->loopLength * sourceBpm / 60.0;
+        if (!update.offsetBeats)
+            clip->offsetBeats = clip->offset * sourceBpm / 60.0;
+    }
+
     // (3) Recompute the seconds cache from beats atomically.
     refreshDerivedSeconds(clipId, projectBPM);
 

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -67,6 +67,15 @@ bool seedSourceMetadataFromCachedDetection(ClipInfo& clip, double projectBPM) {
     return true;
 }
 
+void syncUnlockedSourceTotalBeatsToLoopLength(ClipInfo& clip) {
+    if (!clip.isAudio() || clip.audio().interpretation.totalBeatsLocked ||
+        clip.loopLengthBeats <= 0.0) {
+        return;
+    }
+
+    clip.audio().interpretation.totalBeats = clip.loopLengthBeats;
+}
+
 }  // namespace
 
 ClipManager& ClipManager::getInstance() {
@@ -814,6 +823,7 @@ void ClipManager::setLoopLength(ClipId clipId, double loopLength, double bpm) {
                                      ? clip->audio().interpretation.bpm
                                      : bpm;
                 clip->loopLengthBeats = (clip->loopLength * convBpm) / 60.0;
+                syncUnlockedSourceTotalBeatsToLoopLength(*clip);
             }
             sanitizeAudioClip(*clip);
         }
@@ -842,6 +852,7 @@ void ClipManager::setLoopStartAndLength(ClipId clipId, double loopStart, double 
                                      : bpm;
                 clip->loopStartBeats = (clip->loopStart * convBpm) / 60.0;
                 clip->loopLengthBeats = (clip->loopLength * convBpm) / 60.0;
+                syncUnlockedSourceTotalBeatsToLoopLength(*clip);
                 if (loopStartMoved && clip->audio().interpretation.bpm > 0.0)
                     clip->offsetBeats = clip->offset * clip->audio().interpretation.bpm / 60.0;
             }
@@ -892,14 +903,18 @@ void ClipManager::applyAudioClipBeats(ClipId clipId, const AudioClipBeatsUpdate&
         << static_cast<int>(update.interpretationTotalBeats.has_value())
         << " interpretationTotalBeats="
         << (update.interpretationTotalBeats ? *update.interpretationTotalBeats : -1.0)
+        << " lockInterpretationTotalBeats=" << static_cast<int>(update.lockInterpretationTotalBeats)
         << " projectBPM=" << projectBPM);
 
     // (1) Detected metadata — write-only role. Inspector "BPM" corrections
     // and BPM-detection callbacks land here. Never touched by the beat slider.
     if (update.interpretationBpm)
         clip->audio().interpretation.bpm = juce::jmax(0.0, *update.interpretationBpm);
-    if (update.interpretationTotalBeats)
+    if (update.interpretationTotalBeats) {
         clip->audio().interpretation.totalBeats = juce::jmax(0.0, *update.interpretationTotalBeats);
+        if (update.lockInterpretationTotalBeats)
+            clip->audio().interpretation.totalBeatsLocked = true;
+    }
     if (update.sourceDurationSeconds && clip->audio().source.durationSeconds <= 0.0)
         clip->audio().source.durationSeconds = juce::jmax(0.0, *update.sourceDurationSeconds);
     if (clip->audio().source.durationSeconds <= 0.0 && clip->audio().interpretation.bpm > 0.0 &&
@@ -917,8 +932,10 @@ void ClipManager::applyAudioClipBeats(ClipId clipId, const AudioClipBeatsUpdate&
     }
     if (update.loopStartBeats)
         clip->loopStartBeats = juce::jmax(0.0, *update.loopStartBeats);
-    if (update.loopLengthBeats)
+    if (update.loopLengthBeats) {
         clip->loopLengthBeats = juce::jmax(0.0, *update.loopLengthBeats);
+        syncUnlockedSourceTotalBeatsToLoopLength(*clip);
+    }
     if (update.offsetBeats)
         clip->offsetBeats = juce::jmax(0.0, *update.offsetBeats);
     if (update.startBeats)

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -14,34 +14,37 @@ namespace magda {
 
 namespace {
 
-bool sourceBpmLooksDefaulted(const ClipInfo& clip, double projectBPM) {
-    if (clip.sourceBPM <= 0.0)
+bool sourceInterpretationBpmLooksDefaulted(const ClipInfo& clip, double projectBPM) {
+    if (clip.audio().interpretation.bpm <= 0.0)
         return true;
-    return projectBPM > 0.0 && std::abs(clip.sourceBPM - projectBPM) < 0.1;
+    return projectBPM > 0.0 && std::abs(clip.audio().interpretation.bpm - projectBPM) < 0.1;
 }
 
 bool seedSourceMetadataFromCachedDetection(ClipInfo& clip, double projectBPM) {
-    if (!clip.isAudio() || clip.audioFilePath.isEmpty() ||
-        !sourceBpmLooksDefaulted(clip, projectBPM)) {
+    if (!clip.isAudio() || clip.audio().source.filePath.isEmpty() ||
+        !sourceInterpretationBpmLooksDefaulted(clip, projectBPM)) {
         return false;
     }
 
     auto& thumbs = AudioThumbnailManager::getInstance();
-    double cachedBPM = thumbs.getCachedBPM(clip.audioFilePath);
+    double cachedBPM = thumbs.getCachedBPM(clip.audio().source.filePath);
     if (cachedBPM <= 0.0)
         return false;
 
-    clip.sourceBPM = cachedBPM;
+    clip.audio().interpretation.bpm = cachedBPM;
     double fileDuration = 0.0;
-    if (juce::File(clip.audioFilePath).existsAsFile()) {
-        if (auto* thumbnail = thumbs.getThumbnail(clip.audioFilePath)) {
+    if (juce::File(clip.audio().source.filePath).existsAsFile()) {
+        if (auto* thumbnail = thumbs.getThumbnail(clip.audio().source.filePath)) {
             fileDuration = thumbnail->getTotalLength();
         }
     }
     if (fileDuration <= 0.0)
         fileDuration = clip.getSourceLength();
-    if (fileDuration > 0.0)
-        clip.sourceNumBeats = fileDuration * cachedBPM / 60.0;
+    if (fileDuration > 0.0) {
+        if (clip.audio().source.durationSeconds <= 0.0)
+            clip.audio().source.durationSeconds = fileDuration;
+        clip.audio().interpretation.totalBeats = fileDuration * cachedBPM / 60.0;
+    }
 
     return true;
 }
@@ -77,7 +80,8 @@ ClipId ClipManager::createAudioClip(TrackId trackId, double startTime, double le
     } else {
         clip.colour = juce::Colour(Config::getDefaultColour(static_cast<int>(clips_.size())));
     }
-    clip.audioFilePath = audioFilePath;
+    clip.audio().source.filePath = audioFilePath;
+    clip.audio().source.durationSeconds = juce::jmax(0.0, length);
     clip.offset = 0.0;
     clip.speedRatio = 1.0;
 
@@ -100,7 +104,7 @@ ClipId ClipManager::createAudioClip(TrackId trackId, double startTime, double le
         clip.loopEnabled = true;
         clip.autoTempo = true;
         // Source loop beats live in the source-beat domain. Use 0 as "full
-        // source" until metadata detection populates sourceNumBeats.
+        // source" until metadata detection populates source interpretation total beats.
         clip.loopLengthBeats = 0.0;
         clips_[clip.id] = clip;
     }
@@ -110,11 +114,11 @@ ClipId ClipManager::createAudioClip(TrackId trackId, double startTime, double le
 
     // Issue #1157: kick off BPM detection at creation time for session audio
     // clips. The detection callback funnels through applyAudioClipBeats so
-    // sourceBPM/sourceNumBeats land on the canonical update path. Cached
-    // results fire synchronously on the message thread; cache misses run on
-    // a background thread and patch the clip when the scan completes.
-    // Skip when the file doesn't exist on disk — tests pass synthetic paths
-    // and don't run a MessageManager loop, so the detection pool would leak.
+    // source interpretation BPM/source interpretation total beats land on the canonical update
+    // path. Cached results fire synchronously on the message thread; cache misses run on a
+    // background thread and patch the clip when the scan completes. Skip when the file doesn't
+    // exist on disk — tests pass synthetic paths and don't run a MessageManager loop, so the
+    // detection pool would leak.
     if (view == ClipView::Session && audioFilePath.isNotEmpty() &&
         juce::File(audioFilePath).existsAsFile()) {
         ClipId cid = clip.id;
@@ -132,17 +136,18 @@ ClipId ClipManager::createAudioClip(TrackId trackId, double startTime, double le
                 // when the file carries no tempo tag — it sometimes
                 // misdetects (half-time / double-time / outright wrong, e.g.
                 // 80→107 on the user's drum loop). Skip applying the result
-                // if sourceBPM is already populated.
-                if (c->sourceBPM > 0.0)
+                // if source interpretation BPM is already populated.
+                if (c->audio().interpretation.bpm > 0.0)
                     return;
                 AudioClipBeatsUpdate u;
-                u.sourceBPM = detectedBPM;
-                if (auto* thumb =
-                        AudioThumbnailManager::getInstance().getThumbnail(c->audioFilePath)) {
+                u.interpretationBpm = detectedBPM;
+                if (auto* thumb = AudioThumbnailManager::getInstance().getThumbnail(
+                        c->audio().source.filePath)) {
                     double fileDuration = thumb->getTotalLength();
                     if (fileDuration > 0.0) {
+                        u.sourceDurationSeconds = fileDuration;
                         double srcBeats = fileDuration * detectedBPM / 60.0;
-                        u.sourceNumBeats = srcBeats;
+                        u.interpretationTotalBeats = srcBeats;
                         // First-time detection on a freshly-dropped clip:
                         // initialise the loop region to the full source.
                         // loopLengthBeats == 0 is the sentinel set by
@@ -404,8 +409,9 @@ void ClipManager::resizeClip(ClipId clipId, double newLength, bool fromStart, do
             // In non-loop mode, clip length defines the source region — keep loopLength in sync
             if (!clip->loopEnabled && clip->isAudio()) {
                 clip->loopLength = clip->timelineToSource(clip->length);
-                if (clip->autoTempo && clip->sourceBPM > 0.0) {
-                    clip->loopLengthBeats = clip->loopLength * clip->sourceBPM / 60.0;
+                if (clip->autoTempo && clip->audio().interpretation.bpm > 0.0) {
+                    clip->loopLengthBeats =
+                        clip->loopLength * clip->audio().interpretation.bpm / 60.0;
                 }
             }
         }
@@ -437,12 +443,12 @@ ClipId ClipManager::splitClip(ClipId clipId, double splitTime, double tempo) {
 
     // Adjust offset for right clip (TE-aligned: offset is start position in source)
     if (rightClip.isAudio()) {
-        // In autoTempo/warp mode, speedRatio is 1.0 but actual stretch is projectBPM/sourceBPM.
-        // Use the tempo ratio to convert timeline seconds to source seconds.
-        if (clip->isBeatsAuthoritative() && clip->sourceBPM > 0.0 && tempo > 0.0) {
+        // In autoTempo/warp mode, speedRatio is 1.0 but actual stretch is projectBPM/source
+        // interpretation BPM. Use the tempo ratio to convert timeline seconds to source seconds.
+        if (clip->isBeatsAuthoritative() && clip->audio().interpretation.bpm > 0.0 && tempo > 0.0) {
             double deltaBeats = leftLength * tempo / 60.0;
             rightClip.offsetBeats += deltaBeats;
-            rightClip.offset = rightClip.offsetBeats * 60.0 / clip->sourceBPM;
+            rightClip.offset = rightClip.offsetBeats * 60.0 / clip->audio().interpretation.bpm;
         } else {
             rightClip.offset += leftLength * clip->speedRatio;
         }
@@ -510,7 +516,9 @@ ClipId ClipManager::splitClip(ClipId clipId, double splitTime, double tempo) {
         if (clip->loopLengthBeats > leftLenBeats) {
             clip->loopLengthBeats = leftLenBeats;
             if (clip->isAudio()) {
-                double srcBpm = clip->sourceBPM > 0.0 ? clip->sourceBPM : tempo;
+                double srcBpm = clip->audio().interpretation.bpm > 0.0
+                                    ? clip->audio().interpretation.bpm
+                                    : tempo;
                 clip->loopLength = clip->loopLengthBeats / srcBpm * 60.0;
             }
         }
@@ -520,10 +528,13 @@ ClipId ClipManager::splitClip(ClipId clipId, double splitTime, double tempo) {
         if (rightClip.loopLengthBeats > rightLenBeats) {
             rightClip.loopLengthBeats = rightLenBeats;
             if (rightClip.isAudio()) {
-                double srcBpm = rightClip.sourceBPM > 0.0 ? rightClip.sourceBPM : tempo;
-                if (rightClip.autoTempo && rightClip.sourceBPM > 0.0) {
+                double srcBpm = rightClip.audio().interpretation.bpm > 0.0
+                                    ? rightClip.audio().interpretation.bpm
+                                    : tempo;
+                if (rightClip.autoTempo && rightClip.audio().interpretation.bpm > 0.0) {
                     rightClip.loopStartBeats = rightClip.offsetBeats;
-                    rightClip.loopStart = rightClip.loopStartBeats * 60.0 / rightClip.sourceBPM;
+                    rightClip.loopStart =
+                        rightClip.loopStartBeats * 60.0 / rightClip.audio().interpretation.bpm;
                 } else {
                     rightClip.loopStart = rightClip.offset;
                     rightClip.loopStartBeats = rightClip.loopStart * srcBpm / 60.0;
@@ -537,21 +548,27 @@ ClipId ClipManager::splitClip(ClipId clipId, double splitTime, double tempo) {
         clip->loopLength = clip->timelineToSource(clip->length);
         if (clip->isBeatsAuthoritative() && tempo > 0.0) {
             clip->loopLengthBeats =
-                clip->loopLength * (clip->sourceBPM > 0.0 ? clip->sourceBPM : tempo) / 60.0;
+                clip->loopLength *
+                (clip->audio().interpretation.bpm > 0.0 ? clip->audio().interpretation.bpm
+                                                        : tempo) /
+                60.0;
         }
 
         // Right clip: loopStart must match offset so TE's loop range covers the
         // correct source region (otherwise offset falls outside the loop range,
         // causing TE to wrap and produce doubled transients at the split point)
-        if (rightClip.autoTempo && rightClip.sourceBPM > 0.0) {
+        if (rightClip.autoTempo && rightClip.audio().interpretation.bpm > 0.0) {
             rightClip.loopStartBeats = rightClip.offsetBeats;
-            rightClip.loopStart = rightClip.loopStartBeats * 60.0 / rightClip.sourceBPM;
+            rightClip.loopStart =
+                rightClip.loopStartBeats * 60.0 / rightClip.audio().interpretation.bpm;
         } else {
             rightClip.loopStart = rightClip.offset;
         }
         rightClip.loopLength = rightClip.timelineToSource(rightClip.length);
         if (rightClip.isBeatsAuthoritative() && tempo > 0.0) {
-            double srcBpm = rightClip.sourceBPM > 0.0 ? rightClip.sourceBPM : tempo;
+            double srcBpm = rightClip.audio().interpretation.bpm > 0.0
+                                ? rightClip.audio().interpretation.bpm
+                                : tempo;
             if (!rightClip.autoTempo)
                 rightClip.loopStartBeats = rightClip.loopStart * srcBpm / 60.0;
             rightClip.loopLengthBeats = rightClip.loopLength * srcBpm / 60.0;
@@ -624,7 +641,7 @@ void ClipManager::setClipLoopEnabled(ClipId clipId, bool enabled, double project
 
         // When enabling loop on audio clips, transfer offset → loopStart
         // The user's current offset becomes the loop start point (phase resets to 0)
-        if (enabled && clip->isAudio() && clip->audioFilePath.isNotEmpty()) {
+        if (enabled && clip->isAudio() && clip->audio().source.filePath.isNotEmpty()) {
             clip->loopStart = clip->offset;
 
             // Ensure loopLength is set (preserves source extent in loop mode)
@@ -643,10 +660,10 @@ void ClipManager::setClipLoopEnabled(ClipId clipId, bool enabled, double project
 
         // When disabling loop on audio clips, sync loopStart and clamp length to actual file
         // content
-        if (!enabled && clip->isAudio() && clip->audioFilePath.isNotEmpty()) {
+        if (!enabled && clip->isAudio() && clip->audio().source.filePath.isNotEmpty()) {
             clip->loopStart = clip->offset;
             auto* thumbnail =
-                AudioThumbnailManager::getInstance().getThumbnail(clip->audioFilePath);
+                AudioThumbnailManager::getInstance().getThumbnail(clip->audio().source.filePath);
             if (thumbnail) {
                 clip->clampLengthToSource(thumbnail->getTotalLength());
             }
@@ -722,8 +739,8 @@ void ClipManager::setOffset(ClipId clipId, double offset) {
             clip->midiOffset = juce::jmax(0.0, offset);
         } else {
             clip->offset = juce::jmax(0.0, offset);
-            if (clip->autoTempo && clip->sourceBPM > 0.0)
-                clip->offsetBeats = clip->offset * clip->sourceBPM / 60.0;
+            if (clip->autoTempo && clip->audio().interpretation.bpm > 0.0)
+                clip->offsetBeats = clip->offset * clip->audio().interpretation.bpm / 60.0;
             sanitizeAudioClip(*clip);
         }
         notifyClipPropertyChanged(clipId);
@@ -734,8 +751,8 @@ void ClipManager::setLoopPhase(ClipId clipId, double phase) {
     if (auto* clip = getClip(clipId)) {
         if (clip->isAudio() && clip->loopEnabled) {
             clip->offset = clip->loopStart + phase;
-            if (clip->autoTempo && clip->sourceBPM > 0.0)
-                clip->offsetBeats = clip->offset * clip->sourceBPM / 60.0;
+            if (clip->autoTempo && clip->audio().interpretation.bpm > 0.0)
+                clip->offsetBeats = clip->offset * clip->audio().interpretation.bpm / 60.0;
             sanitizeAudioClip(*clip);
             notifyClipPropertyChanged(clipId);
         }
@@ -747,8 +764,11 @@ void ClipManager::setLoopStart(ClipId clipId, double loopStart, double bpm) {
         clip->loopStart = juce::jmax(0.0, loopStart);
         if (clip->isAudio()) {
             if (clip->autoTempo) {
-                // Use sourceBPM for beat conversion — loopStartBeats is in source-beat domain
-                double convBpm = (clip->sourceBPM > 0.0) ? clip->sourceBPM : bpm;
+                // Use source interpretation BPM for beat conversion — loopStartBeats is in
+                // source-beat domain
+                double convBpm = (clip->audio().interpretation.bpm > 0.0)
+                                     ? clip->audio().interpretation.bpm
+                                     : bpm;
                 clip->loopStartBeats = (clip->loopStart * convBpm) / 60.0;
             }
             sanitizeAudioClip(*clip);
@@ -765,8 +785,11 @@ void ClipManager::setLoopLength(ClipId clipId, double loopLength, double bpm) {
             clip->loopLengthBeats = (clip->loopLength * juce::jmax(1.0, bpm)) / 60.0;
         } else if (clip->isAudio()) {
             if (clip->autoTempo) {
-                // Use sourceBPM for beat conversion — loopLengthBeats is in source-beat domain
-                double convBpm = (clip->sourceBPM > 0.0) ? clip->sourceBPM : bpm;
+                // Use source interpretation BPM for beat conversion — loopLengthBeats is in
+                // source-beat domain
+                double convBpm = (clip->audio().interpretation.bpm > 0.0)
+                                     ? clip->audio().interpretation.bpm
+                                     : bpm;
                 clip->loopLengthBeats = (clip->loopLength * convBpm) / 60.0;
             }
             sanitizeAudioClip(*clip);
@@ -791,11 +814,13 @@ void ClipManager::setLoopStartAndLength(ClipId clipId, double loopStart, double 
                 clip->offset = clip->loopStart;
 
             if (clip->autoTempo) {
-                double convBpm = (clip->sourceBPM > 0.0) ? clip->sourceBPM : bpm;
+                double convBpm = (clip->audio().interpretation.bpm > 0.0)
+                                     ? clip->audio().interpretation.bpm
+                                     : bpm;
                 clip->loopStartBeats = (clip->loopStart * convBpm) / 60.0;
                 clip->loopLengthBeats = (clip->loopLength * convBpm) / 60.0;
-                if (loopStartMoved && clip->sourceBPM > 0.0)
-                    clip->offsetBeats = clip->offset * clip->sourceBPM / 60.0;
+                if (loopStartMoved && clip->audio().interpretation.bpm > 0.0)
+                    clip->offsetBeats = clip->offset * clip->audio().interpretation.bpm / 60.0;
             }
             sanitizeAudioClip(*clip);
         } else if (clip->isMidi()) {
@@ -812,19 +837,12 @@ void ClipManager::setLengthBeats(ClipId clipId, double newBeats, double bpm) {
         return;
 
     // Issue #1157: the beat-length slider edits USER INTENT only — how many
-    // timeline beats the clip occupies. Source-file metadata (sourceBPM /
-    // sourceNumBeats) is NOT touched here. Stretch is determined by TE from
-    // (projectBPM / sourceBPM) at sync time.
+    // timeline beats the clip occupies. Source-file metadata (source interpretation BPM /
+    // source interpretation total beats) is NOT touched here. Stretch is determined by TE from
+    // (projectBPM / source interpretation BPM) at sync time.
     //
-    // We also scale loopLengthBeats so that a clip whose timeline length
-    // matches its loop length stays in lockstep — but only when the user
-    // hasn't already shrunk the loop region below the clip length.
     AudioClipBeatsUpdate u;
     u.lengthBeats = newBeats;
-    bool loopMatchesLength =
-        clip->loopLengthBeats <= 0.0 || std::abs(clip->loopLengthBeats - clip->lengthBeats) < 1e-6;
-    if (loopMatchesLength)
-        u.loopLengthBeats = newBeats;
 
     applyAudioClipBeats(clipId, u, bpm);
 }
@@ -837,10 +855,17 @@ void ClipManager::applyAudioClipBeats(ClipId clipId, const AudioClipBeatsUpdate&
 
     // (1) Detected metadata — write-only role. Inspector "BPM" corrections
     // and BPM-detection callbacks land here. Never touched by the beat slider.
-    if (update.sourceBPM)
-        clip->sourceBPM = juce::jmax(0.0, *update.sourceBPM);
-    if (update.sourceNumBeats)
-        clip->sourceNumBeats = juce::jmax(0.0, *update.sourceNumBeats);
+    if (update.interpretationBpm)
+        clip->audio().interpretation.bpm = juce::jmax(0.0, *update.interpretationBpm);
+    if (update.interpretationTotalBeats)
+        clip->audio().interpretation.totalBeats = juce::jmax(0.0, *update.interpretationTotalBeats);
+    if (update.sourceDurationSeconds && clip->audio().source.durationSeconds <= 0.0)
+        clip->audio().source.durationSeconds = juce::jmax(0.0, *update.sourceDurationSeconds);
+    if (clip->audio().source.durationSeconds <= 0.0 && clip->audio().interpretation.bpm > 0.0 &&
+        clip->audio().interpretation.totalBeats > 0.0) {
+        clip->audio().source.durationSeconds =
+            clip->audio().interpretation.totalBeats * 60.0 / clip->audio().interpretation.bpm;
+    }
 
     // (2) User-intent fields — beat-domain canonicals.
     if (update.lengthBeats) {
@@ -885,14 +910,14 @@ void ClipManager::refreshDerivedSeconds(ClipId clipId, double projectBPM) {
     // Source-domain seconds (offset, loopStart, loopLength) for autoTempo
     // audio: depend on SOURCE BPM (a property of the file, not the project).
     // For MIDI clips loopLengthBeats lives in the project-beat domain, so
-    // loopLength uses projectBPM. When sourceBPM is unknown (detection
+    // loopLength uses projectBPM. When source interpretation BPM is unknown (detection
     // pending), leave the source-domain seconds alone — readers fall back to
     // the lengthBeats × 60 / projectBPM path.
-    if (clip->isAudio() && clip->autoTempo && clip->sourceBPM > 0.0) {
-        clip->offset = clip->offsetBeats * 60.0 / clip->sourceBPM;
-        clip->loopStart = clip->loopStartBeats * 60.0 / clip->sourceBPM;
+    if (clip->isAudio() && clip->autoTempo && clip->audio().interpretation.bpm > 0.0) {
+        clip->offset = clip->offsetBeats * 60.0 / clip->audio().interpretation.bpm;
+        clip->loopStart = clip->loopStartBeats * 60.0 / clip->audio().interpretation.bpm;
         if (clip->loopLengthBeats > 0.0)
-            clip->loopLength = clip->loopLengthBeats * 60.0 / clip->sourceBPM;
+            clip->loopLength = clip->loopLengthBeats * 60.0 / clip->audio().interpretation.bpm;
     } else if (clip->isMidi() && projectBPM > 0.0 && clip->loopLengthBeats > 0.0) {
         clip->loopLength = clip->loopLengthBeats * 60.0 / projectBPM;
     }
@@ -1718,10 +1743,11 @@ juce::String ClipManager::generateClipName(ClipType type) const {
 }
 
 void ClipManager::sanitizeAudioClip(ClipInfo& clip) {
-    if (!clip.isAudio() || clip.audioFilePath.isEmpty())
+    if (!clip.isAudio() || clip.audio().source.filePath.isEmpty())
         return;
 
-    auto* thumbnail = AudioThumbnailManager::getInstance().getThumbnail(clip.audioFilePath);
+    auto* thumbnail =
+        AudioThumbnailManager::getInstance().getThumbnail(clip.audio().source.filePath);
     if (!thumbnail)
         return;
 
@@ -1815,19 +1841,21 @@ void ClipManager::copyTimeRangeToClipboard(double startTime, double endTime,
         if (clip.isAudio()) {
             // Adjust offset for the trimmed start position
             double trimFromLeft = overlapStart - clip.startTime;
-            if (clip.isBeatsAuthoritative() && clip.sourceBPM > 0.0 && tempoBPM > 0.0) {
+            if (clip.isBeatsAuthoritative() && clip.audio().interpretation.bpm > 0.0 &&
+                tempoBPM > 0.0) {
                 // autoTempo: work in beats, derive seconds
                 double deltaBeats = trimFromLeft * tempoBPM / 60.0;
                 trimmed.offsetBeats = clip.offsetBeats + deltaBeats;
-                trimmed.offset = trimmed.offsetBeats * 60.0 / clip.sourceBPM;
+                trimmed.offset = trimmed.offsetBeats * 60.0 / clip.audio().interpretation.bpm;
             } else {
                 trimmed.offset = clip.offset + trimFromLeft * clip.speedRatio;
             }
             // Sync loop fields for non-looped clips
             if (!trimmed.loopEnabled) {
-                if (trimmed.autoTempo && trimmed.sourceBPM > 0.0) {
+                if (trimmed.autoTempo && trimmed.audio().interpretation.bpm > 0.0) {
                     trimmed.loopStartBeats = trimmed.offsetBeats;
-                    trimmed.loopStart = trimmed.loopStartBeats * 60.0 / trimmed.sourceBPM;
+                    trimmed.loopStart =
+                        trimmed.loopStartBeats * 60.0 / trimmed.audio().interpretation.bpm;
                 } else {
                     trimmed.loopStart = trimmed.offset;
                 }
@@ -1879,9 +1907,9 @@ std::vector<ClipId> ClipManager::pasteFromClipboard(double pasteTime, TrackId ta
         // Create new clip based on type, using targetView instead of clipData.view
         ClipId newClipId = INVALID_CLIP_ID;
         if (clipData.isAudio()) {
-            if (clipData.audioFilePath.isNotEmpty()) {
+            if (clipData.audio().source.filePath.isNotEmpty()) {
                 newClipId = createAudioClip(newTrackId, newStartTime, clipData.length,
-                                            clipData.audioFilePath, targetView);
+                                            clipData.audio().source.filePath, targetView);
             }
         } else {
             // For MIDI clips, create empty then copy notes
@@ -1931,10 +1959,11 @@ std::vector<ClipId> ClipManager::pasteFromClipboard(double pasteTime, TrackId ta
                 }
 
                 // Source file metadata (always copy — these describe the file itself)
-                if (clipData.sourceBPM > 0.0)
-                    newClip->sourceBPM = clipData.sourceBPM;
-                if (clipData.sourceNumBeats > 0.0)
-                    newClip->sourceNumBeats = clipData.sourceNumBeats;
+                if (clipData.audio().interpretation.bpm > 0.0)
+                    newClip->audio().interpretation.bpm = clipData.audio().interpretation.bpm;
+                if (clipData.audio().interpretation.totalBeats > 0.0)
+                    newClip->audio().interpretation.totalBeats =
+                        clipData.audio().interpretation.totalBeats;
 
                 // Pitch
                 newClip->autoPitch = clipData.autoPitch;

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -17,7 +17,15 @@ namespace {
 bool sourceInterpretationBpmLooksDefaulted(const ClipInfo& clip, double projectBPM) {
     if (clip.audio().interpretation.bpm <= 0.0)
         return true;
-    return projectBPM > 0.0 && std::abs(clip.audio().interpretation.bpm - projectBPM) < 0.1;
+    if (projectBPM <= 0.0 || std::abs(clip.audio().interpretation.bpm - projectBPM) >= 0.1)
+        return false;
+
+    const double sourceDuration = clip.getSourceLength();
+    if (sourceDuration <= 0.0 || clip.audio().interpretation.totalBeats <= 0.0)
+        return true;
+
+    const double projectDefaultBeats = sourceDuration * projectBPM / 60.0;
+    return std::abs(clip.audio().interpretation.totalBeats - projectDefaultBeats) < 0.01;
 }
 
 void traceAudioClipLengthState(const char* label, const ClipInfo& clip, double projectBPM) {
@@ -122,7 +130,7 @@ ClipId ClipManager::createAudioClip(TrackId trackId, double startTime, double le
         clip.loopEnabled = true;
         clip.autoTempo = true;
         // Source loop beats live in the source-beat domain. Use 0 as "full
-        // source" until metadata detection populates source interpretation total beats.
+        // source" until Tracktion loopInfo populates source interpretation metadata.
         clip.loopLengthBeats = 0.0;
         clips_[clip.id] = clip;
     }
@@ -130,53 +138,55 @@ ClipId ClipManager::createAudioClip(TrackId trackId, double startTime, double le
     addToSessionSlotIndex(clips_[clip.id]);
     notifyClipsChanged();
 
-    // Issue #1157: kick off BPM detection at creation time for session audio
-    // clips. The detection callback funnels through applyAudioClipBeats so
-    // source interpretation BPM/source interpretation total beats land on the canonical update
-    // path. Cached results fire synchronously on the message thread; cache misses run on a
-    // background thread and patch the clip when the scan completes. Skip when the file doesn't
-    // exist on disk — tests pass synthetic paths and don't run a MessageManager loop, so the
-    // detection pool would leak.
+    // Tracktion loopInfo is authoritative when it carries real file metadata,
+    // but it can also report project-default values for freshly inserted clips.
+    // Run audio analysis as a fallback and let it replace only unset/defaulted
+    // source interpretation values.
     if (view == ClipView::Session && audioFilePath.isNotEmpty() &&
         juce::File(audioFilePath).existsAsFile()) {
         ClipId cid = clip.id;
-        AudioThumbnailManager::getInstance().requestBPMDetection(
-            audioFilePath, [cid](double detectedBPM) {
+        const double creationProjectBPM = bpm;
+        auto applyDetectedBPM = [cid, creationProjectBPM](double detectedBPM) {
+            if (detectedBPM <= 0.0)
+                return;
+
+            auto& mgr = ClipManager::getInstance();
+            auto* c = mgr.getClip(cid);
+            if (!c || !sourceInterpretationBpmLooksDefaulted(*c, creationProjectBPM))
+                return;
+
+            double fileDuration = c->audio().source.durationSeconds;
+            if (auto* thumb =
+                    AudioThumbnailManager::getInstance().getThumbnail(c->audio().source.filePath)) {
+                if (thumb->getTotalLength() > 0.0)
+                    fileDuration = thumb->getTotalLength();
+            }
+
+            AudioClipBeatsUpdate u;
+            u.interpretationBpm = detectedBPM;
+            if (fileDuration > 0.0) {
+                u.sourceDurationSeconds = fileDuration;
+                const double srcBeats = fileDuration * detectedBPM / 60.0;
+                u.interpretationTotalBeats = srcBeats;
+                if (c->autoTempo && c->loopLengthBeats <= 0.0)
+                    u.loopLengthBeats = srcBeats;
+            }
+
+            double live = ProjectManager::getInstance().getCurrentProjectInfo().tempo;
+            mgr.applyAudioClipBeats(cid, u, live);
+        };
+
+        auto& thumbs = AudioThumbnailManager::getInstance();
+        const double cachedBPM = thumbs.getCachedBPM(audioFilePath);
+        if (cachedBPM > 0.0) {
+            applyDetectedBPM(cachedBPM);
+        } else {
+            thumbs.requestBPMDetection(audioFilePath, [applyDetectedBPM](double detectedBPM) {
                 if (detectedBPM <= 0.0)
                     return;
-                auto& mgr = ClipManager::getInstance();
-                auto* c = mgr.getClip(cid);
-                if (!c)
-                    return;
-                // Issue #1157: file metadata (via TE's loopInfo →
-                // setSourceMetadata) is authoritative when present. Audio
-                // analysis (tracktion::TempoDetect) is a fallback used only
-                // when the file carries no tempo tag — it sometimes
-                // misdetects (half-time / double-time / outright wrong, e.g.
-                // 80→107 on the user's drum loop). Skip applying the result
-                // if source interpretation BPM is already populated.
-                if (c->audio().interpretation.bpm > 0.0)
-                    return;
-                AudioClipBeatsUpdate u;
-                u.interpretationBpm = detectedBPM;
-                if (auto* thumb = AudioThumbnailManager::getInstance().getThumbnail(
-                        c->audio().source.filePath)) {
-                    double fileDuration = thumb->getTotalLength();
-                    if (fileDuration > 0.0) {
-                        u.sourceDurationSeconds = fileDuration;
-                        double srcBeats = fileDuration * detectedBPM / 60.0;
-                        u.interpretationTotalBeats = srcBeats;
-                        // First-time detection on a freshly-dropped clip:
-                        // initialise the loop region to the full source.
-                        // loopLengthBeats == 0 is the sentinel set by
-                        // createAudioClip (see issue #1157).
-                        if (c->loopLengthBeats <= 0.0)
-                            u.loopLengthBeats = srcBeats;
-                    }
-                }
-                double live = ProjectManager::getInstance().getCurrentProjectInfo().tempo;
-                mgr.applyAudioClipBeats(cid, u, live);
+                applyDetectedBPM(detectedBPM);
             });
+        }
     }
 
     return clip.id;

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -67,15 +67,6 @@ bool seedSourceMetadataFromCachedDetection(ClipInfo& clip, double projectBPM) {
     return true;
 }
 
-void syncUnlockedSourceTotalBeatsToLoopLength(ClipInfo& clip) {
-    if (!clip.isAudio() || clip.audio().interpretation.totalBeatsLocked ||
-        clip.loopLengthBeats <= 0.0) {
-        return;
-    }
-
-    clip.audio().interpretation.totalBeats = clip.loopLengthBeats;
-}
-
 }  // namespace
 
 ClipManager& ClipManager::getInstance() {
@@ -823,7 +814,6 @@ void ClipManager::setLoopLength(ClipId clipId, double loopLength, double bpm) {
                                      ? clip->audio().interpretation.bpm
                                      : bpm;
                 clip->loopLengthBeats = (clip->loopLength * convBpm) / 60.0;
-                syncUnlockedSourceTotalBeatsToLoopLength(*clip);
             }
             sanitizeAudioClip(*clip);
         }
@@ -852,7 +842,6 @@ void ClipManager::setLoopStartAndLength(ClipId clipId, double loopStart, double 
                                      : bpm;
                 clip->loopStartBeats = (clip->loopStart * convBpm) / 60.0;
                 clip->loopLengthBeats = (clip->loopLength * convBpm) / 60.0;
-                syncUnlockedSourceTotalBeatsToLoopLength(*clip);
                 if (loopStartMoved && clip->audio().interpretation.bpm > 0.0)
                     clip->offsetBeats = clip->offset * clip->audio().interpretation.bpm / 60.0;
             }
@@ -906,8 +895,8 @@ void ClipManager::applyAudioClipBeats(ClipId clipId, const AudioClipBeatsUpdate&
         << " lockInterpretationTotalBeats=" << static_cast<int>(update.lockInterpretationTotalBeats)
         << " projectBPM=" << projectBPM);
 
-    // (1) Detected metadata — write-only role. Inspector "BPM" corrections
-    // and BPM-detection callbacks land here. Never touched by the beat slider.
+    // (1) Source interpretation metadata. BPM and total beats describe the
+    // same fixed-duration source, so inspector edits may update both together.
     if (update.interpretationBpm)
         clip->audio().interpretation.bpm = juce::jmax(0.0, *update.interpretationBpm);
     if (update.interpretationTotalBeats) {
@@ -934,7 +923,6 @@ void ClipManager::applyAudioClipBeats(ClipId clipId, const AudioClipBeatsUpdate&
         clip->loopStartBeats = juce::jmax(0.0, *update.loopStartBeats);
     if (update.loopLengthBeats) {
         clip->loopLengthBeats = juce::jmax(0.0, *update.loopLengthBeats);
-        syncUnlockedSourceTotalBeatsToLoopLength(*clip);
     }
     if (update.offsetBeats)
         clip->offsetBeats = juce::jmax(0.0, *update.offsetBeats);

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -20,6 +20,24 @@ bool sourceInterpretationBpmLooksDefaulted(const ClipInfo& clip, double projectB
     return projectBPM > 0.0 && std::abs(clip.audio().interpretation.bpm - projectBPM) < 0.1;
 }
 
+void traceAudioClipLengthState(const char* label, const ClipInfo& clip, double projectBPM) {
+    if (!clip.isAudio())
+        return;
+
+    DBG("[ClipLengthTrace] "
+        << label << " id=" << clip.id << " projectBPM=" << projectBPM << " autoTempo="
+        << static_cast<int>(clip.autoTempo) << " loopEnabled=" << static_cast<int>(clip.loopEnabled)
+        << " placement.startBeat=" << clip.placement.startBeat
+        << " placement.lengthBeats=" << clip.placement.lengthBeats
+        << " mirror.startBeats=" << clip.startBeats << " mirror.lengthBeats=" << clip.lengthBeats
+        << " timeline.startTime=" << clip.startTime << " timeline.lengthSeconds=" << clip.length
+        << " loopStartBeats=" << clip.loopStartBeats << " loopLengthBeats=" << clip.loopLengthBeats
+        << " loopStartSeconds=" << clip.loopStart << " loopLengthSeconds=" << clip.loopLength
+        << " source.durationSeconds=" << clip.audio().source.durationSeconds
+        << " interpretation.bpm=" << clip.audio().interpretation.bpm
+        << " interpretation.totalBeats=" << clip.audio().interpretation.totalBeats);
+}
+
 bool seedSourceMetadataFromCachedDetection(ClipInfo& clip, double projectBPM) {
     if (!clip.isAudio() || clip.audio().source.filePath.isEmpty() ||
         !sourceInterpretationBpmLooksDefaulted(clip, projectBPM)) {
@@ -397,6 +415,10 @@ void ClipManager::moveClipToTrack(ClipId clipId, TrackId newTrackId) {
 
 void ClipManager::resizeClip(ClipId clipId, double newLength, bool fromStart, double tempo) {
     if (auto* clip = getClip(clipId)) {
+        traceAudioClipLengthState("resizeClip:before", *clip, tempo);
+        DBG("[ClipLengthTrace] resizeClip request id="
+            << clipId << " newLengthSeconds=" << newLength
+            << " fromStart=" << static_cast<int>(fromStart) << " projectBPM=" << tempo);
         if (fromStart) {
             ClipOperations::resizeContainerFromLeft(*clip, newLength, tempo);
             // Non-loop mode: keep loopStart synced to offset
@@ -415,6 +437,7 @@ void ClipManager::resizeClip(ClipId clipId, double newLength, bool fromStart, do
                 }
             }
         }
+        traceAudioClipLengthState("resizeClip:after", *clip, tempo);
         notifyClipPropertyChanged(clipId);
     }
 }
@@ -836,6 +859,10 @@ void ClipManager::setLengthBeats(ClipId clipId, double newBeats, double bpm) {
     if (!clip || !clip->isAudio() || !clip->autoTempo || bpm <= 0.0)
         return;
 
+    traceAudioClipLengthState("setLengthBeats:before", *clip, bpm);
+    DBG("[ClipLengthTrace] setLengthBeats request id=" << clipId << " newPlacementLengthBeats="
+                                                       << newBeats << " projectBPM=" << bpm);
+
     // Issue #1157: the beat-length slider edits USER INTENT only — how many
     // timeline beats the clip occupies. Source-file metadata (source interpretation BPM /
     // source interpretation total beats) is NOT touched here. Stretch is determined by TE from
@@ -852,6 +879,20 @@ void ClipManager::applyAudioClipBeats(ClipId clipId, const AudioClipBeatsUpdate&
     auto* clip = getClip(clipId);
     if (!clip || !clip->isAudio() || !clip->autoTempo)
         return;
+
+    traceAudioClipLengthState("applyAudioClipBeats:before", *clip, projectBPM);
+    DBG("[ClipLengthTrace] applyAudioClipBeats request id="
+        << clipId << " hasLengthBeats=" << static_cast<int>(update.lengthBeats.has_value())
+        << " lengthBeats=" << (update.lengthBeats ? *update.lengthBeats : -1.0)
+        << " hasLoopLengthBeats=" << static_cast<int>(update.loopLengthBeats.has_value())
+        << " loopLengthBeats=" << (update.loopLengthBeats ? *update.loopLengthBeats : -1.0)
+        << " hasInterpretationBpm=" << static_cast<int>(update.interpretationBpm.has_value())
+        << " interpretationBpm=" << (update.interpretationBpm ? *update.interpretationBpm : -1.0)
+        << " hasInterpretationTotalBeats="
+        << static_cast<int>(update.interpretationTotalBeats.has_value())
+        << " interpretationTotalBeats="
+        << (update.interpretationTotalBeats ? *update.interpretationTotalBeats : -1.0)
+        << " projectBPM=" << projectBPM);
 
     // (1) Detected metadata — write-only role. Inspector "BPM" corrections
     // and BPM-detection callbacks land here. Never touched by the beat slider.
@@ -886,6 +927,7 @@ void ClipManager::applyAudioClipBeats(ClipId clipId, const AudioClipBeatsUpdate&
     // (3) Recompute the seconds cache from beats atomically.
     refreshDerivedSeconds(clipId, projectBPM);
 
+    traceAudioClipLengthState("applyAudioClipBeats:after", *clip, projectBPM);
     notifyClipPropertyChanged(clipId);
 }
 
@@ -893,6 +935,8 @@ void ClipManager::refreshDerivedSeconds(ClipId clipId, double projectBPM) {
     auto* clip = getClip(clipId);
     if (!clip)
         return;
+
+    traceAudioClipLengthState("refreshDerivedSeconds:before", *clip, projectBPM);
 
     // TE requires speedRatio == 1.0 in autoTempo mode.
     if (clip->autoTempo)
@@ -921,6 +965,8 @@ void ClipManager::refreshDerivedSeconds(ClipId clipId, double projectBPM) {
     } else if (clip->isMidi() && projectBPM > 0.0 && clip->loopLengthBeats > 0.0) {
         clip->loopLength = clip->loopLengthBeats * 60.0 / projectBPM;
     }
+
+    traceAudioClipLengthState("refreshDerivedSeconds:after", *clip, projectBPM);
 }
 
 void ClipManager::setSpeedRatio(ClipId clipId, double speedRatio) {
@@ -1958,12 +2004,14 @@ std::vector<ClipId> ClipManager::pasteFromClipboard(double pasteTime, TrackId ta
                     newClip->timeStretchMode = clipData.timeStretchMode;
                 }
 
-                // Source file metadata (always copy — these describe the file itself)
-                if (clipData.audio().interpretation.bpm > 0.0)
-                    newClip->audio().interpretation.bpm = clipData.audio().interpretation.bpm;
-                if (clipData.audio().interpretation.totalBeats > 0.0)
-                    newClip->audio().interpretation.totalBeats =
-                        clipData.audio().interpretation.totalBeats;
+                // Source file metadata describes audio files only.
+                if (clipData.isAudio()) {
+                    if (clipData.audio().interpretation.bpm > 0.0)
+                        newClip->audio().interpretation.bpm = clipData.audio().interpretation.bpm;
+                    if (clipData.audio().interpretation.totalBeats > 0.0)
+                        newClip->audio().interpretation.totalBeats =
+                            clipData.audio().interpretation.totalBeats;
+                }
 
                 // Pitch
                 newClip->autoPitch = clipData.autoPitch;

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -772,7 +772,8 @@ void ClipManager::setOffset(ClipId clipId, double offset) {
 
 void ClipManager::setLoopPhase(ClipId clipId, double phase) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio() && clip->loopEnabled) {
+        const bool loopActive = clip->loopEnabled || clip->autoTempo;
+        if (clip->isAudio() && loopActive) {
             clip->offset = clip->loopStart + phase;
             if (clip->autoTempo && clip->audio().interpretation.bpm > 0.0)
                 clip->offsetBeats = clip->offset * clip->audio().interpretation.bpm / 60.0;
@@ -1836,8 +1837,10 @@ void ClipManager::sanitizeAudioClip(ClipInfo& clip) {
     // Clamp offset to file bounds
     clip.offset = juce::jlimit(0.0, fileDuration, clip.offset);
 
-    // Non-loop mode: keep loopStart synced to offset and clamp clip length
-    if (!clip.loopEnabled) {
+    // Non-loop mode: keep loopStart synced to offset and clamp clip length.
+    // Auto-tempo/BEAT mode also uses loopStart/loopLength as an active source
+    // region, even when the explicit loop toggle is not set.
+    if (!clip.loopEnabled && !clip.autoTempo) {
         clip.loopStart = clip.offset;
         clip.clampLengthToSource(fileDuration);
     }

--- a/magda/daw/core/ClipManager.hpp
+++ b/magda/daw/core/ClipManager.hpp
@@ -231,21 +231,21 @@ class ClipManager {
     // Session audio-clip canonical update path (issue #1157)
     //
     // For session/autoTempo audio clips, ClipInfo holds two roles:
-    //   - DETECTED METADATA — sourceBPM, sourceNumBeats. Properties of the
-    //     audio file. Only ever written via this struct. Inspector "BPM"
-    //     edits write here (a correction, not a stretch).
+    //   - SOURCE INTERPRETATION — AudioClipModel::interpretation. The file's
+    //     musical reading, user-correctable and never clip placement.
     //   - USER INTENT — lengthBeats (timeline beats the clip occupies on
     //     the session/timeline), loopStartBeats / loopLengthBeats (sub-loop
     //     region in source-beat domain), offsetBeats, startBeats. The beat
-    //     slider edits lengthBeats and never touches sourceBPM.
+    //     slider edits lengthBeats and never touches source interpretation.
     //
     // Time-domain fields (length, startTime, offset, loopStart, loopLength)
     // are DERIVED inside applyAudioClipBeats and must not be set directly
     // by callers in this path. speedRatio is forced to 1.0.
     // =====================================================================
     struct AudioClipBeatsUpdate {
-        std::optional<double> sourceBPM;
-        std::optional<double> sourceNumBeats;
+        std::optional<double> sourceDurationSeconds;
+        std::optional<double> interpretationBpm;
+        std::optional<double> interpretationTotalBeats;
         std::optional<double> lengthBeats;
         std::optional<double> loopStartBeats;
         std::optional<double> loopLengthBeats;

--- a/magda/daw/core/ClipManager.hpp
+++ b/magda/daw/core/ClipManager.hpp
@@ -246,6 +246,7 @@ class ClipManager {
         std::optional<double> sourceDurationSeconds;
         std::optional<double> interpretationBpm;
         std::optional<double> interpretationTotalBeats;
+        bool lockInterpretationTotalBeats = false;
         std::optional<double> lengthBeats;
         std::optional<double> loopStartBeats;
         std::optional<double> loopLengthBeats;

--- a/magda/daw/core/ClipOperations.hpp
+++ b/magda/daw/core/ClipOperations.hpp
@@ -563,21 +563,6 @@ class ClipOperations {
                 clip.loopStartBeats = 0.0;
             }
 
-            // Calibrate the source interpretation BPM to the current playback
-            // speed only when it still looks like the project-tempo placeholder.
-            // Preserve real detection/user values so TE applies the intended
-            // projectBPM / source interpretation BPM stretch ratio.
-            double effectiveBPM = bpm / clip.speedRatio;
-            if (std::abs(clip.audio().interpretation.bpm - effectiveBPM) < 0.1) {
-                if (clip.audio().interpretation.bpm > 0.0 &&
-                    clip.audio().interpretation.totalBeats > 0.0) {
-                    double fileDuration = clip.audio().interpretation.totalBeats * 60.0 /
-                                          clip.audio().interpretation.bpm;
-                    clip.audio().interpretation.totalBeats = effectiveBPM * fileDuration / 60.0;
-                }
-                clip.audio().interpretation.bpm = effectiveBPM;
-            }
-
             // Force speedRatio to 1.0 (TE requirement for autoTempo)
             clip.speedRatio = 1.0;
         } else {

--- a/magda/daw/core/ClipOperations.hpp
+++ b/magda/daw/core/ClipOperations.hpp
@@ -77,8 +77,8 @@ class ClipOperations {
         // loopLengthBeats is the authoritative source of truth and should only
         // be updated when the user explicitly changes it, not during tempo-driven resizes.
 
-        if (clip.isAudio() && !clip.audioFilePath.isEmpty()) {
-            bool isAutoTempo = clip.autoTempo && clip.sourceBPM > 0.0 && bpm > 0.0;
+        if (clip.isAudio() && !clip.audio().source.filePath.isEmpty()) {
+            bool isAutoTempo = clip.autoTempo && clip.audio().interpretation.bpm > 0.0 && bpm > 0.0;
 
             if (isAutoTempo) {
                 // Auto-tempo: work in beats (authoritative), derive seconds
@@ -91,7 +91,7 @@ class ClipOperations {
                                        wrapPhase(relBeats + deltaBeats, clip.loopLengthBeats);
                 }
                 // Derive source-time seconds for paint/display
-                clip.offset = clip.offsetBeats * 60.0 / clip.sourceBPM;
+                clip.offset = clip.offsetBeats * 60.0 / clip.audio().interpretation.bpm;
                 if (!clip.loopEnabled)
                     clip.loopStart = clip.offset;
             } else {
@@ -286,7 +286,7 @@ class ClipOperations {
      * @param newLength New clip length
      */
     static inline void stretchClipFromLeft(ClipInfo& clip, double newLength) {
-        if (!clip.isAudio() || clip.audioFilePath.isEmpty()) {
+        if (!clip.isAudio() || clip.audio().source.filePath.isEmpty()) {
             resizeContainerFromLeft(clip, newLength);
             return;
         }
@@ -310,7 +310,7 @@ class ClipOperations {
      * @param newLength New clip length
      */
     static inline void stretchClipFromRight(ClipInfo& clip, double newLength) {
-        if (!clip.isAudio() || clip.audioFilePath.isEmpty()) {
+        if (!clip.isAudio() || clip.audio().source.filePath.isEmpty()) {
             resizeContainerFromRight(clip, newLength);
             return;
         }
@@ -341,37 +341,19 @@ class ClipOperations {
     }
 
     /**
-     * @brief Update autoTempo clip for a new total beat count (stretch).
-     * Adjusts sourceBPM so TE stretches the same source audio to fill newBeats.
-     * Mirrors ClipManager::setLengthBeats logic.
+     * @brief Update only the timeline placement length for an auto-tempo clip.
      */
-    static inline void stretchAutoTempoBeats(ClipInfo& clip, double newTotalBeats, double /*bpm*/) {
-        double sourceSeconds = clip.loopLength > 0.0 ? clip.loopLength : clip.getSourceLength();
-        if (sourceSeconds <= 0.0)
+    static inline void setAutoTempoPlacementLengthBeats(ClipInfo& clip, double newTotalBeats,
+                                                        double bpm) {
+        if (newTotalBeats <= 0.0)
             return;
 
-        // Compute stretch ratio from total beats (handles multiple loop cycles)
-        double oldTotalBeats =
-            clip.placement.lengthBeats > 0.0 ? clip.placement.lengthBeats : clip.loopLengthBeats;
-        if (oldTotalBeats <= 0.0)
-            return;
+        double startBeat = clip.placement.startBeat;
+        if (bpm > 0.0)
+            startBeat = clip.startTime * bpm / 60.0;
 
-        double stretchRatio = newTotalBeats / oldTotalBeats;
-
-        // Scale per-cycle beats proportionally
-        double newLoopBeats = clip.loopLengthBeats * stretchRatio;
-
-        // Update sourceBPM from new per-cycle beats
-        double oldSourceBPM = clip.sourceBPM;
-        clip.sourceBPM = newLoopBeats * 60.0 / sourceSeconds;
-
-        if (oldSourceBPM > 0.0 && clip.sourceNumBeats > 0.0) {
-            clip.sourceNumBeats *= clip.sourceBPM / oldSourceBPM;
-        }
-
-        clip.loopLengthBeats = newLoopBeats;
-        clip.setPlacementBeats(clip.placement.startBeat, newTotalBeats);
-        clip.loopStartBeats = clip.loopStart * clip.sourceBPM / 60.0;
+        clip.setPlacementBeats(startBeat, newTotalBeats);
+        clip.deriveTimesFromBeats(bpm);
     }
 
     /**
@@ -387,7 +369,7 @@ class ClipOperations {
         clip.length = newLength;
         if (clip.autoTempo && bpm > 0.0) {
             double newBeats = newLength * bpm / 60.0;
-            stretchAutoTempoBeats(clip, newBeats, bpm);
+            setAutoTempoPlacementLengthBeats(clip, newBeats, bpm);
         } else {
             clip.speedRatio = newSpeedRatio;
         }
@@ -409,7 +391,7 @@ class ClipOperations {
         clip.startTime = rightEdge - newLength;
         if (clip.autoTempo && bpm > 0.0) {
             double newBeats = newLength * bpm / 60.0;
-            stretchAutoTempoBeats(clip, newBeats, bpm);
+            setAutoTempoPlacementLengthBeats(clip, newBeats, bpm);
         } else {
             clip.speedRatio = newSpeedRatio;
         }
@@ -452,13 +434,13 @@ class ClipOperations {
         if (clip.loopLengthBeats > 0.0) {
             double start = clip.loopStartBeats;
             double length = clip.loopLengthBeats;
-            // Clamp to sourceNumBeats (TE can't read beyond the file)
-            if (clip.sourceNumBeats > 0.0) {
-                if (length > clip.sourceNumBeats) {
-                    length = clip.sourceNumBeats;
+            // Clamp to the interpreted source beat extent (TE can't read beyond the file)
+            if (clip.audio().interpretation.totalBeats > 0.0) {
+                if (length > clip.audio().interpretation.totalBeats) {
+                    length = clip.audio().interpretation.totalBeats;
                     start = 0.0;
-                } else if (start + length > clip.sourceNumBeats) {
-                    start = clip.sourceNumBeats - length;
+                } else if (start + length > clip.audio().interpretation.totalBeats) {
+                    start = clip.audio().interpretation.totalBeats - length;
                     if (start < 0.0)
                         start = 0.0;
                 }
@@ -466,21 +448,21 @@ class ClipOperations {
             return {start, length};
         }
 
-        // Derive from source-time seconds using sourceBPM
-        if (clip.sourceBPM > 0.0) {
-            double srcBps = clip.sourceBPM / 60.0;
+        // Derive from source-time seconds using the source interpretation BPM
+        if (clip.audio().interpretation.bpm > 0.0) {
+            double srcBps = clip.audio().interpretation.bpm / 60.0;
             double start = clip.loopStart * srcBps;
             double length = clip.loopLength * srcBps;
 
             // TE's setLoopRangeBeats clamps end to loopInfo.getNumBeats().
             // In time-based mode loops can wrap past file end, but beat-based
             // mode cannot. Shift the start back so the full region fits.
-            if (clip.sourceNumBeats > 0.0) {
-                if (length > clip.sourceNumBeats) {
-                    length = clip.sourceNumBeats;
+            if (clip.audio().interpretation.totalBeats > 0.0) {
+                if (length > clip.audio().interpretation.totalBeats) {
+                    length = clip.audio().interpretation.totalBeats;
                     start = 0.0;
-                } else if (start + length > clip.sourceNumBeats) {
-                    start = clip.sourceNumBeats - length;
+                } else if (start + length > clip.audio().interpretation.totalBeats) {
+                    start = clip.audio().interpretation.totalBeats - length;
                     if (start < 0.0)
                         start = 0.0;
                 }
@@ -542,8 +524,8 @@ class ClipOperations {
                 clip.timeStretchMode = 4;  // soundtouchBetter
 
             // Convert current offset to beats
-            if (clip.sourceBPM > 0.0)
-                clip.offsetBeats = clip.offset * clip.sourceBPM / 60.0;
+            if (clip.audio().interpretation.bpm > 0.0)
+                clip.offsetBeats = clip.offset * clip.audio().interpretation.bpm / 60.0;
 
             // Convert current timeline position to beats
             clip.setPlacementBeats((clip.startTime * bpm) / 60.0, clip.placement.lengthBeats);
@@ -555,44 +537,45 @@ class ClipOperations {
                 clip.setLoopLengthFromTimeline(clip.length);
             }
 
-            // Issue #1157: when the file carries tempo metadata (sourceBPM +
-            // sourceNumBeats from TE's loopInfo), default lengthBeats to the
-            // file's intrinsic beat count so a freshly-dropped loop becomes
-            // exactly its musical length on toggling BEAT (e.g. a 4-bar loop
-            // is 16 beats long, not 24 derived from timeline-seconds × project
-            // BPM). For files without metadata, fall back to the
-            // length × projectBPM derivation.
-            if (clip.sourceNumBeats > 0.0)
-                clip.setPlacementBeats(clip.placement.startBeat, clip.sourceNumBeats);
+            // Issue #1157: when the file carries source interpretation beats,
+            // default placement length to that musical extent so a
+            // freshly-dropped loop becomes exactly its natural length on
+            // toggling BEAT. For files without interpretation data, fall back
+            // to the timeline length converted at project BPM.
+            if (clip.audio().interpretation.totalBeats > 0.0)
+                clip.setPlacementBeats(clip.placement.startBeat,
+                                       clip.audio().interpretation.totalBeats);
             else
                 clip.setPlacementBeats(clip.placement.startBeat, clip.getLengthInBeats(bpm));
 
-            // loopLengthBeats lives in the SOURCE-beat domain, so it is
-            // derived from sourceBPM (not projectBPM). When sourceBPM is
-            // unknown we fall back to projectBPM — the two agree until
-            // detection / metadata lands.
-            double srcBpm = clip.sourceBPM > 0.0 ? clip.sourceBPM : bpm;
+            // loopLengthBeats lives in the source-beat domain, so it is
+            // derived from source interpretation BPM. When that BPM is unknown
+            // we fall back to project BPM until detection/metadata lands.
+            double srcBpm =
+                clip.audio().interpretation.bpm > 0.0 ? clip.audio().interpretation.bpm : bpm;
             if (clip.loopEnabled && clip.loopLength > 0.0) {
                 clip.loopLengthBeats = clip.loopLength * srcBpm / 60.0;
                 clip.loopStartBeats = clip.loopStart * srcBpm / 60.0;
             } else {
-                clip.loopLengthBeats =
-                    clip.sourceNumBeats > 0.0 ? clip.sourceNumBeats : clip.placement.lengthBeats;
+                clip.loopLengthBeats = clip.audio().interpretation.totalBeats > 0.0
+                                           ? clip.audio().interpretation.totalBeats
+                                           : clip.placement.lengthBeats;
                 clip.loopStartBeats = 0.0;
             }
 
-            // Calibrate sourceBPM to the current playback speed so that enabling
-            // autoTempo doesn't change the audible playback speed — but only when
-            // sourceBPM matches the project BPM (i.e., was defaulted, not detected).
-            // When sourceBPM is from real BPM detection, preserve it so TE applies
-            // the correct stretch ratio (projectBPM / sourceBPM).
+            // Calibrate the source interpretation BPM to the current playback
+            // speed only when it still looks like the project-tempo placeholder.
+            // Preserve real detection/user values so TE applies the intended
+            // projectBPM / source interpretation BPM stretch ratio.
             double effectiveBPM = bpm / clip.speedRatio;
-            if (std::abs(clip.sourceBPM - effectiveBPM) < 0.1) {
-                if (clip.sourceBPM > 0.0 && clip.sourceNumBeats > 0.0) {
-                    double fileDuration = clip.sourceNumBeats * 60.0 / clip.sourceBPM;
-                    clip.sourceNumBeats = effectiveBPM * fileDuration / 60.0;
+            if (std::abs(clip.audio().interpretation.bpm - effectiveBPM) < 0.1) {
+                if (clip.audio().interpretation.bpm > 0.0 &&
+                    clip.audio().interpretation.totalBeats > 0.0) {
+                    double fileDuration = clip.audio().interpretation.totalBeats * 60.0 /
+                                          clip.audio().interpretation.bpm;
+                    clip.audio().interpretation.totalBeats = effectiveBPM * fileDuration / 60.0;
                 }
-                clip.sourceBPM = effectiveBPM;
+                clip.audio().interpretation.bpm = effectiveBPM;
             }
 
             // Force speedRatio to 1.0 (TE requirement for autoTempo)

--- a/magda/daw/core/ClipPropertyCommands.hpp
+++ b/magda/daw/core/ClipPropertyCommands.hpp
@@ -68,6 +68,53 @@ class SetClipOffsetCommand : public UndoableCommand {
 };
 
 /**
+ * @brief Command for setting audio loop phase (source-time seconds relative to loop start).
+ */
+class SetClipLoopPhaseCommand : public UndoableCommand {
+  public:
+    SetClipLoopPhaseCommand(ClipId clipId, double newPhase) : clipId_(clipId), newPhase_(newPhase) {
+        auto* clip = ClipManager::getInstance().getClip(clipId);
+        if (clip)
+            oldPhase_ = (clip->isMidi()) ? clip->midiOffset : clip->getLoopPhase();
+    }
+
+    void execute() override {
+        if (auto* clip = ClipManager::getInstance().getClip(clipId_)) {
+            if (clip->isMidi()) {
+                ClipManager::getInstance().setOffset(clipId_, newPhase_);
+            } else {
+                ClipManager::getInstance().setLoopPhase(clipId_, newPhase_);
+            }
+        }
+    }
+    void undo() override {
+        if (auto* clip = ClipManager::getInstance().getClip(clipId_)) {
+            if (clip->isMidi()) {
+                ClipManager::getInstance().setOffset(clipId_, oldPhase_);
+            } else {
+                ClipManager::getInstance().setLoopPhase(clipId_, oldPhase_);
+            }
+        }
+    }
+    juce::String getDescription() const override {
+        return "Set Clip Loop Phase";
+    }
+
+    bool canMergeWith(const UndoableCommand* other) const override {
+        if (auto* o = dynamic_cast<const SetClipLoopPhaseCommand*>(other))
+            return o->clipId_ == clipId_;
+        return false;
+    }
+    void mergeWith(const UndoableCommand* other) override {
+        newPhase_ = static_cast<const SetClipLoopPhaseCommand*>(other)->newPhase_;
+    }
+
+  private:
+    ClipId clipId_;
+    double oldPhase_ = 0.0, newPhase_;
+};
+
+/**
  * @brief Command for setting a clip's loop start (source-time seconds).
  *
  * Used for inspector edits where the caller separately handles offset/phase

--- a/magda/daw/engine/TracktionEngineWrapperRecording.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperRecording.cpp
@@ -96,13 +96,13 @@ void TracktionEngineWrapper::recordingFinished(
             ClipId clipId = clipManager.createAudioClip(trackId, startSeconds, lengthSeconds,
                                                         audioFilePath, ClipView::Arrangement);
 
-            // Set sourceBPM to the project tempo — we know the exact BPM the clip was
-            // recorded at, so skip unreliable auto-detection in syncClipToEngine.
+            // Set source interpretation BPM to the project tempo — we know the exact BPM the clip
+            // was recorded at, so skip unreliable auto-detection in syncClipToEngine.
             if (auto* newClip = clipManager.getClip(clipId)) {
                 double projectBPM = ProjectManager::getInstance().getCurrentProjectInfo().tempo;
                 if (projectBPM > 0.0) {
-                    newClip->sourceBPM = projectBPM;
-                    newClip->sourceNumBeats = lengthSeconds * projectBPM / 60.0;
+                    newClip->audio().interpretation.bpm = projectBPM;
+                    newClip->audio().interpretation.totalBeats = lengthSeconds * projectBPM / 60.0;
                 }
             }
 

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -500,10 +500,12 @@ void ProjectManager::migrateMediaFiles(const juce::File& oldDir, const juce::Fil
     auto& clipManager = ClipManager::getInstance();
     auto updateClipPaths = [&](const std::vector<ClipInfo>& clips) {
         for (const auto& clipInfo : clips) {
-            if (clipInfo.audioFilePath.isNotEmpty() && clipInfo.audioFilePath.startsWith(oldPath)) {
+            if (clipInfo.isAudio() && clipInfo.audio().source.filePath.isNotEmpty() &&
+                clipInfo.audio().source.filePath.startsWith(oldPath)) {
                 auto* clip = clipManager.getClip(clipInfo.id);
                 if (clip) {
-                    clip->audioFilePath = clip->audioFilePath.replace(oldPath, newPath, false);
+                    clip->audio().source.filePath =
+                        clip->audio().source.filePath.replace(oldPath, newPath, false);
                 }
             }
         }

--- a/magda/daw/project/serialization/ClipSerializer.cpp
+++ b/magda/daw/project/serialization/ClipSerializer.cpp
@@ -79,25 +79,31 @@ juce::var ProjectSerializer::serializeClipInfo(const ClipInfo& clip) {
     if (clip.grooveStrength > 0.0f)
         obj->setProperty("grooveStrength", clip.grooveStrength);
 
-    // Audio source properties. These describe source content only, never
-    // timeline placement.
-    if (clip.audioFilePath.isNotEmpty()) {
+    if (clip.isAudio() && clip.audio().source.filePath.isNotEmpty()) {
+        auto* audioObj = new juce::DynamicObject();
+
         auto* sourceObj = new juce::DynamicObject();
-        sourceObj->setProperty("filePath", clip.audioFilePath);
-        sourceObj->setProperty("offsetSeconds", clip.offset);
-        sourceObj->setProperty("offsetBeats", clip.offsetBeats);
-        sourceObj->setProperty("loopStartSeconds", clip.loopStart);
-        sourceObj->setProperty("loopLengthSeconds", clip.loopLength);
-        sourceObj->setProperty("loopStartBeats", clip.loopStartBeats);
-        sourceObj->setProperty("loopLengthBeats", clip.loopLengthBeats);
-        sourceObj->setProperty("speedRatio", clip.speedRatio);
-        if (clip.sourceNumBeats > 0.0)
-            sourceObj->setProperty("sourceNumBeats", clip.sourceNumBeats);
-        if (clip.sourceBPM > 0.0)
-            sourceObj->setProperty("sourceBPM", clip.sourceBPM);
+        sourceObj->setProperty("filePath", clip.audio().source.filePath);
+        sourceObj->setProperty("durationSeconds", clip.audio().source.durationSeconds);
+        audioObj->setProperty("source", juce::var(sourceObj));
+
+        auto* interpretationObj = new juce::DynamicObject();
+        interpretationObj->setProperty("bpm", clip.audio().interpretation.bpm);
+        interpretationObj->setProperty("totalBeats", clip.audio().interpretation.totalBeats);
+        audioObj->setProperty("interpretation", juce::var(interpretationObj));
+
+        auto* playbackObj = new juce::DynamicObject();
+        playbackObj->setProperty("offsetSeconds", clip.offset);
+        playbackObj->setProperty("offsetBeats", clip.offsetBeats);
+        playbackObj->setProperty("loopStartSeconds", clip.loopStart);
+        playbackObj->setProperty("loopLengthSeconds", clip.loopLength);
+        playbackObj->setProperty("loopStartBeats", clip.loopStartBeats);
+        playbackObj->setProperty("loopLengthBeats", clip.loopLengthBeats);
+        playbackObj->setProperty("speedRatio", clip.speedRatio);
+        audioObj->setProperty("playback", juce::var(playbackObj));
 
         if (clip.warpEnabled) {
-            sourceObj->setProperty("warpEnabled", clip.warpEnabled);
+            audioObj->setProperty("warpEnabled", clip.warpEnabled);
 
             // Serialize warp markers
             if (!clip.warpMarkers.empty()) {
@@ -108,16 +114,16 @@ juce::var ProjectSerializer::serializeClipInfo(const ClipInfo& clip) {
                     wmObj->setProperty("warpTime", wm.warpTime);
                     warpArray.add(juce::var(wmObj));
                 }
-                sourceObj->setProperty("warpMarkers", warpArray);
+                audioObj->setProperty("warpMarkers", warpArray);
             }
         }
         if (clip.analogPitch) {
-            sourceObj->setProperty("analogPitch", clip.analogPitch);
+            audioObj->setProperty("analogPitch", clip.analogPitch);
         }
         if (clip.timeStretchMode != 0) {
-            sourceObj->setProperty("timeStretchMode", clip.timeStretchMode);
+            audioObj->setProperty("timeStretchMode", clip.timeStretchMode);
         }
-        obj->setProperty("audioSource", juce::var(sourceObj));
+        obj->setProperty("audio", juce::var(audioObj));
     }
 
     // MIDI notes
@@ -254,26 +260,36 @@ bool ProjectSerializer::deserializeClipInfo(const juce::var& json, ClipInfo& out
     outClip.grooveStrength =
         static_cast<float>(static_cast<double>(obj->getProperty("grooveStrength")));
 
-    // Audio source properties
-    if (auto* sourceObj = obj->getProperty("audioSource").getDynamicObject()) {
-        outClip.audioFilePath = sourceObj->getProperty("filePath").toString();
-        outClip.offset = sourceObj->getProperty("offsetSeconds");
-        outClip.offsetBeats = sourceObj->getProperty("offsetBeats");
-        outClip.loopStart = sourceObj->getProperty("loopStartSeconds");
-        outClip.loopLength = sourceObj->getProperty("loopLengthSeconds");
-        outClip.loopStartBeats = sourceObj->getProperty("loopStartBeats");
-        outClip.loopLengthBeats = sourceObj->getProperty("loopLengthBeats");
-        outClip.speedRatio = sourceObj->getProperty("speedRatio");
+    if (auto* audioObj = obj->getProperty("audio").getDynamicObject()) {
+        auto* sourceObj = audioObj->getProperty("source").getDynamicObject();
+        auto* interpretationObj = audioObj->getProperty("interpretation").getDynamicObject();
+        auto* playbackObj = audioObj->getProperty("playback").getDynamicObject();
+
+        if (sourceObj == nullptr || interpretationObj == nullptr || playbackObj == nullptr) {
+            lastError_ = "Audio clip is missing source, interpretation, or playback";
+            return false;
+        }
+
+        outClip.audio().source.filePath = sourceObj->getProperty("filePath").toString();
+        outClip.audio().source.durationSeconds = sourceObj->getProperty("durationSeconds");
+        outClip.audio().interpretation.bpm = interpretationObj->getProperty("bpm");
+        outClip.audio().interpretation.totalBeats = interpretationObj->getProperty("totalBeats");
+
+        outClip.offset = playbackObj->getProperty("offsetSeconds");
+        outClip.offsetBeats = playbackObj->getProperty("offsetBeats");
+        outClip.loopStart = playbackObj->getProperty("loopStartSeconds");
+        outClip.loopLength = playbackObj->getProperty("loopLengthSeconds");
+        outClip.loopStartBeats = playbackObj->getProperty("loopStartBeats");
+        outClip.loopLengthBeats = playbackObj->getProperty("loopLengthBeats");
+        outClip.speedRatio = playbackObj->getProperty("speedRatio");
         if (outClip.speedRatio <= 0.0)
             outClip.speedRatio = 1.0;
-        outClip.sourceNumBeats = sourceObj->getProperty("sourceNumBeats");
-        outClip.sourceBPM = sourceObj->getProperty("sourceBPM");
-        outClip.warpEnabled = static_cast<bool>(sourceObj->getProperty("warpEnabled"));
-        outClip.analogPitch = static_cast<bool>(sourceObj->getProperty("analogPitch"));
-        outClip.timeStretchMode = sourceObj->getProperty("timeStretchMode");
+        outClip.warpEnabled = static_cast<bool>(audioObj->getProperty("warpEnabled"));
+        outClip.analogPitch = static_cast<bool>(audioObj->getProperty("analogPitch"));
+        outClip.timeStretchMode = audioObj->getProperty("timeStretchMode");
 
         // Warp markers
-        auto warpMarkersVar = sourceObj->getProperty("warpMarkers");
+        auto warpMarkersVar = audioObj->getProperty("warpMarkers");
         if (warpMarkersVar.isArray()) {
             auto* arr = warpMarkersVar.getArray();
             for (const auto& wmVar : *arr) {

--- a/magda/daw/project/serialization/ClipSerializer.cpp
+++ b/magda/daw/project/serialization/ClipSerializer.cpp
@@ -90,6 +90,8 @@ juce::var ProjectSerializer::serializeClipInfo(const ClipInfo& clip) {
         auto* interpretationObj = new juce::DynamicObject();
         interpretationObj->setProperty("bpm", clip.audio().interpretation.bpm);
         interpretationObj->setProperty("totalBeats", clip.audio().interpretation.totalBeats);
+        interpretationObj->setProperty("totalBeatsLocked",
+                                       clip.audio().interpretation.totalBeatsLocked);
         audioObj->setProperty("interpretation", juce::var(interpretationObj));
 
         auto* playbackObj = new juce::DynamicObject();
@@ -274,6 +276,8 @@ bool ProjectSerializer::deserializeClipInfo(const juce::var& json, ClipInfo& out
         outClip.audio().source.durationSeconds = sourceObj->getProperty("durationSeconds");
         outClip.audio().interpretation.bpm = interpretationObj->getProperty("bpm");
         outClip.audio().interpretation.totalBeats = interpretationObj->getProperty("totalBeats");
+        outClip.audio().interpretation.totalBeatsLocked =
+            static_cast<bool>(interpretationObj->getProperty("totalBeatsLocked"));
 
         outClip.offset = playbackObj->getProperty("offsetSeconds");
         outClip.offsetBeats = playbackObj->getProperty("offsetBeats");

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -194,7 +194,7 @@ void ClipComponent::paint(juce::Graphics& g) {
 size_t ClipComponent::computeWaveformHash(const ClipInfo& clip) {
     size_t h = 0;
     auto combine = [&](size_t v) { h ^= v + 0x9e3779b9 + (h << 6) + (h >> 2); };
-    combine(std::hash<juce::String>{}(clip.audioFilePath));
+    combine(std::hash<juce::String>{}(clip.audio().source.filePath));
     combine(std::hash<double>{}(clip.length));
     combine(std::hash<double>{}(clip.offset));
     combine(std::hash<double>{}(clip.speedRatio));
@@ -276,7 +276,7 @@ void ClipComponent::paintAudioClipDirect(juce::Graphics& g, const ClipInfo& clip
     float gainLinear = juce::Decibels::decibelsToGain(clip.volumeDB + clip.gainDB);
 
     double fileDuration = 0.0;
-    auto* thumbnail = thumbnailManager.getThumbnail(clip.audioFilePath);
+    auto* thumbnail = thumbnailManager.getThumbnail(clip.audio().source.filePath);
     if (thumbnail)
         fileDuration = thumbnail->getTotalLength();
 
@@ -331,8 +331,9 @@ void ClipComponent::paintAudioClipDirect(juce::Graphics& g, const ClipInfo& clip
             double finalSrcEnd = fileDuration > 0.0 ? juce::jmin(srcEnd, fileDuration) : srcEnd;
             if (finalSrcEnd > finalSrcStart &&
                 clipToVisible(drawRect, finalSrcStart, finalSrcEnd)) {
-                thumbnailManager.drawWaveform(g, drawRect, clip.audioFilePath, finalSrcStart,
-                                              finalSrcEnd, waveColour, gainLinear, true, selected);
+                thumbnailManager.drawWaveform(g, drawRect, clip.audio().source.filePath,
+                                              finalSrcStart, finalSrcEnd, waveColour, gainLinear,
+                                              true, selected);
             }
         }
     } else if (di.isLooped()) {
@@ -372,8 +373,9 @@ void ClipComponent::paintAudioClipDirect(juce::Graphics& g, const ClipInfo& clip
                 tileFileEnd = tileFileStart + tileSourceLen * fraction;
             }
             if (clipToVisible(drawRect, tileFileStart, tileFileEnd))
-                thumbnailManager.drawWaveform(g, drawRect, clip.audioFilePath, tileFileStart,
-                                              tileFileEnd, waveColour, gainLinear, true, selected);
+                thumbnailManager.drawWaveform(g, drawRect, clip.audio().source.filePath,
+                                              tileFileStart, tileFileEnd, waveColour, gainLinear,
+                                              true, selected);
             timePos += tileFullDuration;
         }
     } else {
@@ -387,8 +389,8 @@ void ClipComponent::paintAudioClipDirect(juce::Graphics& g, const ClipInfo& clip
         auto drawRect = juce::Rectangle<int>(waveformArea.getX(), waveformArea.getY(), drawWidth,
                                              waveformArea.getHeight());
         if (clipToVisible(drawRect, fileStart, fileEnd))
-            thumbnailManager.drawWaveform(g, drawRect, clip.audioFilePath, fileStart, fileEnd,
-                                          waveColour, gainLinear, true, selected);
+            thumbnailManager.drawWaveform(g, drawRect, clip.audio().source.filePath, fileStart,
+                                          fileEnd, waveColour, gainLinear, true, selected);
     }
 
     if (clip.isReversed)
@@ -410,8 +412,9 @@ void ClipComponent::paintAudioClip(juce::Graphics& g, const ClipInfo& clip,
     }
 
     // Poll until thumbnail is loaded
-    if (clip.audioFilePath.isNotEmpty()) {
-        auto* thumb = AudioThumbnailManager::getInstance().getThumbnail(clip.audioFilePath);
+    if (clip.audio().source.filePath.isNotEmpty()) {
+        auto* thumb =
+            AudioThumbnailManager::getInstance().getThumbnail(clip.audio().source.filePath);
         if (thumb == nullptr || !thumb->isFullyLoaded()) {
             if (!isTimerRunning())
                 startTimer(100);
@@ -424,7 +427,7 @@ void ClipComponent::paintAudioClip(juce::Graphics& g, const ClipInfo& clip,
     g.setColour(bgColour);
     g.fillRoundedRectangle(bounds.toFloat(), CORNER_RADIUS);
 
-    if (clip.audioFilePath.isNotEmpty())
+    if (clip.audio().source.filePath.isNotEmpty())
         paintAudioClipDirect(g, clip, waveformArea, clipDisplayLength);
 
     g.setColour(clip.colour.withAlpha(0.45f));
@@ -960,8 +963,9 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
 
     // Cache file duration for resize clamping
     dragStartFileDuration_ = 0.0;
-    if (clip->isAudio() && clip->audioFilePath.isNotEmpty()) {
-        auto* thumbnail = AudioThumbnailManager::getInstance().getThumbnail(clip->audioFilePath);
+    if (clip->isAudio() && clip->audio().source.filePath.isNotEmpty()) {
+        auto* thumbnail =
+            AudioThumbnailManager::getInstance().getThumbnail(clip->audio().source.filePath);
         if (thumbnail)
             dragStartFileDuration_ = thumbnail->getTotalLength();
     }
@@ -1057,7 +1061,7 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
     // Shift+edge = stretch mode (time-stretches audio source or scales MIDI notes)
     if (isOnLeftEdge(e.x)) {
         if (e.mods.isShiftDown() &&
-            ((clip->isAudio() && clip->audioFilePath.isNotEmpty()) || clip->isMidi())) {
+            ((clip->isAudio() && clip->audio().source.filePath.isNotEmpty()) || clip->isMidi())) {
             dragMode_ = DragMode::StretchLeft;
             dragStartSpeedRatio_ = clip->speedRatio;
             dragStartClipSnapshot_ = *clip;
@@ -1068,7 +1072,7 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
         }
     } else if (isOnRightEdge(e.x)) {
         if (e.mods.isShiftDown() &&
-            ((clip->isAudio() && clip->audioFilePath.isNotEmpty()) || clip->isMidi())) {
+            ((clip->isAudio() && clip->audio().source.filePath.isNotEmpty()) || clip->isMidi())) {
             dragMode_ = DragMode::StretchRight;
             dragStartSpeedRatio_ = clip->speedRatio;
             dragStartClipSnapshot_ = *clip;
@@ -1077,6 +1081,7 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
             dragStartClipSnapshot_ = *clip;
             // Capture original lengths of other selected clips for multi-resize
             dragStartSelectedLengths_.clear();
+            dragStartSelectedClipSnapshots_.clear();
             multiResizeMaxDelta_ = std::numeric_limits<double>::max();
             const auto& selected = SelectionManager::getInstance().getSelectedClips();
             if (selected.size() > 1 && selected.count(clipId_)) {
@@ -1085,8 +1090,10 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
                     const auto* c = cm.getClip(cid);
                     if (!c)
                         continue;
-                    if (cid != clipId_)
+                    if (cid != clipId_) {
                         dragStartSelectedLengths_[cid] = c->length;
+                        dragStartSelectedClipSnapshots_[cid] = *c;
+                    }
 
                     // Find max resize before hitting next non-selected clip
                     auto trackClips = cm.getClipsOnTrack(c->trackId);
@@ -1302,6 +1309,7 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
                     mutableClip->loopStart = resizePreviewClip_.loopStart;
                     mutableClip->startBeats = resizePreviewClip_.startBeats;
                     mutableClip->lengthBeats = resizePreviewClip_.lengthBeats;
+                    mutableClip->placement = resizePreviewClip_.placement;
                     mutableClip->midiOffset = resizePreviewClip_.midiOffset;
                     cm.forceNotifyClipPropertyChanged(clipId_);
                 }
@@ -1699,6 +1707,7 @@ void ClipComponent::mouseUp(const juce::MouseEvent& e) {
                         c->midiTrimOffset = dragStartClipSnapshot_.midiTrimOffset;
                         c->startBeats = dragStartClipSnapshot_.startBeats;
                         c->lengthBeats = dragStartClipSnapshot_.lengthBeats;
+                        c->placement = dragStartClipSnapshot_.placement;
                     }
                 }
 
@@ -1726,10 +1735,19 @@ void ClipComponent::mouseUp(const juce::MouseEvent& e) {
                     auto& cm = ClipManager::getInstance();
                     if (auto* c = cm.getClip(clipId_)) {
                         c->length = dragStartLength_;
+                        c->startBeats = dragStartClipSnapshot_.startBeats;
+                        c->lengthBeats = dragStartClipSnapshot_.lengthBeats;
+                        c->placement = dragStartClipSnapshot_.placement;
                     }
                     for (auto& [cid, origLen] : dragStartSelectedLengths_) {
                         if (auto* c = cm.getClip(cid)) {
                             c->length = origLen;
+                            if (auto it = dragStartSelectedClipSnapshots_.find(cid);
+                                it != dragStartSelectedClipSnapshots_.end()) {
+                                c->startBeats = it->second.startBeats;
+                                c->lengthBeats = it->second.lengthBeats;
+                                c->placement = it->second.placement;
+                            }
                         }
                     }
                 }
@@ -1738,6 +1756,7 @@ void ClipComponent::mouseUp(const juce::MouseEvent& e) {
                     onClipResized(clipId_, finalLength, false);
                 }
                 dragStartSelectedLengths_.clear();
+                dragStartSelectedClipSnapshots_.clear();
                 break;
             }
 

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -204,6 +204,8 @@ size_t ClipComponent::computeWaveformHash(const ClipInfo& clip) {
     combine(std::hash<bool>{}(clip.loopEnabled));
     combine(std::hash<double>{}(clip.loopStart));
     combine(std::hash<double>{}(clip.loopLength));
+    combine(std::hash<double>{}(clip.loopLengthBeats));
+    combine(std::hash<double>{}(clip.audio().interpretation.totalBeats));
     combine(std::hash<bool>{}(clip.warpEnabled));
     combine(std::hash<bool>{}(clip.autoTempo));
     combine(std::hash<double>{}(clip.fadeIn));
@@ -337,7 +339,35 @@ void ClipComponent::paintAudioClipDirect(juce::Graphics& g, const ClipInfo& clip
             }
         }
     } else if (di.isLooped()) {
+        double sourceDurationForBeats = clip.audio().source.durationSeconds;
+        if (sourceDurationForBeats <= 0.0 && fileDuration > 0.0)
+            sourceDurationForBeats = fileDuration;
+        if (sourceDurationForBeats <= 0.0)
+            sourceDurationForBeats = di.sourceLength;
+
+        auto timelineDeltaToPreviewSource = [&](double timelineDelta) {
+            if (clip.autoTempo && clip.audio().interpretation.totalBeats > 0.0 &&
+                sourceDurationForBeats > 0.0 && tempo > 0.0) {
+                double projectBeats = timelineDelta * tempo / 60.0;
+                return projectBeats * sourceDurationForBeats /
+                       clip.audio().interpretation.totalBeats;
+            }
+            return di.timelineToSource(timelineDelta);
+        };
+
+        auto sourceDeltaToPreviewTimeline = [&](double sourceDelta) {
+            if (clip.autoTempo && clip.audio().interpretation.totalBeats > 0.0 &&
+                sourceDurationForBeats > 0.0 && tempo > 0.0) {
+                double sourceBeats =
+                    sourceDelta * clip.audio().interpretation.totalBeats / sourceDurationForBeats;
+                return sourceBeats * 60.0 / tempo;
+            }
+            return di.sourceToTimeline(sourceDelta);
+        };
+
         double loopCycle = di.loopLengthSeconds;
+        if (clip.autoTempo && clip.loopLengthBeats > 0.0 && tempo > 0.0)
+            loopCycle = clip.loopLengthBeats * 60.0 / tempo;
         double fileStart = di.loopStart;
         double fileEnd = di.loopStart + di.sourceLength;
         if (fileDuration > 0.0 && fileEnd > fileDuration)
@@ -347,7 +377,7 @@ void ClipComponent::paintAudioClipDirect(juce::Graphics& g, const ClipInfo& clip
             phaseSource = wrapPhase(resizePreviewClip_.offset - resizePreviewClip_.loopStart,
                                     di.sourceLength);
         }
-        double phaseTimeline = di.sourceToTimeline(phaseSource);
+        double phaseTimeline = sourceDeltaToPreviewTimeline(phaseSource);
         bool isFirstTile = (phaseTimeline > 0.001);
 
         double timePos = 0.0;
@@ -356,9 +386,11 @@ void ClipComponent::paintAudioClipDirect(juce::Graphics& g, const ClipInfo& clip
             double tileFullDuration = loopCycle;
             if (isFirstTile) {
                 tileFileStart = fileStart + phaseSource;
-                tileFullDuration = loopCycle - phaseTimeline;
+                tileFullDuration = sourceDeltaToPreviewTimeline(fileEnd - tileFileStart);
                 isFirstTile = false;
             }
+            if (tileFullDuration <= 0.0001)
+                break;
             double cycleEnd = juce::jmin(timePos + tileFullDuration, clipDisplayLength);
             int drawX = waveformArea.getX() + static_cast<int>(timePos * pixelsPerSecond + 0.5);
             int drawRight =
@@ -366,12 +398,8 @@ void ClipComponent::paintAudioClipDirect(juce::Graphics& g, const ClipInfo& clip
             auto drawRect = juce::Rectangle<int>(drawX, waveformArea.getY(), drawRight - drawX,
                                                  waveformArea.getHeight());
             double tileDuration = cycleEnd - timePos;
-            double tileSourceLen = fileEnd - tileFileStart;
-            double tileFileEnd = tileFileStart + tileSourceLen;
-            if (tileDuration < tileFullDuration - 0.0001) {
-                double fraction = tileDuration / tileFullDuration;
-                tileFileEnd = tileFileStart + tileSourceLen * fraction;
-            }
+            double tileFileEnd = tileFileStart + timelineDeltaToPreviewSource(tileDuration);
+            tileFileEnd = juce::jmin(tileFileEnd, fileEnd);
             if (clipToVisible(drawRect, tileFileStart, tileFileEnd))
                 thumbnailManager.drawWaveform(g, drawRect, clip.audio().source.filePath,
                                               tileFileStart, tileFileEnd, waveColour, gainLinear,

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -392,18 +392,44 @@ void ClipComponent::paintAudioClipDirect(juce::Graphics& g, const ClipInfo& clip
             if (tileFullDuration <= 0.0001)
                 break;
             double cycleEnd = juce::jmin(timePos + tileFullDuration, clipDisplayLength);
-            int drawX = waveformArea.getX() + static_cast<int>(timePos * pixelsPerSecond + 0.5);
-            int drawRight =
-                waveformArea.getX() + static_cast<int>(cycleEnd * pixelsPerSecond + 0.5);
-            auto drawRect = juce::Rectangle<int>(drawX, waveformArea.getY(), drawRight - drawX,
-                                                 waveformArea.getHeight());
-            double tileDuration = cycleEnd - timePos;
-            double tileFileEnd = tileFileStart + timelineDeltaToPreviewSource(tileDuration);
-            tileFileEnd = juce::jmin(tileFileEnd, fileEnd);
-            if (clipToVisible(drawRect, tileFileStart, tileFileEnd))
-                thumbnailManager.drawWaveform(g, drawRect, clip.audio().source.filePath,
-                                              tileFileStart, tileFileEnd, waveColour, gainLinear,
-                                              true, selected);
+            double remainingTileDuration = cycleEnd - timePos;
+            double segmentTime = timePos;
+            double segmentSourceStart = tileFileStart;
+            int safety = 0;
+            while (remainingTileDuration > 0.0001 && safety++ < 128) {
+                if (segmentSourceStart >= fileEnd - 0.0001)
+                    segmentSourceStart = fileStart;
+
+                double remainingSource = fileEnd - segmentSourceStart;
+                double fullSegmentDuration = sourceDeltaToPreviewTimeline(remainingSource);
+                if (remainingSource <= 0.0001 || fullSegmentDuration <= 0.0001)
+                    break;
+
+                double segmentDuration = juce::jmin(remainingTileDuration, fullSegmentDuration);
+                double segmentEnd = segmentTime + segmentDuration;
+                int segmentX =
+                    waveformArea.getX() + static_cast<int>(segmentTime * pixelsPerSecond + 0.5);
+                int segmentRight =
+                    waveformArea.getX() + static_cast<int>(segmentEnd * pixelsPerSecond + 0.5);
+                auto segmentRect =
+                    juce::Rectangle<int>(segmentX, waveformArea.getY(), segmentRight - segmentX,
+                                         waveformArea.getHeight());
+
+                double segmentSourceEnd =
+                    segmentSourceStart + timelineDeltaToPreviewSource(segmentDuration);
+                segmentSourceEnd = juce::jmin(segmentSourceEnd, fileEnd);
+                if (clipToVisible(segmentRect, segmentSourceStart, segmentSourceEnd))
+                    thumbnailManager.drawWaveform(g, segmentRect, clip.audio().source.filePath,
+                                                  segmentSourceStart, segmentSourceEnd, waveColour,
+                                                  gainLinear, true, selected);
+
+                segmentTime = segmentEnd;
+                remainingTileDuration -= segmentDuration;
+                if (segmentDuration >= fullSegmentDuration - 0.0001)
+                    segmentSourceStart = fileStart;
+                else
+                    segmentSourceStart = segmentSourceEnd;
+            }
             timePos += tileFullDuration;
         }
     } else {

--- a/magda/daw/ui/components/clips/ClipComponent.hpp
+++ b/magda/daw/ui/components/clips/ClipComponent.hpp
@@ -136,6 +136,8 @@ class ClipComponent : public juce::Component, public ClipManagerListener, privat
     ClipInfo resizePreviewClip_;      // Preview clip state during resize-left drag
     std::unordered_map<ClipId, double>
         dragStartSelectedLengths_;  // Original lengths of other selected clips
+    std::unordered_map<ClipId, ClipInfo>
+        dragStartSelectedClipSnapshots_;  // Original full state for multi-resize preview restore
     double multiResizeMaxDelta_ =
         std::numeric_limits<double>::max();  // Max length increase before collision
     DragThrottle stretchThrottle_{50};

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -1944,8 +1944,8 @@ void TrackContentPanel::updateClipComponentPositions() {
         // floating point drift that causes position to shift with zoom.
         double startBeats =
             (clip->startBeats >= 0.0) ? clip->startBeats : clip->startTime * tempoBPM / 60.0;
-        double clipBeats =
-            (clip->lengthBeats > 0.0) ? clip->lengthBeats : clip->length * tempoBPM / 60.0;
+        double clipBeats = (clip->placement.lengthBeats > 0.0) ? clip->placement.lengthBeats
+                                                               : clip->length * tempoBPM / 60.0;
         int clipX = beatsToPixel(startBeats);
         int clipWidth = static_cast<int>(std::round(clipBeats * currentZoom));
 

--- a/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
@@ -187,8 +187,8 @@ void TrackContentPanel::updateMultiClipDrag(const juce::Point<int>& currentPos) 
             const auto* clip = ClipManager::getInstance().getClip(dragInfo.clipId);
             if (clip) {
                 int ghostX = beatsToPixel(newStartTime * tempoBPM / 60.0);
-                double ghostBeats = (clip->autoTempo && clip->lengthBeats > 0.0)
-                                        ? clip->lengthBeats
+                double ghostBeats = (clip->autoTempo && clip->placement.lengthBeats > 0.0)
+                                        ? clip->placement.lengthBeats
                                         : clip->length * tempoBPM / 60.0;
                 int ghostWidth = static_cast<int>(std::round(ghostBeats * currentZoom));
                 auto trackArea = getTrackLaneArea(targetTrackIdx);
@@ -207,8 +207,8 @@ void TrackContentPanel::updateMultiClipDrag(const juce::Point<int>& currentPos) 
             const auto* clip = ClipManager::getInstance().getClip(dragInfo.clipId);
             if (clip) {
                 int ghostX = beatsToPixel(newStartTime * tempoBPM / 60.0);
-                double ghostBeats = (clip->autoTempo && clip->lengthBeats > 0.0)
-                                        ? clip->lengthBeats
+                double ghostBeats = (clip->autoTempo && clip->placement.lengthBeats > 0.0)
+                                        ? clip->placement.lengthBeats
                                         : clip->length * tempoBPM / 60.0;
                 int ghostWidth = static_cast<int>(std::round(ghostBeats * currentZoom));
                 auto trackArea = getTrackLaneArea(targetTrackIdx);
@@ -486,8 +486,8 @@ void TrackContentPanel::moveClipsWithTimeSelection(double deltaTime) {
                 const auto* clip = ClipManager::getInstance().getClip(info.clipId);
                 if (clip) {
                     int newX = beatsToPixel(newStartTime * tempoBPM / 60.0);
-                    double clipBts = (clip->autoTempo && clip->lengthBeats > 0.0)
-                                         ? clip->lengthBeats
+                    double clipBts = (clip->autoTempo && clip->placement.lengthBeats > 0.0)
+                                         ? clip->placement.lengthBeats
                                          : clip->length * tempoBPM / 60.0;
                     int clipWidth = static_cast<int>(std::round(clipBts * currentZoom));
                     clipComp->setBounds(newX, clipComp->getY(), juce::jmax(10, clipWidth),

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -60,7 +60,7 @@ void WaveformGridComponent::paint(juce::Graphics& g) {
 }
 
 void WaveformGridComponent::paintWaveform(juce::Graphics& g, const magda::ClipInfo& clip) {
-    if (clip.audioFilePath.isEmpty())
+    if (clip.audio().source.filePath.isEmpty())
         return;
 
     auto layout = computeWaveformLayout(clip);
@@ -148,7 +148,7 @@ void WaveformGridComponent::paintWaveformThumbnail(juce::Graphics& g, const magd
         return;
 
     auto& thumbnailManager = magda::AudioThumbnailManager::getInstance();
-    auto* thumbnail = thumbnailManager.getThumbnail(clip.audioFilePath);
+    auto* thumbnail = thumbnailManager.getThumbnail(clip.audio().source.filePath);
     double fileDuration = thumbnail ? thumbnail->getTotalLength() : 0.0;
     // The waveform editor only ever shows the focused clip, so the waveform is
     // always rendered as if "selected" — black, to match arrangement-view styling.
@@ -204,8 +204,8 @@ void WaveformGridComponent::paintWaveformThumbnail(juce::Graphics& g, const magd
                                            audioWidth;
                     tStart = juce::jlimit(displayStart, displayEnd, tStart);
                     tEnd = juce::jlimit(displayStart, displayEnd, tEnd);
-                    thumbnailManager.drawWaveform(g, drawRect, clip.audioFilePath, tStart, tEnd,
-                                                  waveColour, vertZoom, useHighRes);
+                    thumbnailManager.drawWaveform(g, drawRect, clip.audio().source.filePath, tStart,
+                                                  tEnd, waveColour, vertZoom, useHighRes);
                 }
             }
         }
@@ -259,8 +259,8 @@ void WaveformGridComponent::paintWaveformThumbnail(juce::Graphics& g, const magd
             }
             // Draw dimmer to indicate it's outside the loop
             auto dimColour = waveColour.withAlpha(0.4f);
-            thumbnailManager.drawWaveform(g, drawRect, clip.audioFilePath, visFileStart, visFileEnd,
-                                          dimColour, vertZoom, useHighRes);
+            thumbnailManager.drawWaveform(g, drawRect, clip.audio().source.filePath, visFileStart,
+                                          visFileEnd, dimColour, vertZoom, useHighRes);
             if (clip.isReversed)
                 g.restoreState();
         }
@@ -297,8 +297,9 @@ void WaveformGridComponent::paintWaveformOverlays(juce::Graphics& g, const magda
     // Clip info overlay — show file name on the waveform
     g.setColour(clip.colour);
     g.setFont(FontManager::getInstance().getUIFont(12.0f));
-    juce::String displayName =
-        clip.audioFilePath.isNotEmpty() ? juce::File(clip.audioFilePath).getFileName() : clip.name;
+    juce::String displayName = clip.audio().source.filePath.isNotEmpty()
+                                   ? juce::File(clip.audio().source.filePath).getFileName()
+                                   : clip.name;
     g.drawText(displayName, visibleRect.reduced(8, 4), juce::Justification::topLeft, true);
 
     // Border — draw only the visible edges
@@ -416,7 +417,7 @@ void WaveformGridComponent::paintWarpedWaveform(juce::Graphics& g, const magda::
                                                 juce::Rectangle<int> waveformRect,
                                                 juce::Colour waveColour, float vertZoom) {
     auto& thumbnailManager = magda::AudioThumbnailManager::getInstance();
-    auto* thumbnail = thumbnailManager.getThumbnail(clip.audioFilePath);
+    auto* thumbnail = thumbnailManager.getThumbnail(clip.audio().source.filePath);
     double fileDuration = thumbnail ? thumbnail->getTotalLength() : 0.0;
 
     double displayStartTime = getDisplayStartTime();
@@ -571,8 +572,9 @@ void WaveformGridComponent::paintWarpedWaveform(juce::Graphics& g, const magda::
             double finalSrcEnd =
                 fileDuration > 0.0 ? juce::jmin(clippedSrcEnd, fileDuration) : clippedSrcEnd;
             if (finalSrcEnd > finalSrcStart) {
-                thumbnailManager.drawWaveform(g, drawRect, clip.audioFilePath, finalSrcStart,
-                                              finalSrcEnd, waveColour, vertZoom, true);
+                thumbnailManager.drawWaveform(g, drawRect, clip.audio().source.filePath,
+                                              finalSrcStart, finalSrcEnd, waveColour, vertZoom,
+                                              true);
             }
         }
     }
@@ -1024,7 +1026,7 @@ void WaveformGridComponent::mouseDown(const juce::MouseEvent& event) {
     }
 
     auto* clip = magda::ClipManager::getInstance().getClip(editingClipId_);
-    if (!clip || !clip->isAudio() || clip->audioFilePath.isEmpty()) {
+    if (!clip || !clip->isAudio() || clip->audio().source.filePath.isEmpty()) {
         return;
     }
 
@@ -1172,7 +1174,8 @@ void WaveformGridComponent::mouseDown(const juce::MouseEvent& event) {
 
     // Cache file duration for trim clamping
     dragStartFileDuration_ = 0.0;
-    auto* thumbnail = magda::AudioThumbnailManager::getInstance().getThumbnail(clip->audioFilePath);
+    auto* thumbnail =
+        magda::AudioThumbnailManager::getInstance().getThumbnail(clip->audio().source.filePath);
     if (thumbnail) {
         dragStartFileDuration_ = thumbnail->getTotalLength();
     }
@@ -1253,7 +1256,7 @@ void WaveformGridComponent::mouseDrag(const juce::MouseEvent& event) {
 
     // Get clip for direct modification during drag (performance optimization)
     auto* clip = magda::ClipManager::getInstance().getClip(editingClipId_);
-    if (!clip || clip->audioFilePath.isEmpty())
+    if (!clip || clip->audio().source.filePath.isEmpty())
         return;
 
     double deltaSeconds = (event.x - dragStartX_) / horizontalZoom_;
@@ -1291,8 +1294,8 @@ void WaveformGridComponent::mouseDrag(const juce::MouseEvent& event) {
                 clip->length =
                     juce::jmax(magda::ClipOperations::MIN_CLIP_LENGTH, endTime - clip->startTime);
 
-                if (clip->autoTempo && clip->sourceBPM > 0.0)
-                    clip->offsetBeats = clip->offset * clip->sourceBPM / 60.0;
+                if (clip->autoTempo && clip->audio().interpretation.bpm > 0.0)
+                    clip->offsetBeats = clip->offset * clip->audio().interpretation.bpm / 60.0;
                 clip->loopStart = clip->offset;
                 clip->clampLengthToSource(dragStartFileDuration_);
             }
@@ -1322,8 +1325,8 @@ void WaveformGridComponent::mouseDrag(const juce::MouseEvent& event) {
                 }
             }
             clip->offset = clip->loopStart + newPhase;
-            if (clip->autoTempo && clip->sourceBPM > 0.0)
-                clip->offsetBeats = clip->offset * clip->sourceBPM / 60.0;
+            if (clip->autoTempo && clip->audio().interpretation.bpm > 0.0)
+                clip->offsetBeats = clip->offset * clip->audio().interpretation.bpm / 60.0;
             break;
         }
         case DragMode::StretchRight: {
@@ -1422,7 +1425,7 @@ void WaveformGridComponent::mouseMove(const juce::MouseEvent& event) {
     }
 
     const auto* clip = getClip();
-    if (!clip || clip->audioFilePath.isEmpty()) {
+    if (!clip || clip->audio().source.filePath.isEmpty()) {
         setMouseCursor(juce::MouseCursor::NormalCursor);
         return;
     }

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -614,7 +614,7 @@ void WaveformGridComponent::paintClipBoundaries(juce::Graphics& g) {
     }
 
     const bool hasVisibleLoopPhase =
-        isLooped && displayInfo_.sourceLength > 0.0 && std::abs(displayInfo_.loopOffset) > 1e-6;
+        isLooped && displayInfo_.sourceLength > 0.0 && displayInfo_.loopLengthSeconds > 0.0;
 
     // Offset marker (orange) — only meaningful in non-loop mode. In loop mode
     // offset is represented by the phase marker inside the loop region.
@@ -1124,11 +1124,15 @@ void WaveformGridComponent::mouseDown(const juce::MouseEvent& event) {
     // Phase marker takes priority over edge resize so a click on the "P" marker doesn't
     // fall through to the source-extent right-edge hit-test (which used to silently shorten
     // the loop when the phase landed near the file end).
-    if (isNearPhaseMarker(x, *clip)) {
+    const bool nearPhaseMarker = isNearPhaseMarker(x, *clip);
+    const bool nearLeftEdge = isNearLeftEdge(x, *clip);
+    const bool nearRightEdge = isNearRightEdge(x, *clip);
+
+    if (nearPhaseMarker) {
         dragMode_ = DragMode::PhaseMarker;
-    } else if (isNearLeftEdge(x, *clip)) {
+    } else if (nearLeftEdge) {
         dragMode_ = shiftHeld ? DragMode::StretchLeft : DragMode::ResizeLeft;
-    } else if (isNearRightEdge(x, *clip) && shiftHeld) {
+    } else if (nearRightEdge && shiftHeld) {
         // Right-edge resize is intentionally disabled — only Shift+drag (stretch) survives.
         // Plain right-edge drag used to call resizeSourceExtent → setLoopLengthFromTimeline,
         // which is the loop-end edit and is handled on the timeline ruler instead.
@@ -1492,9 +1496,8 @@ bool WaveformGridComponent::isNearRightEdge(int x, const magda::ClipInfo& clip) 
 }
 
 bool WaveformGridComponent::isNearPhaseMarker(int x, const magda::ClipInfo& clip) const {
-    if (!clip.loopEnabled || displayInfo_.loopLengthSeconds <= 0.0)
-        return false;
-    if (displayInfo_.sourceLength <= 0.0 || std::abs(displayInfo_.loopOffset) <= 1e-6)
+    const bool loopActive = clip.loopEnabled || clip.autoTempo;
+    if (!loopActive || displayInfo_.loopLengthSeconds <= 0.0 || displayInfo_.sourceLength <= 0.0)
         return false;
     int phaseX = timeToPixel(getDisplayStartTime() + displayInfo_.loopPhasePositionSeconds);
     return std::abs(x - phaseX) <= EDGE_GRAB_DISTANCE;

--- a/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
+++ b/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
@@ -304,11 +304,11 @@ void AudioClipPropertiesContent::createControls() {
     };
     addAndMakeVisible(*bpmValue_);
 
-    beatsLabel_ = makeLabel("Source Beats");
+    beatsLabel_ = makeLabel("Beats");
     beatsValue_ = std::make_unique<DraggableValueLabel>(DraggableValueLabel::Format::Raw);
     beatsValue_->setRange(0.25, 4096.0, 4.0);
     beatsValue_->setDecimalPlaces(2);
-    beatsValue_->setSuffix(" source beats");
+    beatsValue_->setSuffix("");
     beatsValue_->setSnapToInteger(true);
     beatsValue_->setDrawBackground(false);
     beatsValue_->setDrawBorder(true);

--- a/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
+++ b/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
@@ -273,19 +273,26 @@ void AudioClipPropertiesContent::createControls() {
 
         double newBPM = bpmValue_->getValue();
 
-        // BPM and source beats are independent user-editable interpretation fields.
-        // A BPM correction must not silently rewrite the source beat count.
+        // BPM and Beats are two editable views of the same fixed-duration source
+        // interpretation. Editing either one must keep the other coherent.
         if (clip->autoTempo) {
             double bpm = 120.0;
             if (auto* tc = magda::TimelineController::getCurrent())
                 bpm = tc->getState().tempo.bpm;
             magda::ClipManager::AudioClipBeatsUpdate u;
             u.interpretationBpm = newBPM;
+            double durationSeconds = clip->audio().source.durationSeconds;
             if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
                     clip->audio().source.filePath)) {
                 double fileDuration = thumb->getTotalLength();
+                if (fileDuration > 0.0)
+                    durationSeconds = fileDuration;
                 if (fileDuration > 0.0 && clip->audio().source.durationSeconds <= 0.0)
                     u.sourceDurationSeconds = fileDuration;
+            }
+            if (durationSeconds > 0.0) {
+                u.interpretationTotalBeats = durationSeconds * newBPM / 60.0;
+                u.lockInterpretationTotalBeats = true;
             }
             magda::ClipManager::getInstance().applyAudioClipBeats(clipId_, u, bpm);
         } else {
@@ -338,6 +345,8 @@ void AudioClipPropertiesContent::createControls() {
         magda::ClipManager::AudioClipBeatsUpdate u;
         u.interpretationTotalBeats = newSourceBeats;
         u.lockInterpretationTotalBeats = true;
+        if (durationSeconds > 0.0)
+            u.interpretationBpm = newSourceBeats * 60.0 / durationSeconds;
         if (durationSeconds > 0.0 && clip->audio().source.durationSeconds <= 0.0)
             u.sourceDurationSeconds = durationSeconds;
 

--- a/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
+++ b/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
@@ -273,11 +273,8 @@ void AudioClipPropertiesContent::createControls() {
 
         double newBPM = bpmValue_->getValue();
 
-        // Issue #1157: BPM edit is a CORRECTION of detected file metadata,
-        // not a stretch control. Mirror ClipInspectorSections — for autoTempo
-        // clips, route through the canonical setter so length/loopLengthBeats
-        // are not clobbered. Use the file's actual duration (not the loop
-        // region) to derive source interpretation total beats.
+        // BPM and source beats are independent user-editable interpretation fields.
+        // A BPM correction must not silently rewrite the source beat count.
         if (clip->autoTempo) {
             double bpm = 120.0;
             if (auto* tc = magda::TimelineController::getCurrent())
@@ -287,10 +284,8 @@ void AudioClipPropertiesContent::createControls() {
             if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
                     clip->audio().source.filePath)) {
                 double fileDuration = thumb->getTotalLength();
-                if (fileDuration > 0.0) {
+                if (fileDuration > 0.0 && clip->audio().source.durationSeconds <= 0.0)
                     u.sourceDurationSeconds = fileDuration;
-                    u.interpretationTotalBeats = fileDuration * newBPM / 60.0;
-                }
             }
             magda::ClipManager::getInstance().applyAudioClipBeats(clipId_, u, bpm);
         } else {
@@ -302,7 +297,6 @@ void AudioClipPropertiesContent::createControls() {
                 if (fileDuration > 0.0) {
                     if (clip->audio().source.durationSeconds <= 0.0)
                         clip->audio().source.durationSeconds = fileDuration;
-                    clip->audio().interpretation.totalBeats = fileDuration * newBPM / 60.0;
                 }
             }
             magda::ClipManager::getInstance().forceNotifyClipPropertyChanged(clipId_);
@@ -310,11 +304,11 @@ void AudioClipPropertiesContent::createControls() {
     };
     addAndMakeVisible(*bpmValue_);
 
-    beatsLabel_ = makeLabel("Beats");
+    beatsLabel_ = makeLabel("Source Beats");
     beatsValue_ = std::make_unique<DraggableValueLabel>(DraggableValueLabel::Format::Raw);
-    beatsValue_->setRange(0.25, 128.0, 4.0);
+    beatsValue_->setRange(0.25, 4096.0, 4.0);
     beatsValue_->setDecimalPlaces(2);
-    beatsValue_->setSuffix(" beats");
+    beatsValue_->setSuffix(" source beats");
     beatsValue_->setSnapToInteger(true);
     beatsValue_->setDrawBackground(false);
     beatsValue_->setDrawBorder(true);
@@ -324,12 +318,48 @@ void AudioClipPropertiesContent::createControls() {
     beatsValue_->onValueChange = [this]() {
         if (clipId_ == magda::INVALID_CLIP_ID)
             return;
-        double bpm = 120.0;
+        auto* clip = magda::ClipManager::getInstance().getClip(clipId_);
+        if (!clip || !clip->isAudio())
+            return;
+
+        const double newSourceBeats = beatsValue_->getValue();
+        double projectBpm = 120.0;
         if (auto* tc = magda::TimelineController::getCurrent())
-            bpm = tc->getState().tempo.bpm;
-        magda::UndoManager::getInstance().executeCommand(
-            std::make_unique<magda::SetClipLengthBeatsCommand>(clipId_, beatsValue_->getValue(),
-                                                               bpm));
+            projectBpm = tc->getState().tempo.bpm;
+
+        double durationSeconds = clip->audio().source.durationSeconds;
+        if (durationSeconds <= 0.0) {
+            if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
+                    clip->audio().source.filePath)) {
+                durationSeconds = thumb->getTotalLength();
+            }
+        }
+
+        magda::ClipManager::AudioClipBeatsUpdate u;
+        u.interpretationTotalBeats = newSourceBeats;
+        if (durationSeconds > 0.0 && clip->audio().source.durationSeconds <= 0.0)
+            u.sourceDurationSeconds = durationSeconds;
+
+        DBG("[InspectorTrace] audioClipProperties:sourceBeatsEdit id="
+            << clip->id << " newUiValue=" << newSourceBeats
+            << " targetField=source.interpretation.totalBeats"
+            << " before.source.interpretation.totalBeats="
+            << clip->audio().interpretation.totalBeats
+            << " before.source.interpretation.bpm=" << clip->audio().interpretation.bpm
+            << " before.placement.lengthBeats=" << clip->placement.lengthBeats
+            << " before.loopLengthBeats=" << clip->loopLengthBeats
+            << " durationSeconds=" << durationSeconds);
+
+        magda::ClipManager::getInstance().applyAudioClipBeats(clipId_, u, projectBpm);
+
+        if (auto* afterClip = magda::ClipManager::getInstance().getClip(clipId_)) {
+            DBG("[InspectorTrace] audioClipProperties:sourceBeatsEditApplied id="
+                << afterClip->id << " after.source.interpretation.totalBeats="
+                << afterClip->audio().interpretation.totalBeats
+                << " after.source.interpretation.bpm=" << afterClip->audio().interpretation.bpm
+                << " after.placement.lengthBeats=" << afterClip->placement.lengthBeats
+                << " after.loopLengthBeats=" << afterClip->loopLengthBeats);
+        }
     };
     addAndMakeVisible(*beatsValue_);
 
@@ -469,8 +499,18 @@ void AudioClipPropertiesContent::updateFromClip() {
         bpmValue_->setValue(
             clip->audio().interpretation.bpm > 0.0 ? clip->audio().interpretation.bpm : 120.0,
             juce::dontSendNotification);
-        beatsValue_->setValue(clip->placement.lengthBeats > 0.0 ? clip->placement.lengthBeats : 4.0,
+        beatsValue_->setValue(clip->audio().interpretation.totalBeats > 0.0
+                                  ? clip->audio().interpretation.totalBeats
+                                  : 4.0,
                               juce::dontSendNotification);
+        DBG("[InspectorTrace] audioClipProperties:sourceBeatsDisplay id="
+            << clip->id << " ui.value=" << beatsValue_->getValue()
+            << " boundField=source.interpretation.totalBeats"
+            << " source.interpretation.totalBeats=" << clip->audio().interpretation.totalBeats
+            << " source.interpretation.bpm=" << clip->audio().interpretation.bpm
+            << " source.durationSeconds=" << clip->audio().source.durationSeconds
+            << " placement.lengthBeats=" << clip->placement.lengthBeats
+            << " loopLengthBeats=" << clip->loopLengthBeats);
         pitchValue_->setValue(static_cast<double>(clip->pitchChange), juce::dontSendNotification);
         volumeValue_->setValue(static_cast<double>(clip->volumeDB), juce::dontSendNotification);
         gainValue_->setValue(static_cast<double>(clip->gainDB), juce::dontSendNotification);
@@ -484,7 +524,7 @@ void AudioClipPropertiesContent::updateFromClip() {
     stretchValue_->setEnabled(enabled && !isAutoTempo);
     stretchModeCombo_->setEnabled(enabled);
     bpmValue_->setEnabled(enabled);
-    beatsValue_->setEnabled(enabled && isAutoTempo);
+    beatsValue_->setEnabled(enabled);
     pitchValue_->setEnabled(enabled);
     analogPitchToggle_->setEnabled(enabled && !isAutoTempo && !(hasClip && clip->warpEnabled));
     transientSensValue_->setEnabled(enabled);

--- a/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
+++ b/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
@@ -146,47 +146,55 @@ void AudioClipPropertiesContent::createControls() {
         if (auto* tc = magda::TimelineController::getCurrent())
             bpm = tc->getState().tempo.bpm;
 
-        const bool sourceBpmLooksDefaulted =
-            clip->sourceBPM <= 0.0 || (bpm > 0.0 && std::abs(clip->sourceBPM - bpm) < 0.1);
-        if (enable && clip->isAudio() && sourceBpmLooksDefaulted) {
+        const bool sourceInterpretationBpmLooksDefaulted =
+            clip->audio().interpretation.bpm <= 0.0 ||
+            (bpm > 0.0 && std::abs(clip->audio().interpretation.bpm - bpm) < 0.1);
+        if (enable && clip->isAudio() && sourceInterpretationBpmLooksDefaulted) {
             // Issue #1157: only seed from AudioThumbnailManager when the
             // file didn't carry tempo metadata. setSourceMetadata (from TE's
             // loopInfo) is authoritative when present.
             auto& thumbs = magda::AudioThumbnailManager::getInstance();
-            double cached = thumbs.getCachedBPM(clip->audioFilePath);
+            double cached = thumbs.getCachedBPM(clip->audio().source.filePath);
             if (cached > 0.0) {
-                clip->sourceBPM = cached;
-                if (auto* thumb = thumbs.getThumbnail(clip->audioFilePath)) {
+                clip->audio().interpretation.bpm = cached;
+                if (auto* thumb = thumbs.getThumbnail(clip->audio().source.filePath)) {
                     double fileDuration = thumb->getTotalLength();
-                    if (fileDuration > 0.0)
-                        clip->sourceNumBeats = fileDuration * cached / 60.0;
+                    if (fileDuration > 0.0) {
+                        if (clip->audio().source.durationSeconds <= 0.0)
+                            clip->audio().source.durationSeconds = fileDuration;
+                        clip->audio().interpretation.totalBeats = fileDuration * cached / 60.0;
+                    }
                 }
             } else {
                 auto cid = clipId_;
-                thumbs.requestBPMDetection(clip->audioFilePath, [cid](double detectedBPM) {
-                    if (detectedBPM <= 0.0)
-                        return;
-                    auto& mgr = magda::ClipManager::getInstance();
-                    auto* c = mgr.getClip(cid);
-                    if (!c)
-                        return;
-                    // Issue #1157: file metadata wins over audio analysis.
-                    double live =
-                        magda::ProjectManager::getInstance().getCurrentProjectInfo().tempo;
-                    bool existingLooksDefaulted =
-                        c->sourceBPM > 0.0 && live > 0.0 && std::abs(c->sourceBPM - live) < 0.1;
-                    if (c->sourceBPM > 0.0 && !existingLooksDefaulted)
-                        return;
-                    magda::ClipManager::AudioClipBeatsUpdate u;
-                    u.sourceBPM = detectedBPM;
-                    if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
-                            c->audioFilePath)) {
-                        double fileDuration = thumb->getTotalLength();
-                        if (fileDuration > 0.0)
-                            u.sourceNumBeats = fileDuration * detectedBPM / 60.0;
-                    }
-                    mgr.applyAudioClipBeats(cid, u, live);
-                });
+                thumbs.requestBPMDetection(
+                    clip->audio().source.filePath, [cid](double detectedBPM) {
+                        if (detectedBPM <= 0.0)
+                            return;
+                        auto& mgr = magda::ClipManager::getInstance();
+                        auto* c = mgr.getClip(cid);
+                        if (!c)
+                            return;
+                        // Issue #1157: file metadata wins over audio analysis.
+                        double live =
+                            magda::ProjectManager::getInstance().getCurrentProjectInfo().tempo;
+                        bool existingLooksDefaulted =
+                            c->audio().interpretation.bpm > 0.0 && live > 0.0 &&
+                            std::abs(c->audio().interpretation.bpm - live) < 0.1;
+                        if (c->audio().interpretation.bpm > 0.0 && !existingLooksDefaulted)
+                            return;
+                        magda::ClipManager::AudioClipBeatsUpdate u;
+                        u.interpretationBpm = detectedBPM;
+                        if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
+                                c->audio().source.filePath)) {
+                            double fileDuration = thumb->getTotalLength();
+                            if (fileDuration > 0.0) {
+                                u.sourceDurationSeconds = fileDuration;
+                                u.interpretationTotalBeats = fileDuration * detectedBPM / 60.0;
+                            }
+                        }
+                        mgr.applyAudioClipBeats(cid, u, live);
+                    });
             }
         }
 
@@ -269,28 +277,33 @@ void AudioClipPropertiesContent::createControls() {
         // not a stretch control. Mirror ClipInspectorSections — for autoTempo
         // clips, route through the canonical setter so length/loopLengthBeats
         // are not clobbered. Use the file's actual duration (not the loop
-        // region) to derive sourceNumBeats.
+        // region) to derive source interpretation total beats.
         if (clip->autoTempo) {
             double bpm = 120.0;
             if (auto* tc = magda::TimelineController::getCurrent())
                 bpm = tc->getState().tempo.bpm;
             magda::ClipManager::AudioClipBeatsUpdate u;
-            u.sourceBPM = newBPM;
-            if (auto* thumb =
-                    magda::AudioThumbnailManager::getInstance().getThumbnail(clip->audioFilePath)) {
+            u.interpretationBpm = newBPM;
+            if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
+                    clip->audio().source.filePath)) {
                 double fileDuration = thumb->getTotalLength();
-                if (fileDuration > 0.0)
-                    u.sourceNumBeats = fileDuration * newBPM / 60.0;
+                if (fileDuration > 0.0) {
+                    u.sourceDurationSeconds = fileDuration;
+                    u.interpretationTotalBeats = fileDuration * newBPM / 60.0;
+                }
             }
             magda::ClipManager::getInstance().applyAudioClipBeats(clipId_, u, bpm);
         } else {
-            // Non-autoTempo audio: sourceBPM is just stored metadata.
-            clip->sourceBPM = newBPM;
-            if (auto* thumb =
-                    magda::AudioThumbnailManager::getInstance().getThumbnail(clip->audioFilePath)) {
+            // Non-autoTempo audio: source interpretation BPM is just stored metadata.
+            clip->audio().interpretation.bpm = newBPM;
+            if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
+                    clip->audio().source.filePath)) {
                 double fileDuration = thumb->getTotalLength();
-                if (fileDuration > 0.0)
-                    clip->sourceNumBeats = fileDuration * newBPM / 60.0;
+                if (fileDuration > 0.0) {
+                    if (clip->audio().source.durationSeconds <= 0.0)
+                        clip->audio().source.durationSeconds = fileDuration;
+                    clip->audio().interpretation.totalBeats = fileDuration * newBPM / 60.0;
+                }
             }
             magda::ClipManager::getInstance().forceNotifyClipPropertyChanged(clipId_);
         }
@@ -453,9 +466,10 @@ void AudioClipPropertiesContent::updateFromClip() {
     if (hasClip) {
         stretchValue_->setValue(clip->speedRatio, juce::dontSendNotification);
         stretchModeCombo_->setSelectedId(clip->timeStretchMode + 1, juce::dontSendNotification);
-        bpmValue_->setValue(clip->sourceBPM > 0.0 ? clip->sourceBPM : 120.0,
-                            juce::dontSendNotification);
-        beatsValue_->setValue(clip->lengthBeats > 0.0 ? clip->lengthBeats : 4.0,
+        bpmValue_->setValue(
+            clip->audio().interpretation.bpm > 0.0 ? clip->audio().interpretation.bpm : 120.0,
+            juce::dontSendNotification);
+        beatsValue_->setValue(clip->placement.lengthBeats > 0.0 ? clip->placement.lengthBeats : 4.0,
                               juce::dontSendNotification);
         pitchValue_->setValue(static_cast<double>(clip->pitchChange), juce::dontSendNotification);
         volumeValue_->setValue(static_cast<double>(clip->volumeDB), juce::dontSendNotification);

--- a/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
+++ b/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
@@ -337,6 +337,7 @@ void AudioClipPropertiesContent::createControls() {
 
         magda::ClipManager::AudioClipBeatsUpdate u;
         u.interpretationTotalBeats = newSourceBeats;
+        u.lockInterpretationTotalBeats = true;
         if (durationSeconds > 0.0 && clip->audio().source.durationSeconds <= 0.0)
             u.sourceDurationSeconds = durationSeconds;
 

--- a/magda/daw/ui/panels/content/WaveformEditorContent.cpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.cpp
@@ -140,6 +140,11 @@ class WaveformEditorContent::PlayheadOverlay : public juce::Component {
                    scrollX;
         };
 
+        auto displayPositionToX = [&](double displayPos) -> int {
+            return static_cast<int>(displayPos * owner_.horizontalZoom_) + GRID_LEFT_PADDING -
+                   scrollX;
+        };
+
         auto arrangementToSourceX = [&](double arrangementTime) -> int {
             double relTime = arrangementTime - clip->startTime;
             double sourcePos = clip->offset + timelineDeltaToSourceDelta(relTime);
@@ -166,31 +171,23 @@ class WaveformEditorContent::PlayheadOverlay : public juce::Component {
             double sessionPos = clip->sessionPlayheadPos;
 
             if (sessionPos >= 0.0) {
-                {
-                    double relPos = sessionPos;
-                    if (clip->loopEnabled && clip->loopLength > 0.0) {
-                        double phaseShift = clip->offset - clip->loopStart;
-                        double sourceDelta = timelineDeltaToSourceDelta(relPos);
-                        double wrapped = std::fmod(phaseShift + sourceDelta, clip->loopLength);
-                        if (wrapped < 0.0)
-                            wrapped += clip->loopLength;
-                        double sourcePos = clip->loopStart + wrapped;
-                        int playX = sourcePositionToX(sourcePos);
-                        if (playX >= 0 && playX < getWidth()) {
-                            g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_RED));
-                            g.drawLine(static_cast<float>(playX), 0.0f, static_cast<float>(playX),
-                                       static_cast<float>(getHeight()), 1.5f);
-                        }
-                    } else {
-                        // Non-looping session clip
-                        double sourcePos = clip->offset + timelineDeltaToSourceDelta(relPos);
-                        int playX = sourcePositionToX(sourcePos);
-                        if (playX >= 0 && playX < getWidth()) {
-                            g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_RED));
-                            g.drawLine(static_cast<float>(playX), 0.0f, static_cast<float>(playX),
-                                       static_cast<float>(getHeight()), 1.5f);
-                        }
-                    }
+                int playX = 0;
+                if (clip->loopEnabled && di.loopLengthSeconds > 0.0) {
+                    const double phaseDisplay =
+                        di.loopPhasePositionSeconds - di.loopStartPositionSeconds;
+                    double wrappedDisplay =
+                        std::fmod(phaseDisplay + sessionPos, di.loopLengthSeconds);
+                    if (wrappedDisplay < 0.0)
+                        wrappedDisplay += di.loopLengthSeconds;
+                    playX = displayPositionToX(di.loopStartPositionSeconds + wrappedDisplay);
+                } else {
+                    playX = displayPositionToX(di.offsetPositionSeconds + sessionPos);
+                }
+
+                if (playX >= 0 && playX < getWidth()) {
+                    g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_RED));
+                    g.drawLine(static_cast<float>(playX), 0.0f, static_cast<float>(playX),
+                               static_cast<float>(getHeight()), 1.5f);
                 }
                 // Either way, don't fall through to arrangement mode
                 return;

--- a/magda/daw/ui/panels/content/WaveformEditorContent.cpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.cpp
@@ -123,12 +123,27 @@ class WaveformEditorContent::PlayheadOverlay : public juce::Component {
         // playhead falls within this clip's time range.
         double clipEnd = clip->startTime + clip->length;
 
-        auto arrangementToSourceX = [&](double arrangementTime) -> int {
-            // Map arrangement time to position within source file
-            double relTime = arrangementTime - clip->startTime;
-            double sourcePos = di.offsetPositionSeconds + relTime;
-            return static_cast<int>(sourcePos * owner_.horizontalZoom_) + GRID_LEFT_PADDING -
+        auto timelineDeltaToSourceDelta = [&](double timelineDelta) {
+            double projectBpm = owner_.timeRuler_ ? owner_.timeRuler_->getTempo() : 120.0;
+            double sourceDuration = clip->audio().source.durationSeconds;
+            if (clip->autoTempo && clip->audio().interpretation.totalBeats > 0.0 &&
+                sourceDuration > 0.0 && projectBpm > 0.0) {
+                double projectBeats = timelineDelta * projectBpm / 60.0;
+                return projectBeats * sourceDuration / clip->audio().interpretation.totalBeats;
+            }
+            return di.timelineToSource(timelineDelta);
+        };
+
+        auto sourcePositionToX = [&](double sourcePos) -> int {
+            double displayPos = di.sourceToTimeline(sourcePos);
+            return static_cast<int>(displayPos * owner_.horizontalZoom_) + GRID_LEFT_PADDING -
                    scrollX;
+        };
+
+        auto arrangementToSourceX = [&](double arrangementTime) -> int {
+            double relTime = arrangementTime - clip->startTime;
+            double sourcePos = clip->offset + timelineDeltaToSourceDelta(relTime);
+            return sourcePositionToX(sourcePos);
         };
 
         // Draw edit cursor (triangle at top) — only when inside clip range
@@ -153,14 +168,14 @@ class WaveformEditorContent::PlayheadOverlay : public juce::Component {
             if (sessionPos >= 0.0) {
                 {
                     double relPos = sessionPos;
-                    if (clip->loopEnabled && di.loopLengthSeconds > 0.0) {
-                        double phaseShift = di.offsetPositionSeconds - di.loopStartPositionSeconds;
-                        double wrapped = std::fmod(phaseShift + relPos, di.loopLengthSeconds);
+                    if (clip->loopEnabled && clip->loopLength > 0.0) {
+                        double phaseShift = clip->offset - clip->loopStart;
+                        double sourceDelta = timelineDeltaToSourceDelta(relPos);
+                        double wrapped = std::fmod(phaseShift + sourceDelta, clip->loopLength);
                         if (wrapped < 0.0)
-                            wrapped += di.loopLengthSeconds;
-                        double displayPos = di.loopStartPositionSeconds + wrapped;
-                        int playX = static_cast<int>(displayPos * owner_.horizontalZoom_) +
-                                    GRID_LEFT_PADDING - scrollX;
+                            wrapped += clip->loopLength;
+                        double sourcePos = clip->loopStart + wrapped;
+                        int playX = sourcePositionToX(sourcePos);
                         if (playX >= 0 && playX < getWidth()) {
                             g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_RED));
                             g.drawLine(static_cast<float>(playX), 0.0f, static_cast<float>(playX),
@@ -168,9 +183,8 @@ class WaveformEditorContent::PlayheadOverlay : public juce::Component {
                         }
                     } else {
                         // Non-looping session clip
-                        double sourcePos = di.offsetPositionSeconds + relPos;
-                        int playX = static_cast<int>(sourcePos * owner_.horizontalZoom_) +
-                                    GRID_LEFT_PADDING - scrollX;
+                        double sourcePos = clip->offset + timelineDeltaToSourceDelta(relPos);
+                        int playX = sourcePositionToX(sourcePos);
                         if (playX >= 0 && playX < getWidth()) {
                             g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_RED));
                             g.drawLine(static_cast<float>(playX), 0.0f, static_cast<float>(playX),
@@ -190,15 +204,15 @@ class WaveformEditorContent::PlayheadOverlay : public juce::Component {
                 return;
 
             // Wrap playhead inside loop region when looping is enabled
-            if (clip->loopEnabled && di.loopLengthSeconds > 0.0) {
+            if (clip->loopEnabled && clip->loopLength > 0.0) {
                 double relPos = playPos - clip->startTime;
-                double phaseShift = di.offsetPositionSeconds - di.loopStartPositionSeconds;
-                double wrapped = std::fmod(phaseShift + relPos, di.loopLengthSeconds);
+                double phaseShift = clip->offset - clip->loopStart;
+                double sourceDelta = timelineDeltaToSourceDelta(relPos);
+                double wrapped = std::fmod(phaseShift + sourceDelta, clip->loopLength);
                 if (wrapped < 0.0)
-                    wrapped += di.loopLengthSeconds;
-                double displayPos = di.loopStartPositionSeconds + wrapped;
-                int playX = static_cast<int>(displayPos * owner_.horizontalZoom_) +
-                            GRID_LEFT_PADDING - scrollX;
+                    wrapped += clip->loopLength;
+                double sourcePos = clip->loopStart + wrapped;
+                int playX = sourcePositionToX(sourcePos);
                 if (playX >= 0 && playX < getWidth()) {
                     g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_RED));
                     g.drawLine(static_cast<float>(playX), 0.0f, static_cast<float>(playX),

--- a/magda/daw/ui/panels/content/WaveformEditorContent.cpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.cpp
@@ -832,9 +832,9 @@ void WaveformEditorContent::clipPropertyChanged(magda::ClipId clipId) {
         }
 
         // Check if cached transients were invalidated (e.g. sensitivity changed)
-        if (transientsCached_ && clip->isAudio() && !clip->audioFilePath.isEmpty()) {
+        if (transientsCached_ && clip->isAudio() && !clip->audio().source.filePath.isEmpty()) {
             auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
-                clip->audioFilePath);
+                clip->audio().source.filePath);
             if (!cached) {
                 // Cache was cleared — restart polling for new transients
                 transientsCached_ = false;
@@ -1008,9 +1008,9 @@ void WaveformEditorContent::setClip(magda::ClipId clipId) {
         }
 
         // Check for cached transients or start polling
-        if (clip && clip->isAudio() && !clip->audioFilePath.isEmpty()) {
+        if (clip && clip->isAudio() && !clip->audio().source.filePath.isEmpty()) {
             auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
-                clip->audioFilePath);
+                clip->audio().source.filePath);
             if (cached) {
                 gridComponent_->setTransientTimes(*cached);
                 transientsCached_ = true;
@@ -1103,9 +1103,9 @@ void WaveformEditorContent::updateGridSize() {
             if (relativeTimeMode_) {
                 // In relative mode, ruler spans the full source file duration
                 double fileDuration = 0.0;
-                if (clip->audioFilePath.isNotEmpty()) {
+                if (clip->audio().source.filePath.isNotEmpty()) {
                     auto* thumbnail = magda::AudioThumbnailManager::getInstance().getThumbnail(
-                        clip->audioFilePath);
+                        clip->audio().source.filePath);
                     if (thumbnail) {
                         fileDuration = thumbnail->getTotalLength();
                     }
@@ -1166,9 +1166,9 @@ void WaveformEditorContent::updateDisplayInfo(const magda::ClipInfo& clip) {
 
     // Get file duration for source extent calculation
     double fileDuration = 0.0;
-    if (clip.audioFilePath.isNotEmpty()) {
+    if (clip.audio().source.filePath.isNotEmpty()) {
         auto* thumbnail =
-            magda::AudioThumbnailManager::getInstance().getThumbnail(clip.audioFilePath);
+            magda::AudioThumbnailManager::getInstance().getThumbnail(clip.audio().source.filePath);
         if (thumbnail) {
             fileDuration = thumbnail->getTotalLength();
         }
@@ -1313,9 +1313,9 @@ void WaveformEditorContent::timerCallback() {
 
     if (bridge->getTransientTimes(editingClipId_)) {
         const auto* clip = magda::ClipManager::getInstance().getClip(editingClipId_);
-        if (clip && !clip->audioFilePath.isEmpty()) {
+        if (clip && !clip->audio().source.filePath.isEmpty()) {
             auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
-                clip->audioFilePath);
+                clip->audio().source.filePath);
             if (cached) {
                 gridComponent_->setTransientTimes(*cached);
             }

--- a/magda/daw/ui/panels/content/WaveformEditorContent.cpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.cpp
@@ -171,18 +171,8 @@ class WaveformEditorContent::PlayheadOverlay : public juce::Component {
             double sessionPos = clip->sessionPlayheadPos;
 
             if (sessionPos >= 0.0) {
-                int playX = 0;
-                if (clip->loopEnabled && di.loopLengthSeconds > 0.0) {
-                    const double phaseDisplay =
-                        di.loopPhasePositionSeconds - di.loopStartPositionSeconds;
-                    double wrappedDisplay =
-                        std::fmod(phaseDisplay + sessionPos, di.loopLengthSeconds);
-                    if (wrappedDisplay < 0.0)
-                        wrappedDisplay += di.loopLengthSeconds;
-                    playX = displayPositionToX(di.loopStartPositionSeconds + wrappedDisplay);
-                } else {
-                    playX = displayPositionToX(di.offsetPositionSeconds + sessionPos);
-                }
+                const int playX =
+                    displayPositionToX(di.sessionPlayheadToDisplayPosition(sessionPos));
 
                 if (playX >= 0 && playX < getWidth()) {
                     g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_RED));

--- a/magda/daw/ui/panels/content/inspector/ClipInspector.hpp
+++ b/magda/daw/ui/panels/content/inspector/ClipInspector.hpp
@@ -114,7 +114,9 @@ class ClipInspector : public BaseInspector, public magda::ClipManagerListener {
     std::unique_ptr<magda::DraggableValueLabel> clipStretchValue_;
     juce::ComboBox stretchModeCombo_;
     juce::Label clipBpmValue_;
+    juce::Label clipBpmUnitLabel_;
     std::unique_ptr<magda::DraggableValueLabel> clipBeatsLengthValue_;
+    juce::Label clipBeatsUnitLabel_;
 
     // Pitch section (audio + MIDI)
     juce::Label pitchSectionLabel_;

--- a/magda/daw/ui/panels/content/inspector/ClipInspector.hpp
+++ b/magda/daw/ui/panels/content/inspector/ClipInspector.hpp
@@ -210,6 +210,7 @@ class ClipInspector : public BaseInspector, public magda::ClipManagerListener {
 
     // Update methods
     void updateFromSelectedClip();
+    void updateLoopValueDisplays(const magda::ClipInfo& clip, double projectBPM, int beatsPerBar);
     void showClipControls(bool show);
     void computeClipRange();
     void refreshClipRangeDisplay();

--- a/magda/daw/ui/panels/content/inspector/ClipInspector.hpp
+++ b/magda/daw/ui/panels/content/inspector/ClipInspector.hpp
@@ -63,6 +63,7 @@ class ClipInspector : public BaseInspector, public magda::ClipManagerListener {
     void initFadesSection();
     void initChannelsSection();
     void initViewport();
+    void updateAudioSourceValueDisplays(const magda::ClipInfo& clip);
 
     // Current selection (supports single and multi-clip)
     std::unordered_set<magda::ClipId> selectedClipIds_;

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorLayout.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorLayout.cpp
@@ -61,17 +61,26 @@ void ClipInspector::resized() {
     const int gap = 3;
     const int labelHeight = 14;
     const int valueHeight = 22;
-    int fieldWidth = juce::jmax(1, (containerWidth - iconSize - gap * 3) / 3);
+    const bool hideSecondaryTimingFields = containerWidth < 270;
+    const bool hideAudioUnitLabels = containerWidth < 240;
+    const int timingFieldCount = hideSecondaryTimingFields ? 2 : 3;
+    int fieldWidth =
+        juce::jmax(1, (containerWidth - iconSize - gap * timingFieldCount) / timingFieldCount);
 
     // Position row: position icon — start, end, offset (arrangement clips only)
     if (clipPositionIcon_->isVisible()) {
+        clipOffsetLabel_.setVisible(!hideSecondaryTimingFields);
+        clipContentOffsetValue_->setVisible(!hideSecondaryTimingFields);
+
         auto labelRow = addRow(labelHeight);
         labelRow.removeFromLeft(iconSize + gap);
         clipStartLabel_.setBounds(labelRow.removeFromLeft(fieldWidth));
         labelRow.removeFromLeft(gap);
         clipEndLabel_.setBounds(labelRow.removeFromLeft(fieldWidth));
-        labelRow.removeFromLeft(gap);
-        clipOffsetLabel_.setBounds(labelRow.removeFromLeft(fieldWidth));
+        if (!hideSecondaryTimingFields) {
+            labelRow.removeFromLeft(gap);
+            clipOffsetLabel_.setBounds(labelRow.removeFromLeft(fieldWidth));
+        }
 
         auto valueRow = addRow(valueHeight);
         clipPositionIcon_->setBounds(valueRow.removeFromLeft(iconSize));
@@ -79,8 +88,10 @@ void ClipInspector::resized() {
         clipStartValue_->setBounds(valueRow.removeFromLeft(fieldWidth));
         valueRow.removeFromLeft(gap);
         clipEndValue_->setBounds(valueRow.removeFromLeft(fieldWidth));
-        valueRow.removeFromLeft(gap);
-        clipContentOffsetValue_->setBounds(valueRow.removeFromLeft(fieldWidth));
+        if (!hideSecondaryTimingFields) {
+            valueRow.removeFromLeft(gap);
+            clipContentOffsetValue_->setBounds(valueRow.removeFromLeft(fieldWidth));
+        }
 
         addSeparator();
     }
@@ -93,13 +104,18 @@ void ClipInspector::resized() {
 
     // Loop row: loop toggle + lstart | lend | phase (always shown; greyed when off)
     if (clipLoopToggle_->isVisible()) {
+        clipLoopPhaseLabel_.setVisible(!hideSecondaryTimingFields);
+        clipLoopPhaseValue_->setVisible(!hideSecondaryTimingFields);
+
         auto labelRow = addRow(labelHeight);
         labelRow.removeFromLeft(iconSize + gap);
         clipLoopStartLabel_.setBounds(labelRow.removeFromLeft(fieldWidth));
         labelRow.removeFromLeft(gap);
         clipLoopEndLabel_.setBounds(labelRow.removeFromLeft(fieldWidth));
-        labelRow.removeFromLeft(gap);
-        clipLoopPhaseLabel_.setBounds(labelRow.removeFromLeft(fieldWidth));
+        if (!hideSecondaryTimingFields) {
+            labelRow.removeFromLeft(gap);
+            clipLoopPhaseLabel_.setBounds(labelRow.removeFromLeft(fieldWidth));
+        }
 
         auto valueRow = addRow(valueHeight);
         clipLoopToggle_->setBounds(
@@ -108,8 +124,10 @@ void ClipInspector::resized() {
         clipLoopStartValue_->setBounds(valueRow.removeFromLeft(fieldWidth));
         valueRow.removeFromLeft(gap);
         clipLoopEndValue_->setBounds(valueRow.removeFromLeft(fieldWidth));
-        valueRow.removeFromLeft(gap);
-        clipLoopPhaseValue_->setBounds(valueRow.removeFromLeft(fieldWidth));
+        if (!hideSecondaryTimingFields) {
+            valueRow.removeFromLeft(gap);
+            clipLoopPhaseValue_->setBounds(valueRow.removeFromLeft(fieldWidth));
+        }
     }
     addSeparator();
 
@@ -166,17 +184,29 @@ void ClipInspector::resized() {
                 int bpmWidth = 96;  // matches WARP(46) + gap(4) + BEAT(46)
                 int bpmOffset = (left.getWidth() - bpmWidth) / 2;
                 auto bpmArea = left.withX(left.getX() + bpmOffset).withWidth(bpmWidth);
-                clipBpmValue_.setBounds(bpmArea.removeFromLeft(62).reduced(0, 1));
-                clipBpmUnitLabel_.setBounds(bpmArea.reduced(4, 1));
+                if (hideAudioUnitLabels) {
+                    clipBpmUnitLabel_.setVisible(false);
+                    clipBpmValue_.setBounds(bpmArea.reduced(0, 1));
+                } else {
+                    clipBpmUnitLabel_.setVisible(true);
+                    clipBpmValue_.setBounds(bpmArea.removeFromLeft(62).reduced(0, 1));
+                    clipBpmUnitLabel_.setBounds(bpmArea.reduced(4, 1));
+                }
             }
             if (clipStretchValue_ && clipStretchValue_->isVisible()) {
                 clipStretchValue_->setBounds(right.reduced(0, 1));
             }
             if (clipBeatsLengthValue_->isVisible()) {
                 auto beatsArea = right.reduced(0, 1);
-                clipBeatsLengthValue_->setBounds(
-                    beatsArea.removeFromLeft(juce::jmax(46, beatsArea.getWidth() - 42)));
-                clipBeatsUnitLabel_.setBounds(beatsArea.reduced(4, 0));
+                if (hideAudioUnitLabels) {
+                    clipBeatsUnitLabel_.setVisible(false);
+                    clipBeatsLengthValue_->setBounds(beatsArea);
+                } else {
+                    clipBeatsUnitLabel_.setVisible(true);
+                    clipBeatsLengthValue_->setBounds(
+                        beatsArea.removeFromLeft(juce::jmax(46, beatsArea.getWidth() - 42)));
+                    clipBeatsUnitLabel_.setBounds(beatsArea.reduced(4, 0));
+                }
             }
         }
     }

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorLayout.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorLayout.cpp
@@ -153,7 +153,7 @@ void ClipInspector::resized() {
             }
         }
 
-        // Row 2: [BPM] centered | [speed OR beats]
+        // Row 2: [BPM value + label] centered | [speed OR beats value + label]
         if (clipBpmValue_.isVisible() || (clipStretchValue_ && clipStretchValue_->isVisible()) ||
             clipBeatsLengthValue_->isVisible()) {
             addSpace(4);
@@ -165,13 +165,18 @@ void ClipInspector::resized() {
             if (clipBpmValue_.isVisible()) {
                 int bpmWidth = 96;  // matches WARP(46) + gap(4) + BEAT(46)
                 int bpmOffset = (left.getWidth() - bpmWidth) / 2;
-                clipBpmValue_.setBounds(left.withX(left.getX() + bpmOffset).withWidth(bpmWidth));
+                auto bpmArea = left.withX(left.getX() + bpmOffset).withWidth(bpmWidth);
+                clipBpmValue_.setBounds(bpmArea.removeFromLeft(62).reduced(0, 1));
+                clipBpmUnitLabel_.setBounds(bpmArea.reduced(4, 1));
             }
             if (clipStretchValue_ && clipStretchValue_->isVisible()) {
                 clipStretchValue_->setBounds(right.reduced(0, 1));
             }
             if (clipBeatsLengthValue_->isVisible()) {
-                clipBeatsLengthValue_->setBounds(right.reduced(0, 1));
+                auto beatsArea = right.reduced(0, 1);
+                clipBeatsLengthValue_->setBounds(
+                    beatsArea.removeFromLeft(juce::jmax(46, beatsArea.getWidth() - 42)));
+                clipBeatsUnitLabel_.setBounds(beatsArea.reduced(4, 0));
             }
         }
     }

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -996,14 +996,15 @@ void ClipInspector::initClipPropertiesSection() {
             magda::UndoManager::getInstance().executeCommand(
                 std::make_unique<magda::SetClipOffsetCommand>(primaryClipId(), newPhaseBeats));
         } else {
-            // Audio phase: convert beats to seconds and set offset
-            double bpm = 120.0;
-            if (timelineController_)
-                bpm = timelineController_->getState().tempo.bpm;
-            double newPhaseSeconds = magda::TimelineUtils::beatsToSeconds(newPhaseBeats, bpm);
-            double newOffset = clip->loopStart + newPhaseSeconds;
+            // Audio phase is source-relative, so convert with source BPM, not project BPM.
+            double loopBpm = clip->audio().interpretation.bpm;
+            if (loopBpm <= 0.0 && timelineController_)
+                loopBpm = timelineController_->getState().tempo.bpm;
+            if (loopBpm <= 0.0)
+                loopBpm = 120.0;
+            double newPhaseSeconds = magda::TimelineUtils::beatsToSeconds(newPhaseBeats, loopBpm);
             magda::UndoManager::getInstance().executeCommand(
-                std::make_unique<magda::SetClipOffsetCommand>(primaryClipId(), newOffset));
+                std::make_unique<magda::SetClipLoopPhaseCommand>(primaryClipId(), newPhaseSeconds));
         }
     };
     clipPropsContainer_.addChildComponent(*clipLoopPhaseValue_);

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -369,29 +369,34 @@ void ClipInspector::initClipPropertiesSection() {
         double bpm = timelineController_ ? timelineController_->getState().tempo.bpm : 120.0;
 
         // Issue #1157: BPM edit is a CORRECTION of the detected file metadata,
-        // not a stretch control. We write only sourceBPM (and recompute
-        // sourceNumBeats from the file's true duration). Timeline length and
+        // not a stretch control. We write only source interpretation BPM (and recompute
+        // source interpretation total beats from the file's true duration). Timeline length and
         // loop region are user-intent and untouched — TE will adapt the
-        // playback stretch ratio to the new sourceBPM at the next sync.
+        // playback stretch ratio to the new source interpretation BPM at the next sync.
         if (clip->autoTempo) {
             magda::ClipManager::AudioClipBeatsUpdate u;
-            u.sourceBPM = newBPM;
-            if (auto* thumb =
-                    magda::AudioThumbnailManager::getInstance().getThumbnail(clip->audioFilePath)) {
+            u.interpretationBpm = newBPM;
+            if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
+                    clip->audio().source.filePath)) {
                 double fileDuration = thumb->getTotalLength();
-                if (fileDuration > 0.0)
-                    u.sourceNumBeats = fileDuration * newBPM / 60.0;
+                if (fileDuration > 0.0) {
+                    u.sourceDurationSeconds = fileDuration;
+                    u.interpretationTotalBeats = fileDuration * newBPM / 60.0;
+                }
             }
             magda::ClipManager::getInstance().applyAudioClipBeats(primaryClipId(), u, bpm);
         } else {
-            // Non-autoTempo audio: sourceBPM is just stored metadata, no
+            // Non-autoTempo audio: source interpretation BPM is just stored metadata, no
             // dependent fields to recompute. Direct write is fine.
-            clip->sourceBPM = newBPM;
-            if (auto* thumb =
-                    magda::AudioThumbnailManager::getInstance().getThumbnail(clip->audioFilePath)) {
+            clip->audio().interpretation.bpm = newBPM;
+            if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
+                    clip->audio().source.filePath)) {
                 double fileDuration = thumb->getTotalLength();
-                if (fileDuration > 0.0)
-                    clip->sourceNumBeats = fileDuration * newBPM / 60.0;
+                if (fileDuration > 0.0) {
+                    if (clip->audio().source.durationSeconds <= 0.0)
+                        clip->audio().source.durationSeconds = fileDuration;
+                    clip->audio().interpretation.totalBeats = fileDuration * newBPM / 60.0;
+                }
             }
             magda::ClipManager::getInstance().forceNotifyClipPropertyChanged(primaryClipId());
         }
@@ -643,55 +648,62 @@ void ClipInspector::initClipPropertiesSection() {
             bpm = timelineController_->getState().tempo.bpm;
         }
 
-        // When enabling, seed sourceBPM/sourceNumBeats from detected BPM
-        // (AudioThumbnailManager) since the clip model may have stale metadata
-        // from TE's default loopInfo. Cached value is applied immediately
-        // (pre-setAutoTempo, before the canonical path is open); cache miss
-        // kicks off background detection and the callback funnels through
-        // applyAudioClipBeats once autoTempo is on.
-        const bool sourceBpmLooksDefaulted =
-            clip->sourceBPM <= 0.0 || (bpm > 0.0 && std::abs(clip->sourceBPM - bpm) < 0.1);
-        if (enable && clip->isAudio() && sourceBpmLooksDefaulted) {
+        // When enabling, seed source interpretation BPM/source interpretation total beats from
+        // detected BPM (AudioThumbnailManager) since the clip model may have stale metadata from
+        // TE's default loopInfo. Cached value is applied immediately (pre-setAutoTempo, before the
+        // canonical path is open); cache miss kicks off background detection and the callback
+        // funnels through applyAudioClipBeats once autoTempo is on.
+        const bool sourceInterpretationBpmLooksDefaulted =
+            clip->audio().interpretation.bpm <= 0.0 ||
+            (bpm > 0.0 && std::abs(clip->audio().interpretation.bpm - bpm) < 0.1);
+        if (enable && clip->isAudio() && sourceInterpretationBpmLooksDefaulted) {
             // Issue #1157: only seed from AudioThumbnailManager when the file
             // didn't carry tempo metadata. setSourceMetadata (from TE's
             // loopInfo) is authoritative when present; TempoDetect can be
             // wrong by ~1.3x on syncopated loops.
             auto& thumbs = magda::AudioThumbnailManager::getInstance();
-            double cached = thumbs.getCachedBPM(clip->audioFilePath);
+            double cached = thumbs.getCachedBPM(clip->audio().source.filePath);
             if (cached > 0.0) {
-                clip->sourceBPM = cached;
-                if (auto* thumb = thumbs.getThumbnail(clip->audioFilePath)) {
+                clip->audio().interpretation.bpm = cached;
+                if (auto* thumb = thumbs.getThumbnail(clip->audio().source.filePath)) {
                     double fileDuration = thumb->getTotalLength();
-                    if (fileDuration > 0.0)
-                        clip->sourceNumBeats = fileDuration * cached / 60.0;
+                    if (fileDuration > 0.0) {
+                        if (clip->audio().source.durationSeconds <= 0.0)
+                            clip->audio().source.durationSeconds = fileDuration;
+                        clip->audio().interpretation.totalBeats = fileDuration * cached / 60.0;
+                    }
                 }
             } else {
                 auto cid = primaryClipId();
-                thumbs.requestBPMDetection(clip->audioFilePath, [cid](double detectedBPM) {
-                    if (detectedBPM <= 0.0)
-                        return;
-                    auto& mgr = magda::ClipManager::getInstance();
-                    auto* c = mgr.getClip(cid);
-                    if (!c)
-                        return;
-                    // Issue #1157: file metadata wins over audio analysis.
-                    // TempoDetect can be wrong by ~1.3x on syncopated loops.
-                    double live =
-                        magda::ProjectManager::getInstance().getCurrentProjectInfo().tempo;
-                    bool existingLooksDefaulted =
-                        c->sourceBPM > 0.0 && live > 0.0 && std::abs(c->sourceBPM - live) < 0.1;
-                    if (c->sourceBPM > 0.0 && !existingLooksDefaulted)
-                        return;
-                    magda::ClipManager::AudioClipBeatsUpdate u;
-                    u.sourceBPM = detectedBPM;
-                    if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
-                            c->audioFilePath)) {
-                        double fileDuration = thumb->getTotalLength();
-                        if (fileDuration > 0.0)
-                            u.sourceNumBeats = fileDuration * detectedBPM / 60.0;
-                    }
-                    mgr.applyAudioClipBeats(cid, u, live);
-                });
+                thumbs.requestBPMDetection(
+                    clip->audio().source.filePath, [cid](double detectedBPM) {
+                        if (detectedBPM <= 0.0)
+                            return;
+                        auto& mgr = magda::ClipManager::getInstance();
+                        auto* c = mgr.getClip(cid);
+                        if (!c)
+                            return;
+                        // Issue #1157: file metadata wins over audio analysis.
+                        // TempoDetect can be wrong by ~1.3x on syncopated loops.
+                        double live =
+                            magda::ProjectManager::getInstance().getCurrentProjectInfo().tempo;
+                        bool existingLooksDefaulted =
+                            c->audio().interpretation.bpm > 0.0 && live > 0.0 &&
+                            std::abs(c->audio().interpretation.bpm - live) < 0.1;
+                        if (c->audio().interpretation.bpm > 0.0 && !existingLooksDefaulted)
+                            return;
+                        magda::ClipManager::AudioClipBeatsUpdate u;
+                        u.interpretationBpm = detectedBPM;
+                        if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
+                                c->audio().source.filePath)) {
+                            double fileDuration = thumb->getTotalLength();
+                            if (fileDuration > 0.0) {
+                                u.sourceDurationSeconds = fileDuration;
+                                u.interpretationTotalBeats = fileDuration * detectedBPM / 60.0;
+                            }
+                        }
+                        mgr.applyAudioClipBeats(cid, u, live);
+                    });
             }
         }
 
@@ -807,8 +819,10 @@ void ClipInspector::initClipPropertiesSection() {
             bpm = timelineController_->getState().tempo.bpm;
         }
         // Preserve current phase when moving loop start
-        // Use sourceBPM for audio source-file positions
-        double loopBpm = (clip->isAudio() && clip->sourceBPM > 0.0) ? clip->sourceBPM : bpm;
+        // Use source interpretation BPM for audio source-file positions
+        double loopBpm = (clip->isAudio() && clip->audio().interpretation.bpm > 0.0)
+                             ? clip->audio().interpretation.bpm
+                             : bpm;
         double currentPhase = clip->offset - clip->loopStart;
         double newLoopStartBeats = clipLoopStartValue_->getValue();
         double newLoopStartSeconds =
@@ -849,8 +863,10 @@ void ClipInspector::initClipPropertiesSection() {
         }
 
         // Compute new loop length from loop end - loop start
-        // Use sourceBPM for audio source-file positions
-        double loopBpm = (clip->isAudio() && clip->sourceBPM > 0.0) ? clip->sourceBPM : bpm;
+        // Use source interpretation BPM for audio source-file positions
+        double loopBpm = (clip->isAudio() && clip->audio().interpretation.bpm > 0.0)
+                             ? clip->audio().interpretation.bpm
+                             : bpm;
         double newLoopEndBeats = clipLoopEndValue_->getValue();
         double loopStartBeats = magda::TimelineUtils::secondsToBeats(clip->loopStart, loopBpm);
         double newLoopLengthBeats = newLoopEndBeats - loopStartBeats;
@@ -858,8 +874,8 @@ void ClipInspector::initClipPropertiesSection() {
             newLoopLengthBeats = 0.25;
 
         double newLoopLengthSeconds;
-        if (clip->autoTempo && clip->sourceBPM > 0.0) {
-            newLoopLengthSeconds = (newLoopLengthBeats * 60.0) / clip->sourceBPM;
+        if (clip->autoTempo && clip->audio().interpretation.bpm > 0.0) {
+            newLoopLengthSeconds = (newLoopLengthBeats * 60.0) / clip->audio().interpretation.bpm;
         } else {
             newLoopLengthSeconds =
                 magda::TimelineUtils::beatsToSeconds(newLoopLengthBeats, loopBpm);

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -360,7 +360,7 @@ void ClipInspector::initClipPropertiesSection() {
         if (!clip || !clip->isAudio())
             return;
 
-        // Parse BPM from text (strip " BPM" suffix if present)
+        // Parse BPM from text. Older builds stored the unit in the text, so strip it defensively.
         juce::String text = clipBpmValue_.getText().trimCharactersAtEnd(" BPMbpm");
         double newBPM = text.getDoubleValue();
         DBG("[InspectorTrace] clipInspector:bpmEdit id="
@@ -416,16 +416,21 @@ void ClipInspector::initClipPropertiesSection() {
                 << " after.loopLengthBeats=" << clip->loopLengthBeats);
         }
 
-        // Re-display with suffix
-        clipBpmValue_.setText(juce::String(newBPM, 1) + " BPM", juce::dontSendNotification);
+        clipBpmValue_.setText(juce::String(newBPM, 1), juce::dontSendNotification);
         updateFromSelectedClip();
     };
     clipPropsContainer_.addChildComponent(clipBpmValue_);
 
+    clipBpmUnitLabel_.setText("BPM", juce::dontSendNotification);
+    clipBpmUnitLabel_.setFont(FontManager::getInstance().getUIFont(11.0f));
+    clipBpmUnitLabel_.setColour(juce::Label::textColourId, DarkTheme::getSecondaryTextColour());
+    clipBpmUnitLabel_.setJustificationType(juce::Justification::centredLeft);
+    clipPropsContainer_.addChildComponent(clipBpmUnitLabel_);
+
     // Source interpretation total beats (shown next to source BPM when auto-tempo is enabled)
     clipBeatsLengthValue_ = std::make_unique<DraggableValueLabel>(DraggableValueLabel::Format::Raw);
     clipBeatsLengthValue_->setRange(0.25, 4096.0, 4.0);
-    clipBeatsLengthValue_->setSuffix(" source beats");
+    clipBeatsLengthValue_->setSuffix("");
     clipBeatsLengthValue_->setDecimalPlaces(2);
     clipBeatsLengthValue_->setSnapToInteger(true);
     clipBeatsLengthValue_->setDrawBackground(false);
@@ -479,6 +484,12 @@ void ClipInspector::initClipPropertiesSection() {
         }
     };
     clipPropsContainer_.addChildComponent(*clipBeatsLengthValue_);
+
+    clipBeatsUnitLabel_.setText("Beats", juce::dontSendNotification);
+    clipBeatsUnitLabel_.setFont(FontManager::getInstance().getUIFont(11.0f));
+    clipBeatsUnitLabel_.setColour(juce::Label::textColourId, DarkTheme::getSecondaryTextColour());
+    clipBeatsUnitLabel_.setJustificationType(juce::Justification::centredLeft);
+    clipPropsContainer_.addChildComponent(clipBeatsUnitLabel_);
 
     // Position icon (static, non-interactive)
     clipPositionIcon_ = std::make_unique<magda::SvgButton>("Position", BinaryData::position_svg,

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -363,31 +363,41 @@ void ClipInspector::initClipPropertiesSection() {
         // Parse BPM from text (strip " BPM" suffix if present)
         juce::String text = clipBpmValue_.getText().trimCharactersAtEnd(" BPMbpm");
         double newBPM = text.getDoubleValue();
+        DBG("[InspectorTrace] clipInspector:bpmEdit id="
+            << clip->id << " rawText='" << clipBpmValue_.getText() << "' parsedBpm=" << newBPM
+            << " before.source.interpretation.bpm=" << clip->audio().interpretation.bpm
+            << " before.source.interpretation.totalBeats="
+            << clip->audio().interpretation.totalBeats << " before.placement.lengthBeats="
+            << clip->placement.lengthBeats << " before.loopLengthBeats=" << clip->loopLengthBeats
+            << " autoTempo=" << static_cast<int>(clip->autoTempo));
         if (newBPM < 20.0 || newBPM > 999.0)
             return;
 
         double bpm = timelineController_ ? timelineController_->getState().tempo.bpm : 120.0;
 
-        // Issue #1157: BPM edit is a CORRECTION of the detected file metadata,
-        // not a stretch control. We write only source interpretation BPM (and recompute
-        // source interpretation total beats from the file's true duration). Timeline length and
-        // loop region are user-intent and untouched — TE will adapt the
-        // playback stretch ratio to the new source interpretation BPM at the next sync.
+        // BPM and source beats are independent user-editable interpretation fields.
+        // A BPM correction must not silently rewrite the source beat count.
         if (clip->autoTempo) {
             magda::ClipManager::AudioClipBeatsUpdate u;
             u.interpretationBpm = newBPM;
             if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
                     clip->audio().source.filePath)) {
                 double fileDuration = thumb->getTotalLength();
-                if (fileDuration > 0.0) {
+                if (fileDuration > 0.0 && clip->audio().source.durationSeconds <= 0.0)
                     u.sourceDurationSeconds = fileDuration;
-                    u.interpretationTotalBeats = fileDuration * newBPM / 60.0;
-                }
             }
             magda::ClipManager::getInstance().applyAudioClipBeats(primaryClipId(), u, bpm);
+            if (auto* afterClip = magda::ClipManager::getInstance().getClip(primaryClipId())) {
+                DBG("[InspectorTrace] clipInspector:bpmEditApplied id="
+                    << afterClip->id
+                    << " after.source.interpretation.bpm=" << afterClip->audio().interpretation.bpm
+                    << " after.source.interpretation.totalBeats="
+                    << afterClip->audio().interpretation.totalBeats
+                    << " after.placement.lengthBeats=" << afterClip->placement.lengthBeats
+                    << " after.loopLengthBeats=" << afterClip->loopLengthBeats);
+            }
         } else {
-            // Non-autoTempo audio: source interpretation BPM is just stored metadata, no
-            // dependent fields to recompute. Direct write is fine.
+            // Non-autoTempo audio: source interpretation BPM is just stored metadata.
             clip->audio().interpretation.bpm = newBPM;
             if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
                     clip->audio().source.filePath)) {
@@ -395,10 +405,15 @@ void ClipInspector::initClipPropertiesSection() {
                 if (fileDuration > 0.0) {
                     if (clip->audio().source.durationSeconds <= 0.0)
                         clip->audio().source.durationSeconds = fileDuration;
-                    clip->audio().interpretation.totalBeats = fileDuration * newBPM / 60.0;
                 }
             }
             magda::ClipManager::getInstance().forceNotifyClipPropertyChanged(primaryClipId());
+            DBG("[InspectorTrace] clipInspector:bpmEditApplied id="
+                << clip->id << " after.source.interpretation.bpm="
+                << clip->audio().interpretation.bpm << " after.source.interpretation.totalBeats="
+                << clip->audio().interpretation.totalBeats
+                << " after.placement.lengthBeats=" << clip->placement.lengthBeats
+                << " after.loopLengthBeats=" << clip->loopLengthBeats);
         }
 
         // Re-display with suffix
@@ -407,10 +422,10 @@ void ClipInspector::initClipPropertiesSection() {
     };
     clipPropsContainer_.addChildComponent(clipBpmValue_);
 
-    // Length in beats (shown next to BPM when auto-tempo is enabled)
+    // Source interpretation total beats (shown next to source BPM when auto-tempo is enabled)
     clipBeatsLengthValue_ = std::make_unique<DraggableValueLabel>(DraggableValueLabel::Format::Raw);
-    clipBeatsLengthValue_->setRange(0.25, 128.0, 4.0);  // Min 0.25 beats, max 128 beats
-    clipBeatsLengthValue_->setSuffix(" beats");
+    clipBeatsLengthValue_->setRange(0.25, 4096.0, 4.0);
+    clipBeatsLengthValue_->setSuffix(" source beats");
     clipBeatsLengthValue_->setDecimalPlaces(2);
     clipBeatsLengthValue_->setSnapToInteger(true);
     clipBeatsLengthValue_->setDrawBackground(false);
@@ -420,13 +435,46 @@ void ClipInspector::initClipPropertiesSection() {
         if (primaryClipId() != magda::INVALID_CLIP_ID) {
             auto* clip = magda::ClipManager::getInstance().getClip(primaryClipId());
             if (clip && clip->autoTempo) {
-                double newBeats = clipBeatsLengthValue_->getValue();
-                double bpm =
+                double newSourceBeats = clipBeatsLengthValue_->getValue();
+                double projectBpm =
                     timelineController_ ? timelineController_->getState().tempo.bpm : 120.0;
-                // Stretch: keep source audio constant, change how many beats it fills
-                magda::UndoManager::getInstance().executeCommand(
-                    std::make_unique<magda::SetClipLengthBeatsCommand>(primaryClipId(), newBeats,
-                                                                       bpm));
+
+                double durationSeconds = clip->audio().source.durationSeconds;
+                if (durationSeconds <= 0.0) {
+                    if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
+                            clip->audio().source.filePath)) {
+                        durationSeconds = thumb->getTotalLength();
+                    }
+                }
+
+                magda::ClipManager::AudioClipBeatsUpdate u;
+                u.interpretationTotalBeats = newSourceBeats;
+                if (durationSeconds > 0.0 && clip->audio().source.durationSeconds <= 0.0)
+                    u.sourceDurationSeconds = durationSeconds;
+
+                DBG("[InspectorTrace] clipInspector:sourceBeatsEdit id="
+                    << clip->id << " newUiValue=" << newSourceBeats
+                    << " targetField=source.interpretation.totalBeats"
+                    << " before.placement.lengthBeats=" << clip->placement.lengthBeats
+                    << " before.source.interpretation.totalBeats="
+                    << clip->audio().interpretation.totalBeats
+                    << " before.source.interpretation.bpm=" << clip->audio().interpretation.bpm
+                    << " before.loopLengthBeats=" << clip->loopLengthBeats
+                    << " durationSeconds=" << durationSeconds);
+
+                magda::ClipManager::getInstance().applyAudioClipBeats(primaryClipId(), u,
+                                                                      projectBpm);
+
+                if (auto* afterClip = magda::ClipManager::getInstance().getClip(primaryClipId())) {
+                    DBG("[InspectorTrace] clipInspector:sourceBeatsEditApplied id="
+                        << afterClip->id
+                        << " after.placement.lengthBeats=" << afterClip->placement.lengthBeats
+                        << " after.source.interpretation.totalBeats="
+                        << afterClip->audio().interpretation.totalBeats
+                        << " after.source.interpretation.bpm="
+                        << afterClip->audio().interpretation.bpm
+                        << " after.loopLengthBeats=" << afterClip->loopLengthBeats);
+                }
             }
         }
     };

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -454,6 +454,7 @@ void ClipInspector::initClipPropertiesSection() {
 
                 magda::ClipManager::AudioClipBeatsUpdate u;
                 u.interpretationTotalBeats = newSourceBeats;
+                u.lockInterpretationTotalBeats = true;
                 if (durationSeconds > 0.0 && clip->audio().source.durationSeconds <= 0.0)
                     u.sourceDurationSeconds = durationSeconds;
 

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -375,16 +375,23 @@ void ClipInspector::initClipPropertiesSection() {
 
         double bpm = timelineController_ ? timelineController_->getState().tempo.bpm : 120.0;
 
-        // BPM and source beats are independent user-editable interpretation fields.
-        // A BPM correction must not silently rewrite the source beat count.
+        // BPM and Beats are two editable views of the same fixed-duration source
+        // interpretation. Editing either one must keep the other coherent.
         if (clip->autoTempo) {
             magda::ClipManager::AudioClipBeatsUpdate u;
             u.interpretationBpm = newBPM;
+            double durationSeconds = clip->audio().source.durationSeconds;
             if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
                     clip->audio().source.filePath)) {
                 double fileDuration = thumb->getTotalLength();
+                if (fileDuration > 0.0)
+                    durationSeconds = fileDuration;
                 if (fileDuration > 0.0 && clip->audio().source.durationSeconds <= 0.0)
                     u.sourceDurationSeconds = fileDuration;
+            }
+            if (durationSeconds > 0.0) {
+                u.interpretationTotalBeats = durationSeconds * newBPM / 60.0;
+                u.lockInterpretationTotalBeats = true;
             }
             magda::ClipManager::getInstance().applyAudioClipBeats(primaryClipId(), u, bpm);
             if (auto* afterClip = magda::ClipManager::getInstance().getClip(primaryClipId())) {
@@ -455,6 +462,8 @@ void ClipInspector::initClipPropertiesSection() {
                 magda::ClipManager::AudioClipBeatsUpdate u;
                 u.interpretationTotalBeats = newSourceBeats;
                 u.lockInterpretationTotalBeats = true;
+                if (durationSeconds > 0.0)
+                    u.interpretationBpm = newSourceBeats * 60.0 / durationSeconds;
                 if (durationSeconds > 0.0 && clip->audio().source.durationSeconds <= 0.0)
                     u.sourceDurationSeconds = durationSeconds;
 

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -616,8 +616,9 @@ void ClipInspector::initClipPropertiesSection() {
         if (!clip)
             return;
 
-        // Beat mode requires loop — don't allow disabling
-        if (clip->autoTempo && clipLoopToggle_->isActive())
+        // Beat mode owns looping. Keep the button visually active, but don't let a click
+        // make the model appear to toggle out from under auto-tempo playback.
+        if (clip->autoTempo)
             return;
 
         bool newState = !clipLoopToggle_->isActive();

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSelection.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSelection.cpp
@@ -1,3 +1,4 @@
+#include "../../../../state/TimelineController.hpp"
 #include "../ClipInspector.hpp"
 
 namespace magda::daw::ui {
@@ -42,12 +43,20 @@ void ClipInspector::clipPropertyChanged(magda::ClipId clipId) {
                        (beatSensitivityValue_ && beatSensitivityValue_->isDragging()) ||
                        (transientSensitivityValue_ && transientSensitivityValue_->isDragging());
     if (anyDragging) {
-        // Still update dependent readouts during drag without relayout. Loop-length edits drive
-        // source total beats while unlocked, so the Beats field must follow live.
+        // Still update dependent readouts during drag without relayout. Source Beats/BPM edits can
+        // move the displayed loop end, so the loop row must follow live.
         auto pid = primaryClipId();
         const auto* clip = magda::ClipManager::getInstance().getClip(pid);
         if (clip && clip->isAudio()) {
             updateAudioSourceValueDisplays(*clip);
+            double projectBPM = 120.0;
+            int beatsPerBar = 4;
+            if (timelineController_) {
+                const auto& state = timelineController_->getState();
+                projectBPM = state.tempo.bpm;
+                beatsPerBar = state.tempo.timeSignatureNumerator;
+            }
+            updateLoopValueDisplays(*clip, projectBPM, beatsPerBar);
 
             // PitchChange affects effective mode.
             int effectiveMode = clip->timeStretchMode;

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSelection.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSelection.cpp
@@ -42,10 +42,14 @@ void ClipInspector::clipPropertyChanged(magda::ClipId clipId) {
                        (beatSensitivityValue_ && beatSensitivityValue_->isDragging()) ||
                        (transientSensitivityValue_ && transientSensitivityValue_->isDragging());
     if (anyDragging) {
-        // Still update stretch mode combo during drag — pitchChange affects effective mode
+        // Still update dependent readouts during drag without relayout. Loop-length edits drive
+        // source total beats while unlocked, so the Beats field must follow live.
         auto pid = primaryClipId();
         const auto* clip = magda::ClipManager::getInstance().getClip(pid);
         if (clip && clip->isAudio()) {
+            updateAudioSourceValueDisplays(*clip);
+
+            // PitchChange affects effective mode.
             int effectiveMode = clip->timeStretchMode;
             bool isAnalog = clip->isAnalogPitchActive();
             if (!isAnalog && effectiveMode == 0 &&

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
@@ -11,6 +11,37 @@
 
 namespace magda::daw::ui {
 
+void ClipInspector::updateAudioSourceValueDisplays(const magda::ClipInfo& clip) {
+    if (!clip.isAudio()) {
+        return;
+    }
+
+    const bool showAudioProps = !audioPropsCollapsed_ && clip.isAudio();
+    if (showAudioProps) {
+        double displayBPM = clip.audio().interpretation.bpm;
+        double projectBPM = timelineController_ ? timelineController_->getState().tempo.bpm : 120.0;
+        if (displayBPM <= 0.0 || (!clip.autoTempo && std::abs(displayBPM - projectBPM) < 0.1)) {
+            displayBPM = magda::AudioThumbnailManager::getInstance().getCachedBPM(
+                clip.audio().source.filePath);
+        }
+
+        if (displayBPM > 0.0) {
+            clipBpmValue_.setText(juce::String(displayBPM, 1), juce::dontSendNotification);
+        } else {
+            clipBpmValue_.setText(juce::String::fromUTF8("\xe2\x80\x94"),
+                                  juce::dontSendNotification);
+        }
+    }
+
+    if (showAudioProps && clip.autoTempo && clipBeatsLengthValue_ &&
+        !clipBeatsLengthValue_->isDragging()) {
+        clipBeatsLengthValue_->setValue(clip.audio().interpretation.totalBeats > 0.0
+                                            ? clip.audio().interpretation.totalBeats
+                                            : 4.0,
+                                        juce::dontSendNotification);
+    }
+}
+
 void ClipInspector::updateFromSelectedClip() {
     auto pid = primaryClipId();
     if (pid == magda::INVALID_CLIP_ID) {
@@ -160,12 +191,7 @@ void ClipInspector::updateFromSelectedClip() {
             }
             clipBpmValue_.setVisible(true);
             clipBpmUnitLabel_.setVisible(true);
-            if (displayBPM > 0.0) {
-                clipBpmValue_.setText(juce::String(displayBPM, 1), juce::dontSendNotification);
-            } else {
-                clipBpmValue_.setText(juce::String::fromUTF8("\xe2\x80\x94"),  // em dash
-                                      juce::dontSendNotification);
-            }
+            updateAudioSourceValueDisplays(*clip);
             DBG("[InspectorTrace] clipInspector:bpmDisplay id="
                 << clip->id << " text='" << clipBpmValue_.getText()
                 << "' source.interpretation.bpm=" << clip->audio().interpretation.bpm
@@ -185,10 +211,7 @@ void ClipInspector::updateFromSelectedClip() {
             clipBeatsUnitLabel_.setVisible(true);
             clipBeatsLengthValue_->setEnabled(true);
             clipBeatsLengthValue_->setAlpha(1.0f);
-            clipBeatsLengthValue_->setValue(clip->audio().interpretation.totalBeats > 0.0
-                                                ? clip->audio().interpretation.totalBeats
-                                                : 4.0,
-                                            juce::dontSendNotification);
+            updateAudioSourceValueDisplays(*clip);
             DBG("[InspectorTrace] clipInspector:sourceBeatsDisplay id="
                 << clip->id << " ui.value=" << clipBeatsLengthValue_->getValue()
                 << " boundField=source.interpretation.totalBeats"
@@ -254,12 +277,13 @@ void ClipInspector::updateFromSelectedClip() {
             }
         }
 
-        clipLoopToggle_->setActive(clip->loopEnabled);
-        // Beat mode forces loop on — disable the toggle so user can't turn it off
-        clipLoopToggle_->setEnabled(!clip->autoTempo);
+        clipLoopToggle_->setActive(clip->loopEnabled || clip->autoTempo);
+        // Beat mode forces loop on, but the button should still read as active rather than
+        // disabled. Click handling ignores attempts to toggle it while auto-tempo owns looping.
+        clipLoopToggle_->setEnabled(true);
 
         // Loop state determines offset interactivity and loop row visibility
-        bool loopOn = isSessionClip || clip->loopEnabled;
+        bool loopOn = isSessionClip || clip->loopEnabled || clip->autoTempo;
 
         if (loopOn) {
             // Loop ON: offset in position row becomes disabled/greyed

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
@@ -38,9 +38,10 @@ void ClipInspector::updateFromSelectedClip() {
     // Only for single-clip selection to avoid sanitization conflicts
     if (!isMulti) {
         auto* mutableClip = magda::ClipManager::getInstance().getClip(pid);
-        if (mutableClip && mutableClip->isAudio() && !mutableClip->audioFilePath.isEmpty()) {
+        if (mutableClip && mutableClip->isAudio() &&
+            !mutableClip->audio().source.filePath.isEmpty()) {
             auto* thumbnail = magda::AudioThumbnailManager::getInstance().getThumbnail(
-                mutableClip->audioFilePath);
+                mutableClip->audio().source.filePath);
             if (thumbnail) {
                 const double fileDur = thumbnail->getTotalLength();
                 if (fileDur > 0.0) {
@@ -100,11 +101,11 @@ void ClipInspector::updateFromSelectedClip() {
             swatch->setColour(clip->colour);
 
         // File path label: show audio filename for arrangement audio clips only.
-        if (clip->isAudio() && clip->audioFilePath.isNotEmpty() &&
+        if (clip->isAudio() && clip->audio().source.filePath.isNotEmpty() &&
             clip->view != magda::ClipView::Session && !isMulti) {
-            juce::File audioFile(clip->audioFilePath);
+            juce::File audioFile(clip->audio().source.filePath);
             clipFilePathLabel_.setText(audioFile.getFileName(), juce::dontSendNotification);
-            clipFilePathLabel_.setTooltip(clip->audioFilePath);
+            clipFilePathLabel_.setTooltip(clip->audio().source.filePath);
         } else {
             clipFilePathLabel_.setText("", juce::dontSendNotification);
             clipFilePathLabel_.setTooltip("");
@@ -136,21 +137,21 @@ void ClipInspector::updateFromSelectedClip() {
         }
 
         // Show BPM for audio clips (at bottom with WARP)
-        // Prefer clip's sourceBPM (may be user-edited), fall back to detected BPM
+        // Prefer clip's source interpretation BPM (may be user-edited), fall back to detected BPM
         if (showAudioProps && !isMulti) {
-            double displayBPM = clip->sourceBPM;
+            double displayBPM = clip->audio().interpretation.bpm;
             double projectBPM =
                 timelineController_ ? timelineController_->getState().tempo.bpm : 120.0;
             if (displayBPM <= 0.0 ||
                 (!clip->autoTempo && std::abs(displayBPM - projectBPM) < 0.1)) {
-                // sourceBPM is unset or matches project BPM (defaulted) — use detected.
-                // Read cached value only; if missing, kick off async detection and refresh
-                // the inspector via the existing clipPropertyChanged listener path.
+                // source interpretation BPM is unset or matches project BPM (defaulted) — use
+                // detected. Read cached value only; if missing, kick off async detection and
+                // refresh the inspector via the existing clipPropertyChanged listener path.
                 auto& thumbs = magda::AudioThumbnailManager::getInstance();
-                displayBPM = thumbs.getCachedBPM(clip->audioFilePath);
+                displayBPM = thumbs.getCachedBPM(clip->audio().source.filePath);
                 if (displayBPM <= 0.0) {
                     auto cid = pid;
-                    thumbs.requestBPMDetection(clip->audioFilePath, [cid](double bpm) {
+                    thumbs.requestBPMDetection(clip->audio().source.filePath, [cid](double bpm) {
                         if (bpm <= 0.0)
                             return;
                         magda::ClipManager::getInstance().forceNotifyClipPropertyChanged(cid);
@@ -177,8 +178,9 @@ void ClipInspector::updateFromSelectedClip() {
             // Issue #1157: display lengthBeats (timeline beats — what the slider
             // writes), not loopLengthBeats (source-beat domain). Showing the
             // source-domain value made this readout drift away from the right-side
-            // Clip panel as soon as sourceBPM differed from project BPM.
-            clipBeatsLengthValue_->setValue(clip->lengthBeats, juce::dontSendNotification);
+            // Clip panel as soon as source interpretation BPM differed from project BPM.
+            clipBeatsLengthValue_->setValue(clip->placement.lengthBeats,
+                                            juce::dontSendNotification);
         } else {
             clipBeatsLengthValue_->setVisible(false);
         }
@@ -228,8 +230,9 @@ void ClipInspector::updateFromSelectedClip() {
             if (clip->isMidi()) {
                 clipContentOffsetValue_->setValue(clip->midiOffset, juce::dontSendNotification);
             } else if (clip->isAudio()) {
-                // Use sourceBPM for source-file positions when available
-                double displayBpm = clip->sourceBPM > 0.0 ? clip->sourceBPM : bpm;
+                // Use source interpretation BPM for source-file positions when available
+                double displayBpm =
+                    clip->audio().interpretation.bpm > 0.0 ? clip->audio().interpretation.bpm : bpm;
                 double offsetBeats = magda::TimelineUtils::secondsToBeats(clip->offset, displayBpm);
                 clipContentOffsetValue_->setValue(offsetBeats, juce::dontSendNotification);
             }
@@ -251,8 +254,11 @@ void ClipInspector::updateFromSelectedClip() {
             clipLoopStartLabel_.setVisible(true);
             clipLoopStartValue_->setVisible(true);
             clipLoopStartValue_->setBeatsPerBar(beatsPerBar);
-            // For audio clips, loop start/end are source-file positions — use sourceBPM
-            double loopBpm = (clip->isAudio() && clip->sourceBPM > 0.0) ? clip->sourceBPM : bpm;
+            // For audio clips, loop start/end are source-file positions — use source interpretation
+            // BPM
+            double loopBpm = (clip->isAudio() && clip->audio().interpretation.bpm > 0.0)
+                                 ? clip->audio().interpretation.bpm
+                                 : bpm;
             double loopStartBeats = magda::TimelineUtils::secondsToBeats(clip->loopStart, loopBpm);
             clipLoopStartValue_->setValue(loopStartBeats, juce::dontSendNotification);
             clipLoopStartValue_->setEnabled(true);

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
@@ -166,21 +166,34 @@ void ClipInspector::updateFromSelectedClip() {
                 clipBpmValue_.setText(juce::String::fromUTF8("\xe2\x80\x94"),  // em dash
                                       juce::dontSendNotification);
             }
+            DBG("[InspectorTrace] clipInspector:bpmDisplay id="
+                << clip->id << " text='" << clipBpmValue_.getText()
+                << "' source.interpretation.bpm=" << clip->audio().interpretation.bpm
+                << " source.interpretation.totalBeats=" << clip->audio().interpretation.totalBeats
+                << " source.durationSeconds=" << clip->audio().source.durationSeconds
+                << " placement.lengthBeats=" << clip->placement.lengthBeats
+                << " loopLengthBeats=" << clip->loopLengthBeats);
         } else {
             clipBpmValue_.setVisible(false);
         }
 
-        // Show length in beats for audio clips with auto-tempo enabled (read-only display)
+        // Show source interpretation total beats for audio clips with auto-tempo enabled.
+        // Clip placement length is already represented by start/end and by the clip body itself.
         if (showAudioProps && clip->autoTempo && !isMulti) {
             clipBeatsLengthValue_->setVisible(true);
             clipBeatsLengthValue_->setEnabled(true);
             clipBeatsLengthValue_->setAlpha(1.0f);
-            // Issue #1157: display lengthBeats (timeline beats — what the slider
-            // writes), not loopLengthBeats (source-beat domain). Showing the
-            // source-domain value made this readout drift away from the right-side
-            // Clip panel as soon as source interpretation BPM differed from project BPM.
-            clipBeatsLengthValue_->setValue(clip->placement.lengthBeats,
+            clipBeatsLengthValue_->setValue(clip->audio().interpretation.totalBeats > 0.0
+                                                ? clip->audio().interpretation.totalBeats
+                                                : 4.0,
                                             juce::dontSendNotification);
+            DBG("[InspectorTrace] clipInspector:sourceBeatsDisplay id="
+                << clip->id << " ui.value=" << clipBeatsLengthValue_->getValue()
+                << " boundField=source.interpretation.totalBeats"
+                << " placement.lengthBeats=" << clip->placement.lengthBeats
+                << " source.interpretation.totalBeats=" << clip->audio().interpretation.totalBeats
+                << " source.interpretation.bpm=" << clip->audio().interpretation.bpm
+                << " loopLengthBeats=" << clip->loopLengthBeats);
         } else {
             clipBeatsLengthValue_->setVisible(false);
         }

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
@@ -159,9 +159,9 @@ void ClipInspector::updateFromSelectedClip() {
                 }
             }
             clipBpmValue_.setVisible(true);
+            clipBpmUnitLabel_.setVisible(true);
             if (displayBPM > 0.0) {
-                clipBpmValue_.setText(juce::String(displayBPM, 1) + " BPM",
-                                      juce::dontSendNotification);
+                clipBpmValue_.setText(juce::String(displayBPM, 1), juce::dontSendNotification);
             } else {
                 clipBpmValue_.setText(juce::String::fromUTF8("\xe2\x80\x94"),  // em dash
                                       juce::dontSendNotification);
@@ -175,12 +175,14 @@ void ClipInspector::updateFromSelectedClip() {
                 << " loopLengthBeats=" << clip->loopLengthBeats);
         } else {
             clipBpmValue_.setVisible(false);
+            clipBpmUnitLabel_.setVisible(false);
         }
 
         // Show source interpretation total beats for audio clips with auto-tempo enabled.
         // Clip placement length is already represented by start/end and by the clip body itself.
         if (showAudioProps && clip->autoTempo && !isMulti) {
             clipBeatsLengthValue_->setVisible(true);
+            clipBeatsUnitLabel_.setVisible(true);
             clipBeatsLengthValue_->setEnabled(true);
             clipBeatsLengthValue_->setAlpha(1.0f);
             clipBeatsLengthValue_->setValue(clip->audio().interpretation.totalBeats > 0.0
@@ -196,6 +198,7 @@ void ClipInspector::updateFromSelectedClip() {
                 << " loopLengthBeats=" << clip->loopLengthBeats);
         } else {
             clipBeatsLengthValue_->setVisible(false);
+            clipBeatsUnitLabel_.setVisible(false);
         }
 
         // Get tempo from TimelineController, fallback to 120 BPM if not available
@@ -529,7 +532,9 @@ void ClipInspector::showClipControls(bool show) {
         audioPropsCollapseToggle_.setVisible(false);
         audioPropsLabel_.setVisible(false);
         clipBpmValue_.setVisible(false);
+        clipBpmUnitLabel_.setVisible(false);
         clipBeatsLengthValue_->setVisible(false);
+        clipBeatsUnitLabel_.setVisible(false);
         clipPositionIcon_->setVisible(false);
         clipStartLabel_.setVisible(false);
         clipStartValue_->setVisible(false);

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
@@ -42,6 +42,44 @@ void ClipInspector::updateAudioSourceValueDisplays(const magda::ClipInfo& clip) 
     }
 }
 
+void ClipInspector::updateLoopValueDisplays(const magda::ClipInfo& clip, double projectBPM,
+                                            int beatsPerBar) {
+    if (!clipLoopStartValue_ || !clipLoopEndValue_ || !clipLoopPhaseValue_)
+        return;
+
+    clipLoopStartValue_->setBeatsPerBar(beatsPerBar);
+    clipLoopEndValue_->setBeatsPerBar(beatsPerBar);
+    clipLoopPhaseValue_->setBeatsPerBar(beatsPerBar);
+
+    double loopBpm = projectBPM;
+    if (clip.isAudio() && clip.audio().interpretation.bpm > 0.0)
+        loopBpm = clip.audio().interpretation.bpm;
+    if (loopBpm <= 0.0)
+        loopBpm = 120.0;
+
+    const double loopStartBeats = magda::TimelineUtils::secondsToBeats(clip.loopStart, loopBpm);
+    clipLoopStartValue_->setValue(loopStartBeats, juce::dontSendNotification);
+
+    double loopLengthDisplayBeats = 0.0;
+    if (clip.autoTempo && clip.loopLengthBeats > 0.0) {
+        loopLengthDisplayBeats = clip.loopLengthBeats;
+    } else {
+        const double sourceLength =
+            clip.loopLength > 0.0 ? clip.loopLength : clip.length * clip.speedRatio;
+        loopLengthDisplayBeats = magda::TimelineUtils::secondsToBeats(sourceLength, loopBpm);
+    }
+    clipLoopEndValue_->setValue(loopStartBeats + loopLengthDisplayBeats,
+                                juce::dontSendNotification);
+
+    if (clip.isMidi()) {
+        clipLoopPhaseValue_->setValue(clip.midiOffset, juce::dontSendNotification);
+    } else {
+        const double phaseSeconds = clip.offset - clip.loopStart;
+        const double phaseBeats = magda::TimelineUtils::secondsToBeats(phaseSeconds, loopBpm);
+        clipLoopPhaseValue_->setValue(phaseBeats, juce::dontSendNotification);
+    }
+}
+
 void ClipInspector::updateFromSelectedClip() {
     auto pid = primaryClipId();
     if (pid == magda::INVALID_CLIP_ID) {
@@ -293,46 +331,19 @@ void ClipInspector::updateFromSelectedClip() {
             // Show loop row: lstart | lend | phase
             clipLoopStartLabel_.setVisible(true);
             clipLoopStartValue_->setVisible(true);
-            clipLoopStartValue_->setBeatsPerBar(beatsPerBar);
-            // For audio clips, loop start/end are source-file positions — use source interpretation
-            // BPM
-            double loopBpm = (clip->isAudio() && clip->audio().interpretation.bpm > 0.0)
-                                 ? clip->audio().interpretation.bpm
-                                 : bpm;
-            double loopStartBeats = magda::TimelineUtils::secondsToBeats(clip->loopStart, loopBpm);
-            clipLoopStartValue_->setValue(loopStartBeats, juce::dontSendNotification);
+            updateLoopValueDisplays(*clip, bpm, beatsPerBar);
             clipLoopStartValue_->setEnabled(true);
             clipLoopStartValue_->setAlpha(1.0f);
             clipLoopStartLabel_.setAlpha(1.0f);
 
-            // Display loop end (loopStart + loopLength) in beats
-            double loopLengthDisplayBeats;
-            if (clip->autoTempo && clip->loopLengthBeats > 0.0) {
-                loopLengthDisplayBeats = clip->loopLengthBeats;
-            } else {
-                double sourceLength =
-                    clip->loopLength > 0.0 ? clip->loopLength : clip->length * clip->speedRatio;
-                loopLengthDisplayBeats =
-                    magda::TimelineUtils::secondsToBeats(sourceLength, loopBpm);
-            }
-            double loopEndBeats = loopStartBeats + loopLengthDisplayBeats;
             clipLoopEndLabel_.setVisible(true);
             clipLoopEndValue_->setVisible(true);
-            clipLoopEndValue_->setValue(loopEndBeats, juce::dontSendNotification);
             clipLoopEndValue_->setEnabled(true);
             clipLoopEndValue_->setAlpha(1.0f);
             clipLoopEndLabel_.setAlpha(1.0f);
 
             clipLoopPhaseLabel_.setVisible(true);
             clipLoopPhaseValue_->setVisible(true);
-            clipLoopPhaseValue_->setBeatsPerBar(beatsPerBar);
-            if (clip->isMidi()) {
-                clipLoopPhaseValue_->setValue(clip->midiOffset, juce::dontSendNotification);
-            } else {
-                double phaseSeconds = clip->offset - clip->loopStart;
-                double phaseBeats = magda::TimelineUtils::secondsToBeats(phaseSeconds, loopBpm);
-                clipLoopPhaseValue_->setValue(phaseBeats, juce::dontSendNotification);
-            }
             clipLoopPhaseValue_->setEnabled(true);
             clipLoopPhaseValue_->setAlpha(1.0f);
             clipLoopPhaseLabel_.setAlpha(1.0f);

--- a/magda/daw/ui/views/SessionClipEditor.cpp
+++ b/magda/daw/ui/views/SessionClipEditor.cpp
@@ -31,7 +31,7 @@ class SessionClipEditor::WaveformDisplay : public juce::Component {
 
         // Get clip info
         const auto* clip = ClipManager::getInstance().getClip(clipId_);
-        if (!clip || !clip->isAudio() || clip->audioFilePath.isEmpty()) {
+        if (!clip || !clip->isAudio() || clip->audio().source.filePath.isEmpty()) {
             // No waveform to show
             g.setColour(DarkTheme::getSecondaryTextColour());
             g.setFont(FontManager::getInstance().getUIFont(14.0f));
@@ -43,7 +43,7 @@ class SessionClipEditor::WaveformDisplay : public juce::Component {
 
         // Get waveform from cache
         auto* thumbnail =
-            magda::AudioThumbnailManager::getInstance().getThumbnail(clip->audioFilePath);
+            magda::AudioThumbnailManager::getInstance().getThumbnail(clip->audio().source.filePath);
         if (thumbnail && thumbnail->getTotalLength() > 0.0) {
             // Build display info using project BPM
             double bpm = 120.0;
@@ -317,7 +317,7 @@ void SessionClipEditor::updateControls() {
     lengthLabel_->setText(juce::String(clip->length, 2) + " beats", juce::dontSendNotification);
 
     // Update offset slider
-    if (clip->audioFilePath.isNotEmpty()) {
+    if (clip->audio().source.filePath.isNotEmpty()) {
         offsetSlider_->setValue(clip->offset, juce::dontSendNotification);
     }
 

--- a/magda/daw/ui/views/SessionView.cpp
+++ b/magda/daw/ui/views/SessionView.cpp
@@ -3569,7 +3569,6 @@ void SessionView::filesDropped(const juce::StringArray& files, int x, int y) {
             UndoManager::getInstance().executeCommand(std::make_unique<SetClipNameCommand>(
                 newClipId, audioFile.getFileNameWithoutExtension()));
             clipManager.setClipLoopEnabled(newClipId, true, bpm);
-            clipManager.setLoopLength(newClipId, fileDuration);
             clipManager.setClipSceneIndex(newClipId, sceneSlot);
         }
     };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -141,6 +141,18 @@ target_sources(magda_juce_tests PRIVATE
     # test_export_no_assertion_juce.cpp  # Disabled - see issue #611 (generator device export)
     test_midi_recording_juce.cpp
     test_clip_sync_integration_juce.cpp
+    test_clip_inspector_juce.cpp
+    ../magda/daw/ui/panels/content/inspector/clip/ClipInspectorInit.cpp
+    ../magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+    ../magda/daw/ui/panels/content/inspector/clip/ClipInspectorLifecycle.cpp
+    ../magda/daw/ui/panels/content/inspector/clip/ClipInspectorLayout.cpp
+    ../magda/daw/ui/panels/content/inspector/clip/ClipInspectorSelection.cpp
+    ../magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
+    ../magda/daw/ui/panels/content/inspector/clip/sections/ClipFadesSection.cpp
+    ../magda/daw/ui/components/common/BarsBeatsTicksLabel.cpp
+    ../magda/daw/ui/components/common/DraggableValueLabel.cpp
+    ../magda/daw/ui/components/common/SvgButton.cpp
+    ../magda/daw/ui/themes/FontManager.cpp
     test_automation_modes_juce.cpp
 )
 
@@ -159,4 +171,13 @@ target_link_libraries(magda_juce_tests
 target_include_directories(magda_juce_tests
     PRIVATE
     ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/magda/daw/ui
+    ${CMAKE_SOURCE_DIR}/magda/daw/ui/themes
+    ${CMAKE_SOURCE_DIR}/magda/daw/ui/panels
+    ${CMAKE_SOURCE_DIR}/magda/daw/ui/panels/state
+    ${CMAKE_SOURCE_DIR}/magda/daw/ui/panels/content
+    ${CMAKE_SOURCE_DIR}/magda/daw/ui/state
+    ${CMAKE_SOURCE_DIR}/magda/daw/ui/components
+    ${CMAKE_SOURCE_DIR}/magda/daw/ui/components/common
+    ${CMAKE_SOURCE_DIR}/magda/daw/ui/components/common/curve
 )

--- a/tests/juce_tests_main.cpp
+++ b/tests/juce_tests_main.cpp
@@ -26,7 +26,11 @@ int main(int argc, char* argv[]) {
     std::cout << "Running MAGDA JUCE Unit Tests\n";
     std::cout << "========================================\n\n";
 
-    runner.runTestsInCategory("magda");
+    if (argc > 1) {
+        runner.runTestsWithName(argv[1]);
+    } else {
+        runner.runTestsInCategory("magda");
+    }
 
     std::cout << "\n========================================\n";
     std::cout << "Test Results Summary\n";

--- a/tests/test_audio_clip_stretch.cpp
+++ b/tests/test_audio_clip_stretch.cpp
@@ -20,6 +20,7 @@ TEST_CASE("Audio clip - Stretch factor basics", "[audio][clip][stretch]") {
 
     SECTION("Default stretch factor is 1.0") {
         ClipInfo clip;
+        clip.setAudioContent();
         clip.audio().source.filePath = "test.wav";
         clip.length = 4.0;
         clip.speedRatio = 1.0;
@@ -31,6 +32,7 @@ TEST_CASE("Audio clip - Stretch factor basics", "[audio][clip][stretch]") {
 
     SECTION("Stretch factor affects file time window") {
         ClipInfo clip;
+        clip.setAudioContent();
         clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.length = 4.0;
@@ -45,6 +47,7 @@ TEST_CASE("Audio clip - Stretch factor basics", "[audio][clip][stretch]") {
 
     SECTION("Stretch factor 0.5 = 2x slower") {
         ClipInfo clip;
+        clip.setAudioContent();
         clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.length = 8.0;

--- a/tests/test_audio_clip_stretch.cpp
+++ b/tests/test_audio_clip_stretch.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Audio clip - Stretch factor basics", "[audio][clip][stretch]") {
 
     SECTION("Default stretch factor is 1.0") {
         ClipInfo clip;
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.length = 4.0;
         clip.speedRatio = 1.0;
 
@@ -31,7 +31,7 @@ TEST_CASE("Audio clip - Stretch factor basics", "[audio][clip][stretch]") {
 
     SECTION("Stretch factor affects file time window") {
         ClipInfo clip;
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.length = 4.0;
         clip.speedRatio = 2.0;  // 2x faster
@@ -45,7 +45,7 @@ TEST_CASE("Audio clip - Stretch factor basics", "[audio][clip][stretch]") {
 
     SECTION("Stretch factor 0.5 = 2x slower") {
         ClipInfo clip;
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.length = 8.0;
         clip.speedRatio = 0.5;  // 2x slower
@@ -70,7 +70,7 @@ TEST_CASE("ClipManager - setSpeedRatio clamping", "[audio][clip][stretch]") {
 
         const auto* clip = ClipManager::getInstance().getClip(clipId);
         REQUIRE(clip != nullptr);
-        REQUIRE(clip->audioFilePath == "test.wav");
+        REQUIRE(clip->audio().source.filePath == "test.wav");
 
         // Test minimum clamp
         ClipManager::getInstance().setSpeedRatio(clipId, 0.1);
@@ -282,7 +282,7 @@ TEST_CASE("ClipOperations - stretchAudioFromLeft right edge anchoring",
     SECTION("Multiple stretch events maintain fixed right edge") {
         ClipInfo clip;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.startTime = 10.0;
         clip.length = 5.0;
@@ -337,7 +337,7 @@ TEST_CASE("ClipOperations - stretchAudioFromLeft right edge anchoring",
     SECTION("Stretch factor clamping doesn't break right edge anchoring") {
         ClipInfo clip;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.startTime = 5.0;
         clip.length = 2.0;
@@ -365,7 +365,7 @@ TEST_CASE("ClipOperations - stretchAudioFromLeft right edge anchoring",
     SECTION("Stretch with pre-stretched audio maintains correct calculations") {
         ClipInfo clip;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.startTime = 20.0;
         clip.length = 10.0;

--- a/tests/test_auto_tempo.cpp
+++ b/tests/test_auto_tempo.cpp
@@ -10,7 +10,7 @@
  * These tests verify:
  * - setSourceMetadata only populates unset fields
  * - setAutoTempo uses source beats when detected BPM differs from project BPM
- * - setAutoTempo calibrates sourceBPM when it matches project BPM (defaulted BPM case)
+ * - setAutoTempo calibrates source interpretation BPM when it matches project BPM
  * - getAutoTempoBeatRange produces correct source beats for TE
  * - Clip length is correct after enabling musical mode
  * - getEndBeats returns consistent values
@@ -33,27 +33,27 @@ static constexpr double PROJECT_BPM = 69.0;
 static ClipInfo makeAmenClip(double startTime = 0.0) {
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audioFilePath = "amen_break.wav";
+    clip.audio().source.filePath = "amen_break.wav";
     clip.startTime = startTime;
     clip.length = AMEN_DURATION;  // original duration before stretching
     clip.offset = 0.0;
     clip.speedRatio = 1.0;
-    clip.sourceBPM = AMEN_ORIGINAL_BPM;
-    clip.sourceNumBeats = AMEN_SOURCE_BEATS;
+    clip.audio().interpretation.bpm = AMEN_ORIGINAL_BPM;
+    clip.audio().interpretation.totalBeats = AMEN_SOURCE_BEATS;
     return clip;
 }
 
-// Helper: make a clip where sourceBPM matches projectBPM (defaulted/calibrated case)
+// Helper: make a clip where source interpretation BPM matches project BPM
 static ClipInfo makeCalibratedClip(double projectBPM = 120.0) {
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audioFilePath = "sample.wav";
+    clip.audio().source.filePath = "sample.wav";
     clip.startTime = 0.0;
     clip.length = 2.0;
     clip.offset = 0.0;
     clip.speedRatio = 1.0;
-    clip.sourceBPM = projectBPM;  // matches project → calibration applies
-    clip.sourceNumBeats = 4.0;
+    clip.audio().interpretation.bpm = projectBPM;  // matches project → calibration applies
+    clip.audio().interpretation.totalBeats = 4.0;
     return clip;
 }
 
@@ -63,58 +63,59 @@ static ClipInfo makeCalibratedClip(double projectBPM = 120.0) {
 
 TEST_CASE("ClipInfo::setSourceMetadata - populates unset fields", "[clip][auto-tempo][metadata]") {
     ClipInfo clip;
+    clip.setAudioContent();
 
     SECTION("Sets both fields when unset") {
         clip.setSourceMetadata(4.0, 120.0);
-        REQUIRE(clip.sourceNumBeats == 4.0);
-        REQUIRE(clip.sourceBPM == 120.0);
+        REQUIRE(clip.audio().interpretation.totalBeats == 4.0);
+        REQUIRE(clip.audio().interpretation.bpm == 120.0);
     }
 
     SECTION("Does not overwrite existing values") {
-        clip.sourceNumBeats = 8.0;
-        clip.sourceBPM = 140.0;
+        clip.audio().interpretation.totalBeats = 8.0;
+        clip.audio().interpretation.bpm = 140.0;
         clip.setSourceMetadata(4.0, 120.0);
-        REQUIRE(clip.sourceNumBeats == 8.0);
-        REQUIRE(clip.sourceBPM == 140.0);
+        REQUIRE(clip.audio().interpretation.totalBeats == 8.0);
+        REQUIRE(clip.audio().interpretation.bpm == 140.0);
     }
 
     SECTION("Ignores zero/negative input") {
         clip.setSourceMetadata(0.0, -5.0);
-        REQUIRE(clip.sourceNumBeats == 0.0);
-        REQUIRE(clip.sourceBPM == 0.0);
+        REQUIRE(clip.audio().interpretation.totalBeats == 0.0);
+        REQUIRE(clip.audio().interpretation.bpm == 0.0);
     }
 
     SECTION("Sets one field independently of the other") {
-        clip.sourceBPM = 140.0;  // already set
+        clip.audio().interpretation.bpm = 140.0;  // already set
         clip.setSourceMetadata(4.0, 120.0);
-        REQUIRE(clip.sourceNumBeats == 4.0);  // was unset, gets populated
-        REQUIRE(clip.sourceBPM == 140.0);     // was set, not overwritten
+        REQUIRE(clip.audio().interpretation.totalBeats == 4.0);  // was unset, gets populated
+        REQUIRE(clip.audio().interpretation.bpm == 140.0);       // was set, not overwritten
     }
 }
 
 // ─────────────────────────────────────────────────────────────
 // ClipOperations::setAutoTempo — with real detected BPM
-// When sourceBPM differs from projectBPM, it's a real detected
+// When source interpretation BPM differs from project BPM, it's a real detected
 // BPM and should NOT be calibrated. lengthBeats preserves the
 // clip's current timeline length (not source beats).
 // ─────────────────────────────────────────────────────────────
 
-// Issue #1157: when the file carries tempo metadata (sourceBPM/sourceNumBeats),
-// setAutoTempo defaults lengthBeats to sourceNumBeats so a freshly-dropped loop
+// Issue #1157: when the file carries source interpretation data,
+// setAutoTempo defaults placement length to that beat extent so a freshly-dropped loop
 // becomes its natural musical length, not (length × projectBPM / 60).
 static constexpr double AMEN_EXPECTED_LENGTH_BEATS = AMEN_SOURCE_BEATS;
 
 TEST_CASE("setAutoTempo - preserves real detected BPM", "[clip][auto-tempo]") {
     auto clip = makeAmenClip();
 
-    SECTION("sourceBPM preserved when it differs from project BPM") {
+    SECTION("source interpretation BPM preserved when it differs from project BPM") {
         ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
-        REQUIRE(clip.sourceBPM == Approx(AMEN_ORIGINAL_BPM));
+        REQUIRE(clip.audio().interpretation.bpm == Approx(AMEN_ORIGINAL_BPM));
     }
 
-    SECTION("sourceNumBeats preserved when sourceBPM differs from project BPM") {
+    SECTION("source interpretation total beats preserved when BPM differs from project BPM") {
         ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
-        REQUIRE(clip.sourceNumBeats == Approx(AMEN_SOURCE_BEATS));
+        REQUIRE(clip.audio().interpretation.totalBeats == Approx(AMEN_SOURCE_BEATS));
     }
 
     SECTION("lengthBeats preserves timeline length in project beats") {
@@ -151,37 +152,32 @@ TEST_CASE("setAutoTempo - preserves real detected BPM", "[clip][auto-tempo]") {
 }
 
 // ─────────────────────────────────────────────────────────────
-// sourceBPM calibration — only when sourceBPM ≈ projectBPM
-// (i.e. sourceBPM was defaulted from project, not detected)
+// Source interpretation calibration — only when BPM approximately matches project BPM
+// (i.e. interpretation BPM was defaulted from project, not detected)
 // ─────────────────────────────────────────────────────────────
 
-TEST_CASE("setAutoTempo - calibrates when sourceBPM matches project", "[clip][auto-tempo]") {
-    SECTION("sourceBPM stays at projectBPM when they match") {
+TEST_CASE("setAutoTempo - calibrates when source interpretation BPM matches project",
+          "[clip][auto-tempo]") {
+    SECTION("source interpretation BPM stays at project BPM when they match") {
         auto clip = makeCalibratedClip(120.0);
         ClipOperations::setAutoTempo(clip, true, 120.0);
-        REQUIRE(clip.sourceBPM == Approx(120.0));
+        REQUIRE(clip.audio().interpretation.bpm == Approx(120.0));
     }
 
-    SECTION("sourceBPM = projectBPM / speedRatio when they match and speedRatio != 1") {
+    SECTION("source interpretation BPM equals project BPM / speedRatio when appropriate") {
         auto clip = makeCalibratedClip(120.0);
         clip.speedRatio = 2.0;
-        // effectiveBPM = 120/2 = 60, but sourceBPM = 120 ≠ 60 → no calibration
+        // effectiveBPM = 120/2 = 60, but interpretation BPM = 120, so no calibration
         // Actually this is the "differs" case so calibration is skipped
         ClipOperations::setAutoTempo(clip, true, 120.0);
-        REQUIRE(clip.sourceBPM == Approx(120.0));  // preserved
+        REQUIRE(clip.audio().interpretation.bpm == Approx(120.0));  // preserved
     }
 
-    SECTION("Calibration when sourceBPM was unknown (zero)") {
+    SECTION("Calibration when source interpretation BPM was unknown (zero)") {
         auto clip = makeAmenClip();
-        clip.sourceBPM = 0.0;
+        clip.audio().interpretation.bpm = 0.0;
         ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
-        // sourceBPM was 0, effectiveBPM = 69. |0 - 69| > 0.1, so no calibration.
-        // But sourceBPM was 0 and the code sets effectiveBPM only when they're close.
-        // Actually with sourceBPM=0, the code doesn't enter the calibration branch at all.
-        // sourceBPM stays 0? No — the code has: if (std::abs(clip.sourceBPM - effectiveBPM) < 0.1)
-        // 0 ≠ 69 so calibration is skipped. sourceBPM stays 0.
-        // But we still need a valid sourceBPM for TE. Let's just check it's set.
-        // Actually sourceBPM=0 means unknown, and the fallback compute path will be used.
+        // Unknown interpretation BPM stays unknown; the fallback compute path is used.
     }
 }
 
@@ -200,7 +196,7 @@ TEST_CASE("getAutoTempoBeatRange - source beat range", "[clip][auto-tempo][te-sy
 
     SECTION("Beat range maps to file's natural beat count") {
         // Issue #1157: in beat mode, beats are beats. The loop range returned
-        // here is the source's musical extent — sourceNumBeats for a fresh
+        // here is the source's musical extent for a fresh
         // clip with the whole file as the loop region. Margin allows for
         // AMEN_DURATION/AMEN_ORIGINAL_BPM rounding (~4.0008 vs 4.0).
         auto clip = makeAmenClip();
@@ -275,10 +271,10 @@ TEST_CASE("setAutoTempo - respects existing loop region", "[clip][auto-tempo][lo
         REQUIRE(clip.loopLength == Approx(0.8));
     }
 
-    SECTION("loopLengthBeats is in beats — derived from sourceBPM") {
+    SECTION("loopLengthBeats is in source beats") {
         // Issue #1157: beats are beats. loopLengthBeats describes the loop
         // region's musical extent in beats, regardless of project tempo. For
-        // a 0.8-second loop in a file recorded at sourceBPM=158.6, that's
+        // a 0.8-second loop in a file interpreted at 158.6 BPM, that's
         // 0.8 × 158.6 / 60 ≈ 2.115 beats.
         double expectedLoopBeats = 0.8 * AMEN_ORIGINAL_BPM / 60.0;
         REQUIRE(clip.loopLengthBeats == Approx(expectedLoopBeats));
@@ -351,35 +347,36 @@ TEST_CASE("setAutoTempo - no-op when already in target state", "[clip][auto-temp
 
 // ─────────────────────────────────────────────────────────────
 // Calibration at different project BPMs — only applies when
-// sourceBPM matches projectBPM (defaulted, not detected)
+// Source interpretation BPM matches project BPM (defaulted, not detected)
 // ─────────────────────────────────────────────────────────────
 
-TEST_CASE("setAutoTempo - calibration with matching sourceBPM", "[clip][auto-tempo]") {
-    SECTION("At 120 BPM, sourceBPM preserved when it matches project") {
+TEST_CASE("setAutoTempo - calibration with matching source interpretation BPM",
+          "[clip][auto-tempo]") {
+    SECTION("At 120 BPM, source interpretation BPM preserved when it matches project") {
         auto clip = makeCalibratedClip(120.0);
         ClipOperations::setAutoTempo(clip, true, 120.0);
 
-        REQUIRE(clip.sourceBPM == Approx(120.0));
+        REQUIRE(clip.audio().interpretation.bpm == Approx(120.0));
         REQUIRE(clip.length == Approx(2.0));
         REQUIRE(clip.lengthBeats == Approx(4.0));
         REQUIRE(clip.loopLengthBeats == Approx(4.0));
     }
 
-    SECTION("At 60 BPM with matching sourceBPM, calibrates to 60") {
+    SECTION("At 60 BPM with matching source interpretation BPM, calibrates to 60") {
         auto clip = makeCalibratedClip(60.0);
         clip.length = 4.0;  // 4 beats at 60 BPM
 
         ClipOperations::setAutoTempo(clip, true, 60.0);
 
-        REQUIRE(clip.sourceBPM == Approx(60.0));
-        REQUIRE(60.0 / clip.sourceBPM == Approx(1.0));
+        REQUIRE(clip.audio().interpretation.bpm == Approx(60.0));
+        REQUIRE(60.0 / clip.audio().interpretation.bpm == Approx(1.0));
     }
 
     SECTION("Real detected BPM (158.6) preserved at any project tempo") {
         auto clip = makeAmenClip();
         ClipOperations::setAutoTempo(clip, true, 200.0);
 
-        REQUIRE(clip.sourceBPM == Approx(AMEN_ORIGINAL_BPM));
+        REQUIRE(clip.audio().interpretation.bpm == Approx(AMEN_ORIGINAL_BPM));
     }
 }
 
@@ -395,12 +392,12 @@ TEST_CASE("Regression: loop wrapping past file end", "[clip][auto-tempo][regress
 
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audioFilePath = "long_loop.wav";
+    clip.audio().source.filePath = "long_loop.wav";
     clip.length = FILE_DURATION;
     clip.offset = 5.0;  // near end of file
     clip.speedRatio = 1.0;
-    clip.sourceBPM = FILE_BPM;
-    clip.sourceNumBeats = FILE_BEATS;
+    clip.audio().interpretation.bpm = FILE_BPM;
+    clip.audio().interpretation.totalBeats = FILE_BEATS;
 
     ClipOperations::setAutoTempo(clip, true, 69.0);
 
@@ -412,29 +409,32 @@ TEST_CASE("Regression: loop wrapping past file end", "[clip][auto-tempo][regress
 }
 
 // ─────────────────────────────────────────────────────────────
-// stretchAutoTempoBeats — adjusts sourceBPM for tempo change
+// setAutoTempoPlacementLengthBeats — edits timeline placement only
 // ─────────────────────────────────────────────────────────────
 
-TEST_CASE("stretchAutoTempoBeats - halves tempo when doubling beats", "[clip][auto-tempo]") {
+TEST_CASE("setAutoTempoPlacementLengthBeats - extends placement without rewriting source",
+          "[clip][auto-tempo]") {
     auto clip = makeAmenClip();
     ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
 
-    double originalSourceBPM = clip.sourceBPM;
+    double originalSourceInterpretationBpm = clip.audio().interpretation.bpm;
+    double originalSourceBeats = clip.audio().interpretation.totalBeats;
     double originalLoopLengthBeats = clip.loopLengthBeats;
 
-    // Double the beat count (like stretching to 2x length)
-    ClipOperations::stretchAutoTempoBeats(clip, originalLoopLengthBeats * 2.0, PROJECT_BPM);
+    ClipOperations::setAutoTempoPlacementLengthBeats(clip, originalLoopLengthBeats * 2.0,
+                                                     PROJECT_BPM);
 
-    SECTION("sourceBPM scales by stretch ratio") {
-        // newSourceBPM = newLoopBeats * 60 / sourceSeconds
-        // where newLoopBeats = originalLoopLengthBeats * 2
-        double expectedBPM = (originalLoopLengthBeats * 2.0) * 60.0 / AMEN_DURATION;
-        REQUIRE(clip.sourceBPM == Approx(expectedBPM).margin(0.1));
+    SECTION("source interpretation is unchanged") {
+        REQUIRE(clip.audio().interpretation.bpm ==
+                Approx(originalSourceInterpretationBpm).margin(0.1));
+        REQUIRE(clip.audio().interpretation.totalBeats == Approx(originalSourceBeats).margin(0.01));
     }
 
-    SECTION("loopLengthBeats doubles") {
-        // Slight tolerance — stretchAutoTempoBeats scales by lengthBeats vs
-        // loopLengthBeats ratio which can differ by FP rounding.
-        REQUIRE(clip.loopLengthBeats == Approx(originalLoopLengthBeats * 2.0).margin(0.01));
+    SECTION("loop region stays in source beats") {
+        REQUIRE(clip.loopLengthBeats == Approx(originalLoopLengthBeats).margin(0.01));
+    }
+
+    SECTION("placement length doubles") {
+        REQUIRE(clip.placement.lengthBeats == Approx(originalLoopLengthBeats * 2.0).margin(0.01));
     }
 }

--- a/tests/test_clip_bpm_invariant.cpp
+++ b/tests/test_clip_bpm_invariant.cpp
@@ -446,6 +446,37 @@ TEST_CASE("setAutoTempo adopts cached detected BPM when clip BPM is project defa
     AudioThumbnailManager::getInstance().clearCache();
 }
 
+TEST_CASE("session audio import uses detector when loopInfo is still defaulted",
+          "[clip][bpm][session][issue-1157]") {
+    ClipManager::getInstance().shutdown();
+    AudioThumbnailManager::getInstance().clearCache();
+
+    constexpr double cachedDetectorBPM = 99.0;
+    constexpr double sourceDuration = 5.58141;
+    auto path = juce::File::getCurrentWorkingDirectory().getChildFile(
+        "magda-session-import-cached-bpm.wav");
+    REQUIRE(path.replaceWithText("placeholder"));
+
+    AudioThumbnailManager::getInstance().cacheBPM(path.getFullPathName(), cachedDetectorBPM);
+
+    ClipId clipId = ClipManager::getInstance().createAudioClip(
+        1, 0.0, sourceDuration, path.getFullPathName(), ClipView::Session, PROJECT_BPM);
+
+    const auto* c = ClipManager::getInstance().getClip(clipId);
+    REQUIRE(c != nullptr);
+    REQUIRE(c->view == ClipView::Session);
+    REQUIRE(c->autoTempo);
+    REQUIRE(c->loopEnabled);
+    REQUIRE(c->audio().interpretation.bpm == Approx(cachedDetectorBPM));
+    REQUIRE(c->audio().interpretation.totalBeats ==
+            Approx(sourceDuration * cachedDetectorBPM / 60.0));
+    REQUIRE(c->loopLength == Approx(sourceDuration));
+    REQUIRE(c->loopLengthBeats == Approx(sourceDuration * cachedDetectorBPM / 60.0));
+
+    AudioThumbnailManager::getInstance().clearCache();
+    path.deleteFile();
+}
+
 // ============================================================================
 // BPM-change invariants — the core regression suite for issue #1157.
 //

--- a/tests/test_clip_bpm_invariant.cpp
+++ b/tests/test_clip_bpm_invariant.cpp
@@ -107,7 +107,6 @@ TEST_CASE("applyAudioClipBeats - beat-length edit preserves detected BPM",
     SECTION("Stretching to 8 beats does not change source interpretation BPM") {
         ClipManager::AudioClipBeatsUpdate u;
         u.lengthBeats = 8.0;
-        u.loopLengthBeats = 8.0;
         ClipManager::getInstance().applyAudioClipBeats(seed.id, u, PROJECT_BPM);
 
         const auto* c = ClipManager::getInstance().getClip(seed.id);
@@ -121,7 +120,6 @@ TEST_CASE("applyAudioClipBeats - beat-length edit preserves detected BPM",
     SECTION("Halving target length does not change source interpretation BPM") {
         ClipManager::AudioClipBeatsUpdate u;
         u.lengthBeats = 2.0;
-        u.loopLengthBeats = 2.0;
         ClipManager::getInstance().applyAudioClipBeats(seed.id, u, PROJECT_BPM);
 
         const auto* c = ClipManager::getInstance().getClip(seed.id);
@@ -129,6 +127,43 @@ TEST_CASE("applyAudioClipBeats - beat-length edit preserves detected BPM",
         REQUIRE(c->length == Approx(1.0));
         REQUIRE(c->audio().interpretation.bpm == Approx(DETECTED_BPM));
         REQUIRE(c->audio().interpretation.totalBeats == Approx(DETECTED_NUM_BEATS));
+    }
+}
+
+TEST_CASE("loop-length edit drives source total beats until manual override",
+          "[clip][bpm][issue-1157]") {
+    ClipManager::getInstance().shutdown();
+
+    auto seed = makeSessionAutoTempoClip();
+    ClipManager::getInstance().restoreClip(seed);
+
+    SECTION("Unlocked total beats follows loop length beats") {
+        ClipManager::AudioClipBeatsUpdate u;
+        u.loopLengthBeats = 8.0;
+        ClipManager::getInstance().applyAudioClipBeats(seed.id, u, PROJECT_BPM);
+
+        const auto* c = ClipManager::getInstance().getClip(seed.id);
+        REQUIRE(c != nullptr);
+        REQUIRE(c->loopLengthBeats == Approx(8.0));
+        REQUIRE(c->audio().interpretation.totalBeats == Approx(8.0));
+        REQUIRE_FALSE(c->audio().interpretation.totalBeatsLocked);
+    }
+
+    SECTION("Manual total beats override locks future loop edits out") {
+        ClipManager::AudioClipBeatsUpdate manual;
+        manual.interpretationTotalBeats = 13.0;
+        manual.lockInterpretationTotalBeats = true;
+        ClipManager::getInstance().applyAudioClipBeats(seed.id, manual, PROJECT_BPM);
+
+        ClipManager::AudioClipBeatsUpdate loopEdit;
+        loopEdit.loopLengthBeats = 8.0;
+        ClipManager::getInstance().applyAudioClipBeats(seed.id, loopEdit, PROJECT_BPM);
+
+        const auto* c = ClipManager::getInstance().getClip(seed.id);
+        REQUIRE(c != nullptr);
+        REQUIRE(c->loopLengthBeats == Approx(8.0));
+        REQUIRE(c->audio().interpretation.totalBeats == Approx(13.0));
+        REQUIRE(c->audio().interpretation.totalBeatsLocked);
     }
 }
 

--- a/tests/test_clip_bpm_invariant.cpp
+++ b/tests/test_clip_bpm_invariant.cpp
@@ -9,7 +9,7 @@
 // path (ClipManager::applyAudioClipBeats) that separates audio source facts,
 // source interpretation, and user clip placement.
 // These tests pin the contract:
-//   - BPM corrections never resize the clip on the timeline.
+//   - BPM corrections never resize the clip on the timeline or move the source region in seconds.
 //   - Beat-length edits never touch detected BPM.
 //   - lengthBeats / length / loopLengthBeats / loopLength are atomically
 //     consistent after every call.
@@ -52,9 +52,29 @@ ClipInfo makeSessionAutoTempoClip(ClipId id = 1) {
     clip.startTime = 0.0;
     return clip;
 }
+
+double inspectorLoopEndReadoutBeats(const ClipInfo& clip, double fallbackBPM) {
+    double loopBpm = fallbackBPM;
+    if (clip.isAudio() && clip.audio().interpretation.bpm > 0.0)
+        loopBpm = clip.audio().interpretation.bpm;
+    if (loopBpm <= 0.0)
+        loopBpm = 120.0;
+
+    const double loopStartBeats = clip.loopStart * loopBpm / 60.0;
+    double loopLengthDisplayBeats = 0.0;
+    if (clip.autoTempo && clip.loopLengthBeats > 0.0) {
+        loopLengthDisplayBeats = clip.loopLengthBeats;
+    } else {
+        const double sourceLength =
+            clip.loopLength > 0.0 ? clip.loopLength : clip.length * clip.speedRatio;
+        loopLengthDisplayBeats = sourceLength * loopBpm / 60.0;
+    }
+    return loopStartBeats + loopLengthDisplayBeats;
+}
 }  // namespace
 
-TEST_CASE("applyAudioClipBeats - BPM correction is metadata-only", "[clip][bpm][issue-1157]") {
+TEST_CASE("applyAudioClipBeats - BPM correction preserves source region seconds",
+          "[clip][bpm][issue-1157]") {
     ClipManager::getInstance().shutdown();
 
     auto seed = makeSessionAutoTempoClip();
@@ -72,15 +92,13 @@ TEST_CASE("applyAudioClipBeats - BPM correction is metadata-only", "[clip][bpm][
         REQUIRE(c->audio().source.durationSeconds == Approx(FILE_DURATION));
         REQUIRE(c->audio().interpretation.bpm == Approx(240.0));
         REQUIRE(c->audio().interpretation.totalBeats == Approx(8.0));
-        // User intent untouched.
+        // User timeline intent untouched.
         REQUIRE(c->lengthBeats == Approx(4.0));
-        REQUIRE(c->loopLengthBeats == Approx(4.0));
+        // Source region in seconds is untouched, so its source-beat value changes with BPM.
+        REQUIRE(c->loopLengthBeats == Approx(8.0));
         // Timeline length untouched (still 4 project beats = 2.0 s at 120 BPM).
         REQUIRE(c->length == Approx(2.0));
-        // Source-domain loop length DID update (4 source beats at 240 BPM = 1.0 s
-        // of source audio, half what it was). This is correct: TE will play the
-        // shorter region twice across the same timeline span.
-        REQUIRE(c->loopLength == Approx(1.0));
+        REQUIRE(c->loopLength == Approx(FILE_DURATION));
     }
 
     SECTION("Halving BPM keeps timeline length unchanged") {
@@ -130,14 +148,13 @@ TEST_CASE("applyAudioClipBeats - beat-length edit preserves detected BPM",
     }
 }
 
-TEST_CASE("loop-length edit drives source total beats until manual override",
-          "[clip][bpm][issue-1157]") {
+TEST_CASE("loop-length edit does not rewrite source total beats", "[clip][bpm][issue-1157]") {
     ClipManager::getInstance().shutdown();
 
     auto seed = makeSessionAutoTempoClip();
     ClipManager::getInstance().restoreClip(seed);
 
-    SECTION("Unlocked total beats follows loop length beats") {
+    SECTION("Total beats is source interpretation, not loop length") {
         ClipManager::AudioClipBeatsUpdate u;
         u.loopLengthBeats = 8.0;
         ClipManager::getInstance().applyAudioClipBeats(seed.id, u, PROJECT_BPM);
@@ -145,11 +162,11 @@ TEST_CASE("loop-length edit drives source total beats until manual override",
         const auto* c = ClipManager::getInstance().getClip(seed.id);
         REQUIRE(c != nullptr);
         REQUIRE(c->loopLengthBeats == Approx(8.0));
-        REQUIRE(c->audio().interpretation.totalBeats == Approx(8.0));
+        REQUIRE(c->audio().interpretation.totalBeats == Approx(DETECTED_NUM_BEATS));
         REQUIRE_FALSE(c->audio().interpretation.totalBeatsLocked);
     }
 
-    SECTION("Manual total beats override locks future loop edits out") {
+    SECTION("Manual total beats override remains independent from future loop edits") {
         ClipManager::AudioClipBeatsUpdate manual;
         manual.interpretationTotalBeats = 13.0;
         manual.lockInterpretationTotalBeats = true;
@@ -164,6 +181,60 @@ TEST_CASE("loop-length edit drives source total beats until manual override",
         REQUIRE(c->loopLengthBeats == Approx(8.0));
         REQUIRE(c->audio().interpretation.totalBeats == Approx(13.0));
         REQUIRE(c->audio().interpretation.totalBeatsLocked);
+    }
+}
+
+TEST_CASE("source beats edits update inspector loop end readout",
+          "[clip][bpm][inspector][issue-1157]") {
+    ClipManager::getInstance().shutdown();
+
+    constexpr double sourceBPM = 172.0;
+    constexpr double sourceBeats = 16.0;
+    constexpr double sourceDuration = sourceBeats * 60.0 / sourceBPM;
+
+    auto seed = makeSessionAutoTempoClip();
+    seed.audio().source.durationSeconds = sourceDuration;
+    seed.audio().interpretation.bpm = sourceBPM;
+    seed.audio().interpretation.totalBeats = sourceBeats;
+    seed.setPlacementBeats(0.0, 16.0);
+    seed.length = 16.0 * 60.0 / PROJECT_BPM;
+    seed.loopStart = 0.0;
+    seed.loopStartBeats = 0.0;
+    seed.loopLength = sourceDuration;
+    seed.loopLengthBeats = sourceBeats;
+    ClipManager::getInstance().restoreClip(seed);
+
+    auto applySourceBeats = [&](double beats) {
+        ClipManager::AudioClipBeatsUpdate u;
+        u.interpretationTotalBeats = beats;
+        u.interpretationBpm = beats * 60.0 / sourceDuration;
+        u.lockInterpretationTotalBeats = true;
+        ClipManager::getInstance().applyAudioClipBeats(seed.id, u, PROJECT_BPM);
+    };
+
+    SECTION("16 beats displays a four-bar loop end") {
+        const auto* c = ClipManager::getInstance().getClip(seed.id);
+        REQUIRE(c != nullptr);
+        REQUIRE(c->loopLengthBeats == Approx(16.0));
+        REQUIRE(inspectorLoopEndReadoutBeats(*c, PROJECT_BPM) == Approx(16.0));
+    }
+
+    SECTION("12 then 8 beats updates the loop end without changing source region seconds") {
+        applySourceBeats(12.0);
+        const auto* c = ClipManager::getInstance().getClip(seed.id);
+        REQUIRE(c != nullptr);
+        REQUIRE(c->audio().interpretation.totalBeats == Approx(12.0));
+        REQUIRE(c->loopLength == Approx(sourceDuration));
+        REQUIRE(c->loopLengthBeats == Approx(12.0));
+        REQUIRE(inspectorLoopEndReadoutBeats(*c, PROJECT_BPM) == Approx(12.0));
+
+        applySourceBeats(8.0);
+        c = ClipManager::getInstance().getClip(seed.id);
+        REQUIRE(c != nullptr);
+        REQUIRE(c->audio().interpretation.totalBeats == Approx(8.0));
+        REQUIRE(c->loopLength == Approx(sourceDuration));
+        REQUIRE(c->loopLengthBeats == Approx(8.0));
+        REQUIRE(inspectorLoopEndReadoutBeats(*c, PROJECT_BPM) == Approx(8.0));
     }
 }
 
@@ -359,8 +430,8 @@ TEST_CASE("setAutoTempo adopts cached detected BPM when clip BPM is project defa
 //     contracts proportionally.
 //   - project BPM down → length expands, beats unchanged.
 //   - source interpretation BPM correction → lengthBeats AND length unchanged on the
-//     timeline (BPM is just metadata); only the source-domain loop seconds
-//     change because the source's beat-to-seconds ratio shifted.
+//     timeline; source-region seconds stay fixed, and their source-beat readouts
+//     follow the new interpretation.
 //   - accessor consistency: getTimelineLength matches the cached length
 //     after every operation.
 // ============================================================================
@@ -415,8 +486,8 @@ TEST_CASE("source interpretation BPM correction does not move the clip on the ti
     auto seed = makeSessionAutoTempoClip();
     ClipManager::getInstance().restoreClip(seed);
 
-    // Initial state: clip is 24 timeline beats long, file detected at 120 BPM,
-    // loop covers all 16 source beats (loopLengthBeats matches source interpretation total beats).
+    // Initial state: clip is 24 timeline beats long, file interpreted at 120 BPM,
+    // loop covers an 8-second source region. Its beat readout is 16 beats at 120 BPM.
     seed.lengthBeats = 24.0;
     seed.loopLengthBeats = 16.0;
     seed.audio().interpretation.bpm = 120.0;
@@ -433,7 +504,7 @@ TEST_CASE("source interpretation BPM correction does not move the clip on the ti
     const auto* c = ClipManager::getInstance().getClip(seed.id);
     REQUIRE(c->length == Approx(12.0));  // 24 × 60 / 120
 
-    SECTION("Doubling source interpretation BPM: timeline length unchanged, source seconds halve") {
+    SECTION("Doubling source interpretation BPM: timeline length unchanged, loop beats follow") {
         ClipManager::AudioClipBeatsUpdate u;
         u.interpretationBpm = 240.0;
         u.interpretationTotalBeats = 32.0;
@@ -442,11 +513,11 @@ TEST_CASE("source interpretation BPM correction does not move the clip on the ti
         c = ClipManager::getInstance().getClip(seed.id);
         REQUIRE(c->lengthBeats == Approx(24.0));
         REQUIRE(c->length == Approx(12.0));
-        REQUIRE(c->loopLengthBeats == Approx(16.0));
-        REQUIRE(c->loopLength == Approx(4.0));  // 16 × 60/240
+        REQUIRE(c->loopLength == Approx(8.0));
+        REQUIRE(c->loopLengthBeats == Approx(32.0));  // 8s × 240/60
     }
 
-    SECTION("Halving source interpretation BPM: timeline length unchanged, source seconds double") {
+    SECTION("Halving source interpretation BPM: timeline length unchanged, loop beats follow") {
         ClipManager::AudioClipBeatsUpdate u;
         u.interpretationBpm = 60.0;
         u.interpretationTotalBeats = 8.0;
@@ -455,7 +526,8 @@ TEST_CASE("source interpretation BPM correction does not move the clip on the ti
         c = ClipManager::getInstance().getClip(seed.id);
         REQUIRE(c->lengthBeats == Approx(24.0));
         REQUIRE(c->length == Approx(12.0));
-        REQUIRE(c->loopLength == Approx(16.0));  // 16 × 60/60
+        REQUIRE(c->loopLength == Approx(8.0));
+        REQUIRE(c->loopLengthBeats == Approx(8.0));  // 8s × 60/60
     }
 }
 

--- a/tests/test_clip_bpm_invariant.cpp
+++ b/tests/test_clip_bpm_invariant.cpp
@@ -332,6 +332,33 @@ TEST_CASE("applyAudioClipBeats - all derived fields agree after edit", "[clip][b
     REQUIRE(c->speedRatio == Approx(1.0));
 }
 
+TEST_CASE("beat-mode phase edits do not mutate loop length", "[clip][bpm][phase]") {
+    ClipManager::getInstance().shutdown();
+
+    auto seed = makeSessionAutoTempoClip();
+    seed.loopEnabled = false;  // BEAT mode owns the active source loop.
+    seed.loopStart = 0.0;
+    seed.loopStartBeats = 0.0;
+    seed.offset = 0.0;
+    seed.offsetBeats = 0.0;
+    seed.loopLengthBeats = 4.0;
+    seed.loopLength = FILE_DURATION;
+    ClipManager::getInstance().restoreClip(seed);
+
+    const double phaseBeats = 1.0;
+    const double phaseSeconds = phaseBeats * 60.0 / DETECTED_BPM;
+    ClipManager::getInstance().setLoopPhase(seed.id, phaseSeconds);
+
+    const auto* c = ClipManager::getInstance().getClip(seed.id);
+    REQUIRE(c != nullptr);
+    REQUIRE(c->offset == Approx(phaseSeconds));
+    REQUIRE(c->offsetBeats == Approx(phaseBeats));
+    REQUIRE(c->loopStart == Approx(0.0));
+    REQUIRE(c->loopStartBeats == Approx(0.0));
+    REQUIRE(c->loopLength == Approx(FILE_DURATION));
+    REQUIRE(c->loopLengthBeats == Approx(4.0));
+}
+
 TEST_CASE("applyAudioClipBeats - no-op for non-autoTempo clips", "[clip][bpm][issue-1157]") {
     ClipManager::getInstance().shutdown();
 

--- a/tests/test_clip_bpm_invariant.cpp
+++ b/tests/test_clip_bpm_invariant.cpp
@@ -6,8 +6,8 @@
 #include "magda/daw/core/ClipManager.hpp"
 
 // Issue #1157: session/autoTempo audio clips have a single canonical update
-// path (ClipManager::applyAudioClipBeats) that separates DETECTED metadata
-// (sourceBPM, sourceNumBeats) from USER INTENT (lengthBeats, loop region).
+// path (ClipManager::applyAudioClipBeats) that separates audio source facts,
+// source interpretation, and user clip placement.
 // These tests pin the contract:
 //   - BPM corrections never resize the clip on the timeline.
 //   - Beat-length edits never touch detected BPM.
@@ -29,14 +29,15 @@ ClipInfo makeSessionAutoTempoClip(ClipId id = 1) {
     clip.trackId = 1;
     clip.setAudioContent();
     clip.view = ClipView::Session;
-    clip.audioFilePath = "fake.wav";
+    clip.audio().source.filePath = "fake.wav";
+    clip.audio().source.durationSeconds = FILE_DURATION;
     clip.autoTempo = true;
     clip.loopEnabled = true;
     clip.speedRatio = 1.0;
 
     // Pretend detection has already populated source metadata.
-    clip.sourceBPM = DETECTED_BPM;
-    clip.sourceNumBeats = DETECTED_NUM_BEATS;
+    clip.audio().interpretation.bpm = DETECTED_BPM;
+    clip.audio().interpretation.totalBeats = DETECTED_NUM_BEATS;
 
     // User intent: clip occupies 4 timeline beats, loop covers the full file.
     clip.lengthBeats = 4.0;
@@ -46,7 +47,7 @@ ClipInfo makeSessionAutoTempoClip(ClipId id = 1) {
     // Time-domain values consistent with the above (canonical setter would
     // recompute these; we seed them so reads-without-call still succeed).
     clip.length = clip.lengthBeats * 60.0 / PROJECT_BPM;
-    clip.loopLength = clip.loopLengthBeats * 60.0 / clip.sourceBPM;
+    clip.loopLength = clip.loopLengthBeats * 60.0 / clip.audio().interpretation.bpm;
     clip.loopStart = 0.0;
     clip.startTime = 0.0;
     return clip;
@@ -61,15 +62,16 @@ TEST_CASE("applyAudioClipBeats - BPM correction is metadata-only", "[clip][bpm][
 
     SECTION("Doubling BPM keeps timeline length and lengthBeats unchanged") {
         ClipManager::AudioClipBeatsUpdate u;
-        u.sourceBPM = 240.0;
-        u.sourceNumBeats = FILE_DURATION * 240.0 / 60.0;  // 8 beats at 240 BPM
+        u.interpretationBpm = 240.0;
+        u.interpretationTotalBeats = FILE_DURATION * 240.0 / 60.0;  // 8 beats at 240 BPM
         ClipManager::getInstance().applyAudioClipBeats(seed.id, u, PROJECT_BPM);
 
         const auto* c = ClipManager::getInstance().getClip(seed.id);
         REQUIRE(c != nullptr);
-        // Detected metadata updated.
-        REQUIRE(c->sourceBPM == Approx(240.0));
-        REQUIRE(c->sourceNumBeats == Approx(8.0));
+        // Source fact preserved; interpretation updated.
+        REQUIRE(c->audio().source.durationSeconds == Approx(FILE_DURATION));
+        REQUIRE(c->audio().interpretation.bpm == Approx(240.0));
+        REQUIRE(c->audio().interpretation.totalBeats == Approx(8.0));
         // User intent untouched.
         REQUIRE(c->lengthBeats == Approx(4.0));
         REQUIRE(c->loopLengthBeats == Approx(4.0));
@@ -83,12 +85,13 @@ TEST_CASE("applyAudioClipBeats - BPM correction is metadata-only", "[clip][bpm][
 
     SECTION("Halving BPM keeps timeline length unchanged") {
         ClipManager::AudioClipBeatsUpdate u;
-        u.sourceBPM = 60.0;
-        u.sourceNumBeats = FILE_DURATION * 60.0 / 60.0;  // 2 beats at 60 BPM
+        u.interpretationBpm = 60.0;
+        u.interpretationTotalBeats = FILE_DURATION * 60.0 / 60.0;  // 2 beats at 60 BPM
         ClipManager::getInstance().applyAudioClipBeats(seed.id, u, PROJECT_BPM);
 
         const auto* c = ClipManager::getInstance().getClip(seed.id);
-        REQUIRE(c->sourceBPM == Approx(60.0));
+        REQUIRE(c->audio().source.durationSeconds == Approx(FILE_DURATION));
+        REQUIRE(c->audio().interpretation.bpm == Approx(60.0));
         REQUIRE(c->lengthBeats == Approx(4.0));
         REQUIRE(c->length == Approx(2.0));
     }
@@ -101,7 +104,7 @@ TEST_CASE("applyAudioClipBeats - beat-length edit preserves detected BPM",
     auto seed = makeSessionAutoTempoClip();
     ClipManager::getInstance().restoreClip(seed);
 
-    SECTION("Stretching to 8 beats does not change sourceBPM") {
+    SECTION("Stretching to 8 beats does not change source interpretation BPM") {
         ClipManager::AudioClipBeatsUpdate u;
         u.lengthBeats = 8.0;
         u.loopLengthBeats = 8.0;
@@ -111,11 +114,11 @@ TEST_CASE("applyAudioClipBeats - beat-length edit preserves detected BPM",
         REQUIRE(c->lengthBeats == Approx(8.0));
         REQUIRE(c->length == Approx(4.0));  // 8 beats at 120 BPM
         // Detected metadata MUST NOT have changed.
-        REQUIRE(c->sourceBPM == Approx(DETECTED_BPM));
-        REQUIRE(c->sourceNumBeats == Approx(DETECTED_NUM_BEATS));
+        REQUIRE(c->audio().interpretation.bpm == Approx(DETECTED_BPM));
+        REQUIRE(c->audio().interpretation.totalBeats == Approx(DETECTED_NUM_BEATS));
     }
 
-    SECTION("Halving target length does not change sourceBPM") {
+    SECTION("Halving target length does not change source interpretation BPM") {
         ClipManager::AudioClipBeatsUpdate u;
         u.lengthBeats = 2.0;
         u.loopLengthBeats = 2.0;
@@ -124,9 +127,78 @@ TEST_CASE("applyAudioClipBeats - beat-length edit preserves detected BPM",
         const auto* c = ClipManager::getInstance().getClip(seed.id);
         REQUIRE(c->lengthBeats == Approx(2.0));
         REQUIRE(c->length == Approx(1.0));
-        REQUIRE(c->sourceBPM == Approx(DETECTED_BPM));
-        REQUIRE(c->sourceNumBeats == Approx(DETECTED_NUM_BEATS));
+        REQUIRE(c->audio().interpretation.bpm == Approx(DETECTED_BPM));
+        REQUIRE(c->audio().interpretation.totalBeats == Approx(DETECTED_NUM_BEATS));
     }
+}
+
+TEST_CASE("setLengthBeats extends placement without growing source loop or interpretation",
+          "[clip][bpm][issue-1157]") {
+    ClipManager::getInstance().shutdown();
+
+    auto seed = makeSessionAutoTempoClip();
+    ClipManager::getInstance().restoreClip(seed);
+
+    ClipManager::getInstance().setLengthBeats(seed.id, 8.0, PROJECT_BPM);
+
+    const auto* c = ClipManager::getInstance().getClip(seed.id);
+    REQUIRE(c != nullptr);
+    REQUIRE(c->lengthBeats == Approx(8.0));
+    REQUIRE(c->placement.lengthBeats == Approx(8.0));
+    REQUIRE(c->length == Approx(4.0));
+
+    REQUIRE(c->loopLengthBeats == Approx(4.0));
+    REQUIRE(c->loopLength == Approx(2.0));
+    REQUIRE(c->audio().interpretation.bpm == Approx(DETECTED_BPM));
+    REQUIRE(c->audio().interpretation.totalBeats == Approx(DETECTED_NUM_BEATS));
+    REQUIRE(c->audio().source.durationSeconds == Approx(FILE_DURATION));
+}
+
+TEST_CASE("late source metadata does not overwrite extended clip placement",
+          "[clip][bpm][issue-1157]") {
+    ClipManager::getInstance().shutdown();
+
+    auto clip = makeSessionAutoTempoClip();
+    clip.audio().interpretation.bpm = 0.0;
+    clip.audio().interpretation.totalBeats = 0.0;
+    clip.audio().source.durationSeconds = 0.0;
+    clip.setPlacementBeats(0.0, 356.0);  // 89 bars at 4/4
+    clip.length = 356.0 * 60.0 / PROJECT_BPM;
+    clip.loopLengthBeats = 8.0;
+    clip.loopLength = 8.0 * 60.0 / 172.0;
+
+    clip.setSourceMetadata(8.0, 172.0);
+
+    REQUIRE(clip.placement.lengthBeats == Approx(356.0));
+    REQUIRE(clip.lengthBeats == Approx(356.0));
+    REQUIRE(clip.loopLengthBeats == Approx(8.0));
+    REQUIRE(clip.audio().interpretation.bpm == Approx(172.0));
+    REQUIRE(clip.audio().interpretation.totalBeats == Approx(8.0));
+}
+
+TEST_CASE("resizeClip extends looped beat-mode clip placement only", "[clip][bpm][issue-1157]") {
+    ClipManager::getInstance().shutdown();
+
+    auto seed = makeSessionAutoTempoClip();
+    seed.audio().interpretation.bpm = 172.0;
+    seed.audio().interpretation.totalBeats = 8.0;
+    seed.audio().source.durationSeconds = 8.0 * 60.0 / 172.0;
+    seed.setPlacementBeats(0.0, 8.0);
+    seed.length = 8.0 * 60.0 / PROJECT_BPM;
+    seed.loopLengthBeats = 8.0;
+    seed.loopLength = 8.0 * 60.0 / 172.0;
+    ClipManager::getInstance().restoreClip(seed);
+
+    ClipManager::getInstance().resizeClip(seed.id, 356.0 * 60.0 / PROJECT_BPM, false, PROJECT_BPM);
+
+    const auto* c = ClipManager::getInstance().getClip(seed.id);
+    REQUIRE(c != nullptr);
+    REQUIRE(c->placement.lengthBeats == Approx(356.0));
+    REQUIRE(c->lengthBeats == Approx(356.0));
+    REQUIRE(c->loopLengthBeats == Approx(8.0));
+    REQUIRE(c->audio().interpretation.bpm == Approx(172.0));
+    REQUIRE(c->audio().interpretation.totalBeats == Approx(8.0));
+    REQUIRE(c->audio().source.durationSeconds == Approx(8.0 * 60.0 / 172.0));
 }
 
 TEST_CASE("applyAudioClipBeats - all derived fields agree after edit", "[clip][bpm][issue-1157]") {
@@ -139,8 +211,8 @@ TEST_CASE("applyAudioClipBeats - all derived fields agree after edit", "[clip][b
     // the inspector and waveform display read length, lengthBeats, loopLength,
     // and loopLengthBeats. They must be consistent after one call.
     ClipManager::AudioClipBeatsUpdate u;
-    u.sourceBPM = 100.0;
-    u.sourceNumBeats = FILE_DURATION * 100.0 / 60.0;
+    u.interpretationBpm = 100.0;
+    u.interpretationTotalBeats = FILE_DURATION * 100.0 / 60.0;
     u.lengthBeats = 6.0;
     u.loopLengthBeats = 6.0;
     ClipManager::getInstance().applyAudioClipBeats(seed.id, u, PROJECT_BPM);
@@ -148,8 +220,8 @@ TEST_CASE("applyAudioClipBeats - all derived fields agree after edit", "[clip][b
     const auto* c = ClipManager::getInstance().getClip(seed.id);
     // Timeline-domain pair: length must equal lengthBeats * 60 / projectBPM.
     REQUIRE(c->length == Approx(c->lengthBeats * 60.0 / PROJECT_BPM));
-    // Source-domain pair: loopLength must equal loopLengthBeats * 60 / sourceBPM.
-    REQUIRE(c->loopLength == Approx(c->loopLengthBeats * 60.0 / c->sourceBPM));
+    // Source-domain pair: loopLength must equal loopLengthBeats * 60 / source interpretation BPM.
+    REQUIRE(c->loopLength == Approx(c->loopLengthBeats * 60.0 / c->audio().interpretation.bpm));
     // speedRatio is forced to 1.0.
     REQUIRE(c->speedRatio == Approx(1.0));
 }
@@ -173,13 +245,13 @@ TEST_CASE("applyAudioClipBeats - no-op for non-autoTempo clips", "[clip][bpm][is
     REQUIRE(c->length == Approx(1.0));
 }
 
-TEST_CASE("applyAudioClipBeats - sourceBPM unknown leaves source-seconds intact",
+TEST_CASE("applyAudioClipBeats - source interpretation BPM unknown leaves source-seconds intact",
           "[clip][bpm][issue-1157]") {
     ClipManager::getInstance().shutdown();
 
     auto seed = makeSessionAutoTempoClip();
-    seed.sourceBPM = 0.0;       // detection has not yet completed
-    seed.sourceNumBeats = 0.0;  // ditto
+    seed.audio().interpretation.bpm = 0.0;         // detection has not yet completed
+    seed.audio().interpretation.totalBeats = 0.0;  // ditto
     seed.loopLength = 0.0;
     seed.loopStart = 0.0;
     ClipManager::getInstance().restoreClip(seed);
@@ -191,7 +263,7 @@ TEST_CASE("applyAudioClipBeats - sourceBPM unknown leaves source-seconds intact"
     const auto* c = ClipManager::getInstance().getClip(seed.id);
     REQUIRE(c->lengthBeats == Approx(8.0));
     REQUIRE(c->length == Approx(4.0));  // 8 beats at 120 BPM
-    // loopLength stays 0 — we only touch source-domain seconds when sourceBPM
+    // loopLength stays 0 — we only touch source-domain seconds when source interpretation BPM
     // is known. ClipDisplayInfo and TE have fallback paths for the pre-detection
     // window.
     REQUIRE(c->loopLength == Approx(0.0));
@@ -212,7 +284,7 @@ TEST_CASE("setAutoTempo adopts cached detected BPM when clip BPM is project defa
     seed.trackId = 1;
     seed.setAudioContent();
     seed.view = ClipView::Arrangement;
-    seed.audioFilePath = path;
+    seed.audio().source.filePath = path;
     seed.loopEnabled = false;
     seed.autoTempo = false;
     seed.speedRatio = 1.0;
@@ -220,8 +292,8 @@ TEST_CASE("setAutoTempo adopts cached detected BPM when clip BPM is project defa
     seed.length = sourceDuration;
     seed.loopStart = 0.0;
     seed.loopLength = sourceDuration;
-    seed.sourceBPM = PROJECT_BPM;  // defaulted placeholder, not trusted metadata
-    seed.sourceNumBeats = 0.0;
+    seed.audio().interpretation.bpm = PROJECT_BPM;  // defaulted placeholder, not trusted metadata
+    seed.audio().interpretation.totalBeats = 0.0;
     seed.setPlacementBeats(0.0, sourceDuration * PROJECT_BPM / 60.0);
 
     ClipManager::getInstance().restoreClip(seed);
@@ -232,8 +304,8 @@ TEST_CASE("setAutoTempo adopts cached detected BPM when clip BPM is project defa
     const auto* c = ClipManager::getInstance().getClip(seed.id);
     REQUIRE(c != nullptr);
     REQUIRE(c->autoTempo);
-    REQUIRE(c->sourceBPM == Approx(detectedBPM));
-    REQUIRE(c->sourceNumBeats == Approx(expectedSourceBeats));
+    REQUIRE(c->audio().interpretation.bpm == Approx(detectedBPM));
+    REQUIRE(c->audio().interpretation.totalBeats == Approx(expectedSourceBeats));
     REQUIRE(c->lengthBeats == Approx(expectedSourceBeats));
     REQUIRE(c->placement.lengthBeats == Approx(expectedSourceBeats));
     REQUIRE(c->length == Approx(expectedSourceBeats * 60.0 / PROJECT_BPM));
@@ -251,7 +323,7 @@ TEST_CASE("setAutoTempo adopts cached detected BPM when clip BPM is project defa
 //   - project BPM up → autoTempo clip's lengthBeats unchanged, length
 //     contracts proportionally.
 //   - project BPM down → length expands, beats unchanged.
-//   - sourceBPM correction → lengthBeats AND length unchanged on the
+//   - source interpretation BPM correction → lengthBeats AND length unchanged on the
 //     timeline (BPM is just metadata); only the source-domain loop seconds
 //     change because the source's beat-to-seconds ratio shifted.
 //   - accessor consistency: getTimelineLength matches the cached length
@@ -301,7 +373,7 @@ TEST_CASE("Project-BPM change preserves autoTempo lengthBeats", "[clip][bpm][iss
     }
 }
 
-TEST_CASE("sourceBPM correction does not move the clip on the timeline",
+TEST_CASE("source interpretation BPM correction does not move the clip on the timeline",
           "[clip][bpm][issue-1157]") {
     ClipManager::getInstance().shutdown();
 
@@ -309,27 +381,27 @@ TEST_CASE("sourceBPM correction does not move the clip on the timeline",
     ClipManager::getInstance().restoreClip(seed);
 
     // Initial state: clip is 24 timeline beats long, file detected at 120 BPM,
-    // loop covers all 16 source beats (loopLengthBeats matches sourceNumBeats).
+    // loop covers all 16 source beats (loopLengthBeats matches source interpretation total beats).
     seed.lengthBeats = 24.0;
     seed.loopLengthBeats = 16.0;
-    seed.sourceBPM = 120.0;
-    seed.sourceNumBeats = 16.0;
+    seed.audio().interpretation.bpm = 120.0;
+    seed.audio().interpretation.totalBeats = 16.0;
     ClipManager::getInstance().restoreClip(
         seed);  // no-op (already there) — values applied directly
     ClipManager::AudioClipBeatsUpdate prime;
     prime.lengthBeats = 24.0;
     prime.loopLengthBeats = 16.0;
-    prime.sourceBPM = 120.0;
-    prime.sourceNumBeats = 16.0;
+    prime.interpretationBpm = 120.0;
+    prime.interpretationTotalBeats = 16.0;
     ClipManager::getInstance().applyAudioClipBeats(seed.id, prime, PROJECT_BPM);
 
     const auto* c = ClipManager::getInstance().getClip(seed.id);
     REQUIRE(c->length == Approx(12.0));  // 24 × 60 / 120
 
-    SECTION("Doubling sourceBPM: timeline length unchanged, source seconds halve") {
+    SECTION("Doubling source interpretation BPM: timeline length unchanged, source seconds halve") {
         ClipManager::AudioClipBeatsUpdate u;
-        u.sourceBPM = 240.0;
-        u.sourceNumBeats = 32.0;
+        u.interpretationBpm = 240.0;
+        u.interpretationTotalBeats = 32.0;
         ClipManager::getInstance().applyAudioClipBeats(seed.id, u, PROJECT_BPM);
 
         c = ClipManager::getInstance().getClip(seed.id);
@@ -339,10 +411,10 @@ TEST_CASE("sourceBPM correction does not move the clip on the timeline",
         REQUIRE(c->loopLength == Approx(4.0));  // 16 × 60/240
     }
 
-    SECTION("Halving sourceBPM: timeline length unchanged, source seconds double") {
+    SECTION("Halving source interpretation BPM: timeline length unchanged, source seconds double") {
         ClipManager::AudioClipBeatsUpdate u;
-        u.sourceBPM = 60.0;
-        u.sourceNumBeats = 8.0;
+        u.interpretationBpm = 60.0;
+        u.interpretationTotalBeats = 8.0;
         ClipManager::getInstance().applyAudioClipBeats(seed.id, u, PROJECT_BPM);
 
         c = ClipManager::getInstance().getClip(seed.id);

--- a/tests/test_clip_inspector_juce.cpp
+++ b/tests/test_clip_inspector_juce.cpp
@@ -56,6 +56,20 @@ void expectLoopEnd(juce::UnitTest& test, const ClipInspector& inspector, double 
                                        "Inspector loop end should match source beats");
     }
 }
+
+void expectBpmDisplay(juce::UnitTest& test, const ClipInspector& inspector, double expected) {
+    test.expectWithinAbsoluteError(inspector.clipBpmValue_.getText().getDoubleValue(), expected,
+                                   0.01, "Inspector BPM should match source interpretation BPM");
+}
+
+void expectSourceBeatsDisplay(juce::UnitTest& test, const ClipInspector& inspector,
+                              double expected) {
+    test.expect(inspector.clipBeatsLengthValue_ != nullptr, "Beats widget should exist");
+    if (inspector.clipBeatsLengthValue_ != nullptr) {
+        test.expectWithinAbsoluteError(inspector.clipBeatsLengthValue_->getValue(), expected, 0.001,
+                                       "Inspector Beats should match source interpretation beats");
+    }
+}
 }  // namespace
 
 class ClipInspectorJuceTest final : public juce::UnitTest {
@@ -65,6 +79,8 @@ class ClipInspectorJuceTest final : public juce::UnitTest {
     void runTest() override {
         testFullRefreshTracksSourceBeatEdits();
         testMidDragPropertyChangeRefreshesLoopEnd();
+        testBpmAndBeatsDisplaysRefreshTogether();
+        testLoopEndUsesLoopLengthNotPlacementLength();
     }
 
   private:
@@ -79,14 +95,17 @@ class ClipInspectorJuceTest final : public juce::UnitTest {
         inspector.setBounds(0, 0, 360, 640);
         inspector.setSelectedClip(seed.id);
         expectLoopEnd(*this, inspector, 16.0);
+        expectSourceBeatsDisplay(*this, inspector, 16.0);
 
         applySourceBeats(seed.id, 12.0);
         inspector.clipPropertyChanged(seed.id);
         expectLoopEnd(*this, inspector, 12.0);
+        expectSourceBeatsDisplay(*this, inspector, 12.0);
 
         applySourceBeats(seed.id, 8.0);
         inspector.clipPropertyChanged(seed.id);
         expectLoopEnd(*this, inspector, 8.0);
+        expectSourceBeatsDisplay(*this, inspector, 8.0);
 
         ClipManager::getInstance().clearAllClips();
     }
@@ -114,6 +133,52 @@ class ClipInspectorJuceTest final : public juce::UnitTest {
         expectLoopEnd(*this, inspector, 8.0);
 
         inspector.clipBeatsLengthValue_->isDragging_ = false;
+        ClipManager::getInstance().clearAllClips();
+    }
+
+    void testBpmAndBeatsDisplaysRefreshTogether() {
+        beginTest("BPM and Beats displays refresh from source interpretation");
+        ClipManager::getInstance().clearAllClips();
+
+        auto seed = makeInspectorAudioClip();
+        ClipManager::getInstance().restoreClip(seed);
+
+        ClipInspector inspector;
+        inspector.setBounds(0, 0, 360, 640);
+        inspector.setSelectedClip(seed.id);
+        expectBpmDisplay(*this, inspector, 172.0);
+        expectSourceBeatsDisplay(*this, inspector, 16.0);
+
+        applySourceBeats(seed.id, 12.0);
+        inspector.clipPropertyChanged(seed.id);
+        expectBpmDisplay(*this, inspector, 129.0);
+        expectSourceBeatsDisplay(*this, inspector, 12.0);
+
+        applySourceBeats(seed.id, 8.0);
+        inspector.clipPropertyChanged(seed.id);
+        expectBpmDisplay(*this, inspector, 86.0);
+        expectSourceBeatsDisplay(*this, inspector, 8.0);
+
+        ClipManager::getInstance().clearAllClips();
+    }
+
+    void testLoopEndUsesLoopLengthNotPlacementLength() {
+        beginTest("Inspector loop end follows source loop length, not placement length");
+        ClipManager::getInstance().clearAllClips();
+
+        auto seed = makeInspectorAudioClip();
+        seed.setPlacementBeats(0.0, 96.0);
+        seed.length = 96.0 * 60.0 / projectBPM;
+        seed.loopLengthBeats = 12.0;
+        seed.loopLength = 12.0 * 60.0 / sourceBPM;
+        ClipManager::getInstance().restoreClip(seed);
+
+        ClipInspector inspector;
+        inspector.setBounds(0, 0, 360, 640);
+        inspector.setSelectedClip(seed.id);
+        expectSourceBeatsDisplay(*this, inspector, 16.0);
+        expectLoopEnd(*this, inspector, 12.0);
+
         ClipManager::getInstance().clearAllClips();
     }
 };

--- a/tests/test_clip_inspector_juce.cpp
+++ b/tests/test_clip_inspector_juce.cpp
@@ -1,0 +1,121 @@
+#include <juce_core/juce_core.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "magda/daw/core/ClipInfo.hpp"
+#include "magda/daw/core/ClipManager.hpp"
+
+#define private public
+#include "magda/daw/ui/panels/content/inspector/ClipInspector.hpp"
+#undef private
+
+using namespace magda;
+using magda::daw::ui::ClipInspector;
+
+namespace {
+constexpr double projectBPM = 120.0;
+constexpr double sourceBPM = 172.0;
+constexpr double sourceBeats = 16.0;
+constexpr double sourceDuration = sourceBeats * 60.0 / sourceBPM;
+
+ClipInfo makeInspectorAudioClip(ClipId id = 9001) {
+    ClipInfo clip;
+    clip.id = id;
+    clip.trackId = 1;
+    clip.setAudioContent();
+    clip.view = ClipView::Session;
+    clip.name = "InspectorTest";
+    clip.autoTempo = true;
+    clip.loopEnabled = true;
+    clip.speedRatio = 1.0;
+    clip.audio().source.durationSeconds = sourceDuration;
+    clip.audio().interpretation.bpm = sourceBPM;
+    clip.audio().interpretation.totalBeats = sourceBeats;
+    clip.setPlacementBeats(0.0, sourceBeats);
+    clip.length = sourceBeats * 60.0 / projectBPM;
+    clip.loopStart = 0.0;
+    clip.loopStartBeats = 0.0;
+    clip.loopLength = sourceDuration;
+    clip.loopLengthBeats = sourceBeats;
+    clip.offset = 0.0;
+    clip.offsetBeats = 0.0;
+    return clip;
+}
+
+void applySourceBeats(ClipId clipId, double beats) {
+    ClipManager::AudioClipBeatsUpdate update;
+    update.interpretationTotalBeats = beats;
+    update.interpretationBpm = beats * 60.0 / sourceDuration;
+    update.lockInterpretationTotalBeats = true;
+    ClipManager::getInstance().applyAudioClipBeats(clipId, update, projectBPM);
+}
+
+void expectLoopEnd(juce::UnitTest& test, const ClipInspector& inspector, double expected) {
+    test.expect(inspector.clipLoopEndValue_ != nullptr, "Loop end widget should exist");
+    if (inspector.clipLoopEndValue_ != nullptr) {
+        test.expectWithinAbsoluteError(inspector.clipLoopEndValue_->getValue(), expected, 0.001,
+                                       "Inspector loop end should match source beats");
+    }
+}
+}  // namespace
+
+class ClipInspectorJuceTest final : public juce::UnitTest {
+  public:
+    ClipInspectorJuceTest() : juce::UnitTest("ClipInspector JUCE Tests", "magda") {}
+
+    void runTest() override {
+        testFullRefreshTracksSourceBeatEdits();
+        testMidDragPropertyChangeRefreshesLoopEnd();
+    }
+
+  private:
+    void testFullRefreshTracksSourceBeatEdits() {
+        beginTest("Loop end follows source Beats after full inspector refresh");
+        ClipManager::getInstance().clearAllClips();
+
+        auto seed = makeInspectorAudioClip();
+        ClipManager::getInstance().restoreClip(seed);
+
+        ClipInspector inspector;
+        inspector.setBounds(0, 0, 360, 640);
+        inspector.setSelectedClip(seed.id);
+        expectLoopEnd(*this, inspector, 16.0);
+
+        applySourceBeats(seed.id, 12.0);
+        inspector.clipPropertyChanged(seed.id);
+        expectLoopEnd(*this, inspector, 12.0);
+
+        applySourceBeats(seed.id, 8.0);
+        inspector.clipPropertyChanged(seed.id);
+        expectLoopEnd(*this, inspector, 8.0);
+
+        ClipManager::getInstance().clearAllClips();
+    }
+
+    void testMidDragPropertyChangeRefreshesLoopEnd() {
+        beginTest("Loop end follows source Beats during Beats drag");
+        ClipManager::getInstance().clearAllClips();
+
+        auto seed = makeInspectorAudioClip();
+        ClipManager::getInstance().restoreClip(seed);
+
+        ClipInspector inspector;
+        inspector.setBounds(0, 0, 360, 640);
+        inspector.setSelectedClip(seed.id);
+        expectLoopEnd(*this, inspector, 16.0);
+
+        inspector.clipBeatsLengthValue_->isDragging_ = true;
+
+        applySourceBeats(seed.id, 12.0);
+        inspector.clipPropertyChanged(seed.id);
+        expectLoopEnd(*this, inspector, 12.0);
+
+        applySourceBeats(seed.id, 8.0);
+        inspector.clipPropertyChanged(seed.id);
+        expectLoopEnd(*this, inspector, 8.0);
+
+        inspector.clipBeatsLengthValue_->isDragging_ = false;
+        ClipManager::getInstance().clearAllClips();
+    }
+};
+
+static ClipInspectorJuceTest clipInspectorJuceTest;

--- a/tests/test_clip_resize_operations.cpp
+++ b/tests/test_clip_resize_operations.cpp
@@ -27,7 +27,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.speedRatio = 1.0;
 
@@ -46,7 +46,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.speedRatio = 2.0;  // 2x faster (speedRatio = speed factor semantics)
 
@@ -66,7 +66,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         clip.startTime = 2.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 2.0;  // Previously trimmed
         clip.speedRatio = 1.0;
 
@@ -85,7 +85,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         clip.startTime = 2.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.5;  // Only 0.5s of offset available
         clip.speedRatio = 1.0;
 
@@ -104,7 +104,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         clip.startTime = 1.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.speedRatio = 1.0;
 
@@ -127,7 +127,7 @@ TEST_CASE("ClipOperations::resizeContainerFromRight - audio data unchanged",
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 1.0;
         clip.speedRatio = 1.5;
 
@@ -146,7 +146,7 @@ TEST_CASE("ClipOperations::resizeContainerFromRight - audio data unchanged",
         clip.startTime = 2.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.speedRatio = 1.0;
 
@@ -180,7 +180,7 @@ TEST_CASE("ClipOperations - Sequential resizes maintain correct audio offset",
         clip.startTime = 0.0;
         clip.length = 8.0;  // 2 bars at 120 BPM = 8 beats
         clip.setAudioContent();
-        clip.audioFilePath = "kick_loop.wav";
+        clip.audio().source.filePath = "kick_loop.wav";
         clip.offset = 0.0;
         clip.speedRatio = 1.0;
 
@@ -211,7 +211,7 @@ TEST_CASE("ClipOperations - Sequential resizes maintain correct audio offset",
         clip.startTime = 2.0;
         clip.length = 6.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.speedRatio = 1.0;
 
@@ -399,7 +399,7 @@ TEST_CASE("Left resize with throttled drag updates - offset must use original st
         originalState.startTime = 0.0;
         originalState.length = 4.0;
         originalState.setAudioContent();
-        originalState.audioFilePath = "test.wav";
+        originalState.audio().source.filePath = "test.wav";
         originalState.offset = 0.0;
         originalState.speedRatio = 1.0;
 
@@ -436,7 +436,7 @@ TEST_CASE("Left resize with throttled drag updates - offset must use original st
         originalState.startTime = 0.0;
         originalState.length = 8.0;
         originalState.setAudioContent();
-        originalState.audioFilePath = "test.wav";
+        originalState.audio().source.filePath = "test.wav";
         originalState.offset = 0.0;
         originalState.speedRatio = 2.0;  // 2x slower (speedRatio = stretchFactor semantics)
 
@@ -457,7 +457,7 @@ TEST_CASE("Left resize with throttled drag updates - offset must use original st
         originalState.startTime = 0.0;
         originalState.length = 8.0;
         originalState.setAudioContent();
-        originalState.audioFilePath = "test.wav";
+        originalState.audio().source.filePath = "test.wav";
         originalState.offset = 0.0;
         originalState.speedRatio = 1.0;
 
@@ -491,7 +491,7 @@ TEST_CASE("Left resize with throttled drag updates - offset must use original st
         originalState.startTime = 2.0;
         originalState.length = 4.0;
         originalState.setAudioContent();
-        originalState.audioFilePath = "test.wav";
+        originalState.audio().source.filePath = "test.wav";
         originalState.offset = 2.0;  // Previously trimmed
         originalState.speedRatio = 1.0;
 
@@ -596,7 +596,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart tracks offset for
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.loopStart = 0.0;
         clip.loopEnabled = false;
@@ -613,7 +613,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart tracks offset for
         clip.startTime = 2.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 2.0;
         clip.loopStart = 2.0;
         clip.loopEnabled = false;
@@ -630,7 +630,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart tracks offset for
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.loopStart = 0.0;
         clip.loopEnabled = false;
@@ -647,7 +647,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart tracks offset for
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.loopStart = 0.0;
         clip.loopEnabled = false;
@@ -672,7 +672,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart unchanged for loo
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 1.0;
         clip.loopStart = 0.5;
         clip.loopLength = 2.0;
@@ -695,7 +695,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart unchanged for loo
         clip.startTime = 4.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 1.5;
         clip.loopStart = 0.5;
         clip.loopLength = 2.0;
@@ -714,7 +714,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart unchanged for loo
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 1.0;
         clip.loopStart = 0.5;
         clip.loopLength = 2.0;
@@ -741,7 +741,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart unchanged for loo
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 1.0;
         clip.loopStart = 0.0;
         clip.loopLength = 2.0;
@@ -770,7 +770,7 @@ TEST_CASE("ClipOperations::trimAudioFromLeft - loopStart tracks offset",
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.loopStart = 0.0;
         clip.speedRatio = 1.0;
@@ -786,7 +786,7 @@ TEST_CASE("ClipOperations::trimAudioFromLeft - loopStart tracks offset",
         clip.startTime = 2.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 2.0;
         clip.loopStart = 2.0;
         clip.speedRatio = 1.0;
@@ -802,7 +802,7 @@ TEST_CASE("ClipOperations::trimAudioFromLeft - loopStart tracks offset",
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.loopStart = 0.0;
         clip.speedRatio = 1.5;
@@ -819,7 +819,7 @@ TEST_CASE("ClipOperations::trimAudioFromLeft - loopStart tracks offset",
         clip.startTime = 1.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.5;
         clip.loopStart = 0.5;
         clip.speedRatio = 1.0;
@@ -843,12 +843,12 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - auto-tempo offset uses BPM 
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.offsetBeats = 0.0;
         clip.speedRatio = 1.0;
         clip.autoTempo = true;
-        clip.sourceBPM = 140.0;
+        clip.audio().interpretation.bpm = 140.0;
 
         // Shrink by 1 second at 120 BPM
         ClipOperations::resizeContainerFromLeft(clip, 3.0, 120.0);
@@ -865,7 +865,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - auto-tempo offset uses BPM 
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.offsetBeats = 0.0;
         clip.loopStart = 0.0;
@@ -875,7 +875,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - auto-tempo offset uses BPM 
         clip.loopEnabled = true;
         clip.speedRatio = 1.0;
         clip.autoTempo = true;
-        clip.sourceBPM = 140.0;
+        clip.audio().interpretation.bpm = 140.0;
 
         // Shrink by 1 second at 120 BPM
         ClipOperations::resizeContainerFromLeft(clip, 7.0, 120.0);
@@ -892,11 +892,11 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - auto-tempo offset uses BPM 
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.speedRatio = 2.0;
         clip.autoTempo = false;
-        clip.sourceBPM = 140.0;
+        clip.audio().interpretation.bpm = 140.0;
 
         ClipOperations::resizeContainerFromLeft(clip, 3.0, 120.0);
 
@@ -909,11 +909,11 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - auto-tempo offset uses BPM 
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audioFilePath = "test.wav";
+        clip.audio().source.filePath = "test.wav";
         clip.offset = 0.0;
         clip.speedRatio = 1.0;
         clip.autoTempo = true;
-        clip.sourceBPM = 120.0;  // Same as project
+        clip.audio().interpretation.bpm = 120.0;  // Same as project
 
         ClipOperations::resizeContainerFromLeft(clip, 3.0, 120.0);
 

--- a/tests/test_clip_sync_integration_juce.cpp
+++ b/tests/test_clip_sync_integration_juce.cpp
@@ -5,6 +5,7 @@
 
 // TE internal test utilities (not exposed via module public headers)
 #include "SharedTestEngine.hpp"
+#include "magda/daw/audio/AudioThumbnailManager.hpp"
 #include "magda/daw/audio/TrackController.hpp"
 #include "magda/daw/audio/WarpMarkerManager.hpp"
 #include "magda/daw/audio/session/ClipSynchronizer.hpp"
@@ -59,6 +60,8 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
 
     void runTest() override {
         testCreateAndSyncAudioClip();
+        testSessionImportUsesCachedDetectorFallback();
+        testSessionSyncPreservesDetectedSourceInterpretation();
         testMoveClip();
         testResizeFromRight();
         testResizeFromLeft();
@@ -156,6 +159,73 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         // Source file should match
         auto sourceFile = teClip->getCurrentSourceFile();
         expect(sourceFile == f.sinFile->getFile(), "Source file should match");
+    }
+
+    void testSessionImportUsesCachedDetectorFallback() {
+        beginTest("Session import uses cached detector fallback for defaulted source metadata");
+
+        Fixture f;
+        auto& thumbs = AudioThumbnailManager::getInstance();
+        thumbs.clearCache();
+
+        constexpr double detectedBpm = 172.0;
+        const double sourceDuration = 5.0;
+        const double expectedSourceBeats = sourceDuration * detectedBpm / 60.0;
+        thumbs.cacheBPM(f.audioPath(), detectedBpm);
+
+        auto clipId = ClipManager::getInstance().createAudioClip(
+            f.trackId, 0.0, sourceDuration, f.audioPath(), ClipView::Session, 120.0);
+        auto* clip = ClipManager::getInstance().getClip(clipId);
+        expect(clip != nullptr, "Session clip should exist");
+        if (clip == nullptr)
+            return;
+        expect(clip->view == ClipView::Session, "Clip should be a session clip");
+        expect(clip->autoTempo, "Session audio clips should default to beat mode");
+        expectWithinAbsoluteError(clip->audio().interpretation.bpm, detectedBpm, 0.01);
+        expectWithinAbsoluteError(clip->audio().interpretation.totalBeats, expectedSourceBeats,
+                                  0.01);
+        expectWithinAbsoluteError(clip->loopLengthBeats, expectedSourceBeats, 0.01);
+
+        thumbs.clearCache();
+    }
+
+    void testSessionSyncPreservesDetectedSourceInterpretation() {
+        beginTest("Session sync preserves detector metadata when TE loopInfo is project-default");
+
+        Fixture f;
+        auto& thumbs = AudioThumbnailManager::getInstance();
+        thumbs.clearCache();
+
+        constexpr double detectedBpm = 172.0;
+        const double sourceDuration = 5.0;
+        const double expectedSourceBeats = sourceDuration * detectedBpm / 60.0;
+        thumbs.cacheBPM(f.audioPath(), detectedBpm);
+
+        auto clipId = ClipManager::getInstance().createAudioClip(
+            f.trackId, 0.0, sourceDuration, f.audioPath(), ClipView::Session, 120.0);
+        ClipManager::getInstance().setClipSceneIndex(clipId, 0);
+        if (f.clipSync->getSessionTeClip(clipId) == nullptr)
+            f.clipSync->syncSessionClipToSlot(clipId);
+
+        auto* clip = ClipManager::getInstance().getClip(clipId);
+        expect(clip != nullptr, "Session clip should still exist after sync");
+        if (clip == nullptr)
+            return;
+        expectWithinAbsoluteError(clip->audio().interpretation.bpm, detectedBpm, 0.01);
+        expectWithinAbsoluteError(clip->audio().interpretation.totalBeats, expectedSourceBeats,
+                                  0.01);
+        expectWithinAbsoluteError(clip->loopLengthBeats, expectedSourceBeats, 0.01);
+
+        auto* teClip = dynamic_cast<te::WaveAudioClip*>(f.clipSync->getSessionTeClip(clipId));
+        expect(teClip != nullptr, "Tracktion session clip should exist");
+        if (teClip != nullptr) {
+            auto waveInfo = teClip->getWaveInfo();
+            auto& loopInfo = teClip->getLoopInfo();
+            expectWithinAbsoluteError(loopInfo.getBpm(waveInfo), detectedBpm, 0.01);
+            expectWithinAbsoluteError(loopInfo.getNumBeats(), expectedSourceBeats, 0.01);
+        }
+
+        thumbs.clearCache();
     }
 
     void testMoveClip() {

--- a/tests/test_clip_sync_integration_juce.cpp
+++ b/tests/test_clip_sync_integration_juce.cpp
@@ -324,13 +324,13 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         // Auto-tempo + beat-domain loop region (clips are beat-authoritative).
         auto* clip = ClipManager::getInstance().getClip(clipId);
         clip->autoTempo = true;
-        clip->sourceBPM = 60.0;
-        clip->sourceNumBeats = 5.0;  // 5s sine WAV at 60 BPM
+        clip->audio().interpretation.bpm = 60.0;
+        clip->audio().interpretation.totalBeats = 5.0;  // 5s sine WAV at 60 BPM
         clip->loopEnabled = true;
         clip->loopStartBeats = 0.0;
         clip->loopLengthBeats = 2.0;
-        clip->loopStart = clip->loopStartBeats * 60.0 / clip->sourceBPM;
-        clip->loopLength = clip->loopLengthBeats * 60.0 / clip->sourceBPM;
+        clip->loopStart = clip->loopStartBeats * 60.0 / clip->audio().interpretation.bpm;
+        clip->loopLength = clip->loopLengthBeats * 60.0 / clip->audio().interpretation.bpm;
         f.clipSync->syncClipToEngine(clipId);
 
         expect(teClip->isLooping(), "TE clip should be looping");
@@ -346,7 +346,8 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
     }
 
     void testLoopTimeBased() {
-        beginTest("Loop with container longer than region (non-integer multiple): partial second cycle plays");
+        beginTest("Loop with container longer than region (non-integer multiple): partial second "
+                  "cycle plays");
 
         // Reproduces the bug from the screenshot:
         //   120 BPM, clip = 3 bars, loop region = 2 bars.
@@ -371,8 +372,8 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         // (1.5× the loop region) via setPlacementBeats; deriveTimesFromBeats
         // refreshes the seconds cache so the renderer agrees with TE.
         clip->autoTempo = true;
-        clip->sourceBPM = 60.0;
-        clip->sourceNumBeats = 5.0;
+        clip->audio().interpretation.bpm = 60.0;
+        clip->audio().interpretation.totalBeats = 5.0;
         clip->loopEnabled = true;
         clip->loopStartBeats = 0.0;
         clip->loopLengthBeats = 2.0;

--- a/tests/test_looped_waveform_tile.cpp
+++ b/tests/test_looped_waveform_tile.cpp
@@ -233,6 +233,93 @@ TEST_CASE("ClipDisplayInfo - looped source file ranges", "[clip][display][loop]"
     }
 }
 
+TEST_CASE("ClipDisplayInfo maps session playhead into waveform editor display time",
+          "[clip][display][loop][session-playhead]") {
+    using namespace magda;
+
+    SECTION("Non-looped clips start from the source offset display position") {
+        ClipInfo clip;
+        clip.setAudioContent();
+        clip.startTime = 0.0;
+        clip.length = 8.0;
+        clip.offset = 1.5;
+        clip.speedRatio = 1.0;
+        clip.loopEnabled = false;
+
+        syncPlacement(clip);
+        const auto di = ClipDisplayInfo::from(clip, 120.0);
+
+        REQUIRE(di.sessionPlayheadToDisplayPosition(-0.001) == Catch::Approx(-1.0));
+        REQUIRE(di.sessionPlayheadToDisplayPosition(0.0) == Catch::Approx(1.5));
+        REQUIRE(di.sessionPlayheadToDisplayPosition(2.25) == Catch::Approx(3.75));
+    }
+
+    SECTION("Looped clips at zero phase wrap inside the loop display range") {
+        ClipInfo clip;
+        clip.setAudioContent();
+        clip.startTime = 0.0;
+        clip.length = 12.0;
+        clip.offset = 1.0;
+        clip.speedRatio = 1.0;
+        clip.loopEnabled = true;
+        clip.loopStart = 1.0;
+        clip.loopLength = 4.0;
+
+        syncPlacement(clip);
+        const auto di = ClipDisplayInfo::from(clip, 120.0);
+
+        REQUIRE(di.sessionPlayheadToDisplayPosition(0.0) == Catch::Approx(1.0));
+        REQUIRE(di.sessionPlayheadToDisplayPosition(1.5) == Catch::Approx(2.5));
+        REQUIRE(di.sessionPlayheadToDisplayPosition(4.0) == Catch::Approx(1.0));
+        REQUIRE(di.sessionPlayheadToDisplayPosition(5.25) == Catch::Approx(2.25));
+    }
+
+    SECTION("Looped clips preserve phase offset when wrapping") {
+        ClipInfo clip;
+        clip.setAudioContent();
+        clip.startTime = 0.0;
+        clip.length = 12.0;
+        clip.offset = 2.0;
+        clip.speedRatio = 1.0;
+        clip.loopEnabled = true;
+        clip.loopStart = 1.0;
+        clip.loopLength = 4.0;
+
+        syncPlacement(clip);
+        const auto di = ClipDisplayInfo::from(clip, 120.0);
+
+        REQUIRE(di.sessionPlayheadToDisplayPosition(0.0) == Catch::Approx(2.0));
+        REQUIRE(di.sessionPlayheadToDisplayPosition(2.5) == Catch::Approx(4.5));
+        REQUIRE(di.sessionPlayheadToDisplayPosition(3.0) == Catch::Approx(1.0));
+        REQUIRE(di.sessionPlayheadToDisplayPosition(4.5) == Catch::Approx(2.5));
+    }
+
+    SECTION("Auto-tempo source BPM maps session playhead in display-time seconds") {
+        ClipInfo clip;
+        clip.setAudioContent();
+        clip.autoTempo = true;
+        clip.startTime = 0.0;
+        clip.length = 8.0;
+        clip.speedRatio = 1.0;
+        clip.loopEnabled = true;
+        clip.audio().interpretation.bpm = 172.0;
+        clip.audio().interpretation.totalBeats = 16.0;
+        clip.audio().source.durationSeconds = 16.0 * 60.0 / 172.0;
+        clip.setPlacementBeats(0.0, 16.0);
+        clip.loopStartBeats = 0.0;
+        clip.loopLengthBeats = 16.0;
+        clip.offsetBeats = 4.0;
+
+        const auto di = ClipDisplayInfo::from(clip, 120.0, clip.audio().source.durationSeconds);
+
+        REQUIRE(di.loopLengthSeconds == Catch::Approx(8.0));
+        REQUIRE(di.sessionPlayheadToDisplayPosition(0.0) == Catch::Approx(2.0));
+        REQUIRE(di.sessionPlayheadToDisplayPosition(1.0) == Catch::Approx(3.0));
+        REQUIRE(di.sessionPlayheadToDisplayPosition(6.0) == Catch::Approx(0.0));
+        REQUIRE(di.sessionPlayheadToDisplayPosition(8.5) == Catch::Approx(2.5));
+    }
+}
+
 // ============================================================================
 // Partial tile source range calculation
 // ============================================================================

--- a/tests/test_looped_waveform_tile.cpp
+++ b/tests/test_looped_waveform_tile.cpp
@@ -318,6 +318,60 @@ TEST_CASE("ClipDisplayInfo maps session playhead into waveform editor display ti
         REQUIRE(di.sessionPlayheadToDisplayPosition(6.0) == Catch::Approx(0.0));
         REQUIRE(di.sessionPlayheadToDisplayPosition(8.5) == Catch::Approx(2.5));
     }
+
+    SECTION("Auto-tempo playhead mapping ignores stale source seconds caches") {
+        ClipInfo clip;
+        clip.setAudioContent();
+        clip.autoTempo = true;
+        clip.startTime = 99.0;  // stale cache; placement is authoritative
+        clip.length = 99.0;     // stale cache; placement is authoritative
+        clip.speedRatio = 1.0;
+        clip.loopEnabled = true;
+        clip.audio().interpretation.bpm = 172.0;
+        clip.audio().interpretation.totalBeats = 16.0;
+        clip.audio().source.durationSeconds = 16.0 * 60.0 / 172.0;
+        clip.setPlacementBeats(0.0, 16.0);
+        clip.loopStart = 99.0;   // stale cache; loopStartBeats is authoritative
+        clip.loopLength = 99.0;  // stale cache; loopLengthBeats is authoritative
+        clip.offset = 99.0;      // stale cache; offsetBeats is authoritative
+        clip.loopStartBeats = 4.0;
+        clip.loopLengthBeats = 8.0;
+        clip.offsetBeats = 6.0;
+
+        const auto di = ClipDisplayInfo::from(clip, 120.0, clip.audio().source.durationSeconds);
+
+        REQUIRE(di.loopStartPositionSeconds == Catch::Approx(2.0));
+        REQUIRE(di.loopLengthSeconds == Catch::Approx(4.0));
+        REQUIRE(di.offsetPositionSeconds == Catch::Approx(3.0));
+        REQUIRE(di.sessionPlayheadToDisplayPosition(0.0) == Catch::Approx(3.0));
+        REQUIRE(di.sessionPlayheadToDisplayPosition(3.0) == Catch::Approx(2.0));
+        REQUIRE(di.sessionPlayheadToDisplayPosition(5.5) == Catch::Approx(4.5));
+    }
+
+    SECTION("Auto-tempo display source conversion follows source BPM after Beats edit") {
+        ClipInfo clip;
+        clip.setAudioContent();
+        clip.autoTempo = true;
+        clip.loopEnabled = true;
+        clip.speedRatio = 1.0;
+        clip.audio().interpretation.bpm = 129.0;
+        clip.audio().interpretation.totalBeats = 12.0;
+        clip.audio().source.durationSeconds = 12.0 * 60.0 / 129.0;
+        clip.setPlacementBeats(0.0, 12.0);
+        clip.loopStartBeats = 0.0;
+        clip.loopLengthBeats = 12.0;
+        clip.offsetBeats = 3.0;
+        clip.loopStart = 99.0;
+        clip.loopLength = 99.0;
+        clip.offset = 99.0;
+
+        const auto di = ClipDisplayInfo::from(clip, 120.0, clip.audio().source.durationSeconds);
+
+        REQUIRE(di.fullSourceExtentSeconds == Catch::Approx(6.0));
+        REQUIRE(di.loopLengthSeconds == Catch::Approx(6.0));
+        REQUIRE(di.offsetPositionSeconds == Catch::Approx(1.5));
+        REQUIRE(di.displayPositionToSourceTime(1.5) == Catch::Approx(1.5 * 120.0 / 129.0));
+    }
 }
 
 // ============================================================================

--- a/tests/test_project_serialization.cpp
+++ b/tests/test_project_serialization.cpp
@@ -1,5 +1,6 @@
 #include <juce_core/juce_core.h>
 
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include "magda/daw/core/AutomationManager.hpp"
@@ -9,6 +10,7 @@
 #include "magda/daw/project/serialization/ProjectSerializer.hpp"
 
 using namespace magda;
+using Catch::Approx;
 
 namespace {
 
@@ -143,6 +145,71 @@ TEST_CASE("Project Serialization Basics", "[project][serialization]") {
         REQUIRE(loaded.loopStartBeats == info.loopStartBeats);
         REQUIRE(loaded.loopEndBeats == info.loopEndBeats);
     }
+}
+
+TEST_CASE("Audio clip serialization separates source facts from interpretation",
+          "[project][serialization][audio]") {
+    ProjectTestFixture fixture;
+
+    auto trackId = TrackManager::getInstance().createTrack("Audio", TrackType::Audio);
+
+    ClipInfo clip;
+    clip.id = 42;
+    clip.trackId = trackId;
+    clip.name = "Loop";
+    clip.setAudioContent();
+    clip.setPlacementBeats(4.0, 16.0);
+    clip.audio().source.filePath = "/tmp/loop.wav";
+    clip.audio().source.durationSeconds = 2.7907;
+    clip.audio().interpretation.bpm = 172.0;
+    clip.audio().interpretation.totalBeats = 8.0;
+    clip.autoTempo = true;
+    clip.loopEnabled = true;
+    clip.loopStartBeats = 0.0;
+    clip.loopLengthBeats = 8.0;
+    clip.loopLength = 8.0 * 60.0 / 172.0;
+    ClipManager::getInstance().restoreClip(clip);
+
+    ProjectInfo info;
+    info.name = "Audio Source Model";
+    info.tempo = 120.0;
+
+    auto json = ProjectSerializer::serializeProject(info);
+    auto* rootObj = json.getDynamicObject();
+    REQUIRE(rootObj != nullptr);
+
+    auto* clips = rootObj->getProperty("clips").getArray();
+    REQUIRE(clips != nullptr);
+    REQUIRE(clips->size() == 1);
+
+    auto* clipObj = clips->getReference(0).getDynamicObject();
+    REQUIRE(clipObj != nullptr);
+    REQUIRE(clipObj->getProperty("audioSource").isVoid());
+
+    auto* audioObj = clipObj->getProperty("audio").getDynamicObject();
+    REQUIRE(audioObj != nullptr);
+    auto* sourceObj = audioObj->getProperty("source").getDynamicObject();
+    auto* interpretationObj = audioObj->getProperty("interpretation").getDynamicObject();
+    auto* playbackObj = audioObj->getProperty("playback").getDynamicObject();
+    REQUIRE(sourceObj != nullptr);
+    REQUIRE(interpretationObj != nullptr);
+    REQUIRE(playbackObj != nullptr);
+    auto* placementObj = clipObj->getProperty("placement").getDynamicObject();
+    REQUIRE(placementObj != nullptr);
+    REQUIRE(static_cast<double>(sourceObj->getProperty("durationSeconds")) == Approx(2.7907));
+    REQUIRE(static_cast<double>(interpretationObj->getProperty("totalBeats")) == Approx(8.0));
+    REQUIRE(static_cast<double>(playbackObj->getProperty("loopLengthBeats")) == Approx(8.0));
+    REQUIRE(static_cast<double>(placementObj->getProperty("lengthBeats")) == Approx(16.0));
+
+    ProjectInfo loaded;
+    REQUIRE(ProjectSerializer::deserializeProject(json, loaded));
+    auto* restored = ClipManager::getInstance().getClip(clip.id);
+    REQUIRE(restored != nullptr);
+    REQUIRE(restored->isAudio());
+    REQUIRE(restored->placement.lengthBeats == Approx(16.0));
+    REQUIRE(restored->audio().source.durationSeconds == Approx(2.7907));
+    REQUIRE(restored->audio().interpretation.totalBeats == Approx(8.0));
+    REQUIRE(restored->loopLengthBeats == Approx(8.0));
 }
 
 TEST_CASE("Project with Tracks", "[project][serialization][tracks]") {

--- a/tests/test_project_serialization.cpp
+++ b/tests/test_project_serialization.cpp
@@ -163,6 +163,7 @@ TEST_CASE("Audio clip serialization separates source facts from interpretation",
     clip.audio().source.durationSeconds = 2.7907;
     clip.audio().interpretation.bpm = 172.0;
     clip.audio().interpretation.totalBeats = 8.0;
+    clip.audio().interpretation.totalBeatsLocked = true;
     clip.autoTempo = true;
     clip.loopEnabled = true;
     clip.loopStartBeats = 0.0;
@@ -198,6 +199,7 @@ TEST_CASE("Audio clip serialization separates source facts from interpretation",
     REQUIRE(placementObj != nullptr);
     REQUIRE(static_cast<double>(sourceObj->getProperty("durationSeconds")) == Approx(2.7907));
     REQUIRE(static_cast<double>(interpretationObj->getProperty("totalBeats")) == Approx(8.0));
+    REQUIRE(static_cast<bool>(interpretationObj->getProperty("totalBeatsLocked")));
     REQUIRE(static_cast<double>(playbackObj->getProperty("loopLengthBeats")) == Approx(8.0));
     REQUIRE(static_cast<double>(placementObj->getProperty("lengthBeats")) == Approx(16.0));
 
@@ -209,6 +211,7 @@ TEST_CASE("Audio clip serialization separates source facts from interpretation",
     REQUIRE(restored->placement.lengthBeats == Approx(16.0));
     REQUIRE(restored->audio().source.durationSeconds == Approx(2.7907));
     REQUIRE(restored->audio().interpretation.totalBeats == Approx(8.0));
+    REQUIRE(restored->audio().interpretation.totalBeatsLocked);
     REQUIRE(restored->loopLengthBeats == Approx(8.0));
 }
 

--- a/tests/test_session_clip_playback.cpp
+++ b/tests/test_session_clip_playback.cpp
@@ -961,10 +961,10 @@ TEST_CASE("AutoTempo session clip timing: 172bpm clip in 120bpm project",
     // Scenario from the bug report: 2-bar loop at 172bpm, project at 120bpm
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audioFilePath = "loop_172bpm.wav";
-    clip.sourceBPM = 172.0;
-    clip.sourceNumBeats = 8.0;         // 2 bars = 8 beats
-    clip.length = 8.0 * 60.0 / 172.0;  // ~2.79s original duration
+    clip.audio().source.filePath = "loop_172bpm.wav";
+    clip.audio().interpretation.bpm = 172.0;
+    clip.audio().interpretation.totalBeats = 8.0;  // 2 bars = 8 beats
+    clip.length = 8.0 * 60.0 / 172.0;              // ~2.79s original duration
     clip.speedRatio = 1.0;
     clip.loopEnabled = true;
     clip.loopStart = 0.0;
@@ -1018,9 +1018,9 @@ TEST_CASE("AutoTempo session clip timing: sub-loop region",
     // 8-beat source, but only looping 4 beats
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audioFilePath = "sample.wav";
-    clip.sourceBPM = 140.0;
-    clip.sourceNumBeats = 8.0;
+    clip.audio().source.filePath = "sample.wav";
+    clip.audio().interpretation.bpm = 140.0;
+    clip.audio().interpretation.totalBeats = 8.0;
     clip.length = 8.0 * 60.0 / 140.0;
     clip.speedRatio = 1.0;
     clip.loopEnabled = true;
@@ -1034,7 +1034,7 @@ TEST_CASE("AutoTempo session clip timing: sub-loop region",
     auto [clipLen, loopLen] = computeAutoTempoTimings(clip, PROJECT_BPM);
 
     SECTION("Clip length stays at file's musical beat count") {
-        // Issue #1157: lengthBeats = sourceNumBeats. clipLen derives from
+        // Issue #1157: lengthBeats = source interpretation total beats. clipLen derives from
         // lengthBeats × 60 / projectBPM.
         REQUIRE(clip.lengthBeats == Catch::Approx(8.0));
         REQUIRE(clipLen == Catch::Approx(8.0 * 60.0 / PROJECT_BPM));
@@ -1049,9 +1049,9 @@ TEST_CASE("AutoTempo session clip timing: BPM edge cases",
           "[session][auto-tempo][playhead][edge]") {
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audioFilePath = "sample.wav";
-    clip.sourceBPM = 120.0;
-    clip.sourceNumBeats = 4.0;
+    clip.audio().source.filePath = "sample.wav";
+    clip.audio().interpretation.bpm = 120.0;
+    clip.audio().interpretation.totalBeats = 4.0;
     clip.length = 2.0;
     clip.speedRatio = 1.0;
     clip.loopEnabled = true;
@@ -1089,9 +1089,9 @@ TEST_CASE("AutoTempo session clip: getAutoTempoBeatRange for session loop",
           "[session][auto-tempo][beat-range]") {
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audioFilePath = "loop.wav";
-    clip.sourceBPM = 172.0;
-    clip.sourceNumBeats = 8.0;
+    clip.audio().source.filePath = "loop.wav";
+    clip.audio().interpretation.bpm = 172.0;
+    clip.audio().interpretation.totalBeats = 8.0;
     clip.length = 8.0 * 60.0 / 172.0;
     clip.speedRatio = 1.0;
     clip.loopEnabled = true;
@@ -1105,7 +1105,7 @@ TEST_CASE("AutoTempo session clip: getAutoTempoBeatRange for session loop",
         auto [startBeats, lengthBeats] = ClipOperations::getAutoTempoBeatRange(clip, PROJECT_BPM);
         REQUIRE(startBeats >= 0.0);
         REQUIRE(lengthBeats > 0.0);
-        REQUIRE(startBeats + lengthBeats <= clip.sourceNumBeats + 0.001);
+        REQUIRE(startBeats + lengthBeats <= clip.audio().interpretation.totalBeats + 0.001);
     }
 
     SECTION("Beat range matches stored loopLengthBeats") {


### PR DESCRIPTION
## Summary
- Move audio file facts into AudioClipModel::source and source BPM/beat interpretation into AudioClipModel::interpretation
- Remove flat ClipInfo audio source fields and update call sites/serialization to the nested audio model
- Preserve clip placement length when extending beat-mode loops; source facts and interpretation are no longer rewritten by placement edits

## Validation
- make test-build
- ./cmake-build-debug/tests/magda_tests "[clip][auto-tempo]"
- ./cmake-build-debug/tests/magda_tests "[bpm][clip][issue-1157]"
- ./cmake-build-debug/tests/magda_tests "[serialization]"
- ./cmake-build-debug/tests/magda_tests "[audio][clip][source]"

Note: the focused JUCE tests still emit existing shutdown/assertion noise after passing Catch assertions.