### PR TITLE
Dependabot: roll target-branch to dev/0.17.0 (dev sync)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     # full CI matrix (incl. the self-hosted macOS/Windows jobs); targeting dev
     # keeps bumps off that path and in line with the normal contribution flow.
     # Update this each release cycle when the active dev branch rolls over.
-    target-branch: "dev/0.16.0"
+    target-branch: "dev/0.17.0"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -27,7 +27,7 @@ updates:
     directory: "/"
     # See the gitsubmodule note above: base on the active dev branch so bumps
     # don't trip the pull_request-into-main CI. Bump each release cycle.
-    target-branch: "dev/0.16.0"
+    target-branch: "dev/0.17.0"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Same config rollover as the PR into main, applied to dev/0.17.0 so the next release PR does not revert main back to the deleted dev/0.16.0 target.