### PR TITLE
Faust AI console: conversation history, auto-retry, effect library

### DIFF
--- a/magda/agents/coder_agent.cpp
+++ b/magda/agents/coder_agent.cpp
@@ -10,6 +10,7 @@
 #include "../daw/engine/AudioEngine.hpp"
 #include "faust_agent.hpp"
 #include "internal_plugins.hpp"
+#include "mcp/MCPServerManager.hpp"
 #include "sound_design_agent.hpp"
 
 namespace magda {
@@ -43,8 +44,14 @@ class FaustCoderAgent : public CoderAgent {
         if (result.hasError)
             return juce::String("error: ") + juce::String(result.error);
 
+        // faust-mcp drives the compile verification (and the auto-fix loop). If
+        // it's off, we generated the DSP but it hasn't been verified, so we
+        // stage the source into the editor instead of loading it live.
+        const bool verified = MCPServerManager::getInstance().isServerEnabled("faust-mcp");
+
         auto& mm = *juce::MessageManager::getInstance();
-        auto applyOnce = [name = result.name, source = result.source, path]() -> juce::String {
+        auto applyOnce = [name = result.name, source = result.source, path,
+                          verified]() -> juce::String {
             auto& tm = TrackManager::getInstance();
             auto* device = tm.getDeviceInChainByPath(path);
             if (device == nullptr ||
@@ -56,8 +63,17 @@ class FaustCoderAgent : public CoderAgent {
             auto* faust = dynamic_cast<daw::audio::FaustPlugin*>(plugin.get());
             if (faust == nullptr)
                 return "(could not resolve live Faust plugin)";
-            juce::String err;
             const auto displayName = name.empty() ? juce::String("AI DSP") : juce::String(name);
+
+            // Unverified (MCP off): stage the code into the editor for the user
+            // to compile manually, rather than load it live.
+            if (!verified) {
+                faust->stageSourceForEditing(displayName, juce::String(source));
+                return juce::String("generated \"") + displayName +
+                       "\" - open the editor to compile (Faust MCP off)";
+            }
+
+            juce::String err;
             if (!faust->loadDspSource(displayName, juce::String(source), err))
                 return juce::String("compile error: ") + err;
 

--- a/magda/agents/coder_agent.cpp
+++ b/magda/agents/coder_agent.cpp
@@ -21,6 +21,7 @@ namespace {
 class FaustCoderAgent : public CoderAgent {
   public:
     juce::String generateAndApply(const juce::String& prompt, const ChainNodePath& path,
+                                  llm::Conversation& conversation,
                                   TokenCallback onToken = {}) override {
         agent_.resetCancel();
         if (shouldStop_.load())
@@ -33,9 +34,9 @@ class FaustCoderAgent : public CoderAgent {
                     return false;
                 return onToken(token);
             };
-            result = agent_.generateStreaming(prompt.toStdString(), fwd);
+            result = agent_.generateStreaming(prompt.toStdString(), conversation, fwd);
         } else {
-            result = agent_.generate(prompt.toStdString());
+            result = agent_.generate(prompt.toStdString(), conversation);
         }
         if (shouldStop_.load())
             return "cancelled";

--- a/magda/agents/coder_agent.cpp
+++ b/magda/agents/coder_agent.cpp
@@ -59,6 +59,15 @@ class FaustCoderAgent : public CoderAgent {
             const auto displayName = name.empty() ? juce::String("AI DSP") : juce::String(name);
             if (!faust->loadDspSource(displayName, juce::String(source), err))
                 return juce::String("compile error: ") + err;
+
+            // Faust's parameter set changes at runtime, so the DeviceInfo the
+            // chain UI rebuilds from has to be nudged to the now-active pool
+            // layout, then the live plugin state captured. Without this the
+            // slot rebuild reads stale (empty) params and the device shows no
+            // controls until the user opens the editor and recompiles. Mirrors
+            // FaustUI::tryLoad's refresh after a manual load.
+            bridge->getPluginManager().refreshDeviceParameters(path);
+            bridge->getPluginManager().capturePluginState(path);
             return juce::String("applied \"") + displayName + "\"";
         };
 

--- a/magda/agents/device_ai_agent.hpp
+++ b/magda/agents/device_ai_agent.hpp
@@ -7,6 +7,10 @@
 
 #include "core/ChainNodePath.hpp"
 
+namespace llm {
+struct Conversation;
+}
+
 namespace magda {
 
 /**
@@ -34,8 +38,11 @@ class DeviceAIAgent {
 
     /// Run the agent on `prompt` and apply its output to the device at
     /// `path`. Returns a one-line status. Failure strings start with
-    /// "(" or "error:".
+    /// "(" or "error:". `conversation` carries the running multi-turn history
+    /// (owned/persisted by the caller) and is updated in place; agents that
+    /// don't support multi-turn may ignore it.
     virtual juce::String generateAndApply(const juce::String& prompt, const ChainNodePath& path,
+                                          llm::Conversation& conversation,
                                           TokenCallback onToken = {}) = 0;
 
     /// Best-effort cancel; safe to call from any thread.

--- a/magda/agents/faust_agent.cpp
+++ b/magda/agents/faust_agent.cpp
@@ -179,7 +179,17 @@ FaustAgent::Result FaustAgent::runConversational(const std::string& message,
     auto client = createLLMClient(agentConfig, "faust");
 
     constexpr int kMaxAttempts = 3;
-    juce::String userTurn = juce::String::fromUTF8(message.c_str());
+
+    // Snapshot the conversation as it stands. Each attempt runs against THIS
+    // base, so failed attempts never chain off each other or get persisted:
+    // the retry carries the broken code + error inline instead. On success we
+    // commit only the original prompt + the working reply, keeping the history
+    // clean (no wasted context on fix attempts) for both stateless providers
+    // and the Responses API.
+    const auto baseMessages = conversation.messages;
+    const auto basePrevId = conversation.lastResponseId;
+    const juce::String originalPrompt = juce::String::fromUTF8(message.c_str());
+    juce::String userTurn = originalPrompt;
     std::string lastError;
 
     for (int attempt = 0; attempt < kMaxAttempts; ++attempt) {
@@ -190,6 +200,10 @@ FaustAgent::Result FaustAgent::runConversational(const std::string& message,
             return result;
         }
 
+        llm::Conversation working;
+        working.messages = baseMessages;
+        working.lastResponseId = basePrevId;
+
         llm::Request request;
         request.systemPrompt = juce::String::fromUTF8(getSystemPrompt());
         request.userMessage = userTurn;
@@ -198,13 +212,13 @@ FaustAgent::Result FaustAgent::runConversational(const std::string& message,
         llm::Response response;
         if (onToken) {
             response = client->continueConversationStreaming(
-                conversation, request, [this, &onToken](const juce::String& token) {
+                working, request, [this, &onToken](const juce::String& token) {
                     if (shouldStop_.load())
                         return false;
                     return onToken ? onToken(token) : true;
                 });
         } else {
-            response = client->continueConversation(conversation, request);
+            response = client->continueConversation(working, request);
         }
 
         if (!response.success) {
@@ -216,27 +230,34 @@ FaustAgent::Result FaustAgent::runConversational(const std::string& message,
 
         result = parseJson(response.text.trim());
         if (result.hasError) {
-            // Not valid JSON — ask for a clean re-emit and try again.
+            // Not valid JSON — retry off the original context.
             lastError = result.error;
-            userTurn = "Your previous reply was not valid JSON. Output ONLY the JSON object "
-                       "with fields name, description and source.";
+            userTurn = originalPrompt +
+                       "\n\n(Your previous reply was not valid JSON. Output ONLY the JSON "
+                       "object with fields name, description and source.)";
             continue;
         }
 
         std::string compileErr;
         if (compileCheck(result.name, result.source, compileErr)) {
+            // Success — commit the clean turns (original prompt + working reply)
+            // to the persistent conversation and chain off the good response.
+            conversation.messages.push_back({"user", originalPrompt});
+            conversation.messages.push_back({"assistant", response.text.trim()});
+            conversation.lastResponseId = working.lastResponseId;
             logFaustAgentResult(result);
-            return result;  // success — conversation already holds the good turn
+            return result;
         }
 
-        // Compile failed. The broken JSON is already the last assistant turn in
-        // `conversation`, so feed the compiler error back as the next user turn
-        // and let the model self-correct.
+        // Compile failed. Retry off the ORIGINAL context with the broken code
+        // and the error inline, so failed attempts neither chain off each other
+        // nor get persisted.
         lastError = compileErr;
         if (onToken)
             onToken(juce::String::fromUTF8("\n[compile failed, fixing...]\n"));
-        userTurn = "That failed to compile:\n" + juce::String(compileErr) +
-                   "\nFix the code and output the corrected JSON object.";
+        userTurn = originalPrompt + "\n\n(Your previous attempt failed to compile:\n```\n" +
+                   juce::String(result.source) + "\n```\nCompiler error:\n" +
+                   juce::String(compileErr) + "\nFix it and output the corrected JSON object.)";
     }
 
     result = Result{};

--- a/magda/agents/faust_agent.cpp
+++ b/magda/agents/faust_agent.cpp
@@ -125,47 +125,38 @@ FaustAgent::Result FaustAgent::parseJson(const juce::String& text) {
     return result;
 }
 
-FaustAgent::Result FaustAgent::generate(const std::string& message) {
-    Result result;
-    if (shouldStop_.load()) {
-        result.error = "Cancelled";
-        result.hasError = true;
-        return result;
-    }
-
-    auto agentConfig = Config::getInstance().getAgentLLMConfig(role::MUSIC);
-    auto providerConfig = toLLMProviderConfig(agentConfig, "faust");
-    logFaustAgentConfig(agentConfig, providerConfig);
-
-    if (providerConfig.apiKey.isEmpty() && agentConfig.baseUrl.empty() &&
-        agentConfig.provider != provider::LLAMA_LOCAL) {
-        result.error = "Faust agent API key not configured.";
-        result.hasError = true;
-        return result;
-    }
-
-    auto client = createLLMClient(agentConfig, "faust");
-
-    llm::Request request;
-    request.systemPrompt = juce::String::fromUTF8(getSystemPrompt());
-    request.userMessage = buildUserMessage(message);
-    request.temperature = 0.3f;
-
-    auto response = client->sendRequest(request);
-    if (!response.success) {
-        result.error = response.error.toStdString();
-        result.hasError = true;
-        return result;
-    }
-
-    result = parseJson(response.text.trim());
-    if (!result.hasError)
-        result = validateWithMCP(std::move(result));
-    logFaustAgentResult(result);
-    return result;
+FaustAgent::Result FaustAgent::generate(const std::string& message,
+                                        llm::Conversation& conversation) {
+    return runConversational(message, conversation, {});
 }
 
 FaustAgent::Result FaustAgent::generateStreaming(const std::string& message,
+                                                 llm::Conversation& conversation,
+                                                 TokenCallback onToken) {
+    return runConversational(message, conversation, std::move(onToken));
+}
+
+bool FaustAgent::compileCheck(const std::string& name, const std::string& source,
+                              std::string& errorOut) {
+    auto* mcp = MCPServerManager::getInstance().getServer("faust-mcp");
+    if (mcp == nullptr)
+        return true;  // no validator configured — don't block generation
+
+    auto* args = new juce::DynamicObject();
+    args->setProperty("code", juce::String(source));
+    args->setProperty("name", juce::String(name));
+
+    auto mcpResult = mcp->callTool("compile_faust", juce::var(args));
+    if (mcpResult.success)
+        return true;
+
+    DBG("MCPClient compile_faust error: " + mcpResult.error);
+    errorOut = mcpResult.error.toStdString();
+    return false;
+}
+
+FaustAgent::Result FaustAgent::runConversational(const std::string& message,
+                                                 llm::Conversation& conversation,
                                                  TokenCallback onToken) {
     Result result;
     if (shouldStop_.load()) {
@@ -187,70 +178,73 @@ FaustAgent::Result FaustAgent::generateStreaming(const std::string& message,
 
     auto client = createLLMClient(agentConfig, "faust");
 
-    llm::Request request;
-    request.systemPrompt = juce::String::fromUTF8(getSystemPrompt());
-    request.userMessage = buildUserMessage(message);
-    request.temperature = 0.3f;
+    constexpr int kMaxAttempts = 3;
+    juce::String userTurn = juce::String::fromUTF8(message.c_str());
+    std::string lastError;
 
-    auto response = client->sendStreamingRequest(request, [&](const juce::String& token) {
-        if (shouldStop_.load())
-            return false;
+    for (int attempt = 0; attempt < kMaxAttempts; ++attempt) {
+        if (shouldStop_.load()) {
+            result = Result{};
+            result.error = "Cancelled";
+            result.hasError = true;
+            return result;
+        }
+
+        llm::Request request;
+        request.systemPrompt = juce::String::fromUTF8(getSystemPrompt());
+        request.userMessage = userTurn;
+        request.temperature = 0.3f;
+
+        llm::Response response;
+        if (onToken) {
+            response = client->continueConversationStreaming(
+                conversation, request, [this, &onToken](const juce::String& token) {
+                    if (shouldStop_.load())
+                        return false;
+                    return onToken ? onToken(token) : true;
+                });
+        } else {
+            response = client->continueConversation(conversation, request);
+        }
+
+        if (!response.success) {
+            result = Result{};
+            result.error = response.error.toStdString();
+            result.hasError = true;
+            return result;
+        }
+
+        result = parseJson(response.text.trim());
+        if (result.hasError) {
+            // Not valid JSON — ask for a clean re-emit and try again.
+            lastError = result.error;
+            userTurn = "Your previous reply was not valid JSON. Output ONLY the JSON object "
+                       "with fields name, description and source.";
+            continue;
+        }
+
+        std::string compileErr;
+        if (compileCheck(result.name, result.source, compileErr)) {
+            logFaustAgentResult(result);
+            return result;  // success — conversation already holds the good turn
+        }
+
+        // Compile failed. The broken JSON is already the last assistant turn in
+        // `conversation`, so feed the compiler error back as the next user turn
+        // and let the model self-correct.
+        lastError = compileErr;
         if (onToken)
-            return onToken(token);
-        return true;
-    });
-
-    if (!response.success) {
-        result.error = response.error.toStdString();
-        result.hasError = true;
-        return result;
+            onToken(juce::String::fromUTF8("\n[compile failed, fixing...]\n"));
+        userTurn = "That failed to compile:\n" + juce::String(compileErr) +
+                   "\nFix the code and output the corrected JSON object.";
     }
 
-    result = parseJson(response.text.trim());
-    if (!result.hasError)
-        result = validateWithMCP(std::move(result));
+    result = Result{};
+    result.hasError = true;
+    result.error = "Faust compilation still failing after " + std::to_string(kMaxAttempts) +
+                   " attempts:\n" + lastError;
     logFaustAgentResult(result);
     return result;
-}
-
-FaustAgent::Result FaustAgent::validateWithMCP(Result result) {
-    auto* mcp = MCPServerManager::getInstance().getServer("faust-mcp");
-    if (mcp == nullptr) {
-        lastFailedSource_.clear();
-        lastCompileError_.clear();
-        return result;
-    }
-
-    auto* args = new juce::DynamicObject();
-    args->setProperty("code", juce::String(result.source));
-    args->setProperty("name", juce::String(result.name));
-
-    auto mcpResult = mcp->callTool("compile_faust", juce::var(args));
-    if (mcpResult.success) {
-        lastFailedSource_.clear();
-        lastCompileError_.clear();
-        return result;
-    }
-
-    DBG("MCPClient compile_faust error: " + mcpResult.error);
-    lastFailedSource_ = result.source;
-    lastCompileError_ = mcpResult.error.toStdString();
-
-    result.error = "Faust compilation failed:\n" + lastCompileError_ +
-                   "\n\nWould you like me to try fixing it?";
-    result.hasError = true;
-    return result;
-}
-
-juce::String FaustAgent::buildUserMessage(const std::string& message) const {
-    if (lastFailedSource_.empty())
-        return juce::String::fromUTF8(message.c_str());
-
-    return "My previous Faust code failed to compile:\n\n```\n" + juce::String(lastFailedSource_) +
-           "\n```\n\nCompiler error:\n" + juce::String(lastCompileError_) +
-           "\n\nUser request: " + juce::String::fromUTF8(message.c_str()) +
-           "\n\nFix the code based on the compiler error and the user's request. "
-           "Output the corrected JSON object.";
 }
 
 }  // namespace magda

--- a/magda/agents/faust_agent.hpp
+++ b/magda/agents/faust_agent.hpp
@@ -7,6 +7,10 @@
 
 #include "compact_parser.hpp"  // for TokenCallback
 
+namespace llm {
+struct Conversation;
+}
+
 namespace magda {
 
 class FaustAgent {
@@ -20,8 +24,12 @@ class FaustAgent {
         bool hasError = false;
     };
 
-    Result generate(const std::string& message);
-    Result generateStreaming(const std::string& message, TokenCallback onToken);
+    // `conversation` carries the running multi-turn history (prior generated
+    // DSP, fix attempts) so refinements edit the existing code rather than
+    // starting blank. It is updated in place with the turns from this call.
+    Result generate(const std::string& message, llm::Conversation& conversation);
+    Result generateStreaming(const std::string& message, llm::Conversation& conversation,
+                             TokenCallback onToken);
 
     void requestCancel() {
         shouldStop_ = true;
@@ -33,12 +41,20 @@ class FaustAgent {
   private:
     static const char* getSystemPrompt();
     Result parseJson(const juce::String& text);
-    Result validateWithMCP(Result result);
-    juce::String buildUserMessage(const std::string& message) const;
+
+    // Compile the source through the faust-mcp compile_faust tool. Returns true
+    // if it compiles (or if no MCP server is configured, so generation isn't
+    // blocked); on failure fills errorOut with the compiler message.
+    bool compileCheck(const std::string& name, const std::string& source, std::string& errorOut);
+
+    // Shared body for generate / generateStreaming. Runs the conversational
+    // generate-and-auto-fix loop: on a compile failure the broken reply is
+    // already the last assistant turn, so the error is fed back as the next
+    // user turn, up to kMaxAttempts. Empty onToken = non-streaming.
+    Result runConversational(const std::string& message, llm::Conversation& conversation,
+                             TokenCallback onToken);
 
     std::atomic<bool> shouldStop_{false};
-    std::string lastFailedSource_;
-    std::string lastCompileError_;
 };
 
 }  // namespace magda

--- a/magda/agents/llm_config_utils.hpp
+++ b/magda/agents/llm_config_utils.hpp
@@ -57,6 +57,11 @@ inline llm::ProviderConfig toLLMProviderConfig(const Config::AgentLLMConfig& con
         pc.model = model::CLAUDE_SONNET;
     else if (pc.model.startsWith("claude-haiku-"))
         pc.model = model::CLAUDE_HAIKU;
+
+    // Claude Opus 4.8 deprecated the temperature parameter (like GPT-5) and
+    // rejects requests that include it.
+    if (pc.model.startsWith("claude-opus-"))
+        pc.noTemperature = true;
     pc.baseUrl =
         config.baseUrl.empty() ? defaultBaseUrl(config.provider) : juce::String(config.baseUrl);
 

--- a/magda/agents/llm_config_utils.hpp
+++ b/magda/agents/llm_config_utils.hpp
@@ -45,6 +45,18 @@ inline llm::ProviderConfig toLLMProviderConfig(const Config::AgentLLMConfig& con
     llm::ProviderConfig pc;
     pc.provider = provider;
     pc.model = juce::String(config.model);
+
+    // Until full model customization ships, always resolve to the latest model
+    // per Claude family, so stale saved configs (or an older pinned id) don't
+    // keep loading a superseded model. Self-maintaining: bump the constant and
+    // every config follows. The families ARE the tiers, so collapsing within a
+    // family is safe (unlike GPT-5's sub-tiers, which stay as chosen).
+    if (pc.model.startsWith("claude-opus-"))
+        pc.model = model::CLAUDE_OPUS;
+    else if (pc.model.startsWith("claude-sonnet-"))
+        pc.model = model::CLAUDE_SONNET;
+    else if (pc.model.startsWith("claude-haiku-"))
+        pc.model = model::CLAUDE_HAIKU;
     pc.baseUrl =
         config.baseUrl.empty() ? defaultBaseUrl(config.provider) : juce::String(config.baseUrl);
 

--- a/magda/agents/llm_presets.hpp
+++ b/magda/agents/llm_presets.hpp
@@ -42,7 +42,9 @@ inline constexpr const char* GPT_5_NANO = "gpt-5-nano";
 inline constexpr const char* GPT_5_4 = "gpt-5.4";
 inline constexpr const char* GPT_5_5 = "gpt-5.5";
 // Anthropic
-inline constexpr const char* CLAUDE_OPUS = "claude-opus-4-6";
+inline constexpr const char* CLAUDE_OPUS_4_7 = "claude-opus-4-7";
+inline constexpr const char* CLAUDE_OPUS_4_8 = "claude-opus-4-8";
+inline constexpr const char* CLAUDE_OPUS = CLAUDE_OPUS_4_8;  // latest Opus
 inline constexpr const char* CLAUDE_SONNET = "claude-sonnet-4-6";
 inline constexpr const char* CLAUDE_HAIKU = "claude-haiku-4-5-20251001";
 // Gemini

--- a/magda/agents/mcp/MCPServerManager.cpp
+++ b/magda/agents/mcp/MCPServerManager.cpp
@@ -44,6 +44,16 @@ MCPClient* MCPServerManager::getServer(const juce::String& name) {
     return client.get();
 }
 
+bool MCPServerManager::isServerEnabled(const juce::String& name) const {
+    auto it = configs_.find(name);
+    return it != configs_.end() && it->second.enabled;
+}
+
+bool MCPServerManager::isServerRunning(const juce::String& name) const {
+    auto it = clients_.find(name);
+    return it != clients_.end() && it->second != nullptr && it->second->isRunning();
+}
+
 void MCPServerManager::stopAll() {
     clients_.clear();
 }
@@ -65,9 +75,8 @@ void MCPServerManager::reloadFromConfig() {
             it = clients_.erase(it);
         } else {
             auto oldIt = configs_.find(it->first);
-            if (oldIt != configs_.end() &&
-                (oldIt->second.command != newIt->second.command ||
-                 oldIt->second.args != newIt->second.args)) {
+            if (oldIt != configs_.end() && (oldIt->second.command != newIt->second.command ||
+                                            oldIt->second.args != newIt->second.args)) {
                 it = clients_.erase(it);
             } else {
                 ++it;

--- a/magda/agents/mcp/MCPServerManager.hpp
+++ b/magda/agents/mcp/MCPServerManager.hpp
@@ -13,6 +13,12 @@ class MCPServerManager : public ConfigListener {
 
     MCPClient* getServer(const juce::String& name);
 
+    // Read-only status queries (no side effects — unlike getServer, these
+    // never spawn the server). isServerEnabled reflects config; isServerRunning
+    // is true only once a client has actually been started and handshaked.
+    bool isServerEnabled(const juce::String& name) const;
+    bool isServerRunning(const juce::String& name) const;
+
     void stopAll();
 
     void configChanged() override;

--- a/magda/agents/sound_design_agent.cpp
+++ b/magda/agents/sound_design_agent.cpp
@@ -16,7 +16,9 @@ namespace {
 class FourOscSoundDesignAgent : public SoundDesignAgent {
   public:
     juce::String generateAndApply(const juce::String& prompt, const ChainNodePath& path,
+                                  llm::Conversation& conversation,
                                   TokenCallback onToken = {}) override {
+        juce::ignoreUnused(conversation);  // 4OSC preset design is single-shot
         agent_.resetCancel();
         if (shouldStop_.load())
             return "cancelled";

--- a/magda/daw/audio/plugins/FaustPlugin.cpp
+++ b/magda/daw/audio/plugins/FaustPlugin.cpp
@@ -451,6 +451,16 @@ bool FaustPlugin::loadDspSource(const juce::String& name, const juce::String& so
     return true;
 }
 
+void FaustPlugin::stageSourceForEditing(const juce::String& name, const juce::String& source) {
+    // Editable state only — no compileAndRebind, no active_ swap. The live DSP
+    // and the param pool stay as they are; the editor reads dspSource/dspName
+    // from state, so the user sees the staged code and compiles it when ready.
+    dspName_ = name;
+    dspSource_ = source;
+    state.setProperty("dspName", dspName_, getUndoManager());
+    state.setProperty("dspSource", dspSource_, getUndoManager());
+}
+
 void FaustPlugin::initialise(const te::PluginInitialisationInfo& info) {
     currentSampleRate_ = static_cast<int>(info.sampleRate);
 

--- a/magda/daw/audio/plugins/FaustPlugin.hpp
+++ b/magda/daw/audio/plugins/FaustPlugin.hpp
@@ -86,6 +86,13 @@ class FaustPlugin : public te::Plugin {
     bool loadDspSource(const juce::String& name, const juce::String& source, juce::String& errorOut,
                        FaustCustomViewKind viewKind = FaustCustomViewKind::None);
 
+    // Stage source into the editable state WITHOUT compiling or swapping the
+    // live DSP. The code editor reads `dspSource` from state, so this puts
+    // generated code in front of the user to review and compile manually.
+    // Used when AI-generated code can't be auto-verified (faust-mcp off).
+    // Message thread only.
+    void stageSourceForEditing(const juce::String& name, const juce::String& source);
+
     // Read access for the UI / parameter-info bridge (Phase 4b). The
     // pool's slot table is mutated only by `loadDspSource` on the
     // message thread.

--- a/magda/daw/core/DeviceInfo.hpp
+++ b/magda/daw/core/DeviceInfo.hpp
@@ -108,6 +108,12 @@ struct DeviceInfo {
     // owning DeviceSlotComponent on any notifyTrackDevicesChanged).
     juce::String aiPanelOutput;
 
+    // Serialized llm::Conversation (JSON) for the device's AI panel, so multi-
+    // turn refinement ("make it brighter") survives slot rebuilds. Like
+    // aiPanelOutput this is transient runtime state, owned by the agent: read
+    // before a generation and written back after, on the message thread.
+    juce::String aiConversation;
+
     // Device parameters (populated by DeviceProcessor) — the plugin's own
     // automatable parameters. Wrapper-injected slot params (e.g. TE's
     // PluginWetDryAutomatableParam pair) belong in `wrapperParameters` and

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -7,6 +7,7 @@
 #include "ai/AIPanelComponent.hpp"
 #include "audio/AudioBridge.hpp"
 #include "audio/plugin_manager/PluginManager.hpp"
+#include "audio/plugins/FaustPlugin.hpp"
 #include "audio/plugins/MagdaSamplerPlugin.hpp"
 #include "audio/plugins/OscilloscopePlugin.hpp"
 #include "audio/plugins/SpectrumAnalyzerPlugin.hpp"
@@ -1027,8 +1028,21 @@ void DeviceSlotComponent::setNodePath(const magda::ChainNodePath& path) {
     }
     // Same story for FaustUI: createCustomUI ran before nodePath_ was
     // valid, so the load flow couldn't fire notifyTrackDevicesChanged.
-    if (faustUI_)
+    if (faustUI_) {
         faustUI_->setDevicePath(nodePath_);
+
+        // createCustomUI() also runs in the constructor, before setNodePath(),
+        // so the inline-UI factory's getLivePlugin() resolved against an empty
+        // path, returned null, and never called setPlugin(). That left the
+        // Faust UI's plugin pointer null, so Load / Edit / "From file..." all
+        // silently early-return. Now that the path is valid, resolve the live
+        // plugin and bind it (mirrors the aiPanel_ fixup above).
+        if (auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine())
+            if (auto* bridge = audioEngine->getAudioBridge())
+                if (auto plugin = bridge->getPlugin(nodePath_))
+                    if (auto* faustPlugin = dynamic_cast<daw::audio::FaustPlugin*>(plugin.get()))
+                        faustUI_->setPlugin(faustPlugin);
+    }
 
     // Initial compute for the controller indicator dots — listeners only fire
     // on change, so a slot built after the binding was added wouldn't otherwise

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -1227,10 +1227,12 @@ void DeviceSlotComponent::updateFromDevice(const magda::DeviceInfo& device) {
         currentPresetName_.clear();
         pluginPresetName_.clear();
         currentPluginPresetFile_ = juce::File();
-        // AI panel output is plugin-specific too — wipe so we don't show
-        // stale 4OSC results on a slot that now holds a different plugin.
-        if (auto* live = magda::TrackManager::getInstance().getDeviceInChainByPath(nodePath_))
+        // AI panel output + conversation are plugin-specific too — wipe so we
+        // don't show stale results or carry history onto a different plugin.
+        if (auto* live = magda::TrackManager::getInstance().getDeviceInChainByPath(nodePath_)) {
             live->aiPanelOutput.clear();
+            live->aiConversation.clear();
+        }
     }
 
     device_ = device;

--- a/magda/daw/ui/components/chain/ai/AIPanelComponent.cpp
+++ b/magda/daw/ui/components/chain/ai/AIPanelComponent.cpp
@@ -137,22 +137,35 @@ constexpr const char* kDisclaimerMarker = "\n\nnote: starting point only";
 // but `"<field>":"<value>"` survives intact. Returns empty if not found or
 // the closing quote is missing.
 juce::String extractStringField(const juce::String& text, const juce::String& field) {
-    auto key = "\"" + field + "\":\"";
-    int start = text.indexOf(key);
-    if (start < 0)
+    // Tolerate whitespace around the colon: the model pretty-prints
+    // `"description": "..."` (space after the colon), so a literal
+    // `"field":"` probe misses it and the raw JSON would survive.
+    auto key = "\"" + field + "\"";
+    int i = text.indexOf(key);
+    if (i < 0)
         return {};
-    start += key.length();
-    int end = start;
+    i += key.length();
     const int len = text.length();
-    while (end < len) {
-        auto c = text[end];
-        if (c == '"' && (end == 0 || text[end - 1] != '\\'))
-            break;
-        ++end;
-    }
-    if (end >= len)
+    while (i < len && juce::CharacterFunctions::isWhitespace(text[i]))
+        ++i;
+    if (i >= len || text[i] != ':')
         return {};
-    return text.substring(start, end);
+    ++i;
+    while (i < len && juce::CharacterFunctions::isWhitespace(text[i]))
+        ++i;
+    if (i >= len || text[i] != '"')
+        return {};
+    ++i;
+    int start = i;
+    while (i < len) {
+        auto c = text[i];
+        if (c == '"' && (i == 0 || text[i - 1] != '\\'))
+            break;
+        ++i;
+    }
+    if (i >= len)
+        return {};
+    return text.substring(start, i);
 }
 }  // namespace
 
@@ -317,6 +330,22 @@ void AIPanelComponent::onGenerationFinished(juce::String status) {
                               DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
             output_.insertTextAtCaret(description);
         }
+    }
+
+    // For coder (Faust) devices a successful apply means the generated DSP
+    // passed both the MCP compile_faust check and the live interpreter
+    // compile, so confirm it compiled (green) before the apply line.
+    if (succeeded && isCoderSupported(pluginId_)) {
+        output_.moveCaretToEnd();
+        if (auto t = output_.getText(); t.isNotEmpty() && !t.endsWithChar('\n')) {
+            output_.setColour(juce::TextEditor::textColourId,
+                              DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
+            output_.insertTextAtCaret("\n");
+        }
+        output_.setColour(juce::TextEditor::textColourId, juce::Colours::limegreen);
+        output_.insertTextAtCaret(juce::String(juce::CharPointer_UTF8("\xe2\x9c\x93 compiled")));
+        output_.setColour(juce::TextEditor::textColourId,
+                          DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
     }
 
     output_.moveCaretToEnd();

--- a/magda/daw/ui/components/chain/ai/AIPanelComponent.cpp
+++ b/magda/daw/ui/components/chain/ai/AIPanelComponent.cpp
@@ -1,6 +1,7 @@
 #include "ai/AIPanelComponent.hpp"
 
 #include <BinaryData.h>
+#include <juce_llm/juce_llm.h>
 
 #include "../../../../agents/llm_presets.hpp"
 #include "../../../../agents/mcp/MCPServerManager.hpp"
@@ -14,17 +15,18 @@ namespace magda::daw::ui {
 class AIPanelComponent::GenerateThread : public juce::Thread {
   public:
     GenerateThread(AIPanelComponent& owner, std::unique_ptr<DeviceAIAgent> agent,
-                   juce::String prompt, ChainNodePath path)
+                   juce::String prompt, ChainNodePath path, llm::Conversation conversation)
         : juce::Thread("MAGDA-DeviceAIAgent"),
           owner_(owner),
           agent_(std::move(agent)),
           prompt_(std::move(prompt)),
-          path_(path) {}
+          path_(path),
+          conversation_(std::move(conversation)) {}
 
     void run() override {
         auto safeOwner = juce::WeakReference<AIPanelComponent>(&owner_);
         if (threadShouldExit() || agent_ == nullptr) {
-            postResult(safeOwner, "no agent");
+            postResult(safeOwner, "no agent", {});
             return;
         }
 
@@ -40,10 +42,13 @@ class AIPanelComponent::GenerateThread : public juce::Thread {
             return true;
         };
 
-        auto status = agent_->generateAndApply(prompt_, path_, std::move(onToken));
+        // conversation_ is this thread's own copy (loaded from the device on
+        // submit). generateAndApply updates it in place; we serialise it back
+        // on the message thread so the next turn continues from here.
+        auto status = agent_->generateAndApply(prompt_, path_, conversation_, std::move(onToken));
         if (threadShouldExit())
             return;
-        postResult(safeOwner, status);
+        postResult(safeOwner, status, juce::JSON::toString(conversation_.toVar()));
     }
 
     void cancel() {
@@ -53,10 +58,11 @@ class AIPanelComponent::GenerateThread : public juce::Thread {
     }
 
   private:
-    static void postResult(juce::WeakReference<AIPanelComponent> safeOwner, juce::String status) {
-        juce::MessageManager::callAsync([safeOwner, status]() {
+    static void postResult(juce::WeakReference<AIPanelComponent> safeOwner, juce::String status,
+                           juce::String conversationJson) {
+        juce::MessageManager::callAsync([safeOwner, status, conversationJson]() {
             if (auto* p = safeOwner.get())
-                p->onGenerationFinished(status);
+                p->onGenerationFinished(status, conversationJson);
         });
     }
 
@@ -64,6 +70,7 @@ class AIPanelComponent::GenerateThread : public juce::Thread {
     std::unique_ptr<DeviceAIAgent> agent_;
     juce::String prompt_;
     ChainNodePath path_;
+    llm::Conversation conversation_;
 };
 
 AIPanelComponent::AIPanelComponent() {
@@ -363,7 +370,14 @@ void AIPanelComponent::submitPrompt() {
     streamingStart_ = output_.getText().length();
     persistOutput();
 
-    thread_ = std::make_unique<GenerateThread>(*this, std::move(agent), prompt, path_);
+    // Load the running conversation from the device (message thread) so the
+    // worker continues the multi-turn history. Empty / unparseable = fresh start.
+    llm::Conversation conversation;
+    if (auto* dev = TrackManager::getInstance().getDeviceInChainByPath(path_))
+        conversation = llm::Conversation::fromVar(juce::JSON::parse(dev->aiConversation));
+
+    thread_ = std::make_unique<GenerateThread>(*this, std::move(agent), prompt, path_,
+                                               std::move(conversation));
     thread_->startThread();
 }
 
@@ -379,8 +393,14 @@ void AIPanelComponent::appendStreamingToken(const juce::String& token) {
     persistOutput();
 }
 
-void AIPanelComponent::onGenerationFinished(juce::String status) {
+void AIPanelComponent::onGenerationFinished(juce::String status, juce::String conversationJson) {
     const bool succeeded = status.startsWith("applied");
+
+    // Persist the updated conversation onto the device (message thread) so the
+    // next turn continues the history. Survives the slot rebuild below the same
+    // way aiPanelOutput does.
+    if (auto* dev = TrackManager::getInstance().getDeviceInChainByPath(path_))
+        dev->aiConversation = conversationJson;
 
     // On success, replace the streamed JSON dump with just the preset's
     // description — the param/wave/fx blocks are noise once the apply has
@@ -388,8 +408,21 @@ void AIPanelComponent::onGenerationFinished(juce::String status) {
     // see what came back. Falls back to the streamed text untouched if the
     // description field can't be located.
     if (succeeded && streamingStart_ >= 0 && streamingStart_ < output_.getText().length()) {
-        auto streamed = output_.getText().substring(streamingStart_);
-        auto description = extractStringField(streamed, "description");
+        // Prefer the FINAL assistant turn from the conversation: after a retry
+        // the stream holds several JSON blobs, and the first (failed) one's
+        // description would be wrong. Fall back to the streamed text for agents
+        // with no conversation (4OSC sound design).
+        juce::String description;
+        auto conv = llm::Conversation::fromVar(juce::JSON::parse(conversationJson));
+        for (auto it = conv.messages.rbegin(); it != conv.messages.rend(); ++it) {
+            if (it->role == "assistant") {
+                description = extractStringField(it->content, "description");
+                break;
+            }
+        }
+        if (description.isEmpty())
+            description =
+                extractStringField(output_.getText().substring(streamingStart_), "description");
         if (description.isNotEmpty()) {
             output_.setHighlightedRegion(
                 juce::Range<int>(streamingStart_, output_.getText().length()));
@@ -487,6 +520,9 @@ void AIPanelComponent::persistOutput() {
 void AIPanelComponent::clearChat() {
     output_.setText("", juce::dontSendNotification);
     persistOutput();
+    // Reset the conversation too so the next prompt starts fresh.
+    if (auto* dev = TrackManager::getInstance().getDeviceInChainByPath(path_))
+        dev->aiConversation.clear();
 }
 
 void AIPanelComponent::refreshModelLabel() {

--- a/magda/daw/ui/components/chain/ai/AIPanelComponent.cpp
+++ b/magda/daw/ui/components/chain/ai/AIPanelComponent.cpp
@@ -3,6 +3,7 @@
 #include <BinaryData.h>
 
 #include "../../../../agents/llm_presets.hpp"
+#include "../../../../agents/mcp/MCPServerManager.hpp"
 #include "../../themes/DarkTheme.hpp"
 #include "../../themes/FontManager.hpp"
 #include "core/Config.hpp"
@@ -113,6 +114,16 @@ AIPanelComponent::AIPanelComponent() {
     clearButton_.setAlpha(0.5f);
     clearButton_.onClick = [this]() { clearChat(); };
     addAndMakeVisible(clearButton_);
+
+    // Faust MCP status strip (top). Visibility + content are set in
+    // setDevicePluginId / updateMcpStatus once the device type is known; the
+    // dot is painted in paint(). Hidden until then.
+    mcpStatusLabel_.setFont(FontManager::getInstance().getUIFont(9.0f));
+    mcpStatusLabel_.setColour(juce::Label::backgroundColourId, juce::Colours::transparentBlack);
+    mcpStatusLabel_.setJustificationType(juce::Justification::centredLeft);
+    mcpStatusLabel_.setInterceptsMouseClicks(false, false);
+    mcpStatusLabel_.setVisible(false);
+    addAndMakeVisible(mcpStatusLabel_);
 
     refreshModelLabel();
 }
@@ -227,10 +238,29 @@ void AIPanelComponent::setDevicePluginId(const juce::String& pluginId) {
             "AI not supported for this device",
             DarkTheme::getColour(DarkTheme::TEXT_PRIMARY).withAlpha(0.4f));
     }
+
+    // The Faust MCP strip is only relevant to coder (Faust) devices — a 4OSC
+    // panel doesn't touch faust-mcp, so it shouldn't advertise it.
+    mcpStripVisible_ = coderSupported;
+    mcpStatusLabel_.setVisible(mcpStripVisible_);
+    updateMcpStatus();
+    resized();
 }
 
 void AIPanelComponent::resized() {
     auto bounds = getLocalBounds().reduced(4);
+
+    // Faust MCP status strip at the very top (coder devices only). Leaves a
+    // gutter on the left for the dot painted in paint().
+    if (mcpStripVisible_) {
+        auto strip = bounds.removeFromTop(14);
+        mcpStripBounds_ = strip;
+        mcpStatusLabel_.setBounds(strip.withTrimmedLeft(14));
+        bounds.removeFromTop(2);
+    } else {
+        mcpStripBounds_ = {};
+    }
+
     // Footer strip at the very bottom: model label + clear-chat button.
     auto footerArea = bounds.removeFromBottom(16);
     constexpr int footerButtonSize = 16;
@@ -254,6 +284,43 @@ void AIPanelComponent::paint(juce::Graphics& g) {
     // here so the panel has a consistent outline on all four sides.
     g.setColour(DarkTheme::getColour(DarkTheme::BORDER));
     g.drawRect(getLocalBounds(), 1);
+
+    // Faust MCP status light: dot at the left of the top strip. Grey when
+    // disabled, green when enabled (brighter once actually connected).
+    if (mcpStripVisible_ && !mcpStripBounds_.isEmpty()) {
+        const float r = 6.0f;
+        const float cx = static_cast<float>(mcpStripBounds_.getX()) + r * 0.5f + 2.0f;
+        const float cy = static_cast<float>(mcpStripBounds_.getCentreY());
+        const auto dot = !mcpEnabled_
+                             ? DarkTheme::getColour(DarkTheme::TEXT_PRIMARY).withAlpha(0.3f)
+                             : (mcpRunning_ ? juce::Colours::limegreen
+                                            : juce::Colours::limegreen.withAlpha(0.7f));
+        g.setColour(dot);
+        g.fillEllipse(cx - r * 0.5f, cy - r * 0.5f, r, r);
+    }
+}
+
+void AIPanelComponent::updateMcpStatus() {
+    auto& mgr = magda::MCPServerManager::getInstance();
+    mcpEnabled_ = mgr.isServerEnabled("faust-mcp");
+    mcpRunning_ = mgr.isServerRunning("faust-mcp");
+
+    juce::String text;
+    juce::Colour colour;
+    if (!mcpEnabled_) {
+        text = "Faust MCP off";
+        colour = DarkTheme::getColour(DarkTheme::TEXT_PRIMARY).withAlpha(0.5f);
+    } else if (mcpRunning_) {
+        text = "Faust MCP connected";
+        colour = juce::Colours::limegreen;
+    } else {
+        text = "Faust MCP on";
+        colour = juce::Colours::limegreen.withAlpha(0.85f);
+    }
+
+    mcpStatusLabel_.setText(text, juce::dontSendNotification);
+    mcpStatusLabel_.setColour(juce::Label::textColourId, colour);
+    repaint();
 }
 
 void AIPanelComponent::submitPrompt() {
@@ -332,9 +399,9 @@ void AIPanelComponent::onGenerationFinished(juce::String status) {
         }
     }
 
-    // For coder (Faust) devices a successful apply means the generated DSP
-    // passed both the MCP compile_faust check and the live interpreter
-    // compile, so confirm it compiled (green) before the apply line.
+    // For coder (Faust) devices, a successful result means the DSP passed the
+    // MCP compile_faust check before it was applied. Surface that as a green
+    // verification line; the "applied" line below confirms the live load.
     if (succeeded && isCoderSupported(pluginId_)) {
         output_.moveCaretToEnd();
         if (auto t = output_.getText(); t.isNotEmpty() && !t.endsWithChar('\n')) {
@@ -343,7 +410,8 @@ void AIPanelComponent::onGenerationFinished(juce::String status) {
             output_.insertTextAtCaret("\n");
         }
         output_.setColour(juce::TextEditor::textColourId, juce::Colours::limegreen);
-        output_.insertTextAtCaret(juce::String(juce::CharPointer_UTF8("\xe2\x9c\x93 compiled")));
+        output_.insertTextAtCaret(
+            juce::String(juce::CharPointer_UTF8("\xe2\x9c\x93 compilation verified (MCP)")));
         output_.setColour(juce::TextEditor::textColourId,
                           DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
     }
@@ -359,13 +427,14 @@ void AIPanelComponent::onGenerationFinished(juce::String status) {
                       DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
     output_.insertTextAtCaret(juce::String(juce::CharPointer_UTF8("\xe2\x86\x92 ")) + status);
 
-    // Remind the user the preset is a starting point — only on a successful
-    // apply (status messages from cancel / error / timeout shouldn't suggest
-    // tweaking a preset that was never written). The disclaimer is rendered
-    // in yellow so it doesn't drown in the streamed text above; the marker
-    // string matches kDisclaimerMarker so restoreOutput can recolour it
-    // after a slot rebuild.
-    if (succeeded) {
+    // Remind the user the preset is a starting point — only for sound-design
+    // (4OSC) presets, and only on a successful apply (status messages from
+    // cancel / error / timeout shouldn't suggest tweaking something that was
+    // never written). Faust/coder devices get the "compiled" confirmation
+    // above instead, so the disclaimer would be noise there. Rendered in
+    // yellow; the marker matches kDisclaimerMarker so restoreOutput can
+    // recolour it after a slot rebuild.
+    if (succeeded && isSoundDesignSupported(pluginId_)) {
         output_.setColour(juce::TextEditor::textColourId, juce::Colours::yellow);
         // Wrap with CharPointer_UTF8 (matching the convention used for the
         // arrow above) so the em-dash byte sequence isn't decoded as Latin-1
@@ -379,6 +448,10 @@ void AIPanelComponent::onGenerationFinished(juce::String status) {
     streamingStart_ = -1;
     setBusy(false);
     persistOutput();
+
+    // A generation will have spawned faust-mcp via getServer(), so the strip
+    // can now reflect the live "connected" state.
+    updateMcpStatus();
 
     // Now that the final text is in place and persisted, fire the
     // tree-changed notification four_osc_apply intentionally skipped. The

--- a/magda/daw/ui/components/chain/ai/AIPanelComponent.hpp
+++ b/magda/daw/ui/components/chain/ai/AIPanelComponent.hpp
@@ -54,7 +54,7 @@ class AIPanelComponent : public juce::Component {
     void submitPrompt();
     void appendOutput(const juce::String& line);
     void appendStreamingToken(const juce::String& token);
-    void onGenerationFinished(juce::String status);
+    void onGenerationFinished(juce::String status, juce::String conversationJson);
     void setBusy(bool busy);
     // Mirror output_'s text onto the bound DeviceInfo so slot rebuilds restore it.
     void persistOutput();

--- a/magda/daw/ui/components/chain/ai/AIPanelComponent.hpp
+++ b/magda/daw/ui/components/chain/ai/AIPanelComponent.hpp
@@ -75,6 +75,16 @@ class AIPanelComponent : public juce::Component {
     void clearChat();
     void refreshModelLabel();
 
+    // Faust MCP status strip at the top (shown only for coder / Faust
+    // devices): a dot + "Faust MCP off/on/connected" so it's clear the
+    // compile-check backend is available when generating DSP.
+    juce::Label mcpStatusLabel_;
+    juce::Rectangle<int> mcpStripBounds_;
+    bool mcpStripVisible_ = false;
+    bool mcpEnabled_ = false;
+    bool mcpRunning_ = false;
+    void updateMcpStatus();
+
     // Track where the streaming response started so we can replace the
     // raw JSON the model emits with a clean status line on completion.
     int streamingStart_ = -1;

--- a/magda/daw/ui/components/chain/custom_ui/FaustCodeEditorWindow.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/FaustCodeEditorWindow.cpp
@@ -1,6 +1,7 @@
 #include "custom_ui/FaustCodeEditorWindow.hpp"
 
 #include "ui/themes/DarkTheme.hpp"
+#include "ui/themes/DialogLookAndFeel.hpp"
 #include "ui/themes/FontManager.hpp"
 
 namespace magda::daw::ui {
@@ -19,6 +20,7 @@ class FaustCodeEditorWindow::Content : public juce::Component {
         addAndMakeVisible(editor_);
 
         compileBtn_.setButtonText("Compile");
+        compileBtn_.setLookAndFeel(&lnf_);  // theme font + button styling
         compileBtn_.onClick = [this] { compile(); };
         addAndMakeVisible(compileBtn_);
 
@@ -27,6 +29,10 @@ class FaustCodeEditorWindow::Content : public juce::Component {
         addAndMakeVisible(statusLabel_);
 
         setSize(720, 540);
+    }
+
+    ~Content() override {
+        compileBtn_.setLookAndFeel(nullptr);
     }
 
     void resized() override {
@@ -51,6 +57,7 @@ class FaustCodeEditorWindow::Content : public juce::Component {
         }
     }
 
+    DialogLookAndFeel lnf_;  // declared before compileBtn_ so it outlives it
     juce::CodeDocument document_;
     juce::CodeEditorComponent editor_;
     juce::TextButton compileBtn_;

--- a/magda/daw/ui/components/chain/custom_ui/FaustUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/FaustUI.cpp
@@ -59,7 +59,7 @@ FaustUI::FaustUI() {
     saveButton_ = std::make_unique<magda::SvgButton>("Save DSP", BinaryData::save_svg,
                                                      BinaryData::save_svgSize);
     saveButton_->setOriginalColor(juce::Colour(0xFFB3B3B3));
-    saveButton_->setIconPadding(2.0f);
+    saveButton_->setIconPadding(4.0f);  // floppy glyph is denser; pad more to match Load/Edit
     saveButton_->onClick = [this] { saveDspToFile(); };
     addAndMakeVisible(*saveButton_);
 

--- a/magda/daw/ui/components/chain/custom_ui/FaustUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/FaustUI.cpp
@@ -8,6 +8,7 @@
 #include "audio/plugin_manager/PluginManager.hpp"
 #include "audio/plugins/FaustPlugin.hpp"
 #include "compiled/MagdaDriveCurveView.hpp"
+#include "core/AppPaths.hpp"
 #include "core/TrackManager.hpp"
 #include "custom_ui/FaustCodeEditorWindow.hpp"
 #include "engine/AudioEngine.hpp"
@@ -54,6 +55,13 @@ FaustUI::FaustUI() {
     loadButton_->setIconPadding(2.0f);
     loadButton_->onClick = [this] { showLoadMenu(); };
     addAndMakeVisible(*loadButton_);
+
+    saveButton_ = std::make_unique<magda::SvgButton>("Save DSP", BinaryData::save_svg,
+                                                     BinaryData::save_svgSize);
+    saveButton_->setOriginalColor(juce::Colour(0xFFB3B3B3));
+    saveButton_->setIconPadding(2.0f);
+    saveButton_->onClick = [this] { saveDspToFile(); };
+    addAndMakeVisible(*saveButton_);
 
     editButton_ = std::make_unique<magda::SvgButton>("Edit DSP", BinaryData::script_svg,
                                                      BinaryData::script_svgSize);
@@ -159,30 +167,54 @@ void FaustUI::showLoadMenu() {
     int id = 1;
     for (const auto& s : starters)
         menu.addItem(id++, s.name);
+
+    // User-saved effects from the FaustEffects library (written by the save
+    // button). Grouped in a submenu so the bundled starters stay tidy.
+    auto savedFiles = userEffectsDir().findChildFiles(juce::File::findFiles, false, "*.dsp");
+    savedFiles.sort();
+    const int savedBaseId = id;
+    if (!savedFiles.isEmpty()) {
+        juce::PopupMenu savedMenu;
+        for (const auto& f : savedFiles)
+            savedMenu.addItem(id++, f.getFileNameWithoutExtension());
+        menu.addSeparator();
+        menu.addSubMenu("My Effects", savedMenu);
+    }
+
     menu.addSeparator();
     const int fromFileId = id;
     menu.addItem(fromFileId, "From file...");
 
     menu.showMenuAsync(juce::PopupMenu::Options().withTargetComponent(loadButton_.get()),
-                       [this, starters, fromFileId](int result) {
+                       [this, starters, savedFiles, savedBaseId, fromFileId](int result) {
                            if (result <= 0)
                                return;
                            if (result == fromFileId) {
                                loadFromFile();
                                return;
                            }
-                           const int idx = result - 1;
-                           if (idx < 0 || idx >= static_cast<int>(starters.size()))
+                           if (result < savedBaseId) {
+                               const int idx = result - 1;
+                               if (idx >= 0 && idx < static_cast<int>(starters.size())) {
+                                   const auto& s = starters[static_cast<size_t>(idx)];
+                                   tryLoad(s.name, s.source, s.viewKind);
+                               }
                                return;
-                           const auto& s = starters[static_cast<size_t>(idx)];
-                           tryLoad(s.name, s.source, s.viewKind);
+                           }
+                           const int idx = result - savedBaseId;
+                           if (idx >= 0 && idx < savedFiles.size()) {
+                               const auto file = savedFiles[idx];
+                               if (file.existsAsFile())
+                                   tryLoad(file.getFileNameWithoutExtension(),
+                                           file.loadFileAsString(),
+                                           magda::daw::audio::FaustCustomViewKind::None);
+                           }
                        });
 }
 
 void FaustUI::loadFromFile() {
-    fileChooser_ = std::make_unique<juce::FileChooser>(
-        "Choose a .dsp file", juce::File::getSpecialLocation(juce::File::userHomeDirectory),
-        "*.dsp");
+    fileChooser_ = std::make_unique<juce::FileChooser>("Choose a .dsp file",
+                                                       FaustUI::userEffectsDir(), "*.dsp");
     fileChooser_->launchAsync(
         juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectFiles,
         [this](const juce::FileChooser& fc) {
@@ -192,6 +224,35 @@ void FaustUI::loadFromFile() {
             tryLoad(file.getFileNameWithoutExtension(), file.loadFileAsString(),
                     magda::daw::audio::FaustCustomViewKind::None);
         });
+}
+
+juce::File FaustUI::userEffectsDir() {
+    auto dir = magda::paths::dataDir().getChildFile("FaustEffects");
+    dir.createDirectory();
+    return dir;
+}
+
+void FaustUI::saveDspToFile() {
+    if (plugin_ == nullptr)
+        return;
+    const auto source = plugin_->state.getProperty("dspSource", juce::String()).toString();
+    if (source.isEmpty())
+        return;
+    const auto name = plugin_->state.getProperty("dspName", juce::String("effect")).toString();
+
+    fileChooser_ = std::make_unique<juce::FileChooser>(
+        "Save Faust DSP", userEffectsDir().getChildFile(name + ".dsp"), "*.dsp");
+    fileChooser_->launchAsync(juce::FileBrowserComponent::saveMode |
+                                  juce::FileBrowserComponent::canSelectFiles |
+                                  juce::FileBrowserComponent::warnAboutOverwriting,
+                              [source](const juce::FileChooser& fc) {
+                                  auto file = fc.getResult();
+                                  if (file == juce::File())
+                                      return;
+                                  if (!file.hasFileExtension("dsp"))
+                                      file = file.withFileExtension("dsp");
+                                  file.replaceWithText(source);
+                              });
 }
 
 void FaustUI::showCodeEditor() {
@@ -268,13 +329,17 @@ void FaustUI::resized() {
     logoBounds_ = area.removeFromLeft(72).toFloat();
     area.removeFromLeft(6);
 
-    // Edit / Load icons on the right (ordered left-to-right Load,
-    // Edit so removeFromRight in reverse order).
+    // Save / Load / Edit icons on the right (ordered left-to-right Save,
+    // Load, Edit so removeFromRight in reverse order). Save sits next to the
+    // Load folder.
     constexpr int iconSize = 22;
     editButton_->setBounds(
         area.removeFromRight(iconSize).withSizeKeepingCentre(iconSize, iconSize));
     area.removeFromRight(4);
     loadButton_->setBounds(
+        area.removeFromRight(iconSize).withSizeKeepingCentre(iconSize, iconSize));
+    area.removeFromRight(4);
+    saveButton_->setBounds(
         area.removeFromRight(iconSize).withSizeKeepingCentre(iconSize, iconSize));
     area.removeFromRight(6);
 

--- a/magda/daw/ui/components/chain/custom_ui/FaustUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/FaustUI.hpp
@@ -60,6 +60,11 @@ class FaustUI : public juce::Component {
   private:
     void showLoadMenu();
     void loadFromFile();
+    void saveDspToFile();
+    // User Faust effects dir (dataDir()/FaustEffects), created on demand. Save
+    // target + Load default location, so generated effects build a reusable
+    // library separate from MAGDA .mps presets.
+    static juce::File userEffectsDir();
     void showCodeEditor();
     bool tryLoad(const juce::String& name, const juce::String& source,
                  magda::daw::audio::FaustCustomViewKind viewKind);
@@ -73,6 +78,7 @@ class FaustUI : public juce::Component {
     juce::Rectangle<float> nameBorderBounds_;
     juce::Label nameLabel_;
     juce::Label errorLabel_;
+    std::unique_ptr<magda::SvgButton> saveButton_;
     std::unique_ptr<magda::SvgButton> loadButton_;
     std::unique_ptr<magda::SvgButton> editButton_;
     std::unique_ptr<juce::FileChooser> fileChooser_;

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -20,7 +20,6 @@
 #include "../../../../agents/internal_plugins.hpp"
 #include "../../../../agents/llama_model_manager.hpp"
 #include "../../../../agents/llm_presets.hpp"
-#include "../../../../agents/mcp/MCPServerManager.hpp"
 #include "../../../../agents/music_agent.hpp"
 #include "../../../../agents/router_agent.hpp"
 #include "../../../api/magda_api_live.hpp"
@@ -947,14 +946,6 @@ AIChatConsoleContent::AIChatConsoleContent() {
     configStatusLabel_.setJustificationType(juce::Justification::centredLeft);
     addAndMakeVisible(configStatusLabel_);
 
-    // Faust MCP status strip (top of the AI tab). Text sits to the right of a
-    // status dot painted in paint(); see mcpStripBounds_ / updateMcpStatus().
-    mcpStatusLabel_.setFont(FontManager::getInstance().getMonoFont(10.0f));
-    mcpStatusLabel_.setColour(juce::Label::backgroundColourId, juce::Colours::transparentBlack);
-    mcpStatusLabel_.setJustificationType(juce::Justification::centredLeft);
-    addAndMakeVisible(mcpStatusLabel_);
-    updateMcpStatus();
-
     // Model load/unload button (shown only for local_embedded preset)
     serverToggleButton_ = std::make_unique<magda::SvgButton>(
         "ModelToggle", BinaryData::server_play_svg, BinaryData::server_play_svgSize);
@@ -1294,20 +1285,6 @@ void AIChatConsoleContent::paint(juce::Graphics& g) {
     g.fillAll(DarkTheme::getPanelBackgroundColour());
 
     if (activeTab_ == ConsoleTab::AI) {
-        // Faust MCP status light: dot at the left of the top strip. Grey when
-        // disabled, green when enabled (brighter once actually connected).
-        if (!mcpStripBounds_.isEmpty()) {
-            const float r = 6.0f;
-            const float cx = static_cast<float>(mcpStripBounds_.getX()) + r;
-            const float cy = static_cast<float>(mcpStripBounds_.getCentreY());
-            const auto dot = !mcpEnabled_
-                                 ? DarkTheme::getSecondaryTextColour().withAlpha(0.4f)
-                                 : (mcpRunning_ ? juce::Colours::limegreen
-                                                : juce::Colours::limegreen.withAlpha(0.7f));
-            g.setColour(dot);
-            g.fillEllipse(cx - r * 0.5f, cy - r * 0.5f, r, r);
-        }
-
         // Draw chat history + status footer as one rounded panel
         auto chatBounds = chatHistory_.getBounds().toFloat();
         auto statusBounds = configStatusLabel_.getBounds().toFloat();
@@ -1380,13 +1357,6 @@ void AIChatConsoleContent::resized() {
     bounds.removeFromBottom(4);  // Spacing above tabs
 
     if (activeTab_ == ConsoleTab::AI) {
-        // Faust MCP status strip at the very top (dot painted in paint()).
-        auto mcpStrip = bounds.removeFromTop(18);
-        mcpStripBounds_ = mcpStrip;
-        mcpStatusLabel_.setBounds(mcpStrip.withTrimmedLeft(16));
-        mcpStatusLabel_.setVisible(true);
-        bounds.removeFromTop(6);  // gap below the strip
-
         // Context bar above tabs
         auto bottomBar = bounds.removeFromBottom(26);
         bottomBarBounds_ = bottomBar;
@@ -1432,10 +1402,6 @@ void AIChatConsoleContent::resized() {
         configStatusLabel_.setBounds(statusBar);
         configStatusLabel_.toFront(false);
     } else {
-        // DSL tab: no MCP strip
-        mcpStatusLabel_.setVisible(false);
-        mcpStripBounds_ = {};
-
         // DSL tab layout
         bounds.removeFromBottom(4);  // Spacing above status bar
         dslStatusLabel_.setBounds(bounds.removeFromBottom(20));
@@ -1450,7 +1416,6 @@ void AIChatConsoleContent::resized() {
 void AIChatConsoleContent::onActivated() {
     buildAliasList();
     updateConfigStatus();
-    updateMcpStatus();
     if (isShowing()) {
         if (activeTab_ == ConsoleTab::AI)
             inputBox_->grabKeyboardFocus();
@@ -1601,7 +1566,6 @@ void AIChatConsoleContent::projectOpened(const magda::ProjectInfo& /*info*/) {
 
 void AIChatConsoleContent::configChanged() {
     updateConfigStatus();
-    updateMcpStatus();
 }
 
 // ============================================================================
@@ -1922,29 +1886,6 @@ void AIChatConsoleContent::updateConfigStatus() {
 
     configStatusLabel_.setText(status, juce::dontSendNotification);
     resized();
-}
-
-void AIChatConsoleContent::updateMcpStatus() {
-    auto& mgr = magda::MCPServerManager::getInstance();
-    mcpEnabled_ = mgr.isServerEnabled("faust-mcp");
-    mcpRunning_ = mgr.isServerRunning("faust-mcp");
-
-    juce::String text;
-    juce::Colour colour;
-    if (!mcpEnabled_) {
-        text = "Faust MCP off";
-        colour = DarkTheme::getSecondaryTextColour().withAlpha(0.6f);
-    } else if (mcpRunning_) {
-        text = "Faust MCP connected";
-        colour = juce::Colours::limegreen;
-    } else {
-        text = "Faust MCP on";
-        colour = juce::Colours::limegreen.withAlpha(0.85f);
-    }
-
-    mcpStatusLabel_.setText(text, juce::dontSendNotification);
-    mcpStatusLabel_.setColour(juce::Label::textColourId, colour);
-    repaint();
 }
 
 bool AIChatConsoleContent::isLocalPreset() const {

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -20,6 +20,7 @@
 #include "../../../../agents/internal_plugins.hpp"
 #include "../../../../agents/llama_model_manager.hpp"
 #include "../../../../agents/llm_presets.hpp"
+#include "../../../../agents/mcp/MCPServerManager.hpp"
 #include "../../../../agents/music_agent.hpp"
 #include "../../../../agents/router_agent.hpp"
 #include "../../../api/magda_api_live.hpp"
@@ -946,6 +947,14 @@ AIChatConsoleContent::AIChatConsoleContent() {
     configStatusLabel_.setJustificationType(juce::Justification::centredLeft);
     addAndMakeVisible(configStatusLabel_);
 
+    // Faust MCP status strip (top of the AI tab). Text sits to the right of a
+    // status dot painted in paint(); see mcpStripBounds_ / updateMcpStatus().
+    mcpStatusLabel_.setFont(FontManager::getInstance().getMonoFont(10.0f));
+    mcpStatusLabel_.setColour(juce::Label::backgroundColourId, juce::Colours::transparentBlack);
+    mcpStatusLabel_.setJustificationType(juce::Justification::centredLeft);
+    addAndMakeVisible(mcpStatusLabel_);
+    updateMcpStatus();
+
     // Model load/unload button (shown only for local_embedded preset)
     serverToggleButton_ = std::make_unique<magda::SvgButton>(
         "ModelToggle", BinaryData::server_play_svg, BinaryData::server_play_svgSize);
@@ -1285,6 +1294,20 @@ void AIChatConsoleContent::paint(juce::Graphics& g) {
     g.fillAll(DarkTheme::getPanelBackgroundColour());
 
     if (activeTab_ == ConsoleTab::AI) {
+        // Faust MCP status light: dot at the left of the top strip. Grey when
+        // disabled, green when enabled (brighter once actually connected).
+        if (!mcpStripBounds_.isEmpty()) {
+            const float r = 6.0f;
+            const float cx = static_cast<float>(mcpStripBounds_.getX()) + r;
+            const float cy = static_cast<float>(mcpStripBounds_.getCentreY());
+            const auto dot = !mcpEnabled_
+                                 ? DarkTheme::getSecondaryTextColour().withAlpha(0.4f)
+                                 : (mcpRunning_ ? juce::Colours::limegreen
+                                                : juce::Colours::limegreen.withAlpha(0.7f));
+            g.setColour(dot);
+            g.fillEllipse(cx - r * 0.5f, cy - r * 0.5f, r, r);
+        }
+
         // Draw chat history + status footer as one rounded panel
         auto chatBounds = chatHistory_.getBounds().toFloat();
         auto statusBounds = configStatusLabel_.getBounds().toFloat();
@@ -1357,6 +1380,13 @@ void AIChatConsoleContent::resized() {
     bounds.removeFromBottom(4);  // Spacing above tabs
 
     if (activeTab_ == ConsoleTab::AI) {
+        // Faust MCP status strip at the very top (dot painted in paint()).
+        auto mcpStrip = bounds.removeFromTop(18);
+        mcpStripBounds_ = mcpStrip;
+        mcpStatusLabel_.setBounds(mcpStrip.withTrimmedLeft(16));
+        mcpStatusLabel_.setVisible(true);
+        bounds.removeFromTop(6);  // gap below the strip
+
         // Context bar above tabs
         auto bottomBar = bounds.removeFromBottom(26);
         bottomBarBounds_ = bottomBar;
@@ -1402,6 +1432,10 @@ void AIChatConsoleContent::resized() {
         configStatusLabel_.setBounds(statusBar);
         configStatusLabel_.toFront(false);
     } else {
+        // DSL tab: no MCP strip
+        mcpStatusLabel_.setVisible(false);
+        mcpStripBounds_ = {};
+
         // DSL tab layout
         bounds.removeFromBottom(4);  // Spacing above status bar
         dslStatusLabel_.setBounds(bounds.removeFromBottom(20));
@@ -1416,6 +1450,7 @@ void AIChatConsoleContent::resized() {
 void AIChatConsoleContent::onActivated() {
     buildAliasList();
     updateConfigStatus();
+    updateMcpStatus();
     if (isShowing()) {
         if (activeTab_ == ConsoleTab::AI)
             inputBox_->grabKeyboardFocus();
@@ -1566,6 +1601,7 @@ void AIChatConsoleContent::projectOpened(const magda::ProjectInfo& /*info*/) {
 
 void AIChatConsoleContent::configChanged() {
     updateConfigStatus();
+    updateMcpStatus();
 }
 
 // ============================================================================
@@ -1886,6 +1922,29 @@ void AIChatConsoleContent::updateConfigStatus() {
 
     configStatusLabel_.setText(status, juce::dontSendNotification);
     resized();
+}
+
+void AIChatConsoleContent::updateMcpStatus() {
+    auto& mgr = magda::MCPServerManager::getInstance();
+    mcpEnabled_ = mgr.isServerEnabled("faust-mcp");
+    mcpRunning_ = mgr.isServerRunning("faust-mcp");
+
+    juce::String text;
+    juce::Colour colour;
+    if (!mcpEnabled_) {
+        text = "Faust MCP off";
+        colour = DarkTheme::getSecondaryTextColour().withAlpha(0.6f);
+    } else if (mcpRunning_) {
+        text = "Faust MCP connected";
+        colour = juce::Colours::limegreen;
+    } else {
+        text = "Faust MCP on";
+        colour = juce::Colours::limegreen.withAlpha(0.85f);
+    }
+
+    mcpStatusLabel_.setText(text, juce::dontSendNotification);
+    mcpStatusLabel_.setColour(juce::Label::textColourId, colour);
+    repaint();
 }
 
 bool AIChatConsoleContent::isLocalPreset() const {

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
@@ -223,15 +223,6 @@ class AIChatConsoleContent : public PanelContent,
     void updateConfigStatus();
     bool isLocalPreset() const;
 
-    // Faust MCP status strip (top of the AI tab). A small status light + label
-    // showing whether the faust-mcp server is enabled / running, so it's clear
-    // at a glance that AI Faust generation has its compile-check backend.
-    juce::Label mcpStatusLabel_;
-    juce::Rectangle<int> mcpStripBounds_;
-    bool mcpEnabled_ = false;
-    bool mcpRunning_ = false;
-    void updateMcpStatus();
-
     // Plugin alias autocomplete
     struct AliasEntry {
         juce::String alias;       // e.g. "serum_2"

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
@@ -223,6 +223,15 @@ class AIChatConsoleContent : public PanelContent,
     void updateConfigStatus();
     bool isLocalPreset() const;
 
+    // Faust MCP status strip (top of the AI tab). A small status light + label
+    // showing whether the faust-mcp server is enabled / running, so it's clear
+    // at a glance that AI Faust generation has its compile-check backend.
+    juce::Label mcpStatusLabel_;
+    juce::Rectangle<int> mcpStripBounds_;
+    bool mcpEnabled_ = false;
+    bool mcpRunning_ = false;
+    void updateMcpStatus();
+
     // Plugin alias autocomplete
     struct AliasEntry {
         juce::String alias;       // e.g. "serum_2"


### PR DESCRIPTION
Routes the Faust AI console + library work into the `epic/faust-improvements` integration branch.

## What's in here
- **AI conversation history + auto-retry.** The per-device Faust AI panel now runs a multi-turn conversation (refinements edit the existing DSP), and on an MCP compile failure it feeds the error back and self-corrects (up to 3 attempts) instead of asking. Failed attempts are kept out of the persisted history.
- **MCP status strip** in the per-device AI panel (off / on / connected), shown for coder devices.
- **Graceful MCP-off.** With faust-mcp off the generated DSP is not auto-applied (unverified); it is staged into the editor for manual compile.
- **Always-latest models.** `toLLMProviderConfig` resolves Claude families to the latest constant, so stale saved configs cannot pin an old model. Bumped Opus to 4.8 and set `noTemperature` for it (4.8 rejects `temperature`).
- **Faust effect library.** A save (floppy) button writes the current DSP to a `.dsp` under the user data dir; the Load menu lists saved effects under "My Effects".
- **Faust UI polish.** Save icon sizing, and the code editor's Compile button on the theme font.

## Dependencies
- Bumps the **juce-llm** submodule to **v0.2.1** (multi-turn Conversation API + Anthropic `noTemperature`). Both juce-llm PRs are merged and tagged on its `main`.

## Notes
- Base is `epic/faust-improvements`, not `main` (integration branch for the broader Faust work; the wasm/JIT backend lands as a separate PR into the same epic).
- Built and exercised locally. CI runs on the local machine.
