### PR TITLE
Headless magda CLI epic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ ifeq ($(UNAME_S),Darwin)
     APP_BINARY_TSAN    := $(BUILD_DIR_TSAN)/magda/daw/magda_daw_app_artefacts/Debug/MAGDA.app/Contents/MacOS/MAGDA
     APP_BUNDLE_DEBUG   := $(BUILD_DIR)/magda/daw/magda_daw_app_artefacts/Debug/MAGDA.app
     APP_BUNDLE_RELEASE := $(BUILD_DIR_RELEASE)/magda/daw/magda_daw_app_artefacts/Release/MAGDA.app
+    CLI_BINARY_DEBUG   := $(BUILD_DIR)/magda/daw/magda_cli_artefacts/Debug/magda_cli
     LAUNCH             := open
 else
     APP_BINARY_DEBUG   := $(BUILD_DIR)/magda/daw/magda_daw_app_artefacts/Debug/MAGDA
@@ -43,6 +44,7 @@ else
     APP_BINARY_TSAN    := $(BUILD_DIR_TSAN)/magda/daw/magda_daw_app_artefacts/Debug/MAGDA
     APP_BUNDLE_DEBUG   := $(APP_BINARY_DEBUG)
     APP_BUNDLE_RELEASE := $(BUILD_DIR_RELEASE)/magda/daw/magda_daw_app_artefacts/Release/MAGDA
+    CLI_BINARY_DEBUG   := $(BUILD_DIR)/magda/daw/magda_cli_artefacts/Debug/magda_cli
     LAUNCH             :=
 endif
 
@@ -171,6 +173,21 @@ run: debug
 run-console: debug
 	@echo "🎵 Running MAGDA DAW (console mode)..."
 	"$(APP_BINARY_DEBUG)"
+
+.PHONY: cli
+cli:
+	@echo "🔨 Building magda-cli (Debug)..."
+	@mkdir -p $(BUILD_DIR) $(CACHE_ROOT)/ccache $(CACHE_ROOT)/tmp $(CACHE_ROOT)/xdg
+	@if [ ! -f $(BUILD_DIR)/CMakeCache.txt ]; then \
+		echo "📝 Configuring project..."; \
+		cd $(BUILD_DIR) && $(BUILD_ENV) cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DMAGDA_BUILD_TESTS=ON ..; \
+	fi
+	cd $(BUILD_DIR) && $(BUILD_ENV) ninja magda_cli
+
+.PHONY: cli-boot
+cli-boot: cli
+	@echo "🎛️  Booting magda-cli headless..."
+	"$(CLI_BINARY_DEBUG)" boot
 
 .PHONY: run-console-cpu
 run-console-cpu: debug-cpu

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -369,10 +369,19 @@ target_sources(magda_plugin_scanner PRIVATE
     engine/plugin_scanner_main.cpp
 )
 
+# Headless CLI for e2e project round-trips.
+juce_add_console_app(magda_cli
+    VERSION "${MAGDA_BUNDLE_VERSION}"
+    COMPANY_NAME "Conceptual Machines"
+    PRODUCT_NAME "MAGDA CLI"
+    BUNDLE_ID "com.MAGDA.MAGDACLI"
+)
+
 # =============================================================================
 # Per-subdirectory sources
 # =============================================================================
 
+add_subdirectory(cli)
 add_subdirectory(core)
 add_subdirectory(audio)
 add_subdirectory(engine)
@@ -557,6 +566,38 @@ target_include_directories(magda_plugin_scanner
     ${CMAKE_CURRENT_SOURCE_DIR}/engine
     ${CMAKE_CURRENT_BINARY_DIR}/generated
 )
+
+target_link_libraries(magda_cli
+    PRIVATE
+    magda_daw
+    juce::juce_core
+    juce::juce_events
+    juce::juce_audio_devices
+    juce::juce_audio_formats
+    tracktion::tracktion_engine
+    $<$<PLATFORM_ID:Linux>:juce::pkgconfig_JUCE_CURL_LINUX_DEPS>
+)
+
+target_compile_definitions(magda_cli
+    PRIVATE
+    JUCE_PLUGINHOST_VST3=1
+    JUCE_PLUGINHOST_AU=1
+    TRACKTION_ENABLE_TIMESTRETCH_SOUNDTOUCH=1
+    JUCE_WEB_BROWSER=0
+    $<$<BOOL:${JUCE_ASIO_ENABLED}>:JUCE_ASIO=1>
+)
+
+target_include_directories(magda_cli
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/engine
+    ${CMAKE_CURRENT_SOURCE_DIR}/project
+    ${CMAKE_CURRENT_BINARY_DIR}/generated
+)
+
+if(APPLE)
+    target_link_options(magda_cli PRIVATE "-Wl,-exported_symbol,_main")
+endif()
 
 # On MSVC Release builds, generate a PDB for crash symbolization.
 # /Zi is applied here (not globally) so llama.cpp and other third-party targets

--- a/magda/daw/api/clip_api.hpp
+++ b/magda/daw/api/clip_api.hpp
@@ -8,6 +8,8 @@
 
 namespace magda {
 
+enum class MidiNoteQuantizeMode { StartOnly, LengthOnly, StartAndLength };
+
 /// Abstract view onto ClipManager — what the agent layer reads and writes.
 class ClipApi {
   public:
@@ -23,6 +25,15 @@ class ClipApi {
 
     virtual void setClipName(ClipId clipId, const juce::String& name) = 0;
     virtual void setGrooveTemplate(ClipId clipId, const juce::String& templateName) = 0;
+
+    virtual bool addMidiNote(ClipId clipId, double startBeat, int noteNumber, double lengthBeats,
+                             int velocity) = 0;
+    virtual bool quantizeMidiNotes(
+        ClipId clipId, const std::vector<size_t>& noteIndices, double gridResolution,
+        MidiNoteQuantizeMode mode = MidiNoteQuantizeMode::StartAndLength) = 0;
+    virtual bool sliceMidiNotes(ClipId clipId, const std::vector<size_t>& noteIndices,
+                                int subdivisions) = 0;
+    virtual bool transposeMidiClip(ClipId clipId, int semitones) = 0;
 
     /**
      * @brief Cached transient times for an audio clip's source file.

--- a/magda/daw/api/clip_api_live.cpp
+++ b/magda/daw/api/clip_api_live.cpp
@@ -2,8 +2,31 @@
 
 #include "../audio/AudioThumbnailManager.hpp"
 #include "../core/ClipManager.hpp"
+#include "../core/MidiNoteCommands.hpp"
+#include "../core/UndoManager.hpp"
 
 namespace magda {
+
+namespace {
+
+QuantizeMode toCoreQuantizeMode(MidiNoteQuantizeMode mode) {
+    switch (mode) {
+        case MidiNoteQuantizeMode::StartOnly:
+            return QuantizeMode::StartOnly;
+        case MidiNoteQuantizeMode::LengthOnly:
+            return QuantizeMode::LengthOnly;
+        case MidiNoteQuantizeMode::StartAndLength:
+            return QuantizeMode::StartAndLength;
+    }
+    return QuantizeMode::StartAndLength;
+}
+
+bool isMidiClip(ClipId clipId) {
+    auto* clip = ClipManager::getInstance().getClip(clipId);
+    return clip != nullptr && clip->isMidi();
+}
+
+}  // namespace
 
 ClipInfo* ClipApiLive::getClip(ClipId clipId) {
     return ClipManager::getInstance().getClip(clipId);
@@ -32,6 +55,45 @@ void ClipApiLive::setClipName(ClipId clipId, const juce::String& name) {
 
 void ClipApiLive::setGrooveTemplate(ClipId clipId, const juce::String& templateName) {
     ClipManager::getInstance().setGrooveTemplate(clipId, templateName);
+}
+
+bool ClipApiLive::addMidiNote(ClipId clipId, double startBeat, int noteNumber, double lengthBeats,
+                              int velocity) {
+    if (!isMidiClip(clipId) || lengthBeats <= 0.0)
+        return false;
+
+    UndoManager::getInstance().executeCommand(
+        std::make_unique<AddMidiNoteCommand>(clipId, startBeat, noteNumber, lengthBeats, velocity));
+    return true;
+}
+
+bool ClipApiLive::quantizeMidiNotes(ClipId clipId, const std::vector<size_t>& noteIndices,
+                                    double gridResolution, MidiNoteQuantizeMode mode) {
+    if (!isMidiClip(clipId) || noteIndices.empty() || gridResolution <= 0.0)
+        return false;
+
+    UndoManager::getInstance().executeCommand(std::make_unique<QuantizeMidiNotesCommand>(
+        clipId, noteIndices, gridResolution, toCoreQuantizeMode(mode)));
+    return true;
+}
+
+bool ClipApiLive::sliceMidiNotes(ClipId clipId, const std::vector<size_t>& noteIndices,
+                                 int subdivisions) {
+    if (!isMidiClip(clipId) || noteIndices.empty() || subdivisions < 2)
+        return false;
+
+    UndoManager::getInstance().executeCommand(
+        std::make_unique<SliceMidiNotesCommand>(clipId, noteIndices, subdivisions));
+    return true;
+}
+
+bool ClipApiLive::transposeMidiClip(ClipId clipId, int semitones) {
+    if (!isMidiClip(clipId))
+        return false;
+
+    UndoManager::getInstance().executeCommand(
+        std::make_unique<TransposeMidiClipCommand>(clipId, semitones));
+    return true;
 }
 
 const juce::Array<double>* ClipApiLive::getCachedTransients(const juce::String& filePath) const {

--- a/magda/daw/api/clip_api_live.hpp
+++ b/magda/daw/api/clip_api_live.hpp
@@ -18,6 +18,14 @@ class ClipApiLive : public ClipApi {
     void setClipName(ClipId clipId, const juce::String& name) override;
     void setGrooveTemplate(ClipId clipId, const juce::String& templateName) override;
 
+    bool addMidiNote(ClipId clipId, double startBeat, int noteNumber, double lengthBeats,
+                     int velocity) override;
+    bool quantizeMidiNotes(ClipId clipId, const std::vector<size_t>& noteIndices,
+                           double gridResolution, MidiNoteQuantizeMode mode) override;
+    bool sliceMidiNotes(ClipId clipId, const std::vector<size_t>& noteIndices,
+                        int subdivisions) override;
+    bool transposeMidiClip(ClipId clipId, int semitones) override;
+
     const juce::Array<double>* getCachedTransients(const juce::String& filePath) const override;
 };
 

--- a/magda/daw/api/magda_api_live.hpp
+++ b/magda/daw/api/magda_api_live.hpp
@@ -64,6 +64,11 @@ class MagdaApiLive : public MagdaApi {
         midi_.setDefaultOutputPort(port);
     }
 
+    /** Wire tempo writes through the owning engine before ProjectInfo is updated. */
+    void setProjectTempoWriter(std::function<void(double)> writer) {
+        project_.setEngineTempoWriter(std::move(writer));
+    }
+
     /** Wire the current-Edit accessor into the live TransportApi. */
     void setEditAccessor(TransportApiLive::EditGetter g) {
         transport_.setEditGetter(std::move(g));

--- a/magda/daw/api/project_api.hpp
+++ b/magda/daw/api/project_api.hpp
@@ -4,12 +4,13 @@
 
 namespace magda {
 
-/// Abstract view onto ProjectManager — read-only project info today.
+/// Abstract view onto ProjectManager.
 class ProjectApi {
   public:
     virtual ~ProjectApi() = default;
 
     virtual const ProjectInfo& getCurrentProjectInfo() const = 0;
+    virtual void setTempo(double bpm) = 0;
 };
 
 }  // namespace magda

--- a/magda/daw/api/project_api_live.cpp
+++ b/magda/daw/api/project_api_live.cpp
@@ -8,4 +8,8 @@ const ProjectInfo& ProjectApiLive::getCurrentProjectInfo() const {
     return ProjectManager::getInstance().getCurrentProjectInfo();
 }
 
+void ProjectApiLive::setTempo(double bpm) {
+    ProjectManager::getInstance().setTempo(bpm);
+}
+
 }  // namespace magda

--- a/magda/daw/api/project_api_live.cpp
+++ b/magda/daw/api/project_api_live.cpp
@@ -9,7 +9,13 @@ const ProjectInfo& ProjectApiLive::getCurrentProjectInfo() const {
 }
 
 void ProjectApiLive::setTempo(double bpm) {
+    if (engineTempoWriter_)
+        engineTempoWriter_(bpm);
     ProjectManager::getInstance().setTempo(bpm);
+}
+
+void ProjectApiLive::setEngineTempoWriter(std::function<void(double)> writer) {
+    engineTempoWriter_ = std::move(writer);
 }
 
 }  // namespace magda

--- a/magda/daw/api/project_api_live.hpp
+++ b/magda/daw/api/project_api_live.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "project_api.hpp"
 
 namespace magda {
@@ -9,6 +11,11 @@ class ProjectApiLive : public ProjectApi {
   public:
     const ProjectInfo& getCurrentProjectInfo() const override;
     void setTempo(double bpm) override;
+
+    void setEngineTempoWriter(std::function<void(double)> writer);
+
+  private:
+    std::function<void(double)> engineTempoWriter_;
 };
 
 }  // namespace magda

--- a/magda/daw/api/project_api_live.hpp
+++ b/magda/daw/api/project_api_live.hpp
@@ -8,6 +8,7 @@ namespace magda {
 class ProjectApiLive : public ProjectApi {
   public:
     const ProjectInfo& getCurrentProjectInfo() const override;
+    void setTempo(double bpm) override;
 };
 
 }  // namespace magda

--- a/magda/daw/cli/CMakeLists.txt
+++ b/magda/daw/cli/CMakeLists.txt
@@ -1,0 +1,3 @@
+target_sources(magda_cli PRIVATE
+    magda_cli_main.cpp
+)

--- a/magda/daw/cli/magda_cli_main.cpp
+++ b/magda/daw/cli/magda_cli_main.cpp
@@ -2,6 +2,11 @@
 #include <juce_events/juce_events.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 
+// clang-format off
+#include <tracktion_engine/tracktion_engine.h>
+// clang-format on
+
+#include <atomic>
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -14,6 +19,7 @@
 #include "api/magda_api.hpp"
 #include "api/project_api.hpp"
 #include "api/track_api.hpp"
+#include "audio/AudioBridge.hpp"
 #include "engine/TracktionEngineWrapper.hpp"
 #include "project/ProjectInfo.hpp"
 #include "project/ProjectManager.hpp"
@@ -21,14 +27,18 @@
 
 namespace {
 
+namespace te = tracktion;
+
 void printUsage(std::ostream& out) {
     out << "magda-cli " << MAGDA_VERSION << "\n"
         << "\n"
         << "Usage:\n"
         << "  magda-cli boot\n"
+        << "  magda-cli init <out.mgd>\n"
         << "  magda-cli run <project.mgd> [--out <out.mgd>]\n"
         << "  magda-cli run <project.mgd> --cmds <cmds.txt> [--out <out.mgd>] [--dump-json]\n"
         << "  magda-cli exec <project.mgd> <commands...> [--out <out.mgd>] [--dump-json]\n"
+        << "  magda-cli render <project.mgd> --wav <out.wav> [--from <time>] [--to <time>]\n"
         << "\n"
         << "Commands:\n"
         << "  set-tempo <bpm>\n"
@@ -93,6 +103,13 @@ std::optional<double> parseDouble(const juce::String& text) {
 std::optional<int> parseInt(const juce::String& text) {
     int value = 0;
     if (std::istringstream{text.toStdString()} >> value)
+        return value;
+    return std::nullopt;
+}
+
+std::optional<int> parsePositiveInt(const juce::String& text) {
+    auto value = parseInt(text);
+    if (value && *value > 0)
         return value;
     return std::nullopt;
 }
@@ -340,6 +357,15 @@ struct RunOptions {
     juce::StringArray execTokens;
 };
 
+struct RenderOptions {
+    juce::File input;
+    juce::File wavOutput;
+    std::optional<double> fromSeconds;
+    std::optional<double> toSeconds;
+    std::optional<double> sampleRate;
+    std::optional<int> bitDepth;
+};
+
 bool loadProjectForCli(const juce::File& input, HeadlessEngineSession& session) {
     auto& projectManager = magda::ProjectManager::getInstance();
     if (!projectManager.loadProject(input, [&session](const magda::ProjectInfo& info) {
@@ -348,6 +374,154 @@ bool loadProjectForCli(const juce::File& input, HeadlessEngineSession& session) 
         std::cerr << "Failed to load project: " << projectManager.getLastError() << "\n";
         return false;
     }
+    return true;
+}
+
+std::optional<double> parseRenderTime(const juce::String& text, const magda::ProjectInfo& info) {
+    auto token = text.trim().toLowerCase();
+    if (token.endsWith("bars")) {
+        auto bars = parseDouble(token.dropLastCharacters(4));
+        if (!bars)
+            return std::nullopt;
+        const double beats = *bars * info.timeSignatureNumerator;
+        return beats * 60.0 / info.tempo;
+    }
+    if (token.endsWith("bar")) {
+        auto bars = parseDouble(token.dropLastCharacters(3));
+        if (!bars)
+            return std::nullopt;
+        const double beats = *bars * info.timeSignatureNumerator;
+        return beats * 60.0 / info.tempo;
+    }
+    if (token.endsWith("beats")) {
+        auto beats = parseDouble(token.dropLastCharacters(5));
+        if (!beats)
+            return std::nullopt;
+        return *beats * 60.0 / info.tempo;
+    }
+    if (token.endsWith("beat")) {
+        auto beats = parseDouble(token.dropLastCharacters(4));
+        if (!beats)
+            return std::nullopt;
+        return *beats * 60.0 / info.tempo;
+    }
+    if (token.endsWith("s"))
+        token = token.dropLastCharacters(1);
+    return parseDouble(token);
+}
+
+double defaultRenderEndSeconds(te::Edit& edit, const magda::ProjectInfo& info) {
+    const auto editLength = edit.getLength().inSeconds();
+    if (editLength > 0.0)
+        return editLength;
+
+    const double beats = static_cast<double>(info.timelineLengthBars) * info.timeSignatureNumerator;
+    const double seconds = beats * 60.0 / info.tempo;
+    return juce::jmax(1.0, seconds);
+}
+
+bool prepareOutputFile(const juce::File& file) {
+    if (!file.getParentDirectory().createDirectory()) {
+        std::cerr << "Failed to create output directory: "
+                  << file.getParentDirectory().getFullPathName() << "\n";
+        return false;
+    }
+
+    if (file.exists() && !file.deleteFile()) {
+        std::cerr << "Failed to replace output file: " << file.getFullPathName() << "\n";
+        return false;
+    }
+
+    return true;
+}
+
+bool renderWav(magda::TracktionEngineWrapper& engine, const RenderOptions& options) {
+    auto* edit = engine.getEdit();
+    if (edit == nullptr) {
+        std::cerr << "No edit is loaded for rendering\n";
+        return false;
+    }
+
+    if (!prepareOutputFile(options.wavOutput))
+        return false;
+
+    const auto& projectInfo = magda::ProjectManager::getInstance().getCurrentProjectInfo();
+    const double startSeconds = options.fromSeconds.value_or(0.0);
+    const double endSeconds =
+        options.toSeconds.value_or(defaultRenderEndSeconds(*edit, projectInfo));
+    if (startSeconds < 0.0 || endSeconds <= startSeconds) {
+        std::cerr << "Render range must have --to greater than --from\n";
+        return false;
+    }
+
+    auto& transport = edit->getTransport();
+    if (transport.isPlaying())
+        transport.stop(false, false);
+
+    te::TransportControl::ReallocationInhibitor setupInhibitor(transport);
+    te::freePlaybackContextIfNotRecording(transport);
+
+    for (auto* track : te::getAudioTracks(*edit))
+        for (auto* plugin : track->pluginList)
+            if (!plugin->isEnabled())
+                plugin->setEnabled(true);
+
+    if (auto* bridge = engine.getAudioBridge())
+        bridge->getPluginManager().prepareForRendering();
+
+    struct RenderGuard {
+        magda::TracktionEngineWrapper& engine;
+        te::Edit& edit;
+        ~RenderGuard() {
+            if (auto* bridge = engine.getAudioBridge())
+                bridge->getPluginManager().restoreAfterRendering();
+            edit.getTransport().ensureContextAllocated();
+            engine.setOfflineRenderActive(false);
+        }
+    } guard{engine, *edit};
+
+    engine.setOfflineRenderActive(true);
+
+    te::Renderer::Parameters params(*edit);
+    params.destFile = options.wavOutput;
+    params.audioFormat = engine.getEngine()->getAudioFileFormatManager().getWavFormat();
+    params.bitDepth = options.bitDepth.value_or(projectInfo.renderBitDepth);
+    params.sampleRateForAudio = options.sampleRate.value_or(projectInfo.sampleRate);
+    params.blockSizeForAudio = 512;
+    params.shouldNormalise = false;
+    params.useMasterPlugins = true;
+    params.usePlugins = true;
+    params.checkNodesForAudio = false;
+    params.realTimeRender = false;
+    params.time = te::TimeRange(te::TimePosition::fromSeconds(startSeconds),
+                                te::TimePosition::fromSeconds(endSeconds));
+
+    std::atomic<float> progress{0.0f};
+    te::Renderer::RenderTask task("MAGDA CLI Render", params, &progress, nullptr);
+    for (;;) {
+        const auto status = task.runJob();
+        if (status == juce::ThreadPoolJob::jobHasFinished)
+            break;
+        if (status == juce::ThreadPoolJob::jobNeedsRunningAgain) {
+            juce::Thread::sleep(1);
+            continue;
+        }
+
+        std::cerr << "Render failed\n";
+        return false;
+    }
+
+    if (task.errorMessage.isNotEmpty()) {
+        std::cerr << "Render failed: " << task.errorMessage << "\n";
+        return false;
+    }
+    if (!options.wavOutput.existsAsFile() || options.wavOutput.getSize() <= 0) {
+        std::cerr << "Render did not produce a WAV file: " << options.wavOutput.getFullPathName()
+                  << "\n";
+        return false;
+    }
+
+    std::cout << "Rendered " << options.wavOutput.getFullPathName() << "\n";
     return true;
 }
 
@@ -418,6 +592,30 @@ int runCli(const RunOptions& options) {
     return 0;
 }
 
+int initProject(const juce::StringArray& args) {
+    if (args.size() != 2) {
+        printUsage(std::cerr);
+        return 2;
+    }
+
+    HeadlessEngineSession session;
+    if (!session.initialize()) {
+        std::cerr << session.error() << "\n";
+        return 1;
+    }
+
+    if (!magda::ProjectManager::getInstance().newProject()) {
+        std::cerr << "Failed to create project: "
+                  << magda::ProjectManager::getInstance().getLastError() << "\n";
+        return 1;
+    }
+
+    if (!saveProjectForCli(fileFromArg(args[1])))
+        return 1;
+
+    return 0;
+}
+
 int runRoundTrip(const juce::StringArray& args) {
     if (args.size() < 2) {
         printUsage(std::cerr);
@@ -451,6 +649,95 @@ int runRoundTrip(const juce::StringArray& args) {
     }
 
     return runCli(options);
+}
+
+int renderProject(const juce::StringArray& args) {
+    if (args.size() < 4) {
+        printUsage(std::cerr);
+        return 2;
+    }
+
+    RenderOptions options;
+    options.input = fileFromArg(args[1]);
+
+    juce::String fromToken;
+    juce::String toToken;
+    for (int i = 2; i < args.size(); ++i) {
+        if (args[i] == "--wav") {
+            if (++i >= args.size()) {
+                printUsage(std::cerr);
+                return 2;
+            }
+            options.wavOutput = fileFromArg(args[i]);
+        } else if (args[i] == "--from") {
+            if (++i >= args.size()) {
+                printUsage(std::cerr);
+                return 2;
+            }
+            fromToken = args[i];
+        } else if (args[i] == "--to") {
+            if (++i >= args.size()) {
+                printUsage(std::cerr);
+                return 2;
+            }
+            toToken = args[i];
+        } else if (args[i] == "--sample-rate") {
+            if (++i >= args.size()) {
+                printUsage(std::cerr);
+                return 2;
+            }
+            options.sampleRate = parseDouble(args[i]);
+            if (!options.sampleRate || *options.sampleRate <= 0.0) {
+                std::cerr << "--sample-rate requires a positive number\n";
+                return 2;
+            }
+        } else if (args[i] == "--bit-depth") {
+            if (++i >= args.size()) {
+                printUsage(std::cerr);
+                return 2;
+            }
+            options.bitDepth = parsePositiveInt(args[i]);
+            if (!options.bitDepth) {
+                std::cerr << "--bit-depth requires a positive integer\n";
+                return 2;
+            }
+        } else {
+            printUsage(std::cerr);
+            return 2;
+        }
+    }
+
+    if (options.wavOutput.getFullPathName().isEmpty()) {
+        std::cerr << "render requires --wav <out.wav>\n";
+        return 2;
+    }
+
+    HeadlessEngineSession session;
+    if (!session.initialize()) {
+        std::cerr << session.error() << "\n";
+        return 1;
+    }
+
+    if (!loadProjectForCli(options.input, session))
+        return 1;
+
+    const auto& info = magda::ProjectManager::getInstance().getCurrentProjectInfo();
+    if (fromToken.isNotEmpty()) {
+        options.fromSeconds = parseRenderTime(fromToken, info);
+        if (!options.fromSeconds) {
+            std::cerr << "Invalid --from time: " << fromToken << "\n";
+            return 2;
+        }
+    }
+    if (toToken.isNotEmpty()) {
+        options.toSeconds = parseRenderTime(toToken, info);
+        if (!options.toSeconds) {
+            std::cerr << "Invalid --to time: " << toToken << "\n";
+            return 2;
+        }
+    }
+
+    return renderWav(session.engine(), options) ? 0 : 1;
 }
 
 int execCommands(const juce::StringArray& args) {
@@ -515,10 +802,14 @@ int main(int argc, char* argv[]) {
 
     if (command == "boot")
         return bootOnly();
+    if (command == "init")
+        return initProject(args);
     if (command == "run")
         return runRoundTrip(args);
     if (command == "exec")
         return execCommands(args);
+    if (command == "render")
+        return renderProject(args);
 
     std::cerr << "Unknown command: " << command << "\n";
     printUsage(std::cerr);

--- a/magda/daw/cli/magda_cli_main.cpp
+++ b/magda/daw/cli/magda_cli_main.cpp
@@ -46,6 +46,10 @@ void printUsage(std::ostream& out) {
         << "  delete-track <track-id>\n"
         << "  add-midi-clip <track-id> <start-beats> <length-beats>\n"
         << "  delete-clip <clip-id>\n"
+        << "  add-midi-note <clip-id> <start-beats> <note> <length-beats> [velocity]\n"
+        << "  quantize-notes <clip-id> <grid-beats> <start|length|both> <all|note-index...>\n"
+        << "  slice-notes <clip-id> <subdivisions> <all|note-index...>\n"
+        << "  transpose-midi-clip <clip-id> <semitones>\n"
         << "  dump --json\n";
 }
 
@@ -224,6 +228,14 @@ class CommandDispatcher {
             return addMidiClip(tokens, index);
         if (command == "delete-clip")
             return deleteClip(tokens, index);
+        if (command == "add-midi-note")
+            return addMidiNote(tokens, index);
+        if (command == "quantize-notes")
+            return quantizeNotes(tokens, index);
+        if (command == "slice-notes")
+            return sliceNotes(tokens, index);
+        if (command == "transpose-midi-clip")
+            return transposeMidiClip(tokens, index);
         if (command == "dump")
             return dump(tokens, index);
 
@@ -300,6 +312,90 @@ class CommandDispatcher {
         return {};
     }
 
+    CommandResult addMidiNote(const juce::StringArray& tokens, size_t& index) {
+        auto clipId = takeInt(tokens, index, "add-midi-note requires <clip-id>");
+        if (!clipId)
+            return fail(lastParseError_);
+        auto start = takeDouble(tokens, index, "add-midi-note requires <start-beats>");
+        if (!start)
+            return fail(lastParseError_);
+        auto noteNumber = takeInt(tokens, index, "add-midi-note requires <note>");
+        if (!noteNumber)
+            return fail(lastParseError_);
+        auto length = takeDouble(tokens, index, "add-midi-note requires <length-beats>");
+        if (!length)
+            return fail(lastParseError_);
+
+        int velocity = 100;
+        if (index < static_cast<size_t>(tokens.size()) &&
+            !isCommand(tokens[static_cast<int>(index)])) {
+            auto parsedVelocity = parseInt(tokens[static_cast<int>(index)]);
+            if (!parsedVelocity)
+                return fail("add-midi-note velocity must be an integer");
+            velocity = *parsedVelocity;
+            ++index;
+        }
+
+        if (!engine_.getMagdaApi().clips().addMidiNote(*clipId, *start, *noteNumber, *length,
+                                                       velocity))
+            return fail("Failed to add MIDI note");
+        std::cout << "note\n";
+        return {};
+    }
+
+    CommandResult quantizeNotes(const juce::StringArray& tokens, size_t& index) {
+        auto clipId = takeInt(tokens, index, "quantize-notes requires <clip-id>");
+        if (!clipId)
+            return fail(lastParseError_);
+        auto grid = takeDouble(tokens, index, "quantize-notes requires <grid-beats>");
+        if (!grid)
+            return fail(lastParseError_);
+        if (index >= static_cast<size_t>(tokens.size()))
+            return fail("quantize-notes requires <start|length|both>");
+
+        auto mode = parseQuantizeMode(tokens[static_cast<int>(index++)]);
+        if (!mode)
+            return fail("quantize-notes mode must be start, length, or both");
+
+        auto indices = takeNoteIndices(tokens, index, *clipId, "quantize-notes");
+        if (indices.empty())
+            return fail("quantize-notes requires at least one note index or all");
+
+        if (!engine_.getMagdaApi().clips().quantizeMidiNotes(*clipId, indices, *grid, *mode))
+            return fail("Failed to quantize MIDI notes");
+        return {};
+    }
+
+    CommandResult sliceNotes(const juce::StringArray& tokens, size_t& index) {
+        auto clipId = takeInt(tokens, index, "slice-notes requires <clip-id>");
+        if (!clipId)
+            return fail(lastParseError_);
+        auto subdivisions = takeInt(tokens, index, "slice-notes requires <subdivisions>");
+        if (!subdivisions)
+            return fail(lastParseError_);
+
+        auto indices = takeNoteIndices(tokens, index, *clipId, "slice-notes");
+        if (indices.empty())
+            return fail("slice-notes requires at least one note index or all");
+
+        if (!engine_.getMagdaApi().clips().sliceMidiNotes(*clipId, indices, *subdivisions))
+            return fail("Failed to slice MIDI notes");
+        return {};
+    }
+
+    CommandResult transposeMidiClip(const juce::StringArray& tokens, size_t& index) {
+        auto clipId = takeInt(tokens, index, "transpose-midi-clip requires <clip-id>");
+        if (!clipId)
+            return fail(lastParseError_);
+        auto semitones = takeInt(tokens, index, "transpose-midi-clip requires <semitones>");
+        if (!semitones)
+            return fail(lastParseError_);
+
+        if (!engine_.getMagdaApi().clips().transposeMidiClip(*clipId, *semitones))
+            return fail("Failed to transpose MIDI clip");
+        return {};
+    }
+
     CommandResult dump(const juce::StringArray& tokens, size_t& index) {
         if (index >= static_cast<size_t>(tokens.size()) ||
             tokens[static_cast<int>(index)] != "--json")
@@ -311,9 +407,54 @@ class CommandDispatcher {
 
     static bool isCommand(const juce::String& token) {
         static const std::set<juce::String> commands = {
-            "set-tempo", "add-track",   "delete-track", "add-midi-clip",
-            "add-clip",  "delete-clip", "dump"};
+            "set-tempo",   "add-track",           "delete-track",  "add-midi-clip",
+            "add-clip",    "delete-clip",         "add-midi-note", "quantize-notes",
+            "slice-notes", "transpose-midi-clip", "dump"};
         return commands.count(token) > 0 || token.startsWith("--");
+    }
+
+    static std::optional<magda::MidiNoteQuantizeMode> parseQuantizeMode(const juce::String& token) {
+        auto normalized = token.trim().toLowerCase();
+        if (normalized == "start")
+            return magda::MidiNoteQuantizeMode::StartOnly;
+        if (normalized == "length")
+            return magda::MidiNoteQuantizeMode::LengthOnly;
+        if (normalized == "both" || normalized == "start-and-length")
+            return magda::MidiNoteQuantizeMode::StartAndLength;
+        return std::nullopt;
+    }
+
+    std::vector<size_t> takeNoteIndices(const juce::StringArray& tokens, size_t& index,
+                                        magda::ClipId clipId, const juce::String& commandName) {
+        std::vector<size_t> indices;
+        if (index >= static_cast<size_t>(tokens.size()) ||
+            isCommand(tokens[static_cast<int>(index)])) {
+            lastParseError_ = commandName + " requires <all|note-index...>";
+            return indices;
+        }
+
+        if (tokens[static_cast<int>(index)] == "all") {
+            ++index;
+            if (auto* clip = engine_.getMagdaApi().clips().getClip(clipId)) {
+                indices.reserve(clip->midiNotes.size());
+                for (size_t i = 0; i < clip->midiNotes.size(); ++i)
+                    indices.push_back(i);
+            }
+            return indices;
+        }
+
+        while (index < static_cast<size_t>(tokens.size()) &&
+               !isCommand(tokens[static_cast<int>(index)])) {
+            auto parsed = parseInt(tokens[static_cast<int>(index)]);
+            if (!parsed || *parsed < 0) {
+                lastParseError_ = commandName + " note indices must be non-negative integers";
+                indices.clear();
+                return indices;
+            }
+            indices.push_back(static_cast<size_t>(*parsed));
+            ++index;
+        }
+        return indices;
     }
 
     std::optional<int> takeInt(const juce::StringArray& tokens, size_t& index,

--- a/magda/daw/cli/magda_cli_main.cpp
+++ b/magda/daw/cli/magda_cli_main.cpp
@@ -7,11 +7,11 @@
 // clang-format on
 
 #include <atomic>
+#include <cmath>
 #include <functional>
 #include <iostream>
 #include <memory>
 #include <optional>
-#include <set>
 #include <sstream>
 #include <vector>
 
@@ -29,29 +29,7 @@ namespace {
 
 namespace te = tracktion;
 
-void printUsage(std::ostream& out) {
-    out << "magda-cli " << MAGDA_VERSION << "\n"
-        << "\n"
-        << "Usage:\n"
-        << "  magda-cli boot\n"
-        << "  magda-cli init <out.mgd>\n"
-        << "  magda-cli run <project.mgd> [--out <out.mgd>]\n"
-        << "  magda-cli run <project.mgd> --cmds <cmds.txt> [--out <out.mgd>] [--dump-json]\n"
-        << "  magda-cli exec <project.mgd> <commands...> [--out <out.mgd>] [--dump-json]\n"
-        << "  magda-cli render <project.mgd> --wav <out.wav> [--from <time>] [--to <time>]\n"
-        << "\n"
-        << "Commands:\n"
-        << "  set-tempo <bpm>\n"
-        << "  add-track <audio|group|aux|chord> [name]\n"
-        << "  delete-track <track-id>\n"
-        << "  add-midi-clip <track-id> <start-beats> <length-beats>\n"
-        << "  delete-clip <clip-id>\n"
-        << "  add-midi-note <clip-id> <start-beats> <note> <length-beats> [velocity]\n"
-        << "  quantize-notes <clip-id> <grid-beats> <start|length|both> <all|note-index...>\n"
-        << "  slice-notes <clip-id> <subdivisions> <all|note-index...>\n"
-        << "  transpose-midi-clip <clip-id> <semitones>\n"
-        << "  dump --json\n";
-}
+void printUsage(std::ostream& out);
 
 juce::File fileFromArg(const juce::String& path) {
     if (juce::File::isAbsolutePath(path))
@@ -98,17 +76,29 @@ bool restoreProjectTiming(magda::TracktionEngineWrapper& engine, const magda::Pr
 }
 
 std::optional<double> parseDouble(const juce::String& text) {
+    const auto input = text.trim().toStdString();
+    if (input.empty())
+        return std::nullopt;
+
     double value = 0.0;
-    if (std::istringstream{text.toStdString()} >> value)
-        return value;
-    return std::nullopt;
+    char trailing = 0;
+    std::istringstream stream(input);
+    if (!(stream >> value) || (stream >> trailing) || !std::isfinite(value))
+        return std::nullopt;
+    return value;
 }
 
 std::optional<int> parseInt(const juce::String& text) {
+    const auto input = text.trim().toStdString();
+    if (input.empty())
+        return std::nullopt;
+
     int value = 0;
-    if (std::istringstream{text.toStdString()} >> value)
-        return value;
-    return std::nullopt;
+    char trailing = 0;
+    std::istringstream stream(input);
+    if (!(stream >> value) || (stream >> trailing))
+        return std::nullopt;
+    return value;
 }
 
 std::optional<int> parsePositiveInt(const juce::String& text) {
@@ -213,31 +203,49 @@ class CommandDispatcher {
   public:
     explicit CommandDispatcher(magda::TracktionEngineWrapper& engine) : engine_(engine) {}
 
+    struct CommandSpec {
+        const char* name;
+        const char* usage;
+        CommandResult (CommandDispatcher::*handler)(const juce::StringArray&, size_t&);
+        bool showInUsage = true;
+    };
+
+    static const std::vector<CommandSpec>& commandSpecs() {
+        static const std::vector<CommandSpec> specs = {
+            {"set-tempo", "set-tempo <bpm>", &CommandDispatcher::setTempo},
+            {"add-track", "add-track <audio|group|aux|chord> [name]", &CommandDispatcher::addTrack},
+            {"add-internal-instrument", "add-internal-instrument <track-id> <plugin-id> [name]",
+             &CommandDispatcher::addInternalInstrument},
+            {"delete-track", "delete-track <track-id>", &CommandDispatcher::deleteTrack},
+            {"add-midi-clip", "add-midi-clip <track-id> <start-beats> <length-beats>",
+             &CommandDispatcher::addMidiClip},
+            {"add-clip", "add-midi-clip <track-id> <start-beats> <length-beats>",
+             &CommandDispatcher::addMidiClip, false},
+            {"delete-clip", "delete-clip <clip-id>", &CommandDispatcher::deleteClip},
+            {"add-midi-note",
+             "add-midi-note <clip-id> <start-beats> <note> <length-beats> "
+             "[velocity]",
+             &CommandDispatcher::addMidiNote},
+            {"quantize-notes",
+             "quantize-notes <clip-id> <grid-beats> <start|length|both> <all|note-index...>",
+             &CommandDispatcher::quantizeNotes},
+            {"slice-notes", "slice-notes <clip-id> <subdivisions> <all|note-index...>",
+             &CommandDispatcher::sliceNotes},
+            {"transpose-midi-clip", "transpose-midi-clip <clip-id> <semitones>",
+             &CommandDispatcher::transposeMidiClip},
+            {"dump", "dump --json", &CommandDispatcher::dump},
+        };
+        return specs;
+    }
+
     CommandResult execute(const juce::StringArray& tokens, size_t& index) {
         if (index >= static_cast<size_t>(tokens.size()))
             return {};
 
         const auto command = tokens[static_cast<int>(index++)];
-        if (command == "set-tempo")
-            return setTempo(tokens, index);
-        if (command == "add-track")
-            return addTrack(tokens, index);
-        if (command == "delete-track")
-            return deleteTrack(tokens, index);
-        if (command == "add-midi-clip" || command == "add-clip")
-            return addMidiClip(tokens, index);
-        if (command == "delete-clip")
-            return deleteClip(tokens, index);
-        if (command == "add-midi-note")
-            return addMidiNote(tokens, index);
-        if (command == "quantize-notes")
-            return quantizeNotes(tokens, index);
-        if (command == "slice-notes")
-            return sliceNotes(tokens, index);
-        if (command == "transpose-midi-clip")
-            return transposeMidiClip(tokens, index);
-        if (command == "dump")
-            return dump(tokens, index);
+        for (const auto& spec : commandSpecs())
+            if (command == spec.name)
+                return (this->*spec.handler)(tokens, index);
 
         return fail("Unknown command: " + command);
     }
@@ -255,7 +263,7 @@ class CommandDispatcher {
             return fail("set-tempo requires a positive numeric bpm");
 
         engine_.setTempo(*bpm);
-        magda::ProjectManager::getInstance().setTempo(*bpm);
+        engine_.getMagdaApi().project().setTempo(*bpm);
         return {};
     }
 
@@ -283,6 +291,36 @@ class CommandDispatcher {
         if (!trackId)
             return fail(lastParseError_);
         engine_.getMagdaApi().tracks().deleteTrack(*trackId);
+        return {};
+    }
+
+    CommandResult addInternalInstrument(const juce::StringArray& tokens, size_t& index) {
+        auto trackId = takeInt(tokens, index, "add-internal-instrument requires <track-id>");
+        if (!trackId)
+            return fail(lastParseError_);
+        if (index >= static_cast<size_t>(tokens.size()))
+            return fail("add-internal-instrument requires <plugin-id>");
+
+        const auto pluginId = tokens[static_cast<int>(index++)];
+        auto name = pluginId;
+        if (index < static_cast<size_t>(tokens.size()) &&
+            !isCommand(tokens[static_cast<int>(index)]))
+            name = tokens[static_cast<int>(index++)];
+
+        magda::DeviceInfo device;
+        device.name = name;
+        device.manufacturer = "MAGDA";
+        device.pluginId = pluginId;
+        device.uniqueId = pluginId;
+        device.fileOrIdentifier = pluginId;
+        device.isInstrument = true;
+        device.deviceType = magda::DeviceType::Instrument;
+        device.format = magda::PluginFormat::Internal;
+
+        const auto deviceId = engine_.getMagdaApi().tracks().addDeviceToTrack(*trackId, device);
+        if (deviceId == magda::INVALID_DEVICE_ID)
+            return fail("Failed to add internal instrument");
+        std::cout << "device " << deviceId << "\n";
         return {};
     }
 
@@ -332,7 +370,7 @@ class CommandDispatcher {
             auto parsedVelocity = parseInt(tokens[static_cast<int>(index)]);
             if (!parsedVelocity)
                 return fail("add-midi-note velocity must be an integer");
-            velocity = *parsedVelocity;
+            velocity = juce::jlimit(0, 127, *parsedVelocity);
             ++index;
         }
 
@@ -406,11 +444,10 @@ class CommandDispatcher {
     }
 
     static bool isCommand(const juce::String& token) {
-        static const std::set<juce::String> commands = {
-            "set-tempo",   "add-track",           "delete-track",  "add-midi-clip",
-            "add-clip",    "delete-clip",         "add-midi-note", "quantize-notes",
-            "slice-notes", "transpose-midi-clip", "dump"};
-        return commands.count(token) > 0 || token.startsWith("--");
+        for (const auto& spec : commandSpecs())
+            if (token == spec.name)
+                return true;
+        return token.startsWith("--");
     }
 
     static std::optional<magda::MidiNoteQuantizeMode> parseQuantizeMode(const juce::String& token) {
@@ -488,6 +525,24 @@ class CommandDispatcher {
     magda::TracktionEngineWrapper& engine_;
     juce::String lastParseError_;
 };
+
+void printUsage(std::ostream& out) {
+    out << "magda-cli " << MAGDA_VERSION << "\n"
+        << "\n"
+        << "Usage:\n"
+        << "  magda-cli boot\n"
+        << "  magda-cli init <out.mgd>\n"
+        << "  magda-cli run <project.mgd> [--out <out.mgd>]\n"
+        << "  magda-cli run <project.mgd> --cmds <cmds.txt> [--out <out.mgd>] [--dump-json]\n"
+        << "  magda-cli exec <project.mgd> <commands...> [--out <out.mgd>] [--dump-json]\n"
+        << "  magda-cli render <project.mgd> --wav <out.wav> [--from <time>] [--to <time>]\n"
+        << "\n"
+        << "Commands:\n";
+
+    for (const auto& spec : CommandDispatcher::commandSpecs())
+        if (spec.showInUsage)
+            out << "  " << spec.usage << "\n";
+}
 
 struct RunOptions {
     juce::File input;

--- a/magda/daw/cli/magda_cli_main.cpp
+++ b/magda/daw/cli/magda_cli_main.cpp
@@ -1,0 +1,144 @@
+#include <juce_core/juce_core.h>
+#include <juce_events/juce_events.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <iostream>
+#include <memory>
+
+#include "engine/TracktionEngineWrapper.hpp"
+#include "project/ProjectManager.hpp"
+#include "version.hpp"
+
+namespace {
+
+void printUsage(std::ostream& out) {
+    out << "magda-cli " << MAGDA_VERSION << "\n"
+        << "\n"
+        << "Usage:\n"
+        << "  magda-cli boot\n"
+        << "  magda-cli run <project.mgd> [--out <out.mgd>]\n"
+        << "\n"
+        << "P0 supports headless boot plus load -> save round-trip.\n";
+}
+
+juce::File fileFromArg(const juce::String& path) {
+    if (juce::File::isAbsolutePath(path))
+        return juce::File(path);
+    return juce::File::getCurrentWorkingDirectory().getChildFile(path);
+}
+
+juce::File defaultOutputFor(const juce::File& input) {
+    auto parent = input.getParentDirectory();
+    auto stem = input.getFileNameWithoutExtension() + "_roundtrip";
+    return parent.getChildFile(stem + ".mgd");
+}
+
+class HeadlessEngineSession {
+  public:
+    bool initialize() {
+        engine_ = std::make_unique<magda::TracktionEngineWrapper>();
+        engine_->setForceHeadless(true);
+        if (!engine_->initialize()) {
+            error_ = "Failed to initialize MAGDA engine";
+            engine_.reset();
+            return false;
+        }
+        return true;
+    }
+
+    magda::TracktionEngineWrapper& engine() {
+        return *engine_;
+    }
+
+    const juce::String& error() const {
+        return error_;
+    }
+
+  private:
+    std::unique_ptr<magda::TracktionEngineWrapper> engine_;
+    juce::String error_;
+};
+
+bool restoreProjectTiming(magda::TracktionEngineWrapper& engine, const magda::ProjectInfo& info) {
+    engine.setTempo(info.tempo);
+    engine.setTimeSignature(info.timeSignatureNumerator, info.timeSignatureDenominator);
+    return true;
+}
+
+int runRoundTrip(const juce::StringArray& args) {
+    if (args.size() != 2 && args.size() != 4) {
+        printUsage(std::cerr);
+        return 2;
+    }
+
+    const auto input = fileFromArg(args[1]);
+    auto output = defaultOutputFor(input);
+
+    if (args.size() == 4) {
+        if (args[2] != "--out") {
+            printUsage(std::cerr);
+            return 2;
+        }
+        output = fileFromArg(args[3]);
+    }
+
+    HeadlessEngineSession session;
+    if (!session.initialize()) {
+        std::cerr << session.error() << "\n";
+        return 1;
+    }
+
+    auto& projectManager = magda::ProjectManager::getInstance();
+    if (!projectManager.loadProject(input, [&session](const magda::ProjectInfo& info) {
+            restoreProjectTiming(session.engine(), info);
+        })) {
+        std::cerr << "Failed to load project: " << projectManager.getLastError() << "\n";
+        return 1;
+    }
+
+    if (!projectManager.saveProjectAs(output)) {
+        std::cerr << "Failed to save project: " << projectManager.getLastError() << "\n";
+        return 1;
+    }
+
+    std::cout << "Saved " << projectManager.getCurrentProjectFile().getFullPathName() << "\n";
+    return 0;
+}
+
+int bootOnly() {
+    HeadlessEngineSession session;
+    if (!session.initialize()) {
+        std::cerr << session.error() << "\n";
+        return 1;
+    }
+
+    std::cout << "MAGDA engine booted headless\n";
+    return 0;
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    juce::ScopedJuceInitialiser_GUI juceInit;
+
+    juce::StringArray args;
+    for (int i = 0; i < argc; ++i)
+        args.add(juce::String(argv[i]));
+
+    if (args.size() < 2 || args[1] == "--help" || args[1] == "-h") {
+        printUsage(args.size() < 2 ? std::cerr : std::cout);
+        return args.size() < 2 ? 2 : 0;
+    }
+
+    const auto command = args[1];
+    args.remove(0);
+
+    if (command == "boot")
+        return bootOnly();
+    if (command == "run")
+        return runRoundTrip(args);
+
+    std::cerr << "Unknown command: " << command << "\n";
+    printUsage(std::cerr);
+    return 2;
+}

--- a/magda/daw/cli/magda_cli_main.cpp
+++ b/magda/daw/cli/magda_cli_main.cpp
@@ -20,6 +20,7 @@
 #include "api/project_api.hpp"
 #include "api/track_api.hpp"
 #include "audio/AudioBridge.hpp"
+#include "engine/OfflineRenderHelper.hpp"
 #include "engine/TracktionEngineWrapper.hpp"
 #include "project/ProjectInfo.hpp"
 #include "project/ProjectManager.hpp"
@@ -262,7 +263,6 @@ class CommandDispatcher {
         if (!bpm || *bpm <= 0.0)
             return fail("set-tempo requires a positive numeric bpm");
 
-        engine_.setTempo(*bpm);
         engine_.getMagdaApi().project().setTempo(*bpm);
         return {};
     }
@@ -651,26 +651,15 @@ bool renderWav(magda::TracktionEngineWrapper& engine, const RenderOptions& optio
     }
 
     auto& transport = edit->getTransport();
-    if (transport.isPlaying())
-        transport.stop(false, false);
-
     te::TransportControl::ReallocationInhibitor setupInhibitor(transport);
-    te::freePlaybackContextIfNotRecording(transport);
-
-    for (auto* track : te::getAudioTracks(*edit))
-        for (auto* plugin : track->pluginList)
-            if (!plugin->isEnabled())
-                plugin->setEnabled(true);
-
-    if (auto* bridge = engine.getAudioBridge())
-        bridge->getPluginManager().prepareForRendering();
+    magda::prepareEditForOfflineRender(*edit);
+    magda::preparePluginsForOfflineRender(engine);
 
     struct RenderGuard {
         magda::TracktionEngineWrapper& engine;
         te::Edit& edit;
         ~RenderGuard() {
-            if (auto* bridge = engine.getAudioBridge())
-                bridge->getPluginManager().restoreAfterRendering();
+            magda::restorePluginsAfterOfflineRender(engine);
             edit.getTransport().ensureContextAllocated();
             engine.setOfflineRenderActive(false);
         }
@@ -678,19 +667,19 @@ bool renderWav(magda::TracktionEngineWrapper& engine, const RenderOptions& optio
 
     engine.setOfflineRenderActive(true);
 
-    te::Renderer::Parameters params(*edit);
-    params.destFile = options.wavOutput;
-    params.audioFormat = engine.getEngine()->getAudioFileFormatManager().getWavFormat();
-    params.bitDepth = options.bitDepth.value_or(projectInfo.renderBitDepth);
-    params.sampleRateForAudio = options.sampleRate.value_or(projectInfo.sampleRate);
-    params.blockSizeForAudio = 512;
-    params.shouldNormalise = false;
-    params.useMasterPlugins = true;
-    params.usePlugins = true;
-    params.checkNodesForAudio = false;
-    params.realTimeRender = false;
-    params.time = te::TimeRange(te::TimePosition::fromSeconds(startSeconds),
-                                te::TimePosition::fromSeconds(endSeconds));
+    auto params = magda::makeOfflineRenderParameters(
+        *edit, {.destFile = options.wavOutput,
+                .audioFormat = engine.getEngine()->getAudioFileFormatManager().getWavFormat(),
+                .bitDepth = options.bitDepth.value_or(projectInfo.renderBitDepth),
+                .sampleRate = options.sampleRate.value_or(projectInfo.sampleRate),
+                .blockSize = 512,
+                .shouldNormalise = false,
+                .useMasterPlugins = true,
+                .usePlugins = true,
+                .checkNodesForAudio = false,
+                .realTimeRender = false,
+                .time = te::TimeRange(te::TimePosition::fromSeconds(startSeconds),
+                                      te::TimePosition::fromSeconds(endSeconds))});
 
     std::atomic<float> progress{0.0f};
     te::Renderer::RenderTask task("MAGDA CLI Render", params, &progress, nullptr);

--- a/magda/daw/cli/magda_cli_main.cpp
+++ b/magda/daw/cli/magda_cli_main.cpp
@@ -2,10 +2,20 @@
 #include <juce_events/juce_events.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 
+#include <functional>
 #include <iostream>
 #include <memory>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <vector>
 
+#include "api/clip_api.hpp"
+#include "api/magda_api.hpp"
+#include "api/project_api.hpp"
+#include "api/track_api.hpp"
 #include "engine/TracktionEngineWrapper.hpp"
+#include "project/ProjectInfo.hpp"
 #include "project/ProjectManager.hpp"
 #include "version.hpp"
 
@@ -17,8 +27,16 @@ void printUsage(std::ostream& out) {
         << "Usage:\n"
         << "  magda-cli boot\n"
         << "  magda-cli run <project.mgd> [--out <out.mgd>]\n"
+        << "  magda-cli run <project.mgd> --cmds <cmds.txt> [--out <out.mgd>] [--dump-json]\n"
+        << "  magda-cli exec <project.mgd> <commands...> [--out <out.mgd>] [--dump-json]\n"
         << "\n"
-        << "P0 supports headless boot plus load -> save round-trip.\n";
+        << "Commands:\n"
+        << "  set-tempo <bpm>\n"
+        << "  add-track <audio|group|aux|chord> [name]\n"
+        << "  delete-track <track-id>\n"
+        << "  add-midi-clip <track-id> <start-beats> <length-beats>\n"
+        << "  delete-clip <clip-id>\n"
+        << "  dump --json\n";
 }
 
 juce::File fileFromArg(const juce::String& path) {
@@ -65,44 +83,406 @@ bool restoreProjectTiming(magda::TracktionEngineWrapper& engine, const magda::Pr
     return true;
 }
 
-int runRoundTrip(const juce::StringArray& args) {
-    if (args.size() != 2 && args.size() != 4) {
-        printUsage(std::cerr);
-        return 2;
+std::optional<double> parseDouble(const juce::String& text) {
+    double value = 0.0;
+    if (std::istringstream{text.toStdString()} >> value)
+        return value;
+    return std::nullopt;
+}
+
+std::optional<int> parseInt(const juce::String& text) {
+    int value = 0;
+    if (std::istringstream{text.toStdString()} >> value)
+        return value;
+    return std::nullopt;
+}
+
+std::optional<magda::TrackType> parseTrackType(const juce::String& text) {
+    auto normalized = text.trim().toLowerCase();
+    if (normalized == "audio" || normalized == "midi")
+        return magda::TrackType::Audio;
+    if (normalized == "group")
+        return magda::TrackType::Group;
+    if (normalized == "aux")
+        return magda::TrackType::Aux;
+    if (normalized == "chord")
+        return magda::TrackType::Chord;
+    return std::nullopt;
+}
+
+juce::String trackTypeToString(magda::TrackType type) {
+    return juce::String(magda::getTrackTypeName(type)).toLowerCase();
+}
+
+juce::var midiNoteToJson(const magda::MidiNote& note) {
+    auto obj = new juce::DynamicObject();
+    obj->setProperty("note", note.noteNumber);
+    obj->setProperty("velocity", note.velocity);
+    obj->setProperty("startBeat", note.startBeat);
+    obj->setProperty("lengthBeats", note.lengthBeats);
+    return obj;
+}
+
+juce::var clipToJson(const magda::ClipInfo& clip) {
+    auto obj = new juce::DynamicObject();
+    obj->setProperty("id", clip.id);
+    obj->setProperty("trackId", clip.trackId);
+    obj->setProperty("name", clip.name);
+    obj->setProperty("type", clip.isAudio() ? "audio" : "midi");
+    obj->setProperty("view", clip.view == magda::ClipView::Session ? "session" : "arrangement");
+    obj->setProperty("startBeat", clip.placement.startBeat);
+    obj->setProperty("lengthBeats", clip.placement.lengthBeats);
+
+    juce::Array<juce::var> notes;
+    for (const auto& note : clip.midiNotes)
+        notes.add(midiNoteToJson(note));
+    obj->setProperty("notes", notes);
+
+    if (clip.isAudio())
+        obj->setProperty("sourceFile", clip.audio().source.filePath);
+
+    return obj;
+}
+
+juce::var trackToJson(magda::MagdaApi& api, const magda::TrackInfo& track) {
+    auto obj = new juce::DynamicObject();
+    obj->setProperty("id", track.id);
+    obj->setProperty("type", trackTypeToString(track.type));
+    obj->setProperty("name", track.name);
+    obj->setProperty("volume", track.volume);
+    obj->setProperty("pan", track.pan);
+    obj->setProperty("muted", track.muted);
+    obj->setProperty("soloed", track.soloed);
+    obj->setProperty("recordArmed", track.recordArmed);
+
+    juce::Array<juce::var> clips;
+    for (auto clipId : api.clips().getClipsOnTrack(track.id)) {
+        if (auto* clip = api.clips().getClip(clipId))
+            clips.add(clipToJson(*clip));
+    }
+    obj->setProperty("clips", clips);
+    return obj;
+}
+
+juce::String dumpProjectJson(magda::MagdaApi& api) {
+    const auto& project = api.project().getCurrentProjectInfo();
+    auto root = new juce::DynamicObject();
+    root->setProperty("name", project.name);
+    root->setProperty("filePath", project.filePath);
+    root->setProperty("tempo", project.tempo);
+    root->setProperty("timeSignatureNumerator", project.timeSignatureNumerator);
+    root->setProperty("timeSignatureDenominator", project.timeSignatureDenominator);
+    root->setProperty("sampleRate", project.sampleRate);
+    root->setProperty("timelineLengthBars", project.timelineLengthBars);
+
+    juce::Array<juce::var> tracks;
+    for (const auto& track : api.tracks().getTracks())
+        tracks.add(trackToJson(api, track));
+    root->setProperty("tracks", tracks);
+
+    return juce::JSON::toString(juce::var(root), true);
+}
+
+struct CommandResult {
+    bool ok = true;
+    juce::String error;
+};
+
+class CommandDispatcher {
+  public:
+    explicit CommandDispatcher(magda::TracktionEngineWrapper& engine) : engine_(engine) {}
+
+    CommandResult execute(const juce::StringArray& tokens, size_t& index) {
+        if (index >= static_cast<size_t>(tokens.size()))
+            return {};
+
+        const auto command = tokens[static_cast<int>(index++)];
+        if (command == "set-tempo")
+            return setTempo(tokens, index);
+        if (command == "add-track")
+            return addTrack(tokens, index);
+        if (command == "delete-track")
+            return deleteTrack(tokens, index);
+        if (command == "add-midi-clip" || command == "add-clip")
+            return addMidiClip(tokens, index);
+        if (command == "delete-clip")
+            return deleteClip(tokens, index);
+        if (command == "dump")
+            return dump(tokens, index);
+
+        return fail("Unknown command: " + command);
     }
 
-    const auto input = fileFromArg(args[1]);
-    auto output = defaultOutputFor(input);
+    void dumpJson() {
+        std::cout << dumpProjectJson(engine_.getMagdaApi()) << "\n";
+    }
 
-    if (args.size() == 4) {
-        if (args[2] != "--out") {
-            printUsage(std::cerr);
-            return 2;
+  private:
+    CommandResult setTempo(const juce::StringArray& tokens, size_t& index) {
+        if (index >= static_cast<size_t>(tokens.size()))
+            return fail("set-tempo requires <bpm>");
+        auto bpm = parseDouble(tokens[static_cast<int>(index++)]);
+        if (!bpm || *bpm <= 0.0)
+            return fail("set-tempo requires a positive numeric bpm");
+
+        engine_.setTempo(*bpm);
+        magda::ProjectManager::getInstance().setTempo(*bpm);
+        return {};
+    }
+
+    CommandResult addTrack(const juce::StringArray& tokens, size_t& index) {
+        if (index >= static_cast<size_t>(tokens.size()))
+            return fail("add-track requires <audio|group|aux|chord>");
+
+        const auto typeToken = tokens[static_cast<int>(index++)];
+        auto type = parseTrackType(typeToken);
+        if (!type)
+            return fail("Unsupported track type: " + typeToken);
+
+        juce::String name = juce::String(magda::getTrackTypeName(*type));
+        if (index < static_cast<size_t>(tokens.size()) &&
+            !isCommand(tokens[static_cast<int>(index)]))
+            name = tokens[static_cast<int>(index++)];
+
+        auto id = engine_.getMagdaApi().tracks().createTrack(name, *type);
+        std::cout << "track " << id << "\n";
+        return {};
+    }
+
+    CommandResult deleteTrack(const juce::StringArray& tokens, size_t& index) {
+        auto trackId = takeInt(tokens, index, "delete-track requires <track-id>");
+        if (!trackId)
+            return fail(lastParseError_);
+        engine_.getMagdaApi().tracks().deleteTrack(*trackId);
+        return {};
+    }
+
+    CommandResult addMidiClip(const juce::StringArray& tokens, size_t& index) {
+        auto trackId = takeInt(tokens, index, "add-midi-clip requires <track-id>");
+        if (!trackId)
+            return fail(lastParseError_);
+        auto start = takeDouble(tokens, index, "add-midi-clip requires <start-beats>");
+        if (!start)
+            return fail(lastParseError_);
+        auto length = takeDouble(tokens, index, "add-midi-clip requires <length-beats>");
+        if (!length)
+            return fail(lastParseError_);
+        if (*length <= 0.0)
+            return fail("add-midi-clip requires a positive length");
+
+        auto id = engine_.getMagdaApi().clips().createMidiClipBeats(*trackId, *start, *length);
+        std::cout << "clip " << id << "\n";
+        return {};
+    }
+
+    CommandResult deleteClip(const juce::StringArray& tokens, size_t& index) {
+        auto clipId = takeInt(tokens, index, "delete-clip requires <clip-id>");
+        if (!clipId)
+            return fail(lastParseError_);
+        engine_.getMagdaApi().clips().deleteClip(*clipId);
+        return {};
+    }
+
+    CommandResult dump(const juce::StringArray& tokens, size_t& index) {
+        if (index >= static_cast<size_t>(tokens.size()) ||
+            tokens[static_cast<int>(index)] != "--json")
+            return fail("dump requires --json");
+        ++index;
+        dumpJson();
+        return {};
+    }
+
+    static bool isCommand(const juce::String& token) {
+        static const std::set<juce::String> commands = {
+            "set-tempo", "add-track",   "delete-track", "add-midi-clip",
+            "add-clip",  "delete-clip", "dump"};
+        return commands.count(token) > 0 || token.startsWith("--");
+    }
+
+    std::optional<int> takeInt(const juce::StringArray& tokens, size_t& index,
+                               const juce::String& missingError) {
+        if (index >= static_cast<size_t>(tokens.size())) {
+            lastParseError_ = missingError;
+            return std::nullopt;
         }
-        output = fileFromArg(args[3]);
+        auto value = parseInt(tokens[static_cast<int>(index++)]);
+        if (!value)
+            lastParseError_ = "Expected integer argument";
+        return value;
     }
 
+    std::optional<double> takeDouble(const juce::StringArray& tokens, size_t& index,
+                                     const juce::String& missingError) {
+        if (index >= static_cast<size_t>(tokens.size())) {
+            lastParseError_ = missingError;
+            return std::nullopt;
+        }
+        auto value = parseDouble(tokens[static_cast<int>(index++)]);
+        if (!value)
+            lastParseError_ = "Expected numeric argument";
+        return value;
+    }
+
+    static CommandResult fail(const juce::String& error) {
+        return {false, error};
+    }
+
+    magda::TracktionEngineWrapper& engine_;
+    juce::String lastParseError_;
+};
+
+struct RunOptions {
+    juce::File input;
+    juce::File output;
+    juce::File commandFile;
+    bool hasCommandFile = false;
+    bool dumpJson = false;
+    juce::StringArray execTokens;
+};
+
+bool loadProjectForCli(const juce::File& input, HeadlessEngineSession& session) {
+    auto& projectManager = magda::ProjectManager::getInstance();
+    if (!projectManager.loadProject(input, [&session](const magda::ProjectInfo& info) {
+            restoreProjectTiming(session.engine(), info);
+        })) {
+        std::cerr << "Failed to load project: " << projectManager.getLastError() << "\n";
+        return false;
+    }
+    return true;
+}
+
+bool saveProjectForCli(const juce::File& output) {
+    auto& projectManager = magda::ProjectManager::getInstance();
+    if (!projectManager.saveProjectAs(output)) {
+        std::cerr << "Failed to save project: " << projectManager.getLastError() << "\n";
+        return false;
+    }
+    std::cout << "Saved " << projectManager.getCurrentProjectFile().getFullPathName() << "\n";
+    return true;
+}
+
+bool executeCommandTokens(CommandDispatcher& dispatcher, const juce::StringArray& tokens) {
+    size_t index = 0;
+    while (index < static_cast<size_t>(tokens.size())) {
+        auto result = dispatcher.execute(tokens, index);
+        if (!result.ok) {
+            std::cerr << result.error << "\n";
+            return false;
+        }
+    }
+    return true;
+}
+
+bool executeCommandFile(CommandDispatcher& dispatcher, const juce::File& file) {
+    if (!file.existsAsFile()) {
+        std::cerr << "Command file does not exist: " << file.getFullPathName() << "\n";
+        return false;
+    }
+
+    juce::StringArray lines;
+    lines.addLines(file.loadFileAsString());
+    for (auto line : lines) {
+        line = line.trim();
+        if (line.isEmpty() || line.startsWith("#"))
+            continue;
+
+        juce::StringArray tokens;
+        tokens.addTokens(line, true);
+        if (!executeCommandTokens(dispatcher, tokens))
+            return false;
+    }
+    return true;
+}
+
+int runCli(const RunOptions& options) {
     HeadlessEngineSession session;
     if (!session.initialize()) {
         std::cerr << session.error() << "\n";
         return 1;
     }
 
-    auto& projectManager = magda::ProjectManager::getInstance();
-    if (!projectManager.loadProject(input, [&session](const magda::ProjectInfo& info) {
-            restoreProjectTiming(session.engine(), info);
-        })) {
-        std::cerr << "Failed to load project: " << projectManager.getLastError() << "\n";
+    if (!loadProjectForCli(options.input, session))
         return 1;
-    }
 
-    if (!projectManager.saveProjectAs(output)) {
-        std::cerr << "Failed to save project: " << projectManager.getLastError() << "\n";
+    CommandDispatcher dispatcher(session.engine());
+    if (options.hasCommandFile && !executeCommandFile(dispatcher, options.commandFile))
         return 1;
-    }
+    if (!options.execTokens.isEmpty() && !executeCommandTokens(dispatcher, options.execTokens))
+        return 1;
+    if (options.dumpJson)
+        dispatcher.dumpJson();
 
-    std::cout << "Saved " << projectManager.getCurrentProjectFile().getFullPathName() << "\n";
+    if (!saveProjectForCli(options.output))
+        return 1;
+
     return 0;
+}
+
+int runRoundTrip(const juce::StringArray& args) {
+    if (args.size() < 2) {
+        printUsage(std::cerr);
+        return 2;
+    }
+
+    RunOptions options;
+    options.input = fileFromArg(args[1]);
+    options.output = defaultOutputFor(options.input);
+
+    for (int i = 2; i < args.size(); ++i) {
+        if (args[i] == "--out") {
+            if (++i >= args.size()) {
+                printUsage(std::cerr);
+                return 2;
+            }
+            options.output = fileFromArg(args[i]);
+        } else if (args[i] == "--cmds") {
+            if (++i >= args.size()) {
+                printUsage(std::cerr);
+                return 2;
+            }
+            options.commandFile = fileFromArg(args[i]);
+            options.hasCommandFile = true;
+        } else if (args[i] == "--dump-json") {
+            options.dumpJson = true;
+        } else {
+            printUsage(std::cerr);
+            return 2;
+        }
+    }
+
+    return runCli(options);
+}
+
+int execCommands(const juce::StringArray& args) {
+    if (args.size() < 3) {
+        printUsage(std::cerr);
+        return 2;
+    }
+
+    RunOptions options;
+    options.input = fileFromArg(args[1]);
+    options.output = defaultOutputFor(options.input);
+
+    for (int i = 2; i < args.size(); ++i) {
+        if (args[i] == "--out") {
+            if (++i >= args.size()) {
+                printUsage(std::cerr);
+                return 2;
+            }
+            options.output = fileFromArg(args[i]);
+        } else if (args[i] == "--dump-json") {
+            options.dumpJson = true;
+        } else {
+            options.execTokens.add(args[i]);
+        }
+    }
+
+    if (options.execTokens.isEmpty() && !options.dumpJson) {
+        printUsage(std::cerr);
+        return 2;
+    }
+
+    return runCli(options);
 }
 
 int bootOnly() {
@@ -137,6 +517,8 @@ int main(int argc, char* argv[]) {
         return bootOnly();
     if (command == "run")
         return runRoundTrip(args);
+    if (command == "exec")
+        return execCommands(args);
 
     std::cerr << "Unknown command: " << command << "\n";
     printUsage(std::cerr);

--- a/magda/daw/engine/CMakeLists.txt
+++ b/magda/daw/engine/CMakeLists.txt
@@ -5,6 +5,7 @@
 target_sources(magda_daw PRIVATE
     TempoLaneBridge.cpp
     TempoLaneSync.cpp
+    OfflineRenderHelper.cpp
     TracktionEngineWrapper.cpp
     TracktionEngineWrapperInit.cpp
     TracktionEngineWrapperDevices.cpp
@@ -21,6 +22,7 @@ target_sources(magda_daw PRIVATE
     PluginWindowManager.cpp
     # Headers (listed for IDE visibility)
     AudioEngine.hpp
+    OfflineRenderHelper.hpp
     TracktionEngineWrapper.hpp
     MagdaUIBehaviour.hpp
 )

--- a/magda/daw/engine/OfflineRenderHelper.cpp
+++ b/magda/daw/engine/OfflineRenderHelper.cpp
@@ -1,0 +1,50 @@
+#include "OfflineRenderHelper.hpp"
+
+#include "../audio/AudioBridge.hpp"
+#include "TracktionEngineWrapper.hpp"
+
+namespace magda {
+
+void prepareEditForOfflineRender(tracktion::Edit& edit) {
+    auto& transport = edit.getTransport();
+    if (transport.isPlaying())
+        transport.stop(false, false);
+
+    tracktion::freePlaybackContextIfNotRecording(transport);
+
+    for (auto* track : tracktion::getAudioTracks(edit))
+        for (auto* plugin : track->pluginList)
+            if (!plugin->isEnabled())
+                plugin->setEnabled(true);
+}
+
+void preparePluginsForOfflineRender(TracktionEngineWrapper& engine) {
+    if (auto* bridge = engine.getAudioBridge())
+        bridge->getPluginManager().prepareForRendering();
+}
+
+void restorePluginsAfterOfflineRender(TracktionEngineWrapper& engine) {
+    if (auto* bridge = engine.getAudioBridge())
+        bridge->getPluginManager().restoreAfterRendering();
+}
+
+tracktion::Renderer::Parameters makeOfflineRenderParameters(
+    tracktion::Edit& edit, const OfflineRenderParametersOptions& options) {
+    tracktion::Renderer::Parameters params(edit);
+    params.destFile = options.destFile;
+    params.audioFormat = options.audioFormat;
+    params.bitDepth = options.bitDepth;
+    params.sampleRateForAudio = options.sampleRate;
+    params.blockSizeForAudio = options.blockSize;
+    params.shouldNormalise = options.shouldNormalise;
+    params.normaliseToLevelDb = options.normaliseToLevelDb;
+    params.useMasterPlugins = options.useMasterPlugins;
+    params.usePlugins = options.usePlugins;
+    params.checkNodesForAudio = options.checkNodesForAudio;
+    params.realTimeRender = options.realTimeRender;
+    if (options.time)
+        params.time = *options.time;
+    return params;
+}
+
+}  // namespace magda

--- a/magda/daw/engine/OfflineRenderHelper.hpp
+++ b/magda/daw/engine/OfflineRenderHelper.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <juce_audio_formats/juce_audio_formats.h>
+
+// clang-format off
+#include <tracktion_engine/tracktion_engine.h>
+// clang-format on
+
+#include <optional>
+
+namespace magda {
+
+class TracktionEngineWrapper;
+
+struct OfflineRenderParametersOptions {
+    juce::File destFile;
+    juce::AudioFormat* audioFormat = nullptr;
+    int bitDepth = 24;
+    double sampleRate = 44100.0;
+    int blockSize = 512;
+    bool shouldNormalise = false;
+    float normaliseToLevelDb = 0.0f;
+    bool useMasterPlugins = true;
+    bool usePlugins = true;
+    bool checkNodesForAudio = false;
+    bool realTimeRender = false;
+    std::optional<tracktion::TimeRange> time;
+};
+
+void prepareEditForOfflineRender(tracktion::Edit& edit);
+void preparePluginsForOfflineRender(TracktionEngineWrapper& engine);
+void restorePluginsAfterOfflineRender(TracktionEngineWrapper& engine);
+
+tracktion::Renderer::Parameters makeOfflineRenderParameters(
+    tracktion::Edit& edit, const OfflineRenderParametersOptions& options);
+
+}  // namespace magda

--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -59,6 +59,18 @@ class TracktionEngineWrapper : public AudioEngine,
     TracktionEngineWrapper();
     ~TracktionEngineWrapper();
 
+    /**
+     * @brief Force the wrapper to skip UI/timer-backed runtime helpers.
+     *
+     * Intended for console tools and e2e tests that boot the engine without a GUI.
+     * The MAGDA_HEADLESS environment variable provides the same behavior.
+     */
+    void setForceHeadless(bool forceHeadless) {
+        forceHeadless_ = forceHeadless;
+    }
+
+    bool isHeadlessRuntime() const;
+
     // Initialize the engine
     bool initialize() override;
     void shutdown() override;
@@ -553,6 +565,7 @@ class TracktionEngineWrapper : public AudioEngine,
     double lastPosition_ = 0.0;  // Previous frame's position (for loop detection)
     bool justStarted_ = false;   // True for one frame after play starts
     bool justLooped_ = false;    // True for one frame after loop
+    bool forceHeadless_ = false;
 
     // Device change tracking
     int lastKnownDeviceCount_ = 0;

--- a/magda/daw/engine/TracktionEngineWrapperInit.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperInit.cpp
@@ -1,3 +1,5 @@
+#include <cstdlib>
+
 #include "../api/magda_api_live.hpp"
 #include "../audio/AudioBridge.hpp"
 #include "../audio/MidiBridge.hpp"
@@ -29,6 +31,24 @@ TracktionEngineWrapper::~TracktionEngineWrapper() {
     shutdown();
 }
 
+bool TracktionEngineWrapper::isHeadlessRuntime() const {
+    if (forceHeadless_)
+        return true;
+
+    if (auto* value = std::getenv("MAGDA_HEADLESS")) {
+        juce::String flag(value);
+        flag = flag.trim().toLowerCase();
+        if (flag.isNotEmpty() && flag != "0" && flag != "false" && flag != "off" && flag != "no") {
+            return true;
+        }
+    }
+
+    auto osType = juce::SystemStats::getOperatingSystemType();
+    bool isMacOS = (osType & juce::SystemStats::MacOSX) != 0;
+    bool isWindows = (osType & juce::SystemStats::Windows) != 0;
+    return std::getenv("DISPLAY") == nullptr && !isMacOS && !isWindows;
+}
+
 void TracktionEngineWrapper::initializePluginFormats() {
     // Register ToneGeneratorPlugin (not registered by default)
     engine_->getPluginManager().createBuiltInType<tracktion::ToneGeneratorPlugin>();
@@ -54,7 +74,7 @@ void TracktionEngineWrapper::initializePluginFormats() {
 
     // Auto-detect newly installed plugins (if enabled). The splash screen
     // wants a flat string; format the phase here.
-    if (Config::getInstance().getScanPluginsOnStartup()) {
+    if (!isHeadlessRuntime() && Config::getInstance().getScanPluginsOnStartup()) {
         auto splashStatus = onPluginScanStatus;
         detectNewPlugins(
             [splashStatus](IncrementalScanPhase phase, const juce::String& currentPlugin) {
@@ -341,12 +361,7 @@ void TracktionEngineWrapper::createEditAndBridges() {
     // Create SessionClipScheduler and PluginWindowManager only when NOT in headless CI
     // Both extend juce::Timer which creates GUI infrastructure and leaks in tests
     // Check: Skip if DISPLAY env var not set (Linux headless) or if explicitly disabled
-    auto osType = juce::SystemStats::getOperatingSystemType();
-    bool isMacOS = (osType & juce::SystemStats::MacOSX) != 0;
-    bool isWindows = (osType & juce::SystemStats::Windows) != 0;
-    bool isHeadless = (std::getenv("DISPLAY") == nullptr && !isMacOS && !isWindows);
-
-    if (!isHeadless) {
+    if (!isHeadlessRuntime()) {
         sessionScheduler_ = std::make_unique<SessionClipScheduler>(
             *audioBridge_, *currentEdit_, audioBridge_->getSessionAudioMonitor());
         // Install the session monitor plugin up-front so the audio-thread
@@ -479,20 +494,24 @@ bool TracktionEngineWrapper::initialize() {
         initializePluginFormats();
         juce::Logger::writeToLog("[Init] initializePluginFormats() done");
 
-        // Initialize device manager with preferred settings
-        juce::Logger::writeToLog("[Init] initializeDeviceManager()...");
-        initializeDeviceManager();
-        juce::Logger::writeToLog("[Init] initializeDeviceManager() done");
+        if (!isHeadlessRuntime()) {
+            // Initialize device manager with preferred settings
+            juce::Logger::writeToLog("[Init] initializeDeviceManager()...");
+            initializeDeviceManager();
+            juce::Logger::writeToLog("[Init] initializeDeviceManager() done");
 
-        // Configure audio devices if user has preferences
-        juce::Logger::writeToLog("[Init] configureAudioDevices()...");
-        configureAudioDevices();
-        juce::Logger::writeToLog("[Init] configureAudioDevices() done");
+            // Configure audio devices if user has preferences
+            juce::Logger::writeToLog("[Init] configureAudioDevices()...");
+            configureAudioDevices();
+            juce::Logger::writeToLog("[Init] configureAudioDevices() done");
 
-        // Setup MIDI devices
-        juce::Logger::writeToLog("[Init] setupMidiDevices()...");
-        setupMidiDevices();
-        juce::Logger::writeToLog("[Init] setupMidiDevices() done");
+            // Setup MIDI devices
+            juce::Logger::writeToLog("[Init] setupMidiDevices()...");
+            setupMidiDevices();
+            juce::Logger::writeToLog("[Init] setupMidiDevices() done");
+        } else {
+            juce::Logger::writeToLog("[Init] Headless mode: skipping audio/MIDI device startup");
+        }
 
         // Create Edit and bridges
         juce::Logger::writeToLog("[Init] createEditAndBridges()...");

--- a/magda/daw/engine/TracktionEngineWrapperInit.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperInit.cpp
@@ -463,6 +463,7 @@ void TracktionEngineWrapper::createEditAndBridges() {
     // app-level Lua controller wiring.
     auto live = std::make_unique<MagdaApiLive>();
     live->setMidiBridge(midiBridge_.get());
+    live->setProjectTempoWriter([this](double bpm) { setTempo(bpm); });
     live->setEditAccessor([this]() -> tracktion::Edit* { return currentEdit_.get(); });
     magdaApi_ = std::move(live);
 

--- a/magda/daw/engine/TracktionEngineWrapperInit.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperInit.cpp
@@ -43,10 +43,7 @@ bool TracktionEngineWrapper::isHeadlessRuntime() const {
         }
     }
 
-    auto osType = juce::SystemStats::getOperatingSystemType();
-    bool isMacOS = (osType & juce::SystemStats::MacOSX) != 0;
-    bool isWindows = (osType & juce::SystemStats::Windows) != 0;
-    return std::getenv("DISPLAY") == nullptr && !isMacOS && !isWindows;
+    return false;
 }
 
 void TracktionEngineWrapper::initializePluginFormats() {

--- a/magda/daw/ui/windows/MainWindowExport.cpp
+++ b/magda/daw/ui/windows/MainWindowExport.cpp
@@ -9,6 +9,7 @@
 #include "core/StringTable.hpp"
 #include "core/TechnicalText.hpp"
 #include "core/TrackManager.hpp"
+#include "engine/OfflineRenderHelper.hpp"
 #include "engine/TracktionEngineWrapper.hpp"
 #include "project/ProjectManager.hpp"
 
@@ -275,146 +276,117 @@ void MainWindow::performExport(const ExportAudioDialog::Settings& settings,
     auto flags = juce::FileBrowserComponent::saveMode | juce::FileBrowserComponent::canSelectFiles |
                  juce::FileBrowserComponent::warnAboutOverwriting;
 
-    fileChooser_->launchAsync(
-        flags, [this, settings, engine, edit, extension](const juce::FileChooser& chooser) {
-            auto file = chooser.getResult();
-            if (file == juce::File()) {
-                fileChooser_.reset();
-                return;
-            }
-
-            // Ensure correct extension
-            if (!file.hasFileExtension(extension)) {
-                file = file.withFileExtension(extension);
-            }
-
-            // CRITICAL: Stop transport AND free playback context before offline rendering
-            // Tracktion Engine asserts that play context is not active during export
-            // (assertion in tracktion_NodeRenderContext.cpp:182)
-            auto& transport = edit->getTransport();
-            if (transport.isPlaying()) {
-                transport.stop(false, false);  // Stop immediately without fading
-            }
-
-            te::TransportControl::ReallocationInhibitor setupInhibitor(transport);
-
-            te::freePlaybackContextIfNotRecording(transport);
-
-            // Enable all plugins for offline rendering
-            // When transport stops, AudioBridge bypasses generator plugins (like test tone)
-            // but we need them enabled for export to work properly
-            for (auto track : te::getAudioTracks(*edit)) {
-                for (auto plugin : track->pluginList) {
-                    if (!plugin->isEnabled()) {
-                        plugin->setEnabled(true);
-                    }
-                }
-            }
-
-            // Create Renderer::Parameters
-            te::Renderer::Parameters params(*edit);
-            params.destFile = file;
-
-            // The chord track is monitor-only: exclude it from the bounce so its
-            // notes never reach the master render. tracksToDo lists every track
-            // index to render (empty = all), so we set all but the chord track.
-            if (auto chordId = magda::TrackManager::getInstance().getChordTrackId();
-                chordId != magda::INVALID_TRACK_ID) {
-                if (auto* bridge = engine->getAudioBridge()) {
-                    if (auto* chordTe = bridge->getAudioTrack(chordId)) {
-                        auto allTracks = te::getAllTracks(*edit);
-                        juce::BigInteger tracksToDo;
-                        for (int i = 0; i < allTracks.size(); ++i)
-                            if (allTracks[i] != chordTe)
-                                tracksToDo.setBit(i);
-                        params.tracksToDo = tracksToDo;
-                    }
-                }
-            }
-
-            // Set audio format
-            auto& formatManager = engine->getEngine()->getAudioFileFormatManager();
-            if (settings.format.startsWith("WAV")) {
-                params.audioFormat = formatManager.getWavFormat();
-            } else if (settings.format == "FLAC") {
-                params.audioFormat = formatManager.getFlacFormat();
-            } else {
-                params.audioFormat = formatManager.getWavFormat();  // Default
-            }
-
-            params.bitDepth = getBitDepthForFormat(settings.format);
-            params.sampleRateForAudio = settings.sampleRate;
-            params.shouldNormalise = settings.normalize;
-            params.normaliseToLevelDb = 0.0f;
-            params.useMasterPlugins = true;
-            params.usePlugins = true;
-
-            // Allow export even when there are no clips (generator devices can still produce audio)
-            params.checkNodesForAudio = false;
-
-            // Match live playback block size so LFO phase reset timing
-            // (which has a one-block delay via pendingNoteOnResync_) behaves
-            // identically to live playback.
-            params.blockSizeForAudio = 512;
-            params.realTimeRender = settings.realTimeRender;
-
-            // Set time range based on export range setting
-            te::TimeRange requestedRange;
-            using ExportRange = ExportAudioDialog::ExportRange;
-            switch (settings.exportRange) {
-                case ExportRange::TimeSelection:
-                    // TODO: Get actual time selection from SelectionManager when implemented
-                    requestedRange = te::TimeRange(te::TimePosition::fromSeconds(0.0),
-                                                   te::TimePosition() + edit->getLength());
-                    break;
-
-                case ExportRange::LoopRegion:
-                    requestedRange = edit->getTransport().getLoopRange();
-                    break;
-
-                case ExportRange::EntireSong:
-                default:
-                    requestedRange = te::TimeRange(te::TimePosition::fromSeconds(0.0),
-                                                   te::TimePosition() + edit->getLength());
-                    break;
-            }
-
-            // Add preroll for offline renders to let plugins settle.
-            // Even with the default 512 block size, some plugins need extra
-            // warmup time. The preroll is rendered then trimmed off.
-            constexpr double prerollSeconds = 2.0;
-            double actualPreroll = 0.0;
-            if (!settings.realTimeRender) {
-                actualPreroll = prerollSeconds;
-                params.time = te::TimeRange(requestedRange.getStart() -
-                                                te::TimeDuration::fromSeconds(actualPreroll),
-                                            requestedRange.getEnd());
-            } else {
-                params.time = requestedRange;
-            }
-
-            // Enable MIDI-triggered LFO modulation for offline rendering.
-            // During live playback, the message-thread timer gates these LFOs
-            // based on held notes, but it can't keep up with non-real-time rendering.
-            auto* audioBridge = engine->getAudioBridge();
-            if (audioBridge)
-                audioBridge->getPluginManager().prepareForRendering();
-
-            // Launch progress window with background rendering (non-blocking)
-            // The window will delete itself via threadComplete() callback.
-            // ExportProgressWindow holds a ReallocationInhibitor to prevent
-            // edit.restartPlayback() from recreating the playback context during render.
-            auto* progressWindow = new ExportProgressWindow(
-                params, file, transport,
-                [audioBridge]() {
-                    if (audioBridge)
-                        audioBridge->getPluginManager().restoreAfterRendering();
-                },
-                actualPreroll, settings.leadInSilence);
-            progressWindow->launchThread();
-
+    fileChooser_->launchAsync(flags, [this, settings, engine, edit,
+                                      extension](const juce::FileChooser& chooser) {
+        auto file = chooser.getResult();
+        if (file == juce::File()) {
             fileChooser_.reset();
-        });
+            return;
+        }
+
+        // Ensure correct extension
+        if (!file.hasFileExtension(extension)) {
+            file = file.withFileExtension(extension);
+        }
+
+        auto& transport = edit->getTransport();
+        te::TransportControl::ReallocationInhibitor setupInhibitor(transport);
+        prepareEditForOfflineRender(*edit);
+
+        auto& formatManager = engine->getEngine()->getAudioFileFormatManager();
+        juce::AudioFormat* audioFormat = formatManager.getWavFormat();
+        if (settings.format.startsWith("WAV")) {
+            audioFormat = formatManager.getWavFormat();
+        } else if (settings.format == "FLAC") {
+            audioFormat = formatManager.getFlacFormat();
+        }
+
+        auto params =
+            makeOfflineRenderParameters(*edit, {.destFile = file,
+                                                .audioFormat = audioFormat,
+                                                .bitDepth = getBitDepthForFormat(settings.format),
+                                                .sampleRate = settings.sampleRate,
+                                                .blockSize = 512,
+                                                .shouldNormalise = settings.normalize,
+                                                .normaliseToLevelDb = 0.0f,
+                                                .useMasterPlugins = true,
+                                                .usePlugins = true,
+                                                .checkNodesForAudio = false,
+                                                .realTimeRender = settings.realTimeRender});
+
+        // The chord track is monitor-only: exclude it from the bounce so its
+        // notes never reach the master render. tracksToDo lists every track
+        // index to render (empty = all), so we set all but the chord track.
+        if (auto chordId = magda::TrackManager::getInstance().getChordTrackId();
+            chordId != magda::INVALID_TRACK_ID) {
+            if (auto* bridge = engine->getAudioBridge()) {
+                if (auto* chordTe = bridge->getAudioTrack(chordId)) {
+                    auto allTracks = te::getAllTracks(*edit);
+                    juce::BigInteger tracksToDo;
+                    for (int i = 0; i < allTracks.size(); ++i)
+                        if (allTracks[i] != chordTe)
+                            tracksToDo.setBit(i);
+                    params.tracksToDo = tracksToDo;
+                }
+            }
+        }
+
+        // Set time range based on export range setting
+        te::TimeRange requestedRange;
+        using ExportRange = ExportAudioDialog::ExportRange;
+        switch (settings.exportRange) {
+            case ExportRange::TimeSelection:
+                // TODO: Get actual time selection from SelectionManager when implemented
+                requestedRange = te::TimeRange(te::TimePosition::fromSeconds(0.0),
+                                               te::TimePosition() + edit->getLength());
+                break;
+
+            case ExportRange::LoopRegion:
+                requestedRange = edit->getTransport().getLoopRange();
+                break;
+
+            case ExportRange::EntireSong:
+            default:
+                requestedRange = te::TimeRange(te::TimePosition::fromSeconds(0.0),
+                                               te::TimePosition() + edit->getLength());
+                break;
+        }
+
+        // Add preroll for offline renders to let plugins settle.
+        // Even with the default 512 block size, some plugins need extra
+        // warmup time. The preroll is rendered then trimmed off.
+        constexpr double prerollSeconds = 2.0;
+        double actualPreroll = 0.0;
+        if (!settings.realTimeRender) {
+            actualPreroll = prerollSeconds;
+            params.time = te::TimeRange(requestedRange.getStart() -
+                                            te::TimeDuration::fromSeconds(actualPreroll),
+                                        requestedRange.getEnd());
+        } else {
+            params.time = requestedRange;
+        }
+
+        // Enable MIDI-triggered LFO modulation for offline rendering.
+        // During live playback, the message-thread timer gates these LFOs
+        // based on held notes, but it can't keep up with non-real-time rendering.
+        auto* audioBridge = engine->getAudioBridge();
+        preparePluginsForOfflineRender(*engine);
+
+        // Launch progress window with background rendering (non-blocking)
+        // The window will delete itself via threadComplete() callback.
+        // ExportProgressWindow holds a ReallocationInhibitor to prevent
+        // edit.restartPlayback() from recreating the playback context during render.
+        auto* progressWindow = new ExportProgressWindow(
+            params, file, transport,
+            [audioBridge]() {
+                if (audioBridge)
+                    audioBridge->getPluginManager().restoreAfterRendering();
+            },
+            actualPreroll, settings.leadInSilence);
+        progressWindow->launchThread();
+
+        fileChooser_.reset();
+    });
 }
 
 juce::String MainWindow::getFileExtensionForFormat(const juce::String& format) const {

--- a/magda/scripting/MagdaApiLuaBindings.cpp
+++ b/magda/scripting/MagdaApiLuaBindings.cpp
@@ -26,6 +26,7 @@ extern "C" {
 #include <lua.h>
 }
 
+#include <optional>
 #include <unordered_set>
 #include <vector>
 
@@ -177,6 +178,28 @@ template <typename T> std::unordered_set<T> readIntSet(lua_State* L, int idx) {
             luaL_error(L, "expected integer at index %d", static_cast<int>(i));
         }
         out.insert(static_cast<T>(lua_tointeger(L, -1)));
+        lua_pop(L, 1);
+    }
+    return out;
+}
+
+std::vector<size_t> readSizeVector(lua_State* L, int idx) {
+    luaL_checktype(L, idx, LUA_TTABLE);
+    std::vector<size_t> out;
+    lua_Integer n = luaL_len(L, idx);
+    out.reserve(static_cast<size_t>(n));
+    for (lua_Integer i = 1; i <= n; ++i) {
+        lua_rawgeti(L, idx, i);
+        if (!lua_isinteger(L, -1)) {
+            lua_pop(L, 1);
+            luaL_error(L, "expected integer at index %d", static_cast<int>(i));
+        }
+        auto value = lua_tointeger(L, -1);
+        if (value < 0) {
+            lua_pop(L, 1);
+            luaL_error(L, "expected non-negative integer at index %d", static_cast<int>(i));
+        }
+        out.push_back(static_cast<size_t>(value));
         lua_pop(L, 1);
     }
     return out;
@@ -435,6 +458,57 @@ int lua_clips_set_groove(lua_State* L) {
     const char* tmpl = luaL_checkstring(L, 2);
     api->clips().setGrooveTemplate(id, juce::String::fromUTF8(tmpl));
     return 0;
+}
+
+int lua_clips_add_midi_note(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<ClipId>(luaL_checkinteger(L, 1));
+    double start = luaL_checknumber(L, 2);
+    int note = static_cast<int>(luaL_checkinteger(L, 3));
+    double length = luaL_checknumber(L, 4);
+    int velocity = static_cast<int>(luaL_optinteger(L, 5, 100));
+    lua_pushboolean(L, api->clips().addMidiNote(id, start, note, length, velocity));
+    return 1;
+}
+
+std::optional<MidiNoteQuantizeMode> luaQuantizeMode(lua_State* L, int idx) {
+    auto mode = juce::String::fromUTF8(luaL_checkstring(L, idx)).trim().toLowerCase();
+    if (mode == "start")
+        return MidiNoteQuantizeMode::StartOnly;
+    if (mode == "length")
+        return MidiNoteQuantizeMode::LengthOnly;
+    if (mode == "both" || mode == "start_and_length" || mode == "start-and-length")
+        return MidiNoteQuantizeMode::StartAndLength;
+    return std::nullopt;
+}
+
+int lua_clips_quantize_notes(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<ClipId>(luaL_checkinteger(L, 1));
+    double grid = luaL_checknumber(L, 2);
+    auto mode = luaQuantizeMode(L, 3);
+    if (!mode)
+        return luaL_error(L, "quantize mode must be start, length, or both");
+    auto indices = readSizeVector(L, 4);
+    lua_pushboolean(L, api->clips().quantizeMidiNotes(id, indices, grid, *mode));
+    return 1;
+}
+
+int lua_clips_slice_notes(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<ClipId>(luaL_checkinteger(L, 1));
+    int subdivisions = static_cast<int>(luaL_checkinteger(L, 2));
+    auto indices = readSizeVector(L, 3);
+    lua_pushboolean(L, api->clips().sliceMidiNotes(id, indices, subdivisions));
+    return 1;
+}
+
+int lua_clips_transpose_midi_clip(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<ClipId>(luaL_checkinteger(L, 1));
+    int semitones = static_cast<int>(luaL_checkinteger(L, 2));
+    lua_pushboolean(L, api->clips().transposeMidiClip(id, semitones));
+    return 1;
 }
 
 // magda.clips.colour(clipId) -> {r=, g=, b=} with each component already
@@ -863,6 +937,10 @@ const FnReg kClipFns[] = {
     {"list_arrangement", lua_clips_list_arrangement},
     {"set_name", lua_clips_set_name},
     {"set_groove", lua_clips_set_groove},
+    {"add_midi_note", lua_clips_add_midi_note},
+    {"quantize_notes", lua_clips_quantize_notes},
+    {"slice_notes", lua_clips_slice_notes},
+    {"transpose_midi_clip", lua_clips_transpose_midi_clip},
     {"colour", lua_clips_colour},
     {nullptr, nullptr},
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -183,6 +183,14 @@ target_compile_definitions(magda_tests
 # Add the test to CTest
 add_test(NAME magda_unit_tests COMMAND magda_tests)
 
+add_test(
+    NAME magda_cli_headless_e2e
+    COMMAND ${CMAKE_COMMAND}
+        -DMAGDA_CLI=$<TARGET_FILE:magda_cli>
+        -DMAGDA_CLI_WORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/magda_cli_headless_e2e
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/magda_cli_headless_e2e.cmake
+)
+
 # For Catch2 test discovery (optional - automatically discovers individual test cases)
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.10")
     include(Catch)

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -12,6 +12,7 @@
 #include <juce_core/juce_core.h>
 
 #include <cassert>
+#include <cmath>
 #include <cstdlib>
 #include <map>
 #include <unordered_map>
@@ -300,6 +301,24 @@ class MockClipApi : public ClipApi {
     std::vector<ClipId> deleted;
     std::vector<std::pair<ClipId, juce::String>> nameWrites;
     std::vector<std::pair<ClipId, juce::String>> grooveWrites;
+    std::vector<std::pair<ClipId, MidiNote>> noteAdds;
+
+    struct QuantizeCall {
+        ClipId clipId;
+        std::vector<size_t> noteIndices;
+        double gridResolution;
+        MidiNoteQuantizeMode mode;
+    };
+    std::vector<QuantizeCall> quantizeCalls;
+
+    struct SliceCall {
+        ClipId clipId;
+        std::vector<size_t> noteIndices;
+        int subdivisions;
+    };
+    std::vector<SliceCall> sliceCalls;
+
+    std::vector<std::pair<ClipId, int>> transposeCalls;
 
     ClipId nextId = 100;
 
@@ -327,6 +346,81 @@ class MockClipApi : public ClipApi {
     }
     void setGrooveTemplate(ClipId id, const juce::String& tmpl) override {
         grooveWrites.push_back({id, tmpl});
+    }
+    bool addMidiNote(ClipId id, double startBeat, int noteNumber, double lengthBeats,
+                     int velocity) override {
+        auto* clip = getClip(id);
+        if (clip == nullptr || !clip->isMidi() || lengthBeats <= 0.0)
+            return false;
+
+        MidiNote note;
+        note.startBeat = startBeat;
+        note.noteNumber = noteNumber;
+        note.lengthBeats = lengthBeats;
+        note.velocity = velocity;
+        noteAdds.push_back({id, note});
+        clip->midiNotes.push_back(note);
+        return true;
+    }
+    bool quantizeMidiNotes(ClipId id, const std::vector<size_t>& noteIndices, double gridResolution,
+                           MidiNoteQuantizeMode mode) override {
+        auto* clip = getClip(id);
+        if (clip == nullptr || !clip->isMidi() || noteIndices.empty() || gridResolution <= 0.0)
+            return false;
+
+        quantizeCalls.push_back({id, noteIndices, gridResolution, mode});
+        for (auto index : noteIndices) {
+            if (index >= clip->midiNotes.size())
+                continue;
+
+            auto& note = clip->midiNotes[index];
+            if (mode == MidiNoteQuantizeMode::StartOnly ||
+                mode == MidiNoteQuantizeMode::StartAndLength)
+                note.startBeat = std::round(note.startBeat / gridResolution) * gridResolution;
+            if (mode == MidiNoteQuantizeMode::LengthOnly ||
+                mode == MidiNoteQuantizeMode::StartAndLength)
+                note.lengthBeats = std::max(
+                    gridResolution, std::round(note.lengthBeats / gridResolution) * gridResolution);
+        }
+        return true;
+    }
+    bool sliceMidiNotes(ClipId id, const std::vector<size_t>& noteIndices,
+                        int subdivisions) override {
+        auto* clip = getClip(id);
+        if (clip == nullptr || !clip->isMidi() || noteIndices.empty() || subdivisions < 2)
+            return false;
+
+        sliceCalls.push_back({id, noteIndices, subdivisions});
+        auto original = clip->midiNotes;
+        std::vector<MidiNote> sliced;
+        for (size_t index = 0; index < original.size(); ++index) {
+            const bool shouldSlice =
+                std::find(noteIndices.begin(), noteIndices.end(), index) != noteIndices.end();
+            if (!shouldSlice || original[index].lengthBeats <= 0.0) {
+                sliced.push_back(original[index]);
+                continue;
+            }
+
+            const double sliceLength = original[index].lengthBeats / subdivisions;
+            for (int slice = 0; slice < subdivisions; ++slice) {
+                auto note = original[index];
+                note.startBeat += sliceLength * slice;
+                note.lengthBeats = sliceLength;
+                sliced.push_back(note);
+            }
+        }
+        clip->midiNotes = std::move(sliced);
+        return true;
+    }
+    bool transposeMidiClip(ClipId id, int semitones) override {
+        auto* clip = getClip(id);
+        if (clip == nullptr || !clip->isMidi())
+            return false;
+
+        transposeCalls.push_back({id, semitones});
+        for (auto& note : clip->midiNotes)
+            note.noteNumber += semitones;
+        return true;
     }
     const juce::Array<double>* getCachedTransients(const juce::String&) const override {
         return nullptr;

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -477,6 +477,9 @@ class MockProjectApi : public ProjectApi {
     const ProjectInfo& getCurrentProjectInfo() const override {
         return info;
     }
+    void setTempo(double bpm) override {
+        info.tempo = bpm;
+    }
 };
 
 class MockFocusedApi : public FocusedApi {

--- a/tests/magda_cli_headless_e2e.cmake
+++ b/tests/magda_cli_headless_e2e.cmake
@@ -1,0 +1,81 @@
+if(NOT DEFINED MAGDA_CLI)
+    message(FATAL_ERROR "MAGDA_CLI is required")
+endif()
+
+if(NOT DEFINED MAGDA_CLI_WORK_DIR)
+    message(FATAL_ERROR "MAGDA_CLI_WORK_DIR is required")
+endif()
+
+file(REMOVE_RECURSE "${MAGDA_CLI_WORK_DIR}")
+file(MAKE_DIRECTORY "${MAGDA_CLI_WORK_DIR}")
+
+set(project_request "${MAGDA_CLI_WORK_DIR}/headless_fixture.mgd")
+set(project_file "${MAGDA_CLI_WORK_DIR}/headless_fixture/headless_fixture.mgd")
+set(mutated_request "${MAGDA_CLI_WORK_DIR}/headless_fixture_mutated.mgd")
+set(mutated_file "${MAGDA_CLI_WORK_DIR}/headless_fixture_mutated/headless_fixture_mutated.mgd")
+set(json_file "${MAGDA_CLI_WORK_DIR}/state.json")
+set(wav_file "${MAGDA_CLI_WORK_DIR}/render.wav")
+
+execute_process(
+    COMMAND "${MAGDA_CLI}" init "${project_request}"
+    RESULT_VARIABLE init_result
+    OUTPUT_VARIABLE init_stdout
+    ERROR_VARIABLE init_stderr
+)
+if(NOT init_result EQUAL 0)
+    message(FATAL_ERROR "magda-cli init failed: ${init_stderr}\n${init_stdout}")
+endif()
+if(NOT EXISTS "${project_file}")
+    message(FATAL_ERROR "magda-cli init did not create ${project_file}")
+endif()
+
+execute_process(
+    COMMAND "${MAGDA_CLI}" exec "${project_file}"
+            set-tempo 96
+            add-track audio Lead
+            add-midi-clip 1 0 4
+            dump --json
+            --out "${mutated_request}"
+    RESULT_VARIABLE exec_result
+    OUTPUT_VARIABLE exec_stdout
+    ERROR_VARIABLE exec_stderr
+)
+if(NOT exec_result EQUAL 0)
+    message(FATAL_ERROR "magda-cli exec failed: ${exec_stderr}\n${exec_stdout}")
+endif()
+if(NOT EXISTS "${mutated_file}")
+    message(FATAL_ERROR "magda-cli exec did not create ${mutated_file}")
+endif()
+
+string(FIND "${exec_stdout}" "\"tempo\": 96" tempo_pos)
+string(FIND "${exec_stdout}" "\"name\": \"Lead\"" track_pos)
+string(FIND "${exec_stdout}" "\"lengthBeats\": 4" clip_pos)
+if(tempo_pos EQUAL -1 OR track_pos EQUAL -1 OR clip_pos EQUAL -1)
+    file(WRITE "${json_file}" "${exec_stdout}")
+    message(FATAL_ERROR "magda-cli JSON state did not match expected markers; wrote ${json_file}")
+endif()
+
+execute_process(
+    COMMAND "${MAGDA_CLI}" render "${mutated_file}" --wav "${wav_file}" --from 0 --to 1bar
+    RESULT_VARIABLE render_result
+    OUTPUT_VARIABLE render_stdout
+    ERROR_VARIABLE render_stderr
+)
+if(NOT render_result EQUAL 0)
+    message(FATAL_ERROR "magda-cli render failed: ${render_stderr}\n${render_stdout}")
+endif()
+if(NOT EXISTS "${wav_file}")
+    message(FATAL_ERROR "magda-cli render did not create ${wav_file}")
+endif()
+
+file(SIZE "${wav_file}" wav_size)
+if(wav_size LESS 44)
+    message(FATAL_ERROR "Rendered WAV is too small: ${wav_size} bytes")
+endif()
+
+file(READ "${wav_file}" wav_header_hex HEX LIMIT 12)
+string(SUBSTRING "${wav_header_hex}" 0 8 riff)
+string(SUBSTRING "${wav_header_hex}" 16 8 wave)
+if(NOT riff STREQUAL "52494646" OR NOT wave STREQUAL "57415645")
+    message(FATAL_ERROR "Rendered output does not have a RIFF/WAVE header")
+endif()

--- a/tests/magda_cli_headless_e2e.cmake
+++ b/tests/magda_cli_headless_e2e.cmake
@@ -34,6 +34,10 @@ execute_process(
             set-tempo 96
             add-track audio Lead
             add-midi-clip 1 0 4
+            add-midi-note 1 0.13 60 1.87 111
+            quantize-notes 1 0.25 both all
+            slice-notes 1 2 all
+            transpose-midi-clip 1 12
             dump --json
             --out "${mutated_request}"
     RESULT_VARIABLE exec_result
@@ -50,7 +54,11 @@ endif()
 string(FIND "${exec_stdout}" "\"tempo\": 96" tempo_pos)
 string(FIND "${exec_stdout}" "\"name\": \"Lead\"" track_pos)
 string(FIND "${exec_stdout}" "\"lengthBeats\": 4" clip_pos)
-if(tempo_pos EQUAL -1 OR track_pos EQUAL -1 OR clip_pos EQUAL -1)
+string(FIND "${exec_stdout}" "\"note\": 72" note_pos)
+string(FIND "${exec_stdout}" "\"velocity\": 111" velocity_pos)
+string(FIND "${exec_stdout}" "\"lengthBeats\": 0.875" sliced_length_pos)
+if(tempo_pos EQUAL -1 OR track_pos EQUAL -1 OR clip_pos EQUAL -1 OR note_pos EQUAL -1
+   OR velocity_pos EQUAL -1 OR sliced_length_pos EQUAL -1)
     file(WRITE "${json_file}" "${exec_stdout}")
     message(FATAL_ERROR "magda-cli JSON state did not match expected markers; wrote ${json_file}")
 endif()

--- a/tests/magda_cli_headless_e2e.cmake
+++ b/tests/magda_cli_headless_e2e.cmake
@@ -33,6 +33,7 @@ execute_process(
     COMMAND "${MAGDA_CLI}" exec "${project_file}"
             set-tempo 96
             add-track audio Lead
+            add-internal-instrument 1 4osc 4OSC
             add-midi-clip 1 0 4
             add-midi-note 1 0.13 60 1.87 111
             quantize-notes 1 0.25 both all
@@ -77,7 +78,7 @@ if(NOT EXISTS "${wav_file}")
 endif()
 
 file(SIZE "${wav_file}" wav_size)
-if(wav_size LESS 44)
+if(wav_size LESS 100000)
     message(FATAL_ERROR "Rendered WAV is too small: ${wav_size} bytes")
 endif()
 


### PR DESCRIPTION
## Summary

Implements the headless magda-cli epic from #1643 across P0-P3:

- Adds a headless CLI bootstrap target and engine initialization path.
- Adds project command dispatch for headless project mutation and JSON state dumps.
- Adds offline WAV rendering and a CTest headless e2e covering init, mutation, dump, save, and render.
- Exposes MIDI note verbs through MagdaApi, delegates to existing undoable command implementations, and wires the verbs through CLI and Lua bindings.

## Validation

- cmake -S . -B build-cli -DMAGDA_BUILD_TESTS=OFF -DMAGDA_HAVE_CLAP=OFF -DMAGDA_BUILD_EXAMPLES=OFF
- cmake --build build-cli --target magda_cli -j 8
- magda_cli boot
- cmake -S . -B build-cli-p2 -DMAGDA_BUILD_TESTS=ON -DMAGDA_HAVE_CLAP=OFF -DMAGDA_BUILD_EXAMPLES=OFF
- cmake --build build-cli-p2 --target magda_cli -j 8
- ctest --test-dir build-cli-p2 -R magda_cli_headless_e2e --output-on-failure
- cmake -S . -B build-cli-p3 -DMAGDA_BUILD_TESTS=ON -DMAGDA_HAVE_CLAP=OFF -DMAGDA_BUILD_EXAMPLES=OFF
- cmake --build build-cli-p3 --target magda_cli -j 8
- cmake --build build-cli-p3 --target magda_scripting -j 8
- ctest --test-dir build-cli-p3 -R magda_cli_headless_e2e --output-on-failure

Draft until CI confirms the new branch state.