### PR TITLE
Harden group tracks against input/recording; centralize track-capability rules

### DIFF
--- a/magda/daw/audio/midi/MidiInputRouter.cpp
+++ b/magda/daw/audio/midi/MidiInputRouter.cpp
@@ -447,7 +447,7 @@ void MidiInputRouter::updateMidiInputRouting() {
     // instrument, so their want is expressed against the parent id.
     std::unordered_set<TrackId> midiTargets;
     for (const auto& track : tm.getTracks()) {
-        if (track.type == TrackType::Aux || track.type == TrackType::Group)
+        if (!track.takesExternalInput())
             continue;
 
         if (!track.receivesLiveMidiInput())
@@ -460,7 +460,7 @@ void MidiInputRouter::updateMidiInputRouting() {
     }
 
     for (const auto& track : tm.getTracks()) {
-        if (track.type == TrackType::Aux || track.type == TrackType::Group)
+        if (!track.takesExternalInput())
             continue;
 
         bool shouldReceiveMidi = midiTargets.count(track.id) > 0;

--- a/magda/daw/audio/midi/MidiInputRouter.cpp
+++ b/magda/daw/audio/midi/MidiInputRouter.cpp
@@ -447,7 +447,7 @@ void MidiInputRouter::updateMidiInputRouting() {
     // instrument, so their want is expressed against the parent id.
     std::unordered_set<TrackId> midiTargets;
     for (const auto& track : tm.getTracks()) {
-        if (track.type == TrackType::Aux)
+        if (track.type == TrackType::Aux || track.type == TrackType::Group)
             continue;
 
         if (!track.receivesLiveMidiInput())
@@ -460,7 +460,7 @@ void MidiInputRouter::updateMidiInputRouting() {
     }
 
     for (const auto& track : tm.getTracks()) {
-        if (track.type == TrackType::Aux)
+        if (track.type == TrackType::Aux || track.type == TrackType::Group)
             continue;
 
         bool shouldReceiveMidi = midiTargets.count(track.id) > 0;

--- a/magda/daw/core/TrackInfo.hpp
+++ b/magda/daw/core/TrackInfo.hpp
@@ -232,6 +232,14 @@ struct TrackInfo {
         return type != TrackType::Aux && type != TrackType::Group;
     }
 
+    // True for tracks that can host an instrument device. Aux/Group summing
+    // buses and the Master track only process signal from elsewhere, so they
+    // never host instruments. Single source of truth for the instrument-add
+    // guards across TrackManager (track and rack-chain add paths).
+    bool canHostInstrument() const {
+        return type != TrackType::Aux && type != TrackType::Group && type != TrackType::Master;
+    }
+
     // MIDI input helpers
     //
     // Single source of truth for "does this track listen to live MIDI input".

--- a/magda/daw/core/TrackInfo.hpp
+++ b/magda/daw/core/TrackInfo.hpp
@@ -224,6 +224,14 @@ struct TrackInfo {
         return parentId == INVALID_TRACK_ID;
     }
 
+    // True for tracks that take external audio/MIDI input and can be recorded /
+    // monitored. Aux send buses and Group summing tracks only pass signal from
+    // elsewhere, so they never take external input. Single source of truth for
+    // the input/record/monitor guards across TrackManager and MidiInputRouter.
+    bool takesExternalInput() const {
+        return type != TrackType::Aux && type != TrackType::Group;
+    }
+
     // MIDI input helpers
     //
     // Single source of truth for "does this track listen to live MIDI input".

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -329,10 +329,13 @@ TrackId TrackManager::createTrack(const juce::String& name, TrackType type) {
     track.audioInputDevice = "";         // Audio input disabled by default (enable via UI)
     // midiOutputDevice left empty - requires specific device selection
 
-    // Assign aux bus index for Aux tracks; aux tracks never receive MIDI
+    // Aux buses and Group summing tracks take no external input, so they never
+    // receive MIDI; every other track listens to all inputs.
     if (type == TrackType::Aux) {
         track.auxBusIndex = nextAuxBusIndex_++;
         track.midiInputDevice = "";  // Aux tracks don't receive MIDI
+    } else if (type == TrackType::Group) {
+        track.midiInputDevice = "";  // Group summing tracks don't receive MIDI
     } else {
         track.midiInputDevice = "all";  // MIDI listens to all inputs
     }
@@ -344,9 +347,10 @@ TrackId TrackManager::createTrack(const juce::String& name, TrackType type) {
     DBG("Created track: " << track.name << " (id=" << trackId << ", type=" << getTrackTypeName(type)
                           << ")");
 
-    // Initialize MIDI routing for this track if audioEngine is available
-    // Aux tracks never receive MIDI; other tracks rely on selection-based routing
-    if (audioEngine_ && type != TrackType::Aux) {
+    // Initialize MIDI routing for this track if audioEngine is available.
+    // Aux buses and Group summing tracks never receive MIDI; other tracks rely
+    // on selection-based routing.
+    if (audioEngine_ && type != TrackType::Aux && type != TrackType::Group) {
         if (auto* midiBridge = audioEngine_->getMidiBridge()) {
             midiBridge->setTrackMidiInput(trackId, "all");
             midiBridge->startMonitoring(trackId);
@@ -1307,6 +1311,10 @@ void TrackManager::setTrackSoloed(TrackId trackId, bool soloed) {
 
 void TrackManager::setTrackRecordArmed(TrackId trackId, bool armed) {
     if (auto* track = getTrack(trackId)) {
+        // Group summing tracks have no clip lane to record into, so they can't
+        // be record-armed.
+        if (track->type == TrackType::Group)
+            return;
         track->recordArmed = armed;
         notifyTrackPropertyChanged(trackId);
     }

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -1729,9 +1729,7 @@ void TrackManager::stampDefaultKitIfMissing(DeviceInfo& dev) {
 
 DeviceId TrackManager::addDeviceToTrack(TrackId trackId, const DeviceInfo& device) {
     if (auto* track = getTrack(trackId)) {
-        if ((track->type == TrackType::Aux || track->type == TrackType::Group ||
-             track->type == TrackType::Master) &&
-            device.isInstrument) {
+        if (!track->canHostInstrument() && device.isInstrument) {
             DBG("Cannot add instrument plugin to non-instrument track");
             return INVALID_DEVICE_ID;
         }
@@ -1754,9 +1752,7 @@ DeviceId TrackManager::addDeviceToTrack(TrackId trackId, const DeviceInfo& devic
 DeviceId TrackManager::addDeviceToTrack(TrackId trackId, const DeviceInfo& device,
                                         int insertIndex) {
     if (auto* track = getTrack(trackId)) {
-        if ((track->type == TrackType::Aux || track->type == TrackType::Group ||
-             track->type == TrackType::Master) &&
-            device.isInstrument) {
+        if (!track->canHostInstrument() && device.isInstrument) {
             DBG("Cannot add instrument plugin to non-instrument track");
             return INVALID_DEVICE_ID;
         }

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -329,16 +329,11 @@ TrackId TrackManager::createTrack(const juce::String& name, TrackType type) {
     track.audioInputDevice = "";         // Audio input disabled by default (enable via UI)
     // midiOutputDevice left empty - requires specific device selection
 
-    // Aux buses and Group summing tracks take no external input, so they never
-    // receive MIDI; every other track listens to all inputs.
-    if (type == TrackType::Aux) {
+    // Aux buses need a bus index. Aux and Group take no external input, so they
+    // never receive MIDI; every other track listens to all inputs.
+    if (type == TrackType::Aux)
         track.auxBusIndex = nextAuxBusIndex_++;
-        track.midiInputDevice = "";  // Aux tracks don't receive MIDI
-    } else if (type == TrackType::Group) {
-        track.midiInputDevice = "";  // Group summing tracks don't receive MIDI
-    } else {
-        track.midiInputDevice = "all";  // MIDI listens to all inputs
-    }
+    track.midiInputDevice = track.takesExternalInput() ? "all" : "";
 
     TrackId trackId = track.id;
     tracks_.push_back(track);
@@ -347,18 +342,10 @@ TrackId TrackManager::createTrack(const juce::String& name, TrackType type) {
     DBG("Created track: " << track.name << " (id=" << trackId << ", type=" << getTrackTypeName(type)
                           << ")");
 
-    // Initialize MIDI routing for this track if audioEngine is available.
-    // Aux buses and Group summing tracks never receive MIDI; other tracks rely
-    // on selection-based routing.
-    if (audioEngine_ && type != TrackType::Aux && type != TrackType::Group) {
-        if (auto* midiBridge = audioEngine_->getMidiBridge()) {
-            midiBridge->setTrackMidiInput(trackId, "all");
-            midiBridge->startMonitoring(trackId);
-        }
-        // Don't auto-route MIDI at the TE level for every new track.
-        // AudioBridge::updateMidiInputRouting() will handle this
-        // based on whether the track is selected or record-armed.
-    }
+    // Register for MIDI input monitoring (no-op for input-less tracks). TE-level
+    // routing is left to AudioBridge::updateMidiInputRouting() based on
+    // selection / record-arm.
+    startMidiMonitoring(track, "all");
 
     // The chord track ships with a Chord Engine (the authoring/suggestion UI
     // the chord panel binds to) followed by a default instrument, so chord
@@ -769,6 +756,18 @@ void TrackManager::deactivateAllMultiOutPairs(TrackId parentTrackId, DeviceId de
     }
 }
 
+void TrackManager::startMidiMonitoring(const TrackInfo& track, const juce::String& deviceId) {
+    // Input-less tracks (Aux, Group) never receive MIDI. TE-level routing is
+    // owned by AudioBridge::updateMidiInputRouting(); this only wires the
+    // MidiBridge activity monitor.
+    if (!audioEngine_ || !track.takesExternalInput())
+        return;
+    if (auto* midiBridge = audioEngine_->getMidiBridge()) {
+        midiBridge->setTrackMidiInput(track.id, deviceId);
+        midiBridge->startMonitoring(track.id);
+    }
+}
+
 void TrackManager::restoreTrack(const TrackInfo& trackInfo) {
     // Check if a track with this ID already exists
     auto it = std::find_if(tracks_.begin(), tracks_.end(),
@@ -781,11 +780,12 @@ void TrackManager::restoreTrack(const TrackInfo& trackInfo) {
 
     tracks_.push_back(trackInfo);
 
-    // Group summing tracks take no external input. Projects saved before this
-    // invariant existed can carry MIDI/audio input, monitoring, or record-arm on
-    // a group (createTrack used to seed every non-Aux track with "all"), so
-    // sanitize on restore rather than let stale on-disk state reintroduce it.
-    if (tracks_.back().type == TrackType::Group) {
+    // Input-less tracks (Aux, Group) take no external input. Projects saved
+    // before this invariant existed can carry MIDI/audio input, monitoring, or
+    // record-arm on them (createTrack used to seed every non-Aux track with
+    // "all"), so sanitize on restore rather than let stale on-disk state
+    // reintroduce it.
+    if (!tracks_.back().takesExternalInput()) {
         auto& restored = tracks_.back();
         restored.recordArmed = false;
         restored.inputMonitor = InputMonitorMode::Off;
@@ -808,14 +808,8 @@ void TrackManager::restoreTrack(const TrackInfo& trackInfo) {
         }
     }
 
-    // Set up MidiBridge monitoring for restored track (same as createTrack).
-    // Aux buses and Group summing tracks never receive MIDI.
-    if (audioEngine_ && trackInfo.type != TrackType::Aux && trackInfo.type != TrackType::Group) {
-        if (auto* midiBridge = audioEngine_->getMidiBridge()) {
-            midiBridge->setTrackMidiInput(trackInfo.id, "all");
-            midiBridge->startMonitoring(trackInfo.id);
-        }
-    }
+    // Register for MIDI input monitoring (no-op for input-less tracks).
+    startMidiMonitoring(trackInfo, "all");
 
     notifyTracksChanged();
     DBG("Restored track: " << trackInfo.name << " (id=" << trackInfo.id << ")");
@@ -956,13 +950,8 @@ TrackId TrackManager::duplicateTrack(TrackId trackId, bool includeDevices) {
         }
     }
 
-    // Set up MIDI monitoring (same as createTrack)
-    if (audioEngine_ && newTrack.type != TrackType::Aux) {
-        if (auto* midiBridge = audioEngine_->getMidiBridge()) {
-            midiBridge->setTrackMidiInput(newId, newTrack.midiInputDevice);
-            midiBridge->startMonitoring(newId);
-        }
-    }
+    // Register for MIDI input monitoring (no-op for input-less tracks).
+    startMidiMonitoring(newTrack, newTrack.midiInputDevice);
 
     notifyTracksChanged();
     DBG("Duplicated track: " << newTrack.name << " (id=" << newId << ")");
@@ -1324,9 +1313,9 @@ void TrackManager::setTrackSoloed(TrackId trackId, bool soloed) {
 
 void TrackManager::setTrackRecordArmed(TrackId trackId, bool armed) {
     if (auto* track = getTrack(trackId)) {
-        // Group summing tracks have no clip lane to record into, so they can't
-        // be record-armed.
-        if (track->type == TrackType::Group)
+        // Input-less tracks (Aux, Group) have no clip lane to record into, so
+        // they can't be record-armed.
+        if (!track->takesExternalInput())
             return;
         track->recordArmed = armed;
         notifyTrackPropertyChanged(trackId);
@@ -1335,9 +1324,9 @@ void TrackManager::setTrackRecordArmed(TrackId trackId, bool armed) {
 
 void TrackManager::setTrackInputMonitor(TrackId trackId, InputMonitorMode mode) {
     if (auto* track = getTrack(trackId)) {
-        // Group summing tracks take no external input, so input monitoring does
-        // not apply to them.
-        if (track->type == TrackType::Group)
+        // Input-less tracks (Aux, Group) take no external input, so input
+        // monitoring does not apply to them.
+        if (!track->takesExternalInput())
             return;
         track->inputMonitor = mode;
         notifyTrackPropertyChanged(trackId);
@@ -1414,15 +1403,8 @@ void TrackManager::setAudioEngine(AudioEngine* audioEngine) {
     // AudioBridge::updateMidiInputRouting() based on selection/arm state.
     if (audioEngine_) {
         for (const auto& track : tracks_) {
-            if (!track.midiInputDevice.isEmpty() && track.type != TrackType::Aux &&
-                track.type != TrackType::Group) {
-                if (auto* midiBridge = audioEngine_->getMidiBridge()) {
-                    midiBridge->setTrackMidiInput(track.id, track.midiInputDevice);
-                    midiBridge->startMonitoring(track.id);
-                }
-                DBG("Synced MIDI monitoring for track " << track.id << ": "
-                                                        << track.midiInputDevice);
-            }
+            if (!track.midiInputDevice.isEmpty())
+                startMidiMonitoring(track, track.midiInputDevice);
         }
     }
 }
@@ -1457,9 +1439,9 @@ void TrackManager::setTrackMidiInput(TrackId trackId, const juce::String& device
         return;
     }
 
-    // Aux buses and Group summing tracks never receive external MIDI
-    if (track->type == TrackType::Aux || track->type == TrackType::Group) {
-        DBG("Cannot set MIDI input on aux/group track " << trackId);
+    // Input-less tracks (Aux, Group) never receive external MIDI
+    if (!track->takesExternalInput()) {
+        DBG("Cannot set MIDI input on input-less track " << trackId);
         return;
     }
 
@@ -1535,9 +1517,9 @@ void TrackManager::setTrackAudioInput(TrackId trackId, const juce::String& devic
         return;
     }
 
-    // Group summing tracks take no external input.
-    if (track->type == TrackType::Group) {
-        DBG("Cannot set audio input on group track " << trackId);
+    // Input-less tracks (Aux, Group) take no external input.
+    if (!track->takesExternalInput()) {
+        DBG("Cannot set audio input on input-less track " << trackId);
         return;
     }
 

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -781,6 +781,18 @@ void TrackManager::restoreTrack(const TrackInfo& trackInfo) {
 
     tracks_.push_back(trackInfo);
 
+    // Group summing tracks take no external input. Projects saved before this
+    // invariant existed can carry MIDI/audio input, monitoring, or record-arm on
+    // a group (createTrack used to seed every non-Aux track with "all"), so
+    // sanitize on restore rather than let stale on-disk state reintroduce it.
+    if (tracks_.back().type == TrackType::Group) {
+        auto& restored = tracks_.back();
+        restored.recordArmed = false;
+        restored.inputMonitor = InputMonitorMode::Off;
+        restored.midiInputDevice = "";
+        restored.audioInputDevice = "";
+    }
+
     // Ensure nextTrackId_ is beyond any restored track IDs
     if (trackInfo.id >= nextTrackId_) {
         nextTrackId_ = trackInfo.id + 1;
@@ -1402,7 +1414,8 @@ void TrackManager::setAudioEngine(AudioEngine* audioEngine) {
     // AudioBridge::updateMidiInputRouting() based on selection/arm state.
     if (audioEngine_) {
         for (const auto& track : tracks_) {
-            if (!track.midiInputDevice.isEmpty() && track.type != TrackType::Aux) {
+            if (!track.midiInputDevice.isEmpty() && track.type != TrackType::Aux &&
+                track.type != TrackType::Group) {
                 if (auto* midiBridge = audioEngine_->getMidiBridge()) {
                     midiBridge->setTrackMidiInput(track.id, track.midiInputDevice);
                     midiBridge->startMonitoring(track.id);

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -796,8 +796,9 @@ void TrackManager::restoreTrack(const TrackInfo& trackInfo) {
         }
     }
 
-    // Set up MidiBridge monitoring for restored track (same as createTrack)
-    if (audioEngine_ && trackInfo.type != TrackType::Aux) {
+    // Set up MidiBridge monitoring for restored track (same as createTrack).
+    // Aux buses and Group summing tracks never receive MIDI.
+    if (audioEngine_ && trackInfo.type != TrackType::Aux && trackInfo.type != TrackType::Group) {
         if (auto* midiBridge = audioEngine_->getMidiBridge()) {
             midiBridge->setTrackMidiInput(trackInfo.id, "all");
             midiBridge->startMonitoring(trackInfo.id);
@@ -1322,6 +1323,10 @@ void TrackManager::setTrackRecordArmed(TrackId trackId, bool armed) {
 
 void TrackManager::setTrackInputMonitor(TrackId trackId, InputMonitorMode mode) {
     if (auto* track = getTrack(trackId)) {
+        // Group summing tracks take no external input, so input monitoring does
+        // not apply to them.
+        if (track->type == TrackType::Group)
+            return;
         track->inputMonitor = mode;
         notifyTrackPropertyChanged(trackId);
     }
@@ -1439,9 +1444,9 @@ void TrackManager::setTrackMidiInput(TrackId trackId, const juce::String& device
         return;
     }
 
-    // Aux tracks never receive MIDI
-    if (track->type == TrackType::Aux) {
-        DBG("Cannot set MIDI input on aux track " << trackId);
+    // Aux buses and Group summing tracks never receive external MIDI
+    if (track->type == TrackType::Aux || track->type == TrackType::Group) {
+        DBG("Cannot set MIDI input on aux/group track " << trackId);
         return;
     }
 
@@ -1514,6 +1519,12 @@ void TrackManager::setTrackMidiOutput(TrackId trackId, const juce::String& devic
 void TrackManager::setTrackAudioInput(TrackId trackId, const juce::String& deviceId) {
     auto* track = getTrack(trackId);
     if (!track) {
+        return;
+    }
+
+    // Group summing tracks take no external input.
+    if (track->type == TrackType::Group) {
+        DBG("Cannot set audio input on group track " << trackId);
         return;
     }
 

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -831,6 +831,11 @@ class TrackManager {
     TrackManager();
     ~TrackManager() = default;
 
+    // Register a track with MidiBridge for input monitoring. No-op when no audio
+    // engine is attached or the track takes no external input (Aux, Group).
+    // Single place for the create/restore/duplicate/engine-attach wiring.
+    void startMidiMonitoring(const TrackInfo& track, const juce::String& deviceId);
+
     // Mutable resolver — used only by the unified setters in
     // TrackManagerModulation.cpp. Kept private so external callers can't
     // reach in and mutate macros/mods without going through the setter

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -188,7 +188,7 @@ DeviceInfo* findUniqueBareDeviceIdMatch(TrackInfo& masterTrack, std::vector<Trac
 DeviceId TrackManager::addDeviceToChain(TrackId trackId, RackId rackId, ChainId chainId,
                                         const DeviceInfo& device) {
     if (auto* track = getTrack(trackId)) {
-        if (track->type == TrackType::Group && device.isInstrument) {
+        if (!track->canHostInstrument() && device.isInstrument) {
             return INVALID_DEVICE_ID;
         }
     }
@@ -206,7 +206,7 @@ DeviceId TrackManager::addDeviceToChain(TrackId trackId, RackId rackId, ChainId 
 DeviceId TrackManager::addDeviceToChainByPath(const ChainNodePath& chainPath,
                                               const DeviceInfo& device) {
     if (auto* track = getTrack(chainPath.trackId)) {
-        if (track->type == TrackType::Group && device.isInstrument) {
+        if (!track->canHostInstrument() && device.isInstrument) {
             return INVALID_DEVICE_ID;
         }
     }
@@ -260,7 +260,7 @@ DeviceId TrackManager::addDeviceToChainByPath(const ChainNodePath& chainPath,
 DeviceId TrackManager::addDeviceToChainByPath(const ChainNodePath& chainPath,
                                               const DeviceInfo& device, int insertIndex) {
     if (auto* track = getTrack(chainPath.trackId)) {
-        if (track->type == TrackType::Group && device.isInstrument) {
+        if (!track->canHostInstrument() && device.isInstrument) {
             return INVALID_DEVICE_ID;
         }
     }

--- a/tests/test_group_tracks_and_macros.cpp
+++ b/tests/test_group_tracks_and_macros.cpp
@@ -138,6 +138,26 @@ TEST_CASE("Group track rejects instrument plugins", "[group_track][instrument]")
     }
 }
 
+TEST_CASE("Group track takes no external input", "[group_track][input]") {
+    GroupMacroTestFixture fixture;
+
+    auto groupId = fixture.tm().createGroupTrack("Bus");
+    REQUIRE(groupId != INVALID_TRACK_ID);
+    auto* group = fixture.tm().getTrack(groupId);
+    REQUIRE(group != nullptr);
+    REQUIRE(group->type == TrackType::Group);
+
+    SECTION("is not seeded with a MIDI input") {
+        REQUIRE(group->midiInputDevice.isEmpty());
+    }
+
+    SECTION("cannot be record-armed") {
+        REQUIRE_FALSE(group->recordArmed);
+        fixture.tm().setTrackRecordArmed(groupId, true);
+        REQUIRE_FALSE(fixture.tm().getTrack(groupId)->recordArmed);
+    }
+}
+
 TEST_CASE("Group track rejects instruments inside rack chains", "[group_track][instrument][rack]") {
     GroupMacroTestFixture fixture;
 

--- a/tests/test_group_tracks_and_macros.cpp
+++ b/tests/test_group_tracks_and_macros.cpp
@@ -156,6 +156,21 @@ TEST_CASE("Group track takes no external input", "[group_track][input]") {
         fixture.tm().setTrackRecordArmed(groupId, true);
         REQUIRE_FALSE(fixture.tm().getTrack(groupId)->recordArmed);
     }
+
+    SECTION("rejects MIDI input assignment") {
+        fixture.tm().setTrackMidiInput(groupId, "all");
+        REQUIRE(fixture.tm().getTrack(groupId)->midiInputDevice.isEmpty());
+    }
+
+    SECTION("rejects audio input assignment") {
+        fixture.tm().setTrackAudioInput(groupId, "some-device");
+        REQUIRE(fixture.tm().getTrack(groupId)->audioInputDevice.isEmpty());
+    }
+
+    SECTION("rejects input monitoring") {
+        fixture.tm().setTrackInputMonitor(groupId, InputMonitorMode::In);
+        REQUIRE(fixture.tm().getTrack(groupId)->inputMonitor == InputMonitorMode::Off);
+    }
 }
 
 TEST_CASE("Group track rejects instruments inside rack chains", "[group_track][instrument][rack]") {

--- a/tests/test_group_tracks_and_macros.cpp
+++ b/tests/test_group_tracks_and_macros.cpp
@@ -339,6 +339,16 @@ TEST_CASE("Audio and Instrument tracks accept instruments", "[group_track][instr
         auto id = fixture.tm().addDeviceToTrack(trackId, instrument);
         REQUIRE(id == INVALID_DEVICE_ID);
     }
+
+    SECTION("Aux track rejects instrument in a rack chain") {
+        auto trackId = fixture.tm().createTrack("Aux", TrackType::Aux);
+        auto rackId = fixture.tm().addRackToTrack(trackId, "FX Rack");
+        auto* rack = fixture.tm().getRack(trackId, rackId);
+        REQUIRE(rack != nullptr);
+        auto chainId = rack->chains[0].id;
+        REQUIRE(fixture.tm().addDeviceToChain(trackId, rackId, chainId, instrument) ==
+                INVALID_DEVICE_ID);
+    }
 }
 
 // ============================================================================

--- a/tests/test_group_tracks_and_macros.cpp
+++ b/tests/test_group_tracks_and_macros.cpp
@@ -173,6 +173,31 @@ TEST_CASE("Group track takes no external input", "[group_track][input]") {
     }
 }
 
+TEST_CASE("Restoring a group track sanitizes stale input state", "[group_track][input]") {
+    GroupMacroTestFixture fixture;
+
+    // Simulate a project saved before the no-input invariant: a group carrying
+    // MIDI/audio input, monitoring, and record-arm.
+    TrackInfo info;
+    info.id = 100;
+    info.name = "Old Bus";
+    info.type = TrackType::Group;
+    info.midiInputDevice = "all";
+    info.audioInputDevice = "some-device";
+    info.inputMonitor = InputMonitorMode::In;
+    info.recordArmed = true;
+
+    fixture.tm().restoreTrack(info);
+
+    auto* g = fixture.tm().getTrack(100);
+    REQUIRE(g != nullptr);
+    REQUIRE(g->type == TrackType::Group);
+    REQUIRE(g->midiInputDevice.isEmpty());
+    REQUIRE(g->audioInputDevice.isEmpty());
+    REQUIRE(g->inputMonitor == InputMonitorMode::Off);
+    REQUIRE_FALSE(g->recordArmed);
+}
+
 TEST_CASE("Group track rejects instruments inside rack chains", "[group_track][instrument][rack]") {
     GroupMacroTestFixture fixture;
 


### PR DESCRIPTION
Groups have no clip timeline (clip drops are blocked and the group lane only draws a child-clip extent indicator), so they can't record or take external input. This makes the data model match the UI, which already hides record / input-monitor / audio-in / MIDI-in on groups.

Group input invariant, enforced at every entry point (createTrack, restoreTrack incl. sanitizing stale on-disk state, duplicateTrack, setAudioEngine, the record/monitor/MIDI-in/audio-in setters, and MidiInputRouter):
- Groups are never seeded with a MIDI input and never registered with MidiBridge.
- Record-arm, input monitoring, and MIDI/audio input assignment are no-ops on groups.

Centralized the scattered `type == Aux/Group/Master` capability checks behind predicates on TrackInfo, so each rule lives in one place:
- `takesExternalInput()` (not Aux, not Group) - the input/record/monitor guards. Also makes Aux consistently input-less (previously only partially guarded).
- `canHostInstrument()` (not Aux, not Group, not Master) - the instrument-add guards in `addDeviceToTrack` and the rack-chain add paths. Fixes an inconsistency where chains rejected instruments only on Group, so instruments could be added to Aux/Master rack chains.

Also dedups the repeated MidiBridge wiring into a private `TrackManager::startMidiMonitoring()` helper. `TrackInfo` stays a pure data model (predicates only, no engine reference).

Tests: group input rejection (seed, record-arm, MIDI/audio input, monitor), restore sanitization, and instrument rejection on an Aux rack chain.

Closes #1689