### PR TITLE
Arrangement time-range editing: Range Editing menus + tempo/pitch ripple

### DIFF
--- a/magda/daw/core/AutomationCommands.cpp
+++ b/magda/daw/core/AutomationCommands.cpp
@@ -259,6 +259,9 @@ bool DuplicateAutomationTimeSelectionCommand::shouldDuplicateLane(
     const AutomationLaneInfo& lane) const {
     if (!lane.visible || !lane.isAbsolute())
         return false;
+    // Tempo is rippled directly on edit.tempoSequence (see TempoSequenceRippleCommand).
+    if (lane.target.kind == ControlTarget::Kind::Tempo)
+        return false;
     if (!laneIds_.empty()) {
         return std::find(laneIds_.begin(), laneIds_.end(), lane.id) != laneIds_.end();
     }
@@ -342,6 +345,10 @@ void DuplicateAutomationTimeSelectionCommand::undo() {
 
 bool InsertTimeAutomationCommand::shouldShiftLane(const AutomationLaneInfo& lane) const {
     if (!lane.visible || !lane.isAbsolute())
+        return false;
+    // The Tempo lane mirrors edit.tempoSequence, which is rippled directly by
+    // TempoSequenceRippleCommand. Shifting it here too would double the ripple.
+    if (lane.target.kind == ControlTarget::Kind::Tempo)
         return false;
     if (!laneIds_.empty()) {
         return std::find(laneIds_.begin(), laneIds_.end(), lane.id) != laneIds_.end();

--- a/magda/daw/engine/CMakeLists.txt
+++ b/magda/daw/engine/CMakeLists.txt
@@ -5,6 +5,7 @@
 target_sources(magda_daw PRIVATE
     TempoLaneBridge.cpp
     TempoLaneSync.cpp
+    TempoSequenceRippleCommand.cpp
     OfflineRenderHelper.cpp
     TracktionEngineWrapper.cpp
     TracktionEngineWrapperInit.cpp

--- a/magda/daw/engine/TempoSequenceRippleCommand.cpp
+++ b/magda/daw/engine/TempoSequenceRippleCommand.cpp
@@ -1,0 +1,117 @@
+#include "TempoSequenceRippleCommand.hpp"
+
+namespace magda {
+
+namespace te = tracktion;
+
+TempoSequenceRippleCommand::TempoSequenceRippleCommand(te::Edit& edit, Mode mode, double startBeat,
+                                                       double endBeat)
+    : edit_(edit), mode_(mode), startBeat_(startBeat), endBeat_(endBeat) {}
+
+TempoSequenceRippleCommand::Snapshot TempoSequenceRippleCommand::readSequences() const {
+    Snapshot s;
+    auto& ts = edit_.tempoSequence;
+
+    for (int i = 0; i < ts.getNumTempos(); ++i)
+        if (auto* t = ts.getTempo(i))
+            s.tempos.push_back({t->getStartBeat().inBeats(), t->getBpm(), t->getCurve()});
+
+    for (int i = 0; i < ts.getNumTimeSigs(); ++i)
+        if (auto* t = ts.getTimeSig(i))
+            s.timeSigs.push_back({t->getStartBeat().inBeats(), t->numerator.get(),
+                                  t->denominator.get(), t->triplets.get()});
+
+    auto& ps = edit_.pitchSequence;
+    for (int i = 0; i < ps.getNumPitches(); ++i)
+        if (auto* p = ps.getPitch(i))
+            s.pitches.push_back({p->getStartBeatNumber().inBeats(), p->getPitch()});
+
+    return s;
+}
+
+TempoSequenceRippleCommand::Snapshot TempoSequenceRippleCommand::rippled(const Snapshot& in) const {
+    Snapshot out;
+    out.tempos = temporipple::rippleEvents(in.tempos, mode_, startBeat_, endBeat_);
+    out.timeSigs = temporipple::rippleEvents(in.timeSigs, mode_, startBeat_, endBeat_);
+    out.pitches = temporipple::rippleEvents(in.pitches, mode_, startBeat_, endBeat_);
+    return out;
+}
+
+void TempoSequenceRippleCommand::applySequences(const Snapshot& s) {
+    auto& ts = edit_.tempoSequence;
+    auto& ps = edit_.pitchSequence;
+
+    // Clips and automation are beat-native (Clip::syncType == syncBarsBeats):
+    // TE only re-anchors them across a tempo change when the change runs through
+    // its remapper. The mutators below pass remapEdit=false, so snapshot every
+    // clip/automation beat up front and remap once after the rebuild. Without
+    // it, clips stay pinned to stale wall-clock seconds and drift off the grid.
+    te::EditTimecodeRemapperSnapshot snap;
+    snap.savePreChangeState(edit_);
+
+    // --- Tempo settings (rebuild in place; keep the beat-0 anchor) ---
+    for (int i = ts.getNumTempos() - 1; i >= 1; --i)
+        ts.removeTempo(i, false);
+    if (!s.tempos.empty()) {
+        if (auto* t0 = ts.getTempo(0))
+            t0->set(te::BeatPosition(), s.tempos[0].bpm, s.tempos[0].curve, false);
+        for (size_t i = 1; i < s.tempos.size(); ++i)
+            ts.insertTempo(te::BeatPosition::fromBeats(s.tempos[i].beat), s.tempos[i].bpm,
+                           s.tempos[i].curve);
+    }
+
+    // --- Time signatures ---
+    for (int i = ts.getNumTimeSigs() - 1; i >= 1; --i)
+        ts.removeTimeSig(i);
+    if (!s.timeSigs.empty()) {
+        if (auto* g0 = ts.getTimeSig(0)) {
+            g0->startBeatNumber = te::BeatPosition();
+            g0->numerator = s.timeSigs[0].numerator;
+            g0->denominator = s.timeSigs[0].denominator;
+            g0->triplets = s.timeSigs[0].triplets;
+        }
+        for (size_t i = 1; i < s.timeSigs.size(); ++i) {
+            if (auto g = ts.insertTimeSig(te::BeatPosition::fromBeats(s.timeSigs[i].beat))) {
+                g->numerator = s.timeSigs[i].numerator;
+                g->denominator = s.timeSigs[i].denominator;
+                g->triplets = s.timeSigs[i].triplets;
+            }
+        }
+    }
+
+    // --- Pitch settings (clear() leaves a single default pitch at beat 0) ---
+    ps.clear();
+    if (!s.pitches.empty()) {
+        if (auto* p0 = ps.getPitch(0)) {
+            p0->setStartBeat(te::BeatPosition());
+            p0->setPitch(s.pitches[0].pitch);
+        }
+        for (size_t i = 1; i < s.pitches.size(); ++i)
+            ps.insertPitch(te::BeatPosition::fromBeats(s.pitches[i].beat), s.pitches[i].pitch);
+    }
+
+    // Reposition every clip / automation point to its saved bar/beat under the
+    // new tempo map. This is what makes clips follow the rippled tempo.
+    snap.remapEdit(edit_);
+}
+
+void TempoSequenceRippleCommand::execute() {
+    before_ = readSequences();
+    const Snapshot after = rippled(before_);
+    changed_ = !(temporipple::sameBeats(before_.tempos, after.tempos) &&
+                 temporipple::sameBeats(before_.timeSigs, after.timeSigs) &&
+                 temporipple::sameBeats(before_.pitches, after.pitches));
+    if (changed_)
+        applySequences(after);
+}
+
+void TempoSequenceRippleCommand::undo() {
+    if (changed_)
+        applySequences(before_);
+}
+
+juce::String TempoSequenceRippleCommand::getDescription() const {
+    return "Ripple Tempo Sequence";
+}
+
+}  // namespace magda

--- a/magda/daw/engine/TempoSequenceRippleCommand.hpp
+++ b/magda/daw/engine/TempoSequenceRippleCommand.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <tracktion_engine/tracktion_engine.h>
+
+#include <vector>
+
+#include "../core/UndoManager.hpp"
+#include "TempoSequenceRippleMath.hpp"
+
+namespace magda {
+
+/**
+ * @brief Ripples the global tempo, time-signature and pitch sequences alongside
+ *        a time-range clip edit.
+ *
+ * Tempo / time-sig / pitch are edit-wide (not per-track), so this runs only for
+ * all-tracks (global) ops and loop ops, mirroring RippleMarkersCommand. It sits
+ * alongside the clip/automation/marker ripple commands in the same compound
+ * operation.
+ *
+ * All shifting is beats-domain. Because moving a tempo event changes the
+ * beats<->seconds map, every apply is wrapped in EditTimecodeRemapperSnapshot
+ * (save before / remap after) so beat-anchored clips and automation keep their
+ * bar/beat position under the new map instead of drifting off the grid. This is
+ * the same pattern TempoLaneBridge uses when it rewrites the sequence.
+ *
+ * IMPORTANT: must run AFTER the clip-shifting commands in the compound op, so
+ * the remapper snapshot sees clips at their final beats.
+ */
+class TempoSequenceRippleCommand : public UndoableCommand {
+  public:
+    using Mode = temporipple::Mode;  // Insert / Delete / Duplicate
+
+    TempoSequenceRippleCommand(tracktion::Edit& edit, Mode mode, double startBeat, double endBeat);
+
+    void execute() override;
+    void undo() override;
+    juce::String getDescription() const override;
+
+  private:
+    struct TempoEvent {
+        double beat;
+        double bpm;
+        float curve;
+    };
+    struct TimeSigEvent {
+        double beat;
+        int numerator;
+        int denominator;
+        bool triplets;
+    };
+    struct PitchEvent {
+        double beat;
+        int pitch;
+    };
+    struct Snapshot {
+        std::vector<TempoEvent> tempos;
+        std::vector<TimeSigEvent> timeSigs;
+        std::vector<PitchEvent> pitches;
+    };
+
+    Snapshot readSequences() const;
+    Snapshot rippled(const Snapshot&) const;
+    void applySequences(const Snapshot&);
+
+    tracktion::Edit& edit_;
+    Mode mode_;
+    double startBeat_;
+    double endBeat_;
+
+    Snapshot before_;       // pre-change state, captured on execute for undo/redo
+    bool changed_ = false;  // false = no-op (nothing to ripple), skip apply/undo
+};
+
+}  // namespace magda

--- a/magda/daw/engine/TempoSequenceRippleMath.hpp
+++ b/magda/daw/engine/TempoSequenceRippleMath.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+// Pure, engine-free beats-domain ripple math for the tempo / time-sig / pitch
+// sequences. Kept free of Tracktion Engine so it can be unit-tested in the fast
+// CLI (Catch2) target; TempoSequenceRippleCommand applies the result to a real
+// te::Edit (which the JUCE test target covers).
+namespace magda::temporipple {
+
+enum class Mode {
+    Insert,     // open a gap [start,end): shift events >= start right by the length
+    Delete,     // close [start,end): drop events inside, shift events >= end left
+    Duplicate,  // open a gap at end, then copy events in [start,end) into it
+};
+
+constexpr double kBeatEps = 1.0e-6;
+
+// Ripple one sequence's events. `T` is any struct with a public `double beat`
+// member (plus whatever payload it carries). Index 0 is the beat-0 anchor that
+// TE always keeps; it never moves and is never dropped or duplicated.
+template <typename T>
+std::vector<T> rippleEvents(const std::vector<T>& in, Mode mode, double startBeat, double endBeat) {
+    const double dur = endBeat - startBeat;
+    std::vector<T> out;
+    out.reserve(in.size());
+
+    for (std::size_t i = 0; i < in.size(); ++i) {
+        T e = in[i];
+        const bool anchor = (i == 0);
+
+        switch (mode) {
+            case Mode::Insert:
+                if (!anchor && e.beat >= startBeat - kBeatEps)
+                    e.beat += dur;
+                out.push_back(e);
+                break;
+
+            case Mode::Delete:
+                if (anchor) {
+                    out.push_back(e);
+                    break;
+                }
+                if (e.beat >= startBeat - kBeatEps && e.beat < endBeat - kBeatEps)
+                    break;  // inside the deleted range -> drop
+                if (e.beat >= endBeat - kBeatEps)
+                    e.beat -= dur;
+                out.push_back(e);
+                break;
+
+            case Mode::Duplicate:
+                // Open a gap at endBeat (everything after it slides right).
+                if (!anchor && e.beat >= endBeat - kBeatEps)
+                    e.beat += dur;
+                out.push_back(e);
+                break;
+        }
+    }
+
+    // Duplicate: copy the events inside [start,end) into the freshly opened gap.
+    if (mode == Mode::Duplicate) {
+        for (std::size_t i = 1; i < in.size(); ++i) {  // never duplicate the anchor
+            const T& e = in[i];
+            if (e.beat >= startBeat - kBeatEps && e.beat < endBeat - kBeatEps) {
+                T copy = e;
+                copy.beat = e.beat + dur;
+                out.push_back(copy);
+            }
+        }
+    }
+
+    std::sort(out.begin(), out.end(), [](const T& a, const T& b) { return a.beat < b.beat; });
+    return out;
+}
+
+// Compare two event lists. Ripple never changes an event's payload, only its
+// beat position and set membership, so size + beats settle equality.
+template <typename T> bool sameBeats(const std::vector<T>& a, const std::vector<T>& b) {
+    if (a.size() != b.size())
+        return false;
+    for (std::size_t i = 0; i < a.size(); ++i)
+        if (std::abs(a[i].beat - b[i].beat) > kBeatEps)
+            return false;
+    return true;
+}
+
+}  // namespace magda::temporipple

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -3330,6 +3330,20 @@ void ClipComponent::showContextMenu() {
         menu.addItem(31, "Duplicate Time Range", hasTimeSelection);
         menu.addItem(32, "Duplicate Loop Range", hasLoop);
         menu.addItem(33, "Split All Tracks at Cursor", hasCursor);
+
+        // Range Editing submenu mirrors the Edit menu's Copy/Cut/Delete/Paste-Ripple set.
+        const bool hasClipboard = ClipManager::getInstance().hasClipsInClipboard();
+        juce::PopupMenu rangeMenu;
+        rangeMenu.addItem(34, "Copy Time Range", hasTimeSelection);
+        rangeMenu.addItem(35, "Cut Time Range", hasTimeSelection);
+        rangeMenu.addItem(36, "Delete Time Range", hasTimeSelection);
+        rangeMenu.addSeparator();
+        rangeMenu.addItem(37, "Copy Loop Range", hasLoop);
+        rangeMenu.addItem(38, "Cut Loop Range", hasLoop);
+        rangeMenu.addItem(39, "Delete Loop Range", hasLoop);
+        rangeMenu.addSeparator();
+        rangeMenu.addItem(40, "Paste (Ripple)", hasClipboard);
+        menu.addSubMenu("Range Editing", rangeMenu);
     }
 
     // Bounce operations (not for chord progressions)
@@ -3700,6 +3714,55 @@ void ClipComponent::showContextMenu() {
             case 33: {  // Split All Tracks at Cursor
                 if (onSplitAllTracksAtCursorRequested) {
                     onSplitAllTracksAtCursorRequested();
+                }
+                break;
+            }
+
+            case 34: {  // Copy Time Range
+                if (onCopyTimeRangeRequested) {
+                    onCopyTimeRangeRequested();
+                }
+                break;
+            }
+
+            case 35: {  // Cut Time Range
+                if (onCutTimeRangeRequested) {
+                    onCutTimeRangeRequested();
+                }
+                break;
+            }
+
+            case 36: {  // Delete Time Range
+                if (onDeleteTimeRangeRequested) {
+                    onDeleteTimeRangeRequested();
+                }
+                break;
+            }
+
+            case 37: {  // Copy Loop Range
+                if (onCopyLoopRangeRequested) {
+                    onCopyLoopRangeRequested();
+                }
+                break;
+            }
+
+            case 38: {  // Cut Loop Range
+                if (onCutLoopRangeRequested) {
+                    onCutLoopRangeRequested();
+                }
+                break;
+            }
+
+            case 39: {  // Delete Loop Range
+                if (onDeleteLoopRangeRequested) {
+                    onDeleteLoopRangeRequested();
+                }
+                break;
+            }
+
+            case 40: {  // Paste (Ripple)
+                if (onPasteRippleRequested) {
+                    onPasteRippleRequested();
                 }
                 break;
             }

--- a/magda/daw/ui/components/clips/ClipComponent.hpp
+++ b/magda/daw/ui/components/clips/ClipComponent.hpp
@@ -97,6 +97,13 @@ class ClipComponent : public juce::Component,
     std::function<void()> onDuplicateTimeRangeRequested;      // ripple-duplicate time range
     std::function<void()> onDuplicateLoopRangeRequested;      // ripple-duplicate the loop region
     std::function<void()> onSplitAllTracksAtCursorRequested;  // split all clips at edit cursor
+    std::function<void()> onCopyTimeRangeRequested;           // copy the time selection's content
+    std::function<void()> onCutTimeRangeRequested;     // copy time selection, then ripple-delete
+    std::function<void()> onDeleteTimeRangeRequested;  // ripple-delete the time selection
+    std::function<void()> onCopyLoopRangeRequested;    // copy the loop region (all tracks)
+    std::function<void()> onCutLoopRangeRequested;     // copy loop region, then ripple-delete
+    std::function<void()> onDeleteLoopRangeRequested;  // ripple-delete the loop region
+    std::function<void()> onPasteRippleRequested;      // ripple-insert clipboard span, then paste
     std::function<void(ClipId)> onBounceInPlaceRequested;  // bounce MIDI clip in place (synth only)
     std::function<void(ClipId)>
         onBounceToNewTrackRequested;               // bounce clip to new track (full chain)

--- a/magda/daw/ui/components/timeline/TimelineComponent.cpp
+++ b/magda/daw/ui/components/timeline/TimelineComponent.cpp
@@ -479,13 +479,13 @@ void TimelineComponent::mouseMove(const juce::MouseEvent& event) {
             }
         }
 
-        // Upper half: zoom (crosshair), Lower half: time selection (I-beam)
-        int rulerMidpoint = layout.getRulerZoneSplitY();
-
-        if (event.y < rulerMidpoint) {
-            setMouseCursor(CursorManager::getInstance().getZoomCursor());
-        } else {
+        // The bottom playhead row is the time-selection zone; everything above it
+        // zooms. Use the SAME boundary as mouseDown (rows.playheadTop) so the
+        // I-beam never appears over an area where a drag actually zooms.
+        if (event.y >= rows.playheadTop) {
             setMouseCursor(juce::MouseCursor::IBeamCursor);
+        } else {
+            setMouseCursor(CursorManager::getInstance().getZoomCursor());
         }
     }
 }

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -2010,6 +2010,20 @@ void TrackContentPanel::showEmptySpaceContextMenu(const juce::MouseEvent& event)
     menu.addItem(8, "Insert Time", !isFrozen && hasTimeSelection);
     menu.addItem(9, "Duplicate Time Range", !isFrozen && hasTimeSelection);
     menu.addItem(10, "Duplicate Loop Range", !isFrozen && hasLoop);
+
+    // Range Editing submenu mirrors the Edit menu's Copy/Cut/Delete/Paste-Ripple set.
+    juce::PopupMenu rangeMenu;
+    rangeMenu.addItem(12, "Copy Time Range", hasTimeSelection);
+    rangeMenu.addItem(13, "Cut Time Range", !isFrozen && hasTimeSelection);
+    rangeMenu.addItem(14, "Delete Time Range", !isFrozen && hasTimeSelection);
+    rangeMenu.addSeparator();
+    rangeMenu.addItem(15, "Copy Loop Range", hasLoop);
+    rangeMenu.addItem(16, "Cut Loop Range", !isFrozen && hasLoop);
+    rangeMenu.addItem(17, "Delete Loop Range", !isFrozen && hasLoop);
+    rangeMenu.addSeparator();
+    rangeMenu.addItem(18, "Paste (Ripple)", !isFrozen && hasClipboard);
+    menu.addSubMenu("Range Editing", rangeMenu);
+
     menu.addSeparator();
     menu.addItem(11, "Split All Tracks at Cursor", !isFrozen && hasCursor);
     menu.addItem(3, "Select All");
@@ -2113,6 +2127,34 @@ void TrackContentPanel::showEmptySpaceContextMenu(const juce::MouseEvent& event)
             case 11:  // Split All Tracks at Cursor
                 if (safeThis && safeThis->onSplitAllTracksAtCursorRequested)
                     safeThis->onSplitAllTracksAtCursorRequested();
+                break;
+            case 12:  // Copy Time Range
+                if (safeThis && safeThis->onCopyTimeRangeRequested)
+                    safeThis->onCopyTimeRangeRequested();
+                break;
+            case 13:  // Cut Time Range
+                if (safeThis && safeThis->onCutTimeRangeRequested)
+                    safeThis->onCutTimeRangeRequested();
+                break;
+            case 14:  // Delete Time Range
+                if (safeThis && safeThis->onDeleteTimeRangeRequested)
+                    safeThis->onDeleteTimeRangeRequested();
+                break;
+            case 15:  // Copy Loop Range
+                if (safeThis && safeThis->onCopyLoopRangeRequested)
+                    safeThis->onCopyLoopRangeRequested();
+                break;
+            case 16:  // Cut Loop Range
+                if (safeThis && safeThis->onCutLoopRangeRequested)
+                    safeThis->onCutLoopRangeRequested();
+                break;
+            case 17:  // Delete Loop Range
+                if (safeThis && safeThis->onDeleteLoopRangeRequested)
+                    safeThis->onDeleteLoopRangeRequested();
+                break;
+            case 18:  // Paste (Ripple)
+                if (safeThis && safeThis->onPasteRippleRequested)
+                    safeThis->onPasteRippleRequested();
                 break;
         }
     });
@@ -2492,6 +2534,34 @@ void TrackContentPanel::rebuildClipComponents() {
         clipComp->onSplitAllTracksAtCursorRequested = [this]() {
             if (onSplitAllTracksAtCursorRequested)
                 onSplitAllTracksAtCursorRequested();
+        };
+        clipComp->onCopyTimeRangeRequested = [this]() {
+            if (onCopyTimeRangeRequested)
+                onCopyTimeRangeRequested();
+        };
+        clipComp->onCutTimeRangeRequested = [this]() {
+            if (onCutTimeRangeRequested)
+                onCutTimeRangeRequested();
+        };
+        clipComp->onDeleteTimeRangeRequested = [this]() {
+            if (onDeleteTimeRangeRequested)
+                onDeleteTimeRangeRequested();
+        };
+        clipComp->onCopyLoopRangeRequested = [this]() {
+            if (onCopyLoopRangeRequested)
+                onCopyLoopRangeRequested();
+        };
+        clipComp->onCutLoopRangeRequested = [this]() {
+            if (onCutLoopRangeRequested)
+                onCutLoopRangeRequested();
+        };
+        clipComp->onDeleteLoopRangeRequested = [this]() {
+            if (onDeleteLoopRangeRequested)
+                onDeleteLoopRangeRequested();
+        };
+        clipComp->onPasteRippleRequested = [this]() {
+            if (onPasteRippleRequested)
+                onPasteRippleRequested();
         };
         clipComp->onBounceInPlaceRequested = [this](ClipId id) {
             if (onBounceInPlaceRequested)

--- a/magda/daw/ui/components/tracks/TrackContentPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.hpp
@@ -189,6 +189,13 @@ class TrackContentPanel : public juce::Component,
     std::function<void()> onDuplicateTimeRangeRequested;   // Ripple-duplicate time range
     std::function<void()> onDuplicateLoopRangeRequested;   // Ripple-duplicate the loop region
     std::function<void()> onSplitAllTracksAtCursorRequested;  // Split all clips at edit cursor
+    std::function<void()> onCopyTimeRangeRequested;           // Copy the time selection's content
+    std::function<void()> onCutTimeRangeRequested;     // Copy time selection, then ripple-delete
+    std::function<void()> onDeleteTimeRangeRequested;  // Ripple-delete the time selection
+    std::function<void()> onCopyLoopRangeRequested;    // Copy the loop region (all tracks)
+    std::function<void()> onCutLoopRangeRequested;     // Copy loop region, then ripple-delete
+    std::function<void()> onDeleteLoopRangeRequested;  // Ripple-delete the loop region
+    std::function<void()> onPasteRippleRequested;      // Ripple-insert clipboard span, then paste
     std::function<void(ClipId)> onBounceInPlaceRequested;     // Bounce MIDI clip in place
     std::function<void(ClipId)> onBounceToNewTrackRequested;  // Bounce clip to new track
     // Fires while a clip is being dragged/resized. The transparent grid overlay

--- a/magda/daw/ui/layout/LayoutConfig.hpp
+++ b/magda/daw/ui/layout/LayoutConfig.hpp
@@ -26,15 +26,6 @@ struct LayoutConfig {
     int rulerLabelFontSize = 11;
     int rulerLabelTopMargin = 10;  // Space between separator line and time labels
 
-    // Ruler interaction zones (fraction of ruler height for zoom area, rest is time selection)
-    float rulerZoomAreaRatio = 0.67f;  // Upper 67% for zoom, lower 33% for time selection
-
-    // Helper to get the Y position that splits zoom/selection zones
-    int getRulerZoneSplitY() const {
-        return chordRowHeight + arrangementBarHeight +
-               static_cast<int>(timeRulerHeight * rulerZoomAreaRatio);
-    }
-
     // Grid/tick spacing - shared between timeline ruler and track content grid
     int minGridPixelSpacing = 50;  // Minimum pixels between grid lines/ticks
 

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -2260,6 +2260,34 @@ void MainView::setupSelectionCallbacks() {
         if (onSplitAllTracksAtCursorRequested)
             onSplitAllTracksAtCursorRequested();
     };
+    trackContentPanel->onCopyTimeRangeRequested = [this]() {
+        if (onCopyTimeRangeRequested)
+            onCopyTimeRangeRequested();
+    };
+    trackContentPanel->onCutTimeRangeRequested = [this]() {
+        if (onCutTimeRangeRequested)
+            onCutTimeRangeRequested();
+    };
+    trackContentPanel->onDeleteTimeRangeRequested = [this]() {
+        if (onDeleteTimeRangeRequested)
+            onDeleteTimeRangeRequested();
+    };
+    trackContentPanel->onCopyLoopRangeRequested = [this]() {
+        if (onCopyLoopRangeRequested)
+            onCopyLoopRangeRequested();
+    };
+    trackContentPanel->onCutLoopRangeRequested = [this]() {
+        if (onCutLoopRangeRequested)
+            onCutLoopRangeRequested();
+    };
+    trackContentPanel->onDeleteLoopRangeRequested = [this]() {
+        if (onDeleteLoopRangeRequested)
+            onDeleteLoopRangeRequested();
+    };
+    trackContentPanel->onPasteRippleRequested = [this]() {
+        if (onPasteRippleRequested)
+            onPasteRippleRequested();
+    };
     trackContentPanel->onBounceInPlaceRequested = [this](ClipId id) {
         if (onBounceInPlaceRequested)
             onBounceInPlaceRequested(id);

--- a/magda/daw/ui/views/MainView.hpp
+++ b/magda/daw/ui/views/MainView.hpp
@@ -89,6 +89,13 @@ class MainView : public juce::Component,
     std::function<void()> onDuplicateTimeRangeRequested;      // Ripple-duplicate time range
     std::function<void()> onDuplicateLoopRangeRequested;      // Ripple-duplicate the loop region
     std::function<void()> onSplitAllTracksAtCursorRequested;  // Split all clips at edit cursor
+    std::function<void()> onCopyTimeRangeRequested;           // Copy the time selection's content
+    std::function<void()> onCutTimeRangeRequested;     // Copy time selection, then ripple-delete
+    std::function<void()> onDeleteTimeRangeRequested;  // Ripple-delete the time selection
+    std::function<void()> onCopyLoopRangeRequested;    // Copy the loop region (all tracks)
+    std::function<void()> onCutLoopRangeRequested;     // Copy loop region, then ripple-delete
+    std::function<void()> onDeleteLoopRangeRequested;  // Ripple-delete the loop region
+    std::function<void()> onPasteRippleRequested;      // Ripple-insert clipboard span, then paste
     std::function<void(ClipId)> onBounceInPlaceRequested;     // Bounce MIDI clip in place
     std::function<void(ClipId)> onBounceToNewTrackRequested;  // Bounce clip to new track
 

--- a/magda/daw/ui/windows/MainWindow.cpp
+++ b/magda/daw/ui/windows/MainWindow.cpp
@@ -682,6 +682,27 @@ MainWindow::MainComponent::MainComponent(AudioEngine* externalEngine) {
     mainView->onSplitAllTracksAtCursorRequested = [this]() {
         getCommandManager().invokeDirectly(CommandIDs::splitAllTracksAtCursor, false);
     };
+    mainView->onCopyTimeRangeRequested = [this]() {
+        getCommandManager().invokeDirectly(CommandIDs::copyTimeRange, false);
+    };
+    mainView->onCutTimeRangeRequested = [this]() {
+        getCommandManager().invokeDirectly(CommandIDs::cutTimeRange, false);
+    };
+    mainView->onDeleteTimeRangeRequested = [this]() {
+        getCommandManager().invokeDirectly(CommandIDs::deleteTimeRange, false);
+    };
+    mainView->onCopyLoopRangeRequested = [this]() {
+        getCommandManager().invokeDirectly(CommandIDs::copyLoopRange, false);
+    };
+    mainView->onCutLoopRangeRequested = [this]() {
+        getCommandManager().invokeDirectly(CommandIDs::cutLoopRange, false);
+    };
+    mainView->onDeleteLoopRangeRequested = [this]() {
+        getCommandManager().invokeDirectly(CommandIDs::deleteLoopRange, false);
+    };
+    mainView->onPasteRippleRequested = [this]() {
+        getCommandManager().invokeDirectly(CommandIDs::pasteRipple, false);
+    };
 
     // Wire bounce callbacks
     mainView->onBounceInPlaceRequested = [this](ClipId clipId) {

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -19,6 +19,7 @@
 #include "audio/AudioBridge.hpp"
 #include "core/LinkModeManager.hpp"
 #include "core/ViewModeController.hpp"
+#include "engine/TempoSequenceRippleCommand.hpp"
 #include "engine/TracktionEngineWrapper.hpp"
 #include "project/ProjectManager.hpp"
 
@@ -89,6 +90,18 @@ TrackId resolvePasteTargetTrack(ViewMode mode) {
     }
 
     return INVALID_TRACK_ID;
+}
+
+// Ripple the global tempo/time-sig/pitch sequences to match a time-range clip
+// edit. These are edit-wide, so callers gate this to all-tracks (global) ops.
+// Must be enqueued AFTER the clip-shifting commands in the compound op so the
+// remapper snapshot sees clips at their final beats.
+void rippleTempoSequence(AudioEngine* audioEngine, TempoSequenceRippleCommand::Mode mode,
+                         double startBeat, double endBeat) {
+    if (auto* eng = dynamic_cast<TracktionEngineWrapper*>(audioEngine))
+        if (auto* ed = eng->getEdit())
+            UndoManager::getInstance().executeCommand(
+                std::make_unique<TempoSequenceRippleCommand>(*ed, mode, startBeat, endBeat));
 }
 
 }  // namespace
@@ -1039,10 +1052,14 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
                 startBeat, durationBeats, trackIds, laneIds);
             if (automationCmd->canShiftPoints())
                 UndoManager::getInstance().executeCommand(std::move(automationCmd));
-            // Markers are global, so only ripple them when the op spans all tracks.
-            if (!sel.automationOnly && sel.isAllTracks())
+            // Markers and tempo/pitch are global, so only ripple them when the
+            // op spans all tracks.
+            if (!sel.automationOnly && sel.isAllTracks()) {
                 UndoManager::getInstance().executeCommand(std::make_unique<RippleMarkersCommand>(
                     RippleMarkersCommand::Mode::Insert, startBeat, sel.endBeats));
+                rippleTempoSequence(getAudioEngine(), TempoSequenceRippleCommand::Mode::Insert,
+                                    startBeat, sel.endBeats);
+            }
             UndoManager::getInstance().endCompoundOperation();
             return true;
         }
@@ -1093,10 +1110,14 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
             }
             if (hasAutomation)
                 UndoManager::getInstance().executeCommand(std::move(automationDupCmd));
-            // Markers are global: only ripple/copy them for all-track duplicates.
-            if (!sel.automationOnly && sel.isAllTracks())
+            // Markers and tempo/pitch are global: only ripple/copy them for
+            // all-track duplicates.
+            if (!sel.automationOnly && sel.isAllTracks()) {
                 UndoManager::getInstance().executeCommand(std::make_unique<RippleMarkersCommand>(
                     RippleMarkersCommand::Mode::Duplicate, startBeat, endBeat));
+                rippleTempoSequence(getAudioEngine(), TempoSequenceRippleCommand::Mode::Duplicate,
+                                    startBeat, endBeat);
+            }
             UndoManager::getInstance().endCompoundOperation();
 
             if (hasClips || hasAutomation) {
@@ -1155,9 +1176,11 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
                 startBeat, endBeat, allTracks, endBeat, allLanes);
             if (autoDup->canDuplicatePoints())
                 UndoManager::getInstance().executeCommand(std::move(autoDup));
-            // Loop ops are global, so markers always ripple.
+            // Loop ops are global, so markers and tempo/pitch always ripple.
             UndoManager::getInstance().executeCommand(std::make_unique<RippleMarkersCommand>(
                 RippleMarkersCommand::Mode::Duplicate, startBeat, endBeat));
+            rippleTempoSequence(getAudioEngine(), TempoSequenceRippleCommand::Mode::Duplicate,
+                                startBeat, endBeat);
 
             UndoManager::getInstance().endCompoundOperation();
 
@@ -1214,6 +1237,8 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
             if (rippleMarkers) {
                 UndoManager::getInstance().executeCommand(std::make_unique<RippleMarkersCommand>(
                     RippleMarkersCommand::Mode::Delete, startBeat, endBeat));
+                rippleTempoSequence(getAudioEngine(), TempoSequenceRippleCommand::Mode::Delete,
+                                    startBeat, endBeat);
                 UndoManager::getInstance().endCompoundOperation();
             }
             // Collapse the selection to the deletion point.
@@ -1246,13 +1271,16 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
             }
             if (info.commandID == cutLoopRange)
                 clipManager.copyBeatRangeToClipboard(startBeat, endBeat, allTracks, bpm);
-            // Loop ops are global, so markers always ripple (one undo step).
+            // Loop ops are global, so markers and tempo/pitch always ripple
+            // (one undo step).
             UndoManager::getInstance().beginCompoundOperation(
                 info.commandID == cutLoopRange ? "Cut Loop Range" : "Delete Loop Range");
             UndoManager::getInstance().executeCommand(
                 std::make_unique<RippleDeleteRangeCommand>(startBeat, endBeat, allTracks, bpm));
             UndoManager::getInstance().executeCommand(std::make_unique<RippleMarkersCommand>(
                 RippleMarkersCommand::Mode::Delete, startBeat, endBeat));
+            rippleTempoSequence(getAudioEngine(), TempoSequenceRippleCommand::Mode::Delete,
+                                startBeat, endBeat);
             UndoManager::getInstance().endCompoundOperation();
             return true;
         }
@@ -1283,9 +1311,11 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
                 std::make_unique<InsertTimeCommand>(targetBeat, span, std::vector<TrackId>{}, bpm));
             UndoManager::getInstance().executeCommand(
                 std::make_unique<PasteClipCommand>(BeatPosition{targetBeat}));
-            // Paste ripples all tracks, so markers shift too.
+            // Paste ripples all tracks, so markers and tempo/pitch shift too.
             UndoManager::getInstance().executeCommand(std::make_unique<RippleMarkersCommand>(
                 RippleMarkersCommand::Mode::Insert, targetBeat, targetBeat + span));
+            rippleTempoSequence(getAudioEngine(), TempoSequenceRippleCommand::Mode::Insert,
+                                targetBeat, targetBeat + span);
             UndoManager::getInstance().endCompoundOperation();
             return true;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TEST_SOURCES
     test_rack_audio.cpp
     test_modulation.cpp
     test_control_target.cpp
+    test_tempo_sequence_ripple_math.cpp
     test_chain_fingerprint.cpp
     test_chain_routing_model.cpp
     test_post_fx_chain.cpp
@@ -252,6 +253,7 @@ target_sources(magda_juce_tests PRIVATE
     test_external_plugin_state_restore_juce.cpp
     test_chord_progression_converter_juce.cpp
     test_audio_driver_type_selection_juce.cpp
+    test_tempo_sequence_ripple_juce.cpp
     ../magda/daw/ui/components/chain/slot/StepSequencerClipExport.cpp
 )
 

--- a/tests/test_tempo_sequence_ripple_juce.cpp
+++ b/tests/test_tempo_sequence_ripple_juce.cpp
@@ -1,0 +1,176 @@
+#include <juce_core/juce_core.h>
+#include <juce_events/juce_events.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+#include <cmath>
+
+#include "JuceTestStateGuard.hpp"
+#include "SharedTestEngine.hpp"
+#include "magda/daw/engine/TempoSequenceRippleCommand.hpp"
+
+namespace te = tracktion;
+
+using Mode = magda::TempoSequenceRippleCommand::Mode;
+
+/**
+ * TempoSequenceRippleCommand ripples the global tempo / time-sig / pitch
+ * sequences alongside a time-range clip edit. All shifting is beats-domain and
+ * wrapped in EditTimecodeRemapperSnapshot so beat-anchored clips keep their
+ * bar/beat position under the new tempo map instead of drifting.
+ */
+class TempoSequenceRippleTest final : public juce::UnitTest {
+  public:
+    TempoSequenceRippleTest() : juce::UnitTest("Tempo Sequence Ripple Tests", "magda") {}
+
+    static double tempoBeat(te::TempoSequence& ts, int i) {
+        return ts.getTempo(i)->getStartBeat().inBeats();
+    }
+
+    void runTest() override {
+        magda::test::ScopedJuceTestState state;
+        auto& wrapper = magda::test::getSharedEngine();
+
+        auto makeEdit = [&wrapper] {
+            return te::Edit::createSingleTrackEdit(*wrapper.getEngine(),
+                                                   te::Edit::EditRole::forEditing);
+        };
+        constexpr double eps = 1.0e-6;
+
+        beginTest("Insert shifts later tempo changes right, leaves earlier ones, undo restores");
+        {
+            auto edit = makeEdit();
+            auto& ts = edit->tempoSequence;
+            ts.insertTempo(te::BeatPosition::fromBeats(4.0), 100.0, 0.0f);  // before insert point
+            ts.insertTempo(te::BeatPosition::fromBeats(16.0), 90.0, 0.0f);  // after insert point
+            expectEquals(ts.getNumTempos(), 3);
+
+            magda::TempoSequenceRippleCommand cmd(*edit, Mode::Insert, 8.0, 12.0);  // +4 beats @8
+            cmd.execute();
+            expectEquals(ts.getNumTempos(), 3);
+            expectWithinAbsoluteError(tempoBeat(ts, 1), 4.0, eps);   // unchanged
+            expectWithinAbsoluteError(tempoBeat(ts, 2), 20.0, eps);  // 16 -> 20
+            expectWithinAbsoluteError(ts.getTempo(2)->getBpm(), 90.0, eps);
+
+            cmd.undo();
+            expectEquals(ts.getNumTempos(), 3);
+            expectWithinAbsoluteError(tempoBeat(ts, 1), 4.0, eps);
+            expectWithinAbsoluteError(tempoBeat(ts, 2), 16.0, eps);
+            edit.reset();
+        }
+
+        beginTest("Delete drops in-range changes and pulls later ones left, undo restores");
+        {
+            auto edit = makeEdit();
+            auto& ts = edit->tempoSequence;
+            ts.insertTempo(te::BeatPosition::fromBeats(10.0), 100.0, 0.0f);  // inside [8,12)
+            ts.insertTempo(te::BeatPosition::fromBeats(20.0), 90.0, 0.0f);   // after end
+            expectEquals(ts.getNumTempos(), 3);
+
+            magda::TempoSequenceRippleCommand cmd(*edit, Mode::Delete, 8.0, 12.0);  // -4 beats
+            cmd.execute();
+            expectEquals(ts.getNumTempos(), 2);                      // the @10 change dropped
+            expectWithinAbsoluteError(tempoBeat(ts, 1), 16.0, eps);  // 20 -> 16
+            expectWithinAbsoluteError(ts.getTempo(1)->getBpm(), 90.0, eps);
+
+            cmd.undo();
+            expectEquals(ts.getNumTempos(), 3);
+            expectWithinAbsoluteError(tempoBeat(ts, 1), 10.0, eps);
+            expectWithinAbsoluteError(tempoBeat(ts, 2), 20.0, eps);
+            edit.reset();
+        }
+
+        beginTest("Duplicate copies in-range changes into the opened gap, undo restores");
+        {
+            auto edit = makeEdit();
+            auto& ts = edit->tempoSequence;
+            ts.insertTempo(te::BeatPosition::fromBeats(12.0), 100.0, 0.0f);  // inside [8,16)
+            ts.insertTempo(te::BeatPosition::fromBeats(20.0), 90.0, 0.0f);   // after end
+            expectEquals(ts.getNumTempos(), 3);
+
+            magda::TempoSequenceRippleCommand cmd(*edit, Mode::Duplicate, 8.0, 16.0);  // dur 8
+            cmd.execute();
+            // original @12 stays, @20 -> 28, copy of @12 lands at 20.
+            expectEquals(ts.getNumTempos(), 4);
+            expectWithinAbsoluteError(tempoBeat(ts, 1), 12.0, eps);
+            expectWithinAbsoluteError(tempoBeat(ts, 2), 20.0, eps);
+            expectWithinAbsoluteError(ts.getTempo(2)->getBpm(), 100.0, eps);  // the copy
+            expectWithinAbsoluteError(tempoBeat(ts, 3), 28.0, eps);
+
+            cmd.undo();
+            expectEquals(ts.getNumTempos(), 3);
+            expectWithinAbsoluteError(tempoBeat(ts, 1), 12.0, eps);
+            expectWithinAbsoluteError(tempoBeat(ts, 2), 20.0, eps);
+            edit.reset();
+        }
+
+        beginTest("No-op when there are no non-anchor events to ripple");
+        {
+            auto edit = makeEdit();
+            auto& ts = edit->tempoSequence;
+            expectEquals(ts.getNumTempos(), 1);  // only the beat-0 anchor
+            magda::TempoSequenceRippleCommand cmd(*edit, Mode::Insert, 8.0, 12.0);
+            cmd.execute();
+            expectEquals(ts.getNumTempos(), 1);
+            cmd.undo();
+            expectEquals(ts.getNumTempos(), 1);
+            edit.reset();
+        }
+
+        beginTest("Insert ripples pitch changes, undo restores");
+        {
+            auto edit = makeEdit();
+            auto& ps = edit->pitchSequence;
+            ps.insertPitch(te::BeatPosition::fromBeats(16.0), 5);
+            expectEquals(ps.getNumPitches(), 2);
+
+            magda::TempoSequenceRippleCommand cmd(*edit, Mode::Insert, 8.0, 12.0);
+            cmd.execute();
+            expectWithinAbsoluteError(ps.getPitch(1)->getStartBeatNumber().inBeats(), 20.0, eps);
+            expectEquals(ps.getPitch(1)->getPitch(), 5);
+
+            cmd.undo();
+            expectWithinAbsoluteError(ps.getPitch(1)->getStartBeatNumber().inBeats(), 16.0, eps);
+            expectEquals(ps.getPitch(1)->getPitch(), 5);
+            edit.reset();
+        }
+
+        beginTest("Clips stay anchored to their beat when the tempo map ripples under them");
+        {
+            auto edit = makeEdit();
+            auto& ts = edit->tempoSequence;
+            ts.insertTempo(te::BeatPosition::fromBeats(16.0), 60.0, 0.0f);  // half tempo after 16
+
+            auto tracks = te::getAudioTracks(*edit);
+            expect(!tracks.isEmpty(), "expected a track from createSingleTrackEdit");
+            auto* track = tracks.getFirst();
+
+            // Place a MIDI clip at beats 32..40 (after the tempo change).
+            const auto start = ts.toTime(te::BeatPosition::fromBeats(32.0));
+            const auto end = ts.toTime(te::BeatPosition::fromBeats(40.0));
+            auto clip = te::insertMIDIClip(*track, te::TimeRange(start, end));
+            expect(clip != nullptr, "failed to insert MIDI clip");
+
+            const double beatBefore = ts.toBeats(clip->getPosition().getStart()).inBeats();
+            expectWithinAbsoluteError(beatBefore, 32.0, 1.0e-3);
+
+            // Ripple-insert 4 beats at beat 8: the tempo change moves 16 -> 20,
+            // but the clip must remain at beat 32 (the remapper re-derives its
+            // seconds). Without the remapper wrap the clip would drift.
+            magda::TempoSequenceRippleCommand cmd(*edit, Mode::Insert, 8.0, 12.0);
+            cmd.execute();
+            expectWithinAbsoluteError(tempoBeat(ts, 1), 20.0, eps);
+            const double beatAfter = ts.toBeats(clip->getPosition().getStart()).inBeats();
+            expectWithinAbsoluteError(beatAfter, 32.0, 1.0e-3, "clip drifted off its beat");
+
+            cmd.undo();
+            expectWithinAbsoluteError(tempoBeat(ts, 1), 16.0, eps);
+            const double beatUndo = ts.toBeats(clip->getPosition().getStart()).inBeats();
+            expectWithinAbsoluteError(beatUndo, 32.0, 1.0e-3);
+
+            clip = nullptr;  // release before the Edit so the clip isn't destroyed dangling
+            edit.reset();
+        }
+    }
+};
+
+static TempoSequenceRippleTest tempoSequenceRippleTest;

--- a/tests/test_tempo_sequence_ripple_math.cpp
+++ b/tests/test_tempo_sequence_ripple_math.cpp
@@ -1,0 +1,102 @@
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+#include "../magda/daw/engine/TempoSequenceRippleMath.hpp"
+
+using magda::temporipple::Mode;
+using magda::temporipple::rippleEvents;
+using magda::temporipple::sameBeats;
+
+namespace {
+// Minimal event: the ripple math only needs a `beat`; `tag` rides along to
+// prove payloads follow their beat (and that copies keep the source payload).
+struct Ev {
+    double beat;
+    int tag = 0;
+};
+
+std::vector<double> beats(const std::vector<Ev>& v) {
+    std::vector<double> b;
+    for (const auto& e : v)
+        b.push_back(e.beat);
+    return b;
+}
+
+// The beat-0 anchor plus caller-supplied events, in the layout the sequences
+// hand us (index 0 is always the anchor).
+std::vector<Ev> seq(std::vector<Ev> events) {
+    std::vector<Ev> v{{0.0, -1}};
+    for (auto& e : events)
+        v.push_back(e);
+    return v;
+}
+}  // namespace
+
+TEST_CASE("ripple Insert shifts events at/after the point, keeps earlier ones", "[tempo_ripple]") {
+    auto in = seq({{4.0, 1}, {16.0, 2}});
+    auto out = rippleEvents(in, Mode::Insert, 8.0, 12.0);  // +4 beats at beat 8
+    REQUIRE(beats(out) == std::vector<double>{0.0, 4.0, 20.0});
+    // The anchor never moves; the @4 event is before the point; @16 -> 20.
+    REQUIRE(out[2].tag == 2);
+}
+
+TEST_CASE("ripple Insert never moves the beat-0 anchor even at point 0", "[tempo_ripple]") {
+    auto in = seq({{8.0, 1}});
+    auto out = rippleEvents(in, Mode::Insert, 0.0, 4.0);
+    REQUIRE(beats(out) == std::vector<double>{0.0, 12.0});  // anchor stays, @8 -> 12
+}
+
+TEST_CASE("ripple Insert on an event exactly at the point moves it", "[tempo_ripple]") {
+    auto in = seq({{8.0, 1}});
+    auto out = rippleEvents(in, Mode::Insert, 8.0, 12.0);
+    REQUIRE(beats(out) == std::vector<double>{0.0, 12.0});  // boundary event shifts with content
+}
+
+TEST_CASE("ripple Delete drops in-range events and pulls later ones left", "[tempo_ripple]") {
+    auto in = seq({{10.0, 1}, {20.0, 2}});
+    auto out = rippleEvents(in, Mode::Delete, 8.0, 12.0);   // -4 beats
+    REQUIRE(beats(out) == std::vector<double>{0.0, 16.0});  // @10 dropped, @20 -> 16
+    REQUIRE(out[1].tag == 2);
+}
+
+TEST_CASE("ripple Delete keeps the anchor and events before the range", "[tempo_ripple]") {
+    auto in = seq({{2.0, 1}, {10.0, 2}, {20.0, 3}});
+    auto out = rippleEvents(in, Mode::Delete, 8.0, 12.0);
+    REQUIRE(beats(out) == std::vector<double>{0.0, 2.0, 16.0});  // @2 stays, @10 dropped, @20->16
+}
+
+TEST_CASE("ripple Delete of an event exactly at range end shifts it to the range start",
+          "[tempo_ripple]") {
+    auto in = seq({{12.0, 1}});
+    auto out = rippleEvents(in, Mode::Delete, 8.0, 12.0);  // [8,12), @12 is at the end (not inside)
+    REQUIRE(beats(out) == std::vector<double>{0.0, 8.0});
+}
+
+TEST_CASE("ripple Duplicate opens a gap and copies in-range events into it", "[tempo_ripple]") {
+    auto in = seq({{12.0, 1}, {20.0, 2}});
+    auto out = rippleEvents(in, Mode::Duplicate, 8.0, 16.0);  // dur 8
+    // @12 stays, @20 -> 28, copy of @12 lands at 20.
+    REQUIRE(beats(out) == std::vector<double>{0.0, 12.0, 20.0, 28.0});
+    REQUIRE(out[2].tag == 1);  // the copy carries the source payload
+    REQUIRE(out[3].tag == 2);
+}
+
+TEST_CASE("ripple Duplicate never copies the anchor", "[tempo_ripple]") {
+    auto in = seq({});  // only the anchor
+    auto out = rippleEvents(in, Mode::Duplicate, 0.0, 8.0);
+    REQUIRE(beats(out) == std::vector<double>{0.0});  // nothing to shift or copy
+}
+
+TEST_CASE("ripple leaves a sequence with only the anchor untouched", "[tempo_ripple]") {
+    auto in = seq({});
+    REQUIRE(sameBeats(rippleEvents(in, Mode::Insert, 8.0, 12.0), in));
+    REQUIRE(sameBeats(rippleEvents(in, Mode::Delete, 8.0, 12.0), in));
+    REQUIRE(sameBeats(rippleEvents(in, Mode::Duplicate, 8.0, 16.0), in));
+}
+
+TEST_CASE("sameBeats detects membership and position changes", "[tempo_ripple]") {
+    auto a = seq({{8.0, 1}});
+    REQUIRE(sameBeats(a, a));
+    REQUIRE_FALSE(sameBeats(a, seq({{12.0, 1}})));  // moved
+    REQUIRE_FALSE(sameBeats(a, seq({})));           // dropped
+}


### PR DESCRIPTION
Extends the arrangement time-range editing work tracked in #1680.

## Range Editing context menus
Adds a "Range Editing" submenu to the clip and empty-space right-click menus, mirroring the Edit menu's Copy / Cut / Delete / Paste (Ripple) set for both the time selection and the loop range. Callbacks are wired ClipComponent -> TrackContentPanel -> MainView -> MainWindow commands.

## Tempo / time-sig / pitch ripple
Insert / Delete / Duplicate time-range ops now shift the global tempo, time-signature and pitch sequences alongside clips and markers, so tempo changes move with the music instead of staying pinned. The mutation is wrapped in EditTimecodeRemapperSnapshot (save/remap) so beat-anchored clips keep their bar/beat position under the new tempo map rather than drifting off the grid.

- New TempoSequenceRippleCommand runs on all-tracks / loop (global) ops, next to RippleMarkersCommand, at all six dispatch sites.
- The pure beats-domain transform lives in TempoSequenceRippleMath.hpp so it can be unit-tested without an Edit.
- The Tempo automation lane is excluded from the InsertTime / Duplicate automation commands so tempoSequence is the single source of truth (no double-shift). TempoLaneSync still mirrors it to the visible lane.

## Tests
- test_tempo_sequence_ripple_math.cpp (Catch2, CLI): the pure ripple math (insert / delete / duplicate, anchor handling, edge cases).
- test_tempo_sequence_ripple_juce.cpp (JUCE): end-to-end against a real Edit, including the clip-anchor / no-drift invariant.

Built and tested locally (make debug, make test-build, make test-juce-build).

Still open from #1680: the marker-span range source (a section span between two markers).
