### PR TITLE
ci(release): emit notarized .app.zip per arch for MuseHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,6 +224,26 @@ jobs:
         echo "Stapling notarization ticket..."
         xcrun stapler staple "$DMG_NAME"
 
+    - name: Create MuseHub app bundle (arm64)
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        # MuseHub rejects DMGs; it wants a notarized .app zipped with symlinks
+        # preserved (their "zip -y"). The DMG notarization above registered this
+        # app's code hash with Apple, so we can staple the ticket straight into
+        # the .app, then ditto-zip it (ditto preserves the framework symlinks a
+        # plain zip would flatten). Stays a CI artifact, not a public release asset.
+        APP_PATH="build/magda/daw/magda_daw_app_artefacts/Release/MAGDA.app"
+        ZIP_NAME="MAGDA-${VERSION}-macOS-arm64.app.zip"
+
+        xcrun stapler staple "$APP_PATH"
+        xcrun stapler validate "$APP_PATH"
+
+        ditto -c -k --keepParent "$APP_PATH" "$ZIP_NAME"
+        shasum -a 256 "$ZIP_NAME" > "${ZIP_NAME}.sha256"
+        echo "MuseHub bundle created: $ZIP_NAME"
+        ls -lh "$ZIP_NAME"
+
     - name: Generate checksum
       env:
         VERSION: ${{ steps.version.outputs.version }}
@@ -239,6 +259,8 @@ jobs:
         path: |
           MAGDA-*-macOS-arm64.dmg
           MAGDA-*-macOS-arm64.dmg.sha256
+          MAGDA-*-macOS-arm64.app.zip
+          MAGDA-*-macOS-arm64.app.zip.sha256
 
     - name: Clean up
       if: always()
@@ -449,6 +471,26 @@ jobs:
         echo "Stapling notarization ticket..."
         xcrun stapler staple "$DMG_NAME"
 
+    - name: Create MuseHub app bundle (x86_64)
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        # MuseHub rejects DMGs; it wants a notarized .app zipped with symlinks
+        # preserved (their "zip -y"). The DMG notarization above registered this
+        # app's code hash with Apple, so we can staple the ticket straight into
+        # the .app, then ditto-zip it (ditto preserves the framework symlinks a
+        # plain zip would flatten). Stays a CI artifact, not a public release asset.
+        APP_PATH="build/magda/daw/magda_daw_app_artefacts/Release/MAGDA.app"
+        ZIP_NAME="MAGDA-${VERSION}-macOS-x86_64.app.zip"
+
+        xcrun stapler staple "$APP_PATH"
+        xcrun stapler validate "$APP_PATH"
+
+        ditto -c -k --keepParent "$APP_PATH" "$ZIP_NAME"
+        shasum -a 256 "$ZIP_NAME" > "${ZIP_NAME}.sha256"
+        echo "MuseHub bundle created: $ZIP_NAME"
+        ls -lh "$ZIP_NAME"
+
     - name: Generate checksum
       env:
         VERSION: ${{ steps.version.outputs.version }}
@@ -464,6 +506,8 @@ jobs:
         path: |
           MAGDA-*-macOS-x86_64.dmg
           MAGDA-*-macOS-x86_64.dmg.sha256
+          MAGDA-*-macOS-x86_64.app.zip
+          MAGDA-*-macOS-x86_64.app.zip.sha256
 
     - name: Clean up
       if: always()
@@ -1003,6 +1047,10 @@ jobs:
           MAGDA-*-Linux-x86_64.AppImage.sha256
 
   create-release:
+    # Publish a GitHub Release only for tag pushes. A workflow_dispatch run is
+    # for regenerating build artifacts (e.g. the MuseHub .app.zip for an already
+    # released version) and must never mutate a published release.
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: [build-macos, build-macos-x86_64, build-windows, build-linux]
     runs-on: ubuntu-latest
     permissions:
@@ -1051,8 +1099,10 @@ jobs:
         generate_release_notes: true
         fail_on_unmatched_files: true
         files: |
-          macos-release/*
-          macos-x86_64-release/*
+          macos-release/MAGDA-*-macOS-arm64.dmg
+          macos-release/MAGDA-*-macOS-arm64.dmg.sha256
+          macos-x86_64-release/MAGDA-*-macOS-x86_64.dmg
+          macos-x86_64-release/MAGDA-*-macOS-x86_64.dmg.sha256
           windows-x86_64-release/MAGDA-*-Windows-x86_64-Setup.exe
           windows-x86_64-release/MAGDA-*-Windows-x86_64-Setup.exe.sha256
           windows-x86_64-release/MAGDA-*-Windows-x86_64.pdb


### PR DESCRIPTION
## What

MuseHub rejects DMG installers on macOS. It wants a notarized `.app` zipped with symlinks preserved (its "zip -y"), which it then installs to /Applications.

This adds, to both mac jobs, a step that runs after DMG notarization:
- `xcrun stapler staple MAGDA.app` (+ validate) - the DMG notarization above already registered the app's code hash with Apple, so the ticket can be stapled straight into the bundle, making the zip validate offline.
- `ditto -c -k --keepParent MAGDA.app MAGDA-<v>-macOS-<arch>.app.zip` - `ditto` preserves the framework symlinks a plain `zip` would flatten.

Produces `MAGDA-<v>-macOS-arm64.app.zip` and `MAGDA-<v>-macOS-x86_64.app.zip`.

## Partner-only, like the Windows MuseHub bundle

The `create-release` asset globs are narrowed to the DMGs, so the `.app.zip`s live in the `macos-release` / `macos-x86_64-release` CI artifacts but are NOT attached to the public GitHub release. Public DMGs on magda.land/GitHub are unchanged.

## Safe regeneration via workflow_dispatch

`create-release` is now gated to tag pushes only (`refs/tags/v*`). A `workflow_dispatch` run becomes a safe "rebuild artifacts" path: it builds every platform and uploads the artifacts (including the MuseHub `.app.zip`) but never publishes or mutates a GitHub release.

This is how we hand MuseHub a bundle for an already released version with no version bump: merge here, then run the Release workflow from `main` with `version: 0.9.1`, and download the `.app.zip`s from the run artifacts.

## Notes

- Intel `.app.zip` comes from the `MAGDA_HAVE_CLAP=OFF` build (no semantic search), same as the Intel DMG.
- YAML validated; ASCII-only.