### PR TITLE
Stage basic_pitch.onnx model in Windows and Linux packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -787,7 +787,7 @@ jobs:
         # DawProjectValidator <exe>/dawproject/*.xsd), so mirror them into
         # staging. Without dawproject/ the validator falls back to the baked-in
         # build-tree source path, which does not exist on an end-user machine.
-        foreach ($dir in @("faustlibraries", "drumkits", "dawproject")) {
+        foreach ($dir in @("faustlibraries", "drumkits", "dawproject", "models")) {
           $src = Join-Path $exeDir $dir
           if (-not (Test-Path $src)) {
             Write-Error "$dir/ missing next to MAGDA.exe at $src"
@@ -1009,7 +1009,7 @@ jobs:
         # DawProjectValidator <exe>/dawproject/*.xsd), so mirror them into the
         # AppDir. Without dawproject/ the validator falls back to the baked-in
         # build-tree source path, which does not exist on an end-user machine.
-        for dir in faustlibraries drumkits dawproject; do
+        for dir in faustlibraries drumkits dawproject models; do
           src="$(dirname "$BINARY")/$dir"
           if [ ! -d "$src" ]; then
             echo "$dir/ missing next to MAGDA binary at $src"

--- a/packaging/windows/magda-installer.nsi
+++ b/packaging/windows/magda-installer.nsi
@@ -75,6 +75,14 @@ Section "Install"
     File /r "${__FILEDIR__}\dawproject\*"
     SetOutPath $INSTDIR
 
+    ; Audio-to-MIDI model - TranscriptionService loads
+    ; <exe>/models/basic_pitch.onnx for "Transcribe to MIDI". Without it the
+    ; feature is unavailable on installed machines (dev builds resolve the
+    ; source-tree fallback, which hides the gap).
+    SetOutPath "$INSTDIR\models"
+    File /r "${__FILEDIR__}\models\*"
+    SetOutPath $INSTDIR
+
     ; Create uninstaller
     WriteUninstaller "$INSTDIR\Uninstall.exe"
 
@@ -118,6 +126,7 @@ Section "Uninstall"
     RMDir /r "$INSTDIR\faustlibraries"
     RMDir /r "$INSTDIR\drumkits"
     RMDir /r "$INSTDIR\dawproject"
+    RMDir /r "$INSTDIR\models"
     RMDir "$INSTDIR"
 
     Delete "$SMPROGRAMS\MAGDA\*.*"


### PR DESCRIPTION
Transcribe to MIDI loads <exe>/models/basic_pitch.onnx via TranscriptionService::findBundledModel. The model is copied next to the binary at build time on every platform and bundled into the macOS .app, but neither the Windows installer nor the Linux AppDir staged it, so installed Windows and Linux builds shipped without the model and the feature was unavailable.

- release.yml: add models/ to the Windows installer staging loop and the Linux AppDir loop (both keep the existing missing-next-to-binary assert).
- magda-installer.nsi: install and uninstall the models\ directory.