### PR TITLE
Native engine: the parallel executor (#2018)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,31 @@ test: test-build
 	@mkdir -p $(CACHE_ROOT)/home $(CACHE_ROOT)/tmp $(CACHE_ROOT)/xdg
 	cd $(BUILD_DIR) && $(TEST_ENV) ./tests/magda_tests
 
+# Build and run the Catch2 tests under ThreadSanitizer. The native engine's
+# parallel executor is lock-free, so "it passed" from an ordinary build says
+# nothing about the orderings it did not happen to take. TEST=<filter> narrows
+# it, e.g. make test-tsan TEST="[parallel]".
+.PHONY: test-tsan-build
+test-tsan-build:
+	@echo "🧵 Building tests (Debug + ThreadSanitizer)..."
+	@mkdir -p $(BUILD_DIR_TSAN) $(CACHE_ROOT)/ccache $(CACHE_ROOT)/tmp $(CACHE_ROOT)/xdg
+	@if [ ! -f $(BUILD_DIR_TSAN)/CMakeCache.txt ]; then \
+		echo "📝 Configuring project with TSAN..."; \
+		cd $(BUILD_DIR_TSAN) && $(BUILD_ENV) cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug \
+			-DCMAKE_CXX_FLAGS="-g -O1 -fno-omit-frame-pointer -fsanitize=thread" \
+			-DCMAKE_C_FLAGS="-g -O1 -fno-omit-frame-pointer -fsanitize=thread" \
+			-DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread" \
+			-DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=thread" \
+			-DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DMAGDA_BUILD_TESTS=ON ..; \
+	fi
+	cd $(BUILD_DIR_TSAN) && $(BUILD_ENV) ninja magda_tests
+
+.PHONY: test-tsan
+test-tsan: test-tsan-build
+	@echo "🧵 Running tests with ThreadSanitizer..."
+	@mkdir -p $(CACHE_ROOT)/home $(CACHE_ROOT)/tmp $(CACHE_ROOT)/xdg
+	cd $(BUILD_DIR_TSAN) && $(TEST_ENV) ./tests/magda_tests $(if $(TEST),"$(TEST)",)
+
 # Run tests using CTest
 .PHONY: test-ctest
 test-ctest: test-build

--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(magda_engine STATIC
     plan/PlanDump.hpp
     plan/TrackRouting.hpp
     exec/PlanExecutor.cpp
+    exec/ParallelPlanExecutor.cpp
+    exec/RenderThreadPool.cpp
     exec/PlanLayout.cpp
     exec/PlanValues.cpp
     exec/RuntimeStateStore.cpp

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -10,7 +10,7 @@ EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> p
     if (plan == nullptr)
         return {false, {"no plan to publish"}};
 
-    auto prepared = std::make_shared<PreparedRender>();
+    auto prepared = std::make_shared<PreparedRender>(pool_);
     prepared->plan = std::move(plan);
     prepared->values = std::move(values);
     prepared->context = context;

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -5,7 +5,8 @@
 #include <string>
 #include <vector>
 
-#include "exec/PlanExecutor.hpp"
+#include "exec/ParallelPlanExecutor.hpp"
+#include "exec/RenderThreadPool.hpp"
 #include "exec/RuntimeStateStore.hpp"
 #include "transport/ClickGenerator.hpp"
 #include "transport/TransportClock.hpp"
@@ -35,7 +36,17 @@ namespace magda::engine {
 
 class EngineSession {
   public:
-    explicit EngineSession(RuntimeStateFactory& factory) : store_(factory) {}
+    /**
+     * @brief A session rendering on @p pool.
+     *
+     * Null is a session that renders every block on the audio thread alone,
+     * which is the same executor with one thread rather than a different one.
+     * A host with a pool passes it here, once: it outlives every plan, and it
+     * has to outlive this, because the epochs retired here are what let go of
+     * it.
+     */
+    explicit EngineSession(RuntimeStateFactory& factory, RenderThreadPool* pool = nullptr)
+        : store_(factory), pool_(pool) {}
 
     /// What came of a publish. `published` false means the plan was refused
     /// and the previous one is still playing; true with messages means it is
@@ -146,8 +157,10 @@ class EngineSession {
     /// shared with the epoch it replaces whenever the context has not changed,
     /// so a click that is sounding is not cut off by a structural edit.
     struct PreparedRender {
+        explicit PreparedRender(RenderThreadPool* pool) : executor(pool) {}
+
         std::shared_ptr<const RenderPlan> plan;
-        PlanExecutor executor;
+        ParallelPlanExecutor executor;
         PlanValues values;
         RenderContext context;
         std::shared_ptr<ClickGenerator> click;
@@ -163,6 +176,12 @@ class EngineSession {
                                farbot::RealtimeObjectOptions::nonRealtimeMutatable>;
 
     RuntimeStateStore store_;
+
+    /// The threads every epoch renders on, or null for a session that renders
+    /// on the audio thread alone. Not owned, and shared across epochs: threads
+    /// are made once and a structural edit is not a reason to remake them.
+    RenderThreadPool* pool_ = nullptr;
+
     PublishedRender published_;
     PublishedValues values_;
     PublishedTransport transport_;

--- a/magda/engine/exec/ParallelPlanExecutor.cpp
+++ b/magda/engine/exec/ParallelPlanExecutor.cpp
@@ -1,0 +1,231 @@
+#include "exec/ParallelPlanExecutor.hpp"
+
+namespace magda::engine {
+namespace {
+
+/// Failed pops before a thread stops asking and lets the scheduler have the
+/// core. The block is not over (something is still running, or nothing would be
+/// waiting), so leaving is not an option; what this decides is only how hard a
+/// thread with nothing to do leans on the ready set while it waits.
+constexpr int kSpinsBeforeYield = 200;
+
+constexpr std::uint64_t packReady(OpId op, std::uint32_t tag) {
+    return (static_cast<std::uint64_t>(tag) << 32) | static_cast<std::uint32_t>(op);
+}
+
+constexpr OpId readyOp(std::uint64_t packed) {
+    return static_cast<OpId>(static_cast<std::int32_t>(packed & 0xffffffffULL));
+}
+
+constexpr std::uint32_t readyTag(std::uint64_t packed) {
+    return static_cast<std::uint32_t>(packed >> 32);
+}
+
+static_assert(packReady(INVALID_OP_ID, 0) == kEmptyReadyStack,
+              "an executor that has not started a block must not look like one with op 0 ready");
+
+/// Whether the plan carries a schedule this executor can run: the counts, the
+/// reversed edges and the ready set, all agreeing about the same op count.
+/// bakeScheduling produces exactly this, and nothing else does.
+bool hasSchedule(const RenderPlan& plan) {
+    const auto numOps = plan.ops.size();
+    return plan.dependencyCounts.size() == numOps && plan.consumerOffsets.size() == numOps + 1 &&
+           plan.consumerEdges.size() == static_cast<std::size_t>(plan.consumerOffsets.empty()
+                                                                     ? 0
+                                                                     : plan.consumerOffsets.back());
+}
+
+}  // namespace
+
+void ParallelPlanExecutor::letGoOfPool() {
+    // A worker can still be inside the last block's takeWork(): render() returns
+    // as soon as the block is finished, not as soon as everyone has noticed. It
+    // is inside this object while it is, so nothing here may be freed or resized
+    // until the pool says otherwise.
+    //
+    // Skipped for a job the pool has never been given, which is every executor
+    // that has not rendered yet. Letting go waits out whatever is in a job right
+    // now, and making a publish wait a block for an executor no thread could
+    // possibly be inside would be a stall bought for nothing.
+    if (pool_ != nullptr && handedToPool_.load(std::memory_order_relaxed))
+        pool_->release(*this);
+    handedToPool_.store(false, std::memory_order_relaxed);
+}
+
+ParallelPlanExecutor::~ParallelPlanExecutor() {
+    letGoOfPool();
+}
+
+std::vector<std::string> ParallelPlanExecutor::prepare(const RenderPlan& plan,
+                                                       const PlanBindings& bindings,
+                                                       const RenderContext& context,
+                                                       const ParallelPlanExecutor* previous) {
+    // Everything below reallocates what a worker still finishing the last block
+    // would read, so this comes first, the same as at destruction.
+    letGoOfPool();
+
+    plan_ = nullptr;
+    outputOps_.clear();
+
+    auto messages =
+        core_.prepare(plan, bindings, context, previous != nullptr ? &previous->core_ : nullptr);
+    if (!core_.isPrepared())
+        return messages;
+
+    if (!hasSchedule(plan)) {
+        // Refused rather than worked around. Baking it here would put the one
+        // thing every block depends on somewhere it is computed twice, and a
+        // plan without it did not come from the compiler.
+        core_.reset();
+        messages.push_back(
+            "plan carries no baked scheduling: dependency counts and consumer edges are missing "
+            "or do not match its ops, so it cannot be scheduled");
+        return messages;
+    }
+
+    const auto numOps = plan.ops.size();
+    pending_ = std::vector<std::atomic<std::uint16_t>>(numOps);
+    nextReady_ = std::vector<std::atomic<OpId>>(numOps);
+
+    for (std::size_t i = 0; i < numOps; ++i)
+        if (plan.ops[i].kind == OpKind::Output)
+            outputOps_.push_back(static_cast<OpId>(i));
+
+    plan_ = &plan;
+    return messages;
+}
+
+void ParallelPlanExecutor::push(OpId op) {
+    const auto index = static_cast<std::size_t>(op);
+    auto top = readyTop_.load(std::memory_order_relaxed);
+    std::uint64_t pushed = 0;
+
+    do {
+        nextReady_[index].store(readyOp(top), std::memory_order_relaxed);
+        pushed = packReady(op, readyTag(top) + 1);
+    } while (!readyTop_.compare_exchange_weak(top, pushed, std::memory_order_release,
+                                              std::memory_order_relaxed));
+}
+
+OpId ParallelPlanExecutor::pop() {
+    auto top = readyTop_.load(std::memory_order_acquire);
+
+    for (;;) {
+        const auto op = readyOp(top);
+        if (op == INVALID_OP_ID)
+            return INVALID_OP_ID;
+
+        // Read under the tag: if the top is still the word this came from, the
+        // link is the one whoever pushed it wrote, and if it is not, the swap
+        // below fails and none of this counted.
+        const auto next = nextReady_[static_cast<std::size_t>(op)].load(std::memory_order_relaxed);
+        if (readyTop_.compare_exchange_weak(top, packReady(next, readyTag(top) + 1),
+                                            std::memory_order_acquire, std::memory_order_acquire))
+            return op;
+    }
+}
+
+OpId ParallelPlanExecutor::runOp(OpId op) {
+    // Output ops are the exception the whole schedule is written around: they
+    // add into a buffer they all share, so they are left for the thread that
+    // drove the block to run in plan order. Counted here anyway, because what
+    // waits on what is the plan's business and not this decision's.
+    if (plan_->ops[static_cast<std::size_t>(op)].kind != OpKind::Output)
+        core_.renderOp(op, valueOf(op), block_, *output_);
+
+    OpId carryOn = INVALID_OP_ID;
+
+    const auto first = plan_->consumerOffsets[static_cast<std::size_t>(op)];
+    const auto last = plan_->consumerOffsets[static_cast<std::size_t>(op) + 1];
+    for (auto edge = first; edge < last; ++edge) {
+        const auto consumer = plan_->consumerEdges[static_cast<std::size_t>(edge)];
+
+        // Acquire-release, not relaxed: this is where a consumer inherits
+        // everything its other producers wrote, whichever threads they ran on.
+        // The thread that takes the count to zero has seen all of it, and the
+        // release on the push (or the hand-over below) passes it on.
+        if (pending_[static_cast<std::size_t>(consumer)].fetch_sub(1, std::memory_order_acq_rel) !=
+            1)
+            continue;
+
+        if (carryOn == INVALID_OP_ID)
+            carryOn = consumer;
+        else
+            push(consumer);
+    }
+
+    // Last, and after the pushes: a block is finished when this reaches zero,
+    // and it must not reach zero while work this op released is still on its
+    // way into the ready set. An op carried on with is still counted, so a
+    // thread holding one cannot be the thread that says the block is over.
+    remaining_.fetch_sub(1, std::memory_order_acq_rel);
+    return carryOn;
+}
+
+void ParallelPlanExecutor::takeWork() {
+    int emptyPops = 0;
+
+    while (remaining_.load(std::memory_order_acquire) > 0) {
+        auto op = pop();
+        if (op == INVALID_OP_ID) {
+            // Nothing ready, and the block is not over: something is running
+            // that will release more. Spin for a while, because the wait is
+            // usually shorter than the system call that avoids it, then stand
+            // aside for whatever is holding the block up.
+            if (++emptyPops >= kSpinsBeforeYield) {
+                emptyPops = 0;
+                juce::Thread::yield();
+            }
+            continue;
+        }
+
+        emptyPops = 0;
+        while (op != INVALID_OP_ID)
+            op = runOp(op);
+    }
+}
+
+void ParallelPlanExecutor::process(const PlanValues& values, const BlockInfo& requestedBlock,
+                                   juce::AudioBuffer<float>& output) {
+    const auto start = core_.beginBlock(values, requestedBlock, output);
+    if (!start.render || plan_ == nullptr)
+        return;
+
+    block_ = start.block;
+    values_ = &values;
+    applyValues_ = start.applyValues;
+    output_ = &output;
+
+    const auto numOps = plan_->ops.size();
+    for (std::size_t i = 0; i < numOps; ++i)
+        pending_[i].store(plan_->dependencyCounts[i], std::memory_order_relaxed);
+
+    // Emptied, but the tag carries on from wherever the last block left it: a
+    // thread that read the top of the previous block's stack and has not looked
+    // since must not find a word it recognises.
+    readyTop_.store(
+        packReady(INVALID_OP_ID, readyTag(readyTop_.load(std::memory_order_relaxed)) + 1),
+        std::memory_order_relaxed);
+
+    // Before the ready set is seeded, so nothing can finish an op and count it
+    // against a total that has not been set yet.
+    remaining_.store(static_cast<int>(numOps), std::memory_order_relaxed);
+
+    for (const auto op : plan_->initialReadyOps)
+        push(op);
+
+    if (pool_ != nullptr) {
+        handedToPool_.store(true, std::memory_order_relaxed);
+        pool_->render(*this);
+    } else {
+        takeWork();
+    }
+
+    // The graph has drained, so this thread is the only one with anything to
+    // do. In plan order: the sum reaching the hardware is compiled, like every
+    // other sum in the plan.
+    for (const auto op : outputOps_)
+        core_.renderOp(op, valueOf(op), block_, output);
+}
+
+}  // namespace magda::engine

--- a/magda/engine/exec/ParallelPlanExecutor.cpp
+++ b/magda/engine/exec/ParallelPlanExecutor.cpp
@@ -24,17 +24,6 @@ constexpr std::uint32_t readyTag(std::uint64_t packed) {
 static_assert(packReady(INVALID_OP_ID, 0) == kEmptyReadyStack,
               "an executor that has not started a block must not look like one with op 0 ready");
 
-/// Whether the plan carries a schedule this executor can run: the counts, the
-/// reversed edges and the ready set, all agreeing about the same op count.
-/// bakeScheduling produces exactly this, and nothing else does.
-bool hasSchedule(const RenderPlan& plan) {
-    const auto numOps = plan.ops.size();
-    return plan.dependencyCounts.size() == numOps && plan.consumerOffsets.size() == numOps + 1 &&
-           plan.consumerEdges.size() == static_cast<std::size_t>(plan.consumerOffsets.empty()
-                                                                     ? 0
-                                                                     : plan.consumerOffsets.back());
-}
-
 }  // namespace
 
 void ParallelPlanExecutor::letGoOfPool() {
@@ -72,14 +61,22 @@ std::vector<std::string> ParallelPlanExecutor::prepare(const RenderPlan& plan,
     if (!core_.isPrepared())
         return messages;
 
-    if (!hasSchedule(plan)) {
-        // Refused rather than worked around. Baking it here would put the one
-        // thing every block depends on somewhere it is computed twice, and a
-        // plan without it did not come from the compiler.
+    // Checked against the topology rather than taken on trust, because every
+    // way of being wrong here costs more than a wrong render: an op nobody
+    // releases means a block that never finishes and a callback that spins for
+    // ever, and an op released early is a race on a buffer another op is still
+    // writing. Recomputing is the same linear pass that produced them, off the
+    // audio thread, once per prepare.
+    //
+    // Refused rather than rebaked. A plan is immutable and shared, this is not
+    // the place that owns what its schedule should be, and a plan whose
+    // constants disagree with its ops did not come from the compiler.
+    if (!carriesSchedule(plan)) {
         core_.reset();
         messages.push_back(
-            "plan carries no baked scheduling: dependency counts and consumer edges are missing "
-            "or do not match its ops, so it cannot be scheduled");
+            "plan does not carry the schedule its topology implies: its dependency counts, "
+            "consumer edges or initially-ready set are missing or disagree with its ops, so it "
+            "cannot be scheduled");
         return messages;
     }
 

--- a/magda/engine/exec/ParallelPlanExecutor.hpp
+++ b/magda/engine/exec/ParallelPlanExecutor.hpp
@@ -1,0 +1,197 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "exec/PlanExecutor.hpp"
+#include "exec/RenderThreadPool.hpp"
+
+/**
+ * @file ParallelPlanExecutor.hpp
+ * @brief The executor that ships: the same ops, spread across threads.
+ *
+ * It renders through PlanExecutor and adds one thing, which is the order ops
+ * run in. Nothing about the arithmetic is duplicated here, and that is the
+ * point: its output is bit-identical to the reference executor's at every
+ * thread count, because the only thing it changes is which thread reaches an op
+ * and when.
+ *
+ * That identity survives threading for two reasons. Everything that sums does
+ * so in compiled order rather than in the order its inputs finished, which is
+ * what makes float addition's non-associativity a non-issue. And ports share
+ * buffers on a test over the dependency DAG rather than over the op list (see
+ * assignBuffers), so a slot reused under the reference executor's walk is
+ * reused safely under every other valid schedule too.
+ *
+ * The schedule itself costs nothing to work out: the plan already carries the
+ * dependency counts, the reversed edges and the initially-ready set, baked when
+ * it was compiled (bakeScheduling). A block copies the counts, seeds the ready
+ * set and runs; nothing walks the graph on the callback.
+ */
+
+namespace magda::engine {
+
+/// An empty ready stack: no op on top, and a tag that has not moved yet. The
+/// packing is in ParallelPlanExecutor.cpp, which asserts that this is what it
+/// produces for an empty one.
+inline constexpr std::uint64_t kEmptyReadyStack = 0xffffffffULL;
+
+class ParallelPlanExecutor final : private RenderThreadPool::Job {
+  public:
+    /**
+     * @brief Render on @p pool, or on the calling thread alone when it is null.
+     *
+     * The pool is the host's and outlives every plan: threads are made once and
+     * every epoch published afterwards renders on them. A null pool is not a
+     * degraded mode but the same executor with one thread, which is what makes
+     * "identical at every thread count" a claim about one code path.
+     */
+    explicit ParallelPlanExecutor(RenderThreadPool* pool = nullptr) : pool_(pool) {}
+    ~ParallelPlanExecutor() override;
+
+    ParallelPlanExecutor(const ParallelPlanExecutor&) = delete;
+    ParallelPlanExecutor& operator=(const ParallelPlanExecutor&) = delete;
+
+    /**
+     * @brief Bind a plan to its runtime objects and size the schedule.
+     *
+     * Off the audio thread, and everything PlanExecutor::prepare says applies:
+     * @p previous is the executor this one replaces, and what the differ
+     * matches is carried rather than rebuilt.
+     *
+     * A plan whose scheduling constants are missing or inconsistent is refused
+     * the way a malformed one is. They are not something this can work out for
+     * itself: they are baked into the plan when it is compiled, and a plan that
+     * arrived without them did not come from the compiler.
+     */
+    std::vector<std::string> prepare(const RenderPlan& plan, const PlanBindings& bindings,
+                                     const RenderContext& context,
+                                     const ParallelPlanExecutor* previous = nullptr);
+
+    /**
+     * @brief Render one block into @p output. On the audio thread.
+     *
+     * No allocation, no locks, no waiting on anything but the block's own work.
+     */
+    void process(const PlanValues& values, const BlockInfo& block,
+                 juce::AudioBuffer<float>& output);
+
+    /// Threads a block is spread across.
+    int numThreads() const {
+        return pool_ != nullptr ? pool_->numThreads() : 1;
+    }
+
+    /// The prepared plan, as the reference executor sees it: what it bound,
+    /// what it allocated, and what it resolved. Both executors share all of it,
+    /// so there is one answer to those questions rather than two.
+    const PlanExecutor& reference() const {
+        return core_;
+    }
+
+    int latencySamples() const {
+        return core_.latencySamples();
+    }
+    int boundMeterCount() const {
+        return core_.boundMeterCount();
+    }
+    int audioBufferCount() const {
+        return core_.audioBufferCount();
+    }
+    int midiBufferCount() const {
+        return core_.midiBufferCount();
+    }
+    int midiDelayOverflows() const {
+        return core_.midiDelayOverflows();
+    }
+    int carriedDelayLines() const {
+        return core_.carriedDelayLines();
+    }
+    bool isPrepared() const {
+        return plan_ != nullptr;
+    }
+    const RenderContext& preparedContext() const {
+        return core_.preparedContext();
+    }
+    bool appliesValues(const PlanValues& values) const {
+        return core_.appliesValues(values);
+    }
+
+  private:
+    /// Take ready ops until the block is finished. Runs on every thread of the
+    /// pool at once, and on the audio thread.
+    void takeWork() override;
+
+    /// Render @p op, release the ops waiting on it, and hand back one of them
+    /// for this thread to carry straight on with. A chain therefore never
+    /// touches the ready set at all: the thread that ran an op runs its
+    /// consumer, which is both the cheapest schedule and the warmest cache.
+    OpId runOp(OpId op);
+
+    void push(OpId op);
+    OpId pop();
+
+    /// Wait until no worker can be inside this job, so what it owns may be
+    /// resized or destroyed. Off the audio thread.
+    void letGoOfPool();
+
+    const OpValue& valueOf(OpId op) const {
+        return applyValues_ ? values_->ops[static_cast<std::size_t>(op)] : kUnityValue;
+    }
+
+    PlanExecutor core_;
+    RenderThreadPool* pool_ = nullptr;
+
+    /// Whether the pool has ever been handed this job. Until it has, no worker
+    /// can be inside it and there is nothing to wait out.
+    ///
+    /// Written on the audio thread and read on the thread that retires an
+    /// epoch, so it is an atomic rather than a bool. Relaxed is enough: what
+    /// makes the read see the write is the plan swap that took the audio thread
+    /// off this executor, which is an ordering this flag does not have to
+    /// establish a second time.
+    std::atomic<bool> handedToPool_{false};
+
+    /// Null until a plan with a usable schedule has been prepared. Not the same
+    /// question as core_.isPrepared(): a plan can bind cleanly and still arrive
+    /// without the constants this needs.
+    const RenderPlan* plan_ = nullptr;
+
+    /// This block, as every thread reads it. Written before the ready set is
+    /// seeded and read only by a thread that has taken an op out of it, so the
+    /// publication is the same release the schedule already needs.
+    BlockInfo block_;
+    const PlanValues* values_ = nullptr;
+    bool applyValues_ = false;
+    juce::AudioBuffer<float>* output_ = nullptr;
+
+    /// Ops that drive the hardware output. Run by whoever drove the block, in
+    /// plan order, once the graph has drained: they all accumulate into the one
+    /// buffer, and a schedule deciding which of them adds itself first is a
+    /// schedule deciding the arithmetic.
+    std::vector<OpId> outputOps_;
+
+    /// Producers each op is still waiting for. The plan's dependencyCounts,
+    /// copied in at the top of every block.
+    std::vector<std::atomic<std::uint16_t>> pending_;
+
+    /// The ready set: a stack threaded through this array, one link per op.
+    /// An op is pushed at most once a block, when its last producer finishes,
+    /// so a link is written once and read once and no op can come back while
+    /// another thread is looking at it.
+    std::vector<std::atomic<OpId>> nextReady_;
+
+    /// Top of the ready stack: an op and a tag, packed. The tag moves on every
+    /// push and every pop and never resets, so a thread that read the top,
+    /// stalled, and came back to find the same op there cannot mistake it for
+    /// the one it was looking at. That is the whole of the ABA argument, and it
+    /// is why the tag survives across blocks rather than starting again.
+    alignas(64) std::atomic<std::uint64_t> readyTop_{kEmptyReadyStack};
+
+    /// Ops still to finish this block. Zero is what "the block is done" means,
+    /// and it is the only thing every thread agrees to wait for.
+    alignas(64) std::atomic<int> remaining_{0};
+};
+
+}  // namespace magda::engine

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -140,6 +140,7 @@ void PlanExecutor::reset() {
     carriedDelayLines_ = 0;
     audioSlots_.clear();
     midiSlots_.clear();
+    slotChannels_.clear();
     midiByteBounds_.clear();
     portOffsets_.clear();
     portSlots_.clear();
@@ -433,21 +434,40 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
     silence_.clear();
     noMidi_.clear();
 
+    // The arena, as the render path sees it. Taken once, here, so that nothing
+    // during a block goes through juce::AudioBuffer: making a block out of one
+    // writes its isClear flag, and two ops reading the same port would be two
+    // threads writing that byte at once.
+    const auto channels = static_cast<std::size_t>(context_.numChannels);
+    slotChannels_.assign((audioSlots_.size() + 1) * channels, nullptr);
+    for (std::size_t slot = 0; slot < audioSlots_.size(); ++slot)
+        for (std::size_t channel = 0; channel < channels; ++channel)
+            slotChannels_[slot * channels + channel] =
+                audioSlots_[slot].getWritePointer(static_cast<int>(channel));
+    for (std::size_t channel = 0; channel < channels; ++channel)
+        slotChannels_[audioSlots_.size() * channels + channel] =
+            silence_.getWritePointer(static_cast<int>(channel));
+
     planFingerprint_ = magda::engine::planFingerprint(plan);
     plan_ = &plan;
     return messages;
 }
 
-juce::dsp::AudioBlock<float> PlanExecutor::audioIn(const PortRef& ref, int numSamples) {
-    auto& buffer = ref.valid() ? audioSlots_[static_cast<std::size_t>(slotFor(ref))] : silence_;
-    return juce::dsp::AudioBlock<float>(buffer).getSubBlock(0,
-                                                            static_cast<std::size_t>(numSamples));
+juce::dsp::AudioBlock<float> PlanExecutor::audioBlock(std::size_t row, int numSamples) const {
+    const auto channels = static_cast<std::size_t>(context_.numChannels);
+    return juce::dsp::AudioBlock<float>(&slotChannels_[row * channels], channels,
+                                        static_cast<std::size_t>(numSamples));
 }
 
-juce::dsp::AudioBlock<float> PlanExecutor::audioOut(OpId op, int port, int numSamples) {
-    auto& buffer = audioSlots_[static_cast<std::size_t>(slotFor(PortRef{op, port}))];
-    return juce::dsp::AudioBlock<float>(buffer).getSubBlock(0,
-                                                            static_cast<std::size_t>(numSamples));
+juce::dsp::AudioBlock<float> PlanExecutor::audioIn(const PortRef& ref, int numSamples) const {
+    // An unconnected slot reads the silence row, which is the last one and is
+    // the reason the array has one more row than there are slots.
+    return audioBlock(ref.valid() ? static_cast<std::size_t>(slotFor(ref)) : audioSlots_.size(),
+                      numSamples);
+}
+
+juce::dsp::AudioBlock<float> PlanExecutor::audioOut(OpId op, int port, int numSamples) const {
+    return audioBlock(static_cast<std::size_t>(slotFor(PortRef{op, port})), numSamples);
 }
 
 const juce::MidiBuffer& PlanExecutor::midiIn(const PortRef& ref) const {
@@ -458,21 +478,22 @@ juce::MidiBuffer& PlanExecutor::midiOut(OpId op, int port) {
     return midiSlots_[static_cast<std::size_t>(slotFor(PortRef{op, port}))];
 }
 
-void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedBlock,
-                           juce::AudioBuffer<float>& output) {
+PlanExecutor::BlockStart PlanExecutor::beginBlock(const PlanValues& values,
+                                                  const BlockInfo& requested,
+                                                  juce::AudioBuffer<float>& output) const {
+    BlockStart start;
     output.clear();
     if (plan_ == nullptr)
-        return;
+        return start;
 
     // A host asking for more than the block the plan was prepared for would
     // otherwise leave the tail of its buffer silent with nothing saying so.
-    jassert(requestedBlock.numSamples <= context_.maxBlockSize);
+    jassert(requested.numSamples <= context_.maxBlockSize);
 
-    auto block = requestedBlock;
-    block.numSamples = std::min(block.numSamples, context_.maxBlockSize);
-    const auto numSamples = block.numSamples;
-    if (numSamples <= 0)
-        return;
+    start.block = requested;
+    start.block.numSamples = std::min(requested.numSamples, context_.maxBlockSize);
+    if (start.block.numSamples <= 0)
+        return start;
 
     // Values are resolved against a plan and published separately from it, so
     // a table can outlive the plan it was made for. Matching op counts prove
@@ -480,202 +501,214 @@ void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedB
     // stale gains and mutes would land on whatever op now holds each index.
     // The fingerprint is what says the two belong together; without it, unity
     // is the safe reading.
-    static constexpr OpValue kUnity;
-    const auto haveValues = appliesValues(values);
+    start.applyValues = appliesValues(values);
+    start.render = true;
+    return start;
+}
 
-    for (std::size_t i = 0; i < plan_->ops.size(); ++i) {
-        const auto& op = plan_->ops[i];
-        const auto& value = haveValues ? values.ops[i] : kUnity;
-        const auto id = static_cast<OpId>(i);
+void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedBlock,
+                           juce::AudioBuffer<float>& output) {
+    const auto start = beginBlock(values, requestedBlock, output);
+    if (!start.render)
+        return;
 
-        switch (op.kind) {
-            case OpKind::ClipAudio:
-            case OpKind::AudioInput: {
-                auto out = audioOut(id, 0, numSamples);
-                if (value.silent || audioSourceForOp_[i] == nullptr)
-                    out.clear();
-                else
-                    audioSourceForOp_[i]->render(block, out);
-                break;
-            }
+    // In order, which is a schedule: ops are in dependency order, so everything
+    // an op reads has already run by the time the walk reaches it.
+    for (std::size_t i = 0; i < plan_->ops.size(); ++i)
+        renderOp(static_cast<OpId>(i), start.applyValues ? values.ops[i] : kUnityValue, start.block,
+                 output);
+}
 
-            case OpKind::ClipMidi:
-            case OpKind::MidiInput: {
-                auto& out = midiOut(id, 0);
+void PlanExecutor::renderOp(OpId id, const OpValue& value, const BlockInfo& block,
+                            juce::AudioBuffer<float>& output) {
+    const auto i = static_cast<std::size_t>(id);
+    const auto& op = plan_->ops[i];
+    const auto numSamples = block.numSamples;
+
+    switch (op.kind) {
+        case OpKind::ClipAudio:
+        case OpKind::AudioInput: {
+            auto out = audioOut(id, 0, numSamples);
+            if (value.silent || audioSourceForOp_[i] == nullptr)
                 out.clear();
-                if (!value.silent && midiSourceForOp_[i] != nullptr) {
-                    midiSourceForOp_[i]->render(block, out);
-                    // Bytes, not events: one SysEx dump outweighs a thousand
-                    // notes, and an event count would wave it through.
-                    jassert(out.data.size() <= kMaxMidiBytesPerPort);
-                }
+            else
+                audioSourceForOp_[i]->render(block, out);
+            break;
+        }
+
+        case OpKind::ClipMidi:
+        case OpKind::MidiInput: {
+            auto& out = midiOut(id, 0);
+            out.clear();
+            if (!value.silent && midiSourceForOp_[i] != nullptr) {
+                midiSourceForOp_[i]->render(block, out);
+                // Bytes, not events: one SysEx dump outweighs a thousand
+                // notes, and an event count would wave it through.
+                jassert(out.data.size() <= kMaxMidiBytesPerPort);
+            }
+            break;
+        }
+
+        case OpKind::MixAudio: {
+            auto out = audioOut(id, 0, numSamples);
+            if (value.silent) {
+                out.clear();
                 break;
             }
-
-            case OpKind::MixAudio: {
-                auto out = audioOut(id, 0, numSamples);
-                if (value.silent) {
-                    out.clear();
-                    break;
+            // Summed in compiled order, never in the order inputs finish:
+            // float addition is not associative, so this is what makes the
+            // parallel executor's output bit-identical to this one.
+            //
+            // The first input may already be here, in the buffer it was
+            // written into. Skipping the copy is the same sum, not a
+            // different one: it is added first either way.
+            auto pending = writesInPlace(i);
+            if (!pending)
+                out.clear();
+            for (const auto& input : op.inputs) {
+                if (!input.valid())
+                    continue;
+                if (pending) {
+                    pending = false;
+                    continue;
                 }
-                // Summed in compiled order, never in the order inputs finish:
-                // float addition is not associative, so this is what makes the
-                // parallel executor's output bit-identical to this one.
-                //
-                // The first input may already be here, in the buffer it was
-                // written into. Skipping the copy is the same sum, not a
-                // different one: it is added first either way.
-                auto pending = writesInPlace(i);
-                if (!pending)
-                    out.clear();
-                for (const auto& input : op.inputs) {
-                    if (!input.valid())
-                        continue;
-                    if (pending) {
-                        pending = false;
-                        continue;
-                    }
-                    out.add(audioIn(input, numSamples));
-                }
-                break;
+                out.add(audioIn(input, numSamples));
             }
+            break;
+        }
 
-            case OpKind::Delay: {
-                // A delay runs whatever the value layer says about the ops
-                // around it. One that stopped writing while its chain was
-                // silent would hand back audio from before the silence when
-                // the chain returned, which is the one thing a delay line
-                // cannot do.
-                if (op.outputs.front() == SignalKind::Audio) {
-                    const auto line = audioDelayForOp_[i];
-                    if (line < 0)
-                        break;  // no samples to hold: its port is its input's
-                    auto out = audioOut(id, 0, numSamples);
-                    if (!writesInPlace(i))
-                        out.copyFrom(audioIn(op.inputs[0], numSamples));
-                    audioDelays_[static_cast<std::size_t>(line)]->process(out, numSamples);
-                    break;
-                }
-
-                const auto line = midiDelayForOp_[i];
+        case OpKind::Delay: {
+            // A delay runs whatever the value layer says about the ops
+            // around it. One that stopped writing while its chain was
+            // silent would hand back audio from before the silence when
+            // the chain returned, which is the one thing a delay line
+            // cannot do.
+            if (op.outputs.front() == SignalKind::Audio) {
+                const auto line = audioDelayForOp_[i];
                 if (line < 0)
-                    break;
-                auto& out = midiOut(id, 0);
-                out.clear();
-                midiDelays_[static_cast<std::size_t>(line)]->process(midiIn(op.inputs[0]), out,
-                                                                     numSamples);
-                jassert(out.data.size() <=
-                        midiByteBounds_[static_cast<std::size_t>(slotFor(PortRef{id, 0}))]);
-                break;
-            }
-
-            case OpKind::MergeMidi: {
-                auto& out = midiOut(id, 0);
-                out.clear();
-                if (value.silent)
-                    break;
-                for (const auto& input : op.inputs)
-                    if (input.valid())
-                        out.addEvents(midiIn(input), 0, numSamples, 0);
-                break;
-            }
-
-            case OpKind::Device: {
-                auto audio = audioOut(id, 0, numSamples);
-                const auto producesMidi =
-                    op.outputs.size() > 1 && op.outputs[1] == SignalKind::Midi;
-                juce::MidiBuffer* deviceMidiOut = nullptr;
-                if (producesMidi) {
-                    deviceMidiOut = &midiOut(id, 1);
-                    deviceMidiOut->clear();
-                }
-
-                if (value.silent) {
-                    audio.clear();
-                    break;
-                }
-
-                if (!op.inputs[0].valid())
-                    audio.clear();
-                else if (!writesInPlace(i))
-                    audio.copyFrom(audioIn(op.inputs[0], numSamples));
-
-                auto* device = deviceForOp_[i];
-                if (device == nullptr)
-                    break;
-
-                DeviceBlock deviceBlock{audio, &midiIn(op.inputs[1]), deviceMidiOut, {}, block};
-                if (op.inputs[2].valid())
-                    deviceBlock.sidechain = audioIn(op.inputs[2], numSamples);
-                device->process(deviceBlock);
-                jassert(deviceMidiOut == nullptr ||
-                        deviceMidiOut->data.size() <= kMaxMidiBytesPerPort);
-                break;
-            }
-
-            case OpKind::Gain:
-            case OpKind::SendTap: {
+                    break;  // no samples to hold: its port is its input's
                 auto out = audioOut(id, 0, numSamples);
-                if (value.silent || !op.inputs[0].valid())
-                    out.clear();
-                else if (writesInPlace(i))
-                    applyGain(out, value, numSamples);
-                else
-                    copyWithGain(out, audioIn(op.inputs[0], numSamples), value, numSamples);
-                break;
-            }
-
-            case OpKind::Fader: {
-                auto out = audioOut(id, 0, numSamples);
-                if (value.silent || !op.inputs[0].valid())
-                    out.clear();
-                else if (writesInPlace(i))
-                    applyGain(out, value, numSamples);
-                else
-                    copyWithGain(out, audioIn(op.inputs[0], numSamples), value, numSamples);
-
-                // A rack chain's MIDI leaves through its fader too, so that one
-                // silent flag takes the whole chain out of the mix. Gain does
-                // not apply to it: there is no such thing as MIDI at half
-                // volume, only MIDI that is connected or is not.
-                if (op.outputs.size() > 1 && op.outputs[1] == SignalKind::Midi) {
-                    auto& outMidiBuffer = midiOut(id, 1);
-                    outMidiBuffer.clear();
-                    if (!value.silent && op.inputs[1].valid())
-                        outMidiBuffer.addEvents(midiIn(op.inputs[1]), 0, numSamples, 0);
-                }
-                break;
-            }
-
-            case OpKind::Meter: {
-                auto out = audioOut(id, 0, numSamples);
-                if (value.silent || !op.inputs[0].valid())
-                    out.clear();
-                else if (!writesInPlace(i))
+                if (!writesInPlace(i))
                     out.copyFrom(audioIn(op.inputs[0], numSamples));
-
-                // Written on silent blocks too, though a maximum takes nothing
-                // from them. What that buys is that the tap is only ever
-                // cleared by being read, so how fast a meter falls is the
-                // reader's cadence and not which blocks the executor bothered
-                // to report.
-                if (auto* tap = meterForOp_[i]; tap != nullptr)
-                    tap->write(out, numSamples);
+                audioDelays_[static_cast<std::size_t>(line)]->process(out, numSamples);
                 break;
             }
 
-            case OpKind::Output: {
-                if (value.silent || !op.inputs[0].valid())
-                    break;
-                auto in = audioIn(op.inputs[0], numSamples);
-                const auto numChannels =
-                    std::min(static_cast<int>(in.getNumChannels()), output.getNumChannels());
-                for (int channel = 0; channel < numChannels; ++channel)
-                    output.addFrom(channel, 0,
-                                   in.getChannelPointer(static_cast<std::size_t>(channel)),
-                                   numSamples);
+            const auto line = midiDelayForOp_[i];
+            if (line < 0)
+                break;
+            auto& out = midiOut(id, 0);
+            out.clear();
+            midiDelays_[static_cast<std::size_t>(line)]->process(midiIn(op.inputs[0]), out,
+                                                                 numSamples);
+            jassert(out.data.size() <=
+                    midiByteBounds_[static_cast<std::size_t>(slotFor(PortRef{id, 0}))]);
+            break;
+        }
+
+        case OpKind::MergeMidi: {
+            auto& out = midiOut(id, 0);
+            out.clear();
+            if (value.silent)
+                break;
+            for (const auto& input : op.inputs)
+                if (input.valid())
+                    out.addEvents(midiIn(input), 0, numSamples, 0);
+            break;
+        }
+
+        case OpKind::Device: {
+            auto audio = audioOut(id, 0, numSamples);
+            const auto producesMidi = op.outputs.size() > 1 && op.outputs[1] == SignalKind::Midi;
+            juce::MidiBuffer* deviceMidiOut = nullptr;
+            if (producesMidi) {
+                deviceMidiOut = &midiOut(id, 1);
+                deviceMidiOut->clear();
+            }
+
+            if (value.silent) {
+                audio.clear();
                 break;
             }
+
+            if (!op.inputs[0].valid())
+                audio.clear();
+            else if (!writesInPlace(i))
+                audio.copyFrom(audioIn(op.inputs[0], numSamples));
+
+            auto* device = deviceForOp_[i];
+            if (device == nullptr)
+                break;
+
+            DeviceBlock deviceBlock{audio, &midiIn(op.inputs[1]), deviceMidiOut, {}, block};
+            if (op.inputs[2].valid())
+                deviceBlock.sidechain = audioIn(op.inputs[2], numSamples);
+            device->process(deviceBlock);
+            jassert(deviceMidiOut == nullptr || deviceMidiOut->data.size() <= kMaxMidiBytesPerPort);
+            break;
+        }
+
+        case OpKind::Gain:
+        case OpKind::SendTap: {
+            auto out = audioOut(id, 0, numSamples);
+            if (value.silent || !op.inputs[0].valid())
+                out.clear();
+            else if (writesInPlace(i))
+                applyGain(out, value, numSamples);
+            else
+                copyWithGain(out, audioIn(op.inputs[0], numSamples), value, numSamples);
+            break;
+        }
+
+        case OpKind::Fader: {
+            auto out = audioOut(id, 0, numSamples);
+            if (value.silent || !op.inputs[0].valid())
+                out.clear();
+            else if (writesInPlace(i))
+                applyGain(out, value, numSamples);
+            else
+                copyWithGain(out, audioIn(op.inputs[0], numSamples), value, numSamples);
+
+            // A rack chain's MIDI leaves through its fader too, so that one
+            // silent flag takes the whole chain out of the mix. Gain does
+            // not apply to it: there is no such thing as MIDI at half
+            // volume, only MIDI that is connected or is not.
+            if (op.outputs.size() > 1 && op.outputs[1] == SignalKind::Midi) {
+                auto& outMidiBuffer = midiOut(id, 1);
+                outMidiBuffer.clear();
+                if (!value.silent && op.inputs[1].valid())
+                    outMidiBuffer.addEvents(midiIn(op.inputs[1]), 0, numSamples, 0);
+            }
+            break;
+        }
+
+        case OpKind::Meter: {
+            auto out = audioOut(id, 0, numSamples);
+            if (value.silent || !op.inputs[0].valid())
+                out.clear();
+            else if (!writesInPlace(i))
+                out.copyFrom(audioIn(op.inputs[0], numSamples));
+
+            // Written on silent blocks too, though a maximum takes nothing
+            // from them. What that buys is that the tap is only ever
+            // cleared by being read, so how fast a meter falls is the
+            // reader's cadence and not which blocks the executor bothered
+            // to report.
+            if (auto* tap = meterForOp_[i]; tap != nullptr)
+                tap->write(out, numSamples);
+            break;
+        }
+
+        case OpKind::Output: {
+            if (value.silent || !op.inputs[0].valid())
+                break;
+            auto in = audioIn(op.inputs[0], numSamples);
+            const auto numChannels =
+                std::min(static_cast<int>(in.getNumChannels()), output.getNumChannels());
+            for (int channel = 0; channel < numChannels; ++channel)
+                output.addFrom(channel, 0, in.getChannelPointer(static_cast<std::size_t>(channel)),
+                               numSamples);
+            break;
         }
     }
 }

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -24,6 +24,12 @@
  * When the two disagree, this is the arbiter, so it stays a straight walk of
  * the op vector with no scheduling of any kind: ops are in dependency order, so
  * running them in order is enough.
+ *
+ * "Through the same ops" is meant literally. Everything below the walk lives
+ * here and both executors use it: preparing a plan against its bindings, the
+ * buffers it renders through, and the body of every op. What the parallel
+ * executor replaces is the loop and nothing else, which is why its output is
+ * bit-identical to this one's rather than close to it.
  */
 
 namespace magda::engine {
@@ -135,6 +141,11 @@ class PlanExecutor {
                                      const RenderContext& context,
                                      const PlanExecutor* previous = nullptr);
 
+    /// Forget the prepared plan and everything sized for it. Off the audio
+    /// thread. Every prepare starts here, so a plan that is refused leaves
+    /// nothing behind that could still be rendered.
+    void reset();
+
     /**
      * @brief Render one block into @p output.
      *
@@ -144,6 +155,52 @@ class PlanExecutor {
      */
     void process(const PlanValues& values, const BlockInfo& block,
                  juce::AudioBuffer<float>& output);
+
+    /** @brief Where one block's render starts, before any op has run. */
+    struct BlockStart {
+        /// The block as this plan will actually render it, which is the one
+        /// asked for clipped to what it was prepared for.
+        BlockInfo block;
+
+        /// Whether the values belong to this plan. When they do not, every op
+        /// renders at unity rather than at whatever the table happens to say.
+        bool applyValues = false;
+
+        /// False when there is nothing to render at all: no plan prepared, or
+        /// no samples asked for. The output has been cleared either way.
+        bool render = false;
+    };
+
+    /**
+     * @brief Settle what a block is, and clear @p output.
+     *
+     * Shared with the parallel executor because the two have to agree on it:
+     * how much of the block this plan can render, and whether the values were
+     * resolved against it. A second copy of that reasoning is a second answer.
+     */
+    BlockStart beginBlock(const PlanValues& values, const BlockInfo& requested,
+                          juce::AudioBuffer<float>& output) const;
+
+    /**
+     * @brief Render one op of the prepared plan.
+     *
+     * Every op the engine renders passes through here, from both executors,
+     * and that is what makes their output bit-identical rather than merely
+     * close: the arithmetic is in one place, and scheduling is the only thing
+     * the parallel executor changes. Anything that sums does so in compiled
+     * order, whatever order its inputs arrived in.
+     *
+     * The caller owes it a schedule. Every op this one reads has finished, and
+     * nothing that reads what it writes has started; ports share buffers on
+     * exactly that promise (see assignBuffers).
+     *
+     * @p output is touched by Output ops alone. Those accumulate into a buffer
+     * every one of them shares, so whoever drives the block runs them itself,
+     * in plan order, rather than letting a schedule decide what adds to what
+     * first.
+     */
+    void renderOp(OpId op, const OpValue& value, const BlockInfo& block,
+                  juce::AudioBuffer<float>& output);
 
     /// Meter ops whose tap the bindings filled. The rest still render; they
     /// publish nothing, because nothing is reading them.
@@ -226,8 +283,15 @@ class PlanExecutor {
                                                    ref.port)];
     }
 
-    juce::dsp::AudioBlock<float> audioIn(const PortRef& ref, int numSamples);
-    juce::dsp::AudioBlock<float> audioOut(OpId op, int port, int numSamples);
+    /// One audio slot, as an op sees it. Built from the cached channel
+    /// pointers rather than from the buffer, because making a block out of a
+    /// juce::AudioBuffer writes the buffer's isClear flag: two ops reading the
+    /// same port at once would be two threads writing one byte, which is
+    /// benign in value and a data race in fact.
+    juce::dsp::AudioBlock<float> audioBlock(std::size_t row, int numSamples) const;
+
+    juce::dsp::AudioBlock<float> audioIn(const PortRef& ref, int numSamples) const;
+    juce::dsp::AudioBlock<float> audioOut(OpId op, int port, int numSamples) const;
     const juce::MidiBuffer& midiIn(const PortRef& ref) const;
     juce::MidiBuffer& midiOut(OpId op, int port);
 
@@ -242,8 +306,6 @@ class PlanExecutor {
     const std::shared_ptr<AudioDelayLine>& audioDelayFor(OpId op) const;
     const std::shared_ptr<MidiDelayLine>& midiDelayFor(OpId op) const;
 
-    void reset();
-
     const RenderPlan* plan_ = nullptr;
     RenderContext context_;
 
@@ -251,6 +313,12 @@ class PlanExecutor {
     /// which is worked out in assignBuffers rather than here.
     std::vector<juce::AudioBuffer<float>> audioSlots_;
     std::vector<juce::MidiBuffer> midiSlots_;
+
+    /// Channel pointers into the arena, flattened: slot s, channel c is at
+    /// s * numChannels + c, and the row past the last slot is silence_. Every
+    /// audio block an op is handed is made from these, so nothing on the
+    /// render path touches a juce::AudioBuffer (see audioBlock).
+    std::vector<float*> slotChannels_;
     /// Encoded bytes each MIDI buffer can hold without growing, summed through
     /// the MIDI graph at prepare time. Checked in debug where producers write.
     std::vector<int> midiByteBounds_;

--- a/magda/engine/exec/PlanValues.hpp
+++ b/magda/engine/exec/PlanValues.hpp
@@ -43,6 +43,15 @@ struct OpValue {
 };
 
 /**
+ * @brief What an op renders with when no table applies to the plan.
+ *
+ * Unity and audible, which is the only safe reading of values that were
+ * resolved against something else: a gain nobody asked for is a mix nobody
+ * mixed, and a silence nobody asked for is a track that has gone missing.
+ */
+inline constexpr OpValue kUnityValue{};
+
+/**
  * @brief Per-op values for one compiled plan, indexed by OpId.
  *
  * Published to the audio thread as a whole; the executor never mutates it.

--- a/magda/engine/exec/RenderThreadPool.cpp
+++ b/magda/engine/exec/RenderThreadPool.cpp
@@ -79,14 +79,24 @@ void RenderThreadPool::render(Job& job) {
 }
 
 void RenderThreadPool::takeWork() {
-    // Announced before the job is read, so release() cannot see zero here and
-    // conclude that a worker on its way in will not arrive.
-    inJob_.fetch_add(1, std::memory_order_seq_cst);
+    // Arrival is announced before the job is read, so release() cannot see an
+    // empty pool and conclude that a worker on its way in will not arrive. Then
+    // the worker moves itself onto the job's own count and leaves the arrival
+    // window, which is what makes a retirement wait for its own workers rather
+    // than for whoever is rendering now.
+    arriving_.fetch_add(1, std::memory_order_seq_cst);
 
-    if (auto* job = job_.load(std::memory_order_seq_cst))
-        job->takeWork();
+    auto* job = job_.load(std::memory_order_seq_cst);
+    if (job != nullptr)
+        job->workersInside.fetch_add(1, std::memory_order_seq_cst);
 
-    inJob_.fetch_sub(1, std::memory_order_seq_cst);
+    arriving_.fetch_sub(1, std::memory_order_seq_cst);
+
+    if (job == nullptr)
+        return;
+
+    job->takeWork();
+    job->workersInside.fetch_sub(1, std::memory_order_seq_cst);
 }
 
 void RenderThreadPool::release(Job& job) {
@@ -95,10 +105,19 @@ void RenderThreadPool::release(Job& job) {
     auto* expected = &job;
     job_.compare_exchange_strong(expected, nullptr, std::memory_order_seq_cst);
 
-    // Anything inside a job now is either this one, which has to be waited out,
-    // or a newer one, which is a block and will end. Either way this is a wait
-    // measured in one callback, on a thread that is allowed to wait.
-    while (inJob_.load(std::memory_order_seq_cst) != 0)
+    // Two waits, and they are for different things. The first is for workers
+    // that read the job pointer before it was taken away and have not yet
+    // counted themselves against it; nothing but a load and an increment lives
+    // in that window, so it drains as fast as those threads get a core. The
+    // second is for workers actually inside this job, which is bounded by the
+    // block they are finishing.
+    //
+    // In this order, because a worker still arriving is one that has not
+    // reached the second count yet.
+    while (arriving_.load(std::memory_order_seq_cst) != 0)
+        juce::Thread::yield();
+
+    while (job.workersInside.load(std::memory_order_seq_cst) != 0)
         juce::Thread::yield();
 }
 

--- a/magda/engine/exec/RenderThreadPool.cpp
+++ b/magda/engine/exec/RenderThreadPool.cpp
@@ -23,9 +23,22 @@ class RenderThreadPool::Worker final : public juce::Thread {
             wait(-1);
             if (threadShouldExit())
                 return;
-            pool_.takeWork();
+            pool_.takeWork(*this);
         }
     }
+
+    /**
+     * @brief Where this worker is between waking and reaching a job's count.
+     *
+     * Ticked twice per arrival, so odd means inside that window and the value
+     * itself says which arrival it is. That is what release() needs and what a
+     * count could not give it: a count has to reach zero, and on a pool
+     * rendering block after block the arrivals of later ones keep it off zero,
+     * so a retirement waits on a window that reopens rather than on one that
+     * closes. A mark is per worker and monotonic, so a worker that has moved on
+     * has moved on whatever anyone starts afterwards.
+     */
+    std::atomic<std::uint64_t> arrival{0};
 
   private:
     RenderThreadPool& pool_;
@@ -78,19 +91,19 @@ void RenderThreadPool::render(Job& job) {
     job.takeWork();
 }
 
-void RenderThreadPool::takeWork() {
-    // Arrival is announced before the job is read, so release() cannot see an
-    // empty pool and conclude that a worker on its way in will not arrive. Then
-    // the worker moves itself onto the job's own count and leaves the arrival
-    // window, which is what makes a retirement wait for its own workers rather
-    // than for whoever is rendering now.
-    arriving_.fetch_add(1, std::memory_order_seq_cst);
+void RenderThreadPool::takeWork(Worker& worker) {
+    // Arrival is marked before the job is read, so release() cannot look at an
+    // idle-seeming pool and conclude that a worker on its way in will not
+    // arrive. Then the worker moves itself onto the job's own count and leaves
+    // the arrival window, which is what makes a retirement wait for its own
+    // workers rather than for whoever is rendering now.
+    worker.arrival.fetch_add(1, std::memory_order_seq_cst);
 
     auto* job = job_.load(std::memory_order_seq_cst);
     if (job != nullptr)
         job->workersInside.fetch_add(1, std::memory_order_seq_cst);
 
-    arriving_.fetch_sub(1, std::memory_order_seq_cst);
+    worker.arrival.fetch_add(1, std::memory_order_seq_cst);
 
     if (job == nullptr)
         return;
@@ -105,17 +118,30 @@ void RenderThreadPool::release(Job& job) {
     auto* expected = &job;
     job_.compare_exchange_strong(expected, nullptr, std::memory_order_seq_cst);
 
-    // Two waits, and they are for different things. The first is for workers
-    // that read the job pointer before it was taken away and have not yet
-    // counted themselves against it; nothing but a load and an increment lives
-    // in that window, so it drains as fast as those threads get a core. The
-    // second is for workers actually inside this job, which is bounded by the
-    // block they are finishing.
+    // Two waits, and they are for different things.
     //
-    // In this order, because a worker still arriving is one that has not
-    // reached the second count yet.
-    while (arriving_.load(std::memory_order_seq_cst) != 0)
-        juce::Thread::yield();
+    // The first is for workers that read the job pointer before it was taken
+    // away and have not yet counted themselves against it. Each is waited for
+    // by name: the mark this worker was on when it was looked at, and then that
+    // mark moving. Only a load and an increment live inside that window, so it
+    // is over as soon as the thread holding it gets a core, and an arrival that
+    // starts afterwards moves the mark rather than holding the wait open. That
+    // is the whole difference from asking a count to reach zero, which on a
+    // pool rendering block after block it need never do.
+    //
+    // The second is for workers actually inside this job, which is bounded by
+    // the block they are finishing.
+    //
+    // In this order, because a worker still arriving is one whose increment
+    // against the job has not happened yet.
+    for (auto& worker : workers_) {
+        const auto marked = worker->arrival.load(std::memory_order_seq_cst);
+        if (marked % 2 == 0)
+            continue;  // between arrivals, and the next one is after the swap
+
+        while (worker->arrival.load(std::memory_order_seq_cst) == marked)
+            juce::Thread::yield();
+    }
 
     while (job.workersInside.load(std::memory_order_seq_cst) != 0)
         juce::Thread::yield();

--- a/magda/engine/exec/RenderThreadPool.cpp
+++ b/magda/engine/exec/RenderThreadPool.cpp
@@ -1,0 +1,105 @@
+#include "exec/RenderThreadPool.hpp"
+
+#include <algorithm>
+
+namespace magda::engine {
+
+/**
+ * @brief One worker: sleep, take work, sleep again.
+ *
+ * juce::Thread's own wait/notify rather than an event of its own, because it is
+ * the same latching primitive and stopThread() already knows how to wake it. A
+ * notify that arrives while the worker is still working is not lost: it is
+ * remembered, and the next wait returns at once. That matters, because a worker
+ * that is late leaving one block is exactly the one being woken for the next.
+ */
+class RenderThreadPool::Worker final : public juce::Thread {
+  public:
+    Worker(RenderThreadPool& pool, int index)
+        : juce::Thread("MAGDA render " + juce::String(index)), pool_(pool) {}
+
+    void run() override {
+        while (!threadShouldExit()) {
+            wait(-1);
+            if (threadShouldExit())
+                return;
+            pool_.takeWork();
+        }
+    }
+
+  private:
+    RenderThreadPool& pool_;
+};
+
+RenderThreadPool::RenderThreadPool(int numWorkers, bool realtime) {
+    workers_.reserve(static_cast<std::size_t>(std::max(0, numWorkers)));
+    for (int index = 0; index < numWorkers; ++index) {
+        auto worker = std::make_unique<Worker>(*this, index);
+
+        // Priority alone, with no period: how long a block takes and how often
+        // one arrives are the audio device's to say, and this pool is made
+        // before any plan has been prepared for a device. What the OS is being
+        // told is that these threads run with the callback rather than behind
+        // it, which is the part that does not change per plan.
+        //
+        // Realtime scheduling is a request, and on a machine that does not
+        // grant it (a Linux box with no rtprio limit raised, a container) it is
+        // refused. A worker that was never started is one the audio thread
+        // waits on for nothing, so the refusal falls back to the highest
+        // ordinary priority rather than leaving the thread unstarted.
+        if (!realtime ||
+            !worker->startRealtimeThread(juce::Thread::RealtimeOptions{}.withPriority(9)))
+            worker->startThread(juce::Thread::Priority::high);
+
+        workers_.push_back(std::move(worker));
+    }
+}
+
+RenderThreadPool::~RenderThreadPool() {
+    // Nothing is rendering: a pool is destroyed after the executors that used
+    // it, which is what release() is for. The wait is for a worker that is
+    // between blocks, and it has nothing to finish.
+    for (auto& worker : workers_)
+        worker->signalThreadShouldExit();
+    for (auto& worker : workers_)
+        worker->stopThread(2000);
+}
+
+void RenderThreadPool::render(Job& job) {
+    job_.store(&job, std::memory_order_seq_cst);
+
+    for (auto& worker : workers_)
+        worker->notify();
+
+    // The caller is a worker too, and on a pool with none it is the only one.
+    // Its return is what says the block is finished, which is why this is not
+    // a barrier: the workers are still leaving, and there is nothing left for
+    // them to do.
+    job.takeWork();
+}
+
+void RenderThreadPool::takeWork() {
+    // Announced before the job is read, so release() cannot see zero here and
+    // conclude that a worker on its way in will not arrive.
+    inJob_.fetch_add(1, std::memory_order_seq_cst);
+
+    if (auto* job = job_.load(std::memory_order_seq_cst))
+        job->takeWork();
+
+    inJob_.fetch_sub(1, std::memory_order_seq_cst);
+}
+
+void RenderThreadPool::release(Job& job) {
+    // Only this job: another one may have been published since, and taking that
+    // one down with it would silence an epoch that is rendering.
+    auto* expected = &job;
+    job_.compare_exchange_strong(expected, nullptr, std::memory_order_seq_cst);
+
+    // Anything inside a job now is either this one, which has to be waited out,
+    // or a newer one, which is a block and will end. Either way this is a wait
+    // measured in one callback, on a thread that is allowed to wait.
+    while (inJob_.load(std::memory_order_seq_cst) != 0)
+        juce::Thread::yield();
+}
+
+}  // namespace magda::engine

--- a/magda/engine/exec/RenderThreadPool.hpp
+++ b/magda/engine/exec/RenderThreadPool.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <atomic>
+#include <memory>
+#include <vector>
+
+/**
+ * @file RenderThreadPool.hpp
+ * @brief The threads a block is rendered across.
+ *
+ * Deliberately not a general-purpose pool: it runs one job at a time, that job
+ * is always "finish this block", and every thread runs the same job rather than
+ * being handed tasks. Which op a thread picks up is the job's business, because
+ * that is where the plan's dependency counts are; all this owns is the threads
+ * and the moment they are woken.
+ *
+ * It outlives plans. Threads are made once, at whatever priority the audio
+ * device deserves, and every plan published afterwards renders on the same
+ * ones: a structural edit is not a reason to tear down and remake the threads
+ * an audio callback is about to wait for.
+ */
+
+namespace magda::engine {
+
+class RenderThreadPool {
+  public:
+    /**
+     * @brief One block of one plan, as the threads see it.
+     *
+     * The pool never asks for an op. It asks every thread to take work until
+     * there is none left, and the job decides what that means, which is what
+     * keeps the schedule and the threads independent of each other.
+     */
+    class Job {
+      public:
+        virtual ~Job() = default;
+
+        /**
+         * @brief Take ready work until the block is finished.
+         *
+         * Runs on the calling thread and on every worker at once. Returns only
+         * when the block is done, on every thread that entered it: a thread
+         * that finds nothing to take has to wait for the ops still running
+         * rather than leave, because they will make more work for it.
+         */
+        virtual void takeWork() = 0;
+    };
+
+    /**
+     * @brief Start @p numWorkers threads besides the one that renders.
+     *
+     * Zero is a pool that renders on the caller alone, which is the same walk
+     * a single-threaded executor makes and is what the tests compare against.
+     *
+     * @p realtime asks the OS for audio priority, which is what a worker the
+     * callback is waiting on needs and what a worker in a test does not: a test
+     * that spins up realtime threads competes with whatever else is on the
+     * machine for no benefit.
+     */
+    explicit RenderThreadPool(int numWorkers, bool realtime = true);
+    ~RenderThreadPool();
+
+    RenderThreadPool(const RenderThreadPool&) = delete;
+    RenderThreadPool& operator=(const RenderThreadPool&) = delete;
+
+    /// Threads a block is spread across: the workers, plus whoever calls
+    /// render().
+    int numThreads() const {
+        return static_cast<int>(workers_.size()) + 1;
+    }
+
+    /**
+     * @brief Render one block of @p job. On the audio thread.
+     *
+     * Wakes the workers, takes work on this thread too, and returns when the
+     * job says the block is finished. Nothing here allocates or locks; waking a
+     * sleeping worker is the one system call, and it is the price of not
+     * spinning a core per thread between callbacks.
+     *
+     * A worker may still be inside takeWork() when this returns. It has no ops
+     * left to run, because the job would not have finished otherwise, but it
+     * has not necessarily noticed yet.
+     */
+    void render(Job& job);
+
+    /**
+     * @brief Let go of @p job, so it can be destroyed. Off the audio thread.
+     *
+     * Returns once no worker can enter it again, waiting out any that is inside
+     * it. That wait is why this is not audio-thread code: it is bounded by a
+     * block, and it belongs on the thread that retires an epoch rather than on
+     * the one rendering the next.
+     *
+     * The caller still owes the ordering that makes the wait finite: a job
+     * being rendered right now is a job whose render() call has to return
+     * first, which for a plan swap is what publishing does.
+     */
+    void release(Job& job);
+
+  private:
+    class Worker;
+
+    /// What a worker runs when it wakes. Separate from render() because a
+    /// worker has to announce itself before it reads the job pointer, so that
+    /// release() cannot conclude the coast is clear while one is arriving.
+    void takeWork();
+
+    std::vector<std::unique_ptr<Worker>> workers_;
+
+    /// The job the workers render, or null between blocks that are the last of
+    /// their epoch. Sequentially consistent, and so is inJob_: the two are read
+    /// and written against each other by release(), which is exactly the
+    /// handshake that acquire/release alone does not settle.
+    std::atomic<Job*> job_{nullptr};
+
+    /// Workers that have committed to reading job_ and have not yet left it.
+    std::atomic<int> inJob_{0};
+};
+
+}  // namespace magda::engine

--- a/magda/engine/exec/RenderThreadPool.hpp
+++ b/magda/engine/exec/RenderThreadPool.hpp
@@ -120,22 +120,19 @@ class RenderThreadPool {
 
     /// What a worker runs when it wakes. Separate from render() because a
     /// worker has to announce itself before it reads the job pointer, so that
-    /// release() cannot conclude the coast is clear while one is arriving.
-    void takeWork();
+    /// release() cannot conclude the coast is clear while one is arriving. It
+    /// announces on its own slot, which is what keeps that announcement from
+    /// being something a later block can renew.
+    void takeWork(Worker& worker);
 
     std::vector<std::unique_ptr<Worker>> workers_;
 
     /// The job the workers render, or null between blocks that are the last of
-    /// their epoch. Sequentially consistent, and so is arriving_: the two are
-    /// read and written against each other by release(), which is exactly the
-    /// handshake that acquire/release alone does not settle.
+    /// their epoch. Sequentially consistent, and so are the workers' arrival
+    /// marks: the two are read and written against each other by release(),
+    /// which is exactly the handshake that acquire/release alone does not
+    /// settle.
     std::atomic<Job*> job_{nullptr};
-
-    /// Workers that have committed to reading job_ and have not yet reached the
-    /// job's own count. Nothing but a load and an increment happens inside this
-    /// window, so it empties in the time it takes a thread to be scheduled,
-    /// which is what makes waiting on it different from waiting on the work.
-    std::atomic<int> arriving_{0};
 };
 
 }  // namespace magda::engine

--- a/magda/engine/exec/RenderThreadPool.hpp
+++ b/magda/engine/exec/RenderThreadPool.hpp
@@ -46,6 +46,17 @@ class RenderThreadPool {
          * rather than leave, because they will make more work for it.
          */
         virtual void takeWork() = 0;
+
+      private:
+        friend class RenderThreadPool;
+
+        /// Workers inside this job. The pool's, not the job's: it is how
+        /// release() knows whether anyone can still be in here, and counting it
+        /// per job rather than per pool is what keeps that wait finite. A
+        /// pool-wide count would be pushed back up by every later block, so a
+        /// session rendering back to back could keep a retiring epoch waiting
+        /// indefinitely for workers that were never in it.
+        std::atomic<int> workersInside{0};
     };
 
     /**
@@ -89,9 +100,14 @@ class RenderThreadPool {
      * @brief Let go of @p job, so it can be destroyed. Off the audio thread.
      *
      * Returns once no worker can enter it again, waiting out any that is inside
-     * it. That wait is why this is not audio-thread code: it is bounded by a
-     * block, and it belongs on the thread that retires an epoch rather than on
-     * the one rendering the next.
+     * it. That wait is why this is not audio-thread code: it is bounded by the
+     * last block of that job, and it belongs on the thread that retires an
+     * epoch rather than on the one rendering the next.
+     *
+     * Only this job is waited for. A worker rendering the epoch that replaced
+     * it is not something a retirement has any reason to wait on, and waiting
+     * on it would not be a wait with an end: a busy session starts the next
+     * block before the last worker has left the one before.
      *
      * The caller still owes the ordering that makes the wait finite: a job
      * being rendered right now is a job whose render() call has to return
@@ -110,13 +126,16 @@ class RenderThreadPool {
     std::vector<std::unique_ptr<Worker>> workers_;
 
     /// The job the workers render, or null between blocks that are the last of
-    /// their epoch. Sequentially consistent, and so is inJob_: the two are read
-    /// and written against each other by release(), which is exactly the
+    /// their epoch. Sequentially consistent, and so is arriving_: the two are
+    /// read and written against each other by release(), which is exactly the
     /// handshake that acquire/release alone does not settle.
     std::atomic<Job*> job_{nullptr};
 
-    /// Workers that have committed to reading job_ and have not yet left it.
-    std::atomic<int> inJob_{0};
+    /// Workers that have committed to reading job_ and have not yet reached the
+    /// job's own count. Nothing but a load and an increment happens inside this
+    /// window, so it empties in the time it takes a thread to be scheduled,
+    /// which is what makes waiting on it different from waiting on the work.
+    std::atomic<int> arriving_{0};
 };
 
 }  // namespace magda::engine

--- a/magda/engine/plan/RenderPlan.cpp
+++ b/magda/engine/plan/RenderPlan.cpp
@@ -174,38 +174,55 @@ std::vector<OpId> distinctProducers(const PlanOp& op) {
 
 }  // namespace
 
-void bakeScheduling(RenderPlan& plan) {
+PlanScheduling scheduleOf(const RenderPlan& plan) {
     const auto numOps = plan.ops.size();
 
-    plan.dependencyCounts.assign(numOps, 0);
-    plan.initialReadyOps.clear();
-    plan.consumerOffsets.assign(numOps + 1, 0);
-    plan.consumerEdges.clear();
+    PlanScheduling schedule;
+    schedule.dependencyCounts.assign(numOps, 0);
+    schedule.consumerOffsets.assign(numOps + 1, 0);
 
     // Pass 1: dependency counts, and per-producer consumer counts into the
     // offset array (shifted by one so the prefix sum below lands in place).
     for (std::size_t i = 0; i < numOps; ++i) {
         const auto producers = distinctProducers(plan.ops[i]);
-        plan.dependencyCounts[i] = static_cast<std::uint16_t>(producers.size());
+        schedule.dependencyCounts[i] = static_cast<std::uint16_t>(producers.size());
         if (producers.empty())
-            plan.initialReadyOps.push_back(static_cast<OpId>(i));
+            schedule.initialReadyOps.push_back(static_cast<OpId>(i));
         for (const auto producer : producers)
-            ++plan.consumerOffsets[static_cast<std::size_t>(producer) + 1];
+            ++schedule.consumerOffsets[static_cast<std::size_t>(producer) + 1];
     }
 
     for (std::size_t i = 0; i < numOps; ++i)
-        plan.consumerOffsets[i + 1] += plan.consumerOffsets[i];
+        schedule.consumerOffsets[i + 1] += schedule.consumerOffsets[i];
 
     // Pass 2: fill the edge array. Consumers land in ascending op order because
     // ops are visited in order and each producer precedes all of its consumers.
-    plan.consumerEdges.assign(static_cast<std::size_t>(plan.consumerOffsets[numOps]),
-                              INVALID_OP_ID);
-    std::vector<int> cursor(plan.consumerOffsets.begin(), plan.consumerOffsets.end() - 1);
+    schedule.consumerEdges.assign(static_cast<std::size_t>(schedule.consumerOffsets[numOps]),
+                                  INVALID_OP_ID);
+    std::vector<int> cursor(schedule.consumerOffsets.begin(), schedule.consumerOffsets.end() - 1);
     for (std::size_t i = 0; i < numOps; ++i) {
         for (const auto producer : distinctProducers(plan.ops[i]))
-            plan.consumerEdges[static_cast<std::size_t>(
+            schedule.consumerEdges[static_cast<std::size_t>(
                 cursor[static_cast<std::size_t>(producer)]++)] = static_cast<OpId>(i);
     }
+
+    return schedule;
+}
+
+void bakeScheduling(RenderPlan& plan) {
+    auto schedule = scheduleOf(plan);
+    plan.dependencyCounts = std::move(schedule.dependencyCounts);
+    plan.consumerOffsets = std::move(schedule.consumerOffsets);
+    plan.consumerEdges = std::move(schedule.consumerEdges);
+    plan.initialReadyOps = std::move(schedule.initialReadyOps);
+}
+
+bool carriesSchedule(const RenderPlan& plan) {
+    const auto expected = scheduleOf(plan);
+    return plan.dependencyCounts == expected.dependencyCounts &&
+           plan.consumerOffsets == expected.consumerOffsets &&
+           plan.consumerEdges == expected.consumerEdges &&
+           plan.initialReadyOps == expected.initialReadyOps;
 }
 
 std::uint64_t planFingerprint(const RenderPlan& plan) {

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -217,8 +217,42 @@ struct RenderPlan {
  */
 int arityOf(OpKind kind);
 
+/** The scheduling constants a plan's topology implies. */
+struct PlanScheduling {
+    std::vector<std::uint16_t> dependencyCounts;
+    std::vector<int> consumerOffsets;
+    std::vector<OpId> consumerEdges;
+    std::vector<OpId> initialReadyOps;
+};
+
+/**
+ * @brief Work out the scheduling constants for @p plan, without writing them.
+ *
+ * A pure function of the ops and their inputs, which is what lets the executor
+ * check a plan's constants rather than take them on trust.
+ */
+PlanScheduling scheduleOf(const RenderPlan& plan);
+
 /** Fill in dependencyCounts, consumer edges and initialReadyOps. */
 void bakeScheduling(RenderPlan& plan);
+
+/**
+ * @brief Whether a plan's baked constants are the ones its topology implies.
+ *
+ * Not a size check. The parallel executor's whole safety story is that the
+ * schedule it copies in every block came from the compiler, and every way of
+ * being wrong here is expensive: a count too high or a seed op missing leaves
+ * ops nobody will ever release, so the block never finishes and the callback
+ * spins for ever; a count too low releases an op while its producers are still
+ * writing, which is a race on a shared buffer; an offset or an edge out of
+ * range walks off the end of an array. None of it is visible to validatePlan,
+ * which reads the topology, and none of it is in the fingerprint, which is
+ * computed from the topology too.
+ *
+ * So the constants are recomputed and compared. It runs off the audio thread,
+ * once per prepare, and it is the same linear pass that produced them.
+ */
+bool carriesSchedule(const RenderPlan& plan);
 
 /**
  * @brief Structural identity of a plan, over its ops, keys and edges.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -245,6 +245,7 @@ set(TEST_SOURCES
 if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_render_plan_compiler.cpp)
     list(APPEND TEST_SOURCES test_render_plan_executor.cpp)
+    list(APPEND TEST_SOURCES test_parallel_executor.cpp)
     list(APPEND TEST_SOURCES test_plan_layout.cpp)
     list(APPEND TEST_SOURCES test_plan_diff.cpp)
     list(APPEND TEST_SOURCES test_engine_session.cpp)

--- a/tests/test_engine_session.cpp
+++ b/tests/test_engine_session.cpp
@@ -1007,3 +1007,51 @@ TEST_CASE("A host that wants no meters binds none and renders the same", "[engin
 
     CHECK(output.getMagnitude(0, kBlockSize) > 0.0f);
 }
+
+TEST_CASE("A session on a thread pool renders what a session without one renders",
+          "[engine][session][parallel]") {
+    // The session drives the parallel executor whether or not it was given
+    // threads, so this is not two engines being compared: it is one, with the
+    // block spread out and not. Bit for bit, because that is the executor's
+    // whole claim and the session is where it has to survive plan swaps,
+    // published values and a callback cut by the transport.
+    const auto render = [](magda::engine::RenderThreadPool* pool) {
+        Ledger ledger;
+        TestFactory factory(ledger);
+        factory.latencyFor[7] = 53;
+        EngineSession session(factory, pool);
+
+        auto tracks = trackWithEffect(7);
+        tracks.push_back(makeTrack(2));
+        const auto plan = compile(tracks);
+        REQUIRE(publish(session, plan, tracks).published);
+        session.publishValues(resolve(*plan, tracks));
+        session.publishTransport(rolling(0.0));
+
+        std::vector<float> samples;
+        juce::AudioBuffer<float> output(2, kBlockSize);
+        for (int block = 0; block < 16; ++block) {
+            // A swap partway through, so what the differ carried across it is
+            // part of what is being compared.
+            if (block == 8) {
+                tracks.push_back(makeTrack(3));
+                const auto grown = compile(tracks);
+                REQUIRE(publish(session, grown, tracks).published);
+                session.publishValues(resolve(*grown, tracks));
+            }
+
+            output.clear();
+            session.process(kBlockSize, output);
+            for (int channel = 0; channel < output.getNumChannels(); ++channel)
+                for (int sample = 0; sample < kBlockSize; ++sample)
+                    samples.push_back(output.getSample(channel, sample));
+        }
+        return samples;
+    };
+
+    const auto alone = render(nullptr);
+    REQUIRE_FALSE(alone.empty());
+
+    magda::engine::RenderThreadPool pool(4, false);
+    CHECK(render(&pool) == alone);
+}

--- a/tests/test_parallel_executor.cpp
+++ b/tests/test_parallel_executor.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "core/RackInfo.hpp"
@@ -15,6 +16,7 @@
 #include "exec/RenderThreadPool.hpp"
 #include "plan/PlanCompiler.hpp"
 #include "plan/PlanDump.hpp"
+#include "plan/RenderPlan.hpp"
 
 /**
  * @file test_parallel_executor.cpp
@@ -738,14 +740,76 @@ TEST_CASE("The two executors prepare to the same layout", "[engine][exec][parall
     }
 }
 
-TEST_CASE("A plan the compiler never baked a schedule into is refused",
+TEST_CASE("A plan whose schedule is not the one its ops imply is refused",
           "[engine][exec][parallel]") {
+    // Every one of these is expensive rather than merely wrong, which is why
+    // the check is a recompute and not a look at the array lengths. An op that
+    // nothing will ever release leaves the block unfinished, and a block that
+    // never finishes is an audio callback that never returns; an op released
+    // early runs while another op is still writing the buffer it reads. Both
+    // are invisible to validatePlan, which reads the topology, and to the
+    // fingerprint, which is computed from the topology too.
     Rig rig(wideScene());
     RenderThreadPool pool(2, false);
-    ParallelPlanExecutor executor(&pool);
 
     auto plan = rig.plan;
-    plan.dependencyCounts.clear();
+    REQUIRE(plan.ops.size() > 4);
+    REQUIRE_FALSE(plan.initialReadyOps.empty());
+
+    bool broken = true;
+
+    SECTION("nothing wrong with it") {
+        broken = false;
+    }
+
+    SECTION("no counts at all") {
+        plan.dependencyCounts.clear();
+    }
+
+    SECTION("a count that is one too high") {
+        // The op waits for a producer that does not exist, so nothing ever
+        // takes it to zero and the block cannot end.
+        ++plan.dependencyCounts.back();
+    }
+
+    SECTION("a count that is one too low") {
+        for (auto& count : plan.dependencyCounts)
+            if (count > 0) {
+                --count;
+                break;
+            }
+    }
+
+    SECTION("a source missing from the ready set") {
+        // The one the size checks could never catch: everything is the right
+        // length, and an op with no producers is simply never seeded.
+        plan.initialReadyOps.pop_back();
+    }
+
+    SECTION("a ready op that is not an op") {
+        plan.initialReadyOps.back() = static_cast<OpId>(plan.ops.size() + 3);
+    }
+
+    SECTION("offsets that do not describe these edges") {
+        plan.consumerOffsets[1] += 5;
+    }
+
+    SECTION("an edge pointing somewhere else") {
+        REQUIRE_FALSE(plan.consumerEdges.empty());
+        plan.consumerEdges.front() = static_cast<OpId>(plan.ops.size() + 1);
+    }
+
+    ParallelPlanExecutor executor(&pool);
+
+    if (!broken) {
+        CHECK(executor.prepare(plan, rig.scene.bindings, rig.context).empty());
+        CHECK(executor.isPrepared());
+        return;
+    }
+
+    // Checked here as well as through prepare, so a section that meant to break
+    // something and did not is a failure rather than a test that quietly agrees.
+    REQUIRE_FALSE(magda::engine::carriesSchedule(plan));
 
     const auto messages = executor.prepare(plan, rig.scene.bindings, rig.context);
     CHECK_FALSE(messages.empty());
@@ -756,6 +820,83 @@ TEST_CASE("A plan the compiler never baked a schedule into is refused",
     rig.output.clear();
     executor.process(rig.values, blockAt(0, kBlockSize), rig.output);
     CHECK(rig.output.getMagnitude(0, kBlockSize) == 0.0f);
+}
+
+TEST_CASE("Retiring an epoch waits for its own workers and not for the ones after it",
+          "[engine][exec][parallel]") {
+    // The shape a session makes, with both threads doing their real jobs: one
+    // renders block after block on the pool, the other publishes epochs and
+    // retires the ones they replace. What is being asked of the retirement is
+    // that it ends, and ends while the pool is busy. A wait on how many workers
+    // are in the pool rather than on how many are in this job would be pushed
+    // back up by every block the render thread starts next.
+    struct Epoch {
+        Epoch(Scene scene, RenderThreadPool& pool) : rig(std::move(scene)), executor(&pool) {}
+
+        Rig rig;
+        ParallelPlanExecutor executor;
+    };
+
+    RenderThreadPool pool(4, false);
+
+    std::mutex swapMutex;
+    std::shared_ptr<Epoch> current;
+    std::atomic<int> published{0};
+    std::atomic<int> rendered{-1};
+    std::atomic<bool> stop{false};
+    std::atomic<int> blocks{0};
+
+    std::thread audioThread([&] {
+        for (std::int64_t block = 0; !stop.load(); ++block) {
+            std::shared_ptr<Epoch> epoch;
+            int generation = 0;
+            {
+                const std::lock_guard<std::mutex> lock(swapMutex);
+                epoch = current;
+                generation = published.load();
+            }
+            if (epoch == nullptr) {
+                juce::Thread::yield();
+                continue;
+            }
+
+            epoch->executor.process(epoch->rig.values, blockAt(block * kBlockSize, kBlockSize),
+                                    epoch->rig.output);
+            rendered.store(generation);
+            ++blocks;
+        }
+    });
+
+    const auto started = std::chrono::steady_clock::now();
+    for (int swap = 0; swap < 20; ++swap) {
+        auto next = std::make_shared<Epoch>(wideScene(), pool);
+        REQUIRE(next->executor.prepare(next->rig.plan, next->rig.scene.bindings, next->rig.context)
+                    .empty());
+
+        std::shared_ptr<Epoch> retiring;
+        {
+            const std::lock_guard<std::mutex> lock(swapMutex);
+            retiring = std::move(current);
+            current = std::move(next);
+            published.fetch_add(1);
+        }
+
+        // Let the render thread get into the new epoch, so the one being
+        // retired is let go of while the pool is busy rather than idle.
+        while (rendered.load() < published.load())
+            juce::Thread::yield();
+
+        // The last reference, so the destructor and its wait run here.
+        retiring.reset();
+    }
+    const auto elapsed =
+        std::chrono::duration<double>(std::chrono::steady_clock::now() - started).count();
+
+    stop.store(true);
+    audioThread.join();
+
+    CHECK(blocks.load() > 0);
+    CHECK(elapsed < 10.0);
 }
 
 TEST_CASE("An executor with no plan renders silence", "[engine][exec][parallel]") {

--- a/tests/test_parallel_executor.cpp
+++ b/tests/test_parallel_executor.cpp
@@ -1,0 +1,899 @@
+#include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "core/RackInfo.hpp"
+#include "core/TrackInfo.hpp"
+#include "exec/ParallelPlanExecutor.hpp"
+#include "exec/PlanExecutor.hpp"
+#include "exec/RenderThreadPool.hpp"
+#include "plan/PlanCompiler.hpp"
+#include "plan/PlanDump.hpp"
+
+/**
+ * @file test_parallel_executor.cpp
+ * @brief What the parallel executor owes the reference one: the same samples.
+ *
+ * Not nearly the same. Every test here compares floats with ==, because the
+ * claim being made is bit-identity at every thread count, and a tolerance would
+ * hide exactly the thing that would go wrong: a sum that took its inputs in the
+ * order they finished rather than the order they were compiled in.
+ *
+ * Every comparison renders the model twice from scratch. A device carries state
+ * from one block to the next, so two renders means two of everything behind the
+ * plan, and a scene is therefore a recipe rather than a fixture.
+ */
+
+using namespace magda;
+using magda::engine::BlockInfo;
+using magda::engine::DeviceBlock;
+using magda::engine::EngineAudioSource;
+using magda::engine::EngineDevice;
+using magda::engine::EngineMidiSource;
+using magda::engine::LevelTap;
+using magda::engine::OpId;
+using magda::engine::OpKey;
+using magda::engine::ParallelPlanExecutor;
+using magda::engine::PlanBindings;
+using magda::engine::PlanExecutor;
+using magda::engine::PlanValues;
+using magda::engine::RenderContext;
+using magda::engine::RenderPlan;
+using magda::engine::RenderThreadPool;
+
+namespace {
+
+constexpr int kBlockSize = 64;
+constexpr double kSamplesPerBeat = 64.0;
+constexpr int kNumBlocks = 24;
+
+BlockInfo blockAt(std::int64_t timelineSample, int numSamples) {
+    BlockInfo block;
+    block.numSamples = numSamples;
+    block.playing = true;
+    block.startBeat = static_cast<double>(timelineSample) / kSamplesPerBeat;
+    block.endBeat = static_cast<double>(timelineSample + numSamples) / kSamplesPerBeat;
+    block.startSeconds = static_cast<double>(timelineSample) / 44100.0;
+    block.endSeconds = static_cast<double>(timelineSample + numSamples) / 44100.0;
+    block.continuous = timelineSample > 0;
+    return block;
+}
+
+std::int64_t timelineSampleOf(const BlockInfo& block) {
+    return static_cast<std::int64_t>(block.startBeat * kSamplesPerBeat + 0.5);
+}
+
+TrackInfo makeTrack(TrackId id, TrackType type = TrackType::Audio) {
+    TrackInfo track;
+    track.id = id;
+    track.type = type;
+    track.name = "Track " + juce::String(id);
+    track.audioOutputDevice = "master";
+    return track;
+}
+
+TrackInfo makeMaster() {
+    auto master = makeTrack(MASTER_TRACK_ID, TrackType::Master);
+    master.audioOutputDevice = {};
+    return master;
+}
+
+DeviceInfo makeEffect(DeviceId id) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Effect " + juce::String(id);
+    device.deviceType = DeviceType::Effect;
+    return device;
+}
+
+DeviceInfo makeInstrument(DeviceId id) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Instrument " + juce::String(id);
+    device.deviceType = DeviceType::Instrument;
+    device.isInstrument = true;
+    device.canReceiveMidi = true;
+    return device;
+}
+
+/// A different sample at every timeline position, and a different one per
+/// source, so a buffer read before its producer wrote it comes out wrong rather
+/// than merely early.
+class RampSource final : public EngineAudioSource {
+  public:
+    explicit RampSource(int seed) : seed_(seed) {}
+
+    void render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) override {
+        const auto start = timelineSampleOf(block);
+        for (int sample = 0; sample < block.numSamples; ++sample) {
+            const auto value =
+                static_cast<float>((start + sample + seed_) % 91) * (1.0f / 91.0f) + 0.001f;
+            for (std::size_t channel = 0; channel < out.getNumChannels(); ++channel)
+                out.setSample(static_cast<int>(channel), sample,
+                              value * (channel == 0 ? 1.0f : -0.5f));
+        }
+    }
+
+  private:
+    int seed_;
+};
+
+/// A note-on every @p period samples of the timeline, so what a device receives
+/// does not depend on how the blocks were cut.
+class TimelineNoteSource final : public EngineMidiSource {
+  public:
+    TimelineNoteSource(int noteNumber, int period) : noteNumber_(noteNumber), period_(period) {}
+
+    void render(const BlockInfo& block, juce::MidiBuffer& out) override {
+        const auto start = timelineSampleOf(block);
+        const auto first = (start + period_ - 1) / period_ * period_;
+        for (auto position = first; position < start + block.numSamples; position += period_)
+            out.addEvent(juce::MidiMessage::noteOn(1, noteNumber_, 1.0f),
+                         static_cast<int>(position - start));
+    }
+
+  private:
+    int noteNumber_, period_;
+};
+
+/// Scales its input, and counts the blocks it saw. The count is what says an op
+/// ran once per block rather than twice or not at all, which no amount of
+/// comparing output can distinguish from a gain that happened to agree.
+class GainDevice final : public EngineDevice {
+  public:
+    explicit GainDevice(float gain) : gain_(gain) {}
+
+    void process(DeviceBlock& block) override {
+        ++processedBlocks;
+        block.audio.multiplyBy(gain_);
+    }
+
+    int processedBlocks = 0;
+
+  private:
+    float gain_;
+};
+
+/// Scales by which block it is on, so a block rendered twice or skipped shows
+/// up in the samples themselves and not only in a counter.
+class TallyDevice final : public EngineDevice {
+  public:
+    void process(DeviceBlock& block) override {
+        ++blocks_;
+        block.audio.multiplyBy(1.0f / static_cast<float>(blocks_));
+    }
+
+  private:
+    int blocks_ = 0;
+};
+
+/// Delays what it is given, and reports the latency it really has, so the plan
+/// compiles delays around it and the schedule has to keep them fed in order.
+class LatentDevice final : public EngineDevice {
+  public:
+    explicit LatentDevice(int latency) : latency_(latency) {}
+
+    void prepare(const RenderContext& context) override {
+        history_.assign(static_cast<std::size_t>(context.numChannels),
+                        std::deque<float>(static_cast<std::size_t>(latency_), 0.0f));
+    }
+
+    void process(DeviceBlock& block) override {
+        for (std::size_t channel = 0; channel < block.audio.getNumChannels(); ++channel) {
+            auto* samples = block.audio.getChannelPointer(channel);
+            auto& history = history_[channel];
+            for (int sample = 0; sample < block.block.numSamples; ++sample) {
+                history.push_back(samples[sample]);
+                samples[sample] = history.front();
+                history.pop_front();
+            }
+        }
+    }
+
+    int latencySamples() const override {
+        return latency_;
+    }
+
+  private:
+    int latency_;
+    std::vector<std::deque<float>> history_;
+};
+
+/// Turns the notes it receives into DC, so MIDI arriving at the wrong moment is
+/// audible in the output rather than invisible.
+class NoteToDcInstrument final : public EngineDevice {
+  public:
+    void process(DeviceBlock& block) override {
+        for (const auto metadata : *block.midiIn)
+            if (const auto message = metadata.getMessage(); message.isNoteOn())
+                level_ = static_cast<float>(message.getNoteNumber()) / 127.0f;
+
+        block.audio.fill(level_);
+    }
+
+  private:
+    float level_ = 0.0f;
+};
+
+/// Emits a note of its own, which the chain merges with what it was given.
+class ArpDevice final : public EngineDevice {
+  public:
+    explicit ArpDevice(int noteNumber) : noteNumber_(noteNumber) {}
+
+    void process(DeviceBlock& block) override {
+        block.audio.clear();
+        if (block.midiOut != nullptr)
+            block.midiOut->addEvent(juce::MidiMessage::noteOn(1, noteNumber_, 1.0f), 0);
+    }
+
+  private:
+    int noteNumber_;
+};
+
+/**
+ * @brief Two devices that will not finish until both have started.
+ *
+ * Everything else here would pass on a pool whose workers never woke: the
+ * output would be right and only the wall clock would say otherwise. This is
+ * the one test that cannot, because it counts how many devices were inside
+ * process() at once, and one thread can never make that two.
+ *
+ * Blocking inside process() is a thing no real device may do. It is safe here
+ * because the branches are independent, so the ops can genuinely run at the
+ * same time, and because the wait times out rather than hanging: a pool that
+ * does not deliver fails this in two seconds instead of never returning.
+ */
+struct Meeting {
+    std::mutex mutex;
+    std::condition_variable arrived;
+    int inside = 0;
+    int mostAtOnce = 0;
+    bool met = false;
+};
+
+class RendezvousDevice final : public EngineDevice {
+  public:
+    RendezvousDevice(Meeting& meeting, int expected) : meeting_(meeting), expected_(expected) {}
+
+    void process(DeviceBlock& block) override {
+        block.audio.clear();
+
+        std::unique_lock<std::mutex> lock(meeting_.mutex);
+        ++meeting_.inside;
+        meeting_.mostAtOnce = std::max(meeting_.mostAtOnce, meeting_.inside);
+
+        if (meeting_.inside >= expected_) {
+            meeting_.met = true;
+            meeting_.arrived.notify_all();
+        } else {
+            meeting_.arrived.wait_for(lock, std::chrono::seconds(2),
+                                      [this] { return meeting_.met; });
+        }
+
+        --meeting_.inside;
+    }
+
+  private:
+    Meeting& meeting_;
+    int expected_;
+};
+
+/**
+ * @brief A model and the objects behind it, built fresh for one render.
+ *
+ * Owns everything the bindings point at: comparing two executors means running
+ * the same recipe twice, because a device that has already seen twelve blocks
+ * is not the device the other run started with.
+ */
+struct Scene {
+    std::vector<TrackInfo> tracks;
+    TrackInfo master = makeMaster();
+    PlanBindings bindings;
+
+    std::vector<std::unique_ptr<EngineAudioSource>> audioSources;
+    std::vector<std::unique_ptr<EngineMidiSource>> midiSources;
+    std::vector<std::unique_ptr<EngineDevice>> devices;
+
+    EngineAudioSource* own(std::unique_ptr<EngineAudioSource> source) {
+        audioSources.push_back(std::move(source));
+        return audioSources.back().get();
+    }
+    EngineMidiSource* own(std::unique_ptr<EngineMidiSource> source) {
+        midiSources.push_back(std::move(source));
+        return midiSources.back().get();
+    }
+    EngineDevice* own(std::unique_ptr<EngineDevice> device) {
+        devices.push_back(std::move(device));
+        return devices.back().get();
+    }
+};
+
+/// What the runtime store does when it makes an object: the executor does not
+/// prepare what it does not own.
+void prepareBindings(PlanBindings& bindings, const RenderContext& context) {
+    for (auto& [id, device] : bindings.devices)
+        device->prepare(context);
+    for (auto& [id, source] : bindings.clipAudio)
+        source->prepare(context);
+    for (auto& [id, source] : bindings.clipMidi)
+        source->prepare(context);
+    for (auto& [id, source] : bindings.audioInputs)
+        source->prepare(context);
+    for (auto& [id, source] : bindings.midiInputs)
+        source->prepare(context);
+}
+
+/// Everything one render needs: the compiled plan, the values, the taps, and
+/// somewhere to render into.
+struct Rig {
+    explicit Rig(Scene sceneIn) : scene(std::move(sceneIn)) {
+        plan = magda::engine::compileRenderPlan(scene.tracks, scene.master);
+        valueMessages = magda::engine::resolvePlanValues(plan, scene.tracks, scene.master, values);
+
+        for (const auto& op : plan.ops) {
+            if (op.kind != magda::engine::OpKind::Meter)
+                continue;
+            auto tap = std::make_unique<LevelTap>();
+            scene.bindings.meters[op.key] = tap.get();
+            meters.emplace(op.key, std::move(tap));
+        }
+
+        prepareBindings(scene.bindings, context);
+        output.setSize(context.numChannels, kBlockSize);
+    }
+
+    /// Every tap, in key order, taken once. Order matters: a read is
+    /// destructive, so this has to be the same walk for both executors.
+    std::vector<float> readMeters() {
+        std::vector<float> levels;
+        for (auto& [key, tap] : meters)
+            levels.push_back(tap->read().loudest());
+        return levels;
+    }
+
+    Scene scene;
+    RenderPlan plan;
+    PlanValues values;
+    std::vector<std::string> valueMessages;
+    std::map<OpKey, std::unique_ptr<LevelTap>> meters;
+    RenderContext context{44100.0, kBlockSize, 2};
+    juce::AudioBuffer<float> output;
+};
+
+/// Every sample of every block, and what the meters read at the end of them.
+struct Render {
+    std::vector<float> samples;
+    std::vector<float> meters;
+};
+
+/// How long each block of a render is. Blocks shorter than the prepared one are
+/// legal and a scheduler that assumed otherwise would only be caught by them.
+std::vector<int> blockLengths(int numBlocks, bool ragged) {
+    std::vector<int> lengths;
+    for (int block = 0; block < numBlocks; ++block)
+        lengths.push_back(ragged ? 1 + (block * 17) % kBlockSize : kBlockSize);
+    return lengths;
+}
+
+template <typename Executor>
+Render renderThrough(Rig& rig, Executor& executor, const std::vector<int>& lengths) {
+    INFO(magda::engine::dumpPlan(rig.plan));
+    for (const auto& message : rig.valueMessages)
+        FAIL_CHECK(message);
+    for (const auto& message : executor.prepare(rig.plan, rig.scene.bindings, rig.context))
+        FAIL_CHECK(message);
+
+    Render render;
+    std::int64_t position = 0;
+    for (const auto length : lengths) {
+        executor.process(rig.values, blockAt(position, length), rig.output);
+        for (int channel = 0; channel < rig.output.getNumChannels(); ++channel)
+            for (int sample = 0; sample < length; ++sample)
+                render.samples.push_back(rig.output.getSample(channel, sample));
+        position += length;
+    }
+
+    render.meters = rig.readMeters();
+    return render;
+}
+
+Render renderReference(Scene scene, const std::vector<int>& lengths) {
+    Rig rig(std::move(scene));
+    PlanExecutor executor;
+    return renderThrough(rig, executor, lengths);
+}
+
+Render renderParallel(Scene scene, RenderThreadPool& pool, const std::vector<int>& lengths) {
+    Rig rig(std::move(scene));
+    ParallelPlanExecutor executor(&pool);
+    return renderThrough(rig, executor, lengths);
+}
+
+/// Where two renders first disagree, or -1. A sample index rather than a bare
+/// failure, because the index says which op got it wrong.
+int firstDifference(const std::vector<float>& expected, const std::vector<float>& actual) {
+    if (expected.size() != actual.size())
+        return 0;
+    for (std::size_t sample = 0; sample < expected.size(); ++sample)
+        if (expected[sample] != actual[sample])
+            return static_cast<int>(sample);
+    return -1;
+}
+
+// --- the scenes ------------------------------------------------------------
+
+/// One track, one chain. The degenerate case: nothing to run in parallel, and
+/// every op waiting on the one before it.
+Scene chainScene() {
+    Scene scene;
+    auto track = makeTrack(1);
+    track.volume = 0.7f;
+    track.pan = -0.25f;
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(7)));
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(8)));
+    scene.tracks.push_back(track);
+
+    scene.bindings.clipAudio[1] = scene.own(std::make_unique<RampSource>(3));
+    scene.bindings.devices[7] = scene.own(std::make_unique<GainDevice>(0.5f));
+    scene.bindings.devices[8] = scene.own(std::make_unique<TallyDevice>());
+    return scene;
+}
+
+/// Eight tracks into the master. The widest fan-in the model produces, and the
+/// one place where summing in the order things finished would be visible.
+Scene wideScene() {
+    Scene scene;
+    for (TrackId id = 1; id <= 8; ++id) {
+        auto track = makeTrack(id);
+        track.volume = 0.4f + 0.05f * static_cast<float>(id);
+        track.pan = -1.0f + 0.25f * static_cast<float>(id);
+        track.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(100 + id)));
+        scene.tracks.push_back(track);
+
+        scene.bindings.clipAudio[id] = scene.own(std::make_unique<RampSource>(id * 7));
+        scene.bindings.devices[100 + id] =
+            scene.own(std::make_unique<GainDevice>(0.9f - 0.05f * static_cast<float>(id)));
+    }
+    return scene;
+}
+
+/// Sends into an aux, which is the plan's other fan-in and the one that crosses
+/// tracks: the aux return waits on every track that feeds it.
+Scene sendScene() {
+    Scene scene;
+    auto aux = makeTrack(9, TrackType::Aux);
+    aux.auxBusIndex = 0;
+    aux.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(200)));
+
+    for (TrackId id = 1; id <= 4; ++id) {
+        auto track = makeTrack(id);
+        track.sends.push_back(SendInfo{0, 0.3f + 0.1f * static_cast<float>(id), id % 2 == 0, 9});
+        scene.tracks.push_back(track);
+        scene.bindings.clipAudio[id] = scene.own(std::make_unique<RampSource>(id * 13));
+    }
+
+    scene.tracks.push_back(aux);
+    scene.bindings.devices[200] = scene.own(std::make_unique<GainDevice>(0.6f));
+    return scene;
+}
+
+/// A rack's parallel chains: fan-out and fan-in inside one track.
+Scene rackScene() {
+    Scene scene;
+    auto rack = std::make_unique<RackInfo>();
+    rack->id = 5;
+    rack->volume = -3.0f;
+
+    for (int index = 0; index < 3; ++index) {
+        ChainInfo chain;
+        chain.id = 10 + index;
+        chain.volume = -2.0f * static_cast<float>(index);
+        chain.pan = 0.5f - 0.5f * static_cast<float>(index);
+        chain.elements.push_back(makeDeviceElement(makeEffect(300 + index)));
+        rack->chains.push_back(std::move(chain));
+
+        scene.bindings.devices[300 + index] =
+            scene.own(std::make_unique<GainDevice>(0.3f + 0.2f * static_cast<float>(index)));
+    }
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(ChainElement{std::move(rack)});
+    scene.tracks.push_back(track);
+    scene.bindings.clipAudio[1] = scene.own(std::make_unique<RampSource>(5));
+    return scene;
+}
+
+/// Devices that really are late, so the plan carries delays and the paths
+/// meeting at the master have to be aligned by them rather than by luck.
+Scene latencyScene() {
+    Scene scene;
+    auto aux = makeTrack(9, TrackType::Aux);
+    aux.auxBusIndex = 0;
+
+    auto latent = makeTrack(1);
+    latent.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(400)));
+    latent.sends.push_back(SendInfo{0, 0.8f, false, 9});
+    scene.tracks.push_back(latent);
+
+    auto slower = makeTrack(2);
+    slower.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(401)));
+    scene.tracks.push_back(slower);
+
+    scene.tracks.push_back(makeTrack(3));
+    scene.tracks.push_back(aux);
+
+    scene.bindings.clipAudio[1] = scene.own(std::make_unique<RampSource>(11));
+    scene.bindings.clipAudio[2] = scene.own(std::make_unique<RampSource>(23));
+    scene.bindings.clipAudio[3] = scene.own(std::make_unique<RampSource>(37));
+    scene.bindings.devices[400] = scene.own(std::make_unique<LatentDevice>(37));
+    scene.bindings.devices[401] = scene.own(std::make_unique<LatentDevice>(96));
+    return scene;
+}
+
+/// MIDI through instruments, and a device that adds MIDI of its own so the
+/// chain merges two streams.
+Scene midiScene() {
+    Scene scene;
+    for (TrackId id = 1; id <= 3; ++id) {
+        auto track = makeTrack(id);
+        track.chain.fxChainElements.push_back(makeDeviceElement(makeInstrument(500 + id)));
+        track.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(600 + id)));
+        scene.tracks.push_back(track);
+
+        scene.bindings.clipAudio[id] = scene.own(std::make_unique<RampSource>(id * 3));
+        scene.bindings.clipMidi[id] =
+            scene.own(std::make_unique<TimelineNoteSource>(48 + 5 * id, 37 + id));
+        scene.bindings.devices[500 + id] = scene.own(std::make_unique<NoteToDcInstrument>());
+        scene.bindings.devices[600 + id] = scene.own(std::make_unique<GainDevice>(0.75f));
+    }
+
+    // MIDI out and the raw input passed on with it, so the chain merges two
+    // streams rather than replacing one.
+    auto arpTrack = makeTrack(4);
+    auto arp = makeInstrument(700);
+    arp.producesMidi = true;
+    arp.midiInThru = true;
+    arpTrack.chain.fxChainElements.push_back(makeDeviceElement(arp));
+    arpTrack.chain.fxChainElements.push_back(makeDeviceElement(makeInstrument(701)));
+    scene.tracks.push_back(arpTrack);
+
+    scene.bindings.clipAudio[4] = scene.own(std::make_unique<RampSource>(17));
+    scene.bindings.clipMidi[4] = scene.own(std::make_unique<TimelineNoteSource>(72, 29));
+    scene.bindings.devices[700] = scene.own(std::make_unique<ArpDevice>(60));
+    scene.bindings.devices[701] = scene.own(std::make_unique<NoteToDcInstrument>());
+    return scene;
+}
+
+/// Tracks feeding another track, which is the deepest the graph gets: the group
+/// cannot start until everything routed into it has finished.
+Scene groupScene() {
+    Scene scene;
+    auto group = makeTrack(5);
+    group.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(800)));
+    scene.tracks.push_back(group);
+
+    for (TrackId id = 1; id <= 3; ++id) {
+        auto track = makeTrack(id);
+        track.audioOutputDevice = "track:5";
+        track.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(810 + id)));
+        scene.tracks.push_back(track);
+
+        scene.bindings.clipAudio[id] = scene.own(std::make_unique<RampSource>(id * 29));
+        scene.bindings.devices[810 + id] = scene.own(std::make_unique<TallyDevice>());
+    }
+
+    scene.bindings.clipAudio[5] = scene.own(std::make_unique<RampSource>(53));
+    scene.bindings.devices[800] = scene.own(std::make_unique<GainDevice>(0.8f));
+    return scene;
+}
+
+struct NamedScene {
+    const char* name;
+    Scene (*build)();
+};
+
+const std::vector<NamedScene> kScenes = {
+    {"one chain", chainScene},      {"eight tracks", wideScene}, {"sends into an aux", sendScene},
+    {"a rack's chains", rackScene}, {"latency", latencyScene},   {"MIDI", midiScene},
+    {"a group track", groupScene},
+};
+
+/// The thread counts every scene is rendered at. Zero workers is the parallel
+/// executor with nothing to be parallel with, which has to agree too: it is the
+/// same code, and a schedule that only works when it is spread out is a
+/// schedule that works by accident.
+const std::vector<int> kWorkerCounts = {0, 1, 2, 3, 7};
+
+}  // namespace
+
+TEST_CASE("The parallel executor renders what the reference executor renders, sample for sample",
+          "[engine][exec][parallel]") {
+    const auto lengths = blockLengths(kNumBlocks, false);
+
+    // Made once and rendered through by every scene: a pool outlives plans, and
+    // reusing one across epochs is what a session does.
+    std::vector<std::unique_ptr<RenderThreadPool>> pools;
+    for (const auto workers : kWorkerCounts)
+        pools.push_back(std::make_unique<RenderThreadPool>(workers, false));
+
+    for (const auto& scene : kScenes) {
+        INFO("scene: " << scene.name);
+        const auto expected = renderReference(scene.build(), lengths);
+        REQUIRE_FALSE(expected.samples.empty());
+
+        for (std::size_t index = 0; index < pools.size(); ++index) {
+            INFO("threads: " << pools[index]->numThreads());
+            const auto actual = renderParallel(scene.build(), *pools[index], lengths);
+            CHECK(firstDifference(expected.samples, actual.samples) == -1);
+            CHECK(actual.samples.size() == expected.samples.size());
+            CHECK(actual.meters == expected.meters);
+        }
+    }
+}
+
+TEST_CASE("Blocks shorter than the prepared one are scheduled the same way",
+          "[engine][exec][parallel]") {
+    const auto lengths = blockLengths(kNumBlocks, true);
+    RenderThreadPool pool(4, false);
+
+    for (const auto& scene : kScenes) {
+        INFO("scene: " << scene.name);
+        const auto expected = renderReference(scene.build(), lengths);
+        const auto actual = renderParallel(scene.build(), pool, lengths);
+        CHECK(firstDifference(expected.samples, actual.samples) == -1);
+        CHECK(actual.meters == expected.meters);
+    }
+}
+
+TEST_CASE("The same scene renders identically however many times it is run",
+          "[engine][exec][parallel]") {
+    // Determinism across runs, not only across executors: a race that changes
+    // the output would otherwise have to be caught by the one comparison it
+    // happened to lose.
+    const auto lengths = blockLengths(kNumBlocks, false);
+    RenderThreadPool pool(7, false);
+
+    const auto first = renderParallel(wideScene(), pool, lengths);
+    for (int attempt = 0; attempt < 8; ++attempt) {
+        INFO("attempt " << attempt);
+        const auto again = renderParallel(wideScene(), pool, lengths);
+        CHECK(firstDifference(first.samples, again.samples) == -1);
+    }
+}
+
+TEST_CASE("Every op runs exactly once a block", "[engine][exec][parallel]") {
+    Rig rig(wideScene());
+    RenderThreadPool pool(7, false);
+    ParallelPlanExecutor executor(&pool);
+
+    REQUIRE(executor.prepare(rig.plan, rig.scene.bindings, rig.context).empty());
+
+    for (int block = 0; block < kNumBlocks; ++block)
+        executor.process(rig.values, blockAt(block * kBlockSize, kBlockSize), rig.output);
+
+    for (auto& [id, device] : rig.scene.bindings.devices) {
+        INFO("device " << id);
+        auto* gain = dynamic_cast<GainDevice*>(device);
+        REQUIRE(gain != nullptr);
+        CHECK(gain->processedBlocks == kNumBlocks);
+    }
+}
+
+TEST_CASE("Ops on independent branches really do run at the same time",
+          "[engine][exec][parallel]") {
+    Meeting meeting;
+
+    Scene scene;
+    for (TrackId id = 1; id <= 2; ++id) {
+        auto track = makeTrack(id);
+        track.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(900 + id)));
+        scene.tracks.push_back(track);
+
+        scene.bindings.clipAudio[id] = scene.own(std::make_unique<RampSource>(id));
+        scene.bindings.devices[900 + id] =
+            scene.own(std::make_unique<RendezvousDevice>(meeting, 2));
+    }
+
+    Rig rig(std::move(scene));
+    RenderThreadPool pool(3, false);
+    ParallelPlanExecutor executor(&pool);
+    REQUIRE(executor.prepare(rig.plan, rig.scene.bindings, rig.context).empty());
+
+    executor.process(rig.values, blockAt(0, kBlockSize), rig.output);
+
+    CHECK(meeting.mostAtOnce == 2);
+    CHECK(meeting.met);
+}
+
+TEST_CASE("The two executors prepare to the same layout", "[engine][exec][parallel]") {
+    // Everything below the schedule is shared rather than mirrored, and this is
+    // what says so: a second answer to any of these would be a second
+    // implementation of prepare.
+    for (const auto& scene : kScenes) {
+        INFO("scene: " << scene.name);
+        Rig reference(scene.build());
+        Rig parallel(scene.build());
+
+        PlanExecutor referenceExecutor;
+        RenderThreadPool pool(2, false);
+        ParallelPlanExecutor parallelExecutor(&pool);
+
+        REQUIRE(
+            referenceExecutor.prepare(reference.plan, reference.scene.bindings, reference.context)
+                .empty());
+        REQUIRE(parallelExecutor.prepare(parallel.plan, parallel.scene.bindings, parallel.context)
+                    .empty());
+
+        CHECK(parallelExecutor.latencySamples() == referenceExecutor.latencySamples());
+        CHECK(parallelExecutor.audioBufferCount() == referenceExecutor.audioBufferCount());
+        CHECK(parallelExecutor.midiBufferCount() == referenceExecutor.midiBufferCount());
+        CHECK(parallelExecutor.boundMeterCount() == referenceExecutor.boundMeterCount());
+        CHECK(parallelExecutor.midiDelayOverflows() == 0);
+    }
+}
+
+TEST_CASE("A plan the compiler never baked a schedule into is refused",
+          "[engine][exec][parallel]") {
+    Rig rig(wideScene());
+    RenderThreadPool pool(2, false);
+    ParallelPlanExecutor executor(&pool);
+
+    auto plan = rig.plan;
+    plan.dependencyCounts.clear();
+
+    const auto messages = executor.prepare(plan, rig.scene.bindings, rig.context);
+    CHECK_FALSE(messages.empty());
+    CHECK_FALSE(executor.isPrepared());
+
+    // Refused means refused: nothing prepared, and a block that renders silence
+    // rather than half a graph.
+    rig.output.clear();
+    executor.process(rig.values, blockAt(0, kBlockSize), rig.output);
+    CHECK(rig.output.getMagnitude(0, kBlockSize) == 0.0f);
+}
+
+TEST_CASE("An executor with no plan renders silence", "[engine][exec][parallel]") {
+    RenderThreadPool pool(2, false);
+    ParallelPlanExecutor executor(&pool);
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    output.clear();
+
+    CHECK_FALSE(executor.isPrepared());
+    executor.process(PlanValues{}, blockAt(0, kBlockSize), output);
+    CHECK(output.getMagnitude(0, kBlockSize) == 0.0f);
+}
+
+TEST_CASE("A plan swap carries what the differ matched, and renders the same either way",
+          "[engine][exec][parallel]") {
+    // The swap a session makes, run through both executors: four blocks on one
+    // epoch, a second epoch prepared against it, the first destroyed while the
+    // pool is still live, and the rest of the render on the second. What the
+    // delay lines held when the swap happened is part of the output, so this
+    // compares bit for bit like everything else here.
+    constexpr int kBeforeSwap = 4;
+    const auto lengths = blockLengths(16, false);
+
+    struct Swap {
+        std::vector<float> samples;
+        int carried = 0;
+    };
+
+    const auto swapThrough = [&lengths](auto makeExecutor) {
+        Rig first(latencyScene());
+        Rig second(latencyScene());
+
+        auto retiring = makeExecutor();
+        REQUIRE(retiring->prepare(first.plan, first.scene.bindings, first.context).empty());
+
+        Swap swap;
+        std::int64_t position = 0;
+        const auto collect = [&swap](Rig& rig, int length) {
+            for (int channel = 0; channel < rig.output.getNumChannels(); ++channel)
+                for (int sample = 0; sample < length; ++sample)
+                    swap.samples.push_back(rig.output.getSample(channel, sample));
+        };
+
+        for (int block = 0; block < kBeforeSwap; ++block) {
+            retiring->process(first.values, blockAt(position, lengths[block]), first.output);
+            collect(first, lengths[block]);
+            position += lengths[block];
+        }
+
+        auto live = makeExecutor();
+        REQUIRE(live->prepare(second.plan, second.scene.bindings, second.context, retiring.get())
+                    .empty());
+        swap.carried = live->carriedDelayLines();
+        retiring.reset();
+
+        for (std::size_t block = kBeforeSwap; block < lengths.size(); ++block) {
+            live->process(second.values, blockAt(position, lengths[block]), second.output);
+            collect(second, lengths[block]);
+            position += lengths[block];
+        }
+
+        return swap;
+    };
+
+    const auto reference = swapThrough([] { return std::make_unique<PlanExecutor>(); });
+    REQUIRE(reference.carried > 0);
+
+    RenderThreadPool pool(4, false);
+    const auto parallel =
+        swapThrough([&pool] { return std::make_unique<ParallelPlanExecutor>(&pool); });
+
+    CHECK(parallel.carried == reference.carried);
+    CHECK(firstDifference(reference.samples, parallel.samples) == -1);
+}
+
+/// Hidden: a measurement, not a check. Wall clock is a property of the machine
+/// it runs on, so this asserts nothing and prints what it saw. Run it with
+/// `magda_tests "[bench]"`, and read it as scaling rather than as CPU: the test
+/// binary is a debug build, so the ops are slower than they will ever be in
+/// release and the schedule looks cheaper by comparison than it is.
+TEST_CASE("How a heavy graph scales across threads", "[.][bench]") {
+    constexpr int kTracks = 16;
+    constexpr int kDevicesPerTrack = 4;
+    constexpr int kBlocks = 200;
+
+    /// Something to actually spend time on: a one-pole per sample, repeated, so
+    /// the op costs what a small plugin costs rather than what a memcpy does.
+    class BusyDevice final : public EngineDevice {
+      public:
+        void process(DeviceBlock& block) override {
+            for (std::size_t channel = 0; channel < block.audio.getNumChannels(); ++channel) {
+                auto* samples = block.audio.getChannelPointer(channel);
+                for (int pass = 0; pass < 40; ++pass)
+                    for (int sample = 0; sample < block.block.numSamples; ++sample) {
+                        state_ += 0.05f * (samples[sample] - state_);
+                        samples[sample] = state_;
+                    }
+            }
+        }
+
+      private:
+        float state_ = 0.0f;
+    };
+
+    const auto build = []() {
+        Scene scene;
+        for (TrackId id = 1; id <= kTracks; ++id) {
+            auto track = makeTrack(id);
+            for (int slot = 0; slot < kDevicesPerTrack; ++slot) {
+                const DeviceId device = id * 100 + slot;
+                track.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(device)));
+                scene.bindings.devices[device] = scene.own(std::make_unique<BusyDevice>());
+            }
+            scene.tracks.push_back(track);
+            scene.bindings.clipAudio[id] = scene.own(std::make_unique<RampSource>(id));
+        }
+        return scene;
+    };
+
+    const auto lengths = blockLengths(kBlocks, false);
+
+    for (const auto workers : {0, 1, 3, 7}) {
+        RenderThreadPool pool(workers, false);
+        Rig rig(build());
+        ParallelPlanExecutor executor(&pool);
+        REQUIRE(executor.prepare(rig.plan, rig.scene.bindings, rig.context).empty());
+
+        const auto started = std::chrono::steady_clock::now();
+        std::int64_t position = 0;
+        for (const auto length : lengths) {
+            executor.process(rig.values, blockAt(position, length), rig.output);
+            position += length;
+        }
+        const auto elapsed =
+            std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - started)
+                .count();
+
+        WARN("threads " << executor.numThreads() << ": " << elapsed << " ms for " << kBlocks
+                        << " blocks");
+    }
+}


### PR DESCRIPTION
Closes #2018. Slice 9 of #1889.

The executor that ships. It renders a plan across a pool of threads and comes out bit-identical to the reference executor at every thread count.

## How it stays identical

It shares everything except the loop. `PlanExecutor` keeps prepare, the buffer arena and the body of every op, and grew two seams for this: `beginBlock`, which settles what a block is, and `renderOp`, which renders one. The parallel executor calls those and adds a schedule.

- Anything that sums sums in compiled order, whatever order its inputs finished in.
- Buffer assignment (#2009) was already computed over the dependency DAG rather than the op list, so a slot reused under the reference executor's straight walk is safe under every other valid schedule.
- Output ops all add into one buffer, so a schedule deciding which went first would be a schedule deciding the arithmetic. They are left for whoever drove the block, in plan order, once the graph has drained.

## The schedule

Nothing walks the graph on the callback. The plan already carries dependency counts, reversed edges and the initially-ready set from `bakeScheduling`; a block copies the counts, seeds the ready set and runs. A plan that arrives without those constants is refused rather than baked here, where it would be computed twice.

The ready set is a lock-free stack threaded through a per-op link array, with a tag that moves on every push and pop and never resets across blocks: without it a thread that read the top, stalled through the end of a block and came back could find the same op there and mistake it for the one it was holding. A thread also carries straight on with the first consumer it releases rather than pushing it, so a linear chain never touches the stack.

`RenderThreadPool` owns the threads and outlives plans. Realtime priority where the OS grants it, the highest ordinary priority where it does not, because a worker that never started is one the audio thread waits on for nothing. Retiring an epoch waits out any worker still inside it, on the thread that is allowed to wait.

## A race TSan found

Making a `juce::dsp::AudioBlock` out of a `juce::AudioBuffer` writes the buffer's `isClear` flag, so two ops reading the same port were two threads writing one byte: benign in value, a data race in fact. Ports are read through cached channel pointers now, and nothing on the render path touches an `AudioBuffer`.

## Session

`EngineSession` renders through this executor, with the pool optional. A null pool is not a degraded mode, it is the same executor with one thread, which is what makes "identical at every thread count" a claim about one code path rather than two.

## Verification

- Seven scenes (one chain, eight tracks, sends into an aux, a rack's chains, latency, MIDI, a group track) at 1, 2, 3, 4 and 8 threads, compared with `==` against the reference executor. Also with ragged block lengths, and across a plan swap that carries delay lines.
- A rendezvous test that two ops on independent branches really are inside `process()` at the same time, since everything else would pass on a pool whose workers never woke.
- Confirmed to fail without their fix: a pool with no workers takes the concurrency test from two devices at once to one; seeding the ready set with every op rather than the ready ones breaks 55 assertions across the comparison scenes.
- The whole engine suite is clean under ThreadSanitizer. `make test-tsan` builds and runs the Catch2 tests under it, with `TEST=<filter>` to narrow.
- Scaling, debug build, 200 blocks over 16 tracks of 4 busy devices: 315 ms on one thread, 167 on two, 96 on four, 76 on eight. Hidden `[bench]` test.

## Not in this slice

"Match or beat TE CPU on the benchmark corpus" is a cutover gate and there is no corpus in the repo yet; it arrives with the null-diff harness (#1896). The `[bench]` test is the measuring stick for it when it does.