### PR TITLE
feat: restore Intel Mac support via MAGDA_HAVE_CLAP feature gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build-macos:
-    runs-on: macos-14  # Apple Silicon; arm64-only (ONNX Runtime 1.26 has no Intel macOS build)
+    runs-on: macos-14  # Apple Silicon; includes the CLAP semantic-search backend (ORT-only on arm64)
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -244,6 +244,229 @@ jobs:
       if: always()
       run: |
         # Remove temporary signing keychain
+        KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+        if [ -f "$KEYCHAIN_PATH" ]; then
+          security delete-keychain "$KEYCHAIN_PATH"
+        fi
+        rm -rf build
+
+  build-macos-x86_64:
+    # Intel Mac build (MAGDA_HAVE_CLAP=OFF, no semantic search).
+    # macos-13 is the last x86_64 runner GitHub offers — when it goes away we
+    # will need a self-hosted runner or to drop this build.
+    runs-on: macos-13
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        lfs: true
+
+    - name: Install dependencies
+      run: |
+        brew install ninja create-dmg
+        if ! command -v sccache &>/dev/null; then
+          brew install sccache
+        fi
+
+    - name: Extract version
+      id: version
+      run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          VERSION="${{ github.event.inputs.version }}"
+        else
+          VERSION="${GITHUB_REF_NAME#v}"
+        fi
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Version: $VERSION"
+
+    - name: Configure CMake (x86_64)
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        cmake -B build -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_OSX_ARCHITECTURES="x86_64" \
+          -DCMAKE_OSX_DEPLOYMENT_TARGET="11.0" \
+          -DMAGDA_BUILD_TESTS=OFF \
+          -DMAGDA_FULL_VERSION="$VERSION" \
+          -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+
+    - name: Build
+      run: cmake --build build --config Release -j $(sysctl -n hw.ncpu)
+
+    - name: Verify app bundle
+      run: |
+        APP_PATH="build/magda/daw/magda_daw_app_artefacts/Release/MAGDA.app"
+        if [ ! -d "$APP_PATH" ]; then
+          echo "MAGDA.app not found at $APP_PATH"
+          find build -name "MAGDA.app" -type d || true
+          exit 1
+        fi
+        echo "MAGDA.app found at $APP_PATH"
+        ls -la "$APP_PATH/Contents/MacOS/"
+
+    - name: Import signing certificate
+      env:
+        MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+        MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+      run: |
+        KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+        KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+
+        security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+        echo "$MACOS_CERTIFICATE_P12" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+        security import "$RUNNER_TEMP/certificate.p12" \
+          -k "$KEYCHAIN_PATH" \
+          -P "$MACOS_CERTIFICATE_PASSWORD" \
+          -T /usr/bin/codesign \
+          -T /usr/bin/productsign
+        rm "$RUNNER_TEMP/certificate.p12"
+
+        security set-key-partition-list -S apple-tool:,apple:,codesign:,productsign: \
+          -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+        security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+        security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+    - name: Code sign app bundle
+      run: |
+        APP_PATH="build/magda/daw/magda_daw_app_artefacts/Release/MAGDA.app"
+        IDENTITY="Developer ID Application: Luca Romagnoli (VH54FX3Z7U)"
+        ENTITLEMENTS="packaging/macos/entitlements.plist"
+
+        if [ -f "$APP_PATH/Contents/MacOS/magda_plugin_scanner" ]; then
+          echo "Signing plugin scanner..."
+          codesign --force --verify --verbose --timestamp \
+            --options runtime \
+            --entitlements "$ENTITLEMENTS" \
+            --sign "$IDENTITY" \
+            "$APP_PATH/Contents/MacOS/magda_plugin_scanner"
+        fi
+
+        find "$APP_PATH/Contents/Frameworks" -name "*.dylib" -o -name "*.framework" 2>/dev/null | while read -r lib; do
+          echo "Signing: $lib"
+          codesign --force --verify --verbose --timestamp \
+            --options runtime \
+            --sign "$IDENTITY" \
+            "$lib"
+        done
+
+        echo "Signing MAGDA.app..."
+        codesign --force --verify --verbose --timestamp \
+          --options runtime \
+          --entitlements "$ENTITLEMENTS" \
+          --sign "$IDENTITY" \
+          "$APP_PATH"
+
+    - name: Verify signature
+      run: |
+        APP_PATH="build/magda/daw/magda_daw_app_artefacts/Release/MAGDA.app"
+        echo "Verifying codesign..."
+        codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+        echo "Verifying Gatekeeper assessment..."
+        spctl --assess --type execute -vvv "$APP_PATH" || echo "spctl check failed (may need notarization)"
+
+    - name: Create DMG
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        APP_PATH="build/magda/daw/magda_daw_app_artefacts/Release/MAGDA.app"
+        DMG_NAME="MAGDA-${VERSION}-macOS-x86_64.dmg"
+
+        set +e
+        create-dmg \
+          --volname "MAGDA" \
+          --window-pos 200 120 \
+          --window-size 600 400 \
+          --icon-size 100 \
+          --icon "MAGDA.app" 150 190 \
+          --app-drop-link 450 190 \
+          "$DMG_NAME" \
+          "$APP_PATH"
+        CREATE_DMG_EXIT=$?
+        set -e
+
+        if [ ! -f "$DMG_NAME" ]; then
+          echo "create-dmg failed and no DMG was produced (exit code $CREATE_DMG_EXIT)"
+          exit 1
+        fi
+
+        echo "DMG created: $DMG_NAME"
+        ls -lh "$DMG_NAME"
+
+    - name: Sign DMG
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        DMG_NAME="MAGDA-${VERSION}-macOS-x86_64.dmg"
+        codesign --force --sign "Developer ID Application: Luca Romagnoli (VH54FX3Z7U)" "$DMG_NAME"
+        codesign --verify --verbose "$DMG_NAME"
+
+    - name: Notarize DMG
+      timeout-minutes: 30
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+        NOTARIZATION_APPLE_ID: ${{ secrets.NOTARIZATION_APPLE_ID }}
+        NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
+      run: |
+        DMG_NAME="MAGDA-${VERSION}-macOS-x86_64.dmg"
+
+        echo "Submitting for notarization..."
+        SUBMIT_OUTPUT=$(xcrun notarytool submit "$DMG_NAME" \
+          --apple-id "$NOTARIZATION_APPLE_ID" \
+          --password "$NOTARIZATION_PASSWORD" \
+          --team-id "VH54FX3Z7U" \
+          --wait 2>&1) || true
+        echo "$SUBMIT_OUTPUT"
+
+        set +o pipefail
+        SUBMISSION_ID=$(echo "$SUBMIT_OUTPUT" | grep "id:" | head -1 | awk '{print $2}') || true
+        STATUS=$(echo "$SUBMIT_OUTPUT" | grep "status:" | tail -1 | awk '{print $2}') || true
+        set -o pipefail
+
+        if [ -z "$SUBMISSION_ID" ] || [ -z "$STATUS" ]; then
+          echo "Failed to parse notarization output:"
+          echo "$SUBMIT_OUTPUT"
+          exit 1
+        fi
+
+        if [ "$STATUS" != "Accepted" ]; then
+          echo "Notarization failed with status: $STATUS"
+          echo "Fetching notarization log..."
+          xcrun notarytool log "$SUBMISSION_ID" \
+            --apple-id "$NOTARIZATION_APPLE_ID" \
+            --password "$NOTARIZATION_PASSWORD" \
+            --team-id "VH54FX3Z7U"
+          exit 1
+        fi
+
+        echo "Stapling notarization ticket..."
+        xcrun stapler staple "$DMG_NAME"
+
+    - name: Generate checksum
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        DMG_NAME="MAGDA-${VERSION}-macOS-x86_64.dmg"
+        shasum -a 256 "$DMG_NAME" > "${DMG_NAME}.sha256"
+        cat "${DMG_NAME}.sha256"
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: macos-x86_64-release
+        path: |
+          MAGDA-*-macOS-x86_64.dmg
+          MAGDA-*-macOS-x86_64.dmg.sha256
+
+    - name: Clean up
+      if: always()
+      run: |
         KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
         if [ -f "$KEYCHAIN_PATH" ]; then
           security delete-keychain "$KEYCHAIN_PATH"
@@ -779,7 +1002,7 @@ jobs:
           MAGDA-*-Linux-x86_64.AppImage.sha256
 
   create-release:
-    needs: [build-macos, build-windows, build-linux]
+    needs: [build-macos, build-macos-x86_64, build-windows, build-linux]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -828,6 +1051,7 @@ jobs:
         fail_on_unmatched_files: true
         files: |
           macos-release/*
+          macos-x86_64-release/*
           windows-x86_64-release/MAGDA-*-Windows-x86_64-Setup.exe
           windows-x86_64-release/MAGDA-*-Windows-x86_64-Setup.exe.sha256
           windows-x86_64-release/MAGDA-*-Windows-x86_64.pdb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,21 @@ option(MAGDA_BUILD_TESTS "Build tests" ON)
 option(MAGDA_BUILD_EXAMPLES "Build developer example tools (e.g. lua_smoke REPL)" OFF)
 option(MAGDA_BUILD_JUCE_ADAPTER "Build JUCE/Tracktion adapter" OFF)
 
+# CLAP semantic-search backend (ONNX Runtime). Forced off on Intel macOS because
+# upstream ORT dropped osx-x86_64 prebuilts in 1.26. The rest of the media DB
+# (catalogue, indexing, metadata search) still works without it.
+set(_magda_clap_default ON)
+if(APPLE)
+    if(CMAKE_OSX_ARCHITECTURES)
+        if(NOT CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
+            set(_magda_clap_default OFF)
+        endif()
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|i386")
+        set(_magda_clap_default OFF)
+    endif()
+endif()
+option(MAGDA_HAVE_CLAP "Enable CLAP audio/text encoders via ONNX Runtime" ${_magda_clap_default})
+
 # Find packages
 find_package(Threads REQUIRED)
 
@@ -280,28 +295,31 @@ add_subdirectory(third_party/sqlite)
 
 # ONNX Runtime 1.26.0 — CLAP inference engine for the media DB (issue #768).
 # Microsoft ships prebuilt binaries per (OS, arch); we pin one per platform.
-# Intel macOS is intentionally unsupported: upstream dropped osx-x86_64 in 1.26.
-set(ORT_VERSION 1.26.0)
-if(APPLE AND (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64"
-              OR CMAKE_OSX_ARCHITECTURES MATCHES "arm64"))
-    set(ORT_URL  "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-osx-arm64-${ORT_VERSION}.tgz")
-    set(ORT_HASH SHA256=7a1280bbb1701ea514f71828765237e7896e0f2e1cd332f1f70dbd5c3e33aca3)
-elseif(UNIX AND NOT APPLE)
-    set(ORT_URL  "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-${ORT_VERSION}.tgz")
-    set(ORT_HASH SHA256=1254da24fb389cf39dc0ff3451ab48301740ffbfcbaf646849df92f80ee92c57)
-elseif(WIN32)
-    set(ORT_URL  "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-win-x64-${ORT_VERSION}.zip")
-    set(ORT_HASH SHA256=6ebe99b5564bf4d029b6e93eac9ff423682b6212eade769e9ca3f685eaf500b4)
-else()
-    message(FATAL_ERROR "ONNX Runtime: no prebuilt binary for this platform")
+# Skipped on Intel macOS (MAGDA_HAVE_CLAP=OFF) since upstream dropped
+# osx-x86_64 in 1.26 — those builds ship without semantic search.
+if(MAGDA_HAVE_CLAP)
+    set(ORT_VERSION 1.26.0)
+    if(APPLE AND (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64"
+                  OR CMAKE_OSX_ARCHITECTURES MATCHES "arm64"))
+        set(ORT_URL  "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-osx-arm64-${ORT_VERSION}.tgz")
+        set(ORT_HASH SHA256=7a1280bbb1701ea514f71828765237e7896e0f2e1cd332f1f70dbd5c3e33aca3)
+    elseif(UNIX AND NOT APPLE)
+        set(ORT_URL  "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-${ORT_VERSION}.tgz")
+        set(ORT_HASH SHA256=1254da24fb389cf39dc0ff3451ab48301740ffbfcbaf646849df92f80ee92c57)
+    elseif(WIN32)
+        set(ORT_URL  "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-win-x64-${ORT_VERSION}.zip")
+        set(ORT_HASH SHA256=6ebe99b5564bf4d029b6e93eac9ff423682b6212eade769e9ca3f685eaf500b4)
+    else()
+        message(FATAL_ERROR "ONNX Runtime: no prebuilt binary for this platform (set MAGDA_HAVE_CLAP=OFF to skip)")
+    endif()
+    FetchContent_Declare(
+        onnxruntime
+        URL      ${ORT_URL}
+        URL_HASH ${ORT_HASH}
+    )
+    FetchContent_MakeAvailable(onnxruntime)
+    add_subdirectory(third_party/onnxruntime)
 endif()
-FetchContent_Declare(
-    onnxruntime
-    URL      ${ORT_URL}
-    URL_HASH ${ORT_HASH}
-)
-FetchContent_MakeAvailable(onnxruntime)
-add_subdirectory(third_party/onnxruntime)
 
 # Simple agent system - no external dependencies needed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,10 @@ option(MAGDA_BUILD_JUCE_ADAPTER "Build JUCE/Tracktion adapter" OFF)
 # (catalogue, indexing, metadata search) still works without it.
 set(_magda_clap_default ON)
 if(APPLE)
+    # ORT 1.26 only ships single-arch binaries, so any build that targets
+    # x86_64 (Intel-only or arm64+x86_64 universal) must disable CLAP.
     if(CMAKE_OSX_ARCHITECTURES)
-        if(NOT CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
+        if(CMAKE_OSX_ARCHITECTURES MATCHES "x86_64|i386")
             set(_magda_clap_default OFF)
         endif()
     elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|i386")

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -624,32 +624,35 @@ endif()
 # the FetchContent `_deps/onnxruntime-src/lib/` build-dir path into the binary's
 # rpath, which does not exist on an end-user machine, so the distributed app
 # must carry the runtime library itself or it aborts at launch ("Library not
-# loaded: @rpath/libonnxruntime.1.dylib").
-if(APPLE)
-    # Place the dylib in the bundle's Frameworks/ — the release codesign step
-    # already signs everything there — and add an rpath so the loader finds it.
-    # The executable references @rpath/libonnxruntime.1.dylib (the lib's own
-    # install name), so the bundled file must use that exact name.
-    add_custom_command(TARGET magda_daw_app POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E make_directory
-            "$<TARGET_BUNDLE_CONTENT_DIR:magda_daw_app>/Frameworks"
-        COMMAND ${CMAKE_COMMAND} -E copy
-            "${ONNXRUNTIME_LIB_DIR}/libonnxruntime.dylib"
-            "$<TARGET_BUNDLE_CONTENT_DIR:magda_daw_app>/Frameworks/libonnxruntime.1.dylib"
-        COMMENT "Bundling ONNX Runtime dylib into app Frameworks"
-    )
-    set_property(TARGET magda_daw_app APPEND PROPERTY
-        BUILD_RPATH "@executable_path/../Frameworks")
-elseif(WIN32)
-    # Windows only searches the exe's directory, the cwd, and PATH — none of
-    # which include the FetchContent lib dir — so without this copy the first
-    # ORT call (Sample Tagger load) faults when the delay-loaded DLL fails to
-    # resolve.
-    add_custom_command(TARGET magda_daw_app POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${ONNXRUNTIME_LIB_DIR}/onnxruntime.dll"
-            "${ONNXRUNTIME_LIB_DIR}/onnxruntime_providers_shared.dll"
-            "$<TARGET_FILE_DIR:magda_daw_app>"
-        COMMENT "Copying ONNX Runtime DLLs alongside app executable"
-    )
+# loaded: @rpath/libonnxruntime.1.dylib"). Skipped when MAGDA_HAVE_CLAP is off
+# (Intel macOS) since there's no ORT to bundle.
+if(MAGDA_HAVE_CLAP)
+    if(APPLE)
+        # Place the dylib in the bundle's Frameworks/ — the release codesign step
+        # already signs everything there — and add an rpath so the loader finds it.
+        # The executable references @rpath/libonnxruntime.1.dylib (the lib's own
+        # install name), so the bundled file must use that exact name.
+        add_custom_command(TARGET magda_daw_app POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E make_directory
+                "$<TARGET_BUNDLE_CONTENT_DIR:magda_daw_app>/Frameworks"
+            COMMAND ${CMAKE_COMMAND} -E copy
+                "${ONNXRUNTIME_LIB_DIR}/libonnxruntime.dylib"
+                "$<TARGET_BUNDLE_CONTENT_DIR:magda_daw_app>/Frameworks/libonnxruntime.1.dylib"
+            COMMENT "Bundling ONNX Runtime dylib into app Frameworks"
+        )
+        set_property(TARGET magda_daw_app APPEND PROPERTY
+            BUILD_RPATH "@executable_path/../Frameworks")
+    elseif(WIN32)
+        # Windows only searches the exe's directory, the cwd, and PATH — none of
+        # which include the FetchContent lib dir — so without this copy the first
+        # ORT call (Sample Tagger load) faults when the delay-loaded DLL fails to
+        # resolve.
+        add_custom_command(TARGET magda_daw_app POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${ONNXRUNTIME_LIB_DIR}/onnxruntime.dll"
+                "${ONNXRUNTIME_LIB_DIR}/onnxruntime_providers_shared.dll"
+                "$<TARGET_FILE_DIR:magda_daw_app>"
+            COMMENT "Copying ONNX Runtime DLLs alongside app executable"
+        )
+    endif()
 endif()

--- a/magda/daw/media_db/CMakeLists.txt
+++ b/magda/daw/media_db/CMakeLists.txt
@@ -19,4 +19,8 @@ target_sources(magda_daw PRIVATE
     Scan.cpp
 )
 
-target_link_libraries(magda_daw PUBLIC sqlite3 onnxruntime)
+target_link_libraries(magda_daw PUBLIC sqlite3)
+if(MAGDA_HAVE_CLAP)
+    target_link_libraries(magda_daw PUBLIC onnxruntime)
+    target_compile_definitions(magda_daw PUBLIC MAGDA_HAVE_CLAP=1)
+endif()

--- a/magda/daw/media_db/ClapAudioEncoder.cpp
+++ b/magda/daw/media_db/ClapAudioEncoder.cpp
@@ -1,6 +1,6 @@
 #include "ClapAudioEncoder.hpp"
 
-#ifdef MAGDA_HAVE_CLAP
+#if defined(MAGDA_HAVE_CLAP) && MAGDA_HAVE_CLAP
 
 #include <onnxruntime_cxx_api.h>
 

--- a/magda/daw/media_db/ClapAudioEncoder.cpp
+++ b/magda/daw/media_db/ClapAudioEncoder.cpp
@@ -1,5 +1,7 @@
 #include "ClapAudioEncoder.hpp"
 
+#ifdef MAGDA_HAVE_CLAP
+
 #include <onnxruntime_cxx_api.h>
 
 #include <algorithm>
@@ -160,3 +162,39 @@ std::vector<float> ClapAudioEncoder::embed(const float* mono, int numSamples) {
 }
 
 }  // namespace magda::media
+
+#else  // MAGDA_HAVE_CLAP
+
+// Stub implementation for builds without ONNX Runtime (currently Intel macOS).
+// MediaDbContext's encoder factory catches the ctor throw and leaves the
+// encoder pointer null; downstream callers already null-check, so embed() etc.
+// are unreachable in practice.
+// NOLINTBEGIN(readability-convert-member-functions-to-static,performance-unnecessary-value-param,hicpp-named-parameter)
+namespace magda::media {
+
+struct ClapAudioEncoder::Impl {};
+
+ClapAudioEncoder::ClapAudioEncoder(const std::filesystem::path& /*modelPath*/) {
+    throw ClapEncoderError("CLAP backend not available on this build");
+}
+ClapAudioEncoder::~ClapAudioEncoder() = default;
+ClapAudioEncoder::ClapAudioEncoder(ClapAudioEncoder&&) noexcept = default;
+ClapAudioEncoder& ClapAudioEncoder::operator=(ClapAudioEncoder&&) noexcept = default;
+
+int ClapAudioEncoder::dim() const noexcept { return 512; }
+int ClapAudioEncoder::sampleRate() const noexcept { return 48000; }
+
+const std::string& ClapAudioEncoder::modelId() const noexcept {
+    static const std::string kEmpty;
+    return kEmpty;
+}
+void ClapAudioEncoder::setModelId(std::string /*id*/) {}
+
+std::vector<float> ClapAudioEncoder::embed(const float* /*mono*/, int /*numSamples*/) {
+    return {};
+}
+
+}  // namespace magda::media
+// NOLINTEND(readability-convert-member-functions-to-static,performance-unnecessary-value-param,hicpp-named-parameter)
+
+#endif  // MAGDA_HAVE_CLAP

--- a/magda/daw/media_db/ClapTextEncoder.cpp
+++ b/magda/daw/media_db/ClapTextEncoder.cpp
@@ -1,6 +1,6 @@
 #include "ClapTextEncoder.hpp"
 
-#ifdef MAGDA_HAVE_CLAP
+#if defined(MAGDA_HAVE_CLAP) && MAGDA_HAVE_CLAP
 
 #include <onnxruntime_cxx_api.h>
 

--- a/magda/daw/media_db/ClapTextEncoder.cpp
+++ b/magda/daw/media_db/ClapTextEncoder.cpp
@@ -1,5 +1,7 @@
 #include "ClapTextEncoder.hpp"
 
+#ifdef MAGDA_HAVE_CLAP
+
 #include <onnxruntime_cxx_api.h>
 
 #include <array>
@@ -142,3 +144,39 @@ std::vector<float> ClapTextEncoder::embedTokens(const std::vector<int64_t>& inpu
 }
 
 }  // namespace magda::media
+
+#else  // MAGDA_HAVE_CLAP
+
+// Stub implementation for builds without ONNX Runtime (currently Intel macOS).
+// MediaDbContext's encoder factory catches the ctor throw and leaves the
+// encoder pointer null; downstream callers already null-check, so embedTokens
+// is unreachable in practice.
+// NOLINTBEGIN(readability-convert-member-functions-to-static,performance-unnecessary-value-param,hicpp-named-parameter)
+namespace magda::media {
+
+struct ClapTextEncoder::Impl {};
+
+ClapTextEncoder::ClapTextEncoder(const std::filesystem::path& /*modelPath*/) {
+    throw ClapTextEncoderError("CLAP backend not available on this build");
+}
+ClapTextEncoder::~ClapTextEncoder() = default;
+ClapTextEncoder::ClapTextEncoder(ClapTextEncoder&&) noexcept = default;
+ClapTextEncoder& ClapTextEncoder::operator=(ClapTextEncoder&&) noexcept = default;
+
+int ClapTextEncoder::dim() const noexcept { return 512; }
+
+const std::string& ClapTextEncoder::modelId() const noexcept {
+    static const std::string kEmpty;
+    return kEmpty;
+}
+void ClapTextEncoder::setModelId(std::string /*id*/) {}
+
+std::vector<float> ClapTextEncoder::embedTokens(const std::vector<int64_t>& /*inputIds*/,
+                                                const std::vector<int64_t>& /*attentionMask*/) {
+    return {};
+}
+
+}  // namespace magda::media
+// NOLINTEND(readability-convert-member-functions-to-static,performance-unnecessary-value-param,hicpp-named-parameter)
+
+#endif  // MAGDA_HAVE_CLAP

--- a/magda/daw/media_db/MediaDbContext.hpp
+++ b/magda/daw/media_db/MediaDbContext.hpp
@@ -22,7 +22,7 @@ namespace magda::media {
 // text→audio search, zero-shot tagging). Currently false on Intel macOS;
 // see CMakeLists.txt for the gate.
 constexpr bool clapBackendAvailable() noexcept {
-#ifdef MAGDA_HAVE_CLAP
+#if defined(MAGDA_HAVE_CLAP) && MAGDA_HAVE_CLAP
     return true;
 #else
     return false;

--- a/magda/daw/media_db/MediaDbContext.hpp
+++ b/magda/daw/media_db/MediaDbContext.hpp
@@ -18,6 +18,17 @@
 
 namespace magda::media {
 
+// True when the build includes the ONNX-backed CLAP encoders (semantic
+// text→audio search, zero-shot tagging). Currently false on Intel macOS;
+// see CMakeLists.txt for the gate.
+constexpr bool clapBackendAvailable() noexcept {
+#ifdef MAGDA_HAVE_CLAP
+    return true;
+#else
+    return false;
+#endif
+}
+
 class MediaDatabase;
 class ClapAudioEncoder;
 class ClapTextEncoder;

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -1433,7 +1433,9 @@ AISettingsDialog::AISettingsDialog() {
     cloudPage_ = std::make_unique<CloudPage>();
     localPage_ = std::make_unique<LocalPage>();
     configPage_ = std::make_unique<ConfigPage>();
-    samplePage_ = std::make_unique<SampleTaggerPage>();
+    if constexpr (magda::media::clapBackendAvailable()) {
+        samplePage_ = std::make_unique<SampleTaggerPage>();
+    }
 
     // Wire config page to sibling pages
     configPage_->cloudPage = cloudPage_.get();
@@ -1443,7 +1445,9 @@ AISettingsDialog::AISettingsDialog() {
     tabbedComponent_.addTab("Cloud", tabBg, cloudPage_.get(), false);
     tabbedComponent_.addTab("Local", tabBg, localPage_.get(), false);
     tabbedComponent_.addTab("Config", tabBg, configPage_.get(), false);
-    tabbedComponent_.addTab("Sample Analyzer", tabBg, samplePage_.get(), false);
+    if (samplePage_) {
+        tabbedComponent_.addTab("Sample Analyzer", tabBg, samplePage_.get(), false);
+    }
 
     // Refresh config combos when switching to Config tab
     tabbedComponent_.onTabChanged = [this](int tabIndex) {
@@ -1496,7 +1500,9 @@ void AISettingsDialog::loadSettings() {
     cloudPage_->load(config);
     localPage_->load(config);
     configPage_->load(config);
-    samplePage_->load(config);
+    if (samplePage_) {
+        samplePage_->load(config);
+    }
 }
 
 void AISettingsDialog::applySettings() {
@@ -1504,7 +1510,9 @@ void AISettingsDialog::applySettings() {
     cloudPage_->apply(config);
     localPage_->apply(config);
     configPage_->apply(config);
-    samplePage_->apply(config);
+    if (samplePage_) {
+        samplePage_->apply(config);
+    }
     config.save();
 }
 

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
@@ -688,10 +688,12 @@ class MediaDbBrowserContent::ResultsTableModel : public juce::TableListBoxModel 
                          !owner_.indexing_ && selectedCount == 1 && rowMissing);
             menu.addItem(5, "Delete selected rows (" + juce::String(selectedCount) + ")",
                          !owner_.indexing_);
-            menu.addSeparator();
-            menu.addItem(1, "Find similar sounds to \"" + fileName + "\"");
-            menu.addSeparator();
-            menu.addItem(2, "Analyze selected rows (" + juce::String(selectedCount) + ")");
+            if constexpr (magda::media::clapBackendAvailable()) {
+                menu.addSeparator();
+                menu.addItem(1, "Find similar sounds to \"" + fileName + "\"");
+                menu.addSeparator();
+                menu.addItem(2, "Analyze selected rows (" + juce::String(selectedCount) + ")");
+            }
             const juce::Component::SafePointer<MediaDbBrowserContent> self(&owner_);
             const auto seedId = r.fileId;
             const auto seedName = fileName;
@@ -2067,9 +2069,11 @@ void MediaDbBrowserContent::applySearchResultsToUi() {
             }
         } else {
             text = "No results match the current filters.";
-            if (!queryText_.isEmpty() && !magda::media::SampleTaggerDownloader::isInstalled()) {
-                text += "\n\nText search is filename / tag only without the AI Sample "
-                        "Analyzer.\nInstall it from AI Settings > Sample Analyzer.";
+            if constexpr (magda::media::clapBackendAvailable()) {
+                if (!queryText_.isEmpty() && !magda::media::SampleTaggerDownloader::isInstalled()) {
+                    text += "\n\nText search is filename / tag only without the AI Sample "
+                            "Analyzer.\nInstall it from AI Settings > Sample Analyzer.";
+                }
             }
         }
         emptyState_.setText(text, juce::dontSendNotification);
@@ -2188,24 +2192,26 @@ void MediaDbBrowserContent::startIndexing(const juce::File& dir,
             }));
     };
 
-    if (!magda::media::SampleTaggerDownloader::isInstalled()) {
-        const juce::Component::SafePointer<MediaDbBrowserContent> self(this);
-        juce::AlertWindow::showAsync(
-            juce::MessageBoxOptions()
-                .withIconType(juce::MessageBoxIconType::InfoIcon)
-                .withTitle("AI Sample Analyzer not installed")
-                .withMessage(
-                    "Indexing will run, but without the Sample Analyzer the library can only do "
-                    "filename / tag / family / BPM filtering - no semantic text search.\n\n"
-                    "Install it any time from AI Settings > Sample Analyzer.")
-                .withButton("Continue indexing")
-                .withButton("Cancel"),
-            [self, presentTagOptionsDialog = std::move(presentTagOptionsDialog)](int result) {
-                if (auto* page = self.getComponent(); page != nullptr && result == 1) {
-                    presentTagOptionsDialog();
-                }
-            });
-        return;
+    if constexpr (magda::media::clapBackendAvailable()) {
+        if (!magda::media::SampleTaggerDownloader::isInstalled()) {
+            const juce::Component::SafePointer<MediaDbBrowserContent> self(this);
+            juce::AlertWindow::showAsync(
+                juce::MessageBoxOptions()
+                    .withIconType(juce::MessageBoxIconType::InfoIcon)
+                    .withTitle("AI Sample Analyzer not installed")
+                    .withMessage(
+                        "Indexing will run, but without the Sample Analyzer the library can only "
+                        "do filename / tag / family / BPM filtering - no semantic text search.\n\n"
+                        "Install it any time from AI Settings > Sample Analyzer.")
+                    .withButton("Continue indexing")
+                    .withButton("Cancel"),
+                [self, presentTagOptionsDialog = std::move(presentTagOptionsDialog)](int result) {
+                    if (auto* page = self.getComponent(); page != nullptr && result == 1) {
+                        presentTagOptionsDialog();
+                    }
+                });
+            return;
+        }
     }
     presentTagOptionsDialog();
 }


### PR DESCRIPTION
Compile-time flag (forced OFF on osx-x86_64) excludes the ONNX-backed CLAP encoders, which is the only piece of the media DB that needs ORT. Intel Mac builds now ship the full DAW + media DB minus semantic search and zero-shot tagging.

- CMake: skip ORT FetchContent + onnxruntime link when MAGDA_HAVE_CLAP=OFF
- ClapAudio/TextEncoder.cpp: PIMPL bodies wrapped in #ifdef so files compile without ORT (stub ctor throws; MediaDbContext catch already leaves the encoder pointer null, callers null-check)
- UI: hide "Find similar" / "Analyze rows" context items, AI Sample Analyzer install alert, and the Sample Analyzer settings tab on Intel Mac
- release.yml: add build-macos-x86_64 job on macos-13 producing a separate signed/notarized DMG