### PR TITLE
Force device gain to unity while the device is bypassed (#1189)

### DIFF
--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -588,8 +588,13 @@ void AudioBridge::devicePropertyChanged(DeviceId deviceId) {
                     tePlugin->setEnabled(!device->bypassed);
             }
 
-            // Push gain to the audio-graph atomic so DeviceGainNode picks it up
-            deviceMetering_.setGain(deviceId, device->gainValue);
+            // Push gain to the audio-graph atomic so DeviceGainNode picks it up.
+            // DeviceGainNode sits OUTSIDE the plugin in the TE graph (between the plugin and
+            // the level meter), so it stays active even when the plugin is bypassed. Force
+            // unity while bypassed so the slider stops attenuating signal that isn't going
+            // through the plugin (#1189). The user's gainValue is preserved on DeviceInfo
+            // and gets re-pushed when the device is re-enabled.
+            deviceMetering_.setGain(deviceId, device->bypassed ? 1.0f : device->gainValue);
 
             // When bypass changes, resync modifiers so they are removed/restored
             pluginManager_.resyncDeviceModifiers(track.id);


### PR DESCRIPTION
DeviceGainNode lives outside the plugin in TE's graph — it sits between the plugin and the level meter so meters reflect post-gain levels — and its gain atomic is updated unconditionally from device->gainValue. As a result, bypassing the plugin only short-circuits the plugin's own processing; the gain stage stayed active and kept attenuating the dry signal that flowed past the bypassed plugin. Moving the slider on a bypassed device was audible.

Push 1.0 to the atomic when the device is bypassed. The user's gainValue is preserved on DeviceInfo, so the next devicePropertyChanged after re-enabling restores it.