### PR TITLE
Compile the JUCE/TE module stack once instead of per target

### DIFF
--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -409,8 +409,19 @@ if(WIN32)
     endif()
 endif()
 
-target_link_libraries(magda_daw
-    PUBLIC
+# JUCE / Tracktion modules are JUCE "module" INTERFACE libraries: their unity
+# .cpp lives in INTERFACE_SOURCES, so linking them PUBLIC propagates those
+# sources to every dependent, which then recompiles the entire JUCE+TE stack
+# (measured: juce_core x14, juce_audio_basics x7 across the 7 targets). Compile
+# them ONCE here instead:
+#   - PRIVATE so the sources land only in magda_daw and do not propagate;
+#   - as a STATIC lib, magda_daw still forwards the modules' LINK requirements
+#     (system frameworks, the compiled objects) to final executables, made
+#     explicit via the INTERFACE $<LINK_ONLY:...> entry;
+#   - the compile usage (header search paths + JUCE_MODULE_AVAILABLE_* defines)
+#     is re-exported below without the sources, so dependents still #include
+#     JUCE headers but never recompile the modules.
+set(MAGDA_JUCE_STACK
     juce::juce_core
     juce::juce_cryptography  # SHA-256 verification of downloaded model files
     juce::juce_data_structures
@@ -422,14 +433,34 @@ target_link_libraries(magda_daw
     juce::juce_gui_extra
     tracktion::tracktion_engine
     juce_llm
+)
+target_link_libraries(magda_daw
+    PUBLIC
     MagdaAssets
     magda::mutable  # Mutable Instruments DSP for the native Elements/Rings/Clouds ports (#1581)
-    $<$<PLATFORM_ID:Linux>:juce::pkgconfig_JUCE_BROWSER_LINUX_DEPS>
-    $<$<PLATFORM_ID:Linux>:juce::pkgconfig_JUCE_CURL_LINUX_DEPS>
     PRIVATE
+    ${MAGDA_JUCE_STACK}
     LibXml2::LibXml2
     faust::libfaust
+    $<$<PLATFORM_ID:Linux>:juce::pkgconfig_JUCE_BROWSER_LINUX_DEPS>
+    $<$<PLATFORM_ID:Linux>:juce::pkgconfig_JUCE_CURL_LINUX_DEPS>
+    INTERFACE
+    # Carry the modules forward to dependents for LINKING only (frameworks +
+    # the objects already inside magda_daw's archive), never for compiling.
+    $<LINK_ONLY:${MAGDA_JUCE_STACK}>
+    $<$<PLATFORM_ID:Linux>:$<LINK_ONLY:juce::pkgconfig_JUCE_BROWSER_LINUX_DEPS>>
+    $<$<PLATFORM_ID:Linux>:$<LINK_ONLY:juce::pkgconfig_JUCE_CURL_LINUX_DEPS>>
 )
+# Re-export JUCE/TE compile usage (include dirs + defines, NO sources) so
+# dependents can still #include JUCE headers. magda_daw's own resolved
+# INCLUDE_DIRECTORIES / COMPILE_DEFINITIONS already hold the full transitive
+# JUCE closure (CMake resolved it when the modules were linked PRIVATE above),
+# so forward exactly those - this avoids having to enumerate TE's hidden juce
+# module dependencies by hand.
+target_include_directories(magda_daw INTERFACE
+    $<BUILD_INTERFACE:$<TARGET_PROPERTY:magda_daw,INCLUDE_DIRECTORIES>>)
+target_compile_definitions(magda_daw INTERFACE
+    $<TARGET_PROPERTY:magda_daw,COMPILE_DEFINITIONS>)
 
 target_compile_definitions(magda_daw
     PUBLIC
@@ -447,15 +478,11 @@ target_link_libraries(magda_daw_app
     magda_agents
     magda_scripting
     MagdaAssets
-    juce::juce_gui_basics
-    juce::juce_gui_extra
-    juce::juce_audio_devices
-    juce::juce_audio_formats
-    juce::juce_audio_processors
-    juce::juce_audio_utils
-    tracktion::tracktion_engine
-    $<$<PLATFORM_ID:Linux>:juce::pkgconfig_JUCE_BROWSER_LINUX_DEPS>
-    $<$<PLATFORM_ID:Linux>:juce::pkgconfig_JUCE_CURL_LINUX_DEPS>
+    # JUCE/TE come transitively from magda_daw: its re-exported INTERFACE gives
+    # the headers + defines to compile this target's own sources, and its
+    # $<LINK_ONLY:...> forwards the modules' frameworks + the objects already in
+    # magda_daw's archive. Linking the juce:: modules here directly would just
+    # recompile the whole stack again (the duplication this refactor removes).
 )
 
 target_compile_definitions(magda_daw_app

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -470,6 +470,14 @@ target_compile_definitions(magda_daw
     TRACKTION_ENABLE_TIMESTRETCH_SOUNDTOUCH=1
     MAGDA_DAWPROJECT_SCHEMA_DIR="${CMAKE_SOURCE_DIR}/third_party/dawproject"
     $<$<BOOL:${JUCE_ASIO_ENABLED}>:JUCE_ASIO=1>
+    PRIVATE
+    # Tracktion Engine carries a MAGDA test hook (magdaTestEvaluateLoopSessionDecision,
+    # in tracktion_TransportControl.cpp) gated on MAGDA_ENABLE_TEST_HOOKS. TE now
+    # compiles ONCE here instead of being recompiled by magda_juce_tests, so the
+    # hook must be built into magda_daw's archive when tests are enabled, or the
+    # JUCE test exe fails to link it. Off for release (MAGDA_BUILD_TESTS=OFF), so
+    # the hook is never shipped.
+    $<$<BOOL:${MAGDA_BUILD_TESTS}>:MAGDA_ENABLE_TEST_HOOKS=1>
 )
 
 target_link_libraries(magda_daw_app

--- a/magda/scripting/CMakeLists.txt
+++ b/magda/scripting/CMakeLists.txt
@@ -101,7 +101,8 @@ add_library(magda_scripting STATIC ${MAGDA_SCRIPTING_SOURCES})
 target_link_libraries(magda_scripting
     PUBLIC
     lua_static
-    juce::juce_core
+    # juce_core comes transitively from magda_daw (compiled once there); a
+    # direct link would recompile the JUCE stack into this target again.
     # MagdaApi headers live under magda/daw/api/. The bindings need the
     # full DAW types (TrackInfo, ClipInfo, ProjectInfo). Long-term these
     # types could be split into a thin "magda_api_types" lib so scripting

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -158,8 +158,8 @@ target_link_libraries(magda_tests
     magda_agents
     magda_scripting
     Catch2::Catch2WithMain
-    juce::juce_core
-    juce::juce_gui_basics
+    # JUCE (core + gui_basics) comes transitively from magda_daw, compiled once
+    # there; direct links would recompile the JUCE stack into this target.
 )
 
 # Include directories
@@ -250,9 +250,8 @@ target_link_libraries(magda_juce_tests
     PRIVATE
     magda_daw
     magda_agents
-    juce::juce_core
-    juce::juce_events
-    juce::juce_gui_basics
+    # JUCE (core/events/gui_basics) comes transitively from magda_daw, compiled
+    # once there; direct links would recompile the JUCE stack into this target.
     # Linux: juce_gui_extra is pulled in transitively via magda_daw's
     # JUCE_MODULE_AVAILABLE flags (so its .cpp gets compiled into this
     # target). Its compilation requires GTK / WebKit headers — expose


### PR DESCRIPTION
Draft - macOS validated; needs Windows + Linux CI to confirm before merge.

## Problem
JUCE/Tracktion modules are JUCE "module" INTERFACE libraries whose unity `.cpp` lives in `INTERFACE_SOURCES`. `magda_daw` linked them **PUBLIC**, so the sources propagated to every dependent and each target recompiled the whole stack. Measured across the 7 JUCE-using targets: `juce_core` compiled **14x**, `juce_audio_basics` **7x**, etc. Several targets also linked `juce::` modules directly, compounding it. Likely the single biggest chunk of build time on every platform.

## Fix
Compile the modules **once** in `magda_daw`:
- link the JUCE/TE modules **PRIVATE** so their sources land only in `magda_daw` and do not propagate;
- as a static lib, `magda_daw` still forwards the modules' link requirements (frameworks + its archived objects) to final executables, made explicit via an `INTERFACE` LINK_ONLY entry;
- re-export `magda_daw`'s own resolved `INCLUDE_DIRECTORIES` / `COMPILE_DEFINITIONS` as `INTERFACE` (no sources) so dependents still include JUCE headers and see the `JUCE_MODULE_AVAILABLE_*` defines. Using the resolved properties captures the full transitive closure (including TE's hidden juce module deps) without hand-enumeration.

Then drop the now-redundant direct `juce::` links from `magda_daw_app`, `magda_scripting`, `magda_tests` and `magda_juce_tests`. `magda_plugin_scanner` stays standalone (it does not link `magda_daw`; routing it through would pull the whole DAW).

## Result
The JUCE/TE stack compiles **once** (in `magda_daw`) instead of up to 7x. Confirmed in the Ninja graph: `juce_core` 14 -> 1 real target (+ `juceaide`, JUCE's own codegen tool, and the standalone scanner subset).

## Validation
- **macOS: builds + links.** Both `magda_tests` (Catch2 exe) and the `MAGDA.app` GUI target compile and link with all direct juce links removed.
- **Windows / Linux: not yet validated** - LINK_ONLY is standard CMake, but per-platform framework/system-lib resolution can only be proven on those runners. That is what this draft is for.
