### PR TITLE
WebSocket API: subscriptions, revisioned events, and backpressure (#1857)

### DIFF
--- a/docs/remote-api-contract.md
+++ b/docs/remote-api-contract.md
@@ -33,6 +33,59 @@ shared input/output schemas. A transport may add its own correlation or
 framing metadata outside these envelopes, but it must not change the contract
 payload.
 
+## Subscriptions
+
+Ten topics partition what a client can watch: `project`, `tracks`, `clips`,
+`devices`, `selection`, `transport`, `session`, `automation`, and the two
+continuous ones, `meters` and `playhead`.
+
+`subscriptions.subscribe`, `.unsubscribe`, `.list`, and `.resync` are declared in
+the registry like any other operation and marked `transportScoped: true`. They
+are executed by the transport adapter rather than by the dispatcher, because
+what a connection watches is state only that connection has. Dispatching one
+through a transport that cannot push fails with `invalid_request` rather than
+`unknown_operation` — the operation is real, and only the route is wrong.
+
+A pushed change is one envelope, independent of the transport that carries it:
+
+```json
+{ "topic": "clips", "type": "delta", "revision": 57, "payload": {} }
+```
+
+`type` is one of:
+
+- `snapshot` — complete state for the topic, in the same shape as the topic's
+  read operation (`tracks` is `tracks.list`, `project` is `project.get`, and so
+  on). Delivered in the reply to `subscribe` and `resync`, so a client is never
+  subscribed without knowing what it is watching, and pushed as an event when a
+  client has fallen behind.
+- `delta` — what changed since the previous event on that topic. For `tracks`,
+  `clips`, `automation`, and `session` the payload is
+  `{"added": [], "updated": [], "removed": []}`, where `removed` carries
+  identities only — an id, or `{trackId, sceneIndex}` for a session slot. Apply
+  `added` and `updated` as upserts keyed by id: a client may legitimately be sent
+  a change it already has, and doing so must be harmless. For `project`,
+  `transport`, `selection`, and `devices` the payload is the topic's full state,
+  because there is nothing useful to diff.
+- `sample` — a point reading of `meters` or `playhead`. Latest value wins,
+  intermediate readings are discarded, and a dropped sample is never resent.
+
+`revision` orders the stream and is the same counter `expected_revision` uses.
+Continuous motion — a parameter following an LFO, a drag preview — publishes
+events without advancing it, so equal revisions on consecutive events are
+expected and mean "nothing was committed".
+
+`subscribe` takes `fromRevision` for reconnects. If it equals the current
+revision, no committed change has been missed and the snapshots are skipped;
+any other value is an explicit full resync, because no per-revision history is
+kept to replay from. `resync` forces the same thing at any time.
+
+Delivery is bounded rather than buffered. A client that stops reading has its
+events dropped, is marked for resync, and receives a `snapshot` in place of the
+`delta` it missed as soon as it reads again; one that never resumes is
+disconnected. Subscribing to `meters` or `playhead` costs nothing until asked
+for: nothing samples them otherwise.
+
 ## Deliberately excluded data
 
 DTO fields are allow-listed. In particular, the remote API does not expose:

--- a/docs/remote-api-contract.md
+++ b/docs/remote-api-contract.md
@@ -80,11 +80,16 @@ revision, no committed change has been missed and the snapshots are skipped;
 any other value is an explicit full resync, because no per-revision history is
 kept to replay from. `resync` forces the same thing at any time.
 
+Opening a different project invalidates every discrete topic at once, so a
+client watching only `tracks` hears about the swap rather than continuing to
+show the outgoing project's contents.
+
 Delivery is bounded rather than buffered. A client that stops reading has its
-events dropped, is marked for resync, and receives a `snapshot` in place of the
-`delta` it missed as soon as it reads again; one that never resumes is
-disconnected. Subscribing to `meters` or `playhead` costs nothing until asked
-for: nothing samples them otherwise.
+events dropped and is marked for resync; the snapshot it is owed is retried on
+its own until it is taken, so a client that fell behind is not left stale by the
+project happening to go quiet. One that never resumes is disconnected.
+Subscribing to `meters` or `playhead` costs nothing until asked for: nothing
+samples them otherwise.
 
 ## Deliberately excluded data
 

--- a/docs/remote-api-contract.md
+++ b/docs/remote-api-contract.md
@@ -75,10 +75,17 @@ Continuous motion — a parameter following an LFO, a drag preview — publishes
 events without advancing it, so equal revisions on consecutive events are
 expected and mean "nothing was committed".
 
-`subscribe` takes `fromRevision` for reconnects. If it equals the current
-revision, no committed change has been missed and the snapshots are skipped;
-any other value is an explicit full resync, because no per-revision history is
-kept to replay from. `resync` forces the same thing at any time.
+`subscribe` always delivers snapshots, including on a reconnect, and
+`subscriptions.resync` forces the same thing at any time. There is no "resume
+from revision N": `revision` counts committed mutations, while events are also
+published for motion that commits nothing, so a client that disconnected and
+missed one of those has a revision indistinguishable from a client that saw it.
+A cursor that cannot tell those apart cannot be used to skip state.
+
+A client that knows it already has state — because it is about to resync itself,
+or only cares about what happens from now on — passes `"snapshot": false`. That
+is the client asserting it, which is the difference: being wrong about it is then
+its own choice rather than the server's guess.
 
 Opening a different project invalidates every discrete topic at once, so a
 client watching only `tracks` hears about the swap rather than continuing to

--- a/magda/daw/api/CMakeLists.txt
+++ b/magda/daw/api/CMakeLists.txt
@@ -21,6 +21,8 @@ target_sources(magda_daw PRIVATE
     remote_service.cpp
     remote_changes.cpp
     remote_model_bridge_live.cpp
+    remote_subscriptions.cpp
+    remote_meters_live.cpp
     remote_websocket_server.cpp
     remote_api_host.cpp
     # Headers (listed for IDE visibility)
@@ -56,4 +58,7 @@ target_sources(magda_daw PRIVATE
     remote_service.hpp
     remote_changes.hpp
     remote_model_bridge.hpp
+    remote_subscriptions.hpp
+    remote_websocket_server.hpp
+    remote_api_host.hpp
 )

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -457,6 +457,91 @@ const juce::var& automationLaneSchema() {
     return value;
 }
 
+// ---------------------------------------------------------------------------
+// Subscription schemas (#1857)
+// ---------------------------------------------------------------------------
+
+/// The topic names, spelled once. Kept in step with `magda::remote::Topic` by
+/// the round-trip test over `parseTopic`, which fails the moment the two drift.
+const char* kTopicEnumJson =
+    R"json({"type":"array","minItems":1,"maxItems":10,
+            "items":{"type":"string","enum":["project","tracks","clips","devices","selection",
+                                             "transport","session","automation","meters",
+                                             "playhead"]}})json";
+
+juce::var topicListSchema() {
+    return parseSchema(kTopicEnumJson);
+}
+
+/// `{"topics":[…]}` with topics optional — absent means every subscribed topic.
+juce::var topicSelectionSchema() {
+    auto schema = parseSchema(R"json({
+        "type":"object","properties":{"topics":{}},"additionalProperties":false
+    })json");
+    schema["properties"].getDynamicObject()->setProperty("topics", topicListSchema());
+    return schema;
+}
+
+juce::var subscribeInputSchema() {
+    auto schema = parseSchema(R"json({
+        "type":"object",
+        "properties":{
+            "topics":{},
+            "fromRevision":{"type":"integer","minimum":0},
+            "snapshot":{"type":"boolean"}
+        },
+        "required":["topics"],"additionalProperties":false
+    })json");
+    schema["properties"].getDynamicObject()->setProperty("topics", topicListSchema());
+    return schema;
+}
+
+/**
+ * @brief The pushed envelope, published so a client can generate against it.
+ *
+ * `payload` is deliberately unconstrained: for a snapshot it is the matching
+ * read operation's output, for a delta it is `{added,updated,removed}` or that
+ * same output, and for a sample it is a meter or playhead reading. Declaring one
+ * shape here would be declaring a false one.
+ */
+const juce::var& subscriptionEventSchema() {
+    static const auto value = parseSchema(R"json({
+        "type":"object",
+        "properties":{
+            "topic":{"type":"string"},
+            "type":{"type":"string","enum":["snapshot","delta","sample"]},
+            "revision":{"type":"integer","minimum":0},
+            "payload":{}
+        },
+        "required":["topic","type","revision","payload"],
+        "additionalProperties":false
+    })json");
+    return value;
+}
+
+/// `withSnapshots` distinguishes the two methods that hand back initial state
+/// in their reply from the two that only report what is subscribed.
+juce::var subscriptionResultSchema(bool withSnapshots) {
+    auto schema = parseSchema(R"json({
+        "type":"object",
+        "properties":{
+            "topics":{"type":"array","items":{"type":"string"}},
+            "revision":{"type":"integer","minimum":0}
+        },
+        "required":["topics","revision"],
+        "additionalProperties":false
+    })json");
+    if (!withSnapshots)
+        return schema;
+
+    auto* properties = schema["properties"].getDynamicObject();
+    properties->setProperty("snapshots", arraySchema(subscriptionEventSchema()));
+    schema.getDynamicObject()->setProperty(
+        "required", juce::var(juce::Array<juce::var>{juce::var("topics"), juce::var("revision"),
+                                                     juce::var("snapshots")}));
+    return schema;
+}
+
 bool matchesType(const juce::var& value, const juce::String& type) {
     if (type == "object")
         return value.getDynamicObject() != nullptr;
@@ -567,6 +652,9 @@ void validateValue(const juce::var& value, const juce::var& schema, const juce::
         const auto maxItems = schemaObject->getProperty("maxItems");
         if (!maxItems.isVoid() && array->size() > static_cast<int>(maxItems))
             addIssue(issues, path, "max_items", "Array exceeds the allowed item count");
+        const auto minItems = schemaObject->getProperty("minItems");
+        if (!minItems.isVoid() && array->size() < static_cast<int>(minItems))
+            addIssue(issues, path, "min_items", "Array has fewer items than allowed");
         const auto itemSchema = schemaObject->getProperty("items");
         if (!itemSchema.isVoid()) {
             for (int index = 0; index < array->size(); ++index)
@@ -1427,6 +1515,8 @@ OperationRegistry::OperationRegistry() {
         })json"),
         sessionSchema());
 
+    add("automation.listLanes", "List every automation lane in the project", OperationAccess::Read,
+        &handlers::automationListLanes, emptyObjectSchema(), arraySchema(automationLaneSchema()));
     add("automation.getLane", "Get an automation lane", OperationAccess::Read,
         &handlers::automationGetLane, operationInputSchema(R"json({
             "type":"object","properties":{"laneId":{"type":"integer","minimum":0}},
@@ -1465,13 +1555,47 @@ OperationRegistry::OperationRegistry() {
         })json"),
         automationLaneSchema());
 
+    // -----------------------------------------------------------------------
+    // Subscriptions (#1857)
+    //
+    // Declared here and executed by the transport. Subscribing is per-connection
+    // state and the dispatcher has no connections, but the contract — names,
+    // schemas, what a snapshot looks like — has to be one thing or the WebSocket
+    // and MCP adapters will grow two. `system.describe` therefore lists these
+    // like any other operation, marked so a client can tell that reaching them
+    // needs a transport that can push.
+    // -----------------------------------------------------------------------
+
+    auto addTransportScoped = [this](const char* name, const char* summary, juce::var input,
+                                     juce::var output) {
+        input = input.clone();
+        applyRequestLimits(input);
+        operations_.push_back({juce::String(name), juce::String(summary), OperationAccess::Read,
+                               std::move(input), std::move(output), nullptr, true});
+    };
+
+    addTransportScoped(
+        "subscriptions.subscribe",
+        "Start receiving change events for the given topics, with an initial snapshot",
+        subscribeInputSchema(), subscriptionResultSchema(true));
+    addTransportScoped("subscriptions.unsubscribe",
+                       "Stop receiving change events; no topics means every topic",
+                       topicSelectionSchema(), subscriptionResultSchema(false));
+    addTransportScoped("subscriptions.list", "List the topics this connection is subscribed to",
+                       emptyObjectSchema(), subscriptionResultSchema(false));
+    addTransportScoped("subscriptions.resync",
+                       "Re-send a complete snapshot for the subscribed topics",
+                       topicSelectionSchema(), subscriptionResultSchema(true));
+
     // A declared operation with no implementation is a startup failure, not a
     // runtime surprise. Before handlers lived on the descriptor there was
     // nothing to catch it, and the registry advertised 36 operations that
-    // `system.describe` would happily list and no transport could execute.
+    // `system.describe` would happily list and no transport could execute. A
+    // transport-scoped operation is the one legitimate exception: its
+    // implementation lives in the adapter, so there is nothing to point at here.
     for (const auto& operation : operations_) {
-        jassert(operation.handler != nullptr);
-        if (operation.handler == nullptr)
+        jassert(operation.transportScoped == (operation.handler == nullptr));
+        if (!operation.transportScoped && operation.handler == nullptr)
             juce::Logger::writeToLog("Remote API operation has no handler: " + operation.name);
     }
 }
@@ -1502,6 +1626,9 @@ juce::var OperationRegistry::describe() const {
         object->setProperty("access", operation.access == OperationAccess::Read ? "read" : "write");
         object->setProperty("inputSchema", operation.inputSchema.clone());
         object->setProperty("outputSchema", operation.outputSchema.clone());
+        // Always present rather than only when true: a client deciding whether
+        // it can call something should read a field, not infer one from silence.
+        object->setProperty("transportScoped", operation.transportScoped);
         operations.add(object);
     }
     result->setProperty("operations", operations);

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -482,12 +482,20 @@ juce::var topicSelectionSchema() {
     return schema;
 }
 
+/**
+ * @brief `{"topics":[…], "snapshot": true}`.
+ *
+ * No revision to resume from. A project revision counts committed mutations,
+ * and subscription events are also published for motion that commits nothing,
+ * so naming a revision cannot establish that a client saw every event up to it.
+ * `snapshot:false` is the deliberate opt-out — the client asserting it has state
+ * and will resync itself — rather than the server guessing on its behalf.
+ */
 juce::var subscribeInputSchema() {
     auto schema = parseSchema(R"json({
         "type":"object",
         "properties":{
             "topics":{},
-            "fromRevision":{"type":"integer","minimum":0},
             "snapshot":{"type":"boolean"}
         },
         "required":["topics"],"additionalProperties":false

--- a/magda/daw/api/remote_api.hpp
+++ b/magda/daw/api/remote_api.hpp
@@ -376,8 +376,27 @@ struct OperationDescriptor {
      * a table keyed by name so a transport cannot reach a different
      * implementation than the one declared — there is only one place to look,
      * and the registry constructor asserts every declared operation has one.
+     *
+     * Null only for a `transportScoped` operation, which by definition has no
+     * implementation that could run here.
      */
     OperationHandler handler = nullptr;
+
+    /**
+     * Executed by the transport adapter rather than by `RemoteApiService`.
+     *
+     * The subscription methods (#1857) are the reason this exists: subscribing
+     * is per-connection state, and a connection is the one thing the dispatcher
+     * deliberately knows nothing about. Their names, summaries, and schemas
+     * still belong here — that is what stops the WebSocket and MCP adapters
+     * declaring two different contracts for the same thing, and what keeps
+     * `system.describe` a complete catalogue.
+     *
+     * Dispatching one through the service is an error, and says so, rather than
+     * failing as an unknown operation: a client that reaches this has asked for
+     * something real over a transport that cannot carry it.
+     */
+    bool transportScoped = false;
 };
 
 class OperationRegistry {

--- a/magda/daw/api/remote_api_host.cpp
+++ b/magda/daw/api/remote_api_host.cpp
@@ -6,6 +6,7 @@
 #include "Config.hpp"
 #include "remote_model_bridge.hpp"
 #include "remote_service.hpp"
+#include "remote_subscriptions.hpp"
 #include "remote_websocket_server.hpp"
 
 #if JUCE_WINDOWS
@@ -152,9 +153,13 @@ bool writeTokenFile(const juce::File& file, const juce::String& token, int port)
 
 }  // namespace
 
-RemoteApiHost::RemoteApiHost(MagdaApi& api)
+RemoteApiHost::RemoteApiHost(MagdaApi& api, AudioEngine* engine)
     : service_(std::make_unique<RemoteApiService>(api)),
-      bridge_(std::make_unique<ModelChangeBridge>(*service_)) {}
+      bridge_(std::make_unique<ModelChangeBridge>(*service_)),
+      subscriptions_(std::make_unique<SubscriptionHub>(api, *service_)) {
+    if (engine != nullptr)
+        subscriptions_->setMeterSource(makeLiveMeterSource(*engine));
+}
 
 RemoteApiHost::~RemoteApiHost() {
     stop();
@@ -193,7 +198,7 @@ bool RemoteApiHost::start() {
     for (const auto& origin : config.getRemoteApiAllowedOrigins())
         options.allowedOrigins.push_back(juce::String::fromUTF8(origin.c_str()));
 
-    server_ = std::make_unique<RemoteWebSocketServer>(*service_, options);
+    server_ = std::make_unique<RemoteWebSocketServer>(*service_, options, subscriptions_.get());
     if (!server_->start()) {
         server_.reset();
         token_ = {};
@@ -220,6 +225,11 @@ void RemoteApiHost::stop() {
         server_->stop();
         server_.reset();
     }
+    // After the server, so no connection is still registered, and before the
+    // service's own shutdown, because this is what detaches the change listener
+    // the service owns.
+    if (subscriptions_ != nullptr)
+        subscriptions_->shutdown();
     // The token dies with the run that generated it; leaving the file behind
     // would advertise a port that is no longer listening and a credential that
     // no longer works.
@@ -245,6 +255,10 @@ juce::File RemoteApiHost::tokenFile() const {
 
 RemoteApiService& RemoteApiHost::service() {
     return *service_;
+}
+
+SubscriptionHub& RemoteApiHost::subscriptions() {
+    return *subscriptions_;
 }
 
 }  // namespace remote

--- a/magda/daw/api/remote_api_host.hpp
+++ b/magda/daw/api/remote_api_host.hpp
@@ -6,6 +6,7 @@
 
 namespace magda {
 
+class AudioEngine;
 class MagdaApi;
 
 namespace remote {
@@ -13,6 +14,7 @@ namespace remote {
 class ModelChangeBridge;
 class RemoteApiService;
 class RemoteWebSocketServer;
+class SubscriptionHub;
 
 /**
  * @brief Owns the remote API for the lifetime of a running MAGDA (#1856).
@@ -59,7 +61,16 @@ class RemoteWebSocketServer;
  */
 class RemoteApiHost {
   public:
-    explicit RemoteApiHost(MagdaApi& api);
+    /**
+     * @brief Construct the remote API over a facade, and optionally an engine.
+     *
+     * `engine` is what the `meters` subscription reads (#1857) and the only
+     * thing it is used for. Passing nothing is a supported configuration, not a
+     * degraded one: the whole API works, and `meters` delivers empty samples
+     * rather than failing — a host with no audio engine is not something a
+     * remote client can detect or act on.
+     */
+    explicit RemoteApiHost(MagdaApi& api, AudioEngine* engine = nullptr);
     ~RemoteApiHost();
 
     RemoteApiHost(const RemoteApiHost&) = delete;
@@ -90,9 +101,19 @@ class RemoteApiHost {
     /// its own.
     RemoteApiService& service();
 
+    /// The subscription hub, for the same reason: MCP resource updates and
+    /// WebSocket subscriptions have to be fed by one projection of the model,
+    /// not two.
+    SubscriptionHub& subscriptions();
+
   private:
+    // Declaration order is destruction order reversed, and it is load-bearing:
+    // the server's connections deregister from the hub, the hub listens to the
+    // service's change source, and the bridge writes into the service. Each has
+    // to outlive the thing that talks to it.
     std::unique_ptr<RemoteApiService> service_;
     std::unique_ptr<ModelChangeBridge> bridge_;
+    std::unique_ptr<SubscriptionHub> subscriptions_;
     std::unique_ptr<RemoteWebSocketServer> server_;
     juce::String token_;
 };

--- a/magda/daw/api/remote_changes.cpp
+++ b/magda/daw/api/remote_changes.cpp
@@ -37,6 +37,10 @@ const char* toString(Topic topic) {
     return "project";
 }
 
+bool isContinuousTopic(Topic topic) {
+    return topic == Topic::Meters || topic == Topic::Playhead;
+}
+
 std::optional<Topic> parseTopic(juce::StringRef topic) {
     const juce::String name(topic);
     for (std::size_t index = 0; index < TOPIC_COUNT; ++index) {

--- a/magda/daw/api/remote_changes.hpp
+++ b/magda/daw/api/remote_changes.hpp
@@ -42,6 +42,16 @@ const char* toString(Topic topic);
 std::optional<Topic> parseTopic(juce::StringRef topic);
 
 /**
+ * @brief True for `Meters` and `Playhead`.
+ *
+ * The two that are sampled rather than published. Nothing in the model marks
+ * them — the playhead moves without notifying anyone — so they are never part of
+ * a "everything changed" sweep and never carry a revisioned delta. Callers that
+ * iterate every topic almost always mean the eight discrete ones.
+ */
+bool isContinuousTopic(Topic topic);
+
+/**
  * @brief Coalescing, revisioned source of "what changed".
  *
  * Sits between MAGDA's model listeners and every remote transport. Model

--- a/magda/daw/api/remote_handlers.cpp
+++ b/magda/daw/api/remote_handlers.cpp
@@ -646,6 +646,13 @@ HandlerResult sessionLaunchScene(MagdaApi& api, const juce::var& input, const Re
 // Automation
 // ===========================================================================
 
+HandlerResult automationListLanes(MagdaApi& api, const juce::var&, const RequestContext&) {
+    std::vector<juce::var> items;
+    for (const auto& lane : api.automation().getLanes())
+        items.push_back(toJson(makeAutomationLaneDto(lane)));
+    return HandlerResult::ok(toJsonArray(items));
+}
+
 HandlerResult automationGetLane(MagdaApi& api, const juce::var& input, const RequestContext&) {
     const auto laneId = static_cast<AutomationLaneId>(static_cast<int>(input["laneId"]));
     const auto* lane = api.automation().getLane(laneId);

--- a/magda/daw/api/remote_handlers.hpp
+++ b/magda/daw/api/remote_handlers.hpp
@@ -73,6 +73,7 @@ HandlerResult sessionStopAll(MagdaApi&, const juce::var&, const RequestContext&)
 HandlerResult sessionLaunchScene(MagdaApi&, const juce::var&, const RequestContext&);
 
 // Automation
+HandlerResult automationListLanes(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult automationGetLane(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult automationCreateLane(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult automationAddPoint(MagdaApi&, const juce::var&, const RequestContext&);

--- a/magda/daw/api/remote_meters_live.cpp
+++ b/magda/daw/api/remote_meters_live.cpp
@@ -1,0 +1,67 @@
+#include "../audio/AudioBridge.hpp"
+#include "../engine/AudioEngine.hpp"
+#include "remote_subscriptions.hpp"
+
+namespace magda::remote {
+namespace {
+
+/**
+ * Reads the levels the audio path has already published, and nothing else.
+ *
+ * The audio thread's part of metering is over before this runs: `LevelMeasurer`
+ * clients are drained on the message thread at 30 Hz and pushed into a lock-free
+ * ring, and this drains that ring. So there is no WebSocket work on the audio
+ * thread, no work added to it, and no new tap in the graph — a meter subscriber
+ * costs the audio path exactly nothing.
+ *
+ * `drainToLatest` rather than `peekLatest`: the ring is eight deep and pushes
+ * keep arriving whether or not anyone reads, so a reader that never consumes
+ * sees the ring fill and then stops seeing anything new. Draining to the newest
+ * value is also the sampling policy the subscription asks for — latest value
+ * wins, intermediate readings discarded.
+ *
+ * This is a dedicated ring, not the one the mixer reads, because popping from
+ * that one would take frames away from the on-screen meters.
+ */
+class LiveMeterSource final : public MeterSource {
+  public:
+    explicit LiveMeterSource(AudioEngine& engine) : engine_(engine) {}
+
+    std::vector<TrackLevels> sample() override {
+        std::vector<TrackLevels> levels;
+
+        auto* bridge = engine_.getAudioBridge();
+        if (bridge == nullptr)
+            return levels;
+
+        // The ring is indexed by track id, so ask the tracks that exist rather
+        // than sweeping all 128 slots. Ids come from the ring's own bound, which
+        // is what makes the loop safe without knowing the project.
+        auto& buffer = bridge->getRemoteMeteringBuffer();
+        for (TrackId trackId = 0; trackId < MeteringBuffer::kMaxTracks; ++trackId) {
+            MeterData data;
+            if (!buffer.drainToLatest(trackId, data))
+                continue;
+            levels.push_back({trackId, data.peakL, data.peakR, data.clipped});
+        }
+
+        // The master bus is metered separately — it has no track id and no ring,
+        // just a pair of atomics the same 30 Hz pass writes. It is reported under
+        // the master sentinel so a client addresses it the way it addresses the
+        // master track everywhere else in the API.
+        levels.push_back({MASTER_TRACK_ID, bridge->getMasterPeakL(), bridge->getMasterPeakR(),
+                          bridge->getMasterPeakL() > 1.0f || bridge->getMasterPeakR() > 1.0f});
+        return levels;
+    }
+
+  private:
+    AudioEngine& engine_;
+};
+
+}  // namespace
+
+std::unique_ptr<MeterSource> makeLiveMeterSource(AudioEngine& engine) {
+    return std::make_unique<LiveMeterSource>(engine);
+}
+
+}  // namespace magda::remote

--- a/magda/daw/api/remote_model_bridge_live.cpp
+++ b/magda/daw/api/remote_model_bridge_live.cpp
@@ -61,7 +61,9 @@ class ModelChangeBridge::Impl final : public TrackManagerListener,
     // ---- TrackManagerListener -------------------------------------------
 
     void tracksChanged() override {
-        service_.noteModelChanged(Topic::Tracks);
+        // Session slots are keyed by track, so a track appearing or going away
+        // adds or removes a whole column of the grid.
+        service_.noteModelChanged({Topic::Tracks, Topic::Session});
     }
     void trackPropertyChanged(int) override {
         service_.noteModelChanged(Topic::Tracks);
@@ -101,17 +103,21 @@ class ModelChangeBridge::Impl final : public TrackManagerListener,
 
     // ---- ClipManagerListener --------------------------------------------
 
+    // The session grid is projected out of the clips rather than stored beside
+    // them, so anything that adds, removes, or moves a clip can change it. The
+    // extra topic costs nothing when it did not: an unchanged projection is
+    // coalesced away before an event is built.
     void clipsChanged() override {
-        service_.noteModelChanged(Topic::Clips);
+        service_.noteModelChanged({Topic::Clips, Topic::Session});
     }
     void clipPropertyChanged(ClipId) override {
-        service_.noteModelChanged(Topic::Clips);
+        service_.noteModelChanged({Topic::Clips, Topic::Session});
     }
     void clipPropertiesChanged(const std::vector<ClipId>&) override {
         // Overridden rather than inherited: the base implementation fans out to
         // one clipPropertyChanged per id, which would be one revision bump per
         // clip for what the user did as a single multi-selection drag.
-        service_.noteModelChanged(Topic::Clips);
+        service_.noteModelChanged({Topic::Clips, Topic::Session});
     }
     void clipSelectionChanged(ClipId) override {
         service_.noteModelChanged(Topic::Selection);

--- a/magda/daw/api/remote_service.cpp
+++ b/magda/daw/api/remote_service.cpp
@@ -168,6 +168,19 @@ void RemoteApiService::dispatch(const juce::String& operationName, const juce::v
         return;
     }
 
+    // A subscription method reached the dispatcher, which means the transport
+    // that received it cannot push. Saying so beats UnknownOperation: the
+    // operation is real and the client's request is well formed, and the only
+    // thing wrong is where it arrived.
+    if (operation->transportScoped) {
+        onComplete(Response::failure(ErrorCode::InvalidRequest,
+                                     operationName +
+                                         " is handled by the transport, and this transport "
+                                         "does not support subscriptions",
+                                     revision));
+        return;
+    }
+
     // Validation happens here, on the caller's thread, precisely because it is
     // a pure function of the request: a malformed or oversized payload is
     // rejected without ever occupying the message thread.

--- a/magda/daw/api/remote_service.cpp
+++ b/magda/daw/api/remote_service.cpp
@@ -23,12 +23,19 @@ namespace {
 std::vector<Topic> topicsFor(const juce::String& operationName) {
     if (operationName.startsWith("project."))
         return {Topic::Project};
+    // Session slots are keyed by track and derived from clips, so a track
+    // disappearing takes its column of the grid with it.
     if (operationName == "tracks.create" || operationName == "tracks.delete")
-        return {Topic::Tracks, Topic::Clips, Topic::Devices};
+        return {Topic::Tracks, Topic::Clips, Topic::Devices, Topic::Session};
     if (operationName.startsWith("tracks."))
         return {Topic::Tracks};
+    // `session.get` projects its slots out of the clips, so creating or deleting
+    // one changes the session grid whether or not the request said "session".
+    // Over-broad on the clip operations that cannot affect it — adding a note —
+    // which costs nothing: an unchanged projection is coalesced away before any
+    // event is built.
     if (operationName.startsWith("clips."))
-        return {Topic::Clips};
+        return {Topic::Clips, Topic::Session};
     if (operationName.startsWith("devices.") || operationName.startsWith("racks."))
         return {Topic::Devices};
     if (operationName.startsWith("selection."))
@@ -402,9 +409,21 @@ void RemoteApiService::projectReplaced() {
     // silently applied to different state. Pending changes describe the
     // outgoing project, so they are dropped rather than delivered — but the
     // swap itself is published, at the new revision, so subscribers resync.
+    //
+    // Every discrete topic, not just `project`: a different project has
+    // different tracks, clips, devices, selection, session grid, automation, and
+    // transport state, and a subscriber watching only one of those would
+    // otherwise hear nothing at all and keep showing the old project's contents
+    // until something happened to change that topic in the new one. The two
+    // continuous topics are excluded because nothing marks them — a meter
+    // reading is sampled, not invalidated.
     const auto revision = revision_.fetch_add(1, std::memory_order_acq_rel) + 1;
     changes_.discardPending();
-    changes_.markChanged(Topic::Project, revision);
+    for (std::size_t index = 0; index < TOPIC_COUNT; ++index) {
+        const auto topic = static_cast<Topic>(index);
+        if (!isContinuousTopic(topic))
+            changes_.markChanged(topic, revision);
+    }
 
     {
         const std::lock_guard<std::mutex> lock(cacheMutex_);
@@ -413,20 +432,26 @@ void RemoteApiService::projectReplaced() {
 }
 
 void RemoteApiService::noteModelChanged(Topic topic) {
+    noteModelChanged({topic});
+}
+
+void RemoteApiService::noteModelChanged(std::initializer_list<Topic> topics) {
     if (shutdown_.load(std::memory_order_acquire))
         return;
 
     // Fired from inside a handler's own mutation. The dispatcher publishes one
     // revision for the whole request when the handler returns, so bumping again
-    // here would advance it two or more times for one logical write. The topic
-    // is still marked, so subscribers see the change either way.
+    // here would advance it two or more times for one logical write. The topics
+    // are still marked, so subscribers see the change either way.
     if (isExecutingOnThisThread()) {
-        changes_.markChanged(topic, currentRevision() + 1);
+        for (const auto topic : topics)
+            changes_.markChanged(topic, currentRevision() + 1);
         return;
     }
 
     const auto revision = revision_.fetch_add(1, std::memory_order_acq_rel) + 1;
-    changes_.markChanged(topic, revision);
+    for (const auto topic : topics)
+        changes_.markChanged(topic, revision);
 }
 
 void RemoteApiService::noteModelActivity(Topic topic) {

--- a/magda/daw/api/remote_service.hpp
+++ b/magda/daw/api/remote_service.hpp
@@ -132,6 +132,16 @@ class RemoteApiService {
     void noteModelChanged(Topic topic);
 
     /**
+     * @brief The same, for a change that invalidates several topics at once.
+     *
+     * One revision for the whole set rather than one per topic. Creating a
+     * session clip changes both `clips` and the `session` grid derived from it,
+     * and that is one edit — advancing the counter twice for it would be the
+     * same double-bump the re-entrancy check above exists to prevent.
+     */
+    void noteModelChanged(std::initializer_list<Topic> topics);
+
+    /**
      * @brief Record continuous movement on a topic without bumping the revision.
      *
      * For values that change at automation or gesture rate — a drag preview, a

--- a/magda/daw/api/remote_subscriptions.cpp
+++ b/magda/daw/api/remote_subscriptions.cpp
@@ -19,12 +19,6 @@ std::size_t indexOf(Topic topic) {
     return static_cast<std::size_t>(topic);
 }
 
-/// Sampled rather than published: driven by their own timer, never by a model
-/// notification, and never delta-encoded.
-bool isSampled(Topic topic) {
-    return topic == Topic::Meters || topic == Topic::Playhead;
-}
-
 juce::var makeObject() {
     return juce::var(new juce::DynamicObject());
 }
@@ -442,7 +436,7 @@ void SubscriptionHub::applyTopology() {
             const auto topic = static_cast<Topic>(index);
             if (!anySubscriberLocked(topic))
                 continue;
-            if (isSampled(topic))
+            if (isContinuousTopic(topic))
                 wantSampler = true;
             else
                 wantChanges = true;
@@ -599,51 +593,73 @@ void SubscriptionHub::deliverLocked(Client& client, const SubscriptionEvent& eve
     ++client.consecutiveDrops;
 }
 
+bool SubscriptionHub::owesSnapshotLocked(Topic topic) const {
+    const auto index = indexOf(topic);
+    return std::any_of(clients_.begin(), clients_.end(), [index](const Client& client) {
+        return client.subscribed[index] && client.needsSnapshot[index];
+    });
+}
+
 void SubscriptionHub::publishTopicLocked(Topic topic, Revision revision) {
     const auto index = indexOf(topic);
+
+    // A client that refused an event is owed complete state, and it is owed it
+    // whether or not anything has changed since. Deciding that before the
+    // early-out below is what makes the promise good: otherwise the snapshot
+    // would arrive only on the next observable change, and a client that dropped
+    // one event from a project that then went quiet would stay stale until it
+    // thought to ask for a resync.
+    const bool owed = owesSnapshotLocked(topic);
+
     auto current = projectTopic(topic);
     auto& state = topics_[index];
+    const bool hadBaseline = state.hasBaseline;
 
     SubscriptionEvent delta{topic, SubscriptionEvent::Type::Delta, revision, {}};
-    bool haveDelta = false;
+    bool changed = !hadBaseline;
 
-    if (state.hasBaseline) {
+    if (hadBaseline) {
         if (!keyFieldsFor(topic).empty()) {
             const auto difference = diffElements(topic, state.baseline, current);
-            if (!difference.changed()) {
-                // The topic was marked but nothing observable changed — a
-                // parameter that came back to where it started, or a
-                // notification for state this projection does not expose. The
-                // coalescing that matters most is the event never sent.
-                state.baseline = current;
-                return;
-            }
-            delta.payload = difference.toJson();
+            changed = difference.changed();
+            if (changed)
+                delta.payload = difference.toJson();
         } else {
-            if (deepEquals(state.baseline, current)) {
-                state.baseline = current;
-                return;
-            }
-            delta.payload = current;
+            changed = !deepEquals(state.baseline, current);
+            if (changed)
+                delta.payload = current;
         }
-        haveDelta = true;
     }
 
     state.baseline = current;
     state.hasBaseline = true;
+
+    // The topic was marked but nothing observable changed — a parameter that
+    // came back to where it started, or a notification for state this projection
+    // does not expose — and nobody is behind. The coalescing that matters most
+    // is the event never sent.
+    if (!changed && !owed)
+        return;
 
     const SubscriptionEvent snapshot{topic, SubscriptionEvent::Type::Snapshot, revision, current};
 
     for (auto& client : clients_) {
         if (!client.subscribed[index])
             continue;
-        const bool complete = client.needsSnapshot[index] || !haveDelta;
-        deliverLocked(client, complete ? snapshot : delta);
+        if (client.needsSnapshot[index] || !hadBaseline) {
+            deliverLocked(client, snapshot);
+            continue;
+        }
+        // A client that is current and has nothing to be told: this pass exists
+        // only for the ones that are behind.
+        if (changed)
+            deliverLocked(client, delta);
     }
 }
 
 void SubscriptionHub::publish(const std::vector<ChangeSource::Change>& changes) {
     bool dropped = false;
+    std::vector<Topic> stillOwed;
     {
         const std::lock_guard<std::mutex> lock(mutex_);
         if (shutdown_)
@@ -652,7 +668,7 @@ void SubscriptionHub::publish(const std::vector<ChangeSource::Change>& changes) 
         for (const auto& change : changes) {
             // Nothing marks these, and if something did, a revisioned delta is
             // the wrong shape for a continuous signal.
-            if (isSampled(change.topic))
+            if (isContinuousTopic(change.topic))
                 continue;
             if (!anySubscriberLocked(change.topic))
                 continue;
@@ -660,6 +676,24 @@ void SubscriptionHub::publish(const std::vector<ChangeSource::Change>& changes) 
         }
 
         dropped = dropAbandonedLocked();
+
+        for (std::size_t index = 0; index < TOPIC_COUNT; ++index) {
+            const auto topic = static_cast<Topic>(index);
+            if (!isContinuousTopic(topic) && owesSnapshotLocked(topic))
+                stillOwed.push_back(topic);
+        }
+    }
+
+    // A client that refused again is owed a snapshot that nothing else will
+    // deliver: a quiet project produces no flush at all, so there would be no
+    // next attempt. Marking the topic dirty schedules one, which keeps the retry
+    // on the coalescing pump that already exists rather than giving it a timer
+    // of its own — and keeps the disconnect budget meaning what it says, since
+    // each retry is one more flush the client refused.
+    if (!stillOwed.empty()) {
+        const auto revision = service_.currentRevision();
+        for (const auto topic : stillOwed)
+            service_.changes().markChanged(topic, revision);
     }
 
     // Only when the client set actually changed. This runs inside the flush
@@ -690,18 +724,31 @@ bool SubscriptionHub::dropAbandonedLocked() {
     if (options_.droppedFlushesBeforeDisconnect <= 0)
         return false;
 
-    const auto abandoned =
-        std::remove_if(clients_.begin(), clients_.end(), [this](const Client& client) {
-            return client.consecutiveDrops >= options_.droppedFlushesBeforeDisconnect;
-        });
-    if (abandoned == clients_.end())
+    const auto abandoned = [this](const Client& client) {
+        return client.consecutiveDrops >= options_.droppedFlushesBeforeDisconnect;
+    };
+
+    // Collected before anything is removed, and deliberately not from the tail
+    // that `remove_if` leaves behind. That tail holds moved-from elements, not
+    // the ones that matched: with a stalled client followed by a healthy one,
+    // the healthy one is moved over the stalled one and what remains at the end
+    // is a hollowed-out copy whose `disconnect` is empty. The stalled client
+    // would then be dropped from the hub while keeping its socket, its thread,
+    // and its connection slot — silently, because the callback that was supposed
+    // to close it no longer exists.
+    std::vector<Disconnect> departing;
+    for (const auto& client : clients_)
+        if (abandoned(client) && client.disconnect != nullptr)
+            departing.push_back(client.disconnect);
+
+    const auto removed = std::remove_if(clients_.begin(), clients_.end(), abandoned);
+    if (removed == clients_.end())
         return false;
+    clients_.erase(removed, clients_.end());
 
-    for (auto it = abandoned; it != clients_.end(); ++it)
-        if (it->disconnect != nullptr)
-            it->disconnect("subscriber is not consuming events");
+    for (const auto& disconnect : departing)
+        disconnect("subscriber is not consuming events");
 
-    clients_.erase(abandoned, clients_.end());
     releaseIdleTopicsLocked();
     return true;
 }
@@ -713,7 +760,7 @@ bool SubscriptionHub::dropAbandonedLocked() {
 void SubscriptionHub::sendSnapshotsLocked(Client& client, const std::vector<Topic>& topics,
                                           Revision revision, juce::Array<juce::var>& into) {
     for (const auto topic : topics) {
-        if (isSampled(topic))
+        if (isContinuousTopic(topic))
             continue;
 
         const auto index = indexOf(topic);
@@ -847,7 +894,7 @@ Response SubscriptionHub::execute(ClientId client, const juce::String& method,
                 sendSnapshotsLocked(*entry, requested, revision, snapshots);
             else
                 for (const auto topic : requested)
-                    if (!isSampled(topic) && !topics_[indexOf(topic)].hasBaseline) {
+                    if (!isContinuousTopic(topic) && !topics_[indexOf(topic)].hasBaseline) {
                         topics_[indexOf(topic)].baseline = projectTopic(topic);
                         topics_[indexOf(topic)].hasBaseline = true;
                     }

--- a/magda/daw/api/remote_subscriptions.cpp
+++ b/magda/daw/api/remote_subscriptions.cpp
@@ -925,17 +925,23 @@ Response SubscriptionHub::execute(ClientId client, const juce::String& method,
             for (const auto topic : requested)
                 entry->subscribed[indexOf(topic)] = true;
 
-            // A client that reconnects at the revision the project is still on
-            // has missed no committed change and may skip the snapshots. Any
-            // other revision — including one it never saw — is an explicit
-            // resync, because no per-revision history is kept to replay from.
-            const auto from = params["fromRevision"];
-            const bool current = !from.isVoid() && static_cast<juce::int64>(from) ==
-                                                       static_cast<juce::int64>(revision);
+            // Subscribing snapshots, and the only thing that stops it is the
+            // client saying so.
+            //
+            // There was a `fromRevision` here that skipped the snapshots when a
+            // reconnecting client named the revision the project was still on.
+            // It cannot work: `noteModelActivity` publishes events without
+            // advancing the revision — a clip's play state, a parameter under
+            // automation — so a client can disconnect at revision N, miss one of
+            // those, and come back naming N. The revision is a commit cursor and
+            // proves only that nothing was committed; establishing event
+            // continuity would need a second, per-topic cursor on the wire, and
+            // being wrong about it leaves a client silently stale, which is the
+            // failure this whole design is meant to make impossible.
             const auto wanted = params["snapshot"];
             const bool asked = wanted.isVoid() || static_cast<bool>(wanted);
 
-            if (asked && !current)
+            if (asked)
                 sendSnapshotsLocked(*entry, requested, revision, snapshots);
             else
                 for (const auto topic : requested)

--- a/magda/daw/api/remote_subscriptions.cpp
+++ b/magda/daw/api/remote_subscriptions.cpp
@@ -264,7 +264,24 @@ struct SubscriptionHub::Client {
     /// Set when a delivery was refused: the client has no baseline for the
     /// delta it just missed, so the next thing it takes has to be complete.
     std::array<bool, TOPIC_COUNT> needsSnapshot{};
+
+    /// Flushes in a row in which this client refused something.
     int consecutiveDrops = 0;
+
+    /**
+     * What happened to this client during the flush now in progress.
+     *
+     * Meaningful only between the start and the end of one `publish`, which
+     * resets them and folds them into `consecutiveDrops` exactly once. They
+     * exist because a flush delivers up to one event per subscribed topic, and
+     * per-event accounting gets both directions wrong: several refusals in one
+     * flush would count as several flushes, and — worse — a client that accepts
+     * one topic and refuses another every time would have the counter reset by
+     * the acceptance before the refusal put it back, so it would sit at one
+     * forever while the refused topic stayed permanently stale.
+     */
+    bool refusedThisFlush = false;
+    bool acceptedThisFlush = false;
 };
 
 /**
@@ -579,7 +596,7 @@ void SubscriptionHub::deliverLocked(Client& client, const SubscriptionEvent& eve
         if (event.type == SubscriptionEvent::Type::Snapshot)
             client.needsSnapshot[index] = false;
         if (event.type != SubscriptionEvent::Type::Sample)
-            client.consecutiveDrops = 0;
+            client.acceptedThisFlush = true;
         return;
     }
 
@@ -590,7 +607,27 @@ void SubscriptionHub::deliverLocked(Client& client, const SubscriptionEvent& eve
         return;
 
     client.needsSnapshot[index] = true;
-    ++client.consecutiveDrops;
+    client.refusedThisFlush = true;
+}
+
+/**
+ * Charge one flush against every client that refused something during it.
+ *
+ * A refusal outweighs an acceptance in the same flush: a client keeping up on
+ * one topic while never taking another is not keeping up, and counting the
+ * acceptance would leave it connected and permanently stale on the rest.
+ *
+ * A flush that delivered nothing to a client leaves its count alone. That is not
+ * evidence in either direction, and a subscriber to a quiet topic must not have
+ * its arrears forgiven by the silence.
+ */
+void SubscriptionHub::foldFlushOutcomesLocked() {
+    for (auto& client : clients_) {
+        if (client.refusedThisFlush)
+            ++client.consecutiveDrops;
+        else if (client.acceptedThisFlush)
+            client.consecutiveDrops = 0;
+    }
 }
 
 bool SubscriptionHub::owesSnapshotLocked(Topic topic) const {
@@ -665,6 +702,11 @@ void SubscriptionHub::publish(const std::vector<ChangeSource::Change>& changes) 
         if (shutdown_)
             return;
 
+        for (auto& client : clients_) {
+            client.refusedThisFlush = false;
+            client.acceptedThisFlush = false;
+        }
+
         for (const auto& change : changes) {
             // Nothing marks these, and if something did, a revisioned delta is
             // the wrong shape for a continuous signal.
@@ -675,6 +717,9 @@ void SubscriptionHub::publish(const std::vector<ChangeSource::Change>& changes) 
             publishTopicLocked(change.topic, change.revision);
         }
 
+        // Once per client per flush, after every topic has had its turn, so the
+        // unit the disconnect threshold counts is the one it is named for.
+        foldFlushOutcomesLocked();
         dropped = dropAbandonedLocked();
 
         for (std::size_t index = 0; index < TOPIC_COUNT; ++index) {

--- a/magda/daw/api/remote_subscriptions.cpp
+++ b/magda/daw/api/remote_subscriptions.cpp
@@ -1,0 +1,900 @@
+#include "remote_subscriptions.hpp"
+
+#include <juce_events/juce_events.h>
+
+#include <algorithm>
+
+#include "magda_api.hpp"
+#include "transport_api.hpp"
+
+namespace magda::remote {
+namespace {
+
+constexpr const char* kSubscribe = "subscriptions.subscribe";
+constexpr const char* kUnsubscribe = "subscriptions.unsubscribe";
+constexpr const char* kList = "subscriptions.list";
+constexpr const char* kResync = "subscriptions.resync";
+
+std::size_t indexOf(Topic topic) {
+    return static_cast<std::size_t>(topic);
+}
+
+/// Sampled rather than published: driven by their own timer, never by a model
+/// notification, and never delta-encoded.
+bool isSampled(Topic topic) {
+    return topic == Topic::Meters || topic == Topic::Playhead;
+}
+
+juce::var makeObject() {
+    return juce::var(new juce::DynamicObject());
+}
+
+void setProperty(const juce::var& object, const char* name, const juce::var& value) {
+    if (auto* dynamicObject = object.getDynamicObject())
+        dynamicObject->setProperty(juce::Identifier(name), value);
+}
+
+/**
+ * @brief Structural equality for two projected payloads.
+ *
+ * `juce::var::operator==` compares two DynamicObjects by pointer, so every
+ * re-projection would look different from the one before it and every marked
+ * topic would produce an event whether or not anything changed. Comparing
+ * serialized JSON instead would be correct but allocates a string per element
+ * per flush, which is the wrong cost for something run over every clip in the
+ * project at 30 Hz.
+ */
+bool deepEquals(const juce::var& lhs, const juce::var& rhs) {
+    if (auto* lhsObject = lhs.getDynamicObject()) {
+        auto* rhsObject = rhs.getDynamicObject();
+        if (rhsObject == nullptr)
+            return false;
+
+        const auto& lhsProperties = lhsObject->getProperties();
+        const auto& rhsProperties = rhsObject->getProperties();
+        if (lhsProperties.size() != rhsProperties.size())
+            return false;
+
+        for (int i = 0; i < lhsProperties.size(); ++i) {
+            const auto name = lhsProperties.getName(i);
+            if (!rhsProperties.contains(name))
+                return false;
+            if (!deepEquals(lhsProperties.getValueAt(i), rhsProperties[name]))
+                return false;
+        }
+        return true;
+    }
+
+    if (const auto* lhsArray = lhs.getArray()) {
+        const auto* rhsArray = rhs.getArray();
+        if (rhsArray == nullptr || lhsArray->size() != rhsArray->size())
+            return false;
+        for (int i = 0; i < lhsArray->size(); ++i)
+            if (!deepEquals(lhsArray->getReference(i), rhsArray->getReference(i)))
+                return false;
+        return true;
+    }
+
+    // Anything else is a scalar; a scalar never equals a container.
+    if (rhs.getDynamicObject() != nullptr || rhs.getArray() != nullptr)
+        return false;
+    return lhs == rhs;
+}
+
+/**
+ * @brief The fields that identify one element of a keyed topic.
+ *
+ * Empty for a topic that is not diffed element-wise. `devices` is deliberately
+ * absent: a `DeviceId` is unique only within one track section, so an id-keyed
+ * diff would merge three different devices into one.
+ */
+std::vector<const char*> keyFieldsFor(Topic topic) {
+    switch (topic) {
+        case Topic::Tracks:
+        case Topic::Clips:
+        case Topic::Automation:
+            return {"id"};
+        case Topic::Session:
+            return {"trackId", "sceneIndex"};
+        case Topic::Project:
+        case Topic::Devices:
+        case Topic::Selection:
+        case Topic::Transport:
+        case Topic::Meters:
+        case Topic::Playhead:
+            break;
+    }
+    return {};
+}
+
+/// The member of a keyed topic's payload that holds its elements, or nullptr
+/// when the payload is the array itself.
+const char* collectionFieldFor(Topic topic) {
+    return topic == Topic::Session ? "slots" : nullptr;
+}
+
+const juce::Array<juce::var>* elementsOf(Topic topic, const juce::var& payload) {
+    if (const auto* field = collectionFieldFor(topic))
+        return payload[field].getArray();
+    return payload.getArray();
+}
+
+juce::String keyOf(const juce::var& element, const std::vector<const char*>& fields) {
+    juce::String key;
+    for (const auto* field : fields) {
+        // A unit separator rather than a plain join: two id fields concatenated
+        // bare would make {1, 23} and {12, 3} the same key.
+        key << element[field].toString() << juce::String::charToString(31);
+    }
+    return key;
+}
+
+/// What a `removed` entry carries: the bare id for a single-field key, and the
+/// identifying fields as an object for a composite one.
+juce::var identityOf(const juce::var& element, const std::vector<const char*>& fields) {
+    if (fields.size() == 1)
+        return element[fields.front()];
+
+    auto identity = makeObject();
+    for (const auto* field : fields)
+        setProperty(identity, field, element[field]);
+    return identity;
+}
+
+struct Diff {
+    juce::Array<juce::var> added;
+    juce::Array<juce::var> updated;
+    juce::Array<juce::var> removed;
+
+    bool changed() const {
+        return !added.isEmpty() || !updated.isEmpty() || !removed.isEmpty();
+    }
+
+    juce::var toJson() const {
+        auto payload = makeObject();
+        setProperty(payload, "added", added);
+        setProperty(payload, "updated", updated);
+        setProperty(payload, "removed", removed);
+        return payload;
+    }
+};
+
+Diff diffElements(Topic topic, const juce::var& previous, const juce::var& current) {
+    const auto fields = keyFieldsFor(topic);
+    Diff diff;
+
+    const auto* before = elementsOf(topic, previous);
+    const auto* after = elementsOf(topic, current);
+    if (after == nullptr)
+        return diff;
+
+    std::vector<std::pair<juce::String, const juce::var*>> beforeByKey;
+    if (before != nullptr) {
+        beforeByKey.reserve(static_cast<std::size_t>(before->size()));
+        for (const auto& element : *before)
+            beforeByKey.emplace_back(keyOf(element, fields), &element);
+        std::sort(beforeByKey.begin(), beforeByKey.end(),
+                  [](const auto& lhs, const auto& rhs) { return lhs.first < rhs.first; });
+    }
+
+    const auto find = [&beforeByKey](const juce::String& key) -> const juce::var* {
+        const auto found = std::lower_bound(
+            beforeByKey.begin(), beforeByKey.end(), key,
+            [](const auto& entry, const juce::String& value) { return entry.first < value; });
+        if (found == beforeByKey.end() || found->first != key)
+            return nullptr;
+        return found->second;
+    };
+
+    std::vector<juce::String> seen;
+    seen.reserve(static_cast<std::size_t>(after->size()));
+
+    for (const auto& element : *after) {
+        auto key = keyOf(element, fields);
+        const auto* existing = find(key);
+        if (existing == nullptr)
+            diff.added.add(element);
+        else if (!deepEquals(*existing, element))
+            diff.updated.add(element);
+        seen.push_back(std::move(key));
+    }
+
+    std::sort(seen.begin(), seen.end());
+    for (const auto& [key, element] : beforeByKey)
+        if (!std::binary_search(seen.begin(), seen.end(), key))
+            diff.removed.add(identityOf(*element, fields));
+
+    return diff;
+}
+
+/// The read operation whose output is a topic's complete state. Reusing the
+/// registry's own handlers is what keeps a pushed snapshot byte-identical to
+/// what polling the same operation would return.
+const char* snapshotOperationFor(Topic topic) {
+    switch (topic) {
+        case Topic::Project:
+            return "project.get";
+        case Topic::Tracks:
+            return "tracks.list";
+        case Topic::Clips:
+            return "clips.list";
+        case Topic::Devices:
+            return "devices.list";
+        case Topic::Selection:
+            return "selection.get";
+        case Topic::Transport:
+            return "transport.get";
+        case Topic::Session:
+            return "session.get";
+        case Topic::Automation:
+            return "automation.listLanes";
+        case Topic::Meters:
+        case Topic::Playhead:
+            break;
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+const char* toString(SubscriptionEvent::Type type) {
+    switch (type) {
+        case SubscriptionEvent::Type::Snapshot:
+            return "snapshot";
+        case SubscriptionEvent::Type::Delta:
+            return "delta";
+        case SubscriptionEvent::Type::Sample:
+            return "sample";
+    }
+    return "snapshot";
+}
+
+juce::var SubscriptionEvent::toJson() const {
+    auto event = makeObject();
+    setProperty(event, "topic", juce::String(toString(topic)));
+    setProperty(event, "type", juce::String(toString(type)));
+    setProperty(event, "revision", static_cast<juce::int64>(revision));
+    setProperty(event, "payload", payload);
+    return event;
+}
+
+// ===========================================================================
+// Internals
+// ===========================================================================
+
+struct SubscriptionHub::Client {
+    ClientId id = 0;
+    Sink sink;
+    Disconnect disconnect;
+    std::array<bool, TOPIC_COUNT> subscribed{};
+    /// Set when a delivery was refused: the client has no baseline for the
+    /// delta it just missed, so the next thing it takes has to be complete.
+    std::array<bool, TOPIC_COUNT> needsSnapshot{};
+    int consecutiveDrops = 0;
+};
+
+/**
+ * Drives `sampleNow` for the two continuous topics.
+ *
+ * Separate from the hub for the same reason `ChangeSource::Pump` is: the header
+ * does not inherit `juce::Timer`, and a headless host — where constructing a
+ * Timer is invalid — simply never creates one and calls `sampleNow()` directly.
+ */
+class SubscriptionHub::Sampler : private juce::Timer {
+  public:
+    Sampler(SubscriptionHub& owner, int intervalMs) : owner_(owner) {
+        startTimer(intervalMs);
+    }
+
+    ~Sampler() override {
+        stopTimer();
+    }
+
+  private:
+    void timerCallback() override {
+        owner_.sampleNow();
+    }
+
+    SubscriptionHub& owner_;
+};
+
+/**
+ * Keeps the change-source listener from outliving the hub.
+ *
+ * `ChangeSource::flush` copies its listeners and calls them outside its own
+ * lock, so `removeListener` returns without waiting for a call already in
+ * flight. Taking this mutex and clearing the pointer in `shutdown()` is what
+ * makes "no listener is running and none can start" true — the same shape
+ * `RemoteApiService::ExecutionState` uses for queued work.
+ */
+struct SubscriptionHub::Gate {
+    std::mutex mutex;
+    SubscriptionHub* hub = nullptr;
+};
+
+// ===========================================================================
+// SubscriptionHub
+// ===========================================================================
+
+SubscriptionHub::SubscriptionHub(MagdaApi& api, RemoteApiService& service)
+    : SubscriptionHub(api, service, Options{}) {}
+
+SubscriptionHub::SubscriptionHub(MagdaApi& api, RemoteApiService& service, Options options)
+    : api_(api), service_(service), options_(options), gate_(std::make_shared<Gate>()) {
+    gate_->hub = this;
+}
+
+SubscriptionHub::~SubscriptionHub() {
+    shutdown();
+}
+
+void SubscriptionHub::shutdown() {
+    // Retire the listener first and outside the hub's own lock: this blocks
+    // until any flush already inside publish() has finished, and that flush
+    // needs mutex_ to finish.
+    {
+        const std::lock_guard<std::mutex> lock(gate_->mutex);
+        gate_->hub = nullptr;
+    }
+
+    int token = 0;
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        if (shutdown_)
+            return;
+        shutdown_ = true;
+        token = changeToken_;
+        changeToken_ = 0;
+        clients_.clear();
+        for (auto& topic : topics_)
+            topic = {};
+        sampler_.reset();
+    }
+
+    if (token != 0)
+        service_.changes().removeListener(token);
+}
+
+SubscriptionHub::ClientId SubscriptionHub::addClient(Sink sink, Disconnect disconnect) {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    if (shutdown_)
+        return 0;
+
+    const auto id = nextClientId_++;
+    clients_.push_back(Client{id, std::move(sink), std::move(disconnect), {}, {}, 0});
+    return id;
+}
+
+void SubscriptionHub::removeClient(ClientId client) {
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        const auto found = std::remove_if(clients_.begin(), clients_.end(),
+                                          [client](const Client& c) { return c.id == client; });
+        if (found == clients_.end())
+            return;
+        clients_.erase(found, clients_.end());
+        releaseIdleTopicsLocked();
+    }
+    // This runs on the departing connection's own thread, so the timers are
+    // somebody else's to touch.
+    scheduleTopology();
+}
+
+int SubscriptionHub::clientCount() const {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return static_cast<int>(clients_.size());
+}
+
+void SubscriptionHub::setMeterSource(std::unique_ptr<MeterSource> source) {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    meters_ = std::move(source);
+}
+
+bool SubscriptionHub::isSubscriptionMethod(const juce::String& method) {
+    return method == kSubscribe || method == kUnsubscribe || method == kList || method == kResync;
+}
+
+SubscriptionHub::Client* SubscriptionHub::findLocked(ClientId client) {
+    const auto found = std::find_if(clients_.begin(), clients_.end(),
+                                    [client](const Client& c) { return c.id == client; });
+    return found == clients_.end() ? nullptr : &*found;
+}
+
+bool SubscriptionHub::anySubscriberLocked(Topic topic) const {
+    const auto index = indexOf(topic);
+    return std::any_of(clients_.begin(), clients_.end(),
+                       [index](const Client& client) { return client.subscribed[index]; });
+}
+
+void SubscriptionHub::releaseIdleTopicsLocked() {
+    // A baseline exists to diff against; with nobody subscribed there is nothing
+    // to diff for, and holding a projection of every clip in the project on
+    // behalf of no one is exactly the memory this design is trying not to spend.
+    for (std::size_t index = 0; index < TOPIC_COUNT; ++index)
+        if (!anySubscriberLocked(static_cast<Topic>(index)))
+            topics_[index] = {};
+}
+
+/**
+ * Reconcile both timers with what is actually subscribed.
+ *
+ * Both are `juce::Timer`s, and both are started and stopped through this one
+ * function on the message thread, never from a transport thread and never from
+ * inside a timer callback. JUCE releases its own lock before invoking a timer
+ * callback, so stopping a timer from elsewhere can free one whose callback is
+ * on the stack — and `~Timer` says as much in an assertion.
+ *
+ * Detaching matters as much as attaching: `ChangeSource::addListener` starts the
+ * 30 Hz flush timer, so a hub that stayed subscribed with no clients would keep
+ * waking the message thread for the life of the process.
+ */
+void SubscriptionHub::applyTopology() {
+    bool wantChanges = false;
+    bool wantSampler = false;
+    int existing = 0;
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        topologyPending_ = false;
+        if (shutdown_)
+            return;
+
+        for (std::size_t index = 0; index < TOPIC_COUNT; ++index) {
+            const auto topic = static_cast<Topic>(index);
+            if (!anySubscriberLocked(topic))
+                continue;
+            if (isSampled(topic))
+                wantSampler = true;
+            else
+                wantChanges = true;
+        }
+        existing = changeToken_;
+
+        // No MessageManager means no timer thread at all — the headless case,
+        // where tests drive sampleNow() and flush() by hand.
+        const bool canTime = juce::MessageManager::getInstanceWithoutCreating() != nullptr;
+        if (!wantSampler)
+            sampler_.reset();
+        else if (sampler_ == nullptr && canTime)
+            sampler_ = std::make_unique<Sampler>(*this, std::max(1, options_.samplingIntervalMs));
+    }
+
+    if (wantChanges == (existing != 0))
+        return;
+
+    if (wantChanges) {
+        auto gate = gate_;
+        const auto token = service_.changes().addListener(
+            [gate](const std::vector<ChangeSource::Change>& changes) {
+                const std::lock_guard<std::mutex> lock(gate->mutex);
+                if (gate->hub != nullptr)
+                    gate->hub->publish(changes);
+            });
+
+        bool keep = false;
+        {
+            const std::lock_guard<std::mutex> lock(mutex_);
+            // Shutdown may have landed while the listener was being attached,
+            // in which case this token is surplus.
+            if (!shutdown_ && changeToken_ == 0) {
+                changeToken_ = token;
+                keep = true;
+            }
+        }
+        if (!keep)
+            service_.changes().removeListener(token);
+        return;
+    }
+
+    int token = 0;
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        token = changeToken_;
+        changeToken_ = 0;
+    }
+    if (token != 0)
+        service_.changes().removeListener(token);
+}
+
+void SubscriptionHub::scheduleTopology() {
+    // Deliberately asynchronous even when this is already the message thread:
+    // publish() and dropAbandoned() run inside the flush timer's own callback,
+    // and detaching the listener there would destroy that timer mid-callback.
+    if (juce::MessageManager::getInstanceWithoutCreating() == nullptr) {
+        applyTopology();
+        return;
+    }
+
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        if (shutdown_ || topologyPending_)
+            return;
+        topologyPending_ = true;
+    }
+
+    auto gate = gate_;
+    if (!juce::MessageManager::callAsync([gate] {
+            const std::lock_guard<std::mutex> lock(gate->mutex);
+            if (gate->hub != nullptr)
+                gate->hub->applyTopology();
+        })) {
+        // The message loop is going away, so nothing will reconcile anything
+        // again; shutdown() detaches everything regardless.
+        const std::lock_guard<std::mutex> lock(mutex_);
+        topologyPending_ = false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Projection
+// ---------------------------------------------------------------------------
+
+juce::var SubscriptionHub::projectTopic(Topic topic) {
+    const auto* name = snapshotOperationFor(topic);
+    if (name == nullptr)
+        return {};
+
+    const auto* operation = OperationRegistry::instance().find(name);
+    if (operation == nullptr || operation->handler == nullptr) {
+        jassertfalse;  // A topic naming an operation the registry does not have.
+        return {};
+    }
+
+    RequestContext context;
+    context.clientId = "subscriptions";
+    auto result = operation->handler(api_, makeObject(), context);
+    return result.failed() ? juce::var() : result.value;
+}
+
+juce::var SubscriptionHub::sampleTopic(Topic topic) {
+    if (topic == Topic::Playhead) {
+        auto payload = makeObject();
+        setProperty(payload, "positionBeats", api_.transport().getPositionBeats());
+        setProperty(payload, "playing", api_.transport().isPlaying());
+        return payload;
+    }
+
+    juce::Array<juce::var> levels;
+    // No engine means no meters. Delivering an empty sample rather than an error
+    // keeps the subscription valid on a headless host, which is not something a
+    // remote client can do anything about.
+    if (meters_ != nullptr) {
+        for (const auto& track : meters_->sample()) {
+            auto entry = makeObject();
+            setProperty(entry, "trackId", static_cast<int>(track.trackId));
+            setProperty(entry, "peakL", static_cast<double>(track.peakL));
+            setProperty(entry, "peakR", static_cast<double>(track.peakR));
+            setProperty(entry, "clipped", track.clipped);
+            levels.add(entry);
+        }
+    }
+
+    auto payload = makeObject();
+    setProperty(payload, "tracks", levels);
+    return payload;
+}
+
+// ---------------------------------------------------------------------------
+// Delivery
+// ---------------------------------------------------------------------------
+
+void SubscriptionHub::deliverLocked(Client& client, const SubscriptionEvent& event) {
+    const auto index = indexOf(event.topic);
+    const bool sent = client.sink != nullptr && client.sink(event);
+
+    if (sent) {
+        if (event.type == SubscriptionEvent::Type::Snapshot)
+            client.needsSnapshot[index] = false;
+        if (event.type != SubscriptionEvent::Type::Sample)
+            client.consecutiveDrops = 0;
+        return;
+    }
+
+    // A refused sample is the policy working, not a client falling behind:
+    // meters and the playhead are latest-value-wins and the next one is along in
+    // a few tens of milliseconds.
+    if (event.type == SubscriptionEvent::Type::Sample)
+        return;
+
+    client.needsSnapshot[index] = true;
+    ++client.consecutiveDrops;
+}
+
+void SubscriptionHub::publishTopicLocked(Topic topic, Revision revision) {
+    const auto index = indexOf(topic);
+    auto current = projectTopic(topic);
+    auto& state = topics_[index];
+
+    SubscriptionEvent delta{topic, SubscriptionEvent::Type::Delta, revision, {}};
+    bool haveDelta = false;
+
+    if (state.hasBaseline) {
+        if (!keyFieldsFor(topic).empty()) {
+            const auto difference = diffElements(topic, state.baseline, current);
+            if (!difference.changed()) {
+                // The topic was marked but nothing observable changed — a
+                // parameter that came back to where it started, or a
+                // notification for state this projection does not expose. The
+                // coalescing that matters most is the event never sent.
+                state.baseline = current;
+                return;
+            }
+            delta.payload = difference.toJson();
+        } else {
+            if (deepEquals(state.baseline, current)) {
+                state.baseline = current;
+                return;
+            }
+            delta.payload = current;
+        }
+        haveDelta = true;
+    }
+
+    state.baseline = current;
+    state.hasBaseline = true;
+
+    const SubscriptionEvent snapshot{topic, SubscriptionEvent::Type::Snapshot, revision, current};
+
+    for (auto& client : clients_) {
+        if (!client.subscribed[index])
+            continue;
+        const bool complete = client.needsSnapshot[index] || !haveDelta;
+        deliverLocked(client, complete ? snapshot : delta);
+    }
+}
+
+void SubscriptionHub::publish(const std::vector<ChangeSource::Change>& changes) {
+    bool dropped = false;
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        if (shutdown_)
+            return;
+
+        for (const auto& change : changes) {
+            // Nothing marks these, and if something did, a revisioned delta is
+            // the wrong shape for a continuous signal.
+            if (isSampled(change.topic))
+                continue;
+            if (!anySubscriberLocked(change.topic))
+                continue;
+            publishTopicLocked(change.topic, change.revision);
+        }
+
+        dropped = dropAbandonedLocked();
+    }
+
+    // Only when the client set actually changed. This runs inside the flush
+    // timer's callback, so the reconciliation it asks for has to happen later.
+    if (dropped)
+        scheduleTopology();
+}
+
+void SubscriptionHub::sampleNow() {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    if (shutdown_)
+        return;
+
+    const auto revision = service_.currentRevision();
+    for (const auto topic : {Topic::Meters, Topic::Playhead}) {
+        if (!anySubscriberLocked(topic))
+            continue;
+
+        const SubscriptionEvent event{topic, SubscriptionEvent::Type::Sample, revision,
+                                      sampleTopic(topic)};
+        for (auto& client : clients_)
+            if (client.subscribed[indexOf(topic)])
+                deliverLocked(client, event);
+    }
+}
+
+bool SubscriptionHub::dropAbandonedLocked() {
+    if (options_.droppedFlushesBeforeDisconnect <= 0)
+        return false;
+
+    const auto abandoned =
+        std::remove_if(clients_.begin(), clients_.end(), [this](const Client& client) {
+            return client.consecutiveDrops >= options_.droppedFlushesBeforeDisconnect;
+        });
+    if (abandoned == clients_.end())
+        return false;
+
+    for (auto it = abandoned; it != clients_.end(); ++it)
+        if (it->disconnect != nullptr)
+            it->disconnect("subscriber is not consuming events");
+
+    clients_.erase(abandoned, clients_.end());
+    releaseIdleTopicsLocked();
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Methods
+// ---------------------------------------------------------------------------
+
+void SubscriptionHub::sendSnapshotsLocked(Client& client, const std::vector<Topic>& topics,
+                                          Revision revision, juce::Array<juce::var>& into) {
+    for (const auto topic : topics) {
+        if (isSampled(topic))
+            continue;
+
+        const auto index = indexOf(topic);
+        auto current = projectTopic(topic);
+
+        // Deliberately does not overwrite an existing baseline. Another client
+        // may still be current against it, and moving it forward here would
+        // silently swallow the change it has not been told about yet. The new
+        // subscriber may therefore receive a delta covering ground its snapshot
+        // already had, which is harmless: added and updated are upserts keyed by
+        // id, so applying one twice lands in the same place.
+        if (!topics_[index].hasBaseline) {
+            topics_[index].baseline = current;
+            topics_[index].hasBaseline = true;
+        }
+
+        client.needsSnapshot[index] = false;
+        into.add(SubscriptionEvent{topic, SubscriptionEvent::Type::Snapshot, revision,
+                                   std::move(current)}
+                     .toJson());
+    }
+}
+
+bool SubscriptionHub::handle(ClientId client, const juce::String& method, const juce::var& params,
+                             Completion onComplete) {
+    if (!isSubscriptionMethod(method))
+        return false;
+    jassert(onComplete != nullptr);
+
+    const auto revision = service_.currentRevision();
+
+    // Validated on the calling thread, for the reason `RemoteApiService` does
+    // the same: it is a pure function of the request, so a malformed one never
+    // occupies the message thread. Against the schema the registry advertises,
+    // so a transport never grows its own copy of the contract.
+    const auto* operation = OperationRegistry::instance().find(method);
+    if (operation == nullptr) {
+        onComplete(Response::failure(ErrorCode::UnknownOperation, "unknown operation: " + method,
+                                     revision));
+        return true;
+    }
+    if (auto error = validateOperationInput(*operation, params)) {
+        onComplete(Response::failure(*error, revision));
+        return true;
+    }
+
+    std::vector<Topic> requested;
+    bool topicsGiven = false;
+    if (const auto* array = params["topics"].getArray()) {
+        topicsGiven = true;
+        for (const auto& entry : *array) {
+            const auto topic = parseTopic(entry.toString());
+            if (!topic) {
+                onComplete(Response::failure(ErrorCode::ValidationFailed,
+                                             "unknown topic: " + entry.toString(), revision));
+                return true;
+            }
+            if (std::find(requested.begin(), requested.end(), *topic) == requested.end())
+                requested.push_back(*topic);
+        }
+    }
+
+    // Everything past this point projects live model state, which is message
+    // thread only. Copied before the job takes ownership, so the callAsync
+    // failure path still has a way to answer.
+    auto fallback = onComplete;
+    auto gate = gate_;
+    auto job = [gate, client, method, params, requested, topicsGiven, revision,
+                onComplete = std::move(onComplete)]() mutable {
+        Response response;
+        {
+            const std::lock_guard<std::mutex> lock(gate->mutex);
+            response = gate->hub != nullptr
+                           ? gate->hub->execute(client, method, params, requested, topicsGiven)
+                           : Response::failure(ErrorCode::Cancelled, "subscriptions are shut down",
+                                               revision);
+        }
+        onComplete(std::move(response));
+    };
+
+    // Already on the message thread, or there is no message thread to hop to —
+    // the headless host, where posting would queue work nothing dispatches.
+    if (juce::MessageManager::existsAndIsCurrentThread() ||
+        juce::MessageManager::getInstanceWithoutCreating() == nullptr) {
+        job();
+        return true;
+    }
+
+    if (!juce::MessageManager::callAsync(std::move(job)))
+        fallback(Response::failure(ErrorCode::Cancelled,
+                                   "message loop is shutting down; request not dispatched",
+                                   revision));
+    return true;
+}
+
+Response SubscriptionHub::execute(ClientId client, const juce::String& method,
+                                  const juce::var& params, const std::vector<Topic>& requested,
+                                  bool topicsGiven) {
+    const auto revision = service_.currentRevision();
+
+    Response response;
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        if (shutdown_)
+            return Response::failure(ErrorCode::Cancelled, "remote API service is shut down",
+                                     revision);
+
+        auto* entry = findLocked(client);
+        if (entry == nullptr)
+            return Response::failure(ErrorCode::InternalError, "connection is not subscribable",
+                                     revision);
+
+        auto result = makeObject();
+        juce::Array<juce::var> snapshots;
+
+        if (method == kSubscribe) {
+            for (const auto topic : requested)
+                entry->subscribed[indexOf(topic)] = true;
+
+            // A client that reconnects at the revision the project is still on
+            // has missed no committed change and may skip the snapshots. Any
+            // other revision — including one it never saw — is an explicit
+            // resync, because no per-revision history is kept to replay from.
+            const auto from = params["fromRevision"];
+            const bool current = !from.isVoid() && static_cast<juce::int64>(from) ==
+                                                       static_cast<juce::int64>(revision);
+            const auto wanted = params["snapshot"];
+            const bool asked = wanted.isVoid() || static_cast<bool>(wanted);
+
+            if (asked && !current)
+                sendSnapshotsLocked(*entry, requested, revision, snapshots);
+            else
+                for (const auto topic : requested)
+                    if (!isSampled(topic) && !topics_[indexOf(topic)].hasBaseline) {
+                        topics_[indexOf(topic)].baseline = projectTopic(topic);
+                        topics_[indexOf(topic)].hasBaseline = true;
+                    }
+        } else if (method == kUnsubscribe) {
+            // No topics means all of them: the shape a client uses when it is
+            // going away rather than narrowing what it watches.
+            for (std::size_t index = 0; index < TOPIC_COUNT; ++index) {
+                const auto topic = static_cast<Topic>(index);
+                if (!topicsGiven ||
+                    std::find(requested.begin(), requested.end(), topic) != requested.end())
+                    entry->subscribed[index] = false;
+            }
+            releaseIdleTopicsLocked();
+        } else if (method == kResync) {
+            std::vector<Topic> targets;
+            for (std::size_t index = 0; index < TOPIC_COUNT; ++index) {
+                const auto topic = static_cast<Topic>(index);
+                if (!entry->subscribed[index])
+                    continue;
+                if (topicsGiven &&
+                    std::find(requested.begin(), requested.end(), topic) == requested.end())
+                    continue;
+                targets.push_back(topic);
+            }
+            sendSnapshotsLocked(*entry, targets, revision, snapshots);
+            // The client has just been handed complete state, so whatever it
+            // missed no longer matters.
+            entry->consecutiveDrops = 0;
+        }
+
+        juce::Array<juce::var> subscribed;
+        for (std::size_t index = 0; index < TOPIC_COUNT; ++index)
+            if (entry->subscribed[index])
+                subscribed.add(juce::String(toString(static_cast<Topic>(index))));
+
+        setProperty(result, "topics", subscribed);
+        setProperty(result, "revision", static_cast<juce::int64>(revision));
+        if (method != kList && method != kUnsubscribe)
+            setProperty(result, "snapshots", snapshots);
+
+        response = Response::success(result, revision);
+    }
+
+    // This is the message thread and not a timer callback, so the timers can be
+    // reconciled here and the client is subscribed by the time it is told so.
+    applyTopology();
+    return response;
+}
+
+}  // namespace magda::remote

--- a/magda/daw/api/remote_subscriptions.hpp
+++ b/magda/daw/api/remote_subscriptions.hpp
@@ -1,0 +1,307 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "remote_api.hpp"
+#include "remote_changes.hpp"
+#include "remote_service.hpp"
+
+namespace magda {
+
+class AudioEngine;
+class MagdaApi;
+
+namespace remote {
+
+/**
+ * @brief One pushed state change, independent of the transport that carries it.
+ *
+ * The envelope is deliberately four fields and no framing: WebSocket wraps it in
+ * a JSON-RPC notification, MCP (#1858) will wrap it in a resource update, and
+ * neither shape belongs in here. `revision` is the project revision the payload
+ * describes, which is what makes a stream orderable and a gap detectable.
+ */
+struct SubscriptionEvent {
+    enum class Type {
+        /// Complete state for the topic. The first delivery on a topic, and the
+        /// recovery form after a client falls behind.
+        Snapshot,
+        /// What changed since the previous event on this topic. Only meaningful
+        /// to a client that received every earlier event in order.
+        Delta,
+        /// A point reading of a continuously changing value — meters, playhead.
+        /// Carries no history and is safe to drop.
+        Sample,
+    };
+
+    Topic topic = Topic::Project;
+    Type type = Type::Snapshot;
+    Revision revision = INITIAL_REVISION;
+    juce::var payload;
+
+    /// `{"topic":…,"type":…,"revision":…,"payload":…}`
+    juce::var toJson() const;
+};
+
+const char* toString(SubscriptionEvent::Type type);
+
+/**
+ * @brief Where per-track meter levels come from.
+ *
+ * An interface rather than a direct read of the audio engine because the remote
+ * API layer is built and tested without one: `magda_tests` links the API but not
+ * the engine, and the hub has to be exercisable there. The live implementation
+ * lives in `remote_meters_live.cpp`, the same `_live` split the rest of the
+ * facade uses.
+ *
+ * `sample()` is called on the message thread and must not block: it reads a
+ * lock-free snapshot the audio path has already published, and never touches the
+ * audio thread itself.
+ */
+class MeterSource {
+  public:
+    struct TrackLevels {
+        TrackId trackId = INVALID_TRACK_ID;
+        float peakL = 0.0f;
+        float peakR = 0.0f;
+        bool clipped = false;
+
+        bool operator==(const TrackLevels&) const = default;
+    };
+
+    virtual ~MeterSource() = default;
+
+    /// Latest levels for every track that has any, plus `MASTER_TRACK_ID`.
+    virtual std::vector<TrackLevels> sample() = 0;
+};
+
+/**
+ * @brief Turns "a topic changed" into per-client event streams (#1857).
+ *
+ * Sits between `ChangeSource` — which says *that* a topic changed, coalesced and
+ * revisioned — and the transports, which have to say *what* changed to each
+ * client that asked. It is shared rather than private to the WebSocket adapter
+ * for the same reason `ChangeSource` is: MCP resource updates need the identical
+ * projection and the identical resync rules, and the second implementation would
+ * drift from the first.
+ *
+ * ## What a client receives
+ *
+ * One `Snapshot` per topic when it subscribes, then a `Delta` per coalesced
+ * flush in which that topic changed. Deltas are computed once per topic per
+ * flush and shared by every subscriber, so N clients cost one projection rather
+ * than N.
+ *
+ * Not every topic deltas. `tracks`, `clips`, `automation`, and `session` are
+ * keyed collections where a delta is most of the saving — a note added to one
+ * clip should not re-send every clip in the project. `project`, `transport`, and
+ * `selection` are single small objects with nothing to diff. `devices` is a
+ * three-array graph whose ids are unique only within a track section, so an
+ * id-keyed diff would be wrong rather than merely unhelpful; it re-sends the
+ * graph, which changes at edit rate and not at gesture rate. Those four
+ * therefore arrive as `Delta` events whose payload is the whole topic — the type
+ * still tells a client this is a change rather than a subscription snapshot.
+ *
+ * `meters` and `playhead` never delta and are never driven by `ChangeSource`.
+ * Nothing marks them: the playhead moves without notifying anyone and meters are
+ * a continuous signal. They are sampled on their own timer instead, at
+ * `Options::samplingIntervalMs`, latest value wins. A client that does not
+ * subscribe to them costs nothing, and the timer does not run.
+ *
+ * ## Falling behind
+ *
+ * A sink returns false when the client cannot take the event — its outgoing
+ * queue is full, which for a bounded queue means the client has stopped reading.
+ * The event is dropped, not buffered: buffering on behalf of a client that is
+ * not listening is how a stalled connection grows memory without limit. The
+ * client is marked for resync, so the next event it *can* take is a fresh
+ * `Snapshot` rather than a delta it has no baseline for. A client that keeps
+ * refusing for `Options::droppedFlushesBeforeDisconnect` consecutive flushes is
+ * disconnected: at that point it is holding a connection slot and a thread and
+ * consuming nothing.
+ *
+ * Dropped `Sample` events do not count towards either, because dropping them is
+ * the specified behaviour rather than a symptom.
+ *
+ * ## Threading
+ *
+ * Projection reads live model state, so it happens on the message thread and
+ * nowhere else — the same constraint `RemoteApiService` exists to enforce, for
+ * the same reason. `publish` and `sampleNow` are already there, driven by
+ * timers. `handle` is not: it arrives on a transport thread, validates its input
+ * there, and hops for the part that touches the model, which is why it answers
+ * through a callback rather than returning a `Response`.
+ *
+ * Timer lifetime is the other reason. The flush listener and the sampler are
+ * `juce::Timer`s, and JUCE calls a timer's callback with its own lock released —
+ * so starting or stopping one from a network thread can destroy a timer whose
+ * callback is running. Every change to what is subscribed therefore only records
+ * the intent; the timers themselves are reconciled on the message thread.
+ *
+ * One mutex covers the client table and the per-topic baselines. Sinks are
+ * called while it is held — a sink appends to the client's own queue and must
+ * not call back into the hub.
+ */
+class SubscriptionHub {
+  public:
+    using ClientId = int;
+
+    /// Deliver one event. Returns false when the client cannot take it now.
+    using Sink = std::function<bool(const SubscriptionEvent&)>;
+
+    /// Drop a client that has stopped consuming. Called with the hub's lock
+    /// held, so it must do no more than mark the connection.
+    using Disconnect = std::function<void(const juce::String& reason)>;
+
+    /// Answer to one subscription method. Called exactly once.
+    using Completion = std::function<void(Response)>;
+
+    struct Options {
+        /// Cadence for `meters` and `playhead`. 20 Hz: fast enough for a meter
+        /// bridge or a moving playhead readout, and an order of magnitude below
+        /// the block rate that produces the underlying values.
+        int samplingIntervalMs = 50;
+
+        /// Consecutive flushes a client may refuse before it is disconnected.
+        /// At the 30 Hz flush cadence this is about three seconds of a client
+        /// that is connected, subscribed, and reading nothing.
+        int droppedFlushesBeforeDisconnect = 100;
+    };
+
+    // Two overloads rather than a defaulted parameter: `Options`'s own member
+    // initializers are not usable in a default argument inside the class that
+    // declares it.
+    SubscriptionHub(MagdaApi& api, RemoteApiService& service);
+    SubscriptionHub(MagdaApi& api, RemoteApiService& service, Options options);
+    ~SubscriptionHub();
+
+    SubscriptionHub(const SubscriptionHub&) = delete;
+    SubscriptionHub& operator=(const SubscriptionHub&) = delete;
+
+    /// Register a transport connection. The returned id addresses it until
+    /// `removeClient`; ids are never reused.
+    ClientId addClient(Sink sink, Disconnect disconnect);
+    void removeClient(ClientId client);
+
+    /// Subscribed clients. For tests and diagnostics.
+    int clientCount() const;
+
+    /**
+     * @brief Execute one subscription method on behalf of a client.
+     *
+     * Returns false without calling `onComplete` when `method` is not a
+     * subscription method, which is the adapter's signal to route it to
+     * `RemoteApiService::dispatch` instead.
+     *
+     * Otherwise `onComplete` is invoked exactly once: on the calling thread for
+     * a request rejected before the hop, and on the message thread for one that
+     * had to read the model. Input is validated against the same schema the
+     * registry advertises, so a transport does not re-declare one.
+     */
+    bool handle(ClientId client, const juce::String& method, const juce::var& params,
+                Completion onComplete);
+
+    /// True for the four `subscriptions.*` methods the registry declares as
+    /// transport-scoped.
+    static bool isSubscriptionMethod(const juce::String& method);
+
+    /**
+     * @brief Project the topics that changed and push them.
+     *
+     * Wired to `RemoteApiService::changes()` for the hub's lifetime. Exposed
+     * because a host with no MessageManager has no flush timer, which is the
+     * headless test case.
+     */
+    void publish(const std::vector<ChangeSource::Change>& changes);
+
+    /// Read and push `meters` and `playhead`. Driven by the sampling timer;
+    /// exposed for the same reason as `publish`.
+    void sampleNow();
+
+    /**
+     * @brief Install the source `meters` reads.
+     *
+     * Without one, `meters` subscribes successfully and delivers empty samples
+     * rather than failing: whether an audio engine exists is not something a
+     * remote client can do anything about, and a subscription that errors on a
+     * headless host would make every client special-case it.
+     */
+    void setMeterSource(std::unique_ptr<MeterSource> source);
+
+    /// Stop delivering, drop every client, and detach from the change source.
+    /// Idempotent; the destructor calls it. Call on the message thread, which is
+    /// where the timers it stops belong.
+    void shutdown();
+
+  private:
+    struct Client;
+    struct Gate;
+    class Sampler;
+
+    /// State the hub keeps per topic so it can produce a delta rather than a
+    /// snapshot. Held only while the topic has at least one subscriber.
+    struct TopicState {
+        bool hasBaseline = false;
+        juce::var baseline;
+    };
+
+    juce::var projectTopic(Topic topic);
+    juce::var sampleTopic(Topic topic);
+
+    Response execute(ClientId client, const juce::String& method, const juce::var& params,
+                     const std::vector<Topic>& requested, bool topicsGiven);
+
+    void publishTopicLocked(Topic topic, Revision revision);
+    void deliverLocked(Client& client, const SubscriptionEvent& event);
+    void sendSnapshotsLocked(Client& client, const std::vector<Topic>& topics, Revision revision,
+                             juce::Array<juce::var>& into);
+    bool anySubscriberLocked(Topic topic) const;
+    void releaseIdleTopicsLocked();
+    /// @return true when a client was dropped, so the caller knows to reconcile.
+    bool dropAbandonedLocked();
+
+    /// Reconcile the flush listener and the sampling timer with what is
+    /// subscribed. Message thread only — it starts and stops `juce::Timer`s.
+    void applyTopology();
+    /// Ask for that reconciliation from wherever this is called, including from
+    /// inside a timer callback.
+    void scheduleTopology();
+
+    Client* findLocked(ClientId client);
+
+    MagdaApi& api_;
+    RemoteApiService& service_;
+    const Options options_;
+
+    mutable std::mutex mutex_;
+    std::vector<Client> clients_;
+    ClientId nextClientId_ = 1;
+    std::array<TopicState, TOPIC_COUNT> topics_{};
+
+    std::unique_ptr<MeterSource> meters_;
+    std::unique_ptr<Sampler> sampler_;
+
+    std::shared_ptr<Gate> gate_;
+    int changeToken_ = 0;
+    bool topologyPending_ = false;
+    bool shutdown_ = false;
+};
+
+/**
+ * @brief The meter source backed by a running audio engine.
+ *
+ * Defined in `remote_meters_live.cpp`, which is the only file in the remote API
+ * layer that includes the engine — the same `_live` split `ModelChangeBridge`
+ * uses for the model singletons.
+ */
+std::unique_ptr<MeterSource> makeLiveMeterSource(AudioEngine& engine);
+
+}  // namespace remote
+}  // namespace magda

--- a/magda/daw/api/remote_subscriptions.hpp
+++ b/magda/daw/api/remote_subscriptions.hpp
@@ -263,6 +263,8 @@ class SubscriptionHub {
     void sendSnapshotsLocked(Client& client, const std::vector<Topic>& topics, Revision revision,
                              juce::Array<juce::var>& into);
     bool anySubscriberLocked(Topic topic) const;
+    /// Whether any subscriber of `topic` is behind and owed a snapshot.
+    bool owesSnapshotLocked(Topic topic) const;
     void releaseIdleTopicsLocked();
     /// @return true when a client was dropped, so the caller knows to reconcile.
     bool dropAbandonedLocked();

--- a/magda/daw/api/remote_subscriptions.hpp
+++ b/magda/daw/api/remote_subscriptions.hpp
@@ -260,6 +260,7 @@ class SubscriptionHub {
 
     void publishTopicLocked(Topic topic, Revision revision);
     void deliverLocked(Client& client, const SubscriptionEvent& event);
+    void foldFlushOutcomesLocked();
     void sendSnapshotsLocked(Client& client, const std::vector<Topic>& topics, Revision revision,
                              juce::Array<juce::var>& into);
     bool anySubscriberLocked(Topic topic) const;

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -399,6 +399,22 @@ struct Connection {
         ready.notify_one();
     }
 
+    /**
+     * @brief Whether this connection has been retired by anything but its reader.
+     *
+     * `markClosed` is how a foreign thread — the subscription hub dropping a
+     * subscriber that stopped consuming — says the connection is finished, and
+     * it is all a foreign thread may do, because the reader owns the socket.
+     * That only ends the connection if the reader looks, which is why this is
+     * checked around every frame rather than only when replies are queued:
+     * without it a client dropped for backpressure keeps having its requests
+     * executed, mutations and all, and only its replies are thrown away.
+     */
+    bool isClosed() const {
+        const std::lock_guard<std::mutex> lock(mutex);
+        return closed;
+    }
+
     void markClosed() {
         std::deque<Outgoing> abandoned;
         {
@@ -757,8 +773,15 @@ struct RemoteWebSocketServer::Impl {
         });
 
         std::string message;
-        while (socket.is_open() && running.load()) {
+        while (socket.is_open() && running.load() && !connection->isClosed()) {
             if (socket.read(message) == httplib::ws::ReadResult::Fail)
+                break;
+            // Re-checked after the read, not only before it: the read is where
+            // this thread spends its time, so a connection retired while it was
+            // blocked would otherwise get one more request executed on the way
+            // out — and for a client dropped for backpressure, one more per
+            // frame it kept sending.
+            if (connection->isClosed())
                 break;
             handleMessage(connection, message);
         }

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -34,6 +34,7 @@
 #include <utility>
 
 #include "remote_service.hpp"
+#include "remote_subscriptions.hpp"
 
 namespace magda {
 namespace remote {
@@ -42,6 +43,11 @@ namespace {
 
 /// The path a client upgrades on. Everything else 404s.
 constexpr const char* kEndpoint = "/rpc";
+
+/// The notification method every pushed event arrives under. One method rather
+/// than one per topic: a client routes on `params.topic`, and a JSON-RPC library
+/// that dispatches on method name needs exactly one handler registered.
+constexpr const char* kEventMethod = "subscriptions.event";
 
 /**
  * How often the server pings an idle client.
@@ -160,6 +166,22 @@ std::string replyFor(const juce::var& id, const Response& response) {
     return juce::JSON::toString(reply, true).toStdString();
 }
 
+/**
+ * A pushed event as a JSON-RPC notification — a request with no `id`.
+ *
+ * The standard's own shape for something that expects no reply, and the reason
+ * an event is not simply a `result` with no request behind it: a client library
+ * routes on `method`, and every one of them already knows that a missing id
+ * means "do not answer this".
+ */
+std::string notificationFor(const SubscriptionEvent& event) {
+    auto notification = makeObject();
+    setProperty(notification, "jsonrpc", "2.0");
+    setProperty(notification, "method", kEventMethod);
+    setProperty(notification, "params", event.toJson());
+    return juce::JSON::toString(notification, true).toStdString();
+}
+
 bool isNumber(const juce::var& value) {
     return value.isInt() || value.isInt64() || value.isDouble();
 }
@@ -259,20 +281,26 @@ bool secureEquals(const juce::String& a, const juce::String& b) {
  * its payload rather than reaching for a stack frame that has returned.
  */
 struct Connection {
-    Connection(httplib::ws::WebSocket& webSocket, int identifier, int maxQueued, double burst)
+    Connection(httplib::ws::WebSocket& webSocket, int identifier, int maxQueued, int maxEvents,
+               double burst)
         : socket(webSocket),
           id(identifier),
           maxQueuedReplies(maxQueued),
+          maxQueuedEvents(maxEvents),
           tokens(burst),
           lastRefill(std::chrono::steady_clock::now()) {}
 
     httplib::ws::WebSocket& socket;
     const int id;
     const int maxQueuedReplies;
+    const int maxQueuedEvents;
+
+    /// The hub's handle on this connection, or 0 when subscriptions are off.
+    SubscriptionHub::ClientId subscriber = 0;
 
     /**
-     * A reply waiting to be written, and whether it carries an admitted
-     * request's slot.
+     * A frame waiting to be written, whether it carries an admitted request's
+     * slot, and which budget it was drawn from.
      *
      * Ownership has to travel with the payload. Releasing at the point a reply
      * is produced and again when it is written decrements twice for one
@@ -285,6 +313,7 @@ struct Connection {
     struct Outgoing {
         std::string payload;
         bool ownsSlot = false;
+        bool isEvent = false;
     };
 
     mutable std::mutex mutex;
@@ -292,6 +321,13 @@ struct Connection {
     std::deque<Outgoing> outbox;
     bool closed = false;
     int inFlight = 0;
+
+    // Counted rather than derived from `outbox.size()`, because the two share
+    // one queue — ordering between a reply and the event it caused is worth
+    // keeping — while holding separate budgets. Sizing either from the total
+    // would let a burst of one starve the other.
+    int queuedReplies = 0;
+    int queuedEvents = 0;
 
     double tokens;
     std::chrono::steady_clock::time_point lastRefill;
@@ -309,12 +345,35 @@ struct Connection {
     bool enqueue(std::string payload, bool ownsSlot) {
         {
             const std::lock_guard<std::mutex> lock(mutex);
-            if (closed || static_cast<int>(outbox.size()) >= maxQueuedReplies) {
+            if (closed || queuedReplies >= maxQueuedReplies) {
                 if (ownsSlot)
                     releaseLocked();
                 return false;
             }
-            outbox.push_back({std::move(payload), ownsSlot});
+            ++queuedReplies;
+            outbox.push_back({std::move(payload), ownsSlot, false});
+        }
+        ready.notify_one();
+        return true;
+    }
+
+    /**
+     * @brief Queue one pushed event, or refuse it.
+     *
+     * Refusing is not a failure to report: it is the answer the subscription hub
+     * needs. A client over its event budget has stopped reading, so the hub stops
+     * sending it deltas it could not apply anyway and hands it a snapshot when it
+     * catches up. Nothing is retried and nothing is buffered past the cap.
+     *
+     * Never carries a request slot — an event answers no request.
+     */
+    bool enqueueEvent(std::string payload) {
+        {
+            const std::lock_guard<std::mutex> lock(mutex);
+            if (closed || queuedEvents >= maxQueuedEvents)
+                return false;
+            ++queuedEvents;
+            outbox.push_back({std::move(payload), false, true});
         }
         ready.notify_one();
         return true;
@@ -346,6 +405,8 @@ struct Connection {
             const std::lock_guard<std::mutex> lock(mutex);
             closed = true;
             abandoned.swap(outbox);
+            queuedReplies = 0;
+            queuedEvents = 0;
             for (const auto& entry : abandoned)
                 if (entry.ownsSlot)
                     releaseLocked();
@@ -395,11 +456,12 @@ struct Connection {
 // ===========================================================================
 
 struct RemoteWebSocketServer::Impl {
-    Impl(RemoteApiService& apiService, Options serverOptions)
-        : service(apiService), options(std::move(serverOptions)) {}
+    Impl(RemoteApiService& apiService, Options serverOptions, SubscriptionHub* hub)
+        : service(apiService), options(std::move(serverOptions)), subscriptions(hub) {}
 
     RemoteApiService& service;
     const Options options;
+    SubscriptionHub* const subscriptions;
 
     httplib::Server server;
     std::thread listener;
@@ -560,6 +622,26 @@ struct RemoteWebSocketServer::Impl {
             return;
         }
 
+        // Answered here rather than by the dispatcher: what a connection watches
+        // is state only the connection has. The names and schemas still come
+        // from the shared registry, which the hub validates against. The hub
+        // makes its own hop to the message thread for the part that reads the
+        // model, so this completes the same way a dispatch does.
+        if (SubscriptionHub::isSubscriptionMethod(method)) {
+            if (subscriptions == nullptr) {
+                connection->complete(
+                    replyFor(id, Response::failure(ErrorCode::InvalidRequest,
+                                                   "this transport does not support subscriptions",
+                                                   service.currentRevision())));
+                return;
+            }
+            subscriptions->handle(connection->subscriber, method, params,
+                                  [connection, id](Response response) {
+                                      connection->complete(replyFor(id, response));
+                                  });
+            return;
+        }
+
         RequestContext context;
         context.clientId = "ws:" + juce::String(connection->id);
         // Scoped by connection so two clients reusing id 1 do not collide in the
@@ -613,15 +695,33 @@ struct RemoteWebSocketServer::Impl {
      * before this returns, because `socket` lives on this stack frame.
      */
     void runConnection(httplib::ws::WebSocket& socket) {
-        auto connection = std::make_shared<Connection>(socket, nextConnectionId.fetch_add(1),
-                                                       options.maxQueuedRepliesPerConnection,
-                                                       options.maxInFlightPerConnection);
+        auto connection = std::make_shared<Connection>(
+            socket, nextConnectionId.fetch_add(1), options.maxQueuedRepliesPerConnection,
+            options.maxQueuedEventsPerConnection, options.maxInFlightPerConnection);
 
         if (!registerConnection(connection)) {
             // Lost a race for the last slot. Closing from here is safe because
             // this is the connection's own thread, the only one allowed to read.
             socket.close(httplib::ws::CloseStatus::PolicyViolation, "connection limit reached");
             return;
+        }
+
+        // The hub holds the connection alive for as long as it is registered,
+        // which costs nothing: `Connection` refers to the socket but never
+        // touches it from here — an event only reaches the outbox, and a
+        // disconnect only sets a flag. Both are safe on any thread, and the
+        // deregistration below is unconditional.
+        if (subscriptions != nullptr) {
+            connection->subscriber = subscriptions->addClient(
+                [connection](const SubscriptionEvent& event) {
+                    return connection->enqueueEvent(notificationFor(event));
+                },
+                [connection](const juce::String&) {
+                    // Marking is all a foreign thread may do. The reader owns
+                    // the socket and notices within one read timeout, which is
+                    // the same shutdown path stop() uses.
+                    connection->markClosed();
+                });
         }
 
         std::thread writer([connection] {
@@ -635,6 +735,14 @@ struct RemoteWebSocketServer::Impl {
                         break;
                     outgoing = std::move(connection->outbox.front());
                     connection->outbox.pop_front();
+                    // The budget is freed when the frame leaves the queue, not
+                    // when its bytes land: a subscriber's next event may as well
+                    // be admitted while this one is still going out, because the
+                    // memory it was holding is already back.
+                    if (outgoing.isEvent)
+                        --connection->queuedEvents;
+                    else
+                        --connection->queuedReplies;
                 }
                 const auto sent = connection->socket.send(outgoing.payload);
                 // The slot belongs to the request until its bytes are gone, so a
@@ -655,6 +763,13 @@ struct RemoteWebSocketServer::Impl {
             handleMessage(connection, message);
         }
 
+        // Deregister before closing: removeClient takes the hub's lock, so it
+        // returns only once a publish already inside the sink has finished. The
+        // other order would leave the hub calling into a connection this thread
+        // is dismantling.
+        if (subscriptions != nullptr && connection->subscriber != 0)
+            subscriptions->removeClient(connection->subscriber);
+
         connection->markClosed();
         writer.join();
 
@@ -669,8 +784,9 @@ struct RemoteWebSocketServer::Impl {
 // RemoteWebSocketServer
 // ===========================================================================
 
-RemoteWebSocketServer::RemoteWebSocketServer(RemoteApiService& service, Options options)
-    : impl_(std::make_unique<Impl>(service, std::move(options))) {}
+RemoteWebSocketServer::RemoteWebSocketServer(RemoteApiService& service, Options options,
+                                             SubscriptionHub* subscriptions)
+    : impl_(std::make_unique<Impl>(service, std::move(options), subscriptions)) {}
 
 RemoteWebSocketServer::~RemoteWebSocketServer() {
     stop();

--- a/magda/daw/api/remote_websocket_server.hpp
+++ b/magda/daw/api/remote_websocket_server.hpp
@@ -10,6 +10,7 @@ namespace magda {
 namespace remote {
 
 class RemoteApiService;
+class SubscriptionHub;
 
 /**
  * @brief JSON-RPC 2.0 over WebSocket, on top of `RemoteApiService` (#1856).
@@ -52,6 +53,30 @@ class RemoteApiService;
  * and the revision, so a client that lost an optimistic-concurrency race can
  * resync without a second call.
  *
+ * ## Pushed events
+ *
+ * A subscribed client (#1857) also receives server-to-client notifications —
+ * JSON-RPC requests with no `id`, which is the standard's own shape for
+ * something that expects no reply:
+ *
+ *     {"jsonrpc":"2.0","method":"subscriptions.event",
+ *      "params":{"topic":"tracks","type":"delta","revision":57,"payload":{…}}}
+ *
+ * Inbound notifications are still refused; the asymmetry is deliberate. A
+ * request without an id cannot be answered, and every operation's answer carries
+ * a revision the client needs. An event is the opposite case: there is nothing
+ * to answer, and inventing an id would only invite a reply.
+ *
+ * `subscriptions.subscribe`, `.unsubscribe`, `.list`, and `.resync` are answered
+ * by this class rather than by the dispatcher, because what a connection is
+ * subscribed to is per-connection state and the dispatcher has no connections.
+ * Their names and schemas still come from the shared registry, which marks them
+ * `transportScoped`; this class adds no contract of its own.
+ *
+ * Events share the reply queue, so a mutation's reply and the event describing
+ * it arrive in the order they were produced, but they hold a separate budget:
+ * see `Options::maxQueuedEventsPerConnection`.
+ *
  * ## Threading
  *
  * The message thread is never used for I/O. The listener runs on its own
@@ -92,8 +117,14 @@ class RemoteApiService;
  * read timeout from expiring on a live connection. A client that neither sends
  * nor reads produces no traffic at all and will be dropped, because nothing
  * distinguishes it from one that has gone away. This costs a real client
- * nothing — waiting for replies and, once #1857 lands, for pushed changes, is
- * where a client spends its time anyway.
+ * nothing — waiting for replies and for pushed changes is where a client spends
+ * its time anyway.
+ *
+ * **Keep reading while subscribed.** A subscriber that stops consuming has its
+ * events dropped rather than buffered, is told so by receiving a `snapshot`
+ * where it expected a `delta`, and is eventually disconnected. Nothing about
+ * that is recoverable by the server on the client's behalf: a queue held for a
+ * client that is not reading is memory spent on nobody.
  */
 class RemoteWebSocketServer {
   public:
@@ -150,6 +181,24 @@ class RemoteWebSocketServer {
         /// queue would grow for as long as it kept talking.
         int maxQueuedRepliesPerConnection = 32;
 
+        /**
+         * Pushed events allowed to sit unwritten before further ones are
+         * dropped (#1857).
+         *
+         * Budgeted separately from replies rather than sharing their cap, in
+         * both directions. A client subscribed to a busy project generates
+         * events continuously, and one outbox cap would let them crowd out the
+         * answer to the request the client is waiting on; conversely a burst of
+         * replies must not silently cost a subscriber its stream. Ordering is
+         * still one queue, so a mutation's reply and the event it caused arrive
+         * in the order they were produced.
+         *
+         * Dropping is the whole policy: an event refused here tells the
+         * subscription hub the client is behind, and it answers with a fresh
+         * snapshot rather than with the deltas it missed.
+         */
+        int maxQueuedEventsPerConnection = 64;
+
         /// Token-bucket rate limit per connection. Bursts up to
         /// `maxInFlightPerConnection`, then holds this rate.
         double maxRequestsPerSecond = 50.0;
@@ -159,7 +208,11 @@ class RemoteWebSocketServer {
         int defaultDeadlineMs = 10'000;
     };
 
-    RemoteWebSocketServer(RemoteApiService& service, Options options);
+    /// `subscriptions` is optional: without one the four `subscriptions.*`
+    /// methods fail with a clear message rather than silently doing nothing, and
+    /// the rest of the API is unaffected. It must outlive this server.
+    RemoteWebSocketServer(RemoteApiService& service, Options options,
+                          SubscriptionHub* subscriptions = nullptr);
     ~RemoteWebSocketServer();
 
     RemoteWebSocketServer(const RemoteWebSocketServer&) = delete;

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -1278,6 +1278,7 @@ void AudioBridge::timerCallback() {
 
                         meteringBuffer_.pushLevels(trackId, data);
                         recordingMeteringBuffer_.pushLevels(trackId, data);
+                        remoteMeteringBuffer_.pushLevels(trackId, data);
 
                         // Write audio peak to sidechain bus for Audio-triggered modulators
                         float peak = std::max(data.peakL, data.peakR);

--- a/magda/daw/audio/AudioBridge.hpp
+++ b/magda/daw/audio/AudioBridge.hpp
@@ -421,6 +421,19 @@ class AudioBridge : public TrackManagerListener, public ClipManagerListener, pub
         return recordingMeteringBuffer_;
     }
 
+    /**
+     * @brief Get the dedicated remote-API metering buffer (#1857)
+     *
+     * A third buffer for the same reason there is a second. A reader that pops
+     * takes data away from the others, and one that only peeks stops seeing new
+     * data once the ring fills — which it does within a second when no UI meter
+     * is on screen to drain it. A remote meter subscriber has to work with the
+     * mixer closed, so it gets its own ring and drains it to the latest value.
+     */
+    MeteringBuffer& getRemoteMeteringBuffer() {
+        return remoteMeteringBuffer_;
+    }
+
     // =========================================================================
     // Parameter Queue
     // =========================================================================
@@ -836,6 +849,7 @@ class AudioBridge : public TrackManagerListener, public ClipManagerListener, pub
     // Lock-free communication buffers
     MeteringBuffer meteringBuffer_;
     MeteringBuffer recordingMeteringBuffer_;
+    MeteringBuffer remoteMeteringBuffer_;
 
     // Phase 1 refactoring: Pure data managers (extracted from AudioBridge)
     TransportStateManager transportState_;

--- a/magda/daw/magda_daw_main.cpp
+++ b/magda/daw/magda_daw_main.cpp
@@ -349,7 +349,11 @@ class MagdaDAWApplication : public JUCEApplication {
         // 4b. Remote API (#1856). Off unless configuration says otherwise, and
         // it opens nothing at all when disabled. After the window, because the
         // model bridge attaches to managers the engine has finished setting up.
-        remoteApi_ = std::make_unique<magda::remote::RemoteApiHost>(daw_engine_->getMagdaApi());
+        // The engine is passed for the `meters` subscription (#1857), which
+        // reads the levels the audio path already publishes; nothing else in the
+        // remote API touches it.
+        remoteApi_ = std::make_unique<magda::remote::RemoteApiHost>(daw_engine_->getMagdaApi(),
+                                                                    daw_engine_.get());
         if (remoteApi_->start())
             juce::Logger::writeToLog("Remote API token written to " +
                                      remoteApi_->tokenFile().getFullPathName());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -195,6 +195,7 @@ set(TEST_SOURCES
     test_remote_api_contract.cpp
     test_remote_service.cpp
     test_remote_changes.cpp
+    test_remote_subscriptions.cpp
     test_remote_model_bridge.cpp
     test_remote_websocket_server.cpp
     test_remote_api_host.cpp

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -54,6 +54,11 @@ namespace magda::test {
 
 class StubAutomationApi : public AutomationApi {
   public:
+    /// Seedable, unlike the rest of this stub. `automation.listLanes` backs the
+    /// `automation` subscription topic, so enumerating lanes has to be a read a
+    /// test can drive rather than an abort.
+    std::vector<AutomationLaneInfo> lanes;
+
     AutomationLaneId createLane(const AutomationTarget&, AutomationLaneType) override {
         std::abort();
     }
@@ -73,7 +78,7 @@ class StubAutomationApi : public AutomationApi {
         std::abort();
     }
     const std::vector<AutomationLaneInfo>& getLanes() const override {
-        std::abort();
+        return lanes;
     }
     std::vector<AutomationLaneId> getLanesForTrack(TrackId) const override {
         std::abort();
@@ -355,7 +360,13 @@ class MockTrackApi : public TrackApi {
     int getNumTracks() const override {
         return static_cast<int>(tracks.size());
     }
+    /// Counted so a test can assert how often the model was read, not only what
+    /// came back — the subscription hub promises one projection per flush no
+    /// matter how many clients are watching.
+    mutable int getTracksCalls = 0;
+
     const std::vector<TrackInfo>& getTracks() const override {
+        ++getTracksCalls;
         return tracks;
     }
     TrackInfo* getTrack(TrackId id) override {

--- a/tests/test_remote_model_bridge.cpp
+++ b/tests/test_remote_model_bridge.cpp
@@ -6,6 +6,7 @@
 #include "MockMagdaApi.hpp"
 #include "magda/daw/api/remote_model_bridge.hpp"
 #include "magda/daw/api/remote_service.hpp"
+#include "magda/daw/core/ClipManager.hpp"
 #include "magda/daw/core/TrackManager.hpp"
 #include "magda/daw/core/UndoManager.hpp"
 
@@ -135,4 +136,25 @@ TEST_CASE("A shut-down service ignores model notifications", "[remote][bridge][l
     fixture.service.changes().flush();
 
     REQUIRE(fixture.seen.empty());
+}
+
+TEST_CASE("Clip and track notifications also invalidate the session grid", "[remote][bridge]") {
+    BridgeFixture fixture;
+    const auto before = fixture.service.currentRevision();
+
+    // The session grid is projected out of the clips and keyed by track, so a
+    // subscriber watching only `session` has to hear about both. Marking only
+    // the obvious topic would leave it showing a grid the project no longer has.
+    TrackManager::getInstance().createTrack("Drums", TrackType::Audio);
+    ClipManager::getInstance().clearAllClips();
+    fixture.service.changes().flush();
+
+    REQUIRE(fixture.sawTopic(Topic::Tracks));
+    REQUIRE(fixture.sawTopic(Topic::Clips));
+    REQUIRE(fixture.sawTopic(Topic::Session));
+
+    // Two edits, two revisions — not four. A change that invalidates several
+    // topics is still one change, and advancing the counter per topic would make
+    // every multi-topic edit look like several to an optimistic writer.
+    REQUIRE(fixture.service.currentRevision() == before + 2);
 }

--- a/tests/test_remote_service.cpp
+++ b/tests/test_remote_service.cpp
@@ -55,11 +55,16 @@ TEST_CASE("Every declared operation has a handler", "[remote][service][registry]
     // The property the handler-on-descriptor design exists to guarantee: before
     // it, the registry declared 36 operations and implemented none, and nothing
     // detected that.
+    //
+    // Transport-scoped operations (#1857) are the one deliberate exception, and
+    // the assertion is two-way rather than a carve-out: an operation with no
+    // handler must say it is the transport's, and one that claims to be the
+    // transport's must not also carry a handler here.
     const auto& operations = OperationRegistry::instance().operations();
     REQUIRE_FALSE(operations.empty());
     for (const auto& operation : operations) {
         INFO("operation: " << operation.name);
-        REQUIRE(operation.handler != nullptr);
+        REQUIRE((operation.handler != nullptr) == !operation.transportScoped);
     }
 }
 

--- a/tests/test_remote_subscriptions.cpp
+++ b/tests/test_remote_subscriptions.cpp
@@ -1,0 +1,942 @@
+// Subscriptions, revisioned events, and backpressure (#1857).
+//
+// Everything here is hub behaviour with no socket involved: what a subscriber
+// receives, when a delta becomes a snapshot, and what happens to a client that
+// stops consuming. How those events reach a WebSocket client is
+// test_remote_websocket_server.cpp.
+//
+// The Catch2 runner has no MessageManager, so there is no flush timer and no
+// sampling timer. `flush()` and `sampleNow()` are called directly, which makes
+// every ordering assertion here deterministic rather than timing-dependent.
+
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+#include <vector>
+
+#include "MockMagdaApi.hpp"
+#include "magda/daw/api/remote_service.hpp"
+#include "magda/daw/api/remote_subscriptions.hpp"
+
+using namespace magda;
+using namespace magda::remote;
+using magda::test::MockMagdaApi;
+
+namespace {
+
+/// Reads MagdaApi live state, which asserts the message thread. The same
+/// accommodation every other remote test makes.
+struct MessageThreadRelaxation {
+    ScopedMessageThreadAssertionDisabler disabler;
+};
+
+/// A subscriber that remembers what it was sent and can be told to stop taking
+/// events, which is how backpressure is provoked without a real socket.
+struct Recorder {
+    std::vector<SubscriptionEvent> events;
+    bool accepting = true;
+    int refused = 0;
+    int disconnects = 0;
+    juce::String lastReason;
+
+    SubscriptionHub::Sink sink() {
+        return [this](const SubscriptionEvent& event) {
+            if (!accepting) {
+                ++refused;
+                return false;
+            }
+            events.push_back(event);
+            return true;
+        };
+    }
+
+    SubscriptionHub::Disconnect disconnect() {
+        return [this](const juce::String& reason) {
+            ++disconnects;
+            lastReason = reason;
+        };
+    }
+
+    std::vector<SubscriptionEvent> forTopic(Topic topic) const {
+        std::vector<SubscriptionEvent> matching;
+        for (const auto& event : events)
+            if (event.topic == topic)
+                matching.push_back(event);
+        return matching;
+    }
+
+    void clear() {
+        events.clear();
+    }
+};
+
+class FakeMeters : public MeterSource {
+  public:
+    std::vector<TrackLevels> levels;
+    int calls = 0;
+
+    std::vector<TrackLevels> sample() override {
+        ++calls;
+        return levels;
+    }
+};
+
+juce::var stringArray(const std::vector<const char*>& values) {
+    juce::Array<juce::var> array;
+    for (const auto* value : values)
+        array.add(juce::String(value));
+    return array;
+}
+
+juce::var params(std::initializer_list<std::pair<const char*, juce::var>> fields) {
+    auto* result = new juce::DynamicObject();
+    for (const auto& [key, value] : fields)
+        result->setProperty(key, value);
+    return result;
+}
+
+/// The hub answers through a callback because it hops to the message thread for
+/// anything that reads the model. With no MessageManager in this runner there is
+/// nowhere to hop, so the job runs inline and this is synchronous — the same
+/// accommodation `RemoteApiService::dispatch` makes.
+Response call(SubscriptionHub& hub, SubscriptionHub::ClientId client, const char* method,
+              const juce::var& input) {
+    Response captured;
+    int completions = 0;
+    const bool claimed = hub.handle(client, juce::String(method), input, [&](Response response) {
+        captured = std::move(response);
+        ++completions;
+    });
+    REQUIRE(claimed);
+    REQUIRE(completions == 1);
+    return captured;
+}
+
+Response subscribe(SubscriptionHub& hub, SubscriptionHub::ClientId client,
+                   const std::vector<const char*>& topics) {
+    return call(hub, client, "subscriptions.subscribe", params({{"topics", stringArray(topics)}}));
+}
+
+int snapshotCount(const Response& response) {
+    const auto* snapshots = response.result["snapshots"].getArray();
+    return snapshots == nullptr ? -1 : snapshots->size();
+}
+
+std::vector<juce::String> topicsOf(const Response& response) {
+    std::vector<juce::String> names;
+    if (const auto* array = response.result["topics"].getArray())
+        for (const auto& entry : *array)
+            names.push_back(entry.toString());
+    return names;
+}
+
+TrackInfo makeTrack(TrackId id, const juce::String& name) {
+    TrackInfo track;
+    track.id = id;
+    track.name = name;
+    track.type = TrackType::Audio;
+    return track;
+}
+
+/// One committed edit: bump the revision, mark the topic, and deliver.
+void commit(RemoteApiService& service, Topic topic) {
+    service.noteModelChanged(topic);
+    service.changes().flush();
+}
+
+}  // namespace
+
+TEST_CASE("Subscribing returns a snapshot for every requested model topic",
+          "[remote][subscriptions]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    const auto response = subscribe(hub, client, {"tracks", "transport"});
+
+    REQUIRE(response.ok);
+    REQUIRE(topicsOf(response) == std::vector<juce::String>{"tracks", "transport"});
+    REQUIRE(snapshotCount(response) == 2);
+
+    // The snapshot is the read operation's own output, not a second projection
+    // of it: a client that polled tracks.list would have received this exactly.
+    const auto* snapshots = response.result["snapshots"].getArray();
+    const auto tracks = (*snapshots)[0];
+    REQUIRE(tracks["topic"].toString() == "tracks");
+    REQUIRE(tracks["type"].toString() == "snapshot");
+    REQUIRE(tracks["payload"].getArray()->size() == 1);
+    REQUIRE(tracks["payload"][0]["name"].toString() == "Drums");
+
+    // Snapshots ride in the reply rather than arriving as events, so there is
+    // no window in which a client is subscribed and has no state.
+    REQUIRE(recorder.events.empty());
+}
+
+TEST_CASE("The continuous topics have no snapshot to deliver", "[remote][subscriptions][meters]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    const auto response = subscribe(hub, client, {"meters", "playhead"});
+
+    REQUIRE(response.ok);
+    // A meter reading is a sample, not state: there is no "current value since
+    // revision N" to hand over, only the next one along.
+    REQUIRE(snapshotCount(response) == 0);
+    REQUIRE(topicsOf(response).size() == 2);
+}
+
+TEST_CASE("A committed change delivers only what changed", "[remote][subscriptions][delta]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+    api.tracks_.tracks.push_back(makeTrack(2, "Bass"));
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"tracks"});
+
+    api.tracks_.tracks[1].name = "Sub Bass";
+    api.tracks_.tracks.push_back(makeTrack(3, "Keys"));
+    api.tracks_.tracks.erase(api.tracks_.tracks.begin());
+    commit(service, Topic::Tracks);
+
+    REQUIRE(recorder.events.size() == 1);
+    const auto& event = recorder.events.front();
+    REQUIRE(event.topic == Topic::Tracks);
+    REQUIRE(event.type == SubscriptionEvent::Type::Delta);
+    REQUIRE(event.revision == service.currentRevision());
+
+    REQUIRE(event.payload["added"].getArray()->size() == 1);
+    REQUIRE(event.payload["added"][0]["id"].toString() == "3");
+    REQUIRE(event.payload["updated"].getArray()->size() == 1);
+    REQUIRE(event.payload["updated"][0]["name"].toString() == "Sub Bass");
+    // Removals carry the identity alone. Sending the whole departed object
+    // would be sending state the client is about to throw away.
+    REQUIRE(event.payload["removed"].getArray()->size() == 1);
+    REQUIRE(static_cast<int>(event.payload["removed"][0]) == 1);
+}
+
+TEST_CASE("A topic with no element identity delivers its whole state",
+          "[remote][subscriptions][delta]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.project_.info.tempo = 120.0;
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"project"});
+
+    api.project_.info.tempo = 140.0;
+    commit(service, Topic::Project);
+
+    REQUIRE(recorder.events.size() == 1);
+    // `project` is one small object with nothing to diff, so the delta is the
+    // object. The type still says delta: this is a change, not a subscription.
+    REQUIRE(recorder.events[0].type == SubscriptionEvent::Type::Delta);
+    REQUIRE(static_cast<double>(recorder.events[0].payload["tempo"]) == 140.0);
+}
+
+TEST_CASE("A notification that changed nothing observable sends nothing",
+          "[remote][subscriptions][coalescing]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"tracks"});
+
+    // The model says the topic changed, and by the projection's reckoning it did
+    // not — a value that came back to where it started, or state this DTO does
+    // not expose. The cheapest event is the one never sent.
+    api.tracks_.tracks[0].name = "Temporary";
+    api.tracks_.tracks[0].name = "Drums";
+    commit(service, Topic::Tracks);
+
+    REQUIRE(recorder.events.empty());
+}
+
+TEST_CASE("A burst of model notifications coalesces to one event",
+          "[remote][subscriptions][coalescing]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"tracks"});
+
+    // The acceptance criterion: sustained 100 Hz control changes must not become
+    // 100 callbacks per second per client. Marking is what a fader move does;
+    // one flush is what a client sees.
+    for (int i = 0; i < 100; ++i) {
+        api.tracks_.tracks[0].volume = 0.5f + static_cast<float>(i) * 0.001f;
+        service.noteModelChanged(Topic::Tracks);
+    }
+    service.changes().flush();
+
+    REQUIRE(recorder.events.size() == 1);
+    REQUIRE(recorder.events[0].revision == service.currentRevision());
+}
+
+TEST_CASE("Events arrive in revision order across topics", "[remote][subscriptions][ordering]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"tracks", "project", "transport"});
+
+    api.tracks_.tracks[0].name = "Kit";
+    commit(service, Topic::Tracks);
+    api.project_.info.tempo = 128.0;
+    commit(service, Topic::Project);
+    api.transport_.playing = true;
+    commit(service, Topic::Transport);
+
+    REQUIRE(recorder.events.size() == 3);
+    REQUIRE(recorder.events[0].topic == Topic::Tracks);
+    REQUIRE(recorder.events[1].topic == Topic::Project);
+    REQUIRE(recorder.events[2].topic == Topic::Transport);
+    for (std::size_t i = 1; i < recorder.events.size(); ++i)
+        REQUIRE(recorder.events[i].revision > recorder.events[i - 1].revision);
+}
+
+TEST_CASE("A client that refuses an event is resynced rather than patched",
+          "[remote][subscriptions][backpressure]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"tracks"});
+
+    // The client stops reading. Its delta is dropped, not queued: holding it
+    // would be memory spent on a client that is not listening.
+    recorder.accepting = false;
+    api.tracks_.tracks[0].name = "Kit";
+    commit(service, Topic::Tracks);
+    REQUIRE(recorder.refused == 1);
+    REQUIRE(recorder.events.empty());
+
+    // It starts reading again. It has no baseline for the delta it missed, so
+    // what it gets is complete state rather than the next increment.
+    recorder.accepting = true;
+    api.tracks_.tracks.push_back(makeTrack(2, "Bass"));
+    commit(service, Topic::Tracks);
+
+    REQUIRE(recorder.events.size() == 1);
+    REQUIRE(recorder.events[0].type == SubscriptionEvent::Type::Snapshot);
+    REQUIRE(recorder.events[0].payload.getArray()->size() == 2);
+
+    // And it is back on deltas from there.
+    recorder.clear();
+    api.tracks_.tracks.push_back(makeTrack(3, "Keys"));
+    commit(service, Topic::Tracks);
+    REQUIRE(recorder.events.size() == 1);
+    REQUIRE(recorder.events[0].type == SubscriptionEvent::Type::Delta);
+}
+
+TEST_CASE("A client that never resumes is disconnected", "[remote][subscriptions][backpressure]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub::Options options;
+    options.droppedFlushesBeforeDisconnect = 3;
+    SubscriptionHub hub(api, service, options);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"tracks"});
+    REQUIRE(hub.clientCount() == 1);
+
+    recorder.accepting = false;
+    for (int i = 0; i < 3; ++i) {
+        api.tracks_.tracks[0].volume = 0.1f * static_cast<float>(i + 1);
+        commit(service, Topic::Tracks);
+    }
+
+    // It is holding a connection, a thread, and a place in every fan-out while
+    // consuming none of it.
+    REQUIRE(recorder.disconnects == 1);
+    REQUIRE(recorder.lastReason.isNotEmpty());
+    REQUIRE(hub.clientCount() == 0);
+}
+
+TEST_CASE("A dropped sample is not a client falling behind",
+          "[remote][subscriptions][backpressure][meters]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub::Options options;
+    options.droppedFlushesBeforeDisconnect = 2;
+    SubscriptionHub hub(api, service, options);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"playhead"});
+
+    recorder.accepting = false;
+    for (int i = 0; i < 20; ++i)
+        hub.sampleNow();
+
+    // Latest-value-wins means a discarded sample is the policy working. Counting
+    // it against the client would disconnect every subscriber that briefly
+    // stalled on a meter frame it did not need.
+    REQUIRE(recorder.refused == 20);
+    REQUIRE(recorder.disconnects == 0);
+    REQUIRE(hub.clientCount() == 1);
+}
+
+TEST_CASE("Meters and the playhead are sampled from their own sources",
+          "[remote][subscriptions][meters]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.transport_.positionBeats = 12.5;
+    api.transport_.playing = true;
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    auto meters = std::make_unique<FakeMeters>();
+    auto* metersRaw = meters.get();
+    metersRaw->levels = {{1, 0.5f, 0.25f, false}, {MASTER_TRACK_ID, 0.9f, 0.9f, true}};
+    hub.setMeterSource(std::move(meters));
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"meters", "playhead"});
+
+    hub.sampleNow();
+
+    const auto meterEvents = recorder.forTopic(Topic::Meters);
+    REQUIRE(meterEvents.size() == 1);
+    REQUIRE(meterEvents[0].type == SubscriptionEvent::Type::Sample);
+    REQUIRE(meterEvents[0].payload["tracks"].getArray()->size() == 2);
+    REQUIRE(static_cast<int>(meterEvents[0].payload["tracks"][1]["trackId"]) == MASTER_TRACK_ID);
+    REQUIRE(static_cast<bool>(meterEvents[0].payload["tracks"][1]["clipped"]));
+
+    const auto playhead = recorder.forTopic(Topic::Playhead);
+    REQUIRE(playhead.size() == 1);
+    REQUIRE(static_cast<double>(playhead[0].payload["positionBeats"]) == 12.5);
+    REQUIRE(static_cast<bool>(playhead[0].payload["playing"]));
+}
+
+TEST_CASE("Sampling costs nothing when nobody is subscribed to it",
+          "[remote][subscriptions][meters]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    auto meters = std::make_unique<FakeMeters>();
+    auto* metersRaw = meters.get();
+    hub.setMeterSource(std::move(meters));
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"tracks"});
+
+    hub.sampleNow();
+    hub.sampleNow();
+
+    // The meter source is never read on behalf of a subscriber that did not ask
+    // for meters — the whole point of making them opt-in.
+    REQUIRE(metersRaw->calls == 0);
+    REQUIRE(recorder.events.empty());
+}
+
+TEST_CASE("A subscriber only hears about topics it asked for", "[remote][subscriptions]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder tracksOnly;
+    Recorder projectOnly;
+    SubscriptionHub hub(api, service);
+
+    const auto a = hub.addClient(tracksOnly.sink(), tracksOnly.disconnect());
+    const auto b = hub.addClient(projectOnly.sink(), projectOnly.disconnect());
+    subscribe(hub, a, {"tracks"});
+    subscribe(hub, b, {"project"});
+
+    api.tracks_.tracks[0].name = "Kit";
+    commit(service, Topic::Tracks);
+
+    REQUIRE(tracksOnly.events.size() == 1);
+    REQUIRE(projectOnly.events.empty());
+}
+
+TEST_CASE("Unsubscribing stops delivery", "[remote][subscriptions]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"tracks", "project"});
+
+    const auto narrowed = call(hub, client, "subscriptions.unsubscribe",
+                               params({{"topics", stringArray({"tracks"})}}));
+    REQUIRE(narrowed.ok);
+    REQUIRE(topicsOf(narrowed) == std::vector<juce::String>{"project"});
+
+    api.tracks_.tracks[0].name = "Kit";
+    commit(service, Topic::Tracks);
+    REQUIRE(recorder.events.empty());
+
+    // No topics means all of them: the shape a client uses when it is going away
+    // rather than narrowing what it watches.
+    const auto all = call(hub, client, "subscriptions.unsubscribe", params({}));
+    REQUIRE(topicsOf(all).empty());
+
+    api.project_.info.tempo = 90.0;
+    commit(service, Topic::Project);
+    REQUIRE(recorder.events.empty());
+}
+
+TEST_CASE("subscriptions.list reports what this connection watches", "[remote][subscriptions]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    REQUIRE(topicsOf(call(hub, client, "subscriptions.list", params({}))).empty());
+
+    subscribe(hub, client, {"clips", "tracks"});
+    const auto listed = topicsOf(call(hub, client, "subscriptions.list", params({})));
+    // Reported in topic order rather than subscription order, so a client can
+    // compare two listings without sorting them first.
+    REQUIRE(listed == std::vector<juce::String>{"tracks", "clips"});
+}
+
+TEST_CASE("Resync hands back complete state and clears the client's arrears",
+          "[remote][subscriptions][resync]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub::Options options;
+    options.droppedFlushesBeforeDisconnect = 3;
+    SubscriptionHub hub(api, service, options);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"tracks", "project"});
+
+    recorder.accepting = false;
+    api.tracks_.tracks[0].name = "Kit";
+    commit(service, Topic::Tracks);
+    api.tracks_.tracks[0].name = "Kit 2";
+    commit(service, Topic::Tracks);
+    recorder.accepting = true;
+
+    const auto resync =
+        call(hub, client, "subscriptions.resync", params({{"topics", stringArray({"tracks"})}}));
+    REQUIRE(resync.ok);
+    REQUIRE(snapshotCount(resync) == 1);
+    const auto* snapshots = resync.result["snapshots"].getArray();
+    REQUIRE((*snapshots)[0]["topic"].toString() == "tracks");
+    REQUIRE((*snapshots)[0]["payload"][0]["name"].toString() == "Kit 2");
+
+    // Two flushes were missed out of an allowance of three. Having been handed
+    // complete state, what it missed no longer matters, so the count starts over
+    // rather than carrying it to a disconnect.
+    api.tracks_.tracks[0].volume = 0.2f;
+    commit(service, Topic::Tracks);
+    api.tracks_.tracks[0].volume = 0.3f;
+    commit(service, Topic::Tracks);
+    REQUIRE(recorder.disconnects == 0);
+}
+
+TEST_CASE("Resync with no topics covers everything subscribed", "[remote][subscriptions][resync]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"tracks", "project", "meters"});
+
+    const auto resync = call(hub, client, "subscriptions.resync", params({}));
+    // Two, not three: `meters` is subscribed but has no state to resync to.
+    REQUIRE(snapshotCount(resync) == 2);
+}
+
+TEST_CASE("Reconnecting at the current revision skips the snapshots",
+          "[remote][subscriptions][resync]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    commit(service, Topic::Tracks);
+    const auto revision = service.currentRevision();
+    REQUIRE(revision > INITIAL_REVISION);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    const auto resumed = call(hub, client, "subscriptions.subscribe",
+                              params({{"topics", stringArray({"tracks"})},
+                                      {"fromRevision", static_cast<juce::int64>(revision)}}));
+    REQUIRE(resumed.ok);
+    // Nothing has been committed since the client last looked, so re-sending
+    // every track would be a full transfer to say "no change".
+    REQUIRE(snapshotCount(resumed) == 0);
+
+    // And it is a live subscriber from there, on deltas.
+    api.tracks_.tracks.push_back(makeTrack(2, "Bass"));
+    commit(service, Topic::Tracks);
+    REQUIRE(recorder.events.size() == 1);
+    REQUIRE(recorder.events[0].type == SubscriptionEvent::Type::Delta);
+    REQUIRE(recorder.events[0].payload["added"].getArray()->size() == 1);
+}
+
+TEST_CASE("Reconnecting at a revision that has moved on forces a full resync",
+          "[remote][subscriptions][resync]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    commit(service, Topic::Tracks);
+    const auto stale = service.currentRevision();
+    commit(service, Topic::Tracks);
+    REQUIRE(service.currentRevision() > stale);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    const auto resumed = call(hub, client, "subscriptions.subscribe",
+                              params({{"topics", stringArray({"tracks"})},
+                                      {"fromRevision", static_cast<juce::int64>(stale)}}));
+
+    // No per-revision history is kept, so a client that is behind by any amount
+    // cannot be caught up incrementally. Saying so explicitly beats replaying
+    // what happens to still be in memory.
+    REQUIRE(snapshotCount(resumed) == 1);
+}
+
+TEST_CASE("A second subscriber does not cost the first one its next delta",
+          "[remote][subscriptions][resync]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder first;
+    Recorder second;
+    SubscriptionHub hub(api, service);
+
+    const auto a = hub.addClient(first.sink(), first.disconnect());
+    subscribe(hub, a, {"tracks"});
+
+    // A change lands, and a new client subscribes before the flush that would
+    // have told the first one about it. Moving the shared baseline forward for
+    // the newcomer would swallow that change for the incumbent.
+    api.tracks_.tracks.push_back(makeTrack(2, "Bass"));
+    service.noteModelChanged(Topic::Tracks);
+
+    const auto b = hub.addClient(second.sink(), second.disconnect());
+    const auto joined = subscribe(hub, b, {"tracks"});
+    REQUIRE(snapshotCount(joined) == 1);
+    REQUIRE((*joined.result["snapshots"].getArray())[0]["payload"].getArray()->size() == 2);
+
+    service.changes().flush();
+
+    REQUIRE(first.events.size() == 1);
+    REQUIRE(first.events[0].payload["added"].getArray()->size() == 1);
+    // The newcomer sees a delta it already had. Added and updated are upserts
+    // keyed by id, so applying one twice lands in the same place.
+    REQUIRE(second.events.size() == 1);
+}
+
+TEST_CASE("Subscription input is validated against the declared schema",
+          "[remote][subscriptions][errors]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+
+    const auto unknown = call(hub, client, "subscriptions.subscribe",
+                              params({{"topics", stringArray({"telemetry"})}}));
+    REQUIRE_FALSE(unknown.ok);
+    REQUIRE(unknown.error.code == ErrorCode::ValidationFailed);
+
+    const auto empty = call(hub, client, "subscriptions.subscribe",
+                            params({{"topics", juce::var(juce::Array<juce::var>{})}}));
+    REQUIRE_FALSE(empty.ok);
+    REQUIRE(empty.error.code == ErrorCode::ValidationFailed);
+
+    const auto missing = call(hub, client, "subscriptions.subscribe", params({}));
+    REQUIRE_FALSE(missing.ok);
+    REQUIRE(missing.error.code == ErrorCode::ValidationFailed);
+
+    const auto extra = call(hub, client, "subscriptions.subscribe",
+                            params({{"topics", stringArray({"tracks"})}, {"forever", true}}));
+    REQUIRE_FALSE(extra.ok);
+    REQUIRE(extra.error.code == ErrorCode::ValidationFailed);
+}
+
+TEST_CASE("A method that is not a subscription method is not claimed",
+          "[remote][subscriptions][errors]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    // Returning false without answering is the transport's signal to route it to
+    // the dispatcher instead.
+    int completions = 0;
+    REQUIRE_FALSE(hub.handle(client, "tracks.list", params({}), [&](Response) { ++completions; }));
+    REQUIRE(completions == 0);
+    REQUIRE_FALSE(SubscriptionHub::isSubscriptionMethod("tracks.list"));
+    REQUIRE(SubscriptionHub::isSubscriptionMethod("subscriptions.subscribe"));
+}
+
+TEST_CASE("A subscription method reaching the dispatcher is refused with a reason",
+          "[remote][subscriptions][errors]") {
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    Response captured;
+    int completions = 0;
+    service.dispatch("subscriptions.subscribe", juce::var(new juce::DynamicObject()), {},
+                     [&](Response response) {
+                         captured = std::move(response);
+                         ++completions;
+                     });
+
+    REQUIRE(completions == 1);
+    REQUIRE_FALSE(captured.ok);
+    // Not UnknownOperation: the operation is real and the request is well formed.
+    // The only thing wrong is the transport it arrived on.
+    REQUIRE(captured.error.code == ErrorCode::InvalidRequest);
+    REQUIRE(captured.error.message.contains("subscriptions"));
+}
+
+TEST_CASE("The registry declares the subscription methods it cannot execute",
+          "[remote][subscriptions][registry]") {
+    const auto& registry = OperationRegistry::instance();
+    for (const auto* name : {"subscriptions.subscribe", "subscriptions.unsubscribe",
+                             "subscriptions.list", "subscriptions.resync"}) {
+        INFO("operation: " << name);
+        const auto* operation = registry.find(name);
+        REQUIRE(operation != nullptr);
+        // Declared here so both adapters share one contract; implemented in the
+        // adapter because a connection is the one thing the registry has no
+        // notion of.
+        REQUIRE(operation->transportScoped);
+        REQUIRE(operation->handler == nullptr);
+        REQUIRE(operation->access == OperationAccess::Read);
+    }
+
+    const auto described = registry.describe();
+    const auto* operations = described["operations"].getArray();
+    REQUIRE(operations != nullptr);
+    bool sawSubscribe = false;
+    for (const auto& operation : *operations) {
+        // Present on every entry rather than only where true: a client deciding
+        // what it can call should read a field, not infer one from silence.
+        REQUIRE(operation["transportScoped"].isBool());
+        if (operation["name"].toString() == "subscriptions.subscribe")
+            sawSubscribe = static_cast<bool>(operation["transportScoped"]);
+    }
+    REQUIRE(sawSubscribe);
+}
+
+TEST_CASE("Removing a client stops delivery and releases its topics",
+          "[remote][subscriptions][lifetime]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"tracks"});
+    hub.removeClient(client);
+    REQUIRE(hub.clientCount() == 0);
+
+    api.tracks_.tracks[0].name = "Kit";
+    commit(service, Topic::Tracks);
+    REQUIRE(recorder.events.empty());
+
+    // Rejoining gets a snapshot rather than a delta against a baseline that was
+    // released with the last subscriber.
+    Recorder rejoined;
+    const auto next = hub.addClient(rejoined.sink(), rejoined.disconnect());
+    REQUIRE(snapshotCount(subscribe(hub, next, {"tracks"})) == 1);
+}
+
+TEST_CASE("Shutdown stops delivery and survives a later flush",
+          "[remote][subscriptions][lifetime]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"tracks"});
+    hub.shutdown();
+
+    api.tracks_.tracks[0].name = "Kit";
+    commit(service, Topic::Tracks);
+    REQUIRE(recorder.events.empty());
+
+    // Idempotent, and every method fails closed afterwards rather than
+    // registering a subscriber nothing will ever feed.
+    hub.shutdown();
+    REQUIRE(hub.addClient(recorder.sink(), recorder.disconnect()) == 0);
+    REQUIRE_FALSE(call(hub, client, "subscriptions.list", params({})).ok);
+}
+
+// ===========================================================================
+// Load
+// ===========================================================================
+
+TEST_CASE("One flush projects each topic once, however many clients are watching",
+          "[remote][subscriptions][load]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    for (TrackId id = 1; id <= 50; ++id)
+        api.tracks_.tracks.push_back(makeTrack(id, "Track " + juce::String(id)));
+
+    RemoteApiService service(api);
+    SubscriptionHub hub(api, service);
+
+    constexpr int kClients = 32;
+    std::vector<std::unique_ptr<Recorder>> recorders;
+    for (int i = 0; i < kClients; ++i) {
+        recorders.push_back(std::make_unique<Recorder>());
+        subscribe(hub, hub.addClient(recorders.back()->sink(), recorders.back()->disconnect()),
+                  {"tracks"});
+    }
+
+    api.tracks_.getTracksCalls = 0;
+    api.tracks_.tracks[0].name = "Renamed";
+    commit(service, Topic::Tracks);
+
+    // The projection is the expensive half — every track, every field — and it
+    // is shared. Doing it per subscriber would make a busy project quadratic in
+    // clients, which is the failure this design exists to avoid.
+    REQUIRE(api.tracks_.getTracksCalls == 1);
+    for (const auto& recorder : recorders) {
+        REQUIRE(recorder->events.size() == 1);
+        REQUIRE(recorder->events[0].type == SubscriptionEvent::Type::Delta);
+    }
+}
+
+TEST_CASE("Sustained change is one event per client per flush", "[remote][subscriptions][load]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"tracks"});
+
+    // A hundred flushes of a fader that is moving at a hundred times that rate.
+    // The acceptance criterion is about what reaches the client, and it is the
+    // flush count that bounds it, not the notification count.
+    constexpr int kFlushes = 100;
+    constexpr int kMarksPerFlush = 100;
+    for (int flush = 0; flush < kFlushes; ++flush) {
+        for (int mark = 0; mark < kMarksPerFlush; ++mark) {
+            api.tracks_.tracks[0].volume =
+                static_cast<float>(flush * kMarksPerFlush + mark) * 0.0001f;
+            service.noteModelActivity(Topic::Tracks);
+        }
+        service.changes().flush();
+    }
+
+    REQUIRE(recorder.events.size() == kFlushes);
+    // Motion, not commits: `noteModelActivity` deliberately leaves the revision
+    // alone, or optimistic concurrency would be unusable during playback.
+    REQUIRE(service.currentRevision() == INITIAL_REVISION);
+}
+
+TEST_CASE("A client that has stopped reading does not hold up the others",
+          "[remote][subscriptions][load][backpressure]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder stalled;
+    Recorder healthy;
+    SubscriptionHub::Options options;
+    options.droppedFlushesBeforeDisconnect = 5;
+    SubscriptionHub hub(api, service, options);
+
+    subscribe(hub, hub.addClient(stalled.sink(), stalled.disconnect()), {"tracks"});
+    subscribe(hub, hub.addClient(healthy.sink(), healthy.disconnect()), {"tracks"});
+
+    stalled.accepting = false;
+    for (int i = 0; i < 4; ++i) {
+        api.tracks_.tracks[0].volume = 0.1f * static_cast<float>(i + 1);
+        commit(service, Topic::Tracks);
+    }
+
+    // Nothing was queued for the stalled client and nothing was retried, so its
+    // neighbour's stream is exactly what it would have been alone.
+    REQUIRE(stalled.events.empty());
+    REQUIRE(healthy.events.size() == 4);
+    for (const auto& event : healthy.events)
+        REQUIRE(event.type == SubscriptionEvent::Type::Delta);
+    REQUIRE(hub.clientCount() == 2);
+}

--- a/tests/test_remote_subscriptions.cpp
+++ b/tests/test_remote_subscriptions.cpp
@@ -601,8 +601,61 @@ TEST_CASE("Resync with no topics covers everything subscribed", "[remote][subscr
     REQUIRE(snapshotCount(resync) == 2);
 }
 
-TEST_CASE("Reconnecting at the current revision skips the snapshots",
+TEST_CASE("Subscribing snapshots even when the revision has not moved",
           "[remote][subscriptions][resync]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder first;
+    SubscriptionHub hub(api, service);
+
+    subscribe(hub, hub.addClient(first.sink(), first.disconnect()), {"tracks"});
+    const auto revision = service.currentRevision();
+
+    // Motion, not a commit. `noteModelActivity` publishes an event and
+    // deliberately leaves the revision alone, because bumping it for a parameter
+    // that is merely following automation would make optimistic concurrency
+    // unusable whenever the transport is rolling.
+    api.tracks_.tracks[0].volume = 0.75f;
+    service.noteModelActivity(Topic::Tracks);
+    service.changes().flush();
+    REQUIRE(first.events.size() == 1);
+    REQUIRE(service.currentRevision() == revision);
+
+    // A client that missed exactly that event and reconnects has a cursor
+    // identical to a client that saw it. The revision cannot tell them apart, so
+    // resuming on one would leave the stale client stale and never say so.
+    Recorder reconnecting;
+    const auto resumed =
+        call(hub, hub.addClient(reconnecting.sink(), reconnecting.disconnect()),
+             "subscriptions.subscribe", params({{"topics", stringArray({"tracks"})}}));
+    REQUIRE(snapshotCount(resumed) == 1);
+    const auto* snapshots = resumed.result["snapshots"].getArray();
+    REQUIRE(static_cast<double>((*snapshots)[0]["payload"][0]["volume"]) == 0.75);
+}
+
+TEST_CASE("A revision cannot be offered as a subscription cursor",
+          "[remote][subscriptions][resync]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    // Rejected rather than ignored. A client that used to send this is asking
+    // for a guarantee the server cannot make, and being told so beats silently
+    // getting the snapshots it thought it had skipped.
+    const auto refused = call(hub, client, "subscriptions.subscribe",
+                              params({{"topics", stringArray({"tracks"})},
+                                      {"fromRevision", static_cast<juce::int64>(0)}}));
+    REQUIRE_FALSE(refused.ok);
+    REQUIRE(refused.error.code == ErrorCode::ValidationFailed);
+}
+
+TEST_CASE("A client that says it has state is not sent any", "[remote][subscriptions][resync]") {
     MessageThreadRelaxation relaxation;
     MockMagdaApi api;
     api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
@@ -611,51 +664,22 @@ TEST_CASE("Reconnecting at the current revision skips the snapshots",
     Recorder recorder;
     SubscriptionHub hub(api, service);
 
-    commit(service, Topic::Tracks);
-    const auto revision = service.currentRevision();
-    REQUIRE(revision > INITIAL_REVISION);
-
     const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    // The client's assertion, not the server's inference — which is the whole
+    // difference. It is on the client to be right, and `subscriptions.resync` is
+    // there for when it is not.
     const auto resumed = call(hub, client, "subscriptions.subscribe",
-                              params({{"topics", stringArray({"tracks"})},
-                                      {"fromRevision", static_cast<juce::int64>(revision)}}));
+                              params({{"topics", stringArray({"tracks"})}, {"snapshot", false}}));
     REQUIRE(resumed.ok);
-    // Nothing has been committed since the client last looked, so re-sending
-    // every track would be a full transfer to say "no change".
     REQUIRE(snapshotCount(resumed) == 0);
 
-    // And it is a live subscriber from there, on deltas.
+    // Still a live subscriber, and on deltas: the baseline was established even
+    // though nothing was sent.
     api.tracks_.tracks.push_back(makeTrack(2, "Bass"));
     commit(service, Topic::Tracks);
     REQUIRE(recorder.events.size() == 1);
     REQUIRE(recorder.events[0].type == SubscriptionEvent::Type::Delta);
     REQUIRE(recorder.events[0].payload["added"].getArray()->size() == 1);
-}
-
-TEST_CASE("Reconnecting at a revision that has moved on forces a full resync",
-          "[remote][subscriptions][resync]") {
-    MessageThreadRelaxation relaxation;
-    MockMagdaApi api;
-    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
-
-    RemoteApiService service(api);
-    Recorder recorder;
-    SubscriptionHub hub(api, service);
-
-    commit(service, Topic::Tracks);
-    const auto stale = service.currentRevision();
-    commit(service, Topic::Tracks);
-    REQUIRE(service.currentRevision() > stale);
-
-    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
-    const auto resumed = call(hub, client, "subscriptions.subscribe",
-                              params({{"topics", stringArray({"tracks"})},
-                                      {"fromRevision", static_cast<juce::int64>(stale)}}));
-
-    // No per-revision history is kept, so a client that is behind by any amount
-    // cannot be caught up incrementally. Saying so explicitly beats replaying
-    // what happens to still be in memory.
-    REQUIRE(snapshotCount(resumed) == 1);
 }
 
 TEST_CASE("A second subscriber does not cost the first one its next delta",

--- a/tests/test_remote_subscriptions.cpp
+++ b/tests/test_remote_subscriptions.cpp
@@ -1077,3 +1077,93 @@ TEST_CASE("A session subscriber hears about a clip that changes the grid",
     REQUIRE(sessionOnly.events[0].topic == Topic::Session);
     REQUIRE(sessionOnly.events[0].payload["added"].getArray()->size() == 1);
 }
+
+TEST_CASE("Keeping up on one topic is not keeping up", "[remote][subscriptions][backpressure]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+    api.project_.info.tempo = 120.0;
+
+    RemoteApiService service(api);
+    SubscriptionHub::Options options;
+    options.droppedFlushesBeforeDisconnect = 3;
+    SubscriptionHub hub(api, service, options);
+
+    // A client whose outgoing queue holds one event, drained between flushes —
+    // the shape a real connection has when its writer is slower than the model.
+    // Each flush it takes the first topic offered and refuses the second.
+    struct Budgeted {
+        int capacity = 1;
+        int queued = 0;
+        int refused = 0;
+        int disconnects = 0;
+        std::vector<Topic> taken;
+
+        SubscriptionHub::Sink sink() {
+            return [this](const SubscriptionEvent& event) {
+                if (queued >= capacity) {
+                    ++refused;
+                    return false;
+                }
+                ++queued;
+                taken.push_back(event.topic);
+                return true;
+            };
+        }
+        SubscriptionHub::Disconnect disconnect() {
+            return [this](const juce::String&) { ++disconnects; };
+        }
+        void drain() {
+            queued = 0;
+        }
+    };
+
+    Budgeted client;
+    subscribe(hub, hub.addClient(client.sink(), client.disconnect()), {"project", "tracks"});
+
+    for (int flush = 0; flush < 3; ++flush) {
+        client.drain();
+        api.project_.info.tempo += 1.0;
+        api.tracks_.tracks[0].volume = 0.1f * static_cast<float>(flush + 1);
+        service.noteModelChanged(Topic::Project);
+        service.noteModelChanged(Topic::Tracks);
+        service.changes().flush();
+    }
+
+    // It accepted something every single flush. Counting that as recovery would
+    // reset the tally before the refusal in the same flush could raise it, so it
+    // would sit at one forever: connected, apparently healthy, and permanently
+    // stale on the topic it never manages to take.
+    REQUIRE(client.refused == 3);
+    REQUIRE(client.disconnects == 1);
+    REQUIRE(hub.clientCount() == 0);
+}
+
+TEST_CASE("Several refusals in one flush are one flush", "[remote][subscriptions][backpressure]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub::Options options;
+    options.droppedFlushesBeforeDisconnect = 2;
+    SubscriptionHub hub(api, service, options);
+
+    subscribe(hub, hub.addClient(recorder.sink(), recorder.disconnect()),
+              {"project", "tracks", "transport"});
+
+    recorder.accepting = false;
+    api.project_.info.tempo = 128.0;
+    api.tracks_.tracks[0].name = "Kit";
+    api.transport_.playing = true;
+    for (const auto topic : {Topic::Project, Topic::Tracks, Topic::Transport})
+        service.noteModelChanged(topic);
+    service.changes().flush();
+
+    // Three topics refused, but one flush. The threshold is stated in flushes,
+    // so a client watching more topics must not be disconnected sooner for it.
+    REQUIRE(recorder.refused == 3);
+    REQUIRE(recorder.disconnects == 0);
+    REQUIRE(hub.clientCount() == 1);
+}

--- a/tests/test_remote_subscriptions.cpp
+++ b/tests/test_remote_subscriptions.cpp
@@ -940,3 +940,140 @@ TEST_CASE("A client that has stopped reading does not hold up the others",
         REQUIRE(event.type == SubscriptionEvent::Type::Delta);
     REQUIRE(hub.clientCount() == 2);
 }
+
+// ===========================================================================
+// Recovery and invalidation
+// ===========================================================================
+
+TEST_CASE("The stalled client is the one disconnected, not whoever follows it",
+          "[remote][subscriptions][backpressure]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder stalled;
+    Recorder healthy;
+    SubscriptionHub::Options options;
+    options.droppedFlushesBeforeDisconnect = 2;
+    SubscriptionHub hub(api, service, options);
+
+    // Order matters. Removing the stalled client compacts the healthy one over
+    // the top of it, so a disconnect callback read from the tail afterwards
+    // belongs to a moved-from copy rather than to the client that stalled.
+    subscribe(hub, hub.addClient(stalled.sink(), stalled.disconnect()), {"tracks"});
+    subscribe(hub, hub.addClient(healthy.sink(), healthy.disconnect()), {"tracks"});
+
+    stalled.accepting = false;
+    for (int i = 0; i < 2; ++i) {
+        api.tracks_.tracks[0].volume = 0.1f * static_cast<float>(i + 1);
+        commit(service, Topic::Tracks);
+    }
+
+    // The one that stopped consuming is told to go, and it is the only one:
+    // dropping it while leaving its socket open would strand a thread and a
+    // connection slot for the life of the process.
+    REQUIRE(stalled.disconnects == 1);
+    REQUIRE(healthy.disconnects == 0);
+    REQUIRE(hub.clientCount() == 1);
+    REQUIRE_FALSE(healthy.events.empty());
+}
+
+TEST_CASE("A refused event is followed by a snapshot even if nothing else changes",
+          "[remote][subscriptions][backpressure][resync]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder recorder;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(recorder.sink(), recorder.disconnect());
+    subscribe(hub, client, {"tracks"});
+
+    recorder.accepting = false;
+    api.tracks_.tracks[0].name = "Kit";
+    commit(service, Topic::Tracks);
+    REQUIRE(recorder.refused == 1);
+
+    // The project goes quiet. Nothing will ever change this topic again, so a
+    // recovery that waited for the next observable change would wait forever —
+    // the client would be silently stale until it thought to ask for a resync.
+    recorder.accepting = true;
+    service.changes().flush();
+
+    REQUIRE(recorder.events.size() == 1);
+    REQUIRE(recorder.events[0].type == SubscriptionEvent::Type::Snapshot);
+    REQUIRE(recorder.events[0].payload[0]["name"].toString() == "Kit");
+
+    // And the retry stops once the debt is paid, rather than republishing on
+    // every flush from then on.
+    recorder.clear();
+    service.changes().flush();
+    REQUIRE(recorder.events.empty());
+}
+
+TEST_CASE("Opening a different project reaches subscribers of every topic",
+          "[remote][subscriptions][resync]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Old project"));
+
+    RemoteApiService service(api);
+    Recorder tracksOnly;
+    SubscriptionHub hub(api, service);
+
+    // Deliberately not subscribed to `project`. A client watching one topic
+    // would otherwise keep showing the outgoing project's contents until
+    // something happened to change that same topic in the new one.
+    const auto client = hub.addClient(tracksOnly.sink(), tracksOnly.disconnect());
+    subscribe(hub, client, {"tracks"});
+
+    api.tracks_.tracks.clear();
+    api.tracks_.tracks.push_back(makeTrack(9, "New project"));
+    service.projectReplaced();
+    service.changes().flush();
+
+    REQUIRE(tracksOnly.events.size() == 1);
+    const auto& payload = tracksOnly.events[0].payload;
+    REQUIRE(payload["removed"].getArray()->size() == 1);
+    REQUIRE(static_cast<int>(payload["removed"][0]) == 1);
+    REQUIRE(payload["added"].getArray()->size() == 1);
+    REQUIRE(payload["added"][0]["name"].toString() == "New project");
+}
+
+TEST_CASE("A session subscriber hears about a clip that changes the grid",
+          "[remote][subscriptions][delta]") {
+    MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.tracks_.tracks.push_back(makeTrack(1, "Drums"));
+
+    RemoteApiService service(api);
+    Recorder sessionOnly;
+    SubscriptionHub hub(api, service);
+
+    const auto client = hub.addClient(sessionOnly.sink(), sessionOnly.disconnect());
+    subscribe(hub, client, {"session"});
+
+    // `session.get` projects its slots out of the clips rather than storing them
+    // beside them, so a clip operation that marked only `clips` would leave this
+    // subscriber stale for as long as the session grid went untouched.
+    ClipInfo clip;
+    clip.id = 50;
+    clip.trackId = 1;
+    clip.name = "Loop";
+    clip.setMidiContent();
+    clip.view = ClipView::Session;
+    clip.sceneIndex = 0;
+    api.clips_.clips.emplace(clip.id, clip);
+    api.clips_.clipsOnTrack[1] = {clip.id};
+
+    for (const auto topic : {Topic::Clips, Topic::Session})
+        service.noteModelChanged(topic);
+    service.changes().flush();
+
+    REQUIRE(sessionOnly.events.size() == 1);
+    REQUIRE(sessionOnly.events[0].topic == Topic::Session);
+    REQUIRE(sessionOnly.events[0].payload["added"].getArray()->size() == 1);
+}

--- a/tests/test_remote_websocket_live_juce.cpp
+++ b/tests/test_remote_websocket_live_juce.cpp
@@ -1,13 +1,16 @@
 #include <httplib.h>
 
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "magda/daw/api/magda_api_live.hpp"
 #include "magda/daw/api/remote_model_bridge.hpp"
 #include "magda/daw/api/remote_service.hpp"
+#include "magda/daw/api/remote_subscriptions.hpp"
 #include "magda/daw/api/remote_websocket_server.hpp"
 #include "magda/daw/core/AutomationManager.hpp"
 #include "magda/daw/core/ClipManager.hpp"
@@ -143,6 +146,68 @@ class RemoteWebSocketLiveTest final : public juce::UnitTest {
             // overwrite an edit it never saw.
             expect(fixture.service.currentRevision() > before);
         }
+
+        beginTest("A UI edit reaches a subscribed client through the real flush timer");
+        {
+            Fixture fixture;
+
+            // Everything else in the remote suite drives the coalescing window by
+            // hand, because the Catch2 runner has no MessageManager for a timer
+            // to live on. Here there is one, so this is the only place the 30 Hz
+            // pump — and the hop from a model listener to a socket write — is
+            // actually exercised.
+            const auto pushed = fixture.subscribeThenObserve({"tracks"}, [] {
+                TrackManager::getInstance().createTrack("By hand", TrackType::Audio);
+            });
+
+            expect(pushed["method"].toString() == "subscriptions.event");
+            expect(pushed["id"].isVoid());
+            expect(pushed["params"]["topic"].toString() == "tracks");
+            const auto* added = pushed["params"]["payload"]["added"].getArray();
+            expect(added != nullptr);
+            if (added != nullptr && !added->isEmpty())
+                expect((*added)[0]["name"].toString() == "By hand");
+        }
+
+        beginTest("Snapshots are projected on the message thread, not the socket's");
+        {
+            Fixture fixture;
+
+            // `selection`, `session`, and `transport` all project through
+            // helpers that assert the message thread, and this target does not
+            // relax that assertion. Subscribing arrives on a connection thread,
+            // so a hub that projected where the request landed would trip here —
+            // which is the whole reason handle() answers through a callback.
+            juce::Array<juce::var> topics;
+            topics.add("selection");
+            topics.add("session");
+            topics.add("transport");
+
+            const auto reply = fixture.exchange(
+                requestJson("subscriptions.subscribe", object({{"topics", topics}})));
+
+            expect(reply["error"].isVoid());
+            const auto* snapshots = reply["result"]["snapshots"].getArray();
+            expect(snapshots != nullptr);
+            if (snapshots != nullptr)
+                expect(snapshots->size() == 3);
+        }
+
+        beginTest("The playhead is sampled on its own timer, with nothing marking it");
+        {
+            Fixture fixture;
+
+            // Nothing in the model ever says the playhead moved — it moves with
+            // the transport and notifies no one. A sample arriving at all is the
+            // sampling timer working, which is the half of #1857 that no model
+            // notification can drive.
+            const auto pushed = fixture.subscribeThenObserve({"playhead"}, [] {});
+
+            expect(pushed["method"].toString() == "subscriptions.event");
+            expect(pushed["params"]["topic"].toString() == "playhead");
+            expect(pushed["params"]["type"].toString() == "sample");
+            expect(pushed["params"]["payload"].hasProperty("positionBeats"));
+        }
     }
 
   private:
@@ -150,20 +215,29 @@ class RemoteWebSocketLiveTest final : public juce::UnitTest {
         MagdaApiLive api;
         RemoteApiService service{api};
         std::unique_ptr<ModelChangeBridge> bridge;
+        std::unique_ptr<SubscriptionHub> subscriptions;
         std::unique_ptr<RemoteWebSocketServer> server;
 
         Fixture() {
             reset();
             bridge = std::make_unique<ModelChangeBridge>(service);
 
+            SubscriptionHub::Options hubOptions;
+            // Faster than the shipping 20 Hz so a sampling test spends less of
+            // its budget waiting. It is still the real timer, on the real
+            // message thread — which is the part being exercised.
+            hubOptions.samplingIntervalMs = 10;
+            subscriptions = std::make_unique<SubscriptionHub>(api, service, hubOptions);
+
             RemoteWebSocketServer::Options options;
             options.bearerToken = kToken;
-            server = std::make_unique<RemoteWebSocketServer>(service, options);
+            server = std::make_unique<RemoteWebSocketServer>(service, options, subscriptions.get());
             server->start();
         }
 
         ~Fixture() {
             server.reset();
+            subscriptions.reset();
             bridge.reset();
             reset();
         }
@@ -196,9 +270,7 @@ class RemoteWebSocketLiveTest final : public juce::UnitTest {
             std::string received;
 
             std::thread worker([&] {
-                httplib::ws::WebSocketClient client(
-                    "ws://127.0.0.1:" + std::to_string(server->boundPort()) + "/rpc",
-                    {{"Authorization", std::string("Bearer ") + kToken}});
+                httplib::ws::WebSocketClient client(url(), headers());
                 if (client.connect()) {
                     client.send(payload);
                     client.read(received);
@@ -206,16 +278,72 @@ class RemoteWebSocketLiveTest final : public juce::UnitTest {
                 finished.store(true);
             });
 
-            const auto deadline =
-                juce::Time::getMillisecondCounter() + static_cast<juce::uint32>(timeoutMs);
-            while (!finished.load() && juce::Time::getMillisecondCounter() < deadline)
-                juce::MessageManager::getInstance()->runDispatchLoopUntil(10);
-
+            pumpUntil(finished, timeoutMs);
             worker.join();
 
             juce::var parsed;
             juce::JSON::parse(juce::String(received), parsed);
             return parsed;
+        }
+
+        /**
+         * @brief Subscribe over a real socket, cause something, and read what is pushed.
+         *
+         * The same split as `exchange`, for the same reason and one more: the
+         * flush timer and the sampling timer both live on the message thread, so
+         * this thread pumping is what produces the event the worker is waiting
+         * for.
+         */
+        juce::var subscribeThenObserve(const std::vector<const char*>& topics,
+                                       const std::function<void()>& cause, int timeoutMs = 15000) {
+            juce::Array<juce::var> names;
+            for (const auto* topic : topics)
+                names.add(juce::String(topic));
+
+            std::atomic<bool> subscribed{false};
+            std::atomic<bool> finished{false};
+            std::string reply;
+            std::string event;
+
+            std::thread worker([&] {
+                httplib::ws::WebSocketClient client(url(), headers());
+                if (client.connect()) {
+                    client.send(
+                        requestJson("subscriptions.subscribe", object({{"topics", names}})));
+                    if (client.read(reply) == httplib::ws::ReadResult::Text) {
+                        // Only now is the subscription registered, so only now is
+                        // it safe to cause the change it is meant to observe.
+                        subscribed.store(true);
+                        client.read(event);
+                    }
+                }
+                subscribed.store(true);
+                finished.store(true);
+            });
+
+            pumpUntil(subscribed, timeoutMs);
+            cause();
+            pumpUntil(finished, timeoutMs);
+            worker.join();
+
+            juce::var parsed;
+            juce::JSON::parse(juce::String(event), parsed);
+            return parsed;
+        }
+
+        std::string url() const {
+            return "ws://127.0.0.1:" + std::to_string(server->boundPort()) + "/rpc";
+        }
+
+        static httplib::Headers headers() {
+            return {{"Authorization", std::string("Bearer ") + kToken}};
+        }
+
+        static void pumpUntil(const std::atomic<bool>& done, int timeoutMs) {
+            const auto deadline =
+                juce::Time::getMillisecondCounter() + static_cast<juce::uint32>(timeoutMs);
+            while (!done.load() && juce::Time::getMillisecondCounter() < deadline)
+                juce::MessageManager::getInstance()->runDispatchLoopUntil(10);
         }
     };
 };

--- a/tests/test_remote_websocket_server.cpp
+++ b/tests/test_remote_websocket_server.cpp
@@ -785,3 +785,41 @@ TEST_CASE("A subscriber that cannot take events is dropped, not queued for",
     // stopped being a subscriber.
     REQUIRE(hub.clientCount() == 0);
 }
+
+TEST_CASE("A dropped subscriber stops being able to change the project",
+          "[remote][websocket][subscriptions][limits]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    SubscriptionHub::Options hubOptions;
+    hubOptions.droppedFlushesBeforeDisconnect = 1;
+    SubscriptionHub hub(api, service, hubOptions);
+
+    auto options = testOptions();
+    options.maxQueuedEventsPerConnection = 0;
+    RemoteWebSocketServer server(service, options, &hub);
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(endpoint(server), authorised());
+    REQUIRE(client.connect());
+    roundTrip(client, request("subscriptions.subscribe", topicList({"transport"})));
+
+    api.transport_.playing = true;
+    service.noteModelChanged(Topic::Transport);
+    service.changes().flush();
+    REQUIRE(hub.clientCount() == 0);
+
+    // Marking a connection closed is all a foreign thread may do — the reader
+    // owns the socket. That only ends the connection if the reader looks, and
+    // until it did, a client dropped for backpressure kept getting its requests
+    // executed with only the replies thrown away.
+    REQUIRE(client.send(request("transport.play", {}, 2)));
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(20);
+    while (server.connectionCount() > 0 && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    REQUIRE(server.connectionCount() == 0);
+    REQUIRE(api.transport_.playCalls == 0);
+}

--- a/tests/test_remote_websocket_server.cpp
+++ b/tests/test_remote_websocket_server.cpp
@@ -16,6 +16,7 @@
 
 #include "MockMagdaApi.hpp"
 #include "magda/daw/api/remote_service.hpp"
+#include "magda/daw/api/remote_subscriptions.hpp"
 #include "magda/daw/api/remote_websocket_server.hpp"
 
 using namespace magda;
@@ -61,14 +62,30 @@ std::string request(const juce::String& method, const juce::var& params = {},
     return juce::JSON::toString(juce::var(object), true).toStdString();
 }
 
+/// Read one frame, whatever it is. A subscribed client receives replies and
+/// pushed events on the same socket, so a test that expects an event has to read
+/// frames rather than round-trip requests.
+juce::var readFrame(httplib::ws::WebSocketClient& client) {
+    std::string message;
+    REQUIRE(client.read(message) == httplib::ws::ReadResult::Text);
+    juce::var parsed;
+    REQUIRE(juce::JSON::parse(juce::String(message), parsed).wasOk());
+    return parsed;
+}
+
 /// Send one request, read one reply, parse it.
 juce::var roundTrip(httplib::ws::WebSocketClient& client, const std::string& payload) {
     REQUIRE(client.send(payload));
-    std::string reply;
-    REQUIRE(client.read(reply) == httplib::ws::ReadResult::Text);
-    juce::var parsed;
-    REQUIRE(juce::JSON::parse(juce::String(reply), parsed).wasOk());
-    return parsed;
+    return readFrame(client);
+}
+
+juce::var topicList(const std::vector<const char*>& topics) {
+    juce::Array<juce::var> array;
+    for (const auto* topic : topics)
+        array.add(juce::String(topic));
+    auto* params = new juce::DynamicObject();
+    params->setProperty("topics", array);
+    return params;
 }
 
 int errorCodeOf(const juce::var& reply) {
@@ -567,4 +584,204 @@ TEST_CASE("The connection cap holds when clients arrive together", "[remote][web
     // there would mean reserving for requests cpp-httplib may never hand to a
     // handler, and those reservations would never come back.
     REQUIRE(connected.load() >= peak);
+}
+
+// ===========================================================================
+// Subscriptions (#1857)
+// ===========================================================================
+
+TEST_CASE("A subscriber is pushed changes another client made",
+          "[remote][websocket][subscriptions]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    api.project_.info.tempo = 120.0;
+
+    RemoteApiService service(api);
+    SubscriptionHub hub(api, service);
+    RemoteWebSocketServer server(service, testOptions(), &hub);
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient watcher(endpoint(server), authorised());
+    REQUIRE(watcher.connect());
+
+    const auto subscribed =
+        roundTrip(watcher, request("subscriptions.subscribe", topicList({"project"})));
+    REQUIRE(subscribed["error"].isVoid());
+    // State arrives in the reply, so there is no window in which a client is
+    // subscribed and does not know what it is watching.
+    const auto* snapshots = subscribed["result"]["snapshots"].getArray();
+    REQUIRE(snapshots != nullptr);
+    REQUIRE(snapshots->size() == 1);
+    REQUIRE((*snapshots)[0]["type"].toString() == "snapshot");
+    REQUIRE(static_cast<double>((*snapshots)[0]["payload"]["tempo"]) == 120.0);
+
+    {
+        httplib::ws::WebSocketClient editor(endpoint(server), authorised());
+        REQUIRE(editor.connect());
+        auto* tempo = new juce::DynamicObject();
+        tempo->setProperty("tempo", 145.0);
+        const auto applied = roundTrip(editor, request("project.setTempo", juce::var(tempo), 7));
+        REQUIRE(applied["error"].isVoid());
+    }
+
+    // No MessageManager in the Catch2 runner means no flush timer, so the
+    // coalescing window is closed by hand. In the app this is the 30 Hz pump.
+    service.changes().flush();
+
+    const auto event = readFrame(watcher);
+    REQUIRE(event["jsonrpc"].toString() == "2.0");
+    REQUIRE(event["method"].toString() == "subscriptions.event");
+    // A notification: no id, because there is nothing for the client to answer.
+    REQUIRE(event["id"].isVoid());
+    REQUIRE(event["params"]["topic"].toString() == "project");
+    REQUIRE(event["params"]["type"].toString() == "delta");
+    REQUIRE(static_cast<juce::int64>(event["params"]["revision"]) > 0);
+    REQUIRE(static_cast<double>(event["params"]["payload"]["tempo"]) == 145.0);
+}
+
+TEST_CASE("A subscriber's own reply precedes the event it caused",
+          "[remote][websocket][subscriptions][ordering]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    SubscriptionHub hub(api, service);
+    RemoteWebSocketServer server(service, testOptions(), &hub);
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(endpoint(server), authorised());
+    REQUIRE(client.connect());
+    roundTrip(client, request("subscriptions.subscribe", topicList({"transport"})));
+
+    const auto reply = roundTrip(client, request("transport.play", {}, 2));
+    REQUIRE(static_cast<int>(reply["id"]) == 2);
+
+    service.changes().flush();
+
+    // Events share the reply queue precisely so this holds: a client applies the
+    // change it asked for before it is told the change happened, rather than
+    // having to reconcile the two arriving out of order.
+    const auto event = readFrame(client);
+    REQUIRE(event["method"].toString() == "subscriptions.event");
+    REQUIRE(event["params"]["topic"].toString() == "transport");
+    REQUIRE(static_cast<juce::int64>(event["params"]["revision"]) ==
+            static_cast<juce::int64>(reply["meta"]["revision"]));
+}
+
+TEST_CASE("A transport with no subscription support says so",
+          "[remote][websocket][subscriptions][errors]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    // Deliberately no hub — the configuration an embedder gets by leaving the
+    // argument off.
+    RemoteWebSocketServer server(service, testOptions());
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(endpoint(server), authorised());
+    REQUIRE(client.connect());
+
+    const auto refused =
+        roundTrip(client, request("subscriptions.subscribe", topicList({"tracks"})));
+    // A real operation over a transport that cannot carry it, so InvalidRequest
+    // rather than method-not-found: telling the client it asked for something
+    // that does not exist would send it looking for a spelling mistake.
+    REQUIRE(errorCodeOf(refused) == -32600);
+    REQUIRE(juce::String(refused["error"]["message"].toString()).contains("subscriptions"));
+}
+
+TEST_CASE("Subscription input is rejected by the shared schema",
+          "[remote][websocket][subscriptions][errors]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    SubscriptionHub hub(api, service);
+    RemoteWebSocketServer server(service, testOptions(), &hub);
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(endpoint(server), authorised());
+    REQUIRE(client.connect());
+
+    // The transport declares no schema of its own; this is the registry's, the
+    // same one system.describe publishes.
+    const auto unknown =
+        roundTrip(client, request("subscriptions.subscribe", topicList({"telemetry"})));
+    REQUIRE(errorCodeOf(unknown) == -32602);
+
+    const auto missing = roundTrip(client, request("subscriptions.subscribe", {}, 2));
+    REQUIRE(errorCodeOf(missing) == -32602);
+}
+
+TEST_CASE("A subscriber that disconnects stops costing the others",
+          "[remote][websocket][subscriptions][lifetime]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    SubscriptionHub hub(api, service);
+    RemoteWebSocketServer server(service, testOptions(), &hub);
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient survivor(endpoint(server), authorised());
+    REQUIRE(survivor.connect());
+    roundTrip(survivor, request("subscriptions.subscribe", topicList({"transport"})));
+
+    {
+        httplib::ws::WebSocketClient leaving(endpoint(server), authorised());
+        REQUIRE(leaving.connect());
+        roundTrip(leaving, request("subscriptions.subscribe", topicList({"transport"})));
+        REQUIRE(hub.clientCount() == 2);
+    }
+
+    // The connection's own thread deregisters it, within one read timeout of the
+    // socket closing.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(20);
+    while (hub.clientCount() > 1 && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    REQUIRE(hub.clientCount() == 1);
+
+    // And the one still there is unaffected.
+    roundTrip(survivor, request("transport.play", {}, 2));
+    service.changes().flush();
+    const auto event = readFrame(survivor);
+    REQUIRE(event["params"]["topic"].toString() == "transport");
+}
+
+TEST_CASE("A subscriber that cannot take events is dropped, not queued for",
+          "[remote][websocket][subscriptions][limits]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    SubscriptionHub::Options hubOptions;
+    hubOptions.droppedFlushesBeforeDisconnect = 2;
+    SubscriptionHub hub(api, service, hubOptions);
+
+    auto options = testOptions();
+    // No room for a single event. A budget of zero is the same code path as a
+    // client whose socket has stopped draining, without the timing.
+    options.maxQueuedEventsPerConnection = 0;
+    RemoteWebSocketServer server(service, options, &hub);
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(endpoint(server), authorised());
+    REQUIRE(client.connect());
+
+    // Replies draw on their own budget, so this still works. Sharing one cap
+    // would let a busy subscription starve the answer a client is waiting on.
+    const auto subscribed =
+        roundTrip(client, request("subscriptions.subscribe", topicList({"transport"})));
+    REQUIRE(subscribed["error"].isVoid());
+    REQUIRE(hub.clientCount() == 1);
+
+    for (int i = 0; i < 2; ++i) {
+        // Really change something: a topic that was marked but projects the same
+        // is coalesced away before anyone is asked to take it, which would leave
+        // nothing for the client to refuse.
+        api.transport_.playing = !api.transport_.playing;
+        service.noteModelChanged(Topic::Transport);
+        service.changes().flush();
+    }
+
+    // Nothing was buffered on its behalf and nothing was retried; it simply
+    // stopped being a subscriber.
+    REQUIRE(hub.clientCount() == 0);
 }


### PR DESCRIPTION
Closes #1857. Part of #701, on top of #1855 and #1856.

## Summary

Remote clients can now be pushed changes instead of polling for them, without mirroring every internal model notification or flooding the JUCE message queue.

A new `SubscriptionHub` sits between `ChangeSource` (#1855), which says *that* a topic changed, and the transports, which have to say *what* changed to each client that asked. It is shared rather than private to the WebSocket adapter because MCP resource updates (#1858) need the identical projection and the identical resync rules, and the second implementation would drift from the first.

## What a client receives

A transport-neutral envelope of topic, type, revision, and payload:

```json
{ "topic": "clips", "type": "delta", "revision": 57, "payload": { "added": [], "updated": [], "removed": [] } }
```

- **`snapshot`** — complete state for the topic, in the same shape as the topic's read operation (`tracks` is `tracks.list`, and so on). Delivered in the reply to `subscribe`/`resync`, so a client is never subscribed without knowing what it is watching, and pushed as an event when a client has fallen behind.
- **`delta`** — `{added, updated, removed}` for `tracks`, `clips`, `automation`, and `session`. `project`, `transport`, `selection`, and `devices` send their whole state, because there is nothing useful to diff — a `DeviceId` is unique only within a track section, so an id-keyed diff of `devices` would be wrong rather than merely unhelpful.
- **`sample`** — `meters` and `playhead`. Opt-in, never delta-encoded, latest value wins.

A topic that was marked but projects identically sends nothing at all, and each topic is projected once per flush however many clients are watching.

## Meters and the playhead

Nothing in the model marks either — the playhead moves without notifying anyone and meters are a continuous signal — so they are sampled on their own 20 Hz timer. The live meter source drains a dedicated `MeteringBuffer` on `AudioBridge`, a third ring alongside the recording one: peeking the mixer's ring goes stale as soon as it fills with no UI meter draining it, which is exactly the headless case a remote subscriber is in. The audio thread is untouched — metering is already published lock-free and drained on the message thread.

## Backpressure

Dropped, not buffered. A refused event marks the client, so the next thing it takes is a `snapshot` rather than a delta it has no baseline for; persistent refusal disconnects it. Events share the reply queue for ordering but hold a separate budget, so a busy subscription cannot starve the answer a client is waiting on, and a burst of replies cannot silently cost a subscriber its stream.

## The contract

`subscriptions.subscribe`, `.unsubscribe`, `.list`, and `.resync` are declared in the shared registry and marked `transportScoped`: names and schemas in one place, execution in the adapter, and `system.describe` stays a complete catalogue. Dispatching one through the service fails with `invalid_request` rather than `unknown_operation` — the operation is real, and only the route is wrong. Also adds `automation.listLanes`, which the `automation` topic needed as a snapshot source, and `minItems` support in the schema validator.

## Two things the design had to get right

Projection reads live model state, so `handle()` validates on the calling thread and hops to the message thread for the rest, answering through a callback the way `dispatch` does.

Both timers are reconciled only on the message thread, and never from inside a timer callback: JUCE invokes a timer callback with its own lock released, so stopping one from elsewhere can free a timer whose callback is on the stack.

## Testing

- `test_remote_subscriptions.cpp` — load, ordering, resync, coalescing, and the slow-client policy against a mock, with `flush()` and `sampleNow()` driven by hand so nothing is timing-dependent.
- `test_remote_websocket_server.cpp` — subscribe, push, ordering, and the per-connection event budget end to end over a real socket.
- `test_remote_websocket_live_juce.cpp` — with the message-thread assertion enabled: the real 30 Hz flush timer, the sampling timer, and the hop itself.

Full Catch2 suite passes (2116 cases, 34 new); full JUCE suite passes; `make debug` builds clean. `clang-tidy` was not available locally, so `make lint-changed` did not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)