### PR TITLE
Native engine: offline render and tap ops (#2017)

### DIFF
--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(magda_engine STATIC
     exec/PlanValues.cpp
     exec/RuntimeStateStore.cpp
     exec/EngineSession.cpp
+    exec/OfflineRender.cpp
     exec/PlanExecutor.hpp
     exec/PlanLayout.hpp
     exec/PlanValues.hpp
@@ -29,6 +30,9 @@ add_library(magda_engine STATIC
     exec/RenderContext.hpp
     exec/RuntimeStateStore.hpp
     exec/EngineSession.hpp
+    exec/OfflineRender.hpp
+    tap/LevelTap.hpp
+    tap/SampleRing.hpp
     transport/TempoMap.cpp
     transport/TransportClock.cpp
     transport/ClickGenerator.cpp
@@ -40,10 +44,13 @@ add_library(magda_engine STATIC
     io/PrefetchStream.cpp
     io/PrefetchThread.cpp
     io/StreamingAudioSource.cpp
+    io/FileAudioSource.cpp
     io/AudioFileReader.hpp
+    io/ClipPlacement.hpp
     io/PrefetchStream.hpp
     io/PrefetchThread.hpp
     io/StreamingAudioSource.hpp
+    io/FileAudioSource.hpp
 )
 add_library(magda::engine ALIAS magda_engine)
 
@@ -91,7 +98,7 @@ endforeach()
 # Engine. Quoted includes may only reach the model layer ("core/...") or the
 # engine's own headers.
 
-set(MAGDA_ENGINE_ALLOWED_QUOTED_PREFIXES "core/" "plan/" "exec/" "transport/" "io/")
+set(MAGDA_ENGINE_ALLOWED_QUOTED_PREFIXES "core/" "plan/" "exec/" "transport/" "io/" "tap/")
 
 file(GLOB_RECURSE MAGDA_ENGINE_SOURCES CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"

--- a/magda/engine/exec/OfflineRender.cpp
+++ b/magda/engine/exec/OfflineRender.cpp
@@ -1,0 +1,128 @@
+#include "exec/OfflineRender.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "transport/TransportState.hpp"
+
+namespace magda::engine {
+namespace {
+
+std::int64_t samplesBetween(double startSeconds, double endSeconds, double sampleRate) {
+    if (endSeconds <= startSeconds)
+        return 0;
+    return static_cast<std::int64_t>(std::llround((endSeconds - startSeconds) * sampleRate));
+}
+
+}  // namespace
+
+OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& values,
+                                  const RenderContext& context, const TempoMap& tempo,
+                                  const OfflineRenderRequest& request, OfflineRenderSink& sink,
+                                  const std::function<bool()>& shouldContinue) {
+    OfflineRenderResult result;
+
+    if (!executor.isPrepared() || !executor.appliesValues(values)) {
+        result.refused = true;
+        return result;
+    }
+
+    // Held to what the plan was prepared for, the way a callback is: the
+    // executor asserts on a longer block, and here the same number also says
+    // how much buffer there is to render into.
+    const auto blockSize = std::clamp(request.blockSize, 1, context.maxBlockSize);
+
+    // How long the range is, asked once. Deriving the length up front rather
+    // than watching the cursor cross the end is what keeps the answer the same
+    // at every block size: the last block is cut to land exactly on it, and no
+    // block's length depends on how the ones before it were cut.
+    const auto rangeSamples = samplesBetween(tempo.beatToTime(request.startBeat),
+                                             tempo.beatToTime(request.endBeat), context.sampleRate);
+    const auto tailSamples =
+        request.tailSeconds > 0.0
+            ? static_cast<std::int64_t>(std::llround(request.tailSeconds * context.sampleRate))
+            : 0;
+
+    juce::AudioBuffer<float> buffer(context.numChannels, blockSize);
+
+    // The clock playback uses, driven by a request nobody typed. It is what
+    // makes the cursor a function of the sample count rather than a sum of
+    // per-block steps, which is the whole of why this renders the same at any
+    // block size.
+    TransportClock clock;
+
+    TransportSnapshot snapshot;
+    snapshot.tempo = tempo;
+
+    // Both left off, and named here rather than left to the defaults, because
+    // both would be wrong in a way that is hard to hear until it has shipped. A
+    // loop would print the range twice into a bounce that asked for it once,
+    // and the metronome is not the graph's to begin with: it is summed after
+    // the plan during playback and is not summed at all here.
+    snapshot.loop = {};
+    snapshot.click = {};
+
+    // Generation one, because the clock starts at zero and applies the first
+    // request it has not seen. A count-in is a monitoring aid and would print
+    // the beats before the range into the render.
+    snapshot.request.generation = 1;
+    snapshot.request.playing = true;
+    snapshot.request.locate = true;
+    snapshot.request.positionBeat = request.startBeat;
+    snapshot.request.countInBeats = 0.0;
+
+    const auto renderSpan = [&](std::int64_t samples) {
+        while (samples > 0) {
+            if (shouldContinue && !shouldContinue()) {
+                result.cancelled = true;
+                return;
+            }
+
+            const auto numSamples = static_cast<int>(std::min<std::int64_t>(samples, blockSize));
+
+            // Cleared here rather than by the executor, exactly as a callback
+            // clears it: the Output op sums into what it is handed, so what a
+            // plan with nothing routed to the output renders is silence only if
+            // silence is what was already there.
+            buffer.clear();
+
+            for (const auto& segment : clock.advance(snapshot, context.sampleRate, numSamples)) {
+                juce::AudioBuffer<float> piece(buffer.getArrayOfWritePointers(),
+                                               buffer.getNumChannels(), segment.startSample,
+                                               segment.block.numSamples);
+                executor.process(values, segment.block, piece);
+            }
+
+            sink.write(buffer, numSamples);
+
+            result.samplesRendered += numSamples;
+            ++result.blocksRendered;
+            samples -= numSamples;
+        }
+    };
+
+    renderSpan(rangeSamples);
+
+    if (result.cancelled || tailSamples <= 0)
+        return result;
+
+    // The tail, with the transport stopped where the range ended. A stopped
+    // block is already defined as one the graph runs through without the
+    // timeline moving, so reverbs and delays ring out and nothing that comes
+    // after the range starts playing.
+    //
+    // It is exactly as long as it was asked for. Stopping at the first silent
+    // block would be shorter and would sometimes be wrong: a gated or tremolo'd
+    // tail goes fully silent in the middle and would be cut off there. The
+    // caller has the samples and can trim what it does not want, which is a
+    // decision it can make and this cannot.
+    snapshot.request.generation = 2;
+    snapshot.request.playing = false;
+    snapshot.request.locate = false;
+
+    renderSpan(tailSamples);
+
+    return result;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/exec/OfflineRender.cpp
+++ b/magda/engine/exec/OfflineRender.cpp
@@ -22,7 +22,16 @@ OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& valu
                                   const std::function<bool()>& shouldContinue) {
     OfflineRenderResult result;
 
-    if (!executor.isPrepared() || !executor.appliesValues(values)) {
+    // The context is refused on the same grounds the values are, and for the
+    // same reason: what the executor does with either when they do not belong
+    // to it is render something plausible and say nothing. Blocks are sized and
+    // the clock is advanced from the argument, while process() renders at most
+    // what it was prepared for, so a longer maxBlockSize prints the head of
+    // every block and silence for the rest. A sample rate that disagrees puts
+    // the whole render at the wrong speed, and a channel count that does at the
+    // wrong width.
+    if (!executor.isPrepared() || !executor.appliesValues(values) ||
+        !(executor.preparedContext() == context)) {
         result.refused = true;
         return result;
     }
@@ -80,10 +89,11 @@ OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& valu
 
             const auto numSamples = static_cast<int>(std::min<std::int64_t>(samples, blockSize));
 
-            // Cleared here rather than by the executor, exactly as a callback
-            // clears it: the Output op sums into what it is handed, so what a
-            // plan with nothing routed to the output renders is silence only if
-            // silence is what was already there.
+            // The executor clears each piece it is handed, so this covers only
+            // what no piece reaches. Nothing should qualify, because a callback
+            // with samples in it always yields at least one segment, and the
+            // cost of being wrong about that is the previous block printed
+            // twice into a file.
             buffer.clear();
 
             for (const auto& segment : clock.advance(snapshot, context.sampleRate, numSamples)) {

--- a/magda/engine/exec/OfflineRender.cpp
+++ b/magda/engine/exec/OfflineRender.cpp
@@ -101,6 +101,15 @@ OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& valu
         }
     };
 
+    // Applied before anything renders rather than by the first block, because a
+    // range that rounds to no samples renders no blocks and would leave the
+    // locate unapplied: the tail below would then stand at beat zero, where the
+    // clock starts, instead of where the range ended. A zero-length advance
+    // takes the request and does nothing else, and for a range that does render
+    // it changes nothing, because the first real block would have applied the
+    // same request a moment later.
+    clock.advance(snapshot, context.sampleRate, 0);
+
     renderSpan(rangeSamples);
 
     if (result.cancelled || tailSamples <= 0)

--- a/magda/engine/exec/OfflineRender.hpp
+++ b/magda/engine/exec/OfflineRender.hpp
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include <cstdint>
+#include <functional>
+
+#include "exec/PlanExecutor.hpp"
+#include "exec/PlanValues.hpp"
+#include "exec/RenderContext.hpp"
+#include "transport/TempoMap.hpp"
+#include "transport/TransportClock.hpp"
+
+/**
+ * @file OfflineRender.hpp
+ * @brief The same plan, pulled by something that is not an audio device.
+ *
+ * Bounce, freeze and the null-diff harness are one question: render this
+ * stretch of the timeline as fast as the machine will do it. Nothing about the
+ * plan changes for it. The executor, the ops and the transport are the ones
+ * playback uses, and that is the whole point: a harness that rendered through a
+ * second implementation would prove things about the second implementation.
+ *
+ * What differs is who is pulling. There is no callback to be late for, so a
+ * source may wait for a disk (io/FileAudioSource), nothing counts an underrun,
+ * and the block size is a batching choice rather than a property of a device.
+ * Output must not depend on it, and there is a test that says so.
+ */
+
+namespace magda::engine {
+
+/** What to render, and how much of the machine to hand it. */
+struct OfflineRenderRequest {
+    /// The stretch of timeline to render, in beats, half-open. Beats because
+    /// that is what the model positions things in: a bounce of bars one to nine
+    /// is a beat range, and what it is worth in seconds is the tempo map's
+    /// answer rather than the caller's.
+    double startBeat = 0.0;
+    double endBeat = 0.0;
+
+    /**
+     * @brief How long to keep rendering after the range, for tails.
+     *
+     * In seconds, because a reverb tail is a duration and not a musical length:
+     * it does not get shorter when the tempo goes up.
+     *
+     * Rendered with the transport stopped, which is already what the engine
+     * means by a stopped block: the graph keeps running so tails ring out, and
+     * the cursor stands still. Standing still is what makes it a tail rather
+     * than more of the song, because a cursor that kept moving would start
+     * whatever clip comes after the range and print it into the bounce.
+     */
+    double tailSeconds = 0.0;
+
+    /// How much timeline to ask the executor for at a time. A pure batching
+    /// choice: the render is sample-identical at any value, and larger is only
+    /// faster. Held to what the plan was prepared for.
+    int blockSize = 512;
+};
+
+/** What came of a render. */
+struct OfflineRenderResult {
+    /// Samples handed to the sink, tail included.
+    std::int64_t samplesRendered = 0;
+
+    /// Blocks the sink was called with.
+    int blocksRendered = 0;
+
+    /// True when the caller's shouldContinue said to stop. What was already
+    /// written stays written: an abandoned bounce is a short file, not a
+    /// corrupt one, and the caller is the one that knows which of those it
+    /// wants to keep.
+    bool cancelled = false;
+
+    /**
+     * @brief Nothing was rendered, and not because the range was empty.
+     *
+     * The executor was not prepared, or the values do not belong to the plan it
+     * was prepared with. Refused rather than rendered, for the reason a publish
+     * refuses the same thing: what the executor does with values it cannot
+     * apply is render at unity, so the alternative is a bounce with every fader
+     * at 0 dB and nothing anywhere saying why.
+     */
+    bool refused = false;
+};
+
+/**
+ * @brief Where an offline render's audio goes.
+ *
+ * A block at a time rather than one buffer for the whole range, because the
+ * range can be an hour long and a caller writing a file has no reason to hold
+ * it. The buffer is the renderer's and is reused: a sink that wants to keep the
+ * audio copies it.
+ */
+class OfflineRenderSink {
+  public:
+    virtual ~OfflineRenderSink() = default;
+
+    /// Off the audio thread, so a sink may write a file, allocate and block.
+    virtual void write(const juce::AudioBuffer<float>& block, int numSamples) = 0;
+};
+
+/**
+ * @brief Render @p request through @p executor into @p sink.
+ *
+ * The executor has to be prepared already, for @p context, with the devices and
+ * sources the render should use. Preparing it is the caller's because the
+ * choices are the caller's: a bounce at 96 kHz of a session running at 44.1 is
+ * a different context and therefore different device state, and a freeze of one
+ * track is a different plan.
+ *
+ * @p tempo is the map the range is resolved through and the one the ops see. It
+ * does not change during a render: an offline render is one pass over a
+ * timeline whose tempo track is whatever it was when the render started.
+ *
+ * @p shouldContinue is asked once per block and may be empty. A render of a
+ * long range is the one thing in the engine a user is left waiting for, so it
+ * is interruptible from the start rather than once someone complains.
+ *
+ * The metronome is not rendered. It is not in the graph, it is never recorded,
+ * and a click printed into a bounce is the oldest bug in audio software.
+ */
+OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& values,
+                                  const RenderContext& context, const TempoMap& tempo,
+                                  const OfflineRenderRequest& request, OfflineRenderSink& sink,
+                                  const std::function<bool()>& shouldContinue = {});
+
+}  // namespace magda::engine

--- a/magda/engine/exec/PlanBindings.hpp
+++ b/magda/engine/exec/PlanBindings.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <map>
 #include <unordered_map>
 
 #include "core/TypeIds.hpp"
 #include "exec/EngineDevice.hpp"
+#include "plan/RenderPlan.hpp"
+#include "tap/LevelTap.hpp"
 
 namespace magda::engine {
 
@@ -28,6 +31,26 @@ struct PlanBindings {
     /// Live hardware input feeding a track (AudioInput / MidiInput ops).
     std::unordered_map<TrackId, EngineAudioSource*> audioInputs;
     std::unordered_map<TrackId, EngineMidiSource*> midiInputs;
+
+    /**
+     * @brief Where each Meter op publishes its level.
+     *
+     * Keyed by the whole OpKey rather than by model ID, because a device's
+     * meter and the device itself share a DeviceId and differ only in their
+     * role. It is the one binding whose key is the op's rather than the
+     * model's, which is what a tap is: a place in the signal rather than a
+     * thing in the project.
+     *
+     * Ordered rather than hashed because OpKey already compares and nothing
+     * here is on the audio thread: prepare() resolves these into a flat per-op
+     * table and the maps are never touched again.
+     *
+     * A Meter op with nothing bound is a meter nobody is reading, which is not
+     * an error and is not reported as one. Offline render binds none of these,
+     * and a plan compiled for a project whose mixer is not on screen binds only
+     * what is.
+     */
+    std::map<OpKey, LevelTap*> meters;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -31,16 +31,6 @@ void applyGain(juce::dsp::AudioBlock<float> block, const OpValue& value, int num
                                               numSamples);
 }
 
-float peakOf(juce::dsp::AudioBlock<float> block, int numSamples) {
-    float peak = 0.0f;
-    for (std::size_t channel = 0; channel < block.getNumChannels(); ++channel) {
-        const auto range = juce::FloatVectorOperations::findMinAndMax(
-            block.getChannelPointer(channel), numSamples);
-        peak = std::max({peak, std::abs(range.getStart()), std::abs(range.getEnd())});
-    }
-    return peak;
-}
-
 }  // namespace
 
 void AudioDelayLine::prepare(int numChannels, int delaySamples, int maxBlockSize) {
@@ -161,7 +151,8 @@ void PlanExecutor::reset() {
     deviceForOp_.clear();
     audioSourceForOp_.clear();
     midiSourceForOp_.clear();
-    meterLevels_.clear();
+    meterForOp_.clear();
+    boundMeterCount_ = 0;
 }
 
 std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const PlanBindings& bindings,
@@ -186,7 +177,7 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
     deviceForOp_.assign(numOps, nullptr);
     audioSourceForOp_.assign(numOps, nullptr);
     midiSourceForOp_.assign(numOps, nullptr);
-    meterLevels_.assign(numOps, 0.0f);
+    meterForOp_.assign(numOps, nullptr);
 
     const auto describe = [&plan](std::size_t index) {
         return "op " + std::to_string(index) + " (" + toString(plan.ops[index].kind) + " " +
@@ -247,6 +238,22 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                     break;
                 }
                 deviceForOp_[i] = found->second;
+                break;
+            }
+
+            case OpKind::Meter: {
+                // Silently optional, unlike every other binding above. A meter
+                // is the one op whose runtime object exists for something
+                // outside the render: unbound, the op still passes its audio
+                // on, and the only thing missing is a display nobody asked for.
+                // Reporting it would put a line per track and per device slot
+                // in front of every host that renders without a mixer, which is
+                // every offline render there is.
+                const auto found = bindings.meters.find(op.key);
+                if (found == bindings.meters.end() || found->second == nullptr)
+                    break;
+                meterForOp_[i] = found->second;
+                ++boundMeterCount_;
                 break;
             }
 
@@ -646,7 +653,14 @@ void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedB
                     out.clear();
                 else if (!writesInPlace(i))
                     out.copyFrom(audioIn(op.inputs[0], numSamples));
-                meterLevels_[i] = peakOf(out, numSamples);
+
+                // Written on silent blocks too, though a maximum takes nothing
+                // from them. What that buys is that the tap is only ever
+                // cleared by being read, so how fast a meter falls is the
+                // reader's cadence and not which blocks the executor bothered
+                // to report.
+                if (auto* tap = meterForOp_[i]; tap != nullptr)
+                    tap->write(out, numSamples);
                 break;
             }
 

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -189,6 +189,20 @@ class PlanExecutor {
     }
 
     /**
+     * @brief The device properties the prepared plan was prepared for.
+     *
+     * Readable because anything driving the executor has to agree with it, and
+     * because the disagreement is silent where it matters. process() renders at
+     * most maxBlockSize samples and says so only through an assert, so a caller
+     * that sized its blocks from a different context prints the first
+     * maxBlockSize samples of each one and silence for the rest: a bounce full
+     * of regular gaps, in release, from a build that passed every test.
+     */
+    const RenderContext& preparedContext() const {
+        return context_;
+    }
+
+    /**
      * @brief Whether process() would apply @p values rather than ignore them.
      *
      * The one definition of applicable, so that a caller deciding which table

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -145,11 +145,10 @@ class PlanExecutor {
     void process(const PlanValues& values, const BlockInfo& block,
                  juce::AudioBuffer<float>& output);
 
-    /// Peak level of each Meter op's block, indexed by OpId, zero elsewhere.
-    /// A plain vector for now: publishing meters to the UI thread without
-    /// tearing is the metering slice's problem, not the executor's.
-    const std::vector<float>& meterLevels() const {
-        return meterLevels_;
+    /// Meter ops whose tap the bindings filled. The rest still render; they
+    /// publish nothing, because nothing is reading them.
+    int boundMeterCount() const {
+        return boundMeterCount_;
     }
 
     /// Samples the prepared plan's output is delayed by: what the devices along
@@ -274,7 +273,10 @@ class PlanExecutor {
     juce::AudioBuffer<float> silence_;
     juce::MidiBuffer noMidi_;
 
-    std::vector<float> meterLevels_;
+    /// Per op: where a Meter op publishes, or null for one nobody reads. Bound
+    /// once here so the audio thread never looks a key up.
+    std::vector<LevelTap*> meterForOp_;
+    int boundMeterCount_ = 0;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -53,6 +53,16 @@ void collectDeviceIds(const std::vector<ChainElement>& elements, std::set<Device
     }
 }
 
+/// Whether a Meter op's key still names something the model holds. A meter at a
+/// device slot lives and dies with the device; one at a track, with the track.
+/// The key says which, because the compiler only ever emits a meter at one of
+/// those two places.
+bool isNamed(const OpKey& key, const RuntimeStateIds& ids) {
+    if (key.deviceId != INVALID_DEVICE_ID)
+        return ids.devices.contains(key.deviceId);
+    return ids.tracks.contains(key.trackId);
+}
+
 /// Entries whose key nothing in `named` holds any more.
 template <typename Map, typename Ids> std::size_t eraseUnnamed(Map& map, const Ids& named) {
     std::size_t removed = 0;
@@ -124,12 +134,34 @@ PlanBindings RuntimeStateStore::realise(const RenderPlan& plan, const RenderCont
                     bindings.midiInputs[trackId] = source;
                 break;
 
+            case OpKind::Meter:
+                // Its own path rather than realiseOne's, because a tap has
+                // nothing to prepare: it holds two atomics, and what they mean
+                // does not depend on a sample rate or a block size. That is
+                // also why a context change leaves the taps alone above, where
+                // it prepares everything else again: a meter reads on through
+                // a device switch instead of dropping to silence.
+                if (auto* tap = realiseMeter(op.key))
+                    bindings.meters[op.key] = tap;
+                break;
+
             default:
                 break;
         }
     }
 
     return bindings;
+}
+
+LevelTap* RuntimeStateStore::realiseMeter(const OpKey& key) {
+    if (const auto found = meters_.find(key); found != meters_.end())
+        return found->second.get();
+
+    auto created = factory_.createMeter(key);
+    if (created == nullptr)
+        return nullptr;
+
+    return meters_.emplace(key, std::move(created)).first->second.get();
 }
 
 std::size_t RuntimeStateStore::releaseDeleted(const RenderPlan& livePlan,
@@ -149,14 +181,35 @@ std::size_t RuntimeStateStore::releaseDeleted(const RenderPlan& livePlan,
             case OpKind::MidiInput:
                 keep.tracks.insert(op.key.trackId);
                 break;
+            case OpKind::Meter:
+                // Same unconditional reading as everything else the live plan
+                // names: the executor holds a pointer to this tap and the audio
+                // thread is writing through it right now.
+                if (op.key.deviceId != INVALID_DEVICE_ID)
+                    keep.devices.insert(op.key.deviceId);
+                else
+                    keep.tracks.insert(op.key.trackId);
+                break;
             default:
                 break;
         }
     }
 
-    return eraseUnnamed(devices_, keep.devices) + eraseUnnamed(clipAudio_, keep.tracks) +
-           eraseUnnamed(clipMidi_, keep.tracks) + eraseUnnamed(audioInputs_, keep.tracks) +
-           eraseUnnamed(midiInputs_, keep.tracks);
+    std::size_t removed =
+        eraseUnnamed(devices_, keep.devices) + eraseUnnamed(clipAudio_, keep.tracks) +
+        eraseUnnamed(clipMidi_, keep.tracks) + eraseUnnamed(audioInputs_, keep.tracks) +
+        eraseUnnamed(midiInputs_, keep.tracks);
+
+    for (auto entry = meters_.begin(); entry != meters_.end();) {
+        if (isNamed(entry->first, keep)) {
+            ++entry;
+            continue;
+        }
+        entry = meters_.erase(entry);
+        ++removed;
+    }
+
+    return removed;
 }
 
 RuntimeStateIds collectRuntimeStateIds(const std::vector<TrackInfo>& tracks,
@@ -181,7 +234,7 @@ RuntimeStateIds collectRuntimeStateIds(const std::vector<TrackInfo>& tracks,
 
 std::size_t RuntimeStateStore::size() const {
     return devices_.size() + clipAudio_.size() + clipMidi_.size() + audioInputs_.size() +
-           midiInputs_.size();
+           midiInputs_.size() + meters_.size();
 }
 
 }  // namespace magda::engine

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <memory>
 #include <set>
 #include <unordered_map>
@@ -7,6 +8,7 @@
 
 #include "exec/PlanBindings.hpp"
 #include "plan/RenderPlan.hpp"
+#include "tap/LevelTap.hpp"
 
 namespace magda {
 struct TrackInfo;
@@ -53,6 +55,23 @@ class RuntimeStateFactory {
         return nullptr;
     }
     virtual std::unique_ptr<EngineMidiSource> createMidiInput(TrackId) {
+        return nullptr;
+    }
+
+    /**
+     * @brief The level tap behind one Meter op, or nullptr for one nobody reads.
+     *
+     * Declining is the ordinary answer rather than a failure: a plan has a
+     * meter at every track, every device slot and the master, and a host with
+     * no mixer on screen wants none of them. What it costs to decline is the
+     * meter, and nothing else: the op still renders, because a Meter op is a
+     * point in the signal path first and a display second.
+     *
+     * Handed the whole key because a device's meter and the device itself share
+     * a DeviceId. Which track or device the tap belongs to is read off the key,
+     * and so is what kind of meter it is.
+     */
+    virtual std::unique_ptr<LevelTap> createMeter(const OpKey&) {
         return nullptr;
     }
 };
@@ -135,6 +154,12 @@ class RuntimeStateStore {
     std::size_t size() const;
 
   private:
+    /// The tap for one Meter op, asking the factory once if there is none. A
+    /// factory that declines is asked again next time, exactly as it is for
+    /// everything else: a mixer that opens after the plan was published should
+    /// get its meters at the next publish rather than never.
+    LevelTap* realiseMeter(const OpKey& key);
+
     RuntimeStateFactory& factory_;
 
     /// What everything the store holds has been prepared for. Set by the first
@@ -147,6 +172,12 @@ class RuntimeStateStore {
     std::unordered_map<TrackId, std::unique_ptr<EngineMidiSource>> clipMidi_;
     std::unordered_map<TrackId, std::unique_ptr<EngineAudioSource>> audioInputs_;
     std::unordered_map<TrackId, std::unique_ptr<EngineMidiSource>> midiInputs_;
+
+    /// Keyed by the op's whole key, and retained by the model IDs that key
+    /// names: a meter is kept while the track or device it reads exists, which
+    /// is the same rule everything else here follows read through the one
+    /// binding whose identity is not a bare model ID.
+    std::map<OpKey, std::unique_ptr<LevelTap>> meters_;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/io/AudioFileReader.hpp
+++ b/magda/engine/io/AudioFileReader.hpp
@@ -38,10 +38,17 @@ class AudioFileReader {
     /**
      * @brief Read @p numSamples into @p destination from @p destinationOffset.
      *
-     * Called on the prefetch thread, never on the audio thread. Returns how
-     * many samples were actually available, which is short only at the end of
-     * the file; the rest of the destination is cleared rather than left
-     * holding whatever was there.
+     * One consumer per reader, on any thread that is not the audio thread. The
+     * prefetch thread is one such consumer and an offline render is another,
+     * but never through the same instance: a read is a seek and a read
+     * together, so two of them interleaving leaves both somewhere neither
+     * asked for. Locking here instead would put a bounce and the prefetch
+     * thread in each other's way, which is the wrong trade for a file that
+     * could simply have been opened twice.
+     *
+     * Returns how many samples were actually available, which is short only at
+     * the end of the file; the rest of the destination is cleared rather than
+     * left holding whatever was there.
      *
      * The destination carries the engine's channel count rather than the
      * file's: a mono file fans out to every channel, and a file with more

--- a/magda/engine/io/ClipPlacement.hpp
+++ b/magda/engine/io/ClipPlacement.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+/**
+ * @file ClipPlacement.hpp
+ * @brief Where a file sits on the timeline, and which of its samples plays when.
+ *
+ * The one mapping from a moment on the timeline to a sample of a file. It lives
+ * on its own rather than inside a source because there is more than one source:
+ * playback reads through a prefetch stream and cannot wait, an offline render
+ * reads straight through the file and may. If each of them worked out where it
+ * was in the file, a bounce could disagree with what was heard by a sample and
+ * nothing would say which of the two was right.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief A file's position on the timeline, in seconds.
+ *
+ * In seconds rather than beats. The clip layer positions clips in beats, as the
+ * model does, and resolves them to seconds through the tempo map before they
+ * reach here; a source that had to do it itself would need a tempo map on the
+ * audio thread, and there would then be two of them.
+ */
+struct ClipPlacement {
+    double startSeconds = 0.0;
+    double endSeconds = 0.0;
+
+    /// The sample of the file that plays at @ref startSeconds. What trimming
+    /// the front of a clip moves.
+    std::int64_t sourceOffsetSamples = 0;
+};
+
+/**
+ * @brief The file sample that plays at @p seconds on the timeline.
+ *
+ * At @p sampleRate, the device's rate, not the file's, and that is not a slip.
+ * One file sample is consumed per output sample, so a position derived at any
+ * other rate would disagree with what playing actually gets through: every
+ * block would land somewhere the reader was not expecting, which is a seek, and
+ * a file at a mismatched rate would spend every callback re-pointing the reader
+ * and hearing nothing. Deriving it at the device's rate keeps the two in step,
+ * and what a mismatched file costs is then pitch rather than playback.
+ *
+ * Rate conversion belongs to the clip layer (#1890), which owns stretch and
+ * warp and is the same question asked once.
+ */
+inline std::int64_t sourceSampleAt(const ClipPlacement& placement, double seconds,
+                                   double sampleRate) {
+    return placement.sourceOffsetSamples +
+           static_cast<std::int64_t>(std::llround((seconds - placement.startSeconds) * sampleRate));
+}
+
+}  // namespace magda::engine

--- a/magda/engine/io/FileAudioSource.cpp
+++ b/magda/engine/io/FileAudioSource.cpp
@@ -1,0 +1,53 @@
+#include "io/FileAudioSource.hpp"
+
+#include <algorithm>
+
+namespace magda::engine {
+
+FileAudioSource::FileAudioSource(AudioFileReader& reader, const ClipPlacement& placement)
+    : reader_(reader), placement_(placement) {}
+
+void FileAudioSource::prepare(const RenderContext& context) {
+    sampleRate_ = context.sampleRate;
+    scratch_.setSize(context.numChannels, context.maxBlockSize, false, true, true);
+}
+
+void FileAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {
+    out.clear();
+
+    if (!block.playing || block.numSamples <= 0)
+        return;
+
+    // The part of the block the clip covers, as samples of it. Half-open at
+    // both ends, so a clip ending exactly on a block boundary contributes
+    // nothing to the block that starts there. Identical to the streaming
+    // source, because it is the same clip in the same place.
+    const auto first = block.sampleForTime(std::max(block.startSeconds, placement_.startSeconds));
+    const auto last = block.sampleForTime(std::min(block.endSeconds, placement_.endSeconds));
+    const auto count = last - first;
+
+    if (count <= 0)
+        return;
+
+    const auto sourceStart = sourceSampleAt(std::max(block.startSeconds, placement_.startSeconds));
+
+    // Past the end of the file is silence rather than a short block: the clip
+    // says how long it is and a file that ran out inside it is a file that ran
+    // out, not a reason to move what comes after.
+    if (scratch_.getNumSamples() < count ||
+        scratch_.getNumChannels() < static_cast<int>(out.getNumChannels()))
+        scratch_.setSize(
+            std::max(scratch_.getNumChannels(), static_cast<int>(out.getNumChannels())),
+            std::max(scratch_.getNumSamples(), count), false, true, true);
+
+    reader_.read(scratch_, 0, sourceStart, count);
+
+    const auto channels =
+        std::min(static_cast<int>(out.getNumChannels()), scratch_.getNumChannels());
+    for (auto channel = 0; channel < channels; ++channel)
+        juce::FloatVectorOperations::copy(out.getChannelPointer(static_cast<std::size_t>(channel)) +
+                                              first,
+                                          scratch_.getReadPointer(channel), count);
+}
+
+}  // namespace magda::engine

--- a/magda/engine/io/FileAudioSource.hpp
+++ b/magda/engine/io/FileAudioSource.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include "exec/EngineDevice.hpp"
+#include "io/AudioFileReader.hpp"
+#include "io/ClipPlacement.hpp"
+
+/**
+ * @file FileAudioSource.hpp
+ * @brief One placed file, read straight through, for a caller that may wait.
+ *
+ * The offline twin of StreamingAudioSource, and deliberately the same thing
+ * with one piece removed. Playback cannot wait for a disk, so it reads through
+ * a prefetch stream that hands over whatever arrived in time and counts what
+ * did not. An offline render has no callback to starve: waiting for the disk
+ * costs the render wall-clock time and costs the audio nothing, so there is no
+ * stream, no thread, no chunk pool and no underrun to report.
+ *
+ * What the two share is the mapping (io/ClipPlacement), and sharing it is the
+ * point. A bounce that worked out its own file positions could disagree with
+ * what was played by a sample, and the only way anyone would find out is by
+ * listening to the render.
+ *
+ * Never on the audio thread. It reads a file where it stands.
+ */
+
+namespace magda::engine {
+
+class FileAudioSource final : public EngineAudioSource {
+  public:
+    /// The reader is owned elsewhere, so the same file can back an offline
+    /// render and whatever else the host has open on it.
+    FileAudioSource(AudioFileReader& reader, const ClipPlacement& placement);
+
+    void prepare(const RenderContext& context) override;
+
+    /**
+     * @brief Render the part of this block the clip covers.
+     *
+     * The same shape as StreamingAudioSource::render, block for block: the rest
+     * of the block is silence, a block the transport is not moving through
+     * renders nothing, and the file position comes from where the block is on
+     * the timeline rather than from where the last read finished. Deriving it
+     * from the timeline is what makes an offline render of a range identical
+     * whatever block size it was pulled at, since no block's output depends on
+     * how the ones before it were cut.
+     *
+     * Rate conversion is not done here either. The file's own samples come out
+     * one per output sample, and a file recorded at another rate plays at the
+     * wrong pitch until the clip layer resamples it (#1890).
+     */
+    void render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) override;
+
+    /// The file sample that plays at a moment on the timeline. The same
+    /// mapping StreamingAudioSource uses, at this source's placement and rate.
+    std::int64_t sourceSampleAt(double seconds) const {
+        return engine::sourceSampleAt(placement_, seconds, sampleRate_);
+    }
+
+  private:
+    AudioFileReader& reader_;
+    ClipPlacement placement_;
+    double sampleRate_ = 44100.0;
+
+    /// What the reader fills, because AudioFileReader reads into a buffer and
+    /// render() is handed a block. Sized in prepare() and grown if a caller
+    /// pulls a longer block than it said it would, which is legal here and
+    /// nowhere else: allocating is what the audio thread cannot do, and this is
+    /// not the audio thread.
+    juce::AudioBuffer<float> scratch_;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/io/FileAudioSource.hpp
+++ b/magda/engine/io/FileAudioSource.hpp
@@ -29,8 +29,13 @@ namespace magda::engine {
 
 class FileAudioSource final : public EngineAudioSource {
   public:
-    /// The reader is owned elsewhere, so the same file can back an offline
-    /// render and whatever else the host has open on it.
+    /// The reader is owned elsewhere, and is this source's alone while it
+    /// exists. One file backing two consumers is two readers over it, not one
+    /// shared between them: a reader seeks and reads as one operation, so two
+    /// of them interleaving lands both somewhere neither asked for. The path
+    /// that makes this concrete is not exotic, it is a stem export, which is
+    /// one render per stem over the same files and is the obvious thing to run
+    /// in parallel.
     FileAudioSource(AudioFileReader& reader, const ClipPlacement& placement);
 
     void prepare(const RenderContext& context) override;

--- a/magda/engine/io/StreamingAudioSource.cpp
+++ b/magda/engine/io/StreamingAudioSource.cpp
@@ -12,19 +12,6 @@ void StreamingAudioSource::prepare(const RenderContext& context) {
     sampleRate_ = context.sampleRate;
 }
 
-std::int64_t StreamingAudioSource::sourceSampleAt(double seconds) const {
-    // At the device's rate, not the file's, and that is not a slip. One file
-    // sample is copied per output sample below, so a position derived at any
-    // other rate would disagree with what playing actually consumes: every
-    // block would land somewhere the stream was not expecting, which is a seek,
-    // and a file at the wrong rate would spend every callback re-pointing the
-    // reader and hearing nothing. Deriving it at the device's rate keeps the
-    // two in step, and what a mismatched file costs is then pitch rather than
-    // playback.
-    return placement_.sourceOffsetSamples + static_cast<std::int64_t>(std::llround(
-                                                (seconds - placement_.startSeconds) * sampleRate_));
-}
-
 void StreamingAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {
     out.clear();
 

--- a/magda/engine/io/StreamingAudioSource.hpp
+++ b/magda/engine/io/StreamingAudioSource.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include "exec/EngineDevice.hpp"
+#include "io/ClipPlacement.hpp"
 #include "io/PrefetchStream.hpp"
 
 /**
@@ -21,23 +22,6 @@
  */
 
 namespace magda::engine {
-
-/**
- * @brief Where a file sits on the timeline, and where playback starts in it.
- *
- * In seconds rather than beats. The clip layer positions clips in beats, as the
- * model does, and resolves them to seconds through the tempo map before they
- * reach here; a source that had to do it itself would need a tempo map on the
- * audio thread, and there would then be two of them.
- */
-struct ClipPlacement {
-    double startSeconds = 0.0;
-    double endSeconds = 0.0;
-
-    /// The sample of the file that plays at @ref startSeconds. What trimming
-    /// the front of a clip moves.
-    std::int64_t sourceOffsetSamples = 0;
-};
 
 class StreamingAudioSource final : public EngineAudioSource {
   public:
@@ -78,8 +62,14 @@ class StreamingAudioSource final : public EngineAudioSource {
      * Whoever schedules playback knows where it is about to start before the
      * callback does, and a stream told in advance is one that does not have to
      * seek in the block that needs the samples.
+     *
+     * The shared mapping, read at this source's placement and rate. An offline
+     * render of the same clip resolves to the same file sample through the same
+     * function, which is what makes a bounce the thing that was heard.
      */
-    std::int64_t sourceSampleAt(double seconds) const;
+    std::int64_t sourceSampleAt(double seconds) const {
+        return engine::sourceSampleAt(placement_, seconds, sampleRate_);
+    }
 
   private:
     PrefetchStream& stream_;

--- a/magda/engine/tap/LevelTap.hpp
+++ b/magda/engine/tap/LevelTap.hpp
@@ -58,6 +58,15 @@ class LevelTap {
      * A tap nobody reads accumulates rather than growing: peak is a maximum, so
      * a meter that goes unwatched for a minute reports that minute's loudest
      * sample the next time it is read.
+     *
+     * Each channel is taken on its own, so a read is not one instant across the
+     * two of them. A read landing between the channels of a write comes back
+     * with one that has this block in it and one that does not, which on a
+     * meter is a single frame where a signal shows on the left and not the
+     * right. Nothing is lost to it: the channel that missed the read keeps its
+     * level for the next one. Making the pair atomic means packing both floats
+     * into one word, which is worth doing if that frame ever proves visible and
+     * is not worth doing before.
      */
     Levels read() {
         Levels levels;
@@ -85,14 +94,17 @@ class LevelTap {
                 block.getChannelPointer(static_cast<std::size_t>(channel)), numSamples);
             const auto peak = std::max(std::abs(range.getStart()), std::abs(range.getEnd()));
             accumulate(channel, peak);
-        }
 
-        // A mono block on a stereo tap reads as the same level on both, which is
-        // what it sounds like. Nothing in the engine produces one today; a tap
-        // that reported silence on the right if something did would be a meter
-        // lying about audible signal.
-        if (channels == 1)
-            accumulate(1, peaks_[0].load(std::memory_order_relaxed));
+            // A mono block on a stereo tap reads as the same level on both,
+            // which is what it sounds like. The block's own peak rather than
+            // whatever channel 0 holds by now: a read landing between the two
+            // takes that slot to zero, and the transient would then reach
+            // neither channel rather than both. Nothing in the engine produces
+            // a mono block today, which is the argument for getting the path
+            // right while nothing depends on it.
+            if (channels == 1)
+                accumulate(1, peak);
+        }
     }
 
     /// Drop what has not been read. For a meter whose signal has gone away:

--- a/magda/engine/tap/LevelTap.hpp
+++ b/magda/engine/tap/LevelTap.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
+
+/**
+ * @file LevelTap.hpp
+ * @brief What a Meter op writes and a meter reads.
+ *
+ * The plan is topology, so a Meter op names a location and owns nothing. This
+ * is what stands behind it, and the host owns it for the same reason it owns a
+ * device: it outlives the plans that reference it, so a structural edit
+ * somewhere else in the project does not reset a meter that was reading.
+ *
+ * One writer (the audio thread) and one reader (whoever draws the meter). Two
+ * readers would each take part of what the other was owed, because a read is
+ * destructive; that is a property of metering rather than an oversight, see
+ * read().
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief Peak level per channel, published without a lock.
+ *
+ * Stereo, because the plan carries no channel layouts and every audio port in
+ * it is the context's channel count, which is two. A tap fed a wider block
+ * reports the first two channels rather than folding them, because nothing in
+ * the model says what the rest of them mean.
+ */
+class LevelTap {
+  public:
+    static constexpr int kNumChannels = 2;
+
+    struct Levels {
+        std::array<float, kNumChannels> peak{};
+
+        float loudest() const {
+            return std::max(peak[0], peak[1]);
+        }
+    };
+
+    /**
+     * @brief Take the levels and start again. Off the audio thread.
+     *
+     * Destructive, and that is what makes a meter a meter: what it reports is
+     * the loudest thing since it was last looked at, not the loudest thing in
+     * whichever block the reader happened to land on. A non-destructive read
+     * would let the frame rate decide how much of the signal the meter ever
+     * sees, so a drum hit would show or not show depending on how busy the UI
+     * was, and a meter that misses transients is worse than no meter.
+     *
+     * A tap nobody reads accumulates rather than growing: peak is a maximum, so
+     * a meter that goes unwatched for a minute reports that minute's loudest
+     * sample the next time it is read.
+     */
+    Levels read() {
+        Levels levels;
+        for (auto channel = 0; channel < kNumChannels; ++channel)
+            levels.peak[static_cast<std::size_t>(channel)] =
+                peaks_[static_cast<std::size_t>(channel)].exchange(0.0f, std::memory_order_acq_rel);
+        return levels;
+    }
+
+    /**
+     * @brief Fold one block into what the next read will report. Audio thread.
+     *
+     * A maximum rather than an assignment, so no block is lost between two
+     * reads however short the blocks are and however slowly the reader polls.
+     */
+    void write(juce::dsp::AudioBlock<const float> block, int numSamples) {
+        if (numSamples <= 0)
+            return;
+
+        const auto channels =
+            std::min(static_cast<int>(block.getNumChannels()), static_cast<int>(kNumChannels));
+
+        for (auto channel = 0; channel < channels; ++channel) {
+            const auto range = juce::FloatVectorOperations::findMinAndMax(
+                block.getChannelPointer(static_cast<std::size_t>(channel)), numSamples);
+            const auto peak = std::max(std::abs(range.getStart()), std::abs(range.getEnd()));
+            accumulate(channel, peak);
+        }
+
+        // A mono block on a stereo tap reads as the same level on both, which is
+        // what it sounds like. Nothing in the engine produces one today; a tap
+        // that reported silence on the right if something did would be a meter
+        // lying about audible signal.
+        if (channels == 1)
+            accumulate(1, peaks_[0].load(std::memory_order_relaxed));
+    }
+
+    /// Drop what has not been read. For a meter whose signal has gone away:
+    /// a device that was removed should fall to silence rather than hold its
+    /// last peak until something reads it.
+    void clear() {
+        for (auto& peak : peaks_)
+            peak.store(0.0f, std::memory_order_release);
+    }
+
+  private:
+    /// Compare-and-swap rather than a plain store, because the reader may take
+    /// the value between the load and the store and a store would then put back
+    /// a peak that had already been reported.
+    void accumulate(int channel, float peak) {
+        auto& slot = peaks_[static_cast<std::size_t>(channel)];
+        auto current = slot.load(std::memory_order_relaxed);
+        while (peak > current &&
+               !slot.compare_exchange_weak(current, peak, std::memory_order_acq_rel,
+                                           std::memory_order_relaxed)) {
+        }
+    }
+
+    std::array<std::atomic<float>, kNumChannels> peaks_{};
+};
+
+}  // namespace magda::engine

--- a/magda/engine/tap/SampleRing.hpp
+++ b/magda/engine/tap/SampleRing.hpp
@@ -1,0 +1,129 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_core/juce_core.h>
+#include <juce_dsp/juce_dsp.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <vector>
+
+/**
+ * @file SampleRing.hpp
+ * @brief The recent past of a signal, for something that draws it.
+ *
+ * An oscilloscope and a spectrum want the same thing and neither wants a queue:
+ * they want the last N samples whenever they happen to ask, and they would
+ * rather miss what went by while they were not looking than fall behind it. So
+ * the writer always overwrites the oldest sample and never blocks, and the
+ * reader always sees the present.
+ *
+ * The same seam as LevelTap, for the other half of the tap question: a level is
+ * one number per block, this is the samples themselves. An analysis device owns
+ * one of these and the UI reads it; the engine writes it from process().
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief A single-producer, single-consumer history of the most recent samples.
+ *
+ * Mono. Every analysis MAGDA draws (a trace, an FFT) is of the summed signal,
+ * and a per-channel history would double the memory to be summed on the way out
+ * anyway.
+ *
+ * Tearing is possible and bounded: if the reader stalls for as long as the ring
+ * is deep, the writer laps it and the oldest few samples of what it copies are
+ * from the new lap. At the default capacity that is a third of a second of
+ * audio, which a UI would have to have stopped entirely to hit, and the cost
+ * when it happens is one ragged frame of a drawing.
+ */
+class SampleRing {
+  public:
+    /// Rounded up to a power of two: the index is a mask rather than a modulo,
+    /// which is what keeps the write loop free of division.
+    explicit SampleRing(int capacity = 16384)
+        : capacity_(juce::nextPowerOfTwo(std::max(1024, capacity))),
+          mask_(static_cast<std::size_t>(capacity_) - 1),
+          samples_(static_cast<std::size_t>(capacity_), 0.0f) {}
+
+    int capacity() const {
+        return capacity_;
+    }
+
+    /// Audio thread. Append mono samples.
+    void write(const float* samples, int numSamples) {
+        if (numSamples <= 0)
+            return;
+
+        auto position = writePosition_.load(std::memory_order_relaxed);
+        for (auto i = 0; i < numSamples; ++i)
+            samples_[(position + static_cast<std::size_t>(i)) & mask_] = samples[i];
+
+        writePosition_.store(position + static_cast<std::size_t>(numSamples),
+                             std::memory_order_release);
+    }
+
+    /**
+     * @brief Audio thread. Append the mean of @p block's channels.
+     *
+     * Summed straight into the ring rather than through scratch, which is what
+     * lets this have no maximum block size. A tap that had to be prepared for a
+     * block size would have to do something when handed a longer one, and the
+     * only quiet options are to allocate or to drop the block: one is forbidden
+     * here and the other is a display that goes blank exactly when a host
+     * changes its buffer size.
+     */
+    void writeDownmix(juce::dsp::AudioBlock<const float> block, int numSamples) {
+        const auto channels = static_cast<int>(block.getNumChannels());
+        if (numSamples <= 0 || channels <= 0)
+            return;
+
+        const auto scale = 1.0f / static_cast<float>(channels);
+        auto position = writePosition_.load(std::memory_order_relaxed);
+
+        for (auto i = 0; i < numSamples; ++i) {
+            auto sum = 0.0f;
+            for (auto channel = 0; channel < channels; ++channel)
+                sum += block.getSample(channel, i);
+            samples_[(position + static_cast<std::size_t>(i)) & mask_] = sum * scale;
+        }
+
+        writePosition_.store(position + static_cast<std::size_t>(numSamples),
+                             std::memory_order_release);
+    }
+
+    /**
+     * @brief Copy the most recent @p numSamples into @p destination.
+     *
+     * Off the audio thread. Zero-padded at the front while the ring has not
+     * filled once, so a display opened a moment ago draws silence rather than
+     * whatever the allocation held. Returns the running count of samples ever
+     * written, which is how a caller tells that nothing new has arrived since
+     * it last asked without comparing the audio itself.
+     */
+    std::size_t readLatest(float* destination, int numSamples) const {
+        const auto position = writePosition_.load(std::memory_order_acquire);
+
+        for (auto i = 0; i < numSamples; ++i) {
+            const auto index = static_cast<long long>(position) - numSamples + i;
+            destination[i] = index < 0 ? 0.0f : samples_[static_cast<std::size_t>(index) & mask_];
+        }
+
+        return position;
+    }
+
+    /// Samples written since construction. Off the audio thread.
+    std::size_t writePosition() const {
+        return writePosition_.load(std::memory_order_acquire);
+    }
+
+  private:
+    const int capacity_;
+    const std::size_t mask_;
+    std::vector<float> samples_;
+    std::atomic<std::size_t> writePosition_{0};
+};
+
+}  // namespace magda::engine

--- a/magda/engine/tap/SampleRing.hpp
+++ b/magda/engine/tap/SampleRing.hpp
@@ -108,20 +108,32 @@ class SampleRing {
     /**
      * @brief Copy the most recent @p numSamples into @p destination.
      *
-     * Off the audio thread. Zero-padded at the front while the ring has not
-     * filled once, so a display opened a moment ago draws silence rather than
-     * whatever the allocation held. Returns the running count of samples ever
-     * written, which is how a caller tells that nothing new has arrived since
-     * it last asked without comparing the audio itself.
+     * Off the audio thread. Zero-padded at the front for anything the ring
+     * cannot answer for, which is two cases and one rule: history from before
+     * it had been written to, and history older than it is deep. A caller
+     * asking for a longer window than the ring holds gets silence in front of
+     * what there is, rather than the ring's contents repeated: the masked index
+     * would happily fold two laps onto the same slots and hand back a
+     * duplicated waveform, which draws as a signal that was never played and
+     * transforms as harmonics that were never there.
+     *
+     * Returns the running count of samples ever written, which is how a caller
+     * tells that nothing new has arrived since it last asked without comparing
+     * the audio itself.
      */
     std::size_t readLatest(float* destination, int numSamples) const {
         const auto position = writePosition_.load(std::memory_order_acquire);
 
+        // The oldest position still in the ring. Below it the slot has been
+        // overwritten by a later lap and answers for a different sample.
+        const auto oldest = static_cast<long long>(position) - capacity_;
+
         for (auto i = 0; i < numSamples; ++i) {
             const auto index = static_cast<long long>(position) - numSamples + i;
-            destination[i] = index < 0 ? 0.0f
-                                       : samples_[static_cast<std::size_t>(index) & mask_].load(
-                                             std::memory_order_relaxed);
+            destination[i] = index < 0 || index < oldest
+                                 ? 0.0f
+                                 : samples_[static_cast<std::size_t>(index) & mask_].load(
+                                       std::memory_order_relaxed);
         }
 
         return position;

--- a/magda/engine/tap/SampleRing.hpp
+++ b/magda/engine/tap/SampleRing.hpp
@@ -38,6 +38,15 @@ namespace magda::engine {
  * from the new lap. At the default capacity that is a third of a second of
  * audio, which a UI would have to have stopped entirely to hit, and the cost
  * when it happens is one ragged frame of a drawing.
+ *
+ * The slots are atomic so that the lap is that and nothing more. Plain floats
+ * would make it a data race, which is undefined rather than merely ragged: the
+ * bound above would be a claim about what compilers happen to do, and the first
+ * analysis device wired to a ring would hand `make tsan` a real positive, whose
+ * only answers are a suppression that blunts the tool or a rewrite under time
+ * pressure. Relaxed on both sides, because the ordering that matters is the
+ * position counter's and the slots order nothing: what this compiles to is the
+ * plain loads and stores it would have been anyway.
  */
 class SampleRing {
   public:
@@ -46,7 +55,7 @@ class SampleRing {
     explicit SampleRing(int capacity = 16384)
         : capacity_(juce::nextPowerOfTwo(std::max(1024, capacity))),
           mask_(static_cast<std::size_t>(capacity_) - 1),
-          samples_(static_cast<std::size_t>(capacity_), 0.0f) {}
+          samples_(static_cast<std::size_t>(capacity_)) {}
 
     int capacity() const {
         return capacity_;
@@ -57,9 +66,10 @@ class SampleRing {
         if (numSamples <= 0)
             return;
 
-        auto position = writePosition_.load(std::memory_order_relaxed);
+        const auto position = writePosition_.load(std::memory_order_relaxed);
         for (auto i = 0; i < numSamples; ++i)
-            samples_[(position + static_cast<std::size_t>(i)) & mask_] = samples[i];
+            samples_[(position + static_cast<std::size_t>(i)) & mask_].store(
+                samples[i], std::memory_order_relaxed);
 
         writePosition_.store(position + static_cast<std::size_t>(numSamples),
                              std::memory_order_release);
@@ -81,13 +91,14 @@ class SampleRing {
             return;
 
         const auto scale = 1.0f / static_cast<float>(channels);
-        auto position = writePosition_.load(std::memory_order_relaxed);
+        const auto position = writePosition_.load(std::memory_order_relaxed);
 
         for (auto i = 0; i < numSamples; ++i) {
             auto sum = 0.0f;
             for (auto channel = 0; channel < channels; ++channel)
                 sum += block.getSample(channel, i);
-            samples_[(position + static_cast<std::size_t>(i)) & mask_] = sum * scale;
+            samples_[(position + static_cast<std::size_t>(i)) & mask_].store(
+                sum * scale, std::memory_order_relaxed);
         }
 
         writePosition_.store(position + static_cast<std::size_t>(numSamples),
@@ -108,7 +119,9 @@ class SampleRing {
 
         for (auto i = 0; i < numSamples; ++i) {
             const auto index = static_cast<long long>(position) - numSamples + i;
-            destination[i] = index < 0 ? 0.0f : samples_[static_cast<std::size_t>(index) & mask_];
+            destination[i] = index < 0 ? 0.0f
+                                       : samples_[static_cast<std::size_t>(index) & mask_].load(
+                                             std::memory_order_relaxed);
         }
 
         return position;
@@ -122,7 +135,9 @@ class SampleRing {
   private:
     const int capacity_;
     const std::size_t mask_;
-    std::vector<float> samples_;
+    /// Value-initialised, which for an atomic is zero: a ring that has not been
+    /// written to yet reads as silence rather than as whatever was allocated.
+    std::vector<std::atomic<float>> samples_;
     std::atomic<std::size_t> writePosition_{0};
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -253,6 +253,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_click_generator.cpp)
     list(APPEND TEST_SOURCES test_prefetch_stream.cpp)
     list(APPEND TEST_SOURCES test_streaming_audio_source.cpp)
+    list(APPEND TEST_SOURCES test_file_audio_source.cpp)
+    list(APPEND TEST_SOURCES test_offline_render.cpp)
+    list(APPEND TEST_SOURCES test_engine_taps.cpp)
 endif()
 
 # Create test executable

--- a/tests/test_engine_session.cpp
+++ b/tests/test_engine_session.cpp
@@ -136,12 +136,43 @@ class TestFactory final : public RuntimeStateFactory {
         return std::make_unique<ConstantSource>(1.0f);
     }
 
+    /// A host with a mixer on screen: every meter the plan has gets one. A host
+    /// without would return nullptr here and nothing else would change.
+    std::unique_ptr<magda::engine::LevelTap> createMeter(const magda::engine::OpKey& key) override {
+        if (!makesMeters)
+            return nullptr;
+
+        ++metersCreated;
+        auto tap = std::make_unique<magda::engine::LevelTap>();
+        metersByKey[key] = tap.get();
+        return tap;
+    }
+
+    bool makesMeters = true;
+    int metersCreated = 0;
+    std::map<magda::engine::OpKey, magda::engine::LevelTap*> metersByKey;
+
     LedgerDevice* lastDevice = nullptr;
     std::map<DeviceId, LedgerDevice*> devicesById;
 
   private:
     Ledger& ledger_;
 };
+
+/// The one meter with this role at this location, or null.
+magda::engine::LevelTap* meterAt(const TestFactory& factory, const RenderPlan& plan,
+                                 magda::engine::OpRole role, TrackId trackId,
+                                 DeviceId deviceId = INVALID_DEVICE_ID) {
+    for (const auto& op : plan.ops) {
+        if (op.kind != magda::engine::OpKind::Meter || op.key.role != role)
+            continue;
+        if (op.key.trackId != trackId || op.key.deviceId != deviceId)
+            continue;
+        const auto found = factory.metersByKey.find(op.key);
+        return found == factory.metersByKey.end() ? nullptr : found->second;
+    }
+    return nullptr;
+}
 
 std::shared_ptr<const RenderPlan> compile(const std::vector<TrackInfo>& tracks) {
     return std::make_shared<const RenderPlan>(
@@ -499,7 +530,11 @@ TEST_CASE("What a swap drops is destroyed on the publishing thread", "[engine][s
     // destructor.
     CHECK(ledger.devicesDestroyed == 1);
     CHECK(ledger.lastDestroyingThread.load() == std::this_thread::get_id());
-    CHECK(session.runtimeObjectCount() == 1);  // the clip source is still named
+
+    // What the model still names: the track's clip source, the track's meter
+    // and the master's. The device's own meter went with the device, keyed on
+    // the DeviceId that is no longer there.
+    CHECK(session.runtimeObjectCount() == 3);
 }
 
 TEST_CASE("Bypass and chain power keep the device, deletion destroys it", "[engine][session]") {
@@ -861,4 +896,114 @@ TEST_CASE("The metronome is added after the plan, not through it",
 
         CHECK(output.getMagnitude(0, kBlockSize) > 0.1f);
     }
+}
+
+TEST_CASE("A meter is bound at the master, at a track and at a device slot",
+          "[engine][session][tap]") {
+    // The three places the issue names, and the three the compiler emits a
+    // Meter op at. A tap that only reached one of them would leave a mixer with
+    // meters on some strips and not others.
+    Ledger ledger;
+    TestFactory factory(ledger);
+    EngineSession session(factory);
+
+    const auto tracks = trackWithEffect(7);
+    const auto plan = compile(tracks);
+    REQUIRE(publish(session, plan, tracks).published);
+
+    CHECK(meterAt(factory, *plan, magda::engine::OpRole::TrackMeter, MASTER_TRACK_ID) != nullptr);
+    CHECK(meterAt(factory, *plan, magda::engine::OpRole::TrackMeter, 1) != nullptr);
+    CHECK(meterAt(factory, *plan, magda::engine::OpRole::DeviceMeter, 1, 7) != nullptr);
+}
+
+TEST_CASE("A meter reads the level the track is rendering", "[engine][session][tap]") {
+    Ledger ledger;
+    TestFactory factory(ledger);
+    EngineSession session(factory);
+
+    const std::vector<TrackInfo> tracks{makeTrack(1)};
+    const auto plan = compile(tracks);
+    REQUIRE(publish(session, plan, tracks).published);
+
+    auto* tap = meterAt(factory, *plan, magda::engine::OpRole::TrackMeter, 1);
+    REQUIRE(tap != nullptr);
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    session.publishTransport(rolling(0.0));
+    session.process(kBlockSize, output);
+
+    // The source renders at unity and nothing between it and the meter
+    // attenuates, so this is the whole of the path from a block to a display.
+    CHECK(tap->read().loudest() == approx(1.0f));
+}
+
+TEST_CASE("A meter is the same tap across a plan swap", "[engine][session][tap]") {
+    // The differ's promise, applied to taps: a structural edit elsewhere in the
+    // project must not reset a meter that was reading. Rebuilding it would drop
+    // whatever it had accumulated since the last poll, which is a meter that
+    // flickers to zero every time a device is added anywhere.
+    Ledger ledger;
+    TestFactory factory(ledger);
+    EngineSession session(factory);
+
+    const std::vector<TrackInfo> before{makeTrack(1)};
+    const auto firstPlan = compile(before);
+    REQUIRE(publish(session, firstPlan, before).published);
+
+    auto* firstTap = meterAt(factory, *firstPlan, magda::engine::OpRole::TrackMeter, 1);
+    REQUIRE(firstTap != nullptr);
+    const auto metersAfterFirst = factory.metersCreated;
+
+    const auto after = trackWithEffect(7);
+    const auto secondPlan = compile(after);
+    REQUIRE(publish(session, secondPlan, after).published);
+
+    CHECK(meterAt(factory, *secondPlan, magda::engine::OpRole::TrackMeter, 1) == firstTap);
+
+    // Only the new device's meter was made. The track's and the master's were
+    // already there and were handed back.
+    CHECK(factory.metersCreated == metersAfterFirst + 1);
+}
+
+TEST_CASE("A meter goes when the device it reads is deleted", "[engine][session][tap]") {
+    Ledger ledger;
+    TestFactory factory(ledger);
+    EngineSession session(factory);
+
+    const auto withEffect = trackWithEffect(7);
+    const auto firstPlan = compile(withEffect);
+    REQUIRE(publish(session, firstPlan, withEffect).published);
+    const auto objectsWithEffect = session.runtimeObjectCount();
+
+    const std::vector<TrackInfo> withoutEffect{makeTrack(1)};
+    const auto secondPlan = compile(withoutEffect);
+    REQUIRE(publish(session, secondPlan, withoutEffect).published);
+
+    // The device and its meter, both keyed on the DeviceId the model no longer
+    // holds. A tap that outlived its device would be a row in the mixer for
+    // something that is not there.
+    CHECK(session.runtimeObjectCount() == objectsWithEffect - 2);
+}
+
+TEST_CASE("A host that wants no meters binds none and renders the same", "[engine][session][tap]") {
+    Ledger ledger;
+    TestFactory factory(ledger);
+    factory.makesMeters = false;
+    EngineSession session(factory);
+
+    const auto tracks = trackWithEffect(7);
+    const auto plan = compile(tracks);
+    const auto result = publish(session, plan, tracks);
+
+    // Not a diagnostic. A plan has a meter at every track and device slot, and
+    // an export reporting one line per meter would bury whatever it had to say.
+    CHECK(result.published);
+    CHECK(result.messages.empty());
+    CHECK(factory.metersCreated == 0);
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    session.publishTransport(rolling(0.0));
+    session.process(kBlockSize, output);
+
+    CHECK(output.getMagnitude(0, kBlockSize) > 0.0f);
 }

--- a/tests/test_engine_taps.cpp
+++ b/tests/test_engine_taps.cpp
@@ -153,6 +153,33 @@ TEST_CASE("A sample ring keeps the newest samples once it has wrapped", "[engine
     CHECK(read[1] == approx(static_cast<float>(written.size() - 1)));
 }
 
+TEST_CASE("A sample ring pads a window longer than it is deep", "[engine][tap]") {
+    // A scope on a long timebase asks for more history than the ring holds.
+    // What it must not get is the ring twice: the masked index folds two laps
+    // onto the same slots, and the second copy would draw as signal that was
+    // never played.
+    SampleRing ring(1024);
+    const auto capacity = ring.capacity();
+
+    std::vector<float> written(static_cast<std::size_t>(capacity) * 2);
+    for (std::size_t i = 0; i < written.size(); ++i)
+        written[i] = 1.0f + static_cast<float>(i);
+    ring.write(written.data(), static_cast<int>(written.size()));
+
+    std::vector<float> read(static_cast<std::size_t>(capacity) * 2);
+    ring.readLatest(read.data(), static_cast<int>(read.size()));
+
+    // The half the ring cannot answer for is silence, not a repeat.
+    for (auto sample = 0; sample < capacity; ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(read[static_cast<std::size_t>(sample)] == approx(0.0f));
+    }
+
+    // The half it can is the newest audio, in order.
+    CHECK(read[static_cast<std::size_t>(capacity)] == approx(written[written.size() - capacity]));
+    CHECK(read.back() == approx(written.back()));
+}
+
 TEST_CASE("A sample ring downmixes without a maximum block size", "[engine][tap]") {
     SampleRing ring(1024);
 

--- a/tests/test_engine_taps.cpp
+++ b/tests/test_engine_taps.cpp
@@ -174,6 +174,48 @@ TEST_CASE("A sample ring downmixes without a maximum block size", "[engine][tap]
     CHECK(ring.writePosition() == static_cast<std::size_t>(numSamples));
 }
 
+TEST_CASE("A sample ring reads while it is being written", "[engine][tap]") {
+    // The SPSC claim, across two threads, which is where the atomic slots earn
+    // themselves: under `make tsan` a plain float ring laps the reader and
+    // reports a race. What is asserted is only what the class promises, that a
+    // read returns samples the writer has written and the position never goes
+    // backwards. Which samples is deliberately not asserted: the reader is
+    // allowed to be lapped, and that is the documented bound rather than a
+    // failure.
+    SampleRing ring(1024);
+    constexpr int kWrites = 20000;
+    std::atomic<bool> writing{true};
+
+    std::thread writer([&] {
+        for (auto i = 0; i < kWrites; ++i) {
+            const auto sample = static_cast<float>(i % 100) * 0.01f;
+            ring.write(&sample, 1);
+        }
+        writing = false;
+    });
+
+    std::vector<float> read(64);
+    std::size_t lastPosition = 0;
+    auto reads = 0;
+
+    while (writing) {
+        const auto position = ring.readLatest(read.data(), static_cast<int>(read.size()));
+        REQUIRE(position >= lastPosition);
+        lastPosition = position;
+        ++reads;
+    }
+
+    writer.join();
+
+    CHECK(reads > 0);
+    CHECK(ring.writePosition() == static_cast<std::size_t>(kWrites));
+
+    // Whatever it was lapped by along the way, the ring settles on the last
+    // samples written once the writer stops.
+    ring.readLatest(read.data(), static_cast<int>(read.size()));
+    CHECK(read.back() == approx(static_cast<float>((kWrites - 1) % 100) * 0.01f));
+}
+
 TEST_CASE("A level tap loses nothing to a reader running beside the writer", "[engine][tap]") {
     LevelTap tap;
 

--- a/tests/test_engine_taps.cpp
+++ b/tests/test_engine_taps.cpp
@@ -212,8 +212,16 @@ TEST_CASE("A sample ring reads while it is being written", "[engine][tap]") {
     SampleRing ring(1024);
     constexpr int kWrites = 20000;
     std::atomic<bool> writing{true};
+    std::atomic<bool> readerReady{false};
 
+    // The writer waits to be joined before it starts. Without the handshake the
+    // whole run can finish before this thread first looks at `writing`, which
+    // is a legal schedule on a loaded CI box and would leave the test asserting
+    // about an overlap that never happened.
     std::thread writer([&] {
+        while (!readerReady) {
+        }
+
         for (auto i = 0; i < kWrites; ++i) {
             const auto sample = static_cast<float>(i % 100) * 0.01f;
             ring.write(&sample, 1);
@@ -225,6 +233,7 @@ TEST_CASE("A sample ring reads while it is being written", "[engine][tap]") {
     std::size_t lastPosition = 0;
     auto reads = 0;
 
+    readerReady = true;
     while (writing) {
         const auto position = ring.readLatest(read.data(), static_cast<int>(read.size()));
         REQUIRE(position >= lastPosition);

--- a/tests/test_engine_taps.cpp
+++ b/tests/test_engine_taps.cpp
@@ -1,0 +1,205 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <thread>
+#include <vector>
+
+#include "tap/LevelTap.hpp"
+#include "tap/SampleRing.hpp"
+
+using magda::engine::LevelTap;
+using magda::engine::SampleRing;
+
+namespace {
+
+Catch::Approx approx(float value) {
+    return Catch::Approx(value).margin(1e-6);
+}
+
+/// A stereo block whose channels differ, so a tap that folded them together
+/// would be caught rather than merely suspected.
+struct Block {
+    Block(std::initializer_list<float> left, std::initializer_list<float> right)
+        : samples(2, static_cast<int>(left.size())) {
+        int index = 0;
+        for (const auto value : left)
+            samples.setSample(0, index++, value);
+        index = 0;
+        for (const auto value : right)
+            samples.setSample(1, index++, value);
+    }
+
+    juce::dsp::AudioBlock<const float> block() const {
+        return juce::dsp::AudioBlock<const float>(samples);
+    }
+
+    int numSamples() const {
+        return samples.getNumSamples();
+    }
+
+    juce::AudioBuffer<float> samples;
+};
+
+}  // namespace
+
+TEST_CASE("A level tap reports each channel's own peak", "[engine][tap]") {
+    LevelTap tap;
+    const Block block({0.25f, -0.5f}, {0.1f, 0.75f});
+
+    tap.write(block.block(), block.numSamples());
+
+    const auto levels = tap.read();
+    CHECK(levels.peak[0] == approx(0.5f));
+    CHECK(levels.peak[1] == approx(0.75f));
+}
+
+TEST_CASE("A level tap reports the loudest block since it was read, not the last one",
+          "[engine][tap]") {
+    LevelTap tap;
+
+    // The transient is in the middle. A meter that reported the most recent
+    // block would show the quiet one that followed it, which is how a drum hit
+    // goes missing on a display that is not polling fast enough.
+    tap.write(Block({0.2f}, {0.2f}).block(), 1);
+    tap.write(Block({0.9f}, {0.9f}).block(), 1);
+    tap.write(Block({0.1f}, {0.1f}).block(), 1);
+
+    CHECK(tap.read().loudest() == approx(0.9f));
+}
+
+TEST_CASE("Reading a level tap starts it again", "[engine][tap]") {
+    LevelTap tap;
+    tap.write(Block({0.6f}, {0.6f}).block(), 1);
+
+    REQUIRE(tap.read().loudest() == approx(0.6f));
+
+    // Nothing has been written since, so the peak that was already reported is
+    // not reported twice: a meter that held its value would never fall.
+    CHECK(tap.read().loudest() == approx(0.0f));
+}
+
+TEST_CASE("Silence written to a level tap does not lower what has not been read", "[engine][tap]") {
+    LevelTap tap;
+    tap.write(Block({0.8f}, {0.8f}).block(), 1);
+    tap.write(Block({0.0f}, {0.0f}).block(), 1);
+
+    // How fast a meter falls is the reader's cadence. A silent block that took
+    // the peak back down would make it the block size instead, so a hit landing
+    // just before a poll would be missed at one buffer size and caught at
+    // another.
+    CHECK(tap.read().loudest() == approx(0.8f));
+}
+
+TEST_CASE("A level tap reports a mono block on both channels", "[engine][tap]") {
+    LevelTap tap;
+    juce::AudioBuffer<float> mono(1, 1);
+    mono.setSample(0, 0, 0.4f);
+
+    tap.write(juce::dsp::AudioBlock<const float>(mono), 1);
+
+    const auto levels = tap.read();
+    CHECK(levels.peak[0] == approx(0.4f));
+    CHECK(levels.peak[1] == approx(0.4f));
+}
+
+TEST_CASE("A cleared level tap has nothing to report", "[engine][tap]") {
+    LevelTap tap;
+    tap.write(Block({0.9f}, {0.9f}).block(), 1);
+
+    tap.clear();
+
+    CHECK(tap.read().loudest() == approx(0.0f));
+}
+
+TEST_CASE("A sample ring hands back the samples most recently written", "[engine][tap]") {
+    SampleRing ring(1024);
+    std::vector<float> written(300);
+    for (std::size_t i = 0; i < written.size(); ++i)
+        written[i] = static_cast<float>(i);
+
+    ring.write(written.data(), static_cast<int>(written.size()));
+
+    std::vector<float> read(4);
+    CHECK(ring.readLatest(read.data(), 4) == written.size());
+    CHECK(read[0] == approx(296.0f));
+    CHECK(read[3] == approx(299.0f));
+}
+
+TEST_CASE("A sample ring that has not filled once pads with silence", "[engine][tap]") {
+    SampleRing ring(1024);
+    const float sample = 1.0f;
+    ring.write(&sample, 1);
+
+    std::vector<float> read(4);
+    ring.readLatest(read.data(), 4);
+
+    // Silence in front rather than whatever the allocation held: a scope opened
+    // a moment ago draws a flat line, not noise.
+    CHECK(read[0] == approx(0.0f));
+    CHECK(read[2] == approx(0.0f));
+    CHECK(read[3] == approx(1.0f));
+}
+
+TEST_CASE("A sample ring keeps the newest samples once it has wrapped", "[engine][tap]") {
+    SampleRing ring(1024);
+    const auto capacity = ring.capacity();
+
+    std::vector<float> written(static_cast<std::size_t>(capacity) + 100);
+    for (std::size_t i = 0; i < written.size(); ++i)
+        written[i] = static_cast<float>(i);
+    ring.write(written.data(), static_cast<int>(written.size()));
+
+    std::vector<float> read(2);
+    ring.readLatest(read.data(), 2);
+    CHECK(read[1] == approx(static_cast<float>(written.size() - 1)));
+}
+
+TEST_CASE("A sample ring downmixes without a maximum block size", "[engine][tap]") {
+    SampleRing ring(1024);
+
+    // Longer than anything a prepare could have been told about. Writing
+    // straight into the ring is what makes that a non-question; a tap with
+    // scratch would have to drop the block or allocate.
+    const auto numSamples = ring.capacity() / 2;
+    juce::AudioBuffer<float> stereo(2, numSamples);
+    for (int sample = 0; sample < numSamples; ++sample) {
+        stereo.setSample(0, sample, 1.0f);
+        stereo.setSample(1, sample, 0.0f);
+    }
+
+    ring.writeDownmix(juce::dsp::AudioBlock<const float>(stereo), numSamples);
+
+    std::vector<float> read(1);
+    ring.readLatest(read.data(), 1);
+    CHECK(read[0] == approx(0.5f));
+    CHECK(ring.writePosition() == static_cast<std::size_t>(numSamples));
+}
+
+TEST_CASE("A level tap loses nothing to a reader running beside the writer", "[engine][tap]") {
+    LevelTap tap;
+
+    // The one thing the compare-and-swap in accumulate() is there for: a read
+    // landing between a write's load and its store must not put back a peak
+    // that has already been reported, and must not swallow one that has not.
+    // The loudest sample is written once, so exactly one read has to see it.
+    constexpr int kWrites = 20000;
+    std::atomic<bool> writing{true};
+
+    std::thread writer([&] {
+        for (auto i = 0; i < kWrites; ++i) {
+            const auto level = i == kWrites / 2 ? 1.0f : 0.25f;
+            juce::AudioBuffer<float> buffer(2, 1);
+            buffer.setSample(0, 0, level);
+            buffer.setSample(1, 0, level);
+            tap.write(juce::dsp::AudioBlock<const float>(buffer), 1);
+        }
+        writing = false;
+    });
+
+    auto sawTheTransient = false;
+    while (writing)
+        sawTheTransient |= tap.read().loudest() > 0.9f;
+    sawTheTransient |= tap.read().loudest() > 0.9f;
+
+    writer.join();
+    CHECK(sawTheTransient);
+}

--- a/tests/test_file_audio_source.cpp
+++ b/tests/test_file_audio_source.cpp
@@ -1,0 +1,251 @@
+#include <algorithm>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <vector>
+
+#include "io/FileAudioSource.hpp"
+#include "io/StreamingAudioSource.hpp"
+
+using magda::engine::AudioFileReader;
+using magda::engine::BlockInfo;
+using magda::engine::ClipPlacement;
+using magda::engine::FileAudioSource;
+using magda::engine::PrefetchSettings;
+using magda::engine::PrefetchStream;
+using magda::engine::RenderContext;
+using magda::engine::StreamingAudioSource;
+
+namespace {
+
+constexpr double kSampleRate = 44100.0;
+constexpr int kBlockSize = 64;
+
+/// Sample n reads back as n, so where a sample came from is readable off its
+/// value rather than inferred from where it landed.
+class CountingReader final : public AudioFileReader {
+  public:
+    explicit CountingReader(std::int64_t length) : length_(length) {}
+
+    std::int64_t lengthInSamples() const override {
+        return length_;
+    }
+
+    double sampleRate() const override {
+        return kSampleRate;
+    }
+
+    int numChannels() const override {
+        return 2;
+    }
+
+    int read(juce::AudioBuffer<float>& destination, int destinationOffset, std::int64_t startSample,
+             int numSamples) override {
+        const auto available =
+            static_cast<int>(std::clamp<std::int64_t>(length_ - startSample, 0, numSamples));
+
+        for (auto channel = 0; channel < destination.getNumChannels(); ++channel)
+            for (auto sample = 0; sample < available; ++sample)
+                destination.setSample(channel, destinationOffset + sample,
+                                      static_cast<float>(startSample + sample));
+
+        if (available < numSamples)
+            destination.clear(destinationOffset + available, numSamples - available);
+
+        return available;
+    }
+
+  private:
+    std::int64_t length_;
+};
+
+RenderContext context() {
+    return RenderContext{kSampleRate, kBlockSize, 2};
+}
+
+Catch::Approx approx(float value) {
+    return Catch::Approx(value).margin(1e-4);
+}
+
+BlockInfo blockFrom(double startSeconds, int numSamples = kBlockSize, bool continuous = true) {
+    BlockInfo block;
+    block.numSamples = numSamples;
+    block.playing = true;
+    block.startSeconds = startSeconds;
+    block.endSeconds = startSeconds + numSamples / kSampleRate;
+    block.startBeat = startSeconds * 2.0;
+    block.endBeat = block.endSeconds * 2.0;
+    block.continuous = continuous;
+    return block;
+}
+
+/// The whole of channel 0 across @p numBlocks consecutive blocks, so what a
+/// source rendered is one stream rather than a pile of buffers.
+std::vector<float> renderStream(magda::engine::EngineAudioSource& source, double startSeconds,
+                                int numBlocks, int blockSize = kBlockSize) {
+    juce::AudioBuffer<float> buffer(2, blockSize);
+    std::vector<float> stream;
+
+    for (auto index = 0; index < numBlocks; ++index) {
+        const auto seconds = startSeconds + index * blockSize / kSampleRate;
+        source.render(blockFrom(seconds, blockSize, index > 0),
+                      juce::dsp::AudioBlock<float>(buffer));
+        for (auto sample = 0; sample < blockSize; ++sample)
+            stream.push_back(buffer.getSample(0, sample));
+    }
+
+    return stream;
+}
+
+}  // namespace
+
+TEST_CASE("An offline source plays the samples the clip is placed over", "[engine][io][offline]") {
+    CountingReader reader(100000);
+    const ClipPlacement placement{0.0, 1.0, 0};
+    FileAudioSource source(reader, placement);
+    source.prepare(context());
+
+    const auto stream = renderStream(source, 0.0, 3);
+
+    REQUIRE(stream.size() == static_cast<std::size_t>(3 * kBlockSize));
+    CHECK(stream[0] == approx(0.0f));
+    CHECK(stream[1] == approx(1.0f));
+    CHECK(stream[kBlockSize] == approx(static_cast<float>(kBlockSize)));
+    CHECK(stream.back() == approx(static_cast<float>(3 * kBlockSize - 1)));
+}
+
+TEST_CASE("An offline source and a streaming one render the same clip identically",
+          "[engine][io][offline]") {
+    // The claim the whole offline path rests on: a bounce is what was heard.
+    // The two read through different machinery and share only the placement
+    // mapping, so this is what catches them drifting apart.
+    const ClipPlacement placement{0.5, 2.0, 1000};
+
+    // Starting shortly before the clip, so the comparison covers the silence in
+    // front of it, the block its start falls inside, and material either side
+    // of a chunk boundary. Starting on it would compare two runs of silence and
+    // pass whatever the two sources did with a file.
+    constexpr double kFirstBlockSeconds = 0.49;
+    constexpr int kBlocks = 40;
+
+    CountingReader offlineReader(100000);
+    FileAudioSource offline(offlineReader, placement);
+    offline.prepare(context());
+    const auto offlineStream = renderStream(offline, kFirstBlockSeconds, kBlocks);
+
+    PrefetchStream stream(std::make_unique<CountingReader>(100000), context(),
+                          PrefetchSettings{256, 8});
+    StreamingAudioSource live(stream, placement);
+    live.prepare(context());
+
+    // No prefetch thread: fill() is pumped here instead, so the live source is
+    // never short and the comparison is about the samples rather than about a
+    // disk's timing. Cued and taken up before the first block, which is what
+    // scheduling material ahead of the callback amounts to.
+    stream.seek(live.sourceSampleAt(placement.startSeconds));
+    stream.applyPendingCue();
+
+    juce::AudioBuffer<float> buffer(2, kBlockSize);
+    std::vector<float> liveStream;
+
+    for (auto index = 0; index < kBlocks; ++index) {
+        while (stream.fill()) {
+        }
+
+        const auto seconds = kFirstBlockSeconds + index * kBlockSize / kSampleRate;
+        live.render(blockFrom(seconds, kBlockSize, index > 0),
+                    juce::dsp::AudioBlock<float>(buffer));
+        for (auto sample = 0; sample < kBlockSize; ++sample)
+            liveStream.push_back(buffer.getSample(0, sample));
+    }
+
+    CHECK(stream.underruns() == 0);
+
+    // The comparison has to be over material. Two runs of silence agree
+    // perfectly and say nothing, which is what this test did before the range
+    // was moved onto the clip.
+    const auto sounding = std::count_if(offlineStream.begin(), offlineStream.end(),
+                                        [](float sample) { return sample != 0.0f; });
+    REQUIRE(sounding > kBlockSize);
+
+    REQUIRE(liveStream.size() == offlineStream.size());
+    for (std::size_t sample = 0; sample < offlineStream.size(); ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(liveStream[sample] == approx(offlineStream[sample]));
+    }
+}
+
+TEST_CASE("An offline source renders the same samples at any block size", "[engine][io][offline]") {
+    const ClipPlacement placement{0.0, 4.0, 0};
+
+    CountingReader shortReader(100000);
+    FileAudioSource shortBlocks(shortReader, placement);
+    shortBlocks.prepare(RenderContext{kSampleRate, 16, 2});
+
+    CountingReader longReader(100000);
+    FileAudioSource longBlocks(longReader, placement);
+    longBlocks.prepare(RenderContext{kSampleRate, 256, 2});
+
+    const auto fromShort = renderStream(shortBlocks, 0.0, 16, 16);
+    const auto fromLong = renderStream(longBlocks, 0.0, 1, 256);
+
+    REQUIRE(fromShort.size() == fromLong.size());
+    for (std::size_t sample = 0; sample < fromShort.size(); ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(fromShort[sample] == approx(fromLong[sample]));
+    }
+}
+
+TEST_CASE("An offline source renders silence outside the clip", "[engine][io][offline]") {
+    CountingReader reader(100000);
+
+    // The clip starts a quarter of a block in and ends half a block later.
+    const auto quarter = 0.25 * kBlockSize / kSampleRate;
+    const ClipPlacement placement{quarter, quarter + 0.5 * kBlockSize / kSampleRate, 0};
+    FileAudioSource source(reader, placement);
+    source.prepare(context());
+
+    juce::AudioBuffer<float> buffer(2, kBlockSize);
+    buffer.clear();
+    source.render(blockFrom(0.0), juce::dsp::AudioBlock<float>(buffer));
+
+    CHECK(buffer.getSample(0, 0) == approx(0.0f));
+    CHECK(buffer.getSample(0, kBlockSize / 4) == approx(0.0f));
+    CHECK(buffer.getSample(0, kBlockSize / 4 + 1) == approx(1.0f));
+    CHECK(buffer.getSample(0, 3 * kBlockSize / 4) == approx(0.0f));
+    CHECK(buffer.getSample(0, kBlockSize - 1) == approx(0.0f));
+}
+
+TEST_CASE("An offline source renders nothing while the transport is stopped",
+          "[engine][io][offline]") {
+    CountingReader reader(100000);
+    FileAudioSource source(reader, ClipPlacement{0.0, 4.0, 0});
+    source.prepare(context());
+
+    juce::AudioBuffer<float> buffer(2, kBlockSize);
+    auto block = blockFrom(1.0);
+    block.playing = false;
+    block.endSeconds = block.startSeconds;
+
+    source.render(block, juce::dsp::AudioBlock<float>(buffer));
+
+    for (auto sample = 0; sample < kBlockSize; ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(buffer.getSample(0, sample) == approx(0.0f));
+    }
+}
+
+TEST_CASE("An offline source runs off the end of a file as silence", "[engine][io][offline]") {
+    // The clip claims more material than the file has. What is missing is
+    // silence, and the clip stays the length it was placed at: a file that ran
+    // out is not a reason to move what comes after it.
+    CountingReader reader(kBlockSize + 10);
+    FileAudioSource source(reader, ClipPlacement{0.0, 4.0, 0});
+    source.prepare(context());
+
+    const auto stream = renderStream(source, 0.0, 2);
+
+    CHECK(stream[kBlockSize + 9] == approx(static_cast<float>(kBlockSize + 9)));
+    CHECK(stream[kBlockSize + 10] == approx(0.0f));
+    CHECK(stream.back() == approx(0.0f));
+}

--- a/tests/test_offline_render.cpp
+++ b/tests/test_offline_render.cpp
@@ -1,0 +1,387 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <map>
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "core/RackInfo.hpp"
+#include "core/TrackInfo.hpp"
+#include "exec/OfflineRender.hpp"
+#include "exec/PlanValues.hpp"
+#include "plan/PlanCompiler.hpp"
+#include "plan/RenderPlan.hpp"
+#include "tap/LevelTap.hpp"
+
+using namespace magda;
+using magda::engine::BlockInfo;
+using magda::engine::DeviceBlock;
+using magda::engine::EngineAudioSource;
+using magda::engine::EngineDevice;
+using magda::engine::OfflineRenderRequest;
+using magda::engine::OfflineRenderSink;
+using magda::engine::PlanBindings;
+using magda::engine::PlanExecutor;
+using magda::engine::PlanValues;
+using magda::engine::RenderContext;
+using magda::engine::RenderPlan;
+using magda::engine::TempoMap;
+
+namespace {
+
+constexpr double kSampleRate = 44100.0;
+
+TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Audio) {
+    TrackInfo track;
+    track.id = id;
+    track.type = type;
+    track.name = "Track " + juce::String(id);
+    track.audioOutputDevice = "master";
+    return track;
+}
+
+TrackInfo makeMaster() {
+    auto master = makeTrack(MASTER_TRACK_ID, TrackType::Master);
+    master.audioOutputDevice = {};
+    return master;
+}
+
+DeviceInfo makeEffect(DeviceId id) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Effect " + juce::String(id);
+    device.deviceType = DeviceType::Effect;
+    return device;
+}
+
+/// A tempo map with one tempo, so what a beat is worth in seconds is arithmetic
+/// a test can do in its head.
+TempoMap tempoAt(double bpm) {
+    return TempoMap({{0.0, bpm, 0.0f}}, {});
+}
+
+/// A value derived from where the block is on the timeline rather than from how
+/// many blocks have gone by. That is the whole of what block-size independence
+/// asks of a source: two short blocks must render what one long one would.
+class TimelineRamp final : public EngineAudioSource {
+  public:
+    void prepare(const RenderContext& context) override {
+        sampleRate_ = context.sampleRate;
+    }
+
+    void render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) override {
+        out.clear();
+        if (!block.playing)
+            return;
+
+        const auto start = std::llround(block.startSeconds * sampleRate_);
+        for (auto sample = 0; sample < block.numSamples; ++sample) {
+            const auto value = static_cast<float>((start + sample) % 251) * (1.0f / 251.0f);
+            for (std::size_t channel = 0; channel < out.getNumChannels(); ++channel)
+                out.setSample(static_cast<int>(channel), sample, value);
+        }
+    }
+
+  private:
+    double sampleRate_ = kSampleRate;
+};
+
+/// Rings on after its input stops, which is what a tail is. Counts the blocks
+/// it saw, so a stopped block reaching the graph at all is checkable.
+class DecayDevice final : public EngineDevice {
+  public:
+    void process(DeviceBlock& block) override {
+        ++blocksProcessed;
+        for (auto sample = 0; sample < block.block.numSamples; ++sample) {
+            for (std::size_t channel = 0; channel < block.audio.getNumChannels(); ++channel) {
+                level_ = std::max(
+                    level_, std::abs(block.audio.getSample(static_cast<int>(channel), sample)));
+            }
+            for (std::size_t channel = 0; channel < block.audio.getNumChannels(); ++channel)
+                block.audio.setSample(static_cast<int>(channel), sample, level_);
+            level_ *= 0.9999f;
+        }
+    }
+
+    int blocksProcessed = 0;
+
+  private:
+    float level_ = 0.0f;
+};
+
+/// Everything a render produced, as one stream per channel, so two renders are
+/// comparable sample for sample however they were cut into blocks.
+class CollectingSink final : public OfflineRenderSink {
+  public:
+    void write(const juce::AudioBuffer<float>& block, int numSamples) override {
+        for (auto sample = 0; sample < numSamples; ++sample)
+            samples.push_back(block.getSample(0, sample));
+        ++blocks;
+    }
+
+    std::vector<float> samples;
+    int blocks = 0;
+};
+
+/// Compiles a one-track plan and prepares an executor for it, so a test says
+/// what it renders and nothing about how a plan is built.
+struct Harness {
+    explicit Harness(bool withDecay = false) {
+        auto track = makeTrack(1);
+        if (withDecay)
+            track.chain.fxChainElements.push_back(makeEffect(10));
+
+        tracks = {track};
+        master = makeMaster();
+        plan = magda::engine::compileRenderPlan(tracks, master);
+    }
+
+    /// Prepared for @p maxBlockSize, which is the only thing an offline render
+    /// is allowed to have an opinion about.
+    std::vector<std::string> prepare(int maxBlockSize) {
+        context = RenderContext{kSampleRate, maxBlockSize, 2};
+
+        source = std::make_unique<TimelineRamp>();
+        source->prepare(context);
+        bindings.clipAudio[1] = source.get();
+
+        for (const auto& op : plan.ops) {
+            if (op.kind != magda::engine::OpKind::Device)
+                continue;
+            auto device = std::make_unique<DecayDevice>();
+            device->prepare(context);
+            decay = device.get();
+            devices.push_back(std::move(device));
+            bindings.devices[op.key.deviceId] = decay;
+        }
+
+        valueMessages = magda::engine::resolvePlanValues(plan, tracks, master, values);
+        return executor.prepare(plan, bindings, context);
+    }
+
+    magda::engine::OfflineRenderResult render(const OfflineRenderRequest& request,
+                                              CollectingSink& sink,
+                                              const std::function<bool()>& shouldContinue = {}) {
+        return magda::engine::renderOffline(executor, values, context, tempo, request, sink,
+                                            shouldContinue);
+    }
+
+    std::vector<TrackInfo> tracks;
+    TrackInfo master;
+    RenderPlan plan;
+    PlanBindings bindings;
+    PlanValues values;
+    std::vector<std::string> valueMessages;
+    PlanExecutor executor;
+    RenderContext context;
+    TempoMap tempo = tempoAt(120.0);
+
+    std::unique_ptr<TimelineRamp> source;
+    std::vector<std::unique_ptr<DecayDevice>> devices;
+    DecayDevice* decay = nullptr;
+};
+
+Catch::Approx approx(float value) {
+    return Catch::Approx(value).margin(1e-6);
+}
+
+}  // namespace
+
+TEST_CASE("An offline render covers exactly the range it was asked for", "[engine][offline]") {
+    Harness harness;
+    REQUIRE(harness.prepare(512).empty());
+
+    // Four beats at 120 bpm is two seconds.
+    CollectingSink sink;
+    const auto result = harness.render({0.0, 4.0, 0.0, 512}, sink);
+
+    CHECK_FALSE(result.refused);
+    CHECK_FALSE(result.cancelled);
+    CHECK(result.samplesRendered == static_cast<std::int64_t>(std::llround(2.0 * kSampleRate)));
+    CHECK(sink.samples.size() == static_cast<std::size_t>(result.samplesRendered));
+}
+
+TEST_CASE("An offline render is the same audio at any block size", "[engine][offline]") {
+    // The property the null-diff harness rests on. If this can fail, a
+    // difference between the two engines could be a difference in how the
+    // comparison was pulled rather than in what they render.
+    std::vector<float> reference;
+
+    for (const auto blockSize : {17, 64, 512, 4096}) {
+        Harness harness;
+        REQUIRE(harness.prepare(4096).empty());
+
+        CollectingSink sink;
+        const auto result = harness.render({1.0, 5.0, 0.0, blockSize}, sink);
+        REQUIRE_FALSE(result.refused);
+
+        INFO("block size " << blockSize);
+        if (reference.empty()) {
+            reference = sink.samples;
+            REQUIRE_FALSE(reference.empty());
+
+            // Comparing two renders of silence would pass at every block size
+            // and mean nothing, so the material has to be material.
+            const auto distinct = std::set<float>(reference.begin(), reference.end()).size();
+            REQUIRE(distinct > 100);
+            continue;
+        }
+
+        REQUIRE(sink.samples.size() == reference.size());
+        for (std::size_t sample = 0; sample < reference.size(); ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(sink.samples[sample] == approx(reference[sample]));
+        }
+    }
+}
+
+TEST_CASE("An offline render starts where the range starts", "[engine][offline]") {
+    // Two renders of the same beat, reached from different places. What comes
+    // out has to be the same audio: the cursor is a position on the timeline,
+    // not a distance from wherever the render happened to begin.
+    Harness fromZero;
+    REQUIRE(fromZero.prepare(512).empty());
+    CollectingSink wholeRange;
+    fromZero.render({0.0, 8.0, 0.0, 512}, wholeRange);
+
+    Harness fromFour;
+    REQUIRE(fromFour.prepare(512).empty());
+    CollectingSink secondHalf;
+    fromFour.render({4.0, 8.0, 0.0, 512}, secondHalf);
+
+    const auto offset = wholeRange.samples.size() - secondHalf.samples.size();
+    REQUIRE(secondHalf.samples.size() > 0);
+    for (std::size_t sample = 0; sample < secondHalf.samples.size(); ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(secondHalf.samples[sample] == approx(wholeRange.samples[offset + sample]));
+    }
+}
+
+TEST_CASE("An offline render keeps rendering for the tail it was given", "[engine][offline]") {
+    Harness harness(true);
+    REQUIRE(harness.prepare(512).empty());
+    REQUIRE(harness.decay != nullptr);
+
+    CollectingSink sink;
+    const auto result = harness.render({0.0, 2.0, 0.5, 512}, sink);
+
+    const auto rangeSamples = static_cast<std::int64_t>(std::llround(1.0 * kSampleRate));
+    const auto tailSamples = static_cast<std::int64_t>(std::llround(0.5 * kSampleRate));
+    CHECK(result.samplesRendered == rangeSamples + tailSamples);
+
+    // The tail is audible, not silence appended to the file: the graph kept
+    // running through blocks the timeline did not move across.
+    CHECK(sink.samples.back() != approx(0.0f));
+}
+
+TEST_CASE("A tail is exactly as long as it was asked for", "[engine][offline]") {
+    // Not "until it goes quiet". A gated or tremolo'd tail is silent in the
+    // middle, and a render that stopped at the first silent block would cut it
+    // there; trimming what the caller does not want is the caller's, because it
+    // has the samples and this does not have the intent.
+    Harness harness;
+    REQUIRE(harness.prepare(512).empty());
+
+    CollectingSink sink;
+    const auto result = harness.render({0.0, 1.0, 0.25, 512}, sink);
+
+    const auto rangeSamples = static_cast<std::int64_t>(std::llround(0.5 * kSampleRate));
+    const auto tailSamples = static_cast<std::int64_t>(std::llround(0.25 * kSampleRate));
+    CHECK(result.samplesRendered == rangeSamples + tailSamples);
+
+    // Nothing is placed after the range, so the tail of a plan with no tail in
+    // it is silence, and it is still exactly the length asked for.
+    CHECK(sink.samples.back() == approx(0.0f));
+}
+
+TEST_CASE("Nothing plays during an offline render's tail", "[engine][offline]") {
+    // The cursor stands still, so material after the range is not printed into
+    // the bounce. A source that rendered on through the tail would be the
+    // clearest possible sign the transport kept moving.
+    Harness harness;
+    REQUIRE(harness.prepare(512).empty());
+
+    CollectingSink sink;
+    harness.render({0.0, 2.0, 0.5, 512}, sink);
+
+    const auto rangeSamples = static_cast<std::size_t>(std::llround(1.0 * kSampleRate));
+    for (auto sample = rangeSamples; sample < sink.samples.size(); ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(sink.samples[sample] == approx(0.0f));
+    }
+}
+
+TEST_CASE("An offline render stops when the caller says to", "[engine][offline]") {
+    Harness harness;
+    REQUIRE(harness.prepare(512).empty());
+
+    CollectingSink sink;
+    auto blocksLeft = 3;
+    const auto result =
+        harness.render({0.0, 64.0, 0.0, 512}, sink, [&blocksLeft] { return blocksLeft-- > 0; });
+
+    CHECK(result.cancelled);
+    CHECK(result.blocksRendered == 3);
+
+    // What was rendered stays rendered. An abandoned bounce is a short file
+    // rather than a corrupt one, and which of those to keep is the caller's.
+    CHECK(sink.samples.size() == static_cast<std::size_t>(3 * 512));
+}
+
+TEST_CASE("An empty range renders nothing and is not a failure", "[engine][offline]") {
+    Harness harness;
+    REQUIRE(harness.prepare(512).empty());
+
+    CollectingSink sink;
+    const auto result = harness.render({4.0, 4.0, 0.0, 512}, sink);
+
+    CHECK_FALSE(result.refused);
+    CHECK(result.samplesRendered == 0);
+    CHECK(sink.blocks == 0);
+}
+
+TEST_CASE("An offline render refuses values that belong to another plan", "[engine][offline]") {
+    Harness harness;
+    REQUIRE(harness.prepare(512).empty());
+
+    // What the executor would do with these is render at unity, which as a
+    // bounce is a file with every fader at 0 dB and nothing saying why.
+    harness.values.planFingerprint ^= 1;
+
+    CollectingSink sink;
+    const auto result = harness.render({0.0, 4.0, 0.0, 512}, sink);
+
+    CHECK(result.refused);
+    CHECK(result.samplesRendered == 0);
+    CHECK(sink.blocks == 0);
+}
+
+TEST_CASE("An offline render does not need meters bound", "[engine][offline]") {
+    // A plan has a meter at every track and device slot. Offline there is
+    // nothing watching them, and needing to bind one per meter to render a
+    // bounce would be ceremony that every host doing an export would pay.
+    Harness harness;
+    const auto messages = harness.prepare(512);
+    REQUIRE(messages.empty());
+    CHECK(harness.executor.boundMeterCount() == 0);
+
+    CollectingSink sink;
+    CHECK_FALSE(harness.render({0.0, 4.0, 0.0, 512}, sink).refused);
+    CHECK(sink.samples.size() > 0);
+}
+
+TEST_CASE("An offline render's block size is held to what the plan was prepared for",
+          "[engine][offline]") {
+    Harness harness;
+    REQUIRE(harness.prepare(128).empty());
+
+    CollectingSink sink;
+    const auto result = harness.render({0.0, 4.0, 0.0, 4096}, sink);
+
+    CHECK_FALSE(result.refused);
+    CHECK(result.samplesRendered == static_cast<std::int64_t>(std::llround(2.0 * kSampleRate)));
+    // Cut to the prepared size rather than asserted against: the caller's block
+    // size is a batching hint and the render is the same audio either way.
+    CHECK(result.blocksRendered == static_cast<int>((result.samplesRendered + 127) / 128));
+}

--- a/tests/test_offline_render.cpp
+++ b/tests/test_offline_render.cpp
@@ -397,6 +397,37 @@ TEST_CASE("An offline render refuses values that belong to another plan", "[engi
     CHECK(sink.blocks == 0);
 }
 
+TEST_CASE("An offline render refuses a context the plan was not prepared for",
+          "[engine][offline]") {
+    // Every field, because each one goes wrong differently and all of them go
+    // wrong quietly. A longer maxBlockSize gets the head of every block and
+    // silence for the rest, since the executor renders only what it prepared
+    // for and says so with an assert that is not there in release. A different
+    // rate runs the whole bounce at the wrong speed, and a different channel
+    // count renders it at the wrong width.
+    Harness harness;
+    REQUIRE(harness.prepare(512).empty());
+
+    auto mismatched = harness.context;
+    SECTION("a longer block than it prepared for") {
+        mismatched.maxBlockSize = 4096;
+    }
+    SECTION("another sample rate") {
+        mismatched.sampleRate = 96000.0;
+    }
+    SECTION("another channel count") {
+        mismatched.numChannels = 1;
+    }
+
+    CollectingSink sink;
+    const auto result = magda::engine::renderOffline(harness.executor, harness.values, mismatched,
+                                                     harness.tempo, {0.0, 4.0, 0.0, 512}, sink);
+
+    CHECK(result.refused);
+    CHECK(result.samplesRendered == 0);
+    CHECK(sink.blocks == 0);
+}
+
 TEST_CASE("An offline render does not need meters bound", "[engine][offline]") {
     // A plan has a meter at every track and device slot. Offline there is
     // nothing watching them, and needing to bind one per meter to render a

--- a/tests/test_offline_render.cpp
+++ b/tests/test_offline_render.cpp
@@ -93,6 +93,7 @@ class DecayDevice final : public EngineDevice {
   public:
     void process(DeviceBlock& block) override {
         ++blocksProcessed;
+        startBeats.push_back(block.block.startBeat);
         for (auto sample = 0; sample < block.block.numSamples; ++sample) {
             for (std::size_t channel = 0; channel < block.audio.getNumChannels(); ++channel) {
                 level_ = std::max(
@@ -105,6 +106,11 @@ class DecayDevice final : public EngineDevice {
     }
 
     int blocksProcessed = 0;
+
+    /// Where on the timeline each block sat. A device sees every block, tail
+    /// included, which is what makes it the one thing that can say where a
+    /// stopped block thinks it is.
+    std::vector<double> startBeats;
 
   private:
     float level_ = 0.0f;
@@ -309,6 +315,40 @@ TEST_CASE("Nothing plays during an offline render's tail", "[engine][offline]") 
     for (auto sample = rangeSamples; sample < sink.samples.size(); ++sample) {
         INFO("sample " << sample);
         REQUIRE(sink.samples[sample] == approx(0.0f));
+    }
+}
+
+TEST_CASE("A tail stands where the range ended", "[engine][offline]") {
+    Harness harness(true);
+    REQUIRE(harness.prepare(512).empty());
+    REQUIRE(harness.decay != nullptr);
+
+    CollectingSink sink;
+    harness.render({4.0, 8.0, 0.25, 512}, sink);
+
+    REQUIRE_FALSE(harness.decay->startBeats.empty());
+    CHECK(harness.decay->startBeats.front() == approx(4.0f));
+    CHECK(harness.decay->startBeats.back() == approx(8.0f));
+}
+
+TEST_CASE("An empty range's tail stands where the range was, not at the beginning",
+          "[engine][offline]") {
+    // A range that rounds to no samples renders no blocks, so nothing had
+    // applied the locate. The tail would then run at beat zero, where the clock
+    // starts, and a transport-aware device would be handed a tail from the
+    // wrong end of the song.
+    Harness harness(true);
+    REQUIRE(harness.prepare(512).empty());
+    REQUIRE(harness.decay != nullptr);
+
+    CollectingSink sink;
+    const auto result = harness.render({4.0, 4.0, 0.25, 512}, sink);
+
+    CHECK(result.samplesRendered == static_cast<std::int64_t>(std::llround(0.25 * kSampleRate)));
+    REQUIRE_FALSE(harness.decay->startBeats.empty());
+    for (const auto beat : harness.decay->startBeats) {
+        INFO("block at beat " << beat);
+        REQUIRE(beat == approx(4.0f));
     }
 }
 

--- a/tests/test_render_plan_executor.cpp
+++ b/tests/test_render_plan_executor.cpp
@@ -1,6 +1,8 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <deque>
+#include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -365,7 +367,22 @@ struct Harness {
         valueMessages = magda::engine::resolvePlanValues(plan, tracks, master, values);
         const RenderContext context{44100.0, kBlockSize, 2};
         prepareBindings(bindings, context);
+        bindMeters();
         return executor.prepare(plan, bindings, context);
+    }
+
+    /// A tap on every Meter op, which is what a host with a mixer on screen
+    /// binds. Nothing forces it: a Meter op with no tap renders the same and
+    /// publishes nothing.
+    void bindMeters() {
+        for (const auto& op : plan.ops) {
+            if (op.kind != magda::engine::OpKind::Meter)
+                continue;
+            auto& tap = meters[op.key];
+            if (tap == nullptr)
+                tap = std::make_unique<magda::engine::LevelTap>();
+            bindings.meters[op.key] = tap.get();
+        }
     }
 
     /// Prepares, requiring both layers to have nothing to report.
@@ -397,14 +414,20 @@ struct Harness {
         return magda::engine::INVALID_OP_ID;
     }
 
-    float meterFor(OpRole role, TrackId trackId) const {
-        return executor.meterLevels()[static_cast<std::size_t>(opWithRole(role, trackId))];
+    /// Takes the tap's level, which is what reading a meter does: it reports
+    /// the loudest thing since it was last read and starts again.
+    float takeMeterFor(OpRole role, TrackId trackId) {
+        const auto op = opWithRole(role, trackId);
+        const auto found = meters.find(plan.ops[static_cast<std::size_t>(op)].key);
+        REQUIRE(found != meters.end());
+        return found->second->read().loudest();
     }
 
     std::vector<TrackInfo> tracks;
     TrackInfo master;
     RenderPlan plan;
     PlanBindings bindings;
+    std::map<magda::engine::OpKey, std::unique_ptr<magda::engine::LevelTap>> meters;
     PlanValues values;
     std::vector<std::string> valueMessages;
     PlanExecutor executor;
@@ -521,7 +544,7 @@ TEST_CASE("Mute silences the track after its meter has read it", "[engine][exec]
     CHECK(harness.outputSample() == approx(0.0f));
     // Mute is its own stage after the meter, so a muted track still shows a
     // level: folding it into the fader would make the meter read silence.
-    CHECK(harness.meterFor(OpRole::TrackMeter, 1) == approx(0.8f));
+    CHECK(harness.takeMeterFor(OpRole::TrackMeter, 1) == approx(0.8f));
 }
 
 TEST_CASE("Solo silences the tracks that are not soloed", "[engine][exec]") {
@@ -775,7 +798,7 @@ TEST_CASE("A rack chain out of the mix contributes neither audio nor MIDI", "[en
         // The instrument in the muted chain never ran, so the chain adds
         // nothing to the mix: it is out of the graph, not turned down.
         CHECK(harness.outputSample() == approx(0.25f));
-        CHECK(harness.meterFor(OpRole::DeviceMeter, 1) == approx(0.0f));
+        CHECK(harness.takeMeterFor(OpRole::DeviceMeter, 1) == approx(0.0f));
     }
 
     SECTION("a sibling chain is soloed") {
@@ -790,7 +813,7 @@ TEST_CASE("A rack chain out of the mix contributes neither audio nor MIDI", "[en
         harness.prepareCleanly();
         harness.render();
         CHECK(harness.outputSample() == approx(0.25f));
-        CHECK(harness.meterFor(OpRole::DeviceMeter, 1) == approx(0.0f));
+        CHECK(harness.takeMeterFor(OpRole::DeviceMeter, 1) == approx(0.0f));
     }
 }
 
@@ -855,7 +878,7 @@ TEST_CASE("A rack inside a chain out of the mix stops processing", "[engine][exe
     harness.render();
 
     CHECK(nested.processedBlocks == 0);
-    CHECK(harness.meterFor(OpRole::DeviceMeter, 1) == approx(0.0f));
+    CHECK(harness.takeMeterFor(OpRole::DeviceMeter, 1) == approx(0.0f));
     CHECK(harness.outputSample() == approx(0.0f));
 }
 


### PR DESCRIPTION
Slice 8 of #1889. Closes #2017.

## Offline plan rendering

`exec/OfflineRender` drives the executor playback drives, over a beat range, through its own `TransportClock`. Loop, count-in and metronome are all off, and named as off rather than left to defaults: a loop would print the range twice into a bounce that asked for it once, and a click printed into a bounce is the oldest bug in audio software.

The tail renders with the transport stopped, which the engine already defines as the graph running while the timeline stands still, so reverbs ring out and nothing after the range starts playing. It is exactly as long as it was asked for. Stopping at the first silent block would be shorter and would sometimes be wrong, because a gated or tremolo'd tail goes fully silent in the middle; trimming is the caller's, since only it has the samples and the intent.

Values that do not belong to the prepared plan are refused rather than rendered, for the reason a publish refuses them: the executor's answer to values it cannot apply is unity, so the alternative is a bounce with every fader at 0 dB and nothing saying why.

## The offline source

`io/FileAudioSource` reads straight through `AudioFileReader` and is allowed to wait, because there is no callback to starve: no stream, no thread, no chunk pool, no underrun to count.

The placement mapping moves out of `StreamingAudioSource` into `io/ClipPlacement`, so live and offline resolve file positions through one function. A bounce that worked out its own could disagree with what was heard by a sample, and the only way anyone finds out is by listening to the render.

## Taps

`tap/LevelTap` is what a Meter op publishes through: stereo peak, bound by `OpKey` in `PlanBindings`, owned by `RuntimeStateStore` and carried across plan swaps, so a structural edit elsewhere in the project does not reset a meter that was reading. A read takes the peak and starts again, so a meter reports the loudest thing since it was last looked at rather than whichever block the UI happened to land on. `PlanExecutor::meterLevels()` is gone.

`tap/SampleRing` is the same seam for analysis (oscilloscope, spectrum): the most recent N samples, single producer, single consumer. It downmixes straight into the ring, so unlike the incumbent's `AudioTapBuffer` it has no maximum block size and cannot silently drop a block when a host changes its buffer size.

A Meter op with nothing bound is a meter nobody is reading. It is not reported as unbound, because a plan has a meter at every track and every device slot, and every offline render there is would pay for those diagnostics.

## Tests

`test_offline_render.cpp`, `test_file_audio_source.cpp`, `test_engine_taps.cpp`, plus meter lifetime cases in `test_engine_session.cpp`.

The load-bearing one is block-size independence: the same range renders sample-identical at 17, 64, 512 and 4096. #1896 cannot compare two engines over one fixture unless a difference in the output means a difference in what they render rather than in how the comparison was pulled.

Both cross-checking tests were confirmed to fail without their fix. Offsetting the offline source's mapping by one sample fails the agreement test at sample 441, the clip start; leaving the final block uncut fails block-size independence on length. The agreement test was vacuous when first written (the range never reached the clip, so it compared two runs of silence), which is what that mutation found; it now starts before the clip and asserts the comparison is over material.

Meters are store-owned objects, so `runtimeObjectCount()` counts them. One pre-existing session assertion moved from 1 to 3 and now names what survives instead of only counting.

Full Catch2 suite green: 2012 passed, 0 failed, 13 skipped. `magda_juce_tests` builds clean.