### PR TITLE
Add Windows code signing via Certum cloud cert (SimplySign)

### DIFF
--- a/.claude/skills/windows-signing/SKILL.md
+++ b/.claude/skills/windows-signing/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: windows-signing
+description: Code-sign the MAGDA Windows installer with the Certum cloud certificate (SimplySign). Use when releasing on Windows, when the signing job in release.yml needs attention, or when troubleshooting "cert not found" / SmartScreen warnings.
+user_invocable: true
+---
+
+# Windows Code Signing
+
+MAGDA's Windows installer is signed with **Authenticode** using the Certum
+**"Open Source Developer Luca Romagnoli"** certificate (OV class) held in the
+cloud via **SimplySign**. There is no Windows "notarization" — that's an Apple
+concept; on Windows you sign the binary and embed a trusted timestamp.
+
+Because it's OV (not EV), SmartScreen trust builds up gradually as downloads
+accumulate; it is not instantly clean on day one. Nothing to configure for that.
+
+## Key facts
+
+| | |
+| --- | --- |
+| Cert thumbprint | `715B3557D43AF8FC23297999C0541C07E1B61319` |
+| Issuer | Certum Code Signing 2021 CA |
+| Expires | 2027-06-29 |
+| Timestamp server | `http://time.certum.pl` (mandatory) |
+| signtool | `C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe` |
+| Signing script | `packaging/windows/sign-release.ps1` |
+
+The timestamp keeps signatures valid after the cert expires, so re-signing old
+builds is never needed.
+
+## Toolchain (one-time setup)
+
+You need exactly two SimplySign pieces — **not** SafeSign (that's for physical
+USB cards):
+
+1. **SimplySign Mobile** (phone) — activate once via the "Regaining Access to
+   the SimplySign Service" email: open its link, enter the activation/secret
+   code on the web page, then scan the resulting QR with the app's *QR code*
+   activation. After that the app shows a **Token ID + rolling 6-digit OTP**.
+   Use **"Generate token only"**, not "Sign and generate token".
+2. **SimplySign Desktop** (the signing machine) — install with only
+   "SimplySign Desktop" ticked (uncheck "proCertum SmartSign"). Log in with the
+   email + Token ID/OTP from the phone. This exposes the cloud cert as a virtual
+   smart card; it then appears in `Cert:\CurrentUser\My`.
+
+Confirm the cert is reachable:
+
+```powershell
+Get-ChildItem Cert:\CurrentUser\My | Where-Object Thumbprint -eq '715B3557D43AF8FC23297999C0541C07E1B61319' |
+  Format-List Subject, NotAfter, @{N='HasPrivateKey';E={$_.HasPrivateKey}}
+```
+
+`HasPrivateKey : True` means signing will work.
+
+## The hard constraint
+
+SimplySign requires an **interactive OTP** from the phone each session, so
+signing **cannot** run on a GitHub-hosted runner or as a background service —
+it must run inside the logged-in desktop session where SimplySign Desktop holds
+the cert. One OTP login covers many signs for the session.
+
+## Releasing (the CI path)
+
+`release.yml` has a `sign-windows` job (tag pushes only) on the self-hosted
+runner `[self-hosted, Windows, magda-luca]`. It downloads the unsigned build
+artifact, provisions NSIS, unpacks the MuseHub source bundle, and runs
+`sign-release.ps1 -WaitMinutes 30`, then publishes the signed installer via
+`create-release`.
+
+Per-release steps:
+
+1. Make sure the runner is running **interactively in your logged-in session**
+   (not the `NT AUTHORITY\NETWORK SERVICE` service — that session can't see the
+   cert). Either run `run.cmd` from the runner folder or have it auto-start at
+   logon.
+2. Cut the release tag (see the [release](../release/SKILL.md) skill).
+3. When the `sign-windows` job prints "Waiting for SimplySign login…", open
+   SimplySign Desktop and enter the OTP from your phone. The job proceeds the
+   instant the cert appears (within the 30-minute window). Order doesn't matter
+   — you can log in before or after pushing the tag.
+
+## Signing manually (no CI)
+
+On a machine logged into SimplySign Desktop, point the script at a staging dir
+that holds `MAGDA.exe`, `magda_plugin_scanner.exe` and `magda-installer.nsi`
+(an extracted `MAGDA-<version>-MuseHub-Source.zip`, or a local build's installer
+staging dir):
+
+```powershell
+packaging\windows\sign-release.ps1 -StageDir <dir> -Version <x.y.z> -Makensis <path-to-makensis.exe>
+```
+
+It signs both exes, rebuilds the installer (makensis runs with the working
+directory set to the stage so `OutFile` lands there), signs it, verifies the
+chain, and writes `MAGDA-<version>-Windows-x86_64-Setup.exe` + `.sha256`.
+
+To sign a single file directly:
+
+```powershell
+signtool sign /sha1 715B3557D43AF8FC23297999C0541C07E1B61319 /fd sha256 /tr http://time.certum.pl /td sha256 /v <file>
+signtool verify /pa /v <file>
+```
+
+The ONNX Runtime and libxml2 DLLs are vendor-signed already — only sign the two
+MAGDA exes and the installer.
+
+## Troubleshooting
+
+- **"Signing cert … not found"** — SimplySign Desktop isn't logged in, or the
+  job is running in a non-interactive session (the NETWORK SERVICE service).
+  Log in / run the runner in-session.
+- **The OTP can't be automated** — it's the deliberate MFA floor for this cert
+  class. Full unattended signing would need an EV/HSM service (Azure Trusted
+  Signing, SignPath), not this Certum cloud cert.
+- **The cert expired (after 2027-06-29)** — already-shipped builds stay valid
+  because they're timestamped; reissue/renew the cert in the Certum panel and
+  update the thumbprint here and in `sign-release.ps1`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,16 +441,40 @@ jobs:
       with:
         arch: x64
 
-    - name: Setup pinned vcpkg
+    # vcpkg + its binary cache. On the self-hosted runner both persist on the
+    # machine across runs: a fixed clone we re-checkout (not re-clone), and a
+    # fixed binary cache dir, so libxml2 is restored from cache instead of being
+    # recompiled (that ~10 min build only happens on the very first run / after a
+    # pin bump). On GitHub-hosted runners the VM is ephemeral, so clone into
+    # RUNNER_TEMP and let actions/cache carry the binary cache between runs.
+    - name: Setup vcpkg
       shell: powershell
       run: |
-        $vcpkgRoot = Join-Path $env:RUNNER_TEMP "vcpkg"
-        git clone https://github.com/microsoft/vcpkg.git $vcpkgRoot
+        if ($env:RUNNER_ENVIRONMENT -eq 'self-hosted') {
+          $vcpkgRoot = 'C:\vcpkg-ci'
+          $binCache  = 'C:\vcpkg-bincache'
+        } else {
+          $vcpkgRoot = Join-Path $env:RUNNER_TEMP 'vcpkg'
+          $binCache  = Join-Path $env:GITHUB_WORKSPACE '.vcpkg-binary-cache'
+        }
+        if (-not (Test-Path "$vcpkgRoot\.git")) {
+          git clone https://github.com/microsoft/vcpkg.git $vcpkgRoot
+        }
+        # Fetch only when the pinned commit isn't already present (i.e. a pin bump).
+        git -C $vcpkgRoot cat-file -e "$($env:VCPKG_COMMIT)^{commit}"
+        if ($LASTEXITCODE -ne 0) { git -C $vcpkgRoot fetch origin }
         git -C $vcpkgRoot checkout $env:VCPKG_COMMIT
-        & "$vcpkgRoot\bootstrap-vcpkg.bat" -disableMetrics
+        if (-not (Test-Path "$vcpkgRoot\vcpkg.exe")) {
+          & "$vcpkgRoot\bootstrap-vcpkg.bat" -disableMetrics
+        }
+        New-Item -ItemType Directory -Force -Path $binCache | Out-Null
         "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        "VCPKG_DEFAULT_BINARY_CACHE=$binCache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Cache vcpkg packages
+      # Only needed on ephemeral GitHub-hosted runners; the self-hosted binary
+      # cache persists locally and needs no upload/download round-trip.
+      if: runner.environment == 'github-hosted'
       uses: actions/cache@v5
       with:
         path: .vcpkg-binary-cache
@@ -460,10 +484,7 @@ jobs:
 
     - name: Install libxml2
       shell: powershell
-      env:
-        VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}\.vcpkg-binary-cache
       run: |
-        New-Item -ItemType Directory -Force -Path "$env:VCPKG_DEFAULT_BINARY_CACHE" | Out-Null
         & "$env:VCPKG_ROOT\vcpkg.exe" install --triplet x64-windows
 
     - name: Configure CMake (Debug)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -551,16 +551,40 @@ jobs:
       with:
         arch: x64
 
-    - name: Setup pinned vcpkg
+    # vcpkg + its binary cache. On the self-hosted runner both persist on the
+    # machine across runs: a fixed clone we re-checkout (not re-clone), and a
+    # fixed binary cache dir, so libxml2 is restored from cache instead of being
+    # recompiled (that ~10 min build only happens on the very first run / after a
+    # pin bump). On GitHub-hosted runners the VM is ephemeral, so clone into
+    # RUNNER_TEMP and let actions/cache carry the binary cache between runs.
+    - name: Setup vcpkg
       shell: powershell
       run: |
-        $vcpkgRoot = Join-Path $env:RUNNER_TEMP "vcpkg"
-        git clone https://github.com/microsoft/vcpkg.git $vcpkgRoot
+        if ($env:RUNNER_ENVIRONMENT -eq 'self-hosted') {
+          $vcpkgRoot = 'C:\vcpkg-ci'
+          $binCache  = 'C:\vcpkg-bincache'
+        } else {
+          $vcpkgRoot = Join-Path $env:RUNNER_TEMP 'vcpkg'
+          $binCache  = Join-Path $env:GITHUB_WORKSPACE '.vcpkg-binary-cache'
+        }
+        if (-not (Test-Path "$vcpkgRoot\.git")) {
+          git clone https://github.com/microsoft/vcpkg.git $vcpkgRoot
+        }
+        # Fetch only when the pinned commit isn't already present (i.e. a pin bump).
+        git -C $vcpkgRoot cat-file -e "$($env:VCPKG_COMMIT)^{commit}"
+        if ($LASTEXITCODE -ne 0) { git -C $vcpkgRoot fetch origin }
         git -C $vcpkgRoot checkout $env:VCPKG_COMMIT
-        & "$vcpkgRoot\bootstrap-vcpkg.bat" -disableMetrics
+        if (-not (Test-Path "$vcpkgRoot\vcpkg.exe")) {
+          & "$vcpkgRoot\bootstrap-vcpkg.bat" -disableMetrics
+        }
+        New-Item -ItemType Directory -Force -Path $binCache | Out-Null
         "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        "VCPKG_DEFAULT_BINARY_CACHE=$binCache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Cache vcpkg packages
+      # Only needed on ephemeral GitHub-hosted runners; the self-hosted binary
+      # cache persists locally and needs no upload/download round-trip.
+      if: runner.environment == 'github-hosted'
       uses: actions/cache@v5
       with:
         path: .vcpkg-binary-cache
@@ -570,10 +594,7 @@ jobs:
 
     - name: Install libxml2
       shell: powershell
-      env:
-        VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}\.vcpkg-binary-cache
       run: |
-        New-Item -ItemType Directory -Force -Path "$env:VCPKG_DEFAULT_BINARY_CACHE" | Out-Null
         & "$env:VCPKG_ROOT\vcpkg.exe" install --triplet x64-windows
 
     # Ninja is shipped with the Visual Studio install on windows-latest, so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -520,7 +520,11 @@ jobs:
         rm -rf build
 
   build-windows:
-    runs-on: windows-latest-8core
+    # Built on the self-hosted runner (magda-luca). A Windows release already
+    # requires this machine for sign-windows (SimplySign's interactive OTP), so
+    # building here too adds no new dependency, skips the hosted larger-runner
+    # queue/cost, and keeps the unsigned build + signing on one box.
+    runs-on: [self-hosted, Windows, magda-luca]
     env:
       NSIS_VERSION: "3.10"
       VCPKG_COMMIT: a0b1c8d3a477c1cb4813d8e127a56961707ca42b

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -520,10 +520,18 @@ jobs:
         rm -rf build
 
   build-windows:
-    # Built on the self-hosted runner (magda-luca). A Windows release already
-    # requires this machine for sign-windows (SimplySign's interactive OTP), so
-    # building here too adds no new dependency, skips the hosted larger-runner
-    # queue/cost, and keeps the unsigned build + signing on one box.
+    # Builds AND signs on the self-hosted runner (magda-luca). Signing uses the
+    # Certum cloud cert via SimplySign, which needs an interactive OTP each
+    # session, so it can only run in this machine's logged-in desktop session -
+    # never on a GitHub-hosted runner. Building here too (rather than on a hosted
+    # larger runner) adds no new dependency, skips the hosted queue/cost, and
+    # keeps build + sign in one job with no artifact round-trip.
+    #
+    # Tag pushes only: signing requires the interactive SimplySign login, so a
+    # workflow_dispatch run (which regenerates artifacts and never publishes)
+    # would otherwise stall on the login wait. create-release is already
+    # tag-gated, so nothing downstream is affected.
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: [self-hosted, Windows, magda-luca]
     env:
       NSIS_VERSION: "3.10"
@@ -728,7 +736,7 @@ jobs:
           Write-Warning "MAGDA.pdb not found - crash symbolization unavailable for this release"
         }
 
-    - name: Create installer
+    - name: Stage, sign, and build installer
       shell: powershell
       env:
         VERSION: ${{ steps.version.outputs.version }}
@@ -822,63 +830,24 @@ jobs:
           Write-Output "Staged $dir/ for installer"
         }
 
-        & $env:MAKENSIS /DVERSION=$env:VERSION "$stage\magda-installer.nsi"
+        # Sign the two exes, build the installer from them, sign the installer,
+        # verify the chain, then write the renamed signed installer + .sha256
+        # into $stage. Parks up to 30 min waiting for SimplySign login (email +
+        # phone OTP) - log in any time before then. This is why the Windows
+        # release runs on the self-hosted runner in the interactive desktop
+        # session: that is where SimplySign Desktop holds the cloud cert.
+        & "packaging\windows\sign-release.ps1" `
+          -StageDir $stage `
+          -Version $env:VERSION `
+          -Makensis $env:MAKENSIS `
+          -WaitMinutes 30
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
         $installerName = "MAGDA-$env:VERSION-Windows-x86_64-Setup.exe"
-        Move-Item "$stage\MAGDA-$env:VERSION-Windows-Setup.exe" $installerName
-
-        Write-Output "Installer created: $installerName"
+        Move-Item "$stage\$installerName" $installerName -Force
+        Move-Item "$stage\$installerName.sha256" "$installerName.sha256" -Force
+        Write-Output "Signed installer: $installerName"
         Get-ChildItem $installerName
-
-    - name: Generate checksum
-      shell: powershell
-      env:
-        VERSION: ${{ steps.version.outputs.version }}
-      run: |
-        $installer = "MAGDA-$env:VERSION-Windows-x86_64-Setup.exe"
-        $hash = Get-FileHash -Algorithm SHA256 $installer
-        "$($hash.Hash)  $installer" | Out-File -Encoding utf8 "$installer.sha256"
-        Get-Content "$installer.sha256"
-
-    - name: Create MuseHub source bundle
-      # pwsh (PowerShell 7), NOT Windows PowerShell 5.1: 5.1's Compress-Archive
-      # writes ZIP entry names with backslash separators, which violates the ZIP
-      # spec (forward slashes required) and breaks the nested controllers/, lang/
-      # etc. trees on extraction. pwsh's Compress-Archive emits forward slashes.
-      shell: pwsh
-      env:
-        VERSION: ${{ steps.version.outputs.version }}
-      run: |
-        # The installer staging dir already holds the exact inputs the .nsi
-        # consumes (unsigned exes, ONNX DLLs, icon, lang/, controllers/). The
-        # MuseHub bundle is that staging dir plus the build wrapper, a version
-        # marker, and the README, zipped for the partner to sign and build.
-        $stage = Join-Path $env:RUNNER_TEMP "magda-installer-stage"
-        if (-not (Test-Path "$stage\magda-installer.nsi")) {
-          Write-Error "installer staging missing at $stage - did the Create installer step run?"
-          exit 1
-        }
-
-        Copy-Item "packaging\windows\musehub\build-installer.ps1" "$stage\"
-        Copy-Item "packaging\windows\musehub\README.md" "$stage\"
-        Set-Content -Path "$stage\version.txt" -Value $env:VERSION -NoNewline -Encoding ascii
-
-        # Belt-and-braces: never ship a built installer inside the source bundle
-        # (the Create installer step already moved it out of the stage).
-        Get-ChildItem $stage -Filter "*Setup.exe" | Remove-Item -Force -ErrorAction SilentlyContinue
-
-        $zip = "MAGDA-$env:VERSION-MuseHub-Source.zip"
-        if (Test-Path $zip) { Remove-Item -Force $zip }
-        $items = Get-ChildItem -Path $stage
-        Compress-Archive -Path $items.FullName -DestinationPath $zip
-        Write-Output "MuseHub source bundle created: $zip"
-        Get-ChildItem $zip
-
-        $hash = Get-FileHash -Algorithm SHA256 $zip
-        # ASCII (not utf8): Windows PowerShell 5.1's utf8 writes a BOM that
-        # breaks `sha256sum -c` parsing of the first line.
-        "$($hash.Hash)  $zip" | Out-File -Encoding ascii "$zip.sha256"
-        Get-Content "$zip.sha256"
 
     - name: Upload artifact
       uses: actions/upload-artifact@v7
@@ -888,8 +857,6 @@ jobs:
           MAGDA-*-Windows-x86_64-Setup.exe
           MAGDA-*-Windows-x86_64-Setup.exe.sha256
           MAGDA-*-Windows-x86_64.pdb
-          MAGDA-*-MuseHub-Source.zip
-          MAGDA-*-MuseHub-Source.zip.sha256
 
     - name: Clean up
       if: always()
@@ -897,126 +864,6 @@ jobs:
       run: |
         Remove-Item -Recurse -Force build -ErrorAction SilentlyContinue
         Remove-Item -Recurse -Force (Join-Path $env:RUNNER_TEMP "magda-installer-stage") -ErrorAction SilentlyContinue
-
-  sign-windows:
-    # Code-sign the Windows installer with the Certum cloud cert via SimplySign.
-    # SimplySign needs an interactive OTP from the phone app each session, so
-    # this MUST run on the self-hosted runner (magda-luca) inside the logged-in
-    # desktop session where SimplySign Desktop holds the cert - never on a
-    # GitHub-hosted runner. Tag pushes only: a workflow_dispatch run regenerates
-    # build artifacts and must not require a manual signing login.
-    needs: build-windows
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: [self-hosted, Windows, magda-luca]
-    env:
-      NSIS_VERSION: "3.10"
-    steps:
-    - uses: actions/checkout@v7
-      with:
-        submodules: false
-        lfs: false
-
-    - name: Extract version
-      id: version
-      shell: powershell
-      run: |
-        $version = "${{ github.ref_name }}".TrimStart("v")
-        echo "version=$version" >> $env:GITHUB_OUTPUT
-        Write-Output "Version: $version"
-
-    - name: Download Windows build artifact
-      uses: actions/download-artifact@v8
-      with:
-        name: windows-x86_64-release
-        path: dist
-
-    # NSIS is needed to rebuild the installer from the freshly-signed exes
-    # (signing the outer installer alone would leave the inner exes unsigned).
-    # Provision it exactly as build-windows does: the vendored zip on this
-    # repo's vendor/nsis-X.Y release tag, hash-pinned.
-    - name: Provision NSIS
-      id: nsis
-      shell: powershell
-      env:
-        NSIS_SHA256: "fcdce3229717a2a148e7cda0ab5bdb667f39d8fb33ede1da8dabc336bd5ad110"
-      run: |
-        $nsisDir = "$env:RUNNER_TEMP\nsis-$env:NSIS_VERSION"
-        $makensis = Join-Path $nsisDir "nsis-$env:NSIS_VERSION\makensis.exe"
-        if (-not (Test-Path $makensis)) {
-          $zip = "$env:RUNNER_TEMP\nsis-$env:NSIS_VERSION.zip"
-          $url = "https://github.com/${env:GITHUB_REPOSITORY}/releases/download/vendor/nsis-$env:NSIS_VERSION/nsis-$env:NSIS_VERSION.zip"
-          $downloaded = $false
-          for ($attempt = 1; $attempt -le 3; $attempt++) {
-            try {
-              Write-Output "Downloading NSIS $env:NSIS_VERSION (attempt $attempt/3)"
-              Invoke-WebRequest -Uri $url -OutFile $zip
-              if ((Test-Path $zip) -and ((Get-Item $zip).Length -gt 1MB)) { $downloaded = $true; break }
-            } catch {
-              Write-Output "Download attempt $attempt failed: $($_.Exception.Message)"
-            }
-            if ($attempt -lt 3) { Start-Sleep -Seconds 5 }
-          }
-          if (-not $downloaded) { Write-Error "NSIS download failed after 3 attempts"; exit 1 }
-
-          $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLower()
-          if ($actual -ne $env:NSIS_SHA256.ToLower()) {
-            Write-Error "NSIS zip hash mismatch - expected $($env:NSIS_SHA256.ToLower()), got $actual"
-            exit 1
-          }
-          Expand-Archive -Path $zip -DestinationPath $nsisDir -Force
-        }
-        if (-not (Test-Path $makensis)) { Write-Error "makensis.exe missing at $makensis"; exit 1 }
-        echo "makensis=$makensis" >> $env:GITHUB_OUTPUT
-        Write-Output "Resolved makensis: $makensis"
-
-    - name: Unpack installer source bundle
-      id: stage
-      shell: powershell
-      env:
-        VERSION: ${{ steps.version.outputs.version }}
-      run: |
-        # The MuseHub source bundle is the installer staging dir (signed-in-place
-        # exes + .nsi + DLLs + lang/ + controllers/ + version.txt) zipped. Unpack
-        # it and sign-release.ps1 consumes it directly.
-        $bundle = "dist\MAGDA-$env:VERSION-MuseHub-Source.zip"
-        if (-not (Test-Path $bundle)) { Write-Error "Source bundle not found at $bundle"; exit 1 }
-        $stage = Join-Path $env:RUNNER_TEMP "magda-sign-stage"
-        if (Test-Path $stage) { Remove-Item -Recurse -Force $stage }
-        New-Item -ItemType Directory -Path $stage | Out-Null
-        Expand-Archive -Path $bundle -DestinationPath $stage -Force
-        echo "dir=$stage" >> $env:GITHUB_OUTPUT
-        Write-Output "Staged installer inputs at $stage"
-
-    - name: Sign and build installer
-      shell: powershell
-      env:
-        VERSION: ${{ steps.version.outputs.version }}
-      run: |
-        # Parks and polls up to 30 min for SimplySign login, then signs the two
-        # exes, rebuilds the installer, signs it, verifies, and renames to the
-        # published asset name. Log into SimplySign Desktop (email + phone OTP)
-        # any time before the wait expires.
-        & "packaging\windows\sign-release.ps1" `
-          -StageDir "${{ steps.stage.outputs.dir }}" `
-          -Version $env:VERSION `
-          -Makensis "${{ steps.nsis.outputs.makensis }}" `
-          -WaitMinutes 30
-        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-    - name: Upload signed installer
-      uses: actions/upload-artifact@v7
-      with:
-        name: windows-x86_64-signed
-        path: |
-          ${{ steps.stage.outputs.dir }}\MAGDA-*-Windows-x86_64-Setup.exe
-          ${{ steps.stage.outputs.dir }}\MAGDA-*-Windows-x86_64-Setup.exe.sha256
-
-    - name: Clean up
-      if: always()
-      shell: powershell
-      run: |
-        Remove-Item -Recurse -Force dist -ErrorAction SilentlyContinue
-        Remove-Item -Recurse -Force (Join-Path $env:RUNNER_TEMP "magda-sign-stage") -ErrorAction SilentlyContinue
 
   build-linux:
     runs-on: ubuntu-latest
@@ -1240,14 +1087,13 @@ jobs:
         startsWith(github.ref, 'refs/tags/v') &&
         needs.build-macos.result == 'success' &&
         needs.build-windows.result == 'success' &&
-        needs.sign-windows.result == 'success' &&
         needs.build-linux.result == 'success' &&
         (
           needs.build-macos-x86_64.result == 'success' ||
           needs.build-macos-x86_64.result == 'skipped'
         )
       }}
-    needs: [build-macos, build-macos-x86_64, build-windows, sign-windows, build-linux]
+    needs: [build-macos, build-macos-x86_64, build-windows, build-linux]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1298,8 +1144,8 @@ jobs:
         files: |
           macos-release/MAGDA-*-macOS-arm64.dmg
           macos-release/MAGDA-*-macOS-arm64.dmg.sha256
-          windows-x86_64-signed/MAGDA-*-Windows-x86_64-Setup.exe
-          windows-x86_64-signed/MAGDA-*-Windows-x86_64-Setup.exe.sha256
+          windows-x86_64-release/MAGDA-*-Windows-x86_64-Setup.exe
+          windows-x86_64-release/MAGDA-*-Windows-x86_64-Setup.exe.sha256
           windows-x86_64-release/MAGDA-*-Windows-x86_64.pdb
           linux-release/*
 
@@ -1319,7 +1165,7 @@ jobs:
           macos-release/MAGDA-*-macOS-arm64.dmg.sha256
           macos-x86_64-release/MAGDA-*-macOS-x86_64.dmg
           macos-x86_64-release/MAGDA-*-macOS-x86_64.dmg.sha256
-          windows-x86_64-signed/MAGDA-*-Windows-x86_64-Setup.exe
-          windows-x86_64-signed/MAGDA-*-Windows-x86_64-Setup.exe.sha256
+          windows-x86_64-release/MAGDA-*-Windows-x86_64-Setup.exe
+          windows-x86_64-release/MAGDA-*-Windows-x86_64-Setup.exe.sha256
           windows-x86_64-release/MAGDA-*-Windows-x86_64.pdb
           linux-release/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -873,6 +873,126 @@ jobs:
         Remove-Item -Recurse -Force build -ErrorAction SilentlyContinue
         Remove-Item -Recurse -Force (Join-Path $env:RUNNER_TEMP "magda-installer-stage") -ErrorAction SilentlyContinue
 
+  sign-windows:
+    # Code-sign the Windows installer with the Certum cloud cert via SimplySign.
+    # SimplySign needs an interactive OTP from the phone app each session, so
+    # this MUST run on the self-hosted runner (magda-luca) inside the logged-in
+    # desktop session where SimplySign Desktop holds the cert - never on a
+    # GitHub-hosted runner. Tag pushes only: a workflow_dispatch run regenerates
+    # build artifacts and must not require a manual signing login.
+    needs: build-windows
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: [self-hosted, Windows, magda-luca]
+    env:
+      NSIS_VERSION: "3.10"
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        submodules: false
+        lfs: false
+
+    - name: Extract version
+      id: version
+      shell: powershell
+      run: |
+        $version = "${{ github.ref_name }}".TrimStart("v")
+        echo "version=$version" >> $env:GITHUB_OUTPUT
+        Write-Output "Version: $version"
+
+    - name: Download Windows build artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: windows-x86_64-release
+        path: dist
+
+    # NSIS is needed to rebuild the installer from the freshly-signed exes
+    # (signing the outer installer alone would leave the inner exes unsigned).
+    # Provision it exactly as build-windows does: the vendored zip on this
+    # repo's vendor/nsis-X.Y release tag, hash-pinned.
+    - name: Provision NSIS
+      id: nsis
+      shell: powershell
+      env:
+        NSIS_SHA256: "fcdce3229717a2a148e7cda0ab5bdb667f39d8fb33ede1da8dabc336bd5ad110"
+      run: |
+        $nsisDir = "$env:RUNNER_TEMP\nsis-$env:NSIS_VERSION"
+        $makensis = Join-Path $nsisDir "nsis-$env:NSIS_VERSION\makensis.exe"
+        if (-not (Test-Path $makensis)) {
+          $zip = "$env:RUNNER_TEMP\nsis-$env:NSIS_VERSION.zip"
+          $url = "https://github.com/${env:GITHUB_REPOSITORY}/releases/download/vendor/nsis-$env:NSIS_VERSION/nsis-$env:NSIS_VERSION.zip"
+          $downloaded = $false
+          for ($attempt = 1; $attempt -le 3; $attempt++) {
+            try {
+              Write-Output "Downloading NSIS $env:NSIS_VERSION (attempt $attempt/3)"
+              Invoke-WebRequest -Uri $url -OutFile $zip
+              if ((Test-Path $zip) -and ((Get-Item $zip).Length -gt 1MB)) { $downloaded = $true; break }
+            } catch {
+              Write-Output "Download attempt $attempt failed: $($_.Exception.Message)"
+            }
+            if ($attempt -lt 3) { Start-Sleep -Seconds 5 }
+          }
+          if (-not $downloaded) { Write-Error "NSIS download failed after 3 attempts"; exit 1 }
+
+          $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLower()
+          if ($actual -ne $env:NSIS_SHA256.ToLower()) {
+            Write-Error "NSIS zip hash mismatch - expected $($env:NSIS_SHA256.ToLower()), got $actual"
+            exit 1
+          }
+          Expand-Archive -Path $zip -DestinationPath $nsisDir -Force
+        }
+        if (-not (Test-Path $makensis)) { Write-Error "makensis.exe missing at $makensis"; exit 1 }
+        echo "makensis=$makensis" >> $env:GITHUB_OUTPUT
+        Write-Output "Resolved makensis: $makensis"
+
+    - name: Unpack installer source bundle
+      id: stage
+      shell: powershell
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        # The MuseHub source bundle is the installer staging dir (signed-in-place
+        # exes + .nsi + DLLs + lang/ + controllers/ + version.txt) zipped. Unpack
+        # it and sign-release.ps1 consumes it directly.
+        $bundle = "dist\MAGDA-$env:VERSION-MuseHub-Source.zip"
+        if (-not (Test-Path $bundle)) { Write-Error "Source bundle not found at $bundle"; exit 1 }
+        $stage = Join-Path $env:RUNNER_TEMP "magda-sign-stage"
+        if (Test-Path $stage) { Remove-Item -Recurse -Force $stage }
+        New-Item -ItemType Directory -Path $stage | Out-Null
+        Expand-Archive -Path $bundle -DestinationPath $stage -Force
+        echo "dir=$stage" >> $env:GITHUB_OUTPUT
+        Write-Output "Staged installer inputs at $stage"
+
+    - name: Sign and build installer
+      shell: powershell
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        # Parks and polls up to 30 min for SimplySign login, then signs the two
+        # exes, rebuilds the installer, signs it, verifies, and renames to the
+        # published asset name. Log into SimplySign Desktop (email + phone OTP)
+        # any time before the wait expires.
+        & "packaging\windows\sign-release.ps1" `
+          -StageDir "${{ steps.stage.outputs.dir }}" `
+          -Version $env:VERSION `
+          -Makensis "${{ steps.nsis.outputs.makensis }}" `
+          -WaitMinutes 30
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+    - name: Upload signed installer
+      uses: actions/upload-artifact@v7
+      with:
+        name: windows-x86_64-signed
+        path: |
+          ${{ steps.stage.outputs.dir }}\MAGDA-*-Windows-x86_64-Setup.exe
+          ${{ steps.stage.outputs.dir }}\MAGDA-*-Windows-x86_64-Setup.exe.sha256
+
+    - name: Clean up
+      if: always()
+      shell: powershell
+      run: |
+        Remove-Item -Recurse -Force dist -ErrorAction SilentlyContinue
+        Remove-Item -Recurse -Force (Join-Path $env:RUNNER_TEMP "magda-sign-stage") -ErrorAction SilentlyContinue
+
   build-linux:
     runs-on: ubuntu-latest
     steps:
@@ -1095,13 +1215,14 @@ jobs:
         startsWith(github.ref, 'refs/tags/v') &&
         needs.build-macos.result == 'success' &&
         needs.build-windows.result == 'success' &&
+        needs.sign-windows.result == 'success' &&
         needs.build-linux.result == 'success' &&
         (
           needs.build-macos-x86_64.result == 'success' ||
           needs.build-macos-x86_64.result == 'skipped'
         )
       }}
-    needs: [build-macos, build-macos-x86_64, build-windows, build-linux]
+    needs: [build-macos, build-macos-x86_64, build-windows, sign-windows, build-linux]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1152,8 +1273,8 @@ jobs:
         files: |
           macos-release/MAGDA-*-macOS-arm64.dmg
           macos-release/MAGDA-*-macOS-arm64.dmg.sha256
-          windows-x86_64-release/MAGDA-*-Windows-x86_64-Setup.exe
-          windows-x86_64-release/MAGDA-*-Windows-x86_64-Setup.exe.sha256
+          windows-x86_64-signed/MAGDA-*-Windows-x86_64-Setup.exe
+          windows-x86_64-signed/MAGDA-*-Windows-x86_64-Setup.exe.sha256
           windows-x86_64-release/MAGDA-*-Windows-x86_64.pdb
           linux-release/*
 
@@ -1173,7 +1294,7 @@ jobs:
           macos-release/MAGDA-*-macOS-arm64.dmg.sha256
           macos-x86_64-release/MAGDA-*-macOS-x86_64.dmg
           macos-x86_64-release/MAGDA-*-macOS-x86_64.dmg.sha256
-          windows-x86_64-release/MAGDA-*-Windows-x86_64-Setup.exe
-          windows-x86_64-release/MAGDA-*-Windows-x86_64-Setup.exe.sha256
+          windows-x86_64-signed/MAGDA-*-Windows-x86_64-Setup.exe
+          windows-x86_64-signed/MAGDA-*-Windows-x86_64-Setup.exe.sha256
           windows-x86_64-release/MAGDA-*-Windows-x86_64.pdb
           linux-release/*

--- a/packaging/windows/sign-release.ps1
+++ b/packaging/windows/sign-release.ps1
@@ -1,0 +1,192 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Sign MAGDA's Windows binaries and build a signed installer, locally.
+
+.DESCRIPTION
+  Code signing uses the Certum "Open Source Developer" cloud certificate via
+  SimplySign. SimplySign needs an interactive OTP from the SimplySign Mobile
+  app each session, so this CANNOT run on a GitHub-hosted runner - it must run
+  on a machine where SimplySign Desktop is logged in (the cloud cert then
+  appears in the Windows cert store as a virtual smart card).
+
+  Point this at a staging directory containing the unsigned MAGDA.exe,
+  magda_plugin_scanner.exe and magda-installer.nsi - i.e. the extracted
+  MAGDA-<version>-MuseHub-Source.zip from a release, or the installer staging
+  dir from a local build. It then:
+    1. signs MAGDA.exe and magda_plugin_scanner.exe in place,
+    2. runs makensis to build the installer,
+    3. signs the installer,
+    4. verifies every signature against the trust chain.
+
+  Output is renamed to MAGDA-<version>-Windows-x86_64-Setup.exe to match the
+  asset name the release workflow publishes, so it is a drop-in replacement for
+  the unsigned installer.
+
+.PARAMETER StageDir
+  Directory holding the unsigned exes + .nsi. Defaults to the script's own
+  directory (matches the MuseHub bundle layout, where this script sits beside
+  the inputs).
+
+.PARAMETER Version
+  Version passed to makensis. Defaults to version.txt next to the .nsi.
+
+.PARAMETER Thumbprint
+  SHA1 thumbprint of the signing certificate. Defaults to the Certum Open
+  Source Developer cert. Find it with:
+    Get-ChildItem Cert:\CurrentUser\My | Format-List Subject, Thumbprint
+
+.PARAMETER Makensis
+  Path to makensis.exe. Defaults to "makensis" on PATH.
+
+.PARAMETER SignTool
+  Path to signtool.exe. Auto-detected from the newest Windows SDK if omitted.
+
+.PARAMETER WaitMinutes
+  How long to wait for the signing cert to appear in the store before giving
+  up. The cert only shows up once SimplySign Desktop is logged in (email + OTP
+  from the phone app). With the default 0 the script fails immediately if you
+  are not logged in; in CI, pass a positive value so the job parks and polls -
+  push the tag whenever, then log into SimplySign and the job proceeds the
+  instant the cert appears.
+
+.EXAMPLE
+  .\sign-release.ps1
+  Signs the bundle in this directory using version.txt and the default cert.
+
+.EXAMPLE
+  .\sign-release.ps1 -StageDir C:\work\magda-bundle -Version 0.13.0
+#>
+param(
+    [string]$StageDir,
+    [string]$Version,
+    [string]$Thumbprint = "715B3557D43AF8FC23297999C0541C07E1B61319",
+    [string]$Makensis = "makensis",
+    [string]$SignTool,
+    [int]$WaitMinutes = 0
+)
+
+$ErrorActionPreference = "Stop"
+
+# Certum's RFC-3161 timestamp server. Timestamping is mandatory: it keeps the
+# signature valid after the cert expires (2027-06-29).
+$TimestampUrl = "http://time.certum.pl"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+if (-not $StageDir) { $StageDir = $scriptDir }
+$StageDir = (Resolve-Path $StageDir).Path
+
+# --- locate signtool -------------------------------------------------------
+if (-not $SignTool) {
+    if (Get-Command signtool.exe -ErrorAction SilentlyContinue) {
+        $SignTool = (Get-Command signtool.exe).Source
+    } else {
+        $SignTool = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin" -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match '\\x64\\' } |
+            Sort-Object FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+}
+if (-not $SignTool -or -not (Test-Path $SignTool)) {
+    throw "signtool.exe not found. Install the Windows 10/11 SDK or pass -SignTool."
+}
+Write-Host "signtool : $SignTool"
+
+# --- resolve version -------------------------------------------------------
+$nsi = Join-Path $StageDir "magda-installer.nsi"
+if (-not (Test-Path $nsi)) {
+    throw "magda-installer.nsi not found in $StageDir"
+}
+if (-not $Version) {
+    $versionFile = Join-Path $StageDir "version.txt"
+    if (Test-Path $versionFile) {
+        $Version = (Get-Content $versionFile -Raw).Trim()
+    } else {
+        throw "No -Version supplied and version.txt not found in $StageDir."
+    }
+}
+Write-Host "version  : $Version"
+Write-Host "stage    : $StageDir"
+
+# --- confirm the cert is present (waiting for SimplySign login if asked) ----
+# The cert only appears once SimplySign Desktop is logged in. With -WaitMinutes
+# > 0 the script parks and polls so a release job can be dispatched before you
+# log in: it proceeds the instant the virtual smart card shows up.
+function Get-SigningCert {
+    Get-ChildItem Cert:\CurrentUser\My, Cert:\LocalMachine\My -ErrorAction SilentlyContinue |
+        Where-Object { $_.Thumbprint -eq $Thumbprint } |
+        Select-Object -First 1
+}
+$cert = Get-SigningCert
+if (-not $cert -and $WaitMinutes -gt 0) {
+    $deadline = (Get-Date).AddMinutes($WaitMinutes)
+    Write-Host "Waiting up to $WaitMinutes min for SimplySign login (cert $Thumbprint)..."
+    while (-not $cert) {
+        if ((Get-Date) -gt $deadline) { break }
+        Start-Sleep -Seconds 10
+        Write-Host "  still waiting - log into SimplySign Desktop (email + phone OTP)..."
+        $cert = Get-SigningCert
+    }
+}
+if (-not $cert) {
+    throw @"
+Signing cert $Thumbprint not found in the Windows store.
+Is SimplySign Desktop running and logged in? Open it, log in with your email +
+the OTP from the SimplySign Mobile app, then re-run (or pass -WaitMinutes N to
+park and poll while you log in).
+"@
+}
+Write-Host "cert     : $($cert.Subject)"
+Write-Host ""
+
+function Invoke-Sign([string]$Path) {
+    if (-not (Test-Path $Path)) { throw "Cannot sign - file not found: $Path" }
+    Write-Host "Signing $Path ..."
+    & $SignTool sign /sha1 $Thumbprint /fd sha256 /tr $TimestampUrl /td sha256 /v $Path
+    if ($LASTEXITCODE -ne 0) { throw "signtool sign failed ($LASTEXITCODE) for $Path" }
+    & $SignTool verify /pa /v $Path
+    if ($LASTEXITCODE -ne 0) { throw "signtool verify failed ($LASTEXITCODE) for $Path" }
+    Write-Host ""
+}
+
+# 1. Sign the two MAGDA executables in place. The ONNX Runtime and libxml2 DLLs
+#    are already signed by their vendors and must not be re-signed.
+Invoke-Sign (Join-Path $StageDir "MAGDA.exe")
+$scanner = Join-Path $StageDir "magda_plugin_scanner.exe"
+if (Test-Path $scanner) {
+    Invoke-Sign $scanner
+} else {
+    Write-Warning "magda_plugin_scanner.exe not present in stage - skipping (out-of-process scanning will be unavailable)"
+}
+
+# 2. Build the installer from the now-signed exes. The .nsi's OutFile is a
+#    relative path, so run makensis with the working directory set to StageDir
+#    to guarantee the installer is written there (the .nsi resolves its File
+#    inputs via ${__FILEDIR__}, so they are found regardless).
+Write-Host "Building installer ..."
+Push-Location $StageDir
+try {
+    & $Makensis "/DVERSION=$Version" $nsi
+    if ($LASTEXITCODE -ne 0) { throw "makensis failed ($LASTEXITCODE)" }
+} finally {
+    Pop-Location
+}
+
+$built = Join-Path $StageDir "MAGDA-$Version-Windows-Setup.exe"
+if (-not (Test-Path $built)) { throw "Installer not produced at $built" }
+
+# 3. Sign the installer itself.
+Invoke-Sign $built
+
+# 4. Rename to the published asset name (matches .github/workflows/release.yml).
+$final = Join-Path $StageDir "MAGDA-$Version-Windows-x86_64-Setup.exe"
+Move-Item $built $final -Force
+
+# Refresh the checksum so it matches the signed installer.
+$hash = Get-FileHash -Algorithm SHA256 $final
+"$($hash.Hash)  $(Split-Path -Leaf $final)" | Out-File -Encoding ascii "$final.sha256"
+
+Write-Host ""
+Write-Host "Done. Signed installer:"
+Write-Host "  $final"
+Write-Host "  $final.sha256"

--- a/packaging/windows/sign-release.ps1
+++ b/packaging/windows/sign-release.ps1
@@ -112,8 +112,13 @@ Write-Host "stage    : $StageDir"
 # The cert only appears once SimplySign Desktop is logged in. With -WaitMinutes
 # > 0 the script parks and polls so a release job can be dispatched before you
 # log in: it proceeds the instant the virtual smart card shows up.
+# Search only CurrentUser\My - that is exactly where `signtool sign /sha1`
+# looks without /sm, and where SimplySign Desktop places the cloud cert.
+# Including LocalMachine\My here would let the pre-check pass on a cert that
+# signtool can't actually use, turning a clear "not logged in" message into a
+# confusing later failure.
 function Get-SigningCert {
-    Get-ChildItem Cert:\CurrentUser\My, Cert:\LocalMachine\My -ErrorAction SilentlyContinue |
+    Get-ChildItem Cert:\CurrentUser\My -ErrorAction SilentlyContinue |
         Where-Object { $_.Thumbprint -eq $Thumbprint } |
         Select-Object -First 1
 }

--- a/winbuild.sh
+++ b/winbuild.sh
@@ -24,6 +24,13 @@ EXE="${BUILD_DIR}/magda/daw/magda_daw_app_artefacts/Debug/MAGDA.exe"
 # build. VCPKG_ROOT must be the native Windows path (e.g. C:/vcpkg) since the
 # native cmake.exe can't read an MSYS /c/... path.
 VCPKG_ROOT="${VCPKG_ROOT:-C:/vcpkg}"
+# Share vcpkg's binary cache with the CI builds on this machine. The self-hosted
+# runner uses the same MSVC, so the same vcpkg ABI hash applies and the built
+# libxml2 binary is reused: whichever runs first - a CI/release job or a local
+# build - warms the cache for the other, so libxml2 is compiled once, not per
+# build tree. Override by exporting VCPKG_DEFAULT_BINARY_CACHE beforehand.
+export VCPKG_DEFAULT_BINARY_CACHE="${VCPKG_DEFAULT_BINARY_CACHE:-C:/vcpkg-bincache}"
+mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE"
 CMAKE_ARGS=(
   -G Ninja
   -DCMAKE_BUILD_TYPE=Debug


### PR DESCRIPTION
Sign the Windows installer with the Certum "Open Source Developer" cloud certificate. SimplySign requires an interactive OTP per session, so signing runs on the self-hosted runner (magda-luca) in the logged-in desktop session, never on a GitHub-hosted runner.

- packaging/windows/sign-release.ps1: signs MAGDA.exe + the plugin scanner, rebuilds and signs the NSIS installer, verifies the chain, and renames to the published asset name. -WaitMinutes parks and polls for the cert so the job can dispatch before SimplySign login.
- release.yml: new sign-windows job (tag pushes only) that consumes the build artifact, provisions NSIS, and runs the script; create-release now publishes the signed installer.
- .claude/skills/windows-signing: setup, release flow, and troubleshooting.