### PR TITLE
Fix thrashing ccache on Linux CI (500 MB -> 3 GB)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,12 @@ jobs:
         key: ${{ runner.os }}-ccache-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-ccache-
+        # Default cap is 500 MB, far too small for this project (llama + ggml +
+        # faust + onnx + JUCE + TE). It filled and thrashed, giving an ~8% hit
+        # rate and recompiling ~92% of TUs every run. 3G holds the whole build
+        # (~1.5G compressed) with headroom, so warm runs are mostly cache hits,
+        # and stays under the 10G repo cache budget shared with the other caches.
+        max-size: 3G
 
     - name: Cache CMake build directory
       uses: actions/cache@v5
@@ -114,7 +120,7 @@ jobs:
     - name: Build
       run: |
         echo "Building with $(nproc) cores..."
-        cmake --build build --config Debug -j$(nproc) -- -v
+        cmake --build build --config Debug -j$(nproc)
 
     - name: Check build artifacts
       run: |

--- a/.github/workflows/juce-tests-linux.yml
+++ b/.github/workflows/juce-tests-linux.yml
@@ -62,6 +62,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-juce-ccache-
           ${{ runner.os }}-ccache-
+        # Default 500 MB cap thrashes on this project; hold the whole build.
+        # Kept under the 10G repo cache budget shared with the other caches.
+        max-size: 3G
 
     - name: Configure CMake
       run: |


### PR DESCRIPTION
The Linux build job ran ~43 min with an ~8% ccache hit rate: the cache sat pinned at ccache's default 500 MB cap (reported 0.5/0.5 GB, 107%), far too small for llama + ggml + faust + onnx + JUCE + TE, so it evicted entries before the next run could reuse them and recompiled ~92% of TUs every time.

Raise max-size to 3 GB in both Linux workflows (ci.yml and juce-tests-linux.yml). 3G holds the whole build (~1.5G compressed) with headroom while staying under the 10 GB per-repo cache budget shared with the build-directory cache. Warm runs should now be mostly cache hits.

Also drop `-- -v` from the Linux build so ninja stops printing every command line (huge logs, no benefit).