### PR TITLE
Distinguish Faust radio from menu, and honour [tooltip:...]

### DIFF
--- a/magda/daw/audio/plugins/FaustMetadataParser.cpp
+++ b/magda/daw/audio/plugins/FaustMetadataParser.cpp
@@ -11,7 +11,8 @@ namespace {
 // label or keep it intact for forward-compatibility.
 bool isKnownKey(const juce::String& key) {
     return key == "idx" || key == "unit" || key == "scale" || key == "style" || key == "role" ||
-           key == "hidden" || key == "gate" || key == "scaleAnchor" || key == "scaleanchor";
+           key == "hidden" || key == "gate" || key == "scaleAnchor" || key == "scaleanchor" ||
+           key == "tooltip";
 }
 
 // `[style:menu{'A':0;'B':1}]` payloads — the value passed to
@@ -102,12 +103,23 @@ bool applyFaustAnnotation(const juce::String& key, const juce::String& value,
         const auto parts = splitStyleValue(value);
         const auto kind = parts.kind.toLowerCase();
         if (kind == "menu" || kind == "radio") {
-            metadata.isMenuStyle = true;
+            metadata.choiceStyle =
+                (kind == "radio") ? FaustChoiceStyle::Radio : FaustChoiceStyle::Menu;
             metadata.menuChoices = parseMenuChoices(parts.braceBody);
         }
         // Other style values (knob / led / numerical) are recognised
         // and stripped from the clean label, but don't surface a flag —
         // they're purely visual hints we don't act on.
+        return true;
+    }
+    if (key == "tooltip") {
+        // Faust's own convention for documenting a control. Kept verbatim
+        // apart from trimming and surrounding quotes, which authors add out
+        // of habit from the `declare` form where they are required.
+        auto v = value.trim();
+        if (v.length() >= 2 && v.startsWithChar('"') && v.endsWithChar('"'))
+            v = v.substring(1, v.length() - 1);
+        metadata.tooltip = v;
         return true;
     }
     if (key == "role") {
@@ -230,10 +242,12 @@ void mergeFaustMetadata(ControlMetadata& parent, const ControlMetadata& child) {
         parent.unit = child.unit;
     if (child.logScale)
         parent.logScale = true;
-    if (child.isMenuStyle) {
-        parent.isMenuStyle = true;
+    if (child.isChoiceStyle()) {
+        parent.choiceStyle = child.choiceStyle;
         parent.menuChoices = child.menuChoices;
     }
+    if (child.tooltip.isNotEmpty())
+        parent.tooltip = child.tooltip;
     // Role/hidden follow the same "non-default child wins" rule as the
     // other tags: a control-level annotation overrides a group-level
     // default. We can't distinguish "child explicitly said User" from

--- a/magda/daw/audio/plugins/FaustMetadataParser.hpp
+++ b/magda/daw/audio/plugins/FaustMetadataParser.hpp
@@ -29,6 +29,25 @@ enum class FaustControlRole {
 };
 
 /**
+ * @brief How a choice control asked to be presented.
+ *
+ * Faust distinguishes `[style:menu{…}]` from `[style:radio{…}]`. Both
+ * describe the same underlying discrete parameter, so they share
+ * `menuChoices` and both map to `FaustParamSlot::Kind::Discrete`; only
+ * the presentation differs. The UI layer decides whether it can honour
+ * Radio (a long choice list is better served by a dropdown regardless of
+ * what the author asked for).
+ */
+enum class FaustChoiceStyle {
+    /// Not a choice control.
+    None,
+    /// `[style:menu{…}]` — dropdown.
+    Menu,
+    /// `[style:radio{…}]` — mutually exclusive buttons, all visible.
+    Radio,
+};
+
+/**
  * @brief Parsed output of a Faust label like
  *        "Cutoff [unit:Hz] [scale:log] [idx:7]".
  *
@@ -56,10 +75,20 @@ struct ControlMetadata {
     /// was a menu or radio.
     std::vector<std::pair<float, juce::String>> menuChoices;
 
-    /// Whether the menu/radio style was set (distinguishes "no menu
-    /// declared" from "empty menu" — defensive; Faust shouldn't emit
-    /// the latter).
-    bool isMenuStyle = false;
+    /// Which choice style was declared, if any. None also distinguishes
+    /// "no choice style declared" from "declared but empty choice list"
+    /// (defensive; Faust shouldn't emit the latter).
+    FaustChoiceStyle choiceStyle = FaustChoiceStyle::None;
+
+    /// True iff a menu or radio style was declared, whatever the flavour.
+    bool isChoiceStyle() const {
+        return choiceStyle != FaustChoiceStyle::None;
+    }
+
+    /// Free-text help from `[tooltip:…]`, Faust's own convention for
+    /// documenting a control. Empty if absent. Purely presentational:
+    /// it never affects the kind, range, or automation of a parameter.
+    juce::String tooltip;
 
     /// MAGDA role tag from `[role:<value>]`. Defaults to User.
     FaustControlRole role = FaustControlRole::User;

--- a/magda/daw/audio/plugins/FaustParamInfo.cpp
+++ b/magda/daw/audio/plugins/FaustParamInfo.cpp
@@ -68,6 +68,10 @@ magda::ParameterInfo discreteInfo(const FaustParamSlot& slot) {
     info.unit = slot.unit;
     info.scale = magda::ParameterScale::Discrete;
     info.modulatable = false;  // matches ParameterPresets::discrete
+    // `[style:radio{…}]` asks for visible buttons, `[style:menu{…}]` for a
+    // dropdown. Both are the same parameter; only the widget differs, and the
+    // UI is free to ignore the request when the list is too long for a cell.
+    info.radioChoices = (slot.choiceStyle == FaustChoiceStyle::Radio);
 
     // Sort choices by underlying value, then expose just the labels in
     // that order. ParameterInfo::Discrete indexes choices by
@@ -121,6 +125,7 @@ magda::ParameterInfo paramInfoFromSlot(const FaustParamSlot& slot) {
     if (!slot.active || slot.hidden) {
         info = placeholderForInactive(slot);
         info.group = slot.group;
+        info.tooltip = slot.tooltip;
         return info;
     }
     switch (slot.kind) {
@@ -138,6 +143,7 @@ magda::ParameterInfo paramInfoFromSlot(const FaustParamSlot& slot) {
             break;
     }
     info.group = slot.group;
+    info.tooltip = slot.tooltip;
     return info;
 }
 

--- a/magda/daw/audio/plugins/FaustParamPool.cpp
+++ b/magda/daw/audio/plugins/FaustParamPool.cpp
@@ -25,13 +25,18 @@ void fillSlot(FaustParamSlot& slot, int index, const HarvestedControl& h) {
     // Style menu/radio overrides the kind even if the harvester
     // reported Continuous — Faust users do `hslider("Mode
     // [style:menu{…}]", …)` and expect a dropdown.
-    slot.kind = h.metadata.isMenuStyle ? FaustParamSlot::Kind::Discrete : h.kind;
+    slot.kind = h.metadata.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : h.kind;
     slot.minValue = h.minValue;
     slot.maxValue = h.maxValue;
     slot.stepValue = h.stepValue;
     slot.defaultValue = h.defaultValue;
     slot.logScale = h.metadata.logScale;
     slot.choices = h.metadata.menuChoices;
+    // Set unconditionally: resetSlot deliberately keeps descriptive fields
+    // across a deactivate/reactivate cycle, so anything left conditional here
+    // would carry over from whatever DSP previously owned this slot.
+    slot.choiceStyle = h.metadata.choiceStyle;
+    slot.tooltip = h.metadata.tooltip;
     slot.zone = h.zone;
     slot.role = h.metadata.role;
     slot.hidden = h.metadata.hidden;

--- a/magda/daw/audio/plugins/FaustParamSlot.hpp
+++ b/magda/daw/audio/plugins/FaustParamSlot.hpp
@@ -63,6 +63,14 @@ struct FaustParamSlot {
     // `[style:radio{…}]`. Empty for non-discrete slots.
     std::vector<std::pair<float, juce::String>> choices;
 
+    // Which presentation the author asked for. Menu and Radio are the same
+    // parameter either way; only the widget differs. None for non-discrete
+    // slots. UI-only: the audio path never reads it.
+    FaustChoiceStyle choiceStyle = FaustChoiceStyle::None;
+
+    // Free text from `[tooltip:…]`, shown on hover. UI-only.
+    juce::String tooltip;
+
     // Pointer into the live DSP's zone. Only valid while the matching
     // FaustState is alive. The audio thread must NOT read this directly
     // off a slot — see the class comment.

--- a/magda/daw/audio/plugins/FaustPlugin.cpp
+++ b/magda/daw/audio/plugins/FaustPlugin.cpp
@@ -253,7 +253,7 @@ std::shared_ptr<FaustPlugin::FaustState> FaustPlugin::compileAndRebind(const juc
         const auto& h = harvested[i];
         DBG("  [" << static_cast<int>(i) << "] kind=" << (int)h.kind << " label='" << h.label
                   << "' min=" << h.minValue << " max=" << h.maxValue
-                  << " idx=" << h.metadata.slotIndex << " menu=" << (int)h.metadata.isMenuStyle);
+                  << " idx=" << h.metadata.slotIndex << " choice=" << (int)h.metadata.choiceStyle);
     }
 
     auto report = pool_.rebindFromHarvest(harvested);

--- a/magda/daw/audio/plugins/compiled/MagdaBitcrusherCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaBitcrusherCompiledPlugin.cpp
@@ -82,7 +82,7 @@ class CrusherHarvester : public ::UI {
 
         CrusherHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         harvest.controls.push_back(std::move(c));
     }

--- a/magda/daw/audio/plugins/compiled/MagdaChorusCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaChorusCompiledPlugin.cpp
@@ -86,7 +86,7 @@ class ChorusHarvester : public ::UI {
 
         ChorusHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         c.choices = merged.menuChoices;
         c.gateSlotIndex = merged.gateSlotIndex;

--- a/magda/daw/audio/plugins/compiled/MagdaClipperCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaClipperCompiledPlugin.cpp
@@ -82,7 +82,7 @@ class ClipperHarvester : public ::UI {
 
         ClipperHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         harvest.controls.push_back(std::move(c));
     }

--- a/magda/daw/audio/plugins/compiled/MagdaCompressorCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaCompressorCompiledPlugin.cpp
@@ -92,7 +92,7 @@ class EngineHarvester : public ::UI {
 
         EngineHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         harvest.controls.push_back(std::move(c));
     }

--- a/magda/daw/audio/plugins/compiled/MagdaDelayCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaDelayCompiledPlugin.cpp
@@ -92,7 +92,7 @@ class DelayHarvester : public ::UI {
 
         DelayHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         c.choices = merged.menuChoices;
         c.gateSlotIndex = merged.gateSlotIndex;

--- a/magda/daw/audio/plugins/compiled/MagdaDimensionCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaDimensionCompiledPlugin.cpp
@@ -88,7 +88,7 @@ class EngineHarvester : public ::UI {
 
         EngineHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         harvest.controls.push_back(std::move(c));
     }

--- a/magda/daw/audio/plugins/compiled/MagdaFilterCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaFilterCompiledPlugin.cpp
@@ -107,7 +107,7 @@ class EngineHarvester : public ::UI {
 
         EngineHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         c.choices = merged.menuChoices;
         harvest.controls.push_back(std::move(c));

--- a/magda/daw/audio/plugins/compiled/MagdaFlangerCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaFlangerCompiledPlugin.cpp
@@ -86,7 +86,7 @@ class FlangerHarvester : public ::UI {
 
         FlangerHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         c.choices = merged.menuChoices;
         c.gateSlotIndex = merged.gateSlotIndex;

--- a/magda/daw/audio/plugins/compiled/MagdaFreqShiftCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaFreqShiftCompiledPlugin.cpp
@@ -82,7 +82,7 @@ class FreqShiftHarvester : public ::UI {
 
         FreqShiftHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         harvest.controls.push_back(std::move(c));
     }

--- a/magda/daw/audio/plugins/compiled/MagdaGateExpanderCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaGateExpanderCompiledPlugin.cpp
@@ -80,8 +80,9 @@ class GateHarvester : public ::UI {
             }
         }
 
-        harvest.controls.push_back(
-            {merged.slotIndex, merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind, zone});
+        harvest.controls.push_back({merged.slotIndex,
+                                    merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind,
+                                    zone});
     }
 
     std::map<FAUSTFLOAT*, ControlMetadata> pendingByZone_;

--- a/magda/daw/audio/plugins/compiled/MagdaGrainDelayCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaGrainDelayCompiledPlugin.cpp
@@ -85,7 +85,7 @@ class GrainDelayHarvester : public ::UI {
 
         GrainDelayHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         c.choices = merged.menuChoices;
         c.gateSlotIndex = merged.gateSlotIndex;

--- a/magda/daw/audio/plugins/compiled/MagdaGritCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaGritCompiledPlugin.cpp
@@ -86,7 +86,7 @@ class GritHarvester : public ::UI {
 
         GritHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         c.choices = merged.menuChoices;
         harvest.controls.push_back(std::move(c));

--- a/magda/daw/audio/plugins/compiled/MagdaModCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaModCompiledPlugin.cpp
@@ -86,7 +86,7 @@ class ModHarvester : public ::UI {
 
         ModHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         c.choices = merged.menuChoices;
         c.gateSlotIndex = merged.gateSlotIndex;

--- a/magda/daw/audio/plugins/compiled/MagdaPhaserCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaPhaserCompiledPlugin.cpp
@@ -82,7 +82,7 @@ class PhaserHarvester : public ::UI {
 
         PhaserHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         harvest.controls.push_back(std::move(c));
     }

--- a/magda/daw/audio/plugins/compiled/MagdaPitchCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaPitchCompiledPlugin.cpp
@@ -84,7 +84,7 @@ class EngineHarvester : public ::UI {
 
         EngineHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         harvest.controls.push_back(std::move(c));
     }

--- a/magda/daw/audio/plugins/compiled/MagdaReverbCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaReverbCompiledPlugin.cpp
@@ -94,7 +94,7 @@ class EngineHarvester : public ::UI {
 
         EngineHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         harvest.controls.push_back(std::move(c));
     }

--- a/magda/daw/audio/plugins/compiled/MagdaRingModCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaRingModCompiledPlugin.cpp
@@ -86,7 +86,7 @@ class RingModHarvester : public ::UI {
 
         RingModHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         c.choices = merged.menuChoices;
         c.gateSlotIndex = merged.gateSlotIndex;

--- a/magda/daw/audio/plugins/compiled/MagdaSaturatorCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaSaturatorCompiledPlugin.cpp
@@ -85,7 +85,7 @@ class SaturatorHarvester : public ::UI {
 
         SaturatorHarvest::Control c;
         c.idx = merged.slotIndex;
-        c.kind = merged.isMenuStyle ? FaustParamSlot::Kind::Discrete : kind;
+        c.kind = merged.isChoiceStyle() ? FaustParamSlot::Kind::Discrete : kind;
         c.zone = zone;
         c.choices = merged.menuChoices;
         harvest.controls.push_back(std::move(c));

--- a/magda/daw/core/ParameterInfo.hpp
+++ b/magda/daw/core/ParameterInfo.hpp
@@ -71,6 +71,9 @@ struct ParameterInfo {
     // Optional UI-only page/group name. Runtime Faust devices populate this
     // from the outermost author vgroup/hgroup/tgroup.
     juce::String group;
+    // Optional UI-only hover help. Runtime Faust devices populate this from
+    // `[tooltip:…]`. Never affects value handling.
+    juce::String tooltip;
 
     // Value range — ALL stored in REAL parameter units (Hz, dB, %, …).
     // Consumers never see normalized values here; the normalized↔real
@@ -110,6 +113,13 @@ struct ParameterInfo {
 
     // Discrete values (if scale == Discrete)
     std::vector<juce::String> choices;  // e.g., {"Off", "Low", "High"}
+
+    // Request from the parameter's author that `choices` be shown as a row of
+    // mutually exclusive buttons rather than a dropdown, so a small choice set
+    // is readable without opening a popup. Advisory only: the UI falls back to
+    // a dropdown when the list is too long to fit a cell. Set by Faust
+    // `[style:radio{…}]`; `[style:menu{…}]` leaves it false.
+    bool radioChoices = false;
 
     // Curated tick labels for the automation lane axis. When non-empty (and
     // scale==Discrete), the lane uses these (realValue, label) pairs for tick

--- a/magda/daw/ui/components/chain/params/ParamSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/params/ParamSlotComponent.cpp
@@ -1,5 +1,7 @@
 #include "params/ParamSlotComponent.hpp"
 
+#include <cmath>
+
 #include "core/LinkModeManager.hpp"
 #include "core/ParameterUtils.hpp"
 #include "params/ParamLinkMenu.hpp"
@@ -174,6 +176,12 @@ ParamSlotComponent::~ParamSlotComponent() {
 
     if (momentaryButton_)
         momentaryButton_->release();
+
+    // Detach the shared LookAndFeel before the buttons die.
+    for (auto& button : choiceButtons_) {
+        if (button)
+            button->setLookAndFeel(nullptr);
+    }
 
     if (amountLabel_.isOnDesktop()) {
         amountLabel_.removeFromDesktop();
@@ -446,6 +454,32 @@ void ParamSlotComponent::setParamValue(double value) {
     // lane readout against the curve. setValueWithInterval(..., 0.0, ...)
     // writes the exact value and still triggers the label refresh.
     valueSlider_.setValueWithInterval(value, 0.0, juce::dontSendNotification);
+
+    // A discrete widget owns its own selection, and neither value-only refresh
+    // path re-runs setParameterInfo: ParamHostComponent::updateParameterValues
+    // and the single-param echo in DeviceParameterChangeHandler both land here.
+    // Without this, an automation or macro move on a choice param leaves the
+    // dropdown (or the segmented row, which cannot self-toggle because
+    // selection is driven explicitly) showing a stale choice until the whole
+    // parameter list is rebuilt.
+    syncDiscreteSelection(value);
+}
+
+void ParamSlotComponent::syncDiscreteSelection(double value) {
+    const int count = static_cast<int>(paramInfo_.choices.size());
+    if (count <= 0)
+        return;
+
+    // Discrete params carry the choice index as their value.
+    const int selected = juce::jlimit(0, count - 1, static_cast<int>(std::lround(value)));
+
+    if (discreteCombo_ && discreteCombo_->isVisible())
+        discreteCombo_->setSelectedItemIndex(selected, juce::dontSendNotification);
+
+    for (int i = 0; i < static_cast<int>(choiceButtons_.size()); ++i) {
+        if (auto& button = choiceButtons_[static_cast<size_t>(i)])
+            button->setToggleState(i == selected, juce::dontSendNotification);
+    }
 }
 
 void ParamSlotComponent::refreshAutomationTarget() {
@@ -507,6 +541,7 @@ void ParamSlotComponent::setParameterInfo(const magda::ParameterInfo& info) {
 
     // Hide all widgets first
     valueSlider_.setVisible(false);
+    hideChoiceButtons();
     if (discreteCombo_)
         discreteCombo_->setVisible(false);
     if (boolToggle_)
@@ -545,18 +580,73 @@ void ParamSlotComponent::setParameterInfo(const magda::ParameterInfo& info) {
             boolToggle_->setVisible(true);
         }
     } else if (info.scale == magda::ParameterScale::Discrete && !info.choices.empty()) {
-        if (!discreteCombo_) {
-            discreteCombo_ = std::make_unique<juce::ComboBox>();
-            addAndMakeVisible(*discreteCombo_);
+        if (wantsSegmentedChoices(info)) {
+            rebuildChoiceButtons(info, deferToSlot);
+        } else {
+            if (!discreteCombo_) {
+                discreteCombo_ = std::make_unique<juce::ComboBox>();
+                addAndMakeVisible(*discreteCombo_);
+            }
+            configureDiscreteCombo(*discreteCombo_, info, deferToSlot);
+            discreteCombo_->setVisible(true);
         }
-        configureDiscreteCombo(*discreteCombo_, info, deferToSlot);
-        discreteCombo_->setVisible(true);
     } else {
         valueSlider_.setVisible(true);
         configureSliderFormatting(valueSlider_, info);
     }
 
+    applyTooltip(info.tooltip);
     resized();
+}
+
+void ParamSlotComponent::rebuildChoiceButtons(const magda::ParameterInfo& info,
+                                              const std::function<void(double)>& onValueChanged) {
+    const int count = static_cast<int>(info.choices.size());
+    if (static_cast<int>(choiceButtons_.size()) != count) {
+        choiceButtons_.clear();
+        for (int i = 0; i < count; ++i) {
+            auto button = std::make_unique<juce::TextButton>();
+            addAndMakeVisible(*button);
+            choiceButtons_.push_back(std::move(button));
+        }
+    }
+
+    // Discrete params carry the choice index as their value, matching what the
+    // dropdown reports through configureDiscreteCombo.
+    const int selected =
+        juce::jlimit(0, count - 1, static_cast<int>(std::lround(info.currentValue)));
+    for (int i = 0; i < count; ++i) {
+        auto& button = *choiceButtons_[static_cast<size_t>(i)];
+        configureChoiceButton(button, info.choices[static_cast<size_t>(i)], i, count,
+                              i == selected);
+        button.onClick = [cb = onValueChanged, i]() {
+            if (cb)
+                cb(static_cast<double>(i));
+        };
+        button.setVisible(true);
+    }
+}
+
+void ParamSlotComponent::hideChoiceButtons() {
+    for (auto& button : choiceButtons_) {
+        if (button)
+            button->setVisible(false);
+    }
+}
+
+void ParamSlotComponent::applyTooltip(const juce::String& tooltip) {
+    setTooltip(tooltip);
+    valueSlider_.setTooltip(tooltip);
+    if (discreteCombo_)
+        discreteCombo_->setTooltip(tooltip);
+    if (boolToggle_)
+        boolToggle_->setTooltip(tooltip);
+    if (momentaryButton_)
+        momentaryButton_->setTooltip(tooltip);
+    for (auto& button : choiceButtons_) {
+        if (button)
+            button->setTooltip(tooltip);
+    }
 }
 
 void ParamSlotComponent::setFonts(const juce::Font& labelFont, const juce::Font& valueFont) {
@@ -586,6 +676,13 @@ void ParamSlotComponent::lookAndFeelChanged() {
 
     if (discreteCombo_) {
         discreteCombo_->setColour(juce::ComboBox::textColourId, primaryText);
+    }
+
+    // Re-theme without touching toggle state, so a palette switch can't clear
+    // which segment is selected.
+    for (auto& button : choiceButtons_) {
+        if (button)
+            applyChoiceButtonColours(*button);
     }
 
     repaint();
@@ -698,6 +795,7 @@ void ParamSlotComponent::resized() {
         nameLabel_.setVisible(false);
         valueSlider_.setVisible(false);
         valueSlider_.setBounds(bounds);
+        hideChoiceButtons();
         if (discreteCombo_)
             discreteCombo_->setVisible(false);
         if (boolToggle_)
@@ -712,7 +810,18 @@ void ParamSlotComponent::resized() {
     int labelHeight = juce::jmin(12, getHeight() / 3);
     nameLabel_.setBounds(bounds.removeFromTop(labelHeight));
 
-    if (discreteCombo_ && discreteCombo_->isVisible()) {
+    if (!choiceButtons_.empty() && choiceButtons_.front()->isVisible()) {
+        auto row = bounds.reduced(2);
+        const int count = static_cast<int>(choiceButtons_.size());
+        // Derive each edge from the row width rather than accumulating a
+        // per-segment width, so rounding cannot leave a gap at the right edge.
+        for (int i = 0; i < count; ++i) {
+            const int left = row.getX() + (row.getWidth() * i) / count;
+            const int right = row.getX() + (row.getWidth() * (i + 1)) / count;
+            choiceButtons_[static_cast<size_t>(i)]->setBounds(left, row.getY(), right - left,
+                                                              row.getHeight());
+        }
+    } else if (discreteCombo_ && discreteCombo_->isVisible()) {
         discreteCombo_->setBounds(bounds.reduced(2));
     } else if (boolToggle_ && boolToggle_->isVisible()) {
         // Centre checkbox in the cell — needs enough space for JUCE tick rendering

--- a/magda/daw/ui/components/chain/params/ParamSlotComponent.hpp
+++ b/magda/daw/ui/components/chain/params/ParamSlotComponent.hpp
@@ -26,6 +26,7 @@ namespace magda::daw::ui {
  * Supports link mode: when a mod/macro is in link mode, clicking this param creates a link.
  */
 class ParamSlotComponent : public juce::Component,
+                           public juce::SettableTooltipClient,
                            public juce::DragAndDropTarget,
                            public magda::LinkModeManagerListener,
                            public magda::MidiLearnCoordinatorListener,
@@ -192,6 +193,20 @@ class ParamSlotComponent : public juce::Component,
     // Build a ParamLinkContext from current state
     ParamLinkContext buildLinkContext() const;
 
+    // Create/refresh the segmented row for a discrete param. Reuses the
+    // existing buttons when the choice count is unchanged so a value echo
+    // doesn't churn child components on every refresh.
+    void rebuildChoiceButtons(const magda::ParameterInfo& info,
+                              const std::function<void(double)>& onValueChanged);
+    void hideChoiceButtons();
+    // Point whichever discrete widget is live at the choice `value` selects.
+    // Called from setParamValue so automation echoes move the widget, not just
+    // the underlying slider.
+    void syncDiscreteSelection(double value);
+    // Push a param's help text onto every widget that can own the mouse, since
+    // JUCE resolves tooltips from the component under the pointer only.
+    void applyTooltip(const juce::String& tooltip);
+
     // LinkModeManagerListener implementation
     void modLinkModeChanged(bool active, const magda::ModSelection& selection) override;
     void macroLinkModeChanged(bool active, const magda::MacroSelection& selection) override;
@@ -241,6 +256,9 @@ class ParamSlotComponent : public juce::Component,
     std::unique_ptr<juce::ComboBox> discreteCombo_;   // For discrete/choice parameters
     std::unique_ptr<juce::ToggleButton> boolToggle_;  // For boolean parameters
     std::unique_ptr<MomentaryParamButton> momentaryButton_;
+    // For discrete params whose author asked for visible buttons — one segment
+    // per choice. Empty when the cell renders a dropdown instead.
+    std::vector<std::unique_ptr<juce::TextButton>> choiceButtons_;
     magda::ParameterInfo paramInfo_;  // Parameter metadata for formatting
 
     // Shift+drag state for mod amount editing

--- a/magda/daw/ui/components/chain/params/ParamWidgetSetup.cpp
+++ b/magda/daw/ui/components/chain/params/ParamWidgetSetup.cpp
@@ -142,4 +142,31 @@ void configureDiscreteCombo(juce::ComboBox& combo, const magda::ParameterInfo& i
                                juce::dontSendNotification);
 }
 
+bool wantsSegmentedChoices(const magda::ParameterInfo& info) {
+    return info.radioChoices && !info.choices.empty() &&
+           static_cast<int>(info.choices.size()) <= kMaxSegmentedChoices;
+}
+
+void applyChoiceButtonColours(juce::TextButton& button) {
+    button.setColour(juce::TextButton::buttonColourId,
+                     DarkTheme::getColour(DarkTheme::BACKGROUND).brighter(0.10f));
+    button.setColour(juce::TextButton::buttonOnColourId,
+                     DarkTheme::getColour(DarkTheme::ACCENT_PRIMARY));
+    button.setColour(juce::TextButton::textColourOffId, DarkTheme::getSecondaryTextColour());
+    button.setColour(juce::TextButton::textColourOnId, juce::Colours::white);
+}
+
+void configureChoiceButton(juce::TextButton& button, const juce::String& text, int index, int count,
+                           bool selected) {
+    button.setButtonText(text);
+    button.setLookAndFeel(&FlatTabButtonLookAndFeel::getInstance());
+    // Selection is driven explicitly below, not by click-toggle or a radio
+    // group: JUCE's radio handling leaves the previous segment lit as well.
+    button.setClickingTogglesState(false);
+    button.setConnectedEdges((index > 0 ? juce::Button::ConnectedOnLeft : 0) |
+                             (index < count - 1 ? juce::Button::ConnectedOnRight : 0));
+    applyChoiceButtonColours(button);
+    button.setToggleState(selected, juce::dontSendNotification);
+}
+
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/params/ParamWidgetSetup.hpp
+++ b/magda/daw/ui/components/chain/params/ParamWidgetSetup.hpp
@@ -38,4 +38,39 @@ void configureMomentaryButton(MomentaryParamButton& button,
 void configureDiscreteCombo(juce::ComboBox& combo, const magda::ParameterInfo& info,
                             std::function<void(double)> onValueChanged);
 
+/**
+ * @brief Most choices that still get the visible-buttons treatment.
+ *
+ * Past this a row of segments in a grid cell is narrower than its own labels,
+ * so a dropdown reads better even when the author asked for buttons.
+ */
+constexpr int kMaxSegmentedChoices = 4;
+
+/**
+ * @brief True iff @p info should render as a segmented button row.
+ *
+ * Requires the author to have asked (`radioChoices`) and the choice list to be
+ * short enough to stay legible. Everything else falls back to the dropdown.
+ */
+bool wantsSegmentedChoices(const magda::ParameterInfo& info);
+
+/**
+ * @brief Apply theme colours to one segment of a choice row.
+ *
+ * Split out from configureChoiceButton so lookAndFeelChanged() can re-theme a
+ * row without knowing which segment is selected.
+ */
+void applyChoiceButtonColours(juce::TextButton& button);
+
+/**
+ * @brief Configure one segment of a discrete parameter's button row.
+ *
+ * @p index / @p count drive the connected edges so the row reads as a single
+ * control. Selection is set explicitly rather than via a JUCE radio group,
+ * which leaves two segments lit at once. The caller owns the button and wires
+ * its onClick.
+ */
+void configureChoiceButton(juce::TextButton& button, const juce::String& text, int index, int count,
+                           bool selected);
+
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/components/common/TextSlider.hpp
+++ b/magda/daw/ui/components/common/TextSlider.hpp
@@ -24,7 +24,13 @@ namespace magda::daw::ui {
  * Shift+double-click and Shift+right-click are retained as legacy edit gestures.
  * Supports dB and pan formatting.
  */
-class TextSlider : public juce::Component, public magda::AutomationManagerListener {
+// SettableTooltipClient so a parameter's own help text can be shown on hover.
+// JUCE's TooltipWindow only queries the component directly under the mouse and
+// does not walk up to parents, so the slider has to be a client in its own
+// right rather than relying on the cell that owns it.
+class TextSlider : public juce::Component,
+                   public juce::SettableTooltipClient,
+                   public magda::AutomationManagerListener {
   public:
     enum class Format { Decimal, Decibels, Pan };
     enum class Orientation { Horizontal, Vertical };

--- a/tests/test_faust_metadata_parser.cpp
+++ b/tests/test_faust_metadata_parser.cpp
@@ -29,8 +29,10 @@ TEST_CASE("parseFaustLabel - strips known annotations", "[faust][metadata]") {
 }
 
 TEST_CASE("parseFaustLabel - keeps unknown annotations intact", "[faust][metadata]") {
-    auto p = parseFaustLabel("Cutoff [tooltip:nice] [unit:Hz]");
-    REQUIRE(p.cleanLabel == "Cutoff [tooltip:nice]");
+    // `colour` is deliberately not a key MAGDA claims, so it must survive in
+    // the visible label rather than being silently swallowed.
+    auto p = parseFaustLabel("Cutoff [colour:red] [unit:Hz]");
+    REQUIRE(p.cleanLabel == "Cutoff [colour:red]");
     REQUIRE(p.metadata.unit == "Hz");
 }
 
@@ -91,7 +93,7 @@ TEST_CASE("parseFaustLabel - scale exp does not set log", "[faust][metadata]") {
 TEST_CASE("parseFaustLabel - style menu populates choices", "[faust][metadata]") {
     auto p = parseFaustLabel("Mode [style:menu{'Off':0;'Low':1;'High':2}]");
     REQUIRE(p.cleanLabel == "Mode");
-    REQUIRE(p.metadata.isMenuStyle);
+    REQUIRE(p.metadata.choiceStyle == FaustChoiceStyle::Menu);
     REQUIRE(p.metadata.menuChoices.size() == 3);
     REQUIRE(p.metadata.menuChoices[0].first == 0.0f);
     REQUIRE(p.metadata.menuChoices[0].second == "Off");
@@ -103,15 +105,45 @@ TEST_CASE("parseFaustLabel - style menu populates choices", "[faust][metadata]")
 
 TEST_CASE("parseFaustLabel - style radio populates choices", "[faust][metadata]") {
     auto p = parseFaustLabel("Voice [style:radio{'Mono':0;'Poly':1}]");
-    REQUIRE(p.metadata.isMenuStyle);
+    REQUIRE(p.metadata.choiceStyle == FaustChoiceStyle::Radio);
     REQUIRE(p.metadata.menuChoices.size() == 2);
     REQUIRE(p.metadata.menuChoices[1].second == "Poly");
+}
+
+TEST_CASE("parseFaustLabel - radio and menu stay distinguishable", "[faust][metadata]") {
+    // The whole point of the discriminator: both are choice controls with the
+    // same payload, and only the requested presentation differs.
+    auto menu = parseFaustLabel("Mode [style:menu{'A':0;'B':1}]");
+    auto radio = parseFaustLabel("Mode [style:radio{'A':0;'B':1}]");
+    REQUIRE(menu.metadata.menuChoices == radio.metadata.menuChoices);
+    REQUIRE(menu.metadata.choiceStyle != radio.metadata.choiceStyle);
 }
 
 TEST_CASE("parseFaustLabel - style knob recognised but no menu", "[faust][metadata]") {
     auto p = parseFaustLabel("Cutoff [style:knob]");
     REQUIRE(p.cleanLabel == "Cutoff");
-    REQUIRE_FALSE(p.metadata.isMenuStyle);
+    REQUIRE_FALSE(p.metadata.isChoiceStyle());
+}
+
+// ============================================================================
+// parseFaustLabel — tooltip
+// ============================================================================
+
+TEST_CASE("parseFaustLabel - tooltip is captured and stripped", "[faust][metadata]") {
+    auto p = parseFaustLabel("Cutoff [idx:0] [tooltip:Filter corner frequency]");
+    REQUIRE(p.cleanLabel == "Cutoff");
+    REQUIRE(p.metadata.tooltip == "Filter corner frequency");
+    REQUIRE(p.metadata.slotIndex == 0);
+}
+
+TEST_CASE("parseFaustLabel - tooltip drops surrounding quotes", "[faust][metadata]") {
+    auto p = parseFaustLabel("Drive [tooltip:\"How hard the stage clips\"]");
+    REQUIRE(p.metadata.tooltip == "How hard the stage clips");
+}
+
+TEST_CASE("parseFaustLabel - absent tooltip stays empty", "[faust][metadata]") {
+    auto p = parseFaustLabel("Cutoff [unit:Hz]");
+    REQUIRE(p.metadata.tooltip.isEmpty());
 }
 
 TEST_CASE("parseFaustLabel - menu accepts double quotes too", "[faust][metadata]") {
@@ -128,7 +160,7 @@ TEST_CASE("parseFaustLabel - menu skips malformed entries", "[faust][metadata]")
 
 TEST_CASE("parseFaustLabel - empty menu body yields empty choices", "[faust][metadata]") {
     auto p = parseFaustLabel("Mode [style:menu{}]");
-    REQUIRE(p.metadata.isMenuStyle);
+    REQUIRE(p.metadata.isChoiceStyle());
     REQUIRE(p.metadata.menuChoices.empty());
 }
 
@@ -138,7 +170,7 @@ TEST_CASE("parseFaustLabel - empty menu body yields empty choices", "[faust][met
 
 TEST_CASE("applyFaustAnnotation - rejects unknown key", "[faust][metadata]") {
     ControlMetadata m;
-    REQUIRE_FALSE(applyFaustAnnotation("tooltip", "hi", m));
+    REQUIRE_FALSE(applyFaustAnnotation("colour", "red", m));
     REQUIRE(m.unit.isEmpty());
 }
 
@@ -191,16 +223,48 @@ TEST_CASE("mergeFaustMetadata - control idx overrides group idx", "[faust][metad
 
 TEST_CASE("mergeFaustMetadata - control menu replaces group menu", "[faust][metadata]") {
     ControlMetadata group;
-    group.isMenuStyle = true;
+    group.choiceStyle = FaustChoiceStyle::Menu;
     group.menuChoices = {{0.0f, "GroupA"}, {1.0f, "GroupB"}};
 
     ControlMetadata control;
-    control.isMenuStyle = true;
+    control.choiceStyle = FaustChoiceStyle::Menu;
     control.menuChoices = {{0.0f, "CtrlA"}};
 
     mergeFaustMetadata(group, control);
     REQUIRE(group.menuChoices.size() == 1);
     REQUIRE(group.menuChoices[0].second == "CtrlA");
+}
+
+TEST_CASE("mergeFaustMetadata - control choice style wins over group", "[faust][metadata]") {
+    ControlMetadata group;
+    group.choiceStyle = FaustChoiceStyle::Menu;
+    group.menuChoices = {{0.0f, "GroupA"}};
+
+    ControlMetadata control;
+    control.choiceStyle = FaustChoiceStyle::Radio;
+    control.menuChoices = {{0.0f, "CtrlA"}};
+
+    mergeFaustMetadata(group, control);
+    REQUIRE(group.choiceStyle == FaustChoiceStyle::Radio);
+}
+
+TEST_CASE("mergeFaustMetadata - control tooltip overrides group", "[faust][metadata]") {
+    ControlMetadata group;
+    group.tooltip = "group help";
+
+    ControlMetadata control;
+    control.tooltip = "control help";
+
+    mergeFaustMetadata(group, control);
+    REQUIRE(group.tooltip == "control help");
+}
+
+TEST_CASE("mergeFaustMetadata - group tooltip survives a silent control", "[faust][metadata]") {
+    ControlMetadata group;
+    group.tooltip = "group help";
+
+    mergeFaustMetadata(group, ControlMetadata{});
+    REQUIRE(group.tooltip == "group help");
 }
 
 // ============================================================================

--- a/tests/test_faust_param_info.cpp
+++ b/tests/test_faust_param_info.cpp
@@ -117,6 +117,37 @@ TEST_CASE("paramInfoFromSlot - author group propagates", "[faust][paraminfo]") {
     REQUIRE(info.group == "Filter");
 }
 
+TEST_CASE("paramInfoFromSlot - tooltip propagates", "[faust][paraminfo]") {
+    auto slot = makeContinuousSlot(3, "Cutoff");
+    slot.tooltip = "Filter corner frequency";
+    REQUIRE(paramInfoFromSlot(slot).tooltip == "Filter corner frequency");
+}
+
+TEST_CASE("paramInfoFromSlot - tooltip survives the hidden-slot path", "[faust][paraminfo]") {
+    // Hidden slots go through placeholderForInactive, which builds a fresh
+    // ParameterInfo and so has to copy the UI-only fields separately.
+    auto slot = makeContinuousSlot(3, "Tempo");
+    slot.hidden = true;
+    slot.tooltip = "Project tempo in BPM";
+    REQUIRE(paramInfoFromSlot(slot).tooltip == "Project tempo in BPM");
+}
+
+TEST_CASE("paramInfoFromSlot - radio style requests segmented choices", "[faust][paraminfo]") {
+    auto slot = makeDiscreteSlot(0, "Voice", {{0.0f, "Mono"}, {1.0f, "Poly"}});
+    slot.choiceStyle = FaustChoiceStyle::Radio;
+    REQUIRE(paramInfoFromSlot(slot).radioChoices);
+}
+
+TEST_CASE("paramInfoFromSlot - menu style stays a dropdown", "[faust][paraminfo]") {
+    auto slot = makeDiscreteSlot(0, "Mode", {{0.0f, "Off"}, {1.0f, "On"}});
+    slot.choiceStyle = FaustChoiceStyle::Menu;
+    auto info = paramInfoFromSlot(slot);
+    REQUIRE_FALSE(info.radioChoices);
+    // Both styles are still the same discrete parameter underneath.
+    REQUIRE(info.scale == ParameterScale::Discrete);
+    REQUIRE(info.choices.size() == 2);
+}
+
 // ============================================================================
 // Boolean
 // ============================================================================

--- a/tests/test_faust_param_pool.cpp
+++ b/tests/test_faust_param_pool.cpp
@@ -198,7 +198,7 @@ TEST_CASE("FaustParamPool - trigger kind preserved", "[faust][pool]") {
 TEST_CASE("FaustParamPool - menu metadata promotes Continuous to Discrete", "[faust][pool]") {
     FaustParamPool pool;
     auto h = makeContinuous("Mode", 0.0f, 2.0f);
-    h.metadata.isMenuStyle = true;
+    h.metadata.choiceStyle = FaustChoiceStyle::Menu;
     h.metadata.menuChoices = {{0.0f, "Off"}, {1.0f, "Low"}, {2.0f, "High"}};
 
     pool.rebindFromHarvest({h});
@@ -260,7 +260,7 @@ TEST_CASE("FaustParamPool - clearActive deactivates everything", "[faust][pool]"
 TEST_CASE("FaustParamPool - discrete descriptor carries sorted real values", "[faust][pool]") {
     FaustParamPool pool;
     auto h = makeContinuous("Mode", 0.0f, 2.0f);
-    h.metadata.isMenuStyle = true;
+    h.metadata.choiceStyle = FaustChoiceStyle::Menu;
     h.metadata.menuChoices = {{2.0f, "High"}, {0.0f, "Off"}, {1.0f, "Low"}};
 
     auto report = pool.rebindFromHarvest({h});

--- a/tests/test_faust_ui_harvester.cpp
+++ b/tests/test_faust_ui_harvester.cpp
@@ -86,7 +86,7 @@ TEST_CASE("FaustUIHarvester maps active widgets to shared control kinds", "[faus
     REQUIRE(harvester.controls()[0].kind == FaustParamSlot::Kind::Trigger);
     REQUIRE(harvester.controls()[1].kind == FaustParamSlot::Kind::Boolean);
     REQUIRE(harvester.controls()[2].kind == FaustParamSlot::Kind::Continuous);
-    REQUIRE(harvester.controls()[2].metadata.isMenuStyle);
+    REQUIRE(harvester.controls()[2].metadata.isChoiceStyle());
 
     FaustParamPool pool;
     pool.rebindFromHarvest(harvester.controls());


### PR DESCRIPTION
Two annotations that shared the same fate on the way to the UI.

`[style:radio{...}]` and `[style:menu{...}]` both collapsed onto a single isMenuStyle bool, so a DSP author could not ask for a visible, mutually exclusive choice control: everything became a dropdown. ControlMetadata now carries a FaustChoiceStyle discriminator, which reaches the UI as ParameterInfo::radioChoices, and a radio param renders as a segmented button row. The request is advisory: past four choices a row of segments is narrower than its own labels, so the cell falls back to the dropdown.

`[tooltip:...]` is Faust's own convention for documenting a control, and MAGDA did not recognise the key at all. Since unknown keys are kept in the clean label for forward compatibility, a patch declaring one showed the bracket text in the control's name instead of any help. The key is now parsed and applied to the cell's widgets on hover.

Tooltips go on the widgets rather than just the cell because JUCE resolves them from the component directly under the pointer and does not walk up to parents, so TextSlider and ParamSlotComponent both became SettableTooltipClients.

Two parser tests used `tooltip` as their example of an unrecognised key. They now use `colour`, which MAGDA still does not claim.

Closes #1923, closes #1935.