### PR TITLE
Fix drum-grid slice macros not driving pad envelopes

### DIFF
--- a/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
+++ b/magda/daw/audio/plugins/MagdaSamplerPlugin.cpp
@@ -173,8 +173,11 @@ MagdaSamplerPlugin::MagdaSamplerPlugin(const te::PluginCreationInfo& info) : Plu
 
     // ADSR parameters
     attackValue.referTo(state, te::IDs::attack, um, 0.001f);
+    // Time params use a logarithmic skew (0.4) so equal knob/macro movement
+    // gives perceptually-even change: most audible action is in the first few
+    // hundred ms, which a linear range crams into the bottom of the range.
     attackParam = addParam(
-        "attack", "Attack", {0.001f, 5.0f, 0.001f},
+        "attack", "Attack", {0.001f, 5.0f, 0.001f, 0.4f},
         [](float v) { return juce::String(v, 3) + " s"; },
         [](const juce::String& s) {
             return s.upToFirstOccurrenceOf(" ", false, false).getFloatValue();
@@ -183,7 +186,8 @@ MagdaSamplerPlugin::MagdaSamplerPlugin(const te::PluginCreationInfo& info) : Plu
     static const juce::Identifier decayId("decay");
     decayValue.referTo(state, decayId, um, 0.1f);
     decayParam = addParam(
-        "decay", "Decay", {0.001f, 5.0f, 0.1f}, [](float v) { return juce::String(v, 3) + " s"; },
+        "decay", "Decay", {0.001f, 5.0f, 0.001f, 0.4f},
+        [](float v) { return juce::String(v, 3) + " s"; },
         [](const juce::String& s) {
             return s.upToFirstOccurrenceOf(" ", false, false).getFloatValue();
         });
@@ -194,7 +198,7 @@ MagdaSamplerPlugin::MagdaSamplerPlugin(const te::PluginCreationInfo& info) : Plu
 
     releaseValue.referTo(state, te::IDs::release, um, 0.1f);
     releaseParam = addParam(
-        "release", "Release", {0.001f, 10.0f, 0.1f},
+        "release", "Release", {0.001f, 10.0f, 0.001f, 0.4f},
         [](float v) { return juce::String(v, 3) + " s"; },
         [](const juce::String& s) {
             return s.upToFirstOccurrenceOf(" ", false, false).getFloatValue();

--- a/magda/daw/core/ClipCommands.cpp
+++ b/magda/daw/core/ClipCommands.cpp
@@ -2196,8 +2196,8 @@ void zeroSamplerAdsrBase(daw::audio::MagdaSamplerPlugin& sampler) {
     sampler.releaseValue = releaseMin;
 }
 
-void addSamplerAdsrMacroLinks(DeviceInfo& drumGridDevice, TrackId trackId, DeviceId samplerDeviceId,
-                              te::Plugin& sampler) {
+void addSamplerAdsrMacroLinks(DeviceInfo& drumGridDevice, TrackId trackId, int chainIndex,
+                              DeviceId samplerDeviceId, te::Plugin& sampler) {
     if (samplerDeviceId == INVALID_DEVICE_ID)
         return;
 
@@ -2209,7 +2209,12 @@ void addSamplerAdsrMacroLinks(DeviceInfo& drumGridDevice, TrackId trackId, Devic
     const std::array<AdsrParam, 4> adsrParams = {
         {{0, "attack"}, {1, "decay"}, {2, "sustain"}, {3, "release"}}};
 
-    const auto samplerPath = ChainNodePath::topLevelDevice(trackId, samplerDeviceId);
+    // The pad sampler is a DrumGrid-internal device, registered in the audio
+    // sync under a nested chainDevice path (see syncDrumGridPadPlugins). Build
+    // the same path here so the macro link resolves; a topLevelDevice path
+    // would not be found and the modulation would never attach.
+    const auto samplerPath =
+        ChainNodePath::chainDevice(trackId, drumGridDevice.id, chainIndex, samplerDeviceId);
     for (const auto& adsrParam : adsrParams) {
         if (adsrParam.macroIndex < 0 ||
             adsrParam.macroIndex >= static_cast<int>(drumGridDevice.macros.size()))
@@ -2240,7 +2245,7 @@ void linkAssignedDrumGridSamplerAdsrMacros(DeviceInfo& drumGridDevice, TrackId t
             continue;
 
         zeroSamplerAdsrBase(*sampler);
-        addSamplerAdsrMacroLinks(drumGridDevice, trackId,
+        addSamplerAdsrMacroLinks(drumGridDevice, trackId, chain->index,
                                  drumGrid.getPluginDeviceId(chain->index, 0), *sampler);
     }
 }


### PR DESCRIPTION
Slicing an audio clip to a Drum Grid auto-maps four macros (Attack/ Decay/Sustain/Release) onto each pad sampler's envelope, but the links never attached, so hits played with the zeroed base ADSR (a few samples long) and stayed dead even after unlinking.

Two fixes:
- ClipCommands: the macro link target was built as a top-level-device path, but pad samplers are DrumGrid-internal devices registered under a nested chainDevice path (see syncDrumGridPadPlugins). The lookup never resolved, so no modifier was attached. Build the chainDevice path so every link resolves.
- MagdaSamplerPlugin: attack/decay/release used a linear range with a coarse 0.1s step, cramming all the audible action into the bottom of the knob (a macro sweep hit "fully open" by ~0.2). Give them a logarithmic skew (0.4) and a fine step so the macros sweep evenly.