### PR TITLE
Require patch name and description declares on generated Faust DSP

### DIFF
--- a/magda/agents/faust_agent.cpp
+++ b/magda/agents/faust_agent.cpp
@@ -24,6 +24,15 @@ OUTPUT SCHEMA:
   "source": "<a complete, valid Faust program>"
 }
 
+PATCH METADATA — REQUIRED:
+- The source MUST open with these two declares, before the import and before any
+  control, with values identical to the JSON "name" and "description" fields:
+      declare name "<the JSON name>";
+      declare description "<the JSON description>";
+- MAGDA reads these back off the saved .dsp to title and describe the patch in the
+  library. Without them the patch shows up nameless with no description, so they
+  are as required as the DSP itself. Do not leave either one empty.
+
 POLYPHONIC INSTRUMENT RULES — REQUIRED:
 - This is one MIDI voice driven by MAGDA's Faust voice allocator. Declare exactly these reserved
   controls, with these lowercase labels and NO [idx:N] metadata:
@@ -57,6 +66,15 @@ OUTPUT SCHEMA:
   "description": "<one short sentence describing the sound/processor>",
   "source": "<a complete, valid Faust program>"
 }
+
+PATCH METADATA — REQUIRED:
+- The source MUST open with these two declares, before the import and before any
+  control, with values identical to the JSON "name" and "description" fields:
+      declare name "<the JSON name>";
+      declare description "<the JSON description>";
+- MAGDA reads these back off the saved .dsp to title and describe the patch in the
+  library. Without them the patch shows up nameless with no description, so they
+  are as required as the DSP itself. Do not leave either one empty.
 
 SOURCE RULES — VERY IMPORTANT:
 - Write process as a single processing chain from input to output, e.g.
@@ -99,31 +117,47 @@ User: "warm tape saturator with subtle wow"
 {
   "name": "Tape Warmth",
   "description": "Soft tape-style saturator with gentle wow modulation.",
-  "source": "import(\"stdfaust.lib\");\ndrive = hslider(\"Drive [idx:0]\", 3, 0, 10, 0.01);\nwow = hslider(\"Wow [idx:1]\", 0.3, 0, 1, 0.01);\nmix = hslider(\"Mix [idx:2]\", 0.8, 0, 1, 0.01);\nlfo = os.osc(0.6) * 0.002 * wow;\nsat(x) = ef.cubicnl(drive/10, 0) : *(0.7);\nprocess = _ <: *(1.0 + lfo) : sat : _ * mix + _ * (1.0 - mix);"
+  "source": "declare name \"Tape Warmth\";\ndeclare description \"Soft tape-style saturator with gentle wow modulation.\";\nimport(\"stdfaust.lib\");\ndrive = hslider(\"Drive [idx:0]\", 3, 0, 10, 0.01);\nwow = hslider(\"Wow [idx:1]\", 0.3, 0, 1, 0.01);\nmix = hslider(\"Mix [idx:2]\", 0.8, 0, 1, 0.01);\nlfo = os.osc(0.6) * 0.002 * wow;\nsat(x) = ef.cubicnl(drive/10, 0) : *(0.7);\nprocess = _ <: *(1.0 + lfo) : sat : _ * mix + _ * (1.0 - mix);"
 }
 
 User: "gentle plate reverb with mode switch"
 {
   "name": "Plate Lite",
   "description": "Short, dark plate reverb with a Plate / Hall mode.",
-  "source": "import(\"stdfaust.lib\");\nsize = hslider(\"Size [idx:0]\", 0.5, 0, 1, 0.01);\ndamp = hslider(\"Damp [idx:1]\", 0.6, 0, 1, 0.01);\nmix = hslider(\"Mix [idx:2]\", 0.35, 0, 1, 0.01);\nmode = hslider(\"Mode [idx:3][style:menu{'Plate':0;'Hall':1}]\", 0, 0, 1, 1);\nfreeze = checkbox(\"Freeze [idx:4]\");\nfb = (0.7 + size * 0.28 + mode * 0.02) * (1.0 - freeze) + freeze * 0.999;\nwet = re.mono_freeverb(fb, fb, damp, 0.5);\nprocess = _ <: (_ : *(1.0 - mix)), (_ : wet : *(mix)) :> _;"
+  "source": "declare name \"Plate Lite\";\ndeclare description \"Short, dark plate reverb with a Plate / Hall mode.\";\nimport(\"stdfaust.lib\");\nsize = hslider(\"Size [idx:0]\", 0.5, 0, 1, 0.01);\ndamp = hslider(\"Damp [idx:1]\", 0.6, 0, 1, 0.01);\nmix = hslider(\"Mix [idx:2]\", 0.35, 0, 1, 0.01);\nmode = hslider(\"Mode [idx:3][style:menu{'Plate':0;'Hall':1}]\", 0, 0, 1, 1);\nfreeze = checkbox(\"Freeze [idx:4]\");\nfb = (0.7 + size * 0.28 + mode * 0.02) * (1.0 - freeze) + freeze * 0.999;\nwet = re.mono_freeverb(fb, fb, damp, 0.5);\nprocess = _ <: (_ : *(1.0 - mix)), (_ : wet : *(mix)) :> _;"
 }
 )PROMPT";
 }
 
 namespace {
 
-// MAGDA-side validation of the [idx:N] parameter contract, run BEFORE the Faust
-// compile check. The Faust compiler treats our [...] tags as opaque label text,
-// so a missing / duplicate / out-of-range idx (or >64 controls) compiles fine
-// yet breaks parameter links on the next regeneration. Catch it here and feed
-// failures into the same retry loop the compiler errors use.
+// MAGDA-side validation of the [idx:N] parameter contract and the patch
+// metadata declares, run BEFORE the Faust compile check. The Faust compiler
+// treats our [...] tags as opaque label text and accepts a patch with no
+// declares at all, so a missing / duplicate / out-of-range idx (or >64
+// controls), or a nameless patch, compiles fine yet breaks parameter links on
+// the next regeneration or lands in the library with nothing to identify it.
+// Catch it here and feed failures into the same retry loop the compiler errors
+// use.
 bool validateSourceImpl(FaustAgent::Target target, const std::string& source,
                         std::string& errorOut) {
     static const std::regex controlDecl(
         R"RX((hslider|vslider|nentry|checkbox|button)\s*\(\s*"([^"]*)")RX");
 
     juce::StringArray problems;
+
+    // Same shape readPatchInfo() scans for, so anything that passes here is
+    // something MAGDA can actually read back off the saved .dsp.
+    const auto hasDeclare = [&source](const std::string& key) {
+        const std::regex re("declare\\s+" + key + "\\s+\"([^\"]+)\"");
+        std::smatch m;
+        return std::regex_search(source, m, re) && juce::String(m[1].str()).trim().isNotEmpty();
+    };
+    if (!hasDeclare("name"))
+        problems.add("source is missing a non-empty declare name \"...\"");
+    if (!hasDeclare("description"))
+        problems.add("source is missing a non-empty declare description \"...\"");
+
     std::array<bool, 64> used{};
     int userControlCount = 0;
     bool sawFreq = false;

--- a/tests/test_faust_agent.cpp
+++ b/tests/test_faust_agent.cpp
@@ -6,6 +6,8 @@ using magda::FaustAgent;
 
 TEST_CASE("Faust instrument validation accepts reserved voice controls", "[agents][faust]") {
     const std::string source = R"FAUST(
+declare name "Test Voice";
+declare description "A saw voice for validation tests.";
 import("stdfaust.lib");
 freq = hslider("freq", 440, 20, 20000, 0.01);
 gain = hslider("gain", 0.5, 0, 1, 0.01);
@@ -23,6 +25,8 @@ TEST_CASE("Faust instrument validation rejects missing or indexed reserved contr
     std::string error;
     CHECK_FALSE(
         FaustAgent::validateSource(FaustAgent::Target::Instrument,
+                                   "declare name \"Broken\";\n"
+                                   "declare description \"Missing gate.\";\n"
                                    "freq = hslider(\"freq [idx:0]\", 440, 20, 20000, 0.01);\n"
                                    "gain = hslider(\"gain\", 0.5, 0, 1, 0.01);\n"
                                    "process = _;",
@@ -35,7 +39,50 @@ TEST_CASE("Faust effect validation keeps the existing indexed control contract",
           "[agents][faust]") {
     std::string error;
     CHECK(FaustAgent::validateSource(FaustAgent::Target::Effect,
+                                     "declare name \"Drive\";\n"
+                                     "declare description \"A drive stage.\";\n"
                                      "drive = hslider(\"Drive [idx:0]\", 1, 0, 10, 0.1);\n"
                                      "process = _;",
                                      error));
+}
+
+// The Faust compiler accepts a patch with no declares at all, so nothing but
+// this check stops a generated patch landing in the library with no name and
+// no description to identify it by.
+TEST_CASE("Faust validation requires the patch name and description declares", "[agents][faust]") {
+    const std::string body = "drive = hslider(\"Drive [idx:0]\", 1, 0, 10, 0.1);\n"
+                             "process = _;";
+
+    std::string error;
+    CHECK_FALSE(FaustAgent::validateSource(FaustAgent::Target::Effect, body, error));
+    CHECK(error.find("declare name") != std::string::npos);
+    CHECK(error.find("declare description") != std::string::npos);
+
+    error.clear();
+    CHECK_FALSE(FaustAgent::validateSource(FaustAgent::Target::Effect,
+                                           "declare name \"Drive\";\n" + body, error));
+    CHECK(error.find("declare description") != std::string::npos);
+
+    // Present but empty is the same as absent: readPatchInfo would hand the
+    // library a blank string either way.
+    error.clear();
+    CHECK_FALSE(FaustAgent::validateSource(FaustAgent::Target::Effect,
+                                           "declare name \"Drive\";\n"
+                                           "declare description \"\";\n" +
+                                               body,
+                                           error));
+    CHECK(error.find("declare description") != std::string::npos);
+}
+
+TEST_CASE("Faust instrument validation requires the metadata declares too", "[agents][faust]") {
+    std::string error;
+    CHECK_FALSE(FaustAgent::validateSource(FaustAgent::Target::Instrument,
+                                           "import(\"stdfaust.lib\");\n"
+                                           "freq = hslider(\"freq\", 440, 20, 20000, 0.01);\n"
+                                           "gain = hslider(\"gain\", 0.5, 0, 1, 0.01);\n"
+                                           "gate = button(\"gate\");\n"
+                                           "process = os.sawtooth(freq) * gain * gate <: _, _;",
+                                           error));
+    CHECK(error.find("declare name") != std::string::npos);
+    CHECK(error.find("declare description") != std::string::npos);
 }


### PR DESCRIPTION
A generated patch carried its name and description only in the agent's JSON envelope, never in the .dsp itself. readPatchInfo scans the saved source for `declare name` / `declare description`, so once a patch was saved to the library it showed up with nothing to identify it by.

Both system prompts now require the source to open with those two declares, carrying the same values as the JSON fields, and the worked examples in the effect prompt were updated so they don't contradict the rule they teach.

Prompting alone isn't enforcement, so validateSource checks for both declares using the same pattern readPatchInfo scans for, treating a present-but-empty value as missing. It runs before the MCP compile, so a nameless patch costs a retry with the reason inline rather than a wasted compile. This applies to instrument and effect alike: the Faust compiler accepts a patch with no declares at all, so nothing else was catching it.