### PR TITLE
Waveform loading: progressive render, broken-file state, and zoomed-out grid

### DIFF
--- a/magda/daw/audio/AudioBridge.hpp
+++ b/magda/daw/audio/AudioBridge.hpp
@@ -203,7 +203,7 @@ class AudioBridge : public TrackManagerListener, public ClipManagerListener, pub
      * @brief Detect transient times for an audio clip's source file
      *
      * On first call, kicks off async transient detection via TE's WarpTimeManager.
-     * Subsequent calls poll for completion. Results are cached per file path.
+     * Completion is delivered by callback and results are cached per file path.
      *
      * @param clipId The MAGDA clip ID (must be an audio clip)
      * @return true if transients are ready (cached), false if still detecting

--- a/magda/daw/audio/AudioThumbnailManager.cpp
+++ b/magda/daw/audio/AudioThumbnailManager.cpp
@@ -89,24 +89,32 @@ void AudioThumbnailManager::drawWaveform(juce::Graphics& g, const juce::Rectangl
         return;
 
     auto* thumbnail = getThumbnail(audioFilePath);
-    if (thumbnail == nullptr || !thumbnail->isFullyLoaded()) {
-        // Draw placeholder if thumbnail not ready
+    if (thumbnail == nullptr) {
+        // No thumbnail at all yet (reader not created): nothing to draw.
         g.setColour(colour.withAlpha(0.3f));
         g.drawText("Loading...", bounds, juce::Justification::centred);
         return;
     }
 
-    // Clamp times to valid range
+    // Clamp times to valid range. getTotalLength() is known as soon as the reader
+    // is set, even before the sample data has finished streaming in.
     double totalLength = thumbnail->getTotalLength();
     startTime = juce::jlimit(0.0, totalLength, startTime);
     endTime = juce::jlimit(startTime, totalLength, endTime);
+
+    // While the thumbnail is still streaming in, draw whatever has loaded so far
+    // (drawChannels renders up to getNumSamplesFinished()) so a long file fills
+    // in progressively instead of snapping in all at once at the end. The smooth
+    // high-res renderer reads the file/peak-cache directly, so it is held back
+    // until loading has settled to avoid expensive per-paint disk reads mid-load.
+    const bool fullyLoaded = thumbnail->isFullyLoaded();
 
     // useHighRes opts into the path-based smooth renderer (drawWaveformFromSamples).
     // Below the samples-per-pixel threshold the smooth envelope is visibly
     // better; above it (zoomed far out) the cheap JUCE thumbnail is used, since
     // the smooth path's disk read would be a waste when the result is the same
     // pixel soup.
-    if (useHighRes) {
+    if (useHighRes && fullyLoaded) {
         auto* reader = getOrCreateReader(audioFilePath);
         if (reader != nullptr && reader->sampleRate > 0.0) {
             double timeRange = endTime - startTime;

--- a/magda/daw/audio/AudioThumbnailManager.cpp
+++ b/magda/daw/audio/AudioThumbnailManager.cpp
@@ -276,10 +276,12 @@ const juce::Array<double>* AudioThumbnailManager::getCachedTransients(
 void AudioThumbnailManager::cacheTransients(const juce::String& filePath,
                                             const juce::Array<double>& times) {
     transientCache_[filePath] = times;
+    transientListeners_.call([&](TransientCacheListener& l) { l.transientsChanged(filePath); });
 }
 
 void AudioThumbnailManager::clearCachedTransients(const juce::String& filePath) {
     transientCache_.erase(filePath);
+    transientListeners_.call([&](TransientCacheListener& l) { l.transientsChanged(filePath); });
 }
 
 juce::AudioFormatReader* AudioThumbnailManager::getOrCreateReader(

--- a/magda/daw/audio/AudioThumbnailManager.cpp
+++ b/magda/daw/audio/AudioThumbnailManager.cpp
@@ -90,9 +90,16 @@ void AudioThumbnailManager::drawWaveform(juce::Graphics& g, const juce::Rectangl
 
     auto* thumbnail = getThumbnail(audioFilePath);
     if (thumbnail == nullptr) {
-        // No thumbnail at all yet (reader not created): nothing to draw.
-        g.setColour(colour.withAlpha(0.3f));
-        g.drawText("Loading...", bounds, juce::Justification::centred);
+        // A null thumbnail is terminal, not transient: getThumbnail() creates the
+        // reader synchronously, so the only way to get here is a file that cannot
+        // be opened - moved, deleted, or unreadable. Show a clear broken state
+        // instead of a perpetual "Loading..." (#1415).
+        g.setColour(juce::Colours::red.withAlpha(0.16f));
+        g.fillRect(bounds);
+        if (bounds.getWidth() >= 54) {
+            g.setColour(juce::Colours::red.brighter(0.2f).withAlpha(0.9f));
+            g.drawText("Missing file", bounds, juce::Justification::centred);
+        }
         return;
     }
 

--- a/magda/daw/audio/AudioThumbnailManager.cpp
+++ b/magda/daw/audio/AudioThumbnailManager.cpp
@@ -4,7 +4,6 @@
 
 // clang-format off
 #include <tracktion_engine/tracktion_engine.h>
-#include <tracktion_engine/timestretch/tracktion_TempoDetect.h>
 // clang-format on
 
 namespace magda {
@@ -160,33 +159,11 @@ void AudioThumbnailManager::drawWaveform(juce::Graphics& g, const juce::Rectangl
 }
 
 namespace {
-// Pure detection routine — no cache, no threading. Safe to call from any thread
-// as long as the format manager is local. Returns 0.0 on failure.
+// BPM DSP fallback is disabled. Tracktion/SoundTouch BPMDetect is crashing on
+// some files inside its worker thread; return unknown BPM instead of risking the app.
 double runBpmDetection(const juce::String& filePath) {
-    juce::File audioFile(filePath);
-    if (!audioFile.existsAsFile())
-        return 0.0;
-
-    // Local format manager — juce::AudioFormatManager is not thread-safe to share.
-    juce::AudioFormatManager fm;
-    fm.registerBasicFormats();
-
-    std::unique_ptr<juce::AudioFormatReader> reader(fm.createReaderFor(audioFile));
-    if (!reader)
-        return 0.0;
-
-    tracktion::engine::TempoDetect detector(static_cast<int>(reader->numChannels),
-                                            reader->sampleRate);
-    float bpm = detector.processReader(*reader);
-
-    if (!detector.isBpmSensible())
-        return 0.0;
-
-    double result = static_cast<double>(bpm);
-    // Snap to nearest integer BPM if within 0.5 — most music uses whole-number tempos
-    double rounded = std::round(result);
-    if (std::abs(result - rounded) < 0.5)
-        result = rounded;
+    juce::ignoreUnused(filePath);
+    constexpr double result = 0.0;
     return result;
 }
 }  // namespace
@@ -215,7 +192,7 @@ void AudioThumbnailManager::cacheBPM(const juce::String& filePath, double bpm) {
 
 void AudioThumbnailManager::requestBPMDetection(const juce::String& filePath,
                                                 std::function<void(double)> onComplete) {
-    // Caches and pending-callback map are message-thread only (no locks).
+    // Caches are message-thread only (no locks).
     JUCE_ASSERT_MESSAGE_THREAD;
 
     // Cache hit — fire callback synchronously and return.
@@ -226,42 +203,10 @@ void AudioThumbnailManager::requestBPMDetection(const juce::String& filePath,
         return;
     }
 
-    // Already in flight for this file — append callback and dedupe.
-    auto pendingIt = pendingBpmCallbacks_.find(filePath);
-    if (pendingIt != pendingBpmCallbacks_.end()) {
-        if (onComplete)
-            pendingIt->second.push_back(std::move(onComplete));
-        return;
-    }
-
-    // First request for this file — register pending entry, lazy-create the
-    // thread pool, and enqueue the background scan.
-    auto& callbacks = pendingBpmCallbacks_[filePath];
+    const double result = runBpmDetection(filePath);
+    bpmCache_[filePath] = result;
     if (onComplete)
-        callbacks.push_back(std::move(onComplete));
-
-    getOrCreateBackgroundPool().addJob([filePath]() {
-        const double result = runBpmDetection(filePath);
-
-        juce::MessageManager::callAsync([filePath, result]() {
-            auto& self = AudioThumbnailManager::getInstance();
-            self.bpmCache_[filePath] = result;
-
-            auto it = self.pendingBpmCallbacks_.find(filePath);
-            if (it == self.pendingBpmCallbacks_.end())
-                return;
-
-            // Move callbacks out before invoking — the entry is erased
-            // immediately so re-entrant requests during callback iteration
-            // see a clean state and hit the cache.
-            auto callbacks = std::move(it->second);
-            self.pendingBpmCallbacks_.erase(it);
-
-            for (auto& cb : callbacks) {
-                cb(result);
-            }
-        });
-    });
+        onComplete(result);
 }
 
 const juce::Array<double>* AudioThumbnailManager::getCachedTransients(
@@ -275,11 +220,24 @@ const juce::Array<double>* AudioThumbnailManager::getCachedTransients(
 
 void AudioThumbnailManager::cacheTransients(const juce::String& filePath,
                                             const juce::Array<double>& times) {
+    if (!juce::MessageManager::getInstance()->isThisTheMessageThread()) {
+        juce::MessageManager::callAsync([filePath, times]() {
+            AudioThumbnailManager::getInstance().cacheTransients(filePath, times);
+        });
+        return;
+    }
+
     transientCache_[filePath] = times;
     transientListeners_.call([&](TransientCacheListener& l) { l.transientsChanged(filePath); });
 }
 
 void AudioThumbnailManager::clearCachedTransients(const juce::String& filePath) {
+    if (!juce::MessageManager::getInstance()->isThisTheMessageThread()) {
+        juce::MessageManager::callAsync(
+            [filePath]() { AudioThumbnailManager::getInstance().clearCachedTransients(filePath); });
+        return;
+    }
+
     transientCache_.erase(filePath);
     transientListeners_.call([&](TransientCacheListener& l) { l.transientsChanged(filePath); });
 }
@@ -517,7 +475,6 @@ void AudioThumbnailManager::clearCache() {
     thumbnails_.clear();
     thumbnailCache_->clear();
     bpmCache_.clear();
-    pendingBpmCallbacks_.clear();
     transientCache_.clear();
     readerIndex_.clear();
     readerLru_.clear();
@@ -529,7 +486,6 @@ void AudioThumbnailManager::invalidateFile(const juce::String& audioFilePath) {
     thumbnails_.erase(audioFilePath);
     thumbnailCache_->clear();
     bpmCache_.erase(audioFilePath);
-    pendingBpmCallbacks_.erase(audioFilePath);
     transientCache_.erase(audioFilePath);
 
     auto readerIt = readerIndex_.find(audioFilePath);
@@ -585,15 +541,11 @@ void AudioThumbnailManager::requestPeakCacheLoad(const juce::String& audioFilePa
 }
 
 void AudioThumbnailManager::shutdown() {
-    // Stop any in-flight background jobs (BPM detection or peak compute)
-    // before tearing down state. The 5000ms timeout caps the wait —
-    // TempoDetect doesn't honour interruption mid-scan, but a single scan
-    // should fit comfortably under that bound.
+    // Stop any in-flight peak-compute jobs before tearing down state.
     if (backgroundThreadPool_) {
         backgroundThreadPool_->removeAllJobs(true, 5000);
         backgroundThreadPool_.reset();
     }
-    pendingBpmCallbacks_.clear();
     pendingPeakComputes_.clear();
     peakCaches_.clear();
 

--- a/magda/daw/audio/AudioThumbnailManager.hpp
+++ b/magda/daw/audio/AudioThumbnailManager.hpp
@@ -16,6 +16,19 @@ namespace magda {
 class WaveformPeakCache;
 
 /**
+ * @brief Notified when a file's cached transient set changes.
+ *
+ * Fired when transients are recomputed/cached or cleared (e.g. the user changes
+ * the detection sensitivity). Lets the waveform editor refresh on a callback
+ * instead of polling. Message thread only.
+ */
+class TransientCacheListener {
+  public:
+    virtual ~TransientCacheListener() = default;
+    virtual void transientsChanged(const juce::String& filePath) = 0;
+};
+
+/**
  * @brief Manages audio waveform thumbnails for visualization
  *
  * Provides caching and rendering of audio waveforms using JUCE's AudioThumbnail.
@@ -113,6 +126,14 @@ class AudioThumbnailManager {
      */
     void clearCachedTransients(const juce::String& filePath);
 
+    /// Subscribe to transient-cache changes (recompute/clear). Message thread.
+    void addTransientCacheListener(TransientCacheListener* l) {
+        transientListeners_.add(l);
+    }
+    void removeTransientCacheListener(TransientCacheListener* l) {
+        transientListeners_.remove(l);
+    }
+
     /**
      * @brief Clear the thumbnail cache (useful for freeing memory)
      */
@@ -162,6 +183,8 @@ class AudioThumbnailManager {
 
     // Transient detection cache (file path -> transient times in source-file seconds)
     std::map<juce::String, juce::Array<double>> transientCache_;
+    // Notified when transientCache_ changes for a file (recompute or clear).
+    juce::ListenerList<TransientCacheListener> transientListeners_;
 
     // LRU cache for AudioFormatReaders (raw-sample waveform rendering)
     static constexpr size_t MAX_CACHED_READERS = 16;

--- a/magda/daw/audio/AudioThumbnailManager.hpp
+++ b/magda/daw/audio/AudioThumbnailManager.hpp
@@ -70,12 +70,12 @@ class AudioThumbnailManager {
                       bool useHighRes = false, bool thick = false);
 
     /**
-     * @brief Detect BPM of an audio file using Tracktion's TempoDetect.
+     * @brief Detect BPM of an audio file.
      *
-     * BLOCKING — walks the entire file on the calling thread. External callers
-     * should prefer requestBPMDetection() to avoid hanging the UI.
+     * DSP detection is currently disabled because Tracktion/SoundTouch BPMDetect
+     * can crash inside its worker thread on some files.
      * @param filePath Absolute path to the audio file
-     * @return Detected BPM, or 0.0 if detection fails or result is not sensible
+     * @return Cached/external BPM, or 0.0 when unknown.
      */
     double detectBPM(const juce::String& filePath);
 
@@ -94,13 +94,11 @@ class AudioThumbnailManager {
     void cacheBPM(const juce::String& filePath, double bpm);
 
     /**
-     * @brief Request asynchronous BPM detection.
+     * @brief Request BPM detection.
      *
      * If the result is already cached, @p onComplete fires synchronously on the
-     * calling (message) thread. Otherwise the scan is enqueued on a background
-     * thread and @p onComplete fires on the message thread when complete.
-     * Multiple concurrent requests for the same file are deduped — only one
-     * background scan runs and all callbacks fire when it finishes.
+     * calling (message) thread. Otherwise this currently returns 0.0
+     * synchronously because DSP BPM fallback is disabled.
      *
      * Must be called from the message thread.
      */
@@ -170,16 +168,11 @@ class AudioThumbnailManager {
     // Message-thread only — never touched from background detection threads.
     std::map<juce::String, double> bpmCache_;
 
-    // Background thread pool shared by BPM detection and peak-cache compute
-    // jobs. Lazy-initialized on first use. Single thread — disk I/O serializes
+    // Background thread pool for peak-cache compute jobs. Lazy-initialized on first use.
+    // Single thread — disk I/O serializes
     // and the work is bursty, so a pool of 1 keeps things predictable.
     std::unique_ptr<juce::ThreadPool> backgroundThreadPool_;
     juce::ThreadPool& getOrCreateBackgroundPool();
-
-    // In-flight BPM detection requests. Keyed by file path; value is the list of
-    // callbacks to fire when detection completes. Used to dedupe concurrent
-    // requests for the same file. Message-thread only.
-    std::map<juce::String, std::vector<std::function<void(double)>>> pendingBpmCallbacks_;
 
     // Transient detection cache (file path -> transient times in source-file seconds)
     std::map<juce::String, juce::Array<double>> transientCache_;

--- a/magda/daw/audio/WarpMarkerManager.cpp
+++ b/magda/daw/audio/WarpMarkerManager.cpp
@@ -1,5 +1,7 @@
 #include "WarpMarkerManager.hpp"
 
+#include <juce_events/juce_events.h>
+
 #include "../core/ClipManager.hpp"
 #include "AudioThumbnailManager.hpp"
 
@@ -42,76 +44,70 @@ te::WaveAudioClip* findWaveAudioClip(te::Edit& edit,
 }  // namespace
 
 WarpMarkerManager::~WarpMarkerManager() {
-    // Stop the coalescing timer before any of our maps are torn down so
-    // a fire mid-destruction can't reach into half-destroyed state.
-    coalescingTimer_.stopTimer();
-    coalescingTimer_.callback = nullptr;
+    for (auto& [_, active] : activeDetections_) {
+        if (active.warpManager != nullptr)
+            active.warpManager->removeListener(this);
+    }
 }
 
 void WarpMarkerManager::setTransientSensitivity(
     te::Edit& edit, const std::map<ClipId, std::string>& clipIdToEngineId, ClipId clipId,
     float sensitivity) {
-    // Coalesce: just record the latest value per clip and (re)start a
-    // short timer. Hot paths (slider drags) hit this method many times
-    // per second; we want exactly ONE TE detection job per clip per
-    // coalescing window.
-    //
     // Resolve the engineId at queue time (a single map lookup) instead
-    // of snapshotting the whole clipIdToEngineId map per call — the map
-    // can be large for arrangements and copying it on every slider tick
-    // would dominate even with coalescing.
-    PendingDetection& slot = pendingByClip_[clipId];
-    slot.sensitivity = sensitivity;
+    // of snapshotting the whole clipIdToEngineId map per call.
+    PendingDetection det;
+    det.sensitivity = sensitivity;
     auto it = clipIdToEngineId.find(clipId);
-    slot.engineId = (it != clipIdToEngineId.end()) ? it->second : std::string{};
-    slot.edit = &edit;
+    det.engineId = (it != clipIdToEngineId.end()) ? it->second : std::string{};
+    det.edit = &edit;
 
-    coalescingTimer_.callback = [this]() { applyPendingSensitivities(); };
-    coalescingTimer_.startTimer(kCoalesceMs);
-}
-
-void WarpMarkerManager::applyPendingSensitivities() {
-    auto pending = std::move(pendingByClip_);
-    pendingByClip_.clear();
-
-    for (const auto& [clipId, det] : pending) {
-        if (det.edit == nullptr)
-            continue;
-
-        // If a detection is already in flight for this clip, parking
-        // the latest value is enough — getTransientTimes will pick it
-        // up on completion and schedule one rerun. This avoids the
-        // race that produced the original ThreadPool crash: never two
-        // overlapping detection jobs against the same WarpTimeManager.
-        if (detectionInFlight_.count(clipId)) {
-            dirtyAfterCompletion_[clipId] = det;
-            continue;
-        }
-        applySensitivityNow(*det.edit, det.engineId, clipId, det.sensitivity);
-    }
+    // Restart immediately so the latest sensitivity doesn't wait behind an old
+    // detection job. WarpTimeManager::detectTransients detaches/cancels the
+    // previous job before submitting the replacement.
+    applySensitivityNow(edit, det.engineId, clipId, sensitivity);
 }
 
 void WarpMarkerManager::applySensitivityNow(te::Edit& edit, const std::string& engineId,
                                             ClipId clipId, float sensitivity) {
+    startDetection(edit, engineId, clipId, sensitivity);
+}
+
+bool WarpMarkerManager::startDetection(te::Edit& edit, const std::string& engineId, ClipId clipId,
+                                       std::optional<float> sensitivity) {
     const auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (!clip || !clip->isAudio() || clip->audio().source.filePath.isEmpty())
-        return;
+    if (!clip)
+        return false;
+    if (!clip->isAudio())
+        return false;
+    if (clip->audio().source.filePath.isEmpty())
+        return false;
 
     te::WaveAudioClip* audioClipPtr = findWaveAudioClipByEngineId(edit, engineId);
     if (!audioClipPtr)
-        return;
+        return false;
 
     auto& warpManager = audioClipPtr->getWarpTimeManager();
-    warpManager.setTransientSensitivity(sensitivity);
+    if (sensitivity.has_value())
+        warpManager.setTransientSensitivity(*sensitivity);
+
+    auto active = activeDetections_.find(clipId);
+    if (active != activeDetections_.end() && active->second.warpManager != nullptr) {
+        active->second.warpManager->removeListener(this);
+        clipByWarpManager_.erase(active->second.warpManager);
+    }
+
+    warpManager.addListener(this);
+    detectionInFlight_.insert(clipId);
+    activeDetections_[clipId] = {clip->audio().source.filePath,
+                                 te::WarpTimeManager::Ptr(&warpManager)};
+    clipByWarpManager_[&warpManager] = clipId;
+
+    // Clear cache so listeners know the displayed transients are stale.
+    AudioThumbnailManager::getInstance().clearCachedTransients(clip->audio().source.filePath);
+
     warpManager.detectTransients();
 
-    // Clear cache so the next poll picks up fresh results.
-    AudioThumbnailManager::getInstance().clearCachedTransients(clip->audio().source.filePath);
-    detectionStarted_.insert(clipId);
-    detectionInFlight_.insert(clipId);
-
-    DBG("WarpMarkerManager: set sensitivity=" << sensitivity << " for "
-                                              << clip->audio().source.filePath);
+    return true;
 }
 
 bool WarpMarkerManager::getTransientTimes(te::Edit& edit,
@@ -119,75 +115,65 @@ bool WarpMarkerManager::getTransientTimes(te::Edit& edit,
                                           ClipId clipId) {
     // Get clip info for file path
     const auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (!clip || !clip->isAudio() || clip->audio().source.filePath.isEmpty()) {
+    if (!clip || !clip->isAudio() || clip->audio().source.filePath.isEmpty())
         return false;
-    }
 
     // Check cache first
     auto& thumbnailManager = AudioThumbnailManager::getInstance();
-    if (thumbnailManager.getCachedTransients(clip->audio().source.filePath) != nullptr) {
+    if (thumbnailManager.getCachedTransients(clip->audio().source.filePath) != nullptr)
         return true;
-    }
+
+    if (detectionInFlight_.count(clipId))
+        return false;
 
     // Find TE WaveAudioClip via shared helper
     te::WaveAudioClip* audioClipPtr = findWaveAudioClip(edit, clipIdToEngineId, clipId);
-    if (!audioClipPtr) {
+    if (!audioClipPtr)
         return false;
-    }
 
-    // Get WarpTimeManager from the clip
-    auto& warpManager = audioClipPtr->getWarpTimeManager();
-
-    // Kick off detection if not already running. detectTransients() uses
-    // getOrCreateDetectionJob which returns the existing job if one is
-    // already in flight for this file+config, so calling it once is safe.
-    // We must NOT call it on every poll because it resets transientTimes.
-    //
-    // Mark in-flight here too — without this, a sensitivity change that
-    // arrives during the initial poll-driven detection wouldn't see the
-    // guard and would submit a second overlapping TE job, reproducing
-    // the original ThreadPool crash.
-    if (!detectionStarted_.count(clipId)) {
-        warpManager.detectTransients();
-        detectionStarted_.insert(clipId);
-        detectionInFlight_.insert(clipId);
-    }
-
-    // Poll for completion
-    auto [complete, transientPositions] = warpManager.getTransientTimes();
-
-    if (complete) {
-        // Detection finished — clear the in-flight flag.
-        detectionInFlight_.erase(clipId);
-
-        // If a newer sensitivity arrived while we were running, fire
-        // one more detection with that value. Skip caching the
-        // about-to-be-stale results and report `false` so the UI keeps
-        // polling until the rerun completes.
-        auto dirty = dirtyAfterCompletion_.find(clipId);
-        if (dirty != dirtyAfterCompletion_.end()) {
-            const auto det = std::move(dirty->second);
-            dirtyAfterCompletion_.erase(dirty);
-            if (det.edit != nullptr) {
-                applySensitivityNow(*det.edit, det.engineId, clipId, det.sensitivity);
-                return false;
-            }
-        }
-
-        // No dirt — cache the result and report complete.
-        juce::Array<double> times;
-        times.ensureStorageAllocated(transientPositions.size());
-        for (const auto& tp : transientPositions) {
-            times.add(tp.inSeconds());
-        }
-
-        thumbnailManager.cacheTransients(clip->audio().source.filePath, times);
-        DBG("WarpMarkerManager: Cached " << times.size() << " transients for "
-                                         << clip->audio().source.filePath);
-        return true;
-    }
-
+    startDetection(edit, clipIdToEngineId.at(clipId), clipId, std::nullopt);
     return false;
+}
+
+void WarpMarkerManager::transientDetectionFinished(te::WarpTimeManager& warpManager,
+                                                   bool completedOk) {
+    if (!juce::MessageManager::getInstance()->isThisTheMessageThread()) {
+        juce::MessageManager::callAsync([this, warpManagerPtr = &warpManager, completedOk]() {
+            if (warpManagerPtr != nullptr)
+                transientDetectionFinished(*warpManagerPtr, completedOk);
+        });
+        return;
+    }
+
+    auto it = clipByWarpManager_.find(&warpManager);
+    if (it == clipByWarpManager_.end())
+        return;
+
+    finishDetection(it->second, warpManager, completedOk);
+}
+
+void WarpMarkerManager::finishDetection(ClipId clipId, te::WarpTimeManager& warpManager,
+                                        bool completedOk) {
+    warpManager.removeListener(this);
+    clipByWarpManager_.erase(&warpManager);
+    detectionInFlight_.erase(clipId);
+
+    auto active = activeDetections_.find(clipId);
+    const juce::String filePath =
+        active != activeDetections_.end() ? active->second.filePath : juce::String();
+    activeDetections_.erase(clipId);
+
+    auto [complete, transientPositions] = warpManager.getTransientTimes();
+    if (!completedOk || !complete || filePath.isEmpty())
+        return;
+
+    juce::Array<double> times;
+    times.ensureStorageAllocated(transientPositions.size());
+    for (const auto& tp : transientPositions) {
+        times.add(tp.inSeconds());
+    }
+
+    AudioThumbnailManager::getInstance().cacheTransients(filePath, times);
 }
 
 void WarpMarkerManager::enableWarp(te::Edit& edit,

--- a/magda/daw/audio/WarpMarkerManager.hpp
+++ b/magda/daw/audio/WarpMarkerManager.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <juce_core/juce_core.h>
-#include <juce_events/juce_events.h>
 #include <tracktion_engine/tracktion_engine.h>
 
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -38,7 +38,7 @@ struct WarpMarkerInfo {
  * - All operations run on message thread (UI thread)
  * - Delegates to Tracktion Engine's WarpTimeManager
  */
-class WarpMarkerManager {
+class WarpMarkerManager : private te::WarpTimeManager::Listener {
   public:
     WarpMarkerManager() = default;
     ~WarpMarkerManager();
@@ -47,7 +47,7 @@ class WarpMarkerManager {
      * @brief Detect transient times for an audio clip's source file
      *
      * On first call, kicks off async transient detection via TE's WarpTimeManager.
-     * Subsequent calls poll for completion. Results are cached per file path.
+     * Completion is delivered by WarpTimeManager callback and cached per file path.
      *
      * @param edit Tracktion Engine edit
      * @param clipIdToEngineId Mapping from MAGDA clip ID to TE clip ID
@@ -131,26 +131,12 @@ class WarpMarkerManager {
                           ClipId clipId, int index);
 
   private:
-    // Tracks which clips have had detection kicked off (to avoid restarting on every poll)
-    std::set<ClipId> detectionStarted_;
-
-    // -------- Coalescing + in-flight guard for setTransientSensitivity --------
+    // -------- In-flight guard for transient detection --------
     //
     // The UI can spam sensitivity changes (slider drag = many calls/sec).
-    // Each call previously triggered a TE detection job, and overlapping
-    // jobs share `te::WarpTimeManager` state — a worker can dereference
-    // data that a newer job replaced and crash inside the TE thread pool
-    // (KERN_INVALID_ADDRESS at offset 0x10).
-    //
-    // The fix lives here, not in the UI, so any future caller benefits:
-    //   1. setTransientSensitivity records the latest value per clip and
-    //      starts/restarts a short coalescing timer (kCoalesceMs).
-    //   2. When the timer fires, only the most recent sensitivity per
-    //      clip is applied, and a TE job is submitted at most once per
-    //      clip per coalescing window.
-    //   3. If a detection is already in flight for a clip, the new value
-    //      is parked in dirtyAfterCompletion_; getTransientTimes() picks
-    //      it up when it observes completion and schedules the rerun.
+    // Restart detection immediately for the latest value; WarpTimeManager
+    // detaches/cancels the previous job and reports the surviving job by
+    // callback, so stale jobs can't overwrite the cache.
     struct PendingDetection {
         float sensitivity = 0.0f;
         // Resolved at queue time so the slider hot-path doesn't snapshot the
@@ -160,26 +146,21 @@ class WarpMarkerManager {
         te::Edit* edit = nullptr;
     };
 
-    static constexpr int kCoalesceMs = 75;
-
-    class CoalescingTimer : public juce::Timer {
-      public:
-        std::function<void()> callback;
-        void timerCallback() override {
-            stopTimer();
-            if (callback)
-                callback();
-        }
+    struct ActiveDetection {
+        juce::String filePath;
+        te::WarpTimeManager::Ptr warpManager;
     };
 
-    void applyPendingSensitivities();
+    bool startDetection(te::Edit& edit, const std::string& engineId, ClipId clipId,
+                        std::optional<float> sensitivity);
     void applySensitivityNow(te::Edit& edit, const std::string& engineId, ClipId clipId,
                              float sensitivity);
+    void finishDetection(ClipId clipId, te::WarpTimeManager& warpManager, bool completedOk);
+    void transientDetectionFinished(te::WarpTimeManager&, bool completedOk) override;
 
-    std::map<ClipId, PendingDetection> pendingByClip_;
     std::set<ClipId> detectionInFlight_;
-    std::map<ClipId, PendingDetection> dirtyAfterCompletion_;
-    CoalescingTimer coalescingTimer_;
+    std::map<ClipId, ActiveDetection> activeDetections_;
+    std::map<te::WarpTimeManager*, ClipId> clipByWarpManager_;
 };
 
 }  // namespace magda

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -385,12 +385,6 @@ ClipId ClipManager::createAudioClipBeats(TrackId trackId, double startBeats, dou
         const double cachedBPM = thumbs.getCachedBPM(audioFilePath);
         if (cachedBPM > 0.0) {
             applyDetectedBPM(cachedBPM);
-        } else {
-            thumbs.requestBPMDetection(audioFilePath, [applyDetectedBPM](double detectedBPM) {
-                if (detectedBPM <= 0.0)
-                    return;
-                applyDetectedBPM(detectedBPM);
-            });
         }
     }
 

--- a/magda/daw/media_db/AudioFeatures.cpp
+++ b/magda/daw/media_db/AudioFeatures.cpp
@@ -4,14 +4,6 @@
 #include <juce_audio_formats/juce_audio_formats.h>
 #include <juce_dsp/juce_dsp.h>
 
-// clang-format off
-// tracktion_engine.h MUST come before tracktion_TempoDetect.h: the
-// TempoDetect header uses unqualified SampleCount / AudioScratchBuffer
-// names that are only in scope after the umbrella header is processed.
-#include <tracktion_engine/tracktion_engine.h>
-#include <tracktion_engine/timestretch/tracktion_TempoDetect.h>
-// clang-format on
-
 #include <array>
 #include <cmath>
 #include <cstring>
@@ -121,25 +113,8 @@ std::optional<double> metadataBpm(const juce::StringPairArray& meta) {
 }
 
 std::optional<double> dspBpm(const std::filesystem::path& path) {
-    juce::AudioFormatManager fm;
-    fm.registerBasicFormats();
-    juce::File jpath(juce::String(path.string()));
-    std::unique_ptr<juce::AudioFormatReader> reader(fm.createReaderFor(jpath));
-    if (!reader) {
-        return std::nullopt;
-    }
-    tracktion::engine::TempoDetect detector(static_cast<int>(reader->numChannels),
-                                            reader->sampleRate);
-    const float bpm = detector.processReader(*reader);
-    if (!detector.isBpmSensible()) {
-        return std::nullopt;
-    }
-    double d = static_cast<double>(bpm);
-    const double rounded = std::round(d);
-    if (std::abs(d - rounded) < 0.5) {
-        d = rounded;
-    }
-    return d;
+    (void)path;
+    return std::nullopt;
 }
 
 // ---- Spectral stats ----------------------------------------------------
@@ -357,7 +332,7 @@ std::optional<AudioFeatures> extractFeatures(const std::filesystem::path& path) 
     f.channels = decoded->channels;
     f.durationS = static_cast<double>(decoded->lengthSamples) / decoded->sampleRate;
 
-    // --- BPM: filename > metadata > DSP ---
+    // --- BPM: filename > metadata ---
     if (auto p = parseBpmFromPath(path)) {
         f.bpm = *p;
     } else if (auto m = metadataBpm(decoded->metadata)) {

--- a/magda/daw/media_db/AudioFeatures.hpp
+++ b/magda/daw/media_db/AudioFeatures.hpp
@@ -1,15 +1,15 @@
 // Deterministic per-file audio features (issue #768).
 //
 // Mirrors prototypes/media_db/.../features/audio_features.py — same fields,
-// same output ranges, same null semantics. Implementation differs: BPM uses
-// Tracktion's TempoDetect; spectral / chroma analysis uses juce::dsp::FFT
+// same output ranges, same null semantics. Implementation differs: BPM currently
+// uses filename/metadata only; spectral / chroma analysis uses juce::dsp::FFT
 // instead of librosa.
 //
 // Source-of-truth precedence for BPM and key, in order:
 //   1. Filename token (parseBpmFromPath / parseKeyFromPath in PathRules)
 //   2. Audio metadata chunks (ACID tempo, ACID root note via JUCE reader
 //      metadataValues)
-//   3. DSP fallback (TempoDetect for BPM, chroma + Krumhansl for key)
+//   3. DSP fallback for key (chroma + Krumhansl); BPM DSP fallback is disabled.
 //
 // The cheap tiers run first so a well-named sample never pays the DSP cost.
 
@@ -26,7 +26,8 @@ struct AudioFeatures {
     int sampleRate = 0;
     int channels = 0;
 
-    // Source tier: filename > metadata > DSP. nullopt if no source produced a
+    // Source tier: filename > metadata > DSP. BPM DSP fallback is disabled.
+    // nullopt if no source produced a
     // sensible value (silence, no key marker on atonal content, etc.).
     std::optional<double> bpm;
     std::optional<std::string> keyRoot;   // "C", "C#", "D", ...

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -160,7 +160,35 @@ ClipComponent::ClipComponent(ClipId clipId, TrackContentPanel* parent)
 
 ClipComponent::~ClipComponent() {
     stopTimer();
+    if (waveformListenerPath_.isNotEmpty())
+        AudioThumbnailManager::getInstance().removeThumbnailChangeListener(waveformListenerPath_,
+                                                                           this);
     ClipManager::getInstance().removeListener(this);
+}
+
+void ClipComponent::updateWaveformLoadListener(const juce::String& audioFilePath) {
+    auto& mgr = AudioThumbnailManager::getInstance();
+    auto* thumb = audioFilePath.isNotEmpty() ? mgr.getThumbnail(audioFilePath) : nullptr;
+    // Listen only while the thumbnail exists and is still streaming in; once it
+    // is fully loaded (or the clip has no audio) we want no listener.
+    const juce::String wanted =
+        (thumb != nullptr && !thumb->isFullyLoaded()) ? audioFilePath : juce::String();
+    if (wanted == waveformListenerPath_)
+        return;
+    if (waveformListenerPath_.isNotEmpty())
+        mgr.removeThumbnailChangeListener(waveformListenerPath_, this);
+    waveformListenerPath_ = wanted;
+    if (waveformListenerPath_.isNotEmpty())
+        if (auto* t = mgr.getThumbnail(waveformListenerPath_))
+            t->addChangeListener(this);
+}
+
+void ClipComponent::changeListenerCallback(juce::ChangeBroadcaster*) {
+    // The thumbnail streamed in more samples. Repaint to fill the waveform
+    // progressively, and drop the listener once it has finished loading.
+    const auto* clip = getClipInfo();
+    updateWaveformLoadListener(clip != nullptr ? clip->audio().source.filePath : juce::String());
+    repaint();
 }
 
 void ClipComponent::paint(juce::Graphics& g) {
@@ -605,15 +633,11 @@ void ClipComponent::paintAudioClip(juce::Graphics& g, const ClipInfo& clip,
             clipDisplayLength = previewLength_;
     }
 
-    // Poll until thumbnail is loaded
-    if (clip.audio().source.filePath.isNotEmpty()) {
-        auto* thumb =
-            AudioThumbnailManager::getInstance().getThumbnail(clip.audio().source.filePath);
-        if (thumb == nullptr || !thumb->isFullyLoaded()) {
-            if (!isTimerRunning())
-                startTimer(100);
-        }
-    }
+    // Repaint as the thumbnail streams in (progressive fill). Registering a
+    // change listener is reliable regardless of mouse hover, unlike the old
+    // poll timer which only repainted while hovered, so long loads no longer
+    // look frozen until they finish.
+    updateWaveformLoadListener(clip.audio().source.filePath);
 
     // Draw directly — no offscreen cache.  AudioThumbnail is already a
     // pre-computed waveform cache (512 samples/point) so drawing from it is fast.

--- a/magda/daw/ui/components/clips/ClipComponent.hpp
+++ b/magda/daw/ui/components/clips/ClipComponent.hpp
@@ -23,7 +23,10 @@ class TrackContentPanel;
  * - Resize handles (left/right edges)
  * - Selection
  */
-class ClipComponent : public juce::Component, public ClipManagerListener, private juce::Timer {
+class ClipComponent : public juce::Component,
+                      public ClipManagerListener,
+                      public juce::ChangeListener,
+                      private juce::Timer {
   public:
     explicit ClipComponent(ClipId clipId, TrackContentPanel* parent);
     ~ClipComponent() override;
@@ -53,6 +56,10 @@ class ClipComponent : public juce::Component, public ClipManagerListener, privat
     void clipsChanged() override;
     void clipPropertyChanged(ClipId clipId) override;
     void clipSelectionChanged(ClipId clipId) override;
+
+    // ChangeListener - the audio thumbnail broadcasts as its samples stream in,
+    // so we repaint to fill the waveform progressively while a long file loads.
+    void changeListenerCallback(juce::ChangeBroadcaster* source) override;
 
     // Selection state
     bool isSelected() const {
@@ -217,6 +224,12 @@ class ClipComponent : public juce::Component, public ClipManagerListener, privat
                               juce::Rectangle<int> waveformArea, double clipDisplayLength,
                               juce::Colour waveColourOverride = {});
     void timerCallback() override;
+
+    // Register/unregister as a change listener on the clip's audio thumbnail
+    // while it is still loading, so the waveform repaints as data streams in and
+    // the listener is dropped once the thumbnail is fully loaded. Idempotent.
+    void updateWaveformLoadListener(const juce::String& audioFilePath);
+    juce::String waveformListenerPath_;  // thumbnail path we are currently listening to (or empty)
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ClipComponent)
 };

--- a/magda/daw/ui/components/timeline/TimeRuler.cpp
+++ b/magda/daw/ui/components/timeline/TimeRuler.cpp
@@ -574,8 +574,26 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
             beatLabelInterval *= 2;
     }
 
+    // Coarsen the ticks when they would be denser than this. With a fixed grid
+    // resolution set (grid on), intervalBeats does not adapt to zoom, so a long
+    // clip zoomed fully out draws a tick per beat and the header fills with a
+    // solid wall of ticks. Drawing every Nth tick (the stride rounded up to a
+    // whole number of intervals per bar) keeps them on bar boundaries.
+    const double pixelsPerInterval = intervalBeats * zoom;
+    constexpr double kMinPixelsPerTick = 12.0;
+    long long tickStride = 1;
+    if (pixelsPerInterval > 0.0 && pixelsPerInterval < kMinPixelsPerTick) {
+        tickStride = static_cast<long long>(std::ceil(kMinPixelsPerTick / pixelsPerInterval));
+        if (intervalBeats > 0.0) {
+            const long long perBar =
+                std::max<long long>(1, std::llround(barLengthBeats / intervalBeats));
+            tickStride = ((tickStride + perBar - 1) / perBar) * perBar;
+        }
+    }
+    startStep -= startStep % tickStride;  // keep the drawn subset aligned to the origin
+
     // Pass 1: Draw grid ticks only (no labels)
-    for (long long step = startStep;; ++step) {
+    for (long long step = startStep;; step += tickStride) {
         double beat = barOriginBeats + step * intervalBeats;
         if (beat > barOriginBeats + totalTimelineBeats)
             break;

--- a/magda/daw/ui/components/timeline/TimeRuler.cpp
+++ b/magda/daw/ui/components/timeline/TimeRuler.cpp
@@ -474,36 +474,18 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
     const int height = getHeight();
     const int width = getWidth();
 
-    // Use grid resolution if provided, otherwise compute from zoom level
-    double intervalBeats = 1.0;
-
-    if (gridResolutionBeats > 0.0) {
+    // Display interval in beats. Match the arrangement exactly
+    // (GridConstants::computeGridInterval): adapt to zoom so lines stay at least
+    // ~50px apart, growing to multi-bar steps when zoomed out. A finer snap grid
+    // still snaps but never forces the display denser than the adaptive interval.
+    constexpr int minPixelSpacing = 50;  // matches LayoutConfig::minGridPixelSpacing
+    const double frac = GridConstants::findBeatSubdivision(zoom, minPixelSpacing);
+    double intervalBeats =
+        (frac > 0.0) ? frac
+                     : static_cast<double>(timeSigNumerator) *
+                           GridConstants::findBarMultiple(zoom, timeSigNumerator, minPixelSpacing);
+    if (gridResolutionBeats > intervalBeats)
         intervalBeats = gridResolutionBeats;
-    } else {
-        // Auto-compute from zoom (same logic as TimelineComponent)
-        const double beatFractions[] = {0.0078125, 0.015625, 0.03125, 0.0625,
-                                        0.125,     0.25,     0.5,     1.0};
-        const int barMultiples[] = {1, 2, 4, 8, 16, 32};
-        const int minPixelSpacing = 12;
-        bool foundInterval = false;
-
-        for (double fraction : beatFractions) {
-            if (fraction * zoom >= minPixelSpacing) {
-                intervalBeats = fraction;
-                foundInterval = true;
-                break;
-            }
-        }
-
-        if (!foundInterval) {
-            for (int mult : barMultiples) {
-                if (static_cast<double>(timeSigNumerator * mult) * zoom >= minPixelSpacing) {
-                    intervalBeats = timeSigNumerator * mult;
-                    break;
-                }
-            }
-        }
-    }
 
     double pixelsPerBeat = zoom;
     double pixelsPerBar = zoom * timeSigNumerator;
@@ -522,14 +504,22 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
     int labelHeight = labelBottom - labelY;
     int mediumTickHeight = tickHeightMajor() * 2 / 3;
 
-    // Determine bar label interval (show every Nth bar when zoomed out)
-    int barLabelInterval = 1;
-    if (pixelsPerBar < 40)
-        barLabelInterval = 8;
-    else if (pixelsPerBar < 60)
-        barLabelInterval = 4;
-    else if (pixelsPerBar < 90)
-        barLabelInterval = 2;
+    // Determine bar label interval. When the display interval already spans
+    // multiple bars (zoomed out), label every grid line so labels match the
+    // lines, exactly as the arrangement does. Only thin by pixel width when the
+    // grid is still at single-bar (or finer) resolution.
+    int gridBarMultiple = 1;
+    if (intervalBeats >= barLengthBeats)
+        gridBarMultiple = static_cast<int>(std::round(intervalBeats / barLengthBeats));
+    int barLabelInterval = gridBarMultiple;
+    if (gridBarMultiple <= 1) {
+        if (pixelsPerBar < 40)
+            barLabelInterval = 8;
+        else if (pixelsPerBar < 60)
+            barLabelInterval = 4;
+        else if (pixelsPerBar < 90)
+            barLabelInterval = 2;
+    }
 
     int currentScrollOffset = linkedViewport ? linkedViewport->getViewPositionX() : scrollOffset;
     double barOriginBeats = barOriginSeconds * tempo / 60.0;
@@ -574,26 +564,8 @@ void TimeRuler::drawBarsBeatsMode(juce::Graphics& g) {
             beatLabelInterval *= 2;
     }
 
-    // Coarsen the ticks when they would be denser than this. With a fixed grid
-    // resolution set (grid on), intervalBeats does not adapt to zoom, so a long
-    // clip zoomed fully out draws a tick per beat and the header fills with a
-    // solid wall of ticks. Drawing every Nth tick (the stride rounded up to a
-    // whole number of intervals per bar) keeps them on bar boundaries.
-    const double pixelsPerInterval = intervalBeats * zoom;
-    constexpr double kMinPixelsPerTick = 12.0;
-    long long tickStride = 1;
-    if (pixelsPerInterval > 0.0 && pixelsPerInterval < kMinPixelsPerTick) {
-        tickStride = static_cast<long long>(std::ceil(kMinPixelsPerTick / pixelsPerInterval));
-        if (intervalBeats > 0.0) {
-            const long long perBar =
-                std::max<long long>(1, std::llround(barLengthBeats / intervalBeats));
-            tickStride = ((tickStride + perBar - 1) / perBar) * perBar;
-        }
-    }
-    startStep -= startStep % tickStride;  // keep the drawn subset aligned to the origin
-
     // Pass 1: Draw grid ticks only (no labels)
-    for (long long step = startStep;; step += tickStride) {
+    for (long long step = startStep;; ++step) {
         double beat = barOriginBeats + step * intervalBeats;
         if (beat > barOriginBeats + totalTimelineBeats)
             break;

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 
 #include "../../state/TimelineController.hpp"
+#include "../../state/TimelineState.hpp"  // GridConstants (shared adaptive grid interval)
 #include "../../themes/CursorManager.hpp"
 #include "../../themes/DarkTheme.hpp"
 #include "../../themes/FontManager.hpp"
@@ -386,8 +387,28 @@ void WaveformGridComponent::paintBeatGrid(juce::Graphics& g, const magda::ClipIn
     if (bpm <= 0.0)
         return;
     double secondsPerBeat = 60.0 / bpm;
-    double secondsPerGrid = gridBeats * secondsPerBeat;
     double beatsPerBar = static_cast<double>(timeRuler_->getTimeSigNumerator());
+
+    // Match the arrangement (GridConstants::computeGridInterval): never draw grid
+    // lines or bar numbers denser than ~50px. The display interval grows to
+    // multi-bar steps when zoomed out, so a long clip shows e.g. one line every
+    // 16 bars instead of a wall. A finer snap resolution still snaps but does not
+    // force the display denser.
+    const double pixelsPerBeat = secondsPerBeat * horizontalZoom_;
+    constexpr int kMinGridLinePx = 50;  // matches LayoutConfig::minGridPixelSpacing
+    {
+        const int timeSigNum = juce::jmax(1, static_cast<int>(beatsPerBar));
+        const double frac =
+            magda::GridConstants::findBeatSubdivision(pixelsPerBeat, kMinGridLinePx);
+        const double adaptiveBeats =
+            (frac > 0.0)
+                ? frac
+                : static_cast<double>(timeSigNum) * magda::GridConstants::findBarMultiple(
+                                                        pixelsPerBeat, timeSigNum, kMinGridLinePx);
+        if (adaptiveBeats > gridBeats)
+            gridBeats = adaptiveBeats;
+    }
+    double secondsPerGrid = gridBeats * secondsPerBeat;
 
     // Grid origin in display seconds. In REL display time is clip-local, so
     // active clip start is 0. In ABS display time is project timeline seconds.
@@ -407,40 +428,14 @@ void WaveformGridComponent::paintBeatGrid(juce::Graphics& g, const magda::ClipIn
     visibleStartDisplay = juce::jmax(visibleStartDisplay, waveformStartDisplay);
     visibleEndDisplay = juce::jmin(visibleEndDisplay, waveformEndDisplay);
 
-    // Coarsen the grid when lines would be denser than this. A long clip zoomed
-    // fully out has thousands of beats across a few hundred pixels, which without
-    // this collapses into a solid wall of vertical bars. Drawing every Nth grid
-    // line (snapped to the origin so the subset is stable while scrolling) keeps
-    // the grid legible. The stride is a whole multiple of the grid unit, so when
-    // the grid divides the bar it lands on bar/beat boundaries.
-    const double pixelsPerGrid = secondsPerGrid * horizontalZoom_;
-    constexpr double kMinPixelsPerGridLine = 6.0;
-    long long stride = 1;
-    if (pixelsPerGrid > 0.0 && pixelsPerGrid < kMinPixelsPerGridLine) {
-        stride = static_cast<long long>(std::ceil(kMinPixelsPerGridLine / pixelsPerGrid));
-        // Round the stride up to a whole number of grid lines per bar so the
-        // coarsened lines land on bar boundaries (keeping their numbers) rather
-        // than arbitrary off-bar beats.
-        if (beatsPerBar > 0.0) {
-            const long long linesPerBar =
-                std::max<long long>(1, std::llround(beatsPerBar / gridBeats));
-            stride = ((stride + linesPerBar - 1) / linesPerBar) * linesPerBar;
-        }
-    }
-
-    // First grid line at or before the visible start, snapped down to a stride
-    // boundary relative to the origin so the drawn lines don't shift on scroll.
-    long long startK =
-        static_cast<long long>(std::floor((visibleStartDisplay - originDisplay) / secondsPerGrid));
-    startK -= ((startK % stride) + stride) % stride;
+    // First grid line at or before the visible start.
+    double startK = std::floor((visibleStartDisplay - originDisplay) / secondsPerGrid);
+    double iterStart = originDisplay + startK * secondsPerGrid;
     double iterEnd = visibleEndDisplay + secondsPerGrid;
 
     auto& fontMgr = FontManager::getInstance();
 
-    for (long long k = startK;; k += stride) {
-        double displayTime = originDisplay + static_cast<double>(k) * secondsPerGrid;
-        if (displayTime >= iterEnd)
-            break;
+    for (double displayTime = iterStart; displayTime < iterEnd; displayTime += secondsPerGrid) {
         int px = timeToPixel(displayTime);
 
         if (px < waveformRect.getX() || px > waveformRect.getRight())

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -3,6 +3,7 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 
 #include <cmath>
+#include <limits>
 
 #include "../../state/TimelineController.hpp"
 #include "../../state/TimelineState.hpp"  // GridConstants (shared adaptive grid interval)
@@ -314,11 +315,15 @@ void WaveformGridComponent::paintWaveformOverlays(juce::Graphics& g, const magda
     // Beat grid overlay (after waveform, before markers)
     paintBeatGrid(g, clip);
 
-    // Transient or warp markers
+    // Draw transient markers whenever detection data is present. Warp markers
+    // are an editing overlay, but they must not hide transient sensitivity
+    // feedback from the waveform editor.
+    if (!transientTimes_.isEmpty()) {
+        paintTransientMarkers(g, clip);
+    }
+
     if (warpMode_ && !warpMarkers_.empty()) {
         paintWarpMarkers(g, clip);
-    } else if (!warpMode_ && !transientTimes_.isEmpty()) {
-        paintTransientMarkers(g, clip);
     }
 
     // Center line — clipped to visible rect
@@ -803,16 +808,6 @@ void WaveformGridComponent::paintTransientMarkers(juce::Graphics& g, const magda
     auto waveformRect =
         juce::Rectangle<int>(positionPixels, bounds.getY(), widthPixels, bounds.getHeight());
 
-    // Transient markers are a per-onset slicing aid that only makes sense when
-    // zoomed in far enough to place individual hits. Hide them when zoomed out
-    // (beats closer together than this on screen), where they are just noise
-    // scattered over the waveform rather than something you can act on.
-    const double bpm = currentTimelineBpm();
-    const double pixelsPerBeat = bpm > 0.0 ? (60.0 / bpm) * horizontalZoom_ : 0.0;
-    constexpr double kMinPixelsPerBeatForTransients = 16.0;
-    if (pixelsPerBeat < kMinPixelsPerBeatForTransients)
-        return;
-
     // Faint line for the body, with a solid handle triangle at the top so a
     // transient reads as a marker and is never mistaken for a grid line.
     const juce::Colour lineColour = juce::Colours::white.withAlpha(0.25f);
@@ -823,6 +818,10 @@ void WaveformGridComponent::paintTransientMarkers(juce::Graphics& g, const magda
     // Visible pixel range for culling
     int visibleLeft = 0;
     int visibleRight = getWidth();
+    int inSourceCount = 0;
+    int drawnCount = 0;
+    int firstDrawnPx = std::numeric_limits<int>::max();
+    double firstDrawnTime = 0.0;
 
     auto drawMarkersForCycle = [&](double cycleOffset, double sourceStart, double sourceEnd) {
         const float top = static_cast<float>(waveformRect.getY());
@@ -830,6 +829,7 @@ void WaveformGridComponent::paintTransientMarkers(juce::Graphics& g, const magda
         for (double t : transientTimes_) {
             if (t < sourceStart || t >= sourceEnd)
                 continue;
+            ++inSourceCount;
 
             // Convert source time to timeline display time via ClipDisplayInfo
             double displayTime = displayInfo_.sourceToTimeline(t - sourceStart) + cycleOffset;
@@ -853,6 +853,11 @@ void WaveformGridComponent::paintTransientMarkers(juce::Graphics& g, const magda
             handle.addTriangle(fx - kHandleHalfW, top, fx + kHandleHalfW, top, fx, top + kHandleH);
             g.setColour(handleColour);
             g.fillPath(handle);
+            ++drawnCount;
+            if (px < firstDrawnPx) {
+                firstDrawnPx = px;
+                firstDrawnTime = t;
+            }
         }
     };
 
@@ -860,6 +865,8 @@ void WaveformGridComponent::paintTransientMarkers(juce::Graphics& g, const magda
     double sourceStart = displayInfo_.sourceFileStart;
     double sourceEnd = displayInfo_.sourceFileEnd;
     drawMarkersForCycle(0.0, sourceStart, sourceEnd);
+
+    juce::ignoreUnused(drawnCount, inSourceCount, firstDrawnPx, firstDrawnTime);
 }
 
 void WaveformGridComponent::paintNoClipMessage(juce::Graphics& g) {

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -803,16 +803,15 @@ void WaveformGridComponent::paintTransientMarkers(juce::Graphics& g, const magda
     auto waveformRect =
         juce::Rectangle<int>(positionPixels, bounds.getY(), widthPixels, bounds.getHeight());
 
-    // Transient markers are a per-onset slicing aid. Zoomed far out on a long
-    // file there are thousands of them across a few hundred pixels, collapsing
-    // into a meaningless wall, so hide them once they would be closer together
-    // than this on average.
-    const int markerCount = transientTimes_.size();
-    if (markerCount > 1) {
-        const double avgSpacingPx = static_cast<double>(widthPixels) / markerCount;
-        if (avgSpacingPx < 6.0)
-            return;
-    }
+    // Transient markers are a per-onset slicing aid that only makes sense when
+    // zoomed in far enough to place individual hits. Hide them when zoomed out
+    // (beats closer together than this on screen), where they are just noise
+    // scattered over the waveform rather than something you can act on.
+    const double bpm = currentTimelineBpm();
+    const double pixelsPerBeat = bpm > 0.0 ? (60.0 / bpm) * horizontalZoom_ : 0.0;
+    constexpr double kMinPixelsPerBeatForTransients = 16.0;
+    if (pixelsPerBeat < kMinPixelsPerBeatForTransients)
+        return;
 
     g.setColour(juce::Colours::white.withAlpha(0.25f));
 

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -26,6 +26,33 @@ WaveformGridComponent::WaveformGridComponent() {
     setName("WaveformGrid");
 }
 
+WaveformGridComponent::~WaveformGridComponent() {
+    if (waveformListenerPath_.isNotEmpty())
+        magda::AudioThumbnailManager::getInstance().removeThumbnailChangeListener(
+            waveformListenerPath_, this);
+}
+
+void WaveformGridComponent::updateWaveformLoadListener(const juce::String& audioFilePath) {
+    auto& mgr = magda::AudioThumbnailManager::getInstance();
+    auto* thumb = audioFilePath.isNotEmpty() ? mgr.getThumbnail(audioFilePath) : nullptr;
+    const juce::String wanted =
+        (thumb != nullptr && !thumb->isFullyLoaded()) ? audioFilePath : juce::String();
+    if (wanted == waveformListenerPath_)
+        return;
+    if (waveformListenerPath_.isNotEmpty())
+        mgr.removeThumbnailChangeListener(waveformListenerPath_, this);
+    waveformListenerPath_ = wanted;
+    if (waveformListenerPath_.isNotEmpty())
+        if (auto* t = mgr.getThumbnail(waveformListenerPath_))
+            t->addChangeListener(this);
+}
+
+void WaveformGridComponent::changeListenerCallback(juce::ChangeBroadcaster*) {
+    const auto* clip = getClip();
+    updateWaveformLoadListener(clip != nullptr ? clip->audio().source.filePath : juce::String());
+    repaint();
+}
+
 void WaveformGridComponent::paint(juce::Graphics& g) {
     auto bounds = getLocalBounds();
     if (bounds.getWidth() <= 0 || bounds.getHeight() <= 0)
@@ -157,6 +184,8 @@ void WaveformGridComponent::paintWaveformThumbnail(juce::Graphics& g, const magd
         return;
 
     auto& thumbnailManager = magda::AudioThumbnailManager::getInstance();
+    // Repaint as the thumbnail streams in (progressive fill while loading).
+    updateWaveformLoadListener(clip.audio().source.filePath);
     auto* thumbnail = thumbnailManager.getThumbnail(clip.audio().source.filePath);
     double fileDuration = thumbnail ? thumbnail->getTotalLength() : 0.0;
     // The waveform editor only ever shows the focused clip, so the waveform is

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -448,15 +448,12 @@ void WaveformGridComponent::paintBeatGrid(juce::Graphics& g, const magda::ClipIn
         bool isBar = (std::fmod(std::abs(beatPosRounded), beatsPerBar) < 0.001);
         bool isBeat = (std::fmod(std::abs(beatPosRounded), 1.0) < 0.001);
 
-        // Bar/beat/subdivision grid lines are white (matching the timeline),
-        // with the hierarchy carried by opacity. Transients are grey (below), so
-        // the two never look alike.
         if (isBar) {
-            g.setColour(juce::Colours::white.withAlpha(0.7f));
+            g.setColour(juce::Colour(0xFF707070));
         } else if (isBeat) {
-            g.setColour(juce::Colours::white.withAlpha(0.45f));
+            g.setColour(juce::Colour(0xFF585858));
         } else {
-            g.setColour(juce::Colours::white.withAlpha(0.28f));
+            g.setColour(juce::Colour(0xFF454545));
         }
 
         g.drawVerticalLine(px, static_cast<float>(waveformRect.getY()),
@@ -816,13 +813,20 @@ void WaveformGridComponent::paintTransientMarkers(juce::Graphics& g, const magda
     if (pixelsPerBeat < kMinPixelsPerBeatForTransients)
         return;
 
-    g.setColour(juce::Colours::white.withAlpha(0.25f));  // faint (reads grey), dimmer than the bars
+    // Faint line for the body, with a solid handle triangle at the top so a
+    // transient reads as a marker and is never mistaken for a grid line.
+    const juce::Colour lineColour = juce::Colours::white.withAlpha(0.25f);
+    const juce::Colour handleColour = juce::Colours::white.withAlpha(0.85f);
+    constexpr float kHandleHalfW = 4.0f;
+    constexpr float kHandleH = 6.0f;
 
     // Visible pixel range for culling
     int visibleLeft = 0;
     int visibleRight = getWidth();
 
     auto drawMarkersForCycle = [&](double cycleOffset, double sourceStart, double sourceEnd) {
+        const float top = static_cast<float>(waveformRect.getY());
+        const float bottom = static_cast<float>(waveformRect.getBottom());
         for (double t : transientTimes_) {
             if (t < sourceStart || t >= sourceEnd)
                 continue;
@@ -840,8 +844,15 @@ void WaveformGridComponent::paintTransientMarkers(juce::Graphics& g, const magda
             if (px < waveformRect.getX() || px > waveformRect.getRight())
                 continue;
 
-            g.drawVerticalLine(px, static_cast<float>(waveformRect.getY()),
-                               static_cast<float>(waveformRect.getBottom()));
+            g.setColour(lineColour);
+            g.drawVerticalLine(px, top, bottom);
+
+            // Downward-pointing handle triangle flush with the top edge.
+            const float fx = static_cast<float>(px);
+            juce::Path handle;
+            handle.addTriangle(fx - kHandleHalfW, top, fx + kHandleHalfW, top, fx, top + kHandleH);
+            g.setColour(handleColour);
+            g.fillPath(handle);
         }
     };
 

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -808,6 +808,17 @@ void WaveformGridComponent::paintTransientMarkers(juce::Graphics& g, const magda
     auto waveformRect =
         juce::Rectangle<int>(positionPixels, bounds.getY(), widthPixels, bounds.getHeight());
 
+    // Transient markers are a per-onset slicing aid. Zoomed far out on a long
+    // file there are thousands of them across a few hundred pixels, collapsing
+    // into a meaningless wall, so hide them once they would be closer together
+    // than this on average.
+    const int markerCount = transientTimes_.size();
+    if (markerCount > 1) {
+        const double avgSpacingPx = static_cast<double>(widthPixels) / markerCount;
+        if (avgSpacingPx < 6.0)
+            return;
+    }
+
     g.setColour(juce::Colours::white.withAlpha(0.25f));
 
     // Visible pixel range for culling

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -448,12 +448,15 @@ void WaveformGridComponent::paintBeatGrid(juce::Graphics& g, const magda::ClipIn
         bool isBar = (std::fmod(std::abs(beatPosRounded), beatsPerBar) < 0.001);
         bool isBeat = (std::fmod(std::abs(beatPosRounded), 1.0) < 0.001);
 
+        // Bar/beat/subdivision grid lines are white (matching the timeline),
+        // with the hierarchy carried by opacity. Transients are grey (below), so
+        // the two never look alike.
         if (isBar) {
-            g.setColour(juce::Colour(0xFF707070));
+            g.setColour(juce::Colours::white.withAlpha(0.7f));
         } else if (isBeat) {
-            g.setColour(juce::Colour(0xFF585858));
+            g.setColour(juce::Colours::white.withAlpha(0.45f));
         } else {
-            g.setColour(juce::Colour(0xFF454545));
+            g.setColour(juce::Colours::white.withAlpha(0.28f));
         }
 
         g.drawVerticalLine(px, static_cast<float>(waveformRect.getY()),
@@ -813,7 +816,7 @@ void WaveformGridComponent::paintTransientMarkers(juce::Graphics& g, const magda
     if (pixelsPerBeat < kMinPixelsPerBeatForTransients)
         return;
 
-    g.setColour(juce::Colours::white.withAlpha(0.25f));
+    g.setColour(juce::Colours::white.withAlpha(0.25f));  // faint (reads grey), dimmer than the bars
 
     // Visible pixel range for culling
     int visibleLeft = 0;

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -407,14 +407,40 @@ void WaveformGridComponent::paintBeatGrid(juce::Graphics& g, const magda::ClipIn
     visibleStartDisplay = juce::jmax(visibleStartDisplay, waveformStartDisplay);
     visibleEndDisplay = juce::jmin(visibleEndDisplay, waveformEndDisplay);
 
-    // Find the first grid line at or before the visible start
-    double startK = std::floor((visibleStartDisplay - originDisplay) / secondsPerGrid);
-    double iterStart = originDisplay + startK * secondsPerGrid;
+    // Coarsen the grid when lines would be denser than this. A long clip zoomed
+    // fully out has thousands of beats across a few hundred pixels, which without
+    // this collapses into a solid wall of vertical bars. Drawing every Nth grid
+    // line (snapped to the origin so the subset is stable while scrolling) keeps
+    // the grid legible. The stride is a whole multiple of the grid unit, so when
+    // the grid divides the bar it lands on bar/beat boundaries.
+    const double pixelsPerGrid = secondsPerGrid * horizontalZoom_;
+    constexpr double kMinPixelsPerGridLine = 6.0;
+    long long stride = 1;
+    if (pixelsPerGrid > 0.0 && pixelsPerGrid < kMinPixelsPerGridLine) {
+        stride = static_cast<long long>(std::ceil(kMinPixelsPerGridLine / pixelsPerGrid));
+        // Round the stride up to a whole number of grid lines per bar so the
+        // coarsened lines land on bar boundaries (keeping their numbers) rather
+        // than arbitrary off-bar beats.
+        if (beatsPerBar > 0.0) {
+            const long long linesPerBar =
+                std::max<long long>(1, std::llround(beatsPerBar / gridBeats));
+            stride = ((stride + linesPerBar - 1) / linesPerBar) * linesPerBar;
+        }
+    }
+
+    // First grid line at or before the visible start, snapped down to a stride
+    // boundary relative to the origin so the drawn lines don't shift on scroll.
+    long long startK =
+        static_cast<long long>(std::floor((visibleStartDisplay - originDisplay) / secondsPerGrid));
+    startK -= ((startK % stride) + stride) % stride;
     double iterEnd = visibleEndDisplay + secondsPerGrid;
 
     auto& fontMgr = FontManager::getInstance();
 
-    for (double displayTime = iterStart; displayTime < iterEnd; displayTime += secondsPerGrid) {
+    for (long long k = startK;; k += stride) {
+        double displayTime = originDisplay + static_cast<double>(k) * secondsPerGrid;
+        if (displayTime >= iterEnd)
+            break;
         int px = timeToPixel(displayTime);
 
         if (px < waveformRect.getX() || px > waveformRect.getRight())

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.hpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.hpp
@@ -25,14 +25,18 @@ enum class GridResolution { Off, Bar, Beat, Eighth, Sixteenth, ThirtySecond };
  * Designed to be placed inside a Viewport for scrolling.
  * Similar to PianoRollGridComponent architecture.
  */
-class WaveformGridComponent : public juce::Component {
+class WaveformGridComponent : public juce::Component, public juce::ChangeListener {
   public:
     WaveformGridComponent();
-    ~WaveformGridComponent() override = default;
+    ~WaveformGridComponent() override;
 
     // Component overrides
     void paint(juce::Graphics& g) override;
     void resized() override;
+
+    // ChangeListener - repaint as the thumbnail streams in so a long file fills
+    // in progressively instead of appearing all at once when loading finishes.
+    void changeListenerCallback(juce::ChangeBroadcaster* source) override;
 
     // Mouse interaction
     void mouseDown(const juce::MouseEvent& event) override;
@@ -323,6 +327,11 @@ class WaveformGridComponent : public juce::Component {
 
     // Get current clip
     const magda::ClipInfo* getClip() const;
+
+    // Listen on the clip's audio thumbnail while it is still loading so the
+    // waveform repaints as data streams in; drop the listener once fully loaded.
+    void updateWaveformLoadListener(const juce::String& audioFilePath);
+    juce::String waveformListenerPath_;  // thumbnail path we are listening to (or empty)
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(WaveformGridComponent)
 };

--- a/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
+++ b/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
@@ -56,7 +56,7 @@ struct SourceDisplayValues {
     double totalBeats = 0.0;
 };
 
-SourceDisplayValues getSourceDisplayValues(const magda::ClipInfo& clip, magda::ClipId clipId) {
+SourceDisplayValues getSourceDisplayValues(const magda::ClipInfo& clip) {
     SourceDisplayValues values;
     if (!clip.isAudio())
         return values;
@@ -72,11 +72,6 @@ SourceDisplayValues getSourceDisplayValues(const magda::ClipInfo& clip, magda::C
         const double cachedBpm = thumbs.getCachedBPM(clip.audio().source.filePath);
         if (cachedBpm > 0.0) {
             values.bpm = cachedBpm;
-        } else if (clip.audio().source.filePath.isNotEmpty()) {
-            thumbs.requestBPMDetection(clip.audio().source.filePath, [clipId](double bpm) {
-                if (bpm > 0.0)
-                    magda::ClipManager::getInstance().forceNotifyClipPropertyChanged(clipId);
-            });
         }
     }
 
@@ -232,36 +227,6 @@ void AudioClipPropertiesContent::createControls() {
                         clip->audio().interpretation.totalBeats = fileDuration * cached / 60.0;
                     }
                 }
-            } else {
-                auto cid = clipId_;
-                thumbs.requestBPMDetection(
-                    clip->audio().source.filePath, [cid](double detectedBPM) {
-                        if (detectedBPM <= 0.0)
-                            return;
-                        auto& mgr = magda::ClipManager::getInstance();
-                        auto* c = mgr.getClip(cid);
-                        if (!c)
-                            return;
-                        // Issue #1157: file metadata wins over audio analysis.
-                        double live =
-                            magda::ProjectManager::getInstance().getCurrentProjectInfo().tempo;
-                        bool existingLooksDefaulted =
-                            c->audio().interpretation.bpm > 0.0 && magda::isValidBpm(live) &&
-                            std::abs(c->audio().interpretation.bpm - live) < 0.1;
-                        if (c->audio().interpretation.bpm > 0.0 && !existingLooksDefaulted)
-                            return;
-                        magda::ClipManager::AudioClipBeatsUpdate u;
-                        u.interpretationBpm = detectedBPM;
-                        if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
-                                c->audio().source.filePath)) {
-                            double fileDuration = thumb->getTotalLength();
-                            if (fileDuration > 0.0) {
-                                u.sourceDurationSeconds = fileDuration;
-                                u.interpretationTotalBeats = fileDuration * detectedBPM / 60.0;
-                            }
-                        }
-                        mgr.applyAudioClipBeats(cid, u, live);
-                    });
             }
         }
 
@@ -640,7 +605,7 @@ void AudioClipPropertiesContent::updateFromClip() {
         stretchValue_->setValue(clip->speedRatio, juce::dontSendNotification);
         stretchModeCombo_->setSelectedId(clip->getEffectiveTimeStretchMode() + 1,
                                          juce::dontSendNotification);
-        const auto sourceDisplay = getSourceDisplayValues(*clip, clipId_);
+        const auto sourceDisplay = getSourceDisplayValues(*clip);
         bpmValue_->setValue(sourceDisplay.bpm > 0.0 ? sourceDisplay.bpm : magda::DEFAULT_BPM,
                             juce::dontSendNotification);
         beatsValue_->setValue(sourceDisplay.totalBeats > 0.0 ? sourceDisplay.totalBeats : 4.0,

--- a/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
+++ b/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
@@ -567,6 +567,14 @@ void AudioClipPropertiesContent::createControls() {
             return;
         bridge->setTransientSensitivity(clipId_,
                                         static_cast<float>(transientSensValue_->getValue()));
+        // setTransientSensitivity re-detects and clears the transient cache, but
+        // only after a coalescing delay. Clear it synchronously now so the
+        // property-change notification below sees the cache gone and the waveform
+        // editor restarts its transient poll, giving a live update as you drag.
+        if (const auto* clip = magda::ClipManager::getInstance().getClip(clipId_))
+            if (clip->isAudio() && !clip->audio().source.filePath.isEmpty())
+                magda::AudioThumbnailManager::getInstance().clearCachedTransients(
+                    clip->audio().source.filePath);
         magda::ClipManager::getInstance().forceNotifyClipPropertyChanged(clipId_);
     };
     addAndMakeVisible(*transientSensValue_);

--- a/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
+++ b/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
@@ -567,14 +567,6 @@ void AudioClipPropertiesContent::createControls() {
             return;
         bridge->setTransientSensitivity(clipId_,
                                         static_cast<float>(transientSensValue_->getValue()));
-        // setTransientSensitivity re-detects and clears the transient cache, but
-        // only after a coalescing delay. Clear it synchronously now so the
-        // property-change notification below sees the cache gone and the waveform
-        // editor restarts its transient poll, giving a live update as you drag.
-        if (const auto* clip = magda::ClipManager::getInstance().getClip(clipId_))
-            if (clip->isAudio() && !clip->audio().source.filePath.isEmpty())
-                magda::AudioThumbnailManager::getInstance().clearCachedTransients(
-                    clip->audio().source.filePath);
         magda::ClipManager::getInstance().forceNotifyClipPropertyChanged(clipId_);
     };
     addAndMakeVisible(*transientSensValue_);

--- a/magda/daw/ui/panels/content/WaveformEditorContent.cpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.cpp
@@ -236,6 +236,9 @@ WaveformEditorContent::WaveformEditorContent() {
     // Register as UndoManager listener (for warp marker refresh on undo/redo)
     magda::UndoManager::getInstance().addListener(this);
 
+    // Refresh transients on a callback when the detector recomputes them.
+    magda::AudioThumbnailManager::getInstance().addTransientCacheListener(this);
+
     // Create time ruler
     timeRuler_ = std::make_unique<magda::TimeRuler>();
     timeRuler_->setDisplayMode(magda::TimeRuler::DisplayMode::BarsBeats);
@@ -616,6 +619,7 @@ WaveformEditorContent::~WaveformEditorContent() {
 
     magda::ClipManager::getInstance().removeListener(this);
     magda::UndoManager::getInstance().removeListener(this);
+    magda::AudioThumbnailManager::getInstance().removeTransientCacheListener(this);
 
     // Clear look and feel before destruction
     if (timeModeButton_)
@@ -873,6 +877,22 @@ void WaveformEditorContent::clipPropertyChanged(magda::ClipId clipId) {
         updateGridSize();
         repaint();
     }
+}
+
+void WaveformEditorContent::transientsChanged(const juce::String& filePath) {
+    if (editingClipId_ == magda::INVALID_CLIP_ID)
+        return;
+    const auto* clip = magda::ClipManager::getInstance().getClip(editingClipId_);
+    if (clip == nullptr || !clip->isAudio() || clip->audio().source.filePath != filePath)
+        return;
+    // The detector recomputed (or cleared) this clip's transients, e.g. the user
+    // dragged the sensitivity slider. Re-arm the poll: getTransientTimes() yields
+    // the fresh set once detection finishes, and timerCallback() pushes it to the
+    // grid. The currently-shown markers stay until the new ones are ready, so the
+    // update is live without a flash.
+    transientsCached_ = false;
+    transientPollCount_ = 0;
+    startTimer(250);
 }
 
 void WaveformEditorContent::clipSelectionChanged(magda::ClipId clipId) {

--- a/magda/daw/ui/panels/content/WaveformEditorContent.cpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.cpp
@@ -640,6 +640,45 @@ void WaveformEditorContent::paint(juce::Graphics& g) {
     g.fillAll(DarkTheme::getPanelBackgroundColour());
 }
 
+void WaveformEditorContent::paintOverChildren(juce::Graphics& g) {
+    if (!transientsUpdating_)
+        return;
+
+    auto bounds = getLocalBounds();
+    if (bounds.isEmpty())
+        return;
+
+    constexpr int overlayW = 172;
+    constexpr int overlayH = 30;
+    auto area = juce::Rectangle<int>(overlayW, overlayH)
+                    .withRightX(bounds.getRight() - 12)
+                    .withY(TIME_RULER_HEIGHT + 10)
+                    .getIntersection(bounds);
+    if (area.isEmpty())
+        return;
+
+    g.setColour(DarkTheme::getColour(DarkTheme::SURFACE).withAlpha(0.88f));
+    g.fillRoundedRectangle(area.toFloat(), 6.0f);
+    g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(0.9f));
+    g.drawRoundedRectangle(area.toFloat().reduced(0.5f), 6.0f, 1.0f);
+
+    auto spinnerArea = area.removeFromLeft(32).reduced(8).toFloat();
+    const auto centre = spinnerArea.getCentre();
+    const float radius = juce::jmin(spinnerArea.getWidth(), spinnerArea.getHeight()) * 0.45f;
+    for (int i = 0; i < 12; ++i) {
+        const float t = static_cast<float>(i) / 12.0f;
+        const float angle = transientSpinnerPhase_ + t * juce::MathConstants<float>::twoPi;
+        const float alpha = 0.18f + 0.72f * t;
+        const auto p = centre + juce::Point<float>(std::cos(angle), std::sin(angle)) * radius;
+        g.setColour(DarkTheme::getAccentColour().withAlpha(alpha));
+        g.fillEllipse(p.x - 1.6f, p.y - 1.6f, 3.2f, 3.2f);
+    }
+
+    g.setColour(DarkTheme::getTextColour());
+    g.setFont(FontManager::getInstance().getUIFont(12.0f));
+    g.drawText("Updating transients", area.reduced(0, 1), juce::Justification::centredLeft, false);
+}
+
 void WaveformEditorContent::resized() {
     auto bounds = getLocalBounds();
 
@@ -863,14 +902,16 @@ void WaveformEditorContent::clipPropertyChanged(magda::ClipId clipId) {
         }
 
         // Check if cached transients were invalidated (e.g. sensitivity changed)
-        if (transientsCached_ && clip->isAudio() && !clip->audio().source.filePath.isEmpty()) {
+        if (clip->isAudio() && !clip->audio().source.filePath.isEmpty()) {
             auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
                 clip->audio().source.filePath);
-            if (!cached) {
-                // Cache was cleared — restart polling for new transients
+            if (cached) {
+                gridComponent_->setTransientTimes(*cached);
+                transientsCached_ = true;
+                setTransientsUpdating(false);
+            } else {
                 transientsCached_ = false;
-                transientPollCount_ = 0;
-                startTimer(250);
+                requestTransientDetection();
             }
         }
 
@@ -883,16 +924,38 @@ void WaveformEditorContent::transientsChanged(const juce::String& filePath) {
     if (editingClipId_ == magda::INVALID_CLIP_ID)
         return;
     const auto* clip = magda::ClipManager::getInstance().getClip(editingClipId_);
-    if (clip == nullptr || !clip->isAudio() || clip->audio().source.filePath != filePath)
+    if (clip == nullptr)
         return;
-    // The detector recomputed (or cleared) this clip's transients, e.g. the user
-    // dragged the sensitivity slider. Re-arm the poll: getTransientTimes() yields
-    // the fresh set once detection finishes, and timerCallback() pushes it to the
-    // grid. The currently-shown markers stay until the new ones are ready, so the
-    // update is live without a flash.
+    if (!clip->isAudio())
+        return;
+    if (clip->audio().source.filePath != filePath)
+        return;
+    auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(filePath);
+    if (cached) {
+        double bpm = 120.0;
+        if (auto* controller = magda::TimelineController::getCurrent())
+            bpm = controller->getState().tempo.bpm;
+
+        const double clipStart = clip->getTimelineStart(bpm);
+        const double clipLength = clip->getTimelineLength(bpm);
+        gridComponent_->setClip(editingClipId_);
+        gridComponent_->updateClipPosition(clipStart, clipLength);
+        timeRuler_->setClipLength(clipLength);
+        updateDisplayInfo(*clip);
+        updateGridSize();
+
+        gridComponent_->setTransientTimes(*cached);
+        gridComponent_->repaint();
+        if (viewport_)
+            viewport_->repaint();
+        repaint();
+        transientsCached_ = true;
+        setTransientsUpdating(false);
+        return;
+    }
+
     transientsCached_ = false;
-    transientPollCount_ = 0;
-    startTimer(250);
+    setTransientsUpdating(true);
 }
 
 void WaveformEditorContent::clipSelectionChanged(magda::ClipId clipId) {
@@ -981,8 +1044,6 @@ void WaveformEditorContent::setClip(magda::ClipId clipId) {
     if (editingClipId_ != clipId) {
         editingClipId_ = clipId;
         transientsCached_ = false;
-        transientPollCount_ = 0;
-        stopTimer();
         gridComponent_->setClip(clipId);
 
         // Update time ruler with clip info
@@ -1036,15 +1097,16 @@ void WaveformEditorContent::setClip(magda::ClipId clipId) {
             }
         }
 
-        // Check for cached transients or start polling
+        // Check for cached transients or request async detection.
         if (clip && clip->isAudio() && !clip->audio().source.filePath.isEmpty()) {
             auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
                 clip->audio().source.filePath);
             if (cached) {
                 gridComponent_->setTransientTimes(*cached);
                 transientsCached_ = true;
+                setTransientsUpdating(false);
             } else {
-                startTimer(250);
+                requestTransientDetection();
             }
         }
 
@@ -1307,22 +1369,11 @@ magda::AudioBridge* WaveformEditorContent::getBridge() {
     return audioEngine->getAudioBridge();
 }
 
-// ============================================================================
-// Timer (Transient Detection Polling)
-// ============================================================================
-
-void WaveformEditorContent::timerCallback() {
-    if (transientsCached_ || editingClipId_ == magda::INVALID_CLIP_ID) {
-        stopTimer();
+void WaveformEditorContent::requestTransientDetection() {
+    if (transientsCached_)
         return;
-    }
-
-    if (++transientPollCount_ >= MAX_TRANSIENT_POLL_ATTEMPTS) {
-        DBG("WaveformEditorContent: transient detection timed out after "
-            << MAX_TRANSIENT_POLL_ATTEMPTS << " attempts");
-        stopTimer();
+    if (editingClipId_ == magda::INVALID_CLIP_ID)
         return;
-    }
 
     auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine();
     if (!audioEngine)
@@ -1332,6 +1383,7 @@ void WaveformEditorContent::timerCallback() {
     if (!bridge)
         return;
 
+    setTransientsUpdating(true);
     if (bridge->getTransientTimes(editingClipId_)) {
         const auto* clip = magda::ClipManager::getInstance().getClip(editingClipId_);
         if (clip && !clip->audio().source.filePath.isEmpty()) {
@@ -1339,11 +1391,37 @@ void WaveformEditorContent::timerCallback() {
                 clip->audio().source.filePath);
             if (cached) {
                 gridComponent_->setTransientTimes(*cached);
+                setTransientsUpdating(false);
             }
         }
         transientsCached_ = true;
+    }
+}
+
+void WaveformEditorContent::setTransientsUpdating(bool updating) {
+    if (transientsUpdating_ == updating)
+        return;
+
+    transientsUpdating_ = updating;
+    transientSpinnerPhase_ = 0.0f;
+    if (transientsUpdating_) {
+        startTimerHz(30);
+    } else {
         stopTimer();
     }
+    repaint();
+}
+
+void WaveformEditorContent::timerCallback() {
+    if (!transientsUpdating_) {
+        stopTimer();
+        return;
+    }
+
+    transientSpinnerPhase_ += 0.22f;
+    if (transientSpinnerPhase_ > juce::MathConstants<float>::twoPi)
+        transientSpinnerPhase_ -= juce::MathConstants<float>::twoPi;
+    repaint();
 }
 
 // ============================================================================

--- a/magda/daw/ui/panels/content/WaveformEditorContent.hpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.hpp
@@ -28,11 +28,11 @@ namespace magda::daw::ui {
  * Architecture based on PianoRollContent pattern.
  */
 class WaveformEditorContent : public PanelContent,
+                              private juce::Timer,
                               public magda::ClipManagerListener,
                               public magda::UndoManagerListener,
                               public TimelineStateListener,
-                              public magda::TransientCacheListener,
-                              public juce::Timer {
+                              public magda::TransientCacheListener {
   public:
     WaveformEditorContent();
     ~WaveformEditorContent() override;
@@ -46,6 +46,7 @@ class WaveformEditorContent : public PanelContent,
     }
 
     void paint(juce::Graphics& g) override;
+    void paintOverChildren(juce::Graphics& g) override;
     void resized() override;
 
     void onActivated() override;
@@ -176,10 +177,12 @@ class WaveformEditorContent : public PanelContent,
     // Warp state tracking
     bool wasWarpEnabled_ = false;
 
-    // Transient detection polling
+    // Transient detection
     bool transientsCached_ = false;
-    int transientPollCount_ = 0;
-    static constexpr int MAX_TRANSIENT_POLL_ATTEMPTS = 40;  // ~10s at 250ms interval
+    bool transientsUpdating_ = false;
+    float transientSpinnerPhase_ = 0.0f;
+    void requestTransientDetection();
+    void setTransientsUpdating(bool updating);
     void timerCallback() override;
 
     // Header drag-zoom state

--- a/magda/daw/ui/panels/content/WaveformEditorContent.hpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "PanelContent.hpp"
+#include "audio/AudioThumbnailManager.hpp"  // TransientCacheListener
 #include "core/ClipDisplayInfo.hpp"
 #include "core/ClipManager.hpp"
 #include "core/UndoManager.hpp"
@@ -30,6 +31,7 @@ class WaveformEditorContent : public PanelContent,
                               public magda::ClipManagerListener,
                               public magda::UndoManagerListener,
                               public TimelineStateListener,
+                              public magda::TransientCacheListener,
                               public juce::Timer {
   public:
     WaveformEditorContent();
@@ -72,6 +74,10 @@ class WaveformEditorContent : public PanelContent,
 
     // TimelineStateListener
     void timelineStateChanged(const TimelineState& state, ChangeFlags changes) override;
+
+    // TransientCacheListener - the detector recomputed/cleared transients for a
+    // file (e.g. sensitivity changed); refresh on the callback instead of polling.
+    void transientsChanged(const juce::String& filePath) override;
 
     // Set the clip to edit
     void setClip(magda::ClipId clipId);

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -738,22 +738,18 @@ void ClipInspector::initClipPropertiesSection() {
         return clipIds;
     };
 
-    auto seedSourceInterpretation = [](magda::ClipId cid, auto& clip, double bpm) {
+    auto seedSourceInterpretation = [](auto& clip, double bpm) {
         // When enabling, seed source interpretation BPM/source interpretation total beats from
-        // detected BPM (AudioThumbnailManager) since the clip model may have stale metadata from
-        // TE's default loopInfo. Cached value is applied immediately (pre-setAutoTempo, before the
-        // canonical path is open); cache miss kicks off background detection and the callback
-        // funnels through applyAudioClipBeats once autoTempo is on.
+        // cached metadata since the clip model may have stale metadata from TE's default loopInfo.
         const bool sourceInterpretationBpmLooksDefaulted =
             clip.audio().interpretation.bpm <= 0.0 ||
             (magda::isValidBpm(bpm) && std::abs(clip.audio().interpretation.bpm - bpm) < 0.1);
         if (!sourceInterpretationBpmLooksDefaulted)
             return;
 
-        // Issue #1157: only seed from AudioThumbnailManager when the file
-        // didn't carry tempo metadata. setSourceMetadata (from TE's
-        // loopInfo) is authoritative when present; TempoDetect can be
-        // wrong by ~1.3x on syncopated loops.
+        // Issue #1157: only seed from cached metadata when the file didn't
+        // carry tempo metadata. setSourceMetadata (from TE's loopInfo) is
+        // authoritative when present.
         auto& thumbs = magda::AudioThumbnailManager::getInstance();
         double cached = thumbs.getCachedBPM(clip.audio().source.filePath);
         if (cached > 0.0) {
@@ -766,34 +762,6 @@ void ClipInspector::initClipPropertiesSection() {
                     clip.audio().interpretation.totalBeats = fileDuration * cached / 60.0;
                 }
             }
-        } else {
-            thumbs.requestBPMDetection(clip.audio().source.filePath, [cid](double detectedBPM) {
-                if (detectedBPM <= 0.0)
-                    return;
-                auto& mgr = magda::ClipManager::getInstance();
-                auto* c = mgr.getClip(cid);
-                if (!c)
-                    return;
-                // Issue #1157: file metadata wins over audio analysis.
-                // TempoDetect can be wrong by ~1.3x on syncopated loops.
-                double live = magda::ProjectManager::getInstance().getCurrentProjectInfo().tempo;
-                bool existingLooksDefaulted = c->audio().interpretation.bpm > 0.0 &&
-                                              magda::isValidBpm(live) &&
-                                              std::abs(c->audio().interpretation.bpm - live) < 0.1;
-                if (c->audio().interpretation.bpm > 0.0 && !existingLooksDefaulted)
-                    return;
-                magda::ClipManager::AudioClipBeatsUpdate u;
-                u.interpretationBpm = detectedBPM;
-                if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
-                        c->audio().source.filePath)) {
-                    double fileDuration = thumb->getTotalLength();
-                    if (fileDuration > 0.0) {
-                        u.sourceDurationSeconds = fileDuration;
-                        u.interpretationTotalBeats = fileDuration * detectedBPM / 60.0;
-                    }
-                }
-                mgr.applyAudioClipBeats(cid, u, live);
-            });
         }
     };
 
@@ -817,7 +785,7 @@ void ClipInspector::initClipPropertiesSection() {
                         if (!targetClip || !targetClip->isAudio())
                             return;
                         if (enable)
-                            seedSourceInterpretation(id, *targetClip, bpm);
+                            seedSourceInterpretation(*targetClip, bpm);
                         manager.setAutoTempo(id, enable, bpm);
                     }));
             }
@@ -1829,7 +1797,7 @@ void ClipInspector::initPlaybackSection() {
         if (bridge) {
             bridge->setTransientSensitivity(
                 primaryClipId(), static_cast<float>(transientSensitivityValue_->getValue()));
-            // Notify listeners so WaveformEditorContent restarts transient polling
+            // Notify listeners so WaveformEditorContent requests fresh callback-driven transients.
             magda::ClipManager::getInstance().forceNotifyClipPropertyChanged(primaryClipId());
         }
     };

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
@@ -261,19 +261,10 @@ void ClipInspector::updateFromSelectedClip() {
                 timelineController_ ? timelineController_->getState().tempo.bpm : 120.0;
             if (displayBPM <= 0.0 ||
                 (!clip->autoTempo && std::abs(displayBPM - projectBPM) < 0.1)) {
-                // source interpretation BPM is unset or matches project BPM (defaulted) — use
-                // detected. Read cached value only; if missing, kick off async detection and
-                // refresh the inspector via the existing clipPropertyChanged listener path.
+                // Source interpretation BPM is unset/defaulted. Read cached metadata only;
+                // do not launch DSP BPM analysis from display code.
                 auto& thumbs = magda::AudioThumbnailManager::getInstance();
                 displayBPM = thumbs.getCachedBPM(clip->audio().source.filePath);
-                if (displayBPM <= 0.0) {
-                    auto cid = pid;
-                    thumbs.requestBPMDetection(clip->audio().source.filePath, [cid](double bpm) {
-                        if (bpm <= 0.0)
-                            return;
-                        magda::ClipManager::getInstance().forceNotifyClipPropertyChanged(cid);
-                    });
-                }
             }
             clipBpmValue_.setVisible(true);
             clipBpmUnitLabel_.setVisible(true);


### PR DESCRIPTION
Three related fixes to how audio clip waveforms load and draw.

## Progressive waveform rendering (#1416)
Long files used to show nothing until the thumbnail finished, then snap in all at once, which read as a frozen load.
- `drawWaveform` no longer gates on `isFullyLoaded()`; it draws whatever the thumbnail has streamed in so far, so the waveform fills in left to right. The expensive high-res smooth renderer is still held back until loading settles.
- `ClipComponent` and `WaveformGridComponent` now listen to the thumbnail's change broadcasts and repaint as data arrives, dropping the listener once fully loaded. This replaces `ClipComponent`'s poll timer that only repainted while the mouse was hovering.

## Moved/missing files shown as broken (#1415)
A moved or deleted source file left the preview stuck on "Loading..." forever. A null thumbnail is terminal (the reader is created synchronously), so it now paints a clear broken state: a red wash over the clip plus a "Missing file" label, instead of a perpetual loading placeholder.

## Coarsen the zoomed-out editor grid
A long clip zoomed fully out drew one grid line per beat across a few hundred pixels, collapsing into a solid wall of vertical bars. The grid now draws every Nth line so lines stay a few pixels apart, snapped to the origin (stable while scrolling) and rounded to a whole number of lines per bar so the kept lines land on numbered bars.

Closes #1415
Closes #1416