### PR TITLE
Utility: display stereo Width as 0-200% instead of 0-2

### DIFF
--- a/magda/daw/audio/plugins/compiled/MagdaUtilityCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaUtilityCompiledPlugin.cpp
@@ -75,10 +75,11 @@ void MagdaUtilityCompiledPlugin::buildHostParameters() {
                                .maxValue = 1.0f,
                                .defaultValue = 0.0f};
     hostSlotInfo_[kWidthSlot] = {.name = "Width",
+                                 .unit = magda::technicalText(magda::TechnicalTextToken::Percent),
                                  .scale = magda::ParameterScale::Linear,
                                  .minValue = 0.0f,
-                                 .maxValue = 2.0f,
-                                 .defaultValue = 1.0f};
+                                 .maxValue = 200.0f,
+                                 .defaultValue = 100.0f};
     hostSlotInfo_[kLowMonoFreqSlot] = {.name = "Low Mono Freq",
                                        .unit =
                                            magda::technicalText(magda::TechnicalTextToken::Hertz),
@@ -173,7 +174,7 @@ void MagdaUtilityCompiledPlugin::applyToBuffer(const te::PluginRenderContext& fc
     const float gainDb = slotDisplayValue(kGainSlot);
     const float gain = gainDb <= -59.99f ? 0.0f : juce::Decibels::decibelsToGain(gainDb);
     const float pan = juce::jlimit(-1.0f, 1.0f, slotDisplayValue(kPanSlot));
-    const float width = juce::jlimit(0.0f, 2.0f, slotDisplayValue(kWidthSlot));
+    const float width = juce::jlimit(0.0f, 200.0f, slotDisplayValue(kWidthSlot)) * 0.01f;
     const float lowMonoFreq = slotDisplayValue(kLowMonoFreqSlot);
     const bool mono = slotDisplayValue(kMonoSlot) >= 0.5f;
     const bool lowMono = slotDisplayValue(kLowMonoSlot) >= 0.5f && !mono;

--- a/magda/daw/project/serialization/TrackSerializer.cpp
+++ b/magda/daw/project/serialization/TrackSerializer.cpp
@@ -10,6 +10,27 @@ namespace magda {
 
 namespace {
 
+// Pre-0.16 projects stored the Utility device's Width parameter as a 0-2 M/S
+// multiplier; it is now 0-200 %. The old shape is unambiguous in the file
+// (maxValue 2 vs 200), so rescale in place — no version gate needed. The
+// plugin state chunk stores the normalized knob position, which is
+// scale-independent and needs no migration.
+void migrateUtilityWidthToPercent(DeviceInfo& device) {
+    constexpr int kUtilityWidthSlot = 2;  // MagdaUtilityCompiledPlugin::kWidthSlot
+    if (!device.pluginId.equalsIgnoreCase("magda_utility"))
+        return;
+
+    for (auto& param : device.parameters) {
+        if (param.paramIndex != kUtilityWidthSlot || param.maxValue > 2.001f)
+            continue;
+        param.currentValue *= 100.0f;
+        param.minValue = 0.0f;
+        param.maxValue = 200.0f;
+        param.defaultValue = 100.0f;
+        param.unit = technicalText(TechnicalTextToken::Percent);
+    }
+}
+
 void enforcePostFxAnalysisDeviceOrder(std::vector<PostFxChainElement>& elements) {
     auto findAnalysis = [&elements](int order) {
         return std::find_if(elements.begin(), elements.end(), [order](const auto& element) {
@@ -567,6 +588,8 @@ bool ProjectSerializer::deserializeDeviceInfo(const juce::var& json, DeviceInfo&
             outDevice.parameters.push_back(param);
         }
     }
+
+    migrateUtilityWidthToPercent(outDevice);
 
     // Visible parameters
     auto visibleParamsVar = obj->getProperty("visibleParameters");

--- a/magda/daw/ui/components/chain/compiled/CompiledUtilityView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledUtilityView.cpp
@@ -85,10 +85,11 @@ CompiledUtilityView::CompiledUtilityView(juce::String /*pluginId*/) {
     };
     addAndMakeVisible(panLabel_);
 
-    widthLabel_.setRange(0.0, 2.0, 1.0);
-    widthLabel_.setValue(1.0, juce::dontSendNotification);
+    widthLabel_.setRange(0.0, 200.0, 100.0);
+    widthLabel_.setValue(100.0, juce::dontSendNotification);
     widthLabel_.setFontSize(9.0f);
-    widthLabel_.setDecimalPlaces(2);
+    widthLabel_.setDecimalPlaces(0);
+    widthLabel_.setSuffix("%");
     widthLabel_.setFillColour(fillColour);
     widthLabel_.onValueChange = [this]() {
         writeParameter(Util::kWidthSlot, static_cast<float>(widthLabel_.getValue()));
@@ -184,7 +185,7 @@ void CompiledUtilityView::syncFromDevice() {
     gainValue_.setText(formatGainDb(gain), juce::dontSendNotification);
     panLabel_.setValue(valueForSlot(deviceSnapshot_, Util::kPanSlot, 0.0f),
                        juce::dontSendNotification);
-    widthLabel_.setValue(valueForSlot(deviceSnapshot_, Util::kWidthSlot, 1.0f),
+    widthLabel_.setValue(valueForSlot(deviceSnapshot_, Util::kWidthSlot, 100.0f),
                          juce::dontSendNotification);
     xoverLabel_.setValue(valueForSlot(deviceSnapshot_, Util::kLowMonoFreqSlot, 120.0f),
                          juce::dontSendNotification);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,6 +86,7 @@ set(TEST_SOURCES
     # Internal track-to-track routing (issue #1690)
     test_internal_track_routing.cpp
     test_master_track_serialization.cpp
+    test_utility_width_migration.cpp
     test_automation_agent.cpp
     test_mix_analysis_agent.cpp
     test_mix_analysis_audio.cpp

--- a/tests/test_utility_width_migration.cpp
+++ b/tests/test_utility_width_migration.cpp
@@ -1,0 +1,151 @@
+#include <juce_core/juce_core.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/core/AutomationManager.hpp"
+#include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/project/ProjectManager.hpp"
+
+using namespace magda;
+
+namespace {
+
+juce::File testTempRoot() {
+    auto envTmp = juce::SystemStats::getEnvironmentVariable("TMPDIR", {});
+    auto root = envTmp.isNotEmpty() ? juce::File(envTmp)
+                                    : juce::File::getSpecialLocation(juce::File::tempDirectory);
+    root.createDirectory();
+    return root;
+}
+
+struct MigrationFixture {
+    std::vector<juce::File> tempFiles;
+    std::vector<juce::File> tempDirs;
+
+    MigrationFixture() {
+        TrackManager::getInstance().clearAllTracks();
+        ClipManager::getInstance().clearAllClips();
+        AutomationManager::getInstance().clearAll();
+    }
+
+    ~MigrationFixture() {
+        for (auto& dir : tempDirs) {
+            if (dir.isDirectory())
+                dir.deleteRecursively();
+        }
+        for (auto& file : tempFiles) {
+            if (file.existsAsFile())
+                file.deleteFile();
+        }
+        TrackManager::getInstance().clearAllTracks();
+        ClipManager::getInstance().clearAllClips();
+        AutomationManager::getInstance().clearAll();
+    }
+
+    juce::File createTempProjectFile(const juce::String& suffix) {
+        auto file = testTempRoot().getNonexistentChildFile("width_migration", suffix);
+        tempFiles.push_back(file);
+        auto wrapperDir =
+            file.getParentDirectory().getChildFile(file.getFileNameWithoutExtension());
+        tempDirs.push_back(wrapperDir);
+        return file;
+    }
+
+    static juce::File wrappedPath(const juce::File& file) {
+        auto projectName = file.getFileNameWithoutExtension();
+        auto parentDir = file.getParentDirectory();
+        if (parentDir.getFileName() != projectName) {
+            auto wrapperDir = parentDir.getChildFile(projectName);
+            return wrapperDir.getChildFile(file.getFileName());
+        }
+        return file;
+    }
+};
+
+ParameterInfo makeWidthParam(float minValue, float maxValue, float defaultValue,
+                             float currentValue) {
+    ParameterInfo param;
+    param.paramIndex = 2;  // MagdaUtilityCompiledPlugin::kWidthSlot
+    param.name = "Width";
+    param.minValue = minValue;
+    param.maxValue = maxValue;
+    param.defaultValue = defaultValue;
+    param.currentValue = currentValue;
+    param.scale = ParameterScale::Linear;
+    return param;
+}
+
+}  // namespace
+
+TEST_CASE("Old-scale Utility Width migrates to percent on load",
+          "[project][serialization][migration]") {
+    MigrationFixture fixture;
+
+    auto& tm = TrackManager::getInstance();
+    auto& pm = ProjectManager::getInstance();
+
+    // A pre-0.16 project stored Width as a 0-2 multiplier. Recreate that model
+    // shape and save it; the file then carries the old-scale values verbatim.
+    auto trackId = tm.createTrack("Utility Track");
+    DeviceInfo utility;
+    utility.name = "Utility";
+    utility.pluginId = "magda_utility";
+    utility.format = PluginFormat::Internal;
+    utility.parameters.push_back(makeWidthParam(0.0f, 2.0f, 1.0f, 1.5f));
+    auto deviceId = tm.addDeviceToTrack(trackId, utility);
+    REQUIRE(deviceId != INVALID_DEVICE_ID);
+
+    auto tempFile = fixture.createTempProjectFile(".mgd");
+    auto actualFile = MigrationFixture::wrappedPath(tempFile);
+    REQUIRE(pm.saveProjectAs(tempFile));
+
+    tm.clearAllTracks();
+    REQUIRE(pm.loadProject(actualFile));
+
+    auto* track = tm.getTrack(trackId);
+    REQUIRE(track != nullptr);
+    REQUIRE(track->chain.fxChainElements.size() == 1);
+    REQUIRE(isDevice(track->chain.fxChainElements[0]));
+
+    const auto& device = getDevice(track->chain.fxChainElements[0]);
+    REQUIRE(device.parameters.size() == 1);
+    const auto& width = device.parameters[0];
+    CHECK(width.currentValue == 150.0f);
+    CHECK(width.minValue == 0.0f);
+    CHECK(width.maxValue == 200.0f);
+    CHECK(width.defaultValue == 100.0f);
+}
+
+TEST_CASE("Percent-scale Utility Width passes through load unchanged",
+          "[project][serialization][migration]") {
+    MigrationFixture fixture;
+
+    auto& tm = TrackManager::getInstance();
+    auto& pm = ProjectManager::getInstance();
+
+    auto trackId = tm.createTrack("Utility Track");
+    DeviceInfo utility;
+    utility.name = "Utility";
+    utility.pluginId = "magda_utility";
+    utility.format = PluginFormat::Internal;
+    utility.parameters.push_back(makeWidthParam(0.0f, 200.0f, 100.0f, 150.0f));
+    auto deviceId = tm.addDeviceToTrack(trackId, utility);
+    REQUIRE(deviceId != INVALID_DEVICE_ID);
+
+    auto tempFile = fixture.createTempProjectFile(".mgd");
+    auto actualFile = MigrationFixture::wrappedPath(tempFile);
+    REQUIRE(pm.saveProjectAs(tempFile));
+
+    tm.clearAllTracks();
+    REQUIRE(pm.loadProject(actualFile));
+
+    auto* track = tm.getTrack(trackId);
+    REQUIRE(track != nullptr);
+    REQUIRE(track->chain.fxChainElements.size() == 1);
+
+    const auto& device = getDevice(track->chain.fxChainElements[0]);
+    REQUIRE(device.parameters.size() == 1);
+    CHECK(device.parameters[0].currentValue == 150.0f);
+    CHECK(device.parameters[0].maxValue == 200.0f);
+}


### PR DESCRIPTION
Reparameterize the Utility device's Width slot from a raw 0-2 M/S multiplier to a 0-200% range (default 100%), with the DSP scaling back to the same multiplier so the sound is unchanged. The readout now shows integer percent with a % suffix and accepts percent text entry.

Pre-0.16 projects stored Width on the old 0-2 scale; migrate on load in TrackSerializer::deserializeDeviceInfo, detecting the old shape by its stored maxValue (2 vs 200) so no version gate is needed. The plugin state chunk stores the normalized knob position, which is scale-independent and needs no migration.

Add model-level migration tests covering both the old-scale rescale and the new-scale pass-through.