### PR TITLE
Remote API: authenticated JSON-RPC 2.0 over WebSocket (#1856)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,6 +315,22 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(cpp-httplib)
 
+# cpp-httplib is configured by macros read inside a header-only library, so a
+# #define in one .cpp changes the inline functions that translation unit sees and
+# nothing else. Two TUs in one executable disagreeing about a limit is an ODR
+# violation whose winner is chosen by the linker, so the values live here, once,
+# on the target every consumer already links.
+#
+# The payload cap governs how much of a frame is read into memory before any
+# handler sees it. The read timeout is how long a connection's reader may sit in
+# read() before it comes up for air, and therefore how long shutdown can take:
+# cpp-httplib offers no way to interrupt a blocked reader, so this is the
+# cancellation quantum (see remote_websocket_server.cpp).
+target_compile_definitions(httplib INTERFACE
+    CPPHTTPLIB_WEBSOCKET_MAX_PAYLOAD_LENGTH=262144
+    CPPHTTPLIB_WEBSOCKET_READ_TIMEOUT_SECOND=3
+)
+
 # Simple agent system - no external dependencies needed
 
 # Product-based subdirectories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,29 @@ if(MAGDA_HAVE_CLAP)
     add_subdirectory(third_party/onnxruntime)
 endif()
 
+# cpp-httplib 0.52.0 — HTTP/WebSocket transport for the remote API (issue #1856).
+# Header-only on purpose: HTTPLIB_COMPILE splits the header with a Python script,
+# and the adapter includes it from a single TU behind a pimpl, so there is
+# nothing to gain for a new build prerequisite.
+#
+# OPENSSL, ZLIB, BROTLI and ZSTD all default to "use it if you find it", which
+# would make the build depend on whatever happens to be installed on the machine.
+# Forced off so every platform compiles the same thing; the remote API binds
+# loopback only, so there is no TLS to configure.
+set(HTTPLIB_COMPILE                  OFF CACHE BOOL "" FORCE)
+set(HTTPLIB_INSTALL                  OFF CACHE BOOL "" FORCE)
+set(HTTPLIB_TEST                     OFF CACHE BOOL "" FORCE)
+set(HTTPLIB_USE_OPENSSL_IF_AVAILABLE OFF CACHE BOOL "" FORCE)
+set(HTTPLIB_USE_ZLIB_IF_AVAILABLE    OFF CACHE BOOL "" FORCE)
+set(HTTPLIB_USE_BROTLI_IF_AVAILABLE  OFF CACHE BOOL "" FORCE)
+set(HTTPLIB_USE_ZSTD_IF_AVAILABLE    OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+    cpp-httplib
+    GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
+    GIT_TAG v0.52.0
+)
+FetchContent_MakeAvailable(cpp-httplib)
+
 # Simple agent system - no external dependencies needed
 
 # Product-based subdirectories

--- a/docs/remote-api-transport.md
+++ b/docs/remote-api-transport.md
@@ -69,9 +69,10 @@ maintained library with the right hook turned out to be free.
 ## Chosen: cpp-httplib, pinned at v0.52.0
 
 MIT, no required dependencies — OpenSSL, zlib, Brotli and zstd are all
-`#ifdef`-optional. It is already in the tree at
-`third_party/llama.cpp/vendor/cpp-httplib/` (0.50.1), which is how it was found,
-but we do not consume it from there (see below).
+`#ifdef`-optional. It is already vendored inside llama.cpp at
+`third_party/llama.cpp/vendor/cpp-httplib/`, which is how it was found, but we
+do not consume it from there (see below). The version there moves with the
+submodule, so it is not quoted here.
 
 Version 0.50 has a WebSocket server, and its upgrade path was built for exactly
 this case. From `httplib.cpp:8496`:
@@ -99,9 +100,10 @@ handler; upgrade with a valid token and allowed `Origin` completing and
 round-tripping a JSON-RPC frame; an oversized frame closing the connection; a
 server-initiated close seen by the client; and `stop()` joining the listener.
 
-Eleven checks, all passing, against both 0.50.1 (compiled, from llama.cpp's
-vendored copy) and 0.52.0 (header-only, from the pinned tag) — so the API we
-depend on is stable across the two. Compilation is 2–4 seconds at `-O0`.
+Eleven checks, all passing, against two versions a release apart — 0.50.1
+compiled from a vendored copy, and 0.52.0 header-only from the pinned tag — so
+the API we depend on is stable across the range rather than pinned to one
+release. Compilation is 2–4 seconds at `-O0`.
 
 ## How it is wired
 

--- a/docs/remote-api-transport.md
+++ b/docs/remote-api-transport.md
@@ -1,0 +1,138 @@
+# WebSocket transport for the remote API — dependency decision
+
+Spike outcome for the first scope item on #1856. The contract itself is in
+[remote-api-contract.md](remote-api-contract.md); this records only which
+library carries it over a socket, and why the alternatives were rejected.
+
+**Decision: cpp-httplib, pinned by us via FetchContent.**
+
+## What the transport has to do
+
+Four of #1856's acceptance criteria constrain the choice. The rest are ours to
+implement whatever we pick.
+
+- Refuse a connection with an invalid bearer token or a disallowed `Origin`,
+  and refuse it *closed* — the client must not end up with a live socket.
+- Drop one misbehaving client without disturbing the others.
+- Bound request size, in-flight requests, and rate.
+- Leave no blocked threads or queued writes after disconnect or shutdown.
+
+The first one does most of the work: it means the library has to let us see the
+upgrade request's headers and say no before the handshake completes. That is
+where the obvious candidate falls down.
+
+## Rejected: CHOC `choc_HTTPServer.h` + Boost.Beast
+
+`third_party/tracktion_engine/modules/3rd_party/choc/network/choc_HTTPServer.h`
+is already in the tree via the Tracktion Engine submodule, and #1856 named it as
+the thing to evaluate. Nothing in the repo compiles it today.
+
+It accepts every upgrade unconditionally. `upgradeToWebsocket` (L465–473) starts
+the handshake and *then* calls `upgradedToWebSocket(target)`, which receives the
+request path and nothing else — no `Origin`, no `Authorization`, and no return
+value to refuse with. The `decorator` at L365 only stamps headers onto a
+response that is already going out. `ClientInstance` has no close, so a bad
+client can only be dropped by tearing down the whole listener via
+`HTTPServer::close()` (L644). `messageBodySizeLimit` (10 KB), `timeoutSeconds`
+(30) and `defaultNumThreads` (4) are file-scope constants at L205–207.
+
+So the security criteria need a patched copy of the header — an `allowUpgrade`
+hook, per-connection close, configurable limits. That part is cheap and the ISC
+licence allows it. The cost that does not go away is Boost: L190–193 `#error`s
+without `<boost/beast.hpp>` and `<boost/asio.hpp>`. Boost is in none of
+`third_party/`, `vcpkg.json`, or the CI apt list, so this would put brew boost
+on macOS, `libboost-dev` on Linux, and a vcpkg port on Windows, and change the
+README prerequisites on all three — which currently make a point of needing
+vcpkg only on Windows and only for libxml2.
+
+A patched vendored header plus a first-of-its-kind Boost dependency is a lot to
+carry for a loopback control socket.
+
+## Rejected: websocketpp
+
+Last release 0.8.2, April 2020. Between then and March 2025 the repository took
+one commit, a CMake 4.0 compatibility fix; 483 issues are open. It also needs
+Asio — standalone rather than full Boost, so a lighter dependency than Beast,
+but still a new one. Its handshake `validate` hook would have satisfied the
+security criteria. Maintenance is the objection: this is network-facing code
+where we would be the ones fixing protocol bugs.
+
+## Rejected: hand-rolled RFC 6455 on `juce::StreamingSocket`
+
+Considered while every option still looked like it cost a dependency. Zero new
+dependencies and total control of the handshake, against roughly 500 lines of
+framing, fragmentation, masking, ping/pong and close handling that we would own
+and have to fuzz — plus a vendored SHA-1, since juce_cryptography ships MD5,
+SHA256 and Whirlpool but not the one the accept key needs. Not worth it once a
+maintained library with the right hook turned out to be free.
+
+## Chosen: cpp-httplib, pinned at v0.52.0
+
+MIT, no required dependencies — OpenSSL, zlib, Brotli and zstd are all
+`#ifdef`-optional. It is already in the tree at
+`third_party/llama.cpp/vendor/cpp-httplib/` (0.50.1), which is how it was found,
+but we do not consume it from there (see below).
+
+Version 0.50 has a WebSocket server, and its upgrade path was built for exactly
+this case. From `httplib.cpp:8496`:
+
+> Check `pre_routing_handler_` before upgrading so that authentication and other
+> middleware can reject the request with an HTTP response (e.g., 401) before the
+> protocol switches.
+
+That is the criterion, implemented upstream. The rest follows:
+
+| Need | What it gives us |
+|---|---|
+| Reject before the 101 | `set_pre_routing_handler`, full `Request` headers, returns an ordinary HTTP status |
+| Drop one client | `ws::WebSocket::close(CloseStatus, reason)`, RFC 6455 close codes |
+| Request-size bound | `CPPHTTPLIB_WEBSOCKET_MAX_PAYLOAD_LENGTH` (16 MB default), `set_payload_max_length` |
+| Liveness | server-side ping heartbeat, `set_websocket_ping_interval`, `set_websocket_max_missed_pongs` |
+| Integration tests | `ws::WebSocketClient` in the same library — no test-only dependency |
+
+### Validated, not assumed
+
+A throwaway TU built with `clang++ -std=c++20` exercised the criteria end to
+end: bind on `127.0.0.1` with an ephemeral port; upgrade with no token refused;
+upgrade with a disallowed `Origin` refused; neither refusal reaching the
+handler; upgrade with a valid token and allowed `Origin` completing and
+round-tripping a JSON-RPC frame; an oversized frame closing the connection; a
+server-initiated close seen by the client; and `stop()` joining the listener.
+
+Eleven checks, all passing, against both 0.50.1 (compiled, from llama.cpp's
+vendored copy) and 0.52.0 (header-only, from the pinned tag) — so the API we
+depend on is stable across the two. Compilation is 2–4 seconds at `-O0`.
+
+## How it is wired
+
+Declared in the root `CMakeLists.txt` with FetchContent at tag `v0.52.0`, the
+way `Catch2` already is. Not consumed from llama.cpp's vendor directory: that
+copy belongs to a submodule Dependabot bumps, and could change version or move
+without warning.
+
+Header-only. `HTTPLIB_COMPILE` splits the header using a Python script, and the
+adapter includes it from a single TU behind a pimpl, so there is nothing to gain
+from a new build prerequisite. `HTTPLIB_USE_OPENSSL_IF_AVAILABLE`,
+`..._ZLIB_...`, `..._BROTLI_...` and `..._ZSTD_...` all default to ON — "link it
+if you find it" — which would make the build depend on what happens to be
+installed on the machine. All four are forced OFF, along with `HTTPLIB_INSTALL`
+and `HTTPLIB_TEST`, so every platform compiles the same thing. There is no TLS
+to configure because the listener is loopback-only.
+
+## Constraints this puts on the implementation
+
+**`listen()` blocks; run it on a `juce::Thread`.** Stop it with `stop()` from
+the owning thread and join. This suits the requirement to keep parsing, framing
+and socket writes off the message thread, because none of it is ever on the
+message thread to begin with — the only hop is `RemoteApiService::dispatch`,
+which already does its own.
+
+**Thread-per-connection means connections must be capped.** An in-flight limit
+is on #1856's scope list anyway; it is load-bearing here rather than merely
+good practice.
+
+**WebSocket support is new in cpp-httplib**, and less exercised than Beast's
+equivalent. Mitigated by the threat model — loopback-bound, token-gated, hard
+frame cap, close on anything unexpected — but it is the one place where the
+chosen option is weaker than the rejected one, and worth remembering if
+something protocol-level ever looks wrong.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -343,6 +343,48 @@ TEST_CASE("CriticalSection protects shared state", "[threading]") {
 - ❌ Test rendering/painting (test state instead)
 - ❌ Rely on timing (use deterministic sequences)
 - ❌ Test third-party library behavior
+- ❌ Let POSIX be the implicit default (see below)
+
+## Platform Assumptions
+
+MAGDA ships on macOS, Linux and Windows, and every test runs on all three. A
+test that mentions a **process id, a path, a permission bit, or a signal** is
+making a platform assumption, whether or not it looks like one — and the one
+platform that disagrees is usually Windows, which is also the slowest CI leg to
+find out from.
+
+Prefer a property that does not depend on the difference:
+
+```cpp
+// Assumes POSIX: pid 1 is init/launchd and always alive. On Windows it is not a
+// process at all, so this record is swept and the assertion fails there only.
+const auto other = tokenFile().getSiblingFile("remote-api-1.json");
+REQUIRE(other.existsAsFile());
+
+// No liveness assumption: written after the sweep has already run, so what is
+// under test is that stop() removes this instance's record and nothing else.
+REQUIRE(host.start());
+const auto other = tokenFile().getSiblingFile("remote-api-424242.json");
+other.replaceWithText(...);
+host.stop();
+REQUIRE(other.existsAsFile());
+```
+
+When the difference is the point, guard it and say why:
+
+```cpp
+#if !JUCE_WINDOWS
+// The parent of this process: alive, and not us. Reaching a foreign pid's
+// liveness on Windows portably needs a toolhelp snapshot, which is more
+// machinery than this warrants — the abandoned-record case covers the other
+// half of the same branch everywhere.
+#endif
+```
+
+Values worth distrusting: pids (Windows issues multiples of four, macOS caps
+below 100000, Linux defaults to 4194304), file permissions (`chmod` is a no-op
+on Windows, where ACLs are inherited), path separators and case sensitivity, and
+anything involving signals.
 
 ## Running Tests
 

--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -520,6 +520,10 @@ target_link_libraries(magda_daw
     PRIVATE
     ${MAGDA_JUCE_STACK}
     LibXml2::LibXml2
+    # Remote API transport (#1856). PRIVATE on purpose: httplib.h appears in
+    # remote_websocket_server.cpp and nowhere else, so no dependent inherits a
+    # 20k-line header it does not use.
+    httplib::httplib
     $<$<PLATFORM_ID:Linux>:juce::pkgconfig_JUCE_BROWSER_LINUX_DEPS>
     $<$<PLATFORM_ID:Linux>:juce::pkgconfig_JUCE_CURL_LINUX_DEPS>
     INTERFACE

--- a/magda/daw/api/CMakeLists.txt
+++ b/magda/daw/api/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(magda_daw PRIVATE
     remote_changes.cpp
     remote_model_bridge_live.cpp
     remote_websocket_server.cpp
+    remote_api_host.cpp
     # Headers (listed for IDE visibility)
     magda_api.hpp
     magda_api_live.hpp

--- a/magda/daw/api/CMakeLists.txt
+++ b/magda/daw/api/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(magda_daw PRIVATE
     remote_service.cpp
     remote_changes.cpp
     remote_model_bridge_live.cpp
+    remote_websocket_server.cpp
     # Headers (listed for IDE visibility)
     magda_api.hpp
     magda_api_live.hpp

--- a/magda/daw/api/remote_api_host.cpp
+++ b/magda/daw/api/remote_api_host.cpp
@@ -8,8 +8,14 @@
 #include "remote_service.hpp"
 #include "remote_websocket_server.hpp"
 
-#if !JUCE_WINDOWS
+#if JUCE_WINDOWS
+    #include <windows.h>
+#else
     #include <sys/stat.h>
+    #include <unistd.h>
+
+    #include <cerrno>
+    #include <csignal>
 #endif
 
 namespace magda {
@@ -17,7 +23,74 @@ namespace remote {
 
 namespace {
 
-constexpr const char* kTokenFileName = "remote-api.json";
+/**
+ * Discovery records are per process, not per installation.
+ *
+ * MAGDA does not set `moreThanOneInstanceAllowed()` to false, so two instances
+ * are a supported thing to run. Sharing one file between them means the second
+ * to start hides the first, and the first to stop deletes the record of the one
+ * still running. With a fixed port it is worse, because cpp-httplib sets
+ * SO_REUSEPORT and both listeners bind: a client then holds one instance's token
+ * and may be routed to the other, which does not accept it.
+ *
+ * Naming the record after the process keeps each instance's file its own, and
+ * the pid inside is what makes cleanup safe — an instance deletes only its own,
+ * and a record whose process no longer exists is debris anyone may collect.
+ */
+constexpr const char* kTokenFilePrefix = "remote-api-";
+constexpr const char* kTokenFileSuffix = ".json";
+constexpr const char* kTokenFilePattern = "remote-api-*.json";
+
+juce::int64 currentProcessId() {
+#if JUCE_WINDOWS
+    return static_cast<juce::int64>(GetCurrentProcessId());
+#else
+    return static_cast<juce::int64>(getpid());
+#endif
+}
+
+bool isProcessAlive(juce::int64 processId) {
+#if JUCE_WINDOWS
+    auto* handle =
+        OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, static_cast<DWORD>(processId));
+    if (handle == nullptr)
+        return false;
+    DWORD exitCode = 0;
+    const auto running = GetExitCodeProcess(handle, &exitCode) != 0 && exitCode == STILL_ACTIVE;
+    CloseHandle(handle);
+    return running;
+#else
+    // Signal 0 runs the existence and permission checks without delivering
+    // anything. EPERM means the process is there and belongs to someone else,
+    // which still counts as alive.
+    return kill(static_cast<pid_t>(processId), 0) == 0 || errno == EPERM;
+#endif
+}
+
+/**
+ * @brief Delete records left by instances that are no longer running.
+ *
+ * A crashed run cannot clean up after itself, and with per-process records
+ * nobody else was going to. Ours is left alone here — `start()` handles that —
+ * and so is every record whose process still answers, because that one belongs
+ * to a live instance.
+ *
+ * A pid can in principle be recycled onto an unrelated process, which would keep
+ * one dead record alive a while longer. The cost of that is a file, and the next
+ * sweep after the recycled process exits takes it.
+ */
+void sweepAbandonedRecords(const juce::File& directory, juce::int64 ownProcessId) {
+    for (const auto& record :
+         directory.findChildFiles(juce::File::findFiles, false, kTokenFilePattern)) {
+        const auto owner = record.getFileNameWithoutExtension()
+                               .fromLastOccurrenceOf("-", false, false)
+                               .getLargeIntValue();
+        if (owner <= 0 || owner == ownProcessId)
+            continue;
+        if (!isProcessAlive(owner))
+            record.deleteFile();
+    }
+}
 
 /**
  * @brief 256 bits of entropy, hex encoded.
@@ -60,6 +133,9 @@ bool writeTokenFile(const juce::File& file, const juce::String& token, int port)
     payload->setProperty("port", port);
     payload->setProperty("token", token);
     payload->setProperty("url", "ws://127.0.0.1:" + juce::String(port) + "/rpc");
+    // Whose listener this is. A reader can tell two live instances apart, and
+    // cleanup can tell an abandoned record from someone else's live one.
+    payload->setProperty("pid", currentProcessId());
 
     // Write into the file we just restricted, rather than replaceWithText: that
     // writes a temp file and moves it over the target, so the new inode arrives
@@ -88,14 +164,18 @@ bool RemoteApiHost::start() {
     if (server_ != nullptr && server_->isRunning())
         return true;
 
-    // Anything here predates this listener, and a token file without a listener
-    // behind it is worse than no file: it hands a client a port and a credential
-    // that a crashed previous run left behind. Clearing it before every early
-    // return — disabled in config, no token, a port already taken — keeps the
-    // rule that the file exists only while something is answering on it. The
-    // already-running check comes first so a second call cannot delete a file
-    // that is still good.
+    // Our own record predates this listener, and a record without a listener
+    // behind it is worse than none: it hands a client a port and a credential
+    // that a crashed previous run left behind, and if the OS has reissued that
+    // port it points them at a stranger. Clearing it before every early return —
+    // disabled in config, no token, a port already taken — keeps the rule that a
+    // record exists only while something is answering on it. The already-running
+    // check comes first so a second call cannot delete a record still in use.
     tokenFile().deleteFile();
+
+    // Other instances' records are theirs to remove; only the ones whose process
+    // has gone are ours to sweep.
+    sweepAbandonedRecords(paths::dataDir(), currentProcessId());
 
     auto& config = Config::getInstance();
     if (!config.getRemoteApiEnabled())
@@ -159,7 +239,8 @@ int RemoteApiHost::boundPort() const {
 }
 
 juce::File RemoteApiHost::tokenFile() const {
-    return paths::dataDir().getChildFile(kTokenFileName);
+    return paths::dataDir().getChildFile(juce::String(kTokenFilePrefix) +
+                                         juce::String(currentProcessId()) + kTokenFileSuffix);
 }
 
 RemoteApiService& RemoteApiHost::service() {

--- a/magda/daw/api/remote_api_host.cpp
+++ b/magda/daw/api/remote_api_host.cpp
@@ -85,12 +85,21 @@ RemoteApiHost::~RemoteApiHost() {
 }
 
 bool RemoteApiHost::start() {
+    if (server_ != nullptr && server_->isRunning())
+        return true;
+
+    // Anything here predates this listener, and a token file without a listener
+    // behind it is worse than no file: it hands a client a port and a credential
+    // that a crashed previous run left behind. Clearing it before every early
+    // return — disabled in config, no token, a port already taken — keeps the
+    // rule that the file exists only while something is answering on it. The
+    // already-running check comes first so a second call cannot delete a file
+    // that is still good.
+    tokenFile().deleteFile();
+
     auto& config = Config::getInstance();
     if (!config.getRemoteApiEnabled())
         return false;
-
-    if (server_ != nullptr && server_->isRunning())
-        return true;
 
     token_ = generateToken();
     if (token_.isEmpty()) {

--- a/magda/daw/api/remote_api_host.cpp
+++ b/magda/daw/api/remote_api_host.cpp
@@ -1,0 +1,161 @@
+#include "remote_api_host.hpp"
+
+#include <random>
+
+#include "AppPaths.hpp"
+#include "Config.hpp"
+#include "remote_model_bridge.hpp"
+#include "remote_service.hpp"
+#include "remote_websocket_server.hpp"
+
+#if !JUCE_WINDOWS
+    #include <sys/stat.h>
+#endif
+
+namespace magda {
+namespace remote {
+
+namespace {
+
+constexpr const char* kTokenFileName = "remote-api.json";
+
+/**
+ * @brief 256 bits of entropy, hex encoded.
+ *
+ * `std::random_device` rather than `juce::Random`, because this is a credential:
+ * JUCE's generator is a seeded PRNG whose output is predictable to anyone who
+ * can guess the seed, while `random_device` is backed by the OS entropy source
+ * on every platform MAGDA ships to.
+ */
+juce::String generateToken() {
+    std::random_device entropy;
+    juce::String token;
+    for (int i = 0; i < 8; ++i)
+        token += juce::String::toHexString(static_cast<int>(entropy())).paddedLeft('0', 8);
+    return token;
+}
+
+/**
+ * @brief Publish the token where a local client can find it, and only it.
+ *
+ * Created empty and restricted *before* anything secret goes in, so the token
+ * is never briefly world-readable. On Windows the file inherits the ACL of the
+ * per-user app data directory, which is already owner-only.
+ */
+bool writeTokenFile(const juce::File& file, const juce::String& token, int port) {
+    file.getParentDirectory().createDirectory();
+    file.deleteFile();
+    if (!file.create().wasOk())
+        return false;
+
+#if !JUCE_WINDOWS
+    if (chmod(file.getFullPathName().toRawUTF8(), S_IRUSR | S_IWUSR) != 0) {
+        // Refuse rather than leave a readable credential behind.
+        file.deleteFile();
+        return false;
+    }
+#endif
+
+    auto* payload = new juce::DynamicObject();
+    payload->setProperty("port", port);
+    payload->setProperty("token", token);
+    payload->setProperty("url", "ws://127.0.0.1:" + juce::String(port) + "/rpc");
+
+    // Write into the file we just restricted, rather than replaceWithText: that
+    // writes a temp file and moves it over the target, so the new inode arrives
+    // with default permissions and the chmod above is silently undone.
+    juce::FileOutputStream stream(file);
+    if (!stream.openedOk() ||
+        !stream.writeText(juce::JSON::toString(juce::var(payload), false), false, false, nullptr)) {
+        file.deleteFile();
+        return false;
+    }
+    stream.flush();
+    return true;
+}
+
+}  // namespace
+
+RemoteApiHost::RemoteApiHost(MagdaApi& api)
+    : service_(std::make_unique<RemoteApiService>(api)),
+      bridge_(std::make_unique<ModelChangeBridge>(*service_)) {}
+
+RemoteApiHost::~RemoteApiHost() {
+    stop();
+}
+
+bool RemoteApiHost::start() {
+    auto& config = Config::getInstance();
+    if (!config.getRemoteApiEnabled())
+        return false;
+
+    if (server_ != nullptr && server_->isRunning())
+        return true;
+
+    token_ = generateToken();
+    if (token_.isEmpty()) {
+        DBG("RemoteApiHost: could not generate a token; not starting");
+        return false;
+    }
+
+    RemoteWebSocketServer::Options options;
+    options.bearerToken = token_;
+    options.port = config.getRemoteApiPort();
+    for (const auto& origin : config.getRemoteApiAllowedOrigins())
+        options.allowedOrigins.push_back(juce::String::fromUTF8(origin.c_str()));
+
+    server_ = std::make_unique<RemoteWebSocketServer>(*service_, options);
+    if (!server_->start()) {
+        server_.reset();
+        token_ = {};
+        return false;
+    }
+
+    // A running listener whose token nobody can read is useless and still a
+    // listener, so a failure to publish takes the server down with it.
+    if (!writeTokenFile(tokenFile(), token_, server_->boundPort())) {
+        DBG("RemoteApiHost: could not write " + tokenFile().getFullPathName());
+        server_->stop();
+        server_.reset();
+        token_ = {};
+        return false;
+    }
+
+    juce::Logger::writeToLog(
+        "Remote API listening on ws://127.0.0.1:" + juce::String(server_->boundPort()) + "/rpc");
+    return true;
+}
+
+void RemoteApiHost::stop() {
+    if (server_ != nullptr) {
+        server_->stop();
+        server_.reset();
+    }
+    // The token dies with the run that generated it; leaving the file behind
+    // would advertise a port that is no longer listening and a credential that
+    // no longer works.
+    tokenFile().deleteFile();
+    token_ = {};
+
+    if (service_ != nullptr)
+        service_->shutdown();
+}
+
+bool RemoteApiHost::isRunning() const {
+    return server_ != nullptr && server_->isRunning();
+}
+
+int RemoteApiHost::boundPort() const {
+    return server_ != nullptr ? server_->boundPort() : 0;
+}
+
+juce::File RemoteApiHost::tokenFile() const {
+    return paths::dataDir().getChildFile(kTokenFileName);
+}
+
+RemoteApiService& RemoteApiHost::service() {
+    return *service_;
+}
+
+}  // namespace remote
+}  // namespace magda

--- a/magda/daw/api/remote_api_host.hpp
+++ b/magda/daw/api/remote_api_host.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <memory>
+
+#include "remote_api.hpp"
+
+namespace magda {
+
+class MagdaApi;
+
+namespace remote {
+
+class ModelChangeBridge;
+class RemoteApiService;
+class RemoteWebSocketServer;
+
+/**
+ * @brief Owns the remote API for the lifetime of a running MAGDA (#1856).
+ *
+ * The dispatcher, the model bridge that feeds it local edits, and the WebSocket
+ * transport are three objects with one lifetime and a required construction
+ * order, so something has to own them together. This is that something, and it
+ * is the only place in the app that knows the remote API exists at all.
+ *
+ * Construct and destroy on the message thread: `ModelChangeBridge` attaches to
+ * the model singletons, which notify there.
+ *
+ * ## The token
+ *
+ * Generated per run, never persisted to config. A config file gets copied
+ * between machines, committed by accident, and pasted into bug reports; a
+ * credential in one is a credential that leaks eventually. Instead the token
+ * lives in a file beside the other app data, written with owner-only
+ * permissions and deleted on shutdown, carrying the port alongside it:
+ *
+ *     {"port":51734,"token":"…","url":"ws://127.0.0.1:51734/rpc"}
+ *
+ * A client reads that file to learn where to connect and what to present. This
+ * is the same shape Jupyter uses for its local server, and it means a client on
+ * the machine needs no configuration while a process elsewhere gets nothing.
+ *
+ * ## Disabled means disabled
+ *
+ * `start()` returns false and opens no socket when the feature is off in
+ * config, when no token could be generated, or when the port is taken. There is
+ * no partial state where MAGDA is listening but unauthenticated.
+ */
+class RemoteApiHost {
+  public:
+    explicit RemoteApiHost(MagdaApi& api);
+    ~RemoteApiHost();
+
+    RemoteApiHost(const RemoteApiHost&) = delete;
+    RemoteApiHost& operator=(const RemoteApiHost&) = delete;
+
+    /**
+     * @brief Read config, generate a token, publish it, and start listening.
+     *
+     * A no-op returning false when `Config::getRemoteApiEnabled()` is off, so
+     * the caller can always call this and let configuration decide.
+     */
+    bool start();
+
+    /// Stop listening and remove the token file. Idempotent; the destructor
+    /// calls it.
+    void stop();
+
+    bool isRunning() const;
+
+    /// The port actually bound, or 0 when not running.
+    int boundPort() const;
+
+    /// Where the token was published, whether or not it currently exists.
+    juce::File tokenFile() const;
+
+    /// The dispatcher, for adapters that share it — #1858's MCP adapter is the
+    /// next one, and it must route through the same instance rather than build
+    /// its own.
+    RemoteApiService& service();
+
+  private:
+    std::unique_ptr<RemoteApiService> service_;
+    std::unique_ptr<ModelChangeBridge> bridge_;
+    std::unique_ptr<RemoteWebSocketServer> server_;
+    juce::String token_;
+};
+
+}  // namespace remote
+}  // namespace magda

--- a/magda/daw/api/remote_api_host.hpp
+++ b/magda/daw/api/remote_api_host.hpp
@@ -33,11 +33,23 @@ class RemoteWebSocketServer;
  * lives in a file beside the other app data, written with owner-only
  * permissions and deleted on shutdown, carrying the port alongside it:
  *
- *     {"port":51734,"token":"…","url":"ws://127.0.0.1:51734/rpc"}
+ *     remote-api-<pid>.json
+ *     {"port":51734,"token":"…","url":"ws://127.0.0.1:51734/rpc","pid":4021}
  *
  * A client reads that file to learn where to connect and what to present. This
  * is the same shape Jupyter uses for its local server, and it means a client on
  * the machine needs no configuration while a process elsewhere gets nothing.
+ *
+ * The record is named after the process because MAGDA allows more than one
+ * instance. One shared file would mean the second instance to start hides the
+ * first, and the first to stop deletes the record of the one still running —
+ * and with a fixed port, where SO_REUSEPORT lets both listeners bind, a client
+ * could hold one instance's token and be routed to the other. A client that
+ * finds several records is looking at several running instances and has to
+ * choose; each is independently valid for the port it names.
+ *
+ * A record whose process is gone is debris from a crash, and any instance's
+ * `start()` will collect it. An instance only ever deletes its own live record.
  *
  * ## Disabled means disabled
  *

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -114,12 +114,18 @@ std::string errorReply(const juce::var& id, int code, const juce::String& messag
 /**
  * A dispatcher response as a JSON-RPC reply.
  *
- * The MAGDA envelope and the JSON-RPC envelope say overlapping things, so
- * rather than nest one inside the other the operation's `result` becomes the
- * JSON-RPC `result` with `revision` and `apiVersion` folded in beside it. On
- * failure the revision goes into `error.data`, where it matters most: a client
- * that lost an optimistic-concurrency race learns what the revision actually is
- * in the same message that rejects its write.
+ * `result` is whatever the operation produced, untouched. The revision and API
+ * version go in a `meta` sibling — the mirror of how a request carries its own
+ * meta beside `params`, and the only arrangement that works for every
+ * operation: `tracks.list` answers with a bare array, which has nowhere to hang
+ * a revision, so folding meta into the result would mean wrapping some
+ * operations' output and not others'. A client would then have to know which
+ * shape each operation returns before it could read either one.
+ *
+ * On failure the revision goes into `error.data` instead, where JSON-RPC keeps
+ * application detail, and where it matters most: a client that lost an
+ * optimistic-concurrency race learns the real revision in the message that
+ * rejects its write.
  */
 std::string replyFor(const juce::var& id, const Response& response) {
     if (!response.ok) {
@@ -128,23 +134,15 @@ std::string replyFor(const juce::var& id, const Response& response) {
         return errorReply(id, jsonRpcCodeFor(response.error.code), response.error.message, data);
     }
 
-    auto result = response.result;
-    if (result.getDynamicObject() == nullptr) {
-        // Operations that answer with a bare value still need somewhere to hang
-        // the revision, so they get wrapped rather than losing it.
-        auto wrapped = makeObject();
-        setProperty(wrapped, "value", result);
-        result = wrapped;
-    } else {
-        result = result.clone();
-    }
-    setProperty(result, "revision", static_cast<juce::int64>(response.revision));
-    setProperty(result, "apiVersion", juce::String(API_VERSION.data()));
+    auto meta = makeObject();
+    setProperty(meta, "revision", static_cast<juce::int64>(response.revision));
+    setProperty(meta, "apiVersion", juce::String(API_VERSION.data()));
 
     auto reply = makeObject();
     setProperty(reply, "jsonrpc", "2.0");
     setProperty(reply, "id", id);
-    setProperty(reply, "result", result);
+    setProperty(reply, "result", response.result);
+    setProperty(reply, "meta", meta);
     return juce::JSON::toString(reply, true).toStdString();
 }
 

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -18,6 +18,15 @@
 // cannot raise it.
 #define CPPHTTPLIB_WEBSOCKET_MAX_PAYLOAD_LENGTH (256 * 1024)
 
+// How long a reader may sit in read() before it comes up for air, and therefore
+// how long shutdown can take. cpp-httplib exposes no way to interrupt a blocked
+// reader — there is no socket handle on the request or the socket, and
+// set_socket_options only reaches the listening socket — so this timeout is the
+// cancellation quantum. It is short because the server pings every second (see
+// kPingIntervalSeconds), which keeps frames arriving from any client that is
+// reading, so the timeout only expires on a client that has genuinely stopped.
+#define CPPHTTPLIB_WEBSOCKET_READ_TIMEOUT_SECOND 3
+
 #include <httplib.h>
 
 #include <algorithm>
@@ -40,6 +49,18 @@ namespace {
 
 /// The path a client upgrades on. Everything else 404s.
 constexpr const char* kEndpoint = "/rpc";
+
+/**
+ * How often the server pings an idle client.
+ *
+ * This is what makes the short read timeout safe. A client sitting in `read()`
+ * answers each Ping with a Pong, which cpp-httplib consumes inside the same
+ * read, so frames keep arriving and the timeout never fires on a live
+ * connection. It is the reason a client must stay in `read()` between requests:
+ * one that neither sends nor reads produces no traffic and is indistinguishable
+ * from a dead one.
+ */
+constexpr time_t kPingIntervalSeconds = 1;
 
 // JSON-RPC 2.0 reserves -32768..-32000; -32099..-32000 is the implementation-
 // defined slice, which is where MAGDA's own failure modes land.
@@ -146,6 +167,26 @@ std::string replyFor(const juce::var& id, const Response& response) {
     return juce::JSON::toString(reply, true).toStdString();
 }
 
+bool isNumber(const juce::var& value) {
+    return value.isInt() || value.isInt64() || value.isDouble();
+}
+
+/**
+ * @brief A JSON-RPC id as an idempotency key, or empty for an id we will not take.
+ *
+ * The type has to survive into the key. JSON-RPC treats the number 1 and the
+ * string "1" as different identifiers, so collapsing both to `1` lets a client's
+ * second write silently receive the first one's cached response instead of
+ * executing.
+ */
+juce::String idempotencyKeyFor(const juce::var& id) {
+    if (id.isString())
+        return "s:" + id.toString();
+    if (isNumber(id))
+        return "n:" + id.toString();
+    return {};
+}
+
 /// Compare in time independent of how much of the token matched, so a client
 /// cannot learn the token one byte at a time from response latency.
 bool secureEquals(const juce::String& a, const juce::String& b) {
@@ -173,21 +214,27 @@ bool secureEquals(const juce::String& a, const juce::String& b) {
  * One client's shared state, owned by a `shared_ptr` so a dispatch completion
  * that outlives the socket has something valid to land on.
  *
- * `socket` is a reference to a `ws::WebSocket` living on the reading thread's
- * stack, so it is only ever touched by the reading thread and by the writer
- * thread that the reading thread joins before returning. A completion arriving
- * afterwards finds `closed` set and drops its payload rather than reaching for
- * a socket that no longer exists.
+ * `socket` belongs to the reading thread. That thread alone may call `read()`
+ * or `close()` on it, because `close()` does not merely write a Close frame —
+ * it then reads, waiting for the peer's echo, and `SocketStream` buffers
+ * internally, so a second reader corrupts the first one's state. Writes are
+ * safe from anywhere: every write path in cpp-httplib takes the socket's own
+ * write mutex, which is why the writer thread may send while the reader blocks.
+ *
+ * A completion arriving after the reader has gone finds `closed` set and drops
+ * its payload rather than reaching for a stack frame that has returned.
  */
 struct Connection {
-    Connection(httplib::ws::WebSocket& webSocket, int identifier, double burst)
+    Connection(httplib::ws::WebSocket& webSocket, int identifier, int maxQueued, double burst)
         : socket(webSocket),
           id(identifier),
+          maxQueuedReplies(maxQueued),
           tokens(burst),
           lastRefill(std::chrono::steady_clock::now()) {}
 
     httplib::ws::WebSocket& socket;
     const int id;
+    const int maxQueuedReplies;
 
     mutable std::mutex mutex;
     std::condition_variable ready;
@@ -198,39 +245,71 @@ struct Connection {
     double tokens;
     std::chrono::steady_clock::time_point lastRefill;
 
-    void send(std::string payload) {
+    /**
+     * @brief Queue one reply, or drop it if the client is not keeping up.
+     *
+     * A client that sends without ever reading fills the socket's send buffer,
+     * parks the writer thread inside `send()`, and would otherwise let the
+     * outbox grow without limit. Beyond the cap the payload is dropped: the
+     * alternative is unbounded memory held on behalf of a client that is not
+     * listening to any of it.
+     */
+    bool enqueue(std::string payload) {
         {
             const std::lock_guard<std::mutex> lock(mutex);
-            if (closed)
-                return;
+            if (closed || static_cast<int>(outbox.size()) >= maxQueuedReplies)
+                return false;
             outbox.push_back(std::move(payload));
         }
         ready.notify_one();
+        return true;
     }
 
-    /// Called from the dispatch completion on the message thread. Nothing here
-    /// touches the socket — appending to a deque is all the message thread does.
+    /**
+     * @brief Queue a reply for an admitted request, releasing its slot if it
+     *        cannot be queued.
+     *
+     * Called from the dispatch completion on the message thread, which does no
+     * I/O here — appending to a deque is all of it. The slot itself is not
+     * released until the bytes are actually written, so a client that stops
+     * reading stops being admitted rather than accumulating work.
+     */
     void complete(std::string payload) {
+        if (!enqueue(std::move(payload)))
+            release();
+    }
+
+    /// One admitted request has finished with the socket, by being written or
+    /// by being dropped.
+    void release() {
         {
             const std::lock_guard<std::mutex> lock(mutex);
-            --inFlight;
-            if (closed)
-                return;
-            outbox.push_back(std::move(payload));
+            if (inFlight > 0)
+                --inFlight;
         }
         ready.notify_one();
     }
 
     void markClosed() {
+        std::deque<std::string> abandoned;
         {
             const std::lock_guard<std::mutex> lock(mutex);
             closed = true;
+            abandoned.swap(outbox);
+            inFlight -= static_cast<int>(abandoned.size());
+            if (inFlight < 0)
+                inFlight = 0;
         }
         ready.notify_all();
     }
 
     /**
      * @brief Take one request slot, or say why not.
+     *
+     * Every inbound frame comes through here, including one too malformed to
+     * have a method: parsing costs work and every reply costs memory, so a
+     * client that floods garbage must run out of allowance exactly like one
+     * that floods valid requests.
      *
      * The bucket refills at `ratePerSecond` and holds at most one burst, so a
      * client may spend its allowance at once and then settles to the rate.
@@ -275,9 +354,29 @@ struct RemoteWebSocketServer::Impl {
     mutable std::mutex liveMutex;
     std::vector<std::shared_ptr<Connection>> live;
 
+    /**
+     * Connections admitted but not necessarily registered yet.
+     *
+     * The cap cannot be enforced by counting `live`: authorise() runs before the
+     * handshake and registration happens after it, so concurrent upgrades would
+     * all look at an empty roster and all be let in. This is claimed atomically
+     * at admission and released when the connection's thread returns, which
+     * closes that window.
+     */
+    std::atomic<int> admitted{0};
+
     int connectionCount() const {
         const std::lock_guard<std::mutex> lock(liveMutex);
         return static_cast<int>(live.size());
+    }
+
+    /// True for a request that is actually trying to become a WebSocket on our
+    /// endpoint, so a plain GET cannot consume a connection slot it will never
+    /// give back.
+    bool isUpgradeToEndpoint(const httplib::Request& request) const {
+        return request.path == kEndpoint &&
+               juce::String(request.get_header_value("Upgrade")).equalsIgnoreCase("websocket") &&
+               !request.get_header_value("Sec-WebSocket-Key").empty();
     }
 
     /**
@@ -309,18 +408,42 @@ struct RemoteWebSocketServer::Impl {
             }
         }
 
-        if (connectionCount() >= options.maxConnections) {
-            response.status = httplib::StatusCode::ServiceUnavailable_503;
-            return httplib::Server::HandlerResponse::Handled;
+        if (isUpgradeToEndpoint(request)) {
+            // Claim the slot here rather than testing a count: between a test and
+            // the registration that follows the handshake, every concurrent
+            // upgrade would see the same spare capacity.
+            if (admitted.fetch_add(1) >= options.maxConnections) {
+                admitted.fetch_sub(1);
+                response.status = httplib::StatusCode::ServiceUnavailable_503;
+                return httplib::Server::HandlerResponse::Handled;
+            }
         }
 
         return httplib::Server::HandlerResponse::Unhandled;
     }
 
+    /// Reply to a frame that never became a request, and give back its slot.
+    static void refuse(const std::shared_ptr<Connection>& connection, const juce::var& id, int code,
+                       const juce::String& message) {
+        connection->enqueue(errorReply(id, code, message));
+        connection->release();
+    }
+
     /// Parse one frame and dispatch it, or answer with the reason it failed.
     void handleMessage(const std::shared_ptr<Connection>& connection, const std::string& message) {
+        // Admission comes first, before the frame is even parsed. Rejecting
+        // later would leave the cheapest thing a client can send — a megabyte of
+        // garbage — as the one thing no limit applied to.
+        if (const auto refusal =
+                connection->admit(options.maxInFlightPerConnection, options.maxRequestsPerSecond,
+                                  options.maxInFlightPerConnection);
+            refusal.isNotEmpty()) {
+            connection->enqueue(errorReply({}, kTooManyRequests, refusal));
+            return;
+        }
+
         if (message.size() > options.maxFrameBytes) {
-            connection->send(errorReply({}, kInvalidRequest, "request too large"));
+            refuse(connection, {}, kInvalidRequest, "request too large");
             connection->socket.close(httplib::ws::CloseStatus::MessageTooBig, "request too large");
             return;
         }
@@ -328,7 +451,7 @@ struct RemoteWebSocketServer::Impl {
         juce::var parsed;
         if (juce::JSON::parse(juce::String(message), parsed).failed() ||
             parsed.getDynamicObject() == nullptr) {
-            connection->send(errorReply({}, kParseError, "malformed JSON"));
+            refuse(connection, {}, kParseError, "malformed JSON");
             return;
         }
 
@@ -336,18 +459,27 @@ struct RemoteWebSocketServer::Impl {
         const auto method = parsed["method"].toString();
 
         if (parsed["jsonrpc"].toString() != "2.0") {
-            connection->send(errorReply(id, kInvalidRequest, "jsonrpc must be \"2.0\""));
+            refuse(connection, id, kInvalidRequest, "jsonrpc must be \"2.0\"");
             return;
         }
         if (method.isEmpty()) {
-            connection->send(errorReply(id, kInvalidRequest, "method is required"));
+            refuse(connection, id, kInvalidRequest, "method is required");
             return;
         }
         // Every operation returns a revision the client needs in order to make
         // its next write, so a notification would be a request whose answer the
         // client cannot do without.
         if (id.isVoid() || id.isUndefined()) {
-            connection->send(errorReply({}, kInvalidRequest, "notifications are not supported"));
+            refuse(connection, {}, kInvalidRequest, "notifications are not supported");
+            return;
+        }
+
+        // JSON-RPC allows a string or a number. Anything else has no defined
+        // meaning, and accepting it would put a shape in the idempotency key
+        // that cannot be told apart from another.
+        const auto idKey = idempotencyKeyFor(id);
+        if (idKey.isEmpty()) {
+            refuse(connection, {}, kInvalidRequest, "id must be a string or a number");
             return;
         }
 
@@ -355,23 +487,16 @@ struct RemoteWebSocketServer::Impl {
         if (params.isVoid() || params.isUndefined())
             params = makeObject();
         if (params.getDynamicObject() == nullptr) {
-            connection->send(errorReply(id, kInvalidParams, "params must be an object"));
-            return;
-        }
-
-        if (const auto refusal =
-                connection->admit(options.maxInFlightPerConnection, options.maxRequestsPerSecond,
-                                  options.maxInFlightPerConnection);
-            refusal.isNotEmpty()) {
-            connection->send(errorReply(id, kTooManyRequests, refusal));
+            refuse(connection, id, kInvalidParams, "params must be an object");
             return;
         }
 
         RequestContext context;
         context.clientId = "ws:" + juce::String(connection->id);
         // Scoped by connection so two clients reusing id 1 do not collide in the
-        // dispatcher's idempotency cache.
-        context.requestId = context.clientId + ":" + id.toString();
+        // dispatcher's idempotency cache, and typed so that one client's numeric
+        // 1 and string "1" — different requests under JSON-RPC — cannot either.
+        context.requestId = context.clientId + ":" + idKey;
 
         // Operation schemas are declared additionalProperties:false, so anything
         // that is not operation input has to arrive beside params rather than
@@ -379,15 +504,30 @@ struct RemoteWebSocketServer::Impl {
         const auto meta = parsed["meta"];
         auto deadlineMs = options.defaultDeadlineMs;
         if (meta.getDynamicObject() != nullptr) {
-            if (const auto expected = meta["expectedRevision"]; !expected.isVoid())
+            if (const auto expected = meta["expectedRevision"]; !expected.isVoid()) {
+                if (!isNumber(expected)) {
+                    refuse(connection, id, kInvalidRequest,
+                           "meta.expectedRevision must be a number");
+                    return;
+                }
                 context.expectedRevision =
                     static_cast<Revision>(static_cast<juce::int64>(expected));
-            if (const auto requested = meta["deadlineMs"]; !requested.isVoid())
+            }
+
+            // A client may ask for less time than the server allows, never for
+            // more — and never for none. Taking the minimum without checking the
+            // sign lets -1 win it, after which a non-positive deadline is read as
+            // "no deadline" and the request outlives every bound there is.
+            if (const auto requested = meta["deadlineMs"]; !requested.isVoid()) {
+                if (!isNumber(requested) || static_cast<int>(requested) <= 0) {
+                    refuse(connection, id, kInvalidRequest,
+                           "meta.deadlineMs must be a positive number of milliseconds");
+                    return;
+                }
                 deadlineMs = std::min(deadlineMs, static_cast<int>(requested));
+            }
         }
-        if (deadlineMs > 0)
-            context.deadline =
-                std::chrono::steady_clock::now() + std::chrono::milliseconds(deadlineMs);
+        context.deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(deadlineMs);
 
         service.dispatch(method, params, context, [connection, id](Response response) {
             connection->complete(replyFor(id, response));
@@ -401,7 +541,16 @@ struct RemoteWebSocketServer::Impl {
      * before this returns, because `socket` lives on this stack frame.
      */
     void runConnection(httplib::ws::WebSocket& socket) {
+        // Balances the reservation authorise() took before the handshake.
+        const struct ReservationGuard {
+            std::atomic<int>& count;
+            ~ReservationGuard() {
+                count.fetch_sub(1);
+            }
+        } reservation{admitted};
+
         auto connection = std::make_shared<Connection>(socket, nextConnectionId.fetch_add(1),
+                                                       options.maxQueuedRepliesPerConnection,
                                                        options.maxInFlightPerConnection);
         {
             const std::lock_guard<std::mutex> lock(liveMutex);
@@ -420,7 +569,12 @@ struct RemoteWebSocketServer::Impl {
                     payload = std::move(connection->outbox.front());
                     connection->outbox.pop_front();
                 }
-                if (!connection->socket.send(payload))
+                const auto sent = connection->socket.send(payload);
+                // The slot belongs to the request until its bytes are gone, so a
+                // client that stops reading stops being admitted instead of
+                // queueing more work behind a stalled write.
+                connection->release();
+                if (!sent)
                     break;
             }
         });
@@ -438,16 +592,6 @@ struct RemoteWebSocketServer::Impl {
         {
             const std::lock_guard<std::mutex> lock(liveMutex);
             live.erase(std::remove(live.begin(), live.end(), connection), live.end());
-        }
-    }
-
-    /// Close every live client so their reading threads leave `read()`. Stopping
-    /// the acceptor alone would leave connected clients running indefinitely.
-    void closeLiveConnections() {
-        const std::lock_guard<std::mutex> lock(liveMutex);
-        for (const auto& connection : live) {
-            connection->markClosed();
-            connection->socket.close(httplib::ws::CloseStatus::GoingAway, "server shutting down");
         }
     }
 };
@@ -480,6 +624,13 @@ bool RemoteWebSocketServer::start() {
         });
 
     impl_->server.set_payload_max_length(impl_->options.maxFrameBytes);
+
+    // Keeps traffic flowing on an idle connection so the read timeout stays a
+    // shutdown quantum rather than a disconnect. Deliberately no
+    // set_websocket_max_missed_pongs: that arms cpp-httplib's heartbeat thread
+    // to call close() itself, and close() reads — the exact cross-thread read
+    // this design exists to avoid. A dead peer is caught by the read timeout.
+    impl_->server.set_websocket_ping_interval(kPingIntervalSeconds);
 
     impl_->server.WebSocket(kEndpoint, [this](const httplib::Request&, httplib::ws::WebSocket& ws) {
         impl_->runConnection(ws);
@@ -516,8 +667,19 @@ void RemoteWebSocketServer::stop() {
     if (!impl_->running.exchange(false))
         return;
 
+    // Only mark the connections; do not touch their sockets. `close()` writes a
+    // Close frame and then reads, waiting for the peer's echo, so calling it
+    // here would put this thread into the same buffered stream the connection's
+    // own thread is already blocked reading. Each reader instead notices within
+    // one read timeout and closes its own socket, which is the one thread
+    // allowed to.
+    {
+        const std::lock_guard<std::mutex> lock(impl_->liveMutex);
+        for (const auto& connection : impl_->live)
+            connection->markClosed();
+    }
+
     impl_->server.stop();
-    impl_->closeLiveConnections();
 
     if (impl_->listener.joinable())
         impl_->listener.join();

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -1,0 +1,543 @@
+#include "remote_websocket_server.hpp"
+
+// httplib pulls in <windows.h>, which defines min/max as macros and drags in
+// half the Win32 surface. Both break JUCE headers compiled after it.
+#if JUCE_WINDOWS
+    #ifndef WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
+    #endif
+    #ifndef NOMINMAX
+        #define NOMINMAX
+    #endif
+#endif
+
+// The frame cap has to be a compile-time constant, because it governs how much
+// cpp-httplib will read into memory *before* a handler ever sees the message.
+// Enforcing only in the handler would mean happily buffering 16 MB of a frame we
+// intend to reject. `Options::maxFrameBytes` can lower this per server; it
+// cannot raise it.
+#define CPPHTTPLIB_WEBSOCKET_MAX_PAYLOAD_LENGTH (256 * 1024)
+
+#include <httplib.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include "remote_service.hpp"
+
+namespace magda {
+namespace remote {
+
+namespace {
+
+/// The path a client upgrades on. Everything else 404s.
+constexpr const char* kEndpoint = "/rpc";
+
+// JSON-RPC 2.0 reserves -32768..-32000; -32099..-32000 is the implementation-
+// defined slice, which is where MAGDA's own failure modes land.
+constexpr int kParseError = -32700;
+constexpr int kInvalidRequest = -32600;
+constexpr int kMethodNotFound = -32601;
+constexpr int kInvalidParams = -32602;
+constexpr int kInternalError = -32603;
+constexpr int kNotFound = -32001;
+constexpr int kConflict = -32002;
+constexpr int kTimeout = -32003;
+constexpr int kCancelled = -32004;
+constexpr int kTooManyRequests = -32005;
+
+/**
+ * MAGDA's error taxonomy onto JSON-RPC's.
+ *
+ * The four standard codes are used where they genuinely mean the same thing, so
+ * a generic JSON-RPC client reports something sensible without knowing MAGDA.
+ * The rest have no standard equivalent and take implementation-defined codes;
+ * `error.data.code` always carries the MAGDA name regardless, so a client that
+ * does know MAGDA never has to reason about the mapping.
+ */
+int jsonRpcCodeFor(ErrorCode code) {
+    switch (code) {
+        case ErrorCode::InvalidRequest:
+            return kInvalidRequest;
+        case ErrorCode::UnknownOperation:
+            return kMethodNotFound;
+        case ErrorCode::ValidationFailed:
+            return kInvalidParams;
+        case ErrorCode::NotFound:
+            return kNotFound;
+        case ErrorCode::Conflict:
+            return kConflict;
+        case ErrorCode::Timeout:
+            return kTimeout;
+        case ErrorCode::Cancelled:
+            return kCancelled;
+        case ErrorCode::InternalError:
+            break;
+    }
+    return kInternalError;
+}
+
+juce::var makeObject() {
+    return juce::var(new juce::DynamicObject());
+}
+
+void setProperty(juce::var& object, const char* name, const juce::var& value) {
+    if (auto* dynamicObject = object.getDynamicObject())
+        dynamicObject->setProperty(juce::Identifier(name), value);
+}
+
+/// A JSON-RPC failure. `id` is null when the request was unparseable enough
+/// that we never learned it, which the spec explicitly allows.
+std::string errorReply(const juce::var& id, int code, const juce::String& message,
+                       const juce::var& data = {}) {
+    auto error = makeObject();
+    setProperty(error, "code", code);
+    setProperty(error, "message", message);
+    if (!data.isVoid())
+        setProperty(error, "data", data);
+
+    auto reply = makeObject();
+    setProperty(reply, "jsonrpc", "2.0");
+    setProperty(reply, "id", id);
+    setProperty(reply, "error", error);
+    return juce::JSON::toString(reply, true).toStdString();
+}
+
+/**
+ * A dispatcher response as a JSON-RPC reply.
+ *
+ * The MAGDA envelope and the JSON-RPC envelope say overlapping things, so
+ * rather than nest one inside the other the operation's `result` becomes the
+ * JSON-RPC `result` with `revision` and `apiVersion` folded in beside it. On
+ * failure the revision goes into `error.data`, where it matters most: a client
+ * that lost an optimistic-concurrency race learns what the revision actually is
+ * in the same message that rejects its write.
+ */
+std::string replyFor(const juce::var& id, const Response& response) {
+    if (!response.ok) {
+        auto data = toJson(response.error);
+        setProperty(data, "revision", static_cast<juce::int64>(response.revision));
+        return errorReply(id, jsonRpcCodeFor(response.error.code), response.error.message, data);
+    }
+
+    auto result = response.result;
+    if (result.getDynamicObject() == nullptr) {
+        // Operations that answer with a bare value still need somewhere to hang
+        // the revision, so they get wrapped rather than losing it.
+        auto wrapped = makeObject();
+        setProperty(wrapped, "value", result);
+        result = wrapped;
+    } else {
+        result = result.clone();
+    }
+    setProperty(result, "revision", static_cast<juce::int64>(response.revision));
+    setProperty(result, "apiVersion", juce::String(API_VERSION.data()));
+
+    auto reply = makeObject();
+    setProperty(reply, "jsonrpc", "2.0");
+    setProperty(reply, "id", id);
+    setProperty(reply, "result", result);
+    return juce::JSON::toString(reply, true).toStdString();
+}
+
+/// Compare in time independent of how much of the token matched, so a client
+/// cannot learn the token one byte at a time from response latency.
+bool secureEquals(const juce::String& a, const juce::String& b) {
+    const auto* lhs = a.toRawUTF8();
+    const auto* rhs = b.toRawUTF8();
+    const auto lhsLength = std::strlen(lhs);
+    const auto rhsLength = std::strlen(rhs);
+
+    unsigned char difference = lhsLength == rhsLength ? 0 : 1;
+    for (std::size_t i = 0, count = std::max(lhsLength, rhsLength); i < count; ++i) {
+        const auto left = i < lhsLength ? lhs[i] : '\0';
+        const auto right = i < rhsLength ? rhs[i] : '\0';
+        difference |= static_cast<unsigned char>(left ^ right);
+    }
+    return difference == 0;
+}
+
+}  // namespace
+
+// ===========================================================================
+// Connection
+// ===========================================================================
+
+/**
+ * One client's shared state, owned by a `shared_ptr` so a dispatch completion
+ * that outlives the socket has something valid to land on.
+ *
+ * `socket` is a reference to a `ws::WebSocket` living on the reading thread's
+ * stack, so it is only ever touched by the reading thread and by the writer
+ * thread that the reading thread joins before returning. A completion arriving
+ * afterwards finds `closed` set and drops its payload rather than reaching for
+ * a socket that no longer exists.
+ */
+struct Connection {
+    Connection(httplib::ws::WebSocket& webSocket, int identifier, double burst)
+        : socket(webSocket),
+          id(identifier),
+          tokens(burst),
+          lastRefill(std::chrono::steady_clock::now()) {}
+
+    httplib::ws::WebSocket& socket;
+    const int id;
+
+    mutable std::mutex mutex;
+    std::condition_variable ready;
+    std::deque<std::string> outbox;
+    bool closed = false;
+    int inFlight = 0;
+
+    double tokens;
+    std::chrono::steady_clock::time_point lastRefill;
+
+    void send(std::string payload) {
+        {
+            const std::lock_guard<std::mutex> lock(mutex);
+            if (closed)
+                return;
+            outbox.push_back(std::move(payload));
+        }
+        ready.notify_one();
+    }
+
+    /// Called from the dispatch completion on the message thread. Nothing here
+    /// touches the socket — appending to a deque is all the message thread does.
+    void complete(std::string payload) {
+        {
+            const std::lock_guard<std::mutex> lock(mutex);
+            --inFlight;
+            if (closed)
+                return;
+            outbox.push_back(std::move(payload));
+        }
+        ready.notify_one();
+    }
+
+    void markClosed() {
+        {
+            const std::lock_guard<std::mutex> lock(mutex);
+            closed = true;
+        }
+        ready.notify_all();
+    }
+
+    /**
+     * @brief Take one request slot, or say why not.
+     *
+     * The bucket refills at `ratePerSecond` and holds at most one burst, so a
+     * client may spend its allowance at once and then settles to the rate.
+     * Returns an empty string when the request may proceed.
+     */
+    juce::String admit(int maxInFlight, double ratePerSecond, double burst) {
+        const std::lock_guard<std::mutex> lock(mutex);
+
+        const auto now = std::chrono::steady_clock::now();
+        const auto elapsed = std::chrono::duration<double>(now - lastRefill).count();
+        lastRefill = now;
+        tokens = std::min(burst, tokens + elapsed * ratePerSecond);
+
+        if (inFlight >= maxInFlight)
+            return "too many requests in flight";
+        if (tokens < 1.0)
+            return "rate limit exceeded";
+
+        tokens -= 1.0;
+        ++inFlight;
+        return {};
+    }
+};
+
+// ===========================================================================
+// Impl
+// ===========================================================================
+
+struct RemoteWebSocketServer::Impl {
+    Impl(RemoteApiService& apiService, Options serverOptions)
+        : service(apiService), options(std::move(serverOptions)) {}
+
+    RemoteApiService& service;
+    const Options options;
+
+    httplib::Server server;
+    std::thread listener;
+    std::atomic<bool> running{false};
+    std::atomic<int> port{0};
+    std::atomic<int> nextConnectionId{1};
+
+    mutable std::mutex liveMutex;
+    std::vector<std::shared_ptr<Connection>> live;
+
+    int connectionCount() const {
+        const std::lock_guard<std::mutex> lock(liveMutex);
+        return static_cast<int>(live.size());
+    }
+
+    /**
+     * @brief Everything that can refuse a client, before the protocol switches.
+     *
+     * cpp-httplib consults this ahead of the 101 precisely so authentication can
+     * answer with an HTTP status instead. A refusal here leaves the client with
+     * a failed HTTP request and no socket, which is what "fail closed" has to
+     * mean — rejecting after the upgrade would hand out a connection first and
+     * take it away afterwards.
+     */
+    httplib::Server::HandlerResponse authorise(const httplib::Request& request,
+                                               httplib::Response& response) {
+        if (!secureEquals(juce::String(request.get_header_value("Authorization")),
+                          "Bearer " + options.bearerToken)) {
+            response.status = httplib::StatusCode::Unauthorized_401;
+            return httplib::Server::HandlerResponse::Handled;
+        }
+
+        // A native client sends no Origin at all; only a browser does, and a
+        // browser we did not authorise is refused. Treating "absent" as
+        // "unrecognised" would lock out every non-browser client.
+        if (request.has_header("Origin")) {
+            const juce::String origin(request.get_header_value("Origin"));
+            const auto& permitted = options.allowedOrigins;
+            if (std::find(permitted.begin(), permitted.end(), origin) == permitted.end()) {
+                response.status = httplib::StatusCode::Forbidden_403;
+                return httplib::Server::HandlerResponse::Handled;
+            }
+        }
+
+        if (connectionCount() >= options.maxConnections) {
+            response.status = httplib::StatusCode::ServiceUnavailable_503;
+            return httplib::Server::HandlerResponse::Handled;
+        }
+
+        return httplib::Server::HandlerResponse::Unhandled;
+    }
+
+    /// Parse one frame and dispatch it, or answer with the reason it failed.
+    void handleMessage(const std::shared_ptr<Connection>& connection, const std::string& message) {
+        if (message.size() > options.maxFrameBytes) {
+            connection->send(errorReply({}, kInvalidRequest, "request too large"));
+            connection->socket.close(httplib::ws::CloseStatus::MessageTooBig, "request too large");
+            return;
+        }
+
+        juce::var parsed;
+        if (juce::JSON::parse(juce::String(message), parsed).failed() ||
+            parsed.getDynamicObject() == nullptr) {
+            connection->send(errorReply({}, kParseError, "malformed JSON"));
+            return;
+        }
+
+        const auto id = parsed["id"];
+        const auto method = parsed["method"].toString();
+
+        if (parsed["jsonrpc"].toString() != "2.0") {
+            connection->send(errorReply(id, kInvalidRequest, "jsonrpc must be \"2.0\""));
+            return;
+        }
+        if (method.isEmpty()) {
+            connection->send(errorReply(id, kInvalidRequest, "method is required"));
+            return;
+        }
+        // Every operation returns a revision the client needs in order to make
+        // its next write, so a notification would be a request whose answer the
+        // client cannot do without.
+        if (id.isVoid() || id.isUndefined()) {
+            connection->send(errorReply({}, kInvalidRequest, "notifications are not supported"));
+            return;
+        }
+
+        auto params = parsed["params"];
+        if (params.isVoid() || params.isUndefined())
+            params = makeObject();
+        if (params.getDynamicObject() == nullptr) {
+            connection->send(errorReply(id, kInvalidParams, "params must be an object"));
+            return;
+        }
+
+        if (const auto refusal =
+                connection->admit(options.maxInFlightPerConnection, options.maxRequestsPerSecond,
+                                  options.maxInFlightPerConnection);
+            refusal.isNotEmpty()) {
+            connection->send(errorReply(id, kTooManyRequests, refusal));
+            return;
+        }
+
+        RequestContext context;
+        context.clientId = "ws:" + juce::String(connection->id);
+        // Scoped by connection so two clients reusing id 1 do not collide in the
+        // dispatcher's idempotency cache.
+        context.requestId = context.clientId + ":" + id.toString();
+
+        // Operation schemas are declared additionalProperties:false, so anything
+        // that is not operation input has to arrive beside params rather than
+        // inside it.
+        const auto meta = parsed["meta"];
+        auto deadlineMs = options.defaultDeadlineMs;
+        if (meta.getDynamicObject() != nullptr) {
+            if (const auto expected = meta["expectedRevision"]; !expected.isVoid())
+                context.expectedRevision =
+                    static_cast<Revision>(static_cast<juce::int64>(expected));
+            if (const auto requested = meta["deadlineMs"]; !requested.isVoid())
+                deadlineMs = std::min(deadlineMs, static_cast<int>(requested));
+        }
+        if (deadlineMs > 0)
+            context.deadline =
+                std::chrono::steady_clock::now() + std::chrono::milliseconds(deadlineMs);
+
+        service.dispatch(method, params, context, [connection, id](Response response) {
+            connection->complete(replyFor(id, response));
+        });
+    }
+
+    /**
+     * @brief One client, for as long as it stays connected.
+     *
+     * Runs on a thread cpp-httplib owns. The writer thread it starts is joined
+     * before this returns, because `socket` lives on this stack frame.
+     */
+    void runConnection(httplib::ws::WebSocket& socket) {
+        auto connection = std::make_shared<Connection>(socket, nextConnectionId.fetch_add(1),
+                                                       options.maxInFlightPerConnection);
+        {
+            const std::lock_guard<std::mutex> lock(liveMutex);
+            live.push_back(connection);
+        }
+
+        std::thread writer([connection] {
+            while (true) {
+                std::string payload;
+                {
+                    std::unique_lock<std::mutex> lock(connection->mutex);
+                    connection->ready.wait(
+                        lock, [&] { return connection->closed || !connection->outbox.empty(); });
+                    if (connection->closed)
+                        break;
+                    payload = std::move(connection->outbox.front());
+                    connection->outbox.pop_front();
+                }
+                if (!connection->socket.send(payload))
+                    break;
+            }
+        });
+
+        std::string message;
+        while (socket.is_open() && running.load()) {
+            if (socket.read(message) == httplib::ws::ReadResult::Fail)
+                break;
+            handleMessage(connection, message);
+        }
+
+        connection->markClosed();
+        writer.join();
+
+        {
+            const std::lock_guard<std::mutex> lock(liveMutex);
+            live.erase(std::remove(live.begin(), live.end(), connection), live.end());
+        }
+    }
+
+    /// Close every live client so their reading threads leave `read()`. Stopping
+    /// the acceptor alone would leave connected clients running indefinitely.
+    void closeLiveConnections() {
+        const std::lock_guard<std::mutex> lock(liveMutex);
+        for (const auto& connection : live) {
+            connection->markClosed();
+            connection->socket.close(httplib::ws::CloseStatus::GoingAway, "server shutting down");
+        }
+    }
+};
+
+// ===========================================================================
+// RemoteWebSocketServer
+// ===========================================================================
+
+RemoteWebSocketServer::RemoteWebSocketServer(RemoteApiService& service, Options options)
+    : impl_(std::make_unique<Impl>(service, std::move(options))) {}
+
+RemoteWebSocketServer::~RemoteWebSocketServer() {
+    stop();
+}
+
+bool RemoteWebSocketServer::start() {
+    if (impl_->running.load())
+        return true;
+
+    // An empty token would mean an open listener. There is no configuration
+    // that should produce one, so this fails rather than degrades.
+    if (impl_->options.bearerToken.isEmpty()) {
+        DBG("RemoteWebSocketServer: refusing to start without a bearer token");
+        return false;
+    }
+
+    impl_->server.set_pre_routing_handler(
+        [this](const httplib::Request& request, httplib::Response& response) {
+            return impl_->authorise(request, response);
+        });
+
+    impl_->server.set_payload_max_length(impl_->options.maxFrameBytes);
+
+    impl_->server.WebSocket(kEndpoint, [this](const httplib::Request&, httplib::ws::WebSocket& ws) {
+        impl_->runConnection(ws);
+    });
+
+    // Two different calls, and they are easy to confuse: bind_to_any_port's
+    // second parameter is socket flags, not a port, so passing a configured port
+    // there would bind somewhere else entirely.
+    const auto address = impl_->options.address.toStdString();
+    auto port = impl_->options.port;
+    if (port > 0) {
+        if (!impl_->server.bind_to_port(address, port))
+            port = 0;
+    } else {
+        port = impl_->server.bind_to_any_port(address);
+    }
+
+    if (port <= 0) {
+        DBG("RemoteWebSocketServer: failed to bind " + impl_->options.address + ":" +
+            juce::String(impl_->options.port));
+        return false;
+    }
+
+    impl_->port.store(port);
+    impl_->running.store(true);
+    impl_->listener = std::thread([this] { impl_->server.listen_after_bind(); });
+
+    DBG("RemoteWebSocketServer: listening on ws://" + impl_->options.address + ":" +
+        juce::String(port) + kEndpoint);
+    return true;
+}
+
+void RemoteWebSocketServer::stop() {
+    if (!impl_->running.exchange(false))
+        return;
+
+    impl_->server.stop();
+    impl_->closeLiveConnections();
+
+    if (impl_->listener.joinable())
+        impl_->listener.join();
+
+    impl_->port.store(0);
+}
+
+bool RemoteWebSocketServer::isRunning() const {
+    return impl_->running.load();
+}
+
+int RemoteWebSocketServer::boundPort() const {
+    return impl_->port.load();
+}
+
+int RemoteWebSocketServer::connectionCount() const {
+    return impl_->connectionCount();
+}
+
+}  // namespace remote
+}  // namespace magda

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -11,22 +11,12 @@
     #endif
 #endif
 
-// The frame cap has to be a compile-time constant, because it governs how much
-// cpp-httplib will read into memory *before* a handler ever sees the message.
-// Enforcing only in the handler would mean happily buffering 16 MB of a frame we
-// intend to reject. `Options::maxFrameBytes` can lower this per server; it
-// cannot raise it.
-#define CPPHTTPLIB_WEBSOCKET_MAX_PAYLOAD_LENGTH (256 * 1024)
-
-// How long a reader may sit in read() before it comes up for air, and therefore
-// how long shutdown can take. cpp-httplib exposes no way to interrupt a blocked
-// reader — there is no socket handle on the request or the socket, and
-// set_socket_options only reaches the listening socket — so this timeout is the
-// cancellation quantum. It is short because the server pings every second (see
-// kPingIntervalSeconds), which keeps frames arriving from any client that is
-// reading, so the timeout only expires on a client that has genuinely stopped.
-#define CPPHTTPLIB_WEBSOCKET_READ_TIMEOUT_SECOND 3
-
+// cpp-httplib's frame cap and read timeout are set once, as compile
+// definitions on the httplib target in the root CMakeLists.txt. They cannot be
+// #defined here: this is a header-only library, so a definition in one
+// translation unit changes only the inline functions that unit sees, and two
+// units in an executable disagreeing is an ODR violation the linker resolves
+// however it likes.
 #include <httplib.h>
 
 #include <algorithm>
@@ -194,10 +184,17 @@ std::optional<juce::int64> asIntegerInRange(const juce::var& value, juce::int64 
         const auto number = static_cast<double>(value);
         if (!std::isfinite(number) || number != std::floor(number))
             return std::nullopt;
-        // Compared as doubles, before any conversion: the bounds are exactly
-        // representable and the cast that would be undefined never happens.
-        if (number < static_cast<double>(lowest) || number > static_cast<double>(highest))
+
+        // Establish that the value fits an int64 at all before converting, and
+        // do it against 2^63 exclusive rather than (double)INT64_MAX. That cast
+        // rounds *up* to exactly 2^63, so comparing against it lets 2^63 itself
+        // through as "not greater" and straight into the conversion it was meant
+        // to prevent. The negative bound needs no such care: -2^63 is exactly
+        // representable and is a valid int64.
+        constexpr double twoPow63 = 9223372036854775808.0;
+        if (number >= twoPow63 || number < -twoPow63)
             return std::nullopt;
+
         result = static_cast<juce::int64>(number);
     } else {
         return std::nullopt;
@@ -523,16 +520,21 @@ struct RemoteWebSocketServer::Impl {
         }
 
         const auto id = parsed["id"];
-        const auto method = parsed["method"].toString();
+        const auto methodValue = parsed["method"];
 
         if (parsed["jsonrpc"].toString() != "2.0") {
             refuse(connection, id, kInvalidRequest, "jsonrpc must be \"2.0\"");
             return;
         }
-        if (method.isEmpty()) {
-            refuse(connection, id, kInvalidRequest, "method is required");
+        // JSON-RPC requires a string. Converting whatever arrived would turn
+        // `"method":123` into the operation name "123" and report it as an
+        // unknown operation, which tells the client it asked for something that
+        // does not exist rather than that it sent something malformed.
+        if (!methodValue.isString() || methodValue.toString().isEmpty()) {
+            refuse(connection, id, kInvalidRequest, "method must be a non-empty string");
             return;
         }
+        const auto method = methodValue.toString();
         // Every operation returns a revision the client needs in order to make
         // its next write, so a notification would be a request whose answer the
         // client cannot do without.

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -32,10 +32,13 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <condition_variable>
 #include <cstring>
 #include <deque>
+#include <limits>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 #include <utility>
@@ -172,6 +175,40 @@ bool isNumber(const juce::var& value) {
 }
 
 /**
+ * @brief A JSON number as an exact integer in range, or nothing.
+ *
+ * JSON has one numeric type, so a field declared as a count arrives as a double
+ * whenever it was written with a decimal point — and casting that to `int` or
+ * `int64` truncates silently when it is fractional and is undefined behaviour
+ * when it is out of range or not finite. Neither belongs on a path fed by
+ * whatever a client chose to send, so the value has to be proved integral and
+ * within bounds before it becomes one.
+ */
+std::optional<juce::int64> asIntegerInRange(const juce::var& value, juce::int64 lowest,
+                                            juce::int64 highest) {
+    juce::int64 result = 0;
+
+    if (value.isInt() || value.isInt64()) {
+        result = static_cast<juce::int64>(value);
+    } else if (value.isDouble()) {
+        const auto number = static_cast<double>(value);
+        if (!std::isfinite(number) || number != std::floor(number))
+            return std::nullopt;
+        // Compared as doubles, before any conversion: the bounds are exactly
+        // representable and the cast that would be undefined never happens.
+        if (number < static_cast<double>(lowest) || number > static_cast<double>(highest))
+            return std::nullopt;
+        result = static_cast<juce::int64>(number);
+    } else {
+        return std::nullopt;
+    }
+
+    if (result < lowest || result > highest)
+        return std::nullopt;
+    return result;
+}
+
+/**
  * @brief A JSON-RPC id as an idempotency key, or empty for an id we will not take.
  *
  * The type has to survive into the key. JSON-RPC treats the number 1 and the
@@ -236,9 +273,26 @@ struct Connection {
     const int id;
     const int maxQueuedReplies;
 
+    /**
+     * A reply waiting to be written, and whether it carries an admitted
+     * request's slot.
+     *
+     * Ownership has to travel with the payload. Releasing at the point a reply
+     * is produced and again when it is written decrements twice for one
+     * request; replying to something that was never admitted — a rate-limit
+     * refusal — and releasing on write decrements for a request that never
+     * acquired anything. Either way `inFlight` falls below the truth and
+     * readmits while earlier work is still outstanding, which is the limit
+     * quietly not being a limit.
+     */
+    struct Outgoing {
+        std::string payload;
+        bool ownsSlot = false;
+    };
+
     mutable std::mutex mutex;
     std::condition_variable ready;
-    std::deque<std::string> outbox;
+    std::deque<Outgoing> outbox;
     bool closed = false;
     int inFlight = 0;
 
@@ -252,53 +306,52 @@ struct Connection {
      * parks the writer thread inside `send()`, and would otherwise let the
      * outbox grow without limit. Beyond the cap the payload is dropped: the
      * alternative is unbounded memory held on behalf of a client that is not
-     * listening to any of it.
+     * listening to any of it. A dropped payload that owned a slot releases it
+     * here, so the release happens exactly once either way.
      */
-    bool enqueue(std::string payload) {
+    bool enqueue(std::string payload, bool ownsSlot) {
         {
             const std::lock_guard<std::mutex> lock(mutex);
-            if (closed || static_cast<int>(outbox.size()) >= maxQueuedReplies)
+            if (closed || static_cast<int>(outbox.size()) >= maxQueuedReplies) {
+                if (ownsSlot)
+                    releaseLocked();
                 return false;
-            outbox.push_back(std::move(payload));
+            }
+            outbox.push_back({std::move(payload), ownsSlot});
         }
         ready.notify_one();
         return true;
     }
 
     /**
-     * @brief Queue a reply for an admitted request, releasing its slot if it
-     *        cannot be queued.
+     * @brief Queue the reply to an admitted request.
      *
      * Called from the dispatch completion on the message thread, which does no
-     * I/O here — appending to a deque is all of it. The slot itself is not
-     * released until the bytes are actually written, so a client that stops
-     * reading stops being admitted rather than accumulating work.
+     * I/O here — appending to a deque is all of it. The slot travels with the
+     * payload and is released when the bytes are written, so a client that
+     * stops reading stops being admitted rather than accumulating work.
      */
     void complete(std::string payload) {
-        if (!enqueue(std::move(payload)))
-            release();
+        enqueue(std::move(payload), true);
     }
 
-    /// One admitted request has finished with the socket, by being written or
-    /// by being dropped.
     void release() {
         {
             const std::lock_guard<std::mutex> lock(mutex);
-            if (inFlight > 0)
-                --inFlight;
+            releaseLocked();
         }
         ready.notify_one();
     }
 
     void markClosed() {
-        std::deque<std::string> abandoned;
+        std::deque<Outgoing> abandoned;
         {
             const std::lock_guard<std::mutex> lock(mutex);
             closed = true;
             abandoned.swap(outbox);
-            inFlight -= static_cast<int>(abandoned.size());
-            if (inFlight < 0)
-                inFlight = 0;
+            for (const auto& entry : abandoned)
+                if (entry.ownsSlot)
+                    releaseLocked();
         }
         ready.notify_all();
     }
@@ -332,6 +385,12 @@ struct Connection {
         ++inFlight;
         return {};
     }
+
+  private:
+    void releaseLocked() {
+        if (inFlight > 0)
+            --inFlight;
+    }
 };
 
 // ===========================================================================
@@ -354,29 +413,34 @@ struct RemoteWebSocketServer::Impl {
     mutable std::mutex liveMutex;
     std::vector<std::shared_ptr<Connection>> live;
 
-    /**
-     * Connections admitted but not necessarily registered yet.
-     *
-     * The cap cannot be enforced by counting `live`: authorise() runs before the
-     * handshake and registration happens after it, so concurrent upgrades would
-     * all look at an empty roster and all be let in. This is claimed atomically
-     * at admission and released when the connection's thread returns, which
-     * closes that window.
-     */
-    std::atomic<int> admitted{0};
-
     int connectionCount() const {
         const std::lock_guard<std::mutex> lock(liveMutex);
         return static_cast<int>(live.size());
     }
 
-    /// True for a request that is actually trying to become a WebSocket on our
-    /// endpoint, so a plain GET cannot consume a connection slot it will never
-    /// give back.
-    bool isUpgradeToEndpoint(const httplib::Request& request) const {
-        return request.path == kEndpoint &&
-               juce::String(request.get_header_value("Upgrade")).equalsIgnoreCase("websocket") &&
-               !request.get_header_value("Sec-WebSocket-Key").empty();
+    /**
+     * @brief Claim a slot and register, or refuse — as one indivisible step.
+     *
+     * The cap has to be decided here rather than in `authorise()`. A slot
+     * reserved before the handshake is only given back by the connection
+     * handler, and cpp-httplib has several ways to never reach that handler: an
+     * upgrade this code considers valid but `is_websocket_upgrade` rejects
+     * (it also demands GET, `Connection: upgrade`, and a 24-character base64
+     * key) falls through to a 404, and a failed 101 write returns earlier still.
+     * Each of those would strand a slot for the life of the process, and enough
+     * of them would answer every honest client with 503 until restart.
+     *
+     * Testing and inserting under one lock makes the cap exact without anything
+     * to leak: this runs on the connection's own thread, so the only way to
+     * reach it is to have a connection, and the only way to leave it is through
+     * the same function that removes one.
+     */
+    bool registerConnection(const std::shared_ptr<Connection>& connection) {
+        const std::lock_guard<std::mutex> lock(liveMutex);
+        if (static_cast<int>(live.size()) >= options.maxConnections)
+            return false;
+        live.push_back(connection);
+        return true;
     }
 
     /**
@@ -408,25 +472,25 @@ struct RemoteWebSocketServer::Impl {
             }
         }
 
-        if (isUpgradeToEndpoint(request)) {
-            // Claim the slot here rather than testing a count: between a test and
-            // the registration that follows the handshake, every concurrent
-            // upgrade would see the same spare capacity.
-            if (admitted.fetch_add(1) >= options.maxConnections) {
-                admitted.fetch_sub(1);
-                response.status = httplib::StatusCode::ServiceUnavailable_503;
-                return httplib::Server::HandlerResponse::Handled;
-            }
+        // Best-effort only, and deliberately reserves nothing: a client over the
+        // cap is told so before the handshake rather than after it, but the cap
+        // itself is enforced by registerConnection(), which cannot be raced or
+        // leaked. Reserving here would mean handing a slot to a request that
+        // several cpp-httplib paths never deliver to a handler.
+        if (connectionCount() >= options.maxConnections) {
+            response.status = httplib::StatusCode::ServiceUnavailable_503;
+            return httplib::Server::HandlerResponse::Handled;
         }
 
         return httplib::Server::HandlerResponse::Unhandled;
     }
 
-    /// Reply to a frame that never became a request, and give back its slot.
+    /// Reply to an admitted frame that never became a request. The slot rides
+    /// with the reply and is released when it is written or dropped — never
+    /// here, or it would be released twice.
     static void refuse(const std::shared_ptr<Connection>& connection, const juce::var& id, int code,
                        const juce::String& message) {
-        connection->enqueue(errorReply(id, code, message));
-        connection->release();
+        connection->enqueue(errorReply(id, code, message), true);
     }
 
     /// Parse one frame and dispatch it, or answer with the reason it failed.
@@ -438,7 +502,10 @@ struct RemoteWebSocketServer::Impl {
                 connection->admit(options.maxInFlightPerConnection, options.maxRequestsPerSecond,
                                   options.maxInFlightPerConnection);
             refusal.isNotEmpty()) {
-            connection->enqueue(errorReply({}, kTooManyRequests, refusal));
+            // Nothing was admitted, so this reply owns no slot. Releasing one
+            // when it is written would hand back capacity that belongs to a
+            // request still in flight.
+            connection->enqueue(errorReply({}, kTooManyRequests, refusal), false);
             return;
         }
 
@@ -505,13 +572,14 @@ struct RemoteWebSocketServer::Impl {
         auto deadlineMs = options.defaultDeadlineMs;
         if (meta.getDynamicObject() != nullptr) {
             if (const auto expected = meta["expectedRevision"]; !expected.isVoid()) {
-                if (!isNumber(expected)) {
+                const auto revision =
+                    asIntegerInRange(expected, 0, std::numeric_limits<juce::int64>::max());
+                if (!revision.has_value()) {
                     refuse(connection, id, kInvalidRequest,
-                           "meta.expectedRevision must be a number");
+                           "meta.expectedRevision must be a non-negative whole number");
                     return;
                 }
-                context.expectedRevision =
-                    static_cast<Revision>(static_cast<juce::int64>(expected));
+                context.expectedRevision = static_cast<Revision>(*revision);
             }
 
             // A client may ask for less time than the server allows, never for
@@ -519,12 +587,14 @@ struct RemoteWebSocketServer::Impl {
             // sign lets -1 win it, after which a non-positive deadline is read as
             // "no deadline" and the request outlives every bound there is.
             if (const auto requested = meta["deadlineMs"]; !requested.isVoid()) {
-                if (!isNumber(requested) || static_cast<int>(requested) <= 0) {
+                const auto milliseconds =
+                    asIntegerInRange(requested, 1, std::numeric_limits<int>::max());
+                if (!milliseconds.has_value()) {
                     refuse(connection, id, kInvalidRequest,
-                           "meta.deadlineMs must be a positive number of milliseconds");
+                           "meta.deadlineMs must be a positive whole number of milliseconds");
                     return;
                 }
-                deadlineMs = std::min(deadlineMs, static_cast<int>(requested));
+                deadlineMs = std::min(deadlineMs, static_cast<int>(*milliseconds));
             }
         }
         context.deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(deadlineMs);
@@ -541,39 +611,36 @@ struct RemoteWebSocketServer::Impl {
      * before this returns, because `socket` lives on this stack frame.
      */
     void runConnection(httplib::ws::WebSocket& socket) {
-        // Balances the reservation authorise() took before the handshake.
-        const struct ReservationGuard {
-            std::atomic<int>& count;
-            ~ReservationGuard() {
-                count.fetch_sub(1);
-            }
-        } reservation{admitted};
-
         auto connection = std::make_shared<Connection>(socket, nextConnectionId.fetch_add(1),
                                                        options.maxQueuedRepliesPerConnection,
                                                        options.maxInFlightPerConnection);
-        {
-            const std::lock_guard<std::mutex> lock(liveMutex);
-            live.push_back(connection);
+
+        if (!registerConnection(connection)) {
+            // Lost a race for the last slot. Closing from here is safe because
+            // this is the connection's own thread, the only one allowed to read.
+            socket.close(httplib::ws::CloseStatus::PolicyViolation, "connection limit reached");
+            return;
         }
 
         std::thread writer([connection] {
             while (true) {
-                std::string payload;
+                Connection::Outgoing outgoing;
                 {
                     std::unique_lock<std::mutex> lock(connection->mutex);
                     connection->ready.wait(
                         lock, [&] { return connection->closed || !connection->outbox.empty(); });
                     if (connection->closed)
                         break;
-                    payload = std::move(connection->outbox.front());
+                    outgoing = std::move(connection->outbox.front());
                     connection->outbox.pop_front();
                 }
-                const auto sent = connection->socket.send(payload);
+                const auto sent = connection->socket.send(outgoing.payload);
                 // The slot belongs to the request until its bytes are gone, so a
                 // client that stops reading stops being admitted instead of
-                // queueing more work behind a stalled write.
-                connection->release();
+                // queueing more work behind a stalled write. Replies that never
+                // held a slot — a rate-limit refusal — release nothing.
+                if (outgoing.ownsSlot)
+                    connection->release();
                 if (!sent)
                     break;
             }

--- a/magda/daw/api/remote_websocket_server.hpp
+++ b/magda/daw/api/remote_websocket_server.hpp
@@ -1,0 +1,155 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "remote_api.hpp"
+
+namespace magda {
+namespace remote {
+
+class RemoteApiService;
+
+/**
+ * @brief JSON-RPC 2.0 over WebSocket, on top of `RemoteApiService` (#1856).
+ *
+ * A transport and nothing more. It parses frames, decides who is allowed to
+ * connect, and hands every request to `RemoteApiService::dispatch`. It knows no
+ * operation names, owns no schemas, and never touches `TrackManager`,
+ * `ClipManager`, or any other model object — a second implementation of DAW
+ * operations is exactly what the dispatcher exists to prevent.
+ *
+ * ## Wire format
+ *
+ * Requests are ordinary JSON-RPC 2.0:
+ *
+ *     {"jsonrpc":"2.0","id":7,"method":"tracks.create","params":{...}}
+ *
+ * `method` is an operation name from the registry and `params` is its input,
+ * passed through untouched. Notifications (no `id`) are rejected: every
+ * operation produces a revision the client needs, so there is no useful
+ * fire-and-forget.
+ *
+ * Anything the dispatcher needs that is not operation input rides in a
+ * top-level `meta` sibling of `params`:
+ *
+ *     {"jsonrpc":"2.0","id":7,"method":"tracks.rename","params":{...},
+ *      "meta":{"expectedRevision":42,"deadlineMs":5000}}
+ *
+ * It cannot live inside `params`, because operation schemas are declared with
+ * `additionalProperties:false` and would reject it as an unknown field. A
+ * sibling member is also what JSON-RPC's own extensibility rules expect, and
+ * clients that do not send one simply get the defaults.
+ *
+ * A reply carries the MAGDA envelope's `result` as the JSON-RPC `result`, with
+ * `revision` and `apiVersion` folded in beside it. A failure becomes a JSON-RPC
+ * `error` whose `data` keeps the MAGDA error code and the revision, so a client
+ * that lost an optimistic-concurrency race can resync without a second call.
+ *
+ * ## Threading
+ *
+ * The message thread is never used for I/O. The listener runs on its own
+ * thread, cpp-httplib gives each connection another, and each connection owns a
+ * writer thread that drains an outbox. Reading, parsing, framing, and socket
+ * writes therefore all happen away from the message thread; the only hop into
+ * it is the one `dispatch` already makes for the handler itself.
+ *
+ * That hop is why the writer thread exists. A dispatch completion fires on the
+ * message thread, and writing the response from there would put a socket write
+ * on the UI's thread. Instead the completion appends bytes to the connection's
+ * outbox — a mutex and a deque, no I/O — and returns; the writer thread wakes
+ * and sends. The reading thread is meanwhile blocked in `read()` and could not
+ * have written the reply itself without serializing every client to one
+ * in-flight request.
+ *
+ * ## Lifetime
+ *
+ * A connection can die with requests still queued against it. Completions
+ * capture a `shared_ptr` to per-connection state rather than a raw pointer, and
+ * a closed connection's outbox is drained and discarded — the same shape
+ * `RemoteApiService` uses for work queued against a retired project.
+ *
+ * `stop()` closes the listener, closes every live connection, and joins every
+ * thread it started. It is safe to call twice, and the destructor calls it.
+ */
+class RemoteWebSocketServer {
+  public:
+    struct Options {
+        /// Loopback by default, and the default is the point: this is a local
+        /// control surface, not a service. Binding anywhere else exposes an
+        /// unencrypted socket whose only credential is a bearer token.
+        juce::String address{"127.0.0.1"};
+
+        /// 0 asks the OS for a free port, which is what the tests use.
+        int port = 0;
+
+        /// Required. `start()` fails rather than open an unauthenticated
+        /// listener, so there is no configuration that accidentally allows
+        /// anonymous access.
+        juce::String bearerToken;
+
+        /// Browser origins permitted to upgrade. Empty means no browser may
+        /// connect; a native client sends no `Origin` at all and is unaffected.
+        /// Absent from a request is not the same as unrecognised — the first is
+        /// a non-browser client, the second is a page we did not authorise.
+        std::vector<juce::String> allowedOrigins;
+
+        /// Connections are a thread each, so this is a real resource bound
+        /// rather than a policy knob. Further connections are refused at the
+        /// handshake with 503.
+        int maxConnections = 8;
+
+        /// Frames above this are refused and the connection is closed with
+        /// `MessageTooBig`. Requests are small; anything large is a mistake or
+        /// an attack.
+        std::size_t maxFrameBytes = std::size_t{256} * 1024;
+
+        /// Requests accepted per connection before the dispatcher has answered
+        /// the earlier ones. Handlers are serialized by the service, so this
+        /// bounds how much one client can queue against everyone else.
+        int maxInFlightPerConnection = 8;
+
+        /// Token-bucket rate limit per connection. Bursts up to
+        /// `maxInFlightPerConnection`, then holds this rate.
+        double maxRequestsPerSecond = 50.0;
+
+        /// How long a request may wait before the dispatcher abandons it. A
+        /// client may ask for less via `meta.deadlineMs`, never for more.
+        int defaultDeadlineMs = 10'000;
+    };
+
+    RemoteWebSocketServer(RemoteApiService& service, Options options);
+    ~RemoteWebSocketServer();
+
+    RemoteWebSocketServer(const RemoteWebSocketServer&) = delete;
+    RemoteWebSocketServer& operator=(const RemoteWebSocketServer&) = delete;
+
+    /**
+     * @brief Bind and begin accepting.
+     *
+     * Returns false without opening anything if the token is empty or the port
+     * is unavailable. Binding happens synchronously, so `boundPort()` is usable
+     * the moment this returns true — a caller does not have to poll for it.
+     */
+    bool start();
+
+    /// Stop accepting, close live connections, join every thread. Idempotent.
+    void stop();
+
+    bool isRunning() const;
+
+    /// The port actually bound, which differs from `Options::port` when 0 was
+    /// requested. Zero when not running.
+    int boundPort() const;
+
+    /// Connections currently open. For tests and diagnostics.
+    int connectionCount() const;
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace remote
+}  // namespace magda

--- a/magda/daw/api/remote_websocket_server.hpp
+++ b/magda/daw/api/remote_websocket_server.hpp
@@ -117,9 +117,19 @@ class RemoteWebSocketServer {
         /// a non-browser client, the second is a page we did not authorise.
         std::vector<juce::String> allowedOrigins;
 
-        /// Connections are a thread each, so this is a real resource bound
-        /// rather than a policy knob. Further connections are refused at the
-        /// handshake with 503.
+        /**
+         * Connections are a thread each, so this is a real resource bound rather
+         * than a policy knob, and it is exact: the count is never exceeded.
+         *
+         * How a client over the limit is told is best-effort. Usually it is a
+         * 503 before the handshake. A client that wins the race for the last
+         * slot may instead see the handshake succeed and be closed immediately
+         * afterwards with `PolicyViolation`, because the cap is claimed on the
+         * connection's own thread rather than reserved ahead of it — a
+         * reservation would have to be handed back along every path cpp-httplib
+         * can take to never reach a handler, and one it misses is a slot
+         * stranded for the life of the process.
+         */
         int maxConnections = 8;
 
         /// Frames above this are refused and the connection is closed with

--- a/magda/daw/api/remote_websocket_server.hpp
+++ b/magda/daw/api/remote_websocket_server.hpp
@@ -75,8 +75,25 @@ class RemoteApiService;
  * a closed connection's outbox is drained and discarded — the same shape
  * `RemoteApiService` uses for work queued against a retired project.
  *
- * `stop()` closes the listener, closes every live connection, and joins every
+ * `stop()` closes the listener, marks every connection closed, and joins every
  * thread it started. It is safe to call twice, and the destructor calls it.
+ *
+ * Shutdown is bounded rather than immediate. cpp-httplib exposes no way to
+ * interrupt a reader blocked in `read()` — there is no socket handle on the
+ * request or the socket, and `set_socket_options` reaches only the listening
+ * socket — and its `close()` reads as well as writes, so calling it from the
+ * stopping thread would put two threads in one buffered stream. Each reader
+ * therefore notices on its own, within one read timeout of a few seconds.
+ *
+ * ## What a client has to do
+ *
+ * **Stay in `read()` between requests.** The server pings every second, and a
+ * client sitting in a read answers automatically, which is what keeps the short
+ * read timeout from expiring on a live connection. A client that neither sends
+ * nor reads produces no traffic at all and will be dropped, because nothing
+ * distinguishes it from one that has gone away. This costs a real client
+ * nothing — waiting for replies and, once #1857 lands, for pushed changes, is
+ * where a client spends its time anyway.
  */
 class RemoteWebSocketServer {
   public:
@@ -112,8 +129,16 @@ class RemoteWebSocketServer {
 
         /// Requests accepted per connection before the dispatcher has answered
         /// the earlier ones. Handlers are serialized by the service, so this
-        /// bounds how much one client can queue against everyone else.
+        /// bounds how much one client can queue against everyone else. A slot is
+        /// held until the reply's bytes are written, not until the handler
+        /// returns, so a client that stops reading stops being admitted.
         int maxInFlightPerConnection = 8;
+
+        /// Replies allowed to sit unwritten before further ones are dropped.
+        /// The backstop for a client that sends without ever reading: its socket
+        /// buffer fills, the writer parks inside send(), and without this the
+        /// queue would grow for as long as it kept talking.
+        int maxQueuedRepliesPerConnection = 32;
 
         /// Token-bucket rate limit per connection. Bursts up to
         /// `maxInFlightPerConnection`, then holds this rate.

--- a/magda/daw/api/remote_websocket_server.hpp
+++ b/magda/daw/api/remote_websocket_server.hpp
@@ -42,10 +42,15 @@ class RemoteApiService;
  * sibling member is also what JSON-RPC's own extensibility rules expect, and
  * clients that do not send one simply get the defaults.
  *
- * A reply carries the MAGDA envelope's `result` as the JSON-RPC `result`, with
- * `revision` and `apiVersion` folded in beside it. A failure becomes a JSON-RPC
- * `error` whose `data` keeps the MAGDA error code and the revision, so a client
- * that lost an optimistic-concurrency race can resync without a second call.
+ * A reply mirrors that shape: `result` is the operation's output verbatim, and
+ * `meta` beside it carries `revision` and `apiVersion`. Meta cannot live inside
+ * the result, because not every operation returns an object — `tracks.list`
+ * answers with a bare array — and wrapping only those would make the reply
+ * shape depend on which operation was called.
+ *
+ * A failure becomes a JSON-RPC `error` whose `data` keeps the MAGDA error code
+ * and the revision, so a client that lost an optimistic-concurrency race can
+ * resync without a second call.
  *
  * ## Threading
  *

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -217,6 +217,19 @@ void Config::save() {
     root->setProperty("lastUpdateCheckTimestamp",
                       static_cast<juce::int64>(lastUpdateCheckTimestamp));
 
+    // Remote API — nested "remoteApi" object. No token here by design; it is
+    // generated per run into a file only the user can read.
+    {
+        auto* remoteObj = new juce::DynamicObject();
+        remoteObj->setProperty("enabled", remoteApiEnabled);
+        remoteObj->setProperty("port", remoteApiPort);
+        juce::Array<juce::var> originArray;
+        for (const auto& origin : remoteApiAllowedOrigins)
+            originArray.add(toJuceString(origin));
+        remoteObj->setProperty("allowedOrigins", originArray);
+        root->setProperty("remoteApi", juce::var(remoteObj));
+    }
+
     // Recent projects
     juce::Array<juce::var> recentArray;
     for (const auto& r : recentProjects)
@@ -672,6 +685,20 @@ void Config::load() {
     if (obj->hasProperty("lastUpdateCheckTimestamp"))
         lastUpdateCheckTimestamp = static_cast<int64_t>(
             static_cast<juce::int64>(obj->getProperty("lastUpdateCheckTimestamp")));
+
+    // Remote API — absent means the defaults, which leave the listener off.
+    if (obj->hasProperty("remoteApi")) {
+        if (auto* remoteObj = obj->getProperty("remoteApi").getDynamicObject()) {
+            if (remoteObj->hasProperty("enabled"))
+                remoteApiEnabled = remoteObj->getProperty("enabled");
+            if (remoteObj->hasProperty("port"))
+                remoteApiPort = remoteObj->getProperty("port");
+            remoteApiAllowedOrigins.clear();
+            if (const auto* origins = remoteObj->getProperty("allowedOrigins").getArray())
+                for (const auto& origin : *origins)
+                    remoteApiAllowedOrigins.push_back(origin.toString().toStdString());
+        }
+    }
     recentProjects = getStringArray("recentProjects");
     customPluginPaths = getStringArray("customPluginPaths");
     autoEnabledInsertInputs_ = getStringArray("autoEnabledInsertInputs");

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -436,6 +436,31 @@ class Config {
         lastUpdateCheckTimestamp = ms;
     }
 
+    // Remote API (issue #1856). Off by default: starting a listener is not
+    // something a DAW should do because it was installed, even on loopback.
+    bool getRemoteApiEnabled() const {
+        return remoteApiEnabled;
+    }
+    void setRemoteApiEnabled(bool enabled) {
+        remoteApiEnabled = enabled;
+    }
+    /// 0 asks the OS for a free port. Clients read the actual one out of the
+    /// token file, so a fixed port is a convenience rather than a requirement.
+    int getRemoteApiPort() const {
+        return remoteApiPort;
+    }
+    void setRemoteApiPort(int port) {
+        remoteApiPort = port;
+    }
+    /// Browser origins allowed to connect. Empty means no browser may; native
+    /// clients send no Origin and are unaffected.
+    const std::vector<std::string>& getRemoteApiAllowedOrigins() const {
+        return remoteApiAllowedOrigins;
+    }
+    void setRemoteApiAllowedOrigins(const std::vector<std::string>& origins) {
+        remoteApiAllowedOrigins = origins;
+    }
+
     // Browser filter settings
     bool getBrowserFilterAudio() const {
         return browserFilterAudio;
@@ -1311,6 +1336,14 @@ class Config {
     // Auto-update check
     bool autoCheckUpdates = true;          // Check GitHub for newer releases on startup
     int64_t lastUpdateCheckTimestamp = 0;  // ms since epoch; rate-limit at 24h
+
+    // Remote API (#1856). The bearer token is deliberately absent: it is
+    // generated per run and written to a file only the user can read, so it
+    // never sits in a config file that gets copied around or pasted into a bug
+    // report.
+    bool remoteApiEnabled = false;
+    int remoteApiPort = 0;  // 0 = ephemeral; the token file carries the real one
+    std::vector<std::string> remoteApiAllowedOrigins;
 
     // Export audio settings
     std::string exportFormat = "WAV24";  // WAV16, WAV24, WAV32, FLAC

--- a/magda/daw/magda_daw_main.cpp
+++ b/magda/daw/magda_daw_main.cpp
@@ -13,6 +13,7 @@
 #include "../../magda/agents/llm_client_factory.hpp"
 #include "../../magda/agents/llm_presets.hpp"
 #include "api/magda_api_live.hpp"
+#include "api/remote_api_host.hpp"
 #include "audio/AudioBridge.hpp"
 #include "audio/AudioThumbnailManager.hpp"
 #include "core/AppPaths.hpp"
@@ -86,6 +87,9 @@ class MagdaDAWApplication : public JUCEApplication {
     // layer rather than inside TracktionEngineWrapper so the engine library
     // (magda_daw) doesn't pull magda_scripting into its link line.
     std::unique_ptr<magda::scripting::LuaController> luaController_;
+    // Remote API (#1856): dispatcher, model bridge and WebSocket transport.
+    // Owned here so it is torn down before the managers its bridge listens to.
+    std::unique_ptr<magda::remote::RemoteApiHost> remoteApi_;
     // Latches true once the deferred startup auto-load has fired. The
     // engine's onMidiDevicesReady callback runs on every device-list
     // change, but we only want to auto-load the active script once.
@@ -307,6 +311,14 @@ class MagdaDAWApplication : public JUCEApplication {
         mainWindow_ = std::make_unique<magda::MainWindow>(daw_engine_.get());
         juce::Logger::writeToLog("MainWindow created");
 
+        // 4b. Remote API (#1856). Off unless configuration says otherwise, and
+        // it opens nothing at all when disabled. After the window, because the
+        // model bridge attaches to managers the engine has finished setting up.
+        remoteApi_ = std::make_unique<magda::remote::RemoteApiHost>(daw_engine_->getMagdaApi());
+        if (remoteApi_->start())
+            juce::Logger::writeToLog("Remote API token written to " +
+                                     remoteApi_->tokenFile().getFullPathName());
+
         // 5. Dismiss splash screen
         splashScreen_.reset();
 
@@ -400,6 +412,12 @@ class MagdaDAWApplication : public JUCEApplication {
             modelLoadThread_.join();
         if (sampleTaggerLoadThread_.joinable())
             sampleTaggerLoadThread_.join();
+
+        // Close the remote API before anything else goes away: it holds live
+        // sockets whose threads are calling into the dispatcher, and its model
+        // bridge is attached to managers that are about to shut down.
+        DBG("[0] Remote API shutdown...");
+        remoteApi_.reset();
 
         // Stop timers first to prevent callbacks during destruction
         DBG("[1] ModulatorEngine shutdown...");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -359,6 +359,7 @@ target_sources(magda_juce_tests PRIVATE
     test_midi_bridge_note_events_juce.cpp
     test_section_scoped_device_ids_juce.cpp
     test_remote_service_live_juce.cpp
+    test_remote_websocket_live_juce.cpp
     test_clip_inspector_juce.cpp
     test_multi_clip_resize_preview_juce.cpp
     test_clip_paint_juce.cpp
@@ -428,6 +429,9 @@ target_link_libraries(magda_juce_tests
     # ClipComponent's context menu reaches the AI settings dialog, which lives
     # on the agents library.
     magda_agents
+    # cpp-httplib's WebSocket client, for driving the transport against the live
+    # facade in test_remote_websocket_live_juce.cpp. magda_daw links it PRIVATE.
+    httplib::httplib
     # JUCE (core/events/gui_basics) comes transitively from magda_daw, compiled
     # once there; direct links would recompile the JUCE stack into this target.
     # Linux: juce_gui_extra is pulled in transitively via magda_daw's

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -196,6 +196,7 @@ set(TEST_SOURCES
     test_remote_service.cpp
     test_remote_changes.cpp
     test_remote_model_bridge.cpp
+    test_remote_websocket_server.cpp
     test_device_api.cpp
     test_automation_api_surface.cpp
     # Lua controller tests (issue #592 — MIDI dispatch)
@@ -266,6 +267,10 @@ target_link_libraries(magda_tests
     # Faust runtime headers + the backend selection, so test_faust_backend.cpp
     # resolves to the same factory the app was built with.
     magda_faust_backend
+    # cpp-httplib ships the WebSocket client, so the transport tests in
+    # test_remote_websocket_server.cpp drive real sockets without a test-only
+    # dependency. magda_daw links it PRIVATE, so this target needs its own.
+    httplib::httplib
     # JUCE (core + gui_basics) comes transitively from magda_daw, compiled once
     # there; direct links would recompile the JUCE stack into this target.
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -197,6 +197,7 @@ set(TEST_SOURCES
     test_remote_changes.cpp
     test_remote_model_bridge.cpp
     test_remote_websocket_server.cpp
+    test_remote_api_host.cpp
     test_device_api.cpp
     test_automation_api_surface.cpp
     # Lua controller tests (issue #592 — MIDI dispatch)

--- a/tests/test_remote_api_host.cpp
+++ b/tests/test_remote_api_host.cpp
@@ -60,6 +60,14 @@ TEST_CASE("A disabled remote API opens no listener", "[remote][host][lifecycle]"
     MockMagdaApi api;
     RemoteApiHost host(api);
 
+    // A crashed run never reaches stop(), so its token file outlives it. Left
+    // alone, it advertises a port nothing is listening on and a credential that
+    // opens nothing — and if the OS hands that port to some other process, it
+    // points a client at a stranger.
+    host.tokenFile().getParentDirectory().createDirectory();
+    host.tokenFile().replaceWithText(R"({"port":1,"token":"stale","url":"ws://127.0.0.1:1/rpc"})");
+    REQUIRE(host.tokenFile().existsAsFile());
+
     // The acceptance criterion is about absence: not a listener that refuses
     // everything, but no socket and no published credential at all.
     REQUIRE_FALSE(host.start());
@@ -67,6 +75,14 @@ TEST_CASE("A disabled remote API opens no listener", "[remote][host][lifecycle]"
     REQUIRE(host.boundPort() == 0);
     REQUIRE_FALSE(host.tokenFile().existsAsFile());
 }
+
+// A "port already taken" case would cover the other early returns, but there is
+// no portable way to make binding fail here: cpp-httplib sets SO_REUSEPORT where
+// it exists (httplib.h:10050), so a second listener on the same port succeeds on
+// macOS and Linux, and the alternatives — privileged ports — pass or fail
+// depending on who the test runs as. The clearing happens before every early
+// return rather than on the disabled path alone, so the case above exercises the
+// same statement.
 
 TEST_CASE("Starting publishes a token a local client can use", "[remote][host][auth]") {
     MessageThreadRelaxation relax;

--- a/tests/test_remote_api_host.cpp
+++ b/tests/test_remote_api_host.cpp
@@ -1,0 +1,171 @@
+// Lifecycle and credential handling for the remote API (#1856): what MAGDA
+// opens, what it publishes, and what it leaves behind.
+
+#include <httplib.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+
+#include "MockMagdaApi.hpp"
+#include "magda/daw/api/remote_api_host.hpp"
+#include "magda/daw/core/Config.hpp"
+
+#if !JUCE_WINDOWS
+    #include <sys/stat.h>
+#endif
+
+using namespace magda;
+using namespace magda::remote;
+using magda::test::MockMagdaApi;
+
+namespace {
+
+struct MessageThreadRelaxation {
+    ScopedMessageThreadAssertionDisabler disabler;
+};
+
+/// Config is a process-wide singleton, so a test that changes it has to put it
+/// back or it leaks into whatever runs next.
+struct ScopedRemoteApiConfig {
+    explicit ScopedRemoteApiConfig(bool enabled) {
+        auto& config = Config::getInstance();
+        wasEnabled_ = config.getRemoteApiEnabled();
+        previousPort_ = config.getRemoteApiPort();
+        config.setRemoteApiEnabled(enabled);
+        config.setRemoteApiPort(0);
+    }
+    ~ScopedRemoteApiConfig() {
+        auto& config = Config::getInstance();
+        config.setRemoteApiEnabled(wasEnabled_);
+        config.setRemoteApiPort(previousPort_);
+    }
+
+  private:
+    bool wasEnabled_ = false;
+    int previousPort_ = 0;
+};
+
+juce::var readTokenFile(const juce::File& file) {
+    juce::var parsed;
+    REQUIRE(juce::JSON::parse(file.loadFileAsString(), parsed).wasOk());
+    return parsed;
+}
+
+}  // namespace
+
+TEST_CASE("A disabled remote API opens no listener", "[remote][host][lifecycle]") {
+    MessageThreadRelaxation relax;
+    ScopedRemoteApiConfig config(false);
+
+    MockMagdaApi api;
+    RemoteApiHost host(api);
+
+    // The acceptance criterion is about absence: not a listener that refuses
+    // everything, but no socket and no published credential at all.
+    REQUIRE_FALSE(host.start());
+    REQUIRE_FALSE(host.isRunning());
+    REQUIRE(host.boundPort() == 0);
+    REQUIRE_FALSE(host.tokenFile().existsAsFile());
+}
+
+TEST_CASE("Starting publishes a token a local client can use", "[remote][host][auth]") {
+    MessageThreadRelaxation relax;
+    ScopedRemoteApiConfig config(true);
+
+    MockMagdaApi api;
+    RemoteApiHost host(api);
+    REQUIRE(host.start());
+    REQUIRE(host.isRunning());
+    REQUIRE(host.boundPort() > 0);
+
+    const auto file = host.tokenFile();
+    REQUIRE(file.existsAsFile());
+
+    const auto published = readTokenFile(file);
+    const auto token = published["token"].toString();
+
+    // 256 bits, hex encoded. A short or empty token would still "work" while
+    // being guessable, so the width is worth asserting.
+    REQUIRE(token.length() == 64);
+    REQUIRE(static_cast<int>(published["port"]) == host.boundPort());
+    REQUIRE(published["url"].toString() ==
+            "ws://127.0.0.1:" + juce::String(host.boundPort()) + "/rpc");
+
+    const auto endpoint = published["url"].toString().toStdString();
+
+    SECTION("the published token is accepted") {
+        httplib::ws::WebSocketClient client(endpoint,
+                                            {{"Authorization", "Bearer " + token.toStdString()}});
+        REQUIRE(client.connect());
+    }
+
+    SECTION("anything else is not") {
+        httplib::ws::WebSocketClient client(endpoint, {{"Authorization", "Bearer not-the-token"}});
+        REQUIRE_FALSE(client.connect());
+    }
+}
+
+#if !JUCE_WINDOWS
+TEST_CASE("The token file is readable only by its owner", "[remote][host][auth]") {
+    MessageThreadRelaxation relax;
+    ScopedRemoteApiConfig config(true);
+
+    MockMagdaApi api;
+    RemoteApiHost host(api);
+    REQUIRE(host.start());
+
+    struct stat info {};
+    REQUIRE(stat(host.tokenFile().getFullPathName().toRawUTF8(), &info) == 0);
+
+    // A credential every account on the machine can read is not a credential.
+    REQUIRE((info.st_mode & 0777) == (S_IRUSR | S_IWUSR));
+}
+#endif
+
+TEST_CASE("Stopping takes the credential down with the listener", "[remote][host][lifecycle]") {
+    MessageThreadRelaxation relax;
+    ScopedRemoteApiConfig config(true);
+
+    MockMagdaApi api;
+    RemoteApiHost host(api);
+    REQUIRE(host.start());
+
+    const auto file = host.tokenFile();
+    const auto endpoint = readTokenFile(file)["url"].toString().toStdString();
+    const auto token = readTokenFile(file)["token"].toString().toStdString();
+    REQUIRE(file.existsAsFile());
+
+    host.stop();
+
+    // Leaving the file behind would advertise a dead port and a token that no
+    // longer opens anything.
+    REQUIRE_FALSE(host.isRunning());
+    REQUIRE(host.boundPort() == 0);
+    REQUIRE_FALSE(file.existsAsFile());
+
+    httplib::ws::WebSocketClient client(endpoint, {{"Authorization", "Bearer " + token}});
+    REQUIRE_FALSE(client.connect());
+
+    host.stop();  // idempotent
+}
+
+TEST_CASE("Each run generates its own token", "[remote][host][auth]") {
+    MessageThreadRelaxation relax;
+    ScopedRemoteApiConfig config(true);
+
+    MockMagdaApi api;
+
+    juce::String first;
+    {
+        RemoteApiHost host(api);
+        REQUIRE(host.start());
+        first = readTokenFile(host.tokenFile())["token"].toString();
+    }
+
+    RemoteApiHost second(api);
+    REQUIRE(second.start());
+
+    // Per run, not per install: a token that survived a restart would outlive
+    // the reason anyone was trusted with it.
+    REQUIRE(readTokenFile(second.tokenFile())["token"].toString() != first);
+}

--- a/tests/test_remote_api_host.cpp
+++ b/tests/test_remote_api_host.cpp
@@ -12,6 +12,7 @@
 
 #if !JUCE_WINDOWS
     #include <sys/stat.h>
+    #include <unistd.h>
 #endif
 
 using namespace magda;
@@ -84,23 +85,22 @@ TEST_CASE("A disabled remote API opens no listener", "[remote][host][lifecycle]"
 // return rather than on the disabled path alone, so the case above exercises the
 // same statement.
 
-TEST_CASE("Another instance's record is left alone", "[remote][host][lifecycle]") {
+TEST_CASE("Stopping removes only this instance's record", "[remote][host][lifecycle]") {
     MessageThreadRelaxation relax;
     ScopedRemoteApiConfig config(true);
 
     MockMagdaApi api;
     RemoteApiHost host(api);
-
-    // pid 1 is init/launchd: always running, never us. It stands in for a second
-    // MAGDA instance, which the app permits — moreThanOneInstanceAllowed()
-    // defaults to true. Deleting this on start or stop would strand a live
-    // instance with no way for a client to find it.
-    const auto other = host.tokenFile().getSiblingFile("remote-api-1.json");
-    other.replaceWithText(R"({"port":1,"token":"theirs","url":"ws://127.0.0.1:1/rpc","pid":1})");
-
     REQUIRE(host.start());
+
+    // Written after start(), so the sweep has already run and cannot be what
+    // decides this. It stands in for a second MAGDA instance, which the app
+    // permits — moreThanOneInstanceAllowed() defaults to true. Shutdown deleting
+    // this would strand a live instance with no way for a client to find it.
+    const auto other = host.tokenFile().getSiblingFile("remote-api-424242.json");
+    other.replaceWithText(
+        R"({"port":1,"token":"theirs","url":"ws://127.0.0.1:1/rpc","pid":424242})");
     REQUIRE(host.tokenFile() != other);
-    REQUIRE(other.existsAsFile());
 
     host.stop();
 
@@ -109,6 +109,32 @@ TEST_CASE("Another instance's record is left alone", "[remote][host][lifecycle]"
 
     other.deleteFile();
 }
+
+#if !JUCE_WINDOWS
+TEST_CASE("A live instance's record survives the sweep", "[remote][host][lifecycle]") {
+    MessageThreadRelaxation relax;
+    ScopedRemoteApiConfig config(true);
+
+    MockMagdaApi api;
+    RemoteApiHost host(api);
+
+    // The parent of this test process: alive, and not us. POSIX only — pid 1 is
+    // init there and would do just as well, but on Windows it is not a process
+    // at all, and reaching a foreign pid's liveness portably needs a toolhelp
+    // snapshot that is not worth a test. The abandoned-record case below covers
+    // the other half of the same branch on every platform.
+    const auto parent = static_cast<juce::int64>(getppid());
+    const auto other =
+        host.tokenFile().getSiblingFile("remote-api-" + juce::String(parent) + ".json");
+    REQUIRE(host.tokenFile() != other);
+    other.replaceWithText(R"({"port":1,"token":"theirs","url":"ws://127.0.0.1:1/rpc"})");
+
+    REQUIRE(host.start());
+    REQUIRE(other.existsAsFile());
+
+    other.deleteFile();
+}
+#endif
 
 TEST_CASE("A record whose process is gone is collected", "[remote][host][lifecycle]") {
     MessageThreadRelaxation relax;

--- a/tests/test_remote_api_host.cpp
+++ b/tests/test_remote_api_host.cpp
@@ -84,6 +84,66 @@ TEST_CASE("A disabled remote API opens no listener", "[remote][host][lifecycle]"
 // return rather than on the disabled path alone, so the case above exercises the
 // same statement.
 
+TEST_CASE("Another instance's record is left alone", "[remote][host][lifecycle]") {
+    MessageThreadRelaxation relax;
+    ScopedRemoteApiConfig config(true);
+
+    MockMagdaApi api;
+    RemoteApiHost host(api);
+
+    // pid 1 is init/launchd: always running, never us. It stands in for a second
+    // MAGDA instance, which the app permits — moreThanOneInstanceAllowed()
+    // defaults to true. Deleting this on start or stop would strand a live
+    // instance with no way for a client to find it.
+    const auto other = host.tokenFile().getSiblingFile("remote-api-1.json");
+    other.replaceWithText(R"({"port":1,"token":"theirs","url":"ws://127.0.0.1:1/rpc","pid":1})");
+
+    REQUIRE(host.start());
+    REQUIRE(host.tokenFile() != other);
+    REQUIRE(other.existsAsFile());
+
+    host.stop();
+
+    REQUIRE_FALSE(host.tokenFile().existsAsFile());
+    REQUIRE(other.existsAsFile());
+
+    other.deleteFile();
+}
+
+TEST_CASE("A record whose process is gone is collected", "[remote][host][lifecycle]") {
+    MessageThreadRelaxation relax;
+    ScopedRemoteApiConfig config(true);
+
+    MockMagdaApi api;
+    RemoteApiHost host(api);
+
+    // No live process carries this id: macOS caps pids below 100000 and Linux's
+    // default pid_max is 4194304. A crashed instance cannot clear its own
+    // record, and with a record per process nobody else would have.
+    const auto abandoned = host.tokenFile().getSiblingFile("remote-api-2147483647.json");
+    abandoned.replaceWithText(R"({"port":2,"token":"dead","url":"ws://127.0.0.1:2/rpc"})");
+
+    REQUIRE(host.start());
+    REQUIRE_FALSE(abandoned.existsAsFile());
+
+    abandoned.deleteFile();
+}
+
+TEST_CASE("The record is named after the process that owns it", "[remote][host][lifecycle]") {
+    MessageThreadRelaxation relax;
+    ScopedRemoteApiConfig config(true);
+
+    MockMagdaApi api;
+    RemoteApiHost host(api);
+    REQUIRE(host.start());
+
+    const auto published = readTokenFile(host.tokenFile());
+    const auto pid = static_cast<juce::int64>(published["pid"]);
+
+    REQUIRE(pid > 0);
+    REQUIRE(host.tokenFile().getFileName() == "remote-api-" + juce::String(pid) + ".json");
+}
+
 TEST_CASE("Starting publishes a token a local client can use", "[remote][host][auth]") {
     MessageThreadRelaxation relax;
     ScopedRemoteApiConfig config(true);

--- a/tests/test_remote_websocket_live_juce.cpp
+++ b/tests/test_remote_websocket_live_juce.cpp
@@ -1,5 +1,3 @@
-#define CPPHTTPLIB_WEBSOCKET_MAX_PAYLOAD_LENGTH (256 * 1024)
-
 #include <httplib.h>
 
 #include <atomic>

--- a/tests/test_remote_websocket_live_juce.cpp
+++ b/tests/test_remote_websocket_live_juce.cpp
@@ -1,0 +1,227 @@
+#define CPPHTTPLIB_WEBSOCKET_MAX_PAYLOAD_LENGTH (256 * 1024)
+
+#include <httplib.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "magda/daw/api/magda_api_live.hpp"
+#include "magda/daw/api/remote_model_bridge.hpp"
+#include "magda/daw/api/remote_service.hpp"
+#include "magda/daw/api/remote_websocket_server.hpp"
+#include "magda/daw/core/AutomationManager.hpp"
+#include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/SelectionManager.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/core/UndoManager.hpp"
+
+// The WebSocket transport against the live facade and the real singletons: a
+// frame arriving on a socket becomes an actual change to an actual project.
+// test_remote_websocket_server.cpp proves the transport behaves against a mock;
+// this proves the two halves are connected.
+//
+// It lives in the JUCE target for the reason every command-executing test does:
+// an undoable write constructs ProjectManager through UndoableMutationScope,
+// whose constructor starts a timer, and the Catch2 runner has no message system
+// for that to be valid in.
+
+namespace {
+
+using namespace magda;
+using namespace magda::remote;
+
+constexpr const char* kToken = "live-token-4c71";
+
+juce::var object(std::initializer_list<std::pair<const char*, juce::var>> fields) {
+    auto* result = new juce::DynamicObject();
+    for (const auto& [key, value] : fields)
+        result->setProperty(key, value);
+    return result;
+}
+
+std::string requestJson(const juce::String& method, const juce::var& params,
+                        const juce::var& meta = {}, int id = 1) {
+    auto* request = new juce::DynamicObject();
+    request->setProperty("jsonrpc", "2.0");
+    request->setProperty("id", id);
+    request->setProperty("method", method);
+    request->setProperty("params", params);
+    if (!meta.isVoid())
+        request->setProperty("meta", meta);
+    return juce::JSON::toString(juce::var(request), true).toStdString();
+}
+
+class RemoteWebSocketLiveTest final : public juce::UnitTest {
+  public:
+    RemoteWebSocketLiveTest() : juce::UnitTest("Remote WebSocket Live", "magda") {}
+
+    void runTest() override {
+        beginTest("A frame off the socket creates a real track");
+        {
+            Fixture fixture;
+            const auto before = fixture.service.currentRevision();
+
+            const auto reply = fixture.exchange(requestJson(
+                "tracks.create", object({{"name", "Over the wire"}, {"type", "audio"}})));
+
+            expect(reply["error"].isVoid());
+            expect(reply["jsonrpc"].toString() == "2.0");
+
+            // The point of the whole exercise: not that the transport answered,
+            // but that the project changed.
+            const auto trackId = static_cast<int>(reply["result"]["id"]);
+            const auto* track = TrackManager::getInstance().getTrack(trackId);
+            expect(track != nullptr);
+            if (track != nullptr)
+                expect(track->name == "Over the wire");
+
+            // The revision the client is told is the one it can write against.
+            expect(fixture.service.currentRevision() == before + 1);
+            expect(static_cast<juce::int64>(reply["meta"]["revision"]) ==
+                   static_cast<juce::int64>(before + 1));
+        }
+
+        beginTest("A read over the socket sees what a write over the socket did");
+        {
+            Fixture fixture;
+            fixture.exchange(
+                requestJson("tracks.create", object({{"name", "First"}, {"type", "audio"}})));
+            const auto reply = fixture.exchange(requestJson("tracks.list", object({})));
+
+            expect(reply["error"].isVoid());
+            // tracks.list answers with a bare array, and it arrives as one:
+            // result is the operation's output rather than a wrapper around it.
+            const auto* tracks = reply["result"].getArray();
+            expect(tracks != nullptr);
+            if (tracks != nullptr) {
+                expect(tracks->size() == 1);
+                if (!tracks->isEmpty())
+                    expect((*tracks)[0]["name"].toString() == "First");
+            }
+        }
+
+        beginTest("A stale expectedRevision is refused and changes nothing");
+        {
+            Fixture fixture;
+            fixture.exchange(
+                requestJson("tracks.create", object({{"name", "Present"}, {"type", "audio"}})));
+
+            const auto stale = static_cast<juce::int64>(INITIAL_REVISION);
+            const auto reply = fixture.exchange(
+                requestJson("tracks.create", object({{"name", "Doomed"}, {"type", "audio"}}),
+                            object({{"expectedRevision", stale}})));
+
+            // Conflict has no standard JSON-RPC code, so it takes an
+            // implementation-defined one and carries the MAGDA name in data.
+            expect(static_cast<int>(reply["error"]["code"]) == -32002);
+            expect(reply["error"]["data"]["code"].toString() == "conflict");
+
+            // The revision comes back with the rejection, so a client that lost
+            // the race can retry without a second round trip to discover it.
+            expect(static_cast<juce::int64>(reply["error"]["data"]["revision"]) ==
+                   static_cast<juce::int64>(fixture.service.currentRevision()));
+
+            expect(TrackManager::getInstance().getTracks().size() == 1);
+        }
+
+        beginTest("An edit made in the UI is visible to the next request");
+        {
+            Fixture fixture;
+            const auto before = fixture.service.currentRevision();
+
+            // Not through the API — this is the user doing something in MAGDA
+            // while a client is connected, which is what the model bridge is for.
+            TrackManager::getInstance().createTrack("By hand", TrackType::Audio);
+
+            const auto reply = fixture.exchange(requestJson("tracks.list", object({})));
+            const auto* tracks = reply["result"].getArray();
+            expect(tracks != nullptr);
+            if (tracks != nullptr)
+                expect(tracks->size() == 1);
+
+            // The client's expectedRevision has to go stale, or it would happily
+            // overwrite an edit it never saw.
+            expect(fixture.service.currentRevision() > before);
+        }
+    }
+
+  private:
+    struct Fixture {
+        MagdaApiLive api;
+        RemoteApiService service{api};
+        std::unique_ptr<ModelChangeBridge> bridge;
+        std::unique_ptr<RemoteWebSocketServer> server;
+
+        Fixture() {
+            reset();
+            bridge = std::make_unique<ModelChangeBridge>(service);
+
+            RemoteWebSocketServer::Options options;
+            options.bearerToken = kToken;
+            server = std::make_unique<RemoteWebSocketServer>(service, options);
+            server->start();
+        }
+
+        ~Fixture() {
+            server.reset();
+            bridge.reset();
+            reset();
+        }
+
+        Fixture(const Fixture&) = delete;
+        Fixture& operator=(const Fixture&) = delete;
+
+        static void reset() {
+            AutomationManager::getInstance().clearAll();
+            ClipManager::getInstance().clearAllClips();
+            TrackManager::getInstance().clearAllTracks();
+            UndoManager::getInstance().clearHistory();
+            SelectionManager::getInstance().clearSelection();
+        }
+
+        /**
+         * @brief One request over a real socket, from a thread that is not this one.
+         *
+         * Both halves are load-bearing. The socket work has to happen elsewhere
+         * because a blocking read here would never return: dispatch hops to the
+         * message thread, and the message thread is this one, so the handler
+         * could not run until the read gave up. Meanwhile this thread has to
+         * keep pumping, because that hop is what executes the operation.
+         *
+         * That is exactly the arrangement the real app is in, which is why it is
+         * worth reproducing rather than working around.
+         */
+        juce::var exchange(const std::string& payload, int timeoutMs = 5000) {
+            std::atomic<bool> finished{false};
+            std::string received;
+
+            std::thread worker([&] {
+                httplib::ws::WebSocketClient client(
+                    "ws://127.0.0.1:" + std::to_string(server->boundPort()) + "/rpc",
+                    {{"Authorization", std::string("Bearer ") + kToken}});
+                if (client.connect()) {
+                    client.send(payload);
+                    client.read(received);
+                }
+                finished.store(true);
+            });
+
+            const auto deadline =
+                juce::Time::getMillisecondCounter() + static_cast<juce::uint32>(timeoutMs);
+            while (!finished.load() && juce::Time::getMillisecondCounter() < deadline)
+                juce::MessageManager::getInstance()->runDispatchLoopUntil(10);
+
+            worker.join();
+
+            juce::var parsed;
+            juce::JSON::parse(juce::String(received), parsed);
+            return parsed;
+        }
+    };
+};
+
+RemoteWebSocketLiveTest remoteWebSocketLiveTest;
+
+}  // namespace

--- a/tests/test_remote_websocket_server.cpp
+++ b/tests/test_remote_websocket_server.cpp
@@ -172,10 +172,11 @@ TEST_CASE("A request round-trips as JSON-RPC 2.0", "[remote][websocket][framing]
     REQUIRE(reply["jsonrpc"].toString() == "2.0");
     REQUIRE(static_cast<int>(reply["id"]) == 1);
     REQUIRE(reply["error"].isVoid());
-    // The revision rides in the result so a client can seed its next write from
-    // the reply rather than making a second call for it.
-    REQUIRE(static_cast<juce::int64>(reply["result"]["revision"]) >= INITIAL_REVISION);
-    REQUIRE(reply["result"]["apiVersion"].toString().isNotEmpty());
+    // The revision rides in meta beside the result, so a client can seed its
+    // next write from the reply rather than making a second call for it, and so
+    // the result stays exactly what the operation returned.
+    REQUIRE(static_cast<juce::int64>(reply["meta"]["revision"]) >= INITIAL_REVISION);
+    REQUIRE(reply["meta"]["apiVersion"].toString().isNotEmpty());
 
     server.stop();
 }

--- a/tests/test_remote_websocket_server.cpp
+++ b/tests/test_remote_websocket_server.cpp
@@ -6,8 +6,6 @@
 // malformed frame does, and how limits and shutdown behave. What the operations
 // themselves do belongs to test_remote_service.cpp.
 
-#define CPPHTTPLIB_WEBSOCKET_MAX_PAYLOAD_LENGTH (256 * 1024)
-
 #include <httplib.h>
 
 #include <catch2/catch_test_macros.hpp>
@@ -483,8 +481,40 @@ TEST_CASE("Numbers in meta must be whole and in range", "[remote][websocket][fra
     REQUIRE(send(R"({"expectedRevision":-1})") == -32600);
     REQUIRE(send(R"({"expectedRevision":2.5})") == -32600);
 
-    // Whole and in range still works.
+    // 2^63 exactly. Guarding with (double)INT64_MAX does not catch this: that
+    // conversion rounds *up* to 2^63, so the value is equal to the bound rather
+    // than above it, passes a `>` test, and reaches a cast that is undefined.
+    // expectedRevision is the one that reaches for the full int64 range, so it
+    // is the one that has to be checked at the boundary.
+    REQUIRE(send(R"({"expectedRevision":9223372036854775808})") == -32600);
+    REQUIRE(send(R"({"expectedRevision":-1e19})") == -32600);
+
+    // Whole and in range still works, at the boundary and below it.
     REQUIRE(send(R"({"deadlineMs":250})") != -32600);
+    REQUIRE(send(R"({"expectedRevision":0})") != -32600);
+}
+
+TEST_CASE("method must be a string", "[remote][websocket][framing][errors]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteWebSocketServer server(service, testOptions());
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(endpoint(server), authorised());
+    REQUIRE(client.connect());
+
+    // Converting whatever arrived would make `123` the operation name "123" and
+    // report it as unknown — telling the client it asked for something that does
+    // not exist, when what it actually did was send something malformed.
+    REQUIRE(errorCodeOf(roundTrip(client, R"({"jsonrpc":"2.0","id":1,"method":123})")) == -32600);
+    REQUIRE(errorCodeOf(roundTrip(client, R"({"jsonrpc":"2.0","id":1,"method":true})")) == -32600);
+    REQUIRE(errorCodeOf(roundTrip(
+                client, R"({"jsonrpc":"2.0","id":1,"method":["tracks.list"]})")) == -32600);
+
+    // A string that names nothing is still a well-formed request for something
+    // that does not exist, and keeps its own code.
+    REQUIRE(errorCodeOf(roundTrip(client, request("tracks.summonDragon"))) == -32601);
 }
 
 TEST_CASE("The connection cap holds when clients arrive together", "[remote][websocket][limits]") {

--- a/tests/test_remote_websocket_server.cpp
+++ b/tests/test_remote_websocket_server.cpp
@@ -123,7 +123,10 @@ TEST_CASE("An upgrade without a valid token is refused before the handshake",
     // No connection was ever established, which is the difference between
     // failing closed and hanging up after the fact.
     REQUIRE(server.connectionCount() == 0);
-    server.stop();
+    // No explicit stop(): the server is declared before the client, so the
+    // client is destroyed first and its socket shutdown wakes the reader at
+    // once. Stopping while a client is still connected would instead wait out
+    // the read timeout, which is what the shutdown test below measures.
 }
 
 TEST_CASE("Origin is checked only when the client sends one", "[remote][websocket][auth]") {
@@ -154,7 +157,10 @@ TEST_CASE("Origin is checked only when the client sends one", "[remote][websocke
         REQUIRE(client.connect());
     }
 
-    server.stop();
+    // No explicit stop(): the server is declared before the client, so the
+    // client is destroyed first and its socket shutdown wakes the reader at
+    // once. Stopping while a client is still connected would instead wait out
+    // the read timeout, which is what the shutdown test below measures.
 }
 
 TEST_CASE("A request round-trips as JSON-RPC 2.0", "[remote][websocket][framing]") {
@@ -178,7 +184,10 @@ TEST_CASE("A request round-trips as JSON-RPC 2.0", "[remote][websocket][framing]
     REQUIRE(static_cast<juce::int64>(reply["meta"]["revision"]) >= INITIAL_REVISION);
     REQUIRE(reply["meta"]["apiVersion"].toString().isNotEmpty());
 
-    server.stop();
+    // No explicit stop(): the server is declared before the client, so the
+    // client is destroyed first and its socket shutdown wakes the reader at
+    // once. Stopping while a client is still connected would instead wait out
+    // the read timeout, which is what the shutdown test below measures.
 }
 
 TEST_CASE("Malformed requests fail with the right JSON-RPC code",
@@ -223,7 +232,10 @@ TEST_CASE("Malformed requests fail with the right JSON-RPC code",
                 -32602);
     }
 
-    server.stop();
+    // No explicit stop(): the server is declared before the client, so the
+    // client is destroyed first and its socket shutdown wakes the reader at
+    // once. Stopping while a client is still connected would instead wait out
+    // the read timeout, which is what the shutdown test below measures.
 }
 
 TEST_CASE("Connections are capped", "[remote][websocket][limits]") {
@@ -246,7 +258,10 @@ TEST_CASE("Connections are capped", "[remote][websocket][limits]") {
     httplib::ws::WebSocketClient third(endpoint(server), authorised());
     REQUIRE_FALSE(third.connect());
 
-    server.stop();
+    // No explicit stop(): the server is declared before the client, so the
+    // client is destroyed first and its socket shutdown wakes the reader at
+    // once. Stopping while a client is still connected would instead wait out
+    // the read timeout, which is what the shutdown test below measures.
 }
 
 TEST_CASE("An oversized frame closes the connection", "[remote][websocket][limits]") {
@@ -263,7 +278,10 @@ TEST_CASE("An oversized frame closes the connection", "[remote][websocket][limit
     std::string ignored;
     REQUIRE(client.read(ignored) == httplib::ws::ReadResult::Fail);
 
-    server.stop();
+    // No explicit stop(): the server is declared before the client, so the
+    // client is destroyed first and its socket shutdown wakes the reader at
+    // once. Stopping while a client is still connected would instead wait out
+    // the read timeout, which is what the shutdown test below measures.
 }
 
 TEST_CASE("Shutdown closes live connections and joins every thread",
@@ -278,8 +296,11 @@ TEST_CASE("Shutdown closes live connections and joins every thread",
     REQUIRE(client.connect());
     REQUIRE(roundTrip(client, request("tracks.list"))["error"].isVoid());
 
-    // Stopping the acceptor alone would leave this client's reading thread
-    // parked in read() until its timeout; stop() has to close it explicitly.
+    // Stopping with a client still connected is the bounded case: nothing can
+    // interrupt a reader blocked in read(), so stop() marks the connection and
+    // waits for the reader to come up for air on its own. It must not touch the
+    // socket itself — close() reads as well as writes, and a second reader on
+    // one buffered stream is a data race, not merely a slow shutdown.
     server.stop();
 
     REQUIRE_FALSE(server.isRunning());
@@ -291,4 +312,153 @@ TEST_CASE("Shutdown closes live connections and joins every thread",
 
     // Idempotent: the destructor calls it too.
     server.stop();
+}
+
+TEST_CASE("meta.deadlineMs may only shorten the deadline", "[remote][websocket][limits][errors]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteWebSocketServer server(service, testOptions());
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(endpoint(server), authorised());
+    REQUIRE(client.connect());
+
+    // A negative value used to win the min() against the server's default, and
+    // a non-positive deadline then read as "no deadline at all" — so the way to
+    // escape the bound was to ask for less than none of it.
+    SECTION("negative is refused") {
+        REQUIRE(
+            errorCodeOf(roundTrip(
+                client,
+                R"({"jsonrpc":"2.0","id":1,"method":"tracks.list","meta":{"deadlineMs":-1}})")) ==
+            -32600);
+    }
+
+    SECTION("zero is refused") {
+        REQUIRE(
+            errorCodeOf(roundTrip(
+                client,
+                R"({"jsonrpc":"2.0","id":1,"method":"tracks.list","meta":{"deadlineMs":0}})")) ==
+            -32600);
+    }
+
+    SECTION("a non-number is refused") {
+        REQUIRE(
+            errorCodeOf(roundTrip(
+                client,
+                R"({"jsonrpc":"2.0","id":1,"method":"tracks.list","meta":{"deadlineMs":"soon"}})")) ==
+            -32600);
+    }
+
+    SECTION("a shorter one is accepted") {
+        const auto reply = roundTrip(
+            client, R"({"jsonrpc":"2.0","id":1,"method":"tracks.list","meta":{"deadlineMs":250}})");
+        REQUIRE(reply["error"].isVoid());
+    }
+}
+
+TEST_CASE("A numeric id and the same digits as a string are different requests",
+          "[remote][websocket][framing]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteWebSocketServer server(service, testOptions());
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(endpoint(server), authorised());
+    REQUIRE(client.connect());
+
+    const auto setTempo = R"({"jsonrpc":"2.0","id":%ID%,"method":"project.setTempo",)"
+                          R"("params":{"tempo":%BPM%}})";
+    const auto build = [&setTempo](const char* id, const char* bpm) {
+        return juce::String(setTempo).replace("%ID%", id).replace("%BPM%", bpm).toStdString();
+    };
+
+    REQUIRE(roundTrip(client, build("1", "120.0"))["error"].isVoid());
+    REQUIRE(api.project_.info.tempo == 120.0);
+
+    REQUIRE(roundTrip(client, build("\"1\"", "140.0"))["error"].isVoid());
+
+    // JSON-RPC treats the number 1 and the string "1" as distinct identifiers.
+    // Flattening both to `1` in the idempotency key made the second write replay
+    // the first one's response instead of executing — and the cache is keyed on
+    // the request id alone, not the method, so the mutation vanished silently.
+    REQUIRE(api.project_.info.tempo == 140.0);
+}
+
+TEST_CASE("An id of an unusable shape is refused", "[remote][websocket][framing][errors]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteWebSocketServer server(service, testOptions());
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(endpoint(server), authorised());
+    REQUIRE(client.connect());
+
+    REQUIRE(errorCodeOf(roundTrip(
+                client, R"({"jsonrpc":"2.0","id":{"a":1},"method":"tracks.list"})")) == -32600);
+    REQUIRE(errorCodeOf(roundTrip(
+                client, R"({"jsonrpc":"2.0","id":[1],"method":"tracks.list"})")) == -32600);
+}
+
+TEST_CASE("Garbage is rate limited like anything else", "[remote][websocket][limits]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    auto options = testOptions();
+    options.maxRequestsPerSecond = 5.0;
+    options.maxInFlightPerConnection = 2;  // also the burst
+    RemoteWebSocketServer server(service, options);
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(endpoint(server), authorised());
+    REQUIRE(client.connect());
+
+    // Admission used to happen after parsing, which left the cheapest thing a
+    // client can send as the one thing no limit applied to.
+    bool refused = false;
+    for (int i = 0; i < 6 && !refused; ++i)
+        refused = errorCodeOf(roundTrip(client, "{not json at all")) == -32005;
+
+    REQUIRE(refused);
+}
+
+TEST_CASE("The connection cap holds when clients arrive together", "[remote][websocket][limits]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    auto options = testOptions();
+    options.maxConnections = 2;
+    RemoteWebSocketServer server(service, options);
+    REQUIRE(server.start());
+
+    // The cap used to be a count read before the handshake and a registration
+    // performed after it, so upgrades racing each other all saw room.
+    constexpr int kAttempts = 8;
+    std::atomic<int> connected{0};
+    std::atomic<int> finished{0};
+    std::vector<std::thread> clients;
+
+    for (int i = 0; i < kAttempts; ++i) {
+        clients.emplace_back([&] {
+            httplib::ws::WebSocketClient client(endpoint(server), authorised());
+            if (client.connect())
+                ++connected;
+            ++finished;
+            // Hold the connection until every attempt has been made, so a slot
+            // freed early cannot be handed to a later arrival.
+            while (finished.load() < kAttempts)
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        });
+    }
+
+    for (auto& thread : clients)
+        thread.join();
+
+    REQUIRE(connected.load() <= options.maxConnections);
+    REQUIRE(connected.load() > 0);
 }

--- a/tests/test_remote_websocket_server.cpp
+++ b/tests/test_remote_websocket_server.cpp
@@ -1,0 +1,293 @@
+// The WebSocket transport for the remote API (#1856), end to end over a real
+// loopback socket. cpp-httplib ships the client, so these are genuine
+// connections rather than a hand-driven handler.
+//
+// Everything here is transport behaviour: who is allowed to connect, what a
+// malformed frame does, and how limits and shutdown behave. What the operations
+// themselves do belongs to test_remote_service.cpp.
+
+#define CPPHTTPLIB_WEBSOCKET_MAX_PAYLOAD_LENGTH (256 * 1024)
+
+#include <httplib.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "MockMagdaApi.hpp"
+#include "magda/daw/api/remote_service.hpp"
+#include "magda/daw/api/remote_websocket_server.hpp"
+
+using namespace magda;
+using namespace magda::remote;
+using magda::test::MockMagdaApi;
+
+namespace {
+
+constexpr const char* kToken = "spike-token-9f3a";
+constexpr const char* kOrigin = "http://localhost:5173";
+
+/// Reads MagdaApi live state, which asserts the message thread. The Catch2
+/// runner has no MessageManager, so suspend that assertion — the same
+/// accommodation the other remote tests make. With no message thread to hop to,
+/// dispatch also runs inline on the connection's own thread, which makes these
+/// tests deterministic rather than timing-dependent.
+struct MessageThreadRelaxation {
+    ScopedMessageThreadAssertionDisabler disabler;
+};
+
+RemoteWebSocketServer::Options testOptions() {
+    RemoteWebSocketServer::Options options;
+    options.bearerToken = kToken;
+    options.allowedOrigins = {kOrigin};
+    return options;
+}
+
+std::string endpoint(const RemoteWebSocketServer& server) {
+    return "ws://127.0.0.1:" + std::to_string(server.boundPort()) + "/rpc";
+}
+
+httplib::Headers authorised() {
+    return {{"Authorization", std::string("Bearer ") + kToken}};
+}
+
+std::string request(const juce::String& method, const juce::var& params = {},
+                    const juce::var& id = 1) {
+    auto* object = new juce::DynamicObject();
+    object->setProperty("jsonrpc", "2.0");
+    object->setProperty("id", id);
+    object->setProperty("method", method);
+    object->setProperty("params", params.isVoid() ? juce::var(new juce::DynamicObject()) : params);
+    return juce::JSON::toString(juce::var(object), true).toStdString();
+}
+
+/// Send one request, read one reply, parse it.
+juce::var roundTrip(httplib::ws::WebSocketClient& client, const std::string& payload) {
+    REQUIRE(client.send(payload));
+    std::string reply;
+    REQUIRE(client.read(reply) == httplib::ws::ReadResult::Text);
+    juce::var parsed;
+    REQUIRE(juce::JSON::parse(juce::String(reply), parsed).wasOk());
+    return parsed;
+}
+
+int errorCodeOf(const juce::var& reply) {
+    return static_cast<int>(reply["error"]["code"]);
+}
+
+}  // namespace
+
+TEST_CASE("The server refuses to start without a bearer token", "[remote][websocket][auth]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    RemoteWebSocketServer::Options options;
+    options.bearerToken = {};
+    RemoteWebSocketServer server(service, options);
+
+    // An open listener is never a valid outcome of a missing credential, so this
+    // fails rather than starting something anonymous.
+    REQUIRE_FALSE(server.start());
+    REQUIRE_FALSE(server.isRunning());
+    REQUIRE(server.boundPort() == 0);
+}
+
+TEST_CASE("An upgrade without a valid token is refused before the handshake",
+          "[remote][websocket][auth]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteWebSocketServer server(service, testOptions());
+    REQUIRE(server.start());
+
+    SECTION("no Authorization header at all") {
+        httplib::ws::WebSocketClient client(endpoint(server));
+        REQUIRE_FALSE(client.connect());
+    }
+
+    SECTION("a token that is close but wrong") {
+        httplib::ws::WebSocketClient client(
+            endpoint(server), {{"Authorization", std::string("Bearer ") + kToken + "x"}});
+        REQUIRE_FALSE(client.connect());
+    }
+
+    SECTION("the right token under the wrong scheme") {
+        httplib::ws::WebSocketClient client(endpoint(server),
+                                            {{"Authorization", std::string("Basic ") + kToken}});
+        REQUIRE_FALSE(client.connect());
+    }
+
+    // No connection was ever established, which is the difference between
+    // failing closed and hanging up after the fact.
+    REQUIRE(server.connectionCount() == 0);
+    server.stop();
+}
+
+TEST_CASE("Origin is checked only when the client sends one", "[remote][websocket][auth]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteWebSocketServer server(service, testOptions());
+    REQUIRE(server.start());
+
+    SECTION("an unlisted browser origin is refused") {
+        auto headers = authorised();
+        headers.emplace("Origin", "http://evil.example");
+        httplib::ws::WebSocketClient client(endpoint(server), headers);
+        REQUIRE_FALSE(client.connect());
+    }
+
+    SECTION("a listed browser origin is allowed") {
+        auto headers = authorised();
+        headers.emplace("Origin", kOrigin);
+        httplib::ws::WebSocketClient client(endpoint(server), headers);
+        REQUIRE(client.connect());
+    }
+
+    SECTION("a native client sending no Origin is allowed") {
+        // Absent is not the same as unrecognised. Treating it as a refusal would
+        // lock out every non-browser client, which is most of them.
+        httplib::ws::WebSocketClient client(endpoint(server), authorised());
+        REQUIRE(client.connect());
+    }
+
+    server.stop();
+}
+
+TEST_CASE("A request round-trips as JSON-RPC 2.0", "[remote][websocket][framing]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteWebSocketServer server(service, testOptions());
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(endpoint(server), authorised());
+    REQUIRE(client.connect());
+
+    const auto reply = roundTrip(client, request("tracks.list"));
+
+    REQUIRE(reply["jsonrpc"].toString() == "2.0");
+    REQUIRE(static_cast<int>(reply["id"]) == 1);
+    REQUIRE(reply["error"].isVoid());
+    // The revision rides in the result so a client can seed its next write from
+    // the reply rather than making a second call for it.
+    REQUIRE(static_cast<juce::int64>(reply["result"]["revision"]) >= INITIAL_REVISION);
+    REQUIRE(reply["result"]["apiVersion"].toString().isNotEmpty());
+
+    server.stop();
+}
+
+TEST_CASE("Malformed requests fail with the right JSON-RPC code",
+          "[remote][websocket][framing][errors]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteWebSocketServer server(service, testOptions());
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(endpoint(server), authorised());
+    REQUIRE(client.connect());
+
+    SECTION("unparseable JSON is a parse error") {
+        REQUIRE(errorCodeOf(roundTrip(client, "{not json at all")) == -32700);
+    }
+
+    SECTION("a missing jsonrpc version is an invalid request") {
+        REQUIRE(errorCodeOf(roundTrip(client, R"({"id":1,"method":"tracks.list"})")) == -32600);
+    }
+
+    SECTION("a notification is refused, because every reply carries a revision") {
+        REQUIRE(errorCodeOf(roundTrip(client, R"({"jsonrpc":"2.0","method":"tracks.list"})")) ==
+                -32600);
+    }
+
+    SECTION("an unknown operation is method-not-found") {
+        REQUIRE(errorCodeOf(roundTrip(client, request("tracks.summonDragon"))) == -32601);
+    }
+
+    SECTION("schema-invalid params are invalid-params") {
+        const auto reply = roundTrip(client, request("project.setTempo"));
+        REQUIRE(errorCodeOf(reply) == -32602);
+        // The MAGDA code survives the mapping, so a client that knows MAGDA does
+        // not have to reason backwards from the JSON-RPC code.
+        REQUIRE(reply["error"]["data"]["code"].toString() == "validation_failed");
+    }
+
+    SECTION("params of the wrong shape are rejected before dispatch") {
+        REQUIRE(errorCodeOf(roundTrip(
+                    client, R"({"jsonrpc":"2.0","id":1,"method":"tracks.list","params":42})")) ==
+                -32602);
+    }
+
+    server.stop();
+}
+
+TEST_CASE("Connections are capped", "[remote][websocket][limits]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    auto options = testOptions();
+    options.maxConnections = 2;
+    RemoteWebSocketServer server(service, options);
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient first(endpoint(server), authorised());
+    httplib::ws::WebSocketClient second(endpoint(server), authorised());
+    REQUIRE(first.connect());
+    REQUIRE(second.connect());
+
+    // Connections are a thread each, so the cap is a resource bound rather than
+    // a policy knob, and it is enforced at the handshake.
+    httplib::ws::WebSocketClient third(endpoint(server), authorised());
+    REQUIRE_FALSE(third.connect());
+
+    server.stop();
+}
+
+TEST_CASE("An oversized frame closes the connection", "[remote][websocket][limits]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteWebSocketServer server(service, testOptions());
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(endpoint(server), authorised());
+    REQUIRE(client.connect());
+
+    client.send(std::string(CPPHTTPLIB_WEBSOCKET_MAX_PAYLOAD_LENGTH + 1024, 'x'));
+    std::string ignored;
+    REQUIRE(client.read(ignored) == httplib::ws::ReadResult::Fail);
+
+    server.stop();
+}
+
+TEST_CASE("Shutdown closes live connections and joins every thread",
+          "[remote][websocket][lifecycle]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteWebSocketServer server(service, testOptions());
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(endpoint(server), authorised());
+    REQUIRE(client.connect());
+    REQUIRE(roundTrip(client, request("tracks.list"))["error"].isVoid());
+
+    // Stopping the acceptor alone would leave this client's reading thread
+    // parked in read() until its timeout; stop() has to close it explicitly.
+    server.stop();
+
+    REQUIRE_FALSE(server.isRunning());
+    REQUIRE(server.boundPort() == 0);
+    REQUIRE(server.connectionCount() == 0);
+
+    std::string ignored;
+    REQUIRE(client.read(ignored) == httplib::ws::ReadResult::Fail);
+
+    // Idempotent: the destructor calls it too.
+    server.stop();
+}

--- a/tests/test_remote_websocket_server.cpp
+++ b/tests/test_remote_websocket_server.cpp
@@ -426,6 +426,67 @@ TEST_CASE("Garbage is rate limited like anything else", "[remote][websocket][lim
     REQUIRE(refused);
 }
 
+TEST_CASE("A malformed upgrade cannot strand a connection slot", "[remote][websocket][limits]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    auto options = testOptions();
+    options.maxConnections = 2;
+    RemoteWebSocketServer server(service, options);
+    REQUIRE(server.start());
+
+    // Authenticated, addressed to the endpoint, and carrying an Upgrade header,
+    // but with a key cpp-httplib rejects: it wants 24 base64 characters. These
+    // fall through to a 404 without ever reaching the WebSocket handler, so a
+    // slot claimed before the handshake would never be given back — and enough
+    // of them would answer every honest client with 503 until restart.
+    httplib::Client http("127.0.0.1", server.boundPort());
+    const httplib::Headers malformed{{"Authorization", std::string("Bearer ") + kToken},
+                                     {"Upgrade", "websocket"},
+                                     {"Connection", "Upgrade"},
+                                     {"Sec-WebSocket-Key", "too-short"},
+                                     {"Sec-WebSocket-Version", "13"}};
+    for (int i = 0; i < 10; ++i)
+        http.Get("/rpc", malformed);
+
+    REQUIRE(server.connectionCount() == 0);
+
+    httplib::ws::WebSocketClient client(endpoint(server), authorised());
+    REQUIRE(client.connect());
+    REQUIRE(roundTrip(client, request("tracks.list"))["error"].isVoid());
+}
+
+TEST_CASE("Numbers in meta must be whole and in range", "[remote][websocket][framing][errors]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteWebSocketServer server(service, testOptions());
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(endpoint(server), authorised());
+    REQUIRE(client.connect());
+
+    const auto send = [&client](const char* meta) {
+        return errorCodeOf(roundTrip(
+            client, juce::String(R"({"jsonrpc":"2.0","id":1,"method":"tracks.list","meta":%META%})")
+                        .replace("%META%", meta)
+                        .toStdString()));
+    };
+
+    // JSON has one numeric type, so any of these arrives as a double. Casting
+    // that to int truncates a fraction silently and is undefined behaviour when
+    // it does not fit — neither is acceptable on a path fed by whatever a client
+    // decided to send.
+    REQUIRE(send(R"({"deadlineMs":250.5})") == -32600);
+    REQUIRE(send(R"({"deadlineMs":1e18})") == -32600);
+    REQUIRE(send(R"({"expectedRevision":-1})") == -32600);
+    REQUIRE(send(R"({"expectedRevision":2.5})") == -32600);
+
+    // Whole and in range still works.
+    REQUIRE(send(R"({"deadlineMs":250})") != -32600);
+}
+
 TEST_CASE("The connection cap holds when clients arrive together", "[remote][websocket][limits]") {
     MessageThreadRelaxation relax;
     MockMagdaApi api;
@@ -441,6 +502,7 @@ TEST_CASE("The connection cap holds when clients arrive together", "[remote][web
     constexpr int kAttempts = 8;
     std::atomic<int> connected{0};
     std::atomic<int> finished{0};
+    std::atomic<bool> release{false};
     std::vector<std::thread> clients;
 
     for (int i = 0; i < kAttempts; ++i) {
@@ -449,16 +511,30 @@ TEST_CASE("The connection cap holds when clients arrive together", "[remote][web
             if (client.connect())
                 ++connected;
             ++finished;
-            // Hold the connection until every attempt has been made, so a slot
-            // freed early cannot be handed to a later arrival.
-            while (finished.load() < kAttempts)
+            // Hold on until every attempt has been made, so a slot freed early
+            // cannot be handed to a later arrival and hide the overshoot.
+            while (!release.load())
                 std::this_thread::sleep_for(std::chrono::milliseconds(1));
         });
     }
 
+    while (finished.load() < kAttempts)
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    // Registered connections are the real bound, and it is exact: the check and
+    // the insert happen under one lock, on the connection's own thread.
+    const auto peak = server.connectionCount();
+
+    release.store(true);
     for (auto& thread : clients)
         thread.join();
 
-    REQUIRE(connected.load() <= options.maxConnections);
-    REQUIRE(connected.load() > 0);
+    REQUIRE(peak <= options.maxConnections);
+    REQUIRE(peak > 0);
+
+    // A racer can still see its handshake succeed and be closed immediately
+    // afterwards: the pre-handshake 503 is best-effort, because reserving a slot
+    // there would mean reserving for requests cpp-httplib may never hand to a
+    // handler, and those reservations would never come back.
+    REQUIRE(connected.load() >= peak);
 }


### PR DESCRIPTION
Closes #1856. Builds on #1855's dispatcher; nothing here reimplements an operation.

## The dependency spike said no to CHOC

The issue named `choc_HTTPServer.h` as the thing to evaluate. It cannot refuse a connection: `upgradeToWebsocket` starts the handshake and *then* calls `upgradedToWebSocket(target)`, which gets the request path and nothing else — no `Origin`, no `Authorization`, no return value to refuse with. `ClientInstance` has no close, so one bad client can only be dropped by tearing down the whole listener. Two acceptance criteria here are about failing closed, so it would need a patched copy of the header **plus** the first Boost in this tree — brew on macOS, `libboost-dev` on Linux, a vcpkg port on Windows, and a README prerequisite change on all three.

websocketpp is dormant (last release April 2020, one commit since) and still needs Asio. Hand-rolling on `juce::StreamingSocket` was the fallback until it turned out the codebase's networking is all `juce::URL` — an HTTP client that cannot serve — so the consistency would have been with the namespace, not with anything structural, at a price of ~500 lines of framing plus a client implementation for the tests.

**cpp-httplib** was already in the tree, vendored by llama.cpp. MIT, no required dependencies, and its upgrade path consults the pre-routing handler before sending the 101 exactly so authentication can answer 401 instead. It ships a WebSocket client too, so the tests drive real sockets with no test-only dependency. Pinned at `v0.52.0` via FetchContent rather than reached for inside llama.cpp's vendor directory, which Dependabot bumps. Full reasoning in `docs/remote-api-transport.md`.

## What it does

`RemoteWebSocketServer` parses frames, decides who may connect, and hands everything to `RemoteApiService::dispatch`. It knows no operation names and reaches for no manager — the "no direct calls to `TrackManager`/`ClipManager`" criterion holds structurally rather than by discipline.

Refusal happens before the protocol switches: bad token → 401, unlisted browser Origin → 403 — in each case a failed HTTP request and no socket. The connection cap is exact but its *refusal* is best-effort: usually a 503 before the handshake, though a client winning the race for the last slot sees the handshake succeed and a `PolicyViolation` close immediately after. The cap is claimed on the connection's own thread rather than reserved ahead of it, because a reservation has to be handed back along every path cpp-httplib can take to never reach a handler, and one missed path strands a slot for the life of the process. A request with no `Origin` at all is a native client, not an unrecognised page, and is allowed. Token comparison is constant-time.

The message thread does no I/O. Listener thread, a thread per connection, and a writer per connection draining an outbox. The writer is the point: a dispatch completion arrives on the message thread, where writing the reply would put a socket write on the UI's thread, so it appends bytes and returns. Completions hold a `shared_ptr` to per-connection state, so one outliving its socket drops its payload rather than reaching for a returned stack frame.

`RemoteApiHost` owns the dispatcher, model bridge and transport as one lifetime — the first thing to instantiate `RemoteApiService`. Off by default in config. The bearer token is generated per run from `std::random_device`, published to `remote-api.json` in the data dir with the port beside it, and deleted on shutdown; never persisted to config, which gets copied around and pasted into bug reports.

## Wire format

    → {"jsonrpc":"2.0","id":7,"method":"tracks.rename","params":{...},"meta":{"expectedRevision":42}}
    ← {"jsonrpc":"2.0","id":7,"result":{...},"meta":{"revision":43,"apiVersion":"..."}}

`meta` is a sibling of `params` rather than inside it because operation schemas are `additionalProperties:false` and would reject `expectedRevision` as unknown. Replies mirror that: `result` is the operation's output verbatim. Folding meta into the result breaks on the first operation that doesn't return one — `tracks.list` answers with a bare array — and wrapping only those would make the reply shape depend on which operation was called. Failures put the revision in `error.data`, so a client that lost an optimistic-concurrency race learns the real revision in the message that rejects its write.

## Tests

21 Catch2 cases over real loopback sockets (auth, Origin, JSON-RPC error mapping, connection cap, oversized frame, shutdown, token lifecycle) and 4 `juce::UnitTest` cases against the live facade, where a create over the wire produces a track `TrackManager` can be asked about by id. The live ones run each request on a worker thread while pumping the message loop — dispatch hops to the message thread, so a blocking read on it would wait for a handler that cannot run.

Suite: 2050 passed, 13 skipped, 0 failed. The trailing `juce_Timer.cpp:99` assertion is pre-existing and reproduces with all remote tests excluded.

Two bugs the tests caught, both worth naming:

- `bind_to_any_port(host, socket_flags)` takes socket flags second, not a port — a configured port was silently ignored and passed as flags.
- The token file came out `0644`. `replaceWithText` writes a temp file and renames it over the target, so the new inode arrives with default permissions and silently undoes the `chmod`. Now written through a `FileOutputStream` into the already-restricted file.

## Notes for review

- The frame cap is a compile-time constant because it governs how much is read into memory before a handler sees anything; enforcing it only in the handler would mean buffering 16 MB of a frame we intend to reject.
- cpp-httplib's `*_IF_AVAILABLE` options default ON and link whatever OpenSSL/zlib/Brotli/zstd is installed. Forced off, so builds don't differ per machine.
- WebSocket support is newer in cpp-httplib than in Beast. Mitigated by the threat model — loopback, token-gated, hard frame cap — but it is the one axis where the chosen option is weaker than the rejected one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

