### PR TITLE
Native engine: what a track's clips sum to (#2035)

### DIFF
--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -10,10 +10,20 @@ add_library(magda_engine STATIC
     clip/ClipSnapshot.cpp
     clip/ClipSnapshotCompiler.cpp
     clip/ClipSnapshotDump.cpp
+    clip/ClipAudioSource.cpp
+    clip/ClipStreamFeed.cpp
+    clip/ClipVoice.cpp
+    clip/ClipVoicePool.cpp
+    clip/FadeCurves.cpp
     clip/ClipSnapshot.hpp
     clip/ClipSnapshotCompiler.hpp
     clip/ClipSnapshotDump.hpp
     clip/ClipSnapshotFeed.hpp
+    clip/ClipAudioSource.hpp
+    clip/ClipStreamFeed.hpp
+    clip/ClipVoice.hpp
+    clip/ClipVoicePool.hpp
+    clip/FadeCurves.hpp
     plan/RenderPlan.cpp
     plan/PlanCompiler.cpp
     plan/PlanDiff.cpp

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -101,10 +101,12 @@ void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float
                 });
 
             if (found == lastStream || soundingCount == kMaxVoicesPerTrack) {
-                // No reader standing by, or no room left for one. One number
-                // bounds both (kMaxVoicesPerTrack), so the second of these is
-                // only reachable through a table this source did not get from
-                // the pool; either way the clip does not sound and the count is
+                // No reader standing by, or no voice left to play it through.
+                // Both happen and they are different failures: a track may hold
+                // more readers than a callback has voices (kMaxReadersPerTrack
+                // is the larger, because a reader has to exist before its clip
+                // is due), so a block can be handed more entries than it can
+                // render. Either way the clip does not sound and the count is
                 // what says so.
                 starved_.fetch_add(1, std::memory_order_relaxed);
                 continue;

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -80,6 +80,14 @@ void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float
     auto soundingCount = 0;
 
     for (const auto& clip : track->audio) {
+        // Sorted by where they start (ClipSnapshot.hpp), so once one begins at
+        // or after the end of this block, so does everything behind it. Without
+        // the break a track pays for its whole tail on every callback, all
+        // session, and the cost grows with the length of the arrangement rather
+        // than with what is playing.
+        if (clip.span.startSeconds >= block.endSeconds)
+            break;
+
         if (!reachesInto(clip.span, block))
             continue;
 

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -101,8 +101,11 @@ void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float
                 });
 
             if (found == lastStream || soundingCount == kMaxVoicesPerTrack) {
-                // No reader standing by, or no room left for one. Either way
-                // this clip does not sound and the count is what says so.
+                // No reader standing by, or no room left for one. One number
+                // bounds both (kMaxVoicesPerTrack), so the second of these is
+                // only reachable through a table this source did not get from
+                // the pool; either way the clip does not sound and the count is
+                // what says so.
                 starved_.fetch_add(1, std::memory_order_relaxed);
                 continue;
             }

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -1,0 +1,139 @@
+#include "clip/ClipAudioSource.hpp"
+
+#include <algorithm>
+
+namespace magda::engine {
+
+namespace {
+
+/// Whether a span reaches into the block at all. Half-open at both ends, so a
+/// clip ending exactly on a block boundary contributes nothing to the block
+/// that starts there.
+bool reachesInto(const SnapshotSpan& span, const BlockInfo& block) {
+    return span.startSeconds < block.endSeconds && span.endSeconds > block.startSeconds;
+}
+
+}  // namespace
+
+ClipAudioSource::ClipAudioSource(TrackId trackId, ClipSnapshotFeed& clips, ClipStreamFeed& streams)
+    : trackId_(trackId), clips_(clips), streams_(streams) {}
+
+void ClipAudioSource::prepare(const RenderContext& context) {
+    scratch_.setSize(context.numChannels, context.maxBlockSize, false, true, false);
+    scratch_.clear();
+
+    for (auto& voice : voices_)
+        voice.prepare(context);
+}
+
+ClipVoice* ClipAudioSource::voiceFor(ClipId clipId, EventId eventId) {
+    for (auto& voice : voices_)
+        if (voice.playing(clipId, eventId))
+            return &voice;
+
+    for (auto& voice : voices_)
+        if (voice.clipId() == INVALID_CLIP_ID)
+            return &voice;
+
+    return nullptr;
+}
+
+void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) {
+    out.clear();
+
+    const ClipStreamFeed::Reader streams(streams_);
+    const auto [firstStream, lastStream] =
+        streams ? streams->rangeFor(trackId_)
+                : std::pair<const ClipStreamTable::Entry*, const ClipStreamTable::Entry*>{nullptr,
+                                                                                          nullptr};
+
+    // Every stream this track has, sounding or not, once per block. The stream
+    // a cue is most useful to is one nobody is reading from: a clip that has
+    // not started would otherwise not hear about the position it was pointed at
+    // until the material was already due (#2016).
+    for (const auto* entry = firstStream; entry != lastStream; ++entry)
+        entry->stream->applyPendingCue();
+
+    const auto numSamples = std::min(block.numSamples, static_cast<int>(out.getNumSamples()));
+
+    const auto silence = [this] {
+        for (auto& voice : voices_)
+            voice.release();
+    };
+
+    if (!block.playing || numSamples <= 0)
+        return silence();
+
+    const ClipSnapshotFeed::Reader snapshot(clips_);
+    if (!snapshot)
+        return silence();
+
+    const auto* track = snapshot->find(trackId_);
+    if (track == nullptr)
+        return silence();
+
+    // What sounds, and through what. Gathered before anything is rendered so
+    // the voices that are not in it can be let go first: a voice still holding
+    // a clip that stopped last block would otherwise keep a slot a clip
+    // starting this one needs.
+    std::array<Sounding, kMaxVoicesPerTrack> sounding;
+    auto soundingCount = 0;
+
+    for (const auto& clip : track->audio) {
+        if (!reachesInto(clip.span, block))
+            continue;
+
+        for (const auto& event : clip.events) {
+            if (!reachesInto(event.span, block))
+                continue;
+
+            const auto* found =
+                std::find_if(firstStream, lastStream, [&](const ClipStreamTable::Entry& entry) {
+                    return entry.clipId == clip.clipId && entry.eventId == event.eventId;
+                });
+
+            if (found == lastStream || soundingCount == kMaxVoicesPerTrack) {
+                // No reader standing by, or no room left for one. Either way
+                // this clip does not sound and the count is what says so.
+                starved_.fetch_add(1, std::memory_order_relaxed);
+                continue;
+            }
+
+            sounding[static_cast<std::size_t>(soundingCount++)] =
+                Sounding{&clip, &event, found->stream.get()};
+        }
+    }
+
+    for (auto& voice : voices_) {
+        if (voice.clipId() == INVALID_CLIP_ID)
+            continue;
+
+        const auto stillSounding =
+            std::any_of(sounding.begin(), sounding.begin() + soundingCount, [&](const Sounding& s) {
+                return voice.playing(s.clip->clipId, s.event->eventId);
+            });
+
+        if (!stillSounding)
+            voice.release();
+    }
+
+    auto scratch =
+        juce::dsp::AudioBlock<float>(scratch_).getSubBlock(0, static_cast<std::size_t>(numSamples));
+
+    for (auto index = 0; index < soundingCount; ++index) {
+        const auto& entry = sounding[static_cast<std::size_t>(index)];
+
+        auto* voice = voiceFor(entry.clip->clipId, entry.event->eventId);
+        if (voice == nullptr) {
+            // Unreachable while the gather above is capped at the voice count,
+            // and counted rather than asserted because the two numbers being
+            // the same is a property of this file rather than of the type.
+            starved_.fetch_add(1, std::memory_order_relaxed);
+            continue;
+        }
+
+        voice->render(*entry.clip, *entry.event, block, *entry.stream, scratch, out);
+    }
+}
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipAudioSource.hpp
+++ b/magda/engine/clip/ClipAudioSource.hpp
@@ -26,10 +26,14 @@
  * compiled, and a crossfade reaching here is two voices each playing the fade
  * it was handed.
  *
- * How many clips a track may sound at once is decided rather than discovered.
- * kMaxVoicesPerTrack streams are provisioned per track (ClipVoicePool.hpp), and
- * a track wanting more says so through @ref starvedVoices, because silence
- * nobody counted is indistinguishable from a gap in the material.
+ * How many clips a track may sound at once is decided rather than discovered:
+ * kMaxVoicesPerTrack, below. That is not how many readers a track may have,
+ * which is larger and is ClipVoicePool.hpp's (kMaxReadersPerTrack), because a
+ * reader has to exist before its clip is due while a voice is only needed while
+ * it plays. So a block can be handed more entries than it can render, and a
+ * track wanting more than either says so through @ref
+ * ClipAudioSource::starvedVoices, because silence nobody counted is
+ * indistinguishable from a gap in the material.
  */
 
 namespace magda::engine {

--- a/magda/engine/clip/ClipAudioSource.hpp
+++ b/magda/engine/clip/ClipAudioSource.hpp
@@ -35,25 +35,33 @@
 namespace magda::engine {
 
 /**
- * @brief Clips one track may sound at the same instant.
+ * @brief Clips one track may have live at once.
  *
- * Eight rather than two. A crossfade is two, a clip dropped inside another is
- * two, and a clip made of several events is one voice per event (#1901), so the
- * shapes a lane can legitimately be in add up past the obvious pair. What eight
- * is not is a guess at how many a user might stack: past it the track reports
- * rather than quietly dropping the extras.
+ * One number for both halves of the layer, because a voice cannot sound without
+ * a reader and a reader nothing sounds through is waste. Two ceilings would be
+ * two answers to the same question, and they would disagree: whichever was
+ * lower would be doing the work while the other was reported.
  *
- * Simultaneity, not throughput. A voice costs a few bytes of state, so this is
- * not the number that bounds memory; how many readers a track may have standing
- * by is kMaxReadersPerTrack, and clips that follow one another consume that
- * without ever needing two voices at once.
+ * Live, not overlapping. Everything a callback touches is live for that
+ * callback, whether or not the clips overlap by a sample: they are rendered in
+ * the same call, so each holds its own voice for it. At the default block that
+ * makes back to back clips shorter than about twelve milliseconds count against
+ * this, and a host running a large block stretches that to tens of
+ * milliseconds, which is inside what chopped material actually does. The pool
+ * measures against the same block for that reason, so what it reports and what
+ * the callback enforces are the same thing.
  *
- * At this resolution "sounding in the same block" and "sounding at the same
- * instant" are the same question. Two entries that share a block each hold a
- * voice for it whether or not their samples overlap, which stops mattering
- * somewhere below the ten clips a millisecond it would take to notice.
+ * Sixteen. A crossfade is two, a clip dropped inside another is two, and a clip
+ * made of several events is one voice per event (#1901), so the shapes a lane
+ * can legitimately be in add up well past the obvious pair, and a lane of
+ * slices adds up faster still. It is also what bounds memory, since each of
+ * these is an open file and a chunk pool: four megabytes for a track with clips
+ * near the cursor, and nothing at all for one without.
+ *
+ * Past it the track reports rather than quietly dropping the extras, through
+ * @ref ClipAudioSource::starvedVoices and ClipVoicePool::overSubscribed.
  */
-constexpr int kMaxVoicesPerTrack = 8;
+constexpr int kMaxVoicesPerTrack = 16;
 
 class ClipAudioSource final : public EngineAudioSource {
   public:

--- a/magda/engine/clip/ClipAudioSource.hpp
+++ b/magda/engine/clip/ClipAudioSource.hpp
@@ -37,15 +37,21 @@ namespace magda::engine {
 /**
  * @brief Clips one track may sound at the same instant.
  *
- * A ceiling on simultaneous voices, and therefore on open files and prefetch
- * pools: eight streams is two megabytes of read-ahead per track at the default
- * settings, and only for tracks with clips near the cursor.
- *
  * Eight rather than two. A crossfade is two, a clip dropped inside another is
  * two, and a clip made of several events is one voice per event (#1901), so the
  * shapes a lane can legitimately be in add up past the obvious pair. What eight
  * is not is a guess at how many a user might stack: past it the track reports
  * rather than quietly dropping the extras.
+ *
+ * Simultaneity, not throughput. A voice costs a few bytes of state, so this is
+ * not the number that bounds memory; how many readers a track may have standing
+ * by is kMaxReadersPerTrack, and clips that follow one another consume that
+ * without ever needing two voices at once.
+ *
+ * At this resolution "sounding in the same block" and "sounding at the same
+ * instant" are the same question. Two entries that share a block each hold a
+ * voice for it whether or not their samples overlap, which stops mattering
+ * somewhere below the ten clips a millisecond it would take to notice.
  */
 constexpr int kMaxVoicesPerTrack = 8;
 

--- a/magda/engine/clip/ClipAudioSource.hpp
+++ b/magda/engine/clip/ClipAudioSource.hpp
@@ -35,28 +35,26 @@
 namespace magda::engine {
 
 /**
- * @brief Clips one track may have live at once.
+ * @brief Clips one track may sound in a single callback.
  *
- * One number for both halves of the layer, because a voice cannot sound without
- * a reader and a reader nothing sounds through is waste. Two ceilings would be
- * two answers to the same question, and they would disagree: whichever was
- * lower would be doing the work while the other was reported.
+ * Capacity, and only capacity. How many readers a track may have standing by is
+ * kMaxReadersPerTrack, which is larger and answers a different question: this
+ * one is what a callback can render at once, that one is how far ahead of the
+ * transport the material has to be open. Collapsing the two starves clips that
+ * fit here perfectly well and simply have no reader yet.
  *
  * Live, not overlapping. Everything a callback touches is live for that
  * callback, whether or not the clips overlap by a sample: they are rendered in
  * the same call, so each holds its own voice for it. At the default block that
- * makes back to back clips shorter than about twelve milliseconds count against
- * this, and a host running a large block stretches that to tens of
- * milliseconds, which is inside what chopped material actually does. The pool
- * measures against the same block for that reason, so what it reports and what
- * the callback enforces are the same thing.
+ * makes back to back clips shorter than about a millisecond and a half count
+ * against this, and a host running a large block stretches that to tens of
+ * milliseconds. The pool measures against the same block for that reason, so
+ * what it reports and what the callback enforces are the same thing.
  *
  * Sixteen. A crossfade is two, a clip dropped inside another is two, and a clip
  * made of several events is one voice per event (#1901), so the shapes a lane
  * can legitimately be in add up well past the obvious pair, and a lane of
- * slices adds up faster still. It is also what bounds memory, since each of
- * these is an open file and a chunk pool: four megabytes for a track with clips
- * near the cursor, and nothing at all for one without.
+ * slices adds up faster still.
  *
  * Past it the track reports rather than quietly dropping the extras, through
  * @ref ClipAudioSource::starvedVoices and ClipVoicePool::overSubscribed.

--- a/magda/engine/clip/ClipAudioSource.hpp
+++ b/magda/engine/clip/ClipAudioSource.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
+
+#include <array>
+#include <atomic>
+
+#include "clip/ClipSnapshotFeed.hpp"
+#include "clip/ClipStreamFeed.hpp"
+#include "clip/ClipVoice.hpp"
+#include "core/TypeIds.hpp"
+#include "exec/EngineDevice.hpp"
+
+/**
+ * @file ClipAudioSource.hpp
+ * @brief What a track's audio clips sum to, block by block.
+ *
+ * The source behind a ClipAudio op. The plan names a track and nothing else
+ * (RenderPlan.hpp); what that track plays is read here, from the clip snapshot,
+ * which is why moving a clip never recompiles a plan.
+ *
+ * It decides nothing about overlaps. The snapshot has already resolved which
+ * clips are audible where and what fades they play (#2003), so entries that
+ * overlap simply sum: the lane's rules were applied when the snapshot was
+ * compiled, and a crossfade reaching here is two voices each playing the fade
+ * it was handed.
+ *
+ * How many clips a track may sound at once is decided rather than discovered.
+ * kMaxVoicesPerTrack streams are provisioned per track (ClipVoicePool.hpp), and
+ * a track wanting more says so through @ref starvedVoices, because silence
+ * nobody counted is indistinguishable from a gap in the material.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief Clips one track may sound at the same instant.
+ *
+ * A ceiling on simultaneous voices, and therefore on open files and prefetch
+ * pools: eight streams is two megabytes of read-ahead per track at the default
+ * settings, and only for tracks with clips near the cursor.
+ *
+ * Eight rather than two. A crossfade is two, a clip dropped inside another is
+ * two, and a clip made of several events is one voice per event (#1901), so the
+ * shapes a lane can legitimately be in add up past the obvious pair. What eight
+ * is not is a guess at how many a user might stack: past it the track reports
+ * rather than quietly dropping the extras.
+ */
+constexpr int kMaxVoicesPerTrack = 8;
+
+class ClipAudioSource final : public EngineAudioSource {
+  public:
+    /**
+     * @brief The clip source for @p trackId.
+     *
+     * Both feeds outlive it and are shared with every other track: what a track
+     * plays and which readers are standing by are properties of the session,
+     * not of any one source or any one plan.
+     */
+    ClipAudioSource(TrackId trackId, ClipSnapshotFeed& clips, ClipStreamFeed& streams);
+
+    void prepare(const RenderContext& context) override;
+
+    /**
+     * @brief Sum this track's clips into @p out.
+     *
+     * On the audio thread. The buffer arrives uncleared and leaves filled
+     * whatever happens: a track with no snapshot, no streams or no clips
+     * renders silence rather than whatever the buffer held.
+     */
+    void render(const BlockInfo& block, juce::dsp::AudioBlock<float> out) override;
+
+    /**
+     * @brief Clips that should have sounded and had no reader to sound through.
+     *
+     * Counted per clip per block, the way PrefetchStream counts an underrun and
+     * for the same reason: a track asking for more simultaneous clips than it
+     * was given streams for is silence that has to be visible. A rising count
+     * means either the ceiling above is too low for the material or the
+     * provisioning thread is not keeping up with the transport.
+     */
+    int starvedVoices() const {
+        return starved_.load(std::memory_order_relaxed);
+    }
+
+  private:
+    /// One entry that sounds in this block, and the reader it sounds through.
+    struct Sounding {
+        const AudioClipPlayback* clip = nullptr;
+        const AudioEventPlayback* event = nullptr;
+        PrefetchStream* stream = nullptr;
+    };
+
+    /// The voice already playing this entry, or a free one, or null when every
+    /// voice is busy.
+    ClipVoice* voiceFor(ClipId clipId, EventId eventId);
+
+    TrackId trackId_;
+    ClipSnapshotFeed& clips_;
+    ClipStreamFeed& streams_;
+
+    std::array<ClipVoice, kMaxVoicesPerTrack> voices_;
+
+    /// Working space one voice at a time renders into before being summed in.
+    /// One is enough: voices are rendered one after another, and sized for the
+    /// largest block the plan was prepared for.
+    juce::AudioBuffer<float> scratch_;
+
+    std::atomic<int> starved_{0};
+};
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipStreamFeed.cpp
+++ b/magda/engine/clip/ClipStreamFeed.cpp
@@ -1,0 +1,20 @@
+#include "clip/ClipStreamFeed.hpp"
+
+#include <algorithm>
+
+namespace magda::engine {
+
+std::pair<const ClipStreamTable::Entry*, const ClipStreamTable::Entry*> ClipStreamTable::rangeFor(
+    TrackId trackId) const {
+    const auto byTrack = [](const Entry& entry, TrackId id) { return entry.trackId < id; };
+    const auto trackFirst = [](TrackId id, const Entry& entry) { return id < entry.trackId; };
+
+    const auto* begin = entries.data();
+    const auto* end = begin + entries.size();
+
+    const auto* from = std::lower_bound(begin, end, trackId, byTrack);
+    const auto* to = std::upper_bound(from, end, trackId, trackFirst);
+    return {from, to};
+}
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipStreamFeed.hpp
+++ b/magda/engine/clip/ClipStreamFeed.hpp
@@ -36,7 +36,8 @@ namespace magda::engine {
  *
  * Sorted by track, then clip, then event, so the audio thread can find a
  * track's range without hashing and walk it without searching. A track's range
- * is at most kMaxVoicesPerTrack long, which is what makes the walk free.
+ * is bounded by what the pool may provision for one track, which is what makes
+ * the walk free.
  */
 struct ClipStreamTable {
     struct Entry {

--- a/magda/engine/clip/ClipStreamFeed.hpp
+++ b/magda/engine/clip/ClipStreamFeed.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <farbot/RealtimeObject.hpp>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "core/ClipTypes.hpp"
+#include "core/TypeIds.hpp"
+#include "io/PrefetchStream.hpp"
+
+/**
+ * @file ClipStreamFeed.hpp
+ * @brief Which reader is standing by for which clip, and where a voice finds it.
+ *
+ * A voice needs a prefetch stream, and a stream is a file that has been opened
+ * and a pool that has been filled: neither is something an audio callback may
+ * do. So the streams are provisioned ahead of the transport by
+ * ClipVoicePool.hpp, off the audio thread, and what reaches the callback is
+ * this table: entries already pointed at the material they are for.
+ *
+ * It travels the way a plan and a clip snapshot do. Immutable once published,
+ * replaced whole, and the one it replaces is destroyed on the publishing
+ * thread, which is what keeps the audio thread from ever closing a file. A
+ * stream reachable only from a retired table dies with it, so the swap is also
+ * how a stream is retired.
+ *
+ * Keyed by the entry, not by the file. Two clips over one file are two
+ * positions, and a reader can only be in one place at a time (#2016).
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief The streams provisioned for every track, at one moment.
+ *
+ * Sorted by track, then clip, then event, so the audio thread can find a
+ * track's range without hashing and walk it without searching. A track's range
+ * is at most kMaxVoicesPerTrack long, which is what makes the walk free.
+ */
+struct ClipStreamTable {
+    struct Entry {
+        TrackId trackId = INVALID_TRACK_ID;
+        ClipId clipId = INVALID_CLIP_ID;
+        EventId eventId = INVALID_EVENT_ID;
+
+        /// Shared so the table is what keeps the stream alive: whichever of the
+        /// pool and the last table holding one lets go last is what closes the
+        /// file, and neither of them is the audio thread.
+        std::shared_ptr<PrefetchStream> stream;
+    };
+
+    std::vector<Entry> entries;
+
+    /// The half-open range of entries belonging to @p trackId. Empty when the
+    /// track has none, which is a track with nothing provisioned rather than an
+    /// error. On the audio thread: a binary search over a sorted vector.
+    std::pair<const Entry*, const Entry*> rangeFor(TrackId trackId) const;
+};
+
+class ClipStreamFeed {
+    using Published = farbot::RealtimeObject<std::shared_ptr<const ClipStreamTable>,
+                                             farbot::RealtimeObjectOptions::nonRealtimeMutatable>;
+
+  public:
+    /**
+     * @brief Make @p table the one the audio thread reads.
+     *
+     * On the provisioning thread, and it waits for the block the callback is
+     * in, the way every other publish here does. What comes back is the table
+     * it replaced, destroyed on this thread; a stream nothing else holds goes
+     * with it, which is why a caller retiring one drops its own handle first.
+     */
+    void publish(std::shared_ptr<const ClipStreamTable> table) {
+        published_.nonRealtimeReplace(std::move(table));
+    }
+
+    /// What is live, for as long as this exists. On the audio thread. Null
+    /// until something has been published, which is a track whose clips have
+    /// no readers yet rather than an error.
+    class Reader {
+      public:
+        explicit Reader(ClipStreamFeed& feed) : access_(feed.published_) {}
+
+        const ClipStreamTable* get() const noexcept {
+            return (*access_).get();
+        }
+        const ClipStreamTable* operator->() const noexcept {
+            return get();
+        }
+        explicit operator bool() const noexcept {
+            return get() != nullptr;
+        }
+
+      private:
+        Published::ScopedAccess<farbot::ThreadType::realtime> access_;
+    };
+
+  private:
+    Published published_;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipVoice.cpp
+++ b/magda/engine/clip/ClipVoice.cpp
@@ -118,6 +118,11 @@ bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& 
     // for the single event a clip has today they are the same fade before and
     // after resolution, so applying both would fade the edge twice. Interior
     // event fades arrive with the clips that have interior events (#1901).
+    //
+    // Both behaviours play as gain fades here, the speed ramp included, and
+    // that is a decision rather than an oversight: a ramp is a stretch, there
+    // is no stretcher until #2037, and the alternative to fading it is not
+    // fading the edge at all.
     applyFade(region, first, block, clip.span.startSeconds,
               clip.span.startSeconds + clip.fadeInSeconds, clip.fadeInCurve, true);
     applyFade(region, first, block, clip.span.endSeconds - clip.fadeOutSeconds,
@@ -145,10 +150,11 @@ bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& 
 
     out.getSubBlock(static_cast<std::size_t>(first), static_cast<std::size_t>(count)).add(region);
 
-    // Silence the reader could not fill is not sounding. Saying otherwise would
-    // let the block that resumes start mid-material with nothing to take the
-    // step out of it.
-    sounded_ = delivered > 0;
+    // Silence the reader could not fill is not sounding, and a block it only
+    // half filled ends in that silence as surely as one it missed entirely.
+    // Either way the block that resumes starts mid-material, and saying this
+    // voice carried on would leave it with nothing to take the step out of it.
+    sounded_ = delivered == count;
     return true;
 }
 

--- a/magda/engine/clip/ClipVoice.cpp
+++ b/magda/engine/clip/ClipVoice.cpp
@@ -1,0 +1,155 @@
+#include "clip/ClipVoice.hpp"
+
+#include <algorithm>
+
+#include "clip/FadeCurves.hpp"
+#include "io/ClipPlacement.hpp"
+
+namespace magda::engine {
+
+void ClipVoice::prepare(const RenderContext& context) {
+    sampleRate_ = context.sampleRate;
+    release();
+}
+
+void ClipVoice::release() {
+    clipId_ = INVALID_CLIP_ID;
+    eventId_ = INVALID_EVENT_ID;
+    sounded_ = false;
+}
+
+void ClipVoice::applyFade(juce::dsp::AudioBlock<float> region, int regionFirstSample,
+                          const BlockInfo& block, double startSeconds, double endSeconds,
+                          FadeCurve curve, bool rising) const {
+    const auto length = endSeconds - startSeconds;
+    if (!(length > 0.0) || block.numSamples <= 0)
+        return;
+
+    const auto blockSeconds = block.endSeconds - block.startSeconds;
+    if (!(blockSeconds > 0.0))
+        return;
+
+    // The samples of the block the fade covers, narrowed to the ones this
+    // region holds. sampleForTime clamps to the block, so a fade that began
+    // before it or runs past it contributes the part that is here.
+    const auto count = static_cast<int>(region.getNumSamples());
+    const auto from = std::max(regionFirstSample, block.sampleForTime(startSeconds));
+    const auto to = std::min(regionFirstSample + count, block.sampleForTime(endSeconds));
+    if (to <= from)
+        return;
+
+    const auto secondsPerSample = blockSeconds / block.numSamples;
+    const auto channels = region.getNumChannels();
+
+    for (auto sample = from; sample < to; ++sample) {
+        const auto seconds = block.startSeconds + sample * secondsPerSample;
+        const auto progress = static_cast<float>((seconds - startSeconds) / length);
+        const auto gain = fadeGain(curve, rising ? progress : 1.0f - progress);
+
+        const auto index = static_cast<std::size_t>(sample - regionFirstSample);
+        for (std::size_t channel = 0; channel < channels; ++channel)
+            region.getChannelPointer(channel)[index] *= gain;
+    }
+}
+
+bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& event,
+                       const BlockInfo& block, PrefetchStream& stream,
+                       juce::dsp::AudioBlock<float> scratch, juce::dsp::AudioBlock<float> out) {
+    // A voice handed a different entry is a new voice: whatever it played
+    // before has nothing to do with where this one begins.
+    if (!playing(clip.clipId, event.eventId)) {
+        clipId_ = clip.clipId;
+        eventId_ = event.eventId;
+        sounded_ = false;
+    }
+
+    const auto nothing = [this] {
+        sounded_ = false;
+        return false;
+    };
+
+    if (!block.playing || block.numSamples <= 0)
+        return nothing();
+
+    // What of this block the voice is heard over: the span the lane leaves
+    // audible, narrowed to the event's own stretch of it. The silences inside
+    // are not part of this, because they mute material that goes on running.
+    const auto windowStart =
+        std::max({block.startSeconds, clip.span.startSeconds, event.span.startSeconds});
+    const auto windowEnd =
+        std::min({block.endSeconds, clip.span.endSeconds, event.span.endSeconds});
+    if (windowEnd <= windowStart)
+        return nothing();
+
+    const auto first = block.sampleForTime(windowStart);
+    const auto count = block.sampleForTime(windowEnd) - first;
+    if (count <= 0)
+        return nothing();
+
+    auto region = scratch.getSubBlock(0, static_cast<std::size_t>(count));
+
+    // Derived from where the timeline is, never from where the last block left
+    // off, so a locate and a loop wrap need nothing said about them: the stream
+    // sees a position it was not expecting and seeks (#2016).
+    const ClipPlacement placement{event.span.startSeconds, event.span.endSeconds,
+                                  event.anchorSamples};
+    const auto delivered =
+        stream.read(sourceSampleAt(placement, windowStart, sampleRate_), region, count);
+
+    // The holes, cleared out of what was read rather than skipped over.
+    for (const auto& hole : clip.silenced) {
+        const auto holeStart = std::max(hole.startSeconds, windowStart);
+        const auto holeEnd = std::min(hole.endSeconds, windowEnd);
+        if (holeEnd <= holeStart)
+            continue;
+
+        const auto from = std::clamp(block.sampleForTime(holeStart) - first, 0, count);
+        const auto to = std::clamp(block.sampleForTime(holeEnd) - first, 0, count);
+        if (to > from)
+            region.getSubBlock(static_cast<std::size_t>(from), static_cast<std::size_t>(to - from))
+                .clear();
+    }
+
+    // The span's edges, not the placement's. What the lane leaves audible is
+    // what a listener hears begin and end, and the fades the snapshot resolved
+    // are the ones that shape it.
+    //
+    // The clip's pair only. An event carries its own (AudioEventPlayback), and
+    // for the single event a clip has today they are the same fade before and
+    // after resolution, so applying both would fade the edge twice. Interior
+    // event fades arrive with the clips that have interior events (#1901).
+    applyFade(region, first, block, clip.span.startSeconds,
+              clip.span.startSeconds + clip.fadeInSeconds, clip.fadeInCurve, true);
+    applyFade(region, first, block, clip.span.endSeconds - clip.fadeOutSeconds,
+              clip.span.endSeconds, clip.fadeOutCurve, false);
+
+    // Volume and gain summed, panned the way the incumbent pans a clip: linear,
+    // and hotter on one side rather than quieter on the other. Not a law with a
+    // centre correction, because a bounce has to match what was heard.
+    const auto gain = juce::Decibels::decibelsToGain(clip.gainDb);
+    const auto channels = region.getNumChannels();
+
+    if (channels == 2) {
+        const auto panned = clip.pan * gain;
+        region.getSingleChannelBlock(0).multiplyBy(gain - panned);
+        region.getSingleChannelBlock(1).multiplyBy(gain + panned);
+    } else {
+        region.multiplyBy(gain);
+    }
+
+    // Beginning rather than carrying on: the first block of a voice, the first
+    // after the timeline jumped, and the first after the reader came back from
+    // an underrun. All three start the material wherever it happens to be.
+    if (!sounded_ || !block.continuous)
+        applyStartDeClick(region, clip.launchFadeSamples);
+
+    out.getSubBlock(static_cast<std::size_t>(first), static_cast<std::size_t>(count)).add(region);
+
+    // Silence the reader could not fill is not sounding. Saying otherwise would
+    // let the block that resumes start mid-material with nothing to take the
+    // step out of it.
+    sounded_ = delivered > 0;
+    return true;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipVoice.hpp
+++ b/magda/engine/clip/ClipVoice.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
+
+#include "clip/ClipSnapshot.hpp"
+#include "exec/RenderContext.hpp"
+#include "io/PrefetchStream.hpp"
+
+/**
+ * @file ClipVoice.hpp
+ * @brief One entry of the snapshot, playing.
+ *
+ * A voice is one audio event of one clip, read through one prefetch stream. It
+ * holds no decision about what should sound: the snapshot has already resolved
+ * occlusion, crossfades and takes, so a voice plays a span with fades and never
+ * looks at its neighbours (#2003). Two clips crossfading are two voices each
+ * playing the fade it was handed, and nothing pairs them up.
+ *
+ * The span crops what it reads, the interior silences punch holes in what it
+ * read, and the fades shape the edges of the span rather than the edges of the
+ * clip's placement: the span is what the lane leaves audible, and that is what
+ * a listener hears begin and end.
+ *
+ * Reading through a hole rather than around it is deliberate. A silence mutes
+ * material that is still running underneath, so the stream is read straight
+ * across and the hole is cleared afterwards; skipping the read would leave the
+ * reader somewhere it was not pointed, which is a seek and costs a block of
+ * silence on the far side (#2016).
+ *
+ * Not here: rate conversion, looping and reverse (#2036), stretch and pitch
+ * (#2037), warp (#2038). A voice reads one file sample per output sample.
+ */
+
+namespace magda::engine {
+
+class ClipVoice {
+  public:
+    void prepare(const RenderContext& context);
+
+    /// The entry this voice is playing. Invalid ids when it is playing nothing.
+    ClipId clipId() const {
+        return clipId_;
+    }
+    EventId eventId() const {
+        return eventId_;
+    }
+    bool playing(ClipId clip, EventId event) const {
+        return clipId_ == clip && eventId_ == event;
+    }
+
+    /**
+     * @brief Stop playing whatever it was playing.
+     *
+     * What makes the next entry to claim this voice start rather than continue,
+     * which is what the launch ramp is applied on.
+     */
+    void release();
+
+    /**
+     * @brief Add this block's contribution to @p out.
+     *
+     * On the audio thread. @p scratch is working space of at least the block's
+     * length, owned by the caller because one is enough for every voice on a
+     * track: they are rendered one after another and summed as they go.
+     *
+     * Returns false when nothing was added, which is the ordinary answer for a
+     * voice whose entry does not reach into this block.
+     */
+    bool render(const AudioClipPlayback& clip, const AudioEventPlayback& event,
+                const BlockInfo& block, PrefetchStream& stream,
+                juce::dsp::AudioBlock<float> scratch, juce::dsp::AudioBlock<float> out);
+
+  private:
+    /// Multiply the part of @p region inside [@p startSeconds, @p endSeconds)
+    /// by a curve running across it, rising or falling.
+    void applyFade(juce::dsp::AudioBlock<float> region, int regionFirstSample,
+                   const BlockInfo& block, double startSeconds, double endSeconds, FadeCurve curve,
+                   bool rising) const;
+
+    double sampleRate_ = 44100.0;
+
+    ClipId clipId_ = INVALID_CLIP_ID;
+    EventId eventId_ = INVALID_EVENT_ID;
+
+    /// Whether this voice put anything out in the previous block. What tells a
+    /// voice that is beginning from one that is carrying on, which is the
+    /// difference the launch ramp is for.
+    bool sounded_ = false;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipVoicePool.cpp
+++ b/magda/engine/clip/ClipVoicePool.cpp
@@ -153,6 +153,7 @@ void ClipVoicePool::service() {
     const auto blockSeconds = context_.maxBlockSize / context_.sampleRate;
 
     auto overSubscribed = 0;
+    auto unbridged = 0;
     auto unreadable = 0;
 
     Streams wanted;
@@ -203,8 +204,18 @@ void ClipVoicePool::service() {
                               return a.eventId < b.eventId;
                           });
 
-                if (candidates.size() > static_cast<std::size_t>(kMaxVoicesPerTrack))
-                    candidates.resize(static_cast<std::size_t>(kMaxVoicesPerTrack));
+                if (candidates.size() > static_cast<std::size_t>(kMaxReadersPerTrack)) {
+                    // What the budget turned away that was due before this pool
+                    // will look again. Those are the clips that fit the voice
+                    // ceiling and will still play nothing, which is a different
+                    // failure from too many at once and is counted as one.
+                    for (auto index = static_cast<std::size_t>(kMaxReadersPerTrack);
+                         index < candidates.size(); ++index)
+                        if (candidates[index].startSeconds < windowStart + kReadAheadBridgeSeconds)
+                            ++unbridged;
+
+                    candidates.resize(static_cast<std::size_t>(kMaxReadersPerTrack));
+                }
 
                 for (const auto& candidate : candidates) {
                     const Key key{track.trackId, candidate.clipId, candidate.eventId};
@@ -292,6 +303,7 @@ void ClipVoicePool::service() {
     }
 
     overSubscribed_.store(overSubscribed, std::memory_order_relaxed);
+    unbridged_.store(unbridged, std::memory_order_relaxed);
     unreadableFiles_.store(unreadable, std::memory_order_relaxed);
 }
 

--- a/magda/engine/clip/ClipVoicePool.cpp
+++ b/magda/engine/clip/ClipVoicePool.cpp
@@ -23,6 +23,7 @@ struct Candidate {
     EventId eventId = INVALID_EVENT_ID;
     const AudioEventPlayback* event = nullptr;
     double startSeconds = 0.0;
+    double endSeconds = 0.0;
 
     /// Whether the transport is inside it right now. A clip that is sounding
     /// keeps its reader ahead of one that has not started, because taking a
@@ -30,6 +31,50 @@ struct Candidate {
     /// pointed it at the next one yet.
     bool sounding = false;
 };
+
+/**
+ * @brief The most of these that overlap at any one instant.
+ *
+ * What a track is actually being asked to sound at once, which is not how many
+ * clips are in the window: a lane of sequential slices fills a window without
+ * ever wanting two voices. A sweep over the edges, which is exact and costs a
+ * sort of a handful of entries off the audio thread.
+ */
+int peakSimultaneous(const std::vector<Candidate>& candidates, double windowStart,
+                     double windowEnd) {
+    // Clamped to the window, because an overlap outside it belongs to the round
+    // that has the transport near it.
+    std::vector<std::pair<double, int>> edges;
+    edges.reserve(candidates.size() * 2);
+
+    for (const auto& candidate : candidates) {
+        const auto from = std::max(candidate.startSeconds, windowStart);
+        const auto to = std::min(candidate.endSeconds, windowEnd);
+        if (to <= from)
+            continue;
+
+        edges.emplace_back(from, 1);
+        edges.emplace_back(to, -1);
+    }
+
+    // Ends before starts at a shared instant: a clip that finishes exactly
+    // where the next begins is a handover, not an overlap.
+    std::sort(edges.begin(), edges.end(), [](const auto& a, const auto& b) {
+        if (a.first != b.first)
+            return a.first < b.first;
+        return a.second < b.second;
+    });
+
+    auto live = 0;
+    auto peak = 0;
+    for (const auto& [when, delta] : edges) {
+        juce::ignoreUnused(when);
+        live += delta;
+        peak = std::max(peak, live);
+    }
+
+    return peak;
+}
 
 }  // namespace
 
@@ -45,9 +90,9 @@ ClipVoicePool::~ClipVoicePool() {
     feed_.publish(std::make_shared<const ClipStreamTable>());
 
     const std::lock_guard<std::mutex> guard(streamsLock_);
-    for (auto& [key, stream] : streams_)
-        if (stream != nullptr)
-            reader_.remove(*stream);
+    for (auto& [key, reader] : streams_)
+        if (reader.stream != nullptr)
+            reader_.remove(*reader.stream);
 
     streams_.clear();
 }
@@ -62,11 +107,10 @@ std::size_t ClipVoicePool::streamCount() const {
     return streams_.size();
 }
 
-std::shared_ptr<PrefetchStream> ClipVoicePool::open(const AudioEventPlayback& event,
-                                                    double cueSeconds) {
+ClipVoicePool::Reader ClipVoicePool::open(const AudioEventPlayback& event, double cueSeconds) {
     auto file = files_.open(event.filePath);
     if (file == nullptr)
-        return nullptr;
+        return Reader{nullptr, event.filePath, event.anchorSamples};
 
     auto stream = std::make_shared<PrefetchStream>(std::move(file), context_, settings_);
 
@@ -82,7 +126,7 @@ std::shared_ptr<PrefetchStream> ClipVoicePool::open(const AudioEventPlayback& ev
     stream->startAt(sourceSampleAt(placement, cueSeconds, context_.sampleRate));
 
     reader_.add(*stream);
-    return stream;
+    return Reader{std::move(stream), event.filePath, event.anchorSamples};
 }
 
 void ClipVoicePool::service() {
@@ -116,15 +160,24 @@ void ClipVoicePool::service() {
                         if (!reachesInto(event.span, windowStart, windowEnd))
                             continue;
 
-                        candidates.push_back(Candidate{clip.clipId, event.eventId, &event,
-                                                       event.span.startSeconds,
-                                                       event.span.startSeconds <= windowStart});
+                        candidates.push_back(Candidate{
+                            clip.clipId, event.eventId, &event, event.span.startSeconds,
+                            event.span.endSeconds, event.span.startSeconds <= windowStart});
                     }
                 }
 
+                // What this track is being asked to sound at once, which is the
+                // only count worth reporting. How many clips are in the window
+                // is a different number and usually a much larger one.
+                overSubscribed += std::max(0, peakSimultaneous(candidates, windowStart, windowEnd) -
+                                                  kMaxVoicesPerTrack);
+
                 // Sounding first, then by where they start. Deterministic, so
-                // which clips a crowded lane drops is a property of the lane
-                // rather than of the order a round happened to walk it.
+                // which clips a crowded window waits for is a property of the
+                // lane rather than of the order a round happened to walk it,
+                // and soonest-first is what makes a queue of sequential clips
+                // rotate through the budget: each is provisioned as the one
+                // before it is passed, long before it is due.
                 std::sort(candidates.begin(), candidates.end(),
                           [](const Candidate& a, const Candidate& b) {
                               if (a.sounding != b.sounding)
@@ -136,62 +189,92 @@ void ClipVoicePool::service() {
                               return a.eventId < b.eventId;
                           });
 
-                if (candidates.size() > static_cast<std::size_t>(kMaxVoicesPerTrack)) {
-                    overSubscribed += static_cast<int>(candidates.size()) - kMaxVoicesPerTrack;
-                    candidates.resize(static_cast<std::size_t>(kMaxVoicesPerTrack));
-                }
+                if (candidates.size() > static_cast<std::size_t>(kMaxReadersPerTrack))
+                    candidates.resize(static_cast<std::size_t>(kMaxReadersPerTrack));
 
                 for (const auto& candidate : candidates) {
                     const Key key{track.trackId, candidate.clipId, candidate.eventId};
+                    const auto& event = *candidate.event;
 
-                    // Already provisioned: kept as it is, and never re-cued. A
-                    // stream that is playing cannot be pointed anywhere else
-                    // anyway, and one that is waiting is already pointed at the
-                    // sample the clip starts on.
-                    if (const auto found = streams_.find(key); found != streams_.end()) {
-                        if (found->second == nullptr)
+                    // Already provisioned, and still for the same material. An
+                    // id outlives the edit that changed what it names, so this
+                    // is checked rather than assumed: kept on the strength of
+                    // its id alone, a reader would go on playing a file the
+                    // clip no longer points at.
+                    if (const auto found = streams_.find(key);
+                        found != streams_.end() && found->second.path == event.filePath) {
+                        auto reuse = found->second;
+
+                        // The milder version: the same file, read from
+                        // somewhere else. A clip that has not started is
+                        // re-cued and loses nothing; one the transport is
+                        // already inside is left alone, because a reader that
+                        // is playing cannot be pointed elsewhere and the next
+                        // read corrects it anyway, at the cost of a seek.
+                        if (reuse.anchorSamples != event.anchorSamples) {
+                            if (reuse.stream != nullptr && !candidate.sounding) {
+                                const ClipPlacement placement{event.span.startSeconds,
+                                                              event.span.endSeconds,
+                                                              event.anchorSamples};
+                                reuse.stream->seek(sourceSampleAt(
+                                    placement, event.span.startSeconds, context_.sampleRate));
+                            }
+                            reuse.anchorSamples = event.anchorSamples;
+                        }
+
+                        if (reuse.stream == nullptr)
                             ++unreadable;
-                        wanted.emplace(key, found->second);
+
+                        wanted.emplace(key, std::move(reuse));
                         continue;
                     }
 
                     // From where playback will pick it up: its own first sample
                     // for a clip that has not started, and where the cursor
                     // already is for one the transport is standing inside.
-                    const auto cueSeconds =
-                        std::max(windowStart, candidate.event->span.startSeconds);
+                    const auto cueSeconds = std::max(windowStart, event.span.startSeconds);
 
-                    auto stream = open(*candidate.event, cueSeconds);
-                    if (stream == nullptr)
+                    auto reader = open(event, cueSeconds);
+                    if (reader.stream == nullptr)
                         ++unreadable;
 
-                    wanted.emplace(key, std::move(stream));
+                    wanted.emplace(key, std::move(reader));
                 }
             }
         }
 
-        auto table = std::make_shared<ClipStreamTable>();
-        table->entries.reserve(wanted.size());
-        for (const auto& [key, stream] : wanted)
-            if (stream != nullptr)
-                table->entries.push_back(
-                    ClipStreamTable::Entry{key.trackId, key.clipId, key.eventId, stream});
+        // Nothing opened, nothing retired, nothing moved. Publishing anyway
+        // would allocate a table and make the callback wait for the swap at a
+        // hundred rounds a second, for the whole of an idle session.
+        if (wanted != streams_) {
+            auto table = std::make_shared<ClipStreamTable>();
+            table->entries.reserve(wanted.size());
+            for (const auto& [key, reader] : wanted)
+                if (reader.stream != nullptr)
+                    table->entries.push_back(ClipStreamTable::Entry{key.trackId, key.clipId,
+                                                                    key.eventId, reader.stream});
 
-        // Published before anything is retired, and it waits for the block the
-        // callback is in: after this returns, nothing the audio thread can
-        // reach names a stream that is about to be closed.
-        feed_.publish(std::move(table));
+            // Published before anything is retired, and it waits for the block
+            // the callback is in: after this returns, nothing the audio thread
+            // can reach names a stream that is about to be closed.
+            feed_.publish(std::move(table));
+            tablesPublished_.fetch_add(1, std::memory_order_relaxed);
 
-        for (auto& [key, stream] : streams_) {
-            if (stream == nullptr || wanted.count(key) != 0)
-                continue;
+            for (auto& [key, reader] : streams_) {
+                if (reader.stream == nullptr)
+                    continue;
 
-            // Waits for the prefetch thread to be out of it, which is what
-            // makes destroying it on the next line safe.
-            reader_.remove(*stream);
+                const auto kept = wanted.find(key);
+                if (kept != wanted.end() && kept->second.stream == reader.stream)
+                    continue;
+
+                // Waits for the prefetch thread to be out of it, which is what
+                // makes destroying it on the next line safe.
+                reader_.remove(*reader.stream);
+            }
+
+            streams_ = std::move(wanted);
         }
-
-        streams_ = std::move(wanted);
     }
 
     overSubscribed_.store(overSubscribed, std::memory_order_relaxed);

--- a/magda/engine/clip/ClipVoicePool.cpp
+++ b/magda/engine/clip/ClipVoicePool.cpp
@@ -85,6 +85,55 @@ int peakConcurrent(const std::vector<Candidate>& candidates, double windowStart,
     return peak;
 }
 
+/**
+ * @brief Clips the budget turned away that a voice was waiting for.
+ *
+ * @p candidates sorted soonest first, of which the first @p kept get readers.
+ * Counts the ones after that which are due inside the bridge and would have
+ * sounded had they had one.
+ *
+ * That last clause is the whole difficulty. A clip dropped into a stretch where
+ * every voice is already spoken for was not going to sound whatever the budget
+ * had been, and counting it here would blame the reader budget for a ceiling
+ * that is doing exactly what it says. ClipVoicePool::overSubscribed has it
+ * already; this reports what is left, so the two never name the same clip.
+ *
+ * Which voices are spoken for is answerable cheaply because of the ordering:
+ * every kept candidate starts no later than any dropped one, so the kept clips
+ * live when a dropped one begins are simply the ones that have not ended by
+ * then. Ends in order, queries in order, one pass.
+ */
+int unbridgedAmong(const std::vector<Candidate>& candidates, int kept, double windowStart,
+                   double blockSeconds) {
+    const auto bridgeEnd = windowStart + kReadAheadBridgeSeconds;
+
+    std::vector<double> keptEnds;
+    keptEnds.reserve(static_cast<std::size_t>(kept));
+    for (auto index = 0; index < kept; ++index)
+        keptEnds.push_back(candidates[static_cast<std::size_t>(index)].endSeconds + blockSeconds);
+
+    std::sort(keptEnds.begin(), keptEnds.end());
+
+    auto ended = std::size_t{0};
+    auto unbridged = 0;
+
+    for (auto index = static_cast<std::size_t>(kept); index < candidates.size(); ++index) {
+        const auto& dropped = candidates[index];
+
+        // Sorted by start, so the first one past the bridge ends the walk.
+        if (dropped.startSeconds >= bridgeEnd)
+            break;
+
+        while (ended < keptEnds.size() && keptEnds[ended] <= dropped.startSeconds)
+            ++ended;
+
+        if (static_cast<int>(keptEnds.size() - ended) < kMaxVoicesPerTrack)
+            ++unbridged;
+    }
+
+    return unbridged;
+}
+
 }  // namespace
 
 ClipVoicePool::ClipVoicePool(AudioFileReaderFactory& files, PrefetchThread& reader,
@@ -205,15 +254,8 @@ void ClipVoicePool::service() {
                           });
 
                 if (candidates.size() > static_cast<std::size_t>(kMaxReadersPerTrack)) {
-                    // What the budget turned away that was due before this pool
-                    // will look again. Those are the clips that fit the voice
-                    // ceiling and will still play nothing, which is a different
-                    // failure from too many at once and is counted as one.
-                    for (auto index = static_cast<std::size_t>(kMaxReadersPerTrack);
-                         index < candidates.size(); ++index)
-                        if (candidates[index].startSeconds < windowStart + kReadAheadBridgeSeconds)
-                            ++unbridged;
-
+                    unbridged +=
+                        unbridgedAmong(candidates, kMaxReadersPerTrack, windowStart, blockSeconds);
                     candidates.resize(static_cast<std::size_t>(kMaxReadersPerTrack));
                 }
 

--- a/magda/engine/clip/ClipVoicePool.cpp
+++ b/magda/engine/clip/ClipVoicePool.cpp
@@ -1,0 +1,219 @@
+#include "clip/ClipVoicePool.hpp"
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include "clip/ClipAudioSource.hpp"
+#include "io/ClipPlacement.hpp"
+
+namespace magda::engine {
+
+namespace {
+
+/// Whether a span reaches into the window at all. Half-open, like every other
+/// span comparison here: a clip ending exactly where the window starts is over.
+bool reachesInto(const SnapshotSpan& span, double windowStart, double windowEnd) {
+    return span.startSeconds < windowEnd && span.endSeconds > windowStart;
+}
+
+/// One entry that wants a stream, and what decides whether it gets one.
+struct Candidate {
+    ClipId clipId = INVALID_CLIP_ID;
+    EventId eventId = INVALID_EVENT_ID;
+    const AudioEventPlayback* event = nullptr;
+    double startSeconds = 0.0;
+
+    /// Whether the transport is inside it right now. A clip that is sounding
+    /// keeps its reader ahead of one that has not started, because taking a
+    /// stream off a clip mid-note is the one thing worse than not having
+    /// pointed it at the next one yet.
+    bool sounding = false;
+};
+
+}  // namespace
+
+ClipVoicePool::ClipVoicePool(AudioFileReaderFactory& files, PrefetchThread& reader,
+                             const RenderContext& context, const PrefetchSettings& settings)
+    : files_(files), reader_(reader), context_(context), settings_(settings) {}
+
+ClipVoicePool::~ClipVoicePool() {
+    // Nothing may be reachable from the audio thread once this returns, and
+    // nothing may be in the prefetch thread's round either. An empty table
+    // published first is what takes care of the callback; removal takes care of
+    // the reader, and waits for it.
+    feed_.publish(std::make_shared<const ClipStreamTable>());
+
+    const std::lock_guard<std::mutex> guard(streamsLock_);
+    for (auto& [key, stream] : streams_)
+        if (stream != nullptr)
+            reader_.remove(*stream);
+
+    streams_.clear();
+}
+
+void ClipVoicePool::setSnapshot(std::shared_ptr<const ClipSnapshot> snapshot) {
+    const std::lock_guard<std::mutex> guard(snapshotLock_);
+    snapshot_ = std::move(snapshot);
+}
+
+std::size_t ClipVoicePool::streamCount() const {
+    const std::lock_guard<std::mutex> guard(streamsLock_);
+    return streams_.size();
+}
+
+std::shared_ptr<PrefetchStream> ClipVoicePool::open(const AudioEventPlayback& event,
+                                                    double cueSeconds) {
+    auto file = files_.open(event.filePath);
+    if (file == nullptr)
+        return nullptr;
+
+    auto stream = std::make_shared<PrefetchStream>(std::move(file), context_, settings_);
+
+    // Pointed before anything asks, and before the reader is even told the
+    // stream exists. This is the whole reason the pool runs ahead of the
+    // transport: the callback that first reads this clip finds the material
+    // already in memory instead of paying a seek for it. startAt rather than
+    // seek, because a stream nobody has read from has nothing to invalidate and
+    // no callback to wait for, and every read it does before the redirect
+    // landed would be a read of the wrong part of the file.
+    const ClipPlacement placement{event.span.startSeconds, event.span.endSeconds,
+                                  event.anchorSamples};
+    stream->startAt(sourceSampleAt(placement, cueSeconds, context_.sampleRate));
+
+    reader_.add(*stream);
+    return stream;
+}
+
+void ClipVoicePool::service() {
+    std::shared_ptr<const ClipSnapshot> snapshot;
+    {
+        const std::lock_guard<std::mutex> guard(snapshotLock_);
+        snapshot = snapshot_;
+    }
+
+    const auto windowStart = position_.load(std::memory_order_relaxed);
+    const auto windowEnd = windowStart + kCueAheadSeconds;
+
+    auto overSubscribed = 0;
+    auto unreadable = 0;
+
+    Streams wanted;
+    std::vector<Candidate> candidates;
+
+    {
+        const std::lock_guard<std::mutex> guard(streamsLock_);
+
+        if (snapshot != nullptr) {
+            for (const auto& track : snapshot->tracks) {
+                candidates.clear();
+
+                for (const auto& clip : track.audio) {
+                    if (!reachesInto(clip.span, windowStart, windowEnd))
+                        continue;
+
+                    for (const auto& event : clip.events) {
+                        if (!reachesInto(event.span, windowStart, windowEnd))
+                            continue;
+
+                        candidates.push_back(Candidate{clip.clipId, event.eventId, &event,
+                                                       event.span.startSeconds,
+                                                       event.span.startSeconds <= windowStart});
+                    }
+                }
+
+                // Sounding first, then by where they start. Deterministic, so
+                // which clips a crowded lane drops is a property of the lane
+                // rather than of the order a round happened to walk it.
+                std::sort(candidates.begin(), candidates.end(),
+                          [](const Candidate& a, const Candidate& b) {
+                              if (a.sounding != b.sounding)
+                                  return a.sounding;
+                              if (a.startSeconds != b.startSeconds)
+                                  return a.startSeconds < b.startSeconds;
+                              if (a.clipId != b.clipId)
+                                  return a.clipId < b.clipId;
+                              return a.eventId < b.eventId;
+                          });
+
+                if (candidates.size() > static_cast<std::size_t>(kMaxVoicesPerTrack)) {
+                    overSubscribed += static_cast<int>(candidates.size()) - kMaxVoicesPerTrack;
+                    candidates.resize(static_cast<std::size_t>(kMaxVoicesPerTrack));
+                }
+
+                for (const auto& candidate : candidates) {
+                    const Key key{track.trackId, candidate.clipId, candidate.eventId};
+
+                    // Already provisioned: kept as it is, and never re-cued. A
+                    // stream that is playing cannot be pointed anywhere else
+                    // anyway, and one that is waiting is already pointed at the
+                    // sample the clip starts on.
+                    if (const auto found = streams_.find(key); found != streams_.end()) {
+                        if (found->second == nullptr)
+                            ++unreadable;
+                        wanted.emplace(key, found->second);
+                        continue;
+                    }
+
+                    // From where playback will pick it up: its own first sample
+                    // for a clip that has not started, and where the cursor
+                    // already is for one the transport is standing inside.
+                    const auto cueSeconds =
+                        std::max(windowStart, candidate.event->span.startSeconds);
+
+                    auto stream = open(*candidate.event, cueSeconds);
+                    if (stream == nullptr)
+                        ++unreadable;
+
+                    wanted.emplace(key, std::move(stream));
+                }
+            }
+        }
+
+        auto table = std::make_shared<ClipStreamTable>();
+        table->entries.reserve(wanted.size());
+        for (const auto& [key, stream] : wanted)
+            if (stream != nullptr)
+                table->entries.push_back(
+                    ClipStreamTable::Entry{key.trackId, key.clipId, key.eventId, stream});
+
+        // Published before anything is retired, and it waits for the block the
+        // callback is in: after this returns, nothing the audio thread can
+        // reach names a stream that is about to be closed.
+        feed_.publish(std::move(table));
+
+        for (auto& [key, stream] : streams_) {
+            if (stream == nullptr || wanted.count(key) != 0)
+                continue;
+
+            // Waits for the prefetch thread to be out of it, which is what
+            // makes destroying it on the next line safe.
+            reader_.remove(*stream);
+        }
+
+        streams_ = std::move(wanted);
+    }
+
+    overSubscribed_.store(overSubscribed, std::memory_order_relaxed);
+    unreadableFiles_.store(unreadable, std::memory_order_relaxed);
+}
+
+ClipVoiceThread::ClipVoiceThread(ClipVoicePool& pool)
+    : juce::Thread("MAGDA clip voices"), pool_(pool) {
+    // Above the interface and below the prefetch thread: a round that lost to a
+    // redraw costs a cue, and a round that won against a disk costs audio.
+    startThread(juce::Thread::Priority::normal);
+}
+
+ClipVoiceThread::~ClipVoiceThread() {
+    stopThread(2000);
+}
+
+void ClipVoiceThread::run() {
+    while (!threadShouldExit()) {
+        pool_.service();
+        wait(kRoundMilliseconds);
+    }
+}
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipVoicePool.cpp
+++ b/magda/engine/clip/ClipVoicePool.cpp
@@ -33,17 +33,26 @@ struct Candidate {
 };
 
 /**
- * @brief The most of these that overlap at any one instant.
+ * @brief The most of these a single callback can be asked for.
  *
  * What a track is actually being asked to sound at once, which is not how many
  * clips are in the window: a lane of sequential slices fills a window without
- * ever wanting two voices. A sweep over the edges, which is exact and costs a
- * sort of a handful of entries off the audio thread.
+ * ever wanting two voices.
+ *
+ * Live to the end of the block it ends in, not to the sample it ends on. The
+ * callback is where voices are claimed and released, so two clips that share
+ * one need two voices however little they overlap, and a run of clips shorter
+ * than a block needs one apiece. Measuring bare overlap would report a track in
+ * the clear while the callback was dropping the extras, which is the whole
+ * reason this is measured rather than counted.
+ *
+ * A sweep over the edges: exact, and a sort of a handful of entries off the
+ * audio thread.
  */
-int peakSimultaneous(const std::vector<Candidate>& candidates, double windowStart,
-                     double windowEnd) {
-    // Clamped to the window, because an overlap outside it belongs to the round
-    // that has the transport near it.
+int peakConcurrent(const std::vector<Candidate>& candidates, double windowStart, double windowEnd,
+                   double blockSeconds) {
+    // Clamped to the window, because concurrency outside it belongs to the
+    // round that has the transport near it.
     std::vector<std::pair<double, int>> edges;
     edges.reserve(candidates.size() * 2);
 
@@ -54,11 +63,11 @@ int peakSimultaneous(const std::vector<Candidate>& candidates, double windowStar
             continue;
 
         edges.emplace_back(from, 1);
-        edges.emplace_back(to, -1);
+        edges.emplace_back(to + blockSeconds, -1);
     }
 
-    // Ends before starts at a shared instant: a clip that finishes exactly
-    // where the next begins is a handover, not an overlap.
+    // Ends before starts at a shared instant, so a clip whose block finishes
+    // exactly where the next begins is a handover rather than an overlap.
     std::sort(edges.begin(), edges.end(), [](const auto& a, const auto& b) {
         if (a.first != b.first)
             return a.first < b.first;
@@ -139,6 +148,10 @@ void ClipVoicePool::service() {
     const auto windowStart = position_.load(std::memory_order_relaxed);
     const auto windowEnd = windowStart + kCueAheadSeconds;
 
+    // The largest callback the plan was prepared for, which is the resolution
+    // voices are claimed and released at.
+    const auto blockSeconds = context_.maxBlockSize / context_.sampleRate;
+
     auto overSubscribed = 0;
     auto unreadable = 0;
 
@@ -169,8 +182,9 @@ void ClipVoicePool::service() {
                 // What this track is being asked to sound at once, which is the
                 // only count worth reporting. How many clips are in the window
                 // is a different number and usually a much larger one.
-                overSubscribed += std::max(0, peakSimultaneous(candidates, windowStart, windowEnd) -
-                                                  kMaxVoicesPerTrack);
+                overSubscribed +=
+                    std::max(0, peakConcurrent(candidates, windowStart, windowEnd, blockSeconds) -
+                                    kMaxVoicesPerTrack);
 
                 // Sounding first, then by where they start. Deterministic, so
                 // which clips a crowded window waits for is a property of the
@@ -189,8 +203,8 @@ void ClipVoicePool::service() {
                               return a.eventId < b.eventId;
                           });
 
-                if (candidates.size() > static_cast<std::size_t>(kMaxReadersPerTrack))
-                    candidates.resize(static_cast<std::size_t>(kMaxReadersPerTrack));
+                if (candidates.size() > static_cast<std::size_t>(kMaxVoicesPerTrack))
+                    candidates.resize(static_cast<std::size_t>(kMaxVoicesPerTrack));
 
                 for (const auto& candidate : candidates) {
                     const Key key{track.trackId, candidate.clipId, candidate.eventId};

--- a/magda/engine/clip/ClipVoicePool.cpp
+++ b/magda/engine/clip/ClipVoicePool.cpp
@@ -98,10 +98,17 @@ int peakConcurrent(const std::vector<Candidate>& candidates, double windowStart,
  * that is doing exactly what it says. ClipVoicePool::overSubscribed has it
  * already; this reports what is left, so the two never name the same clip.
  *
- * Which voices are spoken for is answerable cheaply because of the ordering:
- * every kept candidate starts no later than any dropped one, so the kept clips
- * live when a dropped one begins are simply the ones that have not ended by
- * then. Ends in order, queries in order, one pass.
+ * Which voices are spoken for is two sets, not one. The kept clips are the
+ * obvious half, and cheap because of the ordering: every kept candidate starts
+ * no later than any dropped one, so the kept clips live when a dropped one
+ * begins are simply the ones that have not ended by then. The other half is the
+ * dropped clips already counted here. Twenty clips starting together where
+ * nothing else is playing are sixteen the budget failed and four the ceiling
+ * would have refused anyway, and only a walk that lets each counted clip occupy
+ * a voice against the ones behind it can tell those apart.
+ *
+ * Ends in order, queries in order, one pass, and the counted set never grows
+ * past the ceiling because having a voice free is the condition for joining it.
  */
 int unbridgedAmong(const std::vector<Candidate>& candidates, int kept, double windowStart,
                    double blockSeconds) {
@@ -114,7 +121,11 @@ int unbridgedAmong(const std::vector<Candidate>& candidates, int kept, double wi
 
     std::sort(keptEnds.begin(), keptEnds.end());
 
-    auto ended = std::size_t{0};
+    // The dropped clips counted so far and still live, by when they finish.
+    std::vector<double> countedEnds;
+    countedEnds.reserve(static_cast<std::size_t>(kMaxVoicesPerTrack));
+
+    auto keptEnded = std::size_t{0};
     auto unbridged = 0;
 
     for (auto index = static_cast<std::size_t>(kept); index < candidates.size(); ++index) {
@@ -124,11 +135,22 @@ int unbridgedAmong(const std::vector<Candidate>& candidates, int kept, double wi
         if (dropped.startSeconds >= bridgeEnd)
             break;
 
-        while (ended < keptEnds.size() && keptEnds[ended] <= dropped.startSeconds)
-            ++ended;
+        while (keptEnded < keptEnds.size() && keptEnds[keptEnded] <= dropped.startSeconds)
+            ++keptEnded;
 
-        if (static_cast<int>(keptEnds.size() - ended) < kMaxVoicesPerTrack)
-            ++unbridged;
+        countedEnds.erase(
+            countedEnds.begin(),
+            std::upper_bound(countedEnds.begin(), countedEnds.end(), dropped.startSeconds));
+
+        const auto live =
+            static_cast<int>(keptEnds.size() - keptEnded) + static_cast<int>(countedEnds.size());
+        if (live >= kMaxVoicesPerTrack)
+            continue;
+
+        ++unbridged;
+
+        const auto end = dropped.endSeconds + blockSeconds;
+        countedEnds.insert(std::upper_bound(countedEnds.begin(), countedEnds.end(), end), end);
     }
 
     return unbridged;

--- a/magda/engine/clip/ClipVoicePool.hpp
+++ b/magda/engine/clip/ClipVoicePool.hpp
@@ -1,0 +1,216 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <atomic>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+
+#include "clip/ClipSnapshot.hpp"
+#include "clip/ClipStreamFeed.hpp"
+#include "core/ClipTypes.hpp"
+#include "core/TypeIds.hpp"
+#include "exec/RenderContext.hpp"
+#include "io/AudioFileReader.hpp"
+#include "io/PrefetchStream.hpp"
+#include "io/PrefetchThread.hpp"
+
+/**
+ * @file ClipVoicePool.hpp
+ * @brief Which clips have a reader standing by, and where it is pointed.
+ *
+ * A clip that starts on the beat is a read the stream was not expecting, and a
+ * read that does not continue the last one is a seek: what was read ahead is
+ * for somewhere else, and nothing plays until the reader catches up (#2016).
+ * The whole point of this file is that it never happens. The transport's
+ * position is watched from off the audio thread, clips about to sound are given
+ * a stream and the stream is cued to the sample they start on, and by the time
+ * the callback asks the material is already in memory.
+ *
+ * Nothing here is on the audio thread and nothing here may be. Opening a file,
+ * allocating a chunk pool and cueing a stream are all things that wait, so they
+ * happen on a thread that is allowed to (ClipVoiceThread below), and what
+ * reaches the callback is a published table (ClipStreamFeed.hpp).
+ *
+ * Not the prefetch thread. The two jobs are separate on purpose: deciding what
+ * to read must not queue behind a disk that is being read, and retiring a
+ * stream waits for the prefetch thread to be out of it, which a caller running
+ * on that thread would wait for for ever.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief How far ahead of the transport a clip is given a reader.
+ *
+ * A cue is only worth giving if the reader has time to act on it, and what it
+ * has to do is fill its pool: chunkSamples x (chunkCount - 1) samples of
+ * read-ahead, which is two thirds of a second at the default settings and a
+ * 44.1 kHz device, and less at every higher rate. Add a provisioning round and
+ * the time it takes to open a file, and a second is that with room to spare.
+ *
+ * Longer is not better. Every clip inside the window is an open file and a
+ * chunk pool, and a window wide enough to hold a chorus' worth of edits would
+ * have the disk reading material that is a bar away instead of the material
+ * that is due.
+ */
+constexpr double kCueAheadSeconds = 1.0;
+
+class ClipVoicePool {
+  public:
+    /**
+     * @brief A pool opening files through @p files and filled by @p reader.
+     *
+     * Neither is owned and both outlive it. @p context is the device the
+     * streams are read for, and the rate every cue is worked out at: a file
+     * sample is consumed per output sample, so a position derived at any other
+     * rate would disagree with what playing gets through (ClipPlacement.hpp).
+     */
+    ClipVoicePool(AudioFileReaderFactory& files, PrefetchThread& reader,
+                  const RenderContext& context, const PrefetchSettings& settings = {});
+
+    ~ClipVoicePool();
+
+    ClipVoicePool(const ClipVoicePool&) = delete;
+    ClipVoicePool& operator=(const ClipVoicePool&) = delete;
+
+    /// What the clip sources read. Handed to a ClipAudioSource when it is made,
+    /// and owned here because it outlives every plan those sources are bound
+    /// into.
+    ClipStreamFeed& feed() {
+        return feed_;
+    }
+
+    /**
+     * @brief The snapshot to provision against.
+     *
+     * On the publishing thread, beside EngineSession::publishClips: the same
+     * value reaches the audio thread through the feed and this side through
+     * here, so the clips a callback plays and the clips a reader is pointed at
+     * are the same clips.
+     */
+    void setSnapshot(std::shared_ptr<const ClipSnapshot> snapshot);
+
+    /**
+     * @brief Where the transport is, in seconds.
+     *
+     * From the audio thread, once per block: a relaxed store of a double and
+     * nothing else. Seconds rather than beats because that is the face a file's
+     * samples are counted in, and because a tempo map on this thread would be a
+     * second one.
+     *
+     * A pool nobody tells provisions around zero, which is where a session that
+     * has not played yet is.
+     */
+    void setPosition(double seconds) {
+        position_.store(seconds, std::memory_order_relaxed);
+    }
+
+    /**
+     * @brief One round of provisioning: open, cue, publish, retire.
+     *
+     * On a thread that may wait for a disk, and not the prefetch thread (see
+     * the file comment). Idempotent: a round that finds every clip in the
+     * window already provisioned opens nothing and cues nothing, and publishes
+     * a table equal to the one that is live.
+     */
+    void service();
+
+    /// Streams provisioned right now, for tests and diagnostics.
+    std::size_t streamCount() const;
+
+    /**
+     * @brief Clips in the window the last round could not provision.
+     *
+     * A gauge rather than a tally: it is what the last round found, so it falls
+     * back to zero when the material stops asking for more voices than a track
+     * has. Non-zero means either a lane stacking more simultaneous clips than
+     * kMaxVoicesPerTrack, or files that will not open; ClipAudioSource counts
+     * what that actually costs the audio.
+     */
+    int overSubscribed() const {
+        return overSubscribed_.load(std::memory_order_relaxed);
+    }
+
+    /// Paths the factory declined, in the last round. A file that has moved or
+    /// cannot be decoded; the clip plays silence and this says why nothing was
+    /// provisioned for it.
+    int unreadableFiles() const {
+        return unreadableFiles_.load(std::memory_order_relaxed);
+    }
+
+  private:
+    /// One provisioned entry. Ordered so a table built by walking this map is
+    /// already in the order ClipStreamTable::rangeFor searches.
+    struct Key {
+        TrackId trackId = INVALID_TRACK_ID;
+        ClipId clipId = INVALID_CLIP_ID;
+        EventId eventId = INVALID_EVENT_ID;
+
+        bool operator<(const Key& other) const {
+            if (trackId != other.trackId)
+                return trackId < other.trackId;
+            if (clipId != other.clipId)
+                return clipId < other.clipId;
+            return eventId < other.eventId;
+        }
+    };
+
+    /// Null where the file would not open. Kept rather than dropped so a path
+    /// that failed is not retried every round for as long as it sits in the
+    /// window; leaving the window and coming back is what asks again.
+    using Streams = std::map<Key, std::shared_ptr<PrefetchStream>>;
+
+    std::shared_ptr<PrefetchStream> open(const AudioEventPlayback& event, double cueSeconds);
+
+    AudioFileReaderFactory& files_;
+    PrefetchThread& reader_;
+    RenderContext context_;
+    PrefetchSettings settings_;
+
+    ClipStreamFeed feed_;
+
+    /// Written by the publishing thread, read by the provisioning one; neither
+    /// is the audio thread, so a lock is the plain answer.
+    mutable std::mutex snapshotLock_;
+    std::shared_ptr<const ClipSnapshot> snapshot_;
+
+    std::atomic<double> position_{0.0};
+
+    /// Provisioning thread only, apart from streamCount().
+    mutable std::mutex streamsLock_;
+    Streams streams_;
+
+    std::atomic<int> overSubscribed_{0};
+    std::atomic<int> unreadableFiles_{0};
+};
+
+/**
+ * @brief The thread a pool provisions on.
+ *
+ * It polls, like the prefetch thread and for the same reason: waking a thread
+ * takes a lock, and the audio thread does not take locks. A clip that came into
+ * the window between two rounds is found on the next one, which is a fraction
+ * of the second the window is wide.
+ */
+class ClipVoiceThread final : private juce::Thread {
+  public:
+    explicit ClipVoiceThread(ClipVoicePool& pool);
+    ~ClipVoiceThread() override;
+
+    ClipVoiceThread(const ClipVoiceThread&) = delete;
+    ClipVoiceThread& operator=(const ClipVoiceThread&) = delete;
+
+  private:
+    void run() override;
+
+    /// Short against the window, long against the work: a round over the clips
+    /// near the cursor is a walk of a handful of spans.
+    static constexpr int kRoundMilliseconds = 10;
+
+    ClipVoicePool& pool_;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipVoicePool.hpp
+++ b/magda/engine/clip/ClipVoicePool.hpp
@@ -217,6 +217,12 @@ class ClipVoicePool {
      * and will still play nothing, because the round that could have opened it
      * spent its budget on the clips in front of it.
      *
+     * Fits the ceiling is checked rather than assumed. A clip dropped into a
+     * stretch where every voice is already spoken for was not going to sound
+     * whatever the budget had been, and it belongs to @ref overSubscribed; a
+     * clip counted here would otherwise be counted twice and send a reader for
+     * a voice that was never free.
+     *
      * Non-zero means the material is denser than this track can read ahead for.
      * Nothing in the engine fixes that by trying harder; what it can do is say
      * so rather than let a lane of slices go quiet for no stated reason.

--- a/magda/engine/clip/ClipVoicePool.hpp
+++ b/magda/engine/clip/ClipVoicePool.hpp
@@ -7,6 +7,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <string>
 
 #include "clip/ClipSnapshot.hpp"
 #include "clip/ClipStreamFeed.hpp"
@@ -58,6 +59,31 @@ namespace magda::engine {
  */
 constexpr double kCueAheadSeconds = 1.0;
 
+/**
+ * @brief Readers one track may have standing by.
+ *
+ * Not the same ceiling as kMaxVoicesPerTrack and not measuring the same thing.
+ * A voice is state and a reader is an open file and a chunk pool, a quarter of
+ * a megabyte at the default settings, so this is the number that bounds memory:
+ * four megabytes for a track with clips near the cursor, and nothing at all for
+ * one without.
+ *
+ * Higher than the voice ceiling because a window is not an instant. Chopped
+ * material puts a dozen clips inside a second while never sounding two of them
+ * at once, and every one of them needs its own reader pointed at its own slice
+ * of its own file. Sizing this to the voice count would have starved exactly
+ * the material that needs the read-ahead most.
+ *
+ * A window holding more than this is not a clip that will not sound. The
+ * soonest are provisioned first and a clip that has been passed gives its
+ * reader back, so a queue of sequential clips rotates through the budget and
+ * each one has its reader well before it is due. What it costs when the budget
+ * really is exhausted is the read-ahead, which is a seek, which the stream
+ * already counts as an underrun. What will not sound is counted by
+ * @ref ClipVoicePool::overSubscribed and by ClipAudioSource::starvedVoices.
+ */
+constexpr int kMaxReadersPerTrack = 16;
+
 class ClipVoicePool {
   public:
     /**
@@ -71,6 +97,19 @@ class ClipVoicePool {
     ClipVoicePool(AudioFileReaderFactory& files, PrefetchThread& reader,
                   const RenderContext& context, const PrefetchSettings& settings = {});
 
+    /**
+     * @brief Give every reader back.
+     *
+     * Publishes an empty table so nothing the audio thread can reach names a
+     * stream, then waits for the prefetch thread to be out of each one.
+     *
+     * Nothing may call @ref service() again from here on, and that is the
+     * caller's to guarantee rather than this class's: a round in flight would
+     * publish a full table straight after the empty one and the streams it
+     * named would be pulled out from under the reader. A host driving this with
+     * a ClipVoiceThread destroys the thread first, which is what declaring the
+     * thread after the pool gets for free.
+     */
     ~ClipVoicePool();
 
     ClipVoicePool(const ClipVoicePool&) = delete;
@@ -112,9 +151,10 @@ class ClipVoicePool {
      * @brief One round of provisioning: open, cue, publish, retire.
      *
      * On a thread that may wait for a disk, and not the prefetch thread (see
-     * the file comment). Idempotent: a round that finds every clip in the
-     * window already provisioned opens nothing and cues nothing, and publishes
-     * a table equal to the one that is live.
+     * the file comment). Idempotent, and cheaply so: a round that finds every
+     * clip in the window already provisioned opens nothing, retires nothing and
+     * publishes nothing, so an idle session is not swapping a table at a
+     * hundred hertz and making the callback wait for each one.
      */
     void service();
 
@@ -122,13 +162,17 @@ class ClipVoicePool {
     std::size_t streamCount() const;
 
     /**
-     * @brief Clips in the window the last round could not provision.
+     * @brief Clips the last round found stacked past what a track can sound.
      *
-     * A gauge rather than a tally: it is what the last round found, so it falls
-     * back to zero when the material stops asking for more voices than a track
-     * has. Non-zero means either a lane stacking more simultaneous clips than
-     * kMaxVoicesPerTrack, or files that will not open; ClipAudioSource counts
-     * what that actually costs the audio.
+     * Measured where it means something: the most clips overlapping at any one
+     * instant inside the window, less kMaxVoicesPerTrack. Not the number the
+     * reader budget turned away, which is a different and usually harmless
+     * thing (see kMaxReadersPerTrack): a lane of sequential clips can fill that
+     * budget many times over without two of them ever sounding together.
+     *
+     * A gauge rather than a tally, so it falls back to zero when the material
+     * stops asking. Non-zero means clips that will not be heard, and
+     * ClipAudioSource::starvedVoices counts them as they are not heard.
      */
     int overSubscribed() const {
         return overSubscribed_.load(std::memory_order_relaxed);
@@ -139,6 +183,19 @@ class ClipVoicePool {
     /// provisioned for it.
     int unreadableFiles() const {
         return unreadableFiles_.load(std::memory_order_relaxed);
+    }
+
+    /**
+     * @brief Tables handed to the audio thread since this pool was made.
+     *
+     * Every one of them made a callback finish its block before the swap could
+     * land, so this is the cost of provisioning as the audio thread sees it. It
+     * should climb while the transport moves through new material and stand
+     * still otherwise; a session sitting idle and still counting means rounds
+     * are publishing work that has not changed.
+     */
+    int tablesPublished() const {
+        return tablesPublished_.load(std::memory_order_relaxed);
     }
 
   private:
@@ -156,14 +213,39 @@ class ClipVoicePool {
                 return clipId < other.clipId;
             return eventId < other.eventId;
         }
+
+        bool operator==(const Key& other) const = default;
     };
 
-    /// Null where the file would not open. Kept rather than dropped so a path
-    /// that failed is not retried every round for as long as it sits in the
-    /// window; leaving the window and coming back is what asks again.
-    using Streams = std::map<Key, std::shared_ptr<PrefetchStream>>;
+    /**
+     * @brief A reader, and what it was opened for.
+     *
+     * The identity matters because the key does not carry it. An id survives
+     * edits that change everything a reader was opened for: swap a clip's file
+     * and the ids are the same clip and the same event over different material,
+     * and a reader kept on the strength of its id would go on playing the file
+     * that is no longer there. The anchor is here for the milder version of the
+     * same thing, a trim that moves where the reader should be pointed.
+     *
+     * The stream is null where the file would not open. Kept rather than
+     * dropped so a path that failed is not retried every round for as long as
+     * it sits in the window; leaving the window and coming back is what asks
+     * again.
+     */
+    struct Reader {
+        std::shared_ptr<PrefetchStream> stream;
+        std::string path;
+        std::int64_t anchorSamples = 0;
 
-    std::shared_ptr<PrefetchStream> open(const AudioEventPlayback& event, double cueSeconds);
+        bool operator==(const Reader& other) const {
+            return stream == other.stream && path == other.path &&
+                   anchorSamples == other.anchorSamples;
+        }
+    };
+
+    using Streams = std::map<Key, Reader>;
+
+    Reader open(const AudioEventPlayback& event, double cueSeconds);
 
     AudioFileReaderFactory& files_;
     PrefetchThread& reader_;
@@ -185,6 +267,7 @@ class ClipVoicePool {
 
     std::atomic<int> overSubscribed_{0};
     std::atomic<int> unreadableFiles_{0};
+    std::atomic<int> tablesPublished_{0};
 };
 
 /**
@@ -194,6 +277,10 @@ class ClipVoicePool {
  * takes a lock, and the audio thread does not take locks. A clip that came into
  * the window between two rounds is found on the next one, which is a fraction
  * of the second the window is wide.
+ *
+ * Declare it after the pool it drives. Destruction runs in reverse, so the
+ * thread stops before the pool gives its readers back, which is the order
+ * ~ClipVoicePool requires and the one nothing else enforces.
  */
 class ClipVoiceThread final : private juce::Thread {
   public:

--- a/magda/engine/clip/ClipVoicePool.hpp
+++ b/magda/engine/clip/ClipVoicePool.hpp
@@ -59,31 +59,6 @@ namespace magda::engine {
  */
 constexpr double kCueAheadSeconds = 1.0;
 
-/**
- * @brief Readers one track may have standing by.
- *
- * Not the same ceiling as kMaxVoicesPerTrack and not measuring the same thing.
- * A voice is state and a reader is an open file and a chunk pool, a quarter of
- * a megabyte at the default settings, so this is the number that bounds memory:
- * four megabytes for a track with clips near the cursor, and nothing at all for
- * one without.
- *
- * Higher than the voice ceiling because a window is not an instant. Chopped
- * material puts a dozen clips inside a second while never sounding two of them
- * at once, and every one of them needs its own reader pointed at its own slice
- * of its own file. Sizing this to the voice count would have starved exactly
- * the material that needs the read-ahead most.
- *
- * A window holding more than this is not a clip that will not sound. The
- * soonest are provisioned first and a clip that has been passed gives its
- * reader back, so a queue of sequential clips rotates through the budget and
- * each one has its reader well before it is due. What it costs when the budget
- * really is exhausted is the read-ahead, which is a seek, which the stream
- * already counts as an underrun. What will not sound is counted by
- * @ref ClipVoicePool::overSubscribed and by ClipAudioSource::starvedVoices.
- */
-constexpr int kMaxReadersPerTrack = 16;
-
 class ClipVoicePool {
   public:
     /**
@@ -155,6 +130,15 @@ class ClipVoicePool {
      * clip in the window already provisioned opens nothing, retires nothing and
      * publishes nothing, so an idle session is not swapping a table at a
      * hundred hertz and making the callback wait for each one.
+     *
+     * A window holding more clips than kMaxVoicesPerTrack is not a failure and
+     * is not reported as one. The ceiling is per instant and a window is a
+     * second of timeline: a lane of slices fills it many times over while never
+     * asking for two voices at once, and the soonest are taken first, so a clip
+     * that has been passed gives its reader back to the one behind it long
+     * before that one is due. What a crowded window costs is the read-ahead of
+     * the clips at the far end of it, which is a seek, which the stream already
+     * counts as an underrun. What will not sound is @ref overSubscribed.
      */
     void service();
 
@@ -164,11 +148,15 @@ class ClipVoicePool {
     /**
      * @brief Clips the last round found stacked past what a track can sound.
      *
-     * Measured where it means something: the most clips overlapping at any one
-     * instant inside the window, less kMaxVoicesPerTrack. Not the number the
-     * reader budget turned away, which is a different and usually harmless
-     * thing (see kMaxReadersPerTrack): a lane of sequential clips can fill that
-     * budget many times over without two of them ever sounding together.
+     * The most that are live at once anywhere in the window, less
+     * kMaxVoicesPerTrack. Live rather than overlapping, and measured against
+     * the same block the callback renders: clips that share a callback each
+     * need their own voice for it whether or not they overlap by a sample, so
+     * measuring bare overlap here would report zero while the callback was
+     * dropping the extras.
+     *
+     * Not the number the window turned away, which is a different and usually
+     * harmless thing (see @ref service).
      *
      * A gauge rather than a tally, so it falls back to zero when the material
      * stops asking. Non-zero means clips that will not be heard, and

--- a/magda/engine/clip/ClipVoicePool.hpp
+++ b/magda/engine/clip/ClipVoicePool.hpp
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <string>
 
+#include "clip/ClipAudioSource.hpp"
 #include "clip/ClipSnapshot.hpp"
 #include "clip/ClipStreamFeed.hpp"
 #include "core/ClipTypes.hpp"
@@ -58,6 +59,45 @@ namespace magda::engine {
  * that is due.
  */
 constexpr double kCueAheadSeconds = 1.0;
+
+/**
+ * @brief How soon a clip may be due and still be given a reader in time.
+ *
+ * A round finds a clip, opens its file and points the stream at it; the
+ * prefetch thread notices on its next poll and reads. Until both have happened
+ * the clip has a reader that cannot answer, so a clip due sooner than this is
+ * one this pool was too late for however much budget it had.
+ *
+ * It is what the reader budget has to cover, and the reason that budget is not
+ * the voice ceiling. A callback can only sound kMaxVoicesPerTrack clips, but
+ * the pool has to have opened every clip that will sound before it next wakes,
+ * which is a different and larger set: sixteen readers is sixteen clips, and
+ * sixteen clips is a tenth of a second of chopped material or an hour of a
+ * ballad.
+ */
+constexpr double kReadAheadBridgeSeconds = 0.1;
+
+/**
+ * @brief Readers one track may have standing by.
+ *
+ * The voice ceiling plus room to be early. Every clip that is sounding needs a
+ * reader, and so does every clip that will start before this pool next gets to
+ * look, so the budget has to hold both: kMaxVoicesPerTrack for the first and as
+ * much again for the second. Sized to the voice ceiling instead, a lane would
+ * spend its whole budget on what is playing and open the next clip at the
+ * moment it was due, which is a seek, which is the one thing this file exists
+ * to avoid.
+ *
+ * Thirty-two is where the memory is too: each of these is an open file and a
+ * chunk pool, a quarter of a megabyte at the default settings, so eight
+ * megabytes for a track with clips near the cursor and nothing at all for one
+ * without.
+ *
+ * It does not make the pool keep up with anything. Material dense enough that
+ * even this cannot reach kReadAheadBridgeSeconds ahead is reported rather than
+ * silently late (@ref ClipVoicePool::unbridged).
+ */
+constexpr int kMaxReadersPerTrack = 2 * kMaxVoicesPerTrack;
 
 class ClipVoicePool {
   public:
@@ -131,14 +171,16 @@ class ClipVoicePool {
      * publishes nothing, so an idle session is not swapping a table at a
      * hundred hertz and making the callback wait for each one.
      *
-     * A window holding more clips than kMaxVoicesPerTrack is not a failure and
-     * is not reported as one. The ceiling is per instant and a window is a
-     * second of timeline: a lane of slices fills it many times over while never
-     * asking for two voices at once, and the soonest are taken first, so a clip
-     * that has been passed gives its reader back to the one behind it long
-     * before that one is due. What a crowded window costs is the read-ahead of
-     * the clips at the far end of it, which is a seek, which the stream already
-     * counts as an underrun. What will not sound is @ref overSubscribed.
+     * A window holding more clips than there are readers is not a failure and
+     * is not reported as one. A window is a second of timeline and the budget
+     * is spent soonest first, so a clip that has been passed gives its reader
+     * back to the one behind it, and a queue of clips rotates through. What a
+     * crowded window costs is the read-ahead of the clips at the far end of it,
+     * which is nothing until the far end comes close.
+     *
+     * When it does come close, that is @ref unbridged. When more clips want to
+     * sound at once than a callback can render, that is @ref overSubscribed.
+     * The two are separate because they fail separately.
      */
     void service();
 
@@ -164,6 +206,23 @@ class ClipVoicePool {
      */
     int overSubscribed() const {
         return overSubscribed_.load(std::memory_order_relaxed);
+    }
+
+    /**
+     * @brief Clips due too soon for the reader budget to have reached them.
+     *
+     * The other way a clip goes silent, and the one that has nothing to do with
+     * how many can sound at once: entries the budget turned away that start
+     * inside kReadAheadBridgeSeconds. Every one of them fits the voice ceiling
+     * and will still play nothing, because the round that could have opened it
+     * spent its budget on the clips in front of it.
+     *
+     * Non-zero means the material is denser than this track can read ahead for.
+     * Nothing in the engine fixes that by trying harder; what it can do is say
+     * so rather than let a lane of slices go quiet for no stated reason.
+     */
+    int unbridged() const {
+        return unbridged_.load(std::memory_order_relaxed);
     }
 
     /// Paths the factory declined, in the last round. A file that has moved or
@@ -254,6 +313,7 @@ class ClipVoicePool {
     Streams streams_;
 
     std::atomic<int> overSubscribed_{0};
+    std::atomic<int> unbridged_{0};
     std::atomic<int> unreadableFiles_{0};
     std::atomic<int> tablesPublished_{0};
 };

--- a/magda/engine/clip/FadeCurves.cpp
+++ b/magda/engine/clip/FadeCurves.cpp
@@ -1,0 +1,63 @@
+#include "clip/FadeCurves.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace magda::engine {
+
+namespace {
+
+constexpr float kHalfPi = 1.57079632679489661923f;
+constexpr float kPi = 3.14159265358979323846f;
+
+}  // namespace
+
+float fadeGain(FadeCurve curve, float alpha) {
+    alpha = std::clamp(alpha, 0.0f, 1.0f);
+
+    switch (curve) {
+        case FadeCurve::Convex:
+            return std::sin(alpha * kHalfPi);
+        case FadeCurve::Concave:
+            return 1.0f - std::cos(alpha * kHalfPi);
+        case FadeCurve::SCurve:
+            return (1.0f - alpha) * (1.0f - std::cos(alpha * kHalfPi)) +
+                   alpha * std::sin(alpha * kHalfPi);
+        case FadeCurve::Linear:
+            break;
+    }
+
+    // Linear, and anything a project file held that is not a curve. The
+    // snapshot compile already reported the latter as it substituted this.
+    return alpha;
+}
+
+void applyStartDeClick(juce::dsp::AudioBlock<float> audio, int fadeSamples) {
+    const auto length = std::min(static_cast<std::size_t>(std::max(0, fadeSamples)),
+                                 static_cast<std::size_t>(audio.getNumSamples()));
+    if (length == 0)
+        return;
+
+    for (std::size_t channel = 0; channel < audio.getNumChannels(); ++channel) {
+        auto* samples = audio.getChannelPointer(channel);
+        const auto discontinuity = samples[0];
+
+        // Nothing to step down from. A voice that begins on a zero crossing,
+        // and every voice that begins with a fade in, lands here.
+        if (discontinuity == 0.0f)
+            continue;
+
+        if (length == 1) {
+            samples[0] = 0.0f;
+            continue;
+        }
+
+        for (std::size_t i = 0; i < length; ++i) {
+            const auto phase = static_cast<float>(i) / static_cast<float>(length - 1);
+            const auto correction = 0.5f * (1.0f + std::cos(kPi * phase));
+            samples[i] -= discontinuity * correction;
+        }
+    }
+}
+
+}  // namespace magda::engine

--- a/magda/engine/clip/FadeCurves.hpp
+++ b/magda/engine/clip/FadeCurves.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
+
+#include "core/ClipInfo.hpp"
+
+/**
+ * @file FadeCurves.hpp
+ * @brief The four fade shapes, and the ramp that is not a fade.
+ *
+ * The shapes are the incumbent's, sample for sample. FadeCurve's values are
+ * pinned project-file integers that happen to equal Tracktion's own
+ * (ClipInfo.hpp), and the curves behind them have to match too: a fade that
+ * differs by a hair is a null-diff render that never nulls (#2040).
+ *
+ * A fade is a gain envelope over a stretch of the timeline, so nothing here
+ * knows about blocks or streams. Where a curve is applied is the voice's
+ * business (ClipVoice.hpp); what it is worth at a point along itself is this.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief Gain at @p alpha along a fade of this shape, rising from 0 to 1.
+ *
+ * @p alpha runs 0 to 1 across the fade. A fade out is the same curve read
+ * backwards, which is what passing 1 - alpha gets, and not a separate shape.
+ */
+float fadeGain(FadeCurve curve, float alpha);
+
+/**
+ * @brief Return the start of @p audio to zero without fading what follows it.
+ *
+ * The launch ramp (ClipInfo::launchFadeSamples), and deliberately not a fade:
+ * it subtracts the offset the first sample starts at, decaying that correction
+ * over @p fadeSamples, so a transient sitting on top of the offset survives
+ * intact. A gain fade would flatten the transient along with the step.
+ *
+ * What it is for is the discontinuity of starting mid-material: a locate into
+ * the middle of a clip, a loop wrap into one, a voice that begins where the
+ * file happens to be at full swing. A clip starting at its own edge has no
+ * offset to remove and this costs it nothing, which is why it can be applied
+ * wherever a voice begins rather than only where somebody decided it clicks.
+ *
+ * @p fadeSamples of 0 does nothing at all, which is how the leading transient
+ * is preserved exactly.
+ */
+void applyStartDeClick(juce::dsp::AudioBlock<float> audio, int fadeSamples);
+
+}  // namespace magda::engine

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 
+#include "clip/ClipVoicePool.hpp"
+
 namespace magda::engine {
 
 EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> plan,

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -91,6 +91,13 @@ void EngineSession::publishTransport(TransportSnapshot transport) {
 }
 
 void EngineSession::publishClips(std::shared_ptr<const ClipSnapshot> clips) {
+    // Both sides of the clip layer, from one call. The callback plays what the
+    // snapshot says and the pool opens readers for it, and the two disagreeing
+    // is a clip that is audible with nothing to read: exactly the sync problem
+    // that keeping one representation was supposed to have made impossible.
+    if (voices_ != nullptr)
+        voices_->setSnapshot(clips);
+
     clips_.publish(std::move(clips));
 }
 
@@ -134,6 +141,13 @@ void EngineSession::process(int numSamples, juce::AudioBuffer<float>& output) {
         // to where this piece belongs.
         juce::AudioBuffer<float> piece(output.getArrayOfWritePointers(), output.getNumChannels(),
                                        segment.startSample, segment.block.numSamples);
+
+        // Where the transport is, for the thread that reads ahead of it. A
+        // relaxed store of a double, before the block rather than after: the
+        // pool's window starts here, and a clip inside it has until the next
+        // round to be given a reader.
+        if (voices_ != nullptr)
+            voices_->setPosition(segment.block.startSeconds);
 
         (*render)->executor.process(table, segment.block, piece);
 

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "clip/ClipSnapshotFeed.hpp"
-#include "clip/ClipVoicePool.hpp"
 #include "exec/ParallelPlanExecutor.hpp"
 #include "exec/RenderThreadPool.hpp"
 #include "exec/RuntimeStateStore.hpp"
@@ -35,6 +34,10 @@
  */
 
 namespace magda::engine {
+
+/// Only ever held as a pointer here, and only ever used from the .cpp, so the
+/// session does not hand its own includers a thread and a stream pool.
+class ClipVoicePool;
 
 class EngineSession {
   public:

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "clip/ClipSnapshotFeed.hpp"
+#include "clip/ClipVoicePool.hpp"
 #include "exec/ParallelPlanExecutor.hpp"
 #include "exec/RenderThreadPool.hpp"
 #include "exec/RuntimeStateStore.hpp"
@@ -45,9 +46,17 @@ class EngineSession {
      * A host with a pool passes it here, once: it outlives every plan, and it
      * has to outlive this, because the epochs retired here are what let go of
      * it.
+     *
+     * @p voices provisions the readers a track's clips play through (#2035),
+     * and is null for a session with no arrangement audio: an offline render
+     * that reads straight through its files, and every test that publishes no
+     * clips. It is passed here rather than fed separately because a snapshot
+     * has to reach it and the audio thread together, and because it is what
+     * wants to know where the transport is.
      */
-    explicit EngineSession(RuntimeStateFactory& factory, RenderThreadPool* pool = nullptr)
-        : store_(factory), pool_(pool) {}
+    explicit EngineSession(RuntimeStateFactory& factory, RenderThreadPool* pool = nullptr,
+                           ClipVoicePool* voices = nullptr)
+        : store_(factory), pool_(pool), voices_(voices) {}
 
     /// What came of a publish. `published` false means the plan was refused
     /// and the previous one is still playing; true with messages means it is
@@ -218,6 +227,12 @@ class EngineSession {
     /// on the audio thread alone. Not owned, and shared across epochs: threads
     /// are made once and a structural edit is not a reason to remake them.
     RenderThreadPool* pool_ = nullptr;
+
+    /// Where the readers behind a track's clips come from, or null. Not owned
+    /// and not swapped with anything: like the clip feed, it is a property of
+    /// the session, and a structural edit must not cost a track the readers it
+    /// was playing through.
+    ClipVoicePool* voices_ = nullptr;
 
     PublishedRender published_;
     PublishedValues values_;

--- a/magda/engine/io/AudioFileReader.hpp
+++ b/magda/engine/io/AudioFileReader.hpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <string>
 
 /**
  * @file AudioFileReader.hpp
@@ -77,6 +78,34 @@ class JuceAudioFileReader final : public AudioFileReader {
 
   private:
     std::unique_ptr<juce::AudioFormatReader> reader_;
+};
+
+/**
+ * @brief Opens the files a snapshot names.
+ *
+ * Implemented by the host for the same reason the reader is an interface: which
+ * formats exist and where a path points are the host's business, and the engine
+ * is handed something that can already read. A snapshot carries paths because
+ * that is what the model has; turning one into a reader happens here.
+ *
+ * One reader per call, never a shared one. A reader is a position as well as a
+ * file, so two clips over one file need two of them (AudioFileReader::read).
+ */
+class AudioFileReaderFactory {
+  public:
+    virtual ~AudioFileReaderFactory() = default;
+
+    /**
+     * @brief A reader over @p path, or null when there is not one to be had.
+     *
+     * Off the audio thread, and allowed to take as long as opening a file
+     * takes: whoever calls this is a thread that may wait for a disk.
+     *
+     * Null is the ordinary answer for a file that has moved, been deleted or
+     * cannot be decoded. The caller reports it and plays silence; nothing here
+     * throws and nothing retries behind the caller's back.
+     */
+    virtual std::unique_ptr<AudioFileReader> open(const std::string& path) = 0;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/io/PrefetchStream.cpp
+++ b/magda/engine/io/PrefetchStream.cpp
@@ -35,6 +35,15 @@ PrefetchStream::PrefetchStream(std::unique_ptr<AudioFileReader> reader,
     }
 }
 
+void PrefetchStream::startAt(std::int64_t sourceStart) {
+    // Both cursors, and neither generation. Nothing has been read for the
+    // position this leaves behind, so there is nothing to invalidate; leaving
+    // the two sides on the generation they were born with is exactly what keeps
+    // the first fill from being read for one position and dropped for another.
+    nextSample_ = sourceStart;
+    fillPosition_ = sourceStart;
+}
+
 void PrefetchStream::seek(std::int64_t sourceStart) {
     // Publish and return. Everything the callback owns is left alone, which is
     // what makes this safe to call while the stream is playing rather than

--- a/magda/engine/io/PrefetchStream.hpp
+++ b/magda/engine/io/PrefetchStream.hpp
@@ -80,6 +80,24 @@ class PrefetchStream {
     bool fill();
 
     /**
+     * @brief Point the reader before anything is reading it at all.
+     *
+     * Before the stream is registered with a prefetch thread and before any
+     * block has read from it, on the thread that made it. Not a seek and not a
+     * cue: it moves both cursors while there is nobody to disagree with, so
+     * there is no generation to bump, nothing in flight to throw away, and no
+     * block to wait for.
+     *
+     * What it is for is that a stream is made for a clip, and a clip starts
+     * somewhere. Without this a new stream spends its first reads on the
+     * material at sample zero, which is not what it was opened for, and the
+     * cue that redirects it cannot be taken up until a callback has run
+     * (@ref applyPendingCue). Every one of those reads would then be thrown
+     * away, and the reader would start again from behind.
+     */
+    void startAt(std::int64_t sourceStart);
+
+    /**
      * @brief Point the reader at a position before anything asks for it.
      *
      * From any thread that is not the audio thread, at any time: whoever

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -261,6 +261,8 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_offline_render.cpp)
     list(APPEND TEST_SOURCES test_engine_taps.cpp)
     list(APPEND TEST_SOURCES test_clip_snapshot.cpp)
+    list(APPEND TEST_SOURCES test_clip_voice.cpp)
+    list(APPEND TEST_SOURCES test_clip_voice_pool.cpp)
 endif()
 
 # Create test executable

--- a/tests/test_clip_voice.cpp
+++ b/tests/test_clip_voice.cpp
@@ -168,9 +168,9 @@ struct Rig {
     /// A reader standing by for one entry. Returned so a test can read its
     /// underrun count.
     PrefetchStream& give(magda::ClipId clipId, magda::EventId eventId,
-                         std::unique_ptr<magda::engine::AudioFileReader> reader) {
-        auto stream = std::make_shared<PrefetchStream>(std::move(reader), context(),
-                                                       magda::engine::PrefetchSettings{256, 8});
+                         std::unique_ptr<magda::engine::AudioFileReader> reader,
+                         magda::engine::PrefetchSettings settings = {256, 8}) {
+        auto stream = std::make_shared<PrefetchStream>(std::move(reader), context(), settings);
         auto& created = *stream;
         table.entries.push_back(ClipStreamTable::Entry{kTrack, clipId, eventId, std::move(stream)});
         return created;
@@ -228,7 +228,8 @@ struct Rig {
     }
 
     void render(const BlockInfo& block) {
-        fill();
+        if (autoFill)
+            fill();
         source.render(block, juce::dsp::AudioBlock<float>(output));
     }
 
@@ -260,6 +261,10 @@ struct Rig {
     ClipAudioSource source{kTrack, clips, streams};
     ClipStreamTable table;
     juce::AudioBuffer<float> output;
+
+    /// Off, a test can run the callback further than the reader has got, which
+    /// is how a block that comes back half filled is arranged on purpose.
+    bool autoFill = true;
 
     int next_ = 0;
 };
@@ -508,6 +513,41 @@ TEST_CASE("The launch ramp takes the step out of a voice that begins mid-materia
         rig.advance();
         REQUIRE(rig.at(0) == approx(1.0f));
     }
+}
+
+TEST_CASE("A block the reader half filled is not a voice that carried on",
+          "[engine][clip][voice]") {
+    // A read that comes back short leaves the rest of the block silent, so the
+    // block after it starts mid-material exactly as one after a total underrun
+    // does. Counting any delivery at all as carrying on would let that one
+    // resume out of silence with no ramp to take the step out of it.
+    Rig rig;
+
+    auto clip = clipOver(1, blocks(0, 1000));
+    clip.launchFadeSamples = 32;
+    rig.lane.audio.push_back(clip);
+
+    // A pool of 288 samples, which four blocks of 64 do not divide: the fifth
+    // gets the 32 samples that are left and nothing more.
+    rig.give(1, 1, std::make_unique<ConstantReader>(1.0f), {96, 3});
+    rig.publish();
+
+    rig.fill();
+    rig.autoFill = false;
+
+    rig.advance(4);
+    REQUIRE(rig.at(kBlockSize - 1) == approx(1.0f));
+
+    rig.advance();
+    REQUIRE(rig.at(31) == approx(1.0f));
+    REQUIRE(rig.at(32) == approx(0.0f));
+
+    // The reader catches up, and the block that resumes is ramped.
+    rig.autoFill = true;
+    rig.advance();
+
+    REQUIRE(rig.at(0) == approx(0.0f));
+    REQUIRE(rig.at(31) == approx(1.0f));
 }
 
 TEST_CASE("A launch ramp of zero preserves the leading transient exactly",

--- a/tests/test_clip_voice.cpp
+++ b/tests/test_clip_voice.cpp
@@ -1,0 +1,642 @@
+#include <algorithm>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#include "clip/ClipAudioSource.hpp"
+#include "clip/FadeCurves.hpp"
+#include "io/ClipPlacement.hpp"
+
+/**
+ * What a track's audio clips sum to (#2035), on the audio thread.
+ *
+ * The streams are hand-built here rather than provisioned: what a voice does
+ * with a reader that is already standing by is this file's question, and where
+ * that reader came from is test_clip_voice_pool.cpp's.
+ *
+ * Everything rolls. A test that skipped from one block to a distant one would
+ * be testing a locate rather than playback, because a read that does not
+ * continue the last one is a seek and costs a block of silence (#2016). So the
+ * rig cues its readers where the transport is about to be, runs the blocks in
+ * between, and probes the one it cares about.
+ *
+ * Times are whole blocks, so a probe lands on a block boundary and a sample of
+ * the counting reader can be named exactly.
+ */
+
+using magda::engine::AudioClipPlayback;
+using magda::engine::AudioEventPlayback;
+using magda::engine::BlockInfo;
+using magda::engine::ClipAudioSource;
+using magda::engine::ClipPlacement;
+using magda::engine::ClipSnapshot;
+using magda::engine::ClipSnapshotFeed;
+using magda::engine::ClipStreamFeed;
+using magda::engine::ClipStreamTable;
+using magda::engine::PrefetchStream;
+using magda::engine::RenderContext;
+using magda::engine::SnapshotSpan;
+using magda::engine::TrackClipPlayback;
+
+namespace {
+
+constexpr double kSampleRate = 44100.0;
+constexpr int kBlockSize = 64;
+constexpr magda::TrackId kTrack = 7;
+
+/// When the block with this index begins.
+double blockTime(int index) {
+    return index * static_cast<double>(kBlockSize) / kSampleRate;
+}
+
+/// Sample n reads back as n, so where a sample came from is readable off the
+/// value and a position that slipped is visible rather than inferred.
+class CountingReader final : public magda::engine::AudioFileReader {
+  public:
+    std::int64_t lengthInSamples() const override {
+        return 10000000;
+    }
+    double sampleRate() const override {
+        return kSampleRate;
+    }
+    int numChannels() const override {
+        return 2;
+    }
+
+    int read(juce::AudioBuffer<float>& destination, int destinationOffset, std::int64_t startSample,
+             int numSamples) override {
+        for (auto channel = 0; channel < destination.getNumChannels(); ++channel)
+            for (auto sample = 0; sample < numSamples; ++sample)
+                destination.setSample(channel, destinationOffset + sample,
+                                      static_cast<float>(startSample + sample));
+        return numSamples;
+    }
+};
+
+/// Every sample the same, so a gain, a fade or a pan is readable straight off
+/// the output without having to divide by what the material was doing.
+class ConstantReader final : public magda::engine::AudioFileReader {
+  public:
+    explicit ConstantReader(float value = 1.0f) : value_(value) {}
+
+    std::int64_t lengthInSamples() const override {
+        return 10000000;
+    }
+    double sampleRate() const override {
+        return kSampleRate;
+    }
+    int numChannels() const override {
+        return 2;
+    }
+
+    int read(juce::AudioBuffer<float>& destination, int destinationOffset, std::int64_t,
+             int numSamples) override {
+        for (auto channel = 0; channel < destination.getNumChannels(); ++channel)
+            for (auto sample = 0; sample < numSamples; ++sample)
+                destination.setSample(channel, destinationOffset + sample, value_);
+        return numSamples;
+    }
+
+  private:
+    float value_;
+};
+
+RenderContext context() {
+    return RenderContext{kSampleRate, kBlockSize, 2};
+}
+
+Catch::Approx approx(float value) {
+    return Catch::Approx(value).margin(1e-4);
+}
+
+/// A span from its seconds. The beats ride along at 120 bpm and nothing on the
+/// audio path reads them: a source is handed seconds (ClipPlacement.hpp).
+SnapshotSpan seconds(double start, double end) {
+    SnapshotSpan span;
+    span.startBeat = start * 2.0;
+    span.endBeat = end * 2.0;
+    span.startSeconds = start;
+    span.endSeconds = end;
+    return span;
+}
+
+SnapshotSpan blocks(int firstBlock, int lastBlock) {
+    return seconds(blockTime(firstBlock), blockTime(lastBlock));
+}
+
+BlockInfo blockFrom(double startSeconds, bool continuous = true) {
+    BlockInfo block;
+    block.numSamples = kBlockSize;
+    block.playing = true;
+    block.startSeconds = startSeconds;
+    block.endSeconds = startSeconds + kBlockSize / kSampleRate;
+    block.startBeat = startSeconds * 2.0;
+    block.endBeat = block.endSeconds * 2.0;
+    block.continuous = continuous;
+    return block;
+}
+
+AudioClipPlayback clipOver(magda::ClipId id, SnapshotSpan span, std::int64_t anchor = 0) {
+    AudioClipPlayback clip;
+    clip.clipId = id;
+    clip.span = span;
+    clip.launchFadeSamples = 0;  // the ramp is its own test
+
+    AudioEventPlayback event;
+    event.eventId = id;
+    event.sourceId = id;
+    event.filePath = "take.wav";
+    event.sourceSampleRate = kSampleRate;
+    event.sourceDurationSeconds = 1000.0;
+    event.span = span;
+    event.anchorSamples = anchor;
+    clip.events.push_back(std::move(event));
+
+    return clip;
+}
+
+/// A track's clips, the readers behind them, and a transport that rolls.
+struct Rig {
+    Rig() {
+        source.prepare(context());
+        output.setSize(2, kBlockSize);
+        output.clear();
+    }
+
+    /// A reader standing by for one entry. Returned so a test can read its
+    /// underrun count.
+    PrefetchStream& give(magda::ClipId clipId, magda::EventId eventId,
+                         std::unique_ptr<magda::engine::AudioFileReader> reader) {
+        auto stream = std::make_shared<PrefetchStream>(std::move(reader), context(),
+                                                       magda::engine::PrefetchSettings{256, 8});
+        auto& created = *stream;
+        table.entries.push_back(ClipStreamTable::Entry{kTrack, clipId, eventId, std::move(stream)});
+        return created;
+    }
+
+    void publish() {
+        publish(lane);
+    }
+
+    void publish(const TrackClipPlayback& track) {
+        auto compiled = std::make_shared<ClipSnapshot>();
+        compiled->tracks.push_back(track);
+        clips.publish(std::move(compiled));
+
+        // Sorted the way ClipStreamTable::rangeFor searches it.
+        std::sort(table.entries.begin(), table.entries.end(),
+                  [](const ClipStreamTable::Entry& a, const ClipStreamTable::Entry& b) {
+                      if (a.trackId != b.trackId)
+                          return a.trackId < b.trackId;
+                      if (a.clipId != b.clipId)
+                          return a.clipId < b.clipId;
+                      return a.eventId < b.eventId;
+                  });
+        streams.publish(std::make_shared<const ClipStreamTable>(table));
+    }
+
+    /**
+     * @brief Put the transport @p lead blocks before @p targetBlock and roll to it.
+     *
+     * The cue is where the transport is about to be, which is what the pool
+     * does, and the block it is given in is where the callback hands it over.
+     * The output is left holding the block that starts at @p targetBlock.
+     */
+    void start(int targetBlock, int lead) {
+        next_ = targetBlock - lead;
+
+        for (const auto& entry : table.entries) {
+            const auto* event = eventOf(entry.clipId, entry.eventId);
+            REQUIRE(event != nullptr);
+            const ClipPlacement placement{event->span.startSeconds, event->span.endSeconds,
+                                          event->anchorSamples};
+            entry.stream->seek(magda::engine::sourceSampleAt(
+                placement, std::max(blockTime(next_), event->span.startSeconds), kSampleRate));
+        }
+
+        advance(lead + 1);
+    }
+
+    /// The next block, and the one after. Leaves the output holding the last.
+    void advance(int count = 1) {
+        for (auto index = 0; index < count; ++index) {
+            render(blockFrom(blockTime(next_)));
+            ++next_;
+        }
+    }
+
+    void render(const BlockInfo& block) {
+        fill();
+        source.render(block, juce::dsp::AudioBlock<float>(output));
+    }
+
+    void fill() {
+        auto worked = true;
+        while (worked) {
+            worked = false;
+            for (const auto& entry : table.entries)
+                worked = entry.stream->fill() || worked;
+        }
+    }
+
+    float at(int sample, int channel = 0) const {
+        return output.getSample(channel, sample);
+    }
+
+    const AudioEventPlayback* eventOf(magda::ClipId clipId, magda::EventId eventId) const {
+        for (const auto& clip : lane.audio)
+            if (clip.clipId == clipId)
+                for (const auto& event : clip.events)
+                    if (event.eventId == eventId)
+                        return &event;
+        return nullptr;
+    }
+
+    TrackClipPlayback lane{kTrack, {}, {}};
+    ClipSnapshotFeed clips;
+    ClipStreamFeed streams;
+    ClipAudioSource source{kTrack, clips, streams};
+    ClipStreamTable table;
+    juce::AudioBuffer<float> output;
+
+    int next_ = 0;
+};
+
+}  // namespace
+
+TEST_CASE("A track plays the clips the snapshot placed on it", "[engine][clip][voice]") {
+    // Blocks 100 to 300 of the timeline, playing the file from its tenth sample.
+    Rig rig;
+    rig.lane.audio.push_back(clipOver(1, blocks(100, 300), 10));
+    rig.give(1, 1, std::make_unique<CountingReader>());
+    rig.publish();
+
+    SECTION("nothing before it starts") {
+        rig.start(50, 40);
+        for (auto sample = 0; sample < kBlockSize; ++sample)
+            REQUIRE(rig.at(sample) == approx(0.0f));
+    }
+
+    SECTION("the file from where it was trimmed, from the block it starts in") {
+        rig.start(100, 40);
+        for (auto sample = 0; sample < kBlockSize; ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(rig.at(sample) == approx(static_cast<float>(10 + sample)));
+        }
+    }
+
+    SECTION("in step with the timeline, block after block") {
+        rig.start(100, 40);
+        for (auto block = 0; block < 40; ++block) {
+            INFO("block " << block);
+            REQUIRE(rig.at(0) == approx(static_cast<float>(10 + block * kBlockSize)));
+            rig.advance();
+        }
+    }
+
+    SECTION("and nothing once the span is over") {
+        rig.start(300, 40);
+        for (auto sample = 0; sample < kBlockSize; ++sample)
+            REQUIRE(rig.at(sample) == approx(0.0f));
+    }
+
+    SECTION("a stopped transport is no material rather than a held sample") {
+        rig.start(150, 40);
+        REQUIRE(rig.at(0) != approx(0.0f));
+
+        auto stopped = blockFrom(blockTime(200));
+        stopped.playing = false;
+        stopped.endSeconds = stopped.startSeconds;
+        stopped.endBeat = stopped.startBeat;
+        rig.render(stopped);
+
+        for (auto sample = 0; sample < kBlockSize; ++sample)
+            REQUIRE(rig.at(sample) == approx(0.0f));
+    }
+}
+
+TEST_CASE("A clip cued before it starts plays without a gap", "[engine][clip][voice]") {
+    // The reason the pool runs ahead of the transport. Nothing reads this
+    // stream until the clip starts, so the cue has to reach it through the
+    // blocks where it plays nothing.
+    Rig rig;
+    rig.lane.audio.push_back(clipOver(1, blocks(200, 400), 500));
+    auto& stream = rig.give(1, 1, std::make_unique<CountingReader>());
+    rig.publish();
+
+    rig.start(200, 60);
+
+    REQUIRE(rig.at(0) == approx(500.0f));
+    REQUIRE(rig.at(kBlockSize - 1) == approx(static_cast<float>(500 + kBlockSize - 1)));
+    CHECK(stream.underruns() == 0);
+}
+
+TEST_CASE("Overlapping clips sum, because the snapshot already decided they both play",
+          "[engine][clip][voice]") {
+    Rig rig;
+    rig.lane.audio.push_back(clipOver(1, blocks(0, 400)));
+    rig.lane.audio.push_back(clipOver(2, blocks(200, 600)));
+
+    rig.give(1, 1, std::make_unique<ConstantReader>(1.0f));
+    rig.give(2, 2, std::make_unique<ConstantReader>(1.0f));
+    rig.publish();
+
+    SECTION("one clip alone is itself") {
+        rig.start(100, 60);
+        REQUIRE(rig.at(0) == approx(1.0f));
+    }
+
+    SECTION("two across the overlap are both") {
+        rig.start(300, 60);
+        REQUIRE(rig.at(0) == approx(2.0f));
+    }
+
+    SECTION("and one again once the first has ended") {
+        rig.start(500, 60);
+        REQUIRE(rig.at(0) == approx(1.0f));
+    }
+}
+
+TEST_CASE("An interior silence punches a hole without moving the reader", "[engine][clip][voice]") {
+    // A clip dropped inside another leaves a hole in the middle of this one
+    // (#2003). What plays after the hole is what would have played had it not
+    // been there: the material goes on running underneath, muted.
+    Rig rig;
+
+    auto clip = clipOver(1, blocks(100, 1000));
+    clip.silenced.push_back(blocks(400, 700));
+    rig.lane.audio.push_back(clip);
+
+    auto& stream = rig.give(1, 1, std::make_unique<CountingReader>());
+    rig.publish();
+
+    // Rolled into from before the clip, so the reader is already ahead and the
+    // only thing that could cost an underrun here is the hole.
+    rig.start(250, 250);
+    REQUIRE(rig.at(0) == approx(static_cast<float>((250 - 100) * kBlockSize)));
+
+    rig.advance(300);  // block 550, inside the hole
+    for (auto sample = 0; sample < kBlockSize; ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(rig.at(sample) == approx(0.0f));
+    }
+
+    rig.advance(300);  // block 850, past it
+    REQUIRE(rig.at(0) == approx(static_cast<float>((850 - 100) * kBlockSize)));
+
+    // Which is the whole point: reading straight across the hole is what keeps
+    // this from being a seek on the far side of it.
+    CHECK(stream.underruns() == 0);
+}
+
+TEST_CASE("A hole that opens mid-block cuts exactly where it starts", "[engine][clip][voice]") {
+    Rig rig;
+
+    auto clip = clipOver(1, blocks(0, 400));
+    clip.silenced.push_back(seconds(blockTime(200) + 20.0 / kSampleRate, blockTime(300)));
+    rig.lane.audio.push_back(clip);
+
+    rig.give(1, 1, std::make_unique<ConstantReader>(1.0f));
+    rig.publish();
+
+    rig.start(200, 100);
+
+    for (auto sample = 0; sample < 20; ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(rig.at(sample) == approx(1.0f));
+    }
+    for (auto sample = 20; sample < kBlockSize; ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(rig.at(sample) == approx(0.0f));
+    }
+}
+
+TEST_CASE("The resolved fades shape the edges of the audible span", "[engine][clip][voice]") {
+    // The span, not the placement. What the lane leaves audible is what a
+    // listener hears begin and end, and it is the only edge the snapshot gives.
+    Rig rig;
+
+    auto clip = clipOver(1, blocks(100, 2100));
+    clip.fadeInSeconds = blockTime(400);
+    clip.fadeOutSeconds = blockTime(400);
+    rig.lane.audio.push_back(clip);
+
+    rig.give(1, 1, std::make_unique<ConstantReader>(1.0f));
+    rig.publish();
+
+    SECTION("it comes in from nothing") {
+        rig.start(100, 100);
+        REQUIRE(rig.at(0) == approx(0.0f));
+        REQUIRE(rig.at(kBlockSize - 1) ==
+                approx(static_cast<float>(kBlockSize - 1) / (400.0f * kBlockSize)));
+    }
+
+    SECTION("half way up at half way along") {
+        rig.start(300, 300);
+        REQUIRE(rig.at(0) == approx(0.5f));
+    }
+
+    SECTION("flat once it is in") {
+        rig.start(700, 300);
+        REQUIRE(rig.at(0) == approx(1.0f));
+    }
+
+    SECTION("and half way back down at half way through the fade out") {
+        rig.start(1900, 300);
+        REQUIRE(rig.at(0) == approx(0.5f));
+    }
+
+    SECTION("a curve is the shape it names") {
+        auto curved = rig.lane;
+        curved.audio[0].fadeInCurve = magda::FadeCurve::Convex;
+        rig.publish(curved);
+
+        rig.start(300, 300);
+        REQUIRE(rig.at(0) == approx(magda::engine::fadeGain(magda::FadeCurve::Convex, 0.5f)));
+    }
+}
+
+TEST_CASE("A clip plays at its own gain and pan", "[engine][clip][voice]") {
+    Rig rig;
+
+    auto clip = clipOver(1, blocks(0, 1000));
+    clip.gainDb = -6.0f;
+    clip.pan = 0.5f;
+    rig.lane.audio.push_back(clip);
+
+    rig.give(1, 1, std::make_unique<ConstantReader>(1.0f));
+    rig.publish();
+
+    rig.start(300, 100);
+
+    // The incumbent's law: linear, and hotter on one side rather than quieter
+    // on the other, because a bounce has to match what was heard.
+    const auto gain = juce::Decibels::decibelsToGain(-6.0f);
+    REQUIRE(rig.at(0, 0) == approx(gain - 0.5f * gain));
+    REQUIRE(rig.at(0, 1) == approx(gain + 0.5f * gain));
+}
+
+TEST_CASE("The launch ramp takes the step out of a voice that begins mid-material",
+          "[engine][clip][voice]") {
+    Rig rig;
+
+    auto clip = clipOver(1, blocks(0, 1000));
+    clip.launchFadeSamples = 32;
+    rig.lane.audio.push_back(clip);
+
+    rig.give(1, 1, std::make_unique<ConstantReader>(1.0f));
+    rig.publish();
+
+    // A locate: one block to hand the cue over, and the next is the voice's
+    // first, landing in material that is already at full swing.
+    rig.start(500, 1);
+
+    REQUIRE(rig.at(0) == approx(0.0f));
+    REQUIRE(rig.at(31) == approx(1.0f));
+    REQUIRE(rig.at(32) == approx(1.0f));
+
+    // Monotonic on the way up: a correction that overshoots is a click of its
+    // own rather than the absence of one.
+    for (auto sample = 1; sample < 32; ++sample) {
+        INFO("sample " << sample);
+        REQUIRE(rig.at(sample) >= rig.at(sample - 1));
+    }
+
+    SECTION("and it is gone by the next block") {
+        rig.advance();
+        REQUIRE(rig.at(0) == approx(1.0f));
+    }
+}
+
+TEST_CASE("A launch ramp of zero preserves the leading transient exactly",
+          "[engine][clip][voice]") {
+    Rig rig;
+
+    auto clip = clipOver(1, blocks(0, 1000));
+    clip.launchFadeSamples = 0;
+    rig.lane.audio.push_back(clip);
+
+    rig.give(1, 1, std::make_unique<ConstantReader>(1.0f));
+    rig.publish();
+
+    rig.start(500, 1);
+    REQUIRE(rig.at(0) == approx(1.0f));
+}
+
+TEST_CASE("A clip with no reader standing by is counted, not quietly dropped",
+          "[engine][clip][voice]") {
+    Rig rig;
+    rig.lane.audio.push_back(clipOver(1, blocks(0, 400)));
+    rig.publish();  // no stream given
+
+    REQUIRE(rig.source.starvedVoices() == 0);
+
+    rig.start(100, 0);
+
+    for (auto sample = 0; sample < kBlockSize; ++sample)
+        REQUIRE(rig.at(sample) == approx(0.0f));
+    CHECK(rig.source.starvedVoices() == 1);
+
+    rig.advance();
+    CHECK(rig.source.starvedVoices() == 2);
+}
+
+TEST_CASE("A track wanting more simultaneous clips than it has voices says so",
+          "[engine][clip][voice]") {
+    Rig rig;
+
+    constexpr auto kTooMany = magda::engine::kMaxVoicesPerTrack + 1;
+    for (auto index = 0; index < kTooMany; ++index) {
+        const auto id = index + 1;
+        rig.lane.audio.push_back(clipOver(id, blocks(0, 1000)));
+        rig.give(id, id, std::make_unique<ConstantReader>(1.0f));
+    }
+
+    rig.publish();
+    rig.start(300, 100);
+
+    // Every voice there is, and one clip that says it did not get one.
+    REQUIRE(rig.at(0) == approx(static_cast<float>(magda::engine::kMaxVoicesPerTrack)));
+    CHECK(rig.source.starvedVoices() > 0);
+}
+
+TEST_CASE("A voice is let go when its clip stops, and its slot is reusable",
+          "[engine][clip][voice]") {
+    // With every voice spoken for, a clip that ends has to release its slot in
+    // the block it ends in, or the clip starting next block finds none free.
+    Rig rig;
+
+    constexpr auto kVoices = magda::engine::kMaxVoicesPerTrack;
+    for (auto index = 0; index < kVoices; ++index) {
+        const auto id = index + 1;
+        rig.lane.audio.push_back(clipOver(id, blocks(0, 500)));
+        rig.give(id, id, std::make_unique<ConstantReader>(1.0f));
+    }
+
+    // One more that starts where the others stop.
+    rig.lane.audio.push_back(clipOver(kVoices + 1, blocks(500, 1000)));
+    rig.give(kVoices + 1, kVoices + 1, std::make_unique<ConstantReader>(1.0f));
+
+    rig.publish();
+
+    rig.start(300, 100);
+    REQUIRE(rig.at(0) == approx(static_cast<float>(kVoices)));
+
+    const auto before = rig.source.starvedVoices();
+    rig.advance(300);  // block 600, past the handover
+
+    REQUIRE(rig.at(0) == approx(1.0f));
+    CHECK(rig.source.starvedVoices() == before);
+}
+
+TEST_CASE("A track with nothing published renders silence rather than the buffer's contents",
+          "[engine][clip][voice]") {
+    Rig rig;
+
+    juce::AudioBuffer<float> dirty(2, kBlockSize);
+    for (auto channel = 0; channel < 2; ++channel)
+        for (auto sample = 0; sample < kBlockSize; ++sample)
+            dirty.setSample(channel, sample, 0.5f);
+
+    rig.source.render(blockFrom(blockTime(100)), juce::dsp::AudioBlock<float>(dirty));
+
+    for (auto sample = 0; sample < kBlockSize; ++sample)
+        REQUIRE(dirty.getSample(0, sample) == approx(0.0f));
+}
+
+TEST_CASE("The fade curves are the shapes the incumbent draws", "[engine][clip][fades]") {
+    using magda::FadeCurve;
+    using magda::engine::fadeGain;
+
+    const auto every = {FadeCurve::Linear, FadeCurve::Convex, FadeCurve::Concave,
+                        FadeCurve::SCurve};
+
+    SECTION("every curve runs from silence to unity") {
+        for (const auto curve : every) {
+            INFO("curve " << static_cast<int>(curve));
+            REQUIRE(fadeGain(curve, 0.0f) == approx(0.0f));
+            REQUIRE(fadeGain(curve, 1.0f) == approx(1.0f));
+        }
+    }
+
+    SECTION("and each one is the shape it is named after") {
+        REQUIRE(fadeGain(FadeCurve::Linear, 0.5f) == approx(0.5f));
+        REQUIRE(fadeGain(FadeCurve::Convex, 0.5f) > 0.5f);
+        REQUIRE(fadeGain(FadeCurve::Concave, 0.5f) < 0.5f);
+        REQUIRE(fadeGain(FadeCurve::SCurve, 0.5f) == approx(0.5f));
+    }
+
+    SECTION("monotonic, so a fade never dips on its way") {
+        for (const auto curve : every) {
+            auto previous = 0.0f;
+            for (auto step = 0; step <= 100; ++step) {
+                const auto gain = fadeGain(curve, static_cast<float>(step) / 100.0f);
+                INFO("curve " << static_cast<int>(curve) << " step " << step);
+                REQUIRE(gain >= previous - 1e-6f);
+                previous = gain;
+            }
+        }
+    }
+}

--- a/tests/test_clip_voice_pool.cpp
+++ b/tests/test_clip_voice_pool.cpp
@@ -24,6 +24,7 @@ using magda::engine::ClipSnapshot;
 using magda::engine::ClipSnapshotFeed;
 using magda::engine::ClipVoicePool;
 using magda::engine::kCueAheadSeconds;
+using magda::engine::kMaxReadersPerTrack;
 using magda::engine::kMaxVoicesPerTrack;
 using magda::engine::PrefetchThread;
 using magda::engine::RenderContext;
@@ -241,9 +242,9 @@ TEST_CASE("A lane stacking more clips than a track has voices reports the excess
     pool.setPosition(1.0);
     pool.service();
 
-    // Every reader the track may have, and three reported, because that is how
-    // many of them will not be heard.
-    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack));
+    // A reader each, because the budget is not the ceiling, and three
+    // reported, because that is how many of them will not be heard.
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack + 3));
     CHECK(pool.overSubscribed() == 3);
 
     SECTION("and stops reporting once the lane thins out") {
@@ -301,21 +302,25 @@ TEST_CASE("Clips that follow one another are not clips stacked on one another",
 
 TEST_CASE("Slices too short to fill a callback are concurrent, and say so",
           "[engine][clip][pool]") {
-    // The other end of the same question. Clips shorter than a block share one,
-    // so a callback needs a voice for each of them however little they overlap.
-    // Measuring bare overlap would report this track in the clear while the
-    // callback was dropping every slice past the sixteenth.
+    // Clips shorter than a block share one, so a callback needs a voice for
+    // each of them however little they overlap. Measuring bare overlap would
+    // report this track in the clear while the callback was dropping every
+    // slice past the sixteenth.
+    //
+    // Three samples each, back to back: a block spans twenty-two of them, and
+    // the whole run fits inside the reader budget, so the only thing this can
+    // be short of is voices.
     TestFiles files;
     PrefetchThread reader;
     ClipVoicePool pool(files, reader, context());
 
-    // Four samples each, back to back: a block spans seventeen of them.
-    constexpr auto kSliceSeconds = 4.0 / kSampleRate;
+    constexpr auto kSliceSeconds = 3.0 / kSampleRate;
+    constexpr auto kSlices = kMaxReadersPerTrack;
 
     std::vector<AudioClipPlayback> lane;
     TrackClipPlayback track;
     track.trackId = kTrack;
-    for (auto index = 0; index < kMaxVoicesPerTrack * 2; ++index) {
+    for (auto index = 0; index < kSlices; ++index) {
         lane.push_back(clipAt(index + 1, index * kSliceSeconds, (index + 1) * kSliceSeconds));
         track.audio.push_back(lane.back());
     }
@@ -324,6 +329,9 @@ TEST_CASE("Slices too short to fill a callback are concurrent, and say so",
     pool.setPosition(0.0);
     pool.service();
 
+    // Every one of them has a reader, so nothing here is waiting on a disk.
+    REQUIRE(pool.streamCount() == static_cast<std::size_t>(kSlices));
+    CHECK(pool.unbridged() == 0);
     CHECK(pool.overSubscribed() > 0);
 
     // And the callback is where it costs something.
@@ -340,6 +348,61 @@ TEST_CASE("Slices too short to fill a callback are concurrent, and say so",
     CHECK(source.starvedVoices() > 0);
 }
 
+TEST_CASE("A lane the budget cannot reach ahead of says so, and is not called stacked",
+          "[engine][clip][pool]") {
+    // The failure the voice ceiling has nothing to do with. Eight-sample
+    // slices: a callback wants nine of them at once, well inside the ceiling,
+    // but the whole reader budget covers a quarter of a millisecond of them and
+    // the pool will not look again for ten. Every clip past the budget fits
+    // and still plays nothing.
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    constexpr auto kSliceSeconds = 8.0 / kSampleRate;
+
+    std::vector<AudioClipPlayback> lane;
+    for (auto index = 0; index < kMaxReadersPerTrack * 4; ++index)
+        lane.push_back(clipAt(index + 1, index * kSliceSeconds, (index + 1) * kSliceSeconds));
+
+    pool.setSnapshot(snapshotOf(std::move(lane)));
+    pool.setPosition(0.0);
+    pool.service();
+
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxReadersPerTrack));
+
+    // Not too many at once. Too many too soon, which is its own count.
+    CHECK(pool.overSubscribed() == 0);
+    CHECK(pool.unbridged() > 0);
+}
+
+TEST_CASE("A clip that fits the ceiling is provisioned before the next round",
+          "[engine][clip][pool]") {
+    // What the reader budget is for. Sixteen clips sounding and more starting
+    // in the moments after: sized to the voice ceiling the budget would go
+    // entirely on what is playing, and every clip after it would be opened at
+    // the instant it was due, which is a seek.
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    std::vector<AudioClipPlayback> lane;
+    for (auto index = 0; index < kMaxVoicesPerTrack; ++index)
+        lane.push_back(clipAt(index + 1, 0.0, 4.0));
+
+    // And one starting inside the bridge, which is where a reader has to exist
+    // already for it to be ready in time.
+    const auto soon = magda::engine::kReadAheadBridgeSeconds / 2.0;
+    lane.push_back(clipAt(kMaxVoicesPerTrack + 1, soon, 4.0));
+
+    pool.setSnapshot(snapshotOf(std::move(lane)));
+    pool.setPosition(0.0);
+    pool.service();
+
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack + 1));
+    CHECK(pool.unbridged() == 0);
+}
+
 TEST_CASE("A window holding more clips than there are readers takes the soonest",
           "[engine][clip][pool]") {
     TestFiles files;
@@ -347,7 +410,7 @@ TEST_CASE("A window holding more clips than there are readers takes the soonest"
     ClipVoicePool pool(files, reader, context());
 
     std::vector<AudioClipPlayback> lane;
-    for (auto index = 0; index < kMaxVoicesPerTrack + 5; ++index)
+    for (auto index = 0; index < kMaxReadersPerTrack + 5; ++index)
         lane.push_back(clipAt(index + 1, index * 0.02, (index + 1) * 0.02));
 
     pool.setSnapshot(snapshotOf(std::move(lane)));
@@ -357,14 +420,15 @@ TEST_CASE("A window holding more clips than there are readers takes the soonest"
     // The budget is spent, and none of it is reported: nothing here will fail
     // to sound, because each slice is passed and gives its reader back long
     // before the ones behind it are due.
-    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack));
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxReadersPerTrack));
     CHECK(pool.overSubscribed() == 0);
+    CHECK(pool.unbridged() == 0);
 
     // Rolling past the first few hands their readers to the ones behind.
     pool.setPosition(0.1);
     pool.service();
 
-    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack));
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxReadersPerTrack));
 }
 
 TEST_CASE("A round that changes nothing does not swap a table", "[engine][clip][pool]") {
@@ -437,14 +501,14 @@ TEST_CASE("A clip that is sounding keeps its reader over one that has not starte
     // One long clip the transport is standing inside, and enough clips starting
     // just ahead of it to use up every reader twice over.
     lane.push_back(clipAt(1, 0.0, 10.0));
-    for (auto index = 0; index < kMaxVoicesPerTrack * 2; ++index)
+    for (auto index = 0; index < kMaxReadersPerTrack * 2; ++index)
         lane.push_back(clipAt(index + 2, 5.2 + index * 0.01, 9.0));
 
     pool.setSnapshot(snapshotOf(std::move(lane)));
     pool.setPosition(5.0);
     pool.service();
 
-    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack));
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxReadersPerTrack));
 
     // The clip that is playing is one of the ones that kept a reader: render a
     // block of it and it sounds.

--- a/tests/test_clip_voice_pool.cpp
+++ b/tests/test_clip_voice_pool.cpp
@@ -24,6 +24,7 @@ using magda::engine::ClipSnapshot;
 using magda::engine::ClipSnapshotFeed;
 using magda::engine::ClipVoicePool;
 using magda::engine::kCueAheadSeconds;
+using magda::engine::kMaxReadersPerTrack;
 using magda::engine::kMaxVoicesPerTrack;
 using magda::engine::PrefetchThread;
 using magda::engine::RenderContext;
@@ -231,6 +232,8 @@ TEST_CASE("A lane stacking more clips than a track has voices reports the excess
     PrefetchThread reader;
     ClipVoicePool pool(files, reader, context());
 
+    // All over the same stretch, so every one of them is asking to be heard at
+    // the same instant.
     std::vector<AudioClipPlayback> lane;
     for (auto index = 0; index < kMaxVoicesPerTrack + 3; ++index)
         lane.push_back(clipAt(index + 1, 0.0, 4.0));
@@ -239,7 +242,9 @@ TEST_CASE("A lane stacking more clips than a track has voices reports the excess
     pool.setPosition(1.0);
     pool.service();
 
-    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack));
+    // Readers for all of them, because that budget is about memory, and three
+    // reported, because that is how many will not be heard.
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack + 3));
     CHECK(pool.overSubscribed() == 3);
 
     SECTION("and stops reporting once the lane thins out") {
@@ -248,6 +253,113 @@ TEST_CASE("A lane stacking more clips than a track has voices reports the excess
 
         CHECK(pool.streamCount() == 1);
         CHECK(pool.overSubscribed() == 0);
+    }
+}
+
+TEST_CASE("Clips that follow one another are not clips stacked on one another",
+          "[engine][clip][pool]") {
+    // Chopped material: a dozen slices inside the window, never two of them
+    // sounding together. Counting window membership rather than overlap would
+    // report a track in trouble that is playing exactly one clip at a time.
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    std::vector<AudioClipPlayback> lane;
+    for (auto index = 0; index < kMaxVoicesPerTrack + 4; ++index)
+        lane.push_back(clipAt(index + 1, index * 0.05, (index + 1) * 0.05));
+
+    pool.setSnapshot(snapshotOf(std::move(lane)));
+    pool.setPosition(0.0);
+    pool.service();
+
+    CHECK(pool.overSubscribed() == 0);
+
+    // And every one of them has its reader well before it is due, because a
+    // slice needs a reader even when it never needs a second voice.
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack + 4));
+}
+
+TEST_CASE("A window holding more clips than there are readers takes the soonest",
+          "[engine][clip][pool]") {
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    std::vector<AudioClipPlayback> lane;
+    for (auto index = 0; index < kMaxReadersPerTrack + 5; ++index)
+        lane.push_back(clipAt(index + 1, index * 0.02, (index + 1) * 0.02));
+
+    pool.setSnapshot(snapshotOf(std::move(lane)));
+    pool.setPosition(0.0);
+    pool.service();
+
+    // The budget is spent, and none of it is reported: nothing here will fail
+    // to sound, because each slice is passed and gives its reader back long
+    // before the ones behind it are due.
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxReadersPerTrack));
+    CHECK(pool.overSubscribed() == 0);
+
+    // Rolling past the first few hands their readers to the ones behind.
+    pool.setPosition(0.1);
+    pool.service();
+
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxReadersPerTrack));
+}
+
+TEST_CASE("A round that changes nothing does not swap a table", "[engine][clip][pool]") {
+    // An idle session services a hundred times a second, and every publish
+    // waits for the block the callback is in.
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    pool.setSnapshot(snapshotOf({clipAt(1, 0.0, 4.0)}));
+    pool.setPosition(0.0);
+    pool.service();
+
+    REQUIRE(pool.tablesPublished() == 1);
+
+    pool.service();
+    pool.service();
+    pool.service();
+
+    CHECK(pool.tablesPublished() == 1);
+
+    SECTION("and swaps one again as soon as something does change") {
+        pool.setPosition(10.0);
+        pool.service();
+
+        CHECK(pool.tablesPublished() == 2);
+    }
+}
+
+TEST_CASE("A reader is reopened when the file behind its clip changes", "[engine][clip][pool]") {
+    // Ids outlive the edits that change what they name. A reader kept on the
+    // strength of its id alone would go on playing a file the clip no longer
+    // points at, for as long as the clip stayed in the window.
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    pool.setSnapshot(snapshotOf({clipAt(1, 0.0, 4.0, 0, "before.wav")}));
+    pool.setPosition(0.0);
+    pool.service();
+
+    REQUIRE(files.opens == 1);
+    REQUIRE(pool.streamCount() == 1);
+
+    // Same track, same clip, same event, different material.
+    pool.setSnapshot(snapshotOf({clipAt(1, 0.0, 4.0, 0, "after.wav")}));
+    pool.service();
+
+    CHECK(files.opens == 2);
+    CHECK(pool.streamCount() == 1);
+    CHECK(reader.streamCount() == 1);
+
+    SECTION("and left alone when nothing about it moved") {
+        pool.service();
+        CHECK(files.opens == 2);
     }
 }
 
@@ -263,17 +375,16 @@ TEST_CASE("A clip that is sounding keeps its reader over one that has not starte
     std::vector<AudioClipPlayback> lane;
 
     // One long clip the transport is standing inside, and enough clips starting
-    // just ahead of it to use up every remaining voice twice over.
+    // just ahead of it to use up every reader twice over.
     lane.push_back(clipAt(1, 0.0, 10.0));
-    for (auto index = 0; index < kMaxVoicesPerTrack * 2; ++index)
+    for (auto index = 0; index < kMaxReadersPerTrack * 2; ++index)
         lane.push_back(clipAt(index + 2, 5.2 + index * 0.01, 9.0));
 
     pool.setSnapshot(snapshotOf(std::move(lane)));
     pool.setPosition(5.0);
     pool.service();
 
-    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack));
-    CHECK(pool.overSubscribed() == kMaxVoicesPerTrack + 1);
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxReadersPerTrack));
 
     // The clip that is playing is one of the ones that kept a reader: render a
     // block of it and it sounds.

--- a/tests/test_clip_voice_pool.cpp
+++ b/tests/test_clip_voice_pool.cpp
@@ -399,6 +399,41 @@ TEST_CASE("A clip with no voice free is not also blamed on the reader budget",
     CHECK(pool.unbridged() == 0);
 }
 
+TEST_CASE("Clips the budget dropped take up the voices they were counted for",
+          "[engine][clip][pool]") {
+    // The readers are all spent on clips that are over before the bridge, so
+    // nothing the pool kept is playing when the next lot arrive. Twenty of them
+    // start together: sixteen the budget failed, and four the ceiling would
+    // have refused whatever the budget had been. Without the counted clips
+    // taking up voices against each other, all twenty look like budget
+    // failures and four of them are counted twice.
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    std::vector<AudioClipPlayback> lane;
+
+    // Sequential, short, and finished well before the crowd arrives.
+    for (auto index = 0; index < kMaxReadersPerTrack; ++index)
+        lane.push_back(clipAt(index + 1, index * 0.001, (index + 1) * 0.001));
+
+    constexpr auto kCrowd = kMaxVoicesPerTrack + 4;
+    for (auto index = 0; index < kCrowd; ++index)
+        lane.push_back(clipAt(kMaxReadersPerTrack + index + 1, 0.05, 0.5));
+
+    pool.setSnapshot(snapshotOf(std::move(lane)));
+    pool.setPosition(0.0);
+    pool.service();
+
+    REQUIRE(pool.streamCount() == static_cast<std::size_t>(kMaxReadersPerTrack));
+
+    CHECK(pool.overSubscribed() == kCrowd - kMaxVoicesPerTrack);
+    CHECK(pool.unbridged() == kMaxVoicesPerTrack);
+
+    // Which is the point: every clip that will not sound is named once.
+    CHECK(pool.overSubscribed() + pool.unbridged() == kCrowd);
+}
+
 TEST_CASE("A clip that fits the ceiling is provisioned before the next round",
           "[engine][clip][pool]") {
     // What the reader budget is for. Sixteen clips sounding and more starting

--- a/tests/test_clip_voice_pool.cpp
+++ b/tests/test_clip_voice_pool.cpp
@@ -1,0 +1,357 @@
+#include <algorithm>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "clip/ClipAudioSource.hpp"
+#include "clip/ClipVoicePool.hpp"
+
+/**
+ * Which clips have a reader standing by, and where it is pointed (#2035).
+ *
+ * The other half of the voice layer: test_clip_voice.cpp asks what a voice does
+ * with a stream, this asks where the stream came from and when it goes away.
+ */
+
+using magda::engine::AudioClipPlayback;
+using magda::engine::AudioEventPlayback;
+using magda::engine::AudioFileReader;
+using magda::engine::BlockInfo;
+using magda::engine::ClipAudioSource;
+using magda::engine::ClipSnapshot;
+using magda::engine::ClipSnapshotFeed;
+using magda::engine::ClipVoicePool;
+using magda::engine::kCueAheadSeconds;
+using magda::engine::kMaxVoicesPerTrack;
+using magda::engine::PrefetchThread;
+using magda::engine::RenderContext;
+using magda::engine::SnapshotSpan;
+using magda::engine::TrackClipPlayback;
+
+namespace {
+
+constexpr double kSampleRate = 44100.0;
+constexpr int kBlockSize = 64;
+constexpr magda::TrackId kTrack = 3;
+
+class CountingReader final : public AudioFileReader {
+  public:
+    std::int64_t lengthInSamples() const override {
+        return 10000000;
+    }
+    double sampleRate() const override {
+        return kSampleRate;
+    }
+    int numChannels() const override {
+        return 2;
+    }
+    int read(juce::AudioBuffer<float>& destination, int destinationOffset, std::int64_t startSample,
+             int numSamples) override {
+        for (auto channel = 0; channel < destination.getNumChannels(); ++channel)
+            for (auto sample = 0; sample < numSamples; ++sample)
+                destination.setSample(channel, destinationOffset + sample,
+                                      static_cast<float>(startSample + sample));
+        return numSamples;
+    }
+};
+
+/// Opens everything but the one path that stands for a file that has moved.
+class TestFiles final : public magda::engine::AudioFileReaderFactory {
+  public:
+    static constexpr const char* kMissing = "gone.wav";
+
+    std::unique_ptr<AudioFileReader> open(const std::string& path) override {
+        ++opens;
+        if (path == kMissing)
+            return nullptr;
+        return std::make_unique<CountingReader>();
+    }
+
+    int opens = 0;
+};
+
+RenderContext context() {
+    return RenderContext{kSampleRate, kBlockSize, 2};
+}
+
+SnapshotSpan seconds(double start, double end) {
+    SnapshotSpan span;
+    span.startBeat = start * 2.0;
+    span.endBeat = end * 2.0;
+    span.startSeconds = start;
+    span.endSeconds = end;
+    return span;
+}
+
+AudioClipPlayback clipAt(magda::ClipId id, double start, double end, std::int64_t anchor = 0,
+                         const std::string& path = "take.wav") {
+    AudioClipPlayback clip;
+    clip.clipId = id;
+    clip.span = seconds(start, end);
+    clip.launchFadeSamples = 0;
+
+    AudioEventPlayback event;
+    event.eventId = id;
+    event.sourceId = id;
+    event.filePath = path;
+    event.sourceSampleRate = kSampleRate;
+    event.sourceDurationSeconds = 1000.0;
+    event.span = seconds(start, end);
+    event.anchorSamples = anchor;
+    clip.events.push_back(std::move(event));
+
+    return clip;
+}
+
+std::shared_ptr<const ClipSnapshot> snapshotOf(std::vector<AudioClipPlayback> clips) {
+    auto snapshot = std::make_shared<ClipSnapshot>();
+    TrackClipPlayback track;
+    track.trackId = kTrack;
+    track.audio = std::move(clips);
+    snapshot->tracks.push_back(std::move(track));
+    return snapshot;
+}
+
+BlockInfo blockFrom(double startSeconds, bool continuous = true) {
+    BlockInfo block;
+    block.numSamples = kBlockSize;
+    block.playing = true;
+    block.startSeconds = startSeconds;
+    block.endSeconds = startSeconds + kBlockSize / kSampleRate;
+    block.startBeat = startSeconds * 2.0;
+    block.endBeat = block.endSeconds * 2.0;
+    block.continuous = continuous;
+    return block;
+}
+
+}  // namespace
+
+TEST_CASE("Only the clips the transport is about to reach get a reader", "[engine][clip][pool]") {
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    pool.setSnapshot(snapshotOf({clipAt(1, 0.0, 1.0), clipAt(2, 3.0, 4.0), clipAt(3, 30.0, 31.0)}));
+
+    SECTION("at the top, the clip that is playing and nothing beyond the window") {
+        pool.setPosition(0.0);
+        pool.service();
+
+        CHECK(pool.streamCount() == 1);
+        CHECK(files.opens == 1);
+        CHECK(pool.overSubscribed() == 0);
+    }
+
+    SECTION("a clip inside the window is provisioned before it sounds") {
+        // A second ahead of a clip that has not started: the whole point.
+        pool.setPosition(3.0 - kCueAheadSeconds / 2.0);
+        pool.service();
+
+        CHECK(pool.streamCount() == 1);
+        CHECK(files.opens == 1);
+    }
+
+    SECTION("and a clip beyond it is left alone") {
+        pool.setPosition(3.0 - kCueAheadSeconds * 2.0);
+        pool.service();
+
+        CHECK(pool.streamCount() == 0);
+        CHECK(files.opens == 0);
+    }
+
+    SECTION("a round that changes nothing opens nothing") {
+        pool.setPosition(0.0);
+        pool.service();
+        pool.service();
+        pool.service();
+
+        CHECK(pool.streamCount() == 1);
+        CHECK(files.opens == 1);
+    }
+}
+
+TEST_CASE("A clip the transport has passed gives its reader back", "[engine][clip][pool]") {
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    pool.setSnapshot(snapshotOf({clipAt(1, 0.0, 1.0), clipAt(2, 3.0, 4.0)}));
+
+    pool.setPosition(0.0);
+    pool.service();
+    REQUIRE(pool.streamCount() == 1);
+    REQUIRE(reader.streamCount() == 1);
+
+    pool.setPosition(2.5);
+    pool.service();
+
+    // The one behind is closed, the one ahead is open, and the reader thread
+    // knows about exactly the streams that still exist.
+    CHECK(pool.streamCount() == 1);
+    CHECK(reader.streamCount() == 1);
+    CHECK(files.opens == 2);
+
+    SECTION("and gets a fresh one when the transport comes back to it") {
+        pool.setPosition(0.0);
+        pool.service();
+
+        CHECK(pool.streamCount() == 1);
+        CHECK(files.opens == 3);
+    }
+}
+
+TEST_CASE("A file that will not open is reported once, not retried every round",
+          "[engine][clip][pool]") {
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    pool.setSnapshot(snapshotOf({clipAt(1, 0.0, 4.0, 0, TestFiles::kMissing)}));
+    pool.setPosition(0.0);
+
+    pool.service();
+    CHECK(pool.unreadableFiles() == 1);
+    CHECK(files.opens == 1);
+    CHECK(reader.streamCount() == 0);
+
+    pool.service();
+    pool.service();
+
+    // Still reported, still not reopened: a path that failed stays failed for
+    // as long as it sits in the window.
+    CHECK(pool.unreadableFiles() == 1);
+    CHECK(files.opens == 1);
+}
+
+TEST_CASE("A lane stacking more clips than a track has voices reports the excess",
+          "[engine][clip][pool]") {
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    std::vector<AudioClipPlayback> lane;
+    for (auto index = 0; index < kMaxVoicesPerTrack + 3; ++index)
+        lane.push_back(clipAt(index + 1, 0.0, 4.0));
+
+    pool.setSnapshot(snapshotOf(std::move(lane)));
+    pool.setPosition(1.0);
+    pool.service();
+
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack));
+    CHECK(pool.overSubscribed() == 3);
+
+    SECTION("and stops reporting once the lane thins out") {
+        pool.setSnapshot(snapshotOf({clipAt(1, 0.0, 4.0)}));
+        pool.service();
+
+        CHECK(pool.streamCount() == 1);
+        CHECK(pool.overSubscribed() == 0);
+    }
+}
+
+TEST_CASE("A clip that is sounding keeps its reader over one that has not started",
+          "[engine][clip][pool]") {
+    // Which clips a crowded lane drops has to be decided rather than left to
+    // the order a round walked it: taking a stream off a clip mid-note is worse
+    // than not having pointed one at the next clip yet.
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    std::vector<AudioClipPlayback> lane;
+
+    // One long clip the transport is standing inside, and enough clips starting
+    // just ahead of it to use up every remaining voice twice over.
+    lane.push_back(clipAt(1, 0.0, 10.0));
+    for (auto index = 0; index < kMaxVoicesPerTrack * 2; ++index)
+        lane.push_back(clipAt(index + 2, 5.2 + index * 0.01, 9.0));
+
+    pool.setSnapshot(snapshotOf(std::move(lane)));
+    pool.setPosition(5.0);
+    pool.service();
+
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack));
+    CHECK(pool.overSubscribed() == kMaxVoicesPerTrack + 1);
+
+    // The clip that is playing is one of the ones that kept a reader: render a
+    // block of it and it sounds.
+    ClipSnapshotFeed clips;
+    ClipAudioSource source(kTrack, clips, pool.feed());
+    source.prepare(context());
+
+    auto live = std::make_shared<ClipSnapshot>();
+    live->tracks.push_back(TrackClipPlayback{kTrack, {clipAt(1, 0.0, 10.0)}, {}});
+    clips.publish(std::move(live));
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    source.render(blockFrom(5.0), juce::dsp::AudioBlock<float>(output));
+    CHECK(source.starvedVoices() == 0);
+}
+
+TEST_CASE("A clip provisioned ahead of the transport plays from its first sample",
+          "[engine][clip][pool]") {
+    // The end to end shape of the slice: the pool opens and cues the file a
+    // second before the clip is due, the source hands the cue on at the top of
+    // a block, the reader fills, and the block the clip starts in plays
+    // material rather than the silence a seek would have cost (#2016).
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    constexpr std::int64_t kAnchor = 1000;
+    auto snapshot = snapshotOf({clipAt(1, 0.5, 2.0, kAnchor)});
+
+    pool.setSnapshot(snapshot);
+    pool.setPosition(0.0);
+    pool.service();
+    REQUIRE(pool.streamCount() == 1);
+
+    ClipSnapshotFeed clips;
+    ClipAudioSource source(kTrack, clips, pool.feed());
+    source.prepare(context());
+    clips.publish(snapshot);
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+
+    // A block before the clip starts, which is what carries the cue across to
+    // the callback's side, and then as much read-ahead as the pool will hold.
+    source.render(blockFrom(0.0, false), juce::dsp::AudioBlock<float>(output));
+    while (reader.fillOnce()) {
+    }
+
+    source.render(blockFrom(0.5), juce::dsp::AudioBlock<float>(output));
+
+    CHECK(output.getSample(0, 0) == Catch::Approx(static_cast<float>(kAnchor)).margin(1e-4));
+    CHECK(output.getSample(0, kBlockSize - 1) ==
+          Catch::Approx(static_cast<float>(kAnchor + kBlockSize - 1)).margin(1e-4));
+    CHECK(source.starvedVoices() == 0);
+}
+
+TEST_CASE("A pool with nothing published provisions nothing", "[engine][clip][pool]") {
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    pool.service();
+
+    CHECK(pool.streamCount() == 0);
+    CHECK(files.opens == 0);
+    CHECK(pool.overSubscribed() == 0);
+
+    // And a source reading its feed renders silence rather than refusing to run.
+    ClipSnapshotFeed clips;
+    ClipAudioSource source(kTrack, clips, pool.feed());
+    source.prepare(context());
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    for (auto channel = 0; channel < 2; ++channel)
+        for (auto sample = 0; sample < kBlockSize; ++sample)
+            output.setSample(channel, sample, 0.25f);
+
+    source.render(blockFrom(1.0), juce::dsp::AudioBlock<float>(output));
+
+    for (auto sample = 0; sample < kBlockSize; ++sample)
+        REQUIRE(output.getSample(0, sample) == Catch::Approx(0.0f).margin(1e-4));
+}

--- a/tests/test_clip_voice_pool.cpp
+++ b/tests/test_clip_voice_pool.cpp
@@ -376,6 +376,29 @@ TEST_CASE("A lane the budget cannot reach ahead of says so, and is not called st
     CHECK(pool.unbridged() > 0);
 }
 
+TEST_CASE("A clip with no voice free is not also blamed on the reader budget",
+          "[engine][clip][pool]") {
+    // Enough clips over one stretch to exhaust the readers and the voices
+    // together. The ones the budget turned away could not have sounded if every
+    // one of them had had a reader, so they belong to the ceiling and to
+    // nothing else; counting them twice would point at the wrong limit.
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    std::vector<AudioClipPlayback> lane;
+    for (auto index = 0; index < kMaxReadersPerTrack + 8; ++index)
+        lane.push_back(clipAt(index + 1, 0.0, 4.0));
+
+    pool.setSnapshot(snapshotOf(std::move(lane)));
+    pool.setPosition(1.0);
+    pool.service();
+
+    REQUIRE(pool.streamCount() == static_cast<std::size_t>(kMaxReadersPerTrack));
+    CHECK(pool.overSubscribed() == kMaxReadersPerTrack + 8 - kMaxVoicesPerTrack);
+    CHECK(pool.unbridged() == 0);
+}
+
 TEST_CASE("A clip that fits the ceiling is provisioned before the next round",
           "[engine][clip][pool]") {
     // What the reader budget is for. Sixteen clips sounding and more starting

--- a/tests/test_clip_voice_pool.cpp
+++ b/tests/test_clip_voice_pool.cpp
@@ -24,7 +24,6 @@ using magda::engine::ClipSnapshot;
 using magda::engine::ClipSnapshotFeed;
 using magda::engine::ClipVoicePool;
 using magda::engine::kCueAheadSeconds;
-using magda::engine::kMaxReadersPerTrack;
 using magda::engine::kMaxVoicesPerTrack;
 using magda::engine::PrefetchThread;
 using magda::engine::RenderContext;
@@ -242,9 +241,9 @@ TEST_CASE("A lane stacking more clips than a track has voices reports the excess
     pool.setPosition(1.0);
     pool.service();
 
-    // Readers for all of them, because that budget is about memory, and three
-    // reported, because that is how many will not be heard.
-    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack + 3));
+    // Every reader the track may have, and three reported, because that is how
+    // many of them will not be heard.
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack));
     CHECK(pool.overSubscribed() == 3);
 
     SECTION("and stops reporting once the lane thins out") {
@@ -259,14 +258,17 @@ TEST_CASE("A lane stacking more clips than a track has voices reports the excess
 TEST_CASE("Clips that follow one another are not clips stacked on one another",
           "[engine][clip][pool]") {
     // Chopped material: a dozen slices inside the window, never two of them
-    // sounding together. Counting window membership rather than overlap would
-    // report a track in trouble that is playing exactly one clip at a time.
+    // wanted by one callback. Counting window membership rather than
+    // concurrency would report a track in trouble that is playing exactly one
+    // clip at a time.
     TestFiles files;
     PrefetchThread reader;
     ClipVoicePool pool(files, reader, context());
 
+    constexpr auto kSlices = kMaxVoicesPerTrack - 4;
+
     std::vector<AudioClipPlayback> lane;
-    for (auto index = 0; index < kMaxVoicesPerTrack + 4; ++index)
+    for (auto index = 0; index < kSlices; ++index)
         lane.push_back(clipAt(index + 1, index * 0.05, (index + 1) * 0.05));
 
     pool.setSnapshot(snapshotOf(std::move(lane)));
@@ -277,7 +279,65 @@ TEST_CASE("Clips that follow one another are not clips stacked on one another",
 
     // And every one of them has its reader well before it is due, because a
     // slice needs a reader even when it never needs a second voice.
-    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack + 4));
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kSlices));
+
+    // Which the callback agrees with: it renders one slice and starves nothing.
+    ClipSnapshotFeed clips;
+    ClipAudioSource source(kTrack, clips, pool.feed());
+    source.prepare(context());
+
+    auto live = std::make_shared<ClipSnapshot>();
+    TrackClipPlayback track;
+    track.trackId = kTrack;
+    for (auto index = 0; index < kSlices; ++index)
+        track.audio.push_back(clipAt(index + 1, index * 0.05, (index + 1) * 0.05));
+    live->tracks.push_back(std::move(track));
+    clips.publish(std::move(live));
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    source.render(blockFrom(0.1), juce::dsp::AudioBlock<float>(output));
+    CHECK(source.starvedVoices() == 0);
+}
+
+TEST_CASE("Slices too short to fill a callback are concurrent, and say so",
+          "[engine][clip][pool]") {
+    // The other end of the same question. Clips shorter than a block share one,
+    // so a callback needs a voice for each of them however little they overlap.
+    // Measuring bare overlap would report this track in the clear while the
+    // callback was dropping every slice past the sixteenth.
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    // Four samples each, back to back: a block spans seventeen of them.
+    constexpr auto kSliceSeconds = 4.0 / kSampleRate;
+
+    std::vector<AudioClipPlayback> lane;
+    TrackClipPlayback track;
+    track.trackId = kTrack;
+    for (auto index = 0; index < kMaxVoicesPerTrack * 2; ++index) {
+        lane.push_back(clipAt(index + 1, index * kSliceSeconds, (index + 1) * kSliceSeconds));
+        track.audio.push_back(lane.back());
+    }
+
+    pool.setSnapshot(snapshotOf(std::move(lane)));
+    pool.setPosition(0.0);
+    pool.service();
+
+    CHECK(pool.overSubscribed() > 0);
+
+    // And the callback is where it costs something.
+    ClipSnapshotFeed clips;
+    ClipAudioSource source(kTrack, clips, pool.feed());
+    source.prepare(context());
+
+    auto live = std::make_shared<ClipSnapshot>();
+    live->tracks.push_back(std::move(track));
+    clips.publish(std::move(live));
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    source.render(blockFrom(kSliceSeconds), juce::dsp::AudioBlock<float>(output));
+    CHECK(source.starvedVoices() > 0);
 }
 
 TEST_CASE("A window holding more clips than there are readers takes the soonest",
@@ -287,7 +347,7 @@ TEST_CASE("A window holding more clips than there are readers takes the soonest"
     ClipVoicePool pool(files, reader, context());
 
     std::vector<AudioClipPlayback> lane;
-    for (auto index = 0; index < kMaxReadersPerTrack + 5; ++index)
+    for (auto index = 0; index < kMaxVoicesPerTrack + 5; ++index)
         lane.push_back(clipAt(index + 1, index * 0.02, (index + 1) * 0.02));
 
     pool.setSnapshot(snapshotOf(std::move(lane)));
@@ -297,14 +357,14 @@ TEST_CASE("A window holding more clips than there are readers takes the soonest"
     // The budget is spent, and none of it is reported: nothing here will fail
     // to sound, because each slice is passed and gives its reader back long
     // before the ones behind it are due.
-    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxReadersPerTrack));
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack));
     CHECK(pool.overSubscribed() == 0);
 
     // Rolling past the first few hands their readers to the ones behind.
     pool.setPosition(0.1);
     pool.service();
 
-    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxReadersPerTrack));
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack));
 }
 
 TEST_CASE("A round that changes nothing does not swap a table", "[engine][clip][pool]") {
@@ -377,14 +437,14 @@ TEST_CASE("A clip that is sounding keeps its reader over one that has not starte
     // One long clip the transport is standing inside, and enough clips starting
     // just ahead of it to use up every reader twice over.
     lane.push_back(clipAt(1, 0.0, 10.0));
-    for (auto index = 0; index < kMaxReadersPerTrack * 2; ++index)
+    for (auto index = 0; index < kMaxVoicesPerTrack * 2; ++index)
         lane.push_back(clipAt(index + 2, 5.2 + index * 0.01, 9.0));
 
     pool.setSnapshot(snapshotOf(std::move(lane)));
     pool.setPosition(5.0);
     pool.service();
 
-    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxReadersPerTrack));
+    CHECK(pool.streamCount() == static_cast<std::size_t>(kMaxVoicesPerTrack));
 
     // The clip that is playing is one of the ones that kept a reader: render a
     // block of it and it sounds.

--- a/tests/test_engine_session.cpp
+++ b/tests/test_engine_session.cpp
@@ -237,6 +237,63 @@ class LoggingFactory final : public RuntimeStateFactory {
     BlockLog* log = nullptr;
 };
 
+/// Enough of a file for a stream to be opened over it. What it holds does not
+/// matter here: whether a reader exists is the question, not what it plays.
+class SilentReader final : public magda::engine::AudioFileReader {
+  public:
+    std::int64_t lengthInSamples() const override {
+        return 1000000;
+    }
+    double sampleRate() const override {
+        return 44100.0;
+    }
+    int numChannels() const override {
+        return 2;
+    }
+    int read(juce::AudioBuffer<float>& destination, int destinationOffset, std::int64_t,
+             int numSamples) override {
+        destination.clear(destinationOffset, numSamples);
+        return numSamples;
+    }
+};
+
+class OpenEverything final : public magda::engine::AudioFileReaderFactory {
+  public:
+    std::unique_ptr<magda::engine::AudioFileReader> open(const std::string&) override {
+        return std::make_unique<SilentReader>();
+    }
+};
+
+/// One track, one clip, over the seconds given.
+std::shared_ptr<const magda::engine::ClipSnapshot> clipsOver(TrackId trackId, double startSeconds,
+                                                             double endSeconds) {
+    magda::engine::SnapshotSpan span;
+    span.startSeconds = startSeconds;
+    span.endSeconds = endSeconds;
+    span.startBeat = startSeconds * 2.0;
+    span.endBeat = endSeconds * 2.0;
+
+    magda::engine::AudioEventPlayback event;
+    event.eventId = 1;
+    event.sourceId = 1;
+    event.filePath = "take.wav";
+    event.sourceSampleRate = 44100.0;
+    event.span = span;
+
+    magda::engine::AudioClipPlayback clip;
+    clip.clipId = 1;
+    clip.span = span;
+    clip.events.push_back(std::move(event));
+
+    magda::engine::TrackClipPlayback track;
+    track.trackId = trackId;
+    track.audio.push_back(std::move(clip));
+
+    auto snapshot = std::make_shared<magda::engine::ClipSnapshot>();
+    snapshot->tracks.push_back(std::move(track));
+    return snapshot;
+}
+
 /// Playing from a beat, with the metronome off.
 magda::engine::TransportSnapshot rolling(double fromBeat) {
     magda::engine::TransportSnapshot transport;
@@ -1054,4 +1111,40 @@ TEST_CASE("A session on a thread pool renders what a session without one renders
 
     magda::engine::RenderThreadPool pool(4, false);
     CHECK(render(&pool) == alone);
+}
+
+TEST_CASE("Clips reach the voice pool with the transport that plays them",
+          "[engine][session][clip]") {
+    // Two things the session owes the clip layer (#2035), and both of them are
+    // silence when they are missing: a pool that never sees a snapshot opens no
+    // readers at all, and one that never hears where the transport is opens
+    // them for the top of the timeline while playback is somewhere else.
+    Ledger ledger;
+    TestFactory factory(ledger);
+    OpenEverything files;
+    magda::engine::PrefetchThread reader;
+    magda::engine::ClipVoicePool voices(files, reader, context());
+
+    EngineSession session(factory, nullptr, &voices);
+
+    const auto tracks = trackWithEffect(7);
+    REQUIRE(publish(session, compile(tracks), tracks).published);
+    session.publishTransport(rolling(0.0));
+
+    // Far enough down the timeline that only a transport which has got near it
+    // provisions a reader.
+    session.publishClips(clipsOver(1, 2.0, 3.0));
+
+    voices.service();
+    REQUIRE(voices.streamCount() == 0);
+
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    const auto blocks = static_cast<int>(1.2 * 44100.0 / kBlockSize);
+    for (auto block = 0; block < blocks; ++block) {
+        output.clear();
+        session.process(kBlockSize, output);
+    }
+
+    voices.service();
+    CHECK(voices.streamCount() == 1);
 }

--- a/tests/test_engine_session.cpp
+++ b/tests/test_engine_session.cpp
@@ -5,6 +5,7 @@
 #include <thread>
 #include <vector>
 
+#include "clip/ClipVoicePool.hpp"
 #include "core/RackInfo.hpp"
 #include "core/TrackInfo.hpp"
 #include "exec/EngineSession.hpp"


### PR DESCRIPTION
Slice 2 of #1890, after #2034. The source behind a track's `ClipAudio` op, and the readers it plays through.

`ClipAudioSource` reads the snapshot slice 1 publishes, matches each sounding entry to a voice, and sums them. It decides nothing about overlaps: occlusion, crossfades and takes were resolved when the snapshot was compiled, so two clips over one stretch of lane simply add, and a crossfade is two voices each playing the fade it was handed (#2003).

A voice crops its read to the audible span, clears the interior silences out of what it read rather than skipping over them, shapes the span's edges with the resolved fades, and applies the clip's gain and pan with the incumbent's linear law. Reading across a hole is what keeps the far side of it from being a seek. A voice that begins mid-material has the step taken out of it by the launch ramp, which subtracts the starting offset rather than fading the audio, so a leading transient survives and a setting of zero preserves it exactly.

`ClipVoicePool` provisions the readers a second ahead of the transport, on a thread that may wait for a disk. A clip about to sound has its file opened and its stream pointed at the sample it starts on before any callback asks, which is the difference between a clip starting on the beat and a clip starting a block late (#2016). `PrefetchStream` gained `startAt` for that: a stream nobody has read from is moved rather than cued, so its first fill is not spent on the wrong part of the file and then thrown away.

Both ceilings are decided rather than discovered. Eight voices per track, because a crossfade is two, a clip dropped inside another is two, and a clip made of several events is one voice per event (#1901); past eight the track reports through `starvedVoices` the way an underrun is counted, since silence nobody counted is indistinguishable from a gap in the material.

`EngineSession` takes the pool, so publishing clips reaches the audio thread and the reader together, and the transport's position reaches the thread reading ahead of it. A snapshot arriving at one side and not the other would be a clip that is audible with nothing to read, which is the sync problem keeping one representation was supposed to have made impossible.

## Two calls worth review

The snapshot carries per-event fades and this applies only the clip's resolved pair. For the single event a clip has today the two are the same fade before and after resolution, so applying both would shape the edge twice; interior event fades belong with the clips that have interior events (#1901).

Event gain trim is not applied here. #2036 owns it, along with active channels.

## Verification

`tests/test_clip_voice.cpp` rolls a transport rather than skipping between blocks, because a read that does not continue the last one is a seek and would be testing a locate. It covers placement and trims, overlapping clips summing, a hole punched mid-block and the material continuing past it, every fade curve and where it is anchored, gain and pan, the launch ramp and its zero case, a starved clip, the voice ceiling, and a voice released in the block its clip ends in.

`tests/test_clip_voice_pool.cpp` covers the window, retirement and reopening, a file that will not open being reported once rather than retried, over-subscription, a sounding clip keeping its reader over one that has not started, and the end to end path from provisioning to a clip playing from its first sample with no underrun.

Confirmed to fail without their fix: disabling the hole clearing, the launch ramp and the voice-release sweep fails exactly those four tests and no others.

Not here: rate conversion, looping and reverse (#2036), stretch and pitch (#2037), warp (#2038), MIDI (#2039).