### PR TITLE
Feat/chord track followups

### DIFF
--- a/magda/daw/core/CMakeLists.txt
+++ b/magda/daw/core/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(magda_daw PRIVATE
     TrackManagerDevices.cpp
     ModulatorEngine.cpp
     ClipManager.cpp
+    ChordProgressionConverter.cpp
     SessionLaunchService.cpp
     MidiFileWriter.cpp
     SelectionManager.cpp
@@ -98,6 +99,7 @@ target_sources(magda_daw PRIVATE
     AutomationCommands.hpp
     MidiNoteCommands.hpp
     ChordAnnotationCommands.hpp
+    ChordProgressionConverter.hpp
     MacroInfo.hpp
     ModInfo.hpp
     ParameterInfo.hpp

--- a/magda/daw/core/ChordProgressionConverter.cpp
+++ b/magda/daw/core/ChordProgressionConverter.cpp
@@ -1,0 +1,79 @@
+#include "ChordProgressionConverter.hpp"
+
+#include <algorithm>
+
+#include "music/ChordEngine.hpp"
+
+namespace magda {
+
+std::vector<ExtractedChord> extractChordsFromNotes(const std::vector<MidiNote>& notes,
+                                                   int beatsPerBar) {
+    std::vector<ExtractedChord> detected;
+    if (notes.empty())
+        return detected;
+
+    const double step = std::max(1, beatsPerBar);
+
+    // Scan only up to the last note end, not the full clip length.
+    double lastNoteEnd = 0.0;
+    for (const auto& note : notes)
+        lastNoteEnd = std::max(lastNoteEnd, note.startBeat + note.lengthBeats);
+
+    auto& engine = magda::music::ChordEngine::getInstance();
+    for (double beat = 0.0; beat < lastNoteEnd; beat += step) {
+        std::vector<magda::music::ChordNote> chordNotes;
+        std::vector<size_t> indices;
+        for (size_t i = 0; i < notes.size(); ++i) {
+            const auto& note = notes[i];
+            if (note.startBeat <= beat && (note.startBeat + note.lengthBeats) > beat) {
+                chordNotes.push_back({note.noteNumber, note.velocity});
+                indices.push_back(i);
+            }
+        }
+
+        if (chordNotes.size() < 2)
+            continue;
+
+        auto chord = engine.detect(chordNotes);
+        if (chord.name == "none" || chord.name == "unknown" || chord.name.isEmpty())
+            continue;
+
+        ExtractedChord ex;
+        ex.startBeat = beat;
+        ex.name = chord.getDisplayName();
+        ex.root = chord.root;
+        ex.quality = chord.quality;
+        ex.noteIndices = std::move(indices);
+        detected.push_back(std::move(ex));
+    }
+
+    // Each chord extends to the next one, or to the last note end for the tail.
+    for (size_t i = 0; i < detected.size(); ++i) {
+        detected[i].lengthBeats = (i + 1 < detected.size())
+                                      ? (detected[i + 1].startBeat - detected[i].startBeat)
+                                      : (lastNoteEnd - detected[i].startBeat);
+    }
+
+    return detected;
+}
+
+std::vector<MidiNote> buildVoicingNotes(music::ChordRoot root, music::ChordQuality quality,
+                                        double startBeat, double lengthBeats, int velocity,
+                                        int octave) {
+    std::vector<MidiNote> out;
+    const auto chord =
+        magda::music::ChordEngine::getInstance().buildChordInRootPosition(root, quality, octave);
+    out.reserve(chord.notes.size());
+    for (const auto& n : chord.notes) {
+        MidiNote m;
+        m.noteNumber = std::clamp(n.noteNumber, 0, 127);
+        m.velocity = velocity;
+        m.startBeat = startBeat;
+        m.lengthBeats = lengthBeats;
+        m.chordGroup = 0;
+        out.push_back(m);
+    }
+    return out;
+}
+
+}  // namespace magda

--- a/magda/daw/core/ChordProgressionConverter.hpp
+++ b/magda/daw/core/ChordProgressionConverter.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <vector>
+
+#include "ClipInfo.hpp"
+#include "music/ChordEnums.hpp"
+
+namespace magda {
+
+/// One detected chord from a bar-by-bar scan of a MIDI clip's notes.
+struct ExtractedChord {
+    double startBeat = 0.0;    // Clip-relative beat where the chord starts
+    double lengthBeats = 0.0;  // Extends to the next chord (or the last note end)
+    juce::String name;         // Display name, e.g. "C4 maj" (carries the octave)
+    // The detected harmony, kept as enums so callers can rebuild a clean voicing
+    // without re-parsing the (octave-bearing) display name.
+    music::ChordRoot root = music::ChordRoot::C;
+    music::ChordQuality quality = music::ChordQuality::Major;
+    std::vector<size_t> noteIndices;  // Indices into the scanned notes vector
+};
+
+/**
+ * @brief Bar-by-bar chord detection over a clip's MIDI notes.
+ *
+ * Mirrors the per-bar scan the piano-roll chord lane performs: at each bar it
+ * gathers the notes sounding there and runs ChordEngine detection. Beats are
+ * clip-relative on input and output. The single source of truth shared by the
+ * in-editor "detect chords" action and the "extract to chord track" feature.
+ */
+std::vector<ExtractedChord> extractChordsFromNotes(const std::vector<MidiNote>& notes,
+                                                   int beatsPerBar);
+
+/**
+ * @brief Build a canonical root-position voicing for a chord.
+ *
+ * Emits the ideal voicing for the given root/quality as MIDI notes at the given
+ * clip-relative position. chordGroup is left at 0 so the caller can link the
+ * notes to a ChordAnnotation. Takes enums (not a name string) so it never has to
+ * parse an octave-bearing display name like "G4 major".
+ */
+std::vector<MidiNote> buildVoicingNotes(music::ChordRoot root, music::ChordQuality quality,
+                                        double startBeat, double lengthBeats, int velocity = 100,
+                                        int octave = 4);
+
+}  // namespace magda

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -20,6 +20,8 @@
 #include "audio/AudioBridge.hpp"
 #include "audio/AudioThumbnailManager.hpp"
 #include "core/AppPaths.hpp"
+#include "core/ChordAnnotationCommands.hpp"
+#include "core/ChordProgressionConverter.hpp"
 #include "core/ClipCommands.hpp"
 #include "core/ClipDisplayInfo.hpp"
 #include "core/ClipOperations.hpp"
@@ -69,6 +71,119 @@ void showExternalEditorFailedAlert(const juce::String& message) {
                                            "Edit in External Editor Failed", message);
 }
 
+// Run chord detection on a MIDI clip and write the result onto the singleton
+// chord track as a new "Progression" clip (canonical voicings + linked chord
+// blocks). When `replace` is set the chord track's existing clips are cleared
+// first; otherwise the new progression is appended. One undo step. (#1506)
+void extractChordsToChordTrack(magda::ClipId sourceClipId, bool replace) {
+    auto& cm = ClipManager::getInstance();
+    const auto* source = cm.getClip(sourceClipId);
+    if (source == nullptr || !source->isMidi() || source->midiNotes.empty())
+        return;
+
+    int beatsPerBar = magda::DEFAULT_TIME_SIGNATURE_NUMERATOR;
+    if (auto* controller = TimelineController::getCurrent())
+        beatsPerBar = controller->getState().tempo.timeSignatureNumerator;
+
+    const auto extracted = magda::extractChordsFromNotes(source->midiNotes, beatsPerBar);
+    if (extracted.empty()) {
+        magda::daw::ui::Toast::showGlobal("No chords detected in clip");
+        return;
+    }
+
+    // Span the chord clip over the source's beat range so the progression sits
+    // beneath the notes it came from.
+    const double clipStart = source->placement.startBeat;
+    double extractEnd = 0.0;
+    for (const auto& ex : extracted)
+        extractEnd = std::max(extractEnd, ex.startBeat + ex.lengthBeats);
+    const double clipLength = std::max(source->placement.lengthBeats, extractEnd);
+
+    auto& tm = TrackManager::getInstance();
+    const auto chordTrackId = tm.ensureChordTrack();
+    if (chordTrackId == magda::INVALID_TRACK_ID)
+        return;
+
+    magda::CompoundOperationScope scope("Extract Chords to Chord Track");
+    auto& undo = UndoManager::getInstance();
+
+    if (replace) {
+        for (const auto cid : cm.getClipsOnTrack(chordTrackId))
+            undo.executeCommand(std::make_unique<DeleteClipCommand>(cid));
+    }
+
+    auto createCmd = std::make_unique<CreateClipCommand>(
+        magda::ClipType::MIDI, chordTrackId, BeatPosition{clipStart}, BeatDuration{clipLength});
+    auto* createPtr = createCmd.get();
+    undo.executeCommand(std::move(createCmd));
+    const auto newClipId = createPtr->getCreatedClipId();
+    auto* newClip = cm.getClip(newClipId);
+    if (newClip == nullptr)
+        return;
+
+    for (const auto& ex : extracted) {
+        const int groupId = newClip->nextChordGroupId++;
+
+        auto notes =
+            magda::buildVoicingNotes(ex.root, ex.quality, ex.startBeat, ex.lengthBeats, 100);
+        for (auto& n : notes)
+            n.chordGroup = groupId;
+
+        magda::ClipInfo::ChordAnnotation annotation;
+        annotation.beatPosition = ex.startBeat;
+        annotation.lengthBeats = ex.lengthBeats;
+        annotation.chordName = ex.name;
+        annotation.chordGroup = groupId;
+        undo.executeCommand(std::make_unique<AddChordAnnotationCommand>(newClipId, annotation));
+
+        if (!notes.empty())
+            undo.executeCommand(std::make_unique<AddMultipleMidiNotesCommand>(
+                newClipId, std::move(notes), "Add Chord Voicing"));
+    }
+
+    cm.forceNotifyClipPropertyChanged(newClipId);
+    magda::daw::ui::Toast::showGlobal(
+        replace ? juce::String("Replaced chord track with detected chords")
+                : "Extracted " + juce::String(static_cast<int>(extracted.size())) +
+                      " chords to chord track");
+}
+
+// Bake a chord-track progression onto a normal track as a plain, editable MIDI
+// clip: the voicings come across as notes, the chord-lane annotations are
+// dropped so the result is decoupled from the chord engine. (#1503)
+void sendProgressionToTrack(magda::ClipId chordClipId, magda::TrackId targetTrackId) {
+    auto& cm = ClipManager::getInstance();
+    const auto* src = cm.getClip(chordClipId);
+    if (src == nullptr || !src->isMidi() || targetTrackId == magda::INVALID_TRACK_ID)
+        return;
+
+    double tempo = 120.0;
+    if (auto* tc = TimelineController::getCurrent())
+        tempo = tc->getState().tempo.bpm;
+
+    magda::CompoundOperationScope scope("Progression to MIDI Clip");
+    auto& undo = UndoManager::getInstance();
+
+    auto dupCmd = std::make_unique<DuplicateClipCommand>(
+        chordClipId, BeatPosition{src->placement.startBeat}, targetTrackId, tempo);
+    auto* dupPtr = dupCmd.get();
+    undo.executeCommand(std::move(dupCmd));
+
+    const auto newClipId = dupPtr->getDuplicatedClipId();
+    auto* newClip = cm.getClip(newClipId);
+    if (newClip == nullptr)
+        return;
+
+    // Strip the chord-ness: a plain MIDI clip with the voicings baked into notes.
+    newClip->chordAnnotations.clear();
+    for (auto& n : newClip->midiNotes)
+        n.chordGroup = 0;
+    newClip->name = src->name;
+    cm.forceNotifyClipPropertyChanged(newClipId);
+
+    magda::daw::ui::Toast::showGlobal("Progression copied as MIDI clip");
+}
+
 constexpr int MIDI_PREVIEW_MIN_NOTE = 21;   // A0
 constexpr int MIDI_PREVIEW_MAX_NOTE = 108;  // C8
 
@@ -76,6 +191,10 @@ constexpr int MIDI_PREVIEW_MAX_NOTE = 108;  // C8
 // the fixed item IDs and the 100-range quantize grid.
 constexpr int kTakeMenuBaseId = 300;
 constexpr int kTakeMenuMaxItems = 64;
+
+// Context-menu IDs for "Send Progression to Track" (one per eligible track),
+// kept clear of the take-selection range (300..363).
+constexpr int kProgressionTargetBaseId = 400;
 
 juce::Path makeClippedRoundedRectPath(juce::Rectangle<int> bounds,
                                       juce::Rectangle<int> visibleBounds, float radius) {
@@ -1742,15 +1861,29 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
             previewStartTime_ = finalTime;
 
             if (isDuplicating_) {
-                // Alt+drag duplicate: show ghost at NEW position, keep original in place
+                // Alt+drag duplicate: show ghost at the NEW position, following the
+                // mouse onto the target track, keeping the original in place.
                 const auto* clip = getClipInfo();
                 if (clip && parentPanel_) {
                     double finalBeats = finalTime * tempoBPM / 60.0;
                     int ghostX = parentPanel_->beatsToPixel(finalBeats);
                     double lengthBeats = dragStartLength_ * tempoBPM / 60.0;
                     int ghostWidth = static_cast<int>(std::round(lengthBeats * pixelsPerBeat));
-                    juce::Rectangle<int> ghostBounds(ghostX, getY(), juce::jmax(10, ghostWidth),
-                                                     getHeight());
+
+                    // Follow the mouse vertically so the ghost lands on whatever
+                    // track the copy will drop onto (matches the mouseUp target).
+                    int ghostY = getY();
+                    int ghostH = getHeight();
+                    const int localY =
+                        e.getScreenPosition().y - parentPanel_->getScreenBounds().getPosition().y;
+                    const int trackIndex = parentPanel_->getTrackIndexAtY(localY);
+                    if (trackIndex >= 0) {
+                        ghostY = parentPanel_->getTrackYPosition(trackIndex);
+                        ghostH = parentPanel_->getTrackTotalHeight(trackIndex);
+                    }
+
+                    juce::Rectangle<int> ghostBounds(ghostX, ghostY, juce::jmax(10, ghostWidth),
+                                                     ghostH);
                     parentPanel_->setClipGhost(clipId_, ghostBounds, clip->colour);
                 }
                 // Don't move the original clip component
@@ -2890,6 +3023,16 @@ void ClipComponent::showContextMenu() {
     // duplicates, render, bounce, transcribe, or MIDI-library save.
     const bool isChord = clipForMenu && isChordClip(*clipForMenu);
 
+    // Eligible destinations for "Send Progression to Track" (chord clips only):
+    // regular hybrid tracks, which can host the baked MIDI clip. Captured below
+    // so the async handler can map menu IDs back to track IDs.
+    std::vector<TrackId> progressionTargets;
+    if (isChord && !isMultiSelection) {
+        for (const auto& t : TrackManager::getInstance().getTracks())
+            if (t.type == TrackType::Audio)
+                progressionTargets.push_back(t.id);
+    }
+
     // "Duplicate Time Selection" is enabled when an active, visible time
     // selection exists — mirrors the gate Cmd+D uses in MainWindowCommands
     // and the empty-area menu in TrackContentPanel.
@@ -2906,6 +3049,25 @@ void ClipComponent::showContextMenu() {
     menu.addItem(2, "Cut", canEdit);
     menu.addItem(3, "Paste", !isFrozen);
     menu.addSeparator();
+
+    // Bake the progression onto a regular track as a plain MIDI clip (#1503).
+    if (isChord && !isMultiSelection) {
+        juce::PopupMenu targetMenu;
+        const auto& tracks = TrackManager::getInstance().getTracks();
+        int idx = 0;
+        for (const auto targetId : progressionTargets) {
+            juce::String label = "Track " + juce::String(targetId);
+            for (const auto& t : tracks)
+                if (t.id == targetId) {
+                    label = t.name.isNotEmpty() ? t.name : label;
+                    break;
+                }
+            targetMenu.addItem(kProgressionTargetBaseId + idx, label);
+            ++idx;
+        }
+        menu.addSubMenu("Send Progression to Track", targetMenu, !progressionTargets.empty());
+        menu.addSeparator();
+    }
 
     // Duplicate
     menu.addItem(4, "Duplicate", canEdit);
@@ -3035,6 +3197,14 @@ void ClipComponent::showContextMenu() {
         if (hasMidi) {
             if (!isChord) {
                 menu.addItem(20, "Save MIDI Clip to Library", canSaveSingleMidi);
+
+                // Extract detected chords onto the (singleton) chord track.
+                if (!isMultiSelection) {
+                    juce::PopupMenu extractMenu;
+                    extractMenu.addItem(23, "Append");
+                    extractMenu.addItem(24, "Replace Chord Track");
+                    menu.addSubMenu("Extract Chords to Chord Track", extractMenu);
+                }
                 menu.addSeparator();
             }
 
@@ -3146,7 +3316,8 @@ void ClipComponent::showContextMenu() {
                                                     safeThis =
                                                         juce::Component::SafePointer<ClipComponent>(
                                                             this),
-                                                    &clipManager, &selectionManager](int result) {
+                                                    progressionTargets, &clipManager,
+                                                    &selectionManager](int result) {
         // The menu is modal-async: the clip (and its parent panel) can be
         // destroyed while it is open, e.g. a project load/close or track delete
         // rebuilds every clip via ClipManager::clearAllClips(). Bail before
@@ -3170,6 +3341,16 @@ void ClipComponent::showContextMenu() {
                 c->audio().source.filePath = c->audio().takes[takeIndex].filePath;
                 clipManager.forceNotifyClipPropertyChanged(clipId_);
             }
+            return;
+        }
+
+        // Send Progression to Track (IDs 400+): bake the chord progression onto
+        // the chosen regular track as a plain MIDI clip.
+        if (result >= kProgressionTargetBaseId &&
+            result < kProgressionTargetBaseId + static_cast<int>(progressionTargets.size())) {
+            const auto targetId =
+                progressionTargets[static_cast<size_t>(result - kProgressionTargetBaseId)];
+            sendProgressionToTrack(clipId_, targetId);
             return;
         }
 
@@ -3270,6 +3451,16 @@ void ClipComponent::showContextMenu() {
                         else
                             magda::daw::ui::Toast::showGlobal("Transcription complete");
                     });
+                break;
+            }
+
+            case 23: {  // Extract Chords to Chord Track (Append)
+                extractChordsToChordTrack(clipId_, false);
+                break;
+            }
+
+            case 24: {  // Extract Chords to Chord Track (Replace)
+                extractChordsToChordTrack(clipId_, true);
                 break;
             }
 

--- a/magda/daw/ui/panels/content/PianoRollContent.cpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.cpp
@@ -13,6 +13,8 @@
 #include "audio/MidiBridge.hpp"
 #include "audio/plugins/MidiChordEnginePlugin.hpp"
 #include "core/ChordAnnotationCommands.hpp"
+#include "core/ChordProgressionContext.hpp"
+#include "core/ChordProgressionConverter.hpp"
 #include "core/GestureRouter.hpp"
 #include "core/MidiNoteCommands.hpp"
 #include "core/SelectionManager.hpp"
@@ -34,6 +36,8 @@
 #include "ui/components/timeline/TimeRuler.hpp"
 
 namespace magda::daw::ui {
+
+bool PianoRollContent::showProgressionOverlay_ = false;
 
 PianoRollContent::PianoRollContent() {
     setName("PianoRoll");
@@ -92,6 +96,22 @@ PianoRollContent::PianoRollContent() {
     chordDetectBtn_->onClick = [this]() { detectChordsFromNotes(); };
     chordDetectBtn_->setVisible(showChordRow_);
     addAndMakeVisible(chordDetectBtn_.get());
+
+    // Progression overlay toggle: ghost the chord-track progression behind this
+    // track's chord lane (#1504). Only meaningful on non-chord tracks.
+    progressionOverlayToggle_ = std::make_unique<magda::SvgButton>(
+        "ProgressionOverlay", BinaryData::iconchordtrackboldm_svg,
+        BinaryData::iconchordtrackboldm_svgSize);
+    progressionOverlayToggle_->setTooltip("Compare against the chord-track progression");
+    progressionOverlayToggle_->setOriginalColor(juce::Colour(0xFFB3B3B3));
+    progressionOverlayToggle_->setActive(showProgressionOverlay_);
+    progressionOverlayToggle_->onClick = [this]() {
+        showProgressionOverlay_ = !showProgressionOverlay_;
+        progressionOverlayToggle_->setActive(showProgressionOverlay_);
+        repaint();
+    };
+    progressionOverlayToggle_->setVisible(false);
+    addAndMakeVisible(progressionOverlayToggle_.get());
 
     // Chord-focus mode shows this in place of the rescan button: a toggle that
     // shows/hides the note grid.
@@ -921,6 +941,18 @@ void PianoRollContent::resized() {
         chordDetectBtn_->setVisible(!chordMode);
         gridToggleBtn_->setVisible(chordMode);
 
+        // The overlay toggle is only useful on a non-chord track when a chord
+        // track exists to overlay from.
+        bool onChordTrack = false;
+        if (const auto* clip = magda::ClipManager::getInstance().getClip(editingClipId_)) {
+            const auto* tr = magda::TrackManager::getInstance().getTrack(clip->trackId);
+            onChordTrack = tr != nullptr && tr->type == magda::TrackType::Chord;
+        }
+        const bool overlayApplies =
+            !chordMode && !onChordTrack && magda::TrackManager::getInstance().hasChordTrack();
+        progressionOverlayToggle_->setVisible(overlayApplies);
+        progressionOverlayToggle_->setActive(showProgressionOverlay_);
+
         if (chordMode) {
             // Grid show/hide toggle: bottom-centre of the chord-lane gutter.
             const int gx = (chordLaneLeftX() - detectSize) / 2;
@@ -933,10 +965,14 @@ void PianoRollContent::resized() {
                 sidebarWidth() + ZOOM_STRIP_WIDTH + (KEYBOARD_WIDTH - detectSize) / 2;
             const int detectY = (chordRowHeight() - detectSize) / 2;
             chordDetectBtn_->setBounds(detectX, detectY, detectSize, detectSize);
+            if (overlayApplies)
+                progressionOverlayToggle_->setBounds(detectX + detectSize + 2, detectY, detectSize,
+                                                     detectSize);
         }
     } else {
         chordDetectBtn_->setVisible(false);
         gridToggleBtn_->setVisible(false);
+        progressionOverlayToggle_->setVisible(false);
     }
 
     // MIDI drawer at bottom (if open). Suppressed in chord-focus mode.
@@ -1418,9 +1454,20 @@ void PianoRollContent::clipsChanged() {
     }
     MidiEditorContent::clipsChanged();
     updateVelocityLane();
+
+    // The comparison overlay reads the chord track's progression, which lives on
+    // a different track than this editor — repaint so it refreshes when chords
+    // are added, moved off the chord track, or cleared.
+    if (showProgressionOverlay_)
+        repaint();
 }
 
 void PianoRollContent::clipPropertyChanged(magda::ClipId clipId) {
+    // A chord-track clip change won't be "displayed" here, but the comparison
+    // overlay still needs to reflect it.
+    if (showProgressionOverlay_)
+        repaint();
+
     // Check if this clip is one of the displayed clips
     const auto& displayedClips = gridComponent_->getClipIds();
     bool isDisplayed = false;
@@ -1724,11 +1771,17 @@ void PianoRollContent::drawChordRow(juce::Graphics& g, juce::Rectangle<int> area
     const auto* clip = (editingClipId_ != magda::INVALID_CLIP_ID)
                            ? magda::ClipManager::getInstance().getClip(editingClipId_)
                            : nullptr;
+
     if (!clip || clip->chordAnnotations.empty()) {
-        // Empty state hint
-        g.setColour(DarkTheme::getSecondaryTextColour().withAlpha(0.3f));
+        // Empty-state hint. The chord lane is populated by chord detection, so
+        // say how to get chords here: the chord-track editor adds them on click;
+        // a normal track detects them from its own notes via the scan button.
+        g.setColour(DarkTheme::getSecondaryTextColour().withAlpha(0.4f));
         g.setFont(FontManager::getInstance().getUIFont(10.0f));
-        g.drawText("No chords detected", area.reduced(4, 0), juce::Justification::centredLeft);
+        const juce::String hint = chordFocusMode()
+                                      ? "Click the lane to add a chord"
+                                      : "No chords - press the scan button to detect from notes";
+        g.drawText(hint, area.reduced(8, 0), juce::Justification::centredLeft, true);
         return;
     }
 
@@ -1742,6 +1795,24 @@ void PianoRollContent::drawChordRow(juce::Graphics& g, juce::Rectangle<int> area
     if (!relativeTimeMode_ && clip->view != magda::ClipView::Session) {
         clipStartBeats = clip->placement.startBeat;
     }
+
+    // Chord-block layout (#1504):
+    //   chord-track chord -> LEFT, with the accent spine
+    //   MIDI-track chord  -> RIGHT, no decoration (always the same spot)
+    // On the chord track's own editor the blocks ARE chord-track chords (left +
+    // spine). On a normal track the MIDI chord sits right/bare, and when the
+    // overlay is on the intended chord-track chord is added left + spine.
+    const bool isChordTrackLane =
+        clip->trackId == magda::TrackManager::getInstance().getChordTrackId();
+    const bool overlay = showProgressionOverlay_ && !isChordTrackLane;
+    const auto master = overlay ? magda::ChordProgressionContext::current()
+                                : std::vector<magda::ProgressionChord>{};
+    auto intendedAt = [&](double absBeat) -> juce::String {
+        for (const auto& mc : master)
+            if (absBeat >= mc.startBeat - 0.01 && absBeat < mc.startBeat + mc.lengthBeats - 0.01)
+                return mc.name;
+        return {};
+    };
 
     for (const auto& annotation : clip->chordAnnotations) {
         double absBeat = annotation.beatPosition + clipStartBeats;
@@ -1765,16 +1836,25 @@ void PianoRollContent::drawChordRow(juce::Graphics& g, juce::Rectangle<int> area
         const bool previewing =
             previewChordGroup() != 0 && annotation.chordGroup == previewChordGroup();
         const auto accent = DarkTheme::getColour(DarkTheme::ACCENT_BLUE);
+
+        // The intended chord-track chord shown alongside this track's chord.
+        // (Agreement/disagreement signalling is deferred — see follow-up issue.)
+        const juce::String intendedName = overlay ? intendedAt(absBeat) : juce::String();
+        const bool comparing = intendedName.isNotEmpty();
+
         // A playing block glows green; otherwise the accent-blue card.
         const auto fillColour =
             previewing ? DarkTheme::getColour(DarkTheme::STATUS_SUCCESS) : accent;
+        const float fillAlpha = previewing ? 0.40f : selected ? 0.22f : 0.13f;
 
-        // Direction 4 "accent spine": subtle slate fill, a bright accent bar down
-        // the left edge, clean name type.
-        g.setColour(fillColour.withAlpha(previewing ? 0.40f : selected ? 0.22f : 0.13f));
+        // Slate card fill.
+        g.setColour(fillColour.withAlpha(fillAlpha));
         g.fillRoundedRectangle(blockBounds.toFloat(), 4.0f);
 
-        if (blockBounds.getWidth() > 8) {
+        // The accent spine belongs to the chord-track chord (left). The MIDI
+        // track's own chord is bare (no spine).
+        const bool hasChordTrackChord = isChordTrackLane || comparing;
+        if (hasChordTrackChord && blockBounds.getWidth() > 8) {
             juce::Rectangle<float> spine(static_cast<float>(blockBounds.getX() + 3),
                                          static_cast<float>(blockBounds.getY() + 3), 3.0f,
                                          static_cast<float>(blockBounds.getHeight() - 6));
@@ -1782,13 +1862,30 @@ void PianoRollContent::drawChordRow(juce::Graphics& g, juce::Rectangle<int> area
             g.fillRoundedRectangle(spine, 1.5f);
         }
 
-        // Chord name in the active notation (C / solfège / both)
+        // Chord name(s) in the active notation (C / solfège / both).
         if (blockBounds.getWidth() > 14) {
-            g.setColour(DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
+            const auto& notation = magda::music::NotationSettings::getInstance();
             g.setFont(FontManager::getInstance().getUIFontMedium(13.0f));
-            g.drawText(magda::music::NotationSettings::getInstance().format(annotation.chordName),
-                       blockBounds.withTrimmedLeft(12).withTrimmedRight(4),
-                       juce::Justification::centredLeft, true);
+            if (isChordTrackLane) {
+                // Chord track's own chord: left, with spine.
+                g.setColour(DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
+                g.drawText(notation.format(annotation.chordName),
+                           blockBounds.withTrimmedLeft(12).withTrimmedRight(4),
+                           juce::Justification::centredLeft, true);
+            } else {
+                // MIDI track chord: always right, no decoration.
+                g.setColour(DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
+                g.drawText(notation.format(annotation.chordName),
+                           blockBounds.withTrimmedLeft(8).withTrimmedRight(8),
+                           juce::Justification::centredRight, true);
+                // Intended chord-track chord (overlay only): left, with spine.
+                if (comparing) {
+                    g.setColour(DarkTheme::getColour(DarkTheme::TEXT_SECONDARY));
+                    g.drawText(notation.format(intendedName),
+                               blockBounds.withTrimmedLeft(12).withTrimmedRight(4),
+                               juce::Justification::centredLeft, true);
+                }
+            }
             g.setFont(FontManager::getInstance().getUIFont(11.0f));
         }
 
@@ -1872,45 +1969,9 @@ void PianoRollContent::detectChordsFromNotes() {
     if (auto* controller = magda::TimelineController::getCurrent())
         beatsPerBar = controller->getState().tempo.timeSignatureNumerator;
 
-    // Find the end of the last note (not the full clip length)
-    double lastNoteEnd = 0.0;
-    for (const auto& note : clip->midiNotes)
-        lastNoteEnd = juce::jmax(lastNoteEnd, note.startBeat + note.lengthBeats);
-
-    double scanLength = lastNoteEnd;
-    double step = beatsPerBar;
-
-    // Collect detected chords with their contributing note indices
-    struct DetectedChord {
-        double beat;
-        juce::String name;
-        std::vector<size_t> noteIndices;
-    };
-    std::vector<DetectedChord> detected;
-
-    auto& engine = magda::music::ChordEngine::getInstance();
-    for (double beat = 0.0; beat < scanLength; beat += step) {
-        // Collect notes sounding at this beat
-        std::vector<magda::music::ChordNote> chordNotes;
-        std::vector<size_t> indices;
-        for (size_t i = 0; i < clip->midiNotes.size(); ++i) {
-            const auto& note = clip->midiNotes[i];
-            if (note.startBeat <= beat && (note.startBeat + note.lengthBeats) > beat) {
-                chordNotes.push_back({note.noteNumber, note.velocity});
-                indices.push_back(i);
-            }
-        }
-
-        if (chordNotes.size() < 2)
-            continue;
-
-        auto chord = engine.detect(chordNotes);
-        if (chord.name == "none" || chord.name == "unknown" || chord.name.isEmpty())
-            continue;
-
-        detected.push_back({beat, chord.getDisplayName(), std::move(indices)});
-    }
-
+    // Bar-by-bar detection lives in the shared converter so this and the
+    // "extract to chord track" feature stay in sync.
+    const auto detected = magda::extractChordsFromNotes(clip->midiNotes, beatsPerBar);
     if (detected.empty())
         return;
 
@@ -1923,23 +1984,20 @@ void PianoRollContent::detectChordsFromNotes() {
     // Assign chordGroup IDs to annotations and their notes
     std::vector<std::pair<size_t, int>> noteGroupAssignments;
 
-    for (size_t i = 0; i < detected.size(); ++i) {
+    for (const auto& ex : detected) {
         int groupId = clip->nextChordGroupId++;
 
         magda::ClipInfo::ChordAnnotation annotation;
-        annotation.beatPosition = detected[i].beat;
-        // Extend to next chord or end of last note
-        annotation.lengthBeats = (i + 1 < detected.size())
-                                     ? (detected[i + 1].beat - detected[i].beat)
-                                     : (lastNoteEnd - detected[i].beat);
-        annotation.chordName = detected[i].name;
+        annotation.beatPosition = ex.startBeat;
+        annotation.lengthBeats = ex.lengthBeats;
+        annotation.chordName = ex.name;
         annotation.chordGroup = groupId;
 
         auto cmd = std::make_unique<magda::AddChordAnnotationCommand>(editingClipId_, annotation);
         magda::UndoManager::getInstance().executeCommand(std::move(cmd));
 
         // Collect note-to-group assignments
-        for (size_t noteIdx : detected[i].noteIndices)
+        for (size_t noteIdx : ex.noteIndices)
             noteGroupAssignments.emplace_back(noteIdx, groupId);
     }
 

--- a/magda/daw/ui/panels/content/PianoRollContent.hpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.hpp
@@ -202,6 +202,11 @@ class PianoRollContent : public MidiEditorContent,
     bool showChordRow_ = false;
     bool isSyncingChords_ = false;  // Re-entry guard for syncChordAnnotations
 
+    // Progression overlay (#1504): ghost the chord-track progression behind a
+    // normal track's chord lane for reference. Global toggle, shared across
+    // editors so it stays on as you move between clips.
+    static bool showProgressionOverlay_;
+
     // Initial centering flag
     bool needsInitialCentering_ = true;
 
@@ -213,7 +218,8 @@ class PianoRollContent : public MidiEditorContent,
     std::unique_ptr<magda::SvgButton> takeLanesToggle_;
     std::unique_ptr<magda::SvgButton> chordToggle_;
     std::unique_ptr<magda::SvgButton> chordDetectBtn_;
-    std::unique_ptr<magda::SvgButton> gridToggleBtn_;  // chord mode: show/hide grid
+    std::unique_ptr<magda::SvgButton> progressionOverlayToggle_;  // #1504 ghost overlay
+    std::unique_ptr<magda::SvgButton> gridToggleBtn_;             // chord mode: show/hide grid
     std::unique_ptr<magda::SvgButton> velocityToggle_;
     std::unique_ptr<magda::SvgButton> pitchGlideToggle_;
     std::unique_ptr<magda::SvgButton> ccLanesBtn_;

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
@@ -353,9 +353,14 @@ void ClipInspector::updateFromSelectedClip() {
         } else if (clip->isMidi() && !isMulti) {
             clipKeyLabel_.setVisible(false);
             clipKeyRootCombo_.setVisible(false);
-            saveLibraryButton_.setVisible(true);
+            // Progressions (chord-track clips) have no library model yet, and a
+            // plain MIDI save would silently drop their chords. Hide the button
+            // for them until the progression library lands (see follow-up issues).
+            const bool isProgression =
+                clip->trackId == magda::TrackManager::getInstance().getChordTrackId();
+            saveLibraryButton_.setVisible(!isProgression);
             saveLibraryButton_.setEnabled(
-                magda::ClipManager::getInstance().canSaveClipToLibrary(pid));
+                !isProgression && magda::ClipManager::getInstance().canSaveClipToLibrary(pid));
         } else {
             clipKeyLabel_.setVisible(false);
             clipKeyRootCombo_.setVisible(false);

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -861,6 +861,7 @@ void MainView::masterChannelChanged() {
         masterHeaderPanel->setVisible(masterVisible_);
         masterContentPanel->setVisible(masterVisible_);
         resized();
+        repaint();  // clear the vacated master-strip area (stale-paint fix)
     }
 }
 
@@ -883,6 +884,7 @@ void MainView::viewModeChanged(ViewMode mode, const AudioEngineProfile& /*profil
     tracksChanged();
 
     resized();
+    repaint();  // clear stale pixels from the previous view (song map / grid)
 }
 
 void MainView::paint(juce::Graphics& g) {
@@ -1077,6 +1079,12 @@ void MainView::resized() {
     if (masterVisible_) {
         masterHeaderPanel->setBounds(arrangementLayout.masterHeaderArea);
         masterContentPanel->setBounds(arrangementLayout.masterContentArea);
+    } else {
+        // Clear stale bounds when the master strip is hidden: otherwise the song
+        // map / master header keep their previous-view bounds and can leave a
+        // fragment behind when the view switches.
+        masterHeaderPanel->setBounds({});
+        masterContentPanel->setBounds({});
     }
     // Always-present footer toggle: hide icon when the master is visible, show
     // icon when it's hidden.

--- a/magda/daw/ui/windows/MainWindowMenus.cpp
+++ b/magda/daw/ui/windows/MainWindowMenus.cpp
@@ -681,6 +681,10 @@ void MainWindow::setupMenuCallbacks() {
         MenuManager::getInstance().menuItemsChanged();
         if (mainComponent && mainComponent->mainView) {
             mainComponent->mainView->resized();
+            // The header column swaps sides, but MainView::paint() draws
+            // side-dependent backgrounds; without a repaint the old side keeps
+            // its painted pixels (the stale grid / song-map fragment).
+            mainComponent->mainView->repaint();
         }
     };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -237,6 +237,7 @@ target_sources(magda_juce_tests PRIVATE
     test_automation_modes_juce.cpp
     test_arrangement_transport_loop_juce.cpp
     test_external_plugin_state_restore_juce.cpp
+    test_chord_progression_converter_juce.cpp
 )
 
 # Link required libraries for JUCE tests
@@ -304,6 +305,9 @@ add_test(NAME external_plugin_state_restore_juce
 
 add_test(NAME section_scoped_device_ids_juce
          COMMAND magda_juce_tests "Section-Scoped Device IDs")
+
+add_test(NAME chord_progression_converter_juce
+         COMMAND magda_juce_tests "Chord Progression Converter Tests")
 
 # Both test executables link magda_daw, which links ONNX Runtime. On Windows the
 # loader only searches the exe's directory, the cwd, and PATH, so without a copy

--- a/tests/test_chord_progression_converter_juce.cpp
+++ b/tests/test_chord_progression_converter_juce.cpp
@@ -1,0 +1,157 @@
+#include <juce_core/juce_core.h>
+
+#include <set>
+
+#include "magda/daw/core/ChordProgressionConverter.hpp"
+
+/**
+ * Unit tests for ChordProgressionConverter — the shared logic behind
+ * "Extract chords to chord track" (#1506) and "Send progression as MIDI"
+ * (#1503). Pure functions over MidiNote vectors and chord names; no Edit or
+ * audio engine required.
+ */
+class ChordProgressionConverterTest final : public juce::UnitTest {
+  public:
+    ChordProgressionConverterTest()
+        : juce::UnitTest("Chord Progression Converter Tests", "magda") {}
+
+    static magda::MidiNote note(int pitch, double startBeat, double lengthBeats,
+                                int velocity = 100) {
+        magda::MidiNote n;
+        n.noteNumber = pitch;
+        n.startBeat = startBeat;
+        n.lengthBeats = lengthBeats;
+        n.velocity = velocity;
+        return n;
+    }
+
+    static std::set<int> pitchClasses(const std::vector<magda::MidiNote>& notes) {
+        std::set<int> pcs;
+        for (const auto& n : notes)
+            pcs.insert(((n.noteNumber % 12) + 12) % 12);
+        return pcs;
+    }
+
+    void runTest() override {
+        using namespace magda;
+        using magda::music::ChordQuality;
+        using magda::music::ChordRoot;
+
+        beginTest("buildVoicingNotes: C major triad at octave 4");
+        {
+            auto notes = buildVoicingNotes(ChordRoot::C, ChordQuality::Major, 0.0, 4.0, 100, 4);
+            expectEquals((int)notes.size(), 3);
+            // ChordRoot::C == 0 -> root midi note 60, plus major third + fifth.
+            expectEquals(notes[0].noteNumber, 60);
+            expect(pitchClasses(notes) == std::set<int>({0, 4, 7}), "C major pitch classes");
+            for (const auto& n : notes) {
+                expectWithinAbsoluteError(n.startBeat, 0.0, 1e-9);
+                expectWithinAbsoluteError(n.lengthBeats, 4.0, 1e-9);
+                expectEquals(n.velocity, 100);
+                expectEquals(n.chordGroup, 0);  // caller links; converter leaves unlinked
+            }
+        }
+
+        beginTest("buildVoicingNotes: minor and seventh chords");
+        {
+            auto am = buildVoicingNotes(ChordRoot::A, ChordQuality::Minor, 8.0, 2.0, 90, 4);
+            expect(pitchClasses(am) == std::set<int>({9, 0, 4}), "A minor pitch classes");
+            for (const auto& n : am) {
+                expectWithinAbsoluteError(n.startBeat, 8.0, 1e-9);
+                expectWithinAbsoluteError(n.lengthBeats, 2.0, 1e-9);
+                expectEquals(n.velocity, 90);
+            }
+
+            auto cmaj7 = buildVoicingNotes(ChordRoot::C, ChordQuality::Major7, 0.0, 4.0, 100, 4);
+            expectEquals((int)cmaj7.size(), 4);
+            expect(pitchClasses(cmaj7) == std::set<int>({0, 4, 7, 11}), "Cmaj7 pitch classes");
+        }
+
+        beginTest("buildVoicingNotes: non-C roots are not collapsed (regression)");
+        {
+            // Regression for the octave-bearing-name bug: a G chord must voice G,
+            // not C. ChordRoot::G == 7 -> root midi note 67 at octave 4.
+            auto g = buildVoicingNotes(ChordRoot::G, ChordQuality::Major, 0.0, 4.0, 100, 4);
+            expectEquals(g[0].noteNumber, 67);
+            expect(pitchClasses(g) == std::set<int>({7, 11, 2}), "G major pitch classes");
+
+            auto f = buildVoicingNotes(ChordRoot::F, ChordQuality::Major, 0.0, 4.0, 100, 4);
+            expect(pitchClasses(f) == std::set<int>({5, 9, 0}), "F major pitch classes");
+        }
+
+        beginTest("buildVoicingNotes: octave parameter shifts the root");
+        {
+            auto c3 = buildVoicingNotes(ChordRoot::C, ChordQuality::Major, 0.0, 4.0, 100, 3);
+            auto c4 = buildVoicingNotes(ChordRoot::C, ChordQuality::Major, 0.0, 4.0, 100, 4);
+            expectEquals(c4[0].noteNumber - c3[0].noteNumber, 12);
+        }
+
+        beginTest("extractChordsFromNotes: two block chords, one per bar");
+        {
+            std::vector<MidiNote> notes;
+            // Bar 0: C major (full bar). Bar 4: G major (full bar). 4 beats/bar.
+            for (int p : {60, 64, 67})
+                notes.push_back(note(p, 0.0, 4.0));
+            for (int p : {67, 71, 74})
+                notes.push_back(note(p, 4.0, 4.0));
+
+            auto chords = extractChordsFromNotes(notes, 4);
+            expectEquals((int)chords.size(), 2);
+            expectWithinAbsoluteError(chords[0].startBeat, 0.0, 1e-9);
+            expectWithinAbsoluteError(chords[0].lengthBeats, 4.0, 1e-9);
+            expectWithinAbsoluteError(chords[1].startBeat, 4.0, 1e-9);
+            expectWithinAbsoluteError(chords[1].lengthBeats, 4.0, 1e-9);
+            expectEquals((int)chords[0].noteIndices.size(), 3);
+            expectEquals((int)chords[1].noteIndices.size(), 3);
+            // The detected root is exposed as an enum (no display-name re-parsing).
+            expect(chords[0].root == ChordRoot::C, "bar 0 is C");
+            expect(chords[1].root == ChordRoot::G, "bar 4 is G");
+        }
+
+        beginTest("extractChordsFromNotes: length extends to the next chord across a gap");
+        {
+            std::vector<MidiNote> notes;
+            for (int p : {60, 64, 67})
+                notes.push_back(note(p, 0.0, 4.0));  // bar 0
+            for (int p : {67, 71, 74})
+                notes.push_back(note(p, 8.0, 4.0));  // bar 8 (bar 4 empty)
+
+            auto chords = extractChordsFromNotes(notes, 4);
+            expectEquals((int)chords.size(), 2);
+            // First chord stretches over the empty bar to the next chord's start.
+            expectWithinAbsoluteError(chords[0].lengthBeats, 8.0, 1e-9);
+            // Last chord runs to the end of its notes.
+            expectWithinAbsoluteError(chords[1].startBeat, 8.0, 1e-9);
+            expectWithinAbsoluteError(chords[1].lengthBeats, 4.0, 1e-9);
+        }
+
+        beginTest("extractChordsFromNotes: a lone note is not a chord");
+        {
+            std::vector<MidiNote> notes{note(60, 0.0, 4.0)};
+            expect(extractChordsFromNotes(notes, 4).empty(), "single note -> no chord");
+        }
+
+        beginTest("extractChordsFromNotes: empty input yields nothing");
+        { expect(extractChordsFromNotes({}, 4).empty(), "no notes -> no chords"); }
+
+        beginTest("round-trip: build a voicing, detect it back to the same root");
+        {
+            const std::pair<ChordRoot, const char*> cases[] = {{ChordRoot::C, "C"},
+                                                               {ChordRoot::A, "Am"},
+                                                               {ChordRoot::G, "G"},
+                                                               {ChordRoot::D, "Dm"},
+                                                               {ChordRoot::F, "F"}};
+            for (const auto& [root, label] : cases) {
+                const auto quality =
+                    juce::String(label).endsWith("m") ? ChordQuality::Minor : ChordQuality::Major;
+                auto voicing = buildVoicingNotes(root, quality, 0.0, 4.0, 100, 4);
+                auto detected = extractChordsFromNotes(voicing, 4);
+                expectEquals((int)detected.size(), 1, juce::String("one chord for ") + label);
+                if (!detected.empty())
+                    expect(detected[0].root == root, juce::String("root round-trips for ") + label);
+            }
+        }
+    }
+};
+
+static ChordProgressionConverterTest chordProgressionConverterTest;


### PR DESCRIPTION
## Chord track follow-ups

- Extract chords from a MIDI clip onto the chord track (append / replace).
- Send a chord-track progression onto a regular track as a plain MIDI clip (voicings baked into notes, chord annotations stripped).
- Chord-track overlay on a normal track's chord lane: chord-track chord on the left with the accent spine, MIDI-track chord on the right. The agree/disagree comparison signal is deferred to #1513.
- Hide Save-to-Library for progression clips until a library model exists (#1511, #1512).
- Shared `ChordProgressionConverter` + JUCE unit tests; fixes a voicing bug where octave-bearing display names parsed non-C roots back to C.

Also bundled (unrelated UI fixes that came up while testing):

- Alt-drag duplicate ghost now follows the mouse onto the target track instead of staying on the source lane (all clip types).
- Arrangement repaint on the "headers on the right" View-menu toggle and the master-strip hide, fixing stale-pixel fragments.

Closes #1506
Closes #1503

Partially addresses #1504 (overlay shipped; the comparison signal is tracked in #1513).
