### PR TITLE
Fix #1880: keep powered-off devices off through audio export

### DIFF
--- a/magda/daw/engine/OfflineRenderHelper.cpp
+++ b/magda/daw/engine/OfflineRenderHelper.cpp
@@ -12,10 +12,10 @@ void prepareEditForOfflineRender(tracktion::Edit& edit) {
 
     tracktion::freePlaybackContextIfNotRecording(transport);
 
-    for (auto* track : tracktion::getAudioTracks(edit))
-        for (auto* plugin : track->pluginList)
-            if (!plugin->isEnabled())
-                plugin->setEnabled(true);
+    // Nothing here may touch plugin enablement (#1880). Every TE plugin's
+    // enabled flag already mirrors TrackManager::isDeviceEffectivelyEnabled,
+    // so powered-off devices must stay off through the render and stay off
+    // afterwards.
 }
 
 void preparePluginsForOfflineRender(TracktionEngineWrapper& engine) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -260,6 +260,7 @@ target_sources(magda_juce_tests PRIVATE
     juce_tests_main.cpp
     test_zoom_simple.cpp
     test_export_transport_stop_juce.cpp
+    test_offline_render_device_power_juce.cpp
     test_tracktion_engine_wrapper_refactoring_juce.cpp
     # test_export_no_assertion_juce.cpp  # Disabled - see issue #611 (generator device export)
     test_midi_recording_juce.cpp
@@ -380,6 +381,9 @@ add_test(NAME external_plugin_state_restore_juce
 
 add_test(NAME section_scoped_device_ids_juce
          COMMAND magda_juce_tests "Section-Scoped Device IDs")
+
+add_test(NAME offline_render_device_power_juce
+         COMMAND magda_juce_tests "Offline Render Device Power Tests")
 
 add_test(NAME chord_progression_converter_juce
          COMMAND magda_juce_tests "Chord Progression Converter Tests")

--- a/tests/test_offline_render_device_power_juce.cpp
+++ b/tests/test_offline_render_device_power_juce.cpp
@@ -1,0 +1,126 @@
+#include <juce_core/juce_core.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+#include "JuceTestStateGuard.hpp"
+#include "SharedTestEngine.hpp"
+#include "magda/daw/audio/AudioBridge.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/engine/OfflineRenderHelper.hpp"
+
+namespace {
+
+magda::DeviceInfo makeInternalDevice(const juce::String& name, const juce::String& pluginId) {
+    magda::DeviceInfo device;
+    device.name = name;
+    device.format = magda::PluginFormat::Internal;
+    device.pluginId = pluginId;
+    return device;
+}
+
+}  // namespace
+
+/**
+ * @brief Powered-off devices must survive an offline render (#1880)
+ *
+ * The export prep used to enable every plugin on every audio track so the test
+ * tone generator would sound offline. That blanket write rendered bypassed
+ * devices into the file and left them running afterwards, while the UI power
+ * button still read "off" because the model was never touched.
+ */
+class OfflineRenderDevicePowerTest final : public juce::UnitTest {
+  public:
+    OfflineRenderDevicePowerTest() : juce::UnitTest("Offline Render Device Power Tests", "magda") {}
+
+    void runTest() override {
+        magda::test::runWithCleanJuceState([this] { testBypassedDeviceStaysBypassed(); });
+        magda::test::runWithCleanJuceState([this] { testChainPowerOffStaysOff(); });
+    }
+
+  private:
+    void testBypassedDeviceStaysBypassed() {
+        beginTest("Per-device power off survives render prep");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto* bridge = wrapper.getAudioBridge();
+        auto* edit = wrapper.getEdit();
+        expect(bridge != nullptr && edit != nullptr, "AudioBridge and Edit must exist");
+        if (!bridge || !edit)
+            return;
+
+        auto& trackManager = magda::TrackManager::getInstance();
+        trackManager.clearAllTracks();
+        trackManager.setAudioEngine(&wrapper);
+
+        const auto trackId = trackManager.createTrack("Render power");
+        const auto fxId =
+            trackManager.addDeviceToTrack(trackId, makeInternalDevice("FX Filter", "magda_filter"));
+        const auto fxPath = magda::ChainNodePath::topLevelDevice(trackId, fxId);
+
+        auto plugin = bridge->getPlugin(fxPath);
+        expect(plugin != nullptr, "Internal FX should have a TE plugin");
+        if (plugin == nullptr) {
+            trackManager.clearAllTracks();
+            return;
+        }
+
+        expect(plugin->isEnabled(), "Freshly added device should be enabled");
+
+        // The power button in the device header / mixer mini chain goes through
+        // this setter, which is what pushes enablement into the engine.
+        trackManager.setDeviceInChainBypassedByPath(fxPath, true);
+        expect(!plugin->isEnabled(), "Powering the device off should disable the TE plugin");
+
+        magda::prepareEditForOfflineRender(*edit);
+
+        expect(!plugin->isEnabled(),
+               "Render prep must leave a powered-off device disabled (#1880)");
+
+        auto* device = trackManager.getDeviceInChainByPath(fxPath);
+        expect(device != nullptr && device->bypassed,
+               "Render prep must not touch the model's bypassed flag");
+
+        trackManager.clearAllTracks();
+    }
+
+    void testChainPowerOffStaysOff() {
+        beginTest("Track chain power off survives render prep");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto* bridge = wrapper.getAudioBridge();
+        auto* edit = wrapper.getEdit();
+        expect(bridge != nullptr && edit != nullptr, "AudioBridge and Edit must exist");
+        if (!bridge || !edit)
+            return;
+
+        auto& trackManager = magda::TrackManager::getInstance();
+        trackManager.clearAllTracks();
+        trackManager.setAudioEngine(&wrapper);
+
+        const auto trackId = trackManager.createTrack("Chain power render");
+        const auto fxId =
+            trackManager.addDeviceToTrack(trackId, makeInternalDevice("FX Filter", "magda_filter"));
+        const auto fxPath = magda::ChainNodePath::topLevelDevice(trackId, fxId);
+
+        auto plugin = bridge->getPlugin(fxPath);
+        expect(plugin != nullptr, "Internal FX should have a TE plugin");
+        if (plugin == nullptr) {
+            trackManager.clearAllTracks();
+            return;
+        }
+
+        trackManager.setChainEnabled(trackId, false);
+        expect(!plugin->isEnabled(), "Chain power off should disable the TE plugin");
+
+        magda::prepareEditForOfflineRender(*edit);
+
+        expect(!plugin->isEnabled(), "Render prep must leave a powered-off chain disabled (#1880)");
+
+        auto* device = trackManager.getDeviceInChainByPath(fxPath);
+        expect(device != nullptr && !device->bypassed,
+               "Chain power must not write the device's own bypassed flag");
+
+        trackManager.clearAllTracks();
+    }
+};
+
+static OfflineRenderDevicePowerTest offlineRenderDevicePowerTest;


### PR DESCRIPTION
Fixes #1880.

## Root cause

The offline render prep enabled every plugin on every audio track before building the render graph:

```cpp
for (auto* track : tracktion::getAudioTracks(edit))
    for (auto* plugin : track->pluginList)
        if (!plugin->isEnabled())
            plugin->setEnabled(true);
```

No restore afterwards, and only the TE flag was written, never the model. That accounts for every symptom in the report: a powered-off device is rendered into the export, it keeps playing after the export, and the power button still reads "off" because `DeviceInfo::bypassed` / `TrackChain::enabled` were untouched.

## Why the loop existed

It came in with the original audio export (80eae7d1, #610) carrying this comment:

> CRITICAL: Enable all plugins for offline rendering. When transport stops, AudioBridge bypasses generator plugins (like test tone) but we need them enabled for export to work properly

A test-tone workaround written as "enable everything". At that point nothing else disabled a `te::Plugin`, so it was harmless. Since then the tone generator moved to a processor-level flag handled in `PluginManager::prepareForRendering()`, and per-device power plus chain power both landed driving exactly the flag this loop stomps. The loop survived the `MainWindow.cpp` decomposition (#646) into `OfflineRenderHelper.cpp` and was never revisited.

## Fix

Delete the loop. `te::Plugin::enabled` already mirrors `TrackManager::isDeviceEffectivelyEnabled` at all times, so the render sees the user's power state as-is. One deletion covers both the per-device power button and the track chain power button.

## Tests

New JUCE suite `tests/test_offline_render_device_power_juce.cpp`:

- per-device power off stays off through `prepareEditForOfflineRender`, and the model's `bypassed` flag is untouched
- track chain power off stays off, without writing the device's own `bypassed` flag

11 checks pass. I restored the old loop and rebuilt to confirm both `#1880` assertions fail without the fix, then removed it again. `Export Transport State Tests` still green.

## Note

The reporter is on 0.16.1, so this needs to reach a release branch too if it should ship before 0.17.