### PR TITLE
Fix external plugin voice clobbered on load by stale parameter array

### DIFF
--- a/magda/daw/audio/plugin_manager/ExternalPluginStateUtil.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginStateUtil.hpp
@@ -29,6 +29,12 @@ inline void refreshExternalPluginParameterCache(tracktion::engine::Plugin* plugi
     auto* ext = dynamic_cast<tracktion::engine::ExternalPlugin*>(plugin);
     if (ext == nullptr)
         return;
+    // Only meaningful once the instance is live. Before async instantiation
+    // completes there are no ExternalAutomatableParameters to refresh, and TE
+    // rebuilds + refreshes the cache itself on completion
+    // (completePluginInstanceCreation). Guard explicitly, matching createPluginOnly.
+    if (ext->isInitialisingAsync() || ext->getAudioPluginInstance() == nullptr)
+        return;
     for (auto* p : ext->getAutomatableParameters())
         if (auto* ep = dynamic_cast<tracktion::engine::ExternalAutomatableParameter*>(p))
             ep->valueChangedByPlugin();
@@ -45,7 +51,13 @@ inline void applyExternalPluginChunk(tracktion::engine::Plugin* plugin, const ju
     auto* ext = dynamic_cast<tracktion::engine::ExternalPlugin*>(plugin);
     if (ext == nullptr)
         return;
+    // Always publish the chunk on the state property: TE reads it during async
+    // instantiation, so this is how an async plugin receives its state.
     ext->state.setProperty(tracktion::engine::IDs::state, chunk, nullptr);
+    // Apply + refresh only once the instance is live (matches createPluginOnly's
+    // guard); for an async plugin TE applies the property itself on completion.
+    if (ext->isInitialisingAsync() || ext->getAudioPluginInstance() == nullptr)
+        return;
     ext->restorePluginStateFromValueTree(ext->state);
     refreshExternalPluginParameterCache(ext);
 }

--- a/magda/daw/audio/plugin_manager/ExternalPluginStateUtil.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginStateUtil.hpp
@@ -9,38 +9,45 @@
 namespace magda {
 
 /**
- * Make an external plugin's native state chunk authoritative over its saved
- * per-parameter array.
+ * Sync TE's AutomatableParameter cache for an external plugin to the plugin's
+ * current (already-restored) parameter values.
  *
- * For a VST/AU the entire voice lives in the native state chunk (pluginState) --
- * it already encodes every parameter. Restoring a device also re-applies the
- * saved per-parameter array (syncFromDeviceInfo), which corrupts the restored
- * voice whenever that array is stale relative to the chunk (e.g. parameters
- * captured during an earlier buggy load, before the param cache tracked the
- * restored voice). Call this AFTER the parameter sync so the chunk wins: it
- * re-asserts the chunk, then refreshes TE's AutomatableParameter cache from the
- * live plugin so the later playback-graph build can't write stale cached values
- * back over the voice.
+ * For a VST/AU the entire voice lives in the native state chunk; restoring it via
+ * setStateInformation updates the plugin but NOT TE's per-parameter cache, which
+ * was read at plugin construction (the default/INIT voice). When the playback
+ * graph is later built TE writes that cache back onto the plugin, reverting the
+ * restored voice. Calling this after the chunk is restored makes the cache agree
+ * with the plugin so the graph build is a no-op. No-op for internal plugins / no
+ * instance.
  *
- * No-ops for internal plugins and for an empty chunk. Callers should re-capture
- * DeviceInfo::parameters (populateParameters) afterwards so the canonical model
- * reflects the restored voice, breaking the stale-array cycle.
- *
- * (The async load path avoids this entirely: it only reads parameters back, never
- * writes the saved array, so the restored chunk is never touched.)
+ * This is the single source of truth for the parameter clobber: it does NOT
+ * depend on call ordering relative to ExternalPluginProcessor::syncFromDeviceInfo,
+ * because syncFromDeviceInfo deliberately does not write the saved per-parameter
+ * array while a chunk is present (see ExternalPluginProcessor.cpp).
  */
-inline void reassertExternalPluginChunk(tracktion::engine::Plugin* plugin,
-                                        const juce::String& pluginState) {
-    if (pluginState.isEmpty())
+inline void refreshExternalPluginParameterCache(tracktion::engine::Plugin* plugin) {
+    auto* ext = dynamic_cast<tracktion::engine::ExternalPlugin*>(plugin);
+    if (ext == nullptr)
+        return;
+    for (auto* p : ext->getAutomatableParameters())
+        if (auto* ep = dynamic_cast<tracktion::engine::ExternalAutomatableParameter*>(p))
+            ep->valueChangedByPlugin();
+}
+
+/**
+ * Apply a saved native-state chunk to an external plugin and sync TE's parameter
+ * cache to it. Use when (re)applying authoritative state, e.g. loading a device
+ * preset. No-op for internal plugins / empty chunk.
+ */
+inline void applyExternalPluginChunk(tracktion::engine::Plugin* plugin, const juce::String& chunk) {
+    if (chunk.isEmpty())
         return;
     auto* ext = dynamic_cast<tracktion::engine::ExternalPlugin*>(plugin);
     if (ext == nullptr)
         return;
-    ext->state.setProperty(tracktion::engine::IDs::state, pluginState, nullptr);
+    ext->state.setProperty(tracktion::engine::IDs::state, chunk, nullptr);
     ext->restorePluginStateFromValueTree(ext->state);
-    for (auto* p : ext->getAutomatableParameters())
-        if (auto* ep = dynamic_cast<tracktion::engine::ExternalAutomatableParameter*>(p))
-            ep->valueChangedByPlugin();
+    refreshExternalPluginParameterCache(ext);
 }
 
 }  // namespace magda

--- a/magda/daw/audio/plugin_manager/ExternalPluginStateUtil.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginStateUtil.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <tracktion_engine/tracktion_engine.h>
+// Internal TE header: ExternalAutomatableParameter is not exposed via the module
+// umbrella, but its public valueChangedByPlugin() is how we refresh TE's parameter
+// cache from a synth after restoring its native state chunk.
+#include <tracktion_engine/plugins/external/tracktion_ExternalAutomatableParameter.h>
+
+namespace magda {
+
+/**
+ * Make an external plugin's native state chunk authoritative over its saved
+ * per-parameter array.
+ *
+ * For a VST/AU the entire voice lives in the native state chunk (pluginState) --
+ * it already encodes every parameter. Restoring a device also re-applies the
+ * saved per-parameter array (syncFromDeviceInfo), which corrupts the restored
+ * voice whenever that array is stale relative to the chunk (e.g. parameters
+ * captured during an earlier buggy load, before the param cache tracked the
+ * restored voice). Call this AFTER the parameter sync so the chunk wins: it
+ * re-asserts the chunk, then refreshes TE's AutomatableParameter cache from the
+ * live plugin so the later playback-graph build can't write stale cached values
+ * back over the voice.
+ *
+ * No-ops for internal plugins and for an empty chunk. Callers should re-capture
+ * DeviceInfo::parameters (populateParameters) afterwards so the canonical model
+ * reflects the restored voice, breaking the stale-array cycle.
+ *
+ * (The async load path avoids this entirely: it only reads parameters back, never
+ * writes the saved array, so the restored chunk is never touched.)
+ */
+inline void reassertExternalPluginChunk(tracktion::engine::Plugin* plugin,
+                                        const juce::String& pluginState) {
+    if (pluginState.isEmpty())
+        return;
+    auto* ext = dynamic_cast<tracktion::engine::ExternalPlugin*>(plugin);
+    if (ext == nullptr)
+        return;
+    ext->state.setProperty(tracktion::engine::IDs::state, pluginState, nullptr);
+    ext->restorePluginStateFromValueTree(ext->state);
+    for (auto* p : ext->getAutomatableParameters())
+        if (auto* ep = dynamic_cast<tracktion::engine::ExternalAutomatableParameter*>(p))
+            ep->valueChangedByPlugin();
+}
+
+}  // namespace magda

--- a/magda/daw/audio/plugin_manager/ExternalPluginStateUtil.hpp
+++ b/magda/daw/audio/plugin_manager/ExternalPluginStateUtil.hpp
@@ -1,10 +1,16 @@
 #pragma once
 
+// clang-format off
+// Order is load-bearing and MUST NOT be sorted: the internal header
+// tracktion_ExternalAutomatableParameter.h is not self-contained (it needs
+// juce::AudioProcessorParameter + AutomatableParameter from the umbrella) and is
+// not exposed via the module umbrella. With SortIncludes on, clang-format would
+// sort "plugins/..." ahead of "tracktion_engine.h" and break the build, so this
+// block is fenced off. We need the internal header for the public
+// valueChangedByPlugin(), which refreshes TE's parameter cache after a restore.
 #include <tracktion_engine/tracktion_engine.h>
-// Internal TE header: ExternalAutomatableParameter is not exposed via the module
-// umbrella, but its public valueChangedByPlugin() is how we refresh TE's parameter
-// cache from a synth after restoring its native state chunk.
 #include <tracktion_engine/plugins/external/tracktion_ExternalAutomatableParameter.h>
+// clang-format on
 
 namespace magda {
 
@@ -20,10 +26,11 @@ namespace magda {
  * with the plugin so the graph build is a no-op. No-op for internal plugins / no
  * instance.
  *
- * This is the single source of truth for the parameter clobber: it does NOT
- * depend on call ordering relative to ExternalPluginProcessor::syncFromDeviceInfo,
- * because syncFromDeviceInfo deliberately does not write the saved per-parameter
- * array while a chunk is present (see ExternalPluginProcessor.cpp).
+ * This is the final step of the baseline -> overlay -> refresh restore sequence
+ * (see restoreDeviceStateWithChunkOverlay in PluginManagerSync.cpp):
+ * syncFromDeviceInfo applies the saved parameter array as a baseline, the native
+ * chunk is applied as the authoritative overlay, then this refreshes TE's cache
+ * to match the resulting plugin state.
  */
 inline void refreshExternalPluginParameterCache(tracktion::engine::Plugin* plugin) {
     auto* ext = dynamic_cast<tracktion::engine::ExternalPlugin*>(plugin);

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -11,6 +11,7 @@
 #include "../PluginWindowBridge.hpp"
 #include "../TrackController.hpp"
 #include "../TracktionHelpers.hpp"
+#include "ExternalPluginStateUtil.hpp"
 #include "PluginManager.hpp"
 #include "modifiers/CurveSnapshot.hpp"
 #include "modifiers/ModifierHelpers.hpp"
@@ -1993,6 +1994,12 @@ void PluginManager::registerRackPluginProcessor(const ChainNodePath& devicePath,
         // Restore parameter values from DeviceInfo onto the newly created plugin
         processor->syncFromDeviceInfo(device);
 
+        // For external plugins (rack / master / post-fx paths) the chunk is
+        // authoritative; re-assert it so the saved parameter array can't clobber
+        // the restored voice, then refresh TE's param cache. Same hazard and fix
+        // as loadDeviceAsPlugin.
+        reassertExternalPluginChunk(plugin.get(), device.pluginState);
+
         // Populate processor-owned fields directly into the canonical
         // DeviceInfo. Snapshotting into a temp and copying only `.parameters`
         // back loses any other processor-populated field (wrapperParameters,
@@ -2181,7 +2188,10 @@ te::Plugin::Ptr PluginManager::loadDeviceAsPlugin(const ChainNodePath& devicePat
                     if (ext->isInitialisingAsync()) {
                         return plugin;  // Return bare wrapper; async poll handles the rest
                     }
-                    // Sync plugin already created — re-apply state now
+                    // Sync plugin already created — re-apply state now. (The
+                    // authoritative restore + param-cache refresh happens after
+                    // syncFromDeviceInfo below, where it can't be clobbered by the
+                    // saved per-parameter array.)
                     if (device.pluginState.isNotEmpty()) {
                         ext->restorePluginStateFromValueTree(ext->state);
                     }
@@ -2229,6 +2239,11 @@ te::Plugin::Ptr PluginManager::loadDeviceAsPlugin(const ChainNodePath& devicePat
                 << device.pluginState.length() << " params=" << device.parameters.size());
             DBG("[ChainMove] restore track input params: " << describeChainMoveParams(device));
             processor->syncFromDeviceInfo(device);
+
+            // Make the native state chunk authoritative over the saved parameter
+            // array (the subsequent populateParameters() then re-captures the
+            // correct values into DeviceInfo, breaking the stale-array cycle).
+            reassertExternalPluginChunk(plugin.get(), device.pluginState);
 
             // Populate processor-owned fields directly into the canonical
             // DeviceInfo (see comment in registerRackPluginProcessor).

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -182,6 +182,24 @@ bool savedPluginStateMatchesRequestedType(const juce::ValueTree& savedState,
 
     return false;
 }
+
+// Restore a loaded device's state as ONE ordered operation, so the
+// baseline -> overlay -> cache-refresh sequence lives in a single place and
+// can't be reordered (or half-applied) by callers:
+//   1. syncFromDeviceInfo applies the saved per-parameter array (plus gain/bypass)
+//      as a BASELINE -- the fallback that survives a missing/rejected/incomplete
+//      native chunk, and the sole source of truth for parameter-only devices.
+//   2. applyExternalPluginChunk applies the native state chunk as the AUTHORITATIVE
+//      overlay (wins wherever it restores) and refreshes TE's parameter cache so
+//      the playback-graph build preserves the merged result rather than writing
+//      construction-time defaults back.
+// Safe for any device type: the overlay no-ops for internal plugins / empty chunk,
+// leaving just the baseline.
+void restoreDeviceStateWithChunkOverlay(DeviceProcessor& processor, const te::Plugin::Ptr& plugin,
+                                        const DeviceInfo& device) {
+    processor.syncFromDeviceInfo(device);
+    applyExternalPluginChunk(plugin.get(), device.pluginState);
+}
 }  // namespace
 
 // =============================================================================
@@ -1991,15 +2009,9 @@ void PluginManager::registerRackPluginProcessor(const ChainNodePath& devicePath,
             << " params=" << device.parameters.size());
         DBG("[ChainMove] restore rack input params: " << describeChainMoveParams(device));
 
-        // Restore parameter values from DeviceInfo onto the newly created plugin
-        processor->syncFromDeviceInfo(device);
-
-        // For external plugins (rack / master / post-fx paths) the chunk was
-        // restored by createPluginOnly and owns the plugin's parameters
-        // (syncFromDeviceInfo skips the saved array while a chunk is present).
-        // Sync TE's parameter cache to the restored plugin. Same hazard and fix
-        // as loadDeviceAsPlugin.
-        refreshExternalPluginParameterCache(plugin.get());
+        // Saved params (baseline) then native chunk (authoritative overlay) then
+        // param-cache refresh -- one ordered op (same as loadDeviceAsPlugin).
+        restoreDeviceStateWithChunkOverlay(*processor, plugin, device);
 
         // Populate processor-owned fields directly into the canonical
         // DeviceInfo. Snapshotting into a temp and copying only `.parameters`
@@ -2239,15 +2251,9 @@ te::Plugin::Ptr PluginManager::loadDeviceAsPlugin(const ChainNodePath& devicePat
                 << device.id << " name='" << device.name << "' track=" << trackId << " stateLen="
                 << device.pluginState.length() << " params=" << device.parameters.size());
             DBG("[ChainMove] restore track input params: " << describeChainMoveParams(device));
-            processor->syncFromDeviceInfo(device);
-
-            // For an external plugin the chunk (restored above) is the source of
-            // truth for the plugin's parameters; syncFromDeviceInfo deliberately
-            // skips the saved array while a chunk is present, so it can't clobber
-            // the voice. Sync TE's parameter cache to the restored plugin so the
-            // playback-graph build doesn't write construction-time defaults back.
-            // populateParameters() then re-captures the canonical values.
-            refreshExternalPluginParameterCache(plugin.get());
+            // Saved params (baseline) then native chunk (authoritative overlay)
+            // then param-cache refresh -- one ordered op, see helper.
+            restoreDeviceStateWithChunkOverlay(*processor, plugin, device);
 
             // Populate processor-owned fields directly into the canonical
             // DeviceInfo (see comment in registerRackPluginProcessor).

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -1994,11 +1994,12 @@ void PluginManager::registerRackPluginProcessor(const ChainNodePath& devicePath,
         // Restore parameter values from DeviceInfo onto the newly created plugin
         processor->syncFromDeviceInfo(device);
 
-        // For external plugins (rack / master / post-fx paths) the chunk is
-        // authoritative; re-assert it so the saved parameter array can't clobber
-        // the restored voice, then refresh TE's param cache. Same hazard and fix
+        // For external plugins (rack / master / post-fx paths) the chunk was
+        // restored by createPluginOnly and owns the plugin's parameters
+        // (syncFromDeviceInfo skips the saved array while a chunk is present).
+        // Sync TE's parameter cache to the restored plugin. Same hazard and fix
         // as loadDeviceAsPlugin.
-        reassertExternalPluginChunk(plugin.get(), device.pluginState);
+        refreshExternalPluginParameterCache(plugin.get());
 
         // Populate processor-owned fields directly into the canonical
         // DeviceInfo. Snapshotting into a temp and copying only `.parameters`
@@ -2240,10 +2241,13 @@ te::Plugin::Ptr PluginManager::loadDeviceAsPlugin(const ChainNodePath& devicePat
             DBG("[ChainMove] restore track input params: " << describeChainMoveParams(device));
             processor->syncFromDeviceInfo(device);
 
-            // Make the native state chunk authoritative over the saved parameter
-            // array (the subsequent populateParameters() then re-captures the
-            // correct values into DeviceInfo, breaking the stale-array cycle).
-            reassertExternalPluginChunk(plugin.get(), device.pluginState);
+            // For an external plugin the chunk (restored above) is the source of
+            // truth for the plugin's parameters; syncFromDeviceInfo deliberately
+            // skips the saved array while a chunk is present, so it can't clobber
+            // the voice. Sync TE's parameter cache to the restored plugin so the
+            // playback-graph build doesn't write construction-time defaults back.
+            // populateParameters() then re-captures the canonical values.
+            refreshExternalPluginParameterCache(plugin.get());
 
             // Populate processor-owned fields directly into the canonical
             // DeviceInfo (see comment in registerRackPluginProcessor).

--- a/magda/daw/audio/processors/external/ExternalPluginProcessor.cpp
+++ b/magda/daw/audio/processors/external/ExternalPluginProcessor.cpp
@@ -152,7 +152,14 @@ void ExternalPluginProcessor::syncFromDeviceInfo(const DeviceInfo& info) {
                 }
             }
         };
-        apply(info.parameters);
+        // The native state chunk is the single source of truth for an external
+        // plugin's own parameters: when one is present it has already restored the
+        // full voice, so writing the saved per-parameter array would overwrite it
+        // with a possibly-stale copy. Only apply the saved plugin parameters for a
+        // parameter-only device (no chunk). The wrapper dry/wet pair is MAGDA's,
+        // not part of the plugin chunk, so it is always applied.
+        if (info.pluginState.isEmpty())
+            apply(info.parameters);
         apply(info.wrapperParameters);
     }
 

--- a/magda/daw/audio/processors/external/ExternalPluginProcessor.cpp
+++ b/magda/daw/audio/processors/external/ExternalPluginProcessor.cpp
@@ -152,14 +152,13 @@ void ExternalPluginProcessor::syncFromDeviceInfo(const DeviceInfo& info) {
                 }
             }
         };
-        // The native state chunk is the single source of truth for an external
-        // plugin's own parameters: when one is present it has already restored the
-        // full voice, so writing the saved per-parameter array would overwrite it
-        // with a possibly-stale copy. Only apply the saved plugin parameters for a
-        // parameter-only device (no chunk). The wrapper dry/wet pair is MAGDA's,
-        // not part of the plugin chunk, so it is always applied.
-        if (info.pluginState.isEmpty())
-            apply(info.parameters);
+        // Apply the saved parameter array as a BASELINE. For an external plugin
+        // with a native state chunk this gets overwritten by the chunk overlay
+        // (see restoreDeviceStateWithChunkOverlay in PluginManagerSync.cpp), but it
+        // is the fallback that survives when the chunk is missing, rejected, or
+        // doesn't cover every host-automatable parameter. For a parameter-only
+        // device (no chunk) it is the sole source of truth.
+        apply(info.parameters);
         apply(info.wrapperParameters);
     }
 

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -3,6 +3,7 @@
 
 #include "../audio/AudioBridge.hpp"
 #include "../audio/TracktionHelpers.hpp"
+#include "../audio/plugin_manager/ExternalPluginStateUtil.hpp"
 #include "../engine/AudioEngine.hpp"
 #include "PluginPreferences.hpp"
 #include "RackInfo.hpp"
@@ -1518,10 +1519,25 @@ bool TrackManager::applyDevicePreset(const ChainNodePath& devicePath,
     if (audioEngine_) {
         if (auto* bridge = audioEngine_->getAudioBridge()) {
             if (auto plugin = bridge->getPlugin(devicePath)) {
-                if (auto* ext = dynamic_cast<tracktion::engine::ExternalPlugin*>(plugin.get())) {
-                    ext->state.setProperty(tracktion::engine::IDs::state, live->pluginState,
-                                           nullptr);
-                    ext->restorePluginStateFromValueTree(ext->state);
+                if (dynamic_cast<tracktion::engine::ExternalPlugin*>(plugin.get()) != nullptr) {
+                    // Only when the preset carries a native state chunk: it is the
+                    // authoritative source for the entire voice. Re-assert it +
+                    // refresh TE's param cache, then re-derive live->parameters from
+                    // the plugin, so the preset's (possibly stale) saved parameter
+                    // array can't clobber the restored voice when the
+                    // devicePropertyChanged notification below drives
+                    // syncFromDeviceInfo. (Same hazard + helper as loadDeviceAsPlugin.)
+                    //
+                    // For a parameter-only preset (no chunk -- e.g. a plugin that
+                    // returns no state, or a legacy preset) we must NOT repopulate:
+                    // that would overwrite the preset's saved parameter values with
+                    // the plugin's current ones. Leave live->parameters as captured
+                    // and let the notification below apply them via syncFromDeviceInfo.
+                    if (live->pluginState.isNotEmpty()) {
+                        reassertExternalPluginChunk(plugin.get(), live->pluginState);
+                        if (auto* proc = bridge->getDeviceProcessor(devicePath))
+                            proc->populateParameters(*live);
+                    }
                 } else if (auto xml = juce::parseXML(live->pluginState)) {
                     auto savedState = juce::ValueTree::fromXml(*xml);
                     if (savedState.isValid())
@@ -1533,11 +1549,14 @@ bool TrackManager::applyDevicePreset(const ChainNodePath& devicePath,
 
     // Notify listeners — devicePropertyChanged covers gain/macros/mods refresh
     // via the AudioBridge sync path, then push each parameter individually so
-    // the UI's ParamGrid pickup matches what the preset captured.
+    // the UI's ParamGrid pickup matches what the preset captured. Address each by
+    // its real `paramIndex` (the TE automatable index), NOT the vector ordinal —
+    // ParameterInfo is not 1:1 with the TE parameter list (wrapper dry/wet live in
+    // wrapperParameters), and both the engine write (setParameterByIndex) and the
+    // UI lookup (findParameterByIndex) interpret the notified index as paramIndex.
     notifyDevicePropertyChanged(devicePath);
-    for (size_t i = 0; i < live->parameters.size(); ++i) {
-        notifyDeviceParameterChanged(devicePath, static_cast<int>(i),
-                                     live->parameters[i].currentValue);
+    for (const auto& p : live->parameters) {
+        notifyDeviceParameterChanged(devicePath, p.paramIndex, p.currentValue);
     }
     return true;
 }

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1534,7 +1534,7 @@ bool TrackManager::applyDevicePreset(const ChainNodePath& devicePath,
                     // the plugin's current ones. Leave live->parameters as captured
                     // and let the notification below apply them via syncFromDeviceInfo.
                     if (live->pluginState.isNotEmpty()) {
-                        reassertExternalPluginChunk(plugin.get(), live->pluginState);
+                        applyExternalPluginChunk(plugin.get(), live->pluginState);
                         if (auto* proc = bridge->getDeviceProcessor(devicePath))
                             proc->populateParameters(*live);
                     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -199,6 +199,7 @@ target_sources(magda_juce_tests PRIVATE
     ../magda/daw/ui/themes/FontManager.cpp
     test_automation_modes_juce.cpp
     test_arrangement_transport_loop_juce.cpp
+    test_external_plugin_state_restore_juce.cpp
 )
 
 # Link required libraries for JUCE tests
@@ -248,3 +249,6 @@ add_test(NAME arrange_beat_native_juce
 
 add_test(NAME midi_bridge_note_events_juce
          COMMAND magda_juce_tests "MidiBridge Note Events Tests")
+
+add_test(NAME external_plugin_state_restore_juce
+         COMMAND magda_juce_tests "External Plugin State Restore Tests")

--- a/tests/test_external_plugin_state_restore_juce.cpp
+++ b/tests/test_external_plugin_state_restore_juce.cpp
@@ -1,11 +1,16 @@
 #include <juce_core/juce_core.h>
-#include <tracktion_engine/plugins/external/tracktion_ExternalAutomatableParameter.h>
 #include <tracktion_engine/tracktion_engine.h>
 
 #include <vector>
 
 #include "SharedTestEngine.hpp"
 #include "magda/daw/audio/AudioBridge.hpp"
+// Pulls in ExternalAutomatableParameter (used directly below) in the correct
+// order behind the tracktion_engine umbrella. Do NOT include the internal
+// tracktion_ExternalAutomatableParameter.h header directly here: it is not
+// self-contained, and clang-format will sort it ahead of the umbrella, breaking
+// the build.
+#include "magda/daw/audio/plugin_manager/ExternalPluginStateUtil.hpp"
 #include "magda/daw/audio/plugin_manager/PluginManager.hpp"
 #include "magda/daw/core/DeviceInfo.hpp"
 #include "magda/daw/core/ParameterInfo.hpp"

--- a/tests/test_external_plugin_state_restore_juce.cpp
+++ b/tests/test_external_plugin_state_restore_juce.cpp
@@ -1,0 +1,547 @@
+#include <juce_core/juce_core.h>
+#include <tracktion_engine/plugins/external/tracktion_ExternalAutomatableParameter.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+#include <vector>
+
+#include "SharedTestEngine.hpp"
+#include "magda/daw/audio/AudioBridge.hpp"
+#include "magda/daw/audio/plugin_manager/PluginManager.hpp"
+#include "magda/daw/core/DeviceInfo.hpp"
+#include "magda/daw/core/ParameterInfo.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+
+namespace te = tracktion;
+
+// ============================================================================
+// External plugin state restore (#1361, fix/vst3-state-not-restored)
+// ============================================================================
+// For an external synth (VST3/AU) the entire voice lives in the native state
+// chunk (DeviceInfo::pluginState). MAGDA also stores a per-parameter array,
+// which is redundant and, when stale relative to the chunk, used to clobber the
+// restored voice: loadDeviceAsPlugin/applyDevicePreset restored the chunk, then
+// syncFromDeviceInfo re-applied the saved parameters and the playback-graph
+// build wrote TE's stale AutomatableParameter cache back over the voice.
+//
+// The fix makes the chunk authoritative: after the param sync the chunk is
+// re-asserted and TE's parameter cache is refreshed from the live plugin. The
+// deterministic, non-flaky signature of the bug is therefore: after loading a
+// device whose chunk and saved-parameter array disagree, TE's parameter cache
+// must match the live plugin (== the chunk's voice), not the stale array.
+//
+// These tests need a real external INSTRUMENT in the scanned KnownPluginList.
+// When none is available (clean CI without Dexed/any VST/AU synth) they skip.
+
+namespace {
+
+constexpr float kTol = 0.02f;
+
+bool approx(float a, float b) {
+    return std::abs(a - b) <= kTol;
+}
+
+// Find any external instrument in the scanned list (prefer Dexed for parity with
+// the bug report). Returns true and fills `out` when one is found.
+bool findExternalInstrument(te::Engine& engine, juce::PluginDescription& out) {
+    bool haveFallback = false;
+    for (const auto& d : engine.getPluginManager().knownPluginList.getTypes()) {
+        if (!d.isInstrument)
+            continue;
+        if (d.pluginFormatName != "VST3" && d.pluginFormatName != "AudioUnit" &&
+            d.pluginFormatName != "VST")
+            continue;
+        if (d.name.containsIgnoreCase("Dexed")) {
+            out = d;
+            return true;
+        }
+        if (!haveFallback) {
+            out = d;
+            haveFallback = true;
+        }
+    }
+    return haveFallback;
+}
+
+magda::PluginFormat formatFor(const juce::PluginDescription& d) {
+    if (d.pluginFormatName == "AudioUnit")
+        return magda::PluginFormat::AU;
+    if (d.pluginFormatName == "VST")
+        return magda::PluginFormat::VST;
+    return magda::PluginFormat::VST3;
+}
+
+magda::DeviceInfo deviceFor(const juce::PluginDescription& d) {
+    magda::DeviceInfo dev;
+    dev.name = d.name;
+    dev.manufacturer = d.manufacturerName;
+    dev.fileOrIdentifier = d.fileOrIdentifier;
+    dev.uniqueId = d.createIdentifierString();
+    dev.format = formatFor(d);
+    dev.isInstrument = true;
+    dev.deviceType = magda::DeviceType::Instrument;
+    return dev;
+}
+
+}  // namespace
+
+class ExternalPluginStateRestoreTest final : public juce::UnitTest {
+  public:
+    ExternalPluginStateRestoreTest()
+        : juce::UnitTest("External Plugin State Restore Tests", "magda") {}
+
+    // Spin the message loop until the (async-loaded) external plugin for `path`
+    // is fully instantiated, or the timeout elapses.
+    te::ExternalPlugin* waitForExternalPlugin(magda::PluginManager& pm,
+                                              const magda::ChainNodePath& path, int timeoutMs) {
+        const auto deadline = juce::Time::getMillisecondCounter() + (juce::uint32)timeoutMs;
+        while (juce::Time::getMillisecondCounter() < deadline) {
+            if (auto p = pm.getPlugin(path))
+                if (auto* ext = dynamic_cast<te::ExternalPlugin*>(p.get()))
+                    if (!ext->isInitialisingAsync() && ext->getAudioPluginInstance() != nullptr)
+                        return ext;
+            juce::MessageManager::getInstance()->runDispatchLoopUntil(40);
+        }
+        return nullptr;
+    }
+
+    te::ExternalAutomatableParameter* findExtParam(te::ExternalPlugin* ext, int paramIndex) {
+        for (auto* p : ext->getAutomatableParameters())
+            if (auto* ep = dynamic_cast<te::ExternalAutomatableParameter*>(p))
+                if (ep->getParameterIndex() == paramIndex)
+                    return ep;
+        return nullptr;
+    }
+
+    // Capture the current normalized values of every automatable parameter, in
+    // the shape syncFromDeviceInfo consumes (paramIndex + currentValue).
+    std::vector<magda::ParameterInfo> captureParams(te::ExternalPlugin* ext) {
+        std::vector<magda::ParameterInfo> out;
+        if (auto* inst = ext->getAudioPluginInstance()) {
+            auto& ps = inst->getParameters();
+            for (int j = 0; j < ps.size(); ++j) {
+                if (!ps[j]->isAutomatable())
+                    continue;
+                magda::ParameterInfo pi;
+                pi.paramIndex = j;
+                pi.currentValue = ps[j]->getValue();
+                pi.minValue = 0.0f;
+                pi.maxValue = 1.0f;
+                pi.teMinValue = 0.0f;
+                pi.teMaxValue = 1.0f;
+                out.push_back(pi);
+            }
+        }
+        return out;
+    }
+
+    // Pick an automatable parameter we can move clearly away from its default,
+    // and apply that change to the live plugin. Returns {paramIndex, defaultVal,
+    // changedVal} or paramIndex == -1 if none found.
+    struct ParamChange {
+        int paramIndex = -1;
+        float defaultVal = 0.0f;
+        float changedVal = 0.0f;
+    };
+    ParamChange makeDistinctVoice(te::ExternalPlugin* ext) {
+        auto* inst = ext->getAudioPluginInstance();
+        if (!inst)
+            return {};
+        auto& ps = inst->getParameters();
+        for (int j = 0; j < ps.size(); ++j) {
+            if (!ps[j]->isAutomatable())
+                continue;
+            auto* ep = findExtParam(ext, j);
+            if (!ep)
+                continue;
+            const float d = ps[j]->getValue();
+            const float target = d < 0.5f ? 0.9f : 0.1f;
+            ep->setParameterFromHost(target, juce::sendNotificationSync);
+            const float actual = ps[j]->getValue();
+            if (std::abs(actual - d) > 0.1f)
+                return {j, d, actual};
+        }
+        return {};
+    }
+
+    // Create a genuinely different voice by switching to another program (the
+    // realistic "load a different patch" case, which reliably refreshes the live
+    // edit buffer). Leaves the plugin on the new program. Returns a parameter that
+    // differs clearly between the original and new program. paramIndex == -1 if
+    // the instrument has too few programs or no clearly-different parameter.
+    ParamChange makeProgramVoice(te::ExternalPlugin* ext) {
+        auto* inst = ext->getAudioPluginInstance();
+        if (!inst)
+            return {};
+        auto& ps = inst->getParameters();
+        const int np = inst->getNumPrograms();
+        if (np < 2)
+            return {};
+        const int orig = inst->getCurrentProgram();
+        std::vector<float> base;
+        for (auto* p : ps)
+            base.push_back(p->getValue());
+        for (int prog = 0; prog < np; ++prog) {
+            if (prog == orig)
+                continue;
+            inst->setCurrentProgram(prog);
+            for (int j = 0; j < ps.size(); ++j) {
+                if (!ps[j]->isAutomatable())
+                    continue;
+                const float v = ps[j]->getValue();
+                if (std::abs(v - base[j]) > 0.2f)
+                    return {j, base[j], v};
+            }
+        }
+        return {};
+    }
+
+    void runTest() override {
+        testProjectReloadKeepsChunkVoice();
+        testRackInstrumentKeepsChunkVoice();
+        testDevicePresetKeepsChunkVoice();
+    }
+
+    // Load a fresh instance of `desc` on a throwaway track, capture its default
+    // parameters, push it to a distinct voice, and return the resulting state
+    // chunk. Removes the throwaway track before returning. Returns false if the
+    // instrument could not be instantiated or no movable parameter was found.
+    bool captureModifiedVoice(magda::TrackManager& tm, magda::AudioBridge* bridge,
+                              magda::PluginManager& pm, const juce::PluginDescription& desc,
+                              std::vector<magda::ParameterInfo>& outDefaults,
+                              juce::String& outChunk, ParamChange& outChange) {
+        const auto srcTrack = tm.createTrack("VoiceSrc");
+        const auto srcDevId = tm.addDeviceToTrack(srcTrack, deviceFor(desc));
+        const auto srcPath = magda::ChainNodePath::topLevelDevice(srcTrack, srcDevId);
+        bridge->syncTrackPlugins(srcTrack);
+
+        auto* src = waitForExternalPlugin(pm, srcPath, 15000);
+        bool ok = false;
+        if (src != nullptr) {
+            outDefaults = captureParams(src);
+            outChange = makeDistinctVoice(src);
+            if (outChange.paramIndex >= 0) {
+                src->flushPluginStateToValueTree();
+                outChunk = src->state.getProperty(te::IDs::state).toString();
+                ok = outChunk.isNotEmpty();
+            }
+        }
+
+        // Drop the throwaway track so it can't interfere with the test track.
+        for (const auto& t : tm.getTracks()) {
+            if (t.id == srcTrack) {
+                tm.deleteTrack(srcTrack);
+                break;
+            }
+        }
+        return ok;
+    }
+
+    // ----------------------------------------------------------------------
+    // Project-load path: loadDeviceAsPlugin must let the chunk win over a stale
+    // saved parameter array.
+    // ----------------------------------------------------------------------
+    void testProjectReloadKeepsChunkVoice() {
+        beginTest("Project reload: chunk voice survives a stale parameter array");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        magda::test::resetTransport(wrapper);
+        auto* bridge = wrapper.getAudioBridge();
+        auto* engine = wrapper.getEngine();
+        expect(bridge != nullptr && engine != nullptr, "Engine + bridge must exist");
+        if (!bridge || !engine)
+            return;
+
+        juce::PluginDescription desc;
+        if (!findExternalInstrument(*engine, desc)) {
+            logMessage("SKIP: no external instrument in the scanned plugin list");
+            return;
+        }
+        logMessage("Using external instrument: " + desc.name + " (" + desc.pluginFormatName + ")");
+
+        auto& tm = magda::TrackManager::getInstance();
+        tm.clearAllTracks();
+        tm.setAudioEngine(&wrapper);
+        auto& pm = bridge->getPluginManager();
+
+        // 1. Load a fresh instance to capture the default voice + chunk for the
+        //    chosen "modified" voice.
+        const auto srcTrack = tm.createTrack("Src");
+        const auto srcDevId = tm.addDeviceToTrack(srcTrack, deviceFor(desc));
+        const auto srcPath = magda::ChainNodePath::topLevelDevice(srcTrack, srcDevId);
+        bridge->syncTrackPlugins(srcTrack);
+
+        auto* src = waitForExternalPlugin(pm, srcPath, 15000);
+        if (src == nullptr) {
+            logMessage("SKIP: instrument failed to instantiate in time");
+            tm.clearAllTracks();
+            tm.setAudioEngine(nullptr);
+            return;
+        }
+
+        const auto defaults = captureParams(src);
+        const auto change = makeDistinctVoice(src);
+        if (change.paramIndex < 0) {
+            logMessage("SKIP: could not find a movable automatable parameter");
+            tm.clearAllTracks();
+            tm.setAudioEngine(nullptr);
+            return;
+        }
+
+        src->flushPluginStateToValueTree();
+        const auto chunkVoiceB = src->state.getProperty(te::IDs::state).toString();
+        expect(chunkVoiceB.isNotEmpty(), "Instrument must expose a state chunk");
+
+        // 2. Build a "buggy saved project" device: chunk encodes voice B, but the
+        //    saved parameter array holds the defaults (voice A). This is exactly
+        //    the stale state a project saved by the pre-fix build contains.
+        auto staleDevice = deviceFor(desc);
+        staleDevice.parameters = defaults;
+        staleDevice.pluginState = chunkVoiceB;
+
+        // 3. Load it on a fresh track (the project-reload path).
+        const auto dstTrack = tm.createTrack("Dst");
+        const auto dstDevId = tm.addDeviceToTrack(dstTrack, staleDevice);
+        const auto dstPath = magda::ChainNodePath::topLevelDevice(dstTrack, dstDevId);
+        bridge->syncTrackPlugins(dstTrack);
+
+        auto* dst = waitForExternalPlugin(pm, dstPath, 15000);
+        expect(dst != nullptr, "Reloaded instrument must instantiate");
+        if (dst == nullptr) {
+            tm.clearAllTracks();
+            tm.setAudioEngine(nullptr);
+            return;
+        }
+        // Let any deferred graph build / param writeback run.
+        juce::MessageManager::getInstance()->runDispatchLoopUntil(300);
+
+        auto* inst = dst->getAudioPluginInstance();
+        expect(inst != nullptr, "Reloaded instance must exist");
+        if (inst == nullptr) {
+            tm.clearAllTracks();
+            tm.setAudioEngine(nullptr);
+            return;
+        }
+
+        const float pluginVal = inst->getParameters()[change.paramIndex]->getValue();
+        auto* cacheParam = findExtParam(dst, change.paramIndex);
+        expect(cacheParam != nullptr, "Reloaded TE automatable parameter must exist");
+        const float cacheVal = cacheParam ? cacheParam->getCurrentValue() : -1.0f;
+
+        // The chunk (voice B) must win over the stale default array (voice A)...
+        expect(approx(pluginVal, change.changedVal),
+               "Plugin parameter should match the chunk voice (" +
+                   juce::String(change.changedVal, 3) + "), got " + juce::String(pluginVal, 3));
+        // ...and TE's parameter cache must agree with the live plugin, so the
+        // playback-graph build cannot later write a stale value back. This is the
+        // assertion that fails on the unfixed sync load path.
+        expect(approx(cacheVal, pluginVal), "TE parameter cache (" + juce::String(cacheVal, 3) +
+                                                ") should match the live plugin (" +
+                                                juce::String(pluginVal, 3) + ") after restore");
+        expect(!approx(change.changedVal, change.defaultVal),
+               "Sanity: modified voice must differ from the default");
+
+        tm.clearAllTracks();
+        tm.setAudioEngine(nullptr);
+    }
+
+    // ----------------------------------------------------------------------
+    // Rack/master load path (createPluginOnly + registerRackPluginProcessor):
+    // integration coverage. An external instrument inside a MAGDA rack must end
+    // up on the chunk's voice with a consistent parameter cache, despite a stale
+    // saved parameter array.
+    //
+    // NOTE: not a discriminating regression guard. Empirically the MAGDA-rack
+    // graph ends up refreshing the inner plugin's parameter cache from the
+    // restored chunk even without the registerRackPluginProcessor reassert, so
+    // this passes with or without that fix (unlike the top-level reload test,
+    // where the deferred graph writeback clobbers a stale cache). The reassert in
+    // registerRackPluginProcessor is kept as a defensive mirror of the validated
+    // top-level fix; this test guards against crashes and gross regressions in
+    // the rack load path and documents the expected end state.
+    // ----------------------------------------------------------------------
+    void testRackInstrumentKeepsChunkVoice() {
+        beginTest("Rack-hosted external instrument: chunk voice survives a stale parameter array");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        magda::test::resetTransport(wrapper);
+        auto* bridge = wrapper.getAudioBridge();
+        auto* engine = wrapper.getEngine();
+        if (!bridge || !engine)
+            return;
+
+        juce::PluginDescription desc;
+        if (!findExternalInstrument(*engine, desc)) {
+            logMessage("SKIP: no external instrument in the scanned plugin list");
+            return;
+        }
+
+        auto& tm = magda::TrackManager::getInstance();
+        tm.clearAllTracks();
+        tm.setAudioEngine(&wrapper);
+        auto& pm = bridge->getPluginManager();
+
+        // Capture a modified voice (chunk B) + the default-program parameter array.
+        std::vector<magda::ParameterInfo> defaults;
+        juce::String chunkVoiceB;
+        ParamChange change;
+        if (!captureModifiedVoice(tm, bridge, pm, desc, defaults, chunkVoiceB, change)) {
+            logMessage("SKIP: could not capture a distinct voice");
+            tm.clearAllTracks();
+            tm.setAudioEngine(nullptr);
+            return;
+        }
+
+        // Build the "buggy saved project" device (chunk = voice B, params = stale
+        // defaults) and place it inside a MAGDA rack chain.
+        auto staleDevice = deviceFor(desc);
+        staleDevice.parameters = defaults;
+        staleDevice.pluginState = chunkVoiceB;
+
+        const auto track = tm.createTrack("RackHost");
+        const auto rackId = tm.addRackToTrack(track, "Rack");
+        auto* rack = tm.getRack(track, rackId);
+        expect(rack != nullptr && !rack->chains.empty(), "Rack with a default chain must exist");
+        if (rack == nullptr || rack->chains.empty()) {
+            tm.clearAllTracks();
+            tm.setAudioEngine(nullptr);
+            return;
+        }
+        const auto chainId = rack->chains[0].id;
+        const auto chainPath = magda::ChainNodePath::chain(track, rackId, chainId);
+        const auto devId = tm.addDeviceToChainByPath(chainPath, staleDevice);
+        const auto devPath = magda::ChainNodePath::chainDevice(track, rackId, chainId, devId);
+        bridge->syncTrackPlugins(track);
+
+        auto* dst = waitForExternalPlugin(pm, devPath, 15000);
+        expect(dst != nullptr, "Rack-hosted instrument must instantiate");
+        if (dst == nullptr) {
+            tm.clearAllTracks();
+            tm.setAudioEngine(nullptr);
+            return;
+        }
+        juce::MessageManager::getInstance()->runDispatchLoopUntil(300);
+
+        auto* inst = dst->getAudioPluginInstance();
+        if (inst == nullptr) {
+            tm.clearAllTracks();
+            tm.setAudioEngine(nullptr);
+            return;
+        }
+        const float pluginVal = inst->getParameters()[change.paramIndex]->getValue();
+        auto* cacheParam = findExtParam(dst, change.paramIndex);
+        const float cacheVal = cacheParam ? cacheParam->getCurrentValue() : -1.0f;
+
+        expect(approx(pluginVal, change.changedVal),
+               "Rack plugin parameter should match the chunk voice (" +
+                   juce::String(change.changedVal, 3) + "), got " + juce::String(pluginVal, 3));
+        expect(approx(cacheVal, pluginVal), "TE parameter cache (" + juce::String(cacheVal, 3) +
+                                                ") should match the live rack plugin (" +
+                                                juce::String(pluginVal, 3) + ")");
+
+        tm.clearAllTracks();
+        tm.setAudioEngine(nullptr);
+    }
+
+    // ----------------------------------------------------------------------
+    // Device-preset path (applyDevicePreset): integration/smoke coverage.
+    //
+    // NOTE: this exercises applyDevicePreset end-to-end with a real external
+    // instrument and asserts the preset's voice is applied and that TE's
+    // parameter cache stays consistent with the live plugin. It is NOT a
+    // discriminating regression guard for the stale-parameter-array clobber:
+    // a program-change preset is refreshed by TE's own setCurrentProgram path,
+    // so it passes with or without the applyDevicePreset cache refresh. The
+    // discriminating guard for the underlying bug is the project-reload test
+    // above. Kept to catch crashes/asserts and gross regressions in the preset
+    // path (the ".mgda preset" flow).
+    // ----------------------------------------------------------------------
+    void testDevicePresetKeepsChunkVoice() {
+        beginTest("Device preset: applies voice and keeps parameter cache consistent");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        magda::test::resetTransport(wrapper);
+        auto* bridge = wrapper.getAudioBridge();
+        auto* engine = wrapper.getEngine();
+        if (!bridge || !engine)
+            return;
+
+        juce::PluginDescription desc;
+        if (!findExternalInstrument(*engine, desc)) {
+            logMessage("SKIP: no external instrument in the scanned plugin list");
+            return;
+        }
+
+        auto& tm = magda::TrackManager::getInstance();
+        tm.clearAllTracks();
+        tm.setAudioEngine(&wrapper);
+        auto& pm = bridge->getPluginManager();
+
+        const auto track = tm.createTrack("Preset Target");
+        const auto devId = tm.addDeviceToTrack(track, deviceFor(desc));
+        const auto path = magda::ChainNodePath::topLevelDevice(track, devId);
+        bridge->syncTrackPlugins(track);
+
+        auto* ext = waitForExternalPlugin(pm, path, 15000);
+        if (ext == nullptr) {
+            logMessage("SKIP: instrument failed to instantiate in time");
+            tm.clearAllTracks();
+            tm.setAudioEngine(nullptr);
+            return;
+        }
+
+        // Capture the default-program parameters, then switch to a different
+        // program to get a genuinely different voice (a realistic preset).
+        const auto defaults = captureParams(ext);
+        const auto change = makeProgramVoice(ext);
+        if (change.paramIndex < 0) {
+            logMessage("SKIP: instrument has too few programs / no distinct voice");
+            tm.clearAllTracks();
+            tm.setAudioEngine(nullptr);
+            return;
+        }
+        ext->flushPluginStateToValueTree();
+        const auto chunkVoiceB = ext->state.getProperty(te::IDs::state).toString();
+
+        // Build the preset off the live device so identity (pluginId/format) matches,
+        // then give it voice B's chunk but the stale default-program parameter array.
+        // syncFromDeviceInfo would write those stale params over the restored voice;
+        // the fix re-derives the parameters from the chunk so the voice wins.
+        auto* liveInfo = tm.getDeviceInChainByPath(path);
+        expect(liveInfo != nullptr, "Live device info must exist");
+        if (!liveInfo) {
+            tm.clearAllTracks();
+            tm.setAudioEngine(nullptr);
+            return;
+        }
+        auto preset = *liveInfo;
+        preset.parameters = defaults;
+        preset.pluginState = chunkVoiceB;
+
+        const bool applied = tm.applyDevicePreset(path, preset);
+        expect(applied, "applyDevicePreset should succeed");
+        juce::MessageManager::getInstance()->runDispatchLoopUntil(300);
+
+        auto* inst = ext->getAudioPluginInstance();
+        if (inst == nullptr) {
+            tm.clearAllTracks();
+            tm.setAudioEngine(nullptr);
+            return;
+        }
+        const float pluginVal = inst->getParameters()[change.paramIndex]->getValue();
+        auto* cacheParam = findExtParam(ext, change.paramIndex);
+        const float cacheVal = cacheParam ? cacheParam->getCurrentValue() : -1.0f;
+
+        expect(approx(pluginVal, change.changedVal),
+               "Preset plugin parameter should match the chunk voice (" +
+                   juce::String(change.changedVal, 3) + "), got " + juce::String(pluginVal, 3));
+        expect(approx(cacheVal, pluginVal), "TE parameter cache (" + juce::String(cacheVal, 3) +
+                                                ") should match the live plugin (" +
+                                                juce::String(pluginVal, 3) +
+                                                ") after applying the preset");
+
+        tm.clearAllTracks();
+        tm.setAudioEngine(nullptr);
+    }
+};
+
+static ExternalPluginStateRestoreTest externalPluginStateRestoreTest;


### PR DESCRIPTION
For VST/AU plugins the native state chunk is authoritative for the whole voice; the saved per-parameter array is redundant and, when stale, overwrites the restored voice (e.g. Dexed reverting toward INIT after reload). Re-assert the chunk after syncFromDeviceInfo and refresh TE's parameter cache so the later playback-graph build cannot write stale values back. Factored into a shared helper (reassertExternalPluginChunk) used by the track-reload, rack, and device-preset load paths.

Also fix the device-preset path: address per-parameter notifications by paramIndex (not the vector ordinal, which is wrong once wrapper dry/wet params are split out), and skip repopulation for parameter-only presets that carry no state chunk.

Add an engine-backed regression test (real external instrument, skips if none) for the reload path, plus integration coverage for the rack and preset paths.