### PR TITLE
docs: document faust-mcp-magda in the Faust device manual

### DIFF
--- a/manual/docs/devices/effects.md
+++ b/manual/docs/devices/effects.md
@@ -85,7 +85,7 @@ Parameters live in a stable pool of slots that persist across recompiles, so mac
 
 [`faust-mcp-magda`](https://github.com/Conceptual-Machines/faust-mcp-magda) is an optional companion tool that exposes the Faust compiler and standard library to AI assistants. MAGDA uses it to validate AI-generated Faust code before loading it into this device, so syntax errors and bad library references get caught up front instead of failing at compile time.
 
-Enable it from **Settings > AI Settings**, on the **Config** page, by turning on the **Faust DSP** toggle. When enabled, MAGDA spawns the MCP server in the background via `npx`; no manual install step is needed. `npx` must be available on the system `PATH` (it ships with Node.js).
+Enable it from **Settings > AI Settings**, on the **Config** page, by turning on the **Faust DSP** toggle. When Faust validation is used, MAGDA will start the MCP server on-demand via `npx`; no manual install step is needed. `npx` must be available on the system `PATH` (it ships with Node.js).
 
 The Faust compiler runs in-process via WebAssembly inside the MCP server, so no separate Faust installation is required either.
 

--- a/manual/docs/devices/effects.md
+++ b/manual/docs/devices/effects.md
@@ -80,3 +80,13 @@ Parameters live in a stable pool of slots that persist across recompiles, so mac
 
 !!! warning "Prototype"
     This device is still a prototype. The DSP is run through the **libfaust interpreter** rather than ahead-of-time-compiled native code, so CPU usage is significantly higher than the pre-compiled MAGDA FX bank. Use it for sketching and experimentation; for production work, ask for the patch to be promoted into a compiled device.
+
+### Writing Faust with AI help
+
+[`faust-mcp-magda`](https://github.com/Conceptual-Machines/faust-mcp-magda) is an optional companion tool that exposes the Faust compiler and standard library to AI assistants. MAGDA uses it to validate AI-generated Faust code before loading it into this device, so syntax errors and bad library references get caught up front instead of failing at compile time.
+
+Enable it from **Settings > AI Settings**, on the **Config** page, by turning on the **Faust DSP** toggle. When enabled, MAGDA spawns the MCP server in the background via `npx`; no manual install step is needed. `npx` must be available on the system `PATH` (it ships with Node.js).
+
+The Faust compiler runs in-process via WebAssembly inside the MCP server, so no separate Faust installation is required either.
+
+The server can also be wired into a separate MCP-aware AI assistant (Claude, Cursor, and similar) directly, by adding it to that client's MCP config; see the [project README](https://github.com/Conceptual-Machines/faust-mcp-magda) for details. This is independent of the MAGDA-side toggle.


### PR DESCRIPTION
## Summary

- Adds a "Writing Faust with AI help" subsection to `manual/docs/devices/effects.md`, under the Faust (Custom DSP) device
- Anchors the primary enable path on the in-app **Settings > AI Settings > Config > Faust DSP** toggle (matches the actual UI string at `AISettingsDialog.cpp:835` and the hint at `:842`)
- Keeps the external-AI-assistant route as a secondary pointer to the repo README, not a primary install step

Base is `main` so the published manual picks the section up without waiting for the next release cycle. Same commit also exists on `dev/0.9.0` via #1292; closing that in favour of this one.

## Test plan

- [ ] Build the manual locally (`mkdocs serve` in `manual/`) and visit the Faust device section
- [ ] Verify the new subsection renders, links resolve, and code formatting is intact