### PR TITLE
Devices decouple 3: inject DAW services and extract magda_music

### DIFF
--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -496,6 +496,7 @@ set(MAGDA_JUCE_STACK
 target_link_libraries(magda_daw
     PUBLIC
     magda_types  # leaf value-type library (#1831); its types appear in magda_daw's public headers
+    magda_music  # leaf music-theory library (#1833)
     MagdaAssets
     magda::mutable  # Mutable Instruments DSP for the native Elements/Rings/Clouds ports (#1581)
     PRIVATE

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -14,6 +14,7 @@
 #include "AudioThumbnailManager.hpp"
 #include "Vst3Preset.hpp"
 #include "modifiers/ADSRDebugLog.hpp"
+#include "plugins/DeviceServices.hpp"
 #include "plugins/InternalPluginRegistry.hpp"
 #include "plugins/MidiInThruSync.hpp"
 #include "processors/ParameterDisplayTextProvider.hpp"
@@ -115,7 +116,8 @@ AudioBridge::AudioBridge(te::Engine& engine, te::Edit& edit)
     : engine_(engine),
       edit_(edit),
       trackController_(engine, edit),
-      pluginManager_(engine, edit, trackController_, pluginWindowBridge_, transportState_),
+      pluginManager_(engine, edit, trackController_, pluginWindowBridge_, transportState_,
+                     TrackManager::getInstance()),
       mixer_(edit, trackController_),
       midiInputRouter_(engine, edit, trackController_),
       controlTargetResolver_(trackController_, pluginManager_),
@@ -125,6 +127,17 @@ AudioBridge::AudioBridge(te::Engine& engine, te::Edit& edit)
       clipSynchronizer_(edit, trackController_, warpMarkerManager_),
       automationPlayback_(*this, edit),
       automationRecording_(edit) {
+    const auto oscilloscopeDefaults = Config::getInstance().getOscilloscopeDefaults();
+    const auto spectrumDefaults = Config::getInstance().getSpectrumDefaults();
+    daw::audio::DeviceServices deviceServices;
+    deviceServices.deviceIdAllocator = &TrackManager::getInstance();
+    deviceServices.trackContext = &TrackManager::getInstance();
+    deviceServices.defaults.oscilloscope.timebaseMs = oscilloscopeDefaults.timebaseMs;
+    deviceServices.defaults.spectrum.fftOrder = spectrumDefaults.fftOrder;
+    deviceServices.defaults.spectrum.slopeDbPerOct = spectrumDefaults.slopeDbPerOct;
+    deviceServices.defaults.spectrum.smoothing = spectrumDefaults.smoothing;
+    daw::audio::registerDeviceServices(edit_, deviceServices);
+
     installDeviceParameterDisplayTextProviderFactory();
 
     // Wire up async plugin load completion callback to notify UI
@@ -164,6 +177,7 @@ AudioBridge::AudioBridge(te::Engine& engine, te::Edit& edit)
 
 AudioBridge::~AudioBridge() {
     DBG("AudioBridge::~AudioBridge - starting cleanup");
+    daw::audio::unregisterDeviceServices(edit_);
 
     // CRITICAL: Acquire lock BEFORE stopping timer to ensure proper synchronization.
     // This prevents race condition where timerCallback() could be running while

--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -384,6 +384,8 @@ target_sources(magda_daw PRIVATE
     session/SessionRecorder.cpp
     plugins/BaseDevicePack.cpp
     plugins/BaseDevicePack.hpp
+    plugins/DeviceServices.cpp
+    plugins/DeviceServices.hpp
     plugins/InternalPluginRegistry.cpp
     plugins/InternalPluginRegistry.hpp
     # Phase 1: Pure data managers
@@ -502,6 +504,23 @@ target_sources(magda_daw PRIVATE
     plugins/StepSequencerPlugin.hpp
     plugins/PolyStepSequencerPlugin.hpp
 )
+
+# Device implementations must receive project state through DeviceServices,
+# never reach upward into the DAW's singleton managers.
+file(GLOB_RECURSE _magda_device_sources CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/plugins/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/plugins/*.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/processors/external/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/processors/external/*.hpp"
+)
+foreach(_magda_daw_audio_source_path IN LISTS _magda_device_sources)
+    file(READ "${_magda_daw_audio_source_path}" _magda_daw_audio_source_text)
+    if(_magda_daw_audio_source_text MATCHES "(TrackManager|Config)::getInstance[ \t]*\\(")
+        message(FATAL_ERROR
+            "Device source calls a DAW singleton instead of DeviceServices: "
+            "${_magda_daw_audio_source_path}")
+    endif()
+endforeach()
 
 target_sources(magda_daw_app PRIVATE
     AudioEngineOptimizer.cpp

--- a/magda/daw/audio/plugin_manager/PluginManager.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.cpp
@@ -174,12 +174,14 @@ void captureVst3Info(DeviceInfo& devInfo, te::ExternalPlugin* ext) {
 
 PluginManager::PluginManager(te::Engine& engine, te::Edit& edit, TrackController& trackController,
                              PluginWindowBridge& pluginWindowBridge,
-                             TransportStateManager& transportState)
+                             TransportStateManager& transportState,
+                             daw::audio::DeviceTrackContext& deviceTrackContext)
     : engine_(engine),
       edit_(edit),
       trackController_(trackController),
       pluginWindowBridge_(pluginWindowBridge),
       transportState_(transportState),
+      deviceTrackContext_(deviceTrackContext),
       instrumentRackManager_(edit),
       rackSyncManager_(edit, *this) {}
 

--- a/magda/daw/audio/plugin_manager/PluginManager.hpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.hpp
@@ -14,6 +14,7 @@
 #include "../../core/SelectionManager.hpp"
 #include "../../core/TypeIds.hpp"
 #include "modifiers/CurveSnapshot.hpp"
+#include "plugins/DeviceServices.hpp"
 #include "plugins/DrumGridPlugin.hpp"
 #include "processors/base/DeviceProcessor.hpp"
 #include "racks/InstrumentRackManager.hpp"
@@ -79,7 +80,8 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener {
      * @param transportState Reference to TransportStateManager for transport state
      */
     PluginManager(te::Engine& engine, te::Edit& edit, TrackController& trackController,
-                  PluginWindowBridge& pluginWindowBridge, TransportStateManager& transportState);
+                  PluginWindowBridge& pluginWindowBridge, TransportStateManager& transportState,
+                  daw::audio::DeviceTrackContext& deviceTrackContext);
 
     // =========================================================================
     // Plugin/Device Lookup
@@ -607,6 +609,7 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener {
     TrackController& trackController_;
     PluginWindowBridge& pluginWindowBridge_;
     TransportStateManager& transportState_;
+    daw::audio::DeviceTrackContext& deviceTrackContext_;
 
     // Instrument rack wrapping (synth + audio passthrough)
     InstrumentRackManager instrumentRackManager_;

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -1334,7 +1334,8 @@ void PluginManager::pollAsyncPluginLoad(const ChainNodePath& devicePath, te::Plu
             }
 
             // Create processor now that the plugin instance is ready
-            auto processor = createDeviceProcessorForPlugin(deviceId, plugin, {});
+            auto processor =
+                createDeviceProcessorForPlugin(deviceId, plugin, {}, &self.deviceTrackContext_);
 
             // Populate parameters on the DeviceInfo
             if (processor) {
@@ -2068,7 +2069,8 @@ void PluginManager::registerRackPluginProcessor(const ChainNodePath& devicePath,
     if (!plugin)
         return;
 
-    auto processor = createDeviceProcessorForPlugin(deviceId, plugin, device.pluginId);
+    auto processor =
+        createDeviceProcessorForPlugin(deviceId, plugin, device.pluginId, &deviceTrackContext_);
 
     if (processor) {
         // Saved params (baseline) then native chunk (authoritative overlay) then
@@ -2289,7 +2291,8 @@ te::Plugin::Ptr PluginManager::loadDeviceAsPlugin(const ChainNodePath& devicePat
     }
 
     if (plugin && !processor)
-        processor = createDeviceProcessorForPlugin(device.id, plugin, device.pluginId);
+        processor = createDeviceProcessorForPlugin(device.id, plugin, device.pluginId,
+                                                   &deviceTrackContext_);
 
     if (plugin) {
         // Update capability flags on the DeviceInfo in TrackManager

--- a/magda/daw/audio/plugins/BaseDevicePack.cpp
+++ b/magda/daw/audio/plugins/BaseDevicePack.cpp
@@ -6,6 +6,7 @@
 #include "TracktionHelpers.hpp"
 #include "plugins/ArpeggiatorPlugin.hpp"
 #include "plugins/AudioSidechainMonitorPlugin.hpp"
+#include "plugins/DeviceServices.hpp"
 #include "plugins/DrumGridPlugin.hpp"
 #include "plugins/FaustInstrumentPlugin.hpp"
 #include "plugins/FaustPlugin.hpp"
@@ -50,6 +51,32 @@ std::unique_ptr<DeviceProcessor> makeProcessor(DeviceId deviceId, te::Plugin::Pt
 template <typename PluginType>
 te::Plugin::Ptr createCustomPlugin(const te::PluginCreationInfo& info) {
     return new PluginType(info);
+}
+
+te::Plugin::Ptr createDrumGridPlugin(const te::PluginCreationInfo& info) {
+    auto services = getDeviceServices(info.edit);
+    jassert(services.deviceIdAllocator != nullptr);
+    return new DrumGridPlugin(info, *services.deviceIdAllocator);
+}
+
+te::Plugin::Ptr createMidiChordEnginePlugin(const te::PluginCreationInfo& info) {
+    auto services = getDeviceServices(info.edit);
+    return new MidiChordEnginePlugin(info, services.trackContext);
+}
+
+te::Plugin::Ptr createOscilloscopePlugin(const te::PluginCreationInfo& info) {
+    auto services = getDeviceServices(info.edit);
+    return new OscilloscopePlugin(info, services.defaults.oscilloscope);
+}
+
+te::Plugin::Ptr createSpectrumAnalyzerPlugin(const te::PluginCreationInfo& info) {
+    auto services = getDeviceServices(info.edit);
+    return new SpectrumAnalyzerPlugin(info, services.defaults.spectrum);
+}
+
+te::Plugin::Ptr createMidiReceivePlugin(const te::PluginCreationInfo& info) {
+    auto services = getDeviceServices(info.edit);
+    return new ::magda::MidiReceivePlugin(info, services.defaults.midiReceive);
 }
 
 te::Plugin::Ptr createFreshValueTreePlugin(te::Edit& edit, const char* xmlTypeName) {
@@ -370,7 +397,7 @@ void registerNativeDevices(InternalPluginRegistry& registry) {
          .tags = kDrumGridTags,
          .tagCount = static_cast<int>(std::size(kDrumGridTags)),
          .createInEdit = createFreshValueTreePlugin,
-         .createCustomPlugin = createCustomPlugin<DrumGridPlugin>});
+         .createCustomPlugin = createDrumGridPlugin});
     add(registry,
         {.pluginId = MidiChordEnginePlugin::xmlTypeName,
          .displayName = "Chord Engine",
@@ -382,7 +409,7 @@ void registerNativeDevices(InternalPluginRegistry& registry) {
          .tags = kChordEngineTags,
          .tagCount = static_cast<int>(std::size(kChordEngineTags)),
          .createInEdit = createValueTreePlugin,
-         .createCustomPlugin = createCustomPlugin<MidiChordEnginePlugin>});
+         .createCustomPlugin = createMidiChordEnginePlugin});
     add(registry,
         {.pluginId = ArpeggiatorPlugin::xmlTypeName,
          .displayName = "Arpeggiator",
@@ -490,7 +517,7 @@ void registerNativeDevices(InternalPluginRegistry& registry) {
          .tags = kOscilloscopeTags,
          .tagCount = static_cast<int>(std::size(kOscilloscopeTags)),
          .createInEdit = createValueTreePlugin,
-         .createCustomPlugin = createCustomPlugin<OscilloscopePlugin>});
+         .createCustomPlugin = createOscilloscopePlugin});
     add(registry,
         {.pluginId = SpectrumAnalyzerPlugin::xmlTypeName,
          .displayName = "Spectrum Analyzer",
@@ -504,7 +531,7 @@ void registerNativeDevices(InternalPluginRegistry& registry) {
          .tags = kSpectrumTags,
          .tagCount = static_cast<int>(std::size(kSpectrumTags)),
          .createInEdit = createValueTreePlugin,
-         .createCustomPlugin = createCustomPlugin<SpectrumAnalyzerPlugin>});
+         .createCustomPlugin = createSpectrumAnalyzerPlugin});
     add(registry,
         {.pluginId = LevelsPlugin::xmlTypeName,
          .displayName = "Levels",
@@ -573,7 +600,7 @@ void registerInfrastructureDevices(InternalPluginRegistry& registry) {
          .canCreateDetached = false,
          .canCreateOnTrack = false,
          .matchesPlugin = matches<::magda::MidiReceivePlugin>,
-         .createCustomPlugin = createCustomPlugin<::magda::MidiReceivePlugin>});
+         .createCustomPlugin = createMidiReceivePlugin});
     add(registry, {.pluginId = ::magda::SidechainMonitorPlugin::xmlTypeName,
                    .displayName = "Sidechain Monitor",
                    .browserCategory = "Utility",

--- a/magda/daw/audio/plugins/DeviceServices.cpp
+++ b/magda/daw/audio/plugins/DeviceServices.cpp
@@ -1,0 +1,57 @@
+#include "plugins/DeviceServices.hpp"
+
+#include <algorithm>
+#include <map>
+#include <mutex>
+
+namespace magda::daw::audio {
+
+namespace {
+
+class FallbackDeviceIdAllocator final : public DeviceIdAllocator {
+  public:
+    DeviceId allocateDeviceId() override {
+        return nextId_++;
+    }
+
+    void ensureDeviceIdAbove(DeviceId id) override {
+        nextId_ = std::max(nextId_, id + 1);
+    }
+
+  private:
+    DeviceId nextId_ = 1;
+};
+
+struct ServiceEntry {
+    DeviceServices services;
+    FallbackDeviceIdAllocator fallbackAllocator;
+};
+
+std::mutex servicesMutex;
+std::map<tracktion::engine::Edit*, ServiceEntry> servicesByEdit;
+
+DeviceServices resolve(ServiceEntry& entry) {
+    auto services = entry.services;
+    if (services.deviceIdAllocator == nullptr)
+        services.deviceIdAllocator = &entry.fallbackAllocator;
+    return services;
+}
+
+}  // namespace
+
+void registerDeviceServices(tracktion::engine::Edit& edit, DeviceServices services) {
+    std::scoped_lock lock(servicesMutex);
+    servicesByEdit[&edit].services = services;
+}
+
+void unregisterDeviceServices(tracktion::engine::Edit& edit) {
+    std::scoped_lock lock(servicesMutex);
+    servicesByEdit.erase(&edit);
+}
+
+DeviceServices getDeviceServices(tracktion::engine::Edit& edit) {
+    std::scoped_lock lock(servicesMutex);
+    return resolve(servicesByEdit[&edit]);
+}
+
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/plugins/DeviceServices.hpp
+++ b/magda/daw/audio/plugins/DeviceServices.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "core/TypeIds.hpp"
+
+namespace tracktion {
+inline namespace engine {
+class Edit;
+}
+}  // namespace tracktion
+
+namespace magda::daw::audio {
+
+class DeviceIdAllocator {
+  public:
+    virtual ~DeviceIdAllocator() = default;
+
+    virtual DeviceId allocateDeviceId() = 0;
+    virtual void ensureDeviceIdAbove(DeviceId id) = 0;
+};
+
+class DeviceTrackContext {
+  public:
+    virtual ~DeviceTrackContext() = default;
+
+    virtual bool isChordTrackMuted() const = 0;
+    virtual void setDeviceParameterValueFromPlugin(DeviceId deviceId, int paramIndex,
+                                                   float value) = 0;
+};
+
+struct DevicePluginDefaults {
+    struct Oscilloscope {
+        float timebaseMs = 10.0f;
+    } oscilloscope;
+
+    struct Spectrum {
+        int fftOrder = 11;
+        float slopeDbPerOct = 4.5f;
+        float smoothing = 0.5f;
+    } spectrum;
+
+    struct MidiReceive {
+        TrackId sourceTrackId = INVALID_TRACK_ID;
+        bool replaceExistingMidi = false;
+    } midiReceive;
+};
+
+struct DeviceServices {
+    DeviceIdAllocator* deviceIdAllocator = nullptr;
+    DeviceTrackContext* trackContext = nullptr;
+    DevicePluginDefaults defaults;
+};
+
+void registerDeviceServices(tracktion::engine::Edit& edit, DeviceServices services);
+void unregisterDeviceServices(tracktion::engine::Edit& edit);
+DeviceServices getDeviceServices(tracktion::engine::Edit& edit);
+
+}  // namespace magda::daw::audio

--- a/magda/daw/audio/plugins/DrumGridPlugin.cpp
+++ b/magda/daw/audio/plugins/DrumGridPlugin.cpp
@@ -3,7 +3,6 @@
 #include <memory>
 #include <vector>
 
-#include "core/TrackManager.hpp"
 #include "plugins/InternalPluginRegistry.hpp"
 #include "plugins/MagdaSamplerPlugin.hpp"
 #include "plugins/compiled/CompiledPluginRegistry.hpp"
@@ -61,7 +60,9 @@ const juce::Identifier DrumGridPlugin::multiOutEnabledId("multiOutEnabled");
 const juce::Identifier DrumGridPlugin::pluginDeviceIdProp("magdaDeviceId");
 
 //==============================================================================
-DrumGridPlugin::DrumGridPlugin(const te::PluginCreationInfo& info) : Plugin(info) {
+DrumGridPlugin::DrumGridPlugin(const te::PluginCreationInfo& info,
+                               DeviceIdAllocator& deviceIdAllocator)
+    : Plugin(info), deviceIdAllocator_(deviceIdAllocator) {
     mixerExpanded_.referTo(state, mixerExpandedId, getUndoManager(), false);
     multiOutEnabled_.referTo(state, multiOutEnabledId, getUndoManager(), false);
 
@@ -597,8 +598,7 @@ void DrumGridPlugin::installSinglePadPlugin(Chain& chain, te::Plugin::Ptr plugin
         return;
 
     // Assign a stable DeviceId for macro/mod linking.
-    plugin->state.setProperty(pluginDeviceIdProp,
-                              magda::TrackManager::getInstance().allocateDeviceId(), nullptr);
+    plugin->state.setProperty(pluginDeviceIdProp, deviceIdAllocator_.allocateDeviceId(), nullptr);
 
     // Initialise BEFORE the plugin can become visible to the audio thread.
     initialisePluginIfNeeded(*plugin, sampleRate_, blockSize_);
@@ -764,8 +764,7 @@ void DrumGridPlugin::addPluginToChain(int chainIndex, const juce::PluginDescript
     initialisePluginIfNeeded(*plugin, sampleRate_, blockSize_);
 
     // Assign a stable DeviceId for macro/mod linking
-    plugin->state.setProperty(pluginDeviceIdProp,
-                              magda::TrackManager::getInstance().allocateDeviceId(), nullptr);
+    plugin->state.setProperty(pluginDeviceIdProp, deviceIdAllocator_.allocateDeviceId(), nullptr);
 
     auto chainTree = findChainTree(chainIndex);
     if (chainTree.isValid()) {
@@ -813,8 +812,7 @@ void DrumGridPlugin::addInternalPluginToChain(int chainIndex, const juce::String
     initialisePluginIfNeeded(*plugin, sampleRate_, blockSize_);
 
     // Assign a stable DeviceId for macro/mod linking
-    plugin->state.setProperty(pluginDeviceIdProp,
-                              magda::TrackManager::getInstance().allocateDeviceId(), nullptr);
+    plugin->state.setProperty(pluginDeviceIdProp, deviceIdAllocator_.allocateDeviceId(), nullptr);
 
     auto chainTree = findChainTree(chainIndex);
     if (chainTree.isValid()) {
@@ -1180,11 +1178,10 @@ void DrumGridPlugin::restorePluginStateFromValueTree(const juce::ValueTree& v) {
                 // Ensure a stable DeviceId exists for macro/mod linking
                 if (!pluginState.hasProperty(pluginDeviceIdProp)) {
                     pluginState.setProperty(pluginDeviceIdProp,
-                                            magda::TrackManager::getInstance().allocateDeviceId(),
-                                            nullptr);
+                                            deviceIdAllocator_.allocateDeviceId(), nullptr);
                 } else {
                     int restoredId = pluginState.getProperty(pluginDeviceIdProp);
-                    magda::TrackManager::getInstance().ensureDeviceIdAbove(restoredId);
+                    deviceIdAllocator_.ensureDeviceIdAbove(restoredId);
                 }
 
                 chain->plugins.push_back(plugin);

--- a/magda/daw/audio/plugins/DrumGridPlugin.hpp
+++ b/magda/daw/audio/plugins/DrumGridPlugin.hpp
@@ -7,6 +7,8 @@
 #include <memory>
 #include <vector>
 
+#include "plugins/DeviceServices.hpp"
+
 namespace magda::daw::audio {
 
 namespace te = tracktion::engine;
@@ -21,7 +23,7 @@ namespace te = tracktion::engine;
  */
 class DrumGridPlugin : public te::Plugin, private juce::Timer {
   public:
-    DrumGridPlugin(const te::PluginCreationInfo&);
+    DrumGridPlugin(const te::PluginCreationInfo&, DeviceIdAllocator&);
     ~DrumGridPlugin() override;
 
     //==============================================================================
@@ -201,6 +203,8 @@ class DrumGridPlugin : public te::Plugin, private juce::Timer {
     te::Plugin* getPadPlugin(int padIndex, int pluginIndex) const;
 
   private:
+    DeviceIdAllocator& deviceIdAllocator_;
+
     // Immutable, audio-thread-readable view of one chain. Holds owning Plugin::Ptr
     // copies so the graph stays alive for the duration of a process block even if
     // the message thread is concurrently rebuilding chains_. Note-range / remap

--- a/magda/daw/audio/plugins/MidiChordEnginePlugin.cpp
+++ b/magda/daw/audio/plugins/MidiChordEnginePlugin.cpp
@@ -1,13 +1,12 @@
 #include "plugins/MidiChordEnginePlugin.hpp"
 
-#include "core/TrackManager.hpp"
-
 namespace magda::daw::audio {
 
 const char* MidiChordEnginePlugin::xmlTypeName = "midichordengine";
 
-MidiChordEnginePlugin::MidiChordEnginePlugin(const te::PluginCreationInfo& info)
-    : te::Plugin(info) {
+MidiChordEnginePlugin::MidiChordEnginePlugin(const te::PluginCreationInfo& info,
+                                             DeviceTrackContext* trackContext)
+    : te::Plugin(info), trackContext_(trackContext) {
     for (auto& n : heldNotes_)
         n.store(0, std::memory_order_relaxed);
     // Start timer here as fallback — initialise() may not be called
@@ -114,14 +113,11 @@ void MidiChordEnginePlugin::applyToBuffer(const te::PluginRenderContext& fc) {
 void MidiChordEnginePlugin::timerCallback() {
     // Drop playback MIDI before it enters this engine when the chord track is
     // muted (audition off) AND the transport is playing. Live authoring while
-    // stopped is unaffected. The chord track is a singleton.
+    // stopped is unaffected. Chord-track state comes from the injected project context.
     {
-        auto& tm = magda::TrackManager::getInstance();
-        const auto chordId = tm.getChordTrackId();
-        const auto* chordTrack =
-            chordId != magda::INVALID_TRACK_ID ? tm.getTrack(chordId) : nullptr;
         const bool playing = edit.getTransport().isPlaying();
-        auditionMuted_.store(chordTrack != nullptr && chordTrack->muted && playing,
+        auditionMuted_.store(trackContext_ != nullptr && trackContext_->isChordTrackMuted() &&
+                                 playing,
                              std::memory_order_relaxed);
     }
 

--- a/magda/daw/audio/plugins/MidiChordEnginePlugin.hpp
+++ b/magda/daw/audio/plugins/MidiChordEnginePlugin.hpp
@@ -8,6 +8,7 @@
 #include "../../music/ChordSuggestionEngine.hpp"
 #include "../../music/KeyModeHistogram.hpp"
 #include "../../music/ScaleDetector.hpp"
+#include "plugins/DeviceServices.hpp"
 
 namespace magda::daw::audio {
 
@@ -27,7 +28,7 @@ namespace te = tracktion::engine;
  */
 class MidiChordEnginePlugin : public te::Plugin, private juce::Timer {
   public:
-    MidiChordEnginePlugin(const te::PluginCreationInfo& info);
+    MidiChordEnginePlugin(const te::PluginCreationInfo& info, DeviceTrackContext* trackContext);
     ~MidiChordEnginePlugin() override;
 
     static const char* getPluginName() {
@@ -158,6 +159,8 @@ class MidiChordEnginePlugin : public te::Plugin, private juce::Timer {
     }
 
   private:
+    DeviceTrackContext* trackContext_ = nullptr;
+
     // --- Audio-thread state (lock-free) ---
 
     // SPSC ring buffer for note events from audio thread → message thread

--- a/magda/daw/audio/plugins/MidiReceivePlugin.cpp
+++ b/magda/daw/audio/plugins/MidiReceivePlugin.cpp
@@ -6,10 +6,14 @@ namespace magda {
 
 const char* MidiReceivePlugin::xmlTypeName = "midireceive";
 
-MidiReceivePlugin::MidiReceivePlugin(const te::PluginCreationInfo& info) : te::Plugin(info) {
+MidiReceivePlugin::MidiReceivePlugin(const te::PluginCreationInfo& info,
+                                     const daw::audio::DevicePluginDefaults::MidiReceive& defaults)
+    : te::Plugin(info) {
     auto um = getUndoManager();
-    sourceTrackIdValue.referTo(state, juce::Identifier("sourceTrackId"), um, INVALID_TRACK_ID);
-    replaceExistingMidiValue.referTo(state, juce::Identifier("replaceExistingMidi"), um, false);
+    sourceTrackIdValue.referTo(state, juce::Identifier("sourceTrackId"), um,
+                               defaults.sourceTrackId);
+    replaceExistingMidiValue.referTo(state, juce::Identifier("replaceExistingMidi"), um,
+                                     defaults.replaceExistingMidi);
     sourceTrackId_ = sourceTrackIdValue.get();
     replaceExistingMidi_ = replaceExistingMidiValue.get();
 }

--- a/magda/daw/audio/plugins/MidiReceivePlugin.hpp
+++ b/magda/daw/audio/plugins/MidiReceivePlugin.hpp
@@ -3,6 +3,7 @@
 #include <tracktion_engine/tracktion_engine.h>
 
 #include "../../core/TypeIds.hpp"
+#include "plugins/DeviceServices.hpp"
 
 namespace magda {
 
@@ -29,7 +30,8 @@ namespace te = tracktion;
  */
 class MidiReceivePlugin : public te::Plugin {
   public:
-    MidiReceivePlugin(const te::PluginCreationInfo& info);
+    MidiReceivePlugin(const te::PluginCreationInfo& info,
+                      const daw::audio::DevicePluginDefaults::MidiReceive& defaults);
     ~MidiReceivePlugin() override;
 
     static const char* getPluginName() {

--- a/magda/daw/audio/plugins/OscilloscopePlugin.hpp
+++ b/magda/daw/audio/plugins/OscilloscopePlugin.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../../core/Config.hpp"
 #include "plugins/AnalysisTapPlugin.hpp"
+#include "plugins/DeviceServices.hpp"
 
 namespace magda::daw::audio {
 
@@ -11,10 +11,11 @@ namespace magda::daw::audio {
  */
 class OscilloscopePlugin : public AnalysisTapPlugin {
   public:
-    explicit OscilloscopePlugin(const te::PluginCreationInfo& info)
+    OscilloscopePlugin(const te::PluginCreationInfo& info,
+                       const DevicePluginDefaults::Oscilloscope& defaults)
         : AnalysisTapPlugin(info, 262144) {  // ~5.4 s at 48k
         timebaseMsValue.referTo(state, juce::Identifier("timebaseMs"), getUndoManager(),
-                                magda::Config::getInstance().getOscilloscopeDefaults().timebaseMs);
+                                defaults.timebaseMs);
     }
 
     static const char* getPluginName() {

--- a/magda/daw/audio/plugins/SpectrumAnalyzerPlugin.hpp
+++ b/magda/daw/audio/plugins/SpectrumAnalyzerPlugin.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../../core/Config.hpp"
 #include "plugins/AnalysisTapPlugin.hpp"
+#include "plugins/DeviceServices.hpp"
 
 namespace magda::daw::audio {
 
@@ -11,13 +11,15 @@ namespace magda::daw::audio {
  */
 class SpectrumAnalyzerPlugin : public AnalysisTapPlugin {
   public:
-    explicit SpectrumAnalyzerPlugin(const te::PluginCreationInfo& info)
+    SpectrumAnalyzerPlugin(const te::PluginCreationInfo& info,
+                           const DevicePluginDefaults::Spectrum& defaults)
         : AnalysisTapPlugin(info, 8192) {  // one FFT frame (max 4096) + headroom
-        const auto d = magda::Config::getInstance().getSpectrumDefaults();
         auto* um = getUndoManager();
-        fftOrderValue.referTo(state, juce::Identifier("fftOrder"), um, d.fftOrder);  // 11 = 2048
-        slopeDbPerOctValue.referTo(state, juce::Identifier("slopeDbPerOct"), um, d.slopeDbPerOct);
-        smoothingValue.referTo(state, juce::Identifier("smoothing"), um, d.smoothing);
+        fftOrderValue.referTo(state, juce::Identifier("fftOrder"), um,
+                              defaults.fftOrder);  // 11 = 2048
+        slopeDbPerOctValue.referTo(state, juce::Identifier("slopeDbPerOct"), um,
+                                   defaults.slopeDbPerOct);
+        smoothingValue.referTo(state, juce::Identifier("smoothing"), um, defaults.smoothing);
     }
 
     static const char* getPluginName() {

--- a/magda/daw/audio/processors/DeviceProcessorFactory.cpp
+++ b/magda/daw/audio/processors/DeviceProcessorFactory.cpp
@@ -8,13 +8,14 @@
 namespace magda {
 
 std::unique_ptr<DeviceProcessor> createDeviceProcessorForPlugin(
-    DeviceId deviceId, tracktion::engine::Plugin::Ptr plugin, const juce::String& pluginId) {
+    DeviceId deviceId, tracktion::engine::Plugin::Ptr plugin, const juce::String& pluginId,
+    daw::audio::DeviceTrackContext* trackContext) {
     if (!plugin)
         return nullptr;
 
     if (auto* ext = dynamic_cast<te::ExternalPlugin*>(plugin.get())) {
         juce::ignoreUnused(ext);
-        auto processor = std::make_unique<ExternalPluginProcessor>(deviceId, plugin);
+        auto processor = std::make_unique<ExternalPluginProcessor>(deviceId, plugin, trackContext);
         processor->startParameterListening();
         return processor;
     }

--- a/magda/daw/audio/processors/DeviceProcessorFactory.hpp
+++ b/magda/daw/audio/processors/DeviceProcessorFactory.hpp
@@ -5,12 +5,14 @@
 #include <memory>
 
 #include "core/TypeIds.hpp"
+#include "plugins/DeviceServices.hpp"
 
 namespace magda {
 
 class DeviceProcessor;
 
 std::unique_ptr<DeviceProcessor> createDeviceProcessorForPlugin(
-    DeviceId deviceId, tracktion::engine::Plugin::Ptr plugin, const juce::String& pluginId);
+    DeviceId deviceId, tracktion::engine::Plugin::Ptr plugin, const juce::String& pluginId,
+    daw::audio::DeviceTrackContext* trackContext = nullptr);
 
 }  // namespace magda

--- a/magda/daw/audio/processors/external/ExternalPluginProcessor.cpp
+++ b/magda/daw/audio/processors/external/ExternalPluginProcessor.cpp
@@ -2,14 +2,14 @@
 
 #include <utility>
 
-#include "core/TrackManager.hpp"
 #include "processors/ParameterDisplayTextProvider.hpp"
 #include "processors/ParameterInfoBuilder.hpp"
 
 namespace magda {
 
-ExternalPluginProcessor::ExternalPluginProcessor(DeviceId deviceId, te::Plugin::Ptr plugin)
-    : DeviceProcessor(deviceId, std::move(plugin)) {}
+ExternalPluginProcessor::ExternalPluginProcessor(DeviceId deviceId, te::Plugin::Ptr plugin,
+                                                 daw::audio::DeviceTrackContext* trackContext)
+    : DeviceProcessor(deviceId, std::move(plugin)), trackContext_(trackContext) {}
 
 ExternalPluginProcessor::~ExternalPluginProcessor() {
     stopParameterListening();
@@ -260,31 +260,14 @@ void ExternalPluginProcessor::propagateParameterChange(te::AutomatableParameter&
 
     const auto deviceId = deviceId_;
     const float valueToStore = param.getCurrentValue();
+    auto* const trackContext = trackContext_;
 
     // Parameter notifications can originate on the audio thread. The processor
     // may be removed before this reaches the message thread, so capture only
     // the value data needed to update the model.
-    juce::MessageManager::callAsync([deviceId, parameterIndex, valueToStore]() {
-        auto& tm = TrackManager::getInstance();
-
-        for (const auto& track : tm.getTracks()) {
-            for (const auto& element : track.chain.fxChainElements) {
-                if (std::holds_alternative<DeviceInfo>(element)) {
-                    const auto& device = std::get<DeviceInfo>(element);
-                    if (device.id == deviceId) {
-                        ChainNodePath path;
-                        path.trackId = track.id;
-                        path.topLevelDeviceId = deviceId;
-
-                        tm.setDeviceParameterValueFromPlugin(path, parameterIndex, valueToStore);
-                        return;
-                    }
-                }
-            }
-
-            // Also search in racks/chains (nested devices)
-            // TODO: Implement nested device search if needed
-        }
+    juce::MessageManager::callAsync([trackContext, deviceId, parameterIndex, valueToStore]() {
+        if (trackContext != nullptr)
+            trackContext->setDeviceParameterValueFromPlugin(deviceId, parameterIndex, valueToStore);
     });
 }
 

--- a/magda/daw/audio/processors/external/ExternalPluginProcessor.hpp
+++ b/magda/daw/audio/processors/external/ExternalPluginProcessor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "plugins/DeviceServices.hpp"
 #include "processors/base/DeviceProcessor.hpp"
 
 namespace magda {
@@ -15,7 +16,8 @@ namespace magda {
  */
 class ExternalPluginProcessor : public DeviceProcessor, public te::AutomatableParameter::Listener {
   public:
-    ExternalPluginProcessor(DeviceId deviceId, te::Plugin::Ptr plugin);
+    ExternalPluginProcessor(DeviceId deviceId, te::Plugin::Ptr plugin,
+                            daw::audio::DeviceTrackContext* trackContext);
     ~ExternalPluginProcessor() override;
 
     void setParameter(const juce::String& paramName, float value) override;
@@ -44,6 +46,7 @@ class ExternalPluginProcessor : public DeviceProcessor, public te::AutomatablePa
     mutable bool parametersCached_ = false;
     bool listeningForChanges_ = false;
     bool settingParameterFromUI_ = false;
+    daw::audio::DeviceTrackContext* trackContext_ = nullptr;
 
     void cacheParameterNames() const;
     void propagateParameterChange(te::AutomatableParameter& param);

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -13,6 +13,7 @@
 #include "TrackInfo.hpp"
 #include "TrackTypes.hpp"
 #include "ViewModeState.hpp"
+#include "audio/plugins/DeviceServices.hpp"
 
 namespace magda {
 
@@ -125,7 +126,7 @@ class TrackManagerListener {
  *
  * Provides CRUD operations for tracks and notifies listeners of changes.
  */
-class TrackManager {
+class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::DeviceTrackContext {
   public:
     static constexpr int MAX_SENDS_PER_TRACK = 8;  // Tracktion Engine aux bus limit
 
@@ -136,7 +137,7 @@ class TrackManager {
     TrackManager& operator=(const TrackManager&) = delete;
 
     // Allocate an FX-section DeviceId (used by DrumGrid for per-pad chain plugins)
-    DeviceId allocateDeviceId() {
+    DeviceId allocateDeviceId() override {
         return nextFxDeviceId_++;
     }
     RackId allocateRackId() {
@@ -146,7 +147,7 @@ class TrackManager {
         return nextChainId_++;
     }
     // Ensure restored DrumGrid pad/plugin IDs do not collide with FX-section IDs.
-    void ensureDeviceIdAbove(DeviceId id) {
+    void ensureDeviceIdAbove(DeviceId id) override {
         nextFxDeviceId_ = std::max(nextFxDeviceId_, id + 1);
     }
     void ensurePostFxDeviceIdAbove(DeviceId id) {
@@ -611,6 +612,8 @@ class TrackManager {
      */
     void setDeviceParameterValueFromPlugin(const ChainNodePath& devicePath, int paramIndex,
                                            float value);
+    void setDeviceParameterValueFromPlugin(DeviceId deviceId, int paramIndex, float value) override;
+    bool isChordTrackMuted() const override;
 
     /**
      * @brief Get plugin latency for a device by querying the audio engine

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -1604,6 +1604,19 @@ void TrackManager::setDeviceParameterValueFromPlugin(const ChainNodePath& device
     }
 }
 
+void TrackManager::setDeviceParameterValueFromPlugin(DeviceId deviceId, int paramIndex,
+                                                     float value) {
+    const auto path = findDevicePath(deviceId);
+    if (path.isValid())
+        setDeviceParameterValueFromPlugin(path, paramIndex, value);
+}
+
+bool TrackManager::isChordTrackMuted() const {
+    const auto chordTrackId = getChordTrackId();
+    const auto* chordTrack = chordTrackId != INVALID_TRACK_ID ? getTrack(chordTrackId) : nullptr;
+    return chordTrack != nullptr && chordTrack->muted;
+}
+
 double TrackManager::getDeviceLatencySeconds(const ChainNodePath& devicePath) {
     auto* device = getDeviceInChainByPath(devicePath);
     if (!device || !audioEngine_)

--- a/magda/daw/music/CMakeLists.txt
+++ b/magda/daw/music/CMakeLists.txt
@@ -1,6 +1,41 @@
-# Music-theory helpers: chord detection and suggestion engines.
-
-target_sources(magda_daw PRIVATE
+# Music-theory leaf: chord detection, notation, and suggestion engines.
+# JUCE modules are compiled once by magda_daw; borrow their compile usage here
+# without linking their INTERFACE_SOURCES into a second static archive.
+add_library(magda_music STATIC
     ChordEngine.cpp
     ChordSuggestionEngine.cpp
+    ChordCache.hpp
+    ChordEngine.hpp
+    ChordEnums.hpp
+    ChordSuggestionEngine.hpp
+    ChordTypes.hpp
+    KeyModeHistogram.hpp
+    LRUCache.hpp
+    NotationSettings.hpp
+    ScaleDetector.hpp
+    Scales.hpp
 )
+
+target_compile_features(magda_music PUBLIC cxx_std_20)
+target_include_directories(magda_music
+    PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    $<TARGET_PROPERTY:juce::juce_core,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:juce::juce_events,INTERFACE_INCLUDE_DIRECTORIES>
+)
+target_compile_definitions(magda_music PUBLIC
+    $<TARGET_PROPERTY:juce::juce_core,INTERFACE_COMPILE_DEFINITIONS>
+    $<TARGET_PROPERTY:juce::juce_events,INTERFACE_COMPILE_DEFINITIONS>
+)
+
+# A leaf music source must not reach upward into DAW, device, engine, project,
+# UI, or other application layers.
+get_target_property(_magda_music_sources magda_music SOURCES)
+foreach(_magda_music_source IN LISTS _magda_music_sources)
+    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/${_magda_music_source}" _magda_music_source_text)
+    if(_magda_music_source_text
+       MATCHES "(^|\n)[ \t]*#[ \t]*include[ \t]*[<\"](\\.\\./|audio/|core/|engine/|project/|ui/|agents/)")
+        message(FATAL_ERROR
+            "magda_music source crosses its leaf-library boundary: ${_magda_music_source}")
+    endif()
+endforeach()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -264,6 +264,7 @@ target_sources(magda_juce_tests PRIVATE
     test_timeline_loop_activation_juce.cpp
     test_midi_signal_routing_juce.cpp
     test_drum_grid_serialization_juce.cpp
+    test_device_services_juce.cpp
     test_master_sidechain_juce.cpp
     test_midi_bridge_note_events_juce.cpp
     test_section_scoped_device_ids_juce.cpp

--- a/tests/test_device_services_juce.cpp
+++ b/tests/test_device_services_juce.cpp
@@ -1,0 +1,128 @@
+#include <juce_core/juce_core.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+#include "SharedTestEngine.hpp"
+#include "magda/daw/audio/plugins/DeviceServices.hpp"
+#include "magda/daw/audio/plugins/DrumGridPlugin.hpp"
+#include "magda/daw/audio/plugins/MidiChordEnginePlugin.hpp"
+#include "magda/daw/audio/plugins/MidiReceivePlugin.hpp"
+#include "magda/daw/audio/plugins/OscilloscopePlugin.hpp"
+#include "magda/daw/audio/plugins/SpectrumAnalyzerPlugin.hpp"
+#include "third_party/tracktion_engine/modules/tracktion_engine/utilities/tracktion_TestUtilities.h"
+
+namespace {
+
+namespace audio = magda::daw::audio;
+namespace te = tracktion::engine;
+
+te::Plugin::Ptr createCustomPlugin(te::Edit& edit, const juce::String& type) {
+    juce::ValueTree state(te::IDs::PLUGIN);
+    state.setProperty(te::IDs::type, type, nullptr);
+    return edit.getPluginCache().createNewPlugin(state);
+}
+
+class TestDeviceServices final : public audio::DeviceIdAllocator, public audio::DeviceTrackContext {
+  public:
+    magda::DeviceId allocateDeviceId() override {
+        return nextDeviceId++;
+    }
+
+    void ensureDeviceIdAbove(magda::DeviceId id) override {
+        nextDeviceId = std::max(nextDeviceId, id + 1);
+    }
+
+    bool isChordTrackMuted() const override {
+        ++chordMuteReads;
+        return chordTrackMuted;
+    }
+
+    void setDeviceParameterValueFromPlugin(magda::DeviceId deviceId, int paramIndex,
+                                           float value) override {
+        lastDeviceId = deviceId;
+        lastParamIndex = paramIndex;
+        lastValue = value;
+    }
+
+    magda::DeviceId nextDeviceId = 700;
+    bool chordTrackMuted = true;
+    mutable int chordMuteReads = 0;
+    magda::DeviceId lastDeviceId = magda::INVALID_DEVICE_ID;
+    int lastParamIndex = -1;
+    float lastValue = 0.0f;
+};
+
+class DeviceServicesInjectionTest final : public juce::UnitTest {
+  public:
+    DeviceServicesInjectionTest() : juce::UnitTest("Device Services Injection", "magda") {}
+
+    void runTest() override {
+        auto& wrapper = magda::test::getSharedEngine();
+        auto edit = te::test_utilities::createTestEdit(*wrapper.getEngine(), 1);
+
+        beginTest("Custom device constructors receive per-edit services and defaults");
+        expect(edit != nullptr);
+        if (edit == nullptr)
+            return;
+
+        TestDeviceServices testServices;
+        audio::DeviceServices services;
+        services.deviceIdAllocator = &testServices;
+        services.trackContext = &testServices;
+        services.defaults.oscilloscope.timebaseMs = 321.0f;
+        services.defaults.spectrum.fftOrder = 12;
+        services.defaults.spectrum.slopeDbPerOct = 2.25f;
+        services.defaults.spectrum.smoothing = 0.75f;
+        services.defaults.midiReceive.sourceTrackId = 42;
+        services.defaults.midiReceive.replaceExistingMidi = true;
+        audio::registerDeviceServices(*edit, services);
+
+        {
+            auto drumPlugin = createCustomPlugin(*edit, audio::DrumGridPlugin::xmlTypeName);
+            auto* drumGrid = dynamic_cast<audio::DrumGridPlugin*>(drumPlugin.get());
+            expect(drumGrid != nullptr);
+            if (drumGrid != nullptr) {
+                drumGrid->loadInternalPluginToPad(0, "magda_kick");
+                const auto* chain = drumGrid->getChainForNote(audio::DrumGridPlugin::baseNote);
+                expect(chain != nullptr);
+                if (chain != nullptr)
+                    expectEquals(drumGrid->getPluginDeviceId(chain->index, 0), 700);
+            }
+
+            auto oscPlugin = createCustomPlugin(*edit, audio::OscilloscopePlugin::xmlTypeName);
+            auto* oscilloscope = dynamic_cast<audio::OscilloscopePlugin*>(oscPlugin.get());
+            expect(oscilloscope != nullptr);
+            if (oscilloscope != nullptr)
+                expectWithinAbsoluteError(oscilloscope->getTimebaseMs(), 321.0f, 0.001f);
+
+            auto spectrumPlugin =
+                createCustomPlugin(*edit, audio::SpectrumAnalyzerPlugin::xmlTypeName);
+            auto* spectrum = dynamic_cast<audio::SpectrumAnalyzerPlugin*>(spectrumPlugin.get());
+            expect(spectrum != nullptr);
+            if (spectrum != nullptr) {
+                expectEquals(spectrum->getFftOrder(), 12);
+                expectWithinAbsoluteError(spectrum->getSlopeDbPerOct(), 2.25f, 0.001f);
+                expectWithinAbsoluteError(spectrum->getSmoothing(), 0.75f, 0.001f);
+            }
+
+            auto midiReceivePlugin =
+                createCustomPlugin(*edit, magda::MidiReceivePlugin::xmlTypeName);
+            auto* midiReceive = dynamic_cast<magda::MidiReceivePlugin*>(midiReceivePlugin.get());
+            expect(midiReceive != nullptr);
+            if (midiReceive != nullptr) {
+                expectEquals(midiReceive->getSourceTrackId(), 42);
+                expect(midiReceive->getReplaceExistingMidi());
+            }
+
+            auto chordPlugin = createCustomPlugin(*edit, audio::MidiChordEnginePlugin::xmlTypeName);
+            expect(dynamic_cast<audio::MidiChordEnginePlugin*>(chordPlugin.get()) != nullptr);
+            juce::MessageManager::getInstance()->runDispatchLoopUntil(50);
+            expect(testServices.chordMuteReads > 0);
+        }
+
+        audio::unregisterDeviceServices(*edit);
+    }
+};
+
+DeviceServicesInjectionTest deviceServicesInjectionTest;
+
+}  // namespace


### PR DESCRIPTION
## Summary

- introduce per-edit device services for device ID allocation, project track context, and configurable device defaults
- remove device-layer `TrackManager::getInstance()` and `Config::getInstance()` call-ins from DrumGrid, MIDI Chord Engine, analyzers, and external plugin parameter propagation
- extract `music/` into the standalone `magda_music` leaf target
- add configure-time singleton/boundary guards and focused injection regressions

## Validation

- `cmake --build cmake-build-debug --target magda_music -j4`
- `cmake --build cmake-build-debug --target magda_daw -j4`
- `cmake --build cmake-build-debug --target magda_juce_tests -j4`
- Device Services Injection: 15/15
- DrumGrid serialization/reload: 64/64
- MIDI signal routing: 208/208
- Music scale detection: 36/36

Closes #1833