### PR TITLE
Canonical ControlTarget serialization and unambiguous remote device paths

### DIFF
--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -357,24 +357,57 @@ const juce::var& sessionSchema() {
     return value;
 }
 
-const juce::var& automationTargetSchema() {
+const juce::var& devicePathSchema() {
     static const auto value = parseSchema(R"json({
         "type":"object",
         "properties":{
-            "kind":{"type":"string","enum":["plugin_param","device_macro","mod_param",
-                "track_volume","track_pan","send_level","tempo"]},
-            "trackId":{"anyOf":[{"type":"null"},{"type":"integer","const":-2},
+            "trackId":{"anyOf":[{"type":"integer","const":-2},
                                 {"type":"integer","minimum":0}]},
-            "deviceId":{"type":["integer","null"],"minimum":0},
-            "parameterIndex":{"type":"integer","minimum":-1},
-            "modId":{"type":"integer","minimum":-1},
-            "modParameterIndex":{"type":"integer","minimum":-1},
-            "sendBusIndex":{"type":"integer","minimum":-1}
+            "section":{"type":"string","enum":["fx","post_fx","mixer_analysis"]},
+            "trackLevel":{"type":"boolean"},
+            "topLevelDeviceId":{"type":["integer","null"],"minimum":0},
+            "steps":{"type":"array","items":{
+                "type":"object",
+                "properties":{
+                    "type":{"type":"string","enum":["rack","chain","device"]},
+                    "id":{"type":"integer","minimum":0}
+                },
+                "required":["type","id"],
+                "additionalProperties":false
+            }}
         },
-        "required":["kind","trackId","deviceId","parameterIndex","modId","modParameterIndex",
-                    "sendBusIndex"],
+        "required":["trackId","section","trackLevel","topLevelDeviceId","steps"],
         "additionalProperties":false
     })json");
+    return value;
+}
+
+const juce::var& automationTargetSchema() {
+    static auto value = [] {
+        auto schema = parseSchema(R"json({
+            "type":"object",
+            "properties":{
+                "kind":{"type":"string","enum":["plugin_param","device_macro","mod_param",
+                    "track_volume","track_pan","send_level","tempo"]},
+                "devicePath":{},
+                "parameterIndex":{"type":"integer","minimum":-1},
+                "modId":{"type":"integer","minimum":-1},
+                "modParameterIndex":{"type":"integer","minimum":-1},
+                "sendBusIndex":{"type":"integer","minimum":-1}
+            },
+            "required":["kind","devicePath","parameterIndex","modId","modParameterIndex",
+                        "sendBusIndex"],
+            "additionalProperties":false
+        })json");
+        // Edit-scoped targets (tempo) carry no path, so null is permitted.
+        auto* nullable = new juce::DynamicObject();
+        juce::Array<juce::var> alternatives;
+        alternatives.add(parseSchema(R"json({"type":"null"})json"));
+        alternatives.add(devicePathSchema());
+        nullable->setProperty("anyOf", juce::var(alternatives));
+        schema["properties"].getDynamicObject()->setProperty("devicePath", juce::var(nullable));
+        return schema;
+    }();
     return value;
 }
 
@@ -866,11 +899,29 @@ juce::var toJson(const AutomationPointDto& dto) {
     return object;
 }
 
+juce::var toJson(const DevicePathDto& dto) {
+    auto object = new juce::DynamicObject();
+    object->setProperty("trackId", dto.trackId);
+    object->setProperty("section", dto.section);
+    object->setProperty("trackLevel", dto.trackLevel);
+    object->setProperty("topLevelDeviceId", nullableId(dto.topLevelDeviceId));
+
+    juce::Array<juce::var> steps;
+    for (const auto& step : dto.steps) {
+        auto* stepObject = new juce::DynamicObject();
+        stepObject->setProperty("type", step.type);
+        stepObject->setProperty("id", step.id);
+        steps.add(juce::var(stepObject));
+    }
+    object->setProperty("steps", juce::var(steps));
+    return object;
+}
+
 juce::var toJson(const AutomationTargetDto& dto) {
     auto object = new juce::DynamicObject();
     object->setProperty("kind", dto.kind);
-    object->setProperty("trackId", nullableId(dto.trackId));
-    object->setProperty("deviceId", nullableId(dto.deviceId));
+    object->setProperty("devicePath",
+                        dto.devicePath.has_value() ? toJson(*dto.devicePath) : juce::var());
     object->setProperty("parameterIndex", dto.parameterIndex);
     object->setProperty("modId", dto.modId);
     object->setProperty("modParameterIndex", dto.modParameterIndex);
@@ -1091,8 +1142,18 @@ std::optional<AutomationLaneDto> automationLaneFromJson(const juce::var& json, E
     dto.name = json["name"].toString();
     const auto target = json["target"];
     dto.target.kind = target["kind"].toString();
-    dto.target.trackId = readNullableId<TrackId>(target, "trackId");
-    dto.target.deviceId = readNullableId<DeviceId>(target, "deviceId");
+    if (const auto path = target["devicePath"]; path.isObject()) {
+        DevicePathDto pathDto;
+        pathDto.trackId = readInt(path, "trackId");
+        pathDto.section = path["section"].toString();
+        pathDto.trackLevel = static_cast<bool>(path["trackLevel"]);
+        pathDto.topLevelDeviceId = readNullableId<DeviceId>(path, "topLevelDeviceId");
+        if (auto* steps = path["steps"].getArray()) {
+            for (const auto& item : *steps)
+                pathDto.steps.push_back({item["type"].toString(), readInt(item, "id")});
+        }
+        dto.target.devicePath = std::move(pathDto);
+    }
     dto.target.parameterIndex = readInt(target, "parameterIndex");
     dto.target.modId = readInt(target, "modId");
     dto.target.modParameterIndex = readInt(target, "modParameterIndex");

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -208,25 +208,55 @@ const juce::var& clipSchema() {
     return value;
 }
 
-const juce::var& deviceSchema() {
+const juce::var& devicePathSchema() {
     static const auto value = parseSchema(R"json({
         "type":"object",
         "properties":{
-            "id":{"type":"integer","minimum":0},
-            "trackId":{"type":"integer","minimum":0},
-            "rackId":{"type":["integer","null"]},
-            "chainId":{"type":["integer","null"]},
-            "name":{"type":"string"},
-            "type":{"type":"string","enum":["instrument","effect","midi","analysis"]},
-            "format":{"type":"string","enum":["vst3","au","vst","internal"]},
-            "instrument":{"type":"boolean"},
-            "bypassed":{"type":"boolean"},
-            "gainDb":{"type":"number"}
+            "trackId":{"anyOf":[{"type":"integer","const":-2},
+                                {"type":"integer","minimum":0}]},
+            "section":{"type":"string","enum":["fx","post_fx","mixer_analysis"]},
+            "trackLevel":{"type":"boolean"},
+            "topLevelDeviceId":{"type":["integer","null"],"minimum":0},
+            "steps":{"type":"array","items":{
+                "type":"object",
+                "properties":{
+                    "type":{"type":"string","enum":["rack","chain","device"]},
+                    "id":{"type":"integer","minimum":0}
+                },
+                "required":["type","id"],
+                "additionalProperties":false
+            }}
         },
-        "required":["id","trackId","rackId","chainId","name","type","format","instrument",
-                    "bypassed","gainDb"],
+        "required":["trackId","section","trackLevel","topLevelDeviceId","steps"],
         "additionalProperties":false
     })json");
+    return value;
+}
+
+const juce::var& deviceSchema() {
+    static auto value = [] {
+        auto schema = parseSchema(R"json({
+            "type":"object",
+            "properties":{
+                "id":{"type":"integer","minimum":0},
+                "trackId":{"type":"integer","minimum":0},
+                "rackId":{"type":["integer","null"]},
+                "chainId":{"type":["integer","null"]},
+                "devicePath":{},
+                "name":{"type":"string"},
+                "type":{"type":"string","enum":["instrument","effect","midi","analysis"]},
+                "format":{"type":"string","enum":["vst3","au","vst","internal"]},
+                "instrument":{"type":"boolean"},
+                "bypassed":{"type":"boolean"},
+                "gainDb":{"type":"number"}
+            },
+            "required":["id","trackId","rackId","chainId","devicePath","name","type","format",
+                        "instrument","bypassed","gainDb"],
+            "additionalProperties":false
+        })json");
+        schema["properties"].getDynamicObject()->setProperty("devicePath", devicePathSchema());
+        return schema;
+    }();
     return value;
 }
 
@@ -354,31 +384,6 @@ const juce::var& sessionSchema() {
         schema["properties"]["slots"].getDynamicObject()->setProperty("items", sessionSlotSchema());
         return schema;
     }();
-    return value;
-}
-
-const juce::var& devicePathSchema() {
-    static const auto value = parseSchema(R"json({
-        "type":"object",
-        "properties":{
-            "trackId":{"anyOf":[{"type":"integer","const":-2},
-                                {"type":"integer","minimum":0}]},
-            "section":{"type":"string","enum":["fx","post_fx","mixer_analysis"]},
-            "trackLevel":{"type":"boolean"},
-            "topLevelDeviceId":{"type":["integer","null"],"minimum":0},
-            "steps":{"type":"array","items":{
-                "type":"object",
-                "properties":{
-                    "type":{"type":"string","enum":["rack","chain","device"]},
-                    "id":{"type":"integer","minimum":0}
-                },
-                "required":["type","id"],
-                "additionalProperties":false
-            }}
-        },
-        "required":["trackId","section","trackLevel","topLevelDeviceId","steps"],
-        "additionalProperties":false
-    })json");
     return value;
 }
 
@@ -622,6 +627,22 @@ std::optional<Id> readNullableId(const juce::var& object, const char* property) 
     return decodeBoundedInt<Id>(value);
 }
 
+// Shared by device listings and automation targets: both address a device the
+// same way, and must not drift apart.
+DevicePathDto devicePathFromJson(const juce::var& json) {
+    DevicePathDto dto;
+    dto.trackId = readInt(json, "trackId");
+    dto.section = json["section"].toString();
+    dto.trackLevel = static_cast<bool>(json["trackLevel"]);
+    dto.topLevelDeviceId = readNullableId<DeviceId>(json, "topLevelDeviceId");
+    if (auto* steps = json["steps"].getArray()) {
+        dto.steps.reserve(static_cast<size_t>(steps->size()));
+        for (const auto& item : *steps)
+            dto.steps.push_back({item["type"].toString(), readInt(item, "id")});
+    }
+    return dto;
+}
+
 template <typename Integer>
 juce::Array<juce::var> integerArray(const std::vector<Integer>& values) {
     juce::Array<juce::var> result;
@@ -795,6 +816,7 @@ juce::var toJson(const DeviceDto& dto) {
     object->setProperty("trackId", dto.trackId);
     object->setProperty("rackId", nullableId(dto.rackId));
     object->setProperty("chainId", nullableId(dto.chainId));
+    object->setProperty("devicePath", toJson(dto.devicePath));
     object->setProperty("name", dto.name);
     object->setProperty("type", dto.type);
     object->setProperty("format", dto.format);
@@ -1028,6 +1050,7 @@ std::optional<DeviceDto> deviceFromJson(const juce::var& json, Error& error) {
     dto.trackId = readInt(json, "trackId");
     dto.rackId = readNullableId<RackId>(json, "rackId");
     dto.chainId = readNullableId<ChainId>(json, "chainId");
+    dto.devicePath = devicePathFromJson(json["devicePath"]);
     dto.name = json["name"].toString();
     dto.type = json["type"].toString();
     dto.format = json["format"].toString();
@@ -1142,18 +1165,8 @@ std::optional<AutomationLaneDto> automationLaneFromJson(const juce::var& json, E
     dto.name = json["name"].toString();
     const auto target = json["target"];
     dto.target.kind = target["kind"].toString();
-    if (const auto path = target["devicePath"]; path.isObject()) {
-        DevicePathDto pathDto;
-        pathDto.trackId = readInt(path, "trackId");
-        pathDto.section = path["section"].toString();
-        pathDto.trackLevel = static_cast<bool>(path["trackLevel"]);
-        pathDto.topLevelDeviceId = readNullableId<DeviceId>(path, "topLevelDeviceId");
-        if (auto* steps = path["steps"].getArray()) {
-            for (const auto& item : *steps)
-                pathDto.steps.push_back({item["type"].toString(), readInt(item, "id")});
-        }
-        dto.target.devicePath = std::move(pathDto);
-    }
+    if (const auto path = target["devicePath"]; path.isObject())
+        dto.target.devicePath = devicePathFromJson(path);
     dto.target.parameterIndex = readInt(target, "parameterIndex");
     dto.target.modId = readInt(target, "modId");
     dto.target.modParameterIndex = readInt(target, "modParameterIndex");

--- a/magda/daw/api/remote_api.hpp
+++ b/magda/daw/api/remote_api.hpp
@@ -120,11 +120,46 @@ struct ClipDto {
     bool operator==(const ClipDto&) const = default;
 };
 
+/**
+ * @brief Public projection of a `ChainNodePath`.
+ *
+ * A device id alone does not identify a device: the main FX chain, the
+ * post-fader list, and the mixer-analysis section each carry their own
+ * `DeviceId` counter, so id 3 can exist in all three at once on one track.
+ * `section` carries that discriminator and `steps` carries the route through
+ * nested racks and chains, so this round-trips to exactly one device.
+ *
+ * Step types are strings rather than enum ordinals: this is a public wire
+ * contract consumed by scripts and MCP clients, and it must not be coupled to
+ * the internal `ChainStepType` ordering.
+ */
+struct DevicePathStepDto {
+    juce::String type;  // "rack" | "chain" | "device"
+    int id = -1;
+
+    bool operator==(const DevicePathStepDto&) const = default;
+};
+
+struct DevicePathDto {
+    TrackId trackId = INVALID_TRACK_ID;
+    juce::String section{"fx"};  // "fx" | "post_fx" | "mixer_analysis"
+    bool trackLevel = false;
+    std::optional<DeviceId> topLevelDeviceId;
+    std::vector<DevicePathStepDto> steps;
+
+    bool operator==(const DevicePathDto&) const = default;
+};
+
 struct DeviceDto {
     DeviceId id = INVALID_DEVICE_ID;
     TrackId trackId = INVALID_TRACK_ID;
+    // Immediate parents, for rendering the graph. `rackId`/`chainId` locate a
+    // device one level up but cannot address it: `id` is unique only within a
+    // section, and nesting can be arbitrarily deep. Use `devicePath` as the
+    // address.
     std::optional<RackId> rackId;
     std::optional<ChainId> chainId;
+    DevicePathDto devicePath;
     juce::String name;
     juce::String type;
     juce::String format;
@@ -216,36 +251,6 @@ struct AutomationPointDto {
     juce::String curve;
 
     bool operator==(const AutomationPointDto&) const = default;
-};
-
-/**
- * @brief Public projection of a `ChainNodePath`.
- *
- * A device id alone does not identify a device: the main FX chain, the
- * post-fader list, and the mixer-analysis section each carry their own
- * `DeviceId` counter, so id 3 can exist in all three at once on one track.
- * `section` carries that discriminator and `steps` carries the route through
- * nested racks and chains, so this round-trips to exactly one device.
- *
- * Step types are strings rather than enum ordinals: this is a public wire
- * contract consumed by scripts and MCP clients, and it must not be coupled to
- * the internal `ChainStepType` ordering.
- */
-struct DevicePathStepDto {
-    juce::String type;  // "rack" | "chain" | "device"
-    int id = -1;
-
-    bool operator==(const DevicePathStepDto&) const = default;
-};
-
-struct DevicePathDto {
-    TrackId trackId = INVALID_TRACK_ID;
-    juce::String section{"fx"};  // "fx" | "post_fx" | "mixer_analysis"
-    bool trackLevel = false;
-    std::optional<DeviceId> topLevelDeviceId;
-    std::vector<DevicePathStepDto> steps;
-
-    bool operator==(const DevicePathDto&) const = default;
 };
 
 struct AutomationTargetDto {

--- a/magda/daw/api/remote_api.hpp
+++ b/magda/daw/api/remote_api.hpp
@@ -7,6 +7,7 @@
 #include <string_view>
 #include <vector>
 
+#include "../core/ChainNodePath.hpp"
 #include "../core/ClipTypes.hpp"
 #include "../core/TypeIds.hpp"
 
@@ -217,10 +218,40 @@ struct AutomationPointDto {
     bool operator==(const AutomationPointDto&) const = default;
 };
 
+/**
+ * @brief Public projection of a `ChainNodePath`.
+ *
+ * A device id alone does not identify a device: the main FX chain, the
+ * post-fader list, and the mixer-analysis section each carry their own
+ * `DeviceId` counter, so id 3 can exist in all three at once on one track.
+ * `section` carries that discriminator and `steps` carries the route through
+ * nested racks and chains, so this round-trips to exactly one device.
+ *
+ * Step types are strings rather than enum ordinals: this is a public wire
+ * contract consumed by scripts and MCP clients, and it must not be coupled to
+ * the internal `ChainStepType` ordering.
+ */
+struct DevicePathStepDto {
+    juce::String type;  // "rack" | "chain" | "device"
+    int id = -1;
+
+    bool operator==(const DevicePathStepDto&) const = default;
+};
+
+struct DevicePathDto {
+    TrackId trackId = INVALID_TRACK_ID;
+    juce::String section{"fx"};  // "fx" | "post_fx" | "mixer_analysis"
+    bool trackLevel = false;
+    std::optional<DeviceId> topLevelDeviceId;
+    std::vector<DevicePathStepDto> steps;
+
+    bool operator==(const DevicePathDto&) const = default;
+};
+
 struct AutomationTargetDto {
     juce::String kind;
-    std::optional<TrackId> trackId;
-    std::optional<DeviceId> deviceId;
+    // Absent for edit-scoped kinds (`tempo`), which address a global value.
+    std::optional<DevicePathDto> devicePath;
     int parameterIndex = -1;
     int modId = -1;
     int modParameterIndex = -1;
@@ -287,6 +318,7 @@ juce::var toJson(const TransportDto& dto);
 juce::var toJson(const SessionSlotDto& dto);
 juce::var toJson(const SessionDto& dto);
 juce::var toJson(const AutomationPointDto& dto);
+juce::var toJson(const DevicePathDto& dto);
 juce::var toJson(const AutomationTargetDto& dto);
 juce::var toJson(const AutomationLaneDto& dto);
 
@@ -311,6 +343,25 @@ SelectionDto makeSelectionDto(MagdaApi& api);
 TransportDto makeTransportDto(MagdaApi& api);
 SessionDto makeSessionDto(MagdaApi& api);
 AutomationLaneDto makeAutomationLaneDto(const AutomationLaneInfo& lane);
+
+/**
+ * @brief Project an internal path to its public form.
+ *
+ * Lifts a leading `Segment` step out into `section` so the remaining steps are
+ * a uniform rack/chain/device route, and maps step types to strings.
+ */
+DevicePathDto makeDevicePathDto(const ChainNodePath& path);
+
+/**
+ * @brief Rebuild an internal path from its public form.
+ *
+ * Returns nullopt on an unrecognised `section` or step `type`. Round-trips
+ * with `makeDevicePathDto` for every path the `ChainNodePath` factories
+ * produce — including which of the three per-section `DeviceId` spaces the
+ * leaf belongs to. An explicit leading `Segment(Fx)` step normalizes to the
+ * implicit form, which is the same path by every accessor.
+ */
+std::optional<ChainNodePath> toChainNodePath(const DevicePathDto& dto);
 
 // makeSelectionDto, makeTransportDto, and makeSessionDto read MagdaApi live
 // state and assert the JUCE message thread. Tests drive them from the Catch2

--- a/magda/daw/api/remote_api_projection.cpp
+++ b/magda/daw/api/remote_api_projection.cpp
@@ -155,12 +155,13 @@ juce::String safeRoutingId(const juce::String& id) {
 }
 
 DeviceDto makeDeviceDto(const DeviceInfo& device, TrackId trackId, std::optional<RackId> rackId,
-                        std::optional<ChainId> chainId) {
+                        std::optional<ChainId> chainId, const ChainNodePath& devicePath) {
     DeviceDto dto;
     dto.id = device.id;
     dto.trackId = trackId;
     dto.rackId = rackId;
     dto.chainId = chainId;
+    dto.devicePath = makeDevicePathDto(devicePath);
     dto.name = device.name;
     dto.type = deviceTypeName(device.deviceType);
     dto.format = pluginFormatName(device.format);
@@ -170,8 +171,11 @@ DeviceDto makeDeviceDto(const DeviceInfo& device, TrackId trackId, std::optional
     return dto;
 }
 
+// `rackPath` addresses this rack; each chain and device extends it, so nesting
+// depth is carried exactly rather than flattened to an immediate parent.
 void appendRack(const RackInfo& rack, TrackId trackId, std::optional<RackId> parentRackId,
-                std::optional<ChainId> parentChainId, DeviceGraphDto& graph) {
+                std::optional<ChainId> parentChainId, const ChainNodePath& rackPath,
+                DeviceGraphDto& graph) {
     RackDto rackDto;
     rackDto.id = rack.id;
     rackDto.trackId = trackId;
@@ -197,15 +201,18 @@ void appendRack(const RackInfo& rack, TrackId trackId, std::optional<RackId> par
         chainDto.volumeDb = chain.volume;
         chainDto.pan = chain.pan;
 
+        const auto chainPath = rackPath.withChain(chain.id);
         for (const auto& element : chain.elements) {
             if (isDevice(element)) {
                 const auto& device = getDevice(element);
                 chainDto.deviceIds.push_back(device.id);
-                graph.devices.push_back(makeDeviceDto(device, trackId, rack.id, chain.id));
+                graph.devices.push_back(makeDeviceDto(device, trackId, rack.id, chain.id,
+                                                      chainPath.withDevice(device.id)));
             } else {
                 const auto& nested = getRack(element);
                 chainDto.nestedRackIds.push_back(nested.id);
-                appendRack(nested, trackId, rack.id, chain.id, graph);
+                appendRack(nested, trackId, rack.id, chain.id, chainPath.withRack(nested.id),
+                           graph);
             }
         }
         graph.chains.push_back(std::move(chainDto));
@@ -296,15 +303,22 @@ DeviceGraphDto makeDeviceGraphDto(const std::vector<TrackInfo>& tracks) {
     for (const auto& track : tracks) {
         for (const auto& element : track.chain.fxChainElements) {
             if (isDevice(element)) {
+                const auto& device = getDevice(element);
                 graph.devices.push_back(
-                    makeDeviceDto(getDevice(element), track.id, std::nullopt, std::nullopt));
+                    makeDeviceDto(device, track.id, std::nullopt, std::nullopt,
+                                  ChainNodePath::topLevelDevice(track.id, device.id)));
             } else {
-                appendRack(getRack(element), track.id, std::nullopt, std::nullopt, graph);
+                const auto& rack = getRack(element);
+                appendRack(rack, track.id, std::nullopt, std::nullopt,
+                           ChainNodePath::rack(track.id, rack.id), graph);
             }
         }
+        // Post-fx devices allocate ids from their own counter, so they collide
+        // with fx-chain ids; only the path tells the two apart.
         for (const auto& element : track.chain.postFxChainElements)
             graph.devices.push_back(
-                makeDeviceDto(element.device, track.id, std::nullopt, std::nullopt));
+                makeDeviceDto(element.device, track.id, std::nullopt, std::nullopt,
+                              ChainNodePath::postFxDevice(track.id, element.device.id)));
         // mixerAnalysisElements are session-only UI state and are deliberately excluded.
     }
     return graph;

--- a/magda/daw/api/remote_api_projection.cpp
+++ b/magda/daw/api/remote_api_projection.cpp
@@ -367,10 +367,8 @@ AutomationLaneDto makeAutomationLaneDto(const AutomationLaneInfo& lane) {
     dto.type = lane.type == AutomationLaneType::Absolute ? "absolute" : "clip_based";
     dto.name = lane.getDisplayName();
     dto.target.kind = juce::String(toString(lane.target.kind));
-    if (!lane.target.isEditScoped() && lane.target.devicePath.trackId != INVALID_TRACK_ID)
-        dto.target.trackId = lane.target.devicePath.trackId;
-    if (lane.target.deviceId() != INVALID_DEVICE_ID)
-        dto.target.deviceId = lane.target.deviceId();
+    if (!lane.target.isEditScoped() && lane.target.devicePath.isValid())
+        dto.target.devicePath = makeDevicePathDto(lane.target.devicePath);
     dto.target.parameterIndex = lane.target.paramIndex;
     dto.target.modId = lane.target.modId;
     dto.target.modParameterIndex = lane.target.modParamIndex;
@@ -381,6 +379,86 @@ AutomationLaneDto makeAutomationLaneDto(const AutomationLaneInfo& lane) {
     }
     dto.clipIds = lane.clipIds;
     return dto;
+}
+
+// ============================================================================
+// ChainNodePath <-> DevicePathDto
+// ============================================================================
+
+DevicePathDto makeDevicePathDto(const ChainNodePath& path) {
+    DevicePathDto dto;
+    dto.trackId = path.trackId;
+    dto.trackLevel = path.isTrackLevel;
+    if (path.topLevelDeviceId != INVALID_DEVICE_ID)
+        dto.topLevelDeviceId = path.topLevelDeviceId;
+
+    // A Segment step is only ever leading (post-fx and mixer-analysis are flat
+    // by construction), so lifting it out leaves a pure rack/chain/device route.
+    size_t first = 0;
+    if (!path.steps.empty() && path.steps.front().type == ChainStepType::Segment) {
+        switch (static_cast<ChainSegment>(path.steps.front().id)) {
+            case ChainSegment::PostFx:
+                dto.section = "post_fx";
+                break;
+            case ChainSegment::MixerAnalysis:
+                dto.section = "mixer_analysis";
+                break;
+            case ChainSegment::Fx:
+                dto.section = "fx";
+                break;
+        }
+        first = 1;
+    }
+
+    for (size_t i = first; i < path.steps.size(); ++i) {
+        const auto& step = path.steps[i];
+        switch (step.type) {
+            case ChainStepType::Rack:
+                dto.steps.push_back({"rack", step.id});
+                break;
+            case ChainStepType::Chain:
+                dto.steps.push_back({"chain", step.id});
+                break;
+            case ChainStepType::Device:
+                dto.steps.push_back({"device", step.id});
+                break;
+            case ChainStepType::Segment:
+                // Non-leading segments are not produced by any factory; drop
+                // rather than emit a step type the public contract lacks.
+                break;
+        }
+    }
+
+    return dto;
+}
+
+std::optional<ChainNodePath> toChainNodePath(const DevicePathDto& dto) {
+    ChainNodePath path;
+    path.trackId = dto.trackId;
+    path.isTrackLevel = dto.trackLevel;
+    path.topLevelDeviceId = dto.topLevelDeviceId.value_or(INVALID_DEVICE_ID);
+
+    if (dto.section == "post_fx") {
+        path.steps.push_back({ChainStepType::Segment, static_cast<int>(ChainSegment::PostFx)});
+    } else if (dto.section == "mixer_analysis") {
+        path.steps.push_back(
+            {ChainStepType::Segment, static_cast<int>(ChainSegment::MixerAnalysis)});
+    } else if (dto.section != "fx") {
+        return std::nullopt;
+    }
+
+    for (const auto& step : dto.steps) {
+        if (step.type == "rack")
+            path.steps.push_back({ChainStepType::Rack, step.id});
+        else if (step.type == "chain")
+            path.steps.push_back({ChainStepType::Chain, step.id});
+        else if (step.type == "device")
+            path.steps.push_back({ChainStepType::Device, step.id});
+        else
+            return std::nullopt;
+    }
+
+    return path;
 }
 
 }  // namespace magda::remote

--- a/magda/daw/core/CMakeLists.txt
+++ b/magda/daw/core/CMakeLists.txt
@@ -5,6 +5,8 @@
 target_sources(magda_daw PRIVATE
     Config.cpp
     AppPaths.cpp
+    ChainNodePath.cpp
+    ControlTarget.cpp
     UIScale.cpp
     UpdateChecker.cpp
     ViewModeController.cpp

--- a/magda/daw/core/ChainNodePath.cpp
+++ b/magda/daw/core/ChainNodePath.cpp
@@ -1,0 +1,64 @@
+#include "ChainNodePath.hpp"
+
+namespace magda {
+
+juce::var toVar(const ChainNodePath& path) {
+    auto* obj = new juce::DynamicObject();
+    obj->setProperty("trackId", path.trackId);
+    obj->setProperty("topLevelDeviceId", path.topLevelDeviceId);
+    obj->setProperty("isTrackLevel", path.isTrackLevel);
+
+    juce::Array<juce::var> steps;
+    for (const auto& step : path.steps) {
+        auto* stepObj = new juce::DynamicObject();
+        stepObj->setProperty("type", static_cast<int>(step.type));
+        stepObj->setProperty("id", step.id);
+        steps.add(juce::var(stepObj));
+    }
+    obj->setProperty("steps", juce::var(steps));
+
+    return juce::var(obj);
+}
+
+bool fromVar(const juce::var& v, ChainNodePath& out) {
+    if (!v.isObject())
+        return false;
+
+    auto* obj = v.getDynamicObject();
+    if (obj == nullptr)
+        return false;
+
+    ChainNodePath path;
+    path.trackId = static_cast<int>(obj->getProperty("trackId"));
+
+    if (obj->hasProperty("topLevelDeviceId"))
+        path.topLevelDeviceId = static_cast<int>(obj->getProperty("topLevelDeviceId"));
+    if (obj->hasProperty("isTrackLevel"))
+        path.isTrackLevel = static_cast<bool>(obj->getProperty("isTrackLevel"));
+
+    auto stepsVar = obj->getProperty("steps");
+    if (stepsVar.isArray()) {
+        for (const auto& stepVar : *stepsVar.getArray()) {
+            if (!stepVar.isObject())
+                continue;
+            auto* stepObj = stepVar.getDynamicObject();
+            if (stepObj == nullptr)
+                continue;
+
+            const auto rawType = static_cast<int>(stepObj->getProperty("type"));
+            if (rawType < static_cast<int>(ChainStepType::Rack) ||
+                rawType > static_cast<int>(ChainStepType::Segment))
+                continue;
+
+            ChainPathStep step;
+            step.type = static_cast<ChainStepType>(rawType);
+            step.id = static_cast<int>(stepObj->getProperty("id"));
+            path.steps.push_back(step);
+        }
+    }
+
+    out = path;
+    return true;
+}
+
+}  // namespace magda

--- a/magda/daw/core/ChainNodePath.cpp
+++ b/magda/daw/core/ChainNodePath.cpp
@@ -1,5 +1,7 @@
 #include "ChainNodePath.hpp"
 
+#include <limits>
+
 namespace magda {
 
 namespace {
@@ -7,13 +9,22 @@ namespace {
 // A missing property reads back as a void var, which converts to 0. Silently
 // accepting that turns an empty object into a valid address, so every numeric
 // field a path depends on must be present and actually numeric.
+//
+// The range check matters as much as the type check: narrowing an out-of-range
+// int64 wraps it into a different valid id, so 4294967297 would address track 1.
 bool readRequiredInt(const juce::DynamicObject& obj, const char* name, int& out) {
     if (!obj.hasProperty(name))
         return false;
     const auto value = obj.getProperty(name);
     if (!value.isInt() && !value.isInt64())
         return false;
-    out = static_cast<int>(value);
+
+    const auto wide = static_cast<juce::int64>(value);
+    if (wide < static_cast<juce::int64>(std::numeric_limits<int>::lowest()) ||
+        wide > static_cast<juce::int64>(std::numeric_limits<int>::max()))
+        return false;
+
+    out = static_cast<int>(wide);
     return true;
 }
 
@@ -113,6 +124,19 @@ bool fromVar(const juce::var& v, ChainNodePath& out) {
         // case: an explicit `false` is left alone.
         path.isTrackLevel = true;
     }
+
+    // Track-level, legacy top-level-device, and stepped routes are three
+    // different ways to say where a path points, and getType() picks between
+    // them by precedence. A path carrying more than one passes isValid() while
+    // its accessors disagree — getDeviceId() prefers topLevelDeviceId, but
+    // isPostFx() reads steps.front() — so the same path resolves to different
+    // devices depending on which accessor the caller reaches for. No factory
+    // builds that combination; only corrupt data does.
+    const int representations = (path.isTrackLevel ? 1 : 0) +
+                                (path.topLevelDeviceId != INVALID_DEVICE_ID ? 1 : 0) +
+                                (path.steps.empty() ? 0 : 1);
+    if (representations > 1)
+        return false;
 
     out = path;
     return true;

--- a/magda/daw/core/ChainNodePath.cpp
+++ b/magda/daw/core/ChainNodePath.cpp
@@ -33,28 +33,56 @@ bool fromVar(const juce::var& v, ChainNodePath& out) {
 
     if (obj->hasProperty("topLevelDeviceId"))
         path.topLevelDeviceId = static_cast<int>(obj->getProperty("topLevelDeviceId"));
-    if (obj->hasProperty("isTrackLevel"))
-        path.isTrackLevel = static_cast<bool>(obj->getProperty("isTrackLevel"));
 
+    // Parsing fails closed. Skipping an unreadable step would shorten the
+    // address rather than reject it, and a shorter path still resolves — just
+    // to a different device. Dropping a leading Segment step in particular
+    // re-points a post-fx path at the main FX chain, because isPostFx() tests
+    // steps.front().
     auto stepsVar = obj->getProperty("steps");
     if (stepsVar.isArray()) {
-        for (const auto& stepVar : *stepsVar.getArray()) {
+        const auto& steps = *stepsVar.getArray();
+        for (int i = 0; i < steps.size(); ++i) {
+            const auto& stepVar = steps.getReference(i);
             if (!stepVar.isObject())
-                continue;
+                return false;
             auto* stepObj = stepVar.getDynamicObject();
             if (stepObj == nullptr)
-                continue;
+                return false;
 
             const auto rawType = static_cast<int>(stepObj->getProperty("type"));
             if (rawType < static_cast<int>(ChainStepType::Rack) ||
                 rawType > static_cast<int>(ChainStepType::Segment))
-                continue;
+                return false;
 
             ChainPathStep step;
             step.type = static_cast<ChainStepType>(rawType);
             step.id = static_cast<int>(stepObj->getProperty("id"));
+
+            // A Segment step names one of the track's flat sections. It is only
+            // ever leading, and its id must be a real ChainSegment.
+            if (step.type == ChainStepType::Segment) {
+                if (i != 0)
+                    return false;
+                if (step.id < static_cast<int>(ChainSegment::Fx) ||
+                    step.id > static_cast<int>(ChainSegment::MixerAnalysis))
+                    return false;
+            }
+
             path.steps.push_back(step);
         }
+    }
+
+    if (obj->hasProperty("isTrackLevel")) {
+        path.isTrackLevel = static_cast<bool>(obj->getProperty("isTrackLevel"));
+    } else if (path.trackId != INVALID_TRACK_ID && path.steps.empty() &&
+               path.topLevelDeviceId == INVALID_DEVICE_ID) {
+        // Legacy producers omitted the flag entirely. A path naming a track but
+        // no steps and no device addresses nothing, and a track-level path is
+        // the only thing that serializes to that shape, so recover it rather
+        // than hand back an unusable address. Scoped to the absent-property
+        // case: an explicit `false` is left alone.
+        path.isTrackLevel = true;
     }
 
     out = path;

--- a/magda/daw/core/ChainNodePath.cpp
+++ b/magda/daw/core/ChainNodePath.cpp
@@ -2,6 +2,23 @@
 
 namespace magda {
 
+namespace {
+
+// A missing property reads back as a void var, which converts to 0. Silently
+// accepting that turns an empty object into a valid address, so every numeric
+// field a path depends on must be present and actually numeric.
+bool readRequiredInt(const juce::DynamicObject& obj, const char* name, int& out) {
+    if (!obj.hasProperty(name))
+        return false;
+    const auto value = obj.getProperty(name);
+    if (!value.isInt() && !value.isInt64())
+        return false;
+    out = static_cast<int>(value);
+    return true;
+}
+
+}  // namespace
+
 juce::var toVar(const ChainNodePath& path) {
     auto* obj = new juce::DynamicObject();
     obj->setProperty("trackId", path.trackId);
@@ -29,18 +46,24 @@ bool fromVar(const juce::var& v, ChainNodePath& out) {
         return false;
 
     ChainNodePath path;
-    path.trackId = static_cast<int>(obj->getProperty("trackId"));
+    // Required: without it an empty object would parse as a path to track 0.
+    if (!readRequiredInt(*obj, "trackId", path.trackId))
+        return false;
 
-    if (obj->hasProperty("topLevelDeviceId"))
-        path.topLevelDeviceId = static_cast<int>(obj->getProperty("topLevelDeviceId"));
+    if (obj->hasProperty("topLevelDeviceId") &&
+        !readRequiredInt(*obj, "topLevelDeviceId", path.topLevelDeviceId))
+        return false;
 
     // Parsing fails closed. Skipping an unreadable step would shorten the
     // address rather than reject it, and a shorter path still resolves — just
     // to a different device. Dropping a leading Segment step in particular
     // re-points a post-fx path at the main FX chain, because isPostFx() tests
     // steps.front().
-    auto stepsVar = obj->getProperty("steps");
-    if (stepsVar.isArray()) {
+    if (obj->hasProperty("steps")) {
+        const auto stepsVar = obj->getProperty("steps");
+        if (!stepsVar.isArray())
+            return false;
+
         const auto& steps = *stepsVar.getArray();
         for (int i = 0; i < steps.size(); ++i) {
             const auto& stepVar = steps.getReference(i);
@@ -50,14 +73,17 @@ bool fromVar(const juce::var& v, ChainNodePath& out) {
             if (stepObj == nullptr)
                 return false;
 
-            const auto rawType = static_cast<int>(stepObj->getProperty("type"));
+            int rawType = 0;
+            if (!readRequiredInt(*stepObj, "type", rawType))
+                return false;
             if (rawType < static_cast<int>(ChainStepType::Rack) ||
                 rawType > static_cast<int>(ChainStepType::Segment))
                 return false;
 
             ChainPathStep step;
             step.type = static_cast<ChainStepType>(rawType);
-            step.id = static_cast<int>(stepObj->getProperty("id"));
+            if (!readRequiredInt(*stepObj, "id", step.id))
+                return false;
 
             // A Segment step names one of the track's flat sections. It is only
             // ever leading, and its id must be a real ChainSegment.
@@ -74,7 +100,10 @@ bool fromVar(const juce::var& v, ChainNodePath& out) {
     }
 
     if (obj->hasProperty("isTrackLevel")) {
-        path.isTrackLevel = static_cast<bool>(obj->getProperty("isTrackLevel"));
+        const auto flag = obj->getProperty("isTrackLevel");
+        if (!flag.isBool())
+            return false;
+        path.isTrackLevel = static_cast<bool>(flag);
     } else if (path.trackId != INVALID_TRACK_ID && path.steps.empty() &&
                path.topLevelDeviceId == INVALID_DEVICE_ID) {
         // Legacy producers omitted the flag entirely. A path naming a track but

--- a/magda/daw/core/ChainNodePath.hpp
+++ b/magda/daw/core/ChainNodePath.hpp
@@ -292,4 +292,32 @@ struct ChainNodePath {
     }
 };
 
+// ============================================================================
+// Canonical serialization
+// ============================================================================
+
+/**
+ * @brief Serialize a path to its canonical persisted JSON form.
+ *
+ * Shape: `{trackId, topLevelDeviceId, isTrackLevel, steps:[{type,id}]}`, where
+ * `type` is the integer value of `ChainStepType`. This is the on-disk format
+ * already used by stored parameter aliases, so it must stay
+ * backward-compatible — see the note on `ChainStepType` about keeping the
+ * enum's integer values stable.
+ *
+ * This is the *persistence* form. The remote API publishes a separate
+ * string-typed projection so external clients never depend on enum ordering.
+ */
+juce::var toVar(const ChainNodePath& path);
+
+/**
+ * @brief Parse a path from its canonical persisted JSON form.
+ *
+ * Tolerant of absent optional fields so older saved data keeps loading.
+ * Returns false and leaves `out` untouched if `v` is not an object; an
+ * unparseable path yields an invalid `ChainNodePath`, which callers should
+ * check with `isValid()`.
+ */
+bool fromVar(const juce::var& v, ChainNodePath& out);
+
 }  // namespace magda

--- a/magda/daw/core/ControlTarget.cpp
+++ b/magda/daw/core/ControlTarget.cpp
@@ -1,0 +1,77 @@
+#include "ControlTarget.hpp"
+
+#include <array>
+
+namespace magda {
+
+namespace {
+
+constexpr std::array<ControlTarget::Kind, 7> ALL_KINDS = {
+    ControlTarget::Kind::PluginParam, ControlTarget::Kind::DeviceMacro,
+    ControlTarget::Kind::ModParam,    ControlTarget::Kind::TrackVolume,
+    ControlTarget::Kind::TrackPan,    ControlTarget::Kind::SendLevel,
+    ControlTarget::Kind::Tempo,
+};
+
+}  // namespace
+
+std::optional<ControlTarget::Kind> parseControlTargetKind(juce::StringRef kind) {
+    const juce::String name(kind);
+    for (auto candidate : ALL_KINDS) {
+        if (name == toString(candidate))
+            return candidate;
+    }
+    return std::nullopt;
+}
+
+juce::var toVar(const ControlTarget& target) {
+    auto* obj = new juce::DynamicObject();
+    obj->setProperty("kind", juce::String(toString(target.kind)));
+
+    // Edit-scoped targets address a global value and carry no path; emitting a
+    // placeholder one would round-trip into a bogus Track[-1] path.
+    if (!target.isEditScoped())
+        obj->setProperty("devicePath", toVar(target.devicePath));
+
+    obj->setProperty("paramIndex", target.paramIndex);
+    obj->setProperty("modId", target.modId);
+    obj->setProperty("modParamIndex", target.modParamIndex);
+    obj->setProperty("sendBusIndex", target.sendBusIndex);
+
+    return juce::var(obj);
+}
+
+bool fromVar(const juce::var& v, ControlTarget& out) {
+    if (!v.isObject())
+        return false;
+
+    auto* obj = v.getDynamicObject();
+    if (obj == nullptr)
+        return false;
+
+    const auto kind = parseControlTargetKind(obj->getProperty("kind").toString());
+    if (!kind.has_value())
+        return false;
+
+    ControlTarget target;
+    target.kind = *kind;
+
+    if (!target.isEditScoped()) {
+        if (!fromVar(obj->getProperty("devicePath"), target.devicePath))
+            return false;
+    }
+
+    if (obj->hasProperty("paramIndex"))
+        target.paramIndex = static_cast<int>(obj->getProperty("paramIndex"));
+    if (obj->hasProperty("modId"))
+        target.modId = static_cast<int>(obj->getProperty("modId"));
+    if (obj->hasProperty("modParamIndex"))
+        target.modParamIndex = static_cast<int>(obj->getProperty("modParamIndex"));
+    if (obj->hasProperty("sendBusIndex"))
+        target.sendBusIndex = static_cast<int>(obj->getProperty("sendBusIndex"));
+
+    out = target;
+    return true;
+}
+
+}  // namespace magda

--- a/magda/daw/core/ControlTarget.hpp
+++ b/magda/daw/core/ControlTarget.hpp
@@ -2,6 +2,8 @@
 
 #include <juce_core/juce_core.h>
 
+#include <optional>
+
 #include "ChainNodePath.hpp"
 #include "TypeIds.hpp"
 
@@ -164,6 +166,34 @@ struct ControlTarget {
         return devicePath.getDeviceId();
     }
 };
+
+// ============================================================================
+// Canonical serialization
+// ============================================================================
+
+/**
+ * @brief Serialize a target to its canonical persisted JSON form.
+ *
+ * Shape: `{kind, devicePath?, paramIndex, modId, modParamIndex, sendBusIndex}`.
+ * `kind` is the stable string from `toString`, not an enum ordinal.
+ * `devicePath` is omitted for edit-scoped kinds (see `isEditScoped`).
+ *
+ * Every consumer that persists a target — macro/mod links, automation lanes,
+ * MIDI/OSC bindings, alias resolvers — should route through this rather than
+ * hand-rolling a copy.
+ */
+juce::var toVar(const ControlTarget& target);
+
+/**
+ * @brief Parse a target from its canonical persisted JSON form.
+ *
+ * Returns false if `v` is not an object or carries an unrecognised `kind`.
+ * A parsed target is not guaranteed meaningful — check `isValid()`.
+ */
+bool fromVar(const juce::var& v, ControlTarget& out);
+
+/** @brief Parse a `toString` kind back to its enum value. */
+std::optional<ControlTarget::Kind> parseControlTargetKind(juce::StringRef kind);
 
 inline const char* toString(ControlTarget::Kind kind) {
     switch (kind) {

--- a/magda/daw/core/aliases/AliasRegistry.cpp
+++ b/magda/daw/core/aliases/AliasRegistry.cpp
@@ -301,24 +301,8 @@ juce::var serializeStoredAlias(const StoredAlias& alias) {
     obj->setProperty("paramIndex", alias.paramIndex);
     obj->setProperty("paramNameAtSetTime", alias.paramNameAtSetTime);
 
-    if (alias.path.has_value()) {
-        // Inline ChainNodePath serialization
-        const auto& path = *alias.path;
-        auto* pathObj = new juce::DynamicObject();
-        pathObj->setProperty("trackId", path.trackId);
-        pathObj->setProperty("topLevelDeviceId", path.topLevelDeviceId);
-        pathObj->setProperty("isTrackLevel", path.isTrackLevel);
-
-        juce::Array<juce::var> stepsArray;
-        for (const auto& step : path.steps) {
-            auto* stepObj = new juce::DynamicObject();
-            stepObj->setProperty("type", static_cast<int>(step.type));
-            stepObj->setProperty("id", step.id);
-            stepsArray.add(juce::var(stepObj));
-        }
-        pathObj->setProperty("steps", juce::var(stepsArray));
-        obj->setProperty("path", juce::var(pathObj));
-    }
+    if (alias.path.has_value())
+        obj->setProperty("path", toVar(*alias.path));
 
     return juce::var(obj);
 }
@@ -337,30 +321,9 @@ bool deserializeStoredAlias(const juce::var& v, StoredAlias& out) {
     out.path = std::nullopt;
 
     if (obj->hasProperty("path")) {
-        auto pathVar = obj->getProperty("path");
-        if (pathVar.isObject()) {
-            auto* pathObj = pathVar.getDynamicObject();
-            ChainNodePath path;
-            path.trackId = static_cast<int>(pathObj->getProperty("trackId"));
-            path.topLevelDeviceId = static_cast<int>(pathObj->getProperty("topLevelDeviceId"));
-            if (pathObj->hasProperty("isTrackLevel"))
-                path.isTrackLevel = static_cast<bool>(pathObj->getProperty("isTrackLevel"));
-
-            auto stepsVar = pathObj->getProperty("steps");
-            if (stepsVar.isArray()) {
-                for (const auto& stepVar : *stepsVar.getArray()) {
-                    if (!stepVar.isObject())
-                        continue;
-                    auto* stepObj = stepVar.getDynamicObject();
-                    ChainPathStep step;
-                    step.type =
-                        static_cast<ChainStepType>(static_cast<int>(stepObj->getProperty("type")));
-                    step.id = static_cast<int>(stepObj->getProperty("id"));
-                    path.steps.push_back(step);
-                }
-            }
+        ChainNodePath path;
+        if (fromVar(obj->getProperty("path"), path))
             out.path = path;
-        }
     }
 
     return out.isValid();

--- a/magda/daw/core/aliases/AliasRegistry.cpp
+++ b/magda/daw/core/aliases/AliasRegistry.cpp
@@ -321,9 +321,16 @@ bool deserializeStoredAlias(const juce::var& v, StoredAlias& out) {
     out.path = std::nullopt;
 
     if (obj->hasProperty("path")) {
-        ChainNodePath path;
-        if (fromVar(obj->getProperty("path"), path))
+        const auto pathVar = obj->getProperty("path");
+        // An absent path means a user-global alias. A path that is present but
+        // unreadable is corrupt, and must not quietly widen the alias to global
+        // scope — that retargets it just as surely as a wrong path would.
+        if (!pathVar.isVoid()) {
+            ChainNodePath path;
+            if (!fromVar(pathVar, path))
+                return false;
             out.path = path;
+        }
     }
 
     return out.isValid();

--- a/magda/daw/core/aliases/AliasRegistry.cpp
+++ b/magda/daw/core/aliases/AliasRegistry.cpp
@@ -320,17 +320,15 @@ bool deserializeStoredAlias(const juce::var& v, StoredAlias& out) {
     out.paramNameAtSetTime = obj->getProperty("paramNameAtSetTime").toString();
     out.path = std::nullopt;
 
+    // An absent path means a user-global alias. A path that is present but
+    // unreadable is corrupt, and must not quietly widen the alias to global
+    // scope — that retargets it just as surely as a wrong path would. JSON null
+    // parses to a void var, so it is caught here too rather than read as absent.
     if (obj->hasProperty("path")) {
-        const auto pathVar = obj->getProperty("path");
-        // An absent path means a user-global alias. A path that is present but
-        // unreadable is corrupt, and must not quietly widen the alias to global
-        // scope — that retargets it just as surely as a wrong path would.
-        if (!pathVar.isVoid()) {
-            ChainNodePath path;
-            if (!fromVar(pathVar, path))
-                return false;
-            out.path = path;
-        }
+        ChainNodePath path;
+        if (!fromVar(obj->getProperty("path"), path))
+            return false;
+        out.path = path;
     }
 
     return out.isValid();

--- a/magda/daw/core/aliases/Target.cpp
+++ b/magda/daw/core/aliases/Target.cpp
@@ -42,46 +42,16 @@ std::optional<ControlTarget::Kind> kindFromJsonString(const juce::String& s) {
     return std::nullopt;
 }
 
+// Shares the canonical ChainNodePath serializer. The wire shape is unchanged —
+// this was a byte-identical copy of it — but the canonical decoder validates
+// types and ranges and fails closed, where this one skipped unreadable steps
+// and so could shorten an address into a different device.
 void encodePath(juce::DynamicObject* obj, const ChainNodePath& path) {
-    auto* pathObj = new juce::DynamicObject();
-    pathObj->setProperty("trackId", path.trackId);
-    pathObj->setProperty("topLevelDeviceId", path.topLevelDeviceId);
-    pathObj->setProperty("isTrackLevel", path.isTrackLevel);
-
-    juce::Array<juce::var> stepsArray;
-    for (const auto& step : path.steps) {
-        auto* stepObj = new juce::DynamicObject();
-        stepObj->setProperty("type", static_cast<int>(step.type));
-        stepObj->setProperty("id", step.id);
-        stepsArray.add(juce::var(stepObj));
-    }
-    pathObj->setProperty("steps", juce::var(stepsArray));
-    obj->setProperty("path", juce::var(pathObj));
+    obj->setProperty("path", toVar(path));
 }
 
 bool decodePath(juce::DynamicObject* obj, ChainNodePath& out) {
-    auto pathVar = obj->getProperty("path");
-    if (!pathVar.isObject())
-        return false;
-    auto* pathObj = pathVar.getDynamicObject();
-    out.trackId = static_cast<int>(pathObj->getProperty("trackId"));
-    out.topLevelDeviceId = static_cast<int>(pathObj->getProperty("topLevelDeviceId"));
-    if (pathObj->hasProperty("isTrackLevel"))
-        out.isTrackLevel = static_cast<bool>(pathObj->getProperty("isTrackLevel"));
-
-    auto stepsVar = pathObj->getProperty("steps");
-    if (stepsVar.isArray()) {
-        for (const auto& stepVar : *stepsVar.getArray()) {
-            if (!stepVar.isObject())
-                continue;
-            auto* stepObj = stepVar.getDynamicObject();
-            ChainPathStep step;
-            step.type = static_cast<ChainStepType>(static_cast<int>(stepObj->getProperty("type")));
-            step.id = static_cast<int>(stepObj->getProperty("id"));
-            out.steps.push_back(step);
-        }
-    }
-    return true;
+    return fromVar(obj->getProperty("path"), out);
 }
 
 }  // namespace

--- a/magda/daw/project/serialization/AutomationModSerializer.cpp
+++ b/magda/daw/project/serialization/AutomationModSerializer.cpp
@@ -346,49 +346,19 @@ bool ProjectSerializer::deserializeBezierHandle(const juce::var& json, BezierHan
     return true;
 }
 
+// Project persistence shares the canonical ChainNodePath serializer rather than
+// keeping its own copy. The previous local writer omitted isTrackLevel, so every
+// saved TrackVolume/TrackPan/SendLevel target reloaded as an invalid path with
+// only a track id; fromVar recovers those legacy files.
 juce::var ProjectSerializer::serializeChainNodePath(const ChainNodePath& path) {
-    auto* obj = new juce::DynamicObject();
-
-    obj->setProperty("trackId", path.trackId);
-    obj->setProperty("topLevelDeviceId", path.topLevelDeviceId);
-
-    juce::Array<juce::var> stepsArray;
-    for (const auto& step : path.steps) {
-        auto* stepObj = new juce::DynamicObject();
-        stepObj->setProperty("type", static_cast<int>(step.type));
-        stepObj->setProperty("id", step.id);
-        stepsArray.add(juce::var(stepObj));
-    }
-    obj->setProperty("steps", juce::var(stepsArray));
-
-    return juce::var(obj);
+    return toVar(path);
 }
 
 bool ProjectSerializer::deserializeChainNodePath(const juce::var& json, ChainNodePath& outPath) {
-    if (!json.isObject()) {
-        lastError_ = "Chain node path is not an object";
+    if (!fromVar(json, outPath)) {
+        lastError_ = "Chain node path is malformed";
         return false;
     }
-
-    auto* obj = json.getDynamicObject();
-
-    outPath.trackId = obj->getProperty("trackId");
-    outPath.topLevelDeviceId = obj->getProperty("topLevelDeviceId");
-
-    auto stepsVar = obj->getProperty("steps");
-    if (stepsVar.isArray()) {
-        auto* arr = stepsVar.getArray();
-        for (const auto& stepVar : *arr) {
-            if (!stepVar.isObject())
-                continue;
-            auto* stepObj = stepVar.getDynamicObject();
-            ChainPathStep step;
-            step.type = static_cast<ChainStepType>(static_cast<int>(stepObj->getProperty("type")));
-            step.id = stepObj->getProperty("id");
-            outPath.steps.push_back(step);
-        }
-    }
-
     return true;
 }
 

--- a/magda/daw/ui/components/chain/CMakeLists.txt
+++ b/magda/daw/ui/components/chain/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(magda_daw_app PRIVATE
+    ChainNodePathDrag.cpp
     NodeComponent.cpp
     ChainRowComponent.cpp
     RackComponent.cpp

--- a/magda/daw/ui/components/chain/ChainNodePathDrag.cpp
+++ b/magda/daw/ui/components/chain/ChainNodePathDrag.cpp
@@ -1,0 +1,57 @@
+#include "ChainNodePathDrag.hpp"
+
+namespace magda::daw::ui {
+
+namespace {
+
+juce::String pathKey(int index) {
+    return index < 0 ? juce::String("path") : "path" + juce::String(index);
+}
+
+}  // namespace
+
+void writeChainNodePathToDragInfo(juce::DynamicObject& obj, const ChainNodePath& path, int index) {
+    obj.setProperty(pathKey(index), toVar(path));
+}
+
+std::optional<ChainNodePath> readChainNodePathFromDragInfo(const juce::DynamicObject& obj,
+                                                           int index) {
+    const auto key = pathKey(index);
+    if (!obj.hasProperty(key))
+        return std::nullopt;
+
+    ChainNodePath path;
+    if (!fromVar(obj.getProperty(key), path))
+        return std::nullopt;
+    if (!path.isValid())
+        return std::nullopt;
+
+    // Post-fx and mixer-analysis are flat, rail-managed sections with no
+    // reorder or reparent semantics, so the drop handlers have never accepted
+    // them. The previous decoders enforced this by refusing to decode a Segment
+    // step at all; state it directly instead.
+    if (path.isPostFx() || path.isMixerAnalysis())
+        return std::nullopt;
+
+    return path;
+}
+
+std::vector<ChainNodePath> readChainNodePathsFromDragInfo(const juce::DynamicObject& obj) {
+    std::vector<ChainNodePath> paths;
+
+    const auto count = static_cast<int>(obj.getProperty("pathCount"));
+    for (int i = 0; i < count; ++i) {
+        if (auto path = readChainNodePathFromDragInfo(obj, i))
+            paths.push_back(*path);
+    }
+
+    // Single-node drags from older call sites carry only the unsuffixed copy.
+    if (paths.empty()) {
+        if (auto path = readChainNodePathFromDragInfo(obj))
+            paths.push_back(*path);
+    }
+
+    return paths;
+}
+
+}  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/ChainNodePathDrag.hpp
+++ b/magda/daw/ui/components/chain/ChainNodePathDrag.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <optional>
+#include <vector>
+
+#include "../../../core/ChainNodePath.hpp"
+
+namespace magda::daw::ui {
+
+/**
+ * @brief Chain-node drag payloads, encoded with the canonical path serializer.
+ *
+ * A chain-element drag description carries one path per dragged node plus an
+ * unsuffixed copy of the first. These helpers own that layout so the drop
+ * handlers do not each re-derive it: previously five near-identical decoders
+ * across three files parsed the path out of flat `trackId`/`stepTypes`/`stepIds`
+ * keys, reading missing properties as 0 and turning unparseable step ids into
+ * `Rack(0)`.
+ *
+ * `index < 0` addresses the unsuffixed copy.
+ */
+void writeChainNodePathToDragInfo(juce::DynamicObject& obj, const ChainNodePath& path,
+                                  int index = -1);
+
+/**
+ * @brief Decode one path from a drag description.
+ *
+ * Returns nullopt when the entry is absent, malformed, or addresses a section
+ * the drop handlers cannot accept.
+ */
+std::optional<ChainNodePath> readChainNodePathFromDragInfo(const juce::DynamicObject& obj,
+                                                           int index = -1);
+
+/**
+ * @brief Decode every path a drag description carries.
+ *
+ * Reads `pathCount` entries, falling back to the unsuffixed copy when none
+ * decode. Malformed entries are dropped rather than failing the whole drag —
+ * a partial selection still has a sensible drop, and each surviving path has
+ * been validated.
+ */
+std::vector<ChainNodePath> readChainNodePathsFromDragInfo(const juce::DynamicObject& obj);
+
+}  // namespace magda::daw::ui

--- a/magda/daw/ui/components/chain/ChainPanel.cpp
+++ b/magda/daw/ui/components/chain/ChainPanel.cpp
@@ -1,5 +1,6 @@
 #include "ChainPanel.hpp"
 
+#include "ChainNodePathDrag.hpp"
 #include "DeviceSlotComponent.hpp"
 #include "NodeComponent.hpp"
 #include "RackComponent.hpp"
@@ -28,57 +29,21 @@ bool dragObjectToChainNodePath(const juce::DynamicObject& obj, magda::ChainNodeP
     if (type != "chainElement" && type != "chainElements")
         return false;
 
-    path.trackId = static_cast<magda::TrackId>(static_cast<int>(obj.getProperty("trackId")));
-    path.topLevelDeviceId =
-        static_cast<magda::DeviceId>(static_cast<int>(obj.getProperty("topLevelDeviceId")));
-    path.isTrackLevel = static_cast<bool>(obj.getProperty("isTrackLevel"));
-
-    auto stepTypes =
-        juce::StringArray::fromTokens(obj.getProperty("stepTypes").toString(), ",", "");
-    auto stepIds = juce::StringArray::fromTokens(obj.getProperty("stepIds").toString(), ",", "");
-    if (stepTypes.size() != stepIds.size())
+    const auto decoded = readChainNodePathFromDragInfo(obj);
+    if (!decoded)
         return false;
-
-    for (int i = 0; i < stepTypes.size(); ++i) {
-        const int typeValue = stepTypes[i].getIntValue();
-        if (typeValue < static_cast<int>(magda::ChainStepType::Rack) ||
-            typeValue > static_cast<int>(magda::ChainStepType::Device))
-            return false;
-        path.steps.push_back(
-            {static_cast<magda::ChainStepType>(typeValue), stepIds[i].getIntValue()});
-    }
-
-    return path.isValid();
+    path = *decoded;
+    return true;
 }
 
 bool dragObjectToChainNodePathAt(const juce::DynamicObject& obj, int index,
                                  magda::ChainNodePath& path) {
     path = {};
-    const auto suffix = juce::String(index);
-
-    path.trackId =
-        static_cast<magda::TrackId>(static_cast<int>(obj.getProperty("trackId" + suffix)));
-    path.topLevelDeviceId = static_cast<magda::DeviceId>(
-        static_cast<int>(obj.getProperty("topLevelDeviceId" + suffix)));
-    path.isTrackLevel = static_cast<bool>(obj.getProperty("isTrackLevel" + suffix));
-
-    auto stepTypes =
-        juce::StringArray::fromTokens(obj.getProperty("stepTypes" + suffix).toString(), ",", "");
-    auto stepIds =
-        juce::StringArray::fromTokens(obj.getProperty("stepIds" + suffix).toString(), ",", "");
-    if (stepTypes.size() != stepIds.size())
+    const auto decoded = readChainNodePathFromDragInfo(obj, index);
+    if (!decoded)
         return false;
-
-    for (int i = 0; i < stepTypes.size(); ++i) {
-        const int typeValue = stepTypes[i].getIntValue();
-        if (typeValue < static_cast<int>(magda::ChainStepType::Rack) ||
-            typeValue > static_cast<int>(magda::ChainStepType::Device))
-            return false;
-        path.steps.push_back(
-            {static_cast<magda::ChainStepType>(typeValue), stepIds[i].getIntValue()});
-    }
-
-    return path.isValid();
+    path = *decoded;
+    return true;
 }
 
 std::vector<magda::ChainNodePath> dragObjectToChainNodePaths(const juce::DynamicObject& obj) {

--- a/magda/daw/ui/components/chain/NodeComponent.cpp
+++ b/magda/daw/ui/components/chain/NodeComponent.cpp
@@ -3,6 +3,7 @@
 #include <BinaryData.h>
 
 #include "../../utils/SelectionPolicy.hpp"
+#include "ChainNodePathDrag.hpp"
 #include "ai/AIPanelComponent.hpp"
 #include "core/AutomationInfo.hpp"
 #include "core/GestureRouter.hpp"
@@ -21,29 +22,6 @@
 namespace magda::daw::ui {
 
 namespace {
-juce::String encodeStepTypes(const magda::ChainNodePath& path) {
-    juce::StringArray values;
-    for (const auto& step : path.steps)
-        values.add(juce::String(static_cast<int>(step.type)));
-    return values.joinIntoString(",");
-}
-
-juce::String encodeStepIds(const magda::ChainNodePath& path) {
-    juce::StringArray values;
-    for (const auto& step : path.steps)
-        values.add(juce::String(step.id));
-    return values.joinIntoString(",");
-}
-
-void writePathToDragInfo(juce::DynamicObject& obj, const magda::ChainNodePath& path,
-                         const juce::String& suffix = {}) {
-    obj.setProperty("trackId" + suffix, path.trackId);
-    obj.setProperty("topLevelDeviceId" + suffix, path.topLevelDeviceId);
-    obj.setProperty("isTrackLevel" + suffix, path.isTrackLevel);
-    obj.setProperty("stepTypes" + suffix, encodeStepTypes(path));
-    obj.setProperty("stepIds" + suffix, encodeStepIds(path));
-}
-
 juce::Image createChainNodeDragImage(const juce::String& label, int itemCount) {
     constexpr int width = 188;
     constexpr int height = 42;
@@ -1301,9 +1279,9 @@ void NodeComponent::mouseDrag(const juce::MouseEvent& e) {
                 auto* dragInfo = new juce::DynamicObject();
                 dragInfo->setProperty("type", paths.size() > 1 ? "chainElements" : "chainElement");
                 dragInfo->setProperty("pathCount", static_cast<int>(paths.size()));
-                writePathToDragInfo(*dragInfo, paths.front());
+                writeChainNodePathToDragInfo(*dragInfo, paths.front());
                 for (int i = 0; i < static_cast<int>(paths.size()); ++i)
-                    writePathToDragInfo(*dragInfo, paths[static_cast<size_t>(i)], juce::String(i));
+                    writeChainNodePathToDragInfo(*dragInfo, paths[static_cast<size_t>(i)], i);
 
                 const auto label =
                     paths.size() > 1 ? juce::String(paths.size()) + " Chain Items" : getNodeName();

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -28,6 +28,7 @@
 #include "../../utils/SelectionPolicy.hpp"
 #include "../automation/AutomationLaneComponent.hpp"
 #include "../automation/AutomationMenu.hpp"
+#include "../chain/ChainNodePathDrag.hpp"
 #include "../common/MasterSpeakerButton.hpp"
 #include "../mixer/LevelMeter.hpp"
 #include "../mixer/LevelMeterScale.hpp"
@@ -41,28 +42,11 @@ namespace {
 
 bool dragObjectToChainNodePathAt(const juce::DynamicObject& obj, int index, ChainNodePath& path) {
     path = {};
-    const auto suffix = juce::String(index);
-    path.trackId = static_cast<TrackId>(static_cast<int>(obj.getProperty("trackId" + suffix)));
-    path.topLevelDeviceId =
-        static_cast<DeviceId>(static_cast<int>(obj.getProperty("topLevelDeviceId" + suffix)));
-    path.isTrackLevel = static_cast<bool>(obj.getProperty("isTrackLevel" + suffix));
-
-    auto stepTypes =
-        juce::StringArray::fromTokens(obj.getProperty("stepTypes" + suffix).toString(), ",", "");
-    auto stepIds =
-        juce::StringArray::fromTokens(obj.getProperty("stepIds" + suffix).toString(), ",", "");
-    if (stepTypes.size() != stepIds.size())
+    const auto decoded = daw::ui::readChainNodePathFromDragInfo(obj, index);
+    if (!decoded)
         return false;
-
-    for (int i = 0; i < stepTypes.size(); ++i) {
-        const int typeValue = stepTypes[i].getIntValue();
-        if (typeValue < static_cast<int>(ChainStepType::Rack) ||
-            typeValue > static_cast<int>(ChainStepType::Device))
-            return false;
-        path.steps.push_back({static_cast<ChainStepType>(typeValue), stepIds[i].getIntValue()});
-    }
-
-    return path.isValid();
+    path = *decoded;
+    return true;
 }
 
 std::vector<ChainNodePath> dragObjectToChainNodePaths(const juce::DynamicObject& obj) {

--- a/magda/daw/ui/panels/content/TrackChainContent.cpp
+++ b/magda/daw/ui/panels/content/TrackChainContent.cpp
@@ -6,6 +6,7 @@
 #include <thread>
 
 #include "../../../../agents/gain_staging_agent.hpp"
+#include "../../components/chain/ChainNodePathDrag.hpp"
 #include "../../components/common/MasterSpeakerButton.hpp"
 #include "../../components/mixer/LevelMeterScale.hpp"
 #include "../../debug/DebugSettings.hpp"
@@ -47,57 +48,21 @@ bool dragObjectToChainNodePath(const juce::DynamicObject& obj, magda::ChainNodeP
     if (type != "chainElement" && type != "chainElements")
         return false;
 
-    path.trackId = static_cast<magda::TrackId>(static_cast<int>(obj.getProperty("trackId")));
-    path.topLevelDeviceId =
-        static_cast<magda::DeviceId>(static_cast<int>(obj.getProperty("topLevelDeviceId")));
-    path.isTrackLevel = static_cast<bool>(obj.getProperty("isTrackLevel"));
-
-    auto stepTypes =
-        juce::StringArray::fromTokens(obj.getProperty("stepTypes").toString(), ",", "");
-    auto stepIds = juce::StringArray::fromTokens(obj.getProperty("stepIds").toString(), ",", "");
-    if (stepTypes.size() != stepIds.size())
+    const auto decoded = readChainNodePathFromDragInfo(obj);
+    if (!decoded)
         return false;
-
-    for (int i = 0; i < stepTypes.size(); ++i) {
-        const int typeValue = stepTypes[i].getIntValue();
-        if (typeValue < static_cast<int>(magda::ChainStepType::Rack) ||
-            typeValue > static_cast<int>(magda::ChainStepType::Device))
-            return false;
-        path.steps.push_back(
-            {static_cast<magda::ChainStepType>(typeValue), stepIds[i].getIntValue()});
-    }
-
-    return path.isValid();
+    path = *decoded;
+    return true;
 }
 
 bool dragObjectToChainNodePathAt(const juce::DynamicObject& obj, int index,
                                  magda::ChainNodePath& path) {
     path = {};
-    const auto suffix = juce::String(index);
-
-    path.trackId =
-        static_cast<magda::TrackId>(static_cast<int>(obj.getProperty("trackId" + suffix)));
-    path.topLevelDeviceId = static_cast<magda::DeviceId>(
-        static_cast<int>(obj.getProperty("topLevelDeviceId" + suffix)));
-    path.isTrackLevel = static_cast<bool>(obj.getProperty("isTrackLevel" + suffix));
-
-    auto stepTypes =
-        juce::StringArray::fromTokens(obj.getProperty("stepTypes" + suffix).toString(), ",", "");
-    auto stepIds =
-        juce::StringArray::fromTokens(obj.getProperty("stepIds" + suffix).toString(), ",", "");
-    if (stepTypes.size() != stepIds.size())
+    const auto decoded = readChainNodePathFromDragInfo(obj, index);
+    if (!decoded)
         return false;
-
-    for (int i = 0; i < stepTypes.size(); ++i) {
-        const int typeValue = stepTypes[i].getIntValue();
-        if (typeValue < static_cast<int>(magda::ChainStepType::Rack) ||
-            typeValue > static_cast<int>(magda::ChainStepType::Device))
-            return false;
-        path.steps.push_back(
-            {static_cast<magda::ChainStepType>(typeValue), stepIds[i].getIntValue()});
-    }
-
-    return path.isValid();
+    path = *decoded;
+    return true;
 }
 
 std::vector<magda::ChainNodePath> dragObjectToChainNodePaths(const juce::DynamicObject& obj) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,9 @@ set(TEST_SOURCES
     # directly - along with FontManager, which its themed button LookAndFeel pulls in.
     ../magda/daw/ui/components/chain/custom_ui/LevelsUI.cpp
     ../magda/daw/ui/themes/FontManager.cpp
+    test_chain_node_path_drag.cpp
+    # ChainNodePathDrag builds into magda_daw_app, so magda_tests needs it directly.
+    ../magda/daw/ui/components/chain/ChainNodePathDrag.cpp
     test_momentary_param_button.cpp
     test_delta_solo.cpp
     test_waveform_editor_absolute_mode.cpp

--- a/tests/test_alias_registry.cpp
+++ b/tests/test_alias_registry.cpp
@@ -300,3 +300,52 @@ TEST_CASE("AliasRegistry - listener is notified on changes", "[aliases][registry
 
     reg.removeListener(&listener);
 }
+
+// ============================================================================
+// Stored alias decoding — a corrupt path must not widen the alias
+// ============================================================================
+
+TEST_CASE("A project-scoped alias round-trips its path", "[alias][serialization]") {
+    const auto alias = makeAlias("serum", 4, "Cutoff", ChainNodePath::chainDevice(1, 2, 3, 4));
+
+    StoredAlias loaded;
+    REQUIRE(deserializeStoredAlias(serializeStoredAlias(alias), loaded));
+    REQUIRE(loaded.path.has_value());
+    REQUIRE(*loaded.path == *alias.path);
+}
+
+TEST_CASE("An alias with no path stays user-global", "[alias][serialization]") {
+    StoredAlias loaded;
+    REQUIRE(deserializeStoredAlias(serializeStoredAlias(makeAlias("serum", 4, "Cutoff")), loaded));
+    REQUIRE_FALSE(loaded.path.has_value());
+}
+
+TEST_CASE("An alias whose path is present but unreadable is rejected", "[alias][serialization]") {
+    // StoredAlias uses an absent path to mean "user-global", and isValid() does
+    // not require one. Dropping an unreadable path would therefore promote a
+    // project-scoped alias to global scope and let it resolve against whatever
+    // device is in context.
+    const auto alias = makeAlias("serum", 4, "Cutoff", ChainNodePath::chainDevice(1, 2, 3, 4));
+
+    SECTION("null") {
+        // JSON null decodes to a void var, which reads the same as absent.
+        auto json = serializeStoredAlias(alias);
+        json.getDynamicObject()->setProperty("path", juce::var());
+        StoredAlias loaded;
+        REQUIRE_FALSE(deserializeStoredAlias(json, loaded));
+    }
+
+    SECTION("not an object") {
+        auto json = serializeStoredAlias(alias);
+        json.getDynamicObject()->setProperty("path", "nonsense");
+        StoredAlias loaded;
+        REQUIRE_FALSE(deserializeStoredAlias(json, loaded));
+    }
+
+    SECTION("an object that is not a path") {
+        auto json = serializeStoredAlias(alias);
+        json.getDynamicObject()->setProperty("path", juce::var(new juce::DynamicObject()));
+        StoredAlias loaded;
+        REQUIRE_FALSE(deserializeStoredAlias(json, loaded));
+    }
+}

--- a/tests/test_chain_node_path_drag.cpp
+++ b/tests/test_chain_node_path_drag.cpp
@@ -1,0 +1,112 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "../magda/daw/ui/components/chain/ChainNodePathDrag.hpp"
+
+using namespace magda;
+using namespace magda::daw::ui;
+
+namespace {
+
+// A drag description as NodeComponent builds it: an unsuffixed copy of the
+// first path, plus one suffixed entry per dragged node.
+juce::var makeDragInfo(const std::vector<ChainNodePath>& paths) {
+    auto* obj = new juce::DynamicObject();
+    obj->setProperty("pathCount", static_cast<int>(paths.size()));
+    if (!paths.empty())
+        writeChainNodePathToDragInfo(*obj, paths.front());
+    for (int i = 0; i < static_cast<int>(paths.size()); ++i)
+        writeChainNodePathToDragInfo(*obj, paths[static_cast<size_t>(i)], i);
+    return juce::var(obj);
+}
+
+}  // namespace
+
+TEST_CASE("Chain drag payloads round-trip a single path", "[ui][drag][chain]") {
+    const auto path = ChainNodePath::chainDevice(1, 2, 4, 6);
+    const auto info = makeDragInfo({path});
+
+    const auto decoded = readChainNodePathFromDragInfo(*info.getDynamicObject());
+    REQUIRE(decoded.has_value());
+    REQUIRE(*decoded == path);
+
+    const auto all = readChainNodePathsFromDragInfo(*info.getDynamicObject());
+    REQUIRE(all == std::vector<ChainNodePath>{path});
+}
+
+TEST_CASE("Chain drag payloads round-trip a multi-node selection", "[ui][drag][chain]") {
+    const std::vector<ChainNodePath> paths{
+        ChainNodePath::topLevelDevice(1, 5),
+        ChainNodePath::chainDevice(1, 2, 4, 6),
+        ChainNodePath::chain(1, 2, 4).withRack(7).withChain(8).withDevice(9),
+    };
+    const auto info = makeDragInfo(paths);
+
+    REQUIRE(readChainNodePathsFromDragInfo(*info.getDynamicObject()) == paths);
+
+    for (int i = 0; i < static_cast<int>(paths.size()); ++i) {
+        const auto decoded = readChainNodePathFromDragInfo(*info.getDynamicObject(), i);
+        REQUIRE(decoded.has_value());
+        REQUIRE(*decoded == paths[static_cast<size_t>(i)]);
+    }
+}
+
+TEST_CASE("A malformed drag entry is dropped, not guessed", "[ui][drag][chain]") {
+    const std::vector<ChainNodePath> paths{ChainNodePath::chainDevice(1, 2, 4, 6),
+                                           ChainNodePath::topLevelDevice(1, 5)};
+    auto info = makeDragInfo(paths);
+
+    SECTION("a corrupt entry drops only itself") {
+        info.getDynamicObject()->setProperty("path1", "nonsense");
+        const auto all = readChainNodePathsFromDragInfo(*info.getDynamicObject());
+        REQUIRE(all == std::vector<ChainNodePath>{paths.front()});
+    }
+
+    SECTION("an absent entry is not read as a default path") {
+        info.getDynamicObject()->removeProperty("path0");
+        info.getDynamicObject()->removeProperty("path1");
+        info.getDynamicObject()->removeProperty("path");
+        REQUIRE(readChainNodePathsFromDragInfo(*info.getDynamicObject()).empty());
+        REQUIRE_FALSE(readChainNodePathFromDragInfo(*info.getDynamicObject()).has_value());
+    }
+
+    SECTION("an out-of-range id is rejected rather than narrowed") {
+        auto path = toVar(ChainNodePath::chainDevice(1, 2, 4, 6));
+        path.getDynamicObject()->setProperty(
+            "trackId",
+            juce::var(static_cast<juce::int64>(1) + (static_cast<juce::int64>(1) << 32)));
+        info.getDynamicObject()->setProperty("path0", path);
+
+        const auto all = readChainNodePathsFromDragInfo(*info.getDynamicObject());
+        REQUIRE(all == std::vector<ChainNodePath>{paths.back()});
+    }
+}
+
+TEST_CASE("Rail-managed sections are not draggable", "[ui][drag][chain]") {
+    // Post-fx and mixer-analysis have no reorder or reparent semantics, so the
+    // drop handlers have never accepted them.
+    for (const auto& path :
+         {ChainNodePath::postFxDevice(1, 3), ChainNodePath::mixerAnalysisDevice(1, 3)}) {
+        const auto info = makeDragInfo({path});
+        REQUIRE_FALSE(readChainNodePathFromDragInfo(*info.getDynamicObject()).has_value());
+        REQUIRE(readChainNodePathsFromDragInfo(*info.getDynamicObject()).empty());
+    }
+}
+
+TEST_CASE("A drag payload falls back to the unsuffixed path", "[ui][drag][chain]") {
+    // Single-node drags from older call sites carry only the unsuffixed copy.
+    const auto path = ChainNodePath::chainDevice(1, 2, 4, 6);
+    auto* obj = new juce::DynamicObject();
+    writeChainNodePathToDragInfo(*obj, path);
+    const juce::var info(obj);
+
+    REQUIRE(readChainNodePathsFromDragInfo(*info.getDynamicObject()) ==
+            std::vector<ChainNodePath>{path});
+}
+
+TEST_CASE("An invalid path is never handed to a drop handler", "[ui][drag][chain]") {
+    auto* obj = new juce::DynamicObject();
+    writeChainNodePathToDragInfo(*obj, ChainNodePath{});
+    const juce::var info(obj);
+
+    REQUIRE_FALSE(readChainNodePathFromDragInfo(*info.getDynamicObject()).has_value());
+}

--- a/tests/test_control_target.cpp
+++ b/tests/test_control_target.cpp
@@ -283,11 +283,66 @@ TEST_CASE("ChainNodePath - malformed input fails closed", "[control_target][seri
         REQUIRE_FALSE(fromVar(juce::var(pathObj), out));
     }
 
+    SECTION("an out-of-range integer is rejected, not narrowed") {
+        // 2^32 + 1 truncates to 1, which is a perfectly good track id.
+        const auto wrapped = static_cast<juce::int64>(1) + (static_cast<juce::int64>(1) << 32);
+
+        auto* pathObj = new juce::DynamicObject();
+        pathObj->setProperty("trackId", juce::var(wrapped));
+        REQUIRE_FALSE(fromVar(juce::var(pathObj), out));
+
+        auto* stepObj = new juce::DynamicObject();
+        stepObj->setProperty("type", static_cast<int>(ChainStepType::Device));
+        stepObj->setProperty("id", juce::var(wrapped));
+        juce::Array<juce::var> steps;
+        steps.add(juce::var(stepObj));
+
+        auto* stepPath = new juce::DynamicObject();
+        stepPath->setProperty("trackId", 1);
+        stepPath->setProperty("steps", juce::var(steps));
+        REQUIRE_FALSE(fromVar(juce::var(stepPath), out));
+    }
+
     SECTION("well-formed paths still parse") {
         REQUIRE(fromVar(rawPath(1, {{SEGMENT_STEP, POST_FX}, {DEVICE_STEP, 3}}), out));
         REQUIRE(out == ChainNodePath::postFxDevice(1, 3));
         REQUIRE(fromVar(rawPath(1, {{RACK_STEP, 2}, {CHAIN_STEP, 4}, {DEVICE_STEP, 6}}), out));
         REQUIRE(out == ChainNodePath::chainDevice(1, 2, 4, 6));
+    }
+}
+
+TEST_CASE("ChainNodePath - the three representations are mutually exclusive",
+          "[control_target][serialization]") {
+    // getType() picks between these by precedence, so a path carrying more than
+    // one passes isValid() while its accessors disagree about where it points.
+    ChainNodePath out;
+
+    SECTION("a top-level device cannot also carry steps") {
+        auto path = toVar(ChainNodePath::postFxDevice(1, 3));
+        path.getDynamicObject()->setProperty("topLevelDeviceId", 5);
+        REQUIRE_FALSE(fromVar(path, out));
+    }
+
+    SECTION("a track-level path cannot also carry steps") {
+        auto path = toVar(ChainNodePath::chainDevice(1, 2, 4, 6));
+        path.getDynamicObject()->setProperty("isTrackLevel", true);
+        REQUIRE_FALSE(fromVar(path, out));
+    }
+
+    SECTION("a track-level path cannot also name a top-level device") {
+        auto path = toVar(ChainNodePath::trackLevel(1));
+        path.getDynamicObject()->setProperty("topLevelDeviceId", 5);
+        REQUIRE_FALSE(fromVar(path, out));
+    }
+
+    SECTION("each representation alone still parses") {
+        REQUIRE(fromVar(toVar(ChainNodePath::trackLevel(1)), out));
+        REQUIRE(fromVar(toVar(ChainNodePath::topLevelDevice(1, 5)), out));
+        REQUIRE(fromVar(toVar(ChainNodePath::chainDevice(1, 2, 4, 6)), out));
+        // A default path names nothing and stays parseable — edit-scoped
+        // targets serialize one, and callers check isValid().
+        REQUIRE(fromVar(toVar(ChainNodePath{}), out));
+        REQUIRE_FALSE(out.isValid());
     }
 }
 

--- a/tests/test_control_target.cpp
+++ b/tests/test_control_target.cpp
@@ -181,25 +181,104 @@ TEST_CASE("ChainNodePath - the three per-section device spaces stay distinct",
     REQUIRE(roundTrip(fx) != roundTrip(analysis));
 }
 
-TEST_CASE("ChainNodePath - malformed input is rejected or ignored",
-          "[control_target][serialization]") {
+namespace {
+
+// Build a path object with a raw step list, bypassing the factories.
+juce::var rawPath(int trackId, std::initializer_list<std::pair<int, int>> steps) {
+    juce::Array<juce::var> stepArray;
+    for (const auto& [type, id] : steps) {
+        auto* stepObj = new juce::DynamicObject();
+        stepObj->setProperty("type", type);
+        stepObj->setProperty("id", id);
+        stepArray.add(juce::var(stepObj));
+    }
+    auto* pathObj = new juce::DynamicObject();
+    pathObj->setProperty("trackId", trackId);
+    pathObj->setProperty("steps", juce::var(stepArray));
+    return juce::var(pathObj);
+}
+
+constexpr int RACK_STEP = static_cast<int>(ChainStepType::Rack);
+constexpr int CHAIN_STEP = static_cast<int>(ChainStepType::Chain);
+constexpr int DEVICE_STEP = static_cast<int>(ChainStepType::Device);
+constexpr int SEGMENT_STEP = static_cast<int>(ChainStepType::Segment);
+constexpr int POST_FX = static_cast<int>(ChainSegment::PostFx);
+
+}  // namespace
+
+TEST_CASE("ChainNodePath - malformed input fails closed", "[control_target][serialization]") {
     ChainNodePath out;
     REQUIRE_FALSE(fromVar(juce::var(), out));
     REQUIRE_FALSE(fromVar(juce::var(42), out));
 
-    // An out-of-range step type is dropped rather than cast into a bogus enum.
-    auto* stepObj = new juce::DynamicObject();
-    stepObj->setProperty("type", 99);
-    stepObj->setProperty("id", 1);
-    juce::Array<juce::var> steps;
-    steps.add(juce::var(stepObj));
+    SECTION("an unknown step type is rejected, not skipped") {
+        // Skipping would shorten this to [Device 3], which still resolves — to
+        // a different device than the one addressed.
+        REQUIRE_FALSE(fromVar(rawPath(1, {{99, 5}, {DEVICE_STEP, 3}}), out));
+    }
 
-    auto* pathObj = new juce::DynamicObject();
-    pathObj->setProperty("trackId", 1);
-    pathObj->setProperty("steps", juce::var(steps));
+    SECTION("a non-object step is rejected") {
+        juce::Array<juce::var> steps;
+        steps.add(juce::var("nonsense"));
+        auto* pathObj = new juce::DynamicObject();
+        pathObj->setProperty("trackId", 1);
+        pathObj->setProperty("steps", juce::var(steps));
+        REQUIRE_FALSE(fromVar(juce::var(pathObj), out));
+    }
 
-    REQUIRE(fromVar(juce::var(pathObj), out));
-    REQUIRE(out.steps.empty());
+    SECTION("an out-of-range segment id is rejected") {
+        // Would otherwise fall through makeDevicePathDto's switch and silently
+        // read as the default "fx" section.
+        REQUIRE_FALSE(fromVar(rawPath(1, {{SEGMENT_STEP, 99}, {DEVICE_STEP, 3}}), out));
+    }
+
+    SECTION("a non-leading segment is rejected") {
+        // isPostFx() only ever inspects steps.front(), so a segment deeper in
+        // the path would be silently ignored.
+        REQUIRE_FALSE(
+            fromVar(rawPath(1, {{RACK_STEP, 2}, {SEGMENT_STEP, POST_FX}, {DEVICE_STEP, 3}}), out));
+    }
+
+    SECTION("well-formed paths still parse") {
+        REQUIRE(fromVar(rawPath(1, {{SEGMENT_STEP, POST_FX}, {DEVICE_STEP, 3}}), out));
+        REQUIRE(out == ChainNodePath::postFxDevice(1, 3));
+        REQUIRE(fromVar(rawPath(1, {{RACK_STEP, 2}, {CHAIN_STEP, 4}, {DEVICE_STEP, 6}}), out));
+        REQUIRE(out == ChainNodePath::chainDevice(1, 2, 4, 6));
+    }
+}
+
+TEST_CASE("ChainNodePath - legacy paths without isTrackLevel are recovered",
+          "[control_target][serialization]") {
+    // Project files written before this flag was persisted stored track-level
+    // targets as a bare trackId, which reloads as an unusable path.
+    ChainNodePath out;
+    auto* legacy = new juce::DynamicObject();
+    legacy->setProperty("trackId", 5);
+    legacy->setProperty("topLevelDeviceId", INVALID_DEVICE_ID);
+    legacy->setProperty("steps", juce::var(juce::Array<juce::var>{}));
+
+    REQUIRE(fromVar(juce::var(legacy), out));
+    REQUIRE(out == ChainNodePath::trackLevel(5));
+    REQUIRE(out.isValid());
+
+    SECTION("an explicit false is honoured, not overridden") {
+        auto* explicitFalse = new juce::DynamicObject();
+        explicitFalse->setProperty("trackId", 5);
+        explicitFalse->setProperty("isTrackLevel", false);
+        explicitFalse->setProperty("steps", juce::var(juce::Array<juce::var>{}));
+
+        ChainNodePath parsed;
+        REQUIRE(fromVar(juce::var(explicitFalse), parsed));
+        REQUIRE_FALSE(parsed.isTrackLevel);
+        REQUIRE_FALSE(parsed.isValid());
+    }
+
+    SECTION("the inference does not fire when the path already addresses something") {
+        ChainNodePath parsed;
+        REQUIRE(fromVar(rawPath(5, {{RACK_STEP, 2}}), parsed));
+        REQUIRE_FALSE(parsed.isTrackLevel);
+        REQUIRE(parsed == ChainNodePath::rack(5, 2));
+    }
 }
 
 TEST_CASE("ControlTarget - JSON round-trip preserves every kind",

--- a/tests/test_control_target.cpp
+++ b/tests/test_control_target.cpp
@@ -5,6 +5,22 @@
 
 using namespace magda;
 
+namespace {
+
+ControlTarget roundTrip(const ControlTarget& target) {
+    ControlTarget out;
+    REQUIRE(fromVar(toVar(target), out));
+    return out;
+}
+
+ChainNodePath roundTrip(const ChainNodePath& path) {
+    ChainNodePath out;
+    REQUIRE(fromVar(toVar(path), out));
+    return out;
+}
+
+}  // namespace
+
 // ============================================================================
 // ControlTarget — equality and validity per kind
 // ============================================================================
@@ -130,4 +146,96 @@ TEST_CASE("ControlTarget - deviceId() accessor", "[control_target]") {
 
     auto trackTarget = ControlTarget::trackVolume(1);
     REQUIRE(trackTarget.deviceId() == INVALID_DEVICE_ID);
+}
+
+// ============================================================================
+// Canonical serialization
+// ============================================================================
+
+TEST_CASE("ChainNodePath - JSON round-trip preserves every representation",
+          "[control_target][serialization]") {
+    REQUIRE(roundTrip(ChainNodePath::trackLevel(3)) == ChainNodePath::trackLevel(3));
+    REQUIRE(roundTrip(ChainNodePath::topLevelDevice(1, 5)) == ChainNodePath::topLevelDevice(1, 5));
+    REQUIRE(roundTrip(ChainNodePath::rack(1, 2)) == ChainNodePath::rack(1, 2));
+    REQUIRE(roundTrip(ChainNodePath::chain(1, 2, 4)) == ChainNodePath::chain(1, 2, 4));
+    REQUIRE(roundTrip(ChainNodePath::chainDevice(1, 2, 4, 6)) ==
+            ChainNodePath::chainDevice(1, 2, 4, 6));
+    REQUIRE(roundTrip(ChainNodePath::postFxDevice(1, 6)) == ChainNodePath::postFxDevice(1, 6));
+    REQUIRE(roundTrip(ChainNodePath::mixerAnalysisDevice(1, 6)) ==
+            ChainNodePath::mixerAnalysisDevice(1, 6));
+
+    const auto nested = ChainNodePath::chain(1, 2, 4).withRack(7).withChain(8).withDevice(9);
+    REQUIRE(roundTrip(nested) == nested);
+}
+
+TEST_CASE("ChainNodePath - the three per-section device spaces stay distinct",
+          "[control_target][serialization]") {
+    // Same DeviceId, three different devices — the section discriminator lives
+    // in the leading Segment step and must survive serialization.
+    const auto fx = ChainNodePath::topLevelDevice(1, 3);
+    const auto postFx = ChainNodePath::postFxDevice(1, 3);
+    const auto analysis = ChainNodePath::mixerAnalysisDevice(1, 3);
+
+    REQUIRE(roundTrip(fx) != roundTrip(postFx));
+    REQUIRE(roundTrip(postFx) != roundTrip(analysis));
+    REQUIRE(roundTrip(fx) != roundTrip(analysis));
+}
+
+TEST_CASE("ChainNodePath - malformed input is rejected or ignored",
+          "[control_target][serialization]") {
+    ChainNodePath out;
+    REQUIRE_FALSE(fromVar(juce::var(), out));
+    REQUIRE_FALSE(fromVar(juce::var(42), out));
+
+    // An out-of-range step type is dropped rather than cast into a bogus enum.
+    auto* stepObj = new juce::DynamicObject();
+    stepObj->setProperty("type", 99);
+    stepObj->setProperty("id", 1);
+    juce::Array<juce::var> steps;
+    steps.add(juce::var(stepObj));
+
+    auto* pathObj = new juce::DynamicObject();
+    pathObj->setProperty("trackId", 1);
+    pathObj->setProperty("steps", juce::var(steps));
+
+    REQUIRE(fromVar(juce::var(pathObj), out));
+    REQUIRE(out.steps.empty());
+}
+
+TEST_CASE("ControlTarget - JSON round-trip preserves every kind",
+          "[control_target][serialization]") {
+    const auto path = ChainNodePath::chainDevice(1, 2, 4, 6);
+
+    REQUIRE(roundTrip(ControlTarget::pluginParam(path, 3)) == ControlTarget::pluginParam(path, 3));
+    REQUIRE(roundTrip(ControlTarget::deviceMacro(path, 2)) == ControlTarget::deviceMacro(path, 2));
+    REQUIRE(roundTrip(ControlTarget::modParam(path, 7, 0)) == ControlTarget::modParam(path, 7, 0));
+    REQUIRE(roundTrip(ControlTarget::trackVolume(1)) == ControlTarget::trackVolume(1));
+    REQUIRE(roundTrip(ControlTarget::trackPan(1)) == ControlTarget::trackPan(1));
+    REQUIRE(roundTrip(ControlTarget::sendLevel(1, 2)) == ControlTarget::sendLevel(1, 2));
+    REQUIRE(roundTrip(ControlTarget::tempo()) == ControlTarget::tempo());
+}
+
+TEST_CASE("ControlTarget - tempo serializes without a device path",
+          "[control_target][serialization]") {
+    const auto json = toVar(ControlTarget::tempo());
+    REQUIRE(json.getDynamicObject() != nullptr);
+    REQUIRE(json["kind"].toString() == "tempo");
+    // Emitting a placeholder path would round-trip into a bogus Track[-1].
+    REQUIRE_FALSE(json.getDynamicObject()->hasProperty("devicePath"));
+
+    const auto restored = roundTrip(ControlTarget::tempo());
+    REQUIRE(restored.isEditScoped());
+    REQUIRE(restored.isValid());
+}
+
+TEST_CASE("ControlTarget - kind is a stable string, not an enum ordinal",
+          "[control_target][serialization]") {
+    REQUIRE(toVar(ControlTarget::sendLevel(1, 2))["kind"].toString() == "send_level");
+    REQUIRE(parseControlTargetKind("send_level") == ControlTarget::Kind::SendLevel);
+    REQUIRE_FALSE(parseControlTargetKind("nonsense").has_value());
+
+    ControlTarget out;
+    auto* obj = new juce::DynamicObject();
+    obj->setProperty("kind", "nonsense");
+    REQUIRE_FALSE(fromVar(juce::var(obj), out));
 }

--- a/tests/test_control_target.cpp
+++ b/tests/test_control_target.cpp
@@ -239,6 +239,50 @@ TEST_CASE("ChainNodePath - malformed input fails closed", "[control_target][seri
             fromVar(rawPath(1, {{RACK_STEP, 2}, {SEGMENT_STEP, POST_FX}, {DEVICE_STEP, 3}}), out));
     }
 
+    SECTION("an empty object is not an address") {
+        // A missing property reads back as void, which converts to 0, so this
+        // would otherwise parse as a track-level path to track 0.
+        REQUIRE_FALSE(fromVar(juce::var(new juce::DynamicObject()), out));
+    }
+
+    SECTION("trackId must be present and numeric") {
+        auto* noTrack = new juce::DynamicObject();
+        noTrack->setProperty("steps", juce::var(juce::Array<juce::var>{}));
+        REQUIRE_FALSE(fromVar(juce::var(noTrack), out));
+
+        auto* textTrack = new juce::DynamicObject();
+        textTrack->setProperty("trackId", "one");
+        REQUIRE_FALSE(fromVar(juce::var(textTrack), out));
+    }
+
+    SECTION("a present steps value that is not an array is rejected") {
+        auto* pathObj = new juce::DynamicObject();
+        pathObj->setProperty("trackId", 1);
+        pathObj->setProperty("steps", "nonsense");
+        REQUIRE_FALSE(fromVar(juce::var(pathObj), out));
+    }
+
+    SECTION("a step missing type or id is rejected") {
+        for (const char* present : {"type", "id"}) {
+            auto* stepObj = new juce::DynamicObject();
+            stepObj->setProperty(present, 0);  // the other half is absent
+            juce::Array<juce::var> steps;
+            steps.add(juce::var(stepObj));
+
+            auto* pathObj = new juce::DynamicObject();
+            pathObj->setProperty("trackId", 1);
+            pathObj->setProperty("steps", juce::var(steps));
+            REQUIRE_FALSE(fromVar(juce::var(pathObj), out));
+        }
+    }
+
+    SECTION("a non-boolean isTrackLevel is rejected") {
+        auto* pathObj = new juce::DynamicObject();
+        pathObj->setProperty("trackId", 1);
+        pathObj->setProperty("isTrackLevel", "yes");
+        REQUIRE_FALSE(fromVar(juce::var(pathObj), out));
+    }
+
     SECTION("well-formed paths still parse") {
         REQUIRE(fromVar(rawPath(1, {{SEGMENT_STEP, POST_FX}, {DEVICE_STEP, 3}}), out));
         REQUIRE(out == ChainNodePath::postFxDevice(1, 3));

--- a/tests/test_project_serialization.cpp
+++ b/tests/test_project_serialization.cpp
@@ -2423,3 +2423,40 @@ TEST_CASE("Delta solo state roundtrips and defaults off for older projects",
     REQUIRE(ProjectSerializer::deserializeRackInfo(rackJson, legacyRack));
     CHECK_FALSE(legacyRack.deltaSolo);
 }
+
+TEST_CASE("Saved automation targets keep the flag that makes a track path valid",
+          "[serialization][automation]") {
+    // The project writer previously omitted isTrackLevel, so every saved
+    // TrackVolume/TrackPan/SendLevel target reloaded as a path carrying a track
+    // id but addressing no node.
+    auto& tracks = TrackManager::getInstance();
+    auto& automation = AutomationManager::getInstance();
+    automation.clearAll();
+    tracks.clearAllTracks();
+
+    const auto trackId = tracks.createTrack("Bass", TrackType::Audio);
+
+    AutomationTarget target;
+    target.kind = ControlTarget::Kind::TrackVolume;
+    target.devicePath = ChainNodePath::trackLevel(trackId);
+    REQUIRE(automation.createLane(target, AutomationLaneType::Absolute) !=
+            INVALID_AUTOMATION_LANE_ID);
+
+    const auto json = ProjectSerializer::serializeAutomation();
+    const auto* lanes = json["lanes"].getArray();
+    REQUIRE(lanes != nullptr);
+    REQUIRE(lanes->size() == 1);
+
+    const auto devicePath = lanes->getReference(0)["target"]["devicePath"];
+    REQUIRE(devicePath.isObject());
+    CHECK(static_cast<bool>(devicePath["isTrackLevel"]));
+
+    // What was written must parse back to the path that was saved.
+    ChainNodePath reloaded;
+    REQUIRE(fromVar(devicePath, reloaded));
+    CHECK(reloaded == ChainNodePath::trackLevel(trackId));
+    CHECK(reloaded.isValid());
+
+    automation.clearAll();
+    tracks.clearAllTracks();
+}

--- a/tests/test_remote_api_contract.cpp
+++ b/tests/test_remote_api_contract.cpp
@@ -105,8 +105,17 @@ TEST_CASE("Remote API input validation returns structured issues",
     }
 
     SECTION("nullable ids reject negative int64 wrap-around") {
-        const DeviceDto device{10,           3,          5,    std::nullopt, "Synth",
-                               "instrument", "internal", true, false,        -3.0};
+        const DeviceDto device{10,
+                               3,
+                               5,
+                               std::nullopt,
+                               makeDevicePathDto(ChainNodePath::chainDevice(3, 5, 7, 10)),
+                               "Synth",
+                               "instrument",
+                               "internal",
+                               true,
+                               false,
+                               -3.0};
         auto json = toJson(device);
         // 5 - 2^32 decodes back to rack 5 if the id is truncated to 32 bits.
         json.getDynamicObject()->setProperty(
@@ -252,7 +261,8 @@ TEST_CASE("Remote API DTOs round-trip through JSON", "[remote-api][contract][dto
     requireRoundTrip(clip, clipFromJson);
 
     const DeviceGraphDto graph{
-        {{10, 3, 20, 30, "Synth", "instrument", "internal", true, false, -3.0}},
+        {{10, 3, 20, 30, makeDevicePathDto(ChainNodePath::chainDevice(3, 20, 30, 10)), "Synth",
+          "instrument", "internal", true, false, -3.0}},
         {{20, 3, std::nullopt, std::nullopt, "Parallel", false, 0.0, 0.0, {30}}},
         {{30, 20, "Main", 0, false, false, false, 0.0, 0.0, {10}, {}}}};
     requireRoundTrip(graph, deviceGraphFromJson);
@@ -394,6 +404,81 @@ TEST_CASE("Remote projections expose only allow-listed state",
     api.transport_.playing = true;
     api.transport_.positionBeats = 6.0;
     REQUIRE(makeTransportDto(api) == TransportDto{true, false, false, 6.0});
+}
+
+TEST_CASE("devices.list addresses colliding fx and post-fx device ids",
+          "[remote-api][contract][device-path]") {
+    // Post-fx devices allocate from nextPostFxDeviceId_, the fx chain from
+    // nextFxDeviceId_, so id 3 legitimately exists in both on one track. Both
+    // project with rackId and chainId null, so before devicePath the two rows
+    // were identical addresses.
+    TrackInfo track;
+    track.id = 1;
+
+    DeviceInfo fxDevice;
+    fxDevice.id = 3;
+    fxDevice.name = "Chorus";
+    track.chain.fxChainElements.push_back(makeDeviceElement(fxDevice));
+
+    DeviceInfo postFxDevice;
+    postFxDevice.id = 3;
+    postFxDevice.name = "Limiter";
+    track.chain.postFxChainElements.push_back({postFxDevice});
+
+    const auto graph = makeDeviceGraphDto({track});
+    REQUIRE(graph.devices.size() == 2);
+    REQUIRE(graph.devices[0].id == graph.devices[1].id);
+    REQUIRE(graph.devices[0].rackId == graph.devices[1].rackId);
+    REQUIRE(graph.devices[0].chainId == graph.devices[1].chainId);
+
+    // The path is what tells them apart.
+    REQUIRE(graph.devices[0].devicePath.section == "fx");
+    REQUIRE(graph.devices[1].devicePath.section == "post_fx");
+    REQUIRE_FALSE(graph.devices[0].devicePath == graph.devices[1].devicePath);
+
+    REQUIRE(toChainNodePath(graph.devices[0].devicePath) == ChainNodePath::topLevelDevice(1, 3));
+    REQUIRE(toChainNodePath(graph.devices[1].devicePath) == ChainNodePath::postFxDevice(1, 3));
+
+    requireRoundTrip(graph, deviceGraphFromJson);
+}
+
+TEST_CASE("devices.list carries full depth for nested racks",
+          "[remote-api][contract][device-path]") {
+    // rackId/chainId name the immediate parent only; a device two racks deep
+    // needs the whole route to be addressable.
+    TrackInfo track;
+    track.id = 1;
+
+    DeviceInfo leaf;
+    leaf.id = 9;
+    leaf.name = "Filter";
+
+    RackInfo inner;
+    inner.id = 7;
+    ChainInfo innerChain;
+    innerChain.id = 8;
+    innerChain.elements.push_back(makeDeviceElement(leaf));
+    inner.chains.push_back(std::move(innerChain));
+
+    RackInfo outer;
+    outer.id = 2;
+    ChainInfo outerChain;
+    outerChain.id = 4;
+    outerChain.elements.push_back(makeRackElement(std::move(inner)));
+    outer.chains.push_back(std::move(outerChain));
+
+    track.chain.fxChainElements.push_back(makeRackElement(std::move(outer)));
+
+    const auto graph = makeDeviceGraphDto({track});
+    REQUIRE(graph.devices.size() == 1);
+
+    const auto& device = graph.devices.front();
+    REQUIRE(device.rackId == 7);
+    REQUIRE(device.chainId == 8);
+    REQUIRE(toChainNodePath(device.devicePath) ==
+            ChainNodePath::chain(1, 2, 4).withRack(7).withChain(8).withDevice(9));
+
+    requireRoundTrip(graph, deviceGraphFromJson);
 }
 
 TEST_CASE("Device paths distinguish the three per-section DeviceId spaces",

--- a/tests/test_remote_api_contract.cpp
+++ b/tests/test_remote_api_contract.cpp
@@ -266,12 +266,13 @@ TEST_CASE("Remote API DTOs round-trip through JSON", "[remote-api][contract][dto
     const SessionDto session{{{3, 2, 9, "playing"}, {4, 2, 12, "queued"}}};
     requireRoundTrip(session, sessionFromJson);
 
-    const AutomationLaneDto lane{5,
-                                 "absolute",
-                                 "Volume",
-                                 {"track_volume", 3, std::nullopt, -1, -1, -1, -1},
-                                 {{7, 0.0, 0.5, "linear"}, {8, 4.0, 0.75, "bezier"}},
-                                 {}};
+    const AutomationLaneDto lane{
+        5,
+        "absolute",
+        "Volume",
+        {"track_volume", DevicePathDto{3, "fx", true, std::nullopt, {}}, -1, -1, -1, -1},
+        {{7, 0.0, 0.5, "linear"}, {8, 4.0, 0.75, "bezier"}},
+        {}};
     requireRoundTrip(lane, automationLaneFromJson);
 }
 
@@ -300,7 +301,7 @@ TEST_CASE("Dense response payloads round-trip and validate against the published
     lane.id = 5;
     lane.type = "absolute";
     lane.name = "Volume";
-    lane.target = {"track_volume", 3, std::nullopt, -1, -1, -1, -1};
+    lane.target = {"track_volume", DevicePathDto{3, "fx", true, std::nullopt, {}}, -1, -1, -1, -1};
     lane.points.reserve(5000);
     for (int index = 0; index < 5000; ++index)
         lane.points.push_back({index, index * 0.25, 0.5, "linear"});
@@ -395,6 +396,105 @@ TEST_CASE("Remote projections expose only allow-listed state",
     REQUIRE(makeTransportDto(api) == TransportDto{true, false, false, 6.0});
 }
 
+TEST_CASE("Device paths distinguish the three per-section DeviceId spaces",
+          "[remote-api][contract][device-path]") {
+    // The main FX chain, the post-fader list, and the mixer-analysis section
+    // each allocate DeviceIds from their own counter, so the same id exists in
+    // all three at once. A projection that carried only trackId + deviceId
+    // collapsed them into one address.
+    const auto fx = ChainNodePath::topLevelDevice(1, 3);
+    const auto postFx = ChainNodePath::postFxDevice(1, 3);
+    const auto analysis = ChainNodePath::mixerAnalysisDevice(1, 3);
+
+    const auto fxDto = makeDevicePathDto(fx);
+    const auto postFxDto = makeDevicePathDto(postFx);
+    const auto analysisDto = makeDevicePathDto(analysis);
+
+    REQUIRE(fxDto.section == "fx");
+    REQUIRE(postFxDto.section == "post_fx");
+    REQUIRE(analysisDto.section == "mixer_analysis");
+
+    REQUIRE_FALSE(fxDto == postFxDto);
+    REQUIRE_FALSE(postFxDto == analysisDto);
+    REQUIRE_FALSE(fxDto == analysisDto);
+
+    // ...and each survives the trip back to an internal path.
+    REQUIRE(toChainNodePath(fxDto) == fx);
+    REQUIRE(toChainNodePath(postFxDto) == postFx);
+    REQUIRE(toChainNodePath(analysisDto) == analysis);
+}
+
+TEST_CASE("Device paths round-trip through nested racks and chains",
+          "[remote-api][contract][device-path]") {
+    SECTION("track level") {
+        const auto path = ChainNodePath::trackLevel(2);
+        const auto dto = makeDevicePathDto(path);
+        REQUIRE(dto.trackLevel);
+        REQUIRE(toChainNodePath(dto) == path);
+    }
+
+    SECTION("device inside a rack chain") {
+        const auto path = ChainNodePath::chainDevice(2, 4, 5, 6);
+        const auto dto = makeDevicePathDto(path);
+        REQUIRE(dto.steps.size() == 3);
+        REQUIRE(toChainNodePath(dto) == path);
+    }
+
+    SECTION("arbitrarily nested racks") {
+        const auto path = ChainNodePath::chain(2, 4, 5).withRack(7).withChain(8).withDevice(9);
+        const auto dto = makeDevicePathDto(path);
+        REQUIRE(toChainNodePath(dto) == path);
+    }
+
+    SECTION("unknown section and step types are rejected, not guessed") {
+        auto dto = makeDevicePathDto(ChainNodePath::chainDevice(2, 4, 5, 6));
+        dto.section = "not_a_section";
+        REQUIRE_FALSE(toChainNodePath(dto).has_value());
+
+        auto stepDto = makeDevicePathDto(ChainNodePath::chainDevice(2, 4, 5, 6));
+        stepDto.steps[0].type = "not_a_step";
+        REQUIRE_FALSE(toChainNodePath(stepDto).has_value());
+    }
+}
+
+TEST_CASE("Automation targets carry a full device path through JSON",
+          "[remote-api][contract][device-path]") {
+    AutomationLaneDto lane;
+    lane.id = 5;
+    lane.type = "absolute";
+    lane.name = "Cutoff";
+    lane.target.kind = "plugin_param";
+    lane.target.devicePath = makeDevicePathDto(ChainNodePath::postFxDevice(1, 3));
+    lane.target.parameterIndex = 2;
+
+    requireRoundTrip(lane, automationLaneFromJson);
+
+    const auto* getLane = OperationRegistry::instance().find("automation.getLane");
+    REQUIRE(getLane != nullptr);
+    REQUIRE(validateJson(toJson(lane), getLane->outputSchema).empty());
+
+    // The same parameter index on the fx-chain device is a different target.
+    AutomationLaneDto fxLane = lane;
+    fxLane.target.devicePath = makeDevicePathDto(ChainNodePath::topLevelDevice(1, 3));
+    REQUIRE_FALSE(toJson(lane).toString() == toJson(fxLane).toString());
+}
+
+TEST_CASE("Edit-scoped automation targets carry no device path",
+          "[remote-api][contract][device-path]") {
+    AutomationLaneDto lane;
+    lane.id = 6;
+    lane.type = "absolute";
+    lane.name = "Tempo";
+    lane.target.kind = "tempo";
+    lane.target.devicePath = std::nullopt;
+
+    requireRoundTrip(lane, automationLaneFromJson);
+
+    const auto* getLane = OperationRegistry::instance().find("automation.getLane");
+    REQUIRE(getLane != nullptr);
+    REQUIRE(validateJson(toJson(lane), getLane->outputSchema).empty());
+}
+
 TEST_CASE("Remote session and automation projections use MagdaApi values",
           "[remote-api][contract][projection]") {
     const ScopedMessageThreadAssertionDisabler threadAssertionGuard;
@@ -434,13 +534,15 @@ TEST_CASE("Remote session and automation projections use MagdaApi values",
     const auto dto = makeAutomationLaneDto(lane);
     REQUIRE(dto.id == 60);
     REQUIRE(dto.target.kind == "track_pan");
-    REQUIRE(dto.target.trackId == 1);
+    REQUIRE(dto.target.devicePath.has_value());
+    REQUIRE(dto.target.devicePath->trackId == 1);
     REQUIRE(dto.points.size() == 2);
     REQUIRE(dto.points[1].curve == "step");
 
     lane.target = AutomationTarget::trackVolume(MASTER_TRACK_ID);
     const auto masterDto = makeAutomationLaneDto(lane);
-    REQUIRE(masterDto.target.trackId == MASTER_TRACK_ID);
+    REQUIRE(masterDto.target.devicePath.has_value());
+    REQUIRE(masterDto.target.devicePath->trackId == MASTER_TRACK_ID);
     const auto* operation = OperationRegistry::instance().find("automation.getLane");
     REQUIRE(operation != nullptr);
     REQUIRE(validateJson(toJson(masterDto), operation->outputSchema).empty());


### PR DESCRIPTION
## Why

`ControlTarget` is the declared canonical address for every writable parameter — its own docs say "every consumer — macro/mod links, automation lanes, MIDI bindings, alias resolvers — speaks `ControlTarget`". But it had no serializer, so the repo had grown three encodings of the same address and no canonical one:

1. `ControlTarget` itself — the intended form, unserializable.
2. `AliasRegistry.cpp:305` — a hand-rolled inline copy, comment and all (`// Inline ChainNodePath serialization`).
3. `remote_api_projection.cpp` — a third form that dropped `ChainNodePath::steps`.

Dropping the steps loses the section discriminator, and that turns out to be load-bearing.

## The bug

`DeviceId` is allocated from three separate counters — `nextFxDeviceId_`, `nextPostFxDeviceId_`, `nextMixerAnalysisDeviceId_` (TrackManager.hpp:431: "Post-fx and mixer-analysis keep their own ID spaces"). So id 3 legitimately exists in all three sections of one track. The discriminator lives in `ChainNodePath::steps.front()`.

Two places dropped it:

- **`AutomationTargetDto`** projected `kind + trackId + deviceId()` — so a lane on fx device #3 and one on post-fx device #3 of the same track serialized to byte-identical JSON. `automation.createLane` already publishes that shape under `API_VERSION 1.0`.
- **`DeviceDto`** projected `rackId`/`chainId` only, both null for top-level *and* post-fx devices — so `devices.list` returned the two as rows differing only in `name`. It also can't express a device nested more than one rack deep.

Nothing decodes either shape yet (the handlers are #1855/#1859 work), so the wire contract is still free to change. Once clients exist it isn't.

## What changed

- `toVar`/`fromVar` for `ChainNodePath` and `ControlTarget`, living next to the types. The path form is byte-identical to what alias files already contain, so existing saves keep loading; `kind` serializes as a stable string, not an enum ordinal.
- `AliasRegistry` routed through the canonical pair (45 lines → 8).
- `DevicePathDto` — the public projection, carrying `section` plus the full rack/chain route. Step types are strings (`"rack"`, `"post_fx"`) rather than enum ordinals: this is a wire contract consumed by scripts and MCP clients (#1858) and must not couple to internal `ChainStepType` ordering.
- `AutomationTargetDto.deviceId` → `devicePath`; `DeviceDto` gains `devicePath`, with a real `ChainNodePath` threaded through the graph walk. `rackId`/`chainId` stay as immediate-parent pointers for tree rendering, now documented as not-an-address.
- `makeDevicePathDto`/`toChainNodePath` for the write direction #1859 needs.
- One shared `devicePathFromJson` between device listings and automation targets, so the two can't drift.

The schema validator has no `$ref` support, so `devicePath` composes into both schemas programmatically via the existing pattern at `remote_api.cpp:412`.

## Also settled

Project IDs are **durable, not session-scoped**: `restoreTrack` keeps the saved id and only bumps the counter past it (TrackManager.cpp:891), and `recalculateIdCounters` rescans on load (:3075-3082). So `DevicePathDto` needs no secondary key. This contradicts the premise in #1757 — its 1-based-visible-order choice for OSC is still right, but because IDs are sparse, not because they're unstable.

## Tests

12 new cases: the three-space ambiguity at both the path and `devices.list` level, a two-rack-deep device, nested-rack round-trips, edit-scoped tempo carrying no path, and malformed-input rejection.

Full suite: **1724 cases, 1711 passed, 13 skipped, 0 failures** (163,690 assertions).

## Notes for review

- `magda_daw` and all tests compile clean. The IDE's clang index can't resolve JUCE headers in this checkout, so inline diagnostics are noise — the `make test-build` output is the real signal.
- Unrelated files that were already unformatted on `dev/0.19.0` are deliberately untouched; `make format` would sweep them into this diff.

Part of #701. Unblocks #1859 and #1757, which both needed one agreed parameter address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)