### PR TITLE
Fix missing libxml2 on Windows; derive version dynamically

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-# Clang-Format Configuration for Magica DAW
+# Clang-Format Configuration for MAGDA DAW
 # Based on LLVM style with customizations for C++ audio development
 
 BasedOnStyle: LLVM

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-# Clang-Tidy Configuration for Magica DAW
+# Clang-Tidy Configuration for MAGDA DAW
 # Static analysis and linting rules for C++ audio development
 
 # Enable checks - comprehensive but practical set

--- a/.clangd
+++ b/.clangd
@@ -1,4 +1,4 @@
-# Clangd Configuration for Magica DAW
+# Clangd Configuration for MAGDA DAW
 # Language server settings for IDE integration
 
 CompileFlags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -729,19 +729,23 @@ jobs:
           Write-Warning "magda_plugin_scanner.exe not found at $scanner"
         }
 
-        # ONNX Runtime DLLs. The build's POST_BUILD step copies these next to
-        # MAGDA.exe; they are delay-loaded by the media DB sample tagger and
-        # Windows only resolves DLLs from the exe's own directory, so they must
-        # ship in the install dir. Required: a missing DLL is a broken release.
-        $onnxDlls = @("onnxruntime.dll", "onnxruntime_providers_shared.dll")
-        foreach ($dll in $onnxDlls) {
-          $src = Join-Path $exeDir $dll
-          if (-not (Test-Path $src)) {
-            Write-Error "$dll missing next to MAGDA.exe at $src"
+        # Runtime DLLs sitting next to MAGDA.exe: the ONNX Runtime DLLs (media DB
+        # sample tagger) and libxml2.dll + its transitive deps (DAWproject XSD
+        # validation), all placed there by the build's POST_BUILD steps. Windows
+        # only resolves DLLs from the exe's own directory, so every one must ship
+        # in the install dir. Stage them all rather than hardcoding names, so a
+        # new vcpkg dep can't silently go missing - then assert the critical ones
+        # are present, because a missing DLL is a broken release.
+        $dlls = Get-ChildItem -Path $exeDir -Filter *.dll -File
+        foreach ($required in @("onnxruntime.dll", "onnxruntime_providers_shared.dll", "libxml2.dll")) {
+          if (-not ($dlls | Where-Object { $_.Name -ieq $required })) {
+            Write-Error "$required missing next to MAGDA.exe at $exeDir"
             exit 1
           }
-          Copy-Item $src "$stage\$dll"
-          Write-Output "Staged $dll for installer"
+        }
+        foreach ($dll in $dlls) {
+          Copy-Item $dll.FullName "$stage\$($dll.Name)"
+          Write-Output "Staged $($dll.Name) for installer"
         }
 
         Copy-Item -Recurse "lang" "$stage\lang"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Pre-commit configuration for Magica DAW
+# Pre-commit configuration for MAGDA DAW
 # Automatic code formatting and quality checks on commit
 
 repos:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,31 @@ if(APPLE AND NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
     set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "Minimum macOS version")
 endif()
 
-project(Magda VERSION 0.1.0 LANGUAGES C CXX)
+# Windows has no system libxml2 (see vcpkg.json); it comes from vcpkg, which CI
+# wires in via -DCMAKE_TOOLCHAIN_FILE. For local dev (CLion, plain cmake, the
+# Makefile) auto-detect a vcpkg install from the VCPKG_ROOT environment variable
+# so find_package(LibXml2) resolves without anyone passing the toolchain by hand.
+# Must run before project(); an explicit -DCMAKE_TOOLCHAIN_FILE still wins, and
+# on macOS/Linux (system libxml2, no VCPKG_ROOT) this is a no-op.
+if(NOT DEFINED CMAKE_TOOLCHAIN_FILE AND DEFINED ENV{VCPKG_ROOT})
+    set(_magda_vcpkg_toolchain "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+    if(EXISTS "${_magda_vcpkg_toolchain}")
+        set(CMAKE_TOOLCHAIN_FILE "${_magda_vcpkg_toolchain}"
+            CACHE STRING "Vcpkg toolchain file")
+    endif()
+    unset(_magda_vcpkg_toolchain)
+endif()
 
-# Display version: prefer explicit -DMAGDA_FULL_VERSION (set by release CI), else
-# derive from git tags (e.g. "0.1.0-rc2" or "0.1.0-rc2-15-g1391223").
+# Derive the version dynamically instead of hardcoding it. Prefer an explicit
+# -DMAGDA_FULL_VERSION (set by release CI); otherwise read it from git tags
+# (e.g. "0.12.0-rc2" or "0.12.0-rc2-15-g1391223"). This runs before project() so
+# the numeric component can feed project(VERSION ...). MAGDA_FALLBACK_VERSION
+# covers builds with no git history or tags (e.g. a source tarball).
+set(MAGDA_FALLBACK_VERSION "0.1.0")
 if(NOT DEFINED MAGDA_FULL_VERSION OR MAGDA_FULL_VERSION STREQUAL "")
     execute_process(
         COMMAND git describe --tags --always
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         OUTPUT_VARIABLE MAGDA_GIT_VERSION
         OUTPUT_STRIP_TRAILING_WHITESPACE
         ERROR_QUIET
@@ -21,20 +38,22 @@ if(NOT DEFINED MAGDA_FULL_VERSION OR MAGDA_FULL_VERSION STREQUAL "")
     if(GIT_DESCRIBE_RESULT EQUAL 0 AND MAGDA_GIT_VERSION MATCHES "^v?(.+)$")
         set(MAGDA_FULL_VERSION "${CMAKE_MATCH_1}")
     else()
-        set(MAGDA_FULL_VERSION "${PROJECT_VERSION}")
+        set(MAGDA_FULL_VERSION "${MAGDA_FALLBACK_VERSION}")
     endif()
 endif()
 
-# Bundle version for the executable metadata (macOS CFBundleShortVersionString /
-# CFBundleVersion, Windows VERSIONINFO). These fields require a numeric dotted
-# version, so strip any pre-release / git-describe suffix from MAGDA_FULL_VERSION
-# (e.g. "0.9.0-rc2-15-g1391223" -> "0.9.0"). Falls back to PROJECT_VERSION when
-# there is no leading numeric component (e.g. a bare commit hash).
-if(MAGDA_FULL_VERSION MATCHES "^([0-9]+(\\.[0-9]+)+)")
+# Numeric dotted version for project() and the executable metadata (macOS
+# CFBundleShortVersionString / CFBundleVersion, Windows VERSIONINFO). These
+# require a plain X.Y.Z, so strip any pre-release / git-describe suffix from
+# MAGDA_FULL_VERSION (e.g. "0.12.0-rc2-15-g1391223" -> "0.12.0"). Falls back when
+# there is no leading numeric component (e.g. a bare commit hash from --always).
+if(MAGDA_FULL_VERSION MATCHES "^v?([0-9]+(\\.[0-9]+)+)")
     set(MAGDA_BUNDLE_VERSION "${CMAKE_MATCH_1}")
 else()
-    set(MAGDA_BUNDLE_VERSION "${PROJECT_VERSION}")
+    set(MAGDA_BUNDLE_VERSION "${MAGDA_FALLBACK_VERSION}")
 endif()
+
+project(Magda VERSION ${MAGDA_BUNDLE_VERSION} LANGUAGES C CXX)
 
 # ccache disabled - causes unnecessary rebuilds with Ninja
 # The interaction between ccache, Ninja, and JUCE's glob verification

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ See [Issues](https://github.com/Conceptual-Machines/magda-core/issues) for known
   (CJK font, etc.). Install with `brew install git-lfs` (macOS),
   `apt install git-lfs` (Debian/Ubuntu), or `choco install git-lfs` (Windows),
   then run `git lfs install` once per machine.
+- **Windows only:** [vcpkg](https://github.com/microsoft/vcpkg) supplies libxml2
+  (there is no system copy on Windows). Clone and bootstrap it once, then set a
+  `VCPKG_ROOT` environment variable pointing at the checkout — the build
+  auto-detects it and installs libxml2 from the `vcpkg.json` manifest on first
+  configure. On macOS/Linux libxml2 comes from the system, so no vcpkg is needed.
+
+  ```powershell
+  git clone https://github.com/microsoft/vcpkg C:\vcpkg
+  C:\vcpkg\bootstrap-vcpkg.bat
+  setx VCPKG_ROOT C:\vcpkg   # reopen the shell so it takes effect
+  ```
 
 ### Quick Start
 

--- a/magda/agents/mcp/MCPClient.cpp
+++ b/magda/agents/mcp/MCPClient.cpp
@@ -1,5 +1,7 @@
 #include "MCPClient.hpp"
 
+#include "version.hpp"
+
 #if JUCE_WINDOWS
 #include <windows.h>
 #else
@@ -91,7 +93,7 @@ bool MCPClient::start() {
 
     auto* clientInfo = new juce::DynamicObject();
     clientInfo->setProperty("name", "MAGDA");
-    clientInfo->setProperty("version", "0.8.0");
+    clientInfo->setProperty("version", MAGDA_VERSION);
     initParams->setProperty("clientInfo", juce::var(clientInfo));
 
     auto response = sendRpc("initialize", juce::var(initParams));

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -290,8 +290,14 @@ add_library(magda_daw STATIC
 # JUCE GUI app — sources contributed below via add_subdirectory().
 juce_add_gui_app(magda_daw_app
     VERSION "${MAGDA_BUNDLE_VERSION}"
-    COMPANY_NAME "MAGDA"
+    COMPANY_NAME "Conceptual Machines"
     PRODUCT_NAME "MAGDA"
+    # Pin the bundle identifier so renaming COMPANY_NAME does not change it.
+    # JUCE derives BUNDLE_ID from COMPANY_NAME + PRODUCT_NAME by default; without
+    # this pin it would become com.ConceptualMachines.MAGDA, relocating user
+    # settings (the OS keys prefs/permissions off the bundle ID) and changing the
+    # macOS signing identity. Keep the original com.MAGDA.MAGDA.
+    BUNDLE_ID "com.MAGDA.MAGDA"
     ICON_BIG "${CMAKE_CURRENT_SOURCE_DIR}/../../assets/app_icon.png"
     ICON_SMALL "${CMAKE_CURRENT_SOURCE_DIR}/../../assets/app_icon.png"
     MICROPHONE_PERMISSION_ENABLED TRUE
@@ -343,8 +349,11 @@ endif()
 # Out-of-process plugin scanner.
 juce_add_console_app(magda_plugin_scanner
     VERSION "${MAGDA_BUNDLE_VERSION}"
-    COMPANY_NAME "MAGDA"
+    COMPANY_NAME "Conceptual Machines"
     PRODUCT_NAME "MAGDA Plugin Scanner"
+    # Pin the bundle identifier so the COMPANY_NAME rename does not change it
+    # (see magda_daw_app above). Keep the original com.MAGDA.MAGDAPluginScanner.
+    BUNDLE_ID "com.MAGDA.MAGDAPluginScanner"
 )
 
 target_sources(magda_plugin_scanner PRIVATE
@@ -723,4 +732,20 @@ if(MAGDA_HAVE_CLAP)
             COMMENT "Copying ONNX Runtime DLLs alongside app executable"
         )
     endif()
+endif()
+
+# libxml2 (DAWproject XSD validation) comes from vcpkg on Windows and links as a
+# DLL. Windows only searches the exe's own directory, so copy libxml2.dll plus
+# its transitive runtime deps next to the executable. TARGET_RUNTIME_DLLS
+# resolves the full closure from the imported vcpkg targets, so we don't have to
+# track the exact dep set (iconv/lzma/zlib/...) by hand. Unconditional on
+# Windows: libxml2 is always linked (unlike ONNX, which is gated on CLAP).
+if(WIN32)
+    add_custom_command(TARGET magda_daw_app POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_RUNTIME_DLLS:magda_daw_app>"
+            "$<TARGET_FILE_DIR:magda_daw_app>"
+        COMMAND_EXPAND_LISTS
+        COMMENT "Copying runtime DLLs (libxml2 + deps) alongside app executable"
+    )
 endif()

--- a/packaging/windows/magda-installer.nsi
+++ b/packaging/windows/magda-installer.nsi
@@ -34,12 +34,13 @@ Section "Install"
     File "${__FILEDIR__}\mgd_doc_icon.ico"
     File /nonfatal "${__FILEDIR__}\magda_plugin_scanner.exe"
 
-    ; ONNX Runtime DLLs - delay-loaded by the media DB sample tagger.
-    ; Windows only searches the exe's directory, so these must sit next to
-    ; MAGDA.exe or the first inference call faults. Required (not /nonfatal):
-    ; a missing DLL here means a broken release, so fail the build loudly.
-    File "${__FILEDIR__}\onnxruntime.dll"
-    File "${__FILEDIR__}\onnxruntime_providers_shared.dll"
+    ; All runtime DLLs staged next to MAGDA.exe: ONNX Runtime (delay-loaded by
+    ; the media DB sample tagger) and libxml2 + its transitive deps (DAWproject
+    ; XSD validation). Windows only searches the exe's directory, so these must
+    ; sit next to MAGDA.exe or the dependent call faults. The release staging
+    ; step asserts the critical DLLs are present, so this fails loudly upstream
+    ; if one goes missing.
+    File "${__FILEDIR__}\*.dll"
 
     ; Localization JSON files - StringTable looks for them next to MAGDA.exe
     SetOutPath "$INSTDIR\lang"
@@ -102,8 +103,7 @@ Section "Uninstall"
     Delete "$INSTDIR\MAGDA.exe"
     Delete "$INSTDIR\mgd_doc_icon.ico"
     Delete "$INSTDIR\magda_plugin_scanner.exe"
-    Delete "$INSTDIR\onnxruntime.dll"
-    Delete "$INSTDIR\onnxruntime_providers_shared.dll"
+    Delete "$INSTDIR\*.dll"
     Delete "$INSTDIR\Uninstall.exe"
     RMDir /r "$INSTDIR\lang"
     RMDir /r "$INSTDIR\controllers"

--- a/setup.sh
+++ b/setup.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Magica DAW Setup Script
+# MAGDA DAW Setup Script
 # This script handles all the initial setup including git submodules
 
 set -e  # Exit on any error
 
-echo "🔮 Magica DAW Setup Script"
+echo "🔮 MAGDA DAW Setup Script"
 echo "=========================="
 
 # Colors for output
@@ -34,7 +34,7 @@ print_error() {
 
 # Check if we're in a git repository
 if [ ! -d ".git" ]; then
-    print_error "This script must be run from the root of the Magica repository"
+    print_error "This script must be run from the root of the MAGDA repository"
     exit 1
 fi
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -190,9 +190,12 @@ endif()
 
 # JUCE Unit Test Console Application
 juce_add_console_app(magda_juce_tests
-    VERSION "0.1.0"
-    COMPANY_NAME "MAGDA"
-    PRODUCT_NAME "Magica JUCE Tests"
+    VERSION "${MAGDA_BUNDLE_VERSION}"
+    COMPANY_NAME "Conceptual Machines"
+    PRODUCT_NAME "Magda JUCE Tests"
+    # Pin a space-free bundle ID; the company name alone would derive
+    # 'com.Conceptual Machines.magda_juce_tests', which JUCE rejects.
+    BUNDLE_ID "com.MAGDA.MagdaJuceTests"
 )
 
 # Add JUCE test sources
@@ -325,5 +328,20 @@ if(MAGDA_HAVE_CLAP AND WIN32)
                 "${ONNXRUNTIME_LIB_DIR}/onnxruntime_providers_shared.dll"
                 "$<TARGET_FILE_DIR:${test_target}>"
             COMMENT "Copying ONNX Runtime DLLs alongside ${test_target}")
+    endforeach()
+endif()
+
+# magda_daw also links libxml2 (DAWproject validation), a DLL on Windows. Mirror
+# the app's runtime-DLL copy so DawProjectValidator tests find libxml2.dll (+ its
+# transitive deps) next to each test exe instead of faulting at load. Unlike the
+# ONNX copy this is not gated on CLAP, since libxml2 is always linked.
+if(WIN32)
+    foreach(test_target magda_tests magda_juce_tests)
+        add_custom_command(TARGET ${test_target} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "$<TARGET_RUNTIME_DLLS:${test_target}>"
+                "$<TARGET_FILE_DIR:${test_target}>"
+            COMMAND_EXPAND_LISTS
+            COMMENT "Copying runtime DLLs (libxml2 + deps) alongside ${test_target}")
     endforeach()
 endif()


### PR DESCRIPTION
## Problem
Windows had no system libxml2. CI installed it via vcpkg, but the release installer never bundled `libxml2.dll`, and local dev never wired the vcpkg toolchain — so `find_package(LibXml2 REQUIRED)` failed at configure and the shipped app faulted at launch on the missing DLL.

## Changes
- **Bundle the DLLs:** copy `libxml2.dll` + transitive deps next to the app and test exes via `TARGET_RUNTIME_DLLS`; stage every `*.dll` into the installer (with guards on the critical ones) and wildcard the NSIS `File`/`Delete`.
- **Local dev:** auto-detect `VCPKG_ROOT` in the top-level `CMakeLists.txt`; document the one-time vcpkg setup in the README.
- **Version:** derive `project()` / `MAGDA_VERSION` from git tags instead of hardcoded `0.1.0`; `MCPClient` reports `MAGDA_VERSION` instead of stale `"0.8.0"`.
- **Naming:** rename leftover `Magica` → MAGDA in tooling configs; set `COMPANY_NAME` to "Conceptual Machines" with pinned `BUNDLE_ID`s so identifiers and user-data paths are unchanged.

## Verification
Local Windows build (vcpkg auto-detected via `VCPKG_ROOT`, no manual toolchain flag): configure + build of `magda_daw_app` and `magda_tests` succeeded, and `libxml2.dll` + `iconv-2.dll` + zlib landed next to both executables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)