### PR TITLE
Fix third-party MIDI sequencers not triggering downstream instruments

### DIFF
--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -472,10 +472,12 @@ void AudioBridge::devicePropertyChanged(const ChainNodePath& devicePath) {
     // instrument wrapper racks; post-fx/mixer-analysis ids are section-local and
     // can overlap with a top-level instrument id.
     if (devicePath.getType() == ChainNodeType::TopLevelDevice) {
-        if (auto* rackInstance =
-                pluginManager_.getInstrumentRackManager().getRackInstance(deviceId)) {
+        auto& rackManager = pluginManager_.getInstrumentRackManager();
+        if (auto* rackInstance = rackManager.getRackInstance(deviceId)) {
             rackInstance->setEnabled(!device->bypassed);
         }
+        // Keep the wrapper's "MIDI in thru" passthrough in sync with the model.
+        rackManager.setMidiInThru(deviceId, device->midiInThru);
     }
 
     // Push gain to the audio-graph atomic so DeviceGainNode picks it up.

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -1270,9 +1270,10 @@ void PluginManager::pollAsyncPluginLoad(const ChainNodePath& devicePath, te::Plu
                     te::Plugin::Ptr rackPlugin;
                     if (numOutputChannels > 2) {
                         rackPlugin = self.instrumentRackManager_.wrapMultiOutInstrument(
-                            plugin, numOutputChannels);
+                            plugin, numOutputChannels, devInfo->midiInThru);
                     } else {
-                        rackPlugin = self.instrumentRackManager_.wrapInstrument(plugin);
+                        rackPlugin =
+                            self.instrumentRackManager_.wrapInstrument(plugin, devInfo->midiInThru);
                     }
 
                     if (rackPlugin) {
@@ -2236,10 +2237,10 @@ te::Plugin::Ptr PluginManager::loadDeviceAsPlugin(const ChainNodePath& devicePat
 
             te::Plugin::Ptr rackPlugin;
             if (numOutputChannels > 2) {
-                rackPlugin =
-                    instrumentRackManager_.wrapMultiOutInstrument(plugin, numOutputChannels);
+                rackPlugin = instrumentRackManager_.wrapMultiOutInstrument(
+                    plugin, numOutputChannels, device.midiInThru);
             } else {
-                rackPlugin = instrumentRackManager_.wrapInstrument(plugin);
+                rackPlugin = instrumentRackManager_.wrapInstrument(plugin, device.midiInThru);
             }
 
             if (rackPlugin) {

--- a/magda/daw/audio/racks/InstrumentRackManager.cpp
+++ b/magda/daw/audio/racks/InstrumentRackManager.cpp
@@ -29,7 +29,7 @@ te::Plugin::Ptr findMeterTapPlugin(te::RackType::Ptr rackType) {
 
 InstrumentRackManager::InstrumentRackManager(te::Edit& edit) : edit_(edit) {}
 
-te::Plugin::Ptr InstrumentRackManager::wrapInstrument(te::Plugin::Ptr instrument) {
+te::Plugin::Ptr InstrumentRackManager::wrapInstrument(te::Plugin::Ptr instrument, bool midiInThru) {
     if (!instrument) {
         return nullptr;
     }
@@ -76,10 +76,19 @@ te::Plugin::Ptr InstrumentRackManager::wrapInstrument(te::Plugin::Ptr instrument
     // MIDI: rack input pin 0 --> synth pin 0
     rackType->addConnection(rackIOId, 0, synthId, 0);
 
-    // Keep MIDI flowing to later track-chain devices. MIDI-triggered FX such
-    // as ShaperBox need the original note stream even when an instrument sits
-    // before them in the chain.
-    rackType->addConnection(rackIOId, 0, rackIOId, 0);
+    // A wrapped plugin's OWN MIDI output always flows to the rack output, so a
+    // MIDI-producing plugin (sequencer, arpeggiator -- e.g. Stochas) triggers
+    // instruments downstream of it in the chain. This is unconditional: a plain
+    // synth emits no MIDI, so the connection simply carries nothing.
+    rackType->addConnection(synthId, 0, rackIOId, 0);
+
+    // The rack's raw MIDI INPUT passing straight through (bypassing the plugin)
+    // is the user-controlled "MIDI in thru" toggle. Off by default: an arp then
+    // forwards only its transformed stream rather than that plus the dry notes.
+    // Enable it to feed a MIDI-triggered FX (e.g. ShaperBox) sitting after the
+    // instrument. See setMidiInThru().
+    if (midiInThru)
+        rackType->addConnection(rackIOId, 0, rackIOId, 0);
 
     // Audio passthrough: rack input pin 1 --> rack output pin 1 (left)
     rackType->addConnection(rackIOId, 1, rackIOId, 1);
@@ -112,9 +121,10 @@ te::Plugin::Ptr InstrumentRackManager::wrapInstrument(te::Plugin::Ptr instrument
 }
 
 te::Plugin::Ptr InstrumentRackManager::wrapMultiOutInstrument(te::Plugin::Ptr instrument,
-                                                              int numOutputChannels) {
+                                                              int numOutputChannels,
+                                                              bool midiInThru) {
     if (!instrument || numOutputChannels <= 2) {
-        return wrapInstrument(instrument);  // Fallback to normal wrapping
+        return wrapInstrument(instrument, midiInThru);  // Fallback to normal wrapping
     }
 
     // 1. Create a new RackType in the edit
@@ -160,8 +170,12 @@ te::Plugin::Ptr InstrumentRackManager::wrapMultiOutInstrument(te::Plugin::Ptr in
     // MIDI: rack input pin 0 --> synth pin 0
     rackType->addConnection(rackIOId, 0, synthId, 0);
 
-    // Keep MIDI flowing to later track-chain devices (see wrapInstrument).
-    rackType->addConnection(rackIOId, 0, rackIOId, 0);
+    // Plugin's own MIDI output always flows downstream (see wrapInstrument).
+    rackType->addConnection(synthId, 0, rackIOId, 0);
+
+    // "MIDI in thru" toggle: raw input bypassing the plugin (see wrapInstrument).
+    if (midiInThru)
+        rackType->addConnection(rackIOId, 0, rackIOId, 0);
 
     // Audio passthrough: rack input pin 1 --> rack output pin 1 (left)
     rackType->addConnection(rackIOId, 1, rackIOId, 1);
@@ -376,6 +390,21 @@ te::RackType::Ptr InstrumentRackManager::getRackType(DeviceId deviceId) const {
         return it->second.rackType;
     }
     return nullptr;
+}
+
+void InstrumentRackManager::setMidiInThru(DeviceId deviceId, bool enabled) {
+    auto it = wrapped_.find(deviceId);
+    if (it == wrapped_.end() || !it->second.rackType)
+        return;
+
+    // Toggle the raw-input-passthrough connection (rack MIDI in --> rack MIDI
+    // out) live. The plugin's own MIDI output (synth pin 0 --> rack out) is
+    // wired unconditionally at wrap time and is untouched here.
+    auto rackIOId = te::EditItemID();  // rack I/O
+    auto& rackType = *it->second.rackType;
+    rackType.removeConnection(rackIOId, 0, rackIOId, 0);
+    if (enabled)
+        rackType.addConnection(rackIOId, 0, rackIOId, 0);
 }
 
 void InstrumentRackManager::clear() {

--- a/magda/daw/audio/racks/InstrumentRackManager.hpp
+++ b/magda/daw/audio/racks/InstrumentRackManager.hpp
@@ -20,7 +20,11 @@ namespace te = tracktion;
  * and synth output are audible on the same track.
  *
  * Rack wiring:
- *   MIDI:             rack I/O pin 0 --> synth pin 0 (no MIDI output passthrough)
+ *   MIDI in:           rack I/O pin 0 --> synth pin 0
+ *   Plugin MIDI out:   synth pin 0 --> rack out pin 0 (always; lets a wrapped
+ *                      sequencer/arp trigger downstream instruments)
+ *   MIDI in thru:      rack I/O pin 0 --> rack out pin 0 (only when midiInThru;
+ *                      passes raw input past the plugin to a downstream MIDI FX)
  *   Audio passthrough: rack I/O pin 1 --> rack out pin 1, pin 2 --> rack out pin 2
  *   Synth output:      synth pin 1/2 --> meter tap pin 1/2 --> rack out pin 1/2
  *   (Multiple connections to same output pin are summed by TE automatically)
@@ -32,17 +36,21 @@ class InstrumentRackManager {
     /**
      * @brief Wrap an instrument plugin in a RackType with audio passthrough
      * @param instrument The instrument plugin to wrap
+     * @param midiInThru Wire raw MIDI input past the plugin to the rack output
+     *                   (for a MIDI-FX placed after the instrument). Default on.
      * @return The RackInstance plugin to insert on the track (or nullptr on failure)
      */
-    te::Plugin::Ptr wrapInstrument(te::Plugin::Ptr instrument);
+    te::Plugin::Ptr wrapInstrument(te::Plugin::Ptr instrument, bool midiInThru = true);
 
     /**
      * @brief Wrap a multi-output instrument in a RackType with all output pins exposed
      * @param instrument The instrument plugin to wrap
      * @param numOutputChannels Total number of output channels (e.g. 32 for 16 stereo pairs)
+     * @param midiInThru See wrapInstrument().
      * @return The main RackInstance plugin (outputs 1,2) to insert on the track
      */
-    te::Plugin::Ptr wrapMultiOutInstrument(te::Plugin::Ptr instrument, int numOutputChannels);
+    te::Plugin::Ptr wrapMultiOutInstrument(te::Plugin::Ptr instrument, int numOutputChannels,
+                                           bool midiInThru = true);
 
     /**
      * @brief Create a RackInstance for a specific output pair from a multi-out instrument
@@ -102,6 +110,15 @@ class InstrumentRackManager {
      * @return The RackType, or nullptr if not wrapped
      */
     te::RackType::Ptr getRackType(DeviceId deviceId) const;
+
+    /**
+     * @brief Toggle the "MIDI in thru" passthrough on a wrapped instrument live
+     * @param deviceId The MAGDA device ID
+     * @param enabled  When true, raw MIDI input is passed past the plugin to the
+     *                 rack output; when false it is not. The plugin's own MIDI
+     *                 output to the rack output is always wired and unaffected.
+     */
+    void setMidiInThru(DeviceId deviceId, bool enabled);
 
     /**
      * @brief Check if a TE plugin on a track is one of our wrapper racks

--- a/magda/daw/core/DeviceInfo.hpp
+++ b/magda/daw/core/DeviceInfo.hpp
@@ -159,6 +159,15 @@ struct DeviceInfo {
     bool canSidechain = false;    // true if TE plugin supports audio sidechain input
     bool canReceiveMidi = false;  // true if TE plugin accepts MIDI input (for cross-track MIDI)
 
+    // "MIDI in thru": for a wrapped instrument, pass the rack's raw MIDI input
+    // past the plugin to the rack output so a MIDI-triggered FX placed after the
+    // instrument still receives the note stream. On by default (matches the
+    // historic always-on passthrough, so old projects without the field keep
+    // working). The plugin's own MIDI output always flows downstream regardless
+    // (so a wrapped sequencer triggers later instruments); this flag only
+    // controls the raw-input bypass.
+    bool midiInThru = true;
+
     // Multi-output configuration (for instruments with >2 output channels)
     MultiOutConfig multiOut;
 

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -456,6 +456,9 @@ class TrackManager {
                                   DeviceId deviceId, bool bypassed);
     void setDeviceInChainBypassedByPath(const ChainNodePath& devicePath, bool bypassed);
 
+    // "MIDI in thru" toggle for a wrapped instrument (see DeviceInfo::midiInThru).
+    void setDeviceInChainMidiInThruByPath(const ChainNodePath& devicePath, bool thru);
+
     // Sidechain configuration (device-level)
     void setSidechainSource(DeviceId targetDevice, TrackId sourceTrack, SidechainConfig::Type type);
     void clearSidechain(DeviceId targetDevice);

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1106,6 +1106,13 @@ void TrackManager::setDeviceInChainBypassedByPath(const ChainNodePath& devicePat
     }
 }
 
+void TrackManager::setDeviceInChainMidiInThruByPath(const ChainNodePath& devicePath, bool thru) {
+    if (auto* device = getDeviceInChainByPath(devicePath)) {
+        device->midiInThru = thru;
+        notifyDevicePropertyChanged(devicePath);
+    }
+}
+
 // ============================================================================
 // Device Parameters
 // ============================================================================

--- a/magda/daw/project/serialization/TrackSerializer.cpp
+++ b/magda/daw/project/serialization/TrackSerializer.cpp
@@ -481,6 +481,9 @@ juce::var ProjectSerializer::serializeDeviceInfo(const DeviceInfo& device) {
     if (device.canReceiveMidi) {
         obj->setProperty("canReceiveMidi", true);
     }
+    // Always persisted: default is true, so a missing field must read back as
+    // true (old projects) and an explicit user-disabled false must survive.
+    obj->setProperty("midiInThru", device.midiInThru);
 
     // Per-instance drum kit rows
     if (!device.kitRows.empty()) {
@@ -637,6 +640,10 @@ bool ProjectSerializer::deserializeDeviceInfo(const juce::var& json, DeviceInfo&
     auto canReceiveMidiVar = obj->getProperty("canReceiveMidi");
     if (!canReceiveMidiVar.isVoid()) {
         outDevice.canReceiveMidi = static_cast<bool>(canReceiveMidiVar);
+    }
+    auto midiInThruVar = obj->getProperty("midiInThru");
+    if (!midiInThruVar.isVoid()) {
+        outDevice.midiInThru = static_cast<bool>(midiInThruVar);
     }
 
     // Plugin native state

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -508,6 +508,25 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
         addAndMakeVisible(*stepRecordButton_);
     }
 
+    // "MIDI in thru" toggle for wrapped instruments. The plugin's own MIDI
+    // output always flows downstream; this only passes the raw input past the
+    // instrument so a MIDI-triggered FX placed after it still receives notes.
+    if (device.isInstrument) {
+        instMidiThruButton_ = std::make_unique<magda::SvgButton>(
+            "MidiInThru", BinaryData::compare_svg, BinaryData::compare_svgSize);
+        instMidiThruButton_->setOriginalColor(juce::Colour(0xFFB3B3B3));
+        instMidiThruButton_->setNormalColor(DarkTheme::getColour(DarkTheme::ACCENT_GREEN));
+        instMidiThruButton_->setTooltip("MIDI in thru: pass input to a MIDI FX after this device");
+        instMidiThruButton_->setToggleable(true);
+        instMidiThruButton_->setActive(device.midiInThru);
+        instMidiThruButton_->onClick = [this]() {
+            const bool enabled = !instMidiThruButton_->isActive();
+            instMidiThruButton_->setActive(enabled);
+            magda::TrackManager::getInstance().setDeviceInChainMidiInThruByPath(nodePath_, enabled);
+        };
+        addAndMakeVisible(*instMidiThruButton_);
+    }
+
     // Create parameter grid (owns slots + pagination).
     paramGrid_ = std::make_unique<ParamHostComponent>(createDeviceSlotParamLayout(traits_));
     paramGrid_->onPrevPage = [this]() { goToPrevPage(); };
@@ -1659,7 +1678,8 @@ void DeviceSlotComponent::resizedHeaderExtra(juce::Rectangle<int>& headerArea) {
          .exportClipButton = exportClipButton_.get(),
          .randomButton = randomButton_.get(),
          .stepRecordButton = stepRecordButton_.get(),
-         .midiThruButton = midiThruButton_.get()},
+         .midiThruButton = midiThruButton_.get(),
+         .instMidiThruButton = instMidiThruButton_.get()},
         BUTTON_SIZE);
 }
 

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
@@ -232,6 +232,8 @@ class DeviceSlotComponent : public NodeComponent,
     std::unique_ptr<magda::SvgButton> randomButton_;      // Step-sequencer pattern randomize
     std::unique_ptr<magda::SvgButton> midiThruButton_;    // Step-sequencer MIDI thru toggle
     std::unique_ptr<magda::SvgButton> stepRecordButton_;  // Step-sequencer step record toggle
+    std::unique_ptr<magda::SvgButton>
+        instMidiThruButton_;  // Wrapped-instrument MIDI in thru toggle
 
     // Parameter host (owns slots + pagination, delegates layout to a
     // DeviceParamLayout strategy chosen at construction).

--- a/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.cpp
@@ -91,6 +91,7 @@ void layoutExpandedDeviceSlotHeader(juce::Rectangle<int>& headerArea,
         setVisibleIfPresent(controls.learnButton, false);
         setVisibleIfPresent(controls.sidechainButton, false);
         setVisibleIfPresent(controls.multiOutButton, false);
+        setVisibleIfPresent(controls.instMidiThruButton, false);
         setVisibleIfPresent(controls.powerButton, true);
         setVisibleIfPresent(controls.presetButton, !traits.isChordEngine);
         setVisibleIfPresent(controls.exportClipButton, true);
@@ -98,6 +99,12 @@ void layoutExpandedDeviceSlotHeader(juce::Rectangle<int>& headerArea,
         placeRight(headerArea, controls.exportClipButton, buttonSize);
         return;
     }
+
+    // "MIDI in thru" toggle shown on wrapped instruments, on the left like the
+    // step-sequencer MIDI thru button.
+    setVisibleIfPresent(controls.instMidiThruButton, device.isInstrument);
+    if (device.isInstrument)
+        placeLeft(headerArea, controls.instMidiThruButton, buttonSize);
 
     setVisibleIfPresent(controls.exportClipButton, false);
     setVisibleIfPresent(controls.sidechainButton,

--- a/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.hpp
@@ -19,9 +19,10 @@ struct DeviceSlotHeaderControls {
     juce::Component* powerButton = nullptr;
     juce::Component* presetButton = nullptr;
     juce::Component* exportClipButton = nullptr;
-    juce::Component* randomButton = nullptr;      // step-sequencer pattern randomize
-    juce::Component* stepRecordButton = nullptr;  // step-sequencer step record toggle
-    juce::Component* midiThruButton = nullptr;    // step-sequencer MIDI thru toggle
+    juce::Component* randomButton = nullptr;        // step-sequencer pattern randomize
+    juce::Component* stepRecordButton = nullptr;    // step-sequencer step record toggle
+    juce::Component* midiThruButton = nullptr;      // step-sequencer MIDI thru toggle
+    juce::Component* instMidiThruButton = nullptr;  // wrapped-instrument MIDI in thru toggle
 };
 
 struct DeviceSlotCollapsedControls {

--- a/tests/test_midi_signal_routing_juce.cpp
+++ b/tests/test_midi_signal_routing_juce.cpp
@@ -129,8 +129,25 @@ class MidiSignalRoutingTest final : public juce::UnitTest {
 
         expect(hasConnection(rackType, rackIO, 0, synthId, 0),
                "Rack MIDI input must feed the instrument");
+        expect(hasConnection(rackType, synthId, 0, rackIO, 0),
+               "Instrument's own MIDI output must always reach the rack output so a "
+               "wrapped sequencer/arp triggers downstream instruments");
         expect(hasConnection(rackType, rackIO, 0, rackIO, 0),
-               "Instrument wrapper must pass MIDI to later track-chain devices");
+               "Raw MIDI in thru is on by default (preserves historic passthrough)");
+
+        // Toggling MIDI in thru adds/removes only the raw-input passthrough.
+        rackManager.recordWrapping(magda::ChainNodePath::topLevelDevice(0, 1), rackInstance->type,
+                                   instrument, rackPlugin);
+        rackManager.setMidiInThru(1, true);
+        expect(hasConnection(rackType, rackIO, 0, rackIO, 0),
+               "Enabling MIDI in thru wires the raw-input passthrough");
+        expect(hasConnection(rackType, synthId, 0, rackIO, 0),
+               "Plugin MIDI output stays wired when in-thru is enabled");
+        rackManager.setMidiInThru(1, false);
+        expect(!hasConnection(rackType, rackIO, 0, rackIO, 0),
+               "Disabling MIDI in thru removes the raw-input passthrough");
+        expect(hasConnection(rackType, synthId, 0, rackIO, 0),
+               "Plugin MIDI output stays wired when in-thru is disabled");
 
         expect(hasConnection(rackType, rackIO, 1, rackIO, 1),
                "Rack must preserve left audio passthrough");


### PR DESCRIPTION
A wrapped instrument's own MIDI output now always flows to the rack output, so a MIDI-producing plugin (sequencer/arp such as Stochas) can trigger an instrument placed after it in the chain. This restores behaviour lost when the rack wiring was reworked.

The raw MIDI-input passthrough (input bypassing the plugin) is now a per-device 'MIDI in thru' toggle, off by default, surfaced as a header button on wrapped instruments and persisted via DeviceInfo. Enable it to feed a MIDI-triggered FX placed after the instrument.

Adds InstrumentRackManager::setMidiInThru for live toggling and extends the MIDI signal routing tests to cover the always-on plugin output and the in-thru add/remove.

Closes #1558