### PR TITLE
Unify clipboard-paste target resolution into a single resolver (#1685)

### DIFF
--- a/magda/daw/core/CMakeLists.txt
+++ b/magda/daw/core/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(magda_daw PRIVATE
     MidiChordMarkers.cpp
     MidiFileWriter.cpp
     SelectionManager.cpp
+    PasteTargetResolver.cpp
     GestureRouter.cpp
     AutomationInfo.cpp
     AutomationManager.cpp
@@ -93,6 +94,7 @@ target_sources(magda_daw PRIVATE
     SessionLaunchService.hpp
     MidiFileWriter.hpp
     SelectionManager.hpp
+    PasteTargetResolver.hpp
     LinkModeManager.hpp
     GainStagingManager.hpp
     UndoManager.hpp

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -2919,6 +2919,11 @@ std::vector<ClipId> ClipManager::pasteFromClipboardBeats(double pasteBeat, Track
     // Track which scene slots have been used during this paste (for multi-clip session paste)
     std::unordered_map<TrackId, int> trackSceneMap;
 
+    // Clips that resolve to no track at all. A real paste entry point always
+    // supplies a target via resolvePasteTarget(), so a non-zero count here means
+    // a caller skipped that resolver (the #1670 class of bug). Surfaced below.
+    int droppedForNoTrack = 0;
+
     for (const auto& clipData : clipboard_) {
         // Calculate new start beat maintaining relative position
         const double newStartBeat = clipData.placement.startBeat + beatOffset;
@@ -2927,6 +2932,7 @@ std::vector<ClipId> ClipManager::pasteFromClipboardBeats(double pasteBeat, Track
         // Determine target track
         TrackId newTrackId = (targetTrackId != INVALID_TRACK_ID) ? targetTrackId : clipData.trackId;
         if (newTrackId == INVALID_TRACK_ID) {
+            ++droppedForNoTrack;
             continue;
         }
 
@@ -3087,6 +3093,13 @@ std::vector<ClipId> ClipManager::pasteFromClipboardBeats(double pasteBeat, Track
 
             newClips.push_back(newClipId);
         }
+    }
+
+    if (droppedForNoTrack > 0) {
+        DBG("CLIPBOARD: pasteFromClipboardBeats dropped "
+            << droppedForNoTrack
+            << " clip(s) with no target track (no explicit target and no source track). "
+               "The paste entry point should resolve a target via resolvePasteTarget().");
     }
 
     if (!newClips.empty())

--- a/magda/daw/core/PasteTargetResolver.cpp
+++ b/magda/daw/core/PasteTargetResolver.cpp
@@ -1,0 +1,45 @@
+#include "PasteTargetResolver.hpp"
+
+#include "SelectionManager.hpp"
+#include "TrackManager.hpp"
+
+namespace magda {
+
+PasteTarget resolvePasteTarget(ViewMode mode, PasteTrackMode trackMode,
+                               const PasteInvocation& invocation) {
+    // Ripple paste keeps every clip on its own source track: there is no single
+    // target, and INVALID_TRACK_ID is the correct, expected value.
+    if (trackMode == PasteTrackMode::PreserveOriginalTracks)
+        return {.trackId = INVALID_TRACK_ID, .ok = true};
+
+    auto& trackManager = TrackManager::getInstance();
+
+    // A context invocation (right-click on a clip, a track area, or a session
+    // slot) targets that track directly. Fall through to selection-based
+    // resolution only if the context track has since disappeared.
+    if (invocation.kind == PasteInvocation::Kind::ContextClip &&
+        invocation.contextTrackId != INVALID_TRACK_ID &&
+        trackManager.getTrack(invocation.contextTrackId) != nullptr) {
+        return {.trackId = invocation.contextTrackId, .ok = true};
+    }
+
+    // Selection-based: the selected track, else the first visible track in this
+    // view, else the first visible track in the arrangement.
+    const auto selectedTrack = SelectionManager::getInstance().getSelectedTrack();
+    if (selectedTrack != INVALID_TRACK_ID && trackManager.getTrack(selectedTrack) != nullptr)
+        return {.trackId = selectedTrack, .ok = true};
+
+    auto visibleTracks = trackManager.getVisibleTracks(mode);
+    if (!visibleTracks.empty())
+        return {.trackId = visibleTracks.front(), .ok = true};
+
+    if (mode != ViewMode::Arrange) {
+        visibleTracks = trackManager.getVisibleTracks(ViewMode::Arrange);
+        if (!visibleTracks.empty())
+            return {.trackId = visibleTracks.front(), .ok = true};
+    }
+
+    return {.trackId = INVALID_TRACK_ID, .ok = false};
+}
+
+}  // namespace magda

--- a/magda/daw/core/PasteTargetResolver.cpp
+++ b/magda/daw/core/PasteTargetResolver.cpp
@@ -15,12 +15,16 @@ PasteTarget resolvePasteTarget(ViewMode mode, PasteTrackMode trackMode,
     auto& trackManager = TrackManager::getInstance();
 
     // A context invocation (right-click on a clip, a track area, or a session
-    // slot) targets that track directly. Fall through to selection-based
-    // resolution only if the context track has since disappeared.
-    if (invocation.kind == PasteInvocation::Kind::ContextClip &&
-        invocation.contextTrackId != INVALID_TRACK_ID &&
-        trackManager.getTrack(invocation.contextTrackId) != nullptr) {
-        return {.trackId = invocation.contextTrackId, .ok = true};
+    // slot) has an explicit target: land on that track, or abort. Never fall
+    // through to the selection. If the context track disappeared between
+    // opening the async menu and running the action, migrating the paste to
+    // whatever is selected is the wrong-track failure this resolver exists to
+    // prevent; a no-op is the safe answer.
+    if (invocation.kind == PasteInvocation::Kind::ContextClip) {
+        if (invocation.contextTrackId != INVALID_TRACK_ID &&
+            trackManager.getTrack(invocation.contextTrackId) != nullptr)
+            return {.trackId = invocation.contextTrackId, .ok = true};
+        return {.trackId = INVALID_TRACK_ID, .ok = false};
     }
 
     // Selection-based: the selected track, else the first visible track in this

--- a/magda/daw/core/PasteTargetResolver.hpp
+++ b/magda/daw/core/PasteTargetResolver.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <cstdint>
+
+#include "TypeIds.hpp"
+#include "ViewModeState.hpp"
+
+namespace magda {
+
+/**
+ * @brief The single authority for computing a clipboard-paste target track.
+ *
+ * Historically every paste entry point (keyboard command, context menu,
+ * track-area menu, session slot) computed its own target track, drawing from
+ * two different selection models. That is how the paste-on-wrong-track bug
+ * (#1670) happened and how the class recurs. This resolver is the ONLY code
+ * allowed to compute a paste target: new entry points describe where they were
+ * invoked from and what track semantic they want, and get back one answer.
+ *
+ * Scope: user-facing "Paste" of the clip clipboard. Duplicate-in-place ops
+ * (Duplicate Time Range / Loop / Selection) are a different operation whose
+ * paste step is definitionally PreserveOriginalTracks and which derive their
+ * multi-track set from the time selection, not from this resolver.
+ */
+
+/// Whether a paste pins every clip onto one resolved track, or lets each clip
+/// keep its own source track.
+enum class PasteTrackMode : std::uint8_t {
+    PinToResolvedTrack,     ///< Normal paste: all clips land on one resolved track.
+    PreserveOriginalTracks  ///< Ripple paste: each clip keeps its source track.
+};
+
+/// Where the paste was invoked from. Determines how PinToResolvedTrack computes
+/// its target; PreserveOriginalTracks ignores it.
+struct PasteInvocation {
+    enum class Kind : std::uint8_t {
+        Selection,   ///< Keyboard/menu command: use the selected track, else first visible.
+        ContextClip  ///< Right-click on a clip/track/slot: use that context track.
+    };
+
+    Kind kind = Kind::Selection;
+    TrackId contextTrackId = INVALID_TRACK_ID;  ///< Only used for ContextClip.
+
+    static PasteInvocation fromSelection() {
+        return {.kind = Kind::Selection, .contextTrackId = INVALID_TRACK_ID};
+    }
+    static PasteInvocation fromContextTrack(TrackId trackId) {
+        return {.kind = Kind::ContextClip, .contextTrackId = trackId};
+    }
+};
+
+/// Outcome of resolution.
+struct PasteTarget {
+    /// Track to pass to pasteFromClipboardBeats. INVALID_TRACK_ID paired with
+    /// PreserveOriginalTracks is intentional (keep each clip's source track).
+    TrackId trackId = INVALID_TRACK_ID;
+    /// False only for PinToResolvedTrack when no track could be resolved (the
+    /// edit has no visible tracks). Callers must abort the paste in that case.
+    bool ok = true;
+};
+
+/// Compute the paste target track. See the header doc for the contract.
+PasteTarget resolvePasteTarget(ViewMode mode, PasteTrackMode trackMode,
+                               const PasteInvocation& invocation);
+
+}  // namespace magda

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -28,6 +28,7 @@
 #include "core/ClipPropertyCommands.hpp"
 #include "core/GestureRouter.hpp"
 #include "core/MidiNoteCommands.hpp"
+#include "core/PasteTargetResolver.hpp"
 #include "core/SelectionManager.hpp"
 #include "core/TempoUtils.hpp"
 #include "core/TrackManager.hpp"
@@ -3449,11 +3450,17 @@ void ClipComponent::showContextMenu() {
                         }
                     }
                     const double bpm = parentPanel_ ? parentPanel_->getTempo() : 120.0;
-                    TrackId targetTrackId = INVALID_TRACK_ID;
+                    TrackId contextTrackId = INVALID_TRACK_ID;
                     if (const auto* contextClip = clipManager.getClip(clipId_))
-                        targetTrackId = contextClip->trackId;
+                        contextTrackId = contextClip->trackId;
+                    const auto target =
+                        resolvePasteTarget(ViewModeController::getInstance().getViewMode(),
+                                           PasteTrackMode::PinToResolvedTrack,
+                                           PasteInvocation::fromContextTrack(contextTrackId));
+                    if (!target.ok)
+                        break;
                     auto cmd = std::make_unique<PasteClipCommand>(
-                        BeatPosition{pasteTime * bpm / 60.0}, targetTrackId);
+                        BeatPosition{pasteTime * bpm / 60.0}, target.trackId);
                     auto* cmdPtr = cmd.get();
                     UndoManager::getInstance().executeCommand(std::move(cmd));
                     const auto& pastedIds = cmdPtr->getPastedClipIds();

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -19,6 +19,7 @@
 #include "core/AutomationCommands.hpp"
 #include "core/ClipCommands.hpp"
 #include "core/MidiChordMarkers.hpp"
+#include "core/PasteTargetResolver.hpp"
 #include "core/SelectionManager.hpp"
 #include "core/TempoUtils.hpp"
 #include "core/TrackCommands.hpp"
@@ -2042,8 +2043,13 @@ void TrackContentPanel::showEmptySpaceContextMenu(const juce::MouseEvent& event)
             }
             case 2: {  // Paste
                 const double bpm = safeThis ? safeThis->getTempo() : 120.0;
+                const auto target = resolvePasteTarget(
+                    ViewModeController::getInstance().getViewMode(),
+                    PasteTrackMode::PinToResolvedTrack, PasteInvocation::fromContextTrack(trackId));
+                if (!target.ok)
+                    break;
                 auto cmd = std::make_unique<PasteClipCommand>(BeatPosition{startTime * bpm / 60.0},
-                                                              trackId);
+                                                              target.trackId);
                 auto* cmdPtr = cmd.get();
                 UndoManager::getInstance().executeCommand(std::move(cmd));
 

--- a/magda/daw/ui/views/SessionView.cpp
+++ b/magda/daw/ui/views/SessionView.cpp
@@ -29,6 +29,7 @@
 #include "core/ClipCommands.hpp"
 #include "core/ClipPropertyCommands.hpp"
 #include "core/Config.hpp"
+#include "core/PasteTargetResolver.hpp"
 #include "core/SelectionManager.hpp"
 #include "core/SessionLaunchService.hpp"
 #include "core/SessionViewState.hpp"
@@ -2602,9 +2603,14 @@ void SessionView::wireClipSlotCallbacks(ClipSlotButton& slot, int trackIndex, in
     slot.onPasteClip = [this, trackIndex, sceneIndex]() {
         if (!ClipManager::getInstance().hasClipsInClipboard())
             return;
-        TrackId tId = visibleTrackIds_[trackIndex];
-        auto cmd = std::make_unique<PasteClipCommand>(BeatPosition{0.0}, tId, ClipView::Session,
-                                                      sceneIndex);
+        const TrackId tId = visibleTrackIds_[trackIndex];
+        const auto target = resolvePasteTarget(ViewModeController::getInstance().getViewMode(),
+                                               PasteTrackMode::PinToResolvedTrack,
+                                               PasteInvocation::fromContextTrack(tId));
+        if (!target.ok)
+            return;
+        auto cmd = std::make_unique<PasteClipCommand>(BeatPosition{0.0}, target.trackId,
+                                                      ClipView::Session, sceneIndex);
         UndoManager::getInstance().executeCommand(std::move(cmd));
     };
     slot.onDuplicateClip = [this, trackIndex, sceneIndex]() {

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -3,6 +3,7 @@
 #include "../../core/ClipManager.hpp"
 #include "../../core/Config.hpp"
 #include "../../core/MidiNoteCommands.hpp"
+#include "../../core/PasteTargetResolver.hpp"
 #include "../../core/SelectionManager.hpp"
 #include "../../core/TrackCommands.hpp"
 #include "../../core/TrackManager.hpp"
@@ -64,32 +65,6 @@ bool overlapsTimelineRange(const ClipInfo& clip, double startSeconds, double end
                            double bpm) {
     return timelineStartSeconds(clip, bpm) < endSeconds &&
            timelineEndSeconds(clip, bpm) > startSeconds;
-}
-
-TrackId resolvePasteTargetTrack(ViewMode mode) {
-    auto& selectionManager = SelectionManager::getInstance();
-    auto& trackManager = TrackManager::getInstance();
-
-    const auto selectedTrack = selectionManager.getSelectedTrack();
-    const auto* selectedTrackInfo =
-        selectedTrack != INVALID_TRACK_ID ? trackManager.getTrack(selectedTrack) : nullptr;
-    if (selectedTrackInfo != nullptr) {
-        return selectedTrack;
-    }
-
-    auto visibleTracks = trackManager.getVisibleTracks(mode);
-    if (!visibleTracks.empty()) {
-        return visibleTracks.front();
-    }
-
-    if (mode != ViewMode::Arrange) {
-        visibleTracks = trackManager.getVisibleTracks(ViewMode::Arrange);
-        if (!visibleTracks.empty()) {
-            return visibleTracks.front();
-        }
-    }
-
-    return INVALID_TRACK_ID;
 }
 
 // Ripple the global tempo/time-sig/pitch sequences to match a time-range clip
@@ -691,10 +666,13 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
 
                 if (viewMode == ViewMode::Live) {
                     // Session view: paste into first empty slot on selected track
-                    TrackId targetTrack = resolvePasteTargetTrack(viewMode);
-                    if (targetTrack == INVALID_TRACK_ID) {
+                    const auto target =
+                        resolvePasteTarget(viewMode, PasteTrackMode::PinToResolvedTrack,
+                                           PasteInvocation::fromSelection());
+                    if (!target.ok) {
                         return true;
                     }
+                    const TrackId targetTrack = target.trackId;
 
                     // Find first empty scene slot on the target track
                     int targetScene = 0;
@@ -732,10 +710,13 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
 
                     const double bpm =
                         mainView ? mainView->getTimelineController().getState().tempo.bpm : 120.0;
-                    const TrackId targetTrack = resolvePasteTargetTrack(viewMode);
-                    if (targetTrack == INVALID_TRACK_ID) {
+                    const auto target =
+                        resolvePasteTarget(viewMode, PasteTrackMode::PinToResolvedTrack,
+                                           PasteInvocation::fromSelection());
+                    if (!target.ok) {
                         return true;
                     }
+                    const TrackId targetTrack = target.trackId;
 
                     auto cmd = std::make_unique<PasteClipCommand>(
                         BeatPosition{pasteTime * bpm / 60.0}, targetTrack, ClipView::Arrangement);
@@ -1306,11 +1287,14 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
 
             // Ripple-insert room on all tracks (pasted clips keep their own
             // tracks), then paste the clipboard into the gap.
+            const auto rippleTarget = resolvePasteTarget(
+                ViewModeController::getInstance().getViewMode(),
+                PasteTrackMode::PreserveOriginalTracks, PasteInvocation::fromSelection());
             UndoManager::getInstance().beginCompoundOperation("Paste (Ripple)");
             UndoManager::getInstance().executeCommand(
                 std::make_unique<InsertTimeCommand>(targetBeat, span, std::vector<TrackId>{}, bpm));
             UndoManager::getInstance().executeCommand(
-                std::make_unique<PasteClipCommand>(BeatPosition{targetBeat}));
+                std::make_unique<PasteClipCommand>(BeatPosition{targetBeat}, rippleTarget.trackId));
             // Paste ripples all tracks, so markers and tempo/pitch shift too.
             UndoManager::getInstance().executeCommand(std::make_unique<RippleMarkersCommand>(
                 RippleMarkersCommand::Mode::Insert, targetBeat, targetBeat + span));


### PR DESCRIPTION
Every clipboard-paste entry point used to compute its own target track, drawing from two different selection models. That is how the paste-on- wrong-track bug (#1670) happened and how the class recurs.

Add PasteTargetResolver: the only code allowed to compute a paste target. It takes (view mode, PasteTrackMode, PasteInvocation) and returns {trackId, ok}, so:
- the paste-vs-ripple semantic is an explicit PasteTrackMode parameter (PinToResolvedTrack vs PreserveOriginalTracks) instead of an accident of which call site passes what,
- the "no track to paste onto, abort" gating lives in one place (ok flag).

Route all five genuine paste entry points through it: paste (Live and Arrange), pasteRipple (now explicitly PreserveOriginalTracks), context-menu paste, track-area menu paste, and session-slot paste. Delete the file-local resolvePasteTargetTrack() and its per-call-site INVALID gating.

pasteFromClipboardBeats() now counts and logs clips dropped for lack of a target track instead of skipping silently; a non-zero count means a caller bypassed the resolver.