### PR TITLE
AI console: show active-view glyph in the context bar (#1402)

### DIFF
--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -810,6 +810,15 @@ AIChatConsoleContent::AIChatConsoleContent() {
         juce::Drawable::createFromImageData(BinaryData::clip_svg, BinaryData::clip_svgSize);
     drumIconDrawable_ = juce::Drawable::createFromImageData(BinaryData::drum_grid_svg,
                                                             BinaryData::drum_grid_svgSize);
+    // View-context glyphs (#1402), matching the footer view switcher.
+    sessionIconDrawable_ = juce::Drawable::createFromImageData(
+        BinaryData::iconsessionboldm_svg, BinaryData::iconsessionboldm_svgSize);
+    arrangeIconDrawable_ = juce::Drawable::createFromImageData(
+        BinaryData::iconarrangementboldm_svg, BinaryData::iconarrangementboldm_svgSize);
+    mixIconDrawable_ = juce::Drawable::createFromImageData(BinaryData::iconmixboldm_svg,
+                                                           BinaryData::iconmixboldm_svgSize);
+    currentViewMode_ = magda::ViewModeController::getInstance().getViewMode();
+    magda::ViewModeController::getInstance().addListener(this);
 
     // Context label (always visible, inside bottom bar)
     contextLabel_.setFont(FontManager::getInstance().getMonoFont(11.0f));
@@ -1027,6 +1036,7 @@ AIChatConsoleContent::AIChatConsoleContent() {
 }
 
 AIChatConsoleContent::~AIChatConsoleContent() {
+    magda::ViewModeController::getInstance().removeListener(this);
     selectedClipContextToggle_.setLookAndFeel(nullptr);
     if (dslEditor_)
         dslEditor_->removeKeyListener(this);
@@ -1315,14 +1325,21 @@ void AIChatConsoleContent::paint(juce::Graphics& g) {
                              combined.getRight() - 1.0f);
 
         // Draw context icon
-        if (contextIcon_ != ContextIcon::None) {
+        {
+            // #1402: the context glyph reflects the active view, not selection.
             juce::Drawable* icon = nullptr;
-            if (contextIcon_ == ContextIcon::Drummer)
-                icon = drumIconDrawable_.get();
-            else if (contextIcon_ == ContextIcon::Track || contextIcon_ == ContextIcon::Device)
-                icon = trackIconDrawable_.get();
-            else if (contextIcon_ == ContextIcon::Clip)
-                icon = clipIconDrawable_.get();
+            switch (currentViewMode_) {
+                case magda::ViewMode::Live:
+                    icon = sessionIconDrawable_.get();
+                    break;
+                case magda::ViewMode::Arrange:
+                    icon = arrangeIconDrawable_.get();
+                    break;
+                case magda::ViewMode::Mix:
+                case magda::ViewMode::Master:
+                    icon = mixIconDrawable_.get();
+                    break;
+            }
 
             if (icon) {
                 auto iconBounds = contextIconBounds_.toFloat().reduced(6.0f);
@@ -1566,6 +1583,15 @@ void AIChatConsoleContent::projectOpened(const magda::ProjectInfo& /*info*/) {
 
 void AIChatConsoleContent::configChanged() {
     updateConfigStatus();
+}
+
+void AIChatConsoleContent::viewModeChanged(magda::ViewMode mode, const magda::AudioEngineProfile&) {
+    if (currentViewMode_ == mode)
+        return;
+    currentViewMode_ = mode;
+    // Slice 1: reflect the view in the context glyph. View-scoped agent routing
+    // (mixer view -> mixing agent) is wired in the routing slice (#1402).
+    repaint();
 }
 
 // ============================================================================

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -323,12 +323,22 @@ void AIChatConsoleContent::RequestThread::run() {
     auto totalStart = std::chrono::steady_clock::now();
     double routerMs = 0.0, agentMs = 0.0;
 
-    // Step 1: Classify intent via router. Skipped entirely when the user is
-    // on a drum-targetable track and didn't lead with an explicit @alias —
-    // context is unambiguous, no need to spend a model call on classification.
-    const bool hasExplicitAlias = juce::String(message).trimStart().startsWithChar('@');
+    // Step 1: Classify intent via router. Skipped entirely when context makes
+    // the target unambiguous: mixer view hard-scopes to the mixing agent
+    // (#1402), and a drum-targetable track routes to the drummer. Either way an
+    // explicit @alias or a slash-rewritten command ("[COMMAND: ...]") opts back
+    // out, so those escape hatches keep working in every view.
+    const auto trimmedMessage = juce::String(message).trimStart();
+    const bool hasExplicitAlias = trimmedMessage.startsWithChar('@');
+    const bool hasExplicitCommand = trimmedMessage.startsWith("[COMMAND:");
+    const bool contextOverridable = !hasExplicitAlias && !hasExplicitCommand;
+    const bool mixerView = (owner_.currentViewMode_ == magda::ViewMode::Mix ||
+                            owner_.currentViewMode_ == magda::ViewMode::Master);
     std::string intent = "COMMAND";  // default fallback
-    if (owner_.drummerModeActive_ && !hasExplicitAlias) {
+    if (mixerView && contextOverridable) {
+        intent = "MIXING";
+        DBG("MAGDA Router: bypassed (mixer view, hard-scoped to mixing agent)");
+    } else if (owner_.drummerModeActive_ && !hasExplicitAlias) {
         intent = "DRUM";
         DBG("MAGDA Router: bypassed (drummer mode, context-driven)");
     } else if (owner_.routerAgent_) {
@@ -598,6 +608,11 @@ void AIChatConsoleContent::RequestThread::run() {
                 musicDescription = std::move(result.description);
             }
         }
+    } else if (intent == "MIXING") {
+        // Mixer view hard-scopes here (#1402). The mixing agent (#886) lands on
+        // a follow-up branch; until then surface a placeholder so the routing is
+        // observable without dispatching to a non-existent agent.
+        error = "Mixing agent is not wired up yet (coming soon).";
     }
 
     agentMs =
@@ -1350,6 +1365,11 @@ void AIChatConsoleContent::paint(juce::Graphics& g) {
                 auto iconCopy = icon->createCopy();
                 iconCopy->replaceColour(svgGrey, colour);
                 iconCopy->replaceColour(svgWhite, colour);
+                // The footer view glyphs use fill="currentColor", which JUCE
+                // resolves to black. Recolour that too (matches SvgButton) or
+                // the icon renders dark regardless of the grey/white swaps.
+                iconCopy->replaceColour(juce::Colours::black, colour);
+                iconCopy->replaceColour(juce::Colour(0xFF000000), colour);
                 iconCopy->drawWithin(g, iconBounds, juce::RectanglePlacement::centred, 1.0f);
             }
         }
@@ -1589,8 +1609,8 @@ void AIChatConsoleContent::viewModeChanged(magda::ViewMode mode, const magda::Au
     if (currentViewMode_ == mode)
         return;
     currentViewMode_ = mode;
-    // Slice 1: reflect the view in the context glyph. View-scoped agent routing
-    // (mixer view -> mixing agent) is wired in the routing slice (#1402).
+    // Reflect the view in the context glyph. The active view also scopes agent
+    // routing in RequestThread::run (mixer view -> mixing agent, #1402).
     repaint();
 }
 

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.hpp
@@ -15,6 +15,7 @@
 #include "../../../../agents/llama_model_manager.hpp"
 #include "../../../core/Config.hpp"
 #include "../../../core/SelectionManager.hpp"
+#include "../../../core/ViewModeController.hpp"
 #include "../../../project/ProjectManager.hpp"
 #include "ChatPromptTokeniser.hpp"
 #include "DSLTokeniser.hpp"
@@ -49,7 +50,8 @@ class AIChatConsoleContent : public PanelContent,
                              private juce::CodeDocument::Listener,
                              public magda::SelectionManagerListener,
                              public magda::ProjectManagerListener,
-                             public magda::ConfigListener {
+                             public magda::ConfigListener,
+                             public magda::ViewModeListener {
   public:
     AIChatConsoleContent();
     ~AIChatConsoleContent() override;
@@ -73,6 +75,9 @@ class AIChatConsoleContent : public PanelContent,
 
     // ConfigListener
     void configChanged() override;
+
+    // ViewModeListener (#1402): swap the console's context glyph + scope routing.
+    void viewModeChanged(magda::ViewMode mode, const magda::AudioEngineProfile& profile) override;
 
     // SelectionManagerListener
     void selectionTypeChanged(magda::SelectionType newType) override;
@@ -123,6 +128,12 @@ class AIChatConsoleContent : public PanelContent,
     std::unique_ptr<juce::Drawable> trackIconDrawable_;
     std::unique_ptr<juce::Drawable> clipIconDrawable_;
     std::unique_ptr<juce::Drawable> drumIconDrawable_;
+    // View-context routing (#1402): the bottom-left glyph reflects the active
+    // view (session / arrangement / mixer), which scopes the console's agent.
+    std::unique_ptr<juce::Drawable> sessionIconDrawable_;
+    std::unique_ptr<juce::Drawable> arrangeIconDrawable_;
+    std::unique_ptr<juce::Drawable> mixIconDrawable_;
+    magda::ViewMode currentViewMode_ = magda::ViewMode::Arrange;
     // True when the selected track's primary instrument carries a kit with at
     // least one role-tagged row. Drives the drummer auto-route in
     // RequestThread::run and the drum context icon below the chat.


### PR DESCRIPTION
First slice of view-context routing. The console subscribes to ViewModeController and the bottom-left glyph now reflects the active view (session / arrangement / mixer) via the footer's view icons, replacing the selection-context glyph; the selected-track label stays alongside. View-scoped agent routing follows in the next slice.