### PR TITLE
Feat: user-selectable UI font family (#92)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -342,6 +342,8 @@
     "scale.label": "UI Scale",
     "scale.auto": "Auto (from display DPI)",
     "font_scale.label": "Font Size",
+    "font_family.label": "UI Font",
+    "font_family.default": "Inter (default)",
     "tab.general": "General",
     "tab.appearance": "Appearance",
     "tab.colours": "Colours",

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -89,6 +89,7 @@ void Config::save() {
     root->setProperty("uiScale", uiScale);
     root->setProperty("theme", toJuceString(theme));
     root->setProperty("uiFontScale", uiFontScale);
+    root->setProperty("uiFontFamily", toJuceString(uiFontFamily));
     root->setProperty("localizedUIFontScale", localizedUIFontScale);
     root->setProperty("confirmTrackDelete", confirmTrackDelete);
     root->setProperty("duplicateLoopGrows", duplicateLoopGrows);
@@ -416,6 +417,7 @@ void Config::load() {
     uiScale = getDouble("uiScale", uiScale);
     setTheme(getString("theme", theme));
     setUIFontScale(getDouble("uiFontScale", uiFontScale));
+    setUIFontFamily(getString("uiFontFamily", uiFontFamily));
     localizedUIFontScaleExplicit = obj->hasProperty("localizedUIFontScale");
     if (localizedUIFontScaleExplicit)
         setLocalizedUIFontScale(getDouble("localizedUIFontScale", localizedUIFontScale));

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -223,6 +223,15 @@ class Config {
         uiFontScale = std::clamp(scale, 0.8, 1.5);
     }
 
+    // UI font family for MAGDA-owned text. Empty = the bundled Inter default;
+    // otherwise a system font family name that FontManager resolves.
+    const std::string& getUIFontFamily() const {
+        return uiFontFamily;
+    }
+    void setUIFontFamily(std::string family) {
+        uiFontFamily = std::move(family);
+    }
+
     // Extra font multiplier for UI text. This compounds with the global UI font scale.
     // English defaults to 100%; locale defaults can seed it higher for denser scripts.
     double getLocalizedUIFontScale() const {
@@ -1146,6 +1155,9 @@ class Config {
 
     // UI font scale: multiplier applied by FontManager to app-owned text fonts.
     double uiFontScale = 1.0;
+
+    // UI font family: empty = bundled Inter default; else a system family name.
+    std::string uiFontFamily;
 
     // Localized UI font scale: additional multiplier for non-English UI languages.
     double localizedUIFontScale = 1.0;

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -85,6 +85,46 @@ void setupSectionHeader(juce::Component& owner, juce::Label& header, const juce:
     owner.addAndMakeVisible(header);
 }
 
+void styleCombo(juce::ComboBox& combo) {
+    combo.setColour(juce::ComboBox::backgroundColourId,
+                    magda::DarkTheme::getColour(magda::DarkTheme::SURFACE));
+    combo.setColour(juce::ComboBox::textColourId,
+                    magda::DarkTheme::getColour(magda::DarkTheme::TEXT_PRIMARY));
+    combo.setColour(juce::ComboBox::outlineColourId,
+                    magda::DarkTheme::getColour(magda::DarkTheme::BORDER));
+}
+
+void setupComboLabel(juce::Component& owner, juce::Label& label, const juce::String& text) {
+    label.setText(text, juce::dontSendNotification);
+    label.setFont(magda::FontManager::getInstance().getUIFont(12.0f));
+    label.setColour(juce::Label::textColourId,
+                    magda::DarkTheme::getColour(magda::DarkTheme::TEXT_PRIMARY));
+    label.setJustificationType(juce::Justification::centredLeft);
+    owner.addAndMakeVisible(label);
+}
+
+void layoutTextSliderRow(juce::Rectangle<int>& bounds, juce::Label& label,
+                         magda::daw::ui::TextSlider& slider, int rowH, int sliderH) {
+    constexpr int sliderW = 96;
+    constexpr int gap = 12;
+    auto row = bounds.removeFromTop(rowH);
+    auto sliderArea = row.removeFromRight(sliderW);
+    row.removeFromRight(gap);
+    label.setBounds(row);
+    slider.setBounds(sliderArea.reduced(0, (rowH - sliderH) / 2));
+}
+
+void layoutComboRow(juce::Rectangle<int>& bounds, juce::Label& label, juce::ComboBox& combo,
+                    int rowH) {
+    const int comboW = juce::jlimit(160, 240, bounds.getWidth() / 2);
+    constexpr int gap = 12;
+    auto row = bounds.removeFromTop(rowH);
+    auto comboArea = row.removeFromRight(comboW);
+    row.removeFromRight(gap);
+    label.setBounds(row);
+    combo.setBounds(comboArea.reduced(0, 4));
+}
+
 juce::String trOr(const juce::String& key, const juce::String& fallback) {
     const auto translated = magda::tr(key);
     return translated == key ? fallback : translated;
@@ -187,7 +227,7 @@ class GeneralPage : public juce::Component {
                     tr("preferences.toggle.auto_crossfade_default"));
 
         setupSectionHeader(*this, languageHeader, tr("preferences.language.header"));
-        setupComboLabel(languageLabel, tr("preferences.language.label"));
+        setupComboLabel(*this, languageLabel, tr("preferences.language.label"));
         styleCombo(languageCombo);
         addAndMakeVisible(languageCombo);
 
@@ -212,19 +252,9 @@ class GeneralPage : public juce::Component {
             }
         };
 
-        setupSectionHeader(*this, scaleHeader, tr("preferences.section.scale"));
-        setupComboLabel(scaleLabel, tr("preferences.scale.label"));
-        styleCombo(scaleCombo);
-        scaleCombo.addItem(tr("preferences.scale.auto"), 1);
-        scaleCombo.addItem("100%", 2);
-        scaleCombo.addItem("125%", 3);
-        scaleCombo.addItem("150%", 4);
-        scaleCombo.addItem("175%", 5);
-        scaleCombo.addItem("200%", 6);
-        addAndMakeVisible(scaleCombo);
-
-        setupTextSlider(*this, fontScaleSlider, fontScaleLabel, tr("preferences.font_scale.label"),
-                        80.0, 150.0, 5.0, magda::TechnicalTextToken::Percent);
+        // Localized Font Size lives with Language: its default is language-driven
+        // (see languageCombo.onChange). UI Scale, UI Font, and Font Size moved to
+        // the Appearance tab.
         setupTextSlider(*this, localizedFontScaleSlider, localizedFontScaleLabel,
                         trOr("preferences.localized_font_scale.label", "Localized Font Size"),
                         100.0, 300.0, 5.0, magda::TechnicalTextToken::Percent);
@@ -313,8 +343,6 @@ class GeneralPage : public juce::Component {
         languageCombo.setSelectedId(selectedId, juce::dontSendNotification);
         restartHint.setVisible(false);
 
-        scaleCombo.setSelectedId(scaleIdForValue(config.getUIScale()), juce::dontSendNotification);
-        fontScaleSlider.setValue(config.getUIFontScale() * 100.0, juce::dontSendNotification);
         localizedFontScaleExplicit_ = config.hasExplicitLocalizedUIFontScale();
         localizedFontScaleSlider.setValue(config.getLocalizedUIFontScale() * 100.0,
                                           juce::dontSendNotification);
@@ -350,16 +378,6 @@ class GeneralPage : public juce::Component {
             }
         }
 
-        double newScale = scaleValueForId(scaleCombo.getSelectedId());
-        if (newScale > 0.0) {
-            applyUIScale(newScale);
-        } else {
-            applyUIScale(dpiOnlyAutoScale(), /*persist=*/false);
-            config.setUIScale(0.0);
-            config.save();
-        }
-
-        config.setUIFontScale(fontScaleSlider.getValue() / 100.0);
         config.setLocalizedUIFontScale(localizedFontScaleSlider.getValue() / 100.0);
     }
 
@@ -379,7 +397,7 @@ class GeneralPage : public juce::Component {
         return padding + headerH + 4 + (rowH * 3) + 8 + secGap + headerH + 4 + (rowH * 2) + 4 +
                secGap + headerH + 4 + rowH + secGap + headerH + 4 + rowH + 4 + rowH + secGap +
                headerH + 4 + rowH + secGap + headerH + 4 + (rowH * 7) + 16 + secGap + headerH + 4 +
-               rowH + 18 + secGap + headerH + 4 + (rowH * 3) + 8 + padding;
+               rowH + 18 + 4 + rowH + padding;
     }
 
     static int getLeftColumnPreferredHeight() {
@@ -388,11 +406,11 @@ class GeneralPage : public juce::Component {
         constexpr int headerH = 28;
         constexpr int secGap = 12;
 
-        return padding + headerH + 4 + (rowH * 3) + 8    // Zoom
-               + secGap + headerH + 4 + rowH             // Timeline
-               + secGap + headerH + 4 + rowH + 4 + rowH  // Transport
-               + secGap + headerH + 4 + rowH + 4 + rowH  // Auto-Save
-               + secGap + headerH + 4 + rowH + 18        // Language
+        return padding + headerH + 4 + (rowH * 3) + 8         // Zoom
+               + secGap + headerH + 4 + rowH                  // Timeline
+               + secGap + headerH + 4 + rowH + 4 + rowH       // Transport
+               + secGap + headerH + 4 + rowH + 4 + rowH       // Auto-Save
+               + secGap + headerH + 4 + rowH + 18 + 4 + rowH  // Language + Localized Font Size
                + padding;
     }
 
@@ -404,7 +422,6 @@ class GeneralPage : public juce::Component {
 
         return padding + headerH + 4 + rowH + 4 + rowH   // Layout
                + secGap + headerH + 4 + (rowH * 7) + 20  // Behaviour
-               + secGap + headerH + 4 + (rowH * 3)       // Display Scale
                + padding;
     }
 
@@ -475,14 +492,6 @@ class GeneralPage : public juce::Component {
         bounds.removeFromTop(4);
         layoutComboRow(bounds, languageLabel, languageCombo, rowH);
         restartHint.setBounds(bounds.removeFromTop(18));
-        bounds.removeFromTop(secGap);
-
-        // UI scale
-        scaleHeader.setBounds(bounds.removeFromTop(headerH));
-        bounds.removeFromTop(4);
-        layoutComboRow(bounds, scaleLabel, scaleCombo, rowH);
-        bounds.removeFromTop(4);
-        layoutTextSliderRow(bounds, fontScaleLabel, fontScaleSlider, rowH, sliderH);
         bounds.removeFromTop(4);
         layoutTextSliderRow(bounds, localizedFontScaleLabel, localizedFontScaleSlider, rowH,
                             sliderH);
@@ -534,6 +543,8 @@ class GeneralPage : public juce::Component {
         left.removeFromTop(4);
         layoutComboRow(left, languageLabel, languageCombo, rowH);
         restartHint.setBounds(left.removeFromTop(18));
+        left.removeFromTop(4);
+        layoutTextSliderRow(left, localizedFontScaleLabel, localizedFontScaleSlider, rowH, sliderH);
 
         // Layout
         layoutHeader.setBounds(right.removeFromTop(headerH));
@@ -561,88 +572,6 @@ class GeneralPage : public juce::Component {
         chordPreviewDefaultToggle.setBounds(right.removeFromTop(rowH).reduced(0, 4));
         right.removeFromTop(4);
         autoCrossfadeDefaultToggle.setBounds(right.removeFromTop(rowH).reduced(0, 4));
-        right.removeFromTop(secGap);
-
-        // Display Scale
-        scaleHeader.setBounds(right.removeFromTop(headerH));
-        right.removeFromTop(4);
-        layoutComboRow(right, scaleLabel, scaleCombo, rowH);
-        right.removeFromTop(4);
-        layoutTextSliderRow(right, fontScaleLabel, fontScaleSlider, rowH, sliderH);
-        right.removeFromTop(4);
-        layoutTextSliderRow(right, localizedFontScaleLabel, localizedFontScaleSlider, rowH,
-                            sliderH);
-    }
-
-    void setupComboLabel(juce::Label& label, const juce::String& text) {
-        label.setText(text, juce::dontSendNotification);
-        label.setFont(FontManager::getInstance().getUIFont(12.0f));
-        label.setColour(juce::Label::textColourId, DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
-        label.setJustificationType(juce::Justification::centredLeft);
-        addAndMakeVisible(label);
-    }
-
-    void styleCombo(juce::ComboBox& combo) {
-        combo.setColour(juce::ComboBox::backgroundColourId,
-                        DarkTheme::getColour(DarkTheme::SURFACE));
-        combo.setColour(juce::ComboBox::textColourId,
-                        DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
-        combo.setColour(juce::ComboBox::outlineColourId, DarkTheme::getColour(DarkTheme::BORDER));
-    }
-
-    static void layoutTextSliderRow(juce::Rectangle<int>& bounds, juce::Label& label,
-                                    magda::daw::ui::TextSlider& slider, int rowH, int sliderH) {
-        constexpr int sliderW = 96;
-        constexpr int gap = 12;
-        auto row = bounds.removeFromTop(rowH);
-        auto sliderArea = row.removeFromRight(sliderW);
-        row.removeFromRight(gap);
-        label.setBounds(row);
-        slider.setBounds(sliderArea.reduced(0, (rowH - sliderH) / 2));
-    }
-
-    static void layoutComboRow(juce::Rectangle<int>& bounds, juce::Label& label,
-                               juce::ComboBox& combo, int rowH) {
-        const int comboW = juce::jlimit(160, 240, bounds.getWidth() / 2);
-        constexpr int gap = 12;
-        auto row = bounds.removeFromTop(rowH);
-        auto comboArea = row.removeFromRight(comboW);
-        row.removeFromRight(gap);
-        label.setBounds(row);
-        combo.setBounds(comboArea.reduced(0, 4));
-    }
-
-    static int scaleIdForValue(double v) {
-        if (v <= 0.0)
-            return 1;
-        if (std::abs(v - 1.0) < 0.01)
-            return 2;
-        if (std::abs(v - 1.25) < 0.01)
-            return 3;
-        if (std::abs(v - 1.5) < 0.01)
-            return 4;
-        if (std::abs(v - 1.75) < 0.01)
-            return 5;
-        if (std::abs(v - 2.0) < 0.01)
-            return 6;
-        return 1;
-    }
-
-    static double scaleValueForId(int id) {
-        switch (id) {
-            case 2:
-                return 1.0;
-            case 3:
-                return 1.25;
-            case 4:
-                return 1.5;
-            case 5:
-                return 1.75;
-            case 6:
-                return 2.0;
-            default:
-                return 0.0;
-        }
     }
 
     juce::Label zoomHeader, timelineHeader, transportHeader, autoSaveHeader;
@@ -656,7 +585,7 @@ class GeneralPage : public juce::Component {
     juce::ToggleButton autoSaveToggle;
     magda::daw::ui::TextSlider autoSaveIntervalSlider;
     juce::Label autoSaveIntervalLabel;
-    juce::Label layoutHeader, behaviorHeader, languageHeader, scaleHeader;
+    juce::Label layoutHeader, behaviorHeader, languageHeader;
     juce::ToggleButton headersOnRightToggle;
     juce::ToggleButton autoHideScrollbarsToggle;
     juce::ToggleButton confirmTrackDeleteToggle, autoMonitorToggle, openMacrosOnSelectToggle;
@@ -670,10 +599,6 @@ class GeneralPage : public juce::Component {
     juce::Label restartHint;
     std::vector<juce::String> availableLanguages_;
     juce::String initialLanguage_;
-    juce::Label scaleLabel;
-    juce::ComboBox scaleCombo;
-    juce::Label fontScaleLabel;
-    magda::daw::ui::TextSlider fontScaleSlider;
     juce::Label localizedFontScaleLabel;
     magda::daw::ui::TextSlider localizedFontScaleSlider;
     bool localizedFontScaleExplicit_ = false;
@@ -724,6 +649,30 @@ class AppearancePage : public juce::Component {
             dir.revealToUser();
         };
         addAndMakeVisible(openThemesFolderButton);
+
+        // Display Scale: UI scale (DPI), UI font family, and global font size.
+        setupSectionHeader(*this, scaleHeader, tr("preferences.section.scale"));
+        setupComboLabel(*this, scaleLabel, tr("preferences.scale.label"));
+        styleCombo(scaleCombo);
+        scaleCombo.addItem(tr("preferences.scale.auto"), 1);
+        scaleCombo.addItem("100%", 2);
+        scaleCombo.addItem("125%", 3);
+        scaleCombo.addItem("150%", 4);
+        scaleCombo.addItem("175%", 5);
+        scaleCombo.addItem("200%", 6);
+        addAndMakeVisible(scaleCombo);
+
+        setupComboLabel(*this, fontFamilyLabel, trOr("preferences.font_family.label", "UI Font"));
+        styleCombo(fontFamilyCombo);
+        fontFamilyCombo.addItem(trOr("preferences.font_family.default", "Inter (default)"), 1);
+        fontFamilies_ = juce::Font::findAllTypefaceNames();
+        fontFamilies_.sort(true);
+        for (int i = 0; i < fontFamilies_.size(); ++i)
+            fontFamilyCombo.addItem(fontFamilies_[i], kFontFamilyIdBase + i);
+        addAndMakeVisible(fontFamilyCombo);
+
+        setupTextSlider(*this, fontScaleSlider, fontScaleLabel, tr("preferences.font_scale.label"),
+                        80.0, 150.0, 5.0, magda::TechnicalTextToken::Percent);
 
         setupSectionHeader(*this, coloursHeader, tr("preferences.section.track_colour_palette"));
 
@@ -782,8 +731,12 @@ class AppearancePage : public juce::Component {
         constexpr int headerH = 28;
         constexpr int colourRowH = 26;
 
-        return padding + headerH + 4 + 32 + 28 + 16 + headerH + 4 + 18 + 4 +
-               ((colourRowH + 2) * MAX_PALETTE_SIZE) + 4 + 24 + 16 + headerH + 4 + 32 + padding;
+        return padding + headerH + 4 + 32 + 28 + 16       // Theme
+               + headerH + 4 + 32 + 4 + 32 + 4 + 32 + 16  // Display Scale
+               + headerH + 4 + 18 + 4 + ((colourRowH + 2) * MAX_PALETTE_SIZE) + 4 + 24 +
+               16                  // Track colours
+               + headerH + 4 + 32  // Clip colours
+               + padding;
     }
 
     void lookAndFeelChanged() override {
@@ -792,13 +745,14 @@ class AppearancePage : public juce::Component {
         const auto surface = DarkTheme::getColour(DarkTheme::SURFACE);
         const auto border = DarkTheme::getColour(DarkTheme::BORDER);
 
-        for (auto* label : {&themeHeader, &coloursHeader, &colourHeaderLabel, &hexHeaderLabel,
-                            &nameHeaderLabel, &clipColourHeader})
+        for (auto* label : {&themeHeader, &scaleHeader, &coloursHeader, &colourHeaderLabel,
+                            &hexHeaderLabel, &nameHeaderLabel, &clipColourHeader})
             label->setColour(juce::Label::textColourId, secondary);
-        themeLabel.setColour(juce::Label::textColourId, primary);
-        clipColourModeLabel.setColour(juce::Label::textColourId, primary);
+        for (auto* label :
+             {&themeLabel, &scaleLabel, &fontFamilyLabel, &fontScaleLabel, &clipColourModeLabel})
+            label->setColour(juce::Label::textColourId, primary);
 
-        for (auto* combo : {&themeCombo, &clipColourModeCombo}) {
+        for (auto* combo : {&themeCombo, &scaleCombo, &fontFamilyCombo, &clipColourModeCombo}) {
             combo->setColour(juce::ComboBox::backgroundColourId, surface);
             combo->setColour(juce::ComboBox::textColourId, primary);
             combo->setColour(juce::ComboBox::outlineColourId, border);
@@ -840,6 +794,18 @@ class AppearancePage : public juce::Component {
             row.removeFromLeft(gap);
             openThemesFolderButton.setBounds(row.reduced(0, 2));
         }
+        bounds.removeFromTop(16);
+
+        // Display Scale
+        scaleHeader.setBounds(bounds.removeFromTop(headerH));
+        bounds.removeFromTop(4);
+        constexpr int rowH = 32;
+        constexpr int sliderH = 24;
+        layoutComboRow(bounds, scaleLabel, scaleCombo, rowH);
+        bounds.removeFromTop(4);
+        layoutComboRow(bounds, fontFamilyLabel, fontFamilyCombo, rowH);
+        bounds.removeFromTop(4);
+        layoutTextSliderRow(bounds, fontScaleLabel, fontScaleSlider, rowH, sliderH);
         bounds.removeFromTop(16);
 
         coloursHeader.setBounds(bounds.removeFromTop(headerH));
@@ -894,6 +860,11 @@ class AppearancePage : public juce::Component {
         rebuildThemeCombo();  // pick up any theme files added since construction
         themeCombo.setSelectedId(themeIdForValue(config.getTheme()), juce::dontSendNotification);
 
+        scaleCombo.setSelectedId(scaleIdForValue(config.getUIScale()), juce::dontSendNotification);
+        fontFamilyCombo.setSelectedId(fontFamilyIdForValue(config.getUIFontFamily()),
+                                      juce::dontSendNotification);
+        fontScaleSlider.setValue(config.getUIFontScale() * 100.0, juce::dontSendNotification);
+
         clearColourRows();
         const auto& palette = config.getTrackColourPalette();
         for (const auto& entry : palette)
@@ -905,6 +876,17 @@ class AppearancePage : public juce::Component {
 
     void applySettings(Config& config) {
         config.setTheme(themeValueForId(themeCombo.getSelectedId()));
+
+        const double newScale = scaleValueForId(scaleCombo.getSelectedId());
+        if (newScale > 0.0) {
+            applyUIScale(newScale);
+        } else {
+            applyUIScale(dpiOnlyAutoScale(), /*persist=*/false);
+            config.setUIScale(0.0);
+            config.save();
+        }
+        config.setUIFontFamily(fontFamilyValueForId(fontFamilyCombo.getSelectedId()));
+        config.setUIFontScale(fontScaleSlider.getValue() / 100.0);
 
         std::vector<Config::TrackColourEntry> palette;
         for (size_t i = 0; i < hexEditors_.size(); ++i) {
@@ -974,6 +956,57 @@ class AppearancePage : public juce::Component {
             if (id == option.comboId)
                 return option.themeId;
         return ThemeManager::kDarkThemeId;
+    }
+
+    // Display Scale id schemes. Font family: id 1 is "Inter (default)"; ids from
+    // kFontFamilyIdBase index into fontFamilies_.
+    static constexpr int kFontFamilyIdBase = 100;
+
+    int fontFamilyIdForValue(const std::string& family) const {
+        if (family.empty())
+            return 1;
+        const int idx = fontFamilies_.indexOf(juce::String(family));
+        return idx >= 0 ? kFontFamilyIdBase + idx : 1;
+    }
+
+    std::string fontFamilyValueForId(int id) const {
+        const int idx = id - kFontFamilyIdBase;
+        if (idx >= 0 && idx < fontFamilies_.size())
+            return fontFamilies_[idx].toStdString();
+        return {};  // "Inter (default)"
+    }
+
+    static int scaleIdForValue(double v) {
+        if (v <= 0.0)
+            return 1;
+        if (std::abs(v - 1.0) < 0.01)
+            return 2;
+        if (std::abs(v - 1.25) < 0.01)
+            return 3;
+        if (std::abs(v - 1.5) < 0.01)
+            return 4;
+        if (std::abs(v - 1.75) < 0.01)
+            return 5;
+        if (std::abs(v - 2.0) < 0.01)
+            return 6;
+        return 1;
+    }
+
+    static double scaleValueForId(int id) {
+        switch (id) {
+            case 2:
+                return 1.0;
+            case 3:
+                return 1.25;
+            case 4:
+                return 1.5;
+            case 5:
+                return 1.75;
+            case 6:
+                return 2.0;
+            default:
+                return 0.0;
+        }
     }
 
     // Exports the current selection's base table (dark/light) as a complete,
@@ -1163,6 +1196,16 @@ class AppearancePage : public juce::Component {
     std::vector<std::unique_ptr<juce::TextEditor>> nameEditors_;
     std::vector<std::unique_ptr<juce::TextButton>> deleteButtons_;
     juce::TextButton addColourButton;
+
+    // Display Scale controls (UI scale, UI font family, global font size).
+    juce::Label scaleHeader;
+    juce::Label scaleLabel;
+    juce::ComboBox scaleCombo;
+    juce::Label fontFamilyLabel;
+    juce::ComboBox fontFamilyCombo;
+    juce::StringArray fontFamilies_;  // system families, combo-order (id = base + index)
+    juce::Label fontScaleLabel;
+    magda::daw::ui::TextSlider fontScaleSlider;
 
     // Clip colour mode
     juce::Label clipColourHeader;

--- a/magda/daw/ui/themes/FontManager.cpp
+++ b/magda/daw/ui/themes/FontManager.cpp
@@ -30,6 +30,8 @@ bool FontManager::initialize() {
     if (!interRegular) {
         DBG("Failed to load Inter-Regular");
         success = false;
+    } else {
+        interFamily = interRegular->getName();
     }
 
     // Load Inter Medium
@@ -106,17 +108,39 @@ void FontManager::shutdown() {
     jetBrainsMonoRegular = nullptr;
     notoSansCJK = nullptr;
     notoSansCJKFamily = {};
+    interFamily = {};
     initialized = false;
 }
 
-juce::Font FontManager::withCJKFallback(juce::Font font) const {
+juce::Font FontManager::withScriptFallbacks(juce::Font font) const {
+    // Inter first (Latin/Cyrillic/Greek), then Noto Sans CJK (zh/ja/ko). This
+    // keeps every supported locale legible even when the primary is a
+    // user-selected system font that only covers Latin.
+    juce::StringArray fallbacks;
+    if (interFamily.isNotEmpty())
+        fallbacks.add(interFamily);
     if (notoSansCJKFamily.isNotEmpty())
-        font.setPreferredFallbackFamilies({notoSansCJKFamily});
+        fallbacks.add(notoSansCJKFamily);
+    if (!fallbacks.isEmpty())
+        font.setPreferredFallbackFamilies(fallbacks);
     return font;
 }
 
 juce::Font FontManager::getInterFont(float size, Weight weight) const {
     size = scaledFontSize(size);
+
+    // A user-selected UI font family overrides the bundled Inter typefaces.
+    // System families resolve by name and only carry plain/bold styles, so the
+    // four Inter weights collapse to plain (Regular/Medium) or bold
+    // (SemiBold/Bold). The CJK fallback still applies.
+    const auto& family = Config::getInstance().getUIFontFamily();
+    if (!family.empty()) {
+        const auto style = (weight == Weight::SemiBold || weight == Weight::Bold)
+                               ? juce::Font::bold
+                               : juce::Font::plain;
+        return withScriptFallbacks(juce::Font(juce::String(family), size, style));
+    }
+
     juce::Typeface* typeface = nullptr;
 
     switch (weight) {
@@ -135,7 +159,7 @@ juce::Font FontManager::getInterFont(float size, Weight weight) const {
     }
 
     if (typeface) {
-        return withCJKFallback(juce::Font(typeface).withHeight(size));
+        return withScriptFallbacks(juce::Font(typeface).withHeight(size));
     }
 
     // Fallback to system font
@@ -149,7 +173,7 @@ juce::Font FontManager::getInterFont(float size, Weight weight) const {
             break;
     }
 
-    return withCJKFallback(juce::Font(FALLBACK_FONT, size, style));
+    return withScriptFallbacks(juce::Font(FALLBACK_FONT, size, style));
 }
 
 juce::Font FontManager::getUIFont(float size) const {
@@ -179,21 +203,21 @@ juce::Font FontManager::getTimeFont(float size) const {
 juce::Font FontManager::getMicrogrammaFont(float size) const {
     size = scaledFontSize(size);
     if (microgrammaBold) {
-        return withCJKFallback(juce::Font(microgrammaBold).withHeight(size));
+        return withScriptFallbacks(juce::Font(microgrammaBold).withHeight(size));
     }
 
     // Fallback to monospace font if Microgramma isn't loaded
-    return withCJKFallback(
+    return withScriptFallbacks(
         juce::Font(juce::Font::getDefaultMonospacedFontName(), size, juce::Font::bold));
 }
 
 juce::Font FontManager::getMonoFont(float size) const {
     size = scaledFontSize(size);
     if (jetBrainsMonoRegular) {
-        return withCJKFallback(juce::Font(jetBrainsMonoRegular).withHeight(size));
+        return withScriptFallbacks(juce::Font(jetBrainsMonoRegular).withHeight(size));
     }
 
-    return withCJKFallback(
+    return withScriptFallbacks(
         juce::Font(juce::Font::getDefaultMonospacedFontName(), size, juce::Font::plain));
 }
 

--- a/magda/daw/ui/themes/FontManager.hpp
+++ b/magda/daw/ui/themes/FontManager.hpp
@@ -65,9 +65,15 @@ class FontManager {
     juce::Typeface::Ptr notoSansCJK;
     juce::String notoSansCJKFamily;
 
-    // Apply the CJK family as a fallback on the given font so characters not
-    // covered by the primary typeface are resolved via Noto Sans CJK.
-    juce::Font withCJKFallback(juce::Font font) const;
+    // Bundled Inter family name, used as a script fallback for user-selected UI
+    // fonts: Inter covers Latin, Cyrillic, Greek, and Vietnamese, so a Latin-only
+    // system font still renders Russian (and other supported locales) correctly.
+    juce::String interFamily;
+
+    // Apply the bundled fallback families to the given font so characters not
+    // covered by the primary typeface resolve via Inter (Latin/Cyrillic/Greek)
+    // then Noto Sans CJK (zh/ja/ko).
+    juce::Font withScriptFallbacks(juce::Font font) const;
 
     // Fallback system font name
     static constexpr const char* FALLBACK_FONT = "Helvetica";

--- a/magda/daw/ui/windows/MainWindow.cpp
+++ b/magda/daw/ui/windows/MainWindow.cpp
@@ -328,6 +328,20 @@ MainWindow::~MainWindow() {
 
 void MainWindow::configChanged() {
     applyThemeFromConfig();
+    applyFontFromConfig();
+}
+
+void MainWindow::applyFontFromConfig() {
+    const auto& family = Config::getInstance().getUIFontFamily();
+    if (family == appliedFontFamily_)
+        return;
+    appliedFontFamily_ = family;
+
+    // FontManager resolves the family live; broadcast a look-and-feel change so
+    // every component re-fetches its fonts and repaints. Components that fetch
+    // fonts in paint()/lookAndFeelChanged update immediately; the few that cache
+    // a juce::Font at construction pick it up on their next rebuild.
+    refreshThemedLookAndFeels();
 }
 
 void MainWindow::applyThemeFromConfig() {

--- a/magda/daw/ui/windows/MainWindow.hpp
+++ b/magda/daw/ui/windows/MainWindow.hpp
@@ -72,6 +72,9 @@ class MainWindow : public juce::DocumentWindow,
   private:
     void updateWindowTitle();
     void applyThemeFromConfig();
+    // Re-broadcasts a look-and-feel change when the UI font family changes, so
+    // components re-fetch fonts from FontManager and repaint.
+    void applyFontFromConfig();
     // Re-applies the active palette to every shared LookAndFeel and broadcasts
     // a look-and-feel change to all top-level windows. Shared by the config
     // switch and hot-reload.
@@ -85,6 +88,7 @@ class MainWindow : public juce::DocumentWindow,
     // File chooser for async file import
     std::unique_ptr<juce::FileChooser> fileChooser_;
     std::string appliedTheme_;
+    std::string appliedFontFamily_;
 
     // Hot-reload for user JSON themes: armed while a user theme is active,
     // idle for built-ins. activeThemeFile_ is the file currently watched.


### PR DESCRIPTION
Add a "UI Font" picker (Inter default + system families) persisted in Config and applied live via a look-and-feel broadcast.

Custom families fall back through Inter (Latin/Cyrillic/Greek) then Noto Sans CJK so every shipped locale stays legible even when the chosen font only covers Latin.

Move the Display Scale section (UI Scale, UI Font, Font Size) to the Appearance tab next to the theme picker; Localized Font Size stays under Language since its default is language-driven. Row/combo layout helpers promoted to file scope so both pages share them.