### PR TITLE
Cache MSVC Debug builds with ccache via /Z7 (Windows CI + local)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,17 +487,35 @@ jobs:
       run: |
         & "$env:VCPKG_ROOT\vcpkg.exe" install --triplet x64-windows
 
+    # ccache for MSVC. The Debug build uses /Z7 (embedded debug info, no shared
+    # PDB), which is what makes MSVC objects cacheable - /Zi could not be cached
+    # and broke the earlier sccache attempt. Mirrors the Linux job.
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ runner.os }}-ccache-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-
+        max-size: 3G
+        variant: ccache
+
     - name: Configure CMake (Debug)
       run: |
         cmake -B build-debug -G Ninja `
           -DCMAKE_BUILD_TYPE=Debug `
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON `
           -DMAGDA_BUILD_TESTS=ON `
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache `
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `
           -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" `
           -DVCPKG_TARGET_TRIPLET=x64-windows
 
     - name: Build (Debug)
       run: cmake --build build-debug --config Debug
+
+    - name: Show ccache statistics
+      if: always()
+      run: ccache -s
 
     - name: Run tests
       timeout-minutes: 5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,13 +82,20 @@ endif()
 
 # Compiler flags
 if(MSVC)
-    set(CMAKE_CXX_FLAGS_DEBUG "/Zi /Od /W3")
+    # Debug uses /Z7 (debug info embedded in each .obj) rather than /Zi (a
+    # separate, shared compile-time PDB). /Z7 has no shared PDB, so:
+    #   - parallel cl.exe workers never contend on a PDB (no /FS needed), and
+    #   - the .obj is self-contained, which is what makes ccache able to cache
+    #     MSVC Debug builds. /Zi can't be cached (the PDB write is a side effect
+    #     ccache can't replay) - that's what broke the earlier sccache attempt.
+    # Release still ships a real PDB for crash symbolication via per-target /Zi
+    # in magda/daw/CMakeLists.txt, so /FS is scoped to Release only.
+    set(CMAKE_CXX_FLAGS_DEBUG "/Z7 /Od /W3")
     set(CMAKE_CXX_FLAGS_RELEASE "/O2 /DNDEBUG")
-    # /FS serialises PDB writes across parallel cl.exe workers (required with
-    # /Zi when the build runs with -j >1). Added via add_compile_options so it
-    # composes with CMake's default MSVC init flags (/DWIN32 /_WINDOWS /EHsc etc.)
-    # instead of replacing them like a top-level -DCMAKE_CXX_FLAGS would.
-    add_compile_options(/FS)
+    # /FS serialises PDB writes across parallel cl.exe workers, required with the
+    # Release per-target /Zi. Added via add_compile_options so it composes with
+    # CMake's default MSVC init flags instead of replacing them.
+    add_compile_options($<$<CONFIG:Release>:/FS>)
     # NOMINMAX: stop <windows.h> defining min()/max() macros, which clobber
     # std::min/std::max. The Faust poly instruments (poly-dsp.h) transitively
     # pull in <windows.h>, so without this they fail to compile on MSVC.

--- a/build.bat
+++ b/build.bat
@@ -33,6 +33,11 @@ if "%INCLUDE%"=="" (
     echo   MSVC %MSVC_VER%, SDK %WINSDK_VER%
 )
 
+REM --- ccache (optional): if on PATH, route cl.exe through it for a big
+REM --- speedup on rebuilds. Safe because Debug uses /Z7 (no shared PDB).
+set "CCACHE_FLAGS="
+where ccache >nul 2>nul && set "CCACHE_FLAGS=-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+
 REM --- Build directories ---
 set "BUILD_DIR=cmake-build-debug"
 set "BUILD_DIR_RELEASE=cmake-build-release"
@@ -61,7 +66,7 @@ echo Building MAGDA DAW (Debug)...
 if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
 if not exist "%BUILD_DIR%\CMakeCache.txt" (
     echo Configuring project...
-    cmake -S . -B "%BUILD_DIR%" -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DMAGDA_BUILD_TESTS=ON
+    cmake -S . -B "%BUILD_DIR%" -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DMAGDA_BUILD_TESTS=ON %CCACHE_FLAGS%
 )
 cmake --build "%BUILD_DIR%"
 goto :end
@@ -76,7 +81,7 @@ goto :end
 :configure
 echo Reconfiguring MAGDA DAW (Debug)...
 if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
-cmake -S . -B "%BUILD_DIR%" -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DMAGDA_BUILD_TESTS=ON
+cmake -S . -B "%BUILD_DIR%" -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DMAGDA_BUILD_TESTS=ON %CCACHE_FLAGS%
 goto :end
 
 :test-build
@@ -84,7 +89,7 @@ echo Building tests...
 if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
 if not exist "%BUILD_DIR%\CMakeCache.txt" (
     echo Configuring project with tests enabled...
-    cmake -S . -B "%BUILD_DIR%" -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DMAGDA_BUILD_TESTS=ON
+    cmake -S . -B "%BUILD_DIR%" -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DMAGDA_BUILD_TESTS=ON %CCACHE_FLAGS%
 )
 cmake --build "%BUILD_DIR%" --target magda_tests
 goto :end


### PR DESCRIPTION
The Windows Debug build had no compiler cache, so CI (and local build.bat) recompiled everything from scratch every time - ~48 min on CI. The blocker was /Zi: its separate compile-time PDB is a side effect ccache can't replay, which is exactly what broke the earlier sccache attempt (the C1041 PDB races, worked around with -j1, then dropped).

Switch the MSVC Debug build to /Z7 (debug info embedded per .obj, no shared PDB). That removes the PDB race at the root and makes objects cacheable. Then wire ccache as the MSVC compiler launcher in both the CI Windows job (hendrikmuhs/ccache-action, 3G) and build.bat (auto-detected on PATH).

Release is untouched: it still emits a real PDB for crash symbolication via the per-target /Zi in magda/daw/CMakeLists.txt, and /FS is now scoped to Release where that /Zi actually needs it. Non-MSVC builds are unaffected.