### PR TITLE
Fix MSVC Debug C1090 PDB race: switch C deps (lua) to /Z7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,11 @@ if(MSVC)
     #     ccache can't replay) - that's what broke the earlier sccache attempt.
     # Release still ships a real PDB for crash symbolication via per-target /Zi
     # in magda/daw/CMakeLists.txt, so /FS is scoped to Release only.
+    # Override BOTH languages: C dependencies built via FetchContent (lua) still
+    # default to /Zi, which reintroduces the shared compile-time PDB this switch
+    # exists to remove. ccache can't replay the PDB side effect, so /Zi C objects
+    # race on mspdbsrv under -j and fail with "C1090 PDB API call failed".
+    set(CMAKE_C_FLAGS_DEBUG "/Z7 /Od /W3")
     set(CMAKE_CXX_FLAGS_DEBUG "/Z7 /Od /W3")
     set(CMAKE_CXX_FLAGS_RELEASE "/O2 /DNDEBUG")
     # /FS serialises PDB writes across parallel cl.exe workers, required with the


### PR DESCRIPTION
## Problem
The Windows Debug build on main fails intermittently with:

```
lua-src\src\loadlib.c(759): fatal error C1090: PDB API call failed, error code '23'
```

#1656 switched the MSVC Debug build to `/Z7` to drop the shared compile-time PDB so ccache can cache objects, but only overrode `CMAKE_CXX_FLAGS_DEBUG`. C dependencies built via FetchContent (lua) still defaulted to `/Zi`, kept emitting a shared `lua_static.pdb`, and ran through ccache - the exact `/Zi` + ccache combination #1656 set out to remove. Under `-j` the `mspdbsrv` writes race and fail intermittently with C1090. The race is why it passed on the PR branch but flaked once on main (it surfaced under #1658's run, which is unrelated to the cause).

## Fix
Mirror the `/Z7` override for `CMAKE_C_FLAGS_DEBUG` so C objects are self-contained and cacheable, with no shared PDB. Also restores ccache effectiveness for the C deps, which were all cache misses before.

Mac/Linux unaffected (the block is `if(MSVC)`-gated). Windows runner confirms.