### PR TITLE
Add delta solo for effects and racks

### DIFF
--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -578,8 +578,10 @@ void AudioBridge::devicePropertyChanged(const ChainNodePath& devicePath) {
     // Apply enablement directly on the TE plugin: syncFromDeviceInfo only
     // knows the device's own bypassed flag, not the chain gate; and plugins
     // without a processor (e.g. Chord Engine) have no other sync path.
-    if (auto tePlugin = pluginManager_.getPlugin(devicePath))
+    if (auto tePlugin = pluginManager_.getPlugin(devicePath)) {
         tePlugin->setEnabled(effectiveEnabled);
+        tePlugin->setDeltaSoloEnabled(device->deltaSolo);
+    }
 
     if (auto tePlugin = pluginManager_.getPlugin(devicePath))
         daw::audio::syncPluginMidiInThru(tePlugin.get(), device->midiInThru);

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -581,10 +581,8 @@ void AudioBridge::devicePropertyChanged(const ChainNodePath& devicePath) {
     if (auto tePlugin = pluginManager_.getPlugin(devicePath)) {
         tePlugin->setEnabled(effectiveEnabled);
         tePlugin->setDeltaSoloEnabled(device->deltaSolo);
-    }
-
-    if (auto tePlugin = pluginManager_.getPlugin(devicePath))
         daw::audio::syncPluginMidiInThru(tePlugin.get(), device->midiInThru);
+    }
 
     // Wrapped instruments consume MIDI while active. Only top-level devices own
     // instrument wrapper racks; post-fx/mixer-analysis ids are section-local and

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -2053,6 +2053,7 @@ te::Plugin::Ptr PluginManager::createPluginOnly(TrackId trackId, const DeviceInf
         // Rack inner devices always live in the insert chain, so the chain
         // power gates them (no full path available here, only the track).
         plugin->setEnabled(!device.bypassed && TrackManager::getInstance().isChainEnabled(trackId));
+        plugin->setDeltaSoloEnabled(device.deltaSolo);
     }
 
     return plugin;

--- a/magda/daw/audio/processors/base/DeviceProcessor.cpp
+++ b/magda/daw/audio/processors/base/DeviceProcessor.cpp
@@ -85,9 +85,19 @@ bool DeviceProcessor::isBypassed() const {
     return plugin_ ? !plugin_->isEnabled() : true;
 }
 
+void DeviceProcessor::setDeltaSolo(bool deltaSolo) {
+    if (plugin_)
+        plugin_->setDeltaSoloEnabled(deltaSolo);
+}
+
+bool DeviceProcessor::isDeltaSolo() const {
+    return plugin_ && plugin_->isDeltaSoloEnabled();
+}
+
 void DeviceProcessor::syncFromDeviceInfo(const DeviceInfo& info) {
     setGainDb(info.gainDb);
     setBypassed(info.bypassed);
+    setDeltaSolo(info.deltaSolo);
 
     // ParameterInfo::paramIndex is the stable plugin/slot index. This keeps
     // restore semantics aligned with live UI writes and supports processors
@@ -103,6 +113,7 @@ void DeviceProcessor::syncToDeviceInfo(DeviceInfo& info) const {
     info.gainDb = gainDb_;
     info.gainValue = gainLinear_;
     info.bypassed = isBypassed();
+    info.deltaSolo = isDeltaSolo();
 }
 
 void DeviceProcessor::applyGain() {

--- a/magda/daw/audio/processors/base/DeviceProcessor.hpp
+++ b/magda/daw/audio/processors/base/DeviceProcessor.hpp
@@ -54,6 +54,8 @@ class DeviceProcessor {
 
     void setBypassed(bool bypassed);
     bool isBypassed() const;
+    void setDeltaSolo(bool deltaSolo);
+    bool isDeltaSolo() const;
 
     virtual void syncFromDeviceInfo(const DeviceInfo& info);
     virtual void syncToDeviceInfo(DeviceInfo& info) const;

--- a/magda/daw/audio/processors/external/ExternalPluginProcessor.cpp
+++ b/magda/daw/audio/processors/external/ExternalPluginProcessor.cpp
@@ -135,6 +135,7 @@ void ExternalPluginProcessor::populateParameters(DeviceInfo& info) const {
 void ExternalPluginProcessor::syncFromDeviceInfo(const DeviceInfo& info) {
     setGainDb(info.gainDb);
     setBypassed(info.bypassed);
+    setDeltaSolo(info.deltaSolo);
 
     settingParameterFromUI_ = true;
 

--- a/magda/daw/audio/racks/RackSyncManager.cpp
+++ b/magda/daw/audio/racks/RackSyncManager.cpp
@@ -37,6 +37,8 @@ void applyRackInstanceState(te::Plugin::Ptr rackPlugin, const RackInfo& rackInfo
     if (!rackInstance)
         return;
 
+    rackInstance->setDeltaSoloEnabled(rackInfo.deltaSolo);
+
     if (rackInfo.bypassed) {
         rackInstance->wetGain->setParameterFromHost(0.0f, juce::dontSendNotification);
         rackInstance->dryGain->setParameterFromHost(1.0f, juce::dontSendNotification);
@@ -743,6 +745,7 @@ void RackSyncManager::loadRackContents(SyncedRack& synced, TrackId trackId,
 
                         // Apply bypass state
                         plugin->setEnabled(!device.bypassed);
+                        plugin->setDeltaSoloEnabled(device.deltaSolo);
                         daw::audio::syncPluginMidiInThru(plugin.get(), device.midiInThru);
 
                     } else {
@@ -1052,6 +1055,7 @@ void RackSyncManager::updateElementPropertiesRecursive(SyncedRack& synced, const
                 auto pluginIt = synced.innerPlugins.find(device.id);
                 if (pluginIt != synced.innerPlugins.end() && pluginIt->second) {
                     pluginIt->second->setEnabled(!device.bypassed);
+                    pluginIt->second->setDeltaSoloEnabled(device.deltaSolo);
                     daw::audio::syncPluginMidiInThru(pluginIt->second.get(), device.midiInThru);
                 }
             } else if (isRack(element)) {

--- a/magda/daw/core/DeviceInfo.hpp
+++ b/magda/daw/core/DeviceInfo.hpp
@@ -117,8 +117,9 @@ struct DeviceInfo {
     juce::String uniqueId;
     juce::String fileOrIdentifier;  // Path to plugin file or AU identifier
 
-    bool bypassed = false;  // Device bypass state
-    bool expanded = true;   // UI expanded state
+    bool bypassed = false;   // Device bypass state
+    bool deltaSolo = false;  // Hear the processed signal minus its latency-aligned dry input
+    bool expanded = true;    // UI expanded state
 
     // UI panel visibility states
     bool modPanelOpen = false;    // Modulator panel visible

--- a/magda/daw/core/RackInfo.hpp
+++ b/magda/daw/core/RackInfo.hpp
@@ -153,6 +153,7 @@ struct RackInfo {
     juce::String name;              // e.g., "FX Rack"
     std::vector<ChainInfo> chains;  // Parallel chains
     bool bypassed = false;
+    bool deltaSolo = false;
     bool expanded = true;  // UI collapsed state
     float volume = 0.0f;   // Rack output volume in dB (0 = unity)
     float pan = 0.0f;      // Rack output pan (-1 to 1)
@@ -183,6 +184,7 @@ struct RackInfo {
           name(other.name),
           chains(other.chains),  // ChainInfo has its own deep copy
           bypassed(other.bypassed),
+          deltaSolo(other.deltaSolo),
           expanded(other.expanded),
           volume(other.volume),
           pan(other.pan),
@@ -199,6 +201,7 @@ struct RackInfo {
             name = other.name;
             chains = other.chains;  // ChainInfo has its own deep copy
             bypassed = other.bypassed;
+            deltaSolo = other.deltaSolo;
             expanded = other.expanded;
             volume = other.volume;
             pan = other.pan;

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -2184,6 +2184,8 @@ void TrackManager::removeDeviceFromTrack(TrackId trackId, DeviceId deviceId) {
 void TrackManager::setDeviceBypassed(TrackId trackId, DeviceId deviceId, bool bypassed) {
     if (auto* device = getDevice(trackId, deviceId)) {
         device->bypassed = bypassed;
+        if (bypassed)
+            device->deltaSolo = false;
         notifyTrackDevicesChanged(trackId);
     }
 }
@@ -2191,6 +2193,8 @@ void TrackManager::setDeviceBypassed(TrackId trackId, DeviceId deviceId, bool by
 void TrackManager::setDeviceBypassedByPath(const ChainNodePath& devicePath, bool bypassed) {
     if (auto* device = getDeviceInChainByPath(devicePath)) {
         device->bypassed = bypassed;
+        if (bypassed)
+            device->deltaSolo = false;
         notifyTrackDevicesChanged(devicePath.trackId);
     }
 }
@@ -2315,7 +2319,27 @@ const RackInfo* TrackManager::getRack(TrackId trackId, RackId rackId) const {
 void TrackManager::setRackBypassed(TrackId trackId, RackId rackId, bool bypassed) {
     if (auto* rack = getRack(trackId, rackId)) {
         rack->bypassed = bypassed;
+        if (bypassed)
+            rack->deltaSolo = false;
         notifyTrackDevicesChanged(trackId);
+    }
+}
+
+void TrackManager::setRackBypassedByPath(const ChainNodePath& rackPath, bool bypassed) {
+    if (auto* rack = getRackByPath(rackPath)) {
+        rack->bypassed = bypassed;
+        if (bypassed)
+            rack->deltaSolo = false;
+        notifyTrackDevicesChanged(rackPath.trackId);
+    }
+}
+
+void TrackManager::setRackDeltaSoloByPath(const ChainNodePath& rackPath, bool deltaSolo) {
+    if (auto* rack = getRackByPath(rackPath)) {
+        rack->deltaSolo = deltaSolo;
+        if (deltaSolo)
+            rack->bypassed = false;
+        notifyTrackDevicesChanged(rackPath.trackId);
     }
 }
 

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -384,6 +384,7 @@ class TrackManager {
     // Path-based variant — preferred for new code; sections will become
     // id-scoped, at which point the bare-id version goes away.
     void setDeviceBypassedByPath(const ChainNodePath& devicePath, bool bypassed);
+    void setDeviceDeltaSoloByPath(const ChainNodePath& devicePath, bool deltaSolo);
     DeviceInfo* getDevice(TrackId trackId, DeviceId deviceId);
 
     // Drum-kit row metadata lives on the device instance — it's a physical
@@ -442,6 +443,8 @@ class TrackManager {
     RackInfo* getRack(TrackId trackId, RackId rackId);
     const RackInfo* getRack(TrackId trackId, RackId rackId) const;
     void setRackBypassed(TrackId trackId, RackId rackId, bool bypassed);
+    void setRackBypassedByPath(const ChainNodePath& rackPath, bool bypassed);
+    void setRackDeltaSoloByPath(const ChainNodePath& rackPath, bool deltaSolo);
     void setRackExpanded(TrackId trackId, RackId rackId, bool expanded);
 
     // Path-based rack lookup (works for nested racks at any depth)

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1106,6 +1106,17 @@ const DeviceInfo* TrackManager::getDeviceInChainByPath(const ChainNodePath& devi
 void TrackManager::setDeviceInChainBypassedByPath(const ChainNodePath& devicePath, bool bypassed) {
     if (auto* device = getDeviceInChainByPath(devicePath)) {
         device->bypassed = bypassed;
+        if (bypassed)
+            device->deltaSolo = false;
+        notifyDevicePropertyChanged(devicePath);
+    }
+}
+
+void TrackManager::setDeviceDeltaSoloByPath(const ChainNodePath& devicePath, bool deltaSolo) {
+    if (auto* device = getDeviceInChainByPath(devicePath)) {
+        device->deltaSolo = deltaSolo;
+        if (deltaSolo)
+            device->bypassed = false;
         notifyDevicePropertyChanged(devicePath);
     }
 }

--- a/magda/daw/project/serialization/TrackSerializer.cpp
+++ b/magda/daw/project/serialization/TrackSerializer.cpp
@@ -409,6 +409,7 @@ juce::var ProjectSerializer::serializeDeviceInfo(const DeviceInfo& device) {
     obj->setProperty("uniqueId", device.uniqueId);
     obj->setProperty("fileOrIdentifier", device.fileOrIdentifier);
     obj->setProperty("bypassed", device.bypassed);
+    obj->setProperty("deltaSolo", device.deltaSolo);
     obj->setProperty("expanded", device.expanded);
     obj->setProperty("modPanelOpen", device.modPanelOpen);
     obj->setProperty("gainPanelOpen", device.gainPanelOpen);
@@ -545,6 +546,8 @@ bool ProjectSerializer::deserializeDeviceInfo(const juce::var& json, DeviceInfo&
     outDevice.uniqueId = obj->getProperty("uniqueId").toString();
     outDevice.fileOrIdentifier = obj->getProperty("fileOrIdentifier").toString();
     outDevice.bypassed = obj->getProperty("bypassed");
+    if (obj->hasProperty("deltaSolo"))
+        outDevice.deltaSolo = static_cast<bool>(obj->getProperty("deltaSolo"));
     outDevice.expanded = obj->getProperty("expanded");
     outDevice.modPanelOpen = obj->getProperty("modPanelOpen");
     outDevice.gainPanelOpen = obj->getProperty("gainPanelOpen");
@@ -700,6 +703,7 @@ juce::var ProjectSerializer::serializeRackInfo(const RackInfo& rack) {
     obj->setProperty("id", rack.id);
     obj->setProperty("name", rack.name);
     obj->setProperty("bypassed", rack.bypassed);
+    obj->setProperty("deltaSolo", rack.deltaSolo);
     obj->setProperty("expanded", rack.expanded);
     obj->setProperty("modPanelOpen", rack.modPanelOpen);
     obj->setProperty("paramPanelOpen", rack.paramPanelOpen);
@@ -749,6 +753,8 @@ bool ProjectSerializer::deserializeRackInfo(const juce::var& json, RackInfo& out
     outRack.id = obj->getProperty("id");
     outRack.name = obj->getProperty("name").toString();
     outRack.bypassed = obj->getProperty("bypassed");
+    if (obj->hasProperty("deltaSolo"))
+        outRack.deltaSolo = static_cast<bool>(obj->getProperty("deltaSolo"));
     outRack.expanded = obj->getProperty("expanded");
     if (obj->hasProperty("modPanelOpen"))
         outRack.modPanelOpen = static_cast<bool>(obj->getProperty("modPanelOpen"));

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -391,12 +391,40 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
         bool active = onButton_->getToggleState();
         onButton_->setActive(active);
         setBypassed(!active);
+        if (!active) {
+            device_.deltaSolo = false;
+            deltaButton_->setToggleState(false, juce::dontSendNotification);
+        }
         magda::TrackManager::getInstance().setDeviceInChainBypassedByPath(nodePath_, !active);
         if (onDeviceBypassChanged) {
             onDeviceBypassChanged(!active);
         }
     };
     addAndMakeVisible(*onButton_);
+
+    deltaButton_ = std::make_unique<juce::TextButton>(juce::String::fromUTF8("\xce\x94"));
+    deltaButton_->setClickingTogglesState(true);
+    deltaButton_->setToggleState(device.deltaSolo, juce::dontSendNotification);
+    deltaButton_->setTooltip("Delta Solo: processed signal minus dry input");
+    deltaButton_->setLookAndFeel(&SmallButtonLookAndFeel::getInstance());
+    deltaButton_->setColour(juce::TextButton::buttonColourId,
+                            DarkTheme::getColour(DarkTheme::SURFACE));
+    deltaButton_->setColour(juce::TextButton::buttonOnColourId,
+                            DarkTheme::getColour(DarkTheme::ACCENT_ORANGE).darker(0.3f));
+    deltaButton_->setColour(juce::TextButton::textColourOffId, DarkTheme::getSecondaryTextColour());
+    deltaButton_->setColour(juce::TextButton::textColourOnId, juce::Colours::white);
+    deltaButton_->onClick = [this]() {
+        const bool enabled = deltaButton_->getToggleState();
+        device_.deltaSolo = enabled;
+        if (enabled) {
+            device_.bypassed = false;
+            setBypassed(false);
+            onButton_->setToggleState(true, juce::dontSendNotification);
+            onButton_->setActive(true);
+        }
+        magda::TrackManager::getInstance().setDeviceDeltaSoloByPath(nodePath_, enabled);
+    };
+    addAndMakeVisible(*deltaButton_);
 
     // Export as MIDI clip button
     if (traits_.isStepSequencer || traits_.isPolyStepSequencer) {
@@ -821,6 +849,7 @@ void DeviceSlotComponent::updateFromDevice(const magda::DeviceInfo& device) {
     setBypassed(device.bypassed);
     onButton_->setToggleState(!device.bypassed, juce::dontSendNotification);
     onButton_->setActive(!device.bypassed);
+    deltaButton_->setToggleState(device.deltaSolo, juce::dontSendNotification);
     syncGainControlsFromDevice();
     if (midiThruButton_ != nullptr && midiThruButton_->isActive() != device.midiInThru)
         midiThruButton_->setActive(device.midiInThru);
@@ -1112,6 +1141,7 @@ void DeviceSlotComponent::resizedHeaderExtra(juce::Rectangle<int>& headerArea) {
          .sidechainButton = scButton_.get(),
          .multiOutButton = multiOutButton_.get(),
          .uiButton = uiButton_.get(),
+         .deltaButton = deltaButton_.get(),
          .powerButton = stripsAnalysisChrome() ? nullptr : onButton_.get(),
          .presetButton = stripsAnalysisChrome() ? nullptr : presetButton_.get(),
          .exportClipButton = exportClipButton_.get(),
@@ -1142,6 +1172,7 @@ void DeviceSlotComponent::resizedCollapsed(juce::Rectangle<int>& area) {
                             .aiButton = aiButton_.get(),
                             .multiOutButton = multiOutButton_.get(),
                             .uiButton = uiButton_.get(),
+                            .deltaButton = deltaButton_.get(),
                             .powerButton = stripsAnalysisChrome() ? nullptr : onButton_.get(),
                             .exportClipButton = exportClipButton_.get(),
                             .randomButton = randomButton_.get(),

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -406,7 +406,7 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     deltaButton_->setClickingTogglesState(true);
     deltaButton_->setToggleState(device.deltaSolo, juce::dontSendNotification);
     deltaButton_->setTooltip("Delta Solo: processed signal minus dry input");
-    deltaButton_->setLookAndFeel(&SmallButtonLookAndFeel::getInstance());
+    deltaButton_->setLookAndFeel(&node_header::getDeltaSoloButtonLookAndFeel());
     deltaButton_->setColour(juce::TextButton::buttonColourId,
                             DarkTheme::getColour(DarkTheme::SURFACE));
     deltaButton_->setColour(juce::TextButton::buttonOnColourId,

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -410,7 +410,7 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     deltaButton_->setColour(juce::TextButton::buttonColourId,
                             DarkTheme::getColour(DarkTheme::SURFACE));
     deltaButton_->setColour(juce::TextButton::buttonOnColourId,
-                            DarkTheme::getColour(DarkTheme::ACCENT_ORANGE).darker(0.3f));
+                            DarkTheme::getColour(DarkTheme::ACCENT_CYAN).darker(0.3f));
     deltaButton_->setColour(juce::TextButton::textColourOffId, DarkTheme::getSecondaryTextColour());
     deltaButton_->setColour(juce::TextButton::textColourOnId, juce::Colours::white);
     deltaButton_->onClick = [this]() {

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
@@ -231,6 +231,7 @@ class DeviceSlotComponent : public NodeComponent,
     std::unique_ptr<magda::SvgButton> uiButton_;
     std::unique_ptr<magda::SvgButton> learnButton_;
     std::unique_ptr<magda::SvgButton> onButton_;
+    std::unique_ptr<juce::TextButton> deltaButton_;
     std::unique_ptr<magda::SvgButton> exportClipButton_;  // Export pattern/chords as MIDI clip
     std::unique_ptr<magda::SvgButton> randomButton_;      // Step-sequencer pattern randomize
     std::unique_ptr<magda::SvgButton> midiThruButton_;    // MIDI source/thru toggle

--- a/magda/daw/ui/components/chain/RackComponent.cpp
+++ b/magda/daw/ui/components/chain/RackComponent.cpp
@@ -114,7 +114,7 @@ void RackComponent::initializeCommon(const magda::RackInfo& rack) {
     deltaButton_->setColour(juce::TextButton::buttonColourId,
                             DarkTheme::getColour(DarkTheme::SURFACE));
     deltaButton_->setColour(juce::TextButton::buttonOnColourId,
-                            DarkTheme::getColour(DarkTheme::ACCENT_ORANGE).darker(0.3f));
+                            DarkTheme::getColour(DarkTheme::ACCENT_CYAN).darker(0.3f));
     deltaButton_->setColour(juce::TextButton::textColourOffId, DarkTheme::getSecondaryTextColour());
     deltaButton_->setColour(juce::TextButton::textColourOnId, juce::Colours::white);
     deltaButton_->onClick = [this]() {

--- a/magda/daw/ui/components/chain/RackComponent.cpp
+++ b/magda/daw/ui/components/chain/RackComponent.cpp
@@ -50,7 +50,9 @@ void RackComponent::initializeCommon(const magda::RackInfo& rack) {
     };
 
     onBypassChanged = [this](bool bypassed) {
-        magda::TrackManager::getInstance().setRackBypassed(trackId_, rackId_, bypassed);
+        if (bypassed)
+            deltaButton_->setToggleState(false, juce::dontSendNotification);
+        magda::TrackManager::getInstance().setRackBypassedByPath(rackPath_, bypassed);
     };
 
     onModPanelToggled = [this](bool visible) {
@@ -103,6 +105,25 @@ void RackComponent::initializeCommon(const magda::RackInfo& rack) {
         setParamPanelVisible(macroButton_->getToggleState());
     };
     addAndMakeVisible(*macroButton_);
+
+    deltaButton_ = std::make_unique<juce::TextButton>(juce::String::fromUTF8("\xce\x94"));
+    deltaButton_->setClickingTogglesState(true);
+    deltaButton_->setToggleState(rack.deltaSolo, juce::dontSendNotification);
+    deltaButton_->setTooltip("Delta Solo: processed rack signal minus dry input");
+    deltaButton_->setLookAndFeel(&SmallButtonLookAndFeel::getInstance());
+    deltaButton_->setColour(juce::TextButton::buttonColourId,
+                            DarkTheme::getColour(DarkTheme::SURFACE));
+    deltaButton_->setColour(juce::TextButton::buttonOnColourId,
+                            DarkTheme::getColour(DarkTheme::ACCENT_ORANGE).darker(0.3f));
+    deltaButton_->setColour(juce::TextButton::textColourOffId, DarkTheme::getSecondaryTextColour());
+    deltaButton_->setColour(juce::TextButton::textColourOnId, juce::Colours::white);
+    deltaButton_->onClick = [this]() {
+        const bool enabled = deltaButton_->getToggleState();
+        if (enabled)
+            setBypassed(false);
+        magda::TrackManager::getInstance().setRackDeltaSoloByPath(rackPath_, enabled);
+    };
+    addAndMakeVisible(*deltaButton_);
 
     // PRESET button (MAGDA rack presets menu) — same indigo pill recipe as
     // DeviceSlotComponent's preset button so device and rack presets read
@@ -268,6 +289,7 @@ void RackComponent::resizedContent(juce::Rectangle<int> contentArea) {
             gainSlider_->setVisible(false);
         if (presetButton_)
             presetButton_->setVisible(false);
+        deltaButton_->setVisible(false);
         // levelMeter_ visibility handled by resizedCollapsed
         return;
     }
@@ -280,6 +302,7 @@ void RackComponent::resizedContent(juce::Rectangle<int> contentArea) {
     macroButton_->setVisible(true);
     if (presetButton_)
         presetButton_->setVisible(true);
+    deltaButton_->setVisible(true);
     levelMeter_.setVisible(true);
 
     // Position the level meter on the right edge of the content area, with
@@ -356,8 +379,8 @@ void RackComponent::resizedContent(juce::Rectangle<int> contentArea) {
 }
 
 void RackComponent::resizedHeaderExtra(juce::Rectangle<int>& headerArea) {
-    // Right edge — [preset][power][delete] — is owned by NodeComponent. Only
-    // place left-side header icons here; do not touch presetButton_.
+    deltaButton_->setBounds(headerArea.removeFromRight(BUTTON_SIZE));
+    headerArea.removeFromRight(4);
     macroButton_->setBounds(headerArea.removeFromLeft(BUTTON_SIZE));
     headerArea.removeFromLeft(4);
     modButton_->setBounds(headerArea.removeFromLeft(BUTTON_SIZE));
@@ -387,6 +410,10 @@ void RackComponent::resizedCollapsed(juce::Rectangle<int>& area) {
     modButton_->setBounds(
         area.removeFromTop(buttonSize).withSizeKeepingCentre(buttonSize, buttonSize));
     modButton_->setVisible(true);
+    area.removeFromTop(4);
+    deltaButton_->setBounds(
+        area.removeFromTop(buttonSize).withSizeKeepingCentre(buttonSize, buttonSize));
+    deltaButton_->setVisible(true);
 }
 
 int RackComponent::getPreferredHeight() const {
@@ -442,6 +469,7 @@ void RackComponent::setAvailableWidth(int width) {
 void RackComponent::updateFromRack(const magda::RackInfo& rack) {
     setNodeName(rack.name);
     setBypassed(rack.bypassed);
+    deltaButton_->setToggleState(rack.deltaSolo, juce::dontSendNotification);
     if (gainSlider_)
         gainSlider_->setValue(rack.volume, juce::dontSendNotification);
     rebuildChainRows();

--- a/magda/daw/ui/components/chain/RackComponent.cpp
+++ b/magda/daw/ui/components/chain/RackComponent.cpp
@@ -110,7 +110,7 @@ void RackComponent::initializeCommon(const magda::RackInfo& rack) {
     deltaButton_->setClickingTogglesState(true);
     deltaButton_->setToggleState(rack.deltaSolo, juce::dontSendNotification);
     deltaButton_->setTooltip("Delta Solo: processed rack signal minus dry input");
-    deltaButton_->setLookAndFeel(&SmallButtonLookAndFeel::getInstance());
+    deltaButton_->setLookAndFeel(&node_header::getDeltaSoloButtonLookAndFeel());
     deltaButton_->setColour(juce::TextButton::buttonColourId,
                             DarkTheme::getColour(DarkTheme::SURFACE));
     deltaButton_->setColour(juce::TextButton::buttonOnColourId,

--- a/magda/daw/ui/components/chain/RackComponent.hpp
+++ b/magda/daw/ui/components/chain/RackComponent.hpp
@@ -101,6 +101,7 @@ class RackComponent : public NodeComponent, public juce::Timer {
     std::unique_ptr<magda::SvgButton> modButton_;     // Modulators toggle
     std::unique_ptr<magda::SvgButton> macroButton_;   // Macros toggle
     std::unique_ptr<magda::SvgButton> presetButton_;  // MAGDA rack presets menu
+    std::unique_ptr<juce::TextButton> deltaButton_;
     juce::TextButton addChainButton_;
 
     // Currently-loaded preset name (empty when none) — used as the default

--- a/magda/daw/ui/components/chain/layout/NodeHeaderStyles.hpp
+++ b/magda/daw/ui/components/chain/layout/NodeHeaderStyles.hpp
@@ -6,8 +6,14 @@
 #include "ui/components/mixer/LevelMeter.hpp"
 #include "ui/components/mixer/LevelMeterScale.hpp"
 #include "ui/themes/DarkTheme.hpp"
+#include "ui/themes/SmallButtonLookAndFeel.hpp"
 
 namespace magda::daw::ui::node_header {
+
+inline SmallButtonLookAndFeel& getDeltaSoloButtonLookAndFeel() {
+    static SmallButtonLookAndFeel instance(10.5f);
+    return instance;
+}
 
 // Flat-thumb LookAndFeel for the device/rack gain slider: draws no track,
 // just a thin horizontal bar at the slider position. Designed to overlay

--- a/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.cpp
@@ -57,7 +57,8 @@ HeaderControlComponents getHeaderControlComponents(DeviceSlotHeaderControls cont
             .exportClipButton = controls.exportClipButton,
             .randomButton = controls.randomButton,
             .stepRecordButton = controls.stepRecordButton,
-            .midiThruButton = controls.midiThruButton};
+            .midiThruButton = controls.midiThruButton,
+            .deltaButton = controls.deltaButton};
 }
 
 }  // namespace

--- a/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotHeaderControls.hpp
@@ -16,6 +16,7 @@ struct DeviceSlotHeaderControls {
     juce::Component* sidechainButton = nullptr;
     juce::Component* multiOutButton = nullptr;
     juce::Component* uiButton = nullptr;
+    juce::Component* deltaButton = nullptr;
     juce::Component* powerButton = nullptr;
     juce::Component* presetButton = nullptr;
     juce::Component* exportClipButton = nullptr;

--- a/magda/daw/ui/components/chain/slot/DeviceSlotHeaderSpec.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotHeaderSpec.cpp
@@ -30,6 +30,8 @@ bool getExpandedVisibility(HeaderControlId id, const HeaderControlVisibility& vi
             return visibility.sidechain;
         case HeaderControlId::ExportClip:
             return visibility.exportClip;
+        case HeaderControlId::Delta:
+            return visibility.delta;
     }
 
     return false;
@@ -61,6 +63,8 @@ bool getCollapsedVisibility(HeaderControlId id, const HeaderControlVisibility& v
             return visibility.multiOut;
         case HeaderControlId::ExportClip:
             return visibility.exportClip;
+        case HeaderControlId::Delta:
+            return visibility.delta;
         case HeaderControlId::Learn:
         case HeaderControlId::Sidechain:
             return false;
@@ -89,6 +93,7 @@ HeaderControlVisibility getHeaderControlVisibility(const DeviceSlotTraits& trait
     visibility.random = traits.isStepSequencer || traits.isPolyStepSequencer;
     visibility.stepRecord = visibility.random;
     visibility.midiThru = supportsMidiSourceToggle(device);
+    visibility.delta = device.deviceType == magda::DeviceType::Effect;
 
     if (isMidiUtilityDeviceSlot(traits)) {
         visibility.learn = false;
@@ -127,6 +132,7 @@ std::vector<HeaderControlSpec> buildHeaderControlSpecs(const DeviceSlotTraits& t
         {HeaderControlId::MultiOut, HeaderControlSide::Right, controls.multiOutButton, 100, 90},
         {HeaderControlId::Sidechain, HeaderControlSide::Right, controls.sidechainButton, 110, 0},
         {HeaderControlId::ExportClip, HeaderControlSide::Right, controls.exportClipButton, 120, 80},
+        {HeaderControlId::Delta, HeaderControlSide::Right, controls.deltaButton, 130, 100},
     };
 
     for (auto& spec : specs) {

--- a/magda/daw/ui/components/chain/slot/DeviceSlotHeaderSpec.hpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotHeaderSpec.hpp
@@ -20,7 +20,8 @@ enum class HeaderControlId {
     UI,
     MultiOut,
     Sidechain,
-    ExportClip
+    ExportClip,
+    Delta
 };
 
 enum class HeaderControlSide { Left, Right };
@@ -37,6 +38,7 @@ struct HeaderControlComponents {
     juce::Component* randomButton = nullptr;
     juce::Component* stepRecordButton = nullptr;
     juce::Component* midiThruButton = nullptr;
+    juce::Component* deltaButton = nullptr;
 };
 
 struct HeaderControlVisibility {
@@ -51,6 +53,7 @@ struct HeaderControlVisibility {
     bool multiOut = false;
     bool sidechain = false;
     bool exportClip = false;
+    bool delta = false;
     bool power = true;
     bool preset = true;
 };

--- a/magda/daw/ui/themes/SmallButtonLookAndFeel.hpp
+++ b/magda/daw/ui/themes/SmallButtonLookAndFeel.hpp
@@ -12,7 +12,7 @@ namespace magda::daw::ui {
  */
 class SmallButtonLookAndFeel : public juce::LookAndFeel_V4 {
   public:
-    SmallButtonLookAndFeel() = default;
+    explicit SmallButtonLookAndFeel(float fontSize = 9.0f) : fontSize_(fontSize) {}
     ~SmallButtonLookAndFeel() override = default;
 
     void drawButtonBackground(juce::Graphics& g, juce::Button& button, const juce::Colour& bgColour,
@@ -42,7 +42,7 @@ class SmallButtonLookAndFeel : public juce::LookAndFeel_V4 {
 
     void drawButtonText(juce::Graphics& g, juce::TextButton& button, bool /*isMouseOverButton*/,
                         bool /*isButtonDown*/) override {
-        auto font = FontManager::getInstance().getUIFontBold(9.0f);
+        auto font = FontManager::getInstance().getUIFontBold(fontSize_);
         g.setFont(font);
         g.setColour(button
                         .findColour(button.getToggleState() ? juce::TextButton::textColourOnId
@@ -59,6 +59,7 @@ class SmallButtonLookAndFeel : public juce::LookAndFeel_V4 {
     }
 
   private:
+    float fontSize_;
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SmallButtonLookAndFeel)
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(TEST_SOURCES
     test_known_plugin_list_duplicates.cpp
     test_device_parameter_pagination.cpp
     test_device_ui_context.cpp
+    test_delta_solo.cpp
     test_waveform_editor_absolute_mode.cpp
     test_clip_batch_edit.cpp
     test_clip_commands.cpp

--- a/tests/test_delta_solo.cpp
+++ b/tests/test_delta_solo.cpp
@@ -69,3 +69,37 @@ TEST_CASE("Delta solo aligns dry input to plugin latency", "[delta_solo][audio][
     CHECK(wet.getSample(0, 2) == Approx(1.0f));
     CHECK(wet.getSample(0, 3) == Approx(0.0f));
 }
+
+TEST_CASE("Delta latency history remains aligned while monitoring is off",
+          "[delta_solo][audio][latency]") {
+    constexpr int latencySamples = 2;
+    constexpr int blockSize = 4;
+
+    tracktion::graph::LatencyProcessor dryDelay;
+    dryDelay.setLatencyNumSamples(latencySamples);
+    dryDelay.prepareToPlay(48000.0, blockSize, 1);
+
+    juce::AudioBuffer<float> disabledBlock(1, blockSize);
+    disabledBlock.clear();
+    disabledBlock.setSample(0, 3, 1.0f);
+    dryDelay.writeAudio(tracktion::graph::toBufferView(disabledBlock));
+    dryDelay.clearAudio(blockSize);
+
+    juce::AudioBuffer<float> enabledBlock(1, blockSize);
+    enabledBlock.clear();
+    dryDelay.writeAudio(tracktion::graph::toBufferView(enabledBlock));
+
+    juce::AudioBuffer<float> alignedDry(1, blockSize);
+    dryDelay.readAudioOverwriting(tracktion::graph::toBufferView(alignedDry));
+
+    juce::AudioBuffer<float> wet(1, blockSize);
+    wet.clear();
+    wet.setSample(0, 1, 2.0f);
+    tracktion::engine::plugin_node_detail::applyDeltaSolo(
+        tracktion::graph::toBufferView(wet), tracktion::graph::toBufferView(alignedDry), true);
+
+    CHECK(wet.getSample(0, 0) == Approx(0.0f));
+    CHECK(wet.getSample(0, 1) == Approx(1.0f));
+    CHECK(wet.getSample(0, 2) == Approx(0.0f));
+    CHECK(wet.getSample(0, 3) == Approx(0.0f));
+}

--- a/tests/test_delta_solo.cpp
+++ b/tests/test_delta_solo.cpp
@@ -1,0 +1,71 @@
+#include <tracktion_engine/tracktion_engine.h>
+#include <tracktion_graph/tracktion_graph.h>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "../third_party/tracktion_engine/modules/tracktion_engine/playback/graph/tracktion_DeltaSolo.h"
+
+using Catch::Approx;
+
+TEST_CASE("Delta solo subtracts the dry signal", "[delta_solo][audio]") {
+    juce::AudioBuffer<float> wet(2, 4);
+    juce::AudioBuffer<float> dry(2, 4);
+
+    for (int channel = 0; channel < 2; ++channel) {
+        for (int sample = 0; sample < 4; ++sample) {
+            dry.setSample(channel, sample, static_cast<float>(sample + 1));
+            wet.setSample(channel, sample, 3.0f * dry.getSample(channel, sample));
+        }
+    }
+
+    tracktion::engine::plugin_node_detail::applyDeltaSolo(
+        tracktion::graph::toBufferView(wet), tracktion::graph::toBufferView(dry), true);
+
+    for (int channel = 0; channel < 2; ++channel)
+        for (int sample = 0; sample < 4; ++sample)
+            CHECK(wet.getSample(channel, sample) == Approx(2.0f * dry.getSample(channel, sample)));
+}
+
+TEST_CASE("Delta solo leaves output unchanged while disabled", "[delta_solo][audio]") {
+    juce::AudioBuffer<float> wet(1, 2);
+    juce::AudioBuffer<float> dry(1, 2);
+    wet.setSample(0, 0, 0.75f);
+    wet.setSample(0, 1, -0.25f);
+    dry.clear();
+    dry.addSample(0, 0, 1.0f);
+
+    tracktion::engine::plugin_node_detail::applyDeltaSolo(
+        tracktion::graph::toBufferView(wet), tracktion::graph::toBufferView(dry), false);
+
+    CHECK(wet.getSample(0, 0) == Approx(0.75f));
+    CHECK(wet.getSample(0, 1) == Approx(-0.25f));
+}
+
+TEST_CASE("Delta solo aligns dry input to plugin latency", "[delta_solo][audio][latency]") {
+    constexpr int latencySamples = 2;
+    constexpr int blockSize = 4;
+
+    tracktion::graph::LatencyProcessor dryDelay;
+    dryDelay.setLatencyNumSamples(latencySamples);
+    dryDelay.prepareToPlay(48000.0, blockSize, 1);
+
+    juce::AudioBuffer<float> input(1, blockSize);
+    input.clear();
+    input.setSample(0, 0, 1.0f);
+
+    juce::AudioBuffer<float> alignedDry(1, blockSize);
+    dryDelay.writeAudio(tracktion::graph::toBufferView(input));
+    dryDelay.readAudioOverwriting(tracktion::graph::toBufferView(alignedDry));
+
+    juce::AudioBuffer<float> wet(1, blockSize);
+    wet.clear();
+    wet.setSample(0, latencySamples, 2.0f);
+    tracktion::engine::plugin_node_detail::applyDeltaSolo(
+        tracktion::graph::toBufferView(wet), tracktion::graph::toBufferView(alignedDry), true);
+
+    CHECK(wet.getSample(0, 0) == Approx(0.0f));
+    CHECK(wet.getSample(0, 1) == Approx(0.0f));
+    CHECK(wet.getSample(0, 2) == Approx(1.0f));
+    CHECK(wet.getSample(0, 3) == Approx(0.0f));
+}

--- a/tests/test_nested_racks.cpp
+++ b/tests/test_nested_racks.cpp
@@ -635,6 +635,43 @@ TEST_CASE("TrackManager: Set Device Bypassed by Path", "[trackmanager][device][p
     }
 }
 
+TEST_CASE("TrackManager: Delta solo and bypass are mutually exclusive by path",
+          "[trackmanager][delta_solo][path]") {
+    TrackManagerTestFixture fixture;
+    auto trackId = fixture.tm().createTrack("Delta Track");
+    auto rackId = fixture.tm().addRackToTrack(trackId, "Outer Rack");
+    auto* rack = fixture.tm().getRack(trackId, rackId);
+    REQUIRE(rack != nullptr);
+
+    auto outerChainPath = ChainNodePath::chain(trackId, rackId, rack->chains[0].id);
+    DeviceInfo device;
+    device.name = "Effect";
+    auto deviceId = fixture.tm().addDeviceToChainByPath(outerChainPath, device);
+    auto devicePath = outerChainPath.withDevice(deviceId);
+
+    fixture.tm().setDeviceDeltaSoloByPath(devicePath, true);
+    auto* liveDevice = fixture.tm().getDeviceInChainByPath(devicePath);
+    REQUIRE(liveDevice != nullptr);
+    CHECK(liveDevice->deltaSolo);
+    CHECK_FALSE(liveDevice->bypassed);
+
+    fixture.tm().setDeviceInChainBypassedByPath(devicePath, true);
+    CHECK(liveDevice->bypassed);
+    CHECK_FALSE(liveDevice->deltaSolo);
+
+    auto nestedRackId = fixture.tm().addRackToChainByPath(outerChainPath, "Nested Rack");
+    auto nestedRackPath = outerChainPath.withRack(nestedRackId);
+    fixture.tm().setRackDeltaSoloByPath(nestedRackPath, true);
+    auto* nestedRack = fixture.tm().getRackByPath(nestedRackPath);
+    REQUIRE(nestedRack != nullptr);
+    CHECK(nestedRack->deltaSolo);
+    CHECK_FALSE(nestedRack->bypassed);
+
+    fixture.tm().setRackBypassedByPath(nestedRackPath, true);
+    CHECK(nestedRack->bypassed);
+    CHECK_FALSE(nestedRack->deltaSolo);
+}
+
 TEST_CASE("TrackManager: Parameter writes follow device id after top-level reorder",
           "[trackmanager][device][path][parameter]") {
     TrackManagerTestFixture fixture;

--- a/tests/test_project_serialization.cpp
+++ b/tests/test_project_serialization.cpp
@@ -2225,3 +2225,38 @@ TEST_CASE("RackInfo panel UI state roundtrip", "[project][serialization][rack][u
     REQUIRE(loaded.paramPanelOpen == true);
     REQUIRE(loaded.chains.size() == 1);
 }
+
+TEST_CASE("Delta solo state roundtrips and defaults off for older projects",
+          "[project][serialization][delta_solo]") {
+    DeviceInfo device;
+    device.id = 11;
+    device.name = "Delta Effect";
+    device.deltaSolo = true;
+
+    auto deviceJson = ProjectSerializer::serializeDeviceInfo(device);
+    DeviceInfo loadedDevice;
+    REQUIRE(ProjectSerializer::deserializeDeviceInfo(deviceJson, loadedDevice));
+    CHECK(loadedDevice.deltaSolo);
+
+    deviceJson.getDynamicObject()->removeProperty("deltaSolo");
+    DeviceInfo legacyDevice;
+    legacyDevice.deltaSolo = false;
+    REQUIRE(ProjectSerializer::deserializeDeviceInfo(deviceJson, legacyDevice));
+    CHECK_FALSE(legacyDevice.deltaSolo);
+
+    RackInfo rack;
+    rack.id = 12;
+    rack.name = "Delta Rack";
+    rack.deltaSolo = true;
+
+    auto rackJson = ProjectSerializer::serializeRackInfo(rack);
+    RackInfo loadedRack;
+    REQUIRE(ProjectSerializer::deserializeRackInfo(rackJson, loadedRack));
+    CHECK(loadedRack.deltaSolo);
+
+    rackJson.getDynamicObject()->removeProperty("deltaSolo");
+    RackInfo legacyRack;
+    legacyRack.deltaSolo = false;
+    REQUIRE(ProjectSerializer::deserializeRackInfo(rackJson, legacyRack));
+    CHECK_FALSE(legacyRack.deltaSolo);
+}


### PR DESCRIPTION
## Summary

- add a delta-solo button to effect and rack headers, including collapsed and nested rack views
- persist delta-solo state and keep it mutually exclusive with bypass
- synchronize device and rack state to latency-aligned wet-minus-dry processing
- update the Tracktion Engine submodule to Conceptual-Machines/tracktion_engine#26

## Why

Delta solo makes it possible to hear only what an effect or rack changes. This provides a direct control in the device bar instead of requiring a mouse-button convention.

For plugins that report latency, the dry input is delayed before subtraction so the result remains phase-aligned. Racks reuse Tracktion's existing compensated dry-return path and retain their wet/dry automation values.

Closes #1675.

## Validation

- `cmake --build cmake-build-debug --target magda_tests -j4`
- `cmake-build-debug/tests/magda_tests "[delta_solo]"` - 33 assertions in 5 test cases passed
- full Catch2 suite - 1,413 test cases and 159,703 assertions passed; 6 optional model tests skipped
- `cmake --build cmake-build-debug --target magda_daw_app -j4`
