### PR TITLE
i18n: collapse duplicate Import/Export {0} strings into shared action…

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,4 +1,8 @@
 {
+  "action": {
+    "import": "Import {0}",
+    "export": "Export {0}"
+  },
   "menu": {
     "file": "File",
     "edit": "Edit",
@@ -19,9 +23,6 @@
     "file.project_settings": "Project Settings",
     "file.collect_files": "Collect Files",
     "file.export_audio": "Export Audio",
-    "file.export_midi": "Export {0}",
-    "file.import_dawproject": "Import {0}",
-    "file.export_dawproject": "Export {0}",
     "file.quit": "Quit",
     "edit.undo": "Undo",
     "edit.redo": "Redo",
@@ -147,8 +148,6 @@
     "save_project_as": "Save Project As",
     "close_project": "Close Project",
     "export_audio": "Export Audio",
-    "import_dawproject": "Import {0}",
-    "export_dawproject": "Export {0}",
     "plugin_settings": "Plugin Settings",
     "preferences": "Preferences",
     "about": "About MAGDA",
@@ -221,8 +220,7 @@
     "option.entire_song": "Entire Song",
     "option.time_selection": "Time Selection",
     "option.loop_region": "Loop Region",
-    "button.export": "Export",
-    "dialog.title": "Export {0}"
+    "button.export": "Export"
   },
   "gain_staging": {
     "dialog.title": "Gain Staging",
@@ -285,7 +283,6 @@
     "alert.cancelled_body": "Export was cancelled.",
     "alert.complete_title": "Export Complete",
     "alert.failed_title": "Export Failed",
-    "alert.midi_title": "Export {0}",
     "alert.audio_success_prefix": "Audio exported successfully to:",
     "alert.midi_success_prefix": "{0} exported successfully to:",
     "error.trim_failed": "Render succeeded but failed to trim preroll.",

--- a/magda/daw/ui/dialogs/ExportMidiDialog.cpp
+++ b/magda/daw/ui/dialogs/ExportMidiDialog.cpp
@@ -138,8 +138,7 @@ void ExportMidiDialog::showDialog(juce::Component* parent,
 
     juce::DialogWindow::LaunchOptions options;
     options.dialogTitle =
-        tr("export_midi.dialog.title")
-            .replace("{0}", magda::technicalText(magda::TechnicalTextToken::Midi));
+        tr("action.export").replace("{0}", magda::technicalText(magda::TechnicalTextToken::Midi));
     options.dialogBackgroundColour = DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND);
     options.content.setOwned(dialog);
     options.escapeKeyTriggersCloseButton = true;

--- a/magda/daw/ui/windows/MainWindowExport.cpp
+++ b/magda/daw/ui/windows/MainWindowExport.cpp
@@ -490,7 +490,7 @@ void MainWindow::performMidiExport(const ExportMidiDialog::Settings& settings) {
         DBG("No MIDI clips found - rangeEndBeats <= rangeStartBeats");
         juce::AlertWindow::showMessageBoxAsync(
             juce::AlertWindow::WarningIcon,
-            tr("export.alert.midi_title")
+            tr("action.export")
                 .replace("{0}", magda::technicalText(magda::TechnicalTextToken::Midi)),
             tr("export.error.no_midi_clips")
                 .replace("{0}", magda::technicalText(magda::TechnicalTextToken::Midi)));
@@ -537,7 +537,7 @@ void MainWindow::performMidiExport(const ExportMidiDialog::Settings& settings) {
         DBG("No MIDI clips with notes found");
         juce::AlertWindow::showMessageBoxAsync(
             juce::AlertWindow::WarningIcon,
-            tr("export.alert.midi_title")
+            tr("action.export")
                 .replace("{0}", magda::technicalText(magda::TechnicalTextToken::Midi)),
             tr("export.error.no_midi_notes")
                 .replace("{0}", magda::technicalText(magda::TechnicalTextToken::Midi)));
@@ -555,8 +555,7 @@ void MainWindow::performMidiExport(const ExportMidiDialog::Settings& settings) {
 
     // Launch file chooser
     fileChooser_ = std::make_unique<juce::FileChooser>(
-        tr("export.alert.midi_title")
-            .replace("{0}", magda::technicalText(magda::TechnicalTextToken::Midi)),
+        tr("action.export").replace("{0}", magda::technicalText(magda::TechnicalTextToken::Midi)),
         defaultFile, "*.mid", true);
 
     auto flags = juce::FileBrowserComponent::saveMode | juce::FileBrowserComponent::canSelectFiles |

--- a/magda/daw/ui/windows/MainWindowMenus.cpp
+++ b/magda/daw/ui/windows/MainWindowMenus.cpp
@@ -157,7 +157,7 @@ void MainWindow::importDawProjectFile(const juce::File& file) {
         if (error.isNotEmpty())
             juce::AlertWindow::showMessageBoxAsync(
                 juce::AlertWindow::WarningIcon,
-                tr("dialogs.import_dawproject")
+                tr("action.import")
                     .replace("{0}", magda::technicalText(magda::TechnicalTextToken::DawProject)),
                 error);
     }
@@ -431,7 +431,7 @@ void MainWindow::setupMenuCallbacks() {
             return;
 
         fileChooser_ = std::make_unique<juce::FileChooser>(
-            tr("dialogs.import_dawproject")
+            tr("action.import")
                 .replace("{0}", magda::technicalText(magda::TechnicalTextToken::DawProject)),
             juce::File::getSpecialLocation(juce::File::userDocumentsDirectory), "*.dawproject",
             true);
@@ -461,7 +461,7 @@ void MainWindow::setupMenuCallbacks() {
                               : juce::File::getSpecialLocation(juce::File::userDocumentsDirectory);
 
         fileChooser_ = std::make_unique<juce::FileChooser>(
-            tr("dialogs.export_dawproject")
+            tr("action.export")
                 .replace("{0}", magda::technicalText(magda::TechnicalTextToken::DawProject)),
             initialDir, "*.dawproject", true);
 
@@ -483,7 +483,7 @@ void MainWindow::setupMenuCallbacks() {
             if (!projectManager.exportDawProject(file)) {
                 juce::AlertWindow::showMessageBoxAsync(
                     juce::AlertWindow::WarningIcon,
-                    tr("dialogs.export_dawproject")
+                    tr("action.export")
                         .replace("{0}",
                                  magda::technicalText(magda::TechnicalTextToken::DawProject)),
                     tr("dialogs.error.export_failed") + " " + projectManager.getLastError());

--- a/magda/daw/ui/windows/MenuManager.cpp
+++ b/magda/daw/ui/windows/MenuManager.cpp
@@ -109,18 +109,18 @@ juce::PopupMenu MenuManager::getMenuForIndex(int topLevelMenuIndex,
             menu.addSeparator();
             menu.addItem(ExportAudio, trEllipsis("menu.file.export_audio"), true, false);
             menu.addItem(ExportMidi,
-                         trEllipsis("menu.file.export_midi")
+                         trEllipsis("action.export")
                              .replace("{0}", magda::technicalText(magda::TechnicalTextToken::Midi)),
                          true, false);
             menu.addSeparator();
             menu.addItem(
                 ImportDawProject,
-                trEllipsis("menu.file.import_dawproject")
+                trEllipsis("action.import")
                     .replace("{0}", magda::technicalText(magda::TechnicalTextToken::DawProject)),
                 true, false);
             menu.addItem(
                 ExportDawProject,
-                trEllipsis("menu.file.export_dawproject")
+                trEllipsis("action.export")
                     .replace("{0}", magda::technicalText(magda::TechnicalTextToken::DawProject)),
                 true, false);
 


### PR DESCRIPTION
… keys

The same source text was duplicated across many keys (menu items, dialog titles, alerts, file choosers), so Crowdin listed "Import {0}" / "Export {0}" as 2 and 5+ separate strings to translate independently — and the count grew with every i18n change.

Add action.import / action.export and point all call sites at them, filling {0} with the per-context TechnicalText token (DAWproject / MIDI). Remove the 7 now-redundant keys (menu.file.export_midi, menu.file.import_dawproject, menu.file.export_dawproject, dialogs.import_dawproject, dialogs.export_dawproject, export_midi.dialog.title, export.alert.midi_title).

Crowdin now has one Import {0} and one Export {0} string, translated once.