### PR TITLE
Build the update dialog's messages from one string each

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -187,12 +187,10 @@
     "error.export_failed": "Failed to export project:",
     "error.export_no_edit": "Cannot export: no Edit loaded",
     "updates.title": "Check for Updates",
-    "updates.up_to_date": "You're running the latest version of MAGDA.",
-    "updates.available_body_prefix": "A new version of MAGDA is available:",
-    "updates.available_body_suffix": "",
-    "updates.current_label": "Current:",
+    "updates.up_to_date": "You're running the latest version of MAGDA ({0}).",
+    "updates.available_body": "A new version of MAGDA is available: {0} (current: {1}).",
     "updates.view_release": "View release",
-    "updates.error_prefix": "Could not check for updates:"
+    "updates.error": "Could not check for updates: {0}"
   },
   "about": {
     "version_prefix": "Version "

--- a/magda/daw/ui/windows/MainWindowMenus.cpp
+++ b/magda/daw/ui/windows/MainWindowMenus.cpp
@@ -945,16 +945,16 @@ void MainWindow::setupMenuCallbacks() {
             if (!r.success) {
                 juce::AlertWindow::showMessageBoxAsync(
                     juce::AlertWindow::WarningIcon, tr("dialogs.updates.title"),
-                    tr("dialogs.updates.error_prefix") + " " + r.errorMessage);
+                    tr("dialogs.updates.error").replace("{0}", r.errorMessage));
                 return;
             }
             UpdateChecker::markChecked();
             if (r.updateAvailable) {
                 juce::AlertWindow::showOkCancelBox(
                     juce::AlertWindow::InfoIcon, tr("dialogs.updates.title"),
-                    tr("dialogs.updates.available_body_prefix") + " " + r.latestVersion + " " +
-                        tr("dialogs.updates.available_body_suffix") + " (" +
-                        tr("dialogs.updates.current_label") + " " + r.currentVersion + ").",
+                    tr("dialogs.updates.available_body")
+                        .replace("{0}", r.latestVersion)
+                        .replace("{1}", r.currentVersion),
                     tr("dialogs.updates.view_release"), tr("dialogs.cancel"), nullptr,
                     juce::ModalCallbackFunction::create([url = r.releaseUrl](int result) {
                         if (result == 1 && url.isNotEmpty())
@@ -963,7 +963,7 @@ void MainWindow::setupMenuCallbacks() {
             } else {
                 juce::AlertWindow::showMessageBoxAsync(
                     juce::AlertWindow::InfoIcon, tr("dialogs.updates.title"),
-                    tr("dialogs.updates.up_to_date") + " (MAGDA " + r.currentVersion + ")");
+                    tr("dialogs.updates.up_to_date").replace("{0}", r.currentVersion));
             }
         });
     };


### PR DESCRIPTION
Every message in the update dialog was assembled from fragments around an interpolated value, and one of the fragments,
`available_body_suffix`, had an empty English source. An empty source is one Crowdin cannot anchor a translation on, so the slot could never be filled in any locale, and its separators still rendered: the dialog showed a double space before the parenthetical.

The real problem is the concatenation. Splitting a sentence around an interpolated value forces every language into English clause order, which is presumably why the suffix escape hatch was added in the first place. One string with {0} / {1} placeholders, the idiom already used elsewhere in the UI, hands the whole sentence to the translator.

All three messages get the same treatment: the update-available body, the up-to-date message (which appended " (MAGDA <version>)" after the full stop of a sentence that had already said MAGDA once), and the error message.