### PR TITLE
Make DAWproject schema validation advisory, not a hard gate

### DIFF
--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -299,49 +299,70 @@ bool ProjectManager::exportDawProject(const juce::File& file) {
     return true;
 }
 
-bool ProjectManager::importDawProject(const juce::File& file,
-                                      std::function<void(const ProjectInfo&)> onBeforeCommit) {
-    if (isDirty_ && !showUnsavedChangesDialog())
-        return false;
+void ProjectManager::importDawProjectAsync(
+    const juce::File& file, std::function<void(const ProjectInfo&)> onBeforeCommit,
+    std::function<void(bool, const juce::String&)> onComplete) {
+    // Pre-flight checks on the message thread.
+    if (isDirty_ && !showUnsavedChangesDialog()) {
+        if (onComplete)
+            onComplete(false, {});  // empty error = user cancelled
+        return;
+    }
 
     if (!file.existsAsFile()) {
-        lastError_ = "File does not exist: " + file.getFullPathName();
-        return false;
+        if (onComplete)
+            onComplete(false, "File does not exist: " + file.getFullPathName());
+        return;
     }
 
     // Set up the project media directory first so embedded audio extracts into
     // it (the "imported" subdir) and persists with the project, rather than into
-    // a throwaway temp folder.
+    // a throwaway temp folder. Done on the message thread before staging so the
+    // background thread has a valid extraction target.
     createTempMediaDirectory();
     ensureMediaSubdirectories(mediaDirectory_);
+    const auto importedDir = getImportedDirectory();
 
-    StagedProjectData staged;
-    if (!ProjectSerializer::loadDawProjectAndStage(file, staged, getImportedDirectory())) {
-        DBG("Failed to import DAWproject: " + ProjectSerializer::getLastError());
-        lastError_ = ProjectSerializer::getLastError();
-        return false;
-    }
+    // Join any previous background load before starting a new one.
+    joinBackgroundThread();
 
-    resetTransportForProjectBoundary();
+    auto fileCopy = file;
+    loadThread_ = std::thread([fileCopy, importedDir, onBeforeCommit, onComplete, this]() {
+        auto staged = std::make_shared<StagedProjectData>();
+        const bool ok = ProjectSerializer::loadDawProjectAndStage(fileCopy, *staged, importedDir);
+        juce::String error;
+        if (!ok) {
+            DBG("Failed to import DAWproject: " + ProjectSerializer::getLastError());
+            error = ProjectSerializer::getLastError();
+        }
 
-    if (onBeforeCommit)
-        onBeforeCommit(staged.info);
+        // Bounce back to the message thread for commit + notification.
+        juce::MessageManager::callAsync([this, staged, ok, error, onBeforeCommit, onComplete]() {
+            if (ok) {
+                resetTransportForProjectBoundary();
 
-    ProjectSerializer::commitStaged(staged);
+                if (onBeforeCommit)
+                    onBeforeCommit(staged->info);
 
-    currentProject_ = staged.info;
-    currentProject_.filePath = {};
-    currentFile_ = juce::File();
-    isProjectOpen_ = true;
+                ProjectSerializer::commitStaged(*staged);
 
-    isDirty_ = true;
-    notifyProjectOpened();
-    notifyDirtyStateChanged();
+                currentProject_ = staged->info;
+                currentProject_.filePath = {};
+                currentFile_ = juce::File();
+                isProjectOpen_ = true;
 
-    if (onAfterLoad)
-        onAfterLoad(currentProject_);
+                isDirty_ = true;
+                notifyProjectOpened();
+                notifyDirtyStateChanged();
 
-    return true;
+                if (onAfterLoad)
+                    onAfterLoad(currentProject_);
+            }
+
+            if (onComplete)
+                onComplete(ok, error);
+        });
+    });
 }
 
 void ProjectManager::loadProjectAsync(const juce::File& file,

--- a/magda/daw/project/ProjectManager.hpp
+++ b/magda/daw/project/ProjectManager.hpp
@@ -100,9 +100,15 @@ class ProjectManager : private juce::Timer {
 
     /**
      * @brief Import a .dawproject archive as a new unsaved Magda project.
+     *
+     * Heavy I/O (zip extraction, embedded-audio unpacking, XML parse) runs on a
+     * background thread; commit + notifications happen on the message thread.
+     * Mirrors loadProjectAsync so a large import does not freeze the UI.
+     * @param onComplete (success, errorMessage); empty error on user cancel.
      */
-    bool importDawProject(const juce::File& file,
-                          std::function<void(const ProjectInfo&)> onBeforeCommit = nullptr);
+    void importDawProjectAsync(const juce::File& file,
+                               std::function<void(const ProjectInfo&)> onBeforeCommit,
+                               std::function<void(bool, const juce::String&)> onComplete);
 
     /**
      * @brief Load project asynchronously (heavy I/O on background thread, commit on message thread)

--- a/magda/daw/project/serialization/DawProjectArchive.cpp
+++ b/magda/daw/project/serialization/DawProjectArchive.cpp
@@ -123,15 +123,26 @@ bool DawProjectArchive::readFromFile(const juce::File& file, ProjectDocument& ou
     if (!readZipEntry(zip, "project.xml", projectXml, error))
         return false;
 
-    if (!DawProjectValidator::validateProjectXml(projectXml, error))
-        return false;
+    // Schema validation is advisory, not a gate. Real-world DAWproject exporters
+    // (e.g. Cubase) emit files that violate the strict <xs:sequence> ordering in
+    // the bundled XSD even when the data is semantically fine, and our parser is
+    // order-independent (it locates children by name). So we log schema problems
+    // for diagnostics but still hand the XML to the parser, which is the real
+    // gate: it fails loudly only if it genuinely cannot read the project.
+    juce::String validationWarning;
+    if (!DawProjectValidator::validateProjectXml(projectXml, validationWarning))
+        juce::Logger::writeToLog("DAWproject import: project.xml failed schema validation, "
+                                 "continuing anyway:\n" +
+                                 validationWarning);
 
     juce::String metadataXml;
-    if (readZipEntry(zip, "metadata.xml", metadataXml, error)) {
-        if (!DawProjectValidator::validateMetadataXml(metadataXml, error))
-            return false;
-    } else {
-        error.clear();
+    juce::String metadataReadError;
+    if (readZipEntry(zip, "metadata.xml", metadataXml, metadataReadError)) {
+        juce::String metadataWarning;
+        if (!DawProjectValidator::validateMetadataXml(metadataXml, metadataWarning))
+            juce::Logger::writeToLog("DAWproject import: metadata.xml failed schema validation, "
+                                     "continuing anyway:\n" +
+                                     metadataWarning);
     }
 
     if (!DawProjectXmlAdapter::fromProjectXml(projectXml, outDocument, error))

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -598,39 +598,52 @@ void ProjectSerializer::commitStagedData(std::vector<TrackInfo>& stagedTracks,
     // are properly notified (prevents stale selection after project load)
     SelectionManager::getInstance().clearSelection();
 
-    // Clear all existing data from managers
-    trackManager.clearAllTracks();
-    clipManager.clearAllClips();
-    automationManager.clearAll();
+    // Coalesce the per-item structural notifications fired by the clear + restore
+    // below into a single one per manager. Without this, restoring N tracks fires
+    // notifyTracksChanged() N times, and each one rebuilds every track/mixer panel
+    // AND re-runs AudioBridge::syncAll() over all tracks -- O(N^2) work that hangs
+    // the UI for seconds on a large project. The batch fires one notification when
+    // the scope closes.
+    {
+        TrackManager::BatchScope trackBatch;
+        ClipManager::BatchScope clipBatch;
+        AutomationManager::BatchScope automationBatch;
 
-    // Restore tracks
-    for (auto& track : stagedTracks) {
-        trackManager.restoreTrack(track);
+        // Clear all existing data from managers
+        trackManager.clearAllTracks();
+        clipManager.clearAllClips();
+        automationManager.clearAll();
+
+        // Restore tracks
+        for (auto& track : stagedTracks) {
+            trackManager.restoreTrack(track);
+        }
+
+        // After all tracks are restored, ensure TrackManager ID counters
+        // (track/device/rack/chain) are updated to avoid ID collisions.
+        trackManager.refreshIdCountersFromTracks();
+
+        // Restore clips
+        for (auto& clip : stagedClips) {
+            clipManager.restoreClip(clip);
+        }
+
+        // Restore automation lanes
+        for (auto& lane : stagedAutomation) {
+            automationManager.restoreLane(lane);
+        }
+
+        // Restore automation clips
+        for (auto& clip : stagedAutomationClips) {
+            automationManager.restoreClip(clip);
+        }
+
+        // Update automation ID counters to avoid collisions
+        automationManager.refreshIdCountersFromLanes();
     }
 
-    // After all tracks are restored, ensure TrackManager ID counters
-    // (track/device/rack/chain) are updated to avoid ID collisions.
-    trackManager.refreshIdCountersFromTracks();
-
-    // Restore clips
-    for (auto& clip : stagedClips) {
-        clipManager.restoreClip(clip);
-    }
-
-    // Restore automation lanes
-    for (auto& lane : stagedAutomation) {
-        automationManager.restoreLane(lane);
-    }
-
-    // Restore automation clips
-    for (auto& clip : stagedAutomationClips) {
-        automationManager.restoreClip(clip);
-    }
-
-    // Update automation ID counters to avoid collisions
-    automationManager.refreshIdCountersFromLanes();
-
-    // Select the first track so the UI has a valid selection after load
+    // Select the first track so the UI has a valid selection after load. Done
+    // after the batch closes so panels exist and reflect the selection.
     if (!stagedTracks.empty()) {
         SelectionManager::getInstance().selectTrack(stagedTracks[0].id);
     }

--- a/magda/daw/ui/windows/MainWindowMenus.cpp
+++ b/magda/daw/ui/windows/MainWindowMenus.cpp
@@ -142,25 +142,27 @@ void MainWindow::importDawProjectFile(const juce::File& file) {
         mainComponent->mainView->getTimelineController().dispatch(ClearTimeSelectionEvent{});
 
     auto& projectManager = ProjectManager::getInstance();
-    const bool ok = projectManager.importDawProject(file, [this](const ProjectInfo& info) {
-        if (!mainComponent || !mainComponent->mainView)
-            return;
-        auto& tc = mainComponent->mainView->getTimelineController();
-        tc.restoreProjectState(info.tempo, info.timeSignatureNumerator,
-                               info.timeSignatureDenominator, info.loopEnabled, info.loopStartBeats,
-                               info.loopEndBeats, info.markers, info.timelineLengthBars);
-    });
-
-    if (!ok) {
-        // Empty lastError = user cancelled the unsaved-changes prompt; stay silent.
-        const auto error = projectManager.getLastError();
-        if (error.isNotEmpty())
-            juce::AlertWindow::showMessageBoxAsync(
-                juce::AlertWindow::WarningIcon,
-                tr("action.import")
-                    .replace("{0}", magda::technicalText(magda::TechnicalTextToken::DawProject)),
-                error);
-    }
+    projectManager.importDawProjectAsync(
+        file,
+        [this](const ProjectInfo& info) {
+            if (!mainComponent || !mainComponent->mainView)
+                return;
+            auto& tc = mainComponent->mainView->getTimelineController();
+            tc.restoreProjectState(info.tempo, info.timeSignatureNumerator,
+                                   info.timeSignatureDenominator, info.loopEnabled,
+                                   info.loopStartBeats, info.loopEndBeats, info.markers,
+                                   info.timelineLengthBars);
+        },
+        [](bool ok, const juce::String& error) {
+            // Empty error = user cancelled the unsaved-changes prompt; stay silent.
+            if (!ok && error.isNotEmpty())
+                juce::AlertWindow::showMessageBoxAsync(
+                    juce::AlertWindow::WarningIcon,
+                    tr("action.import")
+                        .replace("{0}",
+                                 magda::technicalText(magda::TechnicalTextToken::DawProject)),
+                    error);
+        });
 }
 
 // ============================================================================


### PR DESCRIPTION
Importing a DAWproject exported from Cubase 15 aborted with schema errors (out-of-order Devices / automation points vs the bundled XSD's strict <xs:sequence>), so the project never loaded. Our parser is order- independent (it locates children by name), so these files are readable even when they fail strict validation.

Validate for diagnostics and log any schema problems, but continue to the parser instead of returning false. The parser is now the real gate: it fails only if the project genuinely cannot be read. error stays free of schema noise so a real parse failure still surfaces a clear message.