### PR TITLE
feat(ai): sound-design panel assistant for all MAGDA sound generators

### DIFF
--- a/magda/agents/CMakeLists.txt
+++ b/magda/agents/CMakeLists.txt
@@ -67,6 +67,8 @@ dsl_grammar.hpp
     device_ai_agent.hpp
     sound_design_agent.hpp
     sound_design_agent.cpp
+    generic_sound_design_agent.hpp
+    generic_sound_design_agent.cpp
     coder_agent.hpp
     coder_agent.cpp
     mcp/MCPClient.hpp

--- a/magda/agents/generic_sound_design_agent.cpp
+++ b/magda/agents/generic_sound_design_agent.cpp
@@ -1,0 +1,354 @@
+#include "generic_sound_design_agent.hpp"
+
+#include <juce_events/juce_events.h>
+
+#include <functional>
+#include <map>
+#include <vector>
+
+#include "../daw/audio/plugins/compiled/CompiledPluginRegistry.hpp"
+#include "../daw/core/Config.hpp"
+#include "core/DeviceInfo.hpp"
+#include "core/InternalDeviceKind.hpp"
+#include "core/ParameterInfo.hpp"
+#include "core/PresetManager.hpp"
+#include "core/TrackManager.hpp"
+#include "core/aliases/ParamNameNormalize.hpp"
+#include "llm_client_factory.hpp"
+#include "llm_presets.hpp"
+
+namespace magda {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Device classification
+// ---------------------------------------------------------------------------
+
+// Native (non-compiled) MAGDA instruments the generic agent should drive.
+// Sampler and Drum Grid are instruments too but deliberately excluded — the AI
+// preset flow adds little for a sample player / drum machine. Clouds is a
+// granular texture/FX, not a note source, so it's out as well.
+bool isNativeSoundGenerator(const juce::String& pluginId) {
+    switch (classifyInternalDevice(pluginId)) {
+        case InternalDeviceKind::MutableElements:
+        case InternalDeviceKind::MutableRings:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parameter snapshot (message-thread read → worker-thread prompt build)
+// ---------------------------------------------------------------------------
+
+struct ParamSnapshot {
+    int index = -1;
+    juce::String name;
+    juce::String normalized;
+    juce::String unit;
+    float minValue = 0.0f;
+    float maxValue = 1.0f;
+    float currentValue = 0.0f;
+    ParameterScale scale = ParameterScale::Linear;
+    std::vector<juce::String> choices;
+};
+
+// Runs `fn` on the message thread and blocks until it finishes, polling in
+// short slices so a cancel returns promptly. Returns false if cancelled or the
+// hop timed out. Mirrors the apply-side hop in four_osc_apply — DeviceInfo /
+// te::Plugin state must only be touched on the message thread.
+bool runOnMessageThreadBlocking(std::atomic<bool>& stop, std::function<void()> fn) {
+    auto& mm = *juce::MessageManager::getInstance();
+    if (mm.isThisTheMessageThread()) {
+        fn();
+        return true;
+    }
+    struct State {
+        juce::WaitableEvent done;
+        std::function<void()> fn;
+    };
+    auto state = std::make_shared<State>();
+    state->fn = std::move(fn);
+    mm.callAsync([state]() {
+        state->fn();
+        state->done.signal();
+    });
+
+    constexpr int sliceMs = 50;
+    constexpr int maxMs = 5000;
+    for (int waited = 0; waited < maxMs; waited += sliceMs) {
+        if (state->done.wait(sliceMs))
+            return true;
+        if (stop.load())
+            return false;
+    }
+    return false;
+}
+
+// Trim trailing zeros so "5.000" reads as "5" and "0.250" as "0.25".
+juce::String tidyNumber(float v) {
+    juce::String s(v, 3);
+    if (s.containsChar('.')) {
+        while (s.endsWithChar('0'))
+            s = s.dropLastCharacters(1);
+        if (s.endsWithChar('.'))
+            s = s.dropLastCharacters(1);
+    }
+    return s;
+}
+
+// One human-readable line per parameter for the system prompt.
+juce::String describeParam(const ParamSnapshot& p) {
+    juce::String line = "  " + p.name;
+    if (p.unit.isNotEmpty())
+        line += " [" + p.unit + "]";
+    if (p.scale == ParameterScale::Discrete && !p.choices.empty()) {
+        line += " options: " + p.choices[0];
+        for (size_t i = 1; i < p.choices.size(); ++i)
+            line += " | " + p.choices[i];
+    } else {
+        line += " range " + tidyNumber(p.minValue) + ".." + tidyNumber(p.maxValue);
+    }
+    line += " (now " + tidyNumber(p.currentValue) + ")";
+    return line;
+}
+
+juce::String buildSystemPrompt(const juce::String& displayName, const juce::String& description,
+                               const juce::String& categoryOverride,
+                               const std::vector<ParamSnapshot>& params) {
+    juce::String prompt;
+    prompt << "You are a sound designer for the MAGDA \"" << displayName << "\" instrument.";
+    if (description.isNotEmpty())
+        prompt << " " << description;
+    prompt << "\n\nGiven a short user description, design a single preset by choosing values "
+              "for the instrument's parameters. Output ONLY a JSON object — no prose, no "
+              "markdown fences.\n\n";
+
+    prompt << "OUTPUT SCHEMA:\n"
+              "{\n"
+              "  \"name\": \"<2-4 word preset name>\",\n"
+              "  \"description\": \"<one short sentence>\",\n"
+              "  \"params\": { \"<parameter name>\": <value>, ... }\n"
+              "}\n\n";
+
+    prompt << "RULES:\n"
+              "- Use the EXACT parameter names listed below.\n"
+              "- Emit each value in the parameter's own units and within its stated range "
+              "(e.g. a Hz cutoff as a real frequency, an ms time as milliseconds).\n"
+              "- For parameters shown with `options:`, emit one of the listed option labels "
+              "as a string (exact text).\n"
+              "- Omit any parameter you want left at its current value. Only set the ones that "
+              "matter for the requested sound.\n"
+              "- Keep output levels sensible — do not push level/gain parameters to their "
+              "maximum without reason.\n\n";
+
+    if (categoryOverride.isNotEmpty())
+        prompt << "Bias the design toward this character: " << categoryOverride << "\n\n";
+
+    prompt << "PARAMETERS:\n";
+    for (const auto& p : params)
+        prompt << describeParam(p) << "\n";
+
+    return prompt;
+}
+
+// Strip markdown fences ("```json ... ```") an LLM may wrap the payload in.
+juce::String stripFences(const juce::String& text) {
+    auto t = text.trim();
+    if (t.startsWith("```")) {
+        auto firstNl = t.indexOfChar('\n');
+        if (firstNl >= 0)
+            t = t.substring(firstNl + 1);
+        auto lastFence = t.lastIndexOf("```");
+        if (lastFence >= 0)
+            t = t.substring(0, lastFence);
+    }
+    return t.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Apply
+// ---------------------------------------------------------------------------
+
+struct ParsedPreset {
+    juce::String name;
+    juce::String description;
+    // Raw name → value pairs; value is a number or a choice-label string.
+    std::vector<std::pair<juce::String, juce::var>> params;
+};
+
+// Resolve a discrete parameter's incoming value (choice label or index) to the
+// real value the device expects. Choices are laid out evenly across the param's
+// real range, matching ParameterUtils' discrete mapping.
+float discreteRealValue(const ParamSnapshot& p, const juce::var& value) {
+    const int count = static_cast<int>(p.choices.size());
+    const float step = count > 1 ? (p.maxValue - p.minValue) / static_cast<float>(count - 1) : 0.0f;
+
+    if (value.isString()) {
+        const auto wanted = normalizeParamName(value.toString());
+        for (int i = 0; i < count; ++i) {
+            if (normalizeParamName(p.choices[static_cast<size_t>(i)]) == wanted)
+                return p.minValue + static_cast<float>(i) * step;
+        }
+    }
+    // Numeric fallback: treat as a real value and clamp into range.
+    return juce::jlimit(p.minValue, p.maxValue, static_cast<float>(value));
+}
+
+}  // namespace
+
+// ===========================================================================
+
+bool isGenericSoundGeneratorDevice(const juce::String& pluginId) {
+    if (pluginId.isEmpty())
+        return false;
+    if (const auto* spec = daw::audio::compiled::findCompiledPluginSpec(pluginId))
+        return spec->isInstrument;
+    return isNativeSoundGenerator(pluginId);
+}
+
+GenericSoundDesignAgent::GenericSoundDesignAgent(juce::String pluginId, juce::String displayName,
+                                                 juce::String description)
+    : pluginId_(std::move(pluginId)),
+      displayName_(std::move(displayName)),
+      description_(std::move(description)) {}
+
+juce::String GenericSoundDesignAgent::generateAndApply(const juce::String& prompt,
+                                                       const ChainNodePath& path,
+                                                       llm::Conversation& conversation,
+                                                       TokenCallback onToken) {
+    juce::ignoreUnused(conversation);  // single-shot preset design for now
+    shouldStop_ = false;
+    if (shouldStop_.load())
+        return "cancelled";
+
+    // --- 1. Snapshot the device's parameters on the message thread ----------
+    std::vector<ParamSnapshot> params;
+    juce::String deviceName = displayName_;
+    bool deviceFound = false;
+    const bool snapped = runOnMessageThreadBlocking(shouldStop_, [&]() {
+        auto* device = TrackManager::getInstance().getDeviceInChainByPath(path);
+        if (device == nullptr)
+            return;
+        deviceFound = true;
+        if (device->name.isNotEmpty())
+            deviceName = device->name;
+        params.reserve(device->parameters.size());
+        for (size_t i = 0; i < device->parameters.size(); ++i) {
+            const auto& info = device->parameters[i];
+            ParamSnapshot snap;
+            snap.index = static_cast<int>(i);
+            snap.name = info.name;
+            snap.normalized = normalizeParamName(info.name);
+            snap.unit = info.unit;
+            snap.minValue = info.minValue;
+            snap.maxValue = info.maxValue;
+            snap.currentValue = info.currentValue;
+            snap.scale = info.scale;
+            snap.choices = info.choices;
+            if (snap.normalized.isNotEmpty())
+                params.push_back(std::move(snap));
+        }
+    });
+
+    if (!snapped)
+        return shouldStop_.load() ? juce::String("cancelled")
+                                  : juce::String("(device read timed out)");
+    if (!deviceFound)
+        return "(target device not found)";
+    if (params.empty())
+        return "(device exposes no parameters)";
+
+    // --- 2. LLM call (worker thread — never blocks the message thread) ------
+    auto agentConfig = Config::getInstance().getAgentLLMConfig(role::MUSIC);
+    auto providerConfig = toLLMProviderConfig(agentConfig, "sound_design");
+    if (providerConfig.apiKey.isEmpty() && agentConfig.baseUrl.empty() &&
+        agentConfig.provider != provider::LLAMA_LOCAL)
+        return "error: sound design agent API key not configured.";
+
+    auto client = createLLMClient(agentConfig, "sound_design");
+
+    llm::Request request;
+    request.systemPrompt = buildSystemPrompt(deviceName, description_, categoryOverride_, params);
+    request.userMessage = prompt;
+    // Low temperature — sound design rewards consistency over wandering.
+    request.temperature = 0.2f;
+
+    llm::Response response;
+    if (onToken) {
+        response = client->sendStreamingRequest(request, [&](const juce::String& token) {
+            if (shouldStop_.load())
+                return false;
+            return onToken(token);
+        });
+    } else {
+        response = client->sendRequest(request);
+    }
+
+    if (shouldStop_.load())
+        return "cancelled";
+    if (!response.success)
+        return "error: " + response.error;
+
+    // --- 3. Parse the JSON payload ------------------------------------------
+    auto parsed = juce::JSON::parse(stripFences(response.text));
+    auto* obj = parsed.getDynamicObject();
+    if (obj == nullptr)
+        return "error: preset was not valid JSON";
+
+    ParsedPreset preset;
+    preset.name = obj->getProperty("name").toString();
+    preset.description = obj->getProperty("description").toString();
+    if (auto* paramsObj = obj->getProperty("params").getDynamicObject()) {
+        for (const auto& kv : paramsObj->getProperties())
+            preset.params.emplace_back(kv.name.toString(), kv.value);
+    }
+    if (preset.params.empty())
+        return "error: preset contained no parameters";
+
+    // --- 4. Apply on the message thread -------------------------------------
+    std::map<juce::String, const ParamSnapshot*> byName;
+    for (const auto& p : params)
+        byName[p.normalized] = &p;
+
+    int applied = 0;
+    int skipped = 0;
+    const bool didApply = runOnMessageThreadBlocking(shouldStop_, [&]() {
+        auto& tm = TrackManager::getInstance();
+        for (const auto& [rawName, value] : preset.params) {
+            auto it = byName.find(normalizeParamName(rawName));
+            if (it == byName.end()) {
+                ++skipped;
+                continue;
+            }
+            const ParamSnapshot& p = *it->second;
+            float real;
+            if (p.scale == ParameterScale::Discrete && !p.choices.empty())
+                real = discreteRealValue(p, value);
+            else
+                real = juce::jlimit(p.minValue, p.maxValue, static_cast<float>(value));
+            tm.setDeviceParameterValue(path, p.index, real);
+            ++applied;
+        }
+
+        // Seed the next save dialog with the agent's preset name.
+        if (preset.name.isNotEmpty()) {
+            if (auto* device = tm.getDeviceInChainByPath(path))
+                PresetManager::getInstance().setSuggestedPresetName(device->id, preset.name);
+        }
+    });
+
+    if (!didApply)
+        return shouldStop_.load() ? juce::String("cancelled") : juce::String("(apply timed out)");
+    if (applied == 0)
+        return "error: none of the parameters matched this device";
+
+    juce::String status = "applied " + juce::String(applied) + " params to " + deviceName;
+    if (skipped > 0)
+        status += ", skipped " + juce::String(skipped);
+    return status;
+}
+
+}  // namespace magda

--- a/magda/agents/generic_sound_design_agent.hpp
+++ b/magda/agents/generic_sound_design_agent.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include "sound_design_agent.hpp"
+
+namespace magda {
+
+/**
+ * @brief True iff `pluginId` is a MAGDA sound-generator instrument the generic
+ *        sound-design agent can drive.
+ *
+ * Covers the compiled-Faust synths (Poly Synth, FM, the percussion voices) and
+ * the native Mutable ports (Elements, Rings) — everything whose front-panel
+ * controls are exposed as automatable parameters with readable names/ranges.
+ *
+ * Excludes Sampler and Drum Grid (AI adds little there) and 4OSC, which keeps
+ * its bespoke `FourOscAgent` until its wave/filter/voice/FX controls are made
+ * automatable and it can join this path.
+ */
+bool isGenericSoundGeneratorDevice(const juce::String& pluginId);
+
+/**
+ * @brief Device-agnostic "design me a preset" agent driven by parameter
+ *        introspection.
+ *
+ * Unlike `FourOscAgent`, which hard-codes its parameter schema in the system
+ * prompt, this reads the target device's automatable parameters at runtime
+ * (names, units, real-unit ranges, discrete choices) and builds the prompt from
+ * that. The LLM picks values in REAL units (Hz, ms, dB, semitones) — the same
+ * space the device's `ParameterInfo` already reports — so there's no
+ * normalization guesswork. Values are applied through the shared
+ * `TrackManager::setDeviceParameterValue` path.
+ *
+ * The only per-device inputs are the display name + description used to prime
+ * the LLM; the same class serves every generator via
+ * `createSoundDesignAgentFor`.
+ */
+class GenericSoundDesignAgent : public SoundDesignAgent {
+  public:
+    GenericSoundDesignAgent(juce::String pluginId, juce::String displayName,
+                            juce::String description);
+
+    juce::String generateAndApply(const juce::String& prompt, const ChainNodePath& path,
+                                  llm::Conversation& conversation,
+                                  TokenCallback onToken = {}) override;
+
+    void setCategoryOverride(const juce::String& category) override {
+        categoryOverride_ = category;
+    }
+
+    void requestCancel() override {
+        shouldStop_ = true;
+    }
+
+  private:
+    juce::String pluginId_;
+    juce::String displayName_;
+    juce::String description_;
+    juce::String categoryOverride_;
+};
+
+}  // namespace magda

--- a/magda/agents/sound_design_agent.cpp
+++ b/magda/agents/sound_design_agent.cpp
@@ -6,10 +6,13 @@
 #include "audio/plugins/DrumGridPlugin.hpp"
 #include "audio/plugins/PolyStepSequencerPlugin.hpp"
 #include "audio/plugins/StepSequencerPlugin.hpp"
+#include "audio/plugins/compiled/CompiledPluginRegistry.hpp"
+#include "core/InternalDeviceKind.hpp"
 #include "core/TrackManager.hpp"
 #include "engine/AudioEngine.hpp"
 #include "four_osc_agent.hpp"
 #include "four_osc_apply.hpp"
+#include "generic_sound_design_agent.hpp"
 #include "internal_plugins.hpp"
 #include "poly_step_sequencer_agent.hpp"
 #include "poly_step_sequencer_apply.hpp"
@@ -363,15 +366,39 @@ class StepSequencerSoundDesignAgent : public SoundDesignAgent {
 
 std::unique_ptr<SoundDesignAgent> createSoundDesignAgentFor(const juce::String& pluginId) {
     switch (internalPluginFromId(pluginId)) {
+        // 4OSC keeps its bespoke agent for now — its wave/filter/voice/FX
+        // controls are ValueTree properties, not automatable parameters, so it
+        // can't yet go through the generic path. TODO: make those controls
+        // automatable and retire FourOscSoundDesignAgent / FourOscAgent.
         case InternalPlugin::FourOsc:
             return std::make_unique<FourOscSoundDesignAgent>();
+        // The sequencers are MIDI generators with pattern-shaped output, not
+        // parameter presets — they stay on their own bespoke agents.
         case InternalPlugin::PolyStepSequencer:
             return std::make_unique<PolyStepSequencerSoundDesignAgent>();
         case InternalPlugin::StepSequencer:
             return std::make_unique<StepSequencerSoundDesignAgent>();
         default:
-            return nullptr;
+            break;
     }
+
+    // Every other MAGDA sound generator (compiled Faust synths + native Mutable
+    // ports) is driven by the generic parameter-introspection agent. Its only
+    // per-device inputs are the display name + description used to prime the LLM.
+    if (isGenericSoundGeneratorDevice(pluginId)) {
+        juce::String displayName = pluginId;
+        juce::String description;
+        if (const auto* spec = daw::audio::compiled::findCompiledPluginSpec(pluginId)) {
+            displayName = spec->displayName;
+            description = spec->description;
+        } else if (const auto* meta = getInternalDeviceMetadataForPluginId(pluginId)) {
+            displayName = meta->displayName;
+            description = meta->description;
+        }
+        return std::make_unique<GenericSoundDesignAgent>(pluginId, displayName, description);
+    }
+
+    return nullptr;
 }
 
 bool isSoundDesignSupported(const juce::String& pluginId) {

--- a/magda/daw/core/PluginPreferences.cpp
+++ b/magda/daw/core/PluginPreferences.cpp
@@ -81,6 +81,31 @@ void PluginPreferences::setTreatsAsMidiFx(const juce::String& pluginIdentifier,
         pluginIdentifier, treatAsMidiFx ? juce::String(kMidiFxCategoryOverride) : juce::String());
 }
 
+bool PluginPreferences::aiSoundDesignerEnabled(const juce::String& pluginIdentifier) const {
+    if (pluginIdentifier.isEmpty() || pluginIdentifier == kInstrumentRackWrapperId)
+        return true;
+    std::lock_guard<std::mutex> lock(mutex_);
+    return aiSoundDesignerHidden_.find(pluginIdentifier) == aiSoundDesignerHidden_.end();
+}
+
+void PluginPreferences::setAiSoundDesignerEnabled(const juce::String& pluginIdentifier,
+                                                  bool enabled) {
+    if (pluginIdentifier.isEmpty() || pluginIdentifier == kInstrumentRackWrapperId)
+        return;
+
+    bool changed = false;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        changed = enabled ? aiSoundDesignerHidden_.erase(pluginIdentifier) > 0
+                          : aiSoundDesignerHidden_.insert(pluginIdentifier).second;
+        if (changed)
+            saveUnlocked();
+    }
+
+    if (changed)
+        notifyAiSoundDesignerPreferenceChanged(pluginIdentifier);
+}
+
 juce::String PluginPreferences::browserCategoryOverride(
     const juce::String& pluginIdentifier) const {
     if (pluginIdentifier.isEmpty() || pluginIdentifier == kInstrumentRackWrapperId)
@@ -199,6 +224,13 @@ void PluginPreferences::notifyExternalPluginFormatPreferenceChanged(PluginFormat
     });
 }
 
+void PluginPreferences::notifyAiSoundDesignerPreferenceChanged(
+    const juce::String& pluginIdentifier) {
+    listeners_.call([&pluginIdentifier](Listener& listener) {
+        listener.aiSoundDesignerPreferenceChanged(pluginIdentifier);
+    });
+}
+
 std::vector<magda::KitRow> PluginPreferences::defaultKitRows(
     const juce::String& pluginIdentifier) const {
     if (pluginIdentifier.isEmpty() || !hasGlobalKitDefault(pluginIdentifier))
@@ -224,6 +256,7 @@ void PluginPreferences::setDefaultKitRows(const juce::String& pluginIdentifier,
 
 void PluginPreferences::loadUnlocked() {
     drumGridPlugins_.clear();
+    aiSoundDesignerHidden_.clear();
     categoryOverrides_.clear();
     defaultKits_.clear();
     externalFormatPreference_ = PluginFormat::VST3;
@@ -249,6 +282,15 @@ void PluginPreferences::loadUnlocked() {
             auto id = entry.toString();
             if (id.isNotEmpty() && id != kInstrumentRackWrapperId)
                 drumGridPlugins_.insert(id);
+        }
+    }
+
+    auto aiHiddenVar = payload->getProperty("aiSoundDesignerHidden");
+    if (aiHiddenVar.isArray()) {
+        for (const auto& entry : *aiHiddenVar.getArray()) {
+            auto id = entry.toString();
+            if (id.isNotEmpty() && id != kInstrumentRackWrapperId)
+                aiSoundDesignerHidden_.insert(id);
         }
     }
 
@@ -308,6 +350,10 @@ void PluginPreferences::saveUnlocked() const {
     for (const auto& id : drumGridPlugins_)
         prefersList.add(juce::var(id));
 
+    juce::Array<juce::var> aiHiddenList;
+    for (const auto& id : aiSoundDesignerHidden_)
+        aiHiddenList.add(juce::var(id));
+
     juce::Array<juce::var> categoryOverrideList;
     for (const auto& [pluginId, category] : categoryOverrides_) {
         auto* categoryObj = new juce::DynamicObject();
@@ -338,6 +384,7 @@ void PluginPreferences::saveUnlocked() const {
 
     auto* payload = new juce::DynamicObject();
     payload->setProperty("prefersDrumGrid", prefersList);
+    payload->setProperty("aiSoundDesignerHidden", aiHiddenList);
     payload->setProperty("categoryOverrides", categoryOverrideList);
     payload->setProperty("defaultKits", kitsList);
     payload->setProperty("externalPluginFormatPreference",

--- a/magda/daw/core/PluginPreferences.hpp
+++ b/magda/daw/core/PluginPreferences.hpp
@@ -29,6 +29,9 @@ class PluginPreferences {
         virtual void externalPluginFormatPreferenceChanged(PluginFormat preference) {
             juce::ignoreUnused(preference);
         }
+        virtual void aiSoundDesignerPreferenceChanged(const juce::String& pluginIdentifier) {
+            juce::ignoreUnused(pluginIdentifier);
+        }
     };
 
     static PluginPreferences& getInstance();
@@ -69,6 +72,15 @@ class PluginPreferences {
     /** Compatibility helper for the legacy MIDI FX category override. */
     void setTreatsAsMidiFx(const juce::String& pluginIdentifier, bool treatAsMidiFx);
 
+    /** True iff the AI Sound Designer icon/panel should be exposed for this
+     *  plugin. Defaults to true (opt-out): a plugin that has a registered
+     *  sound-design agent shows the panel unless the user has hidden it. */
+    bool aiSoundDesignerEnabled(const juce::String& pluginIdentifier) const;
+
+    /** Show/hide the AI Sound Designer panel for this plugin. Writes
+     *  immediately to disk and notifies listeners. */
+    void setAiSoundDesignerEnabled(const juce::String& pluginIdentifier, bool enabled);
+
     /** Canonical key for user-global plugin preferences from the MAGDA model.
      *  External plugins prefer DeviceInfo::uniqueId (JUCE scan identity).
      *  Internal MAGDA devices fall back to DeviceInfo::pluginId ("4osc",
@@ -95,9 +107,13 @@ class PluginPreferences {
     void saveUnlocked() const;
     void notifyDrumGridPreferenceChanged(const juce::String& pluginIdentifier);
     void notifyExternalPluginFormatPreferenceChanged(PluginFormat preference);
+    void notifyAiSoundDesignerPreferenceChanged(const juce::String& pluginIdentifier);
 
     mutable std::mutex mutex_;
     std::unordered_set<juce::String> drumGridPlugins_;
+    // Plugins for which the user has hidden the AI Sound Designer panel. Stored
+    // as an opt-out set so the default (absent from the set) is "shown".
+    std::unordered_set<juce::String> aiSoundDesignerHidden_;
     std::unordered_map<juce::String, juce::String> categoryOverrides_;
     std::unordered_map<juce::String, std::vector<magda::KitRow>> defaultKits_;
     PluginFormat externalFormatPreference_ = PluginFormat::VST3;

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -152,6 +152,9 @@ DeviceSlotComponent::DeviceSlotComponent(const magda::DeviceInfo& device) : devi
     // Register for gain-staging state so the slot can draw its staging overlay.
     magda::GainStagingManager::getInstance().addListener(this);
 
+    // Register for AI Sound Designer exposure toggles from the plugin browser.
+    magda::PluginPreferences::getInstance().addListener(this);
+
     // Note: BindingRegistry / ControllerRegistry listening is done by
     // NodeComponent (the base class) — it owns the controller-indicator
     // dots and the refresh logic.
@@ -616,8 +619,17 @@ DeviceSlotComponent::~DeviceSlotComponent() {
     magda::TrackManager::getInstance().removeListener(this);
     magda::AutomationManager::getInstance().removeListener(this);
     magda::GainStagingManager::getInstance().removeListener(this);
+    magda::PluginPreferences::getInstance().removeListener(this);
     stopTimer();
     detachInlineUiFromLivePlugin();
+}
+
+void DeviceSlotComponent::aiSoundDesignerPreferenceChanged(const juce::String& pluginIdentifier) {
+    // Only re-lay-out if the toggle was for this slot's device.
+    if (pluginIdentifier != magda::PluginPreferences::identifierForDevice(device_))
+        return;
+    resized();
+    repaint();
 }
 
 void DeviceSlotComponent::timerCallback() {

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
@@ -7,6 +7,7 @@
 #include "core/AutomationManager.hpp"
 #include "core/DeviceInfo.hpp"
 #include "core/GainStagingManager.hpp"
+#include "core/PluginPreferences.hpp"
 #include "core/TrackManager.hpp"
 #include "core/controllers/BindingRegistry.hpp"
 #include "core/controllers/ControllerRegistry.hpp"
@@ -50,7 +51,8 @@ class DeviceSlotComponent : public NodeComponent,
                             public juce::Timer,
                             public magda::TrackManagerListener,
                             public magda::AutomationManagerListener,
-                            public magda::GainStagingListener {
+                            public magda::GainStagingListener,
+                            public magda::PluginPreferences::Listener {
   public:
     static constexpr int BASE_SLOT_WIDTH = 450;  // Maximum width (8 columns)
     static constexpr int NUM_PARAMS_PER_PAGE = 32;
@@ -215,6 +217,10 @@ class DeviceSlotComponent : public NodeComponent,
     // device's staging state changes.
     void deviceGainStageChanged(const magda::ChainNodePath& devicePath,
                                 const magda::DeviceGainStageInfo& info) override;
+
+    // PluginPreferences::Listener — re-layout the header when the user toggles
+    // this device's AI Sound Designer exposure from the plugin browser.
+    void aiSoundDesignerPreferenceChanged(const juce::String& pluginIdentifier) override;
 
   private:
     magda::DeviceInfo device_;

--- a/magda/daw/ui/components/chain/slot/DeviceSlotHeaderSpec.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotHeaderSpec.cpp
@@ -1,10 +1,28 @@
 #include "slot/DeviceSlotHeaderSpec.hpp"
 
 #include "core/PluginCapabilities.hpp"
+#include "core/PluginPreferences.hpp"
 #include "drum_grid/DeviceSlotDrumGridBridge.hpp"
 
 namespace magda::daw::ui {
 namespace {
+
+// The AI Sound Designer icon/panel is exposed per-device: a plugin with a
+// registered agent shows it unless the user has hidden it from the plugin
+// browser (PluginPreferences, opt-out).
+bool aiSoundDesignerEnabledForDevice(const magda::DeviceInfo& device) {
+    return magda::PluginPreferences::getInstance().aiSoundDesignerEnabled(
+        magda::PluginPreferences::identifierForDevice(device));
+}
+
+// Single source of truth for the AI Sound Designer control: shown whenever the
+// device has a registered AI agent (sound-design or coder) and the user hasn't
+// hidden it per-device. Both the collapsed and expanded headers read this via
+// HeaderControlVisibility::ai.
+bool aiSoundDesignerControlVisible(const DeviceSlotTraits& traits,
+                                   const magda::DeviceInfo& device) {
+    return traits.isAISupported && aiSoundDesignerEnabledForDevice(device);
+}
 
 bool getExpandedVisibility(HeaderControlId id, const HeaderControlVisibility& visibility) {
     switch (id) {
@@ -48,7 +66,7 @@ bool getCollapsedVisibility(HeaderControlId id, const HeaderControlVisibility& v
         case HeaderControlId::Mod:
             return visibility.mod;
         case HeaderControlId::AI:
-            return traits.isSoundDesignSupported;
+            return visibility.ai;
         case HeaderControlId::Random:
             return visibility.random;
         case HeaderControlId::StepRecord:
@@ -88,8 +106,7 @@ HeaderControlVisibility getHeaderControlVisibility(const DeviceSlotTraits& trait
     visibility.mod = drum_grid_slot::shouldShowModButton(traits.isDrumGrid, device.deviceType);
     visibility.macro = visibility.mod || traits.isArpeggiator || traits.isStrum ||
                        traits.isStepSequencer || traits.isPolyStepSequencer;
-    visibility.ai = traits.isAISupported && (visibility.mod || traits.isArpeggiator ||
-                                             traits.isStepSequencer || traits.isPolyStepSequencer);
+    visibility.ai = aiSoundDesignerControlVisible(traits, device);
     visibility.random = traits.isStepSequencer || traits.isPolyStepSequencer;
     visibility.stepRecord = visibility.random;
     visibility.midiThru = supportsMidiSourceToggle(device);

--- a/magda/daw/ui/panels/content/PluginBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.cpp
@@ -2,6 +2,7 @@
 
 #include <BinaryData.h>
 
+#include "../../../../agents/sound_design_agent.hpp"
 #include "../../dialogs/ParameterConfigDialog.hpp"
 #include "../../themes/DarkTheme.hpp"
 #include "../../themes/FontManager.hpp"
@@ -790,6 +791,15 @@ void PluginBrowserContent::showPluginContextMenu(const PluginBrowserInfo& plugin
 
     const auto pluginIdentifier = preferenceIdentifierForPlugin(plugin);
 
+    // Devices with a registered sound-design agent can have their AI Sound
+    // Designer icon/panel exposed or hidden per-device (opt-out, defaults on).
+    if (magda::isSoundDesignSupported(plugin.uniqueId)) {
+        menu.addItem(
+            12, "AI Sound Designer", true,
+            magda::PluginPreferences::getInstance().aiSoundDesignerEnabled(pluginIdentifier));
+        menu.addSeparator();
+    }
+
     // Instrument-form plugins can be manually routed as MIDI FX when their
     // runtime metadata is too synth-like to classify automatically.
     if (plugin.category == "Instrument") {
@@ -910,6 +920,13 @@ void PluginBrowserContent::showPluginContextMenu(const PluginBrowserInfo& plugin
                             p.categoryOverride = prefs.browserCategoryOverride(pluginIdentifier);
                     }
                     rebuildTree();
+                    break;
+                }
+                case 12: {
+                    auto& prefs = magda::PluginPreferences::getInstance();
+                    const auto pluginIdentifier = preferenceIdentifierForPlugin(plugin);
+                    prefs.setAiSoundDesignerEnabled(
+                        pluginIdentifier, !prefs.aiSoundDesignerEnabled(pluginIdentifier));
                     break;
                 }
                 case 98:


### PR DESCRIPTION
Add a generic, parameter-introspection SoundDesignAgent that drives any sound generator whose controls are automatable parameters — the compiled Faust synths (Poly Synth, FM, percussion) and the native Mutable ports (Elements, Rings). It introspects the device's parameters at runtime (names, units, real-unit ranges, discrete choices), has the LLM pick values in real units, and applies them via the shared setDeviceParameterValue path.

4OSC keeps its bespoke agent for now — its wave/filter/voice/FX controls are ValueTree properties, not automatable params. TODO: make those automatable and retire FourOscAgent so 4OSC joins the generic path.

Also: per-device opt-out toggle (PluginPreferences + plugin-browser context menu) that hides the AI Sound Designer panel per device, and a single aiSoundDesignerControlVisible property unifying the header AI-button visibility across collapsed and expanded headers.