### PR TITLE
Fix use-after-free when clip context menu outlives its clip

### DIFF
--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -2978,8 +2978,19 @@ void ClipComponent::showContextMenu() {
     }
 
     // Show menu
-    menu.showMenuAsync(juce::PopupMenu::Options(), [this, &clipManager,
-                                                    &selectionManager](int result) {
+    menu.showMenuAsync(juce::PopupMenu::Options(), [this,
+                                                    safeThis =
+                                                        juce::Component::SafePointer<ClipComponent>(
+                                                            this),
+                                                    &clipManager, &selectionManager](int result) {
+        // The menu is modal-async: the clip (and its parent panel) can be
+        // destroyed while it is open, e.g. a project load/close or track delete
+        // rebuilds every clip via ClipManager::clearAllClips(). Bail before
+        // touching any member — parentPanel_ would otherwise be a dangling
+        // non-null pointer (crash in parentPanel_->getTempo()).
+        if (safeThis == nullptr)
+            return;
+
         if (result == 0)
             return;  // Cancelled
 


### PR DESCRIPTION
## Problem

The clip right-click menu (`ClipComponent::showContextMenu`) is modal-async and its `showMenuAsync` callback captured raw `this`. If the clip - and its parent `TrackContentPanel` - is destroyed while the menu is open, selecting an item dereferences freed memory and crashes in `parentPanel_->getTempo()` with a dangling non-null pointer (EXC_BAD_ACCESS / pointer-auth fault).

Any operation that rebuilds clips via `ClipManager::clearAllClips()` can trigger it while the menu is open: project load/close, track delete, etc.

## Fix

Capture a `juce::Component::SafePointer<ClipComponent>` and bail at the top of the callback if the component was destroyed, before touching any member. Matches the SafePointer pattern already used elsewhere in this file.

## Notes

Pre-existing bug (introduced in #615), present on `main` - not specific to any in-flight work. Surfaced via a repeatable repro while testing DAWproject import (the import rebuilds all clips). Built locally on macOS.