### PR TITLE
Feat/launchkey note mode

### DIFF
--- a/magda/daw/api/track_api.hpp
+++ b/magda/daw/api/track_api.hpp
@@ -35,6 +35,7 @@ class TrackApi {
     virtual void setTrackPan(TrackId trackId, float pan, bool fromAutomation = false) = 0;
     virtual void setTrackMuted(TrackId trackId, bool muted) = 0;
     virtual void setTrackSoloed(TrackId trackId, bool soloed) = 0;
+    virtual void setTrackRecordArmed(TrackId trackId, bool armed) = 0;
 
     virtual DeviceId addDeviceToTrack(TrackId trackId, const DeviceInfo& device) = 0;
     virtual DeviceId addDeviceToChain(TrackId trackId, RackId rackId, ChainId chainId,

--- a/magda/daw/api/track_api_live.cpp
+++ b/magda/daw/api/track_api_live.cpp
@@ -56,6 +56,10 @@ void TrackApiLive::setTrackMuted(TrackId trackId, bool muted) {
     TrackManager::getInstance().setTrackMuted(trackId, muted);
 }
 
+void TrackApiLive::setTrackRecordArmed(TrackId trackId, bool armed) {
+    TrackManager::getInstance().setTrackRecordArmed(trackId, armed);
+}
+
 void TrackApiLive::setTrackSoloed(TrackId trackId, bool soloed) {
     TrackManager::getInstance().setTrackSoloed(trackId, soloed);
 }

--- a/magda/daw/api/track_api_live.hpp
+++ b/magda/daw/api/track_api_live.hpp
@@ -23,6 +23,7 @@ class TrackApiLive : public TrackApi {
     void setTrackPan(TrackId trackId, float pan, bool fromAutomation) override;
     void setTrackMuted(TrackId trackId, bool muted) override;
     void setTrackSoloed(TrackId trackId, bool soloed) override;
+    void setTrackRecordArmed(TrackId trackId, bool armed) override;
 
     DeviceId addDeviceToTrack(TrackId trackId, const DeviceInfo& device) override;
     DeviceId addDeviceToChain(TrackId trackId, RackId rackId, ChainId chainId,

--- a/magda/daw/audio/controllers/ControllerParamWriter.cpp
+++ b/magda/daw/audio/controllers/ControllerParamWriter.cpp
@@ -37,9 +37,39 @@ void DefaultControllerParamWriter::write(const ResolveResult& resolved, float va
             break;
         case ControlTarget::Kind::TrackVolume:
         case ControlTarget::Kind::TrackPan:
+            writeTrackLevel(resolved.target, clamped);
+            break;
         case ControlTarget::Kind::SendLevel:
         case ControlTarget::Kind::Tempo:
+            // Not reachable from controller bindings yet: no resolver produces
+            // either kind for a control surface. Wire them here alongside
+            // writeTrackLevel when one does.
             break;
+    }
+}
+
+// Track / master volume and pan. Deliberately routed through TrackManager
+// rather than the te::AutomatableParameter: the setters keep MAGDA's TrackInfo
+// cache in sync and notify the inspector, mixer and headers, and
+// setTrackVolume forwards MASTER_TRACK_ID to setMasterVolume, so
+// @master.volume lands on the edit's master volume plugin without special
+// casing here.
+void DefaultControllerParamWriter::writeTrackLevel(const ControlTarget& target, float clamped) {
+    const auto trackId = target.devicePath.trackId;
+    if (trackId == INVALID_TRACK_ID)
+        return;
+
+    // Same normalized -> real conversion the automation engine applies, so a
+    // controller fader and an automation curve resolve to identical values.
+    const ParameterInfo info = getParameterInfoForTarget(target);
+    const float real = ParameterUtils::normalizedToReal(clamped, info);
+
+    auto& trackMgr = TrackManager::getInstance();
+    if (target.kind == ControlTarget::Kind::TrackVolume) {
+        // The fader range is in dB; TrackManager expects linear gain.
+        trackMgr.setTrackVolume(trackId, std::pow(10.0f, real / 20.0f));
+    } else {
+        trackMgr.setTrackPan(trackId, real);
     }
 }
 

--- a/magda/daw/audio/controllers/ControllerParamWriter.hpp
+++ b/magda/daw/audio/controllers/ControllerParamWriter.hpp
@@ -56,6 +56,7 @@ class DefaultControllerParamWriter : public ControllerParamWriter {
     void writePluginParam(const ControlTarget& target, float clamped);
     void writeMacro(const ControlTarget& target, float clamped);
     void writeModParam(const ControlTarget& target, float clamped);
+    void writeTrackLevel(const ControlTarget& target, float clamped);
 
     AudioBridge& bridge_;
 };

--- a/magda/daw/core/aliases/ResolverRegistry.cpp
+++ b/magda/daw/core/aliases/ResolverRegistry.cpp
@@ -79,6 +79,7 @@ std::optional<ControlTarget> SelectedTrackVolumeResolver::resolve(
 
     // Track volume is represented as a track-level path with paramIndex 0
     ControlTarget t;
+    t.kind = ControlTarget::Kind::TrackVolume;
     t.devicePath = ChainNodePath::trackLevel(trackId);
     t.paramIndex = 0;  // volume
     return t;
@@ -95,6 +96,7 @@ std::optional<ControlTarget> SelectedTrackPanResolver::resolve(
         return std::nullopt;
 
     ControlTarget t;
+    t.kind = ControlTarget::Kind::TrackPan;
     t.devicePath = ChainNodePath::trackLevel(trackId);
     t.paramIndex = 1;  // pan
     return t;
@@ -107,6 +109,7 @@ std::optional<ControlTarget> SelectedTrackPanResolver::resolve(
 std::optional<ControlTarget> MasterVolumeResolver::resolve(const juce::StringPairArray& /*args*/,
                                                            const ChainContext& /*ctx*/) const {
     ControlTarget t;
+    t.kind = ControlTarget::Kind::TrackVolume;
     t.devicePath = ChainNodePath::trackLevel(MASTER_TRACK_ID);
     t.paramIndex = 0;  // volume
     return t;
@@ -119,6 +122,7 @@ std::optional<ControlTarget> MasterVolumeResolver::resolve(const juce::StringPai
 std::optional<ControlTarget> MasterPanResolver::resolve(const juce::StringPairArray& /*args*/,
                                                         const ChainContext& /*ctx*/) const {
     ControlTarget t;
+    t.kind = ControlTarget::Kind::TrackPan;
     t.devicePath = ChainNodePath::trackLevel(MASTER_TRACK_ID);
     t.paramIndex = 1;  // pan
     return t;

--- a/magda/scripting/MagdaApiLuaBindings.cpp
+++ b/magda/scripting/MagdaApiLuaBindings.cpp
@@ -383,6 +383,32 @@ int lua_tracks_set_soloed(lua_State* L) {
     return 0;
 }
 
+// magda.tracks.set_record_armed(trackId, bool) — the write side of the
+// `record_armed` field already exposed on the track table. Tracks that take no
+// external input (Aux, Group) silently ignore this, matching the UI.
+int lua_tracks_set_record_armed(lua_State* L) {
+    auto* api = getApi(L);
+    auto id = static_cast<TrackId>(luaL_checkinteger(L, 1));
+    luaL_checktype(L, 2, LUA_TBOOLEAN);
+    api->tracks().setTrackRecordArmed(id, lua_toboolean(L, 2) != 0);
+    return 0;
+}
+
+// magda.tracks.master() — the master track table. Master is stored apart from
+// the ordinary tracks, so it never appears in magda.tracks.list(); this is the
+// only way a script can reach its id. The usual setters accept that id:
+// set_volume / set_pan route it to the master channel internally.
+int lua_tracks_master(lua_State* L) {
+    auto* api = getApi(L);
+    const TrackInfo* t = api->tracks().getTrack(MASTER_TRACK_ID);
+    if (t == nullptr) {
+        lua_pushnil(L);
+        return 1;
+    }
+    pushTrackTable(L, *t);
+    return 1;
+}
+
 // ---- clips -----------------------------------------------------------------
 
 void pushClipTable(lua_State* L, const ClipInfo& c) {
@@ -951,6 +977,8 @@ const FnReg kTrackFns[] = {
     {"set_pan", lua_tracks_set_pan},
     {"set_muted", lua_tracks_set_muted},
     {"set_soloed", lua_tracks_set_soloed},
+    {"set_record_armed", lua_tracks_set_record_armed},
+    {"master", lua_tracks_master},
     {nullptr, nullptr},
 };
 

--- a/manual/docs/reference/controller-profile-format.md
+++ b/manual/docs/reference/controller-profile-format.md
@@ -114,6 +114,10 @@ Drives the master bus volume. No args.
 
 Drives the master bus pan. No args.
 
+```json
+{ "controlId": "encoder_master_pan", "resolverKind": "master.pan", "args": {} }
+```
+
 ## Multiple profiles per controller
 
 A single piece of hardware doesn't have to be one profile. A Launchkey Mini might be useful in two different ways: knobs driving the focused device's macros, or knobs driving the selected track's volume / pan / sends. Each of those is a different **intent**, and each is its own profile JSON.

--- a/manual/docs/reference/lua-scripting.md
+++ b/manual/docs/reference/lua-scripting.md
@@ -107,13 +107,29 @@ Every function below lives under the global `magda` table. All are message-threa
 | `magda.tracks.create(name [, type])` | integer | Track id; `type` is `"audio"` (default), `"group"`, `"aux"`, `"master"`, or `"multi_out"` |
 | `magda.tracks.delete(id)` | — | |
 | `magda.tracks.count()` | integer | |
-| `magda.tracks.list()` | array of tables | Each table: `{ id, name, type, volume, pan, muted, soloed, record_armed, frozen }` |
+| `magda.tracks.list()` | array of tables | Each table: `{ id, name, type, volume, pan, muted, soloed, record_armed, frozen }`. Does not include the master track |
 | `magda.tracks.get(id)` | table or nil | Same shape as the list entries |
+| `magda.tracks.master()` | table or nil | The master track, which never appears in `list()` |
 | `magda.tracks.set_name(id, name)` | — | |
 | `magda.tracks.set_volume(id, value)` | — | Linear gain 0..1 |
 | `magda.tracks.set_pan(id, value)` | — | -1..1 |
 | `magda.tracks.set_muted(id, bool)` | — | |
 | `magda.tracks.set_soloed(id, bool)` | — | |
+| `magda.tracks.set_record_armed(id, bool)` | — | Ignored on tracks that take no external input (Aux, Group) |
+
+#### Reaching the master track
+
+The master is stored apart from the ordinary tracks, so it is deliberately absent
+from `magda.tracks.list()` and list positions stay aligned with what a control
+surface shows. Use `magda.tracks.master()` to get its id, then pass that id to
+the ordinary setters:
+
+```lua
+local master = magda.tracks.master()
+if master then
+  magda.tracks.set_volume(master.id, e.value / 127.0)
+end
+```
 
 ### `magda.clips`
 

--- a/resources/controllers/scripts/launchkey_mini_mk4.lua
+++ b/resources/controllers/scripts/launchkey_mini_mk4.lua
@@ -39,25 +39,55 @@ local function publish_session_view(sceneOffset, sceneCount)
   end
 end
 
+local function is_launchkey_port(port)
+  return port:lower():find("launchkey") ~= nil
+end
+
 local function is_daw_port(port)
-  return port:lower():find("launchkey") and port:lower():find("daw")
+  local p = port:lower()
+  return p:find("launchkey") ~= nil and p:find("daw") ~= nil
 end
 
 -- Output port name for sends (DAW Out). Resolved on first send.
+--
+-- macOS and Windows put "DAW" in the name of the second interface. Linux
+-- (ALSA) numbers the ports instead, so there is nothing to match on and the
+-- name check alone would silently return nil, taking the handshake, the pad
+-- LEDs and the display down with it. Fall back to the last Launchkey port,
+-- which is the DAW one on the SKUs I have seen.
+--
+-- Either way, setting the ports explicitly on the script's row in the
+-- Controllers dialog wins outright and skips all the guessing.
 local daw_out = nil
 local function find_daw_out()
   if daw_out then return daw_out end
+
   local configured = magda.midi.default_output()
   if configured and configured ~= "" then
     daw_out = configured
     return configured
   end
-  for _, name in ipairs(magda.midi.outputs()) do
+
+  local ports = magda.midi.outputs()
+  for _, name in ipairs(ports) do
     if is_daw_port(name) then
       daw_out = name
+      magda.log.info("[launchkey] DAW Out matched by name: "..name)
       return name
     end
   end
+
+  local fallback = nil
+  for _, name in ipairs(ports) do
+    if is_launchkey_port(name) then fallback = name end
+  end
+  if fallback then
+    daw_out = fallback
+    magda.log.warn("[launchkey] no port name contains 'DAW'; falling back to '"..fallback..
+                   "'. Set the script's ports explicitly if this is the wrong one.")
+    return fallback
+  end
+
   return nil
 end
 
@@ -170,6 +200,61 @@ local function pad_to_track_and_scene(note)
 end
 
 ----------------------------------------------------------------
+-- Pad modes: session (default) and note
+----------------------------------------------------------------
+-- Note mode is the Launchkey equivalent of the Launchpad MK1 script's
+-- User 1 / User 2 modes: the 16 pads stop launching clips and instead play
+-- the selected track's instrument.
+--
+-- This is purely script-side state. MAGDA has no concept of controller
+-- "modes" and neither does the device; the only thing that changes is what
+-- this script does with a pad press.
+local mode = "session"
+
+-- Button that toggles note mode. Every DAW-mode button reports as a CC on
+-- the DAW port, and DEBUG_LOG_EVENTS (near the bottom) prints all of them.
+-- If this default doesn't match a button on your unit, press the one you
+-- want and set this to the number the log prints.
+local USER_MODE_CC = 0x6C
+
+-- Lowest pad note, played by the bottom-left pad. 36 = C2.
+local NOTE_BASE = 36
+
+-- Raw pad note -> played note. Pitch rises left-to-right, bottom row first,
+-- so the lowest note sits at the bottom-left corner.
+--
+-- Worth knowing while testing: the device's own DAW-layout pad notes run the
+-- other way round, top row 96..103 and bottom row 112..119. So the raw notes
+-- put the LOW numbers at the TOP, which is exactly the inversion reported for
+-- the Launchpad MK1 in discussion #1944. If you ever hear this layout upside
+-- down, you are hearing the raw pad notes, not these.
+local function pad_to_note(padNote)
+  if padNote >= 0x70 and padNote <= 0x77 then
+    return NOTE_BASE + (padNote - 0x70)          -- bottom row: 36..43
+  elseif padNote >= 0x60 and padNote <= 0x67 then
+    return NOTE_BASE + 8 + (padNote - 0x60)      -- top row:    44..51
+  end
+  return nil
+end
+
+-- Pads currently held, keyed by raw pad note. Drives LED feedback and makes
+-- sure every injected note-on gets a matching note-off.
+local held_pads = {}
+
+-- Defined up here rather than beside the other mode helpers so on_unload can
+-- reach it: Lua locals are only visible to functions compiled after them.
+local function release_held_notes()
+  local track = magda.selection.track()
+  for padNote in pairs(held_pads) do
+    local note = pad_to_note(padNote)
+    if track and note then
+      magda.midi.inject_note_off(track, 1, note, 0)
+    end
+  end
+  held_pads = {}
+end
+
+----------------------------------------------------------------
 -- Transport row (DAW-port CCs on Channel 16)
 ----------------------------------------------------------------
 -- Mini's transport area in DAW mode (reference fig. 3 p. 9):
@@ -227,6 +312,8 @@ end
 
 function on_unload()
   magda.log.info("[launchkey] unloading")
+  -- Anything still held in note mode would sustain forever otherwise.
+  release_held_notes()
   -- Drop the automap sentinel bindings so the green dot disappears
   -- when the script is gone.
   magda.focused.clear_auto_map()
@@ -321,6 +408,41 @@ local function refresh_leds()
   end
 end
 
+-- Note mode: held pads light bright, the rest show a dim two-tone split so
+-- the pitch direction (bottom row low, top row high) is readable at a glance.
+local function refresh_note_leds()
+  local out = find_daw_out()
+  if not out then return end
+
+  for row = 0, 1 do
+    for col = 0, 7 do
+      local note = PAD_NOTES[row][col + 1]
+      if held_pads[note] then
+        send_palette(out, note, 1, 21)              -- held: bright green
+      elseif row == 1 then
+        send_palette(out, note, 1, 37)              -- bottom row (lower notes)
+      else
+        send_palette(out, note, 1, 41)              -- top row (higher notes)
+      end
+    end
+  end
+end
+
+local function set_mode(next_mode)
+  if mode == next_mode then return end
+  -- Drop anything still held before the pads change meaning, otherwise the
+  -- note-offs never arrive and the instrument sustains forever.
+  release_held_notes()
+  mode = next_mode
+  last_led = {}                     -- force a full repaint on the next tick
+  if mode == "session" then
+    publish_session_view(scene_offset, 2)
+  else
+    publish_session_view(0, 0)      -- clear the session highlight
+  end
+  magda.log.info("[launchkey] pad mode -> "..mode)
+end
+
 ----------------------------------------------------------------
 -- Encoder name display (small LCD shows macro names on knob touch)
 ----------------------------------------------------------------
@@ -409,7 +531,11 @@ local function refresh_transport_leds()
 end
 
 function on_tick(dt)
-  refresh_leds()
+  if mode == "session" then
+    refresh_leds()
+  else
+    refresh_note_leds()
+  end
   refresh_encoder_names()
   refresh_transport_leds()
 end
@@ -428,6 +554,34 @@ local function handle_pad_press(e)
     e.number, track, scene, tostring(clip)))
   if clip then
     magda.session.launch_clip(clip)
+  end
+end
+
+local function handle_note_pad(e)
+  local note = pad_to_note(e.number)
+  if not note then return end
+
+  local track = magda.selection.track()
+  if not track then
+    magda.log.warn("[launchkey] note mode: no track selected")
+    return
+  end
+
+  local isOn = (e.type == 'note_on' and e.value > 0)
+
+  -- Log the raw pad note next to the injected one. If you hear two notes per
+  -- pad, the device's raw note is reaching the track as well as this injected
+  -- one, which means the DAW port is not set as this script's Port In.
+  magda.log.info(string.format(
+    "[launchkey] note mode  raw=%d -> inject=%d %s",
+    e.number, note, isOn and "on" or "off"))
+
+  if isOn then
+    held_pads[e.number] = true
+    magda.midi.inject_note_on(track, e.channel, note, e.value)
+  else
+    held_pads[e.number] = nil
+    magda.midi.inject_note_off(track, e.channel, note, 0)
   end
 end
 
@@ -500,14 +654,22 @@ function on_midi(e)
       e.type, e.channel, e.number, e.value))
   end
 
-  if e.type == 'note_on' and e.value > 0 then
-    handle_pad_press(e)
+  if e.type == 'note_on' or e.type == 'note_off' then
+    if mode == "note" then
+      handle_note_pad(e)
+    elseif e.type == 'note_on' and e.value > 0 then
+      handle_pad_press(e)
+    end
   elseif e.type == 'cc' then
     -- Encoders in DAW + Plugin mode: CCs 21..28 (0x15..0x1C) drive
     -- macros 0..7 of the focused device. Bypasses the JSON profile,
     -- which can't see DAW-port CCs once the script enters DAW mode.
     if e.number >= 0x15 and e.number <= 0x1C then
       magda.focused.set_macro(e.number - 0x15, e.value / 127.0)
+    elseif e.number == USER_MODE_CC then
+      if e.value > 0 then
+        set_mode(mode == "note" and "session" or "note")
+      end
     else
       handle_transport_cc(e)
     end

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,6 +152,8 @@ set(TEST_SOURCES
     test_alias_registry.cpp
     # Parameter alias system tests (PR 3)
     test_alias_resolver.cpp
+    # Track / master level writes driven by control surfaces
+    test_track_level_control_writes.cpp
     # Parameter alias system tests (PR 4 -- AutoAliasGenerator)
     test_alias_auto_gen.cpp
     # Parameter alias system tests (PR 5 -- CuratedAliasLoader)
@@ -307,6 +309,7 @@ target_sources(magda_juce_tests PRIVATE
     test_arranger_launcher_switching_juce.cpp
     test_session_slot_recording_juce.cpp
     test_input_monitor_track_routing_juce.cpp
+    test_controller_track_level_write_juce.cpp
     test_track_midi_recording_preview_juce.cpp
     test_timeline_loop_activation_juce.cpp
     test_midi_signal_routing_juce.cpp

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -233,6 +233,10 @@ class MockTrackApi : public TrackApi {
         TrackId id;
         bool value;
     };
+    struct RecordArmWrite {
+        TrackId id;
+        bool value;
+    };
     struct NameWrite {
         TrackId id;
         juce::String value;
@@ -265,6 +269,7 @@ class MockTrackApi : public TrackApi {
     std::vector<PanWrite> panWrites;
     std::vector<MuteWrite> muteWrites;
     std::vector<SoloWrite> soloWrites;
+    std::vector<RecordArmWrite> recordArmWrites;
     std::vector<DeviceWrite> deviceWrites;
 
     TrackId nextId = 1;
@@ -330,6 +335,9 @@ class MockTrackApi : public TrackApi {
     }
     void setTrackSoloed(TrackId id, bool v) override {
         soloWrites.push_back({id, v});
+    }
+    void setTrackRecordArmed(TrackId id, bool v) override {
+        recordArmWrites.push_back({id, v});
     }
     DeviceId addDeviceToTrack(TrackId trackId, const DeviceInfo& device) override {
         deviceWrites.push_back({trackId, device});

--- a/tests/test_alias_resolver.cpp
+++ b/tests/test_alias_resolver.cpp
@@ -92,6 +92,10 @@ TEST_CASE("TargetResolver - resolve ResolverRef master.volume", "[aliases][resol
 
     auto result = resolver.resolve(Target{rr});
     REQUIRE(result.ok());
+    // The kind drives which branch ControllerParamWriter::write takes. Leaving
+    // it at the PluginParam default routed master volume into the plugin path,
+    // where a track-level path resolves to no device and the write vanished.
+    REQUIRE(result.target.kind == ControlTarget::Kind::TrackVolume);
     REQUIRE(result.target.paramIndex == 0);
     REQUIRE(result.target.devicePath.isTrackLevel);
     REQUIRE(result.target.devicePath.trackId == MASTER_TRACK_ID);
@@ -112,8 +116,10 @@ TEST_CASE("TargetResolver - resolve ResolverRef master.pan", "[aliases][resolver
 
     auto result = resolver.resolve(Target{rr});
     REQUIRE(result.ok());
+    REQUIRE(result.target.kind == ControlTarget::Kind::TrackPan);
     REQUIRE(result.target.paramIndex == 1);
     REQUIRE(result.target.devicePath.isTrackLevel);
+    REQUIRE(result.target.devicePath.trackId == MASTER_TRACK_ID);
 }
 
 TEST_CASE("TargetResolver - resolve unknown ResolverRef kind fails", "[aliases][resolver]") {
@@ -227,6 +233,7 @@ TEST_CASE("TargetResolver::resolveSigil - @master.volume", "[aliases][resolver]"
 
     auto result = resolver.resolveSigil(*parsed);
     REQUIRE(result.ok());
+    REQUIRE(result.target.kind == ControlTarget::Kind::TrackVolume);
     REQUIRE(result.target.devicePath.trackId == MASTER_TRACK_ID);
     REQUIRE(result.target.paramIndex == 0);
 }
@@ -249,8 +256,53 @@ TEST_CASE("TargetResolver::resolveSigil - @selected.volume with selected track",
 
     auto result = resolver.resolveSigil(*parsed);
     REQUIRE(result.ok());
+    REQUIRE(result.target.kind == ControlTarget::Kind::TrackVolume);
     REQUIRE(result.target.devicePath.trackId == 5);
     REQUIRE(result.target.paramIndex == 0);
+}
+
+TEST_CASE("TargetResolver::resolveSigil - @selected.pan carries TrackPan kind",
+          "[aliases][resolver]") {
+    FixedChainContext ctx;
+    ctx.setSelectedTrack(5);
+
+    auto& reg = AliasRegistry::getInstance();
+    reg.clearLayer(AliasLayer::UserProject);
+    reg.clearLayer(AliasLayer::UserGlobal);
+    reg.clearLayer(AliasLayer::Curated);
+    reg.clearLayer(AliasLayer::AutoGen);
+    auto& resolvers = ResolverRegistry::getInstance();
+    TargetResolver resolver{reg, resolvers, ctx};
+
+    auto parsed = tryParse("@selected.pan");
+    REQUIRE(parsed.has_value());
+
+    auto result = resolver.resolveSigil(*parsed);
+    REQUIRE(result.ok());
+    REQUIRE(result.target.kind == ControlTarget::Kind::TrackPan);
+    REQUIRE(result.target.devicePath.trackId == 5);
+    REQUIRE(result.target.paramIndex == 1);
+}
+
+TEST_CASE("TargetResolver::resolveSigil - @master.pan carries TrackPan kind",
+          "[aliases][resolver]") {
+    FixedChainContext ctx;
+    auto& reg = AliasRegistry::getInstance();
+    reg.clearLayer(AliasLayer::UserProject);
+    reg.clearLayer(AliasLayer::UserGlobal);
+    reg.clearLayer(AliasLayer::Curated);
+    reg.clearLayer(AliasLayer::AutoGen);
+    auto& resolvers = ResolverRegistry::getInstance();
+    TargetResolver resolver{reg, resolvers, ctx};
+
+    auto parsed = tryParse("@master.pan");
+    REQUIRE(parsed.has_value());
+
+    auto result = resolver.resolveSigil(*parsed);
+    REQUIRE(result.ok());
+    REQUIRE(result.target.kind == ControlTarget::Kind::TrackPan);
+    REQUIRE(result.target.devicePath.trackId == MASTER_TRACK_ID);
+    REQUIRE(result.target.paramIndex == 1);
 }
 
 TEST_CASE("TargetResolver::resolveSigil - @selected.volume no track selected fails",

--- a/tests/test_controller_track_level_write_juce.cpp
+++ b/tests/test_controller_track_level_write_juce.cpp
@@ -1,0 +1,173 @@
+// Coverage for DefaultControllerParamWriter::writeTrackLevel, the path a
+// control surface takes when a binding resolves to @master.volume,
+// @master.pan, @selected.volume or @selected.pan.
+//
+// This used to be dead: every track-level kind fell through a bare `break` in
+// DefaultControllerParamWriter::write, so a JSON controller binding on
+// master.volume resolved cleanly and then silently did nothing. The router
+// tests all inject a FakeParamWriter, so nothing exercised the real writer.
+//
+// Lives in the JUCE target because DefaultControllerParamWriter takes an
+// AudioBridge&, which needs the shared engine.
+
+#include <juce_core/juce_core.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+#include <cmath>
+
+#include "JuceTestStateGuard.hpp"
+#include "SharedTestEngine.hpp"
+#include "magda/daw/audio/AudioBridge.hpp"
+#include "magda/daw/audio/controllers/ControllerParamWriter.hpp"
+#include "magda/daw/core/ControlTarget.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/engine/TracktionEngineWrapper.hpp"
+
+using namespace magda;
+
+namespace {
+
+ResolveResult makeTrackLevelTarget(ControlTarget::Kind kind, TrackId trackId) {
+    ResolveResult r;
+    r.target.kind = kind;
+    r.target.devicePath = ChainNodePath::trackLevel(trackId);
+    r.target.paramIndex = (kind == ControlTarget::Kind::TrackVolume) ? 0 : 1;
+    r.resolved = true;
+    return r;
+}
+
+}  // namespace
+
+class ControllerTrackLevelWriteTest final : public juce::UnitTest {
+  public:
+    ControllerTrackLevelWriteTest()
+        : juce::UnitTest("Controller Track Level Write Tests", "magda") {}
+
+    void runTest() override {
+        magda::test::runWithCleanJuceState([this] {
+            testMasterVolumeWrite();
+            testMasterPanWrite();
+            testTrackVolumeWrite();
+            testFullScaleAndSilence();
+        });
+    }
+
+  private:
+    void testMasterVolumeWrite() {
+        beginTest("A master.volume binding reaches the master channel");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto* bridge = wrapper.getAudioBridge();
+        expect(bridge != nullptr, "AudioBridge must exist");
+        if (bridge == nullptr)
+            return;
+
+        auto& tm = TrackManager::getInstance();
+        DefaultControllerParamWriter writer{*bridge};
+
+        const auto resolved =
+            makeTrackLevelTarget(ControlTarget::Kind::TrackVolume, MASTER_TRACK_ID);
+        expect(resolved.ok(), "target must resolve");
+
+        // Half scale, then full: the point is that the value moves at all, and
+        // that it moves in the right direction.
+        writer.write(resolved, 0.5f);
+        const float atHalf = tm.getMasterChannel().volume;
+
+        writer.write(resolved, 1.0f);
+        const float atFull = tm.getMasterChannel().volume;
+
+        expect(atFull > atHalf, "a higher controller value must raise master volume");
+        expect(atFull > 0.0f, "full scale must not silence the master");
+    }
+
+    void testMasterPanWrite() {
+        beginTest("A master.pan binding reaches the master channel");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto* bridge = wrapper.getAudioBridge();
+        if (bridge == nullptr)
+            return;
+
+        auto& tm = TrackManager::getInstance();
+        DefaultControllerParamWriter writer{*bridge};
+
+        const auto resolved = makeTrackLevelTarget(ControlTarget::Kind::TrackPan, MASTER_TRACK_ID);
+
+        writer.write(resolved, 0.0f);
+        const float atMin = tm.getMasterChannel().pan;
+
+        writer.write(resolved, 1.0f);
+        const float atMax = tm.getMasterChannel().pan;
+
+        expect(atMax > atMin, "pan must sweep from left to right across the CC range");
+        expect(atMin < 0.0f, "a zero controller value must pan left");
+        expect(atMax > 0.0f, "a full controller value must pan right");
+    }
+
+    void testTrackVolumeWrite() {
+        beginTest("A selected.volume binding reaches an ordinary track");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto* bridge = wrapper.getAudioBridge();
+        if (bridge == nullptr)
+            return;
+
+        auto& tm = TrackManager::getInstance();
+        const auto trackId = tm.createTrack("Fader Target");
+        bridge->createAudioTrack(trackId, "Fader Target");
+
+        const float masterBefore = tm.getMasterChannel().volume;
+
+        DefaultControllerParamWriter writer{*bridge};
+        const auto resolved = makeTrackLevelTarget(ControlTarget::Kind::TrackVolume, trackId);
+        writer.write(resolved, 0.25f);
+
+        const auto* track = tm.getTrack(trackId);
+        expect(track != nullptr, "track must exist");
+        if (track == nullptr)
+            return;
+
+        writer.write(resolved, 0.75f);
+        const auto* after = tm.getTrack(trackId);
+        expect(after != nullptr);
+        if (after == nullptr)
+            return;
+
+        expect(after->volume > 0.0f, "the write must land on the track");
+        expect(tm.getMasterChannel().volume == masterBefore,
+               "a track write must not disturb the master channel");
+    }
+
+    void testFullScaleAndSilence() {
+        beginTest("Controller extremes stay inside the accepted gain range");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto* bridge = wrapper.getAudioBridge();
+        if (bridge == nullptr)
+            return;
+
+        auto& tm = TrackManager::getInstance();
+        DefaultControllerParamWriter writer{*bridge};
+        const auto resolved =
+            makeTrackLevelTarget(ControlTarget::Kind::TrackVolume, MASTER_TRACK_ID);
+
+        writer.write(resolved, 0.0f);
+        const float atZero = tm.getMasterChannel().volume;
+        expect(atZero >= 0.0f, "zero must not produce a negative gain");
+
+        writer.write(resolved, 1.0f);
+        const float atFull = tm.getMasterChannel().volume;
+        // TrackManager clamps to 0..2 (+6 dB); a full-scale controller write
+        // must land inside that window rather than being clipped away.
+        expect(atFull <= 2.0f, "full scale must stay within the +6 dB ceiling");
+        expect(atFull > atZero, "full scale must exceed silence");
+
+        // Values outside 0..1 are clamped by write() before any mapping runs.
+        writer.write(resolved, 5.0f);
+        expect(tm.getMasterChannel().volume == atFull,
+               "an out-of-range value must clamp to the full-scale result");
+    }
+};
+
+static ControllerTrackLevelWriteTest controllerTrackLevelWriteTest;

--- a/tests/test_magda_api_lua_bindings.cpp
+++ b/tests/test_magda_api_lua_bindings.cpp
@@ -141,6 +141,31 @@ TEST_CASE("magda.tracks setters record their writes", "[lua_bindings][tracks]") 
     REQUIRE(mock.tracks_.deleted == std::vector<magda::TrackId>{9});
 }
 
+TEST_CASE("magda.tracks.set_record_armed records its writes", "[lua_bindings][tracks]") {
+    MockMagdaApi mock;
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    REQUIRE(rt.eval("magda.tracks.set_record_armed(3, true)"));
+    REQUIRE(rt.eval("magda.tracks.set_record_armed(4, false)"));
+
+    REQUIRE(mock.tracks_.recordArmWrites.size() == 2);
+    REQUIRE(mock.tracks_.recordArmWrites[0].id == 3);
+    REQUIRE(mock.tracks_.recordArmWrites[0].value == true);
+    REQUIRE(mock.tracks_.recordArmWrites[1].id == 4);
+    REQUIRE(mock.tracks_.recordArmWrites[1].value == false);
+}
+
+TEST_CASE("magda.tracks.set_record_armed rejects a non-boolean", "[lua_bindings][tracks]") {
+    MockMagdaApi mock;
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    REQUIRE_FALSE(rt.eval("magda.tracks.set_record_armed(1, 'yes')"));
+    REQUIRE(rt.lastError().contains("boolean expected"));
+    REQUIRE(mock.tracks_.recordArmWrites.empty());
+}
+
 TEST_CASE("magda.tracks.list returns a snapshot table per track", "[lua_bindings][tracks]") {
     MockMagdaApi mock;
     magda::TrackInfo a;
@@ -169,6 +194,38 @@ TEST_CASE("magda.tracks.get returns nil for an unknown id", "[lua_bindings][trac
     LuaRuntime rt;
     registerMagdaApi(rt.state(), mock);
     REQUIRE(rt.evalToString("type(magda.tracks.get(999))") == std::optional<juce::String>{"nil"});
+}
+
+// Master lives apart from the ordinary tracks, so it never shows up in
+// magda.tracks.list(). magda.tracks.master() is the only route a script has to
+// its id, which the volume / pan setters then accept.
+TEST_CASE("magda.tracks.master returns the master track", "[lua_bindings][tracks]") {
+    MockMagdaApi mock;
+    magda::TrackInfo master;
+    master.id = magda::MASTER_TRACK_ID;
+    master.name = "Master";
+    master.type = magda::TrackType::Master;
+    mock.tracks_.tracks.push_back(master);
+
+    magda::TrackInfo ordinary;
+    ordinary.id = 1;
+    ordinary.name = "Drums";
+    ordinary.type = magda::TrackType::Audio;
+    mock.tracks_.tracks.push_back(ordinary);
+
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+
+    REQUIRE(rt.evalToInt("magda.tracks.master().id") ==
+            std::optional<long long>{magda::MASTER_TRACK_ID});
+    REQUIRE(rt.evalToString("magda.tracks.master().name") == std::optional<juce::String>{"Master"});
+}
+
+TEST_CASE("magda.tracks.master returns nil when there is no master", "[lua_bindings][tracks]") {
+    MockMagdaApi mock;
+    LuaRuntime rt;
+    registerMagdaApi(rt.state(), mock);
+    REQUIRE(rt.evalToString("type(magda.tracks.master())") == std::optional<juce::String>{"nil"});
 }
 
 // ---- selection -------------------------------------------------------------

--- a/tests/test_track_level_control_writes.cpp
+++ b/tests/test_track_level_control_writes.cpp
@@ -1,0 +1,107 @@
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+
+#include "magda/daw/core/AutomationInfo.hpp"
+#include "magda/daw/core/ControlTarget.hpp"
+#include "magda/daw/core/ParameterUtils.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+
+using namespace magda;
+
+// ============================================================================
+// Track-level control writes
+// ============================================================================
+//
+// Covers the invariants DefaultControllerParamWriter::writeTrackLevel relies
+// on when a control surface drives @master.volume / @selected.volume. The
+// writer itself needs an AudioBridge to construct, so the engine-facing half
+// is not exercised here; what is pinned down is the routing and the
+// normalized -> gain conversion, which is where the value actually comes from.
+
+namespace {
+
+void resetState() {
+    TrackManager::getInstance().clearAllTracks();
+}
+
+// Mirrors writeTrackLevel: normalized 0..1 -> real (dB) -> linear gain.
+float normalizedToGain(float normalized) {
+    ControlTarget target;
+    target.kind = ControlTarget::Kind::TrackVolume;
+    target.devicePath = ChainNodePath::trackLevel(MASTER_TRACK_ID);
+    target.paramIndex = 0;
+
+    const ParameterInfo info = getParameterInfoForTarget(target);
+    const float real = ParameterUtils::normalizedToReal(normalized, info);
+    return std::pow(10.0f, real / 20.0f);
+}
+
+}  // namespace
+
+TEST_CASE("setTrackVolume on MASTER_TRACK_ID routes to the master channel",
+          "[controllers][master]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    // This routing is why writeTrackLevel needs no master special case.
+    tm.setTrackVolume(MASTER_TRACK_ID, 0.5f);
+
+    REQUIRE(tm.getMasterChannel().volume == 0.5f);
+    const auto* masterTrack = tm.getTrack(MASTER_TRACK_ID);
+    REQUIRE(masterTrack != nullptr);
+    REQUIRE(masterTrack->volume == 0.5f);
+}
+
+TEST_CASE("setTrackPan on MASTER_TRACK_ID routes to the master channel", "[controllers][master]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    tm.setTrackPan(MASTER_TRACK_ID, -0.25f);
+
+    REQUIRE(tm.getMasterChannel().pan == -0.25f);
+    const auto* masterTrack = tm.getTrack(MASTER_TRACK_ID);
+    REQUIRE(masterTrack != nullptr);
+    REQUIRE(masterTrack->pan == -0.25f);
+}
+
+TEST_CASE("track volume writes do not leak into the master channel", "[controllers][master]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const float masterBefore = tm.getMasterChannel().volume;
+    const TrackId id = tm.createTrack("Drums", TrackType::Audio);
+    tm.setTrackVolume(id, 0.25f);
+
+    const auto* track = tm.getTrack(id);
+    REQUIRE(track != nullptr);
+    REQUIRE(track->volume == 0.25f);
+    REQUIRE(tm.getMasterChannel().volume == masterBefore);
+}
+
+TEST_CASE("normalized controller values map onto the fader gain range", "[controllers][master]") {
+    // A full-scale CC has to reach the top of the fader, and zero has to
+    // silence it. Anything in between simply has to rise monotonically; the
+    // exact curve belongs to ParameterInfo, not to the writer.
+    const float atZero = normalizedToGain(0.0f);
+    const float atHalf = normalizedToGain(0.5f);
+    const float atFull = normalizedToGain(1.0f);
+
+    REQUIRE(atZero < atHalf);
+    REQUIRE(atHalf < atFull);
+    REQUIRE(atZero >= 0.0f);
+
+    // TrackManager clamps to 0..2 (+6 dB), so a full-scale write must land
+    // inside that window rather than being silently clipped.
+    REQUIRE(atFull <= 2.0f);
+}
+
+TEST_CASE("a full-scale controller write survives the TrackManager clamp",
+          "[controllers][master]") {
+    resetState();
+    auto& tm = TrackManager::getInstance();
+
+    const float gain = normalizedToGain(1.0f);
+    tm.setTrackVolume(MASTER_TRACK_ID, gain);
+
+    REQUIRE(tm.getMasterChannel().volume == gain);
+}


### PR DESCRIPTION
Controller work in three parts: a bug report from a user by email, a note mode for the Launchkey, and the docs for both.

## Master and selected volume / pan were unwritable from a control surface

Reported by email against 0.17.1: a JSON controller binding on `master.volume` resolved without error and then did nothing. Two defects were stacked on the way to the parameter, and fixing either alone changes nothing.

**The resolvers never set `kind`.** All four track-level resolvers filled in `devicePath` and `paramIndex` but left `kind` at the `ControlTarget` default of `PluginParam`. That routed `master.volume`, `master.pan`, `selected.volume` and `selected.pan` into `writePluginParam`, where a track-level path matches no device and the write was silently dropped.

**The writer discarded track-level targets.** `DefaultControllerParamWriter::write` sent every track-level kind through a bare `break`. Added `writeTrackLevel`, which:

- reuses the automation engine's `getParameterInfoForTarget` plus `normalizedToReal`, so a controller fader and an automation curve on the same target resolve to the same value
- converts the fader dB back to linear gain
- writes through `TrackManager` rather than the TE parameter, so the inspector, mixer and track headers stay in sync

Master needs no special case there, because `TrackManager::setTrackVolume` already forwards `MASTER_TRACK_ID` to `setMasterVolume`. `SendLevel` and `Tempo` remain unhandled but now carry a comment saying why, since no resolver currently produces either for a control surface.

## Two missing Lua bindings

`magda.tracks.set_record_armed(id, bool)` completes the `record_armed` field that was already exposed read-only, backed by the existing `TrackManager::setTrackRecordArmed` through a new `TrackApi` method.

`magda.tracks.master()` returns the master track. Master is stored apart from the ordinary tracks, so it never appears in `magda.tracks.list()` and a script had no way to reach its id. I did not fold it into `list()` on purpose: that would shift every column index and break the bundled Launchpad and Launchkey scripts, which map list position to hardware column. The volume and pan setters already accept the master id once a script can obtain it.

## Launchkey Mini MK4 note mode

The 16 pads can now play the selected track's instrument instead of launching clips, toggled by `USER_MODE_CC`. Pitch rises left to right, bottom row then top row, so the lowest note is the bottom left pad. Held pads light bright and the two rows are tinted differently so the direction reads at a glance.

Also fixes `find_daw_out` on Linux. The port matcher required "DAW" in the name, which holds on macOS and Windows but not under ALSA, where the ports are numbered instead. There it returned nil and silently took the DAW handshake, the pad LEDs and the display with it. It now falls back to the last Launchkey port and logs the choice. Setting the script's ports explicitly still wins over any of the guessing.

## Testing

The existing `master.volume` and `master.pan` resolver tests asserted `paramIndex` and `devicePath` but never `kind`, which is how this shipped broken. They do now, plus:

- sigil-path cases for `@master.pan` and `@selected.pan`
- Lua binding cases for both new functions, including the type check
- model-level cases for master routing, track writes not leaking into master, and the normalized to gain mapping staying inside the +6 dB ceiling
- a JUCE case driving the real `DefaultControllerParamWriter` against the shared engine

That last one matters because every controller router test injects a `FakeParamWriter`, so nothing had ever exercised the production writer, which is exactly how the empty `break` survived.

Locally: build clean, `magda_tests` 1685 cases and 163440 assertions passing, `magda_juce_tests` all passing.

## Not verified here

The Linux ALSA port fallback and the reporter's Reloop KeyPad Pro setup both need hardware I do not have. The reporter has offered to retest once this ships.
