### PR TITLE
ci: fall back to windows-latest when RUNNER_STATUS_PAT is unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,6 +375,11 @@ jobs:
           GH_TOKEN: ${{ secrets.RUNNER_STATUS_PAT }}
         run: |
           set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo 'labels=["windows-latest"]' >> "$GITHUB_OUTPUT"
+            echo "No RUNNER_STATUS_PAT available in this context (e.g. Dependabot PRs do not see repo secrets); falling back to windows-latest"
+            exit 0
+          fi
           status=$(gh api "repos/${{ github.repository }}/actions/runners" \
             --jq '.runners[] | select(any(.labels[]; .name == "magda-luca")) | .status' \
             | head -n1)


### PR DESCRIPTION
## Summary

Dependabot PRs (and any other context with restricted secrets) don't see the `RUNNER_STATUS_PAT` repo secret, so `pick-windows-runner` sets `GH_TOKEN` to an empty string. `gh api` then errors with "To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable", `set -euo pipefail` aborts the script before the existing fallback branch can run, and `build-and-test-windows` ends up skipped instead of running on `windows-latest`.

This adds an explicit empty-token check at the top of the step. If `GH_TOKEN` is empty, take the `windows-latest` fallback path the script already had for "self-hosted offline".

Reproduces on #1278 (Dependabot llama.cpp bump): the failing `pick-windows-runner` log shows `Secret source: Dependabot` and `GH_TOKEN: ` (blank).

## Test plan

- [ ] Re-run #1278 against this change once merged; `pick-windows-runner` should succeed and `build-and-test-windows` should run on `windows-latest`
- [ ] Confirm a regular (non-Dependabot) PR still picks the self-hosted runner when `magda-luca` is online