### PR TITLE
Coalesce and serialise transient detection per clip

### DIFF
--- a/magda/daw/audio/WarpMarkerManager.cpp
+++ b/magda/daw/audio/WarpMarkerManager.cpp
@@ -36,9 +36,53 @@ te::WaveAudioClip* findWaveAudioClip(te::Edit& edit,
 }
 }  // namespace
 
+WarpMarkerManager::~WarpMarkerManager() {
+    // Stop the coalescing timer before any of our maps are torn down so
+    // a fire mid-destruction can't reach into half-destroyed state.
+    coalescingTimer_.stopTimer();
+    coalescingTimer_.callback = nullptr;
+}
+
 void WarpMarkerManager::setTransientSensitivity(
     te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId, ClipId clipId,
     float sensitivity) {
+    // Coalesce: just record the latest value per clip and (re)start a
+    // short timer. Hot paths (slider drags) hit this method many times
+    // per second; we want exactly ONE TE detection job per clip per
+    // coalescing window.
+    PendingDetection& slot = pendingByClip_[clipId];
+    slot.sensitivity = sensitivity;
+    slot.clipIdToEngineId = clipIdToEngineId;
+    slot.edit = &edit;
+
+    coalescingTimer_.callback = [this]() { applyPendingSensitivities(); };
+    coalescingTimer_.startTimer(kCoalesceMs);
+}
+
+void WarpMarkerManager::applyPendingSensitivities() {
+    auto pending = std::move(pendingByClip_);
+    pendingByClip_.clear();
+
+    for (const auto& [clipId, det] : pending) {
+        if (det.edit == nullptr)
+            continue;
+
+        // If a detection is already in flight for this clip, parking
+        // the latest value is enough — getTransientTimes will pick it
+        // up on completion and schedule one rerun. This avoids the
+        // race that produced the original ThreadPool crash: never two
+        // overlapping detection jobs against the same WarpTimeManager.
+        if (detectionInFlight_.count(clipId)) {
+            dirtyAfterCompletion_[clipId] = det;
+            continue;
+        }
+        applySensitivityNow(*det.edit, det.clipIdToEngineId, clipId, det.sensitivity);
+    }
+}
+
+void WarpMarkerManager::applySensitivityNow(te::Edit& edit,
+                                            const std::map<ClipId, std::string>& clipIdToEngineId,
+                                            ClipId clipId, float sensitivity) {
     const auto* clip = ClipManager::getInstance().getClip(clipId);
     if (!clip || !clip->isAudio() || clip->audio().source.filePath.isEmpty())
         return;
@@ -52,9 +96,9 @@ void WarpMarkerManager::setTransientSensitivity(
     warpManager.detectTransients();
 
     // Clear cache so the next poll picks up fresh results.
-    // Keep clipId in detectionStarted_ since detectTransients() already started the job.
     AudioThumbnailManager::getInstance().clearCachedTransients(clip->audio().source.filePath);
     detectionStarted_.insert(clipId);
+    detectionInFlight_.insert(clipId);
 
     DBG("WarpMarkerManager: set sensitivity=" << sensitivity << " for "
                                               << clip->audio().source.filePath);
@@ -107,6 +151,19 @@ bool WarpMarkerManager::getTransientTimes(te::Edit& edit,
         thumbnailManager.cacheTransients(clip->audio().source.filePath, times);
         DBG("WarpMarkerManager: Cached " << times.size() << " transients for "
                                          << clip->audio().source.filePath);
+
+        // Detection finished — clear the in-flight flag and, if a newer
+        // sensitivity arrived while we were running, fire one more
+        // detection with that value. This is the "dirty after completion"
+        // half of the guard set up in setTransientSensitivity.
+        detectionInFlight_.erase(clipId);
+        auto dirty = dirtyAfterCompletion_.find(clipId);
+        if (dirty != dirtyAfterCompletion_.end()) {
+            const auto det = std::move(dirty->second);
+            dirtyAfterCompletion_.erase(dirty);
+            if (det.edit != nullptr)
+                applySensitivityNow(*det.edit, det.clipIdToEngineId, clipId, det.sensitivity);
+        }
         return true;
     }
 

--- a/magda/daw/audio/WarpMarkerManager.cpp
+++ b/magda/daw/audio/WarpMarkerManager.cpp
@@ -6,16 +6,11 @@
 namespace magda {
 
 namespace {
-// Helper to find WaveAudioClip from MAGDA clip ID.
+// Helper to find WaveAudioClip from a TE engine ID.
 // Searches both arrangement clips on the timeline and session clips in slots.
-te::WaveAudioClip* findWaveAudioClip(te::Edit& edit,
-                                     const std::map<ClipId, std::string>& clipIdToEngineId,
-                                     ClipId clipId) {
-    auto it = clipIdToEngineId.find(clipId);
-    if (it == clipIdToEngineId.end())
+te::WaveAudioClip* findWaveAudioClipByEngineId(te::Edit& edit, const std::string& engineId) {
+    if (engineId.empty())
         return nullptr;
-
-    const auto& engineId = it->second;
     for (auto* track : te::getAudioTracks(edit)) {
         // Search arrangement clips on the timeline
         for (auto* teClip : track->getClips()) {
@@ -34,6 +29,16 @@ te::WaveAudioClip* findWaveAudioClip(te::Edit& edit,
     }
     return nullptr;
 }
+
+// Convenience wrapper: resolve via the caller's clipIdToEngineId map.
+te::WaveAudioClip* findWaveAudioClip(te::Edit& edit,
+                                     const std::map<ClipId, std::string>& clipIdToEngineId,
+                                     ClipId clipId) {
+    auto it = clipIdToEngineId.find(clipId);
+    if (it == clipIdToEngineId.end())
+        return nullptr;
+    return findWaveAudioClipByEngineId(edit, it->second);
+}
 }  // namespace
 
 WarpMarkerManager::~WarpMarkerManager() {
@@ -50,9 +55,15 @@ void WarpMarkerManager::setTransientSensitivity(
     // short timer. Hot paths (slider drags) hit this method many times
     // per second; we want exactly ONE TE detection job per clip per
     // coalescing window.
+    //
+    // Resolve the engineId at queue time (a single map lookup) instead
+    // of snapshotting the whole clipIdToEngineId map per call — the map
+    // can be large for arrangements and copying it on every slider tick
+    // would dominate even with coalescing.
     PendingDetection& slot = pendingByClip_[clipId];
     slot.sensitivity = sensitivity;
-    slot.clipIdToEngineId = clipIdToEngineId;
+    auto it = clipIdToEngineId.find(clipId);
+    slot.engineId = (it != clipIdToEngineId.end()) ? it->second : std::string{};
     slot.edit = &edit;
 
     coalescingTimer_.callback = [this]() { applyPendingSensitivities(); };
@@ -76,18 +87,17 @@ void WarpMarkerManager::applyPendingSensitivities() {
             dirtyAfterCompletion_[clipId] = det;
             continue;
         }
-        applySensitivityNow(*det.edit, det.clipIdToEngineId, clipId, det.sensitivity);
+        applySensitivityNow(*det.edit, det.engineId, clipId, det.sensitivity);
     }
 }
 
-void WarpMarkerManager::applySensitivityNow(te::Edit& edit,
-                                            const std::map<ClipId, std::string>& clipIdToEngineId,
+void WarpMarkerManager::applySensitivityNow(te::Edit& edit, const std::string& engineId,
                                             ClipId clipId, float sensitivity) {
     const auto* clip = ClipManager::getInstance().getClip(clipId);
     if (!clip || !clip->isAudio() || clip->audio().source.filePath.isEmpty())
         return;
 
-    te::WaveAudioClip* audioClipPtr = findWaveAudioClip(edit, clipIdToEngineId, clipId);
+    te::WaveAudioClip* audioClipPtr = findWaveAudioClipByEngineId(edit, engineId);
     if (!audioClipPtr)
         return;
 
@@ -132,16 +142,39 @@ bool WarpMarkerManager::getTransientTimes(te::Edit& edit,
     // getOrCreateDetectionJob which returns the existing job if one is
     // already in flight for this file+config, so calling it once is safe.
     // We must NOT call it on every poll because it resets transientTimes.
+    //
+    // Mark in-flight here too — without this, a sensitivity change that
+    // arrives during the initial poll-driven detection wouldn't see the
+    // guard and would submit a second overlapping TE job, reproducing
+    // the original ThreadPool crash.
     if (!detectionStarted_.count(clipId)) {
         warpManager.detectTransients();
         detectionStarted_.insert(clipId);
+        detectionInFlight_.insert(clipId);
     }
 
     // Poll for completion
     auto [complete, transientPositions] = warpManager.getTransientTimes();
 
     if (complete) {
-        // Convert TimePosition array to double array
+        // Detection finished — clear the in-flight flag.
+        detectionInFlight_.erase(clipId);
+
+        // If a newer sensitivity arrived while we were running, fire
+        // one more detection with that value. Skip caching the
+        // about-to-be-stale results and report `false` so the UI keeps
+        // polling until the rerun completes.
+        auto dirty = dirtyAfterCompletion_.find(clipId);
+        if (dirty != dirtyAfterCompletion_.end()) {
+            const auto det = std::move(dirty->second);
+            dirtyAfterCompletion_.erase(dirty);
+            if (det.edit != nullptr) {
+                applySensitivityNow(*det.edit, det.engineId, clipId, det.sensitivity);
+                return false;
+            }
+        }
+
+        // No dirt — cache the result and report complete.
         juce::Array<double> times;
         times.ensureStorageAllocated(transientPositions.size());
         for (const auto& tp : transientPositions) {
@@ -151,19 +184,6 @@ bool WarpMarkerManager::getTransientTimes(te::Edit& edit,
         thumbnailManager.cacheTransients(clip->audio().source.filePath, times);
         DBG("WarpMarkerManager: Cached " << times.size() << " transients for "
                                          << clip->audio().source.filePath);
-
-        // Detection finished — clear the in-flight flag and, if a newer
-        // sensitivity arrived while we were running, fire one more
-        // detection with that value. This is the "dirty after completion"
-        // half of the guard set up in setTransientSensitivity.
-        detectionInFlight_.erase(clipId);
-        auto dirty = dirtyAfterCompletion_.find(clipId);
-        if (dirty != dirtyAfterCompletion_.end()) {
-            const auto det = std::move(dirty->second);
-            dirtyAfterCompletion_.erase(dirty);
-            if (det.edit != nullptr)
-                applySensitivityNow(*det.edit, det.clipIdToEngineId, clipId, det.sensitivity);
-        }
         return true;
     }
 

--- a/magda/daw/audio/WarpMarkerManager.hpp
+++ b/magda/daw/audio/WarpMarkerManager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <juce_core/juce_core.h>
+#include <juce_events/juce_events.h>
 #include <tracktion_engine/tracktion_engine.h>
 
 #include <map>
@@ -40,7 +41,7 @@ struct WarpMarkerInfo {
 class WarpMarkerManager {
   public:
     WarpMarkerManager() = default;
-    ~WarpMarkerManager() = default;
+    ~WarpMarkerManager();
 
     /**
      * @brief Detect transient times for an audio clip's source file
@@ -132,6 +133,50 @@ class WarpMarkerManager {
   private:
     // Tracks which clips have had detection kicked off (to avoid restarting on every poll)
     std::set<ClipId> detectionStarted_;
+
+    // -------- Coalescing + in-flight guard for setTransientSensitivity --------
+    //
+    // The UI can spam sensitivity changes (slider drag = many calls/sec).
+    // Each call previously triggered a TE detection job, and overlapping
+    // jobs share `te::WarpTimeManager` state — a worker can dereference
+    // data that a newer job replaced and crash inside the TE thread pool
+    // (KERN_INVALID_ADDRESS at offset 0x10).
+    //
+    // The fix lives here, not in the UI, so any future caller benefits:
+    //   1. setTransientSensitivity records the latest value per clip and
+    //      starts/restarts a short coalescing timer (kCoalesceMs).
+    //   2. When the timer fires, only the most recent sensitivity per
+    //      clip is applied, and a TE job is submitted at most once per
+    //      clip per coalescing window.
+    //   3. If a detection is already in flight for a clip, the new value
+    //      is parked in dirtyAfterCompletion_; getTransientTimes() picks
+    //      it up when it observes completion and schedules the rerun.
+    struct PendingDetection {
+        float sensitivity = 0.0f;
+        std::map<ClipId, std::string> clipIdToEngineId;  // snapshot, callers' map is local
+        te::Edit* edit = nullptr;
+    };
+
+    static constexpr int kCoalesceMs = 75;
+
+    class CoalescingTimer : public juce::Timer {
+      public:
+        std::function<void()> callback;
+        void timerCallback() override {
+            stopTimer();
+            if (callback)
+                callback();
+        }
+    };
+
+    void applyPendingSensitivities();
+    void applySensitivityNow(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
+                             ClipId clipId, float sensitivity);
+
+    std::map<ClipId, PendingDetection> pendingByClip_;
+    std::set<ClipId> detectionInFlight_;
+    std::map<ClipId, PendingDetection> dirtyAfterCompletion_;
+    CoalescingTimer coalescingTimer_;
 };
 
 }  // namespace magda

--- a/magda/daw/audio/WarpMarkerManager.hpp
+++ b/magda/daw/audio/WarpMarkerManager.hpp
@@ -153,7 +153,10 @@ class WarpMarkerManager {
     //      it up when it observes completion and schedules the rerun.
     struct PendingDetection {
         float sensitivity = 0.0f;
-        std::map<ClipId, std::string> clipIdToEngineId;  // snapshot, callers' map is local
+        // Resolved at queue time so the slider hot-path doesn't snapshot the
+        // whole clipIdToEngineId map per tick. Empty engineId means we
+        // couldn't resolve the clip (e.g. it was removed) — apply will skip.
+        std::string engineId;
         te::Edit* edit = nullptr;
     };
 
@@ -170,8 +173,8 @@ class WarpMarkerManager {
     };
 
     void applyPendingSensitivities();
-    void applySensitivityNow(te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId,
-                             ClipId clipId, float sensitivity);
+    void applySensitivityNow(te::Edit& edit, const std::string& engineId, ClipId clipId,
+                             float sensitivity);
 
     std::map<ClipId, PendingDetection> pendingByClip_;
     std::set<ClipId> detectionInFlight_;


### PR DESCRIPTION
Slider-driven sensitivity changes were calling
te::WarpTimeManager::detectTransients() once per UI tick, piling up overlapping TE thread-pool jobs against the same WarpTimeManager. A worker would dereference data a newer job had replaced and crash inside the pool (KERN_INVALID_ADDRESS at offset 0x10).

The fix lives in WarpMarkerManager so any caller benefits, not just the slider:

- setTransientSensitivity now records the latest value per clip and starts a 75 ms coalescing timer instead of submitting a job directly. The UI is free to spam.
- When the timer fires, only the most recent value per clip is applied. If a detection is already in flight for that clip, the new value is parked in dirtyAfterCompletion_; getTransientTimes picks it up on completion and schedules one more detection.

Net effect: at most one detection job per clip per coalescing window, and never two overlapping jobs against the same WarpTimeManager.

Submodule bump is the LFO MIDI-gate patch already merged in the fork.