### PR TITLE
Fix AI chat input box rendering white on Windows

### DIFF
--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -898,8 +898,14 @@ AIChatConsoleContent::AIChatConsoleContent() {
     inputBox_->setFont(monoFont);
     inputBox_->setLineNumbersShown(false);
     inputBox_->setScrollbarThickness(8);
+    // CodeEditorComponent forces setOpaque(true) in its own constructor, so a
+    // transparent fill here is undefined depending on how the platform clips
+    // paint-behind-opaque-child (JUCE's TextEditor, by contrast, never
+    // opts into opaque and composites fine with a transparent fill). Paint
+    // the same solid colour as the panel drawn behind it in paint() instead
+    // of relying on transparency — matches dslEditor_'s approach below.
     inputBox_->setColour(juce::CodeEditorComponent::backgroundColourId,
-                         juce::Colours::transparentBlack);
+                         DarkTheme::getColour(DarkTheme::BUTTON_NORMAL));
     inputBox_->setColour(juce::CodeEditorComponent::defaultTextColourId,
                          DarkTheme::getTextColour());
     inputBox_->setColour(juce::CodeEditorComponent::lineNumberBackgroundId,

--- a/magda/daw/ui/windows/MainWindow.cpp
+++ b/magda/daw/ui/windows/MainWindow.cpp
@@ -45,6 +45,15 @@
 #include "engine/TracktionEngineWrapper.hpp"
 #include "project/ProjectManager.hpp"
 
+#if JUCE_WINDOWS
+#include <dwmapi.h>
+#include <windows.h>
+#pragma comment(lib, "dwmapi.lib")
+#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
+#endif
+
 namespace magda {
 
 // Non-blocking notification shown during device initialization
@@ -265,6 +274,20 @@ MainWindow::MainWindow(AudioEngine* audioEngine)
     juce::Logger::writeToLog("[MainWindow] Calling setVisible(true)...");
     setVisible(true);
     juce::Logger::writeToLog("[MainWindow] Window is now visible");
+
+#if JUCE_WINDOWS
+    // The native title bar (setUsingNativeTitleBar(true) above) renders with
+    // Windows' light chrome by default, which shows up as a white strip above
+    // MAGDA's dark UI. Opting the HWND into immersive dark mode makes DWM draw
+    // the title bar/frame dark to match.
+    if (auto* peer = getPeer()) {
+        if (auto hwnd = static_cast<HWND>(peer->getNativeHandle())) {
+            BOOL useDarkMode = TRUE;
+            DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &useDarkMode,
+                                  sizeof(useDarkMode));
+        }
+    }
+#endif
 
     // Listen for project changes to update window title
     ProjectManager::getInstance().addListener(this);


### PR DESCRIPTION
CodeEditorComponent forces setOpaque(true) in its constructor, so filling it with transparentBlack to let the panel behind show through was undefined depending on how the platform clips paint-behind-opaque-child. TextEditor (used for the chat history above it) never opts into opaque and composited fine, which is why only the input box broke. Paint the same solid BUTTON_NORMAL colour the panel uses instead of relying on transparency.