### PR TITLE
Add per-track measurement layer (#1388)

### DIFF
--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -319,6 +319,7 @@ target_sources(magda_daw PRIVATE
     plugin_manager/PluginManagerMacros.cpp
     plugin_manager/PluginManagerModifiers.cpp
     plugin_manager/PluginManagerSidechain.cpp
+    plugin_manager/PluginManagerMeasurement.cpp
     racks/InstrumentRackManager.cpp
     racks/RackSyncManager.cpp
     modifiers/ModifierSync.cpp
@@ -342,6 +343,7 @@ target_sources(magda_daw PRIVATE
     plugins/InstrumentMeterTapPlugin.cpp
     plugins/OscilloscopePlugin.cpp
     plugins/SpectrumAnalyzerPlugin.cpp
+    plugins/TrackMeasurementPlugin.cpp
     plugins/MidiDevicePlugin.cpp
     plugins/FaustPlugin.cpp
     plugins/FaustMetadataParser.cpp

--- a/magda/daw/audio/analysis/TrackMeasurer.hpp
+++ b/magda/daw/audio/analysis/TrackMeasurer.hpp
@@ -1,0 +1,427 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <vector>
+
+namespace magda::daw::audio {
+
+/**
+ * @brief Real-time loudness / level / stereo measurement for one signal point
+ *        (a track output or the master), per issue #1388.
+ *
+ * Implements ITU-R BS.1770-4 K-weighted loudness (momentary / short-term /
+ * gated-integrated LUFS), sample + optional oversampled true-peak, stereo
+ * correlation and width, and the derived dynamics figures (PLR / PSR). It is
+ * the pure DSP core: no Tracktion Engine, no plugin lifecycle, no enablement
+ * policy - the always-on TrackMeasurementPlugin owns those and simply feeds
+ * blocks here while a consumer (Levels meter or mixing agent) is listening.
+ *
+ * Threading: process() is audio-thread, allocation-free after prepare().
+ * read() is message-thread and lock-free. Published scalars are plain atomics;
+ * the integrated-loudness histogram is read with benign races (monotonic
+ * counts, a torn read only yields a slightly stale integrated value - the same
+ * "tearing acceptable for metering" stance as AudioTapBuffer).
+ */
+
+/// LUFS value reported when a window holds no above-floor signal.
+inline constexpr float kSilenceLufs = -100.0f;
+/// dB value reported for silence on the peak fields.
+inline constexpr float kSilenceDb = -200.0f;
+
+struct TrackMeasurementSnapshot {
+    float momentaryLufs = kSilenceLufs;   ///< 400 ms K-weighted window
+    float shortTermLufs = kSilenceLufs;   ///< 3 s K-weighted window
+    float integratedLufs = kSilenceLufs;  ///< gated, since last reset()
+
+    float samplePeakDb = kSilenceDb;  ///< max |sample|, dBFS (always computed)
+    float truePeakDb = kSilenceDb;    ///< oversampled dBTP (only if true-peak enabled)
+
+    float correlation = 1.0f;  ///< L/R correlation [-1, 1] (1 for mono)
+    float width = 0.0f;        ///< side/(mid+side) energy ratio [0,1]: 0 mono, 1 fully out-of-phase
+
+    float plr = 0.0f;  ///< peak-to-loudness ratio: peak - integrated (LU)
+    float psr = 0.0f;  ///< peak-to-short-term ratio: peak - short-term (LU)
+
+    bool truePeakValid = false;  ///< false when oversampled true-peak is disabled
+    bool valid = false;          ///< true once any signal has been processed
+};
+
+class TrackMeasurer {
+  public:
+    /**
+     * @param sampleRate    feed rate
+     * @param maxBlockSize  largest block process() will see
+     * @param enableTruePeak  run the 4x oversampler (master-only by policy; per
+     *                        issue #1388 per-track uses sample peak to keep the
+     *                        N-tracks cost down - true-peak is the heavy part)
+     */
+    void prepare(double sampleRate, int maxBlockSize, bool enableTruePeak) {
+        sampleRate_ = sampleRate > 0.0 ? sampleRate : 48000.0;
+        enableTruePeak_ = enableTruePeak;
+        computeKWeightingCoeffs(sampleRate_);
+        if (enableTruePeak_)
+            buildOversampler();
+        blockSamples_ = juce::jmax(1, static_cast<int>(std::lround(sampleRate_ * 0.1)));  // 100 ms
+        scratchL_.assign(static_cast<size_t>(juce::jmax(1, maxBlockSize)), 0.0f);
+        scratchR_.assign(static_cast<size_t>(juce::jmax(1, maxBlockSize)), 0.0f);
+        reset();
+    }
+
+    /// Clears integrated gating history and all running windows. Audio or message
+    /// thread, but not concurrently with process().
+    void reset() {
+        for (auto& f : filtL_)
+            f = {};
+        for (auto& f : filtR_)
+            f = {};
+        blockEnergy_.fill(0.0);
+        blockCount_ = 0;
+        curBlockAcc_ = 0.0;
+        curBlockN_ = 0;
+        for (auto& h : histogram_)
+            h.store(0, std::memory_order_relaxed);
+        corrSmoothed_ = 1.0f;
+        widthSmoothed_ = 0.0f;
+        for (auto& s : tpDelayL_)
+            s = 0.0f;
+        for (auto& s : tpDelayR_)
+            s = 0.0f;
+        momentary_.store(kSilenceLufs, std::memory_order_relaxed);
+        shortTerm_.store(kSilenceLufs, std::memory_order_relaxed);
+        samplePeak_.store(kSilenceDb, std::memory_order_relaxed);
+        truePeak_.store(kSilenceDb, std::memory_order_relaxed);
+        correlation_.store(1.0f, std::memory_order_relaxed);
+        width_.store(0.0f, std::memory_order_relaxed);
+        valid_.store(false, std::memory_order_relaxed);
+    }
+
+    /// Audio thread. Process one (interleaved-by-pointer) block. Mono is handled
+    /// by treating R == L. Allocation-free.
+    void process(const float* const* channels, int numChannels, int numSamples) noexcept {
+        if (numChannels <= 0 || numSamples <= 0)
+            return;
+        const float* l = channels[0];
+        const float* r = numChannels > 1 ? channels[1] : channels[0];
+        if (numSamples > static_cast<int>(scratchL_.size()))
+            return;  // block exceeds prepared size; skip (signal still passes through upstream)
+
+        double sumMidSq = 0.0, sumSideSq = 0.0, sumLR = 0.0, sumLL = 0.0, sumRR = 0.0;
+        float samplePeak = 0.0f;
+
+        for (int i = 0; i < numSamples; ++i) {
+            const float xl = l[i];
+            const float xr = r[i];
+
+            // Sample peak (cheap, always on).
+            samplePeak = juce::jmax(samplePeak, std::abs(xl), std::abs(xr));
+
+            // K-weighted energy for loudness.
+            const double kl = applyKWeight(filtL_, xl);
+            const double kr = applyKWeight(filtR_, xr);
+            curBlockAcc_ += kl * kl + kr * kr;  // stereo channel weights = 1.0
+            if (++curBlockN_ >= blockSamples_)
+                closeGatingBlock();
+
+            // Mid/side for correlation + width.
+            const double mid = 0.5 * (xl + xr);
+            const double side = 0.5 * (xl - xr);
+            sumMidSq += mid * mid;
+            sumSideSq += side * side;
+            sumLR += static_cast<double>(xl) * xr;
+            sumLL += static_cast<double>(xl) * xl;
+            sumRR += static_cast<double>(xr) * xr;
+        }
+
+        // Sample peak -> dBFS.
+        if (samplePeak > 0.0f)
+            publishMax(samplePeak_, linearToDb(samplePeak));
+
+        // True peak (oversampled) only when enabled.
+        if (enableTruePeak_) {
+            const float tp = juce::jmax(oversamplePeak(tpDelayL_, l, numSamples),
+                                        oversamplePeak(tpDelayR_, r, numSamples));
+            if (tp > 0.0f)
+                publishMax(truePeak_, linearToDb(tp));
+        }
+
+        // Correlation: normalised cross-correlation over the block, one-pole smoothed.
+        const double denom = std::sqrt(sumLL * sumRR);
+        const float instCorr =
+            denom > 1.0e-12 ? static_cast<float>(juce::jlimit(-1.0, 1.0, sumLR / denom)) : 1.0f;
+        corrSmoothed_ += kCorrSmooth * (instCorr - corrSmoothed_);
+        correlation_.store(corrSmoothed_, std::memory_order_relaxed);
+
+        // Width: side energy as a fraction of total mid+side, one-pole smoothed.
+        // Bounded [0,1] and well-defined at the anti-phase limit (mid -> 0 -> width 1).
+        const double msTotal = sumMidSq + sumSideSq;
+        const float instWidth = msTotal > 1.0e-12 ? static_cast<float>(sumSideSq / msTotal) : 0.0f;
+        widthSmoothed_ += kCorrSmooth * (instWidth - widthSmoothed_);
+        width_.store(widthSmoothed_, std::memory_order_relaxed);
+
+        // Momentary (400 ms = last 4 gating blocks) and short-term (3 s = 30 blocks).
+        momentary_.store(windowLufs(4), std::memory_order_relaxed);
+        shortTerm_.store(windowLufs(30), std::memory_order_relaxed);
+        valid_.store(true, std::memory_order_relaxed);
+    }
+
+    /// Message thread. Lock-free snapshot of current measurements.
+    TrackMeasurementSnapshot read() const noexcept {
+        TrackMeasurementSnapshot s;
+        s.valid = valid_.load(std::memory_order_relaxed);
+        s.momentaryLufs = momentary_.load(std::memory_order_relaxed);
+        s.shortTermLufs = shortTerm_.load(std::memory_order_relaxed);
+        s.integratedLufs = computeIntegrated();
+        s.samplePeakDb = samplePeak_.load(std::memory_order_relaxed);
+        s.truePeakValid = enableTruePeak_;
+        s.truePeakDb = enableTruePeak_ ? truePeak_.load(std::memory_order_relaxed) : kSilenceDb;
+        s.correlation = correlation_.load(std::memory_order_relaxed);
+        s.width = width_.load(std::memory_order_relaxed);
+
+        // Dynamics: peak (true-peak if available, else sample peak) above loudness.
+        const float peak =
+            s.truePeakValid && s.truePeakDb > kSilenceDb ? s.truePeakDb : s.samplePeakDb;
+        if (peak > kSilenceDb && s.integratedLufs > kSilenceLufs)
+            s.plr = peak - s.integratedLufs;
+        if (peak > kSilenceDb && s.shortTermLufs > kSilenceLufs)
+            s.psr = peak - s.shortTermLufs;
+        return s;
+    }
+
+    bool truePeakEnabled() const noexcept {
+        return enableTruePeak_;
+    }
+
+  private:
+    // ---- ITU-R BS.1770-4 K-weighting: two cascaded biquads (TDF-II) ----------
+    struct Biquad {
+        double b0 = 1, b1 = 0, b2 = 0, a1 = 0, a2 = 0;
+    };
+    struct BiquadState {
+        double z1 = 0, z2 = 0;
+    };
+
+    Biquad preFilter_;                    // stage 1: high-shelf
+    Biquad highPass_;                     // stage 2: RLB high-pass
+    std::array<BiquadState, 2> filtL_{};  // [0]=pre, [1]=highpass
+    std::array<BiquadState, 2> filtR_{};
+
+    // Coefficient derivation ported from the well-known libebur128 filter design
+    // so LUFS is correct at any sample rate, not just 48 kHz.
+    void computeKWeightingCoeffs(double fs) {
+        {
+            const double f0 = 1681.974450955533;
+            const double G = 3.999843853973347;
+            const double Q = 0.7071752369554196;
+            const double K = std::tan(juce::MathConstants<double>::pi * f0 / fs);
+            const double Vh = std::pow(10.0, G / 20.0);
+            const double Vb = std::pow(Vh, 0.4996667741545416);
+            const double a0 = 1.0 + K / Q + K * K;
+            preFilter_.b0 = (Vh + Vb * K / Q + K * K) / a0;
+            preFilter_.b1 = 2.0 * (K * K - Vh) / a0;
+            preFilter_.b2 = (Vh - Vb * K / Q + K * K) / a0;
+            preFilter_.a1 = 2.0 * (K * K - 1.0) / a0;
+            preFilter_.a2 = (1.0 - K / Q + K * K) / a0;
+        }
+        {
+            const double f0 = 38.13547087602444;
+            const double Q = 0.5003270373238773;
+            const double K = std::tan(juce::MathConstants<double>::pi * f0 / fs);
+            const double a0 = 1.0 + K / Q + K * K;
+            highPass_.b0 = 1.0 / a0;
+            highPass_.b1 = -2.0 / a0;
+            highPass_.b2 = 1.0 / a0;
+            highPass_.a1 = 2.0 * (K * K - 1.0) / a0;
+            highPass_.a2 = (1.0 - K / Q + K * K) / a0;
+        }
+    }
+
+    static double biquad(const Biquad& c, BiquadState& s, double x) noexcept {
+        const double y = c.b0 * x + s.z1;
+        s.z1 = c.b1 * x - c.a1 * y + s.z2;
+        s.z2 = c.b2 * x - c.a2 * y;
+        return y;
+    }
+    double applyKWeight(std::array<BiquadState, 2>& st, double x) const noexcept {
+        return biquad(highPass_, st[1], biquad(preFilter_, st[0], x));
+    }
+
+    // ---- Gating blocks (100 ms) feeding momentary/short-term/integrated -------
+    static constexpr int kRing = 30;           // 30 * 100 ms = 3 s short-term window
+    std::array<double, kRing> blockEnergy_{};  // mean-square per 100 ms block
+    int blockCount_ = 0;                       // total blocks closed since reset
+    double curBlockAcc_ = 0.0;
+    int curBlockN_ = 0;
+    int blockSamples_ = 4800;
+
+    // Integrated histogram: block-loudness in 0.1 LU bins from -70..+5 LUFS.
+    static constexpr int kHistBins = 751;
+    static constexpr double kHistMin = -70.0;
+    static constexpr double kHistStep = 0.1;
+    std::array<std::atomic<std::uint32_t>, kHistBins> histogram_{};
+
+    void closeGatingBlock() noexcept {
+        const double meanSq = curBlockN_ > 0 ? curBlockAcc_ / curBlockN_ : 0.0;
+        blockEnergy_[static_cast<size_t>(blockCount_ % kRing)] = meanSq;
+        ++blockCount_;
+        curBlockAcc_ = 0.0;
+        curBlockN_ = 0;
+
+        // Integrated: 400 ms gating block = last 4 100 ms blocks; absolute -70 LUFS gate.
+        if (blockCount_ >= 4) {
+            double e = 0.0;
+            for (int k = 0; k < 4; ++k)
+                e += blockEnergy_[static_cast<size_t>((blockCount_ - 1 - k) % kRing)];
+            const double meanSq4 = e / 4.0;
+            if (meanSq4 > 0.0) {
+                const double loud = -0.691 + 10.0 * std::log10(meanSq4);
+                if (loud >= -70.0) {
+                    int bin = static_cast<int>(std::lround((loud - kHistMin) / kHistStep));
+                    bin = juce::jlimit(0, kHistBins - 1, bin);
+                    histogram_[static_cast<size_t>(bin)].fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        }
+    }
+
+    /// Loudness over the last `nBlocks` 100 ms blocks (momentary/short-term).
+    float windowLufs(int nBlocks) const noexcept {
+        const int n = juce::jmin(nBlocks, blockCount_, kRing);
+        if (n <= 0)
+            return kSilenceLufs;
+        double e = 0.0;
+        for (int k = 0; k < n; ++k)
+            e += blockEnergy_[static_cast<size_t>((blockCount_ - 1 - k) % kRing)];
+        const double meanSq = e / n;
+        if (meanSq <= 0.0)
+            return kSilenceLufs;
+        return static_cast<float>(-0.691 + 10.0 * std::log10(meanSq));
+    }
+
+    /// Gated integrated loudness from the histogram (BS.1770 relative -10 LU gate).
+    float computeIntegrated() const noexcept {
+        // First pass: ungated mean energy of all blocks above the absolute gate.
+        double sumE = 0.0;
+        std::uint64_t count = 0;
+        for (int b = 0; b < kHistBins; ++b) {
+            const std::uint32_t c =
+                histogram_[static_cast<size_t>(b)].load(std::memory_order_relaxed);
+            if (c == 0)
+                continue;
+            const double loud = kHistMin + b * kHistStep;
+            const double energy = std::pow(10.0, (loud + 0.691) / 10.0);
+            sumE += energy * c;
+            count += c;
+        }
+        if (count == 0)
+            return kSilenceLufs;
+        const double ungated = -0.691 + 10.0 * std::log10(sumE / static_cast<double>(count));
+        const double relGate = ungated - 10.0;
+
+        // Second pass: mean energy of blocks above the relative gate.
+        double sumE2 = 0.0;
+        std::uint64_t count2 = 0;
+        for (int b = 0; b < kHistBins; ++b) {
+            const double loud = kHistMin + b * kHistStep;
+            if (loud < relGate)
+                continue;
+            const std::uint32_t c =
+                histogram_[static_cast<size_t>(b)].load(std::memory_order_relaxed);
+            if (c == 0)
+                continue;
+            const double energy = std::pow(10.0, (loud + 0.691) / 10.0);
+            sumE2 += energy * c;
+            count2 += c;
+        }
+        if (count2 == 0)
+            return kSilenceLufs;
+        return static_cast<float>(-0.691 + 10.0 * std::log10(sumE2 / static_cast<double>(count2)));
+    }
+
+    // ---- True-peak 4x polyphase oversampler ----------------------------------
+    static constexpr int kOsFactor = 4;
+    static constexpr int kTapsPerPhase = 12;
+    std::array<std::array<float, kTapsPerPhase>, kOsFactor> osCoeffs_{};
+    std::array<float, kTapsPerPhase> tpDelayL_{};
+    std::array<float, kTapsPerPhase> tpDelayR_{};
+
+    void buildOversampler() {
+        // Windowed-sinc low-pass (cutoff at original Nyquist), split into 4 polyphase
+        // sub-filters. Hann window over the full kernel for a clean stopband.
+        const int total = kOsFactor * kTapsPerPhase;
+        const double fc = 0.5 / kOsFactor;  // normalised to oversampled rate
+        std::vector<double> kernel(static_cast<size_t>(total));
+        const double mid = (total - 1) / 2.0;
+        for (int n = 0; n < total; ++n) {
+            const double x = n - mid;
+            const double sinc = std::abs(x) < 1.0e-9
+                                    ? 2.0 * fc
+                                    : std::sin(2.0 * juce::MathConstants<double>::pi * fc * x) /
+                                          (juce::MathConstants<double>::pi * x);
+            const double w =
+                0.5 - 0.5 * std::cos(2.0 * juce::MathConstants<double>::pi * n / (total - 1));
+            kernel[static_cast<size_t>(n)] = sinc * w;
+        }
+        // Unity passband gain after upsampling (compensate the kOsFactor zero-stuffing loss).
+        double sum = 0.0;
+        for (double v : kernel)
+            sum += v;
+        const double norm = sum > 1.0e-12 ? (kOsFactor / sum) : 1.0;
+        for (int phase = 0; phase < kOsFactor; ++phase)
+            for (int t = 0; t < kTapsPerPhase; ++t) {
+                const int idx = t * kOsFactor + phase;
+                osCoeffs_[static_cast<size_t>(phase)][static_cast<size_t>(t)] =
+                    idx < total ? static_cast<float>(kernel[static_cast<size_t>(idx)] * norm)
+                                : 0.0f;
+            }
+    }
+
+    float oversamplePeak(std::array<float, kTapsPerPhase>& delay, const float* x, int n) noexcept {
+        float peak = 0.0f;
+        for (int i = 0; i < n; ++i) {
+            // Shift newest sample into the delay line (newest at [0]).
+            for (int t = kTapsPerPhase - 1; t > 0; --t)
+                delay[static_cast<size_t>(t)] = delay[static_cast<size_t>(t - 1)];
+            delay[0] = x[i];
+            for (int phase = 0; phase < kOsFactor; ++phase) {
+                float acc = 0.0f;
+                const auto& c = osCoeffs_[static_cast<size_t>(phase)];
+                for (int t = 0; t < kTapsPerPhase; ++t)
+                    acc += c[static_cast<size_t>(t)] * delay[static_cast<size_t>(t)];
+                peak = juce::jmax(peak, std::abs(acc));
+            }
+        }
+        return peak;
+    }
+
+    static float linearToDb(float lin) noexcept {
+        return lin > 1.0e-9f ? 20.0f * std::log10(lin) : kSilenceDb;
+    }
+
+    static void publishMax(std::atomic<float>& slot, float candidate) noexcept {
+        float cur = slot.load(std::memory_order_relaxed);
+        while (candidate > cur &&
+               !slot.compare_exchange_weak(cur, candidate, std::memory_order_relaxed)) {
+        }
+    }
+
+    static constexpr float kCorrSmooth = 0.2f;  // one-pole smoothing per block
+
+    double sampleRate_ = 48000.0;
+    bool enableTruePeak_ = false;
+    std::vector<float> scratchL_, scratchR_;
+    float corrSmoothed_ = 1.0f, widthSmoothed_ = 0.0f;
+
+    std::atomic<float> momentary_{kSilenceLufs};
+    std::atomic<float> shortTerm_{kSilenceLufs};
+    std::atomic<float> samplePeak_{kSilenceDb};
+    std::atomic<float> truePeak_{kSilenceDb};
+    std::atomic<float> correlation_{1.0f};
+    std::atomic<float> width_{0.0f};
+    std::atomic<bool> valid_{false};
+};
+
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/plugin_manager/PluginManager.hpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.hpp
@@ -27,6 +27,9 @@ struct TrackInfo;
 class TrackController;
 class PluginWindowBridge;
 class TransportStateManager;
+namespace daw::audio {
+class TrackMeasurementPlugin;
+}
 
 /**
  * @brief Result of attempting to load a plugin
@@ -498,6 +501,20 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener {
     void removeAudioSidechainMonitor(TrackId sourceTrackId);
 
     /**
+     * @brief Ensure the always-on per-track measurement tap exists (issue #1388).
+     *
+     * Inserts a TrackMeasurementPlugin post-fader (appended at the end of the
+     * chain, after volume/pan) on the given track, or on the master when
+     * trackId == MASTER_TRACK_ID. The master tap is created with true-peak
+     * enabled; per-track taps use sample peak only. Idempotent: returns the
+     * existing tap if already present. Returns nullptr if the track has no TE
+     * audio track. The tap is dormant until a consumer enables it.
+     */
+    daw::audio::TrackMeasurementPlugin* ensureTrackMeasurementTap(TrackId trackId);
+    void removeTrackMeasurementTap(TrackId trackId);
+    daw::audio::TrackMeasurementPlugin* getTrackMeasurementTap(TrackId trackId) const;
+
+    /**
      * @brief Ensure a MidiReceivePlugin exists before a target device for MIDI sidechain.
      * @param trackId The destination track
      * @param deviceId The device that needs MIDI injection
@@ -637,6 +654,10 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener {
 
     // Audio sidechain monitor plugins (sourceTrackId → AudioSidechainMonitorPlugin)
     std::map<TrackId, te::Plugin::Ptr> audioSidechainMonitors_;
+
+    // Per-track measurement taps (trackId → TrackMeasurementPlugin), issue #1388.
+    // MASTER_TRACK_ID keys the master tap. Lazily inserted on first enable.
+    std::map<TrackId, te::Plugin::Ptr> trackMeasurementTaps_;
 
     // Pre-computed sidechain LFO cache: indexed by source TrackId.
     // Double-buffered: message thread writes to inactive buffer then atomically

--- a/magda/daw/audio/plugin_manager/PluginManagerMeasurement.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerMeasurement.cpp
@@ -1,0 +1,86 @@
+// Per-track measurement tap lifecycle (issue #1388).
+//
+// Inserts/removes the always-on TrackMeasurementPlugin that the Levels meter
+// and the mixing agent read from. Kept separate from the sidechain/sync/
+// modifier partial-class files: measurement is its own concern. The higher-
+// level enablement policy, polling and snapshot API live in
+// TrackMeasurementManager, which drives these through the audio bridge.
+
+#include "../../core/TypeIds.hpp"
+#include "../TrackController.hpp"
+#include "PluginManager.hpp"
+#include "plugins/TrackMeasurementPlugin.hpp"
+
+namespace magda {
+
+namespace {
+
+// Resolve the plugin list to tap: the master's list for MASTER_TRACK_ID,
+// otherwise the track's own chain. Returns nullptr if the track has no TE track.
+te::PluginList* measurementPluginList(te::Edit& edit, TrackController& trackController,
+                                      TrackId trackId) {
+    if (trackId == MASTER_TRACK_ID)
+        return &edit.getMasterPluginList();
+    if (auto* teTrack = trackController.getAudioTrack(trackId))
+        return &teTrack->pluginList;
+    return nullptr;
+}
+
+}  // namespace
+
+daw::audio::TrackMeasurementPlugin* PluginManager::ensureTrackMeasurementTap(TrackId trackId) {
+    // Already tracked? Return the cached instance.
+    if (auto it = trackMeasurementTaps_.find(trackId); it != trackMeasurementTaps_.end())
+        return dynamic_cast<daw::audio::TrackMeasurementPlugin*>(it->second.get());
+
+    auto* list = measurementPluginList(edit_, trackController_, trackId);
+    if (list == nullptr)
+        return nullptr;
+
+    // Adopt an existing tap if one is already on the chain (e.g. after restore).
+    for (int i = 0; i < list->size(); ++i) {
+        if (auto* existing = dynamic_cast<daw::audio::TrackMeasurementPlugin*>((*list)[i])) {
+            trackMeasurementTaps_[trackId] = (*list)[i];
+            return existing;
+        }
+    }
+
+    const bool isMaster = (trackId == MASTER_TRACK_ID);
+    juce::ValueTree pluginState(te::IDs::PLUGIN);
+    pluginState.setProperty(te::IDs::type, daw::audio::TrackMeasurementPlugin::xmlTypeName,
+                            nullptr);
+    // True-peak oversampling is the heavy path, so only the master runs it; per-
+    // track taps stay on sample peak (set via the persisted property pre-create).
+    if (isMaster)
+        pluginState.setProperty(juce::Identifier("measureTruePeak"), true, nullptr);
+
+    auto plugin = edit_.getPluginCache().createNewPlugin(pluginState);
+    if (!plugin)
+        return nullptr;
+
+    // Post-fader: append at the very end of the chain (after volume/pan and TE's
+    // level meter) so the tap measures what actually sums downstream.
+    list->insertPlugin(plugin, list->size(), nullptr);
+    trackMeasurementTaps_[trackId] = plugin;
+    return dynamic_cast<daw::audio::TrackMeasurementPlugin*>(plugin.get());
+}
+
+void PluginManager::removeTrackMeasurementTap(TrackId trackId) {
+    auto it = trackMeasurementTaps_.find(trackId);
+    if (it == trackMeasurementTaps_.end())
+        return;
+
+    auto* plugin = it->second.get();
+    trackMeasurementTaps_.erase(it);
+    if (plugin)
+        plugin->deleteFromParent();
+}
+
+daw::audio::TrackMeasurementPlugin* PluginManager::getTrackMeasurementTap(TrackId trackId) const {
+    auto it = trackMeasurementTaps_.find(trackId);
+    if (it == trackMeasurementTaps_.end())
+        return nullptr;
+    return dynamic_cast<daw::audio::TrackMeasurementPlugin*>(it->second.get());
+}
+
+}  // namespace magda

--- a/magda/daw/audio/plugins/InternalPluginRegistry.cpp
+++ b/magda/daw/audio/plugins/InternalPluginRegistry.cpp
@@ -12,6 +12,7 @@
 #include "plugins/SidechainMonitorPlugin.hpp"
 #include "plugins/SpectrumAnalyzerPlugin.hpp"
 #include "plugins/StepSequencerPlugin.hpp"
+#include "plugins/TrackMeasurementPlugin.hpp"
 #include "processors/DeviceProcessor.hpp"
 #include "processors/internal/MidiDeviceProcessors.hpp"
 #include "processors/internal/NativeDeviceProcessors.hpp"
@@ -142,6 +143,10 @@ const InternalPluginSpec kSpecs[] = {
      "Internal meter tap used to observe instrument output levels.",
      InternalPluginCreateMode::Unsupported, false, false, nullptr, 0,
      matches<InstrumentMeterTapPlugin>, nullptr},
+    {InternalDeviceKind::TrackMeasurement, TrackMeasurementPlugin::xmlTypeName, "Track Measurement",
+     "Meter", "Internal post-fader tap measuring loudness, peak and stereo for the mixing tools.",
+     InternalPluginCreateMode::Unsupported, false, false, nullptr, 0,
+     matches<TrackMeasurementPlugin>, nullptr},
     {InternalDeviceKind::SessionMonitor, ::magda::SessionMonitorPlugin::xmlTypeName,
      "Session Monitor", "Session", "Internal monitor used by session playback and launch state.",
      InternalPluginCreateMode::Unsupported, false, false, nullptr, 0,
@@ -160,7 +165,7 @@ const InternalPluginSpec* const kSpecPtrs[] = {
     &kSpecs[0],  &kSpecs[1],  &kSpecs[2],  &kSpecs[3],  &kSpecs[4],  &kSpecs[5],  &kSpecs[6],
     &kSpecs[7],  &kSpecs[8],  &kSpecs[9],  &kSpecs[10], &kSpecs[11], &kSpecs[12], &kSpecs[13],
     &kSpecs[14], &kSpecs[15], &kSpecs[16], &kSpecs[17], &kSpecs[18], &kSpecs[19], &kSpecs[20],
-    &kSpecs[21], &kSpecs[22], &kSpecs[23], &kSpecs[24], &kSpecs[25],
+    &kSpecs[21], &kSpecs[22], &kSpecs[23], &kSpecs[24], &kSpecs[25], &kSpecs[26],
 };
 
 bool typeMatchesAlias(const juce::String& type, const InternalPluginSpec& spec) {

--- a/magda/daw/audio/plugins/TrackMeasurementPlugin.cpp
+++ b/magda/daw/audio/plugins/TrackMeasurementPlugin.cpp
@@ -1,0 +1,7 @@
+#include "plugins/TrackMeasurementPlugin.hpp"
+
+namespace magda::daw::audio {
+
+const char* TrackMeasurementPlugin::xmlTypeName = "trackmeasurement";
+
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/plugins/TrackMeasurementPlugin.hpp
+++ b/magda/daw/audio/plugins/TrackMeasurementPlugin.hpp
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <tracktion_engine/tracktion_engine.h>
+
+#include <atomic>
+
+#include "analysis/TrackMeasurer.hpp"
+
+namespace magda::daw::audio {
+
+namespace te = tracktion::engine;
+
+/**
+ * @brief Always-on, insert-independent per-track measurement tap (issue #1388).
+ *
+ * Auto-inserted post-fader on every track and the master by the measurement
+ * manager (not user-insertable; showInBrowser=false). Transparent passthrough:
+ * applyToBuffer() never modifies the audio. It feeds the stereo block to a
+ * TrackMeasurer only while a consumer (a visible Levels meter or the mixing
+ * agent mid-pass) has enabled it - otherwise it returns immediately so the
+ * idle cost on un-metered tracks is a single branch per block.
+ *
+ * True-peak oversampling is the one heavy measurement, so it is opt-in per
+ * instance (persisted): the manager enables it on the master only, where
+ * inter-sample peaks matter, and leaves per-track on sample peak.
+ */
+class TrackMeasurementPlugin : public te::Plugin {
+  public:
+    explicit TrackMeasurementPlugin(const te::PluginCreationInfo& info) : te::Plugin(info) {
+        measureTruePeakValue_.referTo(state, juce::Identifier("measureTruePeak"), getUndoManager(),
+                                      false);
+    }
+    ~TrackMeasurementPlugin() override {
+        notifyListenersOfDeletion();
+    }
+
+    static const char* getPluginName() {
+        return "Track Measurement";
+    }
+    static const char* xmlTypeName;
+
+    juce::String getName() const override {
+        return getPluginName();
+    }
+    juce::String getPluginType() override {
+        return xmlTypeName;
+    }
+    juce::String getShortName(int) override {
+        return "Meas";
+    }
+    juce::String getSelectableDescription() override {
+        return getName();
+    }
+
+    /// Dormant-until-consumed. Cheap to flip from the message thread; the audio
+    /// thread reads it relaxed each block.
+    void setMeasurementEnabled(bool shouldMeasure) noexcept {
+        if (shouldMeasure && !enabled_.exchange(true, std::memory_order_acq_rel))
+            pendingReset_.store(true, std::memory_order_release);
+        else
+            enabled_.store(shouldMeasure, std::memory_order_release);
+    }
+    bool isMeasurementEnabled() const noexcept {
+        return enabled_.load(std::memory_order_acquire);
+    }
+
+    /// Persisted: run the oversampled true-peak path (master-only by policy).
+    /// Takes effect on the next initialise(); the manager sets it at creation.
+    void setMeasureTruePeak(bool shouldMeasure) {
+        measureTruePeakValue_ = shouldMeasure;
+    }
+    bool getMeasureTruePeak() const {
+        return measureTruePeakValue_.get();
+    }
+
+    /// Message thread. Latest measurements (lock-free).
+    TrackMeasurementSnapshot getSnapshot() const noexcept {
+        return measurer_.read();
+    }
+
+    void initialise(const te::PluginInitialisationInfo& info) override {
+        measurer_.prepare(info.sampleRate, juce::jmax(1, info.blockSizeSamples),
+                          measureTruePeakValue_.get());
+    }
+    void deinitialise() override {}
+    void reset() override {
+        measurer_.reset();
+    }
+
+    void applyToBuffer(const te::PluginRenderContext& fc) override {
+        // Transparent: read only, never write the buffer or MIDI.
+        if (!enabled_.load(std::memory_order_acquire))
+            return;  // dormant: single branch, no measurement cost
+        if (!fc.destBuffer || fc.bufferNumSamples <= 0)
+            return;
+
+        if (pendingReset_.exchange(false, std::memory_order_acq_rel))
+            measurer_.reset();  // fresh integration window each time a consumer re-enables
+
+        const int numCh = juce::jmin(fc.destBuffer->getNumChannels(), 2);
+        if (numCh <= 0)
+            return;
+        const float* ptrs[2] = {nullptr, nullptr};
+        for (int ch = 0; ch < numCh; ++ch)
+            ptrs[ch] = fc.destBuffer->getReadPointer(ch, fc.bufferStartSample);
+        measurer_.process(ptrs, numCh, fc.bufferNumSamples);
+    }
+
+    bool takesMidiInput() override {
+        return false;
+    }
+    bool takesAudioInput() override {
+        return true;
+    }
+    bool isSynth() override {
+        return false;
+    }
+    bool producesAudioWhenNoAudioInput() override {
+        return false;
+    }
+    double getTailLength() const override {
+        return 0.0;
+    }
+    void restorePluginStateFromValueTree(const juce::ValueTree& v) override {
+        tracktion::copyPropertiesToCachedValues(v, measureTruePeakValue_);
+    }
+
+  private:
+    TrackMeasurer measurer_;
+    std::atomic<bool> enabled_{false};       // dormant until a consumer wants data
+    std::atomic<bool> pendingReset_{false};  // re-enable -> clear gating history on audio thread
+    juce::CachedValue<bool> measureTruePeakValue_;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TrackMeasurementPlugin)
+};
+
+}  // namespace magda::daw::audio

--- a/magda/daw/core/CMakeLists.txt
+++ b/magda/daw/core/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(magda_daw PRIVATE
     AutomationManager.cpp
     LinkModeManager.cpp
     GainStagingManager.cpp
+    TrackMeasurementManager.cpp
     UndoManager.cpp
     ClipCommands.cpp
     ClipPropertyCommands.cpp

--- a/magda/daw/core/InternalDeviceKind.cpp
+++ b/magda/daw/core/InternalDeviceKind.cpp
@@ -16,6 +16,7 @@
 #include "audio/plugins/SidechainMonitorPlugin.hpp"
 #include "audio/plugins/SpectrumAnalyzerPlugin.hpp"
 #include "audio/plugins/StepSequencerPlugin.hpp"
+#include "audio/plugins/TrackMeasurementPlugin.hpp"
 #include "audio/plugins/compiled/CompiledPluginRegistry.hpp"
 #include "audio/session/SessionMonitorPlugin.hpp"
 
@@ -86,6 +87,8 @@ const InternalDeviceMetadata kMetadata[] = {
      "Internal audio monitor used by sidechain-aware devices."},
     {InternalDeviceKind::InstrumentMeterTap, "Instrument Meter Tap", "", "Meter",
      "Internal meter tap used to observe instrument output levels."},
+    {InternalDeviceKind::TrackMeasurement, "Track Measurement", "", "Meter",
+     "Internal post-fader tap measuring loudness, peak and stereo for the mixing tools."},
     {InternalDeviceKind::SessionMonitor, "Session Monitor", "", "Session",
      "Internal monitor used by session playback and launch state."},
     {InternalDeviceKind::Oscilloscope, "Oscilloscope", "", "Analysis",
@@ -141,6 +144,7 @@ InternalDeviceKind classifyInternalDevice(const juce::String& pluginId) {
     using daw::audio::OscilloscopePlugin;
     using daw::audio::SpectrumAnalyzerPlugin;
     using daw::audio::StepSequencerPlugin;
+    using daw::audio::TrackMeasurementPlugin;
     namespace TE = tracktion::engine;
 
     const Mapping kMappings[] = {
@@ -170,6 +174,7 @@ InternalDeviceKind classifyInternalDevice(const juce::String& pluginId) {
         {InternalDeviceKind::Oscilloscope, OscilloscopePlugin::xmlTypeName, nullptr},
         {InternalDeviceKind::SpectrumAnalyzer, SpectrumAnalyzerPlugin::xmlTypeName, nullptr},
         {InternalDeviceKind::InstrumentMeterTap, InstrumentMeterTapPlugin::xmlTypeName, nullptr},
+        {InternalDeviceKind::TrackMeasurement, TrackMeasurementPlugin::xmlTypeName, nullptr},
         {InternalDeviceKind::Faust, FaustPlugin::xmlTypeName, nullptr},
         // Plugins still in plain magda:: (older infra layers).
         {InternalDeviceKind::MidiReceive, MidiReceivePlugin::xmlTypeName, nullptr},

--- a/magda/daw/core/InternalDeviceKind.hpp
+++ b/magda/daw/core/InternalDeviceKind.hpp
@@ -48,6 +48,7 @@ enum class InternalDeviceKind {
     SidechainMonitor,
     AudioSidechainMonitor,
     InstrumentMeterTap,
+    TrackMeasurement,  // always-on per-track loudness/level/stereo tap (issue #1388)
     SessionMonitor,
     // --- Analysis (transparent passthrough; DeviceType::Analysis) -------
     Oscilloscope,

--- a/magda/daw/core/TrackMeasurementManager.cpp
+++ b/magda/daw/core/TrackMeasurementManager.cpp
@@ -1,0 +1,106 @@
+#include "TrackMeasurementManager.hpp"
+
+#include "../audio/AudioBridge.hpp"
+#include "../audio/plugin_manager/PluginManager.hpp"
+#include "../audio/plugins/TrackMeasurementPlugin.hpp"
+#include "../engine/AudioEngine.hpp"
+#include "TrackManager.hpp"
+
+namespace magda {
+
+namespace {
+
+// The tap lifecycle lives in PluginManager, reached through the audio bridge.
+// Returns nullptr before the engine/bridge exist (early startup, headless).
+PluginManager* pluginManager() {
+    auto* engine = TrackManager::getInstance().getAudioEngine();
+    if (engine == nullptr)
+        return nullptr;
+    auto* bridge = engine->getAudioBridge();
+    if (bridge == nullptr)
+        return nullptr;
+    return &bridge->getPluginManager();
+}
+
+}  // namespace
+
+TrackMeasurementManager& TrackMeasurementManager::getInstance() {
+    static TrackMeasurementManager instance;
+    return instance;
+}
+
+void TrackMeasurementManager::setGlobalEnabled(bool shouldEnable) {
+    if (globalEnabled_ == shouldEnable)
+        return;
+    globalEnabled_ = shouldEnable;
+    // Reconcile every desired track: applyTrack removes taps when the global
+    // switch is off (true kill switch) and re-inserts them when it comes back.
+    for (TrackId trackId : enabledTracks_)
+        applyTrack(trackId);
+    if (!globalEnabled_)
+        latest_.clear();
+    updateTimer();
+}
+
+void TrackMeasurementManager::setTrackEnabled(TrackId trackId, bool shouldEnable) {
+    const bool already = enabledTracks_.count(trackId) > 0;
+    if (shouldEnable == already)
+        return;
+    if (shouldEnable)
+        enabledTracks_.insert(trackId);
+    else
+        enabledTracks_.erase(trackId);
+    applyTrack(trackId);
+    updateTimer();
+}
+
+void TrackMeasurementManager::applyTrack(TrackId trackId) {
+    auto* pm = pluginManager();
+    if (pm == nullptr)
+        return;
+    const bool active = globalEnabled_ && enabledTracks_.count(trackId) > 0;
+    if (active) {
+        if (auto* tap = pm->ensureTrackMeasurementTap(trackId))
+            tap->setMeasurementEnabled(true);
+    } else {
+        pm->removeTrackMeasurementTap(trackId);
+        latest_.erase(trackId);
+    }
+}
+
+void TrackMeasurementManager::updateTimer() {
+    const bool shouldRun = globalEnabled_ && !enabledTracks_.empty();
+    if (shouldRun && !isTimerRunning())
+        startTimer(kPollIntervalMs);
+    else if (!shouldRun && isTimerRunning())
+        stopTimer();
+}
+
+void TrackMeasurementManager::timerCallback() {
+    auto* pm = pluginManager();
+    if (pm == nullptr)
+        return;
+    for (TrackId trackId : enabledTracks_) {
+        if (auto* tap = pm->getTrackMeasurementTap(trackId))
+            latest_[trackId] = tap->getSnapshot();
+    }
+    listeners_.call([](TrackMeasurementListener& l) { l.trackMeasurementsUpdated(); });
+}
+
+daw::audio::TrackMeasurementSnapshot TrackMeasurementManager::getSnapshot(TrackId trackId) const {
+    auto it = latest_.find(trackId);
+    if (it == latest_.end())
+        return {};
+    return it->second;
+}
+
+std::vector<std::pair<TrackId, daw::audio::TrackMeasurementSnapshot>>
+TrackMeasurementManager::getAllSnapshots() const {
+    std::vector<std::pair<TrackId, daw::audio::TrackMeasurementSnapshot>> out;
+    out.reserve(latest_.size());
+    for (const auto& [trackId, snapshot] : latest_)
+        out.emplace_back(trackId, snapshot);
+    return out;
+}
+
+}  // namespace magda

--- a/magda/daw/core/TrackMeasurementManager.hpp
+++ b/magda/daw/core/TrackMeasurementManager.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <juce_events/juce_events.h>
+
+#include <map>
+#include <set>
+#include <vector>
+
+#include "../audio/analysis/TrackMeasurer.hpp"
+#include "TypeIds.hpp"
+
+namespace magda {
+
+/**
+ * @brief Owns the per-track measurement layer's enablement and polling (#1388).
+ *
+ * The DSP lives in TrackMeasurer; the always-on tap is TrackMeasurementPlugin;
+ * the tap lifecycle (insert/remove post-fader) lives in PluginManager. This
+ * manager sits on top and decides WHEN measurement runs, polls the taps, and
+ * serves snapshots to consumers (the Levels meter and the mixing agent).
+ *
+ * Enablement contract (see the dormant-until-consumed / user-disable design):
+ *   - A global "Mix Analysis" kill switch. Off => every tap is removed and the
+ *     poll timer stops; nothing runs and nothing is inserted.
+ *   - Per-track enable, requested by consumers. A track only measures while it
+ *     is enabled AND the global switch is on. The desired per-track set is
+ *     remembered across global toggles so re-enabling restores it.
+ *   - Taps are inserted lazily on first enable, not on every track up front.
+ *
+ * Message-thread only. Reaches the tap plugins through the audio bridge.
+ */
+class TrackMeasurementListener {
+  public:
+    virtual ~TrackMeasurementListener() = default;
+    /// Fired after each poll with the set of tracks that have fresh snapshots.
+    virtual void trackMeasurementsUpdated() {}
+};
+
+class TrackMeasurementManager : private juce::Timer {
+  public:
+    static TrackMeasurementManager& getInstance();
+
+    TrackMeasurementManager(const TrackMeasurementManager&) = delete;
+    TrackMeasurementManager& operator=(const TrackMeasurementManager&) = delete;
+
+    // --- Global kill switch ("Mix Analysis") --------------------------------
+    void setGlobalEnabled(bool shouldEnable);
+    bool isGlobalEnabled() const {
+        return globalEnabled_;
+    }
+
+    // --- Per-track enablement (requested by consumers) ----------------------
+    void setTrackEnabled(TrackId trackId, bool shouldEnable);
+    bool isTrackEnabled(TrackId trackId) const {
+        return enabledTracks_.count(trackId) > 0;
+    }
+
+    // --- Snapshots ----------------------------------------------------------
+    /// Latest measurement for a track. `valid == false` if none yet / not enabled.
+    daw::audio::TrackMeasurementSnapshot getSnapshot(TrackId trackId) const;
+    /// All currently-held snapshots (enabled tracks with data), for the agent.
+    std::vector<std::pair<TrackId, daw::audio::TrackMeasurementSnapshot>> getAllSnapshots() const;
+
+    void addListener(TrackMeasurementListener* l) {
+        listeners_.add(l);
+    }
+    void removeListener(TrackMeasurementListener* l) {
+        listeners_.remove(l);
+    }
+
+    /// Poll cadence. Momentary loudness + peaks update fast; this is plenty.
+    static constexpr int kPollIntervalMs = 33;
+
+  private:
+    TrackMeasurementManager() = default;
+
+    void timerCallback() override;
+
+    // Reconcile a single track's tap with (global && desired) state.
+    void applyTrack(TrackId trackId);
+    // Start/stop the poll timer based on whether anything is active.
+    void updateTimer();
+
+    bool globalEnabled_ = false;
+    std::set<TrackId> enabledTracks_;  // desired per-track state
+    std::map<TrackId, daw::audio::TrackMeasurementSnapshot> latest_;
+    juce::ListenerList<TrackMeasurementListener> listeners_;
+};
+
+}  // namespace magda

--- a/magda/daw/engine/MagdaEngineBehaviour.hpp
+++ b/magda/daw/engine/MagdaEngineBehaviour.hpp
@@ -13,6 +13,7 @@
 #include "../audio/plugins/SidechainMonitorPlugin.hpp"
 #include "../audio/plugins/SpectrumAnalyzerPlugin.hpp"
 #include "../audio/plugins/StepSequencerPlugin.hpp"
+#include "../audio/plugins/TrackMeasurementPlugin.hpp"
 #include "../audio/plugins/compiled/CompiledPluginRegistry.hpp"
 #include "../audio/session/SessionMonitorPlugin.hpp"
 #include "../project/ProjectManager.hpp"
@@ -125,6 +126,9 @@ class MagdaEngineBehaviour : public tracktion::EngineBehaviour {
         }
         if (type == daw::audio::InstrumentMeterTapPlugin::xmlTypeName) {
             return new daw::audio::InstrumentMeterTapPlugin(info);
+        }
+        if (type == daw::audio::TrackMeasurementPlugin::xmlTypeName) {
+            return new daw::audio::TrackMeasurementPlugin(info);
         }
         if (type == tracktion::ImpulseResponsePlugin::xmlTypeName) {
             return new tracktion::ImpulseResponsePlugin(info);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -109,6 +109,8 @@ set(TEST_SOURCES
     test_selection_manager_listeners.cpp
     # Configurable user data paths
     test_app_paths.cpp
+    # Mixing pt2 (issue #1388) - per-track loudness/level/stereo measurement DSP
+    test_track_measurer.cpp
     # Media database (issue #768) — Phase A: SQLite skeleton
     test_media_database.cpp
     # Media database (issue #768) — Phase B: scanner + path rules

--- a/tests/test_track_measurer.cpp
+++ b/tests/test_track_measurer.cpp
@@ -1,0 +1,142 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <vector>
+
+#include "../magda/daw/audio/analysis/TrackMeasurer.hpp"
+
+using magda::daw::audio::kSilenceLufs;
+using magda::daw::audio::TrackMeasurementSnapshot;
+using magda::daw::audio::TrackMeasurer;
+
+namespace {
+
+constexpr double kSr = 48000.0;
+constexpr int kBlock = 512;
+constexpr double kPi = 3.14159265358979323846;
+
+// Feed `seconds` of a stereo sine (same signal both channels unless rGain set)
+// through the measurer in kBlock-sized chunks.
+void feedSine(TrackMeasurer& m, double freq, float ampL, float ampR, double seconds,
+              double startPhase = 0.0) {
+    const int total = static_cast<int>(seconds * kSr);
+    std::vector<float> l(kBlock), r(kBlock);
+    double phase = startPhase;
+    const double inc = 2.0 * kPi * freq / kSr;
+    int done = 0;
+    while (done < total) {
+        const int n = std::min(kBlock, total - done);
+        for (int i = 0; i < n; ++i) {
+            const float s = static_cast<float>(std::sin(phase));
+            l[static_cast<size_t>(i)] = ampL * s;
+            r[static_cast<size_t>(i)] = ampR * s;
+            phase += inc;
+        }
+        const float* ch[2] = {l.data(), r.data()};
+        m.process(ch, 2, n);
+        done += n;
+    }
+}
+
+}  // namespace
+
+TEST_CASE("TrackMeasurer - silence reports floor values", "[measurer]") {
+    TrackMeasurer m;
+    m.prepare(kSr, kBlock, false);
+    feedSine(m, 1000.0, 0.0f, 0.0f, 1.0);
+    const auto s = m.read();
+    REQUIRE(s.momentaryLufs == Catch::Approx(kSilenceLufs));
+    REQUIRE(s.shortTermLufs == Catch::Approx(kSilenceLufs));
+    REQUIRE(s.integratedLufs == Catch::Approx(kSilenceLufs));
+}
+
+TEST_CASE("TrackMeasurer - full-scale 1kHz sine lands near 0 LUFS", "[measurer]") {
+    TrackMeasurer m;
+    m.prepare(kSr, kBlock, false);
+    feedSine(m, 1000.0, 1.0f, 1.0f, 4.0);
+    const auto s = m.read();
+    // Amplitude-1 stereo sine: stereo-summed mean square ~= 1.0 (0 dB) minus the
+    // 0.691 offset plus a small K-weighting gain at 1 kHz -> a few tenths around 0.
+    REQUIRE(s.momentaryLufs > -3.0f);
+    REQUIRE(s.momentaryLufs < 2.0f);
+    REQUIRE(s.shortTermLufs > -3.0f);
+    REQUIRE(s.integratedLufs > -3.0f);
+    REQUIRE(s.integratedLufs < 2.0f);
+}
+
+TEST_CASE("TrackMeasurer - halving amplitude drops loudness ~6 LU", "[measurer]") {
+    TrackMeasurer full, half;
+    full.prepare(kSr, kBlock, false);
+    half.prepare(kSr, kBlock, false);
+    feedSine(full, 1000.0, 1.0f, 1.0f, 4.0);
+    feedSine(half, 1000.0, 0.5f, 0.5f, 4.0);
+    const float df = full.read().integratedLufs - half.read().integratedLufs;
+    REQUIRE(df == Catch::Approx(6.02f).margin(0.5f));
+}
+
+TEST_CASE("TrackMeasurer - gated integrated tracks steady short-term", "[measurer]") {
+    TrackMeasurer m;
+    m.prepare(kSr, kBlock, false);
+    feedSine(m, 1000.0, 0.5f, 0.5f, 5.0);
+    const auto s = m.read();
+    REQUIRE(s.integratedLufs == Catch::Approx(s.shortTermLufs).margin(1.0f));
+}
+
+TEST_CASE("TrackMeasurer - sample peak reflects amplitude", "[measurer]") {
+    TrackMeasurer m;
+    m.prepare(kSr, kBlock, false);
+    feedSine(m, 1000.0, 0.5f, 0.5f, 1.0);
+    // 0.5 amplitude -> -6.02 dBFS peak.
+    REQUIRE(m.read().samplePeakDb == Catch::Approx(-6.02f).margin(0.2f));
+}
+
+TEST_CASE("TrackMeasurer - correlation: mono=+1, inverted=-1", "[measurer]") {
+    TrackMeasurer mono, inv;
+    mono.prepare(kSr, kBlock, false);
+    inv.prepare(kSr, kBlock, false);
+    feedSine(mono, 1000.0, 0.5f, 0.5f, 1.0);
+    feedSine(inv, 1000.0, 0.5f, -0.5f, 1.0);
+    REQUIRE(mono.read().correlation == Catch::Approx(1.0f).margin(0.05f));
+    REQUIRE(inv.read().correlation == Catch::Approx(-1.0f).margin(0.05f));
+}
+
+TEST_CASE("TrackMeasurer - width: mono is ~0, decorrelated is larger", "[measurer]") {
+    TrackMeasurer mono;
+    mono.prepare(kSr, kBlock, false);
+    feedSine(mono, 1000.0, 0.5f, 0.5f, 1.0);
+    REQUIRE(mono.read().width == Catch::Approx(0.0f).margin(0.02f));
+
+    // Out-of-phase content has side energy -> non-zero width.
+    TrackMeasurer wide;
+    wide.prepare(kSr, kBlock, false);
+    feedSine(wide, 1000.0, 0.5f, -0.5f, 1.0);
+    REQUIRE(wide.read().width > 0.5f);
+}
+
+TEST_CASE("TrackMeasurer - true peak is enabled-gated and >= sample peak", "[measurer]") {
+    TrackMeasurer off;
+    off.prepare(kSr, kBlock, false);
+    feedSine(off, 1000.0, 0.9f, 0.9f, 1.0);
+    REQUIRE_FALSE(off.read().truePeakValid);
+
+    TrackMeasurer on;
+    on.prepare(kSr, kBlock, true);
+    // A high-frequency near-full-scale tone has inter-sample peaks above the
+    // sampled maxima; true peak must not fall below sample peak.
+    feedSine(on, 11000.0, 0.95f, 0.95f, 1.0);
+    const auto s = on.read();
+    REQUIRE(s.truePeakValid);
+    REQUIRE(s.truePeakDb >= s.samplePeakDb - 0.05f);
+}
+
+TEST_CASE("TrackMeasurer - reset clears state", "[measurer]") {
+    TrackMeasurer m;
+    m.prepare(kSr, kBlock, false);
+    feedSine(m, 1000.0, 1.0f, 1.0f, 2.0);
+    REQUIRE(m.read().valid);
+    m.reset();
+    const auto s = m.read();
+    REQUIRE_FALSE(s.valid);
+    REQUIRE(s.integratedLufs == Catch::Approx(kSilenceLufs));
+    REQUIRE(s.samplePeakDb == Catch::Approx(magda::daw::audio::kSilenceDb));
+}


### PR DESCRIPTION
Real-time loudness/level/stereo measurement that the Levels meter and the mixing agent will read from. Implements ITU-R BS.1770-4 K-weighted LUFS (momentary/short-term/gated integrated), oversampled true-peak, stereo correlation/width, and PLR/PSR.

- TrackMeasurer: lock-free DSP core, correct at any sample rate (+ unit tests)
- TrackMeasurementPlugin: always-on post-fader tap, dormant until a consumer enables it, true-peak oversampling master-only to keep per-track cost low
- PluginManager tap lifecycle: ensure/remove post-fader, master keyed by MASTER_TRACK_ID with true-peak on
- TrackMeasurementManager: global Mix Analysis kill switch, per-track enable, 30 Hz polling, snapshot API for consumers