### PR TITLE
Preview multi-clip left-edge resizes live during the drag

### DIFF
--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -66,6 +66,29 @@ double timelineEndSeconds(const ClipInfo& clip, double bpm) {
     return clip.getTimelineEnd(bpm);
 }
 
+// Left-resize moves the clip start, so the preview has to carry the derived
+// source-domain phase (offset/loopStart/midiOffset) across as well as the
+// placement. Used for the dragged clip and every other clip in the selection.
+void applyLeftResizePreview(ClipInfo& target, const ClipInfo& preview, double bpm) {
+    ClipOperations::setTimelinePlacement(target, timelineStartSeconds(preview, bpm),
+                                         timelineLengthSeconds(preview, bpm), bpm);
+    target.offset = preview.offset;
+    target.loopStart = preview.loopStart;
+    target.midiOffset = preview.midiOffset;
+}
+
+// Undo the fields applyLeftResizePreview touched (plus midiTrimOffset, which
+// resizeContainerFromLeft accumulates), so the resize commands capture the
+// pre-drag state for undo.
+void restoreLeftResizePreview(ClipInfo& target, const ClipInfo& snapshot, double startSeconds,
+                              double lengthSeconds, double bpm) {
+    ClipOperations::setTimelinePlacement(target, startSeconds, lengthSeconds, bpm);
+    target.offset = snapshot.offset;
+    target.loopStart = snapshot.loopStart;
+    target.midiOffset = snapshot.midiOffset;
+    target.midiTrimOffset = snapshot.midiTrimOffset;
+}
+
 void showMidiClipLibrarySaveFailedAlert() {
     juce::AlertWindow::showMessageBoxAsync(
         juce::AlertWindow::WarningIcon, "Save MIDI Clip Failed",
@@ -1244,6 +1267,26 @@ bool ClipComponent::hitTest(int x, int y) {
 // Mouse Handling
 // ============================================================================
 
+void ClipComponent::captureMultiResizeSnapshots() {
+    dragStartSelectedLengths_.clear();
+    dragStartSelectedClipSnapshots_.clear();
+
+    const auto& selected = SelectionManager::getInstance().getSelectedClips();
+    if (selected.size() <= 1 || selected.count(clipId_) == 0)
+        return;
+
+    auto& cm = ClipManager::getInstance();
+    const double tempo = parentPanel_ ? parentPanel_->getTempo() : DEFAULT_BPM;
+    for (auto cid : selected) {
+        if (cid == clipId_)
+            continue;
+        if (const auto* c = cm.getClip(cid)) {
+            dragStartSelectedLengths_[cid] = timelineLengthSeconds(*c, tempo);
+            dragStartSelectedClipSnapshots_[cid] = *c;
+        }
+    }
+}
+
 void ClipComponent::mouseDown(const juce::MouseEvent& e) {
     const auto* clip = getClipInfo();
     if (!clip) {
@@ -1631,6 +1674,9 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
             dragMode_ = DragMode::ResizeLeft;
             dragStartClipSnapshot_ = *clip;
             resizePreviewClip_ = *clip;
+            // Capture original state of other selected clips so the drag can
+            // preview them resizing together (the commit path already does)
+            captureMultiResizeSnapshots();
         }
     } else if (isOnRightEdge(e.x)) {
         if (e.mods.isShiftDown() &&
@@ -1642,8 +1688,7 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
             dragMode_ = DragMode::ResizeRight;
             dragStartClipSnapshot_ = *clip;
             // Capture original lengths of other selected clips for multi-resize
-            dragStartSelectedLengths_.clear();
-            dragStartSelectedClipSnapshots_.clear();
+            captureMultiResizeSnapshots();
             multiResizeMaxDelta_ = std::numeric_limits<double>::max();
             const auto& selected = SelectionManager::getInstance().getSelectedClips();
             if (selected.size() > 1 && selected.count(clipId_)) {
@@ -1653,10 +1698,6 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
                     const auto* c = cm.getClip(cid);
                     if (!c)
                         continue;
-                    if (cid != clipId_) {
-                        dragStartSelectedLengths_[cid] = timelineLengthSeconds(*c, tempo);
-                        dragStartSelectedClipSnapshots_[cid] = *c;
-                    }
 
                     // Find max resize before hitting next non-selected clip
                     auto trackClips = cm.getClipsOnTrack(c->trackId);
@@ -1913,13 +1954,33 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
             if (resizeThrottle_.check()) {
                 auto& cm = magda::ClipManager::getInstance();
                 if (auto* mutableClip = cm.getClip(clipId_)) {
-                    ClipOperations::setTimelinePlacement(
-                        *mutableClip, timelineStartSeconds(resizePreviewClip_, tempoBPM),
-                        timelineLengthSeconds(resizePreviewClip_, tempoBPM), tempoBPM);
-                    mutableClip->offset = resizePreviewClip_.offset;
-                    mutableClip->loopStart = resizePreviewClip_.loopStart;
-                    mutableClip->midiOffset = resizePreviewClip_.midiOffset;
-                    cm.forceNotifyClipPropertyChanged(clipId_);
+                    applyLeftResizePreview(*mutableClip, resizePreviewClip_, tempoBPM);
+
+                    std::vector<magda::ClipId> changedClips;
+                    changedClips.push_back(clipId_);
+
+                    // Also preview the other selected clips with the same delta,
+                    // each recomputed from its own pre-drag snapshot
+                    const double lengthDelta = finalLength - dragStartLength_;
+                    for (auto& [cid, origLen] : dragStartSelectedLengths_) {
+                        auto snapshotIt = dragStartSelectedClipSnapshots_.find(cid);
+                        if (snapshotIt == dragStartSelectedClipSnapshots_.end())
+                            continue;
+                        auto* otherClip = cm.getClip(cid);
+                        if (!otherClip)
+                            continue;
+
+                        ClipInfo otherPreview = snapshotIt->second;
+                        ClipOperations::resizeContainerFromLeft(
+                            otherPreview, juce::jmax(0.1, origLen + lengthDelta), tempoBPM);
+                        if (!otherPreview.loopEnabled && otherPreview.isAudio())
+                            otherPreview.loopStart = otherPreview.offset;
+
+                        applyLeftResizePreview(*otherClip, otherPreview, tempoBPM);
+                        changedClips.push_back(cid);
+                    }
+
+                    cm.forceNotifyMultipleClipPropertiesChanged(changedClips);
                 }
             }
 
@@ -2383,18 +2444,28 @@ void ClipComponent::mouseUp(const juce::MouseEvent& e) {
                 {
                     auto& cm = ClipManager::getInstance();
                     if (auto* c = cm.getClip(clipId_)) {
-                        ClipOperations::setTimelinePlacement(*c, dragStartTime_, dragStartLength_,
-                                                             commitTempoBPM);
-                        c->offset = dragStartClipSnapshot_.offset;
-                        c->loopStart = dragStartClipSnapshot_.loopStart;
-                        c->midiOffset = dragStartClipSnapshot_.midiOffset;
-                        c->midiTrimOffset = dragStartClipSnapshot_.midiTrimOffset;
+                        restoreLeftResizePreview(*c, dragStartClipSnapshot_, dragStartTime_,
+                                                 dragStartLength_, commitTempoBPM);
+                    }
+                    // Same for the other selected clips previewed during the drag
+                    for (auto& [cid, origLen] : dragStartSelectedLengths_) {
+                        auto snapshotIt = dragStartSelectedClipSnapshots_.find(cid);
+                        if (snapshotIt == dragStartSelectedClipSnapshots_.end())
+                            continue;
+                        if (auto* c = cm.getClip(cid)) {
+                            restoreLeftResizePreview(
+                                *c, snapshotIt->second,
+                                timelineStartSeconds(snapshotIt->second, commitTempoBPM), origLen,
+                                commitTempoBPM);
+                        }
                     }
                 }
 
                 if (onClipResized) {
                     onClipResized(clipId_, finalLength, true);
                 }
+                dragStartSelectedLengths_.clear();
+                dragStartSelectedClipSnapshots_.clear();
                 break;
             }
 

--- a/magda/daw/ui/components/clips/ClipComponent.hpp
+++ b/magda/daw/ui/components/clips/ClipComponent.hpp
@@ -265,6 +265,10 @@ class ClipComponent : public juce::Component,
     // Helper to get current clip info
     const ClipInfo* getClipInfo() const;
 
+    // Capture pre-drag length + full state of the other selected clips so a
+    // multi-clip resize can preview them live and restore them before commit.
+    void captureMultiResizeSnapshots();
+
     // Context menu
     void showContextMenu();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -310,6 +310,7 @@ target_sources(magda_juce_tests PRIVATE
     test_midi_bridge_note_events_juce.cpp
     test_section_scoped_device_ids_juce.cpp
     test_clip_inspector_juce.cpp
+    test_multi_clip_resize_preview_juce.cpp
     test_multiband_curve_view_juce.cpp
     test_timeline_extreme_zoom_paint_juce.cpp
     test_arrange_beat_native_juce.cpp
@@ -332,6 +333,21 @@ target_sources(magda_juce_tests PRIVATE
     ../magda/daw/ui/panels/content/inspector/clip/sections/ChordProgressionSection.cpp
     ../magda/daw/ui/panels/content/inspector/clip/sections/ClipFadesSection.cpp
     ../magda/daw/ui/panels/content/inspector/clip/sections/ClipTakesSection.cpp
+    ../magda/daw/ui/components/clips/ClipComponent.cpp
+    ../magda/daw/ui/components/tracks/TrackContentPanel.cpp
+    ../magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
+    ../magda/daw/ui/components/automation/AutomationLaneComponent.cpp
+    ../magda/daw/ui/components/automation/AutomationCurveEditor.cpp
+    ../magda/daw/ui/components/common/curve/CurveEditorBase.cpp
+    ../magda/daw/ui/components/common/curve/CurvePointComponent.cpp
+    ../magda/daw/ui/components/common/curve/CurveBezierHandle.cpp
+    ../magda/daw/ui/components/common/curve/CurveTensionHandle.cpp
+    ../magda/daw/ui/components/automation/AutomationClipComponent.cpp
+    ../magda/daw/ui/components/waveform/ClipWaveformPainter.cpp
+    ../magda/daw/ui/components/common/Toast.cpp
+    ../magda/daw/ui/dialogs/AISettingsDialog.cpp
+    ../magda/daw/ui/interaction/ArrangementCursorMap.cpp
+    ../magda/daw/ui/panels/state/PanelController.cpp
     ../magda/daw/ui/components/common/BarsBeatsTicksLabel.cpp
     ../magda/daw/ui/components/common/ValueLabelControl.cpp
     ../magda/daw/ui/components/common/DraggableValueLabel.cpp
@@ -351,6 +367,9 @@ target_sources(magda_juce_tests PRIVATE
 target_link_libraries(magda_juce_tests
     PRIVATE
     magda_daw
+    # ClipComponent's context menu reaches the AI settings dialog, which lives
+    # on the agents library.
+    magda_agents
     # JUCE (core/events/gui_basics) comes transitively from magda_daw, compiled
     # once there; direct links would recompile the JUCE stack into this target.
     # Linux: juce_gui_extra is pulled in transitively via magda_daw's

--- a/tests/test_clip_resize_operations.cpp
+++ b/tests/test_clip_resize_operations.cpp
@@ -942,3 +942,154 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - auto-tempo offset uses BPM 
         REQUIRE(clip.offset == Catch::Approx(1.0));
     }
 }
+
+// ============================================================================
+// Multi-clip left resize preview (#1950)
+// ============================================================================
+
+TEST_CASE("Multi-clip left-resize preview recomputes every clip from its snapshot",
+          "[clip][resize][left][multi][regression]") {
+    /**
+     * REGRESSION TEST (#1950)
+     *
+     * Dragging the left handle of a multi-clip selection previewed only the
+     * dragged clip; the rest jumped into place on mouse release. The drag now
+     * applies the same length delta to every selected clip on each throttled
+     * tick.
+     *
+     * The invariant that makes that safe: each tick recomputes from the
+     * clip's PRE-DRAG snapshot, never from its current (already previewed)
+     * state. Applying the delta to live state accumulates drift, and for MIDI
+     * it accumulates midiTrimOffset once per tick.
+     *
+     * This mirrors the loop in ClipComponent::mouseDrag / DragMode::ResizeLeft.
+     */
+
+    const double bpm = 120.0;
+
+    // One throttled drag tick: rebuild the preview from the snapshot.
+    auto previewTick = [bpm](const ClipInfo& snapshot, double originalLength, double lengthDelta) {
+        ClipInfo preview = snapshot;
+        ClipOperations::resizeContainerFromLeft(preview,
+                                                juce::jmax(0.1, originalLength + lengthDelta), bpm);
+        if (!preview.loopEnabled && preview.isAudio())
+            preview.loopStart = preview.offset;
+        return preview;
+    };
+
+    SECTION("Every selected clip shifts by the same delta, whatever its own start") {
+        ClipInfo dragged;
+        dragged.setAudioContent();
+        dragged.audio().source.filePath = "a.wav";
+        ClipOperations::setTimelinePlacement(dragged, 0.0, 4.0, bpm);
+        dragged.offset = 2.0;
+
+        ClipInfo other;
+        other.setAudioContent();
+        other.audio().source.filePath = "b.wav";
+        ClipOperations::setTimelinePlacement(other, 10.0, 6.0, bpm);
+        other.offset = 3.0;
+
+        // Drag the left handle right by 1 second: both clips shrink by 1
+        const double lengthDelta = -1.0;
+
+        ClipInfo draggedPreview = previewTick(dragged, 4.0, lengthDelta);
+        ClipInfo otherPreview = previewTick(other, 6.0, lengthDelta);
+
+        REQUIRE(draggedPreview.getTimelineStart(bpm) == Catch::Approx(1.0));
+        REQUIRE(draggedPreview.getTimelineLength(bpm) == Catch::Approx(3.0));
+        REQUIRE(otherPreview.getTimelineStart(bpm) == Catch::Approx(11.0));
+        REQUIRE(otherPreview.getTimelineLength(bpm) == Catch::Approx(5.0));
+
+        // Ends stay pinned — left resize only moves the start
+        REQUIRE(draggedPreview.getTimelineEnd(bpm) == Catch::Approx(4.0));
+        REQUIRE(otherPreview.getTimelineEnd(bpm) == Catch::Approx(16.0));
+
+        // Each clip trims its own audio from its own offset
+        REQUIRE(draggedPreview.offset == Catch::Approx(3.0));
+        REQUIRE(otherPreview.offset == Catch::Approx(4.0));
+        REQUIRE(draggedPreview.loopStart == Catch::Approx(draggedPreview.offset));
+        REQUIRE(otherPreview.loopStart == Catch::Approx(otherPreview.offset));
+    }
+
+    SECTION("Successive ticks do not drift - final tick equals a single-shot resize") {
+        ClipInfo snapshot;
+        snapshot.setAudioContent();
+        snapshot.audio().source.filePath = "b.wav";
+        ClipOperations::setTimelinePlacement(snapshot, 10.0, 6.0, bpm);
+        snapshot.offset = 3.0;
+
+        ClipInfo preview = snapshot;
+        for (double delta : {-0.25, -0.5, -0.75, -1.0})
+            preview = previewTick(snapshot, 6.0, delta);
+
+        ClipInfo singleShot = previewTick(snapshot, 6.0, -1.0);
+
+        REQUIRE(preview.getTimelineStart(bpm) == Catch::Approx(singleShot.getTimelineStart(bpm)));
+        REQUIRE(preview.getTimelineLength(bpm) == Catch::Approx(singleShot.getTimelineLength(bpm)));
+        REQUIRE(preview.offset == Catch::Approx(singleShot.offset));
+
+        // Dragging back to where it started restores the original state
+        ClipInfo backToStart = previewTick(snapshot, 6.0, 0.0);
+        REQUIRE(backToStart.getTimelineStart(bpm) == Catch::Approx(10.0));
+        REQUIRE(backToStart.getTimelineLength(bpm) == Catch::Approx(6.0));
+        REQUIRE(backToStart.offset == Catch::Approx(3.0));
+    }
+
+    SECTION("Non-looped MIDI accumulates midiTrimOffset once, not once per tick") {
+        ClipInfo snapshot;
+        snapshot.setMidiContent();
+        ClipOperations::setTimelinePlacement(snapshot, 0.0, 4.0, bpm);
+        snapshot.midiTrimOffset = 0.0;
+
+        ClipInfo preview = snapshot;
+        for (double delta : {-0.5, -1.0, -1.5, -2.0})
+            preview = previewTick(snapshot, 4.0, delta);
+
+        // 2 seconds at 120 BPM = 4 beats, counted once
+        REQUIRE(preview.getTimelineStart(bpm) == Catch::Approx(2.0));
+        REQUIRE(preview.getTimelineLength(bpm) == Catch::Approx(2.0));
+        REQUIRE(preview.midiTrimOffset == Catch::Approx(4.0));
+    }
+
+    SECTION("Preview matches what the commit path produces for each clip") {
+        // The commit path restores the pre-drag snapshot, then resizes to
+        // originalLength + lengthDelta. The preview must land in the same place.
+        ClipInfo snapshot;
+        snapshot.setAudioContent();
+        snapshot.audio().source.filePath = "c.wav";
+        ClipOperations::setTimelinePlacement(snapshot, 4.0, 5.0, bpm);
+        snapshot.offset = 1.0;
+        snapshot.speedRatio = 2.0;
+
+        const double lengthDelta = 1.5;  // expanding leftwards
+
+        ClipInfo preview = previewTick(snapshot, 5.0, lengthDelta);
+
+        ClipInfo committed = snapshot;  // restored before the resize command runs
+        ClipOperations::resizeContainerFromLeft(committed, 5.0 + lengthDelta, bpm);
+        if (!committed.loopEnabled && committed.isAudio())
+            committed.loopStart = committed.offset;
+
+        REQUIRE(preview.getTimelineStart(bpm) == Catch::Approx(committed.getTimelineStart(bpm)));
+        REQUIRE(preview.getTimelineLength(bpm) == Catch::Approx(committed.getTimelineLength(bpm)));
+        REQUIRE(preview.offset == Catch::Approx(committed.offset));
+        REQUIRE(preview.loopStart == Catch::Approx(committed.loopStart));
+    }
+
+    SECTION("A short clip in the selection clamps instead of inverting") {
+        ClipInfo shortClip;
+        shortClip.setAudioContent();
+        shortClip.audio().source.filePath = "d.wav";
+        ClipOperations::setTimelinePlacement(shortClip, 8.0, 0.5, bpm);
+        shortClip.offset = 0.0;
+
+        // Drag right far past the short clip's own length
+        ClipInfo preview = previewTick(shortClip, 0.5, -2.0);
+
+        REQUIRE(preview.getTimelineLength(bpm) >= 0.1);
+        REQUIRE(preview.getTimelineStart(bpm) < preview.getTimelineEnd(bpm));
+        // End still pinned where it was
+        REQUIRE(preview.getTimelineEnd(bpm) == Catch::Approx(8.5));
+    }
+}

--- a/tests/test_multi_clip_resize_preview_juce.cpp
+++ b/tests/test_multi_clip_resize_preview_juce.cpp
@@ -1,0 +1,265 @@
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <cmath>
+
+#include "JuceTestStateGuard.hpp"
+#include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/SelectionManager.hpp"
+#include "magda/daw/ui/components/clips/ClipComponent.hpp"
+#include "magda/daw/ui/components/tracks/TrackContentPanel.hpp"
+
+/**
+ * Multi-clip resize preview (#1950)
+ *
+ * Drives ClipComponent's real gesture path (mouseDown / mouseDrag / mouseUp)
+ * rather than re-simulating the drag arithmetic, because the bug was that the
+ * preview path and the commit path had drifted apart: the commit path resized
+ * the whole selection, the left-edge drag only resized the clip under the
+ * cursor.
+ *
+ * Both edges are covered so neither can regress independently, and the
+ * mouse-up case pins the rewind that lets the resize commands capture pre-drag
+ * state for undo.
+ */
+
+using namespace magda;
+
+namespace {
+
+constexpr double testTempoBPM = 120.0;
+constexpr double testZoomPixelsPerBeat = 40.0;
+constexpr TrackId testTrackId = 1;
+
+// Non-overlapping clips, deliberately different lengths and starts so a shared
+// delta cannot be confused with a shared absolute position.
+constexpr double clipAStartBeats = 0.0;
+constexpr double clipALengthBeats = 4.0;
+constexpr double clipBStartBeats = 8.0;
+constexpr double clipBLengthBeats = 6.0;
+
+double beatsToSeconds(double beats) {
+    return beats * 60.0 / testTempoBPM;
+}
+
+juce::MouseEvent makeMouseEvent(juce::Component& component, juce::Point<int> position,
+                                juce::Point<int> mouseDownPosition) {
+    return {juce::Desktop::getInstance().getMainMouseSource(),
+            position.toFloat(),
+            juce::ModifierKeys(),
+            1.0f,
+            0.0f,
+            0.0f,
+            0.0f,
+            0.0f,
+            &component,
+            &component,
+            juce::Time::getCurrentTime(),
+            mouseDownPosition.toFloat(),
+            juce::Time::getCurrentTime(),
+            1,
+            false};
+}
+
+struct ClipPlacement {
+    double startSeconds = 0.0;
+    double lengthSeconds = 0.0;
+
+    double endSeconds() const {
+        return startSeconds + lengthSeconds;
+    }
+};
+
+ClipPlacement placementOf(ClipId clipId) {
+    const auto* clip = ClipManager::getInstance().getClip(clipId);
+    if (!clip)
+        return {};
+    return {clip->getTimelineStart(testTempoBPM), clip->getTimelineLength(testTempoBPM)};
+}
+
+void expectNear(juce::UnitTest& test, double actual, double expected, const juce::String& label) {
+    constexpr double tolerance = 1.0e-6;
+    test.expect(std::abs(actual - expected) <= tolerance, label + " expected " +
+                                                              juce::String(expected, 6) + ", got " +
+                                                              juce::String(actual, 6));
+}
+
+// Panel plus two selected MIDI clips, with a ClipComponent for the clip that
+// will be dragged. MIDI keeps the gesture on the resize edges: fade and volume
+// handles are audio-only, so they cannot swallow the mouseDown.
+struct ResizeGestureFixture {
+    TrackContentPanel panel;
+    ClipId draggedClip = INVALID_CLIP_ID;
+    ClipId otherClip = INVALID_CLIP_ID;
+    std::unique_ptr<ClipComponent> draggedComponent;
+
+    ResizeGestureFixture() {
+        panel.setSize(2000, 400);
+        panel.setTempo(testTempoBPM);
+        panel.setZoom(testZoomPixelsPerBeat);
+
+        auto& clipManager = ClipManager::getInstance();
+        draggedClip = clipManager.createMidiClipBeats(testTrackId, clipAStartBeats,
+                                                      clipALengthBeats, ClipView::Arrangement);
+        otherClip = clipManager.createMidiClipBeats(testTrackId, clipBStartBeats, clipBLengthBeats,
+                                                    ClipView::Arrangement);
+
+        SelectionManager::getInstance().selectClips({draggedClip, otherClip});
+
+        // Origin-aligned so component-local x equals panel x, which keeps the
+        // drag delta in the events obvious.
+        draggedComponent = std::make_unique<ClipComponent>(draggedClip, &panel);
+        draggedComponent->setSelected(true);
+        panel.addAndMakeVisible(*draggedComponent);
+        draggedComponent->setBounds(
+            0, 0, static_cast<int>(std::round(clipALengthBeats * testZoomPixelsPerBeat)), 60);
+    }
+
+    ~ResizeGestureFixture() {
+        if (draggedComponent)
+            panel.removeChildComponent(draggedComponent.get());
+    }
+
+    // One drag gesture from an edge, in whole pixels. Stops before mouseUp so
+    // the assertions see the live preview state.
+    void dragEdgeBy(int grabX, int deltaPixels) {
+        const juce::Point<int> down{grabX, 4};
+        const juce::Point<int> moved{grabX + deltaPixels, 4};
+        draggedComponent->mouseDown(makeMouseEvent(*draggedComponent, down, down));
+        draggedComponent->mouseDrag(makeMouseEvent(*draggedComponent, moved, down));
+    }
+
+    void releaseAt(int grabX, int deltaPixels) {
+        const juce::Point<int> down{grabX, 4};
+        const juce::Point<int> moved{grabX + deltaPixels, 4};
+        draggedComponent->mouseUp(makeMouseEvent(*draggedComponent, moved, down));
+    }
+
+    int leftEdgeX() const {
+        return 1;
+    }
+
+    int rightEdgeX() const {
+        return draggedComponent->getWidth() - 1;
+    }
+};
+
+class MultiClipResizePreviewJuceTest final : public juce::UnitTest {
+  public:
+    MultiClipResizePreviewJuceTest() : juce::UnitTest("Multi Clip Resize Preview Tests", "magda") {}
+
+    void runTest() override {
+        testLeftEdgePreviewsWholeSelection();
+        testRightEdgePreviewsWholeSelection();
+        testMouseUpRewindsWholeSelection();
+        testSingleSelectionLeavesOthersAlone();
+    }
+
+  private:
+    void testLeftEdgePreviewsWholeSelection() {
+        beginTest("Left-edge drag previews every selected clip (#1950)");
+
+        magda::test::runWithCleanJuceState([this] {
+            ResizeGestureFixture f;
+
+            // Two beats to the right: both clips shrink from the start by 2 beats
+            const int deltaPixels = static_cast<int>(2.0 * testZoomPixelsPerBeat);
+            f.dragEdgeBy(f.leftEdgeX(), deltaPixels);
+
+            const auto dragged = placementOf(f.draggedClip);
+            const auto other = placementOf(f.otherClip);
+
+            expectNear(*this, dragged.startSeconds, beatsToSeconds(clipAStartBeats + 2.0),
+                       "dragged clip start");
+            expectNear(*this, dragged.lengthSeconds, beatsToSeconds(clipALengthBeats - 2.0),
+                       "dragged clip length");
+
+            expectNear(*this, other.startSeconds, beatsToSeconds(clipBStartBeats + 2.0),
+                       "other selected clip start (this is the bug: it used to stay put)");
+            expectNear(*this, other.lengthSeconds, beatsToSeconds(clipBLengthBeats - 2.0),
+                       "other selected clip length");
+
+            // Left resize is a start move: both ends stay where they were
+            expectNear(*this, dragged.endSeconds(),
+                       beatsToSeconds(clipAStartBeats + clipALengthBeats), "dragged clip end");
+            expectNear(*this, other.endSeconds(),
+                       beatsToSeconds(clipBStartBeats + clipBLengthBeats),
+                       "other selected clip end");
+        });
+    }
+
+    void testRightEdgePreviewsWholeSelection() {
+        beginTest("Right-edge drag still previews every selected clip");
+
+        magda::test::runWithCleanJuceState([this] {
+            ResizeGestureFixture f;
+
+            const int deltaPixels = static_cast<int>(-1.0 * testZoomPixelsPerBeat);
+            f.dragEdgeBy(f.rightEdgeX(), deltaPixels);
+
+            const auto dragged = placementOf(f.draggedClip);
+            const auto other = placementOf(f.otherClip);
+
+            expectNear(*this, dragged.startSeconds, beatsToSeconds(clipAStartBeats),
+                       "dragged clip start unchanged");
+            expectNear(*this, dragged.lengthSeconds, beatsToSeconds(clipALengthBeats - 1.0),
+                       "dragged clip length");
+
+            expectNear(*this, other.startSeconds, beatsToSeconds(clipBStartBeats),
+                       "other selected clip start unchanged");
+            expectNear(*this, other.lengthSeconds, beatsToSeconds(clipBLengthBeats - 1.0),
+                       "other selected clip length");
+        });
+    }
+
+    void testMouseUpRewindsWholeSelection() {
+        beginTest("Mouse-up rewinds every previewed clip to its pre-drag state");
+
+        magda::test::runWithCleanJuceState([this] {
+            ResizeGestureFixture f;
+
+            // No onClipResized callback is wired, so nothing commits: what is
+            // left behind is exactly the rewind the resize commands rely on.
+            const int deltaPixels = static_cast<int>(2.0 * testZoomPixelsPerBeat);
+            f.dragEdgeBy(f.leftEdgeX(), deltaPixels);
+            f.releaseAt(f.leftEdgeX(), deltaPixels);
+
+            const auto dragged = placementOf(f.draggedClip);
+            const auto other = placementOf(f.otherClip);
+
+            expectNear(*this, dragged.startSeconds, beatsToSeconds(clipAStartBeats),
+                       "dragged clip start restored");
+            expectNear(*this, dragged.lengthSeconds, beatsToSeconds(clipALengthBeats),
+                       "dragged clip length restored");
+            expectNear(*this, other.startSeconds, beatsToSeconds(clipBStartBeats),
+                       "other selected clip start restored");
+            expectNear(*this, other.lengthSeconds, beatsToSeconds(clipBLengthBeats),
+                       "other selected clip length restored");
+        });
+    }
+
+    void testSingleSelectionLeavesOthersAlone() {
+        beginTest("Left-edge drag on a single selection touches only that clip");
+
+        magda::test::runWithCleanJuceState([this] {
+            ResizeGestureFixture f;
+            SelectionManager::getInstance().selectClip(f.draggedClip);
+
+            const int deltaPixels = static_cast<int>(2.0 * testZoomPixelsPerBeat);
+            f.dragEdgeBy(f.leftEdgeX(), deltaPixels);
+
+            const auto dragged = placementOf(f.draggedClip);
+            const auto other = placementOf(f.otherClip);
+
+            expectNear(*this, dragged.startSeconds, beatsToSeconds(clipAStartBeats + 2.0),
+                       "dragged clip start");
+            expectNear(*this, other.startSeconds, beatsToSeconds(clipBStartBeats),
+                       "unselected clip start untouched");
+            expectNear(*this, other.lengthSeconds, beatsToSeconds(clipBLengthBeats),
+                       "unselected clip length untouched");
+        });
+    }
+};
+
+static MultiClipResizePreviewJuceTest multiClipResizePreviewJuceTestInstance;
+
+}  // namespace


### PR DESCRIPTION
Fixes #1950.

Dragging the left handle of a multi-clip selection moved only the dragged clip until mouse release, then the rest snapped into place. The right handle already previewed the whole selection.

## Cause

`ClipComponent::mouseDown` captured the other selected clips' pre-drag state only in the `ResizeRight` branch, and only that branch's drag tick applied the length delta to them. The commit path (`TrackContentPanel::onClipResized`) has always handled multi-selection for both edges, so the release looked correct while the drag did not.

## Change

- `captureMultiResizeSnapshots()` lifts the per-clip length and snapshot capture out of the `ResizeRight` branch; both edges call it. The right-edge collision clamp stays right-only.
- The `ResizeLeft` drag tick recomputes each other selected clip from its own pre-drag snapshot with the shared delta, via `resizeContainerFromLeft`, which is the same call the commit path makes in `ClipManager::resizeClipBeats`. Recomputing from the snapshot rather than from live state is what stops repeated ticks drifting and stops MIDI accumulating `midiTrimOffset` once per tick.
- Mouse-up rewinds those clips to pre-drag state before the resize commands run, so undo still captures the original state. The dragged clip and the others share `applyLeftResizePreview` / `restoreLeftResizePreview`.

Other clips update on the existing 50 ms resize throttle, same as the right edge. No new TE coupling: this reuses the existing notify path.

## Tests

`tests/test_multi_clip_resize_preview_juce.cpp` (new, in `magda_juce_tests`) drives the real gesture: a `TrackContentPanel`, two selected MIDI clips with different starts and lengths, and `mouseDown` / `mouseDrag` / `mouseUp` with synthesized events. Covers the left edge, the right edge, the mouse-up rewind, and the single-selection case. Verified it fails (2 assertions) with the left-edge capture reverted.

`tests/test_clip_resize_operations.cpp` gains five sections pinning the per-tick formula: shared delta across heterogeneous clips, no drift across successive ticks, `midiTrimOffset` counted once, preview matching the commit path, and min-length clamping.

`ClipComponent` and `TrackContentPanel` build into `magda_daw_app` rather than the `magda_daw` library, so `magda_juce_tests` picks up those sources and their transitive UI dependencies directly, the same way `ClipInspector`'s are already listed, plus a link against `magda_agents`.

Full runs locally: JUCE suite all passed; Catch2 1642 cases, 163264 assertions, 0 failures.
