### PR TITLE
Implement explicit audio clip crossfades (#1499)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -368,6 +368,7 @@
     "toggle.duplicate_loop_grows": "Duplicate Loop Range grows the loop (off: advances it)",
     "toggle.open_plugin_window_on_drop": "Open plugin window when added to a chain",
     "toggle.chord_preview_default": "Preview chord track on playback by default",
+    "toggle.auto_crossfade_default": "Auto-crossfade new audio clips",
     "toggle.show_tooltips": "Show tooltips",
     "button.add_colour": "+ Add Colour",
     "button.browse": "Browse",

--- a/magda/daw/core/ClipCommands.cpp
+++ b/magda/daw/core/ClipCommands.cpp
@@ -414,14 +414,15 @@ bool DeleteClipCommand::validateState() const {
 
 CreateClipCommand::CreateClipCommand(ClipType type, TrackId trackId, BeatPosition startBeat,
                                      BeatDuration lengthBeats, const juce::String& audioFilePath,
-                                     ClipView view, double tempo)
+                                     ClipView view, double tempo, ClipOverlapPolicy overlapPolicy)
     : type_(type),
       trackId_(trackId),
       startBeat_(startBeat.value),
       lengthBeats_(lengthBeats.value),
       audioFilePath_(audioFilePath),
       view_(view),
-      tempo_(tempo) {}
+      tempo_(tempo),
+      overlapPolicy_(overlapPolicy) {}
 
 bool CreateClipCommand::canExecute() const {
     return trackId_ != INVALID_TRACK_ID && lengthBeats_ > 0.0;
@@ -438,10 +439,11 @@ void CreateClipCommand::execute() {
     }
 
     if (type_ == ClipType::Audio) {
-        createdClipId_ = clipManager.createAudioClipBeats(trackId_, startBeat_, lengthBeats_,
-                                                          audioFilePath_, view_, tempo_);
+        createdClipId_ = clipManager.createAudioClipBeats(
+            trackId_, startBeat_, lengthBeats_, audioFilePath_, view_, tempo_, overlapPolicy_);
     } else {
-        createdClipId_ = clipManager.createMidiClipBeats(trackId_, startBeat_, lengthBeats_, view_);
+        createdClipId_ = clipManager.createMidiClipBeats(trackId_, startBeat_, lengthBeats_, view_,
+                                                         overlapPolicy_);
     }
 
     executed_ = true;
@@ -867,6 +869,41 @@ void SetFadeCommand::undo() {
         *clip = beforeState_;
         clipManager.forceNotifyClipsChanged();
     }
+}
+
+// ============================================================================
+// SetCrossfadeCommand
+// ============================================================================
+
+SetCrossfadeCommand::SetCrossfadeCommand(ClipId leftId, ClipId rightId, double startBeat,
+                                         double endBeat, double tempo)
+    : leftId_(leftId), rightId_(rightId), startBeat_(startBeat), endBeat_(endBeat), tempo_(tempo) {
+    auto& clipManager = ClipManager::getInstance();
+    const auto* left = clipManager.getClip(leftId_);
+    const auto* right = clipManager.getClip(rightId_);
+    if (left && right) {
+        leftBefore_ = *left;
+        rightBefore_ = *right;
+        captured_ = true;
+    }
+}
+
+void SetCrossfadeCommand::execute() {
+    if (!captured_)
+        return;
+    ClipManager::getInstance().setCrossfadeRegionBeats(leftId_, rightId_, startBeat_, endBeat_,
+                                                       tempo_);
+}
+
+void SetCrossfadeCommand::undo() {
+    if (!captured_)
+        return;
+    auto& clipManager = ClipManager::getInstance();
+    if (auto* left = clipManager.getClip(leftId_))
+        *left = leftBefore_;
+    if (auto* right = clipManager.getClip(rightId_))
+        *right = rightBefore_;
+    clipManager.forceNotifyClipsChanged();
 }
 
 // ============================================================================

--- a/magda/daw/core/ClipCommands.hpp
+++ b/magda/daw/core/ClipCommands.hpp
@@ -190,7 +190,8 @@ class CreateClipCommand : public ValidatedCommand {
   public:
     CreateClipCommand(ClipType type, TrackId trackId, BeatPosition startBeat,
                       BeatDuration lengthBeats, const juce::String& audioFilePath = {},
-                      ClipView view = ClipView::Arrangement, double tempo = 0.0);
+                      ClipView view = ClipView::Arrangement, double tempo = 0.0,
+                      ClipOverlapPolicy overlapPolicy = ClipOverlapPolicy::PreserveExisting);
 
     juce::String getDescription() const override {
         return type_ == ClipType::Audio ? "Create Audio Clip" : "Create MIDI Clip";
@@ -212,6 +213,7 @@ class CreateClipCommand : public ValidatedCommand {
     juce::String audioFilePath_;
     ClipView view_;
     double tempo_;
+    ClipOverlapPolicy overlapPolicy_;
     ClipId createdClipId_ = INVALID_CLIP_ID;
     std::vector<ClipInfo> arrangementSnapshot_;
 };
@@ -372,6 +374,50 @@ class SetFadeCommand : public UndoableCommand {
     ClipId clipId_;
     ClipInfo beforeState_;
     ClipInfo afterState_;
+};
+
+/**
+ * @brief Command for creating/resizing/removing a crossfade between two clips
+ *
+ * A crossfade is the overlap region between two adjacent audio clips (#1499);
+ * this command moves both joint edges to the target region via
+ * ClipManager::setCrossfadeRegionBeats. Both clips' before-states are captured
+ * at construction, so construct it AFTER restoring any live-drag preview.
+ * startBeat == endBeat butts the joint (removes the crossfade).
+ */
+class SetCrossfadeCommand : public UndoableCommand {
+  public:
+    SetCrossfadeCommand(ClipId leftId, ClipId rightId, double startBeat, double endBeat,
+                        double tempo = 0.0);
+
+    juce::String getDescription() const override {
+        return "Adjust Crossfade";
+    }
+
+    void execute() override;
+    void undo() override;
+
+    bool canMergeWith(const UndoableCommand* other) const override {
+        if (auto* o = dynamic_cast<const SetCrossfadeCommand*>(other))
+            return o->leftId_ == leftId_ && o->rightId_ == rightId_;
+        return false;
+    }
+    void mergeWith(const UndoableCommand* other) override {
+        auto* o = static_cast<const SetCrossfadeCommand*>(other);
+        startBeat_ = o->startBeat_;
+        endBeat_ = o->endBeat_;
+        tempo_ = o->tempo_;
+    }
+
+  private:
+    ClipId leftId_;
+    ClipId rightId_;
+    double startBeat_;
+    double endBeat_;
+    double tempo_;
+    ClipInfo leftBefore_;
+    ClipInfo rightBefore_;
+    bool captured_ = false;
 };
 
 /**

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <unordered_map>
 
 #include "../project/ProjectManager.hpp"
@@ -268,6 +269,9 @@ ClipId ClipManager::createAudioClipBeats(TrackId trackId, double startBeats, dou
     // AudioThumbnailManager when the field is still zero.
     clip.offset = 0.0;
     clip.speedRatio = 1.0;
+    // New audio clips default to AUTO-XFADE (#1499): overlaps with other
+    // auto-crossfade audio clips play as crossfades instead of trimming.
+    clip.autoCrossfade = Config::getInstance().getAutoCrossfadeByDefault();
 
     const double bpm = isValidBpm(projectBPM) ? projectBPM : currentProjectTempoOrDefault();
 
@@ -2102,6 +2106,235 @@ void ClipManager::setLaunchFadeSamples(ClipId clipId, int samples) {
 }
 
 // ============================================================================
+// Crossfades (#1499)
+// ============================================================================
+
+// Guard margin (beats) keeping a crossfade edge strictly inside the other
+// clip, so an overlap can never degenerate into full containment.
+static constexpr double kCrossfadeEdgeGuardBeats = 1e-3;
+
+std::optional<ClipManager::CrossfadeInfo> ClipManager::getCrossfadeAtStart(ClipId clipId) const {
+    const auto* clip = getClip(clipId);
+    if (!clip || clip->view != ClipView::Arrangement || !clip->isAudio() || !clip->autoCrossfade)
+        return std::nullopt;
+
+    const double startB = clip->placement.startBeat;
+    const double endB = clip->placement.endBeat();
+
+    // The previous clip whose tail reaches furthest into this clip.
+    const ClipInfo* best = nullptr;
+    for (const auto& [cid, other] : clips_) {
+        if (other.id == clipId || other.view != ClipView::Arrangement ||
+            other.trackId != clip->trackId || !other.isAudio() || !other.autoCrossfade)
+            continue;
+        const double oStart = other.placement.startBeat;
+        const double oEnd = other.placement.endBeat();
+        if (oStart < startB && oEnd > startB && oEnd < endB) {
+            if (!best || oEnd > best->placement.endBeat())
+                best = &other;
+        }
+    }
+    if (!best)
+        return std::nullopt;
+    return CrossfadeInfo{best->id, clipId, startB, best->placement.endBeat()};
+}
+
+std::optional<ClipManager::CrossfadeInfo> ClipManager::getCrossfadeAtEnd(ClipId clipId) const {
+    const auto* clip = getClip(clipId);
+    if (!clip || clip->view != ClipView::Arrangement || !clip->isAudio() || !clip->autoCrossfade)
+        return std::nullopt;
+
+    const double startB = clip->placement.startBeat;
+    const double endB = clip->placement.endBeat();
+
+    // The next clip whose head reaches furthest back into this clip.
+    const ClipInfo* best = nullptr;
+    for (const auto& [cid, other] : clips_) {
+        if (other.id == clipId || other.view != ClipView::Arrangement ||
+            other.trackId != clip->trackId || !other.isAudio() || !other.autoCrossfade)
+            continue;
+        const double oStart = other.placement.startBeat;
+        const double oEnd = other.placement.endBeat();
+        if (oStart > startB && oStart < endB && oEnd > endB) {
+            if (!best || oStart < best->placement.startBeat)
+                best = &other;
+        }
+    }
+    if (!best)
+        return std::nullopt;
+    return CrossfadeInfo{clipId, best->id, best->placement.startBeat, endB};
+}
+
+ClipId ClipManager::findCrossfadeNeighbour(ClipId clipId, bool atStart) const {
+    const auto* clip = getClip(clipId);
+    if (!clip || !clip->isAudio() || clip->view != ClipView::Arrangement)
+        return INVALID_CLIP_ID;
+
+    // Butt joints from splits are beat-exact; the tolerance only absorbs float
+    // wiggle, it does not bridge real gaps.
+    constexpr double tolBeats = 1e-4;
+    const double startB = clip->placement.startBeat;
+    const double endB = clip->placement.endBeat();
+
+    ClipId bestId = INVALID_CLIP_ID;
+    double bestEdge = 0.0;
+    for (const auto& [cid, other] : clips_) {
+        if (other.id == clipId || other.view != ClipView::Arrangement ||
+            other.trackId != clip->trackId || !other.isAudio())
+            continue;
+        const double oStart = other.placement.startBeat;
+        const double oEnd = other.placement.endBeat();
+        if (atStart) {
+            // Previous clip: starts before us, ends at/inside our span
+            if (oStart < startB && oEnd >= startB - tolBeats && oEnd < endB) {
+                if (bestId == INVALID_CLIP_ID || oEnd > bestEdge) {
+                    bestId = other.id;
+                    bestEdge = oEnd;
+                }
+            }
+        } else {
+            // Next clip: ends after us, starts at/inside our span
+            if (oEnd > endB && oStart <= endB + tolBeats && oStart > startB) {
+                if (bestId == INVALID_CLIP_ID || oStart < bestEdge) {
+                    bestId = other.id;
+                    bestEdge = oStart;
+                }
+            }
+        }
+    }
+    return bestId;
+}
+
+double ClipManager::availableLeftExtensionBeats(const ClipInfo& clip, double bpm) const {
+    if (!clip.isAudio())
+        return 0.0;
+    if (clip.loopEnabled)
+        return std::numeric_limits<double>::infinity();
+    if (clip.autoTempo && clip.audio().interpretation.bpm > 0.0) {
+        // Under autoTempo, timeline beats consume source beats 1:1.
+        return juce::jmax(0.0, clip.offsetBeats);
+    }
+    const double speed = clip.speedRatio > 0.0 ? clip.speedRatio : 1.0;
+    return (juce::jmax(0.0, clip.offset) / speed) * bpm / 60.0;
+}
+
+double ClipManager::availableRightExtensionBeats(const ClipInfo& clip, double bpm) const {
+    if (!clip.isAudio())
+        return 0.0;
+    if (clip.loopEnabled)
+        return std::numeric_limits<double>::infinity();
+    if (clip.autoTempo && clip.audio().interpretation.bpm > 0.0) {
+        const auto& interp = clip.audio().interpretation;
+        const double totalBeats = interp.totalBeats > 0.0
+                                      ? interp.totalBeats
+                                      : clip.audio().source.durationSeconds * interp.bpm / 60.0;
+        if (totalBeats <= 0.0)
+            return std::numeric_limits<double>::infinity();
+        return juce::jmax(0.0, totalBeats - (clip.offsetBeats + clip.placement.lengthBeats));
+    }
+    const double sourceDuration = clip.audio().source.durationSeconds;
+    if (sourceDuration <= 0.0)
+        return std::numeric_limits<double>::infinity();
+    const double speed = clip.speedRatio > 0.0 ? clip.speedRatio : 1.0;
+    const double sourceEnd = clip.offset + clip.getTimelineLength(bpm) * speed;
+    return (juce::jmax(0.0, sourceDuration - sourceEnd) / speed) * bpm / 60.0;
+}
+
+bool ClipManager::setCrossfadeRegionBeats(ClipId leftId, ClipId rightId, double startBeat,
+                                          double endBeat, double tempo) {
+    auto* left = getClip(leftId);
+    auto* right = getClip(rightId);
+    if (!left || !right || left == right)
+        return false;
+    if (left->trackId != right->trackId)
+        return false;
+    if (left->view != ClipView::Arrangement || right->view != ClipView::Arrangement)
+        return false;
+    if (!left->isAudio() || !right->isAudio())
+        return false;
+    if (endBeat < startBeat)
+        return false;
+
+    if (right->placement.startBeat < left->placement.startBeat)
+        std::swap(left, right);
+
+    const double bpm = isValidBpm(tempo) ? tempo : currentProjectTempoOrDefault();
+    const double minLenBeats = ClipInfo::MIN_CLIP_LENGTH * bpm / 60.0;
+
+    const double leftStart = left->placement.startBeat;
+    const double leftEnd = left->placement.endBeat();
+    const double rightStart = right->placement.startBeat;
+    const double rightEnd = right->placement.endBeat();
+
+    // Left clip's new right edge: keep it strictly inside the right clip
+    // (no containment), keep the left clip at least minimum length, and don't
+    // outrun the left clip's source tail.
+    const double maxLeftEnd = juce::jmin(rightEnd - kCrossfadeEdgeGuardBeats,
+                                         leftEnd + availableRightExtensionBeats(*left, bpm));
+    const double minLeftEnd = leftStart + minLenBeats;
+    if (maxLeftEnd < minLeftEnd)
+        return false;
+    const double newEnd = juce::jlimit(minLeftEnd, maxLeftEnd, endBeat);
+
+    // Right clip's new left edge: strictly after the left clip's start, keep
+    // the right clip at least minimum length, and don't read before the start
+    // of its source.
+    const double minRightStart = juce::jmax(leftStart + kCrossfadeEdgeGuardBeats,
+                                            rightStart - availableLeftExtensionBeats(*right, bpm));
+    const double maxRightStart = rightEnd - minLenBeats;
+    if (maxRightStart < minRightStart)
+        return false;
+    const double newStart = juce::jlimit(minRightStart, maxRightStart, startBeat);
+
+    bool leftChanged = std::abs(newEnd - leftEnd) > 1e-9;
+    bool rightChanged = std::abs(newStart - rightStart) > 1e-9;
+
+    if (leftChanged) {
+        // Beat-domain target; the seconds boundary stays confined to the
+        // resize helpers (same convention as resolveOverlaps).
+        ClipOperations::resizeContainerFromRight(*left, (newEnd - leftStart) * 60.0 / bpm, bpm);
+    }
+    if (rightChanged) {
+        ClipOperations::resizeContainerFromLeft(*right, (rightEnd - newStart) * 60.0 / bpm, bpm);
+    }
+
+    // A non-empty overlap is a crossfade: both clips need the flag so TE
+    // fades both edges.
+    if (newEnd - newStart > 0.0) {
+        if (!left->autoCrossfade) {
+            left->autoCrossfade = true;
+            leftChanged = true;
+        }
+        if (!right->autoCrossfade) {
+            right->autoCrossfade = true;
+            rightChanged = true;
+        }
+    }
+
+    if (leftChanged)
+        notifyClipPropertyChanged(left->id);
+    if (rightChanged)
+        notifyClipPropertyChanged(right->id);
+    return true;
+}
+
+bool ClipManager::setCrossfadeBeats(ClipId leftId, ClipId rightId, double durationBeats,
+                                    double tempo) {
+    const auto* left = getClip(leftId);
+    const auto* right = getClip(rightId);
+    if (!left || !right)
+        return false;
+    if (right->placement.startBeat < left->placement.startBeat)
+        std::swap(left, right);
+
+    // Joint centre: middle of the current overlap; for abutting clips this is
+    // simply the touch point.
+    const double centre = (right->placement.startBeat + left->placement.endBeat()) * 0.5;
+    const double half = juce::jmax(0.0, durationBeats) * 0.5;
+    return setCrossfadeRegionBeats(left->id, right->id, centre - half, centre + half, tempo);
+}
+
+// ============================================================================
 // Channels
 // ============================================================================
 
@@ -2531,8 +2764,14 @@ void ClipManager::resolveOverlaps(ClipId dominantClipId) {
     const TrackId trackId = dominant->trackId;
     const double bpm = currentProjectTempoOrDefault();
 
+    // An auto-crossfade audio dominant keeps partial overlaps with other audio
+    // clips as crossfades instead of trimming them (#1499). Capture the flags
+    // up front — the dominant pointer is not safe to use once clips_ mutates.
+    const bool dominantWantsCrossfade = dominant->isAudio() && dominant->autoCrossfade;
+
     // Collect IDs to delete and clips to resize (avoid iterator invalidation)
     std::vector<ClipId> toDelete;
+    std::vector<ClipId> toCrossfade;
 
     struct ResizeOp {
         ClipId id;
@@ -2565,11 +2804,21 @@ void ClipManager::resolveOverlaps(ClipId dominantClipId) {
             // C fully covered by D → delete
             toDelete.push_back(clip.id);
         } else if (cStartB < dStartB && cEndB <= dEndB) {
-            // C overlaps from left → trim right edge to dStartB
-            toResize.push_back({clip.id, dStartB - cStartB, false});
+            // C overlaps from left → keep as crossfade, or trim right edge to
+            // dStartB. Strict cEndB < dEndB: an edge-aligned tail is
+            // containment-like, not a partial overlap to crossfade.
+            if (dominantWantsCrossfade && clip.isAudio() && cEndB < dEndB) {
+                toCrossfade.push_back(clip.id);
+            } else {
+                toResize.push_back({clip.id, dStartB - cStartB, false});
+            }
         } else if (cStartB >= dStartB && cEndB > dEndB) {
-            // C overlaps from right → trim left edge to dEndB
-            toResize.push_back({clip.id, cEndB - dEndB, true});
+            // C overlaps from right → keep as crossfade, or trim left edge to dEndB
+            if (dominantWantsCrossfade && clip.isAudio() && cStartB > dStartB) {
+                toCrossfade.push_back(clip.id);
+            } else {
+                toResize.push_back({clip.id, cEndB - dEndB, true});
+            }
         } else if (cStartB < dStartB && cEndB > dEndB) {
             // C fully contains D → split into left + right, keeping both ends.
             // Previously this only kept the left portion and silently dropped
@@ -2624,6 +2873,17 @@ void ClipManager::resolveOverlaps(ClipId dominantClipId) {
                 ClipOperations::resizeContainerFromRight(*clip, newLengthSeconds, bpm);
             }
             notifyClipPropertyChanged(op.id);
+        }
+    }
+
+    // Kept overlaps become crossfades: the neighbour needs the flag too so TE
+    // fades both sides (the dominant already has it).
+    for (auto id : toCrossfade) {
+        if (auto* clip = getClip(id)) {
+            if (!clip->autoCrossfade) {
+                clip->autoCrossfade = true;
+                notifyClipPropertyChanged(id);
+            }
         }
     }
 }

--- a/magda/daw/core/ClipManager.hpp
+++ b/magda/daw/core/ClipManager.hpp
@@ -425,6 +425,64 @@ class ClipManager {
 
     void setLaunchFadeSamples(ClipId clipId, int samples);
 
+    // ========================================================================
+    // Crossfades (#1499)
+    //
+    // A crossfade IS an overlap: two audio arrangement clips on the same track
+    // whose placements partially overlap and whose autoCrossfade flags are set.
+    // Playback fades come from TE's auto-crossfade over the overlap region
+    // (each clip's stored fadeIn/fadeOut returns when the clips are pulled
+    // apart). The geometry is beat-domain and lives in the placements, so it
+    // serializes and round-trips with them — there is no separate duration
+    // field to keep in sync.
+    // ========================================================================
+
+    struct CrossfadeInfo {
+        ClipId leftClipId = INVALID_CLIP_ID;   // earlier clip (fades out)
+        ClipId rightClipId = INVALID_CLIP_ID;  // later clip (fades in)
+        double startBeat = 0.0;                // overlap start (right clip's start)
+        double endBeat = 0.0;                  // overlap end (left clip's end)
+
+        double lengthBeats() const {
+            return endBeat - startBeat;
+        }
+    };
+
+    /// The crossfade covering this clip's start/end edge, if any. Only
+    /// returns a value when the overlap qualifies (both clips audio,
+    /// arrangement, autoCrossfade on, partial overlap).
+    std::optional<CrossfadeInfo> getCrossfadeAtStart(ClipId clipId) const;
+    std::optional<CrossfadeInfo> getCrossfadeAtEnd(ClipId clipId) const;
+
+    /// The audio clip abutting/overlapping this clip's start (previous) or
+    /// end (next) that a crossfade could be created with — regardless of the
+    /// autoCrossfade flags. INVALID_CLIP_ID if none.
+    ClipId findCrossfadeNeighbour(ClipId clipId, bool atStart) const;
+
+    /**
+     * @brief Set the crossfade overlap region between two clips — the core
+     *        beats-authoritative crossfade edit.
+     *
+     * Moves the left clip's right edge to endBeat and the right clip's left
+     * edge to startBeat (content-anchored, via the container resize helpers),
+     * clamped so neither clip swallows the other and neither runs out of
+     * source material. Enables autoCrossfade on both clips when the resulting
+     * overlap is non-empty. startBeat == endBeat butts the joint (removes the
+     * crossfade; the flags stay).
+     *
+     * @return false when the pair is not crossfade-capable (different track,
+     *         non-audio, no joint between them).
+     */
+    bool setCrossfadeRegionBeats(ClipId leftId, ClipId rightId, double startBeat, double endBeat,
+                                 double tempo = 0.0);
+
+    /**
+     * @brief Create/resize a crossfade centred on the joint (current overlap
+     *        centre, or the touch point for abutting clips).
+     *        durationBeats == 0 removes it.
+     */
+    bool setCrossfadeBeats(ClipId leftId, ClipId rightId, double durationBeats, double tempo = 0.0);
+
     // Channels
     void setLeftChannelActive(ClipId clipId, bool active);
     void setRightChannelActive(ClipId clipId, bool active);
@@ -778,6 +836,14 @@ class ClipManager {
 
     double findNonOverlappingStartBeats(TrackId trackId, double desiredStartBeats,
                                         double lengthBeats, ClipView view) const;
+
+    // How far (in timeline beats) an audio clip's edge can extend before it
+    // runs out of source material. Left = earlier than its current start
+    // (bounded by the source read offset), right = past its current end
+    // (bounded by the source duration). Unbounded (infinity) for looping
+    // clips and when the source duration is unknown.
+    double availableLeftExtensionBeats(const ClipInfo& clip, double bpm) const;
+    double availableRightExtensionBeats(const ClipInfo& clip, double bpm) const;
 
     // Unified clip storage — ClipView is a property, not storage identity
     std::unordered_map<ClipId, ClipInfo> clips_;

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -228,6 +228,7 @@ void Config::save() {
     root->setProperty("stopUpdatesPlayhead", stopUpdatesPlayhead);
     root->setProperty("followPlayhead", followPlayhead);
     root->setProperty("chordPreviewOnByDefault", chordPreviewOnByDefault);
+    root->setProperty("autoCrossfadeByDefault", autoCrossfadeByDefault);
 
     // Clip colour mode
     root->setProperty("clipColourMode", clipColourMode);
@@ -631,6 +632,7 @@ void Config::load() {
     stopUpdatesPlayhead = getBool("stopUpdatesPlayhead", stopUpdatesPlayhead);
     followPlayhead = getBool("followPlayhead", followPlayhead);
     chordPreviewOnByDefault = getBool("chordPreviewOnByDefault", chordPreviewOnByDefault);
+    autoCrossfadeByDefault = getBool("autoCrossfadeByDefault", autoCrossfadeByDefault);
 
     clipColourMode = getInt("clipColourMode", clipColourMode);
 

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -337,6 +337,16 @@ class Config {
         chordPreviewOnByDefault = enabled;
     }
 
+    // Whether newly created audio clips get AUTO-XFADE enabled (#1499): their
+    // overlaps with other auto-crossfade audio clips play as crossfades
+    // instead of being trimmed away.
+    bool getAutoCrossfadeByDefault() const {
+        return autoCrossfadeByDefault;
+    }
+    void setAutoCrossfadeByDefault(bool enabled) {
+        autoCrossfadeByDefault = enabled;
+    }
+
     // Recent Projects
     std::vector<std::string> getRecentProjects() const {
         return recentProjects;
@@ -1134,6 +1144,9 @@ class Config {
 
     // Audition a new chord track's progression on playback by default.
     bool chordPreviewOnByDefault = false;
+
+    // New audio clips get AUTO-XFADE enabled (see #1499).
+    bool autoCrossfadeByDefault = true;
 
     // Browser filter settings (media explorer)
     bool browserFilterAudio = true;    // Show audio files by default

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -198,6 +198,10 @@ constexpr int kTakeMenuMaxItems = 64;
 // kept clear of the take-selection range (300..363).
 constexpr int kProgressionTargetBaseId = 400;
 
+// Length of a crossfade created from the context menu (#1499). The handles
+// resize it afterwards; setCrossfadeRegionBeats clamps it into both clips.
+constexpr double kDefaultCrossfadeBeats = 0.5;
+
 juce::Path makeClippedRoundedRectPath(juce::Rectangle<int> bounds,
                                       juce::Rectangle<int> visibleBounds, float radius) {
     juce::Path path;
@@ -801,14 +805,39 @@ void ClipComponent::paintAudioClip(juce::Graphics& g, const ClipInfo& clip,
     strokeClippedRoundedRect(g, bounds, visibleBounds, deriveTrackSwatch(clip.colour, 0.45f),
                              CORNER_RADIUS, 1.0f);
 
-    // Fade overlays
-    if (clip.fadeIn > 0.0 || clip.fadeOut > 0.0) {
+    // Fade overlays (crossfaded edges show the overlap-derived fade, #1499)
+    const auto fades = computeEffectiveFades(clip);
+    if (fades.fadeInSeconds > 0.0 || fades.fadeOutSeconds > 0.0) {
         double pps = (clipDisplayLength > 0.0)
                          ? static_cast<double>(waveformArea.getWidth()) / clipDisplayLength
                          : 0.0;
         if (pps > 0.0)
-            paintFadeOverlays(g, clip, waveformArea, pps);
+            paintFadeOverlays(g, clip, fades, waveformArea, pps);
     }
+}
+
+ClipComponent::EffectiveFades ClipComponent::computeEffectiveFades(const ClipInfo& clip) const {
+    EffectiveFades fades;
+    fades.fadeInSeconds = clip.fadeIn;
+    fades.fadeOutSeconds = clip.fadeOut;
+    if (!clip.isAudio() || clip.view != ClipView::Arrangement)
+        return fades;
+
+    auto& cm = ClipManager::getInstance();
+    const double tempo = parentPanel_ ? parentPanel_->getTempo() : 120.0;
+    if (auto xf = cm.getCrossfadeAtStart(clipId_)) {
+        fades.xfIn = xf;
+        fades.fadeInSeconds = xf->lengthBeats() * 60.0 / tempo;
+    }
+    if (auto xf = cm.getCrossfadeAtEnd(clipId_)) {
+        fades.xfOut = xf;
+        fades.fadeOutSeconds = xf->lengthBeats() * 60.0 / tempo;
+    }
+    return fades;
+}
+
+ClipId ClipComponent::findCrossfadeNeighbour(bool atStart) const {
+    return ClipManager::getInstance().findCrossfadeNeighbour(clipId_, atStart);
 }
 
 void ClipComponent::paintMidiClip(juce::Graphics& g, const ClipInfo& clip,
@@ -1153,6 +1182,7 @@ void ClipComponent::paintResizeHandles(juce::Graphics& g, juce::Rectangle<int> b
 }
 
 void ClipComponent::paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip,
+                                      const EffectiveFades& fades,
                                       juce::Rectangle<int> waveformArea, double pixelsPerSecond) {
     constexpr int NUM_STEPS = 32;
     float areaTop = static_cast<float>(waveformArea.getY());
@@ -1161,9 +1191,29 @@ void ClipComponent::paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip,
     float areaLeft = static_cast<float>(waveformArea.getX());
     float areaRight = static_cast<float>(waveformArea.getRight());
 
+    // The counterpart curve of a crossfade (the other clip's fade across the
+    // same overlap) — drawn by both components of the pair so the X reads the
+    // same whichever one is on top.
+    auto strokeCounterpartCurve = [&](float regionStartPx, float regionWidthPx, FadeCurve type,
+                                      bool descending) {
+        juce::Path curve;
+        for (int i = 0; i <= NUM_STEPS; ++i) {
+            float alpha = static_cast<float>(i) / static_cast<float>(NUM_STEPS);
+            float gain = computeFadeGain(descending ? 1.0f - alpha : alpha, type);
+            float x = regionStartPx + alpha * regionWidthPx;
+            float y = areaTop + (1.0f - gain) * areaHeight;
+            if (i == 0)
+                curve.startNewSubPath(x, y);
+            else
+                curve.lineTo(x, y);
+        }
+        g.setColour(juce::Colours::white.withAlpha(0.35f));
+        g.strokePath(curve, juce::PathStrokeType(1.5f));
+    };
+
     // Fade-in overlay
-    if (clip.fadeIn > 0.0) {
-        float fadeInPx = juce::jmin(static_cast<float>(clip.fadeIn * pixelsPerSecond),
+    if (fades.fadeInSeconds > 0.0) {
+        float fadeInPx = juce::jmin(static_cast<float>(fades.fadeInSeconds * pixelsPerSecond),
                                     static_cast<float>(waveformArea.getWidth()));
         if (fadeInPx > 1.0f) {
             // Build overlay path: darkens area above the fade curve
@@ -1198,12 +1248,20 @@ void ClipComponent::paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip,
             }
             g.setColour(juce::Colours::white.withAlpha(0.6f));
             g.strokePath(curveLine, juce::PathStrokeType(1.5f));
+
+            // Crossfade: overlay the previous clip's fade-out curve (the X)
+            if (fades.xfIn) {
+                auto* other = ClipManager::getInstance().getClip(fades.xfIn->leftClipId);
+                strokeCounterpartCurve(areaLeft, fadeInPx,
+                                       static_cast<FadeCurve>(other ? other->fadeOutType : 1),
+                                       true);
+            }
         }
     }
 
     // Fade-out overlay
-    if (clip.fadeOut > 0.0) {
-        float fadeOutPx = juce::jmin(static_cast<float>(clip.fadeOut * pixelsPerSecond),
+    if (fades.fadeOutSeconds > 0.0) {
+        float fadeOutPx = juce::jmin(static_cast<float>(fades.fadeOutSeconds * pixelsPerSecond),
                                      static_cast<float>(waveformArea.getWidth()));
         if (fadeOutPx > 1.0f) {
             float fadeStart = areaRight - fadeOutPx;
@@ -1245,6 +1303,14 @@ void ClipComponent::paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip,
             }
             g.setColour(juce::Colours::white.withAlpha(0.6f));
             g.strokePath(curveLine, juce::PathStrokeType(1.5f));
+
+            // Crossfade: overlay the next clip's fade-in curve (the X)
+            if (fades.xfOut) {
+                auto* other = ClipManager::getInstance().getClip(fades.xfOut->rightClipId);
+                strokeCounterpartCurve(fadeStart, fadeOutPx,
+                                       static_cast<FadeCurve>(other ? other->fadeInType : 1),
+                                       false);
+            }
         }
     }
 }
@@ -1268,10 +1334,11 @@ void ClipComponent::paintFadeHandles(juce::Graphics& g, const ClipInfo& clip,
     float waveTop = static_cast<float>(waveformArea.getY());
 
     auto handleColour = juce::Colour(DarkTheme::ACCENT_ORANGE);
+    const auto fades = computeEffectiveFades(clip);
 
     // Fade-in handle: only visible on hover
     if (hoverFadeIn_) {
-        float fadeInPx = static_cast<float>(clip.fadeIn * pixelsPerSecond);
+        float fadeInPx = static_cast<float>(fades.fadeInSeconds * pixelsPerSecond);
         float cx = static_cast<float>(waveformArea.getX()) + fadeInPx;
         g.setColour(handleColour);
         g.fillRect(cx - half, waveTop, hs, hs);
@@ -1279,7 +1346,7 @@ void ClipComponent::paintFadeHandles(juce::Graphics& g, const ClipInfo& clip,
 
     // Fade-out handle: only visible on hover
     if (hoverFadeOut_) {
-        float fadeOutPx = static_cast<float>(clip.fadeOut * pixelsPerSecond);
+        float fadeOutPx = static_cast<float>(fades.fadeOutSeconds * pixelsPerSecond);
         float cx = static_cast<float>(waveformArea.getRight()) - fadeOutPx;
         g.setColour(handleColour);
         g.fillRect(cx - half, waveTop, hs, hs);
@@ -1630,6 +1697,18 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
             repaint();
             return;
         }
+        // Crossfaded start edge: the handle drives the overlap with the
+        // previous clip (moves its end) instead of this clip's own fade-in.
+        if (auto xfIn = computeEffectiveFades(*clip).xfIn) {
+            if (const auto* other = ClipManager::getInstance().getClip(xfIn->leftClipId)) {
+                dragMode_ = DragMode::CrossfadeIn;
+                crossfadeDragPair_ = *xfIn;
+                dragStartClipSnapshot_ = *clip;
+                crossfadeOtherSnapshot_ = *other;
+                repaint();
+                return;
+            }
+        }
         dragMode_ = DragMode::FadeIn;
         dragStartFadeIn_ = clip->fadeIn;
         dragStartClipSnapshot_ = *clip;
@@ -1658,6 +1737,18 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
             dragMode_ = DragMode::None;
             repaint();
             return;
+        }
+        // Crossfaded end edge: the handle drives the overlap with the next
+        // clip (moves its start) instead of this clip's own fade-out.
+        if (auto xfOut = computeEffectiveFades(*clip).xfOut) {
+            if (const auto* other = ClipManager::getInstance().getClip(xfOut->rightClipId)) {
+                dragMode_ = DragMode::CrossfadeOut;
+                crossfadeDragPair_ = *xfOut;
+                dragStartClipSnapshot_ = *clip;
+                crossfadeOtherSnapshot_ = *other;
+                repaint();
+                return;
+            }
         }
         dragMode_ = DragMode::FadeOut;
         dragStartFadeOut_ = clip->fadeOut;
@@ -2188,6 +2279,42 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
             break;
         }
 
+        case DragMode::CrossfadeIn: {
+            // This clip's geometry is fixed; the handle moves the previous
+            // clip's end (the overlap end). Overlap start = our start.
+            auto wfArea = getLocalBounds().reduced(2, HEADER_HEIGHT + 2);
+            double pps = (dragStartLength_ > 0.0)
+                             ? static_cast<double>(wfArea.getWidth()) / dragStartLength_
+                             : 0.0;
+            if (pps > 0.0) {
+                double px = juce::jmax(0.0, static_cast<double>(e.x - wfArea.getX()));
+                double newEndBeat = crossfadeDragPair_.startBeat + (px / pps) * tempoBPM / 60.0;
+                ClipManager::getInstance().setCrossfadeRegionBeats(
+                    crossfadeDragPair_.leftClipId, crossfadeDragPair_.rightClipId,
+                    crossfadeDragPair_.startBeat, newEndBeat, tempoBPM);
+                repaint();
+            }
+            break;
+        }
+
+        case DragMode::CrossfadeOut: {
+            // The handle moves the next clip's start (the overlap start).
+            // Overlap end = our end.
+            auto wfArea = getLocalBounds().reduced(2, HEADER_HEIGHT + 2);
+            double pps = (dragStartLength_ > 0.0)
+                             ? static_cast<double>(wfArea.getWidth()) / dragStartLength_
+                             : 0.0;
+            if (pps > 0.0) {
+                double px = juce::jmax(0.0, static_cast<double>(wfArea.getRight() - e.x));
+                double newStartBeat = crossfadeDragPair_.endBeat - (px / pps) * tempoBPM / 60.0;
+                ClipManager::getInstance().setCrossfadeRegionBeats(
+                    crossfadeDragPair_.leftClipId, crossfadeDragPair_.rightClipId, newStartBeat,
+                    crossfadeDragPair_.endBeat, tempoBPM);
+                repaint();
+            }
+            break;
+        }
+
         case DragMode::VolumeDrag: {
             // Convert vertical delta to dB (~1 dB per 2px, up = louder)
             auto parentPos = e.getEventRelativeTo(parentPanel_).getPosition();
@@ -2596,6 +2723,45 @@ void ClipComponent::mouseUp(const juce::MouseEvent& e) {
                 break;
             }
 
+            case DragMode::CrossfadeIn:
+            case DragMode::CrossfadeOut: {
+                const bool isIn = savedDragMode == DragMode::CrossfadeIn;
+
+                // Capture the final overlap region from the mouse position
+                double finalStart = crossfadeDragPair_.startBeat;
+                double finalEnd = crossfadeDragPair_.endBeat;
+                auto wfArea = getLocalBounds().reduced(2, HEADER_HEIGHT + 2);
+                double pps = (dragStartLength_ > 0.0)
+                                 ? static_cast<double>(wfArea.getWidth()) / dragStartLength_
+                                 : 0.0;
+                if (pps > 0.0) {
+                    if (isIn) {
+                        double px = juce::jmax(0.0, static_cast<double>(e.x - wfArea.getX()));
+                        finalEnd =
+                            crossfadeDragPair_.startBeat + (px / pps) * commitTempoBPM / 60.0;
+                    } else {
+                        double px = juce::jmax(0.0, static_cast<double>(wfArea.getRight() - e.x));
+                        finalStart =
+                            crossfadeDragPair_.endBeat - (px / pps) * commitTempoBPM / 60.0;
+                    }
+                }
+
+                // Restore both clips to pre-drag state so the command captures
+                // it as the undo state, then apply the final region undoably.
+                auto& cm = ClipManager::getInstance();
+                if (auto* c = cm.getClip(clipId_))
+                    *c = dragStartClipSnapshot_;
+                const ClipId otherId =
+                    isIn ? crossfadeDragPair_.leftClipId : crossfadeDragPair_.rightClipId;
+                if (auto* c = cm.getClip(otherId))
+                    *c = crossfadeOtherSnapshot_;
+
+                UndoManager::getInstance().executeCommand(std::make_unique<SetCrossfadeCommand>(
+                    crossfadeDragPair_.leftClipId, crossfadeDragPair_.rightClipId, finalStart,
+                    finalEnd, commitTempoBPM));
+                break;
+            }
+
             case DragMode::VolumeDrag: {
                 // Restore all clips to pre-drag state for correct undo capture
                 auto& cm = ClipManager::getInstance();
@@ -2827,6 +2993,17 @@ void ClipComponent::clipPropertyChanged(ClipId clipId) {
 
     if (clipId == clipId_) {
         repaint();
+        return;
+    }
+
+    // A same-track audio neighbour's geometry drives this clip's crossfade
+    // rendering (#1499): moving it out of (or into) the overlap must refresh
+    // the fade display here, not just on the moved clip.
+    const auto* clip = getClipInfo();
+    if (clip && clip->isAudio()) {
+        const auto* other = ClipManager::getInstance().getClip(clipId);
+        if (other && other->isAudio() && other->trackId == clip->trackId)
+            repaint();
     }
 }
 
@@ -2900,8 +3077,8 @@ bool ClipComponent::isOnFadeInHandle(int x, int y) const {
     if (pps <= 0.0)
         return false;
 
-    float handleX =
-        static_cast<float>(waveformArea.getX()) + static_cast<float>(clip->fadeIn * pps);
+    float handleX = static_cast<float>(waveformArea.getX()) +
+                    static_cast<float>(computeEffectiveFades(*clip).fadeInSeconds * pps);
     return std::abs(static_cast<float>(x) - handleX) <= FADE_HANDLE_HIT_WIDTH * 0.5f;
 }
 
@@ -2924,8 +3101,8 @@ bool ClipComponent::isOnFadeOutHandle(int x, int y) const {
     if (pps <= 0.0)
         return false;
 
-    float handleX =
-        static_cast<float>(waveformArea.getRight()) - static_cast<float>(clip->fadeOut * pps);
+    float handleX = static_cast<float>(waveformArea.getRight()) -
+                    static_cast<float>(computeEffectiveFades(*clip).fadeOutSeconds * pps);
     return std::abs(static_cast<float>(x) - handleX) <= FADE_HANDLE_HIT_WIDTH * 0.5f;
 }
 
@@ -3201,6 +3378,31 @@ void ClipComponent::showContextMenu() {
     }
     menu.addItem(8, "Join Clips", canJoin && !isFrozen);
     menu.addSeparator();
+
+    // Crossfades (#1499): create at a butt joint / remove an existing one
+    {
+        bool hasXfadeIn = false;
+        bool hasXfadeOut = false;
+        bool canXfadePrev = false;
+        bool canXfadeNext = false;
+        if (!isMultiSelection && canEdit && clipForMenu && clipForMenu->isAudio()) {
+            hasXfadeIn = clipManager.getCrossfadeAtStart(clipId_).has_value();
+            hasXfadeOut = clipManager.getCrossfadeAtEnd(clipId_).has_value();
+            canXfadePrev = !hasXfadeIn && findCrossfadeNeighbour(true) != INVALID_CLIP_ID;
+            canXfadeNext = !hasXfadeOut && findCrossfadeNeighbour(false) != INVALID_CLIP_ID;
+        }
+        if (canXfadePrev || canXfadeNext || hasXfadeIn || hasXfadeOut) {
+            if (canXfadePrev)
+                menu.addItem(45, "Crossfade with Previous Clip");
+            if (canXfadeNext)
+                menu.addItem(46, "Crossfade with Next Clip");
+            if (hasXfadeIn)
+                menu.addItem(47, "Remove Start Crossfade");
+            if (hasXfadeOut)
+                menu.addItem(48, "Remove End Crossfade");
+            menu.addSeparator();
+        }
+    }
 
     // Delete
     menu.addItem(6, "Delete", canEdit);
@@ -3679,6 +3881,40 @@ void ClipComponent::showContextMenu() {
                         UndoManager::getInstance().endCompoundOperation();
 
                     selectionManager.selectClips({leftId});
+                }
+                break;
+            }
+
+            case 45:    // Crossfade with Previous Clip
+            case 46: {  // Crossfade with Next Clip
+                const bool atStart = result == 45;
+                const ClipId neighbourId = findCrossfadeNeighbour(atStart);
+                const auto* c = clipManager.getClip(clipId_);
+                const auto* neighbour = clipManager.getClip(neighbourId);
+                if (c && neighbour) {
+                    const double tempo = parentPanel_ ? parentPanel_->getTempo() : 120.0;
+                    const double centre =
+                        atStart ? (c->placement.startBeat + neighbour->placement.endBeat()) * 0.5
+                                : (neighbour->placement.startBeat + c->placement.endBeat()) * 0.5;
+                    const double half = kDefaultCrossfadeBeats * 0.5;
+                    const ClipId leftId = atStart ? neighbourId : clipId_;
+                    const ClipId rightId = atStart ? clipId_ : neighbourId;
+                    UndoManager::getInstance().executeCommand(std::make_unique<SetCrossfadeCommand>(
+                        leftId, rightId, centre - half, centre + half, tempo));
+                }
+                break;
+            }
+
+            case 47:    // Remove Start Crossfade
+            case 48: {  // Remove End Crossfade
+                auto xf = result == 47 ? clipManager.getCrossfadeAtStart(clipId_)
+                                       : clipManager.getCrossfadeAtEnd(clipId_);
+                if (xf) {
+                    const double tempo = parentPanel_ ? parentPanel_->getTempo() : 120.0;
+                    // Butt the joint at the overlap centre
+                    const double centre = (xf->startBeat + xf->endBeat) * 0.5;
+                    UndoManager::getInstance().executeCommand(std::make_unique<SetCrossfadeCommand>(
+                        xf->leftClipId, xf->rightClipId, centre, centre, tempo));
                 }
                 break;
             }

--- a/magda/daw/ui/components/clips/ClipComponent.hpp
+++ b/magda/daw/ui/components/clips/ClipComponent.hpp
@@ -3,6 +3,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include <limits>
+#include <optional>
 
 #include "core/ClipInfo.hpp"
 #include "core/ClipManager.hpp"
@@ -129,6 +130,8 @@ class ClipComponent : public juce::Component,
         StretchRight,
         FadeIn,
         FadeOut,
+        CrossfadeIn,   // fade-in handle drives the overlap with the previous clip (#1499)
+        CrossfadeOut,  // fade-out handle drives the overlap with the next clip
         VolumeDrag
     };
     DragMode dragMode_ = DragMode::None;
@@ -190,6 +193,11 @@ class ClipComponent : public juce::Component,
     std::unordered_map<ClipId, ClipInfo>
         dragStartSelectedFadeSnapshots_;  // Original state of other selected clips for fade undo
 
+    // Crossfade drag state (#1499): the pair being edited and the neighbour's
+    // pre-drag snapshot (this clip's snapshot lives in dragStartClipSnapshot_).
+    ClipManager::CrossfadeInfo crossfadeDragPair_{};
+    ClipInfo crossfadeOtherSnapshot_;
+
     // Volume handle state
     bool hoverVolumeHandle_ = false;
     float dragStartVolumeDB_ = 0.0f;
@@ -202,6 +210,21 @@ class ClipComponent : public juce::Component,
     static constexpr int FADE_HANDLE_SIZE = 8;
     static constexpr int FADE_HANDLE_HIT_WIDTH = 14;
 
+    // Effective fades for display/interaction (#1499): a crossfaded edge shows
+    // the overlap-derived fade (what TE actually plays) instead of the stored
+    // fadeIn/fadeOut, which return once the clips are pulled apart.
+    struct EffectiveFades {
+        double fadeInSeconds = 0.0;
+        double fadeOutSeconds = 0.0;
+        std::optional<ClipManager::CrossfadeInfo> xfIn;   // crossfade covering the start edge
+        std::optional<ClipManager::CrossfadeInfo> xfOut;  // crossfade covering the end edge
+    };
+    EffectiveFades computeEffectiveFades(const ClipInfo& clip) const;
+
+    // The audio clip abutting/overlapping this clip's start (previous) or end
+    // (next) that a crossfade could be created with. INVALID_CLIP_ID if none.
+    ClipId findCrossfadeNeighbour(bool atStart) const;
+
     // Painting helpers
     void paintAudioClip(juce::Graphics& g, const ClipInfo& clip, juce::Rectangle<int> bounds);
     void paintMidiClip(juce::Graphics& g, const ClipInfo& clip, juce::Rectangle<int> bounds);
@@ -213,7 +236,7 @@ class ClipComponent : public juce::Component,
     bool isChordClip(const ClipInfo& clip) const;
     void paintClipHeader(juce::Graphics& g, const ClipInfo& clip, juce::Rectangle<int> bounds);
     void paintResizeHandles(juce::Graphics& g, juce::Rectangle<int> bounds);
-    void paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip,
+    void paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip, const EffectiveFades& fades,
                            juce::Rectangle<int> waveformArea, double pixelsPerSecond);
     void paintFadeHandles(juce::Graphics& g, const ClipInfo& clip, juce::Rectangle<int> bounds);
     void paintVolumeLine(juce::Graphics& g, const ClipInfo& clip,

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -2409,8 +2409,13 @@ void TrackContentPanel::rebuildClipComponents() {
     // Remove all existing clip components
     clipComponents_.clear();
 
-    // Get only arrangement clips (timeline-based)
-    const auto& clips = ClipManager::getInstance().getArrangementClips();
+    // Get only arrangement clips (timeline-based). Sort by start beat so the
+    // child z-order is deterministic: a later clip sits on top of the one it
+    // crossfades into (#1499) instead of following hash-map iteration order.
+    auto clips = ClipManager::getInstance().getArrangementClips();
+    std::sort(clips.begin(), clips.end(), [](const ClipInfo& a, const ClipInfo& b) {
+        return a.placement.startBeat < b.placement.startBeat;
+    });
 
     // Create a component for each clip that belongs to a visible track
     for (const auto& clip : clips) {
@@ -3464,10 +3469,12 @@ void TrackContentPanel::importFilesAtPosition(const juce::StringArray& files, in
                         static_cast<double>(reader->lengthInSamples) / reader->sampleRate;
                 }
 
+                // Land exactly at the drop point: trim/replace whatever is
+                // beneath instead of shifting the new clip to the next gap.
                 auto cmd = std::make_unique<CreateClipCommand>(
                     ClipType::Audio, targetTrackId, BeatPosition{currentTime * tempoBPM / 60.0},
                     BeatDuration{fileDuration * tempoBPM / 60.0}, filePath.toStdString(),
-                    ClipView::Arrangement, tempoBPM);
+                    ClipView::Arrangement, tempoBPM, ClipOverlapPolicy::ResolveOverlaps);
                 UndoManager::getInstance().executeCommand(std::move(cmd));
 
                 currentTime += fileDuration + 0.5;
@@ -3559,10 +3566,12 @@ void TrackContentPanel::importFilesAtPosition(const juce::StringArray& files, in
                         continue;
                 }
 
-                // Create MIDI clip
+                // Create MIDI clip. Land at the drop point even over existing
+                // clips (no-op on freshly created tracks).
                 auto cmd = std::make_unique<CreateClipCommand>(
                     ClipType::MIDI, clipTrackId, BeatPosition{dropTime * projectTempo / 60.0},
-                    BeatDuration{clipDuration * projectTempo / 60.0});
+                    BeatDuration{clipDuration * projectTempo / 60.0}, juce::String{},
+                    ClipView::Arrangement, 0.0, ClipOverlapPolicy::ResolveOverlaps);
                 auto* cmdPtr = cmd.get();
                 UndoManager::getInstance().executeCommand(std::move(cmd));
 

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -182,6 +182,8 @@ class GeneralPage : public juce::Component {
                     tr("preferences.toggle.open_plugin_window_on_drop"));
         setupToggle(*this, chordPreviewDefaultToggle,
                     tr("preferences.toggle.chord_preview_default"));
+        setupToggle(*this, autoCrossfadeDefaultToggle,
+                    tr("preferences.toggle.auto_crossfade_default"));
 
         setupSectionHeader(*this, languageHeader, tr("preferences.language.header"));
         setupComboLabel(languageLabel, tr("preferences.language.label"));
@@ -284,6 +286,8 @@ class GeneralPage : public juce::Component {
                                                     juce::dontSendNotification);
         chordPreviewDefaultToggle.setToggleState(config.getChordPreviewOnByDefault(),
                                                  juce::dontSendNotification);
+        autoCrossfadeDefaultToggle.setToggleState(config.getAutoCrossfadeByDefault(),
+                                                  juce::dontSendNotification);
 
         languageCombo.clear(juce::dontSendNotification);
         availableLanguages_.clear();
@@ -334,6 +338,7 @@ class GeneralPage : public juce::Component {
         config.setShowTooltips(showTooltipsToggle.getToggleState());
         config.setOpenPluginWindowOnDrop(openPluginWindowOnDropToggle.getToggleState());
         config.setChordPreviewOnByDefault(chordPreviewDefaultToggle.getToggleState());
+        config.setAutoCrossfadeByDefault(autoCrossfadeDefaultToggle.getToggleState());
 
         int selIdx = languageCombo.getSelectedId() - 1;
         if (selIdx >= 0 && selIdx < static_cast<int>(availableLanguages_.size())) {
@@ -372,7 +377,7 @@ class GeneralPage : public juce::Component {
 
         return padding + headerH + 4 + (rowH * 3) + 8 + secGap + headerH + 4 + (rowH * 2) + 4 +
                secGap + headerH + 4 + rowH + secGap + headerH + 4 + rowH + 4 + rowH + secGap +
-               headerH + 4 + rowH + secGap + headerH + 4 + (rowH * 6) + 16 + secGap + headerH + 4 +
+               headerH + 4 + rowH + secGap + headerH + 4 + (rowH * 7) + 16 + secGap + headerH + 4 +
                rowH + 18 + secGap + headerH + 4 + (rowH * 3) + 8 + padding;
     }
 
@@ -397,7 +402,7 @@ class GeneralPage : public juce::Component {
         constexpr int secGap = 12;
 
         return padding + headerH + 4 + rowH + 4 + rowH              // Layout
-               + secGap + headerH + 4 + (rowH * 6) + 20             // Behaviour
+               + secGap + headerH + 4 + (rowH * 7) + 20             // Behaviour
                + secGap + headerH + 4 + rowH + 4 + rowH + 4 + rowH  // Display Scale
                + padding;
     }
@@ -460,6 +465,8 @@ class GeneralPage : public juce::Component {
         openPluginWindowOnDropToggle.setBounds(bounds.removeFromTop(rowH).reduced(0, 4));
         bounds.removeFromTop(4);
         chordPreviewDefaultToggle.setBounds(bounds.removeFromTop(rowH).reduced(0, 4));
+        bounds.removeFromTop(4);
+        autoCrossfadeDefaultToggle.setBounds(bounds.removeFromTop(rowH).reduced(0, 4));
         bounds.removeFromTop(secGap);
 
         // Language
@@ -551,6 +558,8 @@ class GeneralPage : public juce::Component {
         openPluginWindowOnDropToggle.setBounds(right.removeFromTop(rowH).reduced(0, 4));
         right.removeFromTop(4);
         chordPreviewDefaultToggle.setBounds(right.removeFromTop(rowH).reduced(0, 4));
+        right.removeFromTop(4);
+        autoCrossfadeDefaultToggle.setBounds(right.removeFromTop(rowH).reduced(0, 4));
         right.removeFromTop(secGap);
 
         // Display Scale
@@ -654,6 +663,7 @@ class GeneralPage : public juce::Component {
     juce::ToggleButton showTooltipsToggle;
     juce::ToggleButton openPluginWindowOnDropToggle;
     juce::ToggleButton chordPreviewDefaultToggle;
+    juce::ToggleButton autoCrossfadeDefaultToggle;
     juce::Label languageLabel;
     juce::ComboBox languageCombo;
     juce::Label restartHint;

--- a/magda/daw/ui/panels/BottomPanel.cpp
+++ b/magda/daw/ui/panels/BottomPanel.cpp
@@ -266,6 +266,7 @@ BottomPanel::BottomPanel() : TabbedPanel(daw::ui::PanelLocation::Bottom) {
     // Register as listener for selection changes
     ClipManager::getInstance().addListener(this);
     TrackManager::getInstance().addListener(this);
+    SelectionManager::getInstance().addListener(this);
     PluginPreferences::getInstance().addListener(this);
 
     // Register as TimelineStateListener for grid sync
@@ -293,6 +294,7 @@ BottomPanel::~BottomPanel() {
 
     ClipManager::getInstance().removeListener(this);
     TrackManager::getInstance().removeListener(this);
+    SelectionManager::getInstance().removeListener(this);
     PluginPreferences::getInstance().removeListener(this);
     // TimelineController listener removed automatically by timelineListenerGuard_
 
@@ -786,6 +788,14 @@ void BottomPanel::clipSelectionChanged(ClipId /*clipId*/) {
     syncGridControlsFromContent();
 }
 
+void BottomPanel::selectionTypeChanged(SelectionType /*newType*/) {
+    updateContentBasedOnSelection();
+}
+
+void BottomPanel::multiClipSelectionChanged(const std::unordered_set<ClipId>& /*clipIds*/) {
+    updateContentBasedOnSelection();
+}
+
 void BottomPanel::clipPropertyChanged(ClipId clipId) {
     // Re-evaluate header state when clip properties change (e.g. loop toggled
     // on/off, or session-vs-arrangement view switch).
@@ -975,10 +985,33 @@ void BottomPanel::updateContentBasedOnSelection() {
     ClipId selectedClip = clipManager.getSelectedClip();
     TrackId selectedTrack = trackManager.getSelectedTrack();
 
+    // Multi-clip selection bypasses ClipManager's single selection. An
+    // all-audio multi-selection opens the waveform editor in multi mode: a
+    // placeholder instead of one clip's waveform, plus the properties panel
+    // with its multi-capable controls (fades / AUTO-XFADE, #1499).
+    std::unordered_set<ClipId> multiAudioClips;
+    {
+        auto& sel = SelectionManager::getInstance();
+        if (selectedClip == INVALID_CLIP_ID && sel.getSelectedClipCount() > 1) {
+            bool allAudio = true;
+            for (auto cid : sel.getSelectedClips()) {
+                const auto* c = clipManager.getClip(cid);
+                if (!c || !c->isAudio()) {
+                    allAudio = false;
+                    break;
+                }
+            }
+            if (allAudio)
+                multiAudioClips = sel.getSelectedClips();
+        }
+    }
+
     daw::ui::PanelContentType targetContent = daw::ui::PanelContentType::Empty;
     bool needsTabs = false;
 
-    if (selectedClip != INVALID_CLIP_ID) {
+    if (!multiAudioClips.empty()) {
+        targetContent = daw::ui::PanelContentType::WaveformEditor;
+    } else if (selectedClip != INVALID_CLIP_ID) {
         const auto* clip = clipManager.getClip(selectedClip);
         if (!clip) {
             // Clip data temporarily unavailable (e.g. during track rebuild).
@@ -1094,6 +1127,12 @@ void BottomPanel::updateContentBasedOnSelection() {
                                                 juce::dontSendNotification);
         };
     }
+
+    // Push multi-selection state into the waveform editor and the properties
+    // panel (empty set = single-clip mode, restoring normal behaviour).
+    if (auto* waveEditor = dynamic_cast<daw::ui::WaveformEditorContent*>(content))
+        waveEditor->setMultiClipSelection(multiAudioClips);
+    audioPropsPanel_->setMultiSelection(multiAudioClips);
 }
 
 void BottomPanel::setPianoRollFullscreenActive(bool active) {

--- a/magda/daw/ui/panels/BottomPanel.hpp
+++ b/magda/daw/ui/panels/BottomPanel.hpp
@@ -7,6 +7,7 @@
 #include "TabbedPanel.hpp"
 #include "core/ClipManager.hpp"
 #include "core/PluginPreferences.hpp"
+#include "core/SelectionManager.hpp"
 #include "core/TrackManager.hpp"
 #include "utils/ScopedListener.hpp"
 
@@ -35,6 +36,7 @@ class BottomPanel : public daw::ui::TabbedPanel,
                     public juce::DragAndDropTarget,
                     public ClipManagerListener,
                     public TrackManagerListener,
+                    public SelectionManagerListener,
                     public PluginPreferences::Listener,
                     public TimelineStateListener {
   public:
@@ -69,6 +71,12 @@ class BottomPanel : public daw::ui::TabbedPanel,
     // TrackManagerListener
     void tracksChanged() override;
     void trackSelectionChanged(TrackId trackId) override;
+
+    // SelectionManagerListener — multi-clip selections bypass ClipManager's
+    // single-clip selection, so the panel needs these to react (#1499 editor
+    // multi-select: waveform placeholder + multi-capable properties panel).
+    void selectionTypeChanged(SelectionType newType) override;
+    void multiClipSelectionChanged(const std::unordered_set<ClipId>& clipIds) override;
 
     // PluginPreferences::Listener
     void drumGridPreferenceChanged(const juce::String& pluginIdentifier) override;

--- a/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
+++ b/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
@@ -96,13 +96,26 @@ void AudioClipPropertiesContent::onDeactivated() {
     magda::ClipManager::getInstance().removeListener(this);
 }
 
+void AudioClipPropertiesContent::setMultiSelection(
+    const std::unordered_set<magda::ClipId>& clipIds) {
+    auto newSet = clipIds.size() > 1 ? clipIds : std::unordered_set<magda::ClipId>{};
+    if (newSet == multiClipIds_)
+        return;
+    multiClipIds_ = std::move(newSet);
+    if (!multiClipIds_.empty())
+        clipId_ = magda::INVALID_CLIP_ID;
+    updateFromClip();
+}
+
 void AudioClipPropertiesContent::clipSelectionChanged(magda::ClipId clipId) {
     clipId_ = clipId;
+    if (clipId != magda::INVALID_CLIP_ID)
+        multiClipIds_.clear();
     updateFromClip();
 }
 
 void AudioClipPropertiesContent::clipPropertyChanged(magda::ClipId clipId) {
-    if (clipId == clipId_)
+    if (clipId == clipId_ || multiClipIds_.count(clipId) > 0)
         updateFromClip();
 }
 
@@ -609,8 +622,12 @@ void AudioClipPropertiesContent::updateFromClip() {
         panValue_->setValue(static_cast<double>(clip->pan), juce::dontSendNotification);
     }
 
-    fadesSection_->setClip(clipId_);
-    takesSection_->setClip(clipId_);
+    const bool isMulti = multiClipIds_.size() > 1;
+    if (isMulti)
+        fadesSection_->setSelectedClips(multiClipIds_);
+    else
+        fadesSection_->setClip(clipId_);
+    takesSection_->setClip(isMulti ? magda::INVALID_CLIP_ID : clipId_);
 
     bool enabled = hasClip;
     bool isAutoTempo = hasClip && clip->autoTempo;
@@ -641,7 +658,7 @@ void AudioClipPropertiesContent::updateFromClip() {
 void AudioClipPropertiesContent::paint(juce::Graphics& g) {
     g.fillAll(DarkTheme::getPanelBackgroundColour());
 
-    if (clipId_ == magda::INVALID_CLIP_ID) {
+    if (clipId_ == magda::INVALID_CLIP_ID && multiClipIds_.empty()) {
         g.setColour(DarkTheme::getColour(DarkTheme::TEXT_SECONDARY).withAlpha(0.5f));
         g.setFont(FontManager::getInstance().getUIFont(13.0f));
         g.drawText("No audio clip selected", getLocalBounds(), juce::Justification::centred);

--- a/magda/daw/ui/panels/content/AudioClipPropertiesContent.hpp
+++ b/magda/daw/ui/panels/content/AudioClipPropertiesContent.hpp
@@ -3,6 +3,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include <memory>
+#include <unordered_set>
 #include <vector>
 
 #include "PanelContent.hpp"
@@ -41,6 +42,11 @@ class AudioClipPropertiesContent : public PanelContent, public magda::ClipManage
     void onActivated() override;
     void onDeactivated() override;
 
+    // Multi-clip selection (#1499): single-clip controls disable, the fades
+    // section switches to its multi-edit logic (AUTO-XFADE, fade deltas).
+    // An empty/single set restores normal single-clip mode.
+    void setMultiSelection(const std::unordered_set<magda::ClipId>& clipIds);
+
     // ClipManagerListener
     void clipSelectionChanged(magda::ClipId clipId) override;
     void clipPropertyChanged(magda::ClipId clipId) override;
@@ -51,6 +57,7 @@ class AudioClipPropertiesContent : public PanelContent, public magda::ClipManage
     void createControls();
 
     magda::ClipId clipId_ = magda::INVALID_CLIP_ID;
+    std::unordered_set<magda::ClipId> multiClipIds_;  // >1 entries = multi mode
 
     // Section labels
     std::unique_ptr<juce::Label> clipSectionLabel_;

--- a/magda/daw/ui/panels/content/WaveformEditorContent.cpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.cpp
@@ -682,6 +682,21 @@ void WaveformEditorContent::paint(juce::Graphics& g) {
 }
 
 void WaveformEditorContent::paintOverChildren(juce::Graphics& g) {
+    // Multi-clip selection placeholder (#1499): no single waveform to show,
+    // list what is selected instead. Editing happens in the properties panel.
+    if (!multiClipNames_.isEmpty()) {
+        auto bounds = getLocalBounds();
+        g.setColour(DarkTheme::getColour(DarkTheme::TEXT_SECONDARY));
+        g.setFont(FontManager::getInstance().getUIFont(14.0f));
+        auto headline = juce::String(multiClipNames_.size()) + " clips selected";
+        auto textArea = bounds.withSizeKeepingCentre(bounds.getWidth() - 40, 60);
+        g.drawText(headline, textArea.removeFromTop(24), juce::Justification::centred);
+        g.setColour(DarkTheme::getColour(DarkTheme::TEXT_SECONDARY).withAlpha(0.6f));
+        g.setFont(FontManager::getInstance().getUIFont(12.0f));
+        g.drawText(multiClipNames_.joinIntoString(", "), textArea, juce::Justification::centredTop,
+                   true);
+    }
+
     if (!transientsUpdating_)
         return;
 
@@ -962,13 +977,17 @@ void WaveformEditorContent::clipPropertyChanged(magda::ClipId clipId) {
 }
 
 void WaveformEditorContent::transientsChanged(const juce::String& filePath) {
-    if (editingClipId_ == magda::INVALID_CLIP_ID)
+    // Detection finished for a clip we're no longer editing: drop the spinner
+    // (it would otherwise stick — nothing else clears it).
+    if (editingClipId_ == magda::INVALID_CLIP_ID) {
+        setTransientsUpdating(false);
         return;
+    }
     const auto* clip = magda::ClipManager::getInstance().getClip(editingClipId_);
-    if (clip == nullptr)
+    if (clip == nullptr || !clip->isAudio()) {
+        setTransientsUpdating(false);
         return;
-    if (!clip->isAudio())
-        return;
+    }
     if (clip->audio().source.filePath != filePath)
         return;
     auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(filePath);
@@ -1081,7 +1100,40 @@ void WaveformEditorContent::timelineStateChanged(const TimelineState& state, Cha
 // Public Methods
 // ============================================================================
 
+void WaveformEditorContent::setMultiClipSelection(
+    const std::unordered_set<magda::ClipId>& clipIds) {
+    juce::StringArray names;
+    if (clipIds.size() > 1) {
+        auto& cm = magda::ClipManager::getInstance();
+        for (auto cid : clipIds) {
+            if (const auto* clip = cm.getClip(cid))
+                names.add(clip->name);
+        }
+        names.sort(true);
+    }
+    if (names == multiClipNames_)
+        return;
+
+    multiClipNames_ = names;
+    if (!multiClipNames_.isEmpty()) {
+        setClip(magda::INVALID_CLIP_ID);
+        setTransientsUpdating(false);
+        // Hide the grid so its own "No audio clip selected" empty state
+        // doesn't show through underneath the placeholder.
+        if (viewport_)
+            viewport_->setVisible(false);
+    } else if (viewport_) {
+        viewport_->setVisible(true);
+    }
+    repaint();
+}
+
 void WaveformEditorContent::setClip(magda::ClipId clipId) {
+    if (clipId != magda::INVALID_CLIP_ID) {
+        multiClipNames_.clear();
+        if (viewport_)
+            viewport_->setVisible(true);
+    }
     if (editingClipId_ != clipId) {
         editingClipId_ = clipId;
         transientsCached_ = false;
@@ -1149,6 +1201,10 @@ void WaveformEditorContent::setClip(magda::ClipId clipId) {
             } else {
                 requestTransientDetection();
             }
+        } else {
+            // No audio target (deselected / multi-selection / MIDI): nothing
+            // is being waited on — clear the spinner or it sticks forever.
+            setTransientsUpdating(false);
         }
 
         updateGridSize();

--- a/magda/daw/ui/panels/content/WaveformEditorContent.hpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <unordered_set>
 
 #include "PanelContent.hpp"
 #include "audio/AudioThumbnailManager.hpp"  // TransientCacheListener
@@ -86,6 +87,11 @@ class WaveformEditorContent : public PanelContent,
         return editingClipId_;
     }
 
+    // Multi-clip selection (#1499): the editor shows a placeholder listing the
+    // selected clips instead of one clip's waveform. An empty/single set
+    // restores normal single-clip mode.
+    void setMultiClipSelection(const std::unordered_set<magda::ClipId>& clipIds);
+
     // Waveform editor is always source-relative.
     void setRelativeTimeMode(bool relative);
     bool isRelativeTimeMode() const {
@@ -100,6 +106,9 @@ class WaveformEditorContent : public PanelContent,
 
   private:
     magda::ClipId editingClipId_ = magda::INVALID_CLIP_ID;
+
+    // Names of the multi-selected clips (empty = single-clip mode)
+    juce::StringArray multiClipNames_;
 
     bool relativeTimeMode_ = true;
 

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorLayout.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorLayout.cpp
@@ -11,6 +11,12 @@ void ClipInspector::resized() {
     if (bounds.getWidth() < 1 || bounds.getHeight() < 1)
         return;
 
+    // Preserve the scroll position across relayout. The container is
+    // re-anchored at the origin below (setBounds(cb) with cb at 0,0), which
+    // would otherwise snap the view back to the top on every property-driven
+    // update — resized() runs on each one.
+    const auto savedViewPos = clipPropsViewport_.getViewPosition();
+
     // Multi-clip count label (above header when multiple clips selected)
     if (clipCountLabel_.isVisible()) {
         clipCountLabel_.setBounds(bounds.removeFromTop(20));
@@ -423,8 +429,10 @@ void ClipInspector::resized() {
         followActionLoopCountSlider_.setBounds(addRow(24).reduced(0, 1));
     }
 
-    // Set container bounds to accommodate all content
+    // Set container bounds to accommodate all content, then restore the
+    // scroll position (the viewport clamps it if the content shrank).
     clipPropsContainer_.setBounds(cb);
+    clipPropsViewport_.setViewPosition(savedViewPos);
 }
 
 void ClipInspector::ClipPropsContainer::paint(juce::Graphics& g) {

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
@@ -202,7 +202,9 @@ void ClipInspector::updateFromSelectedClip() {
 
     const auto* clip = magda::ClipManager::getInstance().getClip(pid);
     if (clip) {
-        clipNameValue_.setText(clip->name, juce::dontSendNotification);
+        // Multi-selection has no single meaningful name — show a placeholder
+        // instead of whichever clip happens to be primary.
+        clipNameValue_.setText(isMulti ? "-" : clip->name, juce::dontSendNotification);
 
         // Update colour swatch
         auto* swatch = static_cast<magda::ColourSwatch*>(colourSwatch_.get());

--- a/magda/daw/ui/panels/content/inspector/clip/sections/ClipFadesSection.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/sections/ClipFadesSection.cpp
@@ -5,6 +5,7 @@
 #include "../../../../../themes/SmallButtonLookAndFeel.hpp"
 #include "BinaryData.h"
 #include "core/ClipBatchEdit.hpp"
+#include "core/ClipCommands.hpp"
 #include "core/ClipPropertyCommands.hpp"
 #include "core/UndoManager.hpp"
 
@@ -178,6 +179,42 @@ void ClipFadesSection::initControls() {
         };
     }
 
+    // Crossfade duration values (#1499): resize the overlap with the
+    // neighbouring clip around the joint centre. Beat-domain — the crossfade
+    // is placement geometry, not a stored seconds fade.
+    auto setupXfadeValue = [this](std::unique_ptr<magda::DraggableValueLabel>& value,
+                                  const char* tooltip, bool atStart) {
+        value =
+            std::make_unique<magda::DraggableValueLabel>(magda::DraggableValueLabel::Format::Raw);
+        value->setRange(0.0, 64.0, 0.0);
+        value->setSuffix(" b");
+        value->setDecimalPlaces(2);
+        value->setDrawBackground(false);
+        value->setDrawBorder(true);
+        value->setShowFillIndicator(false);
+        value->setTooltip(tooltip);
+        value->onValueChange = [this, atStart]() {
+            const ClipId leftId = atStart ? xfadeInLeftId_ : xfadeOutLeftId_;
+            const ClipId rightId = atStart ? xfadeInRightId_ : xfadeOutRightId_;
+            auto& cm = magda::ClipManager::getInstance();
+            const auto* left = cm.getClip(leftId);
+            const auto* right = cm.getClip(rightId);
+            if (!left || !right)
+                return;
+            const double dur =
+                juce::jmax(0.0, atStart ? xfadeInValue_->getValue() : xfadeOutValue_->getValue());
+            // Joint centre works for both the overlapping and the butted state,
+            // so dragging through 0 and back up keeps working mid-gesture.
+            const double centre = (right->placement.startBeat + left->placement.endBeat()) * 0.5;
+            magda::UndoManager::getInstance().executeCommand(
+                std::make_unique<magda::SetCrossfadeCommand>(leftId, rightId, centre - dur * 0.5,
+                                                             centre + dur * 0.5));
+        };
+        addChildComponent(*value);
+    };
+    setupXfadeValue(xfadeInValue_, "Crossfade with previous clip (beats)", true);
+    setupXfadeValue(xfadeOutValue_, "Crossfade with next clip (beats)", false);
+
     autoCrossfadeToggle_.setButtonText("AUTO-XFADE");
     autoCrossfadeToggle_.setLookAndFeel(&SmallButtonLookAndFeel::getInstance());
     autoCrossfadeToggle_.setColour(juce::TextButton::buttonColourId,
@@ -244,7 +281,13 @@ void ClipFadesSection::setClip(magda::ClipId clipId) {
 }
 
 void ClipFadesSection::setSelectedClips(const std::unordered_set<magda::ClipId>& clipIds) {
-    selectedClipIds_ = clipIds;
+    // Only reassign on a real change. The batch handlers iterate
+    // selectedClipIds_ while each executed command synchronously notifies the
+    // host panel, which calls back into here with the same selection —
+    // reassigning the set mid-iteration invalidates the loop's iterators and
+    // the edit silently stops after the first clip.
+    if (clipIds != selectedClipIds_)
+        selectedClipIds_ = clipIds;
     update();
 }
 
@@ -279,6 +322,48 @@ void ClipFadesSection::update() {
         fadeOutBehaviourButtons_[i]->setVisible(!isSession);
     }
     autoCrossfadeToggle_.setVisible(!isSession);
+
+    // Crossfade rows: single arrangement clip whose edge has a crossfade OR a
+    // crossfade-capable joint (abutting audio neighbour, value 0). Keying the
+    // row off the joint — not the overlap — keeps it alive when the value is
+    // dragged down to 0, and doubles as the creation affordance.
+    hasXfadeIn_ = false;
+    hasXfadeOut_ = false;
+    xfadeInLeftId_ = xfadeInRightId_ = magda::INVALID_CLIP_ID;
+    xfadeOutLeftId_ = xfadeOutRightId_ = magda::INVALID_CLIP_ID;
+    if (!isSession && selectedClipIds_.size() == 1) {
+        auto& cm = magda::ClipManager::getInstance();
+        double xfadeInBeats = 0.0;
+        double xfadeOutBeats = 0.0;
+        if (auto xf = cm.getCrossfadeAtStart(pid)) {
+            hasXfadeIn_ = true;
+            xfadeInLeftId_ = xf->leftClipId;
+            xfadeInRightId_ = xf->rightClipId;
+            xfadeInBeats = xf->lengthBeats();
+        } else if (auto prev = cm.findCrossfadeNeighbour(pid, true);
+                   prev != magda::INVALID_CLIP_ID) {
+            hasXfadeIn_ = true;
+            xfadeInLeftId_ = prev;
+            xfadeInRightId_ = pid;
+        }
+        if (auto xf = cm.getCrossfadeAtEnd(pid)) {
+            hasXfadeOut_ = true;
+            xfadeOutLeftId_ = xf->leftClipId;
+            xfadeOutRightId_ = xf->rightClipId;
+            xfadeOutBeats = xf->lengthBeats();
+        } else if (auto next = cm.findCrossfadeNeighbour(pid, false);
+                   next != magda::INVALID_CLIP_ID) {
+            hasXfadeOut_ = true;
+            xfadeOutLeftId_ = pid;
+            xfadeOutRightId_ = next;
+        }
+        if (hasXfadeIn_ && !xfadeInValue_->isDragging())
+            xfadeInValue_->setValue(xfadeInBeats, juce::dontSendNotification);
+        if (hasXfadeOut_ && !xfadeOutValue_->isDragging())
+            xfadeOutValue_->setValue(xfadeOutBeats, juce::dontSendNotification);
+    }
+    xfadeInValue_->setVisible(hasXfadeIn_);
+    xfadeOutValue_->setVisible(hasXfadeOut_);
 
     // Session controls
     launchFadeLabel_.setVisible(isSession);
@@ -319,6 +404,9 @@ void ClipFadesSection::update() {
                 fadeOutValue_->setTextOverride("-");
             else
                 fadeOutValue_->clearTextOverride();
+            // The toggle acts on (and flips against) the primary clip's state,
+            // so reflect that state — otherwise multi-select clicks look inert.
+            autoCrossfadeToggle_.setToggleState(clip->autoCrossfade, juce::dontSendNotification);
         } else {
             fadeInValue_->setValue(clip->fadeIn, juce::dontSendNotification);
             fadeOutValue_->setValue(clip->fadeOut, juce::dontSendNotification);
@@ -348,6 +436,8 @@ void ClipFadesSection::update() {
 bool ClipFadesSection::isAnyValueDragging() const {
     return (fadeInValue_ && fadeInValue_->isDragging()) ||
            (fadeOutValue_ && fadeOutValue_->isDragging()) ||
+           (xfadeInValue_ && xfadeInValue_->isDragging()) ||
+           (xfadeOutValue_ && xfadeOutValue_->isDragging()) ||
            (launchFadeValue_ && launchFadeValue_->isDragging());
 }
 
@@ -367,8 +457,11 @@ int ClipFadesSection::getPreferredHeight() const {
         return SECTION_H + GAP + ROW_H;
     } else {
         // Section label + gap + fadeIn|fadeOut row + gap + type btns + gap + behaviour btns + gap +
-        // AUTO-XFADE
-        return SECTION_H + GAP + ROW_H + GAP + BTN_H + GAP + BTN_H + GAP + ROW_H;
+        // AUTO-XFADE (+ crossfade row when a crossfaded edge exists)
+        int h = SECTION_H + GAP + ROW_H + GAP + BTN_H + GAP + BTN_H + GAP + ROW_H;
+        if (hasXfadeIn_ || hasXfadeOut_)
+            h += GAP + ROW_H;
+        return h;
     }
 }
 
@@ -452,6 +545,18 @@ void ClipFadesSection::resized() {
 
         // AUTO-XFADE full width
         autoCrossfadeToggle_.setBounds(b.removeFromTop(ROW_H).reduced(0, 1));
+
+        // Crossfade row: two columns mirroring fadeIn | fadeOut
+        if (hasXfadeIn_ || hasXfadeOut_) {
+            b.removeFromTop(GAP);
+            auto row = b.removeFromTop(ROW_H);
+            auto left = row.removeFromLeft(halfW);
+            row.removeFromLeft(colGap);
+            if (xfadeInValue_)
+                xfadeInValue_->setBounds(left);
+            if (xfadeOutValue_)
+                xfadeOutValue_->setBounds(row);
+        }
     }
 }
 

--- a/magda/daw/ui/panels/content/inspector/clip/sections/ClipFadesSection.hpp
+++ b/magda/daw/ui/panels/content/inspector/clip/sections/ClipFadesSection.hpp
@@ -57,6 +57,18 @@ class ClipFadesSection : public juce::Component {
     std::unique_ptr<magda::SvgButton> fadeOutBehaviourButtons_[2];
     juce::TextButton autoCrossfadeToggle_;
 
+    // Crossfade durations (#1499), in beats — shown only when the clip's edge
+    // is crossfaded with a neighbour (single selection). Editing resizes the
+    // overlap around the joint centre.
+    std::unique_ptr<magda::DraggableValueLabel> xfadeInValue_;
+    std::unique_ptr<magda::DraggableValueLabel> xfadeOutValue_;
+    bool hasXfadeIn_ = false;
+    bool hasXfadeOut_ = false;
+    magda::ClipId xfadeInLeftId_ = magda::INVALID_CLIP_ID;
+    magda::ClipId xfadeInRightId_ = magda::INVALID_CLIP_ID;
+    magda::ClipId xfadeOutLeftId_ = magda::INVALID_CLIP_ID;
+    magda::ClipId xfadeOutRightId_ = magda::INVALID_CLIP_ID;
+
     // Session-only controls
     juce::Label launchFadeLabel_;
     std::unique_ptr<magda::DraggableValueLabel> launchFadeValue_;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(TEST_SOURCES
     test_waveform_editor_absolute_mode.cpp
     test_clip_batch_edit.cpp
     test_clip_commands.cpp
+    test_clip_crossfades.cpp
     test_clip_resize_operations.cpp
     test_midi_clip_resize_left.cpp
     test_looped_waveform_tile.cpp

--- a/tests/test_clip_crossfades.cpp
+++ b/tests/test_clip_crossfades.cpp
@@ -1,0 +1,343 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/core/ClipCommands.hpp"
+#include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/Config.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/core/UndoManager.hpp"
+
+/**
+ * Tests for explicit audio clip crossfades (#1499).
+ *
+ * A crossfade is an actual overlap between two adjacent audio arrangement
+ * clips whose autoCrossfade flags are set. The geometry lives in the beat
+ * placements; TE derives the playback fades from the overlap.
+ *
+ * At the default 120 BPM: 1 second = 2 beats.
+ */
+
+using namespace magda;
+
+namespace {
+
+void resetState() {
+    UndoManager::getInstance().clearHistory();
+    ClipManager::getInstance().clearAllClips();
+    TrackManager::getInstance().clearAllTracks();
+}
+
+TrackId createTrack() {
+    return TrackManager::getInstance().createTrack("Track", TrackType::Audio);
+}
+
+// Creates an audio clip with source headroom on both sides (offset 10 s into a
+// 100 s file), so crossfade edge extensions aren't clamped by material limits.
+// Extension clamping itself is covered by its own test case below.
+ClipId createAudioBeats(TrackId trackId, double startBeat, double lengthBeats) {
+    auto& cm = ClipManager::getInstance();
+    const ClipId id =
+        cm.createAudioClipBeats(trackId, startBeat, lengthBeats, "test.wav", ClipView::Arrangement);
+    if (auto* clip = cm.getClip(id)) {
+        clip->audio().source.durationSeconds = 100.0;
+        clip->offset = 10.0;
+        clip->loopStart = 10.0;
+    }
+    return id;
+}
+
+}  // namespace
+
+TEST_CASE("new audio clips follow the auto-crossfade config default", "[crossfade]") {
+    resetState();
+    auto& cm = ClipManager::getInstance();
+    const auto trackId = createTrack();
+
+    const ClipId id = createAudioBeats(trackId, 0.0, 4.0);
+    CHECK(cm.getClip(id)->autoCrossfade == Config::getInstance().getAutoCrossfadeByDefault());
+}
+
+// ============================================================================
+// setCrossfadeBeats — creation, resize, removal
+// ============================================================================
+
+TEST_CASE("setCrossfadeBeats creates an overlap at a butt joint and flags both clips",
+          "[crossfade]") {
+    resetState();
+    auto& cm = ClipManager::getInstance();
+    const auto trackId = createTrack();
+
+    const ClipId a = createAudioBeats(trackId, 0.0, 8.0);
+    const ClipId b = createAudioBeats(trackId, 8.0, 8.0);
+
+    REQUIRE(cm.setCrossfadeBeats(a, b, 2.0));
+
+    const auto* left = cm.getClip(a);
+    const auto* right = cm.getClip(b);
+    REQUIRE(left != nullptr);
+    REQUIRE(right != nullptr);
+
+    // Overlap centred on the old joint (beat 8): [7, 9]
+    CHECK(left->placement.endBeat() == Catch::Approx(9.0));
+    CHECK(right->placement.startBeat == Catch::Approx(7.0));
+    CHECK(right->placement.endBeat() == Catch::Approx(16.0));
+    CHECK(left->autoCrossfade);
+    CHECK(right->autoCrossfade);
+
+    auto xfB = cm.getCrossfadeAtStart(b);
+    REQUIRE(xfB.has_value());
+    CHECK(xfB->leftClipId == a);
+    CHECK(xfB->rightClipId == b);
+    CHECK(xfB->lengthBeats() == Catch::Approx(2.0));
+
+    auto xfA = cm.getCrossfadeAtEnd(a);
+    REQUIRE(xfA.has_value());
+    CHECK(xfA->startBeat == Catch::Approx(7.0));
+    CHECK(xfA->endBeat == Catch::Approx(9.0));
+}
+
+TEST_CASE("setCrossfadeBeats clamps so neither clip is swallowed", "[crossfade]") {
+    resetState();
+    auto& cm = ClipManager::getInstance();
+    const auto trackId = createTrack();
+
+    const ClipId a = createAudioBeats(trackId, 0.0, 4.0);
+    const ClipId b = createAudioBeats(trackId, 4.0, 4.0);
+
+    // Absurd duration: must clamp to a partial overlap, never containment
+    REQUIRE(cm.setCrossfadeBeats(a, b, 100.0));
+
+    const auto* left = cm.getClip(a);
+    const auto* right = cm.getClip(b);
+    CHECK(right->placement.startBeat > left->placement.startBeat);
+    CHECK(left->placement.endBeat() < right->placement.endBeat());
+    CHECK(cm.getCrossfadeAtStart(b).has_value());
+}
+
+TEST_CASE("setCrossfadeBeats with zero duration butts the joint (removal)", "[crossfade]") {
+    resetState();
+    auto& cm = ClipManager::getInstance();
+    const auto trackId = createTrack();
+
+    const ClipId a = createAudioBeats(trackId, 0.0, 8.0);
+    const ClipId b = createAudioBeats(trackId, 8.0, 8.0);
+    REQUIRE(cm.setCrossfadeBeats(a, b, 2.0));
+    REQUIRE(cm.getCrossfadeAtStart(b).has_value());
+
+    REQUIRE(cm.setCrossfadeBeats(a, b, 0.0));
+
+    const auto* left = cm.getClip(a);
+    const auto* right = cm.getClip(b);
+    CHECK(left->placement.endBeat() == Catch::Approx(8.0));
+    CHECK(right->placement.startBeat == Catch::Approx(8.0));
+    CHECK_FALSE(cm.getCrossfadeAtStart(b).has_value());
+    CHECK_FALSE(cm.getCrossfadeAtEnd(a).has_value());
+}
+
+TEST_CASE("setCrossfadeBeats rejects invalid pairs", "[crossfade]") {
+    resetState();
+    auto& cm = ClipManager::getInstance();
+    const auto trackId = createTrack();
+    const auto otherTrackId = createTrack();
+
+    const ClipId a = createAudioBeats(trackId, 0.0, 8.0);
+    const ClipId otherTrack = createAudioBeats(otherTrackId, 8.0, 8.0);
+    const ClipId midi = cm.createMidiClipBeats(trackId, 8.0, 8.0, ClipView::Arrangement);
+
+    CHECK_FALSE(cm.setCrossfadeBeats(a, otherTrack, 2.0));
+    CHECK_FALSE(cm.setCrossfadeBeats(a, midi, 2.0));
+    CHECK_FALSE(cm.setCrossfadeBeats(a, a, 2.0));
+    CHECK_FALSE(cm.setCrossfadeBeats(a, INVALID_CLIP_ID, 2.0));
+}
+
+TEST_CASE("setCrossfadeRegionBeats respects source material bounds", "[crossfade]") {
+    resetState();
+    auto& cm = ClipManager::getInstance();
+    const auto trackId = createTrack();
+
+    // 4 beats = 2 s at 120 BPM. Give both clips exactly 2 s of source with no
+    // spare material: the left clip cannot extend right, the right clip cannot
+    // extend left (offset 0), so no overlap can be created.
+    const ClipId a = createAudioBeats(trackId, 0.0, 4.0);
+    const ClipId b = createAudioBeats(trackId, 4.0, 4.0);
+    cm.getClip(a)->audio().source.durationSeconds = 2.0;
+    cm.getClip(b)->audio().source.durationSeconds = 2.0;
+    cm.getClip(a)->offset = 0.0;
+    cm.getClip(b)->offset = 0.0;
+
+    REQUIRE(cm.setCrossfadeBeats(a, b, 2.0));
+
+    CHECK(cm.getClip(a)->placement.endBeat() == Catch::Approx(4.0));
+    CHECK(cm.getClip(b)->placement.startBeat == Catch::Approx(4.0));
+    CHECK_FALSE(cm.getCrossfadeAtStart(b).has_value());
+
+    // Give the right clip 1 s of pre-roll material (offset 1 s): its edge can
+    // now extend up to 2 beats left, the left clip still cannot move.
+    cm.getClip(b)->audio().source.durationSeconds = 3.0;
+    cm.getClip(b)->offset = 1.0;
+
+    REQUIRE(cm.setCrossfadeBeats(a, b, 4.0));
+    CHECK(cm.getClip(a)->placement.endBeat() == Catch::Approx(4.0));
+    CHECK(cm.getClip(b)->placement.startBeat == Catch::Approx(2.0));
+
+    auto xf = cm.getCrossfadeAtStart(b);
+    REQUIRE(xf.has_value());
+    CHECK(xf->lengthBeats() == Catch::Approx(2.0));
+}
+
+// ============================================================================
+// resolveOverlaps — crossfade-aware overlap policy
+// ============================================================================
+
+TEST_CASE("moving an auto-crossfade clip onto a neighbour keeps the overlap", "[crossfade]") {
+    resetState();
+    auto& cm = ClipManager::getInstance();
+    const auto trackId = createTrack();
+
+    const ClipId a = createAudioBeats(trackId, 0.0, 8.0);
+    const ClipId b = createAudioBeats(trackId, 10.0, 8.0);
+    cm.setAutoCrossfade(b, true);
+
+    cm.moveClipBeats(b, 6.0);
+
+    // Overlap [6, 8] survives as a crossfade; the neighbour gets the flag too
+    CHECK(cm.getClip(a)->placement.endBeat() == Catch::Approx(8.0));
+    CHECK(cm.getClip(b)->placement.startBeat == Catch::Approx(6.0));
+    CHECK(cm.getClip(a)->autoCrossfade);
+
+    auto xf = cm.getCrossfadeAtStart(b);
+    REQUIRE(xf.has_value());
+    CHECK(xf->leftClipId == a);
+    CHECK(xf->startBeat == Catch::Approx(6.0));
+    CHECK(xf->endBeat == Catch::Approx(8.0));
+}
+
+TEST_CASE("moving a clip without auto-crossfade still trims the neighbour", "[crossfade]") {
+    resetState();
+    auto& cm = ClipManager::getInstance();
+    const auto trackId = createTrack();
+
+    // New audio clips default to AUTO-XFADE; pin it off to test the trim path
+    const ClipId a = createAudioBeats(trackId, 0.0, 8.0);
+    const ClipId b = createAudioBeats(trackId, 10.0, 8.0);
+    cm.setAutoCrossfade(a, false);
+    cm.setAutoCrossfade(b, false);
+
+    cm.moveClipBeats(b, 6.0);
+
+    // Existing behaviour: the covered tail of A is trimmed away
+    CHECK(cm.getClip(a)->placement.endBeat() == Catch::Approx(6.0));
+    CHECK_FALSE(cm.getCrossfadeAtStart(b).has_value());
+}
+
+TEST_CASE("auto-crossfade never keeps overlaps with MIDI clips", "[crossfade]") {
+    resetState();
+    auto& cm = ClipManager::getInstance();
+    const auto trackId = createTrack();
+
+    const ClipId midi = cm.createMidiClipBeats(trackId, 0.0, 8.0, ClipView::Arrangement);
+    const ClipId b = createAudioBeats(trackId, 10.0, 8.0);
+    cm.setAutoCrossfade(b, true);
+
+    cm.moveClipBeats(b, 6.0);
+
+    CHECK(cm.getClip(midi)->placement.endBeat() == Catch::Approx(6.0));
+    CHECK_FALSE(cm.getCrossfadeAtStart(b).has_value());
+}
+
+TEST_CASE("full containment still deletes even with auto-crossfade", "[crossfade]") {
+    resetState();
+    auto& cm = ClipManager::getInstance();
+    const auto trackId = createTrack();
+
+    const ClipId a = createAudioBeats(trackId, 2.0, 2.0);
+    const ClipId b = createAudioBeats(trackId, 10.0, 8.0);
+    cm.setAutoCrossfade(b, true);
+
+    cm.moveClipBeats(b, 0.0);
+
+    CHECK(cm.getClip(a) == nullptr);
+}
+
+TEST_CASE("an existing crossfade survives edits to other clips on the track", "[crossfade]") {
+    resetState();
+    auto& cm = ClipManager::getInstance();
+    const auto trackId = createTrack();
+
+    const ClipId a = createAudioBeats(trackId, 0.0, 8.0);
+    const ClipId b = createAudioBeats(trackId, 8.0, 8.0);
+    REQUIRE(cm.setCrossfadeBeats(a, b, 2.0));
+
+    // A third clip lands elsewhere on the track — the A/B crossfade is untouched
+    const ClipId c = createAudioBeats(trackId, 30.0, 4.0);
+    cm.moveClipBeats(c, 20.0);
+
+    auto xf = cm.getCrossfadeAtStart(b);
+    REQUIRE(xf.has_value());
+    CHECK(xf->lengthBeats() == Catch::Approx(2.0));
+}
+
+// ============================================================================
+// SetCrossfadeCommand — undo/redo
+// ============================================================================
+
+TEST_CASE("SetCrossfadeCommand undo restores both clips exactly", "[crossfade]") {
+    resetState();
+    auto& cm = ClipManager::getInstance();
+    auto& um = UndoManager::getInstance();
+    const auto trackId = createTrack();
+
+    // Pin AUTO-XFADE off so the command's flag-enabling side effect (and its
+    // undo) is observable regardless of the creation default.
+    const ClipId a = createAudioBeats(trackId, 0.0, 8.0);
+    const ClipId b = createAudioBeats(trackId, 8.0, 8.0);
+    cm.setAutoCrossfade(a, false);
+    cm.setAutoCrossfade(b, false);
+    const double aEndBefore = cm.getClip(a)->placement.endBeat();
+    const double bStartBefore = cm.getClip(b)->placement.startBeat;
+    const double bOffsetBefore = cm.getClip(b)->offset;
+
+    um.executeCommand(std::make_unique<SetCrossfadeCommand>(a, b, 7.0, 9.0, 120.0));
+
+    REQUIRE(cm.getCrossfadeAtStart(b).has_value());
+
+    um.undo();
+    CHECK(cm.getClip(a)->placement.endBeat() == Catch::Approx(aEndBefore));
+    CHECK(cm.getClip(b)->placement.startBeat == Catch::Approx(bStartBefore));
+    CHECK(cm.getClip(b)->offset == Catch::Approx(bOffsetBefore));
+    CHECK_FALSE(cm.getClip(a)->autoCrossfade);
+    CHECK_FALSE(cm.getClip(b)->autoCrossfade);
+    CHECK_FALSE(cm.getCrossfadeAtStart(b).has_value());
+
+    um.redo();
+    auto xf = cm.getCrossfadeAtStart(b);
+    REQUIRE(xf.has_value());
+    CHECK(xf->startBeat == Catch::Approx(7.0));
+    CHECK(xf->endBeat == Catch::Approx(9.0));
+    CHECK(cm.getClip(a)->autoCrossfade);
+    CHECK(cm.getClip(b)->autoCrossfade);
+}
+
+TEST_CASE("crossfade region edits keep the untouched edge fixed", "[crossfade]") {
+    resetState();
+    auto& cm = ClipManager::getInstance();
+    const auto trackId = createTrack();
+
+    const ClipId a = createAudioBeats(trackId, 0.0, 8.0);
+    const ClipId b = createAudioBeats(trackId, 8.0, 8.0);
+    REQUIRE(cm.setCrossfadeBeats(a, b, 2.0));  // region [7, 9]
+
+    // Drag the overlap end (the fade-in handle gesture): start stays at 7
+    REQUIRE(cm.setCrossfadeRegionBeats(a, b, 7.0, 10.0));
+    auto xf = cm.getCrossfadeAtStart(b);
+    REQUIRE(xf.has_value());
+    CHECK(xf->startBeat == Catch::Approx(7.0));
+    CHECK(xf->endBeat == Catch::Approx(10.0));
+
+    // Drag the overlap start (the fade-out handle gesture): end stays at 10
+    REQUIRE(cm.setCrossfadeRegionBeats(a, b, 6.0, 10.0));
+    xf = cm.getCrossfadeAtStart(b);
+    REQUIRE(xf.has_value());
+    CHECK(xf->startBeat == Catch::Approx(6.0));
+    CHECK(xf->endBeat == Catch::Approx(10.0));
+}

--- a/tests/test_clip_sync_integration_juce.cpp
+++ b/tests/test_clip_sync_integration_juce.cpp
@@ -1657,6 +1657,12 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         auto mover =
             cm.createAudioClip(f.trackId, 0.0, 8.0, f.audioPath(), ClipView::Arrangement, 60.0);
 
+        // New audio clips default to auto-crossfade, which would KEEP this
+        // partial overlap as a crossfade (#1499). Pin it off to exercise the
+        // trim path this test covers.
+        cm.setAutoCrossfade(stationary, false);
+        cm.setAutoCrossfade(mover, false);
+
         cm.moveClip(mover, 4.0, 60.0);
 
         const auto* s = cm.getClip(stationary);
@@ -1683,6 +1689,13 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
             cm.createAudioClip(f.trackId, 0.0, 4.0, f.audioPath(), ClipView::Arrangement, 60.0);
         auto victim =
             cm.createAudioClip(f.trackId, 8.0, 4.0, f.audioPath(), ClipView::Arrangement, 60.0);
+
+        // New audio clips default to auto-crossfade, which the duplicate would
+        // inherit and use to KEEP this partial overlap as a crossfade (#1499).
+        // Pin the source off (the copy inherits the flag) to exercise the trim
+        // path this test covers.
+        cm.setAutoCrossfade(source, false);
+        cm.setAutoCrossfade(victim, false);
 
         auto copy = cm.duplicateClipAt(source, 6.0, f.trackId, 60.0);
         expect(copy != INVALID_CLIP_ID);


### PR DESCRIPTION
A crossfade is an actual overlap between two adjacent audio arrangement clips whose autoCrossfade flags are set; TE derives the playback fades from the overlap region, and the beat-domain geometry serializes with the placements.

Model:
- resolveOverlaps keeps partial overlaps as crossfades when the edited clip has AUTO-XFADE on (flag propagates to the neighbour); trims as before otherwise
- setCrossfadeRegionBeats/setCrossfadeBeats create/resize/remove the overlap, clamped by containment and source material bounds
- getCrossfadeAtStart/End queries, findCrossfadeNeighbour for joints
- SetCrossfadeCommand (mergeable) restores both clips on undo
- new audio clips default to AUTO-XFADE via a config option (Preferences > Behaviour > Auto-crossfade new audio clips)

UI:
- crossfade X rendering in the overlap, drawn by both components so z-order does not matter; deterministic clip z-order by start beat
- fade handles at a crossfaded edge resize the overlap (undoable)
- context menu: crossfade with previous/next clip, remove crossfade
- XFADE beats values in the fades section, keyed off the joint so dragging to 0 keeps the row as a re-creation affordance
- file/browser drops land at the drop point (ResolveOverlaps) instead of shifting to the next gap

Multi-selection editor support:
- all-audio multi-selection keeps the waveform editor open with a placeholder and the properties panel in multi mode (fades section batch edits incl. AUTO-XFADE)
- fixed fades-section batch edits applying to one clip only (the set was reassigned re-entrantly mid-iteration)
- inspector name shows '-' on multi-select; scroll position preserved across property-driven relayouts
- stale crossfade rendering and stuck 'Updating transients' overlay cleared when clips move apart or the editor switches away