### PR TITLE
CI: fix Dependabot PR runs (optional sccache + base bumps on dev)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,12 @@ updates:
   # Git submodules (JUCE, llama.cpp, etc.)
   - package-ecosystem: "gitsubmodule"
     directory: "/"
+    # Base bumps on the active dev branch, not the default branch (main).
+    # main's only PR trigger is `pull_request: [main]`, so PRs into main run the
+    # full CI matrix (incl. the self-hosted macOS/Windows jobs); targeting dev
+    # keeps bumps off that path and in line with the normal contribution flow.
+    # Update this each release cycle when the active dev branch rolls over.
+    target-branch: "dev/0.16.0"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -19,6 +25,9 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    # See the gitsubmodule note above: base on the active dev branch so bumps
+    # don't trip the pull_request-into-main CI. Bump each release cycle.
+    target-branch: "dev/0.16.0"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,13 +136,21 @@ jobs:
     # The S3 bucket is shared across runs/branches and uncapped, so warm hits
     # actually survive. The linux prefix is shared with the JUCE-tests job so
     # their common translation units hit each other's objects.
+    #
+    # Dependabot-triggered runs get no repo secrets and no OIDC id-token, so this
+    # step fails there. Treat it as non-fatal: without credentials the build just
+    # runs cold (see the sccache-gated launcher flags in Configure CMake below).
     - name: Configure AWS credentials (sccache S3, OIDC)
+      id: aws-creds
+      continue-on-error: true
       uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ secrets.AWS_SCCACHE_ROLE_ARN }}
         aws-region: eu-west-2
 
     - name: Setup sccache
+      id: sccache
+      if: steps.aws-creds.outcome == 'success'
       env:
         SCCACHE_BUCKET_SECRET: ${{ secrets.SCCACHE_BUCKET }}
       run: |
@@ -203,8 +211,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
           -DMAGDA_BUILD_TESTS=ON \
-          -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
+          ${{ steps.sccache.outcome == 'success' && '-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache' || '' }} \
           ${{ steps.faust-cache.outputs.cache-hit == 'true' && format('-DMAGDA_FAUST_PREBUILT_DIR={0}/third_party/faust/build', github.workspace) || '' }} \
           ${{ steps.mutable-cache.outputs.cache-hit == 'true' && format('-DMAGDA_MUTABLE_PREBUILT_DIR={0}/third_party/eurorack/build', github.workspace) || '' }}
 
@@ -233,6 +240,7 @@ jobs:
         fi
 
     - name: Show sccache statistics
+      if: steps.sccache.outcome == 'success'
       run: sccache --show-stats
 
     - name: Test summary

--- a/.github/workflows/juce-tests-linux.yml
+++ b/.github/workflows/juce-tests-linux.yml
@@ -60,13 +60,21 @@ jobs:
 
     # Compile cache: sccache backed by S3 (see infra/sccache), sharing the
     # linux key prefix with the main CI job so common translation units hit.
+    #
+    # Dependabot-triggered runs get no repo secrets and no OIDC id-token, so this
+    # step fails there. Treat it as non-fatal: without credentials the build just
+    # runs cold (see the sccache-gated launcher flags in Configure CMake below).
     - name: Configure AWS credentials (sccache S3, OIDC)
+      id: aws-creds
+      continue-on-error: true
       uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ secrets.AWS_SCCACHE_ROLE_ARN }}
         aws-region: eu-west-2
 
     - name: Setup sccache
+      id: sccache
+      if: steps.aws-creds.outcome == 'success'
       env:
         SCCACHE_BUCKET_SECRET: ${{ secrets.SCCACHE_BUCKET }}
       run: |
@@ -116,8 +124,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
           -DMAGDA_BUILD_TESTS=ON \
-          -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
+          ${{ steps.sccache.outcome == 'success' && '-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache' || '' }} \
           ${{ steps.faust-cache.outputs.cache-hit == 'true' && format('-DMAGDA_FAUST_PREBUILT_DIR={0}/third_party/faust/build', github.workspace) || '' }} \
           ${{ steps.mutable-cache.outputs.cache-hit == 'true' && format('-DMAGDA_MUTABLE_PREBUILT_DIR={0}/third_party/eurorack/build', github.workspace) || '' }}
 
@@ -141,4 +148,5 @@ jobs:
         done
 
     - name: Show sccache statistics
+      if: steps.sccache.outcome == 'success'
       run: sccache --show-stats


### PR DESCRIPTION
Two related fixes for how Dependabot bumps interact with CI, surfaced by #1778.

## 1. Make the sccache S3 cache non-fatal

Dependabot-triggered runs (and external fork PRs) get no repo secrets and no OIDC id-token, so the **Configure AWS credentials (sccache S3, OIDC)** step errored and took the whole Linux build/test job down with it - unrelated to the dependency being bumped.

- **Configure AWS credentials** -> `continue-on-error: true` with an `id`, so a missing role ARN no longer fails the job.
- **Setup sccache** -> gated on `steps.aws-creds.outcome == 'success'`.
- **Configure CMake** -> the `-DCMAKE_*_COMPILER_LAUNCHER=sccache` flags are added only when sccache set up successfully (same conditional-expression pattern already used for the Faust/Mutable prebuilt dirs), so a credential-less run builds with plain compilers instead of pointing CMake at a broken sccache.
- **Show sccache statistics** -> gated so it doesn't error when sccache never ran.

Applied to both the main CI job (`ci.yml`) and the Linux JUCE-tests job (`juce-tests-linux.yml`), which share the step. Normal runs are unchanged and keep the warm cache; credential-less runs build cold instead of failing.

## 2. Base Dependabot bumps on the active dev branch

Dependabot had no `target-branch`, so it targeted the default branch (`main`). main's only PR-level CI trigger is `pull_request: [main]`, which runs the full matrix including the self-hosted macOS/Windows jobs - so every bump PR consumed those runners, despite the `dependabot/**` push-ignore trying to avoid exactly that. Point both ecosystems at `dev/0.16.0` so bumps follow the normal contribution flow and stay off the into-main CI path.

> Note: `target-branch` is a literal, so it needs bumping each release cycle when the active dev branch rolls over.

## Note on rollout

The currently-open Dependabot PRs (#1778 etc.) base on `main`; `pull_request` runs use the workflow from the PR merged into its base, so fix #1 only helps those once it reaches `main`. Fix #2 only affects Dependabot PRs opened *after* it merges. Based here on `dev/0.16.0` per the repo convention.