### PR TITLE
Poly Sequencer: zoomable grid, step ruler, chord-strum time bend, step record

### DIFF
--- a/magda/daw/audio/plugins/PolyStepSequencerPlugin.cpp
+++ b/magda/daw/audio/plugins/PolyStepSequencerPlugin.cpp
@@ -332,6 +332,39 @@ void PolyStepSequencerPlugin::clearPattern() {
     }
 }
 
+void PolyStepSequencerPlugin::setStepRecording(bool enabled) {
+    stepRecording_.store(enabled, std::memory_order_relaxed);
+    if (enabled) {
+        stepRecordPosition_.store(0, std::memory_order_relaxed);
+        recordHeldCount_ = 0;
+    }
+}
+
+void PolyStepSequencerPlugin::randomizePattern() {
+    juce::Random rng;
+    auto* um = getUndoManager();
+    if (um != nullptr)
+        um->beginNewTransaction();
+
+    // Clear existing steps first.
+    for (int i = state.getNumChildren() - 1; i >= 0; --i) {
+        if (state.getChild(i).hasType(PSeqIDs::stepTree))
+            state.removeChild(i, um);
+    }
+
+    const int stepCount = juce::jlimit(1, MAX_STEPS, numSteps.get());
+    for (int i = 0; i < stepCount; ++i) {
+        const bool gate = rng.nextFloat() < 0.7f;
+        getOrCreateStepTree(i).setProperty(PSeqIDs::stepGate, gate, um);
+        if (!gate)
+            continue;
+        // 1-3 notes per active step, C2-B3 (addStepNote dedups + caps voices).
+        const int noteCount = 1 + rng.nextInt(3);
+        for (int n = 0; n < noteCount; ++n)
+            addStepNote(i, 36 + rng.nextInt(24));
+    }
+}
+
 bool PolyStepSequencerPlugin::transposePattern(int semitones) {
     if (semitones == 0)
         return true;
@@ -435,6 +468,33 @@ void PolyStepSequencerPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
     if (needsAllNotesOff_) {
         midi.addMidiMessage(juce::MidiMessage::allNotesOff(1), 0.0, te::MPESourceID{});
         needsAllNotesOff_ = false;
+    }
+
+    // --- Step recording: held notes form a chord on the current step; the
+    // step advances once the whole chord is released. ---
+    if (stepRecording_.load(std::memory_order_relaxed)) {
+        const int maxSteps = juce::jlimit(1, MAX_STEPS, numSteps.get());
+        for (auto& msg : midi) {
+            if (msg.isNoteOn()) {
+                const int pos = stepRecordPosition_.load(std::memory_order_relaxed);
+                if (pos < maxSteps) {
+                    const int note = msg.getNoteNumber();
+                    juce::MessageManager::callAsync([this, pos, note] {
+                        addStepNote(pos, note);
+                        setStepGate(pos, true);
+                    });
+                }
+                ++recordHeldCount_;
+            } else if (msg.isNoteOff()) {
+                if (recordHeldCount_ > 0)
+                    --recordHeldCount_;
+                if (recordHeldCount_ == 0) {
+                    const int pos = stepRecordPosition_.load(std::memory_order_relaxed);
+                    if (pos < maxSteps)
+                        stepRecordPosition_.store(pos + 1, std::memory_order_relaxed);
+                }
+            }
+        }
     }
 
     // Save incoming MIDI for thru, then clear for sequencer output

--- a/magda/daw/audio/plugins/PolyStepSequencerPlugin.hpp
+++ b/magda/daw/audio/plugins/PolyStepSequencerPlugin.hpp
@@ -121,8 +121,21 @@ class PolyStepSequencerPlugin : public MidiDevicePlugin {
     /** Remove all steps from the pattern in one undo transaction. */
     void clearPattern();
 
+    /** Replace the pattern with a simple random one: ~70% gates, 1-3 notes per
+     *  active step across two octaves (C2-B3). Single undo transaction. A
+     *  musically-aware variant (scale/chord heuristics) can replace this later. */
+    void randomizePattern();
+
     /** Current playback step index for UI highlight (-1 if not playing). */
     std::atomic<int> currentPlayStep_{-1};
+
+    // --- Step recording: play notes to fill steps. A chord (notes held
+    // together) lands on one step; the step advances when the chord releases.
+    bool isStepRecording() const {
+        return stepRecording_.load(std::memory_order_relaxed);
+    }
+    void setStepRecording(bool enabled);
+    std::atomic<int> stepRecordPosition_{0};  // next step to write (UI highlight)
 
   private:
     // Step clock (handles timing, transport, swing, direction)
@@ -130,6 +143,10 @@ class PolyStepSequencerPlugin : public MidiDevicePlugin {
 
     // --- Step state (mirrored from ValueTree, read on audio thread) ---
     std::array<Step, MAX_STEPS> steps_{};
+
+    // --- Step recording state ---
+    std::atomic<bool> stepRecording_{false};
+    int recordHeldCount_ = 0;  // notes currently held during recording (audio thread)
 
     // --- Audio-thread state ---
     std::array<int, MAX_NOTES_PER_STEP> soundingNotes_{};

--- a/magda/daw/core/MidiNoteCommands.cpp
+++ b/magda/daw/core/MidiNoteCommands.cpp
@@ -39,24 +39,48 @@ std::vector<MidiNoteStartBeat> calculateBentMidiNoteStartBeats(
     if (validStarts.size() < 2)
         return {};
 
-    double minBeat = std::numeric_limits<double>::max();
-    double maxBeat = std::numeric_limits<double>::lowest();
-    for (const auto& start : validStarts) {
-        minBeat = std::min(minBeat, start.startBeat);
-        maxBeat = std::max(maxBeat, start.startBeat);
+    // Order the selection as a sequence of events: by onset, then by pitch so a
+    // chord strums low -> high. Each note then samples the curve at its own
+    // ordinal slot, so notes stacked on one onset (a chord) fan out in time
+    // instead of moving as a rigid block.
+    std::sort(validStarts.begin(), validStarts.end(),
+              [&clip](const MidiNoteStartBeat& a, const MidiNoteStartBeat& b) {
+                  if (a.startBeat != b.startBeat)
+                      return a.startBeat < b.startBeat;
+                  return clip.midiNotes[a.noteIndex].noteNumber <
+                         clip.midiNotes[b.noteIndex].noteNumber;
+              });
+
+    const double minBeat = validStarts.front().startBeat;
+    const double maxBeat = validStarts.back().startBeat;
+    double span = maxBeat - minBeat;
+
+    // Lone chord (all notes share an onset): no grid to warp, so give the strum
+    // a window to spread into, derived from the shortest selected note so it
+    // scales with the part rather than a fixed amount.
+    if (span < 1e-9) {
+        double minLen = std::numeric_limits<double>::max();
+        for (const auto& start : validStarts)
+            minLen = std::min(minLen, clip.midiNotes[start.noteIndex].lengthBeats);
+        if (minLen >= std::numeric_limits<double>::max() || minLen < 1e-9)
+            return {};
+        span = minLen;
     }
 
-    const double span = maxBeat - minBeat;
-    if (span < 1e-9)
-        return {};
+    const int noteCount = static_cast<int>(validStarts.size());
+    const double ordinalDenom = static_cast<double>(noteCount - 1);
 
     std::vector<MidiNoteStartBeat> bentStarts;
     bentStarts.reserve(validStarts.size());
-    for (const auto& start : validStarts) {
-        const double t = (start.startBeat - minBeat) / span;
+    for (int i = 0; i < noteCount; ++i) {
+        const auto& start = validStarts[static_cast<size_t>(i)];
+        const double t = static_cast<double>(i) / ordinalDenom;
         const double tEased =
             daw::audio::StepClock::applyRampCurveWithCycles(t, depth, skew, cycles, hardAngle);
-        double newBeat = minBeat + tEased * span;
+        // Shift each note by how far the curve pushes its ordinal slot, anchored
+        // on its true onset. Depth 0 -> tEased == t -> identity; a uniform mono
+        // line reduces to minBeat + curve(t) * span (the prior behaviour).
+        double newBeat = start.startBeat + (tEased - t) * span;
 
         if (quantize > 0.0f && quantizeSub > 0) {
             const double gridSpacing = span / static_cast<double>(quantizeSub);

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -10,6 +10,7 @@
 #include "audio/plugins/FaustPlugin.hpp"
 #include "audio/plugins/MagdaSamplerPlugin.hpp"
 #include "audio/plugins/OscilloscopePlugin.hpp"
+#include "audio/plugins/PolyStepSequencerPlugin.hpp"
 #include "audio/plugins/SpectrumAnalyzerPlugin.hpp"
 #include "core/Config.hpp"
 #include "core/InternalDeviceKind.hpp"
@@ -465,6 +466,64 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
         addAndMakeVisible(*exportClipButton_);
     }
 
+    // Randomize-pattern button in the header (next to the AI button). Lives at
+    // the slot level so it sits in the header chrome rather than the step
+    // sequencer's body. Shared by the mono and poly step sequencers.
+    if (traits_.isStepSequencer || traits_.isPolyStepSequencer) {
+        randomButton_ = std::make_unique<magda::SvgButton>("Random", BinaryData::random_svg,
+                                                           BinaryData::random_svgSize);
+        applyHeaderIconStyle(*randomButton_, DarkTheme::getColour(DarkTheme::ACCENT_BLUE),
+                             /*toggling*/ false);
+        randomButton_->setTooltip("Randomize pattern");
+        randomButton_->onClick = [this]() {
+            if (traits_.isPolyStepSequencer) {
+                if (auto* poly = customUI_.getPolyStepSeqPlugin())
+                    poly->randomizePattern();
+            } else if (auto* stepSeqPlugin = customUI_.getStepSeqPlugin()) {
+                stepSeqPlugin->randomizePattern();
+            }
+        };
+        addAndMakeVisible(*randomButton_);
+
+        // MIDI-thru toggle (moved out of the sequencer body into the header).
+        midiThruButton_ = std::make_unique<magda::SvgButton>("MidiThru", BinaryData::compare_svg,
+                                                             BinaryData::compare_svgSize);
+        midiThruButton_->setOriginalColor(juce::Colour(0xFFB3B3B3));
+        midiThruButton_->setNormalColor(DarkTheme::getColour(DarkTheme::ACCENT_GREEN));
+        midiThruButton_->setTooltip("MIDI thru: pass input to downstream instruments");
+        midiThruButton_->setToggleable(true);
+        midiThruButton_->onClick = [this]() {
+            const bool on = !midiThruButton_->isActive();
+            midiThruButton_->setActive(on);
+            if (traits_.isPolyStepSequencer) {
+                if (auto* p = customUI_.getPolyStepSeqPlugin())
+                    p->midiThru = on;
+            } else if (auto* p = customUI_.getStepSeqPlugin()) {
+                p->midiThru = on;
+            }
+        };
+        addAndMakeVisible(*midiThruButton_);
+
+        // Step-record toggle (moved out of the sequencer body into the header).
+        stepRecordButton_ = std::make_unique<magda::SvgButton>(
+            "StepRecord", BinaryData::record_circle_svg, BinaryData::record_circle_svgSize);
+        stepRecordButton_->setOriginalColor(juce::Colour(0xFFB3B3B3));
+        stepRecordButton_->setNormalColor(juce::Colour(0xFFCC3333));
+        stepRecordButton_->setTooltip("Step record: play notes to fill steps");
+        stepRecordButton_->setToggleable(true);
+        stepRecordButton_->onClick = [this]() {
+            const bool on = !stepRecordButton_->isActive();
+            stepRecordButton_->setActive(on);
+            if (traits_.isPolyStepSequencer) {
+                if (auto* p = customUI_.getPolyStepSeqPlugin())
+                    p->setStepRecording(on);
+            } else if (auto* p = customUI_.getStepSeqPlugin()) {
+                p->setStepRecording(on);
+            }
+        };
+        addAndMakeVisible(*stepRecordButton_);
+    }
+
     // Create parameter grid (owns slots + pagination).
     paramGrid_ = std::make_unique<ParamHostComponent>(createDeviceSlotParamLayout(traits_));
     paramGrid_->onPrevPage = [this]() { goToPrevPage(); };
@@ -851,6 +910,25 @@ void DeviceSlotComponent::timerCallback() {
         traits_.isChordEngine) {
         refreshDeviceSlotMidiActivity(traits_, customUI_, midiNoteStrip_, lastMidiNote_,
                                       lastChordNotes_, lastChordCount_);
+
+        // Keep the step-seq header toggles in sync with plugin state.
+        if (midiThruButton_ != nullptr || stepRecordButton_ != nullptr) {
+            bool thru = false;
+            bool rec = false;
+            if (traits_.isPolyStepSequencer) {
+                if (auto* p = customUI_.getPolyStepSeqPlugin()) {
+                    thru = p->midiThru.get();
+                    rec = p->isStepRecording();
+                }
+            } else if (auto* p = customUI_.getStepSeqPlugin()) {
+                thru = p->midiThru.get();
+                rec = p->isStepRecording();
+            }
+            if (midiThruButton_ != nullptr && midiThruButton_->isActive() != thru)
+                midiThruButton_->setActive(thru);
+            if (stepRecordButton_ != nullptr && stepRecordButton_->isActive() != rec)
+                stepRecordButton_->setActive(rec);
+        }
     } else {
         // Poll device peak levels for right-side meter strip
         magda::DeviceMeteringManager::DeviceMeterData data;
@@ -1603,7 +1681,10 @@ void DeviceSlotComponent::resizedHeaderExtra(juce::Rectangle<int>& headerArea) {
          .uiButton = uiButton_.get(),
          .powerButton = stripsAnalysisChrome() ? nullptr : onButton_.get(),
          .presetButton = stripsAnalysisChrome() ? nullptr : presetButton_.get(),
-         .exportClipButton = exportClipButton_.get()},
+         .exportClipButton = exportClipButton_.get(),
+         .randomButton = randomButton_.get(),
+         .stepRecordButton = stepRecordButton_.get(),
+         .midiThruButton = midiThruButton_.get()},
         BUTTON_SIZE);
 }
 

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
@@ -229,6 +229,9 @@ class DeviceSlotComponent : public NodeComponent,
     std::unique_ptr<magda::SvgButton> learnButton_;
     std::unique_ptr<magda::SvgButton> onButton_;
     std::unique_ptr<magda::SvgButton> exportClipButton_;  // Export pattern/chords as MIDI clip
+    std::unique_ptr<magda::SvgButton> randomButton_;      // Step-sequencer pattern randomize
+    std::unique_ptr<magda::SvgButton> midiThruButton_;    // Step-sequencer MIDI thru toggle
+    std::unique_ptr<magda::SvgButton> stepRecordButton_;  // Step-sequencer step record toggle
 
     // Parameter host (owns slots + pagination, delegates layout to a
     // DeviceParamLayout strategy chosen at construction).

--- a/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
@@ -2,6 +2,7 @@
 
 #include "audio/plugins/DrumGridPlugin.hpp"
 #include "audio/transport/StepClock.hpp"
+#include "ui/themes/SmallButtonLookAndFeel.hpp"
 #include "ui/themes/SmallComboBoxLookAndFeel.hpp"
 
 namespace magda::daw::ui {
@@ -28,6 +29,49 @@ bool isBlackKey(int noteNumber) {
     static const bool isBlack[] = {false, true,  false, true,  false, false,
                                    true,  false, true,  false, true,  false};
     return isBlack[((noteNumber % 12) + 12) % 12];
+}
+
+constexpr int kStepRulerHeight = 13;  // mini step ruler above the grid
+
+// Step ruler above the grid: a tick per step, heavier + numbered every 4, with
+// the playing step highlighted. Columns align with the cell grid. Shared by the
+// keys and drum-lane views.
+void drawStepRuler(juce::Graphics& g, juce::Rectangle<int> timelineArea,
+                   juce::Rectangle<int> cellArea, int count, float colW, int playStep) {
+    if (timelineArea.isEmpty())
+        return;
+
+    g.setColour(DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.04f));
+    g.fillRect(timelineArea);
+
+    const float top = static_cast<float>(timelineArea.getY());
+    const float bottom = static_cast<float>(timelineArea.getBottom());
+
+    // Highlight the playing step.
+    if (playStep >= 0 && playStep < count) {
+        g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_GREEN).withAlpha(0.45f));
+        g.fillRect(
+            juce::Rectangle<float>(cellArea.getX() + playStep * colW, top, colW, bottom - top));
+    }
+
+    g.setFont(FontManager::getInstance().getUIFont(8.0f));
+    for (int i = 0; i < count; ++i) {
+        const float x = cellArea.getX() + i * colW;
+        const bool group = (i % 4 == 0);
+        g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(group ? 0.5f : 0.2f));
+        g.drawVerticalLine(juce::roundToInt(x), group ? top : top + 4.0f, bottom);
+        if (group) {
+            g.setColour(DarkTheme::getSecondaryTextColour());
+            g.drawText(
+                juce::String(i + 1),
+                juce::Rectangle<float>(x + 2.0f, top, colW - 2.0f, bottom - top).toNearestInt(),
+                juce::Justification::centredLeft);
+        }
+    }
+
+    g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(0.4f));
+    g.drawHorizontalLine(timelineArea.getBottom() - 1, static_cast<float>(cellArea.getX()),
+                         static_cast<float>(cellArea.getRight()));
 }
 
 }  // namespace
@@ -62,7 +106,7 @@ class PolyStepSequencerUI::KeysView : public PolyStepSequencerUI::PatternView {
             return;
 
         // Mini timeline (step ruler) across the top, above the whole grid.
-        timelineArea_ = bounds.removeFromTop(TIMELINE_H);
+        timelineArea_ = bounds.removeFromTop(kStepRulerHeight);
 
         auto arrowStrip = bounds.removeFromLeft(ARROW_STRIP_WIDTH);
         // Left strip, top to bottom: zoom in (+), octave up, octave down,
@@ -84,7 +128,7 @@ class PolyStepSequencerUI::KeysView : public PolyStepSequencerUI::PatternView {
         const float rowH = static_cast<float>(cellArea_.getHeight()) / visibleNotes_;
         const float colW = static_cast<float>(cellArea_.getWidth()) / static_cast<float>(count);
 
-        drawTimeline(g, count, colW);
+        drawStepRuler(g, timelineArea_, cellArea_, count, colW, playStep_);
 
         g.setFont(FontManager::getInstance().getUIFont(7.0f));
 
@@ -216,7 +260,6 @@ class PolyStepSequencerUI::KeysView : public PolyStepSequencerUI::PatternView {
     static constexpr int MIN_VISIBLE_NOTES = 12;      // zoomed in: one octave
     static constexpr int MAX_VISIBLE_NOTES = 48;      // zoomed out: four octaves
     static constexpr int ARROW_STRIP_WIDTH = 14;
-    static constexpr int TIMELINE_H = 13;  // mini step ruler above the grid
 
     void shiftWindow(int semitones) {
         const int next = juce::jlimit(0, 127 - visibleNotes_ + 1, lowNote_ + semitones);
@@ -368,45 +411,6 @@ class PolyStepSequencerUI::KeysView : public PolyStepSequencerUI::PatternView {
             g.drawLine(cx, cy - s, cx, cy + s, 1.0f);  // plus vertical bar
     }
 
-    // Step ruler above the grid: a tick per step, heavier + numbered every 4,
-    // with the playing step highlighted. Aligned to the cell columns.
-    void drawTimeline(juce::Graphics& g, int count, float colW) {
-        if (timelineArea_.isEmpty())
-            return;
-
-        g.setColour(DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.04f));
-        g.fillRect(timelineArea_);
-
-        const float top = static_cast<float>(timelineArea_.getY());
-        const float bottom = static_cast<float>(timelineArea_.getBottom());
-
-        // Highlight the playing step.
-        if (playStep_ >= 0 && playStep_ < count) {
-            g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_GREEN).withAlpha(0.45f));
-            g.fillRect(juce::Rectangle<float>(cellArea_.getX() + playStep_ * colW, top, colW,
-                                              bottom - top));
-        }
-
-        g.setFont(FontManager::getInstance().getUIFont(8.0f));
-        for (int i = 0; i < count; ++i) {
-            const float x = cellArea_.getX() + i * colW;
-            const bool group = (i % 4 == 0);
-            g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(group ? 0.5f : 0.2f));
-            g.drawVerticalLine(juce::roundToInt(x), group ? top : top + 4.0f, bottom);
-            if (group) {
-                g.setColour(DarkTheme::getSecondaryTextColour());
-                g.drawText(
-                    juce::String(i + 1),
-                    juce::Rectangle<float>(x + 2.0f, top, colW - 2.0f, bottom - top).toNearestInt(),
-                    juce::Justification::centredLeft);
-            }
-        }
-
-        g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(0.4f));
-        g.drawHorizontalLine(timelineArea_.getBottom() - 1, static_cast<float>(cellArea_.getX()),
-                             static_cast<float>(cellArea_.getRight()));
-    }
-
     PolySeqPlugin* plugin_ = nullptr;
     int playStep_ = -1;
     int lowNote_ = 48;                          // C2..B3 window — C3 (60) centered
@@ -474,6 +478,9 @@ class PolyStepSequencerUI::DrumLanesView : public PolyStepSequencerUI::PatternVi
         if (bounds.isEmpty() || plugin_ == nullptr || lanes_.empty())
             return;
 
+        // Mini timeline (step ruler) across the top, above the whole grid.
+        timelineArea_ = bounds.removeFromTop(kStepRulerHeight);
+
         auto arrowStrip = bounds.removeFromLeft(ARROW_STRIP_WIDTH);
         scrollUpArea_ = arrowStrip.removeFromTop(arrowStrip.getHeight() / 2);
         scrollDownArea_ = arrowStrip;
@@ -494,6 +501,8 @@ class PolyStepSequencerUI::DrumLanesView : public PolyStepSequencerUI::PatternVi
 
         const int count = juce::jlimit(1, PolySeqPlugin::MAX_STEPS, plugin_->numSteps.get());
         const float colW = static_cast<float>(cellArea_.getWidth()) / static_cast<float>(count);
+
+        drawStepRuler(g, timelineArea_, cellArea_, count, colW, playStep_);
 
         for (int row = 0; row < visible; ++row) {
             const int laneIdx = scrollOffset_ + (visible - 1 - row);
@@ -917,6 +926,7 @@ class PolyStepSequencerUI::DrumLanesView : public PolyStepSequencerUI::PatternVi
     juce::Rectangle<int> scrollDownArea_;
     juce::Rectangle<int> labelArea_;
     juce::Rectangle<int> cellArea_;
+    juce::Rectangle<int> timelineArea_;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DrumLanesView)
 };
@@ -1071,26 +1081,14 @@ PolyStepSequencerUI::PolyStepSequencerUI() {
             plugin_->hardAngle = hardAngle;
     };
 
-    // --- MIDI controls ---
-    midiThruButton_ = std::make_unique<magda::SvgButton>("MidiThru", BinaryData::compare_svg,
-                                                         BinaryData::compare_svgSize);
-    midiThruButton_->setOriginalColor(juce::Colour(0xFFB3B3B3));
-    midiThruButton_->setNormalColor(DarkTheme::getColour(DarkTheme::ACCENT_GREEN));
-    midiThruButton_->setTooltip("MIDI thru: pass input to downstream instruments");
-    midiThruButton_->setToggleable(true);
-    midiThruButton_->setActive(false);
-    midiThruButton_->onClick = [this] {
-        if (plugin_) {
-            bool newState = !midiThruButton_->isActive();
-            midiThruButton_->setActive(newState);
-            plugin_->midiThru = newState;
-        }
-    };
-    addAndMakeVisible(midiThruButton_.get());
+    // MIDI thru / step record live in the device-slot header, owned by
+    // DeviceSlotComponent — not in this body.
 
     // --- View mode toggle (keys / drum) ---
     viewModeButton_.setButtonText("KEYS");
     viewModeButton_.setClickingTogglesState(true);
+    // Theme font + box-style rounding, matching the side-panel sliders/combo.
+    viewModeButton_.setLookAndFeel(&SmallButtonLookAndFeel::getInstance());
     viewModeButton_.setColour(juce::TextButton::buttonColourId,
                               DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.1f));
     viewModeButton_.setColour(juce::TextButton::buttonOnColourId,
@@ -1116,6 +1114,7 @@ PolyStepSequencerUI::~PolyStepSequencerUI() {
     if (watchedState_.isValid())
         watchedState_.removeListener(this);
     dirCombo_.setLookAndFeel(nullptr);
+    viewModeButton_.setLookAndFeel(nullptr);
 }
 
 // =============================================================================
@@ -1177,7 +1176,6 @@ void PolyStepSequencerUI::syncFromPlugin() {
                                 juce::dontSendNotification);
     cyclesSlider_.setValue(static_cast<double>(juce::jlimit(1, steps, plugin_->rampCycles.get())),
                            juce::dontSendNotification);
-    midiThruButton_->setActive(plugin_->midiThru.get());
     patternView_->patternChanged();
     repaint();
 }
@@ -1262,16 +1260,14 @@ void PolyStepSequencerUI::resized() {
     gridRow(swingLabel_, swingSlider_, gateLengthLabel_, gateLengthSlider_);
     gridRow(quantizeLabel_, quantizeSlider_, quantizeSubLabel_, quantizeSubSlider_);
 
-    // DIR on the left, view-mode (keys/drum) + MIDI thru buttons on the right.
+    // DIR on the left, view-mode (keys/drum) toggle on the right.
     {
         auto row = panel.removeFromTop(GRID_CELL_H);
         const int half = (row.getWidth() - COL_GAP) / 2;
         gridCell(dirLabel_, dirCombo_, row.removeFromLeft(half));
         row.removeFromLeft(COL_GAP);
-        row.removeFromTop(CELL_LABEL_H);  // align buttons with the combo, not the label
-        midiThruButton_->setBounds(row.removeFromRight(row.getHeight()));
-        row.removeFromRight(4);
-        viewModeButton_.setBounds(row.reduced(0, 2));
+        row.removeFromTop(CELL_LABEL_H);  // align button with the combo, not the label
+        viewModeButton_.setBounds(row.removeFromLeft(juce::jmin(48, row.getWidth())).reduced(0, 2));
         panel.removeFromTop(ROW_GAP);
     }
 

--- a/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.cpp
@@ -61,24 +61,36 @@ class PolyStepSequencerUI::KeysView : public PolyStepSequencerUI::PatternView {
         if (bounds.isEmpty() || plugin_ == nullptr)
             return;
 
+        // Mini timeline (step ruler) across the top, above the whole grid.
+        timelineArea_ = bounds.removeFromTop(TIMELINE_H);
+
         auto arrowStrip = bounds.removeFromLeft(ARROW_STRIP_WIDTH);
-        octaveUpArea_ = arrowStrip.removeFromTop(arrowStrip.getHeight() / 2);
-        octaveDownArea_ = arrowStrip;
+        // Left strip, top to bottom: zoom in (+), octave up, octave down,
+        // zoom out (-).
+        const int cellH = arrowStrip.getHeight() / 4;
+        zoomInArea_ = arrowStrip.removeFromTop(cellH);
+        octaveUpArea_ = arrowStrip.removeFromTop(cellH);
+        octaveDownArea_ = arrowStrip.removeFromTop(cellH);
+        zoomOutArea_ = arrowStrip;
         gutterArea_ = bounds.removeFromLeft(LEFT_GUTTER_WIDTH - ARROW_STRIP_WIDTH);
         cellArea_ = bounds;
 
+        drawZoomButton(g, zoomInArea_, true);
         drawOctaveArrow(g, octaveUpArea_, true);
         drawOctaveArrow(g, octaveDownArea_, false);
+        drawZoomButton(g, zoomOutArea_, false);
 
         const int count = juce::jlimit(1, PolySeqPlugin::MAX_STEPS, plugin_->numSteps.get());
-        const float rowH = static_cast<float>(cellArea_.getHeight()) / NUM_VISIBLE_NOTES;
+        const float rowH = static_cast<float>(cellArea_.getHeight()) / visibleNotes_;
         const float colW = static_cast<float>(cellArea_.getWidth()) / static_cast<float>(count);
+
+        drawTimeline(g, count, colW);
 
         g.setFont(FontManager::getInstance().getUIFont(7.0f));
 
         // --- Pitch gutter: piano-key style rows, note names on C's ---
-        for (int row = 0; row < NUM_VISIBLE_NOTES; ++row) {
-            const int note = lowNote_ + (NUM_VISIBLE_NOTES - 1 - row);
+        for (int row = 0; row < visibleNotes_; ++row) {
+            const int note = lowNote_ + (visibleNotes_ - 1 - row);
             auto rowRect = juce::Rectangle<float>(static_cast<float>(gutterArea_.getX()),
                                                   gutterArea_.getY() + row * rowH,
                                                   static_cast<float>(gutterArea_.getWidth()), rowH);
@@ -95,8 +107,8 @@ class PolyStepSequencerUI::KeysView : public PolyStepSequencerUI::PatternView {
         }
 
         // --- Cells ---
-        for (int row = 0; row < NUM_VISIBLE_NOTES; ++row) {
-            const int note = lowNote_ + (NUM_VISIBLE_NOTES - 1 - row);
+        for (int row = 0; row < visibleNotes_; ++row) {
+            const int note = lowNote_ + (visibleNotes_ - 1 - row);
             const float y = cellArea_.getY() + row * rowH;
 
             for (int i = 0; i < count; ++i) {
@@ -142,8 +154,8 @@ class PolyStepSequencerUI::KeysView : public PolyStepSequencerUI::PatternView {
             g.drawVerticalLine(juce::roundToInt(x), static_cast<float>(cellArea_.getY()),
                                static_cast<float>(cellArea_.getBottom()));
         }
-        for (int row = 0; row <= NUM_VISIBLE_NOTES; ++row) {
-            const int noteBelow = lowNote_ + (NUM_VISIBLE_NOTES - 1 - row);
+        for (int row = 0; row <= visibleNotes_; ++row) {
+            const int noteBelow = lowNote_ + (visibleNotes_ - 1 - row);
             const float y = cellArea_.getY() + row * rowH;
             g.setColour(DarkTheme::getColour(DarkTheme::BORDER)
                             .withAlpha((noteBelow + 1) % 12 == 0 ? 0.4f : 0.1f));
@@ -157,6 +169,14 @@ class PolyStepSequencerUI::KeysView : public PolyStepSequencerUI::PatternView {
             return;
         const auto pos = e.getPosition();
 
+        if (zoomInArea_.contains(pos)) {
+            zoomBy(-2);  // fewer rows = taller keys
+            return;
+        }
+        if (zoomOutArea_.contains(pos)) {
+            zoomBy(2);
+            return;
+        }
         if (octaveUpArea_.contains(pos)) {
             shiftWindow(12);
             return;
@@ -183,20 +203,40 @@ class PolyStepSequencerUI::KeysView : public PolyStepSequencerUI::PatternView {
         repaint();
     }
 
-    void mouseWheelMove(const juce::MouseEvent&, const juce::MouseWheelDetails& wheel) override {
-        shiftWindow(wheel.deltaY > 0 ? 2 : -2);
+    void mouseWheelMove(const juce::MouseEvent& e, const juce::MouseWheelDetails& wheel) override {
+        // Modifier + wheel zooms the pitch axis; plain wheel scrolls it.
+        if (e.mods.isCommandDown() || e.mods.isCtrlDown())
+            zoomBy(wheel.deltaY > 0 ? -2 : 2);  // scroll up = zoom in (fewer rows)
+        else
+            shiftWindow(wheel.deltaY > 0 ? 2 : -2);
     }
 
   private:
-    static constexpr int NUM_VISIBLE_NOTES = 24;  // ~2 octaves
+    static constexpr int DEFAULT_VISIBLE_NOTES = 24;  // ~2 octaves
+    static constexpr int MIN_VISIBLE_NOTES = 12;      // zoomed in: one octave
+    static constexpr int MAX_VISIBLE_NOTES = 48;      // zoomed out: four octaves
     static constexpr int ARROW_STRIP_WIDTH = 14;
+    static constexpr int TIMELINE_H = 13;  // mini step ruler above the grid
 
     void shiftWindow(int semitones) {
-        const int next = juce::jlimit(0, 127 - NUM_VISIBLE_NOTES + 1, lowNote_ + semitones);
+        const int next = juce::jlimit(0, 127 - visibleNotes_ + 1, lowNote_ + semitones);
         if (next != lowNote_) {
             lowNote_ = next;
             repaint();
         }
+    }
+
+    // Vertical zoom: change how many pitch rows are visible, keeping the centre
+    // pitch roughly anchored. Fewer rows = taller keys (zoomed in).
+    void zoomBy(int deltaNotes) {
+        const int next =
+            juce::jlimit(MIN_VISIBLE_NOTES, MAX_VISIBLE_NOTES, visibleNotes_ + deltaNotes);
+        if (next == visibleNotes_)
+            return;
+        const int centre = lowNote_ + visibleNotes_ / 2;
+        visibleNotes_ = next;
+        lowNote_ = juce::jlimit(0, 127 - visibleNotes_ + 1, centre - visibleNotes_ / 2);
+        repaint();
     }
 
     int stepAt(int x) const {
@@ -215,8 +255,8 @@ class PolyStepSequencerUI::KeysView : public PolyStepSequencerUI::PatternView {
         const int relY = y - cellArea_.getY();
         if (relY < 0 || relY >= cellArea_.getHeight())
             return -1;
-        const int row = relY * NUM_VISIBLE_NOTES / cellArea_.getHeight();
-        return lowNote_ + (NUM_VISIBLE_NOTES - 1 - row);
+        const int row = relY * visibleNotes_ / cellArea_.getHeight();
+        return lowNote_ + (visibleNotes_ - 1 - row);
     }
 
     void showStepContextMenu(int stepIndex) {
@@ -279,7 +319,7 @@ class PolyStepSequencerUI::KeysView : public PolyStepSequencerUI::PatternView {
             return;
 
         auto btn = area.reduced(2);
-        const bool canShift = isUp ? (lowNote_ < 127 - NUM_VISIBLE_NOTES + 1) : (lowNote_ > 0);
+        const bool canShift = isUp ? (lowNote_ < 127 - visibleNotes_ + 1) : (lowNote_ > 0);
 
         g.setColour(canShift ? DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.15f)
                              : DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.05f));
@@ -304,14 +344,81 @@ class PolyStepSequencerUI::KeysView : public PolyStepSequencerUI::PatternView {
         g.fillPath(arrow);
     }
 
+    void drawZoomButton(juce::Graphics& g, juce::Rectangle<int> area, bool isIn) {
+        if (area.isEmpty())
+            return;
+
+        auto btn = area.reduced(2);
+        const bool enabled =
+            isIn ? (visibleNotes_ > MIN_VISIBLE_NOTES) : (visibleNotes_ < MAX_VISIBLE_NOTES);
+
+        g.setColour(enabled ? DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.15f)
+                            : DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.05f));
+        g.fillRoundedRectangle(btn.toFloat(), 2.0f);
+        g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(0.3f));
+        g.drawRoundedRectangle(btn.toFloat(), 2.0f, 0.5f);
+
+        g.setColour(enabled ? DarkTheme::getTextColour()
+                            : DarkTheme::getSecondaryTextColour().withAlpha(0.3f));
+        const float cx = static_cast<float>(btn.getCentreX());
+        const float cy = static_cast<float>(btn.getCentreY());
+        constexpr float s = 3.0f;
+        g.drawLine(cx - s, cy, cx + s, cy, 1.0f);  // minus / plus horizontal bar
+        if (isIn)
+            g.drawLine(cx, cy - s, cx, cy + s, 1.0f);  // plus vertical bar
+    }
+
+    // Step ruler above the grid: a tick per step, heavier + numbered every 4,
+    // with the playing step highlighted. Aligned to the cell columns.
+    void drawTimeline(juce::Graphics& g, int count, float colW) {
+        if (timelineArea_.isEmpty())
+            return;
+
+        g.setColour(DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.04f));
+        g.fillRect(timelineArea_);
+
+        const float top = static_cast<float>(timelineArea_.getY());
+        const float bottom = static_cast<float>(timelineArea_.getBottom());
+
+        // Highlight the playing step.
+        if (playStep_ >= 0 && playStep_ < count) {
+            g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_GREEN).withAlpha(0.45f));
+            g.fillRect(juce::Rectangle<float>(cellArea_.getX() + playStep_ * colW, top, colW,
+                                              bottom - top));
+        }
+
+        g.setFont(FontManager::getInstance().getUIFont(8.0f));
+        for (int i = 0; i < count; ++i) {
+            const float x = cellArea_.getX() + i * colW;
+            const bool group = (i % 4 == 0);
+            g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(group ? 0.5f : 0.2f));
+            g.drawVerticalLine(juce::roundToInt(x), group ? top : top + 4.0f, bottom);
+            if (group) {
+                g.setColour(DarkTheme::getSecondaryTextColour());
+                g.drawText(
+                    juce::String(i + 1),
+                    juce::Rectangle<float>(x + 2.0f, top, colW - 2.0f, bottom - top).toNearestInt(),
+                    juce::Justification::centredLeft);
+            }
+        }
+
+        g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(0.4f));
+        g.drawHorizontalLine(timelineArea_.getBottom() - 1, static_cast<float>(cellArea_.getX()),
+                             static_cast<float>(cellArea_.getRight()));
+    }
+
     PolySeqPlugin* plugin_ = nullptr;
     int playStep_ = -1;
-    int lowNote_ = 48;  // C2..B3 window — C3 (60) centered
+    int lowNote_ = 48;                          // C2..B3 window — C3 (60) centered
+    int visibleNotes_ = DEFAULT_VISIBLE_NOTES;  // pitch rows shown (vertical zoom)
 
+    juce::Rectangle<int> zoomInArea_;
+    juce::Rectangle<int> zoomOutArea_;
     juce::Rectangle<int> octaveUpArea_;
     juce::Rectangle<int> octaveDownArea_;
     juce::Rectangle<int> gutterArea_;
     juce::Rectangle<int> cellArea_;
+    juce::Rectangle<int> timelineArea_;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(KeysView)
 };
@@ -1119,79 +1226,72 @@ void PolyStepSequencerUI::timerCallback() {
 void PolyStepSequencerUI::resized() {
     auto bounds = getLocalBounds().reduced(PADDING);
 
-    // Controls row 1: RATE, STEPS, DIRECTION
-    auto controlRow1 = bounds.removeFromTop(CONTROL_ROW_HEIGHT);
-    int controlWidth = controlRow1.getWidth() / 3;
+    // --- Right-side control panel (controls + time bend) ---
+    // All the sequencer controls live in a column on the right, styled like the
+    // device mod/macro side panel. This hands the full editor height to the
+    // pattern grid, which now only loses the per-step lanes at the bottom.
+    constexpr int SIDE_PANEL_WIDTH = 150;
+    constexpr int SIDE_GAP = 6;
+    sidePanelArea_ = bounds.removeFromRight(SIDE_PANEL_WIDTH);
+    bounds.removeFromRight(SIDE_GAP);
+    auto panel = sidePanelArea_.reduced(6, 5);
+
+    // --- Top controls: 2-column grid, label above each control ---
+    //   RATE  | STEPS
+    //   SWING | GATE
+    //   QUANT | SUB
+    //   DIR   | [KEYS] [thru]
+    constexpr int CELL_LABEL_H = 14;
+    constexpr int GRID_CELL_H = CONTROL_ROW_HEIGHT + CELL_LABEL_H;
+    constexpr int COL_GAP = 6;
+    const auto gridCell = [&](juce::Label& label, juce::Component& ctrl,
+                              juce::Rectangle<int> cell) {
+        label.setBounds(cell.removeFromTop(CELL_LABEL_H));
+        ctrl.setBounds(cell);
+    };
+    const auto gridRow = [&](juce::Label& l1, juce::Component& c1, juce::Label& l2,
+                             juce::Component& c2) {
+        auto row = panel.removeFromTop(GRID_CELL_H);
+        const int half = (row.getWidth() - COL_GAP) / 2;
+        gridCell(l1, c1, row.removeFromLeft(half));
+        row.removeFromLeft(COL_GAP);
+        gridCell(l2, c2, row);
+        panel.removeFromTop(ROW_GAP);
+    };
+    gridRow(rateLabel_, rateSlider_, stepsLabel_, stepsSlider_);
+    gridRow(swingLabel_, swingSlider_, gateLengthLabel_, gateLengthSlider_);
+    gridRow(quantizeLabel_, quantizeSlider_, quantizeSubLabel_, quantizeSubSlider_);
+
+    // DIR on the left, view-mode (keys/drum) + MIDI thru buttons on the right.
     {
-        auto cell = controlRow1.removeFromLeft(controlWidth);
-        rateLabel_.setBounds(cell.removeFromLeft(LABEL_WIDTH));
-        rateSlider_.setBounds(cell);
-    }
-    {
-        auto cell = controlRow1.removeFromLeft(controlWidth);
-        stepsLabel_.setBounds(cell.removeFromLeft(LABEL_WIDTH));
-        stepsSlider_.setBounds(cell);
-    }
-    {
-        dirLabel_.setBounds(controlRow1.removeFromLeft(LABEL_WIDTH));
-        dirCombo_.setBounds(controlRow1);
+        auto row = panel.removeFromTop(GRID_CELL_H);
+        const int half = (row.getWidth() - COL_GAP) / 2;
+        gridCell(dirLabel_, dirCombo_, row.removeFromLeft(half));
+        row.removeFromLeft(COL_GAP);
+        row.removeFromTop(CELL_LABEL_H);  // align buttons with the combo, not the label
+        midiThruButton_->setBounds(row.removeFromRight(row.getHeight()));
+        row.removeFromRight(4);
+        viewModeButton_.setBounds(row.reduced(0, 2));
+        panel.removeFromTop(ROW_GAP);
     }
 
-    bounds.removeFromTop(ROW_GAP);
-
-    // Controls row 2: SWING, GATE, QUANTIZE, SUB, THRU
-    auto controlRow2 = bounds.removeFromTop(CONTROL_ROW_HEIGHT);
-    midiThruButton_->setBounds(controlRow2.removeFromRight(CONTROL_ROW_HEIGHT));
-    controlRow2.removeFromRight(4);
-    viewModeButton_.setBounds(controlRow2.removeFromRight(42).reduced(0, 2));
-    controlRow2.removeFromRight(4);
-    int quarterWidth = controlRow2.getWidth() / 4;
-    {
-        auto cell = controlRow2.removeFromLeft(quarterWidth);
-        swingLabel_.setBounds(cell.removeFromLeft(LABEL_WIDTH));
-        swingSlider_.setBounds(cell);
-    }
-    {
-        auto cell = controlRow2.removeFromLeft(quarterWidth);
-        gateLengthLabel_.setBounds(cell.removeFromLeft(LABEL_WIDTH));
-        gateLengthSlider_.setBounds(cell);
-    }
-    {
-        auto cell = controlRow2.removeFromLeft(quarterWidth);
-        quantizeLabel_.setBounds(cell.removeFromLeft(LABEL_WIDTH));
-        quantizeSlider_.setBounds(cell);
-    }
-    {
-        quantizeSubLabel_.setBounds(controlRow2.removeFromLeft(LABEL_WIDTH));
-        quantizeSubSlider_.setBounds(controlRow2);
-    }
-
-    bounds.removeFromTop(ROW_GAP + 2);
-
-    // TIME BEND block pinned to the bottom (label row + curve with sliders)
+    // --- TIME BEND: label, DEPTH/SKEW/CYCLES row, then the curve fills the
+    // rest of the panel height (as tall as the panel allows) ---
     constexpr int LABEL_H = 14;
     constexpr int CELL_H = CONTROL_ROW_HEIGHT + LABEL_H;
-    constexpr int SLIDER_COL_W = 44;
+    panel.removeFromTop(ROW_GAP + 2);
+    rampLabel_.setBounds(panel.removeFromTop(LABEL_H));
     {
-        auto rampBlock = bounds.removeFromBottom(LABEL_H + CELL_H * 3);
-        rampLabel_.setBounds(rampBlock.removeFromTop(LABEL_H));
-        // Sliders stacked on the right, each with label above
-        auto sliderCol = rampBlock.removeFromRight(SLIDER_COL_W);
-        auto depthCell = sliderCol.removeFromTop(CELL_H);
-        depthLabel_.setBounds(depthCell.removeFromTop(LABEL_H));
-        depthSlider_.setBounds(depthCell);
-        auto skewCell = sliderCol.removeFromTop(CELL_H);
-        skewLabel_.setBounds(skewCell.removeFromTop(LABEL_H));
-        skewSlider_.setBounds(skewCell);
-        auto cyclesCell = sliderCol.removeFromTop(CELL_H);
-        cyclesLabel_.setBounds(cyclesCell.removeFromTop(LABEL_H));
-        cyclesSlider_.setBounds(cyclesCell);
-        // Curve fills remaining width
-        rampBlock.removeFromRight(4);
-        rampCurveDisplay_.setBounds(rampBlock);
+        auto boxRow = panel.removeFromTop(CELL_H);
+        const int cellW = boxRow.getWidth() / 3;
+        gridCell(depthLabel_, depthSlider_, boxRow.removeFromLeft(cellW));
+        gridCell(skewLabel_, skewSlider_, boxRow.removeFromLeft(cellW));
+        gridCell(cyclesLabel_, cyclesSlider_, boxRow);
     }
-    bounds.removeFromBottom(ROW_GAP);
+    panel.removeFromTop(2);
+    rampCurveDisplay_.setBounds(panel);  // curve takes all remaining height
 
+    // --- Main area (left): pattern grid + per-step lanes ---
     // Per-step lanes from the bottom up: PROB, VEL, TIE, GATE
     probabilityArea_ = bounds.removeFromBottom(LANE_HEIGHT);
     bounds.removeFromBottom(ROW_GAP);
@@ -1211,6 +1311,16 @@ void PolyStepSequencerUI::resized() {
 // =============================================================================
 
 void PolyStepSequencerUI::paint(juce::Graphics& g) {
+    // Control side panel: subtle card + left separator, matching the device
+    // mod/macro side panels.
+    if (!sidePanelArea_.isEmpty()) {
+        g.setColour(DarkTheme::getColour(DarkTheme::BACKGROUND_ALT));
+        g.fillRect(sidePanelArea_);
+        g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(0.5f));
+        g.drawVerticalLine(sidePanelArea_.getX(), static_cast<float>(sidePanelArea_.getY()),
+                           static_cast<float>(sidePanelArea_.getBottom()));
+    }
+
     drawToggleRow(g, gateArea_, "GAT", false);
     drawToggleRow(g, tieArea_, "TIE", true);
     drawBarLane(g, velocityArea_, "VEL", false);

--- a/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.hpp
@@ -81,7 +81,7 @@ class PolyStepSequencerUI : public juce::Component,
     juce::Label quantizeSubLabel_;
     LinkableTextSlider quantizeSubSlider_;
 
-    // --- Ramp curve ---
+    // --- Ramp curve (time bend) ---
     juce::Label rampLabel_;
     RampCurveDisplay rampCurveDisplay_;
     juce::Label depthLabel_;
@@ -97,6 +97,9 @@ class PolyStepSequencerUI : public juce::Component,
     // --- View mode toggle (keys / drum) ---
     juce::TextButton viewModeButton_;
     bool drumViewActive_ = false;
+
+    // Right-side control panel bounds (controls + time bend), painted as a card.
+    juce::Rectangle<int> sidePanelArea_;
 
     // --- Pattern view (swapped between KeysView and DrumLanesView) ---
     std::unique_ptr<PatternView> patternView_;

--- a/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/PolyStepSequencerUI.hpp
@@ -91,9 +91,6 @@ class PolyStepSequencerUI : public juce::Component,
     juce::Label cyclesLabel_;
     LinkableTextSlider cyclesSlider_;
 
-    // --- MIDI controls ---
-    std::unique_ptr<magda::SvgButton> midiThruButton_;
-
     // --- View mode toggle (keys / drum) ---
     juce::TextButton viewModeButton_;
     bool drumViewActive_ = false;

--- a/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.cpp
@@ -167,52 +167,9 @@ StepSequencerUI::StepSequencerUI() {
             plugin_->quantizeSub = juce::roundToInt(value);
     };
 
-    // --- MIDI controls ---
-    midiThruButton_ = std::make_unique<magda::SvgButton>("MidiThru", BinaryData::compare_svg,
-                                                         BinaryData::compare_svgSize);
-    midiThruButton_->setOriginalColor(juce::Colour(0xFFB3B3B3));
-    midiThruButton_->setNormalColor(DarkTheme::getColour(DarkTheme::ACCENT_GREEN));
-    midiThruButton_->setTooltip("MIDI thru: pass input to downstream instruments");
-    midiThruButton_->setToggleable(true);
-    midiThruButton_->setActive(false);
-    midiThruButton_->onClick = [this] {
-        if (plugin_) {
-            bool newState = !midiThruButton_->isActive();
-            midiThruButton_->setActive(newState);
-            plugin_->midiThru = newState;
-        }
-    };
-    addAndMakeVisible(midiThruButton_.get());
-
-    stepRecordButton_ = std::make_unique<magda::SvgButton>(
-        "StepRecord", BinaryData::record_circle_svg, BinaryData::record_circle_svgSize);
-    stepRecordButton_->setOriginalColor(juce::Colour(0xFFB3B3B3));
-    stepRecordButton_->setNormalColor(juce::Colour(0xFFCC3333));
-    stepRecordButton_->setTooltip("Step record: play a note to record on the current step");
-    stepRecordButton_->setToggleable(true);
-    stepRecordButton_->onClick = [this] {
-        if (plugin_) {
-            bool newState = !stepRecordButton_->isActive();
-            stepRecordButton_->setActive(newState);
-            plugin_->setStepRecording(newState);
-            repaint();  // Redraw banner
-        }
-    };
-    addAndMakeVisible(stepRecordButton_.get());
-
-    // --- Pattern generation: [RND] ---
-    randomButton_ = std::make_unique<magda::SvgButton>("Random", BinaryData::random_svg,
-                                                       BinaryData::random_svgSize);
-    randomButton_->setOriginalColor(juce::Colour(0xFFB3B3B3));
-    randomButton_->setNormalColor(DarkTheme::getColour(DarkTheme::ACCENT_BLUE));
-    randomButton_->setTooltip("Randomize pattern");
-    randomButton_->onClick = [this] {
-        if (plugin_) {
-            plugin_->randomizePattern();
-            repaint();
-        }
-    };
-    addAndMakeVisible(randomButton_.get());
+    // MIDI thru, step record and pattern randomize live in the device-slot
+    // header (next to the AI button), owned by DeviceSlotComponent — not in
+    // this body.
 }
 
 StepSequencerUI::~StepSequencerUI() {
@@ -264,7 +221,6 @@ void StepSequencerUI::syncFromPlugin() {
                                 juce::dontSendNotification);
     cyclesSlider_.setValue(static_cast<double>(juce::jlimit(1, steps, plugin_->rampCycles.get())),
                            juce::dontSendNotification);
-    midiThruButton_->setActive(plugin_->midiThru.get());
     repaint();
 }
 
@@ -340,12 +296,7 @@ void StepSequencerUI::resized() {
 
     // Controls row 2: SWING, GATE, Q, SUB, THRU, REC
     auto controlRow2 = bounds.removeFromTop(CONTROL_ROW_HEIGHT);
-    // Right side: THRU + REC icons
-    stepRecordButton_->setBounds(controlRow2.removeFromRight(CONTROL_ROW_HEIGHT));
-    controlRow2.removeFromRight(2);
-    midiThruButton_->setBounds(controlRow2.removeFromRight(CONTROL_ROW_HEIGHT));
-    controlRow2.removeFromRight(4);
-    // Left side: 4 controls evenly spaced
+    // THRU / REC moved to the device-slot header. The whole row is controls.
     int quarterWidth = controlRow2.getWidth() / 4;
     {
         auto cell = controlRow2.removeFromLeft(quarterWidth);
@@ -368,6 +319,10 @@ void StepSequencerUI::resized() {
     }
 
     bounds.removeFromTop(ROW_GAP + 2);
+
+    // Mini timeline / step ruler (aligned to the step-box columns)
+    timelineArea_ = bounds.removeFromTop(TIMELINE_HEIGHT).withTrimmedLeft(24);
+    bounds.removeFromTop(ROW_GAP);
 
     // Step boxes (24px left margin to align with ACC/G/T label columns)
     stepBoxArea_ = bounds.removeFromTop(STEP_BOX_SIZE).withTrimmedLeft(24);
@@ -414,12 +369,6 @@ void StepSequencerUI::resized() {
         rampRow.removeFromRight(4);
         rampCurveDisplay_.setBounds(rampRow);
     }
-
-    bounds.removeFromTop(ROW_GAP);
-
-    // Pattern generation row: [RND]
-    auto buttonRow = bounds.removeFromTop(CONTROL_ROW_HEIGHT);
-    randomButton_->setBounds(buttonRow.removeFromLeft(CONTROL_ROW_HEIGHT));
 }
 
 // =============================================================================
@@ -427,12 +376,54 @@ void StepSequencerUI::resized() {
 // =============================================================================
 
 void StepSequencerUI::paint(juce::Graphics& g) {
+    drawTimeline(g, timelineArea_);
     drawStepBoxes(g, stepBoxArea_);
     drawAccentRow(g, accentArea_);
     drawGlideTieRow(g, glideTieArea_);
     drawOctaveArrow(g, octaveDownArea_, true);
     drawKeyboard(g, keyboardArea_);
     drawOctaveArrow(g, octaveUpArea_, false);
+}
+
+// Step ruler above the grid: a tick per step, heavier + numbered every 4, with
+// the playing step highlighted. Columns align with the step boxes below.
+void StepSequencerUI::drawTimeline(juce::Graphics& g, juce::Rectangle<int> area) {
+    if (!plugin_ || area.isEmpty())
+        return;
+
+    const int count = juce::jlimit(1, SeqPlugin::MAX_STEPS, plugin_->numSteps.get());
+    const float colW = static_cast<float>(area.getWidth()) / static_cast<float>(count);
+    const float top = static_cast<float>(area.getY());
+    const float bottom = static_cast<float>(area.getBottom());
+
+    g.setColour(DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.04f));
+    g.fillRect(area);
+
+    // Highlight the playing step.
+    if (currentPlayStep_ >= 0 && currentPlayStep_ < count) {
+        g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_GREEN).withAlpha(0.45f));
+        g.fillRect(
+            juce::Rectangle<float>(area.getX() + currentPlayStep_ * colW, top, colW, bottom - top));
+    }
+
+    g.setFont(FontManager::getInstance().getUIFont(8.0f));
+    for (int i = 0; i < count; ++i) {
+        const float x = area.getX() + i * colW;
+        const bool group = (i % 4 == 0);
+        g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(group ? 0.5f : 0.2f));
+        g.drawVerticalLine(juce::roundToInt(x), group ? top : top + 4.0f, bottom);
+        if (group) {
+            g.setColour(DarkTheme::getSecondaryTextColour());
+            g.drawText(
+                juce::String(i + 1),
+                juce::Rectangle<float>(x + 2.0f, top, colW - 2.0f, bottom - top).toNearestInt(),
+                juce::Justification::centredLeft);
+        }
+    }
+
+    g.setColour(DarkTheme::getColour(DarkTheme::BORDER).withAlpha(0.4f));
+    g.drawHorizontalLine(area.getBottom() - 1, static_cast<float>(area.getX()),
+                         static_cast<float>(area.getRight()));
 }
 
 void StepSequencerUI::drawStepBoxes(juce::Graphics& g, juce::Rectangle<int> area) {

--- a/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/StepSequencerUI.hpp
@@ -72,13 +72,6 @@ class StepSequencerUI : public juce::Component,
     juce::Label quantizeSubLabel_;
     LinkableTextSlider quantizeSubSlider_;
 
-    // --- MIDI controls ---
-    std::unique_ptr<magda::SvgButton> midiThruButton_;
-    std::unique_ptr<magda::SvgButton> stepRecordButton_;
-
-    // --- Pattern generation ---
-    std::unique_ptr<magda::SvgButton> randomButton_;
-
     // --- State ---
     int selectedStep_ = 0;       // Currently selected step for editing
     int currentPlayStep_ = -1;   // Step being played (for highlight)
@@ -89,6 +82,7 @@ class StepSequencerUI : public juce::Component,
 
     // --- Layout constants ---
     static constexpr int CONTROL_ROW_HEIGHT = 22;
+    static constexpr int TIMELINE_HEIGHT = 12;
     static constexpr int STEP_BOX_SIZE = 22;
     static constexpr int TOGGLE_ROW_HEIGHT = 16;
     static constexpr int KEYBOARD_HEIGHT = 48;
@@ -104,6 +98,7 @@ class StepSequencerUI : public juce::Component,
     static constexpr int MAX_BASE_NOTE = 108;  // C8 (108 + 24 would be > 127)
 
     // --- Drawing helpers ---
+    void drawTimeline(juce::Graphics& g, juce::Rectangle<int> area);
     void drawStepBoxes(juce::Graphics& g, juce::Rectangle<int> area);
     void drawAccentRow(juce::Graphics& g, juce::Rectangle<int> area);
     void drawGlideTieRow(juce::Graphics& g, juce::Rectangle<int> area);
@@ -115,6 +110,7 @@ class StepSequencerUI : public juce::Component,
     int getKeyboardNoteAtPosition(juce::Point<int> pos, juce::Rectangle<int> area) const;
 
     // --- Layout bounds (computed in resized, used in paint/mouseDown) ---
+    juce::Rectangle<int> timelineArea_;
     juce::Rectangle<int> stepBoxArea_;
     juce::Rectangle<int> accentArea_;
     juce::Rectangle<int> glideTieArea_;

--- a/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceCustomUIManager.cpp
@@ -364,7 +364,7 @@ int DeviceCustomUIManager::getPreferredContentWidth(int drumGridFallback) const 
     if (stepSequencerUI_)
         return 500;
     if (polyStepSequencerUI_)
-        return 560;
+        return 720;  // 560 grid + ~156 right-hand control panel
     if (oscilloscopeUI_)
         return 500;
     if (spectrumAnalyzerUI_)

--- a/magda/daw/ui/components/chain/slot/DeviceSlotContentLayout.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotContentLayout.cpp
@@ -44,6 +44,7 @@ void layoutMeterStrip(juce::Rectangle<int>& contentArea, const DeviceSlotTraits&
         setVisibleIfPresent(controls.levelMeter, false);
         setVisibleIfPresent(controls.midiNoteStrip, false);
         setVisibleIfPresent(controls.gainSlider, false);
+        setVisibleIfPresent(controls.mixKnob, false);
         return;
     }
 
@@ -73,9 +74,11 @@ void layoutMeterStrip(juce::Rectangle<int>& contentArea, const DeviceSlotTraits&
     }
 
     if (controls.gainSlider != nullptr) {
-        // Analysis devices (oscilloscope / spectrum) are transparent passthroughs:
-        // no volume control. The level meter still shows.
-        if (traits.isAnalysis) {
+        // Analysis devices (oscilloscope / spectrum) are transparent passthroughs
+        // and MIDI utilities emit no audio: neither has a volume control. (The
+        // level meter still shows on analysis; MIDI utilities show the note
+        // strip instead.)
+        if (traits.isAnalysis || usesNoteStrip) {
             controls.gainSlider->setVisible(false);
         } else {
             controls.gainSlider->setBounds(stripBounds);
@@ -83,6 +86,10 @@ void layoutMeterStrip(juce::Rectangle<int>& contentArea, const DeviceSlotTraits&
             controls.gainSlider->toFront(false);
         }
     }
+
+    // No wet/dry mix on MIDI utilities — they have no audio to blend.
+    if (usesNoteStrip)
+        setVisibleIfPresent(controls.mixKnob, false);
 }
 
 void hideBodyControls(DeviceSlotContentFrameControls controls, bool collapsed) {
@@ -151,7 +158,14 @@ bool prepareDeviceSlotContentFrame(juce::Rectangle<int>& contentArea,
             setVisibleIfPresent(controls.pluginPresetsButton, false);
         }
 
-        layoutMeterStrip(contentArea, traits, controls, meterStripWidth);
+        // MIDI devices emit no audio, so they get no peak meter / gain fader /
+        // wet-dry mix. Note-strip utilities keep the strip for their MIDI
+        // activity display (gain + mix hidden inside layoutMeterStrip); any other
+        // MIDI device drops the strip entirely so the body uses the full width.
+        const bool isMidiDevice = device.deviceType == magda::DeviceType::MIDI;
+        const int effectiveMeterWidth =
+            (isMidiDevice && !isMidiUtility(traits)) ? 0 : meterStripWidth;
+        layoutMeterStrip(contentArea, traits, controls, effectiveMeterWidth);
     }
 
     contentArea.removeFromBottom(2);

--- a/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.cpp
@@ -72,6 +72,21 @@ void layoutExpandedDeviceSlotHeader(juce::Rectangle<int>& headerArea,
         setVisibleIfPresent(controls.aiButton, false);
     }
 
+    // Step-sequencer action buttons in the header, next to the AI button:
+    // randomize, step record, MIDI thru.
+    if (traits.isStepSequencer || traits.isPolyStepSequencer) {
+        setVisibleIfPresent(controls.randomButton, true);
+        setVisibleIfPresent(controls.stepRecordButton, true);
+        setVisibleIfPresent(controls.midiThruButton, true);
+        placeLeft(headerArea, controls.randomButton, buttonSize);
+        placeLeft(headerArea, controls.stepRecordButton, buttonSize);
+        placeLeft(headerArea, controls.midiThruButton, buttonSize);
+    } else {
+        setVisibleIfPresent(controls.randomButton, false);
+        setVisibleIfPresent(controls.stepRecordButton, false);
+        setVisibleIfPresent(controls.midiThruButton, false);
+    }
+
     if (isMidiUtility(traits)) {
         setVisibleIfPresent(controls.learnButton, false);
         setVisibleIfPresent(controls.sidechainButton, false);

--- a/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.hpp
@@ -19,6 +19,9 @@ struct DeviceSlotHeaderControls {
     juce::Component* powerButton = nullptr;
     juce::Component* presetButton = nullptr;
     juce::Component* exportClipButton = nullptr;
+    juce::Component* randomButton = nullptr;      // step-sequencer pattern randomize
+    juce::Component* stepRecordButton = nullptr;  // step-sequencer step record toggle
+    juce::Component* midiThruButton = nullptr;    // step-sequencer MIDI thru toggle
 };
 
 struct DeviceSlotCollapsedControls {

--- a/tests/test_midi_clip_sync.cpp
+++ b/tests/test_midi_clip_sync.cpp
@@ -482,8 +482,11 @@ TEST_CASE("BendNoteTimingCommand bends raw MIDI note starts and undoes exactly",
     BendNoteTimingCommand cmd(clipId, {0, 1, 2}, 0.25f, 0.0f, 1, 0.0f, 64, true);
     cmd.execute();
 
+    // Time bend parameterizes each note by its ordinal slot in the sequence
+    // (so stacked chord notes strum), not by absolute beat. The endpoints stay
+    // put (ordinal t=0 and t=1); the middle note bends to its ordinal position.
     REQUIRE(clip->midiNotes[0].startBeat == Catch::Approx(1.0));
-    REQUIRE(clip->midiNotes[1].startBeat == Catch::Approx(2.0));
+    REQUIRE(clip->midiNotes[1].startBeat == Catch::Approx(2.125));
     REQUIRE(clip->midiNotes[2].startBeat == Catch::Approx(3.0));
 
     cmd.undo();


### PR DESCRIPTION
Lands the poly/step sequencer work that didn't make it onto dev/0.12.0 with the #1530 squash (it only carried the MIDI-editor-timeline-on-top change).

- Poly Sequencer: right-side control panel, zoomable grid, mini timeline (step ruler).
- Mini timeline / step ruler added to the mono step sequencer and to the poly drum-lane mode (shared drawStepRuler helper, so keys and drum modes match).
- Piano-roll Time Bend now parameterizes each note by its ordinal slot in the sequence (sorted by onset then pitch) instead of absolute beat, so stacked chord notes fan out into a strum. Depth 0 stays identity; a uniform mono line is unchanged; a lone chord gets a strum window from its shortest note.
- Poly sequencer step recording (held chord lands on a step, advances on release) and randomize pattern.
- Device wrapper: drop peak meter / gain / mix for MIDI devices.

Built locally.