### PR TITLE
Fall back for empty localized strings

### DIFF
--- a/magda/daw/core/StringTable.cpp
+++ b/magda/daw/core/StringTable.cpp
@@ -105,9 +105,9 @@ void StringTable::parseObject(const juce::var& obj, const juce::String& prefix,
 
 juce::String StringTable::get(const juce::String& key) const {
     // Prefer the active locale, then fall back to English, then finally to the
-    // key itself. That way missing translations stay readable as English rather
-    // than surfacing the raw dotted key to users.
-    if (auto it = localized_.find(key); it != localized_.end())
+    // key itself. Empty locale values are treated as untranslated placeholders,
+    // so partially translated files stay readable instead of rendering blanks.
+    if (auto it = localized_.find(key); it != localized_.end() && it->second.isNotEmpty())
         return it->second;
     if (auto it = english_.find(key); it != english_.end())
         return it->second;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ set(TEST_SOURCES
     test_dsl_add_arpeggio.cpp
     test_scale_detection.cpp
     test_step_clock.cpp
+    test_string_table.cpp
     test_mono_note_processor.cpp
     test_sends_and_track_deletion.cpp
     test_master_track_serialization.cpp

--- a/tests/test_string_table.cpp
+++ b/tests/test_string_table.cpp
@@ -1,0 +1,14 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/core/StringTable.hpp"
+
+TEST_CASE("StringTable falls back to English for empty localized placeholders",
+          "[localization][string-table]") {
+    auto& strings = magda::StringTable::getInstance();
+
+    REQUIRE(strings.loadLanguage("ja"));
+    CHECK(strings.get("preferences.language.label") == "UI Language");
+    CHECK(strings.get("dialogs.error.export_no_edit") == "Cannot export: no Edit loaded");
+
+    REQUIRE(strings.loadLanguage("en"));
+}

--- a/tests/test_string_table.cpp
+++ b/tests/test_string_table.cpp
@@ -2,13 +2,33 @@
 
 #include "magda/daw/core/StringTable.hpp"
 
+namespace {
+
+struct StringTableLanguageGuard {
+    explicit StringTableLanguageGuard(magda::StringTable& table)
+        : strings(table), previousLanguage(table.getLanguage()) {}
+
+    ~StringTableLanguageGuard() {
+        if (previousLanguage.isNotEmpty())
+            strings.loadLanguage(previousLanguage);
+    }
+
+    magda::StringTable& strings;
+    juce::String previousLanguage;
+};
+
+}  // namespace
+
 TEST_CASE("StringTable falls back to English for empty localized placeholders",
           "[localization][string-table]") {
     auto& strings = magda::StringTable::getInstance();
-
-    REQUIRE(strings.loadLanguage("ja"));
-    CHECK(strings.get("preferences.language.label") == "UI Language");
-    CHECK(strings.get("dialogs.error.export_no_edit") == "Cannot export: no Edit loaded");
+    StringTableLanguageGuard languageGuard(strings);
 
     REQUIRE(strings.loadLanguage("en"));
+    const auto languageLabel = strings.get("preferences.language.label");
+    const auto exportNoEditMessage = strings.get("dialogs.error.export_no_edit");
+
+    REQUIRE(strings.loadLanguage("ja"));
+    CHECK(strings.get("preferences.language.label") == languageLabel);
+    CHECK(strings.get("dialogs.error.export_no_edit") == exportNoEditMessage);
 }


### PR DESCRIPTION
## Summary

Fixes blank UI labels when a translation file contains an empty string placeholder for a key.

The Japanese translation currently has several keys present with empty values. StringTable::get() treated those as valid localized strings, so labels in Preferences, Controllers, and Plugin Settings rendered as blank instead of falling back to English.

This changes lookup behavior so empty localized values are treated as untranslated placeholders and fall back to English, matching the behavior for missing keys.

## Validation

- cmake --build cmake-build-debug --target magda_tests
- ./cmake-build-debug/tests/magda_tests "StringTable*"
- cmake --build cmake-build-debug --target magda_daw_app

Note: the local working tree still shows a third_party/llama.cpp submodule checkout mismatch after switching between dev/0.9.0 and main; it is not part of this PR.