### PR TITLE
Move Linux CI compile cache to sccache + S3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ env:
 jobs:
   build-and-test-linux:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # assume the sccache S3 role via OIDC
+      contents: read
     # Skip C++ build/test when explicitly requested or when only non-C++ files changed
     if: |
       github.event_name != 'workflow_dispatch' ||
@@ -92,18 +95,31 @@ jobs:
           xvfb
         cp /var/cache/apt/archives/*.deb ~/apt-cache/ 2>/dev/null || true
 
-    - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+    # Compile cache: sccache backed by S3 (see infra/sccache). Replaces the
+    # actions/cache-backed ccache, which was branch-scoped and shared the 10 GB
+    # per-repo cache budget, so ephemeral Linux runs were almost always cold.
+    # The S3 bucket is shared across runs/branches and uncapped, so warm hits
+    # actually survive. The linux prefix is shared with the JUCE-tests job so
+    # their common translation units hit each other's objects.
+    - name: Configure AWS credentials (sccache S3, OIDC)
+      uses: aws-actions/configure-aws-credentials@v4
       with:
-        key: ${{ runner.os }}-ccache-content-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-ccache-content-
-        # Default cap is 500 MB, far too small for this project (llama + ggml +
-        # faust + onnx + JUCE + TE). It filled and thrashed, giving an ~8% hit
-        # rate and recompiling ~92% of TUs every run. 3G holds the whole build
-        # (~1.5G compressed) with headroom, so warm runs are mostly cache hits,
-        # and stays under the 10G repo cache budget shared with the other caches.
-        max-size: 3G
+        role-to-assume: ${{ secrets.AWS_SCCACHE_ROLE_ARN }}
+        aws-region: eu-west-2
+
+    - name: Setup sccache
+      env:
+        SCCACHE_BUCKET_SECRET: ${{ secrets.SCCACHE_BUCKET }}
+      run: |
+        SCCACHE_VERSION=v0.8.1
+        curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" | tar xz
+        sudo mv sccache-*/sccache /usr/local/bin/sccache
+        sccache --version
+        {
+          echo "SCCACHE_BUCKET=${SCCACHE_BUCKET_SECRET}"
+          echo "SCCACHE_REGION=eu-west-2"
+          echo "SCCACHE_S3_KEY_PREFIX=linux"
+        } >> "$GITHUB_ENV"
 
     - name: Cache CMake build directory
       uses: actions/cache@v6
@@ -152,8 +168,8 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
           -DMAGDA_BUILD_TESTS=ON \
-          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
           ${{ steps.faust-cache.outputs.cache-hit == 'true' && format('-DMAGDA_FAUST_PREBUILT_DIR={0}/third_party/faust/build', github.workspace) || '' }} \
           ${{ steps.mutable-cache.outputs.cache-hit == 'true' && format('-DMAGDA_MUTABLE_PREBUILT_DIR={0}/third_party/eurorack/build', github.workspace) || '' }}
 
@@ -181,8 +197,8 @@ jobs:
           exit 1
         fi
 
-    - name: Show ccache statistics
-      run: ccache -s
+    - name: Show sccache statistics
+      run: sccache --show-stats
 
     - name: Test summary
       if: success()

--- a/.github/workflows/juce-tests-linux.yml
+++ b/.github/workflows/juce-tests-linux.yml
@@ -19,16 +19,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  # Hash the compiler's CONTENT, not its mtime, when keying ccache objects.
-  # GitHub-hosted Linux runners reprovision the compiler on each run, so mtime
-  # changes even when the compiler bytes are identical. With ccache's default
-  # compiler_check=mtime, restored caches were 100% misses.
-  CCACHE_COMPILERCHECK: content
-
 jobs:
   juce-tests-linux:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # assume the sccache S3 role via OIDC
+      contents: read
 
     steps:
     - uses: actions/checkout@v7
@@ -62,15 +58,27 @@ jobs:
           mesa-common-dev \
           xvfb
 
-    - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+    # Compile cache: sccache backed by S3 (see infra/sccache), sharing the
+    # linux key prefix with the main CI job so common translation units hit.
+    - name: Configure AWS credentials (sccache S3, OIDC)
+      uses: aws-actions/configure-aws-credentials@v4
       with:
-        key: ${{ runner.os }}-juce-ccache-content-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-juce-ccache-content-
-        # Default 500 MB cap thrashes on this project; hold the whole build.
-        # Kept under the 10G repo cache budget shared with the other caches.
-        max-size: 3G
+        role-to-assume: ${{ secrets.AWS_SCCACHE_ROLE_ARN }}
+        aws-region: eu-west-2
+
+    - name: Setup sccache
+      env:
+        SCCACHE_BUCKET_SECRET: ${{ secrets.SCCACHE_BUCKET }}
+      run: |
+        SCCACHE_VERSION=v0.8.1
+        curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" | tar xz
+        sudo mv sccache-*/sccache /usr/local/bin/sccache
+        sccache --version
+        {
+          echo "SCCACHE_BUCKET=${SCCACHE_BUCKET_SECRET}"
+          echo "SCCACHE_REGION=eu-west-2"
+          echo "SCCACHE_S3_KEY_PREFIX=linux"
+        } >> "$GITHUB_ENV"
 
     # Faust/Mutable prebuilt artifacts (#1669): magda_juce_tests links magda_daw
     # for its JUCE UI/audio-driver coverage, not for Faust/Mutable DSP, but it
@@ -108,8 +116,8 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
           -DMAGDA_BUILD_TESTS=ON \
-          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
           ${{ steps.faust-cache.outputs.cache-hit == 'true' && format('-DMAGDA_FAUST_PREBUILT_DIR={0}/third_party/faust/build', github.workspace) || '' }} \
           ${{ steps.mutable-cache.outputs.cache-hit == 'true' && format('-DMAGDA_MUTABLE_PREBUILT_DIR={0}/third_party/eurorack/build', github.workspace) || '' }}
 
@@ -126,5 +134,5 @@ jobs:
 
         xvfb-run -a "$JUCE_TEST_BIN"
 
-    - name: Show ccache statistics
-      run: ccache -s
+    - name: Show sccache statistics
+      run: sccache --show-stats

--- a/infra/sccache/.gitignore
+++ b/infra/sccache/.gitignore
@@ -1,0 +1,9 @@
+# Local Terraform state and working dirs. State lives on the operator's machine
+# for this small, rarely-changed stack; the .terraform.lock.hcl IS committed.
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+crash.log
+crash.*.log
+*.auto.tfvars.local

--- a/infra/sccache/.terraform.lock.hcl
+++ b/infra/sccache/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/sccache/README.md
+++ b/infra/sccache/README.md
@@ -1,0 +1,40 @@
+# CI sccache S3 cache
+
+Terraform for the shared compile cache the Linux CI jobs use via
+[sccache](https://github.com/mozilla/sccache) with an S3 backend. This replaces
+the `actions/cache`-backed ccache, which was branch-scoped and capped at the
+10 GB per-repo cache budget, so Linux runs were almost always cold.
+
+## What it creates
+
+- An S3 bucket (`magda-ci-sccache-<account-id>`) with public access blocked and
+  a 14-day object-expiry lifecycle rule.
+- An IAM role assumed by GitHub Actions via OIDC, trust-scoped to
+  `repo:Conceptual-Machines/magda-core:*`, with least-privilege
+  `GetObject`/`PutObject`/`ListBucket` on that one bucket.
+
+The account-global GitHub OIDC provider already exists and is referenced, not
+managed here.
+
+## Usage
+
+```sh
+cd infra/sccache
+terraform init
+terraform plan      # review the trust policy before applying
+terraform apply
+```
+
+State is local (`terraform.tfstate`, gitignored). The resources are static and
+rarely change; if this grows, migrate to an S3 state backend.
+
+## Wiring into CI
+
+After `apply`, feed the outputs to the Linux workflow jobs:
+
+- `SCCACHE_BUCKET` = `bucket_name`
+- `SCCACHE_REGION` = `region`
+- `configure-aws-credentials` `role-to-assume` = `role_arn`
+
+The job needs `permissions: id-token: write` for OIDC, and builds with
+`-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache`.

--- a/infra/sccache/main.tf
+++ b/infra/sccache/main.tf
@@ -1,0 +1,109 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+
+# The GitHub Actions OIDC provider is account-global and already exists in this
+# account, so reference it rather than manage a second copy.
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+locals {
+  bucket_name = "${var.bucket_prefix}-${data.aws_caller_identity.current.account_id}"
+}
+
+# --- S3 bucket holding the sccache compile-cache objects ------------------------
+
+resource "aws_s3_bucket" "sccache" {
+  bucket = local.bucket_name
+
+  tags = {
+    Project = "magda"
+    Purpose = "ci-sccache"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "sccache" {
+  bucket                  = aws_s3_bucket.sccache.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Compile-cache objects are disposable; expire them so the bucket self-prunes
+# and does not accumulate cost or stale entries.
+resource "aws_s3_bucket_lifecycle_configuration" "sccache" {
+  bucket = aws_s3_bucket.sccache.id
+
+  rule {
+    id     = "expire-sccache-objects"
+    status = "Enabled"
+
+    filter {} # whole bucket
+
+    expiration {
+      days = var.object_expiry_days
+    }
+  }
+}
+
+# --- IAM role assumed by GitHub Actions via OIDC --------------------------------
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github.arn]
+    }
+
+    # Standard audience for AWS federation.
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    # Scope to this repo only (any branch/tag/PR). CI runs on all branches, so
+    # the subject is left wildcarded past the repo path.
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.github_repo}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "sccache" {
+  name               = var.role_name
+  description        = "GitHub Actions OIDC role for the CI sccache S3 cache (${var.github_repo})."
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+}
+
+# Least privilege: read/write cache objects and list the one bucket, nothing else.
+data "aws_iam_policy_document" "sccache" {
+  statement {
+    sid       = "SccacheObjectReadWrite"
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:PutObject"]
+    resources = ["${aws_s3_bucket.sccache.arn}/*"]
+  }
+
+  statement {
+    sid       = "SccacheListBucket"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.sccache.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "sccache" {
+  name   = "sccache-s3-access"
+  role   = aws_iam_role.sccache.id
+  policy = data.aws_iam_policy_document.sccache.json
+}

--- a/infra/sccache/outputs.tf
+++ b/infra/sccache/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_name" {
+  description = "S3 bucket for sccache objects (set as SCCACHE_BUCKET in CI)."
+  value       = aws_s3_bucket.sccache.id
+}
+
+output "region" {
+  description = "Bucket region (set as SCCACHE_REGION in CI)."
+  value       = var.region
+}
+
+output "role_arn" {
+  description = "IAM role ARN GitHub Actions assumes via OIDC (role-to-assume in configure-aws-credentials)."
+  value       = aws_iam_role.sccache.arn
+}

--- a/infra/sccache/variables.tf
+++ b/infra/sccache/variables.tf
@@ -1,0 +1,29 @@
+variable "region" {
+  description = "AWS region for the sccache bucket. Kept close to where CI runs to minimise cache round-trip latency."
+  type        = string
+  default     = "eu-west-2"
+}
+
+variable "github_repo" {
+  description = "owner/name of the repo whose GitHub Actions runs may assume the cache role."
+  type        = string
+  default     = "Conceptual-Machines/magda-core"
+}
+
+variable "bucket_prefix" {
+  description = "Prefix for the cache bucket name; the account id is appended for global uniqueness."
+  type        = string
+  default     = "magda-ci-sccache"
+}
+
+variable "role_name" {
+  description = "Name of the IAM role GitHub Actions assumes via OIDC."
+  type        = string
+  default     = "magda-ci-sccache"
+}
+
+variable "object_expiry_days" {
+  description = "Days after which cached objects expire, so the bucket self-prunes and stays fresh/cheap."
+  type        = number
+  default     = 14
+}

--- a/infra/sccache/versions.tf
+++ b/infra/sccache/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
The actions/cache-backed ccache was branch-scoped and shared the 10 GB per-repo cache budget, so ephemeral ubuntu-latest runs were almost always cold (~100% miss, recompiling most TUs every run). Replace it on the Linux build and JUCE-test jobs with sccache backed by a shared, uncapped S3 bucket, assumed via GitHub OIDC.

- infra/sccache: Terraform for the S3 bucket (14-day object expiry) plus a repo-scoped, least-privilege OIDC role. State is local/gitignored.
- ci.yml + juce-tests-linux.yml: drop ccache-action and its actions/cache round-trip, add OIDC creds + sccache, share the "linux" key prefix so the two jobs' common translation units hit each other.

codeql stays on ccache (a reliably warm cache breaks its build tracing); Windows is unchanged (self-hosted covers it, and sccache-on-MSVC is a separate spike).