### PR TITLE
Preserve plugins on unmounted volumes

### DIFF
--- a/magda/daw/engine/TracktionEngineWrapper.hpp
+++ b/magda/daw/engine/TracktionEngineWrapper.hpp
@@ -447,13 +447,20 @@ class TracktionEngineWrapper : public AudioEngine,
      * @brief Remove entries from the given known-plugin list whose plugins
      * are no longer installed. Delegates per-entry to
      * AudioPluginFormatManager::doesPluginStillExist so each format decides
-     * correctly — VST/VST3 stat the file path, AU queries AudioComponentFindNext
+     * correctly — VST3 checks the bundle path, AU queries AudioComponentFindNext
      * on the identifier (a plain File::exists() skips every AU entry because
      * their fileOrIdentifier is "AudioUnit:..." and not an absolute path).
+     * Missing file-based plugins on an unavailable external volume are retained:
+     * the missing path does not prove that the plugin was uninstalled.
+     *
+     * @param volumeIsMounted Optional test seam. Receives the external-volume
+     * root inferred from a plugin path and returns whether that root is mounted.
+     * Production callers omit it and use the native mount table.
      * Returns the number of entries removed.
      */
     static int pruneMissingPlugins(juce::KnownPluginList& knownPlugins,
-                                   juce::AudioPluginFormatManager& formatManager);
+                                   juce::AudioPluginFormatManager& formatManager,
+                                   std::function<bool(const juce::String&)> volumeIsMounted = {});
 
     /**
      * @brief Remove entries that share (path, format) with a freshly-scanned

--- a/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperPlugins.cpp
@@ -1,7 +1,14 @@
+#include <fstream>
 #include <map>
+#include <optional>
 #include <set>
+#include <sstream>
 #include <thread>
 #include <utility>
+
+#if defined(__APPLE__)
+    #include <sys/mount.h>
+#endif
 
 #include "../core/AppPaths.hpp"
 #include "PluginScanCoordinator.hpp"
@@ -10,6 +17,113 @@
 #include "core/PluginPreferences.hpp"
 
 namespace magda {
+namespace {
+
+std::optional<juce::String> externalVolumeRootForPath(const juce::String& path) {
+#if JUCE_MAC
+    const juce::String prefix = "/Volumes/";
+    if (!path.startsWith(prefix))
+        return std::nullopt;
+
+    const int volumeEnd = path.indexOfChar(prefix.length(), '/');
+    if (volumeEnd < 0)
+        return std::nullopt;
+    return path.substring(0, volumeEnd);
+#elif JUCE_WINDOWS
+    if (path.length() >= 3 && juce::CharacterFunctions::isLetter(path[0]) && path[1] == ':' &&
+        (path[2] == '\\' || path[2] == '/')) {
+        return path.substring(0, 3);
+    }
+
+    auto normalized = path.replaceCharacter('\\', '/');
+    if (!normalized.startsWith("//"))
+        return std::nullopt;
+    const int serverEnd = normalized.indexOfChar(2, '/');
+    if (serverEnd < 0)
+        return std::nullopt;
+    const int shareEnd = normalized.indexOfChar(serverEnd + 1, '/');
+    if (shareEnd < 0)
+        return std::nullopt;
+    return normalized.substring(0, shareEnd);
+#elif JUCE_LINUX
+    auto rootWithComponents = [&path](const juce::String& prefix,
+                                      int componentCount) -> std::optional<juce::String> {
+        if (!path.startsWith(prefix))
+            return std::nullopt;
+        int end = static_cast<int>(prefix.length());
+        for (int component = 0; component < componentCount; ++component) {
+            end = path.indexOfChar(end, '/');
+            if (end < 0)
+                return std::nullopt;
+            if (component + 1 < componentCount)
+                ++end;
+        }
+        return path.substring(0, end);
+    };
+
+    if (auto root = rootWithComponents("/run/media/", 2))
+        return root;
+    if (auto root = rootWithComponents("/media/", 2))
+        return root;
+    return rootWithComponents("/mnt/", 1);
+#else
+    juce::ignoreUnused(path);
+    return std::nullopt;
+#endif
+}
+
+#if JUCE_LINUX
+juce::String decodeMountInfoPath(const juce::String& encoded) {
+    return encoded.replace("\\040", " ")
+        .replace("\\011", "\t")
+        .replace("\\012", "\n")
+        .replace("\\134", "\\");
+}
+#endif
+
+bool isVolumeMounted(const juce::String& root) {
+#if JUCE_MAC
+    struct statfs* mounts = nullptr;
+    const int count = getmntinfo(&mounts, MNT_NOWAIT);
+    for (int i = 0; i < count; ++i) {
+        if (juce::String::fromUTF8(mounts[i].f_mntonname) == root)
+            return true;
+    }
+    return false;
+#elif JUCE_LINUX
+    std::ifstream input("/proc/self/mountinfo");
+    std::string line;
+    while (std::getline(input, line)) {
+        std::istringstream fields(line);
+        std::string mountId;
+        std::string parentId;
+        std::string device;
+        std::string filesystemRoot;
+        std::string mountPoint;
+        if (fields >> mountId >> parentId >> device >> filesystemRoot >> mountPoint) {
+            if (decodeMountInfoPath(juce::String::fromUTF8(mountPoint.c_str())) == root)
+                return true;
+        }
+    }
+    return false;
+#elif JUCE_WINDOWS
+    return juce::File(root).isDirectory();
+#else
+    juce::ignoreUnused(root);
+    return true;
+#endif
+}
+
+bool shouldPreserveUnavailablePlugin(
+    const juce::PluginDescription& desc,
+    const std::function<bool(const juce::String&)>& volumeIsMounted) {
+    if (!juce::File::isAbsolutePath(desc.fileOrIdentifier))
+        return false;
+    const auto root = externalVolumeRootForPath(desc.fileOrIdentifier);
+    return root.has_value() && !volumeIsMounted(*root);
+}
+
+}  // namespace
 
 std::string TracktionEngineWrapper::addEffect(const std::string& track_id,
                                               const std::string& effect_name) {
@@ -284,15 +398,25 @@ int TracktionEngineWrapper::removeSupersededEntries(
     return superseded.size();
 }
 
-int TracktionEngineWrapper::pruneMissingPlugins(juce::KnownPluginList& knownPlugins,
-                                                juce::AudioPluginFormatManager& formatManager) {
+int TracktionEngineWrapper::pruneMissingPlugins(
+    juce::KnownPluginList& knownPlugins, juce::AudioPluginFormatManager& formatManager,
+    std::function<bool(const juce::String&)> volumeIsMounted) {
+    if (!volumeIsMounted)
+        volumeIsMounted = isVolumeMounted;
+
     juce::Array<juce::PluginDescription> stalePlugins;
     for (int i = 0; i < knownPlugins.getNumTypes(); ++i) {
         auto* desc = knownPlugins.getType(i);
         if (!desc)
             continue;
-        if (!formatManager.doesPluginStillExist(*desc))
+        if (formatManager.doesPluginStillExist(*desc))
+            continue;
+        if (!shouldPreserveUnavailablePlugin(*desc, volumeIsMounted)) {
             stalePlugins.add(*desc);
+        } else {
+            DBG("Keeping unavailable plugin on unmounted volume: "
+                << desc->name << " (" << desc->fileOrIdentifier << ")");
+        }
     }
 
     for (const auto& desc : stalePlugins) {

--- a/tests/test_prune_missing_plugins.cpp
+++ b/tests/test_prune_missing_plugins.cpp
@@ -152,14 +152,17 @@ TEST_CASE("pruneMissingPlugins preserves entries on an unavailable external volu
     list.addType(makeDesc("ExternalVST3", external.pluginPath));
     list.addType(makeDesc("UninstalledLocalVST3", makeAbsentAbsolutePath("Uninstalled.vst3")));
 
-    juce::String probedRoot;
+    bool probedExternalRoot = false;
     const int removed = TracktionEngineWrapper::pruneMissingPlugins(
-        list, formatManager, [&probedRoot](const juce::String& root) {
-            probedRoot = root;
-            return false;
+        list, formatManager, [&external, &probedExternalRoot](const juce::String& root) {
+            if (root == external.volumeRoot) {
+                probedExternalRoot = true;
+                return false;
+            }
+            return true;
         });
 
-    CHECK(probedRoot == external.volumeRoot);
+    CHECK(probedExternalRoot);
     CHECK(removed == 1);
     CHECK(listContainsName(list, "ExternalVST3"));
     CHECK_FALSE(listContainsName(list, "UninstalledLocalVST3"));

--- a/tests/test_prune_missing_plugins.cpp
+++ b/tests/test_prune_missing_plugins.cpp
@@ -67,6 +67,24 @@ void registerTestFormats(juce::AudioPluginFormatManager& fm) {
 #endif
 }
 
+struct ExternalPluginPath {
+    juce::String volumeRoot;
+    juce::String pluginPath;
+};
+
+ExternalPluginPath makeExternalPluginPath() {
+#if JUCE_MAC
+    return {"/Volumes/MAGDA Test Plugins", "/Volumes/MAGDA Test Plugins/VST3/MissingExternal.vst3"};
+#elif JUCE_WINDOWS
+    return {"Z:\\", "Z:\\VST3\\MissingExternal.vst3"};
+#elif JUCE_LINUX
+    return {"/media/magda/MAGDA Test Plugins",
+            "/media/magda/MAGDA Test Plugins/vst3/MissingExternal.vst3"};
+#else
+    return {};
+#endif
+}
+
 }  // namespace
 
 TEST_CASE("pruneMissingPlugins removes stale entries across formats", "[plugin][prune]") {
@@ -117,4 +135,58 @@ TEST_CASE("pruneMissingPlugins handles an empty list", "[plugin][prune]") {
     juce::KnownPluginList list;
     CHECK(TracktionEngineWrapper::pruneMissingPlugins(list, formatManager) == 0);
     CHECK(list.getNumTypes() == 0);
+}
+
+TEST_CASE("pruneMissingPlugins preserves entries on an unavailable external volume",
+          "[plugin][prune]") {
+    const auto external = makeExternalPluginPath();
+    if (external.volumeRoot.isEmpty()) {
+        SUCCEED("External-volume path classification is not supported on this platform");
+        return;
+    }
+
+    juce::AudioPluginFormatManager formatManager;
+    registerTestFormats(formatManager);
+
+    juce::KnownPluginList list;
+    list.addType(makeDesc("ExternalVST3", external.pluginPath));
+    list.addType(makeDesc("UninstalledLocalVST3", makeAbsentAbsolutePath("Uninstalled.vst3")));
+
+    juce::String probedRoot;
+    const int removed = TracktionEngineWrapper::pruneMissingPlugins(
+        list, formatManager, [&probedRoot](const juce::String& root) {
+            probedRoot = root;
+            return false;
+        });
+
+    CHECK(probedRoot == external.volumeRoot);
+    CHECK(removed == 1);
+    CHECK(listContainsName(list, "ExternalVST3"));
+    CHECK_FALSE(listContainsName(list, "UninstalledLocalVST3"));
+}
+
+TEST_CASE("pruneMissingPlugins removes a missing plugin when its external volume is mounted",
+          "[plugin][prune]") {
+    const auto external = makeExternalPluginPath();
+    if (external.volumeRoot.isEmpty()) {
+        SUCCEED("External-volume path classification is not supported on this platform");
+        return;
+    }
+
+    juce::AudioPluginFormatManager formatManager;
+    registerTestFormats(formatManager);
+
+    juce::KnownPluginList list;
+    list.addType(makeDesc("UninstalledExternalVST3", external.pluginPath));
+
+    juce::String probedRoot;
+    const int removed = TracktionEngineWrapper::pruneMissingPlugins(
+        list, formatManager, [&probedRoot](const juce::String& root) {
+            probedRoot = root;
+            return true;
+        });
+
+    CHECK(probedRoot == external.volumeRoot);
+    CHECK(removed == 1);
+    CHECK_FALSE(listContainsName(list, "UninstalledExternalVST3"));
 }


### PR DESCRIPTION
## What changed

- make startup plugin-cache pruning aware of unavailable external volumes
- infer external-volume roots for macOS, Windows drive/UNC paths, and common Linux removable-media mount paths
- consult the native mount table before removing a missing file-based plugin
- retain JUCE's format-specific Audio Unit existence checks
- add regression coverage for disconnected volumes and genuine uninstalls on mounted volumes

## Why

`pruneMissingPlugins` treated every missing VST3 bundle path as an uninstall. If MAGDA launched while the external drive containing that bundle was disconnected, the cached entry was removed; reconnecting the drive on the next launch then caused the plugin to be detected and scanned from scratch.

## Impact

Temporarily disconnecting a plugin-bearing external drive no longer invalidates those cached plugins. Plugins that are genuinely removed while their volume is mounted are still pruned normally.

Closes #1170.

## Validation

- `[plugin][prune]`: 23 assertions across 5 test cases
- `[plugin][duplicates]`: 32 assertions across 14 test cases
- `cmake --build cmake-build-debug --target magda_tests -j 8`
- repository pre-commit checks
