### PR TITLE
Native engine: latency compensation and buffer assignment (#1889)

### DIFF
--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -15,10 +15,12 @@ add_library(magda_engine STATIC
     plan/PlanDump.hpp
     plan/TrackRouting.hpp
     exec/PlanExecutor.cpp
+    exec/PlanLayout.cpp
     exec/PlanValues.cpp
     exec/RuntimeStateStore.cpp
     exec/EngineSession.cpp
     exec/PlanExecutor.hpp
+    exec/PlanLayout.hpp
     exec/PlanValues.hpp
     exec/PlanBindings.hpp
     exec/EngineDevice.hpp

--- a/magda/engine/exec/EngineDevice.hpp
+++ b/magda/engine/exec/EngineDevice.hpp
@@ -19,13 +19,30 @@
 namespace magda::engine {
 
 /**
- * @brief Encoded MIDI one source or device may write to one port in one block.
+ * @brief Encoded MIDI one source or device may write to one port over any
+ *        RenderContext::maxBlockSize samples of the timeline.
  *
  * The executor reserves storage for every MIDI port before the first block, so
  * nothing on the audio thread has to grow a buffer. A port fed by a merge is
  * sized from the sum of what feeds it; the chain has to end somewhere, and this
  * is where: a producer that writes past this forces the very allocation the
  * reservation exists to avoid. Debug builds assert on it at every write site.
+ *
+ * The budget is per span of samples rather than per callback, and the
+ * difference is not pedantry. Blocks may be shorter than the one the plan was
+ * prepared for, so a callback is not a fixed amount of time: a host delivering
+ * one sample at a time against a plan prepared for five hundred and twelve
+ * would fit five hundred and twelve callbacks inside the same stretch of
+ * timeline, and any storage sized from a per-callback figure would be short by
+ * that factor. Nothing noticed while every reservation covered one block; a
+ * delay line holds what is in flight across many, and it is what the amount of
+ * time a callback stands for has to be pinned down for.
+ *
+ * Every producer the engine has already works this way, because MIDI is
+ * positioned on the timeline rather than per call: a clip source renders the
+ * events its block's time range contains, live input delivers what arrived
+ * while that time passed, and a generator places notes at musical positions.
+ * Spelling it out is what lets storage be sized from it.
  *
  * The budget is bytes rather than events because a MIDI message is not a fixed
  * size: one SysEx dump from a controller can outweigh a thousand notes, and a

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -30,6 +30,13 @@ void copyWithGain(juce::dsp::AudioBlock<float> destination, juce::dsp::AudioBloc
             channelGain(value, channel), numSamples);
 }
 
+void applyGain(juce::dsp::AudioBlock<float> block, const OpValue& value, int numSamples) {
+    for (std::size_t channel = 0; channel < block.getNumChannels(); ++channel)
+        juce::FloatVectorOperations::multiply(block.getChannelPointer(channel),
+                                              channelGain(value, static_cast<int>(channel)),
+                                              numSamples);
+}
+
 float peakOf(juce::dsp::AudioBlock<float> block, int numSamples) {
     float peak = 0.0f;
     for (std::size_t channel = 0; channel < block.getNumChannels(); ++channel) {
@@ -42,14 +49,95 @@ float peakOf(juce::dsp::AudioBlock<float> block, int numSamples) {
 
 }  // namespace
 
+void AudioDelayLine::prepare(int numChannels, int delaySamples, int maxBlockSize) {
+    delay_ = delaySamples;
+    writePosition_ = 0;
+    ring_.setSize(numChannels, delaySamples + maxBlockSize, false, true, false);
+    ring_.clear();
+}
+
+void AudioDelayLine::process(juce::dsp::AudioBlock<float> block, int numSamples) {
+    const auto capacity = ring_.getNumSamples();
+    const auto numChannels =
+        std::min(ring_.getNumChannels(), static_cast<int>(block.getNumChannels()));
+
+    // Written before it is read, so a block whose delay is shorter than itself
+    // reads back the samples it just handed over, and an output sharing its
+    // input's buffer is no different from one that does not.
+    for (int done = 0; done < numSamples;) {
+        const auto chunk = std::min(numSamples - done, capacity - writePosition_);
+        for (int channel = 0; channel < numChannels; ++channel)
+            ring_.copyFrom(channel, writePosition_,
+                           block.getChannelPointer(static_cast<std::size_t>(channel)) + done,
+                           chunk);
+        writePosition_ = (writePosition_ + chunk) % capacity;
+        done += chunk;
+    }
+
+    auto readPosition = writePosition_ - numSamples - delay_;
+    while (readPosition < 0)
+        readPosition += capacity;
+
+    for (int done = 0; done < numSamples;) {
+        const auto chunk = std::min(numSamples - done, capacity - readPosition);
+        for (int channel = 0; channel < numChannels; ++channel)
+            juce::FloatVectorOperations::copy(
+                block.getChannelPointer(static_cast<std::size_t>(channel)) + done,
+                ring_.getReadPointer(channel, readPosition), chunk);
+        readPosition = (readPosition + chunk) % capacity;
+        done += chunk;
+    }
+}
+
+void MidiDelayLine::prepare(int delaySamples, int capacityBytes) {
+    delay_ = delaySamples;
+    pending_.clear();
+    scratch_.clear();
+    // Both, and to the same size: they are swapped every block, so the storage
+    // travels with them and one of them being the small one would allocate on
+    // the callback the first time it came round.
+    pending_.ensureSize(static_cast<std::size_t>(capacityBytes));
+    scratch_.ensureSize(static_cast<std::size_t>(capacityBytes));
+}
+
+void MidiDelayLine::process(const juce::MidiBuffer& in, juce::MidiBuffer& out, int numSamples) {
+    scratch_.clear();
+
+    // Positions are relative to the start of the block, so what is still in the
+    // future stays here and moves one block closer.
+    for (const auto metadata : pending_) {
+        if (metadata.samplePosition < numSamples)
+            out.addEvent(metadata.data, metadata.numBytes, metadata.samplePosition);
+        else
+            scratch_.addEvent(metadata.data, metadata.numBytes,
+                              metadata.samplePosition - numSamples);
+    }
+
+    for (const auto metadata : in) {
+        const auto position = metadata.samplePosition + delay_;
+        if (position < numSamples)
+            out.addEvent(metadata.data, metadata.numBytes, position);
+        else
+            scratch_.addEvent(metadata.data, metadata.numBytes, position - numSamples);
+    }
+
+    pending_.swapWith(scratch_);
+}
+
 void PlanExecutor::reset() {
     plan_ = nullptr;
     planFingerprint_ = 0;
+    latencySamples_ = 0;
     audioSlots_.clear();
     midiSlots_.clear();
     midiByteBounds_.clear();
     portOffsets_.clear();
     portSlots_.clear();
+    writesInPlace_.clear();
+    audioDelayForOp_.clear();
+    midiDelayForOp_.clear();
+    audioDelays_.clear();
+    midiDelays_.clear();
     deviceForOp_.clear();
     audioSourceForOp_.clear();
     midiSourceForOp_.clear();
@@ -73,61 +161,6 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
 
     context_ = context;
     const auto numOps = plan.ops.size();
-
-    // Flatten (op, port) to a buffer slot. Audio and MIDI ports are counted
-    // separately; which array a slot indexes follows from the port's kind,
-    // which the plan already carries.
-    portOffsets_.assign(numOps + 1, 0);
-    portSlots_.clear();
-    int numAudioSlots = 0;
-    int numMidiSlots = 0;
-    for (std::size_t i = 0; i < numOps; ++i) {
-        portOffsets_[i] = static_cast<int>(portSlots_.size());
-        for (const auto kind : plan.ops[i].outputs)
-            portSlots_.push_back(kind == SignalKind::Audio ? numAudioSlots++ : numMidiSlots++);
-    }
-    portOffsets_[numOps] = static_cast<int>(portSlots_.size());
-
-    audioSlots_.resize(static_cast<std::size_t>(numAudioSlots));
-    for (auto& buffer : audioSlots_)
-        buffer.setSize(context_.numChannels, context_.maxBlockSize, false, true, false);
-
-    // Reserving a flat amount per MIDI port is not enough: a merge carries
-    // everything that reaches it, so fan-in outgrows any fixed figure and the
-    // first block that does grows a buffer on the callback. The bound is
-    // computed through the MIDI graph instead, which ops being in dependency
-    // order makes a single forward pass. Producers are capped by contract
-    // (kMaxMidiBytesPerPort), and that cap is what the sums are built from.
-    midiSlots_.resize(static_cast<std::size_t>(numMidiSlots));
-    midiByteBounds_.assign(static_cast<std::size_t>(numMidiSlots), kMaxMidiBytesPerPort);
-    for (std::size_t i = 0; i < numOps; ++i) {
-        const auto& op = plan.ops[i];
-        if (op.kind != OpKind::MergeMidi && op.kind != OpKind::Fader)
-            continue;
-
-        int carried = 0;
-        for (std::size_t slot = 0; slot < op.inputs.size(); ++slot) {
-            const auto& input = op.inputs[slot];
-            if (!input.valid())
-                continue;
-            if (plan.ops[static_cast<std::size_t>(input.op)]
-                    .outputs[static_cast<std::size_t>(input.port)] != SignalKind::Midi)
-                continue;
-            carried += midiByteBounds_[static_cast<std::size_t>(slotFor(input))];
-        }
-
-        for (int port = 0; port < static_cast<int>(op.outputs.size()); ++port)
-            if (op.outputs[static_cast<std::size_t>(port)] == SignalKind::Midi)
-                midiByteBounds_[static_cast<std::size_t>(
-                    slotFor(PortRef{static_cast<OpId>(i), port}))] = carried;
-    }
-
-    for (std::size_t slot = 0; slot < midiSlots_.size(); ++slot)
-        midiSlots_[slot].ensureSize(static_cast<std::size_t>(midiByteBounds_[slot]));
-
-    silence_.setSize(context_.numChannels, context_.maxBlockSize, false, true, false);
-    silence_.clear();
-    noMidi_.clear();
 
     deviceForOp_.assign(numOps, nullptr);
     audioSourceForOp_.assign(numOps, nullptr);
@@ -212,15 +245,133 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
         prepareOnce(audioSourceForOp_[i]);
         prepareOnce(midiSourceForOp_[i]);
         prepareOnce(deviceForOp_[i]);
-
-        // Read but not acted on. Latency compensation is its own slice, and a
-        // device that delays its output by samples nobody aligns is a phase
-        // error in the mix rather than a missing feature nobody notices.
-        if (const auto* device = deviceForOp_[i]; device != nullptr && device->latencySamples() > 0)
-            messages.push_back(describe(i) + "device reports " +
-                               std::to_string(device->latencySamples()) +
-                               " samples of latency, which nothing compensates for yet");
     }
+
+    // --- what the bindings decide -------------------------------------------
+    //
+    // Everything below reads the instances rather than the plan or the model. A
+    // plugin only reports its latency once it is loaded and prepared, which is
+    // now, and how many samples each delay holds decides which ports can share
+    // a buffer. So the two passes run here, in this order, on every prepare.
+
+    std::vector<int> deviceLatency(numOps, 0);
+    for (std::size_t i = 0; i < numOps; ++i)
+        if (const auto* device = deviceForOp_[i]; device != nullptr)
+            deviceLatency[i] = device->latencySamples();
+
+    portOffsets_ = portOffsetsOf(plan);
+    const auto latency = resolvePlanLatency(plan, portOffsets_, deviceLatency);
+    latencySamples_ = latency.outputLatency;
+
+    const auto layout = assignBuffers(plan, portOffsets_, latency.delaySamples);
+    portSlots_ = layout.portSlots;
+    writesInPlace_ = layout.writesInPlace;
+
+    audioSlots_.resize(static_cast<std::size_t>(layout.numAudioSlots));
+    for (auto& buffer : audioSlots_)
+        buffer.setSize(context_.numChannels, context_.maxBlockSize, false, true, false);
+
+    // Reserving a flat amount per MIDI port is not enough: a merge carries
+    // everything that reaches it, so fan-in outgrows any fixed figure and the
+    // first block that does grows a buffer on the callback. The bound is
+    // computed through the MIDI graph instead, which ops being in dependency
+    // order makes a single forward pass. Producers are capped by contract
+    // (kMaxMidiBytesPerPort), and that cap is what the sums are built from.
+    //
+    // Ports sharing a buffer changes what that bound is for: one port at a time
+    // is live in a slot, so a slot has to hold the largest of its users rather
+    // than the sum of them.
+    const auto numPorts = static_cast<std::size_t>(portOffsets_.back());
+    std::vector<int> portMidiBytes(numPorts, kMaxMidiBytesPerPort);
+    const auto flatPort = [this](const PortRef& ref) {
+        return static_cast<std::size_t>(portOffsets_[static_cast<std::size_t>(ref.op)] + ref.port);
+    };
+
+    for (std::size_t i = 0; i < numOps; ++i) {
+        const auto& op = plan.ops[i];
+
+        if (op.kind == OpKind::Delay) {
+            if (op.outputs.front() != SignalKind::Midi)
+                continue;
+            // A delay's output block covers one block of its input's time, and
+            // a block-length window falls across two of them unless the delay
+            // is a whole number of blocks. Zero is not a delay at all: the op
+            // does not run and the port is its input's.
+            const auto carried = portMidiBytes[flatPort(op.inputs.front())];
+            portMidiBytes[static_cast<std::size_t>(portOffsets_[i])] =
+                latency.delaySamples[i] == 0 ? carried : 2 * carried;
+            continue;
+        }
+
+        if (op.kind != OpKind::MergeMidi && op.kind != OpKind::Fader)
+            continue;
+
+        int carried = 0;
+        for (const auto& input : op.inputs) {
+            if (!input.valid())
+                continue;
+            if (plan.ops[static_cast<std::size_t>(input.op)]
+                    .outputs[static_cast<std::size_t>(input.port)] != SignalKind::Midi)
+                continue;
+            carried += portMidiBytes[flatPort(input)];
+        }
+
+        for (std::size_t port = 0; port < op.outputs.size(); ++port)
+            if (op.outputs[port] == SignalKind::Midi)
+                portMidiBytes[static_cast<std::size_t>(portOffsets_[i]) + port] = carried;
+    }
+
+    midiSlots_.resize(static_cast<std::size_t>(layout.numMidiSlots));
+    midiByteBounds_.assign(static_cast<std::size_t>(layout.numMidiSlots), 0);
+    for (std::size_t i = 0; i < numOps; ++i) {
+        for (std::size_t port = 0; port < plan.ops[i].outputs.size(); ++port) {
+            if (plan.ops[i].outputs[port] != SignalKind::Midi)
+                continue;
+            const auto flat = static_cast<std::size_t>(portOffsets_[i]) + port;
+            auto& bound = midiByteBounds_[static_cast<std::size_t>(portSlots_[flat])];
+            bound = std::max(bound, portMidiBytes[flat]);
+        }
+    }
+
+    for (std::size_t slot = 0; slot < midiSlots_.size(); ++slot)
+        midiSlots_[slot].ensureSize(static_cast<std::size_t>(midiByteBounds_[slot]));
+
+    // Delay lines, for the edges that turned out to need one. A plan with no
+    // latency in it allocates nothing here, which is the whole point of
+    // resolving the counts before anything is sized.
+    audioDelayForOp_.assign(numOps, -1);
+    midiDelayForOp_.assign(numOps, -1);
+    int numAudioDelays = 0;
+    int numMidiDelays = 0;
+    for (std::size_t i = 0; i < numOps; ++i) {
+        if (plan.ops[i].kind != OpKind::Delay || latency.delaySamples[i] <= 0)
+            continue;
+        if (plan.ops[i].outputs.front() == SignalKind::Audio)
+            audioDelayForOp_[i] = numAudioDelays++;
+        else
+            midiDelayForOp_[i] = numMidiDelays++;
+    }
+
+    audioDelays_.resize(static_cast<std::size_t>(numAudioDelays));
+    midiDelays_.resize(static_cast<std::size_t>(numMidiDelays));
+    for (std::size_t i = 0; i < numOps; ++i) {
+        const auto samples = latency.delaySamples[i];
+        if (audioDelayForOp_[i] >= 0)
+            audioDelays_[static_cast<std::size_t>(audioDelayForOp_[i])].prepare(
+                context_.numChannels, samples, context_.maxBlockSize);
+
+        if (midiDelayForOp_[i] >= 0) {
+            // Every block the delay spans is holding events, plus the one being
+            // filled and the one being drained.
+            const auto blocks = samples / context_.maxBlockSize + 2;
+            midiDelays_[static_cast<std::size_t>(midiDelayForOp_[i])].prepare(
+                samples, blocks * portMidiBytes[flatPort(plan.ops[i].inputs.front())]);
+        }
+    }
+
+    silence_.setSize(context_.numChannels, context_.maxBlockSize, false, true, false);
+    silence_.clear();
+    noMidi_.clear();
 
     planFingerprint_ = planFingerprint(plan);
     plan_ = &plan;
@@ -304,15 +455,59 @@ void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedB
 
             case OpKind::MixAudio: {
                 auto out = audioOut(id, 0, numSamples);
-                out.clear();
-                if (value.silent)
+                if (value.silent) {
+                    out.clear();
                     break;
+                }
                 // Summed in compiled order, never in the order inputs finish:
                 // float addition is not associative, so this is what makes the
                 // parallel executor's output bit-identical to this one.
-                for (const auto& input : op.inputs)
-                    if (input.valid())
-                        out.add(audioIn(input, numSamples));
+                //
+                // The first input may already be here, in the buffer it was
+                // written into. Skipping the copy is the same sum, not a
+                // different one: it is added first either way.
+                auto pending = writesInPlace(i);
+                if (!pending)
+                    out.clear();
+                for (const auto& input : op.inputs) {
+                    if (!input.valid())
+                        continue;
+                    if (pending) {
+                        pending = false;
+                        continue;
+                    }
+                    out.add(audioIn(input, numSamples));
+                }
+                break;
+            }
+
+            case OpKind::Delay: {
+                // A delay runs whatever the value layer says about the ops
+                // around it. One that stopped writing while its chain was
+                // silent would hand back audio from before the silence when
+                // the chain returned, which is the one thing a delay line
+                // cannot do.
+                if (op.outputs.front() == SignalKind::Audio) {
+                    const auto line = audioDelayForOp_[i];
+                    if (line < 0)
+                        break;  // no samples to hold: its port is its input's
+                    auto out = audioOut(id, 0, numSamples);
+                    if (!writesInPlace(i))
+                        out.copyFrom(audioIn(op.inputs[0], numSamples));
+                    audioDelays_[static_cast<std::size_t>(line)].process(out, numSamples);
+                    break;
+                }
+
+                const auto line = midiDelayForOp_[i];
+                if (line < 0)
+                    break;
+                auto& out = midiOut(id, 0);
+                out.clear();
+                midiDelays_[static_cast<std::size_t>(line)].process(midiIn(op.inputs[0]), out,
+                                                                    numSamples);
+                jassert(out.data.size() <=
+                        static_cast<std::size_t>(
+                            midiByteBounds_[static_cast<std::size_t>(slotFor(PortRef{id, 0}))]));
                 break;
             }
 
@@ -342,10 +537,10 @@ void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedB
                     break;
                 }
 
-                if (op.inputs[0].valid())
-                    audio.copyFrom(audioIn(op.inputs[0], numSamples));
-                else
+                if (!op.inputs[0].valid())
                     audio.clear();
+                else if (!writesInPlace(i))
+                    audio.copyFrom(audioIn(op.inputs[0], numSamples));
 
                 auto* device = deviceForOp_[i];
                 if (device == nullptr)
@@ -365,6 +560,8 @@ void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedB
                 auto out = audioOut(id, 0, numSamples);
                 if (value.silent || !op.inputs[0].valid())
                     out.clear();
+                else if (writesInPlace(i))
+                    applyGain(out, value, numSamples);
                 else
                     copyWithGain(out, audioIn(op.inputs[0], numSamples), value, numSamples);
                 break;
@@ -374,6 +571,8 @@ void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedB
                 auto out = audioOut(id, 0, numSamples);
                 if (value.silent || !op.inputs[0].valid())
                     out.clear();
+                else if (writesInPlace(i))
+                    applyGain(out, value, numSamples);
                 else
                     copyWithGain(out, audioIn(op.inputs[0], numSamples), value, numSamples);
 
@@ -394,7 +593,7 @@ void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedB
                 auto out = audioOut(id, 0, numSamples);
                 if (value.silent || !op.inputs[0].valid())
                     out.clear();
-                else
+                else if (!writesInPlace(i))
                     out.copyFrom(audioIn(op.inputs[0], numSamples));
                 meterLevels_[i] = peakOf(out, numSamples);
                 break;

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -91,6 +91,8 @@ void AudioDelayLine::process(juce::dsp::AudioBlock<float> block, int numSamples)
 
 void MidiDelayLine::prepare(int delaySamples, int capacityBytes) {
     delay_ = delaySamples;
+    capacity_ = capacityBytes;
+    overflowed_ = false;
     pending_.clear();
     scratch_.clear();
     // Both, and to the same size: they are swapped every block, so the storage
@@ -122,6 +124,17 @@ void MidiDelayLine::process(const juce::MidiBuffer& in, juce::MidiBuffer& out, i
     }
 
     pending_.swapWith(scratch_);
+
+    // The reservation covers what a port may carry over one block's worth of
+    // samples, times the spans the delay holds in flight. Past it the buffer
+    // grows on the callback, which is the one thing this whole arrangement
+    // exists to avoid, and a producer writing faster than its budget is the
+    // only way to get here. Recorded as well as asserted: a release build
+    // would otherwise take the allocation and say nothing.
+    if (static_cast<int>(pending_.data.size()) > capacity_) {
+        overflowed_ = true;
+        jassertfalse;
+    }
 }
 
 void PlanExecutor::reset() {
@@ -293,10 +306,11 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
         if (op.kind == OpKind::Delay) {
             if (op.outputs.front() != SignalKind::Midi)
                 continue;
-            // A delay's output block covers one block of its input's time, and
-            // a block-length window falls across two of them unless the delay
-            // is a whole number of blocks. Zero is not a delay at all: the op
-            // does not run and the port is its input's.
+            // A delay's output block covers one block's worth of its input's
+            // time, and that stretch falls across two of the spans the budget
+            // is counted over unless the delay is a whole number of them. Zero
+            // is not a delay at all: the op does not run, and the port is its
+            // input's.
             const auto carried = portMidiBytes[flatPort(op.inputs.front())];
             portMidiBytes[static_cast<std::size_t>(portOffsets_[i])] =
                 latency.delaySamples[i] == 0 ? carried : 2 * carried;
@@ -361,8 +375,12 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                 context_.numChannels, samples, context_.maxBlockSize);
 
         if (midiDelayForOp_[i] >= 0) {
-            // Every block the delay spans is holding events, plus the one being
-            // filled and the one being drained.
+            // Everything the delay spans is in flight at once, counted in the
+            // spans the port's budget is a budget over rather than in
+            // callbacks: how many callbacks that stretch of timeline arrives
+            // in is the host's business and would make this the wrong size.
+            // Two spare covers the one being filled and the one being drained,
+            // neither of which lines up with those spans.
             const auto blocks = samples / context_.maxBlockSize + 2;
             midiDelays_[static_cast<std::size_t>(midiDelayForOp_[i])].prepare(
                 samples, blocks * portMidiBytes[flatPort(plan.ops[i].inputs.front())]);

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "exec/PlanBindings.hpp"
+#include "exec/PlanLayout.hpp"
 #include "exec/PlanValues.hpp"
 #include "exec/RenderContext.hpp"
 #include "plan/RenderPlan.hpp"
@@ -24,16 +25,55 @@
 
 namespace magda::engine {
 
+/**
+ * @brief A fixed delay on one audio port, in samples.
+ *
+ * Reads and writes the same block: the input is captured before the delayed
+ * output is read back, so a delay whose output shares its input's buffer is no
+ * different from one that does not.
+ */
+class AudioDelayLine {
+  public:
+    void prepare(int numChannels, int delaySamples, int maxBlockSize);
+    void process(juce::dsp::AudioBlock<float> block, int numSamples);
+
+  private:
+    juce::AudioBuffer<float> ring_;
+    int delay_ = 0;
+    int writePosition_ = 0;
+};
+
+/**
+ * @brief The same delay for one MIDI port.
+ *
+ * Events move by sample position and the ones that fall past the end of the
+ * block are held for the next one, so the storage has to cover every block the
+ * delay spans rather than one block's worth.
+ */
+class MidiDelayLine {
+  public:
+    void prepare(int delaySamples, int capacityBytes);
+    void process(const juce::MidiBuffer& in, juce::MidiBuffer& out, int numSamples);
+
+  private:
+    juce::MidiBuffer pending_, scratch_;
+    int delay_ = 0;
+};
+
 class PlanExecutor {
   public:
     /**
      * @brief Bind a plan to its runtime objects and allocate everything.
      *
      * Off the audio thread. Returns one message per thing the executor cannot
-     * honour: an op with no binding, a device asking for latency compensation
-     * that does not exist yet, a plan that does not validate. A plan that does
-     * not validate is not prepared at all, and process() renders silence until
-     * a good one arrives.
+     * honour: an op with no binding, a plan that does not validate. A plan that
+     * does not validate is not prepared at all, and process() renders silence
+     * until a good one arrives.
+     *
+     * This is also where everything that depends on the bound instances is
+     * settled: how many samples each delay holds, and therefore which ports can
+     * share a buffer. A plugin that changes its reported latency is a re-prepare
+     * of the same plan, not a recompile of a new one.
      */
     std::vector<std::string> prepare(const RenderPlan& plan, const PlanBindings& bindings,
                                      const RenderContext& context);
@@ -55,6 +95,22 @@ class PlanExecutor {
         return meterLevels_;
     }
 
+    /// Samples the prepared plan's output is delayed by: what the devices along
+    /// its longest path to the output report between them.
+    int latencySamples() const {
+        return latencySamples_;
+    }
+
+    /// Audio and MIDI buffers the prepared plan renders through. One per output
+    /// port would always work; sharing is what the assignment pass is for, so
+    /// these are how much it saved.
+    int audioBufferCount() const {
+        return static_cast<int>(audioSlots_.size());
+    }
+    int midiBufferCount() const {
+        return static_cast<int>(midiSlots_.size());
+    }
+
     /// True once a valid plan has been prepared.
     bool isPrepared() const {
         return plan_ != nullptr;
@@ -73,22 +129,35 @@ class PlanExecutor {
     const juce::MidiBuffer& midiIn(const PortRef& ref) const;
     juce::MidiBuffer& midiOut(OpId op, int port);
 
+    /// Whether an op's output port 0 is the buffer one of its inputs arrived
+    /// in, so the copy that would fill it has already happened.
+    bool writesInPlace(std::size_t op) const {
+        return writesInPlace_[op] != 0;
+    }
+
     void reset();
 
     const RenderPlan* plan_ = nullptr;
     RenderContext context_;
 
-    // One scratch buffer per output port, allocated here. The buffer
-    // assignment pass replaces this with an arena sized from the dependency
-    // DAG; until then the mapping is one port, one buffer, which costs memory
-    // and nothing else.
+    /// The arena. Ports share these where no schedule can want both at once,
+    /// which is worked out in assignBuffers rather than here.
     std::vector<juce::AudioBuffer<float>> audioSlots_;
     std::vector<juce::MidiBuffer> midiSlots_;
-    /// Encoded bytes each MIDI port can hold without growing, summed through
+    /// Encoded bytes each MIDI buffer can hold without growing, summed through
     /// the MIDI graph at prepare time. Checked in debug where producers write.
     std::vector<int> midiByteBounds_;
     std::vector<int> portOffsets_;
     std::vector<int> portSlots_;
+    std::vector<char> writesInPlace_;
+
+    /// Per op: the delay line it drives, or -1. Ops that need none are the
+    /// common case, and a plan with no latency in it allocates nothing here.
+    std::vector<int> audioDelayForOp_;
+    std::vector<int> midiDelayForOp_;
+    std::vector<AudioDelayLine> audioDelays_;
+    std::vector<MidiDelayLine> midiDelays_;
+    int latencySamples_ = 0;
 
     /// Identity of the prepared plan; values that do not carry the same one
     /// were resolved against something else and are not applied.

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -47,17 +47,30 @@ class AudioDelayLine {
  * @brief The same delay for one MIDI port.
  *
  * Events move by sample position and the ones that fall past the end of the
- * block are held for the next one, so the storage has to cover every block the
- * delay spans rather than one block's worth.
+ * block are held for the next one, so the storage has to cover every sample the
+ * delay spans rather than one block's worth. That span is what
+ * kMaxMidiBytesPerPort is a budget over: measured per callback it would be
+ * whatever the host chose the block size to be.
  */
 class MidiDelayLine {
   public:
     void prepare(int delaySamples, int capacityBytes);
     void process(const juce::MidiBuffer& in, juce::MidiBuffer& out, int numSamples);
 
+    /// Whether more has ever been in flight than prepare() reserved room for.
+    /// Reported rather than only asserted: past the reservation the buffer
+    /// grows on the callback, and a release build would do that quietly.
+    bool hasOverflowed() const {
+        return overflowed_;
+    }
+
   private:
     juce::MidiBuffer pending_, scratch_;
     int delay_ = 0;
+    /// What prepare() reserved, kept so process() can tell when the budget the
+    /// reservation was computed from has been exceeded.
+    int capacity_ = 0;
+    bool overflowed_ = false;
 };
 
 class PlanExecutor {
@@ -109,6 +122,16 @@ class PlanExecutor {
     }
     int midiBufferCount() const {
         return static_cast<int>(midiSlots_.size());
+    }
+
+    /// MIDI delay lines that have held more than they reserved room for, which
+    /// means a producer wrote past the budget every reservation here is
+    /// computed from. Zero on anything that keeps to it.
+    int midiDelayOverflows() const {
+        int overflows = 0;
+        for (const auto& line : midiDelays_)
+            overflows += line.hasOverflowed() ? 1 : 0;
+        return overflows;
     }
 
     /// True once a valid plan has been prepared.

--- a/magda/engine/exec/PlanLayout.cpp
+++ b/magda/engine/exec/PlanLayout.cpp
@@ -1,0 +1,302 @@
+#include "exec/PlanLayout.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <optional>
+
+namespace magda::engine {
+namespace {
+
+/// Producer ops an op waits on, each counted once however many slots it feeds.
+std::vector<OpId> distinctProducers(const PlanOp& op) {
+    std::vector<OpId> producers;
+    producers.reserve(op.inputs.size());
+    for (const auto& input : op.inputs) {
+        if (!input.valid())
+            continue;
+        if (std::ranges::find(producers, input.op) == producers.end())
+            producers.push_back(input.op);
+    }
+    return producers;
+}
+
+/// A set of ops, one bit each.
+class OpSet {
+  public:
+    void resize(std::size_t numWords) {
+        words_.assign(numWords, 0);
+    }
+    void release() {
+        words_.clear();
+        words_.shrink_to_fit();
+    }
+    bool empty() const {
+        return words_.empty();
+    }
+    void add(OpId op) {
+        words_[static_cast<std::size_t>(op) / 64] |= 1ULL << (static_cast<std::size_t>(op) % 64);
+    }
+    void unite(const OpSet& other) {
+        if (other.empty())
+            return;
+        for (std::size_t i = 0; i < words_.size(); ++i)
+            words_[i] |= other.words_[i];
+    }
+    /// Whether every op in this set is also in @p other.
+    bool isSubsetOf(const OpSet& other) const {
+        if (empty())
+            return true;
+        for (std::size_t i = 0; i < words_.size(); ++i)
+            if ((words_[i] & ~other.words_[i]) != 0)
+                return false;
+        return true;
+    }
+
+  private:
+    std::vector<std::uint64_t> words_;
+};
+
+/// The input slot an op's first output port may be written over, when nothing
+/// else still needs what that slot holds.
+///
+/// Every op here already treats its input as scratch it may overwrite, so this
+/// only removes a copy; it never changes what is computed. MIDI is absent on
+/// purpose: a MIDI op clears its output before writing it, so an output sharing
+/// its input's buffer would clear the events it was about to read.
+std::optional<std::size_t> inPlaceInputOf(const PlanOp& op) {
+    if (op.outputs.empty() || op.outputs.front() != SignalKind::Audio)
+        return std::nullopt;
+
+    switch (op.kind) {
+        // A device is handed its input in the buffer it writes its output to,
+        // which is the contract it already has; sharing means the copy that
+        // sets that up is a copy the buffer already holds.
+        case OpKind::Device:
+        case OpKind::Delay:
+        case OpKind::Gain:
+        case OpKind::SendTap:
+        case OpKind::Meter:
+        case OpKind::Fader:
+            return op.inputs.empty() || !op.inputs.front().valid() ? std::nullopt
+                                                                   : std::optional<std::size_t>(0);
+
+        // A sum can accumulate into the first thing it sums, which is what it
+        // would have copied there anyway.
+        case OpKind::MixAudio:
+            for (std::size_t slot = 0; slot < op.inputs.size(); ++slot)
+                if (op.inputs[slot].valid())
+                    return slot;
+            return std::nullopt;
+
+        case OpKind::ClipAudio:
+        case OpKind::ClipMidi:
+        case OpKind::AudioInput:
+        case OpKind::MidiInput:
+        case OpKind::MergeMidi:
+        case OpKind::Output:
+            return std::nullopt;
+    }
+
+    return std::nullopt;
+}
+
+}  // namespace
+
+std::vector<int> portOffsetsOf(const RenderPlan& plan) {
+    std::vector<int> offsets(plan.ops.size() + 1, 0);
+    int total = 0;
+    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+        offsets[i] = total;
+        total += static_cast<int>(plan.ops[i].outputs.size());
+    }
+    offsets[plan.ops.size()] = total;
+    return offsets;
+}
+
+PlanLatency resolvePlanLatency(const RenderPlan& plan, const std::vector<int>& portOffsets,
+                               const std::vector<int>& deviceLatency) {
+    PlanLatency resolved;
+    resolved.delaySamples.assign(plan.ops.size(), 0);
+    resolved.portLatency.assign(static_cast<std::size_t>(portOffsets.back()), 0);
+
+    const auto flat = [&portOffsets](const PortRef& ref) {
+        return static_cast<std::size_t>(portOffsets[static_cast<std::size_t>(ref.op)] + ref.port);
+    };
+
+    // What an input carries before its delay compensates anything. A delay op
+    // is transparent here: its own count is what this pass is computing, so
+    // the port behind it is what the comparison is between.
+    const auto arriving = [&](const PortRef& input) {
+        const auto& producer = plan.ops[static_cast<std::size_t>(input.op)];
+        return producer.kind == OpKind::Delay ? resolved.portLatency[flat(producer.inputs.front())]
+                                              : resolved.portLatency[flat(input)];
+    };
+
+    // Ops are in dependency order, so everything an op reads is already
+    // resolved by the time the walk reaches it. The delays feeding an op are
+    // resolved from it rather than at their own index, because what they have
+    // to match is the longest path into the op they feed, and only the op
+    // knows every path.
+    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+        const auto& op = plan.ops[i];
+        if (op.kind == OpKind::Delay)
+            continue;
+
+        int target = 0;
+        for (const auto& input : op.inputs)
+            if (input.valid())
+                target = std::max(target, arriving(input));
+
+        for (const auto& input : op.inputs) {
+            if (!input.valid())
+                continue;
+            const auto delayOp = static_cast<std::size_t>(input.op);
+            if (plan.ops[delayOp].kind != OpKind::Delay)
+                continue;
+            resolved.delaySamples[delayOp] = target - arriving(input);
+            resolved.portLatency[flat(PortRef{input.op, 0})] = target;
+        }
+
+        const auto produced =
+            target + (op.kind == OpKind::Device ? std::max(0, deviceLatency[i]) : 0);
+        for (std::size_t port = 0; port < op.outputs.size(); ++port)
+            resolved.portLatency[static_cast<std::size_t>(portOffsets[i]) + port] = produced;
+
+        if (op.kind == OpKind::Output)
+            resolved.outputLatency = std::max(resolved.outputLatency, target);
+    }
+
+    return resolved;
+}
+
+BufferLayout assignBuffers(const RenderPlan& plan, const std::vector<int>& portOffsets,
+                           const std::vector<int>& delaySamples) {
+    const auto numOps = plan.ops.size();
+    const auto numPorts = static_cast<std::size_t>(portOffsets.back());
+    const auto numWords = (numOps + 63) / 64;
+
+    BufferLayout layout;
+    layout.portSlots.assign(numPorts, -1);
+    layout.writesInPlace.assign(numOps, 0);
+    layout.elided.assign(numOps, 0);
+
+    const auto flat = [&portOffsets](const PortRef& ref) {
+        return static_cast<std::size_t>(portOffsets[static_cast<std::size_t>(ref.op)] + ref.port);
+    };
+
+    // A delay holding no samples writes exactly what it read, so its output is
+    // its input's port rather than a copy of it and the op never runs. This is
+    // what makes a plan compiled for compensation cost nothing where there is
+    // none to do: the ops are there, and where the latency is zero so is the
+    // work, the buffer and the copy.
+    std::vector<std::size_t> canonical(numPorts);
+    std::iota(canonical.begin(), canonical.end(), 0);
+    for (std::size_t i = 0; i < numOps; ++i) {
+        const auto& op = plan.ops[i];
+        if (op.kind != OpKind::Delay || delaySamples[i] != 0)
+            continue;
+        layout.elided[i] = 1;
+        canonical[static_cast<std::size_t>(portOffsets[i])] = canonical[flat(op.inputs.front())];
+    }
+
+    // Who reads each port, by the port it resolves to. Elided delays are left
+    // out: they do not run, so nothing waits on them and nothing stays alive
+    // for them. That is also what lets the op behind one work in place.
+    std::vector<std::vector<OpId>> readers(numPorts);
+    for (std::size_t i = 0; i < numOps; ++i) {
+        if (layout.elided[i])
+            continue;
+        for (const auto& input : plan.ops[i].inputs)
+            if (input.valid())
+                readers[canonical[flat(input)]].push_back(static_cast<OpId>(i));
+    }
+
+    // Ops that must have finished before each op can start. Held only while
+    // something downstream still needs it, so what is resident at any point is
+    // the width of the graph rather than its size.
+    std::vector<OpSet> ancestors(numOps);
+    std::vector<int> unreadOutputs(numOps, 0);
+    for (std::size_t i = 0; i < numOps; ++i)
+        for (const auto producer : distinctProducers(plan.ops[i]))
+            ++unreadOutputs[static_cast<std::size_t>(producer)];
+
+    // One keep-alive set per slot: everything that has to be done with the slot
+    // before it can be handed to another port.
+    std::vector<OpSet> audioSlotUsers, midiSlotUsers;
+
+    for (std::size_t i = 0; i < numOps; ++i) {
+        const auto& op = plan.ops[i];
+        const auto producers = distinctProducers(op);
+
+        auto& mine = ancestors[i];
+        mine.resize(numWords);
+        for (const auto producer : producers) {
+            mine.add(producer);
+            mine.unite(ancestors[static_cast<std::size_t>(producer)]);
+        }
+
+        const auto inPlaceSlot = layout.elided[i] ? std::nullopt : inPlaceInputOf(op);
+
+        for (std::size_t port = 0; port < op.outputs.size(); ++port) {
+            const auto flatPort = static_cast<std::size_t>(portOffsets[i]) + port;
+            if (canonical[flatPort] != flatPort)
+                continue;  // elided: it is its input's port and shares its slot
+
+            const auto isAudio = op.outputs[port] == SignalKind::Audio;
+            auto& slotUsers = isAudio ? audioSlotUsers : midiSlotUsers;
+
+            // Writing over an input the op is the last to read costs nothing
+            // and saves both the buffer and the copy that would fill it. "Last
+            // to read" has to mean last in every schedule, and one op reading
+            // the port once is the only form of that which needs no ordering
+            // argument at all.
+            int slot = -1;
+            if (port == 0 && inPlaceSlot.has_value()) {
+                const auto source = canonical[flat(op.inputs[*inPlaceSlot])];
+                const auto& sourceReaders = readers[source];
+                if (sourceReaders.size() == 1 && sourceReaders.front() == static_cast<OpId>(i) &&
+                    layout.portSlots[source] >= 0) {
+                    slot = layout.portSlots[source];
+                    layout.writesInPlace[i] = 1;
+                }
+            }
+
+            if (slot < 0) {
+                for (std::size_t candidate = 0; candidate < slotUsers.size(); ++candidate) {
+                    if (slotUsers[candidate].isSubsetOf(mine)) {
+                        slot = static_cast<int>(candidate);
+                        break;
+                    }
+                }
+            }
+
+            if (slot < 0) {
+                slot = static_cast<int>(slotUsers.size());
+                slotUsers.emplace_back();
+                slotUsers.back().resize(numWords);
+            }
+
+            layout.portSlots[flatPort] = slot;
+
+            // An output nobody reads still owns its buffer while it is written.
+            if (readers[flatPort].empty())
+                slotUsers[static_cast<std::size_t>(slot)].add(static_cast<OpId>(i));
+            for (const auto reader : readers[flatPort])
+                slotUsers[static_cast<std::size_t>(slot)].add(reader);
+        }
+
+        for (const auto producer : producers)
+            if (--unreadOutputs[static_cast<std::size_t>(producer)] == 0)
+                ancestors[static_cast<std::size_t>(producer)].release();
+    }
+
+    for (std::size_t flatPort = 0; flatPort < numPorts; ++flatPort)
+        layout.portSlots[flatPort] = layout.portSlots[canonical[flatPort]];
+
+    layout.numAudioSlots = static_cast<int>(audioSlotUsers.size());
+    layout.numMidiSlots = static_cast<int>(midiSlotUsers.size());
+    return layout;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/exec/PlanLayout.hpp
+++ b/magda/engine/exec/PlanLayout.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <vector>
+
+#include "plan/RenderPlan.hpp"
+
+/**
+ * @file PlanLayout.hpp
+ * @brief What a plan becomes when it meets the instances behind it.
+ *
+ * The plan is topology and the value table is the model; between them sits a
+ * third thing, and this is it: everything that follows from binding a plan to
+ * the objects that will render it. How many samples each delay holds comes from
+ * what a loaded plugin reports, and which ports can share a buffer follows from
+ * that. Neither is in the plan, because neither is knowable when it is
+ * compiled, and neither is a value, because both decide how memory is laid out
+ * before the first block runs.
+ *
+ * Both passes run in full on every prepare. They are linear and they run off
+ * the audio thread; skipping them for locality is how graph engines end up with
+ * wrong-latency bugs nobody can reproduce.
+ *
+ * Both take a plan validatePlan has passed, and lean on it: dependency order,
+ * ports that exist, and delays that sit on exactly one connected edge each.
+ */
+
+namespace magda::engine {
+
+/** Flat index of every op's first output port; one entry past the end. */
+std::vector<int> portOffsetsOf(const RenderPlan& plan);
+
+/**
+ * @brief Where a prepared plan's latency lands, in samples.
+ *
+ * The rule is the one the current engine uses everywhere it has more than one
+ * path meeting: every input of a fan-in is delayed up to the longest of them,
+ * and nothing is ever pulled early. It applies uniformly, which is what makes
+ * sends, sidechains, group tracks and parallel rack chains all come out right
+ * without any of them being a special case: a send tap carries whatever its
+ * source accumulated, and the mix it lands in aligns it with everything else
+ * arriving there, the destination track's own signal included.
+ */
+struct PlanLatency {
+    /// Samples each Delay op holds back. Zero for every other op, and zero for
+    /// a delay whose edge turned out to be the longest one.
+    std::vector<int> delaySamples;
+
+    /// Latency reaching each flat output port.
+    std::vector<int> portLatency;
+
+    /// What the plan's output is delayed by, which is what a host compensating
+    /// for the engine has to know.
+    int outputLatency = 0;
+};
+
+/**
+ * @brief Resolve latency for @p plan.
+ *
+ * @param deviceLatency  per op: what a Device op's bound instance reports, and
+ *                       zero everywhere else.
+ */
+PlanLatency resolvePlanLatency(const RenderPlan& plan, const std::vector<int>& portOffsets,
+                               const std::vector<int>& deviceLatency);
+
+/**
+ * @brief Which buffer each output port renders into.
+ *
+ * Ports share buffers when no schedule can have both live at once. That is a
+ * question about the dependency DAG and not about the order the ops happen to
+ * sit in: the reference executor's straight walk is only one of the orders the
+ * parallel executor may pick, and a slot reused on the strength of that walk is
+ * a race in the other ones. So the test is transitive dependency, and two ports
+ * share only when every op that reads the first must have finished before the
+ * op that writes the second can start.
+ */
+struct BufferLayout {
+    /// Arena slot per flat output port. Audio ports index the audio arena and
+    /// MIDI ports the MIDI arena; which one follows from the port's kind.
+    std::vector<int> portSlots;
+
+    /// Per op: its first output port is the same buffer as one of its inputs,
+    /// so the op works in place and the copy that would feed it is skipped.
+    /// Only set where the op is the last thing to read that input.
+    std::vector<char> writesInPlace;
+
+    /// Per op: the op writes nothing, because it is a delay that turned out to
+    /// need no samples. Its output port is its input's port, which is what
+    /// makes compensation cost nothing where there is none to do.
+    std::vector<char> elided;
+
+    int numAudioSlots = 0;
+    int numMidiSlots = 0;
+};
+
+BufferLayout assignBuffers(const RenderPlan& plan, const std::vector<int>& portOffsets,
+                           const std::vector<int>& delaySamples);
+
+}  // namespace magda::engine

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -292,6 +292,14 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
     const auto& op = plan_.ops[static_cast<std::size_t>(id)];
     const auto& key = op.key;
 
+    // A delay has no value and cannot be given one. Its line has to keep
+    // advancing whatever the model says: one that stopped writing while its
+    // chain was silent would hand back audio from before the silence when the
+    // chain returned. The executor reads no entry for it, so this leaves unity
+    // behind rather than deciding anything.
+    if (op.kind == OpKind::Delay)
+        return;
+
     const auto* track = findTrack(key.trackId);
     if (track == nullptr) {
         report(id, "no track " + std::to_string(key.trackId) + " in the model, rendering silence");
@@ -421,6 +429,11 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
         case OpRole::RackMidiMix:
         case OpRole::TrackMeter:
         case OpRole::HardwareOutput:
+        // Delay roles never reach here: they return above.
+        case OpRole::MixInputDelay:
+        case OpRole::MergeInputDelay:
+        case OpRole::DeviceInputDelay:
+        case OpRole::FaderInputDelay:
             break;
     }
 }

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -184,6 +184,11 @@ class Compiler {
     /// identity survives sources appearing and disappearing.
     PortRef emitMix(const OpKey& key, const std::vector<PortRef>& sources);
 
+    /// Puts a Delay op on each connected input of an op that has more than one,
+    /// so latency compensation has somewhere to land. @p key and @p kind are
+    /// the consuming op's, which is what the delays are keyed to.
+    std::vector<PortRef> alignInputs(const OpKey& key, OpKind kind, std::vector<PortRef> inputs);
+
     const std::vector<TrackInfo>& tracks_;
     const TrackInfo& master_;
     CompileOptions options_;
@@ -375,7 +380,55 @@ std::vector<const TrackInfo*> Compiler::computeTrackOrder() {
 }
 
 PortRef Compiler::emitMix(const OpKey& key, const std::vector<PortRef>& sources) {
-    return PortRef{addOp(OpKind::MixAudio, key, sources, {SignalKind::Audio}), 0};
+    return PortRef{addOp(OpKind::MixAudio, key, alignInputs(key, OpKind::MixAudio, sources),
+                         {SignalKind::Audio}),
+                   0};
+}
+
+std::vector<PortRef> Compiler::alignInputs(const OpKey& key, OpKind kind,
+                                           std::vector<PortRef> inputs) {
+    // One input is its own maximum, so its compensation is zero in every
+    // configuration and the delay would be a copy that never delays anything.
+    // Two or more is the only case where paths can arrive apart, and the
+    // compiler cannot tell whether they will: latency belongs to instances it
+    // has never seen. So the delays go in wherever they could be needed, and
+    // prepare resolves the ones that are not to nothing at all.
+    const auto connected =
+        std::ranges::count_if(inputs, [](const PortRef& p) { return p.valid(); });
+    if (connected < 2)
+        return inputs;
+
+    const auto role = [kind] {
+        switch (kind) {
+            case OpKind::MixAudio:
+                return OpRole::MixInputDelay;
+            case OpKind::MergeMidi:
+                return OpRole::MergeInputDelay;
+            case OpKind::Device:
+                return OpRole::DeviceInputDelay;
+            case OpKind::Fader:
+                return OpRole::FaderInputDelay;
+            default:
+                jassertfalse;  // nothing else fans in
+                return OpRole::MixInputDelay;
+        }
+    }();
+
+    for (std::size_t slot = 0; slot < inputs.size(); ++slot) {
+        auto& input = inputs[slot];
+        if (!input.valid())
+            continue;
+
+        const auto& producer = plan_.ops[static_cast<std::size_t>(input.op)];
+        OpKey delayKey = key;
+        delayKey.role = role;
+        delayKey.index = static_cast<int>(slot);
+        input = PortRef{addOp(OpKind::Delay, delayKey, {input},
+                              {producer.outputs[static_cast<std::size_t>(input.port)]}),
+                        0};
+    }
+
+    return inputs;
 }
 
 ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site,
@@ -383,14 +436,15 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     if (device.bypassed)
         return signal;
 
-    // Delta solo subtracts the device's latency-aligned dry input from its
-    // output, so it needs both a delay line and a second edge carrying the dry
-    // signal past the device. Neither exists yet: it lands with latency
-    // compensation, which is what makes the alignment meaningful.
+    // Delta solo subtracts the device's dry input, aligned to its output, from
+    // that output. The alignment is a delay like any other now; what is still
+    // missing is the edge carrying the dry signal past the device and the op
+    // that subtracts it.
     if (device.deltaSolo)
         diagnose("device " + std::to_string(device.id) + " on track " +
                  std::to_string(site.trackId) +
-                 ": delta solo needs a latency-aligned dry path the plan does not carry yet");
+                 ": delta solo needs a dry edge past the device and an op to subtract it, "
+                 "which the plan does not carry yet");
 
     const auto node = routing::makeRoutingNode(device);
 
@@ -424,8 +478,9 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
         outputs.push_back(SignalKind::Midi);
 
     OpKey key{site.trackId, site.rackId, site.chainId, device.id, OpRole::DeviceProcess, 0};
-    const auto processOp =
-        addOp(OpKind::Device, key, {signal.audio, midiIn, sidechainIn}, std::move(outputs));
+    const auto processOp = addOp(
+        OpKind::Device, key, alignInputs(key, OpKind::Device, {signal.audio, midiIn, sidechainIn}),
+        std::move(outputs));
 
     ChainSignal out;
     out.audio = PortRef{processOp, 0};
@@ -445,8 +500,10 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
         const PortRef deviceMidi{processOp, 1};
         if (node.passesRawMidiInput() && signal.midi.valid()) {
             key.role = OpRole::ChainMidiMerge;
-            out.midi = PortRef{
-                addOp(OpKind::MergeMidi, key, {signal.midi, deviceMidi}, {SignalKind::Midi}), 0};
+            out.midi = PortRef{addOp(OpKind::MergeMidi, key,
+                                     alignInputs(key, OpKind::MergeMidi, {signal.midi, deviceMidi}),
+                                     {SignalKind::Midi}),
+                               0};
         } else {
             out.midi = deviceMidi;
         }
@@ -470,10 +527,13 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
                  " feeds rack modulation, which the plan does not carry yet");
 
     // Same dry path a device's delta solo needs, one level up: the rack
-    // instance subtracts its own latency-aligned input from its wet output.
+    // instance subtracts its own input, aligned to its wet output, from that
+    // output. The current engine keeps a dry edge around every rack instance
+    // for exactly this, and delays it to match the wet path.
     if (rack.deltaSolo)
         diagnose("rack " + std::to_string(rack.id) +
-                 ": delta solo needs a latency-aligned dry path the plan does not carry yet");
+                 ": delta solo needs a dry edge around the rack and an op to subtract it, "
+                 "which the plan does not carry yet");
 
     // A rack with no chains passes signal rather than silence: compiling it to
     // a zero-input mix would silence the track. It is not fully transparent
@@ -531,7 +591,8 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
 
         const auto faderOp =
             addOp(OpKind::Fader, faderKey,
-                  {chainSignal.audio, generatesMidi ? chainSignal.midi : noInput()},
+                  alignInputs(faderKey, OpKind::Fader,
+                              {chainSignal.audio, generatesMidi ? chainSignal.midi : noInput()}),
                   std::move(faderOutputs));
 
         chainAudio.push_back(PortRef{faderOp, 0});
@@ -555,7 +616,10 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
     } else {
         const OpKey midiKey{site.trackId,        rack.id, INVALID_CHAIN_ID, INVALID_DEVICE_ID,
                             OpRole::RackMidiMix, 0};
-        out.midi = PortRef{addOp(OpKind::MergeMidi, midiKey, chainMidi, {SignalKind::Midi}), 0};
+        out.midi =
+            PortRef{addOp(OpKind::MergeMidi, midiKey,
+                          alignInputs(midiKey, OpKind::MergeMidi, chainMidi), {SignalKind::Midi}),
+                    0};
     }
 
     return out;
@@ -683,7 +747,10 @@ void Compiler::emitTrack(const TrackInfo& track) {
     if (!midiSources.empty()) {
         const OpKey key{track.id,          INVALID_RACK_ID,        INVALID_CHAIN_ID,
                         INVALID_DEVICE_ID, OpRole::TrackMidiInput, 0};
-        signal.midi = PortRef{addOp(OpKind::MergeMidi, key, midiSources, {SignalKind::Midi}), 0};
+        signal.midi =
+            PortRef{addOp(OpKind::MergeMidi, key, alignInputs(key, OpKind::MergeMidi, midiSources),
+                          {SignalKind::Midi}),
+                    0};
         trackMidiInput_[track.id] = signal.midi;
     }
 

--- a/magda/engine/plan/RenderPlan.cpp
+++ b/magda/engine/plan/RenderPlan.cpp
@@ -25,6 +25,7 @@ int arityOf(OpKind kind) {
         case OpKind::MixAudio:
         case OpKind::MergeMidi:
             return -1;  // variadic
+        case OpKind::Delay:
         case OpKind::Gain:
         case OpKind::SendTap:
         case OpKind::Meter:
@@ -50,6 +51,8 @@ const char* toString(OpKind kind) {
             return "MixAudio";
         case OpKind::MergeMidi:
             return "MergeMidi";
+        case OpKind::Delay:
+            return "Delay";
         case OpKind::Gain:
             return "Gain";
         case OpKind::Fader:
@@ -104,6 +107,14 @@ const char* toString(OpRole role) {
             return "sendTap";
         case OpRole::HardwareOutput:
             return "hardwareOutput";
+        case OpRole::MixInputDelay:
+            return "mixInputDelay";
+        case OpRole::MergeInputDelay:
+            return "mergeInputDelay";
+        case OpRole::DeviceInputDelay:
+            return "deviceInputDelay";
+        case OpRole::FaderInputDelay:
+            return "faderInputDelay";
     }
     return "?";
 }
@@ -134,6 +145,19 @@ std::string toString(const OpKey& key) {
 }
 
 namespace {
+
+/// Whether a role names a delay on one input slot of the op it is keyed to.
+bool isInputDelayRole(OpRole role) {
+    switch (role) {
+        case OpRole::MixInputDelay:
+        case OpRole::MergeInputDelay:
+        case OpRole::DeviceInputDelay:
+        case OpRole::FaderInputDelay:
+            return true;
+        default:
+            return false;
+    }
+}
 
 /// Producer ops an op waits on, each counted once however many slots it feeds.
 std::vector<OpId> distinctProducers(const PlanOp& op) {
@@ -226,6 +250,14 @@ std::vector<std::string> validatePlan(const RenderPlan& plan) {
     std::vector<std::string> problems;
     const auto numOps = static_cast<OpId>(plan.ops.size());
 
+    // How many input slots anywhere in the plan read each op. Only the delay
+    // rules below need it, and they need it before the op they are checking.
+    std::vector<int> readerCounts(plan.ops.size(), 0);
+    for (const auto& op : plan.ops)
+        for (const auto& input : op.inputs)
+            if (input.valid() && input.op >= 0 && input.op < numOps)
+                ++readerCounts[static_cast<std::size_t>(input.op)];
+
     // The differ hash-joins old and new plans on OpKey, so a duplicate key does
     // not fail loudly: it carries one op's state into another. Identity bugs
     // are the concentrated risk of this design, so uniqueness is an invariant
@@ -272,15 +304,46 @@ std::vector<std::string> validatePlan(const RenderPlan& plan) {
                                    std::to_string(producer.outputs.size()) + " ports");
                 continue;
             }
+            // A delay carries whatever reaches it, so its own output port is
+            // what its input has to agree with.
             const auto expected =
-                (op.kind == OpKind::MergeMidi ||
-                 ((op.kind == OpKind::Device || op.kind == OpKind::Fader) && slot == 1))
-                    ? SignalKind::Midi
-                    : SignalKind::Audio;
+                op.kind == OpKind::Delay
+                    ? (op.outputs.empty() ? SignalKind::Audio : op.outputs.front())
+                    : ((op.kind == OpKind::MergeMidi ||
+                        ((op.kind == OpKind::Device || op.kind == OpKind::Fader) && slot == 1))
+                           ? SignalKind::Midi
+                           : SignalKind::Audio);
             const auto actual = producer.outputs[static_cast<std::size_t>(input.port)];
             if (actual != expected)
                 problems.push_back(label + "input " + std::to_string(slot) + " is " +
                                    toString(actual) + ", expected " + toString(expected));
+        }
+
+        // A delay's sample count is not in the plan: it is resolved when the
+        // plan is prepared, from the latency the ops upstream of its consumer
+        // report. That resolution walks the plan once, forwards, and reads each
+        // delay's count off the consumer it feeds, so it is only well defined
+        // while these three hold. They are cheap here and impossible to check
+        // anywhere else without walking the whole plan again.
+        if (op.kind == OpKind::Delay) {
+            if (!isInputDelayRole(op.key.role))
+                problems.push_back(label + "is a delay but is not keyed to an input slot");
+
+            if (op.inputs.empty() || !op.inputs.front().valid())
+                problems.push_back(label + "is a delay with nothing to compensate");
+
+            if (readerCounts[static_cast<std::size_t>(i)] != 1)
+                problems.push_back(label + "is a delay read by " +
+                                   std::to_string(readerCounts[static_cast<std::size_t>(i)]) +
+                                   " input slots, and a delay compensates exactly one edge");
+
+            if (!op.inputs.empty() && op.inputs.front().valid() && op.inputs.front().op >= 0 &&
+                op.inputs.front().op < i &&
+                plan.ops[static_cast<std::size_t>(op.inputs.front().op)].kind == OpKind::Delay)
+                problems.push_back(label + "is a delay reading another delay, which double-counts "
+                                           "the same edge's compensation");
+        } else if (isInputDelayRole(op.key.role)) {
+            problems.push_back(label + "carries an input-delay role but is not a delay");
         }
 
         // Out-of-range inputs are already reported above; skip them here so a

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -19,6 +19,14 @@
  * A published plan is immutable. Every structural change compiles a new plan
  * and swaps it in atomically; the differ carries runtime state across the swap
  * by matching ops on their OpKey.
+ *
+ * Latency compensation splits along the same seam. Where the delay lines go is
+ * topology and lives here as Delay ops; how many samples each one holds is a
+ * property of a loaded plugin, which the model cannot know and the compiler has
+ * never seen, so it is resolved when the plan is prepared against its bindings.
+ * A plugin whose reported latency changes therefore re-prepares rather than
+ * recompiling, and the plan, its fingerprint and everything keyed on an OpKey
+ * come through untouched.
  */
 
 namespace magda::engine {
@@ -46,6 +54,7 @@ enum class OpKind : std::uint8_t {
     Device,      ///< a device instance (instrument, effect, MIDI or analysis)
     MixAudio,   ///< ordered sum of audio inputs (summing order is compiled, never scheduling order)
     MergeMidi,  ///< ordered merge of MIDI inputs
+    Delay,      ///< latency compensation on one edge; the sample count is bound at prepare time
     Gain,       ///< scalar gain
     Fader,      ///< volume + pan, and the MIDI its stage passes on
     SendTap,    ///< pre/post-fader tap feeding another track
@@ -80,6 +89,16 @@ enum class OpRole : std::uint8_t {
     TrackMute,        ///< mute and solo, applied after the meter and sidechain tap
     SendTap,          ///< one send slot
     HardwareOutput,   ///< the master's hardware output
+
+    // Latency compensation. A delay sits on one edge, so its identity is the
+    // op it feeds plus the input slot it fills: the role says which op that is,
+    // and OpKey::index says which slot. Two ops of the same kind never share a
+    // location, so this is unique wherever the compiler emits it, which
+    // validatePlan's key check is what actually guarantees.
+    MixInputDelay,     ///< aligns one input of a MixAudio
+    MergeInputDelay,   ///< aligns one input of a MergeMidi
+    DeviceInputDelay,  ///< aligns one input slot of a Device
+    FaderInputDelay,   ///< aligns one input slot of a Fader
 };
 
 /**
@@ -226,6 +245,10 @@ std::uint64_t planFingerprint(const RenderPlan& plan);
  * failing; and liveness provenance in both directions, because an over-tagged
  * Live op is silently correct while quietly shrinking what the anticipative
  * executor may precompute.
+ *
+ * Delays get the same treatment: one edge each, no stacking, and a key that
+ * names the slot they fill. Latency resolution reads a delay's count off the op
+ * it feeds, which is only well defined while that holds.
  */
 std::vector<std::string> validatePlan(const RenderPlan& plan);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -245,6 +245,7 @@ set(TEST_SOURCES
 if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_render_plan_compiler.cpp)
     list(APPEND TEST_SOURCES test_render_plan_executor.cpp)
+    list(APPEND TEST_SOURCES test_plan_layout.cpp)
     list(APPEND TEST_SOURCES test_engine_session.cpp)
 endif()
 

--- a/tests/test_engine_session.cpp
+++ b/tests/test_engine_session.cpp
@@ -76,11 +76,18 @@ class LedgerDevice final : public EngineDevice {
         block.audio.multiplyBy(0.5f);
     }
 
+    int latencySamples() const override {
+        return latency;
+    }
+
     DeviceId id() const {
         return id_;
     }
 
     int blocksProcessed = 0;
+    /// What a plugin reports once it is loaded, and may report differently
+    /// later. Not const for the same reason the real thing is not.
+    int latency = 0;
 
   private:
     Ledger& ledger_;
@@ -189,6 +196,46 @@ TEST_CASE("Publishing a plan puts it on the audio thread", "[engine][session]") 
     session.process(BlockInfo{kBlockSize, 0, true}, output);
 
     CHECK(output.getSample(0, 0) == approx(0.5f));
+}
+
+TEST_CASE("A latency change re-prepares the plan rather than recompiling it",
+          "[engine][session][pdc]") {
+    // Where the compensation goes is topology and lives in the plan; how many
+    // samples it holds comes from an instance the compiler has never seen. So a
+    // plugin that changes what it reports is this: the same plan, published
+    // again, with nothing rebuilt and nothing recompiled.
+    Ledger ledger;
+    TestFactory factory(ledger);
+    EngineSession session(factory);
+
+    auto tracks = trackWithEffect(7);
+    tracks.push_back(makeTrack(2));
+    const auto plan = compile(tracks);
+
+    REQUIRE(session.publish(plan, context(), modelIds(tracks)).published);
+    session.publishValues(resolve(*plan, tracks));
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    CHECK(output.getSample(0, 0) == approx(1.5f));
+
+    auto* device = factory.devicesById[7];
+    REQUIRE(device != nullptr);
+    const auto devicesCreated = ledger.devicesCreated.load();
+    device->latency = 16;
+
+    REQUIRE(session.publish(plan, context(), modelIds(tracks)).published);
+
+    CHECK(session.livePlan() == plan);
+    CHECK(ledger.devicesCreated.load() == devicesCreated);
+    CHECK(factory.devicesById[7] == device);
+
+    // Track 2 now waits for the track the device is on, so the first sixteen
+    // samples are the latent track alone and the rest are both.
+    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    CHECK(output.getSample(0, 0) == approx(0.5f));
+    CHECK(output.getSample(0, 15) == approx(0.5f));
+    CHECK(output.getSample(0, 16) == approx(1.5f));
 }
 
 TEST_CASE("A swap carries runtime state that the new plan still names", "[engine][session]") {

--- a/tests/test_plan_layout.cpp
+++ b/tests/test_plan_layout.cpp
@@ -1,0 +1,311 @@
+#include <catch2/catch_test_macros.hpp>
+#include <map>
+#include <set>
+#include <vector>
+
+#include "core/RackInfo.hpp"
+#include "core/TrackInfo.hpp"
+#include "exec/PlanLayout.hpp"
+#include "plan/PlanCompiler.hpp"
+#include "plan/PlanDump.hpp"
+
+using namespace magda;
+using magda::engine::BufferLayout;
+using magda::engine::OpId;
+using magda::engine::OpKind;
+using magda::engine::OpRole;
+using magda::engine::PortRef;
+using magda::engine::RenderPlan;
+using magda::engine::SignalKind;
+
+namespace {
+
+TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Audio) {
+    TrackInfo track;
+    track.id = id;
+    track.type = type;
+    track.name = "Track " + juce::String(id);
+    track.audioOutputDevice = "master";
+    return track;
+}
+
+TrackInfo makeMaster() {
+    auto master = makeTrack(MASTER_TRACK_ID, TrackType::Master);
+    master.audioOutputDevice = {};
+    return master;
+}
+
+DeviceInfo makeEffect(DeviceId id) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Effect " + juce::String(id);
+    device.deviceType = DeviceType::Effect;
+    return device;
+}
+
+/// A plan with enough shapes in it to be worth checking: a rack of two chains,
+/// a send, a sidechain, a group, and an instrument carrying MIDI.
+std::vector<TrackInfo> busyFixture() {
+    auto rack = std::make_unique<RackInfo>();
+    rack->id = 5;
+    for (const ChainId chainId : {ChainId{10}, ChainId{11}}) {
+        ChainInfo chain;
+        chain.id = chainId;
+        chain.elements.push_back(makeDeviceElement(makeEffect(static_cast<DeviceId>(chainId))));
+        rack->chains.push_back(std::move(chain));
+    }
+
+    auto keyed = makeTrack(1);
+    auto compressor = makeEffect(7);
+    compressor.sidechain.type = SidechainConfig::Type::Audio;
+    compressor.sidechain.sourceTrackId = 2;
+    keyed.chain.fxChainElements.push_back(ChainElement{std::move(rack)});
+    keyed.chain.fxChainElements.push_back(makeDeviceElement(compressor));
+    keyed.audioOutputDevice = "track:4";
+    keyed.sends.push_back(SendInfo{0, 0.5f, false, 3});
+
+    auto key = makeTrack(2);
+    key.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(8)));
+
+    auto bus = makeTrack(3);
+    bus.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(9)));
+
+    return {std::move(keyed), std::move(key), std::move(bus), makeTrack(4, TrackType::Group)};
+}
+
+/// Ops that must have finished before each op can start, worked out here
+/// rather than borrowed from the pass under test.
+std::vector<std::set<OpId>> ancestorsOf(const RenderPlan& plan) {
+    std::vector<std::set<OpId>> ancestors(plan.ops.size());
+    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+        for (const auto& input : plan.ops[i].inputs) {
+            if (!input.valid())
+                continue;
+            ancestors[i].insert(input.op);
+            const auto& theirs = ancestors[static_cast<std::size_t>(input.op)];
+            ancestors[i].insert(theirs.begin(), theirs.end());
+        }
+    }
+    return ancestors;
+}
+
+struct Layout {
+    RenderPlan plan;
+    std::vector<int> portOffsets;
+    std::vector<int> delaySamples;
+    BufferLayout buffers;
+
+    std::size_t flat(OpId op, int port) const {
+        return static_cast<std::size_t>(portOffsets[static_cast<std::size_t>(op)] + port);
+    }
+    int slot(OpId op, int port) const {
+        return buffers.portSlots[flat(op, port)];
+    }
+};
+
+Layout layoutOf(const std::vector<TrackInfo>& tracks, const TrackInfo& master,
+                const std::map<DeviceId, int>& latencies = {}) {
+    Layout out;
+    out.plan = magda::engine::compileRenderPlan(tracks, master);
+    out.portOffsets = magda::engine::portOffsetsOf(out.plan);
+
+    std::vector<int> deviceLatency(out.plan.ops.size(), 0);
+    for (std::size_t i = 0; i < out.plan.ops.size(); ++i)
+        if (out.plan.ops[i].kind == OpKind::Device)
+            if (const auto found = latencies.find(out.plan.ops[i].key.deviceId);
+                found != latencies.end())
+                deviceLatency[i] = found->second;
+
+    out.delaySamples =
+        magda::engine::resolvePlanLatency(out.plan, out.portOffsets, deviceLatency).delaySamples;
+    out.buffers = magda::engine::assignBuffers(out.plan, out.portOffsets, out.delaySamples);
+    return out;
+}
+
+/// The one thing sharing a buffer promises: no schedule can want both of the
+/// ports in it at once.
+///
+/// Checked against transitive dependency rather than against the order the ops
+/// happen to sit in. Two ops with no path between them may run in either order
+/// or at the same time, whatever the reference executor's straight walk does
+/// with them, so a slot they both hold is a race the parallel executor would
+/// find and this one never would.
+void requireNoLiveOverlap(const Layout& layout) {
+    const auto& plan = layout.plan;
+    const auto ancestors = ancestorsOf(plan);
+
+    // Where each port really lives: an elided delay does not run, so its output
+    // is the port behind it.
+    std::vector<std::size_t> canonical(layout.buffers.portSlots.size());
+    for (std::size_t i = 0; i < canonical.size(); ++i)
+        canonical[i] = i;
+    for (std::size_t i = 0; i < plan.ops.size(); ++i)
+        if (layout.buffers.elided[i] != 0)
+            canonical[layout.flat(static_cast<OpId>(i), 0)] = canonical[layout.flat(
+                plan.ops[i].inputs.front().op, plan.ops[i].inputs.front().port)];
+
+    std::vector<OpId> producer(canonical.size(), magda::engine::INVALID_OP_ID);
+    std::vector<std::vector<OpId>> readers(canonical.size());
+    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+        if (layout.buffers.elided[i] != 0)
+            continue;
+        for (std::size_t port = 0; port < plan.ops[i].outputs.size(); ++port)
+            producer[canonical[layout.flat(static_cast<OpId>(i), static_cast<int>(port))]] =
+                static_cast<OpId>(i);
+        for (const auto& input : plan.ops[i].inputs)
+            if (input.valid())
+                readers[canonical[layout.flat(input.op, input.port)]].push_back(
+                    static_cast<OpId>(i));
+    }
+
+    // Everything that has to have happened before the port's buffer is free.
+    const auto keepAlive = [&](std::size_t port) {
+        auto ops = readers[port];
+        if (ops.empty())
+            ops.push_back(producer[port]);
+        return ops;
+    };
+
+    const auto isFinishedBefore = [&](std::size_t port, OpId op) {
+        for (const auto keeper : keepAlive(port))
+            if (!ancestors[static_cast<std::size_t>(op)].contains(keeper))
+                return false;
+        return true;
+    };
+
+    // Writing over an input is allowed where the op doing the writing is the
+    // only thing that ever reads it: the read and the write are the same op,
+    // so no order between them exists to get wrong.
+    const auto isWrittenOverBy = [&](std::size_t port, std::size_t other) {
+        const auto writer = producer[other];
+        return layout.buffers.writesInPlace[static_cast<std::size_t>(writer)] != 0 &&
+               readers[port].size() == 1 && readers[port].front() == writer;
+    };
+
+    std::map<std::pair<SignalKind, int>, std::vector<std::size_t>> ports;
+    for (std::size_t i = 0; i < plan.ops.size(); ++i)
+        for (std::size_t port = 0; port < plan.ops[i].outputs.size(); ++port) {
+            const auto flat = layout.flat(static_cast<OpId>(i), static_cast<int>(port));
+            if (canonical[flat] != flat)
+                continue;
+            ports[{plan.ops[i].outputs[port], layout.buffers.portSlots[flat]}].push_back(flat);
+        }
+
+    INFO(magda::engine::dumpPlan(plan));
+    for (const auto& [slot, sharing] : ports) {
+        for (std::size_t a = 0; a < sharing.size(); ++a) {
+            for (std::size_t b = a + 1; b < sharing.size(); ++b) {
+                const auto first = sharing[a];
+                const auto second = sharing[b];
+                const auto safe = isFinishedBefore(first, producer[second]) ||
+                                  isFinishedBefore(second, producer[first]) ||
+                                  isWrittenOverBy(first, second) || isWrittenOverBy(second, first);
+                INFO("ports " << first << " and " << second << " share slot " << slot.second);
+                CHECK(safe);
+            }
+        }
+    }
+}
+
+int countPorts(const Layout& layout, SignalKind kind) {
+    int ports = 0;
+    for (const auto& op : layout.plan.ops)
+        for (const auto output : op.outputs)
+            if (output == kind)
+                ++ports;
+    return ports;
+}
+
+}  // namespace
+
+TEST_CASE("Buffers are shared only where no schedule can want both",
+          "[engine][exec][layout][pdc]") {
+    const auto tracks = busyFixture();
+
+    SECTION("with nothing latent in the plan") {
+        const auto layout = layoutOf(tracks, makeMaster());
+        requireNoLiveOverlap(layout);
+        CHECK(layout.buffers.numAudioSlots < countPorts(layout, SignalKind::Audio));
+    }
+
+    SECTION("with latency spread through it") {
+        const auto layout = layoutOf(tracks, makeMaster(), {{7, 64}, {10, 32}, {9, 128}});
+        requireNoLiveOverlap(layout);
+        CHECK(layout.buffers.numAudioSlots < countPorts(layout, SignalKind::Audio));
+    }
+}
+
+TEST_CASE("A delay holding no samples is not a buffer and not an op",
+          "[engine][exec][layout][pdc]") {
+    const std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+
+    SECTION("with no latency anywhere, every delay disappears") {
+        const auto layout = layoutOf(tracks, makeMaster());
+
+        int delays = 0;
+        for (std::size_t i = 0; i < layout.plan.ops.size(); ++i) {
+            if (layout.plan.ops[i].kind != OpKind::Delay)
+                continue;
+            ++delays;
+            CHECK(layout.delaySamples[i] == 0);
+            CHECK(layout.buffers.elided[i] != 0);
+
+            // Its port is the one behind it rather than a copy of it.
+            const auto& input = layout.plan.ops[i].inputs.front();
+            CHECK(layout.slot(static_cast<OpId>(i), 0) == layout.slot(input.op, input.port));
+        }
+        REQUIRE(delays == 2);
+    }
+
+    SECTION("a delay that has samples to hold is not elided") {
+        const auto layout = layoutOf(tracks, makeMaster(), {{7, 96}});
+        auto latent = tracks;
+        latent[0].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
+        const auto compensated = layoutOf(latent, makeMaster(), {{7, 96}});
+
+        int held = 0;
+        for (std::size_t i = 0; i < compensated.plan.ops.size(); ++i) {
+            if (compensated.plan.ops[i].kind != OpKind::Delay)
+                continue;
+            if (compensated.delaySamples[i] == 0)
+                CHECK(compensated.buffers.elided[i] != 0);
+            else
+                ++held;
+        }
+
+        // The master sums both tracks, and track 2's side of that sum is the
+        // one that has to wait.
+        CHECK(held == 1);
+    }
+}
+
+TEST_CASE("Latency accumulates along a chain and meets at a fan-in",
+          "[engine][exec][layout][pdc]") {
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(8)));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    const auto portOffsets = magda::engine::portOffsetsOf(plan);
+
+    std::vector<int> deviceLatency(plan.ops.size(), 0);
+    for (std::size_t i = 0; i < plan.ops.size(); ++i)
+        if (plan.ops[i].kind == OpKind::Device)
+            deviceLatency[i] = plan.ops[i].key.deviceId == 7 ? 100 : 20;
+
+    const auto latency = magda::engine::resolvePlanLatency(plan, portOffsets, deviceLatency);
+
+    INFO(magda::engine::dumpPlan(plan));
+    CHECK(latency.outputLatency == 120);
+
+    // The master's two inputs: track 1 arrives 120 samples late and needs
+    // nothing, track 2 arrives on time and waits for it.
+    std::vector<int> delays;
+    for (std::size_t i = 0; i < plan.ops.size(); ++i)
+        if (plan.ops[i].key.role == OpRole::MixInputDelay)
+            delays.push_back(latency.delaySamples[i]);
+
+    REQUIRE(delays.size() == 2);
+    CHECK(delays[0] == 0);
+    CHECK(delays[1] == 120);
+}

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -63,12 +63,27 @@ int countRole(const RenderPlan& plan, OpRole role) {
     return static_cast<int>(opsWithRole(plan, role).size());
 }
 
-/// The op an input slot reads, or -1 when the slot is unconnected.
+/// The op an input slot reads, or -1 when the slot is unconnected. Latency
+/// compensation is looked through: a delay stands for the op behind it, and
+/// these tests are about what is routed where rather than about the delays,
+/// which have their own.
 magda::engine::OpId inputOp(const RenderPlan& plan, magda::engine::OpId op, std::size_t slot) {
     const auto& inputs = plan.ops[static_cast<std::size_t>(op)].inputs;
     if (slot >= inputs.size())
         return magda::engine::INVALID_OP_ID;
-    return inputs[slot].op;
+
+    const auto source = inputs[slot].op;
+    if (source == magda::engine::INVALID_OP_ID)
+        return source;
+
+    const auto& producer = plan.ops[static_cast<std::size_t>(source)];
+    return producer.kind == magda::engine::OpKind::Delay ? producer.inputs.front().op : source;
+}
+
+/// The op an input slot reads without looking through anything.
+magda::engine::OpId rawInputOp(const RenderPlan& plan, magda::engine::OpId op, std::size_t slot) {
+    const auto& inputs = plan.ops[static_cast<std::size_t>(op)].inputs;
+    return slot >= inputs.size() ? magda::engine::INVALID_OP_ID : inputs[slot].op;
 }
 
 /// Every fixture must compile to a structurally sound plan; this is asserted
@@ -137,6 +152,45 @@ ops=13 outputs=1
 [ 11] Gain        det   T-2:trackMute                  in=10:0             out=audio       deps=1
 [ 12] Output      det   T-2:hardwareOutput             in=11:0             out=-           deps=1
 ready=0
+)");
+}
+
+TEST_CASE("A second track is a fan-in, and a fan-in is where the delays go",
+          "[engine][plan][compiler][pdc]") {
+    // The same golden surface with one more track in it. Everything the first
+    // track had is unchanged, and what the second one adds is a sum with two
+    // inputs and a delay on each: how many samples they hold is not here,
+    // because it is not known until the plan is prepared against the plugins
+    // it names.
+    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    requireWellFormed(plan);
+
+    CHECK(magda::engine::dumpPlan(plan) == R"(magda-render-plan v1
+ops=20 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
+[  4] Meter       det   T1/D7:deviceMeter              in=3:0              out=audio       deps=1
+[  5] Fader       det   T1:trackFader                  in=4:0,-            out=audio       deps=1
+[  6] Meter       det   T1:trackMeter                  in=5:0              out=audio       deps=1
+[  7] Gain        det   T1:trackMute                   in=6:0              out=audio       deps=1
+[  8] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
+[  9] MixAudio    det   T2:trackAudioInput             in=8:0              out=audio       deps=1
+[ 10] Fader       det   T2:trackFader                  in=9:0,-            out=audio       deps=1
+[ 11] Meter       det   T2:trackMeter                  in=10:0             out=audio       deps=1
+[ 12] Gain        det   T2:trackMute                   in=11:0             out=audio       deps=1
+[ 13] Delay       det   T-2:mixInputDelay              in=7:0              out=audio       deps=1
+[ 14] Delay       det   T-2:mixInputDelay#1            in=12:0             out=audio       deps=1
+[ 15] MixAudio    det   T-2:trackAudioInput            in=13:0,14:0        out=audio       deps=2
+[ 16] Fader       det   T-2:trackFader                 in=15:0,-           out=audio       deps=1
+[ 17] Meter       det   T-2:trackMeter                 in=16:0             out=audio       deps=1
+[ 18] Gain        det   T-2:trackMute                  in=17:0             out=audio       deps=1
+[ 19] Output      det   T-2:hardwareOutput             in=18:0             out=-           deps=1
+ready=0,8
 )");
 }
 
@@ -1107,6 +1161,200 @@ TEST_CASE("validatePlan enforces the differ's identity precondition", "[engine][
     const auto problems = magda::engine::validatePlan(plan);
     REQUIRE(problems.size() == 1);
     CHECK(problems.front().find("same key as op 0") != std::string::npos);
+}
+
+TEST_CASE("validatePlan enforces the delay invariants", "[engine][plan][validate]") {
+    using magda::engine::PlanOp;
+    using magda::engine::PortRef;
+    using magda::engine::SignalKind;
+
+    // Latency resolution reads a delay's sample count off the op it feeds, so
+    // a delay on two edges, or behind another delay, is not a plan that is
+    // merely odd: it is one whose compensation has no single answer.
+    RenderPlan plan;
+
+    PlanOp source;
+    source.kind = OpKind::ClipAudio;
+    source.key = {1, INVALID_RACK_ID, INVALID_CHAIN_ID, INVALID_DEVICE_ID, OpRole::ClipAudio, 0};
+    source.outputs = {SignalKind::Audio};
+    plan.ops.push_back(source);
+
+    PlanOp delay;
+    delay.kind = OpKind::Delay;
+    delay.key = {1, INVALID_RACK_ID, INVALID_CHAIN_ID, INVALID_DEVICE_ID, OpRole::MixInputDelay, 0};
+    delay.inputs = {PortRef{0, 0}};
+    delay.outputs = {SignalKind::Audio};
+
+    SECTION("a delay on two edges is rejected") {
+        plan.ops.push_back(delay);
+
+        for (int reader = 0; reader < 2; ++reader) {
+            PlanOp mix;
+            mix.kind = OpKind::MixAudio;
+            mix.key = {1,
+                       INVALID_RACK_ID,
+                       INVALID_CHAIN_ID,
+                       INVALID_DEVICE_ID,
+                       OpRole::TrackAudioInput,
+                       reader};
+            mix.inputs = {PortRef{1, 0}};
+            mix.outputs = {SignalKind::Audio};
+            plan.ops.push_back(mix);
+        }
+
+        const auto problems = magda::engine::validatePlan(plan);
+        REQUIRE(problems.size() == 1);
+        CHECK(problems.front().find("read by 2 input slots") != std::string::npos);
+    }
+
+    SECTION("a delay behind another delay is rejected") {
+        plan.ops.push_back(delay);
+
+        auto stacked = delay;
+        stacked.key.index = 1;
+        stacked.inputs = {PortRef{1, 0}};
+        plan.ops.push_back(stacked);
+
+        PlanOp mix;
+        mix.kind = OpKind::MixAudio;
+        mix.key = {1, INVALID_RACK_ID, INVALID_CHAIN_ID, INVALID_DEVICE_ID, OpRole::TrackAudioInput,
+                   0};
+        mix.inputs = {PortRef{2, 0}};
+        mix.outputs = {SignalKind::Audio};
+        plan.ops.push_back(mix);
+
+        const auto problems = magda::engine::validatePlan(plan);
+        REQUIRE(problems.size() == 1);
+        CHECK(problems.front().find("delay reading another delay") != std::string::npos);
+    }
+
+    SECTION("a delay keyed to nothing in particular is rejected") {
+        delay.key.role = OpRole::TrackFader;
+        plan.ops.push_back(delay);
+
+        PlanOp mix;
+        mix.kind = OpKind::MixAudio;
+        mix.key = {1, INVALID_RACK_ID, INVALID_CHAIN_ID, INVALID_DEVICE_ID, OpRole::TrackAudioInput,
+                   0};
+        mix.inputs = {PortRef{1, 0}};
+        mix.outputs = {SignalKind::Audio};
+        plan.ops.push_back(mix);
+
+        const auto problems = magda::engine::validatePlan(plan);
+        REQUIRE(problems.size() == 1);
+        CHECK(problems.front().find("not keyed to an input slot") != std::string::npos);
+    }
+
+    SECTION("an op wearing a delay's role without being one is rejected") {
+        PlanOp gain;
+        gain.kind = OpKind::Gain;
+        gain.key = delay.key;
+        gain.inputs = {PortRef{0, 0}};
+        gain.outputs = {SignalKind::Audio};
+        plan.ops.push_back(gain);
+
+        const auto problems = magda::engine::validatePlan(plan);
+        REQUIRE(problems.size() == 1);
+        CHECK(problems.front().find("input-delay role but is not a delay") != std::string::npos);
+    }
+}
+
+TEST_CASE("Latency compensation goes where paths can arrive apart",
+          "[engine][plan][compiler][pdc]") {
+    using magda::engine::OpKind;
+
+    const auto delaysInto = [](const RenderPlan& plan, magda::engine::OpId consumer) {
+        int delays = 0;
+        for (std::size_t slot = 0;
+             slot < plan.ops[static_cast<std::size_t>(consumer)].inputs.size(); ++slot) {
+            const auto source = rawInputOp(plan, consumer, slot);
+            if (source != magda::engine::INVALID_OP_ID &&
+                plan.ops[static_cast<std::size_t>(source)].kind == OpKind::Delay)
+                ++delays;
+        }
+        return delays;
+    };
+
+    SECTION("a sum of two tracks, but not a sum of one") {
+        std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        const auto inputs = opsWithRole(plan, OpRole::TrackAudioInput);
+        REQUIRE(inputs.size() == 3);
+        CHECK(delaysInto(plan, inputs[0]) == 0);  // one clip source
+        CHECK(delaysInto(plan, inputs[1]) == 0);
+        CHECK(delaysInto(plan, inputs[2]) == 2);  // the master, summing both
+        CHECK(countRole(plan, OpRole::MixInputDelay) == 2);
+    }
+
+    SECTION("a device reading audio and MIDI, but not one reading audio alone") {
+        // Track 2 has nothing in it that consumes MIDI, so no MIDI is compiled
+        // for it at all and its effect has one input to wait on.
+        std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeInstrument(3)));
+        tracks[1].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(4)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        const auto devices = opsWithRole(plan, OpRole::DeviceProcess);
+        REQUIRE(devices.size() == 2);
+        CHECK(delaysInto(plan, devices[0]) == 2);  // the instrument: audio and MIDI
+        CHECK(delaysInto(plan, devices[1]) == 0);  // the effect: audio alone
+        CHECK(countRole(plan, OpRole::DeviceInputDelay) == 2);
+    }
+
+    SECTION("a device reading a sidechain") {
+        std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+        auto device = makeEffect(7);
+        device.sidechain.type = SidechainConfig::Type::Audio;
+        device.sidechain.sourceTrackId = 2;
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(device));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        const auto devices = opsWithRole(plan, OpRole::DeviceProcess);
+        REQUIRE(devices.size() == 1);
+        CHECK(delaysInto(plan, devices[0]) == 2);  // audio and the key it is aligned with
+    }
+
+    SECTION("a rack's chains, and the MIDI they generate") {
+        auto rack = std::make_unique<RackInfo>();
+        rack->id = 5;
+        for (const ChainId chainId : {ChainId{10}, ChainId{11}}) {
+            ChainInfo chain;
+            chain.id = chainId;
+            auto arp = makeEffect(static_cast<DeviceId>(chainId));
+            arp.deviceType = DeviceType::MIDI;
+            arp.canReceiveMidi = true;
+            arp.producesMidi = true;
+            arp.midiInThru = false;
+            chain.elements.push_back(makeDeviceElement(arp));
+            rack->chains.push_back(std::move(chain));
+        }
+
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.fxChainElements.push_back(ChainElement{std::move(rack)});
+        tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeInstrument(9)));
+
+        const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+        requireWellFormed(plan);
+
+        const auto mix = opsWithRole(plan, OpRole::RackMix);
+        REQUIRE(mix.size() == 1);
+        CHECK(delaysInto(plan, mix.front()) == 2);
+
+        const auto midiMix = opsWithRole(plan, OpRole::RackMidiMix);
+        REQUIRE(midiMix.size() == 1);
+        CHECK(delaysInto(plan, midiMix.front()) == 2);
+
+        // Each chain's fader carries the chain's audio and its MIDI, which
+        // arrive from different places and so may arrive apart.
+        for (const auto fader : opsWithRole(plan, OpRole::RackChainFader))
+            CHECK(delaysInto(plan, fader) == 2);
+    }
 }
 
 TEST_CASE("validatePlan enforces liveness provenance", "[engine][plan][validate]") {

--- a/tests/test_render_plan_executor.cpp
+++ b/tests/test_render_plan_executor.cpp
@@ -92,6 +92,41 @@ class RampSource final : public EngineAudioSource {
     }
 };
 
+/// A note-on at fixed positions on the timeline, so how the blocks are cut up
+/// does not change what it plays.
+class TimelineNoteSource final : public EngineMidiSource {
+  public:
+    TimelineNoteSource(int noteNumber, int period) : noteNumber_(noteNumber), period_(period) {}
+
+    void render(const BlockInfo& block, juce::MidiBuffer& out) override {
+        const auto first = (block.timelineSample + period_ - 1) / period_ * period_;
+        for (auto position = first; position < block.timelineSample + block.numSamples;
+             position += period_)
+            out.addEvent(juce::MidiMessage::noteOn(1, noteNumber_, 1.0f),
+                         static_cast<int>(position - block.timelineSample));
+    }
+
+  private:
+    int noteNumber_, period_;
+};
+
+/// As many notes per sample as the port's budget allows, to run a delay line
+/// at the rate its storage was reserved for.
+class DenseNoteSource final : public EngineMidiSource {
+  public:
+    DenseNoteSource(int noteNumber, int perSample)
+        : noteNumber_(noteNumber), perSample_(perSample) {}
+
+    void render(const BlockInfo& block, juce::MidiBuffer& out) override {
+        for (int sample = 0; sample < block.numSamples; ++sample)
+            for (int note = 0; note < perSample_; ++note)
+                out.addEvent(juce::MidiMessage::noteOn(1, noteNumber_, 1.0f), sample);
+    }
+
+  private:
+    int noteNumber_, perSample_;
+};
+
 /// A note-on at a fixed offset, every block.
 class NoteSource final : public EngineMidiSource {
   public:
@@ -1234,6 +1269,95 @@ TEST_CASE("Block size does not change what is rendered", "[engine][exec]") {
     REQUIRE(compensatedWhole.size() == compensatedSplit.size());
     for (std::size_t sample = 0; sample < compensatedWhole.size(); ++sample)
         REQUIRE(compensatedWhole[sample] == approx(compensatedSplit[sample]));
+}
+
+TEST_CASE("Block size does not change where delayed MIDI lands", "[engine][exec][pdc]") {
+    // A MIDI delay is the one thing here that holds state across blocks, so it
+    // is the one thing a host cutting the same stretch of timeline into
+    // different callbacks can pull apart. What it carries is budgeted over a
+    // span of samples for exactly that reason: counted per callback, the
+    // reservation would be short by whatever the host chose the block size to
+    // be, and the short blocks below are what would find it.
+    const auto renderNotes = [](const std::vector<int>& blockSizes) {
+        auto track = makeTrack(1);
+        track.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
+        track.chain.fxChainElements.push_back(makeDeviceElement(makeInstrument(8)));
+
+        Harness harness({track}, makeMaster());
+        ConstantSource audio(0.0f);
+        // A period that lines up with no block boundary in the test, so notes
+        // land all over the delay's window rather than at the edges of it.
+        TimelineNoteSource notes(48, 23);
+        LatentDevice latent(80);
+        MidiPositionProbe probe;
+        harness.bindings.clipAudio[1] = &audio;
+        harness.bindings.clipMidi[1] = &notes;
+        harness.bindings.devices[7] = &latent;
+        harness.bindings.devices[8] = &probe;
+        harness.prepareCleanly();
+
+        std::int64_t timelineSample = 0;
+        for (const auto numSamples : blockSizes) {
+            harness.render(numSamples, timelineSample);
+            timelineSample += numSamples;
+        }
+        return probe.positionsOf(48);
+    };
+
+    const auto whole = renderNotes({kBlockSize, kBlockSize, kBlockSize, kBlockSize});
+    const auto split = renderNotes({1, 7, kBlockSize, 3, 1, 40, 20, kBlockSize, 60, 24});
+
+    // The instrument's audio arrives 80 samples late, so its MIDI is held to
+    // meet it: a note at t is seen at t + 80, however the blocks were cut.
+    REQUIRE_FALSE(whole.empty());
+    for (const auto position : whole)
+        CHECK(position % 23 == 80 % 23);
+
+    const auto common = std::min(whole.size(), split.size());
+    REQUIRE(common > 4);
+    for (std::size_t note = 0; note < common; ++note)
+        CHECK(whole[note] == split[note]);
+
+    SECTION("with the port carrying as much as its budget allows") {
+        // Right up against kMaxMidiBytesPerPort for a span of kBlockSize
+        // samples, which is the rate the delay's storage was reserved for. If
+        // that reservation is ever computed from callbacks again, this is what
+        // holds eighty samples of it in flight while the callbacks are short.
+        constexpr int perSample = magda::engine::kMaxMidiBytesPerPort /
+                                  (kBlockSize * magda::engine::kMidiShortMessageBytes);
+
+        auto track = makeTrack(1);
+        track.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
+        track.chain.fxChainElements.push_back(makeDeviceElement(makeInstrument(8)));
+
+        Harness harness({track}, makeMaster());
+        ConstantSource audio(0.0f);
+        DenseNoteSource notes(48, perSample);
+        LatentDevice latent(80);
+        MidiPositionProbe probe;
+        harness.bindings.clipAudio[1] = &audio;
+        harness.bindings.clipMidi[1] = &notes;
+        harness.bindings.devices[7] = &latent;
+        harness.bindings.devices[8] = &probe;
+        harness.prepareCleanly();
+
+        std::int64_t timelineSample = 0;
+        for (const auto numSamples : {1, 3, kBlockSize, 5, 40, kBlockSize, 11, kBlockSize}) {
+            harness.render(numSamples, timelineSample);
+            timelineSample += numSamples;
+        }
+
+        // Everything played more than the delay ago has arrived, and nothing
+        // has arrived early.
+        const auto arrived = probe.positionsOf(48);
+        REQUIRE(arrived.size() == static_cast<std::size_t>((timelineSample - 80) * perSample));
+        CHECK(arrived.front() == 80);
+        CHECK(arrived.back() == static_cast<int>(timelineSample) - 1);
+
+        // And it was all held in the room reserved for it, which is the part a
+        // reservation counted in callbacks rather than samples gets wrong.
+        CHECK(harness.executor.midiDelayOverflows() == 0);
+    }
 }
 
 TEST_CASE("A chain out of the mix silences a nested rack's MIDI too", "[engine][exec]") {

--- a/tests/test_render_plan_executor.cpp
+++ b/tests/test_render_plan_executor.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <deque>
 #include <string>
 #include <vector>
 
@@ -142,6 +143,74 @@ class NoteToDcInstrument final : public EngineDevice {
     float level_ = 0.0f;
 };
 
+/// One sample at timeline position zero and silence everywhere else, so where
+/// a signal ends up is a sample index rather than a level.
+class ImpulseSource final : public EngineAudioSource {
+  public:
+    explicit ImpulseSource(float level) : level_(level) {}
+
+    void render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) override {
+        out.clear();
+        if (block.timelineSample <= 0 && block.timelineSample + block.numSamples > 0)
+            for (std::size_t channel = 0; channel < out.getNumChannels(); ++channel)
+                out.setSample(static_cast<int>(channel), static_cast<int>(-block.timelineSample),
+                              level_);
+    }
+
+  private:
+    float level_;
+};
+
+/// Delays its input, and says so.
+///
+/// Deliberately not the engine's own delay line: a device that reports latency
+/// it does not produce would pass a compensation test whether or not anything
+/// compensated, and one that borrowed the line under test would pass a broken
+/// line twice over.
+class LatentDevice final : public EngineDevice {
+  public:
+    explicit LatentDevice(int latency) : latency_(latency) {}
+
+    void prepare(const RenderContext& context) override {
+        history_.assign(static_cast<std::size_t>(context.numChannels),
+                        std::deque<float>(static_cast<std::size_t>(latency_), 0.0f));
+    }
+
+    void process(DeviceBlock& block) override {
+        for (std::size_t channel = 0; channel < block.audio.getNumChannels(); ++channel) {
+            auto* samples = block.audio.getChannelPointer(channel);
+            auto& history = history_[channel];
+            for (int sample = 0; sample < block.block.numSamples; ++sample) {
+                history.push_back(samples[sample]);
+                samples[sample] = history.front();
+                history.pop_front();
+            }
+        }
+    }
+
+    int latencySamples() const override {
+        return latency_;
+    }
+
+  private:
+    int latency_;
+    std::vector<std::deque<float>> history_;
+};
+
+/// Adds its sidechain to its audio, so where the two arrive relative to each
+/// other is visible downstream.
+class SidechainSumDevice final : public EngineDevice {
+  public:
+    void process(DeviceBlock& block) override {
+        const auto numChannels =
+            std::min(block.audio.getNumChannels(), block.sidechain.getNumChannels());
+        for (std::size_t channel = 0; channel < numChannels; ++channel)
+            juce::FloatVectorOperations::add(block.audio.getChannelPointer(channel),
+                                             block.sidechain.getChannelPointer(channel),
+                                             block.block.numSamples);
+    }
+};
+
 /// Emits MIDI of its own, to exercise the MIDI ports and merges.
 class ArpDevice final : public EngineDevice {
   public:
@@ -155,6 +224,55 @@ class ArpDevice final : public EngineDevice {
 
   private:
     int noteNumber_;
+};
+
+/// An arp whose notes really do come out as late as it says they do, at a fixed
+/// offset into every block.
+class LatentArpDevice final : public EngineDevice {
+  public:
+    LatentArpDevice(int noteNumber, int latency, int offsetInBlock)
+        : noteNumber_(noteNumber), latency_(latency), offset_(offsetInBlock) {}
+
+    void process(DeviceBlock& block) override {
+        block.audio.clear();
+        if (block.midiOut != nullptr && offset_ < block.block.numSamples)
+            block.midiOut->addEvent(juce::MidiMessage::noteOn(1, noteNumber_, 1.0f), offset_);
+    }
+
+    int latencySamples() const override {
+        return latency_;
+    }
+
+  private:
+    int noteNumber_, latency_, offset_;
+};
+
+/// Where every note-on reached it, on the timeline.
+class MidiPositionProbe final : public EngineDevice {
+  public:
+    void process(DeviceBlock& block) override {
+        block.audio.clear();
+        for (const auto metadata : *block.midiIn)
+            if (const auto message = metadata.getMessage(); message.isNoteOn())
+                notes.push_back(
+                    {message.getNoteNumber(),
+                     static_cast<int>(block.block.timelineSample) + metadata.samplePosition});
+    }
+
+    struct Note {
+        int number = 0;
+        int position = 0;
+    };
+    std::vector<Note> notes;
+
+    /// Where the given note landed, once per block it arrived in.
+    std::vector<int> positionsOf(int number) const {
+        std::vector<int> positions;
+        for (const auto& note : notes)
+            if (note.number == number)
+                positions.push_back(note.position);
+        return positions;
+    }
 };
 
 /// Compile, resolve, prepare and render, so a test says what it is about and
@@ -217,6 +335,27 @@ struct Harness {
 
 Catch::Approx approx(float value) {
     return Catch::Approx(value).margin(1e-5);
+}
+
+/// Channel 0 of @p numBlocks consecutive blocks, as one stream, so where a
+/// signal came out is an index into it.
+std::vector<float> renderStream(Harness& harness, int numBlocks) {
+    std::vector<float> stream;
+    for (int block = 0; block < numBlocks; ++block) {
+        harness.render(kBlockSize, static_cast<std::int64_t>(block) * kBlockSize);
+        for (int sample = 0; sample < kBlockSize; ++sample)
+            stream.push_back(harness.outputSample(0, sample));
+    }
+    return stream;
+}
+
+/// Every sample that is not silent, as (position, level).
+std::vector<std::pair<int, float>> soundingSamples(const std::vector<float>& stream) {
+    std::vector<std::pair<int, float>> sounding;
+    for (std::size_t sample = 0; sample < stream.size(); ++sample)
+        if (std::abs(stream[sample]) > 1e-5f)
+            sounding.push_back({static_cast<int>(sample), stream[sample]});
+    return sounding;
 }
 
 }  // namespace
@@ -826,19 +965,187 @@ TEST_CASE("Unbound ops are reported and render silence", "[engine][exec]") {
     CHECK(harness.outputSample() == approx(0.0f));
 }
 
-TEST_CASE("Device latency is reported rather than silently ignored", "[engine][exec]") {
+TEST_CASE("A device's latency becomes the plan's latency", "[engine][exec][pdc]") {
     auto track = makeTrack(1);
     track.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
 
     Harness harness({track}, makeMaster());
-    ConstantSource source(1.0f);
-    GainDevice device(1.0f, 128);
+    ImpulseSource source(0.5f);
+    LatentDevice device(80);
     harness.bindings.clipAudio[1] = &source;
     harness.bindings.devices[7] = &device;
 
-    const auto messages = harness.prepare();
-    REQUIRE(messages.size() == 1);
-    CHECK(messages[0].find("128 samples of latency") != std::string::npos);
+    harness.prepareCleanly();
+    CHECK(harness.executor.latencySamples() == 80);
+
+    // Longer than a block, so the delay has to survive being read back across
+    // one and the ring has to wrap.
+    const auto sounding = soundingSamples(renderStream(harness, 4));
+    REQUIRE(sounding.size() == 1);
+    CHECK(sounding[0].first == 80);
+    CHECK(sounding[0].second == approx(0.5f));
+}
+
+TEST_CASE("Paths that meet are aligned to the longest of them", "[engine][exec][pdc]") {
+    // The current engine delays every input of a sum up to the longest one and
+    // never pulls anything early, wherever that sum happens to be. These are
+    // the places it happens: two tracks meeting in a mix, a group summing
+    // children, a send landing on another track's input, a sidechain meeting
+    // the chain it keys, and a rack's chains meeting each other.
+    ImpulseSource loud(0.5f);
+    ImpulseSource quiet(0.25f);
+    LatentDevice latent(48);
+
+    SECTION("two tracks summed into the master") {
+        auto latentTrack = makeTrack(1);
+        latentTrack.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
+
+        Harness harness({latentTrack, makeTrack(2)}, makeMaster());
+        harness.bindings.clipAudio[1] = &loud;
+        harness.bindings.clipAudio[2] = &quiet;
+        harness.bindings.devices[7] = &latent;
+
+        harness.prepareCleanly();
+        const auto sounding = soundingSamples(renderStream(harness, 3));
+
+        REQUIRE(sounding.size() == 1);
+        CHECK(sounding[0].first == 48);
+        CHECK(sounding[0].second == approx(0.75f));
+    }
+
+    SECTION("a group summing children of unequal latency") {
+        auto latentTrack = makeTrack(1);
+        latentTrack.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
+        latentTrack.audioOutputDevice = "track:3";
+
+        auto cleanTrack = makeTrack(2);
+        cleanTrack.audioOutputDevice = "track:3";
+
+        Harness harness({latentTrack, cleanTrack, makeTrack(3, TrackType::Group)}, makeMaster());
+        harness.bindings.clipAudio[1] = &loud;
+        harness.bindings.clipAudio[2] = &quiet;
+        harness.bindings.devices[7] = &latent;
+
+        harness.prepareCleanly();
+        const auto sounding = soundingSamples(renderStream(harness, 3));
+
+        REQUIRE(sounding.size() == 1);
+        CHECK(sounding[0].first == 48);
+        CHECK(sounding[0].second == approx(0.75f));
+    }
+
+    SECTION("a send from a latent track landing on a track of its own") {
+        auto latentTrack = makeTrack(1);
+        latentTrack.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
+        latentTrack.sends.push_back(SendInfo{0, 1.0f, false, 2});
+
+        Harness harness({latentTrack, makeTrack(2)}, makeMaster());
+        harness.bindings.clipAudio[1] = &loud;
+        harness.bindings.clipAudio[2] = &quiet;
+        harness.bindings.devices[7] = &latent;
+
+        harness.prepareCleanly();
+        const auto sounding = soundingSamples(renderStream(harness, 3));
+
+        // Track 1 direct, the same signal again through the send, and track 2's
+        // own, which the send's arrival is what delays.
+        REQUIRE(sounding.size() == 1);
+        CHECK(sounding[0].first == 48);
+        CHECK(sounding[0].second == approx(1.25f));
+    }
+
+    SECTION("a sidechain meeting the chain it keys") {
+        auto keyed = makeTrack(1);
+        auto device = makeEffect(7);
+        device.sidechain.type = SidechainConfig::Type::Audio;
+        device.sidechain.sourceTrackId = 2;
+        keyed.chain.fxChainElements.push_back(makeDeviceElement(device));
+
+        auto source = makeTrack(2);
+        source.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(8)));
+
+        Harness harness({keyed, source}, makeMaster());
+        SidechainSumDevice sum;
+        harness.bindings.clipAudio[1] = &loud;
+        harness.bindings.clipAudio[2] = &quiet;
+        harness.bindings.devices[7] = &sum;
+        harness.bindings.devices[8] = &latent;
+
+        harness.prepareCleanly();
+        const auto sounding = soundingSamples(renderStream(harness, 3));
+
+        // Track 1's own signal is what moves: the key it is being summed with
+        // arrives 48 samples late, so the plan delays the chain to meet it.
+        REQUIRE(sounding.size() == 1);
+        CHECK(sounding[0].first == 48);
+        CHECK(sounding[0].second == approx(1.0f));
+    }
+
+    SECTION("parallel rack chains of unequal latency") {
+        auto rack = std::make_unique<RackInfo>();
+        rack->id = 5;
+
+        ChainInfo latentChain;
+        latentChain.id = 10;
+        latentChain.elements.push_back(makeDeviceElement(makeEffect(7)));
+        rack->chains.push_back(std::move(latentChain));
+
+        ChainInfo cleanChain;
+        cleanChain.id = 11;
+        rack->chains.push_back(std::move(cleanChain));
+
+        auto track = makeTrack(1);
+        track.chain.fxChainElements.push_back(ChainElement{std::move(rack)});
+
+        Harness harness({track}, makeMaster());
+        harness.bindings.clipAudio[1] = &loud;
+        harness.bindings.devices[7] = &latent;
+
+        harness.prepareCleanly();
+        const auto sounding = soundingSamples(renderStream(harness, 3));
+
+        // Both chains carry the same signal, so aligned they sum to twice it.
+        REQUIRE(sounding.size() == 1);
+        CHECK(sounding[0].first == 48);
+        CHECK(sounding[0].second == approx(1.0f));
+    }
+}
+
+TEST_CASE("MIDI is aligned against the audio it travels with", "[engine][exec][pdc]") {
+    // The current engine carries a plugin's MIDI in the same stream as its
+    // audio, so a delay on that stream moves both. Here they are separate
+    // ports, and the merge is where they meet: the chain's own MIDI is delayed
+    // to where the device's arrives.
+    auto arp = makeEffect(7);
+    arp.deviceType = DeviceType::MIDI;
+    arp.canReceiveMidi = true;
+    arp.producesMidi = true;
+    arp.midiInThru = true;
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(arp));
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeInstrument(8)));
+
+    Harness harness({track}, makeMaster());
+    ConstantSource audio(0.0f);
+    NoteSource notes(40);
+    // 80 samples of latency at a 64 sample block: the arp's own note comes out
+    // 16 samples into the following block, and the chain's has to be held over
+    // the block boundary to land beside it.
+    LatentArpDevice latentArp(72, 80, 16);
+    MidiPositionProbe probe;
+    harness.bindings.clipAudio[1] = &audio;
+    harness.bindings.clipMidi[1] = &notes;
+    harness.bindings.devices[7] = &latentArp;
+    harness.bindings.devices[8] = &probe;
+
+    harness.prepareCleanly();
+    renderStream(harness, 4);
+
+    // Every block's note-on from the source is held 80 samples; the arp's are
+    // already where they claim to be.
+    CHECK(probe.positionsOf(72) == std::vector<int>{16, 80, 144, 208});
+    CHECK(probe.positionsOf(40) == std::vector<int>{80, 144, 208});
 }
 
 TEST_CASE("A malformed plan is refused, and the executor renders silence", "[engine][exec]") {
@@ -885,6 +1192,31 @@ TEST_CASE("Block size does not change what is rendered", "[engine][exec]") {
             out.push_back(harness.outputSample(0, sample));
     };
 
+    // The same, with two tracks and one of them latent, so what is compared is
+    // a delay line read back across a block boundary it does not line up with.
+    const auto renderCompensatedTwice = [](int firstBlock, int secondBlock,
+                                           std::vector<float>& out) {
+        auto latentTrack = makeTrack(1);
+        latentTrack.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
+
+        Harness harness({latentTrack, makeTrack(2)}, makeMaster());
+        RampSource ramp;
+        ConstantSource steady(0.25f);
+        LatentDevice device(37);
+        harness.bindings.clipAudio[1] = &ramp;
+        harness.bindings.clipAudio[2] = &steady;
+        harness.bindings.devices[7] = &device;
+        harness.prepareCleanly();
+
+        harness.render(firstBlock, 0);
+        for (int sample = 0; sample < firstBlock; ++sample)
+            out.push_back(harness.outputSample(0, sample));
+
+        harness.render(secondBlock, firstBlock);
+        for (int sample = 0; sample < secondBlock; ++sample)
+            out.push_back(harness.outputSample(0, sample));
+    };
+
     std::vector<float> whole;
     std::vector<float> split;
     renderTwice(kBlockSize, 0, whole);
@@ -893,6 +1225,15 @@ TEST_CASE("Block size does not change what is rendered", "[engine][exec]") {
     REQUIRE(whole.size() == split.size());
     for (std::size_t sample = 0; sample < whole.size(); ++sample)
         REQUIRE(whole[sample] == approx(split[sample]));
+
+    std::vector<float> compensatedWhole;
+    std::vector<float> compensatedSplit;
+    renderCompensatedTwice(kBlockSize, 0, compensatedWhole);
+    renderCompensatedTwice(kBlockSize / 4, kBlockSize - (kBlockSize / 4), compensatedSplit);
+
+    REQUIRE(compensatedWhole.size() == compensatedSplit.size());
+    for (std::size_t sample = 0; sample < compensatedWhole.size(); ++sample)
+        REQUIRE(compensatedWhole[sample] == approx(compensatedSplit[sample]));
 }
 
 TEST_CASE("A chain out of the mix silences a nested rack's MIDI too", "[engine][exec]") {


### PR DESCRIPTION
Two prepare-time passes over the compiled plan, and one new op.

Compensation is a Delay op on every input edge of a fan-in, keyed to the op it feeds. How many samples each one holds is not in the plan: latency belongs to a loaded instance, which the compiler has never seen, so it is resolved when the plan is prepared against its bindings. A plugin that changes what it reports therefore re-prepares the same plan instead of recompiling a new one, and the plan, its fingerprint and everything keyed on an OpKey come through untouched.

The rule is the current engine's, applied wherever paths meet: every input of a fan-in is delayed up to the longest of them and nothing is pulled early. That covers sends landing on another track, sidechains meeting the chain they key, groups summing children, and a rack's parallel chains, all without any of them being a special case. MIDI is aligned against the audio it travels with, which that engine gets for free by carrying both in one stream.

Buffer assignment replaces one buffer per port with an arena. Ports share only where no schedule can want both at once, tested against transitive dependency rather than the order the ops sit in: the reference executor's straight walk is one of the orders the parallel executor may pick, and a slot reused on the strength of that walk is a race in the others. An op may write over an input it is the only reader of, which keeps a track's whole chain in one buffer.

A delay that turns out to hold no samples is elided: the op does not run and its output port is its input's. That is what lets compensation be uniform in the plan without charging for it in the common case where there is none to do.


Closes #2013.
