### PR TITLE
Fix release build on Apple Clang 15: don't capture structured bindings in lambdas

### DIFF
--- a/magda/daw/audio/racks/RackSyncManager.cpp
+++ b/magda/daw/audio/racks/RackSyncManager.cpp
@@ -1413,7 +1413,9 @@ void RackSyncManager::collectLFOModifiersWithModes(TrackId trackId,
         return n;
     };
 
-    for (const auto& [rackId, synced] : syncedRacks_) {
+    for (const auto& entry : syncedRacks_) {
+        const auto& rackId = entry.first;
+        const auto& synced = entry.second;
         if (synced.trackId != trackId)
             continue;
 
@@ -1502,7 +1504,9 @@ void RackSyncManager::collectLFOModifiersWithModesForSidechainSource(
         return false;
     };
 
-    for (const auto& [rackId, synced] : syncedRacks_) {
+    for (const auto& entry : syncedRacks_) {
+        const auto& rackId = entry.first;
+        const auto& synced = entry.second;
         if (synced.trackId != destinationTrackId)
             continue;
 
@@ -1586,7 +1590,9 @@ void RackSyncManager::syncLFOValuesToVisuals() {
             }
         }
     };
-    for (auto& [rackId, synced] : syncedRacks_) {
+    for (auto& entry : syncedRacks_) {
+        const auto& rackId = entry.first;
+        auto& synced = entry.second;
         auto* rackInfo = tm.getRack(synced.trackId, rackId);
         if (!rackInfo)
             continue;


### PR DESCRIPTION
## Summary
- Three loops in `RackSyncManager.cpp` destructured `syncedRacks_` into `[rackId, synced]` and captured `synced` inside a recursive generic lambda. That construct only compiles on Apple Clang 16+; macos-14 (the release runner) and my local dev machine both ship Clang 15, so the v0.8.0 release build failed.
- Replaced the structured bindings with a plain `entry` plus named references, so the lambdas capture real local variables.
- Net diff is 9/-3 in one file. Builds cleanly locally on Apple Clang 15.

Supersedes #1274 (which bumped CI to macos-15 instead of fixing the source).

## Test plan
- [x] `make debug` succeeds on macos-14 / Apple Clang 15
- [ ] Release workflow build-macos job succeeds