### PR TITLE
Add song navigator minimap in the master content strip

### DIFF
--- a/magda/daw/ui/components/CMakeLists.txt
+++ b/magda/daw/ui/components/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(common)
+add_subdirectory(navigation)
 add_subdirectory(timeline)
 add_subdirectory(tracks)
 add_subdirectory(clips)

--- a/magda/daw/ui/components/navigation/CMakeLists.txt
+++ b/magda/daw/ui/components/navigation/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(magda_daw_app PRIVATE
+    SongNavigatorPanel.cpp
+    SongNavigatorPanel.hpp
+)

--- a/magda/daw/ui/components/navigation/SongNavigatorPanel.cpp
+++ b/magda/daw/ui/components/navigation/SongNavigatorPanel.cpp
@@ -1,0 +1,353 @@
+#include "SongNavigatorPanel.hpp"
+
+#include "../../../core/ClipInfo.hpp"
+#include "../../layout/LayoutConfig.hpp"
+#include "../../themes/DarkTheme.hpp"
+
+namespace magda {
+
+SongNavigatorPanel::SongNavigatorPanel() {
+    setOpaque(true);
+    TrackManager::getInstance().addListener(this);
+    ClipManager::getInstance().addListener(this);
+}
+
+SongNavigatorPanel::~SongNavigatorPanel() {
+    TrackManager::getInstance().removeListener(this);
+    ClipManager::getInstance().removeListener(this);
+    if (controller_) {
+        controller_->removeListener(this);
+    }
+}
+
+void SongNavigatorPanel::setController(TimelineController* controller) {
+    if (controller_) {
+        controller_->removeListener(this);
+    }
+    controller_ = controller;
+    if (controller_) {
+        controller_->addListener(this);
+    }
+    repaint();
+}
+
+// ===== Coordinate helpers =====
+
+double SongNavigatorPanel::totalBeats() const {
+    if (!controller_) {
+        return 1.0;
+    }
+    // The strip spans the whole project timeline (not just the song content).
+    // The mini ruler makes the scale self-evident, so the song's clips end
+    // partway with the remaining project length shown empty after them.
+    return juce::jmax(1.0, controller_->getState().timelineLengthBeats);
+}
+
+int SongNavigatorPanel::beatToX(double beat) const {
+    // Left padding matches the main track content; the right gutter matches the
+    // arrangement's min-zoom label gutter so that, fully zoomed out, the end of
+    // the strip lines up with the end of the arrangement's bars.
+    const int usableWidth =
+        juce::jmax(1, getWidth() - LayoutConfig::TIMELINE_LEFT_PADDING -
+                          static_cast<int>(TimelineState::MIN_ZOOM_RIGHT_LABEL_GUTTER));
+    const double frac = juce::jlimit(0.0, 1.0, beat / totalBeats());
+    return LayoutConfig::TIMELINE_LEFT_PADDING + static_cast<int>(std::round(frac * usableWidth));
+}
+
+double SongNavigatorPanel::xToBeat(int x) const {
+    const int usableWidth =
+        juce::jmax(1, getWidth() - LayoutConfig::TIMELINE_LEFT_PADDING -
+                          static_cast<int>(TimelineState::MIN_ZOOM_RIGHT_LABEL_GUTTER));
+    const double frac = juce::jlimit(
+        0.0, 1.0, static_cast<double>(x - LayoutConfig::TIMELINE_LEFT_PADDING) / usableWidth);
+    return frac * totalBeats();
+}
+
+double SongNavigatorPanel::visibleStartBeats() const {
+    if (!controller_) {
+        return 0.0;
+    }
+    const auto& zoom = controller_->getState().zoom;
+    if (zoom.horizontalZoom <= 0.0) {
+        return 0.0;
+    }
+    return juce::jmax(0.0,
+                      (zoom.scrollX - LayoutConfig::TIMELINE_LEFT_PADDING) / zoom.horizontalZoom);
+}
+
+double SongNavigatorPanel::visibleLengthBeats() const {
+    if (!controller_) {
+        return totalBeats();
+    }
+    const auto& zoom = controller_->getState().zoom;
+    if (zoom.horizontalZoom <= 0.0) {
+        return totalBeats();
+    }
+    return zoom.viewportWidth / zoom.horizontalZoom;
+}
+
+juce::Rectangle<float> SongNavigatorPanel::getViewportBox() const {
+    const double startBeats = visibleStartBeats();
+    const double endBeats = juce::jmin(totalBeats(), startBeats + visibleLengthBeats());
+    const int left = beatToX(startBeats);
+    const int right = beatToX(endBeats);
+    return juce::Rectangle<float>(static_cast<float>(left), 0.0f,
+                                  static_cast<float>(juce::jmax(2, right - left)),
+                                  static_cast<float>(getHeight()));
+}
+
+// ===== Painting =====
+
+void SongNavigatorPanel::paint(juce::Graphics& g) {
+    g.fillAll(DarkTheme::getColour(DarkTheme::TRACK_BACKGROUND));
+
+    auto bounds = getLocalBounds();
+
+    auto& trackManager = TrackManager::getInstance();
+    auto& clipManager = ClipManager::getInstance();
+    const auto& tracks = trackManager.getTracks();
+    const int numTracks = static_cast<int>(tracks.size());
+
+    // Mini ruler band along the top, plus faint bar gridlines down the strip so
+    // the navigator carries its own scale (no need to read it against the main
+    // ruler above, which has a different zoom).
+    const int beatsPerBar =
+        controller_ ? juce::jmax(1, controller_->getState().tempo.timeSignatureNumerator) : 4;
+    const double totalBars = totalBeats() / beatsPerBar;
+    {
+        // Pick a "nice" bar step so labels stay readable (~one per 70px).
+        const int maxLabels = juce::jmax(1, getWidth() / 70);
+        const double rawStep = totalBars / maxLabels;
+        const int niceSteps[] = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512};
+        int barStep = niceSteps[0];
+        for (int s : niceSteps) {
+            barStep = s;
+            if (s >= rawStep) {
+                break;
+            }
+        }
+
+        g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(0.5f));
+        g.fillRect(0, 0, getWidth(), kRulerHeight);
+        g.setFont(8.0f);
+        for (int bar = 1; bar <= static_cast<int>(totalBars); bar += barStep) {
+            const int x = beatToX((bar - 1) * static_cast<double>(beatsPerBar));
+            // Skip ticks/labels that land on (or past) the right edge - they
+            // collide with the border / viewport box and the label gets clipped.
+            if (x >= getWidth() - 2) {
+                continue;
+            }
+            g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(0.6f));
+            g.drawVerticalLine(x, static_cast<float>(kRulerHeight),
+                               static_cast<float>(getHeight()));
+            g.setColour(DarkTheme::getColour(DarkTheme::TEXT_SECONDARY).withAlpha(0.7f));
+            g.drawText(juce::String(bar), x + 2, 0, 40, kRulerHeight,
+                       juce::Justification::centredLeft);
+        }
+    }
+
+    // Height is limited, so merge tracks onto a few lanes rather than one thin
+    // lane per track. numLanes = numTracks when they fit, else fewer (each lane
+    // then holds several tracks' clips stacked together).
+    bool hasContent = false;
+    if (numTracks > 0) {
+        const int lanesTop = kRulerHeight + kVInset;
+        const int availableHeight = juce::jmax(1, getHeight() - lanesTop - kVInset);
+        const int minLaneHeight = 3;
+        const int maxLanes = juce::jmax(1, availableHeight / minLaneHeight);
+        const int numLanes = juce::jmin(numTracks, maxLanes);
+        const float laneHeight = static_cast<float>(availableHeight) / static_cast<float>(numLanes);
+
+        for (int i = 0; i < numTracks; ++i) {
+            const auto& track = tracks[i];
+            const int laneIndex = (i * numLanes) / numTracks;
+            const float laneY = static_cast<float>(lanesTop) + laneIndex * laneHeight;
+
+            const auto clipIds = clipManager.getClipsOnTrack(track.id, ClipView::Arrangement);
+            for (auto clipId : clipIds) {
+                const auto* clip = clipManager.getClip(clipId);
+                if (clip == nullptr) {
+                    continue;
+                }
+
+                const double startBeat = clip->placement.startBeat;
+                const double endBeat = startBeat + clip->placement.lengthBeats;
+                const int x = beatToX(startBeat);
+                const int w = juce::jmax(1, beatToX(endBeat) - x);
+
+                juce::Colour colour = clip->colour;
+                if (colour.isTransparent()) {
+                    colour = track.colour;
+                }
+
+                juce::Rectangle<float> clipRect(static_cast<float>(x), laneY + 0.5f,
+                                                static_cast<float>(w),
+                                                juce::jmax(1.0f, laneHeight - 1.0f));
+                g.setColour(colour.withAlpha(0.85f));
+                g.fillRect(clipRect);
+                hasContent = true;
+            }
+        }
+    }
+
+    // Playhead marker.
+    if (controller_) {
+        const double playBeats = controller_->getState().playhead.playbackPositionBeats;
+        const int px = beatToX(playBeats);
+        g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_ORANGE).withAlpha(0.9f));
+        g.drawVerticalLine(px, 0.0f, static_cast<float>(getHeight()));
+    }
+
+    // Viewport rectangle marking the currently-visible window. Hidden when the
+    // project is empty - a big selection rectangle over a blank strip is noise.
+    if (hasContent) {
+        const auto box = getViewportBox();
+        g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_CYAN).withAlpha(0.15f));
+        g.fillRect(box);
+        g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_CYAN).withAlpha(0.9f));
+        g.drawRect(box, 1.5f);
+    }
+
+    // Outer border.
+    g.setColour(DarkTheme::getColour(DarkTheme::BORDER));
+    g.drawRect(bounds, 1);
+}
+
+// ===== Interaction =====
+
+SongNavigatorPanel::DragMode SongNavigatorPanel::viewportHitTest(juce::Point<int> pos) const {
+    const auto box = getViewportBox();
+    if (std::abs(pos.x - box.getX()) <= kEdgeGrabPx) {
+        return DragMode::ResizeLeft;
+    }
+    if (std::abs(pos.x - box.getRight()) <= kEdgeGrabPx) {
+        return DragMode::ResizeRight;
+    }
+    if (box.contains(static_cast<float>(pos.x), static_cast<float>(pos.y))) {
+        return DragMode::MoveViewport;
+    }
+    return DragMode::None;
+}
+
+void SongNavigatorPanel::mouseMove(const juce::MouseEvent& event) {
+    switch (viewportHitTest(event.getPosition())) {
+        case DragMode::ResizeLeft:
+        case DragMode::ResizeRight:
+            setMouseCursor(juce::MouseCursor::LeftRightResizeCursor);
+            break;
+        case DragMode::MoveViewport:
+            setMouseCursor(juce::MouseCursor::DraggingHandCursor);
+            break;
+        case DragMode::None:
+        default:
+            setMouseCursor(juce::MouseCursor::NormalCursor);
+            break;
+    }
+}
+
+void SongNavigatorPanel::mouseDown(const juce::MouseEvent& event) {
+    if (!controller_) {
+        return;
+    }
+
+    dragMode_ = viewportHitTest(event.getPosition());
+
+    if (dragMode_ == DragMode::None) {
+        // Click on empty strip: recentre the arrangement on the clicked beat.
+        controller_->dispatch(ScrollToBeatEvent{xToBeat(event.x), true});
+        dragMode_ = DragMode::MoveViewport;
+        dragGrabOffsetBeats_ = 0.0;
+        return;
+    }
+
+    if (dragMode_ == DragMode::MoveViewport) {
+        dragGrabOffsetBeats_ = xToBeat(event.x) - visibleStartBeats();
+    }
+}
+
+void SongNavigatorPanel::mouseDrag(const juce::MouseEvent& event) {
+    if (!controller_ || dragMode_ == DragMode::None) {
+        return;
+    }
+
+    const double mouseBeat = xToBeat(event.x);
+
+    switch (dragMode_) {
+        case DragMode::MoveViewport:
+            panToStartBeat(mouseBeat - dragGrabOffsetBeats_);
+            break;
+        case DragMode::ResizeLeft: {
+            const double endBeats = visibleStartBeats() + visibleLengthBeats();
+            const double newStart = juce::jlimit(0.0, endBeats - 0.5, mouseBeat);
+            zoomToVisibleRange(newStart, endBeats - newStart);
+            break;
+        }
+        case DragMode::ResizeRight: {
+            const double startBeats = visibleStartBeats();
+            const double newEnd = juce::jmax(startBeats + 0.5, mouseBeat);
+            zoomToVisibleRange(startBeats, newEnd - startBeats);
+            break;
+        }
+        case DragMode::None:
+        default:
+            break;
+    }
+}
+
+void SongNavigatorPanel::mouseUp(const juce::MouseEvent& /*event*/) {
+    dragMode_ = DragMode::None;
+}
+
+void SongNavigatorPanel::panToStartBeat(double startBeats) {
+    if (!controller_) {
+        return;
+    }
+    const auto& zoom = controller_->getState().zoom;
+    const double clampedStart = juce::jmax(0.0, startBeats);
+    const int scrollX = static_cast<int>(std::round(clampedStart * zoom.horizontalZoom)) +
+                        LayoutConfig::TIMELINE_LEFT_PADDING;
+    controller_->dispatch(SetScrollPositionEvent{scrollX, -1});
+}
+
+void SongNavigatorPanel::zoomToVisibleRange(double startBeats, double lengthBeats) {
+    if (!controller_ || lengthBeats <= 0.0) {
+        return;
+    }
+    const auto& zoom = controller_->getState().zoom;
+    if (zoom.viewportWidth <= 0) {
+        return;
+    }
+
+    const double newZoom = static_cast<double>(zoom.viewportWidth) / lengthBeats;
+    // Anchor the window start at the left edge of the viewport (screen X 0) so
+    // the dragged edge follows the cursor while the opposite edge holds.
+    controller_->dispatch(SetZoomAnchoredBeatsEvent{newZoom, juce::jmax(0.0, startBeats), 0});
+}
+
+// ===== Listeners =====
+
+void SongNavigatorPanel::timelineStateChanged(const TimelineState& /*state*/, ChangeFlags changes) {
+    if (hasFlag(changes, ChangeFlags::Zoom) || hasFlag(changes, ChangeFlags::Scroll) ||
+        hasFlag(changes, ChangeFlags::Playhead) || hasFlag(changes, ChangeFlags::Timeline) ||
+        hasFlag(changes, ChangeFlags::Tempo)) {
+        repaint();
+    }
+}
+
+void SongNavigatorPanel::tracksChanged() {
+    repaint();
+}
+
+void SongNavigatorPanel::clipsChanged() {
+    repaint();
+}
+
+void SongNavigatorPanel::clipPropertyChanged(ClipId /*clipId*/) {
+    repaint();
+}
+
+void SongNavigatorPanel::clipPropertiesChanged(const std::vector<ClipId>& /*clipIds*/) {
+    repaint();
+}
+
+}  // namespace magda

--- a/magda/daw/ui/components/navigation/SongNavigatorPanel.hpp
+++ b/magda/daw/ui/components/navigation/SongNavigatorPanel.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <vector>
+
+#include "../../../core/ClipManager.hpp"
+#include "../../../core/TrackManager.hpp"
+#include "../../state/TimelineController.hpp"
+
+namespace magda {
+
+/**
+ * @brief Whole-song navigator / minimap shown in the master content strip.
+ *
+ * Renders every track's clips compressed to fit the strip width (the entire
+ * song at a glance, independent of the main scroll/zoom) and draws a draggable
+ * viewport rectangle marking the currently-visible window. Click/drag the strip
+ * to recentre the arrangement, drag the box to pan, drag its edges to zoom.
+ *
+ * Implemented as a standalone panel swapped into masterContentArea so the
+ * previous "Master Output" placeholder is easy to restore.
+ */
+class SongNavigatorPanel : public juce::Component,
+                           public TimelineStateListener,
+                           public TrackManagerListener,
+                           public ClipManagerListener {
+  public:
+    SongNavigatorPanel();
+    ~SongNavigatorPanel() override;
+
+    /** Connect to the centralized timeline state. */
+    void setController(TimelineController* controller);
+
+    void paint(juce::Graphics& g) override;
+    void mouseDown(const juce::MouseEvent& event) override;
+    void mouseDrag(const juce::MouseEvent& event) override;
+    void mouseUp(const juce::MouseEvent& event) override;
+    void mouseMove(const juce::MouseEvent& event) override;
+
+    // TimelineStateListener
+    void timelineStateChanged(const TimelineState& state, ChangeFlags changes) override;
+
+    // TrackManagerListener
+    void tracksChanged() override;
+
+    // ClipManagerListener
+    void clipsChanged() override;
+    void clipPropertyChanged(ClipId clipId) override;
+    void clipPropertiesChanged(const std::vector<ClipId>& clipIds) override;
+
+  private:
+    enum class DragMode { None, MoveViewport, ResizeLeft, ResizeRight };
+
+    double totalBeats() const;
+    int beatToX(double beat) const;
+    double xToBeat(int x) const;
+
+    // Visible window (in beats) derived from the controller's zoom/scroll state.
+    double visibleStartBeats() const;
+    double visibleLengthBeats() const;
+    juce::Rectangle<float> getViewportBox() const;
+
+    DragMode viewportHitTest(juce::Point<int> pos) const;
+    void panToStartBeat(double startBeats);
+    void zoomToVisibleRange(double startBeats, double lengthBeats);
+
+    TimelineController* controller_ = nullptr;
+
+    DragMode dragMode_ = DragMode::None;
+    double dragGrabOffsetBeats_ = 0.0;  // mouse-beat minus window-start-beat at grab
+
+    static constexpr int kEdgeGrabPx = 5;
+    static constexpr int kVInset = 3;
+    static constexpr int kRulerHeight = 11;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SongNavigatorPanel)
+};
+
+}  // namespace magda

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -7,6 +7,7 @@
 
 #include "../components/common/SideColumn.hpp"
 #include "../components/mixer/LevelMeterBallistics.hpp"
+#include "../components/navigation/SongNavigatorPanel.hpp"
 #include "../themes/DarkTheme.hpp"
 #include "../themes/FontManager.hpp"
 #include "Config.hpp"
@@ -268,7 +269,8 @@ void MainView::setupComponents() {
     // Create fixed master track row at bottom (matching track panel style)
     masterHeaderPanel = std::make_unique<MasterHeaderPanel>();
     addAndMakeVisible(*masterHeaderPanel);
-    masterContentPanel = std::make_unique<MasterContentPanel>();
+    masterContentPanel = std::make_unique<SongNavigatorPanel>();
+    masterContentPanel->setController(timelineController.get());
     addAndMakeVisible(*masterContentPanel);
 
     // Create horizontal zoom scroll bar (at bottom)

--- a/magda/daw/ui/views/MainView.hpp
+++ b/magda/daw/ui/views/MainView.hpp
@@ -22,6 +22,7 @@ namespace magda {
 
 // Forward declaration
 class AudioEngine;
+class SongNavigatorPanel;
 
 class MainView : public juce::Component,
                  public juce::ScrollBar::Listener,
@@ -153,9 +154,10 @@ class MainView : public juce::Component,
 
     // Fixed master track row at bottom (matching track panel style)
     class MasterHeaderPanel;
-    class MasterContentPanel;
+    class MasterContentPanel;  // legacy "Master Output" placeholder (kept for easy revert)
     std::unique_ptr<MasterHeaderPanel> masterHeaderPanel;
-    std::unique_ptr<MasterContentPanel> masterContentPanel;
+    // Song navigator / minimap occupying the master content strip (issue #1474).
+    std::unique_ptr<SongNavigatorPanel> masterContentPanel;
     int masterStripHeight = 60;
     ViewMode currentViewMode_ = ViewMode::Arrange;
     bool masterVisible_ = true;


### PR DESCRIPTION
Replace the empty Master Output placeholder in masterContentArea with a SongNavigatorPanel: a whole-song overview that renders every track's clips compressed onto merged lanes, scaled to the project timeline length, with a mini bar ruler and gridlines, a playhead marker, and a draggable viewport box. Click to recentre, drag the box to pan, drag its edges to zoom.

The strip reserves the arrangement's min-zoom right gutter so it aligns at full zoom-out, draws the ruler even on an empty project, and hides the viewport box when there is no content.

Closes #1474