### PR TITLE
Loop record takes: per-pass takes + editor take lanes (#1457, #1458)

### DIFF
--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -1536,6 +1536,28 @@ bool ClipSynchronizer::syncMidiClipToEngine(ClipId clipId, const ClipInfo* clip)
     return needsGraphReallocation;
 }
 
+void ClipSynchronizer::applyModelTakesToTeClip(tracktion::WaveAudioClip& teClip,
+                                               const ClipInfo& clip) {
+    if (!clip.isAudio())
+        return;
+
+    const auto& takes = clip.audio().takes;
+    if (takes.empty())
+        return;
+
+    // Already populated (e.g. a plain property re-sync on an existing clip).
+    // Re-adding would duplicate the take list.
+    if (teClip.hasAnyTakes())
+        return;
+
+    // The clip source was created pointing at the active take, so getCurrentTake
+    // resolves it by matching source references — no setCurrentTake needed (and
+    // setCurrentTake assumes project-item takes, which these direct file
+    // references are not).
+    for (const auto& take : takes)
+        teClip.addTake(juce::File(take.filePath));
+}
+
 bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip) {
     namespace te = tracktion;
 
@@ -1660,6 +1682,11 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
 
         DBG("ClipSynchronizer: Created WaveAudioClip (engine ID: " << engineClipId << ")");
     }
+
+    // Re-attach loop-record takes (no-op for ordinary clips). Runs for both the
+    // create path (record / project load) and the update path that follows a
+    // create on a fresh recording.
+    applyModelTakesToTeClip(*audioClipPtr, *clip);
 
     // 3b. REVERSE — must be handled before position/loop/offset sync.
     // setIsReversed triggers updateReversedState() which:

--- a/magda/daw/audio/session/ClipSynchronizer.hpp
+++ b/magda/daw/audio/session/ClipSynchronizer.hpp
@@ -315,6 +315,18 @@ class ClipSynchronizer : public ClipManagerListener, public TrackManagerListener
     bool syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip);
 
     /**
+     * @brief Re-attach loop-record takes onto a freshly built TE clip.
+     *
+     * The model owns the take list (one audio file per loop pass); the TE clip
+     * is rebuilt from scratch on record and on project load, so the takes must
+     * be re-added each time. Idempotent: a no-op if the model has no takes or
+     * the TE clip already carries them. The active take plays back because the
+     * clip's source already points at takes[currentTakeIndex]; the others are
+     * preserved as alternates.
+     */
+    void applyModelTakesToTeClip(tracktion::WaveAudioClip& teClip, const ClipInfo& clip);
+
+    /**
      * @brief Configure autoTempo on a session audio clip in TE
      * @param audioClip The TE WaveAudioClip to configure
      * @param clip The ClipInfo model data

--- a/magda/daw/core/ClipInfo.hpp
+++ b/magda/daw/core/ClipInfo.hpp
@@ -131,9 +131,27 @@ struct AudioSourceInterpretation {
     std::string keyScale;
 };
 
+/**
+ * @brief One loop-record take: a single recorded pass over the loop range.
+ *
+ * Loop recording captures each pass as its own audio file (Tracktion splits the
+ * continuous recording at the loop boundaries). filePath is the on-disk source
+ * for that pass; durationSeconds is its audio length.
+ */
+struct AudioTake {
+    juce::String filePath;
+    double durationSeconds = 0.0;
+};
+
 struct AudioClipModel {
     AudioSourceFacts source;
     AudioSourceInterpretation interpretation;
+
+    // Loop-record takes, one per pass. Empty for ordinary single-source clips.
+    // When non-empty, source.filePath mirrors takes[currentTakeIndex].filePath
+    // (the active take that plays back).
+    std::vector<AudioTake> takes;
+    int currentTakeIndex = 0;
 };
 
 struct MidiClipModel {

--- a/magda/daw/engine/TracktionEngineWrapperRecording.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperRecording.cpp
@@ -138,6 +138,45 @@ void TracktionEngineWrapper::recordingFinished(
             double startSeconds = audioClip->getPosition().getStart().inSeconds();
             double lengthSeconds = audioClip->getPosition().getLength().inSeconds();
 
+            // Loop recording: Tracktion split the continuous capture into one
+            // take (audio file) per loop pass and registered them on the clip.
+            // Harvest them before we drop TE's clip, so no pass is lost. Each
+            // take is a direct file reference (we record outside a TE project),
+            // so resolve via SourceFileReference. The active take is the last
+            // full pass; only the final pass can be partial (mid-pass stop).
+            std::vector<AudioTake> takes;
+            int activeTakeIndex = 0;
+            if (audioClip->hasAnyTakes()) {
+                auto takesTree = audioClip->state.getChildWithName(tracktion::IDs::TAKES);
+                for (int i = 0; i < takesTree.getNumChildren(); ++i) {
+                    auto takeChild = takesTree.getChild(i);
+                    tracktion::SourceFileReference sfr(audioClip->edit, takeChild,
+                                                       tracktion::IDs::source);
+                    juce::File takeFile = sfr.getFile();
+                    if (takeFile == juce::File())
+                        continue;
+                    AudioTake take;
+                    take.filePath = takeFile.getFullPathName();
+                    take.durationSeconds =
+                        tracktion::AudioFile(audioClip->edit.engine, takeFile).getLength();
+                    takes.push_back(take);
+                }
+
+                if (!takes.empty()) {
+                    double loopLen = 0.0;
+                    for (const auto& t : takes)
+                        loopLen = std::max(loopLen, t.durationSeconds);
+                    activeTakeIndex = static_cast<int>(takes.size()) - 1;
+                    if (takes.size() > 1 && takes[activeTakeIndex].durationSeconds < loopLen * 0.95)
+                        activeTakeIndex = static_cast<int>(takes.size()) - 2;
+
+                    // Front the active take as the clip's source + length.
+                    audioFilePath = takes[activeTakeIndex].filePath;
+                    if (takes[activeTakeIndex].durationSeconds > 0.0)
+                        lengthSeconds = takes[activeTakeIndex].durationSeconds;
+                }
+            }
+
             if (lengthSeconds <= 0.0 || audioFilePath.isEmpty() || trackId == INVALID_TRACK_ID) {
                 audioClip->removeFromParent();
                 continue;
@@ -158,6 +197,10 @@ void TracktionEngineWrapper::recordingFinished(
                 if (isValidBpm(projectBPM)) {
                     newClip->audio().interpretation.bpm = projectBPM;
                     newClip->audio().interpretation.totalBeats = lengthSeconds * projectBPM / 60.0;
+                }
+                if (!takes.empty()) {
+                    newClip->audio().takes = std::move(takes);
+                    newClip->audio().currentTakeIndex = activeTakeIndex;
                 }
             }
 

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -577,14 +577,28 @@ void ProjectManager::migrateMediaFiles(const juce::File& oldDir, const juce::Fil
     auto& clipManager = ClipManager::getInstance();
     auto updateClipPaths = [&](const std::vector<ClipInfo>& clips) {
         for (const auto& clipInfo : clips) {
-            if (clipInfo.isAudio() && clipInfo.audio().source.filePath.isNotEmpty() &&
-                clipInfo.audio().source.filePath.startsWith(oldPath)) {
-                auto* clip = clipManager.getClip(clipInfo.id);
-                if (clip) {
+            if (!clipInfo.isAudio())
+                continue;
+            const bool sourceMoved = clipInfo.audio().source.filePath.isNotEmpty() &&
+                                     clipInfo.audio().source.filePath.startsWith(oldPath);
+            bool anyTakeMoved = false;
+            for (const auto& take : clipInfo.audio().takes) {
+                if (take.filePath.startsWith(oldPath)) {
+                    anyTakeMoved = true;
+                    break;
+                }
+            }
+            if (!sourceMoved && !anyTakeMoved)
+                continue;
+            auto* clip = clipManager.getClip(clipInfo.id);
+            if (clip) {
+                if (sourceMoved)
                     clip->audio().source.filePath =
                         clip->audio().source.filePath.replace(oldPath, newPath, false);
-                    updatedClipIds.push_back(clip->id);
-                }
+                for (auto& take : clip->audio().takes)
+                    if (take.filePath.startsWith(oldPath))
+                        take.filePath = take.filePath.replace(oldPath, newPath, false);
+                updatedClipIds.push_back(clip->id);
             }
         }
     };

--- a/magda/daw/project/serialization/ClipSerializer.cpp
+++ b/magda/daw/project/serialization/ClipSerializer.cpp
@@ -168,6 +168,21 @@ juce::var ProjectSerializer::serializeClipInfo(const ClipInfo& clip) {
         if (clip.timeStretchMode != 0) {
             audioObj->setProperty("timeStretchMode", clip.timeStretchMode);
         }
+
+        // Loop-record takes (one source file per pass). Persist so the take
+        // alternates survive save/reload; the engine rebuilds them on sync.
+        if (!clip.audio().takes.empty()) {
+            juce::Array<juce::var> takesArray;
+            for (const auto& take : clip.audio().takes) {
+                auto* takeObj = new juce::DynamicObject();
+                takeObj->setProperty("filePath", take.filePath);
+                takeObj->setProperty("durationSeconds", take.durationSeconds);
+                takesArray.add(juce::var(takeObj));
+            }
+            audioObj->setProperty("takes", takesArray);
+            audioObj->setProperty("currentTakeIndex", clip.audio().currentTakeIndex);
+        }
+
         obj->setProperty("audio", juce::var(audioObj));
     }
 
@@ -410,6 +425,23 @@ bool ProjectSerializer::deserializeClipInfo(const juce::var& json, ClipInfo& out
                     outClip.warpMarkers.push_back(wm);
                 }
             }
+        }
+
+        // Loop-record takes
+        auto takesVar = audioObj->getProperty("takes");
+        if (takesVar.isArray()) {
+            for (const auto& takeVar : *takesVar.getArray()) {
+                if (auto* takeObj = takeVar.getDynamicObject()) {
+                    AudioTake take;
+                    take.filePath = takeObj->getProperty("filePath").toString();
+                    take.durationSeconds = takeObj->getProperty("durationSeconds");
+                    outClip.audio().takes.push_back(take);
+                }
+            }
+            if (!outClip.audio().takes.empty())
+                outClip.audio().currentTakeIndex =
+                    juce::jlimit(0, static_cast<int>(outClip.audio().takes.size()) - 1,
+                                 static_cast<int>(audioObj->getProperty("currentTakeIndex")));
         }
     } else if (outClip.isAudio() && legacyAudioSourceObj != nullptr) {
         outClip.audio().source.filePath = legacyAudioSourceObj->getProperty("filePath").toString();

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -62,6 +62,11 @@ void showExternalEditorFailedAlert(const juce::String& message) {
 constexpr int MIDI_PREVIEW_MIN_NOTE = 21;   // A0
 constexpr int MIDI_PREVIEW_MAX_NOTE = 108;  // C8
 
+// Context-menu IDs for loop-record take selection (one per take), kept clear of
+// the fixed item IDs and the 100-range quantize grid.
+constexpr int kTakeMenuBaseId = 300;
+constexpr int kTakeMenuMaxItems = 64;
+
 juce::Path makeClippedRoundedRectPath(juce::Rectangle<int> bounds,
                                       juce::Rectangle<int> visibleBounds, float radius) {
     juce::Path path;
@@ -2819,6 +2824,21 @@ void ClipComponent::showContextMenu() {
     menu.addItem(16, "Slice at Grid to Drum Grid", canSliceAtGrid);
     menu.addSeparator();
 
+    // Loop-record takes: pick which captured pass plays back. Single audio clip
+    // with more than one take only. IDs 300+ (one per take).
+    {
+        const auto* takeClip = isMultiSelection ? nullptr : getClipInfo();
+        if (takeClip && takeClip->isAudio() && takeClip->audio().takes.size() > 1) {
+            juce::PopupMenu takesMenu;
+            const auto& takes = takeClip->audio().takes;
+            for (int i = 0; i < static_cast<int>(takes.size()); ++i)
+                takesMenu.addItem(kTakeMenuBaseId + i, "Take " + juce::String(i + 1), canEdit,
+                                  i == takeClip->audio().currentTakeIndex);
+            menu.addSubMenu("Takes", takesMenu, canEdit);
+            menu.addSeparator();
+        }
+    }
+
     bool canEditExternally = false;
     if (!isMultiSelection && canEdit) {
         const auto* singleClip = getClipInfo();
@@ -2994,6 +3014,21 @@ void ClipComponent::showContextMenu() {
                                                     &selectionManager](int result) {
         if (result == 0)
             return;  // Cancelled
+
+        // Loop-record take selection (IDs 300+): front the chosen pass as the
+        // clip source and re-sync. ClipSynchronizer detects the source change,
+        // rebuilds the TE clip, and re-attaches the take alternates.
+        if (result >= kTakeMenuBaseId && result < kTakeMenuBaseId + kTakeMenuMaxItems) {
+            const int takeIndex = result - kTakeMenuBaseId;
+            auto* c = clipManager.getClip(clipId_);
+            if (c && c->isAudio() && takeIndex >= 0 &&
+                takeIndex < static_cast<int>(c->audio().takes.size())) {
+                c->audio().currentTakeIndex = takeIndex;
+                c->audio().source.filePath = c->audio().takes[takeIndex].filePath;
+                clipManager.forceNotifyClipPropertyChanged(clipId_);
+            }
+            return;
+        }
 
         switch (result) {
             case 1: {  // Copy

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -106,6 +106,14 @@ void WaveformGridComponent::paintWaveform(juce::Graphics& g, const magda::ClipIn
     if (layout.rect.isEmpty())
         return;
 
+    // Loop-record takes: show each pass as its own stacked lane instead of the
+    // single active-take waveform. Editing overlays (warp/transients) are not
+    // drawn in this mode — they apply per-take and belong to a later pass.
+    if (clip.audio().takes.size() > 1) {
+        paintTakeLanes(g, clip, layout);
+        return;
+    }
+
     paintWaveformBackground(g, clip, layout);
     paintWaveformThumbnail(g, clip, layout);
     paintWaveformOverlays(g, clip, layout);
@@ -304,6 +312,81 @@ void WaveformGridComponent::paintWaveformThumbnail(juce::Graphics& g, const magd
             if (clip.isReversed)
                 g.restoreState();
         }
+    }
+}
+
+int WaveformGridComponent::takeLaneAtY(int y, const WaveformLayout& layout, int takeCount) const {
+    if (takeCount <= 0)
+        return -1;
+    const auto& rect = layout.rect;
+    if (y < rect.getY() || y >= rect.getBottom())
+        return -1;
+    const int laneH = juce::jmax(1, rect.getHeight() / takeCount);
+    return juce::jlimit(0, takeCount - 1, (y - rect.getY()) / laneH);
+}
+
+void WaveformGridComponent::paintTakeLanes(juce::Graphics& g, const magda::ClipInfo& clip,
+                                           const WaveformLayout& layout) {
+    const auto& takes = clip.audio().takes;
+    const int n = static_cast<int>(takes.size());
+    if (n <= 0)
+        return;
+
+    auto& thumbnailManager = magda::AudioThumbnailManager::getInstance();
+    updateWaveformLoadListener(clip.audio().source.filePath);
+    const bool useHighRes = !interactionActive_;
+    const float gainLinear = juce::Decibels::decibelsToGain(clip.volumeDB + clip.gainDB);
+    const auto vertZoom = static_cast<float>(verticalZoom_) * gainLinear;
+
+    const auto rect = layout.rect;
+    const int laneH = juce::jmax(1, rect.getHeight() / n);
+    const int clipStartX = timeToPixel(getDisplayStartTime());
+    const auto localBounds = getLocalBounds();
+    const int activeIndex = clip.audio().currentTakeIndex;
+
+    for (int i = 0; i < n; ++i) {
+        const int laneY = rect.getY() + i * laneH;
+        const bool active = (i == activeIndex);
+        juce::Rectangle<int> laneRect(rect.getX(), laneY, rect.getWidth(), laneH);
+
+        // Lane background + active emphasis.
+        g.setColour(clip.colour.darker(active ? 0.4f : 0.72f));
+        g.fillRect(laneRect.getIntersection(localBounds));
+        if (active) {
+            g.setColour(clip.colour.brighter(0.3f));
+            g.fillRect(laneRect.getX(), laneY, 3, laneH);
+        }
+
+        // Each take drawn at its natural length from the clip start.
+        const double dur = takes[i].durationSeconds > 0.0 ? takes[i].durationSeconds : 0.0;
+        if (dur > 0.0) {
+            const int takeEndX = clipStartX + static_cast<int>(std::round(dur * horizontalZoom_));
+            const int visX0 = juce::jmax(clipStartX, localBounds.getX());
+            const int visX1 = juce::jmin(takeEndX, localBounds.getRight());
+            if (visX1 > visX0) {
+                juce::Rectangle<int> drawRect(visX0, laneY, visX1 - visX0, laneH);
+                drawRect = drawRect.reduced(0, juce::jmin(4, laneH / 4));
+                if (!drawRect.isEmpty()) {
+                    const double tStart = (visX0 - clipStartX) / horizontalZoom_;
+                    const double tEnd = (visX1 - clipStartX) / horizontalZoom_;
+                    const auto waveColour =
+                        active ? juce::Colours::black : juce::Colours::black.withAlpha(0.45f);
+                    thumbnailManager.drawWaveform(
+                        g, drawRect, takes[i].filePath, juce::jlimit(0.0, dur, tStart),
+                        juce::jlimit(0.0, dur, tEnd), waveColour, vertZoom, useHighRes);
+                }
+            }
+        }
+
+        // Lane label + separator.
+        g.setColour(active ? juce::Colours::white : juce::Colours::white.withAlpha(0.55f));
+        g.setFont(juce::Font(juce::FontOptions(11.0f)));
+        g.drawText("Take " + juce::String(i + 1),
+                   juce::Rectangle<int>(clipStartX + 6, laneY + 2, 80, 14),
+                   juce::Justification::centredLeft, true);
+        g.setColour(clip.colour.darker(0.9f));
+        g.drawHorizontalLine(laneY + laneH - 1, static_cast<float>(localBounds.getX()),
+                             static_cast<float>(localBounds.getRight()));
     }
 }
 
@@ -1005,6 +1088,17 @@ void WaveformGridComponent::mouseDown(const juce::MouseEvent& event) {
     if (event.mods.isPopupMenu()) {
         showContextMenu(event);
         return;
+    }
+
+    // Loop-record takes: clicking a lane makes that take active.
+    if (clip->audio().takes.size() > 1) {
+        auto layout = computeWaveformLayout(*clip);
+        int lane = takeLaneAtY(event.y, layout, static_cast<int>(clip->audio().takes.size()));
+        if (lane >= 0) {
+            if (lane != clip->audio().currentTakeIndex && onTakeSelected)
+                onTakeSelected(lane);
+            return;
+        }
     }
 
     // Warp mode interaction

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.hpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.hpp
@@ -202,6 +202,9 @@ class WaveformGridComponent : public juce::Component, public juce::ChangeListene
     std::function<void(int deltaX, int deltaY, int anchorX, const juce::ModifierKeys& mods)>
         onZoomDrag;
 
+    // Fired when the user clicks a take lane (multi-take clip) to make it active.
+    std::function<void(int takeIndex)> onTakeSelected;
+
   private:
     magda::ClipId editingClipId_ = magda::INVALID_CLIP_ID;
 
@@ -296,6 +299,11 @@ class WaveformGridComponent : public juce::Component, public juce::ChangeListene
                                  const WaveformLayout& layout);
     void paintWaveformThumbnail(juce::Graphics& g, const magda::ClipInfo& clip,
                                 const WaveformLayout& layout);
+    // Loop-record takes: stacked equal-height waveform lanes (active highlighted).
+    void paintTakeLanes(juce::Graphics& g, const magda::ClipInfo& clip,
+                        const WaveformLayout& layout);
+    // Returns the take lane index under y (multi-take clip), or -1.
+    int takeLaneAtY(int y, const WaveformLayout& layout, int takeCount) const;
     void paintWaveformOverlays(juce::Graphics& g, const magda::ClipInfo& clip,
                                const WaveformLayout& layout);
     void paintBeatGrid(juce::Graphics& g, const magda::ClipInfo& clip);

--- a/magda/daw/ui/panels/content/WaveformEditorContent.cpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.cpp
@@ -568,6 +568,20 @@ WaveformEditorContent::WaveformEditorContent() {
     gridComponent_->onSliceWarpMarkersToDrumGrid = [this]() { sliceWarpMarkersToDrumGrid(); };
     gridComponent_->onSliceAtGridToDrumGrid = [this]() { sliceAtGridToDrumGrid(); };
 
+    // Loop-record takes: a lane click fronts that take as the clip's source and
+    // re-syncs (ClipSynchronizer rebuilds the TE clip + re-attaches the takes).
+    gridComponent_->onTakeSelected = [this](int takeIndex) {
+        auto& cm = magda::ClipManager::getInstance();
+        auto* clip = cm.getClip(editingClipId_);
+        if (!clip || !clip->isAudio())
+            return;
+        if (takeIndex < 0 || takeIndex >= static_cast<int>(clip->audio().takes.size()))
+            return;
+        clip->audio().currentTakeIndex = takeIndex;
+        clip->audio().source.filePath = clip->audio().takes[takeIndex].filePath;
+        cm.forceNotifyClipPropertyChanged(editingClipId_);
+    };
+
     // Zoom drag on waveform body, resolved through GestureRouter.
     gridComponent_->onZoomDrag = [this](int deltaX, int deltaY, int anchorX,
                                         const juce::ModifierKeys& mods) {


### PR DESCRIPTION
Loop-record takes, in two parts. Closes #1457 and #1458; comping is the follow-up (#1459).

## #1457 — capture: preserve each pass as a take
Loop recording was single-clip and lossy: stopping mid-pass truncated the clip to the stop position and discarded audio captured later in the loop range on earlier passes. Tracktion already splits a looped capture into one take file per pass, but `recordingFinished` threw that away by removing TE's clip and rebuilding a MAGDA clip from the file path alone.

- `ClipInfo`: `AudioClipModel` carries a take list (`AudioTake`) + `currentTakeIndex`.
- `recordingFinished`: harvest the per-pass take files before dropping TE's clip; front the last full pass as the active take.
- `ClipSynchronizer`: re-attach takes whenever the TE clip is rebuilt (record and project load), idempotently. We never call TE's `setCurrentTake` (it assumes project-item takes and would delete our direct-file takes); the clip source points at the active take and the rest are alternates.
- `ClipSerializer`: persist takes so they survive save/reload.
- `ProjectManager`: Save As rewrites take paths alongside the source.
- `ClipComponent`: right-click "Takes" submenu to pick the active take.

## #1458 — editor take lanes
When an audio clip has more than one take, the waveform editor shows each take as its own equal-height lane sharing the time axis, instead of just the single active-take waveform. Active take bright with a colour accent bar, others dimmed. Clicking a lane fronts that take as the clip source and re-syncs.

## Scope / notes
- Audio only. MIDI loop-record takes are a follow-up (MIDI is inline note data, not file-backed).
- Warp/transient overlays are suppressed in multi-take mode; they apply per-take and belong with comping.
- Expanded/collapsed lane view is tracked on #1458.
- Comping (#1459) will be MAGDA-native: TE's comp manager is ruled out because it resolves takes only via ProjectItemID, and our recorded takes are direct file references.

## Testing
Loop-record an audio track over 2+ passes, stop mid-pass. You get a clip playing the last full pass; right-click -> Takes lists every pass; the waveform editor shows the stacked lanes; clicking a lane switches the active take. Save/reload preserves takes. Builds clean; unit tests pass.
