### PR TITLE
i18n: make fully-technical labels non-translatable (24-bit FLAC, Hex RGB)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -209,8 +209,7 @@
     "button.export": "Export",
     "bit_depth.16": "16-bit",
     "bit_depth.24": "24-bit",
-    "bit_depth.32_float": "32-bit Float",
-    "bit_depth.24_flac": "24-bit ({0})"
+    "bit_depth.32_float": "32-bit Float"
   },
   "export_midi": {
     "label.midi_format": "{0} Format:",
@@ -356,7 +355,6 @@
     "button.reveal_explorer": "Show in Explorer",
     "button.reveal_files": "Open in file manager",
     "colours.colour": "Colour",
-    "colours.hex_rgb": "Hex ({0})",
     "colours.name": "Name",
     "colours.new_default_name": "New",
     "colours.default_name_prefix": "Colour",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -192,8 +192,7 @@
     "button.export": "エクスポート",
     "bit_depth.16": "16-bit",
     "bit_depth.24": "24-bit",
-    "bit_depth.32_float": "32-bit 浮動小数点数",
-    "bit_depth.24_flac": "24-bit ({0})"
+    "bit_depth.32_float": "32-bit 浮動小数点数"
   },
   "export_midi": {
     "label.midi_format": "{0} フォーマット：",
@@ -339,7 +338,6 @@
     "button.reveal_explorer": "エクスプローラーで表示",
     "button.reveal_files": "ファイルマネージャーで開く",
     "colours.colour": "色",
-    "colours.hex_rgb": "Hex ({0})",
     "colours.name": "名前",
     "colours.new_default_name": "新しい名前を入れてください",
     "colours.default_name_prefix": "色",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -192,8 +192,7 @@
     "button.export": "Экспортировать",
     "bit_depth.16": "16 бит",
     "bit_depth.24": "24 бит",
-    "bit_depth.32_float": "32 бит с плавающей точкой",
-    "bit_depth.24_flac": "24 бит ({0})"
+    "bit_depth.32_float": "32 бит с плавающей точкой"
   },
   "export_midi": {
     "label.midi_format": "Формат {0}:",
@@ -339,7 +338,6 @@
     "button.reveal_explorer": "Показать в Проводнике",
     "button.reveal_files": "Открыть в файловом менеджере",
     "colours.colour": "Цвет",
-    "colours.hex_rgb": "Hex ({0})",
     "colours.name": "Название",
     "colours.new_default_name": "Новый",
     "colours.default_name_prefix": "Цвет",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -192,8 +192,7 @@
     "button.export": "导出",
     "bit_depth.16": "16位",
     "bit_depth.24": "24位",
-    "bit_depth.32_float": "32位浮点",
-    "bit_depth.24_flac": "24位（{0}）"
+    "bit_depth.32_float": "32位浮点"
   },
   "export_midi": {
     "label.midi_format": "{0}格式：",
@@ -339,7 +338,6 @@
     "button.reveal_explorer": "在资源管理器中显示",
     "button.reveal_files": "在文件管理器中打开",
     "colours.colour": "颜色",
-    "colours.hex_rgb": "十六进制（{0}）",
     "colours.name": "名称",
     "colours.new_default_name": "新建",
     "colours.default_name_prefix": "颜色",

--- a/magda/daw/core/TechnicalText.hpp
+++ b/magda/daw/core/TechnicalText.hpp
@@ -37,6 +37,7 @@ enum class TechnicalTextToken {
     Json,
     Flac,
     Rgb,
+    Hex,
     Lua,
 };
 
@@ -103,6 +104,8 @@ inline juce::String technicalText(TechnicalTextToken token) {
             return "FLAC";
         case TechnicalTextToken::Rgb:
             return "RGB";
+        case TechnicalTextToken::Hex:
+            return "Hex";
         case TechnicalTextToken::Lua:
             return "Lua";
     }

--- a/magda/daw/ui/dialogs/ExportAudioDialog.cpp
+++ b/magda/daw/ui/dialogs/ExportAudioDialog.cpp
@@ -307,10 +307,11 @@ void ExportAudioDialog::updateBitDepthOptions() {
         case 3:  // WAV 32-bit Float
             bitDepthText = tr("export_audio.bit_depth.32_float");
             break;
-        case 4:  // FLAC
-            bitDepthText =
-                tr("export_audio.bit_depth.24_flac")
-                    .replace("{0}", magda::technicalText(magda::TechnicalTextToken::Flac));
+        case 4:  // FLAC — "24-bit (FLAC)"; the format suffix is a fixed technical
+                 // token, so compose from the translatable 24-bit label rather
+                 // than a separate (untranslatable) string.
+            bitDepthText = tr("export_audio.bit_depth.24") + " (" +
+                           magda::technicalText(magda::TechnicalTextToken::Flac) + ")";
             break;
         default:
             bitDepthText = tr("export_audio.bit_depth.24");

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -674,10 +674,11 @@ class ColoursPage : public juce::Component {
                                     DarkTheme::getColour(DarkTheme::TEXT_SECONDARY));
         addAndMakeVisible(colourHeaderLabel);
 
-        hexHeaderLabel.setText(
-            tr("preferences.colours.hex_rgb")
-                .replace("{0}", magda::technicalText(magda::TechnicalTextToken::Rgb)),
-            juce::dontSendNotification);
+        // "Hex (RGB)" — both terms are fixed technical notation, identical in
+        // every locale, so they are tokens rather than a translatable string.
+        hexHeaderLabel.setText(magda::technicalText(magda::TechnicalTextToken::Hex) + " (" +
+                                   magda::technicalText(magda::TechnicalTextToken::Rgb) + ")",
+                               juce::dontSendNotification);
         hexHeaderLabel.setFont(FontManager::getInstance().getUIFont(11.0f));
         hexHeaderLabel.setColour(juce::Label::textColourId,
                                  DarkTheme::getColour(DarkTheme::TEXT_SECONDARY));


### PR DESCRIPTION
\`24-bit (FLAC)\` and \`Hex (RGB)\` are entirely technical notation — identical in every locale — so translating them was pointless and tripped Crowdin's "missing variable" QA on each.

- Add a `Hex` `TechnicalText` token (alongside RGB/FLAC).
- `PreferencesDialog`: compose `Hex (RGB)` from the Hex + RGB tokens.
- `ExportAudioDialog`: compose `24-bit (FLAC)` from the **translatable** `bit_depth.24` label + FLAC token, so the 24-bit part still localizes (e.g. `24位`).
- Remove `export_audio.bit_depth.24_flac` and `preferences.colours.hex_rgb` from all locale files — they drop off Crowdin on the next source sync, clearing the warnings.