### PR TITLE
Fix Faust factory presets missing when running the Linux AppImage (#1999)

### DIFF
--- a/magda/daw/audio/FaustResources.cpp
+++ b/magda/daw/audio/FaustResources.cpp
@@ -4,6 +4,8 @@
 #include <regex>
 #include <string>
 
+#include "core/AppPaths.hpp"
+
 namespace magda::daw::audio {
 
 namespace {
@@ -36,23 +38,30 @@ FaustPatchInfo readPatchInfo(const juce::String& source) {
 }
 
 juce::File getFaustLibrariesPath() {
-    auto exe = juce::File::getSpecialLocation(juce::File::currentApplicationFile);
 #if JUCE_MAC
     // currentApplicationFile is the .app bundle on macOS. Libraries live in
     // Contents/Resources/faustlibraries (matches CMake's POST_BUILD copy).
-    return exe.getChildFile("Contents/Resources/faustlibraries");
+    return juce::File::getSpecialLocation(juce::File::currentApplicationFile)
+        .getChildFile("Contents/Resources/faustlibraries");
 #else
-    // On Windows/Linux, libraries sit next to the executable.
-    return exe.getParentDirectory().getChildFile("faustlibraries");
+    // On Windows/Linux, libraries sit next to the executable. Go through
+    // paths::executableDir() rather than currentApplicationFile so this
+    // resolves inside the mount when running from a Linux AppImage — libfaust
+    // takes this as its -I path, so getting it wrong fails every
+    // import("stdfaust.lib").
+    return magda::paths::executableDir().getChildFile("faustlibraries");
 #endif
 }
 
 juce::File getFaustRuntimeDspPath() {
-    auto exe = juce::File::getSpecialLocation(juce::File::currentApplicationFile);
 #if JUCE_MAC
-    return exe.getChildFile("Contents/Resources/faust_dsp");
+    return juce::File::getSpecialLocation(juce::File::currentApplicationFile)
+        .getChildFile("Contents/Resources/faust_dsp");
 #else
-    return exe.getParentDirectory().getChildFile("faust_dsp");
+    // As above: currentApplicationFile points at the outer .AppImage launcher
+    // under an AppImage, which is why the factory starter DSPs showed up when
+    // running an extracted binary but not from the .AppImage itself (#1999).
+    return magda::paths::executableDir().getChildFile("faust_dsp");
 #endif
 }
 

--- a/magda/daw/core/AppPaths.cpp
+++ b/magda/daw/core/AppPaths.cpp
@@ -117,6 +117,19 @@ juce::File alwaysOSDefault() {
         .getChildFile("MAGDA");
 }
 
+juce::File executableDir() {
+#if JUCE_LINUX
+    // Prefer the real binary: JUCE's currentApplicationFile goes through dladdr,
+    // which on glibc yields argv[0] for the main program, and an AppImage's
+    // type-2 runtime keeps argv[0] pointing at the outer .AppImage. Resources
+    // staged inside the mount would otherwise be looked for next to the user's
+    // downloaded launcher. See the header for the full rationale.
+    if (auto real = juce::File("/proc/self/exe").getLinkedTarget(); real.exists())
+        return real.getParentDirectory();
+#endif
+    return juce::File::getSpecialLocation(juce::File::currentApplicationFile).getParentDirectory();
+}
+
 // ---------------------------------------------------------------------------
 // Computed subpaths
 // ---------------------------------------------------------------------------

--- a/magda/daw/core/AppPaths.hpp
+++ b/magda/daw/core/AppPaths.hpp
@@ -37,6 +37,25 @@ juce::File renderDir();
  *  is anchored here so the override can be read from it. */
 juce::File alwaysOSDefault();
 
+/** Directory holding the running executable, for resources the build stages
+ *  next to the binary (lang/, faustlibraries/, faust_dsp/, drumkits/,
+ *  controllers/, dawproject/, models/).
+ *
+ *  Use this rather than currentApplicationFile().getParentDirectory(): under a
+ *  Linux AppImage, JUCE's currentApplicationFile resolves via argv[0]/dladdr to
+ *  the OUTER .AppImage launcher, so resources are looked for beside the
+ *  downloaded launcher instead of inside the mount and silently come up empty.
+ *  /proc/self/exe always resolves to the real binary inside the mount. That is
+ *  why a bug reproduces from the .AppImage but not from an extracted
+ *  squashfs-root/usr/bin/ run, where the two paths happen to agree.
+ *
+ *  On macOS this is Contents/MacOS inside the bundle — callers wanting
+ *  Contents/Resources should keep their own bundle-relative branch.
+ *
+ *  Linux-only /proc use: BSD would need /proc/curproc/file and procfs is not
+ *  guaranteed to be mounted there. */
+juce::File executableDir();
+
 // ---------------------------------------------------------------------------
 // Computed subpaths under dataDir()
 // ---------------------------------------------------------------------------

--- a/magda/daw/project/serialization/DawProjectValidator.cpp
+++ b/magda/daw/project/serialization/DawProjectValidator.cpp
@@ -7,6 +7,8 @@
 #include <cstdio>
 #include <cstring>
 
+#include "core/AppPaths.hpp"
+
 namespace magda {
 namespace {
 
@@ -15,11 +17,15 @@ juce::File schemaDirectory() {
     // macOS, exe-adjacent elsewhere) via CMake's POST_BUILD copy + install rules.
     // Fall back to the build-tree source dir for dev runs and unit tests, where
     // nothing is staged alongside the executable.
-    auto exe = juce::File::getSpecialLocation(juce::File::currentApplicationFile);
 #if JUCE_MAC
-    auto bundled = exe.getChildFile("Contents/Resources/dawproject");
+    auto bundled = juce::File::getSpecialLocation(juce::File::currentApplicationFile)
+                       .getChildFile("Contents/Resources/dawproject");
 #else
-    auto bundled = exe.getParentDirectory().getChildFile("dawproject");
+    // paths::executableDir(), not currentApplicationFile: under a Linux
+    // AppImage the latter points at the outer launcher, so the staged XSDs
+    // would be missed and validation would silently fall through to the
+    // build-tree path below, which does not exist on a user's machine.
+    auto bundled = magda::paths::executableDir().getChildFile("dawproject");
 #endif
     if (bundled.isDirectory())
         return bundled;


### PR DESCRIPTION
Fixes #1999.

## What was happening

The folder-icon menu on a Faust device lists starter DSPs from `<exe dir>/faust_dsp/effects` (`FaustUI::showLoadMenu` → `getBundledStarterDsps`). That directory was resolved via JUCE's `currentApplicationFile`, which on Linux goes through `dladdr` and on glibc returns `argv[0]` for the main program. An AppImage's type-2 runtime keeps `argv[0]` pointing at the *outer* `.AppImage`, so the lookup landed next to the user's downloaded launcher, found nothing, and `getBundledStarterDsps` returned an empty list with no error or log.

Extracting the AppImage and running `squashfs-root/usr/bin/MAGDA` directly makes `argv[0]` the real binary path, which is why the presets showed up that way — the files were staged correctly all along, only the lookup was wrong.

## The fix

Every other resource lookup in the codebase already carried a `/proc/self/exe` fallback for exactly this reason — `StringTable`, `ControllerProfileRegistry`, `DrumkitManager`, `TranscriptionService`, `MediaCollector`, `LuaScriptStore`, `PluginScanCoordinator`. `FaustResources` was the one that didn't, which is why `lang/` and `drumkits/` work in the AppImage but Faust doesn't.

Rather than add an eighth hand-rolled copy, this puts it behind `magda::paths::executableDir()` and uses it for:

- **`getFaustRuntimeDspPath()`** — the reported bug.
- **`getFaustLibrariesPath()`** — same defect, quieter symptom. This is libfaust's `-I` path, so under the AppImage even a manually loaded `.dsp` would fail to compile on `import("stdfaust.lib")`.
- **`DawProjectValidator::schemaDirectory()`** — latent. It degraded to a build-tree path that doesn't exist on an end-user machine.

macOS keeps its bundle-relative `Contents/Resources` branch; `executableDir()` is `Contents/MacOS` there and deliberately not used for those.

## Testing

Build clean, full suite green (1711 cases / 163585 assertions / 0 failures), `origin/main` merged in and re-verified.

**Not verified end-to-end:** this only reproduces inside a real AppImage, which is produced by the release workflow. The check is to build an AppImage from this branch and confirm a Faust effect's folder menu lists the starter DSPs when run directly, without extracting.

## Out of scope

While tracing this I found that `presets/Devices/*.mps` (7 factory presets for Multiband Compressor and Multiband Dynamics) are staged nowhere — no `install()` rule, no `POST_BUILD` copy, no AppDir or Windows-installer step — and `PresetManager` only reads `~/Documents/MAGDA/Presets`, with no executable-relative component on any platform. Left alone here pending a decision on those presets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)