### PR TITLE
Add Collect Files action to consolidate referenced audio (#1407)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -17,6 +17,7 @@
     "file.close_project": "Close Project",
     "file.save_project": "Save Project",
     "file.save_project_as": "Save Project As...",
+    "file.collect_files": "Collect Files...",
     "file.export_audio": "Export Audio...",
     "file.export_midi": "Export MIDI...",
     "file.quit": "Quit",
@@ -355,6 +356,14 @@
     "error.no_midi_notes": "No MIDI clips with notes to export.",
     "error.midi_write_failed": "Failed to write MIDI file.",
     "error.cannot_create_file": "Could not create output file:"
+  },
+
+  "collect": {
+    "title": "Collect Files",
+    "progress.title": "Collecting Files...",
+    "progress.copying": "Copying referenced audio into the project...",
+    "alert.cancelled": "Collect was cancelled. Some files may not have been copied.",
+    "alert.no_edit": "Open or create a project first."
   },
 
   "common": {

--- a/magda/daw/project/CMakeLists.txt
+++ b/magda/daw/project/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 target_sources(magda_daw PRIVATE
     ProjectManager.cpp
+    MediaCollector.cpp
     serialization/ProjectSerializer.cpp
     serialization/TrackSerializer.cpp
     serialization/ClipSerializer.cpp
@@ -9,5 +10,6 @@ target_sources(magda_daw PRIVATE
     # Headers (listed for IDE visibility)
     ProjectInfo.hpp
     ProjectManager.hpp
+    MediaCollector.hpp
     serialization/ProjectSerializer.hpp
 )

--- a/magda/daw/project/MediaCollector.cpp
+++ b/magda/daw/project/MediaCollector.cpp
@@ -1,0 +1,232 @@
+#include "MediaCollector.hpp"
+
+#include "../audio/AudioThumbnailManager.hpp"
+#include "../audio/plugins/DrumGridPlugin.hpp"
+#include "../audio/plugins/MagdaSamplerPlugin.hpp"
+#include "../core/ClipInfo.hpp"
+#include "../core/ClipManager.hpp"
+#include "../core/TrackManager.hpp"
+#include "../engine/TracktionEngineWrapper.hpp"
+#include "ProjectManager.hpp"
+
+namespace magda {
+
+namespace te = tracktion;
+
+namespace {
+
+// Resolve the running edit, or nullptr if the engine isn't a TracktionEngineWrapper.
+te::Edit* getEdit() {
+    if (auto* wrapper =
+            dynamic_cast<TracktionEngineWrapper*>(TrackManager::getInstance().getAudioEngine()))
+        return wrapper->getEdit();
+    return nullptr;
+}
+
+// Bundled resources roots a factory sample could live under. Mirrors
+// DrumkitManager's bundled-dir probe but stops at the resources parent so any
+// shipped sample (not just drumkits) is recognised.
+juce::Array<juce::File> factoryRoots() {
+    auto appFile = juce::File::getSpecialLocation(juce::File::currentApplicationFile);
+
+    juce::Array<juce::File> roots;
+#if JUCE_MAC
+    roots.add(appFile.getChildFile("Contents/Resources"));
+#endif
+#if JUCE_LINUX
+    if (auto real = juce::File("/proc/self/exe").getLinkedTarget(); real.exists())
+        roots.add(real.getParentDirectory());
+#endif
+    roots.add(appFile.getParentDirectory());
+
+    // Dev-tree: the binary lives deep in cmake-build-*, walk up to the repo's
+    // resources dir so collecting in a dev build also leaves factory kits alone.
+    auto walk = appFile.getParentDirectory();
+    for (int i = 0; i < 8 && walk.exists(); ++i) {
+        auto maybe = walk.getChildFile("resources");
+        if (maybe.isDirectory()) {
+            roots.add(maybe);
+            break;
+        }
+        walk = walk.getParentDirectory();
+    }
+    return roots;
+}
+
+// Pick a destination filename in `dir` that collides neither with an existing
+// file nor with a name already handed out this run (files aren't created yet).
+juce::File uniqueDest(const juce::File& dir, const juce::File& source,
+                      juce::StringArray& usedNames) {
+    auto base = source.getFileNameWithoutExtension();
+    auto ext = source.getFileExtension();
+    auto name = base + ext;
+    int n = 2;
+    while (usedNames.contains(name) || dir.getChildFile(name).existsAsFile()) {
+        name = base + " (" + juce::String(n++) + ")" + ext;
+    }
+    usedNames.add(name);
+    return dir.getChildFile(name);
+}
+
+}  // namespace
+
+bool MediaCollector::isFactoryFile(const juce::File& file) {
+    for (const auto& root : factoryRoots())
+        if (root != juce::File() && file.isAChildOf(root))
+            return true;
+    return false;
+}
+
+MediaCollector::Plan MediaCollector::scan() {
+    Plan plan;
+
+    const auto mediaDir = ProjectManager::getInstance().getMediaDirectory();
+    const auto importedDir = ProjectManager::getInstance().getImportedDirectory();
+    juce::StringArray usedNames;
+
+    // path string -> index into plan.items, so references to the same source
+    // collapse onto one copy.
+    std::map<juce::String, size_t> indexByPath;
+
+    // Classify one referenced path; returns the item index to attach a reference
+    // to, or -1 if the path should be skipped (and bumps the relevant counter).
+    auto resolve = [&](const juce::String& rawPath) -> long {
+        if (rawPath.isEmpty())
+            return -1;
+        const juce::File file(rawPath);
+
+        if (mediaDir != juce::File() && file.isAChildOf(mediaDir)) {
+            ++plan.alreadyLocalCount;
+            return -1;
+        }
+        if (isFactoryFile(file)) {
+            ++plan.factoryCount;
+            return -1;
+        }
+        if (!file.existsAsFile()) {
+            ++plan.missingCount;
+            return -1;
+        }
+
+        const auto key = file.getFullPathName();
+        auto it = indexByPath.find(key);
+        if (it != indexByPath.end())
+            return static_cast<long>(it->second);
+
+        Item item;
+        item.source = file;
+        item.dest = uniqueDest(importedDir, file, usedNames);
+        plan.items.push_back(std::move(item));
+        const auto idx = plan.items.size() - 1;
+        indexByPath[key] = idx;
+        return static_cast<long>(idx);
+    };
+
+    // 1. Audio clip sources.
+    for (const auto& clip : ClipManager::getInstance().getClips()) {
+        if (!clip.isAudio())
+            continue;
+        const auto idx = resolve(clip.audio().source.filePath);
+        if (idx >= 0)
+            plan.items[static_cast<size_t>(idx)].clipRefs.push_back(clip.id);
+    }
+
+    // 2 + 3. Samplers (standalone, incl. inside instrument racks) and drum pads.
+    if (auto* edit = getEdit()) {
+        auto attachSampler = [&](te::Plugin* plugin) {
+            auto* sampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(plugin);
+            if (sampler == nullptr)
+                return;
+            const auto idx = resolve(sampler->getSampleFile().getFullPathName());
+            if (idx >= 0)
+                plan.items[static_cast<size_t>(idx)].samplerRefs.push_back(
+                    te::Plugin::Ptr(sampler));
+        };
+
+        for (auto plugin : te::getAllPlugins(*edit, true)) {
+            attachSampler(plugin);
+
+            // Drum-pad samplers live inside the DrumGridPlugin's own chains, not
+            // in the rack list, so reach them explicitly.
+            if (auto* drumGrid = dynamic_cast<daw::audio::DrumGridPlugin*>(plugin)) {
+                for (const auto& chain : drumGrid->getChains())
+                    for (auto& nested : chain->plugins)
+                        attachSampler(nested.get());
+            }
+        }
+    }
+
+    return plan;
+}
+
+void MediaCollector::copy(Plan& plan, const std::function<void(float)>& onProgress,
+                          std::atomic<bool>& cancel) {
+    ProjectManager::getInstance().getImportedDirectory().createDirectory();
+
+    const auto total = static_cast<int>(plan.items.size());
+    for (int i = 0; i < total; ++i) {
+        if (cancel.load())
+            return;
+        auto& item = plan.items[static_cast<size_t>(i)];
+        item.copied = item.source.copyFileTo(item.dest) && item.dest.existsAsFile();
+        if (onProgress)
+            onProgress(static_cast<float>(i + 1) / static_cast<float>(total));
+    }
+}
+
+MediaCollector::Summary MediaCollector::apply(const Plan& plan) {
+    Summary summary;
+    summary.missing = plan.missingCount;
+    summary.alreadyLocal = plan.alreadyLocalCount;
+    summary.factory = plan.factoryCount;
+
+    auto& clipManager = ClipManager::getInstance();
+    auto& thumbs = AudioThumbnailManager::getInstance();
+
+    for (const auto& item : plan.items) {
+        if (!item.copied) {
+            summary.failed += 1;
+            continue;
+        }
+
+        const auto newPath = item.dest.getFullPathName();
+
+        for (auto clipId : item.clipRefs) {
+            if (auto* clip = clipManager.getClip(clipId); clip != nullptr && clip->isAudio()) {
+                const auto oldPath = clip->audio().source.filePath;
+                clip->audio().source.filePath = newPath;
+                thumbs.invalidateFile(oldPath);
+                thumbs.invalidateFile(newPath);
+                clipManager.forceNotifyClipPropertyChanged(clipId);
+            }
+        }
+
+        for (auto& samplerRef : item.samplerRefs) {
+            if (auto* sampler = dynamic_cast<daw::audio::MagdaSamplerPlugin*>(samplerRef.get()))
+                sampler->loadSample(item.dest);
+        }
+
+        summary.collected += 1;
+    }
+
+    if (summary.collected > 0)
+        ProjectManager::getInstance().markDirty();
+
+    return summary;
+}
+
+juce::String MediaCollector::Summary::toMessage() const {
+    juce::StringArray parts;
+    parts.add(juce::String(collected) + (collected == 1 ? " file collected" : " files collected"));
+    if (failed > 0)
+        parts.add(juce::String(failed) + (failed == 1 ? " failed to copy" : " failed to copy"));
+    if (missing > 0)
+        parts.add(juce::String(missing) + " missing on disk");
+    if (alreadyLocal > 0)
+        parts.add(juce::String(alreadyLocal) + " already in the project");
+    if (factory > 0)
+        parts.add(juce::String(factory) + " factory (left in place)");
+    return parts.joinIntoString(", ") + ".";
+}
+
+}  // namespace magda

--- a/magda/daw/project/MediaCollector.hpp
+++ b/magda/daw/project/MediaCollector.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+// clang-format off
+#include <tracktion_engine/tracktion_engine.h>
+// clang-format on
+
+#include <atomic>
+#include <functional>
+#include <vector>
+
+#include "../core/ClipTypes.hpp"
+
+namespace magda {
+
+/**
+ * @brief "Collect files" — consolidate all externally-referenced audio into the
+ *        project media folder so the project is self-contained (#1407).
+ *
+ * Imported audio (clip sources, sampler samples, drum-pad samples) references its
+ * original file in place by absolute path; nothing copies it into the project. If
+ * the originals move or are deleted, every reference breaks. Collect copies each
+ * distinct external user file once into `<project>_Media/imported/`, repoints every
+ * reference to the copy, dedupes, and marks the project dirty.
+ *
+ * The flow is split so I/O can run off the message thread:
+ *   1. scan()  -- message thread: walk every reference, build the unique external
+ *                 file set with destination filenames pre-assigned.
+ *   2. copy()  -- background thread: copy each source into imported/ (cancellable,
+ *                 reports per-file progress); marks each item copied/failed.
+ *   3. apply() -- message thread: repoint references to the copies, invalidate
+ *                 thumbnails, reload samplers, markDirty.
+ */
+class MediaCollector {
+  public:
+    // One distinct external source file and every reference that points at it.
+    // References are deduped by source path: one copy serves all of them.
+    struct Item {
+        juce::File source;
+        juce::File dest;  // assigned in scan(), created in copy()
+        std::vector<ClipId> clipRefs;
+        // Hold Plugin::Ptr (not raw) so the sampler stays alive between scan and
+        // apply even if the edit is mutated in between.
+        std::vector<tracktion::Plugin::Ptr> samplerRefs;
+        bool copied = false;
+    };
+
+    struct Plan {
+        std::vector<Item> items;
+        int missingCount = 0;       // referenced files that no longer exist on disk
+        int alreadyLocalCount = 0;  // references already under the media dir
+        int factoryCount = 0;       // references to bundled/factory samples
+
+        bool hasWork() const {
+            return !items.empty();
+        }
+    };
+
+    struct Summary {
+        int collected = 0;  // files successfully copied + repointed
+        int failed = 0;     // copy failures (reference left as-is)
+        int missing = 0;
+        int alreadyLocal = 0;
+        int factory = 0;
+
+        juce::String toMessage() const;
+    };
+
+    // Message thread. Walks clips + samplers + drum pads, returns the plan.
+    static Plan scan();
+
+    // Background thread. Copies each item's source into its dest, setting
+    // item.copied. Calls onProgress(0..1) and stops early if cancel becomes true.
+    static void copy(Plan& plan, const std::function<void(float)>& onProgress,
+                     std::atomic<bool>& cancel);
+
+    // Message thread. Repoints references of every copied item, invalidates
+    // thumbnails, reloads samplers, marks the project dirty. Returns a summary.
+    static Summary apply(const Plan& plan);
+
+  private:
+    // True iff `file` ships with the app (under a bundled resources root). Such
+    // samples are left in place -- they travel with the install, not the project.
+    static bool isFactoryFile(const juce::File& file);
+};
+
+}  // namespace magda

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -20,6 +20,7 @@ static const char* const kRecordingsDir = "recordings";
 static const char* const kRendersDir = "renders";
 static const char* const kBouncesDir = "bounces";
 static const char* const kExternalEditsDir = "external-edits";
+static const char* const kImportedDir = "imported";
 static const char* const kTempRootDir = "MAGDA";
 static const char* const kTempPrefix = "UnsavedProject_";
 static constexpr int kStaleTempDays = 7;
@@ -510,6 +511,12 @@ juce::File ProjectManager::getExternalEditsDirectory() const {
     if (mediaDirectory_ == juce::File())
         return {};
     return mediaDirectory_.getChildFile(kExternalEditsDir);
+}
+
+juce::File ProjectManager::getImportedDirectory() const {
+    if (mediaDirectory_ == juce::File())
+        return {};
+    return mediaDirectory_.getChildFile(kImportedDir);
 }
 
 void ProjectManager::createTempMediaDirectory() {

--- a/magda/daw/project/ProjectManager.hpp
+++ b/magda/daw/project/ProjectManager.hpp
@@ -276,6 +276,14 @@ class ProjectManager : private juce::Timer {
     juce::File getExternalEditsDirectory() const;
 
     /**
+     * @brief Get the collected/imported media subdirectory.
+     *
+     * Where "Collect files" copies externally-referenced audio (clip sources,
+     * sampler and drum-pad samples) so the project is self-contained (#1407).
+     */
+    juce::File getImportedDirectory() const;
+
+    /**
      * @brief Delete temp media directories older than 7 days.
      * Call once at app launch.
      */

--- a/magda/daw/ui/windows/MainWindowMenus.cpp
+++ b/magda/daw/ui/windows/MainWindowMenus.cpp
@@ -23,9 +23,71 @@
 #include "core/TrackPropertyCommands.hpp"
 #include "core/UndoManager.hpp"
 #include "engine/TracktionEngineWrapper.hpp"
+#include "project/MediaCollector.hpp"
 #include "project/ProjectManager.hpp"
 
 namespace magda {
+
+namespace {
+
+// Copies the collected files off the message thread (cancellable), then applies
+// the repointing + summary on completion (message thread). The scan has already
+// run on the message thread; this owns the resulting plan.
+class CollectFilesProgressWindow : public juce::ThreadWithProgressWindow {
+  public:
+    explicit CollectFilesProgressWindow(MediaCollector::Plan plan)
+        : ThreadWithProgressWindow(tr("collect.progress.title"), true, true),
+          plan_(std::move(plan)),
+          strCopying_(tr("collect.progress.copying")) {
+        setStatusMessage(strCopying_);
+    }
+
+    void run() override {
+        // copy() checks cancel_ before each file and calls back after each; mirror
+        // the progress window's Cancel button into cancel_ so the next file is
+        // skipped and the copy returns early.
+        MediaCollector::copy(
+            plan_,
+            [this](float p) {
+                setProgress(static_cast<double>(p));
+                if (threadShouldExit())
+                    cancel_.store(true);
+            },
+            cancel_);
+        if (threadShouldExit())
+            cancelled_ = true;
+    }
+
+    void threadComplete(bool userPressedCancel) override {
+        auto plan = std::move(plan_);
+        const bool cancelled = userPressedCancel || cancelled_;
+
+        // JUCE guarantees no further callbacks after threadComplete(); delete
+        // self first, then apply + report on a fresh message-loop iteration
+        // (creating an AlertWindow inside this timer-driven callback can crash).
+        delete this;
+
+        juce::MessageManager::callAsync([plan = std::move(plan), cancelled]() mutable {
+            if (cancelled) {
+                juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::InfoIcon,
+                                                       tr("collect.title"),
+                                                       tr("collect.alert.cancelled"));
+                return;
+            }
+            const auto summary = MediaCollector::apply(plan);
+            juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::InfoIcon, tr("collect.title"),
+                                                   summary.toMessage());
+        });
+    }
+
+  private:
+    MediaCollector::Plan plan_;
+    juce::String strCopying_;
+    std::atomic<bool> cancel_{false};
+    bool cancelled_ = false;
+};
+
+}  // namespace
 
 void MainWindow::openProjectFile(const juce::File& file) {
     if (!file.existsAsFile())
@@ -359,6 +421,27 @@ void MainWindow::setupMenuCallbacks() {
 
             fileChooser_.reset();
         });
+    };
+
+    callbacks.onCollectFiles = [this]() {
+        auto* engine = dynamic_cast<TracktionEngineWrapper*>(mainComponent->getAudioEngine());
+        if (!engine || !engine->getEdit()) {
+            juce::AlertWindow::showMessageBoxAsync(
+                juce::AlertWindow::WarningIcon, tr("collect.title"), tr("collect.alert.no_edit"));
+            return;
+        }
+
+        // Scan on the message thread (touches clips + plugins); if nothing is
+        // external there's no work, so report and stop without a progress window.
+        auto plan = MediaCollector::scan();
+        if (!plan.hasWork()) {
+            juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::InfoIcon, tr("collect.title"),
+                                                   MediaCollector::apply(plan).toMessage());
+            return;
+        }
+
+        // Owns itself; deletes in threadComplete().
+        (new CollectFilesProgressWindow(std::move(plan)))->launchThread();
     };
 
     callbacks.onExportAudio = [this]() {

--- a/magda/daw/ui/windows/MenuManager.cpp
+++ b/magda/daw/ui/windows/MenuManager.cpp
@@ -102,6 +102,8 @@ juce::PopupMenu MenuManager::getMenuForIndex(int topLevelMenuIndex,
             menu.addItem(SaveProject, tr("menu.file.save_project"), true, false);
             menu.addItem(SaveProjectAs, tr("menu.file.save_project_as"), true, false);
             menu.addSeparator();
+            menu.addItem(CollectFiles, tr("menu.file.collect_files"), true, false);
+            menu.addSeparator();
             menu.addItem(ExportAudio, tr("menu.file.export_audio"), true, false);
             menu.addItem(ExportMidi, tr("menu.file.export_midi"), true, false);
 
@@ -304,6 +306,10 @@ void MenuManager::menuItemSelected(int menuItemID, int topLevelMenuIndex) {
         case ImportAudio:
             if (callbacks_.onImportAudio)
                 callbacks_.onImportAudio();
+            break;
+        case CollectFiles:
+            if (callbacks_.onCollectFiles)
+                callbacks_.onCollectFiles();
             break;
         case ExportAudio:
             if (callbacks_.onExportAudio)

--- a/magda/daw/ui/windows/MenuManager.hpp
+++ b/magda/daw/ui/windows/MenuManager.hpp
@@ -19,6 +19,7 @@ class MenuManager : public juce::MenuBarModel, public UndoManagerListener {
         std::function<void()> onSaveProject;
         std::function<void()> onSaveProjectAs;
         std::function<void()> onImportAudio;
+        std::function<void()> onCollectFiles;
         std::function<void()> onExportAudio;
         std::function<void()> onExportMidi;
         std::function<void()> onQuit;
@@ -152,6 +153,7 @@ class MenuManager : public juce::MenuBarModel, public UndoManagerListener {
         ImportAudio = 110,
         ExportAudio,
         ExportMidi,
+        CollectFiles = 115,
         RecentProjectBase = 150,  // 150-159 reserved for recent projects
         Quit = 199,
 


### PR DESCRIPTION
Copy every externally-referenced audio file (clip sources, sampler and drum-pad samples) into <project>_Media/imported/ and repoint each reference to the copy, so the project becomes self-contained and survives moving the folder.

MediaCollector runs in three phases: scan (message thread) builds the unique external-file set, skipping files already under the media dir, factory/bundled samples, and missing sources; copy (background thread, cancellable) duplicates each source once with collision-safe naming; apply (message thread) repoints clips, reloads samplers, invalidates thumbnails, and marks the project dirty.

Wired into File > Collect Files via MenuManager with a ThreadWithProgressWindow for the cancellable copy and a summary alert.