### PR TITLE
ci(release): move Intel macOS build to macos-15-intel runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,9 +252,10 @@ jobs:
 
   build-macos-x86_64:
     # Intel Mac build (MAGDA_HAVE_CLAP=OFF, no semantic search).
-    # macos-13 is the last x86_64 runner GitHub offers — when it goes away we
-    # will need a self-hosted runner or to drop this build.
-    runs-on: macos-13
+    # macos-15-intel is the last x86_64 runner GitHub offers (available until
+    # Aug 2027). macos-13 was retired in Dec 2025. After macos-15-intel goes
+    # away we will need a self-hosted runner or to drop this build.
+    runs-on: macos-15-intel
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
## Problem

The `build-macos-x86_64` release job targets `runs-on: macos-13`. GitHub retired the macOS 13 runner image (deprecation began Sept 2025, fully unsupported December 2025), so the job sits `queued` indefinitely waiting for a runner that no longer exists. This blocked the `v0.9.1-rc0` release run (the other three builds passed; only the Intel job hung).

## Fix

Switch to `macos-15-intel`, the replacement x86_64 image GitHub provides. It is the last Intel image, available until August 2027, after which x86_64 macOS is unsupported on GitHub-hosted runners.

No other changes needed: the job's tooling (brew, ninja, sccache, codesign, keychain) is version-agnostic, and `CMAKE_OSX_DEPLOYMENT_TARGET=11.0` builds fine under the newer SDK.

## Refs

- [GitHub Actions: macOS 13 runner image is closing down](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)
- [runner-images #13045 - macOS 15 Sonoma Intel image](https://github.com/actions/runner-images/issues/13045)