### PR TITLE
Fix session and arrangement clip playback

### DIFF
--- a/magda/daw/audio/WarpMarkerManager.cpp
+++ b/magda/daw/audio/WarpMarkerManager.cpp
@@ -41,6 +41,22 @@ te::WaveAudioClip* findWaveAudioClip(te::Edit& edit,
         return nullptr;
     return findWaveAudioClipByEngineId(edit, it->second);
 }
+
+void storeWarpMarkersInClipModel(ClipId clipId, te::WarpTimeManager& warpManager) {
+    auto* clip = ClipManager::getInstance().getClip(clipId);
+    if (clip == nullptr)
+        return;
+
+    const auto& markers = warpManager.getMarkers();
+    clip->warpMarkers.clear();
+    clip->warpMarkers.reserve(static_cast<size_t>(markers.size()));
+    for (auto* marker : markers) {
+        if (marker != nullptr) {
+            clip->warpMarkers.push_back(
+                {marker->sourceTime.inSeconds(), marker->warpTime.inSeconds()});
+        }
+    }
+}
 }  // namespace
 
 WarpMarkerManager::~WarpMarkerManager() {
@@ -230,6 +246,10 @@ void WarpMarkerManager::enableWarp(te::Edit& edit,
 
     audioClipPtr->setWarpTime(true);
 
+    // ClipInfo is the source copied to MAGDA's clipboard. Keep it current as
+    // markers are created/edited instead of waiting for the project-save pass.
+    storeWarpMarkersInClipModel(clipId, warpManager);
+
     DBG("WarpMarkerManager::enableWarp clip " << clipId << " -> " << warpManager.getMarkers().size()
                                               << " markers");
 }
@@ -244,6 +264,9 @@ void WarpMarkerManager::disableWarp(te::Edit& edit,
     auto& warpManager = audioClipPtr->getWarpTimeManager();
     warpManager.removeAllMarkers();
     audioClipPtr->setWarpTime(false);
+
+    if (auto* clip = ClipManager::getInstance().getClip(clipId))
+        clip->warpMarkers.clear();
 
     DBG("WarpMarkerManager::disableWarp clip " << clipId);
 }
@@ -288,6 +311,8 @@ int WarpMarkerManager::addWarpMarker(te::Edit& edit,
     int teIndex = warpManager.insertMarker(te::WarpMarker(te::TimePosition::fromSeconds(sourceTime),
                                                           te::TimePosition::fromSeconds(warpTime)));
 
+    storeWarpMarkersInClipModel(clipId, warpManager);
+
     int markerCountAfter = warpManager.getMarkers().size();
     DBG("WarpMarkerManager::addWarpMarker clip "
         << clipId << " src=" << sourceTime << " warp=" << warpTime << " -> teIndex=" << teIndex
@@ -307,6 +332,7 @@ double WarpMarkerManager::moveWarpMarker(te::Edit& edit,
     // Use TE index directly - UI now uses the same index space
     auto& warpManager = audioClipPtr->getWarpTimeManager();
     auto result = warpManager.moveMarker(index, te::TimePosition::fromSeconds(newWarpTime));
+    storeWarpMarkersInClipModel(clipId, warpManager);
     return result.inSeconds();
 }
 
@@ -320,6 +346,7 @@ void WarpMarkerManager::removeWarpMarker(te::Edit& edit,
     // Use TE index directly - UI now uses the same index space
     auto& warpManager = audioClipPtr->getWarpTimeManager();
     warpManager.removeMarker(index);
+    storeWarpMarkersInClipModel(clipId, warpManager);
 }
 
 }  // namespace magda

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -142,21 +142,46 @@ bool syncFollowActionToTracktionClip(te::Clip& teClip, const ClipInfo& clip, dou
     return changed;
 }
 
-void restoreWarpMarkers(te::WarpTimeManager& warpManager,
-                        const std::vector<ClipInfo::WarpMarker>& markers) {
-    if (markers.empty())
-        return;
+constexpr double warpMarkerSyncEpsilonSeconds = 1.0e-6;
+
+bool warpMarkerMapsMatch(const juce::Array<te::WarpMarker*>& engineMarkers,
+                         const std::vector<ClipInfo::WarpMarker>& savedMarkers) {
+    if (engineMarkers.size() != static_cast<int>(savedMarkers.size()))
+        return false;
+
+    for (size_t i = 0; i < savedMarkers.size(); ++i) {
+        const auto* engineMarker = engineMarkers[static_cast<int>(i)];
+        const auto& savedMarker = savedMarkers[i];
+        if (engineMarker == nullptr ||
+            std::abs(engineMarker->sourceTime.inSeconds() - savedMarker.sourceTime) >
+                warpMarkerSyncEpsilonSeconds ||
+            std::abs(engineMarker->warpTime.inSeconds() - savedMarker.warpTime) >
+                warpMarkerSyncEpsilonSeconds) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool restoreWarpMarkersIfNeeded(te::WarpTimeManager& warpManager,
+                                const std::vector<ClipInfo::WarpMarker>& markers) {
+    // A valid map needs both boundary markers. In particular, do not insert a
+    // lone saved marker on top of TE's recreated boundaries: that can create a
+    // zero-length segment in WarpTimeManager's stretch-ratio calculation.
+    if (markers.size() < 2)
+        return false;
+
+    const auto& existingMarkers = warpManager.getMarkers();
+
+    // More than the two default boundaries means the live map has already been
+    // edited. Never overwrite it from an older model snapshot.
+    if (existingMarkers.size() > 2 || warpMarkerMapsMatch(existingMarkers, markers))
+        return false;
 
     // removeAllMarkers deliberately recreates TE's start/end boundaries, so
     // inserting the complete saved list would duplicate both boundaries.
     warpManager.removeAllMarkers();
-
-    if (markers.size() == 1) {
-        warpManager.insertMarker(
-            te::WarpMarker(te::TimePosition::fromSeconds(markers.front().sourceTime),
-                           te::TimePosition::fromSeconds(markers.front().warpTime)));
-        return;
-    }
 
     auto& defaultMarkers = warpManager.getMarkers();
     warpManager.moveMarker(0, te::TimePosition::fromSeconds(markers.front().warpTime));
@@ -168,6 +193,8 @@ void restoreWarpMarkers(te::WarpTimeManager& warpManager,
             te::WarpMarker(te::TimePosition::fromSeconds(markers[i].sourceTime),
                            te::TimePosition::fromSeconds(markers[i].warpTime)));
     }
+
+    return true;
 }
 
 bool syncWarpStateToTracktionClip(te::WaveAudioClip& audioClip, const ClipInfo& clip) {
@@ -188,15 +215,12 @@ bool syncWarpStateToTracktionClip(te::WaveAudioClip& audioClip, const ClipInfo& 
 
     if (!clip.warpMarkers.empty()) {
         auto& warpManager = audioClip.getWarpTimeManager();
-        const auto& existingMarkers = warpManager.getMarkers();
 
         // A newly-created WarpTimeManager contains only its two default
         // boundary markers. Replace those with the marker map copied from the
         // source clip, but never overwrite an already-live edited map.
-        if (existingMarkers.size() <= 2) {
-            restoreWarpMarkers(warpManager, clip.warpMarkers);
+        if (restoreWarpMarkersIfNeeded(warpManager, clip.warpMarkers))
             changed = true;
-        }
     }
 
     return changed;
@@ -1966,10 +1990,8 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
         // Restore saved warp markers if TE has no user markers yet
         if (!clip->warpMarkers.empty()) {
             auto& warpManager = audioClipPtr->getWarpTimeManager();
-            auto existingMarkers = warpManager.getMarkers();
             // TE creates 2 default boundary markers; if only those exist, restore saved
-            if (existingMarkers.size() <= 2) {
-                restoreWarpMarkers(warpManager, clip->warpMarkers);
+            if (restoreWarpMarkersIfNeeded(warpManager, clip->warpMarkers)) {
                 DBG("ClipSynchronizer: Restored " << clip->warpMarkers.size()
                                                   << " warp markers for clip " << clipId);
             }

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -142,6 +142,66 @@ bool syncFollowActionToTracktionClip(te::Clip& teClip, const ClipInfo& clip, dou
     return changed;
 }
 
+void restoreWarpMarkers(te::WarpTimeManager& warpManager,
+                        const std::vector<ClipInfo::WarpMarker>& markers) {
+    if (markers.empty())
+        return;
+
+    // removeAllMarkers deliberately recreates TE's start/end boundaries, so
+    // inserting the complete saved list would duplicate both boundaries.
+    warpManager.removeAllMarkers();
+
+    if (markers.size() == 1) {
+        warpManager.insertMarker(
+            te::WarpMarker(te::TimePosition::fromSeconds(markers.front().sourceTime),
+                           te::TimePosition::fromSeconds(markers.front().warpTime)));
+        return;
+    }
+
+    auto& defaultMarkers = warpManager.getMarkers();
+    warpManager.moveMarker(0, te::TimePosition::fromSeconds(markers.front().warpTime));
+    warpManager.moveMarker(defaultMarkers.size() - 1,
+                           te::TimePosition::fromSeconds(markers.back().warpTime));
+
+    for (size_t i = 1; i + 1 < markers.size(); ++i) {
+        warpManager.insertMarker(
+            te::WarpMarker(te::TimePosition::fromSeconds(markers[i].sourceTime),
+                           te::TimePosition::fromSeconds(markers[i].warpTime)));
+    }
+}
+
+bool syncWarpStateToTracktionClip(te::WaveAudioClip& audioClip, const ClipInfo& clip) {
+    bool changed = false;
+
+    if (!clip.warpEnabled) {
+        if (audioClip.getWarpTime()) {
+            audioClip.setWarpTime(false);
+            changed = true;
+        }
+        return changed;
+    }
+
+    if (!audioClip.getWarpTime()) {
+        audioClip.setWarpTime(true);
+        changed = true;
+    }
+
+    if (!clip.warpMarkers.empty()) {
+        auto& warpManager = audioClip.getWarpTimeManager();
+        const auto& existingMarkers = warpManager.getMarkers();
+
+        // A newly-created WarpTimeManager contains only its two default
+        // boundary markers. Replace those with the marker map copied from the
+        // source clip, but never overwrite an already-live edited map.
+        if (existingMarkers.size() <= 2) {
+            restoreWarpMarkers(warpManager, clip.warpMarkers);
+            changed = true;
+        }
+    }
+
+    return changed;
+}
+
 }  // namespace
 
 void ClipSynchronizer::reallocateAndNotify() {
@@ -447,6 +507,10 @@ bool ClipSynchronizer::syncClipPropertyToEngine(ClipId clipId) {
                                 audioClip->setTimeStretchMode(desiredMode);
                                 needsGraphReallocation = true;
                             }
+
+                            needsGraphReallocation =
+                                syncWarpStateToTracktionClip(*audioClip, *clip) ||
+                                needsGraphReallocation;
                         }
                     }
 
@@ -848,8 +912,10 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
 
         // Force WarpTimeManager creation now so its constructor's warp marker
         // insertions (which trigger TreeWatcher → restartPlayback) happen during
-        // initial sync rather than lazily during playback (which causes a click).
+        // initial sync rather than lazily during playback (which causes a click),
+        // then restore any marker map carried by a copied/project-loaded clip.
         audioClipPtr->getWarpTimeManager();
+        syncWarpStateToTracktionClip(*audioClipPtr, *clip);
 
         return true;
 
@@ -1903,12 +1969,7 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
             auto existingMarkers = warpManager.getMarkers();
             // TE creates 2 default boundary markers; if only those exist, restore saved
             if (existingMarkers.size() <= 2) {
-                warpManager.removeAllMarkers();
-                for (const auto& wm : clip->warpMarkers) {
-                    warpManager.insertMarker(
-                        te::WarpMarker(te::TimePosition::fromSeconds(wm.sourceTime),
-                                       te::TimePosition::fromSeconds(wm.warpTime)));
-                }
+                restoreWarpMarkers(warpManager, clip->warpMarkers);
                 DBG("ClipSynchronizer: Restored " << clip->warpMarkers.size()
                                                   << " warp markers for clip " << clipId);
             }

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -3423,10 +3423,16 @@ std::vector<ClipId> ClipManager::pasteFromClipboardBeats(double pasteBeat, Track
                     // Don't overwrite startBeats — createMidiClip/createAudioClip already
                     // computed the correct value from newStartTime
                 }
-                if (!crossViewToSession) {
+                if (!crossViewToSession || clipData.warpEnabled) {
                     newClip->warpEnabled = clipData.warpEnabled;
                     newClip->timeStretchMode = clipData.timeStretchMode;
                 }
+
+                // Warp markers describe the source mapping, not arrangement
+                // placement. Preserve them when copying between either view so
+                // ClipSynchronizer can restore the map into the destination TE clip.
+                if (clipData.isAudio())
+                    newClip->warpMarkers = clipData.warpMarkers;
 
                 // Source file metadata describes audio files only.
                 if (clipData.isAudio()) {

--- a/magda/daw/ui/windows/MainWindow.cpp
+++ b/magda/daw/ui/windows/MainWindow.cpp
@@ -912,6 +912,7 @@ void MainWindow::MainComponent::setupViewModeListener() {
 
     // Listen to track property changes for playback mode updates
     TrackManager::getInstance().addListener(this);
+    trackPropertyChanged(INVALID_TRACK_ID);
 }
 
 void MainWindow::MainComponent::setupAudioEngineCallbacks(AudioEngine* engine) {
@@ -1458,6 +1459,10 @@ void MainWindow::MainComponent::selectionTypeChanged(SelectionType newType) {
     MenuManager::getInstance().updateMenuStates(
         false, false, hasSelection, hasEditCursor, leftPanelVisible, rightPanelVisible,
         bottomPanelVisible, isPlaying, isRecording, isLooping);
+}
+
+void MainWindow::MainComponent::tracksChanged() {
+    trackPropertyChanged(INVALID_TRACK_ID);
 }
 
 void MainWindow::MainComponent::trackPropertyChanged(int /*trackId*/) {

--- a/magda/daw/ui/windows/MainWindow.hpp
+++ b/magda/daw/ui/windows/MainWindow.hpp
@@ -115,7 +115,7 @@ class MainWindow::MainComponent : public juce::Component,
     void selectionTypeChanged(SelectionType newType) override;
 
     // TrackManagerListener
-    void tracksChanged() override {}
+    void tracksChanged() override;
     void trackPropertyChanged(int trackId) override;
 
     // MidiLearnCoordinatorListener

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -235,6 +235,7 @@ target_sources(magda_juce_tests PRIVATE
     # test_export_no_assertion_juce.cpp  # Disabled - see issue #611 (generator device export)
     test_midi_recording_juce.cpp
     test_clip_sync_integration_juce.cpp
+    test_arranger_launcher_switching_juce.cpp
     test_session_slot_recording_juce.cpp
     test_input_monitor_track_routing_juce.cpp
     test_track_midi_recording_preview_juce.cpp

--- a/tests/test_arranger_launcher_switching_juce.cpp
+++ b/tests/test_arranger_launcher_switching_juce.cpp
@@ -1,0 +1,139 @@
+#include <juce_core/juce_core.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+#include <algorithm>
+
+#include "SharedTestEngine.hpp"
+#include "third_party/tracktion_engine/modules/tracktion_engine/playback/graph/tracktion_ArrangerClipControlNode.h"
+#include "third_party/tracktion_engine/modules/tracktion_engine/playback/graph/tracktion_ArrangerLauncherSwitchingNode.h"
+#include "third_party/tracktion_engine/modules/tracktion_engine/playback/graph/tracktion_TracktionEngineNode.h"
+#include "third_party/tracktion_engine/modules/tracktion_engine/utilities/tracktion_TestUtilities.h"
+#include "third_party/tracktion_engine/modules/tracktion_graph/tracktion_graph.h"
+
+namespace te = tracktion;
+
+namespace {
+
+class CountingAudioNode final : public te::graph::Node {
+  public:
+    CountingAudioNode() {
+        setOptimisations({te::graph::ClearBuffers::yes, te::graph::AllocateAudioBuffer::yes});
+    }
+
+    te::graph::NodeProperties getNodeProperties() override {
+        return {.hasAudio = true,
+                .hasMidi = false,
+                .numberOfChannels = 1,
+                .nodeID = 0x617272616e676572ULL};
+    }
+
+    bool isReadyToProcess() override {
+        return true;
+    }
+
+    void process(ProcessContext& pc) override {
+        ++processCount;
+        for (choc::buffer::ChannelCount channel = 0; channel < pc.buffers.audio.getNumChannels();
+             ++channel) {
+            auto* samples = pc.buffers.audio.getIterator(channel).sample;
+            std::fill(samples, samples + pc.buffers.audio.getNumFrames(), 0.5f);
+        }
+    }
+
+    int processCount = 0;
+};
+
+}  // namespace
+
+class ArrangerLauncherSwitchingTest final : public juce::UnitTest {
+  public:
+    ArrangerLauncherSwitchingTest()
+        : juce::UnitTest("Arranger Launcher Conditional Processing Tests", "magda") {}
+
+    void runTest() override {
+        beginTest("Queued launcher stop does not reclaim playback from arrangement");
+
+        te::LaunchHandle launchHandle;
+        launchHandle.play(std::nullopt);
+
+        te::SyncRange syncRange;
+        auto nextSyncPoint = syncRange.end;
+        const auto halfBeat = te::BeatDuration::fromBeats(0.5);
+        nextSyncPoint.monotonicBeat.v = nextSyncPoint.monotonicBeat.v + halfBeat;
+        nextSyncPoint.beat = nextSyncPoint.beat + halfBeat;
+        syncRange = {syncRange.end, nextSyncPoint};
+        launchHandle.advance(syncRange);
+
+        expect(te::ArrangerLauncherSwitchingNode::shouldActivateSlotPlayback(launchHandle),
+               "A playing launcher should claim the track");
+
+        launchHandle.stop(std::nullopt);
+        expect(launchHandle.getPlayingStatus() == te::LaunchHandle::PlayState::playing,
+               "The handle remains playing until the audio thread consumes its stop");
+        expect(launchHandle.getQueuedStatus() == te::LaunchHandle::QueueState::stopQueued,
+               "Back to Arrangement queues an immediate launcher stop");
+        expect(!te::ArrangerLauncherSwitchingNode::shouldActivateSlotPlayback(launchHandle),
+               "A queued stop must not overwrite playSlotClips=false");
+
+        beginTest("Arrangement reader only processes while arrangement owns the track");
+
+        auto* engine = magda::test::getSharedEngine().getEngine();
+        expect(engine != nullptr, "Shared engine should be available");
+        if (engine == nullptr)
+            return;
+
+        auto edit = te::test_utilities::createTestEdit(*engine, 1);
+        auto tracks = te::getAudioTracks(*edit);
+        expect(!tracks.isEmpty(), "Test edit should contain an audio track");
+        if (tracks.isEmpty())
+            return;
+
+        auto* track = tracks.getFirst();
+        auto input = std::make_unique<CountingAudioNode>();
+        auto* inputCounter = input.get();
+        auto controlNode = std::make_unique<te::ArrangerClipControlNode>(*track, std::move(input));
+        auto graph = te::graph::createNodeGraph(std::move(controlNode), false);
+
+        constexpr double sampleRate = 44100.0;
+        constexpr int blockSize = 256;
+        const te::graph::PlaybackInitialisationInfo info{sampleRate, blockSize, *graph, nullptr,
+                                                         {},         {},        false};
+        for (auto* node : graph->orderedNodes)
+            node->initialise(info);
+
+        auto processBlock = [&](int64_t startSample) {
+            for (auto* node : graph->orderedNodes)
+                node->prepareForNextBlock({startSample, startSample + blockSize});
+
+            for (auto* node : graph->orderedNodes) {
+                expect(node->isReadyToProcess(), "Conditional graph should be ready");
+                node->process(blockSize, {startSample, startSample + blockSize});
+            }
+
+            return graph->rootNode->getProcessedOutput().audio;
+        };
+
+        track->playSlotClips = true;
+        auto sessionOutput = processBlock(0);
+        expectEquals(inputCounter->processCount, 0,
+                     "Session ownership must not process the inaudible arrangement reader");
+        expectWithinAbsoluteError(sessionOutput.getSample(0, 0), 0.0f, 0.0001f,
+                                  "Session-owned arrangement reader should output silence");
+
+        track->playSlotClips = false;
+        auto arrangementOutput = processBlock(blockSize);
+        expectEquals(inputCounter->processCount, 1,
+                     "Returning to arrangement should resume its reader on the next block");
+        expectWithinAbsoluteError(arrangementOutput.getSample(0, 0), 0.5f, 0.0001f,
+                                  "Arrangement-owned reader should output arrangement audio");
+
+        track->playSlotClips = true;
+        auto resumedSessionOutput = processBlock(2 * blockSize);
+        expectEquals(inputCounter->processCount, 1,
+                     "Re-entering Session must suspend the arrangement reader again");
+        expectWithinAbsoluteError(resumedSessionOutput.getSample(0, 0), 0.0f, 0.0001f,
+                                  "Suspended arrangement reader should contribute silence");
+    }
+};
+
+static ArrangerLauncherSwitchingTest arrangerLauncherSwitchingTest;

--- a/tests/test_arranger_launcher_switching_juce.cpp
+++ b/tests/test_arranger_launcher_switching_juce.cpp
@@ -1,14 +1,16 @@
 #include <juce_core/juce_core.h>
 #include <tracktion_engine/tracktion_engine.h>
+#include <tracktion_graph/tracktion_graph.h>
 
 #include <algorithm>
 
 #include "SharedTestEngine.hpp"
+// clang-format off
 #include "third_party/tracktion_engine/modules/tracktion_engine/playback/graph/tracktion_ArrangerClipControlNode.h"
-#include "third_party/tracktion_engine/modules/tracktion_engine/playback/graph/tracktion_ArrangerLauncherSwitchingNode.h"
 #include "third_party/tracktion_engine/modules/tracktion_engine/playback/graph/tracktion_TracktionEngineNode.h"
+#include "third_party/tracktion_engine/modules/tracktion_engine/playback/graph/tracktion_ArrangerLauncherSwitchingNode.h"
+// clang-format on
 #include "third_party/tracktion_engine/modules/tracktion_engine/utilities/tracktion_TestUtilities.h"
-#include "third_party/tracktion_engine/modules/tracktion_graph/tracktion_graph.h"
 
 namespace te = tracktion;
 

--- a/tests/test_audio_clip_stretch.cpp
+++ b/tests/test_audio_clip_stretch.cpp
@@ -1,3 +1,4 @@
+#include <tracktion_engine/playback/graph/tracktion_LaunchDeClick.h>
 #include <tracktion_engine/tracktion_engine.h>
 
 #include <catch2/catch_approx.hpp>
@@ -510,6 +511,127 @@ TEST_CASE("Signalsmith adapter honours Tracktion's pull contract",
     REQUIRE(changedSpeed);
     REQUIRE(outputPosition == Catch::Approx(expectedOutputSamples).margin(2.0));
     REQUIRE(result.getRMSLevel(0, 0, outputPosition) > 0.1f);
+}
+
+TEST_CASE("Session launch de-click preserves the leading transient",
+          "[audio][clip][session][transient]") {
+    constexpr int numSamples = 256;
+    juce::AudioBuffer<float> transient(1, numSamples);
+    juce::AudioBuffer<float> baseline(1, numSamples);
+    juce::AudioBuffer<float> combined(1, numSamples);
+
+    for (int sample = 0; sample < numSamples; ++sample) {
+        const auto attack =
+            static_cast<float>(std::sin(juce::MathConstants<double>::twoPi * sample / 37.0) *
+                               std::exp(-static_cast<double>(sample) / 80.0));
+        transient.setSample(0, sample, attack);
+        baseline.setSample(0, sample, 0.5f);
+        combined.setSample(0, sample, 0.5f + attack);
+    }
+
+    auto baselineView = tracktion::engine::toBufferView(baseline);
+    auto combinedView = tracktion::engine::toBufferView(combined);
+    tracktion::engine::applyAudioStartDeClick(baselineView, numSamples);
+    tracktion::engine::applyAudioStartDeClick(combinedView, numSamples);
+
+    REQUIRE(baseline.getSample(0, 0) == Catch::Approx(0.0f).margin(1.0e-6f));
+    REQUIRE(combined.getSample(0, 0) == Catch::Approx(0.0f).margin(1.0e-6f));
+    REQUIRE(baseline.getSample(0, numSamples - 1) == Catch::Approx(0.5f).margin(1.0e-6f));
+
+    for (int sample = 0; sample < numSamples; ++sample) {
+        const auto preservedTransient =
+            combined.getSample(0, sample) - baseline.getSample(0, sample);
+        REQUIRE(preservedTransient ==
+                Catch::Approx(transient.getSample(0, sample)).margin(1.0e-6f));
+    }
+
+    auto transientView = tracktion::engine::toBufferView(transient);
+    const juce::AudioBuffer<float> originalTransient(transient);
+    tracktion::engine::applyAudioStartDeClick(transientView, numSamples);
+
+    for (int sample = 0; sample < numSamples; ++sample)
+        REQUIRE(transient.getSample(0, sample) ==
+                Catch::Approx(originalTransient.getSample(0, sample)).margin(1.0e-6f));
+}
+
+TEST_CASE("Signalsmith preserves a transient at the start of a stream",
+          "[audio][clip][stretch][signalsmith][transient]") {
+    namespace te = tracktion::engine;
+
+    constexpr double sampleRate = 48000.0;
+    constexpr int blockSize = 480;
+    constexpr int hitSpacing = 9600;
+    constexpr int hitLength = 1600;
+    constexpr int sourceSamples = hitSpacing * 5;
+    constexpr float speedRatio = 1.25f;
+
+    juce::AudioBuffer<float> source(1, sourceSamples);
+    source.clear();
+
+    for (int hit = 0; hit < 5; ++hit) {
+        const auto hitStart = hit * hitSpacing;
+
+        for (int sample = 0; sample < hitLength; ++sample) {
+            const auto envelope = std::exp(-static_cast<double>(sample) / 260.0);
+            const auto body =
+                std::sin(juce::MathConstants<double>::twoPi * 95.0 * sample / sampleRate);
+            source.setSample(0, hitStart + sample, static_cast<float>(envelope * body));
+        }
+    }
+
+    juce::AudioBuffer<float> result(1, sourceSamples * 2);
+    result.clear();
+
+    te::TimeStretcher stretcher;
+    stretcher.initialise(sampleRate, blockSize, 1, te::TimeStretcher::signalsmith, {}, true);
+    REQUIRE(stretcher.isInitialised());
+    REQUIRE(stretcher.setSpeedAndPitch(speedRatio, 0.0f));
+
+    int inputPosition = 0;
+    int outputPosition = 0;
+
+    while (inputPosition + stretcher.getFramesNeeded() <= sourceSamples) {
+        const auto framesNeeded = stretcher.getFramesNeeded();
+        const float* inputs[] = {source.getReadPointer(0, inputPosition)};
+        float* outputs[] = {result.getWritePointer(0, outputPosition)};
+
+        const auto produced = stretcher.processData(inputs, framesNeeded, outputs);
+        REQUIRE(produced == blockSize);
+        inputPosition += framesNeeded;
+        outputPosition += produced;
+    }
+
+    for (int guard = 0; guard < 100; ++guard) {
+        float* outputs[] = {result.getWritePointer(0, outputPosition)};
+        const auto produced = stretcher.flush(outputs);
+        if (produced == 0)
+            break;
+        outputPosition += produced;
+    }
+
+    const auto peakAround = [&result, outputPosition](int centre) {
+        const auto start = std::max(0, centre - 1000);
+        const auto end =
+            std::min(outputPosition, centre + juce::roundToInt(hitLength * speedRatio) + 1000);
+        return result.getMagnitude(0, start, end - start);
+    };
+
+    const auto firstPeak = peakAround(0);
+    float laterPeak = 0.0f;
+    for (int hit = 1; hit < 4; ++hit)
+        laterPeak += peakAround(juce::roundToInt(hit * hitSpacing * speedRatio));
+    laterPeak /= 3.0f;
+
+    const auto attackRms = [&result](int start) { return result.getRMSLevel(0, start, blockSize); };
+    const auto firstAttackRms = attackRms(0);
+    float laterAttackRms = 0.0f;
+    for (int hit = 1; hit < 4; ++hit)
+        laterAttackRms += attackRms(juce::roundToInt(hit * hitSpacing * speedRatio));
+    laterAttackRms /= 3.0f;
+
+    CAPTURE(firstPeak, laterPeak, firstAttackRms, laterAttackRms, outputPosition);
+    REQUIRE(firstPeak >= laterPeak * 0.9f);
+    REQUIRE(firstAttackRms >= laterAttackRms * 0.9f);
 }
 
 TEST_CASE("ClipOperations - stretchAudioFromLeft right edge anchoring",

--- a/tests/test_clip_sync_integration_juce.cpp
+++ b/tests/test_clip_sync_integration_juce.cpp
@@ -90,6 +90,7 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         testTrimAudioFromRight();
         testSpeedRatio();
         testBeatModeStretchEngineChangesReallocateGraph();
+        testArrangementWarpClipboardPasteToSessionPreservesMarkers();
         testLoopEnableDisable();
         testBeatModeRoundTripPreservesTrimmedLength();
         testLoopTimeBased();
@@ -526,6 +527,63 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
             expectEquals(
                 reallocationCount, 1,
                 "Creating an arrangement TE clip from a property batch should reallocate once");
+        }
+    }
+
+    void testArrangementWarpClipboardPasteToSessionPreservesMarkers() {
+        beginTest("Arrangement warp clipboard paste to session preserves markers");
+
+        Fixture f;
+        auto& cm = ClipManager::getInstance();
+        auto sourceId =
+            cm.createAudioClip(f.trackId, 0.0, 5.0, f.audioPath(), ClipView::Arrangement, 60.0);
+        auto* source = cm.getClip(sourceId);
+        expect(source != nullptr, "Source clip should exist");
+        if (source == nullptr)
+            return;
+
+        source->warpEnabled = true;
+        source->timeStretchMode = static_cast<int>(te::TimeStretcher::signalsmith);
+        f.clipSync->syncClipToEngine(sourceId);
+
+        const int insertedIndex = f.clipSync->addWarpMarker(sourceId, 1.0, 1.25);
+        expect(insertedIndex >= 0, "User warp marker should be inserted");
+        expectEquals(static_cast<int>(source->warpMarkers.size()), 3,
+                     "Live TE marker edits should be mirrored into ClipInfo");
+
+        cm.copyToClipboard({sourceId});
+        auto pastedIds = cm.pasteFromClipboardBeats(0.0, f.trackId, ClipView::Session, 0);
+        expectEquals(static_cast<int>(pastedIds.size()), 1);
+        if (pastedIds.empty())
+            return;
+
+        const auto pastedId = pastedIds.front();
+        auto* pasted = cm.getClip(pastedId);
+        expect(pasted != nullptr, "Pasted session clip should exist");
+        if (pasted == nullptr)
+            return;
+
+        expect(pasted->warpEnabled, "Pasted session clip should remain warped");
+        expectEquals(pasted->timeStretchMode, static_cast<int>(te::TimeStretcher::signalsmith));
+        expectEquals(static_cast<int>(pasted->warpMarkers.size()), 3,
+                     "Pasted ClipInfo should contain the source marker map");
+
+        if (f.clipSync->getSessionTeClip(pastedId) == nullptr)
+            f.clipSync->syncSessionClipToSlot(pastedId);
+
+        auto* pastedTeClip =
+            dynamic_cast<te::WaveAudioClip*>(f.clipSync->getSessionTeClip(pastedId));
+        expect(pastedTeClip != nullptr, "Pasted clip should be installed in its session slot");
+        if (pastedTeClip == nullptr)
+            return;
+
+        expect(pastedTeClip->getWarpTime(), "Session TE clip should have warp enabled");
+        const auto pastedMarkers = f.clipSync->getWarpMarkers(pastedId);
+        expectEquals(static_cast<int>(pastedMarkers.size()), 3,
+                     "Session TE clip should restore every warp marker");
+        if (pastedMarkers.size() == 3) {
+            expectWithinAbsoluteError(pastedMarkers[1].sourceTime, 1.0, 0.001);
+            expectWithinAbsoluteError(pastedMarkers[1].warpTime, 1.25, 0.001);
         }
     }
 

--- a/tests/test_clip_sync_integration_juce.cpp
+++ b/tests/test_clip_sync_integration_juce.cpp
@@ -91,6 +91,8 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         testSpeedRatio();
         testBeatModeStretchEngineChangesReallocateGraph();
         testArrangementWarpClipboardPasteToSessionPreservesMarkers();
+        testWarpMarkerSyncIsIdempotent();
+        testSingleWarpMarkerMapIsIgnored();
         testLoopEnableDisable();
         testBeatModeRoundTripPreservesTrimmedLength();
         testLoopTimeBased();
@@ -585,6 +587,139 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
             expectWithinAbsoluteError(pastedMarkers[1].sourceTime, 1.0, 0.001);
             expectWithinAbsoluteError(pastedMarkers[1].warpTime, 1.25, 0.001);
         }
+    }
+
+    void testWarpMarkerSyncIsIdempotent() {
+        beginTest("Warp marker sync is idempotent for arrangement and session clips");
+
+        struct WarpStateMutationCounter final : juce::ValueTree::Listener {
+            explicit WarpStateMutationCounter(juce::ValueTree& stateToWatch) : state(stateToWatch) {
+                state.addListener(this);
+            }
+
+            ~WarpStateMutationCounter() override {
+                state.removeListener(this);
+            }
+
+            void valueTreePropertyChanged(juce::ValueTree&, const juce::Identifier&) override {
+                ++mutationCount;
+            }
+
+            void valueTreeChildAdded(juce::ValueTree&, juce::ValueTree&) override {
+                ++mutationCount;
+            }
+
+            void valueTreeChildRemoved(juce::ValueTree&, juce::ValueTree&, int) override {
+                ++mutationCount;
+            }
+
+            juce::ValueTree& state;
+            int mutationCount = 0;
+        };
+
+        Fixture f;
+        auto& cm = ClipManager::getInstance();
+
+        auto arrangementId =
+            cm.createAudioClip(f.trackId, 0.0, 5.0, f.audioPath(), ClipView::Arrangement, 60.0);
+        auto* arrangement = cm.getClip(arrangementId);
+        expect(arrangement != nullptr, "Arrangement clip should exist");
+        if (arrangement == nullptr)
+            return;
+
+        arrangement->warpEnabled = true;
+        f.clipSync->syncClipToEngine(arrangementId);
+        f.clipSync->enableWarp(arrangementId);
+
+        auto* arrangementTeClip = f.getTeAudioClip(arrangementId);
+        expect(arrangementTeClip != nullptr, "Arrangement TE clip should exist");
+        expectEquals(static_cast<int>(arrangement->warpMarkers.size()), 2,
+                     "Enabling warp without user markers should store only the boundaries");
+        if (arrangementTeClip == nullptr || arrangement->warpMarkers.size() != 2)
+            return;
+
+        auto& arrangementWarpManager = arrangementTeClip->getWarpTimeManager();
+        const auto& arrangementMarkersBefore = arrangementWarpManager.getMarkers();
+        expectEquals(arrangementMarkersBefore.size(), 2);
+        if (arrangementMarkersBefore.size() != 2)
+            return;
+
+        WarpStateMutationCounter arrangementMutations(arrangementWarpManager.state);
+        f.clipSync->syncClipToEngine(arrangementId);
+        expectEquals(arrangementMutations.mutationCount, 0,
+                     "An identical saved boundary map must not mutate arrangement markers");
+
+        auto sessionId =
+            cm.createAudioClip(f.trackId, 0.0, 5.0, f.audioPath(), ClipView::Session, 60.0);
+        cm.setClipSceneIndex(sessionId, 0);
+        auto* session = cm.getClip(sessionId);
+        auto* sessionTeClip =
+            dynamic_cast<te::WaveAudioClip*>(f.clipSync->getSessionTeClip(sessionId));
+        expect(session != nullptr, "Session clip should exist");
+        expect(sessionTeClip != nullptr, "Session TE clip should exist");
+        if (session == nullptr || sessionTeClip == nullptr)
+            return;
+
+        session->warpEnabled = true;
+        f.clipSync->enableWarp(sessionId);
+        expectEquals(static_cast<int>(session->warpMarkers.size()), 2,
+                     "Session warp enable should store its boundary map");
+        if (session->warpMarkers.size() != 2)
+            return;
+
+        // Settle other lazily-created session properties before observing graph
+        // reallocations caused by the property change under test.
+        cm.forceNotifyMultipleClipPropertiesChanged({sessionId});
+
+        auto& sessionWarpManager = sessionTeClip->getWarpTimeManager();
+        const auto& sessionMarkersBefore = sessionWarpManager.getMarkers();
+        expectEquals(sessionMarkersBefore.size(), 2);
+        if (sessionMarkersBefore.size() != 2)
+            return;
+
+        // Serialized doubles can differ by sub-microsecond rounding. This must
+        // still compare equal rather than restarting playback on a gain change.
+        session->warpMarkers.front().warpTime += 5.0e-7;
+
+        WarpStateMutationCounter sessionMutations(sessionWarpManager.state);
+        int reallocationCount = 0;
+        f.edit->getTransport().ensureContextAllocated();
+        const bool canObserveReallocation = f.edit->getCurrentPlaybackContext() != nullptr;
+        f.clipSync->onGraphReallocated = [&reallocationCount]() { ++reallocationCount; };
+
+        session->volumeDB = -3.0f;
+        cm.forceNotifyMultipleClipPropertiesChanged({sessionId});
+
+        expectEquals(sessionMutations.mutationCount, 0,
+                     "Equivalent saved boundaries must not mutate session markers");
+        if (canObserveReallocation)
+            expectEquals(reallocationCount, 0,
+                         "A gain change with an equivalent warp map must not rebuild the graph");
+    }
+
+    void testSingleWarpMarkerMapIsIgnored() {
+        beginTest("A malformed single warp marker map is ignored");
+
+        Fixture f;
+        auto& cm = ClipManager::getInstance();
+        auto clipId =
+            cm.createAudioClip(f.trackId, 0.0, 5.0, f.audioPath(), ClipView::Arrangement, 60.0);
+        auto* clip = cm.getClip(clipId);
+        expect(clip != nullptr, "Arrangement clip should exist");
+        if (clip == nullptr)
+            return;
+
+        clip->warpEnabled = true;
+        clip->warpMarkers = {{0.0, 0.0}};
+        f.clipSync->syncClipToEngine(clipId);
+
+        auto* teClip = f.getTeAudioClip(clipId);
+        expect(teClip != nullptr, "Arrangement TE clip should exist");
+        if (teClip == nullptr)
+            return;
+
+        expectEquals(teClip->getWarpTimeManager().getMarkers().size(), 2,
+                     "A lone saved marker must not be inserted over TE's two boundaries");
     }
 
     void testPropertyChangeCreatesMissingReversedArrangementClipSynchronously() {


### PR DESCRIPTION
## What changed

- preserve warp mode and marker maps when arrangement clips are copied into session slots
- synchronize restored warp markers into Tracktion clips
- reconnect Back to Arrangement activation to launcher playback ownership
- add regression coverage for arrangement/session switching, warp-state copying, Signalsmith startup transients, and session launch de-clicking
- update the Tracktion Engine revision for the playback ownership and transient fix: https://github.com/Conceptual-Machines/tracktion_engine/pull/28

## Why

Several arrangement/session paths had diverged. Arrangement clips could continue processing behind a launched session clip, copied session clips lost their warp-marker state, and the UI was not notified when launcher playback took ownership. The session launcher also attenuated the first 256 samples, making the first warped transient sound softer than subsequent loop transients.

## Impact

Session loops are seamless even when arrangement clips exist, pasted warped clips retain visible and functional warp markers, Back to Arrangement activates correctly, and the first launched transient retains its attack.

## Validation

- transient-focused tests: 627 assertions across 2 cases
- Signalsmith tests: 156 assertions across 4 cases
- clip synchronization and arrangement/launcher regression coverage
- full `magda_daw_app` Debug build
- repository pre-commit hooks
