### PR TITLE
Add inter-track masking detection (#1390)

### DIFF
--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -270,6 +270,7 @@ target_sources(magda_daw PRIVATE
     AudioThumbnailManager.cpp
     WaveformPeakCache.cpp
     DeviceMeteringManager.cpp
+    analysis/BandSpectrum.cpp
     FaustResources.cpp
     processors/base/DeviceProcessor.cpp
     processors/base/DeviceProcessor.hpp

--- a/magda/daw/audio/analysis/BandSpectrum.cpp
+++ b/magda/daw/audio/analysis/BandSpectrum.cpp
@@ -1,0 +1,67 @@
+#include "analysis/BandSpectrum.hpp"
+
+#include <juce_dsp/juce_dsp.h>
+
+#include <cmath>
+#include <vector>
+
+namespace magda::daw::audio {
+
+namespace {
+constexpr int kFftOrder = 11;             // 2048-point frame
+constexpr int kFftSize = 1 << kFftOrder;  // 2048
+constexpr float kFloorDb = -120.0f;
+}  // namespace
+
+void computeMaskingBandsDb(const AudioTapBuffer& ring, double sampleRate,
+                           std::array<float, kNumMaskingBands>& outDb) {
+    outDb.fill(kFloorDb);
+    if (sampleRate <= 0.0)
+        return;
+
+    // Pull the most recent frame from the ring.
+    std::vector<float> frame(static_cast<size_t>(kFftSize), 0.0f);
+    ring.readLatest(frame.data(), kFftSize);
+
+    // Hann window (coherent gain 0.5, compensated below).
+    juce::dsp::WindowingFunction<float> window(static_cast<size_t>(kFftSize),
+                                               juce::dsp::WindowingFunction<float>::hann);
+    window.multiplyWithWindowingTable(frame.data(), static_cast<size_t>(kFftSize));
+
+    // Frequency-only forward FFT needs 2*fftSize storage.
+    std::vector<float> fftData(static_cast<size_t>(kFftSize) * 2, 0.0f);
+    std::copy(frame.begin(), frame.end(), fftData.begin());
+    juce::dsp::FFT fft(kFftOrder);
+    fft.performFrequencyOnlyForwardTransform(fftData.data());
+
+    // Per-bin amplitude so a full-scale sine peaks at 1.0 (0 dBFS) in its bin.
+    // juce::dsp::WindowingFunction normalises the window (coherent gain ~1), so
+    // only the one-sided (x2) factor over the frame length is needed. We take the
+    // peak bin within each band (rather than summing the window-smeared mainlobe,
+    // which over-counts): calibrated for tones, monotonic with energy otherwise.
+    const float scale = 2.0f / static_cast<float>(kFftSize);
+    const double binHz = sampleRate / static_cast<double>(kFftSize);
+
+    std::array<float, kNumMaskingBands> peak{};
+    peak.fill(0.0f);
+    for (int bin = 1; bin <= kFftSize / 2; ++bin) {
+        const double freq = bin * binHz;
+        if (freq < maskingBandEdgeHz(0))
+            continue;
+        if (freq >= maskingBandEdgeHz(kNumMaskingBands))
+            break;
+        // Locate the band containing this bin (bands are monotonic in freq).
+        int b = static_cast<int>(std::floor(3.0 * std::log2(freq / 20.0)));
+        b = juce::jlimit(0, kNumMaskingBands - 1, b);
+        const float amp = fftData[static_cast<size_t>(bin)] * scale;
+        peak[static_cast<size_t>(b)] = juce::jmax(peak[static_cast<size_t>(b)], amp);
+    }
+
+    for (int b = 0; b < kNumMaskingBands; ++b) {
+        if (peak[static_cast<size_t>(b)] > 0.0f)
+            outDb[static_cast<size_t>(b)] =
+                juce::jmax(kFloorDb, 20.0f * std::log10(peak[static_cast<size_t>(b)]));
+    }
+}
+
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/analysis/BandSpectrum.hpp
+++ b/magda/daw/audio/analysis/BandSpectrum.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <array>
+
+#include "AudioTapBuffer.hpp"
+#include "MaskingDetector.hpp"
+
+namespace magda::daw::audio {
+
+/**
+ * @brief Compute per-band energy (dB) over the masking band layout from a
+ *        captured mono signal ring, for the masking detector (#1390).
+ *
+ * Message thread. Reads the most recent FFT frame from `ring`, windows it, runs
+ * a forward FFT, and groups bins into the kNumMaskingBands 1/3-octave bands
+ * (band b spans [maskingBandEdgeHz(b), maskingBandEdgeHz(b+1)]). Output is
+ * roughly dBFS: a full-scale tone reads near 0 dB in its band, silence reads at
+ * the floor. Allocates scratch on the message thread (never the audio thread).
+ */
+void computeMaskingBandsDb(const AudioTapBuffer& ring, double sampleRate,
+                           std::array<float, kNumMaskingBands>& outDb);
+
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/analysis/MaskingDetector.hpp
+++ b/magda/daw/audio/analysis/MaskingDetector.hpp
@@ -1,0 +1,150 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <map>
+#include <vector>
+
+namespace magda::daw::audio {
+
+/**
+ * @brief Inter-track frequency-masking detector (issue #1390).
+ *
+ * Pure analysis over per-track band spectra: given each track's energy in a
+ * shared set of 1/3-octave bands, it finds pairs of tracks that compete for the
+ * same frequency region ("kick and bass masking at 80-120 Hz"). This is the
+ * agent-side DSP that feeds the mixing agent (#886); it has no audio-thread or
+ * Tracktion dependency, so it is unit-testable in isolation. The per-track band
+ * energies are produced upstream by the measurement layer's taps (#1388).
+ */
+
+/// 1/3-octave bands from ~20 Hz; band b spans [edge(b), edge(b+1)].
+inline constexpr int kNumMaskingBands = 30;
+
+/// Lower edge of band index (0..kNumMaskingBands), in Hz.
+inline float maskingBandEdgeHz(int edge) {
+    return 20.0f * std::pow(2.0f, static_cast<float>(edge) / 3.0f);  // edge 30 -> ~20480 Hz
+}
+
+/// dB energy treated as "no content" in a band.
+inline constexpr float kMaskingFloorDb = -60.0f;
+
+struct TrackBandEnergies {
+    int trackId = -1;
+    juce::String name;
+    std::array<float, kNumMaskingBands> bandDb{};  // per-band energy, dBFS-ish
+};
+
+struct MaskingFinding {
+    int trackA = -1, trackB = -1;
+    juce::String nameA, nameB;
+    float loHz = 0.0f, hiHz = 0.0f;  // merged offending frequency range
+    float severity = 0.0f;           // 0..1, worst band in the range
+};
+
+struct MaskingOptions {
+    float absFloorDb = kMaskingFloorDb;  // bands below this are ignored
+    float relRangeDb = 12.0f;   // a band "matters" for a track within this of its peak band
+    float minSeverity = 0.12f;  // cull findings weaker than this
+    int maxFindings = 12;       // cap the returned list
+};
+
+namespace masking_detail {
+
+// Perceptual weight: masking is most audible / most common in the mids.
+inline float bandWeight(int b) {
+    const float c = std::sqrt(maskingBandEdgeHz(b) * maskingBandEdgeHz(b + 1));
+    return (c >= 150.0f && c <= 6000.0f) ? 1.0f : 0.45f;
+}
+
+}  // namespace masking_detail
+
+/**
+ * Detect masking between tracks. Returns findings sorted by severity (worst
+ * first), at most opts.maxFindings.
+ */
+inline std::vector<MaskingFinding> detectMasking(const std::vector<TrackBandEnergies>& tracks,
+                                                 const MaskingOptions& opts = {}) {
+    const int n = static_cast<int>(tracks.size());
+
+    // Per-track relative presence in each band: 1.0 at the track's peak band,
+    // ramping to 0 at relRangeDb below it; 0 below the absolute floor.
+    std::vector<std::array<float, kNumMaskingBands>> rel(static_cast<size_t>(juce::jmax(0, n)));
+    for (int t = 0; t < n; ++t) {
+        float peak = opts.absFloorDb;
+        for (int b = 0; b < kNumMaskingBands; ++b)
+            peak = juce::jmax(peak, tracks[static_cast<size_t>(t)].bandDb[static_cast<size_t>(b)]);
+        const float lo = peak - opts.relRangeDb;
+        for (int b = 0; b < kNumMaskingBands; ++b) {
+            const float db = tracks[static_cast<size_t>(t)].bandDb[static_cast<size_t>(b)];
+            float r = 0.0f;
+            if (db > opts.absFloorDb && opts.relRangeDb > 0.0f)
+                r = juce::jlimit(0.0f, 1.0f, (db - lo) / opts.relRangeDb);
+            rel[static_cast<size_t>(t)][static_cast<size_t>(b)] = r;
+        }
+    }
+
+    // Per-pair, per-band severity = weight * min(relA, relB): both tracks must
+    // prominently occupy the band for it to count as mutual masking.
+    std::map<std::pair<int, int>, std::array<float, kNumMaskingBands>> pairBands;
+    for (int i = 0; i < n; ++i) {
+        for (int j = i + 1; j < n; ++j) {
+            std::array<float, kNumMaskingBands> sev{};
+            bool any = false;
+            for (int b = 0; b < kNumMaskingBands; ++b) {
+                const float s = masking_detail::bandWeight(b) *
+                                juce::jmin(rel[static_cast<size_t>(i)][static_cast<size_t>(b)],
+                                           rel[static_cast<size_t>(j)][static_cast<size_t>(b)]);
+                sev[static_cast<size_t>(b)] = s;
+                any = any || s > 0.0f;
+            }
+            if (any)
+                pairBands[{i, j}] = sev;
+        }
+    }
+
+    // Merge consecutive significant bands per pair into one finding (a range),
+    // taking the worst band as the severity.
+    std::vector<MaskingFinding> findings;
+    for (const auto& [pair, sev] : pairBands) {
+        int runStart = -1;
+        float runMax = 0.0f;
+        auto flush = [&](int runEnd) {
+            if (runStart >= 0 && runMax >= opts.minSeverity) {
+                MaskingFinding f;
+                f.trackA = tracks[static_cast<size_t>(pair.first)].trackId;
+                f.trackB = tracks[static_cast<size_t>(pair.second)].trackId;
+                f.nameA = tracks[static_cast<size_t>(pair.first)].name;
+                f.nameB = tracks[static_cast<size_t>(pair.second)].name;
+                f.loHz = maskingBandEdgeHz(runStart);
+                f.hiHz = maskingBandEdgeHz(runEnd + 1);
+                f.severity = runMax;
+                findings.push_back(std::move(f));
+            }
+            runStart = -1;
+            runMax = 0.0f;
+        };
+        for (int b = 0; b < kNumMaskingBands; ++b) {
+            if (sev[static_cast<size_t>(b)] > 0.0f) {
+                if (runStart < 0)
+                    runStart = b;
+                runMax = juce::jmax(runMax, sev[static_cast<size_t>(b)]);
+            } else {
+                flush(b - 1);
+            }
+        }
+        flush(kNumMaskingBands - 1);
+    }
+
+    std::sort(
+        findings.begin(), findings.end(),
+        [](const MaskingFinding& a, const MaskingFinding& b) { return a.severity > b.severity; });
+    if (static_cast<int>(findings.size()) > opts.maxFindings)
+        findings.resize(static_cast<size_t>(opts.maxFindings));
+    return findings;
+}
+
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/analysis/TrackMeasurer.hpp
+++ b/magda/daw/audio/analysis/TrackMeasurer.hpp
@@ -7,6 +7,8 @@
 #include <cmath>
 #include <vector>
 
+#include "AudioTapBuffer.hpp"
+
 namespace magda::daw::audio {
 
 /**
@@ -111,6 +113,7 @@ class TrackMeasurer {
 
         double sumMidSq = 0.0, sumSideSq = 0.0, sumLR = 0.0, sumLL = 0.0, sumRR = 0.0;
         float samplePeak = 0.0f;
+        const bool capture = captureSpectrum_.load(std::memory_order_acquire);
 
         for (int i = 0; i < numSamples; ++i) {
             const float xl = l[i];
@@ -134,7 +137,12 @@ class TrackMeasurer {
             sumLR += static_cast<double>(xl) * xr;
             sumLL += static_cast<double>(xl) * xl;
             sumRR += static_cast<double>(xr) * xr;
+
+            if (capture)
+                scratchL_[static_cast<size_t>(i)] = static_cast<float>(mid);  // mono for band FFT
         }
+        if (capture)
+            spectrumRing_.write(scratchL_.data(), numSamples);
 
         // Sample peak -> dBFS.
         if (samplePeak > 0.0f)
@@ -166,6 +174,23 @@ class TrackMeasurer {
         momentary_.store(windowLufs(4), std::memory_order_relaxed);
         shortTerm_.store(windowLufs(30), std::memory_order_relaxed);
         valid_.store(true, std::memory_order_relaxed);
+    }
+
+    /// Enable capturing a mono signal ring for masking band analysis. Off by
+    /// default; the manager turns it on only during a masking pass. Cheap when
+    /// off (a single branch); when on, just copies a mono downmix to the ring.
+    void setSpectrumCaptureEnabled(bool shouldCapture) noexcept {
+        captureSpectrum_.store(shouldCapture, std::memory_order_release);
+    }
+    bool spectrumCaptureEnabled() const noexcept {
+        return captureSpectrum_.load(std::memory_order_acquire);
+    }
+    /// Message thread. Lock-free access to the captured signal for band analysis.
+    const AudioTapBuffer& getSpectrumRing() const noexcept {
+        return spectrumRing_;
+    }
+    double sampleRate() const noexcept {
+        return sampleRate_;
     }
 
     /// Message thread. Lock-free snapshot of current measurements.
@@ -422,6 +447,11 @@ class TrackMeasurer {
     std::atomic<float> correlation_{1.0f};
     std::atomic<float> width_{0.0f};
     std::atomic<bool> valid_{false};
+
+    // Masking band analysis: a mono signal ring filled only while capture is on.
+    // The FFT/band grouping runs on the message thread (see band_spectrum).
+    std::atomic<bool> captureSpectrum_{false};
+    AudioTapBuffer spectrumRing_{4096};  // >= one 2048-pt FFT frame
 };
 
 }  // namespace magda::daw::audio

--- a/magda/daw/audio/plugins/TrackMeasurementPlugin.hpp
+++ b/magda/daw/audio/plugins/TrackMeasurementPlugin.hpp
@@ -4,6 +4,7 @@
 
 #include <atomic>
 
+#include "analysis/BandSpectrum.hpp"
 #include "analysis/TrackMeasurer.hpp"
 
 namespace magda::daw::audio {
@@ -76,6 +77,17 @@ class TrackMeasurementPlugin : public te::Plugin {
     /// Message thread. Latest measurements (lock-free).
     TrackMeasurementSnapshot getSnapshot() const noexcept {
         return measurer_.read();
+    }
+
+    /// Enable/disable mono signal capture for masking band analysis (heavier; on
+    /// only during a masking pass). Message thread.
+    void setSpectrumCaptureEnabled(bool shouldCapture) noexcept {
+        measurer_.setSpectrumCaptureEnabled(shouldCapture);
+    }
+
+    /// Message thread. Compute the current per-band energy (dB) for masking.
+    void getMaskingBandsDb(std::array<float, kNumMaskingBands>& out) const {
+        computeMaskingBandsDb(measurer_.getSpectrumRing(), measurer_.sampleRate(), out);
     }
 
     void initialise(const te::PluginInitialisationInfo& info) override {

--- a/magda/daw/core/TrackMeasurementManager.cpp
+++ b/magda/daw/core/TrackMeasurementManager.cpp
@@ -60,8 +60,10 @@ void TrackMeasurementManager::applyTrack(TrackId trackId) {
         return;
     const bool active = globalEnabled_ && enabledTracks_.count(trackId) > 0;
     if (active) {
-        if (auto* tap = pm->ensureTrackMeasurementTap(trackId))
+        if (auto* tap = pm->ensureTrackMeasurementTap(trackId)) {
             tap->setMeasurementEnabled(true);
+            tap->setSpectrumCaptureEnabled(maskingEnabled_);
+        }
     } else {
         pm->removeTrackMeasurementTap(trackId);
         latest_.erase(trackId);
@@ -85,6 +87,40 @@ void TrackMeasurementManager::timerCallback() {
             latest_[trackId] = tap->getSnapshot();
     }
     listeners_.call([](TrackMeasurementListener& l) { l.trackMeasurementsUpdated(); });
+}
+
+void TrackMeasurementManager::setMaskingAnalysisEnabled(bool shouldEnable) {
+    if (maskingEnabled_ == shouldEnable)
+        return;
+    maskingEnabled_ = shouldEnable;
+    auto* pm = pluginManager();
+    if (pm == nullptr)
+        return;
+    for (TrackId trackId : enabledTracks_)
+        if (auto* tap = pm->getTrackMeasurementTap(trackId))
+            tap->setSpectrumCaptureEnabled(maskingEnabled_);
+}
+
+std::vector<daw::audio::MaskingFinding> TrackMeasurementManager::getMaskingFindings(
+    const daw::audio::MaskingOptions& opts) const {
+    auto* pm = pluginManager();
+    if (pm == nullptr)
+        return {};
+    auto& tm = TrackManager::getInstance();
+    std::vector<daw::audio::TrackBandEnergies> tracks;
+    tracks.reserve(enabledTracks_.size());
+    for (TrackId trackId : enabledTracks_) {
+        auto* tap = pm->getTrackMeasurementTap(trackId);
+        if (tap == nullptr)
+            continue;
+        daw::audio::TrackBandEnergies tbe;
+        tbe.trackId = trackId;
+        if (const auto* info = tm.getTrack(trackId))
+            tbe.name = info->name;
+        tap->getMaskingBandsDb(tbe.bandDb);
+        tracks.push_back(std::move(tbe));
+    }
+    return daw::audio::detectMasking(tracks, opts);
 }
 
 daw::audio::TrackMeasurementSnapshot TrackMeasurementManager::getSnapshot(TrackId trackId) const {

--- a/magda/daw/core/TrackMeasurementManager.hpp
+++ b/magda/daw/core/TrackMeasurementManager.hpp
@@ -6,6 +6,7 @@
 #include <set>
 #include <vector>
 
+#include "../audio/analysis/MaskingDetector.hpp"
 #include "../audio/analysis/TrackMeasurer.hpp"
 #include "TypeIds.hpp"
 
@@ -61,6 +62,18 @@ class TrackMeasurementManager : private juce::Timer {
     /// All currently-held snapshots (enabled tracks with data), for the agent.
     std::vector<std::pair<TrackId, daw::audio::TrackMeasurementSnapshot>> getAllSnapshots() const;
 
+    // --- Masking analysis (#1390) -------------------------------------------
+    /// Arm/disarm masking band capture on the enabled taps. Heavier than the
+    /// scalar metering, so it is off unless a masking pass wants it.
+    void setMaskingAnalysisEnabled(bool shouldEnable);
+    bool isMaskingAnalysisEnabled() const {
+        return maskingEnabled_;
+    }
+    /// Gather the enabled tracks' current band spectra and detect inter-track
+    /// masking. Returns {} until capture has been armed and audio has flowed.
+    std::vector<daw::audio::MaskingFinding> getMaskingFindings(
+        const daw::audio::MaskingOptions& opts = {}) const;
+
     void addListener(TrackMeasurementListener* l) {
         listeners_.add(l);
     }
@@ -82,6 +95,7 @@ class TrackMeasurementManager : private juce::Timer {
     void updateTimer();
 
     bool globalEnabled_ = false;
+    bool maskingEnabled_ = false;      // masking band capture armed
     std::set<TrackId> enabledTracks_;  // desired per-track state
     std::map<TrackId, daw::audio::TrackMeasurementSnapshot> latest_;
     juce::ListenerList<TrackMeasurementListener> listeners_;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -111,6 +111,8 @@ set(TEST_SOURCES
     test_app_paths.cpp
     # Mixing pt2 (issue #1388) - per-track loudness/level/stereo measurement DSP
     test_track_measurer.cpp
+    # Mixing pt2 (issue #1390) - inter-track frequency masking detector
+    test_masking_detector.cpp
     # Media database (issue #768) — Phase A: SQLite skeleton
     test_media_database.cpp
     # Media database (issue #768) — Phase B: scanner + path rules

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,8 @@ set(TEST_SOURCES
     test_track_measurer.cpp
     # Mixing pt2 (issue #1390) - inter-track frequency masking detector
     test_masking_detector.cpp
+    # Mixing pt2 (issue #1390) - per-track band spectrum (FFT bin -> band mapping)
+    test_band_spectrum.cpp
     # Media database (issue #768) — Phase A: SQLite skeleton
     test_media_database.cpp
     # Media database (issue #768) — Phase B: scanner + path rules

--- a/tests/test_band_spectrum.cpp
+++ b/tests/test_band_spectrum.cpp
@@ -1,0 +1,73 @@
+#include <array>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <vector>
+
+#include "../magda/daw/audio/analysis/AudioTapBuffer.hpp"
+#include "../magda/daw/audio/analysis/BandSpectrum.hpp"
+
+using magda::daw::audio::AudioTapBuffer;
+using magda::daw::audio::computeMaskingBandsDb;
+using magda::daw::audio::kNumMaskingBands;
+using magda::daw::audio::maskingBandEdgeHz;
+
+namespace {
+
+constexpr double kSr = 48000.0;
+constexpr double kPi = 3.14159265358979323846;
+
+// Index of the band that contains a given frequency.
+int bandOf(double hz) {
+    for (int b = 0; b < kNumMaskingBands; ++b)
+        if (hz >= maskingBandEdgeHz(b) && hz < maskingBandEdgeHz(b + 1))
+            return b;
+    return -1;
+}
+
+std::array<float, kNumMaskingBands> bandsForSine(double freq, float amp) {
+    AudioTapBuffer ring(4096);
+    std::vector<float> buf(4096);
+    for (int i = 0; i < 4096; ++i)
+        buf[static_cast<size_t>(i)] =
+            amp * static_cast<float>(std::sin(2.0 * kPi * freq * i / kSr));
+    ring.write(buf.data(), 4096);
+    std::array<float, kNumMaskingBands> out{};
+    computeMaskingBandsDb(ring, kSr, out);
+    return out;
+}
+
+}  // namespace
+
+TEST_CASE("BandSpectrum - a tone lands in its own band", "[bandspectrum]") {
+    const double freq = 1000.0;
+    const int expected = bandOf(freq);
+    REQUIRE(expected >= 0);
+
+    const auto bands = bandsForSine(freq, 1.0f);
+    int argmax = 0;
+    for (int b = 1; b < kNumMaskingBands; ++b)
+        if (bands[static_cast<size_t>(b)] > bands[static_cast<size_t>(argmax)])
+            argmax = b;
+    REQUIRE(argmax == expected);
+}
+
+TEST_CASE("BandSpectrum - full-scale tone reads near 0 dB", "[bandspectrum]") {
+    const auto bands = bandsForSine(1000.0, 1.0f);
+    const int b = bandOf(1000.0);
+    REQUIRE(bands[static_cast<size_t>(b)] > -6.0f);
+    REQUIRE(bands[static_cast<size_t>(b)] < 3.0f);
+}
+
+TEST_CASE("BandSpectrum - halving amplitude drops the band ~6 dB", "[bandspectrum]") {
+    const int b = bandOf(1000.0);
+    const float full = bandsForSine(1000.0, 1.0f)[static_cast<size_t>(b)];
+    const float half = bandsForSine(1000.0, 0.5f)[static_cast<size_t>(b)];
+    REQUIRE((full - half) == Catch::Approx(6.0f).margin(1.0f));
+}
+
+TEST_CASE("BandSpectrum - silence reads at the floor", "[bandspectrum]") {
+    const auto bands = bandsForSine(1000.0, 0.0f);
+    for (int b = 0; b < kNumMaskingBands; ++b)
+        REQUIRE(bands[static_cast<size_t>(b)] < -100.0f);
+}

--- a/tests/test_masking_detector.cpp
+++ b/tests/test_masking_detector.cpp
@@ -1,0 +1,96 @@
+#include <array>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+#include "../magda/daw/audio/analysis/MaskingDetector.hpp"
+
+using magda::daw::audio::detectMasking;
+using magda::daw::audio::kNumMaskingBands;
+using magda::daw::audio::maskingBandEdgeHz;
+using magda::daw::audio::MaskingOptions;
+using magda::daw::audio::TrackBandEnergies;
+
+namespace {
+
+// A track silent everywhere except the given (band -> dB) peaks.
+TrackBandEnergies makeTrack(int id, const char* name,
+                            std::initializer_list<std::pair<int, float>> peaks) {
+    TrackBandEnergies t;
+    t.trackId = id;
+    t.name = name;
+    t.bandDb.fill(-80.0f);
+    for (auto [band, db] : peaks)
+        t.bandDb[static_cast<size_t>(band)] = db;
+    return t;
+}
+
+}  // namespace
+
+TEST_CASE("MaskingDetector - band edges span the audio range", "[masking]") {
+    REQUIRE(maskingBandEdgeHz(0) == Catch::Approx(20.0f));
+    REQUIRE(maskingBandEdgeHz(kNumMaskingBands) == Catch::Approx(20480.0f).margin(1.0f));
+}
+
+TEST_CASE("MaskingDetector - two tracks sharing a band are flagged", "[masking]") {
+    std::vector<TrackBandEnergies> tracks = {makeTrack(1, "Kick", {{16, 0.0f}}),
+                                             makeTrack(2, "Bass", {{16, 0.0f}})};
+    auto findings = detectMasking(tracks);
+    REQUIRE(findings.size() == 1);
+    REQUIRE(findings[0].trackA == 1);
+    REQUIRE(findings[0].trackB == 2);
+    REQUIRE(findings[0].severity > 0.5f);
+    REQUIRE(findings[0].loHz == Catch::Approx(maskingBandEdgeHz(16)));
+    REQUIRE(findings[0].hiHz == Catch::Approx(maskingBandEdgeHz(17)));
+}
+
+TEST_CASE("MaskingDetector - disjoint spectra produce no findings", "[masking]") {
+    std::vector<TrackBandEnergies> tracks = {makeTrack(1, "Sub", {{4, 0.0f}}),
+                                             makeTrack(2, "Air", {{27, 0.0f}})};
+    REQUIRE(detectMasking(tracks).empty());
+}
+
+TEST_CASE("MaskingDetector - single track never masks", "[masking]") {
+    std::vector<TrackBandEnergies> tracks = {makeTrack(1, "Solo", {{10, 0.0f}, {16, 0.0f}})};
+    REQUIRE(detectMasking(tracks).empty());
+}
+
+TEST_CASE("MaskingDetector - stronger overlap ranks above weaker", "[masking]") {
+    // A and B both peak in band 16; C only weakly present there (-10 dB).
+    std::vector<TrackBandEnergies> tracks = {makeTrack(1, "A", {{16, 0.0f}}),
+                                             makeTrack(2, "B", {{16, 0.0f}}),
+                                             makeTrack(3, "C", {{16, -10.0f}})};
+    auto findings = detectMasking(tracks);
+    REQUIRE(findings.size() >= 1);
+    // Worst finding is the full A/B overlap.
+    REQUIRE(((findings[0].trackA == 1 && findings[0].trackB == 2)));
+    // Any A/C or B/C finding is weaker than A/B.
+    for (size_t i = 1; i < findings.size(); ++i)
+        REQUIRE(findings[i].severity <= findings[0].severity);
+}
+
+TEST_CASE("MaskingDetector - adjacent shared bands merge into one range", "[masking]") {
+    std::vector<TrackBandEnergies> tracks = {
+        makeTrack(1, "A", {{15, 0.0f}, {16, 0.0f}, {17, 0.0f}}),
+        makeTrack(2, "B", {{15, 0.0f}, {16, 0.0f}, {17, 0.0f}})};
+    auto findings = detectMasking(tracks);
+    REQUIRE(findings.size() == 1);
+    REQUIRE(findings[0].loHz == Catch::Approx(maskingBandEdgeHz(15)));
+    REQUIRE(findings[0].hiHz == Catch::Approx(maskingBandEdgeHz(18)));
+}
+
+TEST_CASE("MaskingDetector - maxFindings caps the list", "[masking]") {
+    std::vector<TrackBandEnergies> tracks;
+    for (int i = 0; i < 6; ++i)
+        tracks.push_back(makeTrack(i + 1, "T", {{16, 0.0f}}));  // all mutually mask in band 16
+    MaskingOptions opts;
+    opts.maxFindings = 3;
+    auto findings = detectMasking(tracks, opts);
+    REQUIRE(findings.size() == 3);
+}
+
+TEST_CASE("MaskingDetector - content below the floor is ignored", "[masking]") {
+    std::vector<TrackBandEnergies> tracks = {makeTrack(1, "A", {{16, -70.0f}}),
+                                             makeTrack(2, "B", {{16, -70.0f}})};
+    REQUIRE(detectMasking(tracks).empty());
+}


### PR DESCRIPTION
Closes #1390.

Adds inter-track frequency-masking detection: finds pairs of tracks competing for the same frequency region, feeding the mixing agent (#886).

## Detector (pure, tested)
- MaskingDetector over a shared 1/3-octave band layout (30 bands, ~20Hz-20kHz): scores per-pair mutual presence per band, mid-weighted and floor-gated, merges adjacent bands into frequency ranges, returns findings sorted by severity.

## Spectral source (per-track band energies)
- TrackMeasurer: a gated mono signal ring, filled cheaply on the audio thread only while a masking pass is armed.
- BandSpectrum: message-thread FFT grouping bins into the 30 masking bands; peak-per-band, calibrated so a full-scale tone reads ~0 dBFS.
- TrackMeasurementPlugin: setSpectrumCaptureEnabled + getMaskingBandsDb.
- TrackMeasurementManager: setMaskingAnalysisEnabled arms capture on the enabled taps; getMaskingFindings gathers all tracks' band spectra and runs detectMasking.

Dormant unless armed, so idle cost is unchanged.

## Tests
12 new DSP unit tests: masking detector (shared-band flagging, disjoint/single-track no-ops, severity ordering, range merging, maxFindings cap, floor gating) and band spectrum (tone lands in its band, full-scale ~0 dB, halving ~-6 dB, silence floor).

A visual consumer (masking overlay on the Spectrum analyzer) is tracked separately in #1400.