### PR TITLE
Stop Dependabot from auto-running CI; drop it for Tracktion Engine

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Git submodules (JUCE, Tracktion Engine, etc.)
+  # Git submodules (JUCE, llama.cpp, etc.)
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
@@ -11,6 +11,10 @@ updates:
     labels:
       - "dependencies"
       - "security"
+    ignore:
+      # Tracktion Engine is a fork we control and bump deliberately (it carries
+      # MAGDA patches), so Dependabot must never open PRs for it.
+      - dependency-name: "third_party/tracktion_engine"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,10 @@ on:
     # that branch on top of the latest HEAD and force-pushes, so once the base
     # branch has advanced, the push diff carries real code and paths-ignore no
     # longer skips it. Excluding by branch name is the only reliable guard.
-    branches-ignore: [ 'l10n_crowdin_**' ]
+    # 'dependabot/**' so Dependabot bumps never auto-start CI (especially the
+    # self-hosted macOS/Windows build jobs). Validate a bump on demand via the
+    # workflow_dispatch button instead.
+    branches-ignore: [ 'l10n_crowdin_**', 'dependabot/**' ]
     tags-ignore: [ '**' ]
     # Belt-and-suspenders: also skip when a push only touches translation files.
     paths-ignore:

--- a/.github/workflows/juce-tests-linux.yml
+++ b/.github/workflows/juce-tests-linux.yml
@@ -4,7 +4,9 @@ on:
   push:
     # Never run on the Crowdin localization branch (see ci.yml for the rationale):
     # the sync force-pushes onto the latest HEAD, so paths-ignore can't catch it.
-    branches-ignore: [ 'l10n_crowdin_**' ]
+    # 'dependabot/**' so Dependabot bumps never auto-start these tests; run via
+    # workflow_dispatch when validating a bump.
+    branches-ignore: [ 'l10n_crowdin_**', 'dependabot/**' ]
     tags-ignore: [ '**' ]
     paths-ignore:
       - 'lang/**'


### PR DESCRIPTION
Dependabot pushes to dependabot/** branches were triggering ci.yml (including the self-hosted macOS/Windows build jobs) and the Linux JUCE tests automatically. Add 'dependabot/**' to the push branches-ignore on both so bumps never auto-start CI -- validate a bump on demand via workflow_dispatch.

Also ignore third_party/tracktion_engine in the gitsubmodule updates: it is a fork we control and bump deliberately (it carries MAGDA patches).