### PR TITLE
Update the manual for 0.17

### DIFF
--- a/manual/docs/clips.md
+++ b/manual/docs/clips.md
@@ -223,6 +223,12 @@ MAGDA can detect the notes in an audio clip and turn them into MIDI. Right-click
 
 Transcription works best on clearly pitched, reasonably clean material (a solo vocal, a bassline, a lead). Dense mixes and heavily layered audio give rougher results that usually want some cleanup in the [Piano Roll](panels/piano-roll.md).
 
+## Split into Stems
+
+Right-click an audio clip and choose **Split into Stems** to separate it onto new tracks — vocals, drums, bass and other with Demucs, vocals against everything else with Spleeter, or harmonic against percussive content with the download-free HPSS engine. The stem tracks appear in a group beneath the source, the source track is muted, and each stem clip keeps the original's position, stretch mode, and warp markers.
+
+See [Stem Separation](stem-separation.md) for the engines, the model downloads, and where the rendered files land.
+
 ## Crossfades
 
 A crossfade is a real overlap between two adjacent audio clips: the outgoing clip fades down as the incoming clip fades up across the shared region.

--- a/manual/docs/devices/drum-kit.md
+++ b/manual/docs/devices/drum-kit.md
@@ -102,3 +102,7 @@ Band-passed noise shaped by a fast three-peak flam envelope, followed by a diffu
 ## Macros, modulation, and presets
 
 Each drum voice is a standard MAGDA device, so its parameters accept [macros](../modulation/macros.md) and [modulators](../modulation/overview.md), and patches save and recall through the [preset system](../panels/browsers.md). On a Drum Grid, each pad chain can carry its own macro and modulator links.
+
+## AI sound design
+
+Click the **AI** icon in the device header and describe the sound you want. The agent reads this device's own parameters and their real-world ranges, then writes values into them. See [Per-Device AI Panel](../panels/ai-assistant.md#per-device-ai-panel).

--- a/manual/docs/devices/fm0.md
+++ b/manual/docs/devices/fm0.md
@@ -38,3 +38,7 @@ Each operator also has an **Enable** toggle (on by default; disabling stops it b
 ## Macros, modulation, and presets
 
 FM0 sits in the standard device slot, so its parameters accept [macros](../modulation/macros.md) and [modulators](../modulation/overview.md), and patches save and recall through the [preset system](../panels/browsers.md).
+
+## AI sound design
+
+Click the **AI** icon in the device header and describe the sound you want. The agent reads this device's own parameters and their real-world ranges, then writes values into them. See [Per-Device AI Panel](../panels/ai-assistant.md#per-device-ai-panel).

--- a/manual/docs/devices/mutable.md
+++ b/manual/docs/devices/mutable.md
@@ -70,3 +70,9 @@ A stereo granular texture processor with four modes. It processes whatever audio
 ## Macros, modulation, and presets
 
 All three ports are standard MAGDA devices, so their parameters accept [macros](../modulation/macros.md) and [modulators](../modulation/overview.md), and patches save and recall through the [preset system](../panels/browsers.md).
+
+## AI sound design
+
+Click the **AI** icon in the device header and describe the sound you want. The agent reads this device's own parameters and their real-world ranges, then writes values into them. See [Per-Device AI Panel](../panels/ai-assistant.md#per-device-ai-panel).
+
+Materia and Halo support this. Nimbus does not — it processes incoming audio rather than generating notes, so there is no preset for an agent to design.

--- a/manual/docs/devices/physical-models.md
+++ b/manual/docs/devices/physical-models.md
@@ -43,3 +43,7 @@ A struck, fixed-pitch modal church-bell model.
 ## Macros, modulation, and presets
 
 Each model is a standard MAGDA device, so its parameters accept [macros](../modulation/macros.md) and [modulators](../modulation/overview.md), and patches save and recall through the [preset system](../panels/browsers.md).
+
+## AI sound design
+
+Click the **AI** icon in the device header and describe the sound you want. The agent reads this device's own parameters and their real-world ranges, then writes values into them. See [Per-Device AI Panel](../panels/ai-assistant.md#per-device-ai-panel).

--- a/manual/docs/devices/poly-synth.md
+++ b/manual/docs/devices/poly-synth.md
@@ -57,3 +57,7 @@ The amplitude envelope shapes the level of each note.
 ## Macros, modulation, and presets
 
 Like every MAGDA instrument, Poly Synth lives in the standard device slot, so its parameters can be driven by [macros](../modulation/macros.md) and [modulators](../modulation/overview.md), and patches save and recall through the [preset system](../panels/browsers.md).
+
+## AI sound design
+
+Click the **AI** icon in the device header and describe the sound you want. The agent reads this device's own parameters and their real-world ranges, then writes values into them. See [Per-Device AI Panel](../panels/ai-assistant.md#per-device-ai-panel).

--- a/manual/docs/fx-chain.md
+++ b/manual/docs/fx-chain.md
@@ -30,6 +30,12 @@ The chain can contain:
 
 See [Plugin Parameters](plugin-parameters.md) for per-plugin parameter visibility, custom units and ranges, and AI-assisted classification.
 
+### Device Power
+
+The power button in a device header takes the device out of the signal path. A chain's power button does the same for every device in it. Both states are part of the project: they survive save and reload, and they are honoured when you render — a device that is powered off is powered off in an exported or bounced file too.
+
+The gain slider in a device or rack header ignores the scroll wheel until you click it. This keeps a stray trackpad gesture over a device header scrolling the chain rather than changing its gain. Once you have clicked the slider the wheel adjusts it, until the pointer leaves.
+
 ### Delta Solo
 
 The **Δ** button in a device header (tooltip *Delta Solo: processed signal minus dry input*) lets you hear only what that device changes: MAGDA subtracts the device's latency-aligned dry input from its processed output, so you audition the difference alone. It is the direct way to check exactly what a compressor, EQ, or saturator is doing to the signal.

--- a/manual/docs/interface/ai-settings.md
+++ b/manual/docs/interface/ai-settings.md
@@ -1,15 +1,14 @@
 # AI Settings
 
-The **AI Settings** dialog is where you configure the providers and models that power MAGDA's AI features: the [AI Assistant](../panels/ai-assistant.md) chat, the per-device sound-design panels, and the [Media Library](../panels/media-library.md)'s Sample Analyzer.
+The **AI Settings** dialog is where you configure the providers and models that power MAGDA's AI features: the [AI Assistant](../panels/ai-assistant.md) chat, the per-device sound-design panels, the [Media Library](../panels/media-library.md)'s Sample Analyzer, and [Stem Separation](../stem-separation.md).
 
-Open it from **Settings > AI Settings**. The dialog has four tabs.
+Open it from **Settings > AI Settings**. The dialog has three tabs.
 
 | Tab | Purpose |
 |-----|---------|
 | **Cloud** | Register cloud API providers (OpenAI, Anthropic, Gemini, DeepSeek, OpenRouter) |
-| **Local** | Configure the embedded llama.cpp engine and a local GGUF model for offline use |
-| **Config** | Choose which providers the AI agents use and how they trade off quality, speed, and cost |
-| **Sample Analyzer** | Download and load the audio-tagging model used by the Media Library |
+| **Config** | Choose which providers each agent uses, and how they trade off quality, speed, and cost |
+| **Models** | Download and manage every optional local model, grouped by category |
 
 ## Cloud
 
@@ -26,31 +25,25 @@ Registered providers appear in the list below. You can register several and swit
 !!! note "Keys stay on your machine"
     API keys are stored locally in your MAGDA configuration and used only to call the provider you entered them for.
 
-## Local
-
-The Local tab configures the embedded **llama.cpp** engine for fully offline AI, with no network calls and no API key.
-
-- **Download Model** - downloads the MAGDA model (`magda-v0.3.0-q4_k_m.gguf`, fine-tuned for DAW operations) from HuggingFace with a progress indicator.
-- **Model (.gguf)** - the path to the model file. Use **Browse** to point at any GGUF model of your own.
-- **GPU Layers** - how many model layers to offload to the GPU. `-1` offloads all layers (Metal on macOS, CUDA on supported builds); `0` runs on CPU only.
-- **Context** - the context-window size in tokens (default `4096`).
-- **Load Model** / **Unload** - load the model into memory or unload it to free resources.
-- **Load model on startup** - when enabled, the model loads automatically each time MAGDA launches.
-
 ## Config
 
-The Config tab decides which providers the AI agents actually use.
+The Config tab decides which providers the AI agents actually use. The **Setup** dropdown at the top picks how much control you want:
+
+- **Simple** — one decision that applies to every agent.
+- **Advanced** — a provider and model per agent role.
+
+### Simple setup
 
 | Setting | Description |
 |---------|-------------|
 | **Mode** | **Local** (every agent uses a local model), **Cloud** (every agent uses a cloud provider), or **Hybrid** (a mix) |
-| **Source** | In Local mode: **Embedded** (the built-in llama.cpp engine, configured on the Local tab) or **Local server** (an OpenAI-compatible server you run yourself) |
+| **Source** | In Local mode: **Embedded** (the built-in llama.cpp engine, configured under [Models > Local LLM](#local-llm)) or **Local server** (an OpenAI-compatible server you run yourself) |
 | **Provider** | Which registered cloud provider to use, shown for Cloud and Hybrid modes |
 | **Optimize** | Bias agent selection toward **Quality**, **Speed**, or **Cost** |
 
 In **Local** mode the provider and optimize options are hidden, since everything runs locally.
 
-### Local Server (OpenAI-compatible)
+#### Local Server (OpenAI-compatible)
 
 With **Source** set to **Local server**, MAGDA talks to any server that speaks the OpenAI API — **LM Studio**, **Ollama**, **GPUStack**, or a plain `llama.cpp` server. The default address is Ollama's (`http://localhost:11434/v1`); MAGDA normalises whatever form you give it, with or without the `/v1` suffix.
 
@@ -59,12 +52,79 @@ With **Source** set to **Local server**, MAGDA talks to any server that speaks t
 
 One server and one model serve all agent roles, the same way the embedded model does.
 
-## Sample Analyzer
+### Advanced setup
 
-The Sample Analyzer is the audio-tagging model behind the [Media Library](../panels/media-library.md)'s semantic search and "find similar sounds". It is an optional download, separate from the LLM models on the other tabs.
+Advanced replaces the single mode with a grid, one row per agent role. Each row has its own **provider** and **model**, drawn from whatever you registered on the Cloud tab and whatever local backends are available. Switching from Simple to Advanced seeds the grid from your simple settings, so you can start there and adjust only the rows you care about.
 
-- The tab shows the current install state and the **download size**.
-- **Download Sample Analyzer** - fetches the model. Without it, the Library still supports filename, tag, family, shape, key, and BPM filtering, but not text-based semantic search.
-- **Load** / **Unload** - bring the analyzer into memory or release it. It also preloads in the background the first time you enter Library mode.
+| Agent | Handles |
+|-------|---------|
+| **Command** | Turning chat requests into [DSL](../reference/dsl.md) operations on tracks, clips, and devices |
+| **Music** | Generating musical content — notes, patterns, parts |
+| **Faust** | Writing [Faust DSP](../devices/effects.md) code for custom effects |
+| **Chord** | Chord progressions and harmony |
+| **Controller** | [Controller](controllers.md) profiles and scripts |
+| **Theme** | Colour themes |
+
+Choosing a local provider gives a model dropdown of **Embedded** or **Server**. The **Command** row has a third option, **Fast Inference (Command)** — see below.
+
+### Fast Inference (Command)
+
+**Fast Inference** runs Command requests entirely on your machine with a purpose-built model rather than a general-purpose LLM. It is not a chat model: it reads one command and emits the DSL directly, with no streaming and effectively no wait.
+
+Because it is a single-command tagger, it deliberately ignores conversation history — each request is read on its own. For follow-ups that depend on what you said earlier ("now make it louder"), a general model is the better fit.
+
+Fast Inference works out of the box using a small built-in model. Installing the larger [Command model](#command-model) from the Models tab replaces it and markedly improves how well natural phrasing is understood. Cloud providers never use either one.
+
+### MCP Tools
+
+**Faust DSP** validates AI-generated Faust code before MAGDA loads it. MAGDA starts the MCP server on demand through `npx`, so there is nothing to install by hand, but `npx` must be on your system `PATH` (it ships with Node.js). See [Effects — Faust validation](../devices/effects.md) for details.
+
+## Models
+
+Every optional download lives on the Models tab, behind a **Category** dropdown. Categories appear only when your build supports them — the ONNX-backed ones (Sample analysis, Stem separation, Command model) are absent from the Intel macOS build.
+
+Downloads and removals take effect straight away; they do not wait for **OK**.
+
+### Local LLM
+
+Configures the embedded **llama.cpp** engine for fully offline AI, with no network calls and no API key.
+
+- **Download Model** — downloads the MAGDA model (fine-tuned for DAW operations) from HuggingFace with a progress indicator.
+- **Model (.gguf)** — the path to the model file. Use the browse button to point at any GGUF model of your own.
+- **GPU Layers** — **Auto (GPU)** offloads everything the platform can take (Metal on macOS, CUDA on supported builds), **CPU Only** runs without the GPU, and **Custom** lets you enter a layer count for cards that run out of memory on Auto.
+- **Context** — the context-window size in tokens (default `4096`).
+- **Load Model** / **Unload** — load the model into memory or unload it to free resources.
+- **Load model on startup** — when enabled, the model loads automatically each time MAGDA launches.
+
+### Sample analysis
+
+The Sample Analyzer is the audio-tagging model behind the [Media Library](../panels/media-library.md)'s semantic search and "find similar sounds". It is an optional download, separate from the LLM models.
+
+- The page shows the current install state and the **download size**.
+- **Download Sample Analyzer** — fetches the model. Without it, the Library still supports filename, tag, family, shape, key, and BPM filtering, but not text-based semantic search.
+- **Load** / **Unload** — bring the analyzer into memory or release it. It also preloads in the background the first time you enter Library mode.
 
 For how the analyzer is used once installed, see [Media Library > AI Sample Analyzer](../panels/media-library.md#ai-sample-analyzer).
+
+### Stem separation
+
+Weights for the machine-learning engines behind [Split into Stems](../stem-separation.md). The HPSS engine needs nothing here — it is pure signal processing and always available.
+
+| Model | Size | Splits into |
+|-------|------|-------------|
+| **Demucs (4-stem)** | 301 MB | Drums, Bass, Other, Vocals |
+| **Spleeter (2-stem)** | 74 MB | Vocals, Accompaniment |
+
+Each row shows its install state, a progress bar while downloading, and a **Download** / **Remove** button, alongside a link to the HuggingFace repository the weights come from. **Models location** shows where they are stored.
+
+Choosing an uninstalled engine from a clip's **Split into Stems** menu opens this page directly.
+
+### Command model
+
+The larger model behind [Fast Inference](#fast-inference-command): a DeBERTa-v3 encoder fine-tuned to read a command and tag its intent and parameters.
+
+- It is **not bundled** with MAGDA — the download is 429 MB.
+- Without it, Fast Inference still works using the small built-in model. With it, natural phrasing is understood far more reliably.
+- **Models location** defaults to MAGDA's data folder. Use **Browse...** to keep the weights on another drive, or **Reset** to go back to the default.
+- The **Download** button turns into **Cancel** while a download is running, and **Remove** once installed. The location cannot be changed mid-download.
+- A link to the source HuggingFace repository sits under the model name.

--- a/manual/docs/interface/controllers.md
+++ b/manual/docs/interface/controllers.md
@@ -140,7 +140,7 @@ Only one script can be active at a time. Loading a new script replaces the previ
 
 ### Scripts Tab
 
-The Scripts tab in the Controllers dialog lists every `.lua` file in your scripts folder, one row each. Each row shows:
+The Scripts tab in the Controllers dialog lists the scripts available to you — the factory scripts you have enabled, plus every `.lua` file in your own scripts folder. Each row shows:
 
 | Column | Description |
 |---|---|
@@ -152,19 +152,36 @@ The Scripts tab in the Controllers dialog lists every `.lua` file in your script
 
 Header buttons:
 
-- **Open Folder** — reveals the scripts folder in the OS file browser
-- **Import…** — pick a `.lua` from disk, copy it into the scripts folder, refresh the list
+- **+ Add script** — pick from the factory scripts bundled with MAGDA (see [Factory Scripts](#factory-scripts)) and add it to the list
+- **Open Scripts Folder** — reveals your scripts folder in the OS file browser
+- **Import script…** — pick a `.lua` from disk, copy it into the scripts folder, refresh the list. You are asked before an existing file of the same name is replaced.
 - **Reload** — re-evaluate the active script (or load the alphabetically-first script if none is active). Picks up file edits without restarting MAGDA.
 
-Click a row's port columns to assign / change the MIDI ports for that script. Right-click a row to remove the script file.
+Click a row's port columns to assign / change the MIDI ports for that script. Right-click a row for **Reveal in Finder**, **Unload** (on the active script), and **Disable factory script** (on a factory one).
+
+### Factory Scripts
+
+MAGDA ships with ready-made scripts for common controllers. They live inside the application rather than in your scripts folder, and are added to the list through **+ Add script** rather than by copying files.
+
+| Script | Controller |
+|--------|-----------|
+| `launchkey_mini_mk4.lua` | Novation Launchkey Mini MK4 — transport, pads, knobs, scene switching |
+| `launchpad_mk1.lua` | Novation Launchpad MK1 / Classic — session grid, scene launch, banking, User 1/2 note layouts |
+| `launchpad_mk2.lua` | Novation Launchpad MK2 — session grid, scene launch, banking, User 1/2 note layouts |
+| `8-knobs.lua` | Any 8-knob controller — CC 1–8 drive the volume of tracks 1–8 |
+| `foot-pedal.lua` | Any sustain pedal — CC 64 launches and stops the selected session clip |
+
+**Disable factory script** removes one from the list; **+ Add script** brings it back. Once every factory script is enabled the button reports that there is nothing left to add.
+
+To modify one, add it, use **Reveal in Finder** to find it, and copy it into your own scripts folder under a new name.
 
 ### Scripts Folder
 
 | Platform | Path |
 |---|---|
-| macOS | `~/Library/MAGDA/scripts/` |
-| Windows | `%APPDATA%\MAGDA\scripts\` |
-| Linux | `~/.config/MAGDA/scripts/` |
+| macOS | `~/Library/MAGDA/Scripts/Controllers/` |
+| Windows | `%APPDATA%\MAGDA\Scripts\Controllers\` |
+| Linux | `~/.config/MAGDA/Scripts/Controllers/` |
 
 The folder is created on first launch. Drop `.lua` files in there and they show up in the Scripts tab. Per-script port assignments are saved alongside.
 

--- a/manual/docs/interface/plugin-settings.md
+++ b/manual/docs/interface/plugin-settings.md
@@ -24,6 +24,8 @@ Projects you have already saved still load whichever exact plugin they reference
 - **Scan for Plugins** — Start a full scan of all listed directories. A progress bar shows scan progress.
 - **View Scan Report** — Open the log from the most recent scan, showing which plugins were found, loaded, or rejected.
 
+Plugins whose files have disappeared are dropped from the list on startup, with one exception: if the missing file lived on an **external or network volume that is not currently mounted**, the entry is kept. An unplugged drive is not evidence that you uninstalled the plugin, so the entry is waiting for you when you plug it back in. This covers `/Volumes/...` on macOS, drive letters and UNC shares on Windows, and `/media`, `/run/media`, and `/mnt` on Linux.
+
 ## Excluded Plugins
 
 Plugins that failed to load or were manually excluded appear here with the reason and date. Use **Remove Selected** to re-enable individual plugins or **Reset All** to clear the entire exclusion list.

--- a/manual/docs/panels/ai-assistant.md
+++ b/manual/docs/panels/ai-assistant.md
@@ -21,12 +21,28 @@ The assistant is **context-aware** — it knows which tracks, clips, and devices
 
 ### Selection Context
 
-At the bottom of the AI panel, a context indicator shows the currently-selected track, clip, or device.
+At the bottom of the AI panel sits a context bar: an **icon** on the left and a **label** beside it. They do different jobs.
 
-- When the indicator is **on** (orange accent colour), the AI treats your selection as the default target. A request like "add a bassline" with a track selected will target that track instead of creating a new one.
-- Click the indicator to **toggle it off**. The selection is no longer sent to the LLM, and requests are interpreted without a default target.
+**The icon** controls whether your current selection is sent at all. When it is on (orange accent colour), the AI treats the selected track, clip, or device as the default target — a request like "add a bassline" with a track selected targets that track instead of creating a new one. Click it to toggle it off, and requests are interpreted without a default target.
 
-Creating a new track still works either way — just be explicit in the request ("new track", "another track") when the indicator is on.
+Creating a new track still works either way — just be explicit in the request ("new track", "another track") when the icon is on.
+
+**The label** opens a picker for attaching MIDI clips explicitly. It reads *Add MIDI context* when nothing is attached, and summarises what is attached otherwise (`Bass > Verse`, `Bass · all MIDI`, `6 MIDI · 3 tracks`).
+
+### MIDI Context
+
+Attaching MIDI sends the actual notes to the model, so it can answer about what you have written rather than guessing. Useful for "harmonise this", "write a counter-melody to these two parts", or "make the bass follow the chords in the piano clip".
+
+Click the context label to open the picker:
+
+- **Use selection** — attach the selected MIDI clips, or every MIDI clip on the selected tracks.
+- **Clear** — detach everything.
+- The list below shows each track with its MIDI clips indented underneath. Tick a clip to attach it, or a track to attach all of its clips. A track shows a dash instead of a checkmark when only some of its clips are attached.
+
+Attaching context turns the selection icon back on. Audio clips cannot be attached — only MIDI. Clips deleted after being attached drop out of the set on their own.
+
+!!! note "Bounded on purpose"
+    However much you tick, MAGDA sends at most 16 clips, 128 notes per clip, and 256 notes in total, plus up to 32 chord annotations per clip. Selecting an entire project therefore cannot exhaust the model's context window — but it does mean a very large selection is sent in part rather than in full. Attach the clips that matter.
 
 ### How It Works
 
@@ -37,7 +53,7 @@ Creating a new track still works either way — just be explicit in the request 
 
 ### Setup
 
-The AI Assistant supports both cloud LLM providers and a fully offline local model. Configure them in the **AI Settings** dialog (**Settings > AI Settings**); see [AI Settings](../interface/ai-settings.md) for the Cloud, Local, and Config tabs.
+The AI Assistant supports both cloud LLM providers and a fully offline local model. Configure them in the **AI Settings** dialog (**Settings > AI Settings**); see [AI Settings](../interface/ai-settings.md) for the Cloud, Config, and Models tabs.
 
 ### Usage Tips
 
@@ -130,10 +146,24 @@ Prefix your message with a slash command to constrain the AI to a specific domai
 | Command | Description |
 |---------|-------------|
 | `/groove <request>` | Create or apply swing/groove timing templates |
-| `/design <description>` | Generate a 4OSC preset from a natural-language description and apply it to the focused 4OSC device |
+| `/design <description>` | Generate a preset from a natural-language description and apply it to the focused device |
 | `/theme <description>` | Generate a UI colour theme from a natural-language description and apply it live |
+| `/controller <description>` | Generate a hardware [controller profile](../interface/controllers.md) from a description of the surface |
+| `/agent <surface> <request>` | Send one request to a specific agent, overriding the view's usual routing |
+| `/dsl <code>` | Execute [DSL](../reference/dsl.md) directly, with no AI call |
 
-Typing `/` shows an autocomplete popup with available commands.
+Typing `/` shows an autocomplete popup with available commands. Run a command with `--help` for its in-app cheat sheet.
+
+#### `/agent` — Override Routing
+
+Requests are normally routed by the view you are in (see [View Context](#view-context)). `/agent` overrides that for a single message when you want a different specialist:
+
+```
+/agent drummer busier hats in bar 2
+/agent mixer tame the low mids on the bass
+```
+
+Available surfaces: `arrangement`, `piano-roll`, `session`, `mixer`, `automation`, `device`, `master`, `drummer`.
 
 #### `/theme` - AI Theme Generator
 
@@ -145,13 +175,13 @@ Which model powers `/theme` is set by the **Theme** agent role in **AI Settings 
 
 #### `/design` — AI Sound Design
 
-Select a 4OSC device, then type `/design <description>`. The assistant produces a preset (waves, filter type, voice mode, FX gates, ADSR, levels) and applies it directly to the focused device.
+Select a sound generator, then type `/design <description>`. The assistant produces a preset and applies it directly to the focused device.
 
 The chat shows a categorised summary of what changed, plus a one-line apply status. The preset name and category the AI chose become the default values when you save the preset from the device header — just click save and hit Enter.
 
 Built-in safeguards:
 
-- A **master-level safety cap** estimates worst-case peak gain from the active oscillator count, distortion drive, and filter resonance, then clamps the master `level` to keep peaks in a sensible range. The AI's choices are only overridden when they would clip.
+- On 4OSC, a **master-level safety cap** estimates worst-case peak gain from the active oscillator count, distortion drive, and filter resonance, then clamps the master `level` to keep peaks in a sensible range. The AI's choices are only overridden when they would clip.
 - The result is a **starting point**, not a final preset. Tweak by ear before saving.
 
 For example prompts and recipes, see the [4OSC Synth — AI Sound Design](../devices/4osc.md#ai-sound-design-design) section.
@@ -168,9 +198,34 @@ The panel has three rows:
 - **Prompt input** — type a description and press ++enter++ to submit. Submitting cancels any in-flight generation on the same device.
 - **Footer** — shows the active model id on the left and a delete button on the right. The delete button clears the chat for that device only.
 
-Generations are scoped to the device the panel is mounted on. Devices without a sound-design agent (everything except 4OSC at the moment) show **AI design not supported for this device** in place of the prompt placeholder.
+Generations are scoped to the device the panel is mounted on. Devices with no agent behind them show **AI not supported for this device** in place of the prompt placeholder.
 
 This is the same engine as the chat-based `/design` command — same agent, same safeguards, same preset name/category propagation to the save dialog. The panel is just a more direct path: focus the synth, prompt it, hear it.
+
+### Which devices can be designed
+
+| Device | What the agent writes |
+|--------|-----------------------|
+| **[4OSC](../devices/4osc.md)** | Waves, filter type, voice mode, FX gates, ADSR, levels |
+| **MAGDA sound generators** — [Poly Synth](../devices/poly-synth.md), [FM0](../devices/fm0.md), [Physical Models](../devices/physical-models.md), [Mutable ports](../devices/mutable.md) | Any of the device's own parameters |
+| **[Step Sequencer](../devices/step-sequencer.md)** and **[Poly Sequencer](../devices/poly-sequencer.md)** | A pattern rather than a preset |
+| **[Faust](../devices/effects.md) devices** | DSP code — the prompt reads *describe an effect or instrument...* |
+| **Third-party plugins** | The parameters you nominate — see [below](#ai-sound-design-for-third-party-plugins) |
+
+Beyond 4OSC and the sequencers, which keep purpose-written agents, sound design works by **parameter introspection**: the agent reads the device's parameters at runtime — names, units, real-world ranges, and discrete choices — and asks the model for values in those real units (Hz, ms, dB, semitones) rather than in normalised 0–1 terms. That is why it generalises across devices without per-device tuning.
+
+The [Sampler](../devices/sampler.md), [Drum Grid](../devices/drum-grid.md), and effects devices have no sound-design agent.
+
+### AI sound design for third-party plugins
+
+Third-party plugins can be designed too, but not automatically: a plugin exposing hundreds of opaque parameters gives the model nothing useful to work with. You choose what it is allowed to touch.
+
+1. Right-click the plugin in the [Plugin Browser](browsers.md#plugin-browser) and choose **Configure Parameters…**.
+2. Tick the **AI Agent** column for each parameter the designer should be able to set. This column is separate from **Visible** — a parameter can be hidden in the chain and still be available to the AI, or the other way round.
+3. Optionally click **AI Prompt...** to add standing instructions for this plugin — how its oscillator sections are laid out, which parameters interact, anything the parameter names alone do not convey. The button gains a checkmark once a prompt is saved, and the text is prepended to every design request for that plugin.
+4. Set units and ranges for the nominated parameters, either by hand or with **Detect** / **AI Detect**. The better the ranges, the more usable the generated values. See [Plugin Parameters](../plugin-parameters.md).
+
+The **AI** icon appears on the device slot once at least one parameter is ticked. To hide it for a plugin you would rather drive by hand, right-click the plugin in the browser and untoggle **AI Sound Designer**; the setting is per plugin and persists.
 
 ## Param Aliases (`@`)
 

--- a/manual/docs/panels/media-library.md
+++ b/manual/docs/panels/media-library.md
@@ -108,7 +108,7 @@ It is built on CLAP (Contrastive Language-Audio Pre-training), which embeds audi
 
 ### Installing it
 
-The analyzer is a separate download, not bundled with the app. Open the [AI Settings](../interface/ai-settings.md#sample-analyzer) dialog (**Settings > AI Settings**) and pick the **Sample Analyzer** tab, where it shows the download size and a **Download Sample Analyzer** button. Once installed, **Load** brings the models into memory (they also preload in the background the first time you enter Library mode).
+The analyzer is a separate download, not bundled with the app. Open the [AI Settings](../interface/ai-settings.md#sample-analysis) dialog (**Settings > AI Settings**), go to the **Models** tab and pick the **Sample analysis** category, where it shows the download size and a **Download Sample Analyzer** button. Once installed, **Load** brings the models into memory (they also preload in the background the first time you enter Library mode).
 
 The **Sample Analyzer** icon (a database icon) in the [footer status bar](../interface/overview.md#footer) shows the current state. Its colour reflects the state and the tooltip names it: **not installed**, **installed** (downloaded but not loaded), **loading**, or **loaded**.
 

--- a/manual/docs/plugin-parameters.md
+++ b/manual/docs/plugin-parameters.md
@@ -20,20 +20,25 @@ The dialog shows one row per parameter with the following columns:
 
 | Column | Description |
 |--------|-------------|
-| **Name** | Parameter name as reported by the plugin. |
+| **Parameter** | Parameter name as reported by the plugin. |
 | **Visible** | Toggle whether the parameter shows up in MAGDA's chain, inspector, and AI prompts. Hide parameters you never touch to reduce clutter. |
+| **Mini FX** | Include the parameter in the device's compact mini view. |
+| **AI Agent** | Allow the [AI sound designer](panels/ai-assistant.md#ai-sound-design-for-third-party-plugins) to set this parameter. Independent of **Visible**. |
 | **Unit** | Display unit — Hz, dB, ms, %, semitones, or any custom string. |
 | **Range** | Minimum, centre, and maximum values in the parameter's own domain. Narrow the range so sliders and AI-generated values stay in the useful zone. |
-| **Scale** | Linear, logarithmic, or exponential response curve. |
 
 ### Actions
 
-- **Select All / Deselect All** — Toggle visibility across the whole list.
+- **Select All / Deselect All** — Toggle every row in the column chosen by the dropdown beside them (**Visible**, **Mini FX**, or **AI Agent**).
 - **Detect** — Run the deterministic heuristic pass (instant, offline). Picks up units and ranges that the plugin's own display strings give away.
 - **AI Detect** — Run the heuristic pass and then send anything it couldn't resolve to the configured LLM (see below).
-- **Reset** — Discard all inferred units, ranges, and AI-detected values for this plugin and put every parameter back to a plain 0–100 % view.
+- **AI Prompt...** — Standing instructions added to every sound-design request for this plugin. The button shows a checkmark once a prompt is saved.
+- **Reset** — Discard all inferred units, ranges, AI parameter selections, and the custom prompt for this plugin, putting every parameter back to a plain 0–100 % view.
 - **Apply** — Save changes without closing the dialog.
 - **OK / Cancel** — Save and close, or discard.
+
+!!! note "Internal devices"
+    MAGDA's own devices report proper units and ranges already, and their sound designers introspect every parameter, so the dialog drops the **Visible** and **AI Agent** columns for them and offers only the **Mini FX** choice.
 
 ## AI Detect
 
@@ -42,7 +47,7 @@ Typing units and ranges by hand for a plugin with dozens of parameters is tediou
 The results populate the dialog so you can review them before applying — tweak anything you disagree with and hit **Apply**.
 
 !!! note
-    AI Detect uses whichever provider is configured in [Preferences > AI](interface/preferences.md). It works with both cloud providers and local inference.
+    AI Detect uses whichever provider is configured in [AI Settings](interface/ai-settings.md). It works with both cloud providers and local inference.
 
 ## Learn Mode
 

--- a/manual/docs/reference/dsl.md
+++ b/manual/docs/reference/dsl.md
@@ -13,6 +13,23 @@ track(name="Bass", new=true)
   .notes.add_chord(root=C4, quality=major, beat=0, length=4)
 ```
 
+## Project
+
+Project-wide timing settings.
+
+```
+project.set(bpm=128)
+project.set(time_signature="7/8")
+project.set(bpm=128, time_signature="3/4")
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `bpm` | number | Project tempo. `tempo` is accepted as a synonym. |
+| `time_signature` | string | Written as `numerator/denominator`, e.g. `"7/8"` |
+
+At least one of the two must be given.
+
 ## Tracks
 
 ### Creating & referencing tracks
@@ -33,10 +50,20 @@ track(name="Bass").track.set(name="Sub Bass", volume_db=-3, pan=0.5, mute=true, 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string | Rename the track |
+| `colour` | string | Track colour as a hex string, e.g. `"#ff5a36"` |
 | `volume_db` | number | Volume in dB |
 | `pan` | number | Pan position (-1.0 left to 1.0 right) |
 | `mute` | bool | Mute the track |
 | `solo` | bool | Solo the track |
+
+### Grouping and ordering
+
+```
+track(id=1).track.group(name="Drums", tracks="1,2,3")   // Group tracks by 1-based id
+track(id=4).track.move(index=1)                          // Move to first position
+```
+
+`track.group` switches the context to the new group, so you can keep chaining onto it. `track.move` positions the track among its siblings — top-level tracks, or the children of its parent group.
 
 ### Other track operations
 
@@ -67,19 +94,39 @@ track(name="Bass").clip.rename(name="Part {i}")         // Rename selected clips
 track(name="Bass").clip.delete(index=0)                 // Delete clip at index
 ```
 
+### Enabling and disabling clips
+
+```
+track(name="Bass").clip.set(enabled=false, index=0)     // Disable clip at index
+track(name="Bass").clip.set(enabled=false)              // Disable the selected clips
+```
+
+`clip.set` currently takes `enabled` only. Without `index` it acts on the current selection, which makes it natural to chain after a `clips.select(...)` in the same statement. See [Enabling and Disabling Clips](../clips.md#enabling-and-disabling-clips).
+
 ### Selecting clips
 
 ```
 track(id=1).clips.select(clip.length_bars >= 2)
 track(id=1).clips.select(clip.start_bar == 1)
+track(id=1).clips.select(clip.name == "Intro")
+track(id=1).clips.select()                              // Every clip on the track
 ```
 
-| Field | Description |
-|-------|-------------|
-| `clip.length_bars` | Clip length in bars |
-| `clip.start_bar` | Clip start position in bars |
+| Field | Type | Description |
+|-------|------|-------------|
+| `clip.length_bars` | number | Clip length in bars |
+| `clip.start_bar` | number | Clip start position, in bars, 1-based |
+| `clip.start_beats` | number | Clip start position in beats |
+| `clip.length` | number | Clip length in seconds |
+| `clip.start` | number | Clip start position in seconds |
+| `clip.id` | number | Clip id |
+| `clip.track_id` | number | Owning track id |
+| `clip.name` | string | Clip name |
+| `clip.type` | string | Clip type |
 
-Operators: `==`, `!=`, `>`, `>=`, `<`, `<=`
+Prefer the bar and beat fields. `clip.length` and `clip.start` are seconds derived from the current tempo, so a predicate written against them stops matching if the tempo changes.
+
+Operators: `==`, `!=`, `>`, `>=`, `<`, `<=`. String fields accept `==` and `!=` only. Omitting the condition entirely selects every clip on the track.
 
 ## Notes
 
@@ -185,12 +232,37 @@ track(name="Vocals").fx.add(name="Pro-Q 3", format="VST3")
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `name` | string | Effect name |
+| `name` | string | Device name or alias |
 | `format` | string | Optional: `VST3`, `AU`, or `VST` to disambiguate |
 
-**Built-in effects:** `eq`, `compressor`, `reverb`, `delay`, `chorus`, `phaser`, `filter`, `utility`, `pitch shift`, `ir reverb`
+**MAGDA devices** are added by exact display name or by a canonical alias — `eq`, `compressor`, `reverb`, `delay`, `chorus`, `phaser`, `filter`, `utility`, `pitch shift`, `ir reverb` and the rest of the [device registry](../devices/built-in.md). The alias list is generated from the registry itself, so it follows whatever is installed rather than a fixed set.
 
-Third-party plugins are referenced by their scanned name. Use the `@alias` syntax in the AI chat to autocomplete plugin names.
+Third-party plugins are referenced by their scanned name, or by an alias token such as `<pro_q_3>` or `<surge_xt>`. Use the `@alias` syntax in the AI chat to autocomplete plugin names.
+
+## Racks
+
+Rack operations act on the track in context. Each one remembers the rack (and chain) it just touched, so a following call can omit the ids.
+
+```
+track(id=1).rack.new(name="Parallel").rack.chain_new(name="Wet")
+track(id=1).rack.set(id=12, bypassed=true, volume_db=-3)
+track(id=1).rack.chain_set(rack_id=12, chain_id=34, volume_db=-6, pan=0.2)
+track(id=1).rack.chain_delete(rack_id=12, chain_id=34)
+track(id=1).rack.delete(id=12)
+```
+
+| Method | Parameters |
+|--------|------------|
+| `rack.new` | `name` (default `"Rack"`). Creates the rack with its default chain. |
+| `rack.delete` | `id` — defaults to the rack just created |
+| `rack.set` | `id`, plus `bypassed` and/or `volume_db` |
+| `rack.chain_new` | `rack_id` (defaults to the current rack), `name` (default `"Chain"`) |
+| `rack.chain_delete` | `rack_id`, `chain_id` |
+| `rack.chain_set` | `rack_id`, `chain_id`, plus any of `name`, `muted`, `solo`, `bypassed`, `volume_db`, `pan`, `output` |
+
+`rack.set` and `rack.chain_set` need at least one property to change, and report an error otherwise. Rack and chain ids come from the state snapshot — see [FX Chain & Racks](../fx-chain.md).
+
+While a rack chain is in scope, `fx.add` puts the device **inside that chain** rather than on the track's top-level chain. That is what makes a single statement able to build a rack and fill it.
 
 ## Filter Operations
 
@@ -200,8 +272,16 @@ Bulk operations on tracks matching a condition.
 filter(tracks, track.name == "Drums").track.set(mute=true)
 filter(tracks, track.name == "Drums").delete()
 filter(tracks, track.name == "Drums").select()
+filter(tracks, track.name == "Drums").track.group(name="Group")
 filter(tracks, track.name == "Drums").for_each(.clip.new(bar=1, length_bars=4))
 filter(tracks, track.name == "Drums").for_each(.fx.add(name="reverb").track.set(volume_db=-6))
+```
+
+The only supported predicate is an exact name match, `track.name == "..."`. Omitting the condition entirely targets **every** track:
+
+```
+filter(tracks).track.set(mute=true)
+filter(tracks).track.group(name="All Tracks")
 ```
 
 ## Groove / Swing
@@ -261,6 +341,14 @@ groove.list()
 
 Returns all available groove template names (built-in and custom).
 
+## Built-in Functions
+
+```
+track(id=1).clip.new(length_bars=random(1, 4))
+```
+
+`random(min, max)` returns a value between `min` and `max` inclusive — an integer when both arguments are integers, a float otherwise.
+
 ## Examples
 
 ### Simple track with clip
@@ -297,6 +385,27 @@ track(name="Arp", new=true)
   .clip.new(length_bars=4)
   .notes.add_arpeggio(root=E4, quality=min, beat=0, step=0.5, beats=8)
   .notes.add_arpeggio(root=C4, quality=major, beat=8, step=0.5, beats=8)
+```
+
+### Parallel rack
+
+```
+track(name="Drums")
+  .rack.new(name="Parallel")
+  .rack.chain_new(name="Crushed")
+  .fx.add(name="compressor")
+```
+
+### Set the session up in 3/4 at 96 BPM
+
+```
+project.set(bpm=96, time_signature="3/4")
+```
+
+### Disable every clip shorter than a bar
+
+```
+track(id=1).clips.select(clip.length_bars < 1).clip.set(enabled=false)
 ```
 
 ### Bulk operations

--- a/manual/docs/reference/file-formats.md
+++ b/manual/docs/reference/file-formats.md
@@ -13,6 +13,8 @@ MAGDA saves projects in Tracktion Engine's Edit format (`.tracktionedit`), an XM
 
 MAGDA can import and export the **DAWproject** format (`.dawproject`), an open interchange format for moving a project between different DAWs. Use **File → Import DAWproject...** to open one, or **File → Export DAWproject...** to write the current project out. It carries tracks, clips, and basic plugin/automation data — use it to hand a session to another DAW that supports the format, and use the native `.tracktionedit` for full-fidelity MAGDA projects.
 
+On import, MAGDA reads each track's output routing, so tracks feeding a group or an aux land on the right destination rather than all defaulting to the master. Track groups are preserved as groups: Bitwig writes group channels with the same role it uses for the project master, and MAGDA distinguishes the two from the project structure instead of turning every group into a master track.
+
 ## Audio Formats
 
 MAGDA supports the following audio formats:

--- a/manual/docs/reference/lua-scripting.md
+++ b/manual/docs/reference/lua-scripting.md
@@ -222,11 +222,12 @@ end
 
 ## Bundled Examples
 
-Working scripts ship in the `examples/scripts/` folder of the repo:
+Working scripts ship inside the application:
 
-- `foot-pedal.lua` — sustain-pedal launches the selected session clip
+- `foot-pedal.lua` — sustain pedal launches and stops the selected session clip
 - `8-knobs.lua` — eight CCs drive eight track volumes
-- `launchpad.lua` — Novation Launchpad clip launcher with LED feedback
-- `launchkey_mini_mk4.lua` — full Launchkey Mini MK4 surface (transport, pads, knobs, sceneswitching)
+- `launchpad_mk1.lua` — Novation Launchpad MK1 / Classic: session grid, scene launch, banking, User 1/2 note layouts
+- `launchpad_mk2.lua` — the same surface for the Launchpad MK2
+- `launchkey_mini_mk4.lua` — full Launchkey Mini MK4 surface (transport, pads, knobs, scene switching)
 
-Copy any of them into your scripts folder (see [Controllers — Scripts Folder](../interface/controllers.md#scripts-folder)) and load via the Controllers dialog.
+Add any of them from the Controllers dialog's Scripts tab with **+ Add script** — see [Controllers — Factory Scripts](../interface/controllers.md#factory-scripts). To adapt one, reveal it on disk and copy it into your own [scripts folder](../interface/controllers.md#scripts-folder) under a new name.

--- a/manual/docs/stem-separation.md
+++ b/manual/docs/stem-separation.md
@@ -1,0 +1,73 @@
+# Stem Separation
+
+Stem separation splits one audio clip into several, each carrying a different part of the sound: vocals on one track, drums on another, and so on. MAGDA does this offline on your own machine, writing real audio files into the project.
+
+Right-click an audio clip and choose **Split into Stems**, then pick an engine.
+
+## Engines
+
+Three engines are available, trading quality against speed and download size.
+
+| Engine | Stems | Needs a download |
+|--------|-------|------------------|
+| **Harmonic / Percussive (HPSS)** | Harmonic, Percussive | No |
+| **Vocals / Drums / Bass / Other (Demucs)** | Drums, Bass, Other, Vocals | Yes, 301 MB |
+| **Vocals / Accompaniment (Spleeter)** | Vocals, Accompaniment | Yes, 74 MB |
+
+**HPSS** is plain signal processing with no machine-learning model behind it. It separates sustained, pitched content from transient content, so it is the right tool for pulling a drum layer away from a pad or a guitar, and the wrong tool for isolating a singer. It needs no download and works in every build.
+
+**Demucs** gives the best separation of the three and is the slowest. It produces the familiar four-way split.
+
+**Spleeter** is quicker and lighter than Demucs, at the cost of quality, and only splits two ways: the vocal and everything else.
+
+!!! note "Intel macOS"
+    Demucs and Spleeter run on the ONNX runtime, which is not part of the Intel macOS build. On those builds the submenu offers HPSS only.
+
+## Downloading the models
+
+Demucs and Spleeter weights are not bundled with MAGDA — they are fetched on demand.
+
+An engine whose weights are missing shows in the menu with a trailing `...`. Choosing it opens **AI Settings > Models** with the **Stem separation** category selected, rather than failing. You can also go there directly at any time to install or remove either model. See [AI Settings](interface/ai-settings.md#stem-separation).
+
+Downloads come from HuggingFace, are checked against a pinned SHA-256, and land in MAGDA's application data folder under `StemSeparation/models`. The Models page shows the source repository for each one as a clickable link, and lets you remove weights you no longer want to keep on disk.
+
+## What a split produces
+
+Clicking an engine starts a two-phase operation.
+
+**Immediately**, one empty audio track per stem appears directly beneath the source track, wrapped in a group named after the source file (`Guitar Take 3 Stems`). The track area reflects the operation as soon as you click, so you can see what is coming.
+
+**When separation finishes**, a clip lands on each stem track. Each one is a duplicate of the source clip with its audio file swapped for the rendered stem, so start position, offset, loop, stretch mode, and warp markers all stay exactly where they were on the original. Take and comp data is not carried over — that belongs to the original recording, not to a stem of it.
+
+Finally the **source track is muted**, so the stems do not play on top of the material they came from. Unmute it whenever you want to compare.
+
+A loading banner reads *Splitting into stems...* with a live percentage while the split runs. A toast confirms completion, or reports the failure.
+
+### Undo
+
+The split lands as two undo steps: **Split into Stems** creates the tracks and the group, and **Add Stem Clips** adds the clips and mutes the source. Undoing the second restores the source track's mute state along with the clips.
+
+If separation fails part-way, the empty tracks and group created in the first phase are removed for you.
+
+## Where the files go
+
+Stems are written as 32-bit float WAV into a `stems/` folder inside the project's media directory, one subfolder per split named after the source and the engine:
+
+```
+<project media>/stems/Guitar Take 3 - htdemucs/
+    Guitar Take 3 - Drums.wav
+    Guitar Take 3 - Bass.wav
+    Guitar Take 3 - Other.wav
+    Guitar Take 3 - Vocals.wav
+```
+
+Splitting the same clip twice never overwrites an earlier result; the second run gets its own folder.
+
+## Limits
+
+- **One clip at a time.** The menu item is unavailable for a multiple selection.
+- **One split at a time.** Engines are greyed out while another split is running.
+- **The source file must be on disk.** Clips whose audio has gone missing cannot be split.
+- **Very long files are refused.** Separation decodes the whole file into memory, and MAGDA rejects anything that would need more than about a gigabyte rather than attempting it.
+
+Separation is CPU-intensive and runs off the audio thread, so playback keeps going while it works, but expect a Demucs pass over a full song to take a while.

--- a/manual/docs/working-with-ai.md
+++ b/manual/docs/working-with-ai.md
@@ -114,7 +114,7 @@ Running a language model locally is demanding, and your hardware sets a hard cei
 - **CPU instruction set.** On Windows and Linux systems with an Intel or AMD processor, MAGDA's embedded local model requires SSE 4.2 and AVX. This does not affect cloud providers or local-server mode.
 - **GPU.** Local inference is far more responsive with GPU acceleration: Metal on Apple Silicon, or CUDA on supported builds. An Apple Silicon Mac or a dedicated GPU with plenty of VRAM makes a large difference. On CPU alone it still works, just slowly.
 - Larger general-purpose models need correspondingly more RAM (when running on CPU) or VRAM (when offloaded to a GPU). A bigger model on an underpowered machine will be slow, or simply fail to load.
-- If responses are slow or a model fails to load, choose a smaller or more heavily quantised model, lower the **GPU Layers**, or reduce the **Context** size on the [AI Settings](interface/ai-settings.md) Local tab.
+- If responses are slow or a model fails to load, choose a smaller or more heavily quantised model, switch **GPU Layers** to **Custom** with a lower count, or reduce the **Context** size under [AI Settings](interface/ai-settings.md#local-llm) > Models > Local LLM.
 
 If your machine does not meet these specs, do not expect usable local AI from it. Use a cloud provider instead: it will give far better results than a local model struggling on limited hardware.
 

--- a/manual/mkdocs.yml
+++ b/manual/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - Controllers: interface/controllers.md
   - Tracks: tracks.md
   - Clips: clips.md
+  - Stem Separation: stem-separation.md
   - FX Chain & Racks: fx-chain.md
   - Plugin Parameters: plugin-parameters.md
   - Arrangement View: arrangement-view.md


### PR DESCRIPTION
The 0.17 merge touched the manual by one line, so this is the whole release pass.

New page: Stem Separation. Covers the HPSS / Demucs / Spleeter engines, the Intel macOS backend gate, the two-phase track and clip landing, source-track muting, the two undo steps, the stems/ output layout, and the per-split limits.

Rewrites:
- AI Settings had four tabs documented and now has three. Config gains Simple vs Advanced setup, the six agent roles, Fast Inference, and the Faust MCP toggle; Models covers all four download categories including the new Command model.
- AI Assistant: the context bar is two controls, not one. Adds the MIDI context picker and its bounds, a table of which devices can be designed, the third-party plugin parameter flow, and the /agent, /controller and /dsl slash commands.
- DSL reference: project.set, the six rack.* methods, clip.set, track.group / track.move, the full clip predicate field list, random(), and the narrowed filter grammar.

Corrections:
- Plugin Parameters listed a Scale column that is not editable there and omitted Mini FX and the new AI Agent column.
- Controller scripts ship as factory scripts added from the Scripts tab, not files copied out of an examples/ folder that does not exist. Both Launchpad scripts are listed and the scripts folder path is fixed.
- Device power survives export, the header gain slider needs a click before the wheel moves it, plugins on unmounted volumes are kept, and DAWproject import honours track output routing and groups.
- AI sound design is no longer 4OSC only; the generator device pages say so and name the devices that have no agent.