### PR TITLE
Advanced per-agent AI config panel + theme role (#1766)

### DIFF
--- a/magda/agents/theme_agent.cpp
+++ b/magda/agents/theme_agent.cpp
@@ -18,8 +18,6 @@ ThemeAgent::Result ThemeAgent::generate(const std::string& systemPrompt,
         return result;
     }
 
-    // Reuse the MUSIC role: the user already has it configured for creative
-    // generation, and a dedicated theme provider isn't warranted yet.
     auto agentConfig = Config::getInstance().getAgentLLMConfig(role::THEME);
     auto providerConfig = toLLMProviderConfig(agentConfig, "theme");
 

--- a/magda/agents/theme_agent.cpp
+++ b/magda/agents/theme_agent.cpp
@@ -20,7 +20,7 @@ ThemeAgent::Result ThemeAgent::generate(const std::string& systemPrompt,
 
     // Reuse the MUSIC role: the user already has it configured for creative
     // generation, and a dedicated theme provider isn't warranted yet.
-    auto agentConfig = Config::getInstance().getAgentLLMConfig(role::MUSIC);
+    auto agentConfig = Config::getInstance().getAgentLLMConfig(role::THEME);
     auto providerConfig = toLLMProviderConfig(agentConfig, "theme");
 
     if (providerConfig.apiKey.isEmpty() && agentConfig.baseUrl.empty() &&
@@ -62,7 +62,7 @@ ThemeAgent::Result ThemeAgent::generateStreaming(const std::string& systemPrompt
         return result;
     }
 
-    auto agentConfig = Config::getInstance().getAgentLLMConfig(role::MUSIC);
+    auto agentConfig = Config::getInstance().getAgentLLMConfig(role::THEME);
     auto providerConfig = toLLMProviderConfig(agentConfig, "theme");
 
     if (providerConfig.apiKey.isEmpty() && agentConfig.baseUrl.empty() &&

--- a/magda/agents/theme_agent.hpp
+++ b/magda/agents/theme_agent.hpp
@@ -18,8 +18,9 @@ namespace magda {
  * LLM round-trip + cancellation, so the agents library stays free of any UI
  * dependency. The caller supplies the (theme-specific) system prompt.
  *
- * Reuses role::MUSIC for the LLM config so users don't have to configure a
- * separate provider just to generate themes.
+ * Uses role::THEME for the LLM config so the theme agent's provider/model can
+ * be set independently in the Advanced AI config panel (defaults to the music
+ * tier for saved configs that predate the role).
  */
 class ThemeAgent {
   public:

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -473,6 +473,7 @@ void Config::load() {
             if (auto* agentsObj = agentsVar.getDynamicObject()) {
                 bool jsonHadController = false;
                 bool jsonHadMusic = false;
+                bool jsonHadTheme = false;
 
                 for (const auto& prop : agentsObj->getProperties()) {
                     auto role = prop.name.toString().toStdString();
@@ -498,14 +499,18 @@ void Config::load() {
                             jsonHadController = true;
                         if (role == "music")
                             jsonHadMusic = true;
+                        if (role == "theme")
+                            jsonHadTheme = true;
                     }
                 }
 
-                // Saved configs that predate the "controller" role need a live
-                // config. Clone music so the user's cloud setup carries over
-                // instead of leaving the class-default llama_local in place.
+                // Saved configs that predate the "controller"/"theme" roles need
+                // a live config. Clone music so the user's cloud setup carries
+                // over instead of leaving the class-default llama_local in place.
                 if (!jsonHadController && jsonHadMusic)
                     agentConfigs["controller"] = agentConfigs["music"];
+                if (!jsonHadTheme && jsonHadMusic)
+                    agentConfigs["theme"] = agentConfigs["music"];
             }
 
             // Local llama settings

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -1274,10 +1274,9 @@ class Config {
     // AI settings
     std::string aiPreset = "local_embedded";
     std::map<std::string, AgentLLMConfig> agentConfigs = {
-        {"router", {"llama_local", "", "", ""}},
-        {"command", {"llama_local", "", "", ""}},
-        {"music", {"llama_local", "", "", ""}},
-        {"controller", {"llama_local", "", "", ""}},
+        {"router", {"llama_local", "", "", ""}}, {"command", {"llama_local", "", "", ""}},
+        {"music", {"llama_local", "", "", ""}},  {"controller", {"llama_local", "", "", ""}},
+        {"theme", {"llama_local", "", "", ""}},
     };
     std::map<std::string, std::string> aiCredentials;  // provider → API key
     std::string localLlamaUrl = "http://127.0.0.1:8080/v1";

--- a/magda/daw/core/LLMClientProvider.cpp
+++ b/magda/daw/core/LLMClientProvider.cpp
@@ -98,11 +98,16 @@ llm::ProviderConfig toLLMProviderConfig(const Config::AgentLLMConfig& config,
 
     // Collapse Haiku to its dated snapshot (the id the API accepts). Opus and
     // Sonnet versions pass through as-is so per-agent Advanced-panel choices are
-    // honoured; Opus additionally rejects the temperature parameter.
+    // honoured.
     if (pc.model.startsWith("claude-haiku-"))
         pc.model = model::CLAUDE_HAIKU;
 
-    if (pc.model.startsWith("claude-opus-"))
+    // Gate temperature by API, not by model. The Anthropic Messages API and the
+    // OpenAI Responses API reject temperature outright (Fable 5, Sonnet 5, Opus,
+    // gpt-5, o-series...), so never send it there. OpenAI Chat Completions (plus
+    // its compatibles DeepSeek / OpenRouter / local llama-server) and Gemini
+    // both accept it, so it's left on for them.
+    if (providerEnum == llm::Provider::Anthropic || providerEnum == llm::Provider::OpenAIResponses)
         pc.noTemperature = true;
 
     if (isLocalServer) {

--- a/magda/daw/core/LLMClientProvider.cpp
+++ b/magda/daw/core/LLMClientProvider.cpp
@@ -96,11 +96,10 @@ llm::ProviderConfig toLLMProviderConfig(const Config::AgentLLMConfig& config,
     if (isLocalServer && pc.model.isEmpty())
         pc.model = juce::String(Config::getInstance().getLocalServerModel());
 
-    if (pc.model.startsWith("claude-opus-"))
-        pc.model = model::CLAUDE_OPUS;
-    else if (pc.model.startsWith("claude-sonnet-"))
-        pc.model = model::CLAUDE_SONNET;
-    else if (pc.model.startsWith("claude-haiku-"))
+    // Collapse Haiku to its dated snapshot (the id the API accepts). Opus and
+    // Sonnet versions pass through as-is so per-agent Advanced-panel choices are
+    // honoured; Opus additionally rejects the temperature parameter.
+    if (pc.model.startsWith("claude-haiku-"))
         pc.model = model::CLAUDE_HAIKU;
 
     if (pc.model.startsWith("claude-opus-"))

--- a/magda/daw/core/LLMClientProvider.hpp
+++ b/magda/daw/core/LLMClientProvider.hpp
@@ -33,25 +33,62 @@ inline constexpr const char* CLOUD_DEEPSEEK = "cloud_deepseek";
 inline constexpr const char* CLOUD_OPENROUTER = "cloud_openrouter";
 inline constexpr const char* HYBRID_SPEED = "hybrid_speed";
 inline constexpr const char* HYBRID_QUALITY = "hybrid_quality";
+// Sentinel: per-agent provider/model mapping set from the Advanced config
+// panel. Not a built-in preset — agent configs are persisted directly.
+inline constexpr const char* ADVANCED = "advanced";
 }  // namespace preset
 
 namespace model {
+// OpenAI (Chat Completions + Responses API). gpt-5* and the o-series route
+// through the Responses API; gpt-4.1* use Chat Completions.
 inline constexpr const char* GPT_4_1 = "gpt-4.1";
 inline constexpr const char* GPT_4_1_MINI = "gpt-4.1-mini";
 inline constexpr const char* GPT_5 = "gpt-5";
 inline constexpr const char* GPT_5_MINI = "gpt-5-mini";
 inline constexpr const char* GPT_5_NANO = "gpt-5-nano";
+inline constexpr const char* GPT_5_1 = "gpt-5.1";
+inline constexpr const char* GPT_5_2 = "gpt-5.2";
 inline constexpr const char* GPT_5_4 = "gpt-5.4";
+inline constexpr const char* GPT_5_4_MINI = "gpt-5.4-mini";
+inline constexpr const char* GPT_5_4_NANO = "gpt-5.4-nano";
+inline constexpr const char* GPT_5_4_PRO = "gpt-5.4-pro";
 inline constexpr const char* GPT_5_5 = "gpt-5.5";
+inline constexpr const char* GPT_5_5_PRO = "gpt-5.5-pro";
+inline constexpr const char* GPT_5_6_SOL = "gpt-5.6-sol";
+inline constexpr const char* GPT_5_6_TERRA = "gpt-5.6-terra";
+inline constexpr const char* GPT_5_6_LUNA = "gpt-5.6-luna";
+inline constexpr const char* O3 = "o3";
+inline constexpr const char* O3_PRO = "o3-pro";
+
+// Anthropic (Claude). Dateless ids are pinned snapshots (4.6 generation onward).
+inline constexpr const char* CLAUDE_FABLE_5 = "claude-fable-5";
 inline constexpr const char* CLAUDE_OPUS_4_7 = "claude-opus-4-7";
 inline constexpr const char* CLAUDE_OPUS_4_8 = "claude-opus-4-8";
 inline constexpr const char* CLAUDE_OPUS = CLAUDE_OPUS_4_8;
-inline constexpr const char* CLAUDE_SONNET = "claude-sonnet-4-6";
+inline constexpr const char* CLAUDE_SONNET_5 = "claude-sonnet-5";
+inline constexpr const char* CLAUDE_SONNET_4_6 = "claude-sonnet-4-6";
+inline constexpr const char* CLAUDE_SONNET = CLAUDE_SONNET_4_6;  // preset default
 inline constexpr const char* CLAUDE_HAIKU = "claude-haiku-4-5-20251001";
-inline constexpr const char* GEMINI_FLASH = "gemini-2.0-flash";
-inline constexpr const char* GEMINI_PRO = "gemini-2.5-pro";
-inline constexpr const char* DEEPSEEK_CHAT = "deepseek-chat";
-inline constexpr const char* DEEPSEEK_REASONER = "deepseek-reasoner";
+
+// Google Gemini. gemini-2.0-flash was shut down 2026-06-01, so GEMINI_FLASH
+// now aliases the 2.5 flash baseline.
+inline constexpr const char* GEMINI_3_5_FLASH = "gemini-3.5-flash";
+inline constexpr const char* GEMINI_3_1_PRO = "gemini-3.1-pro";
+inline constexpr const char* GEMINI_3_1_FLASH = "gemini-3.1-flash";
+inline constexpr const char* GEMINI_3_1_FLASH_LITE = "gemini-3.1-flash-lite";
+inline constexpr const char* GEMINI_2_5_PRO = "gemini-2.5-pro";
+inline constexpr const char* GEMINI_2_5_FLASH = "gemini-2.5-flash";
+inline constexpr const char* GEMINI_FLASH = GEMINI_2_5_FLASH;
+inline constexpr const char* GEMINI_PRO = GEMINI_2_5_PRO;
+
+// DeepSeek. The legacy deepseek-chat / deepseek-reasoner ids are deprecated
+// (2026-07-24); DEEPSEEK_CHAT / DEEPSEEK_REASONER now alias the V4 ids.
+inline constexpr const char* DEEPSEEK_V4_FLASH = "deepseek-v4-flash";
+inline constexpr const char* DEEPSEEK_V4_PRO = "deepseek-v4-pro";
+inline constexpr const char* DEEPSEEK_CHAT = DEEPSEEK_V4_FLASH;
+inline constexpr const char* DEEPSEEK_REASONER = DEEPSEEK_V4_PRO;
+
+// OpenRouter (routes to many hosted models; the model field is free-text).
 inline constexpr const char* LLAMA_70B = "meta-llama/llama-3.3-70b-instruct";
 }  // namespace model
 

--- a/magda/daw/core/LLMClientProvider.hpp
+++ b/magda/daw/core/LLMClientProvider.hpp
@@ -97,6 +97,7 @@ inline constexpr const char* ROUTER = "router";
 inline constexpr const char* COMMAND = "command";
 inline constexpr const char* MUSIC = "music";
 inline constexpr const char* CONTROLLER = "controller";
+inline constexpr const char* THEME = "theme";
 }  // namespace role
 
 std::string normalizeOpenAIBaseUrl(std::string url);

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -1003,11 +1003,12 @@ class AISettingsDialog::ConfigPage : public juce::Component {
                                      DarkTheme::getColour(DarkTheme::TEXT_DIM));
         addAndMakeVisible(advancedHintLabel_);
 
-        static constexpr std::array<std::pair<const char*, const char*>, 4> kRoles = {{
+        static constexpr std::array<std::pair<const char*, const char*>, 5> kRoles = {{
             {magda::role::ROUTER, "Router"},
             {magda::role::COMMAND, "Command"},
             {magda::role::MUSIC, "Music"},
             {magda::role::CONTROLLER, "Controller"},
+            {magda::role::THEME, "Theme"},
         }};
         for (size_t i = 0; i < agentRows_.size(); ++i) {
             auto& r = agentRows_[i];
@@ -1527,6 +1528,10 @@ class AISettingsDialog::ConfigPage : public juce::Component {
                 out[magda::role::COMMAND] = cmdLocal;
             }
         }
+        // Theme is not part of the built-in presets — default it to the music
+        // tier (creative, structured-JSON generation, same as themes).
+        if (auto it = out.find(magda::role::MUSIC); it != out.end())
+            out[magda::role::THEME] = it->second;
         return out;
     }
 
@@ -1643,7 +1648,7 @@ class AISettingsDialog::ConfigPage : public juce::Component {
 
     // Advanced per-agent grid (AgentRow defined near the top of the class).
     juce::Label advancedHintLabel_;
-    std::array<AgentRow, 4> agentRows_;
+    std::array<AgentRow, 5> agentRows_;
 
     // MCP Tools
     juce::Label mcpSectionLabel_;

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -2,6 +2,9 @@
 
 #include <juce_llm/juce_llm.h>
 
+#include <array>
+#include <utility>
+
 #include "../../../agents/llama_model_manager.hpp"
 #include "../../../agents/llm_config_utils.hpp"
 #include "../../../agents/llm_presets.hpp"
@@ -84,6 +87,31 @@ const ProviderInfo* findProviderInfo(const std::string& id) {
         if (p.id == id)
             return &p;
     return nullptr;
+}
+
+// Known model ids offered per provider in the Advanced grid. The model combos
+// stay editable, so this is a convenience list, not a hard constraint. Local
+// providers return {} — embedded uses the loaded GGUF, local-server models are
+// entered/probed on the Config Local-server picker.
+std::vector<juce::String> knownModelsForProvider(const std::string& providerId) {
+    namespace m = magda::model;
+    if (providerId == magda::provider::OPENAI_CHAT ||
+        providerId == magda::provider::OPENAI_RESPONSES)
+        return {m::GPT_5_6_SOL, m::GPT_5_6_TERRA, m::GPT_5_6_LUNA, m::GPT_5_5_PRO,  m::GPT_5_5,
+                m::GPT_5_4_PRO, m::GPT_5_4,       m::GPT_5_4_MINI, m::GPT_5_4_NANO, m::GPT_5_2,
+                m::GPT_5_1,     m::GPT_5,         m::GPT_5_MINI,   m::GPT_5_NANO,   m::O3_PRO,
+                m::O3,          m::GPT_4_1,       m::GPT_4_1_MINI};
+    if (providerId == magda::provider::ANTHROPIC)
+        return {m::CLAUDE_FABLE_5,  m::CLAUDE_OPUS_4_8,   m::CLAUDE_OPUS_4_7,
+                m::CLAUDE_SONNET_5, m::CLAUDE_SONNET_4_6, m::CLAUDE_HAIKU};
+    if (providerId == magda::provider::GEMINI)
+        return {m::GEMINI_3_5_FLASH,      m::GEMINI_3_1_PRO, m::GEMINI_3_1_FLASH,
+                m::GEMINI_3_1_FLASH_LITE, m::GEMINI_2_5_PRO, m::GEMINI_2_5_FLASH};
+    if (providerId == magda::provider::DEEPSEEK)
+        return {m::DEEPSEEK_V4_PRO, m::DEEPSEEK_V4_FLASH};
+    if (providerId == magda::provider::OPENROUTER)
+        return {m::LLAMA_70B};
+    return {};
 }
 
 // Result of probing an OpenAI-compatible server's GET /v1/models endpoint.
@@ -852,7 +880,32 @@ class AISettingsDialog::ConfigPage : public juce::Component {
     CloudPage* cloudPage = nullptr;
     LocalPage* localPage = nullptr;
 
+    // One Advanced-grid row per agent role.
+    struct AgentRow {
+        std::string role;
+        juce::Label nameLabel;
+        juce::ComboBox providerCombo;
+        juce::ComboBox modelCombo;
+        std::vector<std::string> providerIds;  // parallels providerCombo items
+    };
+
     ConfigPage() {
+        // Setup selector: Simple (preset) / Advanced (per-agent grid)
+        setupLabel_.setText("Setup", juce::dontSendNotification);
+        styleLabel(setupLabel_);
+        addAndMakeVisible(setupLabel_);
+
+        setupCombo_.addItem("Simple", 1);
+        setupCombo_.addItem("Advanced", 2);
+        setupCombo_.setSelectedId(1, juce::dontSendNotification);
+        styleCombo(setupCombo_);
+        setupCombo_.onChange = [this]() {
+            if (setupCombo_.getSelectedId() == 2)
+                seedAdvancedFromSimple();
+            updateSetupUI();
+        };
+        addAndMakeVisible(setupCombo_);
+
         // Mode selector: Local / Cloud / Hybrid
         modeLabel_.setText("Mode", juce::dontSendNotification);
         styleLabel(modeLabel_);
@@ -940,6 +993,40 @@ class AISettingsDialog::ConfigPage : public juce::Component {
         faustMcpHint_.setColour(juce::Label::textColourId,
                                 DarkTheme::getColour(DarkTheme::TEXT_DIM));
         addAndMakeVisible(faustMcpHint_);
+
+        // Advanced per-agent grid: one row per agent role.
+        advancedHintLabel_.setText("Each agent uses its own provider and model. "
+                                   "Providers come from the Cloud and Local tabs.",
+                                   juce::dontSendNotification);
+        advancedHintLabel_.setFont(FontManager::getInstance().getUIFont(10.5f));
+        advancedHintLabel_.setColour(juce::Label::textColourId,
+                                     DarkTheme::getColour(DarkTheme::TEXT_DIM));
+        addAndMakeVisible(advancedHintLabel_);
+
+        static constexpr std::array<std::pair<const char*, const char*>, 4> kRoles = {{
+            {magda::role::ROUTER, "Router"},
+            {magda::role::COMMAND, "Command"},
+            {magda::role::MUSIC, "Music"},
+            {magda::role::CONTROLLER, "Controller"},
+        }};
+        for (size_t i = 0; i < agentRows_.size(); ++i) {
+            auto& r = agentRows_[i];
+            r.role = kRoles[i].first;
+            r.nameLabel.setText(kRoles[i].second, juce::dontSendNotification);
+            styleLabel(r.nameLabel);
+            addAndMakeVisible(r.nameLabel);
+
+            styleCombo(r.providerCombo);
+            AgentRow* rp = &r;
+            r.providerCombo.onChange = [this, rp]() { fillRowModel(*rp, {}); };
+            addAndMakeVisible(r.providerCombo);
+
+            r.modelCombo.setEditableText(true);
+            styleCombo(r.modelCombo);
+            addAndMakeVisible(r.modelCombo);
+        }
+
+        updateSetupUI();
     }
 
     void resized() override {
@@ -947,6 +1034,26 @@ class AISettingsDialog::ConfigPage : public juce::Component {
         const int rowH = 28;
         const int labelW = 80;
 
+        // Setup row (always visible)
+        auto row = bounds.removeFromTop(rowH);
+        setupLabel_.setBounds(row.removeFromLeft(labelW));
+        setupCombo_.setBounds(row.removeFromLeft(160).reduced(0, 2));
+        bounds.removeFromTop(8);
+
+        if (setupCombo_.getSelectedId() == 2)
+            layoutAdvanced(bounds);
+        else
+            layoutSimple(bounds, rowH, labelW);
+
+        // MCP Tools section
+        bounds.removeFromTop(16);
+        mcpSectionLabel_.setBounds(bounds.removeFromTop(22));
+        bounds.removeFromTop(4);
+        faustMcpToggle_.setBounds(bounds.removeFromTop(24));
+        faustMcpHint_.setBounds(bounds.removeFromTop(18).withTrimmedLeft(24));
+    }
+
+    void layoutSimple(juce::Rectangle<int>& bounds, int rowH, int labelW) {
         // Mode row
         auto row = bounds.removeFromTop(rowH);
         modeLabel_.setBounds(row.removeFromLeft(labelW));
@@ -986,13 +1093,24 @@ class AISettingsDialog::ConfigPage : public juce::Component {
             optimizeLabel_.setBounds(row.removeFromLeft(labelW));
             optimizeCombo_.setBounds(row.reduced(0, 2));
         }
+    }
 
-        // MCP Tools section
-        bounds.removeFromTop(16);
-        mcpSectionLabel_.setBounds(bounds.removeFromTop(22));
+    void layoutAdvanced(juce::Rectangle<int>& bounds) {
+        const int rowH = 28;
+        const int nameW = 84;
+        const int providerW = 150;
+
+        advancedHintLabel_.setBounds(bounds.removeFromTop(18));
         bounds.removeFromTop(4);
-        faustMcpToggle_.setBounds(bounds.removeFromTop(24));
-        faustMcpHint_.setBounds(bounds.removeFromTop(18).withTrimmedLeft(24));
+
+        for (auto& r : agentRows_) {
+            auto row = bounds.removeFromTop(rowH);
+            r.nameLabel.setBounds(row.removeFromLeft(nameW));
+            r.providerCombo.setBounds(row.removeFromLeft(providerW).reduced(0, 2));
+            row.removeFromLeft(6);
+            r.modelCombo.setBounds(row.reduced(0, 2));
+            bounds.removeFromTop(4);
+        }
     }
 
     void refreshProviderCombos() {
@@ -1019,12 +1137,144 @@ class AISettingsDialog::ConfigPage : public juce::Component {
             providerCombo_.setSelectedId(providerCombo_.getItemId(0), juce::dontSendNotification);
     }
 
+    // Provider options offered in the Advanced grid: configured cloud
+    // providers (from the Cloud tab) plus the two local sources.
+    std::vector<std::pair<std::string, juce::String>> advancedProviderOptions() const {
+        std::vector<std::pair<std::string, juce::String>> opts;
+        if (cloudPage) {
+            for (const auto& pid : cloudPage->getConfiguredProviders())
+                if (auto* info = findProviderInfo(pid))
+                    opts.emplace_back(pid, juce::String(info->displayName));
+        }
+        opts.emplace_back(magda::provider::LLAMA_LOCAL, juce::String("Local (Embedded)"));
+        opts.emplace_back(magda::provider::LOCAL_SERVER, juce::String("Local Server"));
+        return opts;
+    }
+
+    std::string rowProviderId(const AgentRow& row) const {
+        int idx = row.providerCombo.getSelectedId() - 1;
+        if (idx >= 0 && idx < static_cast<int>(row.providerIds.size()))
+            return row.providerIds[static_cast<size_t>(idx)];
+        return {};
+    }
+
+    // Select the combo item matching a provider id. openai_responses and
+    // openai_chat share one "OpenAI" entry, so they map interchangeably.
+    void selectRowProviderById(AgentRow& row, std::string id) {
+        if (id == magda::provider::OPENAI_RESPONSES)
+            id = magda::provider::OPENAI_CHAT;
+        for (size_t i = 0; i < row.providerIds.size(); ++i) {
+            auto cand = row.providerIds[i];
+            if (cand == magda::provider::OPENAI_RESPONSES)
+                cand = magda::provider::OPENAI_CHAT;
+            if (cand == id) {
+                row.providerCombo.setSelectedId(static_cast<int>(i) + 1,
+                                                juce::dontSendNotification);
+                return;
+            }
+        }
+        if (!row.providerIds.empty())
+            row.providerCombo.setSelectedId(1, juce::dontSendNotification);
+    }
+
+    // Fill a row's model combo from the selected provider's catalogue. Embedded
+    // has no model to pick; local-server falls back to the shared model id.
+    void fillRowModel(AgentRow& row, const juce::String& desiredModel) {
+        auto pid = rowProviderId(row);
+        row.modelCombo.clear(juce::dontSendNotification);
+        if (pid == magda::provider::LLAMA_LOCAL) {
+            row.modelCombo.setText("", juce::dontSendNotification);
+            row.modelCombo.setEnabled(false);
+            return;
+        }
+        row.modelCombo.setEnabled(true);
+        int id = 1;
+        for (const auto& m : knownModelsForProvider(pid))
+            row.modelCombo.addItem(m, id++);
+
+        juce::String want = desiredModel;
+        if (want.isEmpty() && pid == magda::provider::LOCAL_SERVER)
+            want = juce::String(Config::getInstance().getLocalServerModel());
+        if (want.isNotEmpty())
+            row.modelCombo.setText(want, juce::dontSendNotification);
+        else if (row.modelCombo.getNumItems() > 0)
+            row.modelCombo.setSelectedId(1, juce::dontSendNotification);
+    }
+
+    // Rebuild every row's provider combo from the current configured
+    // providers, preserving each row's provider + model selection.
+    void refreshAgentProviderCombos() {
+        auto opts = advancedProviderOptions();
+        for (auto& row : agentRows_) {
+            auto prevProvider = rowProviderId(row);
+            auto prevModel = row.modelCombo.getText();
+            row.providerCombo.clear(juce::dontSendNotification);
+            row.providerIds.clear();
+            int itemId = 1;
+            for (const auto& [pid, disp] : opts) {
+                row.providerCombo.addItem(disp, itemId++);
+                row.providerIds.push_back(pid);
+            }
+            selectRowProviderById(row, prevProvider);
+            fillRowModel(row, prevModel);
+        }
+    }
+
+    // Seed the Advanced grid from whatever the Simple UI currently resolves to,
+    // so switching to Advanced starts from a known baseline.
+    void seedAdvancedFromSimple() {
+        refreshAgentProviderCombos();
+        std::string presetId;
+        auto cfgs = computeSimpleConfigs(presetId);
+        for (auto& row : agentRows_) {
+            auto it = cfgs.find(row.role);
+            if (it == cfgs.end())
+                continue;
+            selectRowProviderById(row, it->second.provider);
+            fillRowModel(row, juce::String(it->second.model));
+        }
+    }
+
+    // Toggle Simple vs Advanced control visibility.
+    void updateSetupUI() {
+        const bool advanced = (setupCombo_.getSelectedId() == 2);
+
+        modeLabel_.setVisible(!advanced);
+        modeCombo_.setVisible(!advanced);
+        if (advanced) {
+            providerLabel_.setVisible(false);
+            providerCombo_.setVisible(false);
+            optimizeLabel_.setVisible(false);
+            optimizeCombo_.setVisible(false);
+            localSourceLabel_.setVisible(false);
+            localSourceCombo_.setVisible(false);
+            modelNameLabel_.setVisible(false);
+            serverModelLabel_.setVisible(false);
+            serverModelCombo_.setVisible(false);
+            serverRefreshBtn_.setVisible(false);
+            serverStatusLabel_.setVisible(false);
+        }
+
+        advancedHintLabel_.setVisible(advanced);
+        for (auto& row : agentRows_) {
+            row.nameLabel.setVisible(advanced);
+            row.providerCombo.setVisible(advanced);
+            row.modelCombo.setVisible(advanced);
+        }
+
+        if (!advanced)
+            updateModeUI();  // restores Simple sub-visibility and calls resized()
+        else
+            resized();
+    }
+
     // Called when the Config tab becomes visible: re-pull provider combos from
     // the Cloud page and refresh the local-server summary from the Local page's
     // live selection.
     void refreshOnShow() {
         refreshProviderCombos();
-        if (modeCombo_.getSelectedId() == 1)
+        refreshAgentProviderCombos();
+        if (setupCombo_.getSelectedId() != 2 && modeCombo_.getSelectedId() == 1)
             updateLocalModelLabel();
     }
 
@@ -1040,7 +1290,12 @@ class AISettingsDialog::ConfigPage : public juce::Component {
         }
         faustMcpToggle_.setToggleState(faustMcpEnabled, juce::dontSendNotification);
 
-        // Determine mode from preset
+        const bool advanced = (presetId == magda::preset::ADVANCED);
+        setupCombo_.setSelectedId(advanced ? 2 : 1, juce::dontSendNotification);
+
+        // Determine mode from preset (also seeds the Simple baseline used if the
+        // user switches back from Advanced; an "advanced" preset falls through
+        // to the Cloud branch below).
         if (presetId.starts_with("local") || presetId == magda::preset::LOCAL_EMBEDDED) {
             modeCombo_.setSelectedId(1, juce::dontSendNotification);
             localSourceCombo_.setSelectedId(presetId == magda::preset::LOCAL_SERVER ? 2 : 1,
@@ -1081,8 +1336,21 @@ class AISettingsDialog::ConfigPage : public juce::Component {
         serverModelCombo_.setText(juce::String(config.getLocalServerModel()),
                                   juce::dontSendNotification);
 
+        if (advanced)
+            loadAdvanced(config);
+
         updateLocalModelLabel();
-        updateModeUI();
+        updateSetupUI();
+    }
+
+    // Seed the Advanced grid from the persisted per-agent configs.
+    void loadAdvanced(Config& config) {
+        refreshAgentProviderCombos();
+        for (auto& row : agentRows_) {
+            auto cfg = config.getAgentLLMConfig(row.role);
+            selectRowProviderById(row, cfg.provider);
+            fillRowModel(row, juce::String(cfg.model));
+        }
     }
 
     // Embedded-GGUF summary (the local-server source uses the model combo, not
@@ -1142,7 +1410,15 @@ class AISettingsDialog::ConfigPage : public juce::Component {
     }
 
     void apply(Config& config) {
-        // MCP servers
+        applyMcp(config);
+        if (setupCombo_.getSelectedId() == 2)
+            applyAdvanced(config);
+        else
+            applySimple(config);
+    }
+
+  private:
+    void applyMcp(Config& config) {
         auto mcpServers = config.getMCPServers();
         bool wantFaustMcp = faustMcpToggle_.getToggleState();
 
@@ -1164,72 +1440,89 @@ class AISettingsDialog::ConfigPage : public juce::Component {
             mcpServers.push_back(std::move(srv));
         }
         config.setMCPServers(mcpServers);
+    }
 
+    void applySimple(Config& config) {
+        std::string presetId;
+        auto cfgs = computeSimpleConfigs(presetId);
+        config.setAIPreset(presetId);
+        for (const auto& [role, cfg] : cfgs)
+            config.setAgentLLMConfig(role, cfg);
+        // Persist the chosen local-server model (this tab owns it).
+        if (modeCombo_.getSelectedId() == 1 && localSourceCombo_.getSelectedId() == 2)
+            config.setLocalServerModel(serverModelCombo_.getText().trim().toStdString());
+    }
+
+    void applyAdvanced(Config& config) {
+        for (auto& row : agentRows_) {
+            Config::AgentLLMConfig cfg;
+            auto pid = rowProviderId(row);
+            auto model = row.modelCombo.getText().trim();
+            // OpenAI: gpt-5* requires the Responses API provider; others (and
+            // gpt-4.1) use the Chat provider.
+            if (pid == magda::provider::OPENAI_CHAT && model.startsWith("gpt-5"))
+                pid = magda::provider::OPENAI_RESPONSES;
+            cfg.provider = pid;
+            cfg.model = (pid == magda::provider::LLAMA_LOCAL) ? std::string{} : model.toStdString();
+            // apiKey left empty — resolved from Cloud-tab credentials at request
+            // time (per-agent key first, then per-provider credential).
+            config.setAgentLLMConfig(row.role, cfg);
+        }
+        config.setAIPreset(magda::preset::ADVANCED);
+    }
+
+    // Resolve the Simple UI selections into per-agent configs without writing to
+    // Config. Returns the preset id via outPresetId. Shared by applySimple and
+    // by seedAdvancedFromSimple.
+    std::map<std::string, Config::AgentLLMConfig> computeSimpleConfigs(std::string& outPresetId) {
+        std::map<std::string, Config::AgentLLMConfig> out;
         int mode = modeCombo_.getSelectedId();
         auto presetId = providerDisplayToPresetId(providerCombo_.getText());
         auto optimize = optimizeCombo_.getText();
 
         if (mode == 1) {
             // Local: embedded GGUF or OpenAI-compatible server.
-            const std::string localPresetId = (localSourceCombo_.getSelectedId() == 2)
-                                                  ? magda::preset::LOCAL_SERVER
-                                                  : magda::preset::LOCAL_EMBEDDED;
-            config.setAIPreset(localPresetId);
-            auto* preset = magda::findPreset(localPresetId);
-            if (preset)
+            outPresetId = (localSourceCombo_.getSelectedId() == 2) ? magda::preset::LOCAL_SERVER
+                                                                   : magda::preset::LOCAL_EMBEDDED;
+            if (auto* preset = magda::findPreset(outPresetId))
                 for (const auto& [role, cfg] : preset->agents)
-                    config.setAgentLLMConfig(role, cfg);
-            // Persist the chosen local-server model (this tab owns it).
-            if (localSourceCombo_.getSelectedId() == 2)
-                config.setLocalServerModel(serverModelCombo_.getText().trim().toStdString());
+                    out[role] = cfg;
         } else if (mode == 2) {
             // Cloud
-            config.setAIPreset(presetId);
-
-            auto* preset = magda::findPreset(presetId);
-            if (preset) {
+            outPresetId = presetId;
+            if (auto* preset = magda::findPreset(presetId)) {
                 for (const auto& [role, presetCfg] : preset->agents) {
                     auto cfg = presetCfg;
                     cfg.apiKey = "";
-                    config.setAgentLLMConfig(role, cfg);
+                    out[role] = cfg;
                 }
             }
-
-            // Cost optimization: use cheaper model for router only
-            // (command needs the full model for CFG/Responses API)
-            if (optimize == "Cost") {
-                auto routerCfg = config.getAgentLLMConfig(magda::role::ROUTER);
-                applyCheaperModel(routerCfg, presetId);
-                config.setAgentLLMConfig(magda::role::ROUTER, routerCfg);
-            }
+            // Cost: cheaper model for router only (command needs the full model
+            // for CFG/Responses API).
+            if (optimize == "Cost")
+                applyCheaperModel(out[magda::role::ROUTER], presetId);
         } else {
-            // Hybrid
-            std::string hybridPresetId =
+            // Hybrid: router always local; music + controller cloud; command
+            // cloud for speed, local for cost.
+            outPresetId =
                 optimize == "Speed" ? magda::preset::HYBRID_SPEED : magda::preset::HYBRID_QUALITY;
-            config.setAIPreset(hybridPresetId);
 
-            // Router is always local
             Config::AgentLLMConfig localCfg;
             localCfg.provider = magda::provider::LLAMA_LOCAL;
-            config.setAgentLLMConfig(magda::role::ROUTER, localCfg);
-
-            // Music always uses cloud
-            auto musicCfg = makeCloudConfig(magda::role::MUSIC, presetId);
-            config.setAgentLLMConfig(magda::role::MUSIC, musicCfg);
-
-            // Command: cloud for speed, local for cost
+            out[magda::role::ROUTER] = localCfg;
+            out[magda::role::MUSIC] = makeCloudConfig(magda::role::MUSIC, presetId);
+            out[magda::role::CONTROLLER] = makeCloudConfig(magda::role::CONTROLLER, presetId);
             if (optimize == "Speed") {
-                auto cmdCfg = makeCloudConfig(magda::role::COMMAND, presetId);
-                config.setAgentLLMConfig(magda::role::COMMAND, cmdCfg);
+                out[magda::role::COMMAND] = makeCloudConfig(magda::role::COMMAND, presetId);
             } else {
                 Config::AgentLLMConfig cmdLocal;
                 cmdLocal.provider = magda::provider::LLAMA_LOCAL;
-                config.setAgentLLMConfig(magda::role::COMMAND, cmdLocal);
+                out[magda::role::COMMAND] = cmdLocal;
             }
         }
+        return out;
     }
 
-  private:
     void updateModeUI() {
         int mode = modeCombo_.getSelectedId();
         bool isLocal = (mode == 1);
@@ -1321,6 +1614,10 @@ class AISettingsDialog::ConfigPage : public juce::Component {
         // openrouter: keep default
     }
 
+    // Setup selector: Simple (preset) vs Advanced (per-agent grid)
+    juce::Label setupLabel_;
+    juce::ComboBox setupCombo_;
+
     juce::Label modeLabel_;
     juce::ComboBox modeCombo_;
     juce::Label providerLabel_;
@@ -1336,6 +1633,10 @@ class AISettingsDialog::ConfigPage : public juce::Component {
     juce::TextButton serverRefreshBtn_;
     juce::String savedProviderDisplay_;
     juce::String savedOptimize_ = "Quality";
+
+    // Advanced per-agent grid (AgentRow defined near the top of the class).
+    juce::Label advancedHintLabel_;
+    std::array<AgentRow, 4> agentRows_;
 
     // MCP Tools
     juce::Label mcpSectionLabel_;

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -1022,7 +1022,7 @@ class AISettingsDialog::ConfigPage : public juce::Component {
             r.providerCombo.onChange = [this, rp]() { fillRowModel(*rp, {}); };
             addAndMakeVisible(r.providerCombo);
 
-            r.modelCombo.setEditableText(true);
+            // Pick-from-list only — no free-text model entry.
             styleCombo(r.modelCombo);
             addAndMakeVisible(r.modelCombo);
         }
@@ -1178,31 +1178,49 @@ class AISettingsDialog::ConfigPage : public juce::Component {
             row.providerCombo.setSelectedId(1, juce::dontSendNotification);
     }
 
-    // Fill a row's model combo from the selected provider's catalogue. Embedded
-    // has no model to pick; local-server falls back to the shared model id.
+    // Fill a row's model combo from the selected provider's catalogue. The combo
+    // is pick-from-list only (no free text). Local providers take no per-agent
+    // model, so the combo is disabled: embedded shows nothing, local-server
+    // shows the shared model id read-only.
     void fillRowModel(AgentRow& row, const juce::String& desiredModel) {
         auto pid = rowProviderId(row);
         row.modelCombo.clear(juce::dontSendNotification);
-        // Local providers take no per-agent model: embedded uses the loaded
-        // GGUF, local-server uses the shared model from the Local/Config tabs.
-        // The combo is disabled; local-server shows the shared id read-only.
         if (pid == magda::provider::LLAMA_LOCAL || pid == magda::provider::LOCAL_SERVER) {
-            juce::String note = (pid == magda::provider::LOCAL_SERVER)
-                                    ? juce::String(Config::getInstance().getLocalServerModel())
-                                    : juce::String();
-            row.modelCombo.setText(note, juce::dontSendNotification);
+            if (pid == magda::provider::LOCAL_SERVER) {
+                auto shared = Config::getInstance().getLocalServerModel();
+                if (!shared.empty()) {
+                    row.modelCombo.addItem(juce::String(shared), 1);
+                    row.modelCombo.setSelectedId(1, juce::dontSendNotification);
+                }
+            }
             row.modelCombo.setEnabled(false);
             return;
         }
         row.modelCombo.setEnabled(true);
-        int id = 1;
-        for (const auto& m : knownModelsForProvider(pid))
-            row.modelCombo.addItem(m, id++);
 
-        if (desiredModel.isNotEmpty())
-            row.modelCombo.setText(desiredModel, juce::dontSendNotification);
-        else if (row.modelCombo.getNumItems() > 0)
-            row.modelCombo.setSelectedId(1, juce::dontSendNotification);
+        auto models = knownModelsForProvider(pid);
+        bool desiredInCatalogue = false;
+        for (const auto& m : models)
+            if (m == desiredModel) {
+                desiredInCatalogue = true;
+                break;
+            }
+
+        int id = 1;
+        int selectId = 0;
+        // Keep any saved model selectable even if it predates the catalogue.
+        if (desiredModel.isNotEmpty() && !desiredInCatalogue) {
+            row.modelCombo.addItem(desiredModel, id);
+            selectId = id;
+            ++id;
+        }
+        for (const auto& m : models) {
+            row.modelCombo.addItem(m, id);
+            if (m == desiredModel)
+                selectId = id;
+            ++id;
+        }
+        row.modelCombo.setSelectedId(selectId > 0 ? selectId : 1, juce::dontSendNotification);
     }
 
     // Rebuild every row's provider combo from the current configured

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -1182,8 +1182,14 @@ class AISettingsDialog::ConfigPage : public juce::Component {
     void fillRowModel(AgentRow& row, const juce::String& desiredModel) {
         auto pid = rowProviderId(row);
         row.modelCombo.clear(juce::dontSendNotification);
-        if (pid == magda::provider::LLAMA_LOCAL) {
-            row.modelCombo.setText("", juce::dontSendNotification);
+        // Local providers take no per-agent model: embedded uses the loaded
+        // GGUF, local-server uses the shared model from the Local/Config tabs.
+        // The combo is disabled; local-server shows the shared id read-only.
+        if (pid == magda::provider::LLAMA_LOCAL || pid == magda::provider::LOCAL_SERVER) {
+            juce::String note = (pid == magda::provider::LOCAL_SERVER)
+                                    ? juce::String(Config::getInstance().getLocalServerModel())
+                                    : juce::String();
+            row.modelCombo.setText(note, juce::dontSendNotification);
             row.modelCombo.setEnabled(false);
             return;
         }
@@ -1192,11 +1198,8 @@ class AISettingsDialog::ConfigPage : public juce::Component {
         for (const auto& m : knownModelsForProvider(pid))
             row.modelCombo.addItem(m, id++);
 
-        juce::String want = desiredModel;
-        if (want.isEmpty() && pid == magda::provider::LOCAL_SERVER)
-            want = juce::String(Config::getInstance().getLocalServerModel());
-        if (want.isNotEmpty())
-            row.modelCombo.setText(want, juce::dontSendNotification);
+        if (desiredModel.isNotEmpty())
+            row.modelCombo.setText(desiredModel, juce::dontSendNotification);
         else if (row.modelCombo.getNumItems() > 0)
             row.modelCombo.setSelectedId(1, juce::dontSendNotification);
     }
@@ -1463,7 +1466,11 @@ class AISettingsDialog::ConfigPage : public juce::Component {
             if (pid == magda::provider::OPENAI_CHAT && model.startsWith("gpt-5"))
                 pid = magda::provider::OPENAI_RESPONSES;
             cfg.provider = pid;
-            cfg.model = (pid == magda::provider::LLAMA_LOCAL) ? std::string{} : model.toStdString();
+            // Local providers carry no per-agent model — it resolves from the
+            // loaded GGUF / shared local-server config at request time.
+            const bool isLocal =
+                (pid == magda::provider::LLAMA_LOCAL || pid == magda::provider::LOCAL_SERVER);
+            cfg.model = isLocal ? std::string{} : model.toStdString();
             // apiKey left empty — resolved from Cloud-tab credentials at request
             // time (per-agent key first, then per-provider credential).
             config.setAgentLLMConfig(row.role, cfg);

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -42,6 +42,7 @@
 #include "../../../core/controllers/ControllerRegistry.hpp"
 #include "../../../project/ProjectManager.hpp"
 #include "../../components/common/SvgButton.hpp"
+#include "../../dialogs/AISettingsDialog.hpp"
 #include "../../state/TimelineController.hpp"
 #include "../../themes/DarkTheme.hpp"
 #include "../../themes/DialogLookAndFeel.hpp"
@@ -1079,6 +1080,11 @@ AIChatConsoleContent::AIChatConsoleContent() {
                                  DarkTheme::getSecondaryTextColour().withAlpha(0.6f));
     configStatusLabel_.setColour(juce::Label::backgroundColourId, juce::Colours::transparentBlack);
     configStatusLabel_.setJustificationType(juce::Justification::centredLeft);
+    // Clickable: opens AI Settings so the footer both reports and edits config.
+    configStatusLabel_.setInterceptsMouseClicks(true, false);
+    configStatusLabel_.addMouseListener(this, false);
+    configStatusLabel_.setMouseCursor(juce::MouseCursor::PointingHandCursor);
+    configStatusLabel_.setTooltip("Open AI Settings");
     addAndMakeVisible(configStatusLabel_);
 
     // Model load/unload button (shown only for local_embedded preset)
@@ -2086,7 +2092,10 @@ void AIChatConsoleContent::updateConfigStatus() {
             status = status.substring(0, 1).toUpperCase() + status.substring(1);
     }
 
-    if (preset == magda::preset::LOCAL_SERVER) {
+    if (preset == magda::preset::ADVANCED) {
+        // Per-agent config: no single model — the router picks per agent.
+        status += juce::String::fromUTF8(" \xc2\xb7 per-agent");
+    } else if (preset == magda::preset::LOCAL_SERVER) {
         auto serverModel = config.getLocalServerModel();
         status +=
             " | " + (serverModel.empty() ? juce::String("No model") : juce::String(serverModel));
@@ -2139,6 +2148,10 @@ bool AIChatConsoleContent::isLocalPreset() const {
 }
 
 void AIChatConsoleContent::mouseUp(const juce::MouseEvent& event) {
+    if (event.originalComponent == &configStatusLabel_) {
+        magda::AISettingsDialog::showDialog(this);
+        return;
+    }
     if (event.originalComponent == &contextLabel_ ||
         (event.originalComponent == this && contextIconBounds_.contains(event.getPosition()))) {
         contextEnabled_ = !contextEnabled_;


### PR DESCRIPTION
Closes #1766.

## Advanced AI config panel
Reworks **AI Settings > Config** with a **Setup: Simple / Advanced** selector.

- **Advanced** reveals a per-agent grid — one row each for **Router / Command / Music / Controller / Theme** — with its own **Provider** and **Model** selector.
- Provider lists come from the configured Cloud providers plus the two local sources (Embedded / Local Server); model dropdowns are editable and seeded from a per-provider catalog.
- Local providers (Embedded, Local Server) disable the model dropdown — embedded uses the loaded GGUF, local-server uses the shared model from the Local/Config tabs.
- Switching to Advanced seeds the grid from whatever Simple currently resolves to; state persists via `setAgentLLMConfig` under a `preset::ADVANCED` sentinel and reloads back into the grid.
- **Simple** mode behaviour is unchanged (extracted into `applySimple` / `computeSimpleConfigs`, shared with the seeding path).

## Theme role
The theme agent previously piggybacked on `role::MUSIC`. It now has a dedicated `role::THEME`, so its provider/model can be set independently in the grid. Default `agentConfigs` entry + load-migration clones music for configs predating the role (same pattern as controller).

## Model catalog refresh
Adds current provider IDs to the `model::` catalog:
- **OpenAI:** gpt-5.6 sol/terra/luna, 5.5(-pro), 5.4(-pro/-mini/-nano), 5.2, 5.1, o3, o3-pro
- **Anthropic:** claude-fable-5, claude-sonnet-5
- **Gemini:** gemini-3.5-flash, 3.1 pro/flash/flash-lite, 2.5-flash
- **DeepSeek:** deepseek-v4-flash/pro

Repoints two dead aliases to live IDs: `GEMINI_FLASH` -> gemini-2.5-flash (2.0-flash shut down 2026-06-01) and `DEEPSEEK_CHAT/REASONER` -> deepseek-v4-flash/pro (legacy IDs deprecated 2026-07-24). Stops collapsing per-version Opus/Sonnet picks in `toLLMProviderConfig` so Advanced-panel model choices are honoured.

Settings-UI rearrangement + wiring; no engine/agent-runtime changes.