### PR TITLE
Poly Sequencer: polyphonic step sequencer with drum mode, AI agents, and pattern editing

### DIFF
--- a/magda/agents/CMakeLists.txt
+++ b/magda/agents/CMakeLists.txt
@@ -53,6 +53,14 @@ dsl_grammar.hpp
     four_osc_agent.cpp
     four_osc_apply.hpp
     four_osc_apply.cpp
+    poly_step_sequencer_agent.hpp
+    poly_step_sequencer_agent.cpp
+    poly_step_sequencer_apply.hpp
+    poly_step_sequencer_apply.cpp
+    step_sequencer_agent.hpp
+    step_sequencer_agent.cpp
+    step_sequencer_apply.hpp
+    step_sequencer_apply.cpp
     faust_agent.hpp
     faust_agent.cpp
     device_ai_agent.hpp

--- a/magda/agents/coder_agent.cpp
+++ b/magda/agents/coder_agent.cpp
@@ -21,6 +21,10 @@ namespace {
 // applies it via FaustPlugin::loadDspSource on the message thread.
 class FaustCoderAgent : public CoderAgent {
   public:
+    juce::String getUserCaveat() const override {
+        return "note: generated code is a starting point - review and refine in the editor.";
+    }
+
     juce::String generateAndApply(const juce::String& prompt, const ChainNodePath& path,
                                   llm::Conversation& conversation,
                                   TokenCallback onToken = {}) override {

--- a/magda/agents/device_ai_agent.hpp
+++ b/magda/agents/device_ai_agent.hpp
@@ -48,6 +48,14 @@ class DeviceAIAgent {
     /// Best-effort cancel; safe to call from any thread.
     virtual void requestCancel() {}
 
+    /// Short yellow caveat shown below the status line after a successful
+    /// generation. Must start with "note: " so the panel's kDisclaimerMarker
+    /// ("\n\nnote: ") matches for re-colouring after slot rebuilds.
+    /// The panel prepends "\n\n"; do not include it here.
+    virtual juce::String getUserCaveat() const {
+        return "note: starting point only - tweak by ear before saving.";
+    }
+
   protected:
     std::atomic<bool> shouldStop_{false};
 };

--- a/magda/agents/internal_plugins.hpp
+++ b/magda/agents/internal_plugins.hpp
@@ -41,6 +41,7 @@ enum class InternalPlugin {
     Arpeggiator,
     MidiChordEngine,
     StepSequencer,
+    PolyStepSequencer,
     Faust,
     Mod,
     Flanger,
@@ -104,6 +105,8 @@ inline const std::vector<InternalPluginInfo>& getInternalPlugins() {
          V::Magda},
         {"Step Sequencer", "stepsequencer", DeviceType::Effect, InternalPlugin::StepSequencer,
          V::Magda},
+        {"Poly Sequencer", "polystepsequencer", DeviceType::Effect,
+         InternalPlugin::PolyStepSequencer, V::Magda},
     };
     return kPlugins;
 }

--- a/magda/agents/mixing_agent.hpp
+++ b/magda/agents/mixing_agent.hpp
@@ -123,6 +123,14 @@ class MixAnalysisAgent {
     static juce::String buildUserMessage(const Input& input);
 
     static const char* getSystemPrompt();
+
+    /** Post-generation caveat shown to the user after a successful mixing agent
+     *  response. Display-only - never sent back to the LLM as conversation history.
+     *  Prefix "note: " matches the DeviceAIAgent caveat convention. */
+    static const char* getUserCaveat() {
+        return "note: suggestions are based on measured analysis - trust your ears for the final "
+               "call.";
+    }
 };
 
 }  // namespace magda

--- a/magda/agents/poly_step_sequencer_agent.cpp
+++ b/magda/agents/poly_step_sequencer_agent.cpp
@@ -1,0 +1,415 @@
+#include "poly_step_sequencer_agent.hpp"
+
+#include "../daw/core/Config.hpp"
+#include "llm_client_factory.hpp"
+#include "llm_presets.hpp"
+
+namespace magda {
+
+// ============================================================================
+// System prompt
+// ============================================================================
+//
+// StepClock::Rate enum values (for the `rate` field):
+//   0 = DottedQuarter  (dotted 1/4)
+//   1 = Quarter        (1/4)
+//   2 = TripletQuarter (1/4T)
+//   3 = DottedEighth   (dotted 1/8)
+//   4 = Eighth         (1/8)
+//   5 = TripletEighth  (1/8T)
+//   6 = DottedSixteenth (dotted 1/16)
+//   7 = Sixteenth      (1/16)    <-- most common default
+//   8 = TripletSixteenth (1/16T)
+//   9 = ThirtySecond   (1/32)
+
+const char* PolyStepSequencerAgent::getSystemPrompt() {
+    return R"PROMPT(You are a pattern designer for the MAGDA built-in Poly Step Sequencer. Given a user
+description, produce a single step-sequencer pattern as JSON. Output ONLY the JSON object --
+no prose, no markdown fences.
+
+The Poly Step Sequencer fires MIDI note events on tempo-synced steps. Each step can hold
+up to 8 simultaneous notes (a chord), plus per-step gate / tie / probability / velocity
+controls. It works for both melodic/chordal patterns and drum patterns.
+
+OUTPUT SCHEMA:
+{
+  "description": "<one short line describing the pattern>",
+  "numSteps": <1-32, integer, OPTIONAL -- omit to keep the current value>,
+  "rate": <0-9, integer, OPTIONAL -- omit to keep the current value>,
+  "swing": <0.0-1.0, float, OPTIONAL -- omit to keep the current value>,
+  "gateLength": <0.0-1.0, float, OPTIONAL -- omit to keep the current value>,
+  "steps": [
+    {
+      "index": <0-based integer>,
+      "gate": <true|false>,
+      "tie": <true|false, optional, default false>,
+      "probability": <0.0-1.0, float, optional, default 1.0>,
+      "velocity": <1-127, integer, optional, default 100>,
+      "notes": [
+        { "note": <0-127 MIDI note number> },
+        { "note": <0-127>, "velocity": <1-127> }
+      ]
+    }
+  ]
+}
+
+RATE TABLE (use the integer, not the string):
+  0  = dotted 1/4  (slow, half-bar feel)
+  1  = 1/4         (quarter notes)
+  2  = 1/4T        (quarter note triplets)
+  3  = dotted 1/8
+  4  = 1/8         (eighth notes)
+  5  = 1/8T        (eighth triplets)
+  6  = dotted 1/16
+  7  = 1/16        (sixteenth notes -- DEFAULT for most patterns)
+  8  = 1/16T       (sixteenth triplets)
+  9  = 1/32        (thirty-second notes, very fast)
+
+STEPS RULES:
+- Only emit steps that have notes. Steps not listed are cleared (gate=off).
+- `gate: true` means the step fires. `gate: false` means rest -- include it
+  only when you want an explicit rest in an otherwise active range.
+- `tie: true` extends the previous step's notes without retrigger (like a
+  note tie/slur). Use for longer sustained notes across adjacent steps.
+- `probability` less than 1.0 injects randomness. 0.75 = fires 3 out of 4
+  times on average. Good for hi-hat variation.
+- `velocity` is the step-level MIDI velocity (1-127). Per-note `velocity`
+  overrides the step value for that specific note only; omit it to inherit.
+- `notes` may be empty when `gate: false` (rest step). For active steps
+  always include at least one note.
+- Note numbers follow standard MIDI: C4 = 60, D4 = 62, E4 = 64, F4 = 65,
+  G4 = 67, A4 = 69, B4 = 71, C5 = 72.
+
+DRUM MAP (General MIDI, use for drum patterns):
+  36 = Kick (Bass Drum)
+  38 = Snare
+  39 = Hand Clap
+  40 = Snare (electric)
+  42 = Hi-hat closed
+  44 = Hi-hat pedal
+  46 = Hi-hat open
+  49 = Crash cymbal
+  51 = Ride cymbal
+  52 = China cymbal
+  57 = Crash 2
+
+MELODY / CHORD VOICINGS:
+- For single-note basslines: one note per step, root of the scale.
+- For power chords: root + 7 semitones (e.g. 48 + 55 for C2 power chord).
+- For triads (major): root, root+4, root+7. Minor: root, root+3, root+7.
+- For pads / sustained chords: set gateLength close to 1.0 and use tie on
+  tied steps.
+- Typical octave ranges: bass 24-48, mid 48-72, high 72-96.
+
+numSteps GUIDELINES:
+- 16 steps: standard for 1-bar patterns at 1/16 rate
+- 8 steps: half-bar, good for fast hi-hat rolls
+- 32 steps: 2-bar phrase
+- For drum patterns 16 is almost always correct.
+
+swing: 0.0 = straight. 0.5 = heavy swing. 0.1-0.2 = light shuffle.
+gateLength: 0.1 = very staccato. 0.5 = moderate. 0.9 = near-legato.
+  Default 0.5 works for most patterns; use 0.2-0.3 for drums/plucks.
+
+DEVICE CONTEXT (may be appended after this prompt):
+When a "DEVICE CONTEXT:" block is appended, it describes the current state of
+the device the user is editing. Follow these rules:
+
+PRESERVING CURRENT SETTINGS:
+- The "currentSettings:" line shows the live device values for numSteps, rate,
+  swing, and gateLength.
+- PRESERVE all of these unless the user's prompt explicitly implies changing
+  them (e.g. "make it 8 steps", "use eighth notes", "add swing", "double time").
+- To preserve a value, simply OMIT that field from your JSON output. The apply
+  code will leave the device value unchanged when the field is absent.
+- CRITICAL: always write a pattern that spans the full current numSteps. If
+  currentSettings shows numSteps=32, produce step indices 0-31 as needed
+  (sparse is fine -- only emit active steps). Do NOT silently shrink the
+  pattern to 16 steps.
+
+- viewMode=keys: the user is editing melodic or chordal material on a piano-roll
+  view. Produce chords, melodies, arpeggios, or basslines. Do NOT produce drum
+  patterns (kick/snare/hi-hat using GM note numbers) unless the prompt
+  explicitly asks for drums.
+
+- viewMode=drum: the user is editing a drum pattern on a drum-lanes view.
+  Produce drum patterns. If a LANE MAP is provided, use exactly those note
+  numbers and reference the pad names in the description. Without a lane map,
+  fall back to the GM DRUM MAP above.
+
+EXAMPLES:
+
+User: "basic 4-on-the-floor kick pattern"
+{"description":"4-on-the-floor kick, 16 steps at 1/16","numSteps":16,"rate":7,"swing":0.0,"gateLength":0.25,"steps":[{"index":0,"gate":true,"velocity":110,"notes":[{"note":36}]},{"index":4,"gate":true,"velocity":110,"notes":[{"note":36}]},{"index":8,"gate":true,"velocity":110,"notes":[{"note":36}]},{"index":12,"gate":true,"velocity":110,"notes":[{"note":36}]}]}
+
+User: "classic trap hi-hat pattern with rolls"
+{"description":"Trap hi-hat: 1/32 pattern with rolls and velocity variation","numSteps":16,"rate":9,"swing":0.1,"gateLength":0.15,"steps":[{"index":0,"gate":true,"velocity":100,"notes":[{"note":42}]},{"index":2,"gate":true,"velocity":80,"notes":[{"note":42}]},{"index":4,"gate":true,"velocity":100,"notes":[{"note":42}]},{"index":5,"gate":true,"velocity":70,"notes":[{"note":42}]},{"index":6,"gate":true,"velocity":90,"notes":[{"note":42}]},{"index":8,"gate":true,"velocity":100,"notes":[{"note":46}]},{"index":10,"gate":true,"velocity":80,"notes":[{"note":42}]},{"index":12,"gate":true,"velocity":100,"notes":[{"note":42}]},{"index":14,"gate":true,"velocity":80,"notes":[{"note":42}]},{"index":15,"gate":true,"velocity":70,"notes":[{"note":42}]}]}
+
+User: "chord progression Cmaj - Am - F - G, one chord per 4 steps"
+{"description":"Cmaj-Am-F-G chord progression, four chords over 16 steps","numSteps":16,"rate":7,"swing":0.0,"gateLength":0.9,"steps":[{"index":0,"gate":true,"velocity":90,"notes":[{"note":60},{"note":64},{"note":67}]},{"index":4,"gate":true,"velocity":90,"notes":[{"note":57},{"note":60},{"note":64}]},{"index":8,"gate":true,"velocity":90,"notes":[{"note":53},{"note":57},{"note":60}]},{"index":12,"gate":true,"velocity":90,"notes":[{"note":55},{"note":59},{"note":62}]}]}
+
+User: "driving 16th note bass line in A minor"
+{"description":"Driving 16th-note bass in A minor","numSteps":16,"rate":7,"swing":0.0,"gateLength":0.4,"steps":[{"index":0,"gate":true,"velocity":105,"notes":[{"note":45}]},{"index":1,"gate":true,"velocity":85,"notes":[{"note":45}]},{"index":2,"gate":true,"velocity":90,"notes":[{"note":48}]},{"index":3,"gate":true,"velocity":80,"notes":[{"note":50}]},{"index":4,"gate":true,"velocity":100,"notes":[{"note":52}]},{"index":5,"gate":true,"velocity":80,"notes":[{"note":50}]},{"index":6,"gate":true,"velocity":85,"notes":[{"note":48}]},{"index":7,"gate":true,"velocity":75,"notes":[{"note":45}]},{"index":8,"gate":true,"velocity":105,"notes":[{"note":45}]},{"index":9,"gate":true,"velocity":80,"notes":[{"note":45}]},{"index":10,"gate":true,"velocity":88,"notes":[{"note":48}]},{"index":11,"gate":true,"velocity":78,"notes":[{"note":52}]},{"index":12,"gate":true,"velocity":100,"notes":[{"note":55}]},{"index":13,"gate":true,"velocity":82,"notes":[{"note":53}]},{"index":14,"gate":true,"velocity":87,"notes":[{"note":52}]},{"index":15,"gate":true,"velocity":78,"notes":[{"note":48}]}]}
+)PROMPT";
+}
+
+// ============================================================================
+// JSON parser
+// ============================================================================
+
+PolyStepSequencerAgent::Preset PolyStepSequencerAgent::parseJson(const juce::String& text,
+                                                                 std::string& outError) {
+    Preset preset;
+
+    // Strip LLM markdown fences if present.
+    juce::String trimmed = text.trim();
+    if (trimmed.startsWith("```")) {
+        auto firstNewline = trimmed.indexOf("\n");
+        if (firstNewline > 0)
+            trimmed = trimmed.substring(firstNewline + 1);
+        if (trimmed.endsWith("```"))
+            trimmed = trimmed.dropLastCharacters(3).trim();
+    }
+
+    auto parsed = juce::JSON::parse(trimmed);
+    auto* obj = parsed.getDynamicObject();
+    if (obj == nullptr) {
+        outError = "preset JSON must be an object";
+        return preset;
+    }
+
+    if (auto desc = obj->getProperty("description"); desc.isString())
+        preset.description = desc.toString().toStdString();
+
+    if (auto ns = obj->getProperty("numSteps"); ns.isInt() || ns.isDouble()) {
+        preset.numSteps = juce::jlimit(1, 32, static_cast<int>(static_cast<double>(ns)));
+    }
+
+    if (auto r = obj->getProperty("rate"); r.isInt() || r.isDouble()) {
+        preset.rate = juce::jlimit(0, 9, static_cast<int>(static_cast<double>(r)));
+    }
+
+    if (auto sw = obj->getProperty("swing"); sw.isDouble() || sw.isInt()) {
+        preset.swing = juce::jlimit(0.0f, 1.0f, static_cast<float>(static_cast<double>(sw)));
+    }
+
+    if (auto gl = obj->getProperty("gateLength"); gl.isDouble() || gl.isInt()) {
+        preset.gateLength = juce::jlimit(0.0f, 1.0f, static_cast<float>(static_cast<double>(gl)));
+    }
+
+    // Parse steps array.
+    auto stepsVar = obj->getProperty("steps");
+    if (!stepsVar.isArray()) {
+        outError = "preset JSON missing 'steps' array";
+        return preset;
+    }
+
+    auto* stepsArr = stepsVar.getArray();
+    if (stepsArr == nullptr || stepsArr->isEmpty()) {
+        // An empty steps array is valid (clears all steps).
+        return preset;
+    }
+
+    for (const auto& stepVar : *stepsArr) {
+        auto* stepObj = stepVar.getDynamicObject();
+        if (stepObj == nullptr)
+            continue;
+
+        StepSpec step;
+
+        auto idxVar = stepObj->getProperty("index");
+        if (!idxVar.isInt() && !idxVar.isDouble())
+            continue;  // index is required
+        step.index = juce::jlimit(0, 31, static_cast<int>(static_cast<double>(idxVar)));
+
+        if (auto g = stepObj->getProperty("gate"); g.isBool() || g.isInt())
+            step.gate = static_cast<bool>(g);
+        else
+            step.gate = true;
+
+        if (auto t = stepObj->getProperty("tie"); t.isBool() || t.isInt())
+            step.tie = static_cast<bool>(t);
+
+        if (auto p = stepObj->getProperty("probability"); p.isDouble() || p.isInt())
+            step.probability = juce::jlimit(0.0f, 1.0f, static_cast<float>(static_cast<double>(p)));
+
+        if (auto v = stepObj->getProperty("velocity"); v.isInt() || v.isDouble())
+            step.velocity = juce::jlimit(1, 127, static_cast<int>(static_cast<double>(v)));
+
+        // Parse notes array for this step.
+        if (auto notesVar = stepObj->getProperty("notes"); notesVar.isArray()) {
+            if (auto* notesArr = notesVar.getArray()) {
+                for (const auto& noteVar : *notesArr) {
+                    auto* noteObj = noteVar.getDynamicObject();
+                    if (noteObj == nullptr)
+                        continue;
+
+                    NoteSpec note;
+                    auto nv = noteObj->getProperty("note");
+                    if (!nv.isInt() && !nv.isDouble())
+                        continue;
+                    note.noteNumber =
+                        juce::jlimit(0, 127, static_cast<int>(static_cast<double>(nv)));
+
+                    if (auto vel = noteObj->getProperty("velocity"); vel.isInt() || vel.isDouble())
+                        note.velocityOverride =
+                            juce::jlimit(1, 127, static_cast<int>(static_cast<double>(vel)));
+                    // else velocityOverride stays 0 (= inherit step velocity)
+
+                    step.notes.push_back(note);
+                    if (static_cast<int>(step.notes.size()) >= 8)
+                        break;  // MAX_NOTES_PER_STEP
+                }
+            }
+        }
+
+        preset.steps.push_back(std::move(step));
+    }
+
+    return preset;
+}
+
+// ============================================================================
+// LLM call
+// ============================================================================
+
+namespace {
+
+void logPolyStepAgentConfig(const Config::AgentLLMConfig& agentConfig,
+                            const llm::ProviderConfig& pc) {
+    DBG("MAGDA PolyStepSequencerAgent config:");
+    DBG("  provider (string) = " + juce::String(agentConfig.provider));
+    DBG("  provider (enum)   = " + juce::String(static_cast<int>(pc.provider)));
+    DBG("  model             = " + pc.model);
+    DBG("  baseUrl           = " + pc.baseUrl);
+    DBG("  apiKey present    = " + juce::String(pc.apiKey.isNotEmpty() ? "yes" : "NO"));
+    DBG("  noTemperature     = " + juce::String(pc.noTemperature ? "yes" : "no"));
+}
+
+void logPolyStepAgentResult(const PolyStepSequencerAgent::GenerateResult& result) {
+    DBG("MAGDA PolyStepSequencerAgent raw output (" +
+        juce::String(static_cast<int>(result.rawOutput.size())) + " chars):");
+    DBG("---8<---");
+    DBG(juce::String(result.rawOutput));
+    DBG("--->8---");
+    DBG("MAGDA PolyStepSequencerAgent parsed: description='" +
+        juce::String(result.preset.description) +
+        "' steps=" + juce::String(static_cast<int>(result.preset.steps.size())));
+    if (!result.error.empty())
+        DBG("MAGDA PolyStepSequencerAgent ERROR: " + juce::String(result.error));
+}
+
+}  // namespace
+
+PolyStepSequencerAgent::GenerateResult PolyStepSequencerAgent::generate(
+    const std::string& message, const std::string& deviceContext) {
+    GenerateResult result;
+
+    if (shouldStop_.load()) {
+        result.error = "Cancelled";
+        result.hasError = true;
+        return result;
+    }
+
+    auto agentConfig = Config::getInstance().getAgentLLMConfig(role::MUSIC);
+    auto providerConfig = toLLMProviderConfig(agentConfig, "poly_step_sequencer");
+    logPolyStepAgentConfig(agentConfig, providerConfig);
+
+    if (providerConfig.apiKey.isEmpty() && agentConfig.baseUrl.empty() &&
+        agentConfig.provider != provider::LLAMA_LOCAL) {
+        result.error = "Poly Step Sequencer agent API key not configured.";
+        result.hasError = true;
+        return result;
+    }
+
+    auto client = createLLMClient(agentConfig, "poly_step_sequencer");
+
+    llm::Request request;
+    auto systemPrompt = juce::String::fromUTF8(getSystemPrompt());
+    if (!deviceContext.empty())
+        systemPrompt += "\n\n" + juce::String::fromUTF8(deviceContext.c_str());
+    request.systemPrompt = systemPrompt;
+    request.userMessage = juce::String::fromUTF8(message.c_str());
+    request.temperature = 0.3f;  // some creativity for patterns
+
+    auto response = client->sendRequest(request);
+    if (!response.success) {
+        result.error = response.error.toStdString();
+        result.hasError = true;
+        return result;
+    }
+
+    auto trimmedText = response.text.trim();
+    result.rawOutput = trimmedText.toStdString();
+
+    std::string parseError;
+    result.preset = parseJson(trimmedText, parseError);
+    if (!parseError.empty()) {
+        result.error = parseError;
+        result.hasError = true;
+    }
+
+    logPolyStepAgentResult(result);
+    return result;
+}
+
+PolyStepSequencerAgent::GenerateResult PolyStepSequencerAgent::generateStreaming(
+    const std::string& message, TokenCallback onToken, const std::string& deviceContext) {
+    GenerateResult result;
+
+    if (shouldStop_.load()) {
+        result.error = "Cancelled";
+        result.hasError = true;
+        return result;
+    }
+
+    auto agentConfig = Config::getInstance().getAgentLLMConfig(role::MUSIC);
+    auto providerConfig = toLLMProviderConfig(agentConfig, "poly_step_sequencer");
+    logPolyStepAgentConfig(agentConfig, providerConfig);
+
+    if (providerConfig.apiKey.isEmpty() && agentConfig.baseUrl.empty() &&
+        agentConfig.provider != provider::LLAMA_LOCAL) {
+        result.error = "Poly Step Sequencer agent API key not configured.";
+        result.hasError = true;
+        return result;
+    }
+
+    auto client = createLLMClient(agentConfig, "poly_step_sequencer");
+
+    llm::Request request;
+    auto systemPromptStr = juce::String::fromUTF8(getSystemPrompt());
+    if (!deviceContext.empty())
+        systemPromptStr += "\n\n" + juce::String::fromUTF8(deviceContext.c_str());
+    request.systemPrompt = systemPromptStr;
+    request.userMessage = juce::String::fromUTF8(message.c_str());
+    request.temperature = 0.3f;
+
+    auto response = client->sendStreamingRequest(request, [&](const juce::String& token) {
+        if (shouldStop_.load())
+            return false;
+        if (onToken)
+            return onToken(token);
+        return true;
+    });
+
+    if (!response.success) {
+        result.error = response.error.toStdString();
+        result.hasError = true;
+        return result;
+    }
+
+    auto trimmedText = response.text.trim();
+    result.rawOutput = trimmedText.toStdString();
+
+    std::string parseError;
+    result.preset = parseJson(trimmedText, parseError);
+    if (!parseError.empty()) {
+        result.error = parseError;
+        result.hasError = true;
+    }
+
+    logPolyStepAgentResult(result);
+    return result;
+}
+
+}  // namespace magda

--- a/magda/agents/poly_step_sequencer_agent.hpp
+++ b/magda/agents/poly_step_sequencer_agent.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <atomic>
+#include <string>
+#include <vector>
+
+#include "compact_parser.hpp"  // for TokenCallback
+
+namespace magda {
+
+/**
+ * @brief Poly Step Sequencer AI agent -- generates a single pattern from a prompt.
+ *
+ * The LLM is instructed to emit a JSON object describing a pattern for the
+ * built-in Poly Step Sequencer device. The pattern carries global settings
+ * (numSteps, rate, swing, gateLength) and a sparse list of steps, each with
+ * gate/tie/probability/velocity and up to 8 notes (chords). Steps omitted
+ * from the array are cleared to defaults (gate off, no notes).
+ *
+ * Reuses role::MUSIC for the LLM config so users don't need separate API
+ * credentials for this device.
+ */
+class PolyStepSequencerAgent {
+  public:
+    struct NoteSpec {
+        int noteNumber = 60;       // MIDI note 0-127
+        int velocityOverride = 0;  // 0 = use step velocity, 1-127 = per-note override
+    };
+
+    struct StepSpec {
+        int index = 0;     // Step index 0-based
+        bool gate = true;  // true = active, false = rest
+        bool tie = false;
+        float probability = 1.0f;  // 0.0-1.0
+        int velocity = 100;        // Step-level MIDI velocity 1-127
+        std::vector<NoteSpec> notes;
+    };
+
+    struct Preset {
+        std::string description;      // one-line summary shown in panel
+        int numSteps = -1;            // 1-32; -1 = leave unchanged (absent from JSON)
+        int rate = -1;                // StepClock::Rate enum value; -1 = leave unchanged
+        float swing = -1.0f;          // 0-1; negative = leave unchanged
+        float gateLength = -1.0f;     // 0-1; negative = leave unchanged
+        std::vector<StepSpec> steps;  // sparse -- unlisted steps will be cleared
+    };
+
+    struct GenerateResult {
+        std::string rawOutput;  // raw LLM text, kept for diagnostics
+        Preset preset;
+        std::string error;
+        bool hasError = false;
+    };
+
+    /** Generate a pattern from a user prompt (background-thread safe).
+     *  deviceContext is an optional string appended to the system prompt to
+     *  convey the current view mode and downstream drum-lane map. */
+    GenerateResult generate(const std::string& message, const std::string& deviceContext = {});
+
+    /** Streaming variant -- onToken fires per token. The parsed Preset is
+     *  only available once streaming completes (JSON must land whole before
+     *  parsing). */
+    GenerateResult generateStreaming(const std::string& message, TokenCallback onToken,
+                                     const std::string& deviceContext = {});
+
+    void requestCancel() {
+        shouldStop_ = true;
+    }
+    void resetCancel() {
+        shouldStop_ = false;
+    }
+
+  private:
+    static const char* getSystemPrompt();
+
+    /** Parse a JSON string into a Preset. Returns empty Preset + sets
+     *  outError on malformed input. Tolerant of LLM markdown fences
+     *  ("```json ... ```") around the payload. */
+    Preset parseJson(const juce::String& text, std::string& outError);
+
+    std::atomic<bool> shouldStop_{false};
+};
+
+}  // namespace magda

--- a/magda/agents/poly_step_sequencer_apply.cpp
+++ b/magda/agents/poly_step_sequencer_apply.cpp
@@ -1,0 +1,101 @@
+#include "poly_step_sequencer_apply.hpp"
+
+#include "audio/AudioBridge.hpp"
+#include "audio/plugins/PolyStepSequencerPlugin.hpp"
+#include "core/PresetManager.hpp"
+#include "core/TrackManager.hpp"
+#include "engine/AudioEngine.hpp"
+#include "internal_plugins.hpp"
+
+namespace magda {
+
+juce::String applyPolyStepSequencerPresetToPath(const PolyStepSequencerAgent::Preset& preset,
+                                                const ChainNodePath& path) {
+    auto& tm = TrackManager::getInstance();
+    auto* device = tm.getDeviceInChainByPath(path);
+    if (device == nullptr ||
+        internalPluginFromId(device->pluginId) != InternalPlugin::PolyStepSequencer)
+        return "(target device is not a Poly Step Sequencer)";
+
+    // Reach the live plugin via AudioBridge.
+    auto* engine = tm.getAudioEngine();
+    auto* bridge = engine ? engine->getAudioBridge() : nullptr;
+    auto plugin = bridge ? bridge->getPlugin(path) : nullptr;
+    auto* seq = dynamic_cast<daw::audio::PolyStepSequencerPlugin*>(plugin.get());
+    if (seq == nullptr)
+        return "(could not resolve live PolyStepSequencerPlugin)";
+
+    // --- Write global settings ---
+    // These are CachedValues backed by the plugin's state ValueTree.
+    // Writing via the state directly is the same pattern used by the UI.
+    // Using nullptr as UndoManager so the globals don't pollute undo history;
+    // the pattern write below goes through the plugin's undo-aware setters.
+    auto* um = seq->getUndoManager();
+
+    if (preset.numSteps >= 1)
+        seq->state.setProperty(juce::Identifier("seqNumSteps"), preset.numSteps, um);
+
+    if (preset.rate >= 0)
+        seq->state.setProperty(juce::Identifier("seqRate"), preset.rate, um);
+
+    if (preset.swing >= 0.0f)
+        seq->state.setProperty(juce::Identifier("seqSwing"), preset.swing, um);
+
+    if (preset.gateLength >= 0.0f)
+        seq->state.setProperty(juce::Identifier("seqGateLength"), preset.gateLength, um);
+
+    // --- Clear all existing steps ---
+    // The plugin's clearStep() is the undo-safe public API for blanking a step.
+    // When numSteps is absent from the preset (sentinel -1), read the live value
+    // so we clear exactly the current active window, not a hardcoded default.
+    const int numStepsToClear =
+        juce::jlimit(1, daw::audio::PolyStepSequencerPlugin::MAX_STEPS,
+                     preset.numSteps >= 1 ? preset.numSteps : seq->numSteps.get());
+    for (int i = 0; i < numStepsToClear; ++i)
+        seq->clearStep(i);
+
+    // --- Write pattern steps ---
+    int stepsWritten = 0;
+    int notesWritten = 0;
+    for (const auto& step : preset.steps) {
+        if (step.index < 0 || step.index >= daw::audio::PolyStepSequencerPlugin::MAX_STEPS)
+            continue;
+
+        // clearStep above already set gate=off, no notes. Only re-set the
+        // properties that differ from that baseline.
+        seq->setStepGate(step.index, step.gate);
+
+        if (step.tie)
+            seq->setStepTie(step.index, true);
+
+        if (step.probability < 1.0f)
+            seq->setStepProbability(step.index, step.probability);
+
+        if (step.velocity != 100)
+            seq->setStepVelocity(step.index, step.velocity);
+
+        for (const auto& note : step.notes) {
+            seq->addStepNote(step.index, note.noteNumber, note.velocityOverride);
+            ++notesWritten;
+        }
+
+        ++stepsWritten;
+    }
+
+    // Capture the mutated live plugin state into MAGDA's DeviceInfo so a
+    // later syncTrackPlugins doesn't re-push stale state. Same approach as
+    // four_osc_apply; intentionally skip notifyTrackDevicesChanged here so
+    // the AI panel stays alive to show the apply status before rebuilding.
+    if (bridge)
+        bridge->getPluginManager().capturePluginState(path);
+
+    // Stash the pattern description as the suggested preset name.
+    if (!preset.description.empty())
+        PresetManager::getInstance().setSuggestedPresetName(device->id,
+                                                            juce::String(preset.description));
+
+    return "applied " + juce::String(stepsWritten) + " step(s), " + juce::String(notesWritten) +
+           " note(s) to " + device->name;
+}
+
+}  // namespace magda

--- a/magda/agents/poly_step_sequencer_apply.hpp
+++ b/magda/agents/poly_step_sequencer_apply.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include "core/ChainNodePath.hpp"
+#include "poly_step_sequencer_agent.hpp"
+
+namespace magda {
+
+/**
+ * @brief Apply a parsed PolyStepSequencer preset to a specific device path.
+ *
+ * Sets global parameters (numSteps, rate, swing, gateLength) via the
+ * plugin's CachedValues, clears all steps, then writes each listed step
+ * via the plugin's public setters (clearStep + setStepGate/Tie/Probability/
+ * Velocity + addStepNote).
+ *
+ * Must be called on the message thread (TE asserts this for ValueTree
+ * writes). The SoundDesignAgent wrapper handles the thread hop.
+ *
+ * Returns a one-line status (e.g. "applied 16 steps to Poly Sequencer") or
+ * an error string starting with "()" if the path doesn't resolve to a
+ * PolyStepSequencerPlugin.
+ */
+juce::String applyPolyStepSequencerPresetToPath(const PolyStepSequencerAgent::Preset& preset,
+                                                const ChainNodePath& path);
+
+}  // namespace magda

--- a/magda/agents/sound_design_agent.cpp
+++ b/magda/agents/sound_design_agent.cpp
@@ -2,9 +2,19 @@
 
 #include <juce_events/juce_events.h>
 
+#include "audio/AudioBridge.hpp"
+#include "audio/plugins/DrumGridPlugin.hpp"
+#include "audio/plugins/PolyStepSequencerPlugin.hpp"
+#include "audio/plugins/StepSequencerPlugin.hpp"
+#include "core/TrackManager.hpp"
+#include "engine/AudioEngine.hpp"
 #include "four_osc_agent.hpp"
 #include "four_osc_apply.hpp"
 #include "internal_plugins.hpp"
+#include "poly_step_sequencer_agent.hpp"
+#include "poly_step_sequencer_apply.hpp"
+#include "step_sequencer_agent.hpp"
+#include "step_sequencer_apply.hpp"
 
 namespace magda {
 
@@ -98,12 +108,267 @@ class FourOscSoundDesignAgent : public SoundDesignAgent {
     juce::String categoryOverride_;
 };
 
+// Build a device-context string for the Poly Step Sequencer agent.
+// Reads viewMode from the plugin and, if a DrumGridPlugin is downstream on
+// the same track, adds a lane map ("note N = <name>").
+// Thread-safe: getPlugin uses a ScopedLock; CachedValue reads are value-copies
+// (atomic-equivalent) safe off the message thread; getChains() is read-only
+// after construction and stable while the edit is live.
+std::string buildPolyStepSequencerContext(const ChainNodePath& path) {
+    auto& tm = TrackManager::getInstance();
+    auto* engine = tm.getAudioEngine();
+    auto* bridge = engine ? engine->getAudioBridge() : nullptr;
+    if (bridge == nullptr)
+        return {};
+
+    auto plugin = bridge->getPlugin(path);
+    auto* seq = dynamic_cast<daw::audio::PolyStepSequencerPlugin*>(plugin.get());
+    if (seq == nullptr)
+        return {};
+
+    std::string ctx = "DEVICE CONTEXT:\n";
+    const auto viewMode = seq->viewMode.get().toStdString();
+    ctx += "viewMode=" + (viewMode.empty() ? "keys" : viewMode) + "\n";
+
+    // Emit current settings so the model knows not to change them unless asked.
+    {
+        char buf[128];
+        std::snprintf(buf, sizeof(buf),
+                      "currentSettings: numSteps=%d, rate=%d, swing=%.2f, gateLength=%.2f\n",
+                      seq->numSteps.get(), seq->rate.get(), static_cast<double>(seq->swing.get()),
+                      static_cast<double>(seq->gateLength.get()));
+        ctx += buf;
+    }
+
+    // Walk the owner track for a downstream DrumGridPlugin (mirrors the
+    // findDownstreamDrumGrid logic in PolyStepSequencerUI).
+    auto* track = seq->getOwnerTrack();
+    if (track != nullptr) {
+        namespace te = tracktion::engine;
+        bool passedSelf = false;
+        daw::audio::DrumGridPlugin* drumGrid = nullptr;
+        daw::audio::DrumGridPlugin* fallback = nullptr;
+        for (auto* p : track->pluginList) {
+            if (p == seq) {
+                passedSelf = true;
+                continue;
+            }
+            auto* found = dynamic_cast<daw::audio::DrumGridPlugin*>(p);
+            if (found == nullptr) {
+                if (auto* rackInstance = dynamic_cast<te::RackInstance*>(p)) {
+                    if (rackInstance->type != nullptr) {
+                        for (auto* inner : rackInstance->type->getPlugins()) {
+                            found = dynamic_cast<daw::audio::DrumGridPlugin*>(inner);
+                            if (found != nullptr)
+                                break;
+                        }
+                    }
+                }
+            }
+            if (found != nullptr) {
+                if (passedSelf) {
+                    drumGrid = found;
+                    break;
+                }
+                if (fallback == nullptr)
+                    fallback = found;
+            }
+        }
+        if (drumGrid == nullptr && !passedSelf)
+            drumGrid = fallback;
+
+        if (drumGrid != nullptr && !drumGrid->getChains().empty()) {
+            ctx += "LANE MAP:\n";
+            for (const auto& chain : drumGrid->getChains()) {
+                if (chain == nullptr)
+                    continue;
+                ctx += "note " + std::to_string(chain->lowNote) + " = " +
+                       chain->name.toStdString() + "\n";
+            }
+        }
+    }
+
+    return ctx;
+}
+
+// Poly Step Sequencer -- generate patterns from a prompt.
+class PolyStepSequencerSoundDesignAgent : public SoundDesignAgent {
+  public:
+    juce::String getUserCaveat() const override {
+        return "note: generated pattern is a starting point - edit steps to taste.";
+    }
+
+    juce::String generateAndApply(const juce::String& prompt, const ChainNodePath& path,
+                                  llm::Conversation& conversation,
+                                  TokenCallback onToken = {}) override {
+        juce::ignoreUnused(conversation);  // pattern design is single-shot
+        agent_.resetCancel();
+        if (shouldStop_.load())
+            return "cancelled";
+
+        // Read plugin state (view mode + downstream drum lane map) before
+        // generation. buildPolyStepSequencerContext is safe off the message
+        // thread: getPlugin uses a ScopedLock and the chain/CachedValue reads
+        // are stable value-copies while the edit is live.
+        const auto deviceContext = buildPolyStepSequencerContext(path);
+
+        PolyStepSequencerAgent::GenerateResult result;
+        if (onToken) {
+            auto fwd = [this, &onToken](const juce::String& token) -> bool {
+                if (shouldStop_.load())
+                    return false;
+                return onToken(token);
+            };
+            result = agent_.generateStreaming(prompt.toStdString(), fwd, deviceContext);
+        } else {
+            result = agent_.generate(prompt.toStdString(), deviceContext);
+        }
+        if (shouldStop_.load())
+            return "cancelled";
+
+        if (result.hasError)
+            return juce::String("error: ") + juce::String(result.error);
+
+        // Apply must run on the message thread (TE ValueTree asserts it).
+        auto& mm = *juce::MessageManager::getInstance();
+        if (mm.isThisTheMessageThread())
+            return applyPolyStepSequencerPresetToPath(result.preset, path);
+
+        struct ApplyState {
+            juce::String status;
+            juce::WaitableEvent done;
+        };
+        auto state = std::make_shared<ApplyState>();
+        const auto preset = result.preset;
+        mm.callAsync([state, preset, path]() {
+            state->status = applyPolyStepSequencerPresetToPath(preset, path);
+            state->done.signal();
+        });
+
+        constexpr int sliceMs = 50;
+        constexpr int maxMs = 5000;
+        for (int waited = 0; waited < maxMs; waited += sliceMs) {
+            if (state->done.wait(sliceMs))
+                return state->status;
+            if (shouldStop_.load())
+                return "cancelled";
+        }
+        return "apply timed out";
+    }
+
+    void requestCancel() override {
+        shouldStop_ = true;
+        agent_.requestCancel();
+    }
+
+  private:
+    PolyStepSequencerAgent agent_;
+};
+
+// Build a device-context string for the mono Step Sequencer agent.
+// Reads the current numSteps/rate/swing/gateLength from the live plugin.
+// Thread-safe: getPlugin uses a ScopedLock; CachedValue reads are value-copies.
+std::string buildStepSequencerContext(const ChainNodePath& path) {
+    auto& tm = TrackManager::getInstance();
+    auto* engine = tm.getAudioEngine();
+    auto* bridge = engine ? engine->getAudioBridge() : nullptr;
+    if (bridge == nullptr)
+        return {};
+
+    auto plugin = bridge->getPlugin(path);
+    auto* seq = dynamic_cast<daw::audio::StepSequencerPlugin*>(plugin.get());
+    if (seq == nullptr)
+        return {};
+
+    char buf[128];
+    std::snprintf(
+        buf, sizeof(buf),
+        "DEVICE CONTEXT:\ncurrentSettings: numSteps=%d, rate=%d, swing=%.2f, gateLength=%.2f\n",
+        seq->numSteps.get(), seq->rate.get(), static_cast<double>(seq->swing.get()),
+        static_cast<double>(seq->gateLength.get()));
+    return buf;
+}
+
+// Mono Step Sequencer -- generate 303-style patterns from a prompt.
+class StepSequencerSoundDesignAgent : public SoundDesignAgent {
+  public:
+    juce::String getUserCaveat() const override {
+        return "note: generated pattern is a starting point - edit steps to taste.";
+    }
+
+    juce::String generateAndApply(const juce::String& prompt, const ChainNodePath& path,
+                                  llm::Conversation& conversation,
+                                  TokenCallback onToken = {}) override {
+        juce::ignoreUnused(conversation);  // pattern design is single-shot
+        agent_.resetCancel();
+        if (shouldStop_.load())
+            return "cancelled";
+
+        const auto deviceContext = buildStepSequencerContext(path);
+
+        StepSequencerAgent::GenerateResult result;
+        if (onToken) {
+            auto fwd = [this, &onToken](const juce::String& token) -> bool {
+                if (shouldStop_.load())
+                    return false;
+                return onToken(token);
+            };
+            result = agent_.generateStreaming(prompt.toStdString(), fwd, deviceContext);
+        } else {
+            result = agent_.generate(prompt.toStdString(), deviceContext);
+        }
+        if (shouldStop_.load())
+            return "cancelled";
+
+        if (result.hasError)
+            return juce::String("error: ") + juce::String(result.error);
+
+        // Apply must run on the message thread (TE ValueTree asserts it).
+        auto& mm = *juce::MessageManager::getInstance();
+        if (mm.isThisTheMessageThread())
+            return applyStepSequencerPresetToPath(result.preset, path);
+
+        struct ApplyState {
+            juce::String status;
+            juce::WaitableEvent done;
+        };
+        auto state = std::make_shared<ApplyState>();
+        const auto preset = result.preset;
+        mm.callAsync([state, preset, path]() {
+            state->status = applyStepSequencerPresetToPath(preset, path);
+            state->done.signal();
+        });
+
+        constexpr int sliceMs = 50;
+        constexpr int maxMs = 5000;
+        for (int waited = 0; waited < maxMs; waited += sliceMs) {
+            if (state->done.wait(sliceMs))
+                return state->status;
+            if (shouldStop_.load())
+                return "cancelled";
+        }
+        return "apply timed out";
+    }
+
+    void requestCancel() override {
+        shouldStop_ = true;
+        agent_.requestCancel();
+    }
+
+  private:
+    StepSequencerAgent agent_;
+};
+
 }  // namespace
 
 std::unique_ptr<SoundDesignAgent> createSoundDesignAgentFor(const juce::String& pluginId) {
     switch (internalPluginFromId(pluginId)) {
         case InternalPlugin::FourOsc:
             return std::make_unique<FourOscSoundDesignAgent>();
+        case InternalPlugin::PolyStepSequencer:
+            return std::make_unique<PolyStepSequencerSoundDesignAgent>();
+        case InternalPlugin::StepSequencer:
+            return std::make_unique<StepSequencerSoundDesignAgent>();
         default:
             return nullptr;
     }

--- a/magda/agents/step_sequencer_agent.cpp
+++ b/magda/agents/step_sequencer_agent.cpp
@@ -1,0 +1,360 @@
+#include "step_sequencer_agent.hpp"
+
+#include "../daw/core/Config.hpp"
+#include "llm_client_factory.hpp"
+#include "llm_presets.hpp"
+
+namespace magda {
+
+// ============================================================================
+// System prompt
+// ============================================================================
+//
+// StepClock::Rate enum values (for the `rate` field):
+//   0 = DottedQuarter  (dotted 1/4)
+//   1 = Quarter        (1/4)
+//   2 = TripletQuarter (1/4T)
+//   3 = DottedEighth   (dotted 1/8)
+//   4 = Eighth         (1/8)
+//   5 = TripletEighth  (1/8T)
+//   6 = DottedSixteenth (dotted 1/16)
+//   7 = Sixteenth      (1/16)    <-- most common default
+//   8 = TripletSixteenth (1/16T)
+//   9 = ThirtySecond   (1/32)
+
+const char* StepSequencerAgent::getSystemPrompt() {
+    return R"PROMPT(You are a pattern designer for the MAGDA built-in mono Step Sequencer (303-style).
+Given a user description, produce a single step-sequencer pattern as JSON. Output ONLY the JSON
+object -- no prose, no markdown fences.
+
+The Step Sequencer is monophonic: each step plays one note at a time, with accent, glide (slide),
+and tie controls. It is designed for acid basslines, melodic sequences, and arpeggios. Steps fire
+on tempo-synced beats.
+
+OUTPUT SCHEMA:
+{
+  "description": "<one short line describing the pattern>",
+  "numSteps": <1-32, integer, OPTIONAL -- omit to keep the current value>,
+  "rate": <0-9, integer, OPTIONAL -- omit to keep the current value>,
+  "swing": <0.0-1.0, float, OPTIONAL -- omit to keep the current value>,
+  "gateLength": <0.0-1.0, float, OPTIONAL -- omit to keep the current value>,
+  "steps": [
+    {
+      "index": <0-based integer>,
+      "note": <0-127 MIDI note number>,
+      "octave": <-2 to +2, integer, applied on top of note>,
+      "gate": <true|false>,
+      "accent": <true|false, optional, default false>,
+      "glide": <true|false, optional, default false>,
+      "tie": <true|false, optional, default false>
+    }
+  ]
+}
+
+RATE TABLE (use the integer, not the string):
+  0  = dotted 1/4  (slow, half-bar feel)
+  1  = 1/4         (quarter notes)
+  2  = 1/4T        (quarter note triplets)
+  3  = dotted 1/8
+  4  = 1/8         (eighth notes)
+  5  = 1/8T        (eighth triplets)
+  6  = dotted 1/16
+  7  = 1/16        (sixteenth notes -- DEFAULT for most patterns)
+  8  = 1/16T       (sixteenth triplets)
+  9  = 1/32        (thirty-second notes, very fast)
+
+STEPS RULES:
+- Emit ALL numSteps steps. Every step in 0..(numSteps-1) must appear in the array.
+- `gate: true` means the step plays a note. `gate: false` is a rest -- include it.
+- `note` is the base MIDI note number (0-127). C4 = 60, D4 = 62, E4 = 64, F4 = 65,
+  G4 = 67, A4 = 69, B4 = 71, C3 = 48, C2 = 36.
+- `octave` is an additional shift of -2 to +2 octaves (12 semitones per octave).
+  Keep octave at 0 unless the user asks for wide range. The effective MIDI note
+  is note + octave * 12 (clamped to 0-127).
+- `accent: true` flags a step as accented (louder velocity). Use for rhythmic emphasis.
+- `glide: true` applies portamento: the previous note slides into this step's pitch.
+  Classic in acid basslines. Glide and tie are mutually exclusive.
+- `tie: true` extends the previous step's note without retriggering. Use for sustained
+  notes across adjacent steps. Tie and glide are mutually exclusive.
+- For rest steps, set gate=false and any convenient note value (it won't sound).
+
+numSteps GUIDELINES:
+- 16 steps at 1/16 rate = one bar (most common)
+- 8 steps at 1/16 rate = half bar
+- 32 steps at 1/16 rate = two bars
+
+swing: 0.0 = straight. 0.5 = heavy swing. 0.1-0.2 = light shuffle.
+gateLength: 0.1 = very staccato. 0.5 = moderate. 0.9 = near-legato.
+  For acid basslines use 0.3-0.5; add glide separately where needed.
+
+DEVICE CONTEXT (may be appended after this prompt):
+When a "DEVICE CONTEXT:" block is appended, it shows the current device settings.
+
+PRESERVING CURRENT SETTINGS:
+- The "currentSettings:" line shows the live values for numSteps, rate, swing,
+  and gateLength.
+- PRESERVE all of these unless the user's prompt explicitly implies changing
+  them (e.g. "make it 8 steps", "use eighth notes", "add swing", "double time").
+- To preserve a value, simply OMIT that field from your JSON output. The apply
+  code will leave the device value unchanged when the field is absent.
+- CRITICAL: always write a pattern that spans the full current numSteps. If
+  currentSettings shows numSteps=32, emit all 32 steps (indices 0-31). The mono
+  sequencer requires ALL steps to be listed (no sparse output).
+
+ACID BASSLINE GUIDELINES:
+- Root, fifth, minor seventh, minor third are the classic acid intervals.
+  E.g. in A minor: A2(45) A3(57) E3(52) G2(43) C3(48).
+- Accent beats 1 and 3 (indices 0, 8 in 16-step). Accent random off-beats for energy.
+- Glide on every 2nd or 3rd step creates the characteristic 303 slide.
+- Mix stepwise movement with jumps of a fourth or fifth.
+- Use 1/16 rate (7) and gateLength 0.3-0.5 for the classic staccato feel.
+
+MELODY GUIDELINES:
+- Keep notes within a scale (major, minor, pentatonic).
+- Use rests (gate=false) for rhythmic breathing.
+- Tie adjacent steps for legato phrases.
+- Octave jumps (octave +/-1) add excitement.
+
+EXAMPLES:
+
+User: "classic acid bassline in A minor, 16 steps"
+{"description":"Acid bassline in A minor, 16 steps 1/16","numSteps":16,"rate":7,"swing":0.0,"gateLength":0.4,"steps":[{"index":0,"note":45,"octave":0,"gate":true,"accent":true,"glide":false,"tie":false},{"index":1,"note":45,"octave":0,"gate":true,"accent":false,"glide":true,"tie":false},{"index":2,"note":48,"octave":0,"gate":true,"accent":false,"glide":false,"tie":false},{"index":3,"note":45,"octave":0,"gate":false,"accent":false,"glide":false,"tie":false},{"index":4,"note":52,"octave":0,"gate":true,"accent":true,"glide":false,"tie":false},{"index":5,"note":52,"octave":0,"gate":true,"accent":false,"glide":true,"tie":false},{"index":6,"note":50,"octave":0,"gate":true,"accent":false,"glide":false,"tie":false},{"index":7,"note":48,"octave":0,"gate":true,"accent":false,"glide":false,"tie":false},{"index":8,"note":45,"octave":0,"gate":true,"accent":true,"glide":false,"tie":false},{"index":9,"note":43,"octave":0,"gate":true,"accent":false,"glide":true,"tie":false},{"index":10,"note":45,"octave":0,"gate":true,"accent":false,"glide":false,"tie":false},{"index":11,"note":45,"octave":0,"gate":false,"accent":false,"glide":false,"tie":false},{"index":12,"note":48,"octave":0,"gate":true,"accent":false,"glide":false,"tie":false},{"index":13,"note":50,"octave":0,"gate":true,"accent":false,"glide":true,"tie":false},{"index":14,"note":52,"octave":0,"gate":true,"accent":true,"glide":false,"tie":false},{"index":15,"note":45,"octave":0,"gate":true,"accent":false,"glide":false,"tie":false}]}
+
+User: "simple 8-step C major melody"
+{"description":"Simple C major melody, 8 steps 1/8","numSteps":8,"rate":4,"swing":0.0,"gateLength":0.6,"steps":[{"index":0,"note":60,"octave":0,"gate":true,"accent":true,"glide":false,"tie":false},{"index":1,"note":62,"octave":0,"gate":true,"accent":false,"glide":false,"tie":false},{"index":2,"note":64,"octave":0,"gate":true,"accent":false,"glide":false,"tie":false},{"index":3,"note":65,"octave":0,"gate":false,"accent":false,"glide":false,"tie":false},{"index":4,"note":67,"octave":0,"gate":true,"accent":true,"glide":false,"tie":false},{"index":5,"note":67,"octave":0,"gate":true,"accent":false,"glide":false,"tie":true},{"index":6,"note":64,"octave":0,"gate":true,"accent":false,"glide":false,"tie":false},{"index":7,"note":60,"octave":0,"gate":true,"accent":false,"glide":false,"tie":false}]}
+)PROMPT";
+}
+
+// ============================================================================
+// JSON parser
+// ============================================================================
+
+StepSequencerAgent::Preset StepSequencerAgent::parseJson(const juce::String& text,
+                                                         std::string& outError) {
+    Preset preset;
+
+    // Strip LLM markdown fences if present.
+    juce::String trimmed = text.trim();
+    if (trimmed.startsWith("```")) {
+        auto firstNewline = trimmed.indexOf("\n");
+        if (firstNewline > 0)
+            trimmed = trimmed.substring(firstNewline + 1);
+        if (trimmed.endsWith("```"))
+            trimmed = trimmed.dropLastCharacters(3).trim();
+    }
+
+    auto parsed = juce::JSON::parse(trimmed);
+    auto* obj = parsed.getDynamicObject();
+    if (obj == nullptr) {
+        outError = "preset JSON must be an object";
+        return preset;
+    }
+
+    if (auto desc = obj->getProperty("description"); desc.isString())
+        preset.description = desc.toString().toStdString();
+
+    if (auto ns = obj->getProperty("numSteps"); ns.isInt() || ns.isDouble())
+        preset.numSteps = juce::jlimit(1, 32, static_cast<int>(static_cast<double>(ns)));
+
+    if (auto r = obj->getProperty("rate"); r.isInt() || r.isDouble())
+        preset.rate = juce::jlimit(0, 9, static_cast<int>(static_cast<double>(r)));
+
+    if (auto sw = obj->getProperty("swing"); sw.isDouble() || sw.isInt())
+        preset.swing = juce::jlimit(0.0f, 1.0f, static_cast<float>(static_cast<double>(sw)));
+
+    if (auto gl = obj->getProperty("gateLength"); gl.isDouble() || gl.isInt())
+        preset.gateLength = juce::jlimit(0.0f, 1.0f, static_cast<float>(static_cast<double>(gl)));
+
+    // Parse steps array.
+    auto stepsVar = obj->getProperty("steps");
+    if (!stepsVar.isArray()) {
+        outError = "preset JSON missing 'steps' array";
+        return preset;
+    }
+
+    auto* stepsArr = stepsVar.getArray();
+    if (stepsArr == nullptr) {
+        outError = "preset JSON 'steps' is null";
+        return preset;
+    }
+
+    for (const auto& stepVar : *stepsArr) {
+        auto* stepObj = stepVar.getDynamicObject();
+        if (stepObj == nullptr)
+            continue;
+
+        StepSpec step;
+
+        auto idxVar = stepObj->getProperty("index");
+        if (!idxVar.isInt() && !idxVar.isDouble())
+            continue;  // index is required
+        step.index = juce::jlimit(0, 31, static_cast<int>(static_cast<double>(idxVar)));
+
+        if (auto n = stepObj->getProperty("note"); n.isInt() || n.isDouble())
+            step.noteNumber = juce::jlimit(0, 127, static_cast<int>(static_cast<double>(n)));
+
+        if (auto o = stepObj->getProperty("octave"); o.isInt() || o.isDouble())
+            step.octaveShift = juce::jlimit(-2, 2, static_cast<int>(static_cast<double>(o)));
+
+        if (auto g = stepObj->getProperty("gate"); g.isBool() || g.isInt())
+            step.gate = static_cast<bool>(g);
+        else
+            step.gate = true;
+
+        if (auto a = stepObj->getProperty("accent"); a.isBool() || a.isInt())
+            step.accent = static_cast<bool>(a);
+
+        if (auto gl = stepObj->getProperty("glide"); gl.isBool() || gl.isInt())
+            step.glide = static_cast<bool>(gl);
+
+        if (auto t = stepObj->getProperty("tie"); t.isBool() || t.isInt())
+            step.tie = static_cast<bool>(t);
+
+        preset.steps.push_back(std::move(step));
+    }
+
+    return preset;
+}
+
+// ============================================================================
+// LLM call
+// ============================================================================
+
+namespace {
+
+void logStepAgentConfig(const Config::AgentLLMConfig& agentConfig, const llm::ProviderConfig& pc) {
+    DBG("MAGDA StepSequencerAgent config:");
+    DBG("  provider (string) = " + juce::String(agentConfig.provider));
+    DBG("  provider (enum)   = " + juce::String(static_cast<int>(pc.provider)));
+    DBG("  model             = " + pc.model);
+    DBG("  baseUrl           = " + pc.baseUrl);
+    DBG("  apiKey present    = " + juce::String(pc.apiKey.isNotEmpty() ? "yes" : "NO"));
+    DBG("  noTemperature     = " + juce::String(pc.noTemperature ? "yes" : "no"));
+}
+
+void logStepAgentResult(const StepSequencerAgent::GenerateResult& result) {
+    DBG("MAGDA StepSequencerAgent raw output (" +
+        juce::String(static_cast<int>(result.rawOutput.size())) + " chars):");
+    DBG("---8<---");
+    DBG(juce::String(result.rawOutput));
+    DBG("--->8---");
+    DBG("MAGDA StepSequencerAgent parsed: description='" + juce::String(result.preset.description) +
+        "' steps=" + juce::String(static_cast<int>(result.preset.steps.size())));
+    if (!result.error.empty())
+        DBG("MAGDA StepSequencerAgent ERROR: " + juce::String(result.error));
+}
+
+}  // namespace
+
+StepSequencerAgent::GenerateResult StepSequencerAgent::generate(const std::string& message,
+                                                                const std::string& deviceContext) {
+    GenerateResult result;
+
+    if (shouldStop_.load()) {
+        result.error = "Cancelled";
+        result.hasError = true;
+        return result;
+    }
+
+    auto agentConfig = Config::getInstance().getAgentLLMConfig(role::MUSIC);
+    auto providerConfig = toLLMProviderConfig(agentConfig, "step_sequencer");
+    logStepAgentConfig(agentConfig, providerConfig);
+
+    if (providerConfig.apiKey.isEmpty() && agentConfig.baseUrl.empty() &&
+        agentConfig.provider != provider::LLAMA_LOCAL) {
+        result.error = "Step Sequencer agent API key not configured.";
+        result.hasError = true;
+        return result;
+    }
+
+    auto client = createLLMClient(agentConfig, "step_sequencer");
+
+    llm::Request request;
+    auto systemPrompt = juce::String::fromUTF8(getSystemPrompt());
+    if (!deviceContext.empty())
+        systemPrompt += "\n\n" + juce::String::fromUTF8(deviceContext.c_str());
+    request.systemPrompt = systemPrompt;
+    request.userMessage = juce::String::fromUTF8(message.c_str());
+    request.temperature = 0.5f;  // some creativity for patterns
+
+    auto response = client->sendRequest(request);
+    if (!response.success) {
+        result.error = response.error.toStdString();
+        result.hasError = true;
+        return result;
+    }
+
+    auto trimmedText = response.text.trim();
+    result.rawOutput = trimmedText.toStdString();
+
+    std::string parseError;
+    result.preset = parseJson(trimmedText, parseError);
+    if (!parseError.empty()) {
+        result.error = parseError;
+        result.hasError = true;
+    }
+
+    logStepAgentResult(result);
+    return result;
+}
+
+StepSequencerAgent::GenerateResult StepSequencerAgent::generateStreaming(
+    const std::string& message, TokenCallback onToken, const std::string& deviceContext) {
+    GenerateResult result;
+
+    if (shouldStop_.load()) {
+        result.error = "Cancelled";
+        result.hasError = true;
+        return result;
+    }
+
+    auto agentConfig = Config::getInstance().getAgentLLMConfig(role::MUSIC);
+    auto providerConfig = toLLMProviderConfig(agentConfig, "step_sequencer");
+    logStepAgentConfig(agentConfig, providerConfig);
+
+    if (providerConfig.apiKey.isEmpty() && agentConfig.baseUrl.empty() &&
+        agentConfig.provider != provider::LLAMA_LOCAL) {
+        result.error = "Step Sequencer agent API key not configured.";
+        result.hasError = true;
+        return result;
+    }
+
+    auto client = createLLMClient(agentConfig, "step_sequencer");
+
+    llm::Request request;
+    auto systemPromptStr = juce::String::fromUTF8(getSystemPrompt());
+    if (!deviceContext.empty())
+        systemPromptStr += "\n\n" + juce::String::fromUTF8(deviceContext.c_str());
+    request.systemPrompt = systemPromptStr;
+    request.userMessage = juce::String::fromUTF8(message.c_str());
+    request.temperature = 0.5f;
+
+    auto response = client->sendStreamingRequest(request, [&](const juce::String& token) {
+        if (shouldStop_.load())
+            return false;
+        if (onToken)
+            return onToken(token);
+        return true;
+    });
+
+    if (!response.success) {
+        result.error = response.error.toStdString();
+        result.hasError = true;
+        return result;
+    }
+
+    auto trimmedText = response.text.trim();
+    result.rawOutput = trimmedText.toStdString();
+
+    std::string parseError;
+    result.preset = parseJson(trimmedText, parseError);
+    if (!parseError.empty()) {
+        result.error = parseError;
+        result.hasError = true;
+    }
+
+    logStepAgentResult(result);
+    return result;
+}
+
+}  // namespace magda

--- a/magda/agents/step_sequencer_agent.hpp
+++ b/magda/agents/step_sequencer_agent.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <atomic>
+#include <string>
+#include <vector>
+
+#include "compact_parser.hpp"  // for TokenCallback
+
+namespace magda {
+
+/**
+ * @brief Mono (303-style) Step Sequencer AI agent -- generates a single pattern from a prompt.
+ *
+ * The LLM is instructed to emit a JSON object describing a pattern for the
+ * built-in mono Step Sequencer device. Each step carries note, octave shift,
+ * gate, accent, glide, and tie. Global settings (numSteps, rate, swing,
+ * gateLength) are also included.
+ *
+ * Reuses role::MUSIC for the LLM config so users don't need separate API
+ * credentials for this device.
+ */
+class StepSequencerAgent {
+  public:
+    struct StepSpec {
+        int index = 0;        // Step index 0-based
+        int noteNumber = 60;  // MIDI note 0-127
+        int octaveShift = 0;  // -2 to +2, applied on top of noteNumber
+        bool gate = true;     // true = active, false = rest
+        bool accent = false;
+        bool glide = false;  // Portamento slide to next note
+        bool tie = false;    // Extend previous note without retrigger
+    };
+
+    struct Preset {
+        std::string description;      // one-line summary shown in panel
+        int numSteps = -1;            // 1-32; -1 = leave unchanged (absent from JSON)
+        int rate = -1;                // StepClock::Rate enum value; -1 = leave unchanged
+        float swing = -1.0f;          // 0-1; negative = leave unchanged
+        float gateLength = -1.0f;     // 0-1; negative = leave unchanged
+        std::vector<StepSpec> steps;  // all current numSteps steps must be present
+    };
+
+    struct GenerateResult {
+        std::string rawOutput;  // raw LLM text, kept for diagnostics
+        Preset preset;
+        std::string error;
+        bool hasError = false;
+    };
+
+    /** Generate a pattern from a user prompt (background-thread safe).
+     *  deviceContext is an optional string appended to the system prompt to
+     *  convey the current device settings. */
+    GenerateResult generate(const std::string& message, const std::string& deviceContext = {});
+
+    /** Streaming variant -- onToken fires per token. The parsed Preset is
+     *  only available once streaming completes (JSON must land whole before
+     *  parsing). */
+    GenerateResult generateStreaming(const std::string& message, TokenCallback onToken,
+                                     const std::string& deviceContext = {});
+
+    void requestCancel() {
+        shouldStop_ = true;
+    }
+    void resetCancel() {
+        shouldStop_ = false;
+    }
+
+  private:
+    static const char* getSystemPrompt();
+
+    /** Parse a JSON string into a Preset. Returns empty Preset + sets
+     *  outError on malformed input. Tolerant of LLM markdown fences
+     *  ("```json ... ```") around the payload. */
+    Preset parseJson(const juce::String& text, std::string& outError);
+
+    std::atomic<bool> shouldStop_{false};
+};
+
+}  // namespace magda

--- a/magda/agents/step_sequencer_apply.cpp
+++ b/magda/agents/step_sequencer_apply.cpp
@@ -1,0 +1,98 @@
+#include "step_sequencer_apply.hpp"
+
+#include "audio/AudioBridge.hpp"
+#include "audio/plugins/StepSequencerPlugin.hpp"
+#include "core/PresetManager.hpp"
+#include "core/TrackManager.hpp"
+#include "engine/AudioEngine.hpp"
+#include "internal_plugins.hpp"
+
+namespace magda {
+
+juce::String applyStepSequencerPresetToPath(const StepSequencerAgent::Preset& preset,
+                                            const ChainNodePath& path) {
+    auto& tm = TrackManager::getInstance();
+    auto* device = tm.getDeviceInChainByPath(path);
+    if (device == nullptr ||
+        internalPluginFromId(device->pluginId) != InternalPlugin::StepSequencer)
+        return "(target device is not a Step Sequencer)";
+
+    // Reach the live plugin via AudioBridge.
+    auto* engine = tm.getAudioEngine();
+    auto* bridge = engine ? engine->getAudioBridge() : nullptr;
+    auto plugin = bridge ? bridge->getPlugin(path) : nullptr;
+    auto* seq = dynamic_cast<daw::audio::StepSequencerPlugin*>(plugin.get());
+    if (seq == nullptr)
+        return "(could not resolve live StepSequencerPlugin)";
+
+    // --- Write global settings ---
+    // CachedValues backed by the plugin's state ValueTree.
+    // Pass the plugin's UndoManager so globals are undo-trackable alongside
+    // the step writes below.
+    auto* um = seq->getUndoManager();
+
+    if (preset.numSteps >= 1)
+        seq->state.setProperty(juce::Identifier("seqNumSteps"), preset.numSteps, um);
+
+    if (preset.rate >= 0)
+        seq->state.setProperty(juce::Identifier("seqRate"), preset.rate, um);
+
+    if (preset.swing >= 0.0f)
+        seq->state.setProperty(juce::Identifier("seqSwing"), preset.swing, um);
+
+    if (preset.gateLength >= 0.0f)
+        seq->state.setProperty(juce::Identifier("seqGateLength"), preset.gateLength, um);
+
+    // --- Clear all existing steps ---
+    // When numSteps is absent from the preset (sentinel -1), read the live value
+    // so we clear exactly the current active window, not a hardcoded default.
+    const int numStepsToClear =
+        juce::jlimit(1, daw::audio::StepSequencerPlugin::MAX_STEPS,
+                     preset.numSteps >= 1 ? preset.numSteps : seq->numSteps.get());
+    for (int i = 0; i < numStepsToClear; ++i)
+        seq->clearStep(i);
+
+    // --- Write pattern steps ---
+    int stepsWritten = 0;
+    for (const auto& step : preset.steps) {
+        if (step.index < 0 || step.index >= daw::audio::StepSequencerPlugin::MAX_STEPS)
+            continue;
+
+        // clearStep above reset everything to defaults (gate=true, note=60,
+        // octave=0, accent=false, glide=false, tie=false). Only set fields
+        // that differ from those defaults.
+        seq->setStepGate(step.index, step.gate);
+
+        if (step.noteNumber != 60)
+            seq->setStepNote(step.index, step.noteNumber);
+
+        if (step.octaveShift != 0)
+            seq->setStepOctaveShift(step.index, step.octaveShift);
+
+        if (step.accent)
+            seq->setStepAccent(step.index, true);
+
+        if (step.glide)
+            seq->setStepGlide(step.index, true);
+
+        if (step.tie)
+            seq->setStepTie(step.index, true);
+
+        ++stepsWritten;
+    }
+
+    // Capture the mutated live plugin state into MAGDA's DeviceInfo so a
+    // later syncTrackPlugins doesn't re-push stale state. Same approach as
+    // poly_step_sequencer_apply.
+    if (bridge)
+        bridge->getPluginManager().capturePluginState(path);
+
+    // Stash the pattern description as the suggested preset name.
+    if (!preset.description.empty())
+        PresetManager::getInstance().setSuggestedPresetName(device->id,
+                                                            juce::String(preset.description));
+
+    return "applied " + juce::String(stepsWritten) + " step(s) to " + device->name;
+}
+
+}  // namespace magda

--- a/magda/agents/step_sequencer_apply.hpp
+++ b/magda/agents/step_sequencer_apply.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include "core/ChainNodePath.hpp"
+#include "step_sequencer_agent.hpp"
+
+namespace magda {
+
+/**
+ * @brief Apply a parsed StepSequencer preset to a specific device path.
+ *
+ * Sets global parameters (numSteps, rate, swing, gateLength) via the
+ * plugin's CachedValues, then writes each step via the plugin's public
+ * setters (setStepNote / setStepOctaveShift / setStepGate / setStepAccent /
+ * setStepGlide / setStepTie / clearStep).
+ *
+ * Must be called on the message thread (TE asserts this for ValueTree
+ * writes). The SoundDesignAgent wrapper handles the thread hop.
+ *
+ * Returns a one-line status (e.g. "applied 16 steps to Step Sequencer") or
+ * an error string starting with "()" if the path doesn't resolve to a
+ * StepSequencerPlugin.
+ */
+juce::String applyStepSequencerPresetToPath(const StepSequencerAgent::Preset& preset,
+                                            const ChainNodePath& path);
+
+}  // namespace magda

--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -349,6 +349,7 @@ target_sources(magda_daw PRIVATE
     plugins/FaustParamInfo.cpp
     transport/StepClock.cpp
     plugins/StepSequencerPlugin.cpp
+    plugins/PolyStepSequencerPlugin.cpp
     # Controller routing (issue #1050 -- Phase C)
     controllers/ControllerParamWriter.cpp
     controllers/ControllerRouter.cpp
@@ -402,6 +403,7 @@ target_sources(magda_daw PRIVATE
     plugins/FaustParamInfo.hpp
     transport/StepClock.hpp
     plugins/StepSequencerPlugin.hpp
+    plugins/PolyStepSequencerPlugin.hpp
 )
 
 target_sources(magda_daw_app PRIVATE

--- a/magda/daw/audio/plugins/InternalPluginRegistry.cpp
+++ b/magda/daw/audio/plugins/InternalPluginRegistry.cpp
@@ -10,6 +10,7 @@
 #include "plugins/MidiChordEnginePlugin.hpp"
 #include "plugins/MidiReceivePlugin.hpp"
 #include "plugins/OscilloscopePlugin.hpp"
+#include "plugins/PolyStepSequencerPlugin.hpp"
 #include "plugins/SidechainMonitorPlugin.hpp"
 #include "plugins/SpectrumAnalyzerPlugin.hpp"
 #include "plugins/StepSequencerPlugin.hpp"
@@ -125,6 +126,10 @@ const InternalPluginSpec kSpecs[] = {
      "MIDI step sequencer for pattern-driven notes and rhythmic control.",
      InternalPluginCreateMode::SavedStateOrFresh, true, true, nullptr, 0,
      matches<StepSequencerPlugin>, makeProcessor<StepSequencerProcessor>, true},
+    {InternalDeviceKind::PolyStepSequencer, PolyStepSequencerPlugin::xmlTypeName, "Poly Sequencer",
+     "MIDI", "Polyphonic MIDI step sequencer with multiple notes per step for chord patterns.",
+     InternalPluginCreateMode::SavedStateOrFresh, true, true, nullptr, 0,
+     matches<PolyStepSequencerPlugin>, makeProcessor<PolyStepSequencerProcessor>, true},
     {InternalDeviceKind::Faust, FaustPlugin::xmlTypeName, "Faust", "Experimental",
      "Interpreted Faust device for loading and editing user DSP code.",
      InternalPluginCreateMode::SavedStateOrFresh, true, true, nullptr, 0, matches<FaustPlugin>,
@@ -168,10 +173,11 @@ const InternalPluginSpec kSpecs[] = {
 };
 
 const InternalPluginSpec* const kSpecPtrs[] = {
-    &kSpecs[0],  &kSpecs[1],  &kSpecs[2],  &kSpecs[3],  &kSpecs[4],  &kSpecs[5],  &kSpecs[6],
-    &kSpecs[7],  &kSpecs[8],  &kSpecs[9],  &kSpecs[10], &kSpecs[11], &kSpecs[12], &kSpecs[13],
-    &kSpecs[14], &kSpecs[15], &kSpecs[16], &kSpecs[17], &kSpecs[18], &kSpecs[19], &kSpecs[20],
-    &kSpecs[21], &kSpecs[22], &kSpecs[23], &kSpecs[24], &kSpecs[25], &kSpecs[26], &kSpecs[27],
+    &kSpecs[0],  &kSpecs[1],  &kSpecs[2],  &kSpecs[3],  &kSpecs[4],  &kSpecs[5],
+    &kSpecs[6],  &kSpecs[7],  &kSpecs[8],  &kSpecs[9],  &kSpecs[10], &kSpecs[11],
+    &kSpecs[12], &kSpecs[13], &kSpecs[14], &kSpecs[15], &kSpecs[16], &kSpecs[17],
+    &kSpecs[18], &kSpecs[19], &kSpecs[20], &kSpecs[21], &kSpecs[22], &kSpecs[23],
+    &kSpecs[24], &kSpecs[25], &kSpecs[26], &kSpecs[27], &kSpecs[28],
 };
 
 bool typeMatchesAlias(const juce::String& type, const InternalPluginSpec& spec) {

--- a/magda/daw/audio/plugins/PolyStepSequencerPlugin.cpp
+++ b/magda/daw/audio/plugins/PolyStepSequencerPlugin.cpp
@@ -1,0 +1,619 @@
+#include "plugins/PolyStepSequencerPlugin.hpp"
+
+namespace magda::daw::audio {
+
+const char* PolyStepSequencerPlugin::xmlTypeName = "polystepsequencer";
+
+// ValueTree property IDs
+namespace PSeqIDs {
+static const juce::Identifier numSteps("seqNumSteps");
+static const juce::Identifier rate("seqRate");
+static const juce::Identifier direction("seqDirection");
+static const juce::Identifier swing("seqSwing");
+static const juce::Identifier gateLength("seqGateLength");
+static const juce::Identifier ramp("seqRamp");
+static const juce::Identifier skew("seqSkew");
+static const juce::Identifier rampCycles("seqRampCycles");
+static const juce::Identifier hardAngle("seqHardAngle");
+static const juce::Identifier quantize("seqQuantize");
+static const juce::Identifier quantizeSub("seqQuantizeSub");
+static const juce::Identifier midiThru("seqMidiThru");
+static const juce::Identifier viewMode("seqViewMode");
+
+// Per-step child tree
+static const juce::Identifier stepTree("STEP");
+static const juce::Identifier stepIndex("idx");
+static const juce::Identifier stepGate("gate");
+static const juce::Identifier stepTie("tie");
+static const juce::Identifier stepProb("prob");
+static const juce::Identifier stepVel("vel");
+
+// Per-note child tree (inside STEP)
+static const juce::Identifier noteTree("NOTE");
+static const juce::Identifier noteNumber("note");
+static const juce::Identifier noteVel("vel");
+}  // namespace PSeqIDs
+
+PolyStepSequencerPlugin::PolyStepSequencerPlugin(const te::PluginCreationInfo& info)
+    : MidiDevicePlugin(info) {
+    auto um = getUndoManager();
+    numSteps.referTo(state, PSeqIDs::numSteps, um, 16);
+    rate.referTo(state, PSeqIDs::rate, um, static_cast<int>(StepClock::Rate::Sixteenth));
+    direction.referTo(state, PSeqIDs::direction, um,
+                      static_cast<int>(StepClock::Direction::Forward));
+    swing.referTo(state, PSeqIDs::swing, um, 0.0f);
+    gateLength.referTo(state, PSeqIDs::gateLength, um, 0.8f);
+    ramp.referTo(state, PSeqIDs::ramp, um, 0.0f);
+    skew.referTo(state, PSeqIDs::skew, um, 0.0f);
+    rampCycles.referTo(state, PSeqIDs::rampCycles, um, 1);
+    hardAngle.referTo(state, PSeqIDs::hardAngle, um, false);
+    quantize.referTo(state, PSeqIDs::quantize, um, 0.0f);
+    quantizeSub.referTo(state, PSeqIDs::quantizeSub, um, 16);
+    midiThru.referTo(state, PSeqIDs::midiThru, um, false);
+    viewMode.referTo(state, PSeqIDs::viewMode, um, "keys");
+
+    // Register automatable parameters for macro/mod linking
+    rateParam = addParam("rate", "Rate", {0.0f, 9.0f, 1.0f});
+    directionParam = addParam("direction", "Direction", {0.0f, 3.0f, 1.0f});
+    swingParam = addParam("swing", "Swing", {0.0f, 1.0f});
+    gateLengthParam = addParam("gatelength", "Gate", {0.05f, 1.0f});
+    rampParam = addParam("ramp", "Timing Depth", {-1.0f, 1.0f});
+    skewParam = addParam("skew", "Timing Skew", {-1.0f, 1.0f});
+
+    // Initialize automatable params from CachedValues
+    rateParam->setParameterFromHost(static_cast<float>(rate.get()), juce::dontSendNotification);
+    directionParam->setParameterFromHost(static_cast<float>(direction.get()),
+                                         juce::dontSendNotification);
+    swingParam->setParameterFromHost(swing.get(), juce::dontSendNotification);
+    gateLengthParam->setParameterFromHost(gateLength.get(), juce::dontSendNotification);
+    rampParam->setParameterFromHost(ramp.get(), juce::dontSendNotification);
+    skewParam->setParameterFromHost(skew.get(), juce::dontSendNotification);
+
+    // Listen for state changes: param sync + pattern mirror (incl. undo/redo)
+    state.addListener(&stateListener_);
+
+    // Mirror steps from ValueTree (if restoring from saved state)
+    loadStepsFromState();
+}
+
+PolyStepSequencerPlugin::~PolyStepSequencerPlugin() {
+    state.removeListener(&stateListener_);
+}
+
+void PolyStepSequencerPlugin::StateListener::valueTreePropertyChanged(
+    juce::ValueTree& tree, const juce::Identifier& property) {
+    if (tree == owner.state)
+        owner.syncParamFromProperty(property);
+    else if (tree.hasType(PSeqIDs::stepTree) || tree.hasType(PSeqIDs::noteTree))
+        owner.loadStepsFromState();
+}
+
+void PolyStepSequencerPlugin::StateListener::valueTreeChildAdded(juce::ValueTree&,
+                                                                 juce::ValueTree& child) {
+    if (child.hasType(PSeqIDs::stepTree) || child.hasType(PSeqIDs::noteTree))
+        owner.loadStepsFromState();
+}
+
+void PolyStepSequencerPlugin::StateListener::valueTreeChildRemoved(juce::ValueTree&,
+                                                                   juce::ValueTree& child, int) {
+    if (child.hasType(PSeqIDs::stepTree) || child.hasType(PSeqIDs::noteTree))
+        owner.loadStepsFromState();
+}
+
+void PolyStepSequencerPlugin::syncParamFromProperty(const juce::Identifier& property) {
+    if (property == PSeqIDs::rate && rateParam)
+        rateParam->setParameterFromHost(static_cast<float>(rate.get()), juce::dontSendNotification);
+    else if (property == PSeqIDs::direction && directionParam)
+        directionParam->setParameterFromHost(static_cast<float>(direction.get()),
+                                             juce::dontSendNotification);
+    else if (property == PSeqIDs::swing && swingParam)
+        swingParam->setParameterFromHost(swing.get(), juce::dontSendNotification);
+    else if (property == PSeqIDs::gateLength && gateLengthParam)
+        gateLengthParam->setParameterFromHost(gateLength.get(), juce::dontSendNotification);
+    else if (property == PSeqIDs::ramp && rampParam)
+        rampParam->setParameterFromHost(ramp.get(), juce::dontSendNotification);
+    else if (property == PSeqIDs::skew && skewParam)
+        skewParam->setParameterFromHost(skew.get(), juce::dontSendNotification);
+}
+
+void PolyStepSequencerPlugin::initialise(const te::PluginInitialisationInfo& info) {
+    MidiDevicePlugin::initialise(info);
+    sampleRate_ = info.sampleRate;
+    stepClock_.setSampleRate(info.sampleRate);
+    stepClock_.reset();
+    soundingCount_ = 0;
+    noteOffCountdown_ = 0;
+    silentBlockCount_ = 0;
+    needsAllNotesOff_ = true;
+}
+
+void PolyStepSequencerPlugin::deinitialise() {
+    stepClock_.reset();
+    soundingCount_ = 0;
+    noteOffCountdown_ = 0;
+    silentBlockCount_ = 0;
+    currentPlayStep_.store(-1, std::memory_order_relaxed);
+    MidiDevicePlugin::deinitialise();
+}
+
+void PolyStepSequencerPlugin::reset() {
+    stepClock_.reset();
+    soundingCount_ = 0;
+    noteOffCountdown_ = 0;
+    currentPlayStep_.store(-1, std::memory_order_relaxed);
+    clearMidiOutDisplay();
+}
+
+void PolyStepSequencerPlugin::restorePluginStateFromValueTree(const juce::ValueTree& v) {
+    tracktion::copyPropertiesToCachedValues(v, numSteps, rate, direction, swing, gateLength, ramp,
+                                            skew, rampCycles, hardAngle, quantize, quantizeSub,
+                                            midiThru, viewMode);
+
+    // Copy step children from the incoming tree into our state
+    // (copyPropertiesToCachedValues only copies properties, not children)
+    for (int i = state.getNumChildren() - 1; i >= 0; --i) {
+        if (state.getChild(i).hasType(PSeqIDs::stepTree))
+            state.removeChild(i, nullptr);
+    }
+    for (int i = 0; i < v.getNumChildren(); ++i) {
+        auto child = v.getChild(i);
+        if (child.hasType(PSeqIDs::stepTree))
+            state.appendChild(child.createCopy(), nullptr);
+    }
+
+    loadStepsFromState();
+}
+
+// =============================================================================
+// Pattern accessors (message thread)
+// =============================================================================
+
+juce::ValueTree PolyStepSequencerPlugin::findStepTree(int index) const {
+    for (int i = 0; i < state.getNumChildren(); ++i) {
+        auto child = state.getChild(i);
+        if (child.hasType(PSeqIDs::stepTree) &&
+            static_cast<int>(child.getProperty(PSeqIDs::stepIndex, -1)) == index)
+            return child;
+    }
+    return {};
+}
+
+juce::ValueTree PolyStepSequencerPlugin::getOrCreateStepTree(int index) {
+    auto existing = findStepTree(index);
+    if (existing.isValid())
+        return existing;
+
+    juce::ValueTree stepVT(PSeqIDs::stepTree);
+    stepVT.setProperty(PSeqIDs::stepIndex, index, nullptr);
+    stepVT.setProperty(PSeqIDs::stepGate, true, nullptr);
+    stepVT.setProperty(PSeqIDs::stepTie, false, nullptr);
+    stepVT.setProperty(PSeqIDs::stepProb, 1.0f, nullptr);
+    stepVT.setProperty(PSeqIDs::stepVel, 100, nullptr);
+    state.appendChild(stepVT, getUndoManager());
+    return stepVT;
+}
+
+juce::ValueTree PolyStepSequencerPlugin::findNoteTree(const juce::ValueTree& stepTree,
+                                                      int noteNumber) {
+    for (int i = 0; i < stepTree.getNumChildren(); ++i) {
+        auto child = stepTree.getChild(i);
+        if (child.hasType(PSeqIDs::noteTree) &&
+            static_cast<int>(child.getProperty(PSeqIDs::noteNumber, -1)) == noteNumber)
+            return child;
+    }
+    return {};
+}
+
+PolyStepSequencerPlugin::Step PolyStepSequencerPlugin::getStep(int index) const {
+    if (index < 0 || index >= MAX_STEPS)
+        return {};
+    return steps_[static_cast<size_t>(index)];
+}
+
+bool PolyStepSequencerPlugin::stepHasNote(int index, int noteNumber) const {
+    if (index < 0 || index >= MAX_STEPS)
+        return false;
+    const auto& step = steps_[static_cast<size_t>(index)];
+    for (int i = 0; i < step.noteCount; ++i) {
+        if (step.notes[static_cast<size_t>(i)].noteNumber == noteNumber)
+            return true;
+    }
+    return false;
+}
+
+void PolyStepSequencerPlugin::setStepGate(int index, bool gateOn) {
+    if (index < 0 || index >= MAX_STEPS)
+        return;
+    getOrCreateStepTree(index).setProperty(PSeqIDs::stepGate, gateOn, getUndoManager());
+}
+
+void PolyStepSequencerPlugin::setStepTie(int index, bool tieOn) {
+    if (index < 0 || index >= MAX_STEPS)
+        return;
+    getOrCreateStepTree(index).setProperty(PSeqIDs::stepTie, tieOn, getUndoManager());
+}
+
+void PolyStepSequencerPlugin::setStepProbability(int index, float probability) {
+    if (index < 0 || index >= MAX_STEPS)
+        return;
+    getOrCreateStepTree(index).setProperty(PSeqIDs::stepProb, juce::jlimit(0.0f, 1.0f, probability),
+                                           getUndoManager());
+}
+
+void PolyStepSequencerPlugin::setStepVelocity(int index, int velocity) {
+    if (index < 0 || index >= MAX_STEPS)
+        return;
+    getOrCreateStepTree(index).setProperty(PSeqIDs::stepVel, juce::jlimit(1, 127, velocity),
+                                           getUndoManager());
+}
+
+void PolyStepSequencerPlugin::addStepNote(int index, int noteNumber, int velocityOverride) {
+    if (index < 0 || index >= MAX_STEPS)
+        return;
+    noteNumber = juce::jlimit(0, 127, noteNumber);
+
+    auto stepVT = getOrCreateStepTree(index);
+    if (findNoteTree(stepVT, noteNumber).isValid())
+        return;  // already present
+
+    int noteCount = 0;
+    for (int i = 0; i < stepVT.getNumChildren(); ++i) {
+        if (stepVT.getChild(i).hasType(PSeqIDs::noteTree))
+            ++noteCount;
+    }
+    if (noteCount >= MAX_NOTES_PER_STEP)
+        return;  // voice cap reached
+
+    juce::ValueTree noteVT(PSeqIDs::noteTree);
+    noteVT.setProperty(PSeqIDs::noteNumber, noteNumber, nullptr);
+    if (velocityOverride > 0)
+        noteVT.setProperty(PSeqIDs::noteVel, juce::jlimit(1, 127, velocityOverride), nullptr);
+    stepVT.appendChild(noteVT, getUndoManager());
+}
+
+void PolyStepSequencerPlugin::removeStepNote(int index, int noteNumber) {
+    if (index < 0 || index >= MAX_STEPS)
+        return;
+    auto stepVT = findStepTree(index);
+    if (!stepVT.isValid())
+        return;
+    auto noteVT = findNoteTree(stepVT, noteNumber);
+    if (noteVT.isValid())
+        stepVT.removeChild(noteVT, getUndoManager());
+}
+
+void PolyStepSequencerPlugin::toggleStepNote(int index, int noteNumber) {
+    if (stepHasNote(index, noteNumber))
+        removeStepNote(index, noteNumber);
+    else
+        addStepNote(index, noteNumber);
+}
+
+void PolyStepSequencerPlugin::setStepNoteVelocity(int index, int noteNumber, int velocityOverride) {
+    if (index < 0 || index >= MAX_STEPS)
+        return;
+    auto stepVT = findStepTree(index);
+    if (!stepVT.isValid())
+        return;
+    auto noteVT = findNoteTree(stepVT, noteNumber);
+    if (!noteVT.isValid())
+        return;
+
+    if (velocityOverride > 0)
+        noteVT.setProperty(PSeqIDs::noteVel, juce::jlimit(1, 127, velocityOverride),
+                           getUndoManager());
+    else
+        noteVT.removeProperty(PSeqIDs::noteVel, getUndoManager());
+}
+
+void PolyStepSequencerPlugin::clearStep(int index) {
+    if (index < 0 || index >= MAX_STEPS)
+        return;
+    auto stepVT = findStepTree(index);
+    if (stepVT.isValid())
+        state.removeChild(stepVT, getUndoManager());
+}
+
+void PolyStepSequencerPlugin::clearPattern() {
+    auto* um = getUndoManager();
+    if (um != nullptr)
+        um->beginNewTransaction();
+    for (int i = state.getNumChildren() - 1; i >= 0; --i) {
+        if (state.getChild(i).hasType(PSeqIDs::stepTree))
+            state.removeChild(i, um);
+    }
+}
+
+bool PolyStepSequencerPlugin::transposePattern(int semitones) {
+    if (semitones == 0)
+        return true;
+
+    for (int i = 0; i < state.getNumChildren(); ++i) {
+        auto stepVT = state.getChild(i);
+        if (!stepVT.hasType(PSeqIDs::stepTree))
+            continue;
+        for (int n = 0; n < stepVT.getNumChildren(); ++n) {
+            auto noteVT = stepVT.getChild(n);
+            if (!noteVT.hasType(PSeqIDs::noteTree))
+                continue;
+            int note = static_cast<int>(noteVT.getProperty(PSeqIDs::noteNumber, 60));
+            if (note + semitones < 0 || note + semitones > 127)
+                return false;
+        }
+    }
+
+    auto* um = getUndoManager();
+    if (um != nullptr)
+        um->beginNewTransaction();
+    for (int i = 0; i < state.getNumChildren(); ++i) {
+        auto stepVT = state.getChild(i);
+        if (!stepVT.hasType(PSeqIDs::stepTree))
+            continue;
+        for (int n = 0; n < stepVT.getNumChildren(); ++n) {
+            auto noteVT = stepVT.getChild(n);
+            if (!noteVT.hasType(PSeqIDs::noteTree))
+                continue;
+            int note = static_cast<int>(noteVT.getProperty(PSeqIDs::noteNumber, 60));
+            noteVT.setProperty(PSeqIDs::noteNumber, note + semitones, um);
+        }
+    }
+    return true;
+}
+
+// =============================================================================
+// State mirroring
+// =============================================================================
+
+void PolyStepSequencerPlugin::loadStepsFromState() {
+    // Reset all steps to defaults
+    steps_.fill(Step{});
+
+    for (int i = 0; i < state.getNumChildren(); ++i) {
+        auto child = state.getChild(i);
+        if (!child.hasType(PSeqIDs::stepTree))
+            continue;
+
+        int idx = child.getProperty(PSeqIDs::stepIndex, -1);
+        if (idx < 0 || idx >= MAX_STEPS)
+            continue;
+
+        auto& s = steps_[static_cast<size_t>(idx)];
+        s.gate = child.getProperty(PSeqIDs::stepGate, true);
+        s.tie = child.getProperty(PSeqIDs::stepTie, false);
+        s.probability = juce::jlimit(0.0f, 1.0f, float(child.getProperty(PSeqIDs::stepProb, 1.0f)));
+        s.velocity = juce::jlimit(1, 127, int(child.getProperty(PSeqIDs::stepVel, 100)));
+
+        s.noteCount = 0;
+        for (int n = 0; n < child.getNumChildren() && s.noteCount < MAX_NOTES_PER_STEP; ++n) {
+            auto noteVT = child.getChild(n);
+            if (!noteVT.hasType(PSeqIDs::noteTree))
+                continue;
+
+            auto& note = s.notes[static_cast<size_t>(s.noteCount)];
+            note.noteNumber =
+                juce::jlimit(0, 127, int(noteVT.getProperty(PSeqIDs::noteNumber, 60)));
+            note.velocity = juce::jlimit(0, 127, int(noteVT.getProperty(PSeqIDs::noteVel, 0)));
+            ++s.noteCount;
+        }
+    }
+}
+
+// =============================================================================
+// Audio thread
+// =============================================================================
+
+void PolyStepSequencerPlugin::killAllNotes(te::MidiMessageArray& midi, double time) {
+    if (soundingCount_ > 0) {
+        for (int i = 0; i < soundingCount_; ++i)
+            midi.addMidiMessage(
+                juce::MidiMessage::noteOff(1, soundingNotes_[static_cast<size_t>(i)]), time,
+                te::MPESourceID{});
+        soundingCount_ = 0;
+        noteOffCountdown_ = 0;
+        clearMidiOutDisplay();
+    }
+}
+
+void PolyStepSequencerPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
+    if (!fc.bufferForMidiMessages)
+        return;
+
+    if (!isEnabled())
+        return;
+
+    auto& midi = *fc.bufferForMidiMessages;
+
+    // Send all-notes-off after re-initialisation to clear any stuck notes
+    if (needsAllNotesOff_) {
+        midi.addMidiMessage(juce::MidiMessage::allNotesOff(1), 0.0, te::MPESourceID{});
+        needsAllNotesOff_ = false;
+    }
+
+    // Save incoming MIDI for thru, then clear for sequencer output
+    te::MidiMessageArray thruMessages;
+    if (midiThru.get()) {
+        for (auto& msg : midi)
+            thruMessages.addMidiMessage(msg, msg.getTimeStamp(), te::MPESourceID{});
+    }
+    midi.clear();
+
+    // Only run when transport is playing
+    if (!fc.isPlaying) {
+        killAllNotes(midi, 0.0);
+        stepClock_.reset();
+        currentPlayStep_.store(-1, std::memory_order_relaxed);
+        silentBlockCount_ = 0;
+        for (auto& msg : thruMessages)
+            midi.addMidiMessage(msg, msg.getTimeStamp(), te::MPESourceID{});
+        return;
+    }
+
+    // Read params (includes macro modulation)
+    auto currentRate = static_cast<StepClock::Rate>(
+        juce::roundToInt(rateParam ? rateParam->getCurrentValue() : rate.get()));
+    auto currentDir = static_cast<StepClock::Direction>(
+        juce::roundToInt(directionParam ? directionParam->getCurrentValue() : direction.get()));
+    float swingVal =
+        juce::jlimit(0.0f, 1.0f, swingParam ? swingParam->getCurrentValue() : swing.get());
+    float gateLengthVal = juce::jlimit(
+        0.05f, 1.0f, gateLengthParam ? gateLengthParam->getCurrentValue() : gateLength.get());
+    float rampVal =
+        juce::jlimit(-1.0f, 1.0f, rampParam ? rampParam->getCurrentValue() : ramp.get());
+    float skewVal =
+        juce::jlimit(-1.0f, 1.0f, skewParam ? skewParam->getCurrentValue() : skew.get());
+
+    int stepCount = juce::jlimit(1, MAX_STEPS, numSteps.get());
+    int bufferSamples = fc.bufferNumSamples;
+    double blockDurationSecs = static_cast<double>(bufferSamples) / sampleRate_;
+
+    // Compute step duration in samples for gate length
+    double bpm = edit.tempoSequence.getBpmAt(fc.editTime.getStart());
+    double stepBeats = StepClock::rateToBeats(currentRate);
+    int stepDurationSamples = std::max(1, static_cast<int>(stepBeats * 60.0 / bpm * sampleRate_));
+
+    int cyclesVal = juce::jlimit(1, 8, rampCycles.get());
+    bool hardAngleVal = hardAngle.get();
+    float quantizeVal = juce::jlimit(0.0f, 1.0f, quantize.get());
+    int quantizeSubVal = juce::jlimit(16, 512, quantizeSub.get());
+
+    // --- Detect structural parameter changes -> reset clock to re-sync ---
+    // Only reset for changes that alter the step grid timing structure
+    // (same rationale as StepSequencerPlugin).
+    int rateInt = static_cast<int>(currentRate);
+    if (rateInt != prevRate_ || cyclesVal != prevCycles_ || hardAngleVal != prevHardAngle_) {
+        killAllNotes(midi, 0.0);
+        stepClock_.reset();
+        prevRate_ = rateInt;
+        prevCycles_ = cyclesVal;
+        prevHardAngle_ = hardAngleVal;
+    }
+
+    // --- Get step events from the clock ---
+    static constexpr int MAX_EVENTS_PER_BLOCK = 16;
+    StepClock::StepEvent events[MAX_EVENTS_PER_BLOCK];
+    int eventCount = stepClock_.processBlock(fc, edit, currentRate, currentDir, swingVal, stepCount,
+                                             events, MAX_EVENTS_PER_BLOCK, rampVal, skewVal,
+                                             cyclesVal, hardAngleVal, quantizeVal, quantizeSubVal);
+
+    // --- Emit pending note-off (sample countdown) ---
+    // Only emit if the countdown fires BEFORE the first step event in this block.
+    // If a step fires first, it handles the note-off transition itself.
+    if (noteOffCountdown_ > 0 && soundingCount_ > 0) {
+        if (noteOffCountdown_ <= bufferSamples) {
+            double countdownTime = static_cast<double>(noteOffCountdown_) / sampleRate_;
+            bool stepFiresFirst = (eventCount > 0 && events[0].timeInBlock <= countdownTime);
+
+            // If the next step is a tie, never kill the notes - let the tie hold them
+            bool nextStepIsTie =
+                (eventCount > 0 && steps_[static_cast<size_t>(events[0].stepIndex)].tie &&
+                 steps_[static_cast<size_t>(events[0].stepIndex)].gate);
+
+            if (!stepFiresFirst && !nextStepIsTie) {
+                killAllNotes(midi, countdownTime);
+            } else {
+                noteOffCountdown_ = 0;
+            }
+        } else {
+            if (eventCount > 0) {
+                noteOffCountdown_ = 0;
+            } else {
+                noteOffCountdown_ -= bufferSamples;
+            }
+        }
+    }
+
+    // --- Process each step event ---
+    for (int i = 0; i < eventCount; ++i) {
+        const auto& evt = events[i];
+        const auto& step = steps_[static_cast<size_t>(evt.stepIndex)];
+
+        currentPlayStep_.store(evt.stepIndex, std::memory_order_relaxed);
+
+        // Rest step - send note-offs if needed
+        if (!step.gate) {
+            killAllNotes(midi, evt.timeInBlock);
+            continue;
+        }
+
+        // Tie step - keep the current notes playing, no retrigger, no new countdown
+        if (step.tie && soundingCount_ > 0) {
+            noteOffCountdown_ = 0;  // Cancel any pending note-off - notes hold
+            continue;
+        }
+
+        // Probability - evaluated once per step fire; failure acts as a rest
+        if (step.probability < 1.0f && nextRandom01() >= step.probability) {
+            killAllNotes(midi, evt.timeInBlock);
+            continue;
+        }
+
+        // Empty step (gate on but no notes) acts as a rest
+        if (step.noteCount == 0) {
+            killAllNotes(midi, evt.timeInBlock);
+            continue;
+        }
+
+        // Note-offs for sounding notes - always BEFORE the new note-ons
+        if (soundingCount_ > 0) {
+            double offTime = std::max(0.0, evt.timeInBlock - 0.0001);
+            for (int n = 0; n < soundingCount_; ++n)
+                midi.addMidiMessage(
+                    juce::MidiMessage::noteOff(1, soundingNotes_[static_cast<size_t>(n)]), offTime,
+                    te::MPESourceID{});
+            soundingCount_ = 0;
+            noteOffCountdown_ = 0;
+        }
+
+        // Note-ons for each note in the step
+        int displayVel = step.velocity;
+        for (int n = 0; n < step.noteCount; ++n) {
+            const auto& note = step.notes[static_cast<size_t>(n)];
+            int vel = juce::jlimit(1, 127, note.velocity > 0 ? note.velocity : step.velocity);
+            midi.addMidiMessage(
+                juce::MidiMessage::noteOn(1, note.noteNumber, static_cast<juce::uint8>(vel)),
+                evt.timeInBlock, te::MPESourceID{});
+            soundingNotes_[static_cast<size_t>(n)] = note.noteNumber;
+            displayVel = vel;
+        }
+        soundingCount_ = step.noteCount;
+        setMidiOutDisplay(step.notes[0].noteNumber, displayVel);
+
+        // Schedule note-off via sample countdown
+        // 100% gate if the next step is a tie (must hold for the tie to extend)
+        int nextIdx = (evt.stepIndex + 1) % stepCount;
+        bool nextIsTie = steps_[static_cast<size_t>(nextIdx)].tie;
+        double gateRatio = nextIsTie ? 1.0 : static_cast<double>(gateLengthVal);
+        int noteOnSample = static_cast<int>(evt.timeInBlock * sampleRate_);
+        int gateSamples = static_cast<int>(stepDurationSamples * gateRatio);
+        noteOffCountdown_ = gateSamples - (bufferSamples - noteOnSample);
+        if (noteOffCountdown_ <= 0) {
+            // Note-off falls within this block
+            double offTimeInBlock =
+                evt.timeInBlock + static_cast<double>(gateSamples) / sampleRate_;
+            offTimeInBlock = std::min(offTimeInBlock, blockDurationSecs);
+            killAllNotes(midi, offTimeInBlock);
+        }
+    }
+
+    // --- Stuck-note safety: kill notes left hanging with no pending note-off ---
+    if (eventCount > 0) {
+        silentBlockCount_ = 0;
+    } else if (soundingCount_ > 0 && noteOffCountdown_ <= 0) {
+        ++silentBlockCount_;
+        if (silentBlockCount_ > 4) {
+            killAllNotes(midi, 0.0);
+            silentBlockCount_ = 0;
+        }
+    }
+
+    // Update UI play position
+    if (eventCount == 0 && !stepClock_.isRunning()) {
+        currentPlayStep_.store(-1, std::memory_order_relaxed);
+    }
+
+    // Re-add thru messages so incoming MIDI reaches downstream instruments
+    for (auto& msg : thruMessages)
+        midi.addMidiMessage(msg, msg.getTimeStamp(), te::MPESourceID{});
+}
+
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/plugins/PolyStepSequencerPlugin.cpp
+++ b/magda/daw/audio/plugins/PolyStepSequencerPlugin.cpp
@@ -147,7 +147,15 @@ void PolyStepSequencerPlugin::reset() {
 void PolyStepSequencerPlugin::restorePluginStateFromValueTree(const juce::ValueTree& v) {
     tracktion::copyPropertiesToCachedValues(v, numSteps, rate, direction, swing, gateLength, ramp,
                                             skew, rampCycles, hardAngle, quantize, quantizeSub,
-                                            midiThru, viewMode);
+                                            midiThru);
+
+    // viewMode is restored separately: the variadic helper does
+    // ValueType(juce::var), and juce::String(juce::var) is ambiguous under
+    // MSVC (var converts to int/double/String, String constructs from each).
+    if (auto* p = v.getPropertyPointer(viewMode.getPropertyID()))
+        viewMode = p->toString();
+    else
+        viewMode.resetToDefault();
 
     // Copy step children from the incoming tree into our state
     // (copyPropertiesToCachedValues only copies properties, not children)

--- a/magda/daw/audio/plugins/PolyStepSequencerPlugin.hpp
+++ b/magda/daw/audio/plugins/PolyStepSequencerPlugin.hpp
@@ -1,0 +1,183 @@
+#pragma once
+
+#include <array>
+
+#include "plugins/MidiDevicePlugin.hpp"
+#include "transport/StepClock.hpp"
+
+namespace magda::daw::audio {
+
+/**
+ * @brief Polyphonic step sequencer MIDI device.
+ *
+ * Like StepSequencerPlugin but each step holds up to 8 notes (chords).
+ * Steps have gate, tie, probability, and a step-level velocity; each note
+ * can optionally override the step velocity.
+ *
+ * The ValueTree is the source of truth for the pattern: setters write STEP /
+ * NOTE children through the undo manager and a listener mirrors the tree back
+ * into the audio-thread step array, so undo/redo just works.
+ *
+ * Uses StepClock for tempo-synced step timing (transport or free-running).
+ */
+class PolyStepSequencerPlugin : public MidiDevicePlugin {
+  public:
+    PolyStepSequencerPlugin(const te::PluginCreationInfo& info);
+    ~PolyStepSequencerPlugin() override;
+
+    static const char* getPluginName() {
+        return "Poly Sequencer";
+    }
+    static const char* xmlTypeName;
+
+    static constexpr int MAX_STEPS = 32;
+    static constexpr int MAX_NOTES_PER_STEP = 8;
+
+    // --- Per-step data ---
+    struct Note {
+        int noteNumber = 60;  // MIDI note 0-127
+        int velocity = 0;     // 0 = use step velocity, 1-127 = per-note override
+    };
+
+    struct Step {
+        bool gate = true;          // true = active, false = rest
+        bool tie = false;          // Extend previous step's notes (no retrigger)
+        float probability = 1.0f;  // 0-1, evaluated once per step fire
+        int velocity = 100;        // Step-level velocity (1-127)
+        int noteCount = 0;
+        std::array<Note, MAX_NOTES_PER_STEP> notes{};
+    };
+
+    // --- te::Plugin overrides ---
+    juce::String getName() const override {
+        return getPluginName();
+    }
+    juce::String getPluginType() override {
+        return xmlTypeName;
+    }
+    juce::String getShortName(int) override {
+        return "PSeq";
+    }
+    juce::String getSelectableDescription() override {
+        return getName();
+    }
+
+    void initialise(const te::PluginInitialisationInfo& info) override;
+    void deinitialise() override;
+    void reset() override;
+
+    void applyToBuffer(const te::PluginRenderContext& fc) override;
+
+    void restorePluginStateFromValueTree(const juce::ValueTree& v) override;
+
+    // --- Parameters (CachedValues for persistence) ---
+    juce::CachedValue<int> numSteps;
+    juce::CachedValue<int> rate;       // StepClock::Rate enum
+    juce::CachedValue<int> direction;  // StepClock::Direction enum
+    juce::CachedValue<float> swing;
+    juce::CachedValue<float> gateLength;  // 0-1 normalized (0.1 = staccato, 1.0 = legato)
+    juce::CachedValue<float> ramp;        // -1.0 to 1.0: bezier timing depth
+    juce::CachedValue<float> skew;        // -1.0 to 1.0: bezier control point offset
+    juce::CachedValue<int> rampCycles;    // 1-8: curve repetitions within one pattern cycle
+    juce::CachedValue<bool> hardAngle;    // true = piecewise linear, false = smooth bezier
+    juce::CachedValue<float> quantize;    // 0.0-1.0: adaptive quantize strength
+    juce::CachedValue<int> quantizeSub;   // quantize grid subdivisions (16, 32, 48... 256)
+
+    /** MIDI thru: pass incoming MIDI to downstream plugins. */
+    juce::CachedValue<bool> midiThru;
+
+    /** Pattern-view mode for the UI ("keys" or "drum"). Persisted with the
+     *  edit and undo-safe; the engine does not act on it. */
+    juce::CachedValue<juce::String> viewMode;
+
+    // --- Automatable parameters (for macro/mod linking) ---
+    te::AutomatableParameter::Ptr rateParam, directionParam;
+    te::AutomatableParameter::Ptr swingParam, gateLengthParam;
+    te::AutomatableParameter::Ptr rampParam, skewParam;
+
+    // --- Pattern access (message thread) ---
+    Step getStep(int index) const;
+    bool stepHasNote(int index, int noteNumber) const;
+
+    void setStepGate(int index, bool gate);
+    void setStepTie(int index, bool tie);
+    void setStepProbability(int index, float probability);
+    void setStepVelocity(int index, int velocity);
+
+    /** Add a note to a step (no-op if already present or step is full).
+     *  velocityOverride 0 = use step velocity, 1-127 = per-note velocity. */
+    void addStepNote(int index, int noteNumber, int velocityOverride = 0);
+    void removeStepNote(int index, int noteNumber);
+    void toggleStepNote(int index, int noteNumber);
+    void setStepNoteVelocity(int index, int noteNumber, int velocityOverride);
+
+    /** Reset a step to defaults (gate on, no notes). */
+    void clearStep(int index);
+
+    /** Shift all notes in all steps by semitones. If any note would leave 0-127, returns false and
+     * leaves the pattern untouched. Single undo transaction. */
+    bool transposePattern(int semitones);
+
+    /** Remove all steps from the pattern in one undo transaction. */
+    void clearPattern();
+
+    /** Current playback step index for UI highlight (-1 if not playing). */
+    std::atomic<int> currentPlayStep_{-1};
+
+  private:
+    // Step clock (handles timing, transport, swing, direction)
+    StepClock stepClock_;
+
+    // --- Step state (mirrored from ValueTree, read on audio thread) ---
+    std::array<Step, MAX_STEPS> steps_{};
+
+    // --- Audio-thread state ---
+    std::array<int, MAX_NOTES_PER_STEP> soundingNotes_{};
+    int soundingCount_ = 0;
+    int noteOffCountdown_ = 0;       // Samples remaining until note-off (0 = no pending)
+    int silentBlockCount_ = 0;       // Blocks with no step events (for safety note-off)
+    bool needsAllNotesOff_ = false;  // Send all-notes-off on next applyToBuffer
+
+    // Previous timing params - detect structural changes that require clock reset
+    int prevRate_ = -1;
+    int prevCycles_ = 1;
+    bool prevHardAngle_ = false;
+
+    // Inline xorshift32 PRNG for step probability (no allocation, audio-thread safe)
+    juce::uint32 rngState_ = 0x9E3779B9u;
+    float nextRandom01() {
+        auto x = rngState_;
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        rngState_ = x;
+        return static_cast<float>(x >> 8) * (1.0f / 16777216.0f);
+    }
+
+    /** Send note-offs for all sounding notes immediately (audio thread). */
+    void killAllNotes(te::MidiMessageArray& midi, double time);
+
+    // --- ValueTree pattern helpers (message thread) ---
+    juce::ValueTree findStepTree(int index) const;
+    juce::ValueTree getOrCreateStepTree(int index);
+    static juce::ValueTree findNoteTree(const juce::ValueTree& stepTree, int noteNumber);
+
+    /** Mirror the STEP/NOTE children of state into steps_. */
+    void loadStepsFromState();
+
+    // Sync CachedValue changes to AutomatableParams
+    void syncParamFromProperty(const juce::Identifier& property);
+
+    struct StateListener : public juce::ValueTree::Listener {
+        PolyStepSequencerPlugin& owner;
+        explicit StateListener(PolyStepSequencerPlugin& o) : owner(o) {}
+        void valueTreePropertyChanged(juce::ValueTree& tree, const juce::Identifier& p) override;
+        void valueTreeChildAdded(juce::ValueTree&, juce::ValueTree& child) override;
+        void valueTreeChildRemoved(juce::ValueTree&, juce::ValueTree& child, int) override;
+    };
+    StateListener stateListener_{*this};
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PolyStepSequencerPlugin)
+};
+
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/plugins/StepSequencerPlugin.cpp
+++ b/magda/daw/audio/plugins/StepSequencerPlugin.cpp
@@ -85,6 +85,23 @@ StepSequencerPlugin::~StepSequencerPlugin() {
     state.removeListener(&paramSyncListener_);
 }
 
+void StepSequencerPlugin::ParamSyncListener::valueTreePropertyChanged(juce::ValueTree&,
+                                                                      const juce::Identifier& p) {
+    owner.syncParamFromProperty(p);
+}
+
+void StepSequencerPlugin::ParamSyncListener::valueTreeChildAdded(juce::ValueTree&,
+                                                                 juce::ValueTree& child) {
+    if (child.hasType(SeqIDs::stepTree))
+        owner.loadStepsFromState();
+}
+
+void StepSequencerPlugin::ParamSyncListener::valueTreeChildRemoved(juce::ValueTree&,
+                                                                   juce::ValueTree& child, int) {
+    if (child.hasType(SeqIDs::stepTree))
+        owner.loadStepsFromState();
+}
+
 void StepSequencerPlugin::syncParamFromProperty(const juce::Identifier& property) {
     if (property == SeqIDs::rate && rateParam)
         rateParam->setParameterFromHost(static_cast<float>(rate.get()), juce::dontSendNotification);
@@ -233,6 +250,35 @@ void StepSequencerPlugin::randomizePattern() {
         step.tie = false;
     }
     saveStepsToState();
+}
+
+void StepSequencerPlugin::clearPattern() {
+    auto* um = getUndoManager();
+    if (um != nullptr)
+        um->beginNewTransaction();
+
+    steps_.fill(Step{});
+
+    // Remove existing step children via undo manager so the operation is undoable
+    for (int i = state.getNumChildren() - 1; i >= 0; --i) {
+        if (state.getChild(i).hasType(SeqIDs::stepTree))
+            state.removeChild(i, um);
+    }
+
+    // Write default steps back so the ValueTree reflects the cleared state
+    int count = juce::jlimit(1, MAX_STEPS, numSteps.get());
+    for (int i = 0; i < count; ++i) {
+        const auto& s = steps_[static_cast<size_t>(i)];
+        juce::ValueTree stepVT(SeqIDs::stepTree);
+        stepVT.setProperty(SeqIDs::stepIndex, i, nullptr);
+        stepVT.setProperty(SeqIDs::stepNote, s.noteNumber, nullptr);
+        stepVT.setProperty(SeqIDs::stepOctave, s.octaveShift, nullptr);
+        stepVT.setProperty(SeqIDs::stepGate, s.gate, nullptr);
+        stepVT.setProperty(SeqIDs::stepAccent, s.accent, nullptr);
+        stepVT.setProperty(SeqIDs::stepGlide, s.glide, nullptr);
+        stepVT.setProperty(SeqIDs::stepTie, s.tie, nullptr);
+        state.appendChild(stepVT, um);
+    }
 }
 
 void StepSequencerPlugin::setPattern(const std::vector<Step>& steps, bool cueOnBar) {

--- a/magda/daw/audio/plugins/StepSequencerPlugin.hpp
+++ b/magda/daw/audio/plugins/StepSequencerPlugin.hpp
@@ -95,6 +95,9 @@ class StepSequencerPlugin : public MidiDevicePlugin {
     /** Randomize all active steps with random notes, gates, accents, and glides. */
     void randomizePattern();
 
+    /** Reset all steps to defaults in one undo transaction. */
+    void clearPattern();
+
     /** Bulk-set the pattern from an external source (e.g. AI generation).
      *  If cueOnBar is true and transport is playing, the new pattern is queued
      *  and swapped in at the next cycle boundary (bar start). */
@@ -155,9 +158,9 @@ class StepSequencerPlugin : public MidiDevicePlugin {
     struct ParamSyncListener : public juce::ValueTree::Listener {
         StepSequencerPlugin& owner;
         explicit ParamSyncListener(StepSequencerPlugin& o) : owner(o) {}
-        void valueTreePropertyChanged(juce::ValueTree&, const juce::Identifier& p) override {
-            owner.syncParamFromProperty(p);
-        }
+        void valueTreePropertyChanged(juce::ValueTree&, const juce::Identifier& p) override;
+        void valueTreeChildAdded(juce::ValueTree&, juce::ValueTree& child) override;
+        void valueTreeChildRemoved(juce::ValueTree&, juce::ValueTree& child, int) override;
     };
     ParamSyncListener paramSyncListener_{*this};
 

--- a/magda/daw/audio/processors/internal/MidiDeviceProcessors.cpp
+++ b/magda/daw/audio/processors/internal/MidiDeviceProcessors.cpp
@@ -33,6 +33,18 @@ void StepSequencerProcessor::customiseParameterInfo(int index, ParameterInfo& in
 }
 
 // =============================================================================
+// PolyStepSequencerProcessor
+// =============================================================================
+
+PolyStepSequencerProcessor::PolyStepSequencerProcessor(DeviceId deviceId, te::Plugin::Ptr plugin)
+    : AutomatablePluginProcessor(deviceId, std::move(plugin)) {}
+
+void PolyStepSequencerProcessor::customiseParameterInfo(int index, ParameterInfo& info) const {
+    // Timing Depth (4) and Timing Skew (5) are bipolar
+    info.bipolarModulation = (index == 4 || index == 5);
+}
+
+// =============================================================================
 // DrumGridProcessor
 // =============================================================================
 

--- a/magda/daw/audio/processors/internal/MidiDeviceProcessors.hpp
+++ b/magda/daw/audio/processors/internal/MidiDeviceProcessors.hpp
@@ -8,6 +8,7 @@ namespace te = tracktion;
 
 namespace daw::audio {
 class ArpeggiatorPlugin;
+class PolyStepSequencerPlugin;
 class StepSequencerPlugin;
 }  // namespace daw::audio
 
@@ -50,6 +51,26 @@ class ArpeggiatorProcessor : public AutomatablePluginProcessor {
 class StepSequencerProcessor : public AutomatablePluginProcessor {
   public:
     StepSequencerProcessor(DeviceId deviceId, te::Plugin::Ptr plugin);
+
+  protected:
+    void customiseParameterInfo(int index, ParameterInfo& info) const override;
+};
+
+/**
+ * @brief Processor for the Poly Step Sequencer plugin
+ *
+ * Exposes CachedValue-based parameters so macros can target them.
+ * Parameters:
+ * - 0: Rate (discrete 0-9)
+ * - 1: Direction (discrete 0-3)
+ * - 2: Swing (0..1)
+ * - 3: Gate (0.05..1)
+ * - 4: Timing Depth (-1..1, ramp curve depth)
+ * - 5: Timing Skew (-1..1, bipolar ramp curve skew)
+ */
+class PolyStepSequencerProcessor : public AutomatablePluginProcessor {
+  public:
+    PolyStepSequencerProcessor(DeviceId deviceId, te::Plugin::Ptr plugin);
 
   protected:
     void customiseParameterInfo(int index, ParameterInfo& info) const override;

--- a/magda/daw/core/InternalDeviceKind.cpp
+++ b/magda/daw/core/InternalDeviceKind.cpp
@@ -14,6 +14,7 @@
 #include "audio/plugins/MidiChordEnginePlugin.hpp"
 #include "audio/plugins/MidiReceivePlugin.hpp"
 #include "audio/plugins/OscilloscopePlugin.hpp"
+#include "audio/plugins/PolyStepSequencerPlugin.hpp"
 #include "audio/plugins/SidechainMonitorPlugin.hpp"
 #include "audio/plugins/SpectrumAnalyzerPlugin.hpp"
 #include "audio/plugins/StepSequencerPlugin.hpp"
@@ -82,6 +83,8 @@ const InternalDeviceMetadata kMetadata[] = {
      "MIDI arpeggiator for rhythmic note patterns and held-note motion."},
     {InternalDeviceKind::StepSequencer, "Step Sequencer", "", "MIDI",
      "MIDI step sequencer for pattern-driven notes and rhythmic control."},
+    {InternalDeviceKind::PolyStepSequencer, "Poly Sequencer", "", "MIDI",
+     "Polyphonic MIDI step sequencer with multiple notes per step for chord patterns."},
     {InternalDeviceKind::SidechainMonitor, "Sidechain Monitor", "", "Utility",
      "Internal monitor used to expose sidechain signal state."},
     {InternalDeviceKind::AudioSidechainMonitor, "Audio Sidechain Monitor", "", "Utility",
@@ -146,6 +149,7 @@ InternalDeviceKind classifyInternalDevice(const juce::String& pluginId) {
     using daw::audio::MagdaSamplerPlugin;
     using daw::audio::MidiChordEnginePlugin;
     using daw::audio::OscilloscopePlugin;
+    using daw::audio::PolyStepSequencerPlugin;
     using daw::audio::SpectrumAnalyzerPlugin;
     using daw::audio::StepSequencerPlugin;
     using daw::audio::TrackMeasurementPlugin;
@@ -175,6 +179,7 @@ InternalDeviceKind classifyInternalDevice(const juce::String& pluginId) {
         {InternalDeviceKind::MidiChordEngine, MidiChordEnginePlugin::xmlTypeName, nullptr},
         {InternalDeviceKind::Arpeggiator, ArpeggiatorPlugin::xmlTypeName, nullptr},
         {InternalDeviceKind::StepSequencer, StepSequencerPlugin::xmlTypeName, nullptr},
+        {InternalDeviceKind::PolyStepSequencer, PolyStepSequencerPlugin::xmlTypeName, nullptr},
         {InternalDeviceKind::Oscilloscope, OscilloscopePlugin::xmlTypeName, nullptr},
         {InternalDeviceKind::SpectrumAnalyzer, SpectrumAnalyzerPlugin::xmlTypeName, nullptr},
         {InternalDeviceKind::Levels, LevelsPlugin::xmlTypeName, nullptr},
@@ -221,6 +226,13 @@ bool isAnalysisDevice(const juce::String& pluginId) {
     const auto kind = classifyInternalDevice(pluginId);
     return kind == InternalDeviceKind::Oscilloscope ||
            kind == InternalDeviceKind::SpectrumAnalyzer || kind == InternalDeviceKind::Levels;
+}
+
+bool isMidiGeneratorDevice(const juce::String& pluginId) {
+    const auto kind = classifyInternalDevice(pluginId);
+    return kind == InternalDeviceKind::StepSequencer ||
+           kind == InternalDeviceKind::PolyStepSequencer ||
+           kind == InternalDeviceKind::Arpeggiator || kind == InternalDeviceKind::MidiChordEngine;
 }
 
 int postFxAnalysisDeviceOrder(const juce::String& pluginId) {

--- a/magda/daw/core/InternalDeviceKind.hpp
+++ b/magda/daw/core/InternalDeviceKind.hpp
@@ -45,6 +45,7 @@ enum class InternalDeviceKind {
     MidiChordEngine,
     Arpeggiator,
     StepSequencer,
+    PolyStepSequencer,
     SidechainMonitor,
     AudioSidechainMonitor,
     InstrumentMeterTap,
@@ -87,6 +88,15 @@ const InternalDeviceMetadata* getInternalDeviceMetadataForPluginId(const juce::S
  * at every creation site.
  */
 bool isAnalysisDevice(const juce::String& pluginId);
+
+/**
+ * @brief True if the pluginId is a MIDI generator/utility device.
+ *
+ * MIDI generators (step sequencer, poly sequencer, arpeggiator, chord engine)
+ * operate on MIDI tracks and make no sense on the master bus.
+ * Used to block these devices from being added to the master track.
+ */
+bool isMidiGeneratorDevice(const juce::String& pluginId);
 
 /**
  * @brief Stable display / chain order for known post-FX analysis devices.

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -1634,6 +1634,11 @@ DeviceId TrackManager::addDeviceToTrack(TrackId trackId, const DeviceInfo& devic
             DBG("Cannot add instrument plugin to non-instrument track");
             return INVALID_DEVICE_ID;
         }
+        if (track->type == TrackType::Master &&
+            (device.deviceType == DeviceType::MIDI || isMidiGeneratorDevice(device.pluginId))) {
+            DBG("Cannot add MIDI generator to master track");
+            return INVALID_DEVICE_ID;
+        }
         DeviceInfo newDevice = device;
         newDevice.id = nextFxDeviceId_++;
         stampDefaultKitIfMissing(newDevice);
@@ -1655,6 +1660,11 @@ DeviceId TrackManager::addDeviceToTrack(TrackId trackId, const DeviceInfo& devic
              track->type == TrackType::Master) &&
             device.isInstrument) {
             DBG("Cannot add instrument plugin to non-instrument track");
+            return INVALID_DEVICE_ID;
+        }
+        if (track->type == TrackType::Master &&
+            (device.deviceType == DeviceType::MIDI || isMidiGeneratorDevice(device.pluginId))) {
+            DBG("Cannot add MIDI generator to master track");
             return INVALID_DEVICE_ID;
         }
         DeviceInfo newDevice = device;

--- a/magda/daw/engine/MagdaEngineBehaviour.hpp
+++ b/magda/daw/engine/MagdaEngineBehaviour.hpp
@@ -11,6 +11,7 @@
 #include "../audio/plugins/MidiChordEnginePlugin.hpp"
 #include "../audio/plugins/MidiReceivePlugin.hpp"
 #include "../audio/plugins/OscilloscopePlugin.hpp"
+#include "../audio/plugins/PolyStepSequencerPlugin.hpp"
 #include "../audio/plugins/SidechainMonitorPlugin.hpp"
 #include "../audio/plugins/SpectrumAnalyzerPlugin.hpp"
 #include "../audio/plugins/StepSequencerPlugin.hpp"
@@ -124,6 +125,9 @@ class MagdaEngineBehaviour : public tracktion::EngineBehaviour {
         }
         if (type == daw::audio::StepSequencerPlugin::xmlTypeName) {
             return new daw::audio::StepSequencerPlugin(info);
+        }
+        if (type == daw::audio::PolyStepSequencerPlugin::xmlTypeName) {
+            return new daw::audio::PolyStepSequencerPlugin(info);
         }
         if (type == daw::audio::OscilloscopePlugin::xmlTypeName) {
             return new daw::audio::OscilloscopePlugin(info);

--- a/magda/daw/ui/components/chain/CMakeLists.txt
+++ b/magda/daw/ui/components/chain/CMakeLists.txt
@@ -74,6 +74,7 @@ target_sources(magda_daw_app PRIVATE
     custom_ui/FourOscUI.cpp
     custom_ui/ArpeggiatorUI.cpp
     custom_ui/StepSequencerUI.cpp
+    custom_ui/PolyStepSequencerUI.cpp
     custom_ui/LevelsUI.cpp
     custom_ui/OscilloscopeUI.cpp
     custom_ui/SpectrumAnalyzerUI.cpp
@@ -164,6 +165,7 @@ target_sources(magda_daw_app PRIVATE
     custom_ui/FourOscUI.hpp
     custom_ui/ArpeggiatorUI.hpp
     custom_ui/StepSequencerUI.hpp
+    custom_ui/PolyStepSequencerUI.hpp
     custom_ui/LevelsUI.hpp
     custom_ui/OscilloscopeUI.hpp
     custom_ui/SpectrumAnalyzerUI.hpp

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -443,8 +443,8 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     };
     addAndMakeVisible(*onButton_);
 
-    // Export as MIDI clip button (step sequencer only for now)
-    if (traits_.isStepSequencer) {
+    // Export as MIDI clip button
+    if (traits_.isStepSequencer || traits_.isPolyStepSequencer) {
         exportClipButton_ = std::make_unique<magda::SvgButton>("ExportClip", BinaryData::copy_svg,
                                                                BinaryData::copy_svgSize);
         applyHeaderIconStyle(*exportClipButton_, DarkTheme::getColour(DarkTheme::ACCENT_GREEN),
@@ -452,9 +452,15 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
         exportClipButton_->setTooltip("Click to copy pattern, drag to timeline");
         exportClipButton_->addMouseListener(this, false);
         exportClipButton_->onClick = [this]() {
-            auto* stepSeqPlugin = customUI_.getStepSeqPlugin();
-            if (stepSeqPlugin != nullptr)
-                copyStepSequencerPatternToClipboard(*stepSeqPlugin);
+            if (traits_.isPolyStepSequencer) {
+                auto* plugin = customUI_.getPolyStepSeqPlugin();
+                if (plugin != nullptr)
+                    copyPolyStepSequencerPatternToClipboard(*plugin);
+            } else {
+                auto* stepSeqPlugin = customUI_.getStepSeqPlugin();
+                if (stepSeqPlugin != nullptr)
+                    copyStepSequencerPatternToClipboard(*stepSeqPlugin);
+            }
         };
         addAndMakeVisible(*exportClipButton_);
     }
@@ -841,7 +847,8 @@ void DeviceSlotComponent::timerCallback() {
         }
     }
 
-    if (traits_.isArpeggiator || traits_.isStepSequencer || traits_.isChordEngine) {
+    if (traits_.isArpeggiator || traits_.isStepSequencer || traits_.isPolyStepSequencer ||
+        traits_.isChordEngine) {
         refreshDeviceSlotMidiActivity(traits_, customUI_, midiNoteStrip_, lastMidiNote_,
                                       lastChordNotes_, lastChordCount_);
     } else {
@@ -1597,8 +1604,13 @@ void DeviceSlotComponent::resizedHeaderExtra(juce::Rectangle<int>& headerArea) {
 }
 
 void DeviceSlotComponent::mouseDrag(const juce::MouseEvent& e) {
-    if (handleStepSequencerPatternExternalDrag(customUI_.getStepSeqPlugin(),
-                                               exportClipButton_.get(), this, e)) {
+    if (traits_.isPolyStepSequencer) {
+        if (handlePolyStepSequencerPatternExternalDrag(customUI_.getPolyStepSeqPlugin(),
+                                                       exportClipButton_.get(), this, e)) {
+            return;
+        }
+    } else if (handleStepSequencerPatternExternalDrag(customUI_.getStepSeqPlugin(),
+                                                      exportClipButton_.get(), this, e)) {
         return;
     }
 

--- a/magda/daw/ui/components/chain/ai/AIPanelComponent.cpp
+++ b/magda/daw/ui/components/chain/ai/AIPanelComponent.cpp
@@ -147,8 +147,9 @@ namespace {
 // from the persisted output and recolour it yellow. Kept here so the writer
 // (onGenerationFinished) and the restorer (setDevicePath) agree on the
 // exact bytes — the leading "\n\n" is part of the marker so split logic
-// works on the first occurrence with no ambiguity.
-constexpr const char* kDisclaimerMarker = "\n\nnote: starting point only";
+// works on the first occurrence with no ambiguity. Both the sound-design
+// and sequencer variants start with "\n\nnote: " so this prefix covers both.
+constexpr const char* kDisclaimerMarker = "\n\nnote: ";
 
 // Extract the value of a top-level JSON string field. The streamed content
 // has had its curly braces replaced with spaces (see appendStreamingToken),
@@ -198,30 +199,37 @@ void AIPanelComponent::setDevicePath(const ChainNodePath& path) {
 }
 
 void AIPanelComponent::restoreOutput(const juce::String& text) {
-    // Re-insert the persisted text section-by-section so the disclaimer keeps
-    // its yellow tint after a slot rebuild. setText would put everything in
-    // one section using the current textColourId — recolouring afterwards is
+    // Re-insert the persisted text section-by-section so each disclaimer line
+    // keeps its yellow tint after a slot rebuild. setText would put everything
+    // in one section using the current textColourId - recolouring afterwards is
     // not something juce::TextEditor supports per range, so we have to insert
-    // the prefix and the disclaimer separately.
+    // the surrounding text and each disclaimer line separately. Only the
+    // disclaimer line itself is yellow; text from later turns must not be.
     output_.setText({}, juce::dontSendNotification);
     if (text.isEmpty())
         return;
 
     output_.moveCaretToEnd();
-    const int markerIdx = text.indexOf(juce::String(kDisclaimerMarker));
-    if (markerIdx < 0) {
+    const juce::String marker(kDisclaimerMarker);
+    int pos = 0;
+    for (;;) {
+        const int markerIdx = text.indexOf(pos, marker);
+        if (markerIdx < 0)
+            break;
+        int lineEnd = text.indexOf(markerIdx + marker.length(), "\n");
+        if (lineEnd < 0)
+            lineEnd = text.length();
         output_.setColour(juce::TextEditor::textColourId,
                           DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
-        output_.insertTextAtCaret(text);
-    } else {
-        output_.setColour(juce::TextEditor::textColourId,
-                          DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
-        output_.insertTextAtCaret(text.substring(0, markerIdx));
+        output_.insertTextAtCaret(text.substring(pos, markerIdx));
         output_.setColour(juce::TextEditor::textColourId, juce::Colours::yellow);
-        output_.insertTextAtCaret(text.substring(markerIdx));
-        output_.setColour(juce::TextEditor::textColourId,
-                          DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
+        output_.insertTextAtCaret(text.substring(markerIdx, lineEnd));
+        pos = lineEnd;
     }
+    output_.setColour(juce::TextEditor::textColourId,
+                      DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
+    if (pos < text.length())
+        output_.insertTextAtCaret(text.substring(pos));
     output_.moveCaretToEnd();
 }
 
@@ -356,6 +364,9 @@ void AIPanelComponent::submitPrompt() {
         return;
     }
 
+    // Capture the caveat before the agent is moved into the thread.
+    pendingCaveat_ = agent->getUserCaveat();
+
     setBusy(true);
 
     // Make sure streaming starts on its own row. insertTextAtCaret keeps any
@@ -460,20 +471,15 @@ void AIPanelComponent::onGenerationFinished(juce::String status, juce::String co
                       DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
     output_.insertTextAtCaret(juce::String(juce::CharPointer_UTF8("\xe2\x86\x92 ")) + status);
 
-    // Remind the user the preset is a starting point — only for sound-design
-    // (4OSC) presets, and only on a successful apply (status messages from
-    // cancel / error / timeout shouldn't suggest tweaking something that was
-    // never written). Faust/coder devices get the "compiled" confirmation
-    // above instead, so the disclaimer would be noise there. Rendered in
-    // yellow; the marker matches kDisclaimerMarker so restoreOutput can
-    // recolour it after a slot rebuild.
-    if (succeeded && isSoundDesignSupported(pluginId_)) {
+    // Remind the user the result is a starting point. The caveat text comes
+    // from the agent via pendingCaveat_ (set in submitPrompt before the agent
+    // moves into the thread). Only shown on a successful apply — cancel/error
+    // status lines shouldn't suggest tweaking something that was never written.
+    // Rendered in yellow; the "\n\nnote: " prefix matches kDisclaimerMarker so
+    // restoreOutput can recolour it after a slot rebuild.
+    if (succeeded && pendingCaveat_.isNotEmpty()) {
         output_.setColour(juce::TextEditor::textColourId, juce::Colours::yellow);
-        // Wrap with CharPointer_UTF8 (matching the convention used for the
-        // arrow above) so the em-dash byte sequence isn't decoded as Latin-1
-        // by juce::String's const char* constructor and rendered as "â".
-        output_.insertTextAtCaret(juce::String(juce::CharPointer_UTF8(
-            "\n\nnote: starting point only \xe2\x80\x94 tweak by ear before saving.")));
+        output_.insertTextAtCaret("\n\n" + pendingCaveat_);
         output_.setColour(juce::TextEditor::textColourId,
                           DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
     }

--- a/magda/daw/ui/components/chain/ai/AIPanelComponent.hpp
+++ b/magda/daw/ui/components/chain/ai/AIPanelComponent.hpp
@@ -93,7 +93,10 @@ class AIPanelComponent : public juce::Component {
     // /design slash command flow in AIChatConsoleContent.
     class GenerateThread;
     std::unique_ptr<GenerateThread> thread_;
-    std::unique_ptr<DeviceAIAgent> agent_;
+
+    // Caveat text captured from the agent before it is moved into the thread.
+    // Used by onGenerationFinished to insert the yellow disclaimer line.
+    juce::String pendingCaveat_;
 
     JUCE_DECLARE_WEAK_REFERENCEABLE(AIPanelComponent)
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AIPanelComponent)

--- a/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
@@ -1,0 +1,1409 @@
+#include "custom_ui/PolyStepSequencerUI.hpp"
+
+#include "audio/plugins/DrumGridPlugin.hpp"
+#include "audio/transport/StepClock.hpp"
+#include "ui/themes/SmallComboBoxLookAndFeel.hpp"
+
+namespace magda::daw::ui {
+
+namespace te = tracktion::engine;
+
+using PolySeqPlugin = daw::audio::PolyStepSequencerPlugin;
+
+namespace {
+
+// Drum Grid chain child type (mirrors DrumGridPlugin's private chainTreeId)
+const juce::Identifier DRUM_CHAIN_TYPE("CHAIN");
+
+const char* POLY_NOTE_NAMES[] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+
+juce::String polyNoteNameShort(int noteNumber) {
+    if (noteNumber < 0 || noteNumber > 127)
+        return "-";
+    int octave = (noteNumber / 12) - 2;
+    return juce::String(POLY_NOTE_NAMES[noteNumber % 12]) + juce::String(octave);
+}
+
+bool isBlackKey(int noteNumber) {
+    static const bool isBlack[] = {false, true,  false, true,  false, false,
+                                   true,  false, true,  false, true,  false};
+    return isBlack[((noteNumber % 12) + 12) % 12];
+}
+
+}  // namespace
+
+// =============================================================================
+// KeysView — piano-roll style pitch x step grid
+// =============================================================================
+
+class PolyStepSequencerUI::KeysView : public PolyStepSequencerUI::PatternView {
+  public:
+    KeysView() = default;
+
+    void setPlugin(PolySeqPlugin* plugin) override {
+        plugin_ = plugin;
+        repaint();
+    }
+
+    void setPlayStep(int step) override {
+        if (step != playStep_) {
+            playStep_ = step;
+            repaint();
+        }
+    }
+
+    void patternChanged() override {
+        repaint();
+    }
+
+    void paint(juce::Graphics& g) override {
+        auto bounds = getLocalBounds();
+        if (bounds.isEmpty() || plugin_ == nullptr)
+            return;
+
+        auto arrowStrip = bounds.removeFromLeft(ARROW_STRIP_WIDTH);
+        octaveUpArea_ = arrowStrip.removeFromTop(arrowStrip.getHeight() / 2);
+        octaveDownArea_ = arrowStrip;
+        gutterArea_ = bounds.removeFromLeft(LEFT_GUTTER_WIDTH - ARROW_STRIP_WIDTH);
+        cellArea_ = bounds;
+
+        drawOctaveArrow(g, octaveUpArea_, true);
+        drawOctaveArrow(g, octaveDownArea_, false);
+
+        const int count = juce::jlimit(1, PolySeqPlugin::MAX_STEPS, plugin_->numSteps.get());
+        const float rowH = static_cast<float>(cellArea_.getHeight()) / NUM_VISIBLE_NOTES;
+        const float colW = static_cast<float>(cellArea_.getWidth()) / static_cast<float>(count);
+
+        g.setFont(FontManager::getInstance().getUIFont(7.0f));
+
+        // --- Pitch gutter: piano-key style rows, note names on C's ---
+        for (int row = 0; row < NUM_VISIBLE_NOTES; ++row) {
+            const int note = lowNote_ + (NUM_VISIBLE_NOTES - 1 - row);
+            auto rowRect = juce::Rectangle<float>(static_cast<float>(gutterArea_.getX()),
+                                                  gutterArea_.getY() + row * rowH,
+                                                  static_cast<float>(gutterArea_.getWidth()), rowH);
+
+            g.setColour(isBlackKey(note) ? juce::Colours::black.withAlpha(0.75f)
+                                         : juce::Colours::white.withAlpha(0.75f));
+            g.fillRect(rowRect.reduced(0.0f, 0.5f));
+
+            if (note % 12 == 0) {
+                g.setColour(DarkTheme::getColour(DarkTheme::BACKGROUND));
+                g.drawText(polyNoteNameShort(note), rowRect.toNearestInt(),
+                           juce::Justification::centred);
+            }
+        }
+
+        // --- Cells ---
+        for (int row = 0; row < NUM_VISIBLE_NOTES; ++row) {
+            const int note = lowNote_ + (NUM_VISIBLE_NOTES - 1 - row);
+            const float y = cellArea_.getY() + row * rowH;
+
+            for (int i = 0; i < count; ++i) {
+                const auto step = plugin_->getStep(i);
+                const float x = cellArea_.getX() + i * colW;
+                auto cellRect =
+                    juce::Rectangle<float>(x + 0.5f, y + 0.5f, colW - 1.0f, rowH - 1.0f);
+
+                // Background: black-key rows darker, playhead column highlighted
+                juce::Colour bg = DarkTheme::getColour(DarkTheme::BACKGROUND)
+                                      .brighter(isBlackKey(note) ? 0.04f : 0.10f);
+                if (i == playStep_)
+                    bg = bg.overlaidWith(
+                        DarkTheme::getColour(DarkTheme::ACCENT_GREEN).withAlpha(0.18f));
+                if (!step.gate)
+                    bg = bg.darker(0.3f);
+                g.setColour(bg);
+                g.fillRect(cellRect);
+
+                // Active note: opacity from effective velocity (per-note
+                // override, falling back to step velocity)
+                int noteVel = 0;
+                for (int n = 0; n < step.noteCount; ++n) {
+                    const auto& sn = step.notes[static_cast<size_t>(n)];
+                    if (sn.noteNumber == note) {
+                        noteVel = sn.velocity > 0 ? sn.velocity : step.velocity;
+                        break;
+                    }
+                }
+                if (noteVel > 0) {
+                    const float alpha = 0.35f + 0.6f * static_cast<float>(noteVel) / 127.0f;
+                    g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_BLUE).withAlpha(alpha));
+                    g.fillRoundedRectangle(cellRect, 1.5f);
+                }
+            }
+        }
+
+        // --- Grid lines: heavier every 4 steps and on C-row boundaries ---
+        for (int i = 0; i <= count; ++i) {
+            const float x = cellArea_.getX() + i * colW;
+            g.setColour(
+                DarkTheme::getColour(DarkTheme::BORDER).withAlpha(i % 4 == 0 ? 0.4f : 0.15f));
+            g.drawVerticalLine(juce::roundToInt(x), static_cast<float>(cellArea_.getY()),
+                               static_cast<float>(cellArea_.getBottom()));
+        }
+        for (int row = 0; row <= NUM_VISIBLE_NOTES; ++row) {
+            const int noteBelow = lowNote_ + (NUM_VISIBLE_NOTES - 1 - row);
+            const float y = cellArea_.getY() + row * rowH;
+            g.setColour(DarkTheme::getColour(DarkTheme::BORDER)
+                            .withAlpha((noteBelow + 1) % 12 == 0 ? 0.4f : 0.1f));
+            g.drawHorizontalLine(juce::roundToInt(y), static_cast<float>(cellArea_.getX()),
+                                 static_cast<float>(cellArea_.getRight()));
+        }
+    }
+
+    void mouseDown(const juce::MouseEvent& e) override {
+        if (plugin_ == nullptr)
+            return;
+        const auto pos = e.getPosition();
+
+        if (octaveUpArea_.contains(pos)) {
+            shiftWindow(12);
+            return;
+        }
+        if (octaveDownArea_.contains(pos)) {
+            shiftWindow(-12);
+            return;
+        }
+
+        if (!cellArea_.contains(pos))
+            return;
+
+        const int step = stepAt(pos.x);
+        const int note = noteAt(pos.y);
+        if (step < 0 || note < 0 || note > 127)
+            return;
+
+        if (e.mods.isRightButtonDown()) {
+            showStepContextMenu(step);
+            return;
+        }
+
+        plugin_->toggleStepNote(step, note);
+        repaint();
+    }
+
+    void mouseWheelMove(const juce::MouseEvent&, const juce::MouseWheelDetails& wheel) override {
+        shiftWindow(wheel.deltaY > 0 ? 2 : -2);
+    }
+
+  private:
+    static constexpr int NUM_VISIBLE_NOTES = 24;  // ~2 octaves
+    static constexpr int ARROW_STRIP_WIDTH = 14;
+
+    void shiftWindow(int semitones) {
+        const int next = juce::jlimit(0, 127 - NUM_VISIBLE_NOTES + 1, lowNote_ + semitones);
+        if (next != lowNote_) {
+            lowNote_ = next;
+            repaint();
+        }
+    }
+
+    int stepAt(int x) const {
+        if (plugin_ == nullptr || cellArea_.getWidth() <= 0)
+            return -1;
+        const int count = juce::jlimit(1, PolySeqPlugin::MAX_STEPS, plugin_->numSteps.get());
+        const int relX = x - cellArea_.getX();
+        if (relX < 0 || relX >= cellArea_.getWidth())
+            return -1;
+        return relX * count / cellArea_.getWidth();
+    }
+
+    int noteAt(int y) const {
+        if (cellArea_.getHeight() <= 0)
+            return -1;
+        const int relY = y - cellArea_.getY();
+        if (relY < 0 || relY >= cellArea_.getHeight())
+            return -1;
+        const int row = relY * NUM_VISIBLE_NOTES / cellArea_.getHeight();
+        return lowNote_ + (NUM_VISIBLE_NOTES - 1 - row);
+    }
+
+    void showStepContextMenu(int stepIndex) {
+        const auto step = plugin_->getStep(stepIndex);
+
+        juce::PopupMenu menu;
+        menu.addItem(1, step.gate ? "Mute Step" : "Unmute Step");
+        menu.addItem(2, "Clear Step");
+        menu.addSeparator();
+
+        juce::PopupMenu patternMenu;
+        patternMenu.addItem(10, "Shift +1 semitone");
+        patternMenu.addItem(11, "Shift -1 semitone");
+        patternMenu.addItem(12, "Shift +1 octave");
+        patternMenu.addItem(13, "Shift -1 octave");
+        patternMenu.addSeparator();
+        patternMenu.addItem(20, "Clear Pattern");
+        menu.addSubMenu("Pattern", patternMenu);
+
+        menu.showMenuAsync(juce::PopupMenu::Options(), [this, stepIndex](int result) {
+            if (plugin_ == nullptr)
+                return;
+            switch (result) {
+                case 1: {
+                    auto s = plugin_->getStep(stepIndex);
+                    plugin_->setStepGate(stepIndex, !s.gate);
+                    break;
+                }
+                case 2:
+                    plugin_->clearStep(stepIndex);
+                    break;
+                case 10:
+                    if (plugin_->transposePattern(1))
+                        shiftWindow(1);
+                    break;
+                case 11:
+                    if (plugin_->transposePattern(-1))
+                        shiftWindow(-1);
+                    break;
+                case 12:
+                    if (plugin_->transposePattern(12))
+                        shiftWindow(12);
+                    break;
+                case 13:
+                    if (plugin_->transposePattern(-12))
+                        shiftWindow(-12);
+                    break;
+                case 20:
+                    plugin_->clearPattern();
+                    break;
+                default:
+                    return;
+            }
+            repaint();
+        });
+    }
+
+    void drawOctaveArrow(juce::Graphics& g, juce::Rectangle<int> area, bool isUp) {
+        if (area.isEmpty())
+            return;
+
+        auto btn = area.reduced(2);
+        const bool canShift = isUp ? (lowNote_ < 127 - NUM_VISIBLE_NOTES + 1) : (lowNote_ > 0);
+
+        g.setColour(canShift ? DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.15f)
+                             : DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.05f));
+        g.fillRoundedRectangle(btn.toFloat(), 2.0f);
+
+        g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(0.3f));
+        g.drawRoundedRectangle(btn.toFloat(), 2.0f, 0.5f);
+
+        g.setColour(canShift ? DarkTheme::getTextColour()
+                             : DarkTheme::getSecondaryTextColour().withAlpha(0.3f));
+        const float cx = static_cast<float>(btn.getCentreX());
+        const float cy = static_cast<float>(btn.getCentreY());
+        constexpr float arrowSize = 4.0f;
+        juce::Path arrow;
+        if (isUp) {
+            arrow.addTriangle(cx - arrowSize, cy + arrowSize, cx + arrowSize, cy + arrowSize, cx,
+                              cy - arrowSize);
+        } else {
+            arrow.addTriangle(cx - arrowSize, cy - arrowSize, cx + arrowSize, cy - arrowSize, cx,
+                              cy + arrowSize);
+        }
+        g.fillPath(arrow);
+    }
+
+    PolySeqPlugin* plugin_ = nullptr;
+    int playStep_ = -1;
+    int lowNote_ = 48;  // C2..B3 window — C3 (60) centered
+
+    juce::Rectangle<int> octaveUpArea_;
+    juce::Rectangle<int> octaveDownArea_;
+    juce::Rectangle<int> gutterArea_;
+    juce::Rectangle<int> cellArea_;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(KeysView)
+};
+
+// =============================================================================
+// DrumLanesView — classic x0x drum-lane grid
+// =============================================================================
+//
+// One horizontal lane per drum sound, lowest note at the bottom (drum machine
+// convention). The lane set is discovered from a Drum Grid plugin downstream
+// of the sequencer in the same chain (one lane per chain, triggered by the
+// chain's low note). Without a Drum Grid a generic GM drum map is shown, and
+// pattern notes that match no lane get an orphan lane so they stay editable.
+
+class PolyStepSequencerUI::DrumLanesView : public PolyStepSequencerUI::PatternView,
+                                           private juce::ValueTree::Listener {
+  public:
+    DrumLanesView() = default;
+
+    ~DrumLanesView() override {
+        detachStateListeners();
+    }
+
+    void setPlugin(PolySeqPlugin* plugin) override {
+        detachStateListeners();
+        plugin_ = plugin;
+
+        // Watch the owner track's tree so the lane set follows Drum Grid
+        // devices being added / removed / reordered in the chain.
+        if (plugin_ != nullptr) {
+            if (auto* track = plugin_->getOwnerTrack()) {
+                trackState_ = track->state;
+                trackState_.addListener(this);
+            }
+        }
+        refreshLanes();
+    }
+
+    void setPlayStep(int step) override {
+        if (step != playStep_) {
+            playStep_ = step;
+            repaint();
+        }
+    }
+
+    void patternChanged() override {
+        // Pattern edits can add or remove orphan lanes
+        refreshLanes();
+    }
+
+    void paint(juce::Graphics& g) override {
+        auto bounds = getLocalBounds();
+        if (bounds.isEmpty() || plugin_ == nullptr || lanes_.empty())
+            return;
+
+        auto arrowStrip = bounds.removeFromLeft(ARROW_STRIP_WIDTH);
+        scrollUpArea_ = arrowStrip.removeFromTop(arrowStrip.getHeight() / 2);
+        scrollDownArea_ = arrowStrip;
+        labelArea_ = bounds.removeFromLeft(LEFT_GUTTER_WIDTH - ARROW_STRIP_WIDTH);
+        cellArea_ = bounds;
+
+        const int numLanes = static_cast<int>(lanes_.size());
+        const int visible = visibleLaneCount();
+        const float laneH = laneHeight();
+        if (visible <= 0)
+            return;
+        clampScrollOffset();
+
+        drawScrollArrow(g, scrollUpArea_, true);
+        drawScrollArrow(g, scrollDownArea_, false);
+
+        g.setFont(FontManager::getInstance().getUIFont(7.0f));
+
+        const int count = juce::jlimit(1, PolySeqPlugin::MAX_STEPS, plugin_->numSteps.get());
+        const float colW = static_cast<float>(cellArea_.getWidth()) / static_cast<float>(count);
+
+        for (int row = 0; row < visible; ++row) {
+            const int laneIdx = scrollOffset_ + (visible - 1 - row);
+            if (laneIdx < 0 || laneIdx >= numLanes)
+                continue;
+            const auto& lane = lanes_[static_cast<size_t>(laneIdx)];
+            const float y = cellArea_.getY() + row * laneH;
+
+            // --- Lane label gutter ---
+            auto labelRect =
+                juce::Rectangle<float>(static_cast<float>(labelArea_.getX()), y,
+                                       static_cast<float>(labelArea_.getWidth()), laneH);
+            g.setColour(DarkTheme::getColour(DarkTheme::BACKGROUND)
+                            .brighter(laneIdx % 2 == 0 ? 0.18f : 0.12f));
+            g.fillRect(labelRect.reduced(0.0f, 0.5f));
+            g.setColour(lane.orphan ? DarkTheme::getSecondaryTextColour()
+                                    : DarkTheme::getTextColour());
+            g.drawText(lane.label, labelRect.toNearestInt().reduced(2, 0),
+                       juce::Justification::centredLeft);
+
+            // --- Cells ---
+            for (int i = 0; i < count; ++i) {
+                const auto step = plugin_->getStep(i);
+                const float x = cellArea_.getX() + i * colW;
+                auto cellRect =
+                    juce::Rectangle<float>(x + 0.5f, y + 0.5f, colW - 1.0f, laneH - 1.0f);
+
+                // Background: alternate lane shading, playhead column highlighted
+                juce::Colour bg = DarkTheme::getColour(DarkTheme::BACKGROUND)
+                                      .brighter(laneIdx % 2 == 0 ? 0.10f : 0.04f);
+                if (i == playStep_)
+                    bg = bg.overlaidWith(
+                        DarkTheme::getColour(DarkTheme::ACCENT_GREEN).withAlpha(0.18f));
+                if (!step.gate)
+                    bg = bg.darker(0.3f);
+                g.setColour(bg);
+                g.fillRect(cellRect);
+
+                // Active hit: opacity from effective velocity (per-note
+                // override, falling back to step velocity)
+                int noteVel = 0;
+                for (int n = 0; n < step.noteCount; ++n) {
+                    const auto& sn = step.notes[static_cast<size_t>(n)];
+                    if (sn.noteNumber == lane.note) {
+                        noteVel = sn.velocity > 0 ? sn.velocity : step.velocity;
+                        break;
+                    }
+                }
+                if (noteVel > 0) {
+                    const float alpha = 0.35f + 0.6f * static_cast<float>(noteVel) / 127.0f;
+                    g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_BLUE).withAlpha(alpha));
+                    g.fillRoundedRectangle(cellRect, 1.5f);
+                }
+            }
+        }
+
+        // --- Grid lines: heavier every 4 steps ---
+        for (int i = 0; i <= count; ++i) {
+            const float x = cellArea_.getX() + i * colW;
+            g.setColour(
+                DarkTheme::getColour(DarkTheme::BORDER).withAlpha(i % 4 == 0 ? 0.4f : 0.15f));
+            g.drawVerticalLine(juce::roundToInt(x), static_cast<float>(cellArea_.getY()),
+                               static_cast<float>(cellArea_.getBottom()));
+        }
+        for (int row = 0; row <= visible; ++row) {
+            const float y = cellArea_.getY() + row * laneH;
+            g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(0.15f));
+            g.drawHorizontalLine(juce::roundToInt(y), static_cast<float>(cellArea_.getX()),
+                                 static_cast<float>(cellArea_.getRight()));
+        }
+    }
+
+    void mouseDown(const juce::MouseEvent& e) override {
+        if (plugin_ == nullptr)
+            return;
+        const auto pos = e.getPosition();
+
+        if (scrollUpArea_.contains(pos)) {
+            scrollBy(1);
+            return;
+        }
+        if (scrollDownArea_.contains(pos)) {
+            scrollBy(-1);
+            return;
+        }
+
+        if (!cellArea_.contains(pos))
+            return;
+
+        const int step = stepAt(pos.x);
+        const int laneIdx = laneAt(pos.y);
+        if (step < 0 || laneIdx < 0)
+            return;
+
+        if (e.mods.isRightButtonDown()) {
+            showStepContextMenu(step);
+            return;
+        }
+
+        plugin_->toggleStepNote(step, lanes_[static_cast<size_t>(laneIdx)].note);
+        repaint();
+    }
+
+    void mouseWheelMove(const juce::MouseEvent&, const juce::MouseWheelDetails& wheel) override {
+        scrollBy(wheel.deltaY > 0 ? 1 : -1);
+    }
+
+  private:
+    static constexpr int ARROW_STRIP_WIDTH = 14;
+    static constexpr int MIN_LANE_HEIGHT = 14;
+
+    struct Lane {
+        int note = 60;        // MIDI note that triggers this lane's sound
+        juce::String label;   // Chain name / GM name / note name
+        bool orphan = false;  // Pattern data with no matching Drum Grid chain
+    };
+
+    // --- Lane discovery ---
+
+    /** Find a Drum Grid downstream of the sequencer on the owner track,
+     *  looking inside rack instances (instruments are rack-wrapped). If the
+     *  sequencer itself is not on the top-level list, any Drum Grid on the
+     *  track is accepted. */
+    daw::audio::DrumGridPlugin* findDownstreamDrumGrid() const {
+        if (plugin_ == nullptr)
+            return nullptr;
+        auto* track = plugin_->getOwnerTrack();
+        if (track == nullptr)
+            return nullptr;
+
+        bool passedSelf = false;
+        daw::audio::DrumGridPlugin* fallback = nullptr;
+        for (auto* p : track->pluginList) {
+            if (p == plugin_) {
+                passedSelf = true;
+                continue;
+            }
+            auto* found = dynamic_cast<daw::audio::DrumGridPlugin*>(p);
+            if (found == nullptr) {
+                if (auto* rackInstance = dynamic_cast<te::RackInstance*>(p)) {
+                    if (rackInstance->type != nullptr) {
+                        for (auto* inner : rackInstance->type->getPlugins()) {
+                            found = dynamic_cast<daw::audio::DrumGridPlugin*>(inner);
+                            if (found != nullptr)
+                                break;
+                        }
+                    }
+                }
+            }
+            if (found != nullptr) {
+                if (passedSelf)
+                    return found;
+                if (fallback == nullptr)
+                    fallback = found;
+            }
+        }
+        return passedSelf ? nullptr : fallback;
+    }
+
+    /** Rebuild the lane list: Drum Grid chains (or GM fallback) + orphan
+     *  lanes for pattern notes that match no chain. Sorted note-ascending so
+     *  the lowest lane paints at the bottom. */
+    void refreshLanes() {
+        auto* drumGrid = findDownstreamDrumGrid();
+
+        // (Re)attach the Drum Grid state listener when the target changes,
+        // so chain renames / note-range edits refresh the lane labels.
+        auto newState = drumGrid != nullptr ? drumGrid->state : juce::ValueTree();
+        if (newState != drumGridState_) {
+            if (drumGridState_.isValid())
+                drumGridState_.removeListener(this);
+            drumGridState_ = newState;
+            if (drumGridState_.isValid())
+                drumGridState_.addListener(this);
+        }
+
+        lanes_.clear();
+        if (drumGrid != nullptr) {
+            for (const auto& chain : drumGrid->getChains()) {
+                if (chain == nullptr)
+                    continue;
+                // The chain's low note is the incoming MIDI note that triggers
+                // the pad (single-note chains have lowNote == highNote).
+                Lane lane;
+                lane.note = chain->lowNote;
+                lane.label =
+                    chain->name.isNotEmpty() ? chain->name : polyNoteNameShort(chain->lowNote);
+                lanes_.push_back(std::move(lane));
+            }
+        }
+
+        if (lanes_.empty()) {
+            // No Drum Grid downstream (or it has no pads yet): GM drum map
+            static const struct {
+                int note;
+                const char* name;
+            } gmLanes[] = {{36, "Kick"}, {38, "Snare"}, {42, "CHat"},  {46, "OHat"},
+                           {41, "LTom"}, {47, "MTom"},  {49, "Crash"}, {51, "Ride"}};
+            for (const auto& gm : gmLanes)
+                lanes_.push_back({gm.note, gm.name, false});
+        }
+
+        // Pattern notes with no matching lane stay visible and editable
+        if (plugin_ != nullptr) {
+            for (int i = 0; i < PolySeqPlugin::MAX_STEPS; ++i) {
+                const auto step = plugin_->getStep(i);
+                for (int n = 0; n < step.noteCount; ++n) {
+                    const int note = step.notes[static_cast<size_t>(n)].noteNumber;
+                    if (!hasLaneForNote(note))
+                        lanes_.push_back({note, polyNoteNameShort(note), true});
+                }
+            }
+        }
+
+        std::sort(lanes_.begin(), lanes_.end(),
+                  [](const Lane& a, const Lane& b) { return a.note < b.note; });
+        lanes_.erase(std::unique(lanes_.begin(), lanes_.end(),
+                                 [](const Lane& a, const Lane& b) { return a.note == b.note; }),
+                     lanes_.end());
+
+        clampScrollOffset();
+        repaint();
+    }
+
+    bool hasLaneForNote(int note) const {
+        for (const auto& lane : lanes_)
+            if (lane.note == note)
+                return true;
+        return false;
+    }
+
+    /** Coalesced async lane refresh (ValueTree callbacks can fire mid-edit). */
+    void triggerLaneRefresh() {
+        if (refreshPending_)
+            return;
+        refreshPending_ = true;
+        juce::MessageManager::callAsync(
+            [safeThis = juce::Component::SafePointer<DrumLanesView>(this)] {
+                if (safeThis != nullptr) {
+                    safeThis->refreshPending_ = false;
+                    safeThis->refreshLanes();
+                }
+            });
+    }
+
+    void detachStateListeners() {
+        if (trackState_.isValid()) {
+            trackState_.removeListener(this);
+            trackState_ = juce::ValueTree();
+        }
+        if (drumGridState_.isValid()) {
+            drumGridState_.removeListener(this);
+            drumGridState_ = juce::ValueTree();
+        }
+    }
+
+    // ValueTree::Listener — chain membership (track tree) + Drum Grid chains
+    void valueTreePropertyChanged(juce::ValueTree& tree, const juce::Identifier&) override {
+        if (tree.hasType(DRUM_CHAIN_TYPE))
+            triggerLaneRefresh();
+    }
+    void valueTreeChildAdded(juce::ValueTree&, juce::ValueTree& child) override {
+        if (child.hasType(te::IDs::PLUGIN) || child.hasType(DRUM_CHAIN_TYPE))
+            triggerLaneRefresh();
+    }
+    void valueTreeChildRemoved(juce::ValueTree&, juce::ValueTree& child, int) override {
+        if (child.hasType(te::IDs::PLUGIN) || child.hasType(DRUM_CHAIN_TYPE))
+            triggerLaneRefresh();
+    }
+    void valueTreeChildOrderChanged(juce::ValueTree& parent, int, int) override {
+        if (parent == trackState_)
+            triggerLaneRefresh();
+    }
+
+    // --- Scrolling / geometry ---
+
+    int visibleLaneCount() const {
+        const int numLanes = static_cast<int>(lanes_.size());
+        if (numLanes == 0 || cellArea_.getHeight() <= 0)
+            return 0;
+        if (numLanes * MIN_LANE_HEIGHT <= cellArea_.getHeight())
+            return numLanes;
+        return juce::jmax(1, cellArea_.getHeight() / MIN_LANE_HEIGHT);
+    }
+
+    float laneHeight() const {
+        const int visible = visibleLaneCount();
+        return visible > 0 ? static_cast<float>(cellArea_.getHeight()) / static_cast<float>(visible)
+                           : 0.0f;
+    }
+
+    void clampScrollOffset() {
+        const int maxOffset = juce::jmax(0, static_cast<int>(lanes_.size()) - visibleLaneCount());
+        scrollOffset_ = juce::jlimit(0, maxOffset, scrollOffset_);
+    }
+
+    void scrollBy(int deltaLanes) {
+        const int previous = scrollOffset_;
+        scrollOffset_ += deltaLanes;
+        clampScrollOffset();
+        if (scrollOffset_ != previous)
+            repaint();
+    }
+
+    int stepAt(int x) const {
+        if (plugin_ == nullptr || cellArea_.getWidth() <= 0)
+            return -1;
+        const int count = juce::jlimit(1, PolySeqPlugin::MAX_STEPS, plugin_->numSteps.get());
+        const int relX = x - cellArea_.getX();
+        if (relX < 0 || relX >= cellArea_.getWidth())
+            return -1;
+        return relX * count / cellArea_.getWidth();
+    }
+
+    int laneAt(int y) const {
+        const int visible = visibleLaneCount();
+        const float laneH = laneHeight();
+        if (visible <= 0 || laneH <= 0.0f)
+            return -1;
+        const int relY = y - cellArea_.getY();
+        if (relY < 0 || relY >= cellArea_.getHeight())
+            return -1;
+        const int row = juce::jmin(visible - 1, static_cast<int>(relY / laneH));
+        const int laneIdx = scrollOffset_ + (visible - 1 - row);
+        return (laneIdx >= 0 && laneIdx < static_cast<int>(lanes_.size())) ? laneIdx : -1;
+    }
+
+    void showStepContextMenu(int stepIndex) {
+        const auto step = plugin_->getStep(stepIndex);
+
+        juce::PopupMenu menu;
+        menu.addItem(1, step.gate ? "Mute Step" : "Unmute Step");
+        menu.addItem(2, "Clear Step");
+        menu.addSeparator();
+
+        juce::PopupMenu patternMenu;
+        patternMenu.addItem(10, "Shift +1 semitone");
+        patternMenu.addItem(11, "Shift -1 semitone");
+        patternMenu.addItem(12, "Shift +1 octave");
+        patternMenu.addItem(13, "Shift -1 octave");
+        patternMenu.addSeparator();
+        patternMenu.addItem(20, "Clear Pattern");
+        menu.addSubMenu("Pattern", patternMenu);
+
+        menu.showMenuAsync(juce::PopupMenu::Options(), [this, stepIndex](int result) {
+            if (plugin_ == nullptr)
+                return;
+            switch (result) {
+                case 1: {
+                    auto s = plugin_->getStep(stepIndex);
+                    plugin_->setStepGate(stepIndex, !s.gate);
+                    break;
+                }
+                case 2:
+                    plugin_->clearStep(stepIndex);
+                    break;
+                case 10:
+                    plugin_->transposePattern(1);
+                    break;
+                case 11:
+                    plugin_->transposePattern(-1);
+                    break;
+                case 12:
+                    plugin_->transposePattern(12);
+                    break;
+                case 13:
+                    plugin_->transposePattern(-12);
+                    break;
+                case 20:
+                    plugin_->clearPattern();
+                    break;
+                default:
+                    return;
+            }
+            repaint();
+        });
+    }
+
+    void drawScrollArrow(juce::Graphics& g, juce::Rectangle<int> area, bool isUp) {
+        if (area.isEmpty())
+            return;
+
+        auto btn = area.reduced(2);
+        const int maxOffset = juce::jmax(0, static_cast<int>(lanes_.size()) - visibleLaneCount());
+        const bool canShift = isUp ? (scrollOffset_ < maxOffset) : (scrollOffset_ > 0);
+
+        g.setColour(canShift ? DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.15f)
+                             : DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.05f));
+        g.fillRoundedRectangle(btn.toFloat(), 2.0f);
+
+        g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(0.3f));
+        g.drawRoundedRectangle(btn.toFloat(), 2.0f, 0.5f);
+
+        g.setColour(canShift ? DarkTheme::getTextColour()
+                             : DarkTheme::getSecondaryTextColour().withAlpha(0.3f));
+        const float cx = static_cast<float>(btn.getCentreX());
+        const float cy = static_cast<float>(btn.getCentreY());
+        constexpr float arrowSize = 4.0f;
+        juce::Path arrow;
+        if (isUp) {
+            arrow.addTriangle(cx - arrowSize, cy + arrowSize, cx + arrowSize, cy + arrowSize, cx,
+                              cy - arrowSize);
+        } else {
+            arrow.addTriangle(cx - arrowSize, cy - arrowSize, cx + arrowSize, cy - arrowSize, cx,
+                              cy + arrowSize);
+        }
+        g.fillPath(arrow);
+    }
+
+    PolySeqPlugin* plugin_ = nullptr;
+    int playStep_ = -1;
+    int scrollOffset_ = 0;  // Index of the bottom-most visible lane
+    bool refreshPending_ = false;
+
+    std::vector<Lane> lanes_;  // Sorted note-ascending (lowest paints at the bottom)
+
+    juce::ValueTree trackState_;     // Owner track tree (chain membership)
+    juce::ValueTree drumGridState_;  // Discovered Drum Grid state (CHAIN children)
+
+    juce::Rectangle<int> scrollUpArea_;
+    juce::Rectangle<int> scrollDownArea_;
+    juce::Rectangle<int> labelArea_;
+    juce::Rectangle<int> cellArea_;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DrumLanesView)
+};
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+PolyStepSequencerUI::PolyStepSequencerUI() {
+    setupLabel(rateLabel_, "RATE");
+    setupSlider(rateSlider_, 0, 9, 1);
+    static const char* rateNames[] = {"1/4.", "1/4",   "1/4T", "1/8.",  "1/8",
+                                      "1/8T", "1/16.", "1/16", "1/16T", "1/32"};
+    rateSlider_.setValueFormatter([](double v) {
+        int idx = juce::jlimit(0, 9, juce::roundToInt(v));
+        return juce::String(rateNames[idx]);
+    });
+    rateSlider_.setValueParser([](const juce::String&) { return 1.0; });
+    rateSlider_.onValueChanged = [this](double value) {
+        if (plugin_)
+            plugin_->rate = juce::roundToInt(value);
+    };
+
+    setupLabel(stepsLabel_, "STEPS");
+    setupSlider(stepsSlider_, 1, PolySeqPlugin::MAX_STEPS, 1);
+    stepsSlider_.setValueFormatter([](double v) { return juce::String(juce::roundToInt(v)); });
+    stepsSlider_.setValueParser([](const juce::String& t) { return t.getDoubleValue(); });
+    stepsSlider_.onValueChanged = [this](double value) {
+        if (plugin_) {
+            int steps = juce::roundToInt(value);
+            plugin_->numSteps = steps;
+            rampCurveDisplay_.setNumTicks(steps);
+            // Clamp cycles to num steps
+            cyclesSlider_.setRange(1.0, static_cast<double>(steps), 1.0);
+            if (cyclesSlider_.getValue() > steps)
+                cyclesSlider_.setValue(static_cast<double>(steps), juce::sendNotificationSync);
+            repaint();
+        }
+    };
+
+    setupLabel(dirLabel_, "DIR");
+    dirCombo_.setLookAndFeel(&SmallComboBoxLookAndFeel::getInstance());
+    dirCombo_.setColour(juce::ComboBox::backgroundColourId,
+                        DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.1f));
+    dirCombo_.setColour(juce::ComboBox::textColourId, DarkTheme::getTextColour());
+    dirCombo_.setColour(juce::ComboBox::outlineColourId, DarkTheme::getColour(DarkTheme::BORDER));
+    dirCombo_.addItem("Forward", 1);
+    dirCombo_.addItem("Reverse", 2);
+    dirCombo_.addItem("Ping-Pong", 3);
+    dirCombo_.addItem("Random", 4);
+    dirCombo_.onChange = [this] {
+        if (plugin_)
+            plugin_->direction = dirCombo_.getSelectedId() - 1;
+    };
+    addAndMakeVisible(dirCombo_);
+
+    setupLabel(swingLabel_, "SWING");
+    setupSlider(swingSlider_, 0.0, 1.0, 0.01);
+    swingSlider_.setValueFormatter(
+        [](double v) { return juce::String(juce::roundToInt(v * 100)) + "%"; });
+    swingSlider_.setValueParser(
+        [](const juce::String& t) { return t.replace("%", "").trim().getDoubleValue() / 100.0; });
+    swingSlider_.onValueChanged = [this](double value) {
+        if (plugin_)
+            plugin_->swing = static_cast<float>(value);
+    };
+
+    setupLabel(gateLengthLabel_, "GATE");
+    setupSlider(gateLengthSlider_, 0.05, 1.0, 0.01);
+    gateLengthSlider_.setValueFormatter(
+        [](double v) { return juce::String(juce::roundToInt(v * 100)) + "%"; });
+    gateLengthSlider_.setValueParser(
+        [](const juce::String& t) { return t.replace("%", "").trim().getDoubleValue() / 100.0; });
+    gateLengthSlider_.onValueChanged = [this](double value) {
+        if (plugin_)
+            plugin_->gateLength = static_cast<float>(value);
+    };
+
+    // Quantize slider (adaptive snap strength 0-100%)
+    setupLabel(quantizeLabel_, "QUANTIZE");
+    setupSlider(quantizeSlider_, 0.0, 1.0, 0.01);
+    quantizeSlider_.setValueFormatter(
+        [](double v) { return juce::String(juce::roundToInt(v * 100)) + "%"; });
+    quantizeSlider_.setValueParser(
+        [](const juce::String& t) { return t.replace("%", "").trim().getDoubleValue() / 100.0; });
+    quantizeSlider_.onValueChanged = [this](double value) {
+        if (plugin_)
+            plugin_->quantize = static_cast<float>(value);
+    };
+
+    // Quantize subdivisions (grid resolution, multiples of 16)
+    setupLabel(quantizeSubLabel_, "SUB");
+    setupSlider(quantizeSubSlider_, 16, 512, 16);
+    quantizeSubSlider_.setValueFormatter(
+        [](double v) { return juce::String(juce::roundToInt(v)); });
+    quantizeSubSlider_.setValueParser(
+        [](const juce::String& t) { return t.trim().getDoubleValue(); });
+    quantizeSubSlider_.onValueChanged = [this](double value) {
+        if (plugin_)
+            plugin_->quantizeSub = juce::roundToInt(value);
+    };
+
+    // --- Ramp curve (time warp) ---
+    setupLabel(rampLabel_, "TIME BEND");
+    addAndMakeVisible(rampCurveDisplay_);
+    rampCurveDisplay_.onCurveChanged = [this](float depth, float skew) {
+        if (plugin_) {
+            plugin_->ramp = depth;
+            plugin_->skew = skew;
+        }
+    };
+
+    setupLabel(depthLabel_, "DEPTH");
+    depthLabel_.setJustificationType(juce::Justification::centred);
+    setupSlider(depthSlider_, -1.0, 1.0, 0.01);
+    depthSlider_.setValueFormatter(
+        [](double v) { return juce::String(juce::roundToInt(v * 100)); });
+    depthSlider_.setValueParser(
+        [](const juce::String& t) { return t.trim().getDoubleValue() / 100.0; });
+    depthSlider_.onValueChanged = [this](double value) {
+        if (plugin_) {
+            plugin_->ramp = static_cast<float>(value);
+            rampCurveDisplay_.setValues(static_cast<float>(value), plugin_->skew.get());
+        }
+    };
+
+    setupLabel(skewLabel_, "SKEW");
+    skewLabel_.setJustificationType(juce::Justification::centred);
+    setupSlider(skewSlider_, -1.0, 1.0, 0.01);
+    skewSlider_.setValueFormatter([](double v) { return juce::String(juce::roundToInt(v * 100)); });
+    skewSlider_.setValueParser(
+        [](const juce::String& t) { return t.trim().getDoubleValue() / 100.0; });
+    skewSlider_.onValueChanged = [this](double value) {
+        if (plugin_) {
+            plugin_->skew = static_cast<float>(value);
+            rampCurveDisplay_.setValues(plugin_->ramp.get(), static_cast<float>(value));
+        }
+    };
+
+    setupLabel(cyclesLabel_, "CYCLES");
+    setupSlider(cyclesSlider_, 1.0, static_cast<double>(PolySeqPlugin::MAX_STEPS), 1.0);
+    cyclesSlider_.setValueFormatter([](double v) { return juce::String(juce::roundToInt(v)); });
+    cyclesSlider_.setValueParser([](const juce::String& t) { return t.getDoubleValue(); });
+    cyclesSlider_.onValueChanged = [this](double value) {
+        if (plugin_)
+            plugin_->rampCycles = juce::roundToInt(value);
+    };
+
+    // Hard angle toggle (right-click on control point)
+    rampCurveDisplay_.onHardAngleChanged = [this](bool hardAngle) {
+        if (plugin_)
+            plugin_->hardAngle = hardAngle;
+    };
+
+    // --- MIDI controls ---
+    midiThruButton_ = std::make_unique<magda::SvgButton>("MidiThru", BinaryData::compare_svg,
+                                                         BinaryData::compare_svgSize);
+    midiThruButton_->setOriginalColor(juce::Colour(0xFFB3B3B3));
+    midiThruButton_->setNormalColor(DarkTheme::getColour(DarkTheme::ACCENT_GREEN));
+    midiThruButton_->setTooltip("MIDI thru: pass input to downstream instruments");
+    midiThruButton_->setToggleable(true);
+    midiThruButton_->setActive(false);
+    midiThruButton_->onClick = [this] {
+        if (plugin_) {
+            bool newState = !midiThruButton_->isActive();
+            midiThruButton_->setActive(newState);
+            plugin_->midiThru = newState;
+        }
+    };
+    addAndMakeVisible(midiThruButton_.get());
+
+    // --- View mode toggle (keys / drum) ---
+    viewModeButton_.setButtonText("KEYS");
+    viewModeButton_.setClickingTogglesState(true);
+    viewModeButton_.setColour(juce::TextButton::buttonColourId,
+                              DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.1f));
+    viewModeButton_.setColour(juce::TextButton::buttonOnColourId,
+                              DarkTheme::getAccentColour().withAlpha(0.6f));
+    viewModeButton_.setColour(juce::TextButton::textColourOffId, DarkTheme::getTextColour());
+    viewModeButton_.setColour(juce::TextButton::textColourOnId, DarkTheme::getTextColour());
+    viewModeButton_.setTooltip("Switch between keys and drum-lane pattern views");
+    viewModeButton_.onClick = [this] {
+        if (plugin_)
+            plugin_->viewMode =
+                viewModeButton_.getToggleState() ? juce::String("drum") : juce::String("keys");
+        updatePatternViewMode();
+    };
+    addAndMakeVisible(viewModeButton_);
+
+    // --- Pattern view (keys mode default; swapped by updatePatternViewMode) ---
+    patternView_ = std::make_unique<KeysView>();
+    addAndMakeVisible(*patternView_);
+}
+
+PolyStepSequencerUI::~PolyStepSequencerUI() {
+    stopTimer();
+    if (watchedState_.isValid())
+        watchedState_.removeListener(this);
+    dirCombo_.setLookAndFeel(nullptr);
+}
+
+// =============================================================================
+// Plugin binding
+// =============================================================================
+
+void PolyStepSequencerUI::setPlugin(daw::audio::PolyStepSequencerPlugin* plugin) {
+    stopTimer();
+    if (watchedState_.isValid())
+        watchedState_.removeListener(this);
+
+    plugin_ = plugin;
+    patternView_->setPlugin(plugin);
+
+    if (plugin_) {
+        watchedState_ = plugin_->state;
+        watchedState_.addListener(this);
+        syncFromPlugin();
+        startTimerHz(30);
+    }
+}
+
+void PolyStepSequencerUI::updatePatternViewMode() {
+    const bool wantDrum = plugin_ != nullptr && plugin_->viewMode.get() == "drum";
+    if (wantDrum != drumViewActive_) {
+        drumViewActive_ = wantDrum;
+        patternView_ = wantDrum ? std::unique_ptr<PatternView>(std::make_unique<DrumLanesView>())
+                                : std::unique_ptr<PatternView>(std::make_unique<KeysView>());
+        addAndMakeVisible(*patternView_);
+        patternView_->setPlugin(plugin_);
+        patternView_->setPlayStep(currentPlayStep_);
+        resized();
+    }
+    viewModeButton_.setToggleState(drumViewActive_, juce::dontSendNotification);
+    viewModeButton_.setButtonText(drumViewActive_ ? "DRUM" : "KEYS");
+}
+
+void PolyStepSequencerUI::syncFromPlugin() {
+    if (!plugin_)
+        return;
+
+    updatePatternViewMode();
+    rateSlider_.setValue(static_cast<double>(plugin_->rate.get()), juce::dontSendNotification);
+    stepsSlider_.setValue(static_cast<double>(plugin_->numSteps.get()), juce::dontSendNotification);
+    dirCombo_.setSelectedId(plugin_->direction.get() + 1, juce::dontSendNotification);
+    swingSlider_.setValue(static_cast<double>(plugin_->swing.get()), juce::dontSendNotification);
+    gateLengthSlider_.setValue(static_cast<double>(plugin_->gateLength.get()),
+                               juce::dontSendNotification);
+    depthSlider_.setValue(static_cast<double>(plugin_->ramp.get()), juce::dontSendNotification);
+    skewSlider_.setValue(static_cast<double>(plugin_->skew.get()), juce::dontSendNotification);
+    rampCurveDisplay_.setValues(plugin_->ramp.get(), plugin_->skew.get());
+    rampCurveDisplay_.setHardAngle(plugin_->hardAngle.get());
+    int steps = plugin_->numSteps.get();
+    rampCurveDisplay_.setNumTicks(steps);
+    cyclesSlider_.setRange(1.0, static_cast<double>(steps), 1.0);
+    quantizeSlider_.setValue(static_cast<double>(plugin_->quantize.get()),
+                             juce::dontSendNotification);
+    quantizeSubSlider_.setValue(static_cast<double>(plugin_->quantizeSub.get()),
+                                juce::dontSendNotification);
+    cyclesSlider_.setValue(static_cast<double>(juce::jlimit(1, steps, plugin_->rampCycles.get())),
+                           juce::dontSendNotification);
+    midiThruButton_->setActive(plugin_->midiThru.get());
+    patternView_->patternChanged();
+    repaint();
+}
+
+void PolyStepSequencerUI::valueTreePropertyChanged(juce::ValueTree&, const juce::Identifier&) {
+    juce::MessageManager::callAsync([safeThis = juce::Component::SafePointer(this)] {
+        if (safeThis)
+            safeThis->syncFromPlugin();
+    });
+}
+
+void PolyStepSequencerUI::valueTreeChildAdded(juce::ValueTree&, juce::ValueTree&) {
+    juce::MessageManager::callAsync([safeThis = juce::Component::SafePointer(this)] {
+        if (safeThis)
+            safeThis->syncFromPlugin();
+    });
+}
+
+void PolyStepSequencerUI::valueTreeChildRemoved(juce::ValueTree&, juce::ValueTree&, int) {
+    juce::MessageManager::callAsync([safeThis = juce::Component::SafePointer(this)] {
+        if (safeThis)
+            safeThis->syncFromPlugin();
+    });
+}
+
+void PolyStepSequencerUI::timerCallback() {
+    if (!plugin_)
+        return;
+
+    int step = plugin_->currentPlayStep_.load(std::memory_order_relaxed);
+    if (step != currentPlayStep_) {
+        currentPlayStep_ = step;
+        patternView_->setPlayStep(step);
+        // Update curve display sweep
+        int numSteps = juce::jlimit(1, PolySeqPlugin::MAX_STEPS, plugin_->numSteps.get());
+        float pos = (step >= 0) ? static_cast<float>(step) / static_cast<float>(numSteps) : -1.0f;
+        rampCurveDisplay_.setPlaybackPosition(pos,
+                                              juce::jlimit(1, numSteps, plugin_->rampCycles.get()));
+    }
+}
+
+// =============================================================================
+// Layout
+// =============================================================================
+
+void PolyStepSequencerUI::resized() {
+    auto bounds = getLocalBounds().reduced(PADDING);
+
+    // Controls row 1: RATE, STEPS, DIRECTION
+    auto controlRow1 = bounds.removeFromTop(CONTROL_ROW_HEIGHT);
+    int controlWidth = controlRow1.getWidth() / 3;
+    {
+        auto cell = controlRow1.removeFromLeft(controlWidth);
+        rateLabel_.setBounds(cell.removeFromLeft(LABEL_WIDTH));
+        rateSlider_.setBounds(cell);
+    }
+    {
+        auto cell = controlRow1.removeFromLeft(controlWidth);
+        stepsLabel_.setBounds(cell.removeFromLeft(LABEL_WIDTH));
+        stepsSlider_.setBounds(cell);
+    }
+    {
+        dirLabel_.setBounds(controlRow1.removeFromLeft(LABEL_WIDTH));
+        dirCombo_.setBounds(controlRow1);
+    }
+
+    bounds.removeFromTop(ROW_GAP);
+
+    // Controls row 2: SWING, GATE, QUANTIZE, SUB, THRU
+    auto controlRow2 = bounds.removeFromTop(CONTROL_ROW_HEIGHT);
+    midiThruButton_->setBounds(controlRow2.removeFromRight(CONTROL_ROW_HEIGHT));
+    controlRow2.removeFromRight(4);
+    viewModeButton_.setBounds(controlRow2.removeFromRight(42).reduced(0, 2));
+    controlRow2.removeFromRight(4);
+    int quarterWidth = controlRow2.getWidth() / 4;
+    {
+        auto cell = controlRow2.removeFromLeft(quarterWidth);
+        swingLabel_.setBounds(cell.removeFromLeft(LABEL_WIDTH));
+        swingSlider_.setBounds(cell);
+    }
+    {
+        auto cell = controlRow2.removeFromLeft(quarterWidth);
+        gateLengthLabel_.setBounds(cell.removeFromLeft(LABEL_WIDTH));
+        gateLengthSlider_.setBounds(cell);
+    }
+    {
+        auto cell = controlRow2.removeFromLeft(quarterWidth);
+        quantizeLabel_.setBounds(cell.removeFromLeft(LABEL_WIDTH));
+        quantizeSlider_.setBounds(cell);
+    }
+    {
+        quantizeSubLabel_.setBounds(controlRow2.removeFromLeft(LABEL_WIDTH));
+        quantizeSubSlider_.setBounds(controlRow2);
+    }
+
+    bounds.removeFromTop(ROW_GAP + 2);
+
+    // TIME BEND block pinned to the bottom (label row + curve with sliders)
+    constexpr int LABEL_H = 14;
+    constexpr int CELL_H = CONTROL_ROW_HEIGHT + LABEL_H;
+    constexpr int SLIDER_COL_W = 44;
+    {
+        auto rampBlock = bounds.removeFromBottom(LABEL_H + CELL_H * 3);
+        rampLabel_.setBounds(rampBlock.removeFromTop(LABEL_H));
+        // Sliders stacked on the right, each with label above
+        auto sliderCol = rampBlock.removeFromRight(SLIDER_COL_W);
+        auto depthCell = sliderCol.removeFromTop(CELL_H);
+        depthLabel_.setBounds(depthCell.removeFromTop(LABEL_H));
+        depthSlider_.setBounds(depthCell);
+        auto skewCell = sliderCol.removeFromTop(CELL_H);
+        skewLabel_.setBounds(skewCell.removeFromTop(LABEL_H));
+        skewSlider_.setBounds(skewCell);
+        auto cyclesCell = sliderCol.removeFromTop(CELL_H);
+        cyclesLabel_.setBounds(cyclesCell.removeFromTop(LABEL_H));
+        cyclesSlider_.setBounds(cyclesCell);
+        // Curve fills remaining width
+        rampBlock.removeFromRight(4);
+        rampCurveDisplay_.setBounds(rampBlock);
+    }
+    bounds.removeFromBottom(ROW_GAP);
+
+    // Per-step lanes from the bottom up: PROB, VEL, TIE, GATE
+    probabilityArea_ = bounds.removeFromBottom(LANE_HEIGHT);
+    bounds.removeFromBottom(ROW_GAP);
+    velocityArea_ = bounds.removeFromBottom(LANE_HEIGHT);
+    bounds.removeFromBottom(ROW_GAP);
+    tieArea_ = bounds.removeFromBottom(TOGGLE_ROW_HEIGHT);
+    bounds.removeFromBottom(ROW_GAP);
+    gateArea_ = bounds.removeFromBottom(TOGGLE_ROW_HEIGHT);
+    bounds.removeFromBottom(ROW_GAP + 2);
+
+    // Pattern grid fills the remaining space
+    patternView_->setBounds(bounds);
+}
+
+// =============================================================================
+// Paint
+// =============================================================================
+
+void PolyStepSequencerUI::paint(juce::Graphics& g) {
+    drawToggleRow(g, gateArea_, "GAT", false);
+    drawToggleRow(g, tieArea_, "TIE", true);
+    drawBarLane(g, velocityArea_, "VEL", false);
+    drawBarLane(g, probabilityArea_, "PRB", true);
+}
+
+void PolyStepSequencerUI::drawToggleRow(juce::Graphics& g, juce::Rectangle<int> area,
+                                        const juce::String& label, bool isTieRow) {
+    if (!plugin_ || area.isEmpty())
+        return;
+
+    int count = juce::jlimit(1, PolySeqPlugin::MAX_STEPS, plugin_->numSteps.get());
+    g.setFont(FontManager::getInstance().getUIFont(7.0f));
+
+    // Row label, aligned with the grid's left gutter
+    g.setColour(DarkTheme::getSecondaryTextColour());
+    g.drawText(label, area.removeFromLeft(LEFT_GUTTER_WIDTH), juce::Justification::centredLeft);
+
+    float boxW = static_cast<float>(area.getWidth()) / static_cast<float>(count);
+
+    for (int i = 0; i < count; ++i) {
+        auto step = plugin_->getStep(i);
+        float x = static_cast<float>(area.getX()) + i * boxW;
+        auto rect =
+            juce::Rectangle<float>(x + 1.0f, static_cast<float>(area.getY()) + 1.0f, boxW - 2.0f,
+                                   static_cast<float>(area.getHeight()) - 2.0f);
+
+        bool on = isTieRow ? step.tie : step.gate;
+        if (on) {
+            g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_GREEN).withAlpha(0.7f));
+            g.fillRoundedRectangle(rect, 2.0f);
+            g.setColour(DarkTheme::getTextColour());
+            g.drawText(isTieRow ? "T" : "G", rect.toNearestInt(), juce::Justification::centred);
+        } else {
+            g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(0.2f));
+            g.fillRoundedRectangle(rect, 2.0f);
+        }
+    }
+}
+
+void PolyStepSequencerUI::drawBarLane(juce::Graphics& g, juce::Rectangle<int> area,
+                                      const juce::String& label, bool isProbability) {
+    if (!plugin_ || area.isEmpty())
+        return;
+
+    int count = juce::jlimit(1, PolySeqPlugin::MAX_STEPS, plugin_->numSteps.get());
+    g.setFont(FontManager::getInstance().getUIFont(7.0f));
+
+    // Lane label, aligned with the grid's left gutter
+    g.setColour(DarkTheme::getSecondaryTextColour());
+    g.drawText(label, area.removeFromLeft(LEFT_GUTTER_WIDTH), juce::Justification::centredLeft);
+
+    float boxW = static_cast<float>(area.getWidth()) / static_cast<float>(count);
+
+    for (int i = 0; i < count; ++i) {
+        auto step = plugin_->getStep(i);
+        float x = static_cast<float>(area.getX()) + i * boxW;
+        auto rect =
+            juce::Rectangle<float>(x + 1.0f, static_cast<float>(area.getY()) + 1.0f, boxW - 2.0f,
+                                   static_cast<float>(area.getHeight()) - 2.0f);
+
+        // Background
+        g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(0.2f));
+        g.fillRoundedRectangle(rect, 2.0f);
+
+        // Value bar from the bottom
+        float ratio = isProbability ? juce::jlimit(0.0f, 1.0f, step.probability)
+                                    : static_cast<float>(step.velocity) / 127.0f;
+        if (ratio > 0.0f) {
+            auto bar = rect.withTrimmedTop(rect.getHeight() * (1.0f - ratio));
+            g.setColour((isProbability ? DarkTheme::getColour(DarkTheme::ACCENT_ORANGE)
+                                       : DarkTheme::getColour(DarkTheme::ACCENT_BLUE))
+                            .withAlpha(0.7f));
+            g.fillRoundedRectangle(bar, 2.0f);
+        }
+    }
+}
+
+// =============================================================================
+// Mouse interaction (per-step lanes; the grid handles its own mouse)
+// =============================================================================
+
+int PolyStepSequencerUI::getStepAtX(int x, int areaX, int areaWidth, int numSteps) const {
+    if (numSteps <= 0 || areaWidth <= 0)
+        return -1;
+    int relX = x - areaX;
+    if (relX < 0 || relX >= areaWidth)
+        return -1;
+    return relX * numSteps / areaWidth;
+}
+
+void PolyStepSequencerUI::applyLaneDrag(const juce::MouseEvent& e) {
+    if (!plugin_ || activeDragLane_ == DragLane::None)
+        return;
+
+    auto area = (activeDragLane_ == DragLane::Velocity ? velocityArea_ : probabilityArea_)
+                    .withTrimmedLeft(LEFT_GUTTER_WIDTH);
+    int count = juce::jlimit(1, PolySeqPlugin::MAX_STEPS, plugin_->numSteps.get());
+    int step = getStepAtX(juce::jlimit(area.getX(), area.getRight() - 1, e.x), area.getX(),
+                          area.getWidth(), count);
+    if (step < 0 || step >= count)
+        return;
+
+    float ratio = 1.0f - static_cast<float>(e.y - area.getY()) /
+                             static_cast<float>(juce::jmax(1, area.getHeight()));
+    ratio = juce::jlimit(0.0f, 1.0f, ratio);
+
+    if (activeDragLane_ == DragLane::Velocity)
+        plugin_->setStepVelocity(step, juce::jlimit(1, 127, juce::roundToInt(ratio * 127.0f)));
+    else
+        plugin_->setStepProbability(step, ratio);
+    repaint();
+}
+
+void PolyStepSequencerUI::mouseDown(const juce::MouseEvent& e) {
+    if (!plugin_)
+        return;
+    auto pos = e.getPosition();
+    int count = juce::jlimit(1, PolySeqPlugin::MAX_STEPS, plugin_->numSteps.get());
+
+    // Gate row — toggle gate
+    if (gateArea_.contains(pos)) {
+        auto contentArea = gateArea_.withTrimmedLeft(LEFT_GUTTER_WIDTH);
+        int step = getStepAtX(pos.x, contentArea.getX(), contentArea.getWidth(), count);
+        if (step >= 0 && step < count) {
+            auto s = plugin_->getStep(step);
+            plugin_->setStepGate(step, !s.gate);
+            repaint();
+        }
+        return;
+    }
+
+    // Tie row — toggle tie
+    if (tieArea_.contains(pos)) {
+        auto contentArea = tieArea_.withTrimmedLeft(LEFT_GUTTER_WIDTH);
+        int step = getStepAtX(pos.x, contentArea.getX(), contentArea.getWidth(), count);
+        if (step >= 0 && step < count) {
+            auto s = plugin_->getStep(step);
+            plugin_->setStepTie(step, !s.tie);
+            repaint();
+        }
+        return;
+    }
+
+    // Velocity / probability lanes — start bar drag
+    if (velocityArea_.contains(pos)) {
+        activeDragLane_ = DragLane::Velocity;
+        applyLaneDrag(e);
+        return;
+    }
+    if (probabilityArea_.contains(pos)) {
+        activeDragLane_ = DragLane::Probability;
+        applyLaneDrag(e);
+        return;
+    }
+}
+
+void PolyStepSequencerUI::mouseDrag(const juce::MouseEvent& e) {
+    applyLaneDrag(e);
+}
+
+void PolyStepSequencerUI::mouseUp(const juce::MouseEvent&) {
+    activeDragLane_ = DragLane::None;
+}
+
+// =============================================================================
+// Setup helpers
+// =============================================================================
+
+void PolyStepSequencerUI::setupLabel(juce::Label& label, const juce::String& text) {
+    label.setText(text, juce::dontSendNotification);
+    label.setFont(FontManager::getInstance().getUIFont(9.0f));
+    label.setColour(juce::Label::textColourId, DarkTheme::getSecondaryTextColour());
+    label.setJustificationType(juce::Justification::centredLeft);
+    addAndMakeVisible(label);
+}
+
+void PolyStepSequencerUI::setupSlider(LinkableTextSlider& slider, double min, double max,
+                                      double step) {
+    slider.setRange(min, max, step);
+    addAndMakeVisible(slider);
+}
+
+std::vector<LinkableTextSlider*> PolyStepSequencerUI::getLinkableSliders() {
+    magda::ChainNodePath dummy;
+    // Param indices match AutomatableParameter registration order:
+    // 0=rate, 1=direction, 2=swing, 3=gatelength, 4=ramp, 5=skew
+    rateSlider_.setLinkContext(magda::INVALID_DEVICE_ID, 0, dummy);
+    swingSlider_.setLinkContext(magda::INVALID_DEVICE_ID, 2, dummy);
+    gateLengthSlider_.setLinkContext(magda::INVALID_DEVICE_ID, 3, dummy);
+    depthSlider_.setLinkContext(magda::INVALID_DEVICE_ID, 4, dummy);
+    skewSlider_.setLinkContext(magda::INVALID_DEVICE_ID, 5, dummy);
+    return {&rateSlider_, &swingSlider_, &gateLengthSlider_, &depthSlider_, &skewSlider_};
+}
+
+}  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.hpp
@@ -1,0 +1,159 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "audio/plugins/PolyStepSequencerPlugin.hpp"
+#include "ui/components/common/LinkableTextSlider.hpp"
+#include "ui/components/common/RampCurveDisplay.hpp"
+#include "ui/components/common/SvgButton.hpp"
+#include "ui/themes/DarkTheme.hpp"
+#include "ui/themes/FontManager.hpp"
+
+namespace magda::daw::ui {
+
+/**
+ * @brief Polyphonic step sequencer UI (keys / drum modes).
+ *
+ * Layout (top to bottom):
+ *   - Controls row: Rate, Steps, Direction
+ *   - Controls row: Swing, Gate Length, Quantize, Sub, view mode, MIDI thru
+ *   - Pattern view: pitch x step grid (keys) or drum-lane grid (drum)
+ *   - Gate row: toggle gate per step
+ *   - Tie row: toggle tie per step
+ *   - Velocity lane: draggable per-step velocity bars
+ *   - Probability lane: draggable per-step probability bars
+ *   - Time bend: ramp curve with depth/skew/cycles sliders
+ *
+ * Click a grid cell to toggle that note at that step. Use the arrows on the
+ * left (or the mouse wheel over the grid) to shift the visible note window.
+ *
+ * The pattern-grid area is a swappable PatternView child: KeysView is a
+ * piano-roll style grid, DrumLanesView is a classic x0x lane layout whose
+ * lanes follow a Drum Grid found downstream in the same chain. The mode is
+ * persisted on the plugin state ("seqViewMode") so it restores with the edit.
+ */
+class PolyStepSequencerUI : public juce::Component,
+                            private juce::ValueTree::Listener,
+                            private juce::Timer {
+  public:
+    PolyStepSequencerUI();
+    ~PolyStepSequencerUI() override;
+
+    void setPlugin(daw::audio::PolyStepSequencerPlugin* plugin);
+
+    std::vector<LinkableTextSlider*> getLinkableSliders();
+
+    void paint(juce::Graphics& g) override;
+    void resized() override;
+    void mouseDown(const juce::MouseEvent& e) override;
+    void mouseDrag(const juce::MouseEvent& e) override;
+    void mouseUp(const juce::MouseEvent& e) override;
+
+  private:
+    /** Base for pattern-view modes (keys / drum), swapped via the mode toggle. */
+    class PatternView : public juce::Component {
+      public:
+        ~PatternView() override = default;
+        virtual void setPlugin(daw::audio::PolyStepSequencerPlugin* plugin) = 0;
+        virtual void setPlayStep(int step) = 0;
+        virtual void patternChanged() = 0;
+    };
+
+    class KeysView;       // Piano-roll style pitch x step grid (defined in .cpp)
+    class DrumLanesView;  // x0x drum-lane grid driven by a downstream Drum Grid (defined in .cpp)
+
+    daw::audio::PolyStepSequencerPlugin* plugin_ = nullptr;
+    juce::ValueTree watchedState_;
+
+    // --- Controls ---
+    juce::Label rateLabel_;
+    LinkableTextSlider rateSlider_;
+    juce::Label stepsLabel_;
+    LinkableTextSlider stepsSlider_;
+    juce::Label dirLabel_;
+    juce::ComboBox dirCombo_;
+    juce::Label swingLabel_;
+    LinkableTextSlider swingSlider_;
+    juce::Label gateLengthLabel_;
+    LinkableTextSlider gateLengthSlider_;
+    juce::Label quantizeLabel_;
+    LinkableTextSlider quantizeSlider_;
+    juce::Label quantizeSubLabel_;
+    LinkableTextSlider quantizeSubSlider_;
+
+    // --- Ramp curve ---
+    juce::Label rampLabel_;
+    RampCurveDisplay rampCurveDisplay_;
+    juce::Label depthLabel_;
+    LinkableTextSlider depthSlider_;
+    juce::Label skewLabel_;
+    LinkableTextSlider skewSlider_;
+    juce::Label cyclesLabel_;
+    LinkableTextSlider cyclesSlider_;
+
+    // --- MIDI controls ---
+    std::unique_ptr<magda::SvgButton> midiThruButton_;
+
+    // --- View mode toggle (keys / drum) ---
+    juce::TextButton viewModeButton_;
+    bool drumViewActive_ = false;
+
+    // --- Pattern view (swapped between KeysView and DrumLanesView) ---
+    std::unique_ptr<PatternView> patternView_;
+
+    // --- State ---
+    int currentPlayStep_ = -1;  // Step being played (for highlight)
+
+    // Lane being drag-edited (velocity / probability bars)
+    enum class DragLane { None, Velocity, Probability };
+    DragLane activeDragLane_ = DragLane::None;
+
+    // --- Layout constants ---
+    static constexpr int CONTROL_ROW_HEIGHT = 22;
+    static constexpr int TOGGLE_ROW_HEIGHT = 16;
+    static constexpr int LANE_HEIGHT = 28;
+    static constexpr int ROW_GAP = 3;
+    static constexpr int PADDING = 4;
+    static constexpr int LABEL_WIDTH = 44;
+
+    /** Left inset shared by the grid (arrows + piano gutter) and the per-step
+     *  lanes below it, so step columns line up vertically. */
+    static constexpr int LEFT_GUTTER_WIDTH = 36;
+
+    // --- Drawing helpers ---
+    void drawToggleRow(juce::Graphics& g, juce::Rectangle<int> area, const juce::String& label,
+                       bool isTieRow);
+    void drawBarLane(juce::Graphics& g, juce::Rectangle<int> area, const juce::String& label,
+                     bool isProbability);
+
+    // --- Hit testing ---
+    int getStepAtX(int x, int areaX, int areaWidth, int numSteps) const;
+    void applyLaneDrag(const juce::MouseEvent& e);
+
+    // --- Layout bounds (computed in resized, used in paint/mouse handlers) ---
+    juce::Rectangle<int> gateArea_;
+    juce::Rectangle<int> tieArea_;
+    juce::Rectangle<int> velocityArea_;
+    juce::Rectangle<int> probabilityArea_;
+
+    // --- Setup helpers ---
+    void setupLabel(juce::Label& label, const juce::String& text);
+    void setupSlider(LinkableTextSlider& slider, double min, double max, double step);
+
+    void syncFromPlugin();
+
+    /** Swap the pattern view to match the plugin's persisted view mode. */
+    void updatePatternViewMode();
+
+    // ValueTree::Listener — reflects external changes (undo/redo, preset load)
+    void valueTreePropertyChanged(juce::ValueTree& tree, const juce::Identifier& property) override;
+    void valueTreeChildAdded(juce::ValueTree& parent, juce::ValueTree& child) override;
+    void valueTreeChildRemoved(juce::ValueTree& parent, juce::ValueTree& child, int index) override;
+
+    // Timer — playhead animation only
+    void timerCallback() override;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PolyStepSequencerUI)
+};
+
+}  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.cpp
@@ -1,11 +1,6 @@
 #include "custom_ui/StepSequencerUI.hpp"
 
-#include <juce_llm/juce_llm.h>
-
-#include "../../../../agents/llm_client_factory.hpp"
 #include "audio/transport/StepClock.hpp"
-#include "core/Config.hpp"
-#include "ui/themes/SmallButtonLookAndFeel.hpp"
 #include "ui/themes/SmallComboBoxLookAndFeel.hpp"
 
 namespace magda::daw::ui {
@@ -19,214 +14,6 @@ juce::String StepSequencerUI::noteNameShort(int noteNumber) {
         return "-";
     int octave = (noteNumber / 12) - 2;
     return juce::String(NOTE_NAMES[noteNumber % 12]) + juce::String(octave);
-}
-
-// =============================================================================
-// AIResultDisplay
-// =============================================================================
-
-StepSequencerUI::AIResultDisplay::AIResultDisplay() {}
-
-void StepSequencerUI::AIResultDisplay::setStreamingText(const juce::String& text) {
-    mode_ = Mode::Streaming;
-    text_ = text;
-    description_ = {};
-    previewSteps_.clear();
-    scrollOffset_ = 0;
-    autoScroll_ = true;
-    spinnerAngle_ = 0.0f;
-    startTimerHz(30);
-    repaint();
-}
-
-void StepSequencerUI::AIResultDisplay::timerCallback() {
-    spinnerAngle_ += 0.15f;
-    if (spinnerAngle_ > juce::MathConstants<float>::twoPi)
-        spinnerAngle_ -= juce::MathConstants<float>::twoPi;
-    repaint();
-}
-
-void StepSequencerUI::AIResultDisplay::appendStreamingToken(const juce::String& token) {
-    mode_ = Mode::Streaming;
-    stopTimer();
-    if (text_ == "Thinking...")
-        text_ = "";
-    text_ += token;
-
-    // Try to extract description early from partial JSON
-    if (description_.isEmpty()) {
-        auto descIdx = text_.indexOf("\"description\"");
-        if (descIdx >= 0) {
-            auto colonIdx = text_.indexOf(descIdx, ":");
-            if (colonIdx >= 0) {
-                auto quoteStart = text_.indexOf(colonIdx, "\"");
-                if (quoteStart >= 0) {
-                    auto quoteEnd = text_.indexOf(quoteStart + 1, "\"");
-                    if (quoteEnd > quoteStart)
-                        description_ = text_.substring(quoteStart + 1, quoteEnd);
-                }
-            }
-        }
-    }
-
-    // Try to parse complete step objects from partial JSON for live preview
-    // Look for complete {...} objects within the steps array
-    previewSteps_.clear();
-    auto stepsIdx = text_.indexOf("\"steps\"");
-    if (stepsIdx >= 0) {
-        auto arrayStart = text_.indexOf(stepsIdx, "[");
-        if (arrayStart >= 0) {
-            // Find each complete step object
-            int searchFrom = arrayStart;
-            while (true) {
-                auto objStart = text_.indexOf(searchFrom, "{");
-                if (objStart < 0)
-                    break;
-                auto objEnd = text_.indexOf(objStart, "}");
-                if (objEnd < 0)
-                    break;  // Incomplete object — stop
-
-                auto objText = text_.substring(objStart, objEnd + 1);
-                auto parsed = juce::JSON::parse(objText);
-                if (parsed.isObject()) {
-                    audio::StepSequencerPlugin::Step step;
-                    step.noteNumber = juce::jlimit(0, 127, (int)parsed.getProperty("note", 60));
-                    step.octaveShift = juce::jlimit(-2, 2, (int)parsed.getProperty("octave", 0));
-                    step.gate = (bool)parsed.getProperty("gate", true);
-                    step.accent = (bool)parsed.getProperty("accent", false);
-                    step.glide = (bool)parsed.getProperty("glide", false);
-                    step.tie = (bool)parsed.getProperty("tie", false);
-                    previewSteps_.push_back(step);
-                }
-                searchFrom = objEnd + 1;
-            }
-        }
-    }
-
-    repaint();
-}
-
-void StepSequencerUI::AIResultDisplay::showResult(const juce::String& description, int) {
-    stopTimer();
-    mode_ = Mode::Streaming;
-    description_ = description;
-    previewSteps_.clear();
-    text_ = {};
-    repaint();
-}
-
-void StepSequencerUI::AIResultDisplay::showError(const juce::String& message) {
-    stopTimer();
-    mode_ = Mode::Streaming;
-    text_ = message;
-    description_ = {};
-    previewSteps_.clear();
-    scrollOffset_ = 0;
-    repaint();
-}
-
-void StepSequencerUI::AIResultDisplay::clear() {
-    stopTimer();
-    mode_ = Mode::Empty;
-    text_ = {};
-    description_ = {};
-    previewSteps_.clear();
-    scrollOffset_ = 0;
-    autoScroll_ = true;
-    repaint();
-}
-
-void StepSequencerUI::AIResultDisplay::paint(juce::Graphics& g) {
-    auto bounds = getLocalBounds().toFloat();
-    if (bounds.isEmpty())
-        return;
-
-    g.setFont(FontManager::getInstance().getUIFont(9.0f));
-    g.setColour(DarkTheme::getSecondaryTextColour());
-
-    if (mode_ == Mode::Streaming) {
-        auto area = bounds.reduced(2, 0);
-        constexpr float lineH = 11.0f;
-
-        // Description header (always visible, not scrolled)
-        if (description_.isNotEmpty()) {
-            g.setColour(DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
-            g.drawText(description_, area.removeFromTop(lineH), juce::Justification::centredLeft,
-                       true);
-            area.removeFromTop(2);
-        } else if (previewSteps_.empty()) {
-            // Draw spinner + text centered
-            constexpr float spinnerSize = 10.0f;
-            float textW = g.getCurrentFont().getStringWidthFloat(text_);
-            float totalW = spinnerSize + 4.0f + textW;
-            float cx = area.getCentreX() - totalW * 0.5f;
-            float cy = area.getCentreY();
-
-            // Spinning arc
-            juce::Path arc;
-            arc.addArc(cx, cy - spinnerSize * 0.5f, spinnerSize, spinnerSize, spinnerAngle_,
-                       spinnerAngle_ + juce::MathConstants<float>::pi * 1.5f, true);
-            g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_GREEN).withAlpha(0.7f));
-            g.strokePath(arc, juce::PathStrokeType(1.5f));
-
-            // Text
-            g.setColour(DarkTheme::getSecondaryTextColour());
-            g.drawText(text_,
-                       juce::Rectangle<float>(cx + spinnerSize + 4.0f, area.getY(), textW + 4.0f,
-                                              area.getHeight()),
-                       juce::Justification::centredLeft, false);
-            return;
-        }
-
-        // Auto-scroll: keep latest steps visible
-        int visibleLines = static_cast<int>(area.getHeight() / lineH);
-        int totalLines = static_cast<int>(previewSteps_.size());
-        int maxScroll = std::max(0, totalLines - visibleLines);
-        if (autoScroll_)
-            scrollOffset_ = maxScroll;
-        scrollOffset_ = juce::jlimit(0, maxScroll, scrollOffset_);
-
-        // Step list
-        g.setFont(FontManager::getInstance().getMonoFont(8.5f));
-        int startIdx = scrollOffset_;
-        int endIdx = std::min(totalLines, startIdx + visibleLines);
-        for (int i = startIdx; i < endIdx; ++i) {
-            auto& s = previewSteps_[static_cast<size_t>(i)];
-            int note = s.noteNumber + s.octaveShift * 12;
-            juce::String noteName = noteNameShort(note);
-
-            juce::String flags;
-            if (!s.gate)
-                flags = "rest";
-            else {
-                if (s.accent)
-                    flags += "acc ";
-                if (s.glide)
-                    flags += "gld ";
-                if (s.tie)
-                    flags += "tie ";
-                if (flags.isEmpty())
-                    flags = "-";
-                else
-                    flags = flags.trim();
-            }
-
-            auto line = juce::String(i + 1).paddedLeft('0', 2) + "  " +
-                        noteName.paddedRight(' ', 4) + " " + flags;
-
-            g.setColour(s.gate ? DarkTheme::getSecondaryTextColour()
-                               : DarkTheme::getColour(DarkTheme::BORDER));
-            g.drawText(line, area.removeFromTop(lineH), juce::Justification::centredLeft, true);
-        }
-    }
-}
-
-void StepSequencerUI::AIResultDisplay::mouseWheelMove(const juce::MouseEvent&,
-                                                      const juce::MouseWheelDetails& wheel) {
-    int delta = wheel.deltaY > 0 ? -2 : 2;
-    scrollOffset_ += delta;
-    autoScroll_ = false;
-    repaint();
 }
 
 // =============================================================================
@@ -413,7 +200,7 @@ StepSequencerUI::StepSequencerUI() {
     };
     addAndMakeVisible(stepRecordButton_.get());
 
-    // --- Pattern generation: [RND] [prompt input] [Generate] ---
+    // --- Pattern generation: [RND] ---
     randomButton_ = std::make_unique<magda::SvgButton>("Random", BinaryData::random_svg,
                                                        BinaryData::random_svgSize);
     randomButton_->setOriginalColor(juce::Colour(0xFFB3B3B3));
@@ -426,70 +213,13 @@ StepSequencerUI::StepSequencerUI() {
         }
     };
     addAndMakeVisible(randomButton_.get());
-
-    aiPromptEditor_.setMultiLine(false);
-    aiPromptEditor_.setTextToShowWhenEmpty("describe a pattern...",
-                                           DarkTheme::getColour(DarkTheme::TEXT_DIM));
-    aiPromptEditor_.setColour(juce::TextEditor::backgroundColourId,
-                              DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.1f));
-    aiPromptEditor_.setColour(juce::TextEditor::textColourId, DarkTheme::getTextColour());
-    aiPromptEditor_.setColour(juce::TextEditor::outlineColourId,
-                              DarkTheme::getColour(DarkTheme::BORDER));
-    aiPromptEditor_.setColour(juce::TextEditor::focusedOutlineColourId,
-                              DarkTheme::getColour(DarkTheme::ACCENT_GREEN));
-    aiPromptEditor_.setFont(FontManager::getInstance().getUIFont(9.0f));
-    aiPromptEditor_.onReturnKey = [this] {
-        generateAIPattern();
-        giveAwayKeyboardFocus();
-    };
-    aiPromptEditor_.onEscapeKey = [this] { giveAwayKeyboardFocus(); };
-    addAndMakeVisible(aiPromptEditor_);
-
-    aiButton_.setButtonText("Generate");
-    aiButton_.setLookAndFeel(&SmallButtonLookAndFeel::getInstance());
-    aiButton_.setColour(juce::TextButton::buttonColourId,
-                        DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.1f));
-    aiButton_.setColour(juce::TextButton::textColourOffId, DarkTheme::getTextColour());
-    aiButton_.setTooltip("Generate pattern with AI");
-    aiButton_.onClick = [this] { generateAIPattern(); };
-    addAndMakeVisible(aiButton_);
-
-    addAndMakeVisible(aiResultDisplay_);
-
-    // AI model indicator
-    aiIcon_ =
-        std::make_unique<magda::SvgButton>("AIIcon", BinaryData::ai_svg, BinaryData::ai_svgSize);
-    aiIcon_->setOriginalColor(juce::Colour(0xFFB3B3B3));
-    aiIcon_->setNormalColor(DarkTheme::getColour(DarkTheme::ACCENT_PURPLE));
-    aiIcon_->setInterceptsMouseClicks(false, false);
-    addAndMakeVisible(*aiIcon_);
-
-    aiClearButton_ = std::make_unique<magda::SvgButton>("ClearAIResult", BinaryData::delete_svg,
-                                                        BinaryData::delete_svgSize);
-    aiClearButton_->setOriginalColor(juce::Colour(0xFFB3B3B3));
-    aiClearButton_->setNormalColor(DarkTheme::getColour(DarkTheme::TEXT_SECONDARY).withAlpha(0.4f));
-    aiClearButton_->setTooltip("Clear AI result");
-    aiClearButton_->onClick = [this] { aiResultDisplay_.clear(); };
-    addAndMakeVisible(aiClearButton_.get());
-
-    auto cfg = magda::Config::getInstance().getAgentLLMConfig("music");
-    auto modelName = cfg.model.empty() ? cfg.provider : cfg.model;
-    aiModelLabel_.setText(juce::String(modelName), juce::dontSendNotification);
-    aiModelLabel_.setFont(FontManager::getInstance().getUIFont(8.5f));
-    aiModelLabel_.setColour(juce::Label::textColourId, DarkTheme::getColour(DarkTheme::TEXT_DIM));
-    aiModelLabel_.setJustificationType(juce::Justification::centredLeft);
-    addAndMakeVisible(aiModelLabel_);
-
-    magda::Config::getInstance().addListener(this);
 }
 
 StepSequencerUI::~StepSequencerUI() {
-    magda::Config::getInstance().removeListener(this);
     stopTimer();
     if (watchedState_.isValid())
         watchedState_.removeListener(this);
     dirCombo_.setLookAndFeel(nullptr);
-    aiButton_.setLookAndFeel(nullptr);
 }
 
 // =============================================================================
@@ -579,16 +309,6 @@ void StepSequencerUI::timerCallback() {
     }
     if (needsRepaint)
         repaint();
-}
-
-void StepSequencerUI::configChanged() {
-    juce::MessageManager::callAsync([safeThis = juce::Component::SafePointer(this)] {
-        if (safeThis) {
-            auto cfg = magda::Config::getInstance().getAgentLLMConfig("music");
-            auto model = cfg.model.empty() ? cfg.provider : cfg.model;
-            safeThis->aiModelLabel_.setText(juce::String(model), juce::dontSendNotification);
-        }
-    });
 }
 
 // =============================================================================
@@ -697,27 +417,9 @@ void StepSequencerUI::resized() {
 
     bounds.removeFromTop(ROW_GAP);
 
-    // Pattern generation row: [RND] [AI] modelname [prompt editor] [Generate]
+    // Pattern generation row: [RND]
     auto buttonRow = bounds.removeFromTop(CONTROL_ROW_HEIGHT);
     randomButton_->setBounds(buttonRow.removeFromLeft(CONTROL_ROW_HEIGHT));
-    buttonRow.removeFromLeft(2);
-    aiIcon_->setBounds(buttonRow.removeFromLeft(CONTROL_ROW_HEIGHT));
-    buttonRow.removeFromLeft(2);
-    aiModelLabel_.setBounds(buttonRow.removeFromLeft(90));
-    buttonRow.removeFromLeft(2);
-    aiClearButton_->setBounds(buttonRow.removeFromRight(CONTROL_ROW_HEIGHT));
-    buttonRow.removeFromRight(2);
-    aiButton_.setBounds(buttonRow.removeFromRight(60));
-    buttonRow.removeFromRight(4);
-    aiPromptEditor_.setBounds(buttonRow);
-
-    // Horizontal separator between generation row and streaming area
-    streamSeparatorY_ = bounds.getY() + 1;
-
-    // AI status row (streaming response / result description) — fill remaining space
-    bounds.removeFromTop(4);
-    if (bounds.getHeight() > 0)
-        aiResultDisplay_.setBounds(bounds);
 }
 
 // =============================================================================
@@ -731,11 +433,6 @@ void StepSequencerUI::paint(juce::Graphics& g) {
     drawOctaveArrow(g, octaveDownArea_, true);
     drawKeyboard(g, keyboardArea_);
     drawOctaveArrow(g, octaveUpArea_, false);
-
-    // Horizontal separator above streaming area
-    if (streamSeparatorY_ > 0)
-        g.drawHorizontalLine(streamSeparatorY_, static_cast<float>(PADDING),
-                             static_cast<float>(getWidth() - PADDING));
 }
 
 void StepSequencerUI::drawStepBoxes(juce::Graphics& g, juce::Rectangle<int> area) {
@@ -1158,160 +855,6 @@ int StepSequencerUI::getKeyboardNoteAtPosition(juce::Point<int> pos,
 }
 
 // =============================================================================
-// AI pattern generation
-// =============================================================================
-
-void StepSequencerUI::generateAIPattern() {
-    if (!plugin_)
-        return;
-
-    auto prompt = aiPromptEditor_.getText().trim();
-    if (prompt.isEmpty())
-        return;
-
-    int numSteps = juce::jlimit(1, SeqPlugin::MAX_STEPS, plugin_->numSteps.get());
-
-    // Build JSON schema for structured output
-    auto stepSchema = llm::Schema::object({
-        {"note", llm::Schema::integer()},
-        {"octave", llm::Schema::integer()},
-        {"gate", llm::Schema::boolean()},
-        {"accent", llm::Schema::boolean()},
-        {"glide", llm::Schema::boolean()},
-        {"tie", llm::Schema::boolean()},
-    });
-    auto stepsArraySchema = llm::Schema::array(stepSchema);
-    if (auto* obj = stepsArraySchema.getDynamicObject()) {
-        obj->setProperty("minItems", numSteps);
-        obj->setProperty("maxItems", numSteps);
-    }
-    auto responseSchema = llm::Schema::object({
-        {"description", llm::Schema::string()},
-        {"steps", stepsArraySchema},
-    });
-
-    auto systemPrompt =
-        juce::String("You are a music pattern generator for a 303-style step sequencer.\n"
-                     "Generate a JSON object with:\n"
-                     "  - description: a short label for the pattern (e.g. \"Acid C minor\", "
-                     "\"Funky bassline\")\n"
-                     "  - steps: array of step objects\n"
-                     "Each step has:\n"
-                     "  - note: MIDI note number (0-127, e.g. 60=C4, 48=C3, 36=C2)\n"
-                     "  - octave: octave shift (-2 to +2, applied on top of note)\n"
-                     "  - gate: true if the step plays, false for rest\n"
-                     "  - accent: true for accented (louder) steps\n"
-                     "  - glide: true for portamento slide to next note\n"
-                     "  - tie: true to extend previous note without retriggering\n"
-                     "Generate exactly " +
-                     juce::String(numSteps) +
-                     " steps. Return only 1 pattern.\n"
-                     "Keep octave at 0 unless the user asks for wide range.\n"
-                     "For acid bass lines, use lots of glides and accents on root/fifth notes.");
-
-    // Disable controls and show thinking indicator
-    aiButton_.setEnabled(false);
-    aiButton_.setButtonText("...");
-    aiPromptEditor_.setEnabled(false);
-    aiResultDisplay_.setStreamingText("Thinking...");
-
-    auto safeThis = juce::Component::SafePointer<StepSequencerUI>(this);
-
-    // Run LLM call on background thread with streaming
-    std::thread([safeThis, prompt, systemPrompt, responseSchema, numSteps]() {
-        auto agentConfig = magda::Config::getInstance().getAgentLLMConfig("music");
-        auto client = magda::createLLMClient(agentConfig, "music");
-
-        llm::Request request;
-        request.systemPrompt = systemPrompt;
-        request.userMessage = prompt;
-        request.temperature = 0.7f;
-        request.schema = responseSchema;
-
-        DBG("AI pattern request - user: " + prompt);
-
-        // Stream tokens to the status label for live feedback
-        auto response = client->sendStreamingRequest(request, [&](const juce::String& token) {
-            auto tokenCopy = token;
-            juce::MessageManager::callAsync([safeThis, tokenCopy]() {
-                if (!safeThis)
-                    return;
-                safeThis->aiResultDisplay_.appendStreamingToken(tokenCopy);
-            });
-            return true;
-        });
-
-        DBG("AI pattern response - success: " + juce::String(response.success ? "true" : "false"));
-        if (!response.success)
-            DBG("AI pattern response - error: " + response.error);
-        DBG("AI pattern response - text: " + response.text);
-
-        juce::MessageManager::callAsync([safeThis, response, prompt, numSteps]() {
-            if (!safeThis)
-                return;
-
-            // Re-enable controls
-            safeThis->aiButton_.setEnabled(true);
-            safeThis->aiButton_.setButtonText("Generate");
-            safeThis->aiPromptEditor_.setEnabled(true);
-
-            if (!response.success || response.text.isEmpty()) {
-                DBG("AI pattern generation failed: " + response.error);
-                safeThis->aiResultDisplay_.showError(response.error.isNotEmpty()
-                                                         ? "Error: " + response.error
-                                                         : "Error: no response");
-                return;
-            }
-
-            // Parse JSON response — strip markdown fences if present
-            auto text = response.text.trim();
-            if (text.startsWith("```")) {
-                auto firstNewline = text.indexOf("\n");
-                auto lastFence = text.lastIndexOf("```");
-                if (firstNewline >= 0 && lastFence > firstNewline)
-                    text = text.substring(firstNewline + 1, lastFence).trim();
-            }
-
-            auto json = juce::JSON::parse(text);
-            // Try "steps" key first, then treat root as array
-            auto* stepsArray = json.getProperty("steps", {}).getArray();
-            if (!stepsArray)
-                stepsArray = json.getArray();
-            if (!stepsArray) {
-                DBG("AI response missing 'steps' array: " + text.substring(0, 200));
-                safeThis->aiResultDisplay_.showError("Error: failed to parse response");
-                return;
-            }
-
-            std::vector<SeqPlugin::Step> steps;
-            for (int i = 0; i < std::min((int)stepsArray->size(), numSteps); ++i) {
-                auto s = (*stepsArray)[i];
-                SeqPlugin::Step step;
-                step.noteNumber = juce::jlimit(0, 127, (int)s.getProperty("note", 60));
-                step.octaveShift = juce::jlimit(-2, 2, (int)s.getProperty("octave", 0));
-                step.gate = (bool)s.getProperty("gate", true);
-                step.accent = (bool)s.getProperty("accent", false);
-                step.glide = (bool)s.getProperty("glide", false);
-                step.tie = (bool)s.getProperty("tie", false);
-                steps.push_back(step);
-            }
-
-            if (safeThis->plugin_ && !steps.empty()) {
-                safeThis->plugin_->setPattern(steps, true);
-
-                // Show the description in the status label
-                auto description = json.getProperty("description", {}).toString().trim();
-                safeThis->aiResultDisplay_.showResult(
-                    description.isNotEmpty() ? description : "Pattern generated",
-                    static_cast<int>(steps.size()));
-
-                safeThis->repaint();
-            }
-        });
-    }).detach();
-}
-
-// =============================================================================
 // Context menu
 // =============================================================================
 
@@ -1329,6 +872,8 @@ void StepSequencerUI::showStepContextMenu(int stepIndex) {
     menu.addItem(1, step.gate ? "Mute Step" : "Unmute Step");
     menu.addItem(2, "Copy to All Steps");
     menu.addItem(3, "Clear Step");
+    menu.addSeparator();
+    menu.addItem(4, "Clear Pattern");
 
     menu.showMenuAsync(juce::PopupMenu::Options(), [this, stepIndex, count](int result) {
         if (!plugin_)
@@ -1355,6 +900,9 @@ void StepSequencerUI::showStepContextMenu(int stepIndex) {
             }
             case 3:
                 plugin_->clearStep(stepIndex);
+                break;
+            case 4:
+                plugin_->clearPattern();
                 break;
             default:
                 return;

--- a/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.hpp
@@ -3,7 +3,6 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include "audio/plugins/StepSequencerPlugin.hpp"
-#include "core/Config.hpp"
 #include "ui/components/common/LinkableTextSlider.hpp"
 #include "ui/components/common/RampCurveDisplay.hpp"
 #include "ui/components/common/SvgButton.hpp"
@@ -28,8 +27,7 @@ namespace magda::daw::ui {
  */
 class StepSequencerUI : public juce::Component,
                         private juce::ValueTree::Listener,
-                        private juce::Timer,
-                        private magda::ConfigListener {
+                        private juce::Timer {
   public:
     StepSequencerUI();
     ~StepSequencerUI() override;
@@ -80,38 +78,6 @@ class StepSequencerUI : public juce::Component,
 
     // --- Pattern generation ---
     std::unique_ptr<magda::SvgButton> randomButton_;
-    juce::TextButton aiButton_{"AI"};
-    juce::TextEditor aiPromptEditor_;
-    juce::Label aiModelLabel_;
-    std::unique_ptr<magda::SvgButton> aiIcon_;
-    std::unique_ptr<magda::SvgButton> aiClearButton_;
-
-    /** Shows streaming status: description + step list that auto-scrolls. */
-    class AIResultDisplay : public juce::Component, private juce::Timer {
-      public:
-        AIResultDisplay();
-        void paint(juce::Graphics& g) override;
-        void mouseWheelMove(const juce::MouseEvent&, const juce::MouseWheelDetails&) override;
-
-        void setStreamingText(const juce::String& text);
-        void appendStreamingToken(const juce::String& token);
-        void showResult(const juce::String& description, int numSteps);
-        void showError(const juce::String& message);
-        void clear();
-
-      private:
-        void timerCallback() override;
-
-        enum class Mode { Empty, Streaming };
-        Mode mode_ = Mode::Empty;
-        juce::String text_;
-        juce::String description_;
-        std::vector<audio::StepSequencerPlugin::Step> previewSteps_;
-        int scrollOffset_ = 0;
-        bool autoScroll_ = true;
-        float spinnerAngle_ = 0.0f;
-    };
-    AIResultDisplay aiResultDisplay_;
 
     // --- State ---
     int selectedStep_ = 0;       // Currently selected step for editing
@@ -158,7 +124,6 @@ class StepSequencerUI : public juce::Component,
     juce::Rectangle<int> rampArea_;
     juce::Rectangle<int> buttonArea_;
     int dividerX_ = 0, dividerY_ = 0, dividerHeight_ = 0;
-    int streamSeparatorY_ = 0;
 
     // --- Setup helpers ---
     void setupLabel(juce::Label& label, const juce::String& text);
@@ -166,17 +131,11 @@ class StepSequencerUI : public juce::Component,
 
     void syncFromPlugin();
 
-    // ConfigListener
-    void configChanged() override;
-
     // ValueTree::Listener
     void valueTreePropertyChanged(juce::ValueTree& tree, const juce::Identifier& property) override;
 
     // Timer — poll playback position
     void timerCallback() override;
-
-    // AI pattern generation
-    void generateAIPattern();
 
     // Context menu
     void showStepContextMenu(int stepIndex);

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -18,6 +18,7 @@
 #include "audio/plugins/MagdaSamplerPlugin.hpp"
 #include "audio/plugins/MidiChordEnginePlugin.hpp"
 #include "audio/plugins/OscilloscopePlugin.hpp"
+#include "audio/plugins/PolyStepSequencerPlugin.hpp"
 #include "audio/plugins/SpectrumAnalyzerPlugin.hpp"
 #include "audio/plugins/StepSequencerPlugin.hpp"
 #include "audio/plugins/compiled/CompiledPluginRegistry.hpp"
@@ -39,6 +40,7 @@
 #include "custom_ui/OscilloscopeUI.hpp"
 #include "custom_ui/PhaserUI.hpp"
 #include "custom_ui/PitchShiftUI.hpp"
+#include "custom_ui/PolyStepSequencerUI.hpp"
 #include "custom_ui/ReverbUI.hpp"
 #include "custom_ui/SamplerUI.hpp"
 #include "custom_ui/SpectrumAnalyzerUI.hpp"
@@ -286,6 +288,8 @@ juce::Component* DeviceCustomUIManager::getActiveUI() const {
         return arpeggiatorUI_.get();
     if (stepSequencerUI_)
         return stepSequencerUI_.get();
+    if (polyStepSequencerUI_)
+        return polyStepSequencerUI_.get();
     if (oscilloscopeUI_)
         return oscilloscopeUI_.get();
     if (spectrumAnalyzerUI_)
@@ -324,6 +328,8 @@ std::vector<LinkableTextSlider*> DeviceCustomUIManager::getLinkableSliders() con
         return arpeggiatorUI_->getLinkableSliders();
     if (stepSequencerUI_)
         return stepSequencerUI_->getLinkableSliders();
+    if (polyStepSequencerUI_)
+        return polyStepSequencerUI_->getLinkableSliders();
     return {};
 }
 
@@ -331,7 +337,7 @@ bool DeviceCustomUIManager::hasAnyUI() const {
     return toneGeneratorUI_ || samplerUI_ || drumGridUI_ || fourOscUI_ || eqUI_ || compressorUI_ ||
            reverbUI_ || delayUI_ || chorusUI_ || phaserUI_ || filterUI_ || pitchShiftUI_ ||
            impulseResponseUI_ || faustUI_ || chordEngineUI_ || arpeggiatorUI_ || stepSequencerUI_ ||
-           oscilloscopeUI_ || spectrumAnalyzerUI_ || levelsUI_;
+           polyStepSequencerUI_ || oscilloscopeUI_ || spectrumAnalyzerUI_ || levelsUI_;
 }
 
 int DeviceCustomUIManager::getPreferredContentWidth(int drumGridFallback) const {
@@ -357,6 +363,8 @@ int DeviceCustomUIManager::getPreferredContentWidth(int drumGridFallback) const 
         return 350;
     if (stepSequencerUI_)
         return 500;
+    if (polyStepSequencerUI_)
+        return 560;
     if (oscilloscopeUI_)
         return 500;
     if (spectrumAnalyzerUI_)
@@ -1311,6 +1319,21 @@ void DeviceCustomUIManager::create(const magda::DeviceInfo& device, juce::Compon
                 if (auto* arp = dynamic_cast<daw::audio::ArpeggiatorPlugin*>(plugin.get())) {
                     arpeggiatorUI_->setArpeggiator(arp);
                     arpPlugin_ = arp;
+                }
+            }
+        }
+    } else if (device.pluginId.containsIgnoreCase(
+                   daw::audio::PolyStepSequencerPlugin::xmlTypeName)) {
+        // NB: checked before the mono sequencer — "polystepsequencer" also
+        // contains "stepsequencer", so the order of these branches matters.
+        polyStepSequencerUI_ = std::make_unique<PolyStepSequencerUI>();
+        parent->addAndMakeVisible(*polyStepSequencerUI_);
+        if (auto* audioEngine = magda::TrackManager::getInstance().getAudioEngine()) {
+            if (auto* bridge = audioEngine->getAudioBridge()) {
+                auto plugin = bridge->getPlugin(devicePath_);
+                if (auto* seq = dynamic_cast<daw::audio::PolyStepSequencerPlugin*>(plugin.get())) {
+                    polyStepSequencerUI_->setPlugin(seq);
+                    polyStepSeqPlugin_ = seq;
                 }
             }
         }

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.hpp
@@ -12,6 +12,7 @@ namespace magda::daw::audio {
 class ArpeggiatorPlugin;
 class MidiChordEnginePlugin;
 class OscilloscopePlugin;
+class PolyStepSequencerPlugin;
 class SpectrumAnalyzerPlugin;
 class StepSequencerPlugin;
 }  // namespace magda::daw::audio
@@ -33,6 +34,7 @@ class LevelsUI;
 class LinkableTextSlider;
 class OscilloscopeUI;
 class PhaserUI;
+class PolyStepSequencerUI;
 class SpectrumAnalyzerUI;
 class PitchShiftUI;
 class ReverbUI;
@@ -158,6 +160,9 @@ class DeviceCustomUIManager {
     daw::audio::StepSequencerPlugin* getStepSeqPlugin() const {
         return stepSeqPlugin_;
     }
+    daw::audio::PolyStepSequencerPlugin* getPolyStepSeqPlugin() const {
+        return polyStepSeqPlugin_;
+    }
     daw::audio::MidiChordEnginePlugin* getChordPlugin() const {
         return chordPlugin_;
     }
@@ -165,6 +170,9 @@ class DeviceCustomUIManager {
     // Allow timerCallback to write stepSeqPlugin_ after setNodePath resolution
     void setStepSeqPlugin(daw::audio::StepSequencerPlugin* p) {
         stepSeqPlugin_ = p;
+    }
+    void setPolyStepSeqPlugin(daw::audio::PolyStepSequencerPlugin* p) {
+        polyStepSeqPlugin_ = p;
     }
 
     // Tab index for FourOscUI persistence across rebuilds
@@ -194,6 +202,9 @@ class DeviceCustomUIManager {
     }
     StepSequencerUI* getStepSequencerUI() const {
         return stepSequencerUI_.get();
+    }
+    PolyStepSequencerUI* getPolyStepSequencerUI() const {
+        return polyStepSequencerUI_.get();
     }
 
   private:
@@ -225,6 +236,7 @@ class DeviceCustomUIManager {
     std::unique_ptr<ChordPanelContent> chordEngineUI_;
     std::unique_ptr<ArpeggiatorUI> arpeggiatorUI_;
     std::unique_ptr<StepSequencerUI> stepSequencerUI_;
+    std::unique_ptr<PolyStepSequencerUI> polyStepSequencerUI_;
     std::unique_ptr<OscilloscopeUI> oscilloscopeUI_;
     std::unique_ptr<SpectrumAnalyzerUI> spectrumAnalyzerUI_;
     std::unique_ptr<LevelsUI> levelsUI_;
@@ -232,6 +244,7 @@ class DeviceCustomUIManager {
     // Plugin raw pointers for timer polling / setNodePath updates
     daw::audio::ArpeggiatorPlugin* arpPlugin_ = nullptr;
     daw::audio::StepSequencerPlugin* stepSeqPlugin_ = nullptr;
+    daw::audio::PolyStepSequencerPlugin* polyStepSeqPlugin_ = nullptr;
     daw::audio::MidiChordEnginePlugin* chordPlugin_ = nullptr;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DeviceCustomUIManager)

--- a/magda/daw/ui/components/chain/slot/DeviceSlotContentLayout.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotContentLayout.cpp
@@ -15,7 +15,8 @@ void setVisibleIfPresent(juce::Component* component, bool shouldBeVisible) {
 }
 
 bool isMidiUtility(const DeviceSlotTraits& traits) {
-    return traits.isChordEngine || traits.isArpeggiator || traits.isStepSequencer;
+    return traits.isChordEngine || traits.isArpeggiator || traits.isStepSequencer ||
+           traits.isPolyStepSequencer;
 }
 
 void layoutPluginPresetButton(juce::Rectangle<int> secondHeaderArea, const DeviceSlotTraits& traits,
@@ -98,9 +99,10 @@ void showExpandedHeaderControls(const DeviceSlotTraits& traits, const magda::Dev
                                 bool internalDevice, DeviceSlotContentFrameControls controls) {
     setVisibleIfPresent(controls.modButton,
                         drum_grid_slot::shouldShowModButton(traits.isDrumGrid, device.deviceType));
-    setVisibleIfPresent(controls.macroButton, drum_grid_slot::shouldShowMacroButton(
-                                                  traits.isDrumGrid, device.deviceType,
-                                                  traits.isArpeggiator, traits.isStepSequencer));
+    setVisibleIfPresent(controls.macroButton,
+                        drum_grid_slot::shouldShowMacroButton(
+                            traits.isDrumGrid, device.deviceType, traits.isArpeggiator,
+                            traits.isStepSequencer || traits.isPolyStepSequencer));
     setVisibleIfPresent(controls.uiButton, !internalDevice || traits.isAnalysis);
     setVisibleIfPresent(controls.powerButton, true);
     setVisibleIfPresent(controls.gainLabel, !isMidiUtility(traits) && !traits.isAnalysis);

--- a/magda/daw/ui/components/chain/slot/DeviceSlotContentPainter.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotContentPainter.cpp
@@ -93,9 +93,10 @@ void paintMidiUtilityHeader(juce::Graphics& g, juce::Rectangle<int> headerArea,
     }
 
     g.setFont(FontManager::getInstance().getMicrogrammaFont(9.0f));
-    const juce::String label = state.traits.isChordEngine   ? "MAGDA Chord Engine"
-                               : state.traits.isArpeggiator ? "MAGDA Arpeggiator"
-                                                            : "MAGDA Step Sequencer";
+    const juce::String label = state.traits.isChordEngine         ? "MAGDA Chord Engine"
+                               : state.traits.isArpeggiator       ? "MAGDA Arpeggiator"
+                               : state.traits.isPolyStepSequencer ? "MAGDA Poly Sequencer"
+                                                                  : "MAGDA Step Sequencer";
     g.drawText(label, textArea, juce::Justification::centredLeft);
 }
 
@@ -145,7 +146,8 @@ void paintDeviceSlotContent(juce::Graphics& g, juce::Rectangle<int> contentArea,
     if (drum_grid_slot::paintContentHeader(g, state.traits.isDrumGrid, state.bypassed, textArea))
         return;
 
-    if (state.traits.isChordEngine || state.traits.isArpeggiator || state.traits.isStepSequencer) {
+    if (state.traits.isChordEngine || state.traits.isArpeggiator || state.traits.isStepSequencer ||
+        state.traits.isPolyStepSequencer) {
         paintMidiUtilityHeader(g, headerArea, textArea, state);
     } else if (state.traits.isTracktionDevice && state.tracktionLogo != nullptr) {
         paintTracktionHeader(g, textArea, state);

--- a/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.cpp
@@ -37,7 +37,8 @@ void placeCollapsedButton(juce::Rectangle<int>& area, juce::Component* component
 }
 
 bool isMidiUtility(const DeviceSlotTraits& traits) {
-    return traits.isChordEngine || traits.isArpeggiator || traits.isStepSequencer;
+    return traits.isChordEngine || traits.isArpeggiator || traits.isStepSequencer ||
+           traits.isPolyStepSequencer;
 }
 
 }  // namespace
@@ -61,7 +62,7 @@ void layoutExpandedDeviceSlotHeader(juce::Rectangle<int>& headerArea,
         placeLeft(headerArea, controls.macroButton, buttonSize);
         placeLeft(headerArea, controls.modButton, buttonSize);
         placeAIButton();
-    } else if (traits.isArpeggiator || traits.isStepSequencer) {
+    } else if (traits.isArpeggiator || traits.isStepSequencer || traits.isPolyStepSequencer) {
         placeLeft(headerArea, controls.macroButton, buttonSize);
         setVisibleIfPresent(controls.modButton, false);
         placeAIButton();
@@ -134,7 +135,8 @@ void layoutCollapsedDeviceSlotControls(juce::Rectangle<int>& area,
 
     const bool showMod = drum_grid_slot::shouldShowModButton(traits.isDrumGrid, device.deviceType);
     const bool showMacro = drum_grid_slot::shouldShowMacroButton(
-        traits.isDrumGrid, device.deviceType, traits.isArpeggiator, traits.isStepSequencer);
+        traits.isDrumGrid, device.deviceType, traits.isArpeggiator,
+        traits.isStepSequencer || traits.isPolyStepSequencer);
     placeCollapsedButton(area, controls.macroButton, buttonSize);
     setVisibleIfPresent(controls.macroButton, showMacro);
 
@@ -168,7 +170,7 @@ void applyMidiOnlyDeviceHeaderVisibility(const DeviceSlotTraits& traits,
         return;
 
     setVisibleIfPresent(modButton, false);
-    if (!traits.isArpeggiator && !traits.isStepSequencer)
+    if (!traits.isArpeggiator && !traits.isStepSequencer && !traits.isPolyStepSequencer)
         setVisibleIfPresent(macroButton, false);
 }
 

--- a/magda/daw/ui/components/chain/slot/DeviceSlotMidiActivity.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotMidiActivity.cpp
@@ -4,6 +4,7 @@
 
 #include "audio/plugins/ArpeggiatorPlugin.hpp"
 #include "audio/plugins/MidiChordEnginePlugin.hpp"
+#include "audio/plugins/PolyStepSequencerPlugin.hpp"
 #include "audio/plugins/StepSequencerPlugin.hpp"
 #include "slot/DeviceCustomUIManager.hpp"
 #include "slot/DeviceSlotTraits.hpp"
@@ -45,6 +46,22 @@ void refreshSingleNoteStrip(daw::audio::StepSequencerPlugin* plugin, magda::Midi
         strip.setNote(note, vel);
 }
 
+void refreshSingleNoteStrip(daw::audio::PolyStepSequencerPlugin* plugin,
+                            magda::MidiNoteStrip& strip, int& lastNote) {
+    if (plugin == nullptr)
+        return;
+
+    const int note = plugin->midiOutNote_.load(std::memory_order_relaxed);
+    const int vel = plugin->midiOutVelocity_.load(std::memory_order_relaxed);
+    if (note != lastNote) {
+        if (lastNote >= 0)
+            strip.clearNote(lastNote);
+        lastNote = note;
+    }
+    if (note >= 0)
+        strip.setNote(note, vel);
+}
+
 void refreshChordStrip(daw::audio::MidiChordEnginePlugin* plugin, magda::MidiNoteStrip& strip,
                        std::array<int, 32>& lastChordNotes, int& lastChordCount) {
     if (plugin == nullptr)
@@ -72,6 +89,8 @@ void refreshDeviceSlotMidiActivity(const DeviceSlotTraits& traits,
         refreshSingleNoteStrip(customUI.getArpPlugin(), midiNoteStrip, lastSingleNote);
     } else if (traits.isStepSequencer) {
         refreshSingleNoteStrip(customUI.getStepSeqPlugin(), midiNoteStrip, lastSingleNote);
+    } else if (traits.isPolyStepSequencer) {
+        refreshSingleNoteStrip(customUI.getPolyStepSeqPlugin(), midiNoteStrip, lastSingleNote);
     } else if (traits.isChordEngine) {
         refreshChordStrip(customUI.getChordPlugin(), midiNoteStrip, lastChordNotes, lastChordCount);
     }

--- a/magda/daw/ui/components/chain/slot/DeviceSlotMidiUiBinding.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotMidiUiBinding.cpp
@@ -3,9 +3,11 @@
 #include "audio/AudioBridge.hpp"
 #include "audio/plugins/ArpeggiatorPlugin.hpp"
 #include "audio/plugins/MidiChordEnginePlugin.hpp"
+#include "audio/plugins/PolyStepSequencerPlugin.hpp"
 #include "audio/plugins/StepSequencerPlugin.hpp"
 #include "core/TrackManager.hpp"
 #include "custom_ui/ArpeggiatorUI.hpp"
+#include "custom_ui/PolyStepSequencerUI.hpp"
 #include "custom_ui/StepSequencerUI.hpp"
 #include "engine/AudioEngine.hpp"
 #include "slot/DeviceCustomUIManager.hpp"
@@ -42,6 +44,13 @@ void bindDeviceSlotMidiCustomUIs(DeviceCustomUIManager& customUI,
         if (auto* seq = dynamic_cast<daw::audio::StepSequencerPlugin*>(plugin.get())) {
             stepSequencerUI->setPlugin(seq);
             customUI.setStepSeqPlugin(seq);
+        }
+    }
+
+    if (auto* polyStepSequencerUI = customUI.getPolyStepSequencerUI()) {
+        if (auto* seq = dynamic_cast<daw::audio::PolyStepSequencerPlugin*>(plugin.get())) {
+            polyStepSequencerUI->setPlugin(seq);
+            customUI.setPolyStepSeqPlugin(seq);
         }
     }
 }

--- a/magda/daw/ui/components/chain/slot/DeviceSlotTraits.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotTraits.cpp
@@ -15,6 +15,7 @@ DeviceSlotTraits makeDeviceSlotTraits(const juce::String& pluginId) {
     traits.isChordEngine = kind == magda::InternalDeviceKind::MidiChordEngine;
     traits.isArpeggiator = kind == magda::InternalDeviceKind::Arpeggiator;
     traits.isStepSequencer = kind == magda::InternalDeviceKind::StepSequencer;
+    traits.isPolyStepSequencer = kind == magda::InternalDeviceKind::PolyStepSequencer;
     traits.isFaust = kind == magda::InternalDeviceKind::Faust;
     traits.isAnalysis = magda::isAnalysisDevice(pluginId);
     traits.hasAnalyzerPopout = kind == magda::InternalDeviceKind::Oscilloscope ||

--- a/magda/daw/ui/components/chain/slot/DeviceSlotTraits.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotTraits.hpp
@@ -11,6 +11,7 @@ struct DeviceSlotTraits {
     bool isChordEngine = false;
     bool isArpeggiator = false;
     bool isStepSequencer = false;
+    bool isPolyStepSequencer = false;
     bool isFaust = false;
     bool isAnalysis = false;  // oscilloscope / spectrum / levels: passthrough, no gain/macros/mods
     bool hasAnalyzerPopout = false;  // scope/spectrum pop into a floating window; levels does not

--- a/magda/daw/ui/components/chain/slot/StepSequencerClipExport.cpp
+++ b/magda/daw/ui/components/chain/slot/StepSequencerClipExport.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "audio/plugins/PolyStepSequencerPlugin.hpp"
 #include "audio/plugins/StepSequencerPlugin.hpp"
 #include "audio/transport/StepClock.hpp"
 #include "core/ClipInfo.hpp"
@@ -35,6 +36,56 @@ std::vector<magda::MidiNote> collectStepSequencerNotes(daw::audio::StepSequencer
         note.startBeat = i * stepBeats;
         note.lengthBeats = stepBeats * gate;
         notes.push_back(note);
+    }
+    return notes;
+}
+
+std::vector<magda::MidiNote> collectPolyStepSequencerNotes(
+    daw::audio::PolyStepSequencerPlugin& plugin) {
+    const int count =
+        juce::jlimit(1, daw::audio::PolyStepSequencerPlugin::MAX_STEPS, plugin.numSteps.get());
+    const auto rateEnum = static_cast<daw::audio::StepClock::Rate>(plugin.rate.get());
+    const double stepBeats = daw::audio::StepClock::rateToBeats(rateEnum);
+    const float gate = plugin.gateLength.get();
+
+    std::vector<magda::MidiNote> notes;
+
+    std::vector<int> spanSteps(static_cast<size_t>(count), 1);
+    for (int i = 0; i < count; ++i) {
+        const auto step = plugin.getStep(i);
+        if (!step.gate || step.tie)
+            continue;
+        int span = 1;
+        for (int j = i + 1; j < count; ++j) {
+            const auto next = plugin.getStep(j);
+            if (next.gate && next.tie)
+                ++span;
+            else
+                break;
+        }
+        spanSteps[static_cast<size_t>(i)] = span;
+    }
+
+    for (int i = 0; i < count; ++i) {
+        const auto step = plugin.getStep(i);
+        if (!step.gate || step.tie)
+            continue;
+        if (step.noteCount == 0)
+            continue;
+
+        double startBeat = i * stepBeats;
+        int span = spanSteps[static_cast<size_t>(i)];
+        double lengthBeats = (span - 1) * stepBeats + stepBeats * static_cast<double>(gate);
+
+        for (int n = 0; n < step.noteCount; ++n) {
+            const auto& sn = step.notes[static_cast<size_t>(n)];
+            magda::MidiNote note;
+            note.noteNumber = juce::jlimit(0, 127, sn.noteNumber);
+            note.velocity = juce::jlimit(1, 127, sn.velocity > 0 ? sn.velocity : step.velocity);
+            note.startBeat = startBeat;
+            note.lengthBeats = lengthBeats;
+            notes.push_back(note);
+        }
     }
     return notes;
 }
@@ -81,6 +132,41 @@ bool handleStepSequencerPatternExternalDrag(daw::audio::StepSequencerPlugin* plu
         exportButton->setAlpha(1.0f);
     }
 
+    return true;
+}
+
+void copyPolyStepSequencerPatternToClipboard(daw::audio::PolyStepSequencerPlugin& plugin) {
+    auto notes = collectPolyStepSequencerNotes(plugin);
+    if (!notes.empty())
+        ClipManager::getInstance().setNoteClipboard(std::move(notes));
+}
+
+juce::File writePolyStepSequencerPatternToTempMidiFile(
+    daw::audio::PolyStepSequencerPlugin& plugin) {
+    auto notes = collectPolyStepSequencerNotes(plugin);
+    if (notes.empty())
+        return {};
+    return daw::MidiFileWriter::writeToTempFile(notes, currentProjectTempoOrDefault(),
+                                                "polyseq-pattern");
+}
+
+bool handlePolyStepSequencerPatternExternalDrag(daw::audio::PolyStepSequencerPlugin* plugin,
+                                                juce::Component* exportButton,
+                                                juce::Component* dragOwner,
+                                                const juce::MouseEvent& event,
+                                                int dragThresholdPx) {
+    if (plugin == nullptr || exportButton == nullptr || dragOwner == nullptr ||
+        event.originalComponent != exportButton ||
+        event.getDistanceFromDragStart() <= dragThresholdPx) {
+        return false;
+    }
+    auto tempFile = writePolyStepSequencerPatternToTempMidiFile(*plugin);
+    if (tempFile.existsAsFile()) {
+        exportButton->setAlpha(0.4f);
+        juce::DragAndDropContainer::performExternalDragDropOfFiles(
+            juce::StringArray{tempFile.getFullPathName()}, false, dragOwner);
+        exportButton->setAlpha(1.0f);
+    }
     return true;
 }
 

--- a/magda/daw/ui/components/chain/slot/StepSequencerClipExport.hpp
+++ b/magda/daw/ui/components/chain/slot/StepSequencerClipExport.hpp
@@ -3,8 +3,9 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 namespace magda::daw::audio {
+class PolyStepSequencerPlugin;
 class StepSequencerPlugin;
-}
+}  // namespace magda::daw::audio
 
 namespace magda::daw::ui {
 
@@ -14,5 +15,12 @@ bool handleStepSequencerPatternExternalDrag(daw::audio::StepSequencerPlugin* plu
                                             juce::Component* exportButton,
                                             juce::Component* dragOwner,
                                             const juce::MouseEvent& event, int dragThresholdPx = 5);
+void copyPolyStepSequencerPatternToClipboard(daw::audio::PolyStepSequencerPlugin& plugin);
+juce::File writePolyStepSequencerPatternToTempMidiFile(daw::audio::PolyStepSequencerPlugin& plugin);
+bool handlePolyStepSequencerPatternExternalDrag(daw::audio::PolyStepSequencerPlugin* plugin,
+                                                juce::Component* exportButton,
+                                                juce::Component* dragOwner,
+                                                const juce::MouseEvent& event,
+                                                int dragThresholdPx = 5);
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -844,6 +844,21 @@ void AIChatConsoleContent::RequestThread::run() {
 
             currentText += juce::String::charToString(0x25C6) + " " + formattedResponse + "\n\n";
             safeThis->chatHistory_.setText(currentText);
+
+            // Append the mixing-agent caveat in a dim secondary colour after the
+            // main response. Inserted after setText so it does not enter the plain
+            // text that gets stored in conversation history (display-only).
+            if (!mixAnalysis.empty() && error.empty()) {
+                safeThis->chatHistory_.moveCaretToEnd();
+                safeThis->chatHistory_.setColour(
+                    juce::TextEditor::textColourId,
+                    DarkTheme::getSecondaryTextColour().withAlpha(0.5f));
+                safeThis->chatHistory_.insertTextAtCaret(
+                    juce::String(magda::MixAnalysisAgent::getUserCaveat()) + "\n\n");
+                safeThis->chatHistory_.setColour(juce::TextEditor::textColourId,
+                                                 DarkTheme::getSecondaryTextColour());
+            }
+
             safeThis->chatHistory_.moveCaretToEnd();
             safeThis->inputBox_->setEnabled(true);
             safeThis->processing_ = false;
@@ -3229,7 +3244,7 @@ void AIChatConsoleContent::finishPresetGeneration(bool success, const juce::Stri
     juce::String body = juce::String::charToString(0x25C6) + " " + header + "\n";
     body << prettyPrintPreset(preset);
     body << "\n  " << applyFourOscPresetToFocusedDevice(preset);
-    body << "\n  starting point — tweak by ear, then save from the device header";
+    body << "\n  starting point - tweak by ear, then save from the device header";
     appendToChat(body);
 }
 


### PR DESCRIPTION
Closes #939, closes #940

## New device: Poly Sequencer

- Polyphonic step sequencer MIDI device: up to 32 steps, up to 8 notes per step (chords), per-step gate/tie/probability/velocity with optional per-note velocity override. Reuses the shared StepClock (rate, direction, swing, time bend, quantize) unchanged.
- Two views in one UI:
  - Keys mode: piano-roll grid (pitch x step), click cells to build chords, scrollable 2-octave window. Note: the grid needs vertical space; drag the device view taller if it is collapsed.
  - Drum mode: x0x lanes discovered from a downstream DrumGrid on the same track (chain names as lane labels, listener-driven re-discovery), GM 8-lane fallback, orphan lanes so pattern data never becomes invisible. View mode persists with the edit.
- Pattern editing: transpose by semitone/octave from the right-click Pattern submenu (atomic: rejected if any note would leave 0-127), Clear Pattern, and copy-to-clip / drag-to-timeline parity with the mono sequencer via the shared export plumbing.

## AI

- Poly and mono sequencer agents on the unified DeviceAIAgent interface; the mono sequencer's old inline LLM path (in-UI prompt editor, detached thread, AIResultDisplay) is removed.
- Generation gets device context: current view mode, the DrumGrid lane map when present, and current settings (numSteps/rate/swing/gateLength are preserved unless the prompt asks to change them).
- Each agent now owns its post-generation user caveat (sound design / sequencers / coder / mixing agent) instead of one recycled string.
- Bugfix: restoring a device AI conversation coloured everything after the first caveat yellow; only the caveat lines are tinted now.

## Misc

- MIDI generator devices (both sequencers, Arpeggiator, Chord Engine) can no longer be added to the master track; guard sits in TrackManager::addDeviceToTrack, the choke point for browser, drag-and-drop, and agent inserts.
- Mono sequencer also gains Clear Pattern.