### PR TITLE
ccache: hash compiler content not mtime (fix 0% hit rate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,14 @@ concurrency:
 
 env:
   VCPKG_COMMIT: a0b1c8d3a477c1cb4813d8e127a56961707ca42b
+  # Hash the compiler's CONTENT, not its mtime, when keying ccache objects.
+  # ccache defaults to compiler_check=mtime, but ephemeral runners reprovision
+  # the VM every run, so the system compiler gets a fresh mtime each time even
+  # though its bytes are identical. With mtime that invalidates 100% of the
+  # restored cache (0% hits, observed on Linux); content makes the same compiler
+  # version hash identically across runs. Covers Linux and the windows-latest
+  # fallback, which lack the global ccache.conf the self-hosted runner carries.
+  CCACHE_COMPILERCHECK: content
 
 jobs:
   build-and-test-linux:


### PR DESCRIPTION
The Linux ccache ran at 0% hits / 100% misses every build despite a populated 0.8 GB cache. ccache defaults to compiler_check=mtime, but ubuntu-latest reprovisions the VM each run, so the system compiler gets a fresh mtime every time even though its bytes are identical -- mtime then invalidates 100% of the restored objects.

Set CCACHE_COMPILERCHECK=content at the workflow env level so the same compiler version hashes identically across runs. Applies to Linux and the windows-latest fallback, which (unlike the self-hosted Windows runner) have no global ccache.conf pinning compiler_check=content.