### PR TITLE
Fix M_PI undeclared identifier on MSVC with prebuilt Mutable artifact

### DIFF
--- a/third_party/mutable-prebuilt/CMakeLists.txt
+++ b/third_party/mutable-prebuilt/CMakeLists.txt
@@ -7,7 +7,13 @@
 # Headers come straight from third_party/eurorack (the submodule checkout),
 # not from the artifact. TEST must stay on the interface: consumers include
 # Mutable Instruments headers directly and need the same portable
-# (non-Cortex-M4) code path the static lib itself was built with.
+# (non-Cortex-M4) code path the static lib itself was built with. Same
+# reasoning for _USE_MATH_DEFINES on MSVC: stmlib's filter.h/cosine_oscillator.h
+# use M_PI, which <cmath> only defines on MSVC when this macro is set before
+# the include - without it here, consumers that include these headers
+# directly fail with "M_PI: undeclared identifier" (the top-level
+# CMakeLists.txt's source-build branch sets this PUBLIC on magda_mutable
+# for the same reason).
 
 if(WIN32)
     set(_mutable_lib "${MAGDA_MUTABLE_PREBUILT_DIR}/lib/magda_mutable.lib")
@@ -23,6 +29,9 @@ add_library(magda_mutable STATIC IMPORTED GLOBAL)
 set_target_properties(magda_mutable PROPERTIES IMPORTED_LOCATION "${_mutable_lib}")
 target_include_directories(magda_mutable INTERFACE "${CMAKE_SOURCE_DIR}/third_party/eurorack")
 target_compile_definitions(magda_mutable INTERFACE TEST)
+if(MSVC)
+    target_compile_definitions(magda_mutable INTERFACE _USE_MATH_DEFINES)
+endif()
 add_library(magda::mutable ALIAS magda_mutable)
 
 unset(_mutable_lib)


### PR DESCRIPTION
## Summary
- Follow-up to #1672: the Windows CI job started failing once it actually exercised the cached/prebuilt Mutable path (`Build (Debug)` step), with `M_PI: undeclared identifier` in `third_party/eurorack/stmlib/dsp/filter.h` and `cosine_oscillator.h`.
- `third_party/mutable-prebuilt/CMakeLists.txt` carried over the `TEST` interface define needed by consumers that include Mutable Instruments headers directly, but missed `_USE_MATH_DEFINES` - MSVC only exposes `M_PI` from `<cmath>` when that macro is defined first. The source-build fallback already sets it `PUBLIC` on `magda_mutable` for the same reason; the IMPORTED-target wrapper needs to match.
- Only surfaced once CI exercised the prebuilt path on Windows - macOS/Linux don't need the macro, so local validation there didn't catch it.

## Test plan
- [x] Verified locally on macOS (configure + build `magda_daw` against the prebuilt Faust/Mutable dirs) - unaffected there since `_USE_MATH_DEFINES` is MSVC-only, confirms no regression.
- [ ] Watch the Windows CI job on this PR to confirm the fix.