### PR TITLE
Speed up and de-noise MSVC builds of vendored libs (eurorack/Faust/llama)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,16 +394,23 @@ if(MSVC)
 
     # The generated resources.cc files are nothing but giant brace-initialised
     # const float lookup tables (elements/resources.cc alone is ~44k lines of FP
-    # literals). MSVC's optimiser is pathologically slow on huge static
-    # initialiser lists, so /O2 spends minutes constant-folding data it can't
-    # optimise anyway. Disable optimisation for just these TUs: pure tables,
-    # zero runtime cost, drops their compile time from minutes to ~instant.
+    # literals). Two MSVC costs here:
+    #   /Od    - the optimiser is pathologically slow constant-folding huge
+    #            static initialiser lists; these are pure data, so disabling
+    #            optimisation costs nothing at runtime.
+    #   /wd4305 - every literal is a double (e.g. 0.0e+00) initialising a
+    #            const float, so MSVC emits a C4305 truncation warning PER
+    #            element. For elements that is ~178k diagnostics, whose
+    #            formatting + log I/O dominates the build. Silencing it is the
+    #            bigger win and clears the warning spam.
+    # TARGET_DIRECTORY scopes the per-file flags to the magda_mutable target
+    # (supported since CMake 3.18; verified the flags actually land).
     set_source_files_properties(
         ${MI_ROOT}/elements/resources.cc
         ${MI_ROOT}/rings/resources.cc
         ${MI_ROOT}/clouds/resources.cc
         TARGET_DIRECTORY magda_mutable
-        PROPERTIES COMPILE_OPTIONS "/Od")
+        PROPERTIES COMPILE_OPTIONS "/Od;/wd4305")
 endif()
 set_target_properties(magda_mutable PROPERTIES POSITION_INDEPENDENT_CODE ON)
 add_library(magda::mutable ALIAS magda_mutable)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,11 +254,19 @@ add_library(faust::libfaust ALIAS staticlib)
 # (both compile compatibility.cpp) so they take the narrow branch
 # upstream Faust expects on Windows; other targets are untouched.
 if(MSVC)
+    # The Faust compiler library is vendored third-party code (~390 TUs) that
+    # leans on implicit numeric conversions, so MSVC floods the build with
+    # benign C4244/C4267/C4305 conversion warnings whose formatting + log I/O
+    # measurably slow it. Not our code and not actionable, so silence them on
+    # both Faust targets alongside the _MBCS define.
+    set(_faust_msvc_quiet /wd4244 /wd4267 /wd4305)
     if(TARGET staticlib)
         target_compile_definitions(staticlib PRIVATE _MBCS)
+        target_compile_options(staticlib PRIVATE ${_faust_msvc_quiet})
     endif()
     if(TARGET faust)
         target_compile_definitions(faust PRIVATE _MBCS)
+        target_compile_options(faust PRIVATE ${_faust_msvc_quiet})
     endif()
 endif()
 
@@ -392,25 +400,30 @@ target_compile_definitions(magda_mutable PUBLIC TEST)
 if(MSVC)
     target_compile_definitions(magda_mutable PUBLIC _USE_MATH_DEFINES)
 
-    # The generated resources.cc files are nothing but giant brace-initialised
-    # const float lookup tables (elements/resources.cc alone is ~44k lines of FP
-    # literals). Two MSVC costs here:
-    #   /Od    - the optimiser is pathologically slow constant-folding huge
-    #            static initialiser lists; these are pure data, so disabling
-    #            optimisation costs nothing at runtime.
-    #   /wd4305 - every literal is a double (e.g. 0.0e+00) initialising a
-    #            const float, so MSVC emits a C4305 truncation warning PER
-    #            element. For elements that is ~178k diagnostics, whose
-    #            formatting + log I/O dominates the build. Silencing it is the
-    #            bigger win and clears the warning spam.
-    # TARGET_DIRECTORY scopes the per-file flags to the magda_mutable target
-    # (supported since CMake 3.18; verified the flags actually land).
+    # This is vendored Mutable Instruments DSP. It leans on implicit numeric
+    # conversions throughout (double literals -> float, size_t -> int32, etc.),
+    # so MSVC emits a flood of benign conversion warnings across stmlib headers
+    # and every dsp/*.cc - tens of thousands of them, whose formatting + log
+    # I/O measurably slow the build. We don't own this code and these are not
+    # actionable, so silence them for the whole target:
+    #   C4305 - truncation double -> float (the literal tables, the worst spam)
+    #   C4244 - conversion, possible loss of data
+    #   C4267 - size_t -> smaller int conversion
+    target_compile_options(magda_mutable PRIVATE /wd4305 /wd4244 /wd4267)
+
+    # The generated resources.cc files are giant brace-initialised const float
+    # lookup tables (elements/resources.cc alone is ~44k lines of FP literals).
+    # MSVC's optimiser is pathologically slow constant-folding huge static
+    # initialiser lists, so /O2 burns minutes on data it can't optimise. Disable
+    # optimisation for just these TUs: pure tables, zero runtime cost.
+    # TARGET_DIRECTORY scopes the per-file flag to magda_mutable (supported since
+    # CMake 3.18; verified the flag actually lands).
     set_source_files_properties(
         ${MI_ROOT}/elements/resources.cc
         ${MI_ROOT}/rings/resources.cc
         ${MI_ROOT}/clouds/resources.cc
         TARGET_DIRECTORY magda_mutable
-        PROPERTIES COMPILE_OPTIONS "/Od;/wd4305")
+        PROPERTIES COMPILE_OPTIONS "/Od")
 endif()
 set_target_properties(magda_mutable PROPERTIES POSITION_INDEPENDENT_CODE ON)
 add_library(magda::mutable ALIAS magda_mutable)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,22 +261,25 @@ add_library(faust::libfaust ALIAS staticlib)
 # error. Define `_MBCS` for Faust's staticlib AND the `faust` executable
 # (both compile compatibility.cpp) so they take the narrow branch
 # upstream Faust expects on Windows; other targets are untouched.
+# The Faust compiler library is vendored third-party code (~390 TUs) that
+# leans on implicit numeric conversions and variable shadowing, flooding the
+# build with benign warnings: MSVC C4244/C4267/C4305, GCC/Clang -Wshadow /
+# -Wunused-* / -Wcast-function-type, etc. None are actionable in code we don't
+# own, and the diagnostic volume slows the build, so silence warnings on both
+# Faust targets. MSVC additionally needs _MBCS (see above).
 if(MSVC)
-    # The Faust compiler library is vendored third-party code (~390 TUs) that
-    # leans on implicit numeric conversions, so MSVC floods the build with
-    # benign C4244/C4267/C4305 conversion warnings whose formatting + log I/O
-    # measurably slow it. Not our code and not actionable, so silence them on
-    # both Faust targets alongside the _MBCS define.
-    set(_faust_msvc_quiet /wd4244 /wd4267 /wd4305)
-    if(TARGET staticlib)
-        target_compile_definitions(staticlib PRIVATE _MBCS)
-        target_compile_options(staticlib PRIVATE ${_faust_msvc_quiet})
-    endif()
-    if(TARGET faust)
-        target_compile_definitions(faust PRIVATE _MBCS)
-        target_compile_options(faust PRIVATE ${_faust_msvc_quiet})
-    endif()
+    set(_faust_quiet /wd4244 /wd4267 /wd4305)
+else()
+    set(_faust_quiet -w)
 endif()
+foreach(_faust_target staticlib faust)
+    if(TARGET ${_faust_target})
+        target_compile_options(${_faust_target} PRIVATE ${_faust_quiet})
+        if(MSVC)
+            target_compile_definitions(${_faust_target} PRIVATE _MBCS)
+        endif()
+    endif()
+endforeach()
 
 # ----------------------------------------------------------------------------
 # magda_compile_faust_dsp(<dsp_file> <class_name> <out_var>)
@@ -432,6 +435,10 @@ if(MSVC)
         ${MI_ROOT}/clouds/resources.cc
         TARGET_DIRECTORY magda_mutable
         PROPERTIES COMPILE_OPTIONS "/Od")
+else()
+    # Same vendored-DSP rationale on GCC/Clang: shadowing + unused-var warnings
+    # from stmlib headers and dsp/*.cc that we won't fix. Silence them.
+    target_compile_options(magda_mutable PRIVATE -w)
 endif()
 set_target_properties(magda_mutable PROPERTIES POSITION_INDEPENDENT_CODE ON)
 add_library(magda::mutable ALIAS magda_mutable)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,14 @@ add_subdirectory(third_party/llama.cpp)
 # llama.cpp doesn't need C++20; building as C++17 avoids MSVC char8_t errors
 if(MSVC)
     set_target_properties(llama PROPERTIES CXX_STANDARD 17)
+    # Vendored llama.cpp leans on implicit numeric conversions (size_t->int,
+    # double->float, etc.), so MSVC emits ~750 benign C4244/C4267/C4305
+    # warnings from src/ and src/models/. Not our code, not actionable, and the
+    # diagnostic volume slows the build; silence them on the llama target.
+    # C4101 = unreferenced local variable (also upstream, also benign).
+    if(TARGET llama)
+        target_compile_options(llama PRIVATE /wd4244 /wd4267 /wd4305 /wd4101)
+    endif()
 endif()
 
 # Faust — runtime DSP compilation. Free tier uses the interpreter backend (no

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,6 +391,19 @@ target_include_directories(magda_mutable PUBLIC ${MI_ROOT})
 target_compile_definitions(magda_mutable PUBLIC TEST)
 if(MSVC)
     target_compile_definitions(magda_mutable PUBLIC _USE_MATH_DEFINES)
+
+    # The generated resources.cc files are nothing but giant brace-initialised
+    # const float lookup tables (elements/resources.cc alone is ~44k lines of FP
+    # literals). MSVC's optimiser is pathologically slow on huge static
+    # initialiser lists, so /O2 spends minutes constant-folding data it can't
+    # optimise anyway. Disable optimisation for just these TUs: pure tables,
+    # zero runtime cost, drops their compile time from minutes to ~instant.
+    set_source_files_properties(
+        ${MI_ROOT}/elements/resources.cc
+        ${MI_ROOT}/rings/resources.cc
+        ${MI_ROOT}/clouds/resources.cc
+        TARGET_DIRECTORY magda_mutable
+        PROPERTIES COMPILE_OPTIONS "/Od")
 endif()
 set_target_properties(magda_mutable PROPERTIES POSITION_INDEPENDENT_CODE ON)
 add_library(magda::mutable ALIAS magda_mutable)


### PR DESCRIPTION
Cuts MSVC build time and clears the warning floods from the vendored C/C++ libraries. No effect on non-MSVC toolchains.

## Build speed
The generated Mutable Instruments `resources.cc` files are giant brace-initialised `const float` lookup tables (`elements/resources.cc` alone is ~44k lines of FP literals). MSVC's optimiser is pathologically slow constant-folding huge static initialiser lists, so `/O2` burned minutes on data it can't optimise. Compile just those three TUs with `/Od` (pure tables, zero runtime cost).

## Warning de-noise
The vendored libraries lean on implicit numeric conversions throughout, so MSVC emitted tens of thousands of benign conversion warnings (`C4244`/`C4267`/`C4305`, plus a stray `C4101`). None are actionable, and formatting + logging that volume measurably slows the Windows build. Silenced per target:

- **eurorack** (`magda_mutable`) — `/wd4244 /wd4267 /wd4305` target-wide
- **Faust** (`staticlib` / `faust`, ~390 TUs) — `/wd4244 /wd4267 /wd4305`
- **llama.cpp** (`llama`, ~750 warnings from `src/` + `src/models/`) — `/wd4244 /wd4267 /wd4305 /wd4101`

All suppression is scoped to the third-party targets; MAGDA's own code keeps its full warning set.