### PR TITLE
Declare full metadata on both default Faust sources

### DIFF
--- a/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
+++ b/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
@@ -41,6 +41,10 @@ bool isReservedVoiceControl(const juce::String& cleanLabel) {
 constexpr const char* kDefaultDspSource = R"FAUST(
 import("stdfaust.lib");
 declare name "Faust Poly Synth";
+declare description "Detuned saw pair through a resonant lowpass. Replace this with your own DSP.";
+declare author "MAGDA";
+declare license "GPL-3.0";
+declare version "1.0";
 
 freq = hslider("freq", 440, 20, 20000, 0.01);
 gain = hslider("gain", 0.5, 0, 1, 0.01);

--- a/magda/daw/audio/plugins/FaustPlugin.cpp
+++ b/magda/daw/audio/plugins/FaustPlugin.cpp
@@ -24,6 +24,10 @@ namespace {
 // before bundled libraries are wired into the search path.
 constexpr const char* kDefaultDspSource = R"FAUST(
 declare name "Passthrough";
+declare description "Stereo passthrough. Replace this with your own DSP.";
+declare author "MAGDA";
+declare license "GPL-3.0";
+declare version "1.0";
 process = _, _;
 )FAUST";
 


### PR DESCRIPTION
readPatchInfo reads name, author, version, license and description out of a .dsp, and every bundled runtime patch carries the block, but the two built-in default sources declared only a name. A fresh Faust effect or instrument therefore showed no credit strip until the user loaded something else, which read as the strip being broken rather than as the patch being undocumented.

Closes the last open criterion on #1823.