### PR TITLE
Fix two async-teardown crashes in the JUCE test suite

### DIFF
--- a/magda/daw/audio/plugins/PolyStepSequencerPlugin.cpp
+++ b/magda/daw/audio/plugins/PolyStepSequencerPlugin.cpp
@@ -479,9 +479,16 @@ void PolyStepSequencerPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
                 const int pos = stepRecordPosition_.load(std::memory_order_relaxed);
                 if (pos < maxSteps) {
                     const int note = msg.getNoteNumber();
-                    juce::MessageManager::callAsync([this, pos, note] {
-                        addStepNote(pos, note);
-                        setStepGate(pos, true);
+                    // callAsync is posted from the audio thread; the plugin can be
+                    // destroyed (track/plugin removal, project reload) before it
+                    // runs. Capture a weak self-ref so a stale callback no-ops
+                    // instead of writing through a freed ValueTree.
+                    auto safeThis = te::makeSafeRef(*this);
+                    juce::MessageManager::callAsync([safeThis, pos, note] {
+                        if (auto* self = safeThis.get()) {
+                            self->addStepNote(pos, note);
+                            self->setStepGate(pos, true);
+                        }
                     });
                 }
                 ++recordHeldCount_;

--- a/magda/daw/audio/plugins/StepSequencerPlugin.cpp
+++ b/magda/daw/audio/plugins/StepSequencerPlugin.cpp
@@ -403,9 +403,16 @@ void StepSequencerPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
                 if (pos < maxSteps) {
                     int note = msg.getNoteNumber();
                     int capturedPos = pos;
-                    juce::MessageManager::callAsync([this, capturedPos, note] {
-                        setStepNote(capturedPos, note);
-                        setStepGate(capturedPos, true);
+                    // callAsync is posted from the audio thread; the plugin can be
+                    // destroyed (track/plugin removal, project reload) before it
+                    // runs. Capture a weak self-ref so a stale callback no-ops
+                    // instead of writing through a freed ValueTree.
+                    auto safeThis = te::makeSafeRef(*this);
+                    juce::MessageManager::callAsync([safeThis, capturedPos, note] {
+                        if (auto* self = safeThis.get()) {
+                            self->setStepNote(capturedPos, note);
+                            self->setStepGate(capturedPos, true);
+                        }
                     });
                     const int nextPos = pos + 1;
                     stepRecordPosition_.store(nextPos, std::memory_order_relaxed);
@@ -496,8 +503,13 @@ void StepSequencerPlugin::applyToBuffer(const te::PluginRenderContext& fc) {
         if (pCount != numSteps.get())
             numSteps = pCount;
         stepCount = juce::jlimit(1, MAX_STEPS, pCount);
-        // Persist to ValueTree (on message thread to avoid blocking audio)
-        juce::MessageManager::callAsync([this] { saveStepsToState(); });
+        // Persist to ValueTree (on message thread to avoid blocking audio).
+        // Weak self-ref: the plugin may be gone before this runs (see above).
+        auto safeThis = te::makeSafeRef(*this);
+        juce::MessageManager::callAsync([safeThis] {
+            if (auto* self = safeThis.get())
+                self->saveStepsToState();
+        });
     }
 
     // --- Get step events from the clock ---

--- a/tests/test_clip_sync_integration_juce.cpp
+++ b/tests/test_clip_sync_integration_juce.cpp
@@ -159,6 +159,19 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         }
 
         ~Fixture() {
+            // The reversed-clip test triggers an async ReverseRenderJob on the
+            // shared engine's background thread pool: it reads this fixture's
+            // source WAV and writes a reversed proxy. If it outlives the fixture
+            // it reverses a deleted source file (hitting an internal jassertfalse)
+            // and derefs the destroyed edit, segfaulting a later unrelated test.
+            // Let any pending job finish (interrupting a reverse mid-render hits
+            // that same jassertfalse) and drain its follow-up message-thread
+            // callbacks BEFORE we destroy the edit and delete the temp WAV.
+            if (auto* engine = magda::test::getSharedEngine().getEngine())
+                engine->getBackgroundJobs().getPool().removeAllJobs(false, 10000);
+            if (auto* mm = juce::MessageManager::getInstanceWithoutCreating())
+                mm->runDispatchLoopUntil(50);
+
             // Destroy ClipSynchronizer first (unregisters listener)
             clipSync.reset();
             warpMarkerManager.reset();


### PR DESCRIPTION
The JUCE test binary runs many shared-engine integration suites back to back in one process; async work that outlives the test that spawned it detonates in a later, unrelated test. This was a ~90%-reproducible segfault locally (the green CI runs were the lucky ~10%). Two independent leaks:

1. ReverseRenderJob leak (test infra): the reversed-clip ClipSync test starts an async reverse render on the engine's background pool, then the fixture deletes the source WAV and Edit before it finishes, so the orphaned job reverses a deleted file and derefs the dead Edit. Drain the pool (letting jobs finish, not interrupting) and pump the loop in the fixture destructor before tearing down.

2. StepSequencerPlugin / PolyStepSequencerPlugin use-after-free (real product bug): applyToBuffer() runs on the audio thread and posts callAsync capturing a raw this to write step state into the plugin's ValueTree. If the plugin is destroyed (track/plugin removal, project reload) before the callback runs it writes through freed memory. Capture a weak self-ref (te::makeSafeRef) so a stale callback no-ops.

Verified: 20/20 clean local runs, from ~90% crash before.