### PR TITLE
Stop reserving a pagination row for single-page devices

### DIFF
--- a/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.cpp
@@ -1151,7 +1151,13 @@ void DeviceSlotComponent::paintContent(juce::Graphics& g, juce::Rectangle<int> c
                             .tracktionLogo = tracktionLogo_.get(),
                             .stepRecording = stepRecording},
                            stripsAnalysisChrome() ? 0 : METER_STRIP_WIDTH, CONTENT_HEADER_HEIGHT,
-                           PAGINATION_HEIGHT, faustHeaderHeight());
+                           paginationRowHeight(), faustHeaderHeight());
+}
+
+int DeviceSlotComponent::paginationRowHeight() const {
+    // 0 when the grid fits one page: it reserves no row then, so the painter
+    // has nothing to rule off.
+    return paramGrid_ != nullptr && paramGrid_->paginates() ? PAGINATION_HEIGHT : 0;
 }
 
 int DeviceSlotComponent::faustHeaderHeight() const {

--- a/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
+++ b/magda/daw/ui/components/chain/DeviceSlotComponent.hpp
@@ -260,6 +260,7 @@ class DeviceSlotComponent : public NodeComponent,
     // Height to carve for faustUI_: the bare header, plus its credit strip
     // when the loaded patch declares metadata.
     int faustHeaderHeight() const;
+    int paginationRowHeight() const;
 
     std::unique_ptr<FaustUI> faustUI_;
     std::unique_ptr<FaustCustomView> faustCustomView_;

--- a/magda/daw/ui/components/chain/params/ParamHostComponent.cpp
+++ b/magda/daw/ui/components/chain/params/ParamHostComponent.cpp
@@ -194,6 +194,7 @@ void ParamHostComponent::updateParamModulation(
 
 void ParamHostComponent::updatePageControls(const magda::DeviceInfo& device, int currentPage,
                                             int totalPages) {
+    const bool wasPaginating = paginates();
     currentPage_ = currentPage;
     totalPages_ = totalPages;
     if (layout_->wantsPageTabs())
@@ -203,6 +204,14 @@ void ParamHostComponent::updatePageControls(const magda::DeviceInfo& device, int
     prevPageButton_->setEnabled(currentPage_ > 0);
     nextPageButton_->setEnabled(currentPage_ < totalPages_ - 1);
     setPaginationVisible(true);
+
+    // Gaining or losing the row changes getChromeHeight(), which the parent
+    // divides the body by. Without this the grid would keep the old geometry
+    // until some unrelated resize.
+    if (paginates() != wasPaginating) {
+        if (auto* parent = getParentComponent())
+            parent->resized();
+    }
 }
 
 void ParamHostComponent::setGridVisible(bool visible) {
@@ -210,8 +219,12 @@ void ParamHostComponent::setGridVisible(bool visible) {
         paramSlots_[i]->setVisible(visible);
 }
 
+bool ParamHostComponent::paginates() const {
+    return layout_->wantsPagination() && totalPages_ > 1;
+}
+
 void ParamHostComponent::setPaginationVisible(bool visible) {
-    const bool effective = visible && layout_->wantsPagination() && totalPages_ > 1;
+    const bool effective = visible && paginates();
     const bool tabs = effective && layout_->wantsPageTabs();
     prevPageButton_->setVisible(effective && !tabs);
     nextPageButton_->setVisible(effective && !tabs);
@@ -256,7 +269,7 @@ void ParamHostComponent::setSlotSelected(int slotIndex, bool selected) {
 }
 
 int ParamHostComponent::getChromeHeight() const {
-    return 2 + (layout_->wantsPagination() ? PAGINATION_HEIGHT + 4 : 0);
+    return 2 + (paginates() ? PAGINATION_HEIGHT + 4 : 0);
 }
 
 void ParamHostComponent::setRowHeight(int rowHeight) {
@@ -273,12 +286,12 @@ void ParamHostComponent::layoutContent(const juce::Font& labelFont, const juce::
 
     area.removeFromTop(2);
     juce::Rectangle<int> paginationArea;
-    if (layout_->wantsPagination()) {
+    if (paginates()) {
         paginationArea = area.removeFromTop(PAGINATION_HEIGHT);
         area.removeFromTop(4);
     }
 
-    if (layout_->wantsPagination()) {
+    if (paginates()) {
         if (layout_->wantsPageTabs()) {
             pageTabBar_->setBounds(paginationArea);
         } else {

--- a/magda/daw/ui/components/chain/params/ParamHostComponent.hpp
+++ b/magda/daw/ui/components/chain/params/ParamHostComponent.hpp
@@ -66,6 +66,11 @@ class ParamHostComponent : public juce::Component {
         return totalPages_;
     }
 
+    /// Whether a pagination row is actually in play. The layout only says it
+    /// *wants* pagination; a device whose parameters fit one page has nothing
+    /// to put in that row, so the row is neither reserved nor drawn.
+    bool paginates() const;
+
     void setGridVisible(bool visible);
     void setPaginationVisible(bool visible);
 

--- a/magda/daw/ui/components/chain/slot/DeviceSlotContentPainter.cpp
+++ b/magda/daw/ui/components/chain/slot/DeviceSlotContentPainter.cpp
@@ -41,8 +41,11 @@ void paintSeparators(juce::Graphics& g, juce::Rectangle<int> contentArea,
         g.drawHorizontalLine(headerBottom, left, right);
     }
 
+    // Rule under the pagination row. `paginationHeight` is 0 when the grid has
+    // a single page: there is no row to separate, and drawing it anyway left a
+    // line with an empty band above it.
     const bool runtimeFaust = state.traits.isFaust || state.traits.isFaustInstrument;
-    if (!state.traits.compiledPresentation &&
+    if (paginationHeight > 0 && !state.traits.compiledPresentation &&
         (!state.internalDevice || runtimeFaust || !state.hasCustomUI)) {
         constexpr int paginationTopPadding = 2;
         constexpr int paginationBottomPadding = 4;


### PR DESCRIPTION
The layouts hardcode wantsPagination() to true, so every device reserved 2 + 18 + 4 px above its first row of parameter cells and the content painter ruled a line under that band. The page controls themselves are gated on totalPages > 1, so a device whose parameters fit one page showed an empty band with a stray line under it.

ParamHostComponent::paginates() now answers what the layout wants AND what the device actually needs, and drives getChromeHeight, layoutContent and the control visibility from that one place. The painter takes 0 for the row height in that case and skips the rule. Single-page devices get those 24px back as grid.

Re-layouts on the transition, since gaining or losing the row changes the chrome height the parent divides the body by.