### PR TITLE
Prompt to save unsaved changes on New/Open/Close

### DIFF
--- a/magda/daw/core/UndoManager.cpp
+++ b/magda/daw/core/UndoManager.cpp
@@ -22,10 +22,10 @@ void UndoManager::executeCommand(std::unique_ptr<UndoableCommand> command) {
     }
 
     const auto beforeStateId = currentStateId_;
-    auto& projectManager = ProjectManager::getInstance();
-    projectManager.beginUndoableMutation();
-    command->execute();
-    projectManager.endUndoableMutation();
+    {
+        ProjectManager::UndoableMutationScope mutationScope;
+        command->execute();
+    }
     currentStateId_ = nextStateId_++;
 
     // If in compound operation, collect commands instead of pushing to stack
@@ -66,10 +66,10 @@ bool UndoManager::undo() {
 
     DBG("📝 UNDO: Undoing '" << entry.command->getDescription() << "'");
 
-    auto& projectManager = ProjectManager::getInstance();
-    projectManager.beginUndoableMutation();
-    entry.command->undo();
-    projectManager.endUndoableMutation();
+    {
+        ProjectManager::UndoableMutationScope mutationScope;
+        entry.command->undo();
+    }
     currentStateId_ = entry.beforeStateId;
 
     // Push to redo stack
@@ -92,10 +92,10 @@ bool UndoManager::redo() {
 
     DBG("📝 UNDO: Redoing '" << entry.command->getDescription() << "'");
 
-    auto& projectManager = ProjectManager::getInstance();
-    projectManager.beginUndoableMutation();
-    entry.command->execute();
-    projectManager.endUndoableMutation();
+    {
+        ProjectManager::UndoableMutationScope mutationScope;
+        entry.command->execute();
+    }
     currentStateId_ = entry.afterStateId;
 
     // Push to undo stack
@@ -122,6 +122,10 @@ juce::String UndoManager::getRedoDescription() const {
 }
 
 void UndoManager::clearHistory() {
+    // The state ids deliberately survive this. Dropping the stacks removes the
+    // route back to the saved state but not the fact that current state differs
+    // from it, so undoHistoryDirty_ stays correct and a later save still clears
+    // it through markCurrentStateSaved().
     undoStack_.clear();
     redoStack_.clear();
     compoundCommands_.clear();

--- a/magda/daw/core/UndoManager.cpp
+++ b/magda/daw/core/UndoManager.cpp
@@ -1,5 +1,7 @@
 #include "UndoManager.hpp"
 
+#include "../project/ProjectManager.hpp"
+
 namespace magda {
 
 // ============================================================================
@@ -21,6 +23,11 @@ void UndoManager::executeCommand(std::unique_ptr<UndoableCommand> command) {
 
     // Execute the command
     command->execute();
+
+    // Every undoable command mutates project state, so this is the one place
+    // that has to flag unsaved changes — otherwise New/Open/Close discard the
+    // user's work without ever showing the unsaved-changes prompt.
+    ProjectManager::getInstance().markDirty();
 
     // If in compound operation, collect commands instead of pushing to stack
     if (compoundDepth_ > 0) {
@@ -57,6 +64,9 @@ bool UndoManager::undo() {
     // Undo the command
     command->undo();
 
+    // Undoing moves state away from what is on disk just as much as doing.
+    ProjectManager::getInstance().markDirty();
+
     // Push to redo stack
     redoStack_.push_back(std::move(command));
 
@@ -78,6 +88,8 @@ bool UndoManager::redo() {
 
     // Re-execute the command
     command->execute();
+
+    ProjectManager::getInstance().markDirty();
 
     // Push to undo stack
     undoStack_.push_back(std::move(command));

--- a/magda/daw/core/UndoManager.cpp
+++ b/magda/daw/core/UndoManager.cpp
@@ -21,32 +21,37 @@ void UndoManager::executeCommand(std::unique_ptr<UndoableCommand> command) {
         return;
     }
 
-    // Execute the command
+    const auto beforeStateId = currentStateId_;
+    auto& projectManager = ProjectManager::getInstance();
+    projectManager.beginUndoableMutation();
     command->execute();
-
-    // Every undoable command mutates project state, so this is the one place
-    // that has to flag unsaved changes — otherwise New/Open/Close discard the
-    // user's work without ever showing the unsaved-changes prompt.
-    ProjectManager::getInstance().markDirty();
+    projectManager.endUndoableMutation();
+    currentStateId_ = nextStateId_++;
 
     // If in compound operation, collect commands instead of pushing to stack
     if (compoundDepth_ > 0) {
         compoundCommands_.push_back(std::move(command));
+        updateProjectDirtyState();
         return;
     }
 
     // Check if we can merge with the previous command
-    if (!undoStack_.empty() && undoStack_.back()->canMergeWith(command.get())) {
-        undoStack_.back()->mergeWith(command.get());
+    // Do not merge across the saved checkpoint: doing so would make the exact
+    // on-disk state unreachable by undo.
+    if (!undoStack_.empty() && beforeStateId != savedStateId_ &&
+        undoStack_.back().command->canMergeWith(command.get())) {
+        undoStack_.back().command->mergeWith(command.get());
+        undoStack_.back().afterStateId = currentStateId_;
     } else {
         // Add to undo stack
-        undoStack_.push_back(std::move(command));
+        undoStack_.push_back({std::move(command), beforeStateId, currentStateId_});
         trimUndoStack();
     }
 
     // Clear redo stack (new action invalidates redo history)
     redoStack_.clear();
 
+    updateProjectDirtyState();
     notifyListeners();
 }
 
@@ -56,20 +61,21 @@ bool UndoManager::undo() {
     }
 
     // Pop from undo stack
-    auto command = std::move(undoStack_.back());
+    auto entry = std::move(undoStack_.back());
     undoStack_.pop_back();
 
-    DBG("📝 UNDO: Undoing '" << command->getDescription() << "'");
+    DBG("📝 UNDO: Undoing '" << entry.command->getDescription() << "'");
 
-    // Undo the command
-    command->undo();
-
-    // Undoing moves state away from what is on disk just as much as doing.
-    ProjectManager::getInstance().markDirty();
+    auto& projectManager = ProjectManager::getInstance();
+    projectManager.beginUndoableMutation();
+    entry.command->undo();
+    projectManager.endUndoableMutation();
+    currentStateId_ = entry.beforeStateId;
 
     // Push to redo stack
-    redoStack_.push_back(std::move(command));
+    redoStack_.push_back(std::move(entry));
 
+    updateProjectDirtyState();
     notifyListeners();
 
     return true;
@@ -81,19 +87,21 @@ bool UndoManager::redo() {
     }
 
     // Pop from redo stack
-    auto command = std::move(redoStack_.back());
+    auto entry = std::move(redoStack_.back());
     redoStack_.pop_back();
 
-    DBG("📝 UNDO: Redoing '" << command->getDescription() << "'");
+    DBG("📝 UNDO: Redoing '" << entry.command->getDescription() << "'");
 
-    // Re-execute the command
-    command->execute();
-
-    ProjectManager::getInstance().markDirty();
+    auto& projectManager = ProjectManager::getInstance();
+    projectManager.beginUndoableMutation();
+    entry.command->execute();
+    projectManager.endUndoableMutation();
+    currentStateId_ = entry.afterStateId;
 
     // Push to undo stack
-    undoStack_.push_back(std::move(command));
+    undoStack_.push_back(std::move(entry));
 
+    updateProjectDirtyState();
     notifyListeners();
 
     return true;
@@ -103,14 +111,14 @@ juce::String UndoManager::getUndoDescription() const {
     if (undoStack_.empty()) {
         return {};
     }
-    return undoStack_.back()->getDescription();
+    return undoStack_.back().command->getDescription();
 }
 
 juce::String UndoManager::getRedoDescription() const {
     if (redoStack_.empty()) {
         return {};
     }
-    return redoStack_.back()->getDescription();
+    return redoStack_.back().command->getDescription();
 }
 
 void UndoManager::clearHistory() {
@@ -121,10 +129,16 @@ void UndoManager::clearHistory() {
     notifyListeners();
 }
 
+void UndoManager::markCurrentStateSaved() {
+    savedStateId_ = currentStateId_;
+    updateProjectDirtyState();
+}
+
 void UndoManager::beginCompoundOperation(const juce::String& description) {
     if (compoundDepth_ == 0) {
         compoundDescription_ = description;
         compoundCommands_.clear();
+        compoundBeforeStateId_ = currentStateId_;
     }
     compoundDepth_++;
 }
@@ -140,7 +154,7 @@ void UndoManager::endCompoundOperation() {
         // Create compound command and add to undo stack
         auto compound =
             std::make_unique<CompoundCommand>(compoundDescription_, std::move(compoundCommands_));
-        undoStack_.push_back(std::move(compound));
+        undoStack_.push_back({std::move(compound), compoundBeforeStateId_, currentStateId_});
         trimUndoStack();
 
         // Clear redo stack
@@ -173,6 +187,10 @@ void UndoManager::trimUndoStack() {
     while (undoStack_.size() > maxUndoSteps_) {
         undoStack_.pop_front();
     }
+}
+
+void UndoManager::updateProjectDirtyState() {
+    ProjectManager::getInstance().setUndoHistoryDirty(currentStateId_ != savedStateId_);
 }
 
 // ============================================================================

--- a/magda/daw/core/UndoManager.hpp
+++ b/magda/daw/core/UndoManager.hpp
@@ -2,6 +2,7 @@
 
 #include <juce_core/juce_core.h>
 
+#include <cstdint>
 #include <deque>
 #include <memory>
 #include <vector>
@@ -132,6 +133,11 @@ class UndoManager {
     void clearHistory();
 
     /**
+     * Record the current history state as matching the project on disk.
+     */
+    void markCurrentStateSaved();
+
+    /**
      * Begin a compound operation (groups multiple commands as one undo step).
      * All commands executed until endCompoundOperation() are grouped.
      */
@@ -169,21 +175,35 @@ class UndoManager {
     void removeListener(UndoManagerListener* listener);
 
   private:
+    struct HistoryEntry {
+        std::unique_ptr<UndoableCommand> command;
+        std::uint64_t beforeStateId = 0;
+        std::uint64_t afterStateId = 0;
+    };
+
     UndoManager();
     ~UndoManager() = default;
 
     void notifyListeners();
     void trimUndoStack();
+    void updateProjectDirtyState();
 
-    std::deque<std::unique_ptr<UndoableCommand>> undoStack_;
-    std::deque<std::unique_ptr<UndoableCommand>> redoStack_;
+    std::deque<HistoryEntry> undoStack_;
+    std::deque<HistoryEntry> redoStack_;
 
     // Compound operation support
     int compoundDepth_ = 0;
     juce::String compoundDescription_;
     std::vector<std::unique_ptr<UndoableCommand>> compoundCommands_;
+    std::uint64_t compoundBeforeStateId_ = 0;
 
     size_t maxUndoSteps_ = 100;
+
+    // Stable state identities let undo/redo recognise the exact state that was
+    // last saved, including after branching or command merging.
+    std::uint64_t currentStateId_ = 0;
+    std::uint64_t savedStateId_ = 0;
+    std::uint64_t nextStateId_ = 1;
 
     std::vector<UndoManagerListener*> listeners_;
 };

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -29,6 +29,9 @@ static const char* const kTempPrefix = "UnsavedProject_";
 static constexpr int kStaleTempDays = 7;
 static const char* const kAutosaveExtension = ".autosave";
 static constexpr int kDefaultAutoSaveIntervalMs = 60000;
+static const char* const kProjectChangedWhileLoading =
+    "The current project changed while the new project was loading. "
+    "Open the file again to avoid losing those changes.";
 
 namespace {
 
@@ -129,9 +132,7 @@ bool ProjectManager::newProject() {
     createTempMediaDirectory();
     ensureMediaSubdirectories(mediaDirectory_);
 
-    // The old project's commands reference ids that no longer exist. Clearing
-    // last also drops the markDirty() that clearAllTracks/Clips may have
-    // triggered, so the fresh project starts clean.
+    // The old project's commands reference ids that no longer exist.
     UndoManager::getInstance().clearHistory();
     clearDirty();
     notifyProjectOpened();
@@ -272,14 +273,12 @@ bool ProjectManager::loadProject(const juce::File& file,
     // The previous project's undo stack cannot be applied to this one — its
     // commands reference track/clip ids that are gone.
     UndoManager::getInstance().clearHistory();
+    clearDirty();
 
     // If we recovered from autosave, mark dirty so the user can save properly
     if (fileToLoad != file) {
-        isDirty_ = true;
-        notifyDirtyStateChanged();
+        markDirty();
         autosaveFile.deleteFile();
-    } else {
-        clearDirty();
     }
 
     deleteAutosaveFile();
@@ -336,46 +335,56 @@ void ProjectManager::importDawProjectAsync(
     // Join any previous background load before starting a new one.
     joinBackgroundThread();
 
+    const auto startingRevision = mutationRevision_;
     auto fileCopy = file;
-    loadThread_ = std::thread([fileCopy, importedDir, onBeforeCommit, onComplete, this]() {
-        auto staged = std::make_shared<StagedProjectData>();
-        const bool ok = ProjectSerializer::loadDawProjectAndStage(fileCopy, *staged, importedDir);
-        juce::String error;
-        if (!ok) {
-            DBG("Failed to import DAWproject: " + ProjectSerializer::getLastError());
-            error = ProjectSerializer::getLastError();
-        }
-
-        // Bounce back to the message thread for commit + notification.
-        juce::MessageManager::callAsync([this, staged, ok, error, onBeforeCommit, onComplete]() {
-            if (ok) {
-                resetTransportForProjectBoundary();
-
-                if (onBeforeCommit)
-                    onBeforeCommit(staged->info);
-
-                ProjectSerializer::commitStaged(*staged);
-
-                currentProject_ = staged->info;
-                currentProject_.filePath = {};
-                currentFile_ = juce::File();
-                isProjectOpen_ = true;
-
-                // An import has never been saved as a .mgd, so it starts dirty
-                // — but the previous project's undo stack still has to go.
-                UndoManager::getInstance().clearHistory();
-                isDirty_ = true;
-                notifyProjectOpened();
-                notifyDirtyStateChanged();
-
-                if (onAfterLoad)
-                    onAfterLoad(currentProject_);
+    loadThread_ =
+        std::thread([fileCopy, importedDir, startingRevision, onBeforeCommit, onComplete, this]() {
+            auto staged = std::make_shared<StagedProjectData>();
+            const bool ok =
+                ProjectSerializer::loadDawProjectAndStage(fileCopy, *staged, importedDir);
+            juce::String error;
+            if (!ok) {
+                DBG("Failed to import DAWproject: " + ProjectSerializer::getLastError());
+                error = ProjectSerializer::getLastError();
             }
 
-            if (onComplete)
-                onComplete(ok, error);
+            // Bounce back to the message thread for commit + notification.
+            juce::MessageManager::callAsync(
+                [this, staged, ok, error, startingRevision, onBeforeCommit, onComplete]() {
+                    if (ok) {
+                        if (mutationRevision_ != startingRevision) {
+                            if (onComplete)
+                                onComplete(false, kProjectChangedWhileLoading);
+                            return;
+                        }
+
+                        resetTransportForProjectBoundary();
+
+                        if (onBeforeCommit)
+                            onBeforeCommit(staged->info);
+
+                        ProjectSerializer::commitStaged(*staged);
+
+                        currentProject_ = staged->info;
+                        currentProject_.filePath = {};
+                        currentFile_ = juce::File();
+                        isProjectOpen_ = true;
+
+                        // An import has never been saved as a .mgd, so it starts dirty
+                        // — but the previous project's undo stack still has to go.
+                        UndoManager::getInstance().clearHistory();
+                        clearDirty();
+                        markDirty();
+                        notifyProjectOpened();
+
+                        if (onAfterLoad)
+                            onAfterLoad(currentProject_);
+                    }
+
+                    if (onComplete)
+                        onComplete(ok, error);
+                });
         });
-    });
 }
 
 void ProjectManager::loadProjectAsync(const juce::File& file,
@@ -413,11 +422,12 @@ void ProjectManager::loadProjectAsync(const juce::File& file,
     // Join any previous background load before starting a new one
     joinBackgroundThread();
 
+    const auto startingRevision = mutationRevision_;
     auto originalFile = file;
 
     // Launch background thread for I/O + parse + staging
     loadThread_ = std::thread([fileCopy, originalFile, recoveredFromAutosave, onBeforeCommit,
-                               onComplete, this]() {
+                               onComplete, startingRevision, this]() {
         auto staged = std::make_shared<StagedProjectData>();
         bool ok = ProjectSerializer::loadAndStage(fileCopy, *staged);
         juce::String error;
@@ -429,8 +439,15 @@ void ProjectManager::loadProjectAsync(const juce::File& file,
 
         // Bounce back to the message thread for commit + notification
         juce::MessageManager::callAsync([this, staged, ok, error, originalFile,
-                                         recoveredFromAutosave, onBeforeCommit, onComplete]() {
+                                         recoveredFromAutosave, startingRevision, onBeforeCommit,
+                                         onComplete]() {
             if (ok) {
+                if (mutationRevision_ != startingRevision) {
+                    if (onComplete)
+                        onComplete(false, kProjectChangedWhileLoading);
+                    return;
+                }
+
                 resetTransportForProjectBoundary();
 
                 // Set tempo/time sig/loop BEFORE committing tracks & clips,
@@ -452,13 +469,11 @@ void ProjectManager::loadProjectAsync(const juce::File& file,
                 // The previous project's undo stack cannot be applied to this
                 // one — its commands reference ids that are gone.
                 UndoManager::getInstance().clearHistory();
+                clearDirty();
 
                 if (recoveredFromAutosave) {
-                    isDirty_ = true;
-                    notifyDirtyStateChanged();
+                    markDirty();
                     deleteAutosaveFile();
-                } else {
-                    clearDirty();
                 }
 
                 notifyProjectOpened();
@@ -541,15 +556,38 @@ void ProjectManager::setLoopSettings(bool enabled, double startBeats, double end
 }
 
 void ProjectManager::markDirty() {
-    if (!isDirty_) {
-        isDirty_ = true;
-        notifyDirtyStateChanged();
-    }
+    ++mutationRevision_;
+    if (undoableMutationDepth_ == 0)
+        externalDirty_ = true;
+    refreshDirtyState();
 }
 
 void ProjectManager::clearDirty() {
-    if (isDirty_) {
-        isDirty_ = false;
+    externalDirty_ = false;
+    UndoManager::getInstance().markCurrentStateSaved();
+    refreshDirtyState();
+}
+
+void ProjectManager::beginUndoableMutation() {
+    ++undoableMutationDepth_;
+}
+
+void ProjectManager::endUndoableMutation() {
+    jassert(undoableMutationDepth_ > 0);
+    if (undoableMutationDepth_ > 0)
+        --undoableMutationDepth_;
+}
+
+void ProjectManager::setUndoHistoryDirty(bool dirty) {
+    ++mutationRevision_;
+    undoHistoryDirty_ = dirty;
+    refreshDirtyState();
+}
+
+void ProjectManager::refreshDirtyState() {
+    const bool shouldBeDirty = externalDirty_ || undoHistoryDirty_;
+    if (isDirty_ != shouldBeDirty) {
+        isDirty_ = shouldBeDirty;
         notifyDirtyStateChanged();
     }
 }

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -10,6 +10,7 @@
 #include "../core/Config.hpp"
 #include "../core/TempoUtils.hpp"
 #include "../core/TrackManager.hpp"
+#include "../core/UndoManager.hpp"
 #include "../engine/AudioEngine.hpp"
 #include "serialization/ProjectSerializer.hpp"
 #include "version.hpp"
@@ -128,6 +129,10 @@ bool ProjectManager::newProject() {
     createTempMediaDirectory();
     ensureMediaSubdirectories(mediaDirectory_);
 
+    // The old project's commands reference ids that no longer exist. Clearing
+    // last also drops the markDirty() that clearAllTracks/Clips may have
+    // triggered, so the fresh project starts clean.
+    UndoManager::getInstance().clearHistory();
     clearDirty();
     notifyProjectOpened();
 
@@ -264,6 +269,10 @@ bool ProjectManager::loadProject(const juce::File& file,
     mediaDirectory_ = file.getParentDirectory().getChildFile(mediaDirName);
     ensureMediaSubdirectories(mediaDirectory_);
 
+    // The previous project's undo stack cannot be applied to this one — its
+    // commands reference track/clip ids that are gone.
+    UndoManager::getInstance().clearHistory();
+
     // If we recovered from autosave, mark dirty so the user can save properly
     if (fileToLoad != file) {
         isDirty_ = true;
@@ -352,6 +361,9 @@ void ProjectManager::importDawProjectAsync(
                 currentFile_ = juce::File();
                 isProjectOpen_ = true;
 
+                // An import has never been saved as a .mgd, so it starts dirty
+                // — but the previous project's undo stack still has to go.
+                UndoManager::getInstance().clearHistory();
                 isDirty_ = true;
                 notifyProjectOpened();
                 notifyDirtyStateChanged();
@@ -372,7 +384,7 @@ void ProjectManager::loadProjectAsync(const juce::File& file,
     // Pre-flight checks on the message thread
     if (isDirty_ && !showUnsavedChangesDialog()) {
         if (onComplete)
-            onComplete(false, "Cancelled by user");
+            onComplete(false, {});  // empty error = user cancelled, not a failure
         return;
     }
 
@@ -437,6 +449,10 @@ void ProjectManager::loadProjectAsync(const juce::File& file,
                 mediaDirectory_ = originalFile.getParentDirectory().getChildFile(mediaDirName);
                 ensureMediaSubdirectories(mediaDirectory_);
 
+                // The previous project's undo stack cannot be applied to this
+                // one — its commands reference ids that are gone.
+                UndoManager::getInstance().clearHistory();
+
                 if (recoveredFromAutosave) {
                     isDirty_ = true;
                     notifyDirtyStateChanged();
@@ -477,6 +493,7 @@ bool ProjectManager::closeProject() {
     currentFile_ = juce::File();
     mediaDirectory_ = juce::File();
     isProjectOpen_ = false;
+    UndoManager::getInstance().clearHistory();
     clearDirty();
     notifyProjectClosed();
 

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -576,12 +576,28 @@ void ProjectManager::endUndoableMutation() {
     jassert(undoableMutationDepth_ > 0);
     if (undoableMutationDepth_ > 0)
         --undoableMutationDepth_;
+
+    // A command just changed project state. Most commands never call
+    // markDirty() themselves, so the revision has to move here or an in-flight
+    // background load would not notice edits made while it was parsing.
+    ++mutationRevision_;
 }
 
 void ProjectManager::setUndoHistoryDirty(bool dirty) {
-    ++mutationRevision_;
+    // Deliberately no revision bump. This runs from the dirty-state
+    // bookkeeping, which clearDirty() drives on every save, so counting it as a
+    // mutation would make saving during a background load abandon that load
+    // and report that the project changed underneath it.
     undoHistoryDirty_ = dirty;
     refreshDirtyState();
+}
+
+ProjectManager::UndoableMutationScope::UndoableMutationScope() {
+    ProjectManager::getInstance().beginUndoableMutation();
+}
+
+ProjectManager::UndoableMutationScope::~UndoableMutationScope() {
+    ProjectManager::getInstance().endUndoableMutation();
 }
 
 void ProjectManager::refreshDirtyState() {

--- a/magda/daw/project/ProjectManager.hpp
+++ b/magda/daw/project/ProjectManager.hpp
@@ -3,6 +3,7 @@
 #include <juce_core/juce_core.h>
 #include <juce_events/juce_events.h>
 
+#include <cstdint>
 #include <functional>
 #include <thread>
 #include <vector>
@@ -315,6 +316,8 @@ class ProjectManager : private juce::Timer {
     static void cleanupStaleTempDirectories();
 
   private:
+    friend class UndoManager;
+
     ProjectManager();
     ~ProjectManager();
 
@@ -327,14 +330,22 @@ class ProjectManager : private juce::Timer {
     juce::File currentFile_;
     juce::File mediaDirectory_;
     bool isDirty_ = false;
+    bool externalDirty_ = false;
+    bool undoHistoryDirty_ = false;
     bool isProjectOpen_ = false;
     bool autoSaveEnabled_ = true;
+    int undoableMutationDepth_ = 0;
+    std::uint64_t mutationRevision_ = 0;
 
     std::vector<ProjectManagerListener*> listeners_;
     juce::String lastError_;
     std::thread loadThread_;
 
     void clearDirty();
+    void beginUndoableMutation();
+    void endUndoableMutation();
+    void setUndoHistoryDirty(bool dirty);
+    void refreshDirtyState();
     void notifyProjectOpened();
     void notifyProjectSaved();
     void notifyProjectClosed();

--- a/magda/daw/project/ProjectManager.hpp
+++ b/magda/daw/project/ProjectManager.hpp
@@ -315,6 +315,24 @@ class ProjectManager : private juce::Timer {
      */
     static void cleanupStaleTempDirectories();
 
+    /**
+     * @brief Brackets an undoable command while it runs.
+     *
+     * markDirty() calls made from inside a command are redundant: the undo
+     * history already tracks that mutation, and routing them to externalDirty_
+     * would make the dirty flag unclearable by undo. This scope suppresses
+     * them, and unwinds on exceptions so a throwing command cannot leave the
+     * suppression permanently latched.
+     */
+    class UndoableMutationScope {
+      public:
+        UndoableMutationScope();
+        ~UndoableMutationScope();
+
+        UndoableMutationScope(const UndoableMutationScope&) = delete;
+        UndoableMutationScope& operator=(const UndoableMutationScope&) = delete;
+    };
+
   private:
     friend class UndoManager;
 

--- a/magda/daw/ui/windows/MainWindowMenus.cpp
+++ b/magda/daw/ui/windows/MainWindowMenus.cpp
@@ -122,8 +122,12 @@ void MainWindow::openProjectFile(const juce::File& file) {
                 safeThis->mainComponent->hideLoadingMessage();
 
             if (!success) {
-                juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon,
-                                                       tr("dialogs.open_project"), error);
+                // Empty error = user cancelled the unsaved-changes prompt;
+                // nothing went wrong, so stay silent.
+                if (error.isNotEmpty()) {
+                    juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon,
+                                                           tr("dialogs.open_project"), error);
+                }
             } else {
                 auto& config = Config::getInstance();
                 config.addRecentProject(file.getFullPathName().toStdString());

--- a/magda/daw/ui/windows/MainWindowMenus.cpp
+++ b/magda/daw/ui/windows/MainWindowMenus.cpp
@@ -98,10 +98,6 @@ void MainWindow::openProjectFile(const juce::File& file) {
     if (mainComponent)
         mainComponent->showLoadingMessage(trEllipsis("dialogs.loading_project"));
 
-    SelectionManager::getInstance().clearSelection();
-    if (mainComponent && mainComponent->mainView)
-        mainComponent->mainView->getTimelineController().dispatch(ClearTimeSelectionEvent{});
-
     auto& projectManager = ProjectManager::getInstance();
     auto safeThis = juce::Component::SafePointer<MainWindow>(this);
     projectManager.loadProjectAsync(
@@ -129,6 +125,12 @@ void MainWindow::openProjectFile(const juce::File& file) {
                                                            tr("dialogs.open_project"), error);
                 }
             } else {
+                SelectionManager::getInstance().clearSelection();
+                if (safeThis->mainComponent && safeThis->mainComponent->mainView) {
+                    safeThis->mainComponent->mainView->getTimelineController().dispatch(
+                        ClearTimeSelectionEvent{});
+                }
+
                 auto& config = Config::getInstance();
                 config.addRecentProject(file.getFullPathName().toStdString());
                 config.save();
@@ -141,31 +143,35 @@ void MainWindow::importDawProjectFile(const juce::File& file) {
     if (!file.existsAsFile())
         return;
 
-    SelectionManager::getInstance().clearSelection();
-    if (mainComponent && mainComponent->mainView)
-        mainComponent->mainView->getTimelineController().dispatch(ClearTimeSelectionEvent{});
-
     auto& projectManager = ProjectManager::getInstance();
+    auto safeThis = juce::Component::SafePointer<MainWindow>(this);
     projectManager.importDawProjectAsync(
         file,
-        [this](const ProjectInfo& info) {
-            if (!mainComponent || !mainComponent->mainView)
+        [safeThis](const ProjectInfo& info) {
+            if (!safeThis || !safeThis->mainComponent || !safeThis->mainComponent->mainView)
                 return;
-            auto& tc = mainComponent->mainView->getTimelineController();
+            auto& tc = safeThis->mainComponent->mainView->getTimelineController();
             tc.restoreProjectState(info.tempo, info.timeSignatureNumerator,
                                    info.timeSignatureDenominator, info.loopEnabled,
                                    info.loopStartBeats, info.loopEndBeats, info.markers,
                                    info.timelineLengthBars);
         },
-        [](bool ok, const juce::String& error) {
+        [safeThis](bool ok, const juce::String& error) {
             // Empty error = user cancelled the unsaved-changes prompt; stay silent.
-            if (!ok && error.isNotEmpty())
+            if (!ok && error.isNotEmpty()) {
                 juce::AlertWindow::showMessageBoxAsync(
                     juce::AlertWindow::WarningIcon,
                     tr("action.import")
                         .replace("{0}",
                                  magda::technicalText(magda::TechnicalTextToken::DawProject)),
                     error);
+            } else if (ok && safeThis) {
+                SelectionManager::getInstance().clearSelection();
+                if (safeThis->mainComponent && safeThis->mainComponent->mainView) {
+                    safeThis->mainComponent->mainView->getTimelineController().dispatch(
+                        ClearTimeSelectionEvent{});
+                }
+            }
         });
 }
 
@@ -178,9 +184,6 @@ void MainWindow::setupMenuCallbacks() {
 
     // File menu callbacks
     callbacks.onNewProject = [this]() {
-        SelectionManager::getInstance().clearSelection();
-        if (mainComponent && mainComponent->mainView)
-            mainComponent->mainView->getTimelineController().dispatch(ClearTimeSelectionEvent{});
         auto& projectManager = ProjectManager::getInstance();
         if (!projectManager.newProject()) {
             const auto lastError = projectManager.getLastError();
@@ -192,6 +195,11 @@ void MainWindow::setupMenuCallbacks() {
                                                        tr("dialogs.new_project"), message);
             }
         } else {
+            SelectionManager::getInstance().clearSelection();
+            if (mainComponent && mainComponent->mainView)
+                mainComponent->mainView->getTimelineController().dispatch(
+                    ClearTimeSelectionEvent{});
+
             // Reset timeline/transport to defaults
             if (mainComponent && mainComponent->mainView) {
                 const auto& info = ProjectManager::getInstance().getCurrentProjectInfo();
@@ -242,9 +250,6 @@ void MainWindow::setupMenuCallbacks() {
     };
 
     callbacks.onCloseProject = [this]() {
-        SelectionManager::getInstance().clearSelection();
-        if (mainComponent && mainComponent->mainView)
-            mainComponent->mainView->getTimelineController().dispatch(ClearTimeSelectionEvent{});
         auto& projectManager = ProjectManager::getInstance();
         if (!projectManager.closeProject()) {
             const auto lastError = projectManager.getLastError();
@@ -255,6 +260,11 @@ void MainWindow::setupMenuCallbacks() {
                     tr("dialogs.error.close_failed") + " " + lastError);
             }
         } else {
+            SelectionManager::getInstance().clearSelection();
+            if (mainComponent && mainComponent->mainView)
+                mainComponent->mainView->getTimelineController().dispatch(
+                    ClearTimeSelectionEvent{});
+
             // Reset timeline/transport to defaults
             if (mainComponent && mainComponent->mainView) {
                 ProjectInfo defaults;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,8 @@ set(TEST_SOURCES
     test_looped_waveform_tile.cpp
     test_project_serialization.cpp
     test_project_document_adapters.cpp
+    # Unsaved-changes tracking across the undo stack and project boundaries
+    test_project_dirty_tracking.cpp
     test_session_clip_playback.cpp
     test_sidechain_triggers.cpp
     test_sidechain_device.cpp

--- a/tests/test_project_dirty_tracking.cpp
+++ b/tests/test_project_dirty_tracking.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
+#include <stdexcept>
 
 #include "magda/daw/core/UndoManager.hpp"
 #include "magda/daw/project/ProjectManager.hpp"
@@ -50,6 +51,22 @@ class MergeableValueCommand : public magda::UndoableCommand {
     int& value_;
     int oldValue_;
     int newValue_;
+};
+
+// Throws out of execute() so the mutation scope has to unwind. If it does not,
+// markDirty() stays suppressed for the rest of the process and the project
+// silently never reports unsaved changes again.
+class ThrowingCommand : public magda::UndoableCommand {
+  public:
+    void execute() override {
+        throw std::runtime_error("command failed");
+    }
+
+    void undo() override {}
+
+    juce::String getDescription() const override {
+        return "Throwing";
+    }
 };
 
 class TempProject {
@@ -155,6 +172,13 @@ TEST_CASE("Undoable commands mark the project dirty", "[project][undo]") {
         undoManager.executeCommand(std::make_unique<NoOpCommand>());
 
         REQUIRE(undoManager.undo());
+        CHECK(projectManager.isDirty());
+    }
+
+    SECTION("a throwing command leaves later external edits still detectable") {
+        REQUIRE_THROWS(undoManager.executeCommand(std::make_unique<ThrowingCommand>()));
+
+        projectManager.markDirty();
         CHECK(projectManager.isDirty());
     }
 

--- a/tests/test_project_dirty_tracking.cpp
+++ b/tests/test_project_dirty_tracking.cpp
@@ -1,0 +1,101 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+
+#include "magda/daw/core/UndoManager.hpp"
+#include "magda/daw/project/ProjectManager.hpp"
+
+namespace {
+
+// A command with no side effects beyond the undo stack itself, so these tests
+// exercise the dirty/history plumbing rather than any manager's state.
+class NoOpCommand : public magda::UndoableCommand {
+  public:
+    void execute() override {}
+    void undo() override {}
+
+    juce::String getDescription() const override {
+        return "No-op";
+    }
+};
+
+// Saving is the only public path that clears the dirty flag. Tests need it both
+// to establish a known-clean starting point and to hand the shared singleton
+// back clean — a dirty ProjectManager would make a later test's newProject() or
+// loadProject() raise the modal unsaved-changes prompt and stall the run.
+juce::File saveToCleanState() {
+    auto& projectManager = magda::ProjectManager::getInstance();
+    auto file = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                    .getChildFile("magda_dirty_tracking")
+                    .getChildFile("DirtyTracking.mgd");
+    REQUIRE(projectManager.saveProjectAs(file));
+    REQUIRE_FALSE(projectManager.isDirty());
+    return projectManager.getCurrentProjectFile();
+}
+
+}  // namespace
+
+TEST_CASE("Undoable commands mark the project dirty", "[project][undo]") {
+    auto& projectManager = magda::ProjectManager::getInstance();
+    auto& undoManager = magda::UndoManager::getInstance();
+
+    saveToCleanState();
+    undoManager.clearHistory();
+
+    SECTION("executing a command") {
+        undoManager.executeCommand(std::make_unique<NoOpCommand>());
+        CHECK(projectManager.isDirty());
+    }
+
+    SECTION("undoing moves state away from the saved file too") {
+        undoManager.executeCommand(std::make_unique<NoOpCommand>());
+        saveToCleanState();
+
+        REQUIRE(undoManager.undo());
+        CHECK(projectManager.isDirty());
+    }
+
+    SECTION("redoing does as well") {
+        undoManager.executeCommand(std::make_unique<NoOpCommand>());
+        REQUIRE(undoManager.undo());
+        saveToCleanState();
+
+        REQUIRE(undoManager.redo());
+        CHECK(projectManager.isDirty());
+    }
+
+    SECTION("a command inside a compound operation still marks dirty") {
+        undoManager.beginCompoundOperation("Compound");
+        undoManager.executeCommand(std::make_unique<NoOpCommand>());
+        CHECK(projectManager.isDirty());
+        undoManager.endCompoundOperation();
+    }
+
+    saveToCleanState();
+    undoManager.clearHistory();
+}
+
+TEST_CASE("Opening a project drops the previous project's undo history",
+          "[project][undo]") {
+    auto& projectManager = magda::ProjectManager::getInstance();
+    auto& undoManager = magda::UndoManager::getInstance();
+
+    auto file = saveToCleanState();
+    undoManager.clearHistory();
+
+    // Save after the edit so the load below starts from a clean project and
+    // does not raise the unsaved-changes prompt — the history must survive the
+    // save and be dropped only by the project boundary.
+    undoManager.executeCommand(std::make_unique<NoOpCommand>());
+    saveToCleanState();
+    REQUIRE(undoManager.canUndo());
+
+    REQUIRE(projectManager.loadProject(file));
+
+    CHECK_FALSE(undoManager.canUndo());
+    CHECK_FALSE(undoManager.canRedo());
+    CHECK_FALSE(projectManager.isDirty());
+
+    saveToCleanState();
+    undoManager.clearHistory();
+}

--- a/tests/test_project_dirty_tracking.cpp
+++ b/tests/test_project_dirty_tracking.cpp
@@ -1,5 +1,4 @@
 #include <catch2/catch_test_macros.hpp>
-
 #include <memory>
 
 #include "magda/daw/core/UndoManager.hpp"
@@ -19,15 +18,70 @@ class NoOpCommand : public magda::UndoableCommand {
     }
 };
 
-// Saving is the only public path that clears the dirty flag. Tests need it both
-// to establish a known-clean starting point and to hand the shared singleton
-// back clean — a dirty ProjectManager would make a later test's newProject() or
-// loadProject() raise the modal unsaved-changes prompt and stall the run.
-juce::File saveToCleanState() {
+class MergeableValueCommand : public magda::UndoableCommand {
+  public:
+    MergeableValueCommand(int& value, int newValue)
+        : value_(value), oldValue_(value), newValue_(newValue) {}
+
+    void execute() override {
+        value_ = newValue_;
+    }
+
+    void undo() override {
+        value_ = oldValue_;
+    }
+
+    juce::String getDescription() const override {
+        return "Set value";
+    }
+
+    bool canMergeWith(const magda::UndoableCommand* other) const override {
+        const auto* otherValue = dynamic_cast<const MergeableValueCommand*>(other);
+        return otherValue != nullptr && &otherValue->value_ == &value_;
+    }
+
+    void mergeWith(const magda::UndoableCommand* other) override {
+        const auto* otherValue = dynamic_cast<const MergeableValueCommand*>(other);
+        REQUIRE(otherValue != nullptr);
+        newValue_ = otherValue->newValue_;
+    }
+
+  private:
+    int& value_;
+    int oldValue_;
+    int newValue_;
+};
+
+class TempProject {
+  public:
+    TempProject()
+        : directory_(juce::File::getSpecialLocation(juce::File::tempDirectory)
+                         .getNonexistentChildFile("magda_dirty_tracking", {})),
+          file_(directory_.getChildFile("DirtyTracking.mgd")) {
+        const auto result = directory_.createDirectory();
+        INFO("Temporary project directory: " << directory_.getFullPathName());
+        INFO("Directory creation error: " << result.getErrorMessage());
+        REQUIRE(result.wasOk());
+    }
+
+    ~TempProject() {
+        directory_.deleteRecursively();
+    }
+
+    const juce::File& file() const {
+        return file_;
+    }
+
+  private:
+    juce::File directory_;
+    juce::File file_;
+};
+
+// Tests establish a known-clean checkpoint through the same save path used by
+// the application. This also hands the shared singleton back clean so later
+// project-boundary tests cannot raise a modal unsaved-changes prompt.
+juce::File saveToCleanState(const juce::File& file) {
     auto& projectManager = magda::ProjectManager::getInstance();
-    auto file = juce::File::getSpecialLocation(juce::File::tempDirectory)
-                    .getChildFile("magda_dirty_tracking")
-                    .getChildFile("DirtyTracking.mgd");
     REQUIRE(projectManager.saveProjectAs(file));
     REQUIRE_FALSE(projectManager.isDirty());
     return projectManager.getCurrentProjectFile();
@@ -38,8 +92,9 @@ juce::File saveToCleanState() {
 TEST_CASE("Undoable commands mark the project dirty", "[project][undo]") {
     auto& projectManager = magda::ProjectManager::getInstance();
     auto& undoManager = magda::UndoManager::getInstance();
+    TempProject tempProject;
 
-    saveToCleanState();
+    saveToCleanState(tempProject.file());
     undoManager.clearHistory();
 
     SECTION("executing a command") {
@@ -47,20 +102,59 @@ TEST_CASE("Undoable commands mark the project dirty", "[project][undo]") {
         CHECK(projectManager.isDirty());
     }
 
-    SECTION("undoing moves state away from the saved file too") {
+    SECTION("undoing back to the saved checkpoint restores clean state") {
         undoManager.executeCommand(std::make_unique<NoOpCommand>());
-        saveToCleanState();
+        REQUIRE(projectManager.isDirty());
+
+        REQUIRE(undoManager.undo());
+        CHECK_FALSE(projectManager.isDirty());
+    }
+
+    SECTION("undoing away from the saved checkpoint marks dirty") {
+        undoManager.executeCommand(std::make_unique<NoOpCommand>());
+        saveToCleanState(tempProject.file());
 
         REQUIRE(undoManager.undo());
         CHECK(projectManager.isDirty());
     }
 
-    SECTION("redoing does as well") {
+    SECTION("redoing back to the saved checkpoint restores clean state") {
         undoManager.executeCommand(std::make_unique<NoOpCommand>());
+        saveToCleanState(tempProject.file());
         REQUIRE(undoManager.undo());
-        saveToCleanState();
+        REQUIRE(projectManager.isDirty());
 
         REQUIRE(undoManager.redo());
+        CHECK_FALSE(projectManager.isDirty());
+    }
+
+    SECTION("branching from before the saved checkpoint remains dirty") {
+        undoManager.executeCommand(std::make_unique<NoOpCommand>());
+        saveToCleanState(tempProject.file());
+        REQUIRE(undoManager.undo());
+
+        undoManager.executeCommand(std::make_unique<NoOpCommand>());
+        CHECK(projectManager.isDirty());
+    }
+
+    SECTION("command merging does not make the saved checkpoint unreachable") {
+        int value = 0;
+        undoManager.executeCommand(std::make_unique<MergeableValueCommand>(value, 1));
+        saveToCleanState(tempProject.file());
+
+        undoManager.executeCommand(std::make_unique<MergeableValueCommand>(value, 2));
+        REQUIRE(value == 2);
+        REQUIRE(undoManager.undo());
+
+        CHECK(value == 1);
+        CHECK_FALSE(projectManager.isDirty());
+    }
+
+    SECTION("external changes remain dirty when undo returns to the saved checkpoint") {
+        projectManager.markDirty();
+        undoManager.executeCommand(std::make_unique<NoOpCommand>());
+
+        REQUIRE(undoManager.undo());
         CHECK(projectManager.isDirty());
     }
 
@@ -71,23 +165,23 @@ TEST_CASE("Undoable commands mark the project dirty", "[project][undo]") {
         undoManager.endCompoundOperation();
     }
 
-    saveToCleanState();
+    saveToCleanState(tempProject.file());
     undoManager.clearHistory();
 }
 
-TEST_CASE("Opening a project drops the previous project's undo history",
-          "[project][undo]") {
+TEST_CASE("Opening a project drops the previous project's undo history", "[project][undo]") {
     auto& projectManager = magda::ProjectManager::getInstance();
     auto& undoManager = magda::UndoManager::getInstance();
+    TempProject tempProject;
 
-    auto file = saveToCleanState();
+    auto file = saveToCleanState(tempProject.file());
     undoManager.clearHistory();
 
     // Save after the edit so the load below starts from a clean project and
     // does not raise the unsaved-changes prompt — the history must survive the
     // save and be dropped only by the project boundary.
     undoManager.executeCommand(std::make_unique<NoOpCommand>());
-    saveToCleanState();
+    saveToCleanState(tempProject.file());
     REQUIRE(undoManager.canUndo());
 
     REQUIRE(projectManager.loadProject(file));
@@ -96,6 +190,6 @@ TEST_CASE("Opening a project drops the previous project's undo history",
     CHECK_FALSE(undoManager.canRedo());
     CHECK_FALSE(projectManager.isDirty());
 
-    saveToCleanState();
+    saveToCleanState(tempProject.file());
     undoManager.clearHistory();
 }


### PR DESCRIPTION
Independent of #1914 / #1916 — branches off `main`, touches no File menu code. Found while testing that PR's New/Open shortcuts: they fired correctly, but opening a project silently discarded unsaved work.

## New/Open/Close never prompted to save

All three check `isDirty_` and raise the unsaved-changes prompt, so the guard was already in place everywhere. It just never fired, because the flag was set from only a handful of places — tempo/time-signature/loop changes, marker edits, the project settings dialog and two external-file paths.

Adding tracks, adding or moving clips, recording, editing notes and every other edit left it `false`. The prompt never appeared and the work was discarded without warning.

Every one of those edits runs through `UndoManager::executeCommand()`, so that single choke point now marks the project dirty — covering all 479 call sites rather than chasing them individually. `undo()` and `redo()` mark it too: both move state away from what is on disk.

## Two problems that only surface once the prompt fires

- **The undo history outlived the project.** Its commands reference track and clip ids from the old project, so undoing after a New/Open/Close applied them to unrelated state. Every project boundary now clears it, including both async commit paths (`loadProjectAsync` and `importDawProjectAsync`, which commit separately from the sync `loadProject`).
- **A cancelled prompt reported itself as an error.** `loadProjectAsync` passed `"Cancelled by user"` and `openProjectFile` showed any error in an alert, so declining to discard your work popped a spurious warning. It now passes an empty error — the convention the sync callers and the DAWproject import path already use — and `openProjectFile` stays silent for it.

## Testing

`tests/test_project_dirty_tracking.cpp` covers execute/undo/redo marking dirty, a command inside a compound operation, and the undo history being dropped at a project boundary.

The risk worth flagging for review: ten test files execute undo commands and several call `loadProject`/`newProject`, so a wrongly-dirty singleton could raise the modal prompt and hang CI. The new tests hand the singleton back clean via a temp-file save, and the full suite passes in both random and declaration order — 1549 passed, 13 skipped, 0 failures, no hang. Debug app builds clean.
