### PR TITLE
Fix the Intel macOS link failure on the ONNX command model

### DIFF
--- a/magda/agents/command_model_onnx.cpp
+++ b/magda/agents/command_model_onnx.cpp
@@ -301,6 +301,44 @@ std::string CommandModelOnnx::generate(const std::string& text) const {
 
 }  // namespace magda
 
+#else  // MAGDA_HAVE_CLAP
+
+// Stub for builds without ONNX Runtime (currently Intel macOS), matching
+// SpleeterSeparator and the CLAP encoders: the class always links, so callers
+// holding one need no conditional compilation of their own. Without this,
+// CommandAgent's unique_ptr member left ~CommandAgent referencing a destructor
+// that no translation unit defined, and the Intel link failed.
+//
+// isInstalled() is false whatever sits on disk, since a downloaded bundle is
+// unusable without a backend to run it, so CommandAgent stays on the conv net.
+// That leaves the remaining members unreachable, and they refuse rather than
+// answer quietly.
+namespace magda {
+
+struct CommandModelOnnx::Impl {};
+
+CommandModelOnnx::CommandModelOnnx(const std::filesystem::path&) {
+    throw CommandModelOnnxError("this build has no ONNX Runtime backend");
+}
+
+CommandModelOnnx::~CommandModelOnnx() = default;
+CommandModelOnnx::CommandModelOnnx(CommandModelOnnx&&) noexcept = default;
+CommandModelOnnx& CommandModelOnnx::operator=(CommandModelOnnx&&) noexcept = default;
+
+bool CommandModelOnnx::isInstalled(const std::filesystem::path&) {
+    return false;
+}
+
+CommandModel::Prediction CommandModelOnnx::predict(const std::string&) const {
+    throw CommandModelOnnxError("this build has no ONNX Runtime backend");
+}
+
+std::string CommandModelOnnx::generate(const std::string&) const {
+    throw CommandModelOnnxError("this build has no ONNX Runtime backend");
+}
+
+}  // namespace magda
+
 #endif  // MAGDA_HAVE_CLAP
 
 // Path resolution and maps.json parsing need no ONNX Runtime, so they live


### PR DESCRIPTION
The `Release` run for tag `v0.17.0` failed in `build-macos-x86_64`, so `create-release` was skipped and 0.17.0 never published.

```
Undefined symbols for architecture x86_64:
  "magda::CommandModelOnnx::~CommandModelOnnx()", referenced from:
      magda::CommandAgent::~CommandAgent() in libmagda_agents.a(command_agent.cpp.o)
```

## Cause

Intel macOS builds with `MAGDA_HAVE_CLAP=OFF` because upstream ORT 1.26 dropped osx-x86_64 prebuilts. `command_model_onnx.cpp` puts its entire implementation inside that guard with no `#else`, while `command_model_onnx.hpp` declares `CommandModelOnnx` unconditionally. `CommandAgent` holds a `std::unique_ptr<CommandModelOnnx>` member, so its defaulted destructor references `~CommandModelOnnx()`, which no translation unit defines on Intel. The `#if` guards inside `generateLocal` never covered the member itself.

## Fix

Add the no-backend stub that the sibling ONNX classes already carry (`SpleeterSeparator.cpp:291`, same shape for the CLAP encoders): `Impl`, ctor, dtor, moves, `isInstalled()` returning false, `predict`/`generate` throwing. The class links everywhere, so consumers need no conditional compilation of their own, and `isInstalled()` being false keeps `CommandAgent` on the conv net exactly as the guarded path did.

Nothing inside the existing guard changes, so arm64, Windows and Linux are bit-identical.

## Verification

Compiled both affected translation units with the real build flags in both configurations and checked symbol resolution directly:

| | with CLAP | without CLAP |
|---|---|---|
| `command_agent.cpp` compiles | yes | yes |
| `command_model_onnx.cpp` compiles | yes | yes |
| `~CommandModelOnnx` undefined in the agent object | yes | yes |
| resolved by the onnx object | yes | yes (was the failure) |

Set-differencing the agent object's undefined symbols against the onnx object's defined ones leaves nothing ONNX-related unresolved.

The `v0.17.0` tag has been deleted; it gets re-cut on main once this lands.