### PR TITLE
Dependabot: roll target-branch to dev/0.19.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     # full CI matrix (incl. the self-hosted macOS/Windows jobs); targeting dev
     # keeps bumps off that path and in line with the normal contribution flow.
     # Update this each release cycle when the active dev branch rolls over.
-    target-branch: "dev/0.18.0"
+    target-branch: "dev/0.19.0"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -32,7 +32,7 @@ updates:
     directory: "/"
     # See the gitsubmodule note above: base on the active dev branch so bumps
     # don't trip the pull_request-into-main CI. Bump each release cycle.
-    target-branch: "dev/0.18.0"
+    target-branch: "dev/0.19.0"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
dev/0.18.0 was deleted when 0.18.0 merged to main, so both ecosystems were targeting a branch that no longer exists. dev/0.19.0 is cut and is the active dev branch now.

Dependabot reads its config from the default branch, so this has to go to main directly rather than riding the next release. Same shape as #1784 last cycle.

Heads up: a PR into main runs the full CI matrix including the self-hosted macOS and Windows jobs, for a two-line YAML change.