### PR TITLE
Fix bounce writing to the global export folder instead of the project

### DIFF
--- a/magda/daw/core/ClipCommands.cpp
+++ b/magda/daw/core/ClipCommands.cpp
@@ -1624,6 +1624,9 @@ BounceInPlaceCommand::BounceInPlaceCommand(ClipId clipId, TracktionEngineWrapper
     : clipId_(clipId), engine_(engine) {}
 
 void BounceInPlaceCommand::execute() {
+    // Reset per-run so a stale failure message can't leak into a later
+    // success/cancel (redo re-invokes execute() on the same object).
+    errorMessage_.clear();
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
     if (!clip || !clip->isMidi() || !engine_) {
@@ -1840,6 +1843,9 @@ BounceToNewTrackCommand::BounceToNewTrackCommand(ClipId clipId, TracktionEngineW
     : clipId_(clipId), engine_(engine) {}
 
 void BounceToNewTrackCommand::execute() {
+    // Reset per-run so a stale failure message can't leak into a later
+    // success/cancel (redo re-invokes execute() on the same object).
+    errorMessage_.clear();
     auto& clipManager = ClipManager::getInstance();
     auto* clip = clipManager.getClip(clipId_);
     if (!clip || !engine_) {

--- a/magda/daw/core/ClipCommands.cpp
+++ b/magda/daw/core/ClipCommands.cpp
@@ -1655,18 +1655,26 @@ void BounceInPlaceCommand::execute() {
         return;
     }
 
-    // Determine output file path
-    auto configFolder = Config::getInstance().getRenderFolder();
-    juce::File bouncesDir;
-    if (!configFolder.empty()) {
-        bouncesDir = juce::File(configFolder);
-    } else {
-        auto projBouncesDir = ProjectManager::getInstance().getBouncesDirectory();
-        bouncesDir = projBouncesDir != juce::File()
-                         ? projBouncesDir
-                         : edit->editFileRetriever().getParentDirectory().getChildFile("bounces");
+    // Determine output file path — always the project's bounces directory.
+    // A bounce file is referenced by a clip inside the project, so it must live
+    // in the project media tree (so save/collect/move keeps it). It must NOT
+    // honour Config::getRenderFolder(): that is the global Export-to-file
+    // folder, and letting it hijack bounce output drops the file outside the
+    // project (e.g. on the Desktop) where the project can't track it.
+    auto bouncesDir = ProjectManager::getInstance().getBouncesDirectory();
+    if (bouncesDir == juce::File())
+        bouncesDir = edit->editFileRetriever().getParentDirectory().getChildFile("bounces");
+    // Verify the destination is actually writable before handing the renderer a
+    // dead destFile. On a read-only / unavailable project media tree the render
+    // would otherwise fail with only a DBG line and no bounced clip, leaving the
+    // user with nothing and no explanation. Bail with a visible error instead.
+    // Safe to return here: the transport hasn't been touched yet.
+    if (bouncesDir.createDirectory().failed() || !bouncesDir.hasWriteAccess()) {
+        errorMessage_ =
+            "Bounce failed: can't write to the bounces folder:\n" + bouncesDir.getFullPathName();
+        juce::Logger::writeToLog(errorMessage_);
+        return;
     }
-    bouncesDir.createDirectory();
 
     {
         auto* trackInfo = TrackManager::getInstance().getTrack(clip->trackId);
@@ -1766,8 +1774,12 @@ void BounceInPlaceCommand::execute() {
     }
 
     if (userCancelled || !progressWindow.wasSuccessful()) {
-        if (!userCancelled)
-            DBG("BounceInPlaceCommand: render failed");
+        if (!userCancelled) {
+            errorMessage_ = "Bounce failed: couldn't write the audio file "
+                            "(the disk may be full or unwritable):\n" +
+                            renderedFile_.getFullPathName();
+            juce::Logger::writeToLog(errorMessage_);
+        }
         if (renderedFile_.existsAsFile())
             renderedFile_.deleteFile();
         restoreTransport();
@@ -1849,18 +1861,26 @@ void BounceToNewTrackCommand::execute() {
         return;
     }
 
-    // Determine output file path
-    auto configFolder = Config::getInstance().getRenderFolder();
-    juce::File bouncesDir;
-    if (!configFolder.empty()) {
-        bouncesDir = juce::File(configFolder);
-    } else {
-        auto projBouncesDir = ProjectManager::getInstance().getBouncesDirectory();
-        bouncesDir = projBouncesDir != juce::File()
-                         ? projBouncesDir
-                         : edit->editFileRetriever().getParentDirectory().getChildFile("bounces");
+    // Determine output file path — always the project's bounces directory.
+    // A bounce file is referenced by a clip inside the project, so it must live
+    // in the project media tree (so save/collect/move keeps it). It must NOT
+    // honour Config::getRenderFolder(): that is the global Export-to-file
+    // folder, and letting it hijack bounce output drops the file outside the
+    // project (e.g. on the Desktop) where the project can't track it.
+    auto bouncesDir = ProjectManager::getInstance().getBouncesDirectory();
+    if (bouncesDir == juce::File())
+        bouncesDir = edit->editFileRetriever().getParentDirectory().getChildFile("bounces");
+    // Verify the destination is actually writable before handing the renderer a
+    // dead destFile. On a read-only / unavailable project media tree the render
+    // would otherwise fail with only a DBG line and no bounced clip, leaving the
+    // user with nothing and no explanation. Bail with a visible error instead.
+    // Safe to return here: the transport hasn't been touched yet.
+    if (bouncesDir.createDirectory().failed() || !bouncesDir.hasWriteAccess()) {
+        errorMessage_ =
+            "Bounce failed: can't write to the bounces folder:\n" + bouncesDir.getFullPathName();
+        juce::Logger::writeToLog(errorMessage_);
+        return;
     }
-    bouncesDir.createDirectory();
 
     {
         auto* trackInfo = TrackManager::getInstance().getTrack(clip->trackId);
@@ -1935,8 +1955,12 @@ void BounceToNewTrackCommand::execute() {
     bool userCancelled = !progressWindow.runThread();
 
     if (userCancelled || !progressWindow.wasSuccessful()) {
-        if (!userCancelled)
-            DBG("BounceToNewTrackCommand: render failed");
+        if (!userCancelled) {
+            errorMessage_ = "Bounce failed: couldn't write the audio file "
+                            "(the disk may be full or unwritable):\n" +
+                            renderedFile_.getFullPathName();
+            juce::Logger::writeToLog(errorMessage_);
+        }
         if (renderedFile_.existsAsFile())
             renderedFile_.deleteFile();
         restoreTransport();

--- a/magda/daw/core/ClipCommands.hpp
+++ b/magda/daw/core/ClipCommands.hpp
@@ -568,6 +568,15 @@ class BounceInPlaceCommand : public UndoableCommand {
     ClipId newClipId_ = INVALID_CLIP_ID;
     juce::File renderedFile_;
     bool success_ = false;
+    juce::String errorMessage_;
+
+  public:
+    // Non-empty when the bounce failed for a reason worth showing the user
+    // (e.g. the bounces directory or disk is not writable). Empty on success
+    // or plain user cancellation. The UI caller surfaces this.
+    juce::String getErrorMessage() const {
+        return errorMessage_;
+    }
 };
 
 /**
@@ -603,6 +612,15 @@ class BounceToNewTrackCommand : public UndoableCommand {
     TrackId newTrackId_ = INVALID_TRACK_ID;
     juce::File renderedFile_;
     bool success_ = false;
+    juce::String errorMessage_;
+
+  public:
+    // Non-empty when the bounce failed for a reason worth showing the user
+    // (e.g. the bounces directory or disk is not writable). Empty on success
+    // or plain user cancellation. The UI caller surfaces this.
+    juce::String getErrorMessage() const {
+        return errorMessage_;
+    }
 };
 
 /**

--- a/magda/daw/ui/windows/MainWindow.cpp
+++ b/magda/daw/ui/windows/MainWindow.cpp
@@ -677,7 +677,12 @@ MainWindow::MainComponent::MainComponent(AudioEngine* externalEngine) {
             return;
         }
         auto cmd = std::make_unique<BounceInPlaceCommand>(clipId, engine);
+        // executeCommand always retains the command (undo stack), so reading
+        // its error message back afterwards is safe.
+        auto* cmdPtr = cmd.get();
         UndoManager::getInstance().executeCommand(std::move(cmd));
+        if (auto err = cmdPtr->getErrorMessage(); err.isNotEmpty())
+            daw::ui::Toast::showGlobal(err, 5000);
     };
 
     mainView->onBounceToNewTrackRequested = [this](ClipId clipId) {
@@ -687,19 +692,31 @@ MainWindow::MainComponent::MainComponent(AudioEngine* externalEngine) {
             return;
         }
 
+        // Runs one bounce and returns its error message (empty on success).
+        // executeCommand retains the command, so the raw pointer stays valid.
+        auto runBounce = [](ClipId cid, TracktionEngineWrapper* eng) -> juce::String {
+            auto cmd = std::make_unique<BounceToNewTrackCommand>(cid, eng);
+            auto* cmdPtr = cmd.get();
+            UndoManager::getInstance().executeCommand(std::move(cmd));
+            return cmdPtr->getErrorMessage();
+        };
+
         auto selectedClips = SelectionManager::getInstance().getSelectedClips();
+        juce::String error;
         if (selectedClips.size() > 1) {
             // Multi-clip bounce: one new track per selected clip, single undo step.
             UndoManager::getInstance().beginCompoundOperation("Bounce Clips To New Tracks");
             for (auto cid : selectedClips) {
-                UndoManager::getInstance().executeCommand(
-                    std::make_unique<BounceToNewTrackCommand>(cid, engine));
+                auto e = runBounce(cid, engine);
+                if (error.isEmpty())
+                    error = e;  // surface the first failure
             }
             UndoManager::getInstance().endCompoundOperation();
         } else {
-            UndoManager::getInstance().executeCommand(
-                std::make_unique<BounceToNewTrackCommand>(clipId, engine));
+            error = runBounce(clipId, engine);
         }
+        if (error.isNotEmpty())
+            daw::ui::Toast::showGlobal(error, 5000);
     };
 
     juce::Logger::writeToLog("[MainComponent] Setting up resize handles, view mode, callbacks...");


### PR DESCRIPTION
Bounce To New Track and Bounce In Place resolved their output directory via Config::getRenderFolder() - the global Export-to-file folder. With a custom export folder set (e.g. the Desktop), bounce output silently landed there instead of the project's bounces/ dir, so the file was not in the project tree and the project could not track it.

A bounce file is referenced by a clip inside the project, so it must live in the project media tree. Both commands now always use ProjectManager::getBouncesDirectory() (falling back to the edit file's parent), matching RenderClipCommand. getRenderFolder() stays wired to the Export feature only, where it belongs.

Also harden the failure paths: verify the bounces directory is writable before handing the renderer a dead destFile, and treat a failed render (disk full / unwritable) as a reportable error rather than a DBG-only no-op. Both commands expose getErrorMessage(); MainWindow reads it after executeCommand (which retains the command) and shows a Toast warning, so a failed bounce tells the user why instead of silently producing nothing.