### PR TITLE
Native engine: render plan IR, compiler and canonical dump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,9 @@ option(MAGDA_BUILD_TESTS "Build tests" ON)
 option(MAGDA_BUILD_EXAMPLES "Build developer example tools (e.g. lua_smoke REPL)" OFF)
 option(MAGDA_BUILD_JUCE_ADAPTER "Build JUCE/Tracktion adapter" OFF)
 option(MAGDA_BUILD_FAUST_VEC_BENCH "Build the Faust scalar-vs-vector codegen benchmark" OFF)
+# The native engine (epic #1882) is dark: built and tested, never linked into
+# the app. On by default so it cannot drift away from the model it compiles.
+option(MAGDA_BUILD_NATIVE_ENGINE "Build the native audio engine target" ON)
 
 # CLAP semantic-search backend (ONNX Runtime). Forced off on Intel macOS because
 # upstream ORT dropped osx-x86_64 prebuilts in 1.26. The rest of the media DB
@@ -295,6 +298,12 @@ endif()
 add_subdirectory(magda/daw)
 add_subdirectory(magda/scripting)
 add_subdirectory(magda/agents)
+
+# Native audio engine — isolated from magda/daw on purpose, so it is added
+# after the model layer it compiles and links nothing else from it.
+if(MAGDA_BUILD_NATIVE_ENGINE)
+    add_subdirectory(magda/engine)
+endif()
 
 # Examples
 if(MAGDA_BUILD_EXAMPLES)

--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -1,0 +1,84 @@
+# MAGDA native audio engine (epic #1882).
+#
+# Dark target: nothing in the app links it yet. It is built on every configure
+# so it cannot rot, and it is deliberately isolated — the C++ standard library,
+# JUCE headers and the MAGDA model layer, nothing else. No Tracktion Engine, no
+# UI, no app services. The boundary check below enforces that at configure time
+# rather than leaving it to review.
+
+add_library(magda_engine STATIC
+    plan/RenderPlan.cpp
+    plan/PlanCompiler.cpp
+    plan/PlanDump.cpp
+    plan/RenderPlan.hpp
+    plan/PlanCompiler.hpp
+    plan/PlanDump.hpp
+)
+add_library(magda::engine ALIAS magda_engine)
+
+target_compile_features(magda_engine PUBLIC cxx_std_20)
+
+# magda_types carries the model-layer headers and publishes magda/daw as its
+# include root, so engine sources resolve "core/<model>.hpp".
+target_link_libraries(magda_engine PUBLIC magda_types)
+
+target_include_directories(magda_engine PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Borrow JUCE's headers and defines without linking the modules: the model
+# headers name juce::String and juce::Colour, and the juce_core / juce_graphics
+# unity sources are already compiled once in magda_daw, so the undefined
+# symbols resolve at the final link instead of duplicating those objects here.
+# Same arrangement magda_types uses.
+target_include_directories(magda_engine PRIVATE
+    $<TARGET_PROPERTY:juce::juce_core,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:juce::juce_graphics,INTERFACE_INCLUDE_DIRECTORIES>)
+target_compile_definitions(magda_engine PRIVATE
+    $<TARGET_PROPERTY:juce::juce_core,INTERFACE_COMPILE_DEFINITIONS>
+    $<TARGET_PROPERTY:juce::juce_graphics,INTERFACE_COMPILE_DEFINITIONS>)
+
+# --- Dependency boundary check -----------------------------------------------
+#
+# Angle-bracket includes may name the standard library or JUCE, never Tracktion
+# Engine. Quoted includes may only reach the model layer ("core/...") or the
+# engine's own headers.
+
+set(MAGDA_ENGINE_ALLOWED_QUOTED_PREFIXES "core/" "plan/")
+
+file(GLOB_RECURSE MAGDA_ENGINE_SOURCES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.hpp")
+
+foreach(_engine_source ${MAGDA_ENGINE_SOURCES})
+    file(RELATIVE_PATH _engine_relative "${CMAKE_SOURCE_DIR}" "${_engine_source}")
+    file(STRINGS "${_engine_source}" _engine_includes REGEX "^[ \t]*#[ \t]*include[ \t]*[<\"]")
+
+    foreach(_include_line ${_engine_includes})
+        string(REGEX REPLACE "^[ \t]*#[ \t]*include[ \t]*[<\"]([^>\"]+)[>\"].*$" "\\1"
+            _included_header "${_include_line}")
+
+        if(_included_header MATCHES "^tracktion")
+            message(FATAL_ERROR
+                "\n"
+                "Native engine boundary violation in ${_engine_relative}:\n"
+                "    includes \"${_included_header}\"\n"
+                "The engine is built to replace Tracktion Engine and must never depend on it.\n")
+        endif()
+
+        if(_include_line MATCHES "#[ \t]*include[ \t]*\"")
+            set(_include_allowed FALSE)
+            foreach(_allowed_prefix ${MAGDA_ENGINE_ALLOWED_QUOTED_PREFIXES})
+                if(_included_header MATCHES "^${_allowed_prefix}")
+                    set(_include_allowed TRUE)
+                endif()
+            endforeach()
+
+            if(NOT _include_allowed)
+                message(FATAL_ERROR
+                    "\n"
+                    "Native engine boundary violation in ${_engine_relative}:\n"
+                    "    includes \"${_included_header}\"\n"
+                    "The engine may only include the model layer (core/) and its own headers.\n")
+            endif()
+        endif()
+    endforeach()
+endforeach()

--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -1,7 +1,7 @@
 # MAGDA native audio engine (epic #1882).
 #
 # Dark target: nothing in the app links it yet. It is built on every configure
-# so it cannot rot, and it is deliberately isolated — the C++ standard library,
+# so it cannot rot, and it is deliberately isolated: the C++ standard library,
 # JUCE headers and the MAGDA model layer, nothing else. No Tracktion Engine, no
 # UI, no app services. The boundary check below enforces that at configure time
 # rather than leaving it to review.

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -1,0 +1,580 @@
+#include "plan/PlanCompiler.hpp"
+
+#include <algorithm>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "core/ChainRoutingModel.hpp"
+#include "core/RackInfo.hpp"
+#include "core/TrackChain.hpp"
+#include "core/TrackInfo.hpp"
+
+namespace magda::engine {
+namespace {
+
+/// The audio + MIDI pair flowing through a chain at one point.
+struct ChainSignal {
+    PortRef audio;
+    PortRef midi;
+};
+
+/// Where a chain element lives, for op keys. Only the innermost rack and chain
+/// are recorded: device ids are project-unique, so deeper nesting needs no
+/// further qualification.
+struct ChainSite {
+    TrackId trackId = INVALID_TRACK_ID;
+    RackId rackId = INVALID_RACK_ID;
+    ChainId chainId = INVALID_CHAIN_ID;
+};
+
+/// Analysis devices are transparent passthroughs with no gain trim and no
+/// meter of their own, so they compile to the process op alone.
+bool isTransparentTap(const DeviceInfo& device) {
+    return device.deviceType == DeviceType::Analysis;
+}
+
+bool consumesMidi(const DeviceInfo& device) {
+    return device.isInstrument || device.canReceiveMidi || device.deviceType == DeviceType::MIDI;
+}
+
+bool elementsConsumeMidi(const std::vector<ChainElement>& elements) {
+    return std::ranges::any_of(elements, [](const ChainElement& element) {
+        if (isDevice(element))
+            return consumesMidi(getDevice(element));
+        if (isRack(element))
+            return std::ranges::any_of(getRack(element).chains, [](const ChainInfo& chain) {
+                return elementsConsumeMidi(chain.elements);
+            });
+        return false;
+    });
+}
+
+bool chainConsumesMidi(const TrackInfo& track) {
+    return elementsConsumeMidi(track.chain.fxChainElements) ||
+           std::ranges::any_of(
+               track.chain.postFxChainElements,
+               [](const PostFxChainElement& element) { return consumesMidi(element.device); });
+}
+
+/// Tracks whose signal a device in `elements` reads as a sidechain input.
+/// `type` narrows the search to audio or MIDI sidechains; nullopt takes both.
+void collectSidechainSources(const std::vector<ChainElement>& elements,
+                             std::optional<SidechainConfig::Type> type, std::set<TrackId>& out) {
+    const auto collect = [&](const SidechainConfig& sidechain) {
+        if (sidechain.isActive() && (!type.has_value() || sidechain.type == *type))
+            out.insert(sidechain.sourceTrackId);
+    };
+
+    for (const auto& element : elements) {
+        if (isDevice(element)) {
+            collect(getDevice(element).sidechain);
+        } else if (isRack(element)) {
+            for (const auto& chain : getRack(element).chains)
+                collectSidechainSources(chain.elements, type, out);
+        }
+    }
+}
+
+void collectSidechainSources(const TrackInfo& track, std::optional<SidechainConfig::Type> type,
+                             std::set<TrackId>& out) {
+    collectSidechainSources(track.chain.fxChainElements, type, out);
+    for (const auto& element : track.chain.postFxChainElements)
+        if (element.device.sidechain.isActive() &&
+            (!type.has_value() || element.device.sidechain.type == *type))
+            out.insert(element.device.sidechain.sourceTrackId);
+}
+
+/// The track a track's audio output feeds. "track:<id>" routes into a group;
+/// everything else (including the default "master" and an empty string) goes
+/// straight to the master track.
+TrackId resolveAudioDestination(const TrackInfo& track) {
+    const auto& routing = track.audioOutputDevice;
+    if (routing.startsWith("track:")) {
+        const auto id = routing.substring(6);
+        if (id.isNotEmpty() && id.containsOnly("-0123456789"))
+            return id.getIntValue();
+    }
+    return MASTER_TRACK_ID;
+}
+
+class Compiler {
+  public:
+    Compiler(const std::vector<TrackInfo>& tracks, const TrackInfo& master,
+             const CompileOptions& options)
+        : tracks_(tracks), master_(master), options_(options) {}
+
+    RenderPlan run();
+
+  private:
+    OpId addOp(OpKind kind, const OpKey& key, std::vector<PortRef> inputs,
+               std::vector<SignalKind> outputs);
+    void diagnose(std::string message);
+
+    const TrackInfo* findTrack(TrackId id) const;
+    TrackId resolveSendDestination(const SendInfo& send) const;
+    std::vector<const TrackInfo*> computeTrackOrder();
+
+    void emitTrack(const TrackInfo& track);
+    ChainSignal emitElements(const std::vector<ChainElement>& elements, const ChainSite& site,
+                             ChainSignal signal);
+    ChainSignal emitDevice(const DeviceInfo& device, const ChainSite& site, ChainSignal signal);
+    ChainSignal emitRack(const RackInfo& rack, const ChainSite& site, ChainSignal signal);
+
+    /// Sums `sources` into one audio port, always through an op so the op's
+    /// identity survives sources appearing and disappearing.
+    PortRef emitMix(const OpKey& key, const std::vector<PortRef>& sources);
+
+    const std::vector<TrackInfo>& tracks_;
+    const TrackInfo& master_;
+    CompileOptions options_;
+
+    RenderPlan plan_;
+    /// Post-fader output of each emitted track: audio sidechain sources read it.
+    std::map<TrackId, PortRef> trackOutput_;
+    /// Chain-head MIDI of each emitted track: MIDI sidechain sources read it.
+    std::map<TrackId, PortRef> trackMidiInput_;
+    /// Signals waiting to be summed into a track that has not been emitted yet:
+    /// child track outputs and incoming send taps.
+    std::map<TrackId, std::vector<PortRef>> pendingInputs_;
+    /// Tracks another track's device reads MIDI from. Their MIDI clips have to
+    /// be compiled even when their own chain has nothing that consumes MIDI.
+    std::set<TrackId> midiSidechainSources_;
+};
+
+OpId Compiler::addOp(OpKind kind, const OpKey& key, std::vector<PortRef> inputs,
+                     std::vector<SignalKind> outputs) {
+    PlanOp op;
+    op.kind = kind;
+    op.key = key;
+    op.inputs = std::move(inputs);
+    op.outputs = std::move(outputs);
+
+    // Liveness flows downstream: an op is live if it reads anything live. Live
+    // sources set their own domain at the call site.
+    op.liveness = LivenessDomain::Deterministic;
+    for (const auto& input : op.inputs) {
+        if (input.valid() &&
+            plan_.ops[static_cast<std::size_t>(input.op)].liveness == LivenessDomain::Live) {
+            op.liveness = LivenessDomain::Live;
+            break;
+        }
+    }
+
+    plan_.ops.push_back(std::move(op));
+    return static_cast<OpId>(plan_.ops.size()) - 1;
+}
+
+void Compiler::diagnose(std::string message) {
+    plan_.diagnostics.push_back(std::move(message));
+}
+
+const TrackInfo* Compiler::findTrack(TrackId id) const {
+    if (id == master_.id)
+        return &master_;
+    const auto found =
+        std::ranges::find_if(tracks_, [id](const TrackInfo& track) { return track.id == id; });
+    return found == tracks_.end() ? nullptr : &*found;
+}
+
+TrackId Compiler::resolveSendDestination(const SendInfo& send) const {
+    if (send.destTrackId != INVALID_TRACK_ID)
+        return send.destTrackId;
+
+    // Older projects stored the aux bus index only.
+    const auto found = std::ranges::find_if(tracks_, [&send](const TrackInfo& track) {
+        return track.auxBusIndex >= 0 && track.auxBusIndex == send.busIndex;
+    });
+    return found == tracks_.end() ? INVALID_TRACK_ID : found->id;
+}
+
+std::vector<const TrackInfo*> Compiler::computeTrackOrder() {
+    const auto numTracks = tracks_.size();
+    std::map<TrackId, std::size_t> indexById;
+    for (std::size_t i = 0; i < numTracks; ++i)
+        indexById[tracks_[i].id] = i;
+
+    // The chord track is a monitor-only progression lane and never renders.
+    std::vector<bool> skipped(numTracks, false);
+    for (std::size_t i = 0; i < numTracks; ++i)
+        skipped[i] = tracks_[i].type == TrackType::Chord;
+
+    std::vector<std::vector<std::size_t>> successors(numTracks);
+    std::vector<int> indegree(numTracks, 0);
+    auto addEdge = [&](std::size_t from, std::size_t to) {
+        if (from == to || skipped[from] || skipped[to])
+            return;
+        successors[from].push_back(to);
+        ++indegree[to];
+    };
+    auto indexOf = [&](TrackId id) -> long {
+        const auto it = indexById.find(id);
+        return it == indexById.end() ? -1 : static_cast<long>(it->second);
+    };
+
+    for (std::size_t i = 0; i < numTracks; ++i) {
+        const auto& track = tracks_[i];
+        if (skipped[i])
+            continue;
+
+        // A track's audio has to exist before whatever sums it.
+        if (const auto destination = indexOf(resolveAudioDestination(track)); destination >= 0)
+            addEdge(i, static_cast<std::size_t>(destination));
+
+        for (const auto& send : track.sends)
+            if (const auto destination = indexOf(resolveSendDestination(send)); destination >= 0)
+                addEdge(i, static_cast<std::size_t>(destination));
+
+        // Sidechain and multi-out read another track, so that track comes first.
+        std::set<TrackId> sidechainSources;
+        collectSidechainSources(track, std::nullopt, sidechainSources);
+        for (const auto sourceId : sidechainSources)
+            if (const auto source = indexOf(sourceId); source >= 0)
+                addEdge(static_cast<std::size_t>(source), i);
+
+        if (track.multiOutLink)
+            if (const auto source = indexOf(track.multiOutLink->sourceTrackId); source >= 0)
+                addEdge(static_cast<std::size_t>(source), i);
+    }
+
+    std::set<std::size_t> ready;
+    std::vector<bool> emitted(numTracks, false);
+    std::size_t remaining = 0;
+    for (std::size_t i = 0; i < numTracks; ++i) {
+        if (skipped[i])
+            continue;
+        ++remaining;
+        if (indegree[i] == 0)
+            ready.insert(i);
+    }
+
+    std::vector<const TrackInfo*> order;
+    order.reserve(remaining);
+    while (order.size() < remaining) {
+        if (ready.empty()) {
+            // Every remaining track waits on another remaining track. Force the
+            // lowest-numbered one and drop the connections that close the cycle.
+            for (std::size_t i = 0; i < numTracks; ++i) {
+                if (skipped[i] || emitted[i])
+                    continue;
+                diagnose("routing cycle through track " + std::to_string(tracks_[i].id) +
+                         ": compiled ahead of its sources, connections closing the cycle dropped");
+                indegree[i] = 0;
+                ready.insert(i);
+                break;
+            }
+        }
+
+        const auto next = *ready.begin();
+        ready.erase(ready.begin());
+        emitted[next] = true;
+        order.push_back(&tracks_[next]);
+        for (const auto successor : successors[next])
+            if (--indegree[successor] == 0 && !emitted[successor])
+                ready.insert(successor);
+    }
+
+    return order;
+}
+
+PortRef Compiler::emitMix(const OpKey& key, const std::vector<PortRef>& sources) {
+    return PortRef{addOp(OpKind::MixAudio, key, sources, {SignalKind::Audio}), 0};
+}
+
+ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site,
+                                 ChainSignal signal) {
+    if (device.bypassed)
+        return signal;
+
+    const auto node = routing::makeRoutingNode(device);
+
+    PortRef midiIn;
+    if (node.usesExternalMidiSidechain()) {
+        const auto source = trackMidiInput_.find(node.midiSidechainSourceTrackId);
+        if (source != trackMidiInput_.end())
+            midiIn = source->second;
+        else
+            diagnose("device " + std::to_string(device.id) + " on track " +
+                     std::to_string(site.trackId) + ": MIDI sidechain source track " +
+                     std::to_string(node.midiSidechainSourceTrackId) + " produces no MIDI");
+    } else if (node.receivesChainMidi()) {
+        midiIn = signal.midi;
+    }
+
+    PortRef sidechainIn;
+    if (device.sidechain.type == SidechainConfig::Type::Audio && device.sidechain.isActive()) {
+        const auto source = trackOutput_.find(device.sidechain.sourceTrackId);
+        if (source != trackOutput_.end())
+            sidechainIn = source->second;
+        else
+            diagnose("device " + std::to_string(device.id) + " on track " +
+                     std::to_string(site.trackId) + ": audio sidechain source track " +
+                     std::to_string(device.sidechain.sourceTrackId) + " is not routed");
+    }
+
+    const auto producesMidi = node.outputsPluginMidi();
+    std::vector<SignalKind> outputs{SignalKind::Audio};
+    if (producesMidi)
+        outputs.push_back(SignalKind::Midi);
+
+    OpKey key{site.trackId, site.rackId, site.chainId, device.id, OpRole::DeviceProcess, 0};
+    const auto processOp =
+        addOp(OpKind::Device, key, {signal.audio, midiIn, sidechainIn}, std::move(outputs));
+
+    ChainSignal out;
+    out.audio = PortRef{processOp, 0};
+
+    if (!isTransparentTap(device)) {
+        key.role = OpRole::DeviceGain;
+        out.audio = PortRef{addOp(OpKind::Gain, key, {out.audio}, {SignalKind::Audio}), 0};
+
+        if (options_.deviceMeters) {
+            key.role = OpRole::DeviceMeter;
+            out.audio = PortRef{addOp(OpKind::Meter, key, {out.audio}, {SignalKind::Audio}), 0};
+        }
+    }
+
+    out.midi = signal.midi;
+    if (producesMidi) {
+        const PortRef deviceMidi{processOp, 1};
+        if (node.passesRawMidiInput() && signal.midi.valid()) {
+            key.role = OpRole::ChainMidiMerge;
+            out.midi = PortRef{
+                addOp(OpKind::MergeMidi, key, {signal.midi, deviceMidi}, {SignalKind::Midi}), 0};
+        } else {
+            out.midi = deviceMidi;
+        }
+    }
+
+    return out;
+}
+
+ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, ChainSignal signal) {
+    if (rack.bypassed)
+        return signal;
+
+    std::vector<PortRef> chainAudio;
+    std::vector<PortRef> chainMidi;
+
+    for (const auto& chain : rack.chains) {
+        if (chain.outputIndex != 0) {
+            // Rack aux outputs feed multi-out tracks, which this compiler does
+            // not wire yet. Compiling nothing for the chain is wrong in a
+            // visible way; compiling it into the main mix would be wrong
+            // silently, and compiling it nowhere would leave dead ops behind.
+            diagnose("rack " + std::to_string(rack.id) + " chain " + std::to_string(chain.id) +
+                     ": aux output " + std::to_string(chain.outputIndex) + " is not routed yet");
+            continue;
+        }
+
+        const ChainSite chainSite{site.trackId, rack.id, chain.id};
+
+        auto chainSignal = signal;
+        if (!chain.bypassed)
+            chainSignal = emitElements(chain.elements, chainSite, chainSignal);
+
+        const OpKey faderKey{site.trackId,           rack.id, chain.id, INVALID_DEVICE_ID,
+                             OpRole::RackChainFader, 0};
+        const PortRef chainOut{
+            addOp(OpKind::Fader, faderKey, {chainSignal.audio}, {SignalKind::Audio}), 0};
+
+        chainAudio.push_back(chainOut);
+        // A chain that leaves the MIDI stream untouched is transparent to it;
+        // only chains that generate MIDI contribute to the rack's MIDI output.
+        if (chainSignal.midi.valid() && !(chainSignal.midi == signal.midi))
+            chainMidi.push_back(chainSignal.midi);
+    }
+
+    ChainSignal out;
+    const OpKey mixKey{site.trackId,      rack.id,         INVALID_CHAIN_ID,
+                       INVALID_DEVICE_ID, OpRole::RackMix, 0};
+    const auto mixed = emitMix(mixKey, chainAudio);
+
+    const OpKey faderKey{site.trackId,      rack.id,           INVALID_CHAIN_ID,
+                         INVALID_DEVICE_ID, OpRole::RackFader, 0};
+    out.audio = PortRef{addOp(OpKind::Fader, faderKey, {mixed}, {SignalKind::Audio}), 0};
+
+    if (chainMidi.empty()) {
+        out.midi = signal.midi;
+    } else if (chainMidi.size() == 1) {
+        out.midi = chainMidi.front();
+    } else {
+        const OpKey midiKey{site.trackId,        rack.id, INVALID_CHAIN_ID, INVALID_DEVICE_ID,
+                            OpRole::RackMidiMix, 0};
+        out.midi = PortRef{addOp(OpKind::MergeMidi, midiKey, chainMidi, {SignalKind::Midi}), 0};
+    }
+
+    return out;
+}
+
+ChainSignal Compiler::emitElements(const std::vector<ChainElement>& elements, const ChainSite& site,
+                                   ChainSignal signal) {
+    for (const auto& element : elements) {
+        if (isDevice(element))
+            signal = emitDevice(getDevice(element), site, signal);
+        else if (isRack(element))
+            signal = emitRack(getRack(element), site, signal);
+    }
+    return signal;
+}
+
+void Compiler::emitTrack(const TrackInfo& track) {
+    const auto isMaster = track.id == master_.id;
+    const ChainSite site{track.id, INVALID_RACK_ID, INVALID_CHAIN_ID};
+
+    // --- chain head ---
+
+    // Aux, Group, MultiOut and Master tracks carry no clips: everything they
+    // render arrives from elsewhere.
+    const auto carriesClips = !isMaster && track.type != TrackType::Aux &&
+                              track.type != TrackType::Group && track.type != TrackType::MultiOut;
+
+    if (track.multiOutLink)
+        diagnose("track " + std::to_string(track.id) + ": multi-out pair " +
+                 std::to_string(track.multiOutLink->outputPairIndex) + " of device " +
+                 std::to_string(track.multiOutLink->sourceDeviceId) +
+                 " is not routed yet, the track renders silence");
+
+    std::vector<PortRef> audioSources;
+    if (carriesClips) {
+        const OpKey key{track.id,          INVALID_RACK_ID,   INVALID_CHAIN_ID,
+                        INVALID_DEVICE_ID, OpRole::ClipAudio, 0};
+        audioSources.push_back(PortRef{addOp(OpKind::ClipAudio, key, {}, {SignalKind::Audio}), 0});
+    }
+
+    const auto monitorsInput = track.recordArmed || track.inputMonitor != InputMonitorMode::Off;
+    if (carriesClips && monitorsInput && track.audioInputDevice.isNotEmpty()) {
+        const OpKey key{track.id,          INVALID_RACK_ID,        INVALID_CHAIN_ID,
+                        INVALID_DEVICE_ID, OpRole::LiveAudioInput, 0};
+        const auto op = addOp(OpKind::AudioInput, key, {}, {SignalKind::Audio});
+        plan_.ops[static_cast<std::size_t>(op)].liveness = LivenessDomain::Live;
+        audioSources.push_back(PortRef{op, 0});
+    }
+
+    if (const auto pending = pendingInputs_.find(track.id); pending != pendingInputs_.end()) {
+        audioSources.insert(audioSources.end(), pending->second.begin(), pending->second.end());
+        pendingInputs_.erase(pending);
+    }
+
+    const OpKey inputKey{track.id,          INVALID_RACK_ID,         INVALID_CHAIN_ID,
+                         INVALID_DEVICE_ID, OpRole::TrackAudioInput, 0};
+    ChainSignal signal;
+    signal.audio = emitMix(inputKey, audioSources);
+
+    std::vector<PortRef> midiSources;
+    if (carriesClips && (chainConsumesMidi(track) || midiSidechainSources_.contains(track.id))) {
+        const OpKey key{track.id,          INVALID_RACK_ID,  INVALID_CHAIN_ID,
+                        INVALID_DEVICE_ID, OpRole::ClipMidi, 0};
+        midiSources.push_back(PortRef{addOp(OpKind::ClipMidi, key, {}, {SignalKind::Midi}), 0});
+    }
+    if (carriesClips && track.receivesLiveMidiInput() && track.midiInputDevice.isNotEmpty()) {
+        const OpKey key{track.id,          INVALID_RACK_ID,       INVALID_CHAIN_ID,
+                        INVALID_DEVICE_ID, OpRole::LiveMidiInput, 0};
+        const auto op = addOp(OpKind::MidiInput, key, {}, {SignalKind::Midi});
+        plan_.ops[static_cast<std::size_t>(op)].liveness = LivenessDomain::Live;
+        midiSources.push_back(PortRef{op, 0});
+    }
+    if (!midiSources.empty()) {
+        const OpKey key{track.id,          INVALID_RACK_ID,        INVALID_CHAIN_ID,
+                        INVALID_DEVICE_ID, OpRole::TrackMidiInput, 0};
+        signal.midi = PortRef{addOp(OpKind::MergeMidi, key, midiSources, {SignalKind::Midi}), 0};
+        trackMidiInput_[track.id] = signal.midi;
+    }
+
+    // --- chain ---
+
+    // Chain power gates the whole insert chain without touching the devices'
+    // own bypass flags. Post-FX and mixer analysis sit outside it.
+    if (track.chain.enabled)
+        signal = emitElements(track.chain.fxChainElements, site, signal);
+
+    for (const auto& element : track.chain.postFxChainElements)
+        signal = emitDevice(element.device, site, signal);
+    for (const auto& element : track.chain.mixerAnalysisElements)
+        signal = emitDevice(element.device, site, signal);
+
+    // --- fader, sends, meter ---
+
+    auto emitSends = [&](bool preFader, PortRef source) {
+        for (std::size_t slot = 0; slot < track.sends.size(); ++slot) {
+            const auto& send = track.sends[slot];
+            if (send.preFader != preFader)
+                continue;
+
+            const auto destination = resolveSendDestination(send);
+            if (destination == INVALID_TRACK_ID) {
+                diagnose("track " + std::to_string(track.id) + " send " + std::to_string(slot) +
+                         ": no destination track for aux bus " + std::to_string(send.busIndex));
+                continue;
+            }
+
+            const OpKey key{track.id,          INVALID_RACK_ID, INVALID_CHAIN_ID,
+                            INVALID_DEVICE_ID, OpRole::SendTap, static_cast<int>(slot)};
+            const auto op = addOp(OpKind::SendTap, key, {source}, {SignalKind::Audio});
+            pendingInputs_[destination].push_back(PortRef{op, 0});
+        }
+    };
+
+    emitSends(true, signal.audio);
+
+    const OpKey faderKey{track.id,          INVALID_RACK_ID,    INVALID_CHAIN_ID,
+                         INVALID_DEVICE_ID, OpRole::TrackFader, 0};
+    PortRef out{addOp(OpKind::Fader, faderKey, {signal.audio}, {SignalKind::Audio}), 0};
+
+    emitSends(false, out);
+
+    const OpKey meterKey{track.id,          INVALID_RACK_ID,    INVALID_CHAIN_ID,
+                         INVALID_DEVICE_ID, OpRole::TrackMeter, 0};
+    out = PortRef{addOp(OpKind::Meter, meterKey, {out}, {SignalKind::Audio}), 0};
+    trackOutput_[track.id] = out;
+
+    // --- output routing ---
+
+    if (isMaster) {
+        const OpKey outputKey{track.id,          INVALID_RACK_ID,        INVALID_CHAIN_ID,
+                              INVALID_DEVICE_ID, OpRole::HardwareOutput, 0};
+        plan_.outputOps.push_back(addOp(OpKind::Output, outputKey, {out}, {}));
+        return;
+    }
+
+    const auto destination = resolveAudioDestination(track);
+    if (destination != master_.id && findTrack(destination) == nullptr) {
+        diagnose("track " + std::to_string(track.id) + ": output routes to missing track " +
+                 std::to_string(destination) + ", summed into the master instead");
+        pendingInputs_[master_.id].push_back(out);
+        return;
+    }
+    pendingInputs_[destination].push_back(out);
+}
+
+RenderPlan Compiler::run() {
+    // A track feeding someone else's MIDI sidechain has to produce MIDI even
+    // when nothing in its own chain consumes it, so this is collected up front.
+    for (const auto& track : tracks_)
+        collectSidechainSources(track, SidechainConfig::Type::MIDI, midiSidechainSources_);
+    collectSidechainSources(master_, SidechainConfig::Type::MIDI, midiSidechainSources_);
+
+    for (const auto* track : computeTrackOrder())
+        emitTrack(*track);
+    emitTrack(master_);
+
+    // Anything still queued belongs to a track that was compiled before its
+    // source, which only happens when a routing cycle was broken above.
+    for (const auto& [trackId, inputs] : pendingInputs_)
+        diagnose("track " + std::to_string(trackId) + ": " + std::to_string(inputs.size()) +
+                 " incoming connection(s) arrived after it was compiled and are not connected");
+
+    bakeScheduling(plan_);
+    return std::move(plan_);
+}
+
+}  // namespace
+
+RenderPlan compileRenderPlan(const std::vector<TrackInfo>& tracks, const TrackInfo& master,
+                             const CompileOptions& options) {
+    return Compiler(tracks, master, options).run();
+}
+
+}  // namespace magda::engine

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -40,23 +40,42 @@ bool consumesMidi(const DeviceInfo& device) {
     return device.isInstrument || device.canReceiveMidi || device.deviceType == DeviceType::MIDI;
 }
 
+/// True when a chain inside a rack will be compiled at all. Aux-routed chains
+/// are not wired yet, and bypassed ones contribute nothing.
+bool chainIsActive(const ChainInfo& chain) {
+    return !chain.bypassed && chain.outputIndex == 0;
+}
+
+/// Whether anything the compiler will actually emit consumes MIDI. Walks only
+/// the live elements, so a bypassed instrument does not keep the track's MIDI
+/// source ops in the plan with nothing to read them.
 bool elementsConsumeMidi(const std::vector<ChainElement>& elements) {
     return std::ranges::any_of(elements, [](const ChainElement& element) {
-        if (isDevice(element))
-            return consumesMidi(getDevice(element));
-        if (isRack(element))
-            return std::ranges::any_of(getRack(element).chains, [](const ChainInfo& chain) {
-                return elementsConsumeMidi(chain.elements);
+        if (isDevice(element)) {
+            const auto& device = getDevice(element);
+            return !device.bypassed && consumesMidi(device);
+        }
+        if (isRack(element)) {
+            const auto& rack = getRack(element);
+            return !rack.bypassed && std::ranges::any_of(rack.chains, [](const ChainInfo& chain) {
+                return chainIsActive(chain) && elementsConsumeMidi(chain.elements);
             });
+        }
         return false;
     });
 }
 
+bool sectionConsumesMidi(const std::vector<PostFxChainElement>& section) {
+    return std::ranges::any_of(section, [](const PostFxChainElement& element) {
+        return !element.device.bypassed && consumesMidi(element.device);
+    });
+}
+
 bool chainConsumesMidi(const TrackInfo& track) {
-    return elementsConsumeMidi(track.chain.fxChainElements) ||
-           std::ranges::any_of(
-               track.chain.postFxChainElements,
-               [](const PostFxChainElement& element) { return consumesMidi(element.device); });
+    // Chain power gates the insert chain; the flat sections sit outside it.
+    return (track.chain.enabled && elementsConsumeMidi(track.chain.fxChainElements)) ||
+           sectionConsumesMidi(track.chain.postFxChainElements) ||
+           sectionConsumesMidi(track.chain.mixerAnalysisElements);
 }
 
 /// Tracks whose signal a device in `elements` reads as a sidechain input.
@@ -82,23 +101,31 @@ void collectSidechainSources(const std::vector<ChainElement>& elements,
             if (rack.bypassed)
                 continue;
             for (const auto& chain : rack.chains)
-                if (!chain.bypassed && chain.outputIndex == 0)
+                if (chainIsActive(chain))
                     collectSidechainSources(chain.elements, type, out);
         }
     }
 }
 
-void collectSidechainSources(const TrackInfo& track, std::optional<SidechainConfig::Type> type,
-                             std::set<TrackId>& out) {
-    // Chain power gates the insert chain; post-FX sits outside it. This mirrors
-    // the emission rules exactly, which is the point.
-    if (track.chain.enabled)
-        collectSidechainSources(track.chain.fxChainElements, type, out);
-
-    for (const auto& element : track.chain.postFxChainElements)
+void collectSidechainSources(const std::vector<PostFxChainElement>& section,
+                             std::optional<SidechainConfig::Type> type, std::set<TrackId>& out) {
+    for (const auto& element : section)
         if (!element.device.bypassed && element.device.sidechain.isActive() &&
             (!type.has_value() || element.device.sidechain.type == *type))
             out.insert(element.device.sidechain.sourceTrackId);
+}
+
+void collectSidechainSources(const TrackInfo& track, std::optional<SidechainConfig::Type> type,
+                             std::set<TrackId>& out) {
+    // Chain power gates the insert chain; the flat sections sit outside it.
+    // This walks exactly what emitTrack emits, which is the point: emission
+    // resolves a sidechain on any device in any section, so collection has to
+    // reach every section too or the two can silently drift apart.
+    if (track.chain.enabled)
+        collectSidechainSources(track.chain.fxChainElements, type, out);
+
+    collectSidechainSources(track.chain.postFxChainElements, type, out);
+    collectSidechainSources(track.chain.mixerAnalysisElements, type, out);
 }
 
 /// What a routing field resolves to. Malformed is deliberately distinct from
@@ -667,6 +694,16 @@ void Compiler::emitTrack(const TrackInfo& track) {
                          ": no destination track for aux bus " + std::to_string(send.busIndex));
                 continue;
             }
+            // A stored destTrackId is taken on trust by resolveSendDestination.
+            // If the track is gone, the tap would queue against a track that is
+            // never compiled and the end-of-run sweep would report it as a
+            // connection lost to a routing cycle, which is not what happened.
+            if (findTrack(destination) == nullptr) {
+                diagnose("track " + std::to_string(track.id) + " send " + std::to_string(slot) +
+                         ": destination track " + std::to_string(destination) +
+                         " does not exist, send not connected");
+                continue;
+            }
 
             const OpKey key{track.id,          INVALID_RACK_ID, INVALID_CHAIN_ID,
                             INVALID_DEVICE_ID, OpRole::SendTap, static_cast<int>(slot)};
@@ -699,6 +736,17 @@ void Compiler::emitTrack(const TrackInfo& track) {
         const OpKey outputKey{track.id,          INVALID_RACK_ID,        INVALID_CHAIN_ID,
                               INVALID_DEVICE_ID, OpRole::HardwareOutput, 0};
         plan_.outputOps.push_back(addOp(OpKind::Output, outputKey, {out}, {}));
+        return;
+    }
+
+    // A malformed output routing is reported for the same reason a malformed
+    // input routing is: the master fallback is a sane default for ordering, but
+    // silently applying it here would hide a broken route.
+    if (parseTrackRoute(track.audioOutputDevice).kind == RouteKind::Malformed) {
+        diagnose("track " + std::to_string(track.id) + ": output routing '" +
+                 track.audioOutputDevice.toStdString() +
+                 "' does not name a track, summed into the master instead");
+        pendingInputs_[master_.id].push_back(out);
         return;
     }
 

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -101,28 +101,35 @@ void collectSidechainSources(const TrackInfo& track, std::optional<SidechainConf
             out.insert(element.device.sidechain.sourceTrackId);
 }
 
-/// The track id in a "track:<id>" routing string, or nullopt for a hardware
-/// device name, the default "master", or an empty field.
-std::optional<TrackId> parseTrackReference(const juce::String& routing) {
+/// What a routing field resolves to. Malformed is deliberately distinct from
+/// External: a broken "track:..." value is a broken internal route, and
+/// collapsing the two would quietly reinterpret it as a hardware device or as
+/// the default master routing instead of reporting it. None means the track
+/// does not read that input at all, so there is nothing to route or report.
+enum class RouteKind { None, External, Track, Malformed };
+
+struct TrackRoute {
+    RouteKind kind = RouteKind::External;
+    TrackId trackId = INVALID_TRACK_ID;
+
+    bool namesTrack() const {
+        return kind == RouteKind::Track;
+    }
+};
+
+/// Parses a routing field: "track:<id>" for an internal route, anything else
+/// (a hardware device name, the default "master", an empty field) is external.
+TrackRoute parseTrackRoute(const juce::String& routing) {
     if (!routing.startsWith("track:"))
-        return std::nullopt;
+        return {RouteKind::External, INVALID_TRACK_ID};
 
     const auto id = routing.substring(6).trim();
-    if (id.isEmpty() || !id.containsOnly("-0123456789"))
-        return std::nullopt;
-    // Rejects "1-2" and bare "-": getIntValue would silently take the leading
-    // digits and route the signal at a track that was never selected.
-    if (juce::String(id.getIntValue()) != id)
-        return std::nullopt;
+    // Rejects "1-2" and a bare "-": getIntValue would take the leading digits
+    // and point the signal at a track that was never selected.
+    if (id.isEmpty() || !id.containsOnly("-0123456789") || juce::String(id.getIntValue()) != id)
+        return {RouteKind::Malformed, INVALID_TRACK_ID};
 
-    return id.getIntValue();
-}
-
-/// The track a track's audio output feeds. "track:<id>" routes into a group;
-/// everything else (including the default "master" and an empty string) goes
-/// straight to the master track.
-TrackId resolveAudioDestination(const TrackInfo& track) {
-    return parseTrackReference(track.audioOutputDevice).value_or(MASTER_TRACK_ID);
+    return {RouteKind::Track, id.getIntValue()};
 }
 
 class Compiler {
@@ -141,6 +148,21 @@ class Compiler {
     const TrackInfo* findTrack(TrackId id) const;
     TrackId resolveSendDestination(const SendInfo& send) const;
     std::vector<const TrackInfo*> computeTrackOrder();
+
+    /// Whether the track has clips and inputs of its own. Aux, Group, MultiOut
+    /// and Master tracks only pass on what reaches them from elsewhere.
+    bool carriesClips(const TrackInfo& track) const;
+
+    /// The routing each input field resolves to, already gated on whether the
+    /// track will actually read it. Ordering discovery and emission both go
+    /// through these, so a route can never be a dependency without also being
+    /// a connection: an ungated edge can invent a cycle, and breaking that
+    /// cycle costs a real connection elsewhere.
+    TrackRoute activeAudioInputRoute(const TrackInfo& track) const;
+    TrackRoute activeMidiInputRoute(const TrackInfo& track) const;
+
+    /// The track this track's audio output feeds; the master by default.
+    TrackId resolveAudioDestination(const TrackInfo& track) const;
 
     void emitTrack(const TrackInfo& track);
     ChainSignal emitElements(const std::vector<ChainElement>& elements, const ChainSite& site,
@@ -213,6 +235,29 @@ const TrackInfo* Compiler::findTrack(TrackId id) const {
     return found == tracks_.end() ? nullptr : &*found;
 }
 
+bool Compiler::carriesClips(const TrackInfo& track) const {
+    return track.id != master_.id && track.type != TrackType::Aux &&
+           track.type != TrackType::Group && track.type != TrackType::MultiOut;
+}
+
+TrackRoute Compiler::activeAudioInputRoute(const TrackInfo& track) const {
+    const auto monitorsInput = track.recordArmed || track.inputMonitor != InputMonitorMode::Off;
+    if (!carriesClips(track) || !monitorsInput || track.audioInputDevice.isEmpty())
+        return {RouteKind::None, INVALID_TRACK_ID};
+    return parseTrackRoute(track.audioInputDevice);
+}
+
+TrackRoute Compiler::activeMidiInputRoute(const TrackInfo& track) const {
+    if (!carriesClips(track) || !track.receivesLiveMidiInput() || track.midiInputDevice.isEmpty())
+        return {RouteKind::None, INVALID_TRACK_ID};
+    return parseTrackRoute(track.midiInputDevice);
+}
+
+TrackId Compiler::resolveAudioDestination(const TrackInfo& track) const {
+    const auto route = parseTrackRoute(track.audioOutputDevice);
+    return route.namesTrack() ? route.trackId : MASTER_TRACK_ID;
+}
+
 TrackId Compiler::resolveSendDestination(const SendInfo& send) const {
     if (send.destTrackId != INVALID_TRACK_ID)
         return send.destTrackId;
@@ -261,16 +306,16 @@ std::vector<const TrackInfo*> Compiler::computeTrackOrder() {
             if (const auto destination = indexOf(resolveSendDestination(send)); destination >= 0)
                 addEdge(i, static_cast<std::size_t>(destination));
 
-        // Sidechains, internal input routes and multi-out all read another
-        // track, so that track comes first.
+        // Sidechains and internal input routes read another track, so that
+        // track comes first. Every edge here has to correspond to a connection
+        // emission will actually make; multi-out is not compiled at all, so it
+        // contributes no edge either.
         std::set<TrackId> upstream;
         collectSidechainSources(track, std::nullopt, upstream);
-        if (const auto source = parseTrackReference(track.audioInputDevice))
-            upstream.insert(*source);
-        if (const auto source = parseTrackReference(track.midiInputDevice))
-            upstream.insert(*source);
-        if (track.multiOutLink)
-            upstream.insert(track.multiOutLink->sourceTrackId);
+        if (const auto route = activeAudioInputRoute(track); route.namesTrack())
+            upstream.insert(route.trackId);
+        if (const auto route = activeMidiInputRoute(track); route.namesTrack())
+            upstream.insert(route.trackId);
 
         for (const auto sourceId : upstream)
             if (const auto source = indexOf(sourceId); source >= 0)
@@ -396,13 +441,31 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
     if (rack.bypassed)
         return signal;
 
-    // A rack with no chains is transparent, not a hole. Compiling it to a
-    // zero-input mix would silence the track; the current engine passes audio
-    // and MIDI straight through. (A rack whose chains all route to aux outputs
-    // does render silence on the main output, and that is the engine's
-    // behaviour too, so only the empty case is special.)
-    if (rack.chains.empty())
-        return signal;
+    // A rack-level sidechain drives the rack's own followers and LFOs, so it is
+    // a modulation source rather than a signal edge, and modulation is not
+    // topology. Reported rather than passed over in silence: the dependency on
+    // the source track is real and lands with the modulation slice.
+    if (rack.sidechain.isActive())
+        diagnose("rack " + std::to_string(rack.id) + ": " +
+                 (rack.sidechain.type == SidechainConfig::Type::MIDI ? "MIDI" : "audio") +
+                 " sidechain from track " + std::to_string(rack.sidechain.sourceTrackId) +
+                 " feeds rack modulation, which the plan does not carry yet");
+
+    // A rack with no chains passes signal rather than silence: compiling it to
+    // a zero-input mix would silence the track. It is not fully transparent
+    // though, because rack volume and pan land on the instance's output gains,
+    // which the current engine applies on the wet path whether or not there are
+    // chains. So the mix is skipped and the rack fader still applies, which
+    // also keeps the fader's identity stable when the first chain is added.
+    // (Bypass is the genuinely transparent case, handled above: it routes the
+    // dry path, which skips those gains entirely. A rack whose chains all go to
+    // aux outputs does render silence on the main output, in the engine too.)
+    if (rack.chains.empty()) {
+        const OpKey faderKey{site.trackId,      rack.id,           INVALID_CHAIN_ID,
+                             INVALID_DEVICE_ID, OpRole::RackFader, 0};
+        return {PortRef{addOp(OpKind::Fader, faderKey, {signal.audio}, {SignalKind::Audio}), 0},
+                signal.midi};
+    }
 
     std::vector<PortRef> chainAudio;
     std::vector<PortRef> chainMidi;
@@ -475,11 +538,6 @@ void Compiler::emitTrack(const TrackInfo& track) {
 
     // --- chain head ---
 
-    // Aux, Group, MultiOut and Master tracks carry no clips: everything they
-    // render arrives from elsewhere.
-    const auto carriesClips = !isMaster && track.type != TrackType::Aux &&
-                              track.type != TrackType::Group && track.type != TrackType::MultiOut;
-
     if (track.multiOutLink)
         diagnose("track " + std::to_string(track.id) + ": multi-out pair " +
                  std::to_string(track.multiOutLink->outputPairIndex) + " of device " +
@@ -487,7 +545,7 @@ void Compiler::emitTrack(const TrackInfo& track) {
                  " is not routed yet, the track renders silence");
 
     std::vector<PortRef> audioSources;
-    if (carriesClips) {
+    if (carriesClips(track)) {
         const OpKey key{track.id,          INVALID_RACK_ID,   INVALID_CHAIN_ID,
                         INVALID_DEVICE_ID, OpRole::ClipAudio, 0};
         audioSources.push_back(PortRef{addOp(OpKind::ClipAudio, key, {}, {SignalKind::Audio}), 0});
@@ -495,26 +553,36 @@ void Compiler::emitTrack(const TrackInfo& track) {
 
     // Input reaches a track only while it is monitoring or armed, whether it
     // comes from hardware or from another track. Both forms go through the
-    // input path in the current engine, so both are gated the same way.
-    const auto monitorsInput = track.recordArmed || track.inputMonitor != InputMonitorMode::Off;
-    if (carriesClips && monitorsInput && track.audioInputDevice.isNotEmpty()) {
-        if (const auto sourceId = parseTrackReference(track.audioInputDevice)) {
+    // input path in the current engine, so both are gated the same way, and
+    // the gate lives in activeAudioInputRoute so ordering agrees with this.
+    switch (const auto route = activeAudioInputRoute(track); route.kind) {
+        case RouteKind::Track: {
             // An internal route carries the source track's post-mute output.
             // Nothing about it is live, so liveness is left to propagate from
             // the source rather than asserted here.
-            if (const auto source = trackRoutedOutput_.find(*sourceId);
+            if (const auto source = trackRoutedOutput_.find(route.trackId);
                 source != trackRoutedOutput_.end())
                 audioSources.push_back(source->second);
             else
                 diagnose("track " + std::to_string(track.id) + ": audio input track " +
-                         std::to_string(*sourceId) + " is not compiled, input not connected");
-        } else {
+                         std::to_string(route.trackId) + " is not compiled, input not connected");
+            break;
+        }
+        case RouteKind::Malformed:
+            diagnose("track " + std::to_string(track.id) + ": audio input routing '" +
+                     track.audioInputDevice.toStdString() +
+                     "' does not name a track, input not connected");
+            break;
+        case RouteKind::External: {
             const OpKey key{track.id,          INVALID_RACK_ID,        INVALID_CHAIN_ID,
                             INVALID_DEVICE_ID, OpRole::LiveAudioInput, 0};
             const auto op = addOp(OpKind::AudioInput, key, {}, {SignalKind::Audio});
             plan_.ops[static_cast<std::size_t>(op)].liveness = LivenessDomain::Live;
             audioSources.push_back(PortRef{op, 0});
+            break;
         }
+        case RouteKind::None:
+            break;
     }
 
     if (const auto pending = pendingInputs_.find(track.id); pending != pendingInputs_.end()) {
@@ -528,28 +596,38 @@ void Compiler::emitTrack(const TrackInfo& track) {
     signal.audio = emitMix(inputKey, audioSources);
 
     std::vector<PortRef> midiSources;
-    if (carriesClips && (chainConsumesMidi(track) || midiSourceTracks_.contains(track.id))) {
+    if (carriesClips(track) && (chainConsumesMidi(track) || midiSourceTracks_.contains(track.id))) {
         const OpKey key{track.id,          INVALID_RACK_ID,  INVALID_CHAIN_ID,
                         INVALID_DEVICE_ID, OpRole::ClipMidi, 0};
         midiSources.push_back(PortRef{addOp(OpKind::ClipMidi, key, {}, {SignalKind::Midi}), 0});
     }
-    if (carriesClips && track.receivesLiveMidiInput() && track.midiInputDevice.isNotEmpty()) {
-        if (const auto sourceId = parseTrackReference(track.midiInputDevice)) {
+    switch (const auto route = activeMidiInputRoute(track); route.kind) {
+        case RouteKind::Track: {
             // An internal MIDI route delivers the source track's incoming MIDI,
             // not what its own chain made of it.
-            if (const auto source = trackMidiInput_.find(*sourceId);
+            if (const auto source = trackMidiInput_.find(route.trackId);
                 source != trackMidiInput_.end())
                 midiSources.push_back(source->second);
             else
                 diagnose("track " + std::to_string(track.id) + ": MIDI input track " +
-                         std::to_string(*sourceId) + " produces no MIDI, input not connected");
-        } else {
+                         std::to_string(route.trackId) + " produces no MIDI, input not connected");
+            break;
+        }
+        case RouteKind::Malformed:
+            diagnose("track " + std::to_string(track.id) + ": MIDI input routing '" +
+                     track.midiInputDevice.toStdString() +
+                     "' does not name a track, input not connected");
+            break;
+        case RouteKind::External: {
             const OpKey key{track.id,          INVALID_RACK_ID,       INVALID_CHAIN_ID,
                             INVALID_DEVICE_ID, OpRole::LiveMidiInput, 0};
             const auto op = addOp(OpKind::MidiInput, key, {}, {SignalKind::Midi});
             plan_.ops[static_cast<std::size_t>(op)].liveness = LivenessDomain::Live;
             midiSources.push_back(PortRef{op, 0});
+            break;
         }
+        case RouteKind::None:
+            break;
     }
     if (!midiSources.empty()) {
         const OpKey key{track.id,          INVALID_RACK_ID,        INVALID_CHAIN_ID,
@@ -639,8 +717,11 @@ RenderPlan Compiler::run() {
     // nothing in its own chain consumes it, so this is collected up front.
     for (const auto& track : tracks_) {
         collectSidechainSources(track, SidechainConfig::Type::MIDI, midiSourceTracks_);
-        if (const auto source = parseTrackReference(track.midiInputDevice))
-            midiSourceTracks_.insert(*source);
+        // Gated the same way the route itself is: an unmonitored route reads
+        // nothing, so making its source compile MIDI ops would leave ops in the
+        // plan that no one reads.
+        if (const auto route = activeMidiInputRoute(track); route.namesTrack())
+            midiSourceTracks_.insert(route.trackId);
     }
     collectSidechainSources(master_, SidechainConfig::Type::MIDI, midiSourceTracks_);
 

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -61,6 +61,10 @@ bool chainConsumesMidi(const TrackInfo& track) {
 
 /// Tracks whose signal a device in `elements` reads as a sidechain input.
 /// `type` narrows the search to audio or MIDI sidechains; nullopt takes both.
+///
+/// Only devices the compiler will actually emit are walked. A sidechain on a
+/// bypassed device is not a dependency, and treating it as one can invent a
+/// cycle that costs a real connection when the cycle breaker resolves it.
 void collectSidechainSources(const std::vector<ChainElement>& elements,
                              std::optional<SidechainConfig::Type> type, std::set<TrackId>& out) {
     const auto collect = [&](const SidechainConfig& sidechain) {
@@ -70,34 +74,55 @@ void collectSidechainSources(const std::vector<ChainElement>& elements,
 
     for (const auto& element : elements) {
         if (isDevice(element)) {
-            collect(getDevice(element).sidechain);
+            const auto& device = getDevice(element);
+            if (!device.bypassed)
+                collect(device.sidechain);
         } else if (isRack(element)) {
-            for (const auto& chain : getRack(element).chains)
-                collectSidechainSources(chain.elements, type, out);
+            const auto& rack = getRack(element);
+            if (rack.bypassed)
+                continue;
+            for (const auto& chain : rack.chains)
+                if (!chain.bypassed && chain.outputIndex == 0)
+                    collectSidechainSources(chain.elements, type, out);
         }
     }
 }
 
 void collectSidechainSources(const TrackInfo& track, std::optional<SidechainConfig::Type> type,
                              std::set<TrackId>& out) {
-    collectSidechainSources(track.chain.fxChainElements, type, out);
+    // Chain power gates the insert chain; post-FX sits outside it. This mirrors
+    // the emission rules exactly, which is the point.
+    if (track.chain.enabled)
+        collectSidechainSources(track.chain.fxChainElements, type, out);
+
     for (const auto& element : track.chain.postFxChainElements)
-        if (element.device.sidechain.isActive() &&
+        if (!element.device.bypassed && element.device.sidechain.isActive() &&
             (!type.has_value() || element.device.sidechain.type == *type))
             out.insert(element.device.sidechain.sourceTrackId);
+}
+
+/// The track id in a "track:<id>" routing string, or nullopt for a hardware
+/// device name, the default "master", or an empty field.
+std::optional<TrackId> parseTrackReference(const juce::String& routing) {
+    if (!routing.startsWith("track:"))
+        return std::nullopt;
+
+    const auto id = routing.substring(6).trim();
+    if (id.isEmpty() || !id.containsOnly("-0123456789"))
+        return std::nullopt;
+    // Rejects "1-2" and bare "-": getIntValue would silently take the leading
+    // digits and route the signal at a track that was never selected.
+    if (juce::String(id.getIntValue()) != id)
+        return std::nullopt;
+
+    return id.getIntValue();
 }
 
 /// The track a track's audio output feeds. "track:<id>" routes into a group;
 /// everything else (including the default "master" and an empty string) goes
 /// straight to the master track.
 TrackId resolveAudioDestination(const TrackInfo& track) {
-    const auto& routing = track.audioOutputDevice;
-    if (routing.startsWith("track:")) {
-        const auto id = routing.substring(6);
-        if (id.isNotEmpty() && id.containsOnly("-0123456789"))
-            return id.getIntValue();
-    }
-    return MASTER_TRACK_ID;
+    return parseTrackReference(track.audioOutputDevice).value_or(MASTER_TRACK_ID);
 }
 
 class Compiler {
@@ -132,16 +157,25 @@ class Compiler {
     CompileOptions options_;
 
     RenderPlan plan_;
-    /// Post-fader output of each emitted track: audio sidechain sources read it.
-    std::map<TrackId, PortRef> trackOutput_;
-    /// Chain-head MIDI of each emitted track: MIDI sidechain sources read it.
+    /// Post-fader, pre-mute output of each emitted track. This is where audio
+    /// sidechains tap, matching where the current engine inserts the sidechain
+    /// send: after the plugin list (the fader included) and before the muting
+    /// node, so a muted source still feeds the compressor keying off it.
+    std::map<TrackId, PortRef> trackSidechainTap_;
+    /// Post-mute output: what the track's destination and any track taking this
+    /// track as its audio input actually receive.
+    std::map<TrackId, PortRef> trackRoutedOutput_;
+    /// Chain-head MIDI of each emitted track: MIDI sidechains and internal MIDI
+    /// routes read it, which is the source track's incoming MIDI rather than
+    /// whatever its own chain made of it.
     std::map<TrackId, PortRef> trackMidiInput_;
     /// Signals waiting to be summed into a track that has not been emitted yet:
     /// child track outputs and incoming send taps.
     std::map<TrackId, std::vector<PortRef>> pendingInputs_;
-    /// Tracks another track's device reads MIDI from. Their MIDI clips have to
-    /// be compiled even when their own chain has nothing that consumes MIDI.
-    std::set<TrackId> midiSidechainSources_;
+    /// Tracks whose MIDI another track reads, through a MIDI sidechain or an
+    /// internal MIDI route. Their MIDI clips have to be compiled even when
+    /// their own chain has nothing that consumes MIDI.
+    std::set<TrackId> midiSourceTracks_;
 };
 
 OpId Compiler::addOp(OpKind kind, const OpKey& key, std::vector<PortRef> inputs,
@@ -227,15 +261,19 @@ std::vector<const TrackInfo*> Compiler::computeTrackOrder() {
             if (const auto destination = indexOf(resolveSendDestination(send)); destination >= 0)
                 addEdge(i, static_cast<std::size_t>(destination));
 
-        // Sidechain and multi-out read another track, so that track comes first.
-        std::set<TrackId> sidechainSources;
-        collectSidechainSources(track, std::nullopt, sidechainSources);
-        for (const auto sourceId : sidechainSources)
-            if (const auto source = indexOf(sourceId); source >= 0)
-                addEdge(static_cast<std::size_t>(source), i);
-
+        // Sidechains, internal input routes and multi-out all read another
+        // track, so that track comes first.
+        std::set<TrackId> upstream;
+        collectSidechainSources(track, std::nullopt, upstream);
+        if (const auto source = parseTrackReference(track.audioInputDevice))
+            upstream.insert(*source);
+        if (const auto source = parseTrackReference(track.midiInputDevice))
+            upstream.insert(*source);
         if (track.multiOutLink)
-            if (const auto source = indexOf(track.multiOutLink->sourceTrackId); source >= 0)
+            upstream.insert(track.multiOutLink->sourceTrackId);
+
+        for (const auto sourceId : upstream)
+            if (const auto source = indexOf(sourceId); source >= 0)
                 addEdge(static_cast<std::size_t>(source), i);
     }
 
@@ -255,12 +293,15 @@ std::vector<const TrackInfo*> Compiler::computeTrackOrder() {
     while (order.size() < remaining) {
         if (ready.empty()) {
             // Every remaining track waits on another remaining track. Force the
-            // lowest-numbered one and drop the connections that close the cycle.
+            // lowest-numbered one. It is not necessarily on the cycle itself,
+            // only blocked by it, so this can also cost connections that were
+            // merely downstream of one; each loss is reported separately when
+            // it arrives too late to connect.
             for (std::size_t i = 0; i < numTracks; ++i) {
                 if (skipped[i] || emitted[i])
                     continue;
-                diagnose("routing cycle through track " + std::to_string(tracks_[i].id) +
-                         ": compiled ahead of its sources, connections closing the cycle dropped");
+                diagnose("routing cycle: track " + std::to_string(tracks_[i].id) +
+                         " compiled ahead of its sources to break it");
                 indegree[i] = 0;
                 ready.insert(i);
                 break;
@@ -305,8 +346,8 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
 
     PortRef sidechainIn;
     if (device.sidechain.type == SidechainConfig::Type::Audio && device.sidechain.isActive()) {
-        const auto source = trackOutput_.find(device.sidechain.sourceTrackId);
-        if (source != trackOutput_.end())
+        const auto source = trackSidechainTap_.find(device.sidechain.sourceTrackId);
+        if (source != trackSidechainTap_.end())
             sidechainIn = source->second;
         else
             diagnose("device " + std::to_string(device.id) + " on track " +
@@ -353,6 +394,14 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
 
 ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, ChainSignal signal) {
     if (rack.bypassed)
+        return signal;
+
+    // A rack with no chains is transparent, not a hole. Compiling it to a
+    // zero-input mix would silence the track; the current engine passes audio
+    // and MIDI straight through. (A rack whose chains all route to aux outputs
+    // does render silence on the main output, and that is the engine's
+    // behaviour too, so only the empty case is special.)
+    if (rack.chains.empty())
         return signal;
 
     std::vector<PortRef> chainAudio;
@@ -444,13 +493,28 @@ void Compiler::emitTrack(const TrackInfo& track) {
         audioSources.push_back(PortRef{addOp(OpKind::ClipAudio, key, {}, {SignalKind::Audio}), 0});
     }
 
+    // Input reaches a track only while it is monitoring or armed, whether it
+    // comes from hardware or from another track. Both forms go through the
+    // input path in the current engine, so both are gated the same way.
     const auto monitorsInput = track.recordArmed || track.inputMonitor != InputMonitorMode::Off;
     if (carriesClips && monitorsInput && track.audioInputDevice.isNotEmpty()) {
-        const OpKey key{track.id,          INVALID_RACK_ID,        INVALID_CHAIN_ID,
-                        INVALID_DEVICE_ID, OpRole::LiveAudioInput, 0};
-        const auto op = addOp(OpKind::AudioInput, key, {}, {SignalKind::Audio});
-        plan_.ops[static_cast<std::size_t>(op)].liveness = LivenessDomain::Live;
-        audioSources.push_back(PortRef{op, 0});
+        if (const auto sourceId = parseTrackReference(track.audioInputDevice)) {
+            // An internal route carries the source track's post-mute output.
+            // Nothing about it is live, so liveness is left to propagate from
+            // the source rather than asserted here.
+            if (const auto source = trackRoutedOutput_.find(*sourceId);
+                source != trackRoutedOutput_.end())
+                audioSources.push_back(source->second);
+            else
+                diagnose("track " + std::to_string(track.id) + ": audio input track " +
+                         std::to_string(*sourceId) + " is not compiled, input not connected");
+        } else {
+            const OpKey key{track.id,          INVALID_RACK_ID,        INVALID_CHAIN_ID,
+                            INVALID_DEVICE_ID, OpRole::LiveAudioInput, 0};
+            const auto op = addOp(OpKind::AudioInput, key, {}, {SignalKind::Audio});
+            plan_.ops[static_cast<std::size_t>(op)].liveness = LivenessDomain::Live;
+            audioSources.push_back(PortRef{op, 0});
+        }
     }
 
     if (const auto pending = pendingInputs_.find(track.id); pending != pendingInputs_.end()) {
@@ -464,17 +528,28 @@ void Compiler::emitTrack(const TrackInfo& track) {
     signal.audio = emitMix(inputKey, audioSources);
 
     std::vector<PortRef> midiSources;
-    if (carriesClips && (chainConsumesMidi(track) || midiSidechainSources_.contains(track.id))) {
+    if (carriesClips && (chainConsumesMidi(track) || midiSourceTracks_.contains(track.id))) {
         const OpKey key{track.id,          INVALID_RACK_ID,  INVALID_CHAIN_ID,
                         INVALID_DEVICE_ID, OpRole::ClipMidi, 0};
         midiSources.push_back(PortRef{addOp(OpKind::ClipMidi, key, {}, {SignalKind::Midi}), 0});
     }
     if (carriesClips && track.receivesLiveMidiInput() && track.midiInputDevice.isNotEmpty()) {
-        const OpKey key{track.id,          INVALID_RACK_ID,       INVALID_CHAIN_ID,
-                        INVALID_DEVICE_ID, OpRole::LiveMidiInput, 0};
-        const auto op = addOp(OpKind::MidiInput, key, {}, {SignalKind::Midi});
-        plan_.ops[static_cast<std::size_t>(op)].liveness = LivenessDomain::Live;
-        midiSources.push_back(PortRef{op, 0});
+        if (const auto sourceId = parseTrackReference(track.midiInputDevice)) {
+            // An internal MIDI route delivers the source track's incoming MIDI,
+            // not what its own chain made of it.
+            if (const auto source = trackMidiInput_.find(*sourceId);
+                source != trackMidiInput_.end())
+                midiSources.push_back(source->second);
+            else
+                diagnose("track " + std::to_string(track.id) + ": MIDI input track " +
+                         std::to_string(*sourceId) + " produces no MIDI, input not connected");
+        } else {
+            const OpKey key{track.id,          INVALID_RACK_ID,       INVALID_CHAIN_ID,
+                            INVALID_DEVICE_ID, OpRole::LiveMidiInput, 0};
+            const auto op = addOp(OpKind::MidiInput, key, {}, {SignalKind::Midi});
+            plan_.ops[static_cast<std::size_t>(op)].liveness = LivenessDomain::Live;
+            midiSources.push_back(PortRef{op, 0});
+        }
     }
     if (!midiSources.empty()) {
         const OpKey key{track.id,          INVALID_RACK_ID,        INVALID_CHAIN_ID,
@@ -495,7 +570,12 @@ void Compiler::emitTrack(const TrackInfo& track) {
     for (const auto& element : track.chain.mixerAnalysisElements)
         signal = emitDevice(element.device, site, signal);
 
-    // --- fader, sends, meter ---
+    // --- fader, sends, meter, mute ---
+    //
+    // Mute is its own stage rather than part of the fader's resolved gain,
+    // because the current engine silences a track after the sidechain send and
+    // after the metering tap. Folding mute into the fader would make a muted
+    // track's meter read silence and would starve any compressor keyed off it.
 
     auto emitSends = [&](bool preFader, PortRef source) {
         for (std::size_t slot = 0; slot < track.sends.size(); ++slot) {
@@ -528,7 +608,12 @@ void Compiler::emitTrack(const TrackInfo& track) {
     const OpKey meterKey{track.id,          INVALID_RACK_ID,    INVALID_CHAIN_ID,
                          INVALID_DEVICE_ID, OpRole::TrackMeter, 0};
     out = PortRef{addOp(OpKind::Meter, meterKey, {out}, {SignalKind::Audio}), 0};
-    trackOutput_[track.id] = out;
+    trackSidechainTap_[track.id] = out;
+
+    const OpKey muteKey{track.id,          INVALID_RACK_ID,   INVALID_CHAIN_ID,
+                        INVALID_DEVICE_ID, OpRole::TrackMute, 0};
+    out = PortRef{addOp(OpKind::Gain, muteKey, {out}, {SignalKind::Audio}), 0};
+    trackRoutedOutput_[track.id] = out;
 
     // --- output routing ---
 
@@ -550,11 +635,14 @@ void Compiler::emitTrack(const TrackInfo& track) {
 }
 
 RenderPlan Compiler::run() {
-    // A track feeding someone else's MIDI sidechain has to produce MIDI even
-    // when nothing in its own chain consumes it, so this is collected up front.
-    for (const auto& track : tracks_)
-        collectSidechainSources(track, SidechainConfig::Type::MIDI, midiSidechainSources_);
-    collectSidechainSources(master_, SidechainConfig::Type::MIDI, midiSidechainSources_);
+    // A track whose MIDI someone else reads has to produce MIDI even when
+    // nothing in its own chain consumes it, so this is collected up front.
+    for (const auto& track : tracks_) {
+        collectSidechainSources(track, SidechainConfig::Type::MIDI, midiSourceTracks_);
+        if (const auto source = parseTrackReference(track.midiInputDevice))
+            midiSourceTracks_.insert(*source);
+    }
+    collectSidechainSources(master_, SidechainConfig::Type::MIDI, midiSourceTracks_);
 
     for (const auto* track : computeTrackOrder())
         emitTrack(*track);

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -144,6 +144,19 @@ struct TrackRoute {
     }
 };
 
+/// Whether input reaches the track at all, for either audio or MIDI.
+///
+/// Auto is deliberately not enough on its own: it maps to TE's automatic
+/// monitor mode, which passes input only while the track is armed. Including it
+/// unarmed would emit a live input op the current engine keeps silent, and
+/// would mark the whole downstream chain Live, pessimising the anticipative
+/// executor for a track that cannot sound. This is why the compiler does not
+/// use TrackInfo::receivesLiveMidiInput, which answers a broader question for
+/// the UI's input-activity light.
+bool monitorsInput(const TrackInfo& track) {
+    return track.recordArmed || track.inputMonitor == InputMonitorMode::In;
+}
+
 /// Parses a routing field: "track:<id>" for an internal route, anything else
 /// (a hardware device name, the default "master", an empty field) is external.
 TrackRoute parseTrackRoute(const juce::String& routing) {
@@ -268,14 +281,13 @@ bool Compiler::carriesClips(const TrackInfo& track) const {
 }
 
 TrackRoute Compiler::activeAudioInputRoute(const TrackInfo& track) const {
-    const auto monitorsInput = track.recordArmed || track.inputMonitor != InputMonitorMode::Off;
-    if (!carriesClips(track) || !monitorsInput || track.audioInputDevice.isEmpty())
+    if (!carriesClips(track) || !monitorsInput(track) || track.audioInputDevice.isEmpty())
         return {RouteKind::None, INVALID_TRACK_ID};
     return parseTrackRoute(track.audioInputDevice);
 }
 
 TrackRoute Compiler::activeMidiInputRoute(const TrackInfo& track) const {
-    if (!carriesClips(track) || !track.receivesLiveMidiInput() || track.midiInputDevice.isEmpty())
+    if (!carriesClips(track) || !monitorsInput(track) || track.midiInputDevice.isEmpty())
         return {RouteKind::None, INVALID_TRACK_ID};
     return parseTrackRoute(track.midiInputDevice);
 }
@@ -570,6 +582,17 @@ void Compiler::emitTrack(const TrackInfo& track) {
                  std::to_string(track.multiOutLink->outputPairIndex) + " of device " +
                  std::to_string(track.multiOutLink->sourceDeviceId) +
                  " is not routed yet, the track renders silence");
+
+    // Freeze is structural: the current engine renders the track, disables its
+    // plugins and plays the render back. Compiling the live chain both diverges
+    // from that output and throws away the CPU saving that is the whole point.
+    // Named rather than half-implemented, because the real shape (a source op
+    // reading the freeze file, device ops skipped) needs its op key decided
+    // first so unfreezing carries state sanely.
+    if (track.frozen)
+        diagnose("track " + std::to_string(track.id) +
+                 ": freeze is not compiled yet, the live chain is planned instead of the "
+                 "rendered freeze file");
 
     std::vector<PortRef> audioSources;
     if (carriesClips(track)) {

--- a/magda/engine/plan/PlanCompiler.hpp
+++ b/magda/engine/plan/PlanCompiler.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <vector>
+
+#include "plan/RenderPlan.hpp"
+
+namespace magda {
+struct TrackInfo;
+}
+
+namespace magda::engine {
+
+/** Compile-time switches that change which ops the plan contains. */
+struct CompileOptions {
+    /// Emit a level tap after each device slot, feeding the chain UI's meters.
+    /// Off in golden tests that are not about metering.
+    bool deviceMeters = true;
+};
+
+/**
+ * @brief Compile the MAGDA track model into a render plan.
+ *
+ * Deterministic: the same model always compiles to the same plan, op for op and
+ * index for index, so plans are golden-testable and the differ sees churn only
+ * where the model actually changed.
+ *
+ * The compiler reads structure only — chain layout, routing, sends, bypass and
+ * chain power. Values (fader positions, gains, send levels, clip contents) stay
+ * out of the plan and reach ops through snapshots.
+ *
+ * Anything the compiler cannot express lands in RenderPlan::diagnostics rather
+ * than being silently dropped.
+ *
+ * @param tracks  every non-master track, in project order
+ * @param master  the master track (id MASTER_TRACK_ID)
+ */
+RenderPlan compileRenderPlan(const std::vector<TrackInfo>& tracks, const TrackInfo& master,
+                             const CompileOptions& options = {});
+
+}  // namespace magda::engine

--- a/magda/engine/plan/PlanCompiler.hpp
+++ b/magda/engine/plan/PlanCompiler.hpp
@@ -24,7 +24,7 @@ struct CompileOptions {
  * index for index, so plans are golden-testable and the differ sees churn only
  * where the model actually changed.
  *
- * The compiler reads structure only — chain layout, routing, sends, bypass and
+ * The compiler reads structure only: chain layout, routing, sends, bypass and
  * chain power. Values (fader positions, gains, send levels, clip contents) stay
  * out of the plan and reach ops through snapshots.
  *

--- a/magda/engine/plan/PlanDump.cpp
+++ b/magda/engine/plan/PlanDump.cpp
@@ -1,0 +1,77 @@
+#include "plan/PlanDump.hpp"
+
+#include <sstream>
+
+namespace magda::engine {
+namespace {
+
+std::string padded(std::string text, std::size_t width) {
+    if (text.size() < width)
+        text.append(width - text.size(), ' ');
+    return text;
+}
+
+std::string rightAligned(int value, std::size_t width) {
+    auto text = std::to_string(value);
+    if (text.size() < width)
+        text.insert(text.begin(), static_cast<long>(width - text.size()), ' ');
+    return text;
+}
+
+std::string describeInputs(const PlanOp& op) {
+    if (op.inputs.empty())
+        return "-";
+
+    std::string text;
+    for (std::size_t i = 0; i < op.inputs.size(); ++i) {
+        if (i > 0)
+            text += ",";
+        const auto& input = op.inputs[i];
+        text += input.valid() ? std::to_string(input.op) + ":" + std::to_string(input.port) : "-";
+    }
+    return text;
+}
+
+std::string describeOutputs(const PlanOp& op) {
+    if (op.outputs.empty())
+        return "-";
+
+    std::string text;
+    for (std::size_t i = 0; i < op.outputs.size(); ++i) {
+        if (i > 0)
+            text += ",";
+        text += toString(op.outputs[i]);
+    }
+    return text;
+}
+
+}  // namespace
+
+std::string dumpPlan(const RenderPlan& plan) {
+    std::ostringstream out;
+    out << "magda-render-plan v" << plan.version << "\n";
+    out << "ops=" << plan.ops.size() << " outputs=" << plan.outputOps.size() << "\n";
+
+    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+        const auto& op = plan.ops[i];
+        out << "[" << rightAligned(static_cast<int>(i), 3) << "] " << padded(toString(op.kind), 11)
+            << " " << padded(toString(op.liveness), 5) << " " << padded(toString(op.key), 30)
+            << " in=" << padded(describeInputs(op), 16)
+            << " out=" << padded(describeOutputs(op), 11);
+        if (i < plan.dependencyCounts.size())
+            out << " deps=" << plan.dependencyCounts[i];
+        out << "\n";
+    }
+
+    out << "ready=";
+    for (std::size_t i = 0; i < plan.initialReadyOps.size(); ++i)
+        out << (i > 0 ? "," : "") << plan.initialReadyOps[i];
+    out << "\n";
+
+    for (const auto& diagnostic : plan.diagnostics)
+        out << "diagnostic: " << diagnostic << "\n";
+
+    return out.str();
+}
+
+}  // namespace magda::engine

--- a/magda/engine/plan/PlanDump.hpp
+++ b/magda/engine/plan/PlanDump.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <string>
+
+#include "plan/RenderPlan.hpp"
+
+namespace magda::engine {
+
+/**
+ * @brief Render a plan as canonical text.
+ *
+ * The dump is the plan's testable surface: golden tests assert it, and it is
+ * what to look at when a compiled plan is not what a model change should have
+ * produced. Deterministic and diff-friendly — one line per op, fixed columns,
+ * no addresses or timings.
+ *
+ * Shape:
+ * @code
+ * magda-render-plan v1
+ * ops=3 outputs=1
+ * [  0] ClipAudio    det   T1:clipAudio        in=-      out=audio     deps=0
+ * ...
+ * ready=0
+ * @endcode
+ *
+ * An input slot reads `<op>:<port>`, or `-` when the slot is unconnected.
+ */
+std::string dumpPlan(const RenderPlan& plan);
+
+}  // namespace magda::engine

--- a/magda/engine/plan/PlanDump.hpp
+++ b/magda/engine/plan/PlanDump.hpp
@@ -11,7 +11,7 @@ namespace magda::engine {
  *
  * The dump is the plan's testable surface: golden tests assert it, and it is
  * what to look at when a compiled plan is not what a model change should have
- * produced. Deterministic and diff-friendly — one line per op, fixed columns,
+ * produced. Deterministic and diff-friendly: one line per op, fixed columns,
  * no addresses or timings.
  *
  * Shape:

--- a/magda/engine/plan/RenderPlan.cpp
+++ b/magda/engine/plan/RenderPlan.cpp
@@ -1,6 +1,7 @@
 #include "plan/RenderPlan.hpp"
 
 #include <algorithm>
+#include <map>
 #include <tuple>
 
 namespace magda::engine {
@@ -186,10 +187,20 @@ std::vector<std::string> validatePlan(const RenderPlan& plan) {
     std::vector<std::string> problems;
     const auto numOps = static_cast<OpId>(plan.ops.size());
 
+    // The differ hash-joins old and new plans on OpKey, so a duplicate key does
+    // not fail loudly: it carries one op's state into another. Identity bugs
+    // are the concentrated risk of this design, so uniqueness is an invariant
+    // here rather than a convention the compiler happens to keep.
+    std::map<OpKey, OpId> keyOwners;
+
     for (OpId i = 0; i < numOps; ++i) {
         const auto& op = plan.ops[static_cast<std::size_t>(i)];
         const auto label =
             "op " + std::to_string(i) + " (" + toString(op.kind) + " " + toString(op.key) + "): ";
+
+        if (const auto [owner, inserted] = keyOwners.emplace(op.key, i); !inserted)
+            problems.push_back(label + "has the same key as op " + std::to_string(owner->second) +
+                               ", so the differ cannot tell them apart");
 
         // Output is the plan's only sink; everything else must produce.
         if (op.outputs.empty() != (op.kind == OpKind::Output))
@@ -232,19 +243,25 @@ std::vector<std::string> validatePlan(const RenderPlan& plan) {
                                    toString(actual) + ", expected " + toString(expected));
         }
 
-        if (op.liveness == LivenessDomain::Deterministic) {
-            // Out-of-range inputs are already reported above; skip them here so
-            // a malformed plan cannot walk off the op vector.
-            const auto liveInput =
-                std::ranges::find_if(op.inputs, [&plan, i](const PortRef& input) {
-                    return input.valid() && input.op >= 0 && input.op < i &&
-                           plan.ops[static_cast<std::size_t>(input.op)].liveness ==
-                               LivenessDomain::Live;
-                });
-            if (liveInput != op.inputs.end())
-                problems.push_back(label + "is deterministic but reads live op " +
-                                   std::to_string(liveInput->op));
-        }
+        // Out-of-range inputs are already reported above; skip them here so a
+        // malformed plan cannot walk off the op vector.
+        const auto liveInput = std::ranges::find_if(op.inputs, [&plan, i](const PortRef& input) {
+            return input.valid() && input.op >= 0 && input.op < i &&
+                   plan.ops[static_cast<std::size_t>(input.op)].liveness == LivenessDomain::Live;
+        });
+        const auto readsLive = liveInput != op.inputs.end();
+
+        if (op.liveness == LivenessDomain::Deterministic && readsLive)
+            problems.push_back(label + "is deterministic but reads live op " +
+                               std::to_string(liveInput->op));
+
+        // The converse matters just as much and is harder to notice, because
+        // over-tagging is semantically harmless: it only shrinks what the
+        // anticipative executor is allowed to precompute. Liveness has to come
+        // from somewhere, and only the input sources originate it.
+        const auto isLiveSource = op.kind == OpKind::AudioInput || op.kind == OpKind::MidiInput;
+        if (op.liveness == LivenessDomain::Live && !isLiveSource && !readsLive)
+            problems.push_back(label + "is live but reads nothing live and is not an input source");
     }
 
     for (const auto outputOp : plan.outputOps) {

--- a/magda/engine/plan/RenderPlan.cpp
+++ b/magda/engine/plan/RenderPlan.cpp
@@ -1,0 +1,258 @@
+#include "plan/RenderPlan.hpp"
+
+#include <algorithm>
+#include <tuple>
+
+namespace magda::engine {
+
+bool OpKey::operator<(const OpKey& o) const {
+    return std::tie(trackId, rackId, chainId, deviceId, role, index) <
+           std::tie(o.trackId, o.rackId, o.chainId, o.deviceId, o.role, o.index);
+}
+
+int arityOf(OpKind kind) {
+    switch (kind) {
+        case OpKind::ClipAudio:
+        case OpKind::ClipMidi:
+        case OpKind::AudioInput:
+        case OpKind::MidiInput:
+            return 0;
+        case OpKind::Device:
+            return 3;  // audio, MIDI, sidechain audio
+        case OpKind::MixAudio:
+        case OpKind::MergeMidi:
+            return -1;  // variadic
+        case OpKind::Gain:
+        case OpKind::Fader:
+        case OpKind::SendTap:
+        case OpKind::Meter:
+        case OpKind::Output:
+            return 1;
+    }
+    return -1;
+}
+
+const char* toString(OpKind kind) {
+    switch (kind) {
+        case OpKind::ClipAudio:
+            return "ClipAudio";
+        case OpKind::ClipMidi:
+            return "ClipMidi";
+        case OpKind::AudioInput:
+            return "AudioInput";
+        case OpKind::MidiInput:
+            return "MidiInput";
+        case OpKind::Device:
+            return "Device";
+        case OpKind::MixAudio:
+            return "MixAudio";
+        case OpKind::MergeMidi:
+            return "MergeMidi";
+        case OpKind::Gain:
+            return "Gain";
+        case OpKind::Fader:
+            return "Fader";
+        case OpKind::SendTap:
+            return "SendTap";
+        case OpKind::Meter:
+            return "Meter";
+        case OpKind::Output:
+            return "Output";
+    }
+    return "?";
+}
+
+const char* toString(OpRole role) {
+    switch (role) {
+        case OpRole::ClipAudio:
+            return "clipAudio";
+        case OpRole::ClipMidi:
+            return "clipMidi";
+        case OpRole::LiveAudioInput:
+            return "liveAudioInput";
+        case OpRole::LiveMidiInput:
+            return "liveMidiInput";
+        case OpRole::TrackAudioInput:
+            return "trackAudioInput";
+        case OpRole::TrackMidiInput:
+            return "trackMidiInput";
+        case OpRole::DeviceProcess:
+            return "deviceProcess";
+        case OpRole::DeviceGain:
+            return "deviceGain";
+        case OpRole::DeviceMeter:
+            return "deviceMeter";
+        case OpRole::ChainMidiMerge:
+            return "chainMidiMerge";
+        case OpRole::RackChainFader:
+            return "rackChainFader";
+        case OpRole::RackMix:
+            return "rackMix";
+        case OpRole::RackMidiMix:
+            return "rackMidiMix";
+        case OpRole::RackFader:
+            return "rackFader";
+        case OpRole::TrackFader:
+            return "trackFader";
+        case OpRole::TrackMeter:
+            return "trackMeter";
+        case OpRole::SendTap:
+            return "sendTap";
+        case OpRole::HardwareOutput:
+            return "hardwareOutput";
+    }
+    return "?";
+}
+
+const char* toString(SignalKind kind) {
+    return kind == SignalKind::Audio ? "audio" : "midi";
+}
+
+const char* toString(LivenessDomain domain) {
+    return domain == LivenessDomain::Live ? "live" : "det";
+}
+
+std::string toString(const OpKey& key) {
+    std::string out;
+    if (key.trackId != INVALID_TRACK_ID)
+        out += "T" + std::to_string(key.trackId);
+    if (key.rackId != INVALID_RACK_ID)
+        out += "/R" + std::to_string(key.rackId);
+    if (key.chainId != INVALID_CHAIN_ID)
+        out += "/C" + std::to_string(key.chainId);
+    if (key.deviceId != INVALID_DEVICE_ID)
+        out += "/D" + std::to_string(key.deviceId);
+    out += ":";
+    out += toString(key.role);
+    if (key.index != 0)
+        out += "#" + std::to_string(key.index);
+    return out;
+}
+
+namespace {
+
+/// Producer ops an op waits on, each counted once however many slots it feeds.
+std::vector<OpId> distinctProducers(const PlanOp& op) {
+    std::vector<OpId> producers;
+    producers.reserve(op.inputs.size());
+    for (const auto& input : op.inputs) {
+        if (!input.valid())
+            continue;
+        if (std::ranges::find(producers, input.op) == producers.end())
+            producers.push_back(input.op);
+    }
+    return producers;
+}
+
+}  // namespace
+
+void bakeScheduling(RenderPlan& plan) {
+    const auto numOps = plan.ops.size();
+
+    plan.dependencyCounts.assign(numOps, 0);
+    plan.initialReadyOps.clear();
+    plan.consumerOffsets.assign(numOps + 1, 0);
+    plan.consumerEdges.clear();
+
+    // Pass 1: dependency counts, and per-producer consumer counts into the
+    // offset array (shifted by one so the prefix sum below lands in place).
+    for (std::size_t i = 0; i < numOps; ++i) {
+        const auto producers = distinctProducers(plan.ops[i]);
+        plan.dependencyCounts[i] = static_cast<std::uint16_t>(producers.size());
+        if (producers.empty())
+            plan.initialReadyOps.push_back(static_cast<OpId>(i));
+        for (const auto producer : producers)
+            ++plan.consumerOffsets[static_cast<std::size_t>(producer) + 1];
+    }
+
+    for (std::size_t i = 0; i < numOps; ++i)
+        plan.consumerOffsets[i + 1] += plan.consumerOffsets[i];
+
+    // Pass 2: fill the edge array. Consumers land in ascending op order because
+    // ops are visited in order and each producer precedes all of its consumers.
+    plan.consumerEdges.assign(static_cast<std::size_t>(plan.consumerOffsets[numOps]),
+                              INVALID_OP_ID);
+    std::vector<int> cursor(plan.consumerOffsets.begin(), plan.consumerOffsets.end() - 1);
+    for (std::size_t i = 0; i < numOps; ++i) {
+        for (const auto producer : distinctProducers(plan.ops[i]))
+            plan.consumerEdges[static_cast<std::size_t>(
+                cursor[static_cast<std::size_t>(producer)]++)] = static_cast<OpId>(i);
+    }
+}
+
+std::vector<std::string> validatePlan(const RenderPlan& plan) {
+    std::vector<std::string> problems;
+    const auto numOps = static_cast<OpId>(plan.ops.size());
+
+    for (OpId i = 0; i < numOps; ++i) {
+        const auto& op = plan.ops[static_cast<std::size_t>(i)];
+        const auto label =
+            "op " + std::to_string(i) + " (" + toString(op.kind) + " " + toString(op.key) + "): ";
+
+        // Output is the plan's only sink; everything else must produce.
+        if (op.outputs.empty() != (op.kind == OpKind::Output))
+            problems.push_back(label + (op.outputs.empty() ? "no output port"
+                                                           : "is a sink and must have no ports"));
+
+        const auto arity = arityOf(op.kind);
+        if (arity >= 0 && static_cast<int>(op.inputs.size()) != arity)
+            problems.push_back(label + "expected " + std::to_string(arity) + " input slots, has " +
+                               std::to_string(op.inputs.size()));
+
+        for (std::size_t slot = 0; slot < op.inputs.size(); ++slot) {
+            const auto& input = op.inputs[slot];
+            if (!input.valid()) {
+                if (arity < 0)
+                    problems.push_back(label + "variadic input " + std::to_string(slot) +
+                                       " is unconnected");
+                continue;
+            }
+            if (input.op < 0 || input.op >= i) {
+                problems.push_back(label + "input " + std::to_string(slot) + " references op " +
+                                   std::to_string(input.op) + ", which is not an earlier op");
+                continue;
+            }
+            const auto& producer = plan.ops[static_cast<std::size_t>(input.op)];
+            if (input.port < 0 || input.port >= static_cast<int>(producer.outputs.size())) {
+                problems.push_back(label + "input " + std::to_string(slot) + " references port " +
+                                   std::to_string(input.port) + " of op " +
+                                   std::to_string(input.op) + ", which has " +
+                                   std::to_string(producer.outputs.size()) + " ports");
+                continue;
+            }
+            const auto expected =
+                (op.kind == OpKind::MergeMidi || (op.kind == OpKind::Device && slot == 1))
+                    ? SignalKind::Midi
+                    : SignalKind::Audio;
+            const auto actual = producer.outputs[static_cast<std::size_t>(input.port)];
+            if (actual != expected)
+                problems.push_back(label + "input " + std::to_string(slot) + " is " +
+                                   toString(actual) + ", expected " + toString(expected));
+        }
+
+        if (op.liveness == LivenessDomain::Deterministic) {
+            // Out-of-range inputs are already reported above; skip them here so
+            // a malformed plan cannot walk off the op vector.
+            const auto liveInput =
+                std::ranges::find_if(op.inputs, [&plan, i](const PortRef& input) {
+                    return input.valid() && input.op >= 0 && input.op < i &&
+                           plan.ops[static_cast<std::size_t>(input.op)].liveness ==
+                               LivenessDomain::Live;
+                });
+            if (liveInput != op.inputs.end())
+                problems.push_back(label + "is deterministic but reads live op " +
+                                   std::to_string(liveInput->op));
+        }
+    }
+
+    for (const auto outputOp : plan.outputOps) {
+        if (outputOp < 0 || outputOp >= numOps)
+            problems.push_back("output op " + std::to_string(outputOp) + " is out of range");
+        else if (plan.ops[static_cast<std::size_t>(outputOp)].kind != OpKind::Output)
+            problems.push_back("output op " + std::to_string(outputOp) + " is not an Output op");
+    }
+
+    return problems;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/plan/RenderPlan.cpp
+++ b/magda/engine/plan/RenderPlan.cpp
@@ -96,6 +96,8 @@ const char* toString(OpRole role) {
             return "trackFader";
         case OpRole::TrackMeter:
             return "trackMeter";
+        case OpRole::TrackMute:
+            return "trackMute";
         case OpRole::SendTap:
             return "sendTap";
         case OpRole::HardwareOutput:

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -1,0 +1,220 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "core/TypeIds.hpp"
+
+/**
+ * @file RenderPlan.hpp
+ * @brief The native engine's render plan IR.
+ *
+ * A render plan is a flat, dependency-ordered list of ops. It encodes signal
+ * topology only — tracks, devices, routing, sends. Clip positions, automation
+ * curves, modulation and parameter values are NOT in the plan: ops read those
+ * through separately swapped snapshots, so editing them never triggers a
+ * compile. Structural recompiles therefore happen only at human speed.
+ *
+ * A published plan is immutable. Every structural change compiles a new plan
+ * and swaps it in atomically; the differ carries runtime state across the swap
+ * by matching ops on their OpKey.
+ */
+
+namespace magda::engine {
+
+/** Index of an op inside RenderPlan::ops. */
+using OpId = int;
+constexpr OpId INVALID_OP_ID = -1;
+
+/** Which kind of signal a port carries. */
+enum class SignalKind : std::uint8_t { Audio, Midi };
+
+/**
+ * @brief What an op computes.
+ *
+ * The vocabulary is deliberately small: anything a device does beyond
+ * processing (its gain trim, its meter tap) is its own op, so the differ can
+ * carry, rebuild and crossfade those pieces independently. Fusing adjacent
+ * cheap ops is a later back-end pass over the same flat list.
+ */
+enum class OpKind : std::uint8_t {
+    ClipAudio,   ///< audio clip playback for one track (reads the clip snapshot)
+    ClipMidi,    ///< MIDI clip playback for one track
+    AudioInput,  ///< live hardware audio input
+    MidiInput,   ///< live MIDI input
+    Device,      ///< a device instance (instrument, effect, MIDI or analysis)
+    MixAudio,   ///< ordered sum of audio inputs (summing order is compiled, never scheduling order)
+    MergeMidi,  ///< ordered merge of MIDI inputs
+    Gain,       ///< scalar gain
+    Fader,      ///< volume + pan
+    SendTap,    ///< pre/post-fader tap feeding another track
+    Meter,      ///< level tap read by the UI
+    Output,     ///< hardware output
+};
+
+/**
+ * @brief The op's structural role at its model location.
+ *
+ * Model ID alone does not identify an op — one device contributes a process op,
+ * a gain op and a meter op, all keyed on the same DeviceId. The role is the
+ * second half of the differ's identity key.
+ */
+enum class OpRole : std::uint8_t {
+    ClipAudio,        ///< the track's audio clip source
+    ClipMidi,         ///< the track's MIDI clip source
+    LiveAudioInput,   ///< the track's live audio input
+    LiveMidiInput,    ///< the track's live MIDI input
+    TrackAudioInput,  ///< sum of everything feeding the track's chain head
+    TrackMidiInput,   ///< merge of everything feeding the track's chain head
+    DeviceProcess,    ///< the device itself
+    DeviceGain,       ///< the device slot's gain trim
+    DeviceMeter,      ///< the device slot's level tap
+    ChainMidiMerge,   ///< raw chain MIDI merged with a device's MIDI output
+    RackChainFader,   ///< one rack chain's volume + pan
+    RackMix,          ///< sum of a rack's chains
+    RackMidiMix,      ///< merge of a rack's chain MIDI outputs
+    RackFader,        ///< the rack's output volume + pan
+    TrackFader,       ///< the track fader
+    TrackMeter,       ///< the track's post-fader level tap
+    SendTap,          ///< one send slot
+    HardwareOutput,   ///< the master's hardware output
+};
+
+/**
+ * @brief Whether an op's output is computable ahead of the transport.
+ *
+ * Deterministic ops depend only on the model, the transport position and
+ * parameter lanes, so an anticipative executor may render them ahead of time.
+ * Live ops depend on the outside world (hardware input) and can never be run
+ * early; liveness propagates downstream from a live source. Carried on every op
+ * from day one so the anticipative executor does not need a new plan format.
+ */
+enum class LivenessDomain : std::uint8_t { Deterministic, Live };
+
+/**
+ * @brief An op's identity across plan swaps.
+ *
+ * The differ hash-joins old and new plans on this key. It is a flat value type
+ * on purpose: no heap, comparable and hashable, so identity work never
+ * allocates. Only the fields relevant to the op's location are set; the rest
+ * stay invalid.
+ */
+struct OpKey {
+    TrackId trackId = INVALID_TRACK_ID;
+    RackId rackId = INVALID_RACK_ID;
+    ChainId chainId = INVALID_CHAIN_ID;
+    DeviceId deviceId = INVALID_DEVICE_ID;
+    OpRole role = OpRole::TrackAudioInput;
+    /// Disambiguates repeats of the same role at the same location (send slot).
+    int index = 0;
+
+    bool operator==(const OpKey& o) const {
+        return trackId == o.trackId && rackId == o.rackId && chainId == o.chainId &&
+               deviceId == o.deviceId && role == o.role && index == o.index;
+    }
+    bool operator!=(const OpKey& o) const {
+        return !(*this == o);
+    }
+    bool operator<(const OpKey& o) const;
+};
+
+/** A reference to one output port of an earlier op. */
+struct PortRef {
+    OpId op = INVALID_OP_ID;
+    int port = 0;
+
+    bool valid() const {
+        return op != INVALID_OP_ID;
+    }
+    bool operator==(const PortRef& o) const {
+        return op == o.op && port == o.port;
+    }
+};
+
+/** An unconnected input slot. Legal wherever the op's arity declares a slot
+ *  that this model configuration does not fill (an effect with no MIDI input,
+ *  a device with no sidechain source). */
+constexpr PortRef noInput() {
+    return PortRef{};
+}
+
+/**
+ * @brief One node of the render plan.
+ *
+ * Input arity is fixed per OpKind (see arityOf), so slot meaning is positional
+ * and stable: unfilled slots hold an invalid PortRef rather than shifting the
+ * remaining inputs down.
+ */
+struct PlanOp {
+    OpKind kind = OpKind::MixAudio;
+    OpKey key;
+    LivenessDomain liveness = LivenessDomain::Deterministic;
+    std::vector<PortRef> inputs;
+    std::vector<SignalKind> outputs;
+};
+
+/**
+ * @brief A compiled, immutable render plan.
+ *
+ * Ops are stored in dependency order: every input references an op at a lower
+ * index. That makes the reference executor a straight walk of the vector, and
+ * lets the parallel executor's scheduling constants be baked here at compile
+ * time rather than rebuilt on the audio thread every block.
+ */
+struct RenderPlan {
+    static constexpr int kVersion = 1;
+
+    int version = kVersion;
+    std::vector<PlanOp> ops;
+
+    /// Ops that drive hardware; the block is finished when these have run.
+    std::vector<OpId> outputOps;
+
+    // --- Scheduling constants, baked by bakeScheduling() ---
+
+    /// Per op: how many distinct producer ops it waits on. The executor memcpys
+    /// this into its live countdown array per block instead of walking the graph.
+    std::vector<std::uint16_t> dependencyCounts;
+
+    /// Reversed edges in CSR form: consumers of op i are
+    /// consumerEdges[consumerOffsets[i] .. consumerOffsets[i + 1]).
+    std::vector<int> consumerOffsets;
+    std::vector<OpId> consumerEdges;
+
+    /// Ops with no dependencies, seeded into the ready queue at block start.
+    std::vector<OpId> initialReadyOps;
+
+    /// Model configurations the compiler could not express, in compile order.
+    /// Never a silent drop: anything the plan does not implement says so here.
+    std::vector<std::string> diagnostics;
+};
+
+/**
+ * @brief Fixed number of input slots for an op kind, or -1 when variadic.
+ *
+ * Device slots are [audio, MIDI, sidechain audio].
+ */
+int arityOf(OpKind kind);
+
+/** Fill in dependencyCounts, consumer edges and initialReadyOps. */
+void bakeScheduling(RenderPlan& plan);
+
+/**
+ * @brief Structural checks over a compiled plan.
+ *
+ * Returns one message per violation, empty when the plan is well formed.
+ * Checks dependency ordering, input arity, port existence and signal-kind
+ * agreement between producer and consumer.
+ */
+std::vector<std::string> validatePlan(const RenderPlan& plan);
+
+const char* toString(OpKind kind);
+const char* toString(OpRole role);
+const char* toString(SignalKind kind);
+const char* toString(LivenessDomain domain);
+
+/** Canonical key text, e.g. "T1/R4/C5/D7:deviceProcess" or "T-2:trackFader". */
+std::string toString(const OpKey& key);
+
+}  // namespace magda::engine

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -11,7 +11,7 @@
  * @brief The native engine's render plan IR.
  *
  * A render plan is a flat, dependency-ordered list of ops. It encodes signal
- * topology only — tracks, devices, routing, sends. Clip positions, automation
+ * topology only: tracks, devices, routing, sends. Clip positions, automation
  * curves, modulation and parameter values are NOT in the plan: ops read those
  * through separately swapped snapshots, so editing them never triggers a
  * compile. Structural recompiles therefore happen only at human speed.
@@ -56,7 +56,7 @@ enum class OpKind : std::uint8_t {
 /**
  * @brief The op's structural role at its model location.
  *
- * Model ID alone does not identify an op — one device contributes a process op,
+ * Model ID alone does not identify an op: one device contributes a process op,
  * a gain op and a meter op, all keyed on the same DeviceId. The role is the
  * second half of the differ's identity key.
  */
@@ -76,7 +76,8 @@ enum class OpRole : std::uint8_t {
     RackMidiMix,      ///< merge of a rack's chain MIDI outputs
     RackFader,        ///< the rack's output volume + pan
     TrackFader,       ///< the track fader
-    TrackMeter,       ///< the track's post-fader level tap
+    TrackMeter,       ///< the track's post-fader, pre-mute level tap
+    TrackMute,        ///< mute and solo, applied after the meter and sidechain tap
     SendTap,          ///< one send slot
     HardwareOutput,   ///< the master's hardware output
 };

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -207,6 +207,13 @@ void bakeScheduling(RenderPlan& plan);
  * Returns one message per violation, empty when the plan is well formed.
  * Checks dependency ordering, input arity, port existence and signal-kind
  * agreement between producer and consumer.
+ *
+ * It also enforces the differ's two preconditions, which are cheap here and
+ * expensive anywhere else: OpKey uniqueness, because the differ hash-joins on
+ * the key and a collision carries one op's state into another rather than
+ * failing; and liveness provenance in both directions, because an over-tagged
+ * Live op is silently correct while quietly shrinking what the anticipative
+ * executor may precompute.
  */
 std::vector<std::string> validatePlan(const RenderPlan& plan);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -235,6 +235,13 @@ set(TEST_SOURCES
     test_spleeter_separator.cpp
 )
 
+# Native audio engine (epic #1882). The engine is a dark target with no TE and
+# no UI, but its compiler is exercised here: the model fixtures it compiles are
+# plain value types, so the plan tests are ordinary model-level Catch2 tests.
+if(MAGDA_BUILD_NATIVE_ENGINE)
+    list(APPEND TEST_SOURCES test_render_plan_compiler.cpp)
+endif()
+
 # Create test executable
 add_executable(magda_tests ${TEST_SOURCES})
 
@@ -251,6 +258,10 @@ target_link_libraries(magda_tests
     # JUCE (core + gui_basics) comes transitively from magda_daw, compiled once
     # there; direct links would recompile the JUCE stack into this target.
 )
+
+if(MAGDA_BUILD_NATIVE_ENGINE)
+    target_link_libraries(magda_tests PRIVATE magda_engine)
+endif()
 
 # Include directories
 target_include_directories(magda_tests

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -973,3 +973,57 @@ TEST_CASE("Sidechain discovery reaches every section emission does", "[engine][p
     REQUIRE(sourceMeter != magda::engine::INVALID_OP_ID);
     CHECK(inputOp(plan, device, 2) == sourceMeter);
 }
+
+TEST_CASE("Auto input monitoring only counts while the track is armed",
+          "[engine][plan][compiler]") {
+    // Auto maps to TE's automatic monitor mode, which passes input only while
+    // armed. Emitting a live op for an unarmed Auto track would both add a op
+    // the engine keeps silent and mark the whole chain downstream Live.
+    SECTION("unarmed Auto emits no live input") {
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].inputMonitor = InputMonitorMode::Auto;
+        tracks[0].audioInputDevice = "Input 1";
+        tracks[0].midiInputDevice = "Keyboard";
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        CHECK(countRole(plan, OpRole::LiveAudioInput) == 0);
+        CHECK(countRole(plan, OpRole::LiveMidiInput) == 0);
+        for (const auto& op : plan.ops)
+            CHECK(op.liveness == magda::engine::LivenessDomain::Deterministic);
+    }
+
+    SECTION("armed Auto emits it") {
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].inputMonitor = InputMonitorMode::Auto;
+        tracks[0].recordArmed = true;
+        tracks[0].audioInputDevice = "Input 1";
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(countRole(plan, OpRole::LiveAudioInput) == 1);
+    }
+
+    SECTION("In emits it without arming") {
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].inputMonitor = InputMonitorMode::In;
+        tracks[0].audioInputDevice = "Input 1";
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(countRole(plan, OpRole::LiveAudioInput) == 1);
+    }
+}
+
+TEST_CASE("A frozen track is reported as not compiled", "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(1)};
+    tracks[0].frozen = true;
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    REQUIRE(plan.diagnostics.size() == 1);
+    CHECK(plan.diagnostics.front().find("freeze") != std::string::npos);
+}

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -1027,3 +1027,73 @@ TEST_CASE("A frozen track is reported as not compiled", "[engine][plan][compiler
     REQUIRE(plan.diagnostics.size() == 1);
     CHECK(plan.diagnostics.front().find("freeze") != std::string::npos);
 }
+
+TEST_CASE("validatePlan enforces the differ's identity precondition", "[engine][plan][validate]") {
+    using magda::engine::LivenessDomain;
+    using magda::engine::PlanOp;
+    using magda::engine::PortRef;
+    using magda::engine::SignalKind;
+
+    RenderPlan plan;
+
+    PlanOp source;
+    source.kind = OpKind::ClipAudio;
+    source.key = {1, INVALID_RACK_ID, INVALID_CHAIN_ID, INVALID_DEVICE_ID, OpRole::ClipAudio, 0};
+    source.outputs = {SignalKind::Audio};
+    plan.ops.push_back(source);
+
+    // Same key, different op. The differ joins on the key, so this does not
+    // fail loudly at swap time: it carries one op's state into the other.
+    PlanOp collision;
+    collision.kind = OpKind::Gain;
+    collision.key = source.key;
+    collision.inputs = {PortRef{0, 0}};
+    collision.outputs = {SignalKind::Audio};
+    plan.ops.push_back(collision);
+
+    const auto problems = magda::engine::validatePlan(plan);
+    REQUIRE(problems.size() == 1);
+    CHECK(problems.front().find("same key as op 0") != std::string::npos);
+}
+
+TEST_CASE("validatePlan enforces liveness provenance", "[engine][plan][validate]") {
+    using magda::engine::LivenessDomain;
+    using magda::engine::PlanOp;
+    using magda::engine::PortRef;
+    using magda::engine::SignalKind;
+
+    RenderPlan plan;
+
+    PlanOp source;
+    source.kind = OpKind::ClipAudio;
+    source.key = {1, INVALID_RACK_ID, INVALID_CHAIN_ID, INVALID_DEVICE_ID, OpRole::ClipAudio, 0};
+    source.outputs = {SignalKind::Audio};
+    plan.ops.push_back(source);
+
+    SECTION("a live op with no live input and no live source is rejected") {
+        PlanOp overTagged;
+        overTagged.kind = OpKind::Gain;
+        overTagged.key = {
+            1, INVALID_RACK_ID, INVALID_CHAIN_ID, INVALID_DEVICE_ID, OpRole::TrackFader, 0};
+        overTagged.liveness = LivenessDomain::Live;
+        overTagged.inputs = {PortRef{0, 0}};
+        overTagged.outputs = {SignalKind::Audio};
+        plan.ops.push_back(overTagged);
+
+        const auto problems = magda::engine::validatePlan(plan);
+        REQUIRE(problems.size() == 1);
+        CHECK(problems.front().find("is live but reads nothing live") != std::string::npos);
+    }
+
+    SECTION("an input source may be live on its own") {
+        PlanOp input;
+        input.kind = OpKind::AudioInput;
+        input.key = {
+            1, INVALID_RACK_ID, INVALID_CHAIN_ID, INVALID_DEVICE_ID, OpRole::LiveAudioInput, 0};
+        input.liveness = LivenessDomain::Live;
+        input.outputs = {SignalKind::Audio};
+        plan.ops.push_back(input);
+
+        CHECK(magda::engine::validatePlan(plan).empty());
+    }
+}

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -842,3 +842,134 @@ TEST_CASE("A rack-level sidechain is reported as unsupported", "[engine][plan][c
     CHECK(plan.diagnostics.front().find("rack 4") != std::string::npos);
     CHECK(plan.diagnostics.front().find("modulation") != std::string::npos);
 }
+
+TEST_CASE("A malformed output routing is reported", "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(1)};
+    tracks[0].audioOutputDevice = "track:";
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    // The master fallback is the right behaviour; applying it silently is not.
+    REQUIRE(plan.diagnostics.size() == 1);
+    CHECK(plan.diagnostics.front().find("output routing") != std::string::npos);
+
+    magda::engine::OpId masterInput = magda::engine::INVALID_OP_ID;
+    for (const auto op : opsWithRole(plan, OpRole::TrackAudioInput))
+        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == MASTER_TRACK_ID)
+            masterInput = op;
+    REQUIRE(masterInput != magda::engine::INVALID_OP_ID);
+    CHECK(plan.ops[static_cast<std::size_t>(masterInput)].inputs.size() == 1);
+}
+
+TEST_CASE("A send to a track that no longer exists is reported as such",
+          "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(1)};
+    tracks[0].sends.push_back(SendInfo{0, 1.0f, false, 99});
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    // Emitting the tap anyway would leave it queued against a track that is
+    // never compiled, and the end-of-run sweep would blame a routing cycle.
+    CHECK(countRole(plan, OpRole::SendTap) == 0);
+    REQUIRE(plan.diagnostics.size() == 1);
+    CHECK(plan.diagnostics.front().find("does not exist") != std::string::npos);
+    CHECK(plan.diagnostics.front().find("cycle") == std::string::npos);
+}
+
+TEST_CASE("Only MIDI consumers the compiler emits pull in a MIDI source",
+          "[engine][plan][compiler]") {
+    SECTION("a bypassed instrument does not") {
+        auto instrument = makeInstrument(3);
+        instrument.bypassed = true;
+
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(instrument));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(countRole(plan, OpRole::ClipMidi) == 0);
+        CHECK(countRole(plan, OpRole::TrackMidiInput) == 0);
+    }
+
+    SECTION("an instrument behind chain power off does not") {
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.enabled = false;
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeInstrument(3)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(countRole(plan, OpRole::ClipMidi) == 0);
+    }
+
+    SECTION("an instrument in a bypassed rack does not") {
+        RackInfo rack;
+        rack.id = 4;
+        rack.bypassed = true;
+        ChainInfo chain;
+        chain.id = 10;
+        chain.elements.push_back(makeDeviceElement(makeInstrument(3)));
+        rack.chains.push_back(std::move(chain));
+
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(countRole(plan, OpRole::ClipMidi) == 0);
+    }
+
+    SECTION("but a MIDI sidechain reader still does, whatever the chain holds") {
+        auto gate = makeEffect(7);
+        gate.canReceiveMidi = true;
+        gate.sidechain.type = SidechainConfig::Type::MIDI;
+        gate.sidechain.sourceTrackId = 2;
+
+        auto bypassed = makeInstrument(3);
+        bypassed.bypassed = true;
+
+        std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(gate));
+        tracks[1].chain.fxChainElements.push_back(makeDeviceElement(bypassed));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(plan.diagnostics.empty());
+
+        // Track 2's own instrument is bypassed, but track 1 reads its MIDI, so
+        // its clips are compiled anyway. Track 1 has a MIDI consumer of its own
+        // and gets a source for the ordinary reason.
+        std::vector<magda::TrackId> clipMidiTracks;
+        for (const auto op : opsWithRole(plan, OpRole::ClipMidi))
+            clipMidiTracks.push_back(plan.ops[static_cast<std::size_t>(op)].key.trackId);
+        CHECK(clipMidiTracks == std::vector<magda::TrackId>{2, 1});
+    }
+}
+
+TEST_CASE("Sidechain discovery reaches every section emission does", "[engine][plan][compiler]") {
+    // Mixer-analysis devices are rail-managed and none sets canSidechain today,
+    // but emitDevice resolves a sidechain wherever it finds one, so collection
+    // has to walk the same sections or ordering silently depends on luck.
+    auto analysisWithSidechain = makeEffect(9);
+    analysisWithSidechain.deviceType = DeviceType::Analysis;
+    analysisWithSidechain.canSidechain = true;
+    analysisWithSidechain.sidechain.type = SidechainConfig::Type::Audio;
+    analysisWithSidechain.sidechain.sourceTrackId = 2;
+
+    // Declared before its source, so only the ordering edge can resolve it.
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+    tracks[0].chain.mixerAnalysisElements.push_back(PostFxChainElement{analysisWithSidechain});
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+    CHECK(plan.diagnostics.empty());
+
+    const auto device = opsWithRole(plan, OpRole::DeviceProcess).front();
+    magda::engine::OpId sourceMeter = magda::engine::INVALID_OP_ID;
+    for (const auto op : opsWithRole(plan, OpRole::TrackMeter))
+        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == 2)
+            sourceMeter = op;
+    REQUIRE(sourceMeter != magda::engine::INVALID_OP_ID);
+    CHECK(inputOp(plan, device, 2) == sourceMeter);
+}

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -98,19 +98,20 @@ TEST_CASE("Empty session compiles to a track feeding the master output",
     CHECK(plan.diagnostics.empty());
     CHECK(plan.outputOps.size() == 1);
 
-    // Track 1: clip source, input mix, fader, meter. Master: input mix, fader,
-    // meter, hardware output.
+    // Track 1: clip source, input mix, fader, meter, mute. Master: input mix,
+    // fader, meter, mute, hardware output.
     CHECK(countRole(plan, OpRole::ClipAudio) == 1);
     CHECK(countRole(plan, OpRole::TrackAudioInput) == 2);
     CHECK(countRole(plan, OpRole::TrackFader) == 2);
     CHECK(countRole(plan, OpRole::TrackMeter) == 2);
+    CHECK(countRole(plan, OpRole::TrackMute) == 2);
     CHECK(countRole(plan, OpRole::HardwareOutput) == 1);
 
-    // The master sums the track's post-fader meter output.
+    // The master sums the track's post-mute output.
     const auto masterInput = opsWithRole(plan, OpRole::TrackAudioInput).back();
-    const auto trackMeter = opsWithRole(plan, OpRole::TrackMeter).front();
+    const auto trackMute = opsWithRole(plan, OpRole::TrackMute).front();
     CHECK(plan.ops[static_cast<std::size_t>(masterInput)].key.trackId == MASTER_TRACK_ID);
-    CHECK(inputOp(plan, masterInput, 0) == trackMeter);
+    CHECK(inputOp(plan, masterInput, 0) == trackMute);
 }
 
 TEST_CASE("The plan dump is the compiler's golden surface", "[engine][plan][compiler]") {
@@ -121,7 +122,7 @@ TEST_CASE("The plan dump is the compiler's golden surface", "[engine][plan][comp
     requireWellFormed(plan);
 
     CHECK(magda::engine::dumpPlan(plan) == R"(magda-render-plan v1
-ops=11 outputs=1
+ops=13 outputs=1
 [  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
@@ -129,10 +130,12 @@ ops=11 outputs=1
 [  4] Meter       det   T1/D7:deviceMeter              in=3:0              out=audio       deps=1
 [  5] Fader       det   T1:trackFader                  in=4:0              out=audio       deps=1
 [  6] Meter       det   T1:trackMeter                  in=5:0              out=audio       deps=1
-[  7] MixAudio    det   T-2:trackAudioInput            in=6:0              out=audio       deps=1
-[  8] Fader       det   T-2:trackFader                 in=7:0              out=audio       deps=1
-[  9] Meter       det   T-2:trackMeter                 in=8:0              out=audio       deps=1
-[ 10] Output      det   T-2:hardwareOutput             in=9:0              out=-           deps=1
+[  7] Gain        det   T1:trackMute                   in=6:0              out=audio       deps=1
+[  8] MixAudio    det   T-2:trackAudioInput            in=7:0              out=audio       deps=1
+[  9] Fader       det   T-2:trackFader                 in=8:0              out=audio       deps=1
+[ 10] Meter       det   T-2:trackMeter                 in=9:0              out=audio       deps=1
+[ 11] Gain        det   T-2:trackMute                  in=10:0             out=audio       deps=1
+[ 12] Output      det   T-2:hardwareOutput             in=11:0             out=-           deps=1
 ready=0
 )");
 }
@@ -349,9 +352,9 @@ TEST_CASE("Group children are summed into the group track", "[engine][plan][comp
     // Both children, in project order, and nothing else: a group carries no
     // clips of its own.
     REQUIRE(plan.ops[static_cast<std::size_t>(groupInput)].inputs.size() == 2);
-    const auto meters = opsWithRole(plan, OpRole::TrackMeter);
-    CHECK(inputOp(plan, groupInput, 0) == meters[0]);
-    CHECK(inputOp(plan, groupInput, 1) == meters[1]);
+    const auto mutes = opsWithRole(plan, OpRole::TrackMute);
+    CHECK(inputOp(plan, groupInput, 0) == mutes[0]);
+    CHECK(inputOp(plan, groupInput, 1) == mutes[1]);
 
     // The master sums the group only; the children route into it, not past it.
     magda::engine::OpId masterInput = magda::engine::INVALID_OP_ID;
@@ -465,7 +468,7 @@ TEST_CASE("Scheduling constants match the compiled dependencies", "[engine][plan
     REQUIRE(plan.consumerOffsets.size() == plan.ops.size() + 1);
 
     // Every op is reachable from the initial ready set by counting down its
-    // dependencies exactly once through the consumer edges — the executor's
+    // dependencies exactly once through the consumer edges: the executor's
     // per-block loop, run here at compile time.
     auto countdown = plan.dependencyCounts;
     std::vector<magda::engine::OpId> queue = plan.initialReadyOps;
@@ -482,4 +485,258 @@ TEST_CASE("Scheduling constants match the compiled dependencies", "[engine][plan
     }
     CHECK(queue.size() == plan.ops.size());
     CHECK(std::ranges::all_of(countdown, [](auto count) { return count == 0; }));
+}
+
+TEST_CASE("An empty rack is transparent", "[engine][plan][compiler]") {
+    RackInfo rack;
+    rack.id = 4;
+
+    std::vector<TrackInfo> tracks{makeTrack(1)};
+    tracks[0].chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    // Compiling an empty rack to a zero-input mix would silence the track.
+    CHECK(countRole(plan, OpRole::RackMix) == 0);
+    CHECK(countRole(plan, OpRole::RackFader) == 0);
+
+    const auto trackInput = opsWithRole(plan, OpRole::TrackAudioInput).front();
+    CHECK(inputOp(plan, opsWithRole(plan, OpRole::TrackFader).front(), 0) == trackInput);
+}
+
+TEST_CASE("A bypassed rack is transparent", "[engine][plan][compiler]") {
+    RackInfo rack;
+    rack.id = 4;
+    rack.bypassed = true;
+    ChainInfo chain;
+    chain.id = 10;
+    chain.elements.push_back(makeDeviceElement(makeEffect(7)));
+    rack.chains.push_back(std::move(chain));
+
+    std::vector<TrackInfo> tracks{makeTrack(1)};
+    tracks[0].chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    CHECK(countRole(plan, OpRole::DeviceProcess) == 0);
+    CHECK(countRole(plan, OpRole::RackMix) == 0);
+    const auto trackInput = opsWithRole(plan, OpRole::TrackAudioInput).front();
+    CHECK(inputOp(plan, opsWithRole(plan, OpRole::TrackFader).front(), 0) == trackInput);
+}
+
+TEST_CASE("Nested racks compile through the outer rack's chain", "[engine][plan][compiler]") {
+    RackInfo inner;
+    inner.id = 8;
+    ChainInfo innerChain;
+    innerChain.id = 20;
+    innerChain.elements.push_back(makeDeviceElement(makeEffect(7)));
+    inner.chains.push_back(std::move(innerChain));
+
+    RackInfo outer;
+    outer.id = 4;
+    ChainInfo outerChain;
+    outerChain.id = 10;
+    outerChain.elements.push_back(makeRackElement(std::move(inner)));
+    outer.chains.push_back(std::move(outerChain));
+
+    std::vector<TrackInfo> tracks{makeTrack(1)};
+    tracks[0].chain.fxChainElements.push_back(makeRackElement(std::move(outer)));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster(), withoutDeviceMeters());
+    requireWellFormed(plan);
+
+    CHECK(countRole(plan, OpRole::RackMix) == 2);
+    CHECK(countRole(plan, OpRole::RackFader) == 2);
+
+    // The device is keyed by its innermost rack and chain, not the outer ones.
+    const auto device = opsWithRole(plan, OpRole::DeviceProcess).front();
+    CHECK(plan.ops[static_cast<std::size_t>(device)].key.rackId == 8);
+    CHECK(plan.ops[static_cast<std::size_t>(device)].key.chainId == 20);
+
+    // Inner rack fader feeds the outer chain fader, which feeds the outer mix.
+    const auto rackFaders = opsWithRole(plan, OpRole::RackFader);
+    const auto chainFaders = opsWithRole(plan, OpRole::RackChainFader);
+    REQUIRE(chainFaders.size() == 2);
+    CHECK(inputOp(plan, chainFaders[1], 0) == rackFaders[0]);
+}
+
+TEST_CASE("A MIDI sidechain reads the source track's chain-head MIDI", "[engine][plan][compiler]") {
+    auto gate = makeEffect(7);
+    gate.canReceiveMidi = true;
+    gate.sidechain.type = SidechainConfig::Type::MIDI;
+    gate.sidechain.sourceTrackId = 2;
+
+    // Track 2 has no instrument of its own, so nothing in its chain consumes
+    // MIDI; its clips still have to be compiled because track 1 reads them.
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(gate));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+    CHECK(plan.diagnostics.empty());
+
+    magda::engine::OpId sourceMidi = magda::engine::INVALID_OP_ID;
+    for (const auto op : opsWithRole(plan, OpRole::TrackMidiInput))
+        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == 2)
+            sourceMidi = op;
+    REQUIRE(sourceMidi != magda::engine::INVALID_OP_ID);
+
+    const auto device = opsWithRole(plan, OpRole::DeviceProcess).front();
+    CHECK(inputOp(plan, device, 1) == sourceMidi);
+}
+
+TEST_CASE("An internal MIDI route reads the source track's MIDI", "[engine][plan][compiler]") {
+    // Declared before its source, so only the routing dependency can order it.
+    std::vector<TrackInfo> tracks{makeTrack(2), makeTrack(1)};
+    tracks[0].midiInputDevice = "track:1";
+    tracks[0].inputMonitor = InputMonitorMode::In;
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeInstrument(3)));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+    CHECK(plan.diagnostics.empty());
+
+    // The route is internal, so it must not compile to a hardware MIDI input.
+    CHECK(countRole(plan, OpRole::LiveMidiInput) == 0);
+
+    magda::engine::OpId sourceMidi = magda::engine::INVALID_OP_ID;
+    magda::engine::OpId destMidi = magda::engine::INVALID_OP_ID;
+    for (const auto op : opsWithRole(plan, OpRole::TrackMidiInput)) {
+        const auto trackId = plan.ops[static_cast<std::size_t>(op)].key.trackId;
+        if (trackId == 1)
+            sourceMidi = op;
+        if (trackId == 2)
+            destMidi = op;
+    }
+    REQUIRE(sourceMidi != magda::engine::INVALID_OP_ID);
+    REQUIRE(destMidi != magda::engine::INVALID_OP_ID);
+
+    // Own clips first, then the routed source.
+    REQUIRE(plan.ops[static_cast<std::size_t>(destMidi)].inputs.size() == 2);
+    CHECK(inputOp(plan, destMidi, 1) == sourceMidi);
+}
+
+TEST_CASE("An internal audio route reads the source track's post-mute output",
+          "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(2), makeTrack(1)};
+    tracks[0].audioInputDevice = "track:1";
+    tracks[0].recordArmed = true;
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+    CHECK(plan.diagnostics.empty());
+
+    CHECK(countRole(plan, OpRole::LiveAudioInput) == 0);
+
+    magda::engine::OpId sourceMute = magda::engine::INVALID_OP_ID;
+    magda::engine::OpId destInput = magda::engine::INVALID_OP_ID;
+    for (const auto op : opsWithRole(plan, OpRole::TrackMute))
+        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == 1)
+            sourceMute = op;
+    for (const auto op : opsWithRole(plan, OpRole::TrackAudioInput))
+        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == 2)
+            destInput = op;
+    REQUIRE(sourceMute != magda::engine::INVALID_OP_ID);
+    REQUIRE(destInput != magda::engine::INVALID_OP_ID);
+
+    REQUIRE(plan.ops[static_cast<std::size_t>(destInput)].inputs.size() == 2);
+    CHECK(inputOp(plan, destInput, 1) == sourceMute);
+}
+
+TEST_CASE("Mute is applied after the meter and the sidechain tap", "[engine][plan][compiler]") {
+    // The current engine sends to the sidechain bus and taps the meter before
+    // the muting node, so a muted track still keys a compressor and still reads
+    // on its own meter.
+    auto compressor = makeEffect(7);
+    compressor.canSidechain = true;
+    compressor.sidechain.type = SidechainConfig::Type::Audio;
+    compressor.sidechain.sourceTrackId = 2;
+
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(compressor));
+    tracks[1].muted = true;
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    const auto muteOf = [&plan](magda::TrackId trackId) {
+        for (const auto op : opsWithRole(plan, OpRole::TrackMute))
+            if (plan.ops[static_cast<std::size_t>(op)].key.trackId == trackId)
+                return op;
+        return magda::engine::INVALID_OP_ID;
+    };
+    const auto meterOf = [&plan](magda::TrackId trackId) {
+        for (const auto op : opsWithRole(plan, OpRole::TrackMeter))
+            if (plan.ops[static_cast<std::size_t>(op)].key.trackId == trackId)
+                return op;
+        return magda::engine::INVALID_OP_ID;
+    };
+
+    // fader -> meter -> mute, per track.
+    REQUIRE(muteOf(2) != magda::engine::INVALID_OP_ID);
+    CHECK(inputOp(plan, muteOf(2), 0) == meterOf(2));
+
+    // The sidechain taps the meter, not the mute.
+    const auto device = opsWithRole(plan, OpRole::DeviceProcess).front();
+    CHECK(inputOp(plan, device, 2) == meterOf(2));
+
+    // What reaches the master is post-mute. Track 2 is summed first because the
+    // sidechain puts it ahead of track 1 in compile order.
+    magda::engine::OpId masterInput = magda::engine::INVALID_OP_ID;
+    for (const auto op : opsWithRole(plan, OpRole::TrackAudioInput))
+        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == MASTER_TRACK_ID)
+            masterInput = op;
+    REQUIRE(masterInput != magda::engine::INVALID_OP_ID);
+    CHECK(inputOp(plan, masterInput, 0) == muteOf(2));
+    CHECK(inputOp(plan, masterInput, 1) == muteOf(1));
+}
+
+TEST_CASE("A sidechain on an inactive device is not an ordering dependency",
+          "[engine][plan][compiler]") {
+    // Track 1 sends to track 2, and a bypassed device on track 1 reads track 2.
+    // Only the send is real; counting the dead sidechain as a dependency would
+    // invent a cycle and cost the send.
+    auto bypassed = makeEffect(7);
+    bypassed.bypassed = true;
+    bypassed.canSidechain = true;
+    bypassed.sidechain.type = SidechainConfig::Type::Audio;
+    bypassed.sidechain.sourceTrackId = 2;
+
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2, TrackType::Aux)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(bypassed));
+    tracks[1].auxBusIndex = 0;
+    tracks[0].sends.push_back(SendInfo{0, 1.0f, false, 2});
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    CHECK(plan.diagnostics.empty());
+    REQUIRE(countRole(plan, OpRole::SendTap) == 1);
+
+    magda::engine::OpId auxInput = magda::engine::INVALID_OP_ID;
+    for (const auto op : opsWithRole(plan, OpRole::TrackAudioInput))
+        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == 2)
+            auxInput = op;
+    REQUIRE(auxInput != magda::engine::INVALID_OP_ID);
+    CHECK(inputOp(plan, auxInput, 0) == opsWithRole(plan, OpRole::SendTap).front());
+}
+
+TEST_CASE("Chain power gates sidechain dependencies too", "[engine][plan][compiler]") {
+    auto compressor = makeEffect(7);
+    compressor.canSidechain = true;
+    compressor.sidechain.type = SidechainConfig::Type::Audio;
+    compressor.sidechain.sourceTrackId = 2;
+
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2, TrackType::Aux)};
+    tracks[0].chain.enabled = false;
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(compressor));
+    tracks[1].auxBusIndex = 0;
+    tracks[0].sends.push_back(SendInfo{0, 1.0f, false, 2});
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+    CHECK(plan.diagnostics.empty());
+    CHECK(countRole(plan, OpRole::SendTap) == 1);
 }

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -1,0 +1,485 @@
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+#include <vector>
+
+#include "core/RackInfo.hpp"
+#include "core/TrackInfo.hpp"
+#include "plan/PlanCompiler.hpp"
+#include "plan/PlanDump.hpp"
+#include "plan/RenderPlan.hpp"
+
+using namespace magda;
+using magda::engine::CompileOptions;
+using magda::engine::OpKind;
+using magda::engine::OpRole;
+using magda::engine::RenderPlan;
+
+namespace {
+
+TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Audio) {
+    TrackInfo track;
+    track.id = id;
+    track.type = type;
+    track.name = "Track " + juce::String(id);
+    track.audioOutputDevice = "master";
+    return track;
+}
+
+TrackInfo makeMaster() {
+    auto master = makeTrack(MASTER_TRACK_ID, TrackType::Master);
+    master.audioOutputDevice = {};
+    return master;
+}
+
+DeviceInfo makeEffect(DeviceId id) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Effect " + juce::String(id);
+    device.deviceType = DeviceType::Effect;
+    return device;
+}
+
+DeviceInfo makeInstrument(DeviceId id) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Instrument " + juce::String(id);
+    device.deviceType = DeviceType::Instrument;
+    device.isInstrument = true;
+    device.canReceiveMidi = true;
+    return device;
+}
+
+/// Ops of one kind+role, in plan order.
+std::vector<magda::engine::OpId> opsWithRole(const RenderPlan& plan, OpRole role) {
+    std::vector<magda::engine::OpId> found;
+    for (std::size_t i = 0; i < plan.ops.size(); ++i)
+        if (plan.ops[i].key.role == role)
+            found.push_back(static_cast<magda::engine::OpId>(i));
+    return found;
+}
+
+int countRole(const RenderPlan& plan, OpRole role) {
+    return static_cast<int>(opsWithRole(plan, role).size());
+}
+
+/// The op an input slot reads, or -1 when the slot is unconnected.
+magda::engine::OpId inputOp(const RenderPlan& plan, magda::engine::OpId op, std::size_t slot) {
+    const auto& inputs = plan.ops[static_cast<std::size_t>(op)].inputs;
+    if (slot >= inputs.size())
+        return magda::engine::INVALID_OP_ID;
+    return inputs[slot].op;
+}
+
+/// Every fixture must compile to a structurally sound plan; this is asserted
+/// alongside whatever each test is actually about.
+void requireWellFormed(const RenderPlan& plan) {
+    const auto problems = magda::engine::validatePlan(plan);
+    INFO(magda::engine::dumpPlan(plan));
+    for (const auto& problem : problems)
+        FAIL_CHECK(problem);
+    REQUIRE(problems.empty());
+}
+
+CompileOptions withoutDeviceMeters() {
+    CompileOptions options;
+    options.deviceMeters = false;
+    return options;
+}
+
+}  // namespace
+
+TEST_CASE("Empty session compiles to a track feeding the master output",
+          "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(1)};
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+
+    requireWellFormed(plan);
+    CHECK(plan.diagnostics.empty());
+    CHECK(plan.outputOps.size() == 1);
+
+    // Track 1: clip source, input mix, fader, meter. Master: input mix, fader,
+    // meter, hardware output.
+    CHECK(countRole(plan, OpRole::ClipAudio) == 1);
+    CHECK(countRole(plan, OpRole::TrackAudioInput) == 2);
+    CHECK(countRole(plan, OpRole::TrackFader) == 2);
+    CHECK(countRole(plan, OpRole::TrackMeter) == 2);
+    CHECK(countRole(plan, OpRole::HardwareOutput) == 1);
+
+    // The master sums the track's post-fader meter output.
+    const auto masterInput = opsWithRole(plan, OpRole::TrackAudioInput).back();
+    const auto trackMeter = opsWithRole(plan, OpRole::TrackMeter).front();
+    CHECK(plan.ops[static_cast<std::size_t>(masterInput)].key.trackId == MASTER_TRACK_ID);
+    CHECK(inputOp(plan, masterInput, 0) == trackMeter);
+}
+
+TEST_CASE("The plan dump is the compiler's golden surface", "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(1)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    CHECK(magda::engine::dumpPlan(plan) == R"(magda-render-plan v1
+ops=11 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
+[  4] Meter       det   T1/D7:deviceMeter              in=3:0              out=audio       deps=1
+[  5] Fader       det   T1:trackFader                  in=4:0              out=audio       deps=1
+[  6] Meter       det   T1:trackMeter                  in=5:0              out=audio       deps=1
+[  7] MixAudio    det   T-2:trackAudioInput            in=6:0              out=audio       deps=1
+[  8] Fader       det   T-2:trackFader                 in=7:0              out=audio       deps=1
+[  9] Meter       det   T-2:trackMeter                 in=8:0              out=audio       deps=1
+[ 10] Output      det   T-2:hardwareOutput             in=9:0              out=-           deps=1
+ready=0
+)");
+}
+
+TEST_CASE("Compilation is deterministic", "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2, TrackType::Aux)};
+    tracks[1].auxBusIndex = 0;
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeInstrument(3)));
+    tracks[0].sends.push_back(SendInfo{0, 0.5f, false, 2});
+
+    const auto first = magda::engine::compileRenderPlan(tracks, makeMaster());
+    const auto second = magda::engine::compileRenderPlan(tracks, makeMaster());
+
+    requireWellFormed(first);
+    CHECK(magda::engine::dumpPlan(first) == magda::engine::dumpPlan(second));
+}
+
+TEST_CASE("A device compiles to process, gain and meter ops", "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(1)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
+
+    SECTION("with device meters") {
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        const auto process = opsWithRole(plan, OpRole::DeviceProcess);
+        const auto gain = opsWithRole(plan, OpRole::DeviceGain);
+        const auto meter = opsWithRole(plan, OpRole::DeviceMeter);
+        REQUIRE(process.size() == 1);
+        REQUIRE(gain.size() == 1);
+        REQUIRE(meter.size() == 1);
+        CHECK(plan.ops[static_cast<std::size_t>(process.front())].key.deviceId == 7);
+        CHECK(inputOp(plan, gain.front(), 0) == process.front());
+        CHECK(inputOp(plan, meter.front(), 0) == gain.front());
+    }
+
+    SECTION("without device meters") {
+        const auto plan =
+            magda::engine::compileRenderPlan(tracks, makeMaster(), withoutDeviceMeters());
+        requireWellFormed(plan);
+        CHECK(countRole(plan, OpRole::DeviceMeter) == 0);
+        CHECK(countRole(plan, OpRole::DeviceGain) == 1);
+    }
+}
+
+TEST_CASE("Analysis devices compile to a bare process op", "[engine][plan][compiler]") {
+    auto scope = makeEffect(9);
+    scope.deviceType = DeviceType::Analysis;
+
+    std::vector<TrackInfo> tracks{makeTrack(1)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(scope));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    CHECK(countRole(plan, OpRole::DeviceProcess) == 1);
+    CHECK(countRole(plan, OpRole::DeviceGain) == 0);
+    CHECK(countRole(plan, OpRole::DeviceMeter) == 0);
+}
+
+TEST_CASE("A MIDI source is compiled only when the chain consumes MIDI",
+          "[engine][plan][compiler]") {
+    SECTION("an effect-only chain has no MIDI source") {
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(countRole(plan, OpRole::ClipMidi) == 0);
+        CHECK(countRole(plan, OpRole::TrackMidiInput) == 0);
+    }
+
+    SECTION("an instrument pulls the track's MIDI clips into the plan") {
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeInstrument(3)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        REQUIRE(countRole(plan, OpRole::ClipMidi) == 1);
+        REQUIRE(countRole(plan, OpRole::TrackMidiInput) == 1);
+
+        const auto instrument = opsWithRole(plan, OpRole::DeviceProcess).front();
+        const auto midiInput = opsWithRole(plan, OpRole::TrackMidiInput).front();
+        CHECK(inputOp(plan, instrument, 1) == midiInput);
+    }
+}
+
+TEST_CASE("Bypass and chain power remove devices from the plan", "[engine][plan][compiler]") {
+    auto bypassed = makeEffect(7);
+    bypassed.bypassed = true;
+
+    SECTION("a bypassed device is not compiled") {
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(bypassed));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+        CHECK(countRole(plan, OpRole::DeviceProcess) == 0);
+    }
+
+    SECTION("chain power gates the insert chain but not post-FX") {
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.enabled = false;
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
+        tracks[0].chain.postFxChainElements.push_back(PostFxChainElement{makeEffect(8)});
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        const auto process = opsWithRole(plan, OpRole::DeviceProcess);
+        REQUIRE(process.size() == 1);
+        CHECK(plan.ops[static_cast<std::size_t>(process.front())].key.deviceId == 8);
+    }
+}
+
+TEST_CASE("A rack compiles to per-chain faders, a mix and a rack fader",
+          "[engine][plan][compiler]") {
+    RackInfo rack;
+    rack.id = 4;
+    for (ChainId chainId : {10, 11}) {
+        ChainInfo chain;
+        chain.id = chainId;
+        chain.elements.push_back(makeDeviceElement(makeEffect(chainId + 90)));
+        rack.chains.push_back(std::move(chain));
+    }
+
+    std::vector<TrackInfo> tracks{makeTrack(1)};
+    tracks[0].chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster(), withoutDeviceMeters());
+    requireWellFormed(plan);
+
+    CHECK(countRole(plan, OpRole::RackChainFader) == 2);
+    CHECK(countRole(plan, OpRole::RackMix) == 1);
+    CHECK(countRole(plan, OpRole::RackFader) == 1);
+
+    // The rack mix sums the chain faders in compiled chain order, and the rack
+    // fader reads the mix.
+    const auto chainFaders = opsWithRole(plan, OpRole::RackChainFader);
+    const auto mix = opsWithRole(plan, OpRole::RackMix).front();
+    CHECK(inputOp(plan, mix, 0) == chainFaders[0]);
+    CHECK(inputOp(plan, mix, 1) == chainFaders[1]);
+    CHECK(inputOp(plan, opsWithRole(plan, OpRole::RackFader).front(), 0) == mix);
+
+    // Devices inside a rack are keyed by their enclosing rack and chain, which
+    // is what lets the differ tell two copies of the same device apart.
+    const auto devices = opsWithRole(plan, OpRole::DeviceProcess);
+    REQUIRE(devices.size() == 2);
+    CHECK(plan.ops[static_cast<std::size_t>(devices[0])].key.rackId == 4);
+    CHECK(plan.ops[static_cast<std::size_t>(devices[0])].key.chainId == 10);
+    CHECK(plan.ops[static_cast<std::size_t>(devices[1])].key.chainId == 11);
+}
+
+TEST_CASE("Sends are compiled after their source track", "[engine][plan][compiler]") {
+    // The aux is declared first in project order, so only the send dependency
+    // can put it after the source track.
+    std::vector<TrackInfo> tracks{makeTrack(2, TrackType::Aux), makeTrack(1)};
+    tracks[0].auxBusIndex = 0;
+    tracks[1].sends.push_back(SendInfo{0, 0.5f, false, 2});
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+    CHECK(plan.diagnostics.empty());
+
+    const auto sendTaps = opsWithRole(plan, OpRole::SendTap);
+    REQUIRE(sendTaps.size() == 1);
+
+    const auto sourceFader = opsWithRole(plan, OpRole::TrackFader).front();
+    CHECK(plan.ops[static_cast<std::size_t>(sourceFader)].key.trackId == 1);
+    // A post-fader send taps the fader output.
+    CHECK(inputOp(plan, sendTaps.front(), 0) == sourceFader);
+
+    // The aux track's input mix reads the send tap.
+    magda::engine::OpId auxInput = magda::engine::INVALID_OP_ID;
+    for (const auto op : opsWithRole(plan, OpRole::TrackAudioInput))
+        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == 2)
+            auxInput = op;
+    REQUIRE(auxInput != magda::engine::INVALID_OP_ID);
+    CHECK(inputOp(plan, auxInput, 0) == sendTaps.front());
+}
+
+TEST_CASE("A pre-fader send taps the signal before the fader", "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2, TrackType::Aux)};
+    tracks[1].auxBusIndex = 0;
+    tracks[0].sends.push_back(SendInfo{0, 1.0f, true, 2});
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    const auto sendTap = opsWithRole(plan, OpRole::SendTap).front();
+    const auto trackInput = opsWithRole(plan, OpRole::TrackAudioInput).front();
+    CHECK(inputOp(plan, sendTap, 0) == trackInput);
+}
+
+TEST_CASE("Group children are summed into the group track", "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(5, TrackType::Group), makeTrack(1), makeTrack(2)};
+    tracks[0].childIds = {1, 2};
+    for (int i = 1; i <= 2; ++i) {
+        tracks[static_cast<std::size_t>(i)].parentId = 5;
+        tracks[static_cast<std::size_t>(i)].audioOutputDevice = "track:5";
+    }
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+    CHECK(plan.diagnostics.empty());
+
+    magda::engine::OpId groupInput = magda::engine::INVALID_OP_ID;
+    for (const auto op : opsWithRole(plan, OpRole::TrackAudioInput))
+        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == 5)
+            groupInput = op;
+    REQUIRE(groupInput != magda::engine::INVALID_OP_ID);
+
+    // Both children, in project order, and nothing else: a group carries no
+    // clips of its own.
+    REQUIRE(plan.ops[static_cast<std::size_t>(groupInput)].inputs.size() == 2);
+    const auto meters = opsWithRole(plan, OpRole::TrackMeter);
+    CHECK(inputOp(plan, groupInput, 0) == meters[0]);
+    CHECK(inputOp(plan, groupInput, 1) == meters[1]);
+
+    // The master sums the group only; the children route into it, not past it.
+    magda::engine::OpId masterInput = magda::engine::INVALID_OP_ID;
+    for (const auto op : opsWithRole(plan, OpRole::TrackAudioInput))
+        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == MASTER_TRACK_ID)
+            masterInput = op;
+    REQUIRE(masterInput != magda::engine::INVALID_OP_ID);
+    CHECK(plan.ops[static_cast<std::size_t>(masterInput)].inputs.size() == 1);
+}
+
+TEST_CASE("An audio sidechain wires the source track's output into the device",
+          "[engine][plan][compiler]") {
+    auto compressor = makeEffect(7);
+    compressor.canSidechain = true;
+    compressor.sidechain.type = SidechainConfig::Type::Audio;
+    compressor.sidechain.sourceTrackId = 2;
+
+    // The sidechained track is declared first; only the sidechain dependency
+    // can reorder it after its source.
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(compressor));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+    CHECK(plan.diagnostics.empty());
+
+    const auto device = opsWithRole(plan, OpRole::DeviceProcess).front();
+    magda::engine::OpId sourceMeter = magda::engine::INVALID_OP_ID;
+    for (const auto op : opsWithRole(plan, OpRole::TrackMeter))
+        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == 2)
+            sourceMeter = op;
+    REQUIRE(sourceMeter != magda::engine::INVALID_OP_ID);
+    CHECK(inputOp(plan, device, 2) == sourceMeter);
+}
+
+TEST_CASE("Liveness propagates downstream from a live input", "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+    tracks[0].recordArmed = true;
+    tracks[0].audioInputDevice = "Input 1";
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    const auto liveOf = [&plan](magda::engine::OpId op) {
+        return plan.ops[static_cast<std::size_t>(op)].liveness ==
+               magda::engine::LivenessDomain::Live;
+    };
+
+    REQUIRE(countRole(plan, OpRole::LiveAudioInput) == 1);
+    CHECK(liveOf(opsWithRole(plan, OpRole::LiveAudioInput).front()));
+
+    // Track 1's chain and everything downstream of it, including the master.
+    for (const auto op : opsWithRole(plan, OpRole::TrackAudioInput)) {
+        const auto trackId = plan.ops[static_cast<std::size_t>(op)].key.trackId;
+        CHECK(liveOf(op) == (trackId == 1 || trackId == MASTER_TRACK_ID));
+    }
+    // Track 2 never touches the live signal.
+    for (const auto op : opsWithRole(plan, OpRole::ClipAudio))
+        CHECK_FALSE(liveOf(op));
+    CHECK(liveOf(plan.outputOps.front()));
+}
+
+TEST_CASE("The chord track is excluded from the plan", "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(9, TrackType::Chord)};
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    for (const auto& op : plan.ops)
+        CHECK(op.key.trackId != 9);
+}
+
+TEST_CASE("A send cycle is broken and reported", "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(1, TrackType::Aux), makeTrack(2, TrackType::Aux)};
+    tracks[0].auxBusIndex = 0;
+    tracks[1].auxBusIndex = 1;
+    tracks[0].sends.push_back(SendInfo{1, 1.0f, false, 2});
+    tracks[1].sends.push_back(SendInfo{0, 1.0f, false, 1});
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+
+    // The plan still has to be executable: a cycle costs a connection, never
+    // plan validity.
+    requireWellFormed(plan);
+    CHECK_FALSE(plan.diagnostics.empty());
+    CHECK(plan.outputOps.size() == 1);
+}
+
+TEST_CASE("A send with no destination is reported", "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(1)};
+    tracks[0].sends.push_back(SendInfo{3, 1.0f, false, INVALID_TRACK_ID});
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    REQUIRE(plan.diagnostics.size() == 1);
+    CHECK(plan.diagnostics.front().find("aux bus 3") != std::string::npos);
+    CHECK(countRole(plan, OpRole::SendTap) == 0);
+}
+
+TEST_CASE("Scheduling constants match the compiled dependencies", "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2, TrackType::Aux)};
+    tracks[1].auxBusIndex = 0;
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeInstrument(3)));
+    tracks[0].sends.push_back(SendInfo{0, 0.5f, false, 2});
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    REQUIRE(plan.dependencyCounts.size() == plan.ops.size());
+    REQUIRE(plan.consumerOffsets.size() == plan.ops.size() + 1);
+
+    // Every op is reachable from the initial ready set by counting down its
+    // dependencies exactly once through the consumer edges — the executor's
+    // per-block loop, run here at compile time.
+    auto countdown = plan.dependencyCounts;
+    std::vector<magda::engine::OpId> queue = plan.initialReadyOps;
+    std::size_t processed = 0;
+    while (processed < queue.size()) {
+        const auto op = queue[processed++];
+        const auto begin = plan.consumerOffsets[static_cast<std::size_t>(op)];
+        const auto end = plan.consumerOffsets[static_cast<std::size_t>(op) + 1];
+        for (auto edge = begin; edge < end; ++edge) {
+            const auto consumer = plan.consumerEdges[static_cast<std::size_t>(edge)];
+            if (--countdown[static_cast<std::size_t>(consumer)] == 0)
+                queue.push_back(consumer);
+        }
+    }
+    CHECK(queue.size() == plan.ops.size());
+    CHECK(std::ranges::all_of(countdown, [](auto count) { return count == 0; }));
+}

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -487,7 +487,7 @@ TEST_CASE("Scheduling constants match the compiled dependencies", "[engine][plan
     CHECK(std::ranges::all_of(countdown, [](auto count) { return count == 0; }));
 }
 
-TEST_CASE("An empty rack is transparent", "[engine][plan][compiler]") {
+TEST_CASE("An empty rack passes signal through its fader", "[engine][plan][compiler]") {
     RackInfo rack;
     rack.id = 4;
 
@@ -497,12 +497,17 @@ TEST_CASE("An empty rack is transparent", "[engine][plan][compiler]") {
     const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
     requireWellFormed(plan);
 
-    // Compiling an empty rack to a zero-input mix would silence the track.
+    // Compiling an empty rack to a zero-input mix would silence the track, and
+    // there is nothing to sum. Rack volume and pan still apply though: the
+    // current engine writes them to the instance output gains regardless of
+    // chains, and they sit on the wet path.
     CHECK(countRole(plan, OpRole::RackMix) == 0);
-    CHECK(countRole(plan, OpRole::RackFader) == 0);
+    REQUIRE(countRole(plan, OpRole::RackFader) == 1);
 
     const auto trackInput = opsWithRole(plan, OpRole::TrackAudioInput).front();
-    CHECK(inputOp(plan, opsWithRole(plan, OpRole::TrackFader).front(), 0) == trackInput);
+    const auto rackFader = opsWithRole(plan, OpRole::RackFader).front();
+    CHECK(inputOp(plan, rackFader, 0) == trackInput);
+    CHECK(inputOp(plan, opsWithRole(plan, OpRole::TrackFader).front(), 0) == rackFader);
 }
 
 TEST_CASE("A bypassed rack is transparent", "[engine][plan][compiler]") {
@@ -739,4 +744,101 @@ TEST_CASE("Chain power gates sidechain dependencies too", "[engine][plan][compil
     requireWellFormed(plan);
     CHECK(plan.diagnostics.empty());
     CHECK(countRole(plan, OpRole::SendTap) == 1);
+}
+
+TEST_CASE("A malformed track route is reported, not reinterpreted", "[engine][plan][compiler]") {
+    SECTION("as an audio input") {
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].audioInputDevice = "track:1-2";
+        tracks[0].recordArmed = true;
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        // Falling back to a hardware input would put a live op in the plan for
+        // a route the user never asked for.
+        CHECK(countRole(plan, OpRole::LiveAudioInput) == 0);
+        REQUIRE(plan.diagnostics.size() == 1);
+        CHECK(plan.diagnostics.front().find("track:1-2") != std::string::npos);
+    }
+
+    SECTION("as a MIDI input") {
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].midiInputDevice = "track:";
+        tracks[0].inputMonitor = InputMonitorMode::In;
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        CHECK(countRole(plan, OpRole::LiveMidiInput) == 0);
+        REQUIRE(plan.diagnostics.size() == 1);
+        CHECK(plan.diagnostics.front().find("MIDI input routing") != std::string::npos);
+    }
+}
+
+TEST_CASE("An inactive internal route is not an ordering dependency", "[engine][plan][compiler]") {
+    // Track 2 has an input from track 1 but is neither armed nor monitoring, so
+    // it reads nothing. Track 1 sidechains from track 2. Counting the dead
+    // route as a dependency would close a cycle and cost the live sidechain.
+    auto compressor = makeEffect(7);
+    compressor.canSidechain = true;
+    compressor.sidechain.type = SidechainConfig::Type::Audio;
+    compressor.sidechain.sourceTrackId = 2;
+
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(compressor));
+    tracks[1].audioInputDevice = "track:1";
+    tracks[1].recordArmed = false;
+    tracks[1].inputMonitor = InputMonitorMode::Off;
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+    CHECK(plan.diagnostics.empty());
+
+    // Track 2 is compiled first and its output reaches the sidechain slot.
+    const auto device = opsWithRole(plan, OpRole::DeviceProcess).front();
+    magda::engine::OpId sourceMeter = magda::engine::INVALID_OP_ID;
+    for (const auto op : opsWithRole(plan, OpRole::TrackMeter))
+        if (plan.ops[static_cast<std::size_t>(op)].key.trackId == 2)
+            sourceMeter = op;
+    REQUIRE(sourceMeter != magda::engine::INVALID_OP_ID);
+    CHECK(inputOp(plan, device, 2) == sourceMeter);
+}
+
+TEST_CASE("An unmonitored MIDI route does not make its source compile MIDI",
+          "[engine][plan][compiler]") {
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+    tracks[1].midiInputDevice = "track:1";
+    tracks[1].inputMonitor = InputMonitorMode::Off;
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    // Track 1 has no MIDI consumer of its own and nothing reads its MIDI, so
+    // compiling clip MIDI for it would leave ops no one consumes.
+    CHECK(countRole(plan, OpRole::ClipMidi) == 0);
+    CHECK(countRole(plan, OpRole::TrackMidiInput) == 0);
+}
+
+TEST_CASE("A rack-level sidechain is reported as unsupported", "[engine][plan][compiler]") {
+    RackInfo rack;
+    rack.id = 4;
+    rack.sidechain.type = SidechainConfig::Type::MIDI;
+    rack.sidechain.sourceTrackId = 2;
+    ChainInfo chain;
+    chain.id = 10;
+    chain.elements.push_back(makeDeviceElement(makeEffect(7)));
+    rack.chains.push_back(std::move(chain));
+
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+    tracks[0].chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    // It drives rack modulation rather than signal, so the plan carries no edge
+    // for it. That is a gap the contract says to name rather than pass over.
+    REQUIRE(plan.diagnostics.size() == 1);
+    CHECK(plan.diagnostics.front().find("rack 4") != std::string::npos);
+    CHECK(plan.diagnostics.front().find("modulation") != std::string::npos);
 }


### PR DESCRIPTION
Part of #1889 (epic #1882). First slice of the delivery split agreed on the issue: plan IR, deterministic compiler and canonical dump. No executor, no PDC, no buffer assignment.

## The IR

`magda/engine/plan/RenderPlan.hpp` — a flat, dependency-ordered op list.

- `OpKey` (track / rack / chain / device ids plus a structural role) is the differ's identity key. A device contributes a process op, a gain op and a meter op, so model id alone cannot identify an op; the role is the other half.
- `LivenessDomain` is on every op from day one, reserved for the anticipative executor. Live sources tag themselves and liveness propagates downstream.
- Input arity is fixed per op kind, so slot meaning stays positional: a device is always `[audio, MIDI, sidechain]` with unfilled slots holding an invalid `PortRef` rather than shifting the rest down.
- `bakeScheduling()` precomputes dependency counts, reversed edges in CSR form and the initial ready list. TE walks every node on the audio thread each block to reseed its queue; here that becomes a memcpy of a plan constant.
- `validatePlan()` checks dependency ordering, arity, port existence, producer/consumer signal-kind agreement and liveness monotonicity.

The plan encodes signal topology only. Clip positions, automation curves, modulation and parameter values stay out, so editing them never triggers a compile.

## The compiler

`magda/engine/plan/PlanCompiler.cpp` compiles the track model directly, taking `TrackInfo` values rather than reaching into `TrackManager`, so it stays pure and offline-testable.

Covered: track chains with nested racks, post-FX and mixer-analysis sections in the order the current engine sequences them, chain power as a gate over the insert chain (post-FX unaffected), device bypass, pre and post-fader sends to aux tracks, group summing, audio and MIDI sidechains, master, hardware output. MIDI stream policy comes from the existing `routing::ChainRoutingModel` rather than being re-derived.

Track emission order is a topological sort over routing, send and sidechain dependencies. A routing cycle is broken deterministically at the lowest-numbered track and reported.

Anything the compiler cannot express lands in `RenderPlan::diagnostics` instead of being dropped silently: rack aux outputs, multi-out pairs, sends with no resolvable destination. Nothing is ever summed into the wrong place to avoid an empty result.

## Isolation

The target is dark behind `MAGDA_BUILD_NATIVE_ENGINE` (default ON so it cannot rot) and linked by nothing but the tests. A configure-time boundary check rejects any Tracktion Engine include and any quoted include outside the model layer, so the isolation the epic asks for is enforced by the build rather than by review. Both branches of the check were verified by temporarily injecting a forbidden include of each kind.

## Tests

`tests/test_render_plan_compiler.cpp`, 17 model-level Catch2 cases including a full-dump golden, a determinism check, and a scheduling test that runs the executor's countdown loop at compile time to prove the baked constants drain every op exactly once. Every fixture also asserts `validatePlan()` is clean.

Full suite locally: 1805 cases, 1792 passed, 13 skipped, 0 failed.

## Next

The minimal single-threaded executor over this plan, then runtime-state ownership and epoch retirement, then PDC and buffer assignment.