### PR TITLE
Fix MIDI input monitoring gated on selection instead of monitor state

### DIFF
--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -107,7 +107,7 @@ AudioBridge::AudioBridge(te::Engine& engine, te::Edit& edit)
 
     // Re-establish MIDI routing and input monitor state after graph reallocate
     clipSynchronizer_.onGraphReallocated = [this]() {
-        updateMidiRoutingForSelection();
+        updateMidiInputRouting();
         resyncAllInputMonitors();
     };
 
@@ -333,7 +333,7 @@ void AudioBridge::trackPropertyChanged(int trackId) {
 
             // Update MIDI routing when record arm changes
             // (armed tracks should receive MIDI even when not selected)
-            updateMidiRoutingForSelection();
+            updateMidiInputRouting();
 
             syncRecordArmedToTE(trackId);
         }
@@ -345,11 +345,11 @@ void AudioBridge::trackPropertyChanged(int trackId) {
 
 void AudioBridge::trackSelectionChanged(TrackId newTrackId) {
     juce::ignoreUnused(newTrackId);
-    updateMidiRoutingForSelection();
+    updateMidiInputRouting();
 }
 
-void AudioBridge::updateMidiRoutingForSelection() {
-    midiInputRouter_.updateForSelection();
+void AudioBridge::updateMidiInputRouting() {
+    midiInputRouter_.updateMidiInputRouting();
 }
 
 void AudioBridge::resyncAllInputMonitors() {
@@ -416,7 +416,7 @@ void AudioBridge::deviceModifiersChanged(TrackId trackId) {
     MAGDA_ADSR_AUDIO_LOG("follower-bridge monitor-refresh-done trackId=" << trackId);
 
     // Re-check MIDI routing in case trigger mode changed to/from MIDI
-    updateMidiRoutingForSelection();
+    updateMidiInputRouting();
     MAGDA_ADSR_AUDIO_LOG("follower-bridge midi-refresh-done trackId=" << trackId);
 }
 
@@ -903,7 +903,7 @@ void AudioBridge::syncAll() {
 
 void AudioBridge::syncTrackPlugins(TrackId trackId) {
     pluginManager_.syncTrackPlugins(trackId);
-    updateMidiRoutingForSelection();
+    updateMidiInputRouting();
 }
 
 void AudioBridge::ensureTrackMapping(TrackId trackId) {

--- a/magda/daw/audio/AudioBridge.hpp
+++ b/magda/daw/audio/AudioBridge.hpp
@@ -882,7 +882,7 @@ class AudioBridge : public TrackManagerListener, public ClipManagerListener, pub
     mutable juce::CriticalSection
         mappingLock_;  // Protects mapping updates (mutable for const getters)
 
-    void updateMidiRoutingForSelection();
+    void updateMidiInputRouting();
     void resyncAllInputMonitors();
 
     void applyPendingMidiRoutes();

--- a/magda/daw/audio/midi/MidiInputRouter.cpp
+++ b/magda/daw/audio/midi/MidiInputRouter.cpp
@@ -1,8 +1,8 @@
 #include "midi/MidiInputRouter.hpp"
 
 #include <functional>
+#include <unordered_set>
 
-#include "../../core/ClipManager.hpp"
 #include "../../core/RackInfo.hpp"
 #include "../../core/TrackManager.hpp"
 #include "TrackController.hpp"
@@ -397,7 +397,7 @@ void MidiInputRouter::setSurfaceOnlyMidiInputPort(const juce::String& midiDevice
     }
 
     removeSurfaceOnlyMidiInputTargets();
-    updateForSelection();
+    updateMidiInputRouting();
 }
 
 void MidiInputRouter::clearSurfaceOnlyMidiInputPorts() {
@@ -406,7 +406,7 @@ void MidiInputRouter::clearSurfaceOnlyMidiInputPorts() {
         surfaceOnlyMidiInputPorts_.clear();
     }
 
-    updateForSelection();
+    updateMidiInputRouting();
 }
 
 juce::String MidiInputRouter::getTrackMidiInput(TrackId trackId) const {
@@ -437,31 +437,33 @@ juce::String MidiInputRouter::getTrackMidiInput(TrackId trackId) const {
     return "all";
 }
 
-void MidiInputRouter::updateForSelection() {
+void MidiInputRouter::updateMidiInputRouting() {
     auto& tm = TrackManager::getInstance();
-    auto selectedTrackId = tm.getSelectedTrack();
 
-    TrackId midiTrackId = selectedTrackId;
-    if (midiTrackId != INVALID_TRACK_ID) {
-        const auto* selectedTrack = tm.getTrack(midiTrackId);
-        if (selectedTrack && selectedTrack->type == TrackType::MultiOut &&
-            selectedTrack->hasParent()) {
-            midiTrackId = selectedTrack->parentId;
-        }
-    }
-    if (midiTrackId == INVALID_TRACK_ID) {
-        auto selectedClipId = ClipManager::getInstance().getSelectedClip();
-        if (selectedClipId != INVALID_CLIP_ID) {
-            if (auto* clip = ClipManager::getInstance().getClip(selectedClipId))
-                midiTrackId = clip->trackId;
-        }
+    // A track receives live MIDI input purely from its own input-monitor state
+    // (In/Auto) or because it is record-armed. Selection does NOT gate this: a
+    // monitored track keeps listening whether or not it is the selected track.
+    // MultiOut child tracks forward their MIDI to the parent that hosts the
+    // instrument, so their want is expressed against the parent id.
+    std::unordered_set<TrackId> midiTargets;
+    for (const auto& track : tm.getTracks()) {
+        if (track.type == TrackType::Aux)
+            continue;
+
+        if (!track.receivesLiveMidiInput())
+            continue;
+
+        TrackId target = track.id;
+        if (track.type == TrackType::MultiOut && track.hasParent())
+            target = track.parentId;
+        midiTargets.insert(target);
     }
 
     for (const auto& track : tm.getTracks()) {
         if (track.type == TrackType::Aux)
             continue;
 
-        bool shouldReceiveMidi = (track.id == midiTrackId) || track.recordArmed;
+        bool shouldReceiveMidi = midiTargets.count(track.id) > 0;
 
         std::function<bool(const std::vector<ChainElement>&)> checkElements;
         checkElements = [&](const std::vector<ChainElement>& elements) -> bool {
@@ -588,7 +590,7 @@ void MidiInputRouter::handlePlaybackContextTick() {
     if (currentContext != lastPlaybackContext_) {
         lastPlaybackContext_ = currentContext;
         if (currentContext != nullptr)
-            updateForSelection();
+            updateMidiInputRouting();
     }
 }
 

--- a/magda/daw/audio/midi/MidiInputRouter.hpp
+++ b/magda/daw/audio/midi/MidiInputRouter.hpp
@@ -27,7 +27,7 @@ class MidiInputRouter {
     void setSurfaceOnlyMidiInputPort(const juce::String& midiDeviceIdOrName);
     void clearSurfaceOnlyMidiInputPorts();
 
-    void updateForSelection();
+    void updateMidiInputRouting();
     void resyncAllInputMonitors();
     void onMidiDevicesAvailable();
     void applyPendingRoutes();

--- a/magda/daw/core/TrackInfo.hpp
+++ b/magda/daw/core/TrackInfo.hpp
@@ -224,6 +224,16 @@ struct TrackInfo {
         return parentId == INVALID_TRACK_ID;
     }
 
+    // MIDI input helpers
+    //
+    // Single source of truth for "does this track listen to live MIDI input".
+    // Gated purely on the track's own monitor/arm state - NOT on selection - so
+    // the TE routing (MidiInputRouter) and the UI activity light agree. A track
+    // listens when input monitoring is enabled (In/Auto) or it is record-armed.
+    bool receivesLiveMidiInput() const {
+        return inputMonitor != InputMonitorMode::Off || recordArmed;
+    }
+
     // View settings helpers
     bool isVisibleIn(ViewMode mode) const {
         return viewSettings.isVisible(mode);

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -352,7 +352,7 @@ TrackId TrackManager::createTrack(const juce::String& name, TrackType type) {
             midiBridge->startMonitoring(trackId);
         }
         // Don't auto-route MIDI at the TE level for every new track.
-        // AudioBridge::updateMidiRoutingForSelection() will handle this
+        // AudioBridge::updateMidiInputRouting() will handle this
         // based on whether the track is selected or record-armed.
     }
 
@@ -1386,7 +1386,7 @@ void TrackManager::setAudioEngine(AudioEngine* audioEngine) {
 
     // Sync existing tracks' MIDI routing (in case tracks were created before engine was set)
     // Only set up MidiBridge monitoring; TE-level MIDI routing is handled by
-    // AudioBridge::updateMidiRoutingForSelection() based on selection/arm state.
+    // AudioBridge::updateMidiInputRouting() based on selection/arm state.
     if (audioEngine_) {
         for (const auto& track : tracks_) {
             if (!track.midiInputDevice.isEmpty() && track.type != TrackType::Aux) {

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -545,14 +545,12 @@ void TrackHeadersPanel::timerCallback() {
         if (counter != header->lastMidiCounter) {
             header->lastMidiCounter = counter;
 
-            // Only show activity when monitoring is active AND the track
-            // is actually receiving MIDI (selected or record-armed)
+            // Only show activity when the track is actually receiving MIDI.
+            // Same predicate as the TE-level routing (MidiInputRouter): monitor
+            // enabled or record-armed - never gated on selection.
             bool showActivity = false;
             if (auto* trackInfo = TrackManager::getInstance().getTrack(header->trackId)) {
-                bool receivingMidi =
-                    trackInfo->recordArmed ||
-                    SelectionManager::getInstance().getSelectedTrack() == header->trackId;
-                if (receivingMidi) {
+                if (trackInfo->receivesLiveMidiInput()) {
                     switch (trackInfo->inputMonitor) {
                         case InputMonitorMode::In:
                             showActivity = true;


### PR DESCRIPTION
A track only listened to live MIDI (and only blinked its activity light) while it was the selected track. Monitoring should follow the track's own input-monitor state, independent of selection.

The 'does this track receive live MIDI' decision was computed in two places with different rules: MidiInputRouter's TE-level routing and the TrackHeadersPanel activity light. Unify them behind a single predicate TrackInfo::receivesLiveMidiInput() (inputMonitor != Off || recordArmed) and drop the selection checks from both. Rename updateForSelection -> updateMidiInputRouting to match the new gating.