### PR TITLE
Native engine: getting audio off a disk in time (#2016)

### DIFF
--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -36,6 +36,14 @@ add_library(magda_engine STATIC
     transport/TransportState.hpp
     transport/TransportClock.hpp
     transport/ClickGenerator.hpp
+    io/AudioFileReader.cpp
+    io/PrefetchStream.cpp
+    io/PrefetchThread.cpp
+    io/StreamingAudioSource.cpp
+    io/AudioFileReader.hpp
+    io/PrefetchStream.hpp
+    io/PrefetchThread.hpp
+    io/StreamingAudioSource.hpp
 )
 add_library(magda::engine ALIAS magda_engine)
 
@@ -83,7 +91,7 @@ endforeach()
 # Engine. Quoted includes may only reach the model layer ("core/...") or the
 # engine's own headers.
 
-set(MAGDA_ENGINE_ALLOWED_QUOTED_PREFIXES "core/" "plan/" "exec/" "transport/")
+set(MAGDA_ENGINE_ALLOWED_QUOTED_PREFIXES "core/" "plan/" "exec/" "transport/" "io/")
 
 file(GLOB_RECURSE MAGDA_ENGINE_SOURCES CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"

--- a/magda/engine/exec/RenderContext.hpp
+++ b/magda/engine/exec/RenderContext.hpp
@@ -58,6 +58,24 @@ struct BlockInfo {
     double endBeat = 0.0;
 
     /**
+     * @brief The same stretch of timeline, in seconds.
+     *
+     * Not a second opinion about where the block is: the clock derives the
+     * beats from this, so they are two faces of one instant and the conversion
+     * between them has happened exactly once, in the one place that owns a
+     * tempo map.
+     *
+     * Both are here because both are asked for, and by different things.
+     * Beats say where on the timeline something is, which is how the model
+     * positions everything. Seconds say how much audio has gone by, which is
+     * what recorded material is measured in and what a file's samples are
+     * counted in. A source reading a file needs the second question answered
+     * and would otherwise need a tempo map to answer it.
+     */
+    double startSeconds = 0.0;
+    double endSeconds = 0.0;
+
+    /**
      * @brief Whether the timeline ran into this block out of the last one.
      *
      * False on the first block after the transport starts, after a locate, and
@@ -96,6 +114,31 @@ struct BlockInfo {
         const auto position = (beat - startBeat) / (endBeat - startBeat);
         const auto sample = static_cast<int>(std::lround(position * numSamples));
         return std::clamp(sample, 0, numSamples - 1);
+    }
+
+    /**
+     * @brief Sample offset within this block of a moment inside it.
+     *
+     * As sampleForBeat, for the seconds face of the same instant. Exact rather
+     * than nearly so: the timeline runs at one second per sample rate through a
+     * block whatever the tempo is doing, so this is a straight line and not an
+     * approximation of a curve.
+     *
+     * One sample past the end of the block is a legal answer here, where it is
+     * not for a beat, and the difference is what the two are for. A beat places
+     * an event, which has to land on a sample this block has. Seconds place the
+     * edges of a region, and a region that runs to the end of the block ends at
+     * the sample after the last one, the way every half-open range does.
+     */
+    int sampleForTime(double seconds) const {
+        if (numSamples <= 0)
+            return 0;
+        if (endSeconds <= startSeconds)
+            return 0;
+
+        const auto position = (seconds - startSeconds) / (endSeconds - startSeconds);
+        const auto sample = static_cast<int>(std::lround(position * numSamples));
+        return std::clamp(sample, 0, numSamples);
     }
 };
 

--- a/magda/engine/io/AudioFileReader.cpp
+++ b/magda/engine/io/AudioFileReader.cpp
@@ -34,8 +34,20 @@ int JuceAudioFileReader::read(juce::AudioBuffer<float>& destination, int destina
     if (available < numSamples)
         destination.clear(destinationOffset + available, numSamples - available);
 
-    if (available > 0)
-        reader_->read(&destination, destinationOffset, available, startSample, true, true);
+    if (available <= 0)
+        return 0;
+
+    // Whether the decode worked is the only thing that says the destination now
+    // holds audio rather than whatever was in it. A reader can fail inside the
+    // length it advertises: a file truncated under us, a stream that went away
+    // mid-frame. Reporting the samples as read anyway would publish undefined
+    // buffer contents as material, and the stream would have no reason to
+    // suspect anything, because a full chunk is exactly what success looks
+    // like.
+    if (!reader_->read(&destination, destinationOffset, available, startSample, true, true)) {
+        destination.clear(destinationOffset, numSamples);
+        return 0;
+    }
 
     return available;
 }

--- a/magda/engine/io/AudioFileReader.cpp
+++ b/magda/engine/io/AudioFileReader.cpp
@@ -1,0 +1,43 @@
+#include "io/AudioFileReader.hpp"
+
+#include <algorithm>
+
+namespace magda::engine {
+
+JuceAudioFileReader::JuceAudioFileReader(std::unique_ptr<juce::AudioFormatReader> reader)
+    : reader_(std::move(reader)) {}
+
+std::int64_t JuceAudioFileReader::lengthInSamples() const {
+    return reader_ != nullptr ? reader_->lengthInSamples : 0;
+}
+
+double JuceAudioFileReader::sampleRate() const {
+    return reader_ != nullptr ? reader_->sampleRate : 0.0;
+}
+
+int JuceAudioFileReader::numChannels() const {
+    return reader_ != nullptr ? static_cast<int>(reader_->numChannels) : 0;
+}
+
+int JuceAudioFileReader::read(juce::AudioBuffer<float>& destination, int destinationOffset,
+                              std::int64_t startSample, int numSamples) {
+    if (reader_ == nullptr || numSamples <= 0)
+        return 0;
+
+    // What the file actually has from here. JUCE would pad the rest with
+    // silence itself, but it would not say how much it padded, and the
+    // difference between a short read and a late one is the difference between
+    // the end of the file and a glitch.
+    const auto available = static_cast<int>(
+        std::clamp<std::int64_t>(reader_->lengthInSamples - startSample, 0, numSamples));
+
+    if (available < numSamples)
+        destination.clear(destinationOffset + available, numSamples - available);
+
+    if (available > 0)
+        reader_->read(&destination, destinationOffset, available, startSample, true, true);
+
+    return available;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/io/AudioFileReader.hpp
+++ b/magda/engine/io/AudioFileReader.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_formats/juce_audio_formats.h>
+
+#include <cstdint>
+#include <memory>
+
+/**
+ * @file AudioFileReader.hpp
+ * @brief Random access to a file's samples, off the audio thread.
+ *
+ * The narrowest thing the prefetcher needs, and deliberately not a file: what
+ * decodes a format, where the file came from and how it was opened are the
+ * host's business. The engine is handed something that can already read.
+ *
+ * That is also what makes the prefetcher testable without a disk. A test reader
+ * that computes its samples exercises every path the real one does, and does it
+ * deterministically, which reading a fixture off a filesystem does not.
+ */
+
+namespace magda::engine {
+
+class AudioFileReader {
+  public:
+    virtual ~AudioFileReader() = default;
+
+    /// Samples in the file, per channel. Constant for the file's lifetime.
+    virtual std::int64_t lengthInSamples() const = 0;
+
+    /// The rate the file was recorded at, which is not necessarily the rate the
+    /// device runs at. Converting between them is the clip layer's problem
+    /// (#1890): what is delivered here is the file's own samples.
+    virtual double sampleRate() const = 0;
+
+    virtual int numChannels() const = 0;
+
+    /**
+     * @brief Read @p numSamples into @p destination from @p destinationOffset.
+     *
+     * Called on the prefetch thread, never on the audio thread. Returns how
+     * many samples were actually available, which is short only at the end of
+     * the file; the rest of the destination is cleared rather than left
+     * holding whatever was there.
+     *
+     * The destination carries the engine's channel count rather than the
+     * file's: a mono file fans out to every channel, and a file with more
+     * channels than the engine renders contributes its first two, because the
+     * model has no way to say what else it should do with them.
+     */
+    virtual int read(juce::AudioBuffer<float>& destination, int destinationOffset,
+                     std::int64_t startSample, int numSamples) = 0;
+};
+
+/**
+ * @brief An AudioFileReader over a JUCE reader the host has already opened.
+ *
+ * Which formats exist, where the file is and whether it is still there are all
+ * settled before this is constructed. Owns the reader it is given.
+ */
+class JuceAudioFileReader final : public AudioFileReader {
+  public:
+    explicit JuceAudioFileReader(std::unique_ptr<juce::AudioFormatReader> reader);
+
+    std::int64_t lengthInSamples() const override;
+    double sampleRate() const override;
+    int numChannels() const override;
+    int read(juce::AudioBuffer<float>& destination, int destinationOffset, std::int64_t startSample,
+             int numSamples) override;
+
+  private:
+    std::unique_ptr<juce::AudioFormatReader> reader_;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/io/PrefetchStream.cpp
+++ b/magda/engine/io/PrefetchStream.cpp
@@ -1,6 +1,7 @@
 #include "io/PrefetchStream.hpp"
 
 #include <algorithm>
+#include <utility>
 
 namespace magda::engine {
 
@@ -42,11 +43,24 @@ void PrefetchStream::seek(std::int64_t sourceStart) {
 }
 
 void PrefetchStream::applyPendingCue() {
+    // Whether anything played out of this stream since the last time it was
+    // asked. Read here rather than in read(), so that what it answers is a
+    // question about the block that just went by.
+    const auto wasSounding = std::exchange(readSinceCueCheck_, false);
+
     farbot::RealtimeObject<SeekRequest, farbot::RealtimeObjectOptions::nonRealtimeMutatable>::
         ScopedAccess<farbot::ThreadType::realtime>
             cue(cue_);
 
     if (cue->generation == appliedCue_)
+        return;
+
+    // A stream that is sounding keeps sounding. Taking the cue up would abandon
+    // the generation the material still playing was read for and hand its pool
+    // back, so the cue would cost a gap and then be overridden by the very next
+    // read anyway, which asks for where playback actually is. It waits instead,
+    // and is taken up when the stream falls silent.
+    if (wasSounding)
         return;
 
     appliedCue_ = cue->generation;
@@ -126,9 +140,11 @@ int PrefetchStream::read(std::int64_t sourceStart, juce::dsp::AudioBlock<float> 
     if (numSamples <= 0)
         return 0;
 
-    // Anything cued since the last block, before deciding whether this one is
-    // a seek: a read that lands exactly where the cue pointed is then not one.
-    applyPendingCue();
+    // Reading is what sounding means. Taking a cue up is not done here: it
+    // happens once at the top of a block, through applyPendingCue, and doing it
+    // again inside the read would see a stream that has not read *yet this
+    // block* and mistake it for one that is not playing at all.
+    readSinceCueCheck_ = true;
 
     if (sourceStart != nextSample_)
         requestSeek(sourceStart);

--- a/magda/engine/io/PrefetchStream.cpp
+++ b/magda/engine/io/PrefetchStream.cpp
@@ -35,7 +35,22 @@ PrefetchStream::PrefetchStream(std::unique_ptr<AudioFileReader> reader,
 }
 
 void PrefetchStream::seek(std::int64_t sourceStart) {
-    requestSeek(sourceStart);
+    // Publish and return. Everything the callback owns is left alone, which is
+    // what makes this safe to call while the stream is playing rather than
+    // safe only if nobody forgets it is not.
+    cue_.nonRealtimeReplace(SeekRequest{sourceStart, ++cueGeneration_});
+}
+
+void PrefetchStream::applyPendingCue() {
+    farbot::RealtimeObject<SeekRequest, farbot::RealtimeObjectOptions::nonRealtimeMutatable>::
+        ScopedAccess<farbot::ThreadType::realtime>
+            cue(cue_);
+
+    if (cue->generation == appliedCue_)
+        return;
+
+    appliedCue_ = cue->generation;
+    requestSeek(cue->sourceStart);
 }
 
 void PrefetchStream::requestSeek(std::int64_t sourceStart) {
@@ -44,6 +59,19 @@ void PrefetchStream::requestSeek(std::int64_t sourceStart) {
 
     // Whatever the callback was reading came from somewhere else now.
     releaseCurrent();
+
+    // And so is everything waiting behind it. Handing the pool back here rather
+    // than as the callback works through it is what lets the reader start
+    // refilling immediately: a stream that was cued but is not being read yet
+    // is the whole point of cueing, and it has no callback coming to recycle
+    // chunks for it. Every chunk in the fifo was read for the generation this
+    // call just left behind, so all of them go.
+    Chunk* stale = nullptr;
+    while (filled_.pop(stale)) {
+        const auto returned = spent_.push(std::move(stale));
+        jassert(returned);
+        juce::ignoreUnused(returned);
+    }
 
     farbot::RealtimeObject<SeekRequest, farbot::RealtimeObjectOptions::realtimeMutatable>::
         ScopedAccess<farbot::ThreadType::realtime>
@@ -97,6 +125,10 @@ int PrefetchStream::read(std::int64_t sourceStart, juce::dsp::AudioBlock<float> 
                          int numSamples) {
     if (numSamples <= 0)
         return 0;
+
+    // Anything cued since the last block, before deciding whether this one is
+    // a seek: a read that lands exactly where the cue pointed is then not one.
+    applyPendingCue();
 
     if (sourceStart != nextSample_)
         requestSeek(sourceStart);

--- a/magda/engine/io/PrefetchStream.cpp
+++ b/magda/engine/io/PrefetchStream.cpp
@@ -1,0 +1,202 @@
+#include "io/PrefetchStream.hpp"
+
+#include <algorithm>
+
+namespace magda::engine {
+
+PrefetchStream::PrefetchStream(std::unique_ptr<AudioFileReader> reader,
+                               const RenderContext& context, const PrefetchSettings& settings)
+    : reader_(std::move(reader)),
+      chunkSamples_(std::max(1, settings.chunkSamples)),
+      // Room for every chunk at once, rounded up to what the fifo insists on:
+      // one sized to the pool exactly could not hold all of it, and farbot
+      // indexes by mask rather than by modulo.
+      filled_(juce::nextPowerOfTwo(std::max(2, settings.chunkCount) + 1)),
+      spent_(juce::nextPowerOfTwo(std::max(2, settings.chunkCount) + 1)) {
+    if (reader_ != nullptr) {
+        length_ = reader_->lengthInSamples();
+        sourceSampleRate_ = reader_->sampleRate();
+    }
+
+    numChannels_ = std::max(1, context.numChannels);
+
+    // A chunk has to be able to answer a whole callback, otherwise a block
+    // longer than a chunk would underrun however far ahead the reader got.
+    chunkSamples_ = std::max(chunkSamples_, context.maxBlockSize);
+
+    pool_.reserve(static_cast<std::size_t>(std::max(2, settings.chunkCount)));
+    for (auto i = 0; i < std::max(2, settings.chunkCount); ++i) {
+        auto chunk = std::make_unique<Chunk>();
+        chunk->audio.setSize(numChannels_, chunkSamples_);
+        chunk->audio.clear();
+        spent_.push(chunk.get());
+        pool_.push_back(std::move(chunk));
+    }
+}
+
+void PrefetchStream::seek(std::int64_t sourceStart) {
+    requestSeek(sourceStart);
+}
+
+void PrefetchStream::requestSeek(std::int64_t sourceStart) {
+    nextSample_ = sourceStart;
+    ++generation_;
+
+    // Whatever the callback was reading came from somewhere else now.
+    releaseCurrent();
+
+    farbot::RealtimeObject<SeekRequest, farbot::RealtimeObjectOptions::realtimeMutatable>::
+        ScopedAccess<farbot::ThreadType::realtime>
+            request(request_);
+    request->sourceStart = sourceStart;
+    request->generation = generation_;
+}
+
+void PrefetchStream::releaseCurrent() {
+    if (current_ == nullptr)
+        return;
+
+    const auto pushed = spent_.push(std::move(current_));
+    jassert(pushed);
+    juce::ignoreUnused(pushed);
+
+    current_ = nullptr;
+    currentOffset_ = 0;
+}
+
+bool PrefetchStream::takeNextChunk() {
+    Chunk* chunk = nullptr;
+
+    while (filled_.pop(chunk)) {
+        // Read for a position that has since been abandoned, or for one the
+        // callback has already gone past. Either way it is not what is being
+        // asked for, and the fifo behind it might be.
+        if (chunk->generation != generation_ ||
+            chunk->startSample + chunk->numSamples <= nextSample_) {
+            spent_.push(std::move(chunk));
+            continue;
+        }
+
+        // The reader is ahead of where the callback is asking. Nothing in the
+        // fifo can fill that gap, so it stays where it is and the callback
+        // takes the silence.
+        if (chunk->startSample > nextSample_) {
+            spent_.push(std::move(chunk));
+            return false;
+        }
+
+        current_ = chunk;
+        currentOffset_ = static_cast<int>(nextSample_ - chunk->startSample);
+        return true;
+    }
+
+    return false;
+}
+
+int PrefetchStream::read(std::int64_t sourceStart, juce::dsp::AudioBlock<float> destination,
+                         int numSamples) {
+    if (numSamples <= 0)
+        return 0;
+
+    if (sourceStart != nextSample_)
+        requestSeek(sourceStart);
+
+    destination.clear();
+
+    auto done = 0;
+
+    while (done < numSamples) {
+        if (current_ == nullptr && !takeNextChunk())
+            break;
+
+        const auto available = current_->numSamples - currentOffset_;
+        const auto count = std::min(available, numSamples - done);
+
+        for (std::size_t channel = 0; channel < destination.getNumChannels(); ++channel) {
+            // A chunk carries the engine's channels rather than the file's, so
+            // this is a straight copy; the modulo is for a destination wider
+            // than the engine renders, which nothing asks for today and which
+            // should repeat rather than fall silent if anything ever does.
+            const auto source = static_cast<int>(channel) % current_->audio.getNumChannels();
+            juce::FloatVectorOperations::copy(
+                destination.getChannelPointer(channel) + done,
+                current_->audio.getReadPointer(source, currentOffset_), count);
+        }
+
+        currentOffset_ += count;
+        nextSample_ += count;
+        done += count;
+
+        if (currentOffset_ >= current_->numSamples)
+            releaseCurrent();
+    }
+
+    if (done < numSamples) {
+        // Past the end of the file nothing is late: there is no sample there to
+        // be waiting for. Anywhere else, the reader did not keep up, and the
+        // callback has just played silence that is not in the material.
+        const auto wanted = std::min<std::int64_t>(sourceStart + numSamples, length_);
+        if (sourceStart + done < wanted)
+            underruns_.fetch_add(1, std::memory_order_relaxed);
+
+        // The cursor moves whether or not the samples arrived. A stream that
+        // resumed where it ran dry would play the missing audio late and stay
+        // late for the rest of the take; the gap is the honest cost.
+        nextSample_ = sourceStart + numSamples;
+    }
+
+    return done;
+}
+
+bool PrefetchStream::fill() {
+    if (reader_ == nullptr)
+        return false;
+
+    {
+        farbot::RealtimeObject<SeekRequest, farbot::RealtimeObjectOptions::realtimeMutatable>::
+            ScopedAccess<farbot::ThreadType::nonRealtime>
+                request(request_);
+
+        if (request->generation != fillGeneration_) {
+            fillGeneration_ = request->generation;
+            fillPosition_ = request->sourceStart;
+            stalled_ = false;
+        }
+    }
+
+    if (stalled_)
+        return false;
+
+    auto worked = false;
+    Chunk* chunk = nullptr;
+
+    while (fillPosition_ < length_ && spent_.pop(chunk)) {
+        const auto count =
+            static_cast<int>(std::min<std::int64_t>(chunkSamples_, length_ - fillPosition_));
+
+        chunk->startSample = fillPosition_;
+        chunk->numSamples = reader_->read(chunk->audio, 0, fillPosition_, count);
+        chunk->generation = fillGeneration_;
+
+        fillPosition_ += chunk->numSamples;
+        worked = true;
+
+        // A reader that gives nothing at a position inside its own file has
+        // stopped being able to answer: a file truncated under us, a device
+        // that went away. Asking again would spin the thread at full tilt
+        // against something that is not going to improve, so the stream stops
+        // reading until a seek gives it somewhere else to try.
+        stalled_ = chunk->numSamples <= 0;
+
+        const auto pushed = filled_.push(std::move(chunk));
+        jassert(pushed);
+        juce::ignoreUnused(pushed);
+
+        if (stalled_)
+            break;
+    }
+
+    return worked;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/io/PrefetchStream.cpp
+++ b/magda/engine/io/PrefetchStream.cpp
@@ -140,16 +140,27 @@ int PrefetchStream::read(std::int64_t sourceStart, juce::dsp::AudioBlock<float> 
     if (numSamples <= 0)
         return 0;
 
-    // Reading is what sounding means. Taking a cue up is not done here: it
-    // happens once at the top of a block, through applyPendingCue, and doing it
-    // again inside the read would see a stream that has not read *yet this
-    // block* and mistake it for one that is not playing at all.
+    destination.clear();
+
+    // Nothing in this request can play: it is past the last sample of the file,
+    // or before the first. Not an underrun, and not a seek either. A stream
+    // whose clip is still placed but whose material has run out has not gone
+    // anywhere, and moving the cursor for it would throw away a cue meant for
+    // wherever it goes next, which is exactly when cueing it is useful.
+    if (sourceStart >= length_ || sourceStart + numSamples <= 0)
+        return 0;
+
+    // Reading is what sounding means, and this is a read that could play
+    // something: one that comes back short because the reader is behind still
+    // counts, because that stream is playing and merely starved. Taking a cue
+    // up is not done here: it happens once at the top of a block, through
+    // applyPendingCue, and doing it again inside the read would see a stream
+    // that has not reached its read *yet this block* and mistake it for one
+    // that is not playing at all.
     readSinceCueCheck_ = true;
 
     if (sourceStart != nextSample_)
         requestSeek(sourceStart);
-
-    destination.clear();
 
     auto done = 0;
 

--- a/magda/engine/io/PrefetchStream.hpp
+++ b/magda/engine/io/PrefetchStream.hpp
@@ -214,9 +214,11 @@ class PrefetchStream {
     std::uint32_t generation_ = 0;
     std::uint32_t appliedCue_ = 0;
 
-    /// Whether anything played out of this stream since the last cue check.
-    /// What separates a stream waiting to be given somewhere to go from one
-    /// already on its way somewhere.
+    /// Whether anything could have played out of this stream since the last
+    /// cue check. What separates a stream waiting to be given somewhere to go
+    /// from one already on its way somewhere, which is not the same question as
+    /// whether it was asked: a clip placed past the end of its own material is
+    /// asked every block and plays nothing.
     bool readSinceCueCheck_ = false;
 
     // Prefetch thread only.

--- a/magda/engine/io/PrefetchStream.hpp
+++ b/magda/engine/io/PrefetchStream.hpp
@@ -1,0 +1,174 @@
+#pragma once
+
+// Ahead of farbot, which leaves including the standard library to whoever uses
+// it: its headers are written to drop into a project that has already done so.
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
+
+#include <atomic>
+#include <cassert>
+#include <cstdint>
+#include <farbot/RealtimeObject.hpp>
+#include <farbot/fifo.hpp>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "exec/RenderContext.hpp"
+#include "io/AudioFileReader.hpp"
+
+/**
+ * @file PrefetchStream.hpp
+ * @brief One file, read ahead of the callback that plays it.
+ *
+ * The audio thread cannot wait for a disk, so it never touches one: a thread
+ * that is allowed to block reads whole chunks ahead of where playback is, and
+ * the callback copies out of what is already in memory. What arrives on the
+ * audio thread is therefore a pointer swap and a copy, and nothing else.
+ *
+ * Chunks rather than a ring of samples, because a chunk can be stamped. A seek
+ * makes everything already read wrong, and the stamp is how the callback knows
+ * that without the reader having to reach into a buffer the callback is using:
+ * stale chunks are recognised on the way out and dropped, which is the same
+ * epoch discipline the plan swap uses.
+ *
+ * Threading: read() on the audio thread, fill() on the prefetch thread,
+ * everything else before either is running. One stream is one reader and is
+ * never shared between tracks.
+ */
+
+namespace magda::engine {
+
+/** How much a stream reads ahead, and in what units. */
+struct PrefetchSettings {
+    /// Samples in one chunk. The unit of disk work: too small and the reader
+    /// thread spends its life in syscalls, too large and a seek costs a whole
+    /// chunk of latency before anything can play.
+    int chunkSamples = 4096;
+
+    /// Chunks in the pool. What is left after subtracting the one the callback
+    /// is reading is how far ahead the stream can get, and therefore how long
+    /// the reader thread may be held up without the callback noticing.
+    int chunkCount = 8;
+};
+
+class PrefetchStream {
+  public:
+    PrefetchStream(std::unique_ptr<AudioFileReader> reader, const RenderContext& context,
+                   const PrefetchSettings& settings = {});
+
+    /**
+     * @brief Fill @p destination with @p numSamples from @p sourceStart.
+     *
+     * On the audio thread. Returns how many samples were there to give; the
+     * rest of the destination is silent.
+     *
+     * A start that is not where the last read left off is a seek: what has been
+     * read ahead is for somewhere else, so it is dropped and the reader is
+     * pointed at the new position. Nothing plays until it has caught up, which
+     * is what @ref underruns counts.
+     */
+    int read(std::int64_t sourceStart, juce::dsp::AudioBlock<float> destination, int numSamples);
+
+    /**
+     * @brief Read ahead. On the prefetch thread.
+     *
+     * Returns true if it did anything, so a caller servicing several streams
+     * can tell a busy round from an idle one and sleep on the difference.
+     */
+    bool fill();
+
+    /// Where the stream will be pointed next. Off the audio thread, before it
+    /// is playing: the callback is what moves the cursor once it is.
+    void seek(std::int64_t sourceStart);
+
+    /**
+     * @brief Blocks the callback could not be given the samples for.
+     *
+     * A seek costs at least one, because a disk cannot be read inside a
+     * callback. Anything beyond that is the reader failing to keep up, which is
+     * a property of the machine rather than of the music, and it has to be
+     * visible: silence that nobody counted is indistinguishable from a gap in
+     * the material.
+     *
+     * The end of the file is not an underrun. There is nothing late about
+     * silence past the last sample.
+     */
+    int underruns() const {
+        return underruns_.load(std::memory_order_relaxed);
+    }
+
+    /// Samples in the file. The one thing the audio thread reads from the
+    /// reader, and it reads it from a copy taken before anything played.
+    std::int64_t lengthInSamples() const {
+        return length_;
+    }
+
+    double sampleRate() const {
+        return sourceSampleRate_;
+    }
+
+  private:
+    /// One read's worth of audio, and where it came from.
+    struct Chunk {
+        juce::AudioBuffer<float> audio;
+        std::int64_t startSample = 0;
+        int numSamples = 0;
+
+        /// Which seek this was read for. A chunk whose generation is not the
+        /// one the callback is asking about was read for a position that has
+        /// since been abandoned.
+        std::uint32_t generation = 0;
+    };
+
+    /// Where the reader has been told to be. Written by the callback, read by
+    /// the prefetch thread; the pair has to travel together, because a position
+    /// read against the wrong generation is a seek to the wrong place.
+    struct SeekRequest {
+        std::int64_t sourceStart = 0;
+        std::uint32_t generation = 0;
+    };
+
+    using ChunkFifo = farbot::fifo<Chunk*, farbot::fifo_options::concurrency::single,
+                                   farbot::fifo_options::concurrency::single>;
+
+    /// Take the next chunk the callback can use, dropping any that were read
+    /// for an abandoned position. Audio thread.
+    bool takeNextChunk();
+
+    /// Hand a spent chunk back to the reader. Audio thread.
+    void releaseCurrent();
+
+    void requestSeek(std::int64_t sourceStart);
+
+    std::unique_ptr<AudioFileReader> reader_;
+    std::int64_t length_ = 0;
+    double sourceSampleRate_ = 0.0;
+    int numChannels_ = 2;
+    int chunkSamples_ = 0;
+
+    std::vector<std::unique_ptr<Chunk>> pool_;
+    ChunkFifo filled_;
+    ChunkFifo spent_;
+
+    farbot::RealtimeObject<SeekRequest, farbot::RealtimeObjectOptions::realtimeMutatable> request_;
+
+    // Audio thread only.
+    Chunk* current_ = nullptr;
+    int currentOffset_ = 0;
+    std::int64_t nextSample_ = 0;
+    std::uint32_t generation_ = 0;
+
+    // Prefetch thread only.
+    std::int64_t fillPosition_ = 0;
+    std::uint32_t fillGeneration_ = 0;
+
+    /// The reader stopped answering somewhere inside its own file. Nothing to
+    /// be done about it here, and everything to be done about not asking it
+    /// again every round until something moves.
+    bool stalled_ = false;
+
+    std::atomic<int> underruns_{0};
+};
+
+}  // namespace magda::engine

--- a/magda/engine/io/PrefetchStream.hpp
+++ b/magda/engine/io/PrefetchStream.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-// Ahead of farbot, which leaves including the standard library to whoever uses
-// it: its headers are written to drop into a project that has already done so.
+// farbot leaves including the standard library to whoever uses it: its headers
+// are written to drop into a project that has already done so, and on their own
+// they do not compile. The JUCE headers above it here bring in what it needs.
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_dsp/juce_dsp.h>
 
@@ -78,9 +79,33 @@ class PrefetchStream {
      */
     bool fill();
 
-    /// Where the stream will be pointed next. Off the audio thread, before it
-    /// is playing: the callback is what moves the cursor once it is.
+    /**
+     * @brief Point the reader at a position before anything asks for it.
+     *
+     * From any thread that is not the audio thread, at any time, including
+     * while the stream is playing: whoever schedules material knows where
+     * playback will be before the callback does, and a stream told in advance
+     * is one that does not have to seek in the block that needs the samples.
+     *
+     * Nothing here touches what the callback owns. It publishes a cue, and the
+     * callback picks it up at the top of its next block through
+     * @ref applyPendingCue, so the seek itself happens where every other seek
+     * happens. That is a block's delay before the reader starts moving, which
+     * is nothing against the reason to cue at all: a clip scheduled a moment
+     * ahead is read ahead long before it plays.
+     */
     void seek(std::int64_t sourceStart);
+
+    /**
+     * @brief Take up a cue, if one is waiting. On the audio thread.
+     *
+     * read() does this itself, so a caller that only reads never has to. What
+     * needs it is a caller that does not read every block: a clip that has not
+     * started yet is exactly the thing a cue is for, and a stream nobody reads
+     * from would otherwise not hear about it until the material it was cued
+     * for was already due.
+     */
+    void applyPendingCue();
 
     /**
      * @brief Blocks the callback could not be given the samples for.
@@ -153,11 +178,23 @@ class PrefetchStream {
 
     farbot::RealtimeObject<SeekRequest, farbot::RealtimeObjectOptions::realtimeMutatable> request_;
 
+    /// A position published from off the audio thread, waiting to be taken up.
+    /// The other direction from @ref request_, and a separate object for the
+    /// same reason it is a different type: one writer each, so neither side is
+    /// ever writing what the other is reading.
+    farbot::RealtimeObject<SeekRequest, farbot::RealtimeObjectOptions::nonRealtimeMutatable> cue_;
+
+    /// The cueing side's own counter. Not shared with @ref generation_, which
+    /// the audio thread owns: what makes a cue new is that it is not the one
+    /// already taken up.
+    std::uint32_t cueGeneration_ = 0;
+
     // Audio thread only.
     Chunk* current_ = nullptr;
     int currentOffset_ = 0;
     std::int64_t nextSample_ = 0;
     std::uint32_t generation_ = 0;
+    std::uint32_t appliedCue_ = 0;
 
     // Prefetch thread only.
     std::int64_t fillPosition_ = 0;

--- a/magda/engine/io/PrefetchStream.hpp
+++ b/magda/engine/io/PrefetchStream.hpp
@@ -82,10 +82,10 @@ class PrefetchStream {
     /**
      * @brief Point the reader at a position before anything asks for it.
      *
-     * From any thread that is not the audio thread, at any time, including
-     * while the stream is playing: whoever schedules material knows where
-     * playback will be before the callback does, and a stream told in advance
-     * is one that does not have to seek in the block that needs the samples.
+     * From any thread that is not the audio thread, at any time: whoever
+     * schedules material knows where playback will be before the callback does,
+     * and a stream told in advance is one that does not have to seek in the
+     * block that needs the samples.
      *
      * Nothing here touches what the callback owns. It publishes a cue, and the
      * callback picks it up at the top of its next block through
@@ -93,17 +93,35 @@ class PrefetchStream {
      * happens. That is a block's delay before the reader starts moving, which
      * is nothing against the reason to cue at all: a clip scheduled a moment
      * ahead is read ahead long before it plays.
+     *
+     * A cue points a stream that is not sounding. One that is keeps playing and
+     * takes the cue up when it stops, because a single reader cannot be in two
+     * places: pointing it somewhere else would abandon the material still
+     * playing and hand back the pool holding it, for a position the next read
+     * would immediately override.
+     *
+     * That is also why a loop's return is not seamless here. Reading the top of
+     * a loop while the end of it is still playing means holding two positions
+     * at once, which is a second fill cursor and a second pool, and it belongs
+     * with whoever owns clip looping (#1890) rather than being half-built
+     * underneath them. Today a wrap costs the block it happens in, and the
+     * underrun count says so.
      */
     void seek(std::int64_t sourceStart);
 
     /**
      * @brief Take up a cue, if one is waiting. On the audio thread.
      *
-     * read() does this itself, so a caller that only reads never has to. What
-     * needs it is a caller that does not read every block: a clip that has not
-     * started yet is exactly the thing a cue is for, and a stream nobody reads
-     * from would otherwise not hear about it until the material it was cued
-     * for was already due.
+     * Once per block, at the top of it, by whoever drives the stream. Not done
+     * inside read(), and the difference matters: what decides whether a cue is
+     * taken up now or waits is whether this stream is sounding, and that
+     * question is only answerable at a block boundary. Asked again halfway
+     * through, a stream that simply has not reached its read yet looks exactly
+     * like one that is silent.
+     *
+     * It has to be a separate call for the same reason. The stream a cue is
+     * most useful to is one nobody is reading from: a clip that has not started
+     * would otherwise not hear about it until the material was already due.
      */
     void applyPendingCue();
 
@@ -195,6 +213,11 @@ class PrefetchStream {
     std::int64_t nextSample_ = 0;
     std::uint32_t generation_ = 0;
     std::uint32_t appliedCue_ = 0;
+
+    /// Whether anything played out of this stream since the last cue check.
+    /// What separates a stream waiting to be given somewhere to go from one
+    /// already on its way somewhere.
+    bool readSinceCueCheck_ = false;
 
     // Prefetch thread only.
     std::int64_t fillPosition_ = 0;

--- a/magda/engine/io/PrefetchThread.cpp
+++ b/magda/engine/io/PrefetchThread.cpp
@@ -1,0 +1,60 @@
+#include "io/PrefetchThread.hpp"
+
+#include <algorithm>
+
+namespace magda::engine {
+
+PrefetchThread::PrefetchThread() : juce::Thread("MAGDA prefetch") {
+    // Above the interface, below the callback. A reader that lost to a redraw
+    // is what an underrun sounds like.
+    startThread(juce::Thread::Priority::high);
+}
+
+PrefetchThread::~PrefetchThread() {
+    stopThread(2000);
+}
+
+void PrefetchThread::add(PrefetchStream& stream) {
+    {
+        const std::lock_guard<std::mutex> guard(lock_);
+        if (std::find(streams_.begin(), streams_.end(), &stream) == streams_.end())
+            streams_.push_back(&stream);
+    }
+
+    notify();
+}
+
+void PrefetchThread::remove(PrefetchStream& stream) {
+    const std::lock_guard<std::mutex> guard(lock_);
+    streams_.erase(std::remove(streams_.begin(), streams_.end(), &stream), streams_.end());
+}
+
+std::size_t PrefetchThread::streamCount() const {
+    const std::lock_guard<std::mutex> guard(lock_);
+    return streams_.size();
+}
+
+bool PrefetchThread::fillOnce() {
+    const std::lock_guard<std::mutex> guard(lock_);
+
+    auto worked = false;
+    for (auto* stream : streams_)
+        worked = stream->fill() || worked;
+
+    return worked;
+}
+
+void PrefetchThread::run() {
+    while (!threadShouldExit()) {
+        // Straight round again while there is reading to do: a stream that has
+        // just been seeked has a whole pool to refill, and sleeping between
+        // chunks would make the gap the callback hears longer than the disk
+        // needs it to be.
+        if (fillOnce())
+            continue;
+
+        wait(kIdleMilliseconds);
+    }
+}
+
+}  // namespace magda::engine

--- a/magda/engine/io/PrefetchThread.hpp
+++ b/magda/engine/io/PrefetchThread.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <mutex>
+#include <vector>
+
+#include "io/PrefetchStream.hpp"
+
+/**
+ * @file PrefetchThread.hpp
+ * @brief The one thread allowed to wait for a disk.
+ *
+ * Every stream in the engine is read from here, on a thread above the ones
+ * drawing the interface and below the one rendering audio. One thread rather
+ * than one per stream: a hundred tracks would otherwise be a hundred threads
+ * competing for the same head, and the order they read in would be decided by
+ * the scheduler rather than by what is about to play.
+ *
+ * It polls. Nothing wakes it from the audio thread, because waking a thread
+ * takes a lock and the callback does not take locks; a stream that has just
+ * been seeked is found on the next round instead, which is what the underrun
+ * count is measuring when it counts a seek.
+ */
+
+namespace magda::engine {
+
+class PrefetchThread final : private juce::Thread {
+  public:
+    PrefetchThread();
+    ~PrefetchThread() override;
+
+    PrefetchThread(const PrefetchThread&) = delete;
+    PrefetchThread& operator=(const PrefetchThread&) = delete;
+
+    /// Start reading for this stream. Off the audio thread; the stream must
+    /// outlive the registration.
+    void add(PrefetchStream& stream);
+
+    /**
+     * @brief Stop reading for it.
+     *
+     * Off the audio thread, and blocks until the thread is out of the stream,
+     * which is what makes it safe to destroy afterwards. The caller is a thread
+     * that is allowed to wait; that is the whole reason removal happens here
+     * rather than wherever the audio thread notices a stream is gone.
+     */
+    void remove(PrefetchStream& stream);
+
+    /// Streams registered right now.
+    std::size_t streamCount() const;
+
+    /// One round of filling, without the thread. For tests, which want to say
+    /// exactly how far ahead the reader got before the callback ran.
+    bool fillOnce();
+
+  private:
+    void run() override;
+
+    /// How long to sleep when every pool is full. Short enough that a seek is
+    /// answered inside a block or two at any sane device size, long enough that
+    /// an idle project is not a thread spinning.
+    static constexpr int kIdleMilliseconds = 5;
+
+    mutable std::mutex lock_;
+    std::vector<PrefetchStream*> streams_;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/io/StreamingAudioSource.cpp
+++ b/magda/engine/io/StreamingAudioSource.cpp
@@ -1,0 +1,51 @@
+#include "io/StreamingAudioSource.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace magda::engine {
+
+StreamingAudioSource::StreamingAudioSource(PrefetchStream& stream, const ClipPlacement& placement)
+    : stream_(stream), placement_(placement) {}
+
+void StreamingAudioSource::prepare(const RenderContext& context) {
+    sampleRate_ = context.sampleRate;
+}
+
+std::int64_t StreamingAudioSource::sourceSampleAt(double seconds) const {
+    // Counted in the file's own samples, from the moment its first sample
+    // plays. The rate is the file's rather than the device's, so a locate lands
+    // on the right sample of the material even when the two differ.
+    const auto rate = stream_.sampleRate() > 0.0 ? stream_.sampleRate() : sampleRate_;
+    return placement_.sourceOffsetSamples +
+           static_cast<std::int64_t>(std::llround((seconds - placement_.startSeconds) * rate));
+}
+
+void StreamingAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {
+    out.clear();
+
+    if (!block.playing || block.numSamples <= 0)
+        return;
+
+    // The part of the block the clip covers, as samples of it. Half-open at
+    // both ends, so a clip ending exactly on a block boundary contributes
+    // nothing to the block that starts there.
+    const auto first = block.sampleForTime(std::max(block.startSeconds, placement_.startSeconds));
+    const auto last = block.sampleForTime(std::min(block.endSeconds, placement_.endSeconds));
+    const auto count = last - first;
+
+    if (count <= 0)
+        return;
+
+    // Where in the file that part begins. Derived from the timeline rather than
+    // from where the last block left off, so a jump needs nothing said about
+    // it: the stream sees a position it was not expecting and seeks, which is
+    // the same path a loop wrap takes.
+    const auto sourceStart = sourceSampleAt(std::max(block.startSeconds, placement_.startSeconds));
+
+    stream_.read(sourceStart,
+                 out.getSubBlock(static_cast<std::size_t>(first), static_cast<std::size_t>(count)),
+                 count);
+}
+
+}  // namespace magda::engine

--- a/magda/engine/io/StreamingAudioSource.cpp
+++ b/magda/engine/io/StreamingAudioSource.cpp
@@ -13,16 +13,25 @@ void StreamingAudioSource::prepare(const RenderContext& context) {
 }
 
 std::int64_t StreamingAudioSource::sourceSampleAt(double seconds) const {
-    // Counted in the file's own samples, from the moment its first sample
-    // plays. The rate is the file's rather than the device's, so a locate lands
-    // on the right sample of the material even when the two differ.
-    const auto rate = stream_.sampleRate() > 0.0 ? stream_.sampleRate() : sampleRate_;
-    return placement_.sourceOffsetSamples +
-           static_cast<std::int64_t>(std::llround((seconds - placement_.startSeconds) * rate));
+    // At the device's rate, not the file's, and that is not a slip. One file
+    // sample is copied per output sample below, so a position derived at any
+    // other rate would disagree with what playing actually consumes: every
+    // block would land somewhere the stream was not expecting, which is a seek,
+    // and a file at the wrong rate would spend every callback re-pointing the
+    // reader and hearing nothing. Deriving it at the device's rate keeps the
+    // two in step, and what a mismatched file costs is then pitch rather than
+    // playback.
+    return placement_.sourceOffsetSamples + static_cast<std::int64_t>(std::llround(
+                                                (seconds - placement_.startSeconds) * sampleRate_));
 }
 
 void StreamingAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {
     out.clear();
+
+    // Every block, sounding or not. A clip that has not started is exactly what
+    // a cue is for, and a stream nobody reads from would not hear about one
+    // until the material it was cued for was already due.
+    stream_.applyPendingCue();
 
     if (!block.playing || block.numSamples <= 0)
         return;

--- a/magda/engine/io/StreamingAudioSource.hpp
+++ b/magda/engine/io/StreamingAudioSource.hpp
@@ -58,9 +58,16 @@ class StreamingAudioSource final : public EngineAudioSource {
      * stopped timeline is not a held sample, it is no material.
      *
      * Rate conversion is not done here. The stream delivers the file's own
-     * samples, and a file recorded at another rate than the device runs at
-     * plays at the wrong pitch until the clip layer resamples it; that layer
-     * owns stretch and warp and this is the same question.
+     * samples, one per output sample, so a file recorded at another rate than
+     * the device runs at plays at the wrong pitch and the wrong length until
+     * the clip layer resamples it; that layer owns stretch and warp and this is
+     * the same question.
+     *
+     * Wrong and continuous, not wrong and broken: positions are derived at the
+     * device's rate so that what is asked for and what is consumed agree. A
+     * mapping at the file's rate would disagree by the difference every block,
+     * which the stream would read as a seek, and a mismatched file would spend
+     * every callback re-pointing the reader and playing nothing at all.
      */
     void render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) override;
 

--- a/magda/engine/io/StreamingAudioSource.hpp
+++ b/magda/engine/io/StreamingAudioSource.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <cstdint>
+
+#include "exec/EngineDevice.hpp"
+#include "io/PrefetchStream.hpp"
+
+/**
+ * @file StreamingAudioSource.hpp
+ * @brief One placed file, rendered through a prefetch stream.
+ *
+ * The seam the plan already has: a ClipAudio op names a track, the host binds
+ * an EngineAudioSource to it, and this is what stands behind that binding for
+ * audio on the arrangement.
+ *
+ * Deliberately one file and one placement. Which clip is playing at a given
+ * moment, what a crossfade between two of them sounds like, and what stretch
+ * and warp do to the mapping are the clip layer's questions (#1890); this is
+ * the layer that gets samples off a disk in time, and it is complete when a
+ * region of a file plays where the model says it should.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief Where a file sits on the timeline, and where playback starts in it.
+ *
+ * In seconds rather than beats. The clip layer positions clips in beats, as the
+ * model does, and resolves them to seconds through the tempo map before they
+ * reach here; a source that had to do it itself would need a tempo map on the
+ * audio thread, and there would then be two of them.
+ */
+struct ClipPlacement {
+    double startSeconds = 0.0;
+    double endSeconds = 0.0;
+
+    /// The sample of the file that plays at @ref startSeconds. What trimming
+    /// the front of a clip moves.
+    std::int64_t sourceOffsetSamples = 0;
+};
+
+class StreamingAudioSource final : public EngineAudioSource {
+  public:
+    /// The stream is owned elsewhere, because the prefetch thread reads it and
+    /// the source is what a plan swap can replace.
+    StreamingAudioSource(PrefetchStream& stream, const ClipPlacement& placement);
+
+    void prepare(const RenderContext& context) override;
+
+    /**
+     * @brief Render the part of this block the clip covers.
+     *
+     * The rest is silence: a source fills its whole block, and a clip that
+     * starts a hundred samples in has a hundred samples of nothing in front of
+     * it rather than a hundred samples of whatever the buffer held.
+     *
+     * A block the transport is not moving through renders nothing at all. A
+     * stopped timeline is not a held sample, it is no material.
+     *
+     * Rate conversion is not done here. The stream delivers the file's own
+     * samples, and a file recorded at another rate than the device runs at
+     * plays at the wrong pitch until the clip layer resamples it; that layer
+     * owns stretch and warp and this is the same question.
+     */
+    void render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) override;
+
+    /**
+     * @brief The file sample that plays at a moment on the timeline.
+     *
+     * Public because pointing the stream at a clip is done from outside it.
+     * Whoever schedules playback knows where it is about to start before the
+     * callback does, and a stream told in advance is one that does not have to
+     * seek in the block that needs the samples.
+     */
+    std::int64_t sourceSampleAt(double seconds) const;
+
+  private:
+    PrefetchStream& stream_;
+    ClipPlacement placement_;
+    double sampleRate_ = 44100.0;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/transport/TransportClock.cpp
+++ b/magda/engine/transport/TransportClock.cpp
@@ -24,12 +24,16 @@ void TransportClock::anchorTo(const TempoMap& tempo, double beat) {
     positionBeats_.store(beat, std::memory_order_relaxed);
 }
 
+double TransportClock::secondsAfter(std::int64_t samples) const {
+    return anchorSeconds_ + static_cast<double>(samples) / sampleRate_;
+}
+
 double TransportClock::beatAfter(const TempoMap& tempo, std::int64_t samples) const {
-    return tempo.timeToBeat(anchorSeconds_ + static_cast<double>(samples) / sampleRate_);
+    return tempo.timeToBeat(secondsAfter(samples));
 }
 
 std::int64_t TransportClock::samplesUntil(const TempoMap& tempo, double beat) const {
-    const auto now = anchorSeconds_ + static_cast<double>(samplesSinceAnchor_) / sampleRate_;
+    const auto now = secondsAfter(samplesSinceAnchor_);
     const auto target = tempo.beatToTime(beat);
     return static_cast<std::int64_t>(std::ceil((target - now) * sampleRate_ - kSampleEpsilon));
 }
@@ -108,11 +112,15 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
     if (!playing_) {
         const auto beat = beatAfter(tempo, samplesSinceAnchor_);
 
+        const auto seconds = secondsAfter(samplesSinceAnchor_);
+
         auto& segment = segments_[0];
         segment.block.numSamples = numSamples;
         segment.block.playing = false;
         segment.block.startBeat = beat;
         segment.block.endBeat = beat;
+        segment.block.startSeconds = seconds;
+        segment.block.endSeconds = seconds;
         segment.block.continuous = continuous_;
         segment.startSample = 0;
         segment.countingIn = false;
@@ -185,6 +193,8 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
         segment.block.playing = true;
         segment.block.startBeat = beatAfter(tempo, samplesSinceAnchor_);
         segment.block.endBeat = beatAfter(tempo, samplesSinceAnchor_ + samples);
+        segment.block.startSeconds = secondsAfter(samplesSinceAnchor_);
+        segment.block.endSeconds = secondsAfter(samplesSinceAnchor_ + samples);
         segment.block.continuous = continuous_;
         segment.startSample = offset;
         segment.countingIn = countingIn_;

--- a/magda/engine/transport/TransportClock.hpp
+++ b/magda/engine/transport/TransportClock.hpp
@@ -100,7 +100,11 @@ class TransportClock {
     /// from.
     void anchorTo(const TempoMap& tempo, double beat);
 
-    /// The beat the cursor would be at @p samples after the anchor.
+    /// Where the cursor would be @p samples after the anchor, in seconds and
+    /// in beats. The seconds are the primitive: the anchor is a position in
+    /// seconds and the device counts samples, so this is the whole of the
+    /// conversion and the beats are that answer read through a tempo map.
+    double secondsAfter(std::int64_t samples) const;
     double beatAfter(const TempoMap& tempo, std::int64_t samples) const;
 
     /// Samples from the cursor until the timeline reaches @p beat, rounded up

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -251,6 +251,8 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_tempo_map.cpp)
     list(APPEND TEST_SOURCES test_transport_clock.cpp)
     list(APPEND TEST_SOURCES test_click_generator.cpp)
+    list(APPEND TEST_SOURCES test_prefetch_stream.cpp)
+    list(APPEND TEST_SOURCES test_streaming_audio_source.cpp)
 endif()
 
 # Create test executable

--- a/tests/test_prefetch_stream.cpp
+++ b/tests/test_prefetch_stream.cpp
@@ -274,7 +274,7 @@ TEST_CASE("A reader that fails is not a reader that returned audio", "[engine][i
             lengthInSamples = 10000;
         }
 
-        bool readSamples(int* const*, int, int, std::int64_t, int) override {
+        bool readSamples(int* const*, int, int, juce::int64, int) override {
             return false;
         }
     };

--- a/tests/test_prefetch_stream.cpp
+++ b/tests/test_prefetch_stream.cpp
@@ -1,0 +1,256 @@
+#include <algorithm>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+
+#include "io/PrefetchStream.hpp"
+
+using magda::engine::AudioFileReader;
+using magda::engine::PrefetchSettings;
+using magda::engine::PrefetchStream;
+using magda::engine::RenderContext;
+
+namespace {
+
+constexpr int kBlockSize = 64;
+
+/**
+ * A file whose samples say where they came from: sample n of channel c reads
+ * back as n + c/2. Anything the stream delivers can therefore be checked
+ * against the position it was supposed to come from, which reading a fixture
+ * off a disk would not give and which is the whole question here.
+ */
+class CountingReader final : public AudioFileReader {
+  public:
+    explicit CountingReader(std::int64_t length, double rate = 44100.0)
+        : length_(length), rate_(rate) {}
+
+    std::int64_t lengthInSamples() const override {
+        return length_;
+    }
+
+    double sampleRate() const override {
+        return rate_;
+    }
+
+    int numChannels() const override {
+        return 2;
+    }
+
+    int read(juce::AudioBuffer<float>& destination, int destinationOffset, std::int64_t startSample,
+             int numSamples) override {
+        ++reads;
+        lastStart = startSample;
+
+        const auto available =
+            static_cast<int>(std::clamp<std::int64_t>(length_ - startSample, 0, numSamples));
+
+        for (auto channel = 0; channel < destination.getNumChannels(); ++channel)
+            for (auto sample = 0; sample < available; ++sample)
+                destination.setSample(channel, destinationOffset + sample,
+                                      valueAt(startSample + sample, channel));
+
+        if (available < numSamples)
+            destination.clear(destinationOffset + available, numSamples - available);
+
+        return available;
+    }
+
+    static float valueAt(std::int64_t sample, int channel) {
+        return static_cast<float>(sample) + static_cast<float>(channel) * 0.5f;
+    }
+
+    int reads = 0;
+    std::int64_t lastStart = -1;
+
+  private:
+    std::int64_t length_;
+    double rate_;
+};
+
+RenderContext context() {
+    return RenderContext{44100.0, kBlockSize, 2};
+}
+
+Catch::Approx approx(float value) {
+    return Catch::Approx(value).margin(1e-4);
+}
+
+/// A stream over a counting file, with the reader kept to hand.
+struct Fixture {
+    explicit Fixture(std::int64_t length = 100000, PrefetchSettings settings = {256, 4}) {
+        auto owned = std::make_unique<CountingReader>(length);
+        reader = owned.get();
+        stream = std::make_unique<PrefetchStream>(std::move(owned), context(), settings);
+        output.setSize(2, kBlockSize);
+        output.clear();
+    }
+
+    /// Point the reader at a position before anything plays from it, which is
+    /// what whoever schedules the material does: a stream that is asked for a
+    /// position it was never pointed at has to seek, and a seek costs a block.
+    void cue(std::int64_t sourceStart) {
+        stream->seek(sourceStart);
+    }
+
+    /// Read one block's worth from a position, having read ahead first.
+    int readPrefetched(std::int64_t sourceStart, int numSamples = kBlockSize) {
+        while (stream->fill()) {
+        }
+        return read(sourceStart, numSamples);
+    }
+
+    int read(std::int64_t sourceStart, int numSamples = kBlockSize) {
+        output.clear();
+        return stream->read(sourceStart, juce::dsp::AudioBlock<float>(output), numSamples);
+    }
+
+    /// What the block holds, if it holds the file from this position.
+    void requireHolds(std::int64_t sourceStart, int numSamples = kBlockSize) {
+        for (auto sample = 0; sample < numSamples; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(output.getSample(0, sample) ==
+                    approx(CountingReader::valueAt(sourceStart + sample, 0)));
+            REQUIRE(output.getSample(1, sample) ==
+                    approx(CountingReader::valueAt(sourceStart + sample, 1)));
+        }
+    }
+
+    void requireSilent(int from, int to) {
+        for (auto sample = from; sample < to; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(output.getSample(0, sample) == approx(0.0f));
+        }
+    }
+
+    CountingReader* reader = nullptr;
+    std::unique_ptr<PrefetchStream> stream;
+    juce::AudioBuffer<float> output;
+};
+
+}  // namespace
+
+TEST_CASE("A stream plays what was read ahead of it", "[engine][io][prefetch]") {
+    Fixture fixture;
+
+    SECTION("from the beginning, block after block") {
+        for (auto block = 0; block < 20; ++block) {
+            const auto position = static_cast<std::int64_t>(block) * kBlockSize;
+            REQUIRE(fixture.readPrefetched(position) == kBlockSize);
+            fixture.requireHolds(position);
+        }
+
+        // Playing straight through is not a seek, however many chunk
+        // boundaries it crosses.
+        CHECK(fixture.stream->underruns() == 0);
+    }
+
+    SECTION("across a chunk boundary in one block") {
+        // The chunk is 256 samples; this block starts 32 short of the end of
+        // the first one, so it is served out of two.
+        fixture.cue(224);
+        REQUIRE(fixture.readPrefetched(224) == kBlockSize);
+        fixture.requireHolds(224);
+    }
+
+    SECTION("in blocks of different lengths") {
+        REQUIRE(fixture.readPrefetched(0, 10) == 10);
+        fixture.requireHolds(0, 10);
+
+        REQUIRE(fixture.readPrefetched(10, 50) == 50);
+        fixture.requireHolds(10, 50);
+    }
+
+    SECTION("with a pool small enough to have to be recycled") {
+        // Two chunks of 64: eight blocks cannot be in flight at once, so this
+        // only works if what the callback finishes with goes back to the
+        // reader.
+        Fixture small(100000, {64, 2});
+
+        for (auto block = 0; block < 8; ++block) {
+            const auto position = static_cast<std::int64_t>(block) * kBlockSize;
+            REQUIRE(small.readPrefetched(position) == kBlockSize);
+            small.requireHolds(position);
+        }
+    }
+}
+
+TEST_CASE("A reader that has not caught up renders silence and says so", "[engine][io][prefetch]") {
+    Fixture fixture;
+
+    SECTION("nothing read ahead is nothing to play") {
+        CHECK(fixture.read(0) == 0);
+        fixture.requireSilent(0, kBlockSize);
+        CHECK(fixture.stream->underruns() == 1);
+    }
+
+    SECTION("and the gap does not become a delay") {
+        // The first block is missed. The second is not the audio the first one
+        // wanted arriving late: it is the audio the second one wanted, which
+        // is what keeps a stream that ran dry once from staying behind for the
+        // rest of the take.
+        CHECK(fixture.read(0) == 0);
+
+        REQUIRE(fixture.readPrefetched(kBlockSize) == kBlockSize);
+        fixture.requireHolds(kBlockSize);
+    }
+
+    SECTION("the end of the file is not an underrun") {
+        Fixture shortFile(100);
+
+        REQUIRE(shortFile.readPrefetched(0, kBlockSize) == kBlockSize);
+        shortFile.requireHolds(0);
+
+        // Half of this block is past the last sample.
+        CHECK(shortFile.readPrefetched(64, kBlockSize) == 36);
+        shortFile.requireHolds(64, 36);
+        shortFile.requireSilent(36, kBlockSize);
+
+        // Entirely past it.
+        CHECK(shortFile.readPrefetched(128, kBlockSize) == 0);
+        shortFile.requireSilent(0, kBlockSize);
+
+        CHECK(shortFile.stream->underruns() == 0);
+    }
+}
+
+TEST_CASE("A seek drops what was read for somewhere else", "[engine][io][prefetch]") {
+    Fixture fixture;
+
+    // A full pool, all of it from the top of the file.
+    while (fixture.stream->fill()) {
+    }
+    REQUIRE(fixture.reader->reads > 0);
+
+    SECTION("the block that seeks plays silence rather than the wrong thing") {
+        CHECK(fixture.read(50000) == 0);
+        fixture.requireSilent(0, kBlockSize);
+        CHECK(fixture.stream->underruns() == 1);
+    }
+
+    SECTION("and what arrives afterwards is from the new position") {
+        fixture.read(50000);
+
+        REQUIRE(fixture.readPrefetched(50000 + kBlockSize) == kBlockSize);
+        fixture.requireHolds(50000 + kBlockSize);
+
+        // Only the seek cost anything. Playing on from there does not.
+        CHECK(fixture.stream->underruns() == 1);
+    }
+
+    SECTION("seeking backwards is the same as seeking forwards") {
+        for (auto block = 0; block < 8; ++block)
+            fixture.readPrefetched(static_cast<std::int64_t>(block) * kBlockSize);
+
+        fixture.read(0);
+        REQUIRE(fixture.readPrefetched(kBlockSize) == kBlockSize);
+        fixture.requireHolds(kBlockSize);
+    }
+}
+
+TEST_CASE("A stream asked for nothing does nothing", "[engine][io][prefetch]") {
+    Fixture fixture;
+
+    CHECK(fixture.readPrefetched(0, 0) == 0);
+    CHECK(fixture.stream->underruns() == 0);
+}

--- a/tests/test_prefetch_stream.cpp
+++ b/tests/test_prefetch_stream.cpp
@@ -91,6 +91,11 @@ struct Fixture {
     /// position it was never pointed at has to seek, and a seek costs a block.
     void cue(std::int64_t sourceStart) {
         stream->seek(sourceStart);
+
+        // Stands in for the callback before this one: a cue is published from
+        // another thread and taken up on the audio thread, which is what keeps
+        // the cross-thread path away from everything the callback owns.
+        stream->applyPendingCue();
     }
 
     /// Read one block's worth from a position, having read ahead first.
@@ -253,4 +258,40 @@ TEST_CASE("A stream asked for nothing does nothing", "[engine][io][prefetch]") {
 
     CHECK(fixture.readPrefetched(0, 0) == 0);
     CHECK(fixture.stream->underruns() == 0);
+}
+
+TEST_CASE("A reader that fails is not a reader that returned audio", "[engine][io][prefetch]") {
+    // A decode can fail inside the length a file advertises: truncated under
+    // us, a stream that went away mid-frame. What must not happen is the
+    // destination's previous contents being reported as material.
+    class FailingFormatReader final : public juce::AudioFormatReader {
+      public:
+        FailingFormatReader() : juce::AudioFormatReader(nullptr, "failing") {
+            sampleRate = 44100.0;
+            bitsPerSample = 32;
+            numChannels = 2;
+            usesFloatingPointData = true;
+            lengthInSamples = 10000;
+        }
+
+        bool readSamples(int* const*, int, int, std::int64_t, int) override {
+            return false;
+        }
+    };
+
+    magda::engine::JuceAudioFileReader reader(std::make_unique<FailingFormatReader>());
+
+    juce::AudioBuffer<float> destination(2, kBlockSize);
+    for (auto channel = 0; channel < 2; ++channel)
+        for (auto sample = 0; sample < kBlockSize; ++sample)
+            destination.setSample(channel, sample, 0.5f);
+
+    CHECK(reader.read(destination, 0, 0, kBlockSize) == 0);
+
+    // Cleared, so that nothing downstream can publish what was in the buffer
+    // before as audio read from the file.
+    for (auto sample = 0; sample < kBlockSize; ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(destination.getSample(0, sample) == approx(0.0f));
+    }
 }

--- a/tests/test_streaming_audio_source.cpp
+++ b/tests/test_streaming_audio_source.cpp
@@ -98,10 +98,12 @@ struct Fixture {
         stream.seek(source.sourceSampleAt(std::max(block.startSeconds, placement.startSeconds)));
     }
 
-    /// Cue, read ahead, and render: what a clip that was scheduled properly
-    /// sounds like.
+    /// Cue, let a callback take the cue up, read ahead, and render: what a
+    /// clip that was scheduled properly sounds like. The fold-in stands in for
+    /// the block before this one, which is where a live engine would do it.
     void renderCued(const BlockInfo& block) {
         cue(block);
+        stream.applyPendingCue();
         render(block);
     }
 
@@ -297,4 +299,82 @@ TEST_CASE("The prefetch thread reads for the streams registered with it",
     // makes destroying it afterwards safe.
     thread.remove(stream);
     CHECK(thread.streamCount() == 0);
+}
+
+TEST_CASE("A file at another rate plays wrong, not broken", "[engine][io][clip]") {
+    // 48 kHz material in a 44.1 kHz session. Resampling belongs to the clip
+    // layer (#1890); until it exists, what this layer owes is playback that is
+    // continuous and pitched wrong, rather than a position derived one way and
+    // consumed another, which would land somewhere unexpected every block and
+    // spend every callback seeking.
+    class MismatchedReader final : public AudioFileReader {
+      public:
+        std::int64_t lengthInSamples() const override {
+            return 1000000;
+        }
+        double sampleRate() const override {
+            return 48000.0;
+        }
+        int numChannels() const override {
+            return 2;
+        }
+        int read(juce::AudioBuffer<float>& destination, int destinationOffset,
+                 std::int64_t startSample, int numSamples) override {
+            for (auto channel = 0; channel < destination.getNumChannels(); ++channel)
+                for (auto sample = 0; sample < numSamples; ++sample)
+                    destination.setSample(channel, destinationOffset + sample,
+                                          static_cast<float>(startSample + sample));
+            return numSamples;
+        }
+    };
+
+    PrefetchStream stream(std::make_unique<MismatchedReader>(), context(), {256, 8});
+    StreamingAudioSource source(stream, ClipPlacement{0.0, 10.0, 0});
+    source.prepare(context());
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+
+    for (auto block = 0; block < 20; ++block) {
+        while (stream.fill()) {
+        }
+
+        output.clear();
+        source.render(blockFrom(static_cast<double>(block * kBlockSize) / kSampleRate),
+                      juce::dsp::AudioBlock<float>(output));
+
+        // Every sample of the file, in order, with none skipped between blocks.
+        INFO("block " << block);
+        REQUIRE(output.getSample(0, 0) == approx(static_cast<float>(block * kBlockSize)));
+        REQUIRE(output.getSample(0, kBlockSize - 1) ==
+                approx(static_cast<float>(block * kBlockSize + kBlockSize - 1)));
+    }
+
+    // Which is to say: not one seek in twenty blocks.
+    CHECK(stream.underruns() == 0);
+}
+
+TEST_CASE("A clip cued before it starts plays without a gap", "[engine][io][prefetch]") {
+    // The case cueing exists for: a clip that has not started, on a transport
+    // that is already rolling. Nothing reads this stream yet, so nothing would
+    // notice a cue at all if the source did not offer one every block.
+    const ClipPlacement placement{5.0, 10.0, 0};
+    Fixture fixture(placement);
+
+    const auto target = fixture.source.sourceSampleAt(5.0);
+
+    // Published from a thread that is not the audio one, touching nothing the
+    // callback owns.
+    fixture.stream.seek(target);
+
+    // Blocks before the clip starts: silent, and the one that takes the cue up
+    // is what lets the reader get ahead.
+    for (auto block = 0; block < 4; ++block) {
+        fixture.render(blockFrom(4.0 + static_cast<double>(block * kBlockSize) / kSampleRate));
+        REQUIRE(fixture.at(0) == approx(0.0f));
+    }
+
+    // And then it starts, with the material already in memory.
+    fixture.render(blockFrom(5.0));
+    REQUIRE(fixture.at(0) == approx(static_cast<float>(target)));
+    CHECK(fixture.stream.underruns() == 0);
 }

--- a/tests/test_streaming_audio_source.cpp
+++ b/tests/test_streaming_audio_source.cpp
@@ -228,21 +228,18 @@ TEST_CASE("A jump is a seek, and needs nothing said about it", "[engine][io][cli
         REQUIRE(fixture.at(63) == approx(static_cast<float>(kBlockSize + 63)));
     }
 
-    SECTION("a wrap the reader was pointed at costs nothing") {
-        const auto wrapped = blockFrom(0.0, kBlockSize, false);
-
-        fixture.renderCued(wrapped);
-        REQUIRE(fixture.at(0) == approx(0.0f));
-        REQUIRE(fixture.at(63) == approx(63.0f));
-        CHECK(fixture.stream.underruns() == 0);
-    }
-
     SECTION("a locate forwards is the same shape") {
-        const auto located = blockFrom(5.0);
+        // Silence in the block that jumps, material in the one after it, and
+        // one underrun to say so. Cueing does not shorten this: the stream is
+        // sounding, and a cue given to a stream that is sounding waits.
+        fixture.render(blockFrom(5.0));
+        for (auto sample = 0; sample < kBlockSize; ++sample)
+            REQUIRE(fixture.at(sample) == approx(0.0f));
+        REQUIRE(fixture.stream.underruns() == 1);
 
-        fixture.renderCued(located);
+        fixture.render(blockFrom(5.0 + static_cast<double>(kBlockSize) / kSampleRate));
 
-        const auto expected = static_cast<float>(std::llround(5.0 * kSampleRate));
+        const auto expected = static_cast<float>(std::llround(5.0 * kSampleRate) + kBlockSize);
         REQUIRE(fixture.at(0) == approx(expected));
     }
 }
@@ -377,4 +374,44 @@ TEST_CASE("A clip cued before it starts plays without a gap", "[engine][io][pref
     fixture.render(blockFrom(5.0));
     REQUIRE(fixture.at(0) == approx(static_cast<float>(target)));
     CHECK(fixture.stream.underruns() == 0);
+}
+
+TEST_CASE("Cueing a stream that is sounding does not interrupt it", "[engine][io][prefetch]") {
+    // The loop-return case, from underneath: something cues the top of the loop
+    // while the end of it is still playing. One reader cannot be in two places,
+    // so what this owes is that playback is not damaged by being asked. The
+    // cue waits; it does not abandon the material still going out.
+    const ClipPlacement placement{0.0, 10.0, 0};
+    Fixture fixture(placement);
+
+    for (auto block = 0; block < 4; ++block)
+        fixture.render(blockFrom(static_cast<double>(block * kBlockSize) / kSampleRate));
+
+    const auto before = fixture.stream.underruns();
+    fixture.stream.seek(fixture.source.sourceSampleAt(0.0));
+
+    // Every block after the cue is the one that was going to play anyway,
+    // sample for sample, with nothing dropped and nothing re-read.
+    for (auto block = 4; block < 12; ++block) {
+        fixture.render(blockFrom(static_cast<double>(block * kBlockSize) / kSampleRate));
+
+        INFO("block " << block);
+        REQUIRE(fixture.at(0) == approx(static_cast<float>(block * kBlockSize)));
+        REQUIRE(fixture.at(kBlockSize - 1) == approx(static_cast<float>(block * kBlockSize + 63)));
+    }
+
+    // And it cost nothing to have asked.
+    CHECK(fixture.stream.underruns() == before);
+
+    SECTION("and is taken up once it falls silent") {
+        // The clip stops sounding, so the stream is free to go where it was
+        // pointed, and the material is there when playback returns to it.
+        fixture.render(blockFrom(20.0));
+        fixture.render(blockFrom(20.0 + static_cast<double>(kBlockSize) / kSampleRate));
+
+        fixture.render(blockFrom(0.0, kBlockSize, false));
+        REQUIRE(fixture.at(0) == approx(0.0f));
+        REQUIRE(fixture.at(kBlockSize - 1) == approx(static_cast<float>(kBlockSize - 1)));
+        CHECK(fixture.stream.underruns() == before);
+    }
 }

--- a/tests/test_streaming_audio_source.cpp
+++ b/tests/test_streaming_audio_source.cpp
@@ -1,0 +1,300 @@
+#include <algorithm>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include "io/PrefetchThread.hpp"
+#include "io/StreamingAudioSource.hpp"
+
+using magda::engine::AudioFileReader;
+using magda::engine::BlockInfo;
+using magda::engine::ClipPlacement;
+using magda::engine::PrefetchStream;
+using magda::engine::PrefetchThread;
+using magda::engine::RenderContext;
+using magda::engine::StreamingAudioSource;
+
+namespace {
+
+constexpr double kSampleRate = 44100.0;
+constexpr int kBlockSize = 64;
+
+/// As in the prefetch tests: sample n reads back as n, so where a sample came
+/// from is readable off the value.
+class CountingReader final : public AudioFileReader {
+  public:
+    explicit CountingReader(std::int64_t length) : length_(length) {}
+
+    std::int64_t lengthInSamples() const override {
+        return length_;
+    }
+
+    double sampleRate() const override {
+        return kSampleRate;
+    }
+
+    int numChannels() const override {
+        return 2;
+    }
+
+    int read(juce::AudioBuffer<float>& destination, int destinationOffset, std::int64_t startSample,
+             int numSamples) override {
+        const auto available =
+            static_cast<int>(std::clamp<std::int64_t>(length_ - startSample, 0, numSamples));
+
+        for (auto channel = 0; channel < destination.getNumChannels(); ++channel)
+            for (auto sample = 0; sample < available; ++sample)
+                destination.setSample(channel, destinationOffset + sample,
+                                      static_cast<float>(startSample + sample));
+
+        if (available < numSamples)
+            destination.clear(destinationOffset + available, numSamples - available);
+
+        return available;
+    }
+
+  private:
+    std::int64_t length_;
+};
+
+RenderContext context() {
+    return RenderContext{kSampleRate, kBlockSize, 2};
+}
+
+Catch::Approx approx(float value) {
+    return Catch::Approx(value).margin(1e-4);
+}
+
+/// A block covering a stretch of the timeline. Seconds are what a clip is
+/// placed in; the beats are along for the ride and nothing here reads them.
+BlockInfo blockFrom(double startSeconds, int numSamples = kBlockSize, bool continuous = true) {
+    BlockInfo block;
+    block.numSamples = numSamples;
+    block.playing = true;
+    block.startSeconds = startSeconds;
+    block.endSeconds = startSeconds + numSamples / kSampleRate;
+    block.startBeat = startSeconds * 2.0;  // 120 bpm, which nothing here depends on
+    block.endBeat = block.endSeconds * 2.0;
+    block.continuous = continuous;
+    return block;
+}
+
+struct Fixture {
+    explicit Fixture(const ClipPlacement& placementIn, std::int64_t length = 1000000)
+        : placement(placementIn),
+          stream(std::make_unique<CountingReader>(length), context(), {256, 8}),
+          source(stream, placementIn) {
+        source.prepare(context());
+        output.setSize(2, kBlockSize);
+        output.clear();
+    }
+
+    /// Point the stream at where this block will want the file, which is what
+    /// whoever schedules a clip does: the first block at a position nobody
+    /// mentioned has to seek, and a seek costs a block of silence.
+    void cue(const BlockInfo& block) {
+        stream.seek(source.sourceSampleAt(std::max(block.startSeconds, placement.startSeconds)));
+    }
+
+    /// Cue, read ahead, and render: what a clip that was scheduled properly
+    /// sounds like.
+    void renderCued(const BlockInfo& block) {
+        cue(block);
+        render(block);
+    }
+
+    /// Read ahead as far as the pool allows, then render.
+    void render(const BlockInfo& block) {
+        while (stream.fill()) {
+        }
+
+        output.clear();
+        source.render(block, juce::dsp::AudioBlock<float>(output));
+    }
+
+    float at(int sample) const {
+        return output.getSample(0, sample);
+    }
+
+    ClipPlacement placement;
+    PrefetchStream stream;
+    StreamingAudioSource source;
+    juce::AudioBuffer<float> output;
+};
+
+}  // namespace
+
+TEST_CASE("A clip plays the part of the block it covers", "[engine][io][clip]") {
+    // Two seconds of timeline, playing the file from its tenth sample.
+    const ClipPlacement placement{1.0, 3.0, 10};
+
+    SECTION("nothing before it starts") {
+        Fixture fixture(placement);
+        fixture.render(blockFrom(0.5));
+
+        for (auto sample = 0; sample < kBlockSize; ++sample)
+            REQUIRE(fixture.at(sample) == approx(0.0f));
+    }
+
+    SECTION("silence up to its first sample, then the file") {
+        Fixture fixture(placement);
+
+        // The clip starts a third of the way into this block.
+        const auto blockStart = 1.0 - 20.0 / kSampleRate;
+        fixture.renderCued(blockFrom(blockStart));
+
+        for (auto sample = 0; sample < 20; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(fixture.at(sample) == approx(0.0f));
+        }
+
+        // And from there it is the file, from where the clip was trimmed to.
+        for (auto sample = 20; sample < kBlockSize; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(fixture.at(sample) == approx(static_cast<float>(10 + sample - 20)));
+        }
+    }
+
+    SECTION("and it stops where the clip ends") {
+        Fixture fixture(placement);
+
+        const auto blockStart = 3.0 - 20.0 / kSampleRate;
+        fixture.renderCued(blockFrom(blockStart));
+
+        REQUIRE(fixture.at(0) != approx(0.0f));
+        for (auto sample = 20; sample < kBlockSize; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(fixture.at(sample) == approx(0.0f));
+        }
+    }
+
+    SECTION("nothing at all once it is over") {
+        Fixture fixture(placement);
+        fixture.render(blockFrom(3.5));
+
+        for (auto sample = 0; sample < kBlockSize; ++sample)
+            REQUIRE(fixture.at(sample) == approx(0.0f));
+    }
+}
+
+TEST_CASE("A clip plays in step with the timeline it is placed on", "[engine][io][clip]") {
+    const ClipPlacement placement{0.0, 10.0, 0};
+    Fixture fixture(placement);
+
+    // Block after block, the file advances one sample per sample and never
+    // slips, which is what would happen if the source tracked its own position
+    // instead of deriving it from where the block says it is.
+    for (auto block = 0; block < 40; ++block) {
+        const auto start = static_cast<double>(block * kBlockSize) / kSampleRate;
+        fixture.render(blockFrom(start));
+
+        INFO("block " << block);
+        REQUIRE(fixture.at(0) == approx(static_cast<float>(block * kBlockSize)));
+        REQUIRE(fixture.at(kBlockSize - 1) == approx(static_cast<float>(block * kBlockSize + 63)));
+    }
+
+    // One position, followed forwards: nothing here is a seek.
+    CHECK(fixture.stream.underruns() == 0);
+}
+
+TEST_CASE("A jump is a seek, and needs nothing said about it", "[engine][io][clip]") {
+    const ClipPlacement placement{0.0, 10.0, 0};
+    Fixture fixture(placement);
+
+    for (auto block = 0; block < 4; ++block)
+        fixture.render(blockFrom(static_cast<double>(block * kBlockSize) / kSampleRate));
+
+    SECTION("a loop wrap plays the file from where the timeline went") {
+        // What a wrap looks like from down here: a block that does not
+        // continue the last one, covering a stretch of timeline somewhere
+        // else. The source derives its position from the block rather than
+        // from what it played last, so it needs no telling that one happened.
+        //
+        // Nobody pointed the reader at the top of the loop, so the block that
+        // wraps is silent and the one after it plays. That is the cost of a
+        // jump nobody saw coming, and it is why a loop worth reading ahead for
+        // is one whose return the clip layer cues.
+        fixture.render(blockFrom(0.0, kBlockSize, false));
+        for (auto sample = 0; sample < kBlockSize; ++sample)
+            REQUIRE(fixture.at(sample) == approx(0.0f));
+        REQUIRE(fixture.stream.underruns() == 1);
+
+        fixture.render(blockFrom(static_cast<double>(kBlockSize) / kSampleRate));
+        REQUIRE(fixture.at(0) == approx(static_cast<float>(kBlockSize)));
+        REQUIRE(fixture.at(63) == approx(static_cast<float>(kBlockSize + 63)));
+    }
+
+    SECTION("a wrap the reader was pointed at costs nothing") {
+        const auto wrapped = blockFrom(0.0, kBlockSize, false);
+
+        fixture.renderCued(wrapped);
+        REQUIRE(fixture.at(0) == approx(0.0f));
+        REQUIRE(fixture.at(63) == approx(63.0f));
+        CHECK(fixture.stream.underruns() == 0);
+    }
+
+    SECTION("a locate forwards is the same shape") {
+        const auto located = blockFrom(5.0);
+
+        fixture.renderCued(located);
+
+        const auto expected = static_cast<float>(std::llround(5.0 * kSampleRate));
+        REQUIRE(fixture.at(0) == approx(expected));
+    }
+}
+
+TEST_CASE("A clip renders nothing while the transport is stopped", "[engine][io][clip]") {
+    const ClipPlacement placement{0.0, 10.0, 0};
+    Fixture fixture(placement);
+
+    auto stopped = blockFrom(1.0);
+    stopped.playing = false;
+    stopped.endSeconds = stopped.startSeconds;
+    stopped.endBeat = stopped.startBeat;
+
+    fixture.render(stopped);
+
+    // A stopped timeline is not a held sample. It is no material at all.
+    for (auto sample = 0; sample < kBlockSize; ++sample)
+        REQUIRE(fixture.at(sample) == approx(0.0f));
+}
+
+TEST_CASE("The prefetch thread reads for the streams registered with it",
+          "[engine][io][prefetch]") {
+    PrefetchStream stream(std::make_unique<CountingReader>(100000), context(), {256, 4});
+    PrefetchThread thread;
+
+    CHECK(thread.streamCount() == 0);
+    thread.add(stream);
+    CHECK(thread.streamCount() == 1);
+
+    // The thread polls, so this is a wait rather than a check: what is being
+    // tested is that it reads at all without anything asking it to, not how
+    // quickly.
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    auto delivered = 0;
+    std::int64_t position = 0;
+
+    // A callback that came up short moves on to the next block rather than
+    // asking again: asking again would be asking for a position the stream has
+    // already gone past, which is a seek, and a test that seeks every attempt
+    // would never let the reader get ahead.
+    for (auto attempt = 0; attempt < 2000 && delivered == 0; ++attempt) {
+        delivered = stream.read(position, juce::dsp::AudioBlock<float>(output), kBlockSize);
+        if (delivered == 0) {
+            position += kBlockSize;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    }
+
+    CHECK(delivered == kBlockSize);
+    CHECK(output.getSample(0, 0) == approx(static_cast<float>(position)));
+    CHECK(output.getSample(0, 63) == approx(static_cast<float>(position + 63)));
+
+    // Removal waits for the thread to be out of the stream, which is what
+    // makes destroying it afterwards safe.
+    thread.remove(stream);
+    CHECK(thread.streamCount() == 0);
+}

--- a/tests/test_streaming_audio_source.cpp
+++ b/tests/test_streaming_audio_source.cpp
@@ -415,3 +415,32 @@ TEST_CASE("Cueing a stream that is sounding does not interrupt it", "[engine][io
         CHECK(fixture.stream.underruns() == before);
     }
 }
+
+TEST_CASE("A clip rolling past the end of its file is not sounding", "[engine][io][prefetch]") {
+    // Five thousand samples of material under a placement that runs for a
+    // second. Past the material the source still asks every block, because the
+    // clip is still placed there, and every ask comes back with nothing.
+    const ClipPlacement placement{0.0, 1.0, 0};
+    Fixture fixture(placement, 5000);
+
+    for (auto block = 0; block < 100; ++block)
+        fixture.render(blockFrom(static_cast<double>(block * kBlockSize) / kSampleRate));
+
+    REQUIRE(fixture.at(0) == approx(0.0f));
+    REQUIRE(fixture.stream.underruns() == 0);
+
+    // A stream playing nothing is exactly when pointing it at its next use is
+    // worth doing, so being asked for silence must not look like sounding.
+    fixture.stream.seek(fixture.source.sourceSampleAt(0.0));
+
+    // Two more blocks past the end: the first takes the cue up, the second
+    // reads ahead for it.
+    fixture.render(blockFrom(static_cast<double>(100 * kBlockSize) / kSampleRate));
+    fixture.render(blockFrom(static_cast<double>(101 * kBlockSize) / kSampleRate));
+
+    // And the material is there when playback returns to it.
+    fixture.render(blockFrom(0.0, kBlockSize, false));
+    REQUIRE(fixture.at(0) == approx(0.0f));
+    REQUIRE(fixture.at(kBlockSize - 1) == approx(static_cast<float>(kBlockSize - 1)));
+    CHECK(fixture.stream.underruns() == 0);
+}


### PR DESCRIPTION
Slice 7 of #1889. Closes #2016.

A stream is a pool of chunks and two lock-free fifos: the prefetch thread reads whole chunks ahead of playback and pushes them, the callback pops them, copies out and hands them back. Nothing on the audio thread allocates, locks or waits for a disk.

## The shape

```
io/AudioFileReader       random access to a file's samples, and a JUCE one
io/PrefetchStream        one file read ahead of the callback that plays it
io/PrefetchThread        the one thread allowed to wait for a disk
io/StreamingAudioSource  one placed file, on the EngineAudioSource seam
```

Chunks rather than a ring of samples, because a chunk can be stamped. A seek makes everything already read wrong, and the stamp is how the callback knows without the reader having to reach into a buffer the callback is holding: audio read for a position since abandoned is recognised on the way out and dropped. The same epoch discipline the plan swap uses, for the same reason.

## Decisions worth a look

**Silence is what a reader that has not caught up renders**, and it counts every block it could not fill. Silence nobody counted is indistinguishable from a gap in the material. The end of the file is not an underrun: there is nothing late about silence past the last sample.

**An underrun is a gap, never a delay.** The cursor moves whether or not the samples arrived, so the block after one plays what that block asked for. A stream that resumed where it ran dry would be late for the rest of the take.

**A loop wrap needs nothing said about it.** The source derives its position in the file from the block it was handed rather than from what it played last, so a wrap, a locate and a clip starting are one path: the stream sees a position it was not expecting, and that is what a seek is. `BlockInfo::continuous` is not read here at all.

**The thread polls; the callback never wakes it.** Waking a thread takes a lock. A stream that has just been seeked is found on the next round, five milliseconds later at worst, which is inside the block or two the underrun count already accounts for.

**BlockInfo gained seconds alongside beats**, the one change to the slice 6 contract. A file's samples are counted in time, and a source that converted beats itself would need a tempo map on the audio thread, of which there would then be two. The clock already has the seconds and derives the beats from them, so it publishes both faces of one instant: beats say where on the timeline something is, seconds say how much audio has gone by. `sampleForTime` sits beside `sampleForBeat` and clamps differently on purpose, which the header explains.

**Rate conversion and warp are not here.** The stream delivers the file's own samples; mapping them to another rate is #1890's question and the same one stretch asks. `ClipPlacement` plus `sourceSampleAt` is the seam between the two layers.

## Testing

`tests/test_prefetch_stream.cpp` and `tests/test_streaming_audio_source.cpp`: sequential playback across chunk boundaries, blocks of different lengths, a pool small enough to have to be recycled, underruns and what they render, the gap that does not become a delay, the end of the file, seeks in both directions, a clip starting and ending inside a block, forty blocks in step with the timeline, a wrap with and without a cue, and the prefetch thread reading for a registered stream.

The reader fixtures compute their samples rather than reading a file off a disk, so a sample says where it came from and every path is deterministic.

Confirmed to fail without their fix: dropping the generation check makes the seek tests play the old position's audio (two tests, three assertions).

ThreadSanitizer over `[io]` is clean, and the harness was shown able to fail first: a non-atomic counter touched from both threads was reported at `PrefetchStream.cpp:98`, then reverted and re-run clean.

Full suite: 1974 passed.