### PR TITLE
CI/release: bump macOS runner to macos-15 (Apple Clang 16)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,11 @@ concurrency:
 
 jobs:
   build-macos:
-    runs-on: macos-14  # Apple Silicon, can build universal binaries
+    runs-on: macos-15  # Apple Silicon (Xcode 16 / Apple Clang 16+).
+    # macos-14 ships Apple Clang 15, which is missing the C++20 capture-of-
+    # structured-binding support; valid C++20 code that captures `auto& [a, b]`
+    # bindings inside generic lambdas fails to compile there. Binary back-compat
+    # is independently controlled by MACOSX_DEPLOYMENT_TARGET=11.0.
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:


### PR DESCRIPTION
## Summary

macos-14 ships Apple Clang 15, which is missing the C++20 capture-of-structured-binding-in-lambda support that landed in upstream Clang 16. This made the v0.8.0-rc0 release build fail on RackSyncManager.cpp where three `for (auto& [k, v] : ...)` loops use `v` inside a generic lambda body — valid C++20, but not buildable under Apple Clang 15.

Bumping to `macos-15` (Apple Clang 16+) unblocks it without changing the source. `MACOSX_DEPLOYMENT_TARGET=11.0` is set independently, so the shipped binary still runs on macOS 11+.

CI's `build-and-test-macos` runs on the local self-hosted runner (which already has a current toolchain), so only `release.yml` needed the bump.

## Test plan

- [ ] Release workflow on this PR / next tag completes the macOS job
- [ ] Resulting .dmg launches on macOS 11/12/13 (back-compat check, manual)