### PR TITLE
Native engine: the transport, in beats (#2015)

### DIFF
--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -29,6 +29,13 @@ add_library(magda_engine STATIC
     exec/RenderContext.hpp
     exec/RuntimeStateStore.hpp
     exec/EngineSession.hpp
+    transport/TempoMap.cpp
+    transport/TransportClock.cpp
+    transport/ClickGenerator.cpp
+    transport/TempoMap.hpp
+    transport/TransportState.hpp
+    transport/TransportClock.hpp
+    transport/ClickGenerator.hpp
 )
 add_library(magda::engine ALIAS magda_engine)
 
@@ -76,7 +83,7 @@ endforeach()
 # Engine. Quoted includes may only reach the model layer ("core/...") or the
 # engine's own headers.
 
-set(MAGDA_ENGINE_ALLOWED_QUOTED_PREFIXES "core/" "plan/" "exec/")
+set(MAGDA_ENGINE_ALLOWED_QUOTED_PREFIXES "core/" "plan/" "exec/" "transport/")
 
 file(GLOB_RECURSE MAGDA_ENGINE_SOURCES CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -1,5 +1,7 @@
 #include "exec/EngineSession.hpp"
 
+#include <algorithm>
+
 namespace magda::engine {
 
 EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> plan,
@@ -11,6 +13,19 @@ EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> p
     auto prepared = std::make_shared<PreparedRender>();
     prepared->plan = std::move(plan);
     prepared->values = std::move(values);
+    prepared->context = context;
+
+    // The metronome is prepared against the device, not the plan, so it is
+    // shared with the epoch it replaces unless the device changed. Sharing is
+    // what keeps a click that is sounding from being cut in half by an edit
+    // somewhere else in the project; a new one is built only when the old one
+    // was made for a sample rate that no longer applies.
+    if (live_ != nullptr && live_->click != nullptr && live_->context == context) {
+        prepared->click = live_->click;
+    } else {
+        prepared->click = std::make_shared<ClickGenerator>();
+        prepared->click->prepare(context);
+    }
 
     // Realising early costs nothing if the plan turns out not to prepare: what
     // it created stays in the store, where the next attempt reuses it and the
@@ -71,12 +86,24 @@ void EngineSession::publishValues(PlanValues values) {
     values_.nonRealtimeReplace(std::move(values));
 }
 
-void EngineSession::process(const BlockInfo& block, juce::AudioBuffer<float>& output) {
+void EngineSession::publishTransport(TransportSnapshot transport) {
+    transport_.nonRealtimeReplace(std::move(transport));
+}
+
+void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output) {
+    output.clear();
+
     PublishedRender::ScopedAccess<farbot::ThreadType::realtime> render(published_);
-    if (*render == nullptr) {
-        output.clear();
+    if (*render == nullptr || numSamples <= 0)
         return;
-    }
+
+    // The executor asserts on a block longer than the plan was prepared for.
+    // Here the same number also says how much buffer there is to write into, so
+    // it is held to what the caller actually provided rather than trusted: the
+    // pieces of a split callback are views onto this, and a view past the end
+    // of it is not a wrong answer, it is someone else's memory.
+    jassert(numSamples <= output.getNumSamples());
+    numSamples = std::min(numSamples, output.getNumSamples());
 
     // Values and plans travel separately and are swapped one after the other,
     // so for the moment between the two the ones in flight can belong to the
@@ -89,7 +116,30 @@ void EngineSession::process(const BlockInfo& block, juce::AudioBuffer<float>& ou
     // it goes live, so anything still matching afterwards arrived after it.
     PublishedValues::ScopedAccess<farbot::ThreadType::realtime> values(values_);
     const auto& table = (*render)->executor.appliesValues(*values) ? *values : (*render)->values;
-    (*render)->executor.process(table, block, output);
+
+    PublishedTransport::ScopedAccess<farbot::ThreadType::realtime> transport(transport_);
+
+    // One callback is one or more stretches of timeline. It is more than one
+    // exactly when a loop wraps inside it, and the pieces are rendered as
+    // separate blocks so that nothing downstream has to know a wrap can happen
+    // in the middle of a buffer. Everything below the plan is block-size
+    // independent already, which is what makes cutting a callback free.
+    for (const auto& segment :
+         clock_.advance(*transport, (*render)->context.sampleRate, numSamples)) {
+        // A view on the output, not a copy: same channels, same memory, offset
+        // to where this piece belongs.
+        juce::AudioBuffer<float> piece(output.getArrayOfWritePointers(), output.getNumChannels(),
+                                       segment.startSample, segment.block.numSamples);
+
+        (*render)->executor.process(table, segment.block, piece);
+
+        // After the plan and outside it. The metronome is not in the graph: it
+        // is never recorded, never routed, and not the master fader's to
+        // attenuate.
+        if ((*render)->click != nullptr)
+            (*render)->click->render(transport->tempo, transport->click, segment.block,
+                                     segment.countingIn, output, segment.startSample);
+    }
 }
 
 }  // namespace magda::engine

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -7,6 +7,8 @@
 
 #include "exec/PlanExecutor.hpp"
 #include "exec/RuntimeStateStore.hpp"
+#include "transport/ClickGenerator.hpp"
+#include "transport/TransportClock.hpp"
 
 /**
  * @file EngineSession.hpp
@@ -78,8 +80,45 @@ class EngineSession {
     /// structural speed, so they travel on their own.
     void publishValues(PlanValues values);
 
-    /// On the audio thread. Renders silence until something is published.
-    void process(const BlockInfo& block, juce::AudioBuffer<float>& output);
+    /**
+     * @brief Tempo, loop, metronome and where the transport has been asked to
+     *        be, as one value.
+     *
+     * On the publishing thread. Travels on its own for the same reason values
+     * do: a tempo edit, a loop drag and a locate are all things that happen
+     * while the plan they apply to keeps playing.
+     *
+     * Nothing is published by default, so a session that has never seen one
+     * renders stopped at the beginning at 120 bpm rather than refusing to run.
+     */
+    void publishTransport(TransportSnapshot transport);
+
+    /**
+     * @brief Render @p numSamples. On the audio thread.
+     *
+     * The transport decides what stretch of timeline that is: the caller says
+     * how many samples the device wants and nothing about where they come from.
+     * A callback that a loop wraps inside is rendered as two blocks, back to
+     * back, and neither of them straddles the wrap.
+     *
+     * Renders silence until a plan is published, and the cursor stands still
+     * while it does. Not a policy about what a transport may do without a
+     * graph: the sample rate is settled when a plan is prepared, and a clock
+     * with no idea how long a sample lasts would be inventing a position rather
+     * than reporting one.
+     */
+    void process(int numSamples, juce::AudioBuffer<float>& output);
+
+    /// Where the transport is, in beats. Readable from any thread; this is
+    /// what a playhead is drawn from.
+    double positionBeats() const {
+        return clock_.positionBeats();
+    }
+
+    /// Callbacks in which a loop was too short to render as separate blocks.
+    int loopWrapOverflows() const {
+        return clock_.loopWrapOverflows();
+    }
 
     /// Runtime objects the store owns right now. On the publishing thread.
     std::size_t runtimeObjectCount() const {
@@ -100,10 +139,18 @@ class EngineSession {
     /// publishValues() has sent since is used when it belongs to this plan, and
     /// these are what the epoch renders with until it does. An epoch never
     /// renders without values that were resolved for it.
+    ///
+    /// The device properties and the metronome ride along for the same reason:
+    /// both are settled against a context, and the only safe moment to settle
+    /// them is while making an epoch nothing is rendering yet. The metronome is
+    /// shared with the epoch it replaces whenever the context has not changed,
+    /// so a click that is sounding is not cut off by a structural edit.
     struct PreparedRender {
         std::shared_ptr<const RenderPlan> plan;
         PlanExecutor executor;
         PlanValues values;
+        RenderContext context;
+        std::shared_ptr<ClickGenerator> click;
     };
 
     using PublishedRender =
@@ -111,10 +158,19 @@ class EngineSession {
                                farbot::RealtimeObjectOptions::nonRealtimeMutatable>;
     using PublishedValues =
         farbot::RealtimeObject<PlanValues, farbot::RealtimeObjectOptions::nonRealtimeMutatable>;
+    using PublishedTransport =
+        farbot::RealtimeObject<TransportSnapshot,
+                               farbot::RealtimeObjectOptions::nonRealtimeMutatable>;
 
     RuntimeStateStore store_;
     PublishedRender published_;
     PublishedValues values_;
+    PublishedTransport transport_;
+
+    /// The cursor. Not published and not swapped: it is where the timeline is,
+    /// which is a property of the session rather than of any plan, and a plan
+    /// swap must not move it.
+    TransportClock clock_;
 
     /// This thread's own handle on the epoch that is rendering. Held because
     /// the next publish prepares against it: the differ needs the plan it was

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -6,12 +6,6 @@
 namespace magda::engine {
 namespace {
 
-/// Bytes MidiBuffer spends on one event: a sample position, a length, and the
-/// message itself. Sized for the longest short message rather than the
-/// average, so a reservation computed from an event count always holds.
-constexpr int kMidiBytesPerEvent =
-    static_cast<int>(sizeof(std::int32_t) + sizeof(std::uint16_t)) + 3;
-
 /// Per-channel gain for a stereo pair. Anything wider alternates, which keeps
 /// the pairs correct if a device ever reports more than two channels; the model
 /// has no way to express one today.
@@ -564,8 +558,7 @@ void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedB
                 midiDelays_[static_cast<std::size_t>(line)]->process(midiIn(op.inputs[0]), out,
                                                                      numSamples);
                 jassert(out.data.size() <=
-                        static_cast<std::size_t>(
-                            midiByteBounds_[static_cast<std::size_t>(slotFor(PortRef{id, 0}))]));
+                        midiByteBounds_[static_cast<std::size_t>(slotFor(PortRef{id, 0}))]);
                 break;
             }
 

--- a/magda/engine/exec/RenderContext.hpp
+++ b/magda/engine/exec/RenderContext.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <cstdint>
+#include <algorithm>
+#include <cmath>
 
 /**
  * @file RenderContext.hpp
@@ -32,18 +33,70 @@ struct RenderContext {
 };
 
 /**
- * @brief The transport state for one block.
+ * @brief The stretch of timeline one block covers.
  *
- * Samples appear here and nowhere else in the engine. Beats are the canonical
- * musical domain; the executor's sample clock is the one place a musical
- * position becomes a sample position. There is no tempo map yet, so the caller
- * supplies the cursor directly and the transport slice replaces it with a
- * tempo-snapshot cursor reading beats.
+ * Beats, because beats are what the model positions things in. The transport's
+ * sample clock is what turns the audio device's sample count into this, once
+ * per block, and it is the only thing that reads a tempo map: an op is handed
+ * the two ends of its block and needs nothing else to know where it is.
+ *
+ * A block never spans a jump. The transport cuts a callback at every loop wrap,
+ * so what arrives here always runs from @ref startBeat to @ref endBeat without
+ * interruption, and @ref continuous says whether the previous block ended where
+ * this one begins.
  */
 struct BlockInfo {
     int numSamples = 0;
-    std::int64_t timelineSample = 0;
-    bool playing = true;
+
+    /// Whether the transport is rolling. A stopped block still renders: the
+    /// graph keeps running so tails ring out and live input passes through.
+    /// What a stopped block does not do is advance the timeline, so its start
+    /// and end beats are the same.
+    bool playing = false;
+
+    double startBeat = 0.0;
+    double endBeat = 0.0;
+
+    /**
+     * @brief Whether the timeline ran into this block out of the last one.
+     *
+     * False on the first block after the transport starts, after a locate, and
+     * after a loop wrap. What that licenses is narrow: anything an op derived
+     * from where the cursor *was* is stale and has to be derived again, which
+     * for a source means seeking.
+     *
+     * What it does not license is a reset. Audio did not stop flowing through
+     * the graph because the cursor moved, so delay lines, reverb tails and
+     * envelopes carry on across a jump exactly as they carry on across any
+     * other block boundary. An op that clears its state here is inventing a gap
+     * the transport never asked for.
+     */
+    bool continuous = false;
+
+    /**
+     * @brief Sample offset within this block of a musical position inside it.
+     *
+     * The conversion every op needs and none of them should be doing twice: a
+     * MIDI clip placing a note, a metronome placing a tick. Linear across the
+     * block, which is exact at a constant tempo and, across a ramp, wrong by
+     * far less than a sample over the few milliseconds a block lasts.
+     *
+     * Positions outside the block clamp to its ends: an event has to land on a
+     * sample this block actually has.
+     */
+    int sampleForBeat(double beat) const {
+        if (numSamples <= 0)
+            return 0;
+        if (endBeat <= startBeat)
+            return 0;
+
+        // Nearest rather than truncated: a position that lands exactly on a
+        // sample has to resolve to that sample, and the arithmetic getting
+        // there is not exact enough for truncation to promise it.
+        const auto position = (beat - startBeat) / (endBeat - startBeat);
+        const auto sample = static_cast<int>(std::lround(position * numSamples));
+        return std::clamp(sample, 0, numSamples - 1);
+    }
 };
 
 }  // namespace magda::engine

--- a/magda/engine/transport/ClickGenerator.cpp
+++ b/magda/engine/transport/ClickGenerator.cpp
@@ -1,0 +1,101 @@
+#include "transport/ClickGenerator.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace magda::engine {
+namespace {
+
+/// A metronome is a transient, not a note: long enough to be heard over a
+/// dense mix, short enough that two of them at 300 bpm do not overlap.
+constexpr double kClickSeconds = 0.04;
+constexpr double kDecaySeconds = 0.008;
+
+/// Long enough to keep the click's own onset from being a click.
+constexpr double kAttackSeconds = 0.001;
+
+constexpr double kBarFrequency = 2000.0;
+constexpr double kBeatFrequency = 1000.0;
+
+void synthesise(juce::AudioBuffer<float>& buffer, double sampleRate, double frequency) {
+    const auto length = buffer.getNumSamples();
+    const auto attack = std::max(1, static_cast<int>(kAttackSeconds * sampleRate));
+    auto* samples = buffer.getWritePointer(0);
+
+    for (auto i = 0; i < length; ++i) {
+        const auto seconds = static_cast<double>(i) / sampleRate;
+        const auto decay = std::exp(-seconds / kDecaySeconds);
+        const auto onset = i < attack ? 0.5 - 0.5 * std::cos(juce::MathConstants<double>::pi *
+                                                             static_cast<double>(i) / attack)
+                                      : 1.0;
+
+        samples[i] = static_cast<float>(
+            std::sin(juce::MathConstants<double>::twoPi * frequency * seconds) * decay * onset);
+    }
+}
+
+}  // namespace
+
+void ClickGenerator::prepare(const RenderContext& context) {
+    const auto length =
+        std::max(1, static_cast<int>(std::lround(kClickSeconds * context.sampleRate)));
+
+    barClick_.setSize(1, length);
+    beatClick_.setSize(1, length);
+    synthesise(barClick_, context.sampleRate, kBarFrequency);
+    synthesise(beatClick_, context.sampleRate, kBeatFrequency);
+
+    sounding_ = nullptr;
+    soundingPosition_ = 0;
+}
+
+void ClickGenerator::trigger(bool accent) {
+    sounding_ = accent ? &barClick_ : &beatClick_;
+    soundingPosition_ = 0;
+}
+
+void ClickGenerator::pour(juce::AudioBuffer<float>& output, int startSample, int numSamples,
+                          float gain) {
+    if (sounding_ == nullptr || numSamples <= 0)
+        return;
+
+    const auto count = std::min({sounding_->getNumSamples() - soundingPosition_, numSamples,
+                                 output.getNumSamples() - startSample});
+    if (count <= 0) {
+        sounding_ = nullptr;
+        return;
+    }
+
+    for (auto channel = 0; channel < output.getNumChannels(); ++channel)
+        output.addFrom(channel, startSample, *sounding_, 0, soundingPosition_, count, gain);
+
+    soundingPosition_ += count;
+    if (soundingPosition_ >= sounding_->getNumSamples())
+        sounding_ = nullptr;
+}
+
+void ClickGenerator::render(const TempoMap& tempo, const ClickSettings& click,
+                            const BlockInfo& block, bool countingIn,
+                            juce::AudioBuffer<float>& output, int startSample) {
+    if (barClick_.getNumSamples() == 0)
+        return;
+
+    // Whatever is still sounding finishes, even if the metronome was switched
+    // off while it was: cutting a decaying blip halfway through is itself a
+    // click, and the switch is a setting rather than a panic.
+    pour(output, startSample, block.numSamples, click.gain);
+
+    if (!click.enabled && !countingIn)
+        return;
+
+    // A stopped block covers no beats, so this walks nothing and the metronome
+    // falls silent without being told to.
+    for (auto tick = tempo.tickAtOrAfter(block.startBeat); tick.beat < block.endBeat;
+         tick = tempo.tickAtOrAfter(tick.nextBeat)) {
+        const auto offset = block.sampleForBeat(tick.beat);
+        trigger(click.emphasiseBars && tick.startsBar);
+        pour(output, startSample + offset, block.numSamples - offset, click.gain);
+    }
+}
+
+}  // namespace magda::engine

--- a/magda/engine/transport/ClickGenerator.hpp
+++ b/magda/engine/transport/ClickGenerator.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include "exec/RenderContext.hpp"
+#include "transport/TransportState.hpp"
+
+/**
+ * @file ClickGenerator.hpp
+ * @brief The metronome.
+ *
+ * Not an op, and deliberately not in the plan. The click is not part of the
+ * model's signal graph: it is never recorded, never routed, and never touched
+ * by the master fader, so putting it in the plan would mean recompiling the
+ * graph to toggle it and finding somewhere to hide it from every render. It is
+ * summed into the output after the plan instead, which is where the incumbent
+ * puts it too.
+ *
+ * The sounds are synthesised once when the generator is prepared, so the audio
+ * thread only ever copies. Two of them: a bar accent and a beat.
+ */
+
+namespace magda::engine {
+
+class ClickGenerator {
+  public:
+    /// Off the audio thread. A generator is prepared once for a device and
+    /// carried across plan swaps, so a click that is sounding stays sounding.
+    void prepare(const RenderContext& context);
+
+    /**
+     * @brief Add this block's clicks to @p output.
+     *
+     * On the audio thread. @p countingIn sounds the metronome whether or not it
+     * is switched on: a count-in that did not count would just be a late start.
+     *
+     * A click outlives the block it starts in, so what is left of one carries
+     * to the next block; that is the only state here, and a locate does not
+     * clear it, for the same reason a locate does not clear a reverb tail.
+     */
+    void render(const TempoMap& tempo, const ClickSettings& click, const BlockInfo& block,
+                bool countingIn, juce::AudioBuffer<float>& output, int startSample);
+
+  private:
+    void trigger(bool accent);
+
+    /// Copy what is left of the sounding click into the block, from
+    /// @p startSample, and advance by however much fitted.
+    void pour(juce::AudioBuffer<float>& output, int startSample, int numSamples, float gain);
+
+    juce::AudioBuffer<float> barClick_, beatClick_;
+
+    /// The click that is sounding, and how far into it we are. Null between
+    /// clicks, which is most of the time.
+    const juce::AudioBuffer<float>* sounding_ = nullptr;
+    int soundingPosition_ = 0;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/transport/TempoMap.cpp
+++ b/magda/engine/transport/TempoMap.cpp
@@ -1,0 +1,293 @@
+#include "transport/TempoMap.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
+
+#include "core/CurveMath.hpp"
+#include "core/TempoUtils.hpp"
+
+namespace magda::engine {
+namespace {
+
+/// Beats are compared, never accumulated, so this only has to absorb the error
+/// in one multiply. A tick computed a billionth of a beat early is on the beat.
+constexpr double kBeatEpsilon = 1.0e-9;
+
+/// How finely a tempo ramp is cut into constant-tempo sections. Four to the
+/// beat, capped, which is what the incumbent uses: at 120 bpm a section is
+/// 125 ms of a curve that is already smooth, and the cap keeps a ramp across a
+/// hundred bars from baking a hundred thousand sections nobody can hear.
+constexpr double kRampSectionsPerBeat = 4.0;
+constexpr double kMaxRampSections = 100.0;
+
+/// The last section has no end. It is given a length rather than an infinity so
+/// that its start time stays a finite number; nothing reads past it, because
+/// every lookup past the last section start resolves to it.
+constexpr double kTailBeats = 1.0e6;
+
+/// Where a ramp has got to, at a beat between two changes.
+///
+/// Evaluated through the model's own curve maths, so a tempo ramp is the curve
+/// the tempo lane draws rather than a second opinion about it.
+double rampedBpm(double beat, const TempoChange& from, const TempoChange& to) {
+    const auto span = to.startBeat - from.startBeat;
+    if (span <= 0.0)
+        return to.bpm;
+
+    const auto position = std::clamp((beat - from.startBeat) / span, 0.0, 1.0);
+    return static_cast<double>(
+        curvemath::evalSegment(static_cast<float>(from.bpm), static_cast<float>(to.bpm), 0.0f,
+                               from.tension, false, static_cast<float>(position)));
+}
+
+/// Bar length in beats. A beat is a quarter note, so a bar of x/y is x quarter
+/// notes scaled by what the denominator says a beat of the signature is worth.
+double barBeatsOf(int numerator, int denominator) {
+    return 4.0 * numerator / denominator;
+}
+
+/// The note value the metronome ticks on, in beats.
+double tickBeatsOf(int denominator) {
+    return 4.0 / denominator;
+}
+
+std::uint64_t mixInto(std::uint64_t hash, std::uint64_t value) {
+    // FNV-1a, as everywhere else in the engine that fingerprints a structure.
+    for (int byte = 0; byte < 8; ++byte) {
+        hash ^= (value >> (byte * 8)) & 0xff;
+        hash *= 1099511628211ULL;
+    }
+    return hash;
+}
+
+std::uint64_t mixDouble(std::uint64_t hash, double value) {
+    std::uint64_t bits = 0;
+    static_assert(sizeof(bits) == sizeof(value));
+    std::memcpy(&bits, &value, sizeof(bits));
+    return mixInto(hash, bits);
+}
+
+}  // namespace
+
+TempoMap::TempoMap() : TempoMap({}, {}) {}
+
+TempoMap::TempoMap(std::vector<TempoChange> tempos, std::vector<TimeSignatureChange> signatures) {
+    if (tempos.empty())
+        tempos.push_back({});
+    if (signatures.empty())
+        signatures.push_back({});
+
+    // Negative positions are clamped rather than refused: the timeline runs
+    // before beat zero (count-in does), but nothing there is editable, so a
+    // change that landed there is a change at the beginning.
+    for (auto& tempo : tempos) {
+        tempo.startBeat = std::max(0.0, tempo.startBeat);
+        tempo.bpm = clampBpm(tempo.bpm);
+        tempo.tension = std::clamp(tempo.tension, -1.0f, 1.0f);
+    }
+
+    for (auto& signature : signatures) {
+        signature.startBeat = std::max(0.0, signature.startBeat);
+        signature.numerator = clampTimeSignatureValue(signature.numerator);
+        signature.denominator = clampTimeSignatureValue(signature.denominator);
+    }
+
+    // Stable, so two changes at the same beat keep the order they arrived in:
+    // that pair is how a step is written, and which of them wins is the whole
+    // meaning of it.
+    std::stable_sort(tempos.begin(), tempos.end(),
+                     [](const auto& a, const auto& b) { return a.startBeat < b.startBeat; });
+    std::stable_sort(signatures.begin(), signatures.end(),
+                     [](const auto& a, const auto& b) { return a.startBeat < b.startBeat; });
+
+    // What precedes the first change is that change's own value, held. For the
+    // tempo that means an extra change at the beginning rather than moving the
+    // first one: moving it would drag the start of its ramp back with it.
+    if (tempos.front().startBeat > 0.0)
+        tempos.insert(tempos.begin(), TempoChange{0.0, tempos.front().bpm, 0.0f});
+    signatures.front().startBeat = 0.0;
+
+    fingerprint_ = 14695981039346656037ULL;
+    fingerprint_ = mixInto(fingerprint_, tempos.size());
+    for (const auto& tempo : tempos) {
+        fingerprint_ = mixDouble(fingerprint_, tempo.startBeat);
+        fingerprint_ = mixDouble(fingerprint_, tempo.bpm);
+        fingerprint_ = mixDouble(fingerprint_, tempo.tension);
+    }
+
+    fingerprint_ = mixInto(fingerprint_, signatures.size());
+    for (const auto& signature : signatures) {
+        fingerprint_ = mixDouble(fingerprint_, signature.startBeat);
+        fingerprint_ = mixInto(fingerprint_, static_cast<std::uint64_t>(signature.numerator));
+        fingerprint_ = mixInto(fingerprint_, static_cast<std::uint64_t>(signature.denominator));
+    }
+
+    // Every beat where anything changes, in order and without repeats. A
+    // section runs from one of these to the next, subdivided if a ramp crosses
+    // it.
+    std::vector<double> changeBeats;
+    changeBeats.reserve(tempos.size() + signatures.size());
+    for (const auto& tempo : tempos)
+        changeBeats.push_back(tempo.startBeat);
+    for (const auto& signature : signatures)
+        changeBeats.push_back(signature.startBeat);
+
+    std::sort(changeBeats.begin(), changeBeats.end());
+    changeBeats.erase(std::unique(changeBeats.begin(), changeBeats.end()), changeBeats.end());
+
+    sections_.reserve(changeBeats.size());
+
+    double time = 0.0;
+    std::size_t tempoIndex = 0, signatureIndex = 0;
+    TempoChange currentTempo = tempos.front();
+    TimeSignatureChange currentSignature = signatures.front();
+    double signatureStartBeat = 0.0;
+    int signatureStartBar = 0;
+
+    for (std::size_t i = 0; i < changeBeats.size(); ++i) {
+        const auto changeBeat = changeBeats[i];
+
+        // The last change at this beat is the one in force from it. Everything
+        // before it was only ever the target of the ramp arriving here, which
+        // is how a step is spelled: ramp to the first, then jump to the last.
+        while (tempoIndex < tempos.size() && tempos[tempoIndex].startBeat <= changeBeat)
+            currentTempo = tempos[tempoIndex++];
+
+        while (signatureIndex < signatures.size() &&
+               signatures[signatureIndex].startBeat <= changeBeat) {
+            const auto& signature = signatures[signatureIndex++];
+
+            // A signature change starts a bar, whether or not the bar it
+            // interrupts was finished.
+            if (signature.startBeat > signatureStartBeat) {
+                const auto bars = std::ceil(
+                    (signature.startBeat - signatureStartBeat) /
+                        barBeatsOf(currentSignature.numerator, currentSignature.denominator) -
+                    kBeatEpsilon);
+                signatureStartBar += static_cast<int>(bars);
+                signatureStartBeat = signature.startBeat;
+            }
+
+            currentSignature = signature;
+        }
+
+        const auto isLast = i + 1 == changeBeats.size();
+        const auto segmentEnd = isLast ? changeBeat + kTailBeats : changeBeats[i + 1];
+        const auto* rampTarget = tempoIndex < tempos.size() ? &tempos[tempoIndex] : nullptr;
+        const auto ramping =
+            rampTarget != nullptr && std::abs(rampTarget->bpm - currentTempo.bpm) > 1.0e-9;
+
+        auto subdivisions = 1;
+        if (ramping)
+            subdivisions = static_cast<int>(std::clamp(
+                kRampSectionsPerBeat * (segmentEnd - changeBeat), 1.0, kMaxRampSections));
+
+        const auto sectionBeats = (segmentEnd - changeBeat) / subdivisions;
+
+        for (auto k = 0; k < subdivisions; ++k) {
+            // Computed from the change beat rather than accumulated, so a long
+            // ramp's sections still start exactly where the next change does.
+            const auto sectionStartBeat = changeBeat + sectionBeats * k;
+
+            Section section;
+            section.startBeat = sectionStartBeat;
+            section.startTime = time;
+            section.bpm =
+                ramping ? rampedBpm(sectionStartBeat, currentTempo, *rampTarget) : currentTempo.bpm;
+            section.secondsPerBeat = 60.0 / section.bpm;
+            section.numerator = currentSignature.numerator;
+            section.denominator = currentSignature.denominator;
+            section.signatureStartBeat = signatureStartBeat;
+            section.signatureStartBar = signatureStartBar;
+            sections_.push_back(section);
+
+            time += sectionBeats * section.secondsPerBeat;
+        }
+    }
+
+    // Where each section's signature gives way to the next. A run of sections
+    // shares a signature, and the run ends where the next one starts.
+    for (std::size_t runStart = 0, i = 1; i <= sections_.size(); ++i) {
+        const auto lastRun = i == sections_.size();
+        if (!lastRun && sections_[i].signatureStartBeat == sections_[runStart].signatureStartBeat)
+            continue;
+
+        const auto signatureEnd =
+            lastRun ? std::numeric_limits<double>::infinity() : sections_[i].startBeat;
+        for (auto section = runStart; section < i; ++section)
+            sections_[section].signatureEndBeat = signatureEnd;
+
+        runStart = i;
+    }
+}
+
+const TempoMap::Section& TempoMap::sectionForBeat(double beat) const {
+    // Before the first section is the first section extended backwards: the
+    // timeline exists before beat zero and has to have a tempo there.
+    auto found = std::upper_bound(
+        sections_.begin(), sections_.end(), beat,
+        [](double value, const Section& section) { return value < section.startBeat; });
+    if (found == sections_.begin())
+        return sections_.front();
+    return *(found - 1);
+}
+
+const TempoMap::Section& TempoMap::sectionForTime(double seconds) const {
+    auto found = std::upper_bound(
+        sections_.begin(), sections_.end(), seconds,
+        [](double value, const Section& section) { return value < section.startTime; });
+    if (found == sections_.begin())
+        return sections_.front();
+    return *(found - 1);
+}
+
+double TempoMap::beatToTime(double beat) const {
+    const auto& section = sectionForBeat(beat);
+    return section.startTime + (beat - section.startBeat) * section.secondsPerBeat;
+}
+
+double TempoMap::timeToBeat(double seconds) const {
+    const auto& section = sectionForTime(seconds);
+    return section.startBeat + (seconds - section.startTime) / section.secondsPerBeat;
+}
+
+double TempoMap::bpmAt(double beat) const {
+    return sectionForBeat(beat).bpm;
+}
+
+BarsAndBeats TempoMap::barsAndBeatsAt(double beat) const {
+    const auto& section = sectionForBeat(beat);
+    const auto barBeats = barBeatsOf(section.numerator, section.denominator);
+    const auto sinceSignature = beat - section.signatureStartBeat;
+    const auto bars = std::floor(sinceSignature / barBeats);
+
+    return {section.signatureStartBar + static_cast<int>(bars),
+            (sinceSignature - bars * barBeats) / tickBeatsOf(section.denominator),
+            section.numerator};
+}
+
+BeatTick TempoMap::tickAtOrAfter(double beat) const {
+    const auto& section = sectionForBeat(beat);
+    const auto tickBeats = tickBeatsOf(section.denominator);
+
+    const auto index = std::ceil((beat - section.signatureStartBeat) / tickBeats - kBeatEpsilon);
+    auto tickBeat = section.signatureStartBeat + index * tickBeats;
+
+    // A signature change starts a bar, so it cuts the tick grid short wherever
+    // it lands.
+    if (tickBeat >= section.signatureEndBeat)
+        return {section.signatureEndBeat,
+                section.signatureEndBeat +
+                    tickBeatsOf(sectionForBeat(section.signatureEndBeat).denominator),
+                true};
+
+    const auto whole = std::llround(index);
+    const auto numerator = static_cast<long long>(section.numerator);
+    const auto inBar = ((whole % numerator) + numerator) % numerator;
+
+    return {tickBeat, std::min(tickBeat + tickBeats, section.signatureEndBeat), inBar == 0};
+}
+
+}  // namespace magda::engine

--- a/magda/engine/transport/TempoMap.cpp
+++ b/magda/engine/transport/TempoMap.cpp
@@ -53,6 +53,20 @@ double tickBeatsOf(int denominator) {
     return 4.0 / denominator;
 }
 
+/// One constant-tempo step of the tempo track, before signatures are merged in.
+struct GridTempo {
+    double startBeat = 0.0;
+    double bpm = 120.0;
+};
+
+/// One signature region, and the bar it opens on.
+struct GridSignature {
+    double startBeat = 0.0;
+    int numerator = 4;
+    int denominator = 4;
+    int startBar = 0;
+};
+
 std::uint64_t mixInto(std::uint64_t hash, std::uint64_t value) {
     // FNV-1a, as everywhere else in the engine that fingerprints a structure.
     for (int byte = 0; byte < 8; ++byte) {
@@ -124,102 +138,122 @@ TempoMap::TempoMap(std::vector<TempoChange> tempos, std::vector<TimeSignatureCha
         fingerprint_ = mixInto(fingerprint_, static_cast<std::uint64_t>(signature.denominator));
     }
 
-    // Every beat where anything changes, in order and without repeats. A
-    // section runs from one of these to the next, subdivided if a ramp crosses
-    // it.
-    std::vector<double> changeBeats;
-    changeBeats.reserve(tempos.size() + signatures.size());
-    for (const auto& tempo : tempos)
-        changeBeats.push_back(tempo.startBeat);
-    for (const auto& signature : signatures)
-        changeBeats.push_back(signature.startBeat);
+    // The tempo grid: where the tempo takes a new constant value, from the
+    // tempo track alone.
+    //
+    // Built before anything knows about signatures, and that is the whole point
+    // of building it separately. A section's tempo has to come from here rather
+    // than from re-evaluating the ramp at the section's own start, because a
+    // signature change cuts sections in two and re-evaluating would give the
+    // second half a different tempo from the one it would have had. Beats would
+    // then move in time when a signature changed, and a signature only groups
+    // beats: it never says when one happens.
+    std::vector<GridTempo> grid;
+    grid.reserve(tempos.size());
 
-    std::sort(changeBeats.begin(), changeBeats.end());
-    changeBeats.erase(std::unique(changeBeats.begin(), changeBeats.end()), changeBeats.end());
+    for (std::size_t i = 0; i < tempos.size(); ++i) {
+        // The last change written at a beat is the one in force from it.
+        // Everything before it was only ever the target of the ramp arriving
+        // there, which is how a step is spelled: ramp to the first, jump to the
+        // last.
+        if (i + 1 < tempos.size() && tempos[i + 1].startBeat <= tempos[i].startBeat)
+            continue;
 
-    sections_.reserve(changeBeats.size());
-
-    double time = 0.0;
-    std::size_t tempoIndex = 0, signatureIndex = 0;
-    TempoChange currentTempo = tempos.front();
-    TimeSignatureChange currentSignature = signatures.front();
-    double signatureStartBeat = 0.0;
-    int signatureStartBar = 0;
-
-    for (std::size_t i = 0; i < changeBeats.size(); ++i) {
-        const auto changeBeat = changeBeats[i];
-
-        // The last change at this beat is the one in force from it. Everything
-        // before it was only ever the target of the ramp arriving here, which
-        // is how a step is spelled: ramp to the first, then jump to the last.
-        while (tempoIndex < tempos.size() && tempos[tempoIndex].startBeat <= changeBeat)
-            currentTempo = tempos[tempoIndex++];
-
-        while (signatureIndex < signatures.size() &&
-               signatures[signatureIndex].startBeat <= changeBeat) {
-            const auto& signature = signatures[signatureIndex++];
-
-            // A signature change starts a bar, whether or not the bar it
-            // interrupts was finished.
-            if (signature.startBeat > signatureStartBeat) {
-                const auto bars = std::ceil(
-                    (signature.startBeat - signatureStartBeat) /
-                        barBeatsOf(currentSignature.numerator, currentSignature.denominator) -
-                    kBeatEpsilon);
-                signatureStartBar += static_cast<int>(bars);
-                signatureStartBeat = signature.startBeat;
-            }
-
-            currentSignature = signature;
-        }
-
-        const auto isLast = i + 1 == changeBeats.size();
-        const auto segmentEnd = isLast ? changeBeat + kTailBeats : changeBeats[i + 1];
-        const auto* rampTarget = tempoIndex < tempos.size() ? &tempos[tempoIndex] : nullptr;
+        const auto& current = tempos[i];
+        const auto* rampTarget = i + 1 < tempos.size() ? &tempos[i + 1] : nullptr;
         const auto ramping =
-            rampTarget != nullptr && std::abs(rampTarget->bpm - currentTempo.bpm) > 1.0e-9;
+            rampTarget != nullptr && std::abs(rampTarget->bpm - current.bpm) > 1.0e-9;
+        const auto spanEnd =
+            rampTarget != nullptr ? rampTarget->startBeat : current.startBeat + kTailBeats;
 
         auto subdivisions = 1;
         if (ramping)
             subdivisions = static_cast<int>(std::clamp(
-                kRampSectionsPerBeat * (segmentEnd - changeBeat), 1.0, kMaxRampSections));
+                kRampSectionsPerBeat * (spanEnd - current.startBeat), 1.0, kMaxRampSections));
 
-        const auto sectionBeats = (segmentEnd - changeBeat) / subdivisions;
+        const auto step = (spanEnd - current.startBeat) / subdivisions;
 
         for (auto k = 0; k < subdivisions; ++k) {
             // Computed from the change beat rather than accumulated, so a long
-            // ramp's sections still start exactly where the next change does.
-            const auto sectionStartBeat = changeBeat + sectionBeats * k;
-
-            Section section;
-            section.startBeat = sectionStartBeat;
-            section.startTime = time;
-            section.bpm =
-                ramping ? rampedBpm(sectionStartBeat, currentTempo, *rampTarget) : currentTempo.bpm;
-            section.secondsPerBeat = 60.0 / section.bpm;
-            section.numerator = currentSignature.numerator;
-            section.denominator = currentSignature.denominator;
-            section.signatureStartBeat = signatureStartBeat;
-            section.signatureStartBar = signatureStartBar;
-            sections_.push_back(section);
-
-            time += sectionBeats * section.secondsPerBeat;
+            // ramp's steps still start exactly where the next change does.
+            const auto startBeat = current.startBeat + step * k;
+            grid.push_back(
+                {startBeat, ramping ? rampedBpm(startBeat, current, *rampTarget) : current.bpm});
         }
     }
 
-    // Where each section's signature gives way to the next. A run of sections
-    // shares a signature, and the run ends where the next one starts.
-    for (std::size_t runStart = 0, i = 1; i <= sections_.size(); ++i) {
-        const auto lastRun = i == sections_.size();
-        if (!lastRun && sections_[i].signatureStartBeat == sections_[runStart].signatureStartBeat)
+    // The signature regions, and which bar each one opens on.
+    std::vector<GridSignature> regions;
+    regions.reserve(signatures.size());
+
+    for (const auto& signature : signatures) {
+        if (!regions.empty() && signature.startBeat <= regions.back().startBeat) {
+            // Coincident: the last one written wins, and the bar it opens is
+            // the one already counted.
+            regions.back().numerator = signature.numerator;
+            regions.back().denominator = signature.denominator;
             continue;
+        }
 
-        const auto signatureEnd =
-            lastRun ? std::numeric_limits<double>::infinity() : sections_[i].startBeat;
-        for (auto section = runStart; section < i; ++section)
-            sections_[section].signatureEndBeat = signatureEnd;
+        if (regions.empty()) {
+            regions.push_back({signature.startBeat, signature.numerator, signature.denominator, 0});
+            continue;
+        }
 
-        runStart = i;
+        // A signature change starts a bar, whether or not the bar it interrupts
+        // was finished.
+        const auto& previous = regions.back();
+        const auto bars = std::ceil((signature.startBeat - previous.startBeat) /
+                                        barBeatsOf(previous.numerator, previous.denominator) -
+                                    kBeatEpsilon);
+        regions.push_back({signature.startBeat, signature.numerator, signature.denominator,
+                           previous.startBar + static_cast<int>(bars)});
+    }
+
+    // A section begins wherever either grid does. Merging is all a signature
+    // does to the tempo: it splits sections, and both halves keep the tempo the
+    // one they came from had.
+    std::vector<double> boundaries;
+    boundaries.reserve(grid.size() + regions.size());
+    for (const auto& tempo : grid)
+        boundaries.push_back(tempo.startBeat);
+    for (const auto& region : regions)
+        boundaries.push_back(region.startBeat);
+
+    std::sort(boundaries.begin(), boundaries.end());
+    boundaries.erase(std::unique(boundaries.begin(), boundaries.end()), boundaries.end());
+
+    sections_.reserve(boundaries.size());
+
+    double time = 0.0;
+    std::size_t gridIndex = 0, regionIndex = 0;
+
+    for (std::size_t i = 0; i < boundaries.size(); ++i) {
+        const auto startBeat = boundaries[i];
+
+        while (gridIndex + 1 < grid.size() && grid[gridIndex + 1].startBeat <= startBeat)
+            ++gridIndex;
+        while (regionIndex + 1 < regions.size() && regions[regionIndex + 1].startBeat <= startBeat)
+            ++regionIndex;
+
+        const auto isLast = i + 1 == boundaries.size();
+        const auto endBeat = isLast ? startBeat + kTailBeats : boundaries[i + 1];
+
+        Section section;
+        section.startBeat = startBeat;
+        section.startTime = time;
+        section.bpm = grid[gridIndex].bpm;
+        section.secondsPerBeat = 60.0 / section.bpm;
+        section.numerator = regions[regionIndex].numerator;
+        section.denominator = regions[regionIndex].denominator;
+        section.signatureStartBeat = regions[regionIndex].startBeat;
+        section.signatureStartBar = regions[regionIndex].startBar;
+        section.signatureEndBeat = regionIndex + 1 < regions.size()
+                                       ? regions[regionIndex + 1].startBeat
+                                       : std::numeric_limits<double>::infinity();
+        sections_.push_back(section);
+
+        time += (endBeat - startBeat) * section.secondsPerBeat;
     }
 }
 

--- a/magda/engine/transport/TempoMap.hpp
+++ b/magda/engine/transport/TempoMap.hpp
@@ -1,0 +1,186 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+/**
+ * @file TempoMap.hpp
+ * @brief The musical timeline: where a beat falls, and what a bar is.
+ *
+ * Beats are the canonical domain. Everything the model positions is positioned
+ * in beats, so this is the only place in the engine that knows what a beat is
+ * worth in seconds, and the only thing that has to change when a tempo does.
+ *
+ * A beat is a quarter note, always, whatever the time signature says. The
+ * signature groups beats into bars and says which note value the metronome
+ * ticks on; it never changes what a beat means, because the model's clip and
+ * automation positions would move underneath the user if it did.
+ *
+ * Value semantics on purpose. A tempo map is published to the audio thread the
+ * way values are: copied off it, swapped in whole, read without a lock. It is
+ * built once per edit of the tempo track and read once per block.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief A tempo, from a beat until the next change.
+ *
+ * Consecutive changes ramp: the tempo travels from this one's bpm to the next
+ * one's across the beats between them, shaped by @ref tension. A step is two
+ * changes at the same beat, which is what the model's curve editor draws when
+ * two points share an x position.
+ */
+struct TempoChange {
+    double startBeat = 0.0;
+    double bpm = 120.0;
+
+    /// Shape of the ramp to the next change, in [-1, 1]: 0 is a straight line,
+    /// positive holds the old tempo longer, negative arrives at the new one
+    /// sooner. The same scalar the model's automation curves store, evaluated
+    /// through the same maths (magda::curvemath), so a tempo ramp sounds like
+    /// the curve the user drew rather than like a second interpretation of it.
+    float tension = 0.0f;
+};
+
+/**
+ * @brief A time signature, from a beat until the next change.
+ *
+ * A signature change always starts a bar: bar lines are counted from the change
+ * rather than continuing whatever grid preceded it.
+ */
+struct TimeSignatureChange {
+    double startBeat = 0.0;
+    int numerator = 4;
+    int denominator = 4;
+};
+
+/** Where a beat falls in the bar grid. */
+struct BarsAndBeats {
+    /// Zero-based, and negative before the first bar: a count-in runs through
+    /// bar -1, which is a real place on the timeline and not an error.
+    int bar = 0;
+
+    /// Position inside the bar, counted in the signature's own beats rather
+    /// than in quarter notes: 3.5 in 6/8 is halfway through the fourth eighth.
+    double beat = 0.0;
+
+    int numerator = 4;
+};
+
+/**
+ * @brief One metronome tick.
+ *
+ * The tick spacing is the signature's beat (the denominator's note value), so
+ * 4/4 ticks on quarter notes and 6/8 on eighths.
+ */
+struct BeatTick {
+    double beat = 0.0;
+
+    /// Where the following tick falls. Carried so a caller can walk ticks
+    /// across a block without inventing an epsilon to step past this one, and
+    /// so a signature change landing mid-tick shortens the gap rather than
+    /// being missed.
+    double nextBeat = 1.0;
+
+    bool startsBar = false;
+};
+
+/**
+ * @brief Tempo and time signature over the whole timeline.
+ *
+ * Built by baking the tempo track into constant-tempo sections, so every
+ * lookup is a binary search and a multiply. A ramp is subdivided rather than
+ * integrated: there is no closed form for the time across a curved tempo, and
+ * a subdivision that is fine enough to be inaudible is what every engine that
+ * offers ramps does. The subdivision is stated in the implementation and is
+ * the one approximation in here.
+ *
+ * Positions before beat zero are legal and extrapolate from the first section:
+ * count-in lives there.
+ */
+class TempoMap {
+  public:
+    /// 120 bpm in 4/4, from the beginning.
+    TempoMap();
+
+    /**
+     * @brief Bake a tempo track.
+     *
+     * Changes may arrive in any order and are sorted here. Neither list has to
+     * start at beat zero: what precedes the first change is that change's own
+     * value held constant, so a project whose first tempo sits at bar 5 does
+     * not silently play the four bars before it at some default.
+     */
+    TempoMap(std::vector<TempoChange> tempos, std::vector<TimeSignatureChange> timeSignatures);
+
+    /** Seconds at a beat. */
+    double beatToTime(double beat) const;
+
+    /** The beat at a time in seconds. */
+    double timeToBeat(double seconds) const;
+
+    /** Tempo at a beat, as the baked sections render it. */
+    double bpmAt(double beat) const;
+
+    /** Where a beat falls in the bar grid. */
+    BarsAndBeats barsAndBeatsAt(double beat) const;
+
+    /**
+     * @brief The first metronome tick at or after @p beat.
+     *
+     * A beat sitting exactly on a tick is that tick, so a block starting on the
+     * downbeat clicks on its first sample rather than a block late.
+     */
+    BeatTick tickAtOrAfter(double beat) const;
+
+    /**
+     * @brief Identity of the tempo track this was baked from.
+     *
+     * Two maps with the same fingerprint place every beat identically. The
+     * transport uses it to notice that the tempo changed under a playing
+     * cursor, which is the one moment a position has to be re-derived without
+     * being treated as a jump.
+     */
+    std::uint64_t fingerprint() const {
+        return fingerprint_;
+    }
+
+    bool operator==(const TempoMap& other) const {
+        return fingerprint_ == other.fingerprint_;
+    }
+
+  private:
+    /// A stretch of timeline at one tempo and one signature. Everything is
+    /// linear inside a section, which is what makes both conversions a
+    /// multiply.
+    struct Section {
+        double startBeat = 0.0;
+        double startTime = 0.0;
+        double bpm = 120.0;
+        double secondsPerBeat = 0.5;
+
+        int numerator = 4;
+        int denominator = 4;
+
+        /// Where the signature this section falls under began, and which bar
+        /// that was. Bars are a function of beats and signatures alone, so they
+        /// are counted here rather than walked through the tempo sections.
+        double signatureStartBeat = 0.0;
+        int signatureStartBar = 0;
+
+        /// Where that signature gives way to the next, or infinity. The
+        /// metronome needs it to know its grid is about to be cut short, and
+        /// needs it without scanning: one ramp between two signature changes
+        /// can be a hundred sections.
+        double signatureEndBeat = 0.0;
+    };
+
+    const Section& sectionForBeat(double beat) const;
+    const Section& sectionForTime(double seconds) const;
+
+    std::vector<Section> sections_;
+    std::uint64_t fingerprint_ = 0;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/transport/TransportClock.cpp
+++ b/magda/engine/transport/TransportClock.cpp
@@ -1,0 +1,183 @@
+#include "transport/TransportClock.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace magda::engine {
+namespace {
+
+constexpr double kBeatEpsilon = 1.0e-9;
+
+/// A boundary this close to the cursor is the cursor. Rounding up to the first
+/// sample at or past a musical position would otherwise turn the position the
+/// clock just anchored to into a boundary one sample ahead of itself.
+constexpr double kSampleEpsilon = 1.0e-2;
+
+}  // namespace
+
+void TransportClock::anchorTo(const TempoMap& tempo, double beat) {
+    anchorSeconds_ = tempo.beatToTime(beat);
+    samplesSinceAnchor_ = 0;
+    tempoFingerprint_ = tempo.fingerprint();
+    positionBeat_ = beat;
+    positionBeats_.store(beat, std::memory_order_relaxed);
+}
+
+double TransportClock::beatAfter(const TempoMap& tempo, std::int64_t samples) const {
+    return tempo.timeToBeat(anchorSeconds_ + static_cast<double>(samples) / sampleRate_);
+}
+
+std::int64_t TransportClock::samplesUntil(const TempoMap& tempo, double beat) const {
+    const auto now = anchorSeconds_ + static_cast<double>(samplesSinceAnchor_) / sampleRate_;
+    const auto target = tempo.beatToTime(beat);
+    return static_cast<std::int64_t>(std::ceil((target - now) * sampleRate_ - kSampleEpsilon));
+}
+
+void TransportClock::applyRequest(const TransportSnapshot& snapshot) {
+    const auto& request = snapshot.request;
+    if (request.generation == generation_)
+        return;
+
+    generation_ = request.generation;
+
+    const auto wasPlaying = playing_;
+    const auto wasAt = positionBeat_;
+
+    playing_ = request.playing;
+    playingPublic_.store(playing_, std::memory_order_relaxed);
+
+    countingIn_ = request.playing && request.countInBeats > 0.0;
+    countInUntilBeat_ = request.positionBeat;
+
+    // A locate is honoured as it was asked for, loop or no loop. The loop is
+    // somewhere the timeline returns to when it gets there, not a pen: a
+    // playhead put down at bar 40 with a two-bar loop enabled plays bar 40,
+    // which is what the user pointed at.
+    const auto position =
+        countingIn_ ? request.positionBeat - request.countInBeats : request.positionBeat;
+
+    anchorTo(snapshot.tempo, position);
+
+    // Starting is a jump, and so is arriving somewhere else. Stopping where the
+    // cursor already was is neither, and neither is a request that only
+    // repeated what the transport was already doing.
+    if ((playing_ && !wasPlaying) || std::abs(position - wasAt) > kBeatEpsilon)
+        continuous_ = false;
+}
+
+void TransportClock::followTempo(const TempoMap& tempo) {
+    if (tempo.fingerprint() == tempoFingerprint_)
+        return;
+
+    // The cursor keeps its beat and gives up its seconds: an edit to the tempo
+    // track moves when a beat happens, not which beat is playing. Continuity
+    // survives it, so this is not a jump, and a source reading the timeline has
+    // nothing to re-derive that the block's own beats do not already tell it.
+    anchorTo(tempo, positionBeat_);
+}
+
+std::span<const TransportClock::Segment> TransportClock::advance(const TransportSnapshot& snapshot,
+                                                                 double sampleRate,
+                                                                 int numSamples) {
+    segmentCount_ = 0;
+
+    if (sampleRate > 0.0 && sampleRate != sampleRate_) {
+        anchorSeconds_ += static_cast<double>(samplesSinceAnchor_) / sampleRate_;
+        samplesSinceAnchor_ = 0;
+        sampleRate_ = sampleRate;
+    }
+
+    const auto& tempo = snapshot.tempo;
+
+    applyRequest(snapshot);
+    followTempo(tempo);
+
+    if (numSamples <= 0)
+        return {};
+
+    if (!playing_) {
+        const auto beat = beatAfter(tempo, samplesSinceAnchor_);
+
+        auto& segment = segments_[0];
+        segment.block.numSamples = numSamples;
+        segment.block.playing = false;
+        segment.block.startBeat = beat;
+        segment.block.endBeat = beat;
+        segment.block.continuous = continuous_;
+        segment.startSample = 0;
+        segment.countingIn = false;
+
+        segmentCount_ = 1;
+        continuous_ = true;
+        positionBeat_ = beat;
+        positionBeats_.store(beat, std::memory_order_relaxed);
+        return {segments_.data(), 1};
+    }
+
+    auto remaining = numSamples;
+    auto offset = 0;
+
+    while (remaining > 0) {
+        // The count-in ends at the play position. Not a jump, but it changes
+        // what the metronome is allowed to do, so the callback is cut there
+        // rather than left to round to whichever side of the beat is nearer.
+        if (countingIn_ && samplesUntil(tempo, countInUntilBeat_) <= 0)
+            countingIn_ = false;
+
+        // Rolling in is not looping. A count-in that started before the loop
+        // end would otherwise wrap on its way to the play position and count
+        // for ever without arriving.
+        const auto looping = snapshot.loop.valid() && !countingIn_;
+        auto untilLoopEnd = looping ? samplesUntil(tempo, snapshot.loop.endBeat)
+                                    : std::numeric_limits<std::int64_t>::max();
+
+        // The loop catches a cursor that reached its end, and only that one:
+        // one already beyond it was put there, and dragging it back would be
+        // ignoring where it was put. Back to the top before anything is
+        // rendered, so no samples are ever taken from past the end.
+        if (looping && untilLoopEnd <= 0 &&
+            beatAfter(tempo, samplesSinceAnchor_) <= snapshot.loop.endBeat + kBeatEpsilon) {
+            anchorTo(tempo, snapshot.loop.startBeat);
+            continuous_ = false;
+            untilLoopEnd = samplesUntil(tempo, snapshot.loop.endBeat);
+        }
+
+        auto samples = static_cast<std::int64_t>(remaining);
+        if (countingIn_)
+            samples = std::min(samples, samplesUntil(tempo, countInUntilBeat_));
+        if (untilLoopEnd > 0)
+            samples = std::min(samples, untilLoopEnd);
+
+        // Both boundaries were just moved past if they were behind, so a whole
+        // segment is left. What is not left is room to keep cutting: past the
+        // last slot, and for a loop too short to have a sample in it, the rest
+        // of the callback plays straight through and the overflow is counted.
+        if (samples < 1 || segmentCount_ + 1 == kMaxSegmentsPerBlock) {
+            if (samples < remaining)
+                loopWrapOverflows_.fetch_add(1, std::memory_order_relaxed);
+            samples = remaining;
+        }
+
+        auto& segment = segments_[static_cast<std::size_t>(segmentCount_++)];
+        segment.block.numSamples = static_cast<int>(samples);
+        segment.block.playing = true;
+        segment.block.startBeat = beatAfter(tempo, samplesSinceAnchor_);
+        segment.block.endBeat = beatAfter(tempo, samplesSinceAnchor_ + samples);
+        segment.block.continuous = continuous_;
+        segment.startSample = offset;
+        segment.countingIn = countingIn_;
+
+        samplesSinceAnchor_ += samples;
+        offset += static_cast<int>(samples);
+        remaining -= static_cast<int>(samples);
+        continuous_ = true;
+    }
+
+    positionBeat_ = beatAfter(tempo, samplesSinceAnchor_);
+    positionBeats_.store(positionBeat_, std::memory_order_relaxed);
+
+    return {segments_.data(), static_cast<std::size_t>(segmentCount_)};
+}
+
+}  // namespace magda::engine

--- a/magda/engine/transport/TransportClock.cpp
+++ b/magda/engine/transport/TransportClock.cpp
@@ -143,10 +143,13 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
 
         // The loop catches a cursor that reached its end, and only that one:
         // one already beyond it was put there, and dragging it back would be
-        // ignoring where it was put. Back to the top before anything is
-        // rendered, so no samples are ever taken from past the end.
-        if (looping && untilLoopEnd <= 0 &&
-            beatAfter(tempo, samplesSinceAnchor_) <= snapshot.loop.endBeat + kBeatEpsilon) {
+        // ignoring where it was put.
+        const auto insideLoop = looping && beatAfter(tempo, samplesSinceAnchor_) <=
+                                               snapshot.loop.endBeat + kBeatEpsilon;
+
+        // Back to the top before anything is rendered, so no samples are ever
+        // taken from past the end.
+        if (insideLoop && untilLoopEnd <= 0) {
             anchorTo(tempo, snapshot.loop.startBeat);
             continuous_ = false;
             untilLoopEnd = samplesUntil(tempo, snapshot.loop.endBeat);
@@ -155,7 +158,14 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
         auto samples = static_cast<std::int64_t>(remaining);
         if (countingIn_)
             samples = std::min(samples, samplesUntil(tempo, countInUntilBeat_));
-        if (untilLoopEnd > 0)
+
+        // Clamped from inside the loop only. From outside it the count is
+        // negative and would cut a callback that is not looping at all; from
+        // inside, it can still be zero, for a loop so short that its end is not
+        // a sample away from its start even after wrapping. That zero is what
+        // routes such a loop into the fallback below rather than letting it
+        // render straight through uncounted.
+        if (insideLoop)
             samples = std::min(samples, untilLoopEnd);
 
         // Both boundaries were just moved past if they were behind, so a whole

--- a/magda/engine/transport/TransportClock.cpp
+++ b/magda/engine/transport/TransportClock.cpp
@@ -48,21 +48,30 @@ void TransportClock::applyRequest(const TransportSnapshot& snapshot) {
     playingPublic_.store(playing_, std::memory_order_relaxed);
 
     countingIn_ = request.playing && request.countInBeats > 0.0;
-    countInUntilBeat_ = request.positionBeat;
 
-    // A locate is honoured as it was asked for, loop or no loop. The loop is
-    // somewhere the timeline returns to when it gets there, not a pen: a
-    // playhead put down at bar 40 with a two-bar loop enabled plays bar 40,
-    // which is what the user pointed at.
-    const auto position =
-        countingIn_ ? request.positionBeat - request.countInBeats : request.positionBeat;
+    // A request that moves the cursor at all: a locate, or a roll-in, which
+    // moves it back to where the count begins. Everything else leaves the
+    // anchor alone rather than re-deriving the position it already has.
+    if (request.locate || countingIn_) {
+        // A locate is honoured as it was asked for, loop or no loop. The loop
+        // is somewhere the timeline returns to when it gets there, not a pen: a
+        // playhead put down at bar 40 with a two-bar loop enabled plays bar 40,
+        // which is what the user pointed at.
+        const auto target = request.locate ? request.positionBeat : wasAt;
+        const auto position = countingIn_ ? target - request.countInBeats : target;
 
-    anchorTo(snapshot.tempo, position);
+        countInUntilBeat_ = target;
+        anchorTo(snapshot.tempo, position);
 
-    // Starting is a jump, and so is arriving somewhere else. Stopping where the
-    // cursor already was is neither, and neither is a request that only
-    // repeated what the transport was already doing.
-    if ((playing_ && !wasPlaying) || std::abs(position - wasAt) > kBeatEpsilon)
+        // Arriving somewhere else is a jump.
+        if (std::abs(position - wasAt) > kBeatEpsilon)
+            continuous_ = false;
+    }
+
+    // As is starting. Stopping where the cursor already was is neither, and
+    // neither is a request that only repeated what the transport was already
+    // doing.
+    if (playing_ && !wasPlaying)
         continuous_ = false;
 }
 
@@ -153,8 +162,10 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
         // segment is left. What is not left is room to keep cutting: past the
         // last slot, and for a loop too short to have a sample in it, the rest
         // of the callback plays straight through and the overflow is counted.
+        auto overflowed = false;
         if (samples < 1 || segmentCount_ + 1 == kMaxSegmentsPerBlock) {
-            if (samples < remaining)
+            overflowed = samples < remaining;
+            if (overflowed)
                 loopWrapOverflows_.fetch_add(1, std::memory_order_relaxed);
             samples = remaining;
         }
@@ -172,6 +183,17 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
         offset += static_cast<int>(samples);
         remaining -= static_cast<int>(samples);
         continuous_ = true;
+
+        // Rendering straight through left the cursor past the loop end, which
+        // is where a cursor that was put there deliberately also sits, and the
+        // guard above cannot tell them apart. Put it back at the top: an
+        // overflow costs this callback its wrapping, and without this it would
+        // cost every callback after it too, because the loop would never catch
+        // the cursor again.
+        if (overflowed && snapshot.loop.valid() && !countingIn_) {
+            anchorTo(tempo, snapshot.loop.startBeat);
+            continuous_ = false;
+        }
     }
 
     positionBeat_ = beatAfter(tempo, samplesSinceAnchor_);

--- a/magda/engine/transport/TransportClock.hpp
+++ b/magda/engine/transport/TransportClock.hpp
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <span>
+
+#include "exec/RenderContext.hpp"
+#include "transport/TransportState.hpp"
+
+/**
+ * @file TransportClock.hpp
+ * @brief The sample clock: where the timeline is, and how far it moved.
+ *
+ * The audio device counts samples, the model counts beats, and this is the one
+ * place the two meet. It holds an anchor (a position on the timeline, and the
+ * sample count at which the cursor was there) and derives everything else from
+ * the samples since: the cursor is a function of the sample count, never a sum
+ * of per-block steps, so it cannot drift and a block cut in half lands in
+ * exactly the same place as the whole one would have.
+ *
+ * It also decides where a callback stops being one stretch of timeline. A loop
+ * wrap is a discontinuity, so the callback is cut at it and each piece is
+ * rendered as its own block; ops therefore never see a block that jumps in the
+ * middle, and never have to work out which of their samples came from where.
+ *
+ * Audio thread, one caller. The position it publishes is readable from
+ * anywhere.
+ */
+
+namespace magda::engine {
+
+class TransportClock {
+  public:
+    /// One stretch of a callback that the timeline runs through in one piece.
+    struct Segment {
+        BlockInfo block;
+
+        /// Where it begins in the callback's buffer.
+        int startSample = 0;
+
+        /// The cursor is still short of the play position, rolling in. The
+        /// metronome sounds through a count-in whether or not it is switched
+        /// on, which is the only thing that reads this.
+        bool countingIn = false;
+    };
+
+    /**
+     * @brief Move the cursor over @p numSamples and say what they cover.
+     *
+     * On the audio thread. The returned segments cover the callback exactly,
+     * in order, with no gaps. There is always at least one for a callback with
+     * samples in it: a stopped transport renders a block that stands still
+     * rather than no block at all.
+     *
+     * The sample rate arrives per call rather than through a prepare, because
+     * everything else about the clock lives on this thread and a rate settled
+     * from another one would be a race for the sake of an argument. A rate that
+     * has changed re-anchors: the cursor is a position in seconds, which
+     * survives it, plus a count of samples, which does not.
+     *
+     * The span points at storage owned by the clock and is valid until the next
+     * call.
+     */
+    std::span<const Segment> advance(const TransportSnapshot& snapshot, double sampleRate,
+                                     int numSamples);
+
+    /// Where the cursor is, in beats. Written on the audio thread, readable
+    /// from anywhere: this is what a playhead is drawn from.
+    double positionBeats() const {
+        return positionBeats_.load(std::memory_order_relaxed);
+    }
+
+    /// Whether the transport is rolling, as the clock currently has it.
+    bool isPlaying() const {
+        return playingPublic_.load(std::memory_order_relaxed);
+    }
+
+    /**
+     * @brief Callbacks in which a loop was too short to be honoured.
+     *
+     * A loop of a few samples would wrap more times in one callback than there
+     * is room to render separately. The rest of the callback plays straight
+     * through instead, and this counts it, because a loop that quietly stopped
+     * looping is exactly the kind of thing that gets blamed on the audio
+     * device.
+     */
+    int loopWrapOverflows() const {
+        return loopWrapOverflows_.load(std::memory_order_relaxed);
+    }
+
+  private:
+    /// How many pieces one callback may be cut into. A loop shorter than a
+    /// block is a stutter effect rather than a mistake, so several wraps in a
+    /// callback are rendered rather than refused; past this the loop is shorter
+    /// than the render can express and the overflow count says so.
+    static constexpr int kMaxSegmentsPerBlock = 32;
+
+    /// The timeline position, in seconds, that @ref samplesSinceAnchor_ counts
+    /// from.
+    void anchorTo(const TempoMap& tempo, double beat);
+
+    /// The beat the cursor would be at @p samples after the anchor.
+    double beatAfter(const TempoMap& tempo, std::int64_t samples) const;
+
+    /// Samples from the cursor until the timeline reaches @p beat, rounded up
+    /// so the answer is the first sample at or past it. Negative when it is
+    /// already behind.
+    std::int64_t samplesUntil(const TempoMap& tempo, double beat) const;
+
+    void applyRequest(const TransportSnapshot& snapshot);
+    void followTempo(const TempoMap& tempo);
+
+    double sampleRate_ = 44100.0;
+
+    std::array<Segment, kMaxSegmentsPerBlock> segments_{};
+    int segmentCount_ = 0;
+
+    /// The request that put the cursor where it is. A snapshot carrying this
+    /// same generation is a republication, not a new instruction.
+    std::uint64_t generation_ = 0;
+
+    bool playing_ = false;
+    double anchorSeconds_ = 0.0;
+    std::int64_t samplesSinceAnchor_ = 0;
+
+    /// The tempo map the anchor was computed against. A different one means
+    /// the seconds under the cursor moved while the beat it stands on did not.
+    std::uint64_t tempoFingerprint_ = 0;
+
+    /// Where the cursor is, kept here as well as published because re-anchoring
+    /// onto an edited tempo map needs the beat and can no longer ask the map
+    /// that produced it.
+    double positionBeat_ = 0.0;
+
+    bool countingIn_ = false;
+    double countInUntilBeat_ = 0.0;
+
+    /// Whether the next block continues the last one.
+    bool continuous_ = false;
+
+    std::atomic<double> positionBeats_{0.0};
+    std::atomic<bool> playingPublic_{false};
+    std::atomic<int> loopWrapOverflows_{0};
+};
+
+}  // namespace magda::engine

--- a/magda/engine/transport/TransportState.hpp
+++ b/magda/engine/transport/TransportState.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <cstdint>
+
+#include "transport/TempoMap.hpp"
+
+/**
+ * @file TransportState.hpp
+ * @brief Everything the transport reads, as one immutable value.
+ *
+ * Published the way values are: resolved on the message thread, swapped in
+ * whole, read on the audio thread without a lock. A tempo edit, a loop drag and
+ * a metronome toggle are all the same kind of event as a fader move, and none
+ * of them compiles a plan.
+ *
+ * Play, stop and locate travel the same way, as a request the clock applies
+ * once. They are state rather than events on purpose: two locates arriving
+ * inside one block should leave the cursor where the second one asked for, and
+ * a queue that replayed both would have it seek twice to get there.
+ */
+
+namespace magda::engine {
+
+/** The stretch of timeline playback returns to, in beats. */
+struct LoopRange {
+    bool enabled = false;
+    double startBeat = 0.0;
+    double endBeat = 0.0;
+
+    /// A range playback can actually run through. A backwards or empty one is
+    /// not looped rather than being repaired into something the user did not
+    /// ask for.
+    bool valid() const {
+        return enabled && endBeat > startBeat;
+    }
+
+    bool operator==(const LoopRange&) const = default;
+};
+
+/** The metronome. */
+struct ClickSettings {
+    bool enabled = false;
+
+    /// Accent the first beat of every bar.
+    bool emphasiseBars = true;
+
+    /// Linear gain, applied to both channels.
+    float gain = 0.5f;
+
+    bool operator==(const ClickSettings&) const = default;
+};
+
+/**
+ * @brief Where the transport has been asked to be.
+ *
+ * @ref generation is what makes it a request rather than a description: the
+ * clock applies a snapshot whose generation it has not seen and ignores the
+ * position in every other one, so republishing the same transport because the
+ * tempo changed does not drag the cursor back to where playback started.
+ * Whoever publishes bumps it for every play, stop and locate, and for nothing
+ * else.
+ */
+struct TransportRequest {
+    std::uint64_t generation = 0;
+    bool playing = false;
+    double positionBeat = 0.0;
+
+    /**
+     * @brief Beats of count-in before @ref positionBeat.
+     *
+     * Resolved by the caller rather than named as a mode here: how many beats a
+     * bar is worth is the tempo map's business, and whether a plain play counts
+     * in at all is the application's. What reaches the engine is a number of
+     * beats to roll in for.
+     *
+     * The cursor starts that far before the play position and reaches it
+     * playing, so material before the start is heard rather than skipped, and
+     * the loop does not wrap the roll-in.
+     */
+    double countInBeats = 0.0;
+};
+
+/** Tempo, loop, metronome and the play request, as one published value. */
+struct TransportSnapshot {
+    TempoMap tempo;
+    LoopRange loop;
+    ClickSettings click;
+    TransportRequest request;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/transport/TransportState.hpp
+++ b/magda/engine/transport/TransportState.hpp
@@ -58,11 +58,28 @@ struct ClickSettings {
  * position in every other one, so republishing the same transport because the
  * tempo changed does not drag the cursor back to where playback started.
  * Whoever publishes bumps it for every play, stop and locate, and for nothing
- * else.
+ * else. It starts at zero and the clock starts there too, so the first real
+ * request has to carry one above it or it will not be applied.
  */
 struct TransportRequest {
     std::uint64_t generation = 0;
     bool playing = false;
+
+    /**
+     * @brief Where to put the cursor, if @ref locate says to move it at all.
+     *
+     * False means the request is about the play state and nothing else: the
+     * cursor stays exactly where it is, and nothing about the timeline is
+     * discontinuous.
+     *
+     * Stopping is what needs it, and stopping is the most common transport
+     * action there is. A stop that had to name a position could only name one
+     * read from positionBeats() on another thread, which is a callback out of
+     * date by the time it arrives: the cursor would step back a few
+     * milliseconds on every stop, and the step would read as a jump, so every
+     * source would seek over a discontinuity nobody asked for.
+     */
+    bool locate = true;
     double positionBeat = 0.0;
 
     /**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -248,6 +248,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_plan_layout.cpp)
     list(APPEND TEST_SOURCES test_plan_diff.cpp)
     list(APPEND TEST_SOURCES test_engine_session.cpp)
+    list(APPEND TEST_SOURCES test_tempo_map.cpp)
+    list(APPEND TEST_SOURCES test_transport_clock.cpp)
+    list(APPEND TEST_SOURCES test_click_generator.cpp)
 endif()
 
 # Create test executable

--- a/tests/test_click_generator.cpp
+++ b/tests/test_click_generator.cpp
@@ -1,0 +1,194 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "transport/ClickGenerator.hpp"
+
+using magda::engine::BlockInfo;
+using magda::engine::ClickGenerator;
+using magda::engine::ClickSettings;
+using magda::engine::RenderContext;
+using magda::engine::TempoMap;
+
+namespace {
+
+constexpr double kSampleRate = 44100.0;
+constexpr int kBlockSize = 512;
+
+/// 120 bpm: 22050 samples to the beat.
+constexpr double kSamplesPerBeat = kSampleRate / 2.0;
+
+BlockInfo blockFrom(double startBeat, int numSamples) {
+    BlockInfo block;
+    block.numSamples = numSamples;
+    block.playing = true;
+    block.startBeat = startBeat;
+    block.endBeat = startBeat + numSamples / kSamplesPerBeat;
+    block.continuous = true;
+    return block;
+}
+
+/// The first sample past @p from with anything in it, or -1.
+int firstSounding(const juce::AudioBuffer<float>& output, int from = 0) {
+    for (auto sample = from; sample < output.getNumSamples(); ++sample)
+        if (output.getSample(0, sample) != 0.0f)
+            return sample;
+    return -1;
+}
+
+/// Where a click begins, or -1. Its very first sample is silent wherever it
+/// lands, because a sine starts at zero, so the burst begins one before the
+/// first thing audible.
+int clickStart(const juce::AudioBuffer<float>& output) {
+    const auto sounding = firstSounding(output);
+    return sounding < 0 ? sounding : sounding - 1;
+}
+
+struct Fixture {
+    Fixture() {
+        generator.prepare(RenderContext{kSampleRate, kBlockSize, 2});
+        output.setSize(2, kBlockSize);
+        output.clear();
+    }
+
+    void render(const BlockInfo& block, bool countingIn = false) {
+        generator.render(tempo, click, block, countingIn, output, 0);
+    }
+
+    ClickGenerator generator;
+    TempoMap tempo;
+    ClickSettings click{true, true, 1.0f};
+    juce::AudioBuffer<float> output;
+};
+
+}  // namespace
+
+TEST_CASE("The metronome sounds where the beat is", "[engine][transport][click]") {
+    Fixture fixture;
+
+    SECTION("on the first sample of a block that starts on a beat") {
+        fixture.render(blockFrom(0.0, kBlockSize));
+        CHECK(clickStart(fixture.output) == 0);
+    }
+
+    SECTION("part way into a block that does not") {
+        // The beat falls a hundred samples in, which is where the click starts
+        // and not a block early or a block late.
+        fixture.render(blockFrom(1.0 - 100.0 / kSamplesPerBeat, kBlockSize));
+        CHECK(clickStart(fixture.output) == 100);
+    }
+
+    SECTION("not at all between beats") {
+        fixture.render(blockFrom(0.25, kBlockSize));
+        CHECK(firstSounding(fixture.output) == -1);
+    }
+
+    SECTION("not at all while stopped") {
+        auto block = blockFrom(0.0, kBlockSize);
+        block.playing = false;
+        block.endBeat = block.startBeat;
+
+        fixture.render(block);
+        CHECK(firstSounding(fixture.output) == -1);
+    }
+}
+
+TEST_CASE("A bar is accented", "[engine][transport][click]") {
+    // A generator apiece, because a click carries into the blocks after it and
+    // one rendered on top of another's tail is not the sound being compared.
+    Fixture onTheBar, offTheBar;
+
+    onTheBar.render(blockFrom(0.0, kBlockSize));
+    offTheBar.render(blockFrom(1.0, kBlockSize));
+
+    REQUIRE(clickStart(onTheBar.output) == 0);
+    REQUIRE(clickStart(offTheBar.output) == 0);
+
+    auto different = false;
+    for (auto sample = 0; sample < kBlockSize; ++sample)
+        different = different ||
+                    onTheBar.output.getSample(0, sample) != offTheBar.output.getSample(0, sample);
+    CHECK(different);
+
+    SECTION("unless the emphasis is off, and then every beat is a beat") {
+        Fixture plain;
+        plain.click.emphasiseBars = false;
+        plain.render(blockFrom(0.0, kBlockSize));
+
+        for (auto sample = 0; sample < kBlockSize; ++sample)
+            REQUIRE(plain.output.getSample(0, sample) == offTheBar.output.getSample(0, sample));
+    }
+}
+
+TEST_CASE("A click outlives the block it starts in", "[engine][transport][click]") {
+    Fixture fixture;
+
+    // A click is forty milliseconds, which is several blocks of five hundred
+    // and twelve samples: what carries is the only state the metronome has.
+    fixture.render(blockFrom(0.0, kBlockSize));
+    REQUIRE(fixture.output.getSample(0, kBlockSize - 1) != 0.0f);
+
+    fixture.output.clear();
+    fixture.render(blockFrom(kBlockSize / kSamplesPerBeat, kBlockSize));
+    CHECK(fixture.output.getSample(0, 0) != 0.0f);
+
+    SECTION("including across a jump, which is not the metronome's business") {
+        fixture.output.clear();
+
+        auto jumped = blockFrom(64.0, kBlockSize);
+        jumped.continuous = false;
+
+        fixture.render(jumped);
+        CHECK(fixture.output.getSample(0, 0) != 0.0f);
+    }
+}
+
+TEST_CASE("The metronome is off when it is off, and on for a count-in",
+          "[engine][transport][click][countin]") {
+    Fixture fixture;
+    fixture.click.enabled = false;
+
+    SECTION("switched off") {
+        fixture.render(blockFrom(0.0, kBlockSize));
+        CHECK(firstSounding(fixture.output) == -1);
+    }
+
+    SECTION("switched off, but counting in") {
+        // A count-in that did not count would just be a late start.
+        fixture.render(blockFrom(0.0, kBlockSize), true);
+        CHECK(clickStart(fixture.output) == 0);
+    }
+
+    SECTION("switched off during a click, which finishes rather than snapping") {
+        fixture.click.enabled = true;
+        fixture.render(blockFrom(0.0, kBlockSize));
+        REQUIRE(fixture.output.getSample(0, kBlockSize - 1) != 0.0f);
+
+        fixture.click.enabled = false;
+        fixture.output.clear();
+        fixture.render(blockFrom(kBlockSize / kSamplesPerBeat, kBlockSize));
+        CHECK(fixture.output.getSample(0, 0) != 0.0f);
+    }
+}
+
+TEST_CASE("The metronome follows the time signature", "[engine][transport][click]") {
+    Fixture fixture;
+    fixture.tempo = TempoMap({}, {{0.0, 6, 8}});
+
+    // Six eighths to the bar: a click every half beat rather than every beat.
+    fixture.render(blockFrom(0.5 - 100.0 / kSamplesPerBeat, kBlockSize));
+    CHECK(clickStart(fixture.output) == 100);
+}
+
+TEST_CASE("Two beats inside one block both sound", "[engine][transport][click]") {
+    Fixture fixture;
+
+    // A block long enough to hold a whole beat, at a tempo where one fits:
+    // the metronome is not once per callback.
+    juce::AudioBuffer<float> output(2, static_cast<int>(kSamplesPerBeat) + 200);
+    output.clear();
+
+    auto block = blockFrom(0.0, output.getNumSamples());
+    fixture.generator.render(fixture.tempo, fixture.click, block, false, output, 0);
+
+    CHECK(clickStart(output) == 0);
+    CHECK(output.getSample(0, static_cast<int>(kSamplesPerBeat) + 1) != 0.0f);
+}

--- a/tests/test_engine_session.cpp
+++ b/tests/test_engine_session.cpp
@@ -209,7 +209,9 @@ class LoggingFactory final : public RuntimeStateFactory {
 /// Playing from a beat, with the metronome off.
 magda::engine::TransportSnapshot rolling(double fromBeat) {
     magda::engine::TransportSnapshot transport;
-    transport.request = {1, true, fromBeat, 0.0};
+    transport.request.generation = 1;
+    transport.request.playing = true;
+    transport.request.positionBeat = fromBeat;
     return transport;
 }
 

--- a/tests/test_engine_session.cpp
+++ b/tests/test_engine_session.cpp
@@ -183,6 +183,36 @@ std::vector<TrackInfo> trackWithEffect(DeviceId deviceId) {
     return {track};
 }
 
+/// Records the stretch of timeline it was asked for, so a test can see how a
+/// callback was cut up on its way to the ops.
+class BlockLog final : public EngineAudioSource {
+  public:
+    void render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) override {
+        out.fill(1.0f);
+        blocks.push_back(block);
+    }
+
+    std::vector<BlockInfo> blocks;
+};
+
+class LoggingFactory final : public RuntimeStateFactory {
+  public:
+    std::unique_ptr<EngineAudioSource> createClipAudioSource(TrackId) override {
+        auto source = std::make_unique<BlockLog>();
+        log = source.get();
+        return source;
+    }
+
+    BlockLog* log = nullptr;
+};
+
+/// Playing from a beat, with the metronome off.
+magda::engine::TransportSnapshot rolling(double fromBeat) {
+    magda::engine::TransportSnapshot transport;
+    transport.request = {1, true, fromBeat, 0.0};
+    return transport;
+}
+
 }  // namespace
 
 TEST_CASE("A session renders nothing until a plan is published", "[engine][session]") {
@@ -192,7 +222,7 @@ TEST_CASE("A session renders nothing until a plan is published", "[engine][sessi
 
     juce::AudioBuffer<float> output(2, kBlockSize);
     output.clear();
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
 
     CHECK(session.livePlan() == nullptr);
     CHECK(output.getSample(0, 0) == approx(0.0f));
@@ -213,7 +243,7 @@ TEST_CASE("Publishing a plan puts it on the audio thread", "[engine][session]") 
     CHECK(session.livePlan() == plan);
 
     juce::AudioBuffer<float> output(2, kBlockSize);
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
 
     CHECK(output.getSample(0, 0) == approx(0.5f));
 }
@@ -236,7 +266,7 @@ TEST_CASE("A latency change re-prepares the plan rather than recompiling it",
     session.publishValues(resolve(*plan, tracks));
 
     juce::AudioBuffer<float> output(2, kBlockSize);
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
     CHECK(output.getSample(0, 0) == approx(1.5f));
 
     auto* device = factory.devicesById[7];
@@ -252,7 +282,7 @@ TEST_CASE("A latency change re-prepares the plan rather than recompiling it",
 
     // Track 2 now waits for the track the device is on, so the first sixteen
     // samples are the latent track alone and the rest are both.
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
     CHECK(output.getSample(0, 0) == approx(0.5f));
     CHECK(output.getSample(0, 15) == approx(0.5f));
     CHECK(output.getSample(0, 16) == approx(1.5f));
@@ -276,13 +306,13 @@ TEST_CASE("Republishing a plan applies the values it was published with", "[engi
     session.publishValues(resolve(*plan, tracks));
 
     juce::AudioBuffer<float> output(2, kBlockSize);
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
     REQUIRE(output.getSample(0, 0) == approx(0.25f));
 
     // The same plan, and nothing published after it.
     tracks[0].volume = 1.0f;
     REQUIRE(publish(session, plan, tracks).published);
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
 
     CHECK(output.getSample(0, 0) == approx(0.5f));
 }
@@ -300,7 +330,7 @@ TEST_CASE("A plan published with another plan's values is refused", "[engine][se
     REQUIRE(publish(session, plan, tracks).published);
 
     juce::AudioBuffer<float> output(2, kBlockSize);
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
     REQUIRE(output.getSample(0, 0) == approx(0.5f));
 
     // A structurally different plan, and this plan's values.
@@ -335,7 +365,7 @@ TEST_CASE("A plan published with another plan's values is refused", "[engine][se
 
     // Still the plan that was right, still rendering what it was.
     CHECK(session.livePlan() == plan);
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
     CHECK(output.getSample(0, 0) == approx(0.5f));
 }
 
@@ -357,7 +387,7 @@ TEST_CASE("An object that is already playing is never prepared again", "[engine]
     CHECK(device->prepareCalls == 1);
 
     juce::AudioBuffer<float> output(2, kBlockSize);
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
     REQUIRE(device->blocksProcessed == 1);
 
     // A second device on the track: a structural edit that keeps the first one.
@@ -392,7 +422,7 @@ TEST_CASE("A structural edit does not cut what is in flight", "[engine][session]
     session.publishValues(resolve(*first, tracks));
 
     juce::AudioBuffer<float> output(2, kBlockSize);
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
 
     // Track 1 through its device, and track 2 arriving sixteen samples in.
     CHECK(output.getSample(0, 0) == approx(0.5f));
@@ -404,7 +434,7 @@ TEST_CASE("A structural edit does not cut what is in flight", "[engine][session]
     REQUIRE(publish(session, second, tracks).published);
     session.publishValues(resolve(*second, tracks));
 
-    session.process(BlockInfo{kBlockSize, kBlockSize, true}, output);
+    session.process(kBlockSize, output);
 
     // Track 1 through both devices now, and track 2 straight away rather than
     // sixteen samples of silence and then a step.
@@ -441,7 +471,7 @@ TEST_CASE("A swap carries runtime state that the new plan still names", "[engine
     CHECK(factory.devicesById[7] == device);
 
     juce::AudioBuffer<float> output(2, kBlockSize);
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
     CHECK(output.getSample(0, 0) == approx(0.25f));
 }
 
@@ -456,7 +486,7 @@ TEST_CASE("What a swap drops is destroyed on the publishing thread", "[engine][s
     session.publishValues(resolve(*firstPlan, withDevice));
 
     juce::AudioBuffer<float> output(2, kBlockSize);
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
     REQUIRE(ledger.devicesDestroyed == 0);
 
     const std::vector<TrackInfo> withoutDevice{makeTrack(1)};
@@ -543,7 +573,7 @@ TEST_CASE("Model IDs that have moved on cannot retire what the live plan uses",
     REQUIRE(factory.devicesById[7] != nullptr);
 
     juce::AudioBuffer<float> output(2, kBlockSize);
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
     CHECK(output.getSample(0, 0) == approx(0.5f));
 
     // It goes when the plan stops naming it too, which is the first moment
@@ -577,7 +607,7 @@ TEST_CASE("A plan that does not prepare leaves the live one playing", "[engine][
     CHECK(session.livePlan() == good);
 
     juce::AudioBuffer<float> output(2, kBlockSize);
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
     CHECK(output.getSample(0, 0) == approx(0.5f));
 }
 
@@ -600,7 +630,7 @@ TEST_CASE("A first plan that is refused leaves a session with nothing live", "[e
     CHECK(session.livePlan() == nullptr);
 
     juce::AudioBuffer<float> output(2, kBlockSize);
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
     CHECK(output.getSample(0, 0) == approx(0.0f));
 
     // This one named nothing, so nothing was created for it. What a refused
@@ -631,7 +661,7 @@ TEST_CASE("A plan renders with values that belong to it, always", "[engine][sess
     session.publishValues(resolve(*firstPlan, tracks));
 
     juce::AudioBuffer<float> output(2, kBlockSize);
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
     REQUIRE(output.getSample(0, 0) == approx(0.25f));
 
     // Swap the device out and publish nothing new: the values in flight belong
@@ -641,13 +671,13 @@ TEST_CASE("A plan renders with values that belong to it, always", "[engine][sess
     const auto secondPlan = compile(replaced);
     publish(session, secondPlan, replaced);
 
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
     CHECK(output.getSample(0, 0) == approx(0.25f));
 
     // And the mixer-speed path still lands, on top of the same reading.
     replaced[0].volume = 1.0f;
     session.publishValues(resolve(*secondPlan, replaced));
-    session.process(BlockInfo{kBlockSize, 0, true}, output);
+    session.process(kBlockSize, output);
     CHECK(output.getSample(0, 0) == approx(0.5f));
 }
 
@@ -683,7 +713,7 @@ TEST_CASE("Swapping under a running audio thread never tears", "[engine][session
     std::thread audio([&] {
         juce::AudioBuffer<float> output(2, kBlockSize);
         while (running.load(std::memory_order_relaxed)) {
-            session.process(BlockInfo{kBlockSize, 0, true}, output);
+            session.process(kBlockSize, output);
             const auto sample = output.getSample(0, 0);
             // Every plan in the rotation renders one of these, and a torn read
             // would land somewhere else entirely.
@@ -718,4 +748,115 @@ TEST_CASE("Swapping under a running audio thread never tears", "[engine][session
     CHECK(ledger.devicesDestroyed > 0);
     CHECK(factory.devicesById[7] != nullptr);
     CHECK(ledger.lastDestroyingThread.load() == std::this_thread::get_id());
+}
+
+// A plan renders one stretch of timeline at a time. The transport is what
+// decides which stretch that is, and what happens when one callback covers two.
+TEST_CASE("A callback the loop wraps inside renders as two blocks",
+          "[engine][session][transport]") {
+    LoggingFactory factory;
+    EngineSession session(factory);
+
+    const std::vector<TrackInfo> tracks{makeTrack(1)};
+    const auto plan = compile(tracks);
+    REQUIRE(publish(session, plan, tracks).published);
+    REQUIRE(factory.log != nullptr);
+
+    // A loop one beat long at 120 bpm: 22050 samples, which a callback lands
+    // inside of after 344 blocks of 64.
+    auto transport = rolling(0.0);
+    transport.loop = {true, 0.0, 1.0};
+    session.publishTransport(transport);
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    for (auto block = 0; block < 345; ++block)
+        session.process(kBlockSize, output);
+
+    REQUIRE(factory.log->blocks.size() == 346);
+
+    const auto& before = factory.log->blocks[344];
+    const auto& after = factory.log->blocks[345];
+
+    // The two pieces of the callback that straddled the loop end. Neither of
+    // them covers the wrap, which is the point: an op is never handed a block
+    // whose timeline jumps in the middle.
+    CHECK(before.numSamples + after.numSamples == kBlockSize);
+    CHECK(before.endBeat == Catch::Approx(1.0).margin(1e-9));
+    CHECK(after.startBeat == Catch::Approx(0.0).margin(1e-9));
+    CHECK(before.continuous);
+    CHECK(!after.continuous);
+}
+
+TEST_CASE("The transport, not the caller, says where the timeline is",
+          "[engine][session][transport]") {
+    LoggingFactory factory;
+    EngineSession session(factory);
+
+    const std::vector<TrackInfo> tracks{makeTrack(1)};
+    const auto plan = compile(tracks);
+    REQUIRE(publish(session, plan, tracks).published);
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+
+    SECTION("stopped until it is asked to play") {
+        session.process(kBlockSize, output);
+
+        REQUIRE(factory.log->blocks.size() == 1);
+        CHECK(!factory.log->blocks[0].playing);
+        CHECK(session.positionBeats() == Catch::Approx(0.0));
+    }
+
+    SECTION("and moves at the rate the tempo map says") {
+        session.publishTransport(rolling(0.0));
+
+        // 22050 samples to the beat at 120 bpm, which is not a whole number of
+        // blocks: the last one is short, and the cursor lands on the beat
+        // either way because it counts samples rather than callbacks.
+        for (auto block = 0; block < 22050 / kBlockSize; ++block)
+            session.process(kBlockSize, output);
+        session.process(22050 % kBlockSize, output);
+
+        CHECK(session.positionBeats() == Catch::Approx(1.0).margin(1e-9));
+        CHECK(factory.log->blocks.back().playing);
+    }
+}
+
+TEST_CASE("The metronome is added after the plan, not through it",
+          "[engine][session][transport][click]") {
+    LoggingFactory factory;
+    EngineSession session(factory);
+
+    // A muted master: the plan renders silence, so anything in the output came
+    // from outside it.
+    auto master = makeMaster();
+    master.muted = true;
+
+    const std::vector<TrackInfo> tracks{makeTrack(1)};
+    const auto plan =
+        std::make_shared<const RenderPlan>(magda::engine::compileRenderPlan(tracks, master));
+
+    PlanValues values;
+    magda::engine::resolvePlanValues(*plan, tracks, master, values);
+    REQUIRE(
+        session
+            .publish(plan, context(), magda::engine::collectRuntimeStateIds(tracks, master), values)
+            .published);
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+
+    SECTION("silent with the metronome off") {
+        session.publishTransport(rolling(0.0));
+        session.process(kBlockSize, output);
+
+        CHECK(output.getMagnitude(0, kBlockSize) == approx(0.0f));
+    }
+
+    SECTION("sounding with it on, through a master that is muted") {
+        auto transport = rolling(0.0);
+        transport.click = {true, true, 1.0f};
+        session.publishTransport(transport);
+        session.process(kBlockSize, output);
+
+        CHECK(output.getMagnitude(0, kBlockSize) > 0.1f);
+    }
 }

--- a/tests/test_render_plan_executor.cpp
+++ b/tests/test_render_plan_executor.cpp
@@ -30,6 +30,30 @@ namespace {
 
 constexpr int kBlockSize = 64;
 
+/// These tests place things on a sample timeline, because that is what makes
+/// two short blocks comparable with one long one, sample for sample. The
+/// transport hands out beats, so the fixtures convert with one constant chosen
+/// so that every sample position is a beat position exactly: what is being
+/// tested here is the executor, and a rounding error in the fixture would look
+/// like one in the thing under test.
+constexpr double kSamplesPerBeat = 64.0;
+
+BlockInfo blockAt(std::int64_t timelineSample, int numSamples, bool continuous = true) {
+    BlockInfo block;
+    block.numSamples = numSamples;
+    block.playing = true;
+    block.startBeat = static_cast<double>(timelineSample) / kSamplesPerBeat;
+    block.endBeat = static_cast<double>(timelineSample + numSamples) / kSamplesPerBeat;
+    block.continuous = continuous;
+    return block;
+}
+
+/// Where a block starts, back in samples. What a real source does with the
+/// clip's own mapping, done here with the fixture's.
+std::int64_t timelineSampleOf(const BlockInfo& block) {
+    return std::llround(block.startBeat * kSamplesPerBeat);
+}
+
 TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Audio) {
     TrackInfo track;
     track.id = id;
@@ -85,7 +109,7 @@ class RampSource final : public EngineAudioSource {
     void render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) override {
         for (int sample = 0; sample < block.numSamples; ++sample) {
             const auto value =
-                static_cast<float>((block.timelineSample + sample) % 97) * (1.0f / 97.0f);
+                static_cast<float>((timelineSampleOf(block) + sample) % 97) * (1.0f / 97.0f);
             for (std::size_t channel = 0; channel < out.getNumChannels(); ++channel)
                 out.setSample(static_cast<int>(channel), sample, value);
         }
@@ -99,11 +123,11 @@ class TimelineNoteSource final : public EngineMidiSource {
     TimelineNoteSource(int noteNumber, int period) : noteNumber_(noteNumber), period_(period) {}
 
     void render(const BlockInfo& block, juce::MidiBuffer& out) override {
-        const auto first = (block.timelineSample + period_ - 1) / period_ * period_;
-        for (auto position = first; position < block.timelineSample + block.numSamples;
-             position += period_)
+        const auto start = timelineSampleOf(block);
+        const auto first = (start + period_ - 1) / period_ * period_;
+        for (auto position = first; position < start + block.numSamples; position += period_)
             out.addEvent(juce::MidiMessage::noteOn(1, noteNumber_, 1.0f),
-                         static_cast<int>(position - block.timelineSample));
+                         static_cast<int>(position - start));
     }
 
   private:
@@ -186,10 +210,10 @@ class ImpulseSource final : public EngineAudioSource {
 
     void render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) override {
         out.clear();
-        if (block.timelineSample <= 0 && block.timelineSample + block.numSamples > 0)
+        const auto start = timelineSampleOf(block);
+        if (start <= 0 && start + block.numSamples > 0)
             for (std::size_t channel = 0; channel < out.getNumChannels(); ++channel)
-                out.setSample(static_cast<int>(channel), static_cast<int>(-block.timelineSample),
-                              level_);
+                out.setSample(static_cast<int>(channel), static_cast<int>(-start), level_);
     }
 
   private:
@@ -291,7 +315,7 @@ class MidiPositionProbe final : public EngineDevice {
             if (const auto message = metadata.getMessage(); message.isNoteOn())
                 notes.push_back(
                     {message.getNoteNumber(),
-                     static_cast<int>(block.block.timelineSample) + metadata.samplePosition});
+                     static_cast<int>(timelineSampleOf(block.block)) + metadata.samplePosition});
     }
 
     struct Note {
@@ -357,7 +381,7 @@ struct Harness {
     }
 
     void render(int numSamples = kBlockSize, std::int64_t timelineSample = 0) {
-        executor.process(values, BlockInfo{numSamples, timelineSample, true}, output);
+        executor.process(values, blockAt(timelineSample, numSamples), output);
     }
 
     float outputSample(int channel = 0, int sample = 0) const {
@@ -1219,7 +1243,7 @@ TEST_CASE("A malformed plan is refused, and the executor renders silence", "[eng
 
     juce::AudioBuffer<float> output(2, 64);
     output.clear();
-    executor.process(PlanValues{}, BlockInfo{64, 0, true}, output);
+    executor.process(PlanValues{}, blockAt(0, 64), output);
     CHECK(output.getSample(0, 0) == approx(0.0f));
 }
 
@@ -1410,7 +1434,7 @@ TEST_CASE("What is in flight survives the plan being replaced", "[engine][exec][
     REQUIRE(first.prepare(plan, bindings, context).empty());
 
     // Block 0 carries the impulse into the delay line and nothing out of it.
-    first.process(values, BlockInfo{kBlockSize, 0, true}, output);
+    first.process(values, blockAt(0, kBlockSize), output);
     CHECK(output.getSample(0, 0) == approx(0.0f));
 
     PlanExecutor second;
@@ -1421,7 +1445,7 @@ TEST_CASE("What is in flight survives the plan being replaced", "[engine][exec][
 
         // Block 1, on the new executor: the impulse comes out where it would
         // have if nothing had happened.
-        second.process(values, BlockInfo{kBlockSize, kBlockSize, true}, output);
+        second.process(values, blockAt(kBlockSize, kBlockSize), output);
         CHECK(output.getSample(0, 80 - kBlockSize) == approx(0.5f));
     }
 
@@ -1429,7 +1453,7 @@ TEST_CASE("What is in flight survives the plan being replaced", "[engine][exec][
         REQUIRE(second.prepare(plan, bindings, context).empty());
         CHECK(second.carriedDelayLines() == 0);
 
-        second.process(values, BlockInfo{kBlockSize, kBlockSize, true}, output);
+        second.process(values, blockAt(kBlockSize, kBlockSize), output);
         CHECK(output.getSample(0, 80 - kBlockSize) == approx(0.0f));
     }
 

--- a/tests/test_tempo_map.cpp
+++ b/tests/test_tempo_map.cpp
@@ -179,6 +179,25 @@ TEST_CASE("Bars come from the time signature, beats do not",
     }
 }
 
+TEST_CASE("A signature groups beats and never moves one", "[engine][transport][tempo][signature]") {
+    // Long enough that the ramp runs out of sections and the cap decides how
+    // finely it is cut, which is where a signature could change the answer: cut
+    // per span, a signature in the middle would buy the ramp twice the
+    // sections and a different beat-to-time everywhere after it.
+    const std::vector<TempoChange> ramp{{0.0, 60.0, 0.0f}, {1000.0, 180.0, 0.0f}};
+
+    const TempoMap plain(ramp, {});
+    const TempoMap regrouped(ramp, {{0.0, 4, 4}, {500.0, 7, 8}});
+
+    for (const auto beat : {1.0, 250.0, 499.0, 500.0, 501.0, 750.0, 1000.0, 1200.0})
+        CHECK(regrouped.beatToTime(beat) == approx(plain.beatToTime(beat)));
+
+    // The signature did what a signature does, and only that.
+    CHECK(plain.barsAndBeatsAt(500.0).numerator == 4);
+    CHECK(regrouped.barsAndBeatsAt(500.0).numerator == 7);
+    CHECK(regrouped.barsAndBeatsAt(500.0).beat == approx(0.0));
+}
+
 TEST_CASE("The metronome grid follows the signature", "[engine][transport][tempo][signature]") {
     SECTION("a beat sitting on a tick is that tick") {
         const TempoMap map;

--- a/tests/test_tempo_map.cpp
+++ b/tests/test_tempo_map.cpp
@@ -1,0 +1,264 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+#include "core/TempoUtils.hpp"
+#include "transport/TempoMap.hpp"
+
+using magda::engine::BarsAndBeats;
+using magda::engine::TempoChange;
+using magda::engine::TempoMap;
+using magda::engine::TimeSignatureChange;
+
+namespace {
+
+Catch::Approx approx(double value) {
+    return Catch::Approx(value).margin(1e-9);
+}
+
+/// Loose enough for a curve that is baked into sections rather than
+/// integrated, tight enough that a wrong shape fails.
+Catch::Approx roughly(double value) {
+    return Catch::Approx(value).epsilon(0.01);
+}
+
+}  // namespace
+
+TEST_CASE("A beat is a quarter note at the tempo it falls under", "[engine][transport][tempo]") {
+    SECTION("nothing configured is 120 in 4/4") {
+        const TempoMap map;
+
+        CHECK(map.bpmAt(0.0) == approx(120.0));
+        CHECK(map.beatToTime(4.0) == approx(2.0));
+        CHECK(map.timeToBeat(2.0) == approx(4.0));
+        CHECK(map.barsAndBeatsAt(4.0).numerator == 4);
+    }
+
+    SECTION("both directions agree wherever you ask") {
+        const TempoMap map({{0.0, 90.0, 0.0f}, {16.0, 150.0, 0.0f}}, {});
+
+        for (const auto beat : {0.0, 3.5, 15.999, 16.0, 40.0})
+            CHECK(map.timeToBeat(map.beatToTime(beat)) == approx(beat));
+    }
+
+    SECTION("a single tempo is the whole timeline") {
+        const TempoMap map({{0.0, 60.0, 0.0f}}, {});
+
+        CHECK(map.beatToTime(8.0) == approx(8.0));
+        CHECK(map.bpmAt(1000.0) == approx(60.0));
+    }
+
+    SECTION("consecutive changes travel between each other") {
+        // The tempo track is a curve the user draws, so two points at
+        // different tempi are a ramp from one to the other, the same way two
+        // points on any other automation lane are. A step is written as two
+        // points at the same beat, which is what the curve editor does when
+        // they share an x position.
+        const TempoMap map({{0.0, 120.0, 0.0f}, {8.0, 60.0, 0.0f}}, {});
+
+        CHECK(map.bpmAt(0.0) == approx(120.0));
+        CHECK(map.bpmAt(8.0) == approx(60.0));
+        CHECK(map.bpmAt(4.0) == roughly(90.0));
+
+        // Slower than eight beats at 120 (4 s), faster than eight at 60 (8 s),
+        // and past the ramp the last tempo is held.
+        CHECK(map.beatToTime(8.0) > 4.0);
+        CHECK(map.beatToTime(8.0) < 8.0);
+        CHECK(map.beatToTime(16.0) - map.beatToTime(8.0) == approx(8.0));
+    }
+
+    SECTION("what precedes the first change is that change, held") {
+        // The tempo track starts at bar 3. The bars before it are not some
+        // default: they are the tempo the project actually opens with.
+        const TempoMap map({{8.0, 60.0, 0.0f}}, {});
+
+        CHECK(map.bpmAt(0.0) == approx(60.0));
+        CHECK(map.beatToTime(8.0) == approx(8.0));
+    }
+
+    SECTION("the timeline exists before beat zero") {
+        // Where a count-in happens. Extrapolated from the first section rather
+        // than clamped, so a roll-in of four beats is four beats long.
+        const TempoMap map;
+
+        CHECK(map.beatToTime(-4.0) == approx(-2.0));
+        CHECK(map.timeToBeat(-2.0) == approx(-4.0));
+        CHECK(map.barsAndBeatsAt(-4.0).bar == -1);
+    }
+}
+
+TEST_CASE("Tempo ramps between changes", "[engine][transport][tempo]") {
+    SECTION("a straight ramp arrives at both ends and takes the middle route") {
+        const TempoMap map({{0.0, 60.0, 0.0f}, {8.0, 120.0, 0.0f}}, {});
+
+        CHECK(map.bpmAt(0.0) == approx(60.0));
+        CHECK(map.bpmAt(4.0) == roughly(90.0));
+
+        // Faster than eight beats at 60 (8 s), slower than eight at 120 (4 s).
+        const auto rampSeconds = map.beatToTime(8.0);
+        CHECK(rampSeconds < 8.0);
+        CHECK(rampSeconds > 4.0);
+
+        // The integral of 60/bpm across the ramp is 8 ln 2, or 5.545 s. The
+        // sections hold the tempo at their start rather than across their
+        // middle, so the sum runs slightly long, by about one part in a
+        // hundred at the steepest ramp the model allows. That is the
+        // approximation the map documents, measured rather than assumed.
+        CHECK(rampSeconds > 5.545);
+        CHECK(rampSeconds < 5.545 * 1.02);
+    }
+
+    SECTION("tension moves where the tempo spends its time") {
+        const TempoMap straight({{0.0, 60.0, 0.0f}, {8.0, 120.0, 0.0f}}, {});
+        const TempoMap holdsOld({{0.0, 60.0, 0.75f}, {8.0, 120.0, 0.0f}}, {});
+        const TempoMap arrivesEarly({{0.0, 60.0, -0.75f}, {8.0, 120.0, 0.0f}}, {});
+
+        // Holding the slower tempo longer makes the same eight beats take
+        // longer; arriving at the faster one sooner makes them take less.
+        CHECK(holdsOld.beatToTime(8.0) > straight.beatToTime(8.0));
+        CHECK(arrivesEarly.beatToTime(8.0) < straight.beatToTime(8.0));
+
+        // Both still start and end at the tempi that were asked for.
+        CHECK(holdsOld.bpmAt(0.0) == approx(60.0));
+        CHECK(arrivesEarly.bpmAt(0.0) == approx(60.0));
+        CHECK(holdsOld.bpmAt(8.0) == approx(120.0));
+        CHECK(arrivesEarly.bpmAt(8.0) == approx(120.0));
+    }
+
+    SECTION("a step is two changes at the same beat") {
+        const TempoMap map({{0.0, 60.0, 0.0f}, {8.0, 60.0, 0.0f}, {8.0, 120.0, 0.0f}}, {});
+
+        // Nothing ramps into beat 8, because the change arriving there is the
+        // tempo already playing.
+        CHECK(map.bpmAt(4.0) == approx(60.0));
+        CHECK(map.beatToTime(8.0) == approx(8.0));
+        CHECK(map.bpmAt(8.0) == approx(120.0));
+        CHECK(map.beatToTime(12.0) == approx(10.0));
+    }
+}
+
+TEST_CASE("Bars come from the time signature, beats do not",
+          "[engine][transport][tempo][signature]") {
+    SECTION("4/4") {
+        const TempoMap map;
+
+        CHECK(map.barsAndBeatsAt(0.0).bar == 0);
+        CHECK(map.barsAndBeatsAt(3.5).bar == 0);
+        CHECK(map.barsAndBeatsAt(3.5).beat == approx(3.5));
+        CHECK(map.barsAndBeatsAt(4.0).bar == 1);
+        CHECK(map.barsAndBeatsAt(4.0).beat == approx(0.0));
+    }
+
+    SECTION("3/4 groups the same beats differently") {
+        const TempoMap map({}, {{0.0, 3, 4}});
+
+        CHECK(map.barsAndBeatsAt(3.0).bar == 1);
+        CHECK(map.beatToTime(3.0) == approx(1.5));  // still quarter notes at 120
+    }
+
+    SECTION("6/8 counts eighths inside a bar of three quarter notes") {
+        const TempoMap map({}, {{0.0, 6, 8}});
+
+        CHECK(map.barsAndBeatsAt(1.5).bar == 0);
+        CHECK(map.barsAndBeatsAt(1.5).beat == approx(3.0));
+        CHECK(map.barsAndBeatsAt(3.0).bar == 1);
+
+        // The beat did not change length: a bar of 6/8 is three quarter notes,
+        // which at 120 is a second and a half whatever it is written as.
+        CHECK(map.beatToTime(3.0) == approx(1.5));
+    }
+
+    SECTION("a signature change starts a bar wherever it lands") {
+        // Two bars of 4/4, then 3/4 from a beat that is not a bar line.
+        const TempoMap map({}, {{0.0, 4, 4}, {9.0, 3, 4}});
+
+        CHECK(map.barsAndBeatsAt(8.0).bar == 2);
+        CHECK(map.barsAndBeatsAt(9.0).bar == 3);
+        CHECK(map.barsAndBeatsAt(9.0).beat == approx(0.0));
+        CHECK(map.barsAndBeatsAt(12.0).bar == 4);
+    }
+}
+
+TEST_CASE("The metronome grid follows the signature", "[engine][transport][tempo][signature]") {
+    SECTION("a beat sitting on a tick is that tick") {
+        const TempoMap map;
+
+        const auto tick = map.tickAtOrAfter(0.0);
+        CHECK(tick.beat == approx(0.0));
+        CHECK(tick.nextBeat == approx(1.0));
+        CHECK(tick.startsBar);
+
+        CHECK(map.tickAtOrAfter(0.25).beat == approx(1.0));
+        CHECK(!map.tickAtOrAfter(1.0).startsBar);
+        CHECK(map.tickAtOrAfter(4.0).startsBar);
+    }
+
+    SECTION("6/8 ticks on eighths and accents every sixth") {
+        const TempoMap map({}, {{0.0, 6, 8}});
+
+        auto tick = map.tickAtOrAfter(0.0);
+        CHECK(tick.beat == approx(0.0));
+        CHECK(tick.nextBeat == approx(0.5));
+        CHECK(tick.startsBar);
+
+        auto accents = 0;
+        auto ticks = 0;
+        for (tick = map.tickAtOrAfter(0.0); tick.beat < 3.0;
+             tick = map.tickAtOrAfter(tick.nextBeat)) {
+            ++ticks;
+            accents += tick.startsBar ? 1 : 0;
+        }
+
+        CHECK(ticks == 6);
+        CHECK(accents == 1);
+    }
+
+    SECTION("a signature change cuts the grid short") {
+        const TempoMap map({}, {{0.0, 4, 4}, {3.5, 4, 4}});
+
+        // The tick after beat 3 would be beat 4, but the signature change at
+        // 3.5 is a bar line and takes its place.
+        const auto tick = map.tickAtOrAfter(3.0);
+        CHECK(tick.beat == approx(3.0));
+        CHECK(tick.nextBeat == approx(3.5));
+        CHECK(map.tickAtOrAfter(3.5).startsBar);
+    }
+
+    SECTION("ticks run backwards from the start of the timeline") {
+        const TempoMap map;
+
+        CHECK(map.tickAtOrAfter(-2.0).beat == approx(-2.0));
+        CHECK(map.tickAtOrAfter(-1.5).beat == approx(-1.0));
+        CHECK(map.tickAtOrAfter(-4.0).startsBar);
+    }
+}
+
+TEST_CASE("A tempo map's fingerprint is what it places beats by", "[engine][transport][tempo]") {
+    const TempoMap plain;
+    const TempoMap same({{0.0, 120.0, 0.0f}}, {{0.0, 4, 4}});
+    const TempoMap faster({{0.0, 140.0, 0.0f}}, {{0.0, 4, 4}});
+    const TempoMap regrouped({{0.0, 120.0, 0.0f}}, {{0.0, 3, 4}});
+
+    CHECK(plain == same);
+    CHECK(!(plain == faster));
+    CHECK(!(plain == regrouped));
+    CHECK(plain.fingerprint() != faster.fingerprint());
+}
+
+TEST_CASE("A tempo track is taken as it is meant, not as it is written",
+          "[engine][transport][tempo]") {
+    SECTION("changes may arrive in any order") {
+        const TempoMap ordered({{0.0, 120.0, 0.0f}, {8.0, 60.0, 0.0f}}, {});
+        const TempoMap shuffled({{8.0, 60.0, 0.0f}, {0.0, 120.0, 0.0f}}, {});
+
+        CHECK(ordered == shuffled);
+        CHECK(shuffled.beatToTime(16.0) == approx(ordered.beatToTime(16.0)));
+        CHECK(shuffled.bpmAt(8.0) == approx(60.0));
+    }
+
+    SECTION("a tempo outside what the model allows is clamped, not honoured") {
+        const TempoMap map({{0.0, 1.0e9, 0.0f}}, {});
+
+        CHECK(map.bpmAt(0.0) == approx(magda::MAX_VALID_BPM));
+    }
+}

--- a/tests/test_transport_clock.cpp
+++ b/tests/test_transport_clock.cpp
@@ -1,0 +1,350 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+#include "transport/TransportClock.hpp"
+
+using magda::engine::TempoMap;
+using magda::engine::TransportClock;
+using magda::engine::TransportSnapshot;
+
+namespace {
+
+constexpr double kSampleRate = 44100.0;
+
+/// 120 bpm: a beat is half a second, 22050 samples, and a bar is four of them.
+constexpr double kSamplesPerBeat = kSampleRate / 2.0;
+
+Catch::Approx approx(double value) {
+    return Catch::Approx(value).margin(1e-9);
+}
+
+/// Playing from a beat, with everything else left alone.
+TransportSnapshot playing(double fromBeat, std::uint64_t generation = 1) {
+    TransportSnapshot snapshot;
+    snapshot.request = {generation, true, fromBeat, 0.0};
+    return snapshot;
+}
+
+TransportSnapshot stopped(double atBeat, std::uint64_t generation = 1) {
+    TransportSnapshot snapshot;
+    snapshot.request = {generation, false, atBeat, 0.0};
+    return snapshot;
+}
+
+/// Every segment of one callback, as a value the checks can read twice.
+struct Rendered {
+    std::vector<TransportClock::Segment> segments;
+
+    int totalSamples() const {
+        auto total = 0;
+        for (const auto& segment : segments)
+            total += segment.block.numSamples;
+        return total;
+    }
+};
+
+Rendered advance(TransportClock& clock, const TransportSnapshot& snapshot, int numSamples) {
+    Rendered rendered;
+    for (const auto& segment : clock.advance(snapshot, kSampleRate, numSamples))
+        rendered.segments.push_back(segment);
+    return rendered;
+}
+
+/// What every callback owes, whatever it did in the middle: the samples the
+/// device asked for, each covered once, in order.
+void requireCovers(const Rendered& rendered, int numSamples) {
+    REQUIRE(rendered.totalSamples() == numSamples);
+
+    auto expected = 0;
+    for (const auto& segment : rendered.segments) {
+        REQUIRE(segment.startSample == expected);
+        expected += segment.block.numSamples;
+    }
+}
+
+}  // namespace
+
+TEST_CASE("A stopped transport still renders, and stands still", "[engine][transport][clock]") {
+    TransportClock clock;
+    const auto snapshot = stopped(8.0);
+
+    const auto first = advance(clock, snapshot, 512);
+    requireCovers(first, 512);
+    REQUIRE(first.segments.size() == 1);
+
+    CHECK(!first.segments[0].block.playing);
+    CHECK(first.segments[0].block.startBeat == approx(8.0));
+    CHECK(first.segments[0].block.endBeat == approx(8.0));
+    CHECK(clock.positionBeats() == approx(8.0));
+
+    // Standing still is not a jump. The block after it continues the one
+    // before, which is what keeps a device's tail ringing out into silence.
+    const auto second = advance(clock, snapshot, 512);
+    CHECK(second.segments[0].block.continuous);
+    CHECK(clock.positionBeats() == approx(8.0));
+}
+
+TEST_CASE("The cursor moves at the rate the tempo says", "[engine][transport][clock]") {
+    TransportClock clock;
+    const auto snapshot = playing(0.0);
+
+    const auto block = advance(clock, snapshot, static_cast<int>(kSamplesPerBeat));
+    REQUIRE(block.segments.size() == 1);
+
+    CHECK(block.segments[0].block.playing);
+    CHECK(block.segments[0].block.startBeat == approx(0.0));
+    CHECK(block.segments[0].block.endBeat == approx(1.0));
+    CHECK(clock.positionBeats() == approx(1.0));
+
+    // Starting is a jump; carrying on is not.
+    CHECK(!block.segments[0].block.continuous);
+    CHECK(advance(clock, snapshot, 512).segments[0].block.continuous);
+}
+
+TEST_CASE("Where the cursor lands does not depend on how the blocks were cut",
+          "[engine][transport][clock]") {
+    // The cursor is a function of the sample count rather than a sum of steps,
+    // so this is exact equality rather than a tolerance: a clock that
+    // accumulated per block would drift here and drift more the longer it ran.
+    TransportClock whole, pieces;
+
+    const auto snapshot = playing(0.0);
+    for (auto i = 0; i < 100; ++i)
+        advance(whole, snapshot, 512);
+
+    for (auto i = 0; i < 100; ++i) {
+        advance(pieces, snapshot, 128);
+        advance(pieces, snapshot, 64);
+        advance(pieces, snapshot, 256);
+        advance(pieces, snapshot, 64);
+    }
+
+    CHECK(whole.positionBeats() == pieces.positionBeats());
+}
+
+TEST_CASE("A loop wrap cuts the callback rather than the timeline",
+          "[engine][transport][clock][loop]") {
+    TransportClock clock;
+    auto snapshot = playing(0.0);
+    snapshot.loop = {true, 0.0, 1.0};  // one beat: 22050 samples
+
+    // Land 100 samples short of the loop end, then ask for a block that
+    // crosses it.
+    advance(clock, snapshot, static_cast<int>(kSamplesPerBeat) - 100);
+
+    const auto crossing = advance(clock, snapshot, 512);
+    requireCovers(crossing, 512);
+    REQUIRE(crossing.segments.size() == 2);
+
+    // Everything up to the loop end, then everything from the loop start. No
+    // block straddles the wrap, so nothing downstream has to know it happened.
+    CHECK(crossing.segments[0].block.numSamples == 100);
+    CHECK(crossing.segments[0].block.endBeat == approx(1.0));
+    CHECK(crossing.segments[0].block.continuous);
+
+    CHECK(crossing.segments[1].startSample == 100);
+    CHECK(crossing.segments[1].block.numSamples == 412);
+    CHECK(crossing.segments[1].block.startBeat == approx(0.0));
+    CHECK(!crossing.segments[1].block.continuous);
+
+    CHECK(clock.loopWrapOverflows() == 0);
+}
+
+TEST_CASE("A loop is entered from before it and left where it ends",
+          "[engine][transport][clock][loop]") {
+    TransportClock clock;
+    auto snapshot = playing(0.0);
+    snapshot.loop = {true, 2.0, 4.0};
+
+    SECTION("playing into a loop from before it is not a wrap") {
+        // Playback starts where it was asked to, two beats before the loop,
+        // and runs straight through the loop start: a loop is a place the
+        // timeline returns to, not a pen it is put in.
+        const auto entering = advance(clock, snapshot, static_cast<int>(kSamplesPerBeat * 2.5));
+        REQUIRE(entering.segments.size() == 1);
+        CHECK(entering.segments[0].block.startBeat == approx(0.0));
+        CHECK(entering.segments[0].block.endBeat == approx(2.5));
+
+        // Carrying on from there wraps at the end of the loop, not at its
+        // start.
+        const auto wrapping = advance(clock, snapshot, static_cast<int>(kSamplesPerBeat * 2));
+        REQUIRE(wrapping.segments.size() == 2);
+        CHECK(wrapping.segments[0].block.endBeat == approx(4.0));
+        CHECK(wrapping.segments[1].block.startBeat == approx(2.0));
+    }
+
+    SECTION("a cursor put down past the loop plays on") {
+        // The loop catches what reaches its end. It does not collect a
+        // playhead that was put down somewhere else entirely, because that
+        // would be ignoring where the user pointed.
+        auto located = playing(9.0, 2);
+        located.loop = snapshot.loop;
+
+        const auto block = advance(clock, located, 512);
+        CHECK(block.segments[0].block.startBeat == approx(9.0));
+        CHECK(block.segments[0].block.endBeat > 9.0);
+    }
+
+    SECTION("a loop dragged behind the cursor leaves it playing") {
+        advance(clock, snapshot, static_cast<int>(kSamplesPerBeat * 3));
+        REQUIRE(clock.positionBeats() == approx(3.0));
+
+        // Same generation: nothing was requested, the loop was dragged.
+        auto moved = snapshot;
+        moved.loop = {true, 0.0, 1.0};
+
+        const auto block = advance(clock, moved, 512);
+        CHECK(block.segments[0].block.startBeat == approx(3.0));
+        CHECK(block.segments[0].block.continuous);
+    }
+
+    SECTION("a loop dragged around the cursor catches it at the new end") {
+        advance(clock, snapshot, static_cast<int>(kSamplesPerBeat * 3));
+
+        auto moved = snapshot;
+        moved.loop = {true, 0.0, 3.5};
+
+        const auto block = advance(clock, moved, static_cast<int>(kSamplesPerBeat));
+        REQUIRE(block.segments.size() == 2);
+        CHECK(block.segments[0].block.endBeat == approx(3.5));
+        CHECK(block.segments[1].block.startBeat == approx(0.0));
+        CHECK(!block.segments[1].block.continuous);
+    }
+}
+
+TEST_CASE("Count-in rolls in before the play position", "[engine][transport][clock][countin]") {
+    TransportClock clock;
+    auto snapshot = playing(4.0);
+    snapshot.request.countInBeats = 2.0;
+    snapshot.loop = {true, 4.0, 8.0};
+
+    SECTION("the cursor starts short of it and plays into it") {
+        const auto opening = advance(clock, snapshot, 512);
+
+        // Two beats before the play position, playing: material before the
+        // start is heard rather than skipped, which is what makes a count-in
+        // different from starting late.
+        CHECK(opening.segments[0].block.startBeat == approx(2.0));
+        CHECK(opening.segments[0].block.playing);
+        CHECK(opening.segments[0].countingIn);
+    }
+
+    SECTION("the loop does not wrap a roll-in") {
+        // A count-in that began before the loop end would otherwise wrap on
+        // its way to the play position and count for ever without arriving.
+        auto late = playing(9.0, 2);
+        late.request.countInBeats = 4.0;
+        late.loop = {true, 0.0, 6.0};
+
+        advance(clock, late, static_cast<int>(kSamplesPerBeat * 3));
+        CHECK(clock.positionBeats() == approx(8.0));
+    }
+
+    SECTION("the callback is cut where the count-in ends") {
+        // Land 100 samples short of the play position.
+        advance(clock, snapshot, static_cast<int>(kSamplesPerBeat * 2) - 100);
+
+        const auto crossing = advance(clock, snapshot, 512);
+        requireCovers(crossing, 512);
+        REQUIRE(crossing.segments.size() == 2);
+
+        CHECK(crossing.segments[0].countingIn);
+        CHECK(crossing.segments[0].block.numSamples == 100);
+        CHECK(!crossing.segments[1].countingIn);
+        CHECK(crossing.segments[1].block.startBeat == approx(4.0));
+
+        // Reaching the play position is not a jump: the cursor played there.
+        CHECK(crossing.segments[1].block.continuous);
+    }
+
+    SECTION("the loop takes over once the count-in is done") {
+        // Two beats of roll-in, the loop's four beats, and half a beat back
+        // inside it: the loop was suppressed for the count-in and for nothing
+        // else.
+        const auto rendered = advance(clock, snapshot, static_cast<int>(kSamplesPerBeat * 6.5));
+
+        REQUIRE(rendered.segments.size() == 3);
+        CHECK(clock.positionBeats() == approx(4.5));
+    }
+}
+
+TEST_CASE("Editing the tempo moves the seconds, not the beat",
+          "[engine][transport][clock][tempo]") {
+    TransportClock clock;
+    const auto snapshot = playing(0.0);
+
+    advance(clock, snapshot, static_cast<int>(kSamplesPerBeat * 2));
+    REQUIRE(clock.positionBeats() == approx(2.0));
+
+    // Same request, half the tempo. The cursor is on beat 2 and stays there;
+    // what changed is how long the next beat takes.
+    auto slower = snapshot;
+    slower.tempo = TempoMap({{0.0, 60.0, 0.0f}}, {});
+
+    const auto block = advance(clock, slower, static_cast<int>(kSampleRate));
+    CHECK(block.segments[0].block.startBeat == approx(2.0));
+    CHECK(block.segments[0].block.endBeat == approx(3.0));
+
+    // Not a jump. Nothing about the timeline broke: a beat is where it always
+    // was, and only its arrival time moved.
+    CHECK(block.segments[0].block.continuous);
+}
+
+TEST_CASE("A request is applied once", "[engine][transport][clock]") {
+    TransportClock clock;
+    const auto snapshot = playing(2.0);
+
+    advance(clock, snapshot, 512);
+    const auto second = advance(clock, snapshot, 512);
+
+    // Republishing the same request does not drag the cursor back to where
+    // playback started, which is what would happen if the position were read
+    // every block rather than the generation.
+    CHECK(second.segments[0].block.startBeat > 2.0);
+    CHECK(second.segments[0].block.continuous);
+
+    SECTION("a new one relocates and says so") {
+        const auto located = advance(clock, playing(16.0, 2), 512);
+        CHECK(located.segments[0].block.startBeat == approx(16.0));
+        CHECK(!located.segments[0].block.continuous);
+    }
+
+    SECTION("stopping where the cursor already is is not a jump") {
+        const auto at = clock.positionBeats();
+        const auto halted = advance(clock, stopped(at, 3), 512);
+
+        CHECK(!halted.segments[0].block.playing);
+        CHECK(halted.segments[0].block.continuous);
+    }
+}
+
+TEST_CASE("A change of sample rate keeps the position it was given", "[engine][transport][clock]") {
+    TransportClock clock;
+    const auto snapshot = playing(0.0);
+
+    clock.advance(snapshot, kSampleRate, static_cast<int>(kSamplesPerBeat));
+    REQUIRE(clock.positionBeats() == approx(1.0));
+
+    // The anchor is a position in seconds, which survives the device changing
+    // under it; the sample count taken at the old rate does not.
+    clock.advance(snapshot, 48000.0, 24000);
+    CHECK(clock.positionBeats() == approx(2.0));
+}
+
+TEST_CASE("A loop too short to render is reported, not silently dropped",
+          "[engine][transport][clock][loop]") {
+    TransportClock clock;
+    auto snapshot = playing(0.0);
+
+    // Around ten samples of loop, against a callback of five hundred: more
+    // wraps than there are segments to render them as.
+    snapshot.loop = {true, 0.0, 10.0 / kSamplesPerBeat};
+
+    const auto block = advance(clock, snapshot, 512);
+
+    // The callback is still covered exactly. What is lost is the wrapping, and
+    // the count is what says so.
+    requireCovers(block, 512);
+    CHECK(clock.loopWrapOverflows() > 0);
+}

--- a/tests/test_transport_clock.cpp
+++ b/tests/test_transport_clock.cpp
@@ -390,6 +390,27 @@ TEST_CASE("A loop too short to render is reported, not silently dropped",
     requireCovers(block, 512);
     CHECK(clock.loopWrapOverflows() > 0);
 
+    SECTION("including one whose end is not a sample away from its start") {
+        // Short enough that the wrap lands where it started: the count of
+        // samples to the loop end comes back zero however many times the
+        // cursor is put back at the top. Without that zero reaching the
+        // fallback, the callback renders straight through with nothing
+        // counted, and the cursor ends past the end where no later callback
+        // will wrap it.
+        TransportClock tiny;
+        auto degenerate = playing(0.0);
+        degenerate.loop = {true, 0.0, 0.005 / kSamplesPerBeat};
+
+        const auto first = advance(tiny, degenerate, 512);
+        requireCovers(first, 512);
+        CHECK(tiny.loopWrapOverflows() == 1);
+
+        const auto second = advance(tiny, degenerate, 512);
+        requireCovers(second, 512);
+        CHECK(second.segments[0].block.startBeat == approx(0.0));
+        CHECK(tiny.loopWrapOverflows() == 2);
+    }
+
     SECTION("and it costs one callback, not every callback after it") {
         // Rendering the remainder straight through leaves the cursor past the
         // loop end, which is also where a cursor located beyond the loop sits.

--- a/tests/test_transport_clock.cpp
+++ b/tests/test_transport_clock.cpp
@@ -22,13 +22,25 @@ Catch::Approx approx(double value) {
 /// Playing from a beat, with everything else left alone.
 TransportSnapshot playing(double fromBeat, std::uint64_t generation = 1) {
     TransportSnapshot snapshot;
-    snapshot.request = {generation, true, fromBeat, 0.0};
+    snapshot.request.generation = generation;
+    snapshot.request.playing = true;
+    snapshot.request.positionBeat = fromBeat;
     return snapshot;
 }
 
 TransportSnapshot stopped(double atBeat, std::uint64_t generation = 1) {
     TransportSnapshot snapshot;
-    snapshot.request = {generation, false, atBeat, 0.0};
+    snapshot.request.generation = generation;
+    snapshot.request.positionBeat = atBeat;
+    return snapshot;
+}
+
+/// Stopping without naming a position: the play state changes and nothing
+/// else does.
+TransportSnapshot halt(std::uint64_t generation) {
+    TransportSnapshot snapshot;
+    snapshot.request.generation = generation;
+    snapshot.request.locate = false;
     return snapshot;
 }
 
@@ -319,6 +331,36 @@ TEST_CASE("A request is applied once", "[engine][transport][clock]") {
     }
 }
 
+TEST_CASE("Stopping does not have to say where", "[engine][transport][clock]") {
+    TransportClock clock;
+
+    advance(clock, playing(0.0), 512);
+    advance(clock, playing(0.0), 512);
+    const auto at = clock.positionBeats();
+
+    // The publisher cannot name where the cursor is: whatever it read from
+    // positionBeats() is a callback out of date by the time the request lands.
+    // Naming a stale position would step the cursor back and read as a jump,
+    // so a stop says nothing about position at all.
+    const auto halted = advance(clock, halt(2), 512);
+
+    CHECK(!halted.segments[0].block.playing);
+    CHECK(halted.segments[0].block.startBeat == approx(at));
+    CHECK(clock.positionBeats() == approx(at));
+    CHECK(halted.segments[0].block.continuous);
+
+    SECTION("and playing again from there does not have to either") {
+        auto resumed = halt(3);
+        resumed.request.playing = true;
+
+        const auto block = advance(clock, resumed, 512);
+        CHECK(block.segments[0].block.startBeat == approx(at));
+
+        // Starting is a jump wherever it starts from.
+        CHECK(!block.segments[0].block.continuous);
+    }
+}
+
 TEST_CASE("A change of sample rate keeps the position it was given", "[engine][transport][clock]") {
     TransportClock clock;
     const auto snapshot = playing(0.0);
@@ -347,4 +389,16 @@ TEST_CASE("A loop too short to render is reported, not silently dropped",
     // the count is what says so.
     requireCovers(block, 512);
     CHECK(clock.loopWrapOverflows() > 0);
+
+    SECTION("and it costs one callback, not every callback after it") {
+        // Rendering the remainder straight through leaves the cursor past the
+        // loop end, which is also where a cursor located beyond the loop sits.
+        // Without putting it back, the next callback would read it as one that
+        // was put there on purpose and never wrap again.
+        const auto next = advance(clock, snapshot, 512);
+
+        requireCovers(next, 512);
+        CHECK(next.segments.size() > 1);
+        CHECK(next.segments[0].block.startBeat == approx(0.0));
+    }
 }


### PR DESCRIPTION
Slice 6 of #1889. BlockInfo::timelineSample is gone: an op is handed the stretch of timeline its block covers, in beats, and EngineSession takes a sample count rather than a cursor.

A native TempoMap bakes the tempo track into constant-tempo sections, so beats and seconds convert with a binary search and a multiply. A beat is a quarter note whatever the signature says; the signature groups beats into bars and says what the metronome ticks on. Consecutive tempo changes ramp, shaped by the same tension the model's curve lane stores and evaluated through the same maths, so a ramp is the curve the user drew rather than a second opinion about it.

The clock holds an anchor and derives the cursor from the samples since, so it cannot drift and a block cut in half lands exactly where the whole one would have. Where a callback covers two stretches of timeline it is cut at the wrap and rendered as two blocks, which is what keeps every op from having to know a loop can wrap mid-buffer. The loop catches a cursor that reaches its end and leaves alone one that was put down beyond it: a locate is honoured as asked.

Transport, loop, count-in and metronome are published the way values are, with a generation counter that makes the play request a request rather than a description. A tempo edit re-anchors on the beat and is not a jump; starting, locating and wrapping are, and what that licenses is re-deriving what came from the cursor, never resetting what came from time.

The metronome is summed after the plan rather than compiled into it: it is never recorded, never routed, and not the master fader's to attenuate.