### PR TITLE
MIDI editor: timeline on top, playhead over chord blocks (#1527)

### DIFF
--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -344,34 +344,11 @@ void PianoRollGridComponent::paint(juce::Graphics& g) {
     }
 
     // Draw playhead line if playing
-    if (playheadPosition_ >= 0.0 && clipLengthBeats_ > 0.0) {
-        // Convert seconds to beats
-        double tempo = 120.0;
-        if (auto* controller = TimelineController::getCurrent()) {
-            tempo = controller->getState().tempo.bpm;
-        }
-        double secondsPerBeat = 60.0 / tempo;
-        double playheadBeats = playheadPosition_ / secondsPerBeat;
-
-        // Only draw when playhead falls within the clip's time range
-        double relBeat = playheadBeats - clipStartBeats_;
-        if (relBeat >= 0.0 && relBeat <= clipLengthBeats_) {
-            double displayBeat = relativeMode_ ? (playheadBeats - clipStartBeats_) : playheadBeats;
-
-            // Wrap playhead within loop region when looping is enabled
-            if (loopEnabled_ && loopLengthBeats_ > 0.0) {
-                double beatPos = relativeMode_ ? displayBeat : (displayBeat - clipStartBeats_);
-                beatPos = std::fmod(beatPos, loopLengthBeats_);
-                if (beatPos < 0.0)
-                    beatPos += loopLengthBeats_;
-                displayBeat = relativeMode_ ? beatPos : (clipStartBeats_ + beatPos);
-            }
-
-            int playheadX = beatToPixel(displayBeat);
-            if (playheadX >= 0 && playheadX <= bounds.getRight()) {
-                g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_BLUE));
-                g.fillRect(playheadX - 1, 0, 2, bounds.getHeight());
-            }
+    {
+        int playheadX = 0;
+        if (getPlayheadDisplayX(playheadX) && playheadX >= 0 && playheadX <= bounds.getRight()) {
+            g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_BLUE));
+            g.fillRect(playheadX - 1, 0, 2, bounds.getHeight());
         }
     }
 
@@ -2528,6 +2505,37 @@ void PianoRollGridComponent::setPlayheadPosition(double positionSeconds) {
         playheadPosition_ = positionSeconds;
         repaint();
     }
+}
+
+bool PianoRollGridComponent::getPlayheadDisplayX(int& gridLocalX) const {
+    if (playheadPosition_ < 0.0 || clipLengthBeats_ <= 0.0)
+        return false;
+
+    // Convert seconds to beats
+    double tempo = 120.0;
+    if (auto* controller = TimelineController::getCurrent())
+        tempo = controller->getState().tempo.bpm;
+    double secondsPerBeat = 60.0 / tempo;
+    double playheadBeats = playheadPosition_ / secondsPerBeat;
+
+    // Only visible when the playhead falls within the clip's time range
+    double relBeat = playheadBeats - clipStartBeats_;
+    if (relBeat < 0.0 || relBeat > clipLengthBeats_)
+        return false;
+
+    double displayBeat = relativeMode_ ? (playheadBeats - clipStartBeats_) : playheadBeats;
+
+    // Wrap playhead within loop region when looping is enabled
+    if (loopEnabled_ && loopLengthBeats_ > 0.0) {
+        double beatPos = relativeMode_ ? displayBeat : (displayBeat - clipStartBeats_);
+        beatPos = std::fmod(beatPos, loopLengthBeats_);
+        if (beatPos < 0.0)
+            beatPos += loopLengthBeats_;
+        displayBeat = relativeMode_ ? beatPos : (clipStartBeats_ + beatPos);
+    }
+
+    gridLocalX = beatToPixel(displayBeat);
+    return true;
 }
 
 void PianoRollGridComponent::setEditCursorPosition(double positionSeconds, bool blinkVisible) {

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.hpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.hpp
@@ -172,6 +172,11 @@ class PianoRollGridComponent : public juce::Component,
     double getPlayheadPosition() const {
         return playheadPosition_;
     }
+    // Grid-local x of the playhead exactly as drawn over the note grid (incl.
+    // loop wrap / relative-mode mapping). Lets the chord lane above the grid
+    // draw a matching playhead line that stays locked while scrolling. Returns
+    // false when the playhead is out of the clip's range (nothing to draw).
+    bool getPlayheadDisplayX(int& gridLocalX) const;
 
     // Edit cursor position (for drawing blinking edit cursor line)
     void setEditCursorPosition(double positionSeconds, bool blinkVisible);

--- a/magda/daw/ui/panels/content/ChordClipContent.cpp
+++ b/magda/daw/ui/panels/content/ChordClipContent.cpp
@@ -215,8 +215,9 @@ void ChordClipContent::onGridToggleClicked() {
 }
 
 bool ChordClipContent::isOnLaneDivider(juce::Point<int> p) const {
-    // The divider sits at the bottom edge of the chord lane (above the ruler).
-    return std::abs(p.y - laneHeight_) <= DIVIDER_HIT;
+    // The divider sits at the bottom edge of the chord lane (the ruler is above
+    // the lane, so the lane starts at chordRowTop()).
+    return std::abs(p.y - (chordRowTop() + laneHeight_)) <= DIVIDER_HIT;
 }
 
 int ChordClipContent::annotationIndexAtBeat(double beat) const {
@@ -365,7 +366,7 @@ void ChordClipContent::mouseMove(const juce::MouseEvent& e) {
         setMouseCursor(juce::MouseCursor::UpDownResizeCursor);
         return;
     }
-    if (e.y < chordRowHeight() && e.x >= chordLaneLeftX()) {
+    if (e.y >= chordRowTop() && e.y < chordRowTop() + chordRowHeight() && e.x >= chordLaneLeftX()) {
         const int idx = annotationIndexAtBeat(chordRowBeatForX(e.x));
         if (idx >= 0) {
             const auto mode = dragModeForBlock(idx, e.x);
@@ -386,7 +387,7 @@ void ChordClipContent::mouseDown(const juce::MouseEvent& e) {
         draggingDivider_ = true;
         return;
     }
-    if (e.y < chordRowHeight() && e.x >= chordLaneLeftX()) {
+    if (e.y >= chordRowTop() && e.y < chordRowTop() + chordRowHeight() && e.x >= chordLaneLeftX()) {
         const int idx = annotationIndexAtBeat(chordRowBeatForX(e.x));
         if (idx >= 0) {
             grabKeyboardFocus();  // so Delete removes the chord, not the clip
@@ -411,7 +412,7 @@ void ChordClipContent::mouseDown(const juce::MouseEvent& e) {
 
 void ChordClipContent::mouseDrag(const juce::MouseEvent& e) {
     if (draggingDivider_) {
-        laneHeight_ = juce::jlimit(MIN_LANE_HEIGHT, maxLaneHeight(), e.y);
+        laneHeight_ = juce::jlimit(MIN_LANE_HEIGHT, maxLaneHeight(), e.y - chordRowTop());
         resized();
         repaint();
         return;
@@ -449,7 +450,7 @@ void ChordClipContent::paintOverChildren(juce::Graphics& g) {
     if (x2 <= x1)
         return;
 
-    const juce::Rectangle<int> ghost(x1 + 1, 2, x2 - x1 - 2, chordRowHeight() - 4);
+    const juce::Rectangle<int> ghost(x1 + 1, chordRowTop() + 2, x2 - x1 - 2, chordRowHeight() - 4);
     const auto accent = DarkTheme::getColour(DarkTheme::ACCENT_BLUE);
     g.setColour(accent.withAlpha(0.22f));
     g.fillRoundedRectangle(ghost.toFloat(), 4.0f);
@@ -483,7 +484,7 @@ void ChordClipContent::mouseUp(const juce::MouseEvent& e) {
 }
 
 void ChordClipContent::mouseDoubleClick(const juce::MouseEvent& e) {
-    if (e.y < chordRowHeight() && e.x >= chordLaneLeftX()) {
+    if (e.y >= chordRowTop() && e.y < chordRowTop() + chordRowHeight() && e.x >= chordLaneLeftX()) {
         const int idx = annotationIndexAtBeat(chordRowBeatForX(e.x));
         if (idx >= 0) {
             openChordEditor(idx);
@@ -516,7 +517,8 @@ void ChordClipContent::openChordEditor(int annIndex) {
     const double bar = ann.beatPosition;
     const int x1 = chordRowXForBeat(ann.beatPosition);
     const int x2 = chordRowXForBeat(ann.beatPosition + ann.lengthBeats);
-    const juce::Rectangle<int> blockLocal(x1, 2, std::max(20, x2 - x1), chordRowHeight() - 4);
+    const juce::Rectangle<int> blockLocal(x1, chordRowTop() + 2, std::max(20, x2 - x1),
+                                          chordRowHeight() - 4);
     const auto screenArea = localAreaToGlobal(blockLocal);
 
     auto popup =
@@ -745,7 +747,7 @@ bool ChordClipContent::isInterestedInFileDrag(const juce::StringArray& files) {
 
 void ChordClipContent::filesDropped(const juce::StringArray& files, int x, int y) {
     // Only the chord lane accepts chord drops.
-    if (y >= chordRowHeight())
+    if (y < chordRowTop() || y >= chordRowTop() + chordRowHeight())
         return;
 
     for (const auto& f : files) {

--- a/magda/daw/ui/panels/content/PianoRollContent.cpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.cpp
@@ -805,6 +805,10 @@ void PianoRollContent::setGridPixelsPerBeat(double ppb) {
 void PianoRollContent::setGridPlayheadPosition(double position) {
     if (gridComponent_)
         gridComponent_->setPlayheadPosition(position);
+    // The chord-band playhead is painted by this component (over the chord row),
+    // so repaint that strip to keep it in step with the grid's playhead.
+    if (showChordRow_)
+        repaint(chordLaneLeftX(), chordRowTop(), getWidth() - chordLaneLeftX(), chordRowHeight());
 }
 
 void PianoRollContent::setGridEditCursorPosition(double pos, bool visible) {
@@ -856,18 +860,19 @@ void PianoRollContent::paint(juce::Graphics& g) {
         drawSidebar(g, sidebarArea);
     }
 
-    // Draw chord row at the top (if visible)
+    // Draw chord row below the ruler (if visible)
     if (showChordRow_) {
         auto chordArea = getLocalBounds();
         chordArea.removeFromLeft(sidebarWidth());
+        chordArea.removeFromTop(chordRowTop());  // ruler occupies the top band
         chordArea = chordArea.removeFromTop(chordRowHeight());
         chordArea.removeFromLeft(ZOOM_STRIP_WIDTH + OCTAVE_LABEL_WIDTH + KEYBOARD_WIDTH);
         drawChordRow(g, chordArea);
 
         // Horizontal separator at bottom of chord row — full width
         g.setColour(DarkTheme::getColour(DarkTheme::BORDER));
-        g.drawHorizontalLine(chordRowHeight() - 1, static_cast<float>(sidebarWidth()),
-                             static_cast<float>(getWidth()));
+        g.drawHorizontalLine(chordRowTop() + chordRowHeight() - 1,
+                             static_cast<float>(sidebarWidth()), static_cast<float>(getWidth()));
     }
 
     // Draw velocity drawer header (if open) — only for legacy path without MidiDrawer
@@ -881,12 +886,26 @@ void PianoRollContent::paint(juce::Graphics& g) {
 }
 
 void PianoRollContent::paintOverChildren(juce::Graphics& g) {
-    // Extend the ruler's tick-area border line through the sidebar/keyboard corner
-    int rulerTop = showChordRow_ ? chordRowHeight() : 0;
-    int tickLineY = rulerTop + RULER_HEIGHT - LayoutConfig::getInstance().rulerMajorTickHeight;
+    // The ruler now sits at the very top; extend its tick-area border line
+    // through the sidebar/keyboard corner.
+    int tickLineY = RULER_HEIGHT - LayoutConfig::getInstance().rulerMajorTickHeight;
     g.setColour(DarkTheme::getColour(DarkTheme::BORDER));
     g.fillRect(sidebarWidth(), tickLineY, ZOOM_STRIP_WIDTH + OCTAVE_LABEL_WIDTH + KEYBOARD_WIDTH,
                1);
+
+    // Playhead over the chord blocks. The grid only draws the playhead across
+    // the note grid, so mirror it in the chord-row band using the exact x the
+    // grid drew (incl. loop wrap) so the two stay locked while scrolling.
+    if (showChordRow_ && gridComponent_ && viewport_) {
+        int gridX = 0;
+        if (gridComponent_->getPlayheadDisplayX(gridX)) {
+            const int contentX = viewport_->getX() + gridX - viewport_->getViewPositionX();
+            if (contentX >= chordLaneLeftX() && contentX <= getWidth()) {
+                g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_BLUE));
+                g.fillRect(contentX - 1, chordRowTop(), 2, chordRowHeight());
+            }
+        }
+    }
 }
 
 void PianoRollContent::resized() {
@@ -900,8 +919,8 @@ void PianoRollContent::resized() {
     const bool hasSidebar = sidebarWidth() > 0;
     int iconSize = 22;
     int padding = (sidebarWidth() - iconSize) / 2;
-    // Chord toggle at top of sidebar — vertically centered in chord row height
-    int chordToggleY = showChordRow_ ? (chordRowHeight() - iconSize) / 2 : padding;
+    // Chord toggle in the sidebar — vertically centered in the chord-row band
+    int chordToggleY = showChordRow_ ? chordRowTop() + (chordRowHeight() - iconSize) / 2 : padding;
     chordToggle_->setVisible(hasSidebar);
     chordToggle_->setBounds(padding, chordToggleY, iconSize, iconSize);
     // Fold toggle directly below the chord toggle
@@ -933,7 +952,14 @@ void PianoRollContent::resized() {
     pitchGlideToggle_->setBounds(padding, getHeight() - 3 * (iconSize + padding), iconSize,
                                  iconSize);
 
-    // Skip chord row space if visible (drawn in paint)
+    // Ruler row at the very top, above the chord lane.
+    {
+        auto rulerArea = bounds.removeFromTop(RULER_HEIGHT);
+        rulerArea.removeFromLeft(ZOOM_STRIP_WIDTH + OCTAVE_LABEL_WIDTH + KEYBOARD_WIDTH);
+        timeRuler_->setBounds(rulerArea);
+    }
+
+    // Chord lane sits directly below the ruler (drawn in paint).
     if (showChordRow_) {
         bounds.removeFromTop(chordRowHeight());
         const int detectSize = 18;
@@ -955,19 +981,19 @@ void PianoRollContent::resized() {
         progressionOverlayToggle_->setActive(showProgressionOverlay_);
 
         if (chordMode) {
-            // Grid show/hide toggle: right side of the ruler row, just below the
-            // chord lane (the ruler stays visible when the grid is hidden).
+            // Grid show/hide toggle: right side of the ruler row at the top (the
+            // ruler stays visible when the grid is hidden).
             const int gridSize = 14;
             const int rightMargin = 6;
             const int gx = chordLaneLeftX() - gridSize - rightMargin;
-            const int gy = chordRowHeight() + (RULER_HEIGHT - gridSize) / 2;
+            const int gy = (RULER_HEIGHT - gridSize) / 2;
             gridToggleBtn_->setBounds(gx, gy, gridSize, gridSize);
             gridToggleBtn_->setActive(gridShown());  // accent when the grid is visible
         } else {
             // Rescan button: keyboard column, vertically centred in the chord row.
             const int detectX =
                 sidebarWidth() + ZOOM_STRIP_WIDTH + (KEYBOARD_WIDTH - detectSize) / 2;
-            const int detectY = (chordRowHeight() - detectSize) / 2;
+            const int detectY = chordRowTop() + (chordRowHeight() - detectSize) / 2;
             chordDetectBtn_->setBounds(detectX, detectY, detectSize, detectSize);
             if (overlayApplies)
                 progressionOverlayToggle_->setBounds(detectX + detectSize + 2, detectY, detectSize,
@@ -1019,11 +1045,6 @@ void PianoRollContent::resized() {
         takeLanes_->setVisible(false);
     }
 
-    // Ruler row
-    auto headerArea = bounds.removeFromTop(RULER_HEIGHT);
-    headerArea.removeFromLeft(ZOOM_STRIP_WIDTH + OCTAVE_LABEL_WIDTH + KEYBOARD_WIDTH);
-    timeRuler_->setBounds(headerArea);
-
     auto zoomStripArea = bounds.removeFromLeft(ZOOM_STRIP_WIDTH);
     verticalZoomStrip_->setBounds(zoomStripArea);
 
@@ -1058,7 +1079,7 @@ void PianoRollContent::resized() {
 void PianoRollContent::mouseDown(const juce::MouseEvent& e) {
     // Chord lane click: offer it to the subclass hook (chord-clip add). The
     // standard piano roll's hook returns false, so the event falls through.
-    if (showChordRow_ && e.y < chordRowHeight()) {
+    if (showChordRow_ && e.y >= chordRowTop() && e.y < chordRowTop() + chordRowHeight()) {
         const int leftPanelWidth =
             sidebarWidth() + ZOOM_STRIP_WIDTH + OCTAVE_LABEL_WIDTH + KEYBOARD_WIDTH;
         if (e.x >= leftPanelWidth && horizontalZoom_ > 0.0) {
@@ -1119,8 +1140,9 @@ void PianoRollContent::mouseWheelMove(const juce::MouseEvent& e,
     const auto gesture = magda::GestureRouter::getInstance().resolve(
         magda::GestureContext::PianoRoll, wheel, e.mods, e.getPosition());
 
-    // Check if mouse is over the chord row area (very top, only when visible)
-    if (showChordRow_ && e.y < chordRowHeight() && e.x >= leftPanelWidth) {
+    // Check if mouse is over the chord row band (below the ruler, when visible)
+    if (showChordRow_ && e.y >= chordRowTop() && e.y < chordRowTop() + chordRowHeight() &&
+        e.x >= leftPanelWidth) {
         if (gesture.type == magda::GestureActionType::ScrollHorizontal &&
             timeRuler_->onScrollRequested) {
             int scrollAmount = static_cast<int>(-gesture.magnitude);
@@ -1130,9 +1152,8 @@ void PianoRollContent::mouseWheelMove(const juce::MouseEvent& e,
         return;
     }
 
-    // Check if mouse is over the time ruler area
-    int rulerTop = showChordRow_ ? chordRowHeight() : 0;
-    if (e.y >= rulerTop && e.y < headerHeight && e.x >= leftPanelWidth) {
+    // Check if mouse is over the time ruler area (very top)
+    if (e.y < RULER_HEIGHT && e.x >= leftPanelWidth) {
         if (gesture.type == magda::GestureActionType::ScrollHorizontal &&
             timeRuler_->onScrollRequested) {
             int scrollAmount = static_cast<int>(-gesture.magnitude);
@@ -1741,7 +1762,8 @@ void PianoRollContent::drawSidebar(juce::Graphics& g, juce::Rectangle<int> area)
     // velocity). Layout mirrors resized() so the lines sit in the gaps.
     const int iconSize = 22;
     const int padding = (sidebarWidth() - iconSize) / 2;
-    const int chordToggleY = showChordRow_ ? (chordRowHeight() - iconSize) / 2 : padding;
+    const int chordToggleY =
+        showChordRow_ ? chordRowTop() + (chordRowHeight() - iconSize) / 2 : padding;
 
     int topClusterBottom = chordToggleY + iconSize;  // chord only
     if (foldToggle_)

--- a/magda/daw/ui/panels/content/PianoRollContent.hpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.hpp
@@ -138,6 +138,11 @@ class PianoRollContent : public MidiEditorContent,
     int chordLaneLeftX() const {
         return sidebarWidth() + ZOOM_STRIP_WIDTH + OCTAVE_LABEL_WIDTH + KEYBOARD_WIDTH;
     }
+    // Top y of the chord lane. The ruler sits at the very top, so the chord lane
+    // (when visible) starts just below it; 0 when the chord row is hidden.
+    int chordRowTop() const {
+        return showChordRow_ ? RULER_HEIGHT : 0;
+    }
     // Called when the chord lane is clicked at the given clip-relative beat.
     // Return true to consume the click (the standard piano roll returns false so
     // the event falls through to the base handler). ChordClipContent uses this


### PR DESCRIPTION
Reorder the piano-roll layout to ruler -> chord lane -> grid (the more standard layout) and sweep the playhead across the chord blocks too.

- Ruler now anchored at the top; chord lane re-anchored to a new chordRowTop() (RULER_HEIGHT when shown, else 0) across paint, resized, the sidebar/detect/grid-toggle buttons, the separator and the mouse hit-tests in PianoRollContent and ChordClipContent.
- PianoRollGridComponent exposes getPlayheadDisplayX() so the chord lane draws a matching playhead line, pixel-locked to the grid (incl. loop wrap) while scrolling.