### PR TITLE
Derive executable bundle version from MAGDA_FULL_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,17 @@ if(NOT DEFINED MAGDA_FULL_VERSION OR MAGDA_FULL_VERSION STREQUAL "")
     endif()
 endif()
 
+# Bundle version for the executable metadata (macOS CFBundleShortVersionString /
+# CFBundleVersion, Windows VERSIONINFO). These fields require a numeric dotted
+# version, so strip any pre-release / git-describe suffix from MAGDA_FULL_VERSION
+# (e.g. "0.9.0-rc2-15-g1391223" -> "0.9.0"). Falls back to PROJECT_VERSION when
+# there is no leading numeric component (e.g. a bare commit hash).
+if(MAGDA_FULL_VERSION MATCHES "^([0-9]+(\\.[0-9]+)*)")
+    set(MAGDA_BUNDLE_VERSION "${CMAKE_MATCH_1}")
+else()
+    set(MAGDA_BUNDLE_VERSION "${PROJECT_VERSION}")
+endif()
+
 # ccache disabled - causes unnecessary rebuilds with Ninja
 # The interaction between ccache, Ninja, and JUCE's glob verification
 # causes all 258+ targets to rebuild on every invocation.

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -266,7 +266,7 @@ add_library(magda_daw STATIC
 
 # JUCE GUI app — sources contributed below via add_subdirectory().
 juce_add_gui_app(magda_daw_app
-    VERSION "0.1.0"
+    VERSION "${MAGDA_BUNDLE_VERSION}"
     COMPANY_NAME "MAGDA"
     PRODUCT_NAME "MAGDA"
     ICON_BIG "${CMAKE_CURRENT_SOURCE_DIR}/../../assets/app_icon.png"
@@ -319,7 +319,7 @@ endif()
 
 # Out-of-process plugin scanner.
 juce_add_console_app(magda_plugin_scanner
-    VERSION "1.0.0"
+    VERSION "${MAGDA_BUNDLE_VERSION}"
     COMPANY_NAME "MAGDA"
     PRODUCT_NAME "MAGDA Plugin Scanner"
 )


### PR DESCRIPTION
## What

The built app's bundle metadata was stuck at `0.1.0`. The macOS `Info.plist` of the released `MAGDA-0.9.0-macOS-arm64.dmg` read `CFBundleShortVersionString = 0.1.0` / `CFBundleVersion = 0.1.0`, because `juce_add_gui_app(magda_daw_app)` hardcoded `VERSION "0.1.0"` (and the plugin scanner hardcoded `1.0.0`), never wired to the real version.

## Fix

- Derive a numeric `MAGDA_BUNDLE_VERSION` from `MAGDA_FULL_VERSION`, stripping any pre-release / git-describe suffix (e.g. `0.9.0-1-g0c842de0e` -> `0.9.0`), since `CFBundleShortVersionString` / Windows `VERSIONINFO` require a numeric dotted version. Falls back to `PROJECT_VERSION` for a bare commit hash.
- Pass `${MAGDA_BUNDLE_VERSION}` to both `magda_daw_app` and `magda_plugin_scanner`.

The in-app `MAGDA_VERSION` (About dialog / splash) still uses the full string.

## Verification

Reconfigured locally; the regenerated `Info.plist` now reads:

```
CFBundleShortVersionString   = 0.9.0
CFBundleVersion              = 0.9.0
```

Fixes #1336