### PR TITLE
Move clips with Shift+arrow keys (#1957)

### DIFF
--- a/magda/daw/ui/components/tracks/TrackContentPanel.hpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanel.hpp
@@ -243,6 +243,13 @@ class TrackContentPanel : public juce::Component,
 
     bool duplicateSelectedArrangementClips(bool includeAutomation, bool asGhost = false);
 
+    // Keyboard clip moves (#1957). Both take -1/+1 and move the whole selection
+    // by one step — one grid unit along the timeline, one track across it —
+    // returning false when nothing moved (no arrangement clips selected, or the
+    // selection is already against the edge it is being pushed towards).
+    bool nudgeSelectedClipsHorizontally(int direction);
+    bool nudgeSelectedClipsToAdjacentTrack(int direction);
+
     // Ghost clip methods (for Alt+drag visual feedback)
     void setClipGhost(ClipId clipId, const juce::Rectangle<int>& bounds,
                       const juce::Colour& colour);

--- a/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
@@ -402,13 +402,18 @@ void TrackContentPanel::cancelMultiClipDrag() {
 
 namespace {
 
-// Group and aux tracks are buses with no clip timeline, the master track has
-// no lane, and the chord track is a singleton whose clips are chord
-// progressions — a MIDI clip landing there would change meaning. None of them
-// are valid nudge targets, so vertical nudging steps over them.
+// Tracks a nudge may move a clip onto. Group and aux tracks are buses with no
+// clip timeline, the master track has no lane, and the chord track is a
+// singleton whose clips are chord progressions — a MIDI clip landing there
+// would change meaning. Multi-out tracks look like ordinary lanes but are
+// owned by a device's output pair: deactivateMultiOutPair() erases the track
+// outright without touching its clips, so anything parked there is orphaned
+// the moment the user switches that output off. Vertical nudging steps over
+// all of them.
 bool canHostNudgedClips(const TrackInfo& track) {
     return track.type != TrackType::Group && track.type != TrackType::Aux &&
-           track.type != TrackType::Master && track.type != TrackType::Chord;
+           track.type != TrackType::Master && track.type != TrackType::Chord &&
+           track.type != TrackType::MultiOut;
 }
 
 // The clips a nudge acts on: the arrangement half of the selection. Session
@@ -425,6 +430,23 @@ std::vector<ClipId> selectedArrangementClips() {
     return clips;
 }
 
+// Frozen tracks are rendered to audio, so their clips must not move out from
+// under the render. Clips there stay selectable, and both the mouse drag
+// (ClipComponent::mouseDrag) and the destructive context actions already
+// refuse them; the keyboard has to refuse them too or the shortcut becomes a
+// hole in the freeze invariant.
+bool isOnFrozenTrack(ClipId clipId) {
+    const auto* clip = ClipManager::getInstance().getClip(clipId);
+    if (clip == nullptr)
+        return false;
+    const auto* track = TrackManager::getInstance().getTrack(clip->trackId);
+    return track != nullptr && track->frozen;
+}
+
+bool anyClipOnFrozenTrack(const std::vector<ClipId>& clips) {
+    return std::any_of(clips.begin(), clips.end(), isOnFrozenTrack);
+}
+
 }  // namespace
 
 bool TrackContentPanel::nudgeSelectedClipsHorizontally(int direction) {
@@ -432,7 +454,7 @@ bool TrackContentPanel::nudgeSelectedClipsHorizontally(int direction) {
         return false;
 
     const auto clips = selectedArrangementClips();
-    if (clips.empty())
+    if (clips.empty() || anyClipOnFrozenTrack(clips))
         return false;
 
     auto& clipManager = ClipManager::getInstance();
@@ -442,25 +464,62 @@ bool TrackContentPanel::nudgeSelectedClipsHorizontally(int direction) {
             anchorStartBeat = std::min(anchorStartBeat, clip->placement.startBeat);
     }
 
+    // The earliest clip anchors the move so the selection keeps its internal
+    // spacing, the same contract a multi-clip drag has.
+    //
+    // The step comes from whichever grid is actually drawn. In Seconds mode
+    // that is a 1/2/5-based interval in seconds, unrelated to the beat
+    // subdivision getSnapBeatFraction() returns — at 90 BPM and 40 px/beat the
+    // ruler shows 1 s lines while the beat fraction is 2 beats (1.333 s), so
+    // taking beats there would move the clip off every visible line. Resolve
+    // in the displayed domain, then convert the target back to beats.
     const auto& state = timelineController->getState();
     interaction::HorizontalNudge nudge;
-    nudge.anchorStartBeat = anchorStartBeat;
-    nudge.gridBeats = state.getSnapBeatFraction();
     nudge.snapToGrid = state.display.snapEnabled;
     nudge.direction = direction;
 
-    // The earliest clip anchors the move so the selection keeps its internal
-    // spacing, the same contract a multi-clip drag has.
-    const double deltaBeats = interaction::horizontalDeltaBeats(nudge);
+    double deltaBeats = 0.0;
+    if (state.display.timeDisplayMode == TimeDisplayMode::Seconds) {
+        const double anchorSeconds = beatsToSeconds(anchorStartBeat);
+        nudge.anchorPosition = anchorSeconds;
+        nudge.gridStep = state.getSnapInterval();
+
+        const double deltaSeconds = interaction::horizontalDelta(nudge);
+        if (deltaSeconds == 0.0)
+            return false;
+        deltaBeats = secondsToBeats(anchorSeconds + deltaSeconds) - anchorStartBeat;
+    } else {
+        nudge.anchorPosition = anchorStartBeat;
+        nudge.gridStep = state.getSnapBeatFraction();
+        deltaBeats = interaction::horizontalDelta(nudge);
+    }
+
     if (deltaBeats == 0.0)
         return false;
+
+    // Apply back-to-front relative to travel. Each MoveClipCommand executes
+    // immediately and ClipManager::moveClipBeats resolves overlaps against
+    // every other clip on the track — including selected ones that have not
+    // moved yet. Nudging two adjacent selected clips rightwards would
+    // otherwise let the leader land on top of its neighbour and trim or delete
+    // it, with the surviving clip decided by unordered_set iteration order.
+    // Moving the far clip first keeps the path clear.
+    std::vector<ClipId> ordered = clips;
+    std::sort(ordered.begin(), ordered.end(), [&](ClipId lhs, ClipId rhs) {
+        const auto* a = clipManager.getClip(lhs);
+        const auto* b = clipManager.getClip(rhs);
+        if (a == nullptr || b == nullptr)
+            return false;
+        return direction > 0 ? a->placement.startBeat > b->placement.startBeat
+                             : a->placement.startBeat < b->placement.startBeat;
+    });
 
     // Always compound, even for one clip: consecutive MoveClipCommands on the
     // same clip merge into a single history entry, which would fold a run of
     // presses into one undo. A press is an action and gets its own step.
     const double bpm = getTempo();
     CompoundOperationScope undoScope("Nudge Clips");
-    for (ClipId clipId : clips) {
+    for (ClipId clipId : ordered) {
         const auto* clip = clipManager.getClip(clipId);
         if (clip == nullptr)
             continue;
@@ -476,14 +535,18 @@ bool TrackContentPanel::nudgeSelectedClipsToAdjacentTrack(int direction) {
         return false;
 
     const auto clips = selectedArrangementClips();
-    if (clips.empty())
+    if (clips.empty() || anyClipOnFrozenTrack(clips))
         return false;
 
+    // Frozen tracks are excluded as destinations for the same reason they are
+    // refused as sources: dropping a clip into a frozen track's lane would put
+    // the model out of step with its rendered audio. Skipping them (rather
+    // than refusing) keeps a frozen lane from walling off the tracks below it.
     auto& trackManager = TrackManager::getInstance();
     std::vector<TrackId> hostTrackIds;
     for (TrackId trackId : visibleTrackIds_) {
         const auto* track = trackManager.getTrack(trackId);
-        if (track != nullptr && canHostNudgedClips(*track))
+        if (track != nullptr && canHostNudgedClips(*track) && !track->frozen)
             hostTrackIds.push_back(trackId);
     }
     if (hostTrackIds.size() < 2)
@@ -524,6 +587,13 @@ bool TrackContentPanel::nudgeSelectedClipsToAdjacentTrack(int direction) {
     const int trackDelta = interaction::verticalTrackDelta(nudge);
     if (trackDelta == 0)
         return false;
+
+    // Same back-to-front rule as the horizontal path: landing on a track a
+    // still-unmoved selected clip occupies would let overlap resolution trim
+    // or delete that clip. Vacate the far track first.
+    std::sort(moves.begin(), moves.end(), [direction](const auto& lhs, const auto& rhs) {
+        return direction > 0 ? lhs.trackIndex > rhs.trackIndex : lhs.trackIndex < rhs.trackIndex;
+    });
 
     CompoundOperationScope undoScope("Move Clips to Track");
     for (const auto& move : moves) {

--- a/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
+++ b/magda/daw/ui/components/tracks/TrackContentPanelClipDrag.cpp
@@ -1,6 +1,9 @@
 // TrackContentPanel — Multi-clip drag, time selection clip handling, and clip ghost methods.
 // Split from TrackContentPanel.cpp for file-size compliance.
 
+#include <limits>
+
+#include "../../interaction/ClipNudge.hpp"
 #include "../clips/ClipComponent.hpp"
 #include "TrackContentPanel.hpp"
 #include "core/ClipCommands.hpp"
@@ -391,6 +394,145 @@ void TrackContentPanel::cancelMultiClipDrag() {
     multiClipDuplicateIds_.clear();
     multiClipDragAnchorTrackIndex_ = -1;
     multiClipDragTrackDelta_ = 0;
+}
+
+// ============================================================================
+// Keyboard Clip Nudging (#1957)
+// ============================================================================
+
+namespace {
+
+// Group and aux tracks are buses with no clip timeline, the master track has
+// no lane, and the chord track is a singleton whose clips are chord
+// progressions — a MIDI clip landing there would change meaning. None of them
+// are valid nudge targets, so vertical nudging steps over them.
+bool canHostNudgedClips(const TrackInfo& track) {
+    return track.type != TrackType::Group && track.type != TrackType::Aux &&
+           track.type != TrackType::Master && track.type != TrackType::Chord;
+}
+
+// The clips a nudge acts on: the arrangement half of the selection. Session
+// clips live in a scene grid, not on the timeline, and are left alone even
+// when a session view put them in the same selection.
+std::vector<ClipId> selectedArrangementClips() {
+    std::vector<ClipId> clips;
+    auto& clipManager = ClipManager::getInstance();
+    for (ClipId clipId : SelectionManager::getInstance().getSelectedClips()) {
+        const auto* clip = clipManager.getClip(clipId);
+        if (clip != nullptr && clip->view == ClipView::Arrangement)
+            clips.push_back(clipId);
+    }
+    return clips;
+}
+
+}  // namespace
+
+bool TrackContentPanel::nudgeSelectedClipsHorizontally(int direction) {
+    if (direction == 0 || timelineController == nullptr)
+        return false;
+
+    const auto clips = selectedArrangementClips();
+    if (clips.empty())
+        return false;
+
+    auto& clipManager = ClipManager::getInstance();
+    double anchorStartBeat = std::numeric_limits<double>::max();
+    for (ClipId clipId : clips) {
+        if (const auto* clip = clipManager.getClip(clipId))
+            anchorStartBeat = std::min(anchorStartBeat, clip->placement.startBeat);
+    }
+
+    const auto& state = timelineController->getState();
+    interaction::HorizontalNudge nudge;
+    nudge.anchorStartBeat = anchorStartBeat;
+    nudge.gridBeats = state.getSnapBeatFraction();
+    nudge.snapToGrid = state.display.snapEnabled;
+    nudge.direction = direction;
+
+    // The earliest clip anchors the move so the selection keeps its internal
+    // spacing, the same contract a multi-clip drag has.
+    const double deltaBeats = interaction::horizontalDeltaBeats(nudge);
+    if (deltaBeats == 0.0)
+        return false;
+
+    // Always compound, even for one clip: consecutive MoveClipCommands on the
+    // same clip merge into a single history entry, which would fold a run of
+    // presses into one undo. A press is an action and gets its own step.
+    const double bpm = getTempo();
+    CompoundOperationScope undoScope("Nudge Clips");
+    for (ClipId clipId : clips) {
+        const auto* clip = clipManager.getClip(clipId);
+        if (clip == nullptr)
+            continue;
+        UndoManager::getInstance().executeCommand(std::make_unique<MoveClipCommand>(
+            clipId, BeatPosition{clip->placement.startBeat + deltaBeats}, bpm));
+    }
+
+    return true;
+}
+
+bool TrackContentPanel::nudgeSelectedClipsToAdjacentTrack(int direction) {
+    if (direction == 0)
+        return false;
+
+    const auto clips = selectedArrangementClips();
+    if (clips.empty())
+        return false;
+
+    auto& trackManager = TrackManager::getInstance();
+    std::vector<TrackId> hostTrackIds;
+    for (TrackId trackId : visibleTrackIds_) {
+        const auto* track = trackManager.getTrack(trackId);
+        if (track != nullptr && canHostNudgedClips(*track))
+            hostTrackIds.push_back(trackId);
+    }
+    if (hostTrackIds.size() < 2)
+        return false;
+
+    struct ClipTrackIndex {
+        ClipId clipId;
+        int trackIndex;
+    };
+    std::vector<ClipTrackIndex> moves;
+    moves.reserve(clips.size());
+
+    auto& clipManager = ClipManager::getInstance();
+    int minTrackIndex = std::numeric_limits<int>::max();
+    int maxTrackIndex = std::numeric_limits<int>::min();
+    for (ClipId clipId : clips) {
+        const auto* clip = clipManager.getClip(clipId);
+        if (clip == nullptr)
+            continue;
+        auto it = std::find(hostTrackIds.begin(), hostTrackIds.end(), clip->trackId);
+        if (it == hostTrackIds.end())
+            return false;  // e.g. a chord clip: the selection moves whole or not at all
+
+        const int trackIndex = static_cast<int>(std::distance(hostTrackIds.begin(), it));
+        moves.push_back({clipId, trackIndex});
+        minTrackIndex = std::min(minTrackIndex, trackIndex);
+        maxTrackIndex = std::max(maxTrackIndex, trackIndex);
+    }
+    if (moves.empty())
+        return false;
+
+    interaction::VerticalNudge nudge;
+    nudge.minTrackIndex = minTrackIndex;
+    nudge.maxTrackIndex = maxTrackIndex;
+    nudge.trackCount = static_cast<int>(hostTrackIds.size());
+    nudge.direction = direction;
+
+    const int trackDelta = interaction::verticalTrackDelta(nudge);
+    if (trackDelta == 0)
+        return false;
+
+    CompoundOperationScope undoScope("Move Clips to Track");
+    for (const auto& move : moves) {
+        const auto targetIndex = static_cast<size_t>(move.trackIndex + trackDelta);
+        UndoManager::getInstance().executeCommand(
+            std::make_unique<MoveClipToTrackCommand>(move.clipId, hostTrackIds[targetIndex]));
+    }
+
+    return true;
 }
 
 // ============================================================================

--- a/magda/daw/ui/interaction/CMakeLists.txt
+++ b/magda/daw/ui/interaction/CMakeLists.txt
@@ -6,6 +6,7 @@
 target_sources(magda_daw PRIVATE
     ArrangementHitTester.cpp
     ArrangementHitTester.hpp
+    ClipNudge.hpp
 )
 
 target_sources(magda_daw_app PRIVATE

--- a/magda/daw/ui/interaction/ClipNudge.hpp
+++ b/magda/daw/ui/interaction/ClipNudge.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+
+namespace magda::interaction {
+
+// ============================================================================
+// CLIP NUDGE (#1957)
+//
+// The keyboard counterpart of a clip drag: arrow keys move the selection along
+// the timeline and across tracks. Both axes resolve to a single delta applied
+// to every selected clip, exactly as a drag does, so a multi-clip selection
+// keeps its internal spacing instead of collapsing onto one position/track.
+//
+// Plain data in, delta out — no components, no singletons — so every rule here
+// is headless-testable (tests/test_clip_nudge.cpp).
+// ============================================================================
+
+/** Horizontal nudge input. Beats throughout: the arrangement's native domain. */
+struct HorizontalNudge {
+    double anchorStartBeat = 0.0;  ///< Earliest selected clip's start.
+    double gridBeats = 1.0;        ///< Current grid step.
+    bool snapToGrid = true;        ///< Timeline snap state.
+    int direction = 1;             ///< -1 = earlier, +1 = later.
+};
+
+/**
+ * @brief Beats to add to every selected clip; 0 means the move is refused.
+ *
+ * With snap on the anchor lands *on* the grid rather than carrying its
+ * off-grid offset along forever — one press from beat 0.5 with a 1-beat grid
+ * goes to 1.0, not 1.5. With snap off it is a plain step of one grid unit.
+ * The timeline starts at beat 0, so a selection near the start clamps flush
+ * against it rather than refusing to move.
+ */
+inline double horizontalDeltaBeats(const HorizontalNudge& nudge) {
+    if (nudge.direction == 0 || !(nudge.gridBeats > 0.0))
+        return 0.0;
+
+    const int step = nudge.direction > 0 ? 1 : -1;
+    double targetBeat = nudge.anchorStartBeat + (step * nudge.gridBeats);
+
+    if (nudge.snapToGrid) {
+        // Work in grid units so the "already on the grid?" test is scale-free.
+        // Without the tolerance, an anchor a hair below a grid line (the usual
+        // residue of earlier snapped moves) reads as off-grid and the nudge
+        // travels an invisible fraction of a beat instead of a whole step.
+        double gridUnits = nudge.anchorStartBeat / nudge.gridBeats;
+        const double nearestUnit = std::round(gridUnits);
+        if (std::abs(gridUnits - nearestUnit) < 1e-6)
+            gridUnits = nearestUnit;
+
+        const double targetUnit =
+            step > 0 ? std::floor(gridUnits) + 1.0 : std::ceil(gridUnits) - 1.0;
+        targetBeat = targetUnit * nudge.gridBeats;
+    }
+
+    targetBeat = std::max(targetBeat, 0.0);
+
+    return targetBeat - nudge.anchorStartBeat;
+}
+
+/**
+ * @brief Vertical nudge input: where the selection sits in the list of
+ *        clip-hosting tracks, in display order.
+ */
+struct VerticalNudge {
+    int minTrackIndex = 0;  ///< Topmost selected clip's track.
+    int maxTrackIndex = 0;  ///< Bottommost selected clip's track.
+    int trackCount = 0;     ///< Number of clip-hosting tracks.
+    int direction = 1;      ///< -1 = up, +1 = down.
+};
+
+/**
+ * @brief Track-index delta for the whole selection; 0 means the move is refused.
+ *
+ * The selection travels as a block or not at all. Clamping per clip the way a
+ * drag does would pile the selection onto the end track and silently destroy
+ * its vertical spread — recoverable only by undo.
+ */
+inline int verticalTrackDelta(const VerticalNudge& nudge) {
+    if (nudge.direction == 0 || nudge.trackCount <= 0)
+        return 0;
+    if (nudge.minTrackIndex < 0 || nudge.maxTrackIndex >= nudge.trackCount ||
+        nudge.minTrackIndex > nudge.maxTrackIndex)
+        return 0;
+
+    const int delta = nudge.direction > 0 ? 1 : -1;
+    if (nudge.minTrackIndex + delta < 0 || nudge.maxTrackIndex + delta >= nudge.trackCount)
+        return 0;
+
+    return delta;
+}
+
+}  // namespace magda::interaction

--- a/magda/daw/ui/interaction/ClipNudge.hpp
+++ b/magda/daw/ui/interaction/ClipNudge.hpp
@@ -17,48 +17,55 @@ namespace magda::interaction {
 // is headless-testable (tests/test_clip_nudge.cpp).
 // ============================================================================
 
-/** Horizontal nudge input. Beats throughout: the arrangement's native domain. */
+/**
+ * @brief Horizontal nudge input.
+ *
+ * Deliberately domain-agnostic: anchor and step are simply "positions" and a
+ * "step" in the same unit. Bars/Beats mode feeds it beats and a beat fraction;
+ * Seconds mode feeds it seconds and the second-based grid interval, because
+ * that is the grid actually drawn on screen. Whichever goes in comes back out.
+ */
 struct HorizontalNudge {
-    double anchorStartBeat = 0.0;  ///< Earliest selected clip's start.
-    double gridBeats = 1.0;        ///< Current grid step.
-    bool snapToGrid = true;        ///< Timeline snap state.
-    int direction = 1;             ///< -1 = earlier, +1 = later.
+    double anchorPosition = 0.0;  ///< Earliest selected clip's start.
+    double gridStep = 1.0;        ///< Current grid step, same unit as the anchor.
+    bool snapToGrid = true;       ///< Timeline snap state.
+    int direction = 1;            ///< -1 = earlier, +1 = later.
 };
 
 /**
- * @brief Beats to add to every selected clip; 0 means the move is refused.
+ * @brief Offset to add to every selected clip; 0 means the move is refused.
  *
  * With snap on the anchor lands *on* the grid rather than carrying its
- * off-grid offset along forever — one press from beat 0.5 with a 1-beat grid
- * goes to 1.0, not 1.5. With snap off it is a plain step of one grid unit.
- * The timeline starts at beat 0, so a selection near the start clamps flush
- * against it rather than refusing to move.
+ * off-grid offset along forever — one press from 0.5 with a step of 1 goes to
+ * 1.0, not 1.5. With snap off it is a plain step of one grid unit. The
+ * timeline starts at 0, so a selection near the start clamps flush against it
+ * rather than refusing to move.
  */
-inline double horizontalDeltaBeats(const HorizontalNudge& nudge) {
-    if (nudge.direction == 0 || !(nudge.gridBeats > 0.0))
+inline double horizontalDelta(const HorizontalNudge& nudge) {
+    if (nudge.direction == 0 || !(nudge.gridStep > 0.0))
         return 0.0;
 
     const int step = nudge.direction > 0 ? 1 : -1;
-    double targetBeat = nudge.anchorStartBeat + (step * nudge.gridBeats);
+    double target = nudge.anchorPosition + (step * nudge.gridStep);
 
     if (nudge.snapToGrid) {
         // Work in grid units so the "already on the grid?" test is scale-free.
         // Without the tolerance, an anchor a hair below a grid line (the usual
         // residue of earlier snapped moves) reads as off-grid and the nudge
-        // travels an invisible fraction of a beat instead of a whole step.
-        double gridUnits = nudge.anchorStartBeat / nudge.gridBeats;
+        // travels an invisible fraction of a step instead of a whole one.
+        double gridUnits = nudge.anchorPosition / nudge.gridStep;
         const double nearestUnit = std::round(gridUnits);
         if (std::abs(gridUnits - nearestUnit) < 1e-6)
             gridUnits = nearestUnit;
 
         const double targetUnit =
             step > 0 ? std::floor(gridUnits) + 1.0 : std::ceil(gridUnits) - 1.0;
-        targetBeat = targetUnit * nudge.gridBeats;
+        target = targetUnit * nudge.gridStep;
     }
 
-    targetBeat = std::max(targetBeat, 0.0);
+    target = std::max(target, 0.0);
 
-    return targetBeat - nudge.anchorStartBeat;
+    return target - nudge.anchorPosition;
 }
 
 /**

--- a/magda/daw/ui/panels/content/MidiEditorContent.hpp
+++ b/magda/daw/ui/panels/content/MidiEditorContent.hpp
@@ -64,15 +64,21 @@ class MidiEditorViewport : public juce::Viewport {
     std::vector<juce::Component*> componentsToRepaint;
 
     bool keyPressed(const juce::KeyPress& key) override {
-        // Alt/Option + arrow keys: allow viewport scrolling
-        // Plain arrow keys: don't handle, let grid component use them for note movement
+        // Arrow keys belong to the MIDI editor and never escape it. The grid
+        // component is a child, so anything reaching this viewport is a key the
+        // grid declined — Alt scrolls, the rest is swallowed. Letting them
+        // through would hand the arrangement's clip nudge (#1957, Shift+arrows)
+        // the chance to move the very clip being edited whenever no note is
+        // selected for the grid to act on.
         if (key.getKeyCode() == juce::KeyPress::upKey ||
             key.getKeyCode() == juce::KeyPress::downKey ||
             key.getKeyCode() == juce::KeyPress::leftKey ||
             key.getKeyCode() == juce::KeyPress::rightKey) {
+            // JUCE's ScrollBar only answers to unmodified arrows, so hand it
+            // the bare key; consumed either way, including at the scroll limits.
             if (key.getModifiers().isAltDown())
-                return juce::Viewport::keyPressed(key);
-            return false;
+                juce::Viewport::keyPressed(juce::KeyPress(key.getKeyCode()));
+            return true;
         }
         return juce::Viewport::keyPressed(key);
     }

--- a/magda/daw/ui/views/MainView.hpp
+++ b/magda/daw/ui/views/MainView.hpp
@@ -115,6 +115,12 @@ class MainView : public juce::Component,
     // Timer implementation (for metering updates)
     void timerCallback() override;
 
+    // Access to the arrangement clip surface (for command handlers — it owns
+    // the display track order the keyboard clip moves step through)
+    TrackContentPanel* getTrackContentPanel() {
+        return trackContentPanel.get();
+    }
+
     // Access to the timeline controller (for child components)
     TimelineController& getTimelineController() {
         return *timelineController;

--- a/magda/daw/ui/windows/CommandIDs.hpp
+++ b/magda/daw/ui/windows/CommandIDs.hpp
@@ -50,6 +50,10 @@ enum {
     duplicateClipAsGhost = 0x101C,    // Copy joins the source's link group (mirrors content)
     makeClipUnique = 0x101D,          // Detach selected ghost clips from their link groups
     toggleClipEnabled = 0x101E,       // 0: enable/disable selected clips (disabled = no playback)
+    nudgeClipsEarlier = 0x101F,       // Shift+Left: move selected clips one grid step earlier
+    nudgeClipsLater = 0x1020,         // Shift+Right: move selected clips one grid step later
+    nudgeClipsUp = 0x1021,            // Shift+Up: move selected clips to the track above
+    nudgeClipsDown = 0x1022,          // Shift+Down: move selected clips to the track below
 
     // Transport menu
     play = 0x2000,  // Space: toggles play/stop (perform() already toggles)

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -56,6 +56,19 @@ ViewMode getNextCycledViewMode(ViewMode mode, bool forward) {
     return ViewMode::Arrange;
 }
 
+// Keyboard clip moves (#1957) act on the arrangement half of the selection.
+// Disabled when there is none, so the arrow keys fall through to whatever else
+// wants them instead of being swallowed by a no-op command.
+bool hasSelectedArrangementClips() {
+    auto& clipManager = ClipManager::getInstance();
+    for (ClipId clipId : SelectionManager::getInstance().getSelectedClips()) {
+        const auto* clip = clipManager.getClip(clipId);
+        if (clip != nullptr && clip->view == ClipView::Arrangement)
+            return true;
+    }
+    return false;
+}
+
 bool containsTimelineTime(const ClipInfo& clip, double timeSeconds, double bpm) {
     return timeSeconds > timelineStartSeconds(clip, bpm) &&
            timeSeconds < timelineEndSeconds(clip, bpm);
@@ -98,7 +111,8 @@ void MainWindow::MainComponent::getAllCommands(juce::Array<juce::CommandID>& com
         splitOrTrim, joinClips, renderClip, renderTimeSelection, setLoopFromClip, toggleClipLoop,
         toggleClipEnabled, escapeAction, insertTime, duplicateTimeRange, duplicateLoopRange,
         splitAllTracksAtCursor, copyTimeRange, cutTimeRange, deleteTimeRange, copyLoopRange,
-        cutLoopRange, deleteLoopRange, pasteRipple,
+        cutLoopRange, deleteLoopRange, pasteRipple, nudgeClipsEarlier, nudgeClipsLater,
+        nudgeClipsUp, nudgeClipsDown,
         // File menu
         newProject, openProject, saveProject, saveProjectAs, exportAudio, closeProject,
         projectSettings, collectFiles, exportMidi, importDawProject, exportDawProject,
@@ -309,6 +323,37 @@ void MainWindow::MainComponent::getCommandInfo(juce::CommandID commandID,
         case escapeAction:
             result.setInfo("Exit Mode", "Exit link mode and clear the edit cursor", "Edit", 0);
             result.addDefaultKeypress(juce::KeyPress::escapeKey, 0);
+            break;
+
+        // Shift+arrows, as in Waveform. NOT Alt+arrows (Bitwig, Fender Studio):
+        // Alt on a clip body already means duplicate here — Alt+drag copies,
+        // Alt+Shift+drag ghost-copies — so Alt+arrow would have one modifier
+        // meaning copy under the mouse and move under the keyboard. That also
+        // leaves Alt+arrow open for a copy-nudge that matches Alt+drag.
+        case nudgeClipsEarlier:
+            result.setInfo("Nudge Clips Earlier", "Move selected clips one grid step earlier",
+                           "Edit", 0);
+            result.addDefaultKeypress(juce::KeyPress::leftKey, juce::ModifierKeys::shiftModifier);
+            result.setActive(hasSelectedArrangementClips());
+            break;
+
+        case nudgeClipsLater:
+            result.setInfo("Nudge Clips Later", "Move selected clips one grid step later", "Edit",
+                           0);
+            result.addDefaultKeypress(juce::KeyPress::rightKey, juce::ModifierKeys::shiftModifier);
+            result.setActive(hasSelectedArrangementClips());
+            break;
+
+        case nudgeClipsUp:
+            result.setInfo("Move Clips Up", "Move selected clips to the track above", "Edit", 0);
+            result.addDefaultKeypress(juce::KeyPress::upKey, juce::ModifierKeys::shiftModifier);
+            result.setActive(hasSelectedArrangementClips());
+            break;
+
+        case nudgeClipsDown:
+            result.setInfo("Move Clips Down", "Move selected clips to the track below", "Edit", 0);
+            result.addDefaultKeypress(juce::KeyPress::downKey, juce::ModifierKeys::shiftModifier);
+            result.setActive(hasSelectedArrangementClips());
             break;
 
         // File menu
@@ -1711,6 +1756,26 @@ bool MainWindow::MainComponent::perform(const InvocationInfo& info) {
                 UndoManager::getInstance().endCompoundOperation();
             }
             return true;
+        }
+
+        case nudgeClipsEarlier:
+        case nudgeClipsLater:
+        case nudgeClipsUp:
+        case nudgeClipsDown: {
+            auto* clipPanel = mainView ? mainView->getTrackContentPanel() : nullptr;
+            if (clipPanel == nullptr)
+                return false;
+
+            const bool acrossTracks =
+                info.commandID == nudgeClipsUp || info.commandID == nudgeClipsDown;
+            const int direction =
+                (info.commandID == nudgeClipsEarlier || info.commandID == nudgeClipsUp) ? -1 : 1;
+
+            // Returning the panel's verdict rather than a blanket true leaves
+            // the key press unconsumed when the selection is already against
+            // the edge it is being pushed towards.
+            return acrossTracks ? clipPanel->nudgeSelectedClipsToAdjacentTrack(direction)
+                                : clipPanel->nudgeSelectedClipsHorizontally(direction);
         }
 
         case play:

--- a/magda/daw/ui/windows/MainWindowCommands.cpp
+++ b/magda/daw/ui/windows/MainWindowCommands.cpp
@@ -56,17 +56,25 @@ ViewMode getNextCycledViewMode(ViewMode mode, bool forward) {
     return ViewMode::Arrange;
 }
 
-// Keyboard clip moves (#1957) act on the arrangement half of the selection.
-// Disabled when there is none, so the arrow keys fall through to whatever else
-// wants them instead of being swallowed by a no-op command.
-bool hasSelectedArrangementClips() {
+// Keyboard clip moves (#1957) act on the arrangement half of the selection,
+// and refuse outright when any of it sits on a frozen track — the same rule
+// the panel enforces, mirrored here so the commands read as disabled instead
+// of silently doing nothing. Disabled also lets the arrow keys fall through to
+// whatever else wants them rather than being swallowed by a no-op command.
+bool canNudgeSelectedClips() {
     auto& clipManager = ClipManager::getInstance();
+    auto& trackManager = TrackManager::getInstance();
+    bool found = false;
     for (ClipId clipId : SelectionManager::getInstance().getSelectedClips()) {
         const auto* clip = clipManager.getClip(clipId);
-        if (clip != nullptr && clip->view == ClipView::Arrangement)
-            return true;
+        if (clip == nullptr || clip->view != ClipView::Arrangement)
+            continue;
+        const auto* track = trackManager.getTrack(clip->trackId);
+        if (track != nullptr && track->frozen)
+            return false;
+        found = true;
     }
-    return false;
+    return found;
 }
 
 bool containsTimelineTime(const ClipInfo& clip, double timeSeconds, double bpm) {
@@ -334,26 +342,26 @@ void MainWindow::MainComponent::getCommandInfo(juce::CommandID commandID,
             result.setInfo("Nudge Clips Earlier", "Move selected clips one grid step earlier",
                            "Edit", 0);
             result.addDefaultKeypress(juce::KeyPress::leftKey, juce::ModifierKeys::shiftModifier);
-            result.setActive(hasSelectedArrangementClips());
+            result.setActive(canNudgeSelectedClips());
             break;
 
         case nudgeClipsLater:
             result.setInfo("Nudge Clips Later", "Move selected clips one grid step later", "Edit",
                            0);
             result.addDefaultKeypress(juce::KeyPress::rightKey, juce::ModifierKeys::shiftModifier);
-            result.setActive(hasSelectedArrangementClips());
+            result.setActive(canNudgeSelectedClips());
             break;
 
         case nudgeClipsUp:
             result.setInfo("Move Clips Up", "Move selected clips to the track above", "Edit", 0);
             result.addDefaultKeypress(juce::KeyPress::upKey, juce::ModifierKeys::shiftModifier);
-            result.setActive(hasSelectedArrangementClips());
+            result.setActive(canNudgeSelectedClips());
             break;
 
         case nudgeClipsDown:
             result.setInfo("Move Clips Down", "Move selected clips to the track below", "Edit", 0);
             result.addDefaultKeypress(juce::KeyPress::downKey, juce::ModifierKeys::shiftModifier);
-            result.setActive(hasSelectedArrangementClips());
+            result.setActive(canNudgeSelectedClips());
             break;
 
         // File menu

--- a/manual/docs/arrangement-view.md
+++ b/manual/docs/arrangement-view.md
@@ -131,6 +131,7 @@ When no time selection is active, editing operations apply to **selected clips**
 - **Split** (++cmd+e++) — Splits selected clips at the edit cursor position
 - **Render** (++cmd+b++) — Renders selected clips to audio in place
 - **Cut / Copy / Paste / Duplicate / Delete** — Operate on the selected clips
+- **Nudge** (++shift++ + arrow keys) — Moves selected clips one grid step along the timeline, or to the neighbouring track. See [Editing Clips](clips.md#editing-clips).
 
 ### Time Selection Editing
 

--- a/manual/docs/clips.md
+++ b/manual/docs/clips.md
@@ -86,6 +86,7 @@ Follow actions chain session clips together for generative arrangement. Once the
 ## Editing Clips
 
 - **Move** — Drag a clip to reposition it on the timeline or move it to another track
+- **Nudge** — With clips selected, ++shift+arrow-left++ / ++shift+arrow-right++ moves them one grid step along the timeline, and ++shift+arrow-up++ / ++shift+arrow-down++ moves them to the neighbouring track. The whole selection moves together, keeping its spacing, and stops rather than piling up when it reaches the first track, the last track, or the start of the timeline. With snap on, the move lands on the grid; with snap off it steps by one grid unit from wherever the clip sits.
 - **Resize** — Drag the left or right edge of a clip to trim its start or end point
 - **Duplicate** — Hold ++alt++ and drag a clip, or press ++cmd+d++
 - **Duplicate with or without automation** — Right-click a clip and choose **Duplicate With Automation** to copy the clip together with the automation under it, or **Duplicate Without Automation** to copy just the clip. Plain **Duplicate** behaves the same as the menu's default.

--- a/manual/docs/reference/keyboard-shortcuts.md
+++ b/manual/docs/reference/keyboard-shortcuts.md
@@ -23,6 +23,8 @@ Everything below is the **default** mapping. You can remap any shortcut from **S
 | ++ctrl+shift+d++ / ++cmd+shift+d++ | Duplicate track (without content) |
 | ++ctrl+a++ / ++cmd+a++ | Select all |
 | ++delete++ / ++backspace++ | Delete selected clips or track |
+| ++shift+arrow-left++ / ++shift+arrow-right++ | Nudge selected clips one grid step earlier / later |
+| ++shift+arrow-up++ / ++shift+arrow-down++ | Move selected clips to the track above / below |
 | ++ctrl+e++ / ++cmd+e++ | Split / trim at cursor or selection |
 | ++ctrl+j++ / ++cmd+j++ | Join clips |
 | ++ctrl+b++ / ++cmd+b++ | Render clip to audio |

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,6 +104,8 @@ set(TEST_SOURCES
     test_string_table.cpp
     # Arrangement pointer hit tester (#1719)
     test_arrangement_hit_tester.cpp
+    # Keyboard clip nudging (#1957)
+    test_clip_nudge.cpp
     test_mono_note_processor.cpp
     test_sends_and_track_deletion.cpp
     # Internal track-to-track routing (issue #1690)
@@ -311,6 +313,7 @@ target_sources(magda_juce_tests PRIVATE
     test_section_scoped_device_ids_juce.cpp
     test_clip_inspector_juce.cpp
     test_multi_clip_resize_preview_juce.cpp
+    test_clip_nudge_juce.cpp
     test_multiband_curve_view_juce.cpp
     test_timeline_extreme_zoom_paint_juce.cpp
     test_arrange_beat_native_juce.cpp

--- a/tests/test_clip_nudge.cpp
+++ b/tests/test_clip_nudge.cpp
@@ -11,10 +11,10 @@ using namespace magda::interaction;
 
 namespace {
 
-HorizontalNudge horizontal(double anchorBeat, int direction, double grid = 1.0, bool snap = true) {
+HorizontalNudge horizontal(double anchorPos, int direction, double grid = 1.0, bool snap = true) {
     HorizontalNudge n;
-    n.anchorStartBeat = anchorBeat;
-    n.gridBeats = grid;
+    n.anchorPosition = anchorPos;
+    n.gridStep = grid;
     n.snapToGrid = snap;
     n.direction = direction;
     return n;
@@ -36,20 +36,20 @@ VerticalNudge vertical(int minIndex, int maxIndex, int trackCount, int direction
 // ============================================================================
 
 TEST_CASE("An on-grid clip moves a full grid step", "[clip_nudge]") {
-    REQUIRE(horizontalDeltaBeats(horizontal(4.0, 1)) == Approx(1.0));
-    REQUIRE(horizontalDeltaBeats(horizontal(4.0, -1)) == Approx(-1.0));
+    REQUIRE(horizontalDelta(horizontal(4.0, 1)) == Approx(1.0));
+    REQUIRE(horizontalDelta(horizontal(4.0, -1)) == Approx(-1.0));
 }
 
 TEST_CASE("The grid step sets the nudge distance", "[clip_nudge]") {
-    REQUIRE(horizontalDeltaBeats(horizontal(4.0, 1, 0.25)) == Approx(0.25));
-    REQUIRE(horizontalDeltaBeats(horizontal(8.0, -1, 4.0)) == Approx(-4.0));
+    REQUIRE(horizontalDelta(horizontal(4.0, 1, 0.25)) == Approx(0.25));
+    REQUIRE(horizontalDelta(horizontal(8.0, -1, 4.0)) == Approx(-4.0));
 }
 
 TEST_CASE("Floating-point residue on a grid line still moves a whole step", "[clip_nudge]") {
     // Repeated snapped moves leave anchors a hair off the line; treating that
     // as off-grid would nudge by an invisible fraction of a beat.
-    REQUIRE(horizontalDeltaBeats(horizontal(4.0 - 1e-12, 1)) == Approx(1.0).margin(1e-9));
-    REQUIRE(horizontalDeltaBeats(horizontal(4.0 + 1e-12, -1)) == Approx(-1.0).margin(1e-9));
+    REQUIRE(horizontalDelta(horizontal(4.0 - 1e-12, 1)) == Approx(1.0).margin(1e-9));
+    REQUIRE(horizontalDelta(horizontal(4.0 + 1e-12, -1)) == Approx(-1.0).margin(1e-9));
 }
 
 // ============================================================================
@@ -57,15 +57,15 @@ TEST_CASE("Floating-point residue on a grid line still moves a whole step", "[cl
 // ============================================================================
 
 TEST_CASE("An off-grid clip lands on the next grid line, not a full step out", "[clip_nudge]") {
-    REQUIRE(horizontalDeltaBeats(horizontal(0.5, 1)) == Approx(0.5));      // 0.5 -> 1.0
-    REQUIRE(horizontalDeltaBeats(horizontal(0.5, -1)) == Approx(-0.5));    // 0.5 -> 0.0
-    REQUIRE(horizontalDeltaBeats(horizontal(4.75, 1)) == Approx(0.25));    // 4.75 -> 5.0
-    REQUIRE(horizontalDeltaBeats(horizontal(4.75, -1)) == Approx(-0.75));  // 4.75 -> 4.0
+    REQUIRE(horizontalDelta(horizontal(0.5, 1)) == Approx(0.5));      // 0.5 -> 1.0
+    REQUIRE(horizontalDelta(horizontal(0.5, -1)) == Approx(-0.5));    // 0.5 -> 0.0
+    REQUIRE(horizontalDelta(horizontal(4.75, 1)) == Approx(0.25));    // 4.75 -> 5.0
+    REQUIRE(horizontalDelta(horizontal(4.75, -1)) == Approx(-0.75));  // 4.75 -> 4.0
 }
 
 TEST_CASE("With snap off, an off-grid clip keeps its offset", "[clip_nudge]") {
-    REQUIRE(horizontalDeltaBeats(horizontal(0.5, 1, 1.0, false)) == Approx(1.0));
-    REQUIRE(horizontalDeltaBeats(horizontal(4.75, -1, 1.0, false)) == Approx(-1.0));
+    REQUIRE(horizontalDelta(horizontal(0.5, 1, 1.0, false)) == Approx(1.0));
+    REQUIRE(horizontalDelta(horizontal(4.75, -1, 1.0, false)) == Approx(-1.0));
 }
 
 // ============================================================================
@@ -73,17 +73,32 @@ TEST_CASE("With snap off, an off-grid clip keeps its offset", "[clip_nudge]") {
 // ============================================================================
 
 TEST_CASE("A clip near the start clamps flush against beat 0", "[clip_nudge]") {
-    REQUIRE(horizontalDeltaBeats(horizontal(0.4, -1, 1.0, false)) == Approx(-0.4));
+    REQUIRE(horizontalDelta(horizontal(0.4, -1, 1.0, false)) == Approx(-0.4));
 }
 
 TEST_CASE("A clip already at beat 0 refuses to move earlier", "[clip_nudge]") {
-    REQUIRE(horizontalDeltaBeats(horizontal(0.0, -1)) == Approx(0.0));
-    REQUIRE(horizontalDeltaBeats(horizontal(0.0, -1, 1.0, false)) == Approx(0.0));
+    REQUIRE(horizontalDelta(horizontal(0.0, -1)) == Approx(0.0));
+    REQUIRE(horizontalDelta(horizontal(0.0, -1, 1.0, false)) == Approx(0.0));
 }
 
 TEST_CASE("A degenerate grid refuses to move", "[clip_nudge]") {
-    REQUIRE(horizontalDeltaBeats(horizontal(4.0, 1, 0.0)) == Approx(0.0));
-    REQUIRE(horizontalDeltaBeats(horizontal(4.0, 0)) == Approx(0.0));
+    REQUIRE(horizontalDelta(horizontal(4.0, 1, 0.0)) == Approx(0.0));
+    REQUIRE(horizontalDelta(horizontal(4.0, 0)) == Approx(0.0));
+}
+
+// ============================================================================
+// Horizontal: the model is unit-agnostic
+// ============================================================================
+
+TEST_CASE("The same rules hold in the seconds domain", "[clip_nudge]") {
+    // Seconds display mode feeds seconds and a second-based interval rather
+    // than beats. At 90 BPM / 40 px per beat the drawn grid is 1 s while the
+    // beat fraction is 2 beats (1.333 s), so the caller must pass the interval
+    // the ruler actually shows — and get a seconds delta straight back.
+    REQUIRE(horizontalDelta(horizontal(2.0, 1, 1.0)) == Approx(1.0));    // 2.0s -> 3.0s
+    REQUIRE(horizontalDelta(horizontal(2.4, 1, 1.0)) == Approx(0.6));    // 2.4s -> 3.0s
+    REQUIRE(horizontalDelta(horizontal(2.4, -1, 1.0)) == Approx(-0.4));  // 2.4s -> 2.0s
+    REQUIRE(horizontalDelta(horizontal(1.0, 1, 0.5)) == Approx(0.5));    // 500 ms grid
 }
 
 // ============================================================================

--- a/tests/test_clip_nudge.cpp
+++ b/tests/test_clip_nudge.cpp
@@ -1,0 +1,121 @@
+// Tests for the keyboard clip-nudge model (#1957): the pure delta rules behind
+// Shift+arrow clip moves. Everything here runs headless on plain data.
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/ui/interaction/ClipNudge.hpp"
+
+using Catch::Approx;
+using namespace magda::interaction;
+
+namespace {
+
+HorizontalNudge horizontal(double anchorBeat, int direction, double grid = 1.0, bool snap = true) {
+    HorizontalNudge n;
+    n.anchorStartBeat = anchorBeat;
+    n.gridBeats = grid;
+    n.snapToGrid = snap;
+    n.direction = direction;
+    return n;
+}
+
+VerticalNudge vertical(int minIndex, int maxIndex, int trackCount, int direction) {
+    VerticalNudge n;
+    n.minTrackIndex = minIndex;
+    n.maxTrackIndex = maxIndex;
+    n.trackCount = trackCount;
+    n.direction = direction;
+    return n;
+}
+
+}  // namespace
+
+// ============================================================================
+// Horizontal: on-grid clips
+// ============================================================================
+
+TEST_CASE("An on-grid clip moves a full grid step", "[clip_nudge]") {
+    REQUIRE(horizontalDeltaBeats(horizontal(4.0, 1)) == Approx(1.0));
+    REQUIRE(horizontalDeltaBeats(horizontal(4.0, -1)) == Approx(-1.0));
+}
+
+TEST_CASE("The grid step sets the nudge distance", "[clip_nudge]") {
+    REQUIRE(horizontalDeltaBeats(horizontal(4.0, 1, 0.25)) == Approx(0.25));
+    REQUIRE(horizontalDeltaBeats(horizontal(8.0, -1, 4.0)) == Approx(-4.0));
+}
+
+TEST_CASE("Floating-point residue on a grid line still moves a whole step", "[clip_nudge]") {
+    // Repeated snapped moves leave anchors a hair off the line; treating that
+    // as off-grid would nudge by an invisible fraction of a beat.
+    REQUIRE(horizontalDeltaBeats(horizontal(4.0 - 1e-12, 1)) == Approx(1.0).margin(1e-9));
+    REQUIRE(horizontalDeltaBeats(horizontal(4.0 + 1e-12, -1)) == Approx(-1.0).margin(1e-9));
+}
+
+// ============================================================================
+// Horizontal: off-grid clips
+// ============================================================================
+
+TEST_CASE("An off-grid clip lands on the next grid line, not a full step out", "[clip_nudge]") {
+    REQUIRE(horizontalDeltaBeats(horizontal(0.5, 1)) == Approx(0.5));      // 0.5 -> 1.0
+    REQUIRE(horizontalDeltaBeats(horizontal(0.5, -1)) == Approx(-0.5));    // 0.5 -> 0.0
+    REQUIRE(horizontalDeltaBeats(horizontal(4.75, 1)) == Approx(0.25));    // 4.75 -> 5.0
+    REQUIRE(horizontalDeltaBeats(horizontal(4.75, -1)) == Approx(-0.75));  // 4.75 -> 4.0
+}
+
+TEST_CASE("With snap off, an off-grid clip keeps its offset", "[clip_nudge]") {
+    REQUIRE(horizontalDeltaBeats(horizontal(0.5, 1, 1.0, false)) == Approx(1.0));
+    REQUIRE(horizontalDeltaBeats(horizontal(4.75, -1, 1.0, false)) == Approx(-1.0));
+}
+
+// ============================================================================
+// Horizontal: the start of the timeline
+// ============================================================================
+
+TEST_CASE("A clip near the start clamps flush against beat 0", "[clip_nudge]") {
+    REQUIRE(horizontalDeltaBeats(horizontal(0.4, -1, 1.0, false)) == Approx(-0.4));
+}
+
+TEST_CASE("A clip already at beat 0 refuses to move earlier", "[clip_nudge]") {
+    REQUIRE(horizontalDeltaBeats(horizontal(0.0, -1)) == Approx(0.0));
+    REQUIRE(horizontalDeltaBeats(horizontal(0.0, -1, 1.0, false)) == Approx(0.0));
+}
+
+TEST_CASE("A degenerate grid refuses to move", "[clip_nudge]") {
+    REQUIRE(horizontalDeltaBeats(horizontal(4.0, 1, 0.0)) == Approx(0.0));
+    REQUIRE(horizontalDeltaBeats(horizontal(4.0, 0)) == Approx(0.0));
+}
+
+// ============================================================================
+// Vertical
+// ============================================================================
+
+TEST_CASE("A clip in the middle of the stack moves one track either way", "[clip_nudge]") {
+    REQUIRE(verticalTrackDelta(vertical(2, 2, 5, 1)) == 1);
+    REQUIRE(verticalTrackDelta(vertical(2, 2, 5, -1)) == -1);
+}
+
+TEST_CASE("The selection moves as a block or not at all", "[clip_nudge]") {
+    // Spread over tracks 0..2 of 4: down is fine, up would clamp the topmost
+    // clip and collapse the spread.
+    REQUIRE(verticalTrackDelta(vertical(0, 2, 4, 1)) == 1);
+    REQUIRE(verticalTrackDelta(vertical(0, 2, 4, -1)) == 0);
+    REQUIRE(verticalTrackDelta(vertical(1, 3, 4, 1)) == 0);
+}
+
+TEST_CASE("Clips on the end tracks refuse to move off the stack", "[clip_nudge]") {
+    REQUIRE(verticalTrackDelta(vertical(0, 0, 3, -1)) == 0);
+    REQUIRE(verticalTrackDelta(vertical(2, 2, 3, 1)) == 0);
+}
+
+TEST_CASE("A single track leaves nowhere to go", "[clip_nudge]") {
+    REQUIRE(verticalTrackDelta(vertical(0, 0, 1, 1)) == 0);
+    REQUIRE(verticalTrackDelta(vertical(0, 0, 1, -1)) == 0);
+}
+
+TEST_CASE("Out-of-range input refuses to move", "[clip_nudge]") {
+    REQUIRE(verticalTrackDelta(vertical(-1, 1, 3, 1)) == 0);
+    REQUIRE(verticalTrackDelta(vertical(0, 3, 3, -1)) == 0);
+    REQUIRE(verticalTrackDelta(vertical(0, 0, 0, 1)) == 0);
+    REQUIRE(verticalTrackDelta(vertical(1, 1, 3, 0)) == 0);
+}

--- a/tests/test_clip_nudge_juce.cpp
+++ b/tests/test_clip_nudge_juce.cpp
@@ -87,6 +87,10 @@ class ClipNudgeJuceTest final : public juce::UnitTest {
     ClipNudgeJuceTest() : juce::UnitTest("Clip Nudge Tests", "magda") {}
 
     void runTest() override {
+        testAdjacentSelectedClipsSurviveANudge();
+        testAdjacentSelectedClipsSurviveAVerticalNudge();
+        testFrozenTracksRefuseNudges();
+        testSecondsModeFollowsTheDisplayedGrid();
         testHorizontalNudgeMovesSelection();
         testHorizontalNudgeKeepsSelectionSpacing();
         testHorizontalNudgeIsOneUndoStepPerPress();
@@ -97,6 +101,126 @@ class ClipNudgeJuceTest final : public juce::UnitTest {
     }
 
   private:
+    // Each MoveClipCommand commits immediately and ClipManager resolves
+    // overlaps against every other clip on the track, selected or not. Without
+    // ordering the moves back-to-front, the leader lands on its still-unmoved
+    // neighbour and deletes it — and which one survived came down to
+    // unordered_set iteration order.
+    void testAdjacentSelectedClipsSurviveANudge() {
+        beginTest("Nudging two touching selected clips does not destroy either");
+
+        magda::test::runWithCleanJuceState([this] {
+            NudgeFixture f;
+            const ClipId first = f.addClip(f.topTrack, 0.0, 4.0);   // 0..4
+            const ClipId second = f.addClip(f.topTrack, 4.0, 4.0);  // 4..8
+            SelectionManager::getInstance().selectClips({first, second});
+
+            expect(f.panel.nudgeSelectedClipsHorizontally(1), "nudge later reported no move");
+            expect(ClipManager::getInstance().getClip(first) != nullptr,
+                   "leading clip was destroyed");
+            expect(ClipManager::getInstance().getClip(second) != nullptr,
+                   "trailing clip was destroyed by the clip moving into it");
+            expectNear(*this, startBeatOf(first), 1.0, "leading clip start");
+            expectNear(*this, startBeatOf(second), 5.0, "trailing clip start");
+
+            // ...and the mirror case travelling the other way.
+            expect(f.panel.nudgeSelectedClipsHorizontally(-1), "nudge earlier reported no move");
+            expect(ClipManager::getInstance().getClip(first) != nullptr,
+                   "leading clip was destroyed moving back");
+            expect(ClipManager::getInstance().getClip(second) != nullptr,
+                   "trailing clip was destroyed moving back");
+            expectNear(*this, startBeatOf(first), 0.0, "leading clip start after moving back");
+            expectNear(*this, startBeatOf(second), 4.0, "trailing clip start after moving back");
+        });
+    }
+
+    void testAdjacentSelectedClipsSurviveAVerticalNudge() {
+        beginTest("Moving a stacked selection across tracks does not destroy either clip");
+
+        magda::test::runWithCleanJuceState([this] {
+            NudgeFixture f;
+            // Same time span on neighbouring tracks: moving the upper one down
+            // lands it exactly on the lower one.
+            const ClipId upper = f.addClip(f.topTrack, 4.0, 4.0);
+            const ClipId lower = f.addClip(f.middleTrack, 4.0, 4.0);
+            SelectionManager::getInstance().selectClips({upper, lower});
+
+            expect(f.panel.nudgeSelectedClipsToAdjacentTrack(1), "nudge down reported no move");
+            expect(ClipManager::getInstance().getClip(upper) != nullptr,
+                   "upper clip was destroyed");
+            expect(ClipManager::getInstance().getClip(lower) != nullptr,
+                   "lower clip was destroyed by the clip moving onto it");
+            expect(trackOf(upper) == f.middleTrack, "upper clip should have moved down one track");
+            expect(trackOf(lower) == f.bottomTrack, "lower clip should have moved down one track");
+        });
+    }
+
+    void testFrozenTracksRefuseNudges() {
+        beginTest("Frozen tracks are refused as nudge sources and destinations");
+
+        magda::test::runWithCleanJuceState([this] {
+            NudgeFixture f;
+            auto& trackManager = TrackManager::getInstance();
+            const ClipId onFrozen = f.addClip(f.topTrack, 4.0);
+            if (auto* track = trackManager.getTrack(f.topTrack))
+                track->frozen = true;
+            SelectionManager::getInstance().selectClips({onFrozen});
+
+            expect(!f.panel.nudgeSelectedClipsHorizontally(1),
+                   "a clip on a frozen track must not move along the timeline");
+            expectNear(*this, startBeatOf(onFrozen), 4.0, "frozen clip start");
+            expect(!f.panel.nudgeSelectedClipsToAdjacentTrack(1),
+                   "a clip on a frozen track must not change track");
+            expect(trackOf(onFrozen) == f.topTrack, "frozen clip track");
+
+            // A frozen track is skipped as a destination too, so the clip below
+            // it steps past rather than into it.
+            if (auto* track = trackManager.getTrack(f.topTrack))
+                track->frozen = false;
+            if (auto* track = trackManager.getTrack(f.middleTrack))
+                track->frozen = true;
+
+            const ClipId mover = f.addClip(f.bottomTrack, 12.0);
+            SelectionManager::getInstance().selectClips({mover});
+            expect(f.panel.nudgeSelectedClipsToAdjacentTrack(-1), "nudge up reported no move");
+            expect(trackOf(mover) == f.topTrack, "clip should skip over the frozen track");
+        });
+    }
+
+    void testSecondsModeFollowsTheDisplayedGrid() {
+        beginTest("Seconds display mode nudges by the second-based grid, not the beat fraction");
+
+        magda::test::runWithCleanJuceState([this] {
+            NudgeFixture f;
+            // The two domains only disagree under auto-grid: a manual 1/4 grid
+            // resolves to the same distance either way, so this must run with
+            // auto-grid on, off 120 BPM, at a pinned zoom.
+            //
+            // 90 BPM, 40 px per beat: the seconds ladder picks the first
+            // interval at least 50 px wide (60t >= 50 -> 1 s = 1.5 beats),
+            // while the beat ladder picks the first power-of-two beat fraction
+            // that fits (40f >= 50 -> 2 beats). 1.5 is a value no beat-fraction
+            // grid can produce, so this only passes if the step came from the
+            // domain the ruler is actually drawing.
+            f.panel.setTempo(90.0);
+            f.controller.dispatch(SetTempoEvent{90.0});
+            f.controller.dispatch(SetZoomEvent{40.0});
+            f.controller.dispatch(SetTimeDisplayModeEvent{TimeDisplayMode::Seconds});
+            f.controller.dispatch(SetGridQuantizeEvent{true, 1, 4});
+
+            const auto& state = f.controller.getState();
+            expectNear(*this, state.getSnapInterval(), 1.0, "seconds grid interval");
+            expectNear(*this, state.getSnapBeatFraction(), 2.0, "beat grid fraction");
+
+            const ClipId clip = f.addClip(f.topTrack, 0.0);
+            SelectionManager::getInstance().selectClips({clip});
+
+            expect(f.panel.nudgeSelectedClipsHorizontally(1), "nudge reported no move");
+            expectNear(*this, startBeatOf(clip), 1.5,
+                       "clip should land on the next second-grid line, not the beat fraction");
+        });
+    }
+
     void testHorizontalNudgeMovesSelection() {
         beginTest("Shift+left/right moves the selected clip one grid step (#1957)");
 

--- a/tests/test_clip_nudge_juce.cpp
+++ b/tests/test_clip_nudge_juce.cpp
@@ -1,0 +1,224 @@
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <cmath>
+
+#include "JuceTestStateGuard.hpp"
+#include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/SelectionManager.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/core/UndoManager.hpp"
+#include "magda/daw/ui/components/tracks/TrackContentPanel.hpp"
+#include "magda/daw/ui/state/TimelineController.hpp"
+#include "magda/daw/ui/state/TimelineEvents.hpp"
+
+/**
+ * Keyboard clip nudging (#1957)
+ *
+ * Drives TrackContentPanel's real nudge entry points — the ones the Shift+arrow
+ * commands call — rather than the pure delta model underneath (that is covered
+ * headless in test_clip_nudge.cpp). What is pinned here is everything the pure
+ * model cannot see: which clips a nudge picks up, which tracks it steps
+ * through, and that each press is a single undo step.
+ */
+
+using namespace magda;
+
+namespace {
+
+constexpr double testTempoBPM = 120.0;
+constexpr double testZoomPixelsPerBeat = 40.0;
+
+double startBeatOf(ClipId clipId) {
+    const auto* clip = ClipManager::getInstance().getClip(clipId);
+    return clip ? clip->placement.startBeat : -1.0;
+}
+
+TrackId trackOf(ClipId clipId) {
+    const auto* clip = ClipManager::getInstance().getClip(clipId);
+    return clip ? clip->trackId : INVALID_TRACK_ID;
+}
+
+void expectNear(juce::UnitTest& test, double actual, double expected, const juce::String& label) {
+    constexpr double tolerance = 1.0e-6;
+    test.expect(std::abs(actual - expected) <= tolerance, label + " expected " +
+                                                              juce::String(expected, 6) + ", got " +
+                                                              juce::String(actual, 6));
+}
+
+// A panel over three audio tracks with a group track in the middle of the
+// stack, so vertical nudging has something it must step over.
+struct NudgeFixture {
+    TimelineController controller;
+    TrackContentPanel panel;
+    TrackId topTrack = INVALID_TRACK_ID;
+    TrackId groupTrack = INVALID_TRACK_ID;
+    TrackId middleTrack = INVALID_TRACK_ID;
+    TrackId bottomTrack = INVALID_TRACK_ID;
+
+    NudgeFixture() {
+        auto& trackManager = TrackManager::getInstance();
+        topTrack = trackManager.createTrack("Top", TrackType::Audio);
+        groupTrack = trackManager.createTrack("Group", TrackType::Group);
+        middleTrack = trackManager.createTrack("Middle", TrackType::Audio);
+        bottomTrack = trackManager.createTrack("Bottom", TrackType::Audio);
+
+        panel.setSize(2000, 400);
+        panel.setTempo(testTempoBPM);
+        panel.setZoom(testZoomPixelsPerBeat);
+        panel.setController(&controller);
+
+        // A fixed 1-beat grid: auto-grid would tie the nudge distance to zoom.
+        // Leaving auto seeds the manual grid from the last auto-computed value
+        // and ignores the requested fraction, so it takes a second dispatch —
+        // now already manual — to pin the grid to 1/4.
+        controller.dispatch(SetGridQuantizeEvent{false, 1, 4});
+        controller.dispatch(SetGridQuantizeEvent{false, 1, 4});
+        controller.dispatch(SetSnapEnabledEvent{true});
+    }
+
+    ClipId addClip(TrackId trackId, double startBeats, double lengthBeats = 4.0) {
+        return ClipManager::getInstance().createMidiClipBeats(trackId, startBeats, lengthBeats,
+                                                              ClipView::Arrangement);
+    }
+};
+
+class ClipNudgeJuceTest final : public juce::UnitTest {
+  public:
+    ClipNudgeJuceTest() : juce::UnitTest("Clip Nudge Tests", "magda") {}
+
+    void runTest() override {
+        testHorizontalNudgeMovesSelection();
+        testHorizontalNudgeKeepsSelectionSpacing();
+        testHorizontalNudgeIsOneUndoStepPerPress();
+        testUnselectedClipsStayPut();
+        testVerticalNudgeStepsOverGroupTracks();
+        testVerticalNudgeStopsAtTheEndOfTheStack();
+        testVerticalNudgeMovesTheSelectionAsABlock();
+    }
+
+  private:
+    void testHorizontalNudgeMovesSelection() {
+        beginTest("Shift+left/right moves the selected clip one grid step (#1957)");
+
+        magda::test::runWithCleanJuceState([this] {
+            NudgeFixture f;
+            const ClipId clip = f.addClip(f.topTrack, 8.0);
+            SelectionManager::getInstance().selectClips({clip});
+
+            expect(f.panel.nudgeSelectedClipsHorizontally(1), "nudge later reported no move");
+            expectNear(*this, startBeatOf(clip), 9.0, "start after nudging later");
+
+            expect(f.panel.nudgeSelectedClipsHorizontally(-1), "nudge earlier reported no move");
+            expectNear(*this, startBeatOf(clip), 8.0, "start after nudging back");
+        });
+    }
+
+    void testHorizontalNudgeKeepsSelectionSpacing() {
+        beginTest("A multi-clip nudge moves every clip by the same delta");
+
+        magda::test::runWithCleanJuceState([this] {
+            NudgeFixture f;
+            // Deliberately off-grid: the anchor snaps to the grid and the rest
+            // travel by its delta, so the gap between them survives.
+            const ClipId early = f.addClip(f.topTrack, 0.5);
+            const ClipId late = f.addClip(f.middleTrack, 6.25);
+            SelectionManager::getInstance().selectClips({early, late});
+
+            expect(f.panel.nudgeSelectedClipsHorizontally(1), "nudge reported no move");
+            expectNear(*this, startBeatOf(early), 1.0, "anchor clip snapped to the grid");
+            expectNear(*this, startBeatOf(late), 6.75, "trailing clip kept its offset");
+        });
+    }
+
+    void testHorizontalNudgeIsOneUndoStepPerPress() {
+        beginTest("Each nudge is its own undo step");
+
+        magda::test::runWithCleanJuceState([this] {
+            NudgeFixture f;
+            const ClipId clip = f.addClip(f.topTrack, 4.0);
+            SelectionManager::getInstance().selectClips({clip});
+
+            f.panel.nudgeSelectedClipsHorizontally(1);
+            f.panel.nudgeSelectedClipsHorizontally(1);
+            expectNear(*this, startBeatOf(clip), 6.0, "start after two nudges");
+
+            auto& undoManager = UndoManager::getInstance();
+            expect(undoManager.undo(), "first undo failed");
+            expectNear(*this, startBeatOf(clip), 5.0, "one undo should step back once, not twice");
+            expect(undoManager.undo(), "second undo failed");
+            expectNear(*this, startBeatOf(clip), 4.0, "start after undoing both nudges");
+        });
+    }
+
+    void testUnselectedClipsStayPut() {
+        beginTest("A nudge only touches the selection");
+
+        magda::test::runWithCleanJuceState([this] {
+            NudgeFixture f;
+            const ClipId selected = f.addClip(f.topTrack, 4.0);
+            const ClipId untouched = f.addClip(f.middleTrack, 4.0);
+            SelectionManager::getInstance().selectClips({selected});
+
+            f.panel.nudgeSelectedClipsHorizontally(1);
+            expectNear(*this, startBeatOf(selected), 5.0, "selected clip start");
+            expectNear(*this, startBeatOf(untouched), 4.0, "unselected clip start");
+        });
+    }
+
+    void testVerticalNudgeStepsOverGroupTracks() {
+        beginTest("Shift+down skips the group track (no clip timeline to land on)");
+
+        magda::test::runWithCleanJuceState([this] {
+            NudgeFixture f;
+            const ClipId clip = f.addClip(f.topTrack, 4.0);
+            SelectionManager::getInstance().selectClips({clip});
+
+            expect(f.panel.nudgeSelectedClipsToAdjacentTrack(1), "nudge down reported no move");
+            expect(trackOf(clip) == f.middleTrack, "clip should land on the track past the group");
+
+            expect(f.panel.nudgeSelectedClipsToAdjacentTrack(-1), "nudge up reported no move");
+            expect(trackOf(clip) == f.topTrack, "clip should come back to the top track");
+        });
+    }
+
+    void testVerticalNudgeStopsAtTheEndOfTheStack() {
+        beginTest("A clip on the end track refuses to move off the stack");
+
+        magda::test::runWithCleanJuceState([this] {
+            NudgeFixture f;
+            const ClipId clip = f.addClip(f.topTrack, 4.0);
+            SelectionManager::getInstance().selectClips({clip});
+
+            expect(!f.panel.nudgeSelectedClipsToAdjacentTrack(-1),
+                   "nudging above the first track should report no move");
+            expect(trackOf(clip) == f.topTrack, "clip should not have moved");
+        });
+    }
+
+    void testVerticalNudgeMovesTheSelectionAsABlock() {
+        beginTest("A spread selection moves whole or not at all");
+
+        magda::test::runWithCleanJuceState([this] {
+            NudgeFixture f;
+            const ClipId upper = f.addClip(f.middleTrack, 4.0);
+            const ClipId lower = f.addClip(f.bottomTrack, 4.0);
+            SelectionManager::getInstance().selectClips({upper, lower});
+
+            // The lower clip is already on the last track: moving down would
+            // clamp it and collapse the pair onto one track, so nothing moves.
+            expect(!f.panel.nudgeSelectedClipsToAdjacentTrack(1),
+                   "nudging down should report no move");
+            expect(trackOf(upper) == f.middleTrack, "upper clip should not have moved");
+            expect(trackOf(lower) == f.bottomTrack, "lower clip should not have moved");
+
+            // Up has room for both, so the pair travels together.
+            expect(f.panel.nudgeSelectedClipsToAdjacentTrack(-1), "nudging up reported no move");
+            expect(trackOf(upper) == f.topTrack, "upper clip should step up one track");
+            expect(trackOf(lower) == f.middleTrack, "lower clip should step up one track");
+        });
+    }
+};
+
+ClipNudgeJuceTest clipNudgeJuceTest;
+
+}  // namespace


### PR DESCRIPTION
Closes #1957.

Adds four Edit commands — **Nudge Clips Earlier/Later** and **Move Clips Up/Down** — bound to `Shift`+arrows, so a clip selection can be moved along the timeline and across tracks from the keyboard. All four are registered with the command manager, so they appear in **Preferences → Shortcuts → Keyboard** under Edit and remaps persist to `config.json`.

## Why Shift and not Alt

The issue cites Bitwig and Fender Studio (`Alt`+arrows) and Waveform (`Shift`+arrows). This uses Shift, because `Alt` on a clip body already means *duplicate* here — `Alt`+drag copies, `Alt+Shift`+drag ghost-copies, `Alt`+drag on a device copies it (`GestureRouter.cpp:294`). `Alt`+arrow would have left one modifier meaning copy under the mouse and move under the keyboard. Waveform uses Shift for exactly this action, and it leaves `Alt`+arrow open for a copy-nudge that matches `Alt`+drag later.

## Behaviour

- Both axes resolve to a **single delta applied to the whole selection**, the same contract a drag has, so a multi-clip selection keeps its internal spacing instead of collapsing.
- With snap on, the horizontal move **lands on the grid** rather than carrying an off-grid offset along forever; beat 0 clamps.
- The step comes from whichever grid is drawn — beat fractions in Bars/Beats, the 1/2/5-based second interval in Seconds mode.
- Vertical moves **step over** group, aux, master, chord and multi-out tracks (no clip timeline to land on) and **refuse rather than clamp** at the ends, so a spread selection can never collapse onto one track.
- Frozen tracks are refused as sources and skipped as destinations, matching what the mouse drag and context menu already enforce.
- Each press is one undo step — this needs an explicit compound scope, since consecutive `MoveClipCommand`s on the same clip otherwise merge.

The MIDI editor viewport now owns every arrow key. It previously tried to scroll on `Alt`+arrows but never did (JUCE's `ScrollBar` only matches unmodified arrows), and the piano roll declines `Shift`+arrows when no note is selected — which would have let the nudge move the very clip being edited.

## Review fixes (second commit)

An adversarial review caught three real defects in the first commit, all covered by regression tests:

- **Overlap resolution ran against clips in the same selection.** Each `MoveClipCommand` commits immediately and `moveClipBeats` resolves overlaps against every other clip on the track, selected or not — so nudging two touching selected clips let the leader trim or delete its still-unmoved neighbour, with the victim decided by `unordered_set` iteration order. Both axes now apply moves back-to-front relative to travel. This keeps the per-clip commands rather than adding an atomic bulk-move: ordering removes the only order-sensitive case, and resolution against clips outside the selection is already order-independent because those clips don't move.
- **Frozen tracks were editable from the keyboard**, bypassing a protection the mouse respects.
- **Seconds display mode nudged by the beat fraction.** At 90 BPM / 40 px per beat the ruler shows 1 s lines while the beat fraction is 2 beats, so clips landed between the lines.

Multi-out tracks were also dropped as destinations: they look like ordinary lanes, but `deactivateMultiOutPair()` erases the track without touching its clips, orphaning anything parked there when the user switches that output off.

## Testing

- `tests/test_clip_nudge.cpp` — 14 headless cases over the pure delta model.
- `tests/test_clip_nudge_juce.cpp` — 11 integration cases driving the panel's real entry points.
- The adjacent-clip cases were verified to **fail without** the ordering fix (trailing clip landed at 6.0 instead of 5.0, trimmed and displaced). The seconds-mode case asserts the two grids genuinely disagree (1 s vs 2 beats) before asserting the outcome, so it cannot pass under the old behaviour.
- Full Catch2 suite green: 1,663 cases / 163,343 assertions.

## Known gaps, deliberately out of scope

The mouse drag path shares the intra-selection overlap hazard and applies no track-type filter at all (`finishMultiClipDrag` just `jlimit`s the index), so dragging can still drop clips on group/aux/multi-out tracks. And `deactivateMultiOutPair` still orphans clips already sitting on a multi-out track in older projects. Both pre-date this change and are wider than this issue.
