### PR TITLE
Fix loop boundary line gap under number ticks; steer concurrent CI to…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,12 +397,21 @@ jobs:
           status=$(printf '%s' "$runner" | cut -f1)
           busy=$(printf '%s' "$runner" | cut -f2)
 
-          if [ "$status" = "online" ] && [ "$busy" != "true" ]; then
+          # The runner only reports busy=true once a job has actually landed on
+          # it. This pick job runs at the very start of the workflow, long before
+          # the Windows build job dispatches, so two CI runs starting close
+          # together both see busy=false and both target magda-luca - the second
+          # then queues behind the first instead of falling back. Guard against
+          # that by also falling back when any other CI run is already in flight.
+          inflight=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?status=in_progress&per_page=100" \
+            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }})] | length" 2>/dev/null || echo "unknown")
+
+          if [ "$status" = "online" ] && [ "$busy" != "true" ] && [ "$inflight" = "0" ]; then
             echo 'labels=["self-hosted","Windows","magda-luca"]' >> "$GITHUB_OUTPUT"
             echo "Using idle self-hosted runner: magda-luca"
           else
             echo 'labels=["windows-latest"]' >> "$GITHUB_OUTPUT"
-            echo "Falling back to windows-latest (magda-luca status: '${status:-not-found}', busy: '${busy:-unknown}')"
+            echo "Falling back to windows-latest (magda-luca status: '${status:-not-found}', busy: '${busy:-unknown}', inflight runs: '${inflight}')"
           fi
 
   build-and-test-windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,8 +403,11 @@ jobs:
           # together both see busy=false and both target magda-luca - the second
           # then queues behind the first instead of falling back. Guard against
           # that by also falling back when any other CI run is already in flight.
-          inflight=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?status=in_progress&per_page=100" \
-            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }})] | length" 2>/dev/null || echo "unknown")
+          # Count every run that is not yet completed (queued/in_progress/
+          # waiting/...): a competing run can still be queued, not in_progress,
+          # at the moment this step executes, and it has already picked a runner.
+          inflight=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?per_page=100" \
+            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }}) | select(.status != \"completed\")] | length" 2>/dev/null || echo "unknown")
 
           if [ "$status" = "online" ] && [ "$busy" != "true" ] && [ "$inflight" = "0" ]; then
             echo 'labels=["self-hosted","Windows","magda-luca"]' >> "$GITHUB_OUTPUT"

--- a/magda/daw/ui/components/timeline/TimelineComponent.cpp
+++ b/magda/daw/ui/components/timeline/TimelineComponent.cpp
@@ -1363,6 +1363,18 @@ void TimelineComponent::drawLoopMarkerFlags(juce::Graphics& g) {
         g.fillRect(endX - 1, stripTop, 2, LOOP_STRIP_HEIGHT);
     }
 
+    // Extend the marker lines down through the tick area so they meet the
+    // full-height loop lines drawn over the tracks below. Without this the
+    // boundary line vanishes across the number-tick band whenever a loop edge
+    // does not coincide with a bar tick (visible once zoomed in).
+    int tickHeight = layout.rulerMajorTickHeight;
+    if (isXVisible(g, getWidth(), startX)) {
+        g.fillRect(startX - 1, tickAreaTop, 2, tickHeight);
+    }
+    if (isXVisible(g, getWidth(), endX)) {
+        g.fillRect(endX - 1, tickAreaTop, 2, tickHeight);
+    }
+
     // Triangular flags
     int flagTop = stripTop + 1;
     int loopPixelWidth = endX - startX;


### PR DESCRIPTION
… hosted runner

TimelineComponent only drew loop boundary lines in the strip, so the line vanished across the number-tick band when a loop edge did not land on a bar tick (visible once zoomed in). Extend the marker lines through the tick area so they meet the full-height overlay lines below.

pick-windows-runner now also falls back to windows-latest when another CI run is already in flight. The runner only reports busy=true once a job lands on it, long after this pick job runs, so two runs starting close together both saw it idle and the second queued behind the busy local runner instead of using a hosted one.