### PR TITLE
AutomationAgent: error on target=selected with no lane selected (#1017)

### DIFF
--- a/magda/agents/automation_executor.cpp
+++ b/magda/agents/automation_executor.cpp
@@ -70,15 +70,11 @@ AutomationLaneId resolveTarget(MagdaApi& api, const AutoTarget& target, juce::St
             auto laneId = sel.getSelectedAutomationLaneId();
             if (laneId != INVALID_AUTOMATION_LANE_ID)
                 return laneId;
-            // Fall back to trackVolume on the selected track — the most
-            // common default for "automate this track".
-            auto trackId = getSelectedTrack(api, err);
-            if (trackId == INVALID_TRACK_ID)
-                return INVALID_AUTOMATION_LANE_ID;
-            AutomationTarget t;
-            t.kind = ControlTarget::Kind::TrackVolume;
-            t.devicePath = ChainNodePath::trackLevel(trackId);
-            return ensureLaneForTarget(api, t);
+            // No fallback: writing volume automation when the user asked for
+            // a specific parameter would silently mis-target (#1017).
+            err = "No automation lane is selected. Select the parameter's lane first, "
+                  "or say which parameter to automate (volume and pan work directly).";
+            return INVALID_AUTOMATION_LANE_ID;
         }
         case AutoTarget::Kind::TrackVolume: {
             auto trackId = getSelectedTrack(api, err);

--- a/tests/test_automation_agent.cpp
+++ b/tests/test_automation_agent.cpp
@@ -229,7 +229,7 @@ TEST_CASE("AutomationExecutor: target=volume is a singleton (two runs = one lane
     REQUIRE(lanes.size() == 1);  // never two volume lanes
 }
 
-TEST_CASE("AutomationExecutor: target=selected falls back to TrackVolume with no lane selected",
+TEST_CASE("AutomationExecutor: target=selected with no lane selected fails without writing",
           "[automation][executor]") {
     resetState();
     auto trackId = makeTrack("Synth");
@@ -238,13 +238,14 @@ TEST_CASE("AutomationExecutor: target=selected falls back to TrackVolume with no
     AutomationParser parser;
     MagdaApiLive api;
     AutomationExecutor exec(api);
-    REQUIRE(
+    // No automation lane selected: must error out rather than silently
+    // writing volume automation (#1017)
+    REQUIRE_FALSE(
         exec.execute(parseOrFail(parser, "AUTO line start=0 end=4 from=0 to=1 target=selected")));
+    REQUIRE(exec.getError().isNotEmpty());
 
     auto lanes = AutomationManager::getInstance().getLanesForTrack(trackId);
-    REQUIRE(lanes.size() == 1);
-    auto* lane = AutomationManager::getInstance().getLane(lanes[0]);
-    REQUIRE(lane->target.kind == ControlTarget::Kind::TrackVolume);
+    REQUIRE(lanes.empty());
 }
 
 TEST_CASE("AutomationExecutor: target=volume with no track selected fails",


### PR DESCRIPTION
The executor silently fell back to creating a track volume lane, so a request like "sweep the filter cutoff" could write volume automation instead. Now it returns an error asking for a lane selection; volume and pan remain directly addressable via their own targets, and aliases cover named parameters.