### PR TITLE
Fix #1967: make the Levels hold figures resettable

### DIFF
--- a/magda/daw/audio/analysis/TrackMeasurer.hpp
+++ b/magda/daw/audio/analysis/TrackMeasurer.hpp
@@ -48,6 +48,9 @@ struct TrackMeasurementSnapshot {
     float plr = 0.0f;  ///< peak-to-loudness ratio: peak - integrated (LU)
     float psr = 0.0f;  ///< peak-to-short-term ratio: peak - short-term (LU)
 
+    bool plrValid = false;  ///< false while either peak or integrated is at the floor
+    bool psrValid = false;  ///< false while either peak or short-term is at the floor
+
     bool truePeakValid = false;  ///< false when oversampled true-peak is disabled
     bool valid = false;          ///< true once any signal has been processed
 };
@@ -215,9 +218,11 @@ class TrackMeasurer {
         // Dynamics: peak (true-peak if available, else sample peak) above loudness.
         const float peak =
             s.truePeakValid && s.truePeakDb > kSilenceDb ? s.truePeakDb : s.samplePeakDb;
-        if (peak > kSilenceDb && s.integratedLufs > kSilenceLufs)
+        s.plrValid = peak > kSilenceDb && s.integratedLufs > kSilenceLufs;
+        s.psrValid = peak > kSilenceDb && s.shortTermLufs > kSilenceLufs;
+        if (s.plrValid)
             s.plr = peak - s.integratedLufs;
-        if (peak > kSilenceDb && s.shortTermLufs > kSilenceLufs)
+        if (s.psrValid)
             s.psr = peak - s.shortTermLufs;
         return s;
     }

--- a/magda/daw/audio/plugins/LevelsPlugin.hpp
+++ b/magda/daw/audio/plugins/LevelsPlugin.hpp
@@ -57,6 +57,13 @@ class LevelsPlugin : public te::Plugin {
             active_.store(shouldMeasure, std::memory_order_release);
     }
 
+    /// Message thread. Clears the gating history and the peak holds, so the held
+    /// figures (integrated LUFS, true peak and the derived PLR) start again from
+    /// the current signal. Applied at the top of the next processed block.
+    void requestReset() noexcept {
+        pendingReset_.store(true, std::memory_order_release);
+    }
+
     /// Message thread. Latest measurements (lock-free).
     TrackMeasurementSnapshot getSnapshot() const noexcept {
         return measurer_.read();
@@ -73,12 +80,26 @@ class LevelsPlugin : public te::Plugin {
 
     void applyToBuffer(const te::PluginRenderContext& fc) override {
         // Transparent: read only, never modify the buffer or MIDI.
+        //
+        // Integrated LUFS, true peak and the derived PLR are hold figures by
+        // definition - they accumulate and never fall back on their own. Restart
+        // them whenever the transport rolls, the way hardware loudness meters do,
+        // so each pass reads the material just played rather than the whole
+        // session (issue #1967). Tracked ahead of the active_ gate so a meter
+        // shown mid-session still restarts on the next roll.
+        const bool playStarted = fc.isPlaying && !wasPlaying_;
+        wasPlaying_ = fc.isPlaying;
+        if (playStarted)
+            pendingReset_.store(true, std::memory_order_release);
+
         if (!active_.load(std::memory_order_acquire))
-            return;  // not showing: single branch, no measurement cost
+            return;  // not showing: no measurement cost beyond the transport edge
         if (!fc.destBuffer || fc.bufferNumSamples <= 0)
             return;
+        // Fresh integration window each time the meter opens, the transport rolls
+        // or the user hits Reset.
         if (pendingReset_.exchange(false, std::memory_order_acq_rel))
-            measurer_.reset();  // fresh integration window each time the meter opens
+            measurer_.reset();
 
         const int numCh = juce::jmin(fc.destBuffer->getNumChannels(), 2);
         if (numCh <= 0)
@@ -109,7 +130,8 @@ class LevelsPlugin : public te::Plugin {
   private:
     TrackMeasurer measurer_;
     std::atomic<bool> active_{false};        // measure only while the UI is showing
-    std::atomic<bool> pendingReset_{false};  // clear gating history on (re)open
+    std::atomic<bool> pendingReset_{false};  // clear gating history on (re)open / roll / Reset
+    bool wasPlaying_ = false;                // audio thread only: transport edge detection
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(LevelsPlugin)
 };

--- a/magda/daw/ui/components/chain/custom_ui/LevelsUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/LevelsUI.cpp
@@ -35,6 +35,15 @@ juce::Colour peakColour(float dbtp) {
 
 LevelsUI::LevelsUI() {
     setOpaque(false);
+
+    using DT = magda::DarkTheme;
+    resetButton_.setTooltip("Restart integrated loudness, peak hold and PLR");
+    resetButton_.setColour(juce::TextButton::buttonColourId,
+                           DT::getColour(DT::BACKGROUND).brighter(0.1f));
+    resetButton_.setColour(juce::TextButton::textColourOffId, DT::getColour(DT::TEXT_DIM));
+    resetButton_.onClick = [this] { resetMeasurement(); };
+    resetButton_.setEnabled(false);  // until a telemetry source is bound
+    addAndMakeVisible(resetButton_);
 }
 
 LevelsUI::~LevelsUI() {
@@ -50,8 +59,23 @@ void LevelsUI::setTelemetrySource(std::shared_ptr<LevelsTelemetrySource> telemet
     if (telemetry_ != nullptr)
         telemetry_->setActive(false);
     telemetry_ = std::move(telemetry);
+    resetButton_.setEnabled(telemetry_ != nullptr);
     updateActiveState();
     repaint();
+}
+
+void LevelsUI::resetMeasurement() {
+    if (telemetry_ != nullptr)
+        telemetry_->requestReset();
+    // Blank the cached readout straight away rather than showing the stale held
+    // values until the audio thread has applied the reset.
+    snapshot_ = {};
+    repaint();
+}
+
+void LevelsUI::resized() {
+    auto area = getLocalBounds().reduced(10, 8);
+    resetButton_.setBounds(area.removeFromBottom(kResetButtonH).removeFromRight(kResetButtonW));
 }
 
 void LevelsUI::visibilityChanged() {
@@ -89,8 +113,9 @@ void LevelsUI::paint(juce::Graphics& g) {
     const auto dim = DT::getColour(DT::TEXT_DIM);
     const auto primary = DT::getColour(DT::TEXT_PRIMARY);
 
-    // Three columns: loudness | dynamics/peak | stereo.
+    // Three columns: loudness | dynamics/peak | stereo, above the Reset strip.
     auto area = bounds.reduced(8.0f, 6.0f);
+    area.removeFromBottom(static_cast<float>(kResetButtonH));
     const float colW = area.getWidth() / 3.0f;
     auto loudCol = area.removeFromLeft(colW).reduced(4.0f, 0.0f);
     auto dynCol = area.removeFromLeft(colW).reduced(4.0f, 0.0f);
@@ -134,8 +159,12 @@ void LevelsUI::paint(juce::Graphics& g) {
     const float tp = s.truePeakValid ? s.truePeakDb : s.samplePeakDb;
     valueRow(dynCol, s.truePeakValid ? "True peak" : "Sample peak", fmtDb(tp), "dB",
              s.valid ? peakColour(tp) : primary, rowH);
-    valueRow(dynCol, "PLR", fmtLu(s.plr), "LU", primary, rowH * 0.8f);
-    valueRow(dynCol, "PSR", fmtLu(s.psr), "LU", dim.brighter(0.4f), rowH * 0.8f);
+    // PLR/PSR are only meaningful once both their terms are above the floor -
+    // show a dash rather than a misleading 0.0 while one of them is silent.
+    valueRow(dynCol, "PLR", s.plrValid ? fmtLu(s.plr) : juce::String("-"), "LU", primary,
+             rowH * 0.8f);
+    valueRow(dynCol, "PSR", s.psrValid ? fmtLu(s.psr) : juce::String("-"), "LU", dim.brighter(0.4f),
+             rowH * 0.8f);
 
     // Column 3: stereo (correlation bar + width).
     g.setColour(DT::getColour(DT::ACCENT_INFO));

--- a/magda/daw/ui/components/chain/custom_ui/LevelsUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/LevelsUI.cpp
@@ -4,6 +4,7 @@
 
 #include "audio/analysis/TrackMeasurer.hpp"
 #include "ui/themes/DarkTheme.hpp"
+#include "ui/themes/SmallButtonLookAndFeel.hpp"
 
 namespace magda::daw::ui {
 
@@ -38,9 +39,10 @@ LevelsUI::LevelsUI() {
 
     using DT = magda::DarkTheme;
     resetButton_.setTooltip("Restart integrated loudness, peak hold and PLR");
-    resetButton_.setColour(juce::TextButton::buttonColourId,
-                           DT::getColour(DT::BACKGROUND).brighter(0.1f));
+    resetButton_.setColour(juce::TextButton::buttonColourId, DT::getColour(DT::SURFACE));
     resetButton_.setColour(juce::TextButton::textColourOffId, DT::getColour(DT::TEXT_DIM));
+    resetButton_.setColour(juce::ComboBox::outlineColourId, DT::getColour(DT::BORDER));
+    resetButton_.setLookAndFeel(&SmallButtonLookAndFeel::getInstance());
     resetButton_.onClick = [this] { resetMeasurement(); };
     resetButton_.setEnabled(false);  // until a telemetry source is bound
     addAndMakeVisible(resetButton_);

--- a/magda/daw/ui/components/chain/custom_ui/LevelsUI.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/LevelsUI.hpp
@@ -21,7 +21,13 @@ class LevelsUI : public juce::Component, private juce::Timer {
 
     void setTelemetrySource(std::shared_ptr<LevelsTelemetrySource> telemetry);
 
+    /// Restart the held figures - integrated loudness, peak hold and PLR - so
+    /// they follow the signal down again (issue #1967). Also driven by the
+    /// Reset button and, plugin-side, by the transport rolling.
+    void resetMeasurement();
+
     void paint(juce::Graphics& g) override;
+    void resized() override;
     void visibilityChanged() override;
     void parentHierarchyChanged() override;
 
@@ -31,8 +37,11 @@ class LevelsUI : public juce::Component, private juce::Timer {
 
     std::shared_ptr<LevelsTelemetrySource> telemetry_;
     daw::audio::TrackMeasurementSnapshot snapshot_;
+    juce::TextButton resetButton_{"RESET"};
 
     static constexpr int kTimerHz = 30;
+    static constexpr int kResetButtonW = 52;
+    static constexpr int kResetButtonH = 16;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(LevelsUI)
 };

--- a/magda/daw/ui/components/chain/custom_ui/PluginTelemetrySources.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/PluginTelemetrySources.hpp
@@ -139,6 +139,11 @@ class LevelsPluginTelemetrySource final : public LevelsTelemetrySource {
             p->setActive(active);
     }
 
+    void requestReset() override {
+        if (auto* p = plugin())
+            p->requestReset();
+    }
+
     daw::audio::TrackMeasurementSnapshot snapshot() const override {
         auto* p = plugin();
         return p != nullptr ? p->getSnapshot() : daw::audio::TrackMeasurementSnapshot{};

--- a/magda/daw/ui/components/chain/custom_ui/TelemetrySources.hpp
+++ b/magda/daw/ui/components/chain/custom_ui/TelemetrySources.hpp
@@ -53,6 +53,8 @@ class LevelsTelemetrySource : public magda::DeviceTelemetrySource {
     }
 
     virtual void setActive(bool active) = 0;
+    /// Restart the held figures (integrated loudness, peak hold and PLR).
+    virtual void requestReset() = 0;
     virtual magda::daw::audio::TrackMeasurementSnapshot snapshot() const = 0;
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,8 +57,10 @@ set(TEST_SOURCES
     test_device_parameter_pagination.cpp
     test_device_ui_context.cpp
     test_levels_ui.cpp
-    # LevelsUI builds into magda_daw_app, so magda_tests needs its implementation directly.
+    # LevelsUI builds into magda_daw_app, so magda_tests needs its implementation
+    # directly - along with FontManager, which its themed button LookAndFeel pulls in.
     ../magda/daw/ui/components/chain/custom_ui/LevelsUI.cpp
+    ../magda/daw/ui/themes/FontManager.cpp
     test_momentary_param_button.cpp
     test_delta_solo.cpp
     test_waveform_editor_absolute_mode.cpp

--- a/tests/test_levels_ui.cpp
+++ b/tests/test_levels_ui.cpp
@@ -12,11 +12,17 @@ class CountingLevelsTelemetrySource final : public magda::daw::ui::LevelsTelemet
         activationStates.push_back(active);
     }
 
+    void requestReset() override {
+        ++resetRequests;
+    }
+
     magda::daw::audio::TrackMeasurementSnapshot snapshot() const override {
-        return {};
+        return held;
     }
 
     std::vector<bool> activationStates;
+    int resetRequests = 0;
+    magda::daw::audio::TrackMeasurementSnapshot held;
 };
 
 }  // namespace
@@ -49,4 +55,42 @@ TEST_CASE("LevelsUI keeps an unchanged telemetry source active", "[levels-ui][te
 
     REQUIRE(secondSource->activationStates.size() == 2);
     CHECK_FALSE(secondSource->activationStates.back());
+}
+
+TEST_CASE("LevelsUI reset forwards to the telemetry source and clears held values",
+          "[levels-ui][telemetry]") {
+    juce::ScopedJuceInitialiser_GUI gui;
+    juce::Component parent;
+    auto levels = std::make_unique<magda::daw::ui::LevelsUI>();
+    auto source = std::make_shared<CountingLevelsTelemetrySource>();
+
+    // Held figures the plugin would still be reporting after the signal stopped.
+    source->held.valid = true;
+    source->held.integratedLufs = -12.0f;
+    source->held.truePeakDb = -1.0f;
+    source->held.truePeakValid = true;
+    source->held.plr = 11.0f;
+    source->held.plrValid = true;
+
+    parent.addAndMakeVisible(*levels);
+    levels->setBounds(0, 0, 460, 160);
+    levels->setTelemetrySource(source);
+
+    // The Reset control must actually land inside the panel.
+    auto* resetButton = levels->getChildComponent(0);
+    REQUIRE(resetButton != nullptr);
+    CHECK(resetButton->isVisible());
+    CHECK(resetButton->isEnabled());
+    CHECK_FALSE(resetButton->getBounds().isEmpty());
+    CHECK(levels->getLocalBounds().contains(resetButton->getBounds()));
+
+    levels->resetMeasurement();
+
+    CHECK(source->resetRequests == 1);
+
+    // A reset with no source bound must be a no-op rather than a crash.
+    levels->setTelemetrySource(nullptr);
+    levels->resetMeasurement();
+
+    CHECK(source->resetRequests == 1);
 }

--- a/tests/test_track_measurer.cpp
+++ b/tests/test_track_measurer.cpp
@@ -148,6 +148,48 @@ TEST_CASE("TrackMeasurer - true peak is enabled-gated and >= sample peak", "[mea
     REQUIRE(s.truePeakDb >= s.samplePeakDb - 0.05f);
 }
 
+TEST_CASE("TrackMeasurer - PLR/PSR are flagged invalid until both terms have signal",
+          "[measurer]") {
+    TrackMeasurer m;
+    m.prepare(kSr, kBlock, false);
+
+    // Silence: no peak and no loudness, so neither ratio is meaningful.
+    feedSine(m, 1000.0, 0.0f, 0.0f, 1.0);
+    auto s = m.read();
+    REQUIRE_FALSE(s.plrValid);
+    REQUIRE_FALSE(s.psrValid);
+    REQUIRE(s.plr == Catch::Approx(0.0f));
+
+    feedSine(m, 1000.0, 0.5f, 0.5f, 4.0);
+    s = m.read();
+    REQUIRE(s.plrValid);
+    REQUIRE(s.psrValid);
+    REQUIRE(s.plr == Catch::Approx(s.samplePeakDb - s.integratedLufs).margin(0.01f));
+    REQUIRE(s.psr == Catch::Approx(s.samplePeakDb - s.shortTermLufs).margin(0.01f));
+}
+
+TEST_CASE("TrackMeasurer - reset drops a held peak back to the current signal", "[measurer]") {
+    TrackMeasurer m;
+    m.prepare(kSr, kBlock, false);
+
+    feedSine(m, 1000.0, 0.9f, 0.9f, 2.0);
+    const float loudPeak = m.read().samplePeakDb;
+    REQUIRE(loudPeak == Catch::Approx(-0.92f).margin(0.2f));
+
+    // A quieter signal cannot pull the peak hold (or the integrated loudness)
+    // down on its own - that is what makes the reset necessary (issue #1967).
+    feedSine(m, 1000.0, 0.1f, 0.1f, 2.0);
+    REQUIRE(m.read().samplePeakDb == Catch::Approx(loudPeak).margin(0.01f));
+    const float heldIntegrated = m.read().integratedLufs;
+
+    m.reset();
+    feedSine(m, 1000.0, 0.1f, 0.1f, 2.0);
+    const auto s = m.read();
+    REQUIRE(s.samplePeakDb == Catch::Approx(-20.0f).margin(0.2f));
+    REQUIRE(s.samplePeakDb < loudPeak - 10.0f);
+    REQUIRE(s.integratedLufs < heldIntegrated - 5.0f);
+}
+
 TEST_CASE("TrackMeasurer - reset clears state", "[measurer]") {
     TrackMeasurer m;
     m.prepare(kSr, kBlock, false);


### PR DESCRIPTION
Fixes #1967.

## The problem

Three of the Levels readings held their largest value and never came back down as the signal dropped, while the others tracked correctly:

- **Integrated LUFS** — a gated accumulation over all history since the last reset (BS.1770), so it never decays.
- **True peak** — a CAS max-hold, so it only ever rises.
- **PLR** — peak − integrated, so it inherits both.

Momentary, Short-term, Correlation and Width are windowed, which is why they behaved. The three hold figures are correct by definition; the real gap was that there was no way to restart them. The only thing that cleared them was collapsing and re-opening the device UI.

## The fix

- `LevelsPlugin` gains `requestReset()`, plus an automatic restart on the transport's play rising edge (`fc.isPlaying`), the way hardware loudness meters restart on roll — so each pass reads the material just played rather than the whole session. The edge is tracked ahead of the `active_` gate so a meter shown mid-session still restarts on the next roll.
- `LevelsUI` gains a **RESET** button for the live-monitoring case where the transport never rolls. It clears the cached readout immediately, and the columns lay out above the button strip.
- PSR was showing a flat `0.0` whenever short-term sat at the floor (visible in the issue screenshot). The snapshot now carries `plrValid`/`psrValid` and the panel draws a dash instead of a misleading zero.

The button is styled through `SmallButtonLookAndFeel`, like the other small buttons in the chain — Inter UI bold at 9pt, 3px corners, `BORDER` outline on `SURFACE`. It initially picked up JUCE's stock look and feel; that is fixed in the second commit.

## Tests

- `test_track_measurer.cpp` — the `plrValid`/`psrValid` flags, and that a quieter signal cannot pull a held peak or the integrated loudness down on its own until `reset()`.
- `test_levels_ui.cpp` — reset forwarding through the telemetry source, the null-source no-op, and the button landing inside the panel.

Full suite passes: 1675 cases, 163k assertions (13 skipped for missing model env vars). The `juce_Timer.cpp:99` assertion at the end of a full run is pre-existing — it fires with these tests excluded too.

One knock-on: `magda_tests` compiles `LevelsUI.cpp` directly rather than linking the app library, so `FontManager.cpp` had to join `TEST_SOURCES` — the themed LookAndFeel pulls it in.

## Verification

The panel was rendered offscreen to check the button and the PLR/PSR dashes rather than eyeballing the code. Worth a look on a real signal to confirm the transport-roll restart feels right in practice.
