### PR TITLE
Make the all-tracks ruler time-selection gesture explicit

### DIFF
--- a/magda/daw/ui/components/timeline/TimelineComponent.cpp
+++ b/magda/daw/ui/components/timeline/TimelineComponent.cpp
@@ -389,7 +389,9 @@ void TimelineComponent::mouseDown(const juce::MouseEvent& event) {
     // the zoom/playhead-click area.
     bool inSectionsArea = event.y >= chordHeight && event.y <= arrangementBottom;
     bool inTimeRulerArea = event.y > arrangementBottom && event.y < rows.playheadTop;
-    bool inTimeSelectionZone = event.y >= rows.playheadTop && event.y <= timeRulerEnd;
+    // The strip beneath the loop marker area: dragging here selects a time range
+    // across ALL tracks (all clips) via onRulerTimeSelectionChanged.
+    bool inAllTracksSelectionStrip = event.y >= rows.playheadTop && event.y <= timeRulerEnd;
 
     // Check for loop marker dragging — only within the loop row.
     if (event.y >= rows.loopTop && event.y < rows.loopBottom) {
@@ -397,8 +399,8 @@ void TimelineComponent::mouseDown(const juce::MouseEvent& event) {
             return;
     }
 
-    // Zone 1a: Lower ruler area (near tick labels) - start time selection
-    if (inTimeSelectionZone) {
+    // Zone 1a: the all-tracks selection strip - start a full-height time selection
+    if (inAllTracksSelectionStrip) {
         isDraggingTimeSelection = true;
         double startBeats = pixelToBeats(event.x);
         startBeats = juce::jlimit(0.0, getTimelineLengthBeats(), startBeats);
@@ -508,8 +510,8 @@ void TimelineComponent::mouseDrag(const juce::MouseEvent& event) {
             timeSelectionEndBeats = currentBeats;
         }
 
-        if (onTimeSelectionBeatsChanged) {
-            onTimeSelectionBeatsChanged(timeSelectionStartBeats, timeSelectionEndBeats);
+        if (onRulerTimeSelectionChanged) {
+            onRulerTimeSelectionChanged(timeSelectionStartBeats, timeSelectionEndBeats);
         }
         repaint();
         return;
@@ -676,8 +678,8 @@ void TimelineComponent::mouseUp(const juce::MouseEvent& event) {
             // Clear the selection
             timeSelectionStartBeats = -1.0;
             timeSelectionEndBeats = -1.0;
-            if (onTimeSelectionBeatsChanged) {
-                onTimeSelectionBeatsChanged(-1.0, -1.0);
+            if (onRulerTimeSelectionChanged) {
+                onRulerTimeSelectionChanged(-1.0, -1.0);
             }
             // Move playhead to click position
             double clickBeats = pixelToBeats(event.x);

--- a/magda/daw/ui/components/timeline/TimelineComponent.hpp
+++ b/magda/daw/ui/components/timeline/TimelineComponent.hpp
@@ -150,8 +150,11 @@ class TimelineComponent : public juce::Component, public TimelineStateListener {
         onLoopRegionBeatsChanged;  // Callback when loop region changes
     std::function<void(const ResolvedGesture&)>
         onArrangementGesture;  // Wheel gesture resolved via GestureRouter (#21/#26)
-    std::function<void(double, double)>
-        onTimeSelectionBeatsChanged;  // Callback when time selection changes in ruler
+    // Fires when the user drags the ruler strip beneath the loop marker area to
+    // select a time range across ALL tracks (every track's clips). Args are
+    // (startBeats, endBeats), or (-1, -1) to clear. Distinct from the per-track
+    // time selection dragged inside TrackContentPanel.
+    std::function<void(double, double)> onRulerTimeSelectionChanged;
     std::function<void(double, double)>
         onZoomToFitBeatsRequested;  // Callback to zoom to fit a beat range (startBeats, endBeats)
 

--- a/magda/daw/ui/state/TimelineEvents.hpp
+++ b/magda/daw/ui/state/TimelineEvents.hpp
@@ -234,6 +234,14 @@ struct SetTimeSelectionBeatsEvent {
           automationOnly(automationOnlyIn),
           automationLaneIds(std::move(automationLaneIdsIn)) {}
 
+    // A full-height selection spanning every track (empty trackIndices). This is
+    // the range source for the ripple/insert/duplicate/delete time-range ops:
+    // it time-selects all clips in [startBeats, endBeats). Used by the ruler
+    // strip drag beneath the loop marker area (see TimelineComponent).
+    static SetTimeSelectionBeatsEvent allTracks(double startBeats, double endBeats) {
+        return SetTimeSelectionBeatsEvent{startBeats, endBeats, /*trackIndices*/ {}};
+    }
+
     double startBeats;
     double endBeats;
     std::set<int> trackIndices;  // Empty = all tracks

--- a/magda/daw/ui/views/MainView.cpp
+++ b/magda/daw/ui/views/MainView.cpp
@@ -534,12 +534,15 @@ void MainView::setupCallbacks() {
         dispatchArrangementGesture(g);
     };
 
-    // Handle time selection from timeline ruler
-    timeline->onTimeSelectionBeatsChanged = [this](double startBeats, double endBeats) {
+    // Dragging the ruler strip beneath the loop marker area selects a time
+    // range across ALL tracks (every track's clips), which is the range source
+    // the ripple/insert/duplicate/delete time-range ops act on.
+    timeline->onRulerTimeSelectionChanged = [this](double startBeats, double endBeats) {
         if (startBeats < 0 || endBeats < 0) {
             timelineController->dispatch(ClearTimeSelectionEvent{});
         } else {
-            timelineController->dispatch(SetTimeSelectionBeatsEvent{startBeats, endBeats, {}});
+            timelineController->dispatch(
+                SetTimeSelectionBeatsEvent::allTracks(startBeats, endBeats));
             // Move playhead to follow the left side of selection
             timelineController->dispatch(SetPlayheadPositionBeatsEvent{startBeats});
         }


### PR DESCRIPTION
Follow-up to the arrangement time-range editing work (merged in #1686). Clarity-only refactor, no behavior change.

The strip beneath the loop marker area drags a full-height, all-tracks time selection (the range source the ripple/insert/duplicate/delete time-range ops act on), but that was only discoverable by tracing a bare `{}` track set through several hops.

- `SetTimeSelectionBeatsEvent::allTracks(start, end)` names the empty-set = all-tracks intent instead of a magic `{}`.
- Rename TimelineComponent's ruler callback `onTimeSelectionBeatsChanged` -> `onRulerTimeSelectionChanged` (disambiguates from TrackContentPanel's per-track selection) and document it.
- Name the mouseDown zone `inAllTracksSelectionStrip` with a comment.

Built locally (make debug).
