### PR TITLE
fix(midi): reduce pitch-bend / CC interpolation density

### DIFF
--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -1412,9 +1412,22 @@ bool ClipSynchronizer::syncMidiClipToEngine(ClipId clipId, const ClipInfo* clip)
         }
     }
 
-    // Add pitch bend events with interpolation
-    interpolateCCEvents(sequence, clip->midiPitchBendData, te::MidiControllerEvent::pitchWheelType,
-                        effectiveOffset, visibleStart, visibleEnd, contentLengthBeats);
+    // Add pitch bend events with interpolation. Skip entirely when every
+    // event in the clip sits at the wheel-rest value (8192) — emitting a
+    // stream of "no-op" pitch wheels is pointless and triggers a deadlock
+    // in fragile synths (see #1193). Real curves that return to rest are
+    // preserved because they contain at least one non-rest event.
+    constexpr int kPitchWheelRest = 8192;
+    const bool allAtRest =
+        !clip->midiPitchBendData.empty() &&
+        std::all_of(clip->midiPitchBendData.begin(), clip->midiPitchBendData.end(),
+                    [](const auto& ev) { return ev.value == kPitchWheelRest; });
+
+    if (!allAtRest) {
+        interpolateCCEvents(sequence, clip->midiPitchBendData,
+                            te::MidiControllerEvent::pitchWheelType, effectiveOffset, visibleStart,
+                            visibleEnd, contentLengthBeats);
+    }
 
     return needsGraphReallocation;
 }

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -1153,7 +1153,11 @@ static void interpolateCCEvents(te::MidiList& sequence, const std::vector<EventT
         return a.beatPosition < b.beatPosition;
     });
 
-    constexpr double kStepSize = 1.0 / 64.0;  // 1/64 beat between interpolated events
+    // 1/16 beat is finer than any synth can audibly resolve (~32 Hz at 120 BPM)
+    // and emits 4x fewer events than the previous 1/64. Density above this was
+    // tipping fragile synths (e.g. Wave Manuel) into deadlock at clip starts /
+    // loop wraps, where catch-up controller events collapse into one buffer.
+    constexpr double kStepSize = 1.0 / 16.0;
 
     // Tracktion Engine stores all controller values in 14-bit range (0-16383).
     // CC values (0-127) must be left-shifted by 7 bits; pitch bend is already 14-bit.
@@ -1196,6 +1200,14 @@ static void interpolateCCEvents(te::MidiList& sequence, const std::vector<EventT
 
         double v1 = static_cast<double>(ev.value);
         double v2 = static_cast<double>(next.value);
+
+        // Skip dense interpolation across constant-value segments: emitting
+        // dozens of identical pitch-wheel/CC events every beat is pure waste
+        // and can deadlock fragile synths when bursts collapse into one buffer.
+        if (static_cast<int>(std::round(v1)) == static_cast<int>(std::round(v2))) {
+            addEvent(ev.beatPosition, ev.value);
+            continue;
+        }
 
         if (ev.curveType == MidiCurveType::Linear) {
             // Generate interpolated events every kStepSize beats

--- a/tests/test_clip_sync_integration_juce.cpp
+++ b/tests/test_clip_sync_integration_juce.cpp
@@ -108,6 +108,7 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         testPasteAudioClipResolvesOverlap();
         testCreateMidiClipResolvesOverlap();
         testMidiSyncClipsNotesToVisibleRangeAfterResize();
+        testMidiSyncSkipsAllRestPitchBendButKeepsRealCurves();
         testMoveClipNoOverlapDoesNotMutateNeighbours();
         testMoveClipToTrackResolvesOverlapOnDestination();
     }
@@ -1651,6 +1652,74 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         }
 
         expect(findNote(64) == nullptr, "Stale note beyond resized clip end should not sync to TE");
+    }
+
+    void testMidiSyncSkipsAllRestPitchBendButKeepsRealCurves() {
+        beginTest("MIDI sync skips pitch-bend when every event is at wheel rest");
+
+        auto countPitchWheelEvents = [](te::MidiClip& teClip) {
+            int count = 0;
+            for (auto* ev : teClip.getSequence().getControllerEvents()) {
+                if (ev != nullptr && ev->getType() == te::MidiControllerEvent::pitchWheelType)
+                    ++count;
+            }
+            return count;
+        };
+
+        // ---- Case 1: every pitch-bend point at rest (8192) → emit nothing ----
+        {
+            Fixture f;
+            auto& cm = ClipManager::getInstance();
+
+            auto clipId = cm.createMidiClipBeats(f.trackId, 0.0, 4.0, ClipView::Arrangement);
+            auto* clip = cm.getClip(clipId);
+            expect(clip != nullptr, "Clip should be created");
+            if (clip == nullptr)
+                return;
+
+            clip->midiPitchBendData = {
+                {8192, 0.0, MidiCurveType::Linear, 0.0, {}, {}},
+                {8192, 1.0, MidiCurveType::Linear, 0.0, {}, {}},
+                {8192, 2.0, MidiCurveType::Step, 0.0, {}, {}},
+            };
+
+            f.clipSync->syncClipToEngine(clipId);
+            auto* teClip = f.getTeMidiClip(clipId);
+            expect(teClip != nullptr, "TE clip should exist after sync");
+            if (teClip == nullptr)
+                return;
+
+            expectEquals(countPitchWheelEvents(*teClip), 0,
+                         "All-at-rest pitch-bend should be filtered out entirely");
+        }
+
+        // ---- Case 2: at least one non-rest point → curve must still be emitted ----
+        {
+            Fixture f;
+            auto& cm = ClipManager::getInstance();
+
+            auto clipId = cm.createMidiClipBeats(f.trackId, 0.0, 4.0, ClipView::Arrangement);
+            auto* clip = cm.getClip(clipId);
+            expect(clip != nullptr);
+            if (clip == nullptr)
+                return;
+
+            // Bend up then return to rest — the return-to-rest event must NOT be dropped.
+            clip->midiPitchBendData = {
+                {8192, 0.0, MidiCurveType::Linear, 0.0, {}, {}},
+                {12000, 1.0, MidiCurveType::Linear, 0.0, {}, {}},
+                {8192, 2.0, MidiCurveType::Step, 0.0, {}, {}},
+            };
+
+            f.clipSync->syncClipToEngine(clipId);
+            auto* teClip = f.getTeMidiClip(clipId);
+            expect(teClip != nullptr);
+            if (teClip == nullptr)
+                return;
+
+            expect(countPitchWheelEvents(*teClip) > 0,
+                   "Real bend curve should still produce pitch-wheel events");
+        }
     }
 
     void testMoveClipNoOverlapDoesNotMutateNeighbours() {


### PR DESCRIPTION
## Summary
- Skip the inner interpolation loop in `interpolateCCEvents` when adjacent points have the same value — constant-value bend/CC segments now cost one event instead of 64.
- Coarsen the interpolation step from 1/64 → 1/16 beat. Still finer than any synth can audibly resolve, and emits 4x fewer events for real curves.

## Context
While investigating #1193, I noticed MAGDA was emitting a synthetic pitch-wheel/CC event every 1/64 beat between adjacent user-authored points and never deduplicating identical values, so a clip with two pitch-bend points at 8192 (wheel at rest) still produced 64 redundant pitch-wheel events per beat.

This change does **not** fix the Wave Manuel deadlock in #1193 — verified locally — but it is a small, defensible cleanup on its own merits: less MIDI traffic, less work in the synth's processBlock, no audible difference on real bend curves.

## Test plan
- [ ] Build cleanly on Windows (verified locally)
- [ ] Replay an existing project with pitch-bend automation and confirm bend curves still sound smooth
- [ ] Confirm CCs (mod wheel, expression, etc.) still automate as expected