### PR TITLE
Project settings model, playback auto-scroll, navigator markers

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -329,6 +329,7 @@
     "slider.interval": "Interval",
     "toggle.enable_autosave": "Enable auto-save",
     "toggle.stop_updates_playhead": "Stop updates playhead",
+    "toggle.follow_playhead": "Follow playhead during playback",
     "toggle.headers_on_right": "Headers on the Right",
     "toggle.autohide_arrangement_scrollbars": "Auto-Hide Arrangement Scrollbars",
     "toggle.confirm_track_delete": "Confirm before deleting tracks",

--- a/lang/en.json
+++ b/lang/en.json
@@ -16,6 +16,7 @@
     "file.close_project": "Close Project",
     "file.save_project": "Save Project",
     "file.save_project_as": "Save Project As...",
+    "file.project_settings": "Project Settings...",
     "file.collect_files": "Collect Files...",
     "file.export_audio": "Export Audio...",
     "file.export_midi": "Export MIDI...",
@@ -166,6 +167,14 @@
   },
   "chain_tree": {
     "label.click_hint": "Click an item to select it in the chain view"
+  },
+  "project_settings": {
+    "total_length": "Total length",
+    "bars": "bars",
+    "sample_rate": "Sample rate",
+    "render_bit_depth": "Render bit depth",
+    "bounce_bit_depth": "Bounce bit depth",
+    "save_as_default": "Save as default for new projects"
   },
   "track_manager": {
     "column.track": "Track",

--- a/magda/daw/core/ClipCommands.cpp
+++ b/magda/daw/core/ClipCommands.cpp
@@ -993,8 +993,8 @@ void RenderClipCommand::execute() {
 
     auto& formatManager = engine_->getEngine()->getAudioFileFormatManager();
     params.audioFormat = formatManager.getWavFormat();
-    params.bitDepth = Config::getInstance().getRenderBitDepth();
-    params.sampleRateForAudio = Config::getInstance().getRenderSampleRate();
+    params.bitDepth = ProjectManager::getInstance().getCurrentProjectInfo().renderBitDepth;
+    params.sampleRateForAudio = ProjectManager::getInstance().getCurrentProjectInfo().sampleRate;
     params.blockSizeForAudio = 512;
     params.usePlugins = false;
     params.useMasterPlugins = false;
@@ -1183,8 +1183,9 @@ void RenderTimeSelectionCommand::execute() {
 
         auto& formatManager = engine_->getEngine()->getAudioFileFormatManager();
         params.audioFormat = formatManager.getWavFormat();
-        params.bitDepth = Config::getInstance().getRenderBitDepth();
-        params.sampleRateForAudio = Config::getInstance().getRenderSampleRate();
+        params.bitDepth = ProjectManager::getInstance().getCurrentProjectInfo().renderBitDepth;
+        params.sampleRateForAudio =
+            ProjectManager::getInstance().getCurrentProjectInfo().sampleRate;
         params.blockSizeForAudio = 512;
         params.usePlugins = false;
         params.useMasterPlugins = false;
@@ -1735,8 +1736,8 @@ void BounceInPlaceCommand::execute() {
     params.destFile = renderedFile_;
     auto& formatManager = engine_->getEngine()->getAudioFileFormatManager();
     params.audioFormat = formatManager.getWavFormat();
-    params.bitDepth = Config::getInstance().getBounceBitDepth();
-    params.sampleRateForAudio = Config::getInstance().getRenderSampleRate();
+    params.bitDepth = ProjectManager::getInstance().getCurrentProjectInfo().bounceBitDepth;
+    params.sampleRateForAudio = ProjectManager::getInstance().getCurrentProjectInfo().sampleRate;
     params.blockSizeForAudio = 512;
     params.usePlugins = true;  // Synth is active, FX are bypassed
     params.useMasterPlugins = false;
@@ -1910,8 +1911,8 @@ void BounceToNewTrackCommand::execute() {
     params.destFile = renderedFile_;
     auto& formatManager = engine_->getEngine()->getAudioFileFormatManager();
     params.audioFormat = formatManager.getWavFormat();
-    params.bitDepth = Config::getInstance().getBounceBitDepth();
-    params.sampleRateForAudio = Config::getInstance().getRenderSampleRate();
+    params.bitDepth = ProjectManager::getInstance().getCurrentProjectInfo().bounceBitDepth;
+    params.sampleRateForAudio = ProjectManager::getInstance().getCurrentProjectInfo().sampleRate;
     params.blockSizeForAudio = 512;
     params.usePlugins = true;  // Full signal chain
     params.useMasterPlugins = false;

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -220,6 +220,7 @@ void Config::save() {
     root->setProperty("scanPluginsOnStartup", scanPluginsOnStartup);
     root->setProperty("loadModelOnStartup", loadModelOnStartup);
     root->setProperty("stopUpdatesPlayhead", stopUpdatesPlayhead);
+    root->setProperty("followPlayhead", followPlayhead);
 
     // Clip colour mode
     root->setProperty("clipColourMode", clipColourMode);
@@ -611,6 +612,7 @@ void Config::load() {
     scanPluginsOnStartup = getBool("scanPluginsOnStartup", scanPluginsOnStartup);
     loadModelOnStartup = getBool("loadModelOnStartup", loadModelOnStartup);
     stopUpdatesPlayhead = getBool("stopUpdatesPlayhead", stopUpdatesPlayhead);
+    followPlayhead = getBool("followPlayhead", followPlayhead);
 
     clipColourMode = getInt("clipColourMode", clipColourMode);
 

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -293,6 +293,14 @@ class Config {
         stopUpdatesPlayhead = enabled;
     }
 
+    // Auto-scroll the arrangement to follow the playhead during playback.
+    bool getFollowPlayhead() const {
+        return followPlayhead;
+    }
+    void setFollowPlayhead(bool enabled) {
+        followPlayhead = enabled;
+    }
+
     // Recent Projects
     std::vector<std::string> getRecentProjects() const {
         return recentProjects;
@@ -1036,6 +1044,9 @@ class Config {
     // See getStopUpdatesPlayhead — default keeps the playhead in place
     // across Stop/Play cycles (Bitwig-style "play from playhead").
     bool stopUpdatesPlayhead = false;
+
+    // Auto-scroll the arrangement to follow the playhead during playback.
+    bool followPlayhead = true;
 
     // Browser filter settings (media explorer)
     bool browserFilterAudio = true;    // Show audio files by default

--- a/magda/daw/project/ProjectInfo.hpp
+++ b/magda/daw/project/ProjectInfo.hpp
@@ -31,8 +31,15 @@ struct ProjectInfo {
     double tempo = DEFAULT_BPM;
     int timeSignatureNumerator = DEFAULT_TIME_SIGNATURE_NUMERATOR;
     int timeSignatureDenominator = DEFAULT_TIME_SIGNATURE_DENOMINATOR;
-    double projectLength = 240.0;  // seconds
-    double sampleRate = 44100.0;
+    double projectLength = 240.0;  // seconds (legacy; derived from timelineLengthBars)
+    double sampleRate = 44100.0;   // project working/render sample rate
+
+    // Total timeline length (per-project; seeded from Config default for new projects)
+    int timelineLengthBars = 256;
+
+    // Render / bounce settings (per-project)
+    int renderBitDepth = 24;  // 16, 24, 32
+    int bounceBitDepth = 32;  // 16, 24, 32 (default 32-bit float for internal bounces)
 
     // Key signature
     int keyRoot = -1;    // 0=C, 1=C#, ..., 11=B; -1=none

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -7,6 +7,7 @@
 
 #include "../core/AutomationManager.hpp"
 #include "../core/ClipManager.hpp"
+#include "../core/Config.hpp"
 #include "../core/TempoUtils.hpp"
 #include "../core/TrackManager.hpp"
 #include "../engine/AudioEngine.hpp"
@@ -111,6 +112,14 @@ bool ProjectManager::newProject() {
     currentProject_ = ProjectInfo();
     currentProject_.name = "Untitled";
     currentProject_.version = MAGDA_VERSION;
+    // Seed per-project settings from the global new-project defaults.
+    {
+        auto& config = Config::getInstance();
+        currentProject_.timelineLengthBars = config.getDefaultTimelineLengthBars();
+        currentProject_.sampleRate = config.getRenderSampleRate();
+        currentProject_.renderBitDepth = config.getRenderBitDepth();
+        currentProject_.bounceBitDepth = config.getBounceBitDepth();
+    }
     currentFile_ = juce::File();
     isProjectOpen_ = true;
 

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -151,6 +151,12 @@ bool ProjectSerializer::loadAndStage(const juce::File& file, StagedProjectData& 
 
         if (projectObj->hasProperty("sampleRate"))
             outData.info.sampleRate = projectObj->getProperty("sampleRate");
+        if (projectObj->hasProperty("timelineLengthBars"))
+            outData.info.timelineLengthBars = projectObj->getProperty("timelineLengthBars");
+        if (projectObj->hasProperty("renderBitDepth"))
+            outData.info.renderBitDepth = projectObj->getProperty("renderBitDepth");
+        if (projectObj->hasProperty("bounceBitDepth"))
+            outData.info.bounceBitDepth = projectObj->getProperty("bounceBitDepth");
         if (projectObj->hasProperty("keyRoot"))
             outData.info.keyRoot = projectObj->getProperty("keyRoot");
         if (projectObj->hasProperty("keyQuality"))
@@ -306,6 +312,9 @@ juce::var ProjectSerializer::serializeProject(const ProjectInfo& info) {
 
     projectObj->setProperty("projectLength", info.projectLength);
     projectObj->setProperty("sampleRate", info.sampleRate);
+    projectObj->setProperty("timelineLengthBars", info.timelineLengthBars);
+    projectObj->setProperty("renderBitDepth", info.renderBitDepth);
+    projectObj->setProperty("bounceBitDepth", info.bounceBitDepth);
     projectObj->setProperty("keyRoot", info.keyRoot);
     projectObj->setProperty("keyQuality", info.keyQuality);
 
@@ -426,6 +435,12 @@ bool ProjectSerializer::deserializeProject(const juce::var& json, ProjectInfo& o
 
     if (projectObj->hasProperty("sampleRate"))
         outInfo.sampleRate = projectObj->getProperty("sampleRate");
+    if (projectObj->hasProperty("timelineLengthBars"))
+        outInfo.timelineLengthBars = projectObj->getProperty("timelineLengthBars");
+    if (projectObj->hasProperty("renderBitDepth"))
+        outInfo.renderBitDepth = projectObj->getProperty("renderBitDepth");
+    if (projectObj->hasProperty("bounceBitDepth"))
+        outInfo.bounceBitDepth = projectObj->getProperty("bounceBitDepth");
     if (projectObj->hasProperty("keyRoot"))
         outInfo.keyRoot = projectObj->getProperty("keyRoot");
     if (projectObj->hasProperty("keyQuality"))

--- a/magda/daw/ui/components/navigation/SongNavigatorPanel.cpp
+++ b/magda/daw/ui/components/navigation/SongNavigatorPanel.cpp
@@ -91,9 +91,10 @@ juce::Rectangle<float> SongNavigatorPanel::getViewportBox() const {
     const double endBeats = juce::jmin(totalBeats(), startBeats + visibleLengthBeats());
     const int left = beatToX(startBeats);
     const int right = beatToX(endBeats);
-    return juce::Rectangle<float>(static_cast<float>(left), 0.0f,
+    // Span the lanes area only - start below the ruler band, like the playhead.
+    return juce::Rectangle<float>(static_cast<float>(left), static_cast<float>(kRulerHeight),
                                   static_cast<float>(juce::jmax(2, right - left)),
-                                  static_cast<float>(getHeight()));
+                                  static_cast<float>(getHeight() - kRulerHeight));
 }
 
 // ===== Painting =====
@@ -201,12 +202,28 @@ void SongNavigatorPanel::paint(juce::Graphics& g) {
         }
     }
 
-    // Playhead marker.
+    // Timeline markers - a coloured line down the strip with a small flag tick
+    // in the ruler band, mirroring the arrangement's markers.
+    if (controller_) {
+        for (const auto& marker : controller_->getState().markers) {
+            const int mx = beatToX(marker.positionBeats);
+            if (mx >= getWidth() - 1) {
+                continue;
+            }
+            g.setColour(marker.colour.withAlpha(0.85f));
+            g.drawVerticalLine(mx, static_cast<float>(kRulerHeight),
+                               static_cast<float>(getHeight()));
+            // Flag tick at the top of the content area (not in the ruler header).
+            g.fillRect(mx, kRulerHeight, 4, 4);
+        }
+    }
+
+    // Playhead marker - starts below the ruler band, like the gridlines.
     if (controller_) {
         const double playBeats = controller_->getState().playhead.playbackPositionBeats;
         const int px = beatToX(playBeats);
         g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_ORANGE).withAlpha(0.9f));
-        g.drawVerticalLine(px, 0.0f, static_cast<float>(getHeight()));
+        g.drawVerticalLine(px, static_cast<float>(kRulerHeight), static_cast<float>(getHeight()));
     }
 
     // Viewport rectangle marking the currently-visible window. Hidden when the
@@ -337,12 +354,12 @@ void SongNavigatorPanel::zoomToVisibleRange(double startBeats, double lengthBeat
 
 // ===== Listeners =====
 
-void SongNavigatorPanel::timelineStateChanged(const TimelineState& /*state*/, ChangeFlags changes) {
-    if (hasFlag(changes, ChangeFlags::Zoom) || hasFlag(changes, ChangeFlags::Scroll) ||
-        hasFlag(changes, ChangeFlags::Playhead) || hasFlag(changes, ChangeFlags::Timeline) ||
-        hasFlag(changes, ChangeFlags::Tempo)) {
-        repaint();
-    }
+void SongNavigatorPanel::timelineStateChanged(const TimelineState& /*state*/,
+                                              ChangeFlags /*changes*/) {
+    // The whole strip is derived from timeline state (zoom, scroll, playhead,
+    // length, tempo, markers), so just repaint when the state changes rather
+    // than filtering on individual flags.
+    repaint();
 }
 
 void SongNavigatorPanel::tracksChanged() {

--- a/magda/daw/ui/components/navigation/SongNavigatorPanel.cpp
+++ b/magda/daw/ui/components/navigation/SongNavigatorPanel.cpp
@@ -45,8 +45,8 @@ double SongNavigatorPanel::totalBeats() const {
 
 int SongNavigatorPanel::beatToX(double beat) const {
     // Left padding matches the main track content; the right gutter matches the
-    // arrangement's min-zoom label gutter so that, fully zoomed out, the end of
-    // the strip lines up with the end of the arrangement's bars.
+    // arrangement's min-zoom label gutter so the strip's end lines up with the
+    // end of the arrangement's bars.
     const int usableWidth =
         juce::jmax(1, getWidth() - LayoutConfig::TIMELINE_LEFT_PADDING -
                           static_cast<int>(TimelineState::MIN_ZOOM_RIGHT_LABEL_GUTTER));
@@ -130,20 +130,31 @@ void SongNavigatorPanel::paint(juce::Graphics& g) {
         g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(0.5f));
         g.fillRect(0, 0, getWidth(), kRulerHeight);
         g.setFont(8.0f);
-        for (int bar = 1; bar <= static_cast<int>(totalBars); bar += barStep) {
-            const int x = beatToX((bar - 1) * static_cast<double>(beatsPerBar));
-            // Skip ticks/labels that land on (or past) the right edge - they
-            // collide with the border / viewport box and the label gets clipped.
+
+        auto drawTick = [&](int barNumber, double beatPos) {
+            const int x = beatToX(beatPos);
             if (x >= getWidth() - 2) {
-                continue;
+                return;
             }
             g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(0.6f));
             g.drawVerticalLine(x, static_cast<float>(kRulerHeight),
                                static_cast<float>(getHeight()));
             g.setColour(DarkTheme::getColour(DarkTheme::TEXT_SECONDARY).withAlpha(0.7f));
-            g.drawText(juce::String(bar), x + 2, 0, 40, kRulerHeight,
+            g.drawText(juce::String(barNumber), x + 2, 0, 40, kRulerHeight,
                        juce::Justification::centredLeft);
+        };
+
+        // The end of the project is bar (totalBars + 1) at the content's right
+        // edge (just before the gutter).
+        const int endBar = static_cast<int>(totalBars) + 1;
+        for (int bar = 1; bar < endBar; bar += barStep) {
+            // Don't crowd the final boundary label drawn below.
+            if (endBar - bar < barStep) {
+                continue;
+            }
+            drawTick(bar, (bar - 1) * static_cast<double>(beatsPerBar));
         }
+        drawTick(endBar, totalBars * static_cast<double>(beatsPerBar));
     }
 
     // Height is limited, so merge tracks onto a few lanes rather than one thin

--- a/magda/daw/ui/components/timeline/MarkerLaneComponent.cpp
+++ b/magda/daw/ui/components/timeline/MarkerLaneComponent.cpp
@@ -138,6 +138,14 @@ void MarkerLaneComponent::mouseUp(const juce::MouseEvent& event) {
         controller->dispatch(GoToMarkerEvent{markerId});
 }
 
+void MarkerLaneComponent::mouseDoubleClick(const juce::MouseEvent& event) {
+    const int markerId = markerAt(event.getPosition());
+    if (markerId == 0)
+        return;
+    if (const auto* marker = findMarker(markerId))
+        showRenameMarkerDialog(markerId, *marker);
+}
+
 void MarkerLaneComponent::mouseMove(const juce::MouseEvent& event) {
     const int markerId = markerAt(event.getPosition());
     if (markerId != hoveredMarkerId_) {

--- a/magda/daw/ui/components/timeline/MarkerLaneComponent.hpp
+++ b/magda/daw/ui/components/timeline/MarkerLaneComponent.hpp
@@ -16,6 +16,7 @@ class MarkerLaneComponent : public juce::Component, public TimelineStateListener
 
     void paint(juce::Graphics& g) override;
     void mouseUp(const juce::MouseEvent& event) override;
+    void mouseDoubleClick(const juce::MouseEvent& event) override;
     void mouseMove(const juce::MouseEvent& event) override;
     void mouseExit(const juce::MouseEvent& event) override;
 

--- a/magda/daw/ui/dialogs/CMakeLists.txt
+++ b/magda/daw/ui/dialogs/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(magda_daw_app PRIVATE
     ParameterConfigDialog.cpp
     PluginSettingsDialog.cpp
     PreferencesDialog.cpp
+    ProjectSettingsDialog.cpp
     TrackManagerDialog.cpp
     AboutDialog.cpp
     SplashScreen.cpp
@@ -21,6 +22,7 @@ target_sources(magda_daw_app PRIVATE
     ParameterConfigDialog.hpp
     PluginSettingsDialog.hpp
     PreferencesDialog.hpp
+    ProjectSettingsDialog.hpp
     TrackManagerDialog.hpp
     AboutDialog.hpp
     SplashScreen.hpp

--- a/magda/daw/ui/dialogs/ExportAudioDialog.cpp
+++ b/magda/daw/ui/dialogs/ExportAudioDialog.cpp
@@ -1,6 +1,7 @@
 #include "ExportAudioDialog.hpp"
 
 #include "../../core/Config.hpp"
+#include "../../project/ProjectManager.hpp"
 #include "../themes/DarkTheme.hpp"
 #include "../themes/DialogLookAndFeel.hpp"
 #include "../themes/FontManager.hpp"
@@ -21,9 +22,9 @@ ExportAudioDialog::ExportAudioDialog() {
     formatComboBox_.addItem("WAV 24-bit", 2);
     formatComboBox_.addItem("WAV 32-bit Float", 3);
     formatComboBox_.addItem("FLAC", 4);
-    // Initialise format from render bit depth preference
-    auto& config = Config::getInstance();
-    int bd = config.getRenderBitDepth();
+    // Initialise format from the project's render bit depth
+    const auto& projectInfo = ProjectManager::getInstance().getCurrentProjectInfo();
+    int bd = projectInfo.renderBitDepth;
     int formatId = 2;  // Default WAV 24-bit
     if (bd >= 32)
         formatId = 3;
@@ -44,8 +45,8 @@ ExportAudioDialog::ExportAudioDialog() {
     sampleRateComboBox_.addItem("48 kHz", 2);
     sampleRateComboBox_.addItem("96 kHz", 3);
     sampleRateComboBox_.addItem("192 kHz", 4);
-    // Initialise sample rate from render preference
-    double savedRate = config.getRenderSampleRate();
+    // Initialise sample rate from the project's sample rate
+    double savedRate = projectInfo.sampleRate;
     int rateId = 1;  // Default 44.1kHz
     if (savedRate >= 192000.0)
         rateId = 4;

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -134,9 +134,7 @@ class GeneralPage : public juce::Component {
                         tr("preferences.slider.zoom_shift_sensitivity"), 1.0, 50.0, 0.5, 1);
 
         setupSectionHeader(*this, timelineHeader, tr("preferences.section.timeline"));
-        setupTextSlider(*this, timelineLengthSlider, timelineLengthLabel,
-                        tr("preferences.slider.default_length"), 16.0, 4096.0, 1.0, 0, " bars");
-        timelineLengthSlider.setSkewForCentre(256.0);
+        // Total timeline length is per-project (File > Project Settings).
         setupTextSlider(*this, viewDurationSlider, viewDurationLabel,
                         tr("preferences.slider.default_view"), 4.0, 128.0, 1.0, 0, " bars");
 
@@ -227,8 +225,6 @@ class GeneralPage : public juce::Component {
                                           juce::dontSendNotification);
         zoomShiftSensitivitySlider.setValue(config.getZoomInSensitivityShift(),
                                             juce::dontSendNotification);
-        timelineLengthSlider.setValue(config.getDefaultTimelineLengthBars(),
-                                      juce::dontSendNotification);
         viewDurationSlider.setValue(config.getDefaultZoomViewBars(), juce::dontSendNotification);
         stopUpdatesPlayheadToggle.setToggleState(config.getStopUpdatesPlayhead(),
                                                  juce::dontSendNotification);
@@ -281,7 +277,6 @@ class GeneralPage : public juce::Component {
         config.setZoomOutSensitivity(zoomOutSensitivitySlider.getValue());
         config.setZoomInSensitivityShift(zoomShiftSensitivitySlider.getValue());
         config.setZoomOutSensitivityShift(zoomShiftSensitivitySlider.getValue());
-        config.setDefaultTimelineLengthBars(static_cast<int>(timelineLengthSlider.getValue()));
         config.setDefaultZoomViewBars(static_cast<int>(viewDurationSlider.getValue()));
         config.setStopUpdatesPlayhead(stopUpdatesPlayheadToggle.getToggleState());
         config.setAutoSaveEnabled(autoSaveToggle.getToggleState());
@@ -369,8 +364,6 @@ class GeneralPage : public juce::Component {
         // Timeline
         timelineHeader.setBounds(bounds.removeFromTop(headerH));
         bounds.removeFromTop(4);
-        layoutTextSliderRow(bounds, timelineLengthLabel, timelineLengthSlider, rowH, sliderH);
-        bounds.removeFromTop(4);
         layoutTextSliderRow(bounds, viewDurationLabel, viewDurationSlider, rowH, sliderH);
         bounds.removeFromTop(secGap);
 
@@ -446,8 +439,6 @@ class GeneralPage : public juce::Component {
 
         // Timeline
         timelineHeader.setBounds(left.removeFromTop(headerH));
-        left.removeFromTop(4);
-        layoutTextSliderRow(left, timelineLengthLabel, timelineLengthSlider, rowH, sliderH);
         left.removeFromTop(4);
         layoutTextSliderRow(left, viewDurationLabel, viewDurationSlider, rowH, sliderH);
         left.removeFromTop(secGap);
@@ -577,8 +568,8 @@ class GeneralPage : public juce::Component {
     magda::daw::ui::TextSlider zoomInSensitivitySlider, zoomOutSensitivitySlider,
         zoomShiftSensitivitySlider;
     juce::Label zoomInLabel, zoomOutLabel, zoomShiftLabel;
-    magda::daw::ui::TextSlider timelineLengthSlider, viewDurationSlider;
-    juce::Label timelineLengthLabel, viewDurationLabel;
+    magda::daw::ui::TextSlider viewDurationSlider;
+    juce::Label viewDurationLabel;
     juce::ToggleButton stopUpdatesPlayheadToggle;
     juce::ToggleButton autoSaveToggle;
     magda::daw::ui::TextSlider autoSaveIntervalSlider;
@@ -919,30 +910,8 @@ class RenderingPage : public juce::Component {
         };
         addAndMakeVisible(renderFolderClearButton);
 
-        // --- Format ---
-        setupSectionHeader(*this, formatHeader, tr("preferences.section.format"));
-
-        setupComboLabel(sampleRateLabel, tr("preferences.label.sample_rate"));
-        sampleRateCombo.addItem("44100 Hz", 1);
-        sampleRateCombo.addItem("48000 Hz", 2);
-        sampleRateCombo.addItem("96000 Hz", 3);
-        sampleRateCombo.addItem("192000 Hz", 4);
-        styleCombo(sampleRateCombo);
-        addAndMakeVisible(sampleRateCombo);
-
-        setupComboLabel(bitDepthLabel, tr("preferences.label.export_bit_depth"));
-        bitDepthCombo.addItem(tr("preferences.option.bit_depth_16"), 1);
-        bitDepthCombo.addItem(tr("preferences.option.bit_depth_24"), 2);
-        bitDepthCombo.addItem(tr("preferences.option.bit_depth_32_float"), 3);
-        styleCombo(bitDepthCombo);
-        addAndMakeVisible(bitDepthCombo);
-
-        setupComboLabel(bounceBitDepthLabel, tr("preferences.label.bounce_bit_depth"));
-        bounceBitDepthCombo.addItem(tr("preferences.option.bit_depth_16"), 1);
-        bounceBitDepthCombo.addItem(tr("preferences.option.bit_depth_24"), 2);
-        bounceBitDepthCombo.addItem(tr("preferences.option.bit_depth_32_float"), 3);
-        styleCombo(bounceBitDepthCombo);
-        addAndMakeVisible(bounceBitDepthCombo);
+        // Sample rate and render/bounce bit depth are per-project (File >
+        // Project Settings), not global preferences.
 
         // --- File Naming ---
         setupSectionHeader(*this, namingHeader, tr("preferences.section.file_naming"));
@@ -981,8 +950,8 @@ class RenderingPage : public juce::Component {
         constexpr int headerH = 28;
         constexpr int secGap = 12;
 
-        return padding + headerH + 4 + rowH + 4 + rowH + secGap + headerH + 4 + (rowH * 3) + 8 +
-               secGap + headerH + 4 + rowH + 4 + rowH + 2 + 18 + padding;
+        return padding + headerH + 4 + rowH + 4 + rowH + secGap + headerH + 4 + rowH + 4 + rowH +
+               2 + 18 + padding;
     }
 
     void resized() override {
@@ -1005,16 +974,6 @@ class RenderingPage : public juce::Component {
             buttonsArea.removeFromRight(4);
             renderFolderBrowseButton.setBounds(buttonsArea.reduced(0, 2));
         }
-        bounds.removeFromTop(secGap);
-
-        // Format
-        formatHeader.setBounds(bounds.removeFromTop(headerH));
-        bounds.removeFromTop(4);
-        layoutComboRow(bounds, sampleRateLabel, sampleRateCombo, rowH, labelW);
-        bounds.removeFromTop(4);
-        layoutComboRow(bounds, bitDepthLabel, bitDepthCombo, rowH, labelW);
-        bounds.removeFromTop(4);
-        layoutComboRow(bounds, bounceBitDepthLabel, bounceBitDepthCombo, rowH, labelW);
         bounds.removeFromTop(secGap);
 
         // File naming
@@ -1045,35 +1004,6 @@ class RenderingPage : public juce::Component {
             renderFolderValue.setText(juce::String(renderFolderPath_), juce::dontSendNotification);
         }
 
-        // Sample rate
-        double sr = config.getRenderSampleRate();
-        if (sr >= 192000.0)
-            sampleRateCombo.setSelectedId(4, juce::dontSendNotification);
-        else if (sr >= 96000.0)
-            sampleRateCombo.setSelectedId(3, juce::dontSendNotification);
-        else if (sr >= 48000.0)
-            sampleRateCombo.setSelectedId(2, juce::dontSendNotification);
-        else
-            sampleRateCombo.setSelectedId(1, juce::dontSendNotification);
-
-        // Bit depth
-        int bd = config.getRenderBitDepth();
-        if (bd >= 32)
-            bitDepthCombo.setSelectedId(3, juce::dontSendNotification);
-        else if (bd >= 24)
-            bitDepthCombo.setSelectedId(2, juce::dontSendNotification);
-        else
-            bitDepthCombo.setSelectedId(1, juce::dontSendNotification);
-
-        // Bounce bit depth
-        int bbd = config.getBounceBitDepth();
-        if (bbd >= 32)
-            bounceBitDepthCombo.setSelectedId(3, juce::dontSendNotification);
-        else if (bbd >= 24)
-            bounceBitDepthCombo.setSelectedId(2, juce::dontSendNotification);
-        else
-            bounceBitDepthCombo.setSelectedId(1, juce::dontSendNotification);
-
         // File patterns
         patternEditor.setText(juce::String(config.getRenderFilePattern()),
                               juce::dontSendNotification);
@@ -1084,16 +1014,6 @@ class RenderingPage : public juce::Component {
     void applySettings(Config& config) {
         config.setRenderFolder(renderFolderPath_);
 
-        static constexpr double sampleRates[] = {44100.0, 48000.0, 96000.0, 192000.0};
-        int srIdx = sampleRateCombo.getSelectedId() - 1;
-        if (srIdx >= 0 && srIdx < 4)
-            config.setRenderSampleRate(sampleRates[srIdx]);
-
-        static constexpr int bitDepths[] = {16, 24, 32};
-        int bdIdx = bitDepthCombo.getSelectedId() - 1;
-        if (bdIdx >= 0 && bdIdx < 3)
-            config.setRenderBitDepth(bitDepths[bdIdx]);
-
         auto pattern = patternEditor.getText().toStdString();
         if (pattern.empty())
             pattern = "<project-name>_<date-time>";
@@ -1103,10 +1023,6 @@ class RenderingPage : public juce::Component {
         if (bouncePattern.empty())
             bouncePattern = "<clip-name>_<date-time>";
         config.setBounceFilePattern(bouncePattern);
-
-        int bbdIdx = bounceBitDepthCombo.getSelectedId() - 1;
-        if (bbdIdx >= 0 && bbdIdx < 3)
-            config.setBounceBitDepth(bitDepths[bbdIdx]);
     }
 
   private:
@@ -1118,30 +1034,12 @@ class RenderingPage : public juce::Component {
         addAndMakeVisible(label);
     }
 
-    void styleCombo(juce::ComboBox& combo) {
-        combo.setColour(juce::ComboBox::backgroundColourId,
-                        DarkTheme::getColour(DarkTheme::SURFACE));
-        combo.setColour(juce::ComboBox::textColourId,
-                        DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
-        combo.setColour(juce::ComboBox::outlineColourId, DarkTheme::getColour(DarkTheme::BORDER));
-    }
-
-    static void layoutComboRow(juce::Rectangle<int>& bounds, juce::Label& label,
-                               juce::ComboBox& combo, int rowH, int labelW) {
-        auto row = bounds.removeFromTop(rowH);
-        label.setBounds(row.removeFromLeft(labelW));
-        combo.setBounds(row.reduced(0, 4));
-    }
-
-    juce::Label renderHeader, formatHeader, namingHeader;
+    juce::Label renderHeader, namingHeader;
     juce::Label renderFolderLabel;
     juce::Label renderFolderValue;
     juce::TextButton renderFolderBrowseButton;
     juce::TextButton renderFolderClearButton;
     std::string renderFolderPath_;
-
-    juce::Label sampleRateLabel, bitDepthLabel, bounceBitDepthLabel;
-    juce::ComboBox sampleRateCombo, bitDepthCombo, bounceBitDepthCombo;
 
     juce::Label patternLabel, bouncePatternLabel, patternHint;
     juce::TextEditor patternEditor, bouncePatternEditor;

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -141,6 +141,7 @@ class GeneralPage : public juce::Component {
         setupSectionHeader(*this, transportHeader, tr("preferences.section.transport"));
         setupToggle(*this, stopUpdatesPlayheadToggle,
                     tr("preferences.toggle.stop_updates_playhead"));
+        setupToggle(*this, followPlayheadToggle, tr("preferences.toggle.follow_playhead"));
 
         setupSectionHeader(*this, autoSaveHeader, tr("preferences.section.autosave"));
         setupToggle(*this, autoSaveToggle, tr("preferences.toggle.enable_autosave"));
@@ -226,6 +227,7 @@ class GeneralPage : public juce::Component {
         zoomShiftSensitivitySlider.setValue(config.getZoomInSensitivityShift(),
                                             juce::dontSendNotification);
         viewDurationSlider.setValue(config.getDefaultZoomViewBars(), juce::dontSendNotification);
+        followPlayheadToggle.setToggleState(config.getFollowPlayhead(), juce::dontSendNotification);
         stopUpdatesPlayheadToggle.setToggleState(config.getStopUpdatesPlayhead(),
                                                  juce::dontSendNotification);
         autoSaveToggle.setToggleState(config.getAutoSaveEnabled(), juce::dontSendNotification);
@@ -279,6 +281,7 @@ class GeneralPage : public juce::Component {
         config.setZoomOutSensitivityShift(zoomShiftSensitivitySlider.getValue());
         config.setDefaultZoomViewBars(static_cast<int>(viewDurationSlider.getValue()));
         config.setStopUpdatesPlayhead(stopUpdatesPlayheadToggle.getToggleState());
+        config.setFollowPlayhead(followPlayheadToggle.getToggleState());
         config.setAutoSaveEnabled(autoSaveToggle.getToggleState());
         config.setAutoSaveIntervalSeconds(static_cast<int>(autoSaveIntervalSlider.getValue()));
         config.setScrollbarOnLeft(headersOnRightToggle.getToggleState());
@@ -335,8 +338,11 @@ class GeneralPage : public juce::Component {
         constexpr int headerH = 28;
         constexpr int secGap = 12;
 
-        return padding + headerH + 4 + (rowH * 3) + 8 + secGap + headerH + 4 + (rowH * 2) + 4 +
-               secGap + headerH + 4 + rowH + secGap + headerH + 4 + rowH + 4 + rowH + padding;
+        return padding + headerH + 4 + (rowH * 3) + 8    // Zoom
+               + secGap + headerH + 4 + rowH             // Timeline
+               + secGap + headerH + 4 + rowH + 4 + rowH  // Transport
+               + secGap + headerH + 4 + rowH + 4 + rowH  // Auto-Save
+               + padding;
     }
 
     static int getRightColumnPreferredHeight() {
@@ -345,8 +351,11 @@ class GeneralPage : public juce::Component {
         constexpr int headerH = 28;
         constexpr int secGap = 12;
 
-        return padding + headerH + 4 + rowH + secGap + headerH + 4 + (rowH * 5) + 12 + secGap +
-               headerH + 4 + rowH + 18 + secGap + headerH + 4 + (rowH * 2) + 4 + padding;
+        return padding + headerH + 4 + rowH + 4 + rowH   // Layout
+               + secGap + headerH + 4 + (rowH * 5) + 16  // Behaviour
+               + secGap + headerH + 4 + rowH + 18        // Language
+               + secGap + headerH + 4 + rowH + 4 + rowH  // Display Scale
+               + padding;
     }
 
     void layoutSingleColumn(juce::Rectangle<int> bounds, int rowH, int sliderH, int headerH,
@@ -371,6 +380,8 @@ class GeneralPage : public juce::Component {
         transportHeader.setBounds(bounds.removeFromTop(headerH));
         bounds.removeFromTop(4);
         stopUpdatesPlayheadToggle.setBounds(bounds.removeFromTop(rowH).reduced(0, 4));
+        bounds.removeFromTop(4);
+        followPlayheadToggle.setBounds(bounds.removeFromTop(rowH).reduced(0, 4));
         bounds.removeFromTop(secGap);
 
         // Auto-Save
@@ -447,6 +458,8 @@ class GeneralPage : public juce::Component {
         transportHeader.setBounds(left.removeFromTop(headerH));
         left.removeFromTop(4);
         stopUpdatesPlayheadToggle.setBounds(left.removeFromTop(rowH).reduced(0, 4));
+        left.removeFromTop(4);
+        followPlayheadToggle.setBounds(left.removeFromTop(rowH).reduced(0, 4));
         left.removeFromTop(secGap);
 
         // Auto-Save
@@ -485,7 +498,7 @@ class GeneralPage : public juce::Component {
         restartHint.setBounds(right.removeFromTop(18));
         right.removeFromTop(secGap);
 
-        // UI scale
+        // Display Scale
         scaleHeader.setBounds(right.removeFromTop(headerH));
         right.removeFromTop(4);
         layoutComboRow(right, scaleLabel, scaleCombo, rowH);
@@ -571,6 +584,7 @@ class GeneralPage : public juce::Component {
     magda::daw::ui::TextSlider viewDurationSlider;
     juce::Label viewDurationLabel;
     juce::ToggleButton stopUpdatesPlayheadToggle;
+    juce::ToggleButton followPlayheadToggle;
     juce::ToggleButton autoSaveToggle;
     magda::daw::ui::TextSlider autoSaveIntervalSlider;
     juce::Label autoSaveIntervalLabel;

--- a/magda/daw/ui/dialogs/ProjectSettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/ProjectSettingsDialog.cpp
@@ -1,0 +1,178 @@
+#include "ProjectSettingsDialog.hpp"
+
+#include "../../core/Config.hpp"
+#include "../../core/StringTable.hpp"
+#include "../../project/ProjectManager.hpp"
+#include "../state/TimelineController.hpp"
+#include "../themes/DarkTheme.hpp"
+#include "../themes/DialogLookAndFeel.hpp"
+#include "../themes/FontManager.hpp"
+
+namespace magda {
+
+namespace {
+constexpr int kRowH = 28;
+constexpr int kPad = 16;
+constexpr int kLabelW = 150;
+
+const double kSampleRates[] = {44100.0, 48000.0, 88200.0, 96000.0, 192000.0};
+const int kBitDepths[] = {16, 24, 32};  // 32 = 32-bit float
+
+void fillSampleRateCombo(juce::ComboBox& c) {
+    for (int i = 0; i < static_cast<int>(std::size(kSampleRates)); ++i)
+        c.addItem(juce::String(static_cast<int>(kSampleRates[i])) + " Hz", i + 1);
+}
+
+void fillBitDepthCombo(juce::ComboBox& c) {
+    c.addItem("16-bit", 1);
+    c.addItem("24-bit", 2);
+    c.addItem("32-bit float", 3);
+}
+
+int indexOfSampleRate(double rate) {
+    for (int i = 0; i < static_cast<int>(std::size(kSampleRates)); ++i)
+        if (std::abs(kSampleRates[i] - rate) < 0.5)
+            return i + 1;
+    return 2;  // default 48000
+}
+
+int indexOfBitDepth(int depth) {
+    for (int i = 0; i < static_cast<int>(std::size(kBitDepths)); ++i)
+        if (kBitDepths[i] == depth)
+            return i + 1;
+    return 2;  // default 24
+}
+}  // namespace
+
+ProjectSettingsDialog::ProjectSettingsDialog() {
+    setLookAndFeel(&daw::ui::DialogLookAndFeel::getInstance());
+
+    auto setupLabel = [this](juce::Label& l, const juce::String& text) {
+        l.setText(text, juce::dontSendNotification);
+        l.setFont(FontManager::getInstance().getUIFont(14.0f));
+        l.setColour(juce::Label::textColourId, DarkTheme::getColour(DarkTheme::TEXT_SECONDARY));
+        addAndMakeVisible(l);
+    };
+
+    setupLabel(lengthLabel_, tr("project_settings.total_length"));
+    setupLabel(sampleRateLabel_, tr("project_settings.sample_rate"));
+    setupLabel(renderBitLabel_, tr("project_settings.render_bit_depth"));
+    setupLabel(bounceBitLabel_, tr("project_settings.bounce_bit_depth"));
+
+    lengthSlider_.setSliderStyle(juce::Slider::IncDecButtons);
+    // Total length is constrained to multiples of 16 bars.
+    lengthSlider_.setRange(16.0, 4096.0, 16.0);
+    lengthSlider_.setTextBoxStyle(juce::Slider::TextBoxLeft, false, 80, kRowH);
+    lengthSlider_.setTextValueSuffix(" " + tr("project_settings.bars"));
+    addAndMakeVisible(lengthSlider_);
+
+    fillSampleRateCombo(sampleRateCombo_);
+    fillBitDepthCombo(renderBitCombo_);
+    fillBitDepthCombo(bounceBitCombo_);
+    addAndMakeVisible(sampleRateCombo_);
+    addAndMakeVisible(renderBitCombo_);
+    addAndMakeVisible(bounceBitCombo_);
+
+    saveAsDefaultBtn_.setButtonText(tr("project_settings.save_as_default"));
+    addAndMakeVisible(saveAsDefaultBtn_);
+
+    okBtn_.onClick = [this]() {
+        applySettings();
+        if (auto* dw = findParentComponentOfClass<juce::DialogWindow>())
+            dw->closeButtonPressed();
+    };
+    cancelBtn_.onClick = [this]() {
+        if (auto* dw = findParentComponentOfClass<juce::DialogWindow>())
+            dw->closeButtonPressed();
+    };
+    addAndMakeVisible(okBtn_);
+    addAndMakeVisible(cancelBtn_);
+
+    loadSettings();
+    // 4 setting rows + checkbox row + button row.
+    setSize(380, kPad * 2 + kRowH * 6 + 12 * 5 + 8);
+}
+
+ProjectSettingsDialog::~ProjectSettingsDialog() {
+    setLookAndFeel(nullptr);
+}
+
+void ProjectSettingsDialog::loadSettings() {
+    const auto& info = ProjectManager::getInstance().getCurrentProjectInfo();
+    lengthSlider_.setValue(info.timelineLengthBars, juce::dontSendNotification);
+    sampleRateCombo_.setSelectedId(indexOfSampleRate(info.sampleRate), juce::dontSendNotification);
+    renderBitCombo_.setSelectedId(indexOfBitDepth(info.renderBitDepth), juce::dontSendNotification);
+    bounceBitCombo_.setSelectedId(indexOfBitDepth(info.bounceBitDepth), juce::dontSendNotification);
+}
+
+void ProjectSettingsDialog::applySettings() {
+    auto& pm = ProjectManager::getInstance();
+    auto& info = pm.getMutableProjectInfo();
+
+    const int bars = juce::jmax(1, static_cast<int>(lengthSlider_.getValue()));
+    info.timelineLengthBars = bars;
+    info.sampleRate = kSampleRates[juce::jmax(0, sampleRateCombo_.getSelectedId() - 1)];
+    info.renderBitDepth = kBitDepths[juce::jmax(0, renderBitCombo_.getSelectedId() - 1)];
+    info.bounceBitDepth = kBitDepths[juce::jmax(0, bounceBitCombo_.getSelectedId() - 1)];
+
+    pm.markDirty();
+
+    // Optionally persist these as the defaults for new projects.
+    if (saveAsDefaultBtn_.getToggleState()) {
+        auto& config = Config::getInstance();
+        config.setDefaultTimelineLengthBars(info.timelineLengthBars);
+        config.setRenderSampleRate(info.sampleRate);
+        config.setRenderBitDepth(info.renderBitDepth);
+        config.setBounceBitDepth(info.bounceBitDepth);
+        config.save();
+    }
+
+    // Apply the new length to the live timeline immediately.
+    if (auto* tc = TimelineController::getCurrent()) {
+        const int beatsPerBar = juce::jmax(1, tc->getState().tempo.timeSignatureNumerator);
+        tc->dispatch(SetTimelineLengthBeatsEvent{static_cast<double>(bars) * beatsPerBar});
+    }
+}
+
+void ProjectSettingsDialog::paint(juce::Graphics& g) {
+    g.fillAll(DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND));
+}
+
+void ProjectSettingsDialog::resized() {
+    auto bounds = getLocalBounds().reduced(kPad);
+
+    auto row = [&](juce::Label& label, juce::Component& control) {
+        auto r = bounds.removeFromTop(kRowH);
+        label.setBounds(r.removeFromLeft(kLabelW));
+        control.setBounds(r);
+        bounds.removeFromTop(12);
+    };
+
+    row(lengthLabel_, lengthSlider_);
+    row(sampleRateLabel_, sampleRateCombo_);
+    row(renderBitLabel_, renderBitCombo_);
+    row(bounceBitLabel_, bounceBitCombo_);
+    saveAsDefaultBtn_.setBounds(bounds.removeFromTop(kRowH));
+
+    auto buttons = bounds.removeFromBottom(kRowH);
+    cancelBtn_.setBounds(buttons.removeFromRight(90));
+    buttons.removeFromRight(8);
+    okBtn_.setBounds(buttons.removeFromRight(90));
+}
+
+void ProjectSettingsDialog::showDialog(juce::Component* parent) {
+    (void)parent;
+    auto* dialog = new ProjectSettingsDialog();
+
+    juce::DialogWindow::LaunchOptions options;
+    options.dialogTitle = tr("menu.file.project_settings");
+    options.dialogBackgroundColour = DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND);
+    options.content.setOwned(dialog);
+    options.escapeKeyTriggersCloseButton = true;
+    options.useNativeTitleBar = true;
+    options.resizable = false;
+
+    options.launchAsync();
+}
+
+}  // namespace magda

--- a/magda/daw/ui/dialogs/ProjectSettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/ProjectSettingsDialog.cpp
@@ -74,6 +74,7 @@ ProjectSettingsDialog::ProjectSettingsDialog() {
     addAndMakeVisible(bounceBitCombo_);
 
     saveAsDefaultBtn_.setButtonText(tr("project_settings.save_as_default"));
+    saveAsDefaultBtn_.setClickingTogglesState(true);
     addAndMakeVisible(saveAsDefaultBtn_);
 
     okBtn_.onClick = [this]() {

--- a/magda/daw/ui/dialogs/ProjectSettingsDialog.hpp
+++ b/magda/daw/ui/dialogs/ProjectSettingsDialog.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+namespace magda {
+
+/**
+ * Per-project settings dialog (File > Project Settings).
+ *
+ * Edits the authoritative per-project values held in ProjectInfo: total timeline
+ * length (bars), working/render sample rate, and render / bounce bit depth.
+ * New projects seed these from the global Config defaults; this dialog overrides
+ * them for the current project.
+ */
+class ProjectSettingsDialog : public juce::Component {
+  public:
+    ProjectSettingsDialog();
+    ~ProjectSettingsDialog() override;
+
+    void resized() override;
+    void paint(juce::Graphics& g) override;
+
+    static void showDialog(juce::Component* parent);
+
+  private:
+    void loadSettings();
+    void applySettings();
+
+    juce::Label lengthLabel_, sampleRateLabel_, renderBitLabel_, bounceBitLabel_;
+    juce::Slider lengthSlider_;
+    juce::ComboBox sampleRateCombo_, renderBitCombo_, bounceBitCombo_;
+    juce::ToggleButton saveAsDefaultBtn_;
+    juce::TextButton okBtn_{"OK"}, cancelBtn_{"Cancel"};
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ProjectSettingsDialog)
+};
+
+}  // namespace magda

--- a/magda/daw/ui/state/TimelineController.cpp
+++ b/magda/daw/ui/state/TimelineController.cpp
@@ -1323,17 +1323,20 @@ TimelineController::ChangeFlags TimelineController::handleEvent(const SetTimelin
 void TimelineController::restoreProjectState(double tempo, int timeSigNum, int timeSigDen,
                                              bool loopEnabled, double loopStartBeats,
                                              double loopEndBeats,
-                                             const std::vector<ProjectTimelineMarker>& markers) {
+                                             const std::vector<ProjectTimelineMarker>& markers,
+                                             int timelineLengthBars) {
     // Unconditionally set state — no early returns
     state.tempo.bpm = clampBpm(tempo);
     state.tempo.timeSignatureNumerator = clampTimeSignatureValue(timeSigNum);
     state.tempo.timeSignatureDenominator = clampTimeSignatureValue(timeSigDen);
 
-    // Recalculate timeline length from configured bars using actual project tempo
-    auto& config = magda::Config::getInstance();
-    state.timelineLengthBeats =
-        config.getDefaultTimelineLengthBars() * state.tempo.timeSignatureNumerator;
-    state.timelineLength = state.tempo.barsToTime(config.getDefaultTimelineLengthBars());
+    // Timeline length is a per-project property; fall back to the global default
+    // (e.g. older projects without the field) when not supplied.
+    const int lengthBars = (timelineLengthBars > 0)
+                               ? timelineLengthBars
+                               : magda::Config::getInstance().getDefaultTimelineLengthBars();
+    state.timelineLengthBeats = lengthBars * state.tempo.timeSignatureNumerator;
+    state.timelineLength = state.tempo.barsToTime(lengthBars);
 
     // Loop: beats are authoritative, derive seconds from BPM
     state.loop.enabled = loopEnabled;

--- a/magda/daw/ui/state/TimelineController.hpp
+++ b/magda/daw/ui/state/TimelineController.hpp
@@ -146,7 +146,8 @@ class TimelineController {
      */
     void restoreProjectState(double tempo, int timeSigNum, int timeSigDen, bool loopEnabled,
                              double loopStartBeats, double loopEndBeats,
-                             const std::vector<ProjectTimelineMarker>& markers = {});
+                             const std::vector<ProjectTimelineMarker>& markers = {},
+                             int timelineLengthBars = -1);
 
     // Backward-compatible alias for ChangeFlags (now at namespace scope)
     using ChangeFlags = magda::ChangeFlags;

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -637,6 +637,14 @@ void MainView::timerCallback() {
 // ===== TimelineStateListener Implementation =====
 
 void MainView::timelineStateChanged(const TimelineState& state, ChangeFlags changes) {
+    // Timeline length changes: the ruler and track content cache their own
+    // length, so push the new value to them (e.g. from Project Settings). The
+    // Zoom flag that accompanies a length change handles the resize/scrollbars.
+    if (hasFlag(changes, ChangeFlags::Timeline)) {
+        timeline->setTimelineLength(state.timelineLength);
+        trackContentPanel->setTimelineLength(state.timelineLength);
+    }
+
     // Zoom/scroll changes
     if (hasFlag(changes, ChangeFlags::Zoom) || hasFlag(changes, ChangeFlags::Scroll)) {
         if (hasFlag(changes, ChangeFlags::Zoom) || hasFlag(changes, ChangeFlags::Scroll))

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -693,6 +693,23 @@ void MainView::timelineStateChanged(const TimelineState& state, ChangeFlags chan
             selectionOverlay->repaint();
         }
 
+        // Auto-scroll: keep the playhead in view while playing. When it runs off
+        // the right edge (or jumps back, e.g. on loop), page the arrangement so
+        // it sits near the left. Dispatching re-enters with a Scroll flag, which
+        // syncs every horizontal surface (handled above).
+        if (state.playhead.isPlaying && Config::getInstance().getFollowPlayhead()) {
+            const int viewW = state.zoom.viewportWidth;
+            if (viewW > 0) {
+                const int playX = state.timeToPixelLocal(playheadPosition);
+                const int scrollX = state.zoom.scrollX;
+                const int margin = 48;
+                if (playX > scrollX + viewW - margin || playX < scrollX) {
+                    timelineController->dispatch(
+                        SetScrollPositionEvent{juce::jmax(0, playX - margin), -1});
+                }
+            }
+        }
+
         if (onPlayheadPositionChanged) {
             onPlayheadPositionChanged(playheadPosition);
         }
@@ -1729,9 +1746,11 @@ void MainView::PlayheadComponent::paint(juce::Graphics& g) {
     // Draw play cursor (vertical line) - only during playback when position differs from edit
     if (isPlaying && playbackPos >= 0 && playbackPos <= owner.timelineLength && playX >= 0 &&
         playX < getWidth()) {
-        // Draw thin vertical line extending full height of track area
+        // Draw thin vertical line extending the full track area, starting at the
+        // top of the track content (just below the playhead/triangle row).
         g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_BLUE));
-        g.drawLine(static_cast<float>(playX), 20.0f, static_cast<float>(playX),
+        const float lineTop = static_cast<float>(LayoutConfig::getInstance().playheadRowHeight);
+        g.drawLine(static_cast<float>(playX), lineTop, static_cast<float>(playX),
                    static_cast<float>(getHeight()), 1.5f);
     }
 }

--- a/magda/daw/ui/windows/MainWindowMenus.cpp
+++ b/magda/daw/ui/windows/MainWindowMenus.cpp
@@ -9,6 +9,7 @@
 #include "../dialogs/ExportMidiDialog.hpp"
 #include "../dialogs/PluginSettingsDialog.hpp"
 #include "../dialogs/PreferencesDialog.hpp"
+#include "../dialogs/ProjectSettingsDialog.hpp"
 #include "../dialogs/TrackManagerDialog.hpp"
 #include "../state/TimelineController.hpp"
 #include "../state/TimelineEvents.hpp"
@@ -110,7 +111,8 @@ void MainWindow::openProjectFile(const juce::File& file) {
             auto& tc = safeThis->mainComponent->mainView->getTimelineController();
             tc.restoreProjectState(info.tempo, info.timeSignatureNumerator,
                                    info.timeSignatureDenominator, info.loopEnabled,
-                                   info.loopStartBeats, info.loopEndBeats, info.markers);
+                                   info.loopStartBeats, info.loopEndBeats, info.markers,
+                                   info.timelineLengthBars);
         },
         [safeThis, file](bool success, const juce::String& error) {
             if (!safeThis)
@@ -155,11 +157,12 @@ void MainWindow::setupMenuCallbacks() {
         } else {
             // Reset timeline/transport to defaults
             if (mainComponent && mainComponent->mainView) {
-                ProjectInfo defaults;
+                const auto& info = ProjectManager::getInstance().getCurrentProjectInfo();
                 auto& tc = mainComponent->mainView->getTimelineController();
-                tc.restoreProjectState(defaults.tempo, defaults.timeSignatureNumerator,
-                                       defaults.timeSignatureDenominator, defaults.loopEnabled,
-                                       defaults.loopStartBeats, defaults.loopEndBeats);
+                tc.restoreProjectState(info.tempo, info.timeSignatureNumerator,
+                                       info.timeSignatureDenominator, info.loopEnabled,
+                                       info.loopStartBeats, info.loopEndBeats, info.markers,
+                                       info.timelineLengthBars);
             }
             // Select master channel by default
             SelectionManager::getInstance().selectTrack(MASTER_TRACK_ID);
@@ -464,6 +467,8 @@ void MainWindow::setupMenuCallbacks() {
     };
 
     callbacks.onPreferences = [this]() { PreferencesDialog::showDialog(this); };
+
+    callbacks.onProjectSettings = [this]() { ProjectSettingsDialog::showDialog(this); };
 
     callbacks.onAISettings = [this]() { AISettingsDialog::showDialog(this); };
 

--- a/magda/daw/ui/windows/MenuManager.cpp
+++ b/magda/daw/ui/windows/MenuManager.cpp
@@ -102,6 +102,7 @@ juce::PopupMenu MenuManager::getMenuForIndex(int topLevelMenuIndex,
             menu.addItem(SaveProject, tr("menu.file.save_project"), true, false);
             menu.addItem(SaveProjectAs, tr("menu.file.save_project_as"), true, false);
             menu.addSeparator();
+            menu.addItem(ProjectSettings, tr("menu.file.project_settings"), true, false);
             menu.addItem(CollectFiles, tr("menu.file.collect_files"), true, false);
             menu.addSeparator();
             menu.addItem(ExportAudio, tr("menu.file.export_audio"), true, false);
@@ -308,6 +309,10 @@ void MenuManager::menuItemSelected(int menuItemID, int topLevelMenuIndex) {
         case SaveProjectAs:
             if (callbacks_.onSaveProjectAs)
                 callbacks_.onSaveProjectAs();
+            break;
+        case ProjectSettings:
+            if (callbacks_.onProjectSettings)
+                callbacks_.onProjectSettings();
             break;
         case CollectFiles:
             if (callbacks_.onCollectFiles)

--- a/magda/daw/ui/windows/MenuManager.hpp
+++ b/magda/daw/ui/windows/MenuManager.hpp
@@ -18,6 +18,7 @@ class MenuManager : public juce::MenuBarModel, public UndoManagerListener {
         std::function<void()> onCloseProject;
         std::function<void()> onSaveProject;
         std::function<void()> onSaveProjectAs;
+        std::function<void()> onProjectSettings;
         std::function<void()> onCollectFiles;
         std::function<void()> onExportAudio;
         std::function<void()> onExportMidi;
@@ -155,6 +156,7 @@ class MenuManager : public juce::MenuBarModel, public UndoManagerListener {
         ExportAudio = 111,
         ExportMidi,
         CollectFiles = 115,
+        ProjectSettings = 116,
         RecentProjectBase = 150,  // 150-159 reserved for recent projects
         Quit = 199,
 


### PR DESCRIPTION
## Summary
Implements the per-project settings model (#1477, including the per-project timeline length from #1476) plus playback auto-scroll and a few navigator/marker touches.

## Project settings
- New **File > Project Settings** dialog: total length (multiples of 16 bars), sample rate, render bit depth, bounce bit depth, with a **Save as default for new projects** checkbox.
- Stored in `ProjectInfo`, serialized to the `.mgd`, applied on load (timeline length now flows through `restoreProjectState`, not the global default).
- Render/bounce (`ClipCommands`) and the Export dialog read sample rate + bit depth from the project, not global `Config`.
- New projects seed all four from the `Config` new-project defaults.
- Preferences: removed the General default-timeline-length slider and the Render Format section (sample rate, render/bounce bit depth) - those `Config` values now serve only as new-project defaults.

## Playback / arrangement
- **Auto-scroll** the arrangement to follow the playhead during playback, gated by a new **Follow playhead during playback** toggle in General preferences (persisted, default on).
- Arrangement playhead line now reaches the top of the track content.

## Song navigator
- Draw timeline markers (coloured line + flag tick in the content area).
- Playhead, viewport box, and markers stay below the ruler band.
- Final bar label always shown.

## Markers
- Double-click a marker in the marker lane to rename it.

Closes #1477.
