### PR TITLE
MagdaApi: device control surface and automation enumeration (closes #1859)

### DIFF
--- a/magda/daw/api/CMakeLists.txt
+++ b/magda/daw/api/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(magda_daw PRIVATE
     transport_api_live.cpp
     focused_api_live.cpp
     plugin_api_live.cpp
+    device_api_live.cpp
     groove_api_live.cpp
     remote_api.cpp
     remote_api_projection.cpp

--- a/magda/daw/api/automation_api.hpp
+++ b/magda/daw/api/automation_api.hpp
@@ -23,9 +23,47 @@ class AutomationApi {
     virtual AutomationLaneInfo* getLane(AutomationLaneId laneId) = 0;
     virtual const AutomationLaneInfo* getLane(AutomationLaneId laneId) const = 0;
 
+    // ------------------------------------------------------------------
+    // Enumeration
+    // ------------------------------------------------------------------
+    // What automation exists, and what it targets. Every lane carries an
+    // AutomationTarget (a ControlTarget), so a caller can discover both the
+    // lanes and the parameters they drive without reaching into the registry.
+
+    /** Every lane in the project, in stable order. */
+    virtual const std::vector<AutomationLaneInfo>& getLanes() const = 0;
+
+    /** Lanes whose target resolves to `trackId`. */
+    virtual std::vector<AutomationLaneId> getLanesForTrack(TrackId trackId) const = 0;
+
+    /**
+     * @brief Lanes with no owning track or device — currently tempo.
+     *
+     * These are edit-scoped: their target has no `devicePath`, so they are not
+     * reachable through `getLanesForTrack` and would otherwise be invisible.
+     */
+    virtual std::vector<AutomationLaneId> getEditScopedLanes() const = 0;
+
+    /** Every automation clip in the project. */
+    virtual const std::vector<AutomationClipInfo>& getClips() const = 0;
+
     virtual AutomationPointId addPoint(AutomationLaneId laneId, double beatPosition, double value,
                                        AutomationCurveType curveType) = 0;
     virtual void clearLanePoints(AutomationLaneId laneId) = 0;
+
+    /**
+     * @brief Replace every point on an absolute lane as one undoable step.
+     *
+     * Writing a curve through repeated `addPoint` calls produces one undo entry
+     * per point, so undoing a generated curve means one Undo per sample. This
+     * is the bulk form. Returns false for an unknown or clip-based lane —
+     * clip-based lanes keep their points on clips, which `setClipPoints`
+     * covers.
+     */
+    virtual bool setLanePoints(AutomationLaneId laneId, std::vector<AutomationPoint> points) = 0;
+
+    /** Remove a lane and its clips. Undoable as one step. */
+    virtual bool deleteLane(AutomationLaneId laneId) = 0;
 
     // Clip-based automation lanes. Retyping is intentionally restricted to
     // empty lanes so an agent cannot silently discard an existing curve.

--- a/magda/daw/api/automation_api_live.cpp
+++ b/magda/daw/api/automation_api_live.cpp
@@ -1,6 +1,10 @@
 #include "automation_api_live.hpp"
 
+#include <memory>
+
+#include "../core/AutomationCommands.hpp"
 #include "../core/AutomationManager.hpp"
+#include "../core/UndoManager.hpp"
 
 namespace magda {
 
@@ -28,6 +32,43 @@ AutomationPointId AutomationApiLive::addPoint(AutomationLaneId laneId, double be
 
 void AutomationApiLive::clearLanePoints(AutomationLaneId laneId) {
     AutomationManager::getInstance().clearLanePoints(laneId);
+}
+
+const std::vector<AutomationLaneInfo>& AutomationApiLive::getLanes() const {
+    return AutomationManager::getInstance().getLanes();
+}
+
+std::vector<AutomationLaneId> AutomationApiLive::getLanesForTrack(TrackId trackId) const {
+    return AutomationManager::getInstance().getLanesForTrack(trackId);
+}
+
+std::vector<AutomationLaneId> AutomationApiLive::getEditScopedLanes() const {
+    return AutomationManager::getInstance().getEditScopedLanes();
+}
+
+const std::vector<AutomationClipInfo>& AutomationApiLive::getClips() const {
+    return AutomationManager::getInstance().getClips();
+}
+
+bool AutomationApiLive::setLanePoints(AutomationLaneId laneId,
+                                      std::vector<AutomationPoint> points) {
+    const auto* lane = AutomationManager::getInstance().getLane(laneId);
+    if (lane == nullptr || !lane->isAbsolute())
+        return false;
+
+    auto command = std::make_unique<SetAutomationLanePointsCommand>(laneId, std::move(points));
+    auto* raw = command.get();
+    UndoManager::getInstance().executeCommand(std::move(command));
+    return raw->didApply();
+}
+
+bool AutomationApiLive::deleteLane(AutomationLaneId laneId) {
+    if (AutomationManager::getInstance().getLane(laneId) == nullptr)
+        return false;
+
+    UndoManager::getInstance().executeCommand(
+        std::make_unique<DeleteAutomationLaneCommand>(laneId));
+    return true;
 }
 
 bool AutomationApiLive::retypeEmptyLane(AutomationLaneId laneId, AutomationLaneType type) {

--- a/magda/daw/api/automation_api_live.hpp
+++ b/magda/daw/api/automation_api_live.hpp
@@ -16,6 +16,13 @@ class AutomationApiLive : public AutomationApi {
     AutomationPointId addPoint(AutomationLaneId laneId, double beatPosition, double value,
                                AutomationCurveType curveType) override;
     void clearLanePoints(AutomationLaneId laneId) override;
+
+    const std::vector<AutomationLaneInfo>& getLanes() const override;
+    std::vector<AutomationLaneId> getLanesForTrack(TrackId trackId) const override;
+    std::vector<AutomationLaneId> getEditScopedLanes() const override;
+    const std::vector<AutomationClipInfo>& getClips() const override;
+    bool setLanePoints(AutomationLaneId laneId, std::vector<AutomationPoint> points) override;
+    bool deleteLane(AutomationLaneId laneId) override;
     bool retypeEmptyLane(AutomationLaneId laneId, AutomationLaneType type) override;
     AutomationClipId createClip(AutomationLaneId laneId, double startBeats,
                                 double lengthBeats) override;

--- a/magda/daw/api/device_api.hpp
+++ b/magda/daw/api/device_api.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <optional>
+#include <vector>
+
+#include "../core/ChainNodePath.hpp"
+#include "../core/DeviceInfo.hpp"
+#include "../core/TypeIds.hpp"
+
+namespace magda {
+
+/**
+ * @brief A device the user can add, described without exposing where it lives.
+ *
+ * `catalogId` is `DeviceInfo::pluginId` — the loader id for internal and
+ * compiled devices ("4osc", "drumgrid"), and the scanned identifier for
+ * external plugins. It is the only handle a caller needs to add a device.
+ *
+ * Deliberately carries no `fileOrIdentifier`: a remote caller must be able to
+ * name a plugin without learning the filesystem layout of the machine hosting
+ * it.
+ */
+struct DeviceCatalogEntry {
+    juce::String catalogId;
+    juce::String name;
+    juce::String manufacturer;
+    juce::String category;
+    juce::String description;
+    PluginFormat format = PluginFormat::Internal;
+    DeviceType type = DeviceType::Effect;
+    bool isInstrument = false;
+
+    bool operator==(const DeviceCatalogEntry&) const = default;
+};
+
+/**
+ * @brief One automatable parameter of a live device.
+ *
+ * Values are in real parameter units (Hz, dB, %), matching `ParameterInfo` —
+ * never MAGDA-normalized automation units. `index` addresses the parameter
+ * within its device and is what `setDeviceParameter` takes.
+ */
+struct DeviceParameter {
+    int index = -1;
+    juce::String stableId;
+    juce::String name;
+    juce::String unit;
+    float minValue = 0.0f;
+    float maxValue = 1.0f;
+    float defaultValue = 0.0f;
+    float currentValue = 0.0f;
+
+    bool operator==(const DeviceParameter&) const = default;
+};
+
+/**
+ * @brief Device discovery and inspection, addressed by `ChainNodePath`.
+ *
+ * Live devices are named by path rather than by `DeviceId`, because a device id
+ * is unique only within one of a track's three sections — the main FX chain,
+ * the post-fader list, and the mixer-analysis rail each allocate from their own
+ * counter. A path also reaches arbitrarily deep into nested racks, which the
+ * `(trackId, rackId, chainId)` triples on `TrackApi` cannot express.
+ *
+ * Read surface only for now. The mutation half — add by catalogue id, remove,
+ * move, bypass, and parameter writes — needs path-based undoable commands that
+ * do not exist yet (`TrackCommands` has add/remove at track level only), and
+ * lands separately so that work gets reviewed on its own terms.
+ */
+class DeviceApi {
+  public:
+    virtual ~DeviceApi() = default;
+
+    /** Every device the user can add — internal, compiled, and external. */
+    virtual std::vector<DeviceCatalogEntry> getCatalog() const = 0;
+
+    /** One catalogue entry, or nullopt if `catalogId` names nothing. */
+    virtual std::optional<DeviceCatalogEntry> findCatalogEntry(
+        const juce::String& catalogId) const = 0;
+
+    /** The device at `devicePath`, or nullptr. */
+    virtual const DeviceInfo* getDevice(const ChainNodePath& devicePath) const = 0;
+
+    /** Empty if the path does not resolve, or the device has no parameters. */
+    virtual std::vector<DeviceParameter> getDeviceParameters(
+        const ChainNodePath& devicePath) const = 0;
+};
+
+}  // namespace magda

--- a/magda/daw/api/device_api.hpp
+++ b/magda/daw/api/device_api.hpp
@@ -64,10 +64,9 @@ struct DeviceParameter {
  * counter. A path also reaches arbitrarily deep into nested racks, which the
  * `(trackId, rackId, chainId)` triples on `TrackApi` cannot express.
  *
- * Read surface only for now. The mutation half — add by catalogue id, remove,
- * move, bypass, and parameter writes — needs path-based undoable commands that
- * do not exist yet (`TrackCommands` has add/remove at track level only), and
- * lands separately so that work gets reviewed on its own terms.
+ * Callers never construct a `DeviceInfo`: `addDevice` takes a catalogue id and
+ * a placement, so plugin internals and file paths stay private to the host.
+ * Every mutation is one undo step.
  */
 class DeviceApi {
   public:
@@ -86,6 +85,35 @@ class DeviceApi {
     /** Empty if the path does not resolve, or the device has no parameters. */
     virtual std::vector<DeviceParameter> getDeviceParameters(
         const ChainNodePath& devicePath) const = 0;
+
+    /**
+     * @brief Add a device to a track's FX chain or to a rack chain.
+     *
+     * `parentPath` is a track-level path for the main FX chain, or a chain path
+     * at any nesting depth. `index` inserts at that position; negative appends.
+     * Returns INVALID_DEVICE_ID if the path or the catalogue id does not
+     * resolve.
+     */
+    virtual DeviceId addDevice(const ChainNodePath& parentPath, const juce::String& catalogId,
+                               int index) = 0;
+
+    /** Remove the device at `devicePath`. */
+    virtual bool removeDevice(const ChainNodePath& devicePath) = 0;
+
+    /** Move a device within the chain it already lives in. */
+    virtual bool moveDevice(const ChainNodePath& devicePath, int toIndex) = 0;
+
+    virtual bool setDeviceBypassed(const ChainNodePath& devicePath, bool bypassed) = 0;
+
+    /**
+     * @brief Write one parameter, in real parameter units.
+     *
+     * Values outside the parameter's range are rejected rather than clamped: a
+     * silently clamped write reports success while doing something the caller
+     * did not ask for.
+     */
+    virtual bool setDeviceParameter(const ChainNodePath& devicePath, int paramIndex,
+                                    float value) = 0;
 };
 
 }  // namespace magda

--- a/magda/daw/api/device_api_live.cpp
+++ b/magda/daw/api/device_api_live.cpp
@@ -1,10 +1,14 @@
 #include "device_api_live.hpp"
 
 #include <algorithm>
+#include <cmath>
+#include <memory>
 
 #include "../audio/plugins/InternalPluginRegistry.hpp"
 #include "../audio/plugins/compiled/CompiledPluginRegistry.hpp"
+#include "../core/TrackCommands.hpp"
 #include "../core/TrackManager.hpp"
+#include "../core/UndoManager.hpp"
 #include "plugin_api_live.hpp"
 
 namespace magda {
@@ -52,6 +56,44 @@ DeviceCatalogEntry entryFromScannedPlugin(const DeviceInfo& device) {
     entry.isInstrument = device.isInstrument;
     entry.type = device.deviceType;
     return entry;
+}
+
+/**
+ * Build the `DeviceInfo` the model needs from a catalogue id.
+ *
+ * This is the boundary the catalogue exists to create: a caller names a device
+ * by id, and the host supplies the loader details — including the plugin's
+ * filesystem location for external plugins, which never leaves this layer.
+ */
+std::optional<DeviceInfo> deviceFromCatalogId(const juce::String& catalogId) {
+    if (catalogId.isEmpty())
+        return std::nullopt;
+
+    const auto fromSpec = [&catalogId](const char* displayName, bool isInstrument) {
+        DeviceInfo device;
+        device.pluginId = catalogId;
+        device.name = safeText(displayName);
+        device.format = PluginFormat::Internal;
+        device.isInstrument = isInstrument;
+        device.deviceType = isInstrument ? DeviceType::Instrument : DeviceType::Effect;
+        return device;
+    };
+
+    if (const auto* spec = daw::audio::compiled::findCompiledPluginSpec(catalogId))
+        return fromSpec(spec->displayName, spec->isInstrument);
+
+    if (const auto* spec = daw::audio::findInternalPluginSpec(catalogId))
+        return fromSpec(spec->displayName, spec->isInstrument);
+
+    // External plugins are loaded from the scan record, which carries the
+    // fileOrIdentifier the host needs and the catalogue deliberately omits.
+    PluginApiLive plugins;
+    for (const auto& scanned : plugins.getAllExternalPlugins()) {
+        if (scanned.pluginId == catalogId || scanned.uniqueId == catalogId)
+            return scanned;
+    }
+
+    return std::nullopt;
 }
 
 }  // namespace
@@ -124,6 +166,81 @@ std::vector<DeviceParameter> DeviceApiLive::getDeviceParameters(
                               info.maxValue, info.defaultValue, info.currentValue});
     }
     return parameters;
+}
+
+DeviceId DeviceApiLive::addDevice(const ChainNodePath& parentPath, const juce::String& catalogId,
+                                  int index) {
+    const auto device = deviceFromCatalogId(catalogId);
+    if (!device.has_value())
+        return INVALID_DEVICE_ID;
+
+    // Track-level addresses the main FX chain; anything else must be a chain.
+    const auto type = parentPath.getType();
+    if (type != ChainNodeType::Track && type != ChainNodeType::Chain)
+        return INVALID_DEVICE_ID;
+    if (type == ChainNodeType::Chain &&
+        TrackManager::getInstance().getChainByPath(parentPath) == nullptr)
+        return INVALID_DEVICE_ID;
+    if (type == ChainNodeType::Track &&
+        TrackManager::getInstance().getTrack(parentPath.trackId) == nullptr)
+        return INVALID_DEVICE_ID;
+
+    auto command = std::make_unique<AddDeviceByPathCommand>(parentPath, *device, index);
+    auto* raw = command.get();
+    UndoManager::getInstance().executeCommand(std::move(command));
+    return raw->getCreatedDeviceId();
+}
+
+bool DeviceApiLive::removeDevice(const ChainNodePath& devicePath) {
+    if (getDevice(devicePath) == nullptr)
+        return false;
+
+    auto command = std::make_unique<RemoveDeviceByPathCommand>(devicePath);
+    auto* raw = command.get();
+    UndoManager::getInstance().executeCommand(std::move(command));
+    return raw->didRemove();
+}
+
+bool DeviceApiLive::moveDevice(const ChainNodePath& devicePath, int toIndex) {
+    if (toIndex < 0 || getDevice(devicePath) == nullptr)
+        return false;
+
+    // A move within one chain is a move to the same parent, which the existing
+    // path-based command already models.
+    const auto parentPath = devicePath.parentChain();
+
+    auto command = std::make_unique<MoveChainElementCommand>(devicePath, parentPath, toIndex);
+    auto* raw = command.get();
+    UndoManager::getInstance().executeCommand(std::move(command));
+    return raw->didMove();
+}
+
+bool DeviceApiLive::setDeviceBypassed(const ChainNodePath& devicePath, bool bypassed) {
+    if (getDevice(devicePath) == nullptr)
+        return false;
+    TrackManager::getInstance().setDeviceBypassedByPath(devicePath, bypassed);
+    return true;
+}
+
+bool DeviceApiLive::setDeviceParameter(const ChainNodePath& devicePath, int paramIndex,
+                                       float value) {
+    const auto* device = getDevice(devicePath);
+    if (device == nullptr)
+        return false;
+
+    const auto match = std::find_if(
+        device->parameters.begin(), device->parameters.end(),
+        [paramIndex](const ParameterInfo& info) { return info.paramIndex == paramIndex; });
+    if (match == device->parameters.end())
+        return false;
+
+    // Reject rather than clamp: a clamped write reports success while setting a
+    // value the caller did not ask for.
+    if (std::isnan(value) || value < match->minValue || value > match->maxValue)
+        return false;
+
+    TrackManager::getInstance().setDeviceParameterValue(devicePath, paramIndex, value);
+    return true;
 }
 
 }  // namespace magda

--- a/magda/daw/api/device_api_live.cpp
+++ b/magda/daw/api/device_api_live.cpp
@@ -1,0 +1,129 @@
+#include "device_api_live.hpp"
+
+#include <algorithm>
+
+#include "../audio/plugins/InternalPluginRegistry.hpp"
+#include "../audio/plugins/compiled/CompiledPluginRegistry.hpp"
+#include "../core/TrackManager.hpp"
+#include "plugin_api_live.hpp"
+
+namespace magda {
+
+namespace {
+
+juce::String safeText(const char* text) {
+    return text != nullptr ? juce::String(text) : juce::String();
+}
+
+DeviceCatalogEntry entryFromCompiledSpec(const daw::audio::compiled::CompiledPluginSpec& spec) {
+    DeviceCatalogEntry entry;
+    entry.catalogId = safeText(spec.pluginId);
+    entry.name = safeText(spec.displayName);
+    entry.category = safeText(spec.browserCategory);
+    entry.description = safeText(spec.description);
+    entry.format = PluginFormat::Internal;
+    entry.isInstrument = spec.isInstrument;
+    entry.type = spec.isInstrument ? DeviceType::Instrument : DeviceType::Effect;
+    return entry;
+}
+
+DeviceCatalogEntry entryFromInternalSpec(const daw::audio::InternalPluginSpec& spec) {
+    DeviceCatalogEntry entry;
+    entry.catalogId = safeText(spec.pluginId);
+    entry.name = safeText(spec.displayName);
+    entry.category = safeText(spec.browserCategory);
+    entry.description = safeText(spec.description);
+    entry.format = PluginFormat::Internal;
+    entry.isInstrument = spec.isInstrument;
+    entry.type = spec.isInstrument ? DeviceType::Instrument : DeviceType::Effect;
+    return entry;
+}
+
+// External plugins arrive as DeviceInfo from the scan. Only the identifying and
+// descriptive fields cross into the catalogue; fileOrIdentifier deliberately
+// does not, so a caller can name a plugin without learning where it lives.
+DeviceCatalogEntry entryFromScannedPlugin(const DeviceInfo& device) {
+    DeviceCatalogEntry entry;
+    entry.catalogId = device.pluginId.isNotEmpty() ? device.pluginId : device.uniqueId;
+    entry.name = device.name;
+    entry.manufacturer = device.manufacturer;
+    entry.category = device.browserCategoryOverride;
+    entry.format = device.format;
+    entry.isInstrument = device.isInstrument;
+    entry.type = device.deviceType;
+    return entry;
+}
+
+}  // namespace
+
+std::vector<DeviceCatalogEntry> DeviceApiLive::getCatalog() const {
+    std::vector<DeviceCatalogEntry> catalog;
+
+    for (const auto* spec : daw::audio::compiled::getAllCompiledPluginSpecs()) {
+        if (spec != nullptr)
+            catalog.push_back(entryFromCompiledSpec(*spec));
+    }
+
+    // showInBrowser is the single source of truth for what the user can add;
+    // the registry also holds internal devices that exist only as host wiring.
+    for (const auto* spec : daw::audio::getAllInternalPluginSpecs()) {
+        if (spec != nullptr && spec->showInBrowser)
+            catalog.push_back(entryFromInternalSpec(*spec));
+    }
+
+    PluginApiLive plugins;
+    for (const auto& device : plugins.getExternalPlugins())
+        catalog.push_back(entryFromScannedPlugin(device));
+
+    // A device pack and a scanned plugin can claim the same id. Keep the first,
+    // which is the built-in, so a third-party plugin cannot shadow it.
+    std::vector<DeviceCatalogEntry> unique;
+    unique.reserve(catalog.size());
+    for (auto& entry : catalog) {
+        if (entry.catalogId.isEmpty())
+            continue;
+        const auto duplicate =
+            std::any_of(unique.begin(), unique.end(), [&entry](const DeviceCatalogEntry& seen) {
+                return seen.catalogId == entry.catalogId;
+            });
+        if (!duplicate)
+            unique.push_back(std::move(entry));
+    }
+
+    return unique;
+}
+
+std::optional<DeviceCatalogEntry> DeviceApiLive::findCatalogEntry(
+    const juce::String& catalogId) const {
+    if (catalogId.isEmpty())
+        return std::nullopt;
+
+    for (const auto& entry : getCatalog()) {
+        if (entry.catalogId == catalogId)
+            return entry;
+    }
+    return std::nullopt;
+}
+
+const DeviceInfo* DeviceApiLive::getDevice(const ChainNodePath& devicePath) const {
+    if (!devicePath.isValid())
+        return nullptr;
+    return TrackManager::getInstance().getDeviceInChainByPath(devicePath);
+}
+
+std::vector<DeviceParameter> DeviceApiLive::getDeviceParameters(
+    const ChainNodePath& devicePath) const {
+    const auto* device = getDevice(devicePath);
+    if (device == nullptr)
+        return {};
+
+    std::vector<DeviceParameter> parameters;
+    parameters.reserve(device->parameters.size());
+    for (const auto& info : device->parameters) {
+        parameters.push_back({info.paramIndex, info.stableId, info.name, info.unit, info.minValue,
+                              info.maxValue, info.defaultValue, info.currentValue});
+    }
+    return parameters;
+}
+
+}  // namespace magda

--- a/magda/daw/api/device_api_live.hpp
+++ b/magda/daw/api/device_api_live.hpp
@@ -14,6 +14,13 @@ class DeviceApiLive : public DeviceApi {
     const DeviceInfo* getDevice(const ChainNodePath& devicePath) const override;
     std::vector<DeviceParameter> getDeviceParameters(
         const ChainNodePath& devicePath) const override;
+
+    DeviceId addDevice(const ChainNodePath& parentPath, const juce::String& catalogId,
+                       int index) override;
+    bool removeDevice(const ChainNodePath& devicePath) override;
+    bool moveDevice(const ChainNodePath& devicePath, int toIndex) override;
+    bool setDeviceBypassed(const ChainNodePath& devicePath, bool bypassed) override;
+    bool setDeviceParameter(const ChainNodePath& devicePath, int paramIndex, float value) override;
 };
 
 }  // namespace magda

--- a/magda/daw/api/device_api_live.hpp
+++ b/magda/daw/api/device_api_live.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "device_api.hpp"
+
+namespace magda {
+
+/// Builds the catalogue from the internal, compiled, and scanned-plugin
+/// registries, and resolves live devices through TrackManager::getInstance().
+class DeviceApiLive : public DeviceApi {
+  public:
+    std::vector<DeviceCatalogEntry> getCatalog() const override;
+    std::optional<DeviceCatalogEntry> findCatalogEntry(
+        const juce::String& catalogId) const override;
+    const DeviceInfo* getDevice(const ChainNodePath& devicePath) const override;
+    std::vector<DeviceParameter> getDeviceParameters(
+        const ChainNodePath& devicePath) const override;
+};
+
+}  // namespace magda

--- a/magda/daw/api/magda_api.hpp
+++ b/magda/daw/api/magda_api.hpp
@@ -15,6 +15,7 @@ class TransportApi;
 class FocusedApi;
 class GrooveApi;
 class PluginApi;
+class DeviceApi;
 
 /**
  * Programmatic facade for MAGDA's DAW state.
@@ -44,6 +45,7 @@ class MagdaApi {
     virtual TransportApi& transport() = 0;
     virtual FocusedApi& focused() = 0;
     virtual PluginApi& plugins() = 0;
+    virtual DeviceApi& devices() = 0;
     virtual GrooveApi& grooves() = 0;
 };
 

--- a/magda/daw/api/magda_api_live.hpp
+++ b/magda/daw/api/magda_api_live.hpp
@@ -3,6 +3,7 @@
 #include "alias_api_live.hpp"
 #include "automation_api_live.hpp"
 #include "clip_api_live.hpp"
+#include "device_api_live.hpp"
 #include "focused_api_live.hpp"
 #include "groove_api_live.hpp"
 #include "magda_api.hpp"
@@ -57,6 +58,9 @@ class MagdaApiLive : public MagdaApi {
     }
     PluginApi& plugins() override {
         return plugins_;
+    }
+    DeviceApi& devices() override {
+        return devices_;
     }
     GrooveApi& grooves() override {
         return grooves_;
@@ -113,6 +117,7 @@ class MagdaApiLive : public MagdaApi {
     TransportApiLive transport_;
     FocusedApiLive focused_;
     PluginApiLive plugins_;
+    DeviceApiLive devices_;
     GrooveApiLive grooves_;
 };
 

--- a/magda/daw/audio/plugin_manager/PluginManager.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.cpp
@@ -70,16 +70,7 @@ te::AutomatableParameter* resolveSameScopeModParam(
 }
 
 ChainNodePath parentContainerForMoveSource(const ChainNodePath& sourceElementPath) {
-    ChainNodePath parent;
-    parent.trackId = sourceElementPath.trackId;
-
-    if (sourceElementPath.topLevelDeviceId != INVALID_DEVICE_ID)
-        return parent;
-
-    parent.steps = sourceElementPath.steps;
-    if (!parent.steps.empty())
-        parent.steps.pop_back();
-    return parent;
+    return sourceElementPath.parentChain();
 }
 
 void collectDevicePathsForMove(const RackInfo& rack, const ChainNodePath& rackPath,

--- a/magda/daw/core/AutomationCommands.cpp
+++ b/magda/daw/core/AutomationCommands.cpp
@@ -784,4 +784,49 @@ void InsertTimeAutomationCommand::undo() {
     shiftedPoints_.clear();
 }
 
+// ============================================================================
+// SetAutomationLanePointsCommand
+// ============================================================================
+
+SetAutomationLanePointsCommand::SetAutomationLanePointsCommand(AutomationLaneId laneId,
+                                                               std::vector<AutomationPoint> points)
+    : laneId_(laneId), points_(std::move(points)) {
+    auto& mgr = AutomationManager::getInstance();
+    const auto* lane = mgr.getLane(laneId_);
+    if (lane == nullptr || !lane->isAbsolute())
+        return;
+
+    storedLane_ = *lane;
+    for (auto clipId : lane->clipIds) {
+        if (const auto* clip = mgr.getClip(clipId))
+            storedClips_.push_back(*clip);
+    }
+    captured_ = true;
+}
+
+void SetAutomationLanePointsCommand::execute() {
+    if (!captured_)
+        return;
+
+    auto& mgr = AutomationManager::getInstance();
+    auto* lane = mgr.getLane(laneId_);
+    if (lane == nullptr)
+        return;
+
+    // One batch so listeners see the replacement as a single change rather than
+    // a clear followed by N inserts.
+    AutomationManager::BatchScope batch;
+    mgr.clearLanePoints(laneId_);
+    for (const auto& point : points_)
+        mgr.addPoint(laneId_, point.beatPosition, point.value, point.curveType);
+
+    applied_ = true;
+}
+
+void SetAutomationLanePointsCommand::undo() {
+    if (!applied_)
+        return;
+    AutomationManager::getInstance().restoreLaneState(storedLane_, storedClips_);
+}
+
 }  // namespace magda

--- a/magda/daw/core/AutomationCommands.hpp
+++ b/magda/daw/core/AutomationCommands.hpp
@@ -692,4 +692,38 @@ class InsertTimeAutomationCommand : public UndoableCommand {
     std::vector<ShiftedPoint> shiftedPoints_;
 };
 
+/**
+ * @brief Replace every point on an absolute lane as one undoable step.
+ *
+ * Writing a curve point by point through AddAutomationPointCommand produces one
+ * undo entry per point, so undoing a generated curve means pressing Undo once
+ * per sample. This captures the lane's full state up front and restores it
+ * verbatim — point ids preserved — so the whole write is one step.
+ *
+ * Absolute lanes only: a clip-based lane keeps its points on its clips, and
+ * `setClipPoints` already covers that.
+ */
+class SetAutomationLanePointsCommand : public UndoableCommand {
+  public:
+    SetAutomationLanePointsCommand(AutomationLaneId laneId, std::vector<AutomationPoint> points);
+
+    void execute() override;
+    void undo() override;
+    juce::String getDescription() const override {
+        return "Set Automation Points";
+    }
+
+    bool didApply() const {
+        return applied_;
+    }
+
+  private:
+    AutomationLaneId laneId_;
+    std::vector<AutomationPoint> points_;
+    AutomationLaneInfo storedLane_;
+    std::vector<AutomationClipInfo> storedClips_;
+    bool captured_ = false;
+    bool applied_ = false;
+};
+
 }  // namespace magda

--- a/magda/daw/core/ChainNodePath.hpp
+++ b/magda/daw/core/ChainNodePath.hpp
@@ -262,6 +262,27 @@ struct ChainNodePath {
         return p;
     }
 
+    /**
+     * @brief The chain this element lives in.
+     *
+     * Differs from `parent()` for a legacy top-level device, whose id lives
+     * outside `steps` — `parent()` returns that path unchanged and so still
+     * addresses the device rather than its container. The result is a chain
+     * path with no steps for the track's main FX chain, which is what the
+     * element-container lookups expect.
+     */
+    ChainNodePath parentChain() const {
+        ChainNodePath p;
+        p.trackId = trackId;
+        if (topLevelDeviceId != INVALID_DEVICE_ID)
+            return p;
+
+        p.steps = steps;
+        if (!p.steps.empty())
+            p.steps.pop_back();
+        return p;
+    }
+
     // Build a human-readable path string (for debugging/display)
     juce::String toString() const {
         juce::String result = "Track[" + juce::String(trackId) + "]";

--- a/magda/daw/core/TrackCommands.cpp
+++ b/magda/daw/core/TrackCommands.cpp
@@ -11,16 +11,8 @@
 namespace magda {
 
 namespace {
-ChainNodePath getChainElementParentPath(const ChainNodePath& path) {
-    ChainNodePath parent;
-    parent.trackId = path.trackId;
-    if (path.topLevelDeviceId != INVALID_DEVICE_ID)
-        return parent;
-
-    parent.steps = path.steps;
-    if (!parent.steps.empty())
-        parent.steps.pop_back();
-    return parent;
+ChainNodePath parentChainOf(const ChainNodePath& path) {
+    return path.parentChain();
 }
 
 std::vector<ChainElement> deepCopyChainElements(const std::vector<ChainElement>& elements) {
@@ -353,7 +345,14 @@ void RemoveDeviceFromTrackCommand::undo() {
     DBG("UNDO: Restoring device " << savedDevice_.name << " (id=" << deviceId_
                                   << "), pluginState length=" << savedDevice_.pluginState.length());
     auto& tm = TrackManager::getInstance();
-    tm.addDeviceToTrack(trackId_, savedDevice_, savedIndex_);
+    // Re-insert with ids preserved. addDeviceToTrack runs the device through
+    // prepareNewDevice, which stamps a fresh DeviceId, so undo would restore it
+    // under a different id and orphan every automation lane, macro link, and
+    // alias that targeted it. ChainElement is move-only, hence the push_back.
+    std::vector<ChainElement> elements;
+    elements.push_back(makeDeviceElement(savedDevice_));
+    tm.insertChainElementsByPath(ChainNodePath::topLevelDevice(trackId_, deviceId_).parentChain(),
+                                 std::move(elements), savedIndex_, /*reassignIds=*/false);
     DBG("UNDO: Restored device " << savedDevice_.name << " (id=" << deviceId_ << ") to track "
                                  << trackId_ << " at index " << savedIndex_);
 }
@@ -443,7 +442,7 @@ void MoveChainElementsCommand::execute() {
         if (!describeChainElementPath(path, type, id))
             continue;
 
-        const auto parentPath = getChainElementParentPath(path);
+        const auto parentPath = parentChainOf(path);
         const int index = tm.getChainElementIndex(path);
         if (index < 0)
             continue;
@@ -508,7 +507,7 @@ void MoveChainElementsCommand::undo() {
             return;
 
         int insertIndex = record.originalIndex;
-        const auto currentParentPath = getChainElementParentPath(currentPath);
+        const auto currentParentPath = parentChainOf(currentPath);
         const int currentIndex = tm.getChainElementIndex(currentPath);
         if (currentParentPath == record.originalParentPath) {
             if (currentIndex == record.originalIndex)
@@ -534,8 +533,7 @@ void MoveChainElementsCommand::undo() {
 
         for (auto it = begin; it != end; ++it) {
             const auto currentPath = findChainElementPath(tm, it->type, it->id);
-            if (!currentPath.isValid() ||
-                getChainElementParentPath(currentPath) != it->originalParentPath) {
+            if (!currentPath.isValid() || parentChainOf(currentPath) != it->originalParentPath) {
                 allStillInOriginalContainer = false;
                 break;
             }
@@ -633,10 +631,10 @@ void WrapChainElementsInRackCommand::execute() {
         return;
     }
 
-    sourceChainPath_ = getChainElementParentPath(sourceElementPaths_.front());
+    sourceChainPath_ = parentChainOf(sourceElementPaths_.front());
     sourceIndex_ = std::numeric_limits<int>::max();
     for (const auto& path : sourceElementPaths_) {
-        if (getChainElementParentPath(path) != sourceChainPath_) {
+        if (parentChainOf(path) != sourceChainPath_) {
             executed_ = false;
             return;
         }
@@ -796,6 +794,102 @@ void CreateTrackWithDeviceCommand::undo() {
 
     TrackManager::getInstance().deleteTrack(createdTrackId_);
     DBG("UNDO: Undid create track with device " << createdTrackId_);
+}
+
+// ============================================================================
+// Path-based device commands
+// ============================================================================
+
+namespace {
+
+void capturePluginStateAt(const ChainNodePath& devicePath) {
+    auto& tm = TrackManager::getInstance();
+    if (auto* engine = tm.getAudioEngine()) {
+        if (auto* bridge = engine->getAudioBridge())
+            bridge->getPluginManager().capturePluginState(devicePath);
+    }
+}
+
+}  // namespace
+
+AddDeviceByPathCommand::AddDeviceByPathCommand(const ChainNodePath& parentPath,
+                                               const DeviceInfo& device, int insertIndex)
+    : parentPath_(parentPath), device_(device), insertIndex_(insertIndex) {}
+
+void AddDeviceByPathCommand::execute() {
+    auto& tm = TrackManager::getInstance();
+
+    if (parentPath_.getType() == ChainNodeType::Track) {
+        createdDeviceId_ = insertIndex_ >= 0
+                               ? tm.addDeviceToTrack(parentPath_.trackId, device_, insertIndex_)
+                               : tm.addDeviceToTrack(parentPath_.trackId, device_);
+        if (createdDeviceId_ != INVALID_DEVICE_ID)
+            createdDevicePath_ =
+                ChainNodePath::topLevelDevice(parentPath_.trackId, createdDeviceId_);
+    } else {
+        createdDeviceId_ = insertIndex_ >= 0
+                               ? tm.addDeviceToChainByPath(parentPath_, device_, insertIndex_)
+                               : tm.addDeviceToChainByPath(parentPath_, device_);
+        if (createdDeviceId_ != INVALID_DEVICE_ID)
+            createdDevicePath_ = parentPath_.withDevice(createdDeviceId_);
+    }
+
+    executed_ = createdDeviceId_ != INVALID_DEVICE_ID;
+    DBG("UNDO: Added device by path " << parentPath_.toString() << " (deviceId=" << createdDeviceId_
+                                      << ")");
+}
+
+void AddDeviceByPathCommand::undo() {
+    if (!executed_ || !createdDevicePath_.isValid())
+        return;
+    TrackManager::getInstance().removeDeviceFromChainByPath(createdDevicePath_);
+    DBG("UNDO: Removed added device " << createdDeviceId_);
+}
+
+RemoveDeviceByPathCommand::RemoveDeviceByPathCommand(const ChainNodePath& devicePath)
+    : devicePath_(devicePath), parentPath_(devicePath.parentChain()) {}
+
+void RemoveDeviceByPathCommand::execute() {
+    auto& tm = TrackManager::getInstance();
+
+    const auto* device = tm.getDeviceInChainByPath(devicePath_);
+    if (device == nullptr)
+        return;
+
+    // Flush live plugin state into DeviceInfo so undo restores how it sounded.
+    capturePluginStateAt(devicePath_);
+
+    device = tm.getDeviceInChainByPath(devicePath_);
+    if (device == nullptr)
+        return;
+
+    savedDevice_ = *device;
+    savedIndex_ = tm.getChainElementIndex(devicePath_);
+    if (savedIndex_ < 0)
+        return;
+
+    tm.removeDeviceFromChainByPath(devicePath_);
+    executed_ = true;
+    DBG("UNDO: Removed device " << savedDevice_.name << " at index " << savedIndex_);
+}
+
+void RemoveDeviceByPathCommand::undo() {
+    if (!executed_)
+        return;
+
+    // Re-insert with ids preserved. The ordinary add path runs the device
+    // through prepareNewDevice, which stamps a fresh DeviceId — undo would then
+    // restore the device under a different id, leaving every automation lane,
+    // macro link, and alias that targeted it pointing at nothing.
+    // ChainElement holds a unique_ptr, so build the vector by move rather than
+    // from an initializer list.
+    std::vector<ChainElement> elements;
+    elements.push_back(makeDeviceElement(savedDevice_));
+    TrackManager::getInstance().insertChainElementsByPath(parentPath_, std::move(elements),
+                                                          savedIndex_, /*reassignIds=*/false);
+
+    DBG("UNDO: Restored device " << savedDevice_.name << " (id=" << savedDevice_.id << ") at index "
+                                 << savedIndex_);
 }
 
 }  // namespace magda

--- a/magda/daw/core/TrackCommands.hpp
+++ b/magda/daw/core/TrackCommands.hpp
@@ -310,4 +310,69 @@ class CreateTrackWithDeviceCommand : public UndoableCommand {
     bool executed_ = false;
 };
 
+/**
+ * @brief Add a device anywhere in the chain tree, addressed by path.
+ *
+ * The track-level `AddDeviceToTrackCommand` above cannot reach into a rack, and
+ * a `(trackId, rackId, chainId)` triple stops at one level of nesting. This
+ * takes the parent path — track-level for the main FX chain, or a chain path at
+ * any depth — so anything the model can express is reachable.
+ */
+class AddDeviceByPathCommand : public UndoableCommand {
+  public:
+    AddDeviceByPathCommand(const ChainNodePath& parentPath, const DeviceInfo& device,
+                           int insertIndex = -1);
+
+    void execute() override;
+    void undo() override;
+    juce::String getDescription() const override {
+        return "Add Device";
+    }
+
+    DeviceId getCreatedDeviceId() const {
+        return createdDeviceId_;
+    }
+
+    /** Path of the device this command created, invalid until it has run. */
+    const ChainNodePath& getCreatedDevicePath() const {
+        return createdDevicePath_;
+    }
+
+  private:
+    ChainNodePath parentPath_;
+    DeviceInfo device_;
+    int insertIndex_ = -1;
+    DeviceId createdDeviceId_ = INVALID_DEVICE_ID;
+    ChainNodePath createdDevicePath_;
+    bool executed_ = false;
+};
+
+/**
+ * @brief Remove a device addressed by path, restoring it in place on undo.
+ *
+ * Captures the plugin's live state before removal so undo restores the device
+ * as it sounded, not as it was first added.
+ */
+class RemoveDeviceByPathCommand : public UndoableCommand {
+  public:
+    explicit RemoveDeviceByPathCommand(const ChainNodePath& devicePath);
+
+    void execute() override;
+    void undo() override;
+    juce::String getDescription() const override {
+        return "Remove Device";
+    }
+
+    bool didRemove() const {
+        return executed_;
+    }
+
+  private:
+    ChainNodePath devicePath_;
+    ChainNodePath parentPath_;
+    DeviceInfo savedDevice_;
+    int savedIndex_ = -1;
+    bool executed_ = false;
+};
+
 }  // namespace magda

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -482,15 +482,7 @@ static std::vector<ChainElement>* getElementContainerForChainPath(TrackManager& 
 }
 
 static ChainNodePath getParentChainPathForElementPath(const ChainNodePath& elementPath) {
-    ChainNodePath parent;
-    parent.trackId = elementPath.trackId;
-    if (elementPath.topLevelDeviceId != INVALID_DEVICE_ID)
-        return parent;
-
-    parent.steps = elementPath.steps;
-    if (!parent.steps.empty())
-        parent.steps.pop_back();
-    return parent;
+    return elementPath.parentChain();
 }
 
 using DevicePathMap = std::map<DeviceId, ChainNodePath>;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -190,6 +190,7 @@ set(TEST_SOURCES
     test_magda_api_lua_bindings.cpp
     test_remote_api_contract.cpp
     test_device_api.cpp
+    test_automation_api_surface.cpp
     # Lua controller tests (issue #592 — MIDI dispatch)
     test_lua_controller.cpp
     # Focused device API tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -189,6 +189,7 @@ set(TEST_SOURCES
     # Lua bindings tests (issue #30 — bind MagdaApi)
     test_magda_api_lua_bindings.cpp
     test_remote_api_contract.cpp
+    test_device_api.cpp
     # Lua controller tests (issue #592 — MIDI dispatch)
     test_lua_controller.cpp
     # Focused device API tests

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -71,6 +71,24 @@ class StubAutomationApi : public AutomationApi {
     void clearLanePoints(AutomationLaneId) override {
         std::abort();
     }
+    const std::vector<AutomationLaneInfo>& getLanes() const override {
+        std::abort();
+    }
+    std::vector<AutomationLaneId> getLanesForTrack(TrackId) const override {
+        std::abort();
+    }
+    std::vector<AutomationLaneId> getEditScopedLanes() const override {
+        std::abort();
+    }
+    const std::vector<AutomationClipInfo>& getClips() const override {
+        std::abort();
+    }
+    bool setLanePoints(AutomationLaneId, std::vector<AutomationPoint>) override {
+        std::abort();
+    }
+    bool deleteLane(AutomationLaneId) override {
+        std::abort();
+    }
     bool retypeEmptyLane(AutomationLaneId, AutomationLaneType) override {
         std::abort();
     }

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -776,6 +776,59 @@ class MockDeviceApi : public DeviceApi {
         }
         return parameters;
     }
+
+    // Recorded mutations, for asserting what a caller invoked.
+    struct AddRecord {
+        ChainNodePath parentPath;
+        juce::String catalogId;
+        int index = -1;
+    };
+    std::vector<AddRecord> added;
+    std::vector<ChainNodePath> removed;
+    std::vector<std::pair<ChainNodePath, int>> moved;
+    std::vector<std::pair<ChainNodePath, bool>> bypassed;
+    std::vector<std::tuple<ChainNodePath, int, float>> parameterWrites;
+    DeviceId nextDeviceId = 1;
+
+    DeviceId addDevice(const ChainNodePath& parentPath, const juce::String& catalogId,
+                       int index) override {
+        if (!findCatalogEntry(catalogId).has_value())
+            return INVALID_DEVICE_ID;
+        added.push_back({parentPath, catalogId, index});
+        return nextDeviceId++;
+    }
+    bool removeDevice(const ChainNodePath& devicePath) override {
+        if (getDevice(devicePath) == nullptr)
+            return false;
+        removed.push_back(devicePath);
+        return true;
+    }
+    bool moveDevice(const ChainNodePath& devicePath, int toIndex) override {
+        if (toIndex < 0 || getDevice(devicePath) == nullptr)
+            return false;
+        moved.emplace_back(devicePath, toIndex);
+        return true;
+    }
+    bool setDeviceBypassed(const ChainNodePath& devicePath, bool value) override {
+        if (getDevice(devicePath) == nullptr)
+            return false;
+        bypassed.emplace_back(devicePath, value);
+        return true;
+    }
+    bool setDeviceParameter(const ChainNodePath& devicePath, int paramIndex, float value) override {
+        const auto* device = getDevice(devicePath);
+        if (device == nullptr)
+            return false;
+        for (const auto& info : device->parameters) {
+            if (info.paramIndex != paramIndex)
+                continue;
+            if (value < info.minValue || value > info.maxValue)
+                return false;
+            parameterWrites.emplace_back(devicePath, paramIndex, value);
+            return true;
+        }
+        return false;
+    }
 };
 
 class MockGrooveApi : public GrooveApi {

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -22,6 +22,7 @@
 #include "magda/daw/api/alias_api.hpp"
 #include "magda/daw/api/automation_api.hpp"
 #include "magda/daw/api/clip_api.hpp"
+#include "magda/daw/api/device_api.hpp"
 #include "magda/daw/api/focused_api.hpp"
 #include "magda/daw/api/groove_api.hpp"
 #include "magda/daw/api/magda_api.hpp"
@@ -741,6 +742,42 @@ class MockPluginApi : public PluginApi {
     }
 };
 
+class MockDeviceApi : public DeviceApi {
+  public:
+    std::vector<DeviceCatalogEntry> catalog;
+    // Live devices, keyed by the path that addresses them.
+    std::map<ChainNodePath, DeviceInfo> devices;
+
+    std::vector<DeviceCatalogEntry> getCatalog() const override {
+        return catalog;
+    }
+    std::optional<DeviceCatalogEntry> findCatalogEntry(
+        const juce::String& catalogId) const override {
+        for (const auto& entry : catalog) {
+            if (entry.catalogId == catalogId)
+                return entry;
+        }
+        return std::nullopt;
+    }
+    const DeviceInfo* getDevice(const ChainNodePath& devicePath) const override {
+        const auto it = devices.find(devicePath);
+        return it != devices.end() ? &it->second : nullptr;
+    }
+    std::vector<DeviceParameter> getDeviceParameters(
+        const ChainNodePath& devicePath) const override {
+        const auto* device = getDevice(devicePath);
+        if (device == nullptr)
+            return {};
+        std::vector<DeviceParameter> parameters;
+        for (const auto& info : device->parameters) {
+            parameters.push_back({info.paramIndex, info.stableId, info.name, info.unit,
+                                  info.minValue, info.maxValue, info.defaultValue,
+                                  info.currentValue});
+        }
+        return parameters;
+    }
+};
+
 class MockGrooveApi : public GrooveApi {
   public:
     juce::StringArray names;
@@ -770,6 +807,7 @@ class MockMagdaApi : public MagdaApi {
     MockTransportApi transport_;
     MockFocusedApi focused_;
     MockPluginApi plugins_;
+    MockDeviceApi devices_;
     MockGrooveApi grooves_;
 
     SelectionApi& selection() override {
@@ -807,6 +845,9 @@ class MockMagdaApi : public MagdaApi {
     }
     PluginApi& plugins() override {
         return plugins_;
+    }
+    DeviceApi& devices() override {
+        return devices_;
     }
     GrooveApi& grooves() override {
         return grooves_;

--- a/tests/test_automation_api_surface.cpp
+++ b/tests/test_automation_api_surface.cpp
@@ -1,0 +1,191 @@
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/api/automation_api_live.hpp"
+#include "magda/daw/core/AutomationManager.hpp"
+#include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/SelectionManager.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/core/UndoManager.hpp"
+
+using namespace magda;
+
+namespace {
+
+void resetState() {
+    AutomationManager::getInstance().clearAll();
+    ClipManager::getInstance().clearAllClips();
+    TrackManager::getInstance().clearAllTracks();
+    UndoManager::getInstance().clearHistory();
+    SelectionManager::getInstance().clearSelection();
+}
+
+AutomationTarget volumeTarget(TrackId id) {
+    AutomationTarget target;
+    target.kind = ControlTarget::Kind::TrackVolume;
+    target.devicePath = ChainNodePath::trackLevel(id);
+    return target;
+}
+
+bool contains(const std::vector<AutomationLaneId>& ids, AutomationLaneId id) {
+    return std::find(ids.begin(), ids.end(), id) != ids.end();
+}
+
+}  // namespace
+
+TEST_CASE("Automation lanes and their targets are enumerable through the facade",
+          "[automation-api][enumeration]") {
+    resetState();
+    auto& tracks = TrackManager::getInstance();
+    auto& automation = AutomationManager::getInstance();
+
+    const auto trackA = tracks.createTrack("A", TrackType::Audio);
+    const auto trackB = tracks.createTrack("B", TrackType::Audio);
+
+    const auto laneA = automation.createLane(volumeTarget(trackA), AutomationLaneType::Absolute);
+    const auto laneB = automation.createLane(volumeTarget(trackB), AutomationLaneType::Absolute);
+
+    AutomationApiLive api;
+    const auto& lanes = api.getLanes();
+    REQUIRE(lanes.size() == 2);
+
+    // Every lane carries the target it drives, so a caller can discover both
+    // the automation and the parameters behind it in one pass.
+    for (const auto& lane : lanes) {
+        REQUIRE(lane.target.isValid());
+        REQUIRE(lane.target.kind == ControlTarget::Kind::TrackVolume);
+    }
+
+    REQUIRE(contains(api.getLanesForTrack(trackA), laneA));
+    REQUIRE_FALSE(contains(api.getLanesForTrack(trackA), laneB));
+    REQUIRE(contains(api.getLanesForTrack(trackB), laneB));
+
+    resetState();
+}
+
+TEST_CASE("Edit-scoped lanes are enumerable even though no track owns them",
+          "[automation-api][enumeration]") {
+    resetState();
+    auto& automation = AutomationManager::getInstance();
+    const auto trackId = TrackManager::getInstance().createTrack("A", TrackType::Audio);
+
+    const auto trackLane =
+        automation.createLane(volumeTarget(trackId), AutomationLaneType::Absolute);
+    const auto tempoLane =
+        automation.createLane(AutomationTarget::tempo(), AutomationLaneType::Absolute);
+
+    AutomationApiLive api;
+    // Tempo has no devicePath, so getLanesForTrack can never reach it — without
+    // this accessor it would be invisible to a remote caller.
+    const auto editScoped = api.getEditScopedLanes();
+    REQUIRE(contains(editScoped, tempoLane));
+    REQUIRE_FALSE(contains(editScoped, trackLane));
+
+    resetState();
+}
+
+TEST_CASE("Bulk point writes are one undo step", "[automation-api][bulk]") {
+    resetState();
+    auto& automation = AutomationManager::getInstance();
+    const auto trackId = TrackManager::getInstance().createTrack("A", TrackType::Audio);
+    const auto laneId = automation.createLane(volumeTarget(trackId), AutomationLaneType::Absolute);
+
+    AutomationApiLive api;
+    // createLane seeds an absolute lane with one point at the target's current
+    // value, so "before" is that lane, not an empty one.
+    const auto pointsBefore = api.getLane(laneId)->absolutePoints.size();
+
+    std::vector<AutomationPoint> points;
+    for (int i = 0; i < 64; ++i) {
+        AutomationPoint point;
+        point.beatPosition = i * 0.25;
+        point.value = static_cast<double>(i) / 64.0;
+        point.curveType = AutomationCurveType::Linear;
+        points.push_back(point);
+    }
+
+    REQUIRE(api.setLanePoints(laneId, points));
+    REQUIRE(api.getLane(laneId)->absolutePoints.size() == 64);
+
+    // The whole curve is one entry, not 64 — otherwise undoing a generated
+    // curve means one Undo per sample.
+    auto& undo = UndoManager::getInstance();
+    REQUIRE(undo.canUndo());
+    undo.undo();
+    REQUIRE(api.getLane(laneId)->absolutePoints.size() == pointsBefore);
+    REQUIRE_FALSE(undo.canUndo());
+
+    undo.redo();
+    REQUIRE(api.getLane(laneId)->absolutePoints.size() == 64);
+
+    resetState();
+}
+
+TEST_CASE("Bulk point writes replace rather than append", "[automation-api][bulk]") {
+    resetState();
+    auto& automation = AutomationManager::getInstance();
+    const auto trackId = TrackManager::getInstance().createTrack("A", TrackType::Audio);
+    const auto laneId = automation.createLane(volumeTarget(trackId), AutomationLaneType::Absolute);
+
+    AutomationApiLive api;
+    AutomationPoint first;
+    first.beatPosition = 0.0;
+    first.value = 0.1;
+    REQUIRE(api.setLanePoints(laneId, {first}));
+    REQUIRE(api.getLane(laneId)->absolutePoints.size() == 1);
+
+    AutomationPoint second;
+    second.beatPosition = 4.0;
+    second.value = 0.9;
+    REQUIRE(api.setLanePoints(laneId, {second}));
+
+    const auto& applied = api.getLane(laneId)->absolutePoints;
+    REQUIRE(applied.size() == 1);
+    REQUIRE(applied.front().beatPosition == 4.0);
+
+    // Undo restores the previous curve, not an empty lane.
+    UndoManager::getInstance().undo();
+    REQUIRE(api.getLane(laneId)->absolutePoints.size() == 1);
+    REQUIRE(api.getLane(laneId)->absolutePoints.front().beatPosition == 0.0);
+
+    resetState();
+}
+
+TEST_CASE("Bulk point writes are refused where they do not apply", "[automation-api][bulk]") {
+    resetState();
+    auto& automation = AutomationManager::getInstance();
+    const auto trackId = TrackManager::getInstance().createTrack("A", TrackType::Audio);
+    AutomationApiLive api;
+
+    SECTION("unknown lane") {
+        REQUIRE_FALSE(api.setLanePoints(INVALID_AUTOMATION_LANE_ID, {}));
+        REQUIRE_FALSE(api.setLanePoints(9999, {}));
+    }
+
+    SECTION("clip-based lane keeps its points on clips") {
+        const auto laneId =
+            automation.createLane(volumeTarget(trackId), AutomationLaneType::ClipBased);
+        REQUIRE_FALSE(api.setLanePoints(laneId, {}));
+    }
+
+    resetState();
+}
+
+TEST_CASE("Deleting a lane through the facade is undoable", "[automation-api][bulk]") {
+    resetState();
+    auto& automation = AutomationManager::getInstance();
+    const auto trackId = TrackManager::getInstance().createTrack("A", TrackType::Audio);
+    const auto laneId = automation.createLane(volumeTarget(trackId), AutomationLaneType::Absolute);
+
+    AutomationApiLive api;
+    REQUIRE(api.getLanes().size() == 1);
+    REQUIRE(api.deleteLane(laneId));
+    REQUIRE(api.getLanes().empty());
+
+    UndoManager::getInstance().undo();
+    REQUIRE(api.getLanes().size() == 1);
+
+    REQUIRE_FALSE(api.deleteLane(9999));
+
+    resetState();
+}

--- a/tests/test_device_api.cpp
+++ b/tests/test_device_api.cpp
@@ -1,10 +1,33 @@
 #include <catch2/catch_test_macros.hpp>
+#include <limits>
+#include <memory>
 #include <set>
 
 #include "magda/daw/api/device_api_live.hpp"
+#include "magda/daw/core/TrackCommands.hpp"
 #include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/core/UndoManager.hpp"
 
 using namespace magda;
+
+namespace {
+
+/// A catalog id that exists in every build, so add tests need no plugin scan.
+juce::String anyCatalogId() {
+    const DeviceApiLive devices;
+    const auto catalog = devices.getCatalog();
+    REQUIRE_FALSE(catalog.empty());
+    return catalog.front().catalogId;
+}
+
+TrackId freshTrack(const juce::String& name) {
+    auto& tracks = TrackManager::getInstance();
+    tracks.clearAllTracks();
+    UndoManager::getInstance().clearHistory();
+    return tracks.createTrack(name, TrackType::Audio);
+}
+
+}  // namespace
 
 TEST_CASE("The device catalog is discoverable and internally consistent", "[device-api][catalog]") {
     const DeviceApiLive devices;
@@ -89,6 +112,246 @@ TEST_CASE("Device parameters are reported in real units", "[device-api][inspecti
     REQUIRE(parameters[0].maxValue == 20000.0f);
     REQUIRE(parameters[0].currentValue == 440.0f);
     REQUIRE(parameters[0].stableId == "cutoff");
+
+    tracks.clearAllTracks();
+}
+
+// ============================================================================
+// Mutations
+// ============================================================================
+
+TEST_CASE("Adding a device by catalog id is one undo step", "[device-api][mutation]") {
+    const auto trackId = freshTrack("Bass");
+    const auto catalogId = anyCatalogId();
+
+    DeviceApiLive devices;
+    const auto deviceId =
+        devices.addDevice(ChainNodePath::trackLevel(trackId), catalogId, /*index=*/-1);
+    REQUIRE(deviceId != INVALID_DEVICE_ID);
+
+    auto& tracks = TrackManager::getInstance();
+    const auto path = tracks.findDevicePath(deviceId);
+    REQUIRE(path.isValid());
+    const auto* added = devices.getDevice(path);
+    REQUIRE(added != nullptr);
+    REQUIRE(added->pluginId == catalogId);
+
+    // One Undo removes it, and one Redo brings it back.
+    auto& undo = UndoManager::getInstance();
+    REQUIRE(undo.canUndo());
+    undo.undo();
+    REQUIRE(tracks.getChainElements(trackId).empty());
+
+    undo.redo();
+    REQUIRE(tracks.getChainElements(trackId).size() == 1);
+
+    tracks.clearAllTracks();
+}
+
+TEST_CASE("Adding a device rejects placements that do not resolve", "[device-api][mutation]") {
+    const auto trackId = freshTrack("Bass");
+    const auto catalogId = anyCatalogId();
+    DeviceApiLive devices;
+
+    SECTION("unknown catalog id") {
+        REQUIRE(devices.addDevice(ChainNodePath::trackLevel(trackId), "not_a_device", -1) ==
+                INVALID_DEVICE_ID);
+    }
+
+    SECTION("track that does not exist") {
+        REQUIRE(devices.addDevice(ChainNodePath::trackLevel(9999), catalogId, -1) ==
+                INVALID_DEVICE_ID);
+    }
+
+    SECTION("a device path is not a placement") {
+        // Only a track or a chain can hold a device.
+        REQUIRE(devices.addDevice(ChainNodePath::topLevelDevice(trackId, 1), catalogId, -1) ==
+                INVALID_DEVICE_ID);
+    }
+
+    SECTION("chain that does not exist") {
+        REQUIRE(devices.addDevice(ChainNodePath::chain(trackId, 42, 43), catalogId, -1) ==
+                INVALID_DEVICE_ID);
+    }
+
+    TrackManager::getInstance().clearAllTracks();
+}
+
+TEST_CASE("Removing a device restores it on undo", "[device-api][mutation]") {
+    const auto trackId = freshTrack("Bass");
+    DeviceApiLive devices;
+    const auto deviceId = devices.addDevice(ChainNodePath::trackLevel(trackId), anyCatalogId(), -1);
+    REQUIRE(deviceId != INVALID_DEVICE_ID);
+
+    auto& tracks = TrackManager::getInstance();
+    const auto path = tracks.findDevicePath(deviceId);
+    REQUIRE(devices.removeDevice(path));
+    REQUIRE(tracks.getChainElements(trackId).empty());
+
+    UndoManager::getInstance().undo();
+    REQUIRE(tracks.getChainElements(trackId).size() == 1);
+
+    // Removing something that is not there is a failure, not a silent no-op.
+    REQUIRE_FALSE(devices.removeDevice(ChainNodePath::topLevelDevice(trackId, 9999)));
+    REQUIRE_FALSE(devices.removeDevice(ChainNodePath{}));
+
+    tracks.clearAllTracks();
+}
+
+TEST_CASE("Undoing a removal restores the device under its original id",
+          "[device-api][mutation][undo]") {
+    // The ordinary add path stamps a fresh DeviceId via prepareNewDevice. If
+    // undo went through it, the device would come back under a different id and
+    // every automation lane, macro link, and alias targeting it would dangle.
+    auto& tracks = TrackManager::getInstance();
+    const auto trackId = freshTrack("Bass");
+    DeviceApiLive devices;
+
+    const auto deviceId = devices.addDevice(ChainNodePath::trackLevel(trackId), anyCatalogId(), -1);
+    const auto path = tracks.findDevicePath(deviceId);
+    REQUIRE(path.isValid());
+
+    REQUIRE(devices.removeDevice(path));
+    UndoManager::getInstance().undo();
+
+    // Same id, and therefore still reachable at the path that addressed it.
+    REQUIRE(tracks.findDevicePath(deviceId) == path);
+    REQUIRE(devices.getDevice(path) != nullptr);
+    REQUIRE(devices.getDevice(path)->id == deviceId);
+
+    tracks.clearAllTracks();
+}
+
+TEST_CASE("The track-level remove command also preserves the device id",
+          "[device-api][mutation][undo]") {
+    // RemoveDeviceFromTrackCommand is what the UI runs when a device is deleted
+    // from a track, and it had the same id-reassigning undo.
+    auto& tracks = TrackManager::getInstance();
+    const auto trackId = freshTrack("Bass");
+
+    DeviceInfo device;
+    device.name = "Filter";
+    device.pluginId = "test_filter";
+    const auto deviceId = tracks.addDeviceToTrack(trackId, device);
+    REQUIRE(deviceId != INVALID_DEVICE_ID);
+    const auto path = tracks.findDevicePath(deviceId);
+
+    auto& undo = UndoManager::getInstance();
+    undo.executeCommand(std::make_unique<RemoveDeviceFromTrackCommand>(trackId, deviceId));
+    REQUIRE(tracks.getChainElements(trackId).empty());
+
+    undo.undo();
+    REQUIRE(tracks.getChainElements(trackId).size() == 1);
+    REQUIRE(tracks.findDevicePath(deviceId) == path);
+
+    tracks.clearAllTracks();
+}
+
+TEST_CASE("Undo restores a device to its original position", "[device-api][mutation][undo]") {
+    auto& tracks = TrackManager::getInstance();
+    const auto trackId = freshTrack("Bass");
+    DeviceApiLive devices;
+    const auto catalogId = anyCatalogId();
+    const auto trackPath = ChainNodePath::trackLevel(trackId);
+
+    const auto first = devices.addDevice(trackPath, catalogId, -1);
+    const auto middle = devices.addDevice(trackPath, catalogId, -1);
+    const auto last = devices.addDevice(trackPath, catalogId, -1);
+    REQUIRE(tracks.getChainElements(trackId).size() == 3);
+
+    REQUIRE(devices.removeDevice(tracks.findDevicePath(middle)));
+    REQUIRE(tracks.getChainElements(trackId).size() == 2);
+
+    UndoManager::getInstance().undo();
+    const auto& elements = tracks.getChainElements(trackId);
+    REQUIRE(elements.size() == 3);
+    // Back in the middle, not appended to the end.
+    REQUIRE(getDevice(elements[0]).id == first);
+    REQUIRE(getDevice(elements[1]).id == middle);
+    REQUIRE(getDevice(elements[2]).id == last);
+
+    tracks.clearAllTracks();
+}
+
+TEST_CASE("Bypass is applied and reported through the facade", "[device-api][mutation]") {
+    const auto trackId = freshTrack("Bass");
+    DeviceApiLive devices;
+    const auto deviceId = devices.addDevice(ChainNodePath::trackLevel(trackId), anyCatalogId(), -1);
+    const auto path = TrackManager::getInstance().findDevicePath(deviceId);
+
+    REQUIRE(devices.setDeviceBypassed(path, true));
+    REQUIRE(devices.getDevice(path)->bypassed);
+    REQUIRE(devices.setDeviceBypassed(path, false));
+    REQUIRE_FALSE(devices.getDevice(path)->bypassed);
+
+    REQUIRE_FALSE(devices.setDeviceBypassed(ChainNodePath{}, true));
+
+    TrackManager::getInstance().clearAllTracks();
+}
+
+TEST_CASE("Parameter writes are range-checked rather than clamped", "[device-api][mutation]") {
+    auto& tracks = TrackManager::getInstance();
+    const auto trackId = freshTrack("Synth");
+
+    DeviceInfo device;
+    device.name = "Filter";
+    device.pluginId = "test_filter";
+    ParameterInfo cutoff;
+    cutoff.paramIndex = 0;
+    cutoff.name = "Cutoff";
+    cutoff.minValue = 20.0f;
+    cutoff.maxValue = 20000.0f;
+    cutoff.currentValue = 440.0f;
+    device.parameters.push_back(cutoff);
+    const auto deviceId = tracks.addDeviceToTrack(trackId, device);
+    const auto path = tracks.findDevicePath(deviceId);
+
+    DeviceApiLive devices;
+    REQUIRE(devices.setDeviceParameter(path, 0, 880.0f));
+
+    SECTION("out of range is refused") {
+        // Clamping would report success while setting something else.
+        REQUIRE_FALSE(devices.setDeviceParameter(path, 0, 19.0f));
+        REQUIRE_FALSE(devices.setDeviceParameter(path, 0, 20001.0f));
+        REQUIRE_FALSE(devices.setDeviceParameter(path, 0, std::numeric_limits<float>::quiet_NaN()));
+    }
+
+    SECTION("unknown parameter index is refused") {
+        REQUIRE_FALSE(devices.setDeviceParameter(path, 7, 100.0f));
+    }
+
+    SECTION("unknown device is refused") {
+        REQUIRE_FALSE(devices.setDeviceParameter(ChainNodePath{}, 0, 100.0f));
+    }
+
+    tracks.clearAllTracks();
+}
+
+TEST_CASE("Devices can be added to a chain inside a rack", "[device-api][mutation]") {
+    auto& tracks = TrackManager::getInstance();
+    const auto trackId = freshTrack("Keys");
+
+    const auto rackId = tracks.addRackToTrack(trackId, "Rack");
+    REQUIRE(rackId != INVALID_RACK_ID);
+    const auto rackPath = ChainNodePath::rack(trackId, rackId);
+    const auto* rack = tracks.getRackByPath(rackPath);
+    REQUIRE(rack != nullptr);
+    REQUIRE_FALSE(rack->chains.empty());
+    const auto chainPath = rackPath.withChain(rack->chains.front().id);
+
+    DeviceApiLive devices;
+    const auto deviceId = devices.addDevice(chainPath, anyCatalogId(), -1);
+    REQUIRE(deviceId != INVALID_DEVICE_ID);
+
+    // The device is reachable at the path that addresses it inside the chain.
+    const auto devicePath = chainPath.withDevice(deviceId);
+    REQUIRE(devices.getDevice(devicePath) != nullptr);
+
+    REQUIRE(devices.removeDevice(devicePath));
+    REQUIRE(devices.getDevice(devicePath) == nullptr);
+
+    UndoManager::getInstance().undo();
+    REQUIRE(devices.getDevice(devicePath) != nullptr);
 
     tracks.clearAllTracks();
 }

--- a/tests/test_device_api.cpp
+++ b/tests/test_device_api.cpp
@@ -1,0 +1,94 @@
+#include <catch2/catch_test_macros.hpp>
+#include <set>
+
+#include "magda/daw/api/device_api_live.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+
+using namespace magda;
+
+TEST_CASE("The device catalog is discoverable and internally consistent", "[device-api][catalog]") {
+    const DeviceApiLive devices;
+    const auto catalog = devices.getCatalog();
+
+    // The compiled and internal registries are linked into this binary, so the
+    // catalog is never empty even with no plugin scan.
+    REQUIRE_FALSE(catalog.empty());
+
+    std::set<juce::String> ids;
+    for (const auto& entry : catalog) {
+        INFO("catalog entry: " << entry.name);
+        // A caller addresses a device by this and nothing else.
+        REQUIRE(entry.catalogId.isNotEmpty());
+        // Ids must be unique or addDevice would be ambiguous.
+        REQUIRE(ids.insert(entry.catalogId).second);
+        REQUIRE(entry.isInstrument == (entry.type == DeviceType::Instrument));
+    }
+}
+
+TEST_CASE("Every catalog entry resolves by its own id", "[device-api][catalog]") {
+    const DeviceApiLive devices;
+    for (const auto& entry : devices.getCatalog()) {
+        const auto found = devices.findCatalogEntry(entry.catalogId);
+        REQUIRE(found.has_value());
+        REQUIRE(*found == entry);
+    }
+}
+
+TEST_CASE("Unknown catalog ids resolve to nothing", "[device-api][catalog]") {
+    const DeviceApiLive devices;
+    REQUIRE_FALSE(devices.findCatalogEntry("not_a_device").has_value());
+    REQUIRE_FALSE(devices.findCatalogEntry("").has_value());
+}
+
+TEST_CASE("Live device lookup rejects paths that address nothing", "[device-api][inspection]") {
+    const DeviceApiLive devices;
+
+    // A default path names no node at all.
+    REQUIRE(devices.getDevice(ChainNodePath{}) == nullptr);
+    REQUIRE(devices.getDeviceParameters(ChainNodePath{}).empty());
+
+    // A well-formed path to a track that does not exist.
+    const auto missing = ChainNodePath::topLevelDevice(9999, 1);
+    REQUIRE(devices.getDevice(missing) == nullptr);
+    REQUIRE(devices.getDeviceParameters(missing).empty());
+}
+
+TEST_CASE("Device parameters are reported in real units", "[device-api][inspection]") {
+    auto& tracks = TrackManager::getInstance();
+    tracks.clearAllTracks();
+    const auto trackId = tracks.createTrack("Synth", TrackType::Audio);
+
+    DeviceInfo device;
+    device.name = "Filter";
+    device.pluginId = "test_filter";
+    ParameterInfo cutoff;
+    cutoff.paramIndex = 0;
+    cutoff.stableId = "cutoff";
+    cutoff.name = "Cutoff";
+    cutoff.unit = "Hz";
+    cutoff.minValue = 20.0f;
+    cutoff.maxValue = 20000.0f;
+    cutoff.defaultValue = 1000.0f;
+    cutoff.currentValue = 440.0f;
+    device.parameters.push_back(cutoff);
+
+    const auto deviceId = tracks.addDeviceToTrack(trackId, device);
+    REQUIRE(deviceId != INVALID_DEVICE_ID);
+
+    const DeviceApiLive devices;
+    const auto path = tracks.findDevicePath(deviceId);
+    REQUIRE(path.isValid());
+    REQUIRE(devices.getDevice(path) != nullptr);
+
+    const auto parameters = devices.getDeviceParameters(path);
+    REQUIRE(parameters.size() == 1);
+    // Real parameter units, not MAGDA-normalized automation units.
+    REQUIRE(parameters[0].name == "Cutoff");
+    REQUIRE(parameters[0].unit == "Hz");
+    REQUIRE(parameters[0].minValue == 20.0f);
+    REQUIRE(parameters[0].maxValue == 20000.0f);
+    REQUIRE(parameters[0].currentValue == 440.0f);
+    REQUIRE(parameters[0].stableId == "cutoff");
+
+    tracks.clearAllTracks();
+}


### PR DESCRIPTION
Closes #1859. The full external device, rack, and automation control surface on `MagdaApi`.

## Why

`MagdaApi` could not answer the questions a remote caller starts with: *what devices can I add*, *what parameters does this one have*, *what automation exists*.

Its only device entry points were `addDeviceToTrack` and `addDeviceToChain`, both taking a fully-constructed `DeviceInfo` — so a caller had to build one, which means knowing plugin internals and filesystem locations, exactly what #1859 says must stay private. `AutomationApi` could look a lane up by id or target but could not enumerate.

## Catalogue

`DeviceCatalogEntry`: a stable `catalogId` plus display metadata, structurally no `fileOrIdentifier`.

`catalogId` is `DeviceInfo::pluginId` — the loader id for internal and compiled devices (`4osc`, `drumgrid`), the scanned identifier for external plugins. `getCatalog()` merges the compiled registry, the internal registry (filtered by `showInBrowser`, the registry's documented source of truth for what a user can add), and the scanned plugin list, deduplicated built-ins-first so a third-party plugin cannot shadow a built-in.

`deviceFromCatalogId` is the boundary the catalogue exists to create: a caller names a device by id, the host supplies the loader details — including the plugin's filesystem location, which never leaves this layer.

## Addressing

Everything is addressed by `ChainNodePath`, not `DeviceId` — a device id is unique only within one of a track's three sections (FX chain, post-fader list, mixer-analysis rail each allocate from their own counter), and a path reaches into nested racks, which the `(trackId, rackId, chainId)` triples on `TrackApi` cannot express.

## Device mutations

Add by catalogue id, remove, move, bypass, parameter writes — each one undo step. This needed new path-based commands: `TrackCommands` had `AddDeviceToTrackCommand` and `RemoveDeviceFromTrackCommand` at *track* level only, so neither could reach into a rack.

Parameter writes are range-checked and **refused** rather than clamped, because a clamped write reports success while setting a value the caller did not ask for.

## Automation

`getLanes`, `getLanesForTrack`, `getEditScopedLanes`, `getClips`. Every lane carries its `AutomationTarget`, so enumerating lanes enumerates the targets too.

`getEditScopedLanes` is load-bearing rather than a convenience: a tempo lane has no `devicePath`, so `getLanesForTrack` can never reach it and it would otherwise be invisible.

`setLanePoints` replaces a whole curve as one undo step. Previously, writing a curve through repeated `addPoint` meant one Undo per point — undoing a generated curve was one Undo per sample. Refused on clip-based lanes, which keep their points on clips and are covered by `setClipPoints`.

## Bug found: undo was losing device identity

`prepareNewDevice` (TrackManager.cpp:3171) stamps a fresh `DeviceId` on every add. Restoring a removed device therefore brought it back **under a different id**, leaving every automation lane, macro link, mod link, and alias that targeted it pointing at nothing.

Not specific to the new code — `RemoveDeviceFromTrackCommand::undo`, which the UI runs when a device is deleted from a track, had it too. Both now re-insert via `insertChainElementsByPath` with `reassignIds=false`.

User-facing effect: delete a device that has automation, undo, and the automation resolves again.

## Cleanup

`ChainNodePath::parentChain()` replaces four hand-rolled copies — `TrackCommands`, `TrackManagerDevices`, `PluginManager`, and the one this work would have added. It differs from the existing `parent()` for a legacy top-level device, whose id lives outside `steps`: `parent()` returns a path that still addresses the device rather than its container, which is a trap worth removing.

## Tests

20 new cases, 372 assertions across `test_device_api.cpp` and `test_automation_api_surface.cpp`: catalogue consistency and id uniqueness, unknown ids refused, invalid paths yielding nothing, parameters in real units, add/remove/move/bypass round-trips, four kinds of unresolvable placement refused, parameter writes refused out of range and for unknown indices, devices added and removed inside a rack chain, undo restoring both original id and original position, the track-level command's id preservation, lane and target enumeration, edit-scoped lane visibility, bulk writes being one undo step and replacing rather than appending, and bulk writes refused on clip-based lanes.

Full suite: 1756 cases, 1743 passed, 13 skipped, 0 failures. App builds clean.

## Follow-up

`TrackApi`'s rack and chain operations still take `(trackId, rackId, chainId)` and cannot address anything inside a nested rack — #1993. A facade gap, not a model gap: `TrackManager` already has a path-based equivalent for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)