### PR TITLE
Native engine: what a track plays, resolved (#2034)

### DIFF
--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -262,8 +262,18 @@ juce_add_binary_data(MagdaAssets
 add_library(magda_types STATIC
     core/ParameterUtils.cpp
     core/DeviceState.cpp
+    # Clip placement rules (#2003). Pure, beat domain, no manager: they answer
+    # against a lane of clips, which is what lets the arrangement ask about a
+    # drag it has not committed and the native engine's clip snapshot ask with
+    # no ClipManager at all (#2034). They live here rather than in magda_daw so
+    # the engine links a leaf instead of the whole DAW.
+    core/ClipOcclusion.cpp
+    core/ClipFades.cpp
     # value-type headers (listed to document the leaf's surface)
     core/TypeIds.hpp
+    core/ClipInfo.hpp
+    core/ClipOcclusion.hpp
+    core/ClipFades.hpp
     core/TechnicalText.hpp
     core/ChainNodePath.hpp
     core/ControlTarget.hpp
@@ -277,11 +287,15 @@ add_library(magda_types STATIC
     core/TempoUtils.hpp
 )
 target_compile_features(magda_types PUBLIC cxx_std_20)
+# juce_graphics as well as juce_core: ClipInfo names juce::Colour. Headers and
+# defines only, on the same terms as juce_core above.
 target_include_directories(magda_types
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}  # dependents resolve "core/<type>.hpp"
-    PRIVATE $<TARGET_PROPERTY:juce::juce_core,INTERFACE_INCLUDE_DIRECTORIES>)
+    PRIVATE $<TARGET_PROPERTY:juce::juce_core,INTERFACE_INCLUDE_DIRECTORIES>
+            $<TARGET_PROPERTY:juce::juce_graphics,INTERFACE_INCLUDE_DIRECTORIES>)
 target_compile_definitions(magda_types
-    PRIVATE $<TARGET_PROPERTY:juce::juce_core,INTERFACE_COMPILE_DEFINITIONS>)
+    PRIVATE $<TARGET_PROPERTY:juce::juce_core,INTERFACE_COMPILE_DEFINITIONS>
+            $<TARGET_PROPERTY:juce::juce_graphics,INTERFACE_COMPILE_DEFINITIONS>)
 
 # Core library — populated by per-subdir CMakeLists.txt below.
 add_library(magda_daw STATIC

--- a/magda/daw/core/CMakeLists.txt
+++ b/magda/daw/core/CMakeLists.txt
@@ -19,7 +19,6 @@ target_sources(magda_daw PRIVATE
     TrackManagerDevices.cpp
     ModulatorEngine.cpp
     ClipManager.cpp
-    ClipOcclusion.cpp
     SourcePool.cpp
     ChordProgressionConverter.cpp
     SessionLaunchService.cpp

--- a/magda/daw/core/ClipFades.cpp
+++ b/magda/daw/core/ClipFades.cpp
@@ -1,0 +1,163 @@
+#include "ClipFades.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "ClipOcclusion.hpp"
+#include "TempoUtils.hpp"
+
+namespace magda {
+
+namespace {
+
+// Placements land on exact beats often enough that "starts at the same beat"
+// has to be a real case, not a float coincidence.
+constexpr double kBeatTol = 1e-6;
+
+std::vector<const ClipInfo*> laneView(const std::vector<ClipInfo>& clips) {
+    std::vector<const ClipInfo*> lane;
+    lane.reserve(clips.size());
+    for (const auto& clip : clips)
+        lane.push_back(&clip);
+    return lane;
+}
+
+}  // namespace
+
+std::optional<CrossfadeInfo> crossfadeAtStartOf(const ClipInfo& clip,
+                                                const std::vector<const ClipInfo*>& lane) {
+    if (clip.view != ClipView::Arrangement || !clip.isAudio() || !clip.autoCrossfade)
+        return std::nullopt;
+
+    const double startB = clip.placement.startBeat;
+    const double endB = clip.placement.endBeat();
+
+    // The clip on the LEFT of this one: it starts first and its tail reaches
+    // over this clip's start edge, so this clip is the one arriving and draws
+    // the fade IN. One fade per clip per overlap - the pair's other curve
+    // belongs to the other clip (#2003).
+    //
+    // Its own AUTO-XFADE is not asked for: the flag is this clip's promise
+    // about its own edge, so a clip fades into a neighbour that hard-cuts just
+    // the same. What IS asked for is that the overlap plays both - fading into
+    // a clip that has been silenced under this one is a dip, not a fade.
+    const ClipInfo* best = nullptr;
+    for (const auto* other : lane) {
+        if (other->id == clip.id || other->view != ClipView::Arrangement ||
+            other->trackId != clip.trackId || !other->isAudio() ||
+            !overlapPlaysThrough(clip, *other))
+            continue;
+        const double oStart = other->placement.startBeat;
+        const double oEnd = other->placement.endBeat();
+        if (!(oEnd > startB))
+            continue;
+        // Starts before this one - or on the very same beat, where the clip on
+        // top is the one arriving.
+        const bool startsFirst =
+            oStart < startB - kBeatTol ||
+            (std::abs(oStart - startB) <= kBeatTol && clipSitsBelow(*other, clip));
+        if (startsFirst) {
+            if (!best || oEnd > best->placement.endBeat())
+                best = other;
+        }
+    }
+    if (!best)
+        return std::nullopt;
+    return CrossfadeInfo{best->id, clip.id, startB, std::min(best->placement.endBeat(), endB)};
+}
+
+std::optional<CrossfadeInfo> crossfadeAtEndOf(const ClipInfo& clip,
+                                              const std::vector<const ClipInfo*>& lane) {
+    if (clip.view != ClipView::Arrangement || !clip.isAudio() || !clip.autoCrossfade)
+        return std::nullopt;
+
+    const double startB = clip.placement.startBeat;
+    const double endB = clip.placement.endBeat();
+
+    // The mirror: the clip on the RIGHT, arriving over this clip's end edge, so
+    // this clip is the one leaving and draws the fade OUT. A clip that swallows
+    // another is not on its right - it started first - so a swallowed clip
+    // fades in and holds, rather than fading in and back out of itself.
+    const ClipInfo* best = nullptr;
+    for (const auto* other : lane) {
+        if (other->id == clip.id || other->view != ClipView::Arrangement ||
+            other->trackId != clip.trackId || !other->isAudio() ||
+            !overlapPlaysThrough(clip, *other))
+            continue;
+        const double oStart = other->placement.startBeat;
+        const double oEnd = other->placement.endBeat();
+        if (!(oStart < endB) ||
+            !(oStart > startB + kBeatTol ||
+              (std::abs(oStart - startB) <= kBeatTol && clipSitsBelow(clip, *other))))
+            continue;
+        // Runs past this clip's end, or ends on the very same beat.
+        if (oEnd > endB - kBeatTol) {
+            if (!best || oStart < best->placement.startBeat)
+                best = other;
+        }
+    }
+    if (!best)
+        return std::nullopt;
+    return CrossfadeInfo{clip.id, best->id, std::max(best->placement.startBeat, startB), endB};
+}
+
+std::optional<CrossfadeInfo> crossfadeAtStartIn(const std::vector<ClipInfo>& lane, ClipId clipId) {
+    for (const auto& clip : lane) {
+        if (clip.id == clipId)
+            return crossfadeAtStartOf(clip, laneView(lane));
+    }
+    return std::nullopt;
+}
+
+std::optional<CrossfadeInfo> crossfadeAtEndIn(const std::vector<ClipInfo>& lane, ClipId clipId) {
+    for (const auto& clip : lane) {
+        if (clip.id == clipId)
+            return crossfadeAtEndOf(clip, laneView(lane));
+    }
+    return std::nullopt;
+}
+
+EffectiveFades effectiveFadesOf(const ClipInfo& clip, const std::vector<const ClipInfo*>& lane,
+                                double bpm) {
+    EffectiveFades fades;
+    if (!clip.isAudio())
+        return fades;
+
+    fades.fadeInSeconds = audioEventRef(clip).fadeInSeconds;
+    fades.fadeOutSeconds = audioEventRef(clip).fadeOutSeconds;
+    if (clip.view != ClipView::Arrangement || !isValidBpm(bpm))
+        return fades;
+
+    const double secondsPerBeat = 60.0 / bpm;
+    if (auto xf = crossfadeAtStartOf(clip, lane)) {
+        fades.xfIn = xf;
+        fades.fadeInSeconds = xf->lengthBeats() * secondsPerBeat;
+    }
+    if (auto xf = crossfadeAtEndOf(clip, lane)) {
+        fades.xfOut = xf;
+        fades.fadeOutSeconds = xf->lengthBeats() * secondsPerBeat;
+    }
+
+    // A short clip with a neighbour on each side can be asked for a fade-in and
+    // a fade-out that together outrun it. Scale them to fit, the same clamp TE
+    // applies, so the curve drawn is the curve played.
+    const double lengthSeconds = clip.placement.lengthBeats * secondsPerBeat;
+    const double total = fades.fadeInSeconds + fades.fadeOutSeconds;
+    if (lengthSeconds > 0.0 && total > lengthSeconds) {
+        const double scale = lengthSeconds / total;
+        fades.fadeInSeconds *= scale;
+        fades.fadeOutSeconds *= scale;
+    }
+
+    return fades;
+}
+
+EffectiveFades effectiveFadesIn(const std::vector<ClipInfo>& lane, ClipId clipId, double bpm) {
+    for (const auto& clip : lane) {
+        if (clip.id == clipId)
+            return effectiveFadesOf(clip, laneView(lane), bpm);
+    }
+    return {};
+}
+
+}  // namespace magda

--- a/magda/daw/core/ClipFades.hpp
+++ b/magda/daw/core/ClipFades.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include "ClipInfo.hpp"
+
+/**
+ * @file ClipFades.hpp
+ * @brief The fades a clip actually plays with, once its neighbours are known.
+ *
+ * A clip's own fade lengths are what it plays only until something overlaps it.
+ * An overlap that plays both clips (#2003) replaces the edge it covers with a
+ * crossfade the length of the overlap, and a clip short enough to be asked for
+ * more fade than it has length gets both scaled to fit. Every reader that draws
+ * or plays a fade has to agree on the result, so it is computed in one place.
+ *
+ * Pure, beat domain, no manager and no engine: it answers against whatever lane
+ * it is handed, which is what lets a drag ask about the arrangement it is about
+ * to make while the mouse is still down, and lets the native engine's clip
+ * snapshot ask about the committed one (#2034).
+ */
+
+namespace magda {
+
+/**
+ * @brief An overlap between two clips that both play, shaped as a crossfade.
+ *
+ * The earlier clip fades out across it, the later one fades in: one curve per
+ * clip, and each clip owns its own.
+ */
+struct CrossfadeInfo {
+    ClipId leftClipId = INVALID_CLIP_ID;   // earlier clip (fades out)
+    ClipId rightClipId = INVALID_CLIP_ID;  // later clip (fades in)
+    double startBeat = 0.0;                // overlap start (right clip's start)
+    double endBeat = 0.0;                  // overlap end (left clip's end)
+
+    double lengthBeats() const {
+        return endBeat - startBeat;
+    }
+};
+
+/**
+ * @brief What a clip's two edges fade over, and why.
+ *
+ * The seconds are what plays. The two optionals say which of them came from an
+ * overlap rather than from the clip's own fade lengths, which is what the lane
+ * draws and what the drag handles grab.
+ */
+struct EffectiveFades {
+    double fadeInSeconds = 0.0;
+    double fadeOutSeconds = 0.0;
+    std::optional<CrossfadeInfo> xfIn;   // overlap covering the start edge
+    std::optional<CrossfadeInfo> xfOut;  // overlap covering the end edge
+};
+
+/// The crossfade covering this clip's start edge, if any. Only answers for an
+/// overlap that qualifies: both clips audio and in the arrangement, this clip's
+/// autoCrossfade on, and the overlap playing both.
+std::optional<CrossfadeInfo> crossfadeAtStartOf(const ClipInfo& clip,
+                                                const std::vector<const ClipInfo*>& lane);
+
+/// The mirror at the end edge.
+std::optional<CrossfadeInfo> crossfadeAtEndOf(const ClipInfo& clip,
+                                              const std::vector<const ClipInfo*>& lane);
+
+/// The same two queries against a lane held by value, which is what a drag
+/// preview and a snapshot compile both have.
+std::optional<CrossfadeInfo> crossfadeAtStartIn(const std::vector<ClipInfo>& lane, ClipId clipId);
+std::optional<CrossfadeInfo> crossfadeAtEndIn(const std::vector<ClipInfo>& lane, ClipId clipId);
+
+/**
+ * @brief The fades @p clip plays with on @p lane at @p bpm.
+ *
+ * An overlap that covers an edge replaces that edge's fade with the length of
+ * the overlap. Whatever the two come to, they are scaled to fit inside the clip
+ * when they would together outrun it, which is the clamp the incumbent engine
+ * applies, so the curve drawn is the curve played.
+ */
+EffectiveFades effectiveFadesOf(const ClipInfo& clip, const std::vector<const ClipInfo*>& lane,
+                                double bpm);
+EffectiveFades effectiveFadesIn(const std::vector<ClipInfo>& lane, ClipId clipId, double bpm);
+
+}  // namespace magda

--- a/magda/daw/core/ClipManager.cpp
+++ b/magda/daw/core/ClipManager.cpp
@@ -2328,119 +2328,14 @@ void ClipManager::setLaunchFadeSamples(ClipId clipId, int samples) {
 // clip, so an overlap can never degenerate into full containment.
 static constexpr double kCrossfadeEdgeGuardBeats = 1e-3;
 
-// Placements land on exact beats often enough that "starts at the same beat"
-// has to be a real case, not a float coincidence.
-static constexpr double kBeatTol = 1e-6;
-
-namespace {
-
-/// Both crossfade queries answer the same question against whatever set of
-/// clips they are given: the committed lane, or a previewed one mid-drag.
-std::optional<ClipManager::CrossfadeInfo> crossfadeAtStartOf(
-    const ClipInfo& clip, const std::vector<const ClipInfo*>& lane) {
-    if (clip.view != ClipView::Arrangement || !clip.isAudio() || !clip.autoCrossfade)
-        return std::nullopt;
-
-    const double startB = clip.placement.startBeat;
-    const double endB = clip.placement.endBeat();
-
-    // The clip on the LEFT of this one: it starts first and its tail reaches
-    // over this clip's start edge, so this clip is the one arriving and draws
-    // the fade IN. One fade per clip per overlap — the pair's other curve
-    // belongs to the other clip (#2003).
-    //
-    // Its own AUTO-XFADE is not asked for: the flag is this clip's promise
-    // about its own edge, so a clip fades into a neighbour that hard-cuts just
-    // the same. What IS asked for is that the overlap plays both — fading into
-    // a clip that has been silenced under this one is a dip, not a fade.
-    const ClipInfo* best = nullptr;
-    for (const auto* other : lane) {
-        if (other->id == clip.id || other->view != ClipView::Arrangement ||
-            other->trackId != clip.trackId || !other->isAudio() ||
-            !overlapPlaysThrough(clip, *other))
-            continue;
-        const double oStart = other->placement.startBeat;
-        const double oEnd = other->placement.endBeat();
-        if (!(oEnd > startB))
-            continue;
-        // Starts before this one — or on the very same beat, where the clip on
-        // top is the one arriving.
-        const bool startsFirst =
-            oStart < startB - kBeatTol ||
-            (std::abs(oStart - startB) <= kBeatTol && clipSitsBelow(*other, clip));
-        if (startsFirst) {
-            if (!best || oEnd > best->placement.endBeat())
-                best = other;
-        }
-    }
-    if (!best)
-        return std::nullopt;
-    return ClipManager::CrossfadeInfo{best->id, clip.id, startB,
-                                      std::min(best->placement.endBeat(), endB)};
-}
-
-std::optional<ClipManager::CrossfadeInfo> crossfadeAtEndOf(
-    const ClipInfo& clip, const std::vector<const ClipInfo*>& lane) {
-    if (clip.view != ClipView::Arrangement || !clip.isAudio() || !clip.autoCrossfade)
-        return std::nullopt;
-
-    const double startB = clip.placement.startBeat;
-    const double endB = clip.placement.endBeat();
-
-    // The mirror: the clip on the RIGHT, arriving over this clip's end edge, so
-    // this clip is the one leaving and draws the fade OUT. A clip that swallows
-    // another is not on its right — it started first — so a swallowed clip
-    // fades in and holds, rather than fading in and back out of itself.
-    const ClipInfo* best = nullptr;
-    for (const auto* other : lane) {
-        if (other->id == clip.id || other->view != ClipView::Arrangement ||
-            other->trackId != clip.trackId || !other->isAudio() ||
-            !overlapPlaysThrough(clip, *other))
-            continue;
-        const double oStart = other->placement.startBeat;
-        const double oEnd = other->placement.endBeat();
-        if (!(oStart < endB) ||
-            !(oStart > startB + kBeatTol ||
-              (std::abs(oStart - startB) <= kBeatTol && clipSitsBelow(clip, *other))))
-            continue;
-        // Runs past this clip's end, or ends on the very same beat.
-        if (oEnd > endB - kBeatTol) {
-            if (!best || oStart < best->placement.startBeat)
-                best = other;
-        }
-    }
-    if (!best)
-        return std::nullopt;
-    return ClipManager::CrossfadeInfo{clip.id, best->id,
-                                      std::max(best->placement.startBeat, startB), endB};
-}
-
-std::vector<const ClipInfo*> laneView(const std::vector<ClipInfo>& clips) {
-    std::vector<const ClipInfo*> lane;
-    lane.reserve(clips.size());
-    for (const auto& clip : clips)
-        lane.push_back(&clip);
-    return lane;
-}
-
-}  // namespace
-
 std::optional<ClipManager::CrossfadeInfo> ClipManager::crossfadeAtStartIn(
     const std::vector<ClipInfo>& lane, ClipId clipId) {
-    for (const auto& clip : lane) {
-        if (clip.id == clipId)
-            return crossfadeAtStartOf(clip, laneView(lane));
-    }
-    return std::nullopt;
+    return ::magda::crossfadeAtStartIn(lane, clipId);
 }
 
 std::optional<ClipManager::CrossfadeInfo> ClipManager::crossfadeAtEndIn(
     const std::vector<ClipInfo>& lane, ClipId clipId) {
-    for (const auto& clip : lane) {
-        if (clip.id == clipId)
-            return crossfadeAtEndOf(clip, laneView(lane));
-    }
-    return std::nullopt;
+    return ::magda::crossfadeAtEndIn(lane, clipId);
 }
 
 std::vector<ClipInfo> ClipManager::arrangementLane(TrackId trackId) const {
@@ -2452,52 +2347,9 @@ std::vector<ClipInfo> ClipManager::arrangementLane(TrackId trackId) const {
     return lane;
 }
 
-namespace {
-
-ClipManager::EffectiveFades effectiveFadesOf(const ClipInfo& clip,
-                                             const std::vector<const ClipInfo*>& lane, double bpm) {
-    ClipManager::EffectiveFades fades;
-    if (!clip.isAudio())
-        return fades;
-
-    fades.fadeInSeconds = audioEventRef(clip).fadeInSeconds;
-    fades.fadeOutSeconds = audioEventRef(clip).fadeOutSeconds;
-    if (clip.view != ClipView::Arrangement || !isValidBpm(bpm))
-        return fades;
-
-    const double secondsPerBeat = 60.0 / bpm;
-    if (auto xf = crossfadeAtStartOf(clip, lane)) {
-        fades.xfIn = xf;
-        fades.fadeInSeconds = xf->lengthBeats() * secondsPerBeat;
-    }
-    if (auto xf = crossfadeAtEndOf(clip, lane)) {
-        fades.xfOut = xf;
-        fades.fadeOutSeconds = xf->lengthBeats() * secondsPerBeat;
-    }
-
-    // A short clip with a neighbour on each side can be asked for a fade-in and
-    // a fade-out that together outrun it. Scale them to fit, the same clamp TE
-    // applies, so the curve drawn is the curve played.
-    const double lengthSeconds = clip.placement.lengthBeats * secondsPerBeat;
-    const double total = fades.fadeInSeconds + fades.fadeOutSeconds;
-    if (lengthSeconds > 0.0 && total > lengthSeconds) {
-        const double scale = lengthSeconds / total;
-        fades.fadeInSeconds *= scale;
-        fades.fadeOutSeconds *= scale;
-    }
-
-    return fades;
-}
-
-}  // namespace
-
 ClipManager::EffectiveFades ClipManager::effectiveFadesIn(const std::vector<ClipInfo>& lane,
                                                           ClipId clipId, double bpm) {
-    for (const auto& clip : lane) {
-        if (clip.id == clipId)
-            return effectiveFadesOf(clip, laneView(lane), bpm);
-    }
-    return {};
+    return ::magda::effectiveFadesIn(lane, clipId, bpm);
 }
 
 ClipManager::EffectiveFades ClipManager::getEffectiveFades(ClipId clipId, double bpm) const {

--- a/magda/daw/core/ClipManager.hpp
+++ b/magda/daw/core/ClipManager.hpp
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "ClipFades.hpp"
 #include "ClipInfo.hpp"
 #include "ClipOperations.hpp"
 #include "ClipTypes.hpp"
@@ -482,16 +483,13 @@ class ClipManager {
     // field to keep in sync.
     // ========================================================================
 
-    struct CrossfadeInfo {
-        ClipId leftClipId = INVALID_CLIP_ID;   // earlier clip (fades out)
-        ClipId rightClipId = INVALID_CLIP_ID;  // later clip (fades in)
-        double startBeat = 0.0;                // overlap start (right clip's start)
-        double endBeat = 0.0;                  // overlap end (left clip's end)
-
-        double lengthBeats() const {
-            return endBeat - startBeat;
-        }
-    };
+    /// The queries themselves live in ClipFades.hpp, on their own, because they
+    /// answer against a lane rather than against the model: the arrangement
+    /// asks about a drag it has not committed, and the native engine's clip
+    /// snapshot asks without a manager at all (#2034). These names stay so the
+    /// call sites that ask the model read as they always did.
+    using CrossfadeInfo = ::magda::CrossfadeInfo;
+    using EffectiveFades = ::magda::EffectiveFades;
 
     /// The crossfade covering this clip's start/end edge, if any. Only
     /// returns a value when the overlap qualifies (both clips audio,
@@ -525,12 +523,6 @@ class ClipManager {
      * @param lane   The clips as they are at this moment, this one included —
      *               the committed lane, or a previewed one mid-drag.
      */
-    struct EffectiveFades {
-        double fadeInSeconds = 0.0;
-        double fadeOutSeconds = 0.0;
-        std::optional<CrossfadeInfo> xfIn;   // overlap covering the start edge
-        std::optional<CrossfadeInfo> xfOut;  // overlap covering the end edge
-    };
     static EffectiveFades effectiveFadesIn(const std::vector<ClipInfo>& lane, ClipId clipId,
                                            double bpm);
 

--- a/magda/daw/core/ClipOcclusion.hpp
+++ b/magda/daw/core/ClipOcclusion.hpp
@@ -32,8 +32,10 @@ struct AudibleSpan {
 
     /// Covers that fall strictly inside the span, in timeline beats — a clip
     /// dropped into the middle of another leaves one. A MIDI clip plays around
-    /// them by dropping the notes that start inside; an audio clip cannot, so
-    /// ClipManager splits audio clips before a hole can reach here.
+    /// them by dropping the notes that start inside. So does an audio clip:
+    /// nothing on a lane is cut, so resolveOverlaps no longer splits one, and
+    /// the native engine's clip snapshot carries the holes through to playback
+    /// (#2034).
     std::vector<BeatRange> silenced;
 
     double endBeat() const {

--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -7,6 +7,13 @@
 # rather than leaving it to review.
 
 add_library(magda_engine STATIC
+    clip/ClipSnapshot.cpp
+    clip/ClipSnapshotCompiler.cpp
+    clip/ClipSnapshotDump.cpp
+    clip/ClipSnapshot.hpp
+    clip/ClipSnapshotCompiler.hpp
+    clip/ClipSnapshotDump.hpp
+    clip/ClipSnapshotFeed.hpp
     plan/RenderPlan.cpp
     plan/PlanCompiler.cpp
     plan/PlanDiff.cpp
@@ -102,7 +109,7 @@ endforeach()
 # Engine. Quoted includes may only reach the model layer ("core/...") or the
 # engine's own headers.
 
-set(MAGDA_ENGINE_ALLOWED_QUOTED_PREFIXES "core/" "plan/" "exec/" "transport/" "io/" "tap/")
+set(MAGDA_ENGINE_ALLOWED_QUOTED_PREFIXES "core/" "clip/" "plan/" "exec/" "transport/" "io/" "tap/")
 
 file(GLOB_RECURSE MAGDA_ENGINE_SOURCES CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"

--- a/magda/engine/clip/ClipSnapshot.cpp
+++ b/magda/engine/clip/ClipSnapshot.cpp
@@ -1,0 +1,16 @@
+#include "clip/ClipSnapshot.hpp"
+
+#include <algorithm>
+
+namespace magda::engine {
+
+const TrackClipPlayback* ClipSnapshot::find(TrackId trackId) const {
+    const auto it = std::lower_bound(
+        tracks.begin(), tracks.end(), trackId,
+        [](const TrackClipPlayback& track, TrackId id) { return track.trackId < id; });
+    if (it == tracks.end() || it->trackId != trackId)
+        return nullptr;
+    return &*it;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipSnapshot.hpp
+++ b/magda/engine/clip/ClipSnapshot.hpp
@@ -14,7 +14,7 @@
  * Clip positions are deliberately not in the render plan (see RenderPlan.hpp):
  * a plan is topology, and moving a clip is not a topology change. Clips reach
  * the audio thread through this instead, swapped in whole the way a plan is, so
- * an edit to a clip never recompiles a plan and never allocates on a callback.
+ * an edit to a clip never recompiles a plan.
  *
  * Resolved is the point of it. Occlusion and crossfades are worked out once, at
  * compile time, by the model functions that already own those rules
@@ -29,7 +29,8 @@
  * are derived here, once, through the tempo map, because a source is handed
  * seconds (ClipPlacement.hpp) and there must not be a second tempo map on the
  * audio thread. The transport publishes both faces of its cursor for the same
- * reason, and the two agree because they come from the same map.
+ * reason; that the two were derived through the same map is what the
+ * fingerprint below is for.
  *
  * Not keyed to a plan. Everything here is keyed by TrackId, so unlike PlanValues
  * it carries no plan fingerprint and a plan swap does not invalidate it. It does
@@ -74,8 +75,9 @@ struct AudioEventPlayback {
     SourceId sourceId = INVALID_SOURCE_ID;
 
     /// Resolved from the source table at compile time, so nothing on the audio
-    /// thread reaches a pool. Empty when the source could not be resolved,
-    /// which is a diagnostic and renders silence.
+    /// thread reaches a pool. Always set in a compiled snapshot: an event whose
+    /// source the table does not hold is dropped with a diagnostic rather than
+    /// carried with nothing to read.
     std::string filePath;
     double sourceSampleRate = 0.0;
     double sourceDurationSeconds = 0.0;

--- a/magda/engine/clip/ClipSnapshot.hpp
+++ b/magda/engine/clip/ClipSnapshot.hpp
@@ -1,0 +1,252 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "core/ClipInfo.hpp"
+#include "core/TypeIds.hpp"
+
+/**
+ * @file ClipSnapshot.hpp
+ * @brief What every track plays, resolved, as one immutable value.
+ *
+ * Clip positions are deliberately not in the render plan (see RenderPlan.hpp):
+ * a plan is topology, and moving a clip is not a topology change. Clips reach
+ * the audio thread through this instead, swapped in whole the way a plan is, so
+ * an edit to a clip never recompiles a plan and never allocates on a callback.
+ *
+ * Resolved is the point of it. Occlusion and crossfades are worked out once, at
+ * compile time, by the model functions that already own those rules
+ * (computeAudibleSpans, effectiveFadesIn), so a `ClipAudio` or `ClipMidi` op
+ * never sees an overlap: it plays a span with fades. An edit recompiles this the
+ * way a structural change recompiles a plan, which is why there is no sync
+ * protocol between two representations of a lane and no state that can go stale
+ * (#2003).
+ *
+ * Both faces of every instant are carried, beats and seconds. Beats are the
+ * model's authority and what auto tempo and warp keep working in; the seconds
+ * are derived here, once, through the tempo map, because a source is handed
+ * seconds (ClipPlacement.hpp) and there must not be a second tempo map on the
+ * audio thread. The transport publishes both faces of its cursor for the same
+ * reason, and the two agree because they come from the same map.
+ *
+ * Not keyed to a plan. Everything here is keyed by TrackId, so unlike PlanValues
+ * it carries no plan fingerprint and a plan swap does not invalidate it. It does
+ * carry the fingerprint of the tempo map its seconds were derived through: a
+ * tempo edit moves every one of them, so a snapshot compiled against another map
+ * is stale in a way nothing downstream could otherwise notice.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief A stretch of timeline, in both domains.
+ *
+ * The seconds are what the ends actually are: a beat span occupies different
+ * wall-clock seconds depending on where it sits on the tempo curve, so the two
+ * ends are converted separately rather than a length being scaled.
+ */
+struct SnapshotSpan {
+    double startBeat = 0.0;
+    double endBeat = 0.0;
+    double startSeconds = 0.0;
+    double endSeconds = 0.0;
+
+    double lengthBeats() const {
+        return endBeat - startBeat;
+    }
+    double lengthSeconds() const {
+        return endSeconds - startSeconds;
+    }
+};
+
+/**
+ * @brief One audio event of a clip, and how its file is to be read.
+ *
+ * The source-domain positions stay in samples at the source's own rate, as the
+ * model holds them: that is what makes a source-BPM reinterpretation leave the
+ * audible region untouched. Converting them is playback's business, and which
+ * conversion depends on the interpretation below.
+ */
+struct AudioEventPlayback {
+    EventId eventId = INVALID_EVENT_ID;
+    SourceId sourceId = INVALID_SOURCE_ID;
+
+    /// Resolved from the source table at compile time, so nothing on the audio
+    /// thread reaches a pool. Empty when the source could not be resolved,
+    /// which is a diagnostic and renders silence.
+    std::string filePath;
+    double sourceSampleRate = 0.0;
+    double sourceDurationSeconds = 0.0;
+
+    /// Where this event sits on the timeline, absolute: the clip's start plus
+    /// the event's own offset.
+    ///
+    /// Not cropped to what the lane leaves audible, deliberately. The anchor
+    /// below is the sample heard at startSeconds, so this is the origin every
+    /// read is derived from; moving it to the audible start would mean
+    /// advancing the anchor with it, and by how much is a question only the
+    /// stretch and warp settings can answer. The clip's span and its silences
+    /// do the cropping, at playback, where that answer exists.
+    SnapshotSpan span;
+
+    // ---- Source domain (samples at the source's own rate) ------------------
+
+    std::int64_t anchorSamples = 0;
+    std::int64_t loopStartSamples = 0;
+    std::int64_t loopLengthSamples = 0;
+
+    /// From the clip: whether the region above repeats to fill the event.
+    bool loopEnabled = false;
+
+    // ---- Interpretation ----------------------------------------------------
+
+    double interpBpm = 0.0;
+    bool autoTempo = false;
+    double speedRatio = 1.0;
+
+    /// What actually runs, not the raw field: a mode left at Off still
+    /// stretches when something else forced a stretcher on
+    /// (AudioEvent::getEffectiveTimeStretchMode). The values are the pinned
+    /// project-file integers in TimeStretchModes.hpp.
+    int timeStretchMode = 0;
+
+    /// Resampling rather than stretching, and only in force when nothing else
+    /// has already forced a stretcher on (AudioEvent::isAnalogPitchActive).
+    bool analogPitch = false;
+
+    bool warpEnabled = false;
+    std::vector<WarpMarker> warpMarkers;
+
+    bool autoPitch = false;
+    int autoPitchMode = 0;
+    float pitchChange = 0.0f;
+    int transpose = 0;
+
+    bool reversed = false;
+    bool leftChannelActive = true;
+    bool rightChannelActive = true;
+
+    /// This event's own trim. The clip's gain sits above it.
+    float gainDb = 0.0f;
+};
+
+/**
+ * @brief One audio clip, as it plays.
+ *
+ * The span is what the lane leaves audible, not the clip's placement, and the
+ * silenced ranges are the holes inside it. Nothing on a lane is cut any more, so
+ * a clip dropped inside another leaves a hole in the middle of an audio clip
+ * rather than splitting it (#2003).
+ */
+struct AudioClipPlayback {
+    ClipId clipId = INVALID_CLIP_ID;
+
+    SnapshotSpan span;
+    std::vector<SnapshotSpan> silenced;
+
+    // ---- Fades, already resolved -------------------------------------------
+    //
+    // What the clip plays with once the lane is known: its own fades, replaced
+    // at either edge by a crossfade the length of the overlap that covers it,
+    // and scaled to fit when the two would together outrun the clip. A
+    // crossfade between two clips is therefore two clips each playing the fade
+    // it was given, and nothing downstream pairs them up.
+
+    double fadeInSeconds = 0.0;
+    double fadeOutSeconds = 0.0;
+    FadeCurve fadeInCurve = FadeCurve::Linear;
+    FadeCurve fadeOutCurve = FadeCurve::Linear;
+
+    /// 0 = gain fade, 1 = speed ramp. A speed ramp is a stretch feature rather
+    /// than a gain one, which is why it travels with the fade.
+    int fadeInBehaviour = 0;
+    int fadeOutBehaviour = 0;
+
+    // ---- Mix ---------------------------------------------------------------
+
+    /// The clip's volume and gain summed, which is how the incumbent applies
+    /// them, in dB. Per-event trim sits under it on the event.
+    float gainDb = 0.0f;
+    float pan = 0.0f;
+
+    /// Ramp on the stopped to playing transition. 0 preserves the leading
+    /// transient.
+    int launchFadeSamples = 0;
+
+    std::vector<AudioEventPlayback> events;
+};
+
+/**
+ * @brief One MIDI clip, as it plays.
+ *
+ * The events are the clip's authoritative lists, which is what a fronted take
+ * or an assembled comp has already been written into: choosing between takes
+ * happens in the model, never here.
+ */
+struct MidiClipPlayback {
+    ClipId clipId = INVALID_CLIP_ID;
+
+    SnapshotSpan span;
+
+    /// A note starting inside one of these does not sound. MIDI plays around a
+    /// hole rather than being cut by it.
+    std::vector<SnapshotSpan> silenced;
+
+    std::vector<MidiNote> notes;
+    std::vector<MidiCCData> cc;
+    std::vector<MidiPitchBendData> pitchBend;
+
+    /// Clip beats, not source samples: a MIDI clip's loop is musical on both
+    /// sides, so it has no seconds face to derive.
+    bool loopEnabled = false;
+    double loopStartBeats = 0.0;
+    double loopLengthBeats = 0.0;
+
+    double offsetBeats = 0.0;      ///< ClipInfo::midiOffset
+    double trimOffsetBeats = 0.0;  ///< ClipInfo::midiTrimOffset
+
+    std::string grooveTemplate;
+    float grooveStrength = 0.0f;
+};
+
+/** Everything one track plays. */
+struct TrackClipPlayback {
+    TrackId trackId = INVALID_TRACK_ID;
+    std::vector<AudioClipPlayback> audio;
+    std::vector<MidiClipPlayback> midi;
+};
+
+/**
+ * @brief The whole arrangement, resolved.
+ *
+ * Tracks are sorted by id and clips within a track by start, so two compiles of
+ * the same model produce the same snapshot, which is what makes it golden
+ * testable and what keeps a dump diff meaningful.
+ */
+struct ClipSnapshot {
+    static constexpr int kVersion = 1;
+
+    int version = kVersion;
+
+    /// The tempo map the seconds were derived through. A snapshot whose
+    /// fingerprint is not the transport's was compiled against a tempo that has
+    /// since changed, and every second in it is wrong by however much the map
+    /// moved.
+    std::uint64_t tempoFingerprint = 0;
+
+    std::vector<TrackClipPlayback> tracks;
+
+    /// Clips the compile could not express, in compile order. Never a silent
+    /// drop: a clip that will not sound says here why. A clip the lane leaves
+    /// inaudible is not one of these, because being covered is not a failure.
+    std::vector<std::string> diagnostics;
+
+    /// The track's playback, or null. A binary search: the audio thread asks
+    /// once per block and the list is sorted, so nothing hashes and nothing
+    /// allocates.
+    const TrackClipPlayback* find(TrackId trackId) const;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipSnapshot.hpp
+++ b/magda/engine/clip/ClipSnapshot.hpp
@@ -132,6 +132,27 @@ struct AudioEventPlayback {
 
     /// This event's own trim. The clip's gain sits above it.
     float gainDb = 0.0f;
+
+    // ---- The event's own fades ---------------------------------------------
+    //
+    // Its own, and not the clip's. The pair on the clip is what its EDGES play,
+    // resolved against the lane; these are what this event fades with inside
+    // it. For the event at a clip edge the two are the same fade before and
+    // after resolution, so playback shapes that edge once, with the clip's.
+    //
+    // They are carried per event because fades are per event in the model, and
+    // a clip holding several of them (#1901) has fades the clip-level pair
+    // cannot express: promoting only the primary event's would lose every
+    // other event's.
+
+    double fadeInSeconds = 0.0;
+    double fadeOutSeconds = 0.0;
+    FadeCurve fadeInCurve = FadeCurve::Linear;
+    FadeCurve fadeOutCurve = FadeCurve::Linear;
+
+    /// 0 = gain fade, 1 = speed ramp, as on the clip.
+    int fadeInBehaviour = 0;
+    int fadeOutBehaviour = 0;
 };
 
 /**

--- a/magda/engine/clip/ClipSnapshotCompiler.cpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.cpp
@@ -51,8 +51,14 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
         TrackClipPlayback track;
         track.trackId = lane.trackId;
 
-        const auto audibleSpans = computeAudibleSpans(lane.clips);
-
+        // Rejected before anything is resolved, not while resolving. Occlusion
+        // and the crossfade queries take every clip in the lane they are given
+        // at face value: neither checks the view or the track, so a session
+        // clip or one belonging to somewhere else would cover its neighbours
+        // for as long as it sat in the lane, and diagnosing it afterwards would
+        // not give back what it had already silenced.
+        std::vector<ClipInfo> arrangement;
+        arrangement.reserve(lane.clips.size());
         for (const auto& clip : lane.clips) {
             const auto label = clipLabel(lane.trackId, clip.id);
 
@@ -67,6 +73,14 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
                     label + "is a session clip in an arrangement lane, it is not played here");
                 continue;
             }
+
+            arrangement.push_back(clip);
+        }
+
+        const auto audibleSpans = computeAudibleSpans(arrangement);
+
+        for (const auto& clip : arrangement) {
+            const auto label = clipLabel(lane.trackId, clip.id);
 
             // Disabled by hand (#1736). Occlusion already treats it as covering
             // nothing; that it plays nothing itself is decided here.
@@ -104,44 +118,62 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
                 continue;
             }
 
+            if (clip.events().empty()) {
+                snapshot.diagnostics.push_back(label +
+                                               "is an audio clip with no events, it plays nothing");
+                continue;
+            }
+
             AudioClipPlayback audio;
             audio.clipId = clip.id;
             audio.span = span;
             audio.silenced = std::move(silenced);
 
-            // Straight from the model, at the tempo where the clip starts: the
-            // arrangement draws its curves from this same call, and a fade
-            // played differently from the one drawn is the bug the shared rule
-            // exists to prevent.
+            // The rule is the model's, the seconds are this map's. Which edge a
+            // crossfade covers, and over which beats, comes from
+            // effectiveFadesIn; how long those beats last is then asked of the
+            // tempo map, like every other span here, rather than of one bpm
+            // reading. Two clips that start under different tempos would
+            // otherwise be told different lengths for the one overlap they
+            // share, and neither would match the spans it sits inside.
+            //
+            // The clamp is the model's too, applied to the exact seconds: a
+            // clip too short for both its fades scales them to fit rather than
+            // playing fades that outrun it.
             const auto fades =
-                effectiveFadesIn(lane.clips, clip.id, tempoMap.bpmAt(clip.placement.startBeat));
-            audio.fadeInSeconds = fades.fadeInSeconds;
-            audio.fadeOutSeconds = fades.fadeOutSeconds;
-
+                effectiveFadesIn(arrangement, clip.id, tempoMap.bpmAt(clip.placement.startBeat));
             const auto& primary = audioEventRef(clip);
+
+            const auto crossfadeSeconds = [&tempoMap](const CrossfadeInfo& overlap) {
+                return tempoMap.beatToTime(overlap.endBeat) -
+                       tempoMap.beatToTime(overlap.startBeat);
+            };
+            double fadeIn = fades.xfIn ? crossfadeSeconds(*fades.xfIn) : primary.fadeInSeconds;
+            double fadeOut = fades.xfOut ? crossfadeSeconds(*fades.xfOut) : primary.fadeOutSeconds;
+
+            const double clipSeconds = tempoMap.beatToTime(clip.placement.endBeat()) -
+                                       tempoMap.beatToTime(clip.placement.startBeat);
+            if (const double total = fadeIn + fadeOut; clipSeconds > 0.0 && total > clipSeconds) {
+                const double scale = clipSeconds / total;
+                fadeIn *= scale;
+                fadeOut *= scale;
+            }
+
+            audio.fadeInSeconds = fadeIn;
+            audio.fadeOutSeconds = fadeOut;
+
+            // The clip's edges are the primary event's edges, so they carry its
+            // curves. A curve that is not one is reported once, below, where
+            // every event is checked rather than only this one.
             bool curveValid = true;
             audio.fadeInCurve = curveFrom(primary.fadeInType, curveValid);
-            if (!curveValid)
-                snapshot.diagnostics.push_back(label + "fade-in curve " +
-                                               std::to_string(primary.fadeInType) +
-                                               " is not a curve, it fades linearly");
             audio.fadeOutCurve = curveFrom(primary.fadeOutType, curveValid);
-            if (!curveValid)
-                snapshot.diagnostics.push_back(label + "fade-out curve " +
-                                               std::to_string(primary.fadeOutType) +
-                                               " is not a curve, it fades linearly");
             audio.fadeInBehaviour = primary.fadeInBehaviour;
             audio.fadeOutBehaviour = primary.fadeOutBehaviour;
 
             audio.gainDb = clip.volumeDB + clip.gainDB;
             audio.pan = clip.pan;
             audio.launchFadeSamples = clip.launchFadeSamples;
-
-            if (clip.events().empty()) {
-                snapshot.diagnostics.push_back(label +
-                                               "is an audio clip with no events, it plays nothing");
-                continue;
-            }
 
             for (const auto& event : clip.events()) {
                 const auto source = sourceById.find(event.sourceId);
@@ -193,8 +225,34 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
                 playback.rightChannelActive = event.rightChannelActive;
                 playback.gainDb = event.gainDB;
 
+                // The event's own, unresolved. The clip's edges play the
+                // resolved pair above; an event inside a clip holding several
+                // of them fades with these, and promoting only the primary
+                // event's would lose every other event's.
+                playback.fadeInSeconds = event.fadeInSeconds;
+                playback.fadeOutSeconds = event.fadeOutSeconds;
+                playback.fadeInCurve = curveFrom(event.fadeInType, curveValid);
+                if (!curveValid)
+                    snapshot.diagnostics.push_back(
+                        label + "event " + std::to_string(event.id) + " fade-in curve " +
+                        std::to_string(event.fadeInType) + " is not a curve, it fades linearly");
+                playback.fadeOutCurve = curveFrom(event.fadeOutType, curveValid);
+                if (!curveValid)
+                    snapshot.diagnostics.push_back(
+                        label + "event " + std::to_string(event.id) + " fade-out curve " +
+                        std::to_string(event.fadeOutType) + " is not a curve, it fades linearly");
+                playback.fadeInBehaviour = event.fadeInBehaviour;
+                playback.fadeOutBehaviour = event.fadeOutBehaviour;
+
                 audio.events.push_back(std::move(playback));
             }
+
+            // Every event it had names something that cannot be read, so there
+            // is nothing to play and nothing to allocate a voice for. Each one
+            // was reported as it was dropped; a clip whose events all went that
+            // way leaves the snapshot with them.
+            if (audio.events.empty())
+                continue;
 
             track.audio.push_back(std::move(audio));
         }

--- a/magda/engine/clip/ClipSnapshotCompiler.cpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.cpp
@@ -1,0 +1,226 @@
+#include "clip/ClipSnapshotCompiler.hpp"
+
+#include <algorithm>
+#include <unordered_map>
+
+#include "core/ClipFades.hpp"
+#include "core/ClipOcclusion.hpp"
+
+namespace magda::engine {
+
+namespace {
+
+std::string clipLabel(TrackId trackId, ClipId clipId) {
+    return "track " + std::to_string(trackId) + " clip " + std::to_string(clipId) + ": ";
+}
+
+/// A fade curve is a pinned project-file integer, so a value outside the four
+/// that exist came from a file nothing in MAGDA wrote. Linear is what an
+/// unreadable curve plays as, and it is reported rather than assumed.
+FadeCurve curveFrom(int stored, bool& valid) {
+    valid = stored >= static_cast<int>(FadeCurve::Linear) &&
+            stored <= static_cast<int>(FadeCurve::SCurve);
+    return valid ? static_cast<FadeCurve>(stored) : FadeCurve::Linear;
+}
+
+SnapshotSpan spanFromBeats(double startBeat, double endBeat, const TempoMap& tempoMap) {
+    SnapshotSpan span;
+    span.startBeat = startBeat;
+    span.endBeat = endBeat;
+    // Both ends converted, never a length scaled: a beat span occupies
+    // different seconds depending on where it sits on the tempo curve.
+    span.startSeconds = tempoMap.beatToTime(startBeat);
+    span.endSeconds = tempoMap.beatToTime(endBeat);
+    return span;
+}
+
+}  // namespace
+
+ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
+                                 const std::vector<ClipSourceInfo>& sources,
+                                 const TempoMap& tempoMap) {
+    ClipSnapshot snapshot;
+    snapshot.tempoFingerprint = tempoMap.fingerprint();
+
+    std::unordered_map<SourceId, const ClipSourceInfo*> sourceById;
+    sourceById.reserve(sources.size());
+    for (const auto& source : sources)
+        sourceById[source.id] = &source;
+
+    for (const auto& lane : lanes) {
+        TrackClipPlayback track;
+        track.trackId = lane.trackId;
+
+        const auto audibleSpans = computeAudibleSpans(lane.clips);
+
+        for (const auto& clip : lane.clips) {
+            const auto label = clipLabel(lane.trackId, clip.id);
+
+            if (clip.trackId != lane.trackId) {
+                snapshot.diagnostics.push_back(label + "belongs to track " +
+                                               std::to_string(clip.trackId) +
+                                               ", it is not played on this lane");
+                continue;
+            }
+            if (clip.view != ClipView::Arrangement) {
+                snapshot.diagnostics.push_back(
+                    label + "is a session clip in an arrangement lane, it is not played here");
+                continue;
+            }
+
+            // Disabled by hand (#1736). Occlusion already treats it as covering
+            // nothing; that it plays nothing itself is decided here.
+            if (!clip.enabled)
+                continue;
+
+            const auto found = audibleSpans.find(clip.id);
+            if (found == audibleSpans.end() || !found->second.audible)
+                continue;  // covered end to end, which is what covering means
+
+            const auto& audible = found->second;
+            const auto span = spanFromBeats(audible.startBeat, audible.endBeat(), tempoMap);
+
+            std::vector<SnapshotSpan> silenced;
+            silenced.reserve(audible.silenced.size());
+            for (const auto& hole : audible.silenced)
+                silenced.push_back(spanFromBeats(hole.start.value, hole.end.value, tempoMap));
+
+            if (clip.isMidi()) {
+                MidiClipPlayback midi;
+                midi.clipId = clip.id;
+                midi.span = span;
+                midi.silenced = std::move(silenced);
+                midi.notes = clip.midiNotes;
+                midi.cc = clip.midiCCData;
+                midi.pitchBend = clip.midiPitchBendData;
+                midi.loopEnabled = clip.loopEnabled;
+                midi.loopStartBeats = clip.loopStartBeats;
+                midi.loopLengthBeats = clip.loopLengthBeats;
+                midi.offsetBeats = clip.midiOffset;
+                midi.trimOffsetBeats = clip.midiTrimOffset;
+                midi.grooveTemplate = clip.grooveTemplate.toStdString();
+                midi.grooveStrength = clip.grooveStrength;
+                track.midi.push_back(std::move(midi));
+                continue;
+            }
+
+            AudioClipPlayback audio;
+            audio.clipId = clip.id;
+            audio.span = span;
+            audio.silenced = std::move(silenced);
+
+            // Straight from the model, at the tempo where the clip starts: the
+            // arrangement draws its curves from this same call, and a fade
+            // played differently from the one drawn is the bug the shared rule
+            // exists to prevent.
+            const auto fades =
+                effectiveFadesIn(lane.clips, clip.id, tempoMap.bpmAt(clip.placement.startBeat));
+            audio.fadeInSeconds = fades.fadeInSeconds;
+            audio.fadeOutSeconds = fades.fadeOutSeconds;
+
+            const auto& primary = audioEventRef(clip);
+            bool curveValid = true;
+            audio.fadeInCurve = curveFrom(primary.fadeInType, curveValid);
+            if (!curveValid)
+                snapshot.diagnostics.push_back(label + "fade-in curve " +
+                                               std::to_string(primary.fadeInType) +
+                                               " is not a curve, it fades linearly");
+            audio.fadeOutCurve = curveFrom(primary.fadeOutType, curveValid);
+            if (!curveValid)
+                snapshot.diagnostics.push_back(label + "fade-out curve " +
+                                               std::to_string(primary.fadeOutType) +
+                                               " is not a curve, it fades linearly");
+            audio.fadeInBehaviour = primary.fadeInBehaviour;
+            audio.fadeOutBehaviour = primary.fadeOutBehaviour;
+
+            audio.gainDb = clip.volumeDB + clip.gainDB;
+            audio.pan = clip.pan;
+            audio.launchFadeSamples = clip.launchFadeSamples;
+
+            if (clip.events().empty()) {
+                snapshot.diagnostics.push_back(label +
+                                               "is an audio clip with no events, it plays nothing");
+                continue;
+            }
+
+            for (const auto& event : clip.events()) {
+                const auto source = sourceById.find(event.sourceId);
+                if (source == sourceById.end()) {
+                    snapshot.diagnostics.push_back(
+                        label + "event " + std::to_string(event.id) + " names source " +
+                        std::to_string(event.sourceId) +
+                        ", which is not in the source table, so it plays nothing");
+                    continue;
+                }
+                if (!(source->second->sampleRate > 0.0)) {
+                    snapshot.diagnostics.push_back(
+                        label + "event " + std::to_string(event.id) + " names source " +
+                        std::to_string(event.sourceId) +
+                        ", whose sample rate is unknown, so it plays nothing");
+                    continue;
+                }
+
+                AudioEventPlayback playback;
+                playback.eventId = event.id;
+                playback.sourceId = event.sourceId;
+                playback.filePath = source->second->path;
+                playback.sourceSampleRate = source->second->sampleRate;
+                playback.sourceDurationSeconds = source->second->durationSeconds;
+
+                const double startBeat = clip.placement.startBeat + event.startBeat;
+                playback.span = spanFromBeats(startBeat, startBeat + event.lengthBeats, tempoMap);
+
+                playback.anchorSamples = event.sourceAnchorSamples;
+                playback.loopStartSamples = event.loopStartSamples;
+                playback.loopLengthSamples = event.loopLengthSamples;
+                playback.loopEnabled = clip.loopEnabled;
+
+                playback.interpBpm = event.interpBpm;
+                playback.autoTempo = event.autoTempo;
+                playback.speedRatio = event.speedRatio;
+                playback.timeStretchMode = event.getEffectiveTimeStretchMode();
+                playback.analogPitch = event.isAnalogPitchActive();
+                playback.warpEnabled = event.warpEnabled;
+                playback.warpMarkers = event.warpMarkers;
+
+                playback.autoPitch = event.autoPitch;
+                playback.autoPitchMode = event.autoPitchMode;
+                playback.pitchChange = event.pitchChange;
+                playback.transpose = event.transpose;
+
+                playback.reversed = event.reversed;
+                playback.leftChannelActive = event.leftChannelActive;
+                playback.rightChannelActive = event.rightChannelActive;
+                playback.gainDb = event.gainDB;
+
+                audio.events.push_back(std::move(playback));
+            }
+
+            track.audio.push_back(std::move(audio));
+        }
+
+        // Sorted by where they start, ties by id: two compiles of one model
+        // have to produce one snapshot, and a lane is held in whatever order
+        // the model happens to keep it.
+        const auto byStart = [](const auto& a, const auto& b) {
+            if (a.span.startBeat != b.span.startBeat)
+                return a.span.startBeat < b.span.startBeat;
+            return a.clipId < b.clipId;
+        };
+        std::sort(track.audio.begin(), track.audio.end(), byStart);
+        std::sort(track.midi.begin(), track.midi.end(), byStart);
+
+        if (!track.audio.empty() || !track.midi.empty())
+            snapshot.tracks.push_back(std::move(track));
+    }
+
+    // ClipSnapshot::find binary searches this.
+    std::sort(snapshot.tracks.begin(), snapshot.tracks.end(),
+              [](const TrackClipPlayback& a, const TrackClipPlayback& b) {
+                  return a.trackId < b.trackId;
+              });
+
+    return snapshot;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipSnapshotCompiler.hpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "clip/ClipSnapshot.hpp"
+#include "core/ClipInfo.hpp"
+#include "core/TypeIds.hpp"
+#include "transport/TempoMap.hpp"
+
+/**
+ * @file ClipSnapshotCompiler.hpp
+ * @brief Compile the clip model into what the audio thread plays.
+ *
+ * Data in, data out: the caller hands over the lanes as the model holds them
+ * and the facts about the files they name, and gets back a resolved snapshot.
+ * Nothing is looked up behind the caller's back, which is what makes the
+ * compile deterministic and golden testable, and what keeps the engine off the
+ * message-thread singletons (ClipManager, SourcePool) that own this data in the
+ * app.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief What the engine needs to know about one media source.
+ *
+ * The facts about the file, resolved by whoever owns the pool. The engine never
+ * probes a file: a snapshot compiled during playback would otherwise open one.
+ */
+struct ClipSourceInfo {
+    SourceId id = INVALID_SOURCE_ID;
+    std::string path;
+    double sampleRate = 0.0;
+    double durationSeconds = 0.0;
+};
+
+/**
+ * @brief One track's arrangement clips, as the model holds them.
+ *
+ * Every arrangement clip on the track, in any order, including the ones that
+ * are covered or disabled: occlusion is resolved per lane and a clip that is
+ * missing from it changes what the others play.
+ */
+struct ClipLane {
+    TrackId trackId = INVALID_TRACK_ID;
+    std::vector<ClipInfo> clips;
+};
+
+/**
+ * @brief Resolve @p lanes into a snapshot.
+ *
+ * Deterministic: the same model always compiles to the same snapshot, entry for
+ * entry, so a dump diff means a model change and nothing else.
+ *
+ * Occlusion and fades come from the model's own functions (computeAudibleSpans,
+ * effectiveFadesIn) rather than from a second implementation of the rules. The
+ * fades are asked for at the tempo where the clip starts, which is the same
+ * question the arrangement asks when it draws them: a fade computed any other
+ * way here would be a second interpretation, and the one on screen would be the
+ * one that was wrong.
+ *
+ * Anything that will not sound lands in ClipSnapshot::diagnostics rather than
+ * disappearing. A clip the lane leaves inaudible is not a diagnostic: being
+ * covered is what covering means.
+ */
+ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
+                                 const std::vector<ClipSourceInfo>& sources,
+                                 const TempoMap& tempoMap);
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipSnapshotCompiler.hpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.hpp
@@ -51,18 +51,24 @@ struct ClipLane {
  * @brief Resolve @p lanes into a snapshot.
  *
  * Deterministic: the same model always compiles to the same snapshot, entry for
- * entry, so a dump diff means a model change and nothing else.
+ * entry, so a dump diff means a model change and nothing else. Tracks and the
+ * clips on them are sorted here, but diagnostics keep the order the lanes
+ * arrived in, so a caller that wants two compiles to dump alike hands the lanes
+ * over in a stable order. Project order is the obvious one.
  *
  * Occlusion and fades come from the model's own functions (computeAudibleSpans,
- * effectiveFadesIn) rather than from a second implementation of the rules. The
- * fades are asked for at the tempo where the clip starts, which is the same
- * question the arrangement asks when it draws them: a fade computed any other
- * way here would be a second interpretation, and the one on screen would be the
- * one that was wrong.
+ * effectiveFadesIn) rather than from a second implementation of the rules. What
+ * this adds is the tempo map: which edge a crossfade covers is the model's
+ * answer, how long those beats last is asked of the map, so the two halves of
+ * one crossfade agree even when their clips start under different tempos. The
+ * arrangement still draws its curves at the project tempo, which is the same
+ * number on a flat map and a thing to reconcile when tempo curves reach
+ * playback.
  *
  * Anything that will not sound lands in ClipSnapshot::diagnostics rather than
- * disappearing. A clip the lane leaves inaudible is not a diagnostic: being
- * covered is what covering means.
+ * disappearing, and does not reach the snapshot: a clip with nothing playable
+ * left is not carried as an empty one. A clip the lane leaves inaudible is
+ * neither, because being covered is what covering means.
  */
 ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
                                  const std::vector<ClipSourceInfo>& sources,

--- a/magda/engine/clip/ClipSnapshotDump.cpp
+++ b/magda/engine/clip/ClipSnapshotDump.cpp
@@ -1,0 +1,144 @@
+#include "clip/ClipSnapshotDump.hpp"
+
+#include <iomanip>
+#include <sstream>
+
+namespace magda::engine {
+namespace {
+
+std::string fixed(double value, int decimals) {
+    std::ostringstream out;
+    out << std::fixed << std::setprecision(decimals) << value;
+    return out.str();
+}
+
+std::string hex(std::uint64_t value) {
+    std::ostringstream out;
+    out << std::hex << value;
+    return out.str();
+}
+
+/// The file's name, never its path: a golden test that carried an absolute
+/// path would pass on the machine that wrote it and nowhere else.
+std::string fileName(const std::string& path) {
+    const auto slash = path.find_last_of("/\\");
+    return slash == std::string::npos ? path : path.substr(slash + 1);
+}
+
+const char* curveName(FadeCurve curve) {
+    switch (curve) {
+        case FadeCurve::Linear:
+            return "lin";
+        case FadeCurve::Convex:
+            return "cvx";
+        case FadeCurve::Concave:
+            return "ccv";
+        case FadeCurve::SCurve:
+            return "scv";
+    }
+    return "lin";
+}
+
+std::string spanText(const SnapshotSpan& span) {
+    return fixed(span.startBeat, 3) + ".." + fixed(span.endBeat, 3) + "b " +
+           fixed(span.startSeconds, 3) + ".." + fixed(span.endSeconds, 3) + "s";
+}
+
+void dumpHoles(std::ostringstream& out, const std::vector<SnapshotSpan>& holes) {
+    for (const auto& hole : holes)
+        out << "    hole " << spanText(hole) << "\n";
+}
+
+void dumpEvent(std::ostringstream& out, const AudioEventPlayback& event) {
+    out << "    event " << event.eventId << " src=" << event.sourceId
+        << " file=" << (event.filePath.empty() ? std::string("-") : fileName(event.filePath))
+        << " rate=" << fixed(event.sourceSampleRate, 0) << " span=" << spanText(event.span)
+        << " anchor=" << event.anchorSamples;
+
+    if (event.loopEnabled)
+        out << " loop=" << event.loopStartSamples << "+" << event.loopLengthSamples;
+    else
+        out << " loop=off";
+
+    out << " stretch=" << event.timeStretchMode << " speed=" << fixed(event.speedRatio, 3)
+        << " bpm=" << fixed(event.interpBpm, 1);
+
+    if (event.autoTempo)
+        out << " auto-tempo";
+    if (event.warpEnabled)
+        out << " warp=" << event.warpMarkers.size();
+    if (event.analogPitch)
+        out << " analog-pitch";
+    if (event.autoPitch)
+        out << " auto-pitch=" << event.autoPitchMode;
+    if (event.pitchChange != 0.0f)
+        out << " pitch=" << fixed(event.pitchChange, 2);
+    if (event.transpose != 0)
+        out << " transpose=" << event.transpose;
+    if (event.reversed)
+        out << " reversed";
+    if (!event.leftChannelActive || !event.rightChannelActive)
+        out << " channels=" << (event.leftChannelActive ? "L" : "-")
+            << (event.rightChannelActive ? "R" : "-");
+    if (event.gainDb != 0.0f)
+        out << " gain=" << fixed(event.gainDb, 1);
+
+    out << "\n";
+}
+
+void dumpAudioClip(std::ostringstream& out, const AudioClipPlayback& clip) {
+    out << "  audio clip=" << clip.clipId << " span=" << spanText(clip.span)
+        << " fade=" << fixed(clip.fadeInSeconds, 3) << "/" << fixed(clip.fadeOutSeconds, 3)
+        << " curve=" << curveName(clip.fadeInCurve) << "/" << curveName(clip.fadeOutCurve)
+        << " behaviour=" << clip.fadeInBehaviour << "/" << clip.fadeOutBehaviour
+        << " gain=" << fixed(clip.gainDb, 1) << " pan=" << fixed(clip.pan, 2)
+        << " launch=" << clip.launchFadeSamples << "\n";
+
+    dumpHoles(out, clip.silenced);
+    for (const auto& event : clip.events)
+        dumpEvent(out, event);
+}
+
+void dumpMidiClip(std::ostringstream& out, const MidiClipPlayback& clip) {
+    out << "  midi clip=" << clip.clipId << " span=" << spanText(clip.span)
+        << " notes=" << clip.notes.size() << " cc=" << clip.cc.size()
+        << " pb=" << clip.pitchBend.size();
+
+    if (clip.loopEnabled)
+        out << " loop=" << fixed(clip.loopStartBeats, 3) << "+" << fixed(clip.loopLengthBeats, 3);
+    else
+        out << " loop=off";
+
+    out << " offset=" << fixed(clip.offsetBeats, 3) << " trim=" << fixed(clip.trimOffsetBeats, 3);
+
+    if (!clip.grooveTemplate.empty())
+        out << " groove=" << clip.grooveTemplate << "@" << fixed(clip.grooveStrength, 2);
+
+    out << "\n";
+    dumpHoles(out, clip.silenced);
+}
+
+}  // namespace
+
+std::string dumpClipSnapshot(const ClipSnapshot& snapshot) {
+    std::ostringstream out;
+    out << "magda-clip-snapshot v" << snapshot.version << "\n";
+    out << "tempo=" << hex(snapshot.tempoFingerprint) << " tracks=" << snapshot.tracks.size()
+        << "\n";
+
+    for (const auto& track : snapshot.tracks) {
+        out << "track " << track.trackId << " audio=" << track.audio.size()
+            << " midi=" << track.midi.size() << "\n";
+        for (const auto& clip : track.audio)
+            dumpAudioClip(out, clip);
+        for (const auto& clip : track.midi)
+            dumpMidiClip(out, clip);
+    }
+
+    for (const auto& diagnostic : snapshot.diagnostics)
+        out << "diagnostic: " << diagnostic << "\n";
+
+    return out.str();
+}
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipSnapshotDump.cpp
+++ b/magda/engine/clip/ClipSnapshotDump.cpp
@@ -83,6 +83,16 @@ void dumpEvent(std::ostringstream& out, const AudioEventPlayback& event) {
     if (event.gainDb != 0.0f)
         out << " gain=" << fixed(event.gainDb, 1);
 
+    // The event's own fades, printed only when it has any: for the one event
+    // that spans its clip these repeat what the clip line already showed, and
+    // what they are here for is the clip that holds several.
+    if (event.fadeInSeconds > 0.0 || event.fadeOutSeconds > 0.0) {
+        out << " fade=" << fixed(event.fadeInSeconds, 3) << "/" << fixed(event.fadeOutSeconds, 3)
+            << " curve=" << curveName(event.fadeInCurve) << "/" << curveName(event.fadeOutCurve);
+        if (event.fadeInBehaviour != 0 || event.fadeOutBehaviour != 0)
+            out << " behaviour=" << event.fadeInBehaviour << "/" << event.fadeOutBehaviour;
+    }
+
     out << "\n";
 }
 

--- a/magda/engine/clip/ClipSnapshotDump.hpp
+++ b/magda/engine/clip/ClipSnapshotDump.hpp
@@ -14,15 +14,15 @@ namespace magda::engine {
  * line per clip, per hole and per event, fixed precision, no paths that depend
  * on the machine.
  *
- * Shape:
- * @code
- * magda-clip-snapshot v1
- * tempo=8f3a1c02 tracks=1
- * track 1 audio=2 midi=0
- *   audio clip=7 span=0.000..8.000b 0.000..4.000s fade=0.500/0.250 curve=lin/lin gain=-3.0 pan=0.00
- * launch=256 hole 2.000..3.000b 1.000..1.500s event 1 src=3 span=0.000..8.000b anchor=0 loop=off
- * stretch=15 speed=1.000 bpm=120.0
- * @endcode
+ * Shape, with the long lines cut short here:
+ *
+ *     magda-clip-snapshot v1
+ *     tempo=8f3a1c02 tracks=1
+ *     track 1 audio=1 midi=0
+ *       audio clip=7 span=0.000..8.000b 0.000..4.000s fade=0.500/0.250 ...
+ *         hole 2.000..3.000b 1.000..1.500s
+ *         event 1 src=3 file=drums.wav rate=48000 span=... anchor=0 ...
+ *     diagnostic: track 1 clip 9: ...
  *
  * The file a source names is dumped as its name only, not its path: a golden
  * test that carried an absolute path would pass on one machine and fail on the

--- a/magda/engine/clip/ClipSnapshotDump.hpp
+++ b/magda/engine/clip/ClipSnapshotDump.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+
+#include "clip/ClipSnapshot.hpp"
+
+namespace magda::engine {
+
+/**
+ * @brief Render a clip snapshot as canonical text.
+ *
+ * The snapshot's testable surface, and what to read when what a track plays is
+ * not what an edit should have made of it. Deterministic and diff-friendly: one
+ * line per clip, per hole and per event, fixed precision, no paths that depend
+ * on the machine.
+ *
+ * Shape:
+ * @code
+ * magda-clip-snapshot v1
+ * tempo=8f3a1c02 tracks=1
+ * track 1 audio=2 midi=0
+ *   audio clip=7 span=0.000..8.000b 0.000..4.000s fade=0.500/0.250 curve=lin/lin gain=-3.0 pan=0.00
+ * launch=256 hole 2.000..3.000b 1.000..1.500s event 1 src=3 span=0.000..8.000b anchor=0 loop=off
+ * stretch=15 speed=1.000 bpm=120.0
+ * @endcode
+ *
+ * The file a source names is dumped as its name only, not its path: a golden
+ * test that carried an absolute path would pass on one machine and fail on the
+ * next.
+ */
+std::string dumpClipSnapshot(const ClipSnapshot& snapshot);
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipSnapshotFeed.hpp
+++ b/magda/engine/clip/ClipSnapshotFeed.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <farbot/RealtimeObject.hpp>
+#include <memory>
+#include <utility>
+
+#include "clip/ClipSnapshot.hpp"
+
+/**
+ * @file ClipSnapshotFeed.hpp
+ * @brief The live clip snapshot: replaced on one thread, read on the other.
+ *
+ * A snapshot travels the way a plan does and for the same reason: it is
+ * immutable once published, so an edit does not mutate what a callback is
+ * reading, it makes a new one and swaps it in. The one it replaces is destroyed
+ * on the publishing thread, which is what keeps the audio thread from ever
+ * freeing a clip list.
+ *
+ * It is separate from the session on purpose. A clip source needs the snapshot
+ * and nothing else the session owns, so it takes one of these; that is also
+ * what lets a source be tested with no session at all.
+ *
+ * One publishing thread. The swap keeps the audio thread out of the publisher's
+ * way, not two publishers out of each other's.
+ */
+
+namespace magda::engine {
+
+class ClipSnapshotFeed {
+    using Published = farbot::RealtimeObject<std::shared_ptr<const ClipSnapshot>,
+                                             farbot::RealtimeObjectOptions::nonRealtimeMutatable>;
+
+  public:
+    /// On the publishing thread.
+    void publish(std::shared_ptr<const ClipSnapshot> snapshot) {
+        published_.nonRealtimeReplace(std::move(snapshot));
+    }
+
+    /**
+     * @brief What is live, for as long as this exists. On the audio thread.
+     *
+     * Null until something has been published, which is a track with nothing to
+     * play rather than an error: a session renders silence before its first
+     * snapshot arrives, exactly as it renders silence before its first plan.
+     */
+    class Reader {
+      public:
+        explicit Reader(ClipSnapshotFeed& feed) : access_(feed.published_) {}
+
+        const ClipSnapshot* get() const noexcept {
+            return (*access_).get();
+        }
+        const ClipSnapshot* operator->() const noexcept {
+            return get();
+        }
+        explicit operator bool() const noexcept {
+            return get() != nullptr;
+        }
+
+      private:
+        Published::ScopedAccess<farbot::ThreadType::realtime> access_;
+    };
+
+  private:
+    Published published_;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipSnapshotFeed.hpp
+++ b/magda/engine/clip/ClipSnapshotFeed.hpp
@@ -21,7 +21,9 @@
  * what lets a source be tested with no session at all.
  *
  * One publishing thread. The swap keeps the audio thread out of the publisher's
- * way, not two publishers out of each other's.
+ * way, not two publishers out of each other's, and publishing waits for the
+ * block the callback is in the way a plan swap does: it is the reading side
+ * that never waits, not this one.
  */
 
 namespace magda::engine {

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -90,6 +90,10 @@ void EngineSession::publishTransport(TransportSnapshot transport) {
     transport_.nonRealtimeReplace(std::move(transport));
 }
 
+void EngineSession::publishClips(std::shared_ptr<const ClipSnapshot> clips) {
+    clips_.publish(std::move(clips));
+}
+
 void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output) {
     output.clear();
 

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "clip/ClipSnapshotFeed.hpp"
 #include "exec/ParallelPlanExecutor.hpp"
 #include "exec/RenderThreadPool.hpp"
 #include "exec/RuntimeStateStore.hpp"
@@ -105,6 +106,30 @@ class EngineSession {
     void publishTransport(TransportSnapshot transport);
 
     /**
+     * @brief What every track plays, resolved (#2034).
+     *
+     * On the publishing thread, and on its own, like values and the transport:
+     * moving a clip is not a topology change and must not compile a plan. The
+     * one it replaces is destroyed here, on this thread.
+     *
+     * Its seconds were derived through a tempo map, so a tempo edit publishes
+     * both: a snapshot compiled against the previous map places every clip at
+     * the seconds that map gave it.
+     */
+    void publishClips(std::shared_ptr<const ClipSnapshot> clips);
+
+    /**
+     * @brief The feed clip sources read.
+     *
+     * Handed to a source when it is created, and owned here because it outlives
+     * every plan those sources are bound into: a structural recompile must not
+     * cost a track the clips it was playing.
+     */
+    ClipSnapshotFeed& clipFeed() {
+        return clips_;
+    }
+
+    /**
      * @brief Render @p numSamples. On the audio thread.
      *
      * The transport decides what stretch of timeline that is: the caller says
@@ -197,6 +222,10 @@ class EngineSession {
     PublishedRender published_;
     PublishedValues values_;
     PublishedTransport transport_;
+
+    /// Not swapped with a plan and not keyed to one: what a track plays is a
+    /// property of the model, and a structural edit is not a reason to lose it.
+    ClipSnapshotFeed clips_;
 
     /// The cursor. Not published and not swapped: it is where the timeline is,
     /// which is a property of the session rather than of any plan, and a plan

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -260,6 +260,7 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_file_audio_source.cpp)
     list(APPEND TEST_SOURCES test_offline_render.cpp)
     list(APPEND TEST_SOURCES test_engine_taps.cpp)
+    list(APPEND TEST_SOURCES test_clip_snapshot.cpp)
 endif()
 
 # Create test executable

--- a/tests/test_clip_snapshot.cpp
+++ b/tests/test_clip_snapshot.cpp
@@ -1,0 +1,458 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "clip/ClipSnapshot.hpp"
+#include "clip/ClipSnapshotCompiler.hpp"
+#include "clip/ClipSnapshotDump.hpp"
+#include "clip/ClipSnapshotFeed.hpp"
+#include "core/ClipFades.hpp"
+#include "core/TimeStretchModes.hpp"
+#include "transport/TempoMap.hpp"
+
+using Catch::Approx;
+using magda::AudioEvent;
+using magda::ClipInfo;
+using magda::ClipView;
+using magda::FadeCurve;
+using magda::engine::ClipLane;
+using magda::engine::ClipSnapshot;
+using magda::engine::ClipSourceInfo;
+using magda::engine::compileClipSnapshot;
+using magda::engine::dumpClipSnapshot;
+using magda::engine::TempoMap;
+
+namespace {
+
+constexpr magda::TrackId kTrack = 1;
+constexpr magda::SourceId kSource = 7;
+
+/// 120 bpm in 4/4 from the beginning: one beat is half a second, which is what
+/// every seconds assertion below is counted in.
+TempoMap makeTempoMap(double bpm = 120.0) {
+    return TempoMap({{0.0, bpm, 0.0f}}, {{0.0, 4, 4}});
+}
+
+std::vector<ClipSourceInfo> makeSources() {
+    return {ClipSourceInfo{kSource, "/tmp/magda-fixtures/loop.wav", 48000.0, 4.0}};
+}
+
+ClipInfo makeAudioClip(magda::ClipId id, double startBeat, double lengthBeats) {
+    ClipInfo clip;
+    clip.id = id;
+    clip.trackId = kTrack;
+    clip.view = ClipView::Arrangement;
+    clip.name = "Clip " + juce::String(id);
+    clip.setAudioContent();
+
+    AudioEvent event;
+    event.sourceId = kSource;
+    event.interpBpm = 120.0;
+    clip.audio().addEvent(event);
+
+    clip.setPlacementBeats(startBeat, lengthBeats);
+    return clip;
+}
+
+ClipInfo makeMidiClip(magda::ClipId id, double startBeat, double lengthBeats) {
+    ClipInfo clip;
+    clip.id = id;
+    clip.trackId = kTrack;
+    clip.view = ClipView::Arrangement;
+    clip.name = "Clip " + juce::String(id);
+    clip.setMidiContent();
+    clip.setPlacementBeats(startBeat, lengthBeats);
+    return clip;
+}
+
+AudioEvent& eventOf(ClipInfo& clip) {
+    return clip.audio().events.front();
+}
+
+ClipSnapshot compile(std::vector<ClipInfo> clips, const TempoMap& tempoMap) {
+    return compileClipSnapshot({ClipLane{kTrack, std::move(clips)}}, makeSources(), tempoMap);
+}
+
+/// What the fixture in the golden test has to compile to, line for line. A diff
+/// here is a change in what a track plays.
+const std::string kGoldenDump =
+    "magda-clip-snapshot v1\n"
+    "tempo=a95350905fc122eb tracks=1\n"
+    "track 1 audio=2 midi=1\n"
+    "  audio clip=1 span=0.000..8.000b 0.000..4.000s fade=0.000/1.000 curve=lin/lin "
+    "behaviour=0/0 gain=0.0 pan=0.00 launch=256\n"
+    "    event 1 src=7 file=loop.wav rate=48000 span=0.000..8.000b 0.000..4.000s anchor=0 "
+    "loop=off stretch=0 speed=1.000 bpm=120.0\n"
+    "  audio clip=2 span=6.000..14.000b 3.000..7.000s fade=1.000/0.000 curve=lin/lin "
+    "behaviour=0/0 gain=0.0 pan=0.00 launch=256\n"
+    "    event 1 src=7 file=loop.wav rate=48000 span=6.000..14.000b 3.000..7.000s anchor=0 "
+    "loop=off stretch=0 speed=1.000 bpm=120.0 reversed\n"
+    "  midi clip=3 span=0.000..4.000b 0.000..2.000s notes=1 cc=0 pb=0 loop=off offset=0.000 "
+    "trim=0.000\n";
+
+const magda::engine::AudioClipPlayback* audioClip(const ClipSnapshot& snapshot, magda::ClipId id) {
+    const auto* track = snapshot.find(kTrack);
+    if (track == nullptr)
+        return nullptr;
+    for (const auto& clip : track->audio)
+        if (clip.clipId == id)
+            return &clip;
+    return nullptr;
+}
+
+}  // namespace
+
+TEST_CASE("A clip on its own compiles to its placement, in both domains", "[engine][clip]") {
+    const auto tempoMap = makeTempoMap();
+    const auto snapshot = compile({makeAudioClip(1, 4.0, 8.0)}, tempoMap);
+
+    REQUIRE(snapshot.tracks.size() == 1);
+    const auto* clip = audioClip(snapshot, 1);
+    REQUIRE(clip != nullptr);
+
+    CHECK(clip->span.startBeat == Approx(4.0));
+    CHECK(clip->span.endBeat == Approx(12.0));
+    CHECK(clip->span.startSeconds == Approx(2.0));
+    CHECK(clip->span.endSeconds == Approx(6.0));
+    CHECK(clip->silenced.empty());
+
+    REQUIRE(clip->events.size() == 1);
+    const auto& event = clip->events.front();
+    CHECK(event.sourceId == kSource);
+    CHECK(event.sourceSampleRate == Approx(48000.0));
+    CHECK(event.span.startSeconds == Approx(2.0));
+    CHECK(event.span.endSeconds == Approx(6.0));
+}
+
+TEST_CASE("The seconds come from the tempo map, and say which one", "[engine][clip]") {
+    const auto slow = makeTempoMap(60.0);
+    const auto fast = makeTempoMap(120.0);
+
+    const auto atSixty = compile({makeAudioClip(1, 4.0, 8.0)}, slow);
+    const auto atOneTwenty = compile({makeAudioClip(1, 4.0, 8.0)}, fast);
+
+    CHECK(audioClip(atSixty, 1)->span.startSeconds == Approx(4.0));
+    CHECK(audioClip(atOneTwenty, 1)->span.startSeconds == Approx(2.0));
+
+    // The beats did not move, only what they are worth.
+    CHECK(audioClip(atSixty, 1)->span.startBeat == Approx(4.0));
+    CHECK(atSixty.tempoFingerprint != atOneTwenty.tempoFingerprint);
+    CHECK(atSixty.tempoFingerprint == slow.fingerprint());
+}
+
+TEST_CASE("A covered clip plays what the lane leaves it", "[engine][clip]") {
+    SECTION("covered end to end, it is not in the snapshot at all") {
+        auto under = makeAudioClip(1, 0.0, 4.0);
+        auto over = makeAudioClip(2, 0.0, 8.0);
+        over.stackOrder = 1;
+
+        const auto snapshot = compile({under, over}, makeTempoMap());
+        CHECK(audioClip(snapshot, 1) == nullptr);
+        CHECK(audioClip(snapshot, 2) != nullptr);
+        // Being covered is what covering means, not a failure to compile.
+        CHECK(snapshot.diagnostics.empty());
+    }
+
+    SECTION("covered at an edge, the edge pulls in") {
+        auto under = makeAudioClip(1, 0.0, 8.0);
+        auto over = makeAudioClip(2, 4.0, 8.0);
+        over.stackOrder = 1;
+
+        const auto snapshot = compile({under, over}, makeTempoMap());
+        const auto* clip = audioClip(snapshot, 1);
+        REQUIRE(clip != nullptr);
+        CHECK(clip->span.startBeat == Approx(0.0));
+        CHECK(clip->span.endBeat == Approx(4.0));
+        CHECK(clip->span.endSeconds == Approx(2.0));
+        CHECK(clip->silenced.empty());
+    }
+
+    SECTION("covered in the middle, an audio clip keeps a hole") {
+        auto under = makeAudioClip(1, 0.0, 16.0);
+        auto over = makeAudioClip(2, 4.0, 4.0);
+        over.stackOrder = 1;
+
+        const auto snapshot = compile({under, over}, makeTempoMap());
+        const auto* clip = audioClip(snapshot, 1);
+        REQUIRE(clip != nullptr);
+        CHECK(clip->span.startBeat == Approx(0.0));
+        CHECK(clip->span.endBeat == Approx(16.0));
+        REQUIRE(clip->silenced.size() == 1);
+        CHECK(clip->silenced.front().startBeat == Approx(4.0));
+        CHECK(clip->silenced.front().endBeat == Approx(8.0));
+        CHECK(clip->silenced.front().startSeconds == Approx(2.0));
+        CHECK(clip->silenced.front().endSeconds == Approx(4.0));
+
+        // The event is NOT cropped with it: the anchor is heard at the event's
+        // own start, and moving that would move every read derived from it.
+        REQUIRE(clip->events.size() == 1);
+        CHECK(clip->events.front().span.startBeat == Approx(0.0));
+        CHECK(clip->events.front().span.endBeat == Approx(16.0));
+    }
+
+    SECTION("play-through leaves both clips whole") {
+        auto under = makeAudioClip(1, 0.0, 8.0);
+        auto over = makeAudioClip(2, 4.0, 8.0);
+        over.stackOrder = 1;
+        under.overlapPlaysBoth = true;  // either side asking is enough
+
+        const auto snapshot = compile({under, over}, makeTempoMap());
+        CHECK(audioClip(snapshot, 1)->span.endBeat == Approx(8.0));
+        CHECK(audioClip(snapshot, 2)->span.startBeat == Approx(4.0));
+    }
+}
+
+TEST_CASE("Fades arrive resolved, and a crossfade is two of them", "[engine][clip]") {
+    auto left = makeAudioClip(1, 0.0, 8.0);
+    auto right = makeAudioClip(2, 6.0, 8.0);
+    right.stackOrder = 1;
+    left.overlapPlaysBoth = true;
+    left.autoCrossfade = true;
+    right.autoCrossfade = true;
+
+    const auto snapshot = compile({left, right}, makeTempoMap());
+
+    // Two beats of overlap at 120 bpm is one second, and each clip plays the
+    // one curve that is its own.
+    CHECK(audioClip(snapshot, 1)->fadeOutSeconds == Approx(1.0));
+    CHECK(audioClip(snapshot, 1)->fadeInSeconds == Approx(0.0));
+    CHECK(audioClip(snapshot, 2)->fadeInSeconds == Approx(1.0));
+    CHECK(audioClip(snapshot, 2)->fadeOutSeconds == Approx(0.0));
+
+    // The same answer the arrangement draws from.
+    const std::vector<ClipInfo> lane{left, right};
+    CHECK(magda::effectiveFadesIn(lane, 2, 120.0).fadeInSeconds ==
+          Approx(audioClip(snapshot, 2)->fadeInSeconds));
+}
+
+TEST_CASE("A clip's own fade and its curve survive the compile", "[engine][clip]") {
+    auto clip = makeAudioClip(1, 0.0, 8.0);
+    eventOf(clip).fadeInSeconds = 0.75;
+    eventOf(clip).fadeOutSeconds = 0.25;
+    eventOf(clip).fadeInType = static_cast<int>(FadeCurve::SCurve);
+    eventOf(clip).fadeOutType = static_cast<int>(FadeCurve::Convex);
+    eventOf(clip).fadeOutBehaviour = 1;  // speed ramp
+
+    const auto snapshot = compile({clip}, makeTempoMap());
+    const auto* compiled = audioClip(snapshot, 1);
+    REQUIRE(compiled != nullptr);
+    CHECK(compiled->fadeInSeconds == Approx(0.75));
+    CHECK(compiled->fadeOutSeconds == Approx(0.25));
+    CHECK(compiled->fadeInCurve == FadeCurve::SCurve);
+    CHECK(compiled->fadeOutCurve == FadeCurve::Convex);
+    CHECK(compiled->fadeOutBehaviour == 1);
+}
+
+TEST_CASE("Clip volume and gain reach the engine summed, as the incumbent applies them",
+          "[engine][clip]") {
+    auto clip = makeAudioClip(1, 0.0, 8.0);
+    clip.volumeDB = -6.0f;
+    clip.gainDB = 2.0f;
+    clip.pan = -0.5f;
+    eventOf(clip).gainDB = 1.5f;
+
+    const auto snapshot = compile({clip}, makeTempoMap());
+    const auto* compiled = audioClip(snapshot, 1);
+    REQUIRE(compiled != nullptr);
+    CHECK(compiled->gainDb == Approx(-4.0f));
+    CHECK(compiled->pan == Approx(-0.5f));
+    // The event's own trim stays under the clip's, rather than being folded in.
+    CHECK(compiled->events.front().gainDb == Approx(1.5f));
+}
+
+TEST_CASE("The stretch mode compiled is the one that runs", "[engine][clip]") {
+    auto clip = makeAudioClip(1, 0.0, 8.0);
+    eventOf(clip).timeStretchMode = magda::time_stretch_mode::kDisabled;
+    eventOf(clip).autoTempo = true;
+
+    const auto snapshot = compile({clip}, makeTempoMap());
+    const auto* compiled = audioClip(snapshot, 1);
+    REQUIRE(compiled != nullptr);
+    // Off plus beat mode still stretches, which is what the model already says
+    // and what the UI already shows.
+    CHECK(compiled->events.front().timeStretchMode == magda::time_stretch_mode::kSignalsmith);
+    CHECK(compiled->events.front().autoTempo);
+}
+
+TEST_CASE("What will not sound says so, and what is merely covered does not", "[engine][clip]") {
+    SECTION("a disabled clip is skipped without comment") {
+        auto clip = makeAudioClip(1, 0.0, 8.0);
+        clip.enabled = false;
+
+        const auto snapshot = compile({clip}, makeTempoMap());
+        CHECK(snapshot.tracks.empty());
+        CHECK(snapshot.diagnostics.empty());
+    }
+
+    SECTION("a session clip in an arrangement lane is reported") {
+        auto clip = makeAudioClip(1, 0.0, 8.0);
+        clip.view = ClipView::Session;
+
+        const auto snapshot = compile({clip}, makeTempoMap());
+        CHECK(snapshot.tracks.empty());
+        REQUIRE(snapshot.diagnostics.size() == 1);
+        CHECK(snapshot.diagnostics.front().find("session clip") != std::string::npos);
+    }
+
+    SECTION("an unresolvable source is reported and plays nothing") {
+        auto clip = makeAudioClip(1, 0.0, 8.0);
+        eventOf(clip).sourceId = 99;
+
+        const auto snapshot = compile({clip}, makeTempoMap());
+        const auto* compiled = audioClip(snapshot, 1);
+        REQUIRE(compiled != nullptr);
+        CHECK(compiled->events.empty());
+        REQUIRE(snapshot.diagnostics.size() == 1);
+        CHECK(snapshot.diagnostics.front().find("source table") != std::string::npos);
+    }
+
+    SECTION("a clip that belongs to another track is reported") {
+        auto clip = makeAudioClip(1, 0.0, 8.0);
+        clip.trackId = kTrack + 1;
+
+        const auto snapshot = compile({clip}, makeTempoMap());
+        CHECK(snapshot.tracks.empty());
+        REQUIRE(snapshot.diagnostics.size() == 1);
+    }
+}
+
+TEST_CASE("A MIDI clip carries its events, its loop and its groove", "[engine][clip]") {
+    auto clip = makeMidiClip(1, 0.0, 8.0);
+    clip.midiNotes.push_back(magda::MidiNote{60, 100, 0.0, 1.0, 0, {}});
+    clip.midiNotes.push_back(magda::MidiNote{64, 90, 1.0, 1.0, 0, {}});
+    clip.loopEnabled = true;
+    clip.loopStartBeats = 0.0;
+    clip.loopLengthBeats = 4.0;
+    clip.midiOffset = 0.5;
+    clip.midiTrimOffset = 0.25;
+    clip.grooveTemplate = "Swing 16";
+    clip.grooveStrength = 0.6f;
+
+    const auto snapshot = compile({clip}, makeTempoMap());
+    const auto* track = snapshot.find(kTrack);
+    REQUIRE(track != nullptr);
+    REQUIRE(track->midi.size() == 1);
+
+    const auto& midi = track->midi.front();
+    CHECK(midi.notes.size() == 2);
+    CHECK(midi.loopEnabled);
+    CHECK(midi.loopLengthBeats == Approx(4.0));
+    CHECK(midi.offsetBeats == Approx(0.5));
+    CHECK(midi.trimOffsetBeats == Approx(0.25));
+    CHECK(midi.grooveTemplate == "Swing 16");
+    CHECK(midi.grooveStrength == Approx(0.6f));
+    CHECK(track->audio.empty());
+}
+
+TEST_CASE("A MIDI clip covered in the middle keeps the hole", "[engine][clip]") {
+    auto under = makeMidiClip(1, 0.0, 16.0);
+    auto over = makeMidiClip(2, 4.0, 4.0);
+    over.stackOrder = 1;
+
+    const auto snapshot = compile({under, over}, makeTempoMap());
+    const auto* track = snapshot.find(kTrack);
+    REQUIRE(track != nullptr);
+    REQUIRE(track->midi.size() == 2);
+
+    const auto& covered = track->midi.front();
+    CHECK(covered.clipId == 1);
+    REQUIRE(covered.silenced.size() == 1);
+    CHECK(covered.silenced.front().startBeat == Approx(4.0));
+    CHECK(covered.silenced.front().endBeat == Approx(8.0));
+}
+
+TEST_CASE("Compiling is deterministic whatever order the lane is held in", "[engine][clip]") {
+    const auto tempoMap = makeTempoMap();
+    auto first = makeAudioClip(1, 8.0, 4.0);
+    auto second = makeAudioClip(2, 0.0, 4.0);
+    auto third = makeMidiClip(3, 4.0, 4.0);
+
+    const auto forwards = compile({first, second, third}, tempoMap);
+    const auto backwards = compile({third, second, first}, tempoMap);
+
+    CHECK(dumpClipSnapshot(forwards) == dumpClipSnapshot(backwards));
+
+    // Sorted by where they start, whatever order they arrived in.
+    const auto* track = forwards.find(kTrack);
+    REQUIRE(track != nullptr);
+    REQUIRE(track->audio.size() == 2);
+    CHECK(track->audio[0].clipId == 2);
+    CHECK(track->audio[1].clipId == 1);
+}
+
+TEST_CASE("A track with nothing to play is not in the snapshot", "[engine][clip]") {
+    const auto snapshot = compileClipSnapshot({ClipLane{kTrack, {}}, ClipLane{kTrack + 1, {}}},
+                                              makeSources(), makeTempoMap());
+    CHECK(snapshot.tracks.empty());
+    CHECK(snapshot.find(kTrack) == nullptr);
+}
+
+TEST_CASE("Tracks are found by id, not by position", "[engine][clip]") {
+    const auto tempoMap = makeTempoMap();
+    std::vector<ClipLane> lanes;
+    for (magda::TrackId id : {5, 2, 9}) {
+        auto clip = makeAudioClip(id * 10, 0.0, 4.0);
+        clip.trackId = id;
+        lanes.push_back(ClipLane{id, {clip}});
+    }
+
+    const auto snapshot = compileClipSnapshot(lanes, makeSources(), tempoMap);
+    REQUIRE(snapshot.tracks.size() == 3);
+    CHECK(snapshot.tracks[0].trackId == 2);
+    CHECK(snapshot.find(9) != nullptr);
+    CHECK(snapshot.find(9)->audio.front().clipId == 90);
+    CHECK(snapshot.find(7) == nullptr);
+}
+
+TEST_CASE("The feed hands the audio thread what was last published", "[engine][clip]") {
+    magda::engine::ClipSnapshotFeed feed;
+
+    {
+        magda::engine::ClipSnapshotFeed::Reader reader(feed);
+        // Nothing published: a track with nothing to play, not an error.
+        CHECK_FALSE(static_cast<bool>(reader));
+        CHECK(reader.get() == nullptr);
+    }
+
+    feed.publish(std::make_shared<const ClipSnapshot>(
+        compile({makeAudioClip(1, 0.0, 4.0)}, makeTempoMap())));
+    {
+        magda::engine::ClipSnapshotFeed::Reader reader(feed);
+        REQUIRE(static_cast<bool>(reader));
+        REQUIRE(reader->find(kTrack) != nullptr);
+        CHECK(reader->find(kTrack)->audio.front().clipId == 1);
+    }
+
+    feed.publish(std::make_shared<const ClipSnapshot>(
+        compile({makeAudioClip(2, 0.0, 4.0)}, makeTempoMap())));
+    {
+        magda::engine::ClipSnapshotFeed::Reader reader(feed);
+        REQUIRE(static_cast<bool>(reader));
+        CHECK(reader->find(kTrack)->audio.front().clipId == 2);
+    }
+}
+
+TEST_CASE("The dump is the snapshot's golden surface", "[engine][clip]") {
+    auto left = makeAudioClip(1, 0.0, 8.0);
+    auto right = makeAudioClip(2, 6.0, 8.0);
+    right.stackOrder = 1;
+    left.overlapPlaysBoth = true;
+    left.autoCrossfade = true;
+    right.autoCrossfade = true;
+    eventOf(right).reversed = true;
+
+    auto midi = makeMidiClip(3, 0.0, 4.0);
+    midi.midiNotes.push_back(magda::MidiNote{60, 100, 0.0, 1.0, 0, {}});
+
+    const auto snapshot = compile({left, right, midi}, makeTempoMap());
+    const auto text = dumpClipSnapshot(snapshot);
+
+    // Nothing in here may depend on the machine that ran it: the file is its
+    // name rather than its path, and every number is fixed precision.
+    CHECK(text.find("/tmp/") == std::string::npos);
+
+    INFO(text);
+    CHECK(text == kGoldenDump);
+}

--- a/tests/test_clip_snapshot.cpp
+++ b/tests/test_clip_snapshot.cpp
@@ -227,6 +227,119 @@ TEST_CASE("Fades arrive resolved, and a crossfade is two of them", "[engine][cli
           Approx(audioClip(snapshot, 2)->fadeInSeconds));
 }
 
+TEST_CASE("Both halves of a crossfade agree across a tempo change", "[engine][clip]") {
+    // 120 bpm until beat 8, 60 bpm after it: the two clips start under
+    // different tempos, and the overlap they share sits across the change.
+    const TempoMap tempoMap({{0.0, 120.0, 0.0f}, {8.0, 60.0, 0.0f}}, {{0.0, 4, 4}});
+
+    auto left = makeAudioClip(1, 0.0, 10.0);
+    auto right = makeAudioClip(2, 6.0, 8.0);
+    right.stackOrder = 1;
+    left.overlapPlaysBoth = true;
+    left.autoCrossfade = true;
+    right.autoCrossfade = true;
+
+    const auto snapshot = compile({left, right}, tempoMap);
+
+    // One overlap, one length: beats 6 to 10 through this map, and not
+    // whatever the bpm at either clip's start would have priced it at.
+    const double overlapSeconds = tempoMap.beatToTime(10.0) - tempoMap.beatToTime(6.0);
+    CHECK(audioClip(snapshot, 1)->fadeOutSeconds == Approx(overlapSeconds));
+    CHECK(audioClip(snapshot, 2)->fadeInSeconds == Approx(overlapSeconds));
+
+    // Which is not what one bpm reading gives: the fade crosses the change.
+    CHECK(overlapSeconds != Approx(4.0 * 60.0 / 120.0));
+    CHECK(overlapSeconds != Approx(4.0 * 60.0 / 60.0));
+
+    // And it agrees with the spans it sits inside.
+    CHECK(audioClip(snapshot, 2)->span.startSeconds == Approx(tempoMap.beatToTime(6.0)));
+    CHECK(audioClip(snapshot, 1)->span.endSeconds == Approx(tempoMap.beatToTime(10.0)));
+}
+
+TEST_CASE("Fades that outrun their clip are scaled to fit it", "[engine][clip]") {
+    auto clip = makeAudioClip(1, 0.0, 2.0);  // one second at 120 bpm
+    eventOf(clip).fadeInSeconds = 3.0;
+    eventOf(clip).fadeOutSeconds = 1.0;
+
+    const auto snapshot = compile({clip}, makeTempoMap());
+    const auto* compiled = audioClip(snapshot, 1);
+    REQUIRE(compiled != nullptr);
+    CHECK(compiled->fadeInSeconds + compiled->fadeOutSeconds == Approx(1.0));
+    CHECK(compiled->fadeInSeconds == Approx(0.75));
+    CHECK(compiled->fadeOutSeconds == Approx(0.25));
+}
+
+TEST_CASE("Every event keeps its own fades, not just the primary", "[engine][clip]") {
+    auto clip = makeAudioClip(1, 0.0, 8.0);
+    eventOf(clip).lengthBeats = 4.0;
+    eventOf(clip).fadeInSeconds = 0.5;
+    eventOf(clip).fadeOutSeconds = 0.25;
+    eventOf(clip).fadeInType = static_cast<int>(FadeCurve::Concave);
+
+    AudioEvent second;
+    second.sourceId = kSource;
+    second.interpBpm = 120.0;
+    second.startBeat = 4.0;
+    second.lengthBeats = 4.0;
+    second.fadeInSeconds = 0.125;
+    second.fadeOutSeconds = 1.5;
+    second.fadeInType = static_cast<int>(FadeCurve::SCurve);
+    second.fadeOutBehaviour = 1;  // speed ramp
+    clip.audio().addEvent(second);
+
+    const auto snapshot = compile({clip}, makeTempoMap());
+    const auto* compiled = audioClip(snapshot, 1);
+    REQUIRE(compiled != nullptr);
+    REQUIRE(compiled->events.size() == 2);
+
+    CHECK(compiled->events[0].fadeInSeconds == Approx(0.5));
+    CHECK(compiled->events[0].fadeOutSeconds == Approx(0.25));
+    CHECK(compiled->events[0].fadeInCurve == FadeCurve::Concave);
+
+    // The event the clip-level pair says nothing about.
+    CHECK(compiled->events[1].fadeInSeconds == Approx(0.125));
+    CHECK(compiled->events[1].fadeOutSeconds == Approx(1.5));
+    CHECK(compiled->events[1].fadeInCurve == FadeCurve::SCurve);
+    CHECK(compiled->events[1].fadeOutBehaviour == 1);
+
+    // The clip's own edges still play the primary event's, resolved.
+    CHECK(compiled->fadeInSeconds == Approx(0.5));
+    CHECK(compiled->fadeOutSeconds == Approx(0.25));
+    CHECK(compiled->fadeInCurve == FadeCurve::Concave);
+}
+
+TEST_CASE("A clip that does not belong to the lane cannot cover one that does", "[engine][clip]") {
+    SECTION("a session clip sitting on top of an arrangement clip") {
+        auto arrangement = makeAudioClip(1, 0.0, 8.0);
+        auto session = makeAudioClip(2, 0.0, 8.0);
+        session.view = ClipView::Session;
+        session.stackOrder = 1;
+
+        const auto snapshot = compile({arrangement, session}, makeTempoMap());
+        const auto* clip = audioClip(snapshot, 1);
+        REQUIRE(clip != nullptr);
+        CHECK(clip->span.startBeat == Approx(0.0));
+        CHECK(clip->span.endBeat == Approx(8.0));
+        CHECK(clip->silenced.empty());
+        CHECK(snapshot.diagnostics.size() == 1);
+    }
+
+    SECTION("a clip from another track sitting on top of it") {
+        auto mine = makeAudioClip(1, 0.0, 16.0);
+        auto stranger = makeAudioClip(2, 4.0, 4.0);
+        stranger.trackId = kTrack + 1;
+        stranger.stackOrder = 1;
+
+        const auto snapshot = compile({mine, stranger}, makeTempoMap());
+        const auto* clip = audioClip(snapshot, 1);
+        REQUIRE(clip != nullptr);
+        CHECK(clip->span.endBeat == Approx(16.0));
+        // The hole it would have punched is not there.
+        CHECK(clip->silenced.empty());
+        CHECK(snapshot.diagnostics.size() == 1);
+    }
+}
+
 TEST_CASE("A clip's own fade and its curve survive the compile", "[engine][clip]") {
     auto clip = makeAudioClip(1, 0.0, 8.0);
     eventOf(clip).fadeInSeconds = 0.75;
@@ -296,16 +409,28 @@ TEST_CASE("What will not sound says so, and what is merely covered does not", "[
         CHECK(snapshot.diagnostics.front().find("session clip") != std::string::npos);
     }
 
-    SECTION("an unresolvable source is reported and plays nothing") {
+    SECTION("an unresolvable source is reported, and takes the clip with it") {
         auto clip = makeAudioClip(1, 0.0, 8.0);
         eventOf(clip).sourceId = 99;
 
         const auto snapshot = compile({clip}, makeTempoMap());
-        const auto* compiled = audioClip(snapshot, 1);
-        REQUIRE(compiled != nullptr);
-        CHECK(compiled->events.empty());
+        // Nothing left to read, so nothing to carry: the same shape a clip with
+        // no events at all comes out as, rather than an empty entry that would
+        // cost a voice to discover.
+        CHECK(audioClip(snapshot, 1) == nullptr);
+        CHECK(snapshot.tracks.empty());
         REQUIRE(snapshot.diagnostics.size() == 1);
         CHECK(snapshot.diagnostics.front().find("source table") != std::string::npos);
+    }
+
+    SECTION("an audio clip with no events is reported the same way") {
+        auto clip = makeAudioClip(1, 0.0, 8.0);
+        clip.audio().events.clear();
+
+        const auto snapshot = compile({clip}, makeTempoMap());
+        CHECK(snapshot.tracks.empty());
+        REQUIRE(snapshot.diagnostics.size() == 1);
+        CHECK(snapshot.diagnostics.front().find("no events") != std::string::npos);
     }
 
     SECTION("a clip that belongs to another track is reported") {


### PR DESCRIPTION
Clip positions are not in the render plan, so they reach the audio thread the way values and the transport do: as their own immutable snapshot, swapped in whole. Moving a clip therefore never compiles a plan.

Resolved is the point of it. Occlusion and crossfades are worked out once, at compile time, by the model functions that already own those rules, so a ClipAudio or ClipMidi op never sees an overlap: it plays a span with fades. An edit recompiles the snapshot the way a structural change recompiles a plan, which leaves no sync protocol between two representations of a lane and no state that can go stale (#2003).

Both faces of every instant are carried. Beats are the model's authority and what auto tempo and warp will keep working in; the seconds are derived here, once, through the tempo map, because a source is handed seconds and there must not be a second tempo map on the audio thread. The snapshot carries the fingerprint of the map they came from, since a tempo edit moves every one of them.

The two rule functions move to magda_types on the way: they are pure and beat domain, and the engine is meant to link the model leaf rather than the whole DAW. ClipManager keeps its names as aliases and forwarders, so every call site that asks the model reads as it always did.