### PR TITLE
ci: skip C++ build/tests on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
     # Belt-and-suspenders: also skip when a push only touches translation files.
     paths-ignore:
       - 'lang/**'
+      - 'manual/**'
+      - 'docs/**'
+      - '**/*.md'
   workflow_dispatch:
     inputs:
       skip-cpp-build:

--- a/.github/workflows/juce-tests-linux.yml
+++ b/.github/workflows/juce-tests-linux.yml
@@ -10,6 +10,9 @@ on:
     tags-ignore: [ '**' ]
     paths-ignore:
       - 'lang/**'
+      - 'manual/**'
+      - 'docs/**'
+      - '**/*.md'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Add manual/**, docs/** and **/*.md to paths-ignore in ci.yml and juce-tests-linux.yml so pushes that only touch documentation no longer kick off the full self-hosted build (only lang/** was excluded before).