### PR TITLE
Audio settings: list devices from the active driver type

### DIFF
--- a/magda/daw/audio/AudioDriverUtils.hpp
+++ b/magda/daw/audio/AudioDriverUtils.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <juce_audio_devices/juce_audio_devices.h>
+
+namespace magda {
+
+/**
+ * Returns the audio driver type whose devices should be listed in the UI: the
+ * one the device manager is currently using, falling back to the first available
+ * type, or nullptr if there are none.
+ *
+ * Listing from getAvailableDeviceTypes()[0] unconditionally was a Mac-first bug:
+ * macOS has a single type (CoreAudio) so [0] is always the active one, but
+ * Windows (Windows Audio / DirectSound / ASIO) and Linux (ALSA / JACK) have
+ * several. Once a non-first driver was selected, [0] listed the wrong driver's
+ * devices and applying one failed with "No such device". The active type is the
+ * source of truth.
+ */
+inline juce::AudioIODeviceType* activeDeviceTypeFor(juce::AudioDeviceManager& deviceManager) {
+    if (auto* current = deviceManager.getCurrentDeviceTypeObject())
+        return current;
+
+    auto& types = deviceManager.getAvailableDeviceTypes();
+    return types.isEmpty() ? nullptr : types.getFirst();
+}
+
+}  // namespace magda

--- a/magda/daw/ui/dialogs/AudioSettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AudioSettingsDialog.cpp
@@ -1,5 +1,6 @@
 #include "AudioSettingsDialog.hpp"
 
+#include "../../audio/AudioDriverUtils.hpp"
 #include "../../core/Config.hpp"
 #include "../themes/DarkTheme.hpp"
 #include "../themes/DialogLookAndFeel.hpp"
@@ -484,19 +485,12 @@ void AudioSettingsDialog::populateDeviceLists() {
     inputDeviceComboBox_.clear();
     outputDeviceComboBox_.clear();
 
-    // List devices from the ACTIVE driver type, not getAvailableDeviceTypes()[0].
-    // On macOS there is only one type (CoreAudio) so the two are identical, but on
-    // Windows there are several (Windows Audio, DirectSound, ASIO). Using [0] meant
-    // the combos always listed Windows-Audio device names even when the user had
-    // selected a different driver in the AudioDeviceSelectorComponent, so applying
-    // a selection failed with "No such device".
-    auto* deviceType = deviceManager_->getCurrentDeviceTypeObject();
-    if (deviceType == nullptr) {
-        auto& deviceTypes = deviceManager_->getAvailableDeviceTypes();
-        if (deviceTypes.isEmpty())
-            return;
-        deviceType = deviceTypes[0];
-    }
+    // List devices from the ACTIVE driver type (see activeDeviceTypeFor): using
+    // getAvailableDeviceTypes()[0] listed the wrong driver's devices once a
+    // non-first driver was selected, failing with "No such device".
+    auto* deviceType = activeDeviceTypeFor(*deviceManager_);
+    if (deviceType == nullptr)
+        return;
     deviceType->scanForDevices();
 
     auto inputDevices = deviceType->getDeviceNames(true);    // Get input devices

--- a/magda/daw/ui/dialogs/AudioSettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AudioSettingsDialog.cpp
@@ -368,6 +368,10 @@ AudioSettingsDialog::AudioSettingsDialog(juce::AudioDeviceManager* deviceManager
     );
     addAndMakeVisible(*deviceSelector_);
 
+    // Refresh the device combos whenever the driver type / device changes via the
+    // selector above, so they keep listing devices for the active driver.
+    deviceManager_->addChangeListener(this);
+
     // Create custom channel selectors for inputs and outputs
     inputChannelSelector_ =
         std::make_unique<CustomChannelSelector>(deviceManager, true, teDeviceManager);
@@ -405,7 +409,24 @@ AudioSettingsDialog::AudioSettingsDialog(juce::AudioDeviceManager* deviceManager
 }
 
 AudioSettingsDialog::~AudioSettingsDialog() {
+    deviceManager_->removeChangeListener(this);
     setLookAndFeel(nullptr);
+}
+
+void AudioSettingsDialog::changeListenerCallback(juce::ChangeBroadcaster* source) {
+    if (source != deviceManager_)
+        return;
+
+    // The active driver / device may have changed (e.g. user switched to ASIO in
+    // the selector). Re-list the combos against the now-current driver type.
+    populateDeviceLists();
+
+    if (auto* device = deviceManager_->getCurrentAudioDevice()) {
+        juce::String labelText = "Current Device: " + device->getName();
+        labelText += " (" + juce::String(device->getInputChannelNames().size()) + " in, ";
+        labelText += juce::String(device->getOutputChannelNames().size()) + " out)";
+        deviceNameLabel_.setText(labelText, juce::dontSendNotification);
+    }
 }
 
 void AudioSettingsDialog::paint(juce::Graphics& g) {
@@ -463,12 +484,19 @@ void AudioSettingsDialog::populateDeviceLists() {
     inputDeviceComboBox_.clear();
     outputDeviceComboBox_.clear();
 
-    auto& deviceTypes = deviceManager_->getAvailableDeviceTypes();
-    if (deviceTypes.isEmpty())
-        return;
-
-    // Get first device type (CoreAudio on macOS)
-    auto* deviceType = deviceTypes[0];
+    // List devices from the ACTIVE driver type, not getAvailableDeviceTypes()[0].
+    // On macOS there is only one type (CoreAudio) so the two are identical, but on
+    // Windows there are several (Windows Audio, DirectSound, ASIO). Using [0] meant
+    // the combos always listed Windows-Audio device names even when the user had
+    // selected a different driver in the AudioDeviceSelectorComponent, so applying
+    // a selection failed with "No such device".
+    auto* deviceType = deviceManager_->getCurrentDeviceTypeObject();
+    if (deviceType == nullptr) {
+        auto& deviceTypes = deviceManager_->getAvailableDeviceTypes();
+        if (deviceTypes.isEmpty())
+            return;
+        deviceType = deviceTypes[0];
+    }
     deviceType->scanForDevices();
 
     auto inputDevices = deviceType->getDeviceNames(true);    // Get input devices

--- a/magda/daw/ui/dialogs/AudioSettingsDialog.hpp
+++ b/magda/daw/ui/dialogs/AudioSettingsDialog.hpp
@@ -48,7 +48,7 @@ class CustomChannelSelector : public juce::Component {
  * Dialog for configuring audio and MIDI device settings.
  * Uses custom channel selectors for fine-grained control.
  */
-class AudioSettingsDialog : public juce::Component {
+class AudioSettingsDialog : public juce::Component, private juce::ChangeListener {
   public:
     explicit AudioSettingsDialog(juce::AudioDeviceManager* deviceManager,
                                  tracktion::DeviceManager* teDeviceManager = nullptr);
@@ -56,6 +56,10 @@ class AudioSettingsDialog : public juce::Component {
 
     void resized() override;
     void paint(juce::Graphics& g) override;
+
+    // Re-list the device combos when the driver type or device changes (e.g. the
+    // user picks a different driver in the AudioDeviceSelectorComponent).
+    void changeListenerCallback(juce::ChangeBroadcaster* source) override;
 
     // Static method to show as modal dialog
     static void showDialog(juce::Component* parent, juce::AudioDeviceManager* deviceManager,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -242,6 +242,7 @@ target_sources(magda_juce_tests PRIVATE
     test_arrangement_transport_loop_juce.cpp
     test_external_plugin_state_restore_juce.cpp
     test_chord_progression_converter_juce.cpp
+    test_audio_driver_type_selection_juce.cpp
     ../magda/daw/ui/components/chain/slot/StepSequencerClipExport.cpp
 )
 

--- a/tests/test_audio_driver_type_selection_juce.cpp
+++ b/tests/test_audio_driver_type_selection_juce.cpp
@@ -1,0 +1,89 @@
+#include <juce_audio_devices/juce_audio_devices.h>
+
+#include "magda/daw/audio/AudioDriverUtils.hpp"
+
+namespace {
+
+/**
+ * Minimal AudioIODeviceType that reports a fixed set of device names. No real
+ * hardware is touched: createDevice returns nullptr (the tests never open a
+ * device), they only ask which type / which names get listed.
+ */
+class FakeDeviceType final : public juce::AudioIODeviceType {
+  public:
+    FakeDeviceType(const juce::String& typeName, juce::StringArray inputs,
+                   juce::StringArray outputs)
+        : juce::AudioIODeviceType(typeName),
+          inputs_(std::move(inputs)),
+          outputs_(std::move(outputs)) {}
+
+    void scanForDevices() override {}
+    juce::StringArray getDeviceNames(bool wantInputNames = false) const override {
+        return wantInputNames ? inputs_ : outputs_;
+    }
+    int getDefaultDeviceIndex(bool) const override {
+        return 0;
+    }
+    int getIndexOfDevice(juce::AudioIODevice*, bool) const override {
+        return -1;
+    }
+    bool hasSeparateInputsAndOutputs() const override {
+        return true;
+    }
+    juce::AudioIODevice* createDevice(const juce::String&, const juce::String&) override {
+        return nullptr;
+    }
+
+  private:
+    juce::StringArray inputs_, outputs_;
+};
+
+/** AudioDeviceManager seeded with two fake driver types: "FakeA" then "FakeB". */
+class TwoTypeDeviceManager final : public juce::AudioDeviceManager {
+  protected:
+    void createAudioDeviceTypes(juce::OwnedArray<juce::AudioIODeviceType>& list) override {
+        list.add(new FakeDeviceType("FakeA", {"A-in"}, {"A-out"}));
+        list.add(new FakeDeviceType("FakeB", {"B-in"}, {"B-out"}));
+    }
+};
+
+}  // namespace
+
+class AudioDriverTypeSelectionTest final : public juce::UnitTest {
+  public:
+    AudioDriverTypeSelectionTest() : juce::UnitTest("Audio Driver Type Selection", "magda") {}
+
+    void runTest() override {
+        beginTest("lists the ACTIVE driver, not the first available one");
+        {
+            // Regression guard for the "No such device" bug: the device list was
+            // taken from getAvailableDeviceTypes()[0] (FakeA) regardless of which
+            // driver was actually active.
+            TwoTypeDeviceManager dm;
+            auto& types = dm.getAvailableDeviceTypes();
+            expectEquals(types.size(), 2);
+
+            dm.setCurrentAudioDeviceType("FakeB", true);
+
+            auto* chosen = magda::activeDeviceTypeFor(dm);
+            expect(chosen != nullptr, "expected a resolved device type");
+            expectEquals(chosen->getTypeName(), juce::String("FakeB"));
+            expectEquals(chosen->getDeviceNames(true)[0], juce::String("B-in"));
+            expectEquals(chosen->getDeviceNames(false)[0], juce::String("B-out"));
+        }
+
+        beginTest("falls back to the first type when none is active");
+        {
+            // getCurrentDeviceTypeObject() returns null before any driver is
+            // chosen; the helper should then pick the first available type.
+            TwoTypeDeviceManager dm;
+            expectEquals(dm.getAvailableDeviceTypes().size(), 2);
+
+            auto* chosen = magda::activeDeviceTypeFor(dm);
+            expect(chosen != nullptr, "expected a fallback device type");
+            expectEquals(chosen->getTypeName(), juce::String("FakeA"));
+        }
+    }
+};
+
+static AudioDriverTypeSelectionTest audioDriverTypeSelectionTest;


### PR DESCRIPTION
On Windows there are multiple audio driver types (Windows Audio, DirectSound, ASIO). The input/output device combos were always listing devices from the first available type, so once a different driver was selected, applying a device failed with 'No such device'. List from the current driver type instead, and refresh the combos when the driver changes. No effect on macOS (single driver type).