### PR TITLE
Fix mouse-wheel scroll on Linux/Windows

### DIFF
--- a/magda/daw/core/GestureRouter.cpp
+++ b/magda/daw/core/GestureRouter.cpp
@@ -14,11 +14,11 @@ namespace magda {
 // ----------------------------------------------------------------------------
 namespace {
 // Horizontal scroll: magnitude is a pixel delta, so sensitivity scales the raw
-// wheel delta (~0.195 per mouse tick on X11) into a sensible pixel step. Tuned
-// to roughly match the vertical viewport step (kViewportScrollSensitivity) so
-// horizontal and vertical wheel scroll feel about the same; the old value of 50
-// left horizontal scroll ~4x slower than vertical. User-overridable (#22).
-constexpr float kScrollSensitivity = 200.0f;
+// wheel delta (~0.195 per mouse tick on X11) into a sensible pixel step. Set a
+// bit above the vertical viewport step (kViewportScrollSensitivity) so a mouse
+// wheel covers timeline distance briskly; the old value of 50 left horizontal
+// scroll ~4x slower than vertical. User-overridable in the gesture prefs (#22).
+constexpr float kScrollSensitivity = 300.0f;
 // Vertical track scroll matches juce::Viewport's default wheel formula
 // (deltaY * 14 * singleStepSize=16), the same factor TrackHeadersPanel uses,
 // so the arrangement body and the headers scroll in lockstep.

--- a/magda/daw/core/GestureRouter.cpp
+++ b/magda/daw/core/GestureRouter.cpp
@@ -13,9 +13,12 @@ namespace magda {
 // site migrates it keeps its own constants.
 // ----------------------------------------------------------------------------
 namespace {
-// Scroll: magnitude is a pixel delta, so sensitivity scales the raw wheel
-// delta (~0.195 per mouse tick on X11) into a sensible pixel step.
-constexpr float kScrollSensitivity = 50.0f;
+// Horizontal scroll: magnitude is a pixel delta, so sensitivity scales the raw
+// wheel delta (~0.195 per mouse tick on X11) into a sensible pixel step. Tuned
+// to roughly match the vertical viewport step (kViewportScrollSensitivity) so
+// horizontal and vertical wheel scroll feel about the same; the old value of 50
+// left horizontal scroll ~4x slower than vertical. User-overridable (#22).
+constexpr float kScrollSensitivity = 200.0f;
 // Vertical track scroll matches juce::Viewport's default wheel formula
 // (deltaY * 14 * singleStepSize=16), the same factor TrackHeadersPanel uses,
 // so the arrangement body and the headers scroll in lockstep.

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -1530,6 +1530,10 @@ void TrackContentPanel::mouseUp(const juce::MouseEvent& event) {
         drawingClipTrackIndex_ = -1;
         drawingClipStartBeat_ = 0.0;
         drawingClipEndBeat_ = 0.0;
+        // The draw set the pen cursor on mouseDown; snap it back to the
+        // zone's hover cursor now instead of leaving the pen until the next
+        // mouse move.
+        refreshCursorFromMouse();
         repaintVisible();
         return;
     }

--- a/magda/daw/ui/components/tracks/TrackContentPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.cpp
@@ -2197,20 +2197,10 @@ void TrackContentPanel::timerCallback() {
             repaint(juce::Rectangle<int>(cursorX - 3, trackArea.getY(), 6, trackArea.getHeight()));
         }
     }
-
-    // Update cursor when modifier keys change (e.g. shift for split mode)
-    if (isMouseOver(true)) {
-        auto mousePos = getMouseXYRelative();
-        bool shiftNow = juce::ModifierKeys::currentModifiers.isShiftDown();
-        if (shiftNow != lastShiftState_) {
-            lastShiftState_ = shiftNow;
-            updateCursorForPosition(mousePos.x, mousePos.y, shiftNow);
-        }
-    }
 }
 
 void TrackContentPanel::mouseMove(const juce::MouseEvent& event) {
-    updateCursorForPosition(event.x, event.y, event.mods.isShiftDown());
+    updateCursorForPosition(event.x, event.y);
 }
 
 void TrackContentPanel::mouseWheelMove(const juce::MouseEvent& event,
@@ -2270,13 +2260,14 @@ interaction::PanelSnapshot TrackContentPanel::makePanelHitSnapshot(int x, int y)
     return s;
 }
 
-void TrackContentPanel::updateCursorForPosition(int x, int y, bool shiftHeld) {
+void TrackContentPanel::updateCursorForPosition(int x, int y) {
     // Zone model + cursor policy live in the shared hit tester (#1719), so
-    // the cursor and the mouseDown gesture can never disagree. (This also
-    // retired an unreachable lower-zone shift-crosshair branch the old
-    // duplicated logic carried.)
+    // the cursor and the mouseDown gesture can never disagree. The hover
+    // cursor is modifier-independent: the pen appears only once a Shift-draw
+    // actually starts (see mouseDown), so Shift stays free for Shift+wheel
+    // horizontal scroll instead of flashing the pen on every Shift press.
     const auto zone = interaction::panelZone(x, y, makePanelHitSnapshot(x, y));
-    setMouseCursor(interaction::toJuceCursor(interaction::panelCursor(zone, shiftHeld)));
+    setMouseCursor(interaction::toJuceCursor(interaction::panelCursor(zone)));
 }
 
 void TrackContentPanel::refreshCursorFromMouse() {
@@ -2287,14 +2278,7 @@ void TrackContentPanel::refreshCursorFromMouse() {
         return;
 
     const auto pos = getMouseXYRelative();
-    updateCursorForPosition(pos.x, pos.y, juce::ModifierKeys::getCurrentModifiers().isShiftDown());
-}
-
-void TrackContentPanel::modifierKeysChanged(const juce::ModifierKeys& mods) {
-    // Shift swaps the empty-lane cursors to draw-clip; recompute without
-    // waiting for a mouse move (#1720).
-    refreshCursorFromMouse();
-    juce::Component::modifierKeysChanged(mods);
+    updateCursorForPosition(pos.x, pos.y);
 }
 
 // ============================================================================

--- a/magda/daw/ui/components/tracks/TrackContentPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.hpp
@@ -305,7 +305,6 @@ class TrackContentPanel : public juce::Component,
     void mouseWheelMove(const juce::MouseEvent& event,
                         const juce::MouseWheelDetails& wheel) override;
     void mouseDoubleClick(const juce::MouseEvent& event) override;
-    void modifierKeysChanged(const juce::ModifierKeys& mods) override;
     void showEmptySpaceContextMenu(const juce::MouseEvent& event);
 
     // Mouse interaction constants and state
@@ -428,12 +427,11 @@ class TrackContentPanel : public juce::Component,
     // Snapshot of selection + lane geometry for the shared hit tester
     // (#1719), which drives the cursor (and, later, gesture dispatch).
     interaction::PanelSnapshot makePanelHitSnapshot(int x, int y) const;
-    void updateCursorForPosition(int x, int y, bool shiftHeld = false);
+    void updateCursorForPosition(int x, int y);
     // Reactive recompute (#1720): re-derive the cursor from the current
     // mouse position when hit-test inputs change without a mouse event
-    // (modifiers, time selection). No-op unless idle-hovering the panel.
+    // (time selection). No-op unless idle-hovering the panel.
     void refreshCursorFromMouse();
-    bool lastShiftState_ = false;
 
     // Marquee methods
     void startMarqueeSelection(const juce::Point<int>& startPoint);

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -1886,8 +1886,15 @@ class ShortcutsPage : public juce::Component {
 
         void mouseWheelMove(const juce::MouseEvent& e,
                             const juce::MouseWheelDetails& wheel) override {
-            if (!handleCaptureWheel(e, wheel))
-                juce::Component::mouseWheelMove(e, wheel);
+            // This runs as a mouse listener for every child (addMouseListener
+            // (this, true)) so Learn can capture a wheel over any row widget —
+            // including the sensitivity slider, which eats the wheel before it
+            // reaches the list viewport. JUCE dispatches listener callbacks
+            // AFTER the target's own handling, so the inner list viewport has
+            // already captured-or-scrolled by now. Never fall through to the
+            // base handler: it would bubble this same event to the outer
+            // preferences viewport and scroll the whole page on top of that.
+            handleCaptureWheel(e, wheel);
         }
 
         bool handleCaptureWheel(const juce::MouseEvent& e, const juce::MouseWheelDetails& wheel) {

--- a/magda/daw/ui/interaction/ArrangementHitTester.cpp
+++ b/magda/daw/ui/interaction/ArrangementHitTester.cpp
@@ -117,7 +117,7 @@ PanelZone panelZone(int x, int y, const PanelSnapshot& s) {
     return panelHit(x, y, s).zone;
 }
 
-CursorKind panelCursor(PanelZone zone, bool shiftHeld) {
+CursorKind panelCursor(PanelZone zone) {
     switch (zone) {
         case PanelZone::SelectionEdgeLeft:
         case PanelZone::SelectionEdgeRight:
@@ -127,9 +127,9 @@ CursorKind panelCursor(PanelZone zone, bool shiftHeld) {
         case PanelZone::OverClip:
             return CursorKind::Normal;
         case PanelZone::EmptyLaneUpper:
-            return shiftHeld ? CursorKind::NoteDraw : CursorKind::Crosshair;
+            return CursorKind::Crosshair;
         case PanelZone::EmptyLaneLower:
-            return shiftHeld ? CursorKind::NoteDraw : CursorKind::IBeam;
+            return CursorKind::IBeam;
         case PanelZone::None:
             break;
     }

--- a/magda/daw/ui/interaction/ArrangementHitTester.hpp
+++ b/magda/daw/ui/interaction/ArrangementHitTester.hpp
@@ -140,9 +140,11 @@ PanelHit panelHit(int x, int y, const PanelSnapshot& s);
  *  clip > upper/lower lane zones. Convenience for panelHit(...).zone. */
 PanelZone panelZone(int x, int y, const PanelSnapshot& s);
 
-/** Cursor for a panel zone. Shift swaps the empty-lane zones to the
- *  draw-clip cursor. */
-CursorKind panelCursor(PanelZone zone, bool shiftHeld);
+/** Cursor for a panel zone. The hover cursor is modifier-independent: the
+ *  draw-clip (pen) cursor only appears once a Shift-draw actually begins, so
+ *  Shift stays free for Shift+wheel horizontal scroll without the pen flashing
+ *  on every Shift press. */
+CursorKind panelCursor(PanelZone zone);
 
 // ============================================================================
 // Clip surface (ClipComponent-local space)

--- a/tests/test_arrangement_hit_tester.cpp
+++ b/tests/test_arrangement_hit_tester.cpp
@@ -64,25 +64,24 @@ TEST_CASE("Panel: empty lane zones split at the lane midline", "[hit-tester]") {
     REQUIRE(panelZone(400, 120, s) == PanelZone::EmptyLaneUpper);
     REQUIRE(panelZone(400, 180, s) == PanelZone::EmptyLaneLower);
 
-    REQUIRE(panelCursor(PanelZone::EmptyLaneUpper, false) == CursorKind::Crosshair);
-    REQUIRE(panelCursor(PanelZone::EmptyLaneLower, false) == CursorKind::IBeam);
-    // Shift = draw-clip cursor in both empty zones.
-    REQUIRE(panelCursor(PanelZone::EmptyLaneUpper, true) == CursorKind::NoteDraw);
-    REQUIRE(panelCursor(PanelZone::EmptyLaneLower, true) == CursorKind::NoteDraw);
+    // The hover cursor is modifier-independent: the pen (NoteDraw) only shows
+    // once a Shift-draw actually begins, so Shift stays free for Shift+wheel
+    // horizontal scroll instead of flashing the pen on hover.
+    REQUIRE(panelCursor(PanelZone::EmptyLaneUpper) == CursorKind::Crosshair);
+    REQUIRE(panelCursor(PanelZone::EmptyLaneLower) == CursorKind::IBeam);
 }
 
 TEST_CASE("Panel: outside every lane is None / Normal", "[hit-tester]") {
     const auto s = makePanel();
     REQUIRE(panelZone(400, 250, s) == PanelZone::None);
-    REQUIRE(panelCursor(PanelZone::None, false) == CursorKind::Normal);
-    REQUIRE(panelCursor(PanelZone::None, true) == CursorKind::Normal);
+    REQUIRE(panelCursor(PanelZone::None) == CursorKind::Normal);
 }
 
 TEST_CASE("Panel: a clip owns its point when no selection is active", "[hit-tester]") {
     auto s = makePanel();
     s.clipAtPoint = true;
     REQUIRE(panelZone(400, 20, s) == PanelZone::OverClip);
-    REQUIRE(panelCursor(PanelZone::OverClip, false) == CursorKind::Normal);
+    REQUIRE(panelCursor(PanelZone::OverClip) == CursorKind::Normal);
 }
 
 TEST_CASE("Panel: selection body beats everything, including clips", "[hit-tester]") {
@@ -90,12 +89,7 @@ TEST_CASE("Panel: selection body beats everything, including clips", "[hit-teste
     s.clipAtPoint = true;
 
     REQUIRE(panelZone(200, 20, s) == PanelZone::SelectionBody);
-    REQUIRE(panelCursor(PanelZone::SelectionBody, false) == CursorKind::DraggingHand);
-
-    // Historical note: the pre-#1719 duplicated lower-zone logic carried an
-    // unreachable shift-crosshair branch for this case; the observable
-    // behavior was (and stays) the grab hand regardless of Shift.
-    REQUIRE(panelCursor(PanelZone::SelectionBody, true) == CursorKind::DraggingHand);
+    REQUIRE(panelCursor(PanelZone::SelectionBody) == CursorKind::DraggingHand);
 }
 
 TEST_CASE("Panel: selection edges win within the threshold, left first", "[hit-tester]") {
@@ -114,8 +108,8 @@ TEST_CASE("Panel: selection edges win within the threshold, left first", "[hit-t
     const auto tiny = makePanelWithSelection(100.0, 104.0);
     REQUIRE(panelZone(102, 20, tiny) == PanelZone::SelectionEdgeLeft);
 
-    REQUIRE(panelCursor(PanelZone::SelectionEdgeLeft, false) == CursorKind::LeftRightResize);
-    REQUIRE(panelCursor(PanelZone::SelectionEdgeRight, false) == CursorKind::LeftRightResize);
+    REQUIRE(panelCursor(PanelZone::SelectionEdgeLeft) == CursorKind::LeftRightResize);
+    REQUIRE(panelCursor(PanelZone::SelectionEdgeRight) == CursorKind::LeftRightResize);
 }
 
 TEST_CASE("Panel: per-track selections only hit their tracks", "[hit-tester]") {


### PR DESCRIPTION
## Summary

The mouse wheel is the only way to scroll on Linux/Windows (no trackpad `deltaX`), and three issues made it unusable. All three are fixed here.

- **Shift+wheel horizontal scroll was shadowed by the pen tool.** The arrangement flipped to the draw-clip pen cursor on every Shift *press*, so Shift+wheel (the mouse-only horizontal-scroll default) felt broken. The hover cursor is now modifier-independent — the pen appears only once a Shift-draw actually starts (`mouseDown`), leaving Shift free for horizontal scroll. Removed the now-dead shift-cursor plumbing (`shiftHeld` params, the timer shift-poll, the `modifierKeysChanged` override, `lastShiftState_`).
- **Preferences → Mouse gestures: recording a wheel gesture scrolled the whole page** instead of capturing. JUCE dispatches listener wheel callbacks *after* the target's own handling, so the page's listener handler fell through to the base handler and bubbled the event to the outer preferences viewport. It now consumes the event.
- **Horizontal arrangement scroll felt ~6× slower than vertical.** Bumped `kScrollSensitivity` 50 → 300 (still user-overridable live in the gesture prefs).

## Testing

- `make test` — `[gesture]` and `[hit-tester]` suites pass (157 assertions); `test_arrangement_hit_tester` updated for the modifier-independent cursor.
- Verified in-app on Linux: Shift+wheel scrolls the arrangement horizontally at a good speed, and Learn-mode gesture capture no longer scrolls the preferences page (including over a row's sensitivity slider).

🤖 Generated with [Claude Code](https://claude.com/claude-code)