### PR TITLE
feat: keyboard autoplay + LEFT/RIGHT transport in sample browser (#1339)

### DIFF
--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
@@ -836,6 +836,45 @@ class MediaDbBrowserContent::ResultsTableModel : public juce::TableListBoxModel 
 };
 
 // ===========================================================================
+// ResultsTable — keyboard handling (issue #1339)
+// ===========================================================================
+
+bool MediaDbBrowserContent::ResultsTable::keyPressed(const juce::KeyPress& key) {
+    // Transport keys: consume regardless of base-class outcome — neither
+    // ListBox nor TableListBox does anything useful with LEFT/RIGHT, so
+    // re-binding them for the audio preview is safe.
+    if (key == juce::KeyPress::leftKey) {
+        if (onStopRequest) {
+            onStopRequest();
+        }
+        return true;
+    }
+    if (key == juce::KeyPress::rightKey) {
+        if (onReplayRequest) {
+            onReplayRequest();
+        }
+        return true;
+    }
+
+    // Navigation keys: let ListBox move the selection, then audition the
+    // new row. We compare before/after so arrowing past the list edge
+    // (selection unchanged) doesn't re-trigger playback.
+    const bool isNav = key == juce::KeyPress::upKey || key == juce::KeyPress::downKey ||
+                       key == juce::KeyPress::pageUpKey || key == juce::KeyPress::pageDownKey ||
+                       key == juce::KeyPress::homeKey || key == juce::KeyPress::endKey;
+
+    const int rowBefore = isNav ? getSelectedRow() : -1;
+    const bool handled = juce::TableListBox::keyPressed(key);
+    if (handled && isNav && onKeyboardRowSelected) {
+        const int rowAfter = getSelectedRow();
+        if (rowAfter >= 0 && rowAfter != rowBefore) {
+            onKeyboardRowSelected(rowAfter);
+        }
+    }
+    return handled;
+}
+
+// ===========================================================================
 // MediaDbBrowserContent
 // ===========================================================================
 
@@ -957,6 +996,32 @@ MediaDbBrowserContent::MediaDbBrowserContent(bool isPopOutInstance)
                             DarkTheme::getColour(DarkTheme::BACKGROUND));
     resultsTable_.setColour(juce::ListBox::outlineColourId, DarkTheme::getBorderColour());
     resultsTable_.setOutlineThickness(1);
+
+    // Issue #1339: keyboard nav over the results list should audition the
+    // highlighted row (same path as the model's cellClicked) and
+    // LEFT/RIGHT should drive the preview transport. Fire onFileSelected
+    // with the row's file so the parent's autoplay-toggle logic in
+    // MediaExplorerContent::dbBrowser_->onFileSelected takes care of the
+    // rest — keeping a single autoplay decision point.
+    resultsTable_.onKeyboardRowSelected = [this](int row) {
+        if (row < 0 || row >= static_cast<int>(results_.size())) {
+            return;
+        }
+        const auto& r = results_[static_cast<size_t>(row)];
+        if (onFileSelected) {
+            onFileSelected(juce::File(juce::String(r.path.string())));
+        }
+    };
+    resultsTable_.onStopRequest = [this]() {
+        if (onPreviewStopRequest) {
+            onPreviewStopRequest();
+        }
+    };
+    resultsTable_.onReplayRequest = [this]() {
+        if (onPreviewReplayRequest) {
+            onPreviewReplayRequest();
+        }
+    };
 
     auto& header = resultsTable_.getHeader();
     header.setColour(juce::TableHeaderComponent::backgroundColourId,

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.hpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.hpp
@@ -56,8 +56,19 @@ class MediaDbBrowserContent : public juce::Component, private juce::Timer {
     // nullopt to clear the filter. Re-runs the search.
     void setKindFilter(std::optional<std::string> kind);
 
-    // Fired when the user clicks a result row.
+    // Fired when the user clicks a result row OR selects a different row
+    // via the keyboard. The parent uses this to drive audition / autoplay,
+    // so keyboard nav (UP/DOWN/PgUp/PgDn/Home/End) needs to fire it too —
+    // not only mouse clicks. See ResultsTable::keyPressed.
     std::function<void(const juce::File&)> onFileSelected;
+
+    // Keyboard transport hooks for the results list (issue #1339):
+    //   LEFT  arrow → onPreviewStopRequest  (stop the current preview)
+    //   RIGHT arrow → onPreviewReplayRequest (restart preview from 0)
+    // Parent (MediaExplorerContent) owns the audio transport, so these
+    // bubble out instead of being handled here.
+    std::function<void()> onPreviewStopRequest;
+    std::function<void()> onPreviewReplayRequest;
 
     // Indexing-progress callbacks. Empty string in onIndexingStatus means
     // "no indexing in progress" — the parent component uses these to
@@ -90,12 +101,28 @@ class MediaDbBrowserContent : public juce::Component, private juce::Timer {
             juce::TableListBox::selectedRowsChanged(row);
         }
 
+        // Keyboard handling for issue #1339 — make UP/DOWN navigation
+        // audition the highlighted row (the model's cellClicked path only
+        // fires on mouse) and bind LEFT/RIGHT to stop / replay-from-zero.
+        // We intercept *after* the base class moves the selection so we
+        // can read the post-move row, and only fire when the row actually
+        // changed (avoids re-trigger when arrowing past the list edge).
+        bool keyPressed(const juce::KeyPress& key) override;
+
         void syncSelectionSnapshot() {
             lastKnownSelection_ = getSelectedRows();
             preClickSelection_ = lastKnownSelection_;
         }
 
         juce::SparseSet<int> preClickSelection_;
+
+        // Wired from MediaDbBrowserContent ctor. Fired with the new row
+        // index after a keyboard nav key changes the selection.
+        std::function<void(int row)> onKeyboardRowSelected;
+        // Wired from MediaDbBrowserContent ctor; forwarded to the parent
+        // browser's transport via the public onPreviewStop/Replay hooks.
+        std::function<void()> onStopRequest;
+        std::function<void()> onReplayRequest;
 
       private:
         juce::SparseSet<int> lastKnownSelection_;

--- a/magda/daw/ui/panels/content/MediaExplorerContent.cpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.cpp
@@ -842,6 +842,12 @@ MediaExplorerContent::MediaExplorerContent() {
                             DarkTheme::getTextColour());
         listComp->setColour(juce::DirectoryContentsDisplayComponent::highlightedTextColourId,
                             DarkTheme::getTextColour());
+        // Issue #1339 — bind LEFT/RIGHT on the file list to preview
+        // stop/replay. UP/DOWN already audition via JUCE's built-in
+        // selection-change path (FileListComponent::selectedRowsChanged
+        // → FileBrowserListener::selectionChanged), provided the list has
+        // keyboard focus.
+        listComp->addKeyListener(this);
     }
 
     // Apply LookAndFeel to ComboBox child and hide the filename editor
@@ -882,10 +888,17 @@ MediaExplorerContent::MediaExplorerContent() {
         loadFileForPreview(f);
         // Match the file-browser's selectionChanged path: respect the Auto
         // toggle so picking a DB row auto-plays when the user wants it.
+        // This fires from both mouse clicks (ResultsTableModel::cellClicked)
+        // and keyboard nav (ResultsTable::keyPressed → onKeyboardRowSelected)
+        // — issue #1339.
         if (autoPlayButton_.getToggleState()) {
             playPreview();
         }
     };
+    // Issue #1339 — LEFT / RIGHT on the DB results table drive the same
+    // preview transport that the filesystem browser uses.
+    dbBrowser_->onPreviewStopRequest = [this]() { stopPreview(); };
+    dbBrowser_->onPreviewReplayRequest = [this]() { restartPreview(); };
     // Surface indexing progress in the preview area so it's visible from
     // both the filesystem browser and the DB browser. Empty string clears.
     dbBrowser_->onIndexingStatus = [this](const juce::String& status) {
@@ -919,6 +932,13 @@ MediaExplorerContent::~MediaExplorerContent() {
         if (auto* comboBox = dynamic_cast<juce::ComboBox*>(fileBrowser_->getChildComponent(i))) {
             comboBox->setLookAndFeel(nullptr);
         }
+    }
+    // Mirror addKeyListener in the ctor (issue #1339). The FileListComponent
+    // is owned by fileBrowser_, which is still alive at the top of this
+    // dtor body — safe to detach now.
+    if (auto* listComp =
+            dynamic_cast<juce::FileListComponent*>(fileBrowser_->getDisplayComponent())) {
+        listComp->removeKeyListener(this);
     }
     fileBrowser_->setLookAndFeel(nullptr);
     autoPlayButton_.setLookAndFeel(nullptr);
@@ -1203,6 +1223,34 @@ void MediaExplorerContent::stopPreview() {
         stopButton_->setEnabled(false);
         thumbnailComponent_->setPlaying(false);
     }
+}
+
+void MediaExplorerContent::restartPreview() {
+    // playPreview() is a no-op while isPlaying_ is true, so stop first.
+    // The stop is a no-op if we aren't already playing, which keeps
+    // "RIGHT arrow on a loaded-but-paused file" working as "play from 0".
+    if (transportSource_ == nullptr || !currentPreviewFile_.existsAsFile()) {
+        return;
+    }
+    if (isPlaying_) {
+        stopPreview();
+    }
+    playPreview();
+}
+
+bool MediaExplorerContent::keyPressed(const juce::KeyPress& key, juce::Component* /*origin*/) {
+    // Issue #1339 — invoked via FileListComponent::addKeyListener above.
+    // Only handle LEFT/RIGHT; UP/DOWN (and PgUp/PgDn/Home/End) are owned
+    // by FileListComponent and already audition via selectionChanged().
+    if (key == juce::KeyPress::leftKey) {
+        stopPreview();
+        return true;
+    }
+    if (key == juce::KeyPress::rightKey) {
+        restartPreview();
+        return true;
+    }
+    return false;
 }
 
 void MediaExplorerContent::setPreviewLockedForIndexing(bool locked) {

--- a/magda/daw/ui/panels/content/MediaExplorerContent.hpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.hpp
@@ -20,7 +20,8 @@ class MediaDbBrowserContent;  // forward decl — defined in MediaDbBrowserConte
 class MediaExplorerContent : public PanelContent,
                              public juce::FileBrowserListener,
                              public juce::ChangeListener,
-                             public juce::Timer {
+                             public juce::Timer,
+                             public juce::KeyListener {
   public:
     MediaExplorerContent();
     ~MediaExplorerContent() override;
@@ -57,6 +58,16 @@ class MediaExplorerContent : public PanelContent,
     // Mouse event overrides (Component already is a MouseListener)
     void mouseDrag(const juce::MouseEvent& e) override;
     void mouseUp(const juce::MouseEvent& e) override;
+
+    // KeyListener — intercepts LEFT/RIGHT on the filesystem file list to
+    // stop / replay the current preview (issue #1339). UP/DOWN are left
+    // to FileListComponent's built-in selection handling, which already
+    // routes through selectionChanged() and triggers autoplay.
+    // The `using` un-hides the inherited Component::keyPressed(KeyPress)
+    // overload that the two-arg KeyListener override would otherwise
+    // shadow (-Woverloaded-virtual).
+    using juce::Component::keyPressed;
+    bool keyPressed(const juce::KeyPress& key, juce::Component* origin) override;
 
   private:
     // Routes a click on the audio/MIDI/preset type icon to either the
@@ -175,6 +186,11 @@ class MediaExplorerContent : public PanelContent,
     void loadFileForPreview(const juce::File& file);
     void playPreview();
     void stopPreview();
+    // Restart the current preview from t=0, even if it's already playing.
+    // playPreview() short-circuits when isPlaying_ is true, so the RIGHT
+    // arrow / DB browser onPreviewReplayRequest path goes through this
+    // wrapper instead of calling playPreview() directly.
+    void restartPreview();
     void setPreviewLockedForIndexing(bool locked);
     void updateFileInfo(const juce::File& file);
     void navigateToDirectory(const juce::File& directory);


### PR DESCRIPTION
UP/DOWN over the Library results table now auditions the highlighted row when 'Auto' is on — previously only mouse clicks did. UP/DOWN in the filesystem browser already worked (JUCE's FileListComponent routes keyboard selection through selectionChanged()), but only when the list itself had keyboard focus, which is why the bug only showed up in the library view.

Both browsers also bind LEFT = stop and RIGHT = replay-from-zero on the preview transport, per the issue author's request.

MediaDbBrowserContent::ResultsTable now overrides keyPressed() to fire new onKeyboardRowSelected / onStopRequest / onReplayRequest callbacks; keyboard nav is routed through keyPressed (not selectedRowsChanged) so that programmatic setSelectedRows calls — e.g. the pill-click sticky- selection restore — do not retrigger autoplay. MediaExplorerContent becomes a juce::KeyListener attached to the inner FileListComponent and owns a restartPreview() helper shared between both browsers.