### PR TITLE
Clip model: separate container from content (#1901)

### DIFF
--- a/magda/agents/dsl_interpreter.cpp
+++ b/magda/agents/dsl_interpreter.cpp
@@ -2877,7 +2877,8 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
     }
 
     // Get cached transients via the api
-    const auto* transients = api_.clips().getCachedTransients(clip->audio().source.filePath);
+    const auto* transients =
+        api_.clips().getCachedTransients(audioEventRef(*clip).sourceFilePath());
     if (!transients || transients->isEmpty()) {
         ctx_.setError("groove.extract: no transients detected for this clip. "
                       "Enable warp or detect transients first.");
@@ -2885,10 +2886,10 @@ bool Interpreter::executeGrooveExtract(const Params& params) {
     }
 
     // Determine clip parameters
-    double clipBPM =
-        clip->audio().interpretation.bpm > 0.0 ? clip->audio().interpretation.bpm : 120.0;
-    double beatDuration = 60.0 / clipBPM;  // seconds per beat
-    double clipStartSec = clip->offset;    // source offset
+    const auto& event = audioEventRef(*clip);
+    double clipBPM = event.interpBpm > 0.0 ? event.interpBpm : 120.0;
+    double beatDuration = 60.0 / clipBPM;         // seconds per beat
+    double clipStartSec = event.anchorSeconds();  // source read position
 
     // notesPerBeat: 2 for 8th notes, 4 for 16th notes
     int notesPerBeat = (resolution >= 16) ? 4 : 2;

--- a/magda/agents/midi_context.cpp
+++ b/magda/agents/midi_context.cpp
@@ -111,7 +111,7 @@ juce::String buildMidiContext(MagdaApi& api, const std::vector<ClipId>& clipIds,
             << " length=" << number(clip.placement.lengthBeats)
             << " enabled=" << (clip.enabled ? "true" : "false")
             << " notes=" << static_cast<int>(clip.midiNotes.size());
-        if (clip.isMidi() && clip.loopEnabled) {
+        if (clip.loopEnabled) {
             out << " loop_start=" << number(clip.loopStartBeats)
                 << " loop_length=" << number(clip.loopLengthBeats);
         }

--- a/magda/agents/midi_context.cpp
+++ b/magda/agents/midi_context.cpp
@@ -111,7 +111,7 @@ juce::String buildMidiContext(MagdaApi& api, const std::vector<ClipId>& clipIds,
             << " length=" << number(clip.placement.lengthBeats)
             << " enabled=" << (clip.enabled ? "true" : "false")
             << " notes=" << static_cast<int>(clip.midiNotes.size());
-        if (clip.loopEnabled) {
+        if (clip.isMidi() && clip.loopEnabled) {
             out << " loop_start=" << number(clip.loopStartBeats)
                 << " loop_length=" << number(clip.loopLengthBeats);
         }

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -712,19 +712,18 @@ void AudioBridge::captureAllPluginStates() {
 void AudioBridge::captureWarpMarkerStates() {
     auto& cm = ClipManager::getInstance();
     for (auto& clip : cm.getArrangementClips()) {
-        if (clip.isAudio() && clip.warpEnabled) {
+        if (clip.isAudio() && audioEventRef(clip).warpEnabled) {
             auto markers = clipSynchronizer_.getWarpMarkers(clip.id);
-            DBG("captureWarpMarkerStates: clip " << clip.id
-                                                 << " warpEnabled=" << (int)clip.warpEnabled
-                                                 << " markers=" << (int)markers.size());
-            auto* mutableClip = cm.getClip(clip.id);
-            if (mutableClip) {
-                mutableClip->warpMarkers.clear();
+            DBG("captureWarpMarkerStates: clip "
+                << clip.id << " warpEnabled=" << (int)audioEventRef(clip).warpEnabled
+                << " markers=" << (int)markers.size());
+            if (auto* event = primaryEventOf(cm.getClip(clip.id))) {
+                event->warpMarkers.clear();
                 for (const auto& m : markers) {
-                    mutableClip->warpMarkers.push_back({m.sourceTime, m.warpTime});
+                    event->warpMarkers.push_back({m.sourceTime, m.warpTime});
                 }
-                DBG("captureWarpMarkerStates: stored " << mutableClip->warpMarkers.size()
-                                                       << " markers into ClipInfo");
+                DBG("captureWarpMarkerStates: stored " << event->warpMarkers.size()
+                                                       << " markers into the audio event");
             }
         }
     }

--- a/magda/daw/audio/ClipCommands.cpp
+++ b/magda/daw/audio/ClipCommands.cpp
@@ -1030,9 +1030,7 @@ void JoinClipsCommand::performAction() {
         }
 
         left->loopEnabled = false;
-        left->loopStart = 0.0;
         left->loopStartBeats = 0.0;
-        left->loopLength = 0.0;
         left->loopLengthBeats = 0.0;
         left->midiOffset = 0.0;
         left->midiTrimOffset = 0.0;
@@ -1229,7 +1227,7 @@ void RenderClipCommand::execute() {
     }
 
     // Determine output file path — always use the project's renders directory
-    juce::File sourceFile(clip->audio().source.filePath);
+    juce::File sourceFile(magda::audioEventRef(*clip).sourceFilePath());
     auto rendersDir = ProjectManager::getInstance().getRendersDirectory();
     if (rendersDir == juce::File())
         rendersDir = sourceFile.getParentDirectory().getChildFile("renders");
@@ -1384,7 +1382,7 @@ void RenderTimeSelectionCommand::execute() {
 
         // Determine output file path from first overlapping clip's source
         auto* firstClip = clipManager.getClip(overlappingIds[0]);
-        juce::File sourceFile(firstClip->audio().source.filePath);
+        juce::File sourceFile(magda::audioEventRef(*firstClip).sourceFilePath());
         auto rendersDir = ProjectManager::getInstance().getRendersDirectory();
         if (rendersDir == juce::File())
             rendersDir = sourceFile.getParentDirectory().getChildFile("renders");
@@ -1523,8 +1521,9 @@ static bool trimLoopedClip(ClipManager& clipManager, const ClipInfo& clip, doubl
         // Adjust midiOffset (phase) for the trimmed portion
         if (clip.isMidi()) {
             double trimBeats = trimAmount * bpm / 60.0;
-            double loopLengthBeats =
-                clip.loopLengthBeats > 0.0 ? clip.loopLengthBeats : clip.placement.lengthBeats;
+            double loopLengthBeats = audioEventRef(clip).loopLengthBeats() > 0.0
+                                         ? audioEventRef(clip).loopLengthBeats()
+                                         : clip.placement.lengthBeats;
             if (loopLengthBeats > 0.0) {
                 double newPhase = std::fmod(clip.midiOffset + trimBeats, loopLengthBeats);
                 if (newPhase < 0.0)
@@ -1914,8 +1913,8 @@ void RippleDeleteRangeCommand::execute() {
                 ClipOperations::setBeatPlacement(*live, startBeat_, clipEnd - endBeat_, bpm);
                 if (clip.isMidi()) {
                     const double trimBeats = endBeat_ - clipStart;
-                    const double loopLenBeats = clip.loopLengthBeats > 0.0
-                                                    ? clip.loopLengthBeats
+                    const double loopLenBeats = audioEventRef(clip).loopLengthBeats() > 0.0
+                                                    ? audioEventRef(clip).loopLengthBeats()
                                                     : clip.placement.lengthBeats;
                     if (loopLenBeats > 0.0) {
                         double phase = std::fmod(clip.midiOffset + trimBeats, loopLenBeats);
@@ -2535,13 +2534,14 @@ void sliceClipAtWarpMarkers(ClipId clipId, double tempo, AudioBridge* bridge) {
     // markers define a non-linear mapping.  With warp off the linear formula
     // is correct, so we convert marker sourceTime values to the linear
     // timeline domain.
-    clip->warpEnabled = false;
+    if (auto* warpEvent = clip->primaryEvent())
+        warpEvent->warpEnabled = false;
     bridge->disableWarp(clipId);
 
     const double bpm = resolveTimelineBpm(tempo);
     double clipStart = clip->getTimelineStart(bpm);
     double clipEnd = clip->getTimelineEnd(bpm);
-    double clipOffset = clip->getSourceOffset();
+    double clipOffset = magda::audioEventRef(*clip).anchorSeconds();
 
     std::vector<double> splitTimes;
     splitTimes.reserve(markers.size());
@@ -2552,10 +2552,10 @@ void sliceClipAtWarpMarkers(ClipId clipId, double tempo, AudioBridge* bridge) {
     for (size_t i = 1; i + 1 < markers.size(); ++i) {
         double sourceDelta = markers[i].sourceTime - clipOffset;
         double splitTime;
-        if (clip->autoTempo && clip->audio().interpretation.bpm > 0.0) {
-            splitTime = clipStart + sourceDelta * clip->audio().interpretation.bpm / bpm;
+        if (magda::audioEventRef(*clip).autoTempo && magda::audioEventRef(*clip).interpBpm > 0.0) {
+            splitTime = clipStart + sourceDelta * magda::audioEventRef(*clip).interpBpm / bpm;
         } else {
-            splitTime = clipStart + sourceDelta / clip->speedRatio;
+            splitTime = clipStart + sourceDelta / magda::audioEventRef(*clip).speedRatio;
         }
         if (splitTime > clipStart && splitTime < clipEnd) {
             splitTimes.push_back(splitTime);
@@ -2577,8 +2577,8 @@ void sliceClipAtGrid(ClipId clipId, double gridInterval, double tempo, AudioBrid
         return;
 
     // Disable warp before splitting if enabled
-    if (clip->warpEnabled) {
-        clip->warpEnabled = false;
+    if (auto* warpEvent = clip->primaryEvent(); warpEvent != nullptr && warpEvent->warpEnabled) {
+        warpEvent->warpEnabled = false;
         if (bridge)
             bridge->disableWarp(clipId);
     }
@@ -2834,21 +2834,21 @@ void sliceWarpMarkersToDrumGrid(ClipId clipId, double tempo, AudioBridge* bridge
         return;
 
     auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (!clip || !clip->isAudio() || clip->audio().source.filePath.isEmpty())
+    if (!clip || !clip->isAudio() || magda::audioEventRef(*clip).sourceFilePath().isEmpty())
         return;
 
     auto markers = bridge->getWarpMarkers(clipId);
     if (markers.size() <= 2)
         return;
 
-    juce::File audioFile(clip->audio().source.filePath);
+    juce::File audioFile(magda::audioEventRef(*clip).sourceFilePath());
     if (!audioFile.existsAsFile())
         return;
 
     const double bpm = resolveTimelineBpm(tempo);
     double clipStart = clip->getTimelineStart(bpm);
     double clipEnd = clip->getTimelineEnd(bpm);
-    double clipOffset = clip->getSourceOffset();
+    double clipOffset = magda::audioEventRef(*clip).anchorSeconds();
 
     // Build sorted interior marker source times
     std::vector<double> interiorSourceTimes;
@@ -2872,10 +2872,10 @@ void sliceWarpMarkersToDrumGrid(ClipId clipId, double tempo, AudioBridge* bridge
 
     auto sourceToTimeline = [&](double sourceTime) -> double {
         double sourceDelta = sourceTime - clipOffset;
-        if (clip->autoTempo && clip->audio().interpretation.bpm > 0.0)
-            return clipStart + sourceDelta * clip->audio().interpretation.bpm / bpm;
+        if (magda::audioEventRef(*clip).autoTempo && magda::audioEventRef(*clip).interpBpm > 0.0)
+            return clipStart + sourceDelta * magda::audioEventRef(*clip).interpBpm / bpm;
         else
-            return clipStart + sourceDelta / clip->speedRatio;
+            return clipStart + sourceDelta / magda::audioEventRef(*clip).speedRatio;
     };
 
     std::vector<SliceRegion> slices;
@@ -2897,25 +2897,25 @@ void sliceAtGridToDrumGrid(ClipId clipId, double gridInterval, double tempo, Aud
         return;
 
     auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (!clip || !clip->isAudio() || clip->audio().source.filePath.isEmpty())
+    if (!clip || !clip->isAudio() || magda::audioEventRef(*clip).sourceFilePath().isEmpty())
         return;
 
-    juce::File audioFile(clip->audio().source.filePath);
+    juce::File audioFile(magda::audioEventRef(*clip).sourceFilePath());
     if (!audioFile.existsAsFile())
         return;
 
     const double bpm = resolveTimelineBpm(tempo);
     double clipStart = clip->getTimelineStart(bpm);
     double clipEnd = clip->getTimelineEnd(bpm);
-    double clipOffset = clip->getSourceOffset();
+    double clipOffset = magda::audioEventRef(*clip).anchorSeconds();
 
     // Convert timeline grid lines to source-file boundaries
     auto timelineToSource = [&](double timelinePos) -> double {
         double delta = timelinePos - clipStart;
-        if (clip->autoTempo && clip->audio().interpretation.bpm > 0.0)
-            return clipOffset + delta * bpm / clip->audio().interpretation.bpm;
+        if (magda::audioEventRef(*clip).autoTempo && magda::audioEventRef(*clip).interpBpm > 0.0)
+            return clipOffset + delta * bpm / magda::audioEventRef(*clip).interpBpm;
         else
-            return clipOffset + delta * clip->speedRatio;
+            return clipOffset + delta * magda::audioEventRef(*clip).speedRatio;
     };
 
     // Build timeline grid positions within the clip

--- a/magda/daw/audio/ClipCommands.cpp
+++ b/magda/daw/audio/ClipCommands.cpp
@@ -1521,9 +1521,8 @@ static bool trimLoopedClip(ClipManager& clipManager, const ClipInfo& clip, doubl
         // Adjust midiOffset (phase) for the trimmed portion
         if (clip.isMidi()) {
             double trimBeats = trimAmount * bpm / 60.0;
-            double loopLengthBeats = audioEventRef(clip).loopLengthBeats() > 0.0
-                                         ? audioEventRef(clip).loopLengthBeats()
-                                         : clip.placement.lengthBeats;
+            double loopLengthBeats =
+                clip.loopLengthBeats > 0.0 ? clip.loopLengthBeats : clip.placement.lengthBeats;
             if (loopLengthBeats > 0.0) {
                 double newPhase = std::fmod(clip.midiOffset + trimBeats, loopLengthBeats);
                 if (newPhase < 0.0)
@@ -1913,8 +1912,8 @@ void RippleDeleteRangeCommand::execute() {
                 ClipOperations::setBeatPlacement(*live, startBeat_, clipEnd - endBeat_, bpm);
                 if (clip.isMidi()) {
                     const double trimBeats = endBeat_ - clipStart;
-                    const double loopLenBeats = audioEventRef(clip).loopLengthBeats() > 0.0
-                                                    ? audioEventRef(clip).loopLengthBeats()
+                    const double loopLenBeats = clip.loopLengthBeats > 0.0
+                                                    ? clip.loopLengthBeats
                                                     : clip.placement.lengthBeats;
                     if (loopLenBeats > 0.0) {
                         double phase = std::fmod(clip.midiOffset + trimBeats, loopLenBeats);

--- a/magda/daw/audio/CompService.cpp
+++ b/magda/daw/audio/CompService.cpp
@@ -217,8 +217,10 @@ void CompService::clearComp(ClipId clipId) {
     audio.compActive = false;
     const int idx = juce::jlimit(0, juce::jmax(0, static_cast<int>(audio.takes.size()) - 1),
                                  audio.currentTakeIndex);
-    if (idx < static_cast<int>(audio.takes.size()))
-        audio.source.filePath = audio.takes[idx].filePath;
+    if (idx < static_cast<int>(audio.takes.size())) {
+        if (auto* event = audio.primaryEvent())
+            event->sourceId = SourcePool::getInstance().acquire(audio.takes[idx].filePath);
+    }
     cm.forceNotifyClipPropertyChanged(clipId);
     cm.pushClipTakeUndo("Clear Comp", before);
 }
@@ -253,8 +255,12 @@ void CompService::renderComp(ClipId clipId) {
             auto* clip = cm.getClip(clipId);
             if (!clip || !clip->isAudio() || !clip->audio().compActive)
                 return;
-            clip->audio().source.filePath = path;
-            clip->audio().source.durationSeconds = dur;
+            auto* event = clip->primaryEvent();
+            if (event == nullptr)
+                return;
+            event->sourceId = SourcePool::getInstance().acquire(path);
+            if (auto* source = SourcePool::getInstance().getMutable(event->sourceId))
+                source->durationSeconds = dur;
             cm.forceNotifyClipPropertyChanged(clipId);
         });
     });

--- a/magda/daw/audio/WarpMarkerManager.cpp
+++ b/magda/daw/audio/WarpMarkerManager.cpp
@@ -43,16 +43,16 @@ te::WaveAudioClip* findWaveAudioClip(te::Edit& edit,
 }
 
 void storeWarpMarkersInClipModel(ClipId clipId, te::WarpTimeManager& warpManager) {
-    auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (clip == nullptr)
+    auto* event = primaryEventOf(ClipManager::getInstance().getClip(clipId));
+    if (event == nullptr)
         return;
 
     const auto& markers = warpManager.getMarkers();
-    clip->warpMarkers.clear();
-    clip->warpMarkers.reserve(static_cast<size_t>(markers.size()));
+    event->warpMarkers.clear();
+    event->warpMarkers.reserve(static_cast<size_t>(markers.size()));
     for (auto* marker : markers) {
         if (marker != nullptr) {
-            clip->warpMarkers.push_back(
+            event->warpMarkers.push_back(
                 {marker->sourceTime.inSeconds(), marker->warpTime.inSeconds()});
         }
     }
@@ -102,13 +102,10 @@ void WarpMarkerManager::applySensitivityNow(te::Edit& edit, const std::string& e
 
 bool WarpMarkerManager::startDetection(te::Edit& edit, const std::string& engineId, ClipId clipId,
                                        std::optional<float> sensitivity) {
-    const auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (!clip)
+    const auto* event = primaryEventOf(ClipManager::getInstance().getClip(clipId));
+    if (event == nullptr || event->sourceFilePath().isEmpty())
         return false;
-    if (!clip->isAudio())
-        return false;
-    if (clip->audio().source.filePath.isEmpty())
-        return false;
+    const auto sourcePath = event->sourceFilePath();
 
     te::WaveAudioClip* audioClipPtr = findWaveAudioClipByEngineId(edit, engineId);
     if (!audioClipPtr)
@@ -126,12 +123,11 @@ bool WarpMarkerManager::startDetection(te::Edit& edit, const std::string& engine
 
     warpManager.addListener(this);
     detectionInFlight_.insert(clipId);
-    activeDetections_[clipId] = {clip->audio().source.filePath,
-                                 te::WarpTimeManager::Ptr(&warpManager)};
+    activeDetections_[clipId] = {sourcePath, te::WarpTimeManager::Ptr(&warpManager)};
     clipByWarpManager_[&warpManager] = clipId;
 
     // Clear cache so listeners know the displayed transients are stale.
-    AudioThumbnailManager::getInstance().clearCachedTransients(clip->audio().source.filePath);
+    AudioThumbnailManager::getInstance().clearCachedTransients(sourcePath);
 
     warpManager.detectTransients();
 
@@ -142,13 +138,13 @@ bool WarpMarkerManager::getTransientTimes(te::Edit& edit,
                                           const std::map<ClipId, std::string>& clipIdToEngineId,
                                           ClipId clipId) {
     // Get clip info for file path
-    const auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (!clip || !clip->isAudio() || clip->audio().source.filePath.isEmpty())
+    const auto* event = primaryEventOf(ClipManager::getInstance().getClip(clipId));
+    if (event == nullptr || event->sourceFilePath().isEmpty())
         return false;
 
     // Check cache first
     auto& thumbnailManager = AudioThumbnailManager::getInstance();
-    if (thumbnailManager.getCachedTransients(clip->audio().source.filePath) != nullptr)
+    if (thumbnailManager.getCachedTransients(event->sourceFilePath()) != nullptr)
         return true;
 
     if (pendingDetections_.count(clipId))
@@ -223,24 +219,25 @@ void WarpMarkerManager::enableWarp(te::Edit& edit,
 
     // Get clip info
     const auto* clip = ClipManager::getInstance().getClip(clipId);
-    if (!clip)
+    const auto* event = primaryEventOf(clip);
+    if (event == nullptr)
         return;
 
-    // Get the clip's offset - this is where playback starts in the source file
-    double clipOffset = clip->getSourceOffset();
+    // The event's anchor is where playback starts in the source file
+    double clipOffset = event->anchorSeconds();
 
     // Get cached transients from AudioThumbnailManager
     auto* cachedTransients =
-        AudioThumbnailManager::getInstance().getCachedTransients(clip->audio().source.filePath);
+        AudioThumbnailManager::getInstance().getCachedTransients(event->sourceFilePath());
     DBG("WarpMarkerManager::enableWarp cachedTransients="
         << (cachedTransients ? juce::String(cachedTransients->size()) : "null")
-        << " file=" << clip->audio().source.filePath << " offset=" << clipOffset);
+        << " file=" << event->sourceFilePath() << " offset=" << clipOffset);
     if (cachedTransients) {
         // Insert identity-mapped markers at each transient position within the visible range
         double bpm = edit.tempoSequence.getBpmAt(te::TimePosition());
         if (bpm <= 0.0)
             bpm = 120.0;
-        double visibleEnd = clipOffset + clip->timelineToSource(clip->getTimelineLength(bpm));
+        double visibleEnd = clipOffset + event->timelineToSource(clip->getTimelineLength(bpm));
         for (double t : *cachedTransients) {
             // Only include transients within the visible portion of the clip
             if (t >= clipOffset && t <= visibleEnd) {
@@ -281,8 +278,8 @@ void WarpMarkerManager::disableWarp(te::Edit& edit,
     warpManager.removeAllMarkers();
     audioClipPtr->setWarpTime(false);
 
-    if (auto* clip = ClipManager::getInstance().getClip(clipId))
-        clip->warpMarkers.clear();
+    if (auto* event = primaryEventOf(ClipManager::getInstance().getClip(clipId)))
+        event->warpMarkers.clear();
 
     DBG("WarpMarkerManager::disableWarp clip " << clipId);
 }

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -71,8 +71,8 @@ double followActionBaseLengthBeats(const ClipInfo& clip, double bpm) {
                 return loopLengthBeats;
         }
 
-        if (audioEventRef(clip).loopLengthBeats() > 0.0)
-            return audioEventRef(clip).loopLengthBeats();
+        if (clip.loopLengthInBeats() > 0.0)
+            return clip.loopLengthInBeats();
 
         const double sourceLength =
             audioEventRef(clip).sourceLengthSeconds(clip.getTimelineLength(bpm));
@@ -1639,9 +1639,10 @@ bool ClipSynchronizer::syncMidiClipToEngine(ClipId clipId, const ClipInfo* clip)
     }
 
     // Set up internal looping on the TE clip
-    if (clip->loopEnabled && audioEventRef(*clip).loopLengthBeats() > 0.0) {
-        // Use the stored loop region length, not the clip container length
-        double loopBeats = audioEventRef(*clip).loopLengthBeats();
+    if (clip->loopEnabled && clip->loopLengthBeats > 0.0) {
+        // Use the stored loop region length, not the clip container length.
+        // This is a MIDI clip: its loop is clip beats on the clip itself.
+        double loopBeats = clip->loopLengthBeats;
         auto& tempoSeq = edit_.tempoSequence;
         auto loopStartTime = tempoSeq.beatsToTime(te::BeatPosition::fromBeats(0.0));
         auto loopEndTime = tempoSeq.beatsToTime(te::BeatPosition::fromBeats(loopBeats));

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -271,9 +271,13 @@ static void seedInterpretationFromLoopInfo(ClipInfo& clip, double numBeats, doub
 
     event->seedInterpretation(numBeats, bpm);
 
+    // A Source is shared by every clip on the file, so this estimate is only
+    // ever a stand-in for facts we could not read: an unresolved source with no
+    // duration at all. Once the file opens, probe() owns both numbers, and one
+    // event's odd interpBpm must not restate them for unrelated clips.
     if (auto* source = SourcePool::getInstance().getMutable(event->sourceId);
-        source != nullptr && source->durationSeconds <= 0.0 && event->interpTotalBeats > 0.0 &&
-        event->interpBpm > 0.0) {
+        source != nullptr && !source->isResolved() && source->durationSeconds <= 0.0 &&
+        event->interpTotalBeats > 0.0 && event->interpBpm > 0.0) {
         source->durationSeconds = event->interpTotalBeats * 60.0 / event->interpBpm;
     }
 }

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -71,8 +71,8 @@ double followActionBaseLengthBeats(const ClipInfo& clip, double bpm) {
                 return loopLengthBeats;
         }
 
-        if (clip.loopLengthInBeats() > 0.0)
-            return clip.loopLengthInBeats();
+        if (clip.loopLengthInBeats(bpm) > 0.0)
+            return clip.loopLengthInBeats(bpm);
 
         const double sourceLength =
             audioEventRef(clip).sourceLengthSeconds(clip.getTimelineLength(bpm));
@@ -1087,10 +1087,17 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
         }
         syncFollowActionToTracktionClip(*midiClipPtr, *clip, bpm);
 
-        // Set LaunchHandle looping state at creation time
+        // Set LaunchHandle looping state at creation time. Same whole-clip
+        // fallback as the loop range above: a legacy clip carrying the 0
+        // sentinel would otherwise get a loop range but a one-shot handle,
+        // and stop after a single pass.
         if (auto lh = midiClipPtr->getLaunchHandle()) {
-            if (clip->loopEnabled && loopLengthBeats > 0.0)
-                lh->setLooping(te::BeatDuration::fromBeats(loopLengthBeats));
+            if (clip->loopEnabled) {
+                const double handleBeats =
+                    loopLengthBeats > 0.0 ? loopLengthBeats : clip->getLengthInBeats(bpm);
+                if (handleBeats > 0.0)
+                    lh->setLooping(te::BeatDuration::fromBeats(handleBeats));
+            }
         }
 
         return true;
@@ -1141,9 +1148,13 @@ void ClipSynchronizer::launchSessionClip(ClipId clipId, bool forceImmediate) {
                     (srcLength / audioEventRef(*clip).speedRatio) * (bpm / 60.0);
                 launchHandle->setLooping(te::BeatDuration::fromBeats(loopDurationBeats));
             } else if (clip->isMidi()) {
-                // Already clip beats.
-                if (clip->loopLengthBeats > 0.0)
-                    launchHandle->setLooping(te::BeatDuration::fromBeats(clip->loopLengthBeats));
+                // Already clip beats, with the whole-clip fallback for the 0
+                // sentinel a legacy project can still carry.
+                const double handleBeats = clip->loopLengthBeats > 0.0
+                                               ? clip->loopLengthBeats
+                                               : clip->getLengthInBeats(bpm);
+                if (handleBeats > 0.0)
+                    launchHandle->setLooping(te::BeatDuration::fromBeats(handleBeats));
             }
         } else {
             launchHandle->setLooping(std::nullopt);

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -462,7 +462,17 @@ bool ClipSynchronizer::syncClipPropertyToEngine(ClipId clipId) {
 
                         // Time-based loop state (existing behavior)
                         double projectBpm = projectBpmAtClip(edit_, *clip);
-                        if (clip->loopEnabled) {
+                        if (clip->loopEnabled && clip->isMidi()) {
+                            // MIDI loops in clip beats. Routing it through the
+                            // audio event's source region reads an empty one
+                            // and loops the whole container instead.
+                            const double loopBeats = clip->loopLengthBeats > 0.0
+                                                         ? clip->loopLengthBeats
+                                                         : clip->getLengthInBeats(projectBpm);
+                            teClip->setLoopRangeBeats(
+                                {te::BeatPosition::fromBeats(clip->loopStartBeats),
+                                 te::BeatPosition::fromBeats(clip->loopStartBeats + loopBeats)});
+                        } else if (clip->loopEnabled) {
                             const double timelineLength = clip->getTimelineLength(projectBpm);
                             if (audioEventRef(*clip).sourceLengthSeconds(timelineLength) > 0.0) {
                                 teClip->setLoopRange(te::TimeRange(
@@ -500,6 +510,13 @@ bool ClipSynchronizer::syncClipPropertyToEngine(ClipId clipId) {
                                 if (loopLengthBeats > 0.0)
                                     launchHandle->setLooping(
                                         te::BeatDuration::fromBeats(loopLengthBeats));
+                            } else if (clip->isMidi()) {
+                                // Already clip beats, same as launchSessionClip.
+                                const double loopBeats =
+                                    clip->loopLengthBeats > 0.0
+                                        ? clip->loopLengthBeats
+                                        : clip->getLengthInBeats(projectBpmAtClip(edit_, *clip));
+                                launchHandle->setLooping(te::BeatDuration::fromBeats(loopBeats));
                             } else {
                                 double bpm = projectBpmAtClip(edit_, *clip);
                                 double loopLengthSeconds = audioEventRef(*clip).sourceLengthSeconds(
@@ -1049,10 +1066,14 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
                                  te::BeatDuration::fromBeats(length), note.velocity, 0, nullptr);
         }
 
-        // Set looping if enabled
+        // Set looping if enabled. A v1 project can still carry the 0
+        // sentinel, which would otherwise ask TE to loop nothing.
         if (clip->loopEnabled) {
-            midiClipPtr->setLoopRangeBeats({te::BeatPosition::fromBeats(loopStartBeat),
-                                            te::BeatPosition::fromBeats(loopEndBeat)});
+            const double rangeLengthBeats =
+                loopLengthBeats > 0.0 ? loopLengthBeats : clip->getLengthInBeats(bpm);
+            midiClipPtr->setLoopRangeBeats(
+                {te::BeatPosition::fromBeats(loopStartBeat),
+                 te::BeatPosition::fromBeats(loopStartBeat + rangeLengthBeats)});
         }
 
         // Set per-clip launch quantization
@@ -1951,7 +1972,7 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
         }
 
         audioClipPtr->setOffset(te::TimeDuration::fromSeconds(
-            audioEventRef(*clip).engineOffsetSeconds(clip->loopEnabled)));
+            audioEventRef(*clip).engineOffsetSeconds(clip->loopEnabled, bpm)));
     }
 
     // 3b. REVERSE — must be handled before position/loop/offset sync.

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -54,23 +54,30 @@ te::FollowAction toTracktionFollowAction(FollowAction action) {
     return te::FollowAction::none;
 }
 
+// The bridge keys its engine-id map on ClipId because Phase A of #1901 gives
+// every audio clip exactly one event: one clip is one TE clip. When a clip can
+// hold several events, the audioEventRef() calls below become a loop over
+// ClipInfo::events() and the map grows an EventId.
+
 bool isSessionLooping(const ClipInfo& clip) {
     return clip.view == ClipView::Session || clip.loopEnabled;
 }
 
 double followActionBaseLengthBeats(const ClipInfo& clip, double bpm) {
     if (isSessionLooping(clip)) {
-        if (clip.isAudio() && clip.autoTempo) {
-            auto [_, loopLengthBeats] = ClipOperations::getAutoTempoBeatRange(clip, bpm);
+        if (clip.isAudio() && audioEventRef(clip).autoTempo) {
+            auto [_, loopLengthBeats] = ClipOperations::getAutoTempoBeatRange(audioEventRef(clip));
             if (loopLengthBeats > 0.0)
                 return loopLengthBeats;
         }
 
-        if (clip.loopLengthBeats > 0.0)
-            return clip.loopLengthBeats;
+        if (audioEventRef(clip).loopLengthBeats() > 0.0)
+            return audioEventRef(clip).loopLengthBeats();
 
-        const double sourceLength = clip.getSourceLength(bpm);
-        const double speed = clip.speedRatio > 0.0 ? clip.speedRatio : 1.0;
+        const double sourceLength =
+            audioEventRef(clip).sourceLengthSeconds(clip.getTimelineLength(bpm));
+        const double speed =
+            audioEventRef(clip).speedRatio > 0.0 ? audioEventRef(clip).speedRatio : 1.0;
         if (sourceLength > 0.0)
             return (sourceLength / speed) * bpm / 60.0;
     }
@@ -146,7 +153,7 @@ bool syncFollowActionToTracktionClip(te::Clip& teClip, const ClipInfo& clip, dou
 constexpr double warpMarkerSyncEpsilonSeconds = 1.0e-6;
 
 bool warpMarkerMapsMatch(const juce::Array<te::WarpMarker*>& engineMarkers,
-                         const std::vector<ClipInfo::WarpMarker>& savedMarkers) {
+                         const std::vector<WarpMarker>& savedMarkers) {
     if (engineMarkers.size() != static_cast<int>(savedMarkers.size()))
         return false;
 
@@ -166,7 +173,7 @@ bool warpMarkerMapsMatch(const juce::Array<te::WarpMarker*>& engineMarkers,
 }
 
 bool restoreWarpMarkersIfNeeded(te::WarpTimeManager& warpManager,
-                                const std::vector<ClipInfo::WarpMarker>& markers) {
+                                const std::vector<WarpMarker>& markers) {
     // A valid map needs both boundary markers. In particular, do not insert a
     // lone saved marker on top of TE's recreated boundaries: that can create a
     // zero-length segment in WarpTimeManager's stretch-ratio calculation.
@@ -201,7 +208,7 @@ bool restoreWarpMarkersIfNeeded(te::WarpTimeManager& warpManager,
 bool syncWarpStateToTracktionClip(te::WaveAudioClip& audioClip, const ClipInfo& clip) {
     bool changed = false;
 
-    if (!clip.warpEnabled) {
+    if (!audioEventRef(clip).warpEnabled) {
         if (audioClip.getWarpTime()) {
             audioClip.setWarpTime(false);
             changed = true;
@@ -214,13 +221,13 @@ bool syncWarpStateToTracktionClip(te::WaveAudioClip& audioClip, const ClipInfo& 
         changed = true;
     }
 
-    if (!clip.warpMarkers.empty()) {
+    if (!audioEventRef(clip).warpMarkers.empty()) {
         auto& warpManager = audioClip.getWarpTimeManager();
 
         // A newly-created WarpTimeManager contains only its two default
         // boundary markers. Replace those with the marker map copied from the
         // source clip, but never overwrite an already-live edited map.
-        if (restoreWarpMarkersIfNeeded(warpManager, clip.warpMarkers))
+        if (restoreWarpMarkersIfNeeded(warpManager, audioEventRef(clip).warpMarkers))
             changed = true;
     }
 
@@ -244,36 +251,46 @@ static void syncAudioSourceInterpretationToLoopInfo(te::WaveAudioClip& audioClip
     auto waveInfo = audioClip.getWaveInfo();
     auto& li = audioClip.getLoopInfo();
 
-    if (clip.audio().interpretation.bpm > 0.0 &&
-        std::abs(li.getBpm(waveInfo) - clip.audio().interpretation.bpm) > 0.1) {
-        li.setBpm(clip.audio().interpretation.bpm, waveInfo);
+    if (audioEventRef(clip).interpBpm > 0.0 &&
+        std::abs(li.getBpm(waveInfo) - audioEventRef(clip).interpBpm) > 0.1) {
+        li.setBpm(audioEventRef(clip).interpBpm, waveInfo);
     }
 
-    if (clip.audio().interpretation.totalBeats > 0.0 &&
-        std::abs(li.getNumBeats() - clip.audio().interpretation.totalBeats) > 0.001) {
-        li.setNumBeats(clip.audio().interpretation.totalBeats);
+    if (audioEventRef(clip).interpTotalBeats > 0.0 &&
+        std::abs(li.getNumBeats() - audioEventRef(clip).interpTotalBeats) > 0.001) {
+        li.setNumBeats(audioEventRef(clip).interpTotalBeats);
     }
 }
 
-static void initialiseSourceLoopBeatsFromMetadata(ClipInfo& clip) {
-    if (!clip.isAudio() || !clip.autoTempo || clip.loopLengthBeats > 0.0)
+/// Seed the interpretation from Tracktion's loopInfo, filling gaps only. The
+/// file duration is a Source fact, so it lands on the pooled source.
+static void seedInterpretationFromLoopInfo(ClipInfo& clip, double numBeats, double bpm) {
+    auto* event = clip.primaryEvent();
+    if (event == nullptr)
         return;
 
-    const double sourceBpm = clip.audio().interpretation.bpm;
-    if (sourceBpm <= 0.0)
-        return;
+    event->seedInterpretation(numBeats, bpm);
 
-    const double sourceTotalBeats = clip.audio().interpretation.totalBeats;
-    clip.loopStartBeats = juce::jmax(0.0, clip.loopStart * sourceBpm / 60.0);
-
-    double loopBeats =
-        clip.loopLength > 0.0 ? clip.loopLength * sourceBpm / 60.0 : sourceTotalBeats;
-    if (sourceTotalBeats > 0.0) {
-        clip.loopStartBeats = juce::jmin(clip.loopStartBeats, sourceTotalBeats);
-        loopBeats = juce::jmin(loopBeats, sourceTotalBeats - clip.loopStartBeats);
+    if (auto* source = SourcePool::getInstance().getMutable(event->sourceId);
+        source != nullptr && source->durationSeconds <= 0.0 && event->interpTotalBeats > 0.0 &&
+        event->interpBpm > 0.0) {
+        source->durationSeconds = event->interpTotalBeats * 60.0 / event->interpBpm;
     }
+}
 
-    clip.loopLengthBeats = juce::jmax(0.0, loopBeats);
+/// A session clip imported before its source beat domain was known carries a
+/// zero-length loop region, meaning "the whole source". Give it a real one now
+/// that the interpretation has arrived.
+static void initialiseSourceLoopRegionFromMetadata(ClipInfo& clip) {
+    auto* event = clip.primaryEvent();
+    if (event == nullptr || !event->autoTempo || event->loopLengthSamples > 0)
+        return;
+    if (event->interpBpm <= 0.0 || event->interpTotalBeats <= 0.0)
+        return;
+
+    const double startBeats = juce::jmin(event->loopStartBeats(), event->interpTotalBeats);
+    event->setLoopStartBeats(startBeats);
+    event->setLoopLengthBeats(juce::jmax(0.0, event->interpTotalBeats - startBeats));
 }
 
 ClipSynchronizer::ClipSynchronizer(te::Edit& edit, TrackController& trackController,
@@ -424,7 +441,7 @@ bool ClipSynchronizer::syncClipPropertyToEngine(ClipId clipId) {
                         needsGraphReallocation;
 
                     // AutoTempo handling for audio clips
-                    bool isAutoTempoAudio = clip->isAudio() && clip->autoTempo;
+                    bool isAutoTempoAudio = clip->isAudio() && audioEventRef(*clip).autoTempo;
 
                     // configureSessionAutoTempo applies the stretch mode
                     // itself; remember what it was so the stretch-mode block
@@ -446,10 +463,14 @@ bool ClipSynchronizer::syncClipPropertyToEngine(ClipId clipId) {
                         // Time-based loop state (existing behavior)
                         double projectBpm = projectBpmAtClip(edit_, *clip);
                         if (clip->loopEnabled) {
-                            if (clip->getSourceLength(projectBpm) > 0.0) {
+                            const double timelineLength = clip->getTimelineLength(projectBpm);
+                            if (audioEventRef(*clip).sourceLengthSeconds(timelineLength) > 0.0) {
                                 teClip->setLoopRange(te::TimeRange(
-                                    te::TimePosition::fromSeconds(clip->getTeLoopStart()),
-                                    te::TimePosition::fromSeconds(clip->getTeLoopEnd(projectBpm))));
+                                    te::TimePosition::fromSeconds(
+                                        audioEventRef(*clip).engineLoopStartSeconds()),
+                                    te::TimePosition::fromSeconds(
+                                        audioEventRef(*clip).engineLoopEndSeconds(
+                                            timelineLength))));
                             }
                         } else if (teClip->isLooping()) {
                             teClip->disableLooping();
@@ -475,14 +496,15 @@ bool ClipSynchronizer::syncClipPropertyToEngine(ClipId clipId) {
                                 // AutoTempo: loop beats come from beat fields
                                 double bpm = projectBpmAtClip(edit_, *clip);
                                 auto [loopStartBeats, loopLengthBeats] =
-                                    ClipOperations::getAutoTempoBeatRange(*clip, bpm);
+                                    ClipOperations::getAutoTempoBeatRange(audioEventRef(*clip));
                                 if (loopLengthBeats > 0.0)
                                     launchHandle->setLooping(
                                         te::BeatDuration::fromBeats(loopLengthBeats));
                             } else {
                                 double bpm = projectBpmAtClip(edit_, *clip);
-                                double loopLengthSeconds =
-                                    clip->getSourceLength(bpm) / clip->speedRatio;
+                                double loopLengthSeconds = audioEventRef(*clip).sourceLengthSeconds(
+                                                               clip->getTimelineLength(bpm)) /
+                                                           audioEventRef(*clip).speedRatio;
                                 double bps = bpm / 60.0;
                                 double loopLengthBeats = loopLengthSeconds * bps;
                                 launchHandle->setLooping(
@@ -498,22 +520,24 @@ bool ClipSynchronizer::syncClipPropertyToEngine(ClipId clipId) {
                         auto* audioClip = dynamic_cast<te::WaveAudioClip*>(teClip);
                         if (audioClip) {
                             // Pitch
-                            bool isAnalog = clip->isAnalogPitchActive();
-                            if (clip->autoPitch != audioClip->getAutoPitch())
-                                audioClip->setAutoPitch(isAnalog ? false : clip->autoPitch);
+                            bool isAnalog = audioEventRef(*clip).isAnalogPitchActive();
+                            if (audioEventRef(*clip).autoPitch != audioClip->getAutoPitch())
+                                audioClip->setAutoPitch(isAnalog ? false
+                                                                 : audioEventRef(*clip).autoPitch);
                             if (isAnalog) {
                                 if (std::abs(audioClip->getPitchChange()) > 0.001f)
                                     audioClip->setPitchChange(0.0f);
                             } else {
-                                if (std::abs(audioClip->getPitchChange() - clip->pitchChange) >
-                                    0.001f)
-                                    audioClip->setPitchChange(clip->pitchChange);
+                                if (std::abs(audioClip->getPitchChange() -
+                                             audioEventRef(*clip).pitchChange) > 0.001f)
+                                    audioClip->setPitchChange(audioEventRef(*clip).pitchChange);
                             }
-                            if (audioClip->getTransposeSemiTones(false) != clip->transpose)
-                                audioClip->setTranspose(clip->transpose);
+                            if (audioClip->getTransposeSemiTones(false) !=
+                                audioEventRef(*clip).transpose)
+                                audioClip->setTranspose(audioEventRef(*clip).transpose);
                             // Playback
-                            if (clip->isReversed != audioClip->getIsReversed())
-                                audioClip->setIsReversed(clip->isReversed);
+                            if (audioEventRef(*clip).reversed != audioClip->getIsReversed())
+                                audioClip->setIsReversed(audioEventRef(*clip).reversed);
                             // Per-Clip Mix
                             {
                                 float combinedGain = clip->volumeDB + clip->gainDB;
@@ -526,11 +550,12 @@ bool ClipSynchronizer::syncClipPropertyToEngine(ClipId clipId) {
                             if (audioClip->getLaunchFadeSamples() != clip->launchFadeSamples)
                                 audioClip->setLaunchFadeSamples(clip->launchFadeSamples);
 
-                            auto desiredMode =
-                                static_cast<te::TimeStretcher::Mode>(clip->timeStretchMode);
+                            auto desiredMode = static_cast<te::TimeStretcher::Mode>(
+                                audioEventRef(*clip).timeStretchMode);
                             if (!isAnalog && desiredMode == te::TimeStretcher::disabled &&
-                                (clip->autoTempo || clip->warpEnabled ||
-                                 std::abs(clip->speedRatio - 1.0) > 0.001))
+                                (audioEventRef(*clip).autoTempo ||
+                                 audioEventRef(*clip).warpEnabled ||
+                                 std::abs(audioEventRef(*clip).speedRatio - 1.0) > 0.001))
                                 desiredMode = te::TimeStretcher::defaultMode;
                             if (isAnalog)
                                 desiredMode = te::TimeStretcher::disabled;
@@ -749,7 +774,7 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
     // migrated temp project media), recreate it so TE follows ClipManager.
     if (auto* existingSlotClip = slot->getClip()) {
         if (clip->isAudio()) {
-            juce::File desiredAudioFile(clip->audio().source.filePath);
+            juce::File desiredAudioFile(audioEventRef(*clip).sourceFilePath());
             if (desiredAudioFile.existsAsFile()) {
                 if (auto* existingAudioClip = dynamic_cast<te::WaveAudioClip*>(existingSlotClip)) {
                     if (existingAudioClip->getOriginalFile() != desiredAudioFile) {
@@ -778,13 +803,13 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
     // TE's free functions insertWaveClip(ClipOwner&, ...) and insertMIDIClip(ClipOwner&, ...)
     // accept ClipSlot as a ClipOwner, creating the clip's ValueTree directly in the slot.
     if (clip->isAudio()) {
-        if (clip->audio().source.filePath.isEmpty())
+        if (audioEventRef(*clip).sourceFilePath().isEmpty())
             return false;
 
-        juce::File audioFile(clip->audio().source.filePath);
+        juce::File audioFile(audioEventRef(*clip).sourceFilePath());
         if (!audioFile.existsAsFile()) {
             DBG("ClipSynchronizer::syncSessionClipToSlot: Audio file not found: "
-                << clip->audio().source.filePath);
+                << audioEventRef(*clip).sourceFilePath());
             return false;
         }
 
@@ -821,12 +846,11 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
             auto& loopInfoRef = audioClipPtr->getLoopInfo();
             auto waveInfo = audioClipPtr->getWaveInfo();
             if (auto* mutableClip = cm.getClip(clipId)) {
-                bool sourceInterpretationBpmWasUnset =
-                    mutableClip->audio().interpretation.bpm <= 0.0;
-                mutableClip->setSourceMetadata(loopInfoRef.getNumBeats(),
+                bool sourceInterpretationBpmWasUnset = audioEventRef(*mutableClip).interpBpm <= 0.0;
+                seedInterpretationFromLoopInfo(*mutableClip, loopInfoRef.getNumBeats(),
                                                loopInfoRef.getBpm(waveInfo));
-                initialiseSourceLoopBeatsFromMetadata(*mutableClip);
-                if (sourceInterpretationBpmWasUnset && mutableClip->autoTempo) {
+                initialiseSourceLoopRegionFromMetadata(*mutableClip);
+                if (sourceInterpretationBpmWasUnset && audioEventRef(*mutableClip).autoTempo) {
                     double projectBpm = projectBpmAtClip(edit_, *clip);
                     cm.refreshDerivedSeconds(clipId, projectBpm);
                     cm.forceNotifyClipPropertyChanged(clipId);
@@ -834,7 +858,7 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
             }
         }
 
-        if (clip->autoTempo) {
+        if (audioEventRef(*clip).autoTempo) {
             configureSessionAutoTempo(audioClipPtr, clip);
         } else {
             // =============================================================
@@ -843,10 +867,12 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
 
             // Set timestretcher mode — keep disabled when mode is 0 and speedRatio is 1.0
             {
-                bool isAnalog = clip->isAnalogPitchActive();
-                auto stretchMode = static_cast<te::TimeStretcher::Mode>(clip->timeStretchMode);
+                bool isAnalog = audioEventRef(*clip).isAnalogPitchActive();
+                auto stretchMode =
+                    static_cast<te::TimeStretcher::Mode>(audioEventRef(*clip).timeStretchMode);
                 if (!isAnalog && stretchMode == te::TimeStretcher::disabled &&
-                    (std::abs(clip->speedRatio - 1.0) > 0.001 || clip->warpEnabled))
+                    (std::abs(audioEventRef(*clip).speedRatio - 1.0) > 0.001 ||
+                     audioEventRef(*clip).warpEnabled))
                     stretchMode = te::TimeStretcher::defaultMode;
                 if (isAnalog)
                     stretchMode = te::TimeStretcher::disabled;
@@ -855,26 +881,28 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
 
             // Set speed ratio (BEFORE offset, since TE offset
             // is in stretched time and must be set after speed ratio)
-            if (std::abs(clip->speedRatio - 1.0) > 0.001) {
+            if (std::abs(audioEventRef(*clip).speedRatio - 1.0) > 0.001) {
                 if (audioClipPtr->getAutoTempo()) {
                     audioClipPtr->setAutoTempo(false);
                 }
-                audioClipPtr->setSpeedRatio(clip->speedRatio);
+                audioClipPtr->setSpeedRatio(audioEventRef(*clip).speedRatio);
             }
 
             // Set file offset (trim point) - relative to loop start, in stretched time
             {
                 double bpm = projectBpmAtClip(edit_, *clip);
-                audioClipPtr->setOffset(
-                    te::TimeDuration::fromSeconds(clip->getTeOffset(clip->loopEnabled, bpm)));
+                audioClipPtr->setOffset(te::TimeDuration::fromSeconds(
+                    audioEventRef(*clip).engineOffsetSeconds(clip->loopEnabled)));
             }
 
             // Set looping properties
             double bpm = projectBpmAtClip(edit_, *clip);
-            if (clip->loopEnabled && clip->getSourceLength(bpm) > 0.0) {
-                audioClipPtr->setLoopRange(
-                    te::TimeRange(te::TimePosition::fromSeconds(clip->getTeLoopStart()),
-                                  te::TimePosition::fromSeconds(clip->getTeLoopEnd(bpm))));
+            if (clip->loopEnabled &&
+                audioEventRef(*clip).sourceLengthSeconds(clip->getTimelineLength(bpm)) > 0.0) {
+                audioClipPtr->setLoopRange(te::TimeRange(
+                    te::TimePosition::fromSeconds(audioEventRef(*clip).engineLoopStartSeconds()),
+                    te::TimePosition::fromSeconds(
+                        audioEventRef(*clip).engineLoopEndSeconds(clip->getTimelineLength(bpm)))));
             }
 
             // TE's ClipOwner auto-enables autoTempo on all session slot clips.
@@ -897,18 +925,18 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
 
         // Sync session-applicable audio properties at creation
         {
-            bool isAnalog = clip->isAnalogPitchActive();
-            if (!isAnalog && clip->autoPitch)
+            bool isAnalog = audioEventRef(*clip).isAnalogPitchActive();
+            if (!isAnalog && audioEventRef(*clip).autoPitch)
                 audioClipPtr->setAutoPitch(true);
             if (isAnalog) {
                 // Analog pitch: don't send pitchChange to TE (resampling handles it)
-            } else if (std::abs(clip->pitchChange) > 0.001f) {
-                audioClipPtr->setPitchChange(clip->pitchChange);
+            } else if (std::abs(audioEventRef(*clip).pitchChange) > 0.001f) {
+                audioClipPtr->setPitchChange(audioEventRef(*clip).pitchChange);
             }
         }
-        if (clip->transpose != 0)
-            audioClipPtr->setTranspose(clip->transpose);
-        if (clip->isReversed)
+        if (audioEventRef(*clip).transpose != 0)
+            audioClipPtr->setTranspose(audioEventRef(*clip).transpose);
+        if (audioEventRef(*clip).reversed)
             audioClipPtr->setIsReversed(true);
         {
             float combinedGain = clip->volumeDB + clip->gainDB;
@@ -929,17 +957,19 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
         // Set LaunchHandle looping state at creation time so it's ready before first launch
         if (auto lh = audioClipPtr->getLaunchHandle()) {
             if (clip->loopEnabled) {
-                if (clip->autoTempo) {
+                if (audioEventRef(*clip).autoTempo) {
                     double bpm = projectBpmAtClip(edit_, *clip);
                     auto [loopStartBeats, loopLengthBeats] =
-                        ClipOperations::getAutoTempoBeatRange(*clip, bpm);
+                        ClipOperations::getAutoTempoBeatRange(audioEventRef(*clip));
                     if (loopLengthBeats > 0.0)
                         lh->setLooping(te::BeatDuration::fromBeats(loopLengthBeats));
                 } else {
                     double bpm = projectBpmAtClip(edit_, *clip);
-                    const double sourceLength = clip->getSourceLength(bpm);
+                    const double sourceLength =
+                        audioEventRef(*clip).sourceLengthSeconds(clip->getTimelineLength(bpm));
                     if (sourceLength > 0.0) {
-                        double loopDurationBeats = (sourceLength / clip->speedRatio) * (bpm / 60.0);
+                        double loopDurationBeats =
+                            (sourceLength / audioEventRef(*clip).speedRatio) * (bpm / 60.0);
                         lh->setLooping(te::BeatDuration::fromBeats(loopDurationBeats));
                     }
                 }
@@ -983,9 +1013,10 @@ bool ClipSynchronizer::syncSessionClipToSlot(ClipId clipId) {
         // Apply midiOffset: exclude notes before offset, shift remaining notes
         auto& sequence = midiClipPtr->getSequence();
         double bpm = projectBpmAtClip(edit_, *clip);
-        double srcLength = clip->getSourceLength(bpm);
-        double loopStartBeat = clip->loopStart * (bpm / 60.0);
-        double loopLengthBeats = srcLength * (bpm / 60.0);
+        // A MIDI clip's loop is already clip beats. Deriving it from an audio
+        // event would read an empty region and loop the whole clip instead.
+        double loopStartBeat = clip->loopStartBeats;
+        double loopLengthBeats = clip->loopLengthBeats;
         double loopEndBeat = loopStartBeat + loopLengthBeats;
         double effectiveOffset = clip->midiOffset;
 
@@ -1072,20 +1103,22 @@ void ClipSynchronizer::launchSessionClip(ClipId clipId, bool forceImmediate) {
     if (clip) {
         if (clip->loopEnabled) {
             double bpm = projectBpmAtClip(edit_, *clip);
-            double srcLength = clip->getSourceLength(bpm);
-            if (clip->isAudio() && clip->autoTempo) {
+            double srcLength =
+                audioEventRef(*clip).sourceLengthSeconds(clip->getTimelineLength(bpm));
+            if (clip->isAudio() && audioEventRef(*clip).autoTempo) {
                 auto [loopStartBeats, loopLengthBeats] =
-                    ClipOperations::getAutoTempoBeatRange(*clip, bpm);
+                    ClipOperations::getAutoTempoBeatRange(audioEventRef(*clip));
                 if (loopLengthBeats > 0.0) {
                     launchHandle->setLooping(te::BeatDuration::fromBeats(loopLengthBeats));
                 }
             } else if (clip->isAudio() && srcLength > 0.0) {
-                double loopDurationBeats = (srcLength / clip->speedRatio) * (bpm / 60.0);
+                double loopDurationBeats =
+                    (srcLength / audioEventRef(*clip).speedRatio) * (bpm / 60.0);
                 launchHandle->setLooping(te::BeatDuration::fromBeats(loopDurationBeats));
-            } else {
-                // MIDI
-                double loopLengthBeats = srcLength * (bpm / 60.0);
-                launchHandle->setLooping(te::BeatDuration::fromBeats(loopLengthBeats));
+            } else if (clip->isMidi()) {
+                // Already clip beats.
+                if (clip->loopLengthBeats > 0.0)
+                    launchHandle->setLooping(te::BeatDuration::fromBeats(clip->loopLengthBeats));
             }
         } else {
             launchHandle->setLooping(std::nullopt);
@@ -1250,7 +1283,7 @@ void ClipSynchronizer::configureSessionAutoTempo(te::WaveAudioClip* audioClip,
     // explicit SoundTouch/Signalsmith selection. Fresh slot clips otherwise
     // retain TE's default mode, making the old modes sound identical to
     // Signalsmith until a later property edit happens to rebuild the graph.
-    auto desiredMode = static_cast<te::TimeStretcher::Mode>(clip->timeStretchMode);
+    auto desiredMode = static_cast<te::TimeStretcher::Mode>(audioEventRef(*clip).timeStretchMode);
     if (desiredMode == te::TimeStretcher::disabled)
         desiredMode = te::TimeStretcher::defaultMode;
 
@@ -1267,13 +1300,14 @@ void ClipSynchronizer::configureSessionAutoTempo(te::WaveAudioClip* audioClip,
 
     // Set offset — for autoTempo, convert source seconds to timeline seconds
     double bpmForOffset = projectBpmAtClip(edit_, *clip);
-    audioClip->setOffset(
-        te::TimeDuration::fromSeconds(clip->getTeOffset(clip->loopEnabled, bpmForOffset)));
+    audioClip->setOffset(te::TimeDuration::fromSeconds(
+        audioEventRef(*clip).engineOffsetSeconds(clip->loopEnabled, bpmForOffset)));
 
     // Set beat-based loop range using the same helper as arrangement path
     if (clip->loopEnabled) {
         double bpm = projectBpmAtClip(edit_, *clip);
-        auto [loopStartBeats, loopLengthBeats] = ClipOperations::getAutoTempoBeatRange(*clip, bpm);
+        auto [loopStartBeats, loopLengthBeats] =
+            ClipOperations::getAutoTempoBeatRange(audioEventRef(*clip));
         if (loopLengthBeats > 0.0) {
             audioClip->setLoopRangeBeats(
                 te::BeatRange(te::BeatPosition::fromBeats(loopStartBeats),
@@ -1605,9 +1639,9 @@ bool ClipSynchronizer::syncMidiClipToEngine(ClipId clipId, const ClipInfo* clip)
     }
 
     // Set up internal looping on the TE clip
-    if (clip->loopEnabled && clip->loopLengthBeats > 0.0) {
+    if (clip->loopEnabled && audioEventRef(*clip).loopLengthBeats() > 0.0) {
         // Use the stored loop region length, not the clip container length
-        double loopBeats = clip->loopLengthBeats;
+        double loopBeats = audioEventRef(*clip).loopLengthBeats();
         auto& tempoSeq = edit_.tempoSequence;
         auto loopStartTime = tempoSeq.beatsToTime(te::BeatPosition::fromBeats(0.0));
         auto loopEndTime = tempoSeq.beatsToTime(te::BeatPosition::fromBeats(loopBeats));
@@ -1763,7 +1797,7 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
         // Source path changed under an existing model clip (e.g. Save As migrated temp media).
         // Recreate the TE clip so playback, warp, and thumbnails resolve the durable file.
         if (audioClipPtr) {
-            juce::File desiredAudioFile(clip->audio().source.filePath);
+            juce::File desiredAudioFile(audioEventRef(*clip).sourceFilePath());
             if (desiredAudioFile.existsAsFile() &&
                 audioClipPtr->getOriginalFile() != desiredAudioFile) {
                 DBG("ClipSynchronizer: Audio source changed, recreating TE clip " << clipId);
@@ -1787,13 +1821,14 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
 
     // 3. CREATE new clip if doesn't exist
     if (!audioClipPtr) {
-        if (clip->audio().source.filePath.isEmpty()) {
+        if (audioEventRef(*clip).sourceFilePath().isEmpty()) {
             DBG("ClipSynchronizer: No audio file for clip " << clipId);
             return needsGraphReallocation;
         }
-        juce::File audioFile(clip->audio().source.filePath);
+        juce::File audioFile(audioEventRef(*clip).sourceFilePath());
         if (!audioFile.existsAsFile()) {
-            DBG("ClipSynchronizer: Audio file not found: " << clip->audio().source.filePath);
+            DBG("ClipSynchronizer: Audio file not found: "
+                << audioEventRef(*clip).sourceFilePath());
             return needsGraphReallocation;
         }
 
@@ -1827,10 +1862,12 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
         // Force defaultMode when speedRatio != 1.0 or warp is enabled.
         // Analog pitch: force disabled mode (pure resampling via speedRatio).
         {
-            bool isAnalog = clip->isAnalogPitchActive();
-            auto stretchMode = static_cast<te::TimeStretcher::Mode>(clip->timeStretchMode);
+            bool isAnalog = audioEventRef(*clip).isAnalogPitchActive();
+            auto stretchMode =
+                static_cast<te::TimeStretcher::Mode>(audioEventRef(*clip).timeStretchMode);
             if (!isAnalog && stretchMode == te::TimeStretcher::disabled &&
-                (std::abs(clip->speedRatio - 1.0) > 0.001 || clip->warpEnabled))
+                (std::abs(audioEventRef(*clip).speedRatio - 1.0) > 0.001 ||
+                 audioEventRef(*clip).warpEnabled))
                 stretchMode = te::TimeStretcher::defaultMode;
             if (isAnalog)
                 stretchMode = te::TimeStretcher::disabled;
@@ -1845,12 +1882,11 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
             auto waveInfo = audioClipPtr->getWaveInfo();
             auto& cm = ClipManager::getInstance();
             if (auto* mutableClip = cm.getClip(clipId)) {
-                bool sourceInterpretationBpmWasUnset =
-                    mutableClip->audio().interpretation.bpm <= 0.0;
-                mutableClip->setSourceMetadata(loopInfoRef.getNumBeats(),
+                bool sourceInterpretationBpmWasUnset = audioEventRef(*mutableClip).interpBpm <= 0.0;
+                seedInterpretationFromLoopInfo(*mutableClip, loopInfoRef.getNumBeats(),
                                                loopInfoRef.getBpm(waveInfo));
-                initialiseSourceLoopBeatsFromMetadata(*mutableClip);
-                if (sourceInterpretationBpmWasUnset && mutableClip->autoTempo) {
+                initialiseSourceLoopRegionFromMetadata(*mutableClip);
+                if (sourceInterpretationBpmWasUnset && audioEventRef(*mutableClip).autoTempo) {
                     double projectBpm = projectBpmAtClip(edit_, *clip);
                     cm.refreshDerivedSeconds(clipId, projectBpm);
                     cm.forceNotifyClipPropertyChanged(clipId);
@@ -1870,14 +1906,15 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
     // create on a fresh recording.
     applyModelTakesToTeClip(*audioClipPtr, *clip);
 
-    const bool useSourceBeatProcessing = clip->autoTempo || clip->warpEnabled;
+    const bool useSourceBeatProcessing =
+        audioEventRef(*clip).autoTempo || audioEventRef(*clip).warpEnabled;
 
     // A project load or graph recreation can create a TE clip whose model is
     // already reversed. Seed the new forward clip with MAGDA's canonical trim
     // coordinates before asking Tracktion to mirror them into proxy space.
     // Otherwise reverseLoopPoints() mirrors TE's default offset (zero), losing
     // the selected source slice until the user toggles reverse off and on again.
-    if (createdAudioClip && clip->isReversed) {
+    if (createdAudioClip && audioEventRef(*clip).reversed) {
         const double bpm = projectBpmAtClip(edit_, *clip);
 
         audioClipPtr->setStart(te::BeatPosition::fromBeats(clip->placement.startBeat), false, true);
@@ -1892,7 +1929,7 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
 
             if (clip->loopEnabled) {
                 auto [loopStartBeats, loopLengthBeats] =
-                    ClipOperations::getAutoTempoBeatRange(*clip, bpm);
+                    ClipOperations::getAutoTempoBeatRange(audioEventRef(*clip));
                 audioClipPtr->setLoopRangeBeats(
                     te::BeatRange(te::BeatPosition::fromBeats(loopStartBeats),
                                   te::BeatDuration::fromBeats(loopLengthBeats)));
@@ -1900,18 +1937,20 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
         } else {
             if (audioClipPtr->getAutoTempo())
                 audioClipPtr->setAutoTempo(false);
-            if (std::abs(audioClipPtr->getSpeedRatio() - clip->speedRatio) > 0.001)
-                audioClipPtr->setSpeedRatio(clip->speedRatio);
+            if (std::abs(audioClipPtr->getSpeedRatio() - audioEventRef(*clip).speedRatio) > 0.001)
+                audioClipPtr->setSpeedRatio(audioEventRef(*clip).speedRatio);
 
-            if (clip->loopEnabled && clip->getSourceLength(bpm) > 0.0) {
-                audioClipPtr->setLoopRange(
-                    te::TimeRange(te::TimePosition::fromSeconds(clip->getTeLoopStart()),
-                                  te::TimePosition::fromSeconds(clip->getTeLoopEnd(bpm))));
+            if (clip->loopEnabled &&
+                audioEventRef(*clip).sourceLengthSeconds(clip->getTimelineLength(bpm)) > 0.0) {
+                audioClipPtr->setLoopRange(te::TimeRange(
+                    te::TimePosition::fromSeconds(audioEventRef(*clip).engineLoopStartSeconds()),
+                    te::TimePosition::fromSeconds(
+                        audioEventRef(*clip).engineLoopEndSeconds(clip->getTimelineLength(bpm)))));
             }
         }
 
-        audioClipPtr->setOffset(
-            te::TimeDuration::fromSeconds(clip->getTeOffset(clip->loopEnabled, bpm)));
+        audioClipPtr->setOffset(te::TimeDuration::fromSeconds(
+            audioEventRef(*clip).engineOffsetSeconds(clip->loopEnabled)));
     }
 
     // 3b. REVERSE — must be handled before position/loop/offset sync.
@@ -1923,8 +1962,8 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
     // We MUST return after this — the subsequent sync steps would overwrite
     // TE's reversed offset/loop with our canonical original-source values.
     // The playback graph rebuild is deferred until the proxy file is ready.
-    if (clip->isReversed != audioClipPtr->getIsReversed()) {
-        audioClipPtr->setIsReversed(clip->isReversed);
+    if (audioEventRef(*clip).reversed != audioClipPtr->getIsReversed()) {
+        audioClipPtr->setIsReversed(audioEventRef(*clip).reversed);
 
         // Tracktion mirrors its offset/loop values into reversed-proxy coordinates.
         // Those are engine implementation details: ClipInfo remains in the original
@@ -1976,10 +2015,10 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
     // Apply engine changes in both beat-based and time-based processing modes.
     // The stretcher is captured in the playback graph, so changing this property
     // must explicitly request a graph rebuild.
-    auto desiredMode = static_cast<te::TimeStretcher::Mode>(clip->timeStretchMode);
-    const bool isAnalog = clip->isAnalogPitchActive();
+    auto desiredMode = static_cast<te::TimeStretcher::Mode>(audioEventRef(*clip).timeStretchMode);
+    const bool isAnalog = audioEventRef(*clip).isAnalogPitchActive();
     if (!isAnalog && desiredMode == te::TimeStretcher::disabled &&
-        (useSourceBeatProcessing || std::abs(clip->speedRatio - 1.0) > 0.001))
+        (useSourceBeatProcessing || std::abs(audioEventRef(*clip).speedRatio - 1.0) > 0.001))
         desiredMode = te::TimeStretcher::defaultMode;
     if (isAnalog)
         desiredMode = te::TimeStretcher::disabled;
@@ -1990,7 +2029,7 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
         needsGraphReallocation = true;
     }
 
-    if (useSourceBeatProcessing && !clip->isReversed) {
+    if (useSourceBeatProcessing && !audioEventRef(*clip).reversed) {
         // ========================================================================
         // AUTO-TEMPO MODE (Beat-based length, maintains musical time)
         // Warp also uses this path — TE only passes warpMap to WaveNodeRealTime
@@ -2011,7 +2050,7 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
             audioClipPtr->setSpeedRatio(1.0);
         }
 
-    } else if (!clip->isReversed) {
+    } else if (!audioEventRef(*clip).reversed) {
         // ========================================================================
         // TIME-BASED MODE (Fixed absolute time, current default behavior)
         // ========================================================================
@@ -2021,7 +2060,7 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
             audioClipPtr->setAutoTempo(false);
         }
 
-        double teSpeedRatio = clip->speedRatio;
+        double teSpeedRatio = audioEventRef(*clip).speedRatio;
         double currentSpeedRatio = audioClipPtr->getSpeedRatio();
 
         if (std::abs(currentSpeedRatio - teSpeedRatio) > 0.001) {
@@ -2030,23 +2069,23 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
         }
 
         // Sync warp state to engine (time-based warp — rare, but handle it)
-        if (clip->warpEnabled != audioClipPtr->getWarpTime()) {
-            audioClipPtr->setWarpTime(clip->warpEnabled);
+        if (audioEventRef(*clip).warpEnabled != audioClipPtr->getWarpTime()) {
+            audioClipPtr->setWarpTime(audioEventRef(*clip).warpEnabled);
         }
     }
 
     // 5b. WARP — sync warp state and restore markers (applies to both code paths)
-    if (clip->warpEnabled) {
+    if (audioEventRef(*clip).warpEnabled) {
         if (!audioClipPtr->getWarpTime()) {
             audioClipPtr->setWarpTime(true);
         }
 
         // Restore saved warp markers if TE has no user markers yet
-        if (!clip->warpMarkers.empty()) {
+        if (!audioEventRef(*clip).warpMarkers.empty()) {
             auto& warpManager = audioClipPtr->getWarpTimeManager();
             // TE creates 2 default boundary markers; if only those exist, restore saved
-            if (restoreWarpMarkersIfNeeded(warpManager, clip->warpMarkers)) {
-                DBG("ClipSynchronizer: Restored " << clip->warpMarkers.size()
+            if (restoreWarpMarkersIfNeeded(warpManager, audioEventRef(*clip).warpMarkers)) {
+                DBG("ClipSynchronizer: Restored " << audioEventRef(*clip).warpMarkers.size()
                                                   << " warp markers for clip " << clipId);
             }
         }
@@ -2056,7 +2095,7 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
     // Use beat-based loop range in auto-tempo/warp mode, time-based otherwise.
     // Tracktion has already mirrored these values into its reverse-proxy domain;
     // canonical source coordinates must not overwrite them on an unrelated sync.
-    if (!clip->isReversed && useSourceBeatProcessing) {
+    if (!audioEventRef(*clip).reversed && useSourceBeatProcessing) {
         // Auto-tempo mode: ALWAYS set beat-based loop range
         // The loop range defines the clip's musical extent (not just the loop region)
 
@@ -2068,13 +2107,13 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
             // setAutoTempo calibrates source interpretation BPM = projectBPM / speedRatio so that
             // enabling autoTempo doesn't change playback speed. TE uses loopInfo to map source
             // beats to source time, so BPM and source beat count must both agree.
-            if (clip->audio().interpretation.bpm > 0.0 ||
-                clip->audio().interpretation.totalBeats > 0.0) {
+            if (audioEventRef(*clip).interpBpm > 0.0 ||
+                audioEventRef(*clip).interpTotalBeats > 0.0) {
                 syncAudioSourceInterpretationToLoopInfo(*audioClipPtr, *clip);
             }
 
             auto [loopStartBeats, loopLengthBeats] =
-                ClipOperations::getAutoTempoBeatRange(*clip, bpm);
+                ClipOperations::getAutoTempoBeatRange(audioEventRef(*clip));
 
             auto loopRange = te::BeatRange(te::BeatPosition::fromBeats(loopStartBeats),
                                            te::BeatDuration::fromBeats(loopLengthBeats));
@@ -2082,14 +2121,17 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
         } else if (audioClipPtr->isLooping()) {
             audioClipPtr->setLoopRangeBeats({});
         }
-    } else if (!clip->isReversed) {
+    } else if (!audioEventRef(*clip).reversed) {
         // Time-based mode: Use time-based loop range
         // Only use setLoopRange (time-based), NOT setLoopRangeBeats which forces
         // autoTempo=true and speedRatio=1.0, breaking time-stretch.
         double bpm = projectBpmAtClip(edit_, *clip);
-        if (clip->loopEnabled && clip->getSourceLength(bpm) > 0.0) {
-            auto loopStartTime = te::TimePosition::fromSeconds(clip->getTeLoopStart());
-            auto loopEndTime = te::TimePosition::fromSeconds(clip->getTeLoopEnd(bpm));
+        if (clip->loopEnabled &&
+            audioEventRef(*clip).sourceLengthSeconds(clip->getTimelineLength(bpm)) > 0.0) {
+            auto loopStartTime =
+                te::TimePosition::fromSeconds(audioEventRef(*clip).engineLoopStartSeconds());
+            auto loopEndTime = te::TimePosition::fromSeconds(
+                audioEventRef(*clip).engineLoopEndSeconds(clip->getTimelineLength(bpm)));
             audioClipPtr->setLoopRange(te::TimeRange(loopStartTime, loopEndTime));
         } else if (audioClipPtr->isLooping()) {
             audioClipPtr->setLoopRange({});
@@ -2098,9 +2140,10 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
 
     // 7. UPDATE audio offset (trim point in file)
     // Must come AFTER loop range — setLoopRangeBeats resets offset internally
-    if (!clip->isReversed) {
+    if (!audioEventRef(*clip).reversed) {
         double projectBpm = projectBpmAtClip(edit_, *clip);
-        double teOffset = juce::jmax(0.0, clip->getTeOffset(clip->loopEnabled, projectBpm));
+        double teOffset = juce::jmax(
+            0.0, audioEventRef(*clip).engineOffsetSeconds(clip->loopEnabled, projectBpm));
         auto currentOffset = audioClipPtr->getPosition().getOffset().inSeconds();
         if (std::abs(currentOffset - teOffset) > 0.001) {
             audioClipPtr->setOffset(te::TimeDuration::fromSeconds(teOffset));
@@ -2109,28 +2152,31 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
 
     // 8. PITCH
     {
-        bool isAnalog = clip->isAnalogPitchActive();
-        if (clip->autoPitch != audioClipPtr->getAutoPitch())
-            audioClipPtr->setAutoPitch(isAnalog ? false : clip->autoPitch);
-        if (static_cast<int>(audioClipPtr->getAutoPitchMode()) != clip->autoPitchMode)
+        bool isAnalog = audioEventRef(*clip).isAnalogPitchActive();
+        if (audioEventRef(*clip).autoPitch != audioClipPtr->getAutoPitch())
+            audioClipPtr->setAutoPitch(isAnalog ? false : audioEventRef(*clip).autoPitch);
+        if (static_cast<int>(audioClipPtr->getAutoPitchMode()) !=
+            audioEventRef(*clip).autoPitchMode)
             audioClipPtr->setAutoPitchMode(
-                static_cast<te::AudioClipBase::AutoPitchMode>(clip->autoPitchMode));
+                static_cast<te::AudioClipBase::AutoPitchMode>(audioEventRef(*clip).autoPitchMode));
         if (isAnalog) {
             if (std::abs(audioClipPtr->getPitchChange()) > 0.001f)
                 audioClipPtr->setPitchChange(0.0f);
         } else {
-            if (std::abs(audioClipPtr->getPitchChange() - clip->pitchChange) > 0.001f)
-                audioClipPtr->setPitchChange(clip->pitchChange);
+            if (std::abs(audioClipPtr->getPitchChange() - audioEventRef(*clip).pitchChange) >
+                0.001f)
+                audioClipPtr->setPitchChange(audioEventRef(*clip).pitchChange);
         }
-        if (audioClipPtr->getTransposeSemiTones(false) != clip->transpose)
-            audioClipPtr->setTranspose(clip->transpose);
+        if (audioClipPtr->getTransposeSemiTones(false) != audioEventRef(*clip).transpose)
+            audioClipPtr->setTranspose(audioEventRef(*clip).transpose);
     }
 
     // 9. BEAT DETECTION
-    if (clip->autoDetectBeats != audioClipPtr->getAutoDetectBeats())
-        audioClipPtr->setAutoDetectBeats(clip->autoDetectBeats);
-    if (std::abs(audioClipPtr->getBeatSensitivity() - clip->beatSensitivity) > 0.001f)
-        audioClipPtr->setBeatSensitivity(clip->beatSensitivity);
+    if (audioEventRef(*clip).autoDetectBeats != audioClipPtr->getAutoDetectBeats())
+        audioClipPtr->setAutoDetectBeats(audioEventRef(*clip).autoDetectBeats);
+    if (std::abs(audioClipPtr->getBeatSensitivity() - audioEventRef(*clip).beatSensitivity) >
+        0.001f)
+        audioClipPtr->setBeatSensitivity(audioEventRef(*clip).beatSensitivity);
 
     // 10. PLAYBACK (isReversed handled at top of function)
 
@@ -2146,24 +2192,30 @@ bool ClipSynchronizer::syncAudioClipToEngine(ClipId clipId, const ClipInfo* clip
     // 12. FADES
     {
         double teFadeIn = audioClipPtr->getFadeIn().inSeconds();
-        if (std::abs(teFadeIn - clip->fadeIn) > 0.001)
-            audioClipPtr->setFadeIn(te::TimeDuration::fromSeconds(clip->fadeIn));
+        if (std::abs(teFadeIn - audioEventRef(*clip).fadeInSeconds) > 0.001)
+            audioClipPtr->setFadeIn(
+                te::TimeDuration::fromSeconds(audioEventRef(*clip).fadeInSeconds));
     }
     {
         double teFadeOut = audioClipPtr->getFadeOut().inSeconds();
-        if (std::abs(teFadeOut - clip->fadeOut) > 0.001)
-            audioClipPtr->setFadeOut(te::TimeDuration::fromSeconds(clip->fadeOut));
+        if (std::abs(teFadeOut - audioEventRef(*clip).fadeOutSeconds) > 0.001)
+            audioClipPtr->setFadeOut(
+                te::TimeDuration::fromSeconds(audioEventRef(*clip).fadeOutSeconds));
     }
-    if (static_cast<int>(audioClipPtr->getFadeInType()) != clip->fadeInType)
-        audioClipPtr->setFadeInType(static_cast<te::AudioFadeCurve::Type>(clip->fadeInType));
-    if (static_cast<int>(audioClipPtr->getFadeOutType()) != clip->fadeOutType)
-        audioClipPtr->setFadeOutType(static_cast<te::AudioFadeCurve::Type>(clip->fadeOutType));
-    if (static_cast<int>(audioClipPtr->getFadeInBehaviour()) != clip->fadeInBehaviour)
+    if (static_cast<int>(audioClipPtr->getFadeInType()) != audioEventRef(*clip).fadeInType)
+        audioClipPtr->setFadeInType(
+            static_cast<te::AudioFadeCurve::Type>(audioEventRef(*clip).fadeInType));
+    if (static_cast<int>(audioClipPtr->getFadeOutType()) != audioEventRef(*clip).fadeOutType)
+        audioClipPtr->setFadeOutType(
+            static_cast<te::AudioFadeCurve::Type>(audioEventRef(*clip).fadeOutType));
+    if (static_cast<int>(audioClipPtr->getFadeInBehaviour()) !=
+        audioEventRef(*clip).fadeInBehaviour)
         audioClipPtr->setFadeInBehaviour(
-            static_cast<te::AudioClipBase::FadeBehaviour>(clip->fadeInBehaviour));
-    if (static_cast<int>(audioClipPtr->getFadeOutBehaviour()) != clip->fadeOutBehaviour)
+            static_cast<te::AudioClipBase::FadeBehaviour>(audioEventRef(*clip).fadeInBehaviour));
+    if (static_cast<int>(audioClipPtr->getFadeOutBehaviour()) !=
+        audioEventRef(*clip).fadeOutBehaviour)
         audioClipPtr->setFadeOutBehaviour(
-            static_cast<te::AudioClipBase::FadeBehaviour>(clip->fadeOutBehaviour));
+            static_cast<te::AudioClipBase::FadeBehaviour>(audioEventRef(*clip).fadeOutBehaviour));
     if (clip->autoCrossfade != audioClipPtr->getAutoCrossfade())
         audioClipPtr->setAutoCrossfade(clip->autoCrossfade);
 

--- a/magda/daw/audio/session/SessionClipScheduler.cpp
+++ b/magda/daw/audio/session/SessionClipScheduler.cpp
@@ -458,6 +458,7 @@ void SessionClipScheduler::updateLaunchTimings(ClipId clipId, const ClipInfo* cl
         data.clipLengthBeats = durationSeconds * bpm / 60.0;
         data.loopLengthBeats = data.clipLengthBeats;
     } else {
+        // MIDI: the launch cycle is the clip length.
         data.clipLengthBeats = clip->getLengthInBeats(bpm);
         data.loopLengthBeats = data.clipLengthBeats;
     }

--- a/magda/daw/audio/session/SessionClipScheduler.cpp
+++ b/magda/daw/audio/session/SessionClipScheduler.cpp
@@ -447,15 +447,14 @@ void SessionClipScheduler::updateLaunchTimings(ClipId clipId, const ClipInfo* cl
     if (bpm <= 0.0)
         bpm = 120.0;
 
-    if (clip->isAudio() && clip->autoTempo) {
+    const auto* event = clip->primaryEvent();
+    if (event != nullptr && event->autoTempo) {
         data.clipLengthBeats = clip->getLengthInBeats(bpm);
-        data.loopLengthBeats =
-            (clip->loopLengthBeats > 0.0) ? clip->loopLengthBeats : data.clipLengthBeats;
-    } else if (clip->isAudio()) {
-        double srcLength = clip->getSourceLoopLength() > 0.0
-                               ? clip->getSourceLoopLength()
-                               : clip->timelineToSource(clip->getTimelineLength(bpm));
-        double durationSeconds = srcLength / clip->speedRatio;
+        const double loopBeats = event->loopLengthBeats();
+        data.loopLengthBeats = loopBeats > 0.0 ? loopBeats : data.clipLengthBeats;
+    } else if (event != nullptr) {
+        const double srcLength = event->sourceLengthSeconds(clip->getTimelineLength(bpm));
+        double durationSeconds = srcLength / event->speedRatio;
         data.clipLengthBeats = durationSeconds * bpm / 60.0;
         data.loopLengthBeats = data.clipLengthBeats;
     } else {

--- a/magda/daw/audio/session/SessionRecorder.cpp
+++ b/magda/daw/audio/session/SessionRecorder.cpp
@@ -214,11 +214,11 @@ void SessionRecorder::finalizeRecording(const ActiveRecording& rec, double stopT
     // Create arrangement clip with the session clip's content
     ClipId newClipId = INVALID_CLIP_ID;
 
-    if (sessionClip->isAudio()) {
-        if (sessionClip->audio().source.filePath.isNotEmpty()) {
-            newClipId = clipManager.createAudioClip(rec.trackId, rec.arrangementStartTime, duration,
-                                                    sessionClip->audio().source.filePath,
-                                                    ClipView::Arrangement);
+    if (const auto* sessionEvent = sessionClip->primaryEvent()) {
+        if (sessionEvent->sourceFilePath().isNotEmpty()) {
+            newClipId =
+                clipManager.createAudioClip(rec.trackId, rec.arrangementStartTime, duration,
+                                            sessionEvent->sourceFilePath(), ClipView::Arrangement);
         }
     } else {
         newClipId = clipManager.createMidiClip(rec.trackId, rec.arrangementStartTime, duration,
@@ -236,31 +236,28 @@ void SessionRecorder::finalizeRecording(const ActiveRecording& rec, double stopT
     newClip->name = sessionClip->name;
     newClip->colour = sessionClip->colour;
 
-    if (sessionClip->isAudio()) {
-        newClip->offset = sessionClip->offset;
-        newClip->loopStart = sessionClip->loopStart;
-        newClip->loopLength = sessionClip->loopLength;
-        newClip->speedRatio = sessionClip->speedRatio;
-
-        // Copy beat-mode / auto-tempo properties so the arrangement clip
-        // stays in the same time-stretch mode as the session clip.
-        newClip->audio().interpretation.bpm = sessionClip->audio().interpretation.bpm;
-        newClip->audio().interpretation.totalBeats = sessionClip->audio().interpretation.totalBeats;
-        newClip->timeStretchMode = sessionClip->timeStretchMode;
-        newClip->loopStartBeats = sessionClip->loopStartBeats;
-        newClip->loopLengthBeats = sessionClip->loopLengthBeats;
+    auto* newEvent = newClip->primaryEvent();
+    const auto* sessionEvent = sessionClip->primaryEvent();
+    if (newEvent != nullptr && sessionEvent != nullptr) {
+        // Read position, source region, stretch and interpretation come across
+        // verbatim; the pooled source and event id belong to the new clip.
+        const EventId keepId = newEvent->id;
+        const SourceId keepSourceId = newEvent->sourceId;
+        *newEvent = *sessionEvent;
+        newEvent->id = keepId;
+        newEvent->sourceId = keepSourceId;
 
         // For autoTempo arrangement clips, startBeats and lengthBeats must
         // reflect the ARRANGEMENT position, not the session clip's values
         // (session clips have startBeats=0 since they live in slots).
-        if (sessionClip->autoTempo) {
+        if (sessionEvent->autoTempo) {
             auto& tempoSeq = edit_.tempoSequence;
             auto startBeatPos =
                 tempoSeq.toBeats(te::TimePosition::fromSeconds(rec.arrangementStartTime));
             auto endBeatPos = tempoSeq.toBeats(te::TimePosition::fromSeconds(stopTime));
             newClip->startBeats = startBeatPos.inBeats();
             newClip->lengthBeats = endBeatPos.inBeats() - startBeatPos.inBeats();
-            newClip->autoTempo = true;
+            newEvent->autoTempo = true;
         } else {
             double bpm = edit_.tempoSequence.getBpmAt(te::TimePosition());
             if (bpm <= 0.0)

--- a/magda/daw/audio/session/SessionRecorder.cpp
+++ b/magda/daw/audio/session/SessionRecorder.cpp
@@ -255,14 +255,18 @@ void SessionRecorder::finalizeRecording(const ActiveRecording& rec, double stopT
             auto startBeatPos =
                 tempoSeq.toBeats(te::TimePosition::fromSeconds(rec.arrangementStartTime));
             auto endBeatPos = tempoSeq.toBeats(te::TimePosition::fromSeconds(stopTime));
-            newClip->startBeats = startBeatPos.inBeats();
-            newClip->lengthBeats = endBeatPos.inBeats() - startBeatPos.inBeats();
+            // Through setPlacementBeats, not the mirror fields: the copy above
+            // brought the session event's slot geometry with it, and only this
+            // re-spans the event over the arrangement clip.
+            newClip->setPlacementBeats(startBeatPos.inBeats(),
+                                       endBeatPos.inBeats() - startBeatPos.inBeats());
             newEvent->autoTempo = true;
         } else {
             double bpm = edit_.tempoSequence.getBpmAt(te::TimePosition());
             if (bpm <= 0.0)
                 bpm = 120.0;
-            newClip->lengthBeats = sessionClip->getLengthInBeats(bpm);
+            newClip->setPlacementBeats(newClip->placement.startBeat,
+                                       sessionClip->getLengthInBeats(bpm));
         }
 
         // For looping audio: enable loop if duration exceeds one pass

--- a/magda/daw/core/AudioClipSourceDisplay.hpp
+++ b/magda/daw/core/AudioClipSourceDisplay.hpp
@@ -38,25 +38,26 @@ inline AudioClipSourceDisplay computeAudioClipSourceDisplay(const ClipInfo& clip
                                                             double fileDurationSeconds,
                                                             double cachedSourceBpm) {
     AudioClipSourceDisplay d;
-    d.sourceFieldsActive = clip.autoTempo;
-    d.speedActive = !clip.autoTempo;
+    const auto& event = audioEventRef(clip);
+    d.sourceFieldsActive = event.autoTempo;
+    d.speedActive = !event.autoTempo;
 
     if (!clip.isAudio())
         return d;
 
-    const double storedBpm = clip.audio().interpretation.bpm;
+    const double storedBpm = event.interpBpm;
     const bool storedBpmLooksDefaulted =
-        storedBpm <= 0.0 || (!clip.autoTempo && std::abs(storedBpm - projectBpm) < 0.1);
+        storedBpm <= 0.0 || (!event.autoTempo && std::abs(storedBpm - projectBpm) < 0.1);
 
     d.bpm = storedBpm;
     if (storedBpmLooksDefaulted && cachedSourceBpm > 0.0)
         d.bpm = cachedSourceBpm;
 
     if (d.bpm > 0.0 && fileDurationSeconds > 0.0 &&
-        (storedBpmLooksDefaulted || clip.audio().interpretation.totalBeats <= 0.0))
+        (storedBpmLooksDefaulted || event.interpTotalBeats <= 0.0))
         d.totalBeats = fileDurationSeconds * d.bpm / 60.0;
     else
-        d.totalBeats = clip.audio().interpretation.totalBeats;
+        d.totalBeats = event.interpTotalBeats;
 
     return d;
 }

--- a/magda/daw/core/CMakeLists.txt
+++ b/magda/daw/core/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(magda_daw PRIVATE
     TrackManagerDevices.cpp
     ModulatorEngine.cpp
     ClipManager.cpp
+    SourcePool.cpp
     ChordProgressionConverter.cpp
     SessionLaunchService.cpp
     MidiChordMarkers.cpp

--- a/magda/daw/core/ClipDisplayInfo.hpp
+++ b/magda/daw/core/ClipDisplayInfo.hpp
@@ -180,30 +180,30 @@ struct ClipDisplayInfo {
     //
     // fileDuration is optional; pass 0 if unknown.
     //
-    // Issue #1157: every seconds-domain value read from `clip` is routed
-    // through ClipInfo accessors (getTimelineLength / getSourceLoopStart /
-    // getSourceLoopLength / getSourceOffset) so autoTempo clips compute
-    // live from beats × BPM and stay correct after BPM changes.
+    // Issue #1157: the timeline seconds come from beat-domain accessors so
+    // autoTempo clips compute live and stay correct after BPM changes. The
+    // source-domain values come off the clip's audio event (#1901).
     static ClipDisplayInfo from(const ClipInfo& clip, double bpm, double fileDuration = 0.0) {
         ClipDisplayInfo d{};
         const double projectBpm = isValidBpm(bpm) ? bpm : DEFAULT_BPM;
+        const auto& event = audioEventRef(clip);
 
         const double clipLength = clip.getTimelineLength(projectBpm);
         const double clipStart = clip.getTimelineStart(projectBpm);
-        const double clipOffset = clip.getSourceOffset();
-        const double clipLoopStart = clip.getSourceLoopStart();
-        const double clipLoopLength = clip.getSourceLoopLength();
+        const double clipOffset = event.anchorSeconds();
+        const double clipLoopStart = event.loopStartSeconds();
+        const double clipLoopLength = event.loopLengthSeconds();
 
         d.startTime = clipStart;
         d.length = clipLength;
         d.endTime = clipStart + clipLength;
         d.offset = clipOffset;
-        d.speedRatio = clip.speedRatio;
-        d.reversed = clip.isReversed;
+        d.speedRatio = event.speedRatio;
+        d.reversed = event.reversed;
 
-        d.autoTempo = clip.autoTempo;
+        d.autoTempo = event.autoTempo;
         d.lengthBeats = clip.placement.lengthBeats;
-        d.loopLengthBeats = clip.loopLengthBeats;
+        d.loopLengthBeats = event.loopLengthBeats();
         d.startBeats = clip.getStartBeats(projectBpm);
         d.endBeats = clip.getEndBeats(projectBpm);
 
@@ -215,12 +215,12 @@ struct ClipDisplayInfo {
         // the loop's beat-count for the same calibration. Issue #1157.
         //
         // Manual stretch: timelineSeconds = sourceSeconds / speedRatio.
-        if (clip.autoTempo && clip.audio().interpretation.bpm > 0.0) {
-            d.srcToTimelineRatio = clip.audio().interpretation.bpm / projectBpm;
-        } else if (clip.autoTempo && clipLoopLength > 0.0 && clip.loopLengthBeats > 0.0) {
-            d.srcToTimelineRatio = (clip.loopLengthBeats * 60.0 / projectBpm) / clipLoopLength;
+        if (event.autoTempo && event.interpBpm > 0.0) {
+            d.srcToTimelineRatio = event.interpBpm / projectBpm;
+        } else if (event.autoTempo && clipLoopLength > 0.0 && d.loopLengthBeats > 0.0) {
+            d.srcToTimelineRatio = (d.loopLengthBeats * 60.0 / projectBpm) / clipLoopLength;
         } else {
-            d.srcToTimelineRatio = (clip.speedRatio > 0.0) ? 1.0 / clip.speedRatio : 1.0;
+            d.srcToTimelineRatio = (event.speedRatio > 0.0) ? 1.0 / event.speedRatio : 1.0;
         }
 
         // ---- Source file extent (always [0, fileDuration]) ----
@@ -232,7 +232,7 @@ struct ClipDisplayInfo {
             // conservative range derived from the clip's own length so
             // the editor still gets something sane to draw.
             const double sourceLenFromLength =
-                (clip.speedRatio > 0.0) ? clipLength * clip.speedRatio : clipLength;
+                (event.speedRatio > 0.0) ? clipLength * event.speedRatio : clipLength;
             d.sourceFileEnd = std::max(clipOffset + sourceLenFromLength, clipOffset + 0.001);
         }
 

--- a/magda/daw/core/ClipInfo.hpp
+++ b/magda/daw/core/ClipInfo.hpp
@@ -187,6 +187,60 @@ struct AudioEvent {
     int64_t loopStartSamples = 0;
     int64_t loopLengthSamples = 0;  // 0 = derive from the event's own length
 
+    /// Source seconds mapped through the warp markers.
+    ///
+    /// Markers are (sourceTime, warpTime) pairs in source seconds, and the map
+    /// between them is piecewise linear. Outside the marker range the source
+    /// plays at its own rate, so the nearest marker's offset carries on at
+    /// slope 1. Identity when warp is off or no markers exist, which makes
+    /// every caller below warp-agnostic.
+    double warpedSourceSeconds(double sourceSeconds) const {
+        if (!warpEnabled || warpMarkers.empty())
+            return sourceSeconds;
+
+        // Storage order is not guaranteed (the renderer sorts by warpTime for
+        // its own purposes), so bracket by value rather than by index.
+        const WarpMarker* below = nullptr;
+        const WarpMarker* above = nullptr;
+        for (const auto& marker : warpMarkers) {
+            if (marker.sourceTime <= sourceSeconds &&
+                (below == nullptr || marker.sourceTime > below->sourceTime)) {
+                below = &marker;
+            }
+            if (marker.sourceTime >= sourceSeconds &&
+                (above == nullptr || marker.sourceTime < above->sourceTime)) {
+                above = &marker;
+            }
+        }
+
+        if (below == nullptr)
+            return sourceSeconds + (above->warpTime - above->sourceTime);
+        if (above == nullptr)
+            return sourceSeconds + (below->warpTime - below->sourceTime);
+
+        const double span = above->sourceTime - below->sourceTime;
+        if (span <= 0.0)
+            return below->warpTime;
+
+        const double t = (sourceSeconds - below->sourceTime) / span;
+        return below->warpTime + t * (above->warpTime - below->warpTime);
+    }
+
+    /// A source-domain instant expressed in TIMELINE beats.
+    ///
+    /// Beat mode and warp both hand the engine source-beat processing, so in
+    /// either the warped position scales by the event's own interpretation.
+    /// Otherwise the region plays at its recorded rate and the timeline span
+    /// comes from seconds and the project tempo.
+    double sourceInstantToTimelineBeats(double sourceSeconds, double projectBpm) const {
+        const double warped = warpedSourceSeconds(sourceSeconds);
+
+        if ((autoTempo || warpEnabled) && interpBpm > 0.0)
+            return warped * interpBpm / 60.0;
+
+        return isValidBpm(projectBpm) ? sourceToTimeline(warped) * projectBpm / 60.0 : 0.0;
+    }
+
     /// Re-express the source-domain positions at a different sample rate.
     ///
     /// They are counts at the source's own rate, so whenever that rate changes
@@ -705,13 +759,7 @@ struct ClipInfo {
         if (event == nullptr)
             return loopStartBeats;
 
-        if (event->autoTempo)
-            return event->loopStartBeats();
-
-        if (!isValidBpm(projectBpm))
-            return 0.0;
-
-        return event->sourceToTimeline(event->loopStartSeconds()) * projectBpm / 60.0;
+        return event->sourceInstantToTimelineBeats(event->loopStartSeconds(), projectBpm);
     }
 
     /// Loop length in TIMELINE beats for whichever content the clip holds.
@@ -727,13 +775,12 @@ struct ClipInfo {
         if (event == nullptr)
             return loopLengthBeats;
 
-        if (event->autoTempo)
-            return event->loopLengthBeats();
-
-        if (!isValidBpm(projectBpm))
-            return 0.0;
-
-        return event->sourceToTimeline(event->loopLengthSeconds()) * projectBpm / 60.0;
+        // The difference of the two mapped boundaries, not a scaled length: a
+        // warped region does not stretch uniformly, so scaling its duration
+        // would disagree with where its end actually lands.
+        const double start = event->loopStartSeconds();
+        return event->sourceInstantToTimelineBeats(start + event->loopLengthSeconds(), projectBpm) -
+               event->sourceInstantToTimelineBeats(start, projectBpm);
     }
 
     // =========================================================================

--- a/magda/daw/core/ClipInfo.hpp
+++ b/magda/daw/core/ClipInfo.hpp
@@ -698,15 +698,42 @@ struct ClipInfo {
     double loopStartBeats = 0.0;
     double loopLengthBeats = 0.0;
 
-    /// Loop length in beats for whichever content the clip holds.
-    ///
-    /// A MIDI clip keeps it in the field above. An audio clip's loop is a
-    /// source region in samples, so its beat length is a view derived through
-    /// the event's interpretation. Reading only one of the two silently
-    /// returns zero for the other, which reads as "not looping".
-    double loopLengthInBeats() const {
+    /// Loop start in TIMELINE beats for whichever content the clip holds.
+    /// Same domain rules as loopLengthInBeats below.
+    double loopStartInBeats(double projectBpm) const {
         const auto* event = primaryEvent();
-        return event != nullptr ? event->loopLengthBeats() : loopLengthBeats;
+        if (event == nullptr)
+            return loopStartBeats;
+
+        if (event->autoTempo)
+            return event->loopStartBeats();
+
+        if (!isValidBpm(projectBpm))
+            return 0.0;
+
+        return event->sourceToTimeline(event->loopStartSeconds()) * projectBpm / 60.0;
+    }
+
+    /// Loop length in TIMELINE beats for whichever content the clip holds.
+    ///
+    /// A MIDI clip keeps it in the field above, already in timeline beats. An
+    /// audio clip's loop is a source region, and the two domains only coincide
+    /// under beat mode, where the source is stretched onto the project grid.
+    /// Off beat mode the region plays at its own rate, so its timeline span
+    /// comes from seconds and the project tempo. AudioEvent::loopLengthBeats()
+    /// is the SOURCE-beat view and is not interchangeable with this.
+    double loopLengthInBeats(double projectBpm) const {
+        const auto* event = primaryEvent();
+        if (event == nullptr)
+            return loopLengthBeats;
+
+        if (event->autoTempo)
+            return event->loopLengthBeats();
+
+        if (!isValidBpm(projectBpm))
+            return 0.0;
+
+        return event->sourceToTimeline(event->loopLengthSeconds()) * projectBpm / 60.0;
     }
 
     // =========================================================================
@@ -868,12 +895,23 @@ struct ClipInfo {
                 copySharedEventFieldsFrom(events()[i], src.events()[i]);
             auto& dstAudio = audio();
             const auto& srcAudio = src.audio();
-            dstAudio.nextEventId = srcAudio.nextEventId;
+            // Ids stay per-instance, so the allocator must never step back
+            // behind one already handed out here. Equal today because every
+            // live flow keeps link-group members at one event; once slicing
+            // lets their histories diverge, taking the source's counter
+            // verbatim could mint a duplicate on the next addEvent.
+            dstAudio.nextEventId = juce::jmax(dstAudio.nextEventId, srcAudio.nextEventId);
             dstAudio.takes = srcAudio.takes;
             dstAudio.currentTakeIndex = srcAudio.currentTakeIndex;
             dstAudio.comp = srcAudio.comp;
             dstAudio.compActive = srcAudio.compActive;
         } else {
+            // Wholesale: this replaces every per-instance event field (anchor,
+            // region, speedRatio, fades, channels, gain, geometry) and adopts
+            // the source's event ids. Only reachable when the event structure
+            // itself differs, which no Phase A flow produces. Slicing will:
+            // it needs a prefix match here, not a swap.
+            jassert(!isAudio() || !src.isAudio() || events().size() == src.events().size());
             content = src.content;
         }
 

--- a/magda/daw/core/ClipInfo.hpp
+++ b/magda/daw/core/ClipInfo.hpp
@@ -4,12 +4,14 @@
 #include <juce_graphics/juce_graphics.h>
 
 #include <cmath>
+#include <cstdint>
 #include <map>
 #include <string>
 #include <variant>
 #include <vector>
 
 #include "ClipTypes.hpp"
+#include "SourcePool.hpp"
 #include "TempoMap.hpp"
 #include "TempoUtils.hpp"
 #include "TimeStretchModes.hpp"
@@ -134,25 +136,265 @@ struct ClipPlacement {
     }
 };
 
-struct AudioSourceFacts {
-    juce::String filePath;
-    double durationSeconds = 0.0;
+/**
+ * @brief One warp marker: a point in the source pinned to a warped position.
+ *
+ * Both sides are seconds, unchanged from before the event split (#1901): the
+ * marker moved onto the event, its units did not. Re-expressing the warp side
+ * in beats would change where markers land under a tempo change, and the
+ * container/content split is meant to be behaviour-neutral.
+ */
+struct WarpMarker {
+    double sourceTime = 0.0;
+    double warpTime = 0.0;
 
-    bool operator==(const AudioSourceFacts&) const = default;
+    bool operator==(const WarpMarker&) const = default;
 };
 
-struct AudioSourceInterpretation {
-    double bpm = 0.0;
-    double totalBeats = 0.0;
-    bool totalBeatsLocked = false;
-    // Musical key the source is interpreted in. Optional — empty = unknown.
-    // Inspector/editor edits live on the clip until the user explicitly saves
-    // them to the media library. keyScale is "major" / "minor" / "" when
-    // unknown; keyRoot is "C" / "C#" / ... / "B" or empty.
+/**
+ * @brief Placement of a source inside a clip (#1901).
+ *
+ * Level 2 of the clip model. An event says which Source is heard, which part of
+ * it, where inside the clip, and how the audio is interpreted. It does NOT know
+ * about the timeline: its geometry is relative to the owning clip's start, and
+ * the clip's bounds are a window that crops it.
+ *
+ * Coordinate rule: everything geometric is beats; the only source-domain values
+ * are the anchor and the loop region, which are samples at the source's own
+ * rate. Storing those in samples (rather than seconds or beats) is what makes a
+ * source-BPM reinterpretation leave the audible region untouched and simply
+ * re-read its musical length.
+ */
+struct AudioEvent {
+    EventId id = INVALID_EVENT_ID;
+    SourceId sourceId = INVALID_SOURCE_ID;
+
+    // ---- Clip-relative geometry (beats) ------------------------------------
+
+    /// Start relative to the owning clip's start. May be negative (the head is
+    /// cropped by the clip window).
+    double startBeat = 0.0;
+    double lengthBeats = 0.0;
+
+    // ---- Source domain (samples at the source's own rate) ------------------
+
+    /// Where reading begins in the source, mapped through the warp map.
+    int64_t sourceAnchorSamples = 0;
+
+    /// Source region that repeats to fill the event: how ONE event tiles its
+    /// own file. Whether it loops at all is ClipInfo::loopEnabled, which both
+    /// content types share and which did not move.
+    int64_t loopStartSamples = 0;
+    int64_t loopLengthSamples = 0;  // 0 = derive from the event's own length
+
+    // ---- Interpretation (seeded from the Source, then owned by the user) ---
+
+    double interpBpm = 0.0;
+    double interpTotalBeats = 0.0;
+    bool interpTotalBeatsLocked = false;
+
+    /// Musical key this event is interpreted in. Empty = unknown. keyRoot is
+    /// "C" / "C#" / ... / "B"; keyScale is "major" / "minor". Inspector edits
+    /// live here until the user explicitly saves them to the media library.
     std::string keyRoot;
     std::string keyScale;
 
-    bool operator==(const AudioSourceInterpretation&) const = default;
+    bool autoTempo = false;
+    double speedRatio = 1.0;
+    int timeStretchMode = 0;
+    bool warpEnabled = false;
+    std::vector<WarpMarker> warpMarkers;
+
+    bool autoPitch = false;
+    bool analogPitch = false;
+    int autoPitchMode = 0;     // 0=pitchTrack, 1=chordTrackMono, 2=chordTrackPoly
+    float pitchChange = 0.0f;  // -48 to +48 semitones
+    int transpose = 0;         // -24 to +24 semitones (only when !autoPitch)
+
+    bool reversed = false;
+    bool autoDetectBeats = false;
+    float beatSensitivity = 0.5f;
+
+    bool leftChannelActive = true;
+    bool rightChannelActive = true;
+
+    // ---- Per-event mix -----------------------------------------------------
+
+    /// Trim for this event alone. The clip's own gain sits above it.
+    float gainDB = 0.0f;
+
+    // Seconds, as before the event split. Fades are per-event now, but making
+    // them tempo-relative is a behaviour change and does not belong in a
+    // structural refactor.
+    double fadeInSeconds = 0.0;
+    double fadeOutSeconds = 0.0;
+    int fadeInType = 1;  // FadeCurve
+    int fadeOutType = 1;
+    int fadeInBehaviour = 0;  // 0=gainFade, 1=speedRamp
+    int fadeOutBehaviour = 0;
+
+    bool operator==(const AudioEvent&) const = default;
+
+    double endBeat() const {
+        return startBeat + lengthBeats;
+    }
+
+    // ---- Source resolution -------------------------------------------------
+
+    const Source* source() const {
+        return SourcePool::getInstance().get(sourceId);
+    }
+    double sourceSampleRate() const {
+        return sourceRateOf(sourceId);
+    }
+    juce::String sourceFilePath() const {
+        return sourcePathOf(sourceId);
+    }
+    double sourceDurationSeconds() const {
+        return sourceDurationOf(sourceId);
+    }
+
+    // ---- Source-domain conversions ----------------------------------------
+    //
+    // Samples are authoritative. Seconds and beats are views onto them, so a
+    // change to interpBpm moves the beat view and leaves the audio alone.
+
+    double anchorSeconds() const {
+        return static_cast<double>(sourceAnchorSamples) / sourceSampleRate();
+    }
+    double anchorBeats() const {
+        return interpBpm > 0.0 ? anchorSeconds() * interpBpm / 60.0 : 0.0;
+    }
+    void setAnchorSeconds(double seconds) {
+        sourceAnchorSamples =
+            static_cast<int64_t>(std::llround(juce::jmax(0.0, seconds) * sourceSampleRate()));
+    }
+    void setAnchorBeats(double beats) {
+        if (interpBpm > 0.0)
+            setAnchorSeconds(juce::jmax(0.0, beats) * 60.0 / interpBpm);
+    }
+
+    double loopStartSeconds() const {
+        return static_cast<double>(loopStartSamples) / sourceSampleRate();
+    }
+    double loopLengthSeconds() const {
+        return static_cast<double>(loopLengthSamples) / sourceSampleRate();
+    }
+    double loopStartBeats() const {
+        return interpBpm > 0.0 ? loopStartSeconds() * interpBpm / 60.0 : 0.0;
+    }
+    double loopLengthBeats() const {
+        return interpBpm > 0.0 ? loopLengthSeconds() * interpBpm / 60.0 : 0.0;
+    }
+    void setLoopStartSeconds(double seconds) {
+        loopStartSamples =
+            static_cast<int64_t>(std::llround(juce::jmax(0.0, seconds) * sourceSampleRate()));
+    }
+    void setLoopLengthSeconds(double seconds) {
+        loopLengthSamples =
+            static_cast<int64_t>(std::llround(juce::jmax(0.0, seconds) * sourceSampleRate()));
+    }
+    void setLoopStartBeats(double beats) {
+        if (interpBpm > 0.0)
+            setLoopStartSeconds(juce::jmax(0.0, beats) * 60.0 / interpBpm);
+    }
+    void setLoopLengthBeats(double beats) {
+        if (interpBpm > 0.0)
+            setLoopLengthSeconds(juce::jmax(0.0, beats) * 60.0 / interpBpm);
+    }
+
+    /// Phase of the read position within the loop region (source seconds).
+    double loopPhaseSeconds() const {
+        return static_cast<double>(sourceAnchorSamples - loopStartSamples) / sourceSampleRate();
+    }
+
+    // ---- Playback interpretation -------------------------------------------
+
+    /// Analog pitch resamples instead of stretching, so it is only in force
+    /// when nothing else has already forced a stretcher on.
+    bool isAnalogPitchActive() const {
+        return analogPitch && !autoTempo && !warpEnabled;
+    }
+
+    /// The stretch mode actually applied at playback. Leaving the mode at "Off"
+    /// while the event is in beat mode, warped, sped up or pitch-shifted still
+    /// stretches, using the default quality engine. UI readouts must show this,
+    /// not the raw field, so the inspector and the audio editor agree.
+    int getEffectiveTimeStretchMode() const {
+        if (timeStretchMode == 0 && !isAnalogPitchActive() &&
+            (autoTempo || warpEnabled || std::abs(speedRatio - 1.0) > 0.001 ||
+             std::abs(pitchChange) > 0.001f)) {
+            return time_stretch_mode::kSignalsmith;
+        }
+        return timeStretchMode;
+    }
+
+    /// Source seconds -> timeline seconds (speed FACTOR: faster = shorter).
+    double sourceToTimeline(double sourceTime) const {
+        return sourceTime / speedRatio;
+    }
+    /// Timeline seconds -> source seconds.
+    double timelineToSource(double timelineTime) const {
+        return timelineTime * speedRatio;
+    }
+
+    /// Source seconds consumed by the event: the loop region if one is set,
+    /// otherwise whatever the event's own timeline extent asks for.
+    double sourceLengthSeconds(double eventTimelineSeconds) const {
+        return loopLengthSamples > 0 ? loopLengthSeconds() : timelineToSource(eventTimelineSeconds);
+    }
+
+    /// Offset handed to the engine, in timeline seconds. Looped: the phase
+    /// within the loop region. Non-looped: the raw trim point in the source.
+    ///
+    /// In beat mode speedRatio is pinned to 1 and the real stretch is
+    /// projectBpm / interpBpm, so the source distance has to travel through the
+    /// beat domain to come out as timeline seconds.
+    double engineOffsetSeconds(bool looped, double projectBpm = 0.0) const {
+        if (autoTempo && isValidBpm(projectBpm)) {
+            const double beats = looped ? (anchorBeats() - loopStartBeats()) : anchorBeats();
+            return beats * 60.0 / projectBpm;
+        }
+        return sourceToTimeline(looped ? loopPhaseSeconds() : anchorSeconds());
+    }
+    double engineLoopStartSeconds() const {
+        return sourceToTimeline(loopStartSeconds());
+    }
+    double engineLoopEndSeconds(double eventTimelineSeconds) const {
+        return sourceToTimeline(loopStartSeconds() + sourceLengthSeconds(eventTimelineSeconds));
+    }
+
+    /// Seed the interpretation from an external analysis (Tracktion loopInfo,
+    /// a detection pass). Only fills gaps, so re-analysing a file can never
+    /// rewrite what the user set.
+    ///
+    /// numBeats is only taken when a BPM is known too: a beat count without an
+    /// anchoring tempo claims musical content the file does not carry, and it
+    /// renders as a plausible-looking integer that never gets corrected once a
+    /// real BPM arrives.
+    void seedInterpretation(double numBeats, double bpm) {
+        if (bpm > 0.0 && interpBpm <= 0.0)
+            interpBpm = bpm;
+        if (numBeats > 0.0 && bpm > 0.0 && interpTotalBeats <= 0.0)
+            interpTotalBeats = numBeats;
+    }
+
+    /// Seed interpretation from the pooled source. Only fills gaps: a value the
+    /// user (or a previous seed) already set is never overwritten, so
+    /// re-analysing a file cannot rewrite an interpretation.
+    void seedInterpretationFromSource() {
+        const auto* src = source();
+        if (src == nullptr)
+            return;
+        if (interpBpm <= 0.0 && src->detectedBpm > 0.0)
+            interpBpm = src->detectedBpm;
+        if (interpTotalBeats <= 0.0 && interpBpm > 0.0 && src->durationSeconds > 0.0)
+            interpTotalBeats = src->durationSeconds * interpBpm / 60.0;
+        if (keyRoot.empty())
+            keyRoot = src->detectedKeyRoot;
+        if (keyScale.empty())
+            keyScale = src->detectedKeyScale;
+    }
 };
 
 /**
@@ -191,22 +433,62 @@ struct CompSection {
 };
 
 struct AudioClipModel {
-    AudioSourceFacts source;
-    AudioSourceInterpretation interpretation;
+    // Ordered list of audio events (#1901). The clip hosts them; it knows
+    // nothing about files directly. Kept sorted by startBeat.
+    //
+    // Today nothing in the app produces more than one event: slicing, comping
+    // and consolidation-without-render are the event-level features that switch
+    // on later. The model, serialization and engine bridge all handle N.
+    std::vector<AudioEvent> events;
+    int nextEventId = 1;
 
     // Loop-record takes, one per pass. Empty for ordinary single-source clips.
-    // When non-empty, source.filePath mirrors takes[currentTakeIndex].filePath
-    // (the active take that plays back).
+    // When non-empty, the primary event's source mirrors
+    // takes[currentTakeIndex].filePath (the active take that plays back).
     std::vector<AudioTake> takes;
     int currentTakeIndex = 0;
 
     // Comping. When compActive is true the clip plays a rendered composite
-    // (source.filePath points at the comp render) assembled from `comp`, which
-    // assigns a take to each region of the comp timeline. Empty comp = no comp.
+    // (the primary event's source is the comp render) assembled from `comp`,
+    // which assigns a take to each region of the comp timeline. Empty = no comp.
+    //
+    // Comping keeps its render-based shape for now; turning takes into event
+    // lanes and dropping the render is the follow-up to #1901, not part of the
+    // schema split.
     std::vector<CompSection> comp;
     bool compActive = false;
 
     bool operator==(const AudioClipModel&) const = default;
+
+    AudioEvent* primaryEvent() {
+        return events.empty() ? nullptr : &events.front();
+    }
+    const AudioEvent* primaryEvent() const {
+        return events.empty() ? nullptr : &events.front();
+    }
+
+    AudioEvent* findEvent(EventId eventId) {
+        for (auto& event : events)
+            if (event.id == eventId)
+                return &event;
+        return nullptr;
+    }
+    const AudioEvent* findEvent(EventId eventId) const {
+        for (const auto& event : events)
+            if (event.id == eventId)
+                return &event;
+        return nullptr;
+    }
+
+    /// Append an event with a freshly allocated id and return it.
+    ///
+    /// The reference is into `events`, so a later addEvent invalidates it.
+    /// Hold the id, not the reference, across calls.
+    AudioEvent& addEvent(AudioEvent event) {
+        event.id = nextEventId++;
+        events.push_back(std::move(event));
+        return events.back();
+    }
 };
 
 /**
@@ -247,7 +529,7 @@ struct MidiClipModel {
     // When non-empty, the active take's events are mirrored into the clip's
     // authoritative ClipInfo::midiNotes / midiCCData / midiPitchBendData (the
     // rendered, engine-synced content) — mirroring how AudioClipModel fronts
-    // takes[currentTakeIndex] into source.filePath.
+    // takes[currentTakeIndex] into the primary event's source.
     std::vector<MidiTake> takes;
     int currentTakeIndex = 0;
 
@@ -357,145 +639,65 @@ struct ClipInfo {
     // removes direct field access.
     double startBeats = 0.0;
 
-    /// Populate source metadata from engine (only sets if not already populated).
-    /// This is source-domain data only; it must never edit clip placement or
-    /// source loop region state.
-    ///
-    /// numBeats is only seeded when bpm is also known. A beat count without an
-    /// anchoring BPM is meaningless — it claims musical content the file
-    /// doesn't actually carry. Without this guard the source-domain
-    /// interpretation gets a bpm=0 / totalBeats=projectBpm×duration seed,
-    /// which renders as "—" in the BPM column but a wrong integer in the
-    /// beats column, and stays that way after the user later sets the real
-    /// BPM unless the BPM-edit path also rewrites totalBeats.
-    void setSourceMetadata(double numBeats, double bpm) {
-        if (!isAudio())
-            return;
+    // =========================================================================
+    // Event access (audio clips)
+    //
+    // Phase A of #1901 never builds a clip with more than one event, so
+    // primaryEvent() is the whole story for existing call sites. It becomes
+    // "the event the user is editing" once the UI gains event selection; it is
+    // not a permanent stand-in for iterating events.
+    // =========================================================================
 
-        auto& source = audio();
-        if (bpm > 0.0 && source.interpretation.bpm <= 0.0)
-            source.interpretation.bpm = bpm;
-        if (numBeats > 0.0 && bpm > 0.0 && source.interpretation.totalBeats <= 0.0)
-            source.interpretation.totalBeats = numBeats;
-        if (source.source.durationSeconds <= 0.0 && source.interpretation.totalBeats > 0.0 &&
-            source.interpretation.bpm > 0.0) {
-            source.source.durationSeconds =
-                source.interpretation.totalBeats * 60.0 / source.interpretation.bpm;
-        }
+    AudioEvent* primaryEvent() {
+        return isAudio() ? audio().primaryEvent() : nullptr;
+    }
+    const AudioEvent* primaryEvent() const {
+        return isAudio() ? audio().primaryEvent() : nullptr;
+    }
+
+    /// Every audio event, empty for MIDI clips.
+    std::vector<AudioEvent>& events() {
+        return audio().events;
+    }
+    const std::vector<AudioEvent>& events() const {
+        return audio().events;
     }
 
     // =========================================================================
-    // Audio playback parameters (TE-aligned terminology)
+    // Looping
+    //
+    // Unchanged by #1901. The toggle is shared by both content types, and
+    // loopStartBeats / loopLengthBeats are the MIDI loop in clip beats. Only
+    // an audio clip's source REGION moved, onto its event, because that is a
+    // position in a file rather than on the timeline.
     // =========================================================================
 
-    // Source offset - where to start reading from source file
-    // TE: Clip::offset (but TE stores in stretched time, we use source time)
-    double offset = 0.0;  // Start position in source file (source-time seconds)
-
-    // Beat-based offset (authoritative for autoTempo clips)
-    // Source beats from file start. offset (seconds) is derived: offsetBeats * 60/source
-    // interpretation BPM
-    double offsetBeats = 0.0;
-
-    // Looping - defines the region that loops
-    // TE: AudioClipBase::loopStart, loopLength, isLooping()
-    bool loopEnabled = false;  // Whether to loop the source region
-    double loopStart = 0.0;    // Where loop region starts in source file (source-time seconds)
-    double loopLength = 0.0;   // Length of loop region (source-time seconds, 0 = use clip length)
-
-    // Time stretch
-    // TE: Clip::speedRatio
-    // speedRatio is a SPEED FACTOR (NOT stretch factor!)
-    // Formula: timeline_seconds = source_seconds / speedRatio
-    // speedRatio = 1.0: normal playback
-    // speedRatio = 2.0: 2x faster (half timeline duration)
-    // speedRatio = 0.5: 2x slower (double timeline duration)
-    double speedRatio = 1.0;  // Playback speed ratio (1.0 = original, 2.0 = 2x speed/half duration)
-
-    bool warpEnabled = false;  // Whether warp markers are active on this clip
-    int timeStretchMode = 0;   // TimeStretcher::Mode (0 = default/auto)
-
-    // Warp marker positions (only populated when warpEnabled == true)
-    struct WarpMarker {
-        double sourceTime;
-        double warpTime;
-
-        bool operator==(const WarpMarker&) const = default;
-    };
-    std::vector<WarpMarker> warpMarkers;
+    bool loopEnabled = false;
+    double loopStartBeats = 0.0;
+    double loopLengthBeats = 0.0;
 
     // =========================================================================
-    // Auto-tempo / Musical mode
+    // Clip-level placement and mix
+    //
+    // How the audio is read and interpreted lives on the events. What stays
+    // here belongs to the container: where it sits, whether it plays, how it is
+    // launched, and its own gain.
     // =========================================================================
-    // When autoTempo=true:
-    // - Beat values are authoritative, time values are derived from BPM
-    // - TE's autoTempo is enabled, clips maintain fixed musical length
-    // - speedRatio must be 1.0 (TE requirement)
-    // When autoTempo=false:
-    // - Timeline placement is still beat-domain
-    // - Source playback uses offset/loop/source seconds without implying timeline position
-    bool autoTempo = false;  // Enable beat-based length (musical mode)
 
-    // Beat-based loop properties (only used when autoTempo = true)
-    // TE: AudioClipBase::loopStartBeats, loopLengthBeats
-    double loopStartBeats = 0.0;   // Loop start in beats (relative to file start)
-    double loopLengthBeats = 0.0;  // Loop length in beats (0 = derive from clip length)
-    double lengthBeats = 4.0;      // Transitional mirror of placement.lengthBeats
-
-    // Pitch
-    bool autoPitch = false;
-    bool analogPitch = false;  // Analog pitch: resample instead of time-stretch
-    bool isAnalogPitchActive() const {
-        return analogPitch && !autoTempo && !warpEnabled;
-    }
-
-    // The time-stretch mode that is actually applied at playback. When the mode
-    // is left at "Off" (0) but the clip is in beat mode, warped, sped up, or
-    // pitch-shifted (without analog pitch), TE silently stretches using its
-    // default quality engine. UI readouts must show this effective mode,
-    // not the raw field, so the inspector and the audio editor agree — e.g.
-    // after a session drop auto-enables beat mode.
-    int getEffectiveTimeStretchMode() const {
-        if (timeStretchMode == 0 && !isAnalogPitchActive() &&
-            (autoTempo || warpEnabled || std::abs(speedRatio - 1.0) > 0.001 ||
-             std::abs(pitchChange) > 0.001f)) {
-            return time_stretch_mode::kSignalsmith;
-        }
-        return timeStretchMode;
-    }
-
-    int autoPitchMode = 0;     // 0=pitchTrack, 1=chordTrackMono, 2=chordTrackPoly
-    float pitchChange = 0.0f;  // -48 to +48 semitones
-    int transpose = 0;         // -24 to +24 semitones (only when !autoPitch)
-
-    // Beat Detection
-    bool autoDetectBeats = false;
-    float beatSensitivity = 0.5f;
-
-    // Playback
-    bool isReversed = false;
+    double lengthBeats = 4.0;  // Transitional mirror of placement.lengthBeats
 
     // Per-Clip Mix
     float volumeDB = 0.0f;  // Volume: -inf to 0 dB (clip handle)
     float gainDB = 0.0f;    // Gain: 0 to +24 dB (inspector only)
     float pan = 0.0f;       // -1.0 to 1.0
 
-    // Fades
-    double fadeIn = 0.0;
-    double fadeOut = 0.0;
-    int fadeInType = 1;  // AudioFadeCurve::Type
-    int fadeOutType = 1;
-    int fadeInBehaviour = 0;  // 0=gainFade, 1=speedRamp
-    int fadeOutBehaviour = 0;
+    // Crossfade with the neighbouring clip on the same track. Crossfades
+    // BETWEEN events inside one clip are an event-level concern.
     bool autoCrossfade = false;
 
     // launchFadeSamples: ramp on the stopped→playing transition. Default 256
     // matches TE's prior hard-coded behaviour; 0 preserves the leading transient.
     int launchFadeSamples = 256;
-
-    // Channels
-    bool leftChannelActive = true;
-    bool rightChannelActive = true;
 
     // MIDI-specific properties
     std::vector<MidiNote> midiNotes;
@@ -555,6 +757,63 @@ struct ClipInfo {
         placement.lengthBeats = juce::jmax(0.0, beatLength);
         startBeats = placement.startBeat;
         lengthBeats = placement.lengthBeats;
+        syncSingleEventToClipBounds();
+    }
+
+    /// Keep a single-event clip's content coextensive with its container.
+    ///
+    /// Phase A of #1901 splits the schema without changing behaviour, so a clip
+    /// and the one event inside it stay the same extent and every existing
+    /// resize/trim path keeps working unchanged. Clips holding several events
+    /// are already representable, and for those the clip bounds are a window
+    /// that crops rather than resizes, so this deliberately does nothing.
+    void syncSingleEventToClipBounds() {
+        if (!isAudio())
+            return;
+        auto& list = audio().events;
+        if (list.size() != 1)
+            return;
+        list.front().startBeat = 0.0;
+        list.front().lengthBeats = placement.lengthBeats;
+    }
+
+    /// Event fields a ghost sibling mirrors: what the source IS and how it is
+    /// interpreted. The placement-coupled fields (anchor, loop region,
+    /// speedRatio, fades, channels, gain, and the event's own geometry) stay
+    /// per-instance, so one ghost's resize or trim cannot corrupt its siblings.
+    /// Kept in lockstep with sharedEventFieldsEqual below.
+    static void copySharedEventFieldsFrom(AudioEvent& dst, const AudioEvent& src) {
+        dst.sourceId = src.sourceId;
+        dst.interpBpm = src.interpBpm;
+        dst.interpTotalBeats = src.interpTotalBeats;
+        dst.interpTotalBeatsLocked = src.interpTotalBeatsLocked;
+        dst.keyRoot = src.keyRoot;
+        dst.keyScale = src.keyScale;
+        dst.autoTempo = src.autoTempo;
+        dst.timeStretchMode = src.timeStretchMode;
+        dst.warpEnabled = src.warpEnabled;
+        dst.warpMarkers = src.warpMarkers;
+        dst.autoPitch = src.autoPitch;
+        dst.analogPitch = src.analogPitch;
+        dst.autoPitchMode = src.autoPitchMode;
+        dst.pitchChange = src.pitchChange;
+        dst.transpose = src.transpose;
+        dst.reversed = src.reversed;
+        dst.autoDetectBeats = src.autoDetectBeats;
+        dst.beatSensitivity = src.beatSensitivity;
+    }
+
+    static bool sharedEventFieldsEqual(const AudioEvent& a, const AudioEvent& b) {
+        return a.sourceId == b.sourceId && a.interpBpm == b.interpBpm &&
+               a.interpTotalBeats == b.interpTotalBeats &&
+               a.interpTotalBeatsLocked == b.interpTotalBeatsLocked && a.keyRoot == b.keyRoot &&
+               a.keyScale == b.keyScale && a.autoTempo == b.autoTempo &&
+               a.timeStretchMode == b.timeStretchMode && a.warpEnabled == b.warpEnabled &&
+               a.warpMarkers == b.warpMarkers && a.autoPitch == b.autoPitch &&
+               a.analogPitch == b.analogPitch && a.autoPitchMode == b.autoPitchMode &&
+               a.pitchChange == b.pitchChange && a.transpose == b.transpose &&
+               a.reversed == b.reversed && a.autoDetectBeats == b.autoDetectBeats &&
+               a.beatSensitivity == b.beatSensitivity;
     }
 
     /// Copy the content-defining fields from a link-group sibling (ghost-clip
@@ -562,32 +821,34 @@ struct ClipInfo {
     /// source is interpreted is shared — including the name (the UI appends a
     /// per-instance #index for display); everything that says WHERE it sits
     /// and how it mixes stays per-instance: id, trackId, colour, view,
-    /// placement (+ derived mirrors), offsets (placement-coupled: left-resize
-    /// trims only that instance), volume/gain/pan, fades, channels, launch and
-    /// grid settings. Loop fields and speedRatio are per-instance too: for
-    /// non-looped audio, resize keeps loopStart/loopLength mirroring
-    /// offset/length, and stretch-resize writes speedRatio — sharing either
-    /// would let one ghost's resize corrupt its siblings.
+    /// placement (+ derived mirrors), volume/gain/pan, launch and grid
+    /// settings, plus the per-instance event fields listed above.
+    ///
+    /// When the two clips disagree on how many events they hold, the sibling's
+    /// event list is taken wholesale: the structure itself changed, and there
+    /// is no per-instance state on an event that does not exist yet.
     void copySharedContentFrom(const ClipInfo& src) {
         name = src.name;
-        content = src.content;
+
+        if (isAudio() && src.isAudio() && events().size() == src.events().size()) {
+            for (size_t i = 0; i < events().size(); ++i)
+                copySharedEventFieldsFrom(events()[i], src.events()[i]);
+            auto& dstAudio = audio();
+            const auto& srcAudio = src.audio();
+            dstAudio.nextEventId = srcAudio.nextEventId;
+            dstAudio.takes = srcAudio.takes;
+            dstAudio.currentTakeIndex = srcAudio.currentTakeIndex;
+            dstAudio.comp = srcAudio.comp;
+            dstAudio.compActive = srcAudio.compActive;
+        } else {
+            content = src.content;
+        }
+
         midiNotes = src.midiNotes;
         midiCCData = src.midiCCData;
         midiPitchBendData = src.midiPitchBendData;
         chordAnnotations = src.chordAnnotations;
         nextChordGroupId = src.nextChordGroupId;
-        warpEnabled = src.warpEnabled;
-        timeStretchMode = src.timeStretchMode;
-        warpMarkers = src.warpMarkers;
-        autoTempo = src.autoTempo;
-        autoPitch = src.autoPitch;
-        analogPitch = src.analogPitch;
-        autoPitchMode = src.autoPitchMode;
-        pitchChange = src.pitchChange;
-        transpose = src.transpose;
-        autoDetectBeats = src.autoDetectBeats;
-        beatSensitivity = src.beatSensitivity;
-        isReversed = src.isReversed;
         grooveTemplate = src.grooveTemplate;
         grooveStrength = src.grooveStrength;
     }
@@ -597,17 +858,27 @@ struct ClipInfo {
     /// ghost-clip propagation skip the deep sibling copies (and the sibling
     /// notifications) when an edit only touched per-instance state.
     bool sharedContentEquals(const ClipInfo& src) const {
-        return name == src.name && content == src.content && midiNotes == src.midiNotes &&
-               midiCCData == src.midiCCData && midiPitchBendData == src.midiPitchBendData &&
-               chordAnnotations == src.chordAnnotations &&
-               nextChordGroupId == src.nextChordGroupId && warpEnabled == src.warpEnabled &&
-               timeStretchMode == src.timeStretchMode && warpMarkers == src.warpMarkers &&
-               autoTempo == src.autoTempo && autoPitch == src.autoPitch &&
-               analogPitch == src.analogPitch && autoPitchMode == src.autoPitchMode &&
-               pitchChange == src.pitchChange && transpose == src.transpose &&
-               autoDetectBeats == src.autoDetectBeats && beatSensitivity == src.beatSensitivity &&
-               isReversed == src.isReversed && grooveTemplate == src.grooveTemplate &&
-               grooveStrength == src.grooveStrength;
+        if (name != src.name || midiNotes != src.midiNotes || midiCCData != src.midiCCData ||
+            midiPitchBendData != src.midiPitchBendData ||
+            chordAnnotations != src.chordAnnotations || nextChordGroupId != src.nextChordGroupId ||
+            grooveTemplate != src.grooveTemplate || grooveStrength != src.grooveStrength) {
+            return false;
+        }
+
+        if (!isAudio() || !src.isAudio())
+            return content == src.content;
+
+        const auto& a = audio();
+        const auto& b = src.audio();
+        if (a.events.size() != b.events.size() || a.nextEventId != b.nextEventId ||
+            a.takes != b.takes || a.currentTakeIndex != b.currentTakeIndex || a.comp != b.comp ||
+            a.compActive != b.compActive) {
+            return false;
+        }
+        for (size_t i = 0; i < a.events.size(); ++i)
+            if (!sharedEventFieldsEqual(a.events[i], b.events[i]))
+                return false;
+        return true;
     }
 
     /// Derive startTime/length from placement beats using the given BPM.
@@ -622,135 +893,9 @@ struct ClipInfo {
         }
     }
 
-    // =========================================================================
-    // Beats-first source-domain setters (audio clips)
-    //
-    // The ONLY supported paths for writing offset / loopStart / loopLength.
-    // They take BEATS and derive the seconds mirror via the source's
-    // interpretation BPM (during the transitional period while the seconds
-    // fields still exist). When all readers are migrated off the seconds
-    // fields, those fields go away and the derive step goes with them.
-    //
-    // Deliberately no `setXxxSeconds` counterpart: a parallel seconds API
-    // would just keep call sites writing seconds and quietly recompute beats,
-    // which is the leak we're trying to close. Callers that have seconds
-    // convert at the call site: beats = seconds × interpBpm / 60.
-    // =========================================================================
-
-    void setSourceOffsetBeats(double beats, double interpBpm) {
-        offsetBeats = juce::jmax(0.0, beats);
-        if (interpBpm > 0.0)
-            offset = offsetBeats * 60.0 / interpBpm;
-    }
-
-    void setLoopStartBeats(double beats, double interpBpm) {
-        loopStartBeats = juce::jmax(0.0, beats);
-        if (interpBpm > 0.0)
-            loopStart = loopStartBeats * 60.0 / interpBpm;
-    }
-
-    void setLoopLengthBeats(double beats, double interpBpm) {
-        loopLengthBeats = juce::jmax(0.0, beats);
-        if (interpBpm > 0.0)
-            loopLength = loopLengthBeats * 60.0 / interpBpm;
-    }
-
     /// Get end position in beats without BPM conversion (beats are always valid for MIDI)
     double getEndBeatsRaw() const {
         return placement.endBeat();
-    }
-
-    /// Convert source-time to timeline-time (speed-factor semantics: timeline = source /
-    /// speedRatio)
-    double sourceToTimeline(double sourceTime) const {
-        return sourceTime / speedRatio;  // Faster = shorter timeline
-    }
-
-    /// Convert timeline-time to source-time (speed-factor semantics: source = timeline *
-    /// speedRatio)
-    double timelineToSource(double timelineTime) const {
-        return timelineTime * speedRatio;  // Timeline × speed = source distance
-    }
-
-    /// Effective source length: loopLength if set, otherwise derived from timeline placement.
-    double getSourceLength(double projectBPM) const {
-        return loopLength > 0.0 ? loopLength : timelineToSource(getTimelineLength(projectBPM));
-    }
-
-    /// Compatibility fallback for callers that still do not have project BPM nearby.
-    double getSourceLength() const {
-        return loopLength > 0.0 ? loopLength : timelineToSource(length);
-    }
-
-    /// Source length expressed in timeline seconds
-    double getSourceLengthOnTimeline(double projectBPM) const {
-        return sourceToTimeline(getSourceLength(projectBPM));
-    }
-
-    /// Compatibility fallback for callers that still do not have project BPM nearby.
-    double getSourceLengthOnTimeline() const {
-        return sourceToTimeline(getSourceLength());
-    }
-
-    /// Loop phase: offset relative to loopStart (meaningful in loop mode)
-    double getLoopPhase() const {
-        return offset - loopStart;
-    }
-
-    /// TE offset in timeline seconds (source / speedRatio).
-    /// TE expects offset in the same time domain as clip start (timeline seconds).
-    /// Looped: phase within the loop region (offset - loopStart).
-    /// Non-looped: raw trim point in the source file.
-    /// For autoTempo clips, offsetBeats is authoritative and converted to
-    /// timeline seconds via projectBPM at the TE boundary.
-    double getTeOffset(bool looped, double projectBPM = 0.0) const {
-        if (autoTempo && isValidBpm(projectBPM)) {
-            // Convert source beats to timeline seconds for TE
-            if (looped)
-                return (offsetBeats - loopStartBeats) * 60.0 / projectBPM;
-            return offsetBeats * 60.0 / projectBPM;
-        }
-        if (looped)
-            return sourceToTimeline(offset - loopStart);
-        return sourceToTimeline(offset);
-    }
-
-    /// TE loop start in timeline seconds (source / speedRatio)
-    double getTeLoopStart() const {
-        return sourceToTimeline(loopStart);
-    }
-
-    /// TE loop end in timeline seconds (source / speedRatio)
-    double getTeLoopEnd(double projectBPM) const {
-        return sourceToTimeline(loopStart + getSourceLength(projectBPM));
-    }
-
-    /// Compatibility fallback for callers that still do not have project BPM nearby.
-    double getTeLoopEnd() const {
-        return sourceToTimeline(loopStart + getSourceLength());
-    }
-
-    /// Sync loopStart to match offset (keeps loop region anchored to playback start)
-    void syncLoopStartToOffset() {
-        loopStart = offset;
-    }
-
-    /// Set loopLength from a timeline-time extent (converts to source-time)
-    void setLoopLengthFromTimeline(double timelineLength) {
-        loopLength = timelineToSource(timelineLength);
-    }
-
-    // =========================================================================
-    // Auto-tempo helpers
-    // =========================================================================
-
-    /// Get effective loop length for display/operations
-    /// Returns beat length when autoTempo=true, time length otherwise
-    double getEffectiveLoopLength() const {
-        if (autoTempo) {
-            return loopLengthBeats;
-        }
-        return loopLength;
     }
 
     /// Convert clip length to beats (using current tempo)
@@ -841,37 +986,39 @@ struct ClipInfo {
     /// placement.lengthBeats; use this (not getTimelineLength) for the slot
     /// progress overlay so the bar and the playhead stay consistent.
     double getTimelineLoopLength(double projectBPM) const {
-        if (loopEnabled && loopLengthBeats > 0.0 && isValidBpm(projectBPM)) {
-            return loopLengthBeats * 60.0 / projectBPM;
+        if (loopEnabled && isValidBpm(projectBPM)) {
+            // MIDI keeps its loop length in clip beats; an audio clip's is the
+            // beat view of its event's source region.
+            const auto* event = primaryEvent();
+            const double beats = event != nullptr ? event->loopLengthBeats() : loopLengthBeats;
+            if (beats > 0.0)
+                return beats * 60.0 / projectBPM;
         }
         return getTimelineLength(projectBPM);
     }
-
-    /// Source-domain seconds for the loop start. For autoTempo clips, computed
-    /// live from loopStartBeats × 60 / source interpretation BPM. For non-autoTempo clips,
-    /// returns the stored field.
-    double getSourceLoopStart() const {
-        if (autoTempo && audio().interpretation.bpm > 0.0) {
-            return loopStartBeats * 60.0 / audio().interpretation.bpm;
-        }
-        return loopStart;
-    }
-
-    /// Source-domain seconds for the loop length.
-    double getSourceLoopLength() const {
-        if (autoTempo && audio().interpretation.bpm > 0.0 && loopLengthBeats > 0.0) {
-            return loopLengthBeats * 60.0 / audio().interpretation.bpm;
-        }
-        return loopLength;
-    }
-
-    /// Source-domain seconds for the read-position offset.
-    double getSourceOffset() const {
-        if (autoTempo && audio().interpretation.bpm > 0.0) {
-            return offsetBeats * 60.0 / audio().interpretation.bpm;
-        }
-        return offset;
-    }
 };
+
+/// Primary audio event of a clip, null-safe on both the clip pointer and the
+/// clip's content type. Most call sites hold a `ClipInfo*` from a lookup that
+/// can miss, and MIDI clips have no events at all.
+inline AudioEvent* primaryEventOf(ClipInfo* clip) {
+    return clip != nullptr ? clip->primaryEvent() : nullptr;
+}
+inline const AudioEvent* primaryEventOf(const ClipInfo* clip) {
+    return clip != nullptr ? clip->primaryEvent() : nullptr;
+}
+
+/// Read-only view of a clip's audio event for code that only ever reads.
+///
+/// Phase A of #1901 gives every audio clip exactly one event spanning it, so
+/// readers that used to reach for a clip-level audio field can reach for this
+/// instead. A MIDI clip yields a default event, which keeps those readers total
+/// without a null branch. Anything that needs to handle several events per clip
+/// iterates ClipInfo::events() rather than calling this.
+inline const AudioEvent& audioEventRef(const ClipInfo& clip) {
+    static const AudioEvent kNoEvent{};
+    const auto* event = clip.primaryEvent();
+    return event != nullptr ? *event : kNoEvent;
+}
 
 }  // namespace magda

--- a/magda/daw/core/ClipInfo.hpp
+++ b/magda/daw/core/ClipInfo.hpp
@@ -676,6 +676,17 @@ struct ClipInfo {
     double loopStartBeats = 0.0;
     double loopLengthBeats = 0.0;
 
+    /// Loop length in beats for whichever content the clip holds.
+    ///
+    /// A MIDI clip keeps it in the field above. An audio clip's loop is a
+    /// source region in samples, so its beat length is a view derived through
+    /// the event's interpretation. Reading only one of the two silently
+    /// returns zero for the other, which reads as "not looping".
+    double loopLengthInBeats() const {
+        const auto* event = primaryEvent();
+        return event != nullptr ? event->loopLengthBeats() : loopLengthBeats;
+    }
+
     // =========================================================================
     // Clip-level placement and mix
     //

--- a/magda/daw/core/ClipInfo.hpp
+++ b/magda/daw/core/ClipInfo.hpp
@@ -655,7 +655,10 @@ struct ClipInfo {
         return isAudio() ? audio().primaryEvent() : nullptr;
     }
 
-    /// Every audio event, empty for MIDI clips.
+    /// Every audio event. Audio clips only: this is a checked variant access
+    /// and throws for MIDI, deliberately, so a caller that has not established
+    /// the content type fails loudly instead of writing into a discarded list.
+    /// Use primaryEvent(), which returns nullptr for MIDI, when unsure.
     std::vector<AudioEvent>& events() {
         return audio().events;
     }

--- a/magda/daw/core/ClipInfo.hpp
+++ b/magda/daw/core/ClipInfo.hpp
@@ -187,6 +187,25 @@ struct AudioEvent {
     int64_t loopStartSamples = 0;
     int64_t loopLengthSamples = 0;  // 0 = derive from the event's own length
 
+    /// Re-express the source-domain positions at a different sample rate.
+    ///
+    /// They are counts at the source's own rate, so whenever that rate changes
+    /// under them (an unresolved source being probed, a relink onto a file at
+    /// another rate, a swap onto a different source for the same audio) the
+    /// same counts would otherwise mean a different instant in the file.
+    void rescaleSourcePositions(double oldRate, double newRate) {
+        if (oldRate <= 0.0 || newRate <= 0.0 || std::abs(newRate - oldRate) < 1.0e-9)
+            return;
+
+        const double ratio = newRate / oldRate;
+        const auto scale = [ratio](int64_t samples) {
+            return static_cast<int64_t>(std::llround(static_cast<double>(samples) * ratio));
+        };
+        sourceAnchorSamples = scale(sourceAnchorSamples);
+        loopStartSamples = scale(loopStartSamples);
+        loopLengthSamples = scale(loopLengthSamples);
+    }
+
     // ---- Interpretation (seeded from the Source, then owned by the user) ---
 
     double interpBpm = 0.0;

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -3478,7 +3478,7 @@ std::vector<ClipId> ClipManager::pasteFromClipboardBeats(double pasteBeat, Track
                         // Reset extended loops to base loop length for
                         // session→session pastes
                         const double bpm = currentProjectTempoOrDefault();
-                        const double loopBeats = clipData.loopLengthBeats;
+                        const double loopBeats = clipData.loopLengthInBeats();
                         const auto* srcLoopEvent = clipData.primaryEvent();
                         if (loopBeats > 0.0 && clipData.lengthBeats > loopBeats) {
                             ClipOperations::setTimelinePlacement(*newClip,

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -226,7 +226,6 @@ void ClipManager::repointEventsToSource(SourceId from, SourceId to) {
     // different rates, so the sample counts have to move with the events.
     const double fromRate = sourceRateOf(from);
     const double toRate = sourceRateOf(to);
-    const double ratio = (fromRate > 0.0 && toRate > 0.0) ? toRate / fromRate : 1.0;
 
     for (auto& [clipId, clip] : clips_) {
         if (!clip.isAudio())
@@ -237,14 +236,7 @@ void ClipManager::repointEventsToSource(SourceId from, SourceId to) {
             if (event.sourceId != from)
                 continue;
 
-            if (std::abs(ratio - 1.0) > 1.0e-9) {
-                const auto rescale = [ratio](int64_t samples) {
-                    return static_cast<int64_t>(std::llround(static_cast<double>(samples) * ratio));
-                };
-                event.sourceAnchorSamples = rescale(event.sourceAnchorSamples);
-                event.loopStartSamples = rescale(event.loopStartSamples);
-                event.loopLengthSamples = rescale(event.loopLengthSamples);
-            }
+            event.rescaleSourcePositions(fromRate, toRate);
             event.sourceId = to;
             touched = true;
         }
@@ -258,11 +250,6 @@ void ClipManager::rescaleEventsForSourceRate(SourceId sourceId, double oldRate, 
     if (sourceId == INVALID_SOURCE_ID || oldRate <= 0.0 || newRate <= 0.0)
         return;
 
-    const double ratio = newRate / oldRate;
-    const auto rescale = [ratio](int64_t samples) {
-        return static_cast<int64_t>(std::llround(static_cast<double>(samples) * ratio));
-    };
-
     for (auto& [clipId, clip] : clips_) {
         if (!clip.isAudio())
             continue;
@@ -272,9 +259,7 @@ void ClipManager::rescaleEventsForSourceRate(SourceId sourceId, double oldRate, 
             if (event.sourceId != sourceId)
                 continue;
 
-            event.sourceAnchorSamples = rescale(event.sourceAnchorSamples);
-            event.loopStartSamples = rescale(event.loopStartSamples);
-            event.loopLengthSamples = rescale(event.loopLengthSamples);
+            event.rescaleSourcePositions(oldRate, newRate);
             touched = true;
         }
 

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -208,6 +208,81 @@ ClipManager& ClipManager::getInstance() {
     return instance;
 }
 
+ClipManager::ClipManager() {
+    // A source's positions are sample counts at its own rate. Until the file is
+    // probed that rate is only the nominal guess, so resolving it (or relinking
+    // to a file at another rate) has to move the counts to keep the same time.
+    SourcePool::getInstance().setRateChangeHandler(
+        [this](SourceId sourceId, double oldRate, double newRate) {
+            rescaleEventsForSourceRate(sourceId, oldRate, newRate);
+        });
+}
+
+void ClipManager::repointEventsToSource(SourceId from, SourceId to) {
+    if (from == to || from == INVALID_SOURCE_ID || to == INVALID_SOURCE_ID)
+        return;
+
+    // The two sources describe the same file but may have been probed at
+    // different rates, so the sample counts have to move with the events.
+    const double fromRate = sourceRateOf(from);
+    const double toRate = sourceRateOf(to);
+    const double ratio = (fromRate > 0.0 && toRate > 0.0) ? toRate / fromRate : 1.0;
+
+    for (auto& [clipId, clip] : clips_) {
+        if (!clip.isAudio())
+            continue;
+
+        bool touched = false;
+        for (auto& event : clip.audio().events) {
+            if (event.sourceId != from)
+                continue;
+
+            if (std::abs(ratio - 1.0) > 1.0e-9) {
+                const auto rescale = [ratio](int64_t samples) {
+                    return static_cast<int64_t>(std::llround(static_cast<double>(samples) * ratio));
+                };
+                event.sourceAnchorSamples = rescale(event.sourceAnchorSamples);
+                event.loopStartSamples = rescale(event.loopStartSamples);
+                event.loopLengthSamples = rescale(event.loopLengthSamples);
+            }
+            event.sourceId = to;
+            touched = true;
+        }
+
+        if (touched)
+            notifyClipPropertyChanged(clipId);
+    }
+}
+
+void ClipManager::rescaleEventsForSourceRate(SourceId sourceId, double oldRate, double newRate) {
+    if (sourceId == INVALID_SOURCE_ID || oldRate <= 0.0 || newRate <= 0.0)
+        return;
+
+    const double ratio = newRate / oldRate;
+    const auto rescale = [ratio](int64_t samples) {
+        return static_cast<int64_t>(std::llround(static_cast<double>(samples) * ratio));
+    };
+
+    for (auto& [clipId, clip] : clips_) {
+        if (!clip.isAudio())
+            continue;
+
+        bool touched = false;
+        for (auto& event : clip.audio().events) {
+            if (event.sourceId != sourceId)
+                continue;
+
+            event.sourceAnchorSamples = rescale(event.sourceAnchorSamples);
+            event.loopStartSamples = rescale(event.loopStartSamples);
+            event.loopLengthSamples = rescale(event.loopLengthSamples);
+            touched = true;
+        }
+
+        if (touched)
+            notifyClipPropertyChanged(clipId);
+    }
+}
+
 // ============================================================================
 // Clip Creation
 // ============================================================================

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -32,44 +32,55 @@ double currentProjectTempoOrDefault() {
     return isValidBpm(bpm) ? bpm : DEFAULT_BPM;
 }
 
-bool sourceInterpretationBpmLooksDefaulted(const ClipInfo& clip, double projectBPM) {
-    if (clip.audio().interpretation.bpm <= 0.0)
+/// Source seconds the event reads: its loop region when one is set, otherwise
+/// whatever its timeline extent asks for.
+double eventSourceLength(const ClipInfo& clip, const AudioEvent& event, double projectBPM) {
+    return event.sourceLengthSeconds(clip.getTimelineLength(projectBPM));
+}
+
+bool interpretationBpmLooksDefaulted(const ClipInfo& clip, const AudioEvent& event,
+                                     double projectBPM) {
+    if (event.interpBpm <= 0.0)
         return true;
-    if (projectBPM <= 0.0 || std::abs(clip.audio().interpretation.bpm - projectBPM) >= 0.1)
+    if (projectBPM <= 0.0 || std::abs(event.interpBpm - projectBPM) >= 0.1)
         return false;
 
-    const double sourceDuration = clip.getSourceLength(projectBPM);
-    if (sourceDuration <= 0.0 || clip.audio().interpretation.totalBeats <= 0.0)
+    const double sourceDuration = eventSourceLength(clip, event, projectBPM);
+    if (sourceDuration <= 0.0 || event.interpTotalBeats <= 0.0)
         return true;
 
     const double projectDefaultBeats = sourceDuration * projectBPM / 60.0;
-    return std::abs(clip.audio().interpretation.totalBeats - projectDefaultBeats) < 0.01;
+    return std::abs(event.interpTotalBeats - projectDefaultBeats) < 0.01;
 }
 
 bool seedSourceMetadataFromCachedDetection(ClipInfo& clip, double projectBPM) {
-    if (!clip.isAudio() || clip.audio().source.filePath.isEmpty() ||
-        !sourceInterpretationBpmLooksDefaulted(clip, projectBPM)) {
+    auto* event = clip.primaryEvent();
+    if (event == nullptr || event->sourceFilePath().isEmpty() ||
+        !interpretationBpmLooksDefaulted(clip, *event, projectBPM)) {
         return false;
     }
 
+    const auto filePath = event->sourceFilePath();
     auto& thumbs = AudioThumbnailManager::getInstance();
-    double cachedBPM = thumbs.getCachedBPM(clip.audio().source.filePath);
+    double cachedBPM = thumbs.getCachedBPM(filePath);
     if (cachedBPM <= 0.0)
         return false;
 
-    clip.audio().interpretation.bpm = cachedBPM;
+    event->interpBpm = cachedBPM;
     double fileDuration = 0.0;
-    if (juce::File(clip.audio().source.filePath).existsAsFile()) {
-        if (auto* thumbnail = thumbs.getThumbnail(clip.audio().source.filePath)) {
+    if (juce::File(filePath).existsAsFile()) {
+        if (auto* thumbnail = thumbs.getThumbnail(filePath)) {
             fileDuration = thumbnail->getTotalLength();
         }
     }
     if (fileDuration <= 0.0)
-        fileDuration = clip.getSourceLength(projectBPM);
+        fileDuration = eventSourceLength(clip, *event, projectBPM);
     if (fileDuration > 0.0) {
-        if (clip.audio().source.durationSeconds <= 0.0)
-            clip.audio().source.durationSeconds = fileDuration;
-        clip.audio().interpretation.totalBeats = fileDuration * cachedBPM / 60.0;
+        if (auto* source = SourcePool::getInstance().getMutable(event->sourceId);
+            source != nullptr && source->durationSeconds <= 0.0) {
+            source->durationSeconds = fileDuration;
+        }
+        event->interpTotalBeats = fileDuration * cachedBPM / 60.0;
     }
 
     return true;
@@ -263,14 +274,14 @@ ClipId ClipManager::createAudioClipBeats(TrackId trackId, double startBeats, dou
     } else {
         clip.colour = juce::Colour(Config::getDefaultColour(static_cast<int>(clips_.size())));
     }
-    clip.audio().source.filePath = audioFilePath;
-    // Don't seed source.durationSeconds from the clip's timeline length —
-    // they're different quantities. ClipSynchronizer's setSourceMetadata
-    // populates this from TE's loopInfo once the engine clip exists; readers
-    // (thumbnail renderer, inspector panels) fall back to the
-    // AudioThumbnailManager when the field is still zero.
-    clip.offset = 0.0;
-    clip.speedRatio = 1.0;
+    // One event spanning the clip. The pooled Source carries the file facts;
+    // the event carries how they are interpreted.
+    AudioEvent event;
+    event.sourceId = SourcePool::getInstance().acquire(audioFilePath);
+    event.speedRatio = 1.0;
+    event.seedInterpretationFromSource();
+    auto& newEvent = clip.audio().addEvent(event);
+
     // New audio clips default to AUTO-XFADE (#1499): overlaps with other
     // auto-crossfade audio clips play as crossfades instead of trimming.
     clip.autoCrossfade = Config::getInstance().getAutoCrossfadeByDefault();
@@ -280,9 +291,9 @@ ClipId ClipManager::createAudioClipBeats(TrackId trackId, double startBeats, dou
     clip.setPlacementBeats(startBeats, lengthBeats);
     clip.deriveTimesFromBeats(bpm);
 
-    // Set loopStart to offset (0), loopLength to the clip's source extent
-    clip.loopStart = 0.0;
-    clip.setLoopLengthFromTimeline(clip.getTimelineLength(bpm));
+    // Read from the top of the file, over a region as long as the clip.
+    newEvent.loopStartSamples = 0;
+    newEvent.setLoopLengthSeconds(newEvent.timelineToSource(clip.getTimelineLength(bpm)));
 
     // Scanner output in the media DB is a hint, but user-saved source
     // interpretation is explicit library metadata and should restore when the
@@ -293,63 +304,65 @@ ClipId ClipManager::createAudioClipBeats(TrackId trackId, double startBeats, dou
             std::filesystem::path(audioFilePath.toStdString()));
         if (savedMetadata) {
             if (savedMetadata->bpm && isValidBpm(*savedMetadata->bpm)) {
-                clip.audio().interpretation.bpm = *savedMetadata->bpm;
+                newEvent.interpBpm = *savedMetadata->bpm;
             }
             if (savedMetadata->totalBeats && *savedMetadata->totalBeats > 0.0) {
-                clip.audio().interpretation.totalBeats = *savedMetadata->totalBeats;
-                clip.audio().interpretation.totalBeatsLocked = true;
+                newEvent.interpTotalBeats = *savedMetadata->totalBeats;
+                newEvent.interpTotalBeatsLocked = true;
             }
             if (savedMetadata->keyRoot && !savedMetadata->keyRoot->empty()) {
-                clip.audio().interpretation.keyRoot = *savedMetadata->keyRoot;
+                newEvent.keyRoot = *savedMetadata->keyRoot;
             }
             if (savedMetadata->keyScale && !savedMetadata->keyScale->empty()) {
-                clip.audio().interpretation.keyScale = *savedMetadata->keyScale;
+                newEvent.keyScale = *savedMetadata->keyScale;
             }
         }
         const auto savedMarkers = magda::media::getUserWarpMarkersForFile(
             std::filesystem::path(audioFilePath.toStdString()));
         if (savedMarkers) {
-            clip.warpMarkers.clear();
-            clip.warpMarkers.reserve(savedMarkers->size());
+            newEvent.warpMarkers.clear();
+            newEvent.warpMarkers.reserve(savedMarkers->size());
             for (const auto& marker : *savedMarkers) {
-                clip.warpMarkers.push_back({marker.sourceSec, marker.beat});
+                newEvent.warpMarkers.push_back({marker.sourceSec, marker.beat});
             }
-            clip.warpEnabled = true;
+            newEvent.warpEnabled = true;
         }
     }
 
-    if (view == ClipView::Arrangement) {
-        clips_[clip.id] = clip;
-    } else {
-        // Session clips loop by default and follow project tempo
+    if (view == ClipView::Session) {
+        // Session clips loop by default and follow project tempo. Leaving the
+        // loop region at zero length means "the whole source" until Tracktion
+        // loopInfo populates the interpretation.
         clip.loopEnabled = true;
-        clip.autoTempo = true;
-        // Source loop beats live in the source-beat domain. Use 0 as "full
-        // source" until Tracktion loopInfo populates source interpretation metadata.
-        clip.loopLengthBeats = 0.0;
-        clips_[clip.id] = clip;
+        newEvent.autoTempo = true;
+        newEvent.loopLengthSamples = 0;
     }
+    clips_[clip.id] = clip;
 
     if (savedMetadata && savedMetadata->beatMode) {
         auto& savedClip = clips_[clip.id];
-        savedClip.autoTempo = *savedMetadata->beatMode;
-        if (savedClip.autoTempo) {
-            savedClip.loopEnabled = true;
-            savedClip.analogPitch = false;
-            savedClip.speedRatio = 1.0;
-            if (savedClip.audio().interpretation.totalBeats > 0.0) {
-                // A beat-mode clip's natural length is its musical length (the
-                // saved beat count), not the raw audio-file duration the caller
-                // derived the placement from. At a project tempo different from the
-                // sample's, file-duration-in-beats != the real beat count, so snap
-                // both the timeline placement and the loop length to the beat count
-                // and let autoTempo stretch the audio to fit.
-                const double beats = savedClip.audio().interpretation.totalBeats;
-                savedClip.setPlacementBeats(startBeats, beats);
-                if (savedClip.loopLengthBeats <= 0.0)
-                    savedClip.loopLengthBeats = beats;
+        auto* savedEvent = savedClip.primaryEvent();
+        if (savedEvent != nullptr) {
+            savedEvent->autoTempo = *savedMetadata->beatMode;
+            if (savedEvent->autoTempo) {
+                savedClip.loopEnabled = true;
+                savedEvent->analogPitch = false;
+                savedEvent->speedRatio = 1.0;
+                if (savedEvent->interpTotalBeats > 0.0) {
+                    // A beat-mode clip's natural length is its musical length
+                    // (the saved beat count), not the raw audio-file duration
+                    // the caller derived the placement from. At a project tempo
+                    // different from the sample's, file-duration-in-beats is not
+                    // the real beat count, so snap both the timeline placement
+                    // and the loop region to the beat count and let autoTempo
+                    // stretch the audio to fit.
+                    const double beats = savedEvent->interpTotalBeats;
+                    savedClip.setPlacementBeats(startBeats, beats);
+                    if (savedEvent->loopLengthSamples <= 0 && savedEvent->interpBpm > 0.0)
+                        savedEvent->setLoopLengthSeconds(beats * 60.0 / savedEvent->interpBpm);
+                }
+                savedClip.deriveTimesFromBeats(bpm);
             }
-            savedClip.deriveTimesFromBeats(bpm);
         }
     }
 
@@ -372,17 +385,18 @@ ClipId ClipManager::createAudioClipBeats(TrackId trackId, double startBeats, dou
 
             auto& mgr = ClipManager::getInstance();
             auto* c = mgr.getClip(cid);
-            if (!c || !sourceInterpretationBpmLooksDefaulted(*c, creationProjectBPM))
+            const auto* ev = c != nullptr ? c->primaryEvent() : nullptr;
+            if (ev == nullptr || !interpretationBpmLooksDefaulted(*c, *ev, creationProjectBPM))
                 return;
 
-            double fileDuration = c->audio().source.durationSeconds;
+            double fileDuration = ev->sourceDurationSeconds();
             if (auto* thumb =
-                    AudioThumbnailManager::getInstance().getThumbnail(c->audio().source.filePath)) {
+                    AudioThumbnailManager::getInstance().getThumbnail(ev->sourceFilePath())) {
                 if (thumb->getTotalLength() > 0.0)
                     fileDuration = thumb->getTotalLength();
             }
             if (fileDuration <= 0.0)
-                fileDuration = c->getSourceLength(creationProjectBPM);
+                fileDuration = eventSourceLength(*c, *ev, creationProjectBPM);
 
             AudioClipBeatsUpdate u;
             u.interpretationBpm = detectedBPM;
@@ -390,7 +404,7 @@ ClipId ClipManager::createAudioClipBeats(TrackId trackId, double startBeats, dou
                 u.sourceDurationSeconds = fileDuration;
                 const double srcBeats = fileDuration * detectedBPM / 60.0;
                 u.interpretationTotalBeats = srcBeats;
-                if (c->autoTempo && c->loopLengthBeats <= 0.0)
+                if (ev->autoTempo && ev->loopLengthSamples <= 0)
                     u.loopLengthBeats = srcBeats;
             }
 
@@ -460,7 +474,6 @@ ClipId ClipManager::createMidiClipBeats(TrackId trackId, double startBeats, doub
         // Session clips loop by default
         clip.loopEnabled = true;
         clip.loopLengthBeats = clip.placement.lengthBeats;
-        clip.loopLength = clip.getTimelineLength(tempo);
         clips_[clip.id] = clip;
     }
 
@@ -637,7 +650,10 @@ void ClipManager::setAudioClipCurrentTake(ClipId clipId, int takeIndex) {
     a.compActive = false;
     a.comp.clear();
     a.currentTakeIndex = takeIndex;
-    a.source.filePath = a.takes[static_cast<size_t>(takeIndex)].filePath;
+    if (auto* event = a.primaryEvent()) {
+        event->sourceId =
+            SourcePool::getInstance().acquire(a.takes[static_cast<size_t>(takeIndex)].filePath);
+    }
     forceNotifyClipPropertyChanged(clipId);
     pushClipStateSnapshot("Select Take", before);
 }
@@ -786,8 +802,12 @@ void ClipManager::deleteClipTake(ClipId clipId, int takeIndex) {
         if (a.compActive && !a.comp.empty()) {
             CompService::getInstance().renderComp(clipId);  // re-renders + notifies
         } else {
-            if (newCurrent < newSize)
-                a.source.filePath = a.takes[static_cast<size_t>(newCurrent)].filePath;
+            if (newCurrent < newSize) {
+                if (auto* event = a.primaryEvent()) {
+                    event->sourceId = SourcePool::getInstance().acquire(
+                        a.takes[static_cast<size_t>(newCurrent)].filePath);
+                }
+            }
             forceNotifyClipPropertyChanged(clipId);
         }
         pushClipStateSnapshot("Delete Take", before);
@@ -860,7 +880,13 @@ bool ClipManager::editAudioClipSourceInExternalEditor(ClipId clipId, juce::Strin
         return false;
     }
 
-    const juce::File sourceFile(clip->audio().source.filePath);
+    auto* event = clip->primaryEvent();
+    if (event == nullptr) {
+        errorMessage = "The clip has no audio to edit.";
+        return false;
+    }
+
+    const juce::File sourceFile(event->sourceFilePath());
     if (!sourceFile.existsAsFile()) {
         errorMessage = "The clip source file could not be found.";
         return false;
@@ -884,10 +910,12 @@ bool ClipManager::editAudioClipSourceInExternalEditor(ClipId clipId, juce::Strin
         return false;
     }
 
-    const auto oldPath = clip->audio().source.filePath;
-    clip->audio().source.filePath = editFile.getFullPathName();
+    const auto oldPath = event->sourceFilePath();
+    // The edit is a separate file, so it gets its own pooled source rather than
+    // relinking the shared one: other clips still reference the original.
+    event->sourceId = SourcePool::getInstance().acquire(editFile.getFullPathName());
     AudioThumbnailManager::getInstance().invalidateFile(oldPath);
-    AudioThumbnailManager::getInstance().invalidateFile(clip->audio().source.filePath);
+    AudioThumbnailManager::getInstance().invalidateFile(event->sourceFilePath());
     notifyClipPropertyChanged(clipId);
     ProjectManager::getInstance().markDirty();
     ExternalEditPoller::getInstance().watch(clipId, editFile);
@@ -1125,13 +1153,18 @@ void ClipManager::resetLoopedClipLength(ClipInfo& clip) {
     if (!clip.loopEnabled)
         return;
 
-    if (clip.loopLengthBeats > 0.0) {
-        const double bpm = currentProjectTempoOrDefault();
-        ClipOperations::setBeatPlacement(clip, clip.placement.startBeat, clip.loopLengthBeats, bpm);
-    } else if (clip.loopLength > 0.0) {
-        const double bpm = currentProjectTempoOrDefault();
+    const double bpm = currentProjectTempoOrDefault();
+    const double loopBeats = clip.loopLengthBeats;
+    const auto* event = clip.primaryEvent();
+
+    if (loopBeats > 0.0) {
+        ClipOperations::setBeatPlacement(clip, clip.placement.startBeat, loopBeats, bpm);
+    } else if (event != nullptr && event->loopLengthSamples > 0) {
+        // No usable beat view (interpretation BPM unknown): fall back to the
+        // region's timeline extent.
         ClipOperations::setTimelinePlacement(clip, clip.getTimelineStart(bpm),
-                                             clip.sourceToTimeline(clip.loopLength), bpm);
+                                             event->sourceToTimeline(event->loopLengthSeconds()),
+                                             bpm);
     }
     clip.loopEnabled = false;
 }
@@ -1175,22 +1208,18 @@ void ClipManager::resizeClipBeats(ClipId clipId, double newLengthBeats, bool fro
     if (auto* clip = getClip(clipId)) {
         const double bpm = isValidBpm(tempo) ? tempo : currentProjectTempoOrDefault();
         const double newLength = newLengthBeats * 60.0 / bpm;
+        auto* event = clip->primaryEvent();
         if (fromStart) {
             ClipOperations::resizeContainerFromLeft(*clip, newLength, bpm);
-            // Non-loop mode: keep loopStart synced to offset
-            if (!clip->loopEnabled && clip->isAudio()) {
-                clip->loopStart = clip->offset;
-            }
+            // Non-loop mode: keep the region anchored at the read position
+            if (event != nullptr && !clip->loopEnabled)
+                event->loopStartSamples = event->sourceAnchorSamples;
         } else {
             ClipOperations::resizeContainerFromRight(*clip, newLength, bpm);
 
-            // In non-loop mode, clip length defines the source region — keep loopLength in sync
-            if (!clip->loopEnabled && clip->isAudio()) {
-                clip->loopLength = clip->timelineToSource(clip->getTimelineLength(bpm));
-                if (clip->autoTempo && clip->audio().interpretation.bpm > 0.0) {
-                    clip->loopLengthBeats =
-                        clip->loopLength * clip->audio().interpretation.bpm / 60.0;
-                }
+            // In non-loop mode the clip length defines the source region
+            if (event != nullptr && !clip->loopEnabled) {
+                event->setLoopLengthSeconds(event->timelineToSource(clip->getTimelineLength(bpm)));
             }
         }
         if (clip->view == ClipView::Arrangement)
@@ -1233,18 +1262,16 @@ ClipId ClipManager::splitClipAtBeat(ClipId clipId, double splitBeat, double temp
     ClipOperations::setBeatPlacement(rightClip, clip->placement.startBeat + leftLengthBeats,
                                      rightLengthBeats, bpm);
 
-    // Adjust offset for right clip (TE-aligned: offset is start position in source)
-    if (rightClip.isAudio()) {
-        // In autoTempo/warp mode, speedRatio is 1.0 but actual stretch is projectBPM/source
-        // interpretation BPM. Use the tempo ratio to convert timeline seconds to source seconds.
-        const bool useSourceBeatProcessing = clip->autoTempo || clip->warpEnabled;
-        if (useSourceBeatProcessing && clip->audio().interpretation.bpm > 0.0) {
-            double deltaBeats = leftLengthBeats;
-            rightClip.offsetBeats += deltaBeats;
-            rightClip.offset = rightClip.offsetBeats * 60.0 / clip->audio().interpretation.bpm;
-        } else {
-            rightClip.offset += leftLength * clip->speedRatio;
-        }
+    // Advance the right half's read position: it starts leftLength further into
+    // the source. In beat/warp mode speedRatio is 1.0 and the real stretch is
+    // projectBPM / interpBpm, so the delta converts through the beat domain.
+    auto* rightEvent = rightClip.primaryEvent();
+    if (rightEvent != nullptr) {
+        const bool useSourceBeatProcessing = rightEvent->autoTempo || rightEvent->warpEnabled;
+        const double sourceDelta = (useSourceBeatProcessing && rightEvent->interpBpm > 0.0)
+                                       ? leftLengthBeats * 60.0 / rightEvent->interpBpm
+                                       : leftLength * rightEvent->speedRatio;
+        rightEvent->setAnchorSeconds(rightEvent->anchorSeconds() + sourceDelta);
     }
 
     // Handle MIDI clip splitting
@@ -1298,80 +1325,38 @@ ClipId ClipManager::splitClipAtBeat(ClipId clipId, double splitBeat, double temp
     clip->name = clip->name + " L";
 
     // Sync loop region after split
-    if (clip->loopEnabled) {
-        const bool autoTempoAudio =
-            clip->isAudio() && clip->autoTempo && clip->audio().interpretation.bpm > 0.0;
-
-        if (autoTempoAudio) {
-            // TE auto-tempo arranger clips need the source loop range to stay in
-            // the original source-beat domain. The right split's offsetBeats
-            // carries the playback phase; truncating loopStartBeats to the
-            // split point makes the right-side WaveNode render silence.
-            const double srcBpm = clip->audio().interpretation.bpm;
-            clip->loopStart = clip->loopStartBeats * 60.0 / srcBpm;
-            clip->loopLength = clip->loopLengthBeats * 60.0 / srcBpm;
-            rightClip.loopStart = rightClip.loopStartBeats * 60.0 / srcBpm;
-            rightClip.loopLength = rightClip.loopLengthBeats * 60.0 / srcBpm;
-        } else {
-            // Looped clip: if the loop region is longer than the new clip length,
-            // truncate it so each half only loops over its own portion.
-            // Left clip
-            double leftLenBeats = leftLengthBeats;
-            if (clip->loopLengthBeats > leftLenBeats) {
-                clip->loopLengthBeats = leftLenBeats;
-                if (clip->isAudio()) {
-                    double srcBpm = clip->audio().interpretation.bpm > 0.0
-                                        ? clip->audio().interpretation.bpm
-                                        : bpm;
-                    clip->loopLength = clip->loopLengthBeats / srcBpm * 60.0;
+    auto* leftEvent = clip->primaryEvent();
+    if (clip->isMidi()) {
+        if (clip->loopEnabled) {
+            // Truncate each half's loop to its own portion.
+            if (clip->loopLengthBeats > leftLengthBeats)
+                clip->loopLengthBeats = leftLengthBeats;
+            if (rightClip.loopLengthBeats > rightLengthBeats)
+                rightClip.loopLengthBeats = rightLengthBeats;
+        }
+    } else if (leftEvent != nullptr && rightEvent != nullptr) {
+        if (clip->loopEnabled) {
+            // Beat-mode events keep the ORIGINAL source loop region: the right
+            // half's anchor carries the playback phase, and truncating the
+            // region to the split point makes the right side render silence.
+            if (!(leftEvent->autoTempo && leftEvent->interpBpm > 0.0)) {
+                if (leftEvent->loopLengthBeats() > leftLengthBeats)
+                    leftEvent->setLoopLengthBeats(leftLengthBeats);
+                if (rightEvent->loopLengthBeats() > rightLengthBeats) {
+                    rightEvent->setLoopLengthBeats(rightLengthBeats);
+                    rightEvent->loopStartSamples = rightEvent->sourceAnchorSamples;
                 }
             }
-
-            // Right clip
-            double rightLenBeats = rightLengthBeats;
-            if (rightClip.loopLengthBeats > rightLenBeats) {
-                rightClip.loopLengthBeats = rightLenBeats;
-                if (rightClip.isAudio()) {
-                    double srcBpm = rightClip.audio().interpretation.bpm > 0.0
-                                        ? rightClip.audio().interpretation.bpm
-                                        : bpm;
-                    if (rightClip.autoTempo && rightClip.audio().interpretation.bpm > 0.0) {
-                        rightClip.loopStartBeats = rightClip.offsetBeats;
-                        rightClip.loopStart =
-                            rightClip.loopStartBeats * 60.0 / rightClip.audio().interpretation.bpm;
-                    } else {
-                        rightClip.loopStart = rightClip.offset;
-                        rightClip.loopStartBeats = rightClip.loopStart * srcBpm / 60.0;
-                    }
-                    rightClip.loopLength = rightClip.loopLengthBeats / srcBpm * 60.0;
-                }
-            }
-        }
-    } else if (clip->isAudio()) {
-        // Non-looped audio: sync loopStart/loopLength to actual source extent
-        // Left clip: loopStart stays at original value, loopLength shrinks
-        clip->loopLength = clip->timelineToSource(clip->getTimelineLength(bpm));
-        clip->loopLengthBeats =
-            clip->loopLength *
-            (clip->audio().interpretation.bpm > 0.0 ? clip->audio().interpretation.bpm : bpm) /
-            60.0;
-
-        // Right clip: loopStart must match offset so TE's loop range covers the
-        // correct source region (otherwise offset falls outside the loop range,
-        // causing TE to wrap and produce doubled transients at the split point)
-        if (rightClip.autoTempo && rightClip.audio().interpretation.bpm > 0.0) {
-            rightClip.loopStartBeats = rightClip.offsetBeats;
-            rightClip.loopStart =
-                rightClip.loopStartBeats * 60.0 / rightClip.audio().interpretation.bpm;
         } else {
-            rightClip.loopStart = rightClip.offset;
+            // Non-looped: each half's source region is exactly what it plays.
+            // The right half's region must start at its anchor, or the engine
+            // wraps and doubles the transient at the split point.
+            leftEvent->setLoopLengthSeconds(
+                leftEvent->timelineToSource(clip->getTimelineLength(bpm)));
+            rightEvent->loopStartSamples = rightEvent->sourceAnchorSamples;
+            rightEvent->setLoopLengthSeconds(
+                rightEvent->timelineToSource(rightClip.getTimelineLength(bpm)));
         }
-        rightClip.loopLength = rightClip.timelineToSource(rightClip.getTimelineLength(bpm));
-        double srcBpm =
-            rightClip.audio().interpretation.bpm > 0.0 ? rightClip.audio().interpretation.bpm : bpm;
-        if (!rightClip.autoTempo)
-            rightClip.loopStartBeats = rightClip.loopStart * srcBpm / 60.0;
-        rightClip.loopLengthBeats = rightClip.loopLength * srcBpm / 60.0;
     }
 
     // Add right clip to the clip pool
@@ -1449,32 +1434,30 @@ void ClipManager::setClipLoopEnabled(ClipId clipId, bool enabled, double project
         // first to turn looping off. Emit a property-changed notification
         // anyway so callers that flipped their local toggle optimistically
         // re-read the (unchanged) model and revert.
-        if (!enabled && clip->autoTempo) {
+        auto* event = clip->primaryEvent();
+        if (!enabled && event != nullptr && event->autoTempo) {
             notifyClipPropertyChanged(clipId);
             return;
         }
         clip->loopEnabled = enabled;
 
         // When enabling loop on MIDI clips, capture current length as loop region
-        // Populate both beat and seconds fields so all existing code paths work
         if (enabled && clip->isMidi()) {
             double bpm = isValidBpm(projectBPM) ? projectBPM : currentProjectTempoOrDefault();
-            if (clip->loopLengthBeats <= 0.0) {
+            if (clip->loopLengthBeats <= 0.0)
                 clip->loopLengthBeats = clip->getLengthInBeats(bpm);
-            }
-            clip->loopLength = clip->loopLengthBeats * 60.0 / bpm;
         }
 
-        // When enabling loop on audio clips, transfer offset → loopStart
-        // The user's current offset becomes the loop start point (phase resets to 0)
-        if (enabled && clip->isAudio() && clip->audio().source.filePath.isNotEmpty()) {
-            clip->loopStart = clip->offset;
+        // When enabling loop on audio, the current read position becomes the
+        // loop start (phase resets to 0).
+        if (enabled && event != nullptr && event->sourceFilePath().isNotEmpty()) {
+            event->loopStartSamples = event->sourceAnchorSamples;
 
-            // Ensure loopLength is set (preserves source extent in loop mode)
-            if (clip->loopLength <= 0.0) {
+            // Ensure the region has a length (preserves the source extent)
+            if (event->loopLengthSamples <= 0) {
                 const double bpm =
                     isValidBpm(projectBPM) ? projectBPM : currentProjectTempoOrDefault();
-                clip->setLoopLengthFromTimeline(clip->getTimelineLength(bpm));
+                event->setLoopLengthSeconds(event->timelineToSource(clip->getTimelineLength(bpm)));
             }
 
             sanitizeAudioClip(*clip);
@@ -1497,20 +1480,21 @@ void ClipManager::setClipLoopEnabled(ClipId clipId, bool enabled, double project
         // after a short loop region. Set the length explicitly to "file
         // content from offset on", routed through setPlacementBeats so the
         // beat domain stays authoritative.
-        if (!enabled && clip->isAudio() && clip->audio().source.filePath.isNotEmpty()) {
-            clip->loopStart = clip->offset;
+        if (!enabled && event != nullptr && event->sourceFilePath().isNotEmpty()) {
+            event->loopStartSamples = event->sourceAnchorSamples;
 
             double fileDuration = 0.0;
-            if (auto* thumbnail = AudioThumbnailManager::getInstance().getThumbnail(
-                    clip->audio().source.filePath)) {
+            if (auto* thumbnail =
+                    AudioThumbnailManager::getInstance().getThumbnail(event->sourceFilePath())) {
                 fileDuration = thumbnail->getTotalLength();
             }
             if (fileDuration <= 0.0)
-                fileDuration = clip->audio().source.durationSeconds;
+                fileDuration = event->sourceDurationSeconds();
 
-            const double speed = clip->speedRatio > 0.0 ? clip->speedRatio : 1.0;
+            const double speed = event->speedRatio > 0.0 ? event->speedRatio : 1.0;
             if (fileDuration > 0.0) {
-                const double availableSource = juce::jmax(0.0, fileDuration - clip->offset);
+                const double availableSource =
+                    juce::jmax(0.0, fileDuration - event->anchorSeconds());
                 const double newTimelineLength =
                     juce::jmax(ClipInfo::MIN_CLIP_LENGTH, availableSource / speed);
                 const double bpm =
@@ -1577,11 +1561,11 @@ void ClipManager::setClipFollowActionLoopCount(ClipId clipId, int loopCount) {
 }
 
 void ClipManager::setClipWarpEnabled(ClipId clipId, bool enabled) {
-    if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio() && clip->warpEnabled != enabled) {
-            clip->warpEnabled = enabled;
+    if (auto* event = primaryEventOf(getClip(clipId))) {
+        if (event->warpEnabled != enabled) {
+            event->warpEnabled = enabled;
             if (enabled)
-                clip->analogPitch = false;  // Analog pitch is incompatible with warp
+                event->analogPitch = false;  // Analog pitch is incompatible with warp
             notifyClipPropertyChanged(clipId);
         }
     }
@@ -1596,8 +1580,11 @@ void ClipManager::setAutoTempo(ClipId clipId, bool enabled, double bpm) {
             ClipOperations::setAutoTempo(*clip, enabled, bpm);
 
             // Ensure time-stretching is enabled when beat mode is on
-            if (enabled && clip->timeStretchMode == time_stretch_mode::kDisabled)
-                clip->timeStretchMode = time_stretch_mode::kSignalsmith;
+            if (auto* event = clip->primaryEvent();
+                enabled && event != nullptr &&
+                event->timeStretchMode == time_stretch_mode::kDisabled) {
+                event->timeStretchMode = time_stretch_mode::kSignalsmith;
+            }
 
             // Issue #1157: ClipOperations::setAutoTempo already wrote
             // lengthBeats from clip.length × bpm / 60 (the legitimate
@@ -1616,15 +1603,8 @@ void ClipManager::setOffset(ClipId clipId, double offset) {
         if (clip->isMidi()) {
             // MIDI phase lives in midiOffset (beats) — caller passes beats directly
             clip->midiOffset = juce::jmax(0.0, offset);
-        } else {
-            if (clip->autoTempo) {
-                const double interpBpm =
-                    clip->audio().interpretation.bpm > 0.0 ? clip->audio().interpretation.bpm : 0.0;
-                const double beats = interpBpm > 0.0 ? offset * interpBpm / 60.0 : 0.0;
-                clip->setSourceOffsetBeats(beats, interpBpm);
-            } else {
-                clip->offset = juce::jmax(0.0, offset);
-            }
+        } else if (auto* event = clip->primaryEvent()) {
+            event->setAnchorSeconds(offset);
             sanitizeAudioClip(*clip);
         }
         notifyClipPropertyChanged(clipId);
@@ -1633,18 +1613,10 @@ void ClipManager::setOffset(ClipId clipId, double offset) {
 
 void ClipManager::setLoopPhase(ClipId clipId, double phase) {
     if (auto* clip = getClip(clipId)) {
-        const bool loopActive = clip->loopEnabled || clip->autoTempo;
-        if (clip->isAudio() && loopActive) {
-            if (clip->autoTempo) {
-                const double interpBpm =
-                    clip->audio().interpretation.bpm > 0.0 ? clip->audio().interpretation.bpm : 0.0;
-                // phase is in source seconds; offset = loopStart + phase
-                const double offsetSecs = clip->getSourceLoopStart() + phase;
-                const double beats = interpBpm > 0.0 ? offsetSecs * interpBpm / 60.0 : 0.0;
-                clip->setSourceOffsetBeats(beats, interpBpm);
-            } else {
-                clip->offset = clip->loopStart + phase;
-            }
+        auto* event = clip->primaryEvent();
+        if (event != nullptr && (clip->loopEnabled || event->autoTempo)) {
+            // phase is in source seconds, measured from the loop start
+            event->setAnchorSeconds(event->loopStartSeconds() + phase);
             sanitizeAudioClip(*clip);
             notifyClipPropertyChanged(clipId);
         }
@@ -1653,21 +1625,13 @@ void ClipManager::setLoopPhase(ClipId clipId, double phase) {
 
 void ClipManager::setLoopStart(ClipId clipId, double loopStart, double bpm) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio() && clip->autoTempo) {
-            const double interpBpm =
-                clip->audio().interpretation.bpm > 0.0 ? clip->audio().interpretation.bpm : bpm;
-            const double beats = interpBpm > 0.0 ? loopStart * interpBpm / 60.0 : 0.0;
-            clip->setLoopStartBeats(beats, interpBpm);
+        if (clip->isMidi()) {
+            const double projectBpm = isValidBpm(bpm) ? bpm : currentProjectTempoOrDefault();
+            clip->loopStartBeats =
+                projectBpm > 0.0 ? (juce::jmax(0.0, loopStart) * projectBpm) / 60.0 : 0.0;
+        } else if (auto* event = clip->primaryEvent()) {
+            event->setLoopStartSeconds(loopStart);
             sanitizeAudioClip(*clip);
-        } else {
-            clip->loopStart = juce::jmax(0.0, loopStart);
-            if (clip->isMidi()) {
-                const double projectBpm = isValidBpm(bpm) ? bpm : currentProjectTempoOrDefault();
-                clip->loopStartBeats =
-                    projectBpm > 0.0 ? (clip->loopStart * projectBpm) / 60.0 : 0.0;
-            }
-            if (clip->isAudio())
-                sanitizeAudioClip(*clip);
         }
         notifyClipPropertyChanged(clipId);
     }
@@ -1676,19 +1640,11 @@ void ClipManager::setLoopStart(ClipId clipId, double loopStart, double bpm) {
 void ClipManager::setLoopLength(ClipId clipId, double loopLength, double bpm) {
     if (auto* clip = getClip(clipId)) {
         if (clip->isMidi()) {
-            clip->loopLength = juce::jmax(0.0, loopLength);
-            // MIDI: keep loopLengthBeats in sync using project BPM
             const double projectBpm = isValidBpm(bpm) ? bpm : currentProjectTempoOrDefault();
-            clip->loopLengthBeats = (clip->loopLength * projectBpm) / 60.0;
-        } else if (clip->isAudio()) {
-            if (clip->autoTempo) {
-                const double interpBpm =
-                    clip->audio().interpretation.bpm > 0.0 ? clip->audio().interpretation.bpm : bpm;
-                const double beats = interpBpm > 0.0 ? loopLength * interpBpm / 60.0 : 0.0;
-                clip->setLoopLengthBeats(beats, interpBpm);
-            } else {
-                clip->loopLength = juce::jmax(0.0, loopLength);
-            }
+            clip->loopLengthBeats =
+                projectBpm > 0.0 ? (juce::jmax(0.0, loopLength) * projectBpm) / 60.0 : 0.0;
+        } else if (auto* event = clip->primaryEvent()) {
+            event->setLoopLengthSeconds(loopLength);
             sanitizeAudioClip(*clip);
         }
         notifyClipPropertyChanged(clipId);
@@ -1700,9 +1656,8 @@ void ClipManager::setMidiLoopStartBeats(ClipId clipId, double loopStartBeats, do
         if (!clip->isMidi())
             return;
 
-        const double projectBpm = isValidBpm(bpm) ? bpm : currentProjectTempoOrDefault();
+        juce::ignoreUnused(bpm);
         clip->loopStartBeats = juce::jmax(0.0, loopStartBeats);
-        clip->loopStart = projectBpm > 0.0 ? (clip->loopStartBeats * 60.0) / projectBpm : 0.0;
         notifyClipPropertyChanged(clipId);
     }
 }
@@ -1712,9 +1667,8 @@ void ClipManager::setMidiLoopLengthBeats(ClipId clipId, double loopLengthBeats, 
         if (!clip->isMidi())
             return;
 
-        const double projectBpm = isValidBpm(bpm) ? bpm : currentProjectTempoOrDefault();
+        juce::ignoreUnused(bpm);
         clip->loopLengthBeats = juce::jmax(0.0, loopLengthBeats);
-        clip->loopLength = projectBpm > 0.0 ? (clip->loopLengthBeats * 60.0) / projectBpm : 0.0;
         notifyClipPropertyChanged(clipId);
     }
 }
@@ -1722,36 +1676,21 @@ void ClipManager::setMidiLoopLengthBeats(ClipId clipId, double loopLengthBeats, 
 void ClipManager::relocateLoopRegion(ClipId clipId, double loopStart, double loopLength,
                                      double bpm) {
     if (auto* clip = getClip(clipId)) {
-        const double oldLoopStart = clip->getSourceLoopStart();
+        if (auto* event = clip->primaryEvent()) {
+            const double oldLoopStart = event->loopStartSeconds();
+            event->setLoopStartSeconds(loopStart);
+            event->setLoopLengthSeconds(loopLength);
 
-        if (clip->isAudio() && clip->autoTempo) {
-            const double interpBpm =
-                clip->audio().interpretation.bpm > 0.0 ? clip->audio().interpretation.bpm : bpm;
-            const double startBeats = interpBpm > 0.0 ? loopStart * interpBpm / 60.0 : 0.0;
-            const double lenBeats = interpBpm > 0.0 ? loopLength * interpBpm / 60.0 : 0.0;
-            clip->setLoopStartBeats(startBeats, interpBpm);
-            clip->setLoopLengthBeats(lenBeats, interpBpm);
+            // Composite intent: moving the region resets the phase to 0 by
+            // snapping the read position to the new loop start.
+            if (std::abs(event->loopStartSeconds() - oldLoopStart) > 1e-9)
+                event->sourceAnchorSamples = event->loopStartSamples;
 
-            // Composite intent: snap offset to new loopStart when it moved
-            const bool loopStartMoved = std::abs(clip->loopStart - oldLoopStart) > 1e-9;
-            if (loopStartMoved) {
-                clip->setSourceOffsetBeats(startBeats, interpBpm);
-            }
             sanitizeAudioClip(*clip);
-        } else {
-            clip->loopStart = juce::jmax(0.0, loopStart);
-            clip->loopLength = juce::jmax(0.0, loopLength);
-
-            if (clip->isAudio()) {
-                // Composite intent: reset phase to 0 by snapping offset to new loopStart
-                const bool loopStartMoved = std::abs(clip->loopStart - oldLoopStart) > 1e-9;
-                if (loopStartMoved)
-                    clip->offset = clip->loopStart;
-                sanitizeAudioClip(*clip);
-            } else if (clip->isMidi()) {
-                const double projectBpm = isValidBpm(bpm) ? bpm : currentProjectTempoOrDefault();
-                clip->loopLengthBeats = (clip->loopLength * projectBpm) / 60.0;
-            }
+        } else if (clip->isMidi()) {
+            const double projectBpm = isValidBpm(bpm) ? bpm : currentProjectTempoOrDefault();
+            clip->loopStartBeats = (juce::jmax(0.0, loopStart) * projectBpm) / 60.0;
+            clip->loopLengthBeats = (juce::jmax(0.0, loopLength) * projectBpm) / 60.0;
         }
 
         notifyClipPropertyChanged(clipId);
@@ -1759,8 +1698,8 @@ void ClipManager::relocateLoopRegion(ClipId clipId, double loopStart, double loo
 }
 
 void ClipManager::setLengthBeats(ClipId clipId, double newBeats, double bpm) {
-    auto* clip = getClip(clipId);
-    if (!clip || !clip->isAudio() || !clip->autoTempo || bpm <= 0.0)
+    const auto* event = primaryEventOf(getClip(clipId));
+    if (event == nullptr || !event->autoTempo || bpm <= 0.0)
         return;
 
     // Issue #1157: the beat-length slider edits USER INTENT only — how many
@@ -1778,26 +1717,22 @@ void ClipManager::recordUserBpm(ClipId clipId, double bpm) {
     if (!isValidBpm(bpm)) {
         return;
     }
-    const auto* clip = getClip(clipId);
-    if (!clip || !clip->isAudio()) {
+    const auto* event = primaryEventOf(getClip(clipId));
+    if (event == nullptr)
         return;
-    }
-    const auto& filePath = clip->audio().source.filePath;
-    if (filePath.isEmpty()) {
+    const auto filePath = event->sourceFilePath();
+    if (filePath.isEmpty())
         return;
-    }
     magda::media::setUserBpmForFile(std::filesystem::path(filePath.toStdString()), bpm);
 }
 
 void ClipManager::recordUserKey(ClipId clipId, const std::string& root) {
-    const auto* clip = getClip(clipId);
-    if (clip == nullptr || !clip->isAudio()) {
+    const auto* event = primaryEventOf(getClip(clipId));
+    if (event == nullptr)
         return;
-    }
-    const auto& filePath = clip->audio().source.filePath;
-    if (filePath.isEmpty()) {
+    const auto filePath = event->sourceFilePath();
+    if (filePath.isEmpty())
         return;
-    }
     std::optional<std::string> rootOpt;
     if (!root.empty()) {
         rootOpt = root;
@@ -1816,18 +1751,17 @@ bool ClipManager::canSaveClipToLibrary(ClipId clipId) const {
         return !clip->midiNotes.empty() || !clip->midiCCData.empty() ||
                !clip->midiPitchBendData.empty() || !clip->chordAnnotations.empty();
     }
-    if (!clip->isAudio()) {
+    const auto* event = clip->primaryEvent();
+    if (event == nullptr)
         return false;
-    }
-    const auto& filePath = clip->audio().source.filePath;
-    if (filePath.isEmpty()) {
+    const auto filePath = event->sourceFilePath();
+    if (filePath.isEmpty())
         return false;
-    }
     return juce::File(filePath).existsAsFile();
 }
 
 bool ClipManager::saveClipToLibrary(ClipId clipId,
-                                    std::optional<std::vector<ClipInfo::WarpMarker>> warpMarkers) {
+                                    std::optional<std::vector<WarpMarker>> warpMarkers) {
     auto* clip = getClip(clipId);
     if (clip == nullptr) {
         return false;
@@ -1882,13 +1816,12 @@ bool ClipManager::saveClipToLibrary(ClipId clipId,
         return true;
     }
 
-    if (!clip->isAudio()) {
+    auto* event = clip->primaryEvent();
+    if (event == nullptr)
         return false;
-    }
-    const auto& filePath = clip->audio().source.filePath;
-    if (filePath.isEmpty()) {
+    const auto filePath = event->sourceFilePath();
+    if (filePath.isEmpty())
         return false;
-    }
     const auto path = std::filesystem::path(filePath.toStdString());
     if (!magda::media::isFileIndexed(path)) {
         auto& ctx = magda::media::MediaDbContext::getInstance();
@@ -1902,24 +1835,26 @@ bool ClipManager::saveClipToLibrary(ClipId clipId,
         }
     }
 
+    // The event's interpretation is what gets promoted to library metadata:
+    // the Source only ever holds detected facts.
     std::optional<double> bpm;
-    if (isValidBpm(clip->audio().interpretation.bpm)) {
-        bpm = clip->audio().interpretation.bpm;
+    if (isValidBpm(event->interpBpm)) {
+        bpm = event->interpBpm;
     }
     std::optional<double> totalBeats;
-    if (clip->audio().interpretation.totalBeats > 0.0) {
-        totalBeats = clip->audio().interpretation.totalBeats;
+    if (event->interpTotalBeats > 0.0) {
+        totalBeats = event->interpTotalBeats;
     }
-    const std::optional<bool> beatMode = clip->autoTempo;
+    const std::optional<bool> beatMode = event->autoTempo;
 
     std::optional<std::string> keyRoot;
-    if (!clip->audio().interpretation.keyRoot.empty()) {
-        keyRoot = clip->audio().interpretation.keyRoot;
+    if (!event->keyRoot.empty()) {
+        keyRoot = event->keyRoot;
     }
 
     std::optional<std::vector<magda::media::WarpMarkerMetadata>> mediaMarkers;
-    if (clip->warpEnabled) {
-        const auto& sourceMarkers = warpMarkers ? *warpMarkers : clip->warpMarkers;
+    if (event->warpEnabled) {
+        const auto& sourceMarkers = warpMarkers ? *warpMarkers : event->warpMarkers;
         std::vector<magda::media::WarpMarkerMetadata> converted;
         converted.reserve(sourceMarkers.size());
         for (const auto& marker : sourceMarkers) {
@@ -1935,24 +1870,29 @@ bool ClipManager::saveClipToLibrary(ClipId clipId,
 void ClipManager::applyAudioClipBeats(ClipId clipId, const AudioClipBeatsUpdate& update,
                                       double projectBPM) {
     auto* clip = getClip(clipId);
-    if (!clip || !clip->isAudio() || !clip->autoTempo)
+    auto* event = primaryEventOf(clip);
+    if (event == nullptr || !event->autoTempo)
         return;
 
-    // (1) Source interpretation metadata. BPM and total beats describe the
-    // same fixed-duration source, so inspector edits may update both together.
+    // (1) Interpretation. BPM and total beats describe the same fixed-duration
+    // source, so inspector edits may update both together.
     if (update.interpretationBpm)
-        clip->audio().interpretation.bpm = juce::jmax(0.0, *update.interpretationBpm);
+        event->interpBpm = juce::jmax(0.0, *update.interpretationBpm);
     if (update.interpretationTotalBeats) {
-        clip->audio().interpretation.totalBeats = juce::jmax(0.0, *update.interpretationTotalBeats);
+        event->interpTotalBeats = juce::jmax(0.0, *update.interpretationTotalBeats);
         if (update.lockInterpretationTotalBeats)
-            clip->audio().interpretation.totalBeatsLocked = true;
+            event->interpTotalBeatsLocked = true;
     }
-    if (update.sourceDurationSeconds && clip->audio().source.durationSeconds <= 0.0)
-        clip->audio().source.durationSeconds = juce::jmax(0.0, *update.sourceDurationSeconds);
-    if (clip->audio().source.durationSeconds <= 0.0 && clip->audio().interpretation.bpm > 0.0 &&
-        clip->audio().interpretation.totalBeats > 0.0) {
-        clip->audio().source.durationSeconds =
-            clip->audio().interpretation.totalBeats * 60.0 / clip->audio().interpretation.bpm;
+    // File duration is a Source fact. Fill it in only while it is unknown; a
+    // real probe always wins over a value inferred from the interpretation.
+    if (auto* source = SourcePool::getInstance().getMutable(event->sourceId);
+        source != nullptr && source->durationSeconds <= 0.0) {
+        if (update.sourceDurationSeconds)
+            source->durationSeconds = juce::jmax(0.0, *update.sourceDurationSeconds);
+        if (source->durationSeconds <= 0.0 && event->interpBpm > 0.0 &&
+            event->interpTotalBeats > 0.0) {
+            source->durationSeconds = event->interpTotalBeats * 60.0 / event->interpBpm;
+        }
     }
 
     // (2) User-intent fields — beat-domain canonicals.
@@ -1962,29 +1902,19 @@ void ClipManager::applyAudioClipBeats(ClipId clipId, const AudioClipBeatsUpdate&
         clip->setPlacementBeats(clip->placement.startBeat,
                                 juce::jmax(minBeats, *update.lengthBeats));
     }
+    // Beat-domain edits convert into the source domain through the (possibly
+    // just-updated) interpretation. A reinterpretation on its own moves no
+    // audio: the anchor and loop region are samples, so their beat views simply
+    // re-read at the new tempo. That is the whole reason they are stored in
+    // samples rather than beats.
     if (update.loopStartBeats)
-        clip->loopStartBeats = juce::jmax(0.0, *update.loopStartBeats);
-    if (update.loopLengthBeats) {
-        clip->loopLengthBeats = juce::jmax(0.0, *update.loopLengthBeats);
-    }
+        event->setLoopStartBeats(juce::jmax(0.0, *update.loopStartBeats));
+    if (update.loopLengthBeats)
+        event->setLoopLengthBeats(juce::jmax(0.0, *update.loopLengthBeats));
     if (update.offsetBeats)
-        clip->offsetBeats = juce::jmax(0.0, *update.offsetBeats);
+        event->setAnchorBeats(juce::jmax(0.0, *update.offsetBeats));
     if (update.startBeats)
         clip->setPlacementBeats(juce::jmax(0.0, *update.startBeats), clip->placement.lengthBeats);
-
-    // If the source interpretation changed, preserve the selected source region in seconds.
-    // loopStartBeats/loopLengthBeats/offsetBeats are derived from source seconds unless the
-    // current update explicitly edits those beat-domain fields.
-    if ((update.interpretationBpm || update.interpretationTotalBeats) &&
-        clip->audio().interpretation.bpm > 0.0) {
-        double sourceBpm = clip->audio().interpretation.bpm;
-        if (!update.loopStartBeats)
-            clip->loopStartBeats = clip->loopStart * sourceBpm / 60.0;
-        if (!update.loopLengthBeats && clip->loopLength > 0.0)
-            clip->loopLengthBeats = clip->loopLength * sourceBpm / 60.0;
-        if (!update.offsetBeats)
-            clip->offsetBeats = clip->offset * sourceBpm / 60.0;
-    }
 
     // (3) Recompute the seconds cache from beats atomically.
     refreshDerivedSeconds(clipId, projectBPM);
@@ -1998,10 +1928,12 @@ void ClipManager::refreshDerivedSeconds(ClipId clipId, double projectBPM) {
         return;
 
     // TE requires speedRatio == 1.0 in autoTempo mode.
-    if (clip->autoTempo)
-        clip->speedRatio = 1.0;
+    if (auto* event = clip->primaryEvent(); event != nullptr && event->autoTempo)
+        event->speedRatio = 1.0;
 
     // Timeline-domain seconds (length, startTime): depend on PROJECT BPM.
+    // The source domain needs no refreshing at all now that it is stored in
+    // samples; only these timeline caches are derived.
     if (isValidBpm(projectBPM)) {
         if (clip->placement.lengthBeats > 0.0)
             clip->length = clip->placement.lengthBeats * 60.0 / projectBPM;
@@ -2009,36 +1941,22 @@ void ClipManager::refreshDerivedSeconds(ClipId clipId, double projectBPM) {
         clip->startBeats = clip->placement.startBeat;
         clip->lengthBeats = clip->placement.lengthBeats;
     }
-
-    // Source-domain seconds (offset, loopStart, loopLength) for autoTempo
-    // audio: depend on SOURCE BPM (a property of the file, not the project).
-    // For MIDI clips loopLengthBeats lives in the project-beat domain, so
-    // loopLength uses projectBPM. When source interpretation BPM is unknown (detection
-    // pending), leave the source-domain seconds alone — readers fall back to
-    // the lengthBeats × 60 / projectBPM path.
-    if (clip->isAudio() && clip->autoTempo && clip->audio().interpretation.bpm > 0.0) {
-        clip->offset = clip->offsetBeats * 60.0 / clip->audio().interpretation.bpm;
-        clip->loopStart = clip->loopStartBeats * 60.0 / clip->audio().interpretation.bpm;
-        if (clip->loopLengthBeats > 0.0)
-            clip->loopLength = clip->loopLengthBeats * 60.0 / clip->audio().interpretation.bpm;
-    } else if (clip->isMidi() && isValidBpm(projectBPM) && clip->loopLengthBeats > 0.0) {
-        clip->loopLength = clip->loopLengthBeats * 60.0 / projectBPM;
-    }
 }
 
 void ClipManager::setSpeedRatio(ClipId clipId, double speedRatio) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
+        if (auto* event = clip->primaryEvent()) {
             const double bpm = currentProjectTempoOrDefault();
-            double oldSourceExtent = clip->timelineToSource(clip->getTimelineLength(bpm));
-            clip->speedRatio = juce::jlimit(ClipOperations::MIN_SPEED_RATIO,
-                                            ClipOperations::MAX_SPEED_RATIO, speedRatio);
-            double newSourceExtent = clip->timelineToSource(clip->getTimelineLength(bpm));
+            double oldSourceExtent = event->timelineToSource(clip->getTimelineLength(bpm));
+            event->speedRatio = juce::jlimit(ClipOperations::MIN_SPEED_RATIO,
+                                             ClipOperations::MAX_SPEED_RATIO, speedRatio);
+            double newSourceExtent = event->timelineToSource(clip->getTimelineLength(bpm));
 
-            // Keep loopLength in sync when the loop covers the full source extent
-            // (non-looped clips, or looped clips where the loop wasn't user-shortened)
-            if (!clip->loopEnabled || std::abs(clip->loopLength - oldSourceExtent) < 0.001) {
-                clip->loopLength = newSourceExtent;
+            // Keep the source region in sync when it covers the full extent
+            // (non-looped events, or looped ones the user has not shortened)
+            if (!clip->loopEnabled ||
+                std::abs(event->loopLengthSeconds() - oldSourceExtent) < 0.001) {
+                event->setLoopLengthSeconds(newSourceExtent);
             }
             notifyClipPropertyChanged(clipId);
         }
@@ -2047,8 +1965,8 @@ void ClipManager::setSpeedRatio(ClipId clipId, double speedRatio) {
 
 void ClipManager::setTimeStretchMode(ClipId clipId, int mode) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
-            clip->timeStretchMode = mode;
+        if (auto* event = clip->primaryEvent()) {
+            event->timeStretchMode = mode;
             notifyClipPropertyChanged(clipId);
         }
     }
@@ -2060,8 +1978,8 @@ void ClipManager::setTimeStretchMode(ClipId clipId, int mode) {
 
 void ClipManager::setAutoPitch(ClipId clipId, bool enabled) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
-            clip->autoPitch = enabled;
+        if (auto* event = clip->primaryEvent()) {
+            event->autoPitch = enabled;
             notifyClipPropertyChanged(clipId);
         }
     }
@@ -2069,15 +1987,15 @@ void ClipManager::setAutoPitch(ClipId clipId, bool enabled) {
 
 void ClipManager::setAnalogPitch(ClipId clipId, bool enabled) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
-            clip->analogPitch = enabled;
-            if (enabled && !clip->autoTempo && !clip->warpEnabled) {
+        if (auto* event = clip->primaryEvent()) {
+            event->analogPitch = enabled;
+            if (enabled && !event->autoTempo && !event->warpEnabled) {
                 // Analog pitch is sample-rate style playback: pitch and speed
                 // are the same factor, and the selected source span stays fixed.
-                const double pitchFactor = std::pow(2.0, clip->pitchChange / 12.0);
+                const double pitchFactor = std::pow(2.0, event->pitchChange / 12.0);
                 const double bpm = currentProjectTempoOrDefault();
-                const double sourceContent = clip->timelineToSource(clip->getTimelineLength(bpm));
-                clip->speedRatio = pitchFactor;
+                const double sourceContent = event->timelineToSource(clip->getTimelineLength(bpm));
+                event->speedRatio = pitchFactor;
                 ClipOperations::setTimelinePlacement(
                     *clip, clip->getTimelineStart(bpm),
                     juce::jmax(ClipInfo::MIN_CLIP_LENGTH, sourceContent / pitchFactor), bpm);
@@ -2091,8 +2009,8 @@ void ClipManager::setAnalogPitch(ClipId clipId, bool enabled) {
 
 void ClipManager::setAutoPitchMode(ClipId clipId, int mode) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
-            clip->autoPitchMode = juce::jlimit(0, 2, mode);
+        if (auto* event = clip->primaryEvent()) {
+            event->autoPitchMode = juce::jlimit(0, 2, mode);
             notifyClipPropertyChanged(clipId);
         }
     }
@@ -2100,14 +2018,14 @@ void ClipManager::setAutoPitchMode(ClipId clipId, int mode) {
 
 void ClipManager::setPitchChange(ClipId clipId, float semitones) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
+        if (auto* event = clip->primaryEvent()) {
             const double bpm = currentProjectTempoOrDefault();
-            const double sourceContent = clip->timelineToSource(clip->getTimelineLength(bpm));
-            clip->pitchChange = juce::jlimit(-48.0f, 48.0f, semitones);
+            const double sourceContent = event->timelineToSource(clip->getTimelineLength(bpm));
+            event->pitchChange = juce::jlimit(-48.0f, 48.0f, semitones);
 
-            if (clip->isAnalogPitchActive()) {
-                const double newFactor = std::pow(2.0, clip->pitchChange / 12.0);
-                clip->speedRatio = newFactor;
+            if (event->isAnalogPitchActive()) {
+                const double newFactor = std::pow(2.0, event->pitchChange / 12.0);
+                event->speedRatio = newFactor;
                 ClipOperations::setTimelinePlacement(
                     *clip, clip->getTimelineStart(bpm),
                     juce::jmax(ClipInfo::MIN_CLIP_LENGTH, sourceContent / newFactor), bpm);
@@ -2122,8 +2040,8 @@ void ClipManager::setPitchChange(ClipId clipId, float semitones) {
 
 void ClipManager::setTranspose(ClipId clipId, int semitones) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
-            clip->transpose = juce::jlimit(-24, 24, semitones);
+        if (auto* event = clip->primaryEvent()) {
+            event->transpose = juce::jlimit(-24, 24, semitones);
             notifyClipPropertyChanged(clipId);
         }
     }
@@ -2135,8 +2053,8 @@ void ClipManager::setTranspose(ClipId clipId, int semitones) {
 
 void ClipManager::setAutoDetectBeats(ClipId clipId, bool enabled) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
-            clip->autoDetectBeats = enabled;
+        if (auto* event = clip->primaryEvent()) {
+            event->autoDetectBeats = enabled;
             notifyClipPropertyChanged(clipId);
         }
     }
@@ -2144,8 +2062,8 @@ void ClipManager::setAutoDetectBeats(ClipId clipId, bool enabled) {
 
 void ClipManager::setBeatSensitivity(ClipId clipId, float sensitivity) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
-            clip->beatSensitivity = juce::jlimit(0.0f, 1.0f, sensitivity);
+        if (auto* event = clip->primaryEvent()) {
+            event->beatSensitivity = juce::jlimit(0.0f, 1.0f, sensitivity);
             notifyClipPropertyChanged(clipId);
         }
     }
@@ -2157,8 +2075,8 @@ void ClipManager::setBeatSensitivity(ClipId clipId, float sensitivity) {
 
 void ClipManager::setIsReversed(ClipId clipId, bool reversed) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
-            clip->isReversed = reversed;
+        if (auto* event = clip->primaryEvent()) {
+            event->reversed = reversed;
             notifyClipPropertyChanged(clipId);
         }
     }
@@ -2223,8 +2141,8 @@ void ClipManager::setClipPan(ClipId clipId, float pan) {
 
 void ClipManager::setFadeIn(ClipId clipId, double seconds) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
-            clip->fadeIn = juce::jmax(0.0, seconds);
+        if (auto* event = clip->primaryEvent()) {
+            event->fadeInSeconds = juce::jmax(0.0, seconds);
             notifyClipPropertyChanged(clipId);
         }
     }
@@ -2232,8 +2150,8 @@ void ClipManager::setFadeIn(ClipId clipId, double seconds) {
 
 void ClipManager::setFadeOut(ClipId clipId, double seconds) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
-            clip->fadeOut = juce::jmax(0.0, seconds);
+        if (auto* event = clip->primaryEvent()) {
+            event->fadeOutSeconds = juce::jmax(0.0, seconds);
             notifyClipPropertyChanged(clipId);
         }
     }
@@ -2241,8 +2159,8 @@ void ClipManager::setFadeOut(ClipId clipId, double seconds) {
 
 void ClipManager::setFadeInType(ClipId clipId, int type) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
-            clip->fadeInType = juce::jlimit(1, 4, type);
+        if (auto* event = clip->primaryEvent()) {
+            event->fadeInType = juce::jlimit(1, 4, type);
             notifyClipPropertyChanged(clipId);
         }
     }
@@ -2250,8 +2168,8 @@ void ClipManager::setFadeInType(ClipId clipId, int type) {
 
 void ClipManager::setFadeOutType(ClipId clipId, int type) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
-            clip->fadeOutType = juce::jlimit(1, 4, type);
+        if (auto* event = clip->primaryEvent()) {
+            event->fadeOutType = juce::jlimit(1, 4, type);
             notifyClipPropertyChanged(clipId);
         }
     }
@@ -2259,8 +2177,8 @@ void ClipManager::setFadeOutType(ClipId clipId, int type) {
 
 void ClipManager::setFadeInBehaviour(ClipId clipId, int behaviour) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
-            clip->fadeInBehaviour = juce::jlimit(0, 1, behaviour);
+        if (auto* event = clip->primaryEvent()) {
+            event->fadeInBehaviour = juce::jlimit(0, 1, behaviour);
             notifyClipPropertyChanged(clipId);
         }
     }
@@ -2268,8 +2186,8 @@ void ClipManager::setFadeInBehaviour(ClipId clipId, int behaviour) {
 
 void ClipManager::setFadeOutBehaviour(ClipId clipId, int behaviour) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
-            clip->fadeOutBehaviour = juce::jlimit(0, 1, behaviour);
+        if (auto* event = clip->primaryEvent()) {
+            event->fadeOutBehaviour = juce::jlimit(0, 1, behaviour);
             notifyClipPropertyChanged(clipId);
         }
     }
@@ -2394,37 +2312,38 @@ ClipId ClipManager::findCrossfadeNeighbour(ClipId clipId, bool atStart) const {
 }
 
 double ClipManager::availableLeftExtensionBeats(const ClipInfo& clip, double bpm) const {
-    if (!clip.isAudio())
+    const auto* event = clip.primaryEvent();
+    if (event == nullptr)
         return 0.0;
     if (clip.loopEnabled)
         return std::numeric_limits<double>::infinity();
-    if (clip.autoTempo && clip.audio().interpretation.bpm > 0.0) {
+    if (event->autoTempo && event->interpBpm > 0.0) {
         // Under autoTempo, timeline beats consume source beats 1:1.
-        return juce::jmax(0.0, clip.offsetBeats);
+        return juce::jmax(0.0, event->anchorBeats());
     }
-    const double speed = clip.speedRatio > 0.0 ? clip.speedRatio : 1.0;
-    return (juce::jmax(0.0, clip.offset) / speed) * bpm / 60.0;
+    const double speed = event->speedRatio > 0.0 ? event->speedRatio : 1.0;
+    return (juce::jmax(0.0, event->anchorSeconds()) / speed) * bpm / 60.0;
 }
 
 double ClipManager::availableRightExtensionBeats(const ClipInfo& clip, double bpm) const {
-    if (!clip.isAudio())
+    const auto* event = clip.primaryEvent();
+    if (event == nullptr)
         return 0.0;
     if (clip.loopEnabled)
         return std::numeric_limits<double>::infinity();
-    if (clip.autoTempo && clip.audio().interpretation.bpm > 0.0) {
-        const auto& interp = clip.audio().interpretation;
-        const double totalBeats = interp.totalBeats > 0.0
-                                      ? interp.totalBeats
-                                      : clip.audio().source.durationSeconds * interp.bpm / 60.0;
+    if (event->autoTempo && event->interpBpm > 0.0) {
+        const double totalBeats = event->interpTotalBeats > 0.0
+                                      ? event->interpTotalBeats
+                                      : event->sourceDurationSeconds() * event->interpBpm / 60.0;
         if (totalBeats <= 0.0)
             return std::numeric_limits<double>::infinity();
-        return juce::jmax(0.0, totalBeats - (clip.offsetBeats + clip.placement.lengthBeats));
+        return juce::jmax(0.0, totalBeats - (event->anchorBeats() + clip.placement.lengthBeats));
     }
-    const double sourceDuration = clip.audio().source.durationSeconds;
+    const double sourceDuration = event->sourceDurationSeconds();
     if (sourceDuration <= 0.0)
         return std::numeric_limits<double>::infinity();
-    const double speed = clip.speedRatio > 0.0 ? clip.speedRatio : 1.0;
-    const double sourceEnd = clip.offset + clip.getTimelineLength(bpm) * speed;
+    const double speed = event->speedRatio > 0.0 ? event->speedRatio : 1.0;
+    const double sourceEnd = event->anchorSeconds() + clip.getTimelineLength(bpm) * speed;
     return (juce::jmax(0.0, sourceDuration - sourceEnd) / speed) * bpm / 60.0;
 }
 
@@ -2528,8 +2447,8 @@ bool ClipManager::setCrossfadeBeats(ClipId leftId, ClipId rightId, double durati
 
 void ClipManager::setLeftChannelActive(ClipId clipId, bool active) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
-            clip->leftChannelActive = active;
+        if (auto* event = clip->primaryEvent()) {
+            event->leftChannelActive = active;
             notifyClipPropertyChanged(clipId);
         }
     }
@@ -2537,8 +2456,8 @@ void ClipManager::setLeftChannelActive(ClipId clipId, bool active) {
 
 void ClipManager::setRightChannelActive(ClipId clipId, bool active) {
     if (auto* clip = getClip(clipId)) {
-        if (clip->isAudio()) {
-            clip->rightChannelActive = active;
+        if (auto* event = clip->primaryEvent()) {
+            event->rightChannelActive = active;
             notifyClipPropertyChanged(clipId);
         }
     }
@@ -3232,39 +3151,41 @@ juce::String ClipManager::generateClipName(ClipType type) const {
 }
 
 void ClipManager::sanitizeAudioClip(ClipInfo& clip) {
-    if (!clip.isAudio() || clip.audio().source.filePath.isEmpty())
+    if (!clip.isAudio())
         return;
 
-    auto* thumbnail =
-        AudioThumbnailManager::getInstance().getThumbnail(clip.audio().source.filePath);
-    double fileDuration = thumbnail ? thumbnail->getTotalLength() : 0.0;
-    if (fileDuration <= 0.0)
-        fileDuration = clip.audio().source.durationSeconds;
-    if (fileDuration <= 0.0)
-        return;
+    // Every event is clamped to its own source: they can point at different
+    // files even though nothing builds such a clip yet.
+    for (auto& event : clip.audio().events) {
+        const auto filePath = event.sourceFilePath();
+        if (filePath.isEmpty())
+            continue;
 
-    clip.loopStart = juce::jlimit(0.0, fileDuration, clip.loopStart);
+        auto* thumbnail = AudioThumbnailManager::getInstance().getThumbnail(filePath);
+        double fileDuration = thumbnail ? thumbnail->getTotalLength() : 0.0;
+        if (fileDuration <= 0.0)
+            fileDuration = event.sourceDurationSeconds();
+        if (fileDuration <= 0.0)
+            continue;
 
-    const double availableFromLoop = fileDuration - clip.loopStart;
-    if (clip.loopLength > availableFromLoop) {
-        const double oldLoopLength = clip.loopLength;
-        clip.loopLength = juce::jmax(0.0, availableFromLoop);
-        if (clip.autoTempo && oldLoopLength > 0.0) {
-            clip.loopLengthBeats *= clip.loopLength / oldLoopLength;
-        }
-    }
+        event.setLoopStartSeconds(juce::jlimit(0.0, fileDuration, event.loopStartSeconds()));
 
-    clip.offset = juce::jlimit(0.0, fileDuration, clip.offset);
+        const double availableFromLoop = fileDuration - event.loopStartSeconds();
+        if (event.loopLengthSeconds() > availableFromLoop)
+            event.setLoopLengthSeconds(juce::jmax(0.0, availableFromLoop));
 
-    if (!clip.loopEnabled && !clip.autoTempo) {
-        const double bpm = currentProjectTempoOrDefault();
-        const double currentLength = clip.getTimelineLength(bpm);
-        const double available = fileDuration - clip.offset;
-        const double maxLength = available / clip.speedRatio;
-        if (currentLength > maxLength) {
-            ClipOperations::setTimelinePlacement(clip, clip.getTimelineStart(bpm),
-                                                 juce::jmax(ClipInfo::MIN_CLIP_LENGTH, maxLength),
-                                                 bpm);
+        event.setAnchorSeconds(juce::jlimit(0.0, fileDuration, event.anchorSeconds()));
+
+        if (!clip.loopEnabled && !event.autoTempo) {
+            const double bpm = currentProjectTempoOrDefault();
+            const double currentLength = clip.getTimelineLength(bpm);
+            const double available = fileDuration - event.anchorSeconds();
+            const double maxLength = available / event.speedRatio;
+            if (currentLength > maxLength) {
+                ClipOperations::setTimelinePlacement(
+                    clip, clip.getTimelineStart(bpm),
+                    juce::jmax(ClipInfo::MIN_CLIP_LENGTH, maxLength), bpm);
+            }
         }
     }
 }
@@ -3330,29 +3251,24 @@ void ClipManager::copyBeatRangeToClipboard(double startBeat, double endBeat,
         ClipOperations::setBeatPlacement(trimmed, overlapStartBeat,
                                          overlapEndBeat - overlapStartBeat, tempoBPM);
 
-        if (clip.isAudio()) {
+        if (auto* trimmedEvent = trimmed.primaryEvent()) {
             // Advance the source read position by the trimmed-off beats.
             const double trimFromLeftBeats = overlapStartBeat - clipStartBeat;
-            if (clip.audio().interpretation.bpm > 0.0) {
-                // autoTempo: beats are authoritative, derive source seconds.
-                trimmed.offsetBeats = clip.offsetBeats + trimFromLeftBeats;
-                trimmed.offset = trimmed.offsetBeats * 60.0 / clip.audio().interpretation.bpm;
+            if (trimmedEvent->interpBpm > 0.0) {
+                // Beat mode: the trim is a source-beat distance.
+                trimmedEvent->setAnchorBeats(trimmedEvent->anchorBeats() + trimFromLeftBeats);
             } else if (isValidBpm(tempoBPM)) {
-                // Non-autoTempo: source offset is seconds. Convert the beat trim
-                // to timeline seconds, then to source seconds via speedRatio.
+                // Otherwise convert the beat trim to timeline seconds, then to
+                // source seconds via speedRatio.
                 const double trimFromLeftSeconds = trimFromLeftBeats * 60.0 / tempoBPM;
-                trimmed.offset = clip.offset + trimFromLeftSeconds * clip.speedRatio;
+                trimmedEvent->setAnchorSeconds(trimmedEvent->anchorSeconds() +
+                                               trimFromLeftSeconds * trimmedEvent->speedRatio);
             }
-            // Sync loop fields for non-looped clips
+            // Sync the source region for non-looped events
             if (!trimmed.loopEnabled) {
-                if (trimmed.autoTempo && trimmed.audio().interpretation.bpm > 0.0) {
-                    trimmed.loopStartBeats = trimmed.offsetBeats;
-                    trimmed.loopStart =
-                        trimmed.loopStartBeats * 60.0 / trimmed.audio().interpretation.bpm;
-                } else {
-                    trimmed.loopStart = trimmed.offset;
-                }
-                trimmed.loopLength = trimmed.timelineToSource(trimmed.getTimelineLength(tempoBPM));
+                trimmedEvent->loopStartSamples = trimmedEvent->sourceAnchorSamples;
+                trimmedEvent->setLoopLengthSeconds(
+                    trimmedEvent->timelineToSource(trimmed.getTimelineLength(tempoBPM)));
             }
         } else if (clip.isMidi() && !clip.midiNotes.empty()) {
             // Notes are in beats relative to clip start; re-base to the overlap.
@@ -3422,13 +3338,13 @@ std::vector<ClipId> ClipManager::pasteFromClipboardBeats(double pasteBeat, Track
 
         // Create new clip based on type, using targetView instead of clipData.view
         ClipId newClipId = INVALID_CLIP_ID;
-        if (clipData.isAudio()) {
-            if (clipData.audio().source.filePath.isNotEmpty()) {
+        if (const auto* pastedEvent = clipData.primaryEvent()) {
+            if (pastedEvent->sourceFilePath().isNotEmpty()) {
                 newClipId = createAudioClipBeats(newTrackId, newStartBeat, clipLengthBeats,
-                                                 clipData.audio().source.filePath, targetView, 0.0,
+                                                 pastedEvent->sourceFilePath(), targetView, 0.0,
                                                  ClipOverlapPolicy::ResolveOverlaps);
             }
-        } else {
+        } else if (clipData.isMidi()) {
             // For MIDI clips, create empty then copy notes
             newClipId = createMidiClipBeats(newTrackId, newStartBeat, clipLengthBeats, targetView,
                                             ClipOverlapPolicy::ResolveOverlaps);
@@ -3470,18 +3386,50 @@ std::vector<ClipId> ClipManager::pasteFromClipboardBeats(double pasteBeat, Track
                 bool crossViewToSession =
                     (targetView == ClipView::Session && clipData.view == ClipView::Arrangement);
 
-                if (clipData.isAudio() && !crossViewToSession) {
-                    newClip->offset = clipData.offset;
-                    newClip->offsetBeats = clipData.offsetBeats;
-                    newClip->loopStart = clipData.loopStart;
-                    newClip->loopLength = clipData.loopLength;
+                auto* newEvent = newClip->primaryEvent();
+                const auto* srcEvent = clipData.primaryEvent();
+                if (newEvent != nullptr && srcEvent != nullptr) {
+                    // The destination event keeps its own identity and its own
+                    // pooled source (createAudioClipBeats already resolved the
+                    // path); everything else comes from the copied event.
+                    const EventId keepId = newEvent->id;
+                    const SourceId keepSourceId = newEvent->sourceId;
+
+                    if (crossViewToSession) {
+                        // createAudioClipBeats already applied the session
+                        // defaults (beat mode, looping, anchor at 0), so the
+                        // fields that place the read head stay as created.
+                        // Interpretation and per-event playback still copy.
+                        if (srcEvent->warpEnabled) {
+                            newEvent->warpEnabled = true;
+                            newEvent->timeStretchMode = srcEvent->timeStretchMode;
+                        }
+                        newEvent->warpMarkers = srcEvent->warpMarkers;
+                        if (srcEvent->interpBpm > 0.0)
+                            newEvent->interpBpm = srcEvent->interpBpm;
+                        if (srcEvent->interpTotalBeats > 0.0)
+                            newEvent->interpTotalBeats = srcEvent->interpTotalBeats;
+                        newEvent->autoPitch = srcEvent->autoPitch;
+                        newEvent->analogPitch = srcEvent->analogPitch;
+                        newEvent->autoPitchMode = srcEvent->autoPitchMode;
+                        newEvent->pitchChange = srcEvent->pitchChange;
+                        newEvent->transpose = srcEvent->transpose;
+                        newEvent->reversed = srcEvent->reversed;
+                        newEvent->leftChannelActive = srcEvent->leftChannelActive;
+                        newEvent->rightChannelActive = srcEvent->rightChannelActive;
+                    } else {
+                        *newEvent = *srcEvent;
+                    }
+
+                    newEvent->id = keepId;
+                    newEvent->sourceId = keepSourceId;
                 }
 
-                // Audio playback — preserve session defaults for cross-view paste
                 if (!crossViewToSession) {
-                    newClip->autoTempo = clipData.autoTempo;
-                    newClip->loopStartBeats = clipData.loopStartBeats;
-                    newClip->loopLengthBeats = clipData.loopLengthBeats;
+                    if (newClip->isMidi() && clipData.isMidi()) {
+                        newClip->loopStartBeats = clipData.loopStartBeats;
+                        newClip->loopLengthBeats = clipData.loopLengthBeats;
+                    }
                     const double pastedLengthBeats = clipData.placement.lengthBeats > 0.0
                                                          ? clipData.placement.lengthBeats
                                                          : clipData.lengthBeats;
@@ -3490,45 +3438,11 @@ std::vector<ClipId> ClipManager::pasteFromClipboardBeats(double pasteBeat, Track
                     // Don't overwrite startBeats — createMidiClip/createAudioClip already
                     // computed the correct value from newStartTime
                 }
-                if (!crossViewToSession || clipData.warpEnabled) {
-                    newClip->warpEnabled = clipData.warpEnabled;
-                    newClip->timeStretchMode = clipData.timeStretchMode;
-                }
-
-                // Warp markers describe the source mapping, not arrangement
-                // placement. Preserve them when copying between either view so
-                // ClipSynchronizer can restore the map into the destination TE clip.
-                if (clipData.isAudio())
-                    newClip->warpMarkers = clipData.warpMarkers;
-
-                // Source file metadata describes audio files only.
-                if (clipData.isAudio()) {
-                    if (clipData.audio().interpretation.bpm > 0.0)
-                        newClip->audio().interpretation.bpm = clipData.audio().interpretation.bpm;
-                    if (clipData.audio().interpretation.totalBeats > 0.0)
-                        newClip->audio().interpretation.totalBeats =
-                            clipData.audio().interpretation.totalBeats;
-                }
-
-                // Pitch
-                newClip->autoPitch = clipData.autoPitch;
-                newClip->analogPitch = clipData.analogPitch;
-                newClip->pitchChange = clipData.pitchChange;
-                newClip->transpose = clipData.transpose;
 
                 // Mix
                 newClip->volumeDB = clipData.volumeDB;
                 newClip->gainDB = clipData.gainDB;
                 newClip->pan = clipData.pan;
-
-                // Playback
-                newClip->isReversed = clipData.isReversed;
-                if (!crossViewToSession)
-                    newClip->speedRatio = clipData.speedRatio;
-
-                // Channels
-                newClip->leftChannelActive = clipData.leftChannelActive;
-                newClip->rightChannelActive = clipData.rightChannelActive;
 
                 // Grid settings
                 newClip->gridAutoGrid = clipData.gridAutoGrid;
@@ -3560,26 +3474,27 @@ std::vector<ClipId> ClipManager::pasteFromClipboardBeats(double pasteBeat, Track
                     newClip->followActionDelayBeats = clipData.followActionDelayBeats;
                     newClip->followActionLoopCount = clipData.followActionLoopCount;
 
-                    if (!crossViewToSession) {
+                    if (!crossViewToSession && clipData.loopEnabled) {
                         // Reset extended loops to base loop length for
                         // session→session pastes
-                        if (clipData.loopEnabled && clipData.loopLengthBeats > 0.0 &&
-                            clipData.lengthBeats > clipData.loopLengthBeats) {
-                            newClip->lengthBeats = clipData.loopLengthBeats;
-                            newClip->loopLengthBeats = clipData.loopLengthBeats;
-                            const double bpm = currentProjectTempoOrDefault();
-                            const double newLength = clipData.loopLengthBeats * 60.0 / bpm;
-                            ClipOperations::setTimelinePlacement(
-                                *newClip, newClip->getTimelineStart(bpm), newLength, bpm);
-                            newClip->loopLength = newClip->getTimelineLength(bpm);
-                        } else if (clipData.loopEnabled && clipData.loopLength > 0.0 &&
-                                   clipData.getTimelineLength(currentProjectTempoOrDefault()) >
-                                       clipData.sourceToTimeline(clipData.loopLength)) {
-                            const double bpm = currentProjectTempoOrDefault();
+                        const double bpm = currentProjectTempoOrDefault();
+                        const double loopBeats = clipData.loopLengthBeats;
+                        const auto* srcLoopEvent = clipData.primaryEvent();
+                        if (loopBeats > 0.0 && clipData.lengthBeats > loopBeats) {
+                            ClipOperations::setTimelinePlacement(*newClip,
+                                                                 newClip->getTimelineStart(bpm),
+                                                                 loopBeats * 60.0 / bpm, bpm);
+                        } else if (loopBeats <= 0.0 && srcLoopEvent != nullptr &&
+                                   srcLoopEvent->loopLengthSamples > 0 &&
+                                   clipData.getTimelineLength(bpm) >
+                                       srcLoopEvent->sourceToTimeline(
+                                           srcLoopEvent->loopLengthSeconds())) {
+                            // No usable beat view of the region: fall back to
+                            // its timeline extent.
                             ClipOperations::setTimelinePlacement(
                                 *newClip, newClip->getTimelineStart(bpm),
-                                clipData.sourceToTimeline(clipData.loopLength), bpm);
-                            newClip->loopLength = clipData.loopLength;
+                                srcLoopEvent->sourceToTimeline(srcLoopEvent->loopLengthSeconds()),
+                                bpm);
                         }
                     }
                 }

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -218,6 +218,29 @@ ClipManager::ClipManager() {
         });
 }
 
+void ClipManager::stashClipboardSourcePaths() {
+    clipboardSourcePaths_.clear();
+    for (const auto& clip : clipboard_) {
+        if (!clip.isAudio())
+            continue;
+        for (const auto& event : clip.audio().events) {
+            if (event.sourceId == INVALID_SOURCE_ID)
+                continue;
+            const auto path = sourcePathOf(event.sourceId);
+            if (path.isNotEmpty())
+                clipboardSourcePaths_[event.sourceId] = path;
+        }
+    }
+}
+
+juce::String ClipManager::clipboardSourcePathFor(const AudioEvent& event) const {
+    if (const auto it = clipboardSourcePaths_.find(event.sourceId);
+        it != clipboardSourcePaths_.end()) {
+        return it->second;
+    }
+    return event.sourceFilePath();
+}
+
 void ClipManager::repointEventsToSource(SourceId from, SourceId to) {
     if (from == to || from == INVALID_SOURCE_ID || to == INVALID_SOURCE_ID)
         return;
@@ -416,9 +439,13 @@ ClipId ClipManager::createAudioClipBeats(TrackId trackId, double startBeats, dou
                     // the real beat count, so snap both the timeline placement
                     // and the loop region to the beat count and let autoTempo
                     // stretch the audio to fit.
+                    // The region follows the placement unconditionally. The
+                    // event was seeded with a file-duration region above, so a
+                    // "not set yet" guard here never fires and the saved beat
+                    // count would be ignored for every arrangement drop.
                     const double beats = savedEvent->interpTotalBeats;
                     savedClip.setPlacementBeats(startBeats, beats);
-                    if (savedEvent->loopLengthSamples <= 0 && savedEvent->interpBpm > 0.0)
+                    if (savedEvent->interpBpm > 0.0)
                         savedEvent->setLoopLengthSeconds(beats * 60.0 / savedEvent->interpBpm);
                 }
                 savedClip.deriveTimesFromBeats(bpm);
@@ -711,8 +738,13 @@ void ClipManager::setAudioClipCurrentTake(ClipId clipId, int takeIndex) {
     a.comp.clear();
     a.currentTakeIndex = takeIndex;
     if (auto* event = a.primaryEvent()) {
+        // Same discipline as repointEventsToSource: the positions are sample
+        // counts at the old take's rate, and an imported or comp-rendered take
+        // need not share it.
+        const double oldRate = sourceRateOf(event->sourceId);
         event->sourceId =
             SourcePool::getInstance().acquire(a.takes[static_cast<size_t>(takeIndex)].filePath);
+        event->rescaleSourcePositions(oldRate, sourceRateOf(event->sourceId));
     }
     forceNotifyClipPropertyChanged(clipId);
     pushClipStateSnapshot("Select Take", before);
@@ -864,8 +896,10 @@ void ClipManager::deleteClipTake(ClipId clipId, int takeIndex) {
         } else {
             if (newCurrent < newSize) {
                 if (auto* event = a.primaryEvent()) {
+                    const double oldRate = sourceRateOf(event->sourceId);
                     event->sourceId = SourcePool::getInstance().acquire(
                         a.takes[static_cast<size_t>(newCurrent)].filePath);
+                    event->rescaleSourcePositions(oldRate, sourceRateOf(event->sourceId));
                 }
             }
             forceNotifyClipPropertyChanged(clipId);
@@ -3278,6 +3312,7 @@ void ClipManager::copyToClipboard(const std::unordered_set<ClipId>& clipIds) {
         }
     }
 
+    stashClipboardSourcePaths();
     DBG("CLIPBOARD: Copied " << clipboard_.size() << " clip(s)");
 }
 
@@ -3354,6 +3389,8 @@ void ClipManager::copyBeatRangeToClipboard(double startBeat, double endBeat,
 
         clipboard_.push_back(trimmed);
     }
+
+    stashClipboardSourcePaths();
 }
 
 void ClipManager::copyTimeRangeToClipboard(double startTime, double endTime,
@@ -3399,10 +3436,11 @@ std::vector<ClipId> ClipManager::pasteFromClipboardBeats(double pasteBeat, Track
         // Create new clip based on type, using targetView instead of clipData.view
         ClipId newClipId = INVALID_CLIP_ID;
         if (const auto* pastedEvent = clipData.primaryEvent()) {
-            if (pastedEvent->sourceFilePath().isNotEmpty()) {
-                newClipId = createAudioClipBeats(newTrackId, newStartBeat, clipLengthBeats,
-                                                 pastedEvent->sourceFilePath(), targetView, 0.0,
-                                                 ClipOverlapPolicy::ResolveOverlaps);
+            const auto pastedPath = clipboardSourcePathFor(*pastedEvent);
+            if (pastedPath.isNotEmpty()) {
+                newClipId =
+                    createAudioClipBeats(newTrackId, newStartBeat, clipLengthBeats, pastedPath,
+                                         targetView, 0.0, ClipOverlapPolicy::ResolveOverlaps);
             }
         } else if (clipData.isMidi()) {
             // For MIDI clips, create empty then copy notes
@@ -3538,7 +3576,7 @@ std::vector<ClipId> ClipManager::pasteFromClipboardBeats(double pasteBeat, Track
                         // Reset extended loops to base loop length for
                         // session→session pastes
                         const double bpm = currentProjectTempoOrDefault();
-                        const double loopBeats = clipData.loopLengthInBeats();
+                        const double loopBeats = clipData.loopLengthInBeats(bpm);
                         const auto* srcLoopEvent = clipData.primaryEvent();
                         if (loopBeats > 0.0 && clipData.lengthBeats > loopBeats) {
                             ClipOperations::setTimelinePlacement(*newClip,
@@ -3668,6 +3706,7 @@ void ClipManager::setMidiClipClipboard(std::vector<MidiNote> notes, juce::String
     clip.deriveTimesFromBeats(currentProjectTempoOrDefault());
 
     clipboard_.push_back(std::move(clip));
+    stashClipboardSourcePaths();
 }
 
 // ============================================================================

--- a/magda/daw/core/ClipManager.hpp
+++ b/magda/daw/core/ClipManager.hpp
@@ -875,6 +875,13 @@ class ClipManager {
     /// turns out to be pooled already, so one file keeps one source.
     void repointEventsToSource(SourceId from, SourceId to);
 
+    /// Record the file behind every clipboard event, so a paste after a
+    /// project switch resolves by path rather than by a renumbered id.
+    void stashClipboardSourcePaths();
+
+    /// Path a clipboard event should paste from.
+    juce::String clipboardSourcePathFor(const AudioEvent& event) const;
+
   private:
     ClipManager();
     ~ClipManager() = default;
@@ -917,6 +924,13 @@ class ClipManager {
 
     // Clipboard storage
     std::vector<ClipInfo> clipboard_;
+    /// File path per source id referenced by the clipboard, captured at copy
+    /// time. The clipboard deliberately survives project switches, but an
+    /// event carries only a SourceId and loading a project clears and
+    /// renumbers the pool, so a stored id would resolve against the new
+    /// project's table: a collision pastes the wrong file, a miss pastes
+    /// nothing. Paths do not collide.
+    std::unordered_map<SourceId, juce::String> clipboardSourcePaths_;
     double clipboardReferenceBeat_ = 0.0;  // Beats; anchor for maintaining relative paste positions
 
     // Note clipboard storage

--- a/magda/daw/core/ClipManager.hpp
+++ b/magda/daw/core/ClipManager.hpp
@@ -417,7 +417,7 @@ class ClipManager {
     [[nodiscard]] bool canSaveClipToLibrary(ClipId clipId) const;
 
     [[nodiscard]] bool saveClipToLibrary(
-        ClipId clipId, std::optional<std::vector<ClipInfo::WarpMarker>> warpMarkers = std::nullopt);
+        ClipId clipId, std::optional<std::vector<WarpMarker>> warpMarkers = std::nullopt);
 
     /** @brief Refresh the seconds-domain cache (length, startTime, offset,
      *         loopStart, loopLength) on a beat-authoritative clip from its
@@ -454,7 +454,8 @@ class ClipManager {
     void setClipGainDB(ClipId clipId, float dB);
     void setClipPan(ClipId clipId, float pan);
 
-    // Fades
+    // Fades. Seconds, as before #1901 — the fade moved onto the audio event,
+    // its units did not.
     void setFadeIn(ClipId clipId, double seconds);
     void setFadeOut(ClipId clipId, double seconds);
     void setFadeInType(ClipId clipId, int type);

--- a/magda/daw/core/ClipManager.hpp
+++ b/magda/daw/core/ClipManager.hpp
@@ -871,9 +871,18 @@ class ClipManager {
     /// Reset a looped clip's length to its base loop length and disable looping
     void resetLoopedClipLength(ClipInfo& clip);
 
+    /// Move every event off @p from and onto @p to. Used when a relink target
+    /// turns out to be pooled already, so one file keeps one source.
+    void repointEventsToSource(SourceId from, SourceId to);
+
   private:
-    ClipManager() = default;
+    ClipManager();
     ~ClipManager() = default;
+
+    /// Rescale every event on @p sourceId whose source-domain positions were
+    /// expressed at @p oldRate. Installed on SourcePool as its rate-change
+    /// handler, so resolving or relinking a file cannot move clip positions.
+    void rescaleEventsForSourceRate(SourceId sourceId, double oldRate, double newRate);
 
     double findNonOverlappingStartBeats(TrackId trackId, double desiredStartBeats,
                                         double lengthBeats, ClipView view) const;

--- a/magda/daw/core/ClipOperations.hpp
+++ b/magda/daw/core/ClipOperations.hpp
@@ -79,7 +79,6 @@ class ClipOperations {
     static inline MidiNoteRange getMidiVisibleRange(const ClipInfo& clip) {
         if (!clip.isMidi())
             return {};
-
         const double lengthBeats =
             (clip.loopEnabled && clip.loopLengthBeats > 0.0)
                 ? clip.loopLengthBeats
@@ -206,44 +205,31 @@ class ClipOperations {
         // loopLengthBeats is the authoritative source of truth and should only
         // be updated when the user explicitly changes it, not during tempo-driven resizes.
 
-        if (clip.isAudio() && !clip.audio().source.filePath.isEmpty()) {
-            bool isAutoTempo =
-                clip.autoTempo && clip.audio().interpretation.bpm > 0.0 && isValidBpm(bpm);
+        auto* event = clip.primaryEvent();
+        if (event != nullptr && !event->sourceFilePath().isEmpty()) {
+            const bool isAutoTempo = event->autoTempo && event->interpBpm > 0.0 && isValidBpm(bpm);
 
-            if (isAutoTempo) {
-                // Auto-tempo: work in beats (authoritative), derive seconds
-                double deltaBeats = actualDelta * bpm / 60.0;
-                if (!clip.loopEnabled) {
-                    clip.offsetBeats = juce::jmax(0.0, clip.offsetBeats + deltaBeats);
-                } else if (clip.loopLengthBeats > 0.0) {
-                    double relBeats = clip.offsetBeats - clip.loopStartBeats;
-                    clip.offsetBeats = clip.loopStartBeats +
-                                       wrapPhase(relBeats + deltaBeats, clip.loopLengthBeats);
-                }
-                // Derive source-time seconds for paint/display
-                clip.offset = clip.offsetBeats * 60.0 / clip.audio().interpretation.bpm;
-                if (!clip.loopEnabled)
-                    clip.loopStart = clip.offset;
+            // Beat mode and manual stretch differ only in how a timeline delta
+            // becomes a source delta: via project BPM, or via speedRatio.
+            const double sourceDelta = isAutoTempo
+                                           ? (actualDelta * bpm / 60.0) * 60.0 / event->interpBpm
+                                           : actualDelta * event->speedRatio;
+
+            if (!clip.loopEnabled) {
+                event->setAnchorSeconds(event->anchorSeconds() + sourceDelta);
+                event->loopStartSamples = event->sourceAnchorSamples;
             } else {
-                // Manual stretch: work in source-time seconds
-                double toSource = clip.speedRatio;
-                if (!clip.loopEnabled) {
-                    double sourceDelta = actualDelta * toSource;
-                    clip.offset = juce::jmax(0.0, clip.offset + sourceDelta);
-                    clip.loopStart = clip.offset;
-                } else {
-                    double sourceLength =
-                        clip.loopLength > 0.0 ? clip.loopLength : clipLength * toSource;
-                    if (sourceLength > 0.0) {
-                        double phaseDelta = actualDelta * toSource;
-                        double relOffset = clip.offset - clip.loopStart;
-                        clip.offset =
-                            clip.loopStart + wrapPhase(relOffset + phaseDelta, sourceLength);
-                    }
+                const double sourceLength = event->loopLengthSamples > 0
+                                                ? event->loopLengthSeconds()
+                                                : clipLength * event->speedRatio;
+                if (sourceLength > 0.0) {
+                    event->setAnchorSeconds(
+                        event->loopStartSeconds() +
+                        wrapPhase(event->loopPhaseSeconds() + sourceDelta, sourceLength));
                 }
             }
         } else if (clip.isMidi()) {
-            // MIDI phase lives in midiOffset (beats). Do NOT touch clip.offset.
+            // MIDI phase lives in midiOffset (beats). There is no source anchor.
             double beatsPerSecond = bpm / 60.0;
             double deltaBeat = actualDelta * beatsPerSecond;
             if (clip.loopEnabled && clip.loopLengthBeats > 0.0) {
@@ -299,26 +285,22 @@ class ClipOperations {
      */
     static inline void sanitizeAudioToSourceDuration(ClipInfo& clip, double fileDuration,
                                                      double bpm = DEFAULT_BPM) {
-        if (!clip.isAudio() || fileDuration <= 0.0)
+        auto* event = clip.primaryEvent();
+        if (event == nullptr || fileDuration <= 0.0)
             return;
         seedPlacementFromTimelineCacheIfNeeded(clip, bpm);
 
-        clip.loopStart = juce::jlimit(0.0, fileDuration, clip.loopStart);
+        event->setLoopStartSeconds(juce::jlimit(0.0, fileDuration, event->loopStartSeconds()));
 
-        const double availableFromLoop = fileDuration - clip.loopStart;
-        if (clip.loopLength > availableFromLoop) {
-            const double oldLoopLength = clip.loopLength;
-            clip.loopLength = juce::jmax(0.0, availableFromLoop);
-            if (clip.autoTempo && oldLoopLength > 0.0) {
-                clip.loopLengthBeats *= clip.loopLength / oldLoopLength;
-            }
-        }
+        const double availableFromLoop = fileDuration - event->loopStartSeconds();
+        if (event->loopLengthSeconds() > availableFromLoop)
+            event->setLoopLengthSeconds(juce::jmax(0.0, availableFromLoop));
 
-        clip.offset = juce::jlimit(0.0, fileDuration, clip.offset);
+        event->setAnchorSeconds(juce::jlimit(0.0, fileDuration, event->anchorSeconds()));
 
-        if (!clip.loopEnabled && !clip.autoTempo) {
-            const double speed = clip.speedRatio > 0.0 ? clip.speedRatio : 1.0;
-            const double maxLength = (fileDuration - clip.offset) / speed;
+        if (!clip.loopEnabled && !event->autoTempo) {
+            const double speed = event->speedRatio > 0.0 ? event->speedRatio : 1.0;
+            const double maxLength = (fileDuration - event->anchorSeconds()) / speed;
             const double currentLength = clip.getTimelineLength(bpm);
             if (currentLength > maxLength) {
                 setTimelinePlacement(clip, clip.getTimelineStart(bpm),
@@ -330,23 +312,19 @@ class ClipOperations {
     static inline void setAudioOffsetPreservingSourceRegion(ClipInfo& clip, double newOffset,
                                                             double fileDuration = 0.0,
                                                             double bpm = DEFAULT_BPM) {
-        if (!clip.isAudio())
+        auto* event = clip.primaryEvent();
+        if (event == nullptr)
             return;
         seedPlacementFromTimelineCacheIfNeeded(clip, bpm);
 
         if (fileDuration > 0.0)
             newOffset = juce::jmin(newOffset, fileDuration);
-        newOffset = juce::jmax(0.0, newOffset);
+        event->setAnchorSeconds(juce::jmax(0.0, newOffset));
 
-        clip.offset = newOffset;
-        if (clip.autoTempo && clip.audio().interpretation.bpm > 0.0) {
-            clip.offsetBeats = clip.offset * clip.audio().interpretation.bpm / 60.0;
-        }
-
-        if (!clip.loopEnabled && !clip.autoTempo && fileDuration > 0.0) {
-            const double speed = clip.speedRatio > 0.0 ? clip.speedRatio : 1.0;
+        if (!clip.loopEnabled && !event->autoTempo && fileDuration > 0.0) {
+            const double speed = event->speedRatio > 0.0 ? event->speedRatio : 1.0;
             const double currentLength = clip.getTimelineLength(bpm);
-            const double maxLength = (fileDuration - clip.offset) / speed;
+            const double maxLength = (fileDuration - event->anchorSeconds()) / speed;
             if (currentLength > maxLength) {
                 setTimelinePlacement(clip, clip.getTimelineStart(bpm),
                                      juce::jmax(MIN_CLIP_LENGTH, maxLength), bpm);
@@ -355,13 +333,11 @@ class ClipOperations {
     }
 
     static inline void setAudioLoopPhaseClamped(ClipInfo& clip, double phase) {
-        if (!clip.isAudio())
+        auto* event = clip.primaryEvent();
+        if (event == nullptr)
             return;
 
-        clip.offset = juce::jmax(0.0, clip.loopStart + phase);
-        if (clip.autoTempo && clip.audio().interpretation.bpm > 0.0) {
-            clip.offsetBeats = clip.offset * clip.audio().interpretation.bpm / 60.0;
-        }
+        event->setAnchorSeconds(juce::jmax(0.0, event->loopStartSeconds() + phase));
     }
 
     /**
@@ -373,20 +349,22 @@ class ClipOperations {
      */
     static inline void trimAudioFromLeft(ClipInfo& clip, double trimAmount,
                                          double fileDuration = 0.0, double bpm = DEFAULT_BPM) {
+        auto* event = clip.primaryEvent();
+        if (event == nullptr)
+            return;
         seedPlacementFromTimelineCacheIfNeeded(clip, bpm);
-        double sourceDelta = trimAmount * clip.speedRatio;
-        double newOffset = clip.offset + sourceDelta;
+        const double oldOffset = event->anchorSeconds();
+        double newOffset = oldOffset + trimAmount * event->speedRatio;
 
         if (fileDuration > 0.0) {
             newOffset = juce::jmin(newOffset, fileDuration);
         }
         newOffset = juce::jmax(0.0, newOffset);
 
-        double actualSourceDelta = newOffset - clip.offset;
-        double timelineDelta = actualSourceDelta / clip.speedRatio;
+        double timelineDelta = (newOffset - oldOffset) / event->speedRatio;
 
-        clip.offset = newOffset;
-        clip.loopStart = clip.offset;
+        event->setAnchorSeconds(newOffset);
+        event->loopStartSamples = event->sourceAnchorSamples;
         const double newStartTime = juce::jmax(0.0, clip.getTimelineStart(bpm) + timelineDelta);
         const double newLength =
             juce::jmax(MIN_CLIP_LENGTH, clip.getTimelineLength(bpm) - timelineDelta);
@@ -402,11 +380,14 @@ class ClipOperations {
      */
     static inline void trimAudioFromRight(ClipInfo& clip, double trimAmount,
                                           double fileDuration = 0.0, double bpm = DEFAULT_BPM) {
+        auto* event = clip.primaryEvent();
+        if (event == nullptr)
+            return;
         seedPlacementFromTimelineCacheIfNeeded(clip, bpm);
         double newLength = clip.getTimelineLength(bpm) - trimAmount;
 
         if (fileDuration > 0.0) {
-            double maxLength = (fileDuration - clip.offset) / clip.speedRatio;
+            double maxLength = (fileDuration - event->anchorSeconds()) / event->speedRatio;
             newLength = juce::jmin(newLength, maxLength);
         }
 
@@ -425,6 +406,9 @@ class ClipOperations {
      */
     static inline void stretchAudioFromRight(ClipInfo& clip, double newLength, double oldLength,
                                              double originalSpeedRatio, double bpm = DEFAULT_BPM) {
+        auto* event = clip.primaryEvent();
+        if (event == nullptr)
+            return;
         seedPlacementFromTimelineCacheIfNeeded(clip, bpm);
         newLength = juce::jmax(MIN_CLIP_LENGTH, newLength);
 
@@ -436,11 +420,11 @@ class ClipOperations {
 
         const double currentStart = clip.getTimelineStart(bpm);
         setTimelinePlacement(clip, currentStart, newLength, bpm);
-        clip.speedRatio = newSpeedRatio;
+        event->speedRatio = newSpeedRatio;
 
-        // Keep loopLength in sync for non-looped clips
+        // Keep the source region in sync for non-looped events
         if (!clip.loopEnabled)
-            clip.loopLength = clip.timelineToSource(clip.getTimelineLength(bpm));
+            event->setLoopLengthSeconds(event->timelineToSource(clip.getTimelineLength(bpm)));
     }
 
     /**
@@ -453,6 +437,9 @@ class ClipOperations {
      */
     static inline void stretchAudioFromLeft(ClipInfo& clip, double newLength, double oldLength,
                                             double originalSpeedRatio, double bpm = DEFAULT_BPM) {
+        auto* event = clip.primaryEvent();
+        if (event == nullptr)
+            return;
         seedPlacementFromTimelineCacheIfNeeded(clip, bpm);
         double rightEdge = clip.getTimelineEnd(bpm);
 
@@ -473,11 +460,11 @@ class ClipOperations {
 
         const double newStart = rightEdge - newLength;
         setTimelinePlacement(clip, newStart, newLength, bpm);
-        clip.speedRatio = newSpeedRatio;
+        event->speedRatio = newSpeedRatio;
 
-        // Keep loopLength in sync for non-looped clips
+        // Keep the source region in sync for non-looped events
         if (!clip.loopEnabled)
-            clip.loopLength = clip.timelineToSource(clip.getTimelineLength(bpm));
+            event->setLoopLengthSeconds(event->timelineToSource(clip.getTimelineLength(bpm)));
     }
 
     // ========================================================================
@@ -491,13 +478,14 @@ class ClipOperations {
      * @param newLength New clip length
      */
     static inline void stretchClipFromLeft(ClipInfo& clip, double newLength) {
-        if (!clip.isAudio() || clip.audio().source.filePath.isEmpty()) {
+        auto* event = clip.primaryEvent();
+        if (event == nullptr || event->sourceFilePath().isEmpty()) {
             resizeContainerFromLeft(clip, newLength);
             return;
         }
 
         double oldLength = clip.getTimelineLength(DEFAULT_BPM);
-        double originalSpeedRatio = clip.speedRatio;
+        double originalSpeedRatio = event->speedRatio;
 
         newLength = juce::jmax(MIN_CLIP_LENGTH, newLength);
         double lengthDelta = oldLength - newLength;
@@ -515,13 +503,14 @@ class ClipOperations {
      * @param newLength New clip length
      */
     static inline void stretchClipFromRight(ClipInfo& clip, double newLength) {
-        if (!clip.isAudio() || clip.audio().source.filePath.isEmpty()) {
+        auto* event = clip.primaryEvent();
+        if (event == nullptr || event->sourceFilePath().isEmpty()) {
             resizeContainerFromRight(clip, newLength);
             return;
         }
 
         double oldLength = clip.getTimelineLength(DEFAULT_BPM);
-        double originalSpeedRatio = clip.speedRatio;
+        double originalSpeedRatio = event->speedRatio;
 
         resizeContainerFromRight(clip, newLength);
 
@@ -583,31 +572,31 @@ class ClipOperations {
      * scales with them.
      */
     static inline void applyAutoTempoStretch(ClipInfo& clip, double ratio) {
-        if (!clip.isAudio() || !(ratio > 0.0) || ratio == 1.0)
+        auto* event = clip.primaryEvent();
+        if (event == nullptr || !(ratio > 0.0) || ratio == 1.0)
             return;
-        auto& interp = clip.audio().interpretation;
-        if (interp.totalBeats > 0.0)
-            interp.totalBeats *= ratio;
-        if (interp.bpm > 0.0)
-            interp.bpm *= ratio;
-        clip.loopStartBeats *= ratio;
-        clip.loopLengthBeats *= ratio;
-        clip.offsetBeats *= ratio;
+        if (event->interpTotalBeats > 0.0)
+            event->interpTotalBeats *= ratio;
+        if (event->interpBpm > 0.0)
+            event->interpBpm *= ratio;
+        // The anchor and loop region are fixed source samples; their beat views
+        // scale with interpBpm on their own, so there is nothing else to touch.
     }
 
     static inline void stretchAbsolute(ClipInfo& clip, double newSpeedRatio, double newLength,
                                        double bpm = DEFAULT_BPM) {
+        auto* event = clip.primaryEvent();
         seedPlacementFromTimelineCacheIfNeeded(clip, bpm);
         const double currentStart = clip.getTimelineStart(bpm);
         const double oldLengthBeats = clip.placement.lengthBeats;
         setTimelinePlacement(clip, currentStart, newLength, bpm);
-        if (clip.autoTempo && isValidBpm(bpm)) {
+        if (event != nullptr && event->autoTempo && isValidBpm(bpm)) {
             double newBeats = newLength * bpm / 60.0;
             if (oldLengthBeats > 0.0)
                 applyAutoTempoStretch(clip, newBeats / oldLengthBeats);
             setAutoTempoPlacementLengthBeats(clip, newBeats, bpm);
-        } else {
-            clip.speedRatio = newSpeedRatio;
+        } else if (event != nullptr) {
+            event->speedRatio = newSpeedRatio;
         }
     }
 
@@ -623,16 +612,17 @@ class ClipOperations {
     static inline void stretchAbsoluteFromLeft(ClipInfo& clip, double newSpeedRatio,
                                                double newLength, double rightEdge,
                                                double bpm = DEFAULT_BPM) {
+        auto* event = clip.primaryEvent();
         seedPlacementFromTimelineCacheIfNeeded(clip, bpm);
         const double oldLengthBeats = clip.placement.lengthBeats;
         setTimelinePlacement(clip, rightEdge - newLength, newLength, bpm);
-        if (clip.autoTempo && isValidBpm(bpm)) {
+        if (event != nullptr && event->autoTempo && isValidBpm(bpm)) {
             double newBeats = newLength * bpm / 60.0;
             if (oldLengthBeats > 0.0)
                 applyAutoTempoStretch(clip, newBeats / oldLengthBeats);
             setAutoTempoPlacementLengthBeats(clip, newBeats, bpm);
-        } else {
-            clip.speedRatio = newSpeedRatio;
+        } else if (event != nullptr) {
+            event->speedRatio = newSpeedRatio;
         }
     }
 
@@ -655,63 +645,34 @@ class ClipOperations {
     /**
      * @brief Calculate the beat-based loop range for Tracktion Engine sync
      *
-     * Converts model beat values (project beats) to SOURCE beats for TE.
-     * TE's loopStartBeats/loopLengthBeats are in source-file beats (clamped
-     * to loopInfo.getNumBeats()), NOT project-timeline beats.
+     * TE's loopStartBeats/loopLengthBeats are in source-file beats (clamped to
+     * loopInfo.getNumBeats()), which is exactly the beat view of the event's
+     * source-domain loop region.
      *
-     * @param clip The clip to calculate for
-     * @param bpm Current project tempo
+     * @param event The event to calculate for
      * @return Pair of (loopStartBeats, loopLengthBeats) in SOURCE beats
      */
-    static inline std::pair<double, double> getAutoTempoBeatRange(const ClipInfo& clip,
-                                                                  double /*bpm*/) {
-        if (!clip.autoTempo && !clip.warpEnabled) {
+    static inline std::pair<double, double> getAutoTempoBeatRange(const AudioEvent& event) {
+        if (!event.autoTempo && !event.warpEnabled)
             return {0.0, 0.0};
-        }
 
-        // Use stored beat values when available (set by setAutoTempo / setClipBeats)
-        if (clip.loopLengthBeats > 0.0) {
-            double start = clip.loopStartBeats;
-            double length = clip.loopLengthBeats;
-            // Clamp to the interpreted source beat extent (TE can't read beyond the file)
-            if (clip.audio().interpretation.totalBeats > 0.0) {
-                if (length > clip.audio().interpretation.totalBeats) {
-                    length = clip.audio().interpretation.totalBeats;
-                    start = 0.0;
-                } else if (start + length > clip.audio().interpretation.totalBeats) {
-                    start = clip.audio().interpretation.totalBeats - length;
-                    if (start < 0.0)
-                        start = 0.0;
-                }
+        double start = event.loopStartBeats();
+        double length = event.loopLengthBeats();
+        if (length <= 0.0)
+            return {0.0, 0.0};
+
+        // TE's setLoopRangeBeats clamps the end to loopInfo.getNumBeats(). In
+        // time-based mode loops can wrap past the file end, beat-based mode
+        // cannot, so shift the start back until the whole region fits.
+        if (event.interpTotalBeats > 0.0) {
+            if (length > event.interpTotalBeats) {
+                length = event.interpTotalBeats;
+                start = 0.0;
+            } else if (start + length > event.interpTotalBeats) {
+                start = juce::jmax(0.0, event.interpTotalBeats - length);
             }
-            return {start, length};
         }
-
-        // Derive from source-time seconds using the source interpretation BPM
-        if (clip.audio().interpretation.bpm > 0.0) {
-            double srcBps = clip.audio().interpretation.bpm / 60.0;
-            double start = clip.loopStart * srcBps;
-            double length = clip.loopLength * srcBps;
-
-            // TE's setLoopRangeBeats clamps end to loopInfo.getNumBeats().
-            // In time-based mode loops can wrap past file end, but beat-based
-            // mode cannot. Shift the start back so the full region fits.
-            if (clip.audio().interpretation.totalBeats > 0.0) {
-                if (length > clip.audio().interpretation.totalBeats) {
-                    length = clip.audio().interpretation.totalBeats;
-                    start = 0.0;
-                } else if (start + length > clip.audio().interpretation.totalBeats) {
-                    start = clip.audio().interpretation.totalBeats - length;
-                    if (start < 0.0)
-                        start = 0.0;
-                }
-            }
-
-            return {start, length};
-        }
-
-        // Fallback: return project beats (correct only when project BPM == source BPM)
-        return {clip.loopStartBeats, clip.loopLengthBeats};
+        return {start, length};
     }
 
     /**
@@ -724,16 +685,27 @@ class ClipOperations {
      */
     static inline void setClipLengthBeats(ClipInfo& clip, double lengthBeats, double loopStartBeats,
                                           double loopLengthBeats, double bpm) {
-        clip.autoTempo = true;
+        auto* event = clip.primaryEvent();
+        if (event == nullptr)
+            return;
+
+        event->autoTempo = true;
         clip.setPlacementBeats(clip.placement.startBeat, lengthBeats);
-        clip.loopLengthBeats = loopLengthBeats > 0.0 ? loopLengthBeats : lengthBeats;
-        clip.loopStartBeats = loopStartBeats;
+
+        // Source beats need the SOURCE tempo to become source seconds. Fall
+        // back to the project tempo while detection has not produced one yet.
+        const double srcBpm = event->interpBpm > 0.0 ? event->interpBpm : bpm;
+        if (srcBpm > 0.0) {
+            const double regionBeats = loopLengthBeats > 0.0 ? loopLengthBeats : lengthBeats;
+            event->setLoopLengthSeconds(regionBeats * 60.0 / srcBpm);
+            event->setLoopStartSeconds(loopStartBeats * 60.0 / srcBpm);
+        }
 
         // Update time-based fields (derived values)
         clip.setLengthFromBeats(lengthBeats, bpm);
 
         // Auto-tempo requires speedRatio=1.0
-        clip.speedRatio = 1.0;
+        event->speedRatio = 1.0;
     }
 
     /**
@@ -743,7 +715,8 @@ class ClipOperations {
      * @param bpm Current tempo for conversion
      */
     static inline void setAutoTempo(ClipInfo& clip, bool enabled, double bpm) {
-        if (clip.autoTempo == enabled)
+        auto* event = clip.primaryEvent();
+        if (event == nullptr || event->autoTempo == enabled)
             return;
 
         if (enabled && !isValidBpm(bpm))
@@ -751,23 +724,15 @@ class ClipOperations {
 
         seedPlacementFromTimelineCacheIfNeeded(clip, bpm);
 
-        const double currentSourceOffset = clip.getSourceOffset();
-        const double currentLoopStart = clip.getSourceLoopStart();
-        const double currentLoopLength = clip.getSourceLoopLength();
-
-        clip.autoTempo = enabled;
+        event->autoTempo = enabled;
 
         if (enabled) {
-            clip.analogPitch = false;  // Analog pitch is incompatible with autoTempo
+            event->analogPitch = false;  // Analog pitch is incompatible with autoTempo
 
             // Auto-tempo requires time-stretching. Preserve any explicitly selected
             // engine, otherwise enable the default quality engine.
-            if (clip.timeStretchMode == time_stretch_mode::kDisabled)
-                clip.timeStretchMode = time_stretch_mode::kSignalsmith;
-
-            // Convert current offset to beats
-            if (clip.audio().interpretation.bpm > 0.0)
-                clip.offsetBeats = clip.offset * clip.audio().interpretation.bpm / 60.0;
+            if (event->timeStretchMode == time_stretch_mode::kDisabled)
+                event->timeStretchMode = time_stretch_mode::kSignalsmith;
 
             // Preserve current timeline position in beat-domain placement.
             clip.setPlacementBeats(clip.getStartBeats(bpm), clip.placement.lengthBeats);
@@ -775,8 +740,8 @@ class ClipOperations {
             // Enable looping (required for TE's autoTempo beat range to work)
             if (!clip.loopEnabled) {
                 clip.loopEnabled = true;
-                clip.loopStart = clip.offset;
-                clip.setLoopLengthFromTimeline(clip.getTimelineLength(bpm));
+                event->loopStartSamples = event->sourceAnchorSamples;
+                event->setLoopLengthSeconds(event->timelineToSource(clip.getTimelineLength(bpm)));
             }
 
             // Issue #1157: when a full, untrimmed source file carries source
@@ -787,59 +752,48 @@ class ClipOperations {
             // back to the full source loop.
             //
             // Prefer interpretation-derived duration (totalBeats × 60 /
-            // sourceBpm) — interpretation is the calibrated musical view of
-            // the file, while source.durationSeconds may have been written by
-            // ClipSynchronizer's setSourceMetadata from TE's auto-detected
-            // loopInfo (often a project-default fallback) before the user or
-            // a later detection pass refined the interpretation. Falling back
-            // to durationSeconds only when interpretation is incomplete.
+            // interpBpm) — the interpretation is the calibrated musical view of
+            // the file, while the pooled source duration is the raw file fact
+            // and may predate a later detection pass.
             double naturalSourceDuration = 0.0;
-            if (clip.audio().interpretation.bpm > 0.0 &&
-                clip.audio().interpretation.totalBeats > 0.0) {
-                naturalSourceDuration =
-                    clip.audio().interpretation.totalBeats * 60.0 / clip.audio().interpretation.bpm;
-            } else if (clip.audio().source.durationSeconds > 0.0) {
-                naturalSourceDuration = clip.audio().source.durationSeconds;
+            if (event->interpBpm > 0.0 && event->interpTotalBeats > 0.0) {
+                naturalSourceDuration = event->interpTotalBeats * 60.0 / event->interpBpm;
+            } else if (event->sourceDurationSeconds() > 0.0) {
+                naturalSourceDuration = event->sourceDurationSeconds();
             }
-            const auto sourceSpan = clip.timelineToSource(clip.getTimelineLength(bpm));
+            const auto sourceSpan = event->timelineToSource(clip.getTimelineLength(bpm));
             const bool coversFullSource = naturalSourceDuration > 0.0 &&
-                                          currentSourceOffset <= 0.001 &&
+                                          event->anchorSeconds() <= 0.001 &&
                                           std::abs(sourceSpan - naturalSourceDuration) <= 0.001;
 
-            if (coversFullSource && clip.audio().interpretation.totalBeats > 0.0)
-                clip.setPlacementBeats(clip.placement.startBeat,
-                                       clip.audio().interpretation.totalBeats);
+            if (coversFullSource && event->interpTotalBeats > 0.0)
+                clip.setPlacementBeats(clip.placement.startBeat, event->interpTotalBeats);
             else
                 clip.setPlacementBeats(clip.placement.startBeat, clip.getLengthInBeats(bpm));
 
-            // loopLengthBeats lives in the source-beat domain, so it is
-            // derived from source interpretation BPM. When that BPM is unknown
-            // we fall back to project BPM until detection/metadata lands.
-            double srcBpm =
-                clip.audio().interpretation.bpm > 0.0 ? clip.audio().interpretation.bpm : bpm;
-            if (clip.loopEnabled && clip.loopLength > 0.0) {
-                clip.loopLengthBeats = clip.loopLength * srcBpm / 60.0;
-                clip.loopStartBeats = clip.loopStart * srcBpm / 60.0;
-            } else {
-                clip.loopLengthBeats = clip.audio().interpretation.totalBeats > 0.0
-                                           ? clip.audio().interpretation.totalBeats
-                                           : clip.placement.lengthBeats;
-                clip.loopStartBeats = 0.0;
+            // A loop region already set is source-domain and needs no
+            // re-derivation. Only a clip that had none needs one seeded, in
+            // source seconds via the source tempo (project tempo while
+            // detection has not produced one yet).
+            if (event->loopLengthSamples <= 0) {
+                const double srcBpm = event->interpBpm > 0.0 ? event->interpBpm : bpm;
+                const double regionBeats = event->interpTotalBeats > 0.0
+                                               ? event->interpTotalBeats
+                                               : clip.placement.lengthBeats;
+                if (srcBpm > 0.0)
+                    event->setLoopLengthSeconds(regionBeats * 60.0 / srcBpm);
+                event->loopStartSamples = 0;
             }
 
             // Force speedRatio to 1.0 (TE requirement for autoTempo)
-            clip.speedRatio = 1.0;
-        } else {
-            // Timeline placement remains beat-domain; only disable source auto-tempo behavior.
-            clip.offset = juce::jmax(0.0, currentSourceOffset);
-            clip.loopStart = juce::jmax(0.0, currentLoopStart);
-            clip.loopLength = juce::jmax(0.0, currentLoopLength);
-            if (clip.loopEnabled && clip.loopLength > 0.0) {
-                clip.offset =
-                    clip.loopStart + wrapPhase(clip.offset - clip.loopStart, clip.loopLength);
-            }
-            clip.loopStartBeats = 0.0;
-            clip.loopLengthBeats = 0.0;
+            event->speedRatio = 1.0;
+        } else if (clip.loopEnabled && event->loopLengthSamples > 0) {
+            // Timeline placement remains beat-domain. The source region is
+            // already in samples and survives the mode change untouched; only
+            // the read phase needs re-wrapping into the region.
+            event->setAnchorSeconds(
+                event->loopStartSeconds() +
+                wrapPhase(event->loopPhaseSeconds(), event->loopLengthSeconds()));
         }
     }
 
@@ -889,22 +843,20 @@ class ClipOperations {
      */
     static inline void moveLoopStart(ClipInfo& clip, double newLoopStart, double fileDuration,
                                      double bpm = DEFAULT_BPM) {
+        auto* event = clip.primaryEvent();
+        if (event == nullptr)
+            return;
         seedPlacementFromTimelineCacheIfNeeded(clip, bpm);
-        double oldLoopLength = clip.loopLength;
-        clip.loopStart = newLoopStart;
-        // Clamp loopLength to available audio from new loopStart
+        event->setLoopStartSeconds(newLoopStart);
+        // Clamp the loop region to the audio available from the new start
         if (fileDuration > 0.0) {
-            double avail = fileDuration - clip.loopStart;
-            if (clip.loopLength > avail) {
-                clip.loopLength = juce::jmax(0.0, avail);
-                if (oldLoopLength > 0.0) {
-                    clip.loopLengthBeats *= clip.loopLength / oldLoopLength;
-                }
-            }
+            const double avail = fileDuration - event->loopStartSeconds();
+            if (event->loopLengthSeconds() > avail)
+                event->setLoopLengthSeconds(juce::jmax(0.0, avail));
         }
-        if (!clip.loopEnabled && !clip.autoTempo && fileDuration > 0.0) {
-            const double speed = clip.speedRatio > 0.0 ? clip.speedRatio : 1.0;
-            const double maxLength = (fileDuration - clip.offset) / speed;
+        if (!clip.loopEnabled && !event->autoTempo && fileDuration > 0.0) {
+            const double speed = event->speedRatio > 0.0 ? event->speedRatio : 1.0;
+            const double maxLength = (fileDuration - event->anchorSeconds()) / speed;
             if (clip.getTimelineLength(bpm) > maxLength) {
                 setTimelinePlacement(clip, clip.getTimelineStart(bpm),
                                      juce::jmax(MIN_CLIP_LENGTH, maxLength), bpm);
@@ -921,7 +873,10 @@ class ClipOperations {
      */
     static inline void resizeSourceExtent(ClipInfo& clip, double newTimelineExtent,
                                           double bpm = DEFAULT_BPM) {
-        clip.setLoopLengthFromTimeline(newTimelineExtent);
+        auto* event = clip.primaryEvent();
+        if (event == nullptr)
+            return;
+        event->setLoopLengthSeconds(event->timelineToSource(newTimelineExtent));
         if (!clip.loopEnabled) {
             const double currentStart = clip.getTimelineStart(bpm);
             setTimelinePlacement(clip, currentStart, newTimelineExtent, bpm);
@@ -941,13 +896,16 @@ class ClipOperations {
     static inline void stretchEditor(ClipInfo& clip, double newSpeedRatio,
                                      double clipLengthScaleFactor, double dragStartClipLength,
                                      double dragStartExtent, double bpm = DEFAULT_BPM) {
-        clip.speedRatio = newSpeedRatio;
+        auto* event = clip.primaryEvent();
+        if (event == nullptr)
+            return;
+        event->speedRatio = newSpeedRatio;
         const double currentStart = clip.getTimelineStart(bpm);
         setTimelinePlacement(clip, currentStart, dragStartClipLength * clipLengthScaleFactor, bpm);
-        // In loop mode, adjust loopLength to keep loop markers fixed on timeline
-        if (clip.loopEnabled && clip.loopLength > 0.0) {
-            clip.loopLength = dragStartExtent / newSpeedRatio;
-        }
+        // In loop mode, adjust the source region to keep the loop markers fixed
+        // on the timeline
+        if (clip.loopEnabled && event->loopLengthSamples > 0)
+            event->setLoopLengthSeconds(dragStartExtent / newSpeedRatio);
     }
 
     /**
@@ -964,13 +922,16 @@ class ClipOperations {
                                              double clipLengthScaleFactor,
                                              double dragStartClipLength, double dragStartExtent,
                                              double rightEdge, double bpm = DEFAULT_BPM) {
-        clip.speedRatio = newSpeedRatio;
+        auto* event = clip.primaryEvent();
+        if (event == nullptr)
+            return;
+        event->speedRatio = newSpeedRatio;
         const double newLength = dragStartClipLength * clipLengthScaleFactor;
         setTimelinePlacement(clip, rightEdge - newLength, newLength, bpm);
-        // In loop mode, adjust loopLength to keep loop markers fixed on timeline
-        if (clip.loopEnabled && clip.loopLength > 0.0) {
-            clip.loopLength = dragStartExtent / newSpeedRatio;
-        }
+        // In loop mode, adjust the source region to keep the loop markers fixed
+        // on the timeline
+        if (clip.loopEnabled && event->loopLengthSamples > 0)
+            event->setLoopLengthSeconds(dragStartExtent / newSpeedRatio);
     }
 
     // =========================================================================
@@ -987,7 +948,6 @@ class ClipOperations {
     static inline void flattenMidiClip(ClipInfo& clip) {
         if (!clip.isMidi())
             return;
-
         std::vector<MidiNote> flatNotes;
         double clipLen = clip.lengthBeats;
 
@@ -1071,12 +1031,10 @@ class ClipOperations {
             clip.midiPitchBendData = std::move(flatPB);
 
             clip.loopEnabled = false;
+            clip.loopLengthBeats = 0.0;
+            clip.loopStartBeats = 0.0;
             clip.midiOffset = 0.0;
             clip.midiTrimOffset = 0.0;
-            clip.loopLengthBeats = 0.0;
-            clip.loopLength = 0.0;
-            clip.loopStart = 0.0;
-            clip.loopStartBeats = 0.0;
         } else {
             // Non-looped: apply midiTrimOffset
             double trimOffset = clip.midiTrimOffset;

--- a/magda/daw/core/ClipOperations.hpp
+++ b/magda/daw/core/ClipOperations.hpp
@@ -219,9 +219,15 @@ class ClipOperations {
                 event->setAnchorSeconds(event->anchorSeconds() + sourceDelta);
                 event->loopStartSamples = event->sourceAnchorSamples;
             } else {
-                const double sourceLength = event->loopLengthSamples > 0
-                                                ? event->loopLengthSeconds()
-                                                : clipLength * event->speedRatio;
+                // With no region set, beat mode has no period to wrap in:
+                // clipLength is timeline seconds at project tempo and
+                // speedRatio is pinned to 1, so using it as a source period
+                // would wrap by the wrong amount. Leave the phase alone, as
+                // the beat-domain path did before the event split.
+                const double sourceLength =
+                    event->loopLengthSamples > 0
+                        ? event->loopLengthSeconds()
+                        : (isAutoTempo ? 0.0 : clipLength * event->speedRatio);
                 if (sourceLength > 0.0) {
                     event->setAnchorSeconds(
                         event->loopStartSeconds() +

--- a/magda/daw/core/ClipPropertyCommands.hpp
+++ b/magda/daw/core/ClipPropertyCommands.hpp
@@ -89,7 +89,9 @@ class SetClipOffsetCommand : public UndoableCommand {
         if (clip) {
             oldClip_ = *clip;
             hasOldClip_ = true;
-            oldOffset_ = (clip->isMidi()) ? clip->midiOffset : clip->getSourceOffset();
+            const auto* ev = clip->primaryEvent();
+            oldOffset_ =
+                clip->isMidi() ? clip->midiOffset : (ev != nullptr ? ev->anchorSeconds() : 0.0);
         }
     }
 
@@ -133,9 +135,11 @@ class SetClipLoopPhaseCommand : public UndoableCommand {
   public:
     SetClipLoopPhaseCommand(ClipId clipId, double newPhase) : clipId_(clipId), newPhase_(newPhase) {
         auto* clip = ClipManager::getInstance().getClip(clipId);
-        if (clip)
-            oldPhase_ = (clip->isMidi()) ? clip->midiOffset
-                                         : clip->getSourceOffset() - clip->getSourceLoopStart();
+        if (clip != nullptr) {
+            const auto* ev = clip->primaryEvent();
+            oldPhase_ =
+                clip->isMidi() ? clip->midiOffset : (ev != nullptr ? ev->loopPhaseSeconds() : 0.0);
+        }
     }
 
     void execute() override {
@@ -186,7 +190,8 @@ class SetClipLoopStartCommand : public UndoableCommand {
     SetClipLoopStartCommand(ClipId clipId, double newLoopStart, double bpm = 120.0)
         : clipId_(clipId), newLoopStart_(newLoopStart), bpm_(bpm) {
         if (auto* clip = ClipManager::getInstance().getClip(clipId))
-            oldLoopStart_ = clip->getSourceLoopStart();
+            if (const auto* ev = clip->primaryEvent())
+                oldLoopStart_ = ev->loopStartSeconds();
     }
 
     void execute() override {
@@ -224,7 +229,8 @@ class SetClipLoopLengthCommand : public UndoableCommand {
     SetClipLoopLengthCommand(ClipId clipId, double newLoopLength, double bpm = 120.0)
         : clipId_(clipId), newLoopLength_(newLoopLength), bpm_(bpm) {
         if (auto* clip = ClipManager::getInstance().getClip(clipId))
-            oldLoopLength_ = clip->getSourceLoopLength();
+            if (const auto* ev = clip->primaryEvent())
+                oldLoopLength_ = ev->loopLengthSeconds();
     }
 
     void execute() override {
@@ -259,7 +265,8 @@ class SetMidiClipLoopStartBeatsCommand : public UndoableCommand {
     SetMidiClipLoopStartBeatsCommand(ClipId clipId, double newLoopStartBeats, double bpm = 120.0)
         : clipId_(clipId), newLoopStartBeats_(newLoopStartBeats), bpm_(bpm) {
         if (auto* clip = ClipManager::getInstance().getClip(clipId))
-            oldLoopStartBeats_ = clip->loopStartBeats;
+            if (clip->isMidi())
+                oldLoopStartBeats_ = clip->loopStartBeats;
     }
 
     void execute() override {
@@ -294,7 +301,8 @@ class SetMidiClipLoopLengthBeatsCommand : public UndoableCommand {
     SetMidiClipLoopLengthBeatsCommand(ClipId clipId, double newLoopLengthBeats, double bpm = 120.0)
         : clipId_(clipId), newLoopLengthBeats_(newLoopLengthBeats), bpm_(bpm) {
         if (auto* clip = ClipManager::getInstance().getClip(clipId))
-            oldLoopLengthBeats_ = clip->loopLengthBeats;
+            if (clip->isMidi())
+                oldLoopLengthBeats_ = clip->loopLengthBeats;
     }
 
     void execute() override {
@@ -337,9 +345,13 @@ class SetClipLoopRangeCommand : public UndoableCommand {
                             double bpm = 120.0)
         : clipId_(clipId), newLoopStart_(newLoopStart), newLoopLength_(newLoopLength), bpm_(bpm) {
         if (auto* clip = ClipManager::getInstance().getClip(clipId)) {
-            oldLoopStart_ = clip->loopStart;
-            oldLoopLength_ = clip->loopLength;
-            oldOffset_ = (clip->isMidi()) ? clip->midiOffset : clip->offset;
+            const auto* ev = clip->primaryEvent();
+            if (ev != nullptr) {
+                oldLoopStart_ = ev->loopStartSeconds();
+                oldLoopLength_ = ev->loopLengthSeconds();
+            }
+            oldOffset_ =
+                clip->isMidi() ? clip->midiOffset : (ev != nullptr ? ev->anchorSeconds() : 0.0);
         }
     }
 
@@ -385,7 +397,8 @@ class SetClipPitchCommand : public UndoableCommand {
     SetClipPitchCommand(ClipId clipId, float newPitch) : clipId_(clipId), newPitch_(newPitch) {
         auto* clip = ClipManager::getInstance().getClip(clipId);
         if (clip)
-            oldPitch_ = clip->pitchChange;
+            if (const auto* ev = clip->primaryEvent())
+                oldPitch_ = ev->pitchChange;
     }
 
     void execute() override {
@@ -421,7 +434,8 @@ class SetClipSpeedRatioCommand : public UndoableCommand {
         : clipId_(clipId), newRatio_(newRatio) {
         auto* clip = ClipManager::getInstance().getClip(clipId);
         if (clip)
-            oldRatio_ = clip->speedRatio;
+            if (const auto* ev = clip->primaryEvent())
+                oldRatio_ = ev->speedRatio;
     }
 
     void execute() override {
@@ -456,7 +470,8 @@ class SetClipStretchModeCommand : public UndoableCommand {
     SetClipStretchModeCommand(ClipId clipId, int newMode) : clipId_(clipId), newMode_(newMode) {
         auto* clip = ClipManager::getInstance().getClip(clipId);
         if (clip)
-            oldMode_ = clip->timeStretchMode;
+            if (const auto* ev = clip->primaryEvent())
+                oldMode_ = ev->timeStretchMode;
     }
 
     void execute() override {
@@ -588,7 +603,8 @@ class SetClipReversedCommand : public UndoableCommand {
         : clipId_(clipId), newReversed_(newReversed) {
         auto* clip = ClipManager::getInstance().getClip(clipId);
         if (clip)
-            oldReversed_ = clip->isReversed;
+            if (const auto* ev = clip->primaryEvent())
+                oldReversed_ = ev->reversed;
     }
 
     void execute() override {
@@ -614,7 +630,8 @@ class SetClipFadeInCommand : public UndoableCommand {
     SetClipFadeInCommand(ClipId clipId, double newFadeIn) : clipId_(clipId), newFadeIn_(newFadeIn) {
         auto* clip = ClipManager::getInstance().getClip(clipId);
         if (clip)
-            oldFadeIn_ = clip->fadeIn;
+            if (const auto* ev = clip->primaryEvent())
+                oldFadeIn_ = ev->fadeInSeconds;
     }
 
     void execute() override {
@@ -650,7 +667,8 @@ class SetClipFadeOutCommand : public UndoableCommand {
         : clipId_(clipId), newFadeOut_(newFadeOut) {
         auto* clip = ClipManager::getInstance().getClip(clipId);
         if (clip)
-            oldFadeOut_ = clip->fadeOut;
+            if (const auto* ev = clip->primaryEvent())
+                oldFadeOut_ = ev->fadeOutSeconds;
     }
 
     void execute() override {
@@ -760,7 +778,8 @@ class SetClipFadeInTypeCommand : public UndoableCommand {
     SetClipFadeInTypeCommand(ClipId clipId, int newType) : clipId_(clipId), newType_(newType) {
         auto* clip = ClipManager::getInstance().getClip(clipId);
         if (clip)
-            oldType_ = clip->fadeInType;
+            if (const auto* ev = clip->primaryEvent())
+                oldType_ = ev->fadeInType;
     }
 
     void execute() override {
@@ -786,7 +805,8 @@ class SetClipFadeOutTypeCommand : public UndoableCommand {
     SetClipFadeOutTypeCommand(ClipId clipId, int newType) : clipId_(clipId), newType_(newType) {
         auto* clip = ClipManager::getInstance().getClip(clipId);
         if (clip)
-            oldType_ = clip->fadeOutType;
+            if (const auto* ev = clip->primaryEvent())
+                oldType_ = ev->fadeOutType;
     }
 
     void execute() override {
@@ -813,7 +833,8 @@ class SetClipFadeInBehaviourCommand : public UndoableCommand {
         : clipId_(clipId), newBehaviour_(newBehaviour) {
         auto* clip = ClipManager::getInstance().getClip(clipId);
         if (clip)
-            oldBehaviour_ = clip->fadeInBehaviour;
+            if (const auto* ev = clip->primaryEvent())
+                oldBehaviour_ = ev->fadeInBehaviour;
     }
 
     void execute() override {
@@ -840,7 +861,8 @@ class SetClipFadeOutBehaviourCommand : public UndoableCommand {
         : clipId_(clipId), newBehaviour_(newBehaviour) {
         auto* clip = ClipManager::getInstance().getClip(clipId);
         if (clip)
-            oldBehaviour_ = clip->fadeOutBehaviour;
+            if (const auto* ev = clip->primaryEvent())
+                oldBehaviour_ = ev->fadeOutBehaviour;
     }
 
     void execute() override {

--- a/magda/daw/core/ClipTypes.hpp
+++ b/magda/daw/core/ClipTypes.hpp
@@ -9,6 +9,24 @@ using ClipId = int;
 constexpr ClipId INVALID_CLIP_ID = -1;
 
 /**
+ * @brief Unique identifier for a pooled media source (#1901).
+ *
+ * Type-agnostic on purpose: audio sources use it today, a MIDI equivalent
+ * reuses the same scheme later. Unique within a project, stable across saves.
+ */
+using SourceId = int;
+constexpr SourceId INVALID_SOURCE_ID = -1;
+
+/**
+ * @brief Identifier for an event inside its owning clip (#1901).
+ *
+ * Unique within the clip only, NOT project-wide: an event is addressed as
+ * (ClipId, EventId). Copying a clip copies its event ids verbatim.
+ */
+using EventId = int;
+constexpr EventId INVALID_EVENT_ID = -1;
+
+/**
  * @brief Clip types
  */
 enum class ClipType {

--- a/magda/daw/core/Source.hpp
+++ b/magda/daw/core/Source.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+
+#include "ClipTypes.hpp"
+
+namespace magda {
+
+/**
+ * @brief Sample rate assumed for a source whose file has never opened.
+ *
+ * Event anchors are stored in source-domain samples, so an anchor cannot be
+ * computed for a file we have never read. Migration and clip creation fall back
+ * to this nominal rate; the first successful open rescales the anchors of every
+ * event pointing at that source (see SourcePool::resolveFacts). The transition
+ * that triggers the rescale is Source::sampleRate going 0 -> real, so no extra
+ * "needs rescale" flag exists.
+ */
+constexpr double kUnresolvedSourceSampleRate = 48000.0;
+
+/**
+ * @brief Immutable facts about one media file, pooled per file (#1901).
+ *
+ * Level 3 of the clip model: Clip (container) hosts AudioEvents, each AudioEvent
+ * references a Source. A Source is never user-editable. Everything a user can
+ * change about how a file is heard (BPM, key, warp, stretch, pitch) lives on the
+ * event; the Source only seeds the defaults for newly created events and acts as
+ * the join point with the media database.
+ */
+struct Source {
+    SourceId id = INVALID_SOURCE_ID;
+    juce::String filePath;
+
+    /// On-disk duration. The ONE seconds value the clip model is allowed to
+    /// carry: it is a property of the file, not of any musical timeline.
+    double durationSeconds = 0.0;
+
+    /// Native sample rate of the file. 0 means the file has never been opened
+    /// successfully (missing, unsupported, or not probed yet).
+    double sampleRate = 0.0;
+
+    // ---- Analysis (detected, not user-owned) --------------------------------
+
+    /// Detected/library tempo. Seeds AudioEvent::interpBpm for new events; the
+    /// event keeps its own copy once created so re-analysis never rewrites a
+    /// user's interpretation.
+    double detectedBpm = 0.0;
+
+    /// Detected/library key. "C".."B" and "major"/"minor"; empty = unknown.
+    std::string detectedKeyRoot;
+    std::string detectedKeyScale;
+
+    /// True once the file has been read and its facts are trustworthy.
+    bool isResolved() const {
+        return sampleRate > 0.0;
+    }
+
+    /// Rate to use when converting between source seconds and source samples.
+    double effectiveSampleRate() const {
+        return sampleRate > 0.0 ? sampleRate : kUnresolvedSourceSampleRate;
+    }
+
+    /// Source-domain seconds -> source-domain samples.
+    int64_t secondsToSamples(double seconds) const {
+        return static_cast<int64_t>(std::llround(seconds * effectiveSampleRate()));
+    }
+
+    /// Source-domain samples -> source-domain seconds.
+    double samplesToSeconds(int64_t samples) const {
+        return static_cast<double>(samples) / effectiveSampleRate();
+    }
+
+    bool operator==(const Source&) const = default;
+};
+
+}  // namespace magda

--- a/magda/daw/core/SourcePool.cpp
+++ b/magda/daw/core/SourcePool.cpp
@@ -3,6 +3,7 @@
 #include <juce_audio_formats/juce_audio_formats.h>
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
 
 namespace magda {
@@ -11,16 +12,6 @@ namespace {
 
 /// Shared reader factory. Registering the basic formats is not cheap, and a
 /// project load probes every referenced file, so keep one manager alive.
-juce::AudioFormatManager& probeFormatManager() {
-    static juce::AudioFormatManager manager;
-    static bool registered = [] {
-        manager.registerBasicFormats();
-        return true;
-    }();
-    juce::ignoreUnused(registered);
-    return manager;
-}
-
 }  // namespace
 
 SourcePool& SourcePool::getInstance() {
@@ -64,7 +55,13 @@ void SourcePool::probe(Source& source) const {
     if (!file.existsAsFile())
         return;
 
-    std::unique_ptr<juce::AudioFormatReader> reader(probeFormatManager().createReaderFor(file));
+    // Built per probe rather than kept in a static: the registered format
+    // objects would outlive JUCE's leak counters and trip the detector at
+    // shutdown. Probing happens once per file, so this costs nothing next to
+    // opening the file and reading its header.
+    juce::AudioFormatManager formats;
+    formats.registerBasicFormats();
+    std::unique_ptr<juce::AudioFormatReader> reader(formats.createReaderFor(file));
     if (reader == nullptr || reader->sampleRate <= 0.0)
         return;
 
@@ -147,31 +144,59 @@ void SourcePool::clear() {
     nextId_ = 1;
 }
 
+void SourcePool::setRateChangeHandler(RateChangeHandler handler) {
+    rateChangeHandler_ = std::move(handler);
+}
+
+void SourcePool::reprobeAndNotify(Source& source, double oldRate) {
+    probe(source);
+    const double newRate = source.effectiveSampleRate();
+
+    // Positions are sample counts at the source's rate. If the rate moved, the
+    // same counts now mean a different time, so they have to be rescaled before
+    // anything reads them back.
+    if (rateChangeHandler_ && oldRate > 0.0 && newRate > 0.0 &&
+        std::abs(newRate - oldRate) > 1.0e-6) {
+        rateChangeHandler_(source.id, oldRate, newRate);
+    }
+}
+
 bool SourcePool::resolveFacts(SourceId id) {
     auto* source = getMutable(id);
     if (source == nullptr)
         return false;
 
     const bool wasResolved = source->isResolved();
-    probe(*source);
+    reprobeAndNotify(*source, source->effectiveSampleRate());
     return !wasResolved && source->isResolved();
 }
 
-bool SourcePool::relink(SourceId id, const juce::String& newFilePath) {
+SourceId SourcePool::relink(SourceId id, const juce::String& newFilePath) {
     auto* source = getMutable(id);
     if (source == nullptr || newFilePath.isEmpty())
-        return false;
+        return INVALID_SOURCE_ID;
 
-    const bool wasResolved = source->isResolved();
+    const auto newKey = canonicalKey(newFilePath);
+
+    // The file may already have a source. Stealing its key would leave two
+    // entries claiming one file, with only one of them reachable by path.
+    if (const auto existing = idByPathKey_.find(newKey);
+        existing != idByPathKey_.end() && existing->second != id) {
+        return existing->second;
+    }
+
+    // Captured before the reset below, so a resolved -> resolved relink onto a
+    // file at a different rate still rescales.
+    const double oldRate = source->effectiveSampleRate();
 
     idByPathKey_.erase(canonicalKey(source->filePath));
     source->filePath = newFilePath;
     source->sampleRate = 0.0;
     source->durationSeconds = 0.0;
-    probe(*source);
-    idByPathKey_[canonicalKey(newFilePath)] = id;
+    reprobeAndNotify(*source, oldRate);
+    idByPathKey_[newKey] = id;
 
-    return !wasResolved && source->isResolved();
+    return id;
 }
 
 void SourcePool::setNextId(int nextId) {

--- a/magda/daw/core/SourcePool.cpp
+++ b/magda/daw/core/SourcePool.cpp
@@ -127,17 +127,6 @@ std::vector<Source> SourcePool::snapshot() const {
     return out;
 }
 
-void SourcePool::retainOnly(const std::unordered_set<SourceId>& live) {
-    for (auto it = sources_.begin(); it != sources_.end();) {
-        if (live.count(it->first) > 0) {
-            ++it;
-            continue;
-        }
-        idByPathKey_.erase(canonicalKey(it->second.filePath));
-        it = sources_.erase(it);
-    }
-}
-
 void SourcePool::clear() {
     sources_.clear();
     idByPathKey_.clear();

--- a/magda/daw/core/SourcePool.cpp
+++ b/magda/daw/core/SourcePool.cpp
@@ -1,0 +1,190 @@
+#include "SourcePool.hpp"
+
+#include <juce_audio_formats/juce_audio_formats.h>
+
+#include <algorithm>
+#include <memory>
+
+namespace magda {
+
+namespace {
+
+/// Shared reader factory. Registering the basic formats is not cheap, and a
+/// project load probes every referenced file, so keep one manager alive.
+juce::AudioFormatManager& probeFormatManager() {
+    static juce::AudioFormatManager manager;
+    static bool registered = [] {
+        manager.registerBasicFormats();
+        return true;
+    }();
+    juce::ignoreUnused(registered);
+    return manager;
+}
+
+}  // namespace
+
+SourcePool& SourcePool::getInstance() {
+    static SourcePool instance;
+    return instance;
+}
+
+juce::String SourcePool::canonicalKey(const juce::String& filePath) {
+    if (filePath.isEmpty())
+        return {};
+
+    // Test the string before building a juce::File: the File constructor
+    // asserts on a relative path, and getFullPathName() would resolve it
+    // against the working directory, which is not what a project-relative path
+    // means. Only canonicalise what is already absolute; anything else keys on
+    // itself.
+    juce::String path =
+        juce::File::isAbsolutePath(filePath) ? juce::File(filePath).getFullPathName() : filePath;
+
+#if JUCE_MAC || JUCE_WINDOWS
+    return path.toLowerCase();
+#else
+    return path;
+#endif
+}
+
+void SourcePool::probe(Source& source) const {
+    if (const auto seeded = seededFacts_.find(canonicalKey(source.filePath));
+        seeded != seededFacts_.end()) {
+        source.durationSeconds = seeded->second.durationSeconds;
+        source.sampleRate = seeded->second.sampleRate;
+        return;
+    }
+
+    // Same reason as canonicalKey: a relative path is not something we can
+    // open, and constructing a juce::File from one asserts.
+    if (!juce::File::isAbsolutePath(source.filePath))
+        return;
+
+    const juce::File file(source.filePath);
+    if (!file.existsAsFile())
+        return;
+
+    std::unique_ptr<juce::AudioFormatReader> reader(probeFormatManager().createReaderFor(file));
+    if (reader == nullptr || reader->sampleRate <= 0.0)
+        return;
+
+    source.sampleRate = reader->sampleRate;
+    source.durationSeconds = static_cast<double>(reader->lengthInSamples) / reader->sampleRate;
+}
+
+SourceId SourcePool::acquire(const juce::String& filePath) {
+    if (filePath.isEmpty())
+        return INVALID_SOURCE_ID;
+
+    const auto key = canonicalKey(filePath);
+    if (const auto it = idByPathKey_.find(key); it != idByPathKey_.end())
+        return it->second;
+
+    Source source;
+    source.id = nextId_++;
+    source.filePath = filePath;
+    probe(source);
+
+    idByPathKey_[key] = source.id;
+    sources_[source.id] = std::move(source);
+    return idByPathKey_[key];
+}
+
+SourceId SourcePool::findByPath(const juce::String& filePath) const {
+    if (filePath.isEmpty())
+        return INVALID_SOURCE_ID;
+    const auto it = idByPathKey_.find(canonicalKey(filePath));
+    return it != idByPathKey_.end() ? it->second : INVALID_SOURCE_ID;
+}
+
+const Source* SourcePool::get(SourceId id) const {
+    const auto it = sources_.find(id);
+    return it != sources_.end() ? &it->second : nullptr;
+}
+
+Source* SourcePool::getMutable(SourceId id) {
+    const auto it = sources_.find(id);
+    return it != sources_.end() ? &it->second : nullptr;
+}
+
+SourceId SourcePool::insert(const Source& source) {
+    if (source.filePath.isEmpty() || source.id == INVALID_SOURCE_ID)
+        return INVALID_SOURCE_ID;
+
+    const auto key = canonicalKey(source.filePath);
+    if (const auto existing = idByPathKey_.find(key); existing != idByPathKey_.end())
+        return existing->second;
+
+    sources_[source.id] = source;
+    idByPathKey_[key] = source.id;
+    nextId_ = std::max(nextId_, source.id + 1);
+    return source.id;
+}
+
+std::vector<Source> SourcePool::snapshot() const {
+    std::vector<Source> out;
+    out.reserve(sources_.size());
+    for (const auto& [id, source] : sources_)
+        out.push_back(source);
+    std::sort(out.begin(), out.end(), [](const Source& a, const Source& b) { return a.id < b.id; });
+    return out;
+}
+
+void SourcePool::retainOnly(const std::unordered_set<SourceId>& live) {
+    for (auto it = sources_.begin(); it != sources_.end();) {
+        if (live.count(it->first) > 0) {
+            ++it;
+            continue;
+        }
+        idByPathKey_.erase(canonicalKey(it->second.filePath));
+        it = sources_.erase(it);
+    }
+}
+
+void SourcePool::clear() {
+    sources_.clear();
+    idByPathKey_.clear();
+    nextId_ = 1;
+}
+
+bool SourcePool::resolveFacts(SourceId id) {
+    auto* source = getMutable(id);
+    if (source == nullptr)
+        return false;
+
+    const bool wasResolved = source->isResolved();
+    probe(*source);
+    return !wasResolved && source->isResolved();
+}
+
+bool SourcePool::relink(SourceId id, const juce::String& newFilePath) {
+    auto* source = getMutable(id);
+    if (source == nullptr || newFilePath.isEmpty())
+        return false;
+
+    const bool wasResolved = source->isResolved();
+
+    idByPathKey_.erase(canonicalKey(source->filePath));
+    source->filePath = newFilePath;
+    source->sampleRate = 0.0;
+    source->durationSeconds = 0.0;
+    probe(*source);
+    idByPathKey_[canonicalKey(newFilePath)] = id;
+
+    return !wasResolved && source->isResolved();
+}
+
+void SourcePool::setNextId(int nextId) {
+    nextId_ = std::max(1, nextId);
+}
+
+void SourcePool::seedFactsForTesting(const juce::String& filePath, double durationSeconds,
+                                     double sampleRate) {
+    seededFacts_[canonicalKey(filePath)] = {durationSeconds, sampleRate};
+}
+
+void SourcePool::clearSeededFactsForTesting() {
+    seededFacts_.clear();
+}
+
+}  // namespace magda

--- a/magda/daw/core/SourcePool.hpp
+++ b/magda/daw/core/SourcePool.hpp
@@ -17,10 +17,12 @@ namespace magda {
  * analysis are stored once and the media database has a single join point per
  * file. Message thread only, like ClipManager.
  *
- * Lifetime: additive within a session. Sources are never removed by an edit
- * (which is why the pool needs no undo support of its own: an undone clip
- * deletion finds its source still there), only by retainOnly() during save and
- * by clear() on project load.
+ * Lifetime: additive within a session, cleared only on project load. Nothing
+ * removes a source once pooled, which is why the pool needs no undo support of
+ * its own: an undone clip deletion, or a paste from a clipboard filled before
+ * the delete, finds its source still there. Saving filters what it writes to
+ * the referenced set rather than pruning the pool, so autosave cannot strand a
+ * source that undo is about to need.
  */
 class SourcePool {
   public:
@@ -60,9 +62,6 @@ class SourcePool {
 
     /// Every source, ordered by id. Used by serialization and the media collector.
     std::vector<Source> snapshot() const;
-
-    /// Drop every source whose id is not in @p live. Called when saving.
-    void retainOnly(const std::unordered_set<SourceId>& live);
 
     void clear();
 

--- a/magda/daw/core/SourcePool.hpp
+++ b/magda/daw/core/SourcePool.hpp
@@ -67,22 +67,43 @@ class SourcePool {
     void clear();
 
     /**
+     * @brief Notified whenever a source's effective sample rate changes.
+     *
+     * Events store their source-domain positions in samples at the source's own
+     * rate, so a rate change silently moves every one of them. The pool cannot
+     * reach the clips itself, so ClipManager installs a handler that rescales
+     * them; firing from inside the pool means no caller of resolveFacts() or
+     * relink() can forget to do it.
+     */
+    using RateChangeHandler = std::function<void(SourceId, double oldRate, double newRate)>;
+    void setRateChangeHandler(RateChangeHandler handler);
+
+    /**
      * @brief Open the file and fill in durationSeconds / sampleRate.
      *
+     * Anchors computed while the source was unresolved were expressed at
+     * kUnresolvedSourceSampleRate; if the file turns out to run at a different
+     * rate, the rate-change handler rescales them before this returns.
+     *
      * @return true when the source became resolved during this call (sampleRate
-     *         went 0 -> real). That transition is the signal to rescale the
-     *         source-domain anchors of every event pointing at it, which were
-     *         computed at kUnresolvedSourceSampleRate.
+     *         went 0 -> real).
      */
     bool resolveFacts(SourceId id);
 
     /**
      * @brief Point a source at a different file and re-probe it.
      *
-     * @return true when the relink resolved a previously unresolved source
-     *         (same anchor-rescale meaning as resolveFacts).
+     * Rescales anchors through the rate-change handler when the new file runs
+     * at a different rate.
+     *
+     * @return the source id that owns @p newFilePath afterwards. That is @p id
+     *         in the normal case, but when the path is already pooled under a
+     *         different source the existing one wins and its id comes back:
+     *         callers must repoint their events at it, or two sources would
+     *         claim one file and break the per-file dedup invariant.
+     *         INVALID_SOURCE_ID when @p id is unknown or the path is empty.
      */
-    bool relink(SourceId id, const juce::String& newFilePath);
+    SourceId relink(SourceId id, const juce::String& newFilePath);
 
     /// Id the next created source will take. Serialization restores this.
     int getNextId() const {
@@ -110,6 +131,12 @@ class SourcePool {
     /// Read duration and sample rate off the file (or the test seed).
     /// Leaves both at 0 when the file cannot be opened.
     void probe(Source& source) const;
+
+    RateChangeHandler rateChangeHandler_;
+
+    /// Re-probe @p source and fire the rate-change handler if the rate moved
+    /// away from @p oldRate (captured by the caller before any reset).
+    void reprobeAndNotify(Source& source, double oldRate);
 
     std::unordered_map<SourceId, Source> sources_;
     std::map<juce::String, SourceId> idByPathKey_;

--- a/magda/daw/core/SourcePool.hpp
+++ b/magda/daw/core/SourcePool.hpp
@@ -1,0 +1,151 @@
+#pragma once
+
+#include <functional>
+#include <map>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "Source.hpp"
+
+namespace magda {
+
+/**
+ * @brief Project-wide pool of media sources, deduplicated per file (#1901).
+ *
+ * Two clips referencing the same file share one Source, so file facts and
+ * analysis are stored once and the media database has a single join point per
+ * file. Message thread only, like ClipManager.
+ *
+ * Lifetime: additive within a session. Sources are never removed by an edit
+ * (which is why the pool needs no undo support of its own: an undone clip
+ * deletion finds its source still there), only by retainOnly() during save and
+ * by clear() on project load.
+ */
+class SourcePool {
+  public:
+    static SourcePool& getInstance();
+
+    SourcePool(const SourcePool&) = delete;
+    SourcePool& operator=(const SourcePool&) = delete;
+
+    /**
+     * @brief Pooled id for a file path, creating the Source if new.
+     *
+     * Probes the file for its facts on first sight. Returns INVALID_SOURCE_ID
+     * only for an empty path.
+     */
+    SourceId acquire(const juce::String& filePath);
+
+    /// Pooled id for a path that is already known, or INVALID_SOURCE_ID.
+    SourceId findByPath(const juce::String& filePath) const;
+
+    const Source* get(SourceId id) const;
+
+    /**
+     * @brief Mutable access for analysis writeback (detected BPM, key, facts).
+     *
+     * Interpretation belongs on the event; only detected/file facts belong here.
+     */
+    Source* getMutable(SourceId id);
+
+    /**
+     * @brief Insert a Source with its id preserved (deserialization).
+     *
+     * Keeps nextId_ ahead of every inserted id. If the path is already pooled
+     * under a different id, the existing entry wins and its id is returned so a
+     * hand-edited project file cannot create two sources for one file.
+     */
+    SourceId insert(const Source& source);
+
+    /// Every source, ordered by id. Used by serialization and the media collector.
+    std::vector<Source> snapshot() const;
+
+    /// Drop every source whose id is not in @p live. Called when saving.
+    void retainOnly(const std::unordered_set<SourceId>& live);
+
+    void clear();
+
+    /**
+     * @brief Open the file and fill in durationSeconds / sampleRate.
+     *
+     * @return true when the source became resolved during this call (sampleRate
+     *         went 0 -> real). That transition is the signal to rescale the
+     *         source-domain anchors of every event pointing at it, which were
+     *         computed at kUnresolvedSourceSampleRate.
+     */
+    bool resolveFacts(SourceId id);
+
+    /**
+     * @brief Point a source at a different file and re-probe it.
+     *
+     * @return true when the relink resolved a previously unresolved source
+     *         (same anchor-rescale meaning as resolveFacts).
+     */
+    bool relink(SourceId id, const juce::String& newFilePath);
+
+    /// Id the next created source will take. Serialization restores this.
+    int getNextId() const {
+        return nextId_;
+    }
+    void setNextId(int nextId);
+
+    /**
+     * @brief Test seam: pretend @p filePath has these facts without touching disk.
+     *
+     * Model tests run headless with no media on disk. Seeded facts are consumed
+     * by acquire()/resolveFacts() in place of a real probe.
+     */
+    void seedFactsForTesting(const juce::String& filePath, double durationSeconds,
+                             double sampleRate);
+    void clearSeededFactsForTesting();
+
+  private:
+    SourcePool() = default;
+    ~SourcePool() = default;
+
+    /// Dedupe key: absolute path, case-folded on the case-insensitive platforms.
+    static juce::String canonicalKey(const juce::String& filePath);
+
+    /// Read duration and sample rate off the file (or the test seed).
+    /// Leaves both at 0 when the file cannot be opened.
+    void probe(Source& source) const;
+
+    std::unordered_map<SourceId, Source> sources_;
+    std::map<juce::String, SourceId> idByPathKey_;
+    int nextId_ = 1;
+
+    struct SeededFacts {
+        double durationSeconds = 0.0;
+        double sampleRate = 0.0;
+    };
+    std::map<juce::String, SeededFacts> seededFacts_;
+};
+
+// ============================================================================
+// Pool accessors
+//
+// AudioEvent stores only a SourceId; everything it needs to talk about the file
+// resolves through these. They are total functions with defined answers for an
+// unknown id so model code never has to branch on "source missing".
+// ============================================================================
+
+/// Sample rate of a source, or kUnresolvedSourceSampleRate when unknown.
+inline double sourceRateOf(SourceId id) {
+    const auto* source = SourcePool::getInstance().get(id);
+    return source != nullptr ? source->effectiveSampleRate() : kUnresolvedSourceSampleRate;
+}
+
+/// File path of a source, empty when unknown.
+inline juce::String sourcePathOf(SourceId id) {
+    const auto* source = SourcePool::getInstance().get(id);
+    return source != nullptr ? source->filePath : juce::String();
+}
+
+/// On-disk duration of a source in seconds, 0 when unknown.
+inline double sourceDurationOf(SourceId id) {
+    const auto* source = SourcePool::getInstance().get(id);
+    return source != nullptr ? source->durationSeconds : 0.0;
+}
+
+}  // namespace magda

--- a/magda/daw/engine/TracktionEngineWrapperRecording.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperRecording.cpp
@@ -207,8 +207,10 @@ void TracktionEngineWrapper::recordingFinished(
             if (auto* newClip = clipManager.getClip(clipId)) {
                 double projectBPM = ProjectManager::getInstance().getCurrentProjectInfo().tempo;
                 if (isValidBpm(projectBPM)) {
-                    newClip->audio().interpretation.bpm = projectBPM;
-                    newClip->audio().interpretation.totalBeats = lengthSeconds * projectBPM / 60.0;
+                    if (auto* event = newClip->primaryEvent()) {
+                        event->interpBpm = projectBPM;
+                        event->interpTotalBeats = lengthSeconds * projectBPM / 60.0;
+                    }
                 }
                 if (!takes.empty()) {
                     newClip->audio().takes = std::move(takes);
@@ -605,10 +607,8 @@ ClipId TracktionEngineWrapper::createEmptySessionSlotRecordingClip(TrackId track
 
     clipManager.setClipSceneIndex(clipId, sceneIndex);
     if (auto* clip = clipManager.getClip(clipId)) {
-        const double tempo = getTempo() > 0.0 ? getTempo() : 120.0;
         clip->loopEnabled = true;
         clip->loopLengthBeats = lengthBeats;
-        clip->loopLength = clip->getTimelineLength(tempo);
     }
     SelectionManager::getInstance().selectClip(clipId);
     clipManager.forceNotifyClipPropertyChanged(clipId);
@@ -661,15 +661,17 @@ bool TracktionEngineWrapper::finalizeSessionSlotAudioRecording(
     if (auto* clipInfo = clipManager.getClip(clipId)) {
         clipInfo->setPlacementBeats(0.0, lengthBeats);
         clipInfo->deriveTimesFromBeats(projectBpm);
-        clipInfo->autoTempo = true;
-        clipInfo->loopEnabled = true;
-        clipInfo->loopStartBeats = 0.0;
-        clipInfo->loopLengthBeats = lengthBeats;
-        clipInfo->loopStart = 0.0;
-        clipInfo->loopLength = clipInfo->getTimelineLength(projectBpm);
-        clipInfo->audio().interpretation.bpm = projectBpm;
-        clipInfo->audio().interpretation.totalBeats = lengthBeats;
-        clipInfo->audio().interpretation.totalBeatsLocked = true;
+        if (auto* event = clipInfo->primaryEvent()) {
+            // Recorded at the project tempo, so the interpretation is exact
+            // rather than detected.
+            event->interpBpm = projectBpm;
+            event->interpTotalBeats = lengthBeats;
+            event->interpTotalBeatsLocked = true;
+            event->autoTempo = true;
+            clipInfo->loopEnabled = true;
+            event->loopStartSamples = 0;
+            event->setLoopLengthSeconds(lengthBeats * 60.0 / projectBpm);
+        }
         clipManager.forceNotifyClipPropertyChanged(clipId);
         SelectionManager::getInstance().selectClip(clipId);
     }
@@ -776,7 +778,6 @@ bool TracktionEngineWrapper::finalizeSessionSlotMidiRecording(TrackId trackId,
         clipInfo->deriveTimesFromBeats(tempo);
         clipInfo->loopEnabled = true;
         clipInfo->loopLengthBeats = lengthBeats;
-        clipInfo->loopLength = clipInfo->getTimelineLength(tempo);
         clipInfo->midiNotes = std::move(recordedNotes);
         clipInfo->midiCCData = std::move(recordedCC);
         clipInfo->midiPitchBendData = std::move(recordedPB);

--- a/magda/daw/project/MediaCollector.cpp
+++ b/magda/daw/project/MediaCollector.cpp
@@ -112,11 +112,11 @@ MediaCollector::Plan MediaCollector::scan() {
 
     // 1. Audio clip sources.
     for (const auto& clip : ClipManager::getInstance().getClips()) {
-        if (!clip.isAudio())
-            continue;
-        const auto idx = resolve(clip.audio().source.filePath);
-        if (idx >= 0)
-            plan.items[static_cast<size_t>(idx)].clipRefs.push_back(clip.id);
+        for (const auto& event : clip.isAudio() ? clip.audio().events : std::vector<AudioEvent>{}) {
+            const auto idx = resolve(event.sourceFilePath());
+            if (idx >= 0)
+                plan.items[static_cast<size_t>(idx)].clipRefs.push_back(clip.id);
+        }
     }
 
     // 2 + 3. Samplers (standalone, incl. inside instrument racks) and drum pads.
@@ -165,13 +165,17 @@ MediaCollector::Summary MediaCollector::apply(const Plan& plan) {
         const auto newPath = item.dest.getFullPathName();
 
         for (auto clipId : item.clipRefs) {
-            if (auto* clip = clipManager.getClip(clipId); clip != nullptr && clip->isAudio()) {
-                const auto oldPath = clip->audio().source.filePath;
-                clip->audio().source.filePath = newPath;
-                thumbs.invalidateFile(oldPath);
-                thumbs.invalidateFile(newPath);
-                clipManager.forceNotifyClipPropertyChanged(clipId);
-            }
+            auto* clip = clipManager.getClip(clipId);
+            auto* event = primaryEventOf(clip);
+            if (event == nullptr)
+                continue;
+            const auto oldPath = event->sourceFilePath();
+            // Repoint the pooled source, not the clip: every clip sharing this
+            // file follows automatically.
+            SourcePool::getInstance().relink(event->sourceId, newPath);
+            thumbs.invalidateFile(oldPath);
+            thumbs.invalidateFile(newPath);
+            clipManager.forceNotifyClipPropertyChanged(clipId);
         }
 
         for (const auto& replace : item.samplerRefs)

--- a/magda/daw/project/MediaCollector.cpp
+++ b/magda/daw/project/MediaCollector.cpp
@@ -1,5 +1,7 @@
 #include "MediaCollector.hpp"
 
+#include <algorithm>
+
 #include "../audio/AudioThumbnailManager.hpp"
 #include "../core/ClipInfo.hpp"
 #include "../core/ClipManager.hpp"
@@ -114,8 +116,19 @@ MediaCollector::Plan MediaCollector::scan() {
     for (const auto& clip : ClipManager::getInstance().getClips()) {
         for (const auto& event : clip.isAudio() ? clip.audio().events : std::vector<AudioEvent>{}) {
             const auto idx = resolve(event.sourceFilePath());
-            if (idx >= 0)
-                plan.items[static_cast<size_t>(idx)].clipRefs.push_back(clip.id);
+            if (idx < 0)
+                continue;
+
+            auto& item = plan.items[static_cast<size_t>(idx)];
+            if (std::find(item.clipRefs.begin(), item.clipRefs.end(), clip.id) ==
+                item.clipRefs.end()) {
+                item.clipRefs.push_back(clip.id);
+            }
+            if (event.sourceId != INVALID_SOURCE_ID &&
+                std::find(item.sourceRefs.begin(), item.sourceRefs.end(), event.sourceId) ==
+                    item.sourceRefs.end()) {
+                item.sourceRefs.push_back(event.sourceId);
+            }
         }
     }
 
@@ -164,19 +177,23 @@ MediaCollector::Summary MediaCollector::apply(const Plan& plan) {
 
         const auto newPath = item.dest.getFullPathName();
 
-        for (auto clipId : item.clipRefs) {
-            auto* clip = clipManager.getClip(clipId);
-            auto* event = primaryEventOf(clip);
-            if (event == nullptr)
-                continue;
-            const auto oldPath = event->sourceFilePath();
-            // Repoint the pooled source, not the clip: every clip sharing this
-            // file follows automatically.
-            SourcePool::getInstance().relink(event->sourceId, newPath);
-            thumbs.invalidateFile(oldPath);
-            thumbs.invalidateFile(newPath);
-            clipManager.forceNotifyClipPropertyChanged(clipId);
+        // Repoint the pooled sources, not the clips: every clip sharing a
+        // file follows automatically.
+        for (auto sourceId : item.sourceRefs) {
+            const auto owner = SourcePool::getInstance().relink(sourceId, newPath);
+            if (owner != INVALID_SOURCE_ID && owner != sourceId) {
+                // The destination was already pooled under another source.
+                // Move the events across rather than leaving two entries
+                // claiming one file.
+                clipManager.repointEventsToSource(sourceId, owner);
+            }
         }
+
+        thumbs.invalidateFile(item.source.getFullPathName());
+        thumbs.invalidateFile(newPath);
+
+        for (auto clipId : item.clipRefs)
+            clipManager.forceNotifyClipPropertyChanged(clipId);
 
         for (const auto& replace : item.samplerRefs)
             replace(item.dest);

--- a/magda/daw/project/MediaCollector.hpp
+++ b/magda/daw/project/MediaCollector.hpp
@@ -36,6 +36,11 @@ class MediaCollector {
         juce::File source;
         juce::File dest;  // assigned in scan(), created in copy()
         std::vector<ClipId> clipRefs;
+        // The pooled sources pointing at this file. Relinking is a per-source
+        // operation, so the work list has to name sources: a clip can hold
+        // several events on different files, and relinking its primary event
+        // would move the wrong one.
+        std::vector<SourceId> sourceRefs;
         std::vector<std::function<void(const juce::File&)>> samplerRefs;
         bool copied = false;
     };

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -4,6 +4,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include <algorithm>
+#include <unordered_set>
 
 #include "../core/AutomationManager.hpp"
 #include "../core/ClipManager.hpp"
@@ -108,9 +109,12 @@ bool ProjectManager::newProject() {
 
     resetTransportForProjectBoundary();
 
-    // Clear all project content from singleton managers
+    // Clear all project content from singleton managers. Source ids are
+    // project-scoped like clip ids, so the pool empties here rather than in
+    // clearAllClips, which the project LOAD path also calls after staging.
     TrackManager::getInstance().clearAllTracks();
     ClipManager::getInstance().clearAllClips();
+    SourcePool::getInstance().clear();
     AutomationManager::getInstance().clearAll();
 
     // Reset project state
@@ -498,9 +502,12 @@ bool ProjectManager::closeProject() {
 
     resetTransportForProjectBoundary();
 
-    // Clear all project content from singleton managers
+    // Clear all project content from singleton managers. Source ids are
+    // project-scoped like clip ids, so the pool empties here rather than in
+    // clearAllClips, which the project LOAD path also calls after staging.
     TrackManager::getInstance().clearAllTracks();
     ClipManager::getInstance().clearAllClips();
+    SourcePool::getInstance().clear();
     AutomationManager::getInstance().clearAll();
 
     // Reset state
@@ -747,11 +754,17 @@ void ProjectManager::migrateMediaFiles(const juce::File& oldDir, const juce::Fil
     // Update clip audio paths that reference the old media directory
     auto& clipManager = ClipManager::getInstance();
     auto updateClipPaths = [&](const std::vector<ClipInfo>& clips) {
+        // Sources are pooled per file, so a moved file is relinked once even
+        // when several clips reference it; the clip loop only decides which
+        // clips need re-notifying.
+        auto& pool = SourcePool::getInstance();
+        std::unordered_set<SourceId> relinked;
         for (const auto& clipInfo : clips) {
-            if (!clipInfo.isAudio())
+            const auto* event = clipInfo.primaryEvent();
+            if (event == nullptr)
                 continue;
-            const bool sourceMoved = clipInfo.audio().source.filePath.isNotEmpty() &&
-                                     clipInfo.audio().source.filePath.startsWith(oldPath);
+            const auto sourcePath = event->sourceFilePath();
+            const bool sourceMoved = sourcePath.isNotEmpty() && sourcePath.startsWith(oldPath);
             bool anyTakeMoved = false;
             for (const auto& take : clipInfo.audio().takes) {
                 if (take.filePath.startsWith(oldPath)) {
@@ -763,9 +776,8 @@ void ProjectManager::migrateMediaFiles(const juce::File& oldDir, const juce::Fil
                 continue;
             auto* clip = clipManager.getClip(clipInfo.id);
             if (clip) {
-                if (sourceMoved)
-                    clip->audio().source.filePath =
-                        clip->audio().source.filePath.replace(oldPath, newPath, false);
+                if (sourceMoved && relinked.insert(event->sourceId).second)
+                    pool.relink(event->sourceId, sourcePath.replace(oldPath, newPath, false));
                 for (auto& take : clip->audio().takes)
                     if (take.filePath.startsWith(oldPath))
                         take.filePath = take.filePath.replace(oldPath, newPath, false);

--- a/magda/daw/project/ProjectManager.cpp
+++ b/magda/daw/project/ProjectManager.cpp
@@ -776,8 +776,13 @@ void ProjectManager::migrateMediaFiles(const juce::File& oldDir, const juce::Fil
                 continue;
             auto* clip = clipManager.getClip(clipInfo.id);
             if (clip) {
-                if (sourceMoved && relinked.insert(event->sourceId).second)
-                    pool.relink(event->sourceId, sourcePath.replace(oldPath, newPath, false));
+                if (sourceMoved && relinked.insert(event->sourceId).second) {
+                    const auto moved = event->sourceId;
+                    const auto owner =
+                        pool.relink(moved, sourcePath.replace(oldPath, newPath, false));
+                    if (owner != INVALID_SOURCE_ID && owner != moved)
+                        clipManager.repointEventsToSource(moved, owner);
+                }
                 for (auto& take : clip->audio().takes)
                     if (take.filePath.startsWith(oldPath))
                         take.filePath = take.filePath.replace(oldPath, newPath, false);

--- a/magda/daw/project/serialization/ClipSerializer.cpp
+++ b/magda/daw/project/serialization/ClipSerializer.cpp
@@ -32,6 +32,293 @@ double getValidProjectTempo(double projectTempo) {
     return isValidBpm(projectTempo) ? projectTempo : DEFAULT_BPM;
 }
 
+juce::var serializeAudioEvent(const AudioEvent& event) {
+    auto* obj = new juce::DynamicObject();
+    obj->setProperty("id", event.id);
+    obj->setProperty("sourceId", event.sourceId);
+
+    obj->setProperty("startBeat", event.startBeat);
+    obj->setProperty("lengthBeats", event.lengthBeats);
+
+    // Source-domain values are samples at the source's own rate. juce::var has
+    // no 64-bit integer, so they travel as strings rather than silently losing
+    // precision through a double on long files.
+    obj->setProperty("anchorSamples", juce::String(event.sourceAnchorSamples));
+    obj->setProperty("loopStartSamples", juce::String(event.loopStartSamples));
+    obj->setProperty("loopLengthSamples", juce::String(event.loopLengthSamples));
+
+    obj->setProperty("interpBpm", event.interpBpm);
+    obj->setProperty("interpTotalBeats", event.interpTotalBeats);
+    obj->setProperty("interpTotalBeatsLocked", event.interpTotalBeatsLocked);
+    if (!event.keyRoot.empty())
+        obj->setProperty("keyRoot", juce::String(event.keyRoot));
+    if (!event.keyScale.empty())
+        obj->setProperty("keyScale", juce::String(event.keyScale));
+
+    obj->setProperty("autoTempo", event.autoTempo);
+    obj->setProperty("speedRatio", event.speedRatio);
+    if (event.timeStretchMode != 0)
+        obj->setProperty("timeStretchMode", event.timeStretchMode);
+    if (event.warpEnabled) {
+        obj->setProperty("warpEnabled", true);
+        if (!event.warpMarkers.empty()) {
+            juce::Array<juce::var> warpArray;
+            for (const auto& wm : event.warpMarkers) {
+                auto* wmObj = new juce::DynamicObject();
+                wmObj->setProperty("sourceTime", wm.sourceTime);
+                wmObj->setProperty("warpTime", wm.warpTime);
+                warpArray.add(juce::var(wmObj));
+            }
+            obj->setProperty("warpMarkers", warpArray);
+        }
+    }
+
+    obj->setProperty("autoPitch", event.autoPitch);
+    if (event.analogPitch)
+        obj->setProperty("analogPitch", true);
+    obj->setProperty("autoPitchMode", event.autoPitchMode);
+    obj->setProperty("pitchChange", event.pitchChange);
+    obj->setProperty("transpose", event.transpose);
+
+    obj->setProperty("reversed", event.reversed);
+    obj->setProperty("autoDetectBeats", event.autoDetectBeats);
+    obj->setProperty("beatSensitivity", event.beatSensitivity);
+
+    obj->setProperty("leftChannelActive", event.leftChannelActive);
+    obj->setProperty("rightChannelActive", event.rightChannelActive);
+
+    obj->setProperty("gainDB", event.gainDB);
+    obj->setProperty("fadeInSeconds", event.fadeInSeconds);
+    obj->setProperty("fadeOutSeconds", event.fadeOutSeconds);
+    obj->setProperty("fadeInType", event.fadeInType);
+    obj->setProperty("fadeOutType", event.fadeOutType);
+    obj->setProperty("fadeInBehaviour", event.fadeInBehaviour);
+    obj->setProperty("fadeOutBehaviour", event.fadeOutBehaviour);
+
+    return juce::var(obj);
+}
+
+int64_t readSamples(const juce::DynamicObject& obj, const char* key) {
+    return obj.hasProperty(key) ? obj.getProperty(key).toString().getLargeIntValue() : 0;
+}
+
+void deserializeAudioEvent(const juce::var& json, AudioEvent& event) {
+    auto* obj = json.getDynamicObject();
+    if (obj == nullptr)
+        return;
+
+    event.id = obj->getProperty("id");
+    event.sourceId = obj->hasProperty("sourceId") ? static_cast<int>(obj->getProperty("sourceId"))
+                                                  : INVALID_SOURCE_ID;
+
+    event.startBeat = obj->getProperty("startBeat");
+    event.lengthBeats = obj->getProperty("lengthBeats");
+
+    event.sourceAnchorSamples = readSamples(*obj, "anchorSamples");
+    event.loopStartSamples = readSamples(*obj, "loopStartSamples");
+    event.loopLengthSamples = readSamples(*obj, "loopLengthSamples");
+
+    event.interpBpm = obj->getProperty("interpBpm");
+    event.interpTotalBeats = obj->getProperty("interpTotalBeats");
+    event.interpTotalBeatsLocked = static_cast<bool>(obj->getProperty("interpTotalBeatsLocked"));
+    event.keyRoot = obj->getProperty("keyRoot").toString().toStdString();
+    event.keyScale = obj->getProperty("keyScale").toString().toStdString();
+
+    event.autoTempo = static_cast<bool>(obj->getProperty("autoTempo"));
+    event.speedRatio = obj->getProperty("speedRatio");
+    if (event.speedRatio <= 0.0)
+        event.speedRatio = 1.0;
+    event.timeStretchMode = obj->getProperty("timeStretchMode");
+    event.warpEnabled = static_cast<bool>(obj->getProperty("warpEnabled"));
+    if (auto warpVar = obj->getProperty("warpMarkers"); warpVar.isArray()) {
+        for (const auto& entry : *warpVar.getArray()) {
+            if (auto* wmObj = entry.getDynamicObject()) {
+                event.warpMarkers.push_back(
+                    {wmObj->getProperty("sourceTime"), wmObj->getProperty("warpTime")});
+            }
+        }
+    }
+
+    event.autoPitch = static_cast<bool>(obj->getProperty("autoPitch"));
+    event.analogPitch = static_cast<bool>(obj->getProperty("analogPitch"));
+    event.autoPitchMode = obj->getProperty("autoPitchMode");
+    event.pitchChange = static_cast<float>(static_cast<double>(obj->getProperty("pitchChange")));
+    event.transpose = obj->getProperty("transpose");
+
+    event.reversed = static_cast<bool>(obj->getProperty("reversed"));
+    event.autoDetectBeats = static_cast<bool>(obj->getProperty("autoDetectBeats"));
+    if (obj->hasProperty("beatSensitivity")) {
+        event.beatSensitivity =
+            static_cast<float>(static_cast<double>(obj->getProperty("beatSensitivity")));
+    }
+
+    if (obj->hasProperty("leftChannelActive"))
+        event.leftChannelActive = static_cast<bool>(obj->getProperty("leftChannelActive"));
+    if (obj->hasProperty("rightChannelActive"))
+        event.rightChannelActive = static_cast<bool>(obj->getProperty("rightChannelActive"));
+
+    event.gainDB = static_cast<float>(static_cast<double>(obj->getProperty("gainDB")));
+    event.fadeInSeconds = obj->getProperty("fadeInSeconds");
+    event.fadeOutSeconds = obj->getProperty("fadeOutSeconds");
+    if (obj->hasProperty("fadeInType"))
+        event.fadeInType = obj->getProperty("fadeInType");
+    if (obj->hasProperty("fadeOutType"))
+        event.fadeOutType = obj->getProperty("fadeOutType");
+    event.fadeInBehaviour = obj->getProperty("fadeInBehaviour");
+    event.fadeOutBehaviour = obj->getProperty("fadeOutBehaviour");
+}
+
+/// Audio interpretation that schema v1 stored on the CLIP rather than on an
+/// event. Collected while reading the clip, then folded into the one migrated
+/// event. v2 files leave every field at its default.
+struct LegacyAudioFields {
+    double fadeIn = 0.0;
+    double fadeOut = 0.0;
+    int fadeInType = 1;
+    int fadeOutType = 1;
+    int fadeInBehaviour = 0;
+    int fadeOutBehaviour = 0;
+    float pitchChange = 0.0f;
+    int transpose = 0;
+    bool autoPitch = false;
+    int autoPitchMode = 0;
+    bool reversed = false;
+    bool autoDetectBeats = false;
+    float beatSensitivity = 0.5f;
+    bool leftChannelActive = true;
+    bool rightChannelActive = true;
+    bool autoTempo = false;
+};
+
+/// The v1 "one source per clip" record, in whichever of the three historical
+/// layouts it was written.
+struct LegacyAudioSource {
+    juce::String filePath;
+    double durationSeconds = 0.0;
+    double interpBpm = 0.0;
+    double interpTotalBeats = 0.0;
+    bool interpTotalBeatsLocked = false;
+
+    double offsetSeconds = 0.0;
+    double offsetBeats = 0.0;
+    double loopStartSeconds = 0.0;
+    double loopLengthSeconds = 0.0;
+    double loopStartBeats = 0.0;
+    double loopLengthBeats = 0.0;
+    double speedRatio = 1.0;
+
+    bool warpEnabled = false;
+    bool analogPitch = false;
+    int timeStretchMode = 0;
+    std::vector<WarpMarker> warpMarkers;
+};
+
+void readLegacyWarpMarkers(const juce::var& warpMarkersVar, std::vector<WarpMarker>& out) {
+    if (!warpMarkersVar.isArray())
+        return;
+    for (const auto& wmVar : *warpMarkersVar.getArray()) {
+        if (auto* wmObj = wmVar.getDynamicObject())
+            out.push_back({wmObj->getProperty("sourceTime"), wmObj->getProperty("warpTime")});
+    }
+}
+
+/// Turn a v1 audio clip into a clip holding exactly one event that spans it.
+///
+/// The source-domain values were seconds (or beats, for autoTempo clips) and
+/// become samples at the source's own rate. When the file cannot be opened the
+/// pool reports a nominal rate and rescales the anchors on the first successful
+/// open, so an offline project still round-trips.
+void migrateLegacyAudioClip(const LegacyAudioSource& v1, const LegacyAudioFields& legacy,
+                            ClipInfo& outClip) {
+    AudioEvent event;
+    event.sourceId = SourcePool::getInstance().acquire(v1.filePath);
+
+    // Duration recorded in the project is a fallback for a file we cannot read.
+    if (auto* source = SourcePool::getInstance().getMutable(event.sourceId);
+        source != nullptr && source->durationSeconds <= 0.0) {
+        double duration = v1.durationSeconds;
+        if (duration <= 0.0 && v1.interpTotalBeats > 0.0 && v1.interpBpm > 0.0)
+            duration = v1.interpTotalBeats * 60.0 / v1.interpBpm;
+        source->durationSeconds = juce::jmax(0.0, duration);
+    }
+
+    event.interpBpm = v1.interpBpm;
+    event.interpTotalBeats = v1.interpTotalBeats;
+    event.interpTotalBeatsLocked = v1.interpTotalBeatsLocked;
+    event.autoTempo = legacy.autoTempo;
+    event.speedRatio = v1.speedRatio > 0.0 ? v1.speedRatio : 1.0;
+    event.timeStretchMode = v1.timeStretchMode;
+    event.warpEnabled = v1.warpEnabled;
+    event.warpMarkers = v1.warpMarkers;
+    event.analogPitch = v1.analogPitch;
+
+    // v1 kept beats authoritative under autoTempo and seconds otherwise. Both
+    // resolve to the same source seconds, which is what becomes the anchor.
+    const bool beatsAuthoritative = legacy.autoTempo && v1.interpBpm > 0.0;
+    const double secondsPerBeat = beatsAuthoritative ? 60.0 / v1.interpBpm : 0.0;
+    event.setAnchorSeconds(beatsAuthoritative ? v1.offsetBeats * secondsPerBeat : v1.offsetSeconds);
+
+    event.setLoopStartSeconds(beatsAuthoritative ? v1.loopStartBeats * secondsPerBeat
+                                                 : v1.loopStartSeconds);
+    event.setLoopLengthSeconds(beatsAuthoritative ? v1.loopLengthBeats * secondsPerBeat
+                                                  : v1.loopLengthSeconds);
+
+    event.autoPitch = legacy.autoPitch;
+    event.autoPitchMode = legacy.autoPitchMode;
+    event.pitchChange = legacy.pitchChange;
+    event.transpose = legacy.transpose;
+    event.reversed = legacy.reversed;
+    event.autoDetectBeats = legacy.autoDetectBeats;
+    event.beatSensitivity = legacy.beatSensitivity;
+    event.leftChannelActive = legacy.leftChannelActive;
+    event.rightChannelActive = legacy.rightChannelActive;
+
+    event.fadeInSeconds = legacy.fadeIn;
+    event.fadeOutSeconds = legacy.fadeOut;
+    event.fadeInType = legacy.fadeInType;
+    event.fadeOutType = legacy.fadeOutType;
+    event.fadeInBehaviour = legacy.fadeInBehaviour;
+    event.fadeOutBehaviour = legacy.fadeOutBehaviour;
+
+    outClip.audio().addEvent(std::move(event));
+    outClip.syncSingleEventToClipBounds();
+}
+
+/// Takes and comp sections are unchanged by the event split.
+void readAudioTakesAndComp(const juce::DynamicObject& audioObj, ClipInfo& outClip) {
+    auto takesVar = audioObj.getProperty("takes");
+    if (takesVar.isArray()) {
+        for (const auto& takeVar : *takesVar.getArray()) {
+            if (auto* takeObj = takeVar.getDynamicObject()) {
+                AudioTake take;
+                take.filePath = takeObj->getProperty("filePath").toString();
+                take.durationSeconds = takeObj->getProperty("durationSeconds");
+                outClip.audio().takes.push_back(take);
+            }
+        }
+        if (!outClip.audio().takes.empty()) {
+            outClip.audio().currentTakeIndex =
+                juce::jlimit(0, static_cast<int>(outClip.audio().takes.size()) - 1,
+                             static_cast<int>(audioObj.getProperty("currentTakeIndex")));
+        }
+    }
+
+    auto compVar = audioObj.getProperty("comp");
+    if (compVar.isArray()) {
+        for (const auto& secVar : *compVar.getArray()) {
+            if (auto* secObj = secVar.getDynamicObject()) {
+                CompSection sec;
+                sec.startSeconds = secObj->getProperty("startSeconds");
+                sec.endSeconds = secObj->getProperty("endSeconds");
+                sec.takeIndex = static_cast<int>(secObj->getProperty("takeIndex"));
+                outClip.audio().comp.push_back(sec);
+            }
+        }
+        outClip.audio().compActive =
+            !outClip.audio().comp.empty() && static_cast<bool>(audioObj.getProperty("compActive"));
+    }
+}
+
 }  // namespace
 
 juce::var ProjectSerializer::serializeClipInfo(const ClipInfo& clip) {
@@ -46,7 +333,6 @@ juce::var ProjectSerializer::serializeClipInfo(const ClipInfo& clip) {
     obj->setProperty("type", static_cast<int>(clip.getType()));
     obj->setProperty("view", static_cast<int>(clip.view));
     obj->setProperty("enabled", clip.enabled);
-    obj->setProperty("loopEnabled", clip.loopEnabled);
     obj->setProperty("sceneIndex", clip.sceneIndex);
     obj->setProperty("launchMode", static_cast<int>(clip.launchMode));
     obj->setProperty("launchQuantize", static_cast<int>(clip.launchQuantize));
@@ -72,47 +358,22 @@ juce::var ProjectSerializer::serializeClipInfo(const ClipInfo& clip) {
     obj->setProperty("gainDB", clip.gainDB);
     obj->setProperty("pan", clip.pan);
 
-    // Fades
-    obj->setProperty("fadeIn", clip.fadeIn);
-    obj->setProperty("fadeOut", clip.fadeOut);
-    obj->setProperty("fadeInType", clip.fadeInType);
-    obj->setProperty("fadeOutType", clip.fadeOutType);
-    obj->setProperty("fadeInBehaviour", clip.fadeInBehaviour);
-    obj->setProperty("fadeOutBehaviour", clip.fadeOutBehaviour);
+    // Crossfade with the neighbouring clip; per-event fades live on the event.
     obj->setProperty("autoCrossfade", clip.autoCrossfade);
     obj->setProperty("launchFadeSamples", clip.launchFadeSamples);
-
-    // Pitch
-    obj->setProperty("pitchChange", clip.pitchChange);
-    obj->setProperty("transpose", clip.transpose);
-    obj->setProperty("autoPitch", clip.autoPitch);
-    obj->setProperty("autoPitchMode", clip.autoPitchMode);
-
-    // Playback
-    obj->setProperty("isReversed", clip.isReversed);
-
-    // Beat detection
-    obj->setProperty("autoDetectBeats", clip.autoDetectBeats);
-    obj->setProperty("beatSensitivity", clip.beatSensitivity);
-
-    // Channels
-    obj->setProperty("leftChannelActive", clip.leftChannelActive);
-    obj->setProperty("rightChannelActive", clip.rightChannelActive);
-
-    // Auto-tempo / Musical mode
-    obj->setProperty("autoTempo", clip.autoTempo);
 
     // MIDI offset
     if (clip.midiOffset != 0.0)
         obj->setProperty("midiOffset", clip.midiOffset);
     if (clip.midiTrimOffset != 0.0)
         obj->setProperty("midiTrimOffset", clip.midiTrimOffset);
+    obj->setProperty("loopEnabled", clip.loopEnabled);
     if (clip.isMidi()) {
+        const auto& midi = clip.midi();
         if (clip.loopStartBeats != 0.0)
             obj->setProperty("loopStartBeats", clip.loopStartBeats);
         if (clip.loopLengthBeats > 0.0)
             obj->setProperty("loopLengthBeats", clip.loopLengthBeats);
-        const auto& midi = clip.midi();
         if (midi.sourceFilePath.isNotEmpty() || !midi.takes.empty()) {
             auto* midiObj = new juce::DynamicObject();
             if (midi.sourceFilePath.isNotEmpty())
@@ -162,52 +423,17 @@ juce::var ProjectSerializer::serializeClipInfo(const ClipInfo& clip) {
     if (clip.grooveStrength > 0.0f)
         obj->setProperty("grooveStrength", clip.grooveStrength);
 
-    if (clip.isAudio() && clip.audio().source.filePath.isNotEmpty()) {
+    if (clip.isAudio() && !clip.audio().events.empty()) {
         auto* audioObj = new juce::DynamicObject();
 
-        auto* sourceObj = new juce::DynamicObject();
-        sourceObj->setProperty("filePath", clip.audio().source.filePath);
-        sourceObj->setProperty("durationSeconds", clip.audio().source.durationSeconds);
-        audioObj->setProperty("source", juce::var(sourceObj));
-
-        auto* interpretationObj = new juce::DynamicObject();
-        interpretationObj->setProperty("bpm", clip.audio().interpretation.bpm);
-        interpretationObj->setProperty("totalBeats", clip.audio().interpretation.totalBeats);
-        interpretationObj->setProperty("totalBeatsLocked",
-                                       clip.audio().interpretation.totalBeatsLocked);
-        audioObj->setProperty("interpretation", juce::var(interpretationObj));
-
-        auto* playbackObj = new juce::DynamicObject();
-        playbackObj->setProperty("offsetSeconds", clip.offset);
-        playbackObj->setProperty("offsetBeats", clip.offsetBeats);
-        playbackObj->setProperty("loopStartSeconds", clip.loopStart);
-        playbackObj->setProperty("loopLengthSeconds", clip.loopLength);
-        playbackObj->setProperty("loopStartBeats", clip.loopStartBeats);
-        playbackObj->setProperty("loopLengthBeats", clip.loopLengthBeats);
-        playbackObj->setProperty("speedRatio", clip.speedRatio);
-        audioObj->setProperty("playback", juce::var(playbackObj));
-
-        if (clip.warpEnabled) {
-            audioObj->setProperty("warpEnabled", clip.warpEnabled);
-
-            // Serialize warp markers
-            if (!clip.warpMarkers.empty()) {
-                juce::Array<juce::var> warpArray;
-                for (const auto& wm : clip.warpMarkers) {
-                    auto* wmObj = new juce::DynamicObject();
-                    wmObj->setProperty("sourceTime", wm.sourceTime);
-                    wmObj->setProperty("warpTime", wm.warpTime);
-                    warpArray.add(juce::var(wmObj));
-                }
-                audioObj->setProperty("warpMarkers", warpArray);
-            }
-        }
-        if (clip.analogPitch) {
-            audioObj->setProperty("analogPitch", clip.analogPitch);
-        }
-        if (clip.timeStretchMode != 0) {
-            audioObj->setProperty("timeStretchMode", clip.timeStretchMode);
-        }
+        // Schema v2 (#1901): the clip hosts a list of events, each referencing a
+        // pooled Source by id. The Source records themselves are written once
+        // per project, not per clip.
+        juce::Array<juce::var> eventsArray;
+        for (const auto& event : clip.audio().events)
+            eventsArray.add(serializeAudioEvent(event));
+        audioObj->setProperty("events", eventsArray);
+        audioObj->setProperty("nextEventId", clip.audio().nextEventId);
 
         // Loop-record takes (one source file per pass). Persist so the take
         // alternates survive save/reload; the engine rebuilds them on sync.
@@ -343,7 +569,6 @@ bool ProjectSerializer::deserializeClipInfo(const juce::var& json, ClipInfo& out
     if (!obj->getProperty("enabled").isVoid())
         outClip.enabled = static_cast<bool>(obj->getProperty("enabled"));
 
-    // Loop settings
     outClip.loopEnabled = static_cast<bool>(obj->getProperty("loopEnabled"));
     outClip.sceneIndex = obj->getProperty("sceneIndex");
 
@@ -381,36 +606,36 @@ bool ProjectSerializer::deserializeClipInfo(const juce::var& json, ClipInfo& out
     outClip.gainDB = static_cast<float>(static_cast<double>(obj->getProperty("gainDB")));
     outClip.pan = static_cast<float>(static_cast<double>(obj->getProperty("pan")));
 
-    // Fades
-    outClip.fadeIn = obj->getProperty("fadeIn");
-    outClip.fadeOut = obj->getProperty("fadeOut");
-    outClip.fadeInType = obj->getProperty("fadeInType");
-    outClip.fadeOutType = obj->getProperty("fadeOutType");
-    outClip.fadeInBehaviour = obj->getProperty("fadeInBehaviour");
-    outClip.fadeOutBehaviour = obj->getProperty("fadeOutBehaviour");
     outClip.autoCrossfade = static_cast<bool>(obj->getProperty("autoCrossfade"));
     outClip.launchFadeSamples = obj->getProperty("launchFadeSamples");
 
-    // Pitch
-    outClip.pitchChange = static_cast<float>(static_cast<double>(obj->getProperty("pitchChange")));
-    outClip.transpose = obj->getProperty("transpose");
-    outClip.autoPitch = static_cast<bool>(obj->getProperty("autoPitch"));
-    outClip.autoPitchMode = obj->getProperty("autoPitchMode");
-
-    // Playback
-    outClip.isReversed = static_cast<bool>(obj->getProperty("isReversed"));
-
-    // Beat detection
-    outClip.autoDetectBeats = static_cast<bool>(obj->getProperty("autoDetectBeats"));
-    outClip.beatSensitivity =
-        static_cast<float>(static_cast<double>(obj->getProperty("beatSensitivity")));
-
-    // Channels
-    outClip.leftChannelActive = static_cast<bool>(obj->getProperty("leftChannelActive"));
-    outClip.rightChannelActive = static_cast<bool>(obj->getProperty("rightChannelActive"));
-
-    // Auto-tempo / Musical mode
-    outClip.autoTempo = static_cast<bool>(obj->getProperty("autoTempo"));
+    // Schema v1 wrote the audio interpretation as clip-level fields. They are
+    // read here and folded into the migrated event further down; v2 files carry
+    // them per event and simply leave these at their defaults.
+    LegacyAudioFields legacy;
+    legacy.fadeIn = obj->getProperty("fadeIn");
+    legacy.fadeOut = obj->getProperty("fadeOut");
+    if (obj->hasProperty("fadeInType"))
+        legacy.fadeInType = obj->getProperty("fadeInType");
+    if (obj->hasProperty("fadeOutType"))
+        legacy.fadeOutType = obj->getProperty("fadeOutType");
+    legacy.fadeInBehaviour = obj->getProperty("fadeInBehaviour");
+    legacy.fadeOutBehaviour = obj->getProperty("fadeOutBehaviour");
+    legacy.pitchChange = static_cast<float>(static_cast<double>(obj->getProperty("pitchChange")));
+    legacy.transpose = obj->getProperty("transpose");
+    legacy.autoPitch = static_cast<bool>(obj->getProperty("autoPitch"));
+    legacy.autoPitchMode = obj->getProperty("autoPitchMode");
+    legacy.reversed = static_cast<bool>(obj->getProperty("isReversed"));
+    legacy.autoDetectBeats = static_cast<bool>(obj->getProperty("autoDetectBeats"));
+    if (obj->hasProperty("beatSensitivity")) {
+        legacy.beatSensitivity =
+            static_cast<float>(static_cast<double>(obj->getProperty("beatSensitivity")));
+    }
+    if (obj->hasProperty("leftChannelActive"))
+        legacy.leftChannelActive = static_cast<bool>(obj->getProperty("leftChannelActive"));
+    if (obj->hasProperty("rightChannelActive"))
+        legacy.rightChannelActive = static_cast<bool>(obj->getProperty("rightChannelActive"));
+    legacy.autoTempo = static_cast<bool>(obj->getProperty("autoTempo"));
 
     // MIDI offset
     outClip.midiOffset = obj->getProperty("midiOffset");
@@ -420,9 +645,6 @@ bool ProjectSerializer::deserializeClipInfo(const juce::var& json, ClipInfo& out
             outClip.loopStartBeats = obj->getProperty("loopStartBeats");
         if (obj->hasProperty("loopLengthBeats"))
             outClip.loopLengthBeats = obj->getProperty("loopLengthBeats");
-
-        if (outClip.loopLength <= 0.0 && outClip.loopLengthBeats > 0.0 && projectTempo > 0.0)
-            outClip.loopLength = outClip.loopLengthBeats * 60.0 / projectTempo;
 
         if (auto* midiObj = obj->getProperty("midi").getDynamicObject()) {
             outClip.midi().sourceFilePath = midiObj->getProperty("sourceFilePath").toString();
@@ -496,7 +718,27 @@ bool ProjectSerializer::deserializeClipInfo(const juce::var& json, ClipInfo& out
         return false;
     }
 
-    if (outClip.isAudio() && audioObj != nullptr) {
+    if (outClip.isAudio() && audioObj != nullptr && audioObj->getProperty("events").isArray()) {
+        // Schema v2 (#1901): events + pooled source ids.
+        for (const auto& eventVar : *audioObj->getProperty("events").getArray()) {
+            AudioEvent event;
+            deserializeAudioEvent(eventVar, event);
+            if (event.id == INVALID_EVENT_ID)
+                event.id = outClip.audio().nextEventId++;
+            outClip.audio().events.push_back(std::move(event));
+        }
+        if (audioObj->hasProperty("nextEventId")) {
+            outClip.audio().nextEventId =
+                juce::jmax(outClip.audio().nextEventId,
+                           static_cast<int>(audioObj->getProperty("nextEventId")));
+        }
+        for (const auto& event : outClip.audio().events)
+            outClip.audio().nextEventId = juce::jmax(outClip.audio().nextEventId, event.id + 1);
+
+        readAudioTakesAndComp(*audioObj, outClip);
+    } else if (outClip.isAudio() && audioObj != nullptr) {
+        // Schema v1: one source + one playback block per clip. It becomes a
+        // clip holding exactly one event spanning it.
         auto* sourceObj = audioObj->getProperty("source").getDynamicObject();
         auto* interpretationObj = audioObj->getProperty("interpretation").getDynamicObject();
         auto* playbackObj = audioObj->getProperty("playback").getDynamicObject();
@@ -506,130 +748,61 @@ bool ProjectSerializer::deserializeClipInfo(const juce::var& json, ClipInfo& out
             return false;
         }
 
-        outClip.audio().source.filePath = sourceObj->getProperty("filePath").toString();
-        outClip.audio().source.durationSeconds = sourceObj->getProperty("durationSeconds");
-        outClip.audio().interpretation.bpm = interpretationObj->getProperty("bpm");
-        outClip.audio().interpretation.totalBeats = interpretationObj->getProperty("totalBeats");
-        outClip.audio().interpretation.totalBeatsLocked =
+        LegacyAudioSource v1;
+        v1.filePath = sourceObj->getProperty("filePath").toString();
+        v1.durationSeconds = sourceObj->getProperty("durationSeconds");
+        v1.interpBpm = interpretationObj->getProperty("bpm");
+        v1.interpTotalBeats = interpretationObj->getProperty("totalBeats");
+        v1.interpTotalBeatsLocked =
             static_cast<bool>(interpretationObj->getProperty("totalBeatsLocked"));
 
-        outClip.offset = playbackObj->getProperty("offsetSeconds");
-        outClip.offsetBeats = playbackObj->getProperty("offsetBeats");
-        outClip.loopStart = playbackObj->getProperty("loopStartSeconds");
-        outClip.loopLength = playbackObj->getProperty("loopLengthSeconds");
-        outClip.loopStartBeats = playbackObj->getProperty("loopStartBeats");
-        outClip.loopLengthBeats = playbackObj->getProperty("loopLengthBeats");
-        outClip.speedRatio = playbackObj->getProperty("speedRatio");
-        if (outClip.speedRatio <= 0.0)
-            outClip.speedRatio = 1.0;
-        outClip.warpEnabled = static_cast<bool>(audioObj->getProperty("warpEnabled"));
-        outClip.analogPitch = static_cast<bool>(audioObj->getProperty("analogPitch"));
-        outClip.timeStretchMode = audioObj->getProperty("timeStretchMode");
+        v1.offsetSeconds = playbackObj->getProperty("offsetSeconds");
+        v1.offsetBeats = playbackObj->getProperty("offsetBeats");
+        v1.loopStartSeconds = playbackObj->getProperty("loopStartSeconds");
+        v1.loopLengthSeconds = playbackObj->getProperty("loopLengthSeconds");
+        v1.loopStartBeats = playbackObj->getProperty("loopStartBeats");
+        v1.loopLengthBeats = playbackObj->getProperty("loopLengthBeats");
+        v1.speedRatio = playbackObj->getProperty("speedRatio");
 
-        // Warp markers
-        auto warpMarkersVar = audioObj->getProperty("warpMarkers");
-        if (warpMarkersVar.isArray()) {
-            auto* arr = warpMarkersVar.getArray();
-            for (const auto& wmVar : *arr) {
-                if (auto* wmObj = wmVar.getDynamicObject()) {
-                    ClipInfo::WarpMarker wm;
-                    wm.sourceTime = wmObj->getProperty("sourceTime");
-                    wm.warpTime = wmObj->getProperty("warpTime");
-                    outClip.warpMarkers.push_back(wm);
-                }
-            }
-        }
+        v1.warpEnabled = static_cast<bool>(audioObj->getProperty("warpEnabled"));
+        v1.analogPitch = static_cast<bool>(audioObj->getProperty("analogPitch"));
+        v1.timeStretchMode = audioObj->getProperty("timeStretchMode");
+        readLegacyWarpMarkers(audioObj->getProperty("warpMarkers"), v1.warpMarkers);
 
-        // Loop-record takes
-        auto takesVar = audioObj->getProperty("takes");
-        if (takesVar.isArray()) {
-            for (const auto& takeVar : *takesVar.getArray()) {
-                if (auto* takeObj = takeVar.getDynamicObject()) {
-                    AudioTake take;
-                    take.filePath = takeObj->getProperty("filePath").toString();
-                    take.durationSeconds = takeObj->getProperty("durationSeconds");
-                    outClip.audio().takes.push_back(take);
-                }
-            }
-            if (!outClip.audio().takes.empty())
-                outClip.audio().currentTakeIndex =
-                    juce::jlimit(0, static_cast<int>(outClip.audio().takes.size()) - 1,
-                                 static_cast<int>(audioObj->getProperty("currentTakeIndex")));
-        }
-
-        // Comp sections
-        auto compVar = audioObj->getProperty("comp");
-        if (compVar.isArray()) {
-            for (const auto& secVar : *compVar.getArray()) {
-                if (auto* secObj = secVar.getDynamicObject()) {
-                    CompSection sec;
-                    sec.startSeconds = secObj->getProperty("startSeconds");
-                    sec.endSeconds = secObj->getProperty("endSeconds");
-                    sec.takeIndex = static_cast<int>(secObj->getProperty("takeIndex"));
-                    outClip.audio().comp.push_back(sec);
-                }
-            }
-            outClip.audio().compActive = !outClip.audio().comp.empty() &&
-                                         static_cast<bool>(audioObj->getProperty("compActive"));
-        }
+        migrateLegacyAudioClip(v1, legacy, outClip);
+        readAudioTakesAndComp(*audioObj, outClip);
     } else if (outClip.isAudio() && legacyAudioSourceObj != nullptr) {
-        outClip.audio().source.filePath = legacyAudioSourceObj->getProperty("filePath").toString();
-        outClip.offset = legacyAudioSourceObj->getProperty("offsetSeconds");
-        outClip.offsetBeats = legacyAudioSourceObj->getProperty("offsetBeats");
-        outClip.loopStart = legacyAudioSourceObj->getProperty("loopStartSeconds");
-        outClip.loopLength = legacyAudioSourceObj->getProperty("loopLengthSeconds");
-        outClip.loopStartBeats = legacyAudioSourceObj->getProperty("loopStartBeats");
-        outClip.loopLengthBeats = legacyAudioSourceObj->getProperty("loopLengthBeats");
-        outClip.speedRatio = legacyAudioSourceObj->getProperty("speedRatio");
-        if (outClip.speedRatio <= 0.0)
-            outClip.speedRatio = 1.0;
+        LegacyAudioSource v1;
+        v1.filePath = legacyAudioSourceObj->getProperty("filePath").toString();
+        v1.offsetSeconds = legacyAudioSourceObj->getProperty("offsetSeconds");
+        v1.offsetBeats = legacyAudioSourceObj->getProperty("offsetBeats");
+        v1.loopStartSeconds = legacyAudioSourceObj->getProperty("loopStartSeconds");
+        v1.loopLengthSeconds = legacyAudioSourceObj->getProperty("loopLengthSeconds");
+        v1.loopStartBeats = legacyAudioSourceObj->getProperty("loopStartBeats");
+        v1.loopLengthBeats = legacyAudioSourceObj->getProperty("loopLengthBeats");
+        v1.speedRatio = legacyAudioSourceObj->getProperty("speedRatio");
+        v1.interpTotalBeats = legacyAudioSourceObj->getProperty("sourceNumBeats");
+        v1.interpBpm = legacyAudioSourceObj->getProperty("sourceBPM");
+        v1.warpEnabled = static_cast<bool>(legacyAudioSourceObj->getProperty("warpEnabled"));
+        v1.analogPitch = static_cast<bool>(legacyAudioSourceObj->getProperty("analogPitch"));
+        v1.timeStretchMode = legacyAudioSourceObj->getProperty("timeStretchMode");
+        readLegacyWarpMarkers(legacyAudioSourceObj->getProperty("warpMarkers"), v1.warpMarkers);
 
-        outClip.audio().interpretation.totalBeats =
-            legacyAudioSourceObj->getProperty("sourceNumBeats");
-        outClip.audio().interpretation.bpm = legacyAudioSourceObj->getProperty("sourceBPM");
-        if (outClip.audio().source.durationSeconds <= 0.0 &&
-            outClip.audio().interpretation.totalBeats > 0.0 &&
-            outClip.audio().interpretation.bpm > 0.0) {
-            outClip.audio().source.durationSeconds = outClip.audio().interpretation.totalBeats *
-                                                     60.0 / outClip.audio().interpretation.bpm;
-        }
-
-        outClip.warpEnabled = static_cast<bool>(legacyAudioSourceObj->getProperty("warpEnabled"));
-        outClip.analogPitch = static_cast<bool>(legacyAudioSourceObj->getProperty("analogPitch"));
-        outClip.timeStretchMode = legacyAudioSourceObj->getProperty("timeStretchMode");
-
-        auto warpMarkersVar = legacyAudioSourceObj->getProperty("warpMarkers");
-        if (warpMarkersVar.isArray()) {
-            auto* arr = warpMarkersVar.getArray();
-            for (const auto& wmVar : *arr) {
-                if (auto* wmObj = wmVar.getDynamicObject()) {
-                    ClipInfo::WarpMarker wm;
-                    wm.sourceTime = wmObj->getProperty("sourceTime");
-                    wm.warpTime = wmObj->getProperty("warpTime");
-                    outClip.warpMarkers.push_back(wm);
-                }
-            }
-        }
+        migrateLegacyAudioClip(v1, legacy, outClip);
     } else if (outClip.isAudio() && obj->hasProperty("audioFilePath")) {
-        outClip.audio().source.filePath = obj->getProperty("audioFilePath").toString();
-        outClip.offset = obj->getProperty("offset");
-        outClip.offsetBeats = obj->getProperty("offsetBeats");
-        outClip.loopStart = obj->getProperty("loopStart");
-        outClip.loopLength = obj->getProperty("loopLength");
-        outClip.loopStartBeats = obj->getProperty("loopStartBeats");
-        outClip.loopLengthBeats = obj->getProperty("loopLengthBeats");
-        outClip.speedRatio = obj->getProperty("speedRatio");
-        if (outClip.speedRatio <= 0.0)
-            outClip.speedRatio = 1.0;
+        LegacyAudioSource v1;
+        v1.filePath = obj->getProperty("audioFilePath").toString();
+        v1.offsetSeconds = obj->getProperty("offset");
+        v1.offsetBeats = obj->getProperty("offsetBeats");
+        v1.loopStartSeconds = obj->getProperty("loopStart");
+        v1.loopLengthSeconds = obj->getProperty("loopLength");
+        v1.loopStartBeats = obj->getProperty("loopStartBeats");
+        v1.loopLengthBeats = obj->getProperty("loopLengthBeats");
+        v1.speedRatio = obj->getProperty("speedRatio");
+        v1.interpTotalBeats = obj->getProperty("sourceNumBeats");
+        v1.interpBpm = obj->getProperty("sourceBPM");
 
-        outClip.audio().interpretation.totalBeats = obj->getProperty("sourceNumBeats");
-        outClip.audio().interpretation.bpm = obj->getProperty("sourceBPM");
-        if (outClip.audio().source.durationSeconds <= 0.0 &&
-            outClip.audio().interpretation.totalBeats > 0.0 &&
-            outClip.audio().interpretation.bpm > 0.0) {
-            outClip.audio().source.durationSeconds = outClip.audio().interpretation.totalBeats *
-                                                     60.0 / outClip.audio().interpretation.bpm;
-        }
+        migrateLegacyAudioClip(v1, legacy, outClip);
     }
 
     // MIDI notes

--- a/magda/daw/project/serialization/ClipSerializer.cpp
+++ b/magda/daw/project/serialization/ClipSerializer.cpp
@@ -59,18 +59,23 @@ juce::var serializeAudioEvent(const AudioEvent& event) {
     obj->setProperty("speedRatio", event.speedRatio);
     if (event.timeStretchMode != 0)
         obj->setProperty("timeStretchMode", event.timeStretchMode);
-    if (event.warpEnabled) {
+    if (event.warpEnabled)
         obj->setProperty("warpEnabled", true);
-        if (!event.warpMarkers.empty()) {
-            juce::Array<juce::var> warpArray;
-            for (const auto& wm : event.warpMarkers) {
-                auto* wmObj = new juce::DynamicObject();
-                wmObj->setProperty("sourceTime", wm.sourceTime);
-                wmObj->setProperty("warpTime", wm.warpTime);
-                warpArray.add(juce::var(wmObj));
-            }
-            obj->setProperty("warpMarkers", warpArray);
+
+    // Markers persist whether or not warp is on. The model treats the two as
+    // independent everywhere else: turning warp off keeps the map, paste
+    // preserves it, and ghosts share it as its own field. Writing it only when
+    // the toggle is on meant re-enabling warp restored the map in-session but
+    // lost it across a save.
+    if (!event.warpMarkers.empty()) {
+        juce::Array<juce::var> warpArray;
+        for (const auto& wm : event.warpMarkers) {
+            auto* wmObj = new juce::DynamicObject();
+            wmObj->setProperty("sourceTime", wm.sourceTime);
+            wmObj->setProperty("warpTime", wm.warpTime);
+            warpArray.add(juce::var(wmObj));
         }
+        obj->setProperty("warpMarkers", warpArray);
     }
 
     obj->setProperty("autoPitch", event.autoPitch);
@@ -229,17 +234,26 @@ void readLegacyWarpMarkers(const juce::var& warpMarkersVar, std::vector<WarpMark
 /// pool reports a nominal rate and rescales the anchors on the first successful
 /// open, so an offline project still round-trips.
 void migrateLegacyAudioClip(const LegacyAudioSource& v1, const LegacyAudioFields& legacy,
-                            ClipInfo& outClip) {
-    AudioEvent event;
-    event.sourceId = SourcePool::getInstance().acquire(v1.filePath);
-
+                            ClipInfo& outClip, std::vector<Source>* legacySources,
+                            double projectTempo) {
     // Duration recorded in the project is a fallback for a file we cannot read.
-    if (auto* source = SourcePool::getInstance().getMutable(event.sourceId);
-        source != nullptr && source->durationSeconds <= 0.0) {
-        double duration = v1.durationSeconds;
-        if (duration <= 0.0 && v1.interpTotalBeats > 0.0 && v1.interpBpm > 0.0)
-            duration = v1.interpTotalBeats * 60.0 / v1.interpBpm;
-        source->durationSeconds = juce::jmax(0.0, duration);
+    double fallbackDuration = v1.durationSeconds;
+    if (fallbackDuration <= 0.0 && v1.interpTotalBeats > 0.0 && v1.interpBpm > 0.0)
+        fallbackDuration = v1.interpTotalBeats * 60.0 / v1.interpBpm;
+    fallbackDuration = juce::jmax(0.0, fallbackDuration);
+
+    AudioEvent event;
+    if (legacySources != nullptr) {
+        // Staging: no pool writes. The anchors below are computed at the
+        // nominal rate and rescaled when install acquires the real file.
+        event.sourceId =
+            ProjectSerializer::stageLegacySource(*legacySources, v1.filePath, fallbackDuration);
+    } else {
+        event.sourceId = SourcePool::getInstance().acquire(v1.filePath);
+        if (auto* source = SourcePool::getInstance().getMutable(event.sourceId);
+            source != nullptr && source->durationSeconds <= 0.0) {
+            source->durationSeconds = fallbackDuration;
+        }
     }
 
     event.interpBpm = v1.interpBpm;
@@ -254,8 +268,15 @@ void migrateLegacyAudioClip(const LegacyAudioSource& v1, const LegacyAudioFields
 
     // v1 kept beats authoritative under autoTempo and seconds otherwise. Both
     // resolve to the same source seconds, which is what becomes the anchor.
-    const bool beatsAuthoritative = legacy.autoTempo && v1.interpBpm > 0.0;
-    const double secondsPerBeat = beatsAuthoritative ? 60.0 / v1.interpBpm : 0.0;
+    //
+    // A v1 clip could be saved with autoTempo on and interpBpm still 0, with
+    // detection pending: its seconds mirrors were deliberately stale and v1
+    // playback read the beat fields through the project tempo. Migrating off
+    // those mirrors would land the clip somewhere it never played, so fall
+    // back to the same tempo v1 did.
+    const double interpretationBpm = v1.interpBpm > 0.0 ? v1.interpBpm : projectTempo;
+    const bool beatsAuthoritative = legacy.autoTempo && isValidBpm(interpretationBpm);
+    const double secondsPerBeat = beatsAuthoritative ? 60.0 / interpretationBpm : 0.0;
     event.setAnchorSeconds(beatsAuthoritative ? v1.offsetBeats * secondsPerBeat : v1.offsetSeconds);
 
     event.setLoopStartSeconds(beatsAuthoritative ? v1.loopStartBeats * secondsPerBeat
@@ -512,7 +533,8 @@ juce::var ProjectSerializer::serializeClipInfo(const ClipInfo& clip) {
 }
 
 bool ProjectSerializer::deserializeClipInfo(const juce::var& json, ClipInfo& outClip,
-                                            double projectTempo) {
+                                            double projectTempo,
+                                            std::vector<Source>* legacySources) {
     if (!json.isObject()) {
         lastError_ = "Clip data is not an object";
         return false;
@@ -769,7 +791,7 @@ bool ProjectSerializer::deserializeClipInfo(const juce::var& json, ClipInfo& out
         v1.timeStretchMode = audioObj->getProperty("timeStretchMode");
         readLegacyWarpMarkers(audioObj->getProperty("warpMarkers"), v1.warpMarkers);
 
-        migrateLegacyAudioClip(v1, legacy, outClip);
+        migrateLegacyAudioClip(v1, legacy, outClip, legacySources, projectTempo);
         readAudioTakesAndComp(*audioObj, outClip);
     } else if (outClip.isAudio() && legacyAudioSourceObj != nullptr) {
         LegacyAudioSource v1;
@@ -788,7 +810,7 @@ bool ProjectSerializer::deserializeClipInfo(const juce::var& json, ClipInfo& out
         v1.timeStretchMode = legacyAudioSourceObj->getProperty("timeStretchMode");
         readLegacyWarpMarkers(legacyAudioSourceObj->getProperty("warpMarkers"), v1.warpMarkers);
 
-        migrateLegacyAudioClip(v1, legacy, outClip);
+        migrateLegacyAudioClip(v1, legacy, outClip, legacySources, projectTempo);
     } else if (outClip.isAudio() && obj->hasProperty("audioFilePath")) {
         LegacyAudioSource v1;
         v1.filePath = obj->getProperty("audioFilePath").toString();
@@ -802,7 +824,7 @@ bool ProjectSerializer::deserializeClipInfo(const juce::var& json, ClipInfo& out
         v1.interpTotalBeats = obj->getProperty("sourceNumBeats");
         v1.interpBpm = obj->getProperty("sourceBPM");
 
-        migrateLegacyAudioClip(v1, legacy, outClip);
+        migrateLegacyAudioClip(v1, legacy, outClip, legacySources, projectTempo);
     }
 
     // MIDI notes

--- a/magda/daw/project/serialization/DawProjectArchive.cpp
+++ b/magda/daw/project/serialization/DawProjectArchive.cpp
@@ -169,8 +169,14 @@ bool DawProjectArchive::readFromFile(const juce::File& file, ProjectDocument& ou
 
         mediaDir.createDirectory();
         if (zip.uncompressEntry(entryIndex, mediaDir, true).wasOk()) {
+            // The anchors were computed against the archive entry, which is not
+            // a file anyone can open, so they are expressed at the nominal rate.
+            // The extracted file has a real one: move them with it, or a
+            // non-48k embedded source imports off by the ratio between them.
+            const double stagedRate = sourceRateOf(event->sourceId);
             event->sourceId = SourcePool::getInstance().acquire(
                 mediaDir.getChildFile(entryName).getFullPathName());
+            event->rescaleSourcePositions(stagedRate, sourceRateOf(event->sourceId));
         }
     }
 

--- a/magda/daw/project/serialization/DawProjectArchive.cpp
+++ b/magda/daw/project/serialization/DawProjectArchive.cpp
@@ -157,9 +157,10 @@ bool DawProjectArchive::readFromFile(const juce::File& file, ProjectDocument& ou
                                     .getChildFile("magda_dawproject_import")
                                     .getChildFile(file.getFileNameWithoutExtension());
     for (auto& clip : outDocument.clips) {
-        if (!clip.isAudio())
+        auto* event = clip.primaryEvent();
+        if (event == nullptr)
             continue;
-        const auto entryName = clip.audio().source.filePath;
+        const auto entryName = event->sourceFilePath();
         if (entryName.isEmpty())
             continue;
         const int entryIndex = zip.getIndexOfFileName(entryName, false);
@@ -167,8 +168,10 @@ bool DawProjectArchive::readFromFile(const juce::File& file, ProjectDocument& ou
             continue;  // external/absolute reference, nothing to extract
 
         mediaDir.createDirectory();
-        if (zip.uncompressEntry(entryIndex, mediaDir, true).wasOk())
-            clip.audio().source.filePath = mediaDir.getChildFile(entryName).getFullPathName();
+        if (zip.uncompressEntry(entryIndex, mediaDir, true).wasOk()) {
+            event->sourceId = SourcePool::getInstance().acquire(
+                mediaDir.getChildFile(entryName).getFullPathName());
+        }
     }
 
     // Pull embedded device state back into the model. fromProjectXml left the

--- a/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
+++ b/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
@@ -752,7 +752,6 @@ juce::XmlElement& addClipElement(juce::XmlElement& parent, const ClipInfo& clip,
 
     // Playback offset + loop region, in the clip's content time unit.
     if (clip.isMidi()) {
-        const auto& midi = clip.midi();
         clipElement->setAttribute("playStart", clip.midiOffset);
         if (clip.loopEnabled && clip.loopLengthBeats > 0.0) {
             clipElement->setAttribute("loopStart", clip.loopStartBeats);

--- a/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
+++ b/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
@@ -861,8 +861,20 @@ ClipInfo clipFromXml(const juce::XmlElement& clipElement, TrackId trackId, ClipI
         if (maxSeconds > 0.0)
             event.interpBpm = maxBeats * 60.0 / maxSeconds;
 
+        // The beat setters below all convert through interpBpm, so without one
+        // they are silent no-ops: the anchor and region would stay at zero
+        // while loopEnabled was set, and the clip would loop the whole source
+        // instead of the region the file states. The importer knows no better
+        // tempo than the project's, which is what the old beat-field import
+        // effectively played at.
+        if (!isValidBpm(event.interpBpm) && maxBeats > 0.0)
+            event.interpBpm = DEFAULT_BPM;
+
+        const bool regionApplicable = isValidBpm(event.interpBpm);
+
         event.setAnchorBeats(clipElement.getDoubleAttribute("playStart", 0.0));
-        if (clipElement.hasAttribute("loopStart") && clipElement.hasAttribute("loopEnd")) {
+        if (regionApplicable && clipElement.hasAttribute("loopStart") &&
+            clipElement.hasAttribute("loopEnd")) {
             clip.loopEnabled = true;
             const double loopStartBeats = clipElement.getDoubleAttribute("loopStart", 0.0);
             event.setLoopStartBeats(loopStartBeats);

--- a/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
+++ b/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
@@ -223,20 +223,20 @@ AudioFileFacts readAudioFileFacts(const juce::File& file) {
 // the File reference) under `parent`, returning it. The Audio descriptor is
 // always seconds-domain; whether the clip plays it in seconds or beats is
 // decided by the parent (plain clip vs <Warps>).
-juce::XmlElement& addAudioElement(juce::XmlElement& parent, const ClipInfo& clip,
+juce::XmlElement& addAudioElement(juce::XmlElement& parent, const AudioEvent& event,
                                   const juce::String& id,
                                   const std::map<juce::String, juce::String>& embeddedBySource) {
-    const auto source = clip.audio().source.filePath;
+    const auto source = event.sourceFilePath();
     const auto facts = readAudioFileFacts(juce::File(source));
 
     auto* audio = parent.createNewChildElement("Audio");
     audio->setAttribute("id", id);
     audio->setAttribute("channels", facts.channels > 0 ? facts.channels : 2);
     audio->setAttribute("sampleRate", facts.sampleRate);
-    // Prefer the clip model's source duration; fall back to the file's length
-    // when the model hasn't recorded one.
-    audio->setAttribute("duration", clip.audio().source.durationSeconds > 0.0
-                                        ? clip.audio().source.durationSeconds
+    // Prefer the pooled source's duration; fall back to the file's length when
+    // the model hasn't recorded one.
+    audio->setAttribute("duration", event.sourceDurationSeconds() > 0.0
+                                        ? event.sourceDurationSeconds()
                                         : facts.durationSeconds);
 
     auto* file = audio->createNewChildElement("File");
@@ -258,27 +258,27 @@ juce::XmlElement& addAudioElement(juce::XmlElement& parent, const ClipInfo& clip
 
 // Plain seconds-domain audio: the <Audio> sits directly in the clip, whose
 // contentTimeUnit is "seconds".
-void addAudioContent(juce::XmlElement& clipElement, const ClipInfo& clip, const juce::String& id,
+void addAudioContent(juce::XmlElement& clipElement, const AudioEvent& event, const juce::String& id,
                      const std::map<juce::String, juce::String>& embeddedBySource) {
-    addAudioElement(clipElement, clip, id, embeddedBySource);
+    addAudioElement(clipElement, event, id, embeddedBySource);
 }
 
 // Beat-locked (autoTempo) audio: the clip's content time is beats, and a <Warps>
 // maps that beat timeline onto the source's seconds via two linear warp markers
 // (clip start -> 0s, source length in beats -> source length in seconds). This
 // is how DAWproject keeps stretched audio tempo-synced instead of one-shot.
-void addWarpedAudioContent(juce::XmlElement& clipElement, const ClipInfo& clip,
+void addWarpedAudioContent(juce::XmlElement& clipElement, const AudioEvent& event,
                            const juce::String& id,
                            const std::map<juce::String, juce::String>& embeddedBySource) {
     auto* warps = clipElement.createNewChildElement("Warps");
     warps->setAttribute("contentTimeUnit", "seconds");
     warps->setAttribute("timeUnit", "beats");
 
-    auto& audio = addAudioElement(*warps, clip, id, embeddedBySource);
+    auto& audio = addAudioElement(*warps, event, id, embeddedBySource);
 
     const double sourceSeconds =
-        audio.getDoubleAttribute("duration", clip.audio().source.durationSeconds);
-    const double totalBeats = clip.audio().interpretation.totalBeats;
+        audio.getDoubleAttribute("duration", event.sourceDurationSeconds());
+    const double totalBeats = event.interpTotalBeats;
 
     auto* start = warps->createNewChildElement("Warp");
     start->setAttribute("time", 0.0);
@@ -744,26 +744,35 @@ juce::XmlElement& addClipElement(juce::XmlElement& parent, const ClipInfo& clip,
     // The parent timeline uses beats for clip time/duration, but a clip's inner
     // content lives in its own content time. MIDI note times and beat-locked
     // audio are beats-domain; plain audio is seconds-domain.
-    const bool beatContent = clip.isMidi() || (clip.isAudio() && clip.autoTempo);
+    // A DAWproject clip exports the primary event: it is the format's own
+    // one-source-per-clip shape, and Phase A of #1901 never builds more.
+    const auto* event = clip.primaryEvent();
+    const bool beatContent = clip.isMidi() || (event != nullptr && event->autoTempo);
     clipElement->setAttribute("contentTimeUnit", beatContent ? "beats" : "seconds");
 
     // Playback offset + loop region, in the clip's content time unit.
-    if (beatContent) {
-        clipElement->setAttribute("playStart", clip.offsetBeats);
+    if (clip.isMidi()) {
+        const auto& midi = clip.midi();
+        clipElement->setAttribute("playStart", clip.midiOffset);
         if (clip.loopEnabled && clip.loopLengthBeats > 0.0) {
             clipElement->setAttribute("loopStart", clip.loopStartBeats);
             clipElement->setAttribute("loopEnd", clip.loopStartBeats + clip.loopLengthBeats);
         }
-    } else {
-        // Plain audio is seconds-domain. Read through the beats-authoritative
-        // accessors rather than the transitional raw seconds fields.
-        clipElement->setAttribute("playStart", clip.getSourceOffset());
+    } else if (event != nullptr && beatContent) {
+        clipElement->setAttribute("playStart", event->anchorBeats());
+        if (clip.loopEnabled && event->loopLengthSamples > 0) {
+            clipElement->setAttribute("loopStart", event->loopStartBeats());
+            clipElement->setAttribute("loopEnd",
+                                      event->loopStartBeats() + event->loopLengthBeats());
+        }
+    } else if (event != nullptr) {
+        clipElement->setAttribute("playStart", event->anchorSeconds());
         if (clip.loopEnabled) {
-            const double loopStart = clip.getSourceLoopStart();
+            const double loopStart = event->loopStartSeconds();
             const double loopLen =
-                clip.getSourceLoopLength() > 0.0
-                    ? clip.getSourceLoopLength()
-                    : juce::jmax(0.0, clip.audio().source.durationSeconds - loopStart);
+                event->loopLengthSamples > 0
+                    ? event->loopLengthSeconds()
+                    : juce::jmax(0.0, event->sourceDurationSeconds() - loopStart);
             clipElement->setAttribute("loopStart", loopStart);
             clipElement->setAttribute("loopEnd", loopStart + loopLen);
         }
@@ -776,12 +785,24 @@ juce::XmlElement& addClipElement(juce::XmlElement& parent, const ClipInfo& clip,
 
     if (clip.isMidi())
         addNotes(*clipElement, clip, idFor("notes", clip.id));
-    else if (clip.isAudio() && clip.autoTempo)
-        addWarpedAudioContent(*clipElement, clip, idFor("audio", clip.id), embeddedBySource);
-    else if (clip.isAudio())
-        addAudioContent(*clipElement, clip, idFor("audio", clip.id), embeddedBySource);
+    else if (event != nullptr && event->autoTempo)
+        addWarpedAudioContent(*clipElement, *event, idFor("audio", clip.id), embeddedBySource);
+    else if (event != nullptr)
+        addAudioContent(*clipElement, *event, idFor("audio", clip.id), embeddedBySource);
 
     return *clipElement;
+}
+
+// Pool an imported file reference. The path may not resolve yet (the archive
+// extractor rewrites it afterwards), so the declared duration is carried over
+// when the file itself cannot be probed.
+SourceId adoptImportedSource(const juce::String& path, double declaredDuration) {
+    const auto sourceId = SourcePool::getInstance().acquire(path);
+    if (auto* source = SourcePool::getInstance().getMutable(sourceId);
+        source != nullptr && source->durationSeconds <= 0.0 && declaredDuration > 0.0) {
+        source->durationSeconds = declaredDuration;
+    }
+    return sourceId;
 }
 
 ClipInfo clipFromXml(const juce::XmlElement& clipElement, TrackId trackId, ClipId clipId) {
@@ -808,7 +829,7 @@ ClipInfo clipFromXml(const juce::XmlElement& clipElement, TrackId trackId, ClipI
         }
 
         // Read offset and loop region (content time = beats for MIDI).
-        clip.offsetBeats = clipElement.getDoubleAttribute("playStart", 0.0);
+        clip.midiOffset = clipElement.getDoubleAttribute("playStart", 0.0);
         if (clipElement.hasAttribute("loopStart") && clipElement.hasAttribute("loopEnd")) {
             clip.loopEnabled = true;
             clip.loopStartBeats = clipElement.getDoubleAttribute("loopStart", 0.0);
@@ -823,11 +844,13 @@ ClipInfo clipFromXml(const juce::XmlElement& clipElement, TrackId trackId, ClipI
     // markers and read the offset/loop region in beats.
     if (auto* warps = clipElement.getChildByName("Warps")) {
         clip.setAudioContent();
-        clip.autoTempo = true;
+        auto& event = clip.audio().addEvent({});
+        event.autoTempo = true;
         if (auto* audioElement = warps->getChildByName("Audio")) {
-            clip.audio().source.durationSeconds = audioElement->getDoubleAttribute("duration", 0.0);
             if (auto* fileElement = audioElement->getChildByName("File"))
-                clip.audio().source.filePath = fileElement->getStringAttribute("path");
+                event.sourceId =
+                    adoptImportedSource(fileElement->getStringAttribute("path"),
+                                        audioElement->getDoubleAttribute("duration", 0.0));
         }
 
         double maxBeats = 0.0, maxSeconds = 0.0;
@@ -835,34 +858,39 @@ ClipInfo clipFromXml(const juce::XmlElement& clipElement, TrackId trackId, ClipI
             maxBeats = juce::jmax(maxBeats, w->getDoubleAttribute("time", 0.0));
             maxSeconds = juce::jmax(maxSeconds, w->getDoubleAttribute("contentTime", 0.0));
         }
-        clip.audio().interpretation.totalBeats = maxBeats;
+        event.interpTotalBeats = maxBeats;
         if (maxSeconds > 0.0)
-            clip.audio().interpretation.bpm = maxBeats * 60.0 / maxSeconds;
+            event.interpBpm = maxBeats * 60.0 / maxSeconds;
 
-        clip.offsetBeats = clipElement.getDoubleAttribute("playStart", 0.0);
+        event.setAnchorBeats(clipElement.getDoubleAttribute("playStart", 0.0));
         if (clipElement.hasAttribute("loopStart") && clipElement.hasAttribute("loopEnd")) {
             clip.loopEnabled = true;
-            clip.loopStartBeats = clipElement.getDoubleAttribute("loopStart", 0.0);
-            clip.loopLengthBeats = juce::jmax(0.0, clipElement.getDoubleAttribute("loopEnd", 0.0) -
-                                                       clip.loopStartBeats);
+            const double loopStartBeats = clipElement.getDoubleAttribute("loopStart", 0.0);
+            event.setLoopStartBeats(loopStartBeats);
+            event.setLoopLengthBeats(
+                juce::jmax(0.0, clipElement.getDoubleAttribute("loopEnd", 0.0) - loopStartBeats));
         }
+        clip.syncSingleEventToClipBounds();
         return clip;
     }
 
     if (auto* audioElement = clipElement.getChildByName("Audio")) {
         clip.setAudioContent();
-        clip.audio().source.durationSeconds = audioElement->getDoubleAttribute("duration", 0.0);
+        auto& event = clip.audio().addEvent({});
         if (auto* fileElement = audioElement->getChildByName("File"))
-            clip.audio().source.filePath = fileElement->getStringAttribute("path");
+            event.sourceId = adoptImportedSource(fileElement->getStringAttribute("path"),
+                                                 audioElement->getDoubleAttribute("duration", 0.0));
 
         // Source read offset and loop region (content time = seconds for audio).
-        clip.offset = clipElement.getDoubleAttribute("playStart", 0.0);
+        event.setAnchorSeconds(clipElement.getDoubleAttribute("playStart", 0.0));
         if (clipElement.hasAttribute("loopStart") && clipElement.hasAttribute("loopEnd")) {
             clip.loopEnabled = true;
-            clip.loopStart = clipElement.getDoubleAttribute("loopStart", 0.0);
-            clip.loopLength =
-                juce::jmax(0.0, clipElement.getDoubleAttribute("loopEnd", 0.0) - clip.loopStart);
+            const double loopStart = clipElement.getDoubleAttribute("loopStart", 0.0);
+            event.setLoopStartSeconds(loopStart);
+            event.setLoopLengthSeconds(
+                juce::jmax(0.0, clipElement.getDoubleAttribute("loopEnd", 0.0) - loopStart));
         }
+        clip.syncSingleEventToClipBounds();
         return clip;
     }
 
@@ -1390,10 +1418,11 @@ std::vector<DawProjectXmlAdapter::EmbeddedAudioFile> DawProjectXmlAdapter::colle
     std::set<juce::String> usedArchivePaths;  // disambiguate same-name distinct sources
 
     for (const auto& clip : document.clips) {
-        if (!clip.isAudio())
+        const auto* event = clip.primaryEvent();
+        if (event == nullptr)
             continue;
 
-        const auto source = clip.audio().source.filePath;
+        const auto source = event->sourceFilePath();
         if (source.isEmpty() || seenSources.count(source) > 0)
             continue;
         seenSources.insert(source);

--- a/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
+++ b/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
@@ -804,7 +804,8 @@ SourceId adoptImportedSource(const juce::String& path, double declaredDuration) 
     return sourceId;
 }
 
-ClipInfo clipFromXml(const juce::XmlElement& clipElement, TrackId trackId, ClipId clipId) {
+ClipInfo clipFromXml(const juce::XmlElement& clipElement, TrackId trackId, ClipId clipId,
+                     double projectTempo) {
     ClipInfo clip;
     clip.id = clipId;
     clip.trackId = trackId;
@@ -864,11 +865,11 @@ ClipInfo clipFromXml(const juce::XmlElement& clipElement, TrackId trackId, ClipI
         // The beat setters below all convert through interpBpm, so without one
         // they are silent no-ops: the anchor and region would stay at zero
         // while loopEnabled was set, and the clip would loop the whole source
-        // instead of the region the file states. The importer knows no better
-        // tempo than the project's, which is what the old beat-field import
+        // instead of the region the file states. The imported project's own
+        // tempo is the best stand-in, and is what the old beat-field import
         // effectively played at.
         if (!isValidBpm(event.interpBpm) && maxBeats > 0.0)
-            event.interpBpm = DEFAULT_BPM;
+            event.interpBpm = isValidBpm(projectTempo) ? projectTempo : DEFAULT_BPM;
 
         const bool regionApplicable = isValidBpm(event.interpBpm);
 
@@ -1333,8 +1334,8 @@ bool DawProjectXmlAdapter::fromProjectXml(const juce::String& xml, ProjectDocume
 
                 if (auto* clips = trackLanes->getChildByName("Clips")) {
                     for (auto* clipElement : clips->getChildWithTagNameIterator("Clip"))
-                        document.clips.push_back(
-                            clipFromXml(*clipElement, trackIt->second, nextClipId++));
+                        document.clips.push_back(clipFromXml(*clipElement, trackIt->second,
+                                                             nextClipId++, document.info.tempo));
                 }
 
                 for (auto* pointsElement : trackLanes->getChildWithTagNameIterator("Points")) {
@@ -1398,7 +1399,8 @@ bool DawProjectXmlAdapter::fromProjectXml(const juce::String& xml, ProjectDocume
                             return;
 
                         if (auto* clipElement = timeline->getChildByName("Clip")) {
-                            auto clip = clipFromXml(*clipElement, trackIt->second, nextClipId++);
+                            auto clip = clipFromXml(*clipElement, trackIt->second, nextClipId++,
+                                                    document.info.tempo);
                             clip.view = ClipView::Session;
                             clip.sceneIndex = sceneIndex;
                             clip.setPlacementBeats(0.0, clip.placement.lengthBeats);

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -253,12 +253,10 @@ bool ProjectSerializer::loadAndStage(const juce::File& file, StagedProjectData& 
             return false;
         }
 
-        // Sources must be pooled before the clips that reference them by id,
-        // and after the outgoing project's pool is dropped. This cannot live in
-        // ClipManager::clearAllClips: the commit phase calls that AFTER the
-        // sources are staged, which would strand every event's source id.
-        SourcePool::getInstance().clear();
-        deserializeSources(obj->getProperty("sources"));
+        // Parsed only. Installing them is a commit-phase job: this runs on a
+        // background thread, the staging steps below can still fail, and the
+        // still-open project's clips are reading the live pool meanwhile.
+        deserializeSourcesToStaging(obj->getProperty("sources"), outData.sources);
 
         if (!deserializeClipsToStaging(obj->getProperty("clips"), outData.clips,
                                        outData.info.tempo)) {
@@ -309,7 +307,13 @@ bool ProjectSerializer::loadAndStage(const juce::File& file, StagedProjectData& 
 }
 
 void ProjectSerializer::commitStaged(StagedProjectData& data) {
+    // Before the clips, which reference these by id.
+    installStagedSources(data.sources, data.clips);
+
     commitStagedData(data.tracks, data.clips, data.automationLanes, data.automationClips);
+
+    // After, so re-probing a source can rescale the events that point at it.
+    resolveStagedSources(data.sources);
 
     // Restore master track chain elements (plugins on the master bus)
     if (data.masterTrack) {
@@ -562,8 +566,8 @@ bool ProjectSerializer::deserializeProject(const juce::var& json, ProjectInfo& o
         return false;  // Failed - no state modified
     }
 
-    SourcePool::getInstance().clear();
-    deserializeSources(obj->getProperty("sources"));
+    std::vector<Source> stagedSources;
+    deserializeSourcesToStaging(obj->getProperty("sources"), stagedSources);
 
     if (!deserializeClipsToStaging(obj->getProperty("clips"), stagedClips, outInfo.tempo)) {
         return false;  // Failed - no state modified
@@ -589,7 +593,9 @@ bool ProjectSerializer::deserializeProject(const juce::var& json, ProjectInfo& o
                                                    stagedAutomation, stagedAutomationClips);
 
     // Stage 2: All components validated successfully - now commit to managers atomically
+    installStagedSources(stagedSources, stagedClips);
     commitStagedData(stagedTracks, stagedClips, stagedAutomation, stagedAutomationClips);
+    resolveStagedSources(stagedSources);
 
     // Restore master track chain elements (plugins on the master bus)
     if (hasMasterTrack) {
@@ -723,9 +729,11 @@ juce::var ProjectSerializer::serializeTracks() {
 }
 
 juce::var ProjectSerializer::serializeSources() {
-    // Only sources some clip still references are written: the pool is additive
-    // within a session so an undone delete can find its source again, and save
-    // is where that garbage is collected.
+    // Only sources some clip still references are written. This filters the
+    // emitted snapshot and deliberately does NOT prune the live pool: the pool
+    // is additive within a session precisely so an undone delete, or a paste
+    // from the clipboard, still finds its source. Autosave runs this on a
+    // timer, so pruning here would quietly break both between saves.
     std::unordered_set<SourceId> live;
     for (const auto& clip : ClipManager::getInstance().getClips()) {
         if (!clip.isAudio())
@@ -733,10 +741,12 @@ juce::var ProjectSerializer::serializeSources() {
         for (const auto& event : clip.audio().events)
             live.insert(event.sourceId);
     }
-    SourcePool::getInstance().retainOnly(live);
 
     juce::Array<juce::var> sourcesArray;
     for (const auto& source : SourcePool::getInstance().snapshot()) {
+        if (live.count(source.id) == 0)
+            continue;
+
         auto* sourceObj = new juce::DynamicObject();
         sourceObj->setProperty("id", source.id);
         sourceObj->setProperty("filePath", source.filePath);
@@ -753,10 +763,11 @@ juce::var ProjectSerializer::serializeSources() {
     return juce::var(sourcesArray);
 }
 
-void ProjectSerializer::deserializeSources(const juce::var& json) {
+void ProjectSerializer::deserializeSourcesToStaging(const juce::var& json,
+                                                    std::vector<Source>& out) {
     if (!json.isArray())
         return;
-    auto& pool = SourcePool::getInstance();
+
     for (const auto& entry : *json.getArray()) {
         auto* sourceObj = entry.getDynamicObject();
         if (sourceObj == nullptr)
@@ -770,13 +781,49 @@ void ProjectSerializer::deserializeSources(const juce::var& json) {
         source.detectedKeyRoot = sourceObj->getProperty("detectedKeyRoot").toString().toStdString();
         source.detectedKeyScale =
             sourceObj->getProperty("detectedKeyScale").toString().toStdString();
-        const auto id = pool.insert(source);
+        out.push_back(std::move(source));
+    }
+}
 
+void ProjectSerializer::installStagedSources(const std::vector<Source>& sources,
+                                             const std::vector<ClipInfo>& stagedClips) {
+    auto& pool = SourcePool::getInstance();
+
+    // A v1 clip has no entry in the table: it acquires from the pool as it
+    // migrates, so its id only exists in the live pool. Carry those across the
+    // swap or they dangle. A file can hold both shapes at once.
+    std::unordered_set<SourceId> known;
+    for (const auto& source : sources)
+        known.insert(source.id);
+
+    std::vector<Source> carried;
+    for (const auto& clip : stagedClips) {
+        if (!clip.isAudio())
+            continue;
+        for (const auto& event : clip.audio().events) {
+            if (event.sourceId == INVALID_SOURCE_ID || !known.insert(event.sourceId).second)
+                continue;
+            if (const auto* live = pool.get(event.sourceId))
+                carried.push_back(*live);
+        }
+    }
+
+    pool.clear();
+    for (const auto& source : sources)
+        pool.insert(source);
+    for (const auto& source : carried)
+        pool.insert(source);
+}
+
+void ProjectSerializer::resolveStagedSources(const std::vector<Source>& sources) {
+    auto& pool = SourcePool::getInstance();
+    for (const auto& source : sources) {
         // A project saved while the file was missing carries sampleRate 0, so
         // its events' anchors were computed at the nominal rate. Re-probing now
-        // resolves the source and rescales them.
-        if (id != INVALID_SOURCE_ID && !source.isResolved())
-            pool.resolveFacts(id);
+        // resolves the source, and the pool's rate-change handler rescales
+        // them: this runs after the clips are committed so those events exist.
+        if (!source.isResolved())
+            pool.resolveFacts(source.id);
     }
 }
 

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -258,8 +258,8 @@ bool ProjectSerializer::loadAndStage(const juce::File& file, StagedProjectData& 
         // still-open project's clips are reading the live pool meanwhile.
         deserializeSourcesToStaging(obj->getProperty("sources"), outData.sources);
 
-        if (!deserializeClipsToStaging(obj->getProperty("clips"), outData.clips,
-                                       outData.info.tempo)) {
+        if (!deserializeClipsToStaging(obj->getProperty("clips"), outData.clips, outData.info.tempo,
+                                       &outData.legacySources)) {
             return false;
         }
 
@@ -308,7 +308,7 @@ bool ProjectSerializer::loadAndStage(const juce::File& file, StagedProjectData& 
 
 void ProjectSerializer::commitStaged(StagedProjectData& data) {
     // Before the clips, which reference these by id.
-    installStagedSources(data.sources, data.clips);
+    installStagedSources(data.sources, data.legacySources, data.clips);
 
     commitStagedData(data.tracks, data.clips, data.automationLanes, data.automationClips);
 
@@ -569,7 +569,9 @@ bool ProjectSerializer::deserializeProject(const juce::var& json, ProjectInfo& o
     std::vector<Source> stagedSources;
     deserializeSourcesToStaging(obj->getProperty("sources"), stagedSources);
 
-    if (!deserializeClipsToStaging(obj->getProperty("clips"), stagedClips, outInfo.tempo)) {
+    std::vector<Source> stagedLegacySources;
+    if (!deserializeClipsToStaging(obj->getProperty("clips"), stagedClips, outInfo.tempo,
+                                   &stagedLegacySources)) {
         return false;  // Failed - no state modified
     }
 
@@ -593,7 +595,7 @@ bool ProjectSerializer::deserializeProject(const juce::var& json, ProjectInfo& o
                                                    stagedAutomation, stagedAutomationClips);
 
     // Stage 2: All components validated successfully - now commit to managers atomically
-    installStagedSources(stagedSources, stagedClips);
+    installStagedSources(stagedSources, stagedLegacySources, stagedClips);
     commitStagedData(stagedTracks, stagedClips, stagedAutomation, stagedAutomationClips);
     resolveStagedSources(stagedSources);
 
@@ -785,34 +787,84 @@ void ProjectSerializer::deserializeSourcesToStaging(const juce::var& json,
     }
 }
 
-void ProjectSerializer::installStagedSources(const std::vector<Source>& sources,
-                                             const std::vector<ClipInfo>& stagedClips) {
-    auto& pool = SourcePool::getInstance();
-
-    // A v1 clip has no entry in the table: it acquires from the pool as it
-    // migrates, so its id only exists in the live pool. Carry those across the
-    // swap or they dangle. A file can hold both shapes at once.
-    std::unordered_set<SourceId> known;
-    for (const auto& source : sources)
-        known.insert(source.id);
-
-    std::vector<Source> carried;
-    for (const auto& clip : stagedClips) {
-        if (!clip.isAudio())
-            continue;
-        for (const auto& event : clip.audio().events) {
-            if (event.sourceId == INVALID_SOURCE_ID || !known.insert(event.sourceId).second)
-                continue;
-            if (const auto* live = pool.get(event.sourceId))
-                carried.push_back(*live);
+SourceId ProjectSerializer::stageLegacySource(std::vector<Source>& legacySources,
+                                              const juce::String& filePath,
+                                              double fallbackDuration) {
+    for (auto& staged : legacySources) {
+        if (staged.filePath == filePath) {
+            // Several v1 clips can name one file with different recorded
+            // durations. Keep the longest: a short one would clamp the other
+            // clips' anchors and cap their right-extension.
+            staged.durationSeconds = juce::jmax(staged.durationSeconds, fallbackDuration);
+            return staged.id;
         }
     }
 
+    Source staged;
+    staged.id = -2 - static_cast<SourceId>(legacySources.size());  // never -1
+    staged.filePath = filePath;
+    staged.durationSeconds = fallbackDuration;
+    legacySources.push_back(std::move(staged));
+    return legacySources.back().id;
+}
+
+void ProjectSerializer::installStagedSources(const std::vector<Source>& sources,
+                                             const std::vector<Source>& legacySources,
+                                             std::vector<ClipInfo>& stagedClips) {
+    auto& pool = SourcePool::getInstance();
     pool.clear();
+
+    // insert() dedups by canonical path and returns the winner, so two entries
+    // for one file (a v2 table entry plus a v1-migrated acquire of the same
+    // path, or two saved paths differing only in case) collapse to one id. The
+    // loser's events have to follow it or they dangle and lose their audio.
+    struct Remap {
+        SourceId owner;
+        double loserRate;
+    };
+    std::unordered_map<SourceId, Remap> remapped;
+
+    const auto installOne = [&](const Source& source) {
+        const auto owner = pool.insert(source);
+        if (owner != INVALID_SOURCE_ID && owner != source.id)
+            remapped[source.id] = {owner, source.effectiveSampleRate()};
+    };
+
     for (const auto& source : sources)
-        pool.insert(source);
-    for (const auto& source : carried)
-        pool.insert(source);
+        installOne(source);
+
+    // v1 sources were staged under provisional ids; this is where they become
+    // real. Acquiring probes the file, so the rate can differ from the nominal
+    // one the migration computed its anchors at.
+    for (const auto& staged : legacySources) {
+        const auto owner = pool.acquire(staged.filePath);
+        if (owner == INVALID_SOURCE_ID)
+            continue;
+
+        if (auto* pooled = pool.getMutable(owner);
+            pooled != nullptr && pooled->durationSeconds <= 0.0 && staged.durationSeconds > 0.0) {
+            pooled->durationSeconds = staged.durationSeconds;
+        }
+        remapped[staged.id] = {owner, staged.effectiveSampleRate()};
+    }
+
+    if (remapped.empty())
+        return;
+
+    for (auto& clip : stagedClips) {
+        if (!clip.isAudio())
+            continue;
+        for (auto& event : clip.audio().events) {
+            const auto it = remapped.find(event.sourceId);
+            if (it == remapped.end())
+                continue;
+
+            // The two entries name the same file but may have been probed at
+            // different rates, so the sample counts move with the id.
+            event.rescaleSourcePositions(it->second.loserRate, sourceRateOf(it->second.owner));
+            event.sourceId = it->second.owner;
+        }
+    }
 }
 
 void ProjectSerializer::resolveStagedSources(const std::vector<Source>& sources) {
@@ -887,7 +939,8 @@ bool ProjectSerializer::deserializeTracksToStaging(const juce::var& json,
 
 bool ProjectSerializer::deserializeClipsToStaging(const juce::var& json,
                                                   std::vector<ClipInfo>& outClips,
-                                                  double projectTempo) {
+                                                  double projectTempo,
+                                                  std::vector<Source>* legacySources) {
     if (!json.isArray()) {
         lastError_ = "Clips data is not an array";
         return false;
@@ -900,7 +953,7 @@ bool ProjectSerializer::deserializeClipsToStaging(const juce::var& json,
     // Deserialize all clips into staging vector (validation phase)
     for (const auto& clipVar : *arr) {
         ClipInfo clip;
-        if (!deserializeClipInfo(clipVar, clip, projectTempo)) {
+        if (!deserializeClipInfo(clipVar, clip, projectTempo, legacySources)) {
             return false;  // Failed - staging vector discarded
         }
         outClips.push_back(std::move(clip));

--- a/magda/daw/project/serialization/ProjectSerializer.cpp
+++ b/magda/daw/project/serialization/ProjectSerializer.cpp
@@ -2,6 +2,8 @@
 
 #include <juce_data_structures/juce_data_structures.h>
 
+#include <unordered_set>
+
 #include "../../core/AutomationManager.hpp"
 #include "../../core/ClipManager.hpp"
 #include "../../core/LegacyDeviceAliases.hpp"
@@ -251,6 +253,13 @@ bool ProjectSerializer::loadAndStage(const juce::File& file, StagedProjectData& 
             return false;
         }
 
+        // Sources must be pooled before the clips that reference them by id,
+        // and after the outgoing project's pool is dropped. This cannot live in
+        // ClipManager::clearAllClips: the commit phase calls that AFTER the
+        // sources are staged, which would strand every event's source id.
+        SourcePool::getInstance().clear();
+        deserializeSources(obj->getProperty("sources"));
+
         if (!deserializeClipsToStaging(obj->getProperty("clips"), outData.clips,
                                        outData.info.tempo)) {
             return false;
@@ -336,6 +345,7 @@ juce::var ProjectSerializer::serializeProject(const ProjectInfo& info) {
 
     // Version and metadata
     obj->setProperty("magdaVersion", info.version);
+    obj->setProperty("schemaVersion", kProjectSchemaVersion);
     obj->setProperty("lastModified", info.lastModified.toISO8601(true));
 
     // Project settings
@@ -399,8 +409,10 @@ juce::var ProjectSerializer::serializeProject(const ProjectInfo& info) {
 
     obj->setProperty("project", juce::var(projectObj));
 
-    // Serialize tracks, clips, and automation
+    // Serialize tracks, clips, and automation. Sources go before clips: a clip's
+    // events reference them by id (#1901).
     obj->setProperty("tracks", serializeTracks());
+    obj->setProperty("sources", serializeSources());
     obj->setProperty("clips", serializeClips());
     obj->setProperty("automation", serializeAutomation());
 
@@ -549,6 +561,9 @@ bool ProjectSerializer::deserializeProject(const juce::var& json, ProjectInfo& o
     if (!deserializeTracksToStaging(obj->getProperty("tracks"), stagedTracks)) {
         return false;  // Failed - no state modified
     }
+
+    SourcePool::getInstance().clear();
+    deserializeSources(obj->getProperty("sources"));
 
     if (!deserializeClipsToStaging(obj->getProperty("clips"), stagedClips, outInfo.tempo)) {
         return false;  // Failed - no state modified
@@ -705,6 +720,64 @@ juce::var ProjectSerializer::serializeTracks() {
     }
 
     return juce::var(tracksArray);
+}
+
+juce::var ProjectSerializer::serializeSources() {
+    // Only sources some clip still references are written: the pool is additive
+    // within a session so an undone delete can find its source again, and save
+    // is where that garbage is collected.
+    std::unordered_set<SourceId> live;
+    for (const auto& clip : ClipManager::getInstance().getClips()) {
+        if (!clip.isAudio())
+            continue;
+        for (const auto& event : clip.audio().events)
+            live.insert(event.sourceId);
+    }
+    SourcePool::getInstance().retainOnly(live);
+
+    juce::Array<juce::var> sourcesArray;
+    for (const auto& source : SourcePool::getInstance().snapshot()) {
+        auto* sourceObj = new juce::DynamicObject();
+        sourceObj->setProperty("id", source.id);
+        sourceObj->setProperty("filePath", source.filePath);
+        sourceObj->setProperty("durationSeconds", source.durationSeconds);
+        sourceObj->setProperty("sampleRate", source.sampleRate);
+        if (source.detectedBpm > 0.0)
+            sourceObj->setProperty("detectedBpm", source.detectedBpm);
+        if (!source.detectedKeyRoot.empty())
+            sourceObj->setProperty("detectedKeyRoot", juce::String(source.detectedKeyRoot));
+        if (!source.detectedKeyScale.empty())
+            sourceObj->setProperty("detectedKeyScale", juce::String(source.detectedKeyScale));
+        sourcesArray.add(juce::var(sourceObj));
+    }
+    return juce::var(sourcesArray);
+}
+
+void ProjectSerializer::deserializeSources(const juce::var& json) {
+    if (!json.isArray())
+        return;
+    auto& pool = SourcePool::getInstance();
+    for (const auto& entry : *json.getArray()) {
+        auto* sourceObj = entry.getDynamicObject();
+        if (sourceObj == nullptr)
+            continue;
+        Source source;
+        source.id = sourceObj->getProperty("id");
+        source.filePath = sourceObj->getProperty("filePath").toString();
+        source.durationSeconds = sourceObj->getProperty("durationSeconds");
+        source.sampleRate = sourceObj->getProperty("sampleRate");
+        source.detectedBpm = sourceObj->getProperty("detectedBpm");
+        source.detectedKeyRoot = sourceObj->getProperty("detectedKeyRoot").toString().toStdString();
+        source.detectedKeyScale =
+            sourceObj->getProperty("detectedKeyScale").toString().toStdString();
+        const auto id = pool.insert(source);
+
+        // A project saved while the file was missing carries sampleRate 0, so
+        // its events' anchors were computed at the nominal rate. Re-probing now
+        // resolves the source and rescales them.
+        if (id != INVALID_SOURCE_ID && !source.isResolved())
+            pool.resolveFacts(id);
+    }
 }
 
 juce::var ProjectSerializer::serializeClips() {

--- a/magda/daw/project/serialization/ProjectSerializer.hpp
+++ b/magda/daw/project/serialization/ProjectSerializer.hpp
@@ -23,6 +23,10 @@ struct StagedProjectData {
     /// after this point, and the open project's clips are reading the pool on
     /// every paint. commitStaged installs them on the message thread.
     std::vector<Source> sources;
+    /// Sources a v1 clip needs, collected during migration under provisional
+    /// negative ids. They are acquired for real at install time: staging runs
+    /// on a background thread and may still fail, so it must not pool them.
+    std::vector<Source> legacySources;
     std::vector<TrackInfo> tracks;
     std::unique_ptr<TrackInfo> masterTrack;  // Master track (id=MASTER_TRACK_ID)
     std::vector<ClipInfo> clips;
@@ -142,8 +146,18 @@ class ProjectSerializer {
     // ========================================================================
 
     static juce::var serializeClipInfo(const ClipInfo& clip);
+
+    /// Provisional id for a v1 source staged rather than pooled. Negative so
+    /// it can never be mistaken for a real pooled id or for INVALID_SOURCE_ID.
+    static SourceId stageLegacySource(std::vector<Source>& legacySources,
+                                      const juce::String& filePath, double fallbackDuration);
+
+    /// @param legacySources when non-null, a v1 clip's source is staged into it
+    ///        under a provisional id instead of being pooled. Project loading
+    ///        passes one; the migration tests drive a single clip and do not.
     static bool deserializeClipInfo(const juce::var& json, ClipInfo& outClip,
-                                    double projectTempo = 120.0);
+                                    double projectTempo = 120.0,
+                                    std::vector<Source>* legacySources = nullptr);
 
     /**
      * @brief Serialize the pooled media sources to a JSON array (#1901).
@@ -165,7 +179,8 @@ class ProjectSerializer {
     /// Resolution is deliberately deferred to resolveStagedSources, which must
     /// run after the clips are in place so the rescale can reach their events.
     static void installStagedSources(const std::vector<Source>& sources,
-                                     const std::vector<ClipInfo>& stagedClips);
+                                     const std::vector<Source>& legacySources,
+                                     std::vector<ClipInfo>& stagedClips);
 
     /// Re-probe sources that were saved unresolved, rescaling the anchors of
     /// every event pointing at them.
@@ -230,7 +245,8 @@ class ProjectSerializer {
      * @return true on success (all clips valid), false on error (no state modified)
      */
     static bool deserializeClipsToStaging(const juce::var& json, std::vector<ClipInfo>& outClips,
-                                          double projectTempo = 120.0);
+                                          double projectTempo = 120.0,
+                                          std::vector<Source>* legacySources = nullptr);
 
     /**
      * @brief Deserialize automation lanes from JSON array to staging vector (validation phase)

--- a/magda/daw/project/serialization/ProjectSerializer.hpp
+++ b/magda/daw/project/serialization/ProjectSerializer.hpp
@@ -4,6 +4,7 @@
 
 #include "../../core/AutomationInfo.hpp"
 #include "../../core/ClipInfo.hpp"
+#include "../../core/Source.hpp"
 #include "../../core/TrackInfo.hpp"
 #include "ProjectInfo.hpp"
 
@@ -17,6 +18,11 @@ namespace magda {
  */
 struct StagedProjectData {
     ProjectInfo info;
+    /// Pooled sources, parsed but not yet installed. Staging must not touch the
+    /// live pool: loadAndStage runs on a background thread and can still fail
+    /// after this point, and the open project's clips are reading the pool on
+    /// every paint. commitStaged installs them on the message thread.
+    std::vector<Source> sources;
     std::vector<TrackInfo> tracks;
     std::unique_ptr<TrackInfo> masterTrack;  // Master track (id=MASTER_TRACK_ID)
     std::vector<ClipInfo> clips;
@@ -146,7 +152,19 @@ class ProjectSerializer {
      * @brief Restore pooled media sources. Must run before clips, whose events
      * reference sources by id.
      */
-    static void deserializeSources(const juce::var& json);
+    /// Parse the sources array into @p out without touching the live pool.
+    static void deserializeSourcesToStaging(const juce::var& json, std::vector<Source>& out);
+
+    /// Replace the pool with @p sources, carrying across any entry that
+    /// @p stagedClips still reference. Message thread, commit phase only.
+    /// Resolution is deliberately deferred to resolveStagedSources, which must
+    /// run after the clips are in place so the rescale can reach their events.
+    static void installStagedSources(const std::vector<Source>& sources,
+                                     const std::vector<ClipInfo>& stagedClips);
+
+    /// Re-probe sources that were saved unresolved, rescaling the anchors of
+    /// every event pointing at them.
+    static void resolveStagedSources(const std::vector<Source>& sources);
 
     /**
      * @brief Serialize all clips to JSON array

--- a/magda/daw/project/serialization/ProjectSerializer.hpp
+++ b/magda/daw/project/serialization/ProjectSerializer.hpp
@@ -36,8 +36,13 @@ struct StagedProjectData {
  * 1 (written as no key at all): a clip carried one audio source and one set of
  *   playback fields.
  * 2: the clip hosts a list of events referencing pooled sources (#1901). Read
- *   support for 1 is permanent; nothing writes it any more, so a v2 file does
- *   not open in an older build.
+ *   support for 1 is permanent.
+ *
+ * There is no version gate on the way in. Already-shipped builds validate only
+ * that magdaVersion is a non-empty string and ignore keys they do not know, so
+ * a v2 file opens in an older build with every audio clip silently stripped of
+ * its source, and saving from there writes that loss back. Nothing this writer
+ * can emit changes that, so treat it as a one-way upgrade rather than a gate.
  */
 constexpr int kProjectSchemaVersion = 2;
 

--- a/magda/daw/project/serialization/ProjectSerializer.hpp
+++ b/magda/daw/project/serialization/ProjectSerializer.hpp
@@ -25,6 +25,17 @@ struct StagedProjectData {
 };
 
 /**
+ * @brief Project file schema version.
+ *
+ * 1 (written as no key at all): a clip carried one audio source and one set of
+ *   playback fields.
+ * 2: the clip hosts a list of events referencing pooled sources (#1901). Read
+ *   support for 1 is permanent; nothing writes it any more, so a v2 file does
+ *   not open in an older build.
+ */
+constexpr int kProjectSchemaVersion = 2;
+
+/**
  * @brief Main serialization class for Magda projects
  *
  * Handles serialization/deserialization of complete project state to/from JSON format.
@@ -110,6 +121,32 @@ class ProjectSerializer {
      * @brief Serialize all tracks to JSON array
      */
     static juce::var serializeTracks();
+
+    // ========================================================================
+    // Clip serialization
+    //
+    // Public so the schema-migration tests can drive a single clip directly.
+    // Feeding a hand-built v1 clip through the whole project path would need
+    // the track and clip managers standing up around it, which buys nothing.
+    // ========================================================================
+
+    static juce::var serializeClipInfo(const ClipInfo& clip);
+    static bool deserializeClipInfo(const juce::var& json, ClipInfo& outClip,
+                                    double projectTempo = 120.0);
+
+    /**
+     * @brief Serialize the pooled media sources to a JSON array (#1901).
+     *
+     * Garbage-collects the pool first: only sources a clip still references are
+     * written.
+     */
+    static juce::var serializeSources();
+
+    /**
+     * @brief Restore pooled media sources. Must run before clips, whose events
+     * reference sources by id.
+     */
+    static void deserializeSources(const juce::var& json);
 
     /**
      * @brief Serialize all clips to JSON array
@@ -211,10 +248,6 @@ class ProjectSerializer {
     // ========================================================================
     // Clip serialization helpers
     // ========================================================================
-
-    static juce::var serializeClipInfo(const ClipInfo& clip);
-    static bool deserializeClipInfo(const juce::var& json, ClipInfo& outClip,
-                                    double projectTempo = 120.0);
 
     static juce::var serializeMidiNote(const MidiNote& data);
     static bool deserializeMidiNote(const juce::var& json, MidiNote& data);

--- a/magda/daw/stem_separation/StemSeparationService.cpp
+++ b/magda/daw/stem_separation/StemSeparationService.cpp
@@ -222,7 +222,7 @@ void StemSeparationService::splitClipIntoStems(ClipId sourceClipId, Engine engin
 
     // Snapshot everything we need off the clip now (message thread); the clip
     // pointer must not be touched on the worker.
-    const juce::String filePath = clip->audio().source.filePath;
+    const juce::String filePath = audioEventRef(*clip).sourceFilePath();
     if (!juce::File(filePath).existsAsFile()) {
         report(INVALID_TRACK_ID, "Audio file not found");
         return;
@@ -403,7 +403,8 @@ void StemSeparationService::splitClipIntoStems(ClipId sourceClipId, Engine engin
                                 if (auto* c = manager.getClip(id)) {
                                     c->name = stemName;
                                     auto& a = c->audio();
-                                    a.source.filePath = path;
+                                    if (auto* event = a.primaryEvent())
+                                        event->sourceId = SourcePool::getInstance().acquire(path);
                                     a.takes.clear();
                                     a.currentTakeIndex = 0;
                                     a.comp.clear();

--- a/magda/daw/transcription/TranscriptionService.cpp
+++ b/magda/daw/transcription/TranscriptionService.cpp
@@ -173,13 +173,13 @@ void TranscriptionService::transcribeAudioClip(ClipId sourceClipId, Completion o
 
     // Snapshot everything we need off the clip now (message thread); the clip
     // pointer must not be touched on the worker.
-    const juce::String filePath = clip->audio().source.filePath;
+    const juce::String filePath = audioEventRef(*clip).sourceFilePath();
     const juce::String sourceName = juce::File(filePath).getFileNameWithoutExtension();
     const TrackId sourceTrackId = clip->trackId;
     const ClipView view = clip->view;
     const double startBeat = clip->placement.startBeat;
     const double lengthBeats = clip->placement.lengthBeats;
-    const double offsetSec = clip->offset;
+    const double offsetSec = audioEventRef(*clip).anchorSeconds();
     const double bpm = projectBpm();
 
     // onComplete needs to survive the lambda copy into the pool.

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -72,8 +72,10 @@ double timelineEndSeconds(const ClipInfo& clip, double bpm) {
 void applyLeftResizePreview(ClipInfo& target, const ClipInfo& preview, double bpm) {
     ClipOperations::setTimelinePlacement(target, timelineStartSeconds(preview, bpm),
                                          timelineLengthSeconds(preview, bpm), bpm);
-    target.offset = preview.offset;
-    target.loopStart = preview.loopStart;
+    if (auto* targetEvent = target.primaryEvent()) {
+        targetEvent->sourceAnchorSamples = audioEventRef(preview).sourceAnchorSamples;
+        targetEvent->loopStartSamples = audioEventRef(preview).loopStartSamples;
+    }
     target.midiOffset = preview.midiOffset;
     // resizeContainerFromLeft accumulates the start move here, and the piano
     // roll positions notes through it. Leaving it behind makes the notes drift
@@ -87,8 +89,10 @@ void applyLeftResizePreview(ClipInfo& target, const ClipInfo& preview, double bp
 void restoreLeftResizePreview(ClipInfo& target, const ClipInfo& snapshot, double startSeconds,
                               double lengthSeconds, double bpm) {
     ClipOperations::setTimelinePlacement(target, startSeconds, lengthSeconds, bpm);
-    target.offset = snapshot.offset;
-    target.loopStart = snapshot.loopStart;
+    if (auto* targetEvent = target.primaryEvent()) {
+        targetEvent->sourceAnchorSamples = audioEventRef(snapshot).sourceAnchorSamples;
+        targetEvent->loopStartSamples = audioEventRef(snapshot).loopStartSamples;
+    }
     target.midiOffset = snapshot.midiOffset;
     target.midiTrimOffset = snapshot.midiTrimOffset;
 }
@@ -380,7 +384,8 @@ void ClipComponent::changeListenerCallback(juce::ChangeBroadcaster*) {
     // The thumbnail streamed in more samples. Repaint to fill the waveform
     // progressively, and drop the listener once it has finished loading.
     const auto* clip = getClipInfo();
-    updateWaveformLoadListener(clip != nullptr ? clip->audio().source.filePath : juce::String());
+    updateWaveformLoadListener(clip != nullptr ? magda::audioEventRef(*clip).sourceFilePath()
+                                               : juce::String());
     repaint();
 }
 
@@ -412,20 +417,33 @@ void ClipComponent::paint(juce::Graphics& g) {
 
     const double tempo = parentPanel_ ? parentPanel_->getTempo() : 120.0;
 
-    // Draw loop boundary corner cuts (after header so they cut through everything)
-    double srcLength = clip->loopLength;
-    if (clip->loopEnabled && srcLength > 0.0) {
+    // Draw loop boundary corner cuts (after header so they cut through
+    // everything). The toggle is the clip's; where the loop LENGTH comes from
+    // depends on content: MIDI keeps it in clip beats, audio derives it from
+    // the event's source region.
+    const auto* loopEvent = clip->primaryEvent();
+    const double beatsPerSecondForLoop = tempo / 60.0;
+    double loopCutLengthBeats = 0.0;
+    if (clip->loopEnabled) {
+        if (loopEvent == nullptr) {
+            loopCutLengthBeats = clip->loopLengthBeats;
+        } else if (const double srcLength = loopEvent->loopLengthSeconds(); srcLength > 0.0) {
+            loopCutLengthBeats = (loopEvent->autoTempo && loopEvent->loopLengthBeats() > 0.0)
+                                     ? loopEvent->loopLengthBeats()
+                                     : srcLength / loopEvent->speedRatio * beatsPerSecondForLoop;
+        }
+    }
+
+    if (loopCutLengthBeats > 0.0) {
         auto clipBounds = getLocalBounds();
-        double beatsPerSecond = tempo / 60.0;
+        double beatsPerSecond = beatsPerSecondForLoop;
         // During resize drag, use preview length so boundaries stay fixed
         double displayLength =
             (isDragging_ && previewLength_ > 0.0) ? previewLength_ : clip->getTimelineLength(tempo);
         double clipLengthInBeats = displayLength * beatsPerSecond;
         // Loop length in beats: use authoritative beat value for autoTempo,
         // otherwise derive from source length and speedRatio
-        double loopLengthBeats = (clip->autoTempo && clip->loopLengthBeats > 0.0)
-                                     ? clip->loopLengthBeats
-                                     : srcLength / clip->speedRatio * beatsPerSecond;
+        const double loopLengthBeats = loopCutLengthBeats;
         double beatRange = juce::jmax(1.0, clipLengthInBeats);
         int numBoundaries = static_cast<int>(clipLengthInBeats / loopLengthBeats);
         auto markerColour = juce::Colours::lightgrey;
@@ -532,22 +550,22 @@ void ClipComponent::paint(juce::Graphics& g) {
 size_t ClipComponent::computeWaveformHash(const ClipInfo& clip) {
     size_t h = 0;
     auto combine = [&](size_t v) { h ^= v + 0x9e3779b9 + (h << 6) + (h >> 2); };
-    combine(std::hash<juce::String>{}(clip.audio().source.filePath));
+    combine(std::hash<juce::String>{}(audioEventRef(clip).sourceFilePath()));
     combine(std::hash<double>{}(clip.placement.lengthBeats));
-    combine(std::hash<double>{}(clip.offset));
-    combine(std::hash<double>{}(clip.speedRatio));
+    combine(std::hash<double>{}(audioEventRef(clip).anchorSeconds()));
+    combine(std::hash<double>{}(audioEventRef(clip).speedRatio));
     combine(std::hash<float>{}(clip.volumeDB));
     combine(std::hash<float>{}(clip.gainDB));
-    combine(std::hash<bool>{}(clip.isReversed));
+    combine(std::hash<bool>{}(audioEventRef(clip).reversed));
     combine(std::hash<bool>{}(clip.loopEnabled));
-    combine(std::hash<double>{}(clip.loopStart));
-    combine(std::hash<double>{}(clip.loopLength));
-    combine(std::hash<double>{}(clip.loopLengthBeats));
-    combine(std::hash<double>{}(clip.audio().interpretation.totalBeats));
-    combine(std::hash<bool>{}(clip.warpEnabled));
-    combine(std::hash<bool>{}(clip.autoTempo));
-    combine(std::hash<double>{}(clip.fadeIn));
-    combine(std::hash<double>{}(clip.fadeOut));
+    combine(std::hash<double>{}(audioEventRef(clip).loopStartSeconds()));
+    combine(std::hash<double>{}(audioEventRef(clip).loopLengthSeconds()));
+    combine(std::hash<double>{}(audioEventRef(clip).loopLengthBeats()));
+    combine(std::hash<double>{}(audioEventRef(clip).interpTotalBeats));
+    combine(std::hash<bool>{}(audioEventRef(clip).warpEnabled));
+    combine(std::hash<bool>{}(audioEventRef(clip).autoTempo));
+    combine(std::hash<double>{}(audioEventRef(clip).fadeInSeconds));
+    combine(std::hash<double>{}(audioEventRef(clip).fadeOutSeconds));
     combine(static_cast<size_t>(clip.colour.getARGB()));
     return h;
 }
@@ -576,8 +594,8 @@ void ClipComponent::paintAudioClipDirect(juce::Graphics& g, const ClipInfo& clip
     spec.colour = waveColourOverride.isTransparent() ? juce::Colours::black : waveColourOverride;
     spec.thick = isSelected_ || SelectionManager::getInstance().isClipSelected(clipId_);
     if (isDragging_ && dragMode_ == DragMode::ResizeLeft) {
-        spec.previewOffset = resizePreviewClip_.offset;
-        spec.previewLoopStart = resizePreviewClip_.loopStart;
+        spec.previewOffset = audioEventRef(resizePreviewClip_).anchorSeconds();
+        spec.previewLoopStart = audioEventRef(resizePreviewClip_).loopStartSeconds();
     }
     daw::ui::paintClipWaveform(g, clip, clipId_, waveformArea, clipDisplayLength, spec);
 }
@@ -605,7 +623,7 @@ void ClipComponent::paintAudioClip(juce::Graphics& g, const ClipInfo& clip,
     // change listener is reliable regardless of mouse hover, unlike the old
     // poll timer which only repainted while hovered, so long loads no longer
     // look frozen until they finish.
-    updateWaveformLoadListener(clip.audio().source.filePath);
+    updateWaveformLoadListener(audioEventRef(clip).sourceFilePath());
 
     // Draw directly — no offscreen cache.  AudioThumbnail is already a
     // pre-computed waveform cache (512 samples/point) so drawing from it is fast.
@@ -617,7 +635,7 @@ void ClipComponent::paintAudioClip(juce::Graphics& g, const ClipInfo& clip,
         bgColour = bgColour.withAlpha(0.55f);
     fillClippedRoundedRect(g, bounds, visibleBounds, bgColour, CORNER_RADIUS);
 
-    if (clip.audio().source.filePath.isNotEmpty())
+    if (audioEventRef(clip).sourceFilePath().isNotEmpty())
         paintAudioClipDirect(g, clip, waveformArea, clipDisplayLength,
                              ghosted ? juce::Colours::black.withAlpha(0.65f) : juce::Colour());
 
@@ -637,8 +655,8 @@ void ClipComponent::paintAudioClip(juce::Graphics& g, const ClipInfo& clip,
 
 ClipComponent::EffectiveFades ClipComponent::computeEffectiveFades(const ClipInfo& clip) const {
     EffectiveFades fades;
-    fades.fadeInSeconds = clip.fadeIn;
-    fades.fadeOutSeconds = clip.fadeOut;
+    fades.fadeInSeconds = audioEventRef(clip).fadeInSeconds;
+    fades.fadeOutSeconds = audioEventRef(clip).fadeOutSeconds;
     if (!clip.isAudio() || clip.view != ClipView::Arrangement)
         return fades;
 
@@ -693,11 +711,12 @@ void ClipComponent::paintMidiNotes(juce::Graphics& g, const ClipInfo& clip,
         (isDragging_ && previewLength_ > 0.0) ? previewLength_ : clip.getTimelineLength(tempo);
     double clipLengthInBeats = displayLength * beatsPerSecond;
 
-    double midiSrcLength =
-        clip.loopLength > 0.0 ? clip.loopLength : displayLength * clip.speedRatio;
+    double midiSrcLength = audioEventRef(clip).loopLengthSeconds() > 0.0
+                               ? audioEventRef(clip).loopLengthSeconds()
+                               : displayLength * audioEventRef(clip).speedRatio;
     double loopLengthBeats =
-        clip.loopLengthBeats > 0.0
-            ? clip.loopLengthBeats
+        audioEventRef(clip).loopLengthBeats() > 0.0
+            ? audioEventRef(clip).loopLengthBeats()
             : (midiSrcLength > 0.0 ? midiSrcLength * beatsPerSecond : clipLengthInBeats);
 
     double midiOffset;
@@ -708,7 +727,7 @@ void ClipComponent::paintMidiNotes(juce::Graphics& g, const ClipInfo& clip,
         midiOffset = clip.loopEnabled ? clip.midiOffset : clip.midiTrimOffset;
     }
 
-    double loopStart = clip.loopStart * beatsPerSecond;
+    double loopStart = audioEventRef(clip).loopStartSeconds() * beatsPerSecond;
     double loopEnd = loopStart + loopLengthBeats;
 
     auto noteCanDisplay = [&](const MidiNote& note) {
@@ -876,11 +895,13 @@ void ClipComponent::paintChordClip(juce::Graphics& g, const ClipInfo& clip,
 
         // A looped clip tiles its source chords across the timeline, the same way
         // paintMidiNotes repeats notes.
-        const double srcLength =
-            clip.loopLength > 0.0 ? clip.loopLength : displayLength * clip.speedRatio;
+        const double srcLength = audioEventRef(clip).loopLengthSeconds() > 0.0
+                                     ? audioEventRef(clip).loopLengthSeconds()
+                                     : displayLength * audioEventRef(clip).speedRatio;
         const double loopLengthBeats =
-            clip.loopLengthBeats > 0.0 ? clip.loopLengthBeats
-                                       : (srcLength > 0.0 ? srcLength * beatsPerSecond : beatRange);
+            audioEventRef(clip).loopLengthBeats() > 0.0
+                ? audioEventRef(clip).loopLengthBeats()
+                : (srcLength > 0.0 ? srcLength * beatsPerSecond : beatRange);
 
         if (clip.loopEnabled && loopLengthBeats > 0.5) {
             const int reps = static_cast<int>(std::ceil(beatRange / loopLengthBeats));
@@ -979,7 +1000,7 @@ void ClipComponent::paintClipHeader(juce::Graphics& g, const ClipInfo& clip,
     }
 
     // Musical mode indicator (auto-tempo)
-    if (clip.autoTempo && clip.isAudio() && headerArea.getWidth() > 16) {
+    if (audioEventRef(clip).autoTempo && clip.isAudio() && headerArea.getWidth() > 16) {
         auto musicalArea = headerArea.removeFromRight(14).reduced(2);
         g.setColour(headerForeground);
         g.setFont(FontManager::getInstance().getUIFont(12.0f));
@@ -1071,7 +1092,8 @@ void ClipComponent::paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip,
             // Trace the fade curve from right to left (gain 1→0)
             for (int i = NUM_STEPS; i >= 0; --i) {
                 float alpha = static_cast<float>(i) / static_cast<float>(NUM_STEPS);
-                float gain = computeFadeGain(alpha, static_cast<FadeCurve>(clip.fadeInType));
+                float gain =
+                    computeFadeGain(alpha, static_cast<FadeCurve>(audioEventRef(clip).fadeInType));
                 float x = areaLeft + alpha * fadeInPx;
                 float y = areaTop + (1.0f - gain) * areaHeight;
                 overlay.lineTo(x, y);
@@ -1085,7 +1107,8 @@ void ClipComponent::paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip,
             juce::Path curveLine;
             for (int i = 0; i <= NUM_STEPS; ++i) {
                 float alpha = static_cast<float>(i) / static_cast<float>(NUM_STEPS);
-                float gain = computeFadeGain(alpha, static_cast<FadeCurve>(clip.fadeInType));
+                float gain =
+                    computeFadeGain(alpha, static_cast<FadeCurve>(audioEventRef(clip).fadeInType));
                 float x = areaLeft + alpha * fadeInPx;
                 float y = areaTop + (1.0f - gain) * areaHeight;
                 if (i == 0)
@@ -1099,9 +1122,9 @@ void ClipComponent::paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip,
             // Crossfade: overlay the previous clip's fade-out curve (the X)
             if (fades.xfIn) {
                 auto* other = ClipManager::getInstance().getClip(fades.xfIn->leftClipId);
-                strokeCounterpartCurve(areaLeft, fadeInPx,
-                                       static_cast<FadeCurve>(other ? other->fadeOutType : 1),
-                                       true);
+                strokeCounterpartCurve(
+                    areaLeft, fadeInPx,
+                    static_cast<FadeCurve>(other ? audioEventRef(*other).fadeOutType : 1), true);
             }
         }
     }
@@ -1124,8 +1147,8 @@ void ClipComponent::paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip,
             for (int i = NUM_STEPS; i >= 0; --i) {
                 float alpha = static_cast<float>(i) / static_cast<float>(NUM_STEPS);
                 // alpha=0 at fadeStart (gain=1), alpha=1 at areaRight (gain=0)
-                float gain =
-                    computeFadeGain(1.0f - alpha, static_cast<FadeCurve>(clip.fadeOutType));
+                float gain = computeFadeGain(
+                    1.0f - alpha, static_cast<FadeCurve>(audioEventRef(clip).fadeOutType));
                 float x = fadeStart + alpha * fadeOutPx;
                 float y = areaTop + (1.0f - gain) * areaHeight;
                 overlay.lineTo(x, y);
@@ -1139,8 +1162,8 @@ void ClipComponent::paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip,
             juce::Path curveLine;
             for (int i = 0; i <= NUM_STEPS; ++i) {
                 float alpha = static_cast<float>(i) / static_cast<float>(NUM_STEPS);
-                float gain =
-                    computeFadeGain(1.0f - alpha, static_cast<FadeCurve>(clip.fadeOutType));
+                float gain = computeFadeGain(
+                    1.0f - alpha, static_cast<FadeCurve>(audioEventRef(clip).fadeOutType));
                 float x = fadeStart + alpha * fadeOutPx;
                 float y = areaTop + (1.0f - gain) * areaHeight;
                 if (i == 0)
@@ -1154,9 +1177,9 @@ void ClipComponent::paintFadeOverlays(juce::Graphics& g, const ClipInfo& clip,
             // Crossfade: overlay the next clip's fade-in curve (the X)
             if (fades.xfOut) {
                 auto* other = ClipManager::getInstance().getClip(fades.xfOut->rightClipId);
-                strokeCounterpartCurve(fadeStart, fadeOutPx,
-                                       static_cast<FadeCurve>(other ? other->fadeInType : 1),
-                                       false);
+                strokeCounterpartCurve(
+                    fadeStart, fadeOutPx,
+                    static_cast<FadeCurve>(other ? audioEventRef(*other).fadeInType : 1), false);
             }
         }
     }
@@ -1545,13 +1568,13 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
         dragStartLength_ = clip->getTimelineLength(tempo);
     }
     dragStartTrackId_ = clip->trackId;
-    dragStartAudioOffset_ = clip->offset;
+    dragStartAudioOffset_ = magda::audioEventRef(*clip).anchorSeconds();
 
     // Cache file duration for resize clamping
     dragStartFileDuration_ = 0.0;
-    if (clip->isAudio() && clip->audio().source.filePath.isNotEmpty()) {
-        auto* thumbnail =
-            AudioThumbnailManager::getInstance().getThumbnail(clip->audio().source.filePath);
+    if (clip->isAudio() && magda::audioEventRef(*clip).sourceFilePath().isNotEmpty()) {
+        auto* thumbnail = AudioThumbnailManager::getInstance().getThumbnail(
+            magda::audioEventRef(*clip).sourceFilePath());
         if (thumbnail)
             dragStartFileDuration_ = thumbnail->getTotalLength();
     }
@@ -1566,7 +1589,7 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
     if (isSelected_ && isOnFadeInHandle(e.x, e.y)) {
         if (e.mods.isShiftDown()) {
             // Shift+click: cycle fade-in type (1→2→3→4→1)
-            int newType = (clip->fadeInType % 4) + 1;
+            int newType = (magda::audioEventRef(*clip).fadeInType % 4) + 1;
             UndoManager::getInstance().executeCommand(
                 std::make_unique<SetClipFadeInTypeCommand>(clipId_, newType));
             dragMode_ = DragMode::None;
@@ -1586,7 +1609,7 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
             }
         }
         dragMode_ = DragMode::FadeIn;
-        dragStartFadeIn_ = clip->fadeIn;
+        dragStartFadeIn_ = magda::audioEventRef(*clip).fadeInSeconds;
         dragStartClipSnapshot_ = *clip;
         // Capture selected clips' state for multi-fade
         dragStartSelectedFadeSnapshots_.clear();
@@ -1607,7 +1630,7 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
     if (isSelected_ && isOnFadeOutHandle(e.x, e.y)) {
         if (e.mods.isShiftDown()) {
             // Shift+click: cycle fade-out type (1→2→3→4→1)
-            int newType = (clip->fadeOutType % 4) + 1;
+            int newType = (magda::audioEventRef(*clip).fadeOutType % 4) + 1;
             UndoManager::getInstance().executeCommand(
                 std::make_unique<SetClipFadeOutTypeCommand>(clipId_, newType));
             dragMode_ = DragMode::None;
@@ -1627,7 +1650,7 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
             }
         }
         dragMode_ = DragMode::FadeOut;
-        dragStartFadeOut_ = clip->fadeOut;
+        dragStartFadeOut_ = magda::audioEventRef(*clip).fadeOutSeconds;
         dragStartClipSnapshot_ = *clip;
         // Capture selected clips' state for multi-fade
         dragStartSelectedFadeSnapshots_.clear();
@@ -1671,9 +1694,10 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
     // Shift+edge = stretch mode (time-stretches audio source or scales MIDI notes)
     if (isOnLeftEdge(e.x)) {
         if (e.mods.isShiftDown() &&
-            ((clip->isAudio() && clip->audio().source.filePath.isNotEmpty()) || clip->isMidi())) {
+            ((clip->isAudio() && magda::audioEventRef(*clip).sourceFilePath().isNotEmpty()) ||
+             clip->isMidi())) {
             dragMode_ = DragMode::StretchLeft;
-            dragStartSpeedRatio_ = clip->speedRatio;
+            dragStartSpeedRatio_ = magda::audioEventRef(*clip).speedRatio;
             dragStartClipSnapshot_ = *clip;
         } else {
             dragMode_ = DragMode::ResizeLeft;
@@ -1717,9 +1741,10 @@ void ClipComponent::mouseDown(const juce::MouseEvent& e) {
         }
     } else if (isOnRightEdge(e.x)) {
         if (e.mods.isShiftDown() &&
-            ((clip->isAudio() && clip->audio().source.filePath.isNotEmpty()) || clip->isMidi())) {
+            ((clip->isAudio() && magda::audioEventRef(*clip).sourceFilePath().isNotEmpty()) ||
+             clip->isMidi())) {
             dragMode_ = DragMode::StretchRight;
-            dragStartSpeedRatio_ = clip->speedRatio;
+            dragStartSpeedRatio_ = magda::audioEventRef(*clip).speedRatio;
             dragStartClipSnapshot_ = *clip;
         } else {
             dragMode_ = DragMode::ResizeRight;
@@ -1996,7 +2021,8 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
             resizePreviewClip_ = dragStartClipSnapshot_;
             ClipOperations::resizeContainerFromLeft(resizePreviewClip_, finalLength, tempoBPM);
             if (!resizePreviewClip_.loopEnabled && resizePreviewClip_.isAudio()) {
-                resizePreviewClip_.loopStart = resizePreviewClip_.offset;
+                if (auto* previewEvent = resizePreviewClip_.primaryEvent())
+                    previewEvent->loopStartSamples = previewEvent->sourceAnchorSamples;
             }
 
             // Throttled: sync to TE for waveform/audio playback
@@ -2022,8 +2048,10 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
                         ClipInfo otherPreview = snapshotIt->second;
                         ClipOperations::resizeContainerFromLeft(
                             otherPreview, juce::jmax(0.1, origLen + lengthDelta), tempoBPM);
-                        if (!otherPreview.loopEnabled && otherPreview.isAudio())
-                            otherPreview.loopStart = otherPreview.offset;
+                        if (auto* otherEvent = otherPreview.primaryEvent();
+                            otherEvent != nullptr && !otherPreview.loopEnabled) {
+                            otherEvent->loopStartSamples = otherEvent->sourceAnchorSamples;
+                        }
 
                         applyLeftResizePreview(*otherClip, otherPreview, tempoBPM);
                         changedClips.push_back(cid);
@@ -2168,7 +2196,8 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
                 double newFadeIn = juce::jmax(0.0, fadeInPx / pps);
                 const auto* ci = getClipInfo();
                 double maxFadeIn =
-                    ci ? timelineLengthSeconds(*ci, tempoBPM) - ci->fadeOut : dragStartLength_;
+                    ci ? timelineLengthSeconds(*ci, tempoBPM) - audioEventRef(*ci).fadeOutSeconds
+                       : dragStartLength_;
                 newFadeIn = juce::jmin(newFadeIn, juce::jmax(0.0, maxFadeIn));
                 double fadeDelta = newFadeIn - dragStartFadeIn_;
                 auto& cm = ClipManager::getInstance();
@@ -2177,10 +2206,11 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
                     const auto* c = cm.getClip(cid);
                     if (!c)
                         continue;
-                    double otherFade = juce::jmax(0.0, snap.fadeIn + fadeDelta);
-                    otherFade =
-                        juce::jmin(otherFade, juce::jmax(0.0, timelineLengthSeconds(*c, tempoBPM) -
-                                                                  c->fadeOut));
+                    double otherFade =
+                        juce::jmax(0.0, audioEventRef(snap).fadeInSeconds + fadeDelta);
+                    otherFade = juce::jmin(
+                        otherFade, juce::jmax(0.0, timelineLengthSeconds(*c, tempoBPM) -
+                                                       magda::audioEventRef(*c).fadeOutSeconds));
                     cm.setFadeIn(cid, otherFade);
                 }
                 repaint();
@@ -2198,7 +2228,8 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
                 double newFadeOut = juce::jmax(0.0, fadeOutPx / pps);
                 const auto* ci = getClipInfo();
                 double maxFadeOut =
-                    ci ? timelineLengthSeconds(*ci, tempoBPM) - ci->fadeIn : dragStartLength_;
+                    ci ? timelineLengthSeconds(*ci, tempoBPM) - audioEventRef(*ci).fadeInSeconds
+                       : dragStartLength_;
                 newFadeOut = juce::jmin(newFadeOut, juce::jmax(0.0, maxFadeOut));
                 double fadeDelta = newFadeOut - dragStartFadeOut_;
                 auto& cm = ClipManager::getInstance();
@@ -2207,10 +2238,11 @@ void ClipComponent::mouseDrag(const juce::MouseEvent& e) {
                     const auto* c = cm.getClip(cid);
                     if (!c)
                         continue;
-                    double otherFade = juce::jmax(0.0, snap.fadeOut + fadeDelta);
-                    otherFade =
-                        juce::jmin(otherFade, juce::jmax(0.0, timelineLengthSeconds(*c, tempoBPM) -
-                                                                  c->fadeIn));
+                    double otherFade =
+                        juce::jmax(0.0, audioEventRef(snap).fadeOutSeconds + fadeDelta);
+                    otherFade = juce::jmin(
+                        otherFade, juce::jmax(0.0, timelineLengthSeconds(*c, tempoBPM) -
+                                                       magda::audioEventRef(*c).fadeInSeconds));
                     cm.setFadeOut(cid, otherFade);
                 }
                 repaint();
@@ -2574,20 +2606,21 @@ void ClipComponent::mouseUp(const juce::MouseEvent& e) {
                         double fadeInPx = static_cast<double>(e.x - wfArea.getX());
                         finalFadeIn = juce::jmax(0.0, fadeInPx / pps);
                         const auto* ci = getClipInfo();
-                        double maxFadeIn =
-                            ci ? timelineLengthSeconds(*ci, commitTempoBPM) - ci->fadeOut
-                               : dragStartLength_;
+                        double maxFadeIn = ci ? timelineLengthSeconds(*ci, commitTempoBPM) -
+                                                    audioEventRef(*ci).fadeOutSeconds
+                                              : dragStartLength_;
                         finalFadeIn = juce::jmin(finalFadeIn, juce::jmax(0.0, maxFadeIn));
                     }
                 }
                 {
                     // Restore all clips to pre-drag state for correct undo capture
                     auto& cm = ClipManager::getInstance();
-                    if (auto* c = cm.getClip(clipId_))
-                        c->fadeIn = dragStartClipSnapshot_.fadeIn;
+                    if (auto* e = primaryEventOf(cm.getClip(clipId_)))
+                        e->fadeInSeconds =
+                            magda::audioEventRef(dragStartClipSnapshot_).fadeInSeconds;
                     for (auto& [cid, snap] : dragStartSelectedFadeSnapshots_) {
-                        if (auto* c = cm.getClip(cid))
-                            c->fadeIn = snap.fadeIn;
+                        if (auto* e = primaryEventOf(cm.getClip(cid)))
+                            e->fadeInSeconds = audioEventRef(snap).fadeInSeconds;
                     }
 
                     double fadeDelta = finalFadeIn - dragStartFadeIn_;
@@ -2603,10 +2636,12 @@ void ClipComponent::mouseUp(const juce::MouseEvent& e) {
                         const auto* c = cm.getClip(cid);
                         if (!c)
                             continue;
-                        double otherFade = juce::jmax(0.0, snap.fadeIn + fadeDelta);
+                        double otherFade =
+                            juce::jmax(0.0, audioEventRef(snap).fadeInSeconds + fadeDelta);
                         otherFade = juce::jmin(
-                            otherFade, juce::jmax(0.0, timelineLengthSeconds(*c, commitTempoBPM) -
-                                                           c->fadeOut));
+                            otherFade,
+                            juce::jmax(0.0, timelineLengthSeconds(*c, commitTempoBPM) -
+                                                magda::audioEventRef(*c).fadeOutSeconds));
                         cm.setFadeIn(cid, otherFade);
                         auto otherCmd = std::make_unique<SetFadeCommand>(cid, snap);
                         UndoManager::getInstance().executeCommand(std::move(otherCmd));
@@ -2631,20 +2666,21 @@ void ClipComponent::mouseUp(const juce::MouseEvent& e) {
                         double fadeOutPx = static_cast<double>(wfArea.getRight() - e.x);
                         finalFadeOut = juce::jmax(0.0, fadeOutPx / pps);
                         const auto* ci = getClipInfo();
-                        double maxFadeOut =
-                            ci ? timelineLengthSeconds(*ci, commitTempoBPM) - ci->fadeIn
-                               : dragStartLength_;
+                        double maxFadeOut = ci ? timelineLengthSeconds(*ci, commitTempoBPM) -
+                                                     audioEventRef(*ci).fadeInSeconds
+                                               : dragStartLength_;
                         finalFadeOut = juce::jmin(finalFadeOut, juce::jmax(0.0, maxFadeOut));
                     }
                 }
                 {
                     // Restore all clips to pre-drag state for correct undo capture
                     auto& cm = ClipManager::getInstance();
-                    if (auto* c = cm.getClip(clipId_))
-                        c->fadeOut = dragStartClipSnapshot_.fadeOut;
+                    if (auto* e = primaryEventOf(cm.getClip(clipId_)))
+                        e->fadeOutSeconds =
+                            magda::audioEventRef(dragStartClipSnapshot_).fadeOutSeconds;
                     for (auto& [cid, snap] : dragStartSelectedFadeSnapshots_) {
-                        if (auto* c = cm.getClip(cid))
-                            c->fadeOut = snap.fadeOut;
+                        if (auto* e = primaryEventOf(cm.getClip(cid)))
+                            e->fadeOutSeconds = audioEventRef(snap).fadeOutSeconds;
                     }
 
                     double fadeDelta = finalFadeOut - dragStartFadeOut_;
@@ -2660,10 +2696,11 @@ void ClipComponent::mouseUp(const juce::MouseEvent& e) {
                         const auto* c = cm.getClip(cid);
                         if (!c)
                             continue;
-                        double otherFade = juce::jmax(0.0, snap.fadeOut + fadeDelta);
+                        double otherFade =
+                            juce::jmax(0.0, audioEventRef(snap).fadeOutSeconds + fadeDelta);
                         otherFade = juce::jmin(
-                            otherFade,
-                            juce::jmax(0.0, timelineLengthSeconds(*c, commitTempoBPM) - c->fadeIn));
+                            otherFade, juce::jmax(0.0, timelineLengthSeconds(*c, commitTempoBPM) -
+                                                           magda::audioEventRef(*c).fadeInSeconds));
                         cm.setFadeOut(cid, otherFade);
                         auto otherCmd = std::make_unique<SetFadeCommand>(cid, snap);
                         UndoManager::getInstance().executeCommand(std::move(otherCmd));
@@ -3204,7 +3241,7 @@ void ClipComponent::showContextMenu() {
         auto* bridge = audioEngine ? audioEngine->getAudioBridge() : nullptr;
 
         auto hasWarpMarkers = [&](const ClipInfo* c, ClipId id) {
-            return c && c->isAudio() && c->warpEnabled && bridge &&
+            return c && c->isAudio() && magda::audioEventRef(*c).warpEnabled && bridge &&
                    bridge->getWarpMarkers(id).size() > 2;
         };
 
@@ -3258,8 +3295,9 @@ void ClipComponent::showContextMenu() {
         bool canEditExternally = false;
         if (!isMultiSelection && canEdit) {
             const auto* singleClip = getClipInfo();
-            canEditExternally = singleClip && singleClip->isAudio() &&
-                                juce::File(singleClip->audio().source.filePath).existsAsFile();
+            canEditExternally =
+                singleClip && singleClip->isAudio() &&
+                juce::File(magda::audioEventRef(*singleClip).sourceFilePath()).existsAsFile();
         }
         menu.addItem(21, "Edit in External Editor", canEditExternally);
 
@@ -3267,9 +3305,10 @@ void ClipComponent::showContextMenu() {
         bool canTranscribe = false;
         if (!isMultiSelection && canEdit) {
             const auto* singleClip = getClipInfo();
-            canTranscribe = singleClip && singleClip->isAudio() &&
-                            juce::File(singleClip->audio().source.filePath).existsAsFile() &&
-                            magda::transcription::TranscriptionService::getInstance().isAvailable();
+            canTranscribe =
+                singleClip && singleClip->isAudio() &&
+                juce::File(magda::audioEventRef(*singleClip).sourceFilePath()).existsAsFile() &&
+                magda::transcription::TranscriptionService::getInstance().isAvailable();
         }
         menu.addItem(22, "Transcribe to MIDI", canTranscribe);
 
@@ -3278,8 +3317,9 @@ void ClipComponent::showContextMenu() {
             bool canSplit = false;
             if (!isMultiSelection && canEdit) {
                 const auto* singleClip = getClipInfo();
-                canSplit = singleClip && singleClip->isAudio() &&
-                           juce::File(singleClip->audio().source.filePath).existsAsFile();
+                canSplit =
+                    singleClip && singleClip->isAudio() &&
+                    juce::File(magda::audioEventRef(*singleClip).sourceFilePath()).existsAsFile();
             }
             auto& stemService = magda::stems::StemSeparationService::getInstance();
             juce::PopupMenu stemMenu;
@@ -3559,7 +3599,7 @@ void ClipComponent::showContextMenu() {
             if (c && c->isAudio() && takeIndex >= 0 &&
                 takeIndex < static_cast<int>(c->audio().takes.size())) {
                 c->audio().currentTakeIndex = takeIndex;
-                c->audio().source.filePath = c->audio().takes[takeIndex].filePath;
+                magda::audioEventRef(*c).sourceFilePath() = c->audio().takes[takeIndex].filePath;
                 clipManager.forceNotifyClipPropertyChanged(clipId_);
             }
             return;
@@ -3724,7 +3764,8 @@ void ClipComponent::showContextMenu() {
 
             case 28: {  // Flatten MIDI Loop (#1737)
                 const auto* clip = clipManager.getClip(clipId_);
-                if (clip && clip->isMidi() && clip->loopEnabled && clip->loopLengthBeats > 0.0) {
+                if (clip && clip->isMidi() && clip->loopEnabled &&
+                    magda::audioEventRef(*clip).loopLengthBeats() > 0.0) {
                     UndoManager::getInstance().executeCommand(
                         std::make_unique<FlattenMidiClipCommand>(clipId_));
                 }

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -560,7 +560,8 @@ size_t ClipComponent::computeWaveformHash(const ClipInfo& clip) {
     combine(std::hash<bool>{}(clip.loopEnabled));
     combine(std::hash<double>{}(audioEventRef(clip).loopStartSeconds()));
     combine(std::hash<double>{}(audioEventRef(clip).loopLengthSeconds()));
-    combine(std::hash<double>{}(clip.loopLengthInBeats()));
+    combine(std::hash<double>{}(clip.loopLengthBeats));
+    combine(std::hash<long long>{}(audioEventRef(clip).loopLengthSamples));
     combine(std::hash<double>{}(audioEventRef(clip).interpTotalBeats));
     combine(std::hash<bool>{}(audioEventRef(clip).warpEnabled));
     combine(std::hash<bool>{}(audioEventRef(clip).autoTempo));
@@ -3754,8 +3755,7 @@ void ClipComponent::showContextMenu() {
 
             case 28: {  // Flatten MIDI Loop (#1737)
                 const auto* clip = clipManager.getClip(clipId_);
-                if (clip && clip->isMidi() && clip->loopEnabled &&
-                    clip->loopLengthInBeats() > 0.0) {
+                if (clip && clip->isMidi() && clip->loopEnabled && clip->loopLengthBeats > 0.0) {
                     UndoManager::getInstance().executeCommand(
                         std::make_unique<FlattenMidiClipCommand>(clipId_));
                 }

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -560,7 +560,7 @@ size_t ClipComponent::computeWaveformHash(const ClipInfo& clip) {
     combine(std::hash<bool>{}(clip.loopEnabled));
     combine(std::hash<double>{}(audioEventRef(clip).loopStartSeconds()));
     combine(std::hash<double>{}(audioEventRef(clip).loopLengthSeconds()));
-    combine(std::hash<double>{}(audioEventRef(clip).loopLengthBeats()));
+    combine(std::hash<double>{}(clip.loopLengthInBeats()));
     combine(std::hash<double>{}(audioEventRef(clip).interpTotalBeats));
     combine(std::hash<bool>{}(audioEventRef(clip).warpEnabled));
     combine(std::hash<bool>{}(audioEventRef(clip).autoTempo));
@@ -711,13 +711,9 @@ void ClipComponent::paintMidiNotes(juce::Graphics& g, const ClipInfo& clip,
         (isDragging_ && previewLength_ > 0.0) ? previewLength_ : clip.getTimelineLength(tempo);
     double clipLengthInBeats = displayLength * beatsPerSecond;
 
-    double midiSrcLength = audioEventRef(clip).loopLengthSeconds() > 0.0
-                               ? audioEventRef(clip).loopLengthSeconds()
-                               : displayLength * audioEventRef(clip).speedRatio;
-    double loopLengthBeats =
-        audioEventRef(clip).loopLengthBeats() > 0.0
-            ? audioEventRef(clip).loopLengthBeats()
-            : (midiSrcLength > 0.0 ? midiSrcLength * beatsPerSecond : clipLengthInBeats);
+    // MIDI loops in clip beats on the container. There is no audio event here
+    // and no source region to consult.
+    double loopLengthBeats = clip.loopLengthBeats > 0.0 ? clip.loopLengthBeats : clipLengthInBeats;
 
     double midiOffset;
     if (isDragging_ && dragMode_ == DragMode::ResizeLeft) {
@@ -727,7 +723,7 @@ void ClipComponent::paintMidiNotes(juce::Graphics& g, const ClipInfo& clip,
         midiOffset = clip.loopEnabled ? clip.midiOffset : clip.midiTrimOffset;
     }
 
-    double loopStart = audioEventRef(clip).loopStartSeconds() * beatsPerSecond;
+    double loopStart = clip.loopStartBeats;
     double loopEnd = loopStart + loopLengthBeats;
 
     auto noteCanDisplay = [&](const MidiNote& note) {
@@ -895,13 +891,9 @@ void ClipComponent::paintChordClip(juce::Graphics& g, const ClipInfo& clip,
 
         // A looped clip tiles its source chords across the timeline, the same way
         // paintMidiNotes repeats notes.
-        const double srcLength = audioEventRef(clip).loopLengthSeconds() > 0.0
-                                     ? audioEventRef(clip).loopLengthSeconds()
-                                     : displayLength * audioEventRef(clip).speedRatio;
+        // Chords annotate MIDI, so the loop is clip beats on the container.
         const double loopLengthBeats =
-            audioEventRef(clip).loopLengthBeats() > 0.0
-                ? audioEventRef(clip).loopLengthBeats()
-                : (srcLength > 0.0 ? srcLength * beatsPerSecond : beatRange);
+            clip.loopLengthBeats > 0.0 ? clip.loopLengthBeats : beatRange;
 
         if (clip.loopEnabled && loopLengthBeats > 0.5) {
             const int reps = static_cast<int>(std::ceil(beatRange / loopLengthBeats));
@@ -3765,7 +3757,7 @@ void ClipComponent::showContextMenu() {
             case 28: {  // Flatten MIDI Loop (#1737)
                 const auto* clip = clipManager.getClip(clipId_);
                 if (clip && clip->isMidi() && clip->loopEnabled &&
-                    magda::audioEventRef(*clip).loopLengthBeats() > 0.0) {
+                    clip->loopLengthInBeats() > 0.0) {
                     UndoManager::getInstance().executeCommand(
                         std::make_unique<FlattenMidiClipCommand>(clipId_));
                 }

--- a/magda/daw/ui/components/clips/ClipComponent.cpp
+++ b/magda/daw/ui/components/clips/ClipComponent.cpp
@@ -3590,9 +3590,7 @@ void ClipComponent::showContextMenu() {
             auto* c = clipManager.getClip(clipId_);
             if (c && c->isAudio() && takeIndex >= 0 &&
                 takeIndex < static_cast<int>(c->audio().takes.size())) {
-                c->audio().currentTakeIndex = takeIndex;
-                magda::audioEventRef(*c).sourceFilePath() = c->audio().takes[takeIndex].filePath;
-                clipManager.forceNotifyClipPropertyChanged(clipId_);
+                clipManager.setAudioClipCurrentTake(clipId_, takeIndex);
             }
             return;
         }

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -39,18 +39,16 @@ double timelineEndBeats(const ClipInfo& clip, double bpm) {
     return clip.getEndBeats(bpm);
 }
 
-// The piano roll only ever edits MIDI, so both of these read the clip's own
-// loop in clip beats. The audio event's loop is a region of a source file and
-// has nothing to say about a note grid.
-double effectiveLoopStartBeats(const ClipInfo& clip, double) {
-    return clip.loopStartBeats > 0.0 ? clip.loopStartBeats : 0.0;
+// Audio clips reach this grid too (PianoRollContent and DrumGridClipContent
+// both route them here), so the loop has to come back in timeline beats for
+// either content type rather than off one domain's field.
+double effectiveLoopStartBeats(const ClipInfo& clip, double bpm) {
+    return juce::jmax(0.0, clip.loopStartInBeats(bpm));
 }
 
 double effectiveLoopLengthBeats(const ClipInfo& clip, double bpm) {
-    if (clip.loopLengthBeats > 0.0)
-        return clip.loopLengthBeats;
-
-    return timelineLengthBeats(clip, bpm);
+    const double loopBeats = clip.loopLengthInBeats(bpm);
+    return loopBeats > 0.0 ? loopBeats : timelineLengthBeats(clip, bpm);
 }
 
 // Grid clicks use the same relative-loop contract as the ruler: display beat is

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -40,21 +40,21 @@ double timelineEndBeats(const ClipInfo& clip, double bpm) {
 }
 
 double effectiveLoopStartBeats(const ClipInfo& clip, double bpm) {
-    if (clip.loopStartBeats > 0.0)
-        return clip.loopStartBeats;
+    if (audioEventRef(clip).loopStartBeats() > 0.0)
+        return audioEventRef(clip).loopStartBeats();
 
-    if (clip.loopStart > 0.0 && bpm > 0.0)
-        return clip.loopStart * bpm / 60.0;
+    if (audioEventRef(clip).loopStartSeconds() > 0.0 && bpm > 0.0)
+        return audioEventRef(clip).loopStartSeconds() * bpm / 60.0;
 
     return 0.0;
 }
 
 double effectiveLoopLengthBeats(const ClipInfo& clip, double bpm) {
-    if (clip.loopLengthBeats > 0.0)
-        return clip.loopLengthBeats;
+    if (audioEventRef(clip).loopLengthBeats() > 0.0)
+        return audioEventRef(clip).loopLengthBeats();
 
-    if (clip.loopLength > 0.0 && bpm > 0.0)
-        return clip.loopLength * bpm / 60.0;
+    if (audioEventRef(clip).loopLengthSeconds() > 0.0 && bpm > 0.0)
+        return audioEventRef(clip).loopLengthSeconds() * bpm / 60.0;
 
     return timelineLengthBeats(clip, bpm);
 }

--- a/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
+++ b/magda/daw/ui/components/pianoroll/PianoRollGridComponent.cpp
@@ -39,22 +39,16 @@ double timelineEndBeats(const ClipInfo& clip, double bpm) {
     return clip.getEndBeats(bpm);
 }
 
-double effectiveLoopStartBeats(const ClipInfo& clip, double bpm) {
-    if (audioEventRef(clip).loopStartBeats() > 0.0)
-        return audioEventRef(clip).loopStartBeats();
-
-    if (audioEventRef(clip).loopStartSeconds() > 0.0 && bpm > 0.0)
-        return audioEventRef(clip).loopStartSeconds() * bpm / 60.0;
-
-    return 0.0;
+// The piano roll only ever edits MIDI, so both of these read the clip's own
+// loop in clip beats. The audio event's loop is a region of a source file and
+// has nothing to say about a note grid.
+double effectiveLoopStartBeats(const ClipInfo& clip, double) {
+    return clip.loopStartBeats > 0.0 ? clip.loopStartBeats : 0.0;
 }
 
 double effectiveLoopLengthBeats(const ClipInfo& clip, double bpm) {
-    if (audioEventRef(clip).loopLengthBeats() > 0.0)
-        return audioEventRef(clip).loopLengthBeats();
-
-    if (audioEventRef(clip).loopLengthSeconds() > 0.0 && bpm > 0.0)
-        return audioEventRef(clip).loopLengthSeconds() * bpm / 60.0;
+    if (clip.loopLengthBeats > 0.0)
+        return clip.loopLengthBeats;
 
     return timelineLengthBeats(clip, bpm);
 }

--- a/magda/daw/ui/components/waveform/ClipWaveformPainter.cpp
+++ b/magda/daw/ui/components/waveform/ClipWaveformPainter.cpp
@@ -54,7 +54,7 @@ void paintClipWaveform(juce::Graphics& g, const ClipInfo& clip, ClipId clipId,
         return rect.getWidth() > 0;
     };
 
-    if (clip.isReversed) {
+    if (audioEventRef(clip).reversed) {
         g.saveState();
         g.addTransform(juce::AffineTransform::scale(-1.0f, 1.0f, waveformArea.getCentreX(),
                                                     waveformArea.getCentreY()));
@@ -63,7 +63,7 @@ void paintClipWaveform(juce::Graphics& g, const ClipInfo& clip, ClipId clipId,
     const double tempo = spec.tempo;
 
     double fileDuration = 0.0;
-    auto* thumbnail = thumbnailManager.getThumbnail(clip.audio().source.filePath);
+    auto* thumbnail = thumbnailManager.getThumbnail(audioEventRef(clip).sourceFilePath());
     if (thumbnail)
         fileDuration = thumbnail->getTotalLength();
 
@@ -74,7 +74,7 @@ void paintClipWaveform(juce::Graphics& g, const ClipInfo& clip, ClipId clipId,
     // potentially extending past the file.
     auto di = ClipDisplayInfo::from(clip, tempo, fileDuration);
 
-    const double displayOffset = spec.previewOffset.value_or(clip.offset);
+    const double displayOffset = spec.previewOffset.value_or(audioEventRef(clip).anchorSeconds());
 
     const bool thick = spec.thick;
     const auto waveColour = spec.colour;
@@ -82,7 +82,7 @@ void paintClipWaveform(juce::Graphics& g, const ClipInfo& clip, ClipId clipId,
 
     bool useWarpedDraw = false;
     std::vector<WarpMarkerInfo> warpMarkers;
-    if (clip.warpEnabled) {
+    if (audioEventRef(clip).warpEnabled) {
         auto* audioEngine = TrackManager::getInstance().getAudioEngine();
         if (audioEngine) {
             auto* bridge = audioEngine->getAudioBridge();
@@ -125,10 +125,10 @@ void paintClipWaveform(juce::Graphics& g, const ClipInfo& clip, ClipId clipId,
         wspec.thick = thick;
         wspec.looped = di.isLooped();
         wspec.cycleWarp = maxWarp - minWarp;
-        daw::ui::drawWarpedWaveform(g, thumbnailManager, clip.audio().source.filePath, warpMarkers,
-                                    wspec);
+        daw::ui::drawWarpedWaveform(g, thumbnailManager, audioEventRef(clip).sourceFilePath(),
+                                    warpMarkers, wspec);
     } else if (di.isLooped()) {
-        double sourceDurationForBeats = clip.audio().source.durationSeconds;
+        double sourceDurationForBeats = audioEventRef(clip).sourceDurationSeconds();
         if (sourceDurationForBeats <= 0.0 && fileDuration > 0.0)
             sourceDurationForBeats = fileDuration;
         if (sourceDurationForBeats <= 0.0)
@@ -136,28 +136,27 @@ void paintClipWaveform(juce::Graphics& g, const ClipInfo& clip, ClipId clipId,
         const double projectBpm = isValidBpm(tempo) ? tempo : DEFAULT_BPM;
 
         auto timelineDeltaToPreviewSource = [&](double timelineDelta) {
-            if (clip.autoTempo && clip.audio().interpretation.totalBeats > 0.0 &&
+            if (audioEventRef(clip).autoTempo && audioEventRef(clip).interpTotalBeats > 0.0 &&
                 sourceDurationForBeats > 0.0) {
                 double projectBeats = timelineDelta * projectBpm / 60.0;
-                return projectBeats * sourceDurationForBeats /
-                       clip.audio().interpretation.totalBeats;
+                return projectBeats * sourceDurationForBeats / audioEventRef(clip).interpTotalBeats;
             }
             return di.timelineToSource(timelineDelta);
         };
 
         auto sourceDeltaToPreviewTimeline = [&](double sourceDelta) {
-            if (clip.autoTempo && clip.audio().interpretation.totalBeats > 0.0 &&
+            if (audioEventRef(clip).autoTempo && audioEventRef(clip).interpTotalBeats > 0.0 &&
                 sourceDurationForBeats > 0.0) {
                 double sourceBeats =
-                    sourceDelta * clip.audio().interpretation.totalBeats / sourceDurationForBeats;
+                    sourceDelta * audioEventRef(clip).interpTotalBeats / sourceDurationForBeats;
                 return sourceBeats * 60.0 / projectBpm;
             }
             return di.sourceToTimeline(sourceDelta);
         };
 
         double loopCycle = di.loopLengthSeconds;
-        if (clip.autoTempo && clip.loopLengthBeats > 0.0)
-            loopCycle = clip.loopLengthBeats * 60.0 / projectBpm;
+        if (audioEventRef(clip).autoTempo && audioEventRef(clip).loopLengthBeats() > 0.0)
+            loopCycle = audioEventRef(clip).loopLengthBeats() * 60.0 / projectBpm;
         // These were named "fileStart/End" but actually hold the loop
         // region's bounds (in source-time). Renamed to match what they
         // really are; per-tile rendering reads from this loop subset, not
@@ -223,9 +222,9 @@ void paintClipWaveform(juce::Graphics& g, const ClipInfo& clip, ClipId clipId,
                     segmentSourceStart + timelineDeltaToPreviewSource(segmentDuration);
                 segmentSourceEnd = juce::jmin(segmentSourceEnd, loopRegionEnd);
                 if (clipToVisible(segmentRect, segmentSourceStart, segmentSourceEnd))
-                    thumbnailManager.drawWaveform(g, segmentRect, clip.audio().source.filePath,
-                                                  segmentSourceStart, segmentSourceEnd, waveColour,
-                                                  gainLinear, true, thick);
+                    thumbnailManager.drawWaveform(
+                        g, segmentRect, audioEventRef(clip).sourceFilePath(), segmentSourceStart,
+                        segmentSourceEnd, waveColour, gainLinear, true, thick);
 
                 segmentTime = segmentEnd;
                 remainingTileDuration -= segmentDuration;
@@ -247,11 +246,11 @@ void paintClipWaveform(juce::Graphics& g, const ClipInfo& clip, ClipId clipId,
         auto drawRect = juce::Rectangle<int>(waveformArea.getX(), waveformArea.getY(), drawWidth,
                                              waveformArea.getHeight());
         if (clipToVisible(drawRect, fileStart, fileEnd))
-            thumbnailManager.drawWaveform(g, drawRect, clip.audio().source.filePath, fileStart,
-                                          fileEnd, waveColour, gainLinear, true, thick);
+            thumbnailManager.drawWaveform(g, drawRect, audioEventRef(clip).sourceFilePath(),
+                                          fileStart, fileEnd, waveColour, gainLinear, true, thick);
     }
 
-    if (clip.isReversed)
+    if (audioEventRef(clip).reversed)
         g.restoreState();
 }
 

--- a/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
+++ b/magda/daw/ui/components/waveform/WaveformGridComponent.cpp
@@ -65,7 +65,8 @@ void WaveformGridComponent::updateWaveformLoadListener(const juce::String& audio
 
 void WaveformGridComponent::changeListenerCallback(juce::ChangeBroadcaster*) {
     const auto* clip = getClip();
-    updateWaveformLoadListener(clip != nullptr ? clip->audio().source.filePath : juce::String());
+    updateWaveformLoadListener(clip != nullptr ? magda::audioEventRef(*clip).sourceFilePath()
+                                               : juce::String());
     repaint();
 }
 
@@ -112,7 +113,7 @@ void WaveformGridComponent::paint(juce::Graphics& g) {
 }
 
 void WaveformGridComponent::paintWaveform(juce::Graphics& g, const magda::ClipInfo& clip) {
-    if (clip.audio().source.filePath.isEmpty())
+    if (audioEventRef(clip).sourceFilePath().isEmpty())
         return;
 
     auto layout = computeWaveformLayout(clip);
@@ -210,8 +211,8 @@ void WaveformGridComponent::paintWaveformThumbnail(juce::Graphics& g, const magd
 
     auto& thumbnailManager = magda::AudioThumbnailManager::getInstance();
     // Repaint as the thumbnail streams in (progressive fill while loading).
-    updateWaveformLoadListener(clip.audio().source.filePath);
-    auto* thumbnail = thumbnailManager.getThumbnail(clip.audio().source.filePath);
+    updateWaveformLoadListener(audioEventRef(clip).sourceFilePath());
+    auto* thumbnail = thumbnailManager.getThumbnail(audioEventRef(clip).sourceFilePath());
     double fileDuration = thumbnail ? thumbnail->getTotalLength() : 0.0;
     // The waveform editor only ever shows the focused clip, so the waveform is
     // always rendered as if "selected" — black, to match arrangement-view styling.
@@ -262,15 +263,16 @@ void WaveformGridComponent::paintWaveformThumbnail(juce::Graphics& g, const magd
                     tEnd = juce::jlimit(displayStart, displayEnd, tEnd);
                     // The editor ruler always describes the original source
                     // file, so draw the full file forward first.
-                    thumbnailManager.drawWaveform(g, drawRect, clip.audio().source.filePath, tStart,
-                                                  tEnd, waveColour, vertZoom, useHighRes);
+                    thumbnailManager.drawWaveform(g, drawRect, audioEventRef(clip).sourceFilePath(),
+                                                  tStart, tEnd, waveColour, vertZoom, useHighRes);
 
                     // Reverse is a clip-region operation, not a whole-file
                     // display transform. Redraw only the selected span in
                     // reverse, leaving its ruler position and surrounding
                     // source waveform unchanged.
-                    if (clip.isReversed && displayInfo_.activeRegionEndPositionSeconds >
-                                               displayInfo_.activeRegionStartPositionSeconds) {
+                    if (audioEventRef(clip).reversed &&
+                        displayInfo_.activeRegionEndPositionSeconds >
+                            displayInfo_.activeRegionStartPositionSeconds) {
                         const int activeLeft =
                             audioLeft +
                             static_cast<int>(std::round(
@@ -302,9 +304,10 @@ void WaveformGridComponent::paintWaveformThumbnail(juce::Graphics& g, const magd
                             g.addTransform(juce::AffineTransform::scale(
                                 -1.0f, 1.0f, activeDrawRect.getCentreX(),
                                 activeDrawRect.getCentreY()));
-                            thumbnailManager.drawWaveform(
-                                g, activeDrawRect, clip.audio().source.filePath, sourceRange.first,
-                                sourceRange.second, waveColour, vertZoom, useHighRes);
+                            thumbnailManager.drawWaveform(g, activeDrawRect,
+                                                          audioEventRef(clip).sourceFilePath(),
+                                                          sourceRange.first, sourceRange.second,
+                                                          waveColour, vertZoom, useHighRes);
                             g.restoreState();
                         }
                     }
@@ -355,8 +358,9 @@ void WaveformGridComponent::paintWaveformThumbnail(juce::Graphics& g, const magd
                 visFileEnd = juce::jmin(visFileEnd, fileDuration);
             // Draw dimmer to indicate it's outside the loop
             auto dimColour = waveColour.withAlpha(0.4f);
-            thumbnailManager.drawWaveform(g, drawRect, clip.audio().source.filePath, visFileStart,
-                                          visFileEnd, dimColour, vertZoom, useHighRes);
+            thumbnailManager.drawWaveform(g, drawRect, audioEventRef(clip).sourceFilePath(),
+                                          visFileStart, visFileEnd, dimColour, vertZoom,
+                                          useHighRes);
         }
     }
 }
@@ -379,7 +383,7 @@ void WaveformGridComponent::paintTakeLanes(juce::Graphics& g, const magda::ClipI
         return;
 
     auto& thumbnailManager = magda::AudioThumbnailManager::getInstance();
-    updateWaveformLoadListener(clip.audio().source.filePath);
+    updateWaveformLoadListener(audioEventRef(clip).sourceFilePath());
     const bool useHighRes = !interactionActive_;
     const float gainLinear = juce::Decibels::decibelsToGain(clip.volumeDB + clip.gainDB);
     const auto vertZoom = static_cast<float>(verticalZoom_) * gainLinear;
@@ -508,8 +512,8 @@ void WaveformGridComponent::paintWaveformOverlays(juce::Graphics& g, const magda
     // Clip info overlay — show file name on the waveform
     g.setColour(clip.colour);
     g.setFont(FontManager::getInstance().getUIFont(12.0f));
-    juce::String displayName = clip.audio().source.filePath.isNotEmpty()
-                                   ? juce::File(clip.audio().source.filePath).getFileName()
+    juce::String displayName = audioEventRef(clip).sourceFilePath().isNotEmpty()
+                                   ? juce::File(audioEventRef(clip).sourceFilePath()).getFileName()
                                    : clip.name;
     g.drawText(displayName, visibleRect.reduced(8, 4), juce::Justification::topLeft, true);
 
@@ -651,7 +655,7 @@ void WaveformGridComponent::paintWarpedWaveform(juce::Graphics& g, const magda::
     // single pass, no loop tiling. The full source remains forward on the
     // editor ruler; a reversed clip redraws only its active span mirrored.
     auto& thumbnailManager = magda::AudioThumbnailManager::getInstance();
-    auto* thumbnail = thumbnailManager.getThumbnail(clip.audio().source.filePath);
+    auto* thumbnail = thumbnailManager.getThumbnail(audioEventRef(clip).sourceFilePath());
     const double fileDuration = thumbnail ? thumbnail->getTotalLength() : 0.0;
     const double displayStartTime = getDisplayStartTime();
 
@@ -665,10 +669,11 @@ void WaveformGridComponent::paintWarpedWaveform(juce::Graphics& g, const magda::
     spec.verticalScale = vertZoom;
     spec.useHighRes = true;
     spec.looped = false;  // source-domain view: one pass, arrangement handles tiling
-    drawWarpedWaveform(g, thumbnailManager, clip.audio().source.filePath, warpMarkers_, spec);
+    drawWarpedWaveform(g, thumbnailManager, audioEventRef(clip).sourceFilePath(), warpMarkers_,
+                       spec);
 
-    if (clip.isReversed && displayInfo_.activeRegionEndPositionSeconds >
-                               displayInfo_.activeRegionStartPositionSeconds) {
+    if (audioEventRef(clip).reversed && displayInfo_.activeRegionEndPositionSeconds >
+                                            displayInfo_.activeRegionStartPositionSeconds) {
         const int activeLeft =
             timeToPixel(displayStartTime + displayInfo_.activeRegionStartPositionSeconds);
         const int activeRight =
@@ -684,7 +689,8 @@ void WaveformGridComponent::paintWarpedWaveform(juce::Graphics& g, const magda::
                                             forwardPosition;
             return (double)timeToPixel(displayStartTime + mirroredPosition);
         };
-        drawWarpedWaveform(g, thumbnailManager, clip.audio().source.filePath, warpMarkers_, spec);
+        drawWarpedWaveform(g, thumbnailManager, audioEventRef(clip).sourceFilePath(), warpMarkers_,
+                           spec);
     }
 }
 
@@ -696,7 +702,8 @@ void WaveformGridComponent::paintClipBoundaries(juce::Graphics& g) {
     auto bounds = getLocalBounds();
     bool isLooped = displayInfo_.isLooped();
     const auto* clip = getClip();
-    const bool canResizeClipEnd = clip && !clip->loopEnabled && !clip->autoTempo;
+    const bool canResizeClipEnd =
+        clip && !clip->loopEnabled && !magda::audioEventRef(*clip).autoTempo;
 
     double baseTime = getDisplayStartTime();
     const double sampleStart = getSampleStartPositionSeconds();
@@ -1162,7 +1169,7 @@ void WaveformGridComponent::mouseDown(const juce::MouseEvent& event) {
     }
 
     auto* clip = magda::ClipManager::getInstance().getClip(editingClipId_);
-    if (!clip || !clip->isAudio() || clip->audio().source.filePath.isEmpty()) {
+    if (!clip || !clip->isAudio() || magda::audioEventRef(*clip).sourceFilePath().isEmpty()) {
         return;
     }
 
@@ -1299,7 +1306,7 @@ void WaveformGridComponent::mouseDown(const juce::MouseEvent& event) {
         dragMode_ = DragMode::PhaseMarker;
     } else if (nearLeftEdge) {
         dragMode_ = shiftHeld ? DragMode::StretchLeft : DragMode::ResizeLeft;
-    } else if (nearRightEdge && !clip->loopEnabled && !clip->autoTempo) {
+    } else if (nearRightEdge && !clip->loopEnabled && !magda::audioEventRef(*clip).autoTempo) {
         dragMode_ = DragMode::ResizeRight;
     } else if (nearRightEdge && shiftHeld) {
         dragMode_ = DragMode::StretchRight;
@@ -1318,17 +1325,20 @@ void WaveformGridComponent::mouseDown(const juce::MouseEvent& event) {
     }
 
     dragStartX_ = x;
-    dragStartAudioOffset_ = clip->loopEnabled ? clip->loopStart : clip->offset;
+    dragStartAudioOffset_ = clip->loopEnabled ? magda::audioEventRef(*clip).loopStartSeconds()
+                                              : magda::audioEventRef(*clip).anchorSeconds();
     const double projectBpm = currentTimelineBpm();
     dragStartStartTime_ = facadeTimelineStart(*clip, projectBpm);
-    dragStartSpeedRatio_ = clip->speedRatio;
+    dragStartSpeedRatio_ = magda::audioEventRef(*clip).speedRatio;
     dragStartClipLength_ = facadeTimelineLength(*clip, projectBpm);
 
     if (dragMode_ == DragMode::PhaseMarker) {
-        double phase = clip->offset - clip->loopStart;
-        if (clip->loopLength > 0.0) {
-            phase =
-                std::fmod(std::fmod(phase, clip->loopLength) + clip->loopLength, clip->loopLength);
+        double phase = magda::audioEventRef(*clip).anchorSeconds() -
+                       magda::audioEventRef(*clip).loopStartSeconds();
+        if (magda::audioEventRef(*clip).loopLengthSeconds() > 0.0) {
+            phase = std::fmod(std::fmod(phase, magda::audioEventRef(*clip).loopLengthSeconds()) +
+                                  magda::audioEventRef(*clip).loopLengthSeconds(),
+                              magda::audioEventRef(*clip).loopLengthSeconds());
         } else {
             phase = juce::jmax(0.0, phase);
         }
@@ -1345,8 +1355,8 @@ void WaveformGridComponent::mouseDown(const juce::MouseEvent& event) {
 
     // Cache file duration for trim clamping
     dragStartFileDuration_ = 0.0;
-    auto* thumbnail =
-        magda::AudioThumbnailManager::getInstance().getThumbnail(clip->audio().source.filePath);
+    auto* thumbnail = magda::AudioThumbnailManager::getInstance().getThumbnail(
+        magda::audioEventRef(*clip).sourceFilePath());
     if (thumbnail) {
         dragStartFileDuration_ = thumbnail->getTotalLength();
     }
@@ -1438,7 +1448,7 @@ void WaveformGridComponent::mouseDrag(const juce::MouseEvent& event) {
 
     // Get clip for direct modification during drag (performance optimization)
     auto* clip = magda::ClipManager::getInstance().getClip(editingClipId_);
-    if (!clip || clip->audio().source.filePath.isEmpty())
+    if (!clip || magda::audioEventRef(*clip).sourceFilePath().isEmpty())
         return;
 
     double deltaSeconds = (event.x - dragStartX_) / horizontalZoom_;
@@ -1479,9 +1489,11 @@ void WaveformGridComponent::mouseDrag(const juce::MouseEvent& event) {
             double timelineDelta = (event.x - dragStartX_) / horizontalZoom_;
             double sourceDelta = displayInfo_.timelineToSource(timelineDelta);
             double newPhase = dragStartLoopOffset_ + sourceDelta;
-            if (clip->loopLength > 0.0) {
-                newPhase = std::fmod(std::fmod(newPhase, clip->loopLength) + clip->loopLength,
-                                     clip->loopLength);
+            if (magda::audioEventRef(*clip).loopLengthSeconds() > 0.0) {
+                newPhase =
+                    std::fmod(std::fmod(newPhase, magda::audioEventRef(*clip).loopLengthSeconds()) +
+                                  magda::audioEventRef(*clip).loopLengthSeconds(),
+                              magda::audioEventRef(*clip).loopLengthSeconds());
             } else {
                 newPhase = juce::jmax(0.0, newPhase);
             }
@@ -1489,9 +1501,11 @@ void WaveformGridComponent::mouseDrag(const juce::MouseEvent& event) {
                 double timelinePhase = displayInfo_.sourceToTimeline(newPhase);
                 timelinePhase = snapTimeToGrid(timelinePhase);
                 newPhase = displayInfo_.timelineToSource(timelinePhase);
-                if (clip->loopLength > 0.0) {
-                    newPhase = std::fmod(std::fmod(newPhase, clip->loopLength) + clip->loopLength,
-                                         clip->loopLength);
+                if (magda::audioEventRef(*clip).loopLengthSeconds() > 0.0) {
+                    newPhase = std::fmod(
+                        std::fmod(newPhase, magda::audioEventRef(*clip).loopLengthSeconds()) +
+                            magda::audioEventRef(*clip).loopLengthSeconds(),
+                        magda::audioEventRef(*clip).loopLengthSeconds());
                 } else {
                     newPhase = juce::jmax(0.0, newPhase);
                 }
@@ -1535,7 +1549,8 @@ void WaveformGridComponent::mouseDrag(const juce::MouseEvent& event) {
             double newSpeedRatio = dragStartSpeedRatio_ / stretchRatio;
             newSpeedRatio = juce::jlimit(magda::ClipOperations::MIN_SPEED_RATIO,
                                          magda::ClipOperations::MAX_SPEED_RATIO, newSpeedRatio);
-            clip->speedRatio = newSpeedRatio;
+            if (auto* stretchEvent = clip->primaryEvent())
+                stretchEvent->speedRatio = newSpeedRatio;
             break;
         }
         case DragMode::StretchLeft: {
@@ -1549,7 +1564,8 @@ void WaveformGridComponent::mouseDrag(const juce::MouseEvent& event) {
             double newSpeedRatio = dragStartSpeedRatio_ / stretchRatio;
             newSpeedRatio = juce::jlimit(magda::ClipOperations::MIN_SPEED_RATIO,
                                          magda::ClipOperations::MAX_SPEED_RATIO, newSpeedRatio);
-            clip->speedRatio = newSpeedRatio;
+            if (auto* stretchEvent = clip->primaryEvent())
+                stretchEvent->speedRatio = newSpeedRatio;
             break;
         }
         default:
@@ -1650,7 +1666,7 @@ void WaveformGridComponent::mouseMove(const juce::MouseEvent& event) {
     }
 
     const auto* clip = getClip();
-    if (!clip || clip->audio().source.filePath.isEmpty()) {
+    if (!clip || magda::audioEventRef(*clip).sourceFilePath().isEmpty()) {
         setMouseCursor(juce::MouseCursor::NormalCursor);
         return;
     }
@@ -1698,7 +1714,7 @@ void WaveformGridComponent::mouseMove(const juce::MouseEvent& event) {
             setMouseCursor(juce::MouseCursor::LeftRightResizeCursor);
         }
     } else if (isNearRightEdge(x, *clip)) {
-        if (!clip->loopEnabled && !clip->autoTempo)
+        if (!clip->loopEnabled && !magda::audioEventRef(*clip).autoTempo)
             setMouseCursor(juce::MouseCursor::LeftRightResizeCursor);
         else if (event.mods.isShiftDown())
             setMouseCursor(juce::MouseCursor::UpDownLeftRightResizeCursor);
@@ -1723,7 +1739,7 @@ bool WaveformGridComponent::isNearLeftEdge(int x, const magda::ClipInfo& clip) c
 
 bool WaveformGridComponent::isNearRightEdge(int x, const magda::ClipInfo& clip) const {
     double rightEdgePosition = displayInfo_.fileExtentTimeline();
-    if (!clip.loopEnabled && !clip.autoTempo) {
+    if (!clip.loopEnabled && !audioEventRef(clip).autoTempo) {
         const double activeClipEnd = displayInfo_.offsetPositionSeconds + clipLength_;
         if (activeClipEnd > displayInfo_.offsetPositionSeconds)
             rightEdgePosition = activeClipEnd;
@@ -1734,7 +1750,7 @@ bool WaveformGridComponent::isNearRightEdge(int x, const magda::ClipInfo& clip) 
 }
 
 bool WaveformGridComponent::isNearPhaseMarker(int x, const magda::ClipInfo& clip) const {
-    const bool loopActive = clip.loopEnabled || clip.autoTempo;
+    const bool loopActive = clip.loopEnabled || audioEventRef(clip).autoTempo;
     if (!loopActive || displayInfo_.loopLengthSeconds <= 0.0)
         return false;
     int phaseX = timeToPixel(getDisplayStartTime() + displayInfo_.loopPhasePositionSeconds);

--- a/magda/daw/ui/panels/BottomPanel.cpp
+++ b/magda/daw/ui/panels/BottomPanel.cpp
@@ -513,7 +513,7 @@ void BottomPanel::setupHeaderControls() {
         if (clipId == INVALID_CLIP_ID)
             return;
         const auto* clip = ClipManager::getInstance().getClip(clipId);
-        if (clip == nullptr || clip->autoTempo)
+        if (clip == nullptr || magda::audioEventRef(*clip).autoTempo)
             return;  // beat mode owns looping; can't toggle here
 
         const bool newState = !loopButton_->isActive();
@@ -1387,7 +1387,8 @@ void BottomPanel::syncLoopButtonState() {
     const auto* clip =
         (clipId != INVALID_CLIP_ID) ? ClipManager::getInstance().getClip(clipId) : nullptr;
     // autoTempo forces looping on; reflect that even though it can't be toggled.
-    loopButton_->setActive(clip != nullptr && (clip->loopEnabled || clip->autoTempo));
+    loopButton_->setActive(clip != nullptr &&
+                           (clip->loopEnabled || magda::audioEventRef(*clip).autoTempo));
 }
 
 void BottomPanel::syncClipEnabledButtonState() {

--- a/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
+++ b/magda/daw/ui/panels/content/AudioClipPropertiesContent.cpp
@@ -35,9 +35,9 @@ double getAudioFileDurationForProperties(const magda::ClipInfo& clip) {
     if (!clip.isAudio())
         return 0.0;
 
-    double durationSeconds = clip.audio().source.durationSeconds;
+    double durationSeconds = audioEventRef(clip).sourceDurationSeconds();
     if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
-            clip.audio().source.filePath)) {
+            audioEventRef(clip).sourceFilePath())) {
         const double fileDuration = thumb->getTotalLength();
         if (fileDuration > 0.0)
             durationSeconds = fileDuration;
@@ -56,8 +56,8 @@ double getProjectBpmForProperties() {
 // Resolve the shared inspector display model (values + which fields are live)
 // for this clip, so this panel and the right-panel clip inspector can't drift.
 magda::AudioClipSourceDisplay resolveSourceDisplay(const magda::ClipInfo& clip) {
-    const double cachedBpm =
-        magda::AudioThumbnailManager::getInstance().getCachedBPM(clip.audio().source.filePath);
+    const double cachedBpm = magda::AudioThumbnailManager::getInstance().getCachedBPM(
+        audioEventRef(clip).sourceFilePath());
     return magda::computeAudioClipSourceDisplay(clip, getProjectBpmForProperties(),
                                                 getAudioFileDurationForProperties(clip), cachedBpm);
 }
@@ -179,7 +179,8 @@ void AudioClipPropertiesContent::createControls() {
         const auto* clip = magda::ClipManager::getInstance().getClip(clipId_);
         if (!clip)
             return;
-        magda::ClipManager::getInstance().setClipWarpEnabled(clipId_, !clip->warpEnabled);
+        magda::ClipManager::getInstance().setClipWarpEnabled(
+            clipId_, !magda::audioEventRef(*clip).warpEnabled);
     };
 
     autoTempoToggle_ = makeToggle("BEAT");
@@ -193,27 +194,31 @@ void AudioClipPropertiesContent::createControls() {
         if (!clip)
             return;
 
-        bool enable = !clip->autoTempo;
+        bool enable = !magda::audioEventRef(*clip).autoTempo;
 
         const double bpm = getProjectBpmForProperties();
 
         const bool sourceInterpretationBpmLooksDefaulted =
-            clip->audio().interpretation.bpm <= 0.0 ||
-            std::abs(clip->audio().interpretation.bpm - bpm) < 0.1;
+            magda::audioEventRef(*clip).interpBpm <= 0.0 ||
+            std::abs(magda::audioEventRef(*clip).interpBpm - bpm) < 0.1;
         if (enable && clip->isAudio() && sourceInterpretationBpmLooksDefaulted) {
             // Issue #1157: only seed from AudioThumbnailManager when the
             // file didn't carry tempo metadata. setSourceMetadata (from TE's
             // loopInfo) is authoritative when present.
             auto& thumbs = magda::AudioThumbnailManager::getInstance();
-            double cached = thumbs.getCachedBPM(clip->audio().source.filePath);
-            if (cached > 0.0) {
-                clip->audio().interpretation.bpm = cached;
-                if (auto* thumb = thumbs.getThumbnail(clip->audio().source.filePath)) {
+            auto* event = clip->primaryEvent();
+            double cached = event != nullptr ? thumbs.getCachedBPM(event->sourceFilePath()) : 0.0;
+            if (event != nullptr && cached > 0.0) {
+                event->interpBpm = cached;
+                if (auto* thumb = thumbs.getThumbnail(event->sourceFilePath())) {
                     double fileDuration = thumb->getTotalLength();
                     if (fileDuration > 0.0) {
-                        if (clip->audio().source.durationSeconds <= 0.0)
-                            clip->audio().source.durationSeconds = fileDuration;
-                        clip->audio().interpretation.totalBeats = fileDuration * cached / 60.0;
+                        if (auto* src =
+                                magda::SourcePool::getInstance().getMutable(event->sourceId);
+                            src != nullptr && src->durationSeconds <= 0.0) {
+                            src->durationSeconds = fileDuration;
+                        }
+                        event->interpTotalBeats = fileDuration * cached / 60.0;
                     }
                 }
             }
@@ -231,7 +236,8 @@ void AudioClipPropertiesContent::createControls() {
         if (!clip)
             return;
         magda::UndoManager::getInstance().executeCommand(
-            std::make_unique<magda::SetClipReversedCommand>(clipId_, !clip->isReversed));
+            std::make_unique<magda::SetClipReversedCommand>(clipId_,
+                                                            !magda::audioEventRef(*clip).reversed));
     };
 
     // ===================== STRETCH SECTION =====================
@@ -298,19 +304,20 @@ void AudioClipPropertiesContent::createControls() {
 
         // BPM and Beats are two editable views of the same fixed-duration source
         // interpretation. Editing either one must keep the other coherent.
-        if (clip->autoTempo) {
+        if (magda::audioEventRef(*clip).autoTempo) {
             double bpm = 120.0;
             if (auto* tc = magda::TimelineController::getCurrent())
                 bpm = tc->getState().tempo.bpm;
             magda::ClipManager::AudioClipBeatsUpdate u;
             u.interpretationBpm = newBPM;
-            double durationSeconds = clip->audio().source.durationSeconds;
+            double durationSeconds = magda::audioEventRef(*clip).sourceDurationSeconds();
             if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
-                    clip->audio().source.filePath)) {
+                    magda::audioEventRef(*clip).sourceFilePath())) {
                 double fileDuration = thumb->getTotalLength();
                 if (fileDuration > 0.0)
                     durationSeconds = fileDuration;
-                if (fileDuration > 0.0 && clip->audio().source.durationSeconds <= 0.0)
+                if (fileDuration > 0.0 &&
+                    magda::audioEventRef(*clip).sourceDurationSeconds() <= 0.0)
                     u.sourceDurationSeconds = fileDuration;
             }
             if (durationSeconds > 0.0) {
@@ -321,13 +328,18 @@ void AudioClipPropertiesContent::createControls() {
             mgr.applyAudioClipBeats(clipId_, u, bpm);
         } else {
             // Non-autoTempo audio: source interpretation BPM is just stored metadata.
-            clip->audio().interpretation.bpm = newBPM;
+            auto* event = clip->primaryEvent();
+            if (event != nullptr)
+                event->interpBpm = newBPM;
             if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
-                    clip->audio().source.filePath)) {
+                    magda::audioEventRef(*clip).sourceFilePath())) {
                 double fileDuration = thumb->getTotalLength();
                 if (fileDuration > 0.0) {
-                    if (clip->audio().source.durationSeconds <= 0.0)
-                        clip->audio().source.durationSeconds = fileDuration;
+                    if (auto* src = magda::SourcePool::getInstance().getMutable(
+                            magda::audioEventRef(*clip).sourceId);
+                        src != nullptr && src->durationSeconds <= 0.0) {
+                        src->durationSeconds = fileDuration;
+                    }
                 }
             }
             auto& mgr = magda::ClipManager::getInstance();
@@ -359,10 +371,10 @@ void AudioClipPropertiesContent::createControls() {
         if (auto* tc = magda::TimelineController::getCurrent())
             projectBpm = tc->getState().tempo.bpm;
 
-        double durationSeconds = clip->audio().source.durationSeconds;
+        double durationSeconds = magda::audioEventRef(*clip).sourceDurationSeconds();
         if (durationSeconds <= 0.0) {
             if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
-                    clip->audio().source.filePath)) {
+                    magda::audioEventRef(*clip).sourceFilePath())) {
                 durationSeconds = thumb->getTotalLength();
             }
         }
@@ -372,7 +384,7 @@ void AudioClipPropertiesContent::createControls() {
         u.lockInterpretationTotalBeats = true;
         if (durationSeconds > 0.0)
             u.interpretationBpm = newSourceBeats * 60.0 / durationSeconds;
-        if (durationSeconds > 0.0 && clip->audio().source.durationSeconds <= 0.0)
+        if (durationSeconds > 0.0 && magda::audioEventRef(*clip).sourceDurationSeconds() <= 0.0)
             u.sourceDurationSeconds = durationSeconds;
 
         magda::ClipManager::getInstance().applyAudioClipBeats(clipId_, u, projectBpm);
@@ -408,7 +420,8 @@ void AudioClipPropertiesContent::createControls() {
         if (rootId >= 2 && rootId <= 13) {
             root = kKeyRoots[rootId - 2];
         }
-        clip->audio().interpretation.keyRoot = root;
+        if (auto* event = clip->primaryEvent())
+            event->keyRoot = root;
         magda::ClipManager::getInstance().forceNotifyClipPropertyChanged(clipId_);
     };
     addAndMakeVisible(*keyRootCombo_);
@@ -422,19 +435,20 @@ void AudioClipPropertiesContent::createControls() {
         if (clip == nullptr || !clip->isAudio()) {
             return;
         }
+        auto* event = clip->primaryEvent();
         const double displayedBpm = bpmValue_ ? bpmValue_->getValue() : 0.0;
-        if (magda::isValidBpm(displayedBpm)) {
-            clip->audio().interpretation.bpm = displayedBpm;
+        if (event != nullptr && magda::isValidBpm(displayedBpm)) {
+            event->interpBpm = displayedBpm;
         }
         const double displayedBeats = beatsValue_ ? beatsValue_->getValue() : 0.0;
-        if (displayedBeats > 0.0) {
-            clip->audio().interpretation.totalBeats = displayedBeats;
-            clip->audio().interpretation.totalBeatsLocked = true;
+        if (event != nullptr && displayedBeats > 0.0) {
+            event->interpTotalBeats = displayedBeats;
+            event->interpTotalBeatsLocked = true;
         }
 
-        std::optional<std::vector<magda::ClipInfo::WarpMarker>> markers;
-        if (clip->warpEnabled) {
-            markers = std::vector<magda::ClipInfo::WarpMarker>{};
+        std::optional<std::vector<magda::WarpMarker>> markers;
+        if (magda::audioEventRef(*clip).warpEnabled) {
+            markers = std::vector<magda::WarpMarker>{};
             if (auto* engine = magda::TrackManager::getInstance().getAudioEngine()) {
                 if (auto* bridge = engine->getAudioBridge()) {
                     const auto liveMarkers = bridge->getWarpMarkers(clipId_);
@@ -445,7 +459,7 @@ void AudioClipPropertiesContent::createControls() {
                 }
             }
             if (markers->empty()) {
-                *markers = clip->warpMarkers;
+                *markers = magda::audioEventRef(*clip).warpMarkers;
             }
         }
 
@@ -492,7 +506,8 @@ void AudioClipPropertiesContent::createControls() {
         const auto* clip = magda::ClipManager::getInstance().getClip(clipId_);
         if (!clip)
             return;
-        magda::ClipManager::getInstance().setAnalogPitch(clipId_, !clip->analogPitch);
+        magda::ClipManager::getInstance().setAnalogPitch(clipId_,
+                                                         !magda::audioEventRef(*clip).analogPitch);
     };
 
     // ===================== TAKES SECTION =====================
@@ -590,14 +605,19 @@ void AudioClipPropertiesContent::updateFromClip() {
     const auto* clip = magda::ClipManager::getInstance().getClip(clipId_);
     bool hasClip = clip != nullptr && clip->isAudio();
 
-    warpToggle_->setToggleState(hasClip && clip->warpEnabled, juce::dontSendNotification);
-    autoTempoToggle_->setToggleState(hasClip && clip->autoTempo, juce::dontSendNotification);
-    analogPitchToggle_->setToggleState(hasClip && clip->analogPitch, juce::dontSendNotification);
-    reverseToggle_->setToggleState(hasClip && clip->isReversed, juce::dontSendNotification);
+    warpToggle_->setToggleState(hasClip && magda::audioEventRef(*clip).warpEnabled,
+                                juce::dontSendNotification);
+    autoTempoToggle_->setToggleState(hasClip && magda::audioEventRef(*clip).autoTempo,
+                                     juce::dontSendNotification);
+    analogPitchToggle_->setToggleState(hasClip && magda::audioEventRef(*clip).analogPitch,
+                                       juce::dontSendNotification);
+    reverseToggle_->setToggleState(hasClip && magda::audioEventRef(*clip).reversed,
+                                   juce::dontSendNotification);
 
     if (hasClip) {
-        stretchValue_->setValue(clip->speedRatio, juce::dontSendNotification);
-        stretchModeCombo_->setSelectedId(clip->getEffectiveTimeStretchMode() + 1,
+        stretchValue_->setValue(magda::audioEventRef(*clip).speedRatio, juce::dontSendNotification);
+        stretchModeCombo_->setSelectedId(magda::audioEventRef(*clip).getEffectiveTimeStretchMode() +
+                                             1,
                                          juce::dontSendNotification);
         const auto sourceDisplay = resolveSourceDisplay(*clip);
         bpmValue_->setValue(sourceDisplay.bpm > 0.0 ? sourceDisplay.bpm : magda::DEFAULT_BPM,
@@ -606,7 +626,7 @@ void AudioClipPropertiesContent::updateFromClip() {
                               juce::dontSendNotification);
         // Mirror the clip's source key root into the combo (-- when unknown).
         {
-            const auto& root = clip->audio().interpretation.keyRoot;
+            const auto& root = magda::audioEventRef(*clip).keyRoot;
             static constexpr const char* kRoots[] = {"C",  "C#", "D",  "D#", "E",  "F",
                                                      "F#", "G",  "G#", "A",  "A#", "B"};
             int rootId = 1;
@@ -618,7 +638,8 @@ void AudioClipPropertiesContent::updateFromClip() {
             }
             keyRootCombo_->setSelectedId(rootId, juce::dontSendNotification);
         }
-        pitchValue_->setValue(static_cast<double>(clip->pitchChange), juce::dontSendNotification);
+        pitchValue_->setValue(static_cast<double>(magda::audioEventRef(*clip).pitchChange),
+                              juce::dontSendNotification);
         volumeValue_->setValue(static_cast<double>(clip->volumeDB), juce::dontSendNotification);
         gainValue_->setValue(static_cast<double>(clip->gainDB), juce::dontSendNotification);
         panValue_->setValue(static_cast<double>(clip->pan), juce::dontSendNotification);
@@ -632,7 +653,7 @@ void AudioClipPropertiesContent::updateFromClip() {
     takesSection_->setClip(isMulti ? magda::INVALID_CLIP_ID : clipId_);
 
     bool enabled = hasClip;
-    bool isAutoTempo = hasClip && clip->autoTempo;
+    bool isAutoTempo = hasClip && magda::audioEventRef(*clip).autoTempo;
     // Speed is live in time-based mode; Source BPM / Beats are live only in beat
     // mode (autoTempo) — they're inert otherwise, so grey them out. Mirrors the
     // right-panel clip inspector.
@@ -641,7 +662,8 @@ void AudioClipPropertiesContent::updateFromClip() {
     bpmValue_->setEnabled(enabled && isAutoTempo);
     beatsValue_->setEnabled(enabled && isAutoTempo);
     pitchValue_->setEnabled(enabled);
-    analogPitchToggle_->setEnabled(enabled && !isAutoTempo && !(hasClip && clip->warpEnabled));
+    analogPitchToggle_->setEnabled(enabled && !isAutoTempo &&
+                                   !(hasClip && magda::audioEventRef(*clip).warpEnabled));
     transientSensValue_->setEnabled(enabled);
     saveLibraryButton_->setEnabled(enabled &&
                                    magda::ClipManager::getInstance().canSaveClipToLibrary(clipId_));

--- a/magda/daw/ui/panels/content/AutomationClipEditorContent.cpp
+++ b/magda/daw/ui/panels/content/AutomationClipEditorContent.cpp
@@ -348,14 +348,12 @@ void AutomationClipEditorContent::paintTrackGhost(juce::Graphics& g) {
             // what the arrangement actually renders.
             const double beatsPerSecond = tempo / 60.0;
             const double clipLengthInBeats = cLenSeconds * beatsPerSecond;
-            const double midiSrcLength =
-                c->loopLength > 0.0 ? c->loopLength : cLenSeconds * c->speedRatio;
+            // A MIDI clip's loop is clip beats: reading it off an audio event
+            // would always miss, and the ghost would stop unrolling.
             const double loopLengthBeats =
-                c->loopLengthBeats > 0.0
-                    ? c->loopLengthBeats
-                    : (midiSrcLength > 0.0 ? midiSrcLength * beatsPerSecond : clipLengthInBeats);
+                c->loopLengthBeats > 0.0 ? c->loopLengthBeats : clipLengthInBeats;
             const double midiOffset = c->loopEnabled ? c->midiOffset : c->midiTrimOffset;
-            const double loopStart = c->loopStart * beatsPerSecond;
+            const double loopStart = c->loopStartBeats;
             const double loopEnd = loopStart + loopLengthBeats;
 
             const auto emitGhost = [&](double displayStart, double displayEnd, int pitch) {
@@ -397,7 +395,7 @@ void AutomationClipEditorContent::paintTrackGhost(juce::Graphics& g) {
                     emitGhost(displayStart, displayStart + note.lengthBeats, note.noteNumber);
                 }
             }
-        } else if (c->isAudio() && c->audio().source.filePath.isNotEmpty()) {
+        } else if (c->isAudio() && magda::audioEventRef(*c).sourceFilePath().isNotEmpty()) {
             const float x0 = beatToPixelF(cStart);
             const float x1 = beatToPixelF(cEnd);
             const auto area = juce::Rectangle<int>(

--- a/magda/daw/ui/panels/content/DrumGridClipContent.cpp
+++ b/magda/daw/ui/panels/content/DrumGridClipContent.cpp
@@ -2839,13 +2839,11 @@ void DrumGridClipContent::updateGridSize() {
 
     // Pass loop region data to grid
     if (clip) {
-        double beatsPerSecond = tempo / 60.0;
-        // The loop is read through the content-aware accessors: a MIDI clip's
-        // loop lives in clip beats, an audio event's in its source domain.
-        juce::ignoreUnused(beatsPerSecond);
-        const double loopOffsetBeats =
-            clip->isMidi() ? clip->loopStartBeats : magda::audioEventRef(*clip).loopStartBeats();
-        const double sourceLengthBeats = clip->loopLengthInBeats();
+        // Both values are timeline beats, which is what the grid draws in. A
+        // MIDI clip keeps them on the container; an audio clip's loop is a
+        // source region that has to come back through the project tempo.
+        const double loopOffsetBeats = clip->loopStartInBeats(tempo);
+        const double sourceLengthBeats = clip->loopLengthInBeats(tempo);
         gridComponent_->setLoopRegion(loopOffsetBeats, sourceLengthBeats, clip->loopEnabled);
     } else {
         gridComponent_->setLoopRegion(0.0, 0.0, false);

--- a/magda/daw/ui/panels/content/DrumGridClipContent.cpp
+++ b/magda/daw/ui/panels/content/DrumGridClipContent.cpp
@@ -2845,7 +2845,7 @@ void DrumGridClipContent::updateGridSize() {
         juce::ignoreUnused(beatsPerSecond);
         const double loopOffsetBeats =
             clip->isMidi() ? clip->loopStartBeats : magda::audioEventRef(*clip).loopStartBeats();
-        const double sourceLengthBeats = clip->loopLengthBeats;
+        const double sourceLengthBeats = clip->loopLengthInBeats();
         gridComponent_->setLoopRegion(loopOffsetBeats, sourceLengthBeats, clip->loopEnabled);
     } else {
         gridComponent_->setLoopRegion(0.0, 0.0, false);

--- a/magda/daw/ui/panels/content/DrumGridClipContent.cpp
+++ b/magda/daw/ui/panels/content/DrumGridClipContent.cpp
@@ -2840,10 +2840,12 @@ void DrumGridClipContent::updateGridSize() {
     // Pass loop region data to grid
     if (clip) {
         double beatsPerSecond = tempo / 60.0;
-        double loopOffsetBeats = clip->loopStart * beatsPerSecond;
-        // MIDI clips use loopLengthBeats directly; audio clips derive from loopLength (seconds)
-        double sourceLengthBeats =
-            clip->loopLengthBeats > 0.0 ? clip->loopLengthBeats : clip->loopLength * beatsPerSecond;
+        // The loop is read through the content-aware accessors: a MIDI clip's
+        // loop lives in clip beats, an audio event's in its source domain.
+        juce::ignoreUnused(beatsPerSecond);
+        const double loopOffsetBeats =
+            clip->isMidi() ? clip->loopStartBeats : magda::audioEventRef(*clip).loopStartBeats();
+        const double sourceLengthBeats = clip->loopLengthBeats;
         gridComponent_->setLoopRegion(loopOffsetBeats, sourceLengthBeats, clip->loopEnabled);
     } else {
         gridComponent_->setLoopRegion(0.0, 0.0, false);

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
@@ -187,7 +187,7 @@ std::optional<magda::ClipId> findOpenClipForPath(const std::filesystem::path& pa
     for (const auto& clip : magda::ClipManager::getInstance().getClips()) {
         juce::String sourcePath;
         if (clip.isAudio()) {
-            sourcePath = clip.audio().source.filePath;
+            sourcePath = audioEventRef(clip).sourceFilePath();
         } else if (clip.isMidi()) {
             sourcePath = clip.midi().sourceFilePath;
         }
@@ -201,14 +201,13 @@ std::optional<magda::ClipId> findOpenClipForPath(const std::filesystem::path& pa
     return std::nullopt;
 }
 
-std::optional<std::vector<magda::ClipInfo::WarpMarker>> currentWarpMarkersForClip(
-    magda::ClipId clipId) {
+std::optional<std::vector<magda::WarpMarker>> currentWarpMarkersForClip(magda::ClipId clipId) {
     auto* clip = magda::ClipManager::getInstance().getClip(clipId);
-    if (clip == nullptr || !clip->isAudio() || !clip->warpEnabled) {
+    if (clip == nullptr || !clip->isAudio() || !magda::audioEventRef(*clip).warpEnabled) {
         return std::nullopt;
     }
 
-    std::vector<magda::ClipInfo::WarpMarker> markers;
+    std::vector<magda::WarpMarker> markers;
     if (auto* engine = magda::TrackManager::getInstance().getAudioEngine()) {
         if (auto* bridge = engine->getAudioBridge()) {
             const auto liveMarkers = bridge->getWarpMarkers(clipId);
@@ -219,7 +218,7 @@ std::optional<std::vector<magda::ClipInfo::WarpMarker>> currentWarpMarkersForCli
         }
     }
     if (markers.empty()) {
-        markers = clip->warpMarkers;
+        markers = magda::audioEventRef(*clip).warpMarkers;
     }
     return markers;
 }

--- a/magda/daw/ui/panels/content/MidiEditorContent.cpp
+++ b/magda/daw/ui/panels/content/MidiEditorContent.cpp
@@ -83,21 +83,20 @@ double facadeTimelineLength(const magda::ClipInfo& c, double bpm) {
 }
 
 double effectiveLoopLengthSeconds(const magda::ClipInfo& clip, double bpm) {
-    if (clip.loopLength > 0.0)
-        return clip.loopLength;
-
-    if (clip.loopLengthBeats > 0.0 && isValidBpm(bpm))
-        return clip.loopLengthBeats * 60.0 / bpm;
+    // This editor's clips are MIDI, whose loop is clip beats. Reading it off
+    // an audio event would always miss, since a MIDI clip has none.
+    if (const double loopBeats = clip.loopLengthBeats; loopBeats > 0.0 && isValidBpm(bpm)) {
+        return loopBeats * 60.0 / bpm;
+    }
 
     return facadeTimelineLength(clip, bpm);
 }
 
 double effectiveLoopStartSeconds(const magda::ClipInfo& clip, double bpm) {
-    if (clip.loopStart > 0.0)
-        return clip.loopStart;
-
-    if (clip.loopStartBeats > 0.0 && isValidBpm(bpm))
-        return clip.loopStartBeats * 60.0 / bpm;
+    const double startBeats =
+        clip.isMidi() ? clip.loopStartBeats : audioEventRef(clip).loopStartBeats();
+    if (startBeats > 0.0 && isValidBpm(bpm))
+        return startBeats * 60.0 / bpm;
 
     return 0.0;
 }
@@ -378,7 +377,7 @@ MidiEditorContent::MidiEditorContent() {
         double phaseBeats = phaseSeconds * bpm / 60.0;
 
         // Wrap within loop length
-        double loopLengthBeats = clip->loopLength * bpm / 60.0;
+        double loopLengthBeats = clip->loopLengthBeats;
         if (loopLengthBeats > 0.0) {
             phaseBeats = std::fmod(phaseBeats, loopLengthBeats);
             if (phaseBeats < 0.0)
@@ -673,7 +672,11 @@ void MidiEditorContent::updateTimeRuler() {
 
     // Set loop region markers and phase marker
     if (clip) {
-        timeRuler_->setLoopRegion(clip->loopStart, clip->loopLength, clip->loopEnabled);
+        // A MIDI clip's loop is clip beats, so it converts to the ruler's
+        // seconds through the project tempo rather than a source rate.
+        const double secondsPerBeat = 60.0 / tempo;
+        timeRuler_->setLoopRegion(clip->loopStartBeats * secondsPerBeat,
+                                  clip->loopLengthBeats * secondsPerBeat, clip->loopEnabled);
         // Show yellow phase marker when looped
         if (clip->loopEnabled) {
             double phaseSeconds = clip->midiOffset * 60.0 / tempo;

--- a/magda/daw/ui/panels/content/MidiEditorContent.cpp
+++ b/magda/daw/ui/panels/content/MidiEditorContent.cpp
@@ -83,9 +83,8 @@ double facadeTimelineLength(const magda::ClipInfo& c, double bpm) {
 }
 
 double effectiveLoopLengthSeconds(const magda::ClipInfo& clip, double bpm) {
-    // This editor's clips are MIDI, whose loop is clip beats. Reading it off
-    // an audio event would always miss, since a MIDI clip has none.
-    if (const double loopBeats = clip.loopLengthBeats; loopBeats > 0.0 && isValidBpm(bpm)) {
+    // Timeline beats for either content type, then into timeline seconds.
+    if (const double loopBeats = clip.loopLengthInBeats(bpm); loopBeats > 0.0 && isValidBpm(bpm)) {
         return loopBeats * 60.0 / bpm;
     }
 
@@ -93,8 +92,7 @@ double effectiveLoopLengthSeconds(const magda::ClipInfo& clip, double bpm) {
 }
 
 double effectiveLoopStartSeconds(const magda::ClipInfo& clip, double bpm) {
-    const double startBeats =
-        clip.isMidi() ? clip.loopStartBeats : audioEventRef(clip).loopStartBeats();
+    const double startBeats = clip.loopStartInBeats(bpm);
     if (startBeats > 0.0 && isValidBpm(bpm))
         return startBeats * 60.0 / bpm;
 

--- a/magda/daw/ui/panels/content/PianoRollContent.cpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.cpp
@@ -1349,7 +1349,7 @@ void PianoRollContent::updateGridSize() {
         juce::ignoreUnused(beatsPerSecond);
         const double loopOffsetBeats =
             clip->isMidi() ? clip->loopStartBeats : magda::audioEventRef(*clip).loopStartBeats();
-        const double sourceLengthBeats = clip->loopLengthBeats;
+        const double sourceLengthBeats = clip->loopLengthInBeats();
         gridComponent_->setLoopRegion(loopOffsetBeats, sourceLengthBeats, clip->loopEnabled);
     } else {
         gridComponent_->setLoopRegion(0.0, 0.0, false);

--- a/magda/daw/ui/panels/content/PianoRollContent.cpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.cpp
@@ -1343,13 +1343,11 @@ void PianoRollContent::updateGridSize() {
         if (auto* controller = magda::TimelineController::getCurrent()) {
             tempo = controller->getState().tempo.bpm;
         }
-        double beatsPerSecond = tempo / 60.0;
-        // The loop is read through the content-aware accessors: a MIDI clip's
-        // loop lives in clip beats, an audio event's in its source domain.
-        juce::ignoreUnused(beatsPerSecond);
-        const double loopOffsetBeats =
-            clip->isMidi() ? clip->loopStartBeats : magda::audioEventRef(*clip).loopStartBeats();
-        const double sourceLengthBeats = clip->loopLengthInBeats();
+        // Both values are timeline beats, which is what the grid draws in. A
+        // MIDI clip keeps them on the container; an audio clip's loop is a
+        // source region that has to come back through the project tempo.
+        const double loopOffsetBeats = clip->loopStartInBeats(tempo);
+        const double sourceLengthBeats = clip->loopLengthInBeats(tempo);
         gridComponent_->setLoopRegion(loopOffsetBeats, sourceLengthBeats, clip->loopEnabled);
     } else {
         gridComponent_->setLoopRegion(0.0, 0.0, false);

--- a/magda/daw/ui/panels/content/PianoRollContent.cpp
+++ b/magda/daw/ui/panels/content/PianoRollContent.cpp
@@ -1344,10 +1344,12 @@ void PianoRollContent::updateGridSize() {
             tempo = controller->getState().tempo.bpm;
         }
         double beatsPerSecond = tempo / 60.0;
-        double loopOffsetBeats = clip->loopStart * beatsPerSecond;
-        // MIDI clips use loopLengthBeats directly; audio clips derive from loopLength (seconds)
-        double sourceLengthBeats =
-            clip->loopLengthBeats > 0.0 ? clip->loopLengthBeats : clip->loopLength * beatsPerSecond;
+        // The loop is read through the content-aware accessors: a MIDI clip's
+        // loop lives in clip beats, an audio event's in its source domain.
+        juce::ignoreUnused(beatsPerSecond);
+        const double loopOffsetBeats =
+            clip->isMidi() ? clip->loopStartBeats : magda::audioEventRef(*clip).loopStartBeats();
+        const double sourceLengthBeats = clip->loopLengthBeats;
         gridComponent_->setLoopRegion(loopOffsetBeats, sourceLengthBeats, clip->loopEnabled);
     } else {
         gridComponent_->setLoopRegion(0.0, 0.0, false);

--- a/magda/daw/ui/panels/content/WaveformEditorContent.cpp
+++ b/magda/daw/ui/panels/content/WaveformEditorContent.cpp
@@ -148,11 +148,12 @@ class WaveformEditorContent::PlayheadOverlay : public juce::Component {
         // to source-file position. Only show cursors when the arrangement
         // playhead falls within this clip's time range.
         auto timelineDeltaToSourceDelta = [&](double timelineDelta) {
-            double sourceDuration = clip->audio().source.durationSeconds;
-            if (clip->autoTempo && clip->audio().interpretation.totalBeats > 0.0 &&
-                sourceDuration > 0.0 && projectBpm > 0.0) {
+            double sourceDuration = magda::audioEventRef(*clip).sourceDurationSeconds();
+            if (magda::audioEventRef(*clip).autoTempo &&
+                magda::audioEventRef(*clip).interpTotalBeats > 0.0 && sourceDuration > 0.0 &&
+                projectBpm > 0.0) {
                 double projectBeats = timelineDelta * projectBpm / 60.0;
-                return projectBeats * sourceDuration / clip->audio().interpretation.totalBeats;
+                return projectBeats * sourceDuration / magda::audioEventRef(*clip).interpTotalBeats;
             }
             return di.timelineToSource(timelineDelta);
         };
@@ -170,7 +171,8 @@ class WaveformEditorContent::PlayheadOverlay : public juce::Component {
 
         auto arrangementToSourceX = [&](double arrangementTime) -> int {
             double relTime = arrangementTime - clipStart;
-            double sourcePos = clip->offset + timelineDeltaToSourceDelta(relTime);
+            double sourcePos =
+                magda::audioEventRef(*clip).anchorSeconds() + timelineDeltaToSourceDelta(relTime);
             return sourcePositionToX(sourcePos);
         };
 
@@ -307,10 +309,15 @@ WaveformEditorContent::WaveformEditorContent() {
         // displayStart/displayEnd are in timeline seconds (from srcToTimeline in ClipDisplayInfo).
         // Reverse the transform to get source seconds.
         auto timelineToSrc = [&](double t) -> double {
-            if (clip->autoTempo && clip->loopLength > 0.0 && clip->loopLengthBeats > 0.0) {
-                return t * clip->loopLength / (clip->loopLengthBeats * 60.0 / bpm);
+            if (magda::audioEventRef(*clip).autoTempo &&
+                magda::audioEventRef(*clip).loopLengthSeconds() > 0.0 &&
+                magda::audioEventRef(*clip).loopLengthBeats() > 0.0) {
+                return t * magda::audioEventRef(*clip).loopLengthSeconds() /
+                       (magda::audioEventRef(*clip).loopLengthBeats() * 60.0 / bpm);
             }
-            return (clip->speedRatio > 0.0) ? t * clip->speedRatio : 0.0;
+            return (magda::audioEventRef(*clip).speedRatio > 0.0)
+                       ? t * magda::audioEventRef(*clip).speedRatio
+                       : 0.0;
         };
 
         double newLoopStart = timelineToSrc(displayStart);
@@ -936,7 +943,7 @@ void WaveformEditorContent::clipPropertyChanged(magda::ClipId clipId) {
             }
 
             // Update warp mode state
-            bool warpEnabled = clip->warpEnabled;
+            bool warpEnabled = magda::audioEventRef(*clip).warpEnabled;
             gridComponent_->setWarpMode(warpEnabled);
 
             if (warpEnabled) {
@@ -958,9 +965,9 @@ void WaveformEditorContent::clipPropertyChanged(magda::ClipId clipId) {
         }
 
         // Check if cached transients were invalidated (e.g. sensitivity changed)
-        if (clip->isAudio() && !clip->audio().source.filePath.isEmpty()) {
+        if (clip->isAudio() && !magda::audioEventRef(*clip).sourceFilePath().isEmpty()) {
             auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
-                clip->audio().source.filePath);
+                magda::audioEventRef(*clip).sourceFilePath());
             if (cached) {
                 gridComponent_->setTransientTimes(*cached);
                 transientsCached_ = true;
@@ -988,7 +995,7 @@ void WaveformEditorContent::transientsChanged(const juce::String& filePath) {
         setTransientsUpdating(false);
         return;
     }
-    if (clip->audio().source.filePath != filePath)
+    if (magda::audioEventRef(*clip).sourceFilePath() != filePath)
         return;
     auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(filePath);
     if (cached) {
@@ -1174,7 +1181,7 @@ void WaveformEditorContent::setClip(magda::ClipId clipId) {
 
         // Update warp mode state
         if (clip) {
-            bool warpEnabled = clip->warpEnabled;
+            bool warpEnabled = magda::audioEventRef(*clip).warpEnabled;
             gridComponent_->setWarpMode(warpEnabled);
             wasWarpEnabled_ = warpEnabled;
 
@@ -1191,9 +1198,9 @@ void WaveformEditorContent::setClip(magda::ClipId clipId) {
         }
 
         // Check for cached transients or request async detection.
-        if (clip && clip->isAudio() && !clip->audio().source.filePath.isEmpty()) {
+        if (clip && clip->isAudio() && !magda::audioEventRef(*clip).sourceFilePath().isEmpty()) {
             auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
-                clip->audio().source.filePath);
+                magda::audioEventRef(*clip).sourceFilePath());
             if (cached) {
                 gridComponent_->setTransientTimes(*cached);
                 transientsCached_ = true;
@@ -1319,9 +1326,9 @@ void WaveformEditorContent::updateGridSize() {
         const auto* clip = magda::ClipManager::getInstance().getClip(editingClipId_);
         if (clip && timeRuler_) {
             double fileDuration = 0.0;
-            if (clip->audio().source.filePath.isNotEmpty()) {
+            if (magda::audioEventRef(*clip).sourceFilePath().isNotEmpty()) {
                 auto* thumbnail = magda::AudioThumbnailManager::getInstance().getThumbnail(
-                    clip->audio().source.filePath);
+                    magda::audioEventRef(*clip).sourceFilePath());
                 if (thumbnail) {
                     fileDuration = thumbnail->getTotalLength();
                 }
@@ -1359,9 +1366,9 @@ void WaveformEditorContent::updateDisplayInfo(const magda::ClipInfo& clip) {
 
     // Get file duration for source extent calculation
     double fileDuration = 0.0;
-    if (clip.audio().source.filePath.isNotEmpty()) {
-        auto* thumbnail =
-            magda::AudioThumbnailManager::getInstance().getThumbnail(clip.audio().source.filePath);
+    if (audioEventRef(clip).sourceFilePath().isNotEmpty()) {
+        auto* thumbnail = magda::AudioThumbnailManager::getInstance().getThumbnail(
+            audioEventRef(clip).sourceFilePath());
         if (thumbnail) {
             fileDuration = thumbnail->getTotalLength();
         }
@@ -1374,7 +1381,7 @@ void WaveformEditorContent::updateDisplayInfo(const magda::ClipInfo& clip) {
     // Update time ruler loop region (green when active, grey when disabled)
     // Display anchored at file start — loop markers at real source positions
     if (timeRuler_) {
-        bool showMarkers = clip.loopEnabled && clip.loopLength > 0.0;
+        bool showMarkers = clip.loopEnabled && audioEventRef(clip).loopLengthSeconds() > 0.0;
         bool loopIsActive = clip.loopEnabled;
         double loopStartPos = info.loopStartPositionSeconds;
         double loopLen = info.loopLengthSeconds;
@@ -1509,9 +1516,9 @@ void WaveformEditorContent::requestTransientDetection() {
     setTransientsUpdating(true);
     if (bridge->getTransientTimes(editingClipId_)) {
         const auto* clip = magda::ClipManager::getInstance().getClip(editingClipId_);
-        if (clip && !clip->audio().source.filePath.isEmpty()) {
+        if (clip && !magda::audioEventRef(*clip).sourceFilePath().isEmpty()) {
             auto* cached = magda::AudioThumbnailManager::getInstance().getCachedTransients(
-                clip->audio().source.filePath);
+                magda::audioEventRef(*clip).sourceFilePath());
             if (cached) {
                 gridComponent_->setTransientTimes(*cached);
                 setTransientsUpdating(false);

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -31,15 +31,15 @@ namespace magda::daw::ui {
 namespace {
 
 double getAudioFileDurationForInspector(const magda::ClipInfo& clip) {
-    if (!clip.isAudio() || clip.audio().source.filePath.isEmpty())
+    if (!clip.isAudio() || audioEventRef(clip).sourceFilePath().isEmpty())
         return 0.0;
 
     if (auto* thumbnail = magda::AudioThumbnailManager::getInstance().getThumbnail(
-            clip.audio().source.filePath)) {
+            audioEventRef(clip).sourceFilePath())) {
         return thumbnail->getTotalLength();
     }
 
-    return clip.audio().source.durationSeconds;
+    return audioEventRef(clip).sourceDurationSeconds();
 }
 
 double displayBeatsToAudioSourceSeconds(const magda::ClipInfo& clip, double displayBeats,
@@ -475,21 +475,21 @@ void ClipInspector::initClipPropertiesSection() {
         // the authoritative musical interpretation. totalBeats = fileDuration ×
         // newBPM / 60, regardless of autoTempo (autoTempo controls playback
         // stretching, not the interpretation metadata).
-        double durationSeconds = clip->audio().source.durationSeconds;
+        double durationSeconds = magda::audioEventRef(*clip).sourceDurationSeconds();
         double thumbDuration = 0.0;
         if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
-                clip->audio().source.filePath)) {
+                magda::audioEventRef(*clip).sourceFilePath())) {
             thumbDuration = thumb->getTotalLength();
             if (thumbDuration > 0.0)
                 durationSeconds = thumbDuration;
         }
         if (durationSeconds <= 0.0)
-            durationSeconds = clip->getSourceLength();
+            durationSeconds = magda::audioEventRef(*clip).sourceLengthSeconds(clip->length);
 
-        if (clip->autoTempo) {
+        if (magda::audioEventRef(*clip).autoTempo) {
             magda::ClipManager::AudioClipBeatsUpdate u;
             u.interpretationBpm = newBPM;
-            if (thumbDuration > 0.0 && clip->audio().source.durationSeconds <= 0.0)
+            if (thumbDuration > 0.0 && magda::audioEventRef(*clip).sourceDurationSeconds() <= 0.0)
                 u.sourceDurationSeconds = thumbDuration;
             if (durationSeconds > 0.0) {
                 u.interpretationTotalBeats = durationSeconds * newBPM / 60.0;
@@ -502,12 +502,16 @@ void ClipInspector::initClipPropertiesSection() {
             // not playback-affecting, but the inspector reads it for display
             // and tooling (autoTempo toggle, future stretch correctness, etc.)
             // so the BPM-and-totalBeats pair must stay coherent here too.
-            clip->audio().interpretation.bpm = newBPM;
-            if (thumbDuration > 0.0 && clip->audio().source.durationSeconds <= 0.0)
-                clip->audio().source.durationSeconds = thumbDuration;
-            if (durationSeconds > 0.0) {
-                clip->audio().interpretation.totalBeats = durationSeconds * newBPM / 60.0;
-                clip->audio().interpretation.totalBeatsLocked = true;
+            if (auto* event = clip->primaryEvent()) {
+                event->interpBpm = newBPM;
+                if (auto* src = magda::SourcePool::getInstance().getMutable(event->sourceId);
+                    src != nullptr && thumbDuration > 0.0 && src->durationSeconds <= 0.0) {
+                    src->durationSeconds = thumbDuration;
+                }
+                if (durationSeconds > 0.0) {
+                    event->interpTotalBeats = durationSeconds * newBPM / 60.0;
+                    event->interpTotalBeatsLocked = true;
+                }
             }
             auto& mgr = magda::ClipManager::getInstance();
             mgr.forceNotifyClipPropertyChanged(primaryClipId());
@@ -536,15 +540,15 @@ void ClipInspector::initClipPropertiesSection() {
     clipBeatsLengthValue_->onValueChange = [this]() {
         if (primaryClipId() != magda::INVALID_CLIP_ID) {
             auto* clip = magda::ClipManager::getInstance().getClip(primaryClipId());
-            if (clip && clip->autoTempo) {
+            if (clip && magda::audioEventRef(*clip).autoTempo) {
                 double newSourceBeats = clipBeatsLengthValue_->getValue();
                 double projectBpm =
                     timelineController_ ? timelineController_->getState().tempo.bpm : 120.0;
 
-                double durationSeconds = clip->audio().source.durationSeconds;
+                double durationSeconds = magda::audioEventRef(*clip).sourceDurationSeconds();
                 if (durationSeconds <= 0.0) {
                     if (auto* thumb = magda::AudioThumbnailManager::getInstance().getThumbnail(
-                            clip->audio().source.filePath)) {
+                            magda::audioEventRef(*clip).sourceFilePath())) {
                         durationSeconds = thumb->getTotalLength();
                     }
                 }
@@ -554,7 +558,8 @@ void ClipInspector::initClipPropertiesSection() {
                 u.lockInterpretationTotalBeats = true;
                 if (durationSeconds > 0.0)
                     u.interpretationBpm = newSourceBeats * 60.0 / durationSeconds;
-                if (durationSeconds > 0.0 && clip->audio().source.durationSeconds <= 0.0)
+                if (durationSeconds > 0.0 &&
+                    magda::audioEventRef(*clip).sourceDurationSeconds() <= 0.0)
                     u.sourceDurationSeconds = durationSeconds;
 
                 magda::ClipManager::getInstance().applyAudioClipBeats(primaryClipId(), u,
@@ -705,7 +710,7 @@ void ClipInspector::initClipPropertiesSection() {
 
         // Beat mode owns looping. Keep the button visually active, but don't let a click
         // make the model appear to toggle out from under auto-tempo playback.
-        if (clip->autoTempo)
+        if (magda::audioEventRef(*clip).autoTempo)
             return;
 
         bool newState = !clipLoopToggle_->isActive();
@@ -807,8 +812,8 @@ void ClipInspector::initClipPropertiesSection() {
         // When enabling, seed source interpretation BPM/source interpretation total beats from
         // cached metadata since the clip model may have stale metadata from TE's default loopInfo.
         const bool sourceInterpretationBpmLooksDefaulted =
-            clip.audio().interpretation.bpm <= 0.0 ||
-            (magda::isValidBpm(bpm) && std::abs(clip.audio().interpretation.bpm - bpm) < 0.1);
+            audioEventRef(clip).interpBpm <= 0.0 ||
+            (magda::isValidBpm(bpm) && std::abs(audioEventRef(clip).interpBpm - bpm) < 0.1);
         if (!sourceInterpretationBpmLooksDefaulted)
             return;
 
@@ -816,15 +821,18 @@ void ClipInspector::initClipPropertiesSection() {
         // carry tempo metadata. setSourceMetadata (from TE's loopInfo) is
         // authoritative when present.
         auto& thumbs = magda::AudioThumbnailManager::getInstance();
-        double cached = thumbs.getCachedBPM(clip.audio().source.filePath);
-        if (cached > 0.0) {
-            clip.audio().interpretation.bpm = cached;
-            if (auto* thumb = thumbs.getThumbnail(clip.audio().source.filePath)) {
+        auto* event = clip.primaryEvent();
+        double cached = event != nullptr ? thumbs.getCachedBPM(event->sourceFilePath()) : 0.0;
+        if (event != nullptr && cached > 0.0) {
+            event->interpBpm = cached;
+            if (auto* thumb = thumbs.getThumbnail(event->sourceFilePath())) {
                 double fileDuration = thumb->getTotalLength();
                 if (fileDuration > 0.0) {
-                    if (clip.audio().source.durationSeconds <= 0.0)
-                        clip.audio().source.durationSeconds = fileDuration;
-                    clip.audio().interpretation.totalBeats = fileDuration * cached / 60.0;
+                    if (auto* src = magda::SourcePool::getInstance().getMutable(event->sourceId);
+                        src != nullptr && src->durationSeconds <= 0.0) {
+                        src->durationSeconds = fileDuration;
+                    }
+                    event->interpTotalBeats = fileDuration * cached / 60.0;
                 }
             }
         }
@@ -868,12 +876,13 @@ void ClipInspector::initClipPropertiesSection() {
         if (targetClipIds.empty())
             return;
 
-        bool newState = !clip->autoTempo;
+        bool newState = !magda::audioEventRef(*clip).autoTempo;
 
         int clipsNeedingStretchReset = 0;
         for (auto cid : targetClipIds) {
             const auto* selectedClip = magda::ClipManager::getInstance().getClip(cid);
-            if (selectedClip && std::abs(selectedClip->speedRatio - 1.0) > 0.001)
+            if (selectedClip &&
+                std::abs(magda::audioEventRef(*selectedClip).speedRatio - 1.0) > 0.001)
                 ++clipsNeedingStretchReset;
         }
 
@@ -881,7 +890,8 @@ void ClipInspector::initClipPropertiesSection() {
             // Show async warning — avoid re-entrancy from synchronous modal loop
             juce::String message = "Auto-tempo mode requires speed ratio 1.0.\n";
             if (clipsNeedingStretchReset == 1 && targetClipIds.size() == 1) {
-                message << "Current stretch (" << juce::String(clip->speedRatio, 2)
+                message << "Current stretch ("
+                        << juce::String(magda::audioEventRef(*clip).speedRatio, 2)
                         << "x) will be reset.\n\nContinue?";
             } else {
                 message << juce::String(clipsNeedingStretchReset)
@@ -923,7 +933,8 @@ void ClipInspector::initClipPropertiesSection() {
         for (auto cid : selectedClipIds_) {
             const auto* c = magda::ClipManager::getInstance().getClip(cid);
             if (c && c->isAudio()) {
-                double newVal = juce::jlimit(0.25, 4.0, c->speedRatio + delta);
+                double newVal =
+                    juce::jlimit(0.25, 4.0, magda::audioEventRef(*c).speedRatio + delta);
                 batch.execute(std::make_unique<magda::SetClipSpeedRatioCommand>(cid, newVal));
             }
         }
@@ -997,7 +1008,8 @@ void ClipInspector::initClipPropertiesSection() {
             if (clip == nullptr || !clip->isAudio()) {
                 continue;
             }
-            clip->audio().interpretation.keyRoot = root;
+            if (auto* event = clip->primaryEvent())
+                event->keyRoot = root;
             magda::ClipManager::getInstance().forceNotifyClipPropertyChanged(cid);
         }
     };
@@ -1014,23 +1026,24 @@ void ClipInspector::initClipPropertiesSection() {
             return;
         }
         const bool savingMidiClip = clip->isMidi();
-        std::optional<std::vector<magda::ClipInfo::WarpMarker>> markers;
+        std::optional<std::vector<magda::WarpMarker>> markers;
         if (clip->isAudio()) {
             const auto bpmText = clipBpmValue_.getText().trimCharactersAtEnd(" BPMbpm");
             const double displayedBpm = bpmText.getDoubleValue();
-            if (magda::isValidBpm(displayedBpm)) {
-                clip->audio().interpretation.bpm = displayedBpm;
+            auto* event = clip->primaryEvent();
+            if (event != nullptr && magda::isValidBpm(displayedBpm)) {
+                event->interpBpm = displayedBpm;
             }
-            if (clipBeatsLengthValue_ && clipBeatsLengthValue_->isVisible()) {
+            if (event != nullptr && clipBeatsLengthValue_ && clipBeatsLengthValue_->isVisible()) {
                 const double displayedBeats = clipBeatsLengthValue_->getValue();
                 if (displayedBeats > 0.0) {
-                    clip->audio().interpretation.totalBeats = displayedBeats;
-                    clip->audio().interpretation.totalBeatsLocked = true;
+                    event->interpTotalBeats = displayedBeats;
+                    event->interpTotalBeatsLocked = true;
                 }
             }
 
-            if (clip->warpEnabled) {
-                markers = std::vector<magda::ClipInfo::WarpMarker>{};
+            if (magda::audioEventRef(*clip).warpEnabled) {
+                markers = std::vector<magda::WarpMarker>{};
                 if (auto* engine = magda::TrackManager::getInstance().getAudioEngine()) {
                     if (auto* bridge = engine->getAudioBridge()) {
                         const auto liveMarkers = bridge->getWarpMarkers(primaryClipId());
@@ -1041,7 +1054,7 @@ void ClipInspector::initClipPropertiesSection() {
                     }
                 }
                 if (markers->empty()) {
-                    *markers = clip->warpMarkers;
+                    *markers = magda::audioEventRef(*clip).warpMarkers;
                 }
             }
         }
@@ -1095,7 +1108,8 @@ void ClipInspector::initClipPropertiesSection() {
         double newLoopStartBeats = clipLoopStartValue_->getValue();
         if (clip->isMidi()) {
             const double newOffsetBeats =
-                juce::jmax(0.0, newLoopStartBeats + clip->midiOffset - clip->loopStartBeats);
+                juce::jmax(0.0, newLoopStartBeats + clip->midiOffset -
+                                    magda::audioEventRef(*clip).loopStartBeats());
             magda::UndoManager::getInstance().beginCompoundOperation("Set Clip Loop Start");
             magda::UndoManager::getInstance().executeCommand(
                 std::make_unique<magda::SetMidiClipLoopStartBeatsCommand>(primaryClipId(),
@@ -1106,7 +1120,8 @@ void ClipInspector::initClipPropertiesSection() {
             return;
         }
 
-        double currentPhase = clip->getSourceOffset() - clip->getSourceLoopStart();
+        double currentPhase = magda::audioEventRef(*clip).anchorSeconds() -
+                              magda::audioEventRef(*clip).loopStartSeconds();
         double newLoopStartSeconds =
             displayBeatsToAudioSourceSeconds(*clip, newLoopStartBeats, bpm);
         newLoopStartSeconds = std::max(0.0, newLoopStartSeconds);
@@ -1151,9 +1166,10 @@ void ClipInspector::initClipPropertiesSection() {
         if (clip->isAudio()) {
             const double newLoopEndSeconds =
                 displayBeatsToAudioSourceSeconds(*clip, newLoopEndBeats, bpm);
-            newLoopLengthSeconds = juce::jmax(0.0, newLoopEndSeconds - clip->getSourceLoopStart());
+            newLoopLengthSeconds =
+                juce::jmax(0.0, newLoopEndSeconds - magda::audioEventRef(*clip).loopStartSeconds());
         } else {
-            double loopStartBeats = clip->loopStartBeats;
+            double loopStartBeats = magda::audioEventRef(*clip).loopStartBeats();
             double newLoopLengthBeats = newLoopEndBeats - loopStartBeats;
             if (newLoopLengthBeats < 0.25)
                 newLoopLengthBeats = 0.25;
@@ -1170,8 +1186,8 @@ void ClipInspector::initClipPropertiesSection() {
 
         if (clip->view == magda::ClipView::Session) {
             double clipEndSeconds = timelineLengthSeconds(*clip, bpm);
-            const double sourceLoopStart = clip->getSourceLoopStart();
-            const double sourceLoopLength = clip->getSourceLoopLength();
+            const double sourceLoopStart = magda::audioEventRef(*clip).loopStartSeconds();
+            const double sourceLoopLength = magda::audioEventRef(*clip).loopLengthSeconds();
             double currentSourceEnd = sourceLoopStart + sourceLoopLength;
             bool sourceEndMatchedClipEnd = std::abs(currentSourceEnd - clipEndSeconds) < 0.001;
             double newSourceEnd = sourceLoopStart + newLoopLengthSeconds;
@@ -1216,8 +1232,8 @@ void ClipInspector::initClipPropertiesSection() {
             return;
 
         double newPhaseOrOffsetBeats = std::max(0.0, clipLoopPhaseValue_->getValue());
-        const bool loopOn =
-            clip->view == magda::ClipView::Session || clip->loopEnabled || clip->autoTempo;
+        const bool loopOn = clip->view == magda::ClipView::Session || clip->loopEnabled ||
+                            magda::audioEventRef(*clip).autoTempo;
         if (clip->isMidi()) {
             // MIDI phase/offset lives in midiOffset (beats)
             magda::UndoManager::getInstance().executeCommand(
@@ -1420,7 +1436,7 @@ void ClipInspector::initPitchSection() {
         auto* clip = magda::ClipManager::getInstance().getClip(primaryClipId());
         if (!clip)
             return;
-        bool newState = !clip->autoPitch;
+        bool newState = !magda::audioEventRef(*clip).autoPitch;
         magda::ClipBatchEdit batch("Set Clip Auto Pitch", selectedClipIds_.size());
         for (auto cid : selectedClipIds_) {
             batch.execute(std::make_unique<magda::SetClipPropertyCommand>(
@@ -1449,7 +1465,7 @@ void ClipInspector::initPitchSection() {
         auto* clip = magda::ClipManager::getInstance().getClip(primaryClipId());
         if (!clip)
             return;
-        bool newState = !clip->analogPitch;
+        bool newState = !magda::audioEventRef(*clip).analogPitch;
         magda::ClipBatchEdit batch("Set Clip Analog Pitch", selectedClipIds_.size());
         for (auto cid : selectedClipIds_) {
             batch.execute(std::make_unique<magda::SetClipPropertyCommand>(
@@ -1540,7 +1556,8 @@ void ClipInspector::initPitchSection() {
             const auto* c = magda::ClipManager::getInstance().getClip(cid);
             if (c && c->isAudio()) {
                 float newVal =
-                    juce::jlimit(-48.0f, 48.0f, c->pitchChange + static_cast<float>(delta));
+                    juce::jlimit(-48.0f, 48.0f,
+                                 magda::audioEventRef(*c).pitchChange + static_cast<float>(delta));
                 batch.execute(std::make_unique<magda::SetClipPitchCommand>(cid, newVal));
             }
         }
@@ -1778,7 +1795,7 @@ void ClipInspector::initPlaybackSection() {
         auto* clip = magda::ClipManager::getInstance().getClip(primaryClipId());
         if (!clip)
             return;
-        bool newState = !clip->isReversed;
+        bool newState = !magda::audioEventRef(*clip).reversed;
         magda::ClipBatchEdit batch("Set Clip Reverse", selectedClipIds_.size());
         for (auto cid : selectedClipIds_) {
             batch.execute(std::make_unique<magda::SetClipReversedCommand>(cid, newState));
@@ -1801,7 +1818,7 @@ void ClipInspector::initPlaybackSection() {
         auto* clip = magda::ClipManager::getInstance().getClip(primaryClipId());
         if (!clip)
             return;
-        bool newState = !clip->autoDetectBeats;
+        bool newState = !magda::audioEventRef(*clip).autoDetectBeats;
         magda::ClipBatchEdit batch("Set Clip Auto Detect Beats", selectedClipIds_.size());
         for (auto cid : selectedClipIds_) {
             batch.execute(std::make_unique<magda::SetClipPropertyCommand>(
@@ -1906,7 +1923,7 @@ void ClipInspector::initChannelsSection() {
         auto* clip = magda::ClipManager::getInstance().getClip(primaryClipId());
         if (!clip)
             return;
-        bool newState = !clip->leftChannelActive;
+        bool newState = !magda::audioEventRef(*clip).leftChannelActive;
         magda::ClipBatchEdit batch("Set Clip Left Channel", selectedClipIds_.size());
         for (auto cid : selectedClipIds_) {
             batch.execute(std::make_unique<magda::SetClipPropertyCommand>(
@@ -1932,7 +1949,7 @@ void ClipInspector::initChannelsSection() {
         auto* clip = magda::ClipManager::getInstance().getClip(primaryClipId());
         if (!clip)
             return;
-        bool newState = !clip->rightChannelActive;
+        bool newState = !magda::audioEventRef(*clip).rightChannelActive;
         magda::ClipBatchEdit batch("Set Clip Right Channel", selectedClipIds_.size());
         for (auto cid : selectedClipIds_) {
             batch.execute(std::make_unique<magda::SetClipPropertyCommand>(

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSections.cpp
@@ -1108,8 +1108,7 @@ void ClipInspector::initClipPropertiesSection() {
         double newLoopStartBeats = clipLoopStartValue_->getValue();
         if (clip->isMidi()) {
             const double newOffsetBeats =
-                juce::jmax(0.0, newLoopStartBeats + clip->midiOffset -
-                                    magda::audioEventRef(*clip).loopStartBeats());
+                juce::jmax(0.0, newLoopStartBeats + clip->midiOffset - clip->loopStartBeats);
             magda::UndoManager::getInstance().beginCompoundOperation("Set Clip Loop Start");
             magda::UndoManager::getInstance().executeCommand(
                 std::make_unique<magda::SetMidiClipLoopStartBeatsCommand>(primaryClipId(),
@@ -1169,7 +1168,7 @@ void ClipInspector::initClipPropertiesSection() {
             newLoopLengthSeconds =
                 juce::jmax(0.0, newLoopEndSeconds - magda::audioEventRef(*clip).loopStartSeconds());
         } else {
-            double loopStartBeats = magda::audioEventRef(*clip).loopStartBeats();
+            double loopStartBeats = clip->loopStartBeats;
             double newLoopLengthBeats = newLoopEndBeats - loopStartBeats;
             if (newLoopLengthBeats < 0.25)
                 newLoopLengthBeats = 0.25;

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSelection.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorSelection.cpp
@@ -60,8 +60,9 @@ void ClipInspector::clipPropertyChanged(magda::ClipId clipId) {
             updateLoopValueDisplays(*clip, projectBPM, beatsPerBar);
 
             // PitchChange affects effective mode.
-            stretchModeCombo_.setSelectedId(clip->getEffectiveTimeStretchMode() + 1,
-                                            juce::dontSendNotification);
+            stretchModeCombo_.setSelectedId(
+                magda::audioEventRef(*clip).getEffectiveTimeStretchMode() + 1,
+                juce::dontSendNotification);
         }
         return;
     }

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
@@ -105,7 +105,7 @@ void ClipInspector::updateLoopValueDisplays(const magda::ClipInfo& clip, double 
         clip.isMidi() ? clip.loopStartBeats : audioEventRef(clip).loopStartBeats();
     clipLoopStartValue_->setValue(loopStartBeats, juce::dontSendNotification);
 
-    double loopLengthDisplayBeats = clip.loopLengthInBeats();
+    double loopLengthDisplayBeats = clip.loopLengthInBeats(loopBpm);
     if (loopLengthDisplayBeats <= 0.0)
         loopLengthDisplayBeats = clip.getLengthInBeats(loopBpm);
     clipLoopEndValue_->setValue(loopStartBeats + loopLengthDisplayBeats,

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
@@ -100,10 +100,12 @@ void ClipInspector::updateLoopValueDisplays(const magda::ClipInfo& clip, double 
         return;
     }
 
-    const double loopStartBeats = audioEventRef(clip).loopStartBeats();
+    // Audio loops a region of its source; MIDI loops clip beats on the clip.
+    const double loopStartBeats =
+        clip.isMidi() ? clip.loopStartBeats : audioEventRef(clip).loopStartBeats();
     clipLoopStartValue_->setValue(loopStartBeats, juce::dontSendNotification);
 
-    double loopLengthDisplayBeats = audioEventRef(clip).loopLengthBeats();
+    double loopLengthDisplayBeats = clip.loopLengthInBeats();
     if (loopLengthDisplayBeats <= 0.0)
         loopLengthDisplayBeats = clip.getLengthInBeats(loopBpm);
     clipLoopEndValue_->setValue(loopStartBeats + loopLengthDisplayBeats,

--- a/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/ClipInspectorState.cpp
@@ -15,15 +15,15 @@ namespace magda::daw::ui {
 namespace {
 
 double getAudioFileDurationForInspector(const magda::ClipInfo& clip) {
-    if (!clip.isAudio() || clip.audio().source.filePath.isEmpty())
+    if (!clip.isAudio() || audioEventRef(clip).sourceFilePath().isEmpty())
         return 0.0;
 
     if (auto* thumbnail = magda::AudioThumbnailManager::getInstance().getThumbnail(
-            clip.audio().source.filePath)) {
+            audioEventRef(clip).sourceFilePath())) {
         return thumbnail->getTotalLength();
     }
 
-    return clip.audio().source.durationSeconds;
+    return audioEventRef(clip).sourceDurationSeconds();
 }
 
 double timelineStartSeconds(const magda::ClipInfo& clip, double bpm) {
@@ -48,8 +48,8 @@ void ClipInspector::updateAudioSourceValueDisplays(const magda::ClipInfo& clip) 
     // Shared with the audio-editor inspector so the two can't drift.
     const double projectBPM =
         timelineController_ ? timelineController_->getState().tempo.bpm : 120.0;
-    const double cachedBpm =
-        magda::AudioThumbnailManager::getInstance().getCachedBPM(clip.audio().source.filePath);
+    const double cachedBpm = magda::AudioThumbnailManager::getInstance().getCachedBPM(
+        audioEventRef(clip).sourceFilePath());
     const auto display = magda::computeAudioClipSourceDisplay(
         clip, projectBPM, getAudioFileDurationForInspector(clip), cachedBpm);
 
@@ -59,7 +59,8 @@ void ClipInspector::updateAudioSourceValueDisplays(const magda::ClipInfo& clip) 
         clipBpmValue_.setText(juce::String::fromUTF8("\xe2\x80\x94"), juce::dontSendNotification);
     }
 
-    if (clip.autoTempo && clipBeatsLengthValue_ && !clipBeatsLengthValue_->isDragging()) {
+    if (audioEventRef(clip).autoTempo && clipBeatsLengthValue_ &&
+        !clipBeatsLengthValue_->isDragging()) {
         clipBeatsLengthValue_->setValue(display.totalBeats > 0.0 ? display.totalBeats : 4.0,
                                         juce::dontSendNotification);
     }
@@ -79,8 +80,8 @@ void ClipInspector::updateLoopValueDisplays(const magda::ClipInfo& clip, double 
     if (clip.isAudio()) {
         const auto info =
             magda::ClipDisplayInfo::from(clip, loopBpm, getAudioFileDurationForInspector(clip));
-        const bool loopOn =
-            clip.view == magda::ClipView::Session || clip.loopEnabled || clip.autoTempo;
+        const bool loopOn = clip.view == magda::ClipView::Session || clip.loopEnabled ||
+                            audioEventRef(clip).autoTempo;
 
         clipLoopStartValue_->setValue(
             magda::TimelineUtils::secondsToBeats(info.loopStartPositionSeconds, loopBpm),
@@ -99,22 +100,25 @@ void ClipInspector::updateLoopValueDisplays(const magda::ClipInfo& clip, double 
         return;
     }
 
-    const double loopStartBeats = clip.loopStartBeats;
+    const double loopStartBeats = audioEventRef(clip).loopStartBeats();
     clipLoopStartValue_->setValue(loopStartBeats, juce::dontSendNotification);
 
-    double loopLengthDisplayBeats = clip.loopLengthBeats;
+    double loopLengthDisplayBeats = audioEventRef(clip).loopLengthBeats();
     if (loopLengthDisplayBeats <= 0.0)
         loopLengthDisplayBeats = clip.getLengthInBeats(loopBpm);
     clipLoopEndValue_->setValue(loopStartBeats + loopLengthDisplayBeats,
                                 juce::dontSendNotification);
 
-    const bool loopOn = clip.view == magda::ClipView::Session || clip.loopEnabled || clip.autoTempo;
+    const bool loopOn =
+        clip.view == magda::ClipView::Session || clip.loopEnabled || audioEventRef(clip).autoTempo;
     clipLoopPhaseLabel_.setText(loopOn ? "phase" : "offset", juce::dontSendNotification);
 
     if (clip.isMidi()) {
         clipLoopPhaseValue_->setValue(clip.midiOffset, juce::dontSendNotification);
     } else {
-        const double sourcePositionSeconds = loopOn ? clip.offset - clip.loopStart : clip.offset;
+        const double sourcePositionSeconds =
+            loopOn ? audioEventRef(clip).anchorSeconds() - audioEventRef(clip).loopStartSeconds()
+                   : audioEventRef(clip).anchorSeconds();
         const double sourcePositionBeats =
             magda::TimelineUtils::secondsToBeats(juce::jmax(0.0, sourcePositionSeconds), loopBpm);
         clipLoopPhaseValue_->setValue(sourcePositionBeats, juce::dontSendNotification);
@@ -149,15 +153,15 @@ void ClipInspector::updateFromSelectedClip() {
     if (!isMulti) {
         auto* mutableClip = magda::ClipManager::getInstance().getClip(pid);
         if (mutableClip && mutableClip->isAudio() &&
-            !mutableClip->audio().source.filePath.isEmpty()) {
+            !magda::audioEventRef(*mutableClip).sourceFilePath().isEmpty()) {
             auto* thumbnail = magda::AudioThumbnailManager::getInstance().getThumbnail(
-                mutableClip->audio().source.filePath);
+                magda::audioEventRef(*mutableClip).sourceFilePath());
             if (thumbnail) {
                 const double fileDur = thumbnail->getTotalLength();
                 if (fileDur > 0.0) {
-                    double newOffset = mutableClip->offset;
-                    double newLoopStart = mutableClip->loopStart;
-                    double newLoopLength = mutableClip->loopLength;
+                    double newOffset = magda::audioEventRef(*mutableClip).anchorSeconds();
+                    double newLoopStart = magda::audioEventRef(*mutableClip).loopStartSeconds();
+                    double newLoopLength = magda::audioEventRef(*mutableClip).loopLengthSeconds();
 
                     bool fixed = false;
 
@@ -180,15 +184,16 @@ void ClipInspector::updateFromSelectedClip() {
                     if (fixed) {
                         auto& clipManager = magda::ClipManager::getInstance();
 
-                        if (newOffset != mutableClip->offset) {
+                        if (newOffset != magda::audioEventRef(*mutableClip).anchorSeconds()) {
                             clipManager.setOffset(pid, newOffset);
                         }
 
-                        if (newLoopStart != mutableClip->loopStart) {
+                        if (newLoopStart != magda::audioEventRef(*mutableClip).loopStartSeconds()) {
                             clipManager.setLoopStart(pid, newLoopStart);
                         }
 
-                        if (newLoopLength != mutableClip->loopLength) {
+                        if (newLoopLength !=
+                            magda::audioEventRef(*mutableClip).loopLengthSeconds()) {
                             clipManager.setLoopLength(pid, newLoopLength);
                         }
 
@@ -216,7 +221,7 @@ void ClipInspector::updateFromSelectedClip() {
         // For loop-record takes/comps the raw render filename is meaningless, so
         // show a take/comp label instead.
         if (!isMulti && clip->view != magda::ClipView::Session && clip->isAudio() &&
-            clip->audio().source.filePath.isNotEmpty()) {
+            magda::audioEventRef(*clip).sourceFilePath().isNotEmpty()) {
             const auto& audio = clip->audio();
             juce::String label;
             if (audio.compActive)
@@ -225,9 +230,9 @@ void ClipInspector::updateFromSelectedClip() {
                 label = "Take " + juce::String(audio.currentTakeIndex + 1) + " / " +
                         juce::String(static_cast<int>(audio.takes.size()));
             else
-                label = juce::File(audio.source.filePath).getFileName();
+                label = juce::File(magda::audioEventRef(*clip).sourceFilePath()).getFileName();
             clipFilePathLabel_.setText(label, juce::dontSendNotification);
-            clipFilePathLabel_.setTooltip(audio.source.filePath);
+            clipFilePathLabel_.setTooltip(magda::audioEventRef(*clip).sourceFilePath());
         } else if (!isMulti && clip->view != magda::ClipView::Session && clip->isMidi() &&
                    clip->midi().sourceFilePath.isNotEmpty()) {
             juce::File sourceFile(clip->midi().sourceFilePath);
@@ -307,15 +312,15 @@ void ClipInspector::updateFromSelectedClip() {
         // Show BPM for audio clips (at bottom with WARP)
         // Prefer clip's source interpretation BPM (may be user-edited), fall back to detected BPM
         if (showAudioProps && !isMulti) {
-            double displayBPM = clip->audio().interpretation.bpm;
+            double displayBPM = magda::audioEventRef(*clip).interpBpm;
             double projectBPM =
                 timelineController_ ? timelineController_->getState().tempo.bpm : 120.0;
-            if (displayBPM <= 0.0 ||
-                (!clip->autoTempo && std::abs(displayBPM - projectBPM) < 0.1)) {
+            if (displayBPM <= 0.0 || (!magda::audioEventRef(*clip).autoTempo &&
+                                      std::abs(displayBPM - projectBPM) < 0.1)) {
                 // Source interpretation BPM is unset/defaulted. Read cached metadata only;
                 // do not launch DSP BPM analysis from display code.
                 auto& thumbs = magda::AudioThumbnailManager::getInstance();
-                displayBPM = thumbs.getCachedBPM(clip->audio().source.filePath);
+                displayBPM = thumbs.getCachedBPM(magda::audioEventRef(*clip).sourceFilePath());
             }
             clipBpmValue_.setVisible(true);
             clipBpmUnitLabel_.setVisible(true);
@@ -323,7 +328,7 @@ void ClipInspector::updateFromSelectedClip() {
             // time-based mode the engine uses speedRatio and never reads it, so
             // grey it out — the mirror of how the speed control is disabled in
             // beat mode.
-            const bool sourceBpmActive = clip->autoTempo;
+            const bool sourceBpmActive = magda::audioEventRef(*clip).autoTempo;
             clipBpmValue_.setEnabled(sourceBpmActive);
             clipBpmValue_.setAlpha(sourceBpmActive ? 1.0f : 0.4f);
             clipBpmUnitLabel_.setAlpha(sourceBpmActive ? 1.0f : 0.4f);
@@ -335,7 +340,7 @@ void ClipInspector::updateFromSelectedClip() {
 
         // Show source interpretation total beats for audio clips with auto-tempo enabled.
         // Clip placement length is already represented by start/end and by the clip body itself.
-        if (showAudioProps && clip->autoTempo && !isMulti) {
+        if (showAudioProps && magda::audioEventRef(*clip).autoTempo && !isMulti) {
             clipBeatsLengthValue_->setVisible(true);
             clipBeatsUnitLabel_.setVisible(true);
             clipBeatsLengthValue_->setEnabled(true);
@@ -349,7 +354,7 @@ void ClipInspector::updateFromSelectedClip() {
         // Show key controls for audio clips. Mirror the clip's source
         // interpretation root into the combo; empty = "--" (unknown).
         if (showAudioProps && !isMulti) {
-            const auto& root = clip->audio().interpretation.keyRoot;
+            const auto& root = magda::audioEventRef(*clip).keyRoot;
             int rootId = 1;
             static constexpr const char* kRoots[] = {"C",  "C#", "D",  "D#", "E",  "F",
                                                      "F#", "G",  "G#", "A",  "A#", "B"};
@@ -426,13 +431,13 @@ void ClipInspector::updateFromSelectedClip() {
             clipLengthValue_->setValue(clip->getLengthInBeats(bpm), juce::dontSendNotification);
         }
 
-        clipLoopToggle_->setActive(clip->loopEnabled || clip->autoTempo);
+        clipLoopToggle_->setActive(clip->loopEnabled || magda::audioEventRef(*clip).autoTempo);
         // Beat mode forces loop on, but the button should still read as active rather than
         // disabled. Click handling ignores attempts to toggle it while auto-tempo owns looping.
         clipLoopToggle_->setEnabled(true);
 
         // Loop state determines source-row labels/interactivity.
-        bool loopOn = isSessionClip || clip->loopEnabled || clip->autoTempo;
+        bool loopOn = isSessionClip || clip->loopEnabled || magda::audioEventRef(*clip).autoTempo;
         updateLoopValueDisplays(*clip, bpm, beatsPerBar);
 
         if (loopOn) {
@@ -478,32 +483,36 @@ void ClipInspector::updateFromSelectedClip() {
         // Warp toggle (visible when audio props expanded)
         clipWarpToggle_.setVisible(showAudioProps);
         if (isAudioClip) {
-            clipWarpToggle_.setToggleState(clip->warpEnabled, juce::dontSendNotification);
+            clipWarpToggle_.setToggleState(magda::audioEventRef(*clip).warpEnabled,
+                                           juce::dontSendNotification);
         }
 
         // Auto-tempo toggle
         clipAutoTempoToggle_.setVisible(showAudioProps);
         if (isAudioClip) {
-            clipAutoTempoToggle_.setToggleState(clip->autoTempo, juce::dontSendNotification);
+            clipAutoTempoToggle_.setToggleState(magda::audioEventRef(*clip).autoTempo,
+                                                juce::dontSendNotification);
             // Disable stretch control when auto-tempo is enabled (speedRatio must be 1.0)
-            if (clip->autoTempo && clipStretchValue_) {
+            if (magda::audioEventRef(*clip).autoTempo && clipStretchValue_) {
                 clipStretchValue_->setEnabled(false);
                 clipStretchValue_->setAlpha(0.4f);
             }
         }
 
-        clipStretchValue_->setVisible(showAudioProps && !clip->autoTempo);
+        clipStretchValue_->setVisible(showAudioProps && !magda::audioEventRef(*clip).autoTempo);
         stretchModeCombo_.setVisible(showAudioProps);
         if (isAudioClip) {
-            clipStretchValue_->setValue(clip->speedRatio, juce::dontSendNotification);
+            clipStretchValue_->setValue(magda::audioEventRef(*clip).speedRatio,
+                                        juce::dontSendNotification);
             // Show the effective stretch mode (auto-upgraded when beat mode / warp
             // / speed / pitch silently engages TE's SoundTouch) so this matches
             // the audio editor's readout.
-            stretchModeCombo_.setSelectedId(clip->getEffectiveTimeStretchMode() + 1,
-                                            juce::dontSendNotification);
+            stretchModeCombo_.setSelectedId(
+                magda::audioEventRef(*clip).getEffectiveTimeStretchMode() + 1,
+                juce::dontSendNotification);
 
             // Enable/disable stretch controls based on auto-tempo mode
-            if (!clip->autoTempo && clipStretchValue_) {
+            if (!magda::audioEventRef(*clip).autoTempo && clipStretchValue_) {
                 clipStretchValue_->setEnabled(true);
                 clipStretchValue_->setAlpha(1.0f);
             }
@@ -551,23 +560,28 @@ void ClipInspector::updateFromSelectedClip() {
         midiTransposeLabel_.setVisible(isMidiClip);
 
         // Analog pitch toggle: visible for audio clips when not in autoTempo/warp mode
-        bool canAnalog = showAudioProps && !clip->autoTempo && !clip->warpEnabled;
+        bool canAnalog = showAudioProps && !magda::audioEventRef(*clip).autoTempo &&
+                         !magda::audioEventRef(*clip).warpEnabled;
         analogPitchToggle_.setVisible(canAnalog);
         if (canAnalog) {
-            analogPitchToggle_.setToggleState(clip->analogPitch, juce::dontSendNotification);
+            analogPitchToggle_.setToggleState(magda::audioEventRef(*clip).analogPitch,
+                                              juce::dontSendNotification);
         }
 
         if (isAudioClip) {
-            autoPitchToggle_.setToggleState(clip->autoPitch, juce::dontSendNotification);
-            autoPitchModeCombo_.setSelectedId(clip->autoPitchMode + 1, juce::dontSendNotification);
-            pitchChangeValue_->setValue(clip->pitchChange, juce::dontSendNotification);
+            autoPitchToggle_.setToggleState(magda::audioEventRef(*clip).autoPitch,
+                                            juce::dontSendNotification);
+            autoPitchModeCombo_.setSelectedId(magda::audioEventRef(*clip).autoPitchMode + 1,
+                                              juce::dontSendNotification);
+            pitchChangeValue_->setValue(magda::audioEventRef(*clip).pitchChange,
+                                        juce::dontSendNotification);
 
             // autoPitchMode only meaningful when autoPitch is on
-            autoPitchModeCombo_.setEnabled(clip->autoPitch);
-            autoPitchModeCombo_.setAlpha(clip->autoPitch ? 1.0f : 0.4f);
+            autoPitchModeCombo_.setEnabled(magda::audioEventRef(*clip).autoPitch);
+            autoPitchModeCombo_.setAlpha(magda::audioEventRef(*clip).autoPitch ? 1.0f : 0.4f);
 
             // When analogPitch is active: disable/dim speedRatio control
-            bool analogActive = clip->isAnalogPitchActive();
+            bool analogActive = magda::audioEventRef(*clip).isAnalogPitchActive();
 
             // When analog pitch is active, dim the speed ratio control
             if (analogActive && clipStretchValue_) {
@@ -608,7 +622,8 @@ void ClipInspector::updateFromSelectedClip() {
             clipVolumeValue_->setValue(clip->volumeDB, juce::dontSendNotification);
             clipPanValue_->setValue(clip->pan, juce::dontSendNotification);
             clipGainValue_->setValue(clip->gainDB, juce::dontSendNotification);
-            reverseToggle_.setToggleState(clip->isReversed, juce::dontSendNotification);
+            reverseToggle_.setToggleState(magda::audioEventRef(*clip).reversed,
+                                          juce::dontSendNotification);
         }
 
         // Playback / Beat Detection section — hidden (all controls moved or unused)
@@ -794,35 +809,44 @@ void ClipInspector::computeClipRange() {
 
         if (first) {
             clipRange_.valid = true;
-            clipRange_.minPitchChange = clipRange_.maxPitchChange = c->pitchChange;
+            clipRange_.minPitchChange = clipRange_.maxPitchChange =
+                magda::audioEventRef(*c).pitchChange;
             clipRange_.minVolumeDB = clipRange_.maxVolumeDB = c->volumeDB;
             clipRange_.minPan = clipRange_.maxPan = c->pan;
             clipRange_.minGainDB = clipRange_.maxGainDB = c->gainDB;
-            clipRange_.minSpeedRatio = clipRange_.maxSpeedRatio = c->speedRatio;
+            clipRange_.minSpeedRatio = clipRange_.maxSpeedRatio =
+                magda::audioEventRef(*c).speedRatio;
             clipRange_.minStartSeconds = clipRange_.maxStartSeconds = timelineStartSeconds(*c, bpm);
             clipRange_.minLengthSeconds = clipRange_.maxLengthSeconds =
                 timelineLengthSeconds(*c, bpm);
-            clipRange_.minOffsetSeconds = clipRange_.maxOffsetSeconds = c->offset;
+            clipRange_.minOffsetSeconds = clipRange_.maxOffsetSeconds =
+                magda::audioEventRef(*c).anchorSeconds();
             first = false;
         } else {
-            clipRange_.minPitchChange = juce::jmin(clipRange_.minPitchChange, c->pitchChange);
-            clipRange_.maxPitchChange = juce::jmax(clipRange_.maxPitchChange, c->pitchChange);
+            clipRange_.minPitchChange =
+                juce::jmin(clipRange_.minPitchChange, magda::audioEventRef(*c).pitchChange);
+            clipRange_.maxPitchChange =
+                juce::jmax(clipRange_.maxPitchChange, magda::audioEventRef(*c).pitchChange);
             clipRange_.minVolumeDB = juce::jmin(clipRange_.minVolumeDB, c->volumeDB);
             clipRange_.maxVolumeDB = juce::jmax(clipRange_.maxVolumeDB, c->volumeDB);
             clipRange_.minPan = juce::jmin(clipRange_.minPan, c->pan);
             clipRange_.maxPan = juce::jmax(clipRange_.maxPan, c->pan);
             clipRange_.minGainDB = juce::jmin(clipRange_.minGainDB, c->gainDB);
             clipRange_.maxGainDB = juce::jmax(clipRange_.maxGainDB, c->gainDB);
-            clipRange_.minSpeedRatio = juce::jmin(clipRange_.minSpeedRatio, c->speedRatio);
-            clipRange_.maxSpeedRatio = juce::jmax(clipRange_.maxSpeedRatio, c->speedRatio);
+            clipRange_.minSpeedRatio =
+                juce::jmin(clipRange_.minSpeedRatio, magda::audioEventRef(*c).speedRatio);
+            clipRange_.maxSpeedRatio =
+                juce::jmax(clipRange_.maxSpeedRatio, magda::audioEventRef(*c).speedRatio);
             const double startSeconds = timelineStartSeconds(*c, bpm);
             const double lengthSeconds = timelineLengthSeconds(*c, bpm);
             clipRange_.minStartSeconds = juce::jmin(clipRange_.minStartSeconds, startSeconds);
             clipRange_.maxStartSeconds = juce::jmax(clipRange_.maxStartSeconds, startSeconds);
             clipRange_.minLengthSeconds = juce::jmin(clipRange_.minLengthSeconds, lengthSeconds);
             clipRange_.maxLengthSeconds = juce::jmax(clipRange_.maxLengthSeconds, lengthSeconds);
-            clipRange_.minOffsetSeconds = juce::jmin(clipRange_.minOffsetSeconds, c->offset);
-            clipRange_.maxOffsetSeconds = juce::jmax(clipRange_.maxOffsetSeconds, c->offset);
+            clipRange_.minOffsetSeconds =
+                juce::jmin(clipRange_.minOffsetSeconds, magda::audioEventRef(*c).anchorSeconds());
+            clipRange_.maxOffsetSeconds =
+                juce::jmax(clipRange_.maxOffsetSeconds, magda::audioEventRef(*c).anchorSeconds());
         }
     }
 }

--- a/magda/daw/ui/panels/content/inspector/clip/sections/ClipFadesSection.cpp
+++ b/magda/daw/ui/panels/content/inspector/clip/sections/ClipFadesSection.cpp
@@ -58,7 +58,7 @@ void ClipFadesSection::initControls() {
         for (auto cid : selectedClipIds_) {
             const auto* c = magda::ClipManager::getInstance().getClip(cid);
             if (c && c->isAudio() && c->view != magda::ClipView::Session) {
-                double newVal = juce::jmax(0.0, c->fadeIn + delta);
+                double newVal = juce::jmax(0.0, magda::audioEventRef(*c).fadeInSeconds + delta);
                 batch.execute(std::make_unique<magda::SetClipFadeInCommand>(cid, newVal));
             }
         }
@@ -82,7 +82,7 @@ void ClipFadesSection::initControls() {
         for (auto cid : selectedClipIds_) {
             const auto* c = magda::ClipManager::getInstance().getClip(cid);
             if (c && c->isAudio() && c->view != magda::ClipView::Session) {
-                double newVal = juce::jmax(0.0, c->fadeOut + delta);
+                double newVal = juce::jmax(0.0, magda::audioEventRef(*c).fadeOutSeconds + delta);
                 batch.execute(std::make_unique<magda::SetClipFadeOutCommand>(cid, newVal));
             }
         }
@@ -377,17 +377,19 @@ void ClipFadesSection::update() {
         bool isMulti = selectedClipIds_.size() > 1;
         if (isMulti) {
             // Show midpoint, set drag starts
-            double minIn = clip->fadeIn, maxIn = clip->fadeIn;
-            double minOut = clip->fadeOut, maxOut = clip->fadeOut;
+            double minIn = magda::audioEventRef(*clip).fadeInSeconds,
+                   maxIn = magda::audioEventRef(*clip).fadeInSeconds;
+            double minOut = magda::audioEventRef(*clip).fadeOutSeconds,
+                   maxOut = magda::audioEventRef(*clip).fadeOutSeconds;
             for (auto cid : selectedClipIds_) {
                 if (cid == pid)
                     continue;
                 const auto* c = magda::ClipManager::getInstance().getClip(cid);
                 if (c && c->isAudio()) {
-                    minIn = juce::jmin(minIn, (double)c->fadeIn);
-                    maxIn = juce::jmax(maxIn, (double)c->fadeIn);
-                    minOut = juce::jmin(minOut, (double)c->fadeOut);
-                    maxOut = juce::jmax(maxOut, (double)c->fadeOut);
+                    minIn = juce::jmin(minIn, (double)magda::audioEventRef(*c).fadeInSeconds);
+                    maxIn = juce::jmax(maxIn, (double)magda::audioEventRef(*c).fadeInSeconds);
+                    minOut = juce::jmin(minOut, (double)magda::audioEventRef(*c).fadeOutSeconds);
+                    maxOut = juce::jmax(maxOut, (double)magda::audioEventRef(*c).fadeOutSeconds);
                 }
             }
             double midIn = (minIn + maxIn) / 2.0;
@@ -408,19 +410,23 @@ void ClipFadesSection::update() {
             // so reflect that state — otherwise multi-select clicks look inert.
             autoCrossfadeToggle_.setToggleState(clip->autoCrossfade, juce::dontSendNotification);
         } else {
-            fadeInValue_->setValue(clip->fadeIn, juce::dontSendNotification);
-            fadeOutValue_->setValue(clip->fadeOut, juce::dontSendNotification);
+            fadeInValue_->setValue(magda::audioEventRef(*clip).fadeInSeconds,
+                                   juce::dontSendNotification);
+            fadeOutValue_->setValue(magda::audioEventRef(*clip).fadeOutSeconds,
+                                    juce::dontSendNotification);
             fadeInValue_->clearTextOverride();
             fadeOutValue_->clearTextOverride();
-            multiFadeInDragStart_ = clip->fadeIn;
-            multiFadeOutDragStart_ = clip->fadeOut;
+            multiFadeInDragStart_ = magda::audioEventRef(*clip).fadeInSeconds;
+            multiFadeOutDragStart_ = magda::audioEventRef(*clip).fadeOutSeconds;
             for (int i = 0; i < 4; ++i) {
-                fadeInTypeButtons_[i]->setActive(i == clip->fadeInType - 1);
-                fadeOutTypeButtons_[i]->setActive(i == clip->fadeOutType - 1);
+                fadeInTypeButtons_[i]->setActive(i == magda::audioEventRef(*clip).fadeInType - 1);
+                fadeOutTypeButtons_[i]->setActive(i == magda::audioEventRef(*clip).fadeOutType - 1);
             }
             for (int i = 0; i < 2; ++i) {
-                fadeInBehaviourButtons_[i]->setActive(i == clip->fadeInBehaviour);
-                fadeOutBehaviourButtons_[i]->setActive(i == clip->fadeOutBehaviour);
+                fadeInBehaviourButtons_[i]->setActive(i ==
+                                                      magda::audioEventRef(*clip).fadeInBehaviour);
+                fadeOutBehaviourButtons_[i]->setActive(
+                    i == magda::audioEventRef(*clip).fadeOutBehaviour);
             }
             autoCrossfadeToggle_.setToggleState(clip->autoCrossfade, juce::dontSendNotification);
         }

--- a/magda/daw/ui/views/SessionClipEditor.cpp
+++ b/magda/daw/ui/views/SessionClipEditor.cpp
@@ -33,7 +33,7 @@ class SessionClipEditor::WaveformDisplay : public juce::Component {
 
         // Get clip info
         const auto* clip = ClipManager::getInstance().getClip(clipId_);
-        if (!clip || !clip->isAudio() || clip->audio().source.filePath.isEmpty()) {
+        if (!clip || !clip->isAudio() || magda::audioEventRef(*clip).sourceFilePath().isEmpty()) {
             // No waveform to show
             g.setColour(DarkTheme::getSecondaryTextColour());
             g.setFont(FontManager::getInstance().getUIFont(14.0f));
@@ -44,8 +44,8 @@ class SessionClipEditor::WaveformDisplay : public juce::Component {
         auto waveformBounds = bounds.reduced(MARGIN);
 
         // Get waveform from cache
-        auto* thumbnail =
-            magda::AudioThumbnailManager::getInstance().getThumbnail(clip->audio().source.filePath);
+        auto* thumbnail = magda::AudioThumbnailManager::getInstance().getThumbnail(
+            magda::audioEventRef(*clip).sourceFilePath());
         if (thumbnail && thumbnail->getTotalLength() > 0.0) {
             // Build display info using project BPM, passing the file
             // duration so sourceFileStart / sourceFileEnd describe the
@@ -66,7 +66,7 @@ class SessionClipEditor::WaveformDisplay : public juce::Component {
             g.setColour(DarkTheme::getColour(DarkTheme::ACCENT_PRIMARY));
             thumbnail->drawChannels(g, waveformBounds, startTime, endTime, 1.0f);
 
-            if (clip->isReversed && di.fileExtentTimeline() > 0.0 &&
+            if (magda::audioEventRef(*clip).reversed && di.fileExtentTimeline() > 0.0 &&
                 di.activeRegionEndPositionSeconds > di.activeRegionStartPositionSeconds) {
                 const double pixelsPerTimelineSecond =
                     waveformBounds.getWidth() / di.fileExtentTimeline();
@@ -355,8 +355,9 @@ void SessionClipEditor::updateControls() {
                           juce::dontSendNotification);
 
     // Update offset slider
-    if (clip->audio().source.filePath.isNotEmpty()) {
-        offsetSlider_->setValue(clip->offset, juce::dontSendNotification);
+    if (magda::audioEventRef(*clip).sourceFilePath().isNotEmpty()) {
+        offsetSlider_->setValue(magda::audioEventRef(*clip).anchorSeconds(),
+                                juce::dontSendNotification);
     }
 
     fadesSection_->setClip(clipId_);

--- a/tests/AudioClipTestHelpers.hpp
+++ b/tests/AudioClipTestHelpers.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "core/ClipInfo.hpp"
+#include "core/SourcePool.hpp"
+
+namespace magda::test {
+
+/// Sample rate model tests pretend their sources have.
+///
+/// An event's anchor and loop region are stored in source samples, so a test
+/// that never touches disk still needs the pool to report a rate. Seeding one
+/// keeps the seconds <-> samples round trip exact instead of silently falling
+/// back to kUnresolvedSourceSampleRate.
+constexpr double kTestSourceSampleRate = 48000.0;
+
+/// Give a clip a single audio event reading a (fake) file.
+///
+/// Mirrors what ClipManager::createAudioClipBeats builds: one event spanning
+/// the clip, on a pooled source. Returns the event so the test can set its
+/// interpretation.
+inline AudioEvent& giveAudioEvent(ClipInfo& clip, const juce::String& filePath,
+                                  double durationSeconds = 0.0,
+                                  double sampleRate = kTestSourceSampleRate) {
+    clip.setAudioContent();
+
+    auto& pool = SourcePool::getInstance();
+    pool.seedFactsForTesting(filePath, durationSeconds, sampleRate);
+
+    AudioEvent event;
+    event.sourceId = pool.acquire(filePath);
+    auto& added = clip.audio().addEvent(std::move(event));
+    clip.syncSingleEventToClipBounds();
+    return added;
+}
+
+/// Set the pooled source's on-disk duration for an existing event.
+///
+/// Duration is a Source fact, not an event field, so a test that wants one
+/// seeds the pool and re-resolves rather than writing it on the clip.
+inline void setSourceDuration(ClipInfo& clip, double durationSeconds,
+                              double sampleRate = kTestSourceSampleRate) {
+    auto* event = clip.primaryEvent();
+    if (event == nullptr)
+        return;
+
+    auto& pool = SourcePool::getInstance();
+    if (event->sourceId == INVALID_SOURCE_ID) {
+        // The test never named a file, so give the event one: a duration has
+        // to live on a pooled Source. The path is unique per call so unrelated
+        // tests never end up sharing (and overwriting) one source.
+        static int syntheticSourceCount = 0;
+        event->sourceId =
+            pool.acquire("magda_test_source_" + juce::String(++syntheticSourceCount) + ".wav");
+    }
+
+    pool.seedFactsForTesting(event->sourceFilePath(), durationSeconds, sampleRate);
+    pool.resolveFacts(event->sourceId);
+    if (auto* source = pool.getMutable(event->sourceId))
+        source->durationSeconds = durationSeconds;
+}
+
+/// Mutable primary audio event, created on demand.
+///
+/// A test that only does `clip.setAudioContent()` has an audio clip with no
+/// event yet; giving it one here means every test can keep writing single
+/// fields without first deciding on a source file.
+inline AudioEvent& audioEvent(ClipInfo& clip) {
+    jassert(clip.isAudio());
+    if (clip.audio().events.empty()) {
+        clip.audio().addEvent({});
+        clip.syncSingleEventToClipBounds();
+    }
+    return *clip.primaryEvent();
+}
+
+}  // namespace magda::test

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,9 @@ set(TEST_SOURCES
     test_auto_tempo.cpp
     test_audio_clip_stretch.cpp
     test_clip_bpm_invariant.cpp
+    test_source_pool.cpp
+    test_clip_event_model.cpp
+    test_clip_schema_migration.cpp
     test_audio_source_length.cpp
     test_audio_export.cpp
     test_offline_render_contract.cpp
@@ -327,6 +330,7 @@ target_sources(magda_juce_tests PRIVATE
     test_section_scoped_device_ids_juce.cpp
     test_clip_inspector_juce.cpp
     test_multi_clip_resize_preview_juce.cpp
+    test_clip_paint_juce.cpp
     test_clip_nudge_juce.cpp
     test_multiband_curve_view_juce.cpp
     test_timeline_extreme_zoom_paint_juce.cpp

--- a/tests/test_audio_clip_stretch.cpp
+++ b/tests/test_audio_clip_stretch.cpp
@@ -4,6 +4,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include "AudioClipTestHelpers.hpp"
 #include "magda/daw/core/ClipInfo.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/ClipOperations.hpp"
@@ -25,25 +26,25 @@ TEST_CASE("Audio clip - Stretch factor basics", "[audio][clip][stretch]") {
     SECTION("Default stretch factor is 1.0") {
         ClipInfo clip;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
+        magda::test::giveAudioEvent(clip, "test.wav");
         clip.length = 4.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         // File window equals length when stretch factor is 1.0
-        double fileWindow = clip.length * clip.speedRatio;
+        double fileWindow = clip.length * magda::test::audioEvent(clip).speedRatio;
         REQUIRE(fileWindow == 4.0);
     }
 
     SECTION("Stretch factor affects file time window") {
         ClipInfo clip;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
         clip.length = 4.0;
-        clip.speedRatio = 2.0;  // 2x faster
+        magda::test::audioEvent(clip).speedRatio = 2.0;  // 2x faster
 
         // File window is double the length when 2x faster
-        double fileWindow = clip.length * clip.speedRatio;
+        double fileWindow = clip.length * magda::test::audioEvent(clip).speedRatio;
         REQUIRE(fileWindow == 8.0);
 
         // Reading from file offset 0-8, displaying as 0-4 seconds
@@ -52,13 +53,13 @@ TEST_CASE("Audio clip - Stretch factor basics", "[audio][clip][stretch]") {
     SECTION("Stretch factor 0.5 = 2x slower") {
         ClipInfo clip;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
         clip.length = 8.0;
-        clip.speedRatio = 0.5;  // 2x slower
+        magda::test::audioEvent(clip).speedRatio = 0.5;  // 2x slower
 
         // File window is half the length when 2x slower
-        double fileWindow = clip.length * clip.speedRatio;
+        double fileWindow = clip.length * magda::test::audioEvent(clip).speedRatio;
         REQUIRE(fileWindow == 4.0);
 
         // Reading from file offset 0-4, displaying as 0-8 seconds
@@ -77,22 +78,22 @@ TEST_CASE("ClipManager - setSpeedRatio clamping", "[audio][clip][stretch]") {
 
         const auto* clip = ClipManager::getInstance().getClip(clipId);
         REQUIRE(clip != nullptr);
-        REQUIRE(clip->audio().source.filePath == "test.wav");
+        REQUIRE(primaryEventOf(clip)->sourceFilePath() == "test.wav");
 
         // Test minimum clamp
         ClipManager::getInstance().setSpeedRatio(clipId, 0.1);
-        REQUIRE(clip->speedRatio == 0.25);
+        REQUIRE(primaryEventOf(clip)->speedRatio == 0.25);
 
         // Test maximum clamp
         ClipManager::getInstance().setSpeedRatio(clipId, 10.0);
-        REQUIRE(clip->speedRatio == 4.0);
+        REQUIRE(primaryEventOf(clip)->speedRatio == 4.0);
 
         // Test valid range
         ClipManager::getInstance().setSpeedRatio(clipId, 1.5);
-        REQUIRE(clip->speedRatio == 1.5);
+        REQUIRE(primaryEventOf(clip)->speedRatio == 1.5);
 
         ClipManager::getInstance().setSpeedRatio(clipId, 0.5);
-        REQUIRE(clip->speedRatio == 0.5);
+        REQUIRE(primaryEventOf(clip)->speedRatio == 0.5);
     }
 }
 
@@ -107,8 +108,8 @@ TEST_CASE("Audio Clip - Left edge resize trims file offset", "[audio][clip][trim
         auto* clip = ClipManager::getInstance().getClip(clipId);
         REQUIRE(clip != nullptr);
 
-        clip->offset = 0.0;
-        clip->speedRatio = 1.0;
+        primaryEventOf(clip)->setAnchorSeconds(0.0);
+        primaryEventOf(clip)->speedRatio = 1.0;
 
         // Trim from left by 1.0 seconds
         ClipManager::getInstance().resizeClip(clipId, 3.0, true);
@@ -118,15 +119,15 @@ TEST_CASE("Audio Clip - Left edge resize trims file offset", "[audio][clip][trim
         REQUIRE(clip->length == 3.0);
 
         // Audio offset advanced by 1.0 second
-        REQUIRE(clip->offset == Catch::Approx(1.0));
+        REQUIRE(primaryEventOf(clip)->anchorSeconds() == Catch::Approx(1.0));
     }
 
     SECTION("Trim with stretch factor converts to file time") {
         ClipId clipId = ClipManager::getInstance().createAudioClip(1, 0.0, 4.0, "test.wav");
         auto* clip = ClipManager::getInstance().getClip(clipId);
 
-        clip->offset = 0.0;
-        clip->speedRatio = 2.0;  // 2x faster, file window = 8.0
+        primaryEventOf(clip)->setAnchorSeconds(0.0);
+        primaryEventOf(clip)->speedRatio = 2.0;  // 2x faster, file window = 8.0
 
         // Trim from left by 2.0 timeline seconds
         ClipManager::getInstance().resizeClip(clipId, 2.0, true);
@@ -135,7 +136,7 @@ TEST_CASE("Audio Clip - Left edge resize trims file offset", "[audio][clip][trim
         REQUIRE(clip->length == 2.0);
 
         // File trim amount = 2.0 * 2.0 = 4.0 file seconds
-        REQUIRE(clip->offset == Catch::Approx(4.0));
+        REQUIRE(primaryEventOf(clip)->anchorSeconds() == Catch::Approx(4.0));
     }
 }
 
@@ -148,7 +149,7 @@ TEST_CASE("Audio Clip - Right edge resize doesn't change offset", "[audio][clip]
         ClipId clipId = ClipManager::getInstance().createAudioClip(1, 0.0, 4.0, "test.wav");
         auto* clip = ClipManager::getInstance().getClip(clipId);
 
-        clip->offset = 1.0;
+        primaryEventOf(clip)->setAnchorSeconds(1.0);
 
         // Resize from right edge
         ClipManager::getInstance().resizeClip(clipId, 6.0, false);
@@ -157,7 +158,7 @@ TEST_CASE("Audio Clip - Right edge resize doesn't change offset", "[audio][clip]
         REQUIRE(clip->length == 6.0);
 
         // Audio offset unchanged
-        REQUIRE(clip->offset == 1.0);
+        REQUIRE(primaryEventOf(clip)->anchorSeconds() == 1.0);
     }
 }
 
@@ -170,17 +171,17 @@ TEST_CASE("Audio Clip - Stretch maintains file window", "[audio][clip][stretch]"
         ClipId clipId = ClipManager::getInstance().createAudioClip(1, 0.0, 4.0, "test.wav");
         auto* clip = ClipManager::getInstance().getClip(clipId);
 
-        clip->offset = 0.0;
-        clip->speedRatio = 1.0;
+        primaryEventOf(clip)->setAnchorSeconds(0.0);
+        primaryEventOf(clip)->speedRatio = 1.0;
 
-        double originalFileWindow = clip->length * clip->speedRatio;
+        double originalFileWindow = clip->length * primaryEventOf(clip)->speedRatio;
         REQUIRE(originalFileWindow == 4.0);
 
         // Stretch 2x slower: length becomes 8, stretch factor becomes 0.5
         clip->length = 8.0;
         ClipManager::getInstance().setSpeedRatio(clipId, 0.5);
 
-        double newFileWindow = clip->length * clip->speedRatio;
+        double newFileWindow = clip->length * primaryEventOf(clip)->speedRatio;
         REQUIRE(newFileWindow == Catch::Approx(originalFileWindow));
     }
 
@@ -188,21 +189,21 @@ TEST_CASE("Audio Clip - Stretch maintains file window", "[audio][clip][stretch]"
         ClipId clipId = ClipManager::getInstance().createAudioClip(1, 0.0, 4.0, "test.wav");
         auto* clip = ClipManager::getInstance().getClip(clipId);
 
-        clip->offset = 1.0;
-        clip->speedRatio = 1.0;
+        primaryEventOf(clip)->setAnchorSeconds(1.0);
+        primaryEventOf(clip)->speedRatio = 1.0;
 
-        double originalFileWindow = clip->length * clip->speedRatio;
+        double originalFileWindow = clip->length * primaryEventOf(clip)->speedRatio;
         REQUIRE(originalFileWindow == 4.0);
 
         // Compress 2x faster: length becomes 2, stretch factor becomes 2.0
         clip->length = 2.0;
         ClipManager::getInstance().setSpeedRatio(clipId, 2.0);
 
-        double newFileWindow = clip->length * clip->speedRatio;
+        double newFileWindow = clip->length * primaryEventOf(clip)->speedRatio;
         REQUIRE(newFileWindow == Catch::Approx(originalFileWindow));
 
         // File offset unchanged
-        REQUIRE(clip->offset == 1.0);
+        REQUIRE(primaryEventOf(clip)->anchorSeconds() == 1.0);
     }
 }
 
@@ -217,18 +218,18 @@ TEST_CASE("Audio Clip - Analog pitch resamples instead of time-stretching",
         auto* clip = ClipManager::getInstance().getClip(clipId);
         REQUIRE(clip != nullptr);
 
-        clip->speedRatio = 1.0;
+        primaryEventOf(clip)->speedRatio = 1.0;
         clip->length = 2.0;
         clip->setPlacementBeats(0.0, 4.0);
 
         ClipManager::getInstance().setAnalogPitch(clipId, true);
         ClipManager::getInstance().setPitchChange(clipId, -12.0f);
 
-        REQUIRE(clip->analogPitch);
-        REQUIRE(clip->speedRatio == Catch::Approx(0.5));
+        REQUIRE(primaryEventOf(clip)->analogPitch);
+        REQUIRE(primaryEventOf(clip)->speedRatio == Catch::Approx(0.5));
         REQUIRE(clip->length == Catch::Approx(4.0));
         REQUIRE(clip->lengthBeats == Catch::Approx(8.0));
-        REQUIRE(clip->timelineToSource(clip->length) == Catch::Approx(2.0));
+        REQUIRE(primaryEventOf(clip)->timelineToSource(clip->length) == Catch::Approx(2.0));
     }
 
     SECTION("Pitch up speeds playback and shrinks timeline length") {
@@ -236,17 +237,17 @@ TEST_CASE("Audio Clip - Analog pitch resamples instead of time-stretching",
         auto* clip = ClipManager::getInstance().getClip(clipId);
         REQUIRE(clip != nullptr);
 
-        clip->speedRatio = 1.0;
+        primaryEventOf(clip)->speedRatio = 1.0;
         clip->length = 2.0;
         clip->setPlacementBeats(0.0, 4.0);
 
         ClipManager::getInstance().setAnalogPitch(clipId, true);
         ClipManager::getInstance().setPitchChange(clipId, 12.0f);
 
-        REQUIRE(clip->speedRatio == Catch::Approx(2.0));
+        REQUIRE(primaryEventOf(clip)->speedRatio == Catch::Approx(2.0));
         REQUIRE(clip->length == Catch::Approx(1.0));
         REQUIRE(clip->lengthBeats == Catch::Approx(2.0));
-        REQUIRE(clip->timelineToSource(clip->length) == Catch::Approx(2.0));
+        REQUIRE(primaryEventOf(clip)->timelineToSource(clip->length) == Catch::Approx(2.0));
     }
 }
 
@@ -264,8 +265,8 @@ TEST_CASE("Audio Clip - Real-world scenario: Amen break trim", "[audio][clip][in
         ClipId clipId = ClipManager::getInstance().createAudioClip(1, 0.0, 9.0, "amen.wav");
         auto* clip = ClipManager::getInstance().getClip(clipId);
 
-        clip->offset = 0.0;
-        clip->speedRatio = 1.0;
+        primaryEventOf(clip)->setAnchorSeconds(0.0);
+        primaryEventOf(clip)->speedRatio = 1.0;
 
         // Trim from left by 1.0 second (to bar 1.3, where first snare is)
         ClipManager::getInstance().resizeClip(clipId, 8.0, true);
@@ -275,7 +276,7 @@ TEST_CASE("Audio Clip - Real-world scenario: Amen break trim", "[audio][clip][in
         REQUIRE(clip->length == 8.0);
 
         // Audio offset advanced to 1.0s (skipping first bar)
-        REQUIRE(clip->offset == Catch::Approx(1.0));
+        REQUIRE(primaryEventOf(clip)->anchorSeconds() == Catch::Approx(1.0));
     }
 
     SECTION("Trim stretched amen break converts to file time") {
@@ -283,8 +284,8 @@ TEST_CASE("Audio Clip - Real-world scenario: Amen break trim", "[audio][clip][in
         ClipId clipId = ClipManager::getInstance().createAudioClip(1, 0.0, 18.0, "amen.wav");
         auto* clip = ClipManager::getInstance().getClip(clipId);
 
-        clip->offset = 0.0;
-        clip->speedRatio = 0.5;  // 2x slower, file window = 9.0s
+        primaryEventOf(clip)->setAnchorSeconds(0.0);
+        primaryEventOf(clip)->speedRatio = 0.5;  // 2x slower, file window = 9.0s
 
         // Trim from left by 2.0 timeline seconds (to first snare)
         ClipManager::getInstance().resizeClip(clipId, 16.0, true);
@@ -293,7 +294,7 @@ TEST_CASE("Audio Clip - Real-world scenario: Amen break trim", "[audio][clip][in
         REQUIRE(clip->length == 16.0);
 
         // File trim amount = 2.0 * 0.5 = 1.0 file seconds
-        REQUIRE(clip->offset == Catch::Approx(1.0));
+        REQUIRE(primaryEventOf(clip)->anchorSeconds() == Catch::Approx(1.0));
     }
 }
 
@@ -337,65 +338,72 @@ TEST_CASE("Audio Clip - Effective time-stretch mode", "[audio][clip][stretch][mo
     auto makeAudioClip = []() {
         ClipInfo clip;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
+        magda::test::giveAudioEvent(clip, "test.wav");
         return clip;
     };
 
     SECTION("Off mode with nothing active stays Off") {
         ClipInfo clip = makeAudioClip();
-        REQUIRE(clip.timeStretchMode == 0);
-        REQUIRE(clip.getEffectiveTimeStretchMode() == 0);
+        REQUIRE(magda::test::audioEvent(clip).timeStretchMode == 0);
+        REQUIRE(magda::test::audioEvent(clip).getEffectiveTimeStretchMode() == 0);
     }
 
     SECTION("Beat mode upgrades Off to Signalsmith") {
         ClipInfo clip = makeAudioClip();
-        clip.autoTempo = true;
-        REQUIRE(clip.getEffectiveTimeStretchMode() == time_stretch_mode::kSignalsmith);
+        magda::test::audioEvent(clip).autoTempo = true;
+        REQUIRE(magda::test::audioEvent(clip).getEffectiveTimeStretchMode() ==
+                time_stretch_mode::kSignalsmith);
     }
 
     SECTION("Warp upgrades Off to Signalsmith") {
         ClipInfo clip = makeAudioClip();
-        clip.warpEnabled = true;
-        REQUIRE(clip.getEffectiveTimeStretchMode() == time_stretch_mode::kSignalsmith);
+        magda::test::audioEvent(clip).warpEnabled = true;
+        REQUIRE(magda::test::audioEvent(clip).getEffectiveTimeStretchMode() ==
+                time_stretch_mode::kSignalsmith);
     }
 
     SECTION("Non-unity speed ratio upgrades Off to Signalsmith") {
         ClipInfo clip = makeAudioClip();
-        clip.speedRatio = 1.5;
-        REQUIRE(clip.getEffectiveTimeStretchMode() == time_stretch_mode::kSignalsmith);
+        magda::test::audioEvent(clip).speedRatio = 1.5;
+        REQUIRE(magda::test::audioEvent(clip).getEffectiveTimeStretchMode() ==
+                time_stretch_mode::kSignalsmith);
     }
 
     SECTION("Pitch change upgrades Off to Signalsmith") {
         ClipInfo clip = makeAudioClip();
-        clip.pitchChange = -3.0f;
-        REQUIRE(clip.getEffectiveTimeStretchMode() == time_stretch_mode::kSignalsmith);
+        magda::test::audioEvent(clip).pitchChange = -3.0f;
+        REQUIRE(magda::test::audioEvent(clip).getEffectiveTimeStretchMode() ==
+                time_stretch_mode::kSignalsmith);
     }
 
     SECTION("Active analog pitch keeps mode at Off (resamples, no stretch)") {
         ClipInfo clip = makeAudioClip();
-        clip.analogPitch = true;
-        clip.pitchChange = -12.0f;  // would otherwise trigger the upgrade
-        REQUIRE(clip.isAnalogPitchActive());
-        REQUIRE(clip.getEffectiveTimeStretchMode() == 0);
+        magda::test::audioEvent(clip).analogPitch = true;
+        magda::test::audioEvent(clip).pitchChange = -12.0f;  // would otherwise trigger the upgrade
+        REQUIRE(magda::test::audioEvent(clip).isAnalogPitchActive());
+        REQUIRE(magda::test::audioEvent(clip).getEffectiveTimeStretchMode() == 0);
     }
 
     SECTION("Analog pitch with beat mode is not active, so still upgrades") {
         ClipInfo clip = makeAudioClip();
-        clip.analogPitch = true;
-        clip.autoTempo = true;  // autoTempo disables analog pitch in TE
-        clip.pitchChange = -12.0f;
-        REQUIRE_FALSE(clip.isAnalogPitchActive());
-        REQUIRE(clip.getEffectiveTimeStretchMode() == time_stretch_mode::kSignalsmith);
+        magda::test::audioEvent(clip).analogPitch = true;
+        magda::test::audioEvent(clip).autoTempo = true;  // autoTempo disables analog pitch in TE
+        magda::test::audioEvent(clip).pitchChange = -12.0f;
+        REQUIRE_FALSE(magda::test::audioEvent(clip).isAnalogPitchActive());
+        REQUIRE(magda::test::audioEvent(clip).getEffectiveTimeStretchMode() ==
+                time_stretch_mode::kSignalsmith);
     }
 
     SECTION("Explicitly chosen mode is preserved, never overridden") {
         ClipInfo clip = makeAudioClip();
-        clip.timeStretchMode = time_stretch_mode::kSoundTouchNormal;
-        clip.autoTempo = true;
-        REQUIRE(clip.getEffectiveTimeStretchMode() == time_stretch_mode::kSoundTouchNormal);
+        magda::test::audioEvent(clip).timeStretchMode = time_stretch_mode::kSoundTouchNormal;
+        magda::test::audioEvent(clip).autoTempo = true;
+        REQUIRE(magda::test::audioEvent(clip).getEffectiveTimeStretchMode() ==
+                time_stretch_mode::kSoundTouchNormal);
 
-        clip.timeStretchMode = time_stretch_mode::kSoundTouchBetter;
-        REQUIRE(clip.getEffectiveTimeStretchMode() == time_stretch_mode::kSoundTouchBetter);
+        magda::test::audioEvent(clip).timeStretchMode = time_stretch_mode::kSoundTouchBetter;
+        REQUIRE(magda::test::audioEvent(clip).getEffectiveTimeStretchMode() ==
+                time_stretch_mode::kSoundTouchBetter);
     }
 }
 
@@ -425,7 +433,7 @@ TEST_CASE("Auto-tempo selects the default quality tier",
     auto makeAudioClip = [] {
         ClipInfo clip;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
+        magda::test::giveAudioEvent(clip, "test.wav");
         clip.length = 4.0;
         return clip;
     };
@@ -433,21 +441,23 @@ TEST_CASE("Auto-tempo selects the default quality tier",
     SECTION("Off upgrades to Signalsmith") {
         auto clip = makeAudioClip();
         ClipOperations::setAutoTempo(clip, true, 120.0);
-        REQUIRE(clip.timeStretchMode == time_stretch_mode::kSignalsmith);
+        REQUIRE(magda::test::audioEvent(clip).timeStretchMode == time_stretch_mode::kSignalsmith);
     }
 
     SECTION("Explicit SoundTouch remains selected") {
         auto clip = makeAudioClip();
-        clip.timeStretchMode = time_stretch_mode::kSoundTouchNormal;
+        magda::test::audioEvent(clip).timeStretchMode = time_stretch_mode::kSoundTouchNormal;
         ClipOperations::setAutoTempo(clip, true, 120.0);
-        REQUIRE(clip.timeStretchMode == time_stretch_mode::kSoundTouchNormal);
+        REQUIRE(magda::test::audioEvent(clip).timeStretchMode ==
+                time_stretch_mode::kSoundTouchNormal);
     }
 
     SECTION("Explicit SoundTouch HQ remains selected") {
         auto clip = makeAudioClip();
-        clip.timeStretchMode = time_stretch_mode::kSoundTouchBetter;
+        magda::test::audioEvent(clip).timeStretchMode = time_stretch_mode::kSoundTouchBetter;
         ClipOperations::setAutoTempo(clip, true, 120.0);
-        REQUIRE(clip.timeStretchMode == time_stretch_mode::kSoundTouchBetter);
+        REQUIRE(magda::test::audioEvent(clip).timeStretchMode ==
+                time_stretch_mode::kSoundTouchBetter);
     }
 }
 
@@ -641,11 +651,11 @@ TEST_CASE("ClipOperations - stretchAudioFromLeft right edge anchoring",
     SECTION("Multiple stretch events maintain fixed right edge") {
         ClipInfo clip;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
         clip.startTime = 10.0;
         clip.length = 5.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         // Calculate expected right edge (should never change)
         double expectedRightEdge = 10.0 + 5.0;  // 15.0
@@ -653,7 +663,7 @@ TEST_CASE("ClipOperations - stretchAudioFromLeft right edge anchoring",
 
         // Capture original values at "mouseDown"
         double originalLength = clip.length;
-        double originalStretchFactor = clip.speedRatio;
+        double originalStretchFactor = magda::test::audioEvent(clip).speedRatio;
 
         // Simulate drag event 1: stretch to 6.0 seconds
         ClipOperations::stretchAudioFromLeft(clip, 6.0, originalLength, originalStretchFactor);
@@ -662,7 +672,8 @@ TEST_CASE("ClipOperations - stretchAudioFromLeft right edge anchoring",
         REQUIRE(rightEdge1 == Catch::Approx(expectedRightEdge));
         REQUIRE(clip.startTime == Catch::Approx(9.0));  // 15.0 - 6.0
         REQUIRE(clip.length == Catch::Approx(6.0));
-        REQUIRE(clip.speedRatio == Catch::Approx(1.0 / 1.2));  // 1.0 / (6.0 / 5.0) = 5.0 / 6.0
+        REQUIRE(magda::test::audioEvent(clip).speedRatio ==
+                Catch::Approx(1.0 / 1.2));  // 1.0 / (6.0 / 5.0) = 5.0 / 6.0
 
         // Simulate drag event 2: stretch to 7.0 seconds (more stretching)
         ClipOperations::stretchAudioFromLeft(clip, 7.0, originalLength, originalStretchFactor);
@@ -671,7 +682,8 @@ TEST_CASE("ClipOperations - stretchAudioFromLeft right edge anchoring",
         REQUIRE(rightEdge2 == Catch::Approx(expectedRightEdge));  // Still 15.0!
         REQUIRE(clip.startTime == Catch::Approx(8.0));            // 15.0 - 7.0
         REQUIRE(clip.length == Catch::Approx(7.0));
-        REQUIRE(clip.speedRatio == Catch::Approx(1.0 / 1.4));  // 1.0 / (7.0 / 5.0) = 5.0 / 7.0
+        REQUIRE(magda::test::audioEvent(clip).speedRatio ==
+                Catch::Approx(1.0 / 1.4));  // 1.0 / (7.0 / 5.0) = 5.0 / 7.0
 
         // Simulate drag event 3: compress to 4.0 seconds (user dragged right)
         ClipOperations::stretchAudioFromLeft(clip, 4.0, originalLength, originalStretchFactor);
@@ -680,7 +692,7 @@ TEST_CASE("ClipOperations - stretchAudioFromLeft right edge anchoring",
         REQUIRE(rightEdge3 == Catch::Approx(expectedRightEdge));  // Still 15.0!
         REQUIRE(clip.startTime == Catch::Approx(11.0));           // 15.0 - 4.0
         REQUIRE(clip.length == Catch::Approx(4.0));
-        REQUIRE(clip.speedRatio ==
+        REQUIRE(magda::test::audioEvent(clip).speedRatio ==
                 Catch::Approx(1.0 / 0.8));  // 1.0 / (4.0 / 5.0) = 5.0 / 4.0 = 1.25
 
         // Simulate drag event 4: back to original length
@@ -690,28 +702,28 @@ TEST_CASE("ClipOperations - stretchAudioFromLeft right edge anchoring",
         REQUIRE(rightEdge4 == Catch::Approx(expectedRightEdge));  // Still 15.0!
         REQUIRE(clip.startTime == Catch::Approx(10.0));           // Back to original
         REQUIRE(clip.length == Catch::Approx(originalLength));    // Back to 5.0
-        REQUIRE(clip.speedRatio == Catch::Approx(1.0));           // Back to 1.0
+        REQUIRE(magda::test::audioEvent(clip).speedRatio == Catch::Approx(1.0));  // Back to 1.0
     }
 
     SECTION("Stretch factor clamping doesn't break right edge anchoring") {
         ClipInfo clip;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
         clip.startTime = 5.0;
         clip.length = 2.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         double expectedRightEdge = 5.0 + 2.0;  // 7.0
         double originalLength = clip.length;
-        double originalStretchFactor = clip.speedRatio;
+        double originalStretchFactor = magda::test::audioEvent(clip).speedRatio;
 
         // Try to stretch to 10.0 (5.0x ratio). The requested speed would clamp at the
         // minimum speed, but keeping the right edge fixed must not push the clip before
         // the timeline origin.
         ClipOperations::stretchAudioFromLeft(clip, 10.0, originalLength, originalStretchFactor);
 
-        REQUIRE(clip.speedRatio == Catch::Approx(2.0 / 7.0));
+        REQUIRE(magda::test::audioEvent(clip).speedRatio == Catch::Approx(2.0 / 7.0));
         REQUIRE(clip.startTime == Catch::Approx(0.0));
         REQUIRE(clip.length == Catch::Approx(7.0));
 
@@ -723,21 +735,21 @@ TEST_CASE("ClipOperations - stretchAudioFromLeft right edge anchoring",
     SECTION("Stretch with pre-stretched audio maintains correct calculations") {
         ClipInfo clip;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
         clip.startTime = 20.0;
         clip.length = 10.0;
-        clip.speedRatio = 2.0;  // Already stretched 2x
+        magda::test::audioEvent(clip).speedRatio = 2.0;  // Already stretched 2x
 
         double expectedRightEdge = 20.0 + 10.0;  // 30.0
         double originalLength = clip.length;
-        double originalStretchFactor = clip.speedRatio;
+        double originalStretchFactor = magda::test::audioEvent(clip).speedRatio;
 
         // Stretch from 10.0 to 15.0 (1.5x stretch on top of existing 2.0x)
         ClipOperations::stretchAudioFromLeft(clip, 15.0, originalLength, originalStretchFactor);
 
         // New stretch factor: 2.0 / (15.0 / 10.0) = 2.0 / 1.5 = 1.333...
-        REQUIRE(clip.speedRatio == Catch::Approx(2.0 / 1.5));
+        REQUIRE(magda::test::audioEvent(clip).speedRatio == Catch::Approx(2.0 / 1.5));
         REQUIRE(clip.length == Catch::Approx(15.0));
 
         // Right edge still anchored

--- a/tests/test_audio_source_length.cpp
+++ b/tests/test_audio_source_length.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include "AudioClipTestHelpers.hpp"
 #include "magda/daw/core/ClipDisplayInfo.hpp"
 #include "magda/daw/core/ClipInfo.hpp"
 #include "magda/daw/core/ClipManager.hpp"
@@ -43,8 +44,8 @@ TEST_CASE("ClipDisplayInfo - file extent always covers the full source file",
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 4.0;
-        clip.offset = 1.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(1.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = false;
 
         syncPlacement(clip);
@@ -63,11 +64,11 @@ TEST_CASE("ClipDisplayInfo - file extent always covers the full source file",
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 4.0;
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = true;
-        clip.loopStart = 1.0;
-        clip.loopLength = 3.0;
+        magda::test::audioEvent(clip).setLoopStartSeconds(1.0);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(3.0);
 
         syncPlacement(clip);
         auto di = ClipDisplayInfo::from(clip, 120.0, /*fileDuration=*/4.0);
@@ -82,11 +83,11 @@ TEST_CASE("ClipDisplayInfo - file extent always covers the full source file",
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 16.0;
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = true;
-        clip.loopStart = 0.0;
-        clip.loopLength = 5.0;
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(5.0);
 
         syncPlacement(clip);
         auto di = ClipDisplayInfo::from(clip, 120.0, /*fileDuration=*/8.0);
@@ -106,8 +107,8 @@ TEST_CASE("ClipDisplayInfo - file extent always covers the full source file",
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 4.0;
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = false;
 
         syncPlacement(clip);
@@ -131,8 +132,8 @@ TEST_CASE("ClipDisplayInfo - srcToTimelineRatio drives both directions",
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 4.0;
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = false;
 
         syncPlacement(clip);
@@ -148,8 +149,8 @@ TEST_CASE("ClipDisplayInfo - srcToTimelineRatio drives both directions",
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 4.0;
-        clip.offset = 0.0;
-        clip.speedRatio = 2.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 2.0;
         clip.loopEnabled = false;
 
         syncPlacement(clip);
@@ -166,7 +167,8 @@ TEST_CASE("ClipDisplayInfo - srcToTimelineRatio drives both directions",
 // Loop region — independent of file extent
 // ============================================================================
 
-TEST_CASE("ClipDisplayInfo - loop region tracks clip.loopStart / loopLength",
+TEST_CASE("ClipDisplayInfo - loop region tracks magda::test::audioEvent(clip).loopStartSeconds() / "
+          "loopLength",
           "[clip][display][loop]") {
     using namespace magda;
 
@@ -180,11 +182,11 @@ TEST_CASE("ClipDisplayInfo - loop region tracks clip.loopStart / loopLength",
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 4.0;
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = true;
-        clip.loopStart = 1.0;
-        clip.loopLength = 0.0;  // sentinel
+        magda::test::audioEvent(clip).setLoopStartSeconds(1.0);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(0.0);  // sentinel
 
         syncPlacement(clip);
         auto di = ClipDisplayInfo::from(clip, 120.0, /*fileDuration=*/4.0);
@@ -199,10 +201,11 @@ TEST_CASE("ClipDisplayInfo - loop region tracks clip.loopStart / loopLength",
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 4.0;
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = false;
-        clip.loopLength = 4.0;  // present but ignored when disabled
+        magda::test::audioEvent(clip).setLoopLengthSeconds(
+            4.0);  // present but ignored when disabled
 
         syncPlacement(clip);
         auto di = ClipDisplayInfo::from(clip, 120.0, /*fileDuration=*/4.0);
@@ -217,11 +220,11 @@ TEST_CASE("ClipDisplayInfo - loop region tracks clip.loopStart / loopLength",
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 16.0;
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = true;
-        clip.loopStart = 1.0;
-        clip.loopLength = 3.0;
+        magda::test::audioEvent(clip).setLoopStartSeconds(1.0);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(3.0);
 
         syncPlacement(clip);
         auto di = ClipDisplayInfo::from(clip, 120.0, /*fileDuration=*/4.0);
@@ -238,11 +241,12 @@ TEST_CASE("ClipDisplayInfo - loop region tracks clip.loopStart / loopLength",
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 16.0;
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = true;
-        clip.loopStart = 3.0;
-        clip.loopLength = 5.0;  // would extend to 8s, file only 4s
+        magda::test::audioEvent(clip).setLoopStartSeconds(3.0);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(
+            5.0);  // would extend to 8s, file only 4s
 
         syncPlacement(clip);
         auto di = ClipDisplayInfo::from(clip, 120.0, /*fileDuration=*/4.0);
@@ -267,12 +271,12 @@ TEST_CASE("ClipManager - setClipLoopEnabled preserves loopLength", "[audio][clip
         auto* clip = ClipManager::getInstance().getClip(clipId);
         REQUIRE(clip != nullptr);
 
-        clip->speedRatio = 1.0;
-        REQUIRE(clip->loopLength == Catch::Approx(4.0));
+        primaryEventOf(clip)->speedRatio = 1.0;
+        REQUIRE(primaryEventOf(clip)->loopLengthSeconds() == Catch::Approx(4.0));
 
         ClipManager::getInstance().setClipLoopEnabled(clipId, true, 120.0);
 
-        REQUIRE(clip->loopLength == Catch::Approx(4.0));
+        REQUIRE(primaryEventOf(clip)->loopLengthSeconds() == Catch::Approx(4.0));
         REQUIRE(clip->loopEnabled == true);
     }
 
@@ -287,18 +291,22 @@ TEST_CASE("ClipManager - setClipLoopEnabled preserves loopLength", "[audio][clip
         // Source is 8s of audio; clip is currently looping a 2s region from
         // offset 1s. Disabling loop should expand the clip back to the
         // remaining 7s of source, in both seconds and beat domains.
-        clip->audio().source.durationSeconds = FILE_DURATION;
-        clip->speedRatio = 1.0;
-        clip->offset = 1.0;
+        magda::SourcePool::getInstance().seedFactsForTesting(primaryEventOf(clip)->sourceFilePath(),
+                                                             FILE_DURATION,
+                                                             magda::test::kTestSourceSampleRate);
+        magda::SourcePool::getInstance().resolveFacts(primaryEventOf(clip)->sourceId);
+        primaryEventOf(clip)->speedRatio = 1.0;
+        primaryEventOf(clip)->setAnchorSeconds(1.0);
         clip->loopEnabled = true;
-        clip->loopStart = 1.0;
-        clip->loopLength = 2.0;
+        primaryEventOf(clip)->setLoopStartSeconds(1.0);
+        primaryEventOf(clip)->setLoopLengthSeconds(2.0);
         clip->length = 2.0;
         clip->setPlacementBeats(0.0, 2.0 * BPM / 60.0);
 
         ClipManager::getInstance().setClipLoopEnabled(clipId, false, BPM);
 
-        const double expectedLength = FILE_DURATION - clip->offset;  // speedRatio = 1
+        const double expectedLength =
+            FILE_DURATION - primaryEventOf(clip)->anchorSeconds();  // speedRatio = 1
         REQUIRE(clip->loopEnabled == false);
         REQUIRE(clip->length == Catch::Approx(expectedLength));
         REQUIRE(clip->placement.lengthBeats == Catch::Approx(expectedLength * BPM / 60.0));
@@ -313,12 +321,15 @@ TEST_CASE("ClipManager - setClipLoopEnabled preserves loopLength", "[audio][clip
         auto* clip = ClipManager::getInstance().getClip(clipId);
         REQUIRE(clip != nullptr);
 
-        clip->audio().source.durationSeconds = FILE_DURATION;
-        clip->speedRatio = SPEED;
-        clip->offset = 0.0;
+        magda::SourcePool::getInstance().seedFactsForTesting(primaryEventOf(clip)->sourceFilePath(),
+                                                             FILE_DURATION,
+                                                             magda::test::kTestSourceSampleRate);
+        magda::SourcePool::getInstance().resolveFacts(primaryEventOf(clip)->sourceId);
+        primaryEventOf(clip)->speedRatio = SPEED;
+        primaryEventOf(clip)->setAnchorSeconds(0.0);
         clip->loopEnabled = true;
-        clip->loopStart = 0.0;
-        clip->loopLength = 1.0;
+        primaryEventOf(clip)->setLoopStartSeconds(0.0);
+        primaryEventOf(clip)->setLoopLengthSeconds(1.0);
         clip->length = 1.0;
         clip->setPlacementBeats(0.0, 1.0 * BPM / 60.0);
 

--- a/tests/test_auto_tempo.cpp
+++ b/tests/test_auto_tempo.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include "AudioClipTestHelpers.hpp"
 #include "magda/daw/core/ClipInfo.hpp"
 #include "magda/daw/core/ClipOperations.hpp"
 
@@ -33,13 +34,13 @@ static constexpr double PROJECT_BPM = 69.0;
 static ClipInfo makeAmenClip(double startTime = 0.0) {
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audio().source.filePath = "amen_break.wav";
+    magda::test::giveAudioEvent(clip, "amen_break.wav");
     clip.startTime = startTime;
     clip.length = AMEN_DURATION;  // original duration before stretching
-    clip.offset = 0.0;
-    clip.speedRatio = 1.0;
-    clip.audio().interpretation.bpm = AMEN_ORIGINAL_BPM;
-    clip.audio().interpretation.totalBeats = AMEN_SOURCE_BEATS;
+    magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+    magda::test::audioEvent(clip).speedRatio = 1.0;
+    magda::test::audioEvent(clip).interpBpm = AMEN_ORIGINAL_BPM;
+    magda::test::audioEvent(clip).interpTotalBeats = AMEN_SOURCE_BEATS;
     return clip;
 }
 
@@ -47,49 +48,51 @@ static ClipInfo makeAmenClip(double startTime = 0.0) {
 static ClipInfo makeCalibratedClip(double projectBPM = 120.0) {
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audio().source.filePath = "sample.wav";
+    magda::test::giveAudioEvent(clip, "sample.wav");
     clip.startTime = 0.0;
     clip.length = 2.0;
-    clip.offset = 0.0;
-    clip.speedRatio = 1.0;
-    clip.audio().interpretation.bpm = projectBPM;  // matches project → calibration applies
-    clip.audio().interpretation.totalBeats = 4.0;
+    magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+    magda::test::audioEvent(clip).speedRatio = 1.0;
+    magda::test::audioEvent(clip).interpBpm = projectBPM;  // matches project → calibration applies
+    magda::test::audioEvent(clip).interpTotalBeats = 4.0;
     return clip;
 }
 
 // ─────────────────────────────────────────────────────────────
-// ClipInfo::setSourceMetadata
+// AudioEvent::seedInterpretation
 // ─────────────────────────────────────────────────────────────
 
-TEST_CASE("ClipInfo::setSourceMetadata - populates unset fields", "[clip][auto-tempo][metadata]") {
+TEST_CASE("AudioEvent::seedInterpretation - populates unset fields",
+          "[clip][auto-tempo][metadata]") {
     ClipInfo clip;
-    clip.setAudioContent();
+    magda::test::giveAudioEvent(clip, "seed.wav");
 
     SECTION("Sets both fields when unset") {
-        clip.setSourceMetadata(4.0, 120.0);
-        REQUIRE(clip.audio().interpretation.totalBeats == 4.0);
-        REQUIRE(clip.audio().interpretation.bpm == 120.0);
+        magda::test::audioEvent(clip).seedInterpretation(4.0, 120.0);
+        REQUIRE(magda::test::audioEvent(clip).interpTotalBeats == 4.0);
+        REQUIRE(magda::test::audioEvent(clip).interpBpm == 120.0);
     }
 
     SECTION("Does not overwrite existing values") {
-        clip.audio().interpretation.totalBeats = 8.0;
-        clip.audio().interpretation.bpm = 140.0;
-        clip.setSourceMetadata(4.0, 120.0);
-        REQUIRE(clip.audio().interpretation.totalBeats == 8.0);
-        REQUIRE(clip.audio().interpretation.bpm == 140.0);
+        magda::test::audioEvent(clip).interpTotalBeats = 8.0;
+        magda::test::audioEvent(clip).interpBpm = 140.0;
+        magda::test::audioEvent(clip).seedInterpretation(4.0, 120.0);
+        REQUIRE(magda::test::audioEvent(clip).interpTotalBeats == 8.0);
+        REQUIRE(magda::test::audioEvent(clip).interpBpm == 140.0);
     }
 
     SECTION("Ignores zero/negative input") {
-        clip.setSourceMetadata(0.0, -5.0);
-        REQUIRE(clip.audio().interpretation.totalBeats == 0.0);
-        REQUIRE(clip.audio().interpretation.bpm == 0.0);
+        magda::test::audioEvent(clip).seedInterpretation(0.0, -5.0);
+        REQUIRE(magda::test::audioEvent(clip).interpTotalBeats == 0.0);
+        REQUIRE(magda::test::audioEvent(clip).interpBpm == 0.0);
     }
 
     SECTION("Sets one field independently of the other") {
-        clip.audio().interpretation.bpm = 140.0;  // already set
-        clip.setSourceMetadata(4.0, 120.0);
-        REQUIRE(clip.audio().interpretation.totalBeats == 4.0);  // was unset, gets populated
-        REQUIRE(clip.audio().interpretation.bpm == 140.0);       // was set, not overwritten
+        magda::test::audioEvent(clip).interpBpm = 140.0;  // already set
+        magda::test::audioEvent(clip).seedInterpretation(4.0, 120.0);
+        REQUIRE(magda::test::audioEvent(clip).interpTotalBeats ==
+                4.0);                                               // was unset, gets populated
+        REQUIRE(magda::test::audioEvent(clip).interpBpm == 140.0);  // was set, not overwritten
     }
 }
 
@@ -110,12 +113,12 @@ TEST_CASE("setAutoTempo - preserves real detected BPM", "[clip][auto-tempo]") {
 
     SECTION("source interpretation BPM preserved when it differs from project BPM") {
         ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
-        REQUIRE(clip.audio().interpretation.bpm == Approx(AMEN_ORIGINAL_BPM));
+        REQUIRE(magda::test::audioEvent(clip).interpBpm == Approx(AMEN_ORIGINAL_BPM));
     }
 
     SECTION("source interpretation total beats preserved when BPM differs from project BPM") {
         ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
-        REQUIRE(clip.audio().interpretation.totalBeats == Approx(AMEN_SOURCE_BEATS));
+        REQUIRE(magda::test::audioEvent(clip).interpTotalBeats == Approx(AMEN_SOURCE_BEATS));
     }
 
     SECTION("lengthBeats preserves timeline length in project beats") {
@@ -128,7 +131,8 @@ TEST_CASE("setAutoTempo - preserves real detected BPM", "[clip][auto-tempo]") {
         // Slight tolerance because AMEN_DURATION (1.513s) doesn't exactly
         // round-trip through AMEN_ORIGINAL_BPM (158.6) to give 4.0 source
         // beats — within a thousandth.
-        REQUIRE(clip.lengthBeats == Approx(clip.loopLengthBeats).margin(0.01));
+        REQUIRE(clip.lengthBeats ==
+                Approx(magda::test::audioEvent(clip).loopLengthBeats()).margin(0.01));
     }
 
     SECTION("startBeats is in project beats") {
@@ -139,9 +143,9 @@ TEST_CASE("setAutoTempo - preserves real detected BPM", "[clip][auto-tempo]") {
     }
 
     SECTION("speedRatio forced to 1.0") {
-        clip.speedRatio = 2.0;
+        magda::test::audioEvent(clip).speedRatio = 2.0;
         ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
-        REQUIRE(clip.speedRatio == 1.0);
+        REQUIRE(magda::test::audioEvent(clip).speedRatio == 1.0);
     }
 
     SECTION("looping gets enabled if not already") {
@@ -161,21 +165,21 @@ TEST_CASE("setAutoTempo - calibrates when source interpretation BPM matches proj
     SECTION("source interpretation BPM stays at project BPM when they match") {
         auto clip = makeCalibratedClip(120.0);
         ClipOperations::setAutoTempo(clip, true, 120.0);
-        REQUIRE(clip.audio().interpretation.bpm == Approx(120.0));
+        REQUIRE(magda::test::audioEvent(clip).interpBpm == Approx(120.0));
     }
 
     SECTION("source interpretation BPM equals project BPM / speedRatio when appropriate") {
         auto clip = makeCalibratedClip(120.0);
-        clip.speedRatio = 2.0;
+        magda::test::audioEvent(clip).speedRatio = 2.0;
         // effectiveBPM = 120/2 = 60, but interpretation BPM = 120, so no calibration
         // Actually this is the "differs" case so calibration is skipped
         ClipOperations::setAutoTempo(clip, true, 120.0);
-        REQUIRE(clip.audio().interpretation.bpm == Approx(120.0));  // preserved
+        REQUIRE(magda::test::audioEvent(clip).interpBpm == Approx(120.0));  // preserved
     }
 
     SECTION("Calibration when source interpretation BPM was unknown (zero)") {
         auto clip = makeAmenClip();
-        clip.audio().interpretation.bpm = 0.0;
+        magda::test::audioEvent(clip).interpBpm = 0.0;
         ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
         // Unknown interpretation BPM stays unknown; the fallback compute path is used.
     }
@@ -190,8 +194,9 @@ TEST_CASE("getAutoTempoBeatRange - source beat range", "[clip][auto-tempo][te-sy
         auto clip = makeAmenClip();
         ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
 
-        auto [startBeats, lengthBeats] = ClipOperations::getAutoTempoBeatRange(clip, PROJECT_BPM);
-        REQUIRE(lengthBeats == Approx(clip.loopLengthBeats));
+        auto [startBeats, lengthBeats] =
+            ClipOperations::getAutoTempoBeatRange(magda::test::audioEvent(clip));
+        REQUIRE(lengthBeats == Approx(magda::test::audioEvent(clip).loopLengthBeats()));
     }
 
     SECTION("Beat range maps to file's natural beat count") {
@@ -202,14 +207,16 @@ TEST_CASE("getAutoTempoBeatRange - source beat range", "[clip][auto-tempo][te-sy
         auto clip = makeAmenClip();
         ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
 
-        auto [startBeats, lengthBeats] = ClipOperations::getAutoTempoBeatRange(clip, PROJECT_BPM);
+        auto [startBeats, lengthBeats] =
+            ClipOperations::getAutoTempoBeatRange(magda::test::audioEvent(clip));
 
         REQUIRE(lengthBeats == Approx(AMEN_SOURCE_BEATS).margin(0.01));
     }
 
     SECTION("Returns {0,0} when autoTempo is off") {
         auto clip = makeAmenClip();
-        auto [startBeats, lengthBeats] = ClipOperations::getAutoTempoBeatRange(clip, PROJECT_BPM);
+        auto [startBeats, lengthBeats] =
+            ClipOperations::getAutoTempoBeatRange(magda::test::audioEvent(clip));
 
         REQUIRE(startBeats == 0.0);
         REQUIRE(lengthBeats == 0.0);
@@ -236,17 +243,18 @@ TEST_CASE("getEndBeats - consistent in auto-tempo mode", "[clip][auto-tempo]") {
 
 TEST_CASE("setAutoTempo - with offset preserves loop start", "[clip][auto-tempo][offset]") {
     auto clip = makeAmenClip();
-    clip.offset = 0.5;
+    magda::test::audioEvent(clip).setAnchorSeconds(0.5);
 
     SECTION("loopStart set to offset when loop was not enabled") {
         ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
-        REQUIRE(clip.loopStart == Approx(0.5));
+        REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() == Approx(0.5));
     }
 
     SECTION("Clamping shifts start when loop exceeds file with offset") {
         ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
 
-        auto [startBeats, lengthBeats] = ClipOperations::getAutoTempoBeatRange(clip, PROJECT_BPM);
+        auto [startBeats, lengthBeats] =
+            ClipOperations::getAutoTempoBeatRange(magda::test::audioEvent(clip));
 
         // Beat range must be non-negative
         REQUIRE(startBeats >= 0.0);
@@ -261,14 +269,14 @@ TEST_CASE("setAutoTempo - with offset preserves loop start", "[clip][auto-tempo]
 TEST_CASE("setAutoTempo - respects existing loop region", "[clip][auto-tempo][loop]") {
     auto clip = makeAmenClip();
     clip.loopEnabled = true;
-    clip.loopStart = 0.3;
-    clip.loopLength = 0.8;
+    magda::test::audioEvent(clip).setLoopStartSeconds(0.3);
+    magda::test::audioEvent(clip).setLoopLengthSeconds(0.8);
 
     ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
 
     SECTION("Does not overwrite existing loopStart/loopLength") {
-        REQUIRE(clip.loopStart == Approx(0.3));
-        REQUIRE(clip.loopLength == Approx(0.8));
+        REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() == Approx(0.3));
+        REQUIRE(magda::test::audioEvent(clip).loopLengthSeconds() == Approx(0.8));
     }
 
     SECTION("loopLengthBeats is in source beats") {
@@ -277,7 +285,7 @@ TEST_CASE("setAutoTempo - respects existing loop region", "[clip][auto-tempo][lo
         // a 0.8-second loop in a file interpreted at 158.6 BPM, that's
         // 0.8 × 158.6 / 60 ≈ 2.115 beats.
         double expectedLoopBeats = 0.8 * AMEN_ORIGINAL_BPM / 60.0;
-        REQUIRE(clip.loopLengthBeats == Approx(expectedLoopBeats));
+        REQUIRE(magda::test::audioEvent(clip).loopLengthBeats() == Approx(expectedLoopBeats));
     }
 }
 
@@ -288,43 +296,50 @@ TEST_CASE("setAutoTempo - respects existing loop region", "[clip][auto-tempo][lo
 TEST_CASE("setAutoTempo - disable preserves source seconds", "[clip][auto-tempo]") {
     auto clip = makeAmenClip();
     clip.loopEnabled = true;
-    clip.loopStart = 0.25;
-    clip.loopLength = 0.75;
-    clip.offset = 0.5;
+    magda::test::audioEvent(clip).setLoopStartSeconds(0.25);
+    magda::test::audioEvent(clip).setLoopLengthSeconds(0.75);
+    magda::test::audioEvent(clip).setAnchorSeconds(0.5);
 
     ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
 
     // Verify beat values were set and are authoritative in auto-tempo mode.
     REQUIRE(clip.lengthBeats > 0.0);
-    REQUIRE(clip.loopLengthBeats > 0.0);
+    REQUIRE(magda::test::audioEvent(clip).loopLengthBeats() > 0.0);
     REQUIRE(clip.startBeats >= 0.0);
 
-    const double expectedOffset = clip.getSourceOffset();
-    const double expectedLoopStart = clip.getSourceLoopStart();
-    const double expectedLoopLength = clip.getSourceLoopLength();
+    const double expectedOffset = magda::test::audioEvent(clip).anchorSeconds();
+    const double expectedLoopStart = magda::test::audioEvent(clip).loopStartSeconds();
+    const double expectedLoopLength = magda::test::audioEvent(clip).loopLengthSeconds();
     const double expectedPhase = wrapPhase(expectedOffset - expectedLoopStart, expectedLoopLength);
 
     ClipOperations::setAutoTempo(clip, false, PROJECT_BPM);
 
     SECTION("Source seconds are preserved") {
-        REQUIRE(clip.offset == Approx(expectedLoopStart + expectedPhase));
-        REQUIRE(clip.loopStart == Approx(expectedLoopStart));
-        REQUIRE(clip.loopLength == Approx(expectedLoopLength));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() ==
+                Approx(expectedLoopStart + expectedPhase));
+        REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() == Approx(expectedLoopStart));
+        REQUIRE(magda::test::audioEvent(clip).loopLengthSeconds() == Approx(expectedLoopLength));
     }
 
-    SECTION("Source beat-loop values are cleared") {
-        REQUIRE(clip.loopStartBeats == 0.0);
-        REQUIRE(clip.loopLengthBeats == 0.0);
+    SECTION("The source region's beat view follows the preserved seconds") {
+        // Beats are a view on the source region, which the section above
+        // asserts is preserved, so leaving beat mode cannot zero them. v1
+        // cleared separate beat fields here purely because it kept two
+        // representations of the same region.
+        REQUIRE(magda::test::audioEvent(clip).loopStartBeats() ==
+                Approx(expectedLoopStart * magda::test::audioEvent(clip).interpBpm / 60.0));
+        REQUIRE(magda::test::audioEvent(clip).loopLengthBeats() ==
+                Approx(expectedLoopLength * magda::test::audioEvent(clip).interpBpm / 60.0));
     }
 
     SECTION("autoTempo is false") {
-        REQUIRE_FALSE(clip.autoTempo);
+        REQUIRE_FALSE(magda::test::audioEvent(clip).autoTempo);
     }
 }
 
 TEST_CASE("setAutoTempo - re-enable preserves trimmed placement length", "[clip][auto-tempo]") {
     auto clip = makeAmenClip();
-    clip.audio().source.durationSeconds = AMEN_DURATION;
+    magda::test::setSourceDuration(clip, AMEN_DURATION);
     clip.loopEnabled = true;
 
     ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
@@ -335,11 +350,11 @@ TEST_CASE("setAutoTempo - re-enable preserves trimmed placement length", "[clip]
     clip.deriveTimesFromBeats(PROJECT_BPM);
 
     ClipOperations::setAutoTempo(clip, false, PROJECT_BPM);
-    REQUIRE_FALSE(clip.autoTempo);
+    REQUIRE_FALSE(magda::test::audioEvent(clip).autoTempo);
     REQUIRE(clip.placement.lengthBeats == Approx(trimmedLengthBeats));
 
     ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
-    REQUIRE(clip.autoTempo);
+    REQUIRE(magda::test::audioEvent(clip).autoTempo);
     REQUIRE(clip.placement.lengthBeats == Approx(trimmedLengthBeats));
     REQUIRE(clip.length == Approx(trimmedLengthBeats * 60.0 / PROJECT_BPM));
 }
@@ -351,19 +366,19 @@ TEST_CASE("setAutoTempo - no-op when already in target state", "[clip][auto-temp
         ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
         double savedLength = clip.length;
         double savedLengthBeats = clip.lengthBeats;
-        double savedLoopLengthBeats = clip.loopLengthBeats;
+        double savedLoopLengthBeats = magda::test::audioEvent(clip).loopLengthBeats();
 
         ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
 
         REQUIRE(clip.length == Approx(savedLength));
         REQUIRE(clip.lengthBeats == Approx(savedLengthBeats));
-        REQUIRE(clip.loopLengthBeats == Approx(savedLoopLengthBeats));
+        REQUIRE(magda::test::audioEvent(clip).loopLengthBeats() == Approx(savedLoopLengthBeats));
     }
 
     SECTION("Disable when already disabled is no-op") {
-        REQUIRE_FALSE(clip.autoTempo);
+        REQUIRE_FALSE(magda::test::audioEvent(clip).autoTempo);
         ClipOperations::setAutoTempo(clip, false, PROJECT_BPM);
-        REQUIRE_FALSE(clip.autoTempo);
+        REQUIRE_FALSE(magda::test::audioEvent(clip).autoTempo);
     }
 }
 
@@ -378,10 +393,10 @@ TEST_CASE("setAutoTempo - calibration with matching source interpretation BPM",
         auto clip = makeCalibratedClip(120.0);
         ClipOperations::setAutoTempo(clip, true, 120.0);
 
-        REQUIRE(clip.audio().interpretation.bpm == Approx(120.0));
+        REQUIRE(magda::test::audioEvent(clip).interpBpm == Approx(120.0));
         REQUIRE(clip.length == Approx(2.0));
         REQUIRE(clip.lengthBeats == Approx(4.0));
-        REQUIRE(clip.loopLengthBeats == Approx(4.0));
+        REQUIRE(magda::test::audioEvent(clip).loopLengthBeats() == Approx(4.0));
     }
 
     SECTION("At 60 BPM with matching source interpretation BPM, calibrates to 60") {
@@ -390,15 +405,15 @@ TEST_CASE("setAutoTempo - calibration with matching source interpretation BPM",
 
         ClipOperations::setAutoTempo(clip, true, 60.0);
 
-        REQUIRE(clip.audio().interpretation.bpm == Approx(60.0));
-        REQUIRE(60.0 / clip.audio().interpretation.bpm == Approx(1.0));
+        REQUIRE(magda::test::audioEvent(clip).interpBpm == Approx(60.0));
+        REQUIRE(60.0 / magda::test::audioEvent(clip).interpBpm == Approx(1.0));
     }
 
     SECTION("Real detected BPM (158.6) preserved at any project tempo") {
         auto clip = makeAmenClip();
         ClipOperations::setAutoTempo(clip, true, 200.0);
 
-        REQUIRE(clip.audio().interpretation.bpm == Approx(AMEN_ORIGINAL_BPM));
+        REQUIRE(magda::test::audioEvent(clip).interpBpm == Approx(AMEN_ORIGINAL_BPM));
     }
 }
 
@@ -414,16 +429,17 @@ TEST_CASE("Regression: loop wrapping past file end", "[clip][auto-tempo][regress
 
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audio().source.filePath = "long_loop.wav";
+    magda::test::giveAudioEvent(clip, "long_loop.wav");
     clip.length = FILE_DURATION;
-    clip.offset = 5.0;  // near end of file
-    clip.speedRatio = 1.0;
-    clip.audio().interpretation.bpm = FILE_BPM;
-    clip.audio().interpretation.totalBeats = FILE_BEATS;
+    magda::test::audioEvent(clip).setAnchorSeconds(5.0);  // near end of file
+    magda::test::audioEvent(clip).speedRatio = 1.0;
+    magda::test::audioEvent(clip).interpBpm = FILE_BPM;
+    magda::test::audioEvent(clip).interpTotalBeats = FILE_BEATS;
 
     ClipOperations::setAutoTempo(clip, true, 69.0);
 
-    auto [startBeats, lengthBeats] = ClipOperations::getAutoTempoBeatRange(clip, 69.0);
+    auto [startBeats, lengthBeats] =
+        ClipOperations::getAutoTempoBeatRange(magda::test::audioEvent(clip));
 
     // Beat range must be non-negative
     REQUIRE(startBeats >= 0.0);
@@ -439,21 +455,23 @@ TEST_CASE("setAutoTempoPlacementLengthBeats - extends placement without rewritin
     auto clip = makeAmenClip();
     ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
 
-    double originalSourceInterpretationBpm = clip.audio().interpretation.bpm;
-    double originalSourceBeats = clip.audio().interpretation.totalBeats;
-    double originalLoopLengthBeats = clip.loopLengthBeats;
+    double originalSourceInterpretationBpm = magda::test::audioEvent(clip).interpBpm;
+    double originalSourceBeats = magda::test::audioEvent(clip).interpTotalBeats;
+    double originalLoopLengthBeats = magda::test::audioEvent(clip).loopLengthBeats();
 
     ClipOperations::setAutoTempoPlacementLengthBeats(clip, originalLoopLengthBeats * 2.0,
                                                      PROJECT_BPM);
 
     SECTION("source interpretation is unchanged") {
-        REQUIRE(clip.audio().interpretation.bpm ==
+        REQUIRE(magda::test::audioEvent(clip).interpBpm ==
                 Approx(originalSourceInterpretationBpm).margin(0.1));
-        REQUIRE(clip.audio().interpretation.totalBeats == Approx(originalSourceBeats).margin(0.01));
+        REQUIRE(magda::test::audioEvent(clip).interpTotalBeats ==
+                Approx(originalSourceBeats).margin(0.01));
     }
 
     SECTION("loop region stays in source beats") {
-        REQUIRE(clip.loopLengthBeats == Approx(originalLoopLengthBeats).margin(0.01));
+        REQUIRE(magda::test::audioEvent(clip).loopLengthBeats() ==
+                Approx(originalLoopLengthBeats).margin(0.01));
     }
 
     SECTION("placement length doubles") {

--- a/tests/test_clip_batch_edit.cpp
+++ b/tests/test_clip_batch_edit.cpp
@@ -87,17 +87,17 @@ TEST_CASE("SetClipPropertyCommand restores setter side effects", "[undo][clip][p
     auto* clip = ClipManager::getInstance().getClip(clipId);
     REQUIRE(clip != nullptr);
 
-    clip->warpEnabled = false;
-    clip->analogPitch = true;
+    primaryEventOf(clip)->warpEnabled = false;
+    primaryEventOf(clip)->analogPitch = true;
 
     undo.executeCommand(std::make_unique<SetClipPropertyCommand>(
         clipId, "Set Clip Warp",
         [](ClipManager& manager, ClipId id) { manager.setClipWarpEnabled(id, true); }));
 
-    REQUIRE(clip->warpEnabled);
-    REQUIRE_FALSE(clip->analogPitch);
+    REQUIRE(primaryEventOf(clip)->warpEnabled);
+    REQUIRE_FALSE(primaryEventOf(clip)->analogPitch);
 
     REQUIRE(undo.undo());
-    REQUIRE_FALSE(clip->warpEnabled);
-    REQUIRE(clip->analogPitch);
+    REQUIRE_FALSE(primaryEventOf(clip)->warpEnabled);
+    REQUIRE(primaryEventOf(clip)->analogPitch);
 }

--- a/tests/test_clip_bpm_invariant.cpp
+++ b/tests/test_clip_bpm_invariant.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include "AudioClipTestHelpers.hpp"
 #include "magda/daw/audio/AudioThumbnailManager.hpp"
 #include "magda/daw/core/ClipInfo.hpp"
 #include "magda/daw/core/ClipManager.hpp"
@@ -31,44 +32,48 @@ ClipInfo makeSessionAutoTempoClip(ClipId id = 1) {
     clip.trackId = 1;
     clip.setAudioContent();
     clip.view = ClipView::Session;
-    clip.audio().source.filePath = "fake.wav";
-    clip.audio().source.durationSeconds = FILE_DURATION;
-    clip.autoTempo = true;
+    magda::test::giveAudioEvent(clip, "fake.wav");
+    magda::test::setSourceDuration(clip, FILE_DURATION);
+    magda::test::audioEvent(clip).autoTempo = true;
     clip.loopEnabled = true;
-    clip.speedRatio = 1.0;
+    magda::test::audioEvent(clip).speedRatio = 1.0;
 
     // Pretend detection has already populated source metadata.
-    clip.audio().interpretation.bpm = DETECTED_BPM;
-    clip.audio().interpretation.totalBeats = DETECTED_NUM_BEATS;
+    magda::test::audioEvent(clip).interpBpm = DETECTED_BPM;
+    magda::test::audioEvent(clip).interpTotalBeats = DETECTED_NUM_BEATS;
 
     // User intent: clip occupies 4 timeline beats, loop covers the full file.
     clip.lengthBeats = 4.0;
-    clip.loopLengthBeats = 4.0;
-    clip.loopStartBeats = 0.0;
+    magda::test::audioEvent(clip).setLoopLengthBeats(4.0);
+    magda::test::audioEvent(clip).setLoopStartBeats(0.0);
 
     // Time-domain values consistent with the above (canonical setter would
     // recompute these; we seed them so reads-without-call still succeed).
     clip.length = clip.lengthBeats * 60.0 / PROJECT_BPM;
-    clip.loopLength = clip.loopLengthBeats * 60.0 / clip.audio().interpretation.bpm;
-    clip.loopStart = 0.0;
+    magda::test::audioEvent(clip).setLoopLengthSeconds(
+        magda::test::audioEvent(clip).loopLengthBeats() * 60.0 /
+        magda::test::audioEvent(clip).interpBpm);
+    magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
     clip.startTime = 0.0;
     return clip;
 }
 
 double inspectorLoopEndReadoutBeats(const ClipInfo& clip, double fallbackBPM) {
     double loopBpm = fallbackBPM;
-    if (clip.isAudio() && clip.audio().interpretation.bpm > 0.0)
-        loopBpm = clip.audio().interpretation.bpm;
+    if (clip.isAudio() && magda::audioEventRef(clip).interpBpm > 0.0)
+        loopBpm = magda::audioEventRef(clip).interpBpm;
     if (loopBpm <= 0.0)
         loopBpm = 120.0;
 
-    const double loopStartBeats = clip.loopStart * loopBpm / 60.0;
+    const double loopStartBeats = magda::audioEventRef(clip).loopStartSeconds() * loopBpm / 60.0;
     double loopLengthDisplayBeats = 0.0;
-    if (clip.autoTempo && clip.loopLengthBeats > 0.0) {
-        loopLengthDisplayBeats = clip.loopLengthBeats;
+    if (magda::audioEventRef(clip).autoTempo &&
+        magda::audioEventRef(clip).loopLengthBeats() > 0.0) {
+        loopLengthDisplayBeats = magda::audioEventRef(clip).loopLengthBeats();
     } else {
-        const double sourceLength =
-            clip.loopLength > 0.0 ? clip.loopLength : clip.length * clip.speedRatio;
+        const double sourceLength = magda::audioEventRef(clip).loopLengthSeconds() > 0.0
+                                        ? magda::audioEventRef(clip).loopLengthSeconds()
+                                        : clip.length * magda::audioEventRef(clip).speedRatio;
         loopLengthDisplayBeats = sourceLength * loopBpm / 60.0;
     }
     return loopStartBeats + loopLengthDisplayBeats;
@@ -91,16 +96,16 @@ TEST_CASE("applyAudioClipBeats - BPM correction preserves source region seconds"
         const auto* c = ClipManager::getInstance().getClip(seed.id);
         REQUIRE(c != nullptr);
         // Source fact preserved; interpretation updated.
-        REQUIRE(c->audio().source.durationSeconds == Approx(FILE_DURATION));
-        REQUIRE(c->audio().interpretation.bpm == Approx(240.0));
-        REQUIRE(c->audio().interpretation.totalBeats == Approx(8.0));
+        REQUIRE(primaryEventOf(c)->sourceDurationSeconds() == Approx(FILE_DURATION));
+        REQUIRE(primaryEventOf(c)->interpBpm == Approx(240.0));
+        REQUIRE(primaryEventOf(c)->interpTotalBeats == Approx(8.0));
         // User timeline intent untouched.
         REQUIRE(c->lengthBeats == Approx(4.0));
         // Source region in seconds is untouched, so its source-beat value changes with BPM.
-        REQUIRE(c->loopLengthBeats == Approx(8.0));
+        REQUIRE(primaryEventOf(c)->loopLengthBeats() == Approx(8.0));
         // Timeline length untouched (still 4 project beats = 2.0 s at 120 BPM).
         REQUIRE(c->length == Approx(2.0));
-        REQUIRE(c->loopLength == Approx(FILE_DURATION));
+        REQUIRE(primaryEventOf(c)->loopLengthSeconds() == Approx(FILE_DURATION));
     }
 
     SECTION("Halving BPM keeps timeline length unchanged") {
@@ -110,8 +115,8 @@ TEST_CASE("applyAudioClipBeats - BPM correction preserves source region seconds"
         ClipManager::getInstance().applyAudioClipBeats(seed.id, u, PROJECT_BPM);
 
         const auto* c = ClipManager::getInstance().getClip(seed.id);
-        REQUIRE(c->audio().source.durationSeconds == Approx(FILE_DURATION));
-        REQUIRE(c->audio().interpretation.bpm == Approx(60.0));
+        REQUIRE(primaryEventOf(c)->sourceDurationSeconds() == Approx(FILE_DURATION));
+        REQUIRE(primaryEventOf(c)->interpBpm == Approx(60.0));
         REQUIRE(c->lengthBeats == Approx(4.0));
         REQUIRE(c->length == Approx(2.0));
     }
@@ -145,7 +150,7 @@ TEST_CASE("getTimelineLoopLength tracks the loop wrap after a BPM reinterpretati
 
     const auto* c = ClipManager::getInstance().getClip(seed.id);
     REQUIRE(c != nullptr);
-    REQUIRE(c->loopLengthBeats == Approx(8.0));
+    REQUIRE(primaryEventOf(c)->loopLengthBeats() == Approx(8.0));
     REQUIRE(c->lengthBeats == Approx(4.0));
 
     // Placement-based length is unchanged (the old, buggy denominator)...
@@ -171,8 +176,8 @@ TEST_CASE("applyAudioClipBeats - beat-length edit preserves detected BPM",
         REQUIRE(c->lengthBeats == Approx(8.0));
         REQUIRE(c->length == Approx(4.0));  // 8 beats at 120 BPM
         // Detected metadata MUST NOT have changed.
-        REQUIRE(c->audio().interpretation.bpm == Approx(DETECTED_BPM));
-        REQUIRE(c->audio().interpretation.totalBeats == Approx(DETECTED_NUM_BEATS));
+        REQUIRE(primaryEventOf(c)->interpBpm == Approx(DETECTED_BPM));
+        REQUIRE(primaryEventOf(c)->interpTotalBeats == Approx(DETECTED_NUM_BEATS));
     }
 
     SECTION("Halving target length does not change source interpretation BPM") {
@@ -183,8 +188,8 @@ TEST_CASE("applyAudioClipBeats - beat-length edit preserves detected BPM",
         const auto* c = ClipManager::getInstance().getClip(seed.id);
         REQUIRE(c->lengthBeats == Approx(2.0));
         REQUIRE(c->length == Approx(1.0));
-        REQUIRE(c->audio().interpretation.bpm == Approx(DETECTED_BPM));
-        REQUIRE(c->audio().interpretation.totalBeats == Approx(DETECTED_NUM_BEATS));
+        REQUIRE(primaryEventOf(c)->interpBpm == Approx(DETECTED_BPM));
+        REQUIRE(primaryEventOf(c)->interpTotalBeats == Approx(DETECTED_NUM_BEATS));
     }
 }
 
@@ -201,9 +206,9 @@ TEST_CASE("loop-length edit does not rewrite source total beats", "[clip][bpm][i
 
         const auto* c = ClipManager::getInstance().getClip(seed.id);
         REQUIRE(c != nullptr);
-        REQUIRE(c->loopLengthBeats == Approx(8.0));
-        REQUIRE(c->audio().interpretation.totalBeats == Approx(DETECTED_NUM_BEATS));
-        REQUIRE_FALSE(c->audio().interpretation.totalBeatsLocked);
+        REQUIRE(primaryEventOf(c)->loopLengthBeats() == Approx(8.0));
+        REQUIRE(primaryEventOf(c)->interpTotalBeats == Approx(DETECTED_NUM_BEATS));
+        REQUIRE_FALSE(primaryEventOf(c)->interpTotalBeatsLocked);
     }
 
     SECTION("Manual total beats override remains independent from future loop edits") {
@@ -218,9 +223,9 @@ TEST_CASE("loop-length edit does not rewrite source total beats", "[clip][bpm][i
 
         const auto* c = ClipManager::getInstance().getClip(seed.id);
         REQUIRE(c != nullptr);
-        REQUIRE(c->loopLengthBeats == Approx(8.0));
-        REQUIRE(c->audio().interpretation.totalBeats == Approx(13.0));
-        REQUIRE(c->audio().interpretation.totalBeatsLocked);
+        REQUIRE(primaryEventOf(c)->loopLengthBeats() == Approx(8.0));
+        REQUIRE(primaryEventOf(c)->interpTotalBeats == Approx(13.0));
+        REQUIRE(primaryEventOf(c)->interpTotalBeatsLocked);
     }
 }
 
@@ -233,15 +238,15 @@ TEST_CASE("source beats edits update inspector loop end readout",
     constexpr double sourceDuration = sourceBeats * 60.0 / sourceBPM;
 
     auto seed = makeSessionAutoTempoClip();
-    seed.audio().source.durationSeconds = sourceDuration;
-    seed.audio().interpretation.bpm = sourceBPM;
-    seed.audio().interpretation.totalBeats = sourceBeats;
+    magda::test::setSourceDuration(seed, sourceDuration);
+    magda::test::audioEvent(seed).interpBpm = sourceBPM;
+    magda::test::audioEvent(seed).interpTotalBeats = sourceBeats;
     seed.setPlacementBeats(0.0, 16.0);
     seed.length = 16.0 * 60.0 / PROJECT_BPM;
-    seed.loopStart = 0.0;
-    seed.loopStartBeats = 0.0;
-    seed.loopLength = sourceDuration;
-    seed.loopLengthBeats = sourceBeats;
+    magda::test::audioEvent(seed).setLoopStartSeconds(0.0);
+    magda::test::audioEvent(seed).setLoopStartBeats(0.0);
+    magda::test::audioEvent(seed).setLoopLengthSeconds(sourceDuration);
+    magda::test::audioEvent(seed).setLoopLengthBeats(sourceBeats);
     ClipManager::getInstance().restoreClip(seed);
 
     auto applySourceBeats = [&](double beats) {
@@ -255,7 +260,7 @@ TEST_CASE("source beats edits update inspector loop end readout",
     SECTION("16 beats displays a four-bar loop end") {
         const auto* c = ClipManager::getInstance().getClip(seed.id);
         REQUIRE(c != nullptr);
-        REQUIRE(c->loopLengthBeats == Approx(16.0));
+        REQUIRE(primaryEventOf(c)->loopLengthBeats() == Approx(16.0));
         REQUIRE(inspectorLoopEndReadoutBeats(*c, PROJECT_BPM) == Approx(16.0));
     }
 
@@ -263,17 +268,17 @@ TEST_CASE("source beats edits update inspector loop end readout",
         applySourceBeats(12.0);
         const auto* c = ClipManager::getInstance().getClip(seed.id);
         REQUIRE(c != nullptr);
-        REQUIRE(c->audio().interpretation.totalBeats == Approx(12.0));
-        REQUIRE(c->loopLength == Approx(sourceDuration));
-        REQUIRE(c->loopLengthBeats == Approx(12.0));
+        REQUIRE(primaryEventOf(c)->interpTotalBeats == Approx(12.0));
+        REQUIRE(primaryEventOf(c)->loopLengthSeconds() == Approx(sourceDuration));
+        REQUIRE(primaryEventOf(c)->loopLengthBeats() == Approx(12.0));
         REQUIRE(inspectorLoopEndReadoutBeats(*c, PROJECT_BPM) == Approx(12.0));
 
         applySourceBeats(8.0);
         c = ClipManager::getInstance().getClip(seed.id);
         REQUIRE(c != nullptr);
-        REQUIRE(c->audio().interpretation.totalBeats == Approx(8.0));
-        REQUIRE(c->loopLength == Approx(sourceDuration));
-        REQUIRE(c->loopLengthBeats == Approx(8.0));
+        REQUIRE(primaryEventOf(c)->interpTotalBeats == Approx(8.0));
+        REQUIRE(primaryEventOf(c)->loopLengthSeconds() == Approx(sourceDuration));
+        REQUIRE(primaryEventOf(c)->loopLengthBeats() == Approx(8.0));
         REQUIRE(inspectorLoopEndReadoutBeats(*c, PROJECT_BPM) == Approx(8.0));
     }
 }
@@ -293,11 +298,11 @@ TEST_CASE("setLengthBeats extends placement without growing source loop or inter
     REQUIRE(c->placement.lengthBeats == Approx(8.0));
     REQUIRE(c->length == Approx(4.0));
 
-    REQUIRE(c->loopLengthBeats == Approx(4.0));
-    REQUIRE(c->loopLength == Approx(2.0));
-    REQUIRE(c->audio().interpretation.bpm == Approx(DETECTED_BPM));
-    REQUIRE(c->audio().interpretation.totalBeats == Approx(DETECTED_NUM_BEATS));
-    REQUIRE(c->audio().source.durationSeconds == Approx(FILE_DURATION));
+    REQUIRE(primaryEventOf(c)->loopLengthBeats() == Approx(4.0));
+    REQUIRE(primaryEventOf(c)->loopLengthSeconds() == Approx(2.0));
+    REQUIRE(primaryEventOf(c)->interpBpm == Approx(DETECTED_BPM));
+    REQUIRE(primaryEventOf(c)->interpTotalBeats == Approx(DETECTED_NUM_BEATS));
+    REQUIRE(primaryEventOf(c)->sourceDurationSeconds() == Approx(FILE_DURATION));
 }
 
 TEST_CASE("late source metadata does not overwrite extended clip placement",
@@ -305,34 +310,34 @@ TEST_CASE("late source metadata does not overwrite extended clip placement",
     ClipManager::getInstance().shutdown();
 
     auto clip = makeSessionAutoTempoClip();
-    clip.audio().interpretation.bpm = 0.0;
-    clip.audio().interpretation.totalBeats = 0.0;
-    clip.audio().source.durationSeconds = 0.0;
+    magda::test::audioEvent(clip).interpBpm = 0.0;
+    magda::test::audioEvent(clip).interpTotalBeats = 0.0;
+    magda::test::setSourceDuration(clip, 0.0);
     clip.setPlacementBeats(0.0, 356.0);  // 89 bars at 4/4
     clip.length = 356.0 * 60.0 / PROJECT_BPM;
-    clip.loopLengthBeats = 8.0;
-    clip.loopLength = 8.0 * 60.0 / 172.0;
+    magda::test::audioEvent(clip).setLoopLengthBeats(8.0);
+    magda::test::audioEvent(clip).setLoopLengthSeconds(8.0 * 60.0 / 172.0);
 
-    clip.setSourceMetadata(8.0, 172.0);
+    magda::test::audioEvent(clip).seedInterpretation(8.0, 172.0);
 
     REQUIRE(clip.placement.lengthBeats == Approx(356.0));
     REQUIRE(clip.lengthBeats == Approx(356.0));
-    REQUIRE(clip.loopLengthBeats == Approx(8.0));
-    REQUIRE(clip.audio().interpretation.bpm == Approx(172.0));
-    REQUIRE(clip.audio().interpretation.totalBeats == Approx(8.0));
+    REQUIRE(magda::test::audioEvent(clip).loopLengthBeats() == Approx(8.0));
+    REQUIRE(magda::test::audioEvent(clip).interpBpm == Approx(172.0));
+    REQUIRE(magda::test::audioEvent(clip).interpTotalBeats == Approx(8.0));
 }
 
 TEST_CASE("resizeClip extends looped beat-mode clip placement only", "[clip][bpm][issue-1157]") {
     ClipManager::getInstance().shutdown();
 
     auto seed = makeSessionAutoTempoClip();
-    seed.audio().interpretation.bpm = 172.0;
-    seed.audio().interpretation.totalBeats = 8.0;
-    seed.audio().source.durationSeconds = 8.0 * 60.0 / 172.0;
+    magda::test::audioEvent(seed).interpBpm = 172.0;
+    magda::test::audioEvent(seed).interpTotalBeats = 8.0;
+    magda::test::setSourceDuration(seed, 8.0 * 60.0 / 172.0);
     seed.setPlacementBeats(0.0, 8.0);
     seed.length = 8.0 * 60.0 / PROJECT_BPM;
-    seed.loopLengthBeats = 8.0;
-    seed.loopLength = 8.0 * 60.0 / 172.0;
+    magda::test::audioEvent(seed).setLoopLengthBeats(8.0);
+    magda::test::audioEvent(seed).setLoopLengthSeconds(8.0 * 60.0 / 172.0);
     ClipManager::getInstance().restoreClip(seed);
 
     ClipManager::getInstance().resizeClip(seed.id, 356.0 * 60.0 / PROJECT_BPM, false, PROJECT_BPM);
@@ -341,10 +346,10 @@ TEST_CASE("resizeClip extends looped beat-mode clip placement only", "[clip][bpm
     REQUIRE(c != nullptr);
     REQUIRE(c->placement.lengthBeats == Approx(356.0));
     REQUIRE(c->lengthBeats == Approx(356.0));
-    REQUIRE(c->loopLengthBeats == Approx(8.0));
-    REQUIRE(c->audio().interpretation.bpm == Approx(172.0));
-    REQUIRE(c->audio().interpretation.totalBeats == Approx(8.0));
-    REQUIRE(c->audio().source.durationSeconds == Approx(8.0 * 60.0 / 172.0));
+    REQUIRE(primaryEventOf(c)->loopLengthBeats() == Approx(8.0));
+    REQUIRE(primaryEventOf(c)->interpBpm == Approx(172.0));
+    REQUIRE(primaryEventOf(c)->interpTotalBeats == Approx(8.0));
+    REQUIRE(primaryEventOf(c)->sourceDurationSeconds() == Approx(8.0 * 60.0 / 172.0));
 }
 
 TEST_CASE("applyAudioClipBeats - all derived fields agree after edit", "[clip][bpm][issue-1157]") {
@@ -367,9 +372,10 @@ TEST_CASE("applyAudioClipBeats - all derived fields agree after edit", "[clip][b
     // Timeline-domain pair: length must equal lengthBeats * 60 / projectBPM.
     REQUIRE(c->length == Approx(c->lengthBeats * 60.0 / PROJECT_BPM));
     // Source-domain pair: loopLength must equal loopLengthBeats * 60 / source interpretation BPM.
-    REQUIRE(c->loopLength == Approx(c->loopLengthBeats * 60.0 / c->audio().interpretation.bpm));
+    REQUIRE(primaryEventOf(c)->loopLengthSeconds() ==
+            Approx(primaryEventOf(c)->loopLengthBeats() * 60.0 / primaryEventOf(c)->interpBpm));
     // speedRatio is forced to 1.0.
-    REQUIRE(c->speedRatio == Approx(1.0));
+    REQUIRE(primaryEventOf(c)->speedRatio == Approx(1.0));
 }
 
 TEST_CASE("beat-mode phase edits do not mutate loop length", "[clip][bpm][phase]") {
@@ -377,12 +383,12 @@ TEST_CASE("beat-mode phase edits do not mutate loop length", "[clip][bpm][phase]
 
     auto seed = makeSessionAutoTempoClip();
     seed.loopEnabled = false;  // BEAT mode owns the active source loop.
-    seed.loopStart = 0.0;
-    seed.loopStartBeats = 0.0;
-    seed.offset = 0.0;
-    seed.offsetBeats = 0.0;
-    seed.loopLengthBeats = 4.0;
-    seed.loopLength = FILE_DURATION;
+    magda::test::audioEvent(seed).setLoopStartSeconds(0.0);
+    magda::test::audioEvent(seed).setLoopStartBeats(0.0);
+    magda::test::audioEvent(seed).setAnchorSeconds(0.0);
+    magda::test::audioEvent(seed).setAnchorBeats(0.0);
+    magda::test::audioEvent(seed).setLoopLengthBeats(4.0);
+    magda::test::audioEvent(seed).setLoopLengthSeconds(FILE_DURATION);
     ClipManager::getInstance().restoreClip(seed);
 
     const double phaseBeats = 1.0;
@@ -391,19 +397,19 @@ TEST_CASE("beat-mode phase edits do not mutate loop length", "[clip][bpm][phase]
 
     const auto* c = ClipManager::getInstance().getClip(seed.id);
     REQUIRE(c != nullptr);
-    REQUIRE(c->offset == Approx(phaseSeconds));
-    REQUIRE(c->offsetBeats == Approx(phaseBeats));
-    REQUIRE(c->loopStart == Approx(0.0));
-    REQUIRE(c->loopStartBeats == Approx(0.0));
-    REQUIRE(c->loopLength == Approx(FILE_DURATION));
-    REQUIRE(c->loopLengthBeats == Approx(4.0));
+    REQUIRE(primaryEventOf(c)->anchorSeconds() == Approx(phaseSeconds));
+    REQUIRE(primaryEventOf(c)->anchorBeats() == Approx(phaseBeats));
+    REQUIRE(primaryEventOf(c)->loopStartSeconds() == Approx(0.0));
+    REQUIRE(primaryEventOf(c)->loopStartBeats() == Approx(0.0));
+    REQUIRE(primaryEventOf(c)->loopLengthSeconds() == Approx(FILE_DURATION));
+    REQUIRE(primaryEventOf(c)->loopLengthBeats() == Approx(4.0));
 }
 
 TEST_CASE("applyAudioClipBeats - no-op for non-autoTempo clips", "[clip][bpm][issue-1157]") {
     ClipManager::getInstance().shutdown();
 
     auto seed = makeSessionAutoTempoClip();
-    seed.autoTempo = false;
+    magda::test::audioEvent(seed).autoTempo = false;
     seed.length = 1.0;
     seed.lengthBeats = 0.0;  // arrangement-style: time-authoritative
     ClipManager::getInstance().restoreClip(seed);
@@ -423,10 +429,10 @@ TEST_CASE("applyAudioClipBeats - source interpretation BPM unknown leaves source
     ClipManager::getInstance().shutdown();
 
     auto seed = makeSessionAutoTempoClip();
-    seed.audio().interpretation.bpm = 0.0;         // detection has not yet completed
-    seed.audio().interpretation.totalBeats = 0.0;  // ditto
-    seed.loopLength = 0.0;
-    seed.loopStart = 0.0;
+    magda::test::audioEvent(seed).interpBpm = 0.0;         // detection has not yet completed
+    magda::test::audioEvent(seed).interpTotalBeats = 0.0;  // ditto
+    magda::test::audioEvent(seed).setLoopLengthSeconds(0.0);
+    magda::test::audioEvent(seed).setLoopStartSeconds(0.0);
     ClipManager::getInstance().restoreClip(seed);
 
     ClipManager::AudioClipBeatsUpdate u;
@@ -439,7 +445,7 @@ TEST_CASE("applyAudioClipBeats - source interpretation BPM unknown leaves source
     // loopLength stays 0 — we only touch source-domain seconds when source interpretation BPM
     // is known. ClipDisplayInfo and TE have fallback paths for the pre-detection
     // window.
-    REQUIRE(c->loopLength == Approx(0.0));
+    REQUIRE(primaryEventOf(c)->loopLengthSeconds() == Approx(0.0));
 }
 
 TEST_CASE("setAutoTempo adopts cached detected BPM when clip BPM is project default",
@@ -457,16 +463,17 @@ TEST_CASE("setAutoTempo adopts cached detected BPM when clip BPM is project defa
     seed.trackId = 1;
     seed.setAudioContent();
     seed.view = ClipView::Arrangement;
-    seed.audio().source.filePath = path;
+    magda::test::giveAudioEvent(seed, path);
     seed.loopEnabled = false;
-    seed.autoTempo = false;
-    seed.speedRatio = 1.0;
+    magda::test::audioEvent(seed).autoTempo = false;
+    magda::test::audioEvent(seed).speedRatio = 1.0;
     seed.startTime = 0.0;
     seed.length = sourceDuration;
-    seed.loopStart = 0.0;
-    seed.loopLength = sourceDuration;
-    seed.audio().interpretation.bpm = PROJECT_BPM;  // defaulted placeholder, not trusted metadata
-    seed.audio().interpretation.totalBeats = 0.0;
+    magda::test::audioEvent(seed).setLoopStartSeconds(0.0);
+    magda::test::audioEvent(seed).setLoopLengthSeconds(sourceDuration);
+    magda::test::audioEvent(seed).interpBpm =
+        PROJECT_BPM;  // defaulted placeholder, not trusted metadata
+    magda::test::audioEvent(seed).interpTotalBeats = 0.0;
     seed.setPlacementBeats(0.0, sourceDuration * PROJECT_BPM / 60.0);
 
     ClipManager::getInstance().restoreClip(seed);
@@ -476,9 +483,9 @@ TEST_CASE("setAutoTempo adopts cached detected BPM when clip BPM is project defa
 
     const auto* c = ClipManager::getInstance().getClip(seed.id);
     REQUIRE(c != nullptr);
-    REQUIRE(c->autoTempo);
-    REQUIRE(c->audio().interpretation.bpm == Approx(detectedBPM));
-    REQUIRE(c->audio().interpretation.totalBeats == Approx(expectedSourceBeats));
+    REQUIRE(primaryEventOf(c)->autoTempo);
+    REQUIRE(primaryEventOf(c)->interpBpm == Approx(detectedBPM));
+    REQUIRE(primaryEventOf(c)->interpTotalBeats == Approx(expectedSourceBeats));
     REQUIRE(c->lengthBeats == Approx(expectedSourceBeats));
     REQUIRE(c->placement.lengthBeats == Approx(expectedSourceBeats));
     REQUIRE(c->length == Approx(expectedSourceBeats * 60.0 / PROJECT_BPM));
@@ -505,13 +512,14 @@ TEST_CASE("session audio import uses detector when loopInfo is still defaulted",
     const auto* c = ClipManager::getInstance().getClip(clipId);
     REQUIRE(c != nullptr);
     REQUIRE(c->view == ClipView::Session);
-    REQUIRE(c->autoTempo);
+    REQUIRE(primaryEventOf(c)->autoTempo);
     REQUIRE(c->loopEnabled);
-    REQUIRE(c->audio().interpretation.bpm == Approx(cachedDetectorBPM));
-    REQUIRE(c->audio().interpretation.totalBeats ==
+    REQUIRE(primaryEventOf(c)->interpBpm == Approx(cachedDetectorBPM));
+    REQUIRE(primaryEventOf(c)->interpTotalBeats ==
             Approx(sourceDuration * cachedDetectorBPM / 60.0));
-    REQUIRE(c->loopLength == Approx(sourceDuration));
-    REQUIRE(c->loopLengthBeats == Approx(sourceDuration * cachedDetectorBPM / 60.0));
+    REQUIRE(primaryEventOf(c)->loopLengthSeconds() == Approx(sourceDuration));
+    REQUIRE(primaryEventOf(c)->loopLengthBeats() ==
+            Approx(sourceDuration * cachedDetectorBPM / 60.0));
 
     AudioThumbnailManager::getInstance().clearCache();
     path.deleteFile();
@@ -536,7 +544,7 @@ TEST_CASE("audio clip creation accepts beat placement without seconds round-trip
     REQUIRE(clip->lengthBeats == Approx(lengthBeats));
     REQUIRE(clip->startTime == Approx(startBeats * 60.0 / projectBpm));
     REQUIRE(clip->length == Approx(lengthBeats * 60.0 / projectBpm));
-    REQUIRE(clip->loopLength == Approx(lengthBeats * 60.0 / projectBpm));
+    REQUIRE(primaryEventOf(clip)->loopLengthSeconds() == Approx(lengthBeats * 60.0 / projectBpm));
 }
 
 TEST_CASE("audio clip manager operations accept beat placement", "[clip][bpm][beats][audio]") {
@@ -644,9 +652,9 @@ TEST_CASE("source interpretation BPM correction does not move the clip on the ti
     // Initial state: clip is 24 timeline beats long, file interpreted at 120 BPM,
     // loop covers an 8-second source region. Its beat readout is 16 beats at 120 BPM.
     seed.lengthBeats = 24.0;
-    seed.loopLengthBeats = 16.0;
-    seed.audio().interpretation.bpm = 120.0;
-    seed.audio().interpretation.totalBeats = 16.0;
+    magda::test::audioEvent(seed).setLoopLengthBeats(16.0);
+    magda::test::audioEvent(seed).interpBpm = 120.0;
+    magda::test::audioEvent(seed).interpTotalBeats = 16.0;
     ClipManager::getInstance().restoreClip(
         seed);  // no-op (already there) — values applied directly
     ClipManager::AudioClipBeatsUpdate prime;
@@ -668,8 +676,8 @@ TEST_CASE("source interpretation BPM correction does not move the clip on the ti
         c = ClipManager::getInstance().getClip(seed.id);
         REQUIRE(c->lengthBeats == Approx(24.0));
         REQUIRE(c->length == Approx(12.0));
-        REQUIRE(c->loopLength == Approx(8.0));
-        REQUIRE(c->loopLengthBeats == Approx(32.0));  // 8s × 240/60
+        REQUIRE(primaryEventOf(c)->loopLengthSeconds() == Approx(8.0));
+        REQUIRE(primaryEventOf(c)->loopLengthBeats() == Approx(32.0));  // 8s × 240/60
     }
 
     SECTION("Halving source interpretation BPM: timeline length unchanged, loop beats follow") {
@@ -681,8 +689,8 @@ TEST_CASE("source interpretation BPM correction does not move the clip on the ti
         c = ClipManager::getInstance().getClip(seed.id);
         REQUIRE(c->lengthBeats == Approx(24.0));
         REQUIRE(c->length == Approx(12.0));
-        REQUIRE(c->loopLength == Approx(8.0));
-        REQUIRE(c->loopLengthBeats == Approx(8.0));  // 8s × 60/60
+        REQUIRE(primaryEventOf(c)->loopLengthSeconds() == Approx(8.0));
+        REQUIRE(primaryEventOf(c)->loopLengthBeats() == Approx(8.0));  // 8s × 60/60
     }
 }
 

--- a/tests/test_clip_commands.cpp
+++ b/tests/test_clip_commands.cpp
@@ -3,6 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <unordered_set>
 
+#include "AudioClipTestHelpers.hpp"
 #include "magda/daw/core/ClipCommands.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/ClipPropertyCommands.hpp"
@@ -398,14 +399,17 @@ TEST_CASE(
     auto& cm = ClipManager::getInstance();
     auto* source = cm.getClip(sourceId);
     REQUIRE(source != nullptr);
-    source->autoTempo = true;
+    primaryEventOf(source)->autoTempo = true;
     source->loopEnabled = true;
-    source->audio().interpretation.bpm = 172.0;
-    source->audio().interpretation.totalBeats = 16.0;
-    source->audio().source.durationSeconds = 16.0 * 60.0 / 172.0;
-    source->loopStartBeats = 0.0;
-    source->loopLengthBeats = 16.0;
-    source->offsetBeats = 0.0;
+    primaryEventOf(source)->interpBpm = 172.0;
+    primaryEventOf(source)->interpTotalBeats = 16.0;
+    magda::SourcePool::getInstance().seedFactsForTesting(primaryEventOf(source)->sourceFilePath(),
+                                                         16.0 * 60.0 / 172.0,
+                                                         magda::test::kTestSourceSampleRate);
+    magda::SourcePool::getInstance().resolveFacts(primaryEventOf(source)->sourceId);
+    primaryEventOf(source)->setLoopStartBeats(0.0);
+    primaryEventOf(source)->setLoopLengthBeats(16.0);
+    primaryEventOf(source)->setAnchorBeats(0.0);
     source->setPlacementBeats(2.0, 4.0);  // actual timeline: 1s..3s at 120 BPM
     source->startTime = 99.0;             // stale transitional cache
     source->length = 99.0;
@@ -424,7 +428,7 @@ TEST_CASE(
     REQUIRE(pasted->length == Catch::Approx(0.5));
     REQUIRE(pasted->placement.startBeat == Catch::Approx(6.0));
     REQUIRE(pasted->placement.lengthBeats == Catch::Approx(1.0));
-    REQUIRE(pasted->offsetBeats == Catch::Approx(1.0));
+    REQUIRE(primaryEventOf(pasted)->anchorBeats() == Catch::Approx(1.0));
 
     proj.setTempo(originalTempo);
 }
@@ -442,17 +446,21 @@ TEST_CASE("copyTimeRangeToClipboard + paste - exact beat slice keeps waveform id
     auto& cm = ClipManager::getInstance();
     auto* source = cm.getClip(sourceId);
     REQUIRE(source != nullptr);
-    source->autoTempo = true;
+    primaryEventOf(source)->autoTempo = true;
     source->loopEnabled = true;
-    source->audio().interpretation.bpm = 172.0;
-    source->audio().interpretation.totalBeats = 16.0;
-    source->audio().source.durationSeconds = 16.0 * 60.0 / 172.0;
-    source->loopStartBeats = 0.0;
-    source->loopLengthBeats = 16.0;
-    source->offsetBeats = 3.0;
-    source->offset = source->offsetBeats * 60.0 / source->audio().interpretation.bpm;
-    source->loopStart = 0.0;
-    source->loopLength = source->audio().source.durationSeconds;
+    primaryEventOf(source)->interpBpm = 172.0;
+    primaryEventOf(source)->interpTotalBeats = 16.0;
+    magda::SourcePool::getInstance().seedFactsForTesting(primaryEventOf(source)->sourceFilePath(),
+                                                         16.0 * 60.0 / 172.0,
+                                                         magda::test::kTestSourceSampleRate);
+    magda::SourcePool::getInstance().resolveFacts(primaryEventOf(source)->sourceId);
+    primaryEventOf(source)->setLoopStartBeats(0.0);
+    primaryEventOf(source)->setLoopLengthBeats(16.0);
+    primaryEventOf(source)->setAnchorBeats(3.0);
+    primaryEventOf(source)->setAnchorSeconds(primaryEventOf(source)->anchorBeats() * 60.0 /
+                                             primaryEventOf(source)->interpBpm);
+    primaryEventOf(source)->setLoopStartSeconds(0.0);
+    primaryEventOf(source)->setLoopLengthSeconds(primaryEventOf(source)->sourceDurationSeconds());
     source->setPlacementBeats(1.0, 1.0);
     source->deriveTimesFromBeats(120.0);
 
@@ -469,19 +477,24 @@ TEST_CASE("copyTimeRangeToClipboard + paste - exact beat slice keeps waveform id
     REQUIRE(pasted != nullptr);
 
     // A copied slice should present the same waveform source identity as A.
-    REQUIRE(pasted->audio().source.filePath == source->audio().source.filePath);
-    REQUIRE(pasted->autoTempo == source->autoTempo);
+    REQUIRE(primaryEventOf(pasted)->sourceFilePath() == primaryEventOf(source)->sourceFilePath());
+    REQUIRE(primaryEventOf(pasted)->autoTempo == primaryEventOf(source)->autoTempo);
     REQUIRE(pasted->loopEnabled == source->loopEnabled);
-    REQUIRE(pasted->offsetBeats == Catch::Approx(source->offsetBeats));
-    REQUIRE(pasted->offset == Catch::Approx(source->offset));
-    REQUIRE(pasted->loopStartBeats == Catch::Approx(source->loopStartBeats));
-    REQUIRE(pasted->loopLengthBeats == Catch::Approx(source->loopLengthBeats));
-    REQUIRE(pasted->loopStart == Catch::Approx(source->loopStart));
-    REQUIRE(pasted->loopLength == Catch::Approx(source->loopLength));
-    REQUIRE(pasted->audio().interpretation.bpm ==
-            Catch::Approx(source->audio().interpretation.bpm));
-    REQUIRE(pasted->audio().interpretation.totalBeats ==
-            Catch::Approx(source->audio().interpretation.totalBeats));
+    REQUIRE(primaryEventOf(pasted)->anchorBeats() ==
+            Catch::Approx(primaryEventOf(source)->anchorBeats()));
+    REQUIRE(primaryEventOf(pasted)->anchorSeconds() ==
+            Catch::Approx(primaryEventOf(source)->anchorSeconds()));
+    REQUIRE(primaryEventOf(pasted)->loopStartBeats() ==
+            Catch::Approx(primaryEventOf(source)->loopStartBeats()));
+    REQUIRE(primaryEventOf(pasted)->loopLengthBeats() ==
+            Catch::Approx(primaryEventOf(source)->loopLengthBeats()));
+    REQUIRE(primaryEventOf(pasted)->loopStartSeconds() ==
+            Catch::Approx(primaryEventOf(source)->loopStartSeconds()));
+    REQUIRE(primaryEventOf(pasted)->loopLengthSeconds() ==
+            Catch::Approx(primaryEventOf(source)->loopLengthSeconds()));
+    REQUIRE(primaryEventOf(pasted)->interpBpm == Catch::Approx(primaryEventOf(source)->interpBpm));
+    REQUIRE(primaryEventOf(pasted)->interpTotalBeats ==
+            Catch::Approx(primaryEventOf(source)->interpTotalBeats));
     REQUIRE(pasted->placement.lengthBeats == Catch::Approx(source->placement.lengthBeats));
 
     REQUIRE(pasted->placement.startBeat != Catch::Approx(source->placement.startBeat));
@@ -532,7 +545,6 @@ TEST_CASE("JoinClipsCommand - basic MIDI join", "[clip][command][join]") {
         REQUIRE(leftClip != nullptr);
         leftClip->loopEnabled = true;
         leftClip->loopLengthBeats = leftClip->placement.lengthBeats;
-        leftClip->loopLength = leftClip->getTimelineLength(120.0);
 
         JoinClipsCommand cmd(left, right);
         REQUIRE(cmd.canExecute());
@@ -543,7 +555,6 @@ TEST_CASE("JoinClipsCommand - basic MIDI join", "[clip][command][join]") {
         REQUIRE(joined->lengthBeats == Catch::Approx(8.0));
         REQUIRE_FALSE(joined->loopEnabled);
         REQUIRE(joined->loopLengthBeats == Catch::Approx(0.0));
-        REQUIRE(joined->loopLength == Catch::Approx(0.0));
         REQUIRE(joined->midiOffset == Catch::Approx(0.0));
         REQUIRE(joined->midiTrimOffset == Catch::Approx(0.0));
         REQUIRE(joined->midiNotes.size() == 2);
@@ -619,7 +630,6 @@ TEST_CASE("FlattenMidiClipCommand - renders a looped MIDI clip across its full l
     // including controller data and pitch bends.
     clip->loopEnabled = true;
     clip->loopLengthBeats = 2.0;
-    clip->loopLength = 1.0;
     clip->midiOffset = 1.0;
     clip->midiTrimOffset = 1.25;
     MidiCCData cc;
@@ -638,7 +648,6 @@ TEST_CASE("FlattenMidiClipCommand - renders a looped MIDI clip across its full l
 
     REQUIRE_FALSE(clip->loopEnabled);
     REQUIRE(clip->loopLengthBeats == Catch::Approx(0.0));
-    REQUIRE(clip->loopLength == Catch::Approx(0.0));
     REQUIRE(clip->midiOffset == Catch::Approx(0.0));
     REQUIRE(clip->midiTrimOffset == Catch::Approx(0.0));
     REQUIRE(clip->midiNotes.size() == 10);
@@ -856,11 +865,11 @@ TEST_CASE("SplitClipCommand - time-based audio ignores detected BPM for source o
     auto& cm = ClipManager::getInstance();
     auto* source = cm.getClip(original);
     REQUIRE(source != nullptr);
-    source->autoTempo = false;
-    source->warpEnabled = false;
-    source->audio().interpretation.bpm = 180.0;
-    source->speedRatio = 1.25;
-    source->offset = 0.4;
+    primaryEventOf(source)->autoTempo = false;
+    primaryEventOf(source)->warpEnabled = false;
+    primaryEventOf(source)->interpBpm = 180.0;
+    primaryEventOf(source)->speedRatio = 1.25;
+    primaryEventOf(source)->setAnchorSeconds(0.4);
 
     SplitClipCommand cmd(original, secondsToBeatPosition(2.0), 120.0);
     REQUIRE(cmd.canExecute());
@@ -870,7 +879,7 @@ TEST_CASE("SplitClipCommand - time-based audio ignores detected BPM for source o
     REQUIRE(right != nullptr);
     // Detected source BPM is metadata when tempo-follow and warp are disabled.
     // The right side must continue at timeline delta * speed ratio.
-    REQUIRE(right->offset == Catch::Approx(0.4 + 2.0 * 1.25));
+    REQUIRE(magda::audioEventRef(*right).anchorSeconds() == Catch::Approx(0.4 + 2.0 * 1.25));
 }
 
 TEST_CASE("SplitClipCommand - undo notifies restored left clip property",
@@ -1168,20 +1177,17 @@ TEST_CASE("MIDI loop start command stores beats without seconds reinterpretation
     auto* clip = ClipManager::getInstance().getClip(clipId);
     REQUIRE(clip != nullptr);
     clip->loopStartBeats = 3.0;
-    clip->loopStart = 2.0;  // 3 beats at 90 BPM
 
     SetMidiClipLoopStartBeatsCommand cmd(clipId, 6.0, bpm);
     cmd.execute();
 
     clip = ClipManager::getInstance().getClip(clipId);
     REQUIRE(clip->loopStartBeats == Catch::Approx(6.0));
-    REQUIRE(clip->loopStart == Catch::Approx(4.0));  // derived cache only
 
     cmd.undo();
 
     clip = ClipManager::getInstance().getClip(clipId);
     REQUIRE(clip->loopStartBeats == Catch::Approx(3.0));
-    REQUIRE(clip->loopStart == Catch::Approx(2.0));
 }
 
 TEST_CASE("MIDI loop length command stores beats without seconds reinterpretation",
@@ -1194,23 +1200,20 @@ TEST_CASE("MIDI loop length command stores beats without seconds reinterpretatio
     auto* clip = ClipManager::getInstance().getClip(clipId);
     REQUIRE(clip != nullptr);
     clip->loopLengthBeats = 3.0;
-    clip->loopLength = 2.0;  // 3 beats at 90 BPM
 
     SetMidiClipLoopLengthBeatsCommand cmd(clipId, 6.0, bpm);
     cmd.execute();
 
     clip = ClipManager::getInstance().getClip(clipId);
     REQUIRE(clip->loopLengthBeats == Catch::Approx(6.0));
-    REQUIRE(clip->loopLength == Catch::Approx(4.0));  // derived cache only
 
     cmd.undo();
 
     clip = ClipManager::getInstance().getClip(clipId);
     REQUIRE(clip->loopLengthBeats == Catch::Approx(3.0));
-    REQUIRE(clip->loopLength == Catch::Approx(2.0));
 }
 
-TEST_CASE("Legacy MIDI loop start seconds setter keeps beat mirror synced",
+TEST_CASE("MIDI loop start setter takes seconds and stores clip beats",
           "[clip][midi][loop][beats]") {
     resetState();
     constexpr double bpm = 90.0;
@@ -1221,7 +1224,6 @@ TEST_CASE("Legacy MIDI loop start seconds setter keeps beat mirror synced",
 
     auto* clip = ClipManager::getInstance().getClip(clipId);
     REQUIRE(clip != nullptr);
-    REQUIRE(clip->loopStart == Catch::Approx(4.0));
     REQUIRE(clip->loopStartBeats == Catch::Approx(6.0));
 }
 
@@ -1260,7 +1262,7 @@ TEST_CASE("DeleteTimeSelectionCommand - looped trim keeps beat placement in sync
     auto* before = ClipManager::getInstance().getClip(clipId);
     REQUIRE(before != nullptr);
     before->loopEnabled = true;
-    before->loopLength = 4.0;
+    magda::primaryEventOf(before)->setLoopLengthSeconds(4.0);
 
     DeleteTimeSelectionCommand cmd(0.0, 3.0, {track}, 120.0);
     cmd.execute();
@@ -1347,7 +1349,7 @@ TEST_CASE("InsertTimeCommand - looped clip spanning insert beat grows",
     auto* before = ClipManager::getInstance().getClip(clipId);
     REQUIRE(before != nullptr);
     before->loopEnabled = true;
-    before->loopLength = 2.0;
+    magda::primaryEventOf(before)->setLoopLengthSeconds(2.0);
 
     // Looped clip spanning the insert beat grows by the inserted duration
     // instead of splitting.

--- a/tests/test_clip_crossfades.cpp
+++ b/tests/test_clip_crossfades.cpp
@@ -1,11 +1,26 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include "AudioClipTestHelpers.hpp"
 #include "magda/daw/core/ClipCommands.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/Config.hpp"
 #include "magda/daw/core/TrackManager.hpp"
 #include "magda/daw/core/UndoManager.hpp"
+
+namespace {
+/// Source duration is a pooled file fact, so a test that wants one seeds the
+/// pool rather than writing it onto the clip.
+void seedSourceDuration(magda::ClipInfo* clip, double durationSeconds) {
+    auto* event = magda::primaryEventOf(clip);
+    if (event == nullptr)
+        return;
+    auto& pool = magda::SourcePool::getInstance();
+    pool.seedFactsForTesting(event->sourceFilePath(), durationSeconds,
+                             magda::test::kTestSourceSampleRate);
+    pool.resolveFacts(event->sourceId);
+}
+}  // namespace
 
 /**
  * Tests for explicit audio clip crossfades (#1499).
@@ -34,14 +49,19 @@ TrackId createTrack() {
 // Creates an audio clip with source headroom on both sides (offset 10 s into a
 // 100 s file), so crossfade edge extensions aren't clamped by material limits.
 // Extension clamping itself is covered by its own test case below.
-ClipId createAudioBeats(TrackId trackId, double startBeat, double lengthBeats) {
+// Sources are pooled per file (#1901), so a test that wants two clips with
+// DIFFERENT source durations has to give them different files.
+ClipId createAudioBeats(TrackId trackId, double startBeat, double lengthBeats,
+                        const juce::String& filePath = "test.wav") {
     auto& cm = ClipManager::getInstance();
     const ClipId id =
-        cm.createAudioClipBeats(trackId, startBeat, lengthBeats, "test.wav", ClipView::Arrangement);
+        cm.createAudioClipBeats(trackId, startBeat, lengthBeats, filePath, ClipView::Arrangement);
     if (auto* clip = cm.getClip(id)) {
-        clip->audio().source.durationSeconds = 100.0;
-        clip->offset = 10.0;
-        clip->loopStart = 10.0;
+        magda::SourcePool::getInstance().seedFactsForTesting(
+            primaryEventOf(clip)->sourceFilePath(), 100.0, magda::test::kTestSourceSampleRate);
+        magda::SourcePool::getInstance().resolveFacts(primaryEventOf(clip)->sourceId);
+        primaryEventOf(clip)->setAnchorSeconds(10.0);
+        primaryEventOf(clip)->setLoopStartSeconds(10.0);
     }
     return id;
 }
@@ -158,12 +178,12 @@ TEST_CASE("setCrossfadeRegionBeats respects source material bounds", "[crossfade
     // 4 beats = 2 s at 120 BPM. Give both clips exactly 2 s of source with no
     // spare material: the left clip cannot extend right, the right clip cannot
     // extend left (offset 0), so no overlap can be created.
-    const ClipId a = createAudioBeats(trackId, 0.0, 4.0);
-    const ClipId b = createAudioBeats(trackId, 4.0, 4.0);
-    cm.getClip(a)->audio().source.durationSeconds = 2.0;
-    cm.getClip(b)->audio().source.durationSeconds = 2.0;
-    cm.getClip(a)->offset = 0.0;
-    cm.getClip(b)->offset = 0.0;
+    const ClipId a = createAudioBeats(trackId, 0.0, 4.0, "xfade_a.wav");
+    const ClipId b = createAudioBeats(trackId, 4.0, 4.0, "xfade_b.wav");
+    seedSourceDuration(cm.getClip(a), 2.0);
+    seedSourceDuration(cm.getClip(b), 2.0);
+    magda::primaryEventOf(cm.getClip(a))->setAnchorSeconds(0.0);
+    magda::primaryEventOf(cm.getClip(b))->setAnchorSeconds(0.0);
 
     REQUIRE(cm.setCrossfadeBeats(a, b, 2.0));
 
@@ -173,8 +193,8 @@ TEST_CASE("setCrossfadeRegionBeats respects source material bounds", "[crossfade
 
     // Give the right clip 1 s of pre-roll material (offset 1 s): its edge can
     // now extend up to 2 beats left, the left clip still cannot move.
-    cm.getClip(b)->audio().source.durationSeconds = 3.0;
-    cm.getClip(b)->offset = 1.0;
+    seedSourceDuration(cm.getClip(b), 3.0);
+    magda::primaryEventOf(cm.getClip(b))->setAnchorSeconds(1.0);
 
     REQUIRE(cm.setCrossfadeBeats(a, b, 4.0));
     CHECK(cm.getClip(a)->placement.endBeat() == Catch::Approx(4.0));
@@ -295,7 +315,7 @@ TEST_CASE("SetCrossfadeCommand undo restores both clips exactly", "[crossfade]")
     cm.setAutoCrossfade(b, false);
     const double aEndBefore = cm.getClip(a)->placement.endBeat();
     const double bStartBefore = cm.getClip(b)->placement.startBeat;
-    const double bOffsetBefore = cm.getClip(b)->offset;
+    const double bOffsetBefore = magda::audioEventRef(*cm.getClip(b)).anchorSeconds();
 
     um.executeCommand(std::make_unique<SetCrossfadeCommand>(a, b, 7.0, 9.0, 120.0));
 
@@ -304,7 +324,7 @@ TEST_CASE("SetCrossfadeCommand undo restores both clips exactly", "[crossfade]")
     um.undo();
     CHECK(cm.getClip(a)->placement.endBeat() == Catch::Approx(aEndBefore));
     CHECK(cm.getClip(b)->placement.startBeat == Catch::Approx(bStartBefore));
-    CHECK(cm.getClip(b)->offset == Catch::Approx(bOffsetBefore));
+    CHECK(magda::audioEventRef(*cm.getClip(b)).anchorSeconds() == Catch::Approx(bOffsetBefore));
     CHECK_FALSE(cm.getClip(a)->autoCrossfade);
     CHECK_FALSE(cm.getClip(b)->autoCrossfade);
     CHECK_FALSE(cm.getCrossfadeAtStart(b).has_value());

--- a/tests/test_clip_event_model.cpp
+++ b/tests/test_clip_event_model.cpp
@@ -387,3 +387,63 @@ TEST_CASE("Loop length in beats is a timeline view, not a source view", "[clip][
         REQUIRE(midiClip.loopStartInBeats(kProjectBpm) == Approx(1.0));
     }
 }
+
+TEST_CASE("A warped loop reports its warped timeline span", "[clip][event][loop][warp]") {
+    // warpEnabled is independent of autoTempo: setClipWarpEnabled does not
+    // turn beat mode on, and the engine treats either as source-beat
+    // processing. Falling through to the linear speedRatio conversion ignored
+    // warpMarkers entirely, so a nonlinearly warped loop reported a start and
+    // length that disagreed with where it actually plays.
+    EventModelFixture fixture;
+    constexpr double kProjectBpm = 120.0;
+
+    ClipInfo clip;
+    clip.setAudioContent();
+    auto& event = magda::test::giveAudioEvent(clip, "/tmp/warped.wav", 8.0);
+    event.interpBpm = 120.0;
+    event.speedRatio = 1.0;
+    event.autoTempo = false;
+    event.warpEnabled = true;
+    clip.loopEnabled = true;
+
+    // The first source second is stretched to two; the second is compressed
+    // back into one. A linear reading cannot tell these apart.
+    event.warpMarkers = {{0.0, 0.0}, {1.0, 2.0}, {2.0, 3.0}};
+
+    SECTION("The mapping is piecewise linear between markers") {
+        REQUIRE(event.warpedSourceSeconds(0.5) == Approx(1.0));
+        REQUIRE(event.warpedSourceSeconds(1.0) == Approx(2.0));
+        REQUIRE(event.warpedSourceSeconds(1.5) == Approx(2.5));
+    }
+
+    SECTION("Outside the marker range the source carries on at its own rate") {
+        REQUIRE(event.warpedSourceSeconds(3.0) == Approx(4.0));
+        REQUIRE(event.warpedSourceSeconds(-1.0) == Approx(-1.0));
+    }
+
+    SECTION("Loop boundaries map through the warp, not around it") {
+        event.setLoopStartSeconds(0.5);
+        event.setLoopLengthSeconds(1.0);  // source 0.5 -> 1.5
+
+        // Warped: 1.0 -> 2.5, so half a beat in and one and a half beats long
+        // at 120. The linear reading would have said 1.0 and 2.0.
+        REQUIRE(clip.loopStartInBeats(kProjectBpm) == Approx(2.0));
+        REQUIRE(clip.loopLengthInBeats(kProjectBpm) == Approx(3.0));
+    }
+
+    SECTION("Turning warp off returns the linear reading") {
+        event.warpEnabled = false;
+        event.setLoopStartSeconds(0.5);
+        event.setLoopLengthSeconds(1.0);
+        REQUIRE(clip.loopStartInBeats(kProjectBpm) == Approx(1.0));
+        REQUIRE(clip.loopLengthInBeats(kProjectBpm) == Approx(2.0));
+    }
+
+    SECTION("No markers is the identity, so warp-on alone changes nothing") {
+        event.warpMarkers.clear();
+        event.setLoopStartSeconds(0.5);
+        event.setLoopLengthSeconds(1.0);
+        REQUIRE(clip.loopStartInBeats(kProjectBpm) == Approx(1.0));
+        REQUIRE(clip.loopLengthInBeats(kProjectBpm) == Approx(2.0));
+    }
+}

--- a/tests/test_clip_event_model.cpp
+++ b/tests/test_clip_event_model.cpp
@@ -338,3 +338,52 @@ TEST_CASE("New events inherit the source's detected facts", "[clip][event][inter
         REQUIRE(event.keyRoot == "C");
     }
 }
+
+TEST_CASE("Loop length in beats is a timeline view, not a source view", "[clip][event][loop]") {
+    // The two domains only coincide under beat mode. Returning the event's own
+    // beat count off beat mode hands source beats to callers that schedule in
+    // timeline beats, which is how a 174 BPM loop in a 120 BPM project ended
+    // up firing its follow action about 45% late.
+    EventModelFixture fixture;
+    constexpr double kProjectBpm = 120.0;
+
+    ClipInfo clip;
+    clip.setAudioContent();
+    auto& event = magda::test::giveAudioEvent(clip, "/tmp/loop-174.wav", 8.0);
+    event.interpBpm = 174.0;
+    event.speedRatio = 1.0;
+    event.setLoopLengthSeconds(2.0);
+    event.setLoopStartSeconds(1.0);
+    clip.loopEnabled = true;
+
+    SECTION("Off beat mode it comes from seconds and the project tempo") {
+        event.autoTempo = false;
+        // Two seconds of audio at its recorded rate spans four beats at 120.
+        REQUIRE(clip.loopLengthInBeats(kProjectBpm) == Approx(4.0));
+        REQUIRE(clip.loopStartInBeats(kProjectBpm) == Approx(2.0));
+        // The source-beat view is a different number, and not the one to use.
+        REQUIRE(event.loopLengthBeats() == Approx(5.8));
+    }
+
+    SECTION("A speed change moves the timeline span, not the source one") {
+        event.autoTempo = false;
+        event.speedRatio = 2.0;  // plays twice as fast
+        REQUIRE(clip.loopLengthInBeats(kProjectBpm) == Approx(2.0));
+        REQUIRE(event.loopLengthSeconds() == Approx(2.0));
+    }
+
+    SECTION("Under beat mode the source is stretched onto the grid") {
+        event.autoTempo = true;
+        REQUIRE(clip.loopLengthInBeats(kProjectBpm) == Approx(5.8));
+    }
+
+    SECTION("A MIDI clip reports its own field for either accessor") {
+        ClipInfo midiClip;
+        midiClip.setMidiContent();
+        midiClip.loopEnabled = true;
+        midiClip.loopStartBeats = 1.0;
+        midiClip.loopLengthBeats = 4.0;
+        REQUIRE(midiClip.loopLengthInBeats(kProjectBpm) == Approx(4.0));
+        REQUIRE(midiClip.loopStartInBeats(kProjectBpm) == Approx(1.0));
+    }
+}

--- a/tests/test_clip_event_model.cpp
+++ b/tests/test_clip_event_model.cpp
@@ -1,0 +1,340 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "AudioClipTestHelpers.hpp"
+#include "core/ClipInfo.hpp"
+#include "core/SourcePool.hpp"
+
+using namespace magda;
+using Catch::Approx;
+
+namespace {
+
+struct EventModelFixture {
+    EventModelFixture() {
+        SourcePool::getInstance().clear();
+        SourcePool::getInstance().clearSeededFactsForTesting();
+    }
+    ~EventModelFixture() {
+        SourcePool::getInstance().clear();
+        SourcePool::getInstance().clearSeededFactsForTesting();
+    }
+};
+
+/// An audio clip with one event on a 120 bpm, 8 beat source.
+ClipInfo makeAudioClip(const juce::String& file = "loop.wav") {
+    ClipInfo clip;
+    auto& event = magda::test::giveAudioEvent(clip, file, 4.0);
+    event.interpBpm = 120.0;
+    event.interpTotalBeats = 8.0;
+    clip.setPlacementBeats(0.0, 8.0);
+    return clip;
+}
+
+}  // namespace
+
+// =============================================================================
+// Container and content stay the same extent (#1901 Phase A)
+// =============================================================================
+
+TEST_CASE("A single-event clip's event spans it", "[clip][event]") {
+    EventModelFixture fixture;
+    auto clip = makeAudioClip();
+
+    REQUIRE(clip.events().size() == 1);
+    REQUIRE(clip.primaryEvent()->startBeat == Approx(0.0));
+    REQUIRE(clip.primaryEvent()->lengthBeats == Approx(8.0));
+
+    SECTION("Resizing the clip resizes its event") {
+        clip.setPlacementBeats(0.0, 12.0);
+        REQUIRE(clip.primaryEvent()->lengthBeats == Approx(12.0));
+    }
+
+    SECTION("Moving the clip leaves the event at the clip's own origin") {
+        // Event geometry is clip-relative, so a move changes nothing inside.
+        clip.setPlacementBeats(16.0, 8.0);
+        REQUIRE(clip.primaryEvent()->startBeat == Approx(0.0));
+        REQUIRE(clip.primaryEvent()->lengthBeats == Approx(8.0));
+    }
+
+    SECTION("A clip holding several events is a window, so its bounds crop") {
+        auto& second = clip.audio().addEvent({});
+        second.startBeat = 8.0;
+        second.lengthBeats = 4.0;
+
+        clip.setPlacementBeats(0.0, 4.0);
+
+        // Neither event was resized: the clip crops at render instead.
+        REQUIRE(clip.events()[0].lengthBeats == Approx(8.0));
+        REQUIRE(clip.events()[1].startBeat == Approx(8.0));
+        REQUIRE(clip.events()[1].lengthBeats == Approx(4.0));
+    }
+}
+
+// =============================================================================
+// The source domain is samples, and beats are a view on it
+// =============================================================================
+
+TEST_CASE("Reinterpreting the source BPM moves no audio", "[clip][event][interpretation]") {
+    EventModelFixture fixture;
+    auto clip = makeAudioClip();
+    auto& event = *clip.primaryEvent();
+
+    event.setAnchorSeconds(1.0);
+    event.setLoopStartSeconds(1.0);
+    event.setLoopLengthSeconds(2.0);
+
+    const auto anchorSamples = event.sourceAnchorSamples;
+    const auto loopStartSamples = event.loopStartSamples;
+    const auto loopLengthSamples = event.loopLengthSamples;
+
+    REQUIRE(event.anchorBeats() == Approx(2.0));      // 1 s at 120 bpm
+    REQUIRE(event.loopLengthBeats() == Approx(4.0));  // 2 s at 120 bpm
+
+    // Halving the interpretation says the same audio is half as many beats.
+    event.interpBpm = 60.0;
+
+    SECTION("The audible region is untouched") {
+        REQUIRE(event.sourceAnchorSamples == anchorSamples);
+        REQUIRE(event.loopStartSamples == loopStartSamples);
+        REQUIRE(event.loopLengthSamples == loopLengthSamples);
+        REQUIRE(event.anchorSeconds() == Approx(1.0));
+        REQUIRE(event.loopLengthSeconds() == Approx(2.0));
+    }
+
+    SECTION("Only the beat view changes") {
+        REQUIRE(event.anchorBeats() == Approx(1.0));
+        REQUIRE(event.loopLengthBeats() == Approx(2.0));
+    }
+}
+
+TEST_CASE("Beat writes into the source domain round-trip", "[clip][event][interpretation]") {
+    EventModelFixture fixture;
+    auto clip = makeAudioClip();
+    auto& event = *clip.primaryEvent();
+
+    event.setAnchorBeats(3.0);
+    REQUIRE(event.anchorBeats() == Approx(3.0));
+    REQUIRE(event.anchorSeconds() == Approx(1.5));
+
+    SECTION("Without an interpretation there is no beat domain to write into") {
+        // Silently converting at some default tempo would invent musical
+        // content the file has not been calibrated to.
+        event.interpBpm = 0.0;
+        const auto before = event.sourceAnchorSamples;
+        event.setAnchorBeats(99.0);
+        REQUIRE(event.sourceAnchorSamples == before);
+        REQUIRE(event.anchorBeats() == Approx(0.0));
+    }
+}
+
+TEST_CASE("The loop phase is measured from the loop start", "[clip][event][loop]") {
+    EventModelFixture fixture;
+    auto clip = makeAudioClip();
+    auto& event = *clip.primaryEvent();
+
+    event.setLoopStartSeconds(1.0);
+    event.setLoopLengthSeconds(2.0);
+    event.setAnchorSeconds(1.5);
+
+    REQUIRE(event.loopPhaseSeconds() == Approx(0.5));
+}
+
+// =============================================================================
+// Events
+// =============================================================================
+
+TEST_CASE("Events get unique ids within their clip", "[clip][event]") {
+    EventModelFixture fixture;
+    auto clip = makeAudioClip();
+
+    // Ids by value: addEvent appends to a vector, so the reference it returns
+    // does not survive the next one.
+    const auto firstId = clip.primaryEvent()->id;
+    const auto secondId = clip.audio().addEvent({}).id;
+    const auto thirdId = clip.audio().addEvent({}).id;
+
+    REQUIRE(firstId != secondId);
+    REQUIRE(secondId != thirdId);
+
+    SECTION("findEvent addresses an event by id") {
+        REQUIRE(clip.audio().findEvent(secondId) != nullptr);
+        REQUIRE(clip.audio().findEvent(secondId)->id == secondId);
+        REQUIRE(clip.audio().findEvent(INVALID_EVENT_ID) == nullptr);
+    }
+}
+
+TEST_CASE("A MIDI clip has no audio event", "[clip][event][midi]") {
+    EventModelFixture fixture;
+    ClipInfo clip;
+    clip.setMidiContent();
+
+    REQUIRE(clip.primaryEvent() == nullptr);
+    REQUIRE(primaryEventOf(&clip) == nullptr);
+
+    SECTION("The read-only view is still total") {
+        // Readers that used to reach for a clip-level audio field must not
+        // have to branch on content type.
+        REQUIRE(audioEventRef(clip).speedRatio == Approx(1.0));
+        REQUIRE_FALSE(clip.loopEnabled);
+    }
+
+    SECTION("Its loop lives in clip beats") {
+        clip.loopEnabled = true;
+        clip.loopLengthBeats = 4.0;
+        REQUIRE(clip.loopEnabled);
+        REQUIRE(clip.loopLengthBeats == Approx(4.0));
+    }
+}
+
+// =============================================================================
+// Ghost clips: what an event shares and what stays per-instance
+// =============================================================================
+
+TEST_CASE("Ghost siblings share interpretation, not placement", "[clip][event][ghost]") {
+    EventModelFixture fixture;
+    auto source = makeAudioClip();
+    auto& sourceEvent = *source.primaryEvent();
+    sourceEvent.warpEnabled = true;
+    sourceEvent.transpose = 5;
+    sourceEvent.reversed = true;
+    sourceEvent.interpBpm = 90.0;
+
+    auto ghost = makeAudioClip();
+    auto& ghostEvent = *ghost.primaryEvent();
+    ghostEvent.setAnchorSeconds(2.0);
+    ghostEvent.setLoopLengthSeconds(1.0);
+    ghostEvent.speedRatio = 2.0;
+    ghostEvent.fadeInSeconds = 0.25;
+    ghostEvent.gainDB = -3.0f;
+
+    ghost.copySharedContentFrom(source);
+
+    SECTION("How the source is interpreted propagates") {
+        REQUIRE(ghostEvent.warpEnabled);
+        REQUIRE(ghostEvent.transpose == 5);
+        REQUIRE(ghostEvent.reversed);
+        REQUIRE(ghostEvent.interpBpm == Approx(90.0));
+    }
+
+    SECTION("Where it reads and how it mixes does not") {
+        // One ghost's trim or resize must never corrupt its siblings.
+        REQUIRE(ghostEvent.anchorSeconds() == Approx(2.0));
+        REQUIRE(ghostEvent.loopLengthSeconds() == Approx(1.0));
+        REQUIRE(ghostEvent.speedRatio == Approx(2.0));
+        REQUIRE(ghostEvent.fadeInSeconds == Approx(0.25));
+        REQUIRE(ghostEvent.gainDB == Approx(-3.0f));
+    }
+}
+
+TEST_CASE("sharedContentEquals ignores per-instance event state", "[clip][event][ghost]") {
+    EventModelFixture fixture;
+    auto a = makeAudioClip();
+    auto b = makeAudioClip();
+
+    REQUIRE(a.sharedContentEquals(b));
+
+    SECTION("A per-instance edit is not a content change") {
+        // The propagation pass skips the deep sibling copies when only
+        // per-instance state moved, so this has to stay in lockstep with
+        // copySharedContentFrom.
+        b.primaryEvent()->setAnchorSeconds(1.0);
+        b.primaryEvent()->speedRatio = 2.0;
+        b.primaryEvent()->fadeOutSeconds = 0.5;
+        REQUIRE(a.sharedContentEquals(b));
+    }
+
+    SECTION("A shared edit is") {
+        b.primaryEvent()->transpose = 7;
+        REQUIRE_FALSE(a.sharedContentEquals(b));
+    }
+
+    SECTION("So is a different source") {
+        b.primaryEvent()->sourceId = SourcePool::getInstance().acquire("other.wav");
+        REQUIRE_FALSE(a.sharedContentEquals(b));
+    }
+}
+
+TEST_CASE("A MIDI clip's loop stays per-instance across ghosts", "[clip][event][ghost][midi]") {
+    EventModelFixture fixture;
+
+    ClipInfo source;
+    source.setMidiContent();
+    source.setPlacementBeats(0.0, 8.0);
+    source.midiNotes.push_back(MidiNote{60, 100, 0.0, 1.0});
+    source.loopEnabled = true;
+    source.loopLengthBeats = 4.0;
+
+    ClipInfo ghost;
+    ghost.setMidiContent();
+    ghost.setPlacementBeats(16.0, 8.0);
+
+    ghost.copySharedContentFrom(source);
+
+    // The loop moved inside the content variant when audio events landed, but
+    // it is still per-instance: one ghost's loop toggle must not silence or
+    // re-length its siblings.
+    REQUIRE(ghost.midiNotes.size() == 1);
+    REQUIRE_FALSE(ghost.loopEnabled);
+    REQUIRE(ghost.loopLengthBeats == Approx(0.0));
+    REQUIRE(source.sharedContentEquals(ghost));
+}
+
+// =============================================================================
+// Interpretation seeding
+// =============================================================================
+
+TEST_CASE("Seeding an interpretation only fills gaps", "[clip][event][interpretation]") {
+    EventModelFixture fixture;
+    AudioEvent event;
+
+    SECTION("Both land when unset") {
+        event.seedInterpretation(4.0, 120.0);
+        REQUIRE(event.interpBpm == Approx(120.0));
+        REQUIRE(event.interpTotalBeats == Approx(4.0));
+    }
+
+    SECTION("A value the user already set is never overwritten") {
+        event.interpBpm = 90.0;
+        event.interpTotalBeats = 16.0;
+        event.seedInterpretation(4.0, 120.0);
+        REQUIRE(event.interpBpm == Approx(90.0));
+        REQUIRE(event.interpTotalBeats == Approx(16.0));
+    }
+
+    SECTION("A beat count without a tempo is not taken") {
+        // It would claim musical content the file has not been calibrated to,
+        // and render as a plausible integer that never gets corrected.
+        event.seedInterpretation(4.0, 0.0);
+        REQUIRE(event.interpTotalBeats == Approx(0.0));
+    }
+}
+
+TEST_CASE("New events inherit the source's detected facts", "[clip][event][interpretation]") {
+    EventModelFixture fixture;
+    auto& pool = SourcePool::getInstance();
+
+    const auto sourceId = pool.acquire("detected.wav");
+    auto* source = pool.getMutable(sourceId);
+    source->detectedBpm = 174.0;
+    source->durationSeconds = 4.0;
+    source->detectedKeyRoot = "F";
+    source->detectedKeyScale = "minor";
+
+    AudioEvent event;
+    event.sourceId = sourceId;
+    event.seedInterpretationFromSource();
+
+    REQUIRE(event.interpBpm == Approx(174.0));
+    REQUIRE(event.interpTotalBeats == Approx(4.0 * 174.0 / 60.0));
+    REQUIRE(event.keyRoot == "F");
+    REQUIRE(event.keyScale == "minor");
+
+    SECTION("Re-seeding cannot rewrite what the user changed") {
+        event.interpBpm = 87.0;
+        event.keyRoot = "C";
+        event.seedInterpretationFromSource();
+        REQUIRE(event.interpBpm == Approx(87.0));
+        REQUIRE(event.keyRoot == "C");
+    }
+}

--- a/tests/test_clip_inspector_juce.cpp
+++ b/tests/test_clip_inspector_juce.cpp
@@ -6,6 +6,7 @@
 #include "magda/daw/core/ClipManager.hpp"
 
 #define private public
+#include "AudioClipTestHelpers.hpp"
 #include "magda/daw/ui/panels/content/inspector/ClipInspector.hpp"
 #undef private
 
@@ -25,20 +26,20 @@ ClipInfo makeInspectorAudioClip(ClipId id = 9001) {
     clip.setAudioContent();
     clip.view = ClipView::Session;
     clip.name = "InspectorTest";
-    clip.autoTempo = true;
+    magda::test::audioEvent(clip).autoTempo = true;
     clip.loopEnabled = true;
-    clip.speedRatio = 1.0;
-    clip.audio().source.durationSeconds = sourceDuration;
-    clip.audio().interpretation.bpm = sourceBPM;
-    clip.audio().interpretation.totalBeats = sourceBeats;
+    magda::test::audioEvent(clip).speedRatio = 1.0;
+    magda::test::setSourceDuration(clip, sourceDuration);
+    magda::test::audioEvent(clip).interpBpm = sourceBPM;
+    magda::test::audioEvent(clip).interpTotalBeats = sourceBeats;
     clip.setPlacementBeats(0.0, sourceBeats);
     clip.length = sourceBeats * 60.0 / projectBPM;
-    clip.loopStart = 0.0;
-    clip.loopStartBeats = 0.0;
-    clip.loopLength = sourceDuration;
-    clip.loopLengthBeats = sourceBeats;
-    clip.offset = 0.0;
-    clip.offsetBeats = 0.0;
+    magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
+    magda::test::audioEvent(clip).setLoopStartBeats(0.0);
+    magda::test::audioEvent(clip).setLoopLengthSeconds(sourceDuration);
+    magda::test::audioEvent(clip).setLoopLengthBeats(sourceBeats);
+    magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+    magda::test::audioEvent(clip).setAnchorBeats(0.0);
     return clip;
 }
 
@@ -162,8 +163,8 @@ class ClipInspectorJuceTest final : public juce::UnitTest {
         auto seed = makeInspectorAudioClip();
         seed.setPlacementBeats(0.0, 96.0);
         seed.length = 96.0 * 60.0 / projectBPM;
-        seed.loopLengthBeats = 12.0;
-        seed.loopLength = 12.0 * 60.0 / sourceBPM;
+        magda::test::audioEvent(seed).setLoopLengthBeats(12.0);
+        magda::test::audioEvent(seed).setLoopLengthSeconds(12.0 * 60.0 / sourceBPM);
         ClipManager::getInstance().restoreClip(seed);
 
         ClipInspector inspector;

--- a/tests/test_clip_paint_juce.cpp
+++ b/tests/test_clip_paint_juce.cpp
@@ -1,0 +1,291 @@
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "AudioClipTestHelpers.hpp"
+#include "JuceTestStateGuard.hpp"
+#include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/SelectionManager.hpp"
+#include "magda/daw/core/SourcePool.hpp"
+#include "magda/daw/ui/components/clips/ClipComponent.hpp"
+#include "magda/daw/ui/components/tracks/TrackContentPanel.hpp"
+
+/**
+ * Clip painting across every content shape (#1901).
+ *
+ * ClipComponent::paint reads the audio event for the loop-cut markers, the
+ * fade handles and the waveform. A MIDI clip has no audio event, so a paint
+ * that reaches for one without checking dereferences null and takes the
+ * message thread down. That is exactly what shipped: the model refactor moved
+ * those reads onto the event and the suite never noticed, because nothing in
+ * it painted a clip.
+ *
+ * These tests render each shape into an offscreen image. They assert almost
+ * nothing about the pixels: surviving the paint IS the assertion, and it is
+ * the one the crash would have failed.
+ */
+
+using namespace magda;
+
+namespace {
+
+constexpr double testTempoBPM = 120.0;
+constexpr double testZoomPixelsPerBeat = 40.0;
+constexpr TrackId testTrackId = 1;
+
+/// Render a clip the way the arrangement does, through the component tree.
+juce::Image renderClip(ClipId clipId, TrackContentPanel& panel) {
+    ClipComponent component(clipId, &panel);
+    component.setBounds(0, 0, 400, 80);
+
+    juce::Image image(juce::Image::ARGB, component.getWidth(), component.getHeight(), true);
+    juce::Graphics g(image);
+    component.paintEntireComponent(g, false);
+    return image;
+}
+
+void paintClip(ClipId clipId, TrackContentPanel& panel) {
+    renderClip(clipId, panel);
+}
+
+/// How many pixels differ between two renders of the same size.
+int pixelsDiffering(const juce::Image& a, const juce::Image& b) {
+    if (a.getWidth() != b.getWidth() || a.getHeight() != b.getHeight())
+        return -1;
+
+    int differing = 0;
+    for (int y = 0; y < a.getHeight(); ++y)
+        for (int x = 0; x < a.getWidth(); ++x)
+            if (a.getPixelAt(x, y) != b.getPixelAt(x, y))
+                ++differing;
+    return differing;
+}
+
+/// A clip whose event points at a source that was never on disk. Painting has
+/// to cope: the file can go missing between sessions.
+ClipId createAudioClip(double startBeats, double lengthBeats,
+                       ClipView view = ClipView::Arrangement) {
+    return ClipManager::getInstance().createAudioClipBeats(
+        testTrackId, startBeats, lengthBeats, "/tmp/magda_paint_test.wav", view, testTempoBPM);
+}
+
+struct PaintFixture {
+    TrackContentPanel panel;
+
+    PaintFixture() {
+        magda::test::resetJuceProjectState();
+        panel.setSize(2000, 400);
+        panel.setTempo(testTempoBPM);
+        panel.setZoom(testZoomPixelsPerBeat);
+    }
+
+    ~PaintFixture() {
+        magda::test::resetJuceProjectState();
+    }
+};
+
+class ClipPaintTests : public juce::UnitTest {
+  public:
+    ClipPaintTests() : juce::UnitTest("Clip painting", "magda") {}
+
+    void runTest() override {
+        beginTest("A plain MIDI clip paints");
+        {
+            PaintFixture fixture;
+            const auto clipId = ClipManager::getInstance().createMidiClipBeats(
+                testTrackId, 0.0, 4.0, ClipView::Arrangement);
+            paintClip(clipId, fixture.panel);
+            expect(true, "painting a MIDI clip must not dereference an audio event");
+        }
+
+        beginTest("A looped MIDI clip paints");
+        {
+            // The crash: the loop-cut markers read loopLengthSeconds off the
+            // clip's audio event, which a MIDI clip does not have.
+            PaintFixture fixture;
+            const auto clipId = ClipManager::getInstance().createMidiClipBeats(
+                testTrackId, 0.0, 16.0, ClipView::Arrangement);
+            auto* clip = ClipManager::getInstance().getClip(clipId);
+            clip->loopEnabled = true;
+            clip->loopLengthBeats = 4.0;
+            paintClip(clipId, fixture.panel);
+            expect(clip->loopEnabled, "the MIDI loop survives a paint");
+        }
+
+        beginTest("A looped MIDI clip draws loop boundary cuts");
+        {
+            // Surviving the paint is not enough: before the event split the
+            // loop length lived on ClipInfo and MIDI clips set it, so looped
+            // MIDI clips drew boundary cuts. Reading the loop off the audio
+            // event silently dropped them, because a MIDI clip has none.
+            PaintFixture fixture;
+            auto& cm = ClipManager::getInstance();
+
+            const auto plainId =
+                cm.createMidiClipBeats(testTrackId, 0.0, 16.0, ClipView::Arrangement);
+            const auto plain = renderClip(plainId, fixture.panel);
+
+            const auto loopedId =
+                cm.createMidiClipBeats(testTrackId, 32.0, 16.0, ClipView::Arrangement);
+            auto* looped = cm.getClip(loopedId);
+            looped->colour = cm.getClip(plainId)->colour;
+            looped->loopEnabled = true;
+            looped->loopLengthBeats = 4.0;
+            const auto withCuts = renderClip(loopedId, fixture.panel);
+
+            expect(pixelsDiffering(plain, withCuts) > 0,
+                   "a looped MIDI clip must render differently from an unlooped one");
+        }
+
+        beginTest("A looped audio clip draws loop boundary cuts");
+        {
+            PaintFixture fixture;
+            auto& cm = ClipManager::getInstance();
+
+            const auto plainId = createAudioClip(0.0, 16.0);
+            const auto plain = renderClip(plainId, fixture.panel);
+
+            const auto loopedId = createAudioClip(32.0, 16.0);
+            auto* looped = cm.getClip(loopedId);
+            looped->colour = cm.getClip(plainId)->colour;
+            auto* event = looped->primaryEvent();
+            event->interpBpm = 120.0;
+            looped->loopEnabled = true;
+            event->setLoopLengthSeconds(2.0);
+            const auto withCuts = renderClip(loopedId, fixture.panel);
+
+            expect(pixelsDiffering(plain, withCuts) > 0,
+                   "a looped audio clip must render differently from an unlooped one");
+        }
+
+        beginTest("A MIDI clip with notes and a phase offset paints");
+        {
+            PaintFixture fixture;
+            const auto clipId = ClipManager::getInstance().createMidiClipBeats(
+                testTrackId, 0.0, 8.0, ClipView::Arrangement);
+            auto* clip = ClipManager::getInstance().getClip(clipId);
+            clip->loopEnabled = true;
+            clip->loopLengthBeats = 2.0;
+            clip->midiOffset = 0.5;
+            clip->midiTrimOffset = 0.25;
+            for (double beat : {0.0, 0.5, 1.0, 1.5})
+                clip->midiNotes.push_back(MidiNote{60, 100, beat, 0.25});
+            paintClip(clipId, fixture.panel);
+            expect(clip->midiNotes.size() == 4, "notes survive a paint");
+        }
+
+        beginTest("An audio clip paints with a missing source file");
+        {
+            // The waveform, fades and loop cuts all read the event; none of
+            // them may assume the file resolved.
+            PaintFixture fixture;
+            const auto clipId = createAudioClip(0.0, 8.0);
+            paintClip(clipId, fixture.panel);
+
+            const auto* event = primaryEventOf(ClipManager::getInstance().getClip(clipId));
+            expect(event != nullptr, "an audio clip keeps its event across a paint");
+        }
+
+        beginTest("A looped audio clip paints its loop cuts");
+        {
+            PaintFixture fixture;
+            const auto clipId = createAudioClip(0.0, 16.0);
+            auto* clip = ClipManager::getInstance().getClip(clipId);
+            auto* event = clip->primaryEvent();
+            event->interpBpm = 120.0;
+            event->interpTotalBeats = 8.0;
+            clip->loopEnabled = true;
+            event->setLoopLengthSeconds(2.0);
+            paintClip(clipId, fixture.panel);
+            expect(clip->loopEnabled, "the source loop survives a paint");
+        }
+
+        beginTest("A beat-mode audio clip paints");
+        {
+            PaintFixture fixture;
+            const auto clipId = createAudioClip(0.0, 8.0);
+            auto* clip = ClipManager::getInstance().getClip(clipId);
+            auto* event = clip->primaryEvent();
+            event->autoTempo = true;
+            event->interpBpm = 174.0;
+            event->interpTotalBeats = 8.0;
+            clip->loopEnabled = true;
+            event->setLoopLengthBeats(8.0);
+            paintClip(clipId, fixture.panel);
+            expect(event->autoTempo, "beat mode survives a paint");
+        }
+
+        beginTest("An audio clip with fades and a trim paints");
+        {
+            PaintFixture fixture;
+            const auto clipId = createAudioClip(0.0, 8.0);
+            auto* event = primaryEventOf(ClipManager::getInstance().getClip(clipId));
+            event->fadeInSeconds = 0.5;
+            event->fadeOutSeconds = 0.75;
+            event->setAnchorSeconds(1.0);
+            event->reversed = true;
+            paintClip(clipId, fixture.panel);
+            expect(event->fadeInSeconds > 0.0, "fades survive a paint");
+        }
+
+        beginTest("An audio clip with no event at all paints");
+        {
+            // Nothing builds this today, but a hand-edited or truncated
+            // project can load one, and paint is the first thing to touch it.
+            PaintFixture fixture;
+            const auto clipId = createAudioClip(0.0, 4.0);
+            auto* clip = ClipManager::getInstance().getClip(clipId);
+            clip->audio().events.clear();
+            paintClip(clipId, fixture.panel);
+            expect(clip->primaryEvent() == nullptr, "an eventless audio clip still paints");
+        }
+
+        beginTest("Session clips paint");
+        {
+            PaintFixture fixture;
+            const auto audioId = createAudioClip(0.0, 4.0, ClipView::Session);
+            const auto midiId = ClipManager::getInstance().createMidiClipBeats(
+                testTrackId, 0.0, 4.0, ClipView::Session);
+            paintClip(audioId, fixture.panel);
+            paintClip(midiId, fixture.panel);
+            expect(true, "session clips of both content types paint");
+        }
+
+        beginTest("A selected clip paints");
+        {
+            PaintFixture fixture;
+            const auto midiId = ClipManager::getInstance().createMidiClipBeats(
+                testTrackId, 0.0, 4.0, ClipView::Arrangement);
+            const auto audioId = createAudioClip(8.0, 4.0);
+            SelectionManager::getInstance().selectClips({midiId, audioId});
+            paintClip(midiId, fixture.panel);
+            paintClip(audioId, fixture.panel);
+            expect(true, "selection overlays paint for both content types");
+        }
+
+        beginTest("A disabled clip paints");
+        {
+            PaintFixture fixture;
+            const auto clipId = ClipManager::getInstance().createMidiClipBeats(
+                testTrackId, 0.0, 4.0, ClipView::Arrangement);
+            ClipManager::getInstance().setClipEnabled(clipId, false);
+            paintClip(clipId, fixture.panel);
+            expect(!ClipManager::getInstance().getClip(clipId)->enabled,
+                   "a disabled clip still paints");
+        }
+
+        beginTest("Ghost siblings paint");
+        {
+            PaintFixture fixture;
+            auto& cm = ClipManager::getInstance();
+            const auto original =
+                cm.createMidiClipBeats(testTrackId, 0.0, 4.0, ClipView::Arrangement);
+            const auto ghost = cm.duplicateClipAsGhostAtBeats(original, 8.0);
+            paintClip(original, fixture.panel);
+            paintClip(ghost, fixture.panel);
+            expect(cm.isGhostClip(original), "ghost clips paint their index badge");
+        }
+    }
+};
+
+ClipPaintTests clipPaintTests;
+
+}  // namespace

--- a/tests/test_clip_resize_operations.cpp
+++ b/tests/test_clip_resize_operations.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include "AudioClipTestHelpers.hpp"
 #include "magda/daw/core/ClipInfo.hpp"
 #include "magda/daw/core/ClipOperations.hpp"
 
@@ -27,9 +28,9 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         // Shrink from left to 3.0 seconds (clip moves right by 1.0)
         ClipOperations::resizeContainerFromLeft(clip, 3.0);
@@ -38,7 +39,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         REQUIRE(clip.length == 3.0);
 
         // Audio offset advanced by 1.0 second (trim amount * speedRatio)
-        REQUIRE(clip.offset == Catch::Approx(1.0));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(1.0));
     }
 
     SECTION("Shrinking from left with speed ratio converts trim to file time") {
@@ -46,9 +47,10 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
-        clip.speedRatio = 2.0;  // 2x faster (speedRatio = speed factor semantics)
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio =
+            2.0;  // 2x faster (speedRatio = speed factor semantics)
 
         // Shrink from left by 2.0 timeline seconds
         ClipOperations::resizeContainerFromLeft(clip, 6.0);
@@ -57,8 +59,8 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         REQUIRE(clip.length == 6.0);
 
         // File offset advances by 2.0 * 2.0 = 4.0 file seconds
-        REQUIRE(clip.offset == Catch::Approx(4.0));
-        REQUIRE(clip.speedRatio == 2.0);  // Unchanged
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(4.0));
+        REQUIRE(magda::test::audioEvent(clip).speedRatio == 2.0);  // Unchanged
     }
 
     SECTION("Expanding from left reveals earlier audio") {
@@ -66,9 +68,9 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         clip.startTime = 2.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 2.0;  // Previously trimmed
-        clip.speedRatio = 1.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(2.0);  // Previously trimmed
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         // Expand from left to 6.0 seconds (clip moves left by 2.0)
         ClipOperations::resizeContainerFromLeft(clip, 6.0);
@@ -77,7 +79,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         REQUIRE(clip.length == 6.0);
 
         // Audio offset reduced (revealing earlier audio)
-        REQUIRE(clip.offset == Catch::Approx(0.0));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(0.0));
     }
 
     SECTION("Expanding from left clamps offset to 0") {
@@ -85,9 +87,9 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         clip.startTime = 2.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.5;  // Only 0.5s of offset available
-        clip.speedRatio = 1.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.5);  // Only 0.5s of offset available
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         // Try to expand from left to 8.0 (would need 4.0s of offset reduction)
         ClipOperations::resizeContainerFromLeft(clip, 8.0);
@@ -96,7 +98,7 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         REQUIRE(clip.length == 8.0);
 
         // Offset clamped to 0.0 (can't go negative)
-        REQUIRE(clip.offset == 0.0);
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == 0.0);
     }
 
     SECTION("Expand past zero clamps startTime correctly") {
@@ -104,9 +106,9 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - trims audio offset", "[clip
         clip.startTime = 1.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         // Try to expand to 8.0 (would put startTime at -3.0, clamped to 0.0)
         ClipOperations::resizeContainerFromLeft(clip, 8.0);
@@ -148,9 +150,9 @@ TEST_CASE("ClipOperations::resizeContainerFromRight - audio data unchanged",
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 1.0;
-        clip.speedRatio = 1.5;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(1.0);
+        magda::test::audioEvent(clip).speedRatio = 1.5;
 
         ClipOperations::resizeContainerFromRight(clip, 3.0);
 
@@ -158,8 +160,8 @@ TEST_CASE("ClipOperations::resizeContainerFromRight - audio data unchanged",
         REQUIRE(clip.length == 3.0);
 
         // All audio properties unchanged
-        REQUIRE(clip.offset == 1.0);
-        REQUIRE(clip.speedRatio == 1.5);
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == 1.0);
+        REQUIRE(magda::test::audioEvent(clip).speedRatio == 1.5);
     }
 
     SECTION("Expanding from right does not modify audio fields") {
@@ -167,17 +169,17 @@ TEST_CASE("ClipOperations::resizeContainerFromRight - audio data unchanged",
         clip.startTime = 2.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         ClipOperations::resizeContainerFromRight(clip, 8.0);
 
         REQUIRE(clip.startTime == 2.0);  // Unchanged
         REQUIRE(clip.length == 8.0);
 
-        REQUIRE(clip.offset == 0.0);
-        REQUIRE(clip.speedRatio == 1.0);
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == 0.0);
+        REQUIRE(magda::test::audioEvent(clip).speedRatio == 1.0);
     }
 
     SECTION("Minimum length enforced") {
@@ -201,30 +203,30 @@ TEST_CASE("ClipOperations - Sequential resizes maintain correct audio offset",
         clip.startTime = 0.0;
         clip.length = 8.0;  // 2 bars at 120 BPM = 8 beats
         clip.setAudioContent();
-        clip.audio().source.filePath = "kick_loop.wav";
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::giveAudioEvent(clip, "kick_loop.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         // Remove 1 beat from left
         ClipOperations::resizeContainerFromLeft(clip, 7.0);
 
         REQUIRE(clip.startTime == 1.0);
         REQUIRE(clip.length == 7.0);
-        REQUIRE(clip.offset == Catch::Approx(1.0));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(1.0));
 
         // Remove another beat from left
         ClipOperations::resizeContainerFromLeft(clip, 6.0);
 
         REQUIRE(clip.startTime == 2.0);
         REQUIRE(clip.length == 6.0);
-        REQUIRE(clip.offset == Catch::Approx(2.0));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(2.0));
 
         // Remove another beat from left
         ClipOperations::resizeContainerFromLeft(clip, 5.0);
 
         REQUIRE(clip.startTime == 3.0);
         REQUIRE(clip.length == 5.0);
-        REQUIRE(clip.offset == Catch::Approx(3.0));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(3.0));
     }
 
     SECTION("Alternating left and right resizes") {
@@ -232,29 +234,30 @@ TEST_CASE("ClipOperations - Sequential resizes maintain correct audio offset",
         clip.startTime = 2.0;
         clip.length = 6.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         // Shrink from left by 1.0
         ClipOperations::resizeContainerFromLeft(clip, 5.0);
         REQUIRE(clip.startTime == 3.0);
-        REQUIRE(clip.offset == Catch::Approx(1.0));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(1.0));
 
         // Expand from right — audio offset unchanged
         ClipOperations::resizeContainerFromRight(clip, 7.0);
         REQUIRE(clip.startTime == 3.0);
-        REQUIRE(clip.offset == Catch::Approx(1.0));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(1.0));
 
         // Expand from left — reveals earlier audio (reduces offset)
         ClipOperations::resizeContainerFromLeft(clip, 9.0);
         REQUIRE(clip.startTime == 1.0);
-        REQUIRE(clip.offset == Catch::Approx(0.0));  // Reduced by 1.0 (clamped from -1.0 to 0.0)
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() ==
+                Catch::Approx(0.0));  // Reduced by 1.0 (clamped from -1.0 to 0.0)
 
         // Shrink from right — audio offset unchanged
         ClipOperations::resizeContainerFromRight(clip, 5.0);
         REQUIRE(clip.startTime == 1.0);
-        REQUIRE(clip.offset == Catch::Approx(0.0));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(0.0));
     }
 }
 
@@ -403,11 +406,10 @@ TEST_CASE("Left resize with throttled drag updates - offset must use original st
      * content shifts by ~2 beats instead of staying aligned.
      *
      * Root cause: During drag, throttled updates modify clip.startTime and
-     * clip.length but NOT clip.offset. On mouseUp, the resize commit
-     * calls ClipOperations::resizeContainerFromLeft() which expects to
-     * operate on pre-drag state but receives post-drag state. The offset
-     * calculation uses the already-modified startTime, resulting in wrong
-     * delta.
+     * clip.length but NOT magda::test::audioEvent(clip).anchorSeconds(). On mouseUp, the resize
+     * commit calls ClipOperations::resizeContainerFromLeft() which expects to operate on pre-drag
+     * state but receives post-drag state. The offset calculation uses the already-modified
+     * startTime, resulting in wrong delta.
      *
      * Fix: The mouseUp handler must compute offset adjustment from
      * the ORIGINAL clip state captured at mouseDown, not from the
@@ -420,9 +422,9 @@ TEST_CASE("Left resize with throttled drag updates - offset must use original st
         originalState.startTime = 0.0;
         originalState.length = 4.0;
         originalState.setAudioContent();
-        originalState.audio().source.filePath = "test.wav";
-        originalState.offset = 0.0;
-        originalState.speedRatio = 1.0;
+        magda::test::giveAudioEvent(originalState, "test.wav");
+        magda::test::audioEvent(originalState).setAnchorSeconds(0.0);
+        magda::test::audioEvent(originalState).speedRatio = 1.0;
 
         // Simulate throttled drag updates (what ClipComponent does during drag)
         // These modify startTime and length but NOT offset
@@ -441,7 +443,8 @@ TEST_CASE("Left resize with throttled drag updates - offset must use original st
 
         // CORRECT approach (the fix): calculate delta from ORIGINAL state
         double correctDelta = finalStartTime - originalState.startTime;  // 1.0 - 0.0 = 1.0
-        double correctOffset = originalState.offset + correctDelta / originalState.speedRatio;
+        double correctOffset = magda::test::audioEvent(originalState).anchorSeconds() +
+                               correctDelta / magda::test::audioEvent(originalState).speedRatio;
 
         REQUIRE(correctDelta == Catch::Approx(1.0));
         REQUIRE(correctOffset == Catch::Approx(1.0));
@@ -457,16 +460,18 @@ TEST_CASE("Left resize with throttled drag updates - offset must use original st
         originalState.startTime = 0.0;
         originalState.length = 8.0;
         originalState.setAudioContent();
-        originalState.audio().source.filePath = "test.wav";
-        originalState.offset = 0.0;
-        originalState.speedRatio = 2.0;  // 2x slower (speedRatio = stretchFactor semantics)
+        magda::test::giveAudioEvent(originalState, "test.wav");
+        magda::test::audioEvent(originalState).setAnchorSeconds(0.0);
+        magda::test::audioEvent(originalState).speedRatio =
+            2.0;  // 2x slower (speedRatio = stretchFactor semantics)
 
         // User drags left edge right by 2 timeline seconds
         double finalStartTime = 2.0;
 
         // CORRECT approach: calculate from original state
         double correctDelta = finalStartTime - originalState.startTime;  // 2.0
-        double correctOffset = originalState.offset + correctDelta / originalState.speedRatio;
+        double correctOffset = magda::test::audioEvent(originalState).anchorSeconds() +
+                               correctDelta / magda::test::audioEvent(originalState).speedRatio;
 
         // 2.0 timeline seconds / 2.0 speedRatio = 1.0 file second offset
         REQUIRE(correctOffset == Catch::Approx(1.0));
@@ -478,9 +483,9 @@ TEST_CASE("Left resize with throttled drag updates - offset must use original st
         originalState.startTime = 0.0;
         originalState.length = 8.0;
         originalState.setAudioContent();
-        originalState.audio().source.filePath = "test.wav";
-        originalState.offset = 0.0;
-        originalState.speedRatio = 1.0;
+        magda::test::giveAudioEvent(originalState, "test.wav");
+        magda::test::audioEvent(originalState).setAnchorSeconds(0.0);
+        magda::test::audioEvent(originalState).speedRatio = 1.0;
 
         // Simulate multiple throttled updates during drag
         // User drags: 0.5s, then 1.0s, then 1.5s, finally 2.0s
@@ -500,7 +505,8 @@ TEST_CASE("Left resize with throttled drag updates - offset must use original st
 
         // CORRECT: Use original state for offset calculation
         double correctDelta = finalStartTime - originalState.startTime;
-        double correctOffset = originalState.offset + correctDelta / originalState.speedRatio;
+        double correctOffset = magda::test::audioEvent(originalState).anchorSeconds() +
+                               correctDelta / magda::test::audioEvent(originalState).speedRatio;
 
         REQUIRE(finalStartTime == 2.0);
         REQUIRE(correctOffset == Catch::Approx(2.0));
@@ -512,9 +518,9 @@ TEST_CASE("Left resize with throttled drag updates - offset must use original st
         originalState.startTime = 2.0;
         originalState.length = 4.0;
         originalState.setAudioContent();
-        originalState.audio().source.filePath = "test.wav";
-        originalState.offset = 2.0;  // Previously trimmed
-        originalState.speedRatio = 1.0;
+        magda::test::giveAudioEvent(originalState, "test.wav");
+        magda::test::audioEvent(originalState).setAnchorSeconds(2.0);  // Previously trimmed
+        magda::test::audioEvent(originalState).speedRatio = 1.0;
 
         // User drags left edge LEFT (expanding) by 2 seconds
         double finalStartTime = 0.0;
@@ -522,7 +528,8 @@ TEST_CASE("Left resize with throttled drag updates - offset must use original st
         // CORRECT: Calculate from original state
         double correctDelta = finalStartTime - originalState.startTime;  // -2.0
         double correctOffset =
-            juce::jmax(0.0, originalState.offset + correctDelta / originalState.speedRatio);
+            juce::jmax(0.0, magda::test::audioEvent(originalState).anchorSeconds() +
+                                correctDelta / magda::test::audioEvent(originalState).speedRatio);
 
         // 2.0 - 2.0 = 0.0 (reveals audio from beginning)
         REQUIRE(correctOffset == Catch::Approx(0.0));
@@ -617,16 +624,17 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart tracks offset for
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
-        clip.loopStart = 0.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
         clip.loopEnabled = false;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         ClipOperations::resizeContainerFromLeft(clip, 3.0);
 
-        REQUIRE(clip.offset == Catch::Approx(1.0));
-        REQUIRE(clip.loopStart == Catch::Approx(clip.offset));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(1.0));
+        REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() ==
+                Catch::Approx(magda::test::audioEvent(clip).anchorSeconds()));
     }
 
     SECTION("Expand from left: loopStart equals offset after resize") {
@@ -634,16 +642,17 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart tracks offset for
         clip.startTime = 2.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 2.0;
-        clip.loopStart = 2.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(2.0);
+        magda::test::audioEvent(clip).setLoopStartSeconds(2.0);
         clip.loopEnabled = false;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         ClipOperations::resizeContainerFromLeft(clip, 6.0);
 
-        REQUIRE(clip.offset == Catch::Approx(0.0));
-        REQUIRE(clip.loopStart == Catch::Approx(clip.offset));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(0.0));
+        REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() ==
+                Catch::Approx(magda::test::audioEvent(clip).anchorSeconds()));
     }
 
     SECTION("Multiple left resizes: loopStart always tracks offset") {
@@ -651,15 +660,16 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart tracks offset for
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
-        clip.loopStart = 0.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
         clip.loopEnabled = false;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         for (int i = 0; i < 5; ++i) {
             ClipOperations::resizeContainerFromLeft(clip, clip.length - 1.0);
-            REQUIRE(clip.loopStart == Catch::Approx(clip.offset));
+            REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() ==
+                    Catch::Approx(magda::test::audioEvent(clip).anchorSeconds()));
         }
     }
 
@@ -668,17 +678,18 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart tracks offset for
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
-        clip.loopStart = 0.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
         clip.loopEnabled = false;
-        clip.speedRatio = 2.0;
+        magda::test::audioEvent(clip).speedRatio = 2.0;
 
         ClipOperations::resizeContainerFromLeft(clip, 6.0);
 
         // 2.0 timeline delta * 2.0 speedRatio = 4.0 source offset
-        REQUIRE(clip.offset == Catch::Approx(4.0));
-        REQUIRE(clip.loopStart == Catch::Approx(clip.offset));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(4.0));
+        REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() ==
+                Catch::Approx(magda::test::audioEvent(clip).anchorSeconds()));
     }
 }
 
@@ -693,19 +704,20 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart unchanged for loo
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 1.0;
-        clip.loopStart = 0.5;
-        clip.loopLength = 2.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(1.0);
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.5);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(2.0);
         clip.loopEnabled = true;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
-        double originalLoopStart = clip.loopStart;
+        double originalLoopStart = magda::test::audioEvent(clip).loopStartSeconds();
 
         ClipOperations::resizeContainerFromLeft(clip, 6.0);
 
         // loopStart must NOT change — it's the user-defined loop anchor
-        REQUIRE(clip.loopStart == Catch::Approx(originalLoopStart));
+        REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() ==
+                Catch::Approx(originalLoopStart));
         // offset should have been adjusted (wrapped within loop region)
         REQUIRE(clip.startTime == 2.0);
         REQUIRE(clip.length == 6.0);
@@ -716,18 +728,19 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart unchanged for loo
         clip.startTime = 4.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 1.5;
-        clip.loopStart = 0.5;
-        clip.loopLength = 2.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(1.5);
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.5);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(2.0);
         clip.loopEnabled = true;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
-        double originalLoopStart = clip.loopStart;
+        double originalLoopStart = magda::test::audioEvent(clip).loopStartSeconds();
 
         ClipOperations::resizeContainerFromLeft(clip, 6.0);
 
-        REQUIRE(clip.loopStart == Catch::Approx(originalLoopStart));
+        REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() ==
+                Catch::Approx(originalLoopStart));
     }
 
     SECTION("Multiple looped resizes: loopStart never changes") {
@@ -735,26 +748,29 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart unchanged for loo
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 1.0;
-        clip.loopStart = 0.5;
-        clip.loopLength = 2.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(1.0);
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.5);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(2.0);
         clip.loopEnabled = true;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
-        double originalLoopStart = clip.loopStart;
+        double originalLoopStart = magda::test::audioEvent(clip).loopStartSeconds();
 
         // Shrink
         ClipOperations::resizeContainerFromLeft(clip, 6.0);
-        REQUIRE(clip.loopStart == Catch::Approx(originalLoopStart));
+        REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() ==
+                Catch::Approx(originalLoopStart));
 
         // Shrink more
         ClipOperations::resizeContainerFromLeft(clip, 4.0);
-        REQUIRE(clip.loopStart == Catch::Approx(originalLoopStart));
+        REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() ==
+                Catch::Approx(originalLoopStart));
 
         // Expand
         ClipOperations::resizeContainerFromLeft(clip, 7.0);
-        REQUIRE(clip.loopStart == Catch::Approx(originalLoopStart));
+        REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() ==
+                Catch::Approx(originalLoopStart));
     }
 
     SECTION("Looped offset wraps within loop region") {
@@ -762,12 +778,12 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart unchanged for loo
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 1.0;
-        clip.loopStart = 0.0;
-        clip.loopLength = 2.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(1.0);
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(2.0);
         clip.loopEnabled = true;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         // Shrink by 3 seconds — phaseDelta = 3.0, wraps within loopLength=2.0
         ClipOperations::resizeContainerFromLeft(clip, 5.0);
@@ -775,8 +791,9 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - loopStart unchanged for loo
         // offset should wrap: relOffset = 1.0-0.0 = 1.0, phaseDelta = 3.0
         // wrapPhase(1.0 + 3.0, 2.0) = wrapPhase(4.0, 2.0) = 0.0
         // new offset = loopStart + 0.0 = 0.0
-        REQUIRE(clip.offset == Catch::Approx(0.0));
-        REQUIRE(clip.loopStart == Catch::Approx(0.0));  // Unchanged
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(0.0));
+        REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() ==
+                Catch::Approx(0.0));  // Unchanged
     }
 }
 
@@ -791,15 +808,16 @@ TEST_CASE("ClipOperations::trimAudioFromLeft - loopStart tracks offset",
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
-        clip.loopStart = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         ClipOperations::trimAudioFromLeft(clip, 1.0);
 
-        REQUIRE(clip.offset == Catch::Approx(1.0));
-        REQUIRE(clip.loopStart == Catch::Approx(clip.offset));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(1.0));
+        REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() ==
+                Catch::Approx(magda::test::audioEvent(clip).anchorSeconds()));
     }
 
     SECTION("Trim outward (extend): loopStart equals offset") {
@@ -807,15 +825,16 @@ TEST_CASE("ClipOperations::trimAudioFromLeft - loopStart tracks offset",
         clip.startTime = 2.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 2.0;
-        clip.loopStart = 2.0;
-        clip.speedRatio = 1.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(2.0);
+        magda::test::audioEvent(clip).setLoopStartSeconds(2.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         ClipOperations::trimAudioFromLeft(clip, -1.0);
 
-        REQUIRE(clip.offset == Catch::Approx(1.0));
-        REQUIRE(clip.loopStart == Catch::Approx(clip.offset));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(1.0));
+        REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() ==
+                Catch::Approx(magda::test::audioEvent(clip).anchorSeconds()));
     }
 
     SECTION("Trim with speed ratio: loopStart equals offset") {
@@ -823,16 +842,17 @@ TEST_CASE("ClipOperations::trimAudioFromLeft - loopStart tracks offset",
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
-        clip.loopStart = 0.0;
-        clip.speedRatio = 1.5;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.5;
 
         ClipOperations::trimAudioFromLeft(clip, 2.0);
 
         // sourceDelta = 2.0 * 1.5 = 3.0
-        REQUIRE(clip.offset == Catch::Approx(3.0));
-        REQUIRE(clip.loopStart == Catch::Approx(clip.offset));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(3.0));
+        REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() ==
+                Catch::Approx(magda::test::audioEvent(clip).anchorSeconds()));
     }
 
     SECTION("Trim clamps to zero: loopStart equals offset") {
@@ -840,16 +860,17 @@ TEST_CASE("ClipOperations::trimAudioFromLeft - loopStart tracks offset",
         clip.startTime = 1.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.5;
-        clip.loopStart = 0.5;
-        clip.speedRatio = 1.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.5);
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.5);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
 
         // Try to extend past start of file
         ClipOperations::trimAudioFromLeft(clip, -2.0);
 
-        REQUIRE(clip.offset == Catch::Approx(0.0));
-        REQUIRE(clip.loopStart == Catch::Approx(clip.offset));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(0.0));
+        REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() ==
+                Catch::Approx(magda::test::audioEvent(clip).anchorSeconds()));
     }
 }
 
@@ -864,12 +885,12 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - auto-tempo offset uses BPM 
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
-        clip.offsetBeats = 0.0;
-        clip.speedRatio = 1.0;
-        clip.autoTempo = true;
-        clip.audio().interpretation.bpm = 140.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).setAnchorBeats(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
+        magda::test::audioEvent(clip).autoTempo = true;
+        magda::test::audioEvent(clip).interpBpm = 140.0;
 
         // Shrink by 1 second at 120 BPM
         ClipOperations::resizeContainerFromLeft(clip, 3.0, 120.0);
@@ -877,8 +898,8 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - auto-tempo offset uses BPM 
         // deltaBeats = 1.0 * 120/60 = 2.0 beats
         // offsetBeats = 0 + 2.0 = 2.0
         // offset (seconds) = 2.0 * 60/140 = 6/7
-        REQUIRE(clip.offsetBeats == Catch::Approx(2.0));
-        REQUIRE(clip.offset == Catch::Approx(120.0 / 140.0));
+        REQUIRE(magda::test::audioEvent(clip).anchorBeats() == Catch::Approx(2.0));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(120.0 / 140.0));
     }
 
     SECTION("Looped auto-tempo: offset wraps using beats") {
@@ -886,17 +907,17 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - auto-tempo offset uses BPM 
         clip.startTime = 0.0;
         clip.length = 8.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
-        clip.offsetBeats = 0.0;
-        clip.loopStart = 0.0;
-        clip.loopStartBeats = 0.0;
-        clip.loopLength = 2.0;                      // 2 source seconds
-        clip.loopLengthBeats = 2.0 * 140.0 / 60.0;  // source beats
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).setAnchorBeats(0.0);
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
+        magda::test::audioEvent(clip).setLoopStartBeats(0.0);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(2.0);               // 2 source seconds
+        magda::test::audioEvent(clip).setLoopLengthBeats(2.0 * 140.0 / 60.0);  // source beats
         clip.loopEnabled = true;
-        clip.speedRatio = 1.0;
-        clip.autoTempo = true;
-        clip.audio().interpretation.bpm = 140.0;
+        magda::test::audioEvent(clip).speedRatio = 1.0;
+        magda::test::audioEvent(clip).autoTempo = true;
+        magda::test::audioEvent(clip).interpBpm = 140.0;
 
         // Shrink by 1 second at 120 BPM
         ClipOperations::resizeContainerFromLeft(clip, 7.0, 120.0);
@@ -904,8 +925,8 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - auto-tempo offset uses BPM 
         // deltaBeats = 1.0 * 120/60 = 2.0 project beats
         // wrapPhase(0 + 2.0, 4.667) = 2.0 beats
         // offset (seconds) = 2.0 * 60/140 = 6/7
-        REQUIRE(clip.offsetBeats == Catch::Approx(2.0));
-        REQUIRE(clip.offset == Catch::Approx(120.0 / 140.0));
+        REQUIRE(magda::test::audioEvent(clip).anchorBeats() == Catch::Approx(2.0));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(120.0 / 140.0));
     }
 
     SECTION("Non-auto-tempo still uses speedRatio") {
@@ -913,16 +934,16 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - auto-tempo offset uses BPM 
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
-        clip.speedRatio = 2.0;
-        clip.autoTempo = false;
-        clip.audio().interpretation.bpm = 140.0;
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 2.0;
+        magda::test::audioEvent(clip).autoTempo = false;
+        magda::test::audioEvent(clip).interpBpm = 140.0;
 
         ClipOperations::resizeContainerFromLeft(clip, 3.0, 120.0);
 
         // Should use speedRatio (2.0), not BPM ratio
-        REQUIRE(clip.offset == Catch::Approx(2.0));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(2.0));
     }
 
     SECTION("Auto-tempo with matching BPMs gives same result as speedRatio=1") {
@@ -930,16 +951,16 @@ TEST_CASE("ClipOperations::resizeContainerFromLeft - auto-tempo offset uses BPM 
         clip.startTime = 0.0;
         clip.length = 4.0;
         clip.setAudioContent();
-        clip.audio().source.filePath = "test.wav";
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
-        clip.autoTempo = true;
-        clip.audio().interpretation.bpm = 120.0;  // Same as project
+        magda::test::giveAudioEvent(clip, "test.wav");
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
+        magda::test::audioEvent(clip).autoTempo = true;
+        magda::test::audioEvent(clip).interpBpm = 120.0;  // Same as project
 
         ClipOperations::resizeContainerFromLeft(clip, 3.0, 120.0);
 
         // 120/120 = 1.0, same as speedRatio
-        REQUIRE(clip.offset == Catch::Approx(1.0));
+        REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(1.0));
     }
 }
 
@@ -972,23 +993,21 @@ TEST_CASE("Multi-clip left-resize preview recomputes every clip from its snapsho
         ClipInfo preview = snapshot;
         ClipOperations::resizeContainerFromLeft(preview,
                                                 juce::jmax(0.1, originalLength + lengthDelta), bpm);
-        if (!preview.loopEnabled && preview.isAudio())
-            preview.loopStart = preview.offset;
+        if (auto* event = preview.primaryEvent(); event != nullptr && !preview.loopEnabled)
+            event->loopStartSamples = event->sourceAnchorSamples;
         return preview;
     };
 
     SECTION("Every selected clip shifts by the same delta, whatever its own start") {
         ClipInfo dragged;
-        dragged.setAudioContent();
-        dragged.audio().source.filePath = "a.wav";
+        magda::test::giveAudioEvent(dragged, "a.wav");
         ClipOperations::setTimelinePlacement(dragged, 0.0, 4.0, bpm);
-        dragged.offset = 2.0;
+        magda::test::audioEvent(dragged).setAnchorSeconds(2.0);
 
         ClipInfo other;
-        other.setAudioContent();
-        other.audio().source.filePath = "b.wav";
+        magda::test::giveAudioEvent(other, "b.wav");
         ClipOperations::setTimelinePlacement(other, 10.0, 6.0, bpm);
-        other.offset = 3.0;
+        magda::test::audioEvent(other).setAnchorSeconds(3.0);
 
         // Drag the left handle right by 1 second: both clips shrink by 1
         const double lengthDelta = -1.0;
@@ -1006,18 +1025,20 @@ TEST_CASE("Multi-clip left-resize preview recomputes every clip from its snapsho
         REQUIRE(otherPreview.getTimelineEnd(bpm) == Catch::Approx(16.0));
 
         // Each clip trims its own audio from its own offset
-        REQUIRE(draggedPreview.offset == Catch::Approx(3.0));
-        REQUIRE(otherPreview.offset == Catch::Approx(4.0));
-        REQUIRE(draggedPreview.loopStart == Catch::Approx(draggedPreview.offset));
-        REQUIRE(otherPreview.loopStart == Catch::Approx(otherPreview.offset));
+        REQUIRE(magda::audioEventRef(draggedPreview).anchorSeconds() == Catch::Approx(3.0));
+        REQUIRE(magda::audioEventRef(otherPreview).anchorSeconds() == Catch::Approx(4.0));
+        REQUIRE(magda::audioEventRef(draggedPreview).loopStartSeconds() ==
+                Catch::Approx(magda::audioEventRef(draggedPreview).anchorSeconds()));
+        REQUIRE(magda::audioEventRef(otherPreview).loopStartSeconds() ==
+                Catch::Approx(magda::audioEventRef(otherPreview).anchorSeconds()));
     }
 
     SECTION("Successive ticks do not drift - final tick equals a single-shot resize") {
         ClipInfo snapshot;
         snapshot.setAudioContent();
-        snapshot.audio().source.filePath = "b.wav";
+        magda::test::giveAudioEvent(snapshot, "b.wav");
         ClipOperations::setTimelinePlacement(snapshot, 10.0, 6.0, bpm);
-        snapshot.offset = 3.0;
+        magda::test::audioEvent(snapshot).setAnchorSeconds(3.0);
 
         ClipInfo preview = snapshot;
         for (double delta : {-0.25, -0.5, -0.75, -1.0})
@@ -1027,13 +1048,14 @@ TEST_CASE("Multi-clip left-resize preview recomputes every clip from its snapsho
 
         REQUIRE(preview.getTimelineStart(bpm) == Catch::Approx(singleShot.getTimelineStart(bpm)));
         REQUIRE(preview.getTimelineLength(bpm) == Catch::Approx(singleShot.getTimelineLength(bpm)));
-        REQUIRE(preview.offset == Catch::Approx(singleShot.offset));
+        REQUIRE(magda::test::audioEvent(preview).anchorSeconds() ==
+                Catch::Approx(magda::audioEventRef(singleShot).anchorSeconds()));
 
         // Dragging back to where it started restores the original state
         ClipInfo backToStart = previewTick(snapshot, 6.0, 0.0);
         REQUIRE(backToStart.getTimelineStart(bpm) == Catch::Approx(10.0));
         REQUIRE(backToStart.getTimelineLength(bpm) == Catch::Approx(6.0));
-        REQUIRE(backToStart.offset == Catch::Approx(3.0));
+        REQUIRE(magda::audioEventRef(backToStart).anchorSeconds() == Catch::Approx(3.0));
     }
 
     SECTION("Non-looped MIDI accumulates midiTrimOffset once, not once per tick") {
@@ -1057,10 +1079,10 @@ TEST_CASE("Multi-clip left-resize preview recomputes every clip from its snapsho
         // originalLength + lengthDelta. The preview must land in the same place.
         ClipInfo snapshot;
         snapshot.setAudioContent();
-        snapshot.audio().source.filePath = "c.wav";
+        magda::test::giveAudioEvent(snapshot, "c.wav");
         ClipOperations::setTimelinePlacement(snapshot, 4.0, 5.0, bpm);
-        snapshot.offset = 1.0;
-        snapshot.speedRatio = 2.0;
+        magda::test::audioEvent(snapshot).setAnchorSeconds(1.0);
+        magda::test::audioEvent(snapshot).speedRatio = 2.0;
 
         const double lengthDelta = 1.5;  // expanding leftwards
 
@@ -1068,21 +1090,22 @@ TEST_CASE("Multi-clip left-resize preview recomputes every clip from its snapsho
 
         ClipInfo committed = snapshot;  // restored before the resize command runs
         ClipOperations::resizeContainerFromLeft(committed, 5.0 + lengthDelta, bpm);
-        if (!committed.loopEnabled && committed.isAudio())
-            committed.loopStart = committed.offset;
+        if (auto* event = committed.primaryEvent(); event != nullptr && !committed.loopEnabled)
+            event->loopStartSamples = event->sourceAnchorSamples;
 
         REQUIRE(preview.getTimelineStart(bpm) == Catch::Approx(committed.getTimelineStart(bpm)));
         REQUIRE(preview.getTimelineLength(bpm) == Catch::Approx(committed.getTimelineLength(bpm)));
-        REQUIRE(preview.offset == Catch::Approx(committed.offset));
-        REQUIRE(preview.loopStart == Catch::Approx(committed.loopStart));
+        REQUIRE(magda::test::audioEvent(preview).anchorSeconds() ==
+                Catch::Approx(magda::test::audioEvent(committed).anchorSeconds()));
+        REQUIRE(magda::test::audioEvent(preview).loopStartSeconds() ==
+                Catch::Approx(magda::test::audioEvent(committed).loopStartSeconds()));
     }
 
     SECTION("A short clip in the selection clamps instead of inverting") {
         ClipInfo shortClip;
-        shortClip.setAudioContent();
-        shortClip.audio().source.filePath = "d.wav";
+        magda::test::giveAudioEvent(shortClip, "d.wav");
         ClipOperations::setTimelinePlacement(shortClip, 8.0, 0.5, bpm);
-        shortClip.offset = 0.0;
+        magda::test::audioEvent(shortClip).setAnchorSeconds(0.0);
 
         // Drag right far past the short clip's own length
         ClipInfo preview = previewTick(shortClip, 0.5, -2.0);

--- a/tests/test_clip_schema_migration.cpp
+++ b/tests/test_clip_schema_migration.cpp
@@ -443,3 +443,53 @@ TEST_CASE("A v2 clip round-trips several events", "[clip][serialization]") {
         REQUIRE(restored.audio().nextEventId > restored.events()[1].id);
     }
 }
+
+TEST_CASE("v1 migration stages its source instead of pooling it",
+          "[clip][serialization][migration][staging]") {
+    // Staging runs on a background thread and can still fail afterwards, so it
+    // must not write the message-thread pool the open project is reading.
+    // Before this, a v1 clip acquired as it migrated: a failed load left its
+    // sources behind and raced every paint-time sourceRateOf.
+    MigrationFixture fixture;
+    auto& pool = SourcePool::getInstance();
+
+    auto v1 = makeV1Clip("/tmp/legacy-staged.wav", 4.0);
+
+    std::vector<Source> legacySources;
+    ClipInfo clip;
+    REQUIRE(ProjectSerializer::deserializeClipInfo(v1, clip, kProjectTempo, &legacySources));
+
+    SECTION("Nothing reached the live pool") {
+        REQUIRE(pool.snapshot().empty());
+        REQUIRE(pool.findByPath("/tmp/legacy-staged.wav") == INVALID_SOURCE_ID);
+    }
+
+    SECTION("The event holds a provisional id backed by the staged entry") {
+        const auto* event = clip.primaryEvent();
+        REQUIRE(event != nullptr);
+        REQUIRE(event->sourceId < INVALID_SOURCE_ID);  // negative, never -1
+        REQUIRE(legacySources.size() == 1);
+        REQUIRE(legacySources.front().id == event->sourceId);
+        REQUIRE(legacySources.front().filePath == "/tmp/legacy-staged.wav");
+        REQUIRE(legacySources.front().durationSeconds == Approx(4.0));
+    }
+
+    SECTION("Two clips on one file share one staged entry, keeping the longest duration") {
+        // A short recorded duration would otherwise clamp the other clip's
+        // anchors and cap its right-extension.
+        auto shorter = makeV1Clip("/tmp/legacy-staged.wav", 1.0);
+        ClipInfo second;
+        REQUIRE(
+            ProjectSerializer::deserializeClipInfo(shorter, second, kProjectTempo, &legacySources));
+
+        REQUIRE(legacySources.size() == 1);
+        REQUIRE(legacySources.front().durationSeconds == Approx(4.0));
+        REQUIRE(second.primaryEvent()->sourceId == clip.primaryEvent()->sourceId);
+    }
+
+    SECTION("Without a sink the live pool is still used, for the single-clip callers") {
+        ClipInfo direct;
+        REQUIRE(ProjectSerializer::deserializeClipInfo(v1, direct, kProjectTempo));
+        REQUIRE(pool.findByPath("/tmp/legacy-staged.wav") != INVALID_SOURCE_ID);
+    }
+}

--- a/tests/test_clip_schema_migration.cpp
+++ b/tests/test_clip_schema_migration.cpp
@@ -1,0 +1,445 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "AudioClipTestHelpers.hpp"
+#include "core/ClipInfo.hpp"
+#include "core/SourcePool.hpp"
+#include "project/serialization/ProjectSerializer.hpp"
+
+using namespace magda;
+using Catch::Approx;
+
+namespace {
+
+constexpr double kProjectTempo = 120.0;
+constexpr double kSourceRate = 48000.0;
+
+struct MigrationFixture {
+    MigrationFixture() {
+        SourcePool::getInstance().clear();
+        SourcePool::getInstance().clearSeededFactsForTesting();
+    }
+    ~MigrationFixture() {
+        SourcePool::getInstance().clear();
+        SourcePool::getInstance().clearSeededFactsForTesting();
+    }
+};
+
+juce::DynamicObject* obj(juce::var& value) {
+    return value.getDynamicObject();
+}
+
+/// A schema v1 audio clip: one source, one interpretation, one playback block,
+/// and the interpretation fields sitting on the clip itself.
+juce::var makeV1Clip(const juce::String& filePath, double sourceDurationSeconds) {
+    auto* clip = new juce::DynamicObject();
+    clip->setProperty("id", 1);
+    clip->setProperty("trackId", 1);
+    clip->setProperty("name", "Migrated");
+    clip->setProperty("type", static_cast<int>(ClipType::Audio));
+    clip->setProperty("view", static_cast<int>(ClipView::Arrangement));
+    clip->setProperty("enabled", true);
+
+    auto* placement = new juce::DynamicObject();
+    placement->setProperty("startBeat", 4.0);
+    placement->setProperty("lengthBeats", 8.0);
+    clip->setProperty("placement", juce::var(placement));
+
+    auto* source = new juce::DynamicObject();
+    source->setProperty("filePath", filePath);
+    source->setProperty("durationSeconds", sourceDurationSeconds);
+
+    auto* interpretation = new juce::DynamicObject();
+    interpretation->setProperty("bpm", 0.0);
+    interpretation->setProperty("totalBeats", 0.0);
+    interpretation->setProperty("totalBeatsLocked", false);
+
+    auto* playback = new juce::DynamicObject();
+    playback->setProperty("offsetSeconds", 0.0);
+    playback->setProperty("offsetBeats", 0.0);
+    playback->setProperty("loopStartSeconds", 0.0);
+    playback->setProperty("loopLengthSeconds", 0.0);
+    playback->setProperty("loopStartBeats", 0.0);
+    playback->setProperty("loopLengthBeats", 0.0);
+    playback->setProperty("speedRatio", 1.0);
+
+    auto* audio = new juce::DynamicObject();
+    audio->setProperty("source", juce::var(source));
+    audio->setProperty("interpretation", juce::var(interpretation));
+    audio->setProperty("playback", juce::var(playback));
+    clip->setProperty("audio", juce::var(audio));
+
+    return juce::var(clip);
+}
+
+juce::DynamicObject& playbackOf(juce::var& clip) {
+    auto audio = obj(clip)->getProperty("audio");
+    return *obj(audio)->getProperty("playback").getDynamicObject();
+}
+
+juce::DynamicObject& interpretationOf(juce::var& clip) {
+    auto audio = obj(clip)->getProperty("audio");
+    return *obj(audio)->getProperty("interpretation").getDynamicObject();
+}
+
+ClipInfo load(const juce::var& clipJson) {
+    ClipInfo out;
+    REQUIRE(ProjectSerializer::deserializeClipInfo(clipJson, out, kProjectTempo));
+    return out;
+}
+
+}  // namespace
+
+// =============================================================================
+// A v1 clip becomes a clip holding exactly one event spanning it
+// =============================================================================
+
+TEST_CASE("A v1 audio clip migrates to a single event", "[clip][serialization][migration]") {
+    MigrationFixture fixture;
+    SourcePool::getInstance().seedFactsForTesting("/tmp/v1.wav", 4.0, kSourceRate);
+
+    auto json = makeV1Clip("/tmp/v1.wav", 4.0);
+    const auto clip = load(json);
+
+    REQUIRE(clip.isAudio());
+    REQUIRE(clip.events().size() == 1);
+
+    const auto& event = *clip.primaryEvent();
+    REQUIRE(event.id != INVALID_EVENT_ID);
+    REQUIRE(event.sourceId != INVALID_SOURCE_ID);
+    REQUIRE(event.sourceFilePath() == "/tmp/v1.wav");
+
+    SECTION("The event spans the clip") {
+        REQUIRE(clip.placement.lengthBeats == Approx(8.0));
+        REQUIRE(event.startBeat == Approx(0.0));
+        REQUIRE(event.lengthBeats == Approx(8.0));
+    }
+
+    SECTION("The file's duration lands on the pooled source, not the event") {
+        REQUIRE(event.sourceDurationSeconds() == Approx(4.0));
+    }
+}
+
+TEST_CASE("Two v1 clips on one file share a pooled source", "[clip][serialization][migration]") {
+    MigrationFixture fixture;
+    SourcePool::getInstance().seedFactsForTesting("/tmp/shared.wav", 4.0, kSourceRate);
+
+    auto first = makeV1Clip("/tmp/shared.wav", 4.0);
+    auto second = makeV1Clip("/tmp/shared.wav", 4.0);
+    obj(second)->setProperty("id", 2);
+
+    const auto a = load(first);
+    const auto b = load(second);
+
+    REQUIRE(a.primaryEvent()->sourceId == b.primaryEvent()->sourceId);
+    REQUIRE(SourcePool::getInstance().snapshot().size() == 1);
+}
+
+// =============================================================================
+// The source domain converts into samples
+// =============================================================================
+
+TEST_CASE("A non-autoTempo v1 clip converts its seconds to samples",
+          "[clip][serialization][migration]") {
+    MigrationFixture fixture;
+    SourcePool::getInstance().seedFactsForTesting("/tmp/v1.wav", 8.0, kSourceRate);
+
+    auto json = makeV1Clip("/tmp/v1.wav", 8.0);
+    playbackOf(json).setProperty("offsetSeconds", 1.5);
+    playbackOf(json).setProperty("loopStartSeconds", 1.0);
+    playbackOf(json).setProperty("loopLengthSeconds", 2.0);
+    playbackOf(json).setProperty("speedRatio", 1.25);
+    obj(json)->setProperty("loopEnabled", true);
+
+    const auto clip = load(json);
+    const auto& event = *clip.primaryEvent();
+
+    REQUIRE(event.sourceAnchorSamples == static_cast<int64_t>(1.5 * kSourceRate));
+    REQUIRE(event.loopStartSamples == static_cast<int64_t>(1.0 * kSourceRate));
+    REQUIRE(event.loopLengthSamples == static_cast<int64_t>(2.0 * kSourceRate));
+    REQUIRE(clip.loopEnabled);
+    REQUIRE(event.speedRatio == Approx(1.25));
+}
+
+TEST_CASE("An autoTempo v1 clip converts its source BEATS to samples",
+          "[clip][serialization][migration]") {
+    MigrationFixture fixture;
+    SourcePool::getInstance().seedFactsForTesting("/tmp/v1.wav", 8.0, kSourceRate);
+
+    // v1 kept beats authoritative under autoTempo and derived the seconds, so
+    // the beat fields are what the migration has to read.
+    auto json = makeV1Clip("/tmp/v1.wav", 8.0);
+    obj(json)->setProperty("autoTempo", true);
+    obj(json)->setProperty("loopEnabled", true);
+    interpretationOf(json).setProperty("bpm", 120.0);
+    interpretationOf(json).setProperty("totalBeats", 16.0);
+    playbackOf(json).setProperty("offsetBeats", 4.0);      // 2 s at 120 bpm
+    playbackOf(json).setProperty("loopStartBeats", 2.0);   // 1 s
+    playbackOf(json).setProperty("loopLengthBeats", 8.0);  // 4 s
+    playbackOf(json).setProperty("offsetSeconds", 999.0);  // stale derived cache
+    playbackOf(json).setProperty("loopStartSeconds", 999.0);
+    playbackOf(json).setProperty("loopLengthSeconds", 999.0);
+
+    const auto clip = load(json);
+    const auto& event = *clip.primaryEvent();
+
+    REQUIRE(event.autoTempo);
+    REQUIRE(event.interpBpm == Approx(120.0));
+    REQUIRE(event.anchorSeconds() == Approx(2.0));
+    REQUIRE(event.loopStartSeconds() == Approx(1.0));
+    REQUIRE(event.loopLengthSeconds() == Approx(4.0));
+
+    SECTION("The beat view survives the round trip") {
+        REQUIRE(event.anchorBeats() == Approx(4.0));
+        REQUIRE(event.loopStartBeats() == Approx(2.0));
+        REQUIRE(event.loopLengthBeats() == Approx(8.0));
+    }
+}
+
+TEST_CASE("A v1 clip whose file is missing migrates and rescales on relink",
+          "[clip][serialization][migration]") {
+    MigrationFixture fixture;
+    // No seeded facts: the pool cannot probe, so the source stays unresolved.
+    auto json = makeV1Clip("/tmp/magda_missing_source.wav", 6.0);
+    playbackOf(json).setProperty("offsetSeconds", 1.0);
+
+    auto clip = load(json);
+    auto& event = *clip.primaryEvent();
+    const auto* source = event.source();
+    REQUIRE(source != nullptr);
+    REQUIRE_FALSE(source->isResolved());
+
+    SECTION("The anchor is computed at the nominal rate") {
+        REQUIRE(event.sourceAnchorSamples ==
+                static_cast<int64_t>(1.0 * kUnresolvedSourceSampleRate));
+        REQUIRE(event.anchorSeconds() == Approx(1.0));
+    }
+
+    SECTION("The declared duration is kept so the clip is still measurable") {
+        REQUIRE(event.sourceDurationSeconds() == Approx(6.0));
+    }
+
+    SECTION("Resolving the file reports the transition that triggers a rescale") {
+        SourcePool::getInstance().seedFactsForTesting("/tmp/magda_missing_source.wav", 6.0,
+                                                      kSourceRate);
+        REQUIRE(SourcePool::getInstance().resolveFacts(event.sourceId));
+        REQUIRE(event.source()->isResolved());
+    }
+}
+
+// =============================================================================
+// Clip-level v1 fields land on the event
+// =============================================================================
+
+TEST_CASE("A v1 clip's interpretation fields move onto its event",
+          "[clip][serialization][migration]") {
+    MigrationFixture fixture;
+    SourcePool::getInstance().seedFactsForTesting("/tmp/v1.wav", 4.0, kSourceRate);
+
+    auto json = makeV1Clip("/tmp/v1.wav", 4.0);
+    obj(json)->setProperty("isReversed", true);
+    obj(json)->setProperty("transpose", -5);
+    obj(json)->setProperty("pitchChange", 2.5);
+    obj(json)->setProperty("autoPitch", true);
+    obj(json)->setProperty("autoPitchMode", 2);
+    obj(json)->setProperty("autoDetectBeats", true);
+    obj(json)->setProperty("beatSensitivity", 0.75);
+    obj(json)->setProperty("leftChannelActive", false);
+    obj(json)->setProperty("fadeIn", 0.25);
+    obj(json)->setProperty("fadeOut", 0.5);
+    obj(json)->setProperty("fadeInType", 3);
+    obj(json)->setProperty("fadeOutBehaviour", 1);
+
+    const auto clip = load(json);
+    const auto& event = *clip.primaryEvent();
+
+    REQUIRE(event.reversed);
+    REQUIRE(event.transpose == -5);
+    REQUIRE(event.pitchChange == Approx(2.5f));
+    REQUIRE(event.autoPitch);
+    REQUIRE(event.autoPitchMode == 2);
+    REQUIRE(event.autoDetectBeats);
+    REQUIRE(event.beatSensitivity == Approx(0.75f));
+    REQUIRE_FALSE(event.leftChannelActive);
+    REQUIRE(event.rightChannelActive);
+
+    SECTION("Fades keep their seconds: the split is behaviour-neutral") {
+        REQUIRE(event.fadeInSeconds == Approx(0.25));
+        REQUIRE(event.fadeOutSeconds == Approx(0.5));
+        REQUIRE(event.fadeInType == 3);
+        REQUIRE(event.fadeOutBehaviour == 1);
+    }
+}
+
+TEST_CASE("A v1 clip's warp markers move onto its event unchanged",
+          "[clip][serialization][migration]") {
+    MigrationFixture fixture;
+    SourcePool::getInstance().seedFactsForTesting("/tmp/v1.wav", 4.0, kSourceRate);
+
+    auto json = makeV1Clip("/tmp/v1.wav", 4.0);
+    auto audio = obj(json)->getProperty("audio");
+    obj(audio)->setProperty("warpEnabled", true);
+
+    juce::Array<juce::var> markers;
+    for (auto pair : {std::pair{0.0, 0.0}, std::pair{1.0, 1.5}}) {
+        auto* marker = new juce::DynamicObject();
+        marker->setProperty("sourceTime", pair.first);
+        marker->setProperty("warpTime", pair.second);
+        markers.add(juce::var(marker));
+    }
+    obj(audio)->setProperty("warpMarkers", markers);
+
+    const auto clip = load(json);
+    const auto& event = *clip.primaryEvent();
+
+    REQUIRE(event.warpEnabled);
+    REQUIRE(event.warpMarkers.size() == 2);
+    REQUIRE(event.warpMarkers[1].sourceTime == Approx(1.0));
+    REQUIRE(event.warpMarkers[1].warpTime == Approx(1.5));
+}
+
+TEST_CASE("A v1 MIDI clip's loop moves into the MIDI content",
+          "[clip][serialization][migration][midi]") {
+    MigrationFixture fixture;
+
+    auto* clip = new juce::DynamicObject();
+    clip->setProperty("id", 3);
+    clip->setProperty("trackId", 1);
+    clip->setProperty("type", static_cast<int>(ClipType::MIDI));
+    clip->setProperty("view", static_cast<int>(ClipView::Arrangement));
+    clip->setProperty("loopEnabled", true);
+    clip->setProperty("loopStartBeats", 2.0);
+    clip->setProperty("loopLengthBeats", 4.0);
+
+    auto* placement = new juce::DynamicObject();
+    placement->setProperty("startBeat", 0.0);
+    placement->setProperty("lengthBeats", 16.0);
+    clip->setProperty("placement", juce::var(placement));
+
+    const auto loaded = load(juce::var(clip));
+
+    REQUIRE(loaded.isMidi());
+    REQUIRE(loaded.primaryEvent() == nullptr);
+    REQUIRE(loaded.loopEnabled);
+    REQUIRE(loaded.loopStartBeats == Approx(2.0));
+    REQUIRE(loaded.loopLengthBeats == Approx(4.0));
+}
+
+// =============================================================================
+// v2 round-trip
+// =============================================================================
+
+TEST_CASE("A v2 audio clip round-trips its events", "[clip][serialization]") {
+    MigrationFixture fixture;
+
+    ClipInfo original;
+    original.id = 11;
+    original.trackId = 1;
+    original.name = "Round Trip";
+    auto& event = magda::test::giveAudioEvent(original, "/tmp/rt.wav", 4.0, kSourceRate);
+    original.setPlacementBeats(2.0, 8.0);
+
+    event.interpBpm = 174.0;
+    event.interpTotalBeats = 12.0;
+    event.interpTotalBeatsLocked = true;
+    event.keyRoot = "A";
+    event.keyScale = "minor";
+    event.autoTempo = true;
+    event.warpEnabled = true;
+    event.warpMarkers.push_back({0.5, 0.75});
+    event.transpose = 3;
+    event.pitchChange = -1.5f;
+    event.reversed = true;
+    event.gainDB = -2.5f;
+    event.fadeInSeconds = 0.1;
+    event.fadeOutType = 4;
+    original.loopEnabled = true;
+    event.setLoopStartSeconds(0.5);
+    event.setLoopLengthSeconds(1.5);
+    event.setAnchorSeconds(0.75);
+
+    const auto json = ProjectSerializer::serializeClipInfo(original);
+    const auto restored = load(json);
+    const auto& restoredEvent = *restored.primaryEvent();
+
+    REQUIRE(restored.events().size() == 1);
+    REQUIRE(restoredEvent.id == event.id);
+    REQUIRE(restoredEvent.sourceFilePath() == "/tmp/rt.wav");
+
+    SECTION("Geometry") {
+        REQUIRE(restored.placement.startBeat == Approx(2.0));
+        REQUIRE(restoredEvent.startBeat == Approx(0.0));
+        REQUIRE(restoredEvent.lengthBeats == Approx(8.0));
+    }
+
+    SECTION("The source domain survives to the sample") {
+        REQUIRE(restoredEvent.sourceAnchorSamples == event.sourceAnchorSamples);
+        REQUIRE(restoredEvent.loopStartSamples == event.loopStartSamples);
+        REQUIRE(restoredEvent.loopLengthSamples == event.loopLengthSamples);
+        REQUIRE(restored.loopEnabled);
+    }
+
+    SECTION("Interpretation and per-event mix") {
+        REQUIRE(restoredEvent.interpBpm == Approx(174.0));
+        REQUIRE(restoredEvent.interpTotalBeats == Approx(12.0));
+        REQUIRE(restoredEvent.interpTotalBeatsLocked);
+        REQUIRE(restoredEvent.keyRoot == "A");
+        REQUIRE(restoredEvent.keyScale == "minor");
+        REQUIRE(restoredEvent.autoTempo);
+        REQUIRE(restoredEvent.transpose == 3);
+        REQUIRE(restoredEvent.pitchChange == Approx(-1.5f));
+        REQUIRE(restoredEvent.reversed);
+        REQUIRE(restoredEvent.gainDB == Approx(-2.5f));
+        REQUIRE(restoredEvent.fadeInSeconds == Approx(0.1));
+        REQUIRE(restoredEvent.fadeOutType == 4);
+    }
+
+    SECTION("Warp markers keep their seconds pair") {
+        REQUIRE(restoredEvent.warpEnabled);
+        REQUIRE(restoredEvent.warpMarkers.size() == 1);
+        REQUIRE(restoredEvent.warpMarkers[0].sourceTime == Approx(0.5));
+        REQUIRE(restoredEvent.warpMarkers[0].warpTime == Approx(0.75));
+    }
+}
+
+TEST_CASE("A long source keeps sample precision through the file", "[clip][serialization]") {
+    MigrationFixture fixture;
+
+    // juce::var has no 64-bit integer, so anchors travel as strings. A double
+    // would start losing whole samples on a long file.
+    ClipInfo original;
+    auto& event = magda::test::giveAudioEvent(original, "/tmp/long.wav", 7200.0, kSourceRate);
+    original.setPlacementBeats(0.0, 4.0);
+    event.sourceAnchorSamples = 345'678'901'234LL;
+
+    const auto restored = load(ProjectSerializer::serializeClipInfo(original));
+    REQUIRE(restored.primaryEvent()->sourceAnchorSamples == 345'678'901'234LL);
+}
+
+TEST_CASE("A v2 clip round-trips several events", "[clip][serialization]") {
+    MigrationFixture fixture;
+
+    // Nothing builds these yet, but the schema and the loader carry N so the
+    // event-level features do not need another migration.
+    ClipInfo original;
+    magda::test::giveAudioEvent(original, "/tmp/a.wav", 4.0, kSourceRate);
+    original.setPlacementBeats(0.0, 8.0);
+
+    auto& second = original.audio().addEvent({});
+    second.sourceId = SourcePool::getInstance().acquire("/tmp/b.wav");
+    second.startBeat = 4.0;
+    second.lengthBeats = 4.0;
+    second.setAnchorSeconds(1.0);
+
+    const auto restored = load(ProjectSerializer::serializeClipInfo(original));
+
+    REQUIRE(restored.events().size() == 2);
+    REQUIRE(restored.events()[0].sourceFilePath() == "/tmp/a.wav");
+    REQUIRE(restored.events()[1].sourceFilePath() == "/tmp/b.wav");
+    REQUIRE(restored.events()[1].startBeat == Approx(4.0));
+    REQUIRE(restored.events()[1].anchorSeconds() == Approx(1.0));
+
+    SECTION("The next event id clears every restored event") {
+        REQUIRE(restored.audio().nextEventId > restored.events()[1].id);
+    }
+}

--- a/tests/test_clip_sync_integration_juce.cpp
+++ b/tests/test_clip_sync_integration_juce.cpp
@@ -6,6 +6,7 @@
 #include <unordered_set>
 
 // TE internal test utilities (not exposed via module public headers)
+#include "AudioClipTestHelpers.hpp"
 #include "SharedTestEngine.hpp"
 #include "magda/daw/audio/AudioThumbnailManager.hpp"
 #include "magda/daw/audio/TrackController.hpp"
@@ -264,16 +265,17 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
     static void configureBeatModeLoop(ClipInfo& clip, double projectBpm, double sourceBpm,
                                       double sourceDurationSeconds, double loopStartBeats,
                                       double loopLengthBeats, double placementLengthBeats) {
-        clip.autoTempo = true;
+        magda::test::audioEvent(clip).autoTempo = true;
         clip.loopEnabled = true;
-        clip.audio().interpretation.bpm = sourceBpm;
-        clip.audio().interpretation.totalBeats = sourceDurationSeconds * sourceBpm / 60.0;
-        clip.loopStartBeats = loopStartBeats;
-        clip.loopLengthBeats = loopLengthBeats;
-        clip.offsetBeats = loopStartBeats;
-        clip.loopStart = loopStartBeats * 60.0 / sourceBpm;
-        clip.loopLength = loopLengthBeats * 60.0 / sourceBpm;
-        clip.offset = clip.offsetBeats * 60.0 / sourceBpm;
+        magda::test::audioEvent(clip).interpBpm = sourceBpm;
+        magda::test::audioEvent(clip).interpTotalBeats = sourceDurationSeconds * sourceBpm / 60.0;
+        magda::test::audioEvent(clip).setLoopStartBeats(loopStartBeats);
+        magda::test::audioEvent(clip).setLoopLengthBeats(loopLengthBeats);
+        magda::test::audioEvent(clip).setAnchorBeats(loopStartBeats);
+        magda::test::audioEvent(clip).setLoopStartSeconds(loopStartBeats * 60.0 / sourceBpm);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(loopLengthBeats * 60.0 / sourceBpm);
+        magda::test::audioEvent(clip).setAnchorSeconds(magda::test::audioEvent(clip).anchorBeats() *
+                                                       60.0 / sourceBpm);
         clip.setPlacementBeats(0.0, placementLengthBeats);
         clip.deriveTimesFromBeats(projectBpm);
     }
@@ -355,11 +357,12 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         if (clip == nullptr)
             return;
         expect(clip->view == ClipView::Session, "Clip should be a session clip");
-        expect(clip->autoTempo, "Session audio clips should default to beat mode");
-        expectWithinAbsoluteError(clip->audio().interpretation.bpm, detectedBpm, 0.01);
-        expectWithinAbsoluteError(clip->audio().interpretation.totalBeats, expectedSourceBeats,
+        expect(primaryEventOf(clip)->autoTempo, "Session audio clips should default to beat mode");
+        expectWithinAbsoluteError(primaryEventOf(clip)->interpBpm, detectedBpm, 0.01);
+        expectWithinAbsoluteError(primaryEventOf(clip)->interpTotalBeats, expectedSourceBeats,
                                   0.01);
-        expectWithinAbsoluteError(clip->loopLengthBeats, expectedSourceBeats, 0.01);
+        expectWithinAbsoluteError(primaryEventOf(clip)->loopLengthBeats(), expectedSourceBeats,
+                                  0.01);
 
         thumbs.clearCache();
     }
@@ -386,10 +389,11 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         expect(clip != nullptr, "Session clip should still exist after sync");
         if (clip == nullptr)
             return;
-        expectWithinAbsoluteError(clip->audio().interpretation.bpm, detectedBpm, 0.01);
-        expectWithinAbsoluteError(clip->audio().interpretation.totalBeats, expectedSourceBeats,
+        expectWithinAbsoluteError(primaryEventOf(clip)->interpBpm, detectedBpm, 0.01);
+        expectWithinAbsoluteError(primaryEventOf(clip)->interpTotalBeats, expectedSourceBeats,
                                   0.01);
-        expectWithinAbsoluteError(clip->loopLengthBeats, expectedSourceBeats, 0.01);
+        expectWithinAbsoluteError(primaryEventOf(clip)->loopLengthBeats(), expectedSourceBeats,
+                                  0.01);
 
         auto* teClip = dynamic_cast<te::WaveAudioClip*>(f.clipSync->getSessionTeClip(clipId));
         expect(teClip != nullptr, "Tracktion session clip should exist");
@@ -459,11 +463,12 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
             return;
 
         constexpr double sourceBpm = 172.0;
-        const double sourceBeats = clip->audio().source.durationSeconds * sourceBpm / 60.0;
-        clip->autoTempo = true;
-        clip->audio().interpretation.bpm = sourceBpm;
-        clip->audio().interpretation.totalBeats = sourceBeats;
-        clip->timeStretchMode = static_cast<int>(te::TimeStretcher::soundtouchNormal);
+        const double sourceBeats = primaryEventOf(clip)->sourceDurationSeconds() * sourceBpm / 60.0;
+        primaryEventOf(clip)->autoTempo = true;
+        primaryEventOf(clip)->interpBpm = sourceBpm;
+        primaryEventOf(clip)->interpTotalBeats = sourceBeats;
+        primaryEventOf(clip)->timeStretchMode =
+            static_cast<int>(te::TimeStretcher::soundtouchNormal);
         clip->setPlacementBeats(0.0, sourceBeats);
         clip->deriveTimesFromBeats(120.0);
 
@@ -480,7 +485,7 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         const bool canObserveReallocation = f.edit->getCurrentPlaybackContext() != nullptr;
         f.clipSync->onGraphReallocated = [&reallocations] { ++reallocations; };
 
-        clip->timeStretchMode = static_cast<int>(te::TimeStretcher::signalsmith);
+        primaryEventOf(clip)->timeStretchMode = static_cast<int>(te::TimeStretcher::signalsmith);
         f.clipSync->syncClipToEngine(clipId);
         expectEquals(static_cast<int>(teClip->getTimeStretchMode()),
                      static_cast<int>(te::TimeStretcher::signalsmith));
@@ -488,7 +493,8 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
             expectEquals(reallocations, 1,
                          "Signalsmith selection should rebuild the playback graph");
 
-        clip->timeStretchMode = static_cast<int>(te::TimeStretcher::soundtouchBetter);
+        primaryEventOf(clip)->timeStretchMode =
+            static_cast<int>(te::TimeStretcher::soundtouchBetter);
         f.clipSync->syncClipToEngine(clipId);
         expectEquals(static_cast<int>(teClip->getTimeStretchMode()),
                      static_cast<int>(te::TimeStretcher::soundtouchBetter));
@@ -503,10 +509,11 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         if (!sessionClip)
             return;
 
-        sessionClip->autoTempo = true;
-        sessionClip->audio().interpretation.bpm = sourceBpm;
-        sessionClip->audio().interpretation.totalBeats = sourceBeats;
-        sessionClip->timeStretchMode = static_cast<int>(te::TimeStretcher::soundtouchNormal);
+        primaryEventOf(sessionClip)->autoTempo = true;
+        primaryEventOf(sessionClip)->interpBpm = sourceBpm;
+        primaryEventOf(sessionClip)->interpTotalBeats = sourceBeats;
+        primaryEventOf(sessionClip)->timeStretchMode =
+            static_cast<int>(te::TimeStretcher::soundtouchNormal);
         cm.setClipSceneIndex(sessionClipId, 0);
         if (f.clipSync->getSessionTeClip(sessionClipId) == nullptr)
             f.clipSync->syncSessionClipToSlot(sessionClipId);
@@ -581,13 +588,13 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         if (source == nullptr)
             return;
 
-        source->warpEnabled = true;
-        source->timeStretchMode = static_cast<int>(te::TimeStretcher::signalsmith);
+        primaryEventOf(source)->warpEnabled = true;
+        primaryEventOf(source)->timeStretchMode = static_cast<int>(te::TimeStretcher::signalsmith);
         f.clipSync->syncClipToEngine(sourceId);
 
         const int insertedIndex = f.clipSync->addWarpMarker(sourceId, 1.0, 1.25);
         expect(insertedIndex >= 0, "User warp marker should be inserted");
-        expectEquals(static_cast<int>(source->warpMarkers.size()), 3,
+        expectEquals(static_cast<int>(primaryEventOf(source)->warpMarkers.size()), 3,
                      "Live TE marker edits should be mirrored into ClipInfo");
 
         cm.copyToClipboard({sourceId});
@@ -602,9 +609,10 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         if (pasted == nullptr)
             return;
 
-        expect(pasted->warpEnabled, "Pasted session clip should remain warped");
-        expectEquals(pasted->timeStretchMode, static_cast<int>(te::TimeStretcher::signalsmith));
-        expectEquals(static_cast<int>(pasted->warpMarkers.size()), 3,
+        expect(primaryEventOf(pasted)->warpEnabled, "Pasted session clip should remain warped");
+        expectEquals(primaryEventOf(pasted)->timeStretchMode,
+                     static_cast<int>(te::TimeStretcher::signalsmith));
+        expectEquals(static_cast<int>(primaryEventOf(pasted)->warpMarkers.size()), 3,
                      "Pasted ClipInfo should contain the source marker map");
 
         if (f.clipSync->getSessionTeClip(pastedId) == nullptr)
@@ -664,15 +672,16 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         if (arrangement == nullptr)
             return;
 
-        arrangement->warpEnabled = true;
+        magda::primaryEventOf(arrangement)->warpEnabled = true;
         f.clipSync->syncClipToEngine(arrangementId);
         f.clipSync->enableWarp(arrangementId);
 
         auto* arrangementTeClip = f.getTeAudioClip(arrangementId);
         expect(arrangementTeClip != nullptr, "Arrangement TE clip should exist");
-        expectEquals(static_cast<int>(arrangement->warpMarkers.size()), 2,
+        expectEquals(static_cast<int>(magda::primaryEventOf(arrangement)->warpMarkers.size()), 2,
                      "Enabling warp without user markers should store only the boundaries");
-        if (arrangementTeClip == nullptr || arrangement->warpMarkers.size() != 2)
+        if (arrangementTeClip == nullptr ||
+            magda::primaryEventOf(arrangement)->warpMarkers.size() != 2)
             return;
 
         auto& arrangementWarpManager = arrangementTeClip->getWarpTimeManager();
@@ -697,11 +706,11 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         if (session == nullptr || sessionTeClip == nullptr)
             return;
 
-        session->warpEnabled = true;
+        primaryEventOf(session)->warpEnabled = true;
         f.clipSync->enableWarp(sessionId);
-        expectEquals(static_cast<int>(session->warpMarkers.size()), 2,
+        expectEquals(static_cast<int>(primaryEventOf(session)->warpMarkers.size()), 2,
                      "Session warp enable should store its boundary map");
-        if (session->warpMarkers.size() != 2)
+        if (primaryEventOf(session)->warpMarkers.size() != 2)
             return;
 
         // Settle other lazily-created session properties before observing graph
@@ -716,7 +725,7 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
 
         // Serialized doubles can differ by sub-microsecond rounding. This must
         // still compare equal rather than restarting playback on a gain change.
-        session->warpMarkers.front().warpTime += 5.0e-7;
+        primaryEventOf(session)->warpMarkers.front().warpTime += 5.0e-7;
 
         WarpStateMutationCounter sessionMutations(sessionWarpManager.state);
         int reallocationCount = 0;
@@ -746,8 +755,8 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         if (clip == nullptr)
             return;
 
-        clip->warpEnabled = true;
-        clip->warpMarkers = {{0.0, 0.0}};
+        primaryEventOf(clip)->warpEnabled = true;
+        primaryEventOf(clip)->warpMarkers = {{0.0, 0.0}};
         f.clipSync->syncClipToEngine(clipId);
 
         auto* teClip = f.getTeAudioClip(clipId);
@@ -799,10 +808,10 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         if (!clip)
             return;
 
-        clip->offset = 1.0;
-        clip->loopStart = 1.0;
+        primaryEventOf(clip)->setAnchorSeconds(1.0);
+        primaryEventOf(clip)->setLoopStartSeconds(1.0);
         f.clipSync->removeClipFromEngine(clipId);
-        clip->isReversed = true;
+        primaryEventOf(clip)->reversed = true;
         cm.forceNotifyMultipleClipPropertiesChanged({clipId, clipId});
 
         auto* teClip = f.getTeAudioClip(clipId);
@@ -812,7 +821,7 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
             return;
 
         expect(teClip->getIsReversed(), "Reversed state should sync before returning");
-        expectWithinAbsoluteError(clip->offset, 1.0, 0.01,
+        expectWithinAbsoluteError(primaryEventOf(clip)->anchorSeconds(), 1.0, 0.01,
                                   "Recreation must preserve the canonical selected offset");
         expectWithinAbsoluteError(
             teClip->getPosition().getOffset().inSeconds(), 3.0, 0.01,
@@ -837,8 +846,8 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
             return;
 
         // The audible selection is source [1, 2]. Its whole-file mirror [3, 4] is silent.
-        clip->offset = 1.0;
-        clip->loopStart = 1.0;
+        primaryEventOf(clip)->setAnchorSeconds(1.0);
+        primaryEventOf(clip)->setLoopStartSeconds(1.0);
         f.clipSync->syncClipToEngine(clipId);
 
         auto* teClip = f.getTeAudioClip(clipId);
@@ -847,10 +856,10 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
             return;
         expectWithinAbsoluteError(teClip->getPosition().getOffset().inSeconds(), 1.0, 0.01);
 
-        clip->isReversed = true;
+        primaryEventOf(clip)->reversed = true;
         f.clipSync->syncClipToEngine(clipId);
 
-        expectWithinAbsoluteError(clip->offset, 1.0, 0.01,
+        expectWithinAbsoluteError(primaryEventOf(clip)->anchorSeconds(), 1.0, 0.01,
                                   "The model must retain the original selected source offset");
 
         if (auto* engine = magda::test::getSharedEngine().getEngine())
@@ -867,7 +876,7 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         // A later property sync must not write the canonical offset directly into the proxy.
         clip->gainDB = -1.0f;
         f.clipSync->syncClipToEngine(clipId);
-        expectWithinAbsoluteError(clip->offset, 1.0, 0.01);
+        expectWithinAbsoluteError(primaryEventOf(clip)->anchorSeconds(), 1.0, 0.01);
         expectWithinAbsoluteError(teClip->getPosition().getOffset().inSeconds(), 3.0, 0.01);
 
         auto result = f.renderToSeconds(1.0);
@@ -1162,8 +1171,9 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         expectWithinAbsoluteError(pos.getEnd().inSeconds(), 4.0, 0.01);
 
         // Offset should have increased by 1.0 * speedRatio (1.0) = 1.0
-        expectWithinAbsoluteError(pos.getOffset().inSeconds(), clip->getTeOffset(clip->loopEnabled),
-                                  0.01);
+        expectWithinAbsoluteError(
+            pos.getOffset().inSeconds(),
+            magda::audioEventRef(*clip).engineOffsetSeconds(clip->loopEnabled), 0.01);
     }
 
     void testTrimAudioFromLeft() {
@@ -1175,7 +1185,7 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         f.clipSync->syncClipToEngine(clipId);
 
         auto* clip = ClipManager::getInstance().getClip(clipId);
-        double originalOffset = clip->offset;
+        double originalOffset = primaryEventOf(clip)->anchorSeconds();
 
         // Trim 1.0s from left
         ClipOperations::trimAudioFromLeft(*clip, 1.0, 0.0, 60.0);
@@ -1185,12 +1195,14 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         expect(teClip != nullptr);
 
         // Offset should have increased
-        expect(clip->offset > originalOffset, "Offset should increase after left trim");
+        expect(primaryEventOf(clip)->anchorSeconds() > originalOffset,
+               "Offset should increase after left trim");
 
         // TE offset should match model's getTeOffset
         auto pos = teClip->getPosition();
-        expectWithinAbsoluteError(pos.getOffset().inSeconds(), clip->getTeOffset(clip->loopEnabled),
-                                  0.01);
+        expectWithinAbsoluteError(
+            pos.getOffset().inSeconds(),
+            magda::audioEventRef(*clip).engineOffsetSeconds(clip->loopEnabled), 0.01);
 
         // Start should have moved right by ~1.0
         expectWithinAbsoluteError(pos.getStart().inSeconds(), 1.0, 0.01);
@@ -1228,7 +1240,7 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         // The actual invariant lives in MAGDA's model:
         //  - In time-based mode, ClipSynchronizer writes the model's speedRatio
         //    to TE; getSpeedRatio() reflects it.
-        //  - In autoTempo, MAGDA's clip->speedRatio is pinned to 1.0 (TE's
+        //  - In autoTempo, MAGDA's primaryEventOf(clip)->speedRatio is pinned to 1.0 (TE's
         //    autoTempo path requires it). TE's stored speedRatio may keep its
         //    pre-autoTempo value because AudioClipBase::setSpeedRatio is a
         //    no-op when autoTempo is on; TE doesn't use it for playback in
@@ -1252,7 +1264,7 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         expectWithinAbsoluteError(teClip->getSpeedRatio(), 2.0, 0.01);
 
         // 2) Flip on autoTempo via the proper API. ClipOperations::setAutoTempo
-        //    pins clip->speedRatio to 1.0 (TE's autoTempo path requires it).
+        //    pins primaryEventOf(clip)->speedRatio to 1.0 (TE's autoTempo path requires it).
         //    TE's getSpeedRatio() is undefined in this mode — TE silently
         //    rejects setSpeedRatio when autoTempo is on — so we don't assert
         //    TE's stored value here.
@@ -1260,8 +1272,8 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
             auto* clip = cm.getClip(clipId);
             if (clip == nullptr)
                 return;
-            clip->audio().interpretation.bpm = 60.0;
-            clip->audio().interpretation.totalBeats = 2.0;
+            primaryEventOf(clip)->interpBpm = 60.0;
+            primaryEventOf(clip)->interpTotalBeats = 2.0;
         }
         cm.setAutoTempo(clipId, true, 60.0);
         f.clipSync->syncClipToEngine(clipId);
@@ -1270,7 +1282,7 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
             if (clip == nullptr)
                 return;
             expect(teClip->getAutoTempo(), "TE clip should be in autoTempo mode");
-            expectWithinAbsoluteError(clip->speedRatio, 1.0, 0.01);
+            expectWithinAbsoluteError(primaryEventOf(clip)->speedRatio, 1.0, 0.01);
         }
 
         // 3) Disable autoTempo, then change model speedRatio to 0.5 → TE
@@ -1294,14 +1306,16 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
 
         // Auto-tempo + beat-domain loop region (clips are beat-authoritative).
         auto* clip = ClipManager::getInstance().getClip(clipId);
-        clip->autoTempo = true;
-        clip->audio().interpretation.bpm = 60.0;
-        clip->audio().interpretation.totalBeats = 5.0;  // 5s sine WAV at 60 BPM
+        primaryEventOf(clip)->autoTempo = true;
+        primaryEventOf(clip)->interpBpm = 60.0;
+        primaryEventOf(clip)->interpTotalBeats = 5.0;  // 5s sine WAV at 60 BPM
         clip->loopEnabled = true;
-        clip->loopStartBeats = 0.0;
-        clip->loopLengthBeats = 2.0;
-        clip->loopStart = clip->loopStartBeats * 60.0 / clip->audio().interpretation.bpm;
-        clip->loopLength = clip->loopLengthBeats * 60.0 / clip->audio().interpretation.bpm;
+        primaryEventOf(clip)->setLoopStartBeats(0.0);
+        primaryEventOf(clip)->setLoopLengthBeats(2.0);
+        primaryEventOf(clip)->setLoopStartSeconds(primaryEventOf(clip)->loopStartBeats() * 60.0 /
+                                                  primaryEventOf(clip)->interpBpm);
+        primaryEventOf(clip)->setLoopLengthSeconds(primaryEventOf(clip)->loopLengthBeats() * 60.0 /
+                                                   primaryEventOf(clip)->interpBpm);
         f.clipSync->syncClipToEngine(clipId);
 
         expect(teClip->isLooping(), "TE clip should be looping");
@@ -1341,7 +1355,8 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         expect(trimmed != nullptr, "Trimmed clip should survive disabling beat mode");
         if (trimmed == nullptr)
             return;
-        expect(!trimmed->autoTempo, "Trimmed clip should be time-based after disabling beat mode");
+        expect(!magda::audioEventRef(*trimmed).autoTempo,
+               "Trimmed clip should be time-based after disabling beat mode");
         expectWithinAbsoluteError(trimmed->placement.lengthBeats, trimmedBeats, 0.001);
 
         ClipManager::getInstance().setAutoTempo(trimmedId, true, projectBpm);
@@ -1349,7 +1364,8 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         expect(trimmed != nullptr, "Trimmed clip should survive re-enabling beat mode");
         if (trimmed == nullptr)
             return;
-        expect(trimmed->autoTempo, "Trimmed clip should be beat-based after re-enabling beat mode");
+        expect(magda::audioEventRef(*trimmed).autoTempo,
+               "Trimmed clip should be beat-based after re-enabling beat mode");
         expectWithinAbsoluteError(trimmed->placement.lengthBeats, trimmedBeats, 0.001);
         expectWithinAbsoluteError(trimmed->length, trimmedBeats * 60.0 / projectBpm, 0.001);
 
@@ -1360,8 +1376,8 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         if (full == nullptr)
             return;
 
-        full->audio().interpretation.bpm = sourceBpm;
-        full->audio().interpretation.totalBeats = sourceBeats;
+        magda::primaryEventOf(full)->interpBpm = sourceBpm;
+        magda::primaryEventOf(full)->interpTotalBeats = sourceBeats;
         ClipManager::getInstance().setAutoTempo(fullId, true, projectBpm);
         full = ClipManager::getInstance().getClip(fullId);
         expect(full != nullptr, "Full source clip should survive enabling beat mode");
@@ -1396,19 +1412,19 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         // Auto-tempo + beat-domain loop region. Container extends to 3 beats
         // (1.5× the loop region) via setPlacementBeats; deriveTimesFromBeats
         // refreshes the seconds cache so the renderer agrees with TE.
-        clip->autoTempo = true;
-        clip->audio().interpretation.bpm = 60.0;
-        clip->audio().interpretation.totalBeats = 5.0;
+        primaryEventOf(clip)->autoTempo = true;
+        primaryEventOf(clip)->interpBpm = 60.0;
+        primaryEventOf(clip)->interpTotalBeats = 5.0;
         clip->loopEnabled = true;
-        clip->loopStartBeats = 0.0;
-        clip->loopLengthBeats = 2.0;
-        clip->loopStart = 0.0;
-        clip->loopLength = 2.0;
+        primaryEventOf(clip)->setLoopStartBeats(0.0);
+        primaryEventOf(clip)->setLoopLengthBeats(2.0);
+        primaryEventOf(clip)->setLoopStartSeconds(0.0);
+        primaryEventOf(clip)->setLoopLengthSeconds(2.0);
         clip->setPlacementBeats(0.0, 3.0);
         clip->deriveTimesFromBeats(60.0);
 
         expect(clip->loopEnabled, "Model: loopEnabled should be true");
-        expectWithinAbsoluteError(clip->loopLengthBeats, 2.0, 0.01);
+        expectWithinAbsoluteError(primaryEventOf(clip)->loopLengthBeats(), 2.0, 0.01);
         expectWithinAbsoluteError(clip->length, 3.0, 0.01);
 
         f.clipSync->syncClipToEngine(clipId);
@@ -1495,16 +1511,16 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         ClipOperations::resizeContainerFromRight(*clip, 3.0, 60.0);
 
         // Enable warp (this routes sync through the auto-tempo/warp code path)
-        clip->warpEnabled = true;
+        primaryEventOf(clip)->warpEnabled = true;
         // Set the current default time-stretch mode.
-        clip->timeStretchMode = static_cast<int>(te::TimeStretcher::defaultMode);
+        primaryEventOf(clip)->timeStretchMode = static_cast<int>(te::TimeStretcher::defaultMode);
 
         // Verify model state
         expect(clip->loopEnabled, "Model: loopEnabled should be true");
-        expect(clip->warpEnabled, "Model: warpEnabled should be true");
-        expect(!clip->autoTempo, "Model: autoTempo should be false");
-        expectWithinAbsoluteError(clip->loopStart, 0.0, 0.01);
-        expectWithinAbsoluteError(clip->loopLength, 2.0, 0.01);
+        expect(primaryEventOf(clip)->warpEnabled, "Model: warpEnabled should be true");
+        expect(!primaryEventOf(clip)->autoTempo, "Model: autoTempo should be false");
+        expectWithinAbsoluteError(primaryEventOf(clip)->loopStartSeconds(), 0.0, 0.01);
+        expectWithinAbsoluteError(primaryEventOf(clip)->loopLengthSeconds(), 2.0, 0.01);
         expectWithinAbsoluteError(clip->length, 3.0, 0.01);
 
         f.clipSync->syncClipToEngine(clipId);
@@ -1595,9 +1611,11 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         // Right clip should have increased offset (by 2.0 * speedRatio)
         auto* rightClip = ClipManager::getInstance().getClip(rightClipId);
         expect(rightClip != nullptr);
-        expectWithinAbsoluteError(rightPos.getOffset().inSeconds(),
-                                  rightClip->getTeOffset(rightClip->loopEnabled), 0.01);
-        expect(rightClip->offset > 0.0, "Right clip offset should be > 0 after split");
+        expectWithinAbsoluteError(
+            rightPos.getOffset().inSeconds(),
+            magda::audioEventRef(*rightClip).engineOffsetSeconds(rightClip->loopEnabled), 0.01);
+        expect(primaryEventOf(rightClip)->anchorSeconds() > 0.0,
+               "Right clip offset should be > 0 after split");
     }
 
     void testSplitDrivesLeftClipUpdateThroughListener() {
@@ -1694,15 +1712,15 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         if (clip == nullptr)
             return;
 
-        clip->autoTempo = true;
+        primaryEventOf(clip)->autoTempo = true;
         clip->loopEnabled = true;
-        clip->audio().interpretation.bpm = 172.0;
-        clip->audio().interpretation.totalBeats = 5.0 * 172.0 / 60.0;
-        clip->loopStartBeats = 0.0;
-        clip->loopLengthBeats = clip->audio().interpretation.totalBeats;
-        clip->loopStart = 0.0;
-        clip->loopLength = 5.0;
-        clip->setPlacementBeats(0.0, clip->audio().interpretation.totalBeats);
+        primaryEventOf(clip)->interpBpm = 172.0;
+        primaryEventOf(clip)->interpTotalBeats = 5.0 * 172.0 / 60.0;
+        primaryEventOf(clip)->setLoopStartBeats(0.0);
+        primaryEventOf(clip)->setLoopLengthBeats(primaryEventOf(clip)->interpTotalBeats);
+        primaryEventOf(clip)->setLoopStartSeconds(0.0);
+        primaryEventOf(clip)->setLoopLengthSeconds(5.0);
+        clip->setPlacementBeats(0.0, primaryEventOf(clip)->interpTotalBeats);
         clip->deriveTimesFromBeats(60.0);
 
         f.clipSync->syncClipToEngine(clipId);
@@ -1760,9 +1778,9 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         if (rightClip == nullptr)
             return;
 
-        expectWithinAbsoluteError(rightClip->loopStartBeats, 0.0, 0.01);
-        expectWithinAbsoluteError(rightClip->loopLengthBeats, 4.0, 0.01);
-        expectWithinAbsoluteError(rightClip->offsetBeats, 4.0, 0.01);
+        expectWithinAbsoluteError(primaryEventOf(rightClip)->loopStartBeats(), 0.0, 0.01);
+        expectWithinAbsoluteError(primaryEventOf(rightClip)->loopLengthBeats(), 4.0, 0.01);
+        expectWithinAbsoluteError(primaryEventOf(rightClip)->anchorBeats(), 4.0, 0.01);
 
         f.clipSync->syncClipToEngine(clipId);
         f.clipSync->syncClipToEngine(rightClipId);
@@ -1798,9 +1816,9 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         configureBeatModeLoop(*clip, 60.0, 172.0, 5.0, 0.0, 5.0 * 172.0 / 60.0, 5.0 * 172.0 / 60.0);
         f.clipSync->syncClipToEngine(clipId);
 
-        const double originalOffsetBeats = clip->offsetBeats;
-        const double originalLoopStartBeats = clip->loopStartBeats;
-        const double originalLoopLengthBeats = clip->loopLengthBeats;
+        const double originalOffsetBeats = primaryEventOf(clip)->anchorBeats();
+        const double originalLoopStartBeats = primaryEventOf(clip)->loopStartBeats();
+        const double originalLoopLengthBeats = primaryEventOf(clip)->loopLengthBeats();
 
         const double duplicateStart = clip->getTimelineEnd(60.0);
         auto duplicateId = cm.duplicateClipAt(clipId, duplicateStart, f.trackId, 60.0);
@@ -1812,13 +1830,17 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
 
         // Source-domain phase is preserved verbatim — duplicating must not
         // change which audio plays. Compare in the source domain only.
-        expectWithinAbsoluteError(duplicate->offsetBeats, originalOffsetBeats, 0.01);
-        expectWithinAbsoluteError(duplicate->loopStartBeats, originalLoopStartBeats, 0.01);
-        expectWithinAbsoluteError(duplicate->loopLengthBeats, originalLoopLengthBeats, 0.01);
+        expectWithinAbsoluteError(primaryEventOf(duplicate)->anchorBeats(), originalOffsetBeats,
+                                  0.01);
+        expectWithinAbsoluteError(primaryEventOf(duplicate)->loopStartBeats(),
+                                  originalLoopStartBeats, 0.01);
+        expectWithinAbsoluteError(primaryEventOf(duplicate)->loopLengthBeats(),
+                                  originalLoopLengthBeats, 0.01);
         // Loop phase modulo the loop length: another way to express "same audio plays".
         expectWithinAbsoluteError(
-            wrapPhase(duplicate->offsetBeats - duplicate->loopStartBeats,
-                      duplicate->loopLengthBeats),
+            wrapPhase(primaryEventOf(duplicate)->anchorBeats() -
+                          primaryEventOf(duplicate)->loopStartBeats(),
+                      primaryEventOf(duplicate)->loopLengthBeats()),
             wrapPhase(originalOffsetBeats - originalLoopStartBeats, originalLoopLengthBeats), 0.01);
 
         // Timeline placement moved to duplicateStart (separate domain — independent of phase).
@@ -1852,9 +1874,9 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         if (rightClip == nullptr)
             return;
 
-        const double srcOffsetBeats = rightClip->offsetBeats;
-        const double srcLoopStartBeats = rightClip->loopStartBeats;
-        const double srcLoopLengthBeats = rightClip->loopLengthBeats;
+        const double srcOffsetBeats = primaryEventOf(rightClip)->anchorBeats();
+        const double srcLoopStartBeats = primaryEventOf(rightClip)->loopStartBeats();
+        const double srcLoopLengthBeats = primaryEventOf(rightClip)->loopLengthBeats();
 
         std::unordered_set<ClipId> copiedIds{rightClipId};
         cm.copyToClipboard(copiedIds);
@@ -1872,12 +1894,15 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
 
         // Source-domain phase carries over verbatim — paste must not change which
         // audio plays.
-        expectWithinAbsoluteError(pastedClip->offsetBeats, srcOffsetBeats, 0.01);
-        expectWithinAbsoluteError(pastedClip->loopStartBeats, srcLoopStartBeats, 0.01);
-        expectWithinAbsoluteError(pastedClip->loopLengthBeats, srcLoopLengthBeats, 0.01);
+        expectWithinAbsoluteError(primaryEventOf(pastedClip)->anchorBeats(), srcOffsetBeats, 0.01);
+        expectWithinAbsoluteError(primaryEventOf(pastedClip)->loopStartBeats(), srcLoopStartBeats,
+                                  0.01);
+        expectWithinAbsoluteError(primaryEventOf(pastedClip)->loopLengthBeats(), srcLoopLengthBeats,
+                                  0.01);
         // Phase within loop — same modulo invariant.
-        expectWithinAbsoluteError(wrapPhase(pastedClip->offsetBeats - pastedClip->loopStartBeats,
-                                            pastedClip->loopLengthBeats),
+        expectWithinAbsoluteError(wrapPhase(primaryEventOf(pastedClip)->anchorBeats() -
+                                                primaryEventOf(pastedClip)->loopStartBeats(),
+                                            primaryEventOf(pastedClip)->loopLengthBeats()),
                                   wrapPhase(srcOffsetBeats - srcLoopStartBeats, srcLoopLengthBeats),
                                   0.01);
 
@@ -1889,7 +1914,8 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         if (pastedTeClip != nullptr) {
             // TE's getOffset is clip-relative seconds derived from
             // (offsetBeats - loopStartBeats) × 60 / projectBpm.
-            const double expectedTeOffset = pastedClip->getTeOffset(true, 60.0);
+            const double expectedTeOffset =
+                magda::audioEventRef(*pastedClip).engineOffsetSeconds(true, 60.0);
             expectWithinAbsoluteError(pastedTeClip->getPosition().getOffset().inSeconds(),
                                       expectedTeOffset, 0.01);
             // Sanity: TE clip's edit start matches the paste timeline position.
@@ -1915,12 +1941,12 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
             return;
 
         // Source: 120 BPM, loop region beats [2, 6) of source (loopStart=2,
-        // loopLength=4). Placement: 0..12 beats at projectBpm=60. clip.offsetBeats
-        // = loopStartBeats = 2 (configureBeatModeLoop).
+        // loopLength=4). Placement: 0..12 beats at projectBpm=60.
+        // magda::test::audioEvent(clip).anchorBeats() = loopStartBeats = 2 (configureBeatModeLoop).
         configureBeatModeLoop(*clip, 60.0, 120.0, 5.0, 2.0, 4.0, 12.0);
-        const double clipLoopStartBeats = clip->loopStartBeats;
-        const double clipLoopLengthBeats = clip->loopLengthBeats;
-        const double clipOffsetBeats = clip->offsetBeats;
+        const double clipLoopStartBeats = primaryEventOf(clip)->loopStartBeats();
+        const double clipLoopLengthBeats = primaryEventOf(clip)->loopLengthBeats();
+        const double clipOffsetBeats = primaryEventOf(clip)->anchorBeats();
 
         // Time-range copy: trim from 5.5s..7.5s within the original timeline.
         // copyTimeRangeToClipboard moves trimmed.offsetBeats forward by
@@ -1942,23 +1968,28 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
             return;
 
         // Loop region in source-domain unchanged by trimming or pasting.
-        expectWithinAbsoluteError(pastedClip->loopStartBeats, clipLoopStartBeats, 0.01);
-        expectWithinAbsoluteError(pastedClip->loopLengthBeats, clipLoopLengthBeats, 0.01);
+        expectWithinAbsoluteError(primaryEventOf(pastedClip)->loopStartBeats(), clipLoopStartBeats,
+                                  0.01);
+        expectWithinAbsoluteError(primaryEventOf(pastedClip)->loopLengthBeats(),
+                                  clipLoopLengthBeats, 0.01);
 
         // offsetBeats advanced by the trim distance, then preserved verbatim
         // by paste. (The paste's timeline position is irrelevant to source phase.)
         const double expectedOffsetBeats = clipOffsetBeats + (kRangeStart - 0.0);  // = 7.5
-        expectWithinAbsoluteError(pastedClip->offsetBeats, expectedOffsetBeats, 0.01);
+        expectWithinAbsoluteError(primaryEventOf(pastedClip)->anchorBeats(), expectedOffsetBeats,
+                                  0.01);
 
         // TE offset is clip-relative seconds: (offsetBeats - loopStartBeats) × 60 / projectBpm.
         const double expectedTeOffset =
             (expectedOffsetBeats - clipLoopStartBeats) * 60.0 / 60.0;  // = 5.5
-        expectWithinAbsoluteError(pastedClip->getTeOffset(true, 60.0), expectedTeOffset, 0.01);
+        expectWithinAbsoluteError(magda::audioEventRef(*pastedClip).engineOffsetSeconds(true, 60.0),
+                                  expectedTeOffset, 0.01);
 
         // Phase modulo loop length is what determines audible content alignment.
         expectWithinAbsoluteError(
-            wrapPhase(pastedClip->offsetBeats - pastedClip->loopStartBeats,
-                      pastedClip->loopLengthBeats),
+            wrapPhase(primaryEventOf(pastedClip)->anchorBeats() -
+                          primaryEventOf(pastedClip)->loopStartBeats(),
+                      primaryEventOf(pastedClip)->loopLengthBeats()),
             wrapPhase(expectedOffsetBeats - clipLoopStartBeats, clipLoopLengthBeats), 0.01);
 
         f.clipSync->syncClipToEngine(pastedId);

--- a/tests/test_clip_sync_integration_juce.cpp
+++ b/tests/test_clip_sync_integration_juce.cpp
@@ -155,6 +155,7 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         testCreateMidiClipPreservesExistingNeighbour();
         testMidiSyncClipsNotesToVisibleRangeAfterResize();
         testMidiSyncSkipsAllRestPitchBendButKeepsRealCurves();
+        testLoopedMidiClipReachesEngineWithItsLoopRange();
         testMoveClipNoOverlapDoesNotMutateNeighbours();
         testMoveClipToTrackResolvesOverlapOnDestination();
     }
@@ -2330,6 +2331,43 @@ class ClipSyncIntegrationTest final : public juce::UnitTest {
         expectWithinAbsoluteError(s->placement.lengthBeats, 8.0, 0.01);
         expectWithinAbsoluteError(i->placement.startBeat, 8.0, 0.01);
         expectWithinAbsoluteError(i->placement.lengthBeats, 8.0, 0.01);
+    }
+
+    void testLoopedMidiClipReachesEngineWithItsLoopRange() {
+        beginTest("A looped MIDI clip reaches the engine with its loop range");
+
+        // The loop of a MIDI clip is clip beats on the container. When the
+        // audio source region moved onto AudioEvent (#1901), this read moved
+        // with it, and a MIDI clip has no event: the length came back zero,
+        // the branch never ran and TE was told to loop nothing. Playback of
+        // every looped MIDI clip stopped after one pass, with nothing in the
+        // model to show for it.
+        Fixture f;
+        auto& cm = ClipManager::getInstance();
+
+        const auto clipId = cm.createMidiClipBeats(f.trackId, 0.0, 16.0, ClipView::Arrangement);
+        auto* clip = cm.getClip(clipId);
+        expect(clip != nullptr, "MIDI clip should exist");
+        if (clip == nullptr)
+            return;
+
+        expect(cm.addMidiNote(clipId, {60, 100, 0.0, 1.0}), "Note should be added");
+        cm.setClipLoopEnabled(clipId, true);
+        cm.setMidiLoopLengthBeats(clipId, 4.0);
+        f.clipSync->syncClipToEngine(clipId);
+
+        auto* teMidiClip = f.getTeMidiClip(clipId);
+        expect(teMidiClip != nullptr, "Tracktion MIDI clip should exist after sync");
+        if (teMidiClip == nullptr)
+            return;
+
+        expect(teMidiClip->isLooping(), "A looped MIDI clip must loop in the engine");
+        expectWithinAbsoluteError(teMidiClip->getLoopLengthBeats().inBeats(), 4.0, 0.01);
+
+        // And the toggle still turns it off.
+        cm.setClipLoopEnabled(clipId, false);
+        f.clipSync->syncClipToEngine(clipId);
+        expect(!teMidiClip->isLooping(), "Unlooping a MIDI clip must reach the engine too");
     }
 
     void testMidiSyncClipsNotesToVisibleRangeAfterResize() {

--- a/tests/test_looped_waveform_tile.cpp
+++ b/tests/test_looped_waveform_tile.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include "AudioClipTestHelpers.hpp"
 #include "magda/daw/core/ClipDisplayInfo.hpp"
 #include "magda/daw/core/ClipInfo.hpp"
 
@@ -80,11 +81,11 @@ TEST_CASE("ClipDisplayInfo - looped source file ranges", "[clip][display][loop]"
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 4.0;
-        clip.offset = 1.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(1.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = false;
-        clip.loopStart = 0.0;
-        clip.loopLength = 0.0;
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(0.0);
 
         syncPlacement(clip);
         auto di = ClipDisplayInfo::from(clip, 120.0);  // fileDuration=0 → fallback
@@ -99,11 +100,12 @@ TEST_CASE("ClipDisplayInfo - looped source file ranges", "[clip][display][loop]"
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 8.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = true;
-        clip.loopStart = 0.5;
-        clip.loopLength = 2.0;
-        clip.offset = clip.loopStart;
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.5);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(2.0);
+        magda::test::audioEvent(clip).setAnchorSeconds(
+            magda::test::audioEvent(clip).loopStartSeconds());
 
         syncPlacement(clip);
         auto di = ClipDisplayInfo::from(clip, 120.0, /*fileDuration=*/4.0);
@@ -127,11 +129,12 @@ TEST_CASE("ClipDisplayInfo - looped source file ranges", "[clip][display][loop]"
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 16.0;
-        clip.speedRatio = 2.0;  // 2x faster
+        magda::test::audioEvent(clip).speedRatio = 2.0;  // 2x faster
         clip.loopEnabled = true;
-        clip.loopStart = 1.0;
-        clip.loopLength = 1.0;
-        clip.offset = clip.loopStart;
+        magda::test::audioEvent(clip).setLoopStartSeconds(1.0);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(1.0);
+        magda::test::audioEvent(clip).setAnchorSeconds(
+            magda::test::audioEvent(clip).loopStartSeconds());
 
         syncPlacement(clip);
         auto di = ClipDisplayInfo::from(clip, 120.0, /*fileDuration=*/3.0);
@@ -155,11 +158,11 @@ TEST_CASE("ClipDisplayInfo - looped source file ranges", "[clip][display][loop]"
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 1.0;
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = true;
-        clip.loopStart = 0.0;
-        clip.loopLength = 0.0;
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(0.0);
 
         syncPlacement(clip);
         auto di = ClipDisplayInfo::from(clip, 120.0, /*fileDuration=*/1.0);
@@ -174,11 +177,12 @@ TEST_CASE("ClipDisplayInfo - looped source file ranges", "[clip][display][loop]"
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 1.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = true;
-        clip.loopStart = 0.5;
-        clip.loopLength = 2.0;
-        clip.offset = clip.loopStart;
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.5);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(2.0);
+        magda::test::audioEvent(clip).setAnchorSeconds(
+            magda::test::audioEvent(clip).loopStartSeconds());
 
         syncPlacement(clip);
         auto di = ClipDisplayInfo::from(clip, 120.0, /*fileDuration=*/4.0);
@@ -194,11 +198,11 @@ TEST_CASE("ClipDisplayInfo - looped source file ranges", "[clip][display][loop]"
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 2.0;
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = true;
-        clip.loopStart = 0.0;
-        clip.loopLength = 2.0;
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(2.0);
 
         syncPlacement(clip);
         auto di = ClipDisplayInfo::from(clip, 120.0, /*fileDuration=*/2.0);
@@ -218,11 +222,11 @@ TEST_CASE("ClipDisplayInfo - looped source file ranges", "[clip][display][loop]"
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 6.0;
-        clip.offset = 0.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(0.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = true;
-        clip.loopStart = 0.0;
-        clip.loopLength = 2.0;
+        magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(2.0);
 
         syncPlacement(clip);
         auto di = ClipDisplayInfo::from(clip, 120.0, /*fileDuration=*/4.0);
@@ -243,8 +247,8 @@ TEST_CASE("ClipDisplayInfo maps session playhead into waveform editor display ti
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 8.0;
-        clip.offset = 1.5;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(1.5);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = false;
 
         syncPlacement(clip);
@@ -260,11 +264,11 @@ TEST_CASE("ClipDisplayInfo maps session playhead into waveform editor display ti
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 12.0;
-        clip.offset = 1.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(1.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = true;
-        clip.loopStart = 1.0;
-        clip.loopLength = 4.0;
+        magda::test::audioEvent(clip).setLoopStartSeconds(1.0);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(4.0);
 
         syncPlacement(clip);
         const auto di = ClipDisplayInfo::from(clip, 120.0);
@@ -280,11 +284,11 @@ TEST_CASE("ClipDisplayInfo maps session playhead into waveform editor display ti
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 12.0;
-        clip.offset = 2.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(2.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = true;
-        clip.loopStart = 1.0;
-        clip.loopLength = 4.0;
+        magda::test::audioEvent(clip).setLoopStartSeconds(1.0);
+        magda::test::audioEvent(clip).setLoopLengthSeconds(4.0);
 
         syncPlacement(clip);
         const auto di = ClipDisplayInfo::from(clip, 120.0);
@@ -298,48 +302,55 @@ TEST_CASE("ClipDisplayInfo maps session playhead into waveform editor display ti
     SECTION("Auto-tempo source BPM maps session playhead in display-time seconds") {
         ClipInfo clip;
         clip.setAudioContent();
-        clip.autoTempo = true;
+        magda::test::audioEvent(clip).autoTempo = true;
         clip.startTime = 0.0;
         clip.length = 8.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = true;
-        clip.audio().interpretation.bpm = 172.0;
-        clip.audio().interpretation.totalBeats = 16.0;
-        clip.audio().source.durationSeconds = 16.0 * 60.0 / 172.0;
+        magda::test::audioEvent(clip).interpBpm = 172.0;
+        magda::test::audioEvent(clip).interpTotalBeats = 16.0;
+        magda::test::setSourceDuration(clip, 16.0 * 60.0 / 172.0);
         clip.setPlacementBeats(0.0, 16.0);
-        clip.loopStartBeats = 0.0;
-        clip.loopLengthBeats = 16.0;
-        clip.offsetBeats = 4.0;
+        magda::test::audioEvent(clip).setLoopStartBeats(0.0);
+        magda::test::audioEvent(clip).setLoopLengthBeats(16.0);
+        magda::test::audioEvent(clip).setAnchorBeats(4.0);
 
-        const auto di = ClipDisplayInfo::from(clip, 120.0, clip.audio().source.durationSeconds);
+        const auto di = ClipDisplayInfo::from(
+            clip, 120.0, magda::test::audioEvent(clip).sourceDurationSeconds());
 
         REQUIRE(di.loopLengthSeconds == Catch::Approx(8.0));
         REQUIRE(di.sessionPlayheadToDisplayPosition(0.0) == Catch::Approx(2.0));
         REQUIRE(di.sessionPlayheadToDisplayPosition(1.0) == Catch::Approx(3.0));
-        REQUIRE(di.sessionPlayheadToDisplayPosition(6.0) == Catch::Approx(0.0));
+        // The anchor is stored in source samples (#1901), so a wrap that
+        // lands on the loop start is exact to a fraction of a sample.
+        REQUIRE(di.sessionPlayheadToDisplayPosition(6.0) == Catch::Approx(0.0).margin(1.0e-4));
         REQUIRE(di.sessionPlayheadToDisplayPosition(8.5) == Catch::Approx(2.5));
     }
 
-    SECTION("Auto-tempo playhead mapping ignores stale source seconds caches") {
+    SECTION("Auto-tempo playhead mapping derives from the single source region") {
         ClipInfo clip;
         clip.setAudioContent();
-        clip.autoTempo = true;
+        magda::test::audioEvent(clip).autoTempo = true;
         clip.startTime = 99.0;  // stale cache; placement is authoritative
         clip.length = 99.0;     // stale cache; placement is authoritative
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = true;
-        clip.audio().interpretation.bpm = 172.0;
-        clip.audio().interpretation.totalBeats = 16.0;
-        clip.audio().source.durationSeconds = 16.0 * 60.0 / 172.0;
+        magda::test::audioEvent(clip).interpBpm = 172.0;
+        magda::test::audioEvent(clip).interpTotalBeats = 16.0;
+        magda::test::setSourceDuration(clip, 16.0 * 60.0 / 172.0);
         clip.setPlacementBeats(0.0, 16.0);
-        clip.loopStart = 99.0;   // stale cache; loopStartBeats is authoritative
-        clip.loopLength = 99.0;  // stale cache; loopLengthBeats is authoritative
-        clip.offset = 99.0;      // stale cache; offsetBeats is authoritative
-        clip.loopStartBeats = 4.0;
-        clip.loopLengthBeats = 8.0;
-        clip.offsetBeats = 6.0;
+        magda::test::audioEvent(clip).setLoopStartSeconds(
+            99.0);  // stale cache; loopStartBeats is authoritative
+        magda::test::audioEvent(clip).setLoopLengthSeconds(
+            99.0);  // stale cache; loopLengthBeats is authoritative
+        magda::test::audioEvent(clip).setAnchorSeconds(
+            99.0);  // stale cache; offsetBeats is authoritative
+        magda::test::audioEvent(clip).setLoopStartBeats(4.0);
+        magda::test::audioEvent(clip).setLoopLengthBeats(8.0);
+        magda::test::audioEvent(clip).setAnchorBeats(6.0);
 
-        const auto di = ClipDisplayInfo::from(clip, 120.0, clip.audio().source.durationSeconds);
+        const auto di = ClipDisplayInfo::from(
+            clip, 120.0, magda::test::audioEvent(clip).sourceDurationSeconds());
 
         REQUIRE(di.loopStartPositionSeconds == Catch::Approx(2.0));
         REQUIRE(di.loopLengthSeconds == Catch::Approx(4.0));
@@ -352,21 +363,23 @@ TEST_CASE("ClipDisplayInfo maps session playhead into waveform editor display ti
     SECTION("Auto-tempo display source conversion follows source BPM after Beats edit") {
         ClipInfo clip;
         clip.setAudioContent();
-        clip.autoTempo = true;
+        magda::test::audioEvent(clip).autoTempo = true;
         clip.loopEnabled = true;
-        clip.speedRatio = 1.0;
-        clip.audio().interpretation.bpm = 129.0;
-        clip.audio().interpretation.totalBeats = 12.0;
-        clip.audio().source.durationSeconds = 12.0 * 60.0 / 129.0;
+        magda::test::audioEvent(clip).speedRatio = 1.0;
+        magda::test::audioEvent(clip).interpBpm = 129.0;
+        magda::test::audioEvent(clip).interpTotalBeats = 12.0;
+        magda::test::setSourceDuration(clip, 12.0 * 60.0 / 129.0);
         clip.setPlacementBeats(0.0, 12.0);
-        clip.loopStartBeats = 0.0;
-        clip.loopLengthBeats = 12.0;
-        clip.offsetBeats = 3.0;
-        clip.loopStart = 99.0;
-        clip.loopLength = 99.0;
-        clip.offset = 99.0;
+        magda::test::audioEvent(clip).setLoopStartBeats(0.0);
+        magda::test::audioEvent(clip).setLoopLengthBeats(12.0);
+        magda::test::audioEvent(clip).setAnchorBeats(3.0);
+        // #1157 poisoned separate seconds caches here to prove the display did
+        // not read them. Since #1901 the source region has one representation
+        // (samples) with seconds and beats as views on it, so there is no
+        // cache left to go stale.
 
-        const auto di = ClipDisplayInfo::from(clip, 120.0, clip.audio().source.durationSeconds);
+        const auto di = ClipDisplayInfo::from(
+            clip, 120.0, magda::test::audioEvent(clip).sourceDurationSeconds());
 
         REQUIRE(di.fileExtentTimeline() == Catch::Approx(6.0));
         REQUIRE(di.loopLengthSeconds == Catch::Approx(6.0));
@@ -384,10 +397,10 @@ TEST_CASE("ClipDisplayInfo keeps a reversed selection on the original source rul
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 2.0;
-        clip.offset = 2.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(2.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = false;
-        clip.isReversed = true;
+        magda::test::audioEvent(clip).reversed = true;
 
         syncPlacement(clip);
         const auto di = ClipDisplayInfo::from(clip, 120.0, 10.0);
@@ -411,10 +424,10 @@ TEST_CASE("ClipDisplayInfo keeps a reversed selection on the original source rul
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 2.0;
-        clip.offset = 2.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(2.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = false;
-        clip.isReversed = true;
+        magda::test::audioEvent(clip).reversed = true;
 
         syncPlacement(clip);
         const auto di = ClipDisplayInfo::from(clip, 120.0, 10.0);
@@ -431,10 +444,10 @@ TEST_CASE("ClipDisplayInfo keeps a reversed selection on the original source rul
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 1.0;
-        clip.offset = 2.0;
-        clip.speedRatio = 2.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(2.0);
+        magda::test::audioEvent(clip).speedRatio = 2.0;
         clip.loopEnabled = false;
-        clip.isReversed = true;
+        magda::test::audioEvent(clip).reversed = true;
 
         syncPlacement(clip);
         const auto di = ClipDisplayInfo::from(clip, 120.0, 10.0);
@@ -452,10 +465,10 @@ TEST_CASE("ClipDisplayInfo keeps a reversed selection on the original source rul
         clip.setAudioContent();
         clip.startTime = 0.0;
         clip.length = 2.0;
-        clip.offset = 2.0;
-        clip.speedRatio = 1.0;
+        magda::test::audioEvent(clip).setAnchorSeconds(2.0);
+        magda::test::audioEvent(clip).speedRatio = 1.0;
         clip.loopEnabled = false;
-        clip.isReversed = false;
+        magda::test::audioEvent(clip).reversed = false;
 
         syncPlacement(clip);
         const auto di = ClipDisplayInfo::from(clip, 120.0, 10.0);

--- a/tests/test_midi_clip_resize_left.cpp
+++ b/tests/test_midi_clip_resize_left.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include "AudioClipTestHelpers.hpp"
 #include "magda/daw/core/ClipInfo.hpp"
 #include "magda/daw/core/ClipOperations.hpp"
 
@@ -28,8 +29,6 @@ static ClipInfo makeMidiClip(double startTime, double length, bool looped = fals
     clip.loopEnabled = looped;
     clip.loopLengthBeats = loopLengthBeats;
     clip.view = ClipView::Arrangement;
-    clip.speedRatio = 1.0;
-    clip.offset = 0.0;
     return clip;
 }
 
@@ -137,29 +136,32 @@ TEST_CASE("MIDI left-resize non-looped - midiOffset stays unchanged even past ti
 }
 
 // ============================================================================
-// Non-looped MIDI: clip.offset must NOT be touched
+// Resizing a MIDI clip must not give it audio state
 // ============================================================================
 
-TEST_CASE("MIDI left-resize non-looped - clip.offset unchanged",
+TEST_CASE("MIDI left-resize non-looped - no audio source state appears",
           "[midi][resize][left][nonlooped][offset]") {
     double bpm = 120.0;
 
-    SECTION("Shrink does not modify clip.offset") {
+    // Since #1901 a MIDI clip has no audio event at all, so "the source read
+    // position is untouched" is checked structurally: the resize must not turn
+    // the clip into something carrying a source anchor.
+    SECTION("Shrink leaves the clip pure MIDI") {
         ClipInfo clip = makeMidiClip(0.0, 4.0);
-        clip.offset = 0.0;
 
         ClipOperations::resizeContainerFromLeft(clip, 3.0, bpm);
 
-        REQUIRE(clip.offset == 0.0);
+        REQUIRE(clip.isMidi());
+        REQUIRE(clip.primaryEvent() == nullptr);
     }
 
-    SECTION("Expand does not modify clip.offset") {
+    SECTION("Expand leaves the clip pure MIDI") {
         ClipInfo clip = makeMidiClip(2.0, 4.0);
-        clip.offset = 1.5;  // Some pre-existing value
 
         ClipOperations::resizeContainerFromLeft(clip, 6.0, bpm);
 
-        REQUIRE(clip.offset == 1.5);
+        REQUIRE(clip.isMidi());
+        REQUIRE(clip.primaryEvent() == nullptr);
     }
 }
 
@@ -225,16 +227,16 @@ TEST_CASE("MIDI left-resize looped - midiOffset wraps within loop",
     }
 }
 
-TEST_CASE("MIDI left-resize looped - clip.offset unchanged",
+TEST_CASE("MIDI left-resize looped - no audio source state appears",
           "[midi][resize][left][looped][offset]") {
     double bpm = 120.0;
 
     ClipInfo clip = makeMidiClip(0.0, 8.0, true, 4.0);
-    clip.offset = 0.0;
 
     ClipOperations::resizeContainerFromLeft(clip, 6.0, bpm);
 
-    REQUIRE(clip.offset == 0.0);
+    REQUIRE(clip.isMidi());
+    REQUIRE(clip.primaryEvent() == nullptr);
 }
 
 // ============================================================================

--- a/tests/test_project_document_adapters.cpp
+++ b/tests/test_project_document_adapters.cpp
@@ -5,6 +5,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include "AudioClipTestHelpers.hpp"
 #include "magda/daw/core/AutomationManager.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/TrackManager.hpp"
@@ -512,13 +513,13 @@ TEST_CASE("DawProjectArchive embeds and extracts referenced audio files",
     clip.name = "Loop";
     clip.setAudioContent();
     clip.setPlacementBeats(0.0, 4.0);
-    clip.audio().source.filePath = source.getFullPathName();
+    magda::test::giveAudioEvent(clip, source.getFullPathName());
     // Looped region + read offset (exact binary fractions so they round-trip
     // bit-for-bit through the double->string->double path).
-    clip.offset = 0.25;
+    magda::test::audioEvent(clip).setAnchorSeconds(0.25);
     clip.loopEnabled = true;
-    clip.loopStart = 0.5;
-    clip.loopLength = 0.25;
+    magda::test::audioEvent(clip).setLoopStartSeconds(0.5);
+    magda::test::audioEvent(clip).setLoopLengthSeconds(0.25);
     document.clips.push_back(clip);
 
     auto archive = createTempDawProjectFile();
@@ -551,7 +552,7 @@ TEST_CASE("DawProjectArchive embeds and extracts referenced audio files",
     REQUIRE(DawProjectArchive::readFromFile(archive, imported, error, extractionDir));
     REQUIRE(imported.clips.size() == 1);
     REQUIRE(imported.clips[0].isAudio());
-    const juce::File extracted(imported.clips[0].audio().source.filePath);
+    const juce::File extracted(magda::audioEventRef(imported.clips[0]).sourceFilePath());
     REQUIRE(extracted.existsAsFile());
     REQUIRE(extracted.getSize() == source.getSize());
 
@@ -563,10 +564,11 @@ TEST_CASE("DawProjectArchive embeds and extracts referenced audio files",
     REQUIRE(static_cast<int>(reader->numChannels) == kChannels);
 
     // Loop region and read offset survive the round-trip.
-    REQUIRE(imported.clips[0].offset == 0.25);
+    const auto& importedEvent = magda::audioEventRef(imported.clips[0]);
+    REQUIRE(importedEvent.anchorSeconds() == Catch::Approx(0.25));
     REQUIRE(imported.clips[0].loopEnabled);
-    REQUIRE(imported.clips[0].loopStart == 0.5);
-    REQUIRE(imported.clips[0].loopLength == 0.25);
+    REQUIRE(importedEvent.loopStartSeconds() == Catch::Approx(0.5));
+    REQUIRE(importedEvent.loopLengthSeconds() == Catch::Approx(0.25));
 
     source.deleteFile();
     archive.deleteFile();
@@ -590,14 +592,17 @@ TEST_CASE("DawProjectXmlAdapter warps beat-locked (autoTempo) audio clips",
     clip.trackId = track.id;
     clip.name = "Warped";
     clip.setAudioContent();
-    clip.setPlacementBeats(0.0, 16.0);                       // a 4-beat loop across 16 beats
-    clip.audio().source.filePath = "/nonexistent/beat.wav";  // not embedded; XML-level test
-    clip.audio().source.durationSeconds = 2.0;
-    clip.audio().interpretation.totalBeats = 4.0;  // source is 4 beats long -> 120 bpm
-    clip.autoTempo = true;
+    clip.setPlacementBeats(0.0, 16.0);                           // a 4-beat loop across 16 beats
+    magda::test::giveAudioEvent(clip, "/nonexistent/beat.wav");  // not embedded; XML-level test
+    magda::test::setSourceDuration(clip, 2.0);
+    magda::test::audioEvent(clip).interpTotalBeats = 4.0;  // source is 4 beats long ...
+    magda::test::audioEvent(clip).interpBpm = 120.0;       // ... at 120 bpm.
+    // The BPM is what makes the source loop expressible in beats at all: the
+    // region is stored in source samples and beats are a view on it (#1901).
+    magda::test::audioEvent(clip).autoTempo = true;
     clip.loopEnabled = true;
-    clip.loopStartBeats = 0.0;
-    clip.loopLengthBeats = 4.0;
+    magda::test::audioEvent(clip).setLoopStartBeats(0.0);
+    magda::test::audioEvent(clip).setLoopLengthBeats(4.0);
     document.clips.push_back(clip);
 
     auto xml = DawProjectXmlAdapter::toProjectXml(document);
@@ -619,12 +624,12 @@ TEST_CASE("DawProjectXmlAdapter warps beat-locked (autoTempo) audio clips",
     REQUIRE(imported.clips.size() == 1);
     const auto& ic = imported.clips[0];
     REQUIRE(ic.isAudio());
-    REQUIRE(ic.autoTempo);
+    REQUIRE(magda::audioEventRef(ic).autoTempo);
     REQUIRE(ic.loopEnabled);
-    REQUIRE(ic.loopStartBeats == 0.0);
-    REQUIRE(ic.loopLengthBeats == 4.0);
-    REQUIRE(ic.audio().interpretation.totalBeats == 4.0);
-    REQUIRE(ic.audio().source.durationSeconds == 2.0);
+    REQUIRE(magda::audioEventRef(ic).loopStartBeats() == 0.0);
+    REQUIRE(magda::audioEventRef(ic).loopLengthBeats() == 4.0);
+    REQUIRE(magda::audioEventRef(ic).interpTotalBeats == 4.0);
+    REQUIRE(magda::audioEventRef(ic).sourceDurationSeconds() == 2.0);
 }
 
 TEST_CASE("DawProjectArchive embeds and restores VST3 device state",

--- a/tests/test_project_serialization.cpp
+++ b/tests/test_project_serialization.cpp
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <filesystem>
 
+#include "AudioClipTestHelpers.hpp"
 #include "magda/daw/core/AppPaths.hpp"
 #include "magda/daw/core/AutomationManager.hpp"
 #include "magda/daw/core/ClipManager.hpp"
@@ -554,7 +555,8 @@ TEST_CASE("Project Serialization Basics", "[project][serialization]") {
         REQUIRE(ProjectSerializer::loadAndStage(actualFile, staged));
         REQUIRE(staged.clips.size() == 1);
         REQUIRE(staged.clips[0].isAudio());
-        REQUIRE(staged.clips[0].audio().source.filePath == expectedFile.getFullPathName());
+        REQUIRE(magda::audioEventRef(staged.clips[0]).sourceFilePath() ==
+                expectedFile.getFullPathName());
         REQUIRE(expectedFile.existsAsFile());
     }
 
@@ -600,16 +602,16 @@ TEST_CASE("Audio clip serialization separates source facts from interpretation",
     clip.name = "Loop";
     clip.setAudioContent();
     clip.setPlacementBeats(4.0, 16.0);
-    clip.audio().source.filePath = "/tmp/loop.wav";
-    clip.audio().source.durationSeconds = 2.7907;
-    clip.audio().interpretation.bpm = 172.0;
-    clip.audio().interpretation.totalBeats = 8.0;
-    clip.audio().interpretation.totalBeatsLocked = true;
-    clip.autoTempo = true;
+    magda::test::giveAudioEvent(clip, "/tmp/loop.wav");
+    magda::test::setSourceDuration(clip, 2.7907);
+    magda::test::audioEvent(clip).interpBpm = 172.0;
+    magda::test::audioEvent(clip).interpTotalBeats = 8.0;
+    magda::test::audioEvent(clip).interpTotalBeatsLocked = true;
+    magda::test::audioEvent(clip).autoTempo = true;
     clip.loopEnabled = true;
-    clip.loopStartBeats = 0.0;
-    clip.loopLengthBeats = 8.0;
-    clip.loopLength = 8.0 * 60.0 / 172.0;
+    magda::test::audioEvent(clip).setLoopStartBeats(0.0);
+    magda::test::audioEvent(clip).setLoopLengthBeats(8.0);
+    magda::test::audioEvent(clip).setLoopLengthSeconds(8.0 * 60.0 / 172.0);
     ClipManager::getInstance().restoreClip(clip);
 
     ProjectInfo info;
@@ -628,20 +630,42 @@ TEST_CASE("Audio clip serialization separates source facts from interpretation",
     REQUIRE(clipObj != nullptr);
     REQUIRE(clipObj->getProperty("audioSource").isVoid());
 
+    // Schema v2 (#1901): the clip holds events, the sources live once per
+    // project, and the clip no longer carries source/interpretation/playback.
+    REQUIRE(static_cast<int>(rootObj->getProperty("schemaVersion")) == kProjectSchemaVersion);
+
+    auto* sources = rootObj->getProperty("sources").getArray();
+    REQUIRE(sources != nullptr);
+    REQUIRE(sources->size() == 1);
+    auto* sourceObj = sources->getReference(0).getDynamicObject();
+    REQUIRE(sourceObj != nullptr);
+    REQUIRE(sourceObj->getProperty("filePath").toString() == "/tmp/loop.wav");
+    REQUIRE(static_cast<double>(sourceObj->getProperty("durationSeconds")) == Approx(2.7907));
+
     auto* audioObj = clipObj->getProperty("audio").getDynamicObject();
     REQUIRE(audioObj != nullptr);
-    auto* sourceObj = audioObj->getProperty("source").getDynamicObject();
-    auto* interpretationObj = audioObj->getProperty("interpretation").getDynamicObject();
-    auto* playbackObj = audioObj->getProperty("playback").getDynamicObject();
-    REQUIRE(sourceObj != nullptr);
-    REQUIRE(interpretationObj != nullptr);
-    REQUIRE(playbackObj != nullptr);
+    REQUIRE(audioObj->getProperty("source").isVoid());
+    REQUIRE(audioObj->getProperty("interpretation").isVoid());
+    REQUIRE(audioObj->getProperty("playback").isVoid());
+
+    auto* events = audioObj->getProperty("events").getArray();
+    REQUIRE(events != nullptr);
+    REQUIRE(events->size() == 1);
+    auto* eventObj = events->getReference(0).getDynamicObject();
+    REQUIRE(eventObj != nullptr);
+    REQUIRE(static_cast<int>(eventObj->getProperty("sourceId")) ==
+            static_cast<int>(sourceObj->getProperty("id")));
+    REQUIRE(static_cast<double>(eventObj->getProperty("interpTotalBeats")) == Approx(8.0));
+    REQUIRE(static_cast<bool>(eventObj->getProperty("interpTotalBeatsLocked")));
+    // The loop toggle is a clip property and did not move onto the event.
+    REQUIRE(static_cast<bool>(clipObj->getProperty("loopEnabled")));
+
+    // The event spans its clip: container and content are the same extent.
+    REQUIRE(static_cast<double>(eventObj->getProperty("startBeat")) == Approx(0.0));
+    REQUIRE(static_cast<double>(eventObj->getProperty("lengthBeats")) == Approx(16.0));
+
     auto* placementObj = clipObj->getProperty("placement").getDynamicObject();
     REQUIRE(placementObj != nullptr);
-    REQUIRE(static_cast<double>(sourceObj->getProperty("durationSeconds")) == Approx(2.7907));
-    REQUIRE(static_cast<double>(interpretationObj->getProperty("totalBeats")) == Approx(8.0));
-    REQUIRE(static_cast<bool>(interpretationObj->getProperty("totalBeatsLocked")));
-    REQUIRE(static_cast<double>(playbackObj->getProperty("loopLengthBeats")) == Approx(8.0));
     REQUIRE(static_cast<double>(placementObj->getProperty("lengthBeats")) == Approx(16.0));
 
     ProjectInfo loaded;
@@ -650,10 +674,10 @@ TEST_CASE("Audio clip serialization separates source facts from interpretation",
     REQUIRE(restored != nullptr);
     REQUIRE(restored->isAudio());
     REQUIRE(restored->placement.lengthBeats == Approx(16.0));
-    REQUIRE(restored->audio().source.durationSeconds == Approx(2.7907));
-    REQUIRE(restored->audio().interpretation.totalBeats == Approx(8.0));
-    REQUIRE(restored->audio().interpretation.totalBeatsLocked);
-    REQUIRE(restored->loopLengthBeats == Approx(8.0));
+    REQUIRE(primaryEventOf(restored)->sourceDurationSeconds() == Approx(2.7907));
+    REQUIRE(primaryEventOf(restored)->interpTotalBeats == Approx(8.0));
+    REQUIRE(primaryEventOf(restored)->interpTotalBeatsLocked);
+    REQUIRE(primaryEventOf(restored)->loopLengthBeats() == Approx(8.0));
 }
 
 TEST_CASE("Session clip follow action settings roundtrip", "[project][serialization][session]") {
@@ -766,7 +790,6 @@ TEST_CASE("Looped MIDI clip serialization preserves loop region separate from pl
     clip.loopEnabled = true;
     clip.setPlacementBeats(0.0, 68.0);  // 17 bars at 4/4
     clip.loopLengthBeats = 8.0;         // 2 bars at 4/4
-    clip.loopLength = 4.0;              // 8 beats at 120 BPM
     clip.midiOffset = 1.0;
 
     MidiNote note;
@@ -806,7 +829,6 @@ TEST_CASE("Looped MIDI clip serialization preserves loop region separate from pl
     REQUIRE(restored->loopEnabled);
     REQUIRE(restored->placement.lengthBeats == Approx(68.0));
     REQUIRE(restored->loopLengthBeats == Approx(8.0));
-    REQUIRE(restored->loopLength == Approx(4.0));
     REQUIRE(restored->midiOffset == Approx(1.0));
     REQUIRE(restored->midi().sourceFilePath == "/tmp/imported-loop.mid");
 }
@@ -875,12 +897,12 @@ TEST_CASE("Saved audio library warp markers survive BPM mismatch re-import",
     REQUIRE(clip != nullptr);
     REQUIRE(clip->isAudio());
 
-    clip->autoTempo = true;
-    clip->audio().interpretation.bpm = 140.0;
-    clip->audio().interpretation.totalBeats = 9.3333333333;
-    clip->audio().interpretation.totalBeatsLocked = true;
-    clip->warpEnabled = true;
-    clip->warpMarkers = {{0.0, 0.0}, {1.234, 1.75}, {3.5, 4.0}};
+    primaryEventOf(clip)->autoTempo = true;
+    primaryEventOf(clip)->interpBpm = 140.0;
+    primaryEventOf(clip)->interpTotalBeats = 9.3333333333;
+    primaryEventOf(clip)->interpTotalBeatsLocked = true;
+    primaryEventOf(clip)->warpEnabled = true;
+    primaryEventOf(clip)->warpMarkers = {{0.0, 0.0}, {1.234, 1.75}, {3.5, 4.0}};
 
     REQUIRE(ClipManager::getInstance().saveClipToLibrary(clipId));
 
@@ -892,14 +914,14 @@ TEST_CASE("Saved audio library warp markers survive BPM mismatch re-import",
     auto* reimported = ClipManager::getInstance().getClip(reimportedId);
     REQUIRE(reimported != nullptr);
     REQUIRE(reimported->isAudio());
-    REQUIRE(reimported->warpEnabled);
-    REQUIRE(reimported->audio().interpretation.bpm == Approx(140.0));
-    REQUIRE(reimported->audio().interpretation.totalBeats == Approx(9.3333333333));
-    REQUIRE(reimported->warpMarkers.size() == 3);
-    REQUIRE(reimported->warpMarkers[1].sourceTime == Approx(1.234));
-    REQUIRE(reimported->warpMarkers[1].warpTime == Approx(1.75));
-    REQUIRE(reimported->warpMarkers[2].sourceTime == Approx(3.5));
-    REQUIRE(reimported->warpMarkers[2].warpTime == Approx(4.0));
+    REQUIRE(primaryEventOf(reimported)->warpEnabled);
+    REQUIRE(primaryEventOf(reimported)->interpBpm == Approx(140.0));
+    REQUIRE(primaryEventOf(reimported)->interpTotalBeats == Approx(9.3333333333));
+    REQUIRE(primaryEventOf(reimported)->warpMarkers.size() == 3);
+    REQUIRE(primaryEventOf(reimported)->warpMarkers[1].sourceTime == Approx(1.234));
+    REQUIRE(primaryEventOf(reimported)->warpMarkers[1].warpTime == Approx(1.75));
+    REQUIRE(primaryEventOf(reimported)->warpMarkers[2].sourceTime == Approx(3.5));
+    REQUIRE(primaryEventOf(reimported)->warpMarkers[2].warpTime == Approx(4.0));
 }
 
 TEST_CASE("MidiFileWriter writes MIDI clip data to a stable destination",
@@ -975,14 +997,14 @@ TEST_CASE("Clip serialization validates type and audio schema", "[project][seria
     clip.name = "Schema";
     clip.setAudioContent();
     clip.setPlacementBeats(0.0, 16.0);
-    clip.audio().source.filePath = "/tmp/schema.wav";
-    clip.audio().source.durationSeconds = 4.0;
-    clip.audio().interpretation.bpm = 120.0;
-    clip.audio().interpretation.totalBeats = 8.0;
-    clip.autoTempo = true;
+    magda::test::giveAudioEvent(clip, "/tmp/schema.wav");
+    magda::test::setSourceDuration(clip, 4.0);
+    magda::test::audioEvent(clip).interpBpm = 120.0;
+    magda::test::audioEvent(clip).interpTotalBeats = 8.0;
+    magda::test::audioEvent(clip).autoTempo = true;
     clip.loopEnabled = true;
-    clip.loopLengthBeats = 8.0;
-    clip.loopLength = 4.0;
+    magda::test::audioEvent(clip).setLoopLengthBeats(8.0);
+    magda::test::audioEvent(clip).setLoopLengthSeconds(4.0);
     ClipManager::getInstance().restoreClip(clip);
 
     ProjectInfo info;
@@ -1062,21 +1084,21 @@ TEST_CASE("Clip serialization validates type and audio schema", "[project][seria
         auto* restored = ClipManager::getInstance().getClip(clip.id);
         REQUIRE(restored != nullptr);
         REQUIRE(restored->isAudio());
-        REQUIRE(restored->audio().source.filePath == "/tmp/legacy.wav");
-        REQUIRE(restored->audio().source.durationSeconds == Approx(4.0));
-        REQUIRE(restored->audio().interpretation.totalBeats == Approx(8.0));
-        REQUIRE(restored->audio().interpretation.bpm == Approx(120.0));
-        REQUIRE(restored->offset == Approx(0.5));
-        REQUIRE(restored->offsetBeats == Approx(1.0));
-        REQUIRE(restored->loopStart == Approx(0.25));
-        REQUIRE(restored->loopLength == Approx(4.0));
-        REQUIRE(restored->loopStartBeats == Approx(0.5));
-        REQUIRE(restored->loopLengthBeats == Approx(8.0));
-        REQUIRE(restored->speedRatio == Approx(1.25));
-        REQUIRE(restored->warpEnabled);
-        REQUIRE(restored->warpMarkers.size() == 1);
-        REQUIRE(restored->warpMarkers.front().sourceTime == Approx(1.0));
-        REQUIRE(restored->warpMarkers.front().warpTime == Approx(1.25));
+        REQUIRE(primaryEventOf(restored)->sourceFilePath() == "/tmp/legacy.wav");
+        REQUIRE(primaryEventOf(restored)->sourceDurationSeconds() == Approx(4.0));
+        REQUIRE(primaryEventOf(restored)->interpTotalBeats == Approx(8.0));
+        REQUIRE(primaryEventOf(restored)->interpBpm == Approx(120.0));
+        REQUIRE(primaryEventOf(restored)->anchorSeconds() == Approx(0.5));
+        REQUIRE(primaryEventOf(restored)->anchorBeats() == Approx(1.0));
+        REQUIRE(primaryEventOf(restored)->loopStartSeconds() == Approx(0.25));
+        REQUIRE(primaryEventOf(restored)->loopLengthSeconds() == Approx(4.0));
+        REQUIRE(primaryEventOf(restored)->loopStartBeats() == Approx(0.5));
+        REQUIRE(primaryEventOf(restored)->loopLengthBeats() == Approx(8.0));
+        REQUIRE(primaryEventOf(restored)->speedRatio == Approx(1.25));
+        REQUIRE(primaryEventOf(restored)->warpEnabled);
+        REQUIRE(primaryEventOf(restored)->warpMarkers.size() == 1);
+        REQUIRE(primaryEventOf(restored)->warpMarkers.front().sourceTime == Approx(1.0));
+        REQUIRE(primaryEventOf(restored)->warpMarkers.front().warpTime == Approx(1.25));
     }
 
     SECTION("Legacy flat audio clip payload migrates placement and audio model") {
@@ -1115,17 +1137,17 @@ TEST_CASE("Clip serialization validates type and audio schema", "[project][seria
         REQUIRE(restored->placement.startBeat == Approx(4.0));
         REQUIRE(restored->placement.lengthBeats == Approx(12.0));
         REQUIRE(restored->length == Approx(6.0));
-        REQUIRE(restored->audio().source.filePath == "/tmp/flat-legacy.wav");
-        REQUIRE(restored->audio().source.durationSeconds == Approx(6.0));
-        REQUIRE(restored->audio().interpretation.totalBeats == Approx(12.0));
-        REQUIRE(restored->audio().interpretation.bpm == Approx(120.0));
-        REQUIRE(restored->offset == Approx(0.25));
-        REQUIRE(restored->offsetBeats == Approx(0.5));
-        REQUIRE(restored->loopStart == Approx(0.125));
-        REQUIRE(restored->loopLength == Approx(6.0));
-        REQUIRE(restored->loopStartBeats == Approx(0.25));
-        REQUIRE(restored->loopLengthBeats == Approx(12.0));
-        REQUIRE(restored->speedRatio == Approx(1.5));
+        REQUIRE(primaryEventOf(restored)->sourceFilePath() == "/tmp/flat-legacy.wav");
+        REQUIRE(primaryEventOf(restored)->sourceDurationSeconds() == Approx(6.0));
+        REQUIRE(primaryEventOf(restored)->interpTotalBeats == Approx(12.0));
+        REQUIRE(primaryEventOf(restored)->interpBpm == Approx(120.0));
+        REQUIRE(primaryEventOf(restored)->anchorSeconds() == Approx(0.25));
+        REQUIRE(primaryEventOf(restored)->anchorBeats() == Approx(0.5));
+        REQUIRE(primaryEventOf(restored)->loopStartSeconds() == Approx(0.125));
+        REQUIRE(primaryEventOf(restored)->loopLengthSeconds() == Approx(6.0));
+        REQUIRE(primaryEventOf(restored)->loopStartBeats() == Approx(0.25));
+        REQUIRE(primaryEventOf(restored)->loopLengthBeats() == Approx(12.0));
+        REQUIRE(primaryEventOf(restored)->speedRatio == Approx(1.5));
     }
 }
 

--- a/tests/test_remote_api_contract.cpp
+++ b/tests/test_remote_api_contract.cpp
@@ -3,6 +3,7 @@
 #include <limits>
 #include <set>
 
+#include "AudioClipTestHelpers.hpp"
 #include "MockMagdaApi.hpp"
 #include "magda/daw/api/remote_api.hpp"
 #include "magda/daw/core/AutomationInfo.hpp"
@@ -371,7 +372,7 @@ TEST_CASE("Remote projections expose only allow-listed state",
     clip.trackId = 1;
     clip.name = "Audio";
     clip.setAudioContent();
-    clip.audio().source.filePath = "/Users/private/source.wav";
+    magda::test::giveAudioEvent(clip, "/Users/private/source.wav");
     clip.setPlacementBeats(2.0, 8.0);
     api.clips_.clips.emplace(clip.id, clip);
     api.clips_.clipsOnTrack[1] = {clip.id};

--- a/tests/test_session_clip_playback.cpp
+++ b/tests/test_session_clip_playback.cpp
@@ -3,6 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 
+#include "AudioClipTestHelpers.hpp"
 #include "magda/daw/core/ClipInfo.hpp"
 #include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/ClipOperations.hpp"
@@ -192,7 +193,7 @@ TEST_CASE("ClipManager persists loop enabled and loop length", "[session][clip][
     SECTION("Default loop state") {
         REQUIRE(clip->loopEnabled == false);
         // loopLength = length * speedRatio = 8.0 * 1.0 = 8.0
-        REQUIRE(clip->loopLength == Catch::Approx(8.0));
+        REQUIRE(primaryEventOf(clip)->loopLengthSeconds() == Catch::Approx(8.0));
     }
 
     SECTION("Enable loop") {
@@ -204,7 +205,7 @@ TEST_CASE("ClipManager persists loop enabled and loop length", "[session][clip][
     SECTION("Set loop length") {
         ClipManager::getInstance().setLoopLength(clipId, 8.0);
         clip = ClipManager::getInstance().getClip(clipId);
-        REQUIRE(clip->loopLength == Catch::Approx(8.0));
+        REQUIRE(primaryEventOf(clip)->loopLengthSeconds() == Catch::Approx(8.0));
     }
 
     SECTION("Disable loop") {
@@ -593,10 +594,11 @@ TEST_CASE("Session MIDI clip loop offset", "[session][midi][loop]") {
     auto& cm = ClipManager::getInstance();
     cm.clearAllClips();
 
+    constexpr double bpm = 120.0;
     TrackId trackId = 1;
     int sceneIndex = 0;
 
-    // Create a 4-beat session MIDI clip (defaults to loop enabled)
+    // Create a 4-second session MIDI clip, 8 beats at 120 bpm (loop on by default)
     ClipId clipId = cm.createMidiClip(trackId, 0.0, 4.0, ClipView::Session);
     REQUIRE(clipId != INVALID_CLIP_ID);
     cm.setClipSceneIndex(clipId, sceneIndex);
@@ -606,37 +608,37 @@ TEST_CASE("Session MIDI clip loop offset", "[session][midi][loop]") {
 
     SECTION("Session clips default to loop enabled with loop length matching clip length") {
         REQUIRE(clip->loopEnabled == true);
-        REQUIRE(clip->loopLength == Catch::Approx(4.0));
+        REQUIRE(clip->loopLengthBeats == Catch::Approx(8.0));
     }
 
     SECTION("Loop offset defaults to zero") {
-        REQUIRE(clip->loopStart == Catch::Approx(0.0));
+        REQUIRE(clip->loopStartBeats == Catch::Approx(0.0));
     }
 
     SECTION("Setting loop offset updates clip state") {
-        cm.setLoopStart(clipId, 2.0);
+        cm.setMidiLoopStartBeats(clipId, 2.0, bpm);
         clip = cm.getClip(clipId);
-        REQUIRE(clip->loopStart == Catch::Approx(2.0));
+        REQUIRE(clip->loopStartBeats == Catch::Approx(2.0));
     }
 
     SECTION("Loop region accounts for offset") {
-        cm.setLoopStart(clipId, 2.0);
-        cm.setLoopLength(clipId, 4.0);
+        cm.setMidiLoopStartBeats(clipId, 2.0, bpm);
+        cm.setMidiLoopLengthBeats(clipId, 4.0, bpm);
         clip = cm.getClip(clipId);
 
-        double loopStart = clip->loopStart;
-        double loopEnd = loopStart + clip->loopLength;
+        double loopStart = clip->loopStartBeats;
+        double loopEnd = loopStart + clip->loopLengthBeats;
         REQUIRE(loopStart == Catch::Approx(2.0));
         REQUIRE(loopEnd == Catch::Approx(6.0));
     }
 
     SECTION("Notes extending past loop end should be truncatable") {
         // Add a note that extends past the loop boundary
-        cm.setLoopStart(clipId, 1.0);
-        cm.setLoopLength(clipId, 2.0);
+        cm.setMidiLoopStartBeats(clipId, 1.0, bpm);
+        cm.setMidiLoopLengthBeats(clipId, 2.0, bpm);
         clip = cm.getClip(clipId);
 
-        double loopEnd = clip->loopStart + clip->loopLength;
+        double loopEnd = clip->loopStartBeats + clip->loopLengthBeats;
         REQUIRE(loopEnd == Catch::Approx(3.0));
 
         // A note at beat 2.5 with length 1.0 would end at 3.5, past loop end
@@ -673,22 +675,22 @@ void applyClipEnd(ClipManager& cm, ClipId clipId, double newClipEndBeats, double
 
     // Re-fetch clip after mutation
     const auto* clip = cm.getClip(clipId);
-    double loopOffset = clip->loopStart;
-    double loopLength = clip->loopLength;
+    double loopOffset = clip->loopStartBeats;
+    double loopLength = clip->loopLengthBeats;
 
     // If loop offset is past new clip end, pull it back
     if (loopOffset >= newClipEndBeats) {
         loopOffset = std::max(0.0, newClipEndBeats - loopLength);
         if (loopOffset < 0.0)
             loopOffset = 0.0;
-        cm.setLoopStart(clipId, loopOffset);
+        cm.setMidiLoopStartBeats(clipId, loopOffset, bpm);
     }
 
     // If loop end exceeds clip end, shrink loop length
     double loopEnd = loopOffset + loopLength;
     if (loopEnd > newClipEndBeats) {
         double clampedLength = std::max(MIN_LOOP_LENGTH_BEATS, newClipEndBeats - loopOffset);
-        cm.setLoopLength(clipId, clampedLength);
+        cm.setMidiLoopLengthBeats(clipId, clampedLength, bpm);
     }
 }
 
@@ -699,13 +701,13 @@ void applyLoopPos(ClipManager& cm, ClipId clipId, double newLoopPos, double bpm)
     const auto* clip = cm.getClip(clipId);
     double clipEndBeats = clip->length / (60.0 / bpm);
 
-    if (newLoopPos + clip->loopLength > clipEndBeats) {
-        newLoopPos = clipEndBeats - clip->loopLength;
+    if (newLoopPos + clip->loopLengthBeats > clipEndBeats) {
+        newLoopPos = clipEndBeats - clip->loopLengthBeats;
     }
     if (newLoopPos < 0.0)
         newLoopPos = 0.0;
 
-    cm.setLoopStart(clipId, newLoopPos);
+    cm.setMidiLoopStartBeats(clipId, newLoopPos, bpm);
 }
 
 /**
@@ -714,10 +716,10 @@ void applyLoopPos(ClipManager& cm, ClipId clipId, double newLoopPos, double bpm)
 void applyLoopLength(ClipManager& cm, ClipId clipId, double newLoopLength, double bpm) {
     const auto* clip = cm.getClip(clipId);
     double clipEndBeats = clip->length / (60.0 / bpm);
-    double loopEnd = clip->loopStart + clip->loopLength;
+    double loopEnd = clip->loopStartBeats + clip->loopLengthBeats;
 
     bool loopEndMatchedClipEnd = std::abs(loopEnd - clipEndBeats) < 0.001;
-    double newLoopEnd = clip->loopStart + newLoopLength;
+    double newLoopEnd = clip->loopStartBeats + newLoopLength;
 
     if (loopEndMatchedClipEnd && newLoopEnd > clipEndBeats) {
         // Grow clip to follow
@@ -727,11 +729,11 @@ void applyLoopLength(ClipManager& cm, ClipId clipId, double newLoopLength, doubl
         clip = cm.getClip(clipId);
         clipEndBeats = clip->length / (60.0 / bpm);
         if (newLoopEnd > clipEndBeats) {
-            newLoopLength = clipEndBeats - clip->loopStart;
+            newLoopLength = clipEndBeats - clip->loopStartBeats;
         }
     }
 
-    cm.setLoopLength(clipId, newLoopLength);
+    cm.setMidiLoopLengthBeats(clipId, newLoopLength, bpm);
 }
 
 }  // namespace
@@ -744,22 +746,22 @@ TEST_CASE("Shrinking clip end clamps loop length", "[session][clip][clamp][end]"
 
     // 8-beat clip, loop offset=0, loop length=8 (loop end == clip end)
     ClipId id = cm.createMidiClip(1, 0.0, 8.0 * spb, ClipView::Session);
-    cm.setLoopStart(id, 0.0);
-    cm.setLoopLength(id, 8.0);
+    cm.setMidiLoopStartBeats(id, 0.0, bpm);
+    cm.setMidiLoopLengthBeats(id, 8.0, bpm);
 
     SECTION("Shrink clip to 6 beats — loop length clamped to 6") {
         applyClipEnd(cm, id, 6.0, bpm);
         auto* clip = cm.getClip(id);
         REQUIRE(clip->length == Catch::Approx(6.0 * spb));
-        REQUIRE(clip->loopLength == Catch::Approx(6.0));
-        REQUIRE(clip->loopStart == Catch::Approx(0.0));
+        REQUIRE(clip->loopLengthBeats == Catch::Approx(6.0));
+        REQUIRE(clip->loopStartBeats == Catch::Approx(0.0));
     }
 
     SECTION("Shrink clip to 4 beats — loop length clamped to 4") {
         applyClipEnd(cm, id, 4.0, bpm);
         auto* clip = cm.getClip(id);
         REQUIRE(clip->length == Catch::Approx(4.0 * spb));
-        REQUIRE(clip->loopLength == Catch::Approx(4.0));
+        REQUIRE(clip->loopLengthBeats == Catch::Approx(4.0));
     }
 }
 
@@ -771,31 +773,31 @@ TEST_CASE("Shrinking clip end clamps loop with offset", "[session][clip][clamp][
 
     // 8-beat clip, loop offset=2, loop length=4 (loop end = 6)
     ClipId id = cm.createMidiClip(1, 0.0, 8.0 * spb, ClipView::Session);
-    cm.setLoopStart(id, 2.0);
-    cm.setLoopLength(id, 4.0);
+    cm.setMidiLoopStartBeats(id, 2.0, bpm);
+    cm.setMidiLoopLengthBeats(id, 4.0, bpm);
 
     SECTION("Shrink clip to 5 — loop end was 6, clamp length to 3") {
         applyClipEnd(cm, id, 5.0, bpm);
         auto* clip = cm.getClip(id);
-        REQUIRE(clip->loopStart == Catch::Approx(2.0));
-        REQUIRE(clip->loopLength == Catch::Approx(3.0));
-        double loopEnd = clip->loopStart + clip->loopLength;
+        REQUIRE(clip->loopStartBeats == Catch::Approx(2.0));
+        REQUIRE(clip->loopLengthBeats == Catch::Approx(3.0));
+        double loopEnd = clip->loopStartBeats + clip->loopLengthBeats;
         REQUIRE(loopEnd <= 5.0 + 0.001);
     }
 
     SECTION("Shrink clip to 3 — loop end was 6, clamp length to 1") {
         applyClipEnd(cm, id, 3.0, bpm);
         auto* clip = cm.getClip(id);
-        REQUIRE(clip->loopStart == Catch::Approx(2.0));
-        REQUIRE(clip->loopLength == Catch::Approx(1.0));
+        REQUIRE(clip->loopStartBeats == Catch::Approx(2.0));
+        REQUIRE(clip->loopLengthBeats == Catch::Approx(1.0));
     }
 
     SECTION("Shrink clip past loop offset — offset pulled back") {
         applyClipEnd(cm, id, 1.0, bpm);
         auto* clip = cm.getClip(id);
         // Offset must be pulled back so loop fits
-        REQUIRE(clip->loopStart < 1.0);
-        double loopEnd = clip->loopStart + clip->loopLength;
+        REQUIRE(clip->loopStartBeats < 1.0);
+        double loopEnd = clip->loopStartBeats + clip->loopLengthBeats;
         REQUIRE(loopEnd <= 1.0 + 0.001);
     }
 }
@@ -809,15 +811,15 @@ TEST_CASE("Shrinking clip end does not affect loop when loop is inside",
 
     // 8-beat clip, loop offset=1, loop length=2 (loop end = 3)
     ClipId id = cm.createMidiClip(1, 0.0, 8.0 * spb, ClipView::Session);
-    cm.setLoopStart(id, 1.0);
-    cm.setLoopLength(id, 2.0);
+    cm.setMidiLoopStartBeats(id, 1.0, bpm);
+    cm.setMidiLoopLengthBeats(id, 2.0, bpm);
 
     // Shrink clip to 5 — loop end is 3, still within bounds
     applyClipEnd(cm, id, 5.0, bpm);
     auto* clip = cm.getClip(id);
 
-    REQUIRE(clip->loopStart == Catch::Approx(1.0));
-    REQUIRE(clip->loopLength == Catch::Approx(2.0));
+    REQUIRE(clip->loopStartBeats == Catch::Approx(1.0));
+    REQUIRE(clip->loopLengthBeats == Catch::Approx(2.0));
 }
 
 TEST_CASE("Loop pos clamped to keep loop within clip", "[session][clip][clamp][pos]") {
@@ -828,27 +830,27 @@ TEST_CASE("Loop pos clamped to keep loop within clip", "[session][clip][clamp][p
 
     // 8-beat clip, loop length=4
     ClipId id = cm.createMidiClip(1, 0.0, 8.0 * spb, ClipView::Session);
-    cm.setLoopStart(id, 0.0);
-    cm.setLoopLength(id, 4.0);
+    cm.setMidiLoopStartBeats(id, 0.0, bpm);
+    cm.setMidiLoopLengthBeats(id, 4.0, bpm);
 
     SECTION("Move loop pos to 4 — loop end 8 == clip end, allowed") {
         applyLoopPos(cm, id, 4.0, bpm);
         auto* clip = cm.getClip(id);
-        REQUIRE(clip->loopStart == Catch::Approx(4.0));
+        REQUIRE(clip->loopStartBeats == Catch::Approx(4.0));
     }
 
     SECTION("Move loop pos to 6 — loop end would be 10, clamped to 4") {
         applyLoopPos(cm, id, 6.0, bpm);
         auto* clip = cm.getClip(id);
-        REQUIRE(clip->loopStart == Catch::Approx(4.0));
-        double loopEnd = clip->loopStart + clip->loopLength;
+        REQUIRE(clip->loopStartBeats == Catch::Approx(4.0));
+        double loopEnd = clip->loopStartBeats + clip->loopLengthBeats;
         REQUIRE(loopEnd <= 8.0 + 0.001);
     }
 
     SECTION("Negative loop pos clamped to 0") {
         applyLoopPos(cm, id, -2.0, bpm);
         auto* clip = cm.getClip(id);
-        REQUIRE(clip->loopStart == Catch::Approx(0.0));
+        REQUIRE(clip->loopStartBeats == Catch::Approx(0.0));
     }
 }
 
@@ -860,20 +862,20 @@ TEST_CASE("Shrinking loop length does not shrink clip", "[session][clip][clamp][
 
     // 8-beat clip, loop offset=0, loop length=8 (aligned with clip end)
     ClipId id = cm.createMidiClip(1, 0.0, 8.0 * spb, ClipView::Session);
-    cm.setLoopStart(id, 0.0);
-    cm.setLoopLength(id, 8.0);
+    cm.setMidiLoopStartBeats(id, 0.0, bpm);
+    cm.setMidiLoopLengthBeats(id, 8.0, bpm);
 
     SECTION("Shrink loop to 4 — clip stays at 8") {
         applyLoopLength(cm, id, 4.0, bpm);
         auto* clip = cm.getClip(id);
-        REQUIRE(clip->loopLength == Catch::Approx(4.0));
+        REQUIRE(clip->loopLengthBeats == Catch::Approx(4.0));
         REQUIRE(clip->length == Catch::Approx(8.0 * spb));
     }
 
     SECTION("Shrink loop to 2 — clip stays at 8") {
         applyLoopLength(cm, id, 2.0, bpm);
         auto* clip = cm.getClip(id);
-        REQUIRE(clip->loopLength == Catch::Approx(2.0));
+        REQUIRE(clip->loopLengthBeats == Catch::Approx(2.0));
         REQUIRE(clip->length == Catch::Approx(8.0 * spb));
     }
 }
@@ -887,13 +889,13 @@ TEST_CASE("Growing loop length when aligned extends clip",
 
     // 8-beat clip, loop offset=0, loop length=8 (aligned with clip end)
     ClipId id = cm.createMidiClip(1, 0.0, 8.0 * spb, ClipView::Session);
-    cm.setLoopStart(id, 0.0);
-    cm.setLoopLength(id, 8.0);
+    cm.setMidiLoopStartBeats(id, 0.0, bpm);
+    cm.setMidiLoopLengthBeats(id, 8.0, bpm);
 
     applyLoopLength(cm, id, 12.0, bpm);
     auto* clip = cm.getClip(id);
 
-    REQUIRE(clip->loopLength == Catch::Approx(12.0));
+    REQUIRE(clip->loopLengthBeats == Catch::Approx(12.0));
     REQUIRE(clip->length == Catch::Approx(12.0 * spb));
 }
 
@@ -906,20 +908,20 @@ TEST_CASE("Growing loop length when NOT aligned clamps to clip end",
 
     // 8-beat clip, loop offset=0, loop length=4 (NOT aligned with clip end)
     ClipId id = cm.createMidiClip(1, 0.0, 8.0 * spb, ClipView::Session);
-    cm.setLoopStart(id, 0.0);
-    cm.setLoopLength(id, 4.0);
+    cm.setMidiLoopStartBeats(id, 0.0, bpm);
+    cm.setMidiLoopLengthBeats(id, 4.0, bpm);
 
     SECTION("Grow loop to 6 — within clip, allowed") {
         applyLoopLength(cm, id, 6.0, bpm);
         auto* clip = cm.getClip(id);
-        REQUIRE(clip->loopLength == Catch::Approx(6.0));
+        REQUIRE(clip->loopLengthBeats == Catch::Approx(6.0));
         REQUIRE(clip->length == Catch::Approx(8.0 * spb));
     }
 
     SECTION("Grow loop to 10 — exceeds clip, clamped to 8") {
         applyLoopLength(cm, id, 10.0, bpm);
         auto* clip = cm.getClip(id);
-        REQUIRE(clip->loopLength == Catch::Approx(8.0));
+        REQUIRE(clip->loopLengthBeats == Catch::Approx(8.0));
         REQUIRE(clip->length == Catch::Approx(8.0 * spb));
     }
 }
@@ -938,8 +940,9 @@ std::pair<double, double> computeAutoTempoTimings(const ClipInfo& clip, double b
     if (bpm <= 0.0)
         bpm = 120.0;
     double clipLength = clip.lengthBeats * 60.0 / bpm;
-    double loopLength =
-        (clip.loopLengthBeats > 0.0) ? clip.loopLengthBeats * 60.0 / bpm : clipLength;
+    double loopLength = (magda::audioEventRef(clip).loopLengthBeats() > 0.0)
+                            ? magda::audioEventRef(clip).loopLengthBeats() * 60.0 / bpm
+                            : clipLength;
     return {clipLength, loopLength};
 }
 
@@ -949,8 +952,10 @@ std::pair<double, double> computeAutoTempoTimings(const ClipInfo& clip, double b
  */
 std::pair<double, double> computeTimeBasedTimings(const ClipInfo& clip) {
     double clipLength = clip.length;
-    double srcLength = clip.loopLength > 0.0 ? clip.loopLength : clip.length * clip.speedRatio;
-    double loopLength = srcLength / clip.speedRatio;
+    double srcLength = magda::audioEventRef(clip).loopLengthSeconds() > 0.0
+                           ? magda::audioEventRef(clip).loopLengthSeconds()
+                           : clip.length * magda::audioEventRef(clip).speedRatio;
+    double loopLength = srcLength / magda::audioEventRef(clip).speedRatio;
     return {clipLength, loopLength};
 }
 
@@ -961,14 +966,14 @@ TEST_CASE("AutoTempo session clip timing: 172bpm clip in 120bpm project",
     // Scenario from the bug report: 2-bar loop at 172bpm, project at 120bpm
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audio().source.filePath = "loop_172bpm.wav";
-    clip.audio().interpretation.bpm = 172.0;
-    clip.audio().interpretation.totalBeats = 8.0;  // 2 bars = 8 beats
-    clip.length = 8.0 * 60.0 / 172.0;              // ~2.79s original duration
-    clip.speedRatio = 1.0;
+    magda::test::giveAudioEvent(clip, "loop_172bpm.wav");
+    magda::test::audioEvent(clip).interpBpm = 172.0;
+    magda::test::audioEvent(clip).interpTotalBeats = 8.0;  // 2 bars = 8 beats
+    clip.length = 8.0 * 60.0 / 172.0;                      // ~2.79s original duration
+    magda::test::audioEvent(clip).speedRatio = 1.0;
     clip.loopEnabled = true;
-    clip.loopStart = 0.0;
-    clip.loopLength = clip.length;
+    magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
+    magda::test::audioEvent(clip).setLoopLengthSeconds(clip.length);
 
     constexpr double PROJECT_BPM = 120.0;
     ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
@@ -995,18 +1000,22 @@ TEST_CASE("AutoTempo session clip timing: 172bpm clip in 120bpm project",
         // Within one loop
         REQUIRE(computeSessionPlayhead(dur * 0.5, loopLen, clipLen, true) ==
                 Catch::Approx(dur * 0.5));
-        // At exact loop boundary, wraps to 0
-        REQUIRE(computeSessionPlayhead(dur, loopLen, clipLen, true) == Catch::Approx(0.0));
-        // One second past loop boundary
-        REQUIRE(computeSessionPlayhead(dur + 1.0, loopLen, clipLen, true) == Catch::Approx(1.0));
+        // At the exact loop boundary, wraps to 0. The loop length comes off a
+        // source region stored in samples (#1901), so the boundary is exact to
+        // a fraction of a sample rather than bit-exact.
+        REQUIRE(computeSessionPlayhead(dur, loopLen, clipLen, true) ==
+                Catch::Approx(0.0).margin(1.0e-4));
+        // One second past the loop boundary, to the same sample tolerance
+        REQUIRE(computeSessionPlayhead(dur + 1.0, loopLen, clipLen, true) ==
+                Catch::Approx(1.0).margin(1.0e-4));
     }
 
     SECTION("Without autoTempo, playhead uses original duration (wrong)") {
         // This demonstrates the bug: without autoTempo timing,
         // the playhead wraps at the original ~2.79s instead of 4s
         ClipInfo rawClip = clip;
-        rawClip.autoTempo = false;
-        rawClip.loopLength = rawClip.length;
+        magda::test::audioEvent(rawClip).autoTempo = false;
+        magda::test::audioEvent(rawClip).setLoopLengthSeconds(rawClip.length);
         auto [clipLen, loopLen] = computeTimeBasedTimings(rawClip);
         // Would wrap at ~2.79s — incorrect for a 120bpm playback
         REQUIRE(loopLen < 3.0);
@@ -1018,14 +1027,14 @@ TEST_CASE("AutoTempo session clip timing: sub-loop region",
     // 8-beat source, but only looping 4 beats
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audio().source.filePath = "sample.wav";
-    clip.audio().interpretation.bpm = 140.0;
-    clip.audio().interpretation.totalBeats = 8.0;
+    magda::test::giveAudioEvent(clip, "sample.wav");
+    magda::test::audioEvent(clip).interpBpm = 140.0;
+    magda::test::audioEvent(clip).interpTotalBeats = 8.0;
     clip.length = 8.0 * 60.0 / 140.0;
-    clip.speedRatio = 1.0;
+    magda::test::audioEvent(clip).speedRatio = 1.0;
     clip.loopEnabled = true;
-    clip.loopStart = 0.0;
-    clip.loopLength = 4.0 * 60.0 / 140.0;  // half the file
+    magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
+    magda::test::audioEvent(clip).setLoopLengthSeconds(4.0 * 60.0 / 140.0);  // half the file
 
     constexpr double PROJECT_BPM = 120.0;
     ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
@@ -1041,7 +1050,8 @@ TEST_CASE("AutoTempo session clip timing: sub-loop region",
     }
 
     SECTION("Loop length uses loopLengthBeats") {
-        REQUIRE(loopLen == Catch::Approx(clip.loopLengthBeats * 60.0 / PROJECT_BPM));
+        REQUIRE(loopLen ==
+                Catch::Approx(magda::audioEventRef(clip).loopLengthBeats() * 60.0 / PROJECT_BPM));
     }
 }
 
@@ -1049,14 +1059,14 @@ TEST_CASE("AutoTempo session clip timing: BPM edge cases",
           "[session][auto-tempo][playhead][edge]") {
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audio().source.filePath = "sample.wav";
-    clip.audio().interpretation.bpm = 120.0;
-    clip.audio().interpretation.totalBeats = 4.0;
+    magda::test::giveAudioEvent(clip, "sample.wav");
+    magda::test::audioEvent(clip).interpBpm = 120.0;
+    magda::test::audioEvent(clip).interpTotalBeats = 4.0;
     clip.length = 2.0;
-    clip.speedRatio = 1.0;
+    magda::test::audioEvent(clip).speedRatio = 1.0;
     clip.loopEnabled = true;
-    clip.loopStart = 0.0;
-    clip.loopLength = 2.0;
+    magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
+    magda::test::audioEvent(clip).setLoopLengthSeconds(2.0);
 
     ClipOperations::setAutoTempo(clip, true, 120.0);
 
@@ -1089,33 +1099,36 @@ TEST_CASE("AutoTempo session clip: getAutoTempoBeatRange for session loop",
           "[session][auto-tempo][beat-range]") {
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audio().source.filePath = "loop.wav";
-    clip.audio().interpretation.bpm = 172.0;
-    clip.audio().interpretation.totalBeats = 8.0;
+    magda::test::giveAudioEvent(clip, "loop.wav");
+    magda::test::audioEvent(clip).interpBpm = 172.0;
+    magda::test::audioEvent(clip).interpTotalBeats = 8.0;
     clip.length = 8.0 * 60.0 / 172.0;
-    clip.speedRatio = 1.0;
+    magda::test::audioEvent(clip).speedRatio = 1.0;
     clip.loopEnabled = true;
-    clip.loopStart = 0.0;
-    clip.loopLength = clip.length;
+    magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
+    magda::test::audioEvent(clip).setLoopLengthSeconds(clip.length);
 
     constexpr double PROJECT_BPM = 120.0;
     ClipOperations::setAutoTempo(clip, true, PROJECT_BPM);
 
     SECTION("Beat range is valid after setAutoTempo") {
-        auto [startBeats, lengthBeats] = ClipOperations::getAutoTempoBeatRange(clip, PROJECT_BPM);
+        auto [startBeats, lengthBeats] =
+            ClipOperations::getAutoTempoBeatRange(magda::test::audioEvent(clip));
         REQUIRE(startBeats >= 0.0);
         REQUIRE(lengthBeats > 0.0);
-        REQUIRE(startBeats + lengthBeats <= clip.audio().interpretation.totalBeats + 0.001);
+        REQUIRE(startBeats + lengthBeats <= magda::audioEventRef(clip).interpTotalBeats + 0.001);
     }
 
     SECTION("Beat range matches stored loopLengthBeats") {
-        auto [startBeats, lengthBeats] = ClipOperations::getAutoTempoBeatRange(clip, PROJECT_BPM);
-        REQUIRE(lengthBeats == Catch::Approx(clip.loopLengthBeats));
+        auto [startBeats, lengthBeats] =
+            ClipOperations::getAutoTempoBeatRange(magda::test::audioEvent(clip));
+        REQUIRE(lengthBeats == Catch::Approx(magda::audioEventRef(clip).loopLengthBeats()));
     }
 
     SECTION("Returns {0,0} when autoTempo is off") {
-        clip.autoTempo = false;
-        auto [startBeats, lengthBeats] = ClipOperations::getAutoTempoBeatRange(clip, PROJECT_BPM);
+        magda::test::audioEvent(clip).autoTempo = false;
+        auto [startBeats, lengthBeats] =
+            ClipOperations::getAutoTempoBeatRange(magda::test::audioEvent(clip));
         REQUIRE(startBeats == 0.0);
         REQUIRE(lengthBeats == 0.0);
     }

--- a/tests/test_session_slot_recording_juce.cpp
+++ b/tests/test_session_slot_recording_juce.cpp
@@ -307,15 +307,17 @@ class SessionSlotRecordingIntegrationTest final : public juce::UnitTest {
         expectEquals(clip->sceneIndex, fixture.sceneIndex);
         expect(clip->isAudio(), "Mirrored clip must be audio");
         expect(clip->loopEnabled, "Recorded session clip should loop");
-        expect(clip->autoTempo, "Recorded session audio should follow the project tempo");
-        expectEquals(clip->audio().source.filePath, audioFile->getFile().getFullPathName());
+        expect(primaryEventOf(clip)->autoTempo,
+               "Recorded session audio should follow the project tempo");
+        expectEquals(primaryEventOf(clip)->sourceFilePath(),
+                     audioFile->getFile().getFullPathName());
         expectWithinAbsoluteError(clip->placement.lengthBeats, 4.0, 0.0001,
                                   "Clip length should snap to a full 4/4 bar");
-        expectWithinAbsoluteError(clip->loopLengthBeats, 4.0, 0.0001,
+        expectWithinAbsoluteError(primaryEventOf(clip)->loopLengthBeats(), 4.0, 0.0001,
                                   "Loop length should match snapped clip length");
-        expectWithinAbsoluteError(clip->audio().interpretation.bpm, 120.0, 0.0001,
+        expectWithinAbsoluteError(primaryEventOf(clip)->interpBpm, 120.0, 0.0001,
                                   "Recorded source BPM should match the project");
-        expectWithinAbsoluteError(clip->audio().interpretation.totalBeats, 4.0, 0.0001,
+        expectWithinAbsoluteError(primaryEventOf(clip)->interpTotalBeats, 4.0, 0.0001,
                                   "Recorded source beats should match the snapped bar length");
 
         auto* teClip = slot->getClip();

--- a/tests/test_source_pool.cpp
+++ b/tests/test_source_pool.cpp
@@ -1,0 +1,226 @@
+#include <juce_audio_formats/juce_audio_formats.h>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <unordered_set>
+
+#include "AudioClipTestHelpers.hpp"
+#include "core/SourcePool.hpp"
+
+using namespace magda;
+using Catch::Approx;
+
+namespace {
+
+struct PoolFixture {
+    PoolFixture() {
+        SourcePool::getInstance().clear();
+        SourcePool::getInstance().clearSeededFactsForTesting();
+    }
+    ~PoolFixture() {
+        SourcePool::getInstance().clear();
+        SourcePool::getInstance().clearSeededFactsForTesting();
+    }
+};
+
+/// Write a real WAV so the pool's probe path can be exercised end to end.
+/// Returns the file; the caller deletes it.
+juce::File writeTempWav(const juce::String& name, double sampleRate, int lengthSamples) {
+    auto file = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                    .getChildFile("magda_source_pool_" + name + ".wav");
+    file.deleteFile();
+
+    juce::WavAudioFormat format;
+    std::unique_ptr<juce::FileOutputStream> stream(file.createOutputStream());
+    if (stream == nullptr)
+        return {};
+
+    std::unique_ptr<juce::AudioFormatWriter> writer(
+        format.createWriterFor(stream.get(), sampleRate, 1, 16, {}, 0));
+    if (writer == nullptr)
+        return {};
+    stream.release();  // the writer owns it now
+
+    juce::AudioBuffer<float> silence(1, lengthSamples);
+    silence.clear();
+    writer->writeFromAudioSampleBuffer(silence, 0, lengthSamples);
+    writer.reset();
+
+    return file;
+}
+
+}  // namespace
+
+TEST_CASE("SourcePool deduplicates by file", "[source][pool]") {
+    PoolFixture fixture;
+    auto& pool = SourcePool::getInstance();
+
+    SECTION("The same path yields the same id") {
+        const auto first = pool.acquire("/tmp/kick.wav");
+        const auto second = pool.acquire("/tmp/kick.wav");
+        REQUIRE(first != INVALID_SOURCE_ID);
+        REQUIRE(first == second);
+        REQUIRE(pool.snapshot().size() == 1);
+    }
+
+    SECTION("Different paths yield different ids") {
+        REQUIRE(pool.acquire("/tmp/kick.wav") != pool.acquire("/tmp/snare.wav"));
+        REQUIRE(pool.snapshot().size() == 2);
+    }
+
+    SECTION("An empty path is not a source") {
+        REQUIRE(pool.acquire("") == INVALID_SOURCE_ID);
+        REQUIRE(pool.snapshot().empty());
+    }
+
+    SECTION("findByPath sees what acquire created, and nothing else") {
+        const auto id = pool.acquire("/tmp/kick.wav");
+        REQUIRE(pool.findByPath("/tmp/kick.wav") == id);
+        REQUIRE(pool.findByPath("/tmp/never-seen.wav") == INVALID_SOURCE_ID);
+    }
+
+#if JUCE_MAC || JUCE_WINDOWS
+    SECTION("Case-insensitive platforms treat one file as one source") {
+        const auto lower = pool.acquire("/tmp/Kick.wav");
+        const auto upper = pool.acquire("/tmp/KICK.WAV");
+        REQUIRE(lower == upper);
+        REQUIRE(pool.snapshot().size() == 1);
+    }
+#endif
+
+    SECTION("A relative path keys on itself rather than the working directory") {
+        // Resolving it against the CWD would make the same project mean
+        // different files depending on where the app was launched from.
+        const auto id = pool.acquire("relative/loop.wav");
+        REQUIRE(id != INVALID_SOURCE_ID);
+        REQUIRE(pool.get(id)->filePath == "relative/loop.wav");
+    }
+}
+
+TEST_CASE("SourcePool insert preserves ids from a project file", "[source][pool][serialization]") {
+    PoolFixture fixture;
+    auto& pool = SourcePool::getInstance();
+
+    Source restored;
+    restored.id = 7;
+    restored.filePath = "/tmp/restored.wav";
+    restored.durationSeconds = 3.5;
+    restored.sampleRate = 44100.0;
+
+    REQUIRE(pool.insert(restored) == 7);
+    REQUIRE(pool.get(7)->durationSeconds == Approx(3.5));
+
+    SECTION("Later acquires do not collide with a restored id") {
+        REQUIRE(pool.acquire("/tmp/other.wav") > 7);
+    }
+
+    SECTION("Re-inserting the same file keeps the first entry") {
+        Source duplicate = restored;
+        duplicate.id = 99;
+        duplicate.durationSeconds = 999.0;
+        REQUIRE(pool.insert(duplicate) == 7);
+        REQUIRE(pool.get(7)->durationSeconds == Approx(3.5));
+        REQUIRE(pool.get(99) == nullptr);
+    }
+}
+
+TEST_CASE("SourcePool garbage collects unreferenced sources", "[source][pool]") {
+    PoolFixture fixture;
+    auto& pool = SourcePool::getInstance();
+
+    const auto kept = pool.acquire("/tmp/kept.wav");
+    const auto dropped = pool.acquire("/tmp/dropped.wav");
+
+    pool.retainOnly({kept});
+
+    REQUIRE(pool.get(kept) != nullptr);
+    REQUIRE(pool.get(dropped) == nullptr);
+    REQUIRE(pool.snapshot().size() == 1);
+
+    SECTION("A dropped path can be re-acquired afterwards") {
+        // The path index has to be cleaned up with the entry, or the file
+        // becomes permanently unreachable.
+        const auto reacquired = pool.acquire("/tmp/dropped.wav");
+        REQUIRE(reacquired != INVALID_SOURCE_ID);
+        REQUIRE(pool.get(reacquired) != nullptr);
+    }
+}
+
+TEST_CASE("SourcePool relink repoints every clip sharing the file", "[source][pool]") {
+    PoolFixture fixture;
+    auto& pool = SourcePool::getInstance();
+
+    const auto id = pool.acquire("/tmp/before.wav");
+    pool.relink(id, "/tmp/after.wav");
+
+    REQUIRE(pool.get(id)->filePath == "/tmp/after.wav");
+    REQUIRE(pool.findByPath("/tmp/after.wav") == id);
+    REQUIRE(pool.findByPath("/tmp/before.wav") == INVALID_SOURCE_ID);
+}
+
+TEST_CASE("SourcePool probes real files for their facts", "[source][pool][probe]") {
+    PoolFixture fixture;
+    auto& pool = SourcePool::getInstance();
+
+    constexpr double kRate = 44100.0;
+    constexpr int kSamples = 22050;  // half a second
+    const auto file = writeTempWav("probe", kRate, kSamples);
+    REQUIRE(file.existsAsFile());
+
+    SECTION("acquire reads sample rate and duration off disk") {
+        const auto id = pool.acquire(file.getFullPathName());
+        const auto* source = pool.get(id);
+        REQUIRE(source != nullptr);
+        REQUIRE(source->isResolved());
+        REQUIRE(source->sampleRate == Approx(kRate));
+        REQUIRE(source->durationSeconds == Approx(0.5));
+    }
+
+    SECTION("A missing file stays unresolved and reports the nominal rate") {
+        const auto id = pool.acquire("/tmp/magda_definitely_missing.wav");
+        const auto* source = pool.get(id);
+        REQUIRE(source != nullptr);
+        REQUIRE_FALSE(source->isResolved());
+        REQUIRE(source->sampleRate == Approx(0.0));
+        REQUIRE(source->effectiveSampleRate() == Approx(kUnresolvedSourceSampleRate));
+    }
+
+    SECTION("resolveFacts reports the unresolved-to-resolved transition once") {
+        // That transition is what tells the model to rescale anchors computed
+        // at the nominal rate, so it must fire exactly once.
+        Source offline;
+        offline.id = 1;
+        offline.filePath = file.getFullPathName();
+        REQUIRE(pool.insert(offline) == 1);
+        REQUIRE_FALSE(pool.get(1)->isResolved());
+
+        REQUIRE(pool.resolveFacts(1));
+        REQUIRE(pool.get(1)->isResolved());
+        REQUIRE(pool.get(1)->sampleRate == Approx(kRate));
+
+        REQUIRE_FALSE(pool.resolveFacts(1));
+    }
+
+    SECTION("relink onto a real file resolves a previously missing source") {
+        const auto id = pool.acquire("/tmp/magda_definitely_missing.wav");
+        REQUIRE_FALSE(pool.get(id)->isResolved());
+        REQUIRE(pool.relink(id, file.getFullPathName()));
+        REQUIRE(pool.get(id)->sampleRate == Approx(kRate));
+    }
+
+    file.deleteFile();
+}
+
+TEST_CASE("Source converts between its own samples and seconds", "[source][pool]") {
+    Source source;
+    source.sampleRate = 48000.0;
+
+    REQUIRE(source.secondsToSamples(0.5) == 24000);
+    REQUIRE(source.samplesToSeconds(24000) == Approx(0.5));
+
+    SECTION("An unresolved source falls back to the nominal rate") {
+        Source unresolved;
+        REQUIRE(unresolved.secondsToSamples(1.0) ==
+                static_cast<int64_t>(kUnresolvedSourceSampleRate));
+    }
+}

--- a/tests/test_source_pool.cpp
+++ b/tests/test_source_pool.cpp
@@ -125,28 +125,6 @@ TEST_CASE("SourcePool insert preserves ids from a project file", "[source][pool]
     }
 }
 
-TEST_CASE("SourcePool garbage collects unreferenced sources", "[source][pool]") {
-    PoolFixture fixture;
-    auto& pool = SourcePool::getInstance();
-
-    const auto kept = pool.acquire("/tmp/kept.wav");
-    const auto dropped = pool.acquire("/tmp/dropped.wav");
-
-    pool.retainOnly({kept});
-
-    REQUIRE(pool.get(kept) != nullptr);
-    REQUIRE(pool.get(dropped) == nullptr);
-    REQUIRE(pool.snapshot().size() == 1);
-
-    SECTION("A dropped path can be re-acquired afterwards") {
-        // The path index has to be cleaned up with the entry, or the file
-        // becomes permanently unreachable.
-        const auto reacquired = pool.acquire("/tmp/dropped.wav");
-        REQUIRE(reacquired != INVALID_SOURCE_ID);
-        REQUIRE(pool.get(reacquired) != nullptr);
-    }
-}
-
 TEST_CASE("SourcePool relink repoints every clip sharing the file", "[source][pool]") {
     PoolFixture fixture;
     auto& pool = SourcePool::getInstance();

--- a/tests/test_source_pool.cpp
+++ b/tests/test_source_pool.cpp
@@ -5,6 +5,7 @@
 #include <unordered_set>
 
 #include "AudioClipTestHelpers.hpp"
+#include "core/ClipManager.hpp"
 #include "core/SourcePool.hpp"
 
 using namespace magda;
@@ -223,4 +224,112 @@ TEST_CASE("Source converts between its own samples and seconds", "[source][pool]
         REQUIRE(unresolved.secondsToSamples(1.0) ==
                 static_cast<int64_t>(kUnresolvedSourceSampleRate));
     }
+}
+
+TEST_CASE("Resolving a source rescales the anchors computed at the nominal rate",
+          "[source][pool][rescale]") {
+    // Anchors are sample counts at the source's own rate. While the file is
+    // missing the pool reports kUnresolvedSourceSampleRate, so everything
+    // computed then is expressed at 48 kHz. Resolving a 44.1 kHz file without
+    // rescaling would reinterpret every one of those counts and shift the clip
+    // by about 9%.
+    PoolFixture fixture;
+    auto& pool = SourcePool::getInstance();
+    auto& cm = ClipManager::getInstance();
+    cm.clearAllClips();
+
+    constexpr double kRealRate = 44100.0;
+    const auto file = writeTempWav("rescale", kRealRate, 44100);
+    REQUIRE(file.existsAsFile());
+
+    // A source that is not resolved yet: insert() does not probe.
+    Source offline;
+    offline.id = 1;
+    offline.filePath = file.getFullPathName();
+    REQUIRE(pool.insert(offline) == 1);
+    REQUIRE_FALSE(pool.get(1)->isResolved());
+
+    const auto clipId = cm.createMidiClipBeats(1, 0.0, 4.0, ClipView::Arrangement);
+    auto* clip = cm.getClip(clipId);
+    REQUIRE(clip != nullptr);
+    clip->setAudioContent();
+    AudioEvent seed;
+    seed.sourceId = 1;
+    auto& event = clip->audio().addEvent(std::move(seed));
+
+    // Half a second in, at the only rate anyone can know about yet.
+    event.setAnchorSeconds(0.5);
+    event.setLoopStartSeconds(0.25);
+    event.setLoopLengthSeconds(0.5);
+    REQUIRE(event.sourceAnchorSamples == 24000);
+
+    REQUIRE(pool.resolveFacts(1));
+    REQUIRE(pool.get(1)->sampleRate == Approx(kRealRate));
+
+    // Same instant in the file, expressed at the rate it actually runs at.
+    auto* rescaled = cm.getClip(clipId)->primaryEvent();
+    REQUIRE(rescaled != nullptr);
+    REQUIRE(rescaled->sourceAnchorSamples == 22050);
+    REQUIRE(rescaled->loopStartSamples == 11025);
+    REQUIRE(rescaled->loopLengthSamples == 22050);
+    REQUIRE(rescaled->anchorSeconds() == Approx(0.5));
+    REQUIRE(rescaled->loopStartSeconds() == Approx(0.25));
+    REQUIRE(rescaled->loopLengthSeconds() == Approx(0.5));
+
+    cm.clearAllClips();
+    file.deleteFile();
+}
+
+TEST_CASE("Relinking to a file at another rate keeps positions in time",
+          "[source][pool][rescale]") {
+    // The 0 -> real transition is not the only rate change: a resolved source
+    // relinked onto a file at a different rate moves just as far.
+    PoolFixture fixture;
+    auto& pool = SourcePool::getInstance();
+    auto& cm = ClipManager::getInstance();
+    cm.clearAllClips();
+
+    const auto at48k = writeTempWav("relink_48k", 48000.0, 48000);
+    const auto at44k = writeTempWav("relink_44k", 44100.0, 44100);
+    REQUIRE(at48k.existsAsFile());
+    REQUIRE(at44k.existsAsFile());
+
+    const auto id = pool.acquire(at48k.getFullPathName());
+    REQUIRE(pool.get(id)->sampleRate == Approx(48000.0));
+
+    const auto clipId = cm.createMidiClipBeats(1, 0.0, 4.0, ClipView::Arrangement);
+    auto* clip = cm.getClip(clipId);
+    clip->setAudioContent();
+    AudioEvent seed;
+    seed.sourceId = id;
+    auto& event = clip->audio().addEvent(std::move(seed));
+    event.setAnchorSeconds(0.5);
+    REQUIRE(event.sourceAnchorSamples == 24000);
+
+    REQUIRE(pool.relink(id, at44k.getFullPathName()) == id);
+
+    auto* rescaled = cm.getClip(clipId)->primaryEvent();
+    REQUIRE(rescaled->sourceAnchorSamples == 22050);
+    REQUIRE(rescaled->anchorSeconds() == Approx(0.5));
+
+    cm.clearAllClips();
+    at48k.deleteFile();
+    at44k.deleteFile();
+}
+
+TEST_CASE("Relinking onto an already pooled file does not steal its key", "[source][pool]") {
+    // insert() guards this case; relink() has to as well, or two sources end
+    // up claiming one file with only one of them reachable by path.
+    PoolFixture fixture;
+    auto& pool = SourcePool::getInstance();
+
+    const auto first = pool.acquire("/tmp/one.wav");
+    const auto second = pool.acquire("/tmp/two.wav");
+    REQUIRE(first != second);
+
+    // The existing owner comes back, and nothing moved.
+    REQUIRE(pool.relink(second, "/tmp/one.wav") == first);
+    REQUIRE(pool.findByPath("/tmp/one.wav") == first);
+    REQUIRE(pool.get(second)->filePath == "/tmp/two.wav");
+    REQUIRE(pool.findByPath("/tmp/two.wav") == second);
 }

--- a/tests/test_waveform_editor_absolute_mode.cpp
+++ b/tests/test_waveform_editor_absolute_mode.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include "AudioClipTestHelpers.hpp"
 #include "magda/daw/core/ClipDisplayInfo.hpp"
 #include "magda/daw/core/ClipInfo.hpp"
 #include "magda/daw/core/ClipManager.hpp"
@@ -280,32 +281,32 @@ TEST_CASE("ClipOperations - audio sanitizing preserves sample start",
           "[clip][audio][offset][regression]") {
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audio().source.filePath = "/tmp/magda_offset_regression.wav";
+    magda::test::giveAudioEvent(clip, "/tmp/magda_offset_regression.wav");
     clip.loopEnabled = false;
-    clip.autoTempo = false;
+    magda::test::audioEvent(clip).autoTempo = false;
     clip.length = 4.0;
-    clip.speedRatio = 1.0;
-    clip.loopStart = 0.25;
-    clip.offset = 0.75;
+    magda::test::audioEvent(clip).speedRatio = 1.0;
+    magda::test::audioEvent(clip).setLoopStartSeconds(0.25);
+    magda::test::audioEvent(clip).setAnchorSeconds(0.75);
 
     ClipOperations::sanitizeAudioToSourceDuration(clip, 8.0);
 
-    REQUIRE(clip.offset == Catch::Approx(0.75));
-    REQUIRE(clip.loopStart == Catch::Approx(0.25));
+    REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(0.75));
+    REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() == Catch::Approx(0.25));
 }
 
 TEST_CASE("ClipOperations - audio sanitizing clamps length through beat placement",
           "[clip][audio][offset][beats][regression]") {
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audio().source.filePath = "/tmp/magda_source_sanitize_beats.wav";
+    magda::test::giveAudioEvent(clip, "/tmp/magda_source_sanitize_beats.wav");
     clip.loopEnabled = false;
-    clip.autoTempo = false;
+    magda::test::audioEvent(clip).autoTempo = false;
     clip.startTime = 2.0;
     clip.length = 10.0;
     clip.setPlacementBeats(4.0, 20.0);
-    clip.speedRatio = 1.0;
-    clip.offset = 3.0;
+    magda::test::audioEvent(clip).speedRatio = 1.0;
+    magda::test::audioEvent(clip).setAnchorSeconds(3.0);
 
     ClipOperations::sanitizeAudioToSourceDuration(clip, 8.0, 120.0);
 
@@ -319,20 +320,20 @@ TEST_CASE("ClipOperations - non-loop offset drag preserves sample start and clam
           "[clip][audio][offset][regression]") {
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audio().source.filePath = "/tmp/magda_offset_drag_regression.wav";
+    magda::test::giveAudioEvent(clip, "/tmp/magda_offset_drag_regression.wav");
     clip.loopEnabled = false;
-    clip.autoTempo = false;
+    magda::test::audioEvent(clip).autoTempo = false;
     clip.startTime = 4.0;
     clip.length = 7.75;
     clip.setPlacementBeats(8.0, 15.5);
-    clip.speedRatio = 1.0;
-    clip.loopStart = 0.25;
-    clip.offset = 0.25;
+    magda::test::audioEvent(clip).speedRatio = 1.0;
+    magda::test::audioEvent(clip).setLoopStartSeconds(0.25);
+    magda::test::audioEvent(clip).setAnchorSeconds(0.25);
 
     ClipOperations::setAudioOffsetPreservingSourceRegion(clip, 0.75, 8.0, 120.0);
 
-    REQUIRE(clip.offset == Catch::Approx(0.75));
-    REQUIRE(clip.loopStart == Catch::Approx(0.25));
+    REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(0.75));
+    REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() == Catch::Approx(0.25));
     REQUIRE(clip.startTime == Catch::Approx(4.0));
     REQUIRE(clip.length == Catch::Approx(7.25));
     REQUIRE(clip.lengthBeats == Catch::Approx(14.5));
@@ -342,13 +343,13 @@ TEST_CASE("ClipDisplayInfo - non-loop source end stays fixed when offset clamps 
           "[clip][audio][offset][display][regression]") {
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audio().source.filePath = "/tmp/magda_offset_display_regression.wav";
+    magda::test::giveAudioEvent(clip, "/tmp/magda_offset_display_regression.wav");
     clip.loopEnabled = false;
-    clip.autoTempo = false;
+    magda::test::audioEvent(clip).autoTempo = false;
     clip.startTime = 0.0;
     clip.length = 8.0;
-    clip.speedRatio = 1.0;
-    clip.offset = 0.0;
+    magda::test::audioEvent(clip).speedRatio = 1.0;
+    magda::test::audioEvent(clip).setAnchorSeconds(0.0);
 
     ClipOperations::setAudioOffsetPreservingSourceRegion(clip, 1.0, 8.0, 120.0);
 
@@ -363,15 +364,15 @@ TEST_CASE("ClipOperations - non-loop right resize changes clip length only",
           "[clip][audio][resize][regression]") {
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audio().source.filePath = "/tmp/magda_right_resize_regression.wav";
+    magda::test::giveAudioEvent(clip, "/tmp/magda_right_resize_regression.wav");
     clip.loopEnabled = false;
-    clip.autoTempo = false;
+    magda::test::audioEvent(clip).autoTempo = false;
     clip.startTime = 0.0;
     clip.length = 2.0;
     clip.setPlacementBeats(0.0, 4.0);
-    clip.speedRatio = 1.0;
-    clip.loopStart = 0.25;
-    clip.offset = 0.5;
+    magda::test::audioEvent(clip).speedRatio = 1.0;
+    magda::test::audioEvent(clip).setLoopStartSeconds(0.25);
+    magda::test::audioEvent(clip).setAnchorSeconds(0.5);
 
     ClipOperations::resizeContainerFromRight(clip, 3.0, 120.0);
 
@@ -379,8 +380,8 @@ TEST_CASE("ClipOperations - non-loop right resize changes clip length only",
 
     REQUIRE(clip.length == Catch::Approx(3.0));
     REQUIRE(clip.lengthBeats == Catch::Approx(6.0));
-    REQUIRE(clip.offset == Catch::Approx(0.5));
-    REQUIRE(clip.loopStart == Catch::Approx(0.25));
+    REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(0.5));
+    REQUIRE(magda::test::audioEvent(clip).loopStartSeconds() == Catch::Approx(0.25));
     REQUIRE(displayInfo.offsetPositionSeconds + clip.getTimelineLength(120.0) ==
             Catch::Approx(3.5));
     REQUIRE(displayInfo.fileExtentTimeline() == Catch::Approx(8.0));
@@ -390,15 +391,17 @@ TEST_CASE("ClipOperations - phase drag clamps audio offset at zero",
           "[clip][audio][phase][regression]") {
     ClipInfo clip;
     clip.setAudioContent();
-    clip.audio().source.filePath = "/tmp/magda_phase_drag_regression.wav";
+    magda::test::giveAudioEvent(clip, "/tmp/magda_phase_drag_regression.wav");
     clip.loopEnabled = true;
-    clip.autoTempo = false;
-    clip.loopStart = -0.25;
-    clip.offset = 0.0;
+    magda::test::audioEvent(clip).autoTempo = false;
+    magda::test::audioEvent(clip).setLoopStartSeconds(0.0);
+    magda::test::audioEvent(clip).setAnchorSeconds(0.0);
 
-    ClipOperations::setAudioLoopPhaseClamped(clip, 0.1);
+    // Dragging the phase before the loop start would put the read position
+    // ahead of the file.
+    ClipOperations::setAudioLoopPhaseClamped(clip, -0.1);
 
-    REQUIRE(clip.offset == Catch::Approx(0.0));
+    REQUIRE(magda::test::audioEvent(clip).anchorSeconds() == Catch::Approx(0.0));
 }
 
 TEST_CASE("SetClipOffsetCommand - non-loop offset clamp restores length on undo",
@@ -412,23 +415,25 @@ TEST_CASE("SetClipOffsetCommand - non-loop offset clamp restores length on undo"
     REQUIRE(clip != nullptr);
 
     clip->loopEnabled = false;
-    clip->autoTempo = false;
-    clip->audio().source.durationSeconds = 8.0;
-    clip->offset = 0.0;
+    primaryEventOf(clip)->autoTempo = false;
+    magda::SourcePool::getInstance().seedFactsForTesting(primaryEventOf(clip)->sourceFilePath(),
+                                                         8.0, magda::test::kTestSourceSampleRate);
+    magda::SourcePool::getInstance().resolveFacts(primaryEventOf(clip)->sourceId);
+    primaryEventOf(clip)->setAnchorSeconds(0.0);
     clip->length = 8.0;
     clip->setPlacementBeats(0.0, 16.0);
 
     SetClipOffsetCommand cmd(clipId, 1.0);
     cmd.execute();
 
-    REQUIRE(clip->offset == Catch::Approx(1.0));
+    REQUIRE(primaryEventOf(clip)->anchorSeconds() == Catch::Approx(1.0));
     REQUIRE(clip->length == Catch::Approx(7.0));
 
     cmd.undo();
 
     clip = clipManager.getClip(clipId);
     REQUIRE(clip != nullptr);
-    REQUIRE(clip->offset == Catch::Approx(0.0));
+    REQUIRE(primaryEventOf(clip)->anchorSeconds() == Catch::Approx(0.0));
     REQUIRE(clip->length == Catch::Approx(8.0));
     REQUIRE(clip->lengthBeats == Catch::Approx(16.0));
 }


### PR DESCRIPTION
Closes #1901. Phase 0 of #1882.

Restructures the clip model into the three levels the plan compiler will be designed against, without changing any behaviour.

## The model

- **`Source`** — immutable file facts (path, duration, sample rate, detected BPM and key), pooled per file in `SourcePool` and deduplicated on canonical path. Additive within a session, so an undone clip deletion still finds its source; garbage collected at save.
- **`AudioEvent`** — the placement of a source inside a clip. Clip-relative geometry in beats; the read anchor and the loop region are the only source-domain values, held as samples at the source's own rate. Every field that said how the audio is interpreted (BPM, warp, stretch mode, pitch, reverse, fades, channels) moved here off `ClipInfo`.
- **`ClipInfo`** — the container: placement, launch properties, enabled, clip gain, and an ordered list of events.

Storing the source domain in samples removes the parallel beats/seconds representations the old model kept in sync by hand. A source-BPM reinterpretation now leaves the audible region untouched and simply re-reads its musical length, which is exactly what the old reconciliation code in `applyAudioClipBeats` was written to achieve.

## Container and content are the same extent

`setPlacementBeats` keeps a single-event clip's event spanning it, so every existing resize, trim and split path behaves as before. Multi-event clips are representable, serializable and testable, but nothing in the app builds one yet: slicing, comping without render and multi-event session clips switch on later.

## Serialization

v2, with permanent read support for v1 (all three of its historical layouts). Sources are written once per project and referenced by id; a v1 clip loads as a clip holding exactly one event spanning it. Anchors convert from the old seconds, or autoTempo beats, into samples. A file that cannot be opened migrates at a nominal rate and rescales on the first successful open. v2 files do not open in older builds; there is no downgrade path.

## Deliberately unchanged

To keep the split behaviour-neutral, three things I had planned differently in the issue comment are left alone:

- fades stay in **seconds** rather than beats
- warp markers keep their `{sourceTime, warpTime}` seconds pair
- the engine bridge still keys its id map on `ClipId`: one clip is one event is one TE clip, so a `(ClipId, EventId)` key would be churn with no behaviour behind it. It grows the `EventId` when multi-event clips do.

MIDI clips keep their content as it was, and takes and comping keep their render-based shape. The MIDI loop moved into `MidiClipModel` but stays per-instance across ghost-clip propagation, as it was when it sat on the clip.

## Bugs found on the way

- `SourcePool` built a `juce::File` from a possibly-relative path in two places, which asserts in debug.
- The pool clear sat in `ClipManager::clearAllClips`, which the project load path calls during its commit phase, **after** the incoming sources are staged. Every restored event's source id was left dangling. Clearing now happens where a project is actually replaced.
- Moving the MIDI loop into `MidiClipModel` put it inside the ghost-clip shared `content`, so a ghost's loop toggle started propagating to its siblings. `copySharedContentFrom` now keeps it per-instance.

## Testing

Full suite green: 1698 passed, 0 failed, 13 skipped, 163587 assertions.

Not covered by the suite, worth exercising on a real project before merge:

- the sample-rate probe path, which needs real audio on disk
- migrating a v1 project whose source file is missing (nominal-rate anchor, rescale on first successful open)
