### PR TITLE
Gate Windows Release build to the self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,12 +546,15 @@ jobs:
           exit 1
         }
 
-    # Release configure/build/verify only run on push to main. Feature-branch
-    # pushes get Debug coverage; the Release link check happens once per merge,
-    # before any tag is cut. release.yml still does the full Release build
-    # end-to-end on tag push.
+    # Release configure/build/verify only run on push to main, and only on the
+    # self-hosted runner (magda-luca). Feature-branch pushes get Debug coverage;
+    # the Release link check happens once per merge, before any tag is cut. We
+    # gate it off windows-latest because that fallback runner is much weaker - a
+    # full Release build there would dominate the run. release.yml still does the
+    # full Release build end-to-end on tag push, so nothing is lost when the
+    # fallback skips it.
     - name: Configure CMake (Release)
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push' && runner.environment == 'self-hosted'
       run: |
         cmake -B build-release -G Ninja `
           -DCMAKE_BUILD_TYPE=Release `
@@ -560,11 +563,11 @@ jobs:
           -DVCPKG_TARGET_TRIPLET=x64-windows
 
     - name: Build (Release)
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push' && runner.environment == 'self-hosted'
       run: cmake --build build-release --config Release
 
     - name: Verify executable
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push' && runner.environment == 'self-hosted'
       run: |
         $exe = Get-ChildItem -Path build-release -Recurse -Filter "MAGDA.exe" | Select-Object -First 1
         if ($exe) {


### PR DESCRIPTION
## Problem
On a push to main the Windows job builds Debug + tests **and** Release. The Release configure/build/verify already only run on `main` + `push`, but they run on whichever runner `pick-windows-runner` selected - including the `windows-latest` fallback used when the self-hosted `magda-luca` machine is busy. That fallback is much weaker, so a full Release build there dominates the run (~1h30m territory).

## Fix
Add `runner.environment == 'self-hosted'` to the three Release steps (Configure / Build / Verify), so the Release link check only runs on `magda-luca`. When the run falls back to `windows-latest`, it does Debug + tests only.

No coverage lost: `release.yml` still does the full Release build end-to-end on tag push.

Follow-up to #1659.