### PR TITLE
Bundle DAWproject XSD schemas in Windows and Linux releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -781,10 +781,13 @@ jobs:
           exit 1
         }
 
-        # Faust standard libraries + stock drumkits. POST_BUILD places both
-        # next to MAGDA.exe; the app loads them from the exe's own directory
-        # (libfaust -I path, DrumkitManager seed), so mirror them into staging.
-        foreach ($dir in @("faustlibraries", "drumkits")) {
+        # Faust standard libraries, stock drumkits, and DAWproject XSD schemas.
+        # POST_BUILD places all three next to MAGDA.exe; the app loads them from
+        # the exe's own directory (libfaust -I path, DrumkitManager seed,
+        # DawProjectValidator <exe>/dawproject/*.xsd), so mirror them into
+        # staging. Without dawproject/ the validator falls back to the baked-in
+        # build-tree source path, which does not exist on an end-user machine.
+        foreach ($dir in @("faustlibraries", "drumkits", "dawproject")) {
           $src = Join-Path $exeDir $dir
           if (-not (Test-Path $src)) {
             Write-Error "$dir/ missing next to MAGDA.exe at $src"
@@ -1000,10 +1003,13 @@ jobs:
         test -d "$APPDIR/usr/bin/controllers/scripts" \
           || { echo "controllers/scripts missing from AppDir staging"; exit 1; }
 
-        # Faust standard libraries + stock drumkits. POST_BUILD places both
-        # next to the binary; the app loads them from the exe's own directory
-        # (libfaust -I path, DrumkitManager seed), so mirror them into the AppDir.
-        for dir in faustlibraries drumkits; do
+        # Faust standard libraries, stock drumkits, and DAWproject XSD schemas.
+        # POST_BUILD places all three next to the binary; the app loads them from
+        # the exe's own directory (libfaust -I path, DrumkitManager seed,
+        # DawProjectValidator <exe>/dawproject/*.xsd), so mirror them into the
+        # AppDir. Without dawproject/ the validator falls back to the baked-in
+        # build-tree source path, which does not exist on an end-user machine.
+        for dir in faustlibraries drumkits dawproject; do
           src="$(dirname "$BINARY")/$dir"
           if [ ! -d "$src" ]; then
             echo "$dir/ missing next to MAGDA binary at $src"

--- a/packaging/windows/magda-installer.nsi
+++ b/packaging/windows/magda-installer.nsi
@@ -67,6 +67,14 @@ Section "Install"
     File /r "${__FILEDIR__}\drumkits\*"
     SetOutPath $INSTDIR
 
+    ; DAWproject XSD schemas - DawProjectValidator validates import/export
+    ; against <exe>/dawproject/Project.xsd and MetaData.xsd. Without these the
+    ; validator falls back to the baked-in build-tree source path, which does
+    ; not exist on an end-user machine, and every DAWproject import fails.
+    SetOutPath "$INSTDIR\dawproject"
+    File /r "${__FILEDIR__}\dawproject\*"
+    SetOutPath $INSTDIR
+
     ; Create uninstaller
     WriteUninstaller "$INSTDIR\Uninstall.exe"
 
@@ -109,6 +117,7 @@ Section "Uninstall"
     RMDir /r "$INSTDIR\controllers"
     RMDir /r "$INSTDIR\faustlibraries"
     RMDir /r "$INSTDIR\drumkits"
+    RMDir /r "$INSTDIR\dawproject"
     RMDir "$INSTDIR"
 
     Delete "$SMPROGRAMS\MAGDA\*.*"


### PR DESCRIPTION
The macOS bundle carries the schemas inside the .app, but the Windows NSIS installer and Linux AppImage staging never included the dawproject/ folder. On installed Windows/Linux machines <exe>/dawproject was absent, so DawProjectValidator fell back to the baked-in build-tree source path (C:\a\magda-core\... on CI), which does not exist on an end-user machine, and every DAWproject import failed with "schema not found".

Stage dawproject/ next to the binary in both release steps and install/ uninstall it in the NSIS script.

Fixes #1560