### PR TITLE
feat: CLAP zero-shot tagging in the media DB indexer (#1319)

### DIFF
--- a/magda/daw/media_db/CMakeLists.txt
+++ b/magda/daw/media_db/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(magda_daw PRIVATE
     MediaDbIndexer.cpp
     MediaDbMetadata.cpp
     MediaDbQuery.cpp
+    MediaDbZeroShotTags.cpp
     MelSpectrogram.cpp
     PathRules.cpp
     RobertaTokenizer.cpp

--- a/magda/daw/media_db/MediaDbIndexer.cpp
+++ b/magda/daw/media_db/MediaDbIndexer.cpp
@@ -656,7 +656,7 @@ void applyZeroShotTagging(sqlite3* db, std::int64_t fileId,
         // ambiguous samples (a 0.5s vocal hit sounds drum-like to CLAP, but
         // a producer who put it in /Vocals/ knew what they made).
         if (fileRow->family.empty() || fileRow->family == "unknown") {
-            const auto clapFamily = familyFromTopTags(hits);
+            const auto clapFamily = familyFromTopLabels(hits);
             if (!clapFamily.empty()) {
                 updateFamily(db, fileId, clapFamily);
             }
@@ -758,6 +758,13 @@ void processOneFile(sqlite3* sqlDb, const ScannedFile& f, MediaDbIndexer::Stats&
         replaceTags(sqlDb, fileId, tags, "path");
         if (existing && f.kind == "audio") {
             deleteEmbeddings(sqlDb, fileId);
+            // Stale CLAP zero-shot tags described the previous audio
+            // content; clear them in the same transaction so the file can't
+            // be left with semantic tags that no longer describe the bytes
+            // on disk. The next embedding pass re-derives them when a
+            // tagger is available; when it isn't, the file simply has no
+            // CLAP tags rather than misleading ones (issue #1319).
+            replaceTags(sqlDb, fileId, {}, "clap-zeroshot");
         }
 
         upsertFts(sqlDb, fileId, buildPathText(f.path), buildTagText(tags));
@@ -931,30 +938,41 @@ std::vector<std::filesystem::path> pathsForIds(sqlite3* db,
 // ---- Public --------------------------------------------------------------
 
 MediaDbIndexer::MediaDbIndexer(MediaDatabase& db, ClapAudioEncoder* encoder,
-                               ClapTextEncoder* textEncoder, RobertaTokenizer* tokenizer)
-    : db_(db), encoder_(encoder), textEncoder_(textEncoder), tokenizer_(tokenizer) {}
+                               TextEncoderProvider textEncoderProvider,
+                               TokenizerProvider tokenizerProvider)
+    : db_(db),
+      encoder_(encoder),
+      textEncoderProvider_(std::move(textEncoderProvider)),
+      tokenizerProvider_(std::move(tokenizerProvider)) {}
 
 MediaDbIndexer::~MediaDbIndexer() = default;
 
 namespace {
-// Lazy-init helper for the indexer's ZeroShotTagger. Embeds every prompt
-// through the text encoder once; if anything throws we leave the tagger
-// pointer null and the embedding loop degrades to "audio embedding only".
-// Caller reports the failure once (not per file) via the failure callback.
+// Lazy-init helper for the indexer's ZeroShotTagger. Invokes the provider
+// lambdas (which may trigger the ~480 MB text-model load) only on the
+// first call, and only when the embedding pass actually has work — see
+// the embedMissing*/embedAudio* call sites which skip this when files is
+// empty. If anything throws we leave the tagger null and the embedding
+// loop degrades to "audio embedding only", reporting the failure once via
+// the failure callback so the per-file path stays quiet.
 ZeroShotTagger* ensureZeroShotTagger(std::unique_ptr<ZeroShotTagger>& slot,
-                                     ClapTextEncoder* textEncoder, RobertaTokenizer* tokenizer,
+                                     const MediaDbIndexer::TextEncoderProvider& textProvider,
+                                     const MediaDbIndexer::TokenizerProvider& tokenizerProvider,
                                      const MediaDbIndexer::FailureFn& failure) {
     if (slot) {
         return slot.get();
     }
+    if (!textProvider || !tokenizerProvider) {
+        return nullptr;
+    }
+    auto* textEncoder = textProvider();
+    auto* tokenizer = tokenizerProvider();
     if (textEncoder == nullptr || tokenizer == nullptr) {
         return nullptr;
     }
     try {
         slot = std::make_unique<ZeroShotTagger>(*textEncoder, *tokenizer);
     } catch (const std::exception& e) {
-        // One-time report so the user sees zero-shot tagging is unavailable
-        // for this scan; subsequent files just skip silently.
         reportFailure(failure, {}, std::string{"zero-shot tag init failed: "} + e.what());
         slot.reset();
     } catch (...) {
@@ -1152,9 +1170,16 @@ MediaDbIndexer::EmbeddingStats MediaDbIndexer::embedMissingAudio(
     const auto files = pendingEmbeddings(sqlDb, modelId, root);
     const int total = static_cast<int>(files.size());
 
-    // Lazy-init zero-shot tagger; null when text encoder / tokenizer are
-    // unavailable, which means we skip CLAP tagging but still embed.
-    auto* tagger = ensureZeroShotTagger(zeroShotTagger_, textEncoder_, tokenizer_, failure_);
+    // Zero-shot tagger needs the text encoder + tokenizer (the latter
+    // triggering a ~480 MB ORT session load). Only ask the providers for
+    // them when we actually have files to process — otherwise installing
+    // the Sample Tagger bundle makes empty / no-op embedding passes pay
+    // the load cost for nothing.
+    ZeroShotTagger* tagger = nullptr;
+    if (!files.empty()) {
+        tagger = ensureZeroShotTagger(zeroShotTagger_, textEncoderProvider_, tokenizerProvider_,
+                                      failure_);
+    }
 
     int done = 0;
     for (const auto& f : files) {
@@ -1225,7 +1250,11 @@ MediaDbIndexer::EmbeddingStats MediaDbIndexer::embedAudioFileIds(
     const auto files = audioRowsForIds(sqlDb, fileIds);
     const int total = static_cast<int>(files.size());
 
-    auto* tagger = ensureZeroShotTagger(zeroShotTagger_, textEncoder_, tokenizer_, failure_);
+    ZeroShotTagger* tagger = nullptr;
+    if (!files.empty()) {
+        tagger = ensureZeroShotTagger(zeroShotTagger_, textEncoderProvider_, tokenizerProvider_,
+                                      failure_);
+    }
 
     int done = 0;
     for (const auto& f : files) {

--- a/magda/daw/media_db/MediaDbIndexer.cpp
+++ b/magda/daw/media_db/MediaDbIndexer.cpp
@@ -18,8 +18,11 @@
 
 #include "AudioFeatures.hpp"
 #include "ClapAudioEncoder.hpp"
+#include "ClapTextEncoder.hpp"
 #include "MediaDatabase.hpp"
+#include "MediaDbZeroShotTags.hpp"
 #include "PathRules.hpp"
+#include "RobertaTokenizer.hpp"
 #include "Scan.hpp"
 
 namespace magda::media {
@@ -570,6 +573,104 @@ std::string buildTagText(const std::vector<std::pair<std::string, float>>& tags)
     return out;
 }
 
+// ---- Zero-shot helpers (issue #1319) ------------------------------------
+
+// Read every tag row for a file across all source_models. Used when the
+// zero-shot pass needs to refresh the FTS row with the union of path +
+// scan + clap-zeroshot tags after writing new clap-zeroshot rows.
+std::vector<std::pair<std::string, float>> readAllTags(sqlite3* db, std::int64_t fileId) {
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(db, "SELECT tag, confidence FROM media_tag WHERE file_id = ?", -1, &stmt,
+                           nullptr) != SQLITE_OK) {
+        return {};
+    }
+    sqlite3_bind_int64(stmt, 1, fileId);
+    std::vector<std::pair<std::string, float>> out;
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        const auto* text = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+        if (text == nullptr) {
+            continue;
+        }
+        out.emplace_back(text, static_cast<float>(sqlite3_column_double(stmt, 1)));
+    }
+    sqlite3_finalize(stmt);
+    return out;
+}
+
+// Read the path + currently-stored family for a file. Family is what we
+// wrote during the scan pass — usually a path hint or "unknown".
+struct ExistingFileRow {
+    std::string path;
+    std::string family;
+};
+std::optional<ExistingFileRow> readFileRow(sqlite3* db, std::int64_t fileId) {
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(db, "SELECT path, family FROM media_file WHERE id = ?", -1, &stmt,
+                           nullptr) != SQLITE_OK) {
+        return std::nullopt;
+    }
+    sqlite3_bind_int64(stmt, 1, fileId);
+    std::optional<ExistingFileRow> result;
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        ExistingFileRow row;
+        if (const auto* p = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0))) {
+            row.path = p;
+        }
+        if (const auto* fam = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1))) {
+            row.family = fam;
+        }
+        result = std::move(row);
+    }
+    sqlite3_finalize(stmt);
+    return result;
+}
+
+void updateFamily(sqlite3* db, std::int64_t fileId, const std::string& family) {
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(db, "UPDATE media_file SET family = ? WHERE id = ?", -1, &stmt,
+                           nullptr) != SQLITE_OK) {
+        return;
+    }
+    sqlite3_bind_text(stmt, 1, family.c_str(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int64(stmt, 2, fileId);
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+}
+
+// After audio embedding: score against the prompt matrix, write the top
+// hits as media_tag rows under the 'clap-zeroshot' source, override family
+// from the top non-texture tag when the scan pass left it "unknown", and
+// refresh the FTS row so tag-text search picks the new tags up. All inside
+// the same transaction the caller opens around upsertEmbedding so a power
+// loss between writes can't leave the DB in a state where the embedding
+// exists but tags/family/FTS are stale.
+void applyZeroShotTagging(sqlite3* db, std::int64_t fileId,
+                          const std::vector<float>& audioEmbedding, const ZeroShotTagger& tagger) {
+    const auto hits = tagger.scoreEmbedding(audioEmbedding.data(), audioEmbedding.size());
+    replaceTags(db, fileId, hits, "clap-zeroshot");
+
+    const auto fileRow = readFileRow(db, fileId);
+    if (fileRow) {
+        // Only overwrite when the path-derived family was non-informative.
+        // The path hint is treated as more reliable than CLAP on short or
+        // ambiguous samples (a 0.5s vocal hit sounds drum-like to CLAP, but
+        // a producer who put it in /Vocals/ knew what they made).
+        if (fileRow->family.empty() || fileRow->family == "unknown") {
+            const auto clapFamily = familyFromTopTags(hits);
+            if (!clapFamily.empty()) {
+                updateFamily(db, fileId, clapFamily);
+            }
+        }
+    }
+
+    // Refresh FTS so tag_text reflects path + scan + clap-zeroshot tags
+    // together. readAllTags is cheap (one indexed SELECT) compared to the
+    // ORT inference we just ran.
+    const auto unioned = readAllTags(db, fileId);
+    const auto pathText = fileRow ? buildPathText(fileRow->path) : std::string{};
+    upsertFts(db, fileId, pathText, buildTagText(unioned));
+}
+
 // ---- Per-file pipeline --------------------------------------------------
 //
 // Same logic in both serial and parallel modes: takes a raw sqlite3* (so
@@ -829,8 +930,40 @@ std::vector<std::filesystem::path> pathsForIds(sqlite3* db,
 
 // ---- Public --------------------------------------------------------------
 
-MediaDbIndexer::MediaDbIndexer(MediaDatabase& db, ClapAudioEncoder* encoder)
-    : db_(db), encoder_(encoder) {}
+MediaDbIndexer::MediaDbIndexer(MediaDatabase& db, ClapAudioEncoder* encoder,
+                               ClapTextEncoder* textEncoder, RobertaTokenizer* tokenizer)
+    : db_(db), encoder_(encoder), textEncoder_(textEncoder), tokenizer_(tokenizer) {}
+
+MediaDbIndexer::~MediaDbIndexer() = default;
+
+namespace {
+// Lazy-init helper for the indexer's ZeroShotTagger. Embeds every prompt
+// through the text encoder once; if anything throws we leave the tagger
+// pointer null and the embedding loop degrades to "audio embedding only".
+// Caller reports the failure once (not per file) via the failure callback.
+ZeroShotTagger* ensureZeroShotTagger(std::unique_ptr<ZeroShotTagger>& slot,
+                                     ClapTextEncoder* textEncoder, RobertaTokenizer* tokenizer,
+                                     const MediaDbIndexer::FailureFn& failure) {
+    if (slot) {
+        return slot.get();
+    }
+    if (textEncoder == nullptr || tokenizer == nullptr) {
+        return nullptr;
+    }
+    try {
+        slot = std::make_unique<ZeroShotTagger>(*textEncoder, *tokenizer);
+    } catch (const std::exception& e) {
+        // One-time report so the user sees zero-shot tagging is unavailable
+        // for this scan; subsequent files just skip silently.
+        reportFailure(failure, {}, std::string{"zero-shot tag init failed: "} + e.what());
+        slot.reset();
+    } catch (...) {
+        reportFailure(failure, {}, "zero-shot tag init failed: unknown error");
+        slot.reset();
+    }
+    return slot.get();
+}
+}  // namespace
 
 void MediaDbIndexer::setProgress(ProgressFn fn) {
     progress_ = std::move(fn);
@@ -1019,6 +1152,10 @@ MediaDbIndexer::EmbeddingStats MediaDbIndexer::embedMissingAudio(
     const auto files = pendingEmbeddings(sqlDb, modelId, root);
     const int total = static_cast<int>(files.size());
 
+    // Lazy-init zero-shot tagger; null when text encoder / tokenizer are
+    // unavailable, which means we skip CLAP tagging but still embed.
+    auto* tagger = ensureZeroShotTagger(zeroShotTagger_, textEncoder_, tokenizer_, failure_);
+
     int done = 0;
     for (const auto& f : files) {
         if (shouldCancel(shouldCancel_)) {
@@ -1048,6 +1185,9 @@ MediaDbIndexer::EmbeddingStats MediaDbIndexer::embedMissingAudio(
             bool transactionOpen = true;
             try {
                 upsertEmbedding(sqlDb, f.fileId, modelId, embedding);
+                if (tagger != nullptr) {
+                    applyZeroShotTagging(sqlDb, f.fileId, embedding, *tagger);
+                }
                 execSqlOrThrow(sqlDb, "COMMIT", "COMMIT media embedding");
                 transactionOpen = false;
             } catch (...) {
@@ -1085,6 +1225,8 @@ MediaDbIndexer::EmbeddingStats MediaDbIndexer::embedAudioFileIds(
     const auto files = audioRowsForIds(sqlDb, fileIds);
     const int total = static_cast<int>(files.size());
 
+    auto* tagger = ensureZeroShotTagger(zeroShotTagger_, textEncoder_, tokenizer_, failure_);
+
     int done = 0;
     for (const auto& f : files) {
         if (shouldCancel(shouldCancel_)) {
@@ -1111,6 +1253,9 @@ MediaDbIndexer::EmbeddingStats MediaDbIndexer::embedAudioFileIds(
             bool transactionOpen = true;
             try {
                 upsertEmbedding(sqlDb, f.fileId, modelId, embedding);
+                if (tagger != nullptr) {
+                    applyZeroShotTagging(sqlDb, f.fileId, embedding, *tagger);
+                }
                 execSqlOrThrow(sqlDb, "COMMIT", "COMMIT selected media embedding");
                 transactionOpen = false;
             } catch (...) {

--- a/magda/daw/media_db/MediaDbIndexer.hpp
+++ b/magda/daw/media_db/MediaDbIndexer.hpp
@@ -78,13 +78,21 @@ class MediaDbIndexer {
         ForceAll,
     };
 
+    using TextEncoderProvider = std::function<ClapTextEncoder*()>;
+    using TokenizerProvider = std::function<RobertaTokenizer*()>;
+
     // db: required. encoder: nullable, controls whether the post-scan
-    // embedding backfill can run. textEncoder + tokenizer: nullable as a
-    // pair, control whether the embedding pass also writes CLAP zero-shot
-    // tags (issue #1319). When either is null the post-scan pass still
-    // produces audio embeddings but skips zero-shot tagging.
+    // embedding backfill can run. textEncoderProvider + tokenizerProvider:
+    // optional, each returns the corresponding model when called. The
+    // indexer only invokes the providers when an embedding pass actually
+    // has pending files, so installing the bundle doesn't make ordinary
+    // indexing scans pay the ~480 MB text-model load cost. Providers
+    // returning null (or providers themselves left empty) disable the
+    // CLAP zero-shot tagging side of the embedding pass while still
+    // producing audio embeddings (issue #1319).
     MediaDbIndexer(MediaDatabase& db, ClapAudioEncoder* encoder,
-                   ClapTextEncoder* textEncoder = nullptr, RobertaTokenizer* tokenizer = nullptr);
+                   TextEncoderProvider textEncoderProvider = {},
+                   TokenizerProvider tokenizerProvider = {});
     ~MediaDbIndexer();
     MediaDbIndexer(const MediaDbIndexer&) = delete;
     MediaDbIndexer& operator=(const MediaDbIndexer&) = delete;
@@ -123,11 +131,11 @@ class MediaDbIndexer {
   private:
     MediaDatabase& db_;
     ClapAudioEncoder* encoder_;
-    ClapTextEncoder* textEncoder_;
-    RobertaTokenizer* tokenizer_;
-    // Built lazily on the first embedding pass when textEncoder_ + tokenizer_
-    // are both available. Held as a unique_ptr so the header doesn't have to
-    // pull in MediaDbZeroShotTags.hpp.
+    TextEncoderProvider textEncoderProvider_;
+    TokenizerProvider tokenizerProvider_;
+    // Built lazily on the first embedding pass that actually has pending
+    // files. Held as a unique_ptr so the header doesn't have to pull in
+    // MediaDbZeroShotTags.hpp.
     std::unique_ptr<ZeroShotTagger> zeroShotTagger_;
     ProgressFn progress_;
     FailureFn failure_;

--- a/magda/daw/media_db/MediaDbIndexer.hpp
+++ b/magda/daw/media_db/MediaDbIndexer.hpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -25,6 +26,9 @@ namespace magda::media {
 
 class MediaDatabase;
 class ClapAudioEncoder;
+class ClapTextEncoder;
+class RobertaTokenizer;
+class ZeroShotTagger;
 
 class MediaDbIndexer {
   public:
@@ -75,8 +79,17 @@ class MediaDbIndexer {
     };
 
     // db: required. encoder: nullable, controls whether the post-scan
-    // embedding backfill can run.
-    MediaDbIndexer(MediaDatabase& db, ClapAudioEncoder* encoder);
+    // embedding backfill can run. textEncoder + tokenizer: nullable as a
+    // pair, control whether the embedding pass also writes CLAP zero-shot
+    // tags (issue #1319). When either is null the post-scan pass still
+    // produces audio embeddings but skips zero-shot tagging.
+    MediaDbIndexer(MediaDatabase& db, ClapAudioEncoder* encoder,
+                   ClapTextEncoder* textEncoder = nullptr, RobertaTokenizer* tokenizer = nullptr);
+    ~MediaDbIndexer();
+    MediaDbIndexer(const MediaDbIndexer&) = delete;
+    MediaDbIndexer& operator=(const MediaDbIndexer&) = delete;
+    MediaDbIndexer(MediaDbIndexer&&) = delete;
+    MediaDbIndexer& operator=(MediaDbIndexer&&) = delete;
 
     void setProgress(ProgressFn fn);
     void setFailureCallback(FailureFn fn);
@@ -110,6 +123,12 @@ class MediaDbIndexer {
   private:
     MediaDatabase& db_;
     ClapAudioEncoder* encoder_;
+    ClapTextEncoder* textEncoder_;
+    RobertaTokenizer* tokenizer_;
+    // Built lazily on the first embedding pass when textEncoder_ + tokenizer_
+    // are both available. Held as a unique_ptr so the header doesn't have to
+    // pull in MediaDbZeroShotTags.hpp.
+    std::unique_ptr<ZeroShotTagger> zeroShotTagger_;
     ProgressFn progress_;
     FailureFn failure_;
     ShouldCancelFn shouldCancel_;

--- a/magda/daw/media_db/MediaDbZeroShotTags.cpp
+++ b/magda/daw/media_db/MediaDbZeroShotTags.cpp
@@ -1,0 +1,249 @@
+#include "MediaDbZeroShotTags.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <unordered_map>
+
+#include "ClapTextEncoder.hpp"
+#include "RobertaTokenizer.hpp"
+
+namespace magda::media {
+
+namespace {
+
+// Single source of truth for the prompt list. Mirrors DEFAULT_TAGS in
+// prototypes/media_db/src/media_db/tags.py — keep the two lists in sync when
+// adjusting taxonomy so the prototype's validation runs stay representative.
+const std::vector<std::string>& staticPrompts() {
+    static const std::vector<std::string> kPrompts = {
+        // drums
+        "the sound of a kick drum",
+        "the sound of a snare drum",
+        "the sound of a clap",
+        "the sound of a hi-hat",
+        "the sound of a cymbal",
+        "the sound of a tom drum",
+        "the sound of a percussion loop",
+        "the sound of a drum loop",
+        "the sound of a 808 bass drum",
+        // bass and lead
+        "the sound of a sub bass",
+        "the sound of a synth bass",
+        "the sound of an acid bass",
+        "the sound of a synth lead",
+        "the sound of a synth pad",
+        "the sound of a synth pluck",
+        "the sound of an arpeggio",
+        // acoustic
+        "the sound of a piano",
+        "the sound of an electric piano",
+        "the sound of an organ",
+        "the sound of an acoustic guitar",
+        "the sound of an electric guitar",
+        "the sound of strings",
+        "the sound of brass",
+        "the sound of woodwinds",
+        "the sound of a vocal",
+        "the sound of a vocal chop",
+        // fx
+        "the sound of a sound effect",
+        "the sound of an impact",
+        "the sound of a riser",
+        "the sound of a downlifter",
+        "the sound of a noise sweep",
+        "the sound of an ambience",
+        "the sound of a foley sound",
+        // texture / mood descriptors
+        "the sound of a dark sound",
+        "the sound of a bright sound",
+        "the sound of a warm sound",
+        "the sound of a metallic sound",
+        "the sound of a distorted sound",
+        "the sound of a clean sound",
+        "the sound of a lo-fi sound",
+        "the sound of a glitchy sound",
+    };
+    return kPrompts;
+}
+
+// Prompt -> coarse family. "texture" is a sentinel; texture prompts can
+// still emit a tag but never set the family (see familyFromTopTags). The
+// keys are the exact prompt strings from staticPrompts() so lookups are
+// trivial; if a caller passes a string that isn't in the map we treat it
+// as unknown.
+const std::unordered_map<std::string, std::string>& staticFamilyMap() {
+    static const std::unordered_map<std::string, std::string> kFamily = {
+        {"the sound of a kick drum", "drum"},
+        {"the sound of a snare drum", "drum"},
+        {"the sound of a clap", "drum"},
+        {"the sound of a hi-hat", "drum"},
+        {"the sound of a cymbal", "drum"},
+        {"the sound of a tom drum", "drum"},
+        {"the sound of a percussion loop", "drum"},
+        {"the sound of a drum loop", "drum"},
+        {"the sound of a 808 bass drum", "drum"},
+
+        {"the sound of a sub bass", "bass"},
+        {"the sound of a synth bass", "bass"},
+        {"the sound of an acid bass", "bass"},
+
+        {"the sound of a synth lead", "lead"},
+        {"the sound of a synth pluck", "lead"},
+        {"the sound of an arpeggio", "lead"},
+
+        {"the sound of a synth pad", "pad"},
+
+        {"the sound of a piano", "keys"},
+        {"the sound of an electric piano", "keys"},
+        {"the sound of an organ", "keys"},
+
+        {"the sound of an acoustic guitar", "guitar"},
+        {"the sound of an electric guitar", "guitar"},
+
+        {"the sound of strings", "orchestral"},
+        {"the sound of brass", "orchestral"},
+        {"the sound of woodwinds", "orchestral"},
+
+        {"the sound of a vocal", "vocal"},
+        {"the sound of a vocal chop", "vocal"},
+
+        {"the sound of a sound effect", "fx"},
+        {"the sound of an impact", "fx"},
+        {"the sound of a riser", "fx"},
+        {"the sound of a downlifter", "fx"},
+        {"the sound of a noise sweep", "fx"},
+        {"the sound of an ambience", "fx"},
+        {"the sound of a foley sound", "fx"},
+
+        {"the sound of a dark sound", "texture"},
+        {"the sound of a bright sound", "texture"},
+        {"the sound of a warm sound", "texture"},
+        {"the sound of a metallic sound", "texture"},
+        {"the sound of a distorted sound", "texture"},
+        {"the sound of a clean sound", "texture"},
+        {"the sound of a lo-fi sound", "texture"},
+        {"the sound of a glitchy sound", "texture"},
+    };
+    return kFamily;
+}
+
+void l2NormalizeInPlace(float* v, std::size_t n) {
+    double sumSq = 0.0;
+    for (std::size_t i = 0; i < n; ++i) {
+        sumSq += static_cast<double>(v[i]) * static_cast<double>(v[i]);
+    }
+    const float norm = static_cast<float>(std::sqrt(sumSq));
+    if (norm <= 0.0F) {
+        return;
+    }
+    const float inv = 1.0F / norm;
+    for (std::size_t i = 0; i < n; ++i) {
+        v[i] *= inv;
+    }
+}
+
+}  // namespace
+
+const std::vector<std::string>& defaultZeroShotPrompts() {
+    return staticPrompts();
+}
+
+const std::string& familyForPrompt(const std::string& prompt) {
+    static const std::string kUnknown = "unknown";
+    const auto& map = staticFamilyMap();
+    if (auto it = map.find(prompt); it != map.end()) {
+        return it->second;
+    }
+    return kUnknown;
+}
+
+std::string familyFromTopTags(const std::vector<std::pair<std::string, float>>& topTags) {
+    // topTags is descending-confidence (scoreEmbedding's contract). Walk it
+    // and return the first non-texture family above the floor. This mirrors
+    // derive.py:family() — first real-instrument candidate wins; texture
+    // descriptors are skipped so "warm sound" can't outrank "synth pad".
+    for (const auto& [tag, conf] : topTags) {
+        if (conf < kZeroShotFamilyFloor) {
+            break;  // sorted; everything after is below threshold
+        }
+        const auto& family = familyForPrompt(tag);
+        if (family.empty() || family == "texture" || family == "unknown") {
+            continue;
+        }
+        return family;
+    }
+    return {};
+}
+
+ZeroShotTagger::ZeroShotTagger(ClapTextEncoder& textEncoder, RobertaTokenizer& tokenizer)
+    : ZeroShotTagger(textEncoder, tokenizer, staticPrompts()) {}
+
+ZeroShotTagger::ZeroShotTagger(ClapTextEncoder& textEncoder, RobertaTokenizer& tokenizer,
+                               std::vector<std::string> prompts)
+    : prompts_(std::move(prompts)) {
+    if (prompts_.empty()) {
+        throw std::runtime_error("ZeroShotTagger: prompt list is empty");
+    }
+
+    const int dim = textEncoder.dim();
+    if (dim <= 0) {
+        throw std::runtime_error("ZeroShotTagger: text encoder reports non-positive dim");
+    }
+    dim_ = static_cast<std::size_t>(dim);
+    promptMatrix_.resize(prompts_.size() * dim_, 0.0F);
+
+    for (std::size_t i = 0; i < prompts_.size(); ++i) {
+        const auto enc = tokenizer.encode(prompts_[i]);
+        auto vec = textEncoder.embedTokens(enc.inputIds, enc.attentionMask);
+        if (vec.size() != dim_) {
+            throw std::runtime_error("ZeroShotTagger: text embedding dim mismatch on prompt " +
+                                     prompts_[i]);
+        }
+        // ClapTextEncoder already L2-normalizes, but re-normalize defensively
+        // — a future refactor could drop normalization at the encoder layer
+        // and we'd silently corrupt cosine math here.
+        l2NormalizeInPlace(vec.data(), vec.size());
+        const auto offset = static_cast<std::ptrdiff_t>(i * dim_);
+        std::copy(vec.begin(), vec.end(), promptMatrix_.begin() + offset);
+    }
+}
+
+std::vector<std::pair<std::string, float>> ZeroShotTagger::scoreEmbedding(
+    const float* audioEmbedding, std::size_t dim, float threshold) const {
+    if (dim != dim_) {
+        throw std::runtime_error("ZeroShotTagger::scoreEmbedding: dim mismatch");
+    }
+
+    std::vector<std::pair<std::string, float>> hits;
+    hits.reserve(prompts_.size());
+    for (std::size_t i = 0; i < prompts_.size(); ++i) {
+        const std::size_t rowStart = i * dim_;
+        double dot = 0.0;
+        for (std::size_t j = 0; j < dim_; ++j) {
+            dot += static_cast<double>(promptMatrix_[rowStart + j]) *
+                   static_cast<double>(audioEmbedding[j]);
+        }
+        const float score = static_cast<float>(dot);
+        if (score >= threshold) {
+            hits.emplace_back(prompts_[i], score);
+        }
+    }
+    std::sort(hits.begin(), hits.end(),
+              [](const auto& a, const auto& b) { return a.second > b.second; });
+    return hits;
+}
+
+std::size_t ZeroShotTagger::numPrompts() const noexcept {
+    return prompts_.size();
+}
+
+std::size_t ZeroShotTagger::embeddingDim() const noexcept {
+    return dim_;
+}
+
+const std::vector<std::string>& ZeroShotTagger::prompts() const noexcept {
+    return prompts_;
+}
+
+}  // namespace magda::media

--- a/magda/daw/media_db/MediaDbZeroShotTags.cpp
+++ b/magda/daw/media_db/MediaDbZeroShotTags.cpp
@@ -12,118 +12,122 @@ namespace magda::media {
 
 namespace {
 
-// Single source of truth for the prompt list. Mirrors DEFAULT_TAGS in
-// prototypes/media_db/src/media_db/tags.py — keep the two lists in sync when
-// adjusting taxonomy so the prototype's validation runs stay representative.
-const std::vector<std::string>& staticPrompts() {
-    static const std::vector<std::string> kPrompts = {
+// Mirrors tags.py's PROMPT_TEMPLATE. The label list stays terse for the DB
+// and the UI; this string is only used internally when we hand text to the
+// CLAP text encoder. Keep the wording in sync with the prototype so the
+// validation runs there stay representative of the C++ embedding values.
+constexpr const char* kPromptTemplate = "the sound of ";
+
+// Single source of truth for the label list. Mirrors DEFAULT_TAGS in
+// prototypes/media_db/src/media_db/tags.py — keep the two lists in sync
+// when adjusting taxonomy so the prototype's validation runs stay
+// representative.
+const std::vector<std::string>& staticLabels() {
+    static const std::vector<std::string> kLabels = {
         // drums
-        "the sound of a kick drum",
-        "the sound of a snare drum",
-        "the sound of a clap",
-        "the sound of a hi-hat",
-        "the sound of a cymbal",
-        "the sound of a tom drum",
-        "the sound of a percussion loop",
-        "the sound of a drum loop",
-        "the sound of a 808 bass drum",
+        "a kick drum",
+        "a snare drum",
+        "a clap",
+        "a hi-hat",
+        "a cymbal",
+        "a tom drum",
+        "a percussion loop",
+        "a drum loop",
+        "a 808 bass drum",
         // bass and lead
-        "the sound of a sub bass",
-        "the sound of a synth bass",
-        "the sound of an acid bass",
-        "the sound of a synth lead",
-        "the sound of a synth pad",
-        "the sound of a synth pluck",
-        "the sound of an arpeggio",
+        "a sub bass",
+        "a synth bass",
+        "an acid bass",
+        "a synth lead",
+        "a synth pad",
+        "a synth pluck",
+        "an arpeggio",
         // acoustic
-        "the sound of a piano",
-        "the sound of an electric piano",
-        "the sound of an organ",
-        "the sound of an acoustic guitar",
-        "the sound of an electric guitar",
-        "the sound of strings",
-        "the sound of brass",
-        "the sound of woodwinds",
-        "the sound of a vocal",
-        "the sound of a vocal chop",
+        "a piano",
+        "an electric piano",
+        "an organ",
+        "an acoustic guitar",
+        "an electric guitar",
+        "strings",
+        "brass",
+        "woodwinds",
+        "a vocal",
+        "a vocal chop",
         // fx
-        "the sound of a sound effect",
-        "the sound of an impact",
-        "the sound of a riser",
-        "the sound of a downlifter",
-        "the sound of a noise sweep",
-        "the sound of an ambience",
-        "the sound of a foley sound",
+        "a sound effect",
+        "an impact",
+        "a riser",
+        "a downlifter",
+        "a noise sweep",
+        "an ambience",
+        "a foley sound",
         // texture / mood descriptors
-        "the sound of a dark sound",
-        "the sound of a bright sound",
-        "the sound of a warm sound",
-        "the sound of a metallic sound",
-        "the sound of a distorted sound",
-        "the sound of a clean sound",
-        "the sound of a lo-fi sound",
-        "the sound of a glitchy sound",
+        "a dark sound",
+        "a bright sound",
+        "a warm sound",
+        "a metallic sound",
+        "a distorted sound",
+        "a clean sound",
+        "a lo-fi sound",
+        "a glitchy sound",
     };
-    return kPrompts;
+    return kLabels;
 }
 
-// Prompt -> coarse family. "texture" is a sentinel; texture prompts can
-// still emit a tag but never set the family (see familyFromTopTags). The
-// keys are the exact prompt strings from staticPrompts() so lookups are
-// trivial; if a caller passes a string that isn't in the map we treat it
-// as unknown.
+// Label -> coarse family. "texture" is a sentinel; texture labels can still
+// emit a tag but never set the family (see familyFromTopLabels).
 const std::unordered_map<std::string, std::string>& staticFamilyMap() {
     static const std::unordered_map<std::string, std::string> kFamily = {
-        {"the sound of a kick drum", "drum"},
-        {"the sound of a snare drum", "drum"},
-        {"the sound of a clap", "drum"},
-        {"the sound of a hi-hat", "drum"},
-        {"the sound of a cymbal", "drum"},
-        {"the sound of a tom drum", "drum"},
-        {"the sound of a percussion loop", "drum"},
-        {"the sound of a drum loop", "drum"},
-        {"the sound of a 808 bass drum", "drum"},
+        {"a kick drum", "drum"},
+        {"a snare drum", "drum"},
+        {"a clap", "drum"},
+        {"a hi-hat", "drum"},
+        {"a cymbal", "drum"},
+        {"a tom drum", "drum"},
+        {"a percussion loop", "drum"},
+        {"a drum loop", "drum"},
+        {"a 808 bass drum", "drum"},
 
-        {"the sound of a sub bass", "bass"},
-        {"the sound of a synth bass", "bass"},
-        {"the sound of an acid bass", "bass"},
+        {"a sub bass", "bass"},
+        {"a synth bass", "bass"},
+        {"an acid bass", "bass"},
 
-        {"the sound of a synth lead", "lead"},
-        {"the sound of a synth pluck", "lead"},
-        {"the sound of an arpeggio", "lead"},
+        {"a synth lead", "lead"},
+        {"a synth pluck", "lead"},
+        {"an arpeggio", "lead"},
 
-        {"the sound of a synth pad", "pad"},
+        {"a synth pad", "pad"},
 
-        {"the sound of a piano", "keys"},
-        {"the sound of an electric piano", "keys"},
-        {"the sound of an organ", "keys"},
+        {"a piano", "keys"},
+        {"an electric piano", "keys"},
+        {"an organ", "keys"},
 
-        {"the sound of an acoustic guitar", "guitar"},
-        {"the sound of an electric guitar", "guitar"},
+        {"an acoustic guitar", "guitar"},
+        {"an electric guitar", "guitar"},
 
-        {"the sound of strings", "orchestral"},
-        {"the sound of brass", "orchestral"},
-        {"the sound of woodwinds", "orchestral"},
+        {"strings", "orchestral"},
+        {"brass", "orchestral"},
+        {"woodwinds", "orchestral"},
 
-        {"the sound of a vocal", "vocal"},
-        {"the sound of a vocal chop", "vocal"},
+        {"a vocal", "vocal"},
+        {"a vocal chop", "vocal"},
 
-        {"the sound of a sound effect", "fx"},
-        {"the sound of an impact", "fx"},
-        {"the sound of a riser", "fx"},
-        {"the sound of a downlifter", "fx"},
-        {"the sound of a noise sweep", "fx"},
-        {"the sound of an ambience", "fx"},
-        {"the sound of a foley sound", "fx"},
+        {"a sound effect", "fx"},
+        {"an impact", "fx"},
+        {"a riser", "fx"},
+        {"a downlifter", "fx"},
+        {"a noise sweep", "fx"},
+        {"an ambience", "fx"},
+        {"a foley sound", "fx"},
 
-        {"the sound of a dark sound", "texture"},
-        {"the sound of a bright sound", "texture"},
-        {"the sound of a warm sound", "texture"},
-        {"the sound of a metallic sound", "texture"},
-        {"the sound of a distorted sound", "texture"},
-        {"the sound of a clean sound", "texture"},
-        {"the sound of a lo-fi sound", "texture"},
-        {"the sound of a glitchy sound", "texture"},
+        {"a dark sound", "texture"},
+        {"a bright sound", "texture"},
+        {"a warm sound", "texture"},
+        {"a metallic sound", "texture"},
+        {"a distorted sound", "texture"},
+        {"a clean sound", "texture"},
+        {"a lo-fi sound", "texture"},
+        {"a glitchy sound", "texture"},
     };
     return kFamily;
 }
@@ -145,29 +149,29 @@ void l2NormalizeInPlace(float* v, std::size_t n) {
 
 }  // namespace
 
-const std::vector<std::string>& defaultZeroShotPrompts() {
-    return staticPrompts();
+const std::vector<std::string>& defaultZeroShotLabels() {
+    return staticLabels();
 }
 
-const std::string& familyForPrompt(const std::string& prompt) {
+const std::string& familyForLabel(const std::string& label) {
     static const std::string kUnknown = "unknown";
     const auto& map = staticFamilyMap();
-    if (auto it = map.find(prompt); it != map.end()) {
+    if (auto it = map.find(label); it != map.end()) {
         return it->second;
     }
     return kUnknown;
 }
 
-std::string familyFromTopTags(const std::vector<std::pair<std::string, float>>& topTags) {
-    // topTags is descending-confidence (scoreEmbedding's contract). Walk it
-    // and return the first non-texture family above the floor. This mirrors
+std::string familyFromTopLabels(const std::vector<std::pair<std::string, float>>& topLabels) {
+    // topLabels is descending-confidence (scoreEmbedding's contract). Walk
+    // it and return the first non-texture family above the floor. Mirrors
     // derive.py:family() — first real-instrument candidate wins; texture
     // descriptors are skipped so "warm sound" can't outrank "synth pad".
-    for (const auto& [tag, conf] : topTags) {
+    for (const auto& [label, conf] : topLabels) {
         if (conf < kZeroShotFamilyFloor) {
             break;  // sorted; everything after is below threshold
         }
-        const auto& family = familyForPrompt(tag);
+        const auto& family = familyForLabel(label);
         if (family.empty() || family == "texture" || family == "unknown") {
             continue;
         }
@@ -177,13 +181,13 @@ std::string familyFromTopTags(const std::vector<std::pair<std::string, float>>& 
 }
 
 ZeroShotTagger::ZeroShotTagger(ClapTextEncoder& textEncoder, RobertaTokenizer& tokenizer)
-    : ZeroShotTagger(textEncoder, tokenizer, staticPrompts()) {}
+    : ZeroShotTagger(textEncoder, tokenizer, staticLabels()) {}
 
 ZeroShotTagger::ZeroShotTagger(ClapTextEncoder& textEncoder, RobertaTokenizer& tokenizer,
-                               std::vector<std::string> prompts)
-    : prompts_(std::move(prompts)) {
-    if (prompts_.empty()) {
-        throw std::runtime_error("ZeroShotTagger: prompt list is empty");
+                               std::vector<std::string> labels)
+    : labels_(std::move(labels)) {
+    if (labels_.empty()) {
+        throw std::runtime_error("ZeroShotTagger: label list is empty");
     }
 
     const int dim = textEncoder.dim();
@@ -191,14 +195,18 @@ ZeroShotTagger::ZeroShotTagger(ClapTextEncoder& textEncoder, RobertaTokenizer& t
         throw std::runtime_error("ZeroShotTagger: text encoder reports non-positive dim");
     }
     dim_ = static_cast<std::size_t>(dim);
-    promptMatrix_.resize(prompts_.size() * dim_, 0.0F);
+    promptMatrix_.resize(labels_.size() * dim_, 0.0F);
 
-    for (std::size_t i = 0; i < prompts_.size(); ++i) {
-        const auto enc = tokenizer.encode(prompts_[i]);
+    for (std::size_t i = 0; i < labels_.size(); ++i) {
+        // Wrap the terse label with "the sound of " before tokenizing — the
+        // text encoder was trained on full sentences, and the prototype
+        // applies the same template (PROMPT_TEMPLATE in tags.py).
+        const std::string prompt = std::string(kPromptTemplate) + labels_[i];
+        const auto enc = tokenizer.encode(prompt);
         auto vec = textEncoder.embedTokens(enc.inputIds, enc.attentionMask);
         if (vec.size() != dim_) {
-            throw std::runtime_error("ZeroShotTagger: text embedding dim mismatch on prompt " +
-                                     prompts_[i]);
+            throw std::runtime_error("ZeroShotTagger: text embedding dim mismatch on label " +
+                                     labels_[i]);
         }
         // ClapTextEncoder already L2-normalizes, but re-normalize defensively
         // — a future refactor could drop normalization at the encoder layer
@@ -216,8 +224,8 @@ std::vector<std::pair<std::string, float>> ZeroShotTagger::scoreEmbedding(
     }
 
     std::vector<std::pair<std::string, float>> hits;
-    hits.reserve(prompts_.size());
-    for (std::size_t i = 0; i < prompts_.size(); ++i) {
+    hits.reserve(labels_.size());
+    for (std::size_t i = 0; i < labels_.size(); ++i) {
         const std::size_t rowStart = i * dim_;
         double dot = 0.0;
         for (std::size_t j = 0; j < dim_; ++j) {
@@ -226,7 +234,7 @@ std::vector<std::pair<std::string, float>> ZeroShotTagger::scoreEmbedding(
         }
         const float score = static_cast<float>(dot);
         if (score >= threshold) {
-            hits.emplace_back(prompts_[i], score);
+            hits.emplace_back(labels_[i], score);
         }
     }
     std::sort(hits.begin(), hits.end(),
@@ -234,16 +242,16 @@ std::vector<std::pair<std::string, float>> ZeroShotTagger::scoreEmbedding(
     return hits;
 }
 
-std::size_t ZeroShotTagger::numPrompts() const noexcept {
-    return prompts_.size();
+std::size_t ZeroShotTagger::numLabels() const noexcept {
+    return labels_.size();
 }
 
 std::size_t ZeroShotTagger::embeddingDim() const noexcept {
     return dim_;
 }
 
-const std::vector<std::string>& ZeroShotTagger::prompts() const noexcept {
-    return prompts_;
+const std::vector<std::string>& ZeroShotTagger::labels() const noexcept {
+    return labels_;
 }
 
 }  // namespace magda::media

--- a/magda/daw/media_db/MediaDbZeroShotTags.hpp
+++ b/magda/daw/media_db/MediaDbZeroShotTags.hpp
@@ -1,13 +1,19 @@
 // CLAP zero-shot tagging for the media DB indexer (issue #1319).
 //
 // Mirrors prototypes/media_db/src/media_db/tags.py — a curated list of
-// short descriptive prompts ("a kick drum", "a synth pad", "a riser") plus
-// a coarse instrument-family map. The C++ port runs each prompt through the
-// loaded ClapTextEncoder + RobertaTokenizer once at construction and keeps a
-// [K, 512] row-major matrix of L2-normalized prompt embeddings; scoring an
-// audio embedding is then a dense matrix-vector dot product (~K * 512
-// multiply-adds — negligible against the encoder pass that produced the
-// audio embedding).
+// short instrument labels ("a kick drum", "a synth pad", "a riser") plus a
+// coarse instrument-family map. The C++ port wraps each label with the
+// "the sound of {label}" prompt template before running it through the
+// loaded ClapTextEncoder + RobertaTokenizer, exactly like the prototype's
+// PROMPT_TEMPLATE; the resulting [K, 512] row-major matrix of L2-normalized
+// embeddings is cached. Scoring an audio embedding is then a dense matrix-
+// vector dot product (~K * 512 multiply-adds — negligible against the
+// encoder pass that produced the audio embedding).
+//
+// Labels (NOT prompts) are what the tagger returns and what the indexer
+// writes into media_tag. The prompt template is an internal detail of the
+// embedding step so the stored tags stay terse and FTS isn't polluted with
+// "the sound of" boilerplate on every match.
 //
 // Family precedence matches derive.py:232 — the indexer's path hint wins;
 // this module only contributes "what does CLAP think it is" when the path
@@ -37,33 +43,35 @@ constexpr float kZeroShotTagThreshold = 0.28F;
 // than to mis-classify a borderline file.
 constexpr float kZeroShotFamilyFloor = 0.20F;
 
-// The taxonomy. Public so tests can assert against it directly without
-// reaching into the .cpp. Order is irrelevant; the index into the prompt
-// list isn't persisted anywhere (tag strings are what the DB stores).
-const std::vector<std::string>& defaultZeroShotPrompts();
+// The taxonomy as short labels suitable for storing in media_tag.tag. The
+// embedding step wraps each label with kPromptTemplate internally before
+// running it through the text encoder; callers never see the "the sound of"
+// form. Order is irrelevant — the index into the list isn't persisted.
+const std::vector<std::string>& defaultZeroShotLabels();
 
-// Coarse family for each prompt above. "texture" is a sentinel that excludes
-// the prompt from family inference (see header preamble).
-const std::string& familyForPrompt(const std::string& prompt);
+// Coarse family for each label above. "texture" is a sentinel that excludes
+// the label from family inference (see header preamble). Returns "unknown"
+// for labels not in the map.
+const std::string& familyForLabel(const std::string& label);
 
 // Apply CLAP's cosine score and produce the family override. Returns the
-// empty string when no non-texture tag clears kZeroShotFamilyFloor; the
+// empty string when no non-texture label clears kZeroShotFamilyFloor; the
 // caller keeps the existing family ("unknown" or the path hint) in that
-// case. `topTags` is expected to be sorted by descending confidence.
-std::string familyFromTopTags(const std::vector<std::pair<std::string, float>>& topTags);
+// case. `topLabels` is expected to be sorted by descending confidence.
+std::string familyFromTopLabels(const std::vector<std::pair<std::string, float>>& topLabels);
 
-// Loads the prompt list, tokenizes each, runs them through the text
-// encoder, and caches the result as a row-major [K, 512] matrix. K is
-// fixed at construction; the matrix is roughly ~80 KB so the one-time cost
-// is trivial relative to the ORT session itself.
+// Loads the labels, wraps each in the prompt template, tokenizes, runs
+// through the text encoder, and caches the result as a row-major [K, 512]
+// matrix. K is fixed at construction; the matrix is roughly ~80 KB so the
+// one-time cost is trivial relative to the ORT session itself.
 //
-// Throws std::runtime_error if any prompt fails to embed — the indexer
+// Throws std::runtime_error if any label fails to embed — the indexer
 // catches and degrades to path-only tagging in that case.
 class ZeroShotTagger {
   public:
     ZeroShotTagger(ClapTextEncoder& textEncoder, RobertaTokenizer& tokenizer);
     ZeroShotTagger(ClapTextEncoder& textEncoder, RobertaTokenizer& tokenizer,
-                   std::vector<std::string> prompts);
+                   std::vector<std::string> labels);
 
     ZeroShotTagger(const ZeroShotTagger&) = delete;
     ZeroShotTagger& operator=(const ZeroShotTagger&) = delete;
@@ -72,8 +80,10 @@ class ZeroShotTagger {
     ~ZeroShotTagger() = default;
 
     // Score a single audio embedding (must be L2-normalized; the audio
-    // encoder already guarantees that) against every prompt. Returns tags
-    // whose cosine score >= threshold, sorted by descending score.
+    // encoder already guarantees that) against every cached prompt. Returns
+    // (label, score) pairs whose cosine score >= threshold, sorted by
+    // descending score. The labels returned are the terse form (suitable
+    // for media_tag.tag), not the wrapped prompt.
     //
     // The audio embedding's dim must equal the cached embedding dim
     // (defaults to 512 for CLAP). Mismatched inputs throw.
@@ -81,13 +91,13 @@ class ZeroShotTagger {
         const float* audioEmbedding, std::size_t dim,
         float threshold = kZeroShotTagThreshold) const;
 
-    [[nodiscard]] std::size_t numPrompts() const noexcept;
+    [[nodiscard]] std::size_t numLabels() const noexcept;
     [[nodiscard]] std::size_t embeddingDim() const noexcept;
-    [[nodiscard]] const std::vector<std::string>& prompts() const noexcept;
+    [[nodiscard]] const std::vector<std::string>& labels() const noexcept;
 
   private:
-    std::vector<std::string> prompts_;  // K
-    std::vector<float> promptMatrix_;   // row-major [K, dim_], L2-normalized
+    std::vector<std::string> labels_;  // K — short, suitable for media_tag.tag
+    std::vector<float> promptMatrix_;  // row-major [K, dim_], L2-normalized
     std::size_t dim_ = 0;
 };
 

--- a/magda/daw/media_db/MediaDbZeroShotTags.hpp
+++ b/magda/daw/media_db/MediaDbZeroShotTags.hpp
@@ -1,0 +1,94 @@
+// CLAP zero-shot tagging for the media DB indexer (issue #1319).
+//
+// Mirrors prototypes/media_db/src/media_db/tags.py — a curated list of
+// short descriptive prompts ("a kick drum", "a synth pad", "a riser") plus
+// a coarse instrument-family map. The C++ port runs each prompt through the
+// loaded ClapTextEncoder + RobertaTokenizer once at construction and keeps a
+// [K, 512] row-major matrix of L2-normalized prompt embeddings; scoring an
+// audio embedding is then a dense matrix-vector dot product (~K * 512
+// multiply-adds — negligible against the encoder pass that produced the
+// audio embedding).
+//
+// Family precedence matches derive.py:232 — the indexer's path hint wins;
+// this module only contributes "what does CLAP think it is" when the path
+// gave no hint. Texture descriptors ("warm sound", "dark sound") are
+// intentionally excluded from the family fallback so a "warm sound" tag can
+// never silently outrank an actual instrument tag.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace magda::media {
+
+class ClapTextEncoder;
+class RobertaTokenizer;
+
+// Cosine threshold for emitting a tag into media_tag. Lower than the human
+// "obviously the right tag" bar — the FTS+filter UI lets recall pay off, and
+// per-tag calibration is a follow-up once we can see real recall gaps.
+constexpr float kZeroShotTagThreshold = 0.28F;
+
+// Floor for promoting a CLAP top-tag to a family. Matches derive.py's
+// FAMILY_TAG_FLOOR: be conservative — better to leave family as "unknown"
+// than to mis-classify a borderline file.
+constexpr float kZeroShotFamilyFloor = 0.20F;
+
+// The taxonomy. Public so tests can assert against it directly without
+// reaching into the .cpp. Order is irrelevant; the index into the prompt
+// list isn't persisted anywhere (tag strings are what the DB stores).
+const std::vector<std::string>& defaultZeroShotPrompts();
+
+// Coarse family for each prompt above. "texture" is a sentinel that excludes
+// the prompt from family inference (see header preamble).
+const std::string& familyForPrompt(const std::string& prompt);
+
+// Apply CLAP's cosine score and produce the family override. Returns the
+// empty string when no non-texture tag clears kZeroShotFamilyFloor; the
+// caller keeps the existing family ("unknown" or the path hint) in that
+// case. `topTags` is expected to be sorted by descending confidence.
+std::string familyFromTopTags(const std::vector<std::pair<std::string, float>>& topTags);
+
+// Loads the prompt list, tokenizes each, runs them through the text
+// encoder, and caches the result as a row-major [K, 512] matrix. K is
+// fixed at construction; the matrix is roughly ~80 KB so the one-time cost
+// is trivial relative to the ORT session itself.
+//
+// Throws std::runtime_error if any prompt fails to embed — the indexer
+// catches and degrades to path-only tagging in that case.
+class ZeroShotTagger {
+  public:
+    ZeroShotTagger(ClapTextEncoder& textEncoder, RobertaTokenizer& tokenizer);
+    ZeroShotTagger(ClapTextEncoder& textEncoder, RobertaTokenizer& tokenizer,
+                   std::vector<std::string> prompts);
+
+    ZeroShotTagger(const ZeroShotTagger&) = delete;
+    ZeroShotTagger& operator=(const ZeroShotTagger&) = delete;
+    ZeroShotTagger(ZeroShotTagger&&) noexcept = default;
+    ZeroShotTagger& operator=(ZeroShotTagger&&) noexcept = default;
+    ~ZeroShotTagger() = default;
+
+    // Score a single audio embedding (must be L2-normalized; the audio
+    // encoder already guarantees that) against every prompt. Returns tags
+    // whose cosine score >= threshold, sorted by descending score.
+    //
+    // The audio embedding's dim must equal the cached embedding dim
+    // (defaults to 512 for CLAP). Mismatched inputs throw.
+    std::vector<std::pair<std::string, float>> scoreEmbedding(
+        const float* audioEmbedding, std::size_t dim,
+        float threshold = kZeroShotTagThreshold) const;
+
+    [[nodiscard]] std::size_t numPrompts() const noexcept;
+    [[nodiscard]] std::size_t embeddingDim() const noexcept;
+    [[nodiscard]] const std::vector<std::string>& prompts() const noexcept;
+
+  private:
+    std::vector<std::string> prompts_;  // K
+    std::vector<float> promptMatrix_;   // row-major [K, dim_], L2-normalized
+    std::size_t dim_ = 0;
+};
+
+}  // namespace magda::media

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
@@ -1734,13 +1734,15 @@ void MediaDbBrowserContent::startAnalyzingFileIds(std::vector<std::int64_t> file
             magda::media::MediaDatabase bgDb(magda::media::MediaDbContext::getInstance().dbPath());
             auto& ctx = magda::media::MediaDbContext::getInstance();
             auto* encoder = ctx.audioEncoder();
-            // Text encoder + tokenizer are nullable; when both are loaded the
-            // indexer also writes CLAP zero-shot tags during the embedding
-            // pass (issue #1319). They share the same ORT/tokenizer state
-            // the query path uses, so loading is amortised across the app.
-            auto* textEncoder = ctx.textEncoder();
-            auto* tokenizer = ctx.tokenizer();
-            magda::media::MediaDbIndexer indexer(bgDb, encoder, textEncoder, tokenizer);
+            // The indexer writes CLAP zero-shot tags during the embedding
+            // pass when the text encoder + tokenizer are available (issue
+            // #1319). Pass providers rather than already-loaded pointers so
+            // the ~480 MB text-model load is deferred until the indexer
+            // actually has pending audio rows to embed.
+            magda::media::MediaDbIndexer indexer(
+                bgDb, encoder,
+                []() { return magda::media::MediaDbContext::getInstance().textEncoder(); },
+                []() { return magda::media::MediaDbContext::getInstance().tokenizer(); });
             indexer.setShouldCancel([cancelToken]() { return cancelToken && cancelToken->load(); });
             indexer.setFailureCallback(
                 [](const std::filesystem::path& failedPath, const std::string& reason) {
@@ -2220,9 +2222,10 @@ void MediaDbBrowserContent::startIndexingWithOptions(
             magda::media::MediaDatabase bgDb(magda::media::MediaDbContext::getInstance().dbPath());
             auto& ctx = magda::media::MediaDbContext::getInstance();
             auto* encoder = ctx.audioEncoder();
-            auto* textEncoder = ctx.textEncoder();
-            auto* tokenizer = ctx.tokenizer();
-            magda::media::MediaDbIndexer indexer(bgDb, encoder, textEncoder, tokenizer);
+            magda::media::MediaDbIndexer indexer(
+                bgDb, encoder,
+                []() { return magda::media::MediaDbContext::getInstance().textEncoder(); },
+                []() { return magda::media::MediaDbContext::getInstance().tokenizer(); });
             indexer.setScanTagOptions(tagOptions);
             indexer.setShouldCancel([cancelToken]() { return cancelToken && cancelToken->load(); });
             indexer.setFailureCallback([&failureMutex, &failureCount,

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
@@ -1732,8 +1732,15 @@ void MediaDbBrowserContent::startAnalyzingFileIds(std::vector<std::int64_t> file
         juce::String finalStatus;
         try {
             magda::media::MediaDatabase bgDb(magda::media::MediaDbContext::getInstance().dbPath());
-            auto* encoder = magda::media::MediaDbContext::getInstance().audioEncoder();
-            magda::media::MediaDbIndexer indexer(bgDb, encoder);
+            auto& ctx = magda::media::MediaDbContext::getInstance();
+            auto* encoder = ctx.audioEncoder();
+            // Text encoder + tokenizer are nullable; when both are loaded the
+            // indexer also writes CLAP zero-shot tags during the embedding
+            // pass (issue #1319). They share the same ORT/tokenizer state
+            // the query path uses, so loading is amortised across the app.
+            auto* textEncoder = ctx.textEncoder();
+            auto* tokenizer = ctx.tokenizer();
+            magda::media::MediaDbIndexer indexer(bgDb, encoder, textEncoder, tokenizer);
             indexer.setShouldCancel([cancelToken]() { return cancelToken && cancelToken->load(); });
             indexer.setFailureCallback(
                 [](const std::filesystem::path& failedPath, const std::string& reason) {
@@ -2211,8 +2218,11 @@ void MediaDbBrowserContent::startIndexingWithOptions(
                                  juce::String(path.string()));
         try {
             magda::media::MediaDatabase bgDb(magda::media::MediaDbContext::getInstance().dbPath());
-            auto* encoder = magda::media::MediaDbContext::getInstance().audioEncoder();
-            magda::media::MediaDbIndexer indexer(bgDb, encoder);
+            auto& ctx = magda::media::MediaDbContext::getInstance();
+            auto* encoder = ctx.audioEncoder();
+            auto* textEncoder = ctx.textEncoder();
+            auto* tokenizer = ctx.tokenizer();
+            magda::media::MediaDbIndexer indexer(bgDb, encoder, textEncoder, tokenizer);
             indexer.setScanTagOptions(tagOptions);
             indexer.setShouldCancel([cancelToken]() { return cancelToken && cancelToken->load(); });
             indexer.setFailureCallback([&failureMutex, &failureCount,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -119,6 +119,8 @@ set(TEST_SOURCES
     test_media_db_indexer.cpp
     # Media database (issue #768) — Phase E2: MediaDbQuery (hybrid search)
     test_media_db_query.cpp
+    # Media database (issue #1319) — CLAP zero-shot tagging
+    test_media_db_zero_shot_tags.cpp
 )
 
 # Create test executable

--- a/tests/test_media_db_zero_shot_tags.cpp
+++ b/tests/test_media_db_zero_shot_tags.cpp
@@ -1,0 +1,172 @@
+// Issue #1319 tests — CLAP zero-shot tagger.
+//
+// Pure-function paths (familyForPrompt, familyFromTopTags, prompt list
+// shape) run unconditionally; the matrix-build path needs the text encoder
+// + tokenizer so it's gated on MAGDA_MEDIA_DB_CLAP_TEXT_MODEL and
+// MAGDA_MEDIA_DB_TOKENIZER_JSON, matching the convention used by the
+// existing clap encoder / tokenizer tests.
+
+#include <algorithm>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+#include <set>
+#include <vector>
+
+#include "../magda/daw/media_db/ClapTextEncoder.hpp"
+#include "../magda/daw/media_db/MediaDbZeroShotTags.hpp"
+#include "../magda/daw/media_db/RobertaTokenizer.hpp"
+
+namespace fs = std::filesystem;
+using magda::media::ClapTextEncoder;
+using magda::media::defaultZeroShotPrompts;
+using magda::media::familyForPrompt;
+using magda::media::familyFromTopTags;
+using magda::media::kZeroShotFamilyFloor;
+using magda::media::RobertaTokenizer;
+using magda::media::ZeroShotTagger;
+
+TEST_CASE("default prompt list covers expected families", "[media_db][zero-shot]") {
+    const auto& prompts = defaultZeroShotPrompts();
+    REQUIRE(prompts.size() >= 30);
+
+    // Spot-check the families we care about most. The set must be a
+    // superset of these — concrete prompt strings can change without
+    // breaking the test as long as the family map keeps producing the
+    // expected coarse buckets.
+    std::set<std::string> families;
+    for (const auto& p : prompts) {
+        families.insert(familyForPrompt(p));
+    }
+    for (const auto& expected : {"drum", "bass", "lead", "pad", "keys", "guitar", "orchestral",
+                                 "vocal", "fx", "texture"}) {
+        REQUIRE(families.count(expected) == 1);
+    }
+}
+
+TEST_CASE("familyForPrompt returns unknown for strings not in the map", "[media_db][zero-shot]") {
+    REQUIRE(familyForPrompt("not a real prompt") == "unknown");
+    REQUIRE(familyForPrompt("") == "unknown");
+}
+
+TEST_CASE("familyFromTopTags picks the top non-texture instrument tag", "[media_db][zero-shot]") {
+    using V = std::vector<std::pair<std::string, float>>;
+
+    SECTION("top instrument tag wins") {
+        V tags{
+            {"the sound of a synth pad", 0.42F},
+            {"the sound of a warm sound", 0.30F},
+        };
+        REQUIRE(familyFromTopTags(tags) == "pad");
+    }
+
+    SECTION("texture is skipped even when it scores higher") {
+        // Texture is sorted first because score is higher, but the function
+        // must walk past it to find the real instrument family.
+        V tags{
+            {"the sound of a warm sound", 0.55F},
+            {"the sound of a synth pad", 0.40F},
+        };
+        REQUIRE(familyFromTopTags(tags) == "pad");
+    }
+
+    SECTION("returns empty when nothing clears the floor") {
+        V tags{
+            {"the sound of a synth pad", kZeroShotFamilyFloor - 0.01F},
+            {"the sound of a kick drum", 0.05F},
+        };
+        REQUIRE(familyFromTopTags(tags).empty());
+    }
+
+    SECTION("returns empty when only texture tags clear the floor") {
+        V tags{
+            {"the sound of a warm sound", 0.40F},
+            {"the sound of a dark sound", 0.30F},
+        };
+        REQUIRE(familyFromTopTags(tags).empty());
+    }
+
+    SECTION("empty input returns empty") {
+        REQUIRE(familyFromTopTags({}).empty());
+    }
+
+    SECTION("unknown-family tags are skipped") {
+        V tags{
+            {"unknown prompt not in map", 0.90F},
+            {"the sound of a vocal", 0.30F},
+        };
+        REQUIRE(familyFromTopTags(tags) == "vocal");
+    }
+
+    SECTION("first non-texture above floor wins, not the absolute top") {
+        // Below-floor instrument tag is ignored even though it's first.
+        V tags{
+            {"the sound of a kick drum", kZeroShotFamilyFloor - 0.001F},
+            {"the sound of a vocal", kZeroShotFamilyFloor + 0.05F},
+        };
+        // Sorted descending — kick is "first" but below floor, so we stop.
+        // (This matches the prototype's behaviour: the floor short-circuits
+        // the walk before later candidates can be considered.)
+        REQUIRE(familyFromTopTags(tags).empty());
+    }
+}
+
+TEST_CASE("ZeroShotTagger builds prompt matrix and scores audio embeddings",
+          "[media_db][zero-shot][needs-model]") {
+    const char* textModelPath = std::getenv("MAGDA_MEDIA_DB_CLAP_TEXT_MODEL");
+    const char* tokenizerPath = std::getenv("MAGDA_MEDIA_DB_TOKENIZER_JSON");
+    if (textModelPath == nullptr || !fs::exists(textModelPath) || tokenizerPath == nullptr ||
+        !fs::exists(tokenizerPath)) {
+        SKIP("set MAGDA_MEDIA_DB_CLAP_TEXT_MODEL + MAGDA_MEDIA_DB_TOKENIZER_JSON to run this test");
+    }
+
+    ClapTextEncoder textEncoder(textModelPath);
+    RobertaTokenizer tokenizer(tokenizerPath);
+
+    ZeroShotTagger tagger(textEncoder, tokenizer);
+    REQUIRE(tagger.numPrompts() == defaultZeroShotPrompts().size());
+    REQUIRE(tagger.embeddingDim() == 512);
+
+    // Score a zero vector — every cosine is 0, so the tagger should emit no
+    // tags at the default threshold. This exercises the scoring math
+    // independently of which audio CLAP would actually recognize.
+    std::vector<float> zeros(tagger.embeddingDim(), 0.0F);
+    const auto hitsAtThreshold = tagger.scoreEmbedding(zeros.data(), zeros.size());
+    REQUIRE(hitsAtThreshold.empty());
+
+    // Same vector with a negative threshold returns every prompt — every
+    // cosine is 0 which exceeds -1.
+    const auto allHits = tagger.scoreEmbedding(zeros.data(), zeros.size(), -1.0F);
+    REQUIRE(allHits.size() == tagger.numPrompts());
+
+    // Take a prompt embedding and use it as the "audio" embedding — its
+    // cosine with itself must be 1.0 (within float tolerance) and the
+    // prompt's own string must appear first in the sorted hits.
+    const auto enc = tokenizer.encode("the sound of a kick drum");
+    auto kickVec = textEncoder.embedTokens(enc.inputIds, enc.attentionMask);
+    REQUIRE(kickVec.size() == tagger.embeddingDim());
+
+    const auto hits = tagger.scoreEmbedding(kickVec.data(), kickVec.size(), 0.0F);
+    REQUIRE_FALSE(hits.empty());
+    REQUIRE(hits.front().first == "the sound of a kick drum");
+    REQUIRE(hits.front().second == Catch::Approx(1.0F).margin(1e-3));
+}
+
+TEST_CASE("ZeroShotTagger rejects mismatched embedding dims",
+          "[media_db][zero-shot][needs-model]") {
+    const char* textModelPath = std::getenv("MAGDA_MEDIA_DB_CLAP_TEXT_MODEL");
+    const char* tokenizerPath = std::getenv("MAGDA_MEDIA_DB_TOKENIZER_JSON");
+    if (textModelPath == nullptr || !fs::exists(textModelPath) || tokenizerPath == nullptr ||
+        !fs::exists(tokenizerPath)) {
+        SKIP("set MAGDA_MEDIA_DB_CLAP_TEXT_MODEL + MAGDA_MEDIA_DB_TOKENIZER_JSON to run this test");
+    }
+
+    ClapTextEncoder textEncoder(textModelPath);
+    RobertaTokenizer tokenizer(tokenizerPath);
+    ZeroShotTagger tagger(textEncoder, tokenizer);
+
+    std::vector<float> wrongDim(tagger.embeddingDim() / 2, 0.0F);
+    REQUIRE_THROWS(tagger.scoreEmbedding(wrongDim.data(), wrongDim.size()));
+}

--- a/tests/test_media_db_zero_shot_tags.cpp
+++ b/tests/test_media_db_zero_shot_tags.cpp
@@ -1,18 +1,17 @@
 // Issue #1319 tests — CLAP zero-shot tagger.
 //
-// Pure-function paths (familyForPrompt, familyFromTopTags, prompt list
+// Pure-function paths (familyForLabel, familyFromTopLabels, label list
 // shape) run unconditionally; the matrix-build path needs the text encoder
 // + tokenizer so it's gated on MAGDA_MEDIA_DB_CLAP_TEXT_MODEL and
 // MAGDA_MEDIA_DB_TOKENIZER_JSON, matching the convention used by the
 // existing clap encoder / tokenizer tests.
 
-#include <algorithm>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <cmath>
 #include <cstdlib>
 #include <filesystem>
 #include <set>
+#include <string>
 #include <vector>
 
 #include "../magda/daw/media_db/ClapTextEncoder.hpp"
@@ -21,24 +20,33 @@
 
 namespace fs = std::filesystem;
 using magda::media::ClapTextEncoder;
-using magda::media::defaultZeroShotPrompts;
-using magda::media::familyForPrompt;
-using magda::media::familyFromTopTags;
+using magda::media::defaultZeroShotLabels;
+using magda::media::familyForLabel;
+using magda::media::familyFromTopLabels;
 using magda::media::kZeroShotFamilyFloor;
 using magda::media::RobertaTokenizer;
 using magda::media::ZeroShotTagger;
 
-TEST_CASE("default prompt list covers expected families", "[media_db][zero-shot]") {
-    const auto& prompts = defaultZeroShotPrompts();
-    REQUIRE(prompts.size() >= 30);
+TEST_CASE("default label list is terse and covers expected families", "[media_db][zero-shot]") {
+    const auto& labels = defaultZeroShotLabels();
+    REQUIRE(labels.size() >= 30);
+
+    // Labels must NOT carry the "the sound of " prompt wrapper — that
+    // wrapping is an internal detail of the embedding step, and storing the
+    // wrapped form would pollute media_tag and the FTS index. Asserting
+    // this directly so future taxonomy edits don't accidentally reintroduce
+    // the wrapper.
+    for (const auto& label : labels) {
+        REQUIRE(label.find("the sound of ") == std::string::npos);
+    }
 
     // Spot-check the families we care about most. The set must be a
-    // superset of these — concrete prompt strings can change without
+    // superset of these — concrete label strings can change without
     // breaking the test as long as the family map keeps producing the
     // expected coarse buckets.
     std::set<std::string> families;
-    for (const auto& p : prompts) {
-        families.insert(familyForPrompt(p));
+    for (const auto& label : labels) {
+        families.insert(familyForLabel(label));
     }
     for (const auto& expected : {"drum", "bass", "lead", "pad", "keys", "guitar", "orchestral",
                                  "vocal", "fx", "texture"}) {
@@ -46,70 +54,73 @@ TEST_CASE("default prompt list covers expected families", "[media_db][zero-shot]
     }
 }
 
-TEST_CASE("familyForPrompt returns unknown for strings not in the map", "[media_db][zero-shot]") {
-    REQUIRE(familyForPrompt("not a real prompt") == "unknown");
-    REQUIRE(familyForPrompt("") == "unknown");
+TEST_CASE("familyForLabel returns unknown for strings not in the map", "[media_db][zero-shot]") {
+    REQUIRE(familyForLabel("not a real label") == "unknown");
+    REQUIRE(familyForLabel("") == "unknown");
+    // The wrapped prompt form is explicitly NOT in the map — a regression
+    // here would mean someone re-keyed the map on prompts instead of labels.
+    REQUIRE(familyForLabel("the sound of a kick drum") == "unknown");
 }
 
-TEST_CASE("familyFromTopTags picks the top non-texture instrument tag", "[media_db][zero-shot]") {
+TEST_CASE("familyFromTopLabels picks the top non-texture instrument tag", "[media_db][zero-shot]") {
     using V = std::vector<std::pair<std::string, float>>;
 
-    SECTION("top instrument tag wins") {
+    SECTION("top instrument label wins") {
         V tags{
-            {"the sound of a synth pad", 0.42F},
-            {"the sound of a warm sound", 0.30F},
+            {"a synth pad", 0.42F},
+            {"a warm sound", 0.30F},
         };
-        REQUIRE(familyFromTopTags(tags) == "pad");
+        REQUIRE(familyFromTopLabels(tags) == "pad");
     }
 
     SECTION("texture is skipped even when it scores higher") {
         // Texture is sorted first because score is higher, but the function
         // must walk past it to find the real instrument family.
         V tags{
-            {"the sound of a warm sound", 0.55F},
-            {"the sound of a synth pad", 0.40F},
+            {"a warm sound", 0.55F},
+            {"a synth pad", 0.40F},
         };
-        REQUIRE(familyFromTopTags(tags) == "pad");
+        REQUIRE(familyFromTopLabels(tags) == "pad");
     }
 
     SECTION("returns empty when nothing clears the floor") {
         V tags{
-            {"the sound of a synth pad", kZeroShotFamilyFloor - 0.01F},
-            {"the sound of a kick drum", 0.05F},
+            {"a synth pad", kZeroShotFamilyFloor - 0.01F},
+            {"a kick drum", 0.05F},
         };
-        REQUIRE(familyFromTopTags(tags).empty());
+        REQUIRE(familyFromTopLabels(tags).empty());
     }
 
-    SECTION("returns empty when only texture tags clear the floor") {
+    SECTION("returns empty when only texture labels clear the floor") {
         V tags{
-            {"the sound of a warm sound", 0.40F},
-            {"the sound of a dark sound", 0.30F},
+            {"a warm sound", 0.40F},
+            {"a dark sound", 0.30F},
         };
-        REQUIRE(familyFromTopTags(tags).empty());
+        REQUIRE(familyFromTopLabels(tags).empty());
     }
 
     SECTION("empty input returns empty") {
-        REQUIRE(familyFromTopTags({}).empty());
+        REQUIRE(familyFromTopLabels({}).empty());
     }
 
-    SECTION("unknown-family tags are skipped") {
+    SECTION("unknown-family labels are skipped") {
         V tags{
-            {"unknown prompt not in map", 0.90F},
-            {"the sound of a vocal", 0.30F},
+            {"unknown label not in map", 0.90F},
+            {"a vocal", 0.30F},
         };
-        REQUIRE(familyFromTopTags(tags) == "vocal");
+        REQUIRE(familyFromTopLabels(tags) == "vocal");
     }
 
     SECTION("first non-texture above floor wins, not the absolute top") {
-        // Below-floor instrument tag is ignored even though it's first.
+        // Below-floor instrument label is ignored even though it's first.
         V tags{
-            {"the sound of a kick drum", kZeroShotFamilyFloor - 0.001F},
-            {"the sound of a vocal", kZeroShotFamilyFloor + 0.05F},
+            {"a kick drum", kZeroShotFamilyFloor - 0.001F},
+            {"a vocal", kZeroShotFamilyFloor + 0.05F},
         };
         // Sorted descending — kick is "first" but below floor, so we stop.
-        // (This matches the prototype's behaviour: the floor short-circuits
-        // the walk before later candidates can be considered.)
-        REQUIRE(familyFromTopTags(tags).empty());
+        // (Matches the prototype's behaviour: the floor short-circuits the
+        // walk before later candidates can be considered.)
+        REQUIRE(familyFromTopLabels(tags).empty());
     }
 }
 
@@ -126,31 +137,31 @@ TEST_CASE("ZeroShotTagger builds prompt matrix and scores audio embeddings",
     RobertaTokenizer tokenizer(tokenizerPath);
 
     ZeroShotTagger tagger(textEncoder, tokenizer);
-    REQUIRE(tagger.numPrompts() == defaultZeroShotPrompts().size());
+    REQUIRE(tagger.numLabels() == defaultZeroShotLabels().size());
     REQUIRE(tagger.embeddingDim() == 512);
 
     // Score a zero vector — every cosine is 0, so the tagger should emit no
-    // tags at the default threshold. This exercises the scoring math
+    // tags at the default threshold. Exercises the scoring math
     // independently of which audio CLAP would actually recognize.
     std::vector<float> zeros(tagger.embeddingDim(), 0.0F);
     const auto hitsAtThreshold = tagger.scoreEmbedding(zeros.data(), zeros.size());
     REQUIRE(hitsAtThreshold.empty());
 
-    // Same vector with a negative threshold returns every prompt — every
+    // Same vector with a negative threshold returns every label — every
     // cosine is 0 which exceeds -1.
     const auto allHits = tagger.scoreEmbedding(zeros.data(), zeros.size(), -1.0F);
-    REQUIRE(allHits.size() == tagger.numPrompts());
+    REQUIRE(allHits.size() == tagger.numLabels());
 
-    // Take a prompt embedding and use it as the "audio" embedding — its
-    // cosine with itself must be 1.0 (within float tolerance) and the
-    // prompt's own string must appear first in the sorted hits.
+    // Take the wrapped prompt embedding for "a kick drum" and use it as
+    // the "audio" embedding — its cosine with itself must be ~1.0 and the
+    // returned label must be the terse form (not the wrapped prompt).
     const auto enc = tokenizer.encode("the sound of a kick drum");
     auto kickVec = textEncoder.embedTokens(enc.inputIds, enc.attentionMask);
     REQUIRE(kickVec.size() == tagger.embeddingDim());
 
     const auto hits = tagger.scoreEmbedding(kickVec.data(), kickVec.size(), 0.0F);
     REQUIRE_FALSE(hits.empty());
-    REQUIRE(hits.front().first == "the sound of a kick drum");
+    REQUIRE(hits.front().first == "a kick drum");
     REQUIRE(hits.front().second == Catch::Approx(1.0F).margin(1e-3));
 }
 


### PR DESCRIPTION
## Summary

- The C++ indexer wrote tags only from path/filename tokens; samples with uninformative names got no semantic tags at all, and `media_file.family` defaulted to `unknown` outside recognised folder structures. The CLAP audio encoder ran for similarity search but was never projected against text prompts during indexing.
- Adds a curated 40-prompt taxonomy mirroring `prototypes/media_db/src/media_db/tags.py`, embeds the prompts once on first use via the existing `ClapTextEncoder` + `RobertaTokenizer`, and scores each audio embedding against the cached `[K, 512]` prompt matrix during the post-scan embedding pass. Top hits above 0.28 are written to `media_tag` with `source_model='clap-zeroshot'`; `media_fts` is refreshed in the same transaction so tag-text search picks them up.
- `media_file.family` is overridden from the top non-texture CLAP tag only when the path-derived family was `unknown` — preserves the existing precedence rule (path > CLAP > unknown). Texture descriptors (`"a warm sound"` etc.) can still emit a tag but never set the family.
- Tagger is lazily initialised; when the text encoder / tokenizer aren't loaded the indexer keeps producing audio embeddings and skips tagging without per-file noise. Init failures are reported once via the existing failure callback.

Closes #1319.

## Test plan

- [x] `make test-build` — debug test binary links cleanly
- [x] `./tests/magda_tests "[media_db][zero-shot]"` — 3 hermetic cases pass, 2 model-gated cases skip with `MAGDA_MEDIA_DB_CLAP_TEXT_MODEL` / `MAGDA_MEDIA_DB_TOKENIZER_JSON` instructions
- [x] `./tests/magda_tests "[media_db]"` — 74 cases pass, no regressions in existing scan / indexer / query suites
- [x] `make debug` — main app links cleanly with the new indexer DI
- [ ] **Needs a manual rescan with the Sample Tagger models installed** to confirm `clap-zeroshot` rows appear in `media_tag` and that tag-text search surfaces semantically-named samples that filename-only tagging missed
- [ ] **Spot-check a folder of uninformatively-named samples** (`Sample01.wav`, numeric IDs) — should now carry CLAP tags and a non-`unknown` family

## Notes

- Branch is based on `dev/0.9.0`, not `main` — the media DB code only exists there.
- Thresholds (`kZeroShotTagThreshold = 0.28F`, `kZeroShotFamilyFloor = 0.20F`) are `constexpr` in `MediaDbZeroShotTags.hpp` so per-tag calibration is a follow-up without ABI risk.
- Out of scope (matches the issue): few-shot anchor tagging, per-prompt threshold calibration.