### PR TITLE
Centralize track-type input invariants in TrackInfo::normalizeForType

### DIFF
--- a/magda/daw/core/TrackInfo.hpp
+++ b/magda/daw/core/TrackInfo.hpp
@@ -240,6 +240,22 @@ struct TrackInfo {
         return type != TrackType::Aux && type != TrackType::Group && type != TrackType::Master;
     }
 
+    // Enforce the track-type invariants on this struct's own fields. Input-less
+    // tracks (Aux send buses, Group summing tracks) only pass signal from
+    // elsewhere: they take no external audio/MIDI input and so cannot be
+    // monitored or record-armed. This is the single normalization boundary for
+    // those rules. Aggregate entry points that accept or mutate whole track
+    // state (create, restore, deserialize) call it so persistence and importers
+    // stay mechanical and cannot let stale on-disk input state become live.
+    void normalizeForType() {
+        if (!takesExternalInput()) {
+            recordArmed = false;
+            inputMonitor = InputMonitorMode::Off;
+            midiInputDevice = "";
+            audioInputDevice = "";
+        }
+    }
+
     // MIDI input helpers
     //
     // Single source of truth for "does this track listen to live MIDI input".

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -329,11 +329,14 @@ TrackId TrackManager::createTrack(const juce::String& name, TrackType type) {
     track.audioInputDevice = "";         // Audio input disabled by default (enable via UI)
     // midiOutputDevice left empty - requires specific device selection
 
-    // Aux buses need a bus index. Aux and Group take no external input, so they
-    // never receive MIDI; every other track listens to all inputs.
+    // Aux buses need a bus index.
     if (type == TrackType::Aux)
         track.auxBusIndex = nextAuxBusIndex_++;
-    track.midiInputDevice = track.takesExternalInput() ? "all" : "";
+
+    // Seed the default "listen to all inputs" and let the single type-invariant
+    // boundary clear it (plus monitor/record-arm) for input-less tracks.
+    track.midiInputDevice = "all";
+    track.normalizeForType();
 
     TrackId trackId = track.id;
     tracks_.push_back(track);
@@ -796,18 +799,11 @@ void TrackManager::restoreTrack(const TrackInfo& trackInfo) {
 
     tracks_.push_back(trackInfo);
 
-    // Input-less tracks (Aux, Group) take no external input. Projects saved
-    // before this invariant existed can carry MIDI/audio input, monitoring, or
-    // record-arm on them (createTrack used to seed every non-Aux track with
-    // "all"), so sanitize on restore rather than let stale on-disk state
-    // reintroduce it.
-    if (!tracks_.back().takesExternalInput()) {
-        auto& restored = tracks_.back();
-        restored.recordArmed = false;
-        restored.inputMonitor = InputMonitorMode::Off;
-        restored.midiInputDevice = "";
-        restored.audioInputDevice = "";
-    }
+    // Projects saved before the input-less-track invariant existed can carry
+    // MIDI/audio input, monitoring, or record-arm on Aux/Group tracks
+    // (createTrack used to seed every non-Aux track with "all"). Normalize on
+    // restore rather than let stale on-disk state reintroduce it.
+    tracks_.back().normalizeForType();
 
     // Ensure nextTrackId_ is beyond any restored track IDs
     if (trackInfo.id >= nextTrackId_) {

--- a/tests/test_project_serialization.cpp
+++ b/tests/test_project_serialization.cpp
@@ -1161,6 +1161,84 @@ TEST_CASE("Project with Tracks", "[project][serialization][tracks]") {
     }
 }
 
+TEST_CASE("normalizeForType clears input state on input-less tracks",
+          "[project][tracks][invariants]") {
+    SECTION("Group track loses external input, monitor, and record-arm") {
+        TrackInfo group;
+        group.type = TrackType::Group;
+        group.recordArmed = true;
+        group.inputMonitor = InputMonitorMode::In;
+        group.midiInputDevice = "all";
+        group.audioInputDevice = "input:1";
+
+        group.normalizeForType();
+
+        REQUIRE(group.recordArmed == false);
+        REQUIRE(group.inputMonitor == InputMonitorMode::Off);
+        REQUIRE(group.midiInputDevice.isEmpty());
+        REQUIRE(group.audioInputDevice.isEmpty());
+    }
+
+    SECTION("Aux track loses external input, monitor, and record-arm") {
+        TrackInfo aux;
+        aux.type = TrackType::Aux;
+        aux.recordArmed = true;
+        aux.inputMonitor = InputMonitorMode::Auto;
+        aux.midiInputDevice = "all";
+        aux.audioInputDevice = "input:2";
+
+        aux.normalizeForType();
+
+        REQUIRE(aux.recordArmed == false);
+        REQUIRE(aux.inputMonitor == InputMonitorMode::Off);
+        REQUIRE(aux.midiInputDevice.isEmpty());
+        REQUIRE(aux.audioInputDevice.isEmpty());
+    }
+
+    SECTION("Input-taking track keeps its input state") {
+        TrackInfo audio;
+        audio.type = TrackType::Audio;
+        audio.recordArmed = true;
+        audio.inputMonitor = InputMonitorMode::In;
+        audio.midiInputDevice = "all";
+        audio.audioInputDevice = "input:3";
+
+        audio.normalizeForType();
+
+        REQUIRE(audio.recordArmed == true);
+        REQUIRE(audio.inputMonitor == InputMonitorMode::In);
+        REQUIRE(audio.midiInputDevice == "all");
+        REQUIRE(audio.audioInputDevice == "input:3");
+    }
+}
+
+TEST_CASE("Restoring a legacy group track normalizes stale input state",
+          "[project][tracks][invariants][restore]") {
+    ProjectTestFixture fixture;
+    auto& trackManager = TrackManager::getInstance();
+
+    // Simulate a group track saved before the input-less invariant existed:
+    // it carries record-arm, input monitoring, and MIDI/audio input routing.
+    TrackInfo legacyGroup;
+    legacyGroup.id = 4200;
+    legacyGroup.type = TrackType::Group;
+    legacyGroup.name = "Legacy Group";
+    legacyGroup.recordArmed = true;
+    legacyGroup.inputMonitor = InputMonitorMode::In;
+    legacyGroup.midiInputDevice = "all";
+    legacyGroup.audioInputDevice = "input:1";
+
+    trackManager.restoreTrack(legacyGroup);
+
+    const auto* restored = trackManager.getTrack(4200);
+    REQUIRE(restored != nullptr);
+    REQUIRE(restored->type == TrackType::Group);
+    REQUIRE(restored->recordArmed == false);
+    REQUIRE(restored->inputMonitor == InputMonitorMode::Off);
+    REQUIRE(restored->midiInputDevice.isEmpty());
+    REQUIRE(restored->audioInputDevice.isEmpty());
+}
+
 TEST_CASE("Project File Format", "[project][serialization][file]") {
     ProjectTestFixture fixture;
 


### PR DESCRIPTION
Introduce TrackInfo::normalizeForType() as the single boundary that enforces input-less-track rules: Aux/Group tracks clear recordArmed, inputMonitor, and MIDI/audio input. createTrack seeds the default input then normalizes; restoreTrack normalizes so legacy on-disk group/aux input state self-heals on load. Deserialization stays mechanical. Setters keep rejecting invalid state at the API boundary.

Closes #1695