### PR TITLE
Media DB UI polish 2

### DIFF
--- a/magda/daw/core/PresetManager.cpp
+++ b/magda/daw/core/PresetManager.cpp
@@ -276,6 +276,40 @@ bool PresetManager::renameChainPreset(const juce::String& oldName, const juce::S
     return renamePresetFile(getPresetsDirectory(), source, dest, lastError_);
 }
 
+std::optional<PresetManager::PresetRef> PresetManager::classifyPresetFile(
+    const juce::File& file) const {
+    if (!file.hasFileExtension(kPresetExtension)) {
+        return std::nullopt;
+    }
+
+    // Relative path from a preset subtree, normalised to forward slashes with
+    // the .mps extension stripped — the form the load APIs accept.
+    auto relName = [&file](const juce::File& base) {
+        auto rel = file.getRelativePathFrom(base).replaceCharacter('\\', '/');
+        if (rel.endsWithIgnoreCase(kPresetExtension)) {
+            rel = rel.dropLastCharacters(juce::String(kPresetExtension).length());
+        }
+        return rel;
+    };
+
+    if (file.isAChildOf(getChainsDirectory())) {
+        return PresetRef{PresetRef::Kind::Chain, relName(getChainsDirectory()), {}};
+    }
+    if (file.isAChildOf(getRacksDirectory())) {
+        return PresetRef{PresetRef::Kind::Rack, relName(getRacksDirectory()), {}};
+    }
+    if (file.isAChildOf(getDevicesDirectory())) {
+        const auto rel = relName(getDevicesDirectory());
+        const int slash = rel.indexOfChar('/');
+        if (slash <= 0) {
+            return std::nullopt;  // a device preset must live under a plugin folder
+        }
+        return PresetRef{PresetRef::Kind::Device, rel.substring(slash + 1),
+                         rel.substring(0, slash)};
+    }
+    return std::nullopt;
+}
+
 // ============================================================================
 // Rack Presets
 // ============================================================================

--- a/magda/daw/core/PresetManager.hpp
+++ b/magda/daw/core/PresetManager.hpp
@@ -2,6 +2,7 @@
 
 #include <juce_core/juce_core.h>
 
+#include <optional>
 #include <unordered_map>
 
 #include "DeviceInfo.hpp"
@@ -152,6 +153,34 @@ class PresetManager {
     /** @brief Rename a device preset. Fails if the destination already exists. */
     bool renameDevicePreset(const juce::String& pluginFolder, const juce::String& oldRelativePath,
                             const juce::String& newRelativePath);
+
+    // ========================================================================
+    // Preset Classification
+    // ========================================================================
+
+    /**
+     * @brief A .mps preset file resolved into the components the load APIs need.
+     *
+     * For Chain/Rack, `name` is the relative preset name (forward-slash,
+     * no extension) accepted by loadChainPreset / loadRackPreset. For Device,
+     * `pluginFolder` is the first segment under Devices/ and `name` is the
+     * remaining relative path accepted by loadDevicePreset.
+     */
+    struct PresetRef {
+        enum class Kind { Chain, Rack, Device };
+        Kind kind{};
+        juce::String name;
+        juce::String pluginFolder;  // device only; empty for chain/rack
+    };
+
+    /**
+     * @brief Classify a .mps file living under the presets tree.
+     *
+     * Returns nullopt when the file is not a .mps, sits outside
+     * Chains/Racks/Devices, or is a device preset not nested under a plugin
+     * folder (and so cannot be addressed by loadDevicePreset).
+     */
+    std::optional<PresetRef> classifyPresetFile(const juce::File& file) const;
 
     // ========================================================================
     // Suggested Preset Names

--- a/magda/daw/media_db/MediaDatabase.cpp
+++ b/magda/daw/media_db/MediaDatabase.cpp
@@ -80,6 +80,14 @@ void migrate(sqlite3* db) {
         execOrThrow(db, "ALTER TABLE media_file ADD COLUMN beat_mode_user INTEGER",
                     "migrate v7 beat_mode_user");
     }
+    // v8: preset rows. Without this column on an existing DB, indexing presets
+    // fails to prepare its INSERT and silently reports every preset as failed.
+    if (!columnExists(db, "media_file", "preset_kind")) {
+        execOrThrow(db,
+                    "ALTER TABLE media_file ADD COLUMN preset_kind TEXT "
+                    "CHECK (preset_kind IN ('chain','rack','device'))",
+                    "migrate v8 preset_kind");
+    }
 }
 
 }  // namespace

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
@@ -88,6 +88,38 @@ std::optional<std::string> selectedString(const juce::ComboBox& cb,
     return table[static_cast<size_t>(id - 1)].toStdString();
 }
 
+class IndexTagOptionsComponent final : public juce::Component {
+  public:
+    IndexTagOptionsComponent() {
+        addAndMakeVisible(includeRootFolderName_);
+        addAndMakeVisible(includePathNodes_);
+
+        includeRootFolderName_.setToggleState(true, juce::dontSendNotification);
+        includePathNodes_.setToggleState(false, juce::dontSendNotification);
+
+        setSize(280, 58);
+    }
+
+    bool includeRootFolderName() const {
+        return includeRootFolderName_.getToggleState();
+    }
+
+    bool includePathNodes() const {
+        return includePathNodes_.getToggleState();
+    }
+
+    void resized() override {
+        auto bounds = getLocalBounds();
+        includeRootFolderName_.setBounds(bounds.removeFromTop(24));
+        bounds.removeFromTop(6);
+        includePathNodes_.setBounds(bounds.removeFromTop(24));
+    }
+
+  private:
+    juce::ToggleButton includeRootFolderName_{"Use folder name"};
+    juce::ToggleButton includePathNodes_{"Use subfolder names"};
+};
+
 juce::String prettyDuration(std::optional<double> seconds) {
     if (!seconds) {
         return "-";
@@ -2057,38 +2089,28 @@ void MediaDbBrowserContent::startIndexing(const juce::File& dir,
                                             "Optional tags are written to each scanned media row.",
                                             juce::MessageBoxIconType::NoIcon);
         alert->addTextEditor("custom_tags", "", "Tags:");
-        juce::StringArray yesNo;
-        yesNo.add("No");
-        yesNo.add("Yes");
-        alert->addComboBox("folder_tag", yesNo, "Use folder name:");
-        alert->addComboBox("path_tags", yesNo, "Use subfolder names:");
-        if (auto* cb = alert->getComboBoxComponent("folder_tag")) {
-            cb->setSelectedId(2, juce::dontSendNotification);
-        }
-        if (auto* cb = alert->getComboBoxComponent("path_tags")) {
-            cb->setSelectedId(1, juce::dontSendNotification);
-        }
+        auto* tagOptionsComponent = new IndexTagOptionsComponent();
+        alert->addCustomComponent(tagOptionsComponent);
         alert->addButton("Start", 1, juce::KeyPress(juce::KeyPress::returnKey));
         alert->addButton("Cancel", 0, juce::KeyPress(juce::KeyPress::escapeKey));
 
         const juce::Component::SafePointer<MediaDbBrowserContent> self(this);
         alert->enterModalState(
-            true, juce::ModalCallbackFunction::create([alert, self, dir, mode](int result) mutable {
+            true, juce::ModalCallbackFunction::create([alert, tagOptionsComponent, self, dir,
+                                                       mode](int result) mutable {
                 if (result != 1) {
                     delete alert;
+                    delete tagOptionsComponent;
                     return;
                 }
 
                 magda::media::MediaDbIndexer::ScanTagOptions options;
                 options.root = std::filesystem::path(dir.getFullPathName().toStdString());
                 options.customTags = parseTags(alert->getTextEditorContents("custom_tags"));
-                if (auto* cb = alert->getComboBoxComponent("folder_tag")) {
-                    options.includeRootFolderName = cb->getSelectedId() == 2;
-                }
-                if (auto* cb = alert->getComboBoxComponent("path_tags")) {
-                    options.includePathNodes = cb->getSelectedId() == 2;
-                }
+                options.includeRootFolderName = tagOptionsComponent->includeRootFolderName();
+                options.includePathNodes = tagOptionsComponent->includePathNodes();
                 delete alert;
+                delete tagOptionsComponent;
 
                 if (self != nullptr) {
                     self->startIndexingWithOptions(dir, mode, std::move(options));

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
@@ -2089,6 +2089,9 @@ void MediaDbBrowserContent::startIndexing(const juce::File& dir,
                                             "Optional tags are written to each scanned media row.",
                                             juce::MessageBoxIconType::NoIcon);
         alert->addTextEditor("custom_tags", "", "Tags:");
+        // AlertWindow::addCustomComponent does NOT take ownership (it holds a
+        // plain Array<Component*>, not an OwnedArray), so this component must be
+        // deleted by us alongside the alert in every callback path below.
         auto* tagOptionsComponent = new IndexTagOptionsComponent();
         alert->addCustomComponent(tagOptionsComponent);
         alert->addButton("Start", 1, juce::KeyPress(juce::KeyPress::returnKey));

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
@@ -138,6 +138,46 @@ juce::String displayNameFor(const magda::media::QueryResult& result) {
     return juce::String(result.path.filename().string());
 }
 
+// A compact, branded chip used as the drag image for preset rows. macOS would
+// otherwise show the generic blank-document icon for an unregistered .mps; this
+// gives a clear, distinctive snapshot naming the preset(s) being dragged.
+juce::Image makePresetDragImage(const juce::StringArray& names) {
+    const juce::String text =
+        names.size() == 1 ? names[0] : (juce::String(names.size()) + " presets");
+    auto font = FontManager::getInstance().getUIFont(12.0F);
+    const int textW = juce::GlyphArrangement::getStringWidthInt(font, text);
+    const int padLeft = 26;  // room for the glyph
+    const int padRight = 12;
+    const int width = juce::jlimit(90, 260, padLeft + textW + padRight);
+    const int height = 26;
+
+    juce::Image img(juce::Image::ARGB, width, height, true);
+    juce::Graphics g(img);
+
+    auto bounds =
+        juce::Rectangle<float>(0.0F, 0.0F, static_cast<float>(width), static_cast<float>(height))
+            .reduced(0.5F);
+    g.setColour(DarkTheme::getColour(DarkTheme::SURFACE).withAlpha(0.96F));
+    g.fillRoundedRectangle(bounds, 6.0F);
+    g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_BLUE));
+    g.drawRoundedRectangle(bounds, 6.0F, 1.5F);
+
+    // Two offset squares read as a stacked "preset".
+    const float gy = static_cast<float>(height) * 0.5F;
+    g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_BLUE));
+    g.fillRoundedRectangle(8.0F, gy - 6.0F, 8.0F, 8.0F, 2.0F);
+    g.setColour(DarkTheme::getColour(DarkTheme::SURFACE).withAlpha(0.96F));
+    g.fillRoundedRectangle(11.0F, gy - 2.5F, 8.0F, 8.0F, 2.0F);
+    g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_BLUE));
+    g.drawRoundedRectangle(11.0F, gy - 2.5F, 8.0F, 8.0F, 2.0F, 1.0F);
+
+    g.setColour(DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
+    g.setFont(font);
+    g.drawText(text, juce::Rectangle<int>(padLeft, 0, width - padLeft - padRight, height),
+               juce::Justification::centredLeft, true);
+    return img;
+}
+
 std::filesystem::path normalizedPath(const std::filesystem::path& path) {
     return path.lexically_normal();
 }
@@ -727,16 +767,43 @@ class MediaDbBrowserContent::ResultsTableModel : public juce::TableListBoxModel 
             return {};
         }
         juce::StringArray paths;
+        juce::StringArray presetNames;
+        bool allPresets = true;
         for (int i = 0; i < selectedRows.size(); ++i) {
             const int row = selectedRows[i];
             if (row < 0 || row >= static_cast<int>(owner_.results_.size())) {
                 continue;
             }
-            paths.addIfNotAlreadyThere(
-                juce::String(owner_.results_[static_cast<size_t>(row)].path.string()));
+            const auto& result = owner_.results_[static_cast<size_t>(row)];
+            paths.addIfNotAlreadyThere(juce::String(result.path.string()));
+            if (result.kind == "preset") {
+                presetNames.add(displayNameFor(result));
+            } else {
+                allPresets = false;
+            }
         }
         if (paths.isEmpty()) {
             return {};
+        }
+
+        // Preset rows: drive a JUCE-internal drag with a clean, branded image on
+        // every platform. The in-app preset drop targets (track FX chain,
+        // arrangement) recognise the {type:"files"} payload, and presets aren't
+        // dragged out to Finder, so the OS file-drag route isn't needed here.
+        // This also avoids macOS showing the generic blank-document .mps icon.
+        if (allPresets) {
+            juce::Array<juce::var> pathArray;
+            for (const auto& p : paths)
+                pathArray.add(p);
+            auto* obj = new juce::DynamicObject();
+            obj->setProperty("type", juce::var("files"));
+            obj->setProperty("paths", juce::var(pathArray));
+            juce::var description(obj);
+            if (auto* container = juce::DragAndDropContainer::findParentDragContainerFor(&owner_)) {
+                container->startDragging(description, &owner_,
+                                         juce::ScaledImage(makePresetDragImage(presetNames)));
+            }
+            return {};  // we started the drag ourselves; suppress ListBox's default
         }
 #if JUCE_LINUX
         juce::Array<juce::var> pathArray;

--- a/magda/daw/ui/panels/content/MediaExplorerContent.cpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.cpp
@@ -95,22 +95,24 @@ class MediaExplorerContent::ThumbnailComponent : public juce::Component,
                                                  public juce::Timer {
   public:
     ThumbnailComponent() {
-        stopIndexingButton_.setButtonText("Stop");
-        stopIndexingButton_.setTooltip("Stop scanning after the current file");
-        stopIndexingButton_.setColour(juce::TextButton::buttonColourId,
-                                      DarkTheme::getColour(DarkTheme::SURFACE));
-        stopIndexingButton_.setColour(juce::TextButton::textColourOffId,
-                                      DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
-        stopIndexingButton_.setColour(juce::TextButton::buttonOnColourId,
-                                      DarkTheme::getColour(DarkTheme::SURFACE_HOVER));
-        stopIndexingButton_.setVisible(false);
-        stopIndexingButton_.onClick = [this]() {
-            stopIndexingButton_.setEnabled(false);
+        stopIndexingButton_ = std::make_unique<magda::SvgButton>(
+            "Stop Scan", BinaryData::server_stop_svg, BinaryData::server_stop_svgSize);
+        stopIndexingButton_->setTooltip("Stop scanning after the current file");
+        stopIndexingButton_->setOriginalColor(juce::Colour(0xffb3b3b3));
+        stopIndexingButton_->setNormalColor(DarkTheme::getColour(DarkTheme::TEXT_SECONDARY));
+        stopIndexingButton_->setHoverColor(DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
+        stopIndexingButton_->setPressedColor(DarkTheme::getColour(DarkTheme::ACCENT_BLUE));
+        stopIndexingButton_->setBorderColor(DarkTheme::getBorderColour());
+        stopIndexingButton_->setCornerRadius(5.0f);
+        stopIndexingButton_->setIconPadding(10.0f);
+        stopIndexingButton_->setVisible(false);
+        stopIndexingButton_->onClick = [this]() {
+            stopIndexingButton_->setEnabled(false);
             if (onStopIndexing) {
                 onStopIndexing();
             }
         };
-        addChildComponent(stopIndexingButton_);
+        addChildComponent(*stopIndexingButton_);
     }
 
     ~ThumbnailComponent() override {
@@ -213,7 +215,7 @@ class MediaExplorerContent::ThumbnailComponent : public juce::Component,
             g.setColour(DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
             g.setFont(FontManager::getInstance().getUIFont(11.0F));
             if (indexingActive_) {
-                bounds.removeFromRight(76);
+                bounds.removeFromRight(48);
             }
             g.drawFittedText(indexingStatus_, bounds.reduced(8), juce::Justification::centred, 3);
             return;
@@ -255,15 +257,19 @@ class MediaExplorerContent::ThumbnailComponent : public juce::Component,
 
     void resized() override {
         auto bounds = getLocalBounds().reduced(8, 6);
-        stopIndexingButton_.setBounds(bounds.removeFromRight(64));
+        if (stopIndexingButton_) {
+            stopIndexingButton_->setBounds(bounds.removeFromRight(38).reduced(1));
+        }
     }
 
   private:
     void updateStopIndexingButtonVisibility() {
         const bool showStop =
             indexingActive_ && indexingStatus_.isNotEmpty() && !currentFile_.existsAsFile();
-        stopIndexingButton_.setVisible(showStop);
-        stopIndexingButton_.setEnabled(showStop);
+        if (stopIndexingButton_) {
+            stopIndexingButton_->setVisible(showStop);
+            stopIndexingButton_->setEnabled(showStop);
+        }
     }
 
     void detachThumbnailListener() {
@@ -280,7 +286,7 @@ class MediaExplorerContent::ThumbnailComponent : public juce::Component,
     double playbackPosition_ = 0.0;
     juce::String indexingStatus_;
     bool indexingActive_ = false;
-    juce::TextButton stopIndexingButton_;
+    std::unique_ptr<magda::SvgButton> stopIndexingButton_;
 };
 
 //==============================================================================
@@ -1656,184 +1662,181 @@ void MediaExplorerContent::fileClicked(const juce::File& file, const juce::Mouse
             menu.addItem(3, "Index this folder");
         }
 
-        menu.showMenuAsync(
-            juce::PopupMenu::Options(), [this, path, file, alreadyIndexed](int result) {
-                if (result == 1) {
-                    auto favs = magda::Config::getInstance().getBrowserFavorites();
-                    favs.erase(std::remove(favs.begin(), favs.end(), path), favs.end());
-                    magda::Config::getInstance().setBrowserFavorites(favs);
-                    magda::Config::getInstance().save();
-                    sidebarComponent_->rebuildFavoriteButtons();
-                } else if (result == 2) {
-                    auto favs = magda::Config::getInstance().getBrowserFavorites();
-                    favs.push_back(path);
-                    magda::Config::getInstance().setBrowserFavorites(favs);
-                    magda::Config::getInstance().save();
-                    sidebarComponent_->rebuildFavoriteButtons();
-                } else if (result == 3 && dbBrowser_) {
-                    dbBrowser_->startIndexing(
-                        file, alreadyIndexed ? magda::media::MediaDbIndexer::Mode::ForceAll
-                                             : magda::media::MediaDbIndexer::Mode::Incremental);
-                } else if (result == 4 && dbBrowser_) {
-                    dbBrowser_->startIndexing(file, magda::media::MediaDbIndexer::Mode::OnlyNew);
-                } else if (result == 5 && dbBrowser_) {
-                    const auto folderName = file.getFileName();
-                    const auto fsPath = std::filesystem::path(file.getFullPathName().toStdString());
-                    juce::Component::SafePointer<MediaExplorerContent> self(this);
-                    juce::AlertWindow::showAsync(
-                        juce::MessageBoxOptions{}
-                            .withIconType(juce::MessageBoxIconType::WarningIcon)
-                            .withTitle("Remove folder from media library")
-                            .withMessage("Remove every indexed entry under \"" + folderName +
-                                         "\" from the media library?\n"
-                                         "Your audio files on disk are untouched.")
-                            .withButton("Remove")
-                            .withButton("Cancel"),
-                        [self, fsPath](int choice) {
-                            if (self == nullptr || choice != 1) {
-                                return;
-                            }
-                            magda::media::removeFolderFromLibrary(fsPath);
-                            if (self->dbBrowser_ != nullptr) {
-                                self->dbBrowser_->refresh();
-                            }
-                        });
-                } else if (result == 6 && dbBrowser_) {
-                    const auto fsPath = std::filesystem::path(file.getFullPathName().toStdString());
-                    juce::Component::SafePointer<MediaExplorerContent> self(this);
-                    moveFolderChooser_ = std::make_unique<juce::FileChooser>(
-                        "Choose the new parent folder",
-                        file.getParentDirectory().exists()
-                            ? file.getParentDirectory()
-                            : juce::File::getSpecialLocation(juce::File::userHomeDirectory));
-                    moveFolderChooser_->launchAsync(
-                        juce::FileBrowserComponent::openMode |
-                            juce::FileBrowserComponent::canSelectDirectories,
-                        [self, fsPath](const juce::FileChooser& fc) {
-                            if (self == nullptr) {
-                                return;
-                            }
-                            const auto picked = fc.getResult();
-                            if (!picked.isDirectory()) {
-                                return;
-                            }
-                            // The chooser returns the new PARENT directory.
-                            // The folder itself keeps its original name at the
-                            // new location, so build the full destination by
-                            // appending the source folder's leaf name.
-                            const auto newParent =
-                                std::filesystem::path(picked.getFullPathName().toStdString());
-                            const auto newFullPath = newParent / fsPath.filename();
+        menu.showMenuAsync(juce::PopupMenu::Options(), [this, path, file,
+                                                        alreadyIndexed](int result) {
+            if (result == 1) {
+                auto favs = magda::Config::getInstance().getBrowserFavorites();
+                favs.erase(std::remove(favs.begin(), favs.end(), path), favs.end());
+                magda::Config::getInstance().setBrowserFavorites(favs);
+                magda::Config::getInstance().save();
+                sidebarComponent_->rebuildFavoriteButtons();
+            } else if (result == 2) {
+                auto favs = magda::Config::getInstance().getBrowserFavorites();
+                favs.push_back(path);
+                magda::Config::getInstance().setBrowserFavorites(favs);
+                magda::Config::getInstance().save();
+                sidebarComponent_->rebuildFavoriteButtons();
+            } else if (result == 3 && dbBrowser_) {
+                dbBrowser_->startIndexing(
+                    file, alreadyIndexed ? magda::media::MediaDbIndexer::Mode::ForceAll
+                                         : magda::media::MediaDbIndexer::Mode::Incremental);
+            } else if (result == 4 && dbBrowser_) {
+                dbBrowser_->startIndexing(file, magda::media::MediaDbIndexer::Mode::OnlyNew);
+            } else if (result == 5 && dbBrowser_) {
+                const auto folderName = file.getFileName();
+                const auto fsPath = std::filesystem::path(file.getFullPathName().toStdString());
+                juce::Component::SafePointer<MediaExplorerContent> self(this);
+                juce::AlertWindow::showAsync(
+                    juce::MessageBoxOptions{}
+                        .withIconType(juce::MessageBoxIconType::WarningIcon)
+                        .withTitle("Remove folder from media library")
+                        .withMessage("Remove every indexed entry under \"" + folderName +
+                                     "\" from the media library?\n"
+                                     "Your audio files on disk are untouched.")
+                        .withButton("Remove")
+                        .withButton("Cancel"),
+                    [self, fsPath](int choice) {
+                        if (self == nullptr || choice != 1) {
+                            return;
+                        }
+                        magda::media::removeFolderFromLibrary(fsPath);
+                        if (self->dbBrowser_ != nullptr) {
+                            self->dbBrowser_->refresh();
+                        }
+                    });
+            } else if (result == 6 && dbBrowser_) {
+                const auto fsPath = std::filesystem::path(file.getFullPathName().toStdString());
+                juce::Component::SafePointer<MediaExplorerContent> self(this);
+                moveFolderChooser_ = std::make_unique<juce::FileChooser>(
+                    "Choose the new parent folder",
+                    file.getParentDirectory().exists()
+                        ? file.getParentDirectory()
+                        : juce::File::getSpecialLocation(juce::File::userHomeDirectory));
+                moveFolderChooser_->launchAsync(
+                    juce::FileBrowserComponent::openMode |
+                        juce::FileBrowserComponent::canSelectDirectories,
+                    [self, fsPath](const juce::FileChooser& fc) {
+                        if (self == nullptr) {
+                            return;
+                        }
+                        const auto picked = fc.getResult();
+                        if (!picked.isDirectory()) {
+                            return;
+                        }
+                        // The chooser returns the new PARENT directory.
+                        // The folder itself keeps its original name at the
+                        // new location, so build the full destination by
+                        // appending the source folder's leaf name.
+                        const auto newParent =
+                            std::filesystem::path(picked.getFullPathName().toStdString());
+                        const auto newFullPath = newParent / fsPath.filename();
 
-                            auto showError = [](const juce::String& msg) {
-                                juce::AlertWindow::showAsync(
-                                    juce::MessageBoxOptions{}
-                                        .withIconType(juce::MessageBoxIconType::WarningIcon)
-                                        .withTitle("Move folder")
-                                        .withMessage(msg)
-                                        .withButton("OK"),
-                                    nullptr);
-                            };
+                        auto showError = [](const juce::String& msg) {
+                            juce::AlertWindow::showAsync(
+                                juce::MessageBoxOptions{}
+                                    .withIconType(juce::MessageBoxIconType::WarningIcon)
+                                    .withTitle("Move folder")
+                                    .withMessage(msg)
+                                    .withButton("OK"),
+                                nullptr);
+                        };
 
-                            if (newFullPath == fsPath) {
-                                showError("The new parent is the folder's current parent — "
-                                          "nothing to do.");
-                                return;
-                            }
-                            std::error_code ec;
-                            if (std::filesystem::exists(newFullPath, ec)) {
-                                showError("A folder named \"" +
-                                          juce::String(fsPath.filename().string()) +
-                                          "\" already exists at the chosen location. Pick a "
-                                          "different parent or remove the existing folder "
-                                          "first.");
-                                return;
-                            }
+                        if (newFullPath == fsPath) {
+                            showError("The new parent is the folder's current parent — "
+                                      "nothing to do.");
+                            return;
+                        }
+                        std::error_code ec;
+                        if (std::filesystem::exists(newFullPath, ec)) {
+                            showError("A folder named \"" +
+                                      juce::String(fsPath.filename().string()) +
+                                      "\" already exists at the chosen location. Pick a "
+                                      "different parent or remove the existing folder "
+                                      "first.");
+                            return;
+                        }
 
-                            // Release every handle MAGDA holds on the
-                            // source tree before attempting the rename.
-                            // Two of our subsystems can keep the source
-                            // alive:
-                            //   1. The file browser's
-                            //      DirectoryContentsList polls its current
-                            //      root and enumerates child entries; if
-                            //      that root is at or under the folder we
-                            //      want to move, switching it away first
-                            //      makes the worker stop walking the
-                            //      doomed directory.
-                            //   2. The preview transport keeps an audio
-                            //      reader open on the last-played file,
-                            //      which sits underneath the source
-                            //      folder when the user just auditioned
-                            //      something from it.
-                            // POSIX would silently let the rename happen
-                            // with these handles still open, but Windows
-                            // returns access-denied — so the cleanup is
-                            // required there and harmless elsewhere.
-                            if (self->fileBrowser_ != nullptr) {
-                                const auto parent = fsPath.parent_path();
-                                if (!parent.empty()) {
-                                    self->fileBrowser_->setRoot(
-                                        juce::File(juce::String(parent.string())));
-                                }
-                            }
-                            self->stopPreview();
-                            if (self->transportSource_) {
-                                self->transportSource_->setSource(nullptr);
-                            }
-                            self->currentPreviewFile_ = juce::File();
-
-                            // Physically move the folder first; only update
-                            // the library rows if that succeeded, otherwise
-                            // the DB would point at a path that doesn't
-                            // exist on disk (the original bug).
-                            std::filesystem::rename(fsPath, newFullPath, ec);
-                            if (ec) {
-                                juce::Logger::writeToLog(
-                                    juce::String("[moveFolder] rename failed: code=") +
-                                    juce::String(ec.value()) + " msg='" +
-                                    juce::String(ec.message()) + "' src='" +
-                                    juce::String(fsPath.string()) + "' dst='" +
-                                    juce::String(newFullPath.string()) + "'");
-                                showError("Could not move the folder on disk: " +
-                                          juce::String(ec.message()) + " (code " +
-                                          juce::String(ec.value()) +
-                                          ").\n\nOn Windows this usually means MAGDA, "
-                                          "File Explorer, or an antivirus is holding the "
-                                          "folder open. Close any preview, switch the "
-                                          "explorer pane to a different folder, then try "
-                                          "again. The media library was not changed.");
-                                return;
-                            }
-
-                            const int rows =
-                                magda::media::moveFolderInLibrary(fsPath, newFullPath);
-                            if (rows < 0) {
-                                // DB update failed after the disk move succeeded.
-                                // Put the folder back so we don't leave the user
-                                // with stale DB rows AND a moved folder.
-                                std::error_code revertEc;
-                                std::filesystem::rename(newFullPath, fsPath, revertEc);
-                                showError(
-                                    "The folder was moved on disk, but the library update "
-                                    "was rolled back (likely a name collision). The folder "
-                                    "has been moved back to its original location.");
-                                return;
-                            }
-                            // Navigate the explorer to the new parent so
-                            // the user lands on the moved folder instead
-                            // of staring at the old (now empty of it)
-                            // location.
-                            if (self->fileBrowser_ != nullptr) {
+                        // Release every handle MAGDA holds on the
+                        // source tree before attempting the rename.
+                        // Two of our subsystems can keep the source
+                        // alive:
+                        //   1. The file browser's
+                        //      DirectoryContentsList polls its current
+                        //      root and enumerates child entries; if
+                        //      that root is at or under the folder we
+                        //      want to move, switching it away first
+                        //      makes the worker stop walking the
+                        //      doomed directory.
+                        //   2. The preview transport keeps an audio
+                        //      reader open on the last-played file,
+                        //      which sits underneath the source
+                        //      folder when the user just auditioned
+                        //      something from it.
+                        // POSIX would silently let the rename happen
+                        // with these handles still open, but Windows
+                        // returns access-denied — so the cleanup is
+                        // required there and harmless elsewhere.
+                        if (self->fileBrowser_ != nullptr) {
+                            const auto parent = fsPath.parent_path();
+                            if (!parent.empty()) {
                                 self->fileBrowser_->setRoot(
-                                    juce::File(juce::String(newParent.string())));
+                                    juce::File(juce::String(parent.string())));
                             }
-                            if (self->dbBrowser_ != nullptr) {
-                                self->dbBrowser_->refresh();
-                            }
-                        });
-                }
-            });
+                        }
+                        self->stopPreview();
+                        if (self->transportSource_) {
+                            self->transportSource_->setSource(nullptr);
+                        }
+                        self->currentPreviewFile_ = juce::File();
+
+                        // Physically move the folder first; only update
+                        // the library rows if that succeeded, otherwise
+                        // the DB would point at a path that doesn't
+                        // exist on disk (the original bug).
+                        std::filesystem::rename(fsPath, newFullPath, ec);
+                        if (ec) {
+                            juce::Logger::writeToLog(
+                                juce::String("[moveFolder] rename failed: code=") +
+                                juce::String(ec.value()) + " msg='" + juce::String(ec.message()) +
+                                "' src='" + juce::String(fsPath.string()) + "' dst='" +
+                                juce::String(newFullPath.string()) + "'");
+                            showError(
+                                "Could not move the folder on disk: " + juce::String(ec.message()) +
+                                " (code " + juce::String(ec.value()) +
+                                ").\n\nOn Windows this usually means MAGDA, "
+                                "File Explorer, or an antivirus is holding the "
+                                "folder open. Close any preview, switch the "
+                                "explorer pane to a different folder, then try "
+                                "again. The media library was not changed.");
+                            return;
+                        }
+
+                        const int rows = magda::media::moveFolderInLibrary(fsPath, newFullPath);
+                        if (rows < 0) {
+                            // DB update failed after the disk move succeeded.
+                            // Put the folder back so we don't leave the user
+                            // with stale DB rows AND a moved folder.
+                            std::error_code revertEc;
+                            std::filesystem::rename(newFullPath, fsPath, revertEc);
+                            showError("The folder was moved on disk, but the library update "
+                                      "was rolled back (likely a name collision). The folder "
+                                      "has been moved back to its original location.");
+                            return;
+                        }
+                        // Navigate the explorer to the new parent so
+                        // the user lands on the moved folder instead
+                        // of staring at the old (now empty of it)
+                        // location.
+                        if (self->fileBrowser_ != nullptr) {
+                            self->fileBrowser_->setRoot(
+                                juce::File(juce::String(newParent.string())));
+                        }
+                        if (self->dbBrowser_ != nullptr) {
+                            self->dbBrowser_->refresh();
+                        }
+                    });
+            }
+        });
         return;
     }
 

--- a/magda/daw/ui/panels/content/TrackChainContent.cpp
+++ b/magda/daw/ui/panels/content/TrackChainContent.cpp
@@ -330,7 +330,15 @@ class DeviceButtonLookAndFeel : public juce::LookAndFeel_V4 {
 //==============================================================================
 // ChainContainer - Container for track chain that paints arrows between elements
 //==============================================================================
-class TrackChainContent::ChainContainer : public juce::Component, public juce::DragAndDropTarget {
+namespace {
+// Defined further down (with the chain-preset menu wiring); declared here so
+// ChainContainer's inline drop handlers can surface load failures the same way.
+void showChainPresetErrorAsync(const juce::String& title, const juce::String& message);
+}  // namespace
+
+class TrackChainContent::ChainContainer : public juce::Component,
+                                          public juce::DragAndDropTarget,
+                                          public juce::FileDragAndDropTarget {
   public:
     explicit ChainContainer(TrackChainContent& owner) : owner_(owner) {}
 
@@ -427,7 +435,14 @@ class TrackChainContent::ChainContainer : public juce::Component, public juce::D
         }
         if (auto* obj = details.description.getDynamicObject()) {
             auto type = obj->getProperty("type").toString();
-            return type == "plugin" || type == "chainElement" || type == "chainElements";
+            if (type == "plugin" || type == "chainElement" || type == "chainElements") {
+                return true;
+            }
+            // Linux: the media browser drags rows as {type:"files",paths:[...]}.
+            // macOS/Windows route the same drop through FileDragAndDropTarget.
+            if (type == "files") {
+                return anyDroppablePreset(filePathsFromDescription(details.description));
+            }
         }
         return false;
     }
@@ -458,6 +473,14 @@ class TrackChainContent::ChainContainer : public juce::Component, public juce::D
                                   : static_cast<int>(nodeComponents_->size());
             const bool shouldScrollToEnd = insertIndex >= static_cast<int>(nodeComponents_->size());
             const auto type = obj->getProperty("type").toString();
+
+            // Linux: media-browser preset rows arrive as a {type:"files"} payload.
+            if (type == "files") {
+                clearDropFeedback();
+                applyDroppedPresets(filePathsFromDescription(details.description), insertIndex,
+                                    shouldScrollToEnd);
+                return;
+            }
 
             if (type == "chainElement" || type == "chainElements") {
                 auto sourcePaths = dragObjectToChainNodePaths(*obj);
@@ -538,7 +561,115 @@ class TrackChainContent::ChainContainer : public juce::Component, public juce::D
         repaint();
     }
 
+    // FileDragAndDropTarget — macOS/Windows deliver the media-browser preset
+    // drag as an OS file drag through here; Linux takes the internal path above.
+    bool isInterestedInFileDrag(const juce::StringArray& files) override {
+        return owner_.selectedTrackId_ != magda::INVALID_TRACK_ID && anyDroppablePreset(files);
+    }
+
+    void fileDragEnter(const juce::StringArray&, int x, int /*y*/) override {
+        owner_.dropInsertIndex_ = owner_.calculateInsertIndex(x);
+        owner_.startTimerHz(10);
+        owner_.resized();
+        repaint();
+    }
+
+    void fileDragMove(const juce::StringArray&, int x, int /*y*/) override {
+        owner_.dropInsertIndex_ = owner_.calculateInsertIndex(x);
+        repaint();
+    }
+
+    void fileDragExit(const juce::StringArray&) override {
+        clearDropFeedback();
+    }
+
+    void filesDropped(const juce::StringArray& files, int /*x*/, int /*y*/) override {
+        const int insertIndex = owner_.dropInsertIndex_ >= 0
+                                    ? owner_.dropInsertIndex_
+                                    : static_cast<int>(nodeComponents_->size());
+        const bool shouldScrollToEnd = insertIndex >= static_cast<int>(nodeComponents_->size());
+        clearDropFeedback();
+        applyDroppedPresets(files, insertIndex, shouldScrollToEnd);
+    }
+
   private:
+    void clearDropFeedback() {
+        owner_.dropInsertIndex_ = -1;
+        owner_.stopTimer();
+        owner_.resized();
+        repaint();
+    }
+
+    static juce::StringArray filePathsFromDescription(const juce::var& description) {
+        juce::StringArray paths;
+        if (auto* obj = description.getDynamicObject()) {
+            if (obj->getProperty("type").toString() == "files") {
+                if (auto* arr = obj->getProperty("paths").getArray()) {
+                    for (const auto& v : *arr) {
+                        paths.add(v.toString());
+                    }
+                }
+            }
+        }
+        return paths;
+    }
+
+    // Phase 1 accepts chain and device presets; rack presets are a follow-up.
+    static bool isDroppablePreset(const juce::String& path) {
+        const auto ref = magda::PresetManager::getInstance().classifyPresetFile(juce::File(path));
+        return ref.has_value() && (ref->kind == magda::PresetManager::PresetRef::Kind::Chain ||
+                                   ref->kind == magda::PresetManager::PresetRef::Kind::Device);
+    }
+
+    static bool anyDroppablePreset(const juce::StringArray& files) {
+        for (const auto& f : files) {
+            if (isDroppablePreset(f)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Load each dropped preset onto the selected track: chain presets replace
+    // the whole chain, device presets insert at the drop position (advancing
+    // the index so a multi-file drop keeps its order).
+    void applyDroppedPresets(const juce::StringArray& files, int insertIndex,
+                             bool shouldScrollToEnd) {
+        const auto trackId = owner_.selectedTrackId_;
+        if (trackId == magda::INVALID_TRACK_ID) {
+            return;
+        }
+        auto& presets = magda::PresetManager::getInstance();
+        auto& tracks = magda::TrackManager::getInstance();
+        for (const auto& path : files) {
+            const auto ref = presets.classifyPresetFile(juce::File(path));
+            if (!ref.has_value()) {
+                continue;
+            }
+            if (ref->kind == magda::PresetManager::PresetRef::Kind::Chain) {
+                std::vector<magda::ChainElement> elements;
+                if (!presets.loadChainPreset(ref->name, elements)) {
+                    showChainPresetErrorAsync("Load Chain Preset Failed", presets.getLastError());
+                    continue;
+                }
+                if (!tracks.applyChainPreset(trackId, std::move(elements))) {
+                    showChainPresetErrorAsync("Load Chain Preset Failed",
+                                              "Failed to apply preset to track.");
+                }
+            } else if (ref->kind == magda::PresetManager::PresetRef::Kind::Device) {
+                magda::DeviceInfo device;
+                if (!presets.loadDevicePreset(ref->pluginFolder, ref->name, device)) {
+                    showChainPresetErrorAsync("Load Device Preset Failed", presets.getLastError());
+                    continue;
+                }
+                owner_.scrollToEndAfterNextDeviceChange_ = shouldScrollToEnd;
+                owner_.suppressNextImplicitScrollToEnd_ = !shouldScrollToEnd;
+                tracks.addDeviceToTrack(trackId, device, insertIndex);
+                ++insertIndex;
+            }
+        }
+    }
+
     void checkAndResetStaleDropState() {
         if (owner_.dropInsertIndex_ >= 0) {
             if (auto* container = juce::DragAndDropContainer::findParentDragContainerFor(this)) {

--- a/tests/test_string_table.cpp
+++ b/tests/test_string_table.cpp
@@ -24,11 +24,22 @@ TEST_CASE("StringTable falls back to English for empty localized placeholders",
     auto& strings = magda::StringTable::getInstance();
     StringTableLanguageGuard languageGuard(strings);
 
+    // Capture the English master values we expect to fall back to. These come
+    // from the real en.json the singleton loads at construction.
     REQUIRE(strings.loadLanguage("en"));
-    const auto languageLabel = strings.get("preferences.language.label");
-    const auto exportNoEditMessage = strings.get("dialogs.error.export_no_edit");
+    const auto englishLabel = strings.get("preferences.language.label");
+    const auto englishExport = strings.get("dialogs.error.export_no_edit");
+    REQUIRE(englishLabel.isNotEmpty());
+    REQUIRE(englishExport.isNotEmpty());
 
-    REQUIRE(strings.loadLanguage("ja"));
-    CHECK(strings.get("preferences.language.label") == languageLabel);
-    CHECK(strings.get("dialogs.error.export_no_edit") == exportNoEditMessage);
+    // Drive a synthetic locale instead of a real translation file: one key
+    // present-but-empty, the other absent entirely. This keeps the test
+    // independent of whatever Crowdin translators have filled in for any
+    // given locale (a real translated key would not exercise the fallback).
+    REQUIRE(strings.loadFromString(R"({"preferences":{"language":{"label":""}}})"));
+
+    // Empty localized value is treated as an untranslated placeholder.
+    CHECK(strings.get("preferences.language.label") == englishLabel);
+    // Key missing from the locale also falls back to the English master.
+    CHECK(strings.get("dialogs.error.export_no_edit") == englishExport);
 }


### PR DESCRIPTION
Follow-up UI polish for the media DB. More commits may land on this branch.

So far:
- Index Folder dialog: replace the two Yes/No combo boxes ("Use folder name", "Use subfolder names") with a custom `IndexTagOptionsComponent` backed by toggle buttons.
- Media explorer: swap the indexing **Stop** `TextButton` for an SVG `server_stop` icon button and tighten the surrounding layout.