### PR TITLE
fix: media browser drag-and-drop on Linux/Wayland

### DIFF
--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -2758,6 +2758,23 @@ bool TrackContentPanel::isInterestedInFileDrag(const juce::StringArray& files) {
 }
 
 void TrackContentPanel::fileDragEnter(const juce::StringArray& files, int x, int y) {
+    beginFilesDropFeedback(files, x, y);
+}
+
+void TrackContentPanel::fileDragMove(const juce::StringArray& /*files*/, int x, int y) {
+    updateFilesDropFeedback(x, y);
+}
+
+void TrackContentPanel::fileDragExit(const juce::StringArray& /*files*/) {
+    endFilesDropFeedback();
+}
+
+void TrackContentPanel::filesDropped(const juce::StringArray& files, int x, int y) {
+    endFilesDropFeedback();
+    importFilesAtPosition(files, x, y);
+}
+
+void TrackContentPanel::beginFilesDropFeedback(const juce::StringArray& files, int x, int y) {
     dropInsertTime_ = juce::jmax(0.0, pixelToTime(x));
     if (snapTimeToGrid) {
         dropInsertTime_ = snapTimeToGrid(dropInsertTime_);
@@ -2801,7 +2818,7 @@ void TrackContentPanel::fileDragEnter(const juce::StringArray& files, int x, int
     repaintVisible();
 }
 
-void TrackContentPanel::fileDragMove(const juce::StringArray& /*files*/, int x, int y) {
+void TrackContentPanel::updateFilesDropFeedback(int x, int y) {
     dropInsertTime_ = juce::jmax(0.0, pixelToTime(x));
     if (snapTimeToGrid) {
         dropInsertTime_ = snapTimeToGrid(dropInsertTime_);
@@ -2809,7 +2826,6 @@ void TrackContentPanel::fileDragMove(const juce::StringArray& /*files*/, int x, 
     const int prevTarget = dropTargetTrackIndex_;
     dropTargetTrackIndex_ = getTrackIndexAtY(y);
 
-    // Update ghost headers when we cross the empty-area / existing-track boundary.
     if (onGhostHeadersChanged && (prevTarget < 0) != (dropTargetTrackIndex_ < 0)) {
         juce::StringArray labels;
         if (dropTargetTrackIndex_ < 0) {
@@ -2822,7 +2838,7 @@ void TrackContentPanel::fileDragMove(const juce::StringArray& /*files*/, int x, 
     repaintVisible();
 }
 
-void TrackContentPanel::fileDragExit(const juce::StringArray& /*files*/) {
+void TrackContentPanel::endFilesDropFeedback() {
     showDropIndicator_ = false;
     draggedAudioFiles_.clear();
     draggedAudioDurations_.clear();
@@ -2831,14 +2847,20 @@ void TrackContentPanel::fileDragExit(const juce::StringArray& /*files*/) {
     repaintVisible();
 }
 
-void TrackContentPanel::filesDropped(const juce::StringArray& files, int x, int y) {
-    showDropIndicator_ = false;
-    draggedAudioFiles_.clear();
-    draggedAudioDurations_.clear();
-    if (onGhostHeadersChanged)
-        onGhostHeadersChanged({});
-    repaintVisible();
+juce::StringArray TrackContentPanel::extractFilePathsFromDescription(const juce::var& description) {
+    juce::StringArray paths;
+    if (auto* obj = description.getDynamicObject()) {
+        if (obj->getProperty("type").toString() == "files") {
+            if (auto* arr = obj->getProperty("paths").getArray()) {
+                for (const auto& v : *arr)
+                    paths.add(v.toString());
+            }
+        }
+    }
+    return paths;
+}
 
+void TrackContentPanel::importFilesAtPosition(const juce::StringArray& files, int x, int y) {
     // Determine drop position (clamp to timeline start, snap if enabled)
     double dropTime = juce::jmax(0.0, pixelToTime(x));
     if (snapTimeToGrid) {
@@ -3137,36 +3159,75 @@ void TrackContentPanel::filesDropped(const juce::StringArray& files, int x, int 
 }
 
 // =============================================================================
-// Plugin Drag-and-Drop Implementation (DragAndDropTarget)
+// Internal Drag-and-Drop Implementation (DragAndDropTarget)
+//
+// Two payload types are accepted via details.description (a DynamicObject):
+//   type="plugin": dropped from the plugin browser → create track with device
+//   type="files", paths=[...]: dropped from the in-app media browser →
+//       same import flow as the OS file-drop path. This route exists because
+//       JUCE's external file DnD does not work on Linux/Wayland.
 // =============================================================================
 
+namespace {
+juce::String dragType(const juce::DragAndDropTarget::SourceDetails& details) {
+    if (auto* obj = details.description.getDynamicObject())
+        return obj->getProperty("type").toString();
+    return {};
+}
+}  // namespace
+
 bool TrackContentPanel::isInterestedInDragSource(const SourceDetails& details) {
-    if (auto* obj = details.description.getDynamicObject()) {
-        return obj->getProperty("type").toString() == "plugin";
-    }
+    const auto type = dragType(details);
+    if (type == "plugin")
+        return true;
+    if (type == "files")
+        return isInterestedInFileDrag(extractFilePathsFromDescription(details.description));
     return false;
 }
 
 void TrackContentPanel::itemDragEnter(const SourceDetails& details) {
+    if (dragType(details) == "files") {
+        beginFilesDropFeedback(extractFilePathsFromDescription(details.description),
+                               details.localPosition.x, details.localPosition.y);
+        return;
+    }
+
     showPluginDropOverlay_ = true;
     pluginDropTrackIndex_ = getTrackIndexAtY(details.localPosition.y);
     repaintVisible();
 }
 
 void TrackContentPanel::itemDragMove(const SourceDetails& details) {
+    if (dragType(details) == "files") {
+        updateFilesDropFeedback(details.localPosition.x, details.localPosition.y);
+        return;
+    }
+
     int prev = pluginDropTrackIndex_;
     pluginDropTrackIndex_ = getTrackIndexAtY(details.localPosition.y);
     if (pluginDropTrackIndex_ != prev)
         repaintVisible();
 }
 
-void TrackContentPanel::itemDragExit(const SourceDetails& /*details*/) {
+void TrackContentPanel::itemDragExit(const SourceDetails& details) {
+    if (dragType(details) == "files") {
+        endFilesDropFeedback();
+        return;
+    }
+
     showPluginDropOverlay_ = false;
     pluginDropTrackIndex_ = -1;
     repaintVisible();
 }
 
 void TrackContentPanel::itemDropped(const SourceDetails& details) {
+    if (dragType(details) == "files") {
+        endFilesDropFeedback();
+        importFilesAtPosition(extractFilePathsFromDescription(details.description),
+                              details.localPosition.x, details.localPosition.y);
+        return;
+    }
+
     showPluginDropOverlay_ = false;
     pluginDropTrackIndex_ = -1;
     repaintVisible();

--- a/magda/daw/ui/components/tracks/TrackContentPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.hpp
@@ -425,6 +425,16 @@ class TrackContentPanel : public juce::Component,
     juce::StringArray draggedAudioFiles_;        // Audio files currently being dragged over
     std::vector<double> draggedAudioDurations_;  // Parallel to draggedAudioFiles_
 
+    // Drop-feedback / import helpers shared by the OS file-drop path
+    // (FileDragAndDropTarget) and the in-app drop path (DragAndDropTarget with
+    // {type:"files", paths:[...]}). The in-app path exists because JUCE's
+    // OS-level DnD does not work on Linux/Wayland.
+    void beginFilesDropFeedback(const juce::StringArray& files, int x, int y);
+    void updateFilesDropFeedback(int x, int y);
+    void endFilesDropFeedback();
+    void importFilesAtPosition(const juce::StringArray& files, int x, int y);
+    static juce::StringArray extractFilePathsFromDescription(const juce::var& description);
+
     // Group track extent cache — avoids walking all descendants every paint
     struct GroupExtent {
         double earliest = 0.0;

--- a/magda/daw/ui/panels/content/MediaExplorerContent.cpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.cpp
@@ -1348,6 +1348,9 @@ void MediaExplorerContent::mouseDrag(const juce::MouseEvent& e) {
         auto* obj = new juce::DynamicObject();
         obj->setProperty("type", juce::var("files"));
         obj->setProperty("paths", juce::var(pathArray));
+        // Wrap immediately so the DynamicObject is owned via ref-counting and
+        // cleans up if findParentDragContainerFor returns null below.
+        juce::var description(obj);
 
         // Build a compact drag image showing the file names instead of
         // letting JUCE auto-snapshot the entire browser panel.
@@ -1376,7 +1379,7 @@ void MediaExplorerContent::mouseDrag(const juce::MouseEvent& e) {
         }
 
         if (auto* container = juce::DragAndDropContainer::findParentDragContainerFor(this))
-            container->startDragging(juce::var(obj), this, juce::ScaledImage(dragImg));
+            container->startDragging(description, this, juce::ScaledImage(dragImg));
 
         // startDragging is non-blocking, so reset state immediately — the drag
         // runs under JUCE's modal drag-image controller and the original

--- a/magda/daw/ui/panels/content/MediaExplorerContent.cpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.cpp
@@ -1334,11 +1334,58 @@ void MediaExplorerContent::mouseDrag(const juce::MouseEvent& e) {
         paths.add(fileForDrag_.getFullPathName());
 
     if (!paths.isEmpty()) {
-        juce::DragAndDropContainer::performExternalDragDropOfFiles(paths, false, this);
+#if JUCE_LINUX
+        // JUCE has no Wayland DnD, and even on X11 external DnD is unreliable
+        // from the same app to itself, so drops into the arrangement silently
+        // fail. Use JUCE-internal DnD instead — TrackContentPanel::itemDropped
+        // recognises the {type:"files",paths} payload and runs the same import
+        // logic as the OS file-drop path. Tradeoff: dragging out of MAGDA into
+        // another app is not possible via this route.
+        juce::Array<juce::var> pathArray;
+        for (const auto& p : paths)
+            pathArray.add(p);
 
-        // The ListBox collapsed the visual selection to the clicked row when
-        // the drag started. Restore the sticky multi-selection now that the
-        // external drag has finished so the user keeps their selection.
+        auto* obj = new juce::DynamicObject();
+        obj->setProperty("type", juce::var("files"));
+        obj->setProperty("paths", juce::var(pathArray));
+
+        // Build a compact drag image showing the file names instead of
+        // letting JUCE auto-snapshot the entire browser panel.
+        const int rowH = 18;
+        const int maxRows = juce::jmin(paths.size(), 5);
+        const int hasMore = (paths.size() > maxRows) ? 1 : 0;
+        const int width = 240;
+        const int height = (maxRows + hasMore) * rowH + 6;
+
+        juce::Image dragImg(juce::Image::ARGB, width, height, true);
+        {
+            juce::Graphics g(dragImg);
+            g.setColour(juce::Colours::black.withAlpha(0.78f));
+            g.fillRoundedRectangle(0.0f, 0.0f, (float)width, (float)height, 4.0f);
+            g.setColour(juce::Colours::white);
+            g.setFont(13.0f);
+            for (int i = 0; i < maxRows; ++i) {
+                g.drawText(juce::File(paths[i]).getFileName(), 8, 3 + i * rowH, width - 16,
+                           rowH, juce::Justification::centredLeft, true);
+            }
+            if (hasMore) {
+                g.drawText("+" + juce::String(paths.size() - maxRows) + " more", 8,
+                           3 + maxRows * rowH, width - 16, rowH,
+                           juce::Justification::centredLeft, true);
+            }
+        }
+
+        if (auto* container = juce::DragAndDropContainer::findParentDragContainerFor(this))
+            container->startDragging(juce::var(obj), this, juce::ScaledImage(dragImg));
+
+        // startDragging is non-blocking, so reset state immediately — the drag
+        // runs under JUCE's modal drag-image controller and the original
+        // component will not receive mouseUp.
+        isDraggingFile_ = false;
+#else
+        juce::DragAndDropContainer::performExternalDragDropOfFiles(paths, false, this);
+#endif
+
         if (stickyRowSelection_.size() >= 2 && listComp != nullptr)
             listComp->setSelectedRows(stickyRowSelection_);
     }


### PR DESCRIPTION
## Summary
- JUCE has no Wayland DnD and routes `performExternalDragDropOfFiles` through the OS even for same-app drops, so dragging samples from the in-app media browser into the arrangement silently failed on Linux. macOS/Windows were unaffected.
- On Linux, route the drag through JUCE-internal DnD: `MediaExplorerContent::mouseDrag` calls `startDragging` with a `{type:"files",paths:[...]}` payload (under `#if JUCE_LINUX`), and `TrackContentPanel::itemDropped` recognises that payload and reuses the same import path as the OS file-drop flow (extracted into shared helpers).
- Linux drag image is a compact filename list instead of a snapshot of the whole browser panel.
- macOS/Windows behavior is unchanged: the source-side switch is gated by `#if JUCE_LINUX`, and the new `TrackContentPanel` branches are only reachable from that producer, so they are dead code on other platforms. Drag-out from MediaExplorer to other apps is preserved on macOS/Windows.

## Test plan
- [ ] Linux/Wayland: drag a single audio file from MediaExplorer onto an existing track — clip is created at drop position.
- [ ] Linux/Wayland: drag multiple files onto empty arrangement area — one new track per file.
- [ ] Linux/Wayland: drag a `.mid` file — MIDI import runs.
- [ ] Linux/Wayland: drop indicator + ghost track headers appear during drag, clear on exit/drop.
- [ ] Linux/Wayland: drag image shows filenames, not a full-panel snapshot.
- [ ] macOS: in-app browser → arrangement still works; drag-out from browser into Finder still works.
- [ ] Windows: in-app browser → arrangement still works; drag-out from browser into Explorer still works.
- [ ] All platforms: dropping files from the OS file manager into the arrangement still works (where the OS supports it).
- [ ] All platforms: plugin-browser drag onto arrangement (separate path) still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)