### PR TITLE
Extract magda_types value-type leaf library (#1831)

### DIFF
--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -263,6 +263,35 @@ juce_add_binary_data(MagdaAssets
 # Targets
 # =============================================================================
 
+# magda_types: leaf library of JUCE-only value types shared by the DAW today and
+# the device library later (epic #1836 / #1831). It borrows juce_core's headers
+# and defines but does NOT link the module: the juce_core unity source is
+# compiled once in magda_daw, so magda_types' undefined juce symbols resolve at
+# the final link instead of duplicating the object. The value-type headers stay
+# physically in core/ for now; relocating them into their own directory (and the
+# include-boundary guard) lands with the device-library carve (#1834).
+add_library(magda_types STATIC
+    core/ParameterUtils.cpp
+    # value-type headers (listed to document the leaf's surface)
+    core/TypeIds.hpp
+    core/TechnicalText.hpp
+    core/ChainNodePath.hpp
+    core/ControlTarget.hpp
+    core/ParameterInfo.hpp
+    core/ParameterUtils.hpp
+    core/DeviceInfo.hpp
+    core/KitRow.hpp
+    core/MacroInfo.hpp
+    core/ModInfo.hpp
+    core/TempoUtils.hpp
+)
+target_compile_features(magda_types PUBLIC cxx_std_20)
+target_include_directories(magda_types
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}  # dependents resolve "core/<type>.hpp"
+    PRIVATE $<TARGET_PROPERTY:juce::juce_core,INTERFACE_INCLUDE_DIRECTORIES>)
+target_compile_definitions(magda_types
+    PRIVATE $<TARGET_PROPERTY:juce::juce_core,INTERFACE_COMPILE_DEFINITIONS>)
+
 # Core library — populated by per-subdir CMakeLists.txt below.
 add_library(magda_daw STATIC
     command.cpp
@@ -450,6 +479,7 @@ set(MAGDA_JUCE_STACK
 )
 target_link_libraries(magda_daw
     PUBLIC
+    magda_types  # leaf value-type library (#1831); its types appear in magda_daw's public headers
     MagdaAssets
     magda::mutable  # Mutable Instruments DSP for the native Elements/Rings/Clouds ports (#1581)
     PRIVATE

--- a/magda/daw/audio/processors/external/ExternalPluginProcessor.cpp
+++ b/magda/daw/audio/processors/external/ExternalPluginProcessor.cpp
@@ -88,6 +88,7 @@ ParameterInfo ExternalPluginProcessor::getParameterInfo(int index) const {
         auto provider = std::make_shared<ParameterInfo::DisplayTextProvider>();
         provider->deviceId = getDeviceId();
         provider->paramIndex = index;
+        provider->formatter = formatParameterDisplayTextFromDevice;
         info.displayText = std::move(provider);
     }
 

--- a/magda/daw/audio/processors/internal/NativeDeviceProcessors.cpp
+++ b/magda/daw/audio/processors/internal/NativeDeviceProcessors.cpp
@@ -90,6 +90,7 @@ void FourOscProcessor::customiseParameterInfo(int index, ParameterInfo& info) co
         auto provider = std::make_shared<ParameterInfo::DisplayTextProvider>();
         provider->deviceId = getDeviceId();
         provider->paramIndex = index;
+        provider->formatter = formatParameterDisplayTextFromDevice;
         info.displayText = std::move(provider);
     }
 }

--- a/magda/daw/core/AutomationInfo.cpp
+++ b/magda/daw/core/AutomationInfo.cpp
@@ -181,6 +181,7 @@ ParameterInfo getParameterInfoForTarget(const AutomationTarget& target) {
                 provider->devicePath = target.devicePath;
                 provider->deviceId = target.devicePath.getDeviceId();
                 provider->paramIndex = target.paramIndex;
+                provider->formatter = formatParameterDisplayTextFromDevice;
                 stored->displayText = std::move(provider);
             }
             return *stored;

--- a/magda/daw/core/CMakeLists.txt
+++ b/magda/daw/core/CMakeLists.txt
@@ -38,8 +38,7 @@ target_sources(magda_daw PRIVATE
     AutomationCommands.cpp
     ClipLaneFlattener.cpp
     MidiNoteCommands.cpp
-    ParameterInfo.cpp
-    ParameterUtils.cpp
+    ParameterInfo.cpp  # DisplayTextProvider glue (TrackManager/DeviceProcessor); stays in magda_daw
     StringTable.cpp
     ParameterDetector.cpp
     PresetManager.cpp
@@ -75,7 +74,6 @@ target_sources(magda_daw PRIVATE
     GridDivision.hpp
     AppPaths.hpp
     UIScale.hpp
-    DeviceInfo.hpp
     DeviceUiContext.hpp
     ViewModeState.hpp
     ViewModeEvents.hpp
@@ -110,19 +108,12 @@ target_sources(magda_daw PRIVATE
     MidiNoteCommands.hpp
     ChordAnnotationCommands.hpp
     ChordProgressionConverter.hpp
-    MacroInfo.hpp
-    ModInfo.hpp
-    ParameterInfo.hpp
     ParameterDetector.hpp
-    ParameterUtils.hpp
-    TempoUtils.hpp
-    TechnicalText.hpp
     AutomationTypes.hpp
     AutomationInfo.hpp
     AutomationManager.hpp
     PresetManager.hpp
     DrumkitManager.hpp
-    KitRow.hpp
     PluginPreferences.hpp
     PluginCapabilities.hpp
     PluginPresetScanner.hpp

--- a/magda/daw/core/ParameterInfo.cpp
+++ b/magda/daw/core/ParameterInfo.cpp
@@ -7,7 +7,8 @@
 
 namespace magda {
 
-juce::String ParameterInfo::DisplayTextProvider::format(float normalizedValue) const {
+juce::String formatParameterDisplayTextFromDevice(
+    const ParameterInfo::DisplayTextProvider& provider, float normalizedValue) {
     auto* engine = TrackManager::getInstance().getAudioEngine();
     if (!engine)
         return {};
@@ -15,16 +16,16 @@ juce::String ParameterInfo::DisplayTextProvider::format(float normalizedValue) c
     if (!bridge)
         return {};
 
-    auto path = devicePath;
-    if (!path.isValid() && deviceId != INVALID_DEVICE_ID)
-        path = TrackManager::getInstance().findDevicePath(deviceId);
+    auto path = provider.devicePath;
+    if (!path.isValid() && provider.deviceId != INVALID_DEVICE_ID)
+        path = TrackManager::getInstance().findDevicePath(provider.deviceId);
     if (!path.isValid())
         return {};
 
     auto* processor = bridge->getDeviceProcessor(path);
     if (!processor)
         return {};
-    return processor->formatParameterValue(paramIndex, normalizedValue);
+    return processor->formatParameterValue(provider.paramIndex, normalizedValue);
 }
 
 }  // namespace magda

--- a/magda/daw/core/ParameterInfo.hpp
+++ b/magda/daw/core/ParameterInfo.hpp
@@ -124,10 +124,16 @@ struct ParameterInfo {
     // gone). Preferred over valueTable when set — exact values, no quantization.
     // Shared so ParameterInfo copies remain cheap.
     struct DisplayTextProvider {
+        using Formatter = juce::String (*)(const DisplayTextProvider&, float);
+
         ChainNodePath devicePath;
         int deviceId = -1;
         int paramIndex = -1;
-        juce::String format(float normalizedValue) const;
+        Formatter formatter = nullptr;
+
+        juce::String format(float normalizedValue) const {
+            return formatter != nullptr ? formatter(*this, normalizedValue) : juce::String{};
+        }
     };
     std::shared_ptr<DisplayTextProvider> displayText;
 
@@ -185,6 +191,12 @@ struct ParameterInfo {
         return minValue < 0.0f && maxValue > 0.0f;
     }
 };
+
+// DAW-side formatter injected into DisplayTextProvider instances that need a
+// live plugin lookup. Keeping the provider's dispatch inline prevents the
+// magda_types leaf archive from acquiring a link-time dependency on magda_daw.
+juce::String formatParameterDisplayTextFromDevice(
+    const ParameterInfo::DisplayTextProvider& provider, float normalizedValue);
 
 struct ParameterNormalizedValue {
     float value = 0.0f;


### PR DESCRIPTION
Create a magda_types STATIC library owning the JUCE-only value-type cluster (TypeIds, DeviceInfo, ParameterInfo/Utils, Macro/Mod/ControlTarget, ChainNodePath, TechnicalText, KitRow, TempoUtils). It compiles ParameterUtils.cpp against juce_core's headers/defines only (borrowed, not linked, so the module unity source is not duplicated); magda_daw links it PUBLIC. The DisplayTextProvider glue (ParameterInfo.cpp) stays in magda_daw.

Headers stay physically in core/ for now; relocating them into their own directory and the include-boundary guard land with the device-library carve (#1834).

First phase of the device-decouple epic (#1836).