### PR TITLE
Fix File menu keyboard shortcuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,21 +411,22 @@ lint-fix:
 		exit 1; \
 	fi
 	@echo "⚠️  This will modify your source files!"
-	@read -p "Continue? [y/N] " -n 1 -r; \
-	echo; \
-	if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
-		find magda/daw -name "*.cpp" -type f -exec \
-			$(CLANG_TIDY) \
-			{} \
-			--config-file=.clang-tidy \
-			--format-style=file \
-			-p=$(BUILD_DIR) \
-			--fix \
-			--fix-errors \;; \
-		echo "✅ Fixes applied"; \
-	else \
-		echo "❌ Cancelled"; \
-	fi
+	@printf "Continue? [y/N] "; \
+	read REPLY; \
+	case "$$REPLY" in \
+		[Yy]*) \
+			find magda/daw -name "*.cpp" -type f -exec \
+				$(CLANG_TIDY) \
+				{} \
+				--config-file=.clang-tidy \
+				--format-style=file \
+				-p=$(BUILD_DIR) \
+				--fix \
+				--fix-errors \;; \
+			echo "✅ Fixes applied" ;; \
+		*) \
+			echo "❌ Cancelled" ;; \
+	esac
 
 # Lint specific file
 .PHONY: lint-file

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,15 @@ else
     LAUNCH             :=
 endif
 
+# clang-tidy lookup. Homebrew's LLVM is newer than the Apple toolchain's, so
+# prefer it when it is installed; otherwise take whatever is on PATH (the
+# distro package on Linux). Override with `make lint CLANG_TIDY=/path/to/it`.
+CLANG_TIDY ?= $(shell if [ -x /opt/homebrew/opt/llvm/bin/clang-tidy ]; then \
+		echo /opt/homebrew/opt/llvm/bin/clang-tidy; \
+	else \
+		command -v clang-tidy 2>/dev/null; \
+	fi)
+
 # Default target
 .PHONY: all
 all: debug
@@ -345,14 +354,15 @@ lint:
 		echo "❌ compile_commands.json not found. Run 'make debug' first."; \
 		exit 1; \
 	fi
-	@if [ ! -f /opt/homebrew/opt/llvm/bin/clang-tidy ]; then \
-		echo "❌ clang-tidy not found at /opt/homebrew/opt/llvm/bin/clang-tidy"; \
-		echo "Install with: brew install llvm"; \
+	@if [ -z "$(CLANG_TIDY)" ]; then \
+		echo "❌ clang-tidy not found on PATH or at /opt/homebrew/opt/llvm/bin"; \
+		echo "Install with: brew install llvm   (macOS)"; \
+		echo "              apt install clang-tidy   (Debian/Ubuntu)"; \
 		exit 1; \
 	fi
 	@echo "📋 Analyzing magda/daw sources..."
 	@find magda/daw -name "*.cpp" -type f -exec \
-		/opt/homebrew/opt/llvm/bin/clang-tidy \
+		$(CLANG_TIDY) \
 		{} \
 		--config-file=.clang-tidy \
 		--format-style=file \
@@ -368,13 +378,17 @@ lint-changed:
 		echo "❌ compile_commands.json not found. Run 'make debug' first."; \
 		exit 1; \
 	fi
+	@if [ -z "$(CLANG_TIDY)" ]; then \
+		echo "❌ clang-tidy not found on PATH or at /opt/homebrew/opt/llvm/bin"; \
+		exit 1; \
+	fi
 	@CHANGED_FILES=$$(git diff --name-only --diff-filter=d HEAD | grep '\.cpp$$' || true); \
 	if [ -z "$$CHANGED_FILES" ]; then \
 		echo "No modified .cpp files found"; \
 	else \
 		echo "Analyzing: $$CHANGED_FILES"; \
 		for file in $$CHANGED_FILES; do \
-			/opt/homebrew/opt/llvm/bin/clang-tidy \
+			$(CLANG_TIDY) \
 				$$file \
 				--config-file=.clang-tidy \
 				--format-style=file \
@@ -397,7 +411,7 @@ lint-fix:
 	echo; \
 	if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
 		find magda/daw -name "*.cpp" -type f -exec \
-			/opt/homebrew/opt/llvm/bin/clang-tidy \
+			$(CLANG_TIDY) \
 			{} \
 			--config-file=.clang-tidy \
 			--format-style=file \
@@ -417,7 +431,11 @@ lint-file:
 		exit 1; \
 	fi
 	@echo "🔍 Analyzing $(FILE)..."
-	@/opt/homebrew/opt/llvm/bin/clang-tidy \
+	@if [ -z "$(CLANG_TIDY)" ]; then \
+		echo "❌ clang-tidy not found on PATH or at /opt/homebrew/opt/llvm/bin"; \
+		exit 1; \
+	fi
+	@$(CLANG_TIDY) \
 		$(FILE) \
 		--config-file=.clang-tidy \
 		--format-style=file \

--- a/Makefile
+++ b/Makefile
@@ -406,6 +406,10 @@ lint-fix:
 		echo "❌ compile_commands.json not found. Run 'make debug' first."; \
 		exit 1; \
 	fi
+	@if [ -z "$(CLANG_TIDY)" ]; then \
+		echo "❌ clang-tidy not found on PATH or at /opt/homebrew/opt/llvm/bin"; \
+		exit 1; \
+	fi
 	@echo "⚠️  This will modify your source files!"
 	@read -p "Continue? [y/N] " -n 1 -r; \
 	echo; \

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -563,6 +563,11 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
     };
 
     switch (info.commandID) {
+        case saveProject:
+        case saveProjectAs:
+        case exportAudio:
+            return MenuManager::getInstance().invokeApplicationCommand(info.commandID);
+
         case undo:
             UndoManager::getInstance().undo();
             return true;

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -106,10 +106,14 @@ void MainWindow::MainComponent::getAllCommands(juce::Array<juce::CommandID>& com
         newAudioTrack, newMidiTrack, deleteTrack, duplicateTrackNoContent,
         duplicateTrackContentOnly, toggleMuteSelectedTracks, toggleSoloSelectedTracks,
         // View
-        zoom, toggleArrangeSession, cycleViewForward, cycleViewBackward, uiScaleUp, uiScaleDown,
+        toggleArrangeSession, cycleViewForward, cycleViewBackward, uiScaleUp, uiScaleDown,
         togglePianoRollFullscreen,
         // Help
-        showHelp, about};
+        about};
+
+    // `zoom` describes a group of View-menu controls, not one action, and
+    // `showHelp` is still a placeholder. Do not expose either as a bindable
+    // command until each has a concrete action to perform.
 
     commands.addArray(allCommands, juce::numElementsInArray(allCommands));
 }
@@ -421,9 +425,6 @@ void MainWindow::MainComponent::getCommandInfo(juce::CommandID commandID,
             break;
 
         // View
-        case zoom:
-            result.setInfo("Zoom", "Zoom controls", "View", 0);
-            break;
         case toggleArrangeSession:
             result.setInfo("Toggle Arrange/Session", "Switch between arrange and session view",
                            "View", 0);
@@ -457,9 +458,6 @@ void MainWindow::MainComponent::getCommandInfo(juce::CommandID commandID,
             break;
 
         // Help
-        case showHelp:
-            result.setInfo("Help", "Show help documentation", "Help", 0);
-            break;
         case about:
             result.setInfo("About", "About this application", "Help", 0);
             break;
@@ -475,12 +473,6 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
     auto& clipManager = ClipManager::getInstance();
     auto& selectionManager = SelectionManager::getInstance();
     auto selectedClips = selectionManager.getSelectedClips();
-
-    // Command-backed application/menu actions share the same callback path as
-    // menu clicks. Keeping this before the local switch prevents registered
-    // menu commands from silently becoming dead custom key bindings.
-    if (MenuManager::getInstance().invokeApplicationCommand(info.commandID))
-        return true;
 
     // Helper: resolve time selection track indices to TrackIds
     auto resolveTimeSelectionTrackIds = [this]() -> std::vector<TrackId> {
@@ -1889,7 +1881,10 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
             return true;
 
         default:
-            return false;
+            // Command-backed application/menu actions share the same callback
+            // path as menu clicks. Using this only as the switch fallback
+            // prevents a future overlap from shadowing a local command case.
+            return MenuManager::getInstance().invokeApplicationCommand(info.commandID);
     }
 }
 

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -89,6 +89,9 @@ void rippleTempoSequence(AudioEngine* audioEngine, TempoSequenceRippleCommand::M
 void MainWindow::MainComponent::getAllCommands(juce::Array<juce::CommandID>& commands) {
     using namespace CommandIDs;
 
+    // `zoom` describes a group of View-menu controls, not one action, and
+    // `showHelp` is still a placeholder. Do not expose either as a bindable
+    // command until each has a concrete action to perform.
     const juce::CommandID allCommands[] = {
         // Edit menu
         undo, redo, cut, copy, paste, duplicate, duplicateClipWithAutomation,
@@ -110,10 +113,6 @@ void MainWindow::MainComponent::getAllCommands(juce::Array<juce::CommandID>& com
         togglePianoRollFullscreen,
         // Help
         about};
-
-    // `zoom` describes a group of View-menu controls, not one action, and
-    // `showHelp` is still a placeholder. Do not expose either as a bindable
-    // command until each has a concrete action to perform.
 
     commands.addArray(allCommands, juce::numElementsInArray(allCommands));
 }

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -476,6 +476,12 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
     auto& selectionManager = SelectionManager::getInstance();
     auto selectedClips = selectionManager.getSelectedClips();
 
+    // Command-backed application/menu actions share the same callback path as
+    // menu clicks. Keeping this before the local switch prevents registered
+    // menu commands from silently becoming dead custom key bindings.
+    if (MenuManager::getInstance().invokeApplicationCommand(info.commandID))
+        return true;
+
     // Helper: resolve time selection track indices to TrackIds
     auto resolveTimeSelectionTrackIds = [this]() -> std::vector<TrackId> {
         std::vector<TrackId> trackIds;
@@ -563,11 +569,6 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
     };
 
     switch (info.commandID) {
-        case saveProject:
-        case saveProjectAs:
-        case exportAudio:
-            return MenuManager::getInstance().invokeApplicationCommand(info.commandID);
-
         case undo:
             UndoManager::getInstance().undo();
             return true;

--- a/magda/daw/ui/windows/MainWindowMenus.cpp
+++ b/magda/daw/ui/windows/MainWindowMenus.cpp
@@ -24,6 +24,7 @@
 #include "core/TrackManager.hpp"
 #include "core/TrackPropertyCommands.hpp"
 #include "core/UndoManager.hpp"
+#include "core/ViewModeController.hpp"
 #include "engine/TracktionEngineWrapper.hpp"
 #include "project/MediaCollector.hpp"
 #include "project/ProjectManager.hpp"
@@ -729,6 +730,13 @@ void MainWindow::setupMenuCallbacks() {
                 tc.dispatch(ZoomToFitBeatsEvent{sel.startBeats, sel.endBeats});
             }
         }
+    };
+
+    callbacks.onToggleArrangeSession = []() {
+        auto& viewModeController = ViewModeController::getInstance();
+        viewModeController.setViewMode(viewModeController.getViewMode() == ViewMode::Live
+                                           ? ViewMode::Arrange
+                                           : ViewMode::Live);
     };
 
     callbacks.onToggleFullscreen = [this]() { setFullScreen(!isFullScreen()); };

--- a/magda/daw/ui/windows/MenuManager.cpp
+++ b/magda/daw/ui/windows/MenuManager.cpp
@@ -42,6 +42,12 @@ bool MenuManager::invokeApplicationCommand(juce::CommandID commandID) {
     std::function<void()>* callback = nullptr;
 
     switch (commandID) {
+        case CommandIDs::newProject:
+            callback = &callbacks_.onNewProject;
+            break;
+        case CommandIDs::openProject:
+            callback = &callbacks_.onOpenProject;
+            break;
         case CommandIDs::saveProject:
             callback = &callbacks_.onSaveProject;
             break;
@@ -51,12 +57,29 @@ bool MenuManager::invokeApplicationCommand(juce::CommandID commandID) {
         case CommandIDs::exportAudio:
             callback = &callbacks_.onExportAudio;
             break;
+        case CommandIDs::deleteTrack:
+            callback = &callbacks_.onDeleteTrack;
+            break;
+        case CommandIDs::toggleArrangeSession:
+            callback = &callbacks_.onToggleArrangeSession;
+            break;
+        case CommandIDs::zoom:
+            callback = &callbacks_.onZoom;
+            break;
+        case CommandIDs::showHelp:
+            callback = &callbacks_.onShowHelp;
+            break;
+        case CommandIDs::about:
+            callback = &callbacks_.onAbout;
+            break;
         default:
             return false;
     }
 
-    if (!*callback)
+    if (!*callback) {
+        jassertfalse;
         return false;
+    }
 
     (*callback)();
     return true;

--- a/magda/daw/ui/windows/MenuManager.cpp
+++ b/magda/daw/ui/windows/MenuManager.cpp
@@ -38,6 +38,30 @@ void MenuManager::initialize(const MenuCallbacks& callbacks) {
     callbacks_ = callbacks;
 }
 
+bool MenuManager::invokeApplicationCommand(juce::CommandID commandID) {
+    std::function<void()>* callback = nullptr;
+
+    switch (commandID) {
+        case CommandIDs::saveProject:
+            callback = &callbacks_.onSaveProject;
+            break;
+        case CommandIDs::saveProjectAs:
+            callback = &callbacks_.onSaveProjectAs;
+            break;
+        case CommandIDs::exportAudio:
+            callback = &callbacks_.onExportAudio;
+            break;
+        default:
+            return false;
+    }
+
+    if (!*callback)
+        return false;
+
+    (*callback)();
+    return true;
+}
+
 void MenuManager::updateMenuStates(bool canUndo, bool canRedo, bool hasSelection,
                                    bool hasEditCursor, bool leftPanelVisible,
                                    bool rightPanelVisible, bool bottomPanelVisible, bool isPlaying,
@@ -101,13 +125,20 @@ juce::PopupMenu MenuManager::getMenuForIndex(int topLevelMenuIndex,
 
             menu.addItem(CloseProject, tr("menu.file.close_project"), true, false);
             menu.addSeparator();
-            menu.addItem(SaveProject, tr("menu.file.save_project"), true, false);
-            menu.addItem(SaveProjectAs, trEllipsis("menu.file.save_project_as"), true, false);
+            menu.addItem(SaveProject,
+                         tr("menu.file.save_project") + keyHint(CommandIDs::saveProject), true,
+                         false);
+            menu.addItem(SaveProjectAs,
+                         trEllipsis("menu.file.save_project_as") +
+                             keyHint(CommandIDs::saveProjectAs),
+                         true, false);
             menu.addSeparator();
             menu.addItem(ProjectSettings, trEllipsis("menu.file.project_settings"), true, false);
             menu.addItem(CollectFiles, trEllipsis("menu.file.collect_files"), true, false);
             menu.addSeparator();
-            menu.addItem(ExportAudio, trEllipsis("menu.file.export_audio"), true, false);
+            menu.addItem(ExportAudio,
+                         trEllipsis("menu.file.export_audio") + keyHint(CommandIDs::exportAudio),
+                         true, false);
             menu.addItem(ExportMidi,
                          trEllipsis("action.export")
                              .replace("{0}", magda::technicalText(magda::TechnicalTextToken::Midi)),
@@ -372,12 +403,10 @@ void MenuManager::menuItemSelected(int menuItemID, int topLevelMenuIndex) {
                 callbacks_.onCloseProject();
             break;
         case SaveProject:
-            if (callbacks_.onSaveProject)
-                callbacks_.onSaveProject();
+            invokeApplicationCommand(CommandIDs::saveProject);
             break;
         case SaveProjectAs:
-            if (callbacks_.onSaveProjectAs)
-                callbacks_.onSaveProjectAs();
+            invokeApplicationCommand(CommandIDs::saveProjectAs);
             break;
         case ProjectSettings:
             if (callbacks_.onProjectSettings)
@@ -388,8 +417,7 @@ void MenuManager::menuItemSelected(int menuItemID, int topLevelMenuIndex) {
                 callbacks_.onCollectFiles();
             break;
         case ExportAudio:
-            if (callbacks_.onExportAudio)
-                callbacks_.onExportAudio();
+            invokeApplicationCommand(CommandIDs::exportAudio);
             break;
         case ExportMidi:
             if (callbacks_.onExportMidi)

--- a/magda/daw/ui/windows/MenuManager.cpp
+++ b/magda/daw/ui/windows/MenuManager.cpp
@@ -63,12 +63,6 @@ bool MenuManager::invokeApplicationCommand(juce::CommandID commandID) {
         case CommandIDs::toggleArrangeSession:
             callback = &callbacks_.onToggleArrangeSession;
             break;
-        case CommandIDs::zoom:
-            callback = &callbacks_.onZoom;
-            break;
-        case CommandIDs::showHelp:
-            callback = &callbacks_.onShowHelp;
-            break;
         case CommandIDs::about:
             callback = &callbacks_.onAbout;
             break;

--- a/magda/daw/ui/windows/MenuManager.hpp
+++ b/magda/daw/ui/windows/MenuManager.hpp
@@ -72,6 +72,7 @@ class MenuManager : public juce::MenuBarModel, public UndoManagerListener {
         std::function<void()> onZoomToFit;
         std::function<void()> onZoomLoopToFit;
         std::function<void()> onZoomSelectionToFit;
+        std::function<void()> onToggleArrangeSession;
         std::function<void()> onToggleFullscreen;
         std::function<void()> onToggleScrollbarPosition;
 
@@ -119,8 +120,8 @@ class MenuManager : public juce::MenuBarModel, public UndoManagerListener {
     void initialize(const MenuCallbacks& callbacks);
 
     // Invoke a command-backed menu action through the same callback used by a
-    // menu click. Returns false when the command is not handled or its callback
-    // has not been configured.
+    // menu click. Returns false when the command is not handled. A missing
+    // callback for a known command is a programming error.
     bool invokeApplicationCommand(juce::CommandID commandID);
 
     // Source of truth for menu shortcut hints (#1352). When set, menu items

--- a/magda/daw/ui/windows/MenuManager.hpp
+++ b/magda/daw/ui/windows/MenuManager.hpp
@@ -118,6 +118,11 @@ class MenuManager : public juce::MenuBarModel, public UndoManagerListener {
     // Set up the menu bar
     void initialize(const MenuCallbacks& callbacks);
 
+    // Invoke a command-backed menu action through the same callback used by a
+    // menu click. Returns false when the command is not handled or its callback
+    // has not been configured.
+    bool invokeApplicationCommand(juce::CommandID commandID);
+
     // Source of truth for menu shortcut hints (#1352). When set, menu items
     // render the command's current key from the mapping set instead of a
     // hardcoded per-platform string, so remaps (#20) stay in sync. Owned by

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -140,6 +140,7 @@ set(TEST_SOURCES
     # Key mapping persistence tests (epic:command-registry -- #20)
     test_key_mapping_store.cpp
     test_menu_manager.cpp
+    # MenuManager builds into magda_daw_app, so magda_tests needs its implementation directly.
     ../magda/daw/ui/windows/MenuManager.cpp
     # MIDI device identifier matcher tests (issue #1050)
     test_midi_device_match.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -139,6 +139,8 @@ set(TEST_SOURCES
     test_gesture_router.cpp
     # Key mapping persistence tests (epic:command-registry -- #20)
     test_key_mapping_store.cpp
+    test_menu_manager.cpp
+    ../magda/daw/ui/windows/MenuManager.cpp
     # MIDI device identifier matcher tests (issue #1050)
     test_midi_device_match.cpp
     # MIDI Learn session tests (issue #924)

--- a/tests/test_menu_manager.cpp
+++ b/tests/test_menu_manager.cpp
@@ -1,0 +1,53 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/ui/windows/CommandIDs.hpp"
+#include "magda/daw/ui/windows/MenuManager.hpp"
+
+namespace {
+
+class MenuCallbacksGuard {
+  public:
+    explicit MenuCallbacksGuard(magda::MenuManager& menuManager) : menuManager_(menuManager) {}
+
+    ~MenuCallbacksGuard() {
+        menuManager_.initialize({});
+    }
+
+  private:
+    magda::MenuManager& menuManager_;
+};
+
+}  // namespace
+
+TEST_CASE("MenuManager dispatches File application commands to menu callbacks",
+          "[commands][menu]") {
+    auto& menuManager = magda::MenuManager::getInstance();
+    MenuCallbacksGuard guard(menuManager);
+
+    int saveProjectCalls = 0;
+    int saveProjectAsCalls = 0;
+    int exportAudioCalls = 0;
+
+    magda::MenuManager::MenuCallbacks callbacks;
+    callbacks.onSaveProject = [&] { ++saveProjectCalls; };
+    callbacks.onSaveProjectAs = [&] { ++saveProjectAsCalls; };
+    callbacks.onExportAudio = [&] { ++exportAudioCalls; };
+    menuManager.initialize(callbacks);
+
+    REQUIRE(menuManager.invokeApplicationCommand(magda::CommandIDs::saveProject));
+    REQUIRE(menuManager.invokeApplicationCommand(magda::CommandIDs::saveProjectAs));
+    REQUIRE(menuManager.invokeApplicationCommand(magda::CommandIDs::exportAudio));
+
+    CHECK(saveProjectCalls == 1);
+    CHECK(saveProjectAsCalls == 1);
+    CHECK(exportAudioCalls == 1);
+}
+
+TEST_CASE("MenuManager rejects commands without a configured File callback", "[commands][menu]") {
+    auto& menuManager = magda::MenuManager::getInstance();
+    MenuCallbacksGuard guard(menuManager);
+    menuManager.initialize({});
+
+    CHECK_FALSE(menuManager.invokeApplicationCommand(magda::CommandIDs::saveProject));
+    CHECK_FALSE(menuManager.invokeApplicationCommand(magda::CommandIDs::undo));
+}

--- a/tests/test_menu_manager.cpp
+++ b/tests/test_menu_manager.cpp
@@ -25,7 +25,7 @@ class MenuCallbacksGuard {
 TEST_CASE("MenuManager dispatches registered application commands to menu callbacks",
           "[commands][menu]") {
     auto& menuManager = magda::MenuManager::getInstance();
-    std::array<int, 10> calls{};
+    std::array<int, 8> calls{};
     MenuCallbacksGuard guard(menuManager);
 
     magda::MenuManager::MenuCallbacks callbacks;
@@ -36,29 +36,23 @@ TEST_CASE("MenuManager dispatches registered application commands to menu callba
     callbacks.onExportAudio = [&] { ++calls[4]; };
     callbacks.onDeleteTrack = [&] { ++calls[5]; };
     callbacks.onToggleArrangeSession = [&] { ++calls[6]; };
-    callbacks.onZoom = [&] { ++calls[7]; };
-    callbacks.onShowHelp = [&] { ++calls[8]; };
-    callbacks.onAbout = [&] { ++calls[9]; };
+    callbacks.onAbout = [&] { ++calls[7]; };
     menuManager.initialize(callbacks);
 
     const std::array commandIDs{
-        magda::CommandIDs::newProject,
-        magda::CommandIDs::openProject,
-        magda::CommandIDs::saveProject,
-        magda::CommandIDs::saveProjectAs,
-        magda::CommandIDs::exportAudio,
-        magda::CommandIDs::deleteTrack,
-        magda::CommandIDs::toggleArrangeSession,
-        magda::CommandIDs::zoom,
-        magda::CommandIDs::showHelp,
-        magda::CommandIDs::about,
+        magda::CommandIDs::newProject,           magda::CommandIDs::openProject,
+        magda::CommandIDs::saveProject,          magda::CommandIDs::saveProjectAs,
+        magda::CommandIDs::exportAudio,          magda::CommandIDs::deleteTrack,
+        magda::CommandIDs::toggleArrangeSession, magda::CommandIDs::about,
     };
 
     for (const auto commandID : commandIDs)
         REQUIRE(menuManager.invokeApplicationCommand(commandID));
 
-    for (const auto callCount : calls)
-        CHECK(callCount == 1);
+    for (size_t i = 0; i < calls.size(); ++i) {
+        CAPTURE(i, commandIDs[i]);
+        CHECK(calls[i] == 1);
+    }
 }
 
 TEST_CASE("MenuManager rejects commands outside its application callback dispatcher",
@@ -68,4 +62,6 @@ TEST_CASE("MenuManager rejects commands outside its application callback dispatc
     menuManager.initialize({});
 
     CHECK_FALSE(menuManager.invokeApplicationCommand(magda::CommandIDs::undo));
+    CHECK_FALSE(menuManager.invokeApplicationCommand(magda::CommandIDs::zoom));
+    CHECK_FALSE(menuManager.invokeApplicationCommand(magda::CommandIDs::showHelp));
 }

--- a/tests/test_menu_manager.cpp
+++ b/tests/test_menu_manager.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <catch2/catch_test_macros.hpp>
 
 #include "magda/daw/ui/windows/CommandIDs.hpp"
@@ -10,6 +11,8 @@ class MenuCallbacksGuard {
     explicit MenuCallbacksGuard(magda::MenuManager& menuManager) : menuManager_(menuManager) {}
 
     ~MenuCallbacksGuard() {
+        // This test target has no application-owned callbacks to restore, so
+        // return the process-wide singleton to its known empty baseline.
         menuManager_.initialize({});
     }
 
@@ -19,35 +22,50 @@ class MenuCallbacksGuard {
 
 }  // namespace
 
-TEST_CASE("MenuManager dispatches File application commands to menu callbacks",
+TEST_CASE("MenuManager dispatches registered application commands to menu callbacks",
           "[commands][menu]") {
     auto& menuManager = magda::MenuManager::getInstance();
+    std::array<int, 10> calls{};
     MenuCallbacksGuard guard(menuManager);
 
-    int saveProjectCalls = 0;
-    int saveProjectAsCalls = 0;
-    int exportAudioCalls = 0;
-
     magda::MenuManager::MenuCallbacks callbacks;
-    callbacks.onSaveProject = [&] { ++saveProjectCalls; };
-    callbacks.onSaveProjectAs = [&] { ++saveProjectAsCalls; };
-    callbacks.onExportAudio = [&] { ++exportAudioCalls; };
+    callbacks.onNewProject = [&] { ++calls[0]; };
+    callbacks.onOpenProject = [&] { ++calls[1]; };
+    callbacks.onSaveProject = [&] { ++calls[2]; };
+    callbacks.onSaveProjectAs = [&] { ++calls[3]; };
+    callbacks.onExportAudio = [&] { ++calls[4]; };
+    callbacks.onDeleteTrack = [&] { ++calls[5]; };
+    callbacks.onToggleArrangeSession = [&] { ++calls[6]; };
+    callbacks.onZoom = [&] { ++calls[7]; };
+    callbacks.onShowHelp = [&] { ++calls[8]; };
+    callbacks.onAbout = [&] { ++calls[9]; };
     menuManager.initialize(callbacks);
 
-    REQUIRE(menuManager.invokeApplicationCommand(magda::CommandIDs::saveProject));
-    REQUIRE(menuManager.invokeApplicationCommand(magda::CommandIDs::saveProjectAs));
-    REQUIRE(menuManager.invokeApplicationCommand(magda::CommandIDs::exportAudio));
+    const std::array commandIDs{
+        magda::CommandIDs::newProject,
+        magda::CommandIDs::openProject,
+        magda::CommandIDs::saveProject,
+        magda::CommandIDs::saveProjectAs,
+        magda::CommandIDs::exportAudio,
+        magda::CommandIDs::deleteTrack,
+        magda::CommandIDs::toggleArrangeSession,
+        magda::CommandIDs::zoom,
+        magda::CommandIDs::showHelp,
+        magda::CommandIDs::about,
+    };
 
-    CHECK(saveProjectCalls == 1);
-    CHECK(saveProjectAsCalls == 1);
-    CHECK(exportAudioCalls == 1);
+    for (const auto commandID : commandIDs)
+        REQUIRE(menuManager.invokeApplicationCommand(commandID));
+
+    for (const auto callCount : calls)
+        CHECK(callCount == 1);
 }
 
-TEST_CASE("MenuManager rejects commands without a configured File callback", "[commands][menu]") {
+TEST_CASE("MenuManager rejects commands outside its application callback dispatcher",
+          "[commands][menu]") {
     auto& menuManager = magda::MenuManager::getInstance();
     MenuCallbacksGuard guard(menuManager);
     menuManager.initialize({});
 
-    CHECK_FALSE(menuManager.invokeApplicationCommand(magda::CommandIDs::saveProject));
     CHECK_FALSE(menuManager.invokeApplicationCommand(magda::CommandIDs::undo));
 }

--- a/tests/test_menu_manager.cpp
+++ b/tests/test_menu_manager.cpp
@@ -45,6 +45,7 @@ TEST_CASE("MenuManager dispatches registered application commands to menu callba
         magda::CommandIDs::exportAudio,          magda::CommandIDs::deleteTrack,
         magda::CommandIDs::toggleArrangeSession, magda::CommandIDs::about,
     };
+    static_assert(calls.size() == commandIDs.size());
 
     for (const auto commandID : commandIDs)
         REQUIRE(menuManager.invokeApplicationCommand(commandID));


### PR DESCRIPTION
Fixes #1911. Scoped to the File menu shortcut bugs only — Save Project, Save As and Export Audio.

New Project and Open Project are deliberately **not** here. They had no default keypress, so wiring them up is a new capability rather than a fix, and they are what pulled in the unsaved-changes work. They moved to #1916 (stacked on this branch), along with the other newly bindable commands. The unsaved-changes bug is its own PR off `main`.

## 1. File menu shortcuts never fired

Save Project, Save As and Export Audio were fully registered: `getAllCommands()` returned them and `getCommandInfo()` gave them names, the "File" category and keypresses (`saveProject` = Cmd/Ctrl+S, `saveProjectAs` = Cmd/Ctrl+Shift+S). So they appeared in the shortcuts editor and looked bound. But `perform()` had no case for them, so each fell through to `default: return false` — JUCE reads that as "not handled" and nothing happens.

Menu clicks kept working because `MenuManager::menuItemSelected()` is a separate path off its own `menuItemID` enum.

`perform()` now routes into `MenuManager::invokeApplicationCommand()`, the same callbacks a menu click uses, so both paths converge on one action per command.

## 2. The File menu showed no shortcut hints

It was the only menu making no `keyHint()` calls, so even Save's Cmd/Ctrl+S was invisible next to its item. Combined with the dead keys above, the File shortcuts read as entirely absent.

## 3. Lint targets were unusable off macOS

`lint`, `lint-changed`, `lint-fix` and `lint-file` hardcoded `/opt/homebrew/opt/llvm/bin/clang-tidy`, so every one failed on Linux even with the distro package installed. A `CLANG_TIDY` variable now prefers the Homebrew binary when present and falls back to `PATH`, with install hints for both platforms when neither resolves.

## Testing

`tests/test_menu_manager.cpp` covers the File commands dispatching to their callbacks plus the unconfigured-callback and unhandled-command rejection paths.

Full suite passes: 1549 passed, 13 skipped, 0 failures. Debug app builds clean. clang-tidy reports nothing new on the changed lines.
