### PR TITLE
Fix arrangement MIDI previews and clip modifier clicks

### DIFF
--- a/magda/daw/core/ClipCommands.cpp
+++ b/magda/daw/core/ClipCommands.cpp
@@ -724,6 +724,7 @@ void JoinClipsCommand::restoreState(const JoinClipsState& state) {
     }
 
     clipManager.forceNotifyClipsChanged();
+    clipManager.forceNotifyClipPropertyChanged(leftClipId_);
 }
 
 void JoinClipsCommand::performAction() {
@@ -734,29 +735,64 @@ void JoinClipsCommand::performAction() {
     if (!left || !right)
         return;
 
-    if (left->isMidi()) {
-        // MIDI join: copy right clip's notes into left, adjusting beat positions
-        const double bpm = resolveTimelineBpm(tempo_);
-        double beatOffset = right->getStartBeats(bpm) - left->getStartBeats(bpm);
+    const double bpm = resolveTimelineBpm(tempo_);
+    const double newEndBeats = right->getEndBeats(bpm);
+    const double leftStartBeats = left->getStartBeats(bpm);
+    const double joinedLengthBeats = newEndBeats - leftStartBeats;
 
-        for (const auto& note : right->midiNotes) {
+    if (left->isMidi()) {
+        // MIDI join behaves like a consolidation pass: render each clip's visible MIDI into
+        // plain local clip coordinates, then append the right clip at its timeline offset.
+        double beatOffset = right->getStartBeats(bpm) - leftStartBeats;
+        ClipInfo flattenedLeft = *left;
+        ClipInfo flattenedRight = *right;
+        ClipOperations::flattenMidiClip(flattenedLeft);
+        ClipOperations::flattenMidiClip(flattenedRight);
+
+        left->midiNotes = std::move(flattenedLeft.midiNotes);
+        left->midiCCData = std::move(flattenedLeft.midiCCData);
+        left->midiPitchBendData = std::move(flattenedLeft.midiPitchBendData);
+
+        for (const auto& note : flattenedRight.midiNotes) {
             MidiNote adjustedNote = note;
             adjustedNote.startBeat += beatOffset;
             left->midiNotes.push_back(adjustedNote);
         }
+
+        for (const auto& cc : flattenedRight.midiCCData) {
+            MidiCCData adjustedCC = cc;
+            adjustedCC.beatPosition += beatOffset;
+            left->midiCCData.push_back(adjustedCC);
+        }
+
+        for (const auto& pitchBend : flattenedRight.midiPitchBendData) {
+            MidiPitchBendData adjustedPitchBend = pitchBend;
+            adjustedPitchBend.beatPosition += beatOffset;
+            left->midiPitchBendData.push_back(adjustedPitchBend);
+        }
+
+        left->loopEnabled = false;
+        left->loopStart = 0.0;
+        left->loopStartBeats = 0.0;
+        left->loopLength = 0.0;
+        left->loopLengthBeats = 0.0;
+        left->midiOffset = 0.0;
+        left->midiTrimOffset = 0.0;
     } else if (left->isAudio()) {
         // Audio join: extend left clip length to cover both clips
         // (offset and speedRatio remain from left clip)
     }
 
     // Extend left clip length
-    const double bpm = resolveTimelineBpm(tempo_);
-    const double newEndBeats = right->getEndBeats(bpm);
-    left->setPlacementBeats(left->getStartBeats(bpm), newEndBeats - left->getStartBeats(bpm));
+    left->setPlacementBeats(leftStartBeats, joinedLengthBeats);
     left->deriveTimesFromBeats(bpm);
 
     // Delete right clip
     clipManager.deleteClip(rightClipId_);
+
+    // The left clip is mutated in place. Deleting the right clip only emits a structural
+    // notification, whose sync planner does not resync already-mapped TE clips.
+    clipManager.forceNotifyClipPropertyChanged(leftClipId_);
 }
 
 bool JoinClipsCommand::validateState() const {

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -237,7 +237,7 @@ void ClipComponent::timerCallback() {
     if (mouseIsOver_) {
         const auto mods = juce::ModifierKeys::currentModifiers;
         updateCursor(mods.isAltDown(), mods.isShiftDown(),
-                     mods.isCommandDown() || mods.isCtrlDown());
+                     mods.isShiftDown() && (mods.isCommandDown() || mods.isCtrlDown()));
         startTimer(50);
     } else {
         stopTimer();
@@ -1010,8 +1010,8 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
 
     // Frozen tracks: allow selection (so piano roll shows content) but block editing
     if (isFrozen && !e.mods.isPopupMenu()) {
-        // Still allow click-to-select and Cmd+click toggle
-        if (e.mods.isCommandDown()) {
+        // Still allow click-to-select and modifier-click toggle
+        if (e.mods.isCommandDown() || e.mods.isCtrlDown()) {
             selectionManager.toggleClipSelection(clipId_);
         } else {
             selectionManager.selectClip(clipId_);
@@ -1023,9 +1023,13 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
         return;
     }
 
-    // Cmd/Ctrl-click acts as an eraser for the clip under the cursor. If the
+    const bool isSelectionModifierDown = e.mods.isCommandDown() || e.mods.isCtrlDown();
+    const bool isEraseClick =
+        e.mods.isLeftButtonDown() && e.mods.isShiftDown() && isSelectionModifierDown;
+
+    // Shift+Cmd/Ctrl-click acts as an eraser for the clip under the cursor. If the
     // clicked clip is part of a multi-selection, erase the selected group.
-    if (e.mods.isLeftButtonDown() && (e.mods.isCommandDown() || e.mods.isCtrlDown())) {
+    if (isEraseClick) {
         std::vector<ClipId> clipIds;
         const auto& selected = selectionManager.getSelectedClips();
         if (selected.count(clipId_) && selected.size() > 1) {
@@ -1048,6 +1052,22 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
 
             SelectionManager::getInstance().clearSelection();
         });
+        return;
+    }
+
+    // Cmd/Ctrl-click toggles clip selection without starting a drag.
+    if (e.mods.isLeftButtonDown() && isSelectionModifierDown) {
+        selectionManager.toggleClipSelection(clipId_);
+        isSelected_ = selectionManager.isClipSelected(clipId_);
+
+        if (isSelected_) {
+            ensureEditorOpen(clipId_);
+            if (onClipSelected)
+                onClipSelected(clipId_);
+        }
+
+        dragMode_ = DragMode::None;
+        repaint();
         return;
     }
 
@@ -2199,7 +2219,7 @@ void ClipComponent::mouseMove(const juce::MouseEvent& e) {
 
     // Always update cursor to check modifier-driven tools.
     updateCursor(e.mods.isAltDown(), e.mods.isShiftDown(),
-                 e.mods.isCommandDown() || e.mods.isCtrlDown());
+                 e.mods.isShiftDown() && (e.mods.isCommandDown() || e.mods.isCtrlDown()));
 
     if (hoverLeftEdge_ != wasHoverLeft || hoverRightEdge_ != wasHoverRight ||
         hoverFadeIn_ != wasHoverFadeIn || hoverFadeOut_ != wasHoverFadeOut ||
@@ -2212,7 +2232,7 @@ void ClipComponent::mouseEnter(const juce::MouseEvent& e) {
     mouseIsOver_ = true;
     startTimer(50);
     updateCursor(e.mods.isAltDown(), e.mods.isShiftDown(),
-                 e.mods.isCommandDown() || e.mods.isCtrlDown());
+                 e.mods.isShiftDown() && (e.mods.isCommandDown() || e.mods.isCtrlDown()));
 }
 
 void ClipComponent::mouseExit(const juce::MouseEvent& /*e*/) {

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -42,6 +42,9 @@ double timelineEndSeconds(const ClipInfo& clip, double bpm) {
     return clip.getTimelineEnd(bpm);
 }
 
+constexpr int MIDI_PREVIEW_MIN_NOTE = 21;   // A0
+constexpr int MIDI_PREVIEW_MAX_NOTE = 108;  // C8
+
 }  // namespace
 
 static float computeFadeGain(float alpha, FadeCurve curve) {
@@ -236,8 +239,7 @@ size_t ClipComponent::computeWaveformHash(const ClipInfo& clip) {
 void ClipComponent::timerCallback() {
     if (mouseIsOver_) {
         const auto mods = juce::ModifierKeys::currentModifiers;
-        updateCursor(mods.isAltDown(), mods.isShiftDown(),
-                     mods.isShiftDown() && (mods.isCommandDown() || mods.isCtrlDown()));
+        updateCursor(mods.isAltDown(), mods.isShiftDown(), mods.isShiftDown() && mods.isCtrlDown());
         startTimer(50);
     } else {
         stopTimer();
@@ -602,24 +604,20 @@ void ClipComponent::paintMidiNotes(juce::Graphics& g, const ClipInfo& clip,
         return displayEnd > 0.0 && displayStart < clipLengthInBeats;
     };
 
-    int minNote = 127, maxNote = 0;
     bool hasVisibleNote = false;
     for (const auto& note : clip.midiNotes) {
         if (!noteCanDisplay(note))
             continue;
 
-        minNote = juce::jmin(minNote, note.noteNumber);
-        maxNote = juce::jmax(maxNote, note.noteNumber);
         hasVisibleNote = true;
+        break;
     }
 
     if (!hasVisibleNote)
         return;
 
-    int rawRange = maxNote - minNote;
-    int padding = juce::jmax(6, rawRange / 4);
-    minNote = juce::jmax(0, minNote - padding);
-    maxNote = juce::jmin(127, maxNote + padding);
+    constexpr int minNote = MIDI_PREVIEW_MIN_NOTE;
+    constexpr int maxNote = MIDI_PREVIEW_MAX_NOTE;
     int noteRange = juce::jmax(12, maxNote - minNote);
     double beatRange = juce::jmax(1.0, clipLengthInBeats);
 
@@ -1008,10 +1006,14 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
         }
     };
 
+    const bool isSelectionModifierDown = e.mods.isCommandDown();
+    const bool isModifiedSelectionClick = isSelectionModifierDown && !e.mods.isShiftDown();
+    const bool isEraseClick = e.mods.isShiftDown() && e.mods.isCtrlDown();
+
     // Frozen tracks: allow selection (so piano roll shows content) but block editing
-    if (isFrozen && !e.mods.isPopupMenu()) {
+    if (isFrozen && (!e.mods.isPopupMenu() || isModifiedSelectionClick)) {
         // Still allow click-to-select and modifier-click toggle
-        if (e.mods.isCommandDown() || e.mods.isCtrlDown()) {
+        if (isModifiedSelectionClick) {
             selectionManager.toggleClipSelection(clipId_);
         } else {
             selectionManager.selectClip(clipId_);
@@ -1023,11 +1025,7 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
         return;
     }
 
-    const bool isSelectionModifierDown = e.mods.isCommandDown() || e.mods.isCtrlDown();
-    const bool isEraseClick =
-        e.mods.isLeftButtonDown() && e.mods.isShiftDown() && isSelectionModifierDown;
-
-    // Shift+Cmd/Ctrl-click acts as an eraser for the clip under the cursor. If the
+    // Shift+Ctrl-click acts as an eraser for the clip under the cursor. If the
     // clicked clip is part of a multi-selection, erase the selected group.
     if (isEraseClick) {
         std::vector<ClipId> clipIds;
@@ -1055,15 +1053,13 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
         return;
     }
 
-    // Cmd/Ctrl-click toggles clip selection without starting a drag.
-    if (e.mods.isLeftButtonDown() && isSelectionModifierDown) {
+    // Cmd-click toggles clip selection without starting a drag.
+    if (isModifiedSelectionClick) {
         selectionManager.toggleClipSelection(clipId_);
         isSelected_ = selectionManager.isClipSelected(clipId_);
 
         if (isSelected_) {
             ensureEditorOpen(clipId_);
-            if (onClipSelected)
-                onClipSelected(clipId_);
         }
 
         dragMode_ = DragMode::None;
@@ -1765,7 +1761,7 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
 
 void ClipComponent::mouseUp(const juce::MouseEvent& e) {
     // Handle right-click for context menu
-    if (e.mods.isPopupMenu()) {
+    if (e.mods.isPopupMenu() && !(e.mods.isShiftDown() && e.mods.isCtrlDown())) {
         showContextMenu();
         return;
     }
@@ -2219,7 +2215,7 @@ void ClipComponent::mouseMove(const juce::MouseEvent& e) {
 
     // Always update cursor to check modifier-driven tools.
     updateCursor(e.mods.isAltDown(), e.mods.isShiftDown(),
-                 e.mods.isShiftDown() && (e.mods.isCommandDown() || e.mods.isCtrlDown()));
+                 e.mods.isShiftDown() && e.mods.isCtrlDown());
 
     if (hoverLeftEdge_ != wasHoverLeft || hoverRightEdge_ != wasHoverRight ||
         hoverFadeIn_ != wasHoverFadeIn || hoverFadeOut_ != wasHoverFadeOut ||
@@ -2232,7 +2228,7 @@ void ClipComponent::mouseEnter(const juce::MouseEvent& e) {
     mouseIsOver_ = true;
     startTimer(50);
     updateCursor(e.mods.isAltDown(), e.mods.isShiftDown(),
-                 e.mods.isShiftDown() && (e.mods.isCommandDown() || e.mods.isCtrlDown()));
+                 e.mods.isShiftDown() && e.mods.isCtrlDown());
 }
 
 void ClipComponent::mouseExit(const juce::MouseEvent& /*e*/) {

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -1022,8 +1022,8 @@ void TrackContentPanel::mouseDown(const juce::MouseEvent& event) {
             }
         }
         if (!onClip) {
-            // Clicked empty space in upper zone - deselect clips (unless Cmd held)
-            if (!event.mods.isCommandDown()) {
+            // Clicked empty space in upper zone - deselect clips unless multi-select modifier held.
+            if (!event.mods.isCommandDown() && !event.mods.isCtrlDown()) {
                 SelectionManager::getInstance().clearSelection();
             }
         }

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -952,10 +952,6 @@ void TrackContentPanel::mouseDown(const juce::MouseEvent& event) {
     // Grab keyboard focus so we can receive key events (like 'B' for blade)
     grabKeyboardFocus();
 
-    // Right-click is handled in mouseUp (context menu); don't start drag/selection
-    if (event.mods.isPopupMenu())
-        return;
-
     // Store initial mouse position for click vs drag detection
     mouseDownX = event.x;
     mouseDownY = event.y;
@@ -966,6 +962,72 @@ void TrackContentPanel::mouseDown(const juce::MouseEvent& event) {
 
     // Reset drag type
     currentDragType_ = DragType::None;
+
+    if (event.mods.isShiftDown() && event.mods.isCtrlDown()) {
+        if (auto* clipComp = getClipComponentAt(event.x, event.y)) {
+            isCreatingSelection = false;
+            isMovingSelection = false;
+            isDrawingClip_ = false;
+
+            std::vector<ClipId> clipIds;
+            const auto clipId = clipComp->getClipId();
+            auto& selectionManager = SelectionManager::getInstance();
+            const auto& selected = selectionManager.getSelectedClips();
+            if (selected.count(clipId) && selected.size() > 1) {
+                clipIds.assign(selected.begin(), selected.end());
+            } else {
+                clipIds.push_back(clipId);
+            }
+
+            juce::MessageManager::callAsync([clipIds = std::move(clipIds)]() {
+                if (clipIds.size() > 1)
+                    UndoManager::getInstance().beginCompoundOperation("Delete Clips");
+
+                for (auto id : clipIds) {
+                    UndoManager::getInstance().executeCommand(
+                        std::make_unique<DeleteClipCommand>(id));
+                }
+
+                if (clipIds.size() > 1)
+                    UndoManager::getInstance().endCompoundOperation();
+
+                SelectionManager::getInstance().clearSelection();
+            });
+            return;
+        }
+    }
+
+    const bool isModifiedSelectionClick = event.mods.isCommandDown() && !event.mods.isShiftDown();
+    if (isModifiedSelectionClick) {
+        if (auto* clipComp = getClipComponentAt(event.x, event.y)) {
+            isCreatingSelection = false;
+            isMovingSelection = false;
+            isDrawingClip_ = false;
+
+            const auto clipId = clipComp->getClipId();
+            auto& selectionManager = SelectionManager::getInstance();
+            selectionManager.toggleClipSelection(clipId);
+            clipComp->setSelected(selectionManager.isClipSelected(clipId));
+
+            if (selectionManager.isClipSelected(clipId)) {
+                const auto* clip = ClipManager::getInstance().getClip(clipId);
+                if (clip) {
+                    auto& panelController = daw::ui::PanelController::getInstance();
+                    panelController.setCollapsed(daw::ui::PanelLocation::Bottom, false);
+                    if (clip->isAudio()) {
+                        panelController.setActiveTabByType(
+                            daw::ui::PanelLocation::Bottom,
+                            daw::ui::PanelContentType::WaveformEditor);
+                    }
+                }
+            }
+            return;
+        }
+    }
+
+    // Right-click is handled in mouseUp (context menu); don't start drag/selection
+    if (event.mods.isPopupMenu())
+        return;
 
     // Zone-based behavior:
     // Upper half of track = clip operations

--- a/manual/docs/arrangement-view.md
+++ b/manual/docs/arrangement-view.md
@@ -43,8 +43,9 @@ The corner toolbar provides quick access to:
 
 - **Move** — Click and drag a clip along the timeline or between tracks
 - **Resize** — Drag the edges of a clip to trim it
-- **Select** — Click a clip to select it; ++ctrl+a++ (++cmd+a++) to select all
+- **Select** — Click a clip to select it; ++cmd++-click (++ctrl++-click on Windows/Linux) to toggle clips in the selection; ++ctrl+a++ (++cmd+a++) to select all
 - **Delete** — Select a clip and press ++delete++ or ++backspace++
+- **Erase** — ++shift+ctrl++-click a clip to delete it directly without selecting first
 - **Duplicate** — ++ctrl+d++ (++cmd+d++) to duplicate selected clips
 
 Drag audio files from the [Media Explorer](panels/browsers.md) directly onto a track to import them as clips.

--- a/manual/docs/clips.md
+++ b/manual/docs/clips.md
@@ -80,7 +80,7 @@ Follow actions chain session clips together for generative arrangement. Once the
 ## Selecting Clips
 
 - **Click** a clip to select it
-- **Shift+click** to add or remove clips from the selection
+- ++cmd++ **+ click** (++ctrl++ **+ click** on Windows/Linux) to add or remove clips from the selection
 - ++cmd+a++ (++ctrl+a++ on Windows/Linux) selects all clips in the arrangement, or all notes when a MIDI editor is focused
 
 ## Editing Clips
@@ -90,7 +90,7 @@ Follow actions chain session clips together for generative arrangement. Once the
 - **Duplicate** — Hold ++alt++ and drag a clip, or press ++cmd+d++
 - **Split** — Position the playhead and use **Edit > Split Clip** or press ++cmd+e++
 - **Delete** — Select the clip and press ++delete++ or ++backspace++
-- **Erase under cursor** — ++cmd++ **+ click** a clip to delete it directly without selecting first. If the clip is part of a multi-selection, the whole group is erased. Acts as a rubber tool.
+- **Erase under cursor** — ++shift+ctrl++ **+ click** a clip to delete it directly without selecting first. If the clip is part of a multi-selection, the whole group is erased. Acts as a rubber tool.
 
 ## Cut, Copy, and Paste
 

--- a/manual/docs/reference/keyboard-shortcuts.md
+++ b/manual/docs/reference/keyboard-shortcuts.md
@@ -26,6 +26,13 @@
 | ++ctrl+b++ / ++cmd+b++ | Render clip to audio |
 | ++ctrl+shift+b++ / ++cmd+shift+b++ | Render time selection |
 
+## Mouse Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| ++cmd++ + click (++ctrl++ + click on Windows/Linux) | Toggle arrangement clip selection |
+| ++shift+ctrl++ + click | Erase arrangement clip under cursor |
+
 ## Tracks
 
 | Shortcut | Action |

--- a/tests/test_clip_commands.cpp
+++ b/tests/test_clip_commands.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <unordered_set>
@@ -61,6 +62,24 @@ static BeatPosition secondsToBeatPosition(double seconds, double bpm = 120.0) {
 static BeatDuration secondsToBeatDuration(double seconds, double bpm = 120.0) {
     return BeatDuration{seconds * bpm / 60.0};
 }
+
+struct RecordingClipListener : ClipManagerListener {
+    int clipsChangedCount = 0;
+    std::vector<ClipId> propertyChangedClipIds;
+
+    void clipsChanged() override {
+        ++clipsChangedCount;
+    }
+
+    void clipPropertyChanged(ClipId clipId) override {
+        propertyChangedClipIds.push_back(clipId);
+    }
+
+    bool sawPropertyChangeFor(ClipId clipId) const {
+        return std::find(propertyChangedClipIds.begin(), propertyChangedClipIds.end(), clipId) !=
+               propertyChangedClipIds.end();
+    }
+};
 
 // ============================================================================
 // DuplicateClipCommand
@@ -476,6 +495,51 @@ TEST_CASE("JoinClipsCommand - basic MIDI join", "[clip][command][join]") {
         REQUIRE(joined->midiNotes[1].startBeat == Catch::Approx(2.0));
         REQUIRE(joined->midiNotes[2].startBeat == Catch::Approx(4.0));
         REQUIRE(joined->midiNotes[3].startBeat == Catch::Approx(5.0));
+    }
+
+    SECTION("Join looped MIDI clips flattens the joined result") {
+        ClipId left = createMidi(track, 0.0, 2.0, {0.0});
+        ClipId right = createMidi(track, 2.0, 2.0, {0.0});
+
+        auto& cm = ClipManager::getInstance();
+        auto* leftClip = cm.getClip(left);
+        REQUIRE(leftClip != nullptr);
+        leftClip->loopEnabled = true;
+        leftClip->loopLengthBeats = leftClip->placement.lengthBeats;
+        leftClip->loopLength = leftClip->getTimelineLength(120.0);
+
+        JoinClipsCommand cmd(left, right);
+        REQUIRE(cmd.canExecute());
+        cmd.execute();
+
+        auto* joined = cm.getClip(left);
+        REQUIRE(joined != nullptr);
+        REQUIRE(joined->lengthBeats == Catch::Approx(8.0));
+        REQUIRE_FALSE(joined->loopEnabled);
+        REQUIRE(joined->loopLengthBeats == Catch::Approx(0.0));
+        REQUIRE(joined->loopLength == Catch::Approx(0.0));
+        REQUIRE(joined->midiOffset == Catch::Approx(0.0));
+        REQUIRE(joined->midiTrimOffset == Catch::Approx(0.0));
+        REQUIRE(joined->midiNotes.size() == 2);
+        REQUIRE(joined->midiNotes[0].startBeat == Catch::Approx(0.0));
+        REQUIRE(joined->midiNotes[1].startBeat == Catch::Approx(4.0));
+    }
+
+    SECTION("Join notifies that the left MIDI clip changed") {
+        ClipId left = createMidi(track, 0.0, 2.0, {0.0});
+        ClipId right = createMidi(track, 2.0, 2.0, {0.0});
+
+        RecordingClipListener listener;
+        ClipManager::getInstance().addListener(&listener);
+
+        JoinClipsCommand cmd(left, right);
+        REQUIRE(cmd.canExecute());
+        cmd.execute();
+
+        ClipManager::getInstance().removeListener(&listener);
+
+        REQUIRE(listener.clipsChangedCount > 0);
+        REQUIRE(listener.sawPropertyChangeFor(left));
     }
 
     SECTION("Join three clips sequentially") {


### PR DESCRIPTION
## Summary
- Use a fixed A0-C8 pitch grid for arrangement MIDI previews so notes never jump when nearby clip contents or selection state changes.
- Restore arrangement clip modifier behavior: Cmd-click toggles selection on macOS, Ctrl-click toggles selection on Windows/Linux, and Shift+Ctrl-click uses the eraser/delete action.
- Handle modifier clicks in both the clip component and track panel so clicks on the full arrangement clip area behave consistently.
- Update the manual shortcut docs to match the final arrangement clip behavior.

## Verification
- `cmake --build cmake-build-debug --target magda_daw_app`