### PR TITLE
Stop juce::String decoding UTF-8 source literals as ASCII

### DIFF
--- a/magda/agents/command_agent.cpp
+++ b/magda/agents/command_agent.cpp
@@ -75,6 +75,7 @@ CommandAgent::GenerateResult CommandAgent::generateLocal(const std::string& mess
         // abstain class, so out-of-scope requests return nothing rather than
         // being mapped onto the nearest command and executed. Say that, rather
         // than reporting it as a malfunction.
+        // utf8-ok: result.error is std::string, so the UTF-8 bytes are kept verbatim.
         result.error = "That is not one of the on-device commands. Editing "
                        "operations work here (tracks, clips, devices, notes); "
                        "playback, mute/solo and questions do not — use a "

--- a/magda/agents/console_agent_orchestrator.cpp
+++ b/magda/agents/console_agent_orchestrator.cpp
@@ -298,7 +298,8 @@ ConsoleExecutionResult ConsoleAgentResultExecutor::execute(ConsoleRunOutput outp
                 if (clausePos > 0 && clausePos < kMaxClipNameLen)
                     clipName = clipName.substring(0, clausePos);
                 if (clipName.length() > kMaxClipNameLen)
-                    clipName = clipName.substring(0, kMaxClipNameLen).trim() + "…";
+                    clipName =
+                        clipName.substring(0, kMaxClipNameLen).trim() + juce::String::fromUTF8("…");
                 ClipManager::getInstance().setClipName(executor.getCurrentClipId(),
                                                        clipName.trim());
             }

--- a/magda/agents/generic_sound_design_agent.cpp
+++ b/magda/agents/generic_sound_design_agent.cpp
@@ -104,9 +104,10 @@ juce::String buildSystemPrompt(const juce::String& displayName, const juce::Stri
     prompt << "You are a sound designer for the \"" << displayName << "\" audio plugin.";
     if (description.isNotEmpty())
         prompt << " " << description;
-    prompt << "\n\nGiven a short user description, design a single preset by choosing values "
-              "for the instrument's parameters. Output ONLY a JSON object — no prose, no "
-              "markdown fences.\n\n";
+    prompt << juce::String::fromUTF8(
+        "\n\nGiven a short user description, design a single preset by choosing values "
+        "for the instrument's parameters. Output ONLY a JSON object — no prose, no "
+        "markdown fences.\n\n");
 
     prompt << "OUTPUT SCHEMA:\n"
               "{\n"
@@ -115,16 +116,17 @@ juce::String buildSystemPrompt(const juce::String& displayName, const juce::Stri
               "  \"params\": { \"<parameter name>\": <value>, ... }\n"
               "}\n\n";
 
-    prompt << "RULES:\n"
-              "- Use the EXACT parameter names listed below.\n"
-              "- Emit each value in the parameter's own units and within its stated range "
-              "(e.g. a Hz cutoff as a real frequency, an ms time as milliseconds).\n"
-              "- For parameters shown with `options:`, emit one of the listed option labels "
-              "as a string (exact text).\n"
-              "- Omit any parameter you want left at its current value. Only set the ones that "
-              "matter for the requested sound.\n"
-              "- Keep output levels sensible — do not push level/gain parameters to their "
-              "maximum without reason.\n\n";
+    prompt << juce::String::fromUTF8(
+        "RULES:\n"
+        "- Use the EXACT parameter names listed below.\n"
+        "- Emit each value in the parameter's own units and within its stated range "
+        "(e.g. a Hz cutoff as a real frequency, an ms time as milliseconds).\n"
+        "- For parameters shown with `options:`, emit one of the listed option labels "
+        "as a string (exact text).\n"
+        "- Omit any parameter you want left at its current value. Only set the ones that "
+        "matter for the requested sound.\n"
+        "- Keep output levels sensible — do not push level/gain parameters to their "
+        "maximum without reason.\n\n");
 
     if (categoryOverride.isNotEmpty())
         prompt << "Bias the design toward this character: " << categoryOverride << "\n\n";

--- a/magda/agents/instruction_executor.cpp
+++ b/magda/agents/instruction_executor.cpp
@@ -980,7 +980,7 @@ bool InstructionExecutor::executeHit(const HitOp& op) {
         }
     }
     if (noteNumber < 0) {
-        results_.add("Skipped " + op.role + " — no row in track's kit");
+        results_.add("Skipped " + op.role + juce::String::fromUTF8(" — no row in track's kit"));
         return true;
     }
 

--- a/magda/agents/llama_model_manager.cpp
+++ b/magda/agents/llama_model_manager.cpp
@@ -158,6 +158,7 @@ LlamaModelManager::InferenceResult LlamaModelManager::infer(const InferenceReque
     InferenceResult result;
 
     if (model_ == nullptr || ctx_ == nullptr) {
+        // utf8-ok: result.error is std::string, so the UTF-8 bytes are kept verbatim.
         result.error = "Local (Embedded) model is not loaded. Download/enable it in "
                        "Settings → Models, or pick a different provider for this agent.";
         return result;

--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -1205,7 +1205,7 @@ void AudioBridge::timerCallback() {
                             const bool renderInProgress =
                                 engine_.getRenderManager().isProxyBeingGenerated(playbackFile);
                             if (playbackFile.isValid() && !renderInProgress) {
-                                DBG("REVERSE TIMER: proxy ready — reallocating ("
+                                DBG("REVERSE TIMER: proxy ready - reallocating ("
                                     << playbackFile.getFile().getFullPathName() << ")");
                                 clipSynchronizer_.clearPendingReverseClipId();
                                 // AudioFile::isValid() can become true before ReverseRenderJob has

--- a/magda/daw/audio/TrackController.cpp
+++ b/magda/daw/audio/TrackController.cpp
@@ -285,7 +285,7 @@ void TrackController::setTrackAudioOutput(TrackId trackId, const juce::String& d
             track->getOutput().setOutputToTrack(targetTrack);
         } else {
             DBG("TrackController::setTrackAudioOutput - target track not found: trackId="
-                << trackId << " targetId=" << targetId << " — falling back to master");
+                << trackId << " targetId=" << targetId << " - falling back to master");
             track->getOutput().setOutputToDefaultDevice(false);
         }
     } else {

--- a/magda/daw/audio/automation/AutomationRecordingEngine.cpp
+++ b/magda/daw/audio/automation/AutomationRecordingEngine.cpp
@@ -69,13 +69,13 @@ void AutomationRecordingEngine::process() {
     bool playing = edit_.getTransport().isPlaying();
 
     if (!wasPlaying_ && playing && isWriteEnabled()) {
-        DBG("[AutoRec] Transport started with write ON — begin recording");
+        DBG("[AutoRec] Transport started with write ON - begin recording");
         UndoManager::getInstance().beginCompoundOperation("Record Automation");
         isRecording_ = true;
         lastRecorded_.clear();
         seedBaselines();
     } else if (wasPlaying_ && !playing && isRecording_) {
-        DBG("[AutoRec] Transport stopped — end recording");
+        DBG("[AutoRec] Transport stopped - end recording");
         flushFinalPoints();
         UndoManager::getInstance().endCompoundOperation();
         isRecording_ = false;
@@ -84,13 +84,13 @@ void AutomationRecordingEngine::process() {
         lanePreRecordingPoints_.clear();
         clearLatchState();
     } else if (playing && isWriteEnabled() && !isRecording_) {
-        DBG("[AutoRec] Write toggled ON mid-playback — begin recording");
+        DBG("[AutoRec] Write toggled ON mid-playback - begin recording");
         UndoManager::getInstance().beginCompoundOperation("Record Automation");
         isRecording_ = true;
         lastRecorded_.clear();
         seedBaselines();
     } else if (isRecording_ && !isWriteEnabled()) {
-        DBG("[AutoRec] Write toggled OFF — end recording");
+        DBG("[AutoRec] Write toggled OFF - end recording");
         flushFinalPoints();
         UndoManager::getInstance().endCompoundOperation();
         isRecording_ = false;
@@ -484,7 +484,7 @@ void AutomationRecordingEngine::onTrackPropertyChanged(int trackId) {
                 static_cast<double>(ParameterUtils::realToNormalized(seedDb, paramInfo));
             const auto* lane = autoMgr.getLane(laneId);
             if (lane && !lane->absolutePoints.empty()) {
-                DBG("[AutoRec] New vol lane — anchor was "
+                DBG("[AutoRec] New vol lane - anchor was "
                     << gainToDb(track->volume) << " dB, correcting to seed=" << seedDb << " dB"
                     << " (track->vol=" << track->volume << " preSeed=" << preSeedVolume << ")");
                 UndoManager::getInstance().executeCommand(

--- a/magda/daw/audio/controllers/ControllerRouter.cpp
+++ b/magda/daw/audio/controllers/ControllerRouter.cpp
@@ -30,7 +30,7 @@ void ControllerRouter::reconfigure() {
         BindingRegistry::getInstance().addListener(this);
         configured_ = true;
     }
-    DBG("ControllerRouter: reconfigure — "
+    DBG("ControllerRouter: reconfigure - "
         << ControllerRegistry::getInstance().all().size() << " controller(s), "
         << BindingRegistry::getInstance().bindings(BindingScope::Global).size()
         << " global binding(s), "
@@ -370,7 +370,7 @@ void ControllerRouter::executeWrite(const BindingId& bindingId, int rawValue, in
 
     // Resolve target and write
     if (!paramWriter_) {
-        DBG("ControllerRouter: no paramWriter_ set — dropping write for binding "
+        DBG("ControllerRouter: no paramWriter_ set - dropping write for binding "
             << bindingId.toDashedString());
         return;
     }

--- a/magda/daw/audio/plugin_manager/PluginManagerModifiers.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerModifiers.cpp
@@ -1090,7 +1090,7 @@ void PluginManager::resyncDeviceModifiers(TrackId trackId) {
             // un-gating and silencing the sidechained track.
             if (renderingActive_.load(std::memory_order_relaxed)) {
                 DBG("[RENDER] skipping full modifier rebuild for track " << trackId
-                                                                         << " — rendering active");
+                                                                         << " - rendering active");
                 updateDeviceModifierProperties(trackId);
             } else {
                 // Link structure changed — full rebuild

--- a/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
+++ b/magda/daw/audio/plugins/FaustInstrumentPlugin.cpp
@@ -602,7 +602,7 @@ FaustInstrumentPlugin::FaustInstrumentPlugin(const te::PluginCreationInfo& info)
     auto compiled = compileAndRebind(
         savedSource.isNotEmpty() ? savedSource : juce::String(kDefaultDspSource), err);
     if (!compiled) {
-        DBG("FaustInstrumentPlugin: failed to compile saved source: " << err << " — using default");
+        DBG("FaustInstrumentPlugin: failed to compile saved source: " << err << " - using default");
         compiled = compileAndRebind(kDefaultDspSource, err);
     }
 

--- a/magda/daw/audio/plugins/FaustPlugin.cpp
+++ b/magda/daw/audio/plugins/FaustPlugin.cpp
@@ -327,7 +327,7 @@ FaustPlugin::FaustPlugin(const te::PluginCreationInfo& info) : te::Plugin(info) 
         savedSource.isNotEmpty() ? savedSource : juce::String(kDefaultDspSource), err);
     activeDspMatchesSource_ = compiled != nullptr;
     if (!compiled) {
-        DBG("FaustPlugin: failed to compile saved source: " << err << " — using default");
+        DBG("FaustPlugin: failed to compile saved source: " << err << " - using default");
         compiled = compileAndRebind(kDefaultDspSource, err);
     }
 

--- a/magda/daw/audio/session/ClipSynchronizer.cpp
+++ b/magda/daw/audio/session/ClipSynchronizer.cpp
@@ -1216,11 +1216,11 @@ void ClipSynchronizer::launchSessionClip(ClipId clipId, bool forceImmediate) {
         if (clip) {
             lastLaunchTimeByTrack_[clip->trackId] = edit_.getTransport().position.get().inSeconds();
         }
-        DBG("ClipSync: play(nullopt) — immediate launch for clip "
+        DBG("ClipSync: play(nullopt) - immediate launch for clip "
             << clipId << " forceImmediate=" << (int)forceImmediate);
         launchHandle->play(std::nullopt);
     } else {
-        DBG("ClipSync: play(beat " << targetBeat->v.inBeats() << ") — quantized launch for clip "
+        DBG("ClipSync: play(beat " << targetBeat->v.inBeats() << ") - quantized launch for clip "
                                    << clipId << " qType=" << static_cast<int>(qType));
         launchHandle->play(*targetBeat);
     }

--- a/magda/daw/audio/session/SessionClipScheduler.cpp
+++ b/magda/daw/audio/session/SessionClipScheduler.cpp
@@ -271,13 +271,13 @@ void SessionClipScheduler::processStateEvents() {
     // symptom is "the UI looks wrong but no logs say why."
     if (uint32_t cmdDropped = audioMonitor_.commandQueue().getDroppedCount()) {
         DBG("SessionClip command queue dropped " << static_cast<int>(cmdDropped)
-                                                 << " push(es) — bursty scene launches exceeding "
+                                                 << " push(es) - bursty scene launches exceeding "
                                                     "queue size?");
         audioMonitor_.commandQueue().clearDroppedCount();
     }
     if (uint32_t stateDropped = audioMonitor_.stateQueue().getDroppedCount()) {
         DBG("SessionClip state queue dropped " << static_cast<int>(stateDropped)
-                                               << " push(es) — message thread fell behind audio");
+                                               << " push(es) - message thread fell behind audio");
         audioMonitor_.stateQueue().clearDroppedCount();
     }
 
@@ -331,7 +331,7 @@ void SessionClipScheduler::processStateEvents() {
     // Transport just stopped — stop all LaunchHandles so clips reset to start.
     // activeSessionClipId stays set (user intent preserved).
     if (wasTransportPlaying_ && !transportPlaying && hasActiveClips()) {
-        DBG("SessionClipScheduler: Transport stopped — stopping all LaunchHandles");
+        DBG("SessionClipScheduler: Transport stopped - stopping all LaunchHandles");
         for (const auto& track : tm.getTracks()) {
             ClipId clipId = track.activeSessionClipId;
             if (clipId == INVALID_CLIP_ID)

--- a/magda/daw/core/MidiNoteCommands.cpp
+++ b/magda/daw/core/MidiNoteCommands.cpp
@@ -162,12 +162,12 @@ void AddMidiNoteCommand::execute() {
     auto* clip = clipManager.getClip(clipId_);
 
     if (!clip) {
-        DBG("AddMidiNoteCommand: clip " + juce::String(clipId_) + " NOT FOUND — note dropped");
+        DBG("AddMidiNoteCommand: clip " + juce::String(clipId_) + " NOT FOUND - note dropped");
         return;
     }
     if (!clip->isMidi()) {
         DBG("AddMidiNoteCommand: clip " + juce::String(clipId_) +
-            " type=" + juce::String(static_cast<int>(clip->getType())) + " != MIDI — note dropped");
+            " type=" + juce::String(static_cast<int>(clip->getType())) + " != MIDI - note dropped");
         return;
     }
 

--- a/magda/daw/core/ParameterDetector.cpp
+++ b/magda/daw/core/ParameterDetector.cpp
@@ -530,7 +530,7 @@ DetectedParameterInfo detectSingleParameter(const ParameterScanInput& input) {
 
     // 5. No clear unit from display text or name — send to AI for refinement.
     // Default to "%" in case AI doesn't reach this param.
-    DETECT_LOG("  [detect] '" << input.name << "' AMBIGUOUS — no unit from display or name");
+    DETECT_LOG("  [detect] '" << input.name << "' AMBIGUOUS - no unit from display or name");
     result.unit = technicalText(TechnicalTextToken::Percent);
     result.confidence = 0.0f;
     result.minValue = input.rangeMin;
@@ -697,7 +697,7 @@ void detectWithAI(const juce::String& pluginName, const std::vector<ParameterSca
     DBG("AI parameter detection - " << totalAmbiguous << " params in " << batches->size()
                                     << " parallel batches");
 
-    auto systemPrompt = juce::String(
+    auto systemPrompt = juce::String::fromUTF8(
         "You are an audio plugin parameter classifier for a DAW.\n"
         "For each parameter, determine:\n"
         "- unit: the physical unit (Hz, dB, ms, %, semitones, cents, BPM, sec, or empty)\n"

--- a/magda/daw/core/StringTable.cpp
+++ b/magda/daw/core/StringTable.cpp
@@ -121,7 +121,7 @@ bool StringTable::loadLanguage(const juce::String& languageCode) {
         // so callers can surface the failure rather than silently using an
         // empty string table.
         if (english_.empty()) {
-            DBG("StringTable::loadLanguage(\"en\"): english_ is empty — en.json not loaded");
+            DBG("StringTable::loadLanguage(\"en\"): english_ is empty - en.json not loaded");
             return false;
         }
         localized_ = english_;

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -802,7 +802,7 @@ TrackId TrackManager::activateMultiOutPair(TrackId parentTrackId, DeviceId devic
     pairRef.trackId = newTrackId;
 
     DBG("TrackManager: Activated multi-out pair " << pairIndex << " for device " << deviceId
-                                                  << " → track " << newTrackId);
+                                                  << " -> track " << newTrackId);
 
     notifyTracksChanged();
     return newTrackId;

--- a/magda/daw/core/UndoManager.cpp
+++ b/magda/daw/core/UndoManager.cpp
@@ -17,7 +17,7 @@ UndoManager::UndoManager() = default;
 
 void UndoManager::executeCommand(std::unique_ptr<UndoableCommand> command) {
     if (!command) {
-        DBG("📝 UNDO: executeCommand called with null command!");
+        DBG("UNDO: executeCommand called with null command!");
         return;
     }
 
@@ -64,7 +64,7 @@ bool UndoManager::undo() {
     auto entry = std::move(undoStack_.back());
     undoStack_.pop_back();
 
-    DBG("📝 UNDO: Undoing '" << entry.command->getDescription() << "'");
+    DBG("UNDO: Undoing '" << entry.command->getDescription() << "'");
 
     {
         ProjectManager::UndoableMutationScope mutationScope;
@@ -90,7 +90,7 @@ bool UndoManager::redo() {
     auto entry = std::move(redoStack_.back());
     redoStack_.pop_back();
 
-    DBG("📝 UNDO: Redoing '" << entry.command->getDescription() << "'");
+    DBG("UNDO: Redoing '" << entry.command->getDescription() << "'");
 
     {
         ProjectManager::UndoableMutationScope mutationScope;
@@ -167,7 +167,7 @@ void UndoManager::endCompoundOperation() {
         compoundCommands_.clear();
         notifyListeners();
 
-        DBG("📝 UNDO: Completed compound operation '" << compoundDescription_ << "'");
+        DBG("UNDO: Completed compound operation '" << compoundDescription_ << "'");
     }
 }
 

--- a/magda/daw/core/controllers/ControllerProfileRegistry.cpp
+++ b/magda/daw/core/controllers/ControllerProfileRegistry.cpp
@@ -136,7 +136,7 @@ void ControllerProfileRegistry::loadFromDirectory(const juce::File& dir) {
         if (existing != profiles_.end()) {
             DBG("ControllerProfileRegistry: duplicate id '" << profileOpt->id << "' in "
                                                             << file.getFullPathName()
-                                                            << " — replacing earlier entry");
+                                                            << " - replacing earlier entry");
             *existing = *profileOpt;
         } else {
             DBG("ControllerProfileRegistry: loaded profile '" << profileOpt->id << "' from "

--- a/magda/daw/core/controllers/ControllerRegistry.cpp
+++ b/magda/daw/core/controllers/ControllerRegistry.cpp
@@ -129,7 +129,7 @@ bool ControllerRegistry::isControllerInputPort(const juce::String& liveIdentifie
 void ControllerRegistry::loadFromConfig(const juce::var& json) {
     controllers_.clear();
 
-    DBG("ControllerRegistry::loadFromConfig — input isArray="
+    DBG("ControllerRegistry::loadFromConfig - input isArray="
         << (json.isArray() ? "yes" : "no") << " isVoid=" << (json.isVoid() ? "yes" : "no")
         << " dump=" << juce::JSON::toString(json, true));
 
@@ -149,7 +149,7 @@ void ControllerRegistry::loadFromConfig(const juce::var& json) {
         }
     }
 
-    DBG("ControllerRegistry::loadFromConfig — " << (int)controllers_.size()
+    DBG("ControllerRegistry::loadFromConfig - " << (int)controllers_.size()
                                                 << " controller(s) loaded");
 
     rebuildSnapshot();

--- a/magda/daw/engine/TracktionEngineWrapperInit.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperInit.cpp
@@ -164,7 +164,7 @@ void TracktionEngineWrapper::initializeDeviceManager() {
                                           << " output channels");
 
     if (juceDeviceManager.getCurrentAudioDevice() == nullptr)
-        DBG("WARNING: No audio device opened after initialise — user can configure in Audio "
+        DBG("WARNING: No audio device opened after initialise - user can configure in Audio "
             "Settings");
 }
 

--- a/magda/daw/engine/TracktionEngineWrapperRecording.cpp
+++ b/magda/daw/engine/TracktionEngineWrapperRecording.cpp
@@ -123,7 +123,7 @@ void TracktionEngineWrapper::recordingFinished(
                 audioTrackInfo && !audioTrackInfo->audioInputDevice.isEmpty();
 
             if (!audioTrackHasInput) {
-                DBG("  skipping audio clip — track has no audio input configured");
+                DBG("  skipping audio clip - track has no audio input configured");
                 audioClip->removeFromParent();
                 continue;
             }

--- a/magda/daw/ui/components/chain/custom_ui/FaustUI.cpp
+++ b/magda/daw/ui/components/chain/custom_ui/FaustUI.cpp
@@ -161,7 +161,7 @@ void FaustUI::refreshNameLabel() {
 bool FaustUI::tryLoad(const juce::String& name, const juce::String& source) {
     DBG("[FaustUI] tryLoad name='" << name << "' src.len=" << source.length());
     if (plugin_ == nullptr) {
-        DBG("[FaustUI] tryLoad: plugin_ is NULL — bailing");
+        DBG("[FaustUI] tryLoad: plugin_ is NULL - bailing");
         return false;
     }
     juce::String err;

--- a/magda/daw/ui/components/common/MixerDebugPanel.cpp
+++ b/magda/daw/ui/components/common/MixerDebugPanel.cpp
@@ -26,8 +26,8 @@ MixerDebugPanel::MixerDebugPanel() {
     addIntSlider("Fader Width", &metrics.faderWidth, 24, 60);
 
     // Spacing (int)
-    addIntSlider("Tick→Fader Gap", &metrics.tickToFaderGap, -5, 10);
-    addIntSlider("Tick→Label Gap", &metrics.tickToLabelGap, -5, 10);
+    addIntSlider(juce::String::fromUTF8("Tick→Fader Gap"), &metrics.tickToFaderGap, -5, 10);
+    addIntSlider(juce::String::fromUTF8("Tick→Label Gap"), &metrics.tickToLabelGap, -5, 10);
 
     // Calculate content height
     contentHeight_ = static_cast<int>(rows.size()) * 50 + 10;

--- a/magda/daw/ui/components/timeline/TimelineComponent.cpp
+++ b/magda/daw/ui/components/timeline/TimelineComponent.cpp
@@ -1071,7 +1071,7 @@ void TimelineComponent::drawTimeMarkers(juce::Graphics& g) {
                             timeStr = juce::String(ms, 1) + "ms";
                         } else {
                             int us = static_cast<int>(time * 1000000);
-                            timeStr = juce::String(us) + "μs";
+                            timeStr = juce::String(us) + juce::String::fromUTF8("μs");
                         }
                     }
 

--- a/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
+++ b/magda/daw/ui/components/tracks/TrackHeadersPanel.cpp
@@ -3766,7 +3766,7 @@ void TrackHeadersPanel::itemDropped(const SourceDetails& details) {
         UndoManager::getInstance().executeCommand(std::move(cmd));
         TrackManager::getInstance().setSelectedTrack(trackId);
 
-        DBG("Dropped plugin on track header: " << juce::String(device.name) << " → track "
+        DBG("Dropped plugin on track header: " << juce::String(device.name) << " -> track "
                                                << trackId);
     } else {
         // Dropped on empty area → create new track with plugin

--- a/magda/daw/ui/dialogs/ControllersDialog.cpp
+++ b/magda/daw/ui/dialogs/ControllersDialog.cpp
@@ -327,7 +327,7 @@ void ControllerProfilesPage::importProfileFile(const juce::File& file, const juc
     if (!issues.empty()) {
         juce::String body = tr("controllers.upload_validation_failed");
         for (const auto& issue : issues)
-            body += "\n  • " + tr(issue.key).replace("{0}", issue.arg);
+            body += juce::String::fromUTF8("\n  • ") + tr(issue.key).replace("{0}", issue.arg);
         return fail(body);
     }
 

--- a/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
+++ b/magda/daw/ui/dialogs/ParameterConfigDialog.cpp
@@ -385,7 +385,8 @@ class ParameterConfigDialog::RangeCell : public juce::Component {
                     return "+inf";
                 return juce::String(v, 1);
             };
-            editor_.setText(formatValue(param.rangeMin) + " — " + formatValue(param.rangeMax),
+            editor_.setText(formatValue(param.rangeMin) + juce::String::fromUTF8(" — ") +
+                                formatValue(param.rangeMax),
                             false);
             editor_.setEnabled(true);
         }
@@ -592,8 +593,8 @@ ParameterConfigDialog::ParameterConfigDialog(const juce::String& pluginName)
             "Discard all inferred units, ranges, AI parameter selections, and custom "
             "instructions for \"" +
                 pluginName_ +
-                "\" and show every parameter as a plain 0–100 % slider.\n\n"
-                "This cannot be undone.",
+                juce::String::fromUTF8("\" and show every parameter as a plain 0–100 % slider.\n\n"
+                                       "This cannot be undone."),
             juce::AlertWindow::QuestionIcon);
         alert->addButton("Reset", 1, juce::KeyPress(juce::KeyPress::returnKey));
         alert->addButton("Cancel", 0, juce::KeyPress(juce::KeyPress::escapeKey));
@@ -1085,7 +1086,7 @@ void ParameterConfigDialog::resetParameterConfiguration() {
     rebuildFilteredList();
     table_.updateContent();
     updateTitle();
-    aiStatusLabel_.setText("Reset to 0–100 %", juce::dontSendNotification);
+    aiStatusLabel_.setText(juce::String::fromUTF8("Reset to 0–100 %"), juce::dontSendNotification);
 }
 
 void ParameterConfigDialog::runHeuristicDetection() {
@@ -1120,7 +1121,7 @@ void ParameterConfigDialog::runHeuristicDetection() {
     juce::String status =
         juce::String(resolved) + " / " + juce::String(visibleInputs.size()) + " resolved";
     if (ambiguous > 0)
-        status += " — use AI Detect for the rest";
+        status += juce::String::fromUTF8(" — use AI Detect for the rest");
     aiStatusLabel_.setText(status, juce::dontSendNotification);
 }
 

--- a/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
+++ b/magda/daw/ui/panels/content/AIChatConsoleContent.cpp
@@ -481,7 +481,7 @@ class AIChatConsoleContent::MidiContextPopup : public juce::Component, private j
                 clipRow.label = clip->name.isNotEmpty() ? clip->name : "Untitled MIDI clip";
                 clipRow.detail = juce::String(static_cast<int>(clip->midiNotes.size())) + " notes";
                 if (clip->view == magda::ClipView::Session)
-                    clipRow.detail += " · live";
+                    clipRow.detail += juce::String::fromUTF8(" · live");
                 rows_.push_back(std::move(clipRow));
             }
         }
@@ -2192,13 +2192,14 @@ juce::String AIChatConsoleContent::getMidiContextSummary() const {
             midiClipsOnTrack += clip != nullptr && clip->isMidi() ? 1 : 0;
         }
         if (midiClipsOnTrack == static_cast<int>(midiContextClipIds_.size()))
-            return trackName + " · all MIDI";
-        return trackName + " · " + juce::String(static_cast<int>(midiContextClipIds_.size())) +
-               " MIDI";
+            return trackName + juce::String::fromUTF8(" · all MIDI");
+        return trackName + juce::String::fromUTF8(" · ") +
+               juce::String(static_cast<int>(midiContextClipIds_.size())) + " MIDI";
     }
 
-    return juce::String(static_cast<int>(midiContextClipIds_.size())) + " MIDI · " +
-           juce::String(static_cast<int>(trackIds.size())) + " tracks";
+    return juce::String(static_cast<int>(midiContextClipIds_.size())) +
+           juce::String::fromUTF8(" MIDI · ") + juce::String(static_cast<int>(trackIds.size())) +
+           " tracks";
 }
 
 bool AIChatConsoleContent::isLastGeneratedMidiClipValid() const {
@@ -3101,8 +3102,9 @@ void AIChatConsoleContent::finishControllerGeneration(bool success, const juce::
 
                 auto profileOpt = magda::ControllerProfileRegistry::getInstance().findById(finalId);
                 if (!profileOpt.has_value()) {
-                    safeThis->appendToChat(juce::String::charToString(0x25C6) +
-                                           " Profile disappeared — cannot enable.");
+                    safeThis->appendToChat(
+                        juce::String::charToString(0x25C6) +
+                        juce::String::fromUTF8(" Profile disappeared — cannot enable."));
                     return;
                 }
 

--- a/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/MediaDbBrowserContent.cpp
@@ -2500,11 +2500,11 @@ void MediaDbBrowserContent::runIndexing(const juce::File& dir,
                 // no idea why no audio analysis ran.
                 const auto skipReason =
                     std::filesystem::exists(ctx.audioModelPath())
-                        ? juce::String(
-                              "Sample Tagger model failed to load — skipping audio analysis")
-                        : juce::String(
+                        ? juce::String(juce::String::fromUTF8(
+                              "Sample Tagger model failed to load — skipping audio analysis"))
+                        : juce::String(juce::String::fromUTF8(
                               "Sample Tagger not installed — skipping audio analysis. Install it "
-                              "in AI Settings to enable semantic search.");
+                              "in AI Settings to enable semantic search."));
                 finalStatus = scanStatus + " | " + skipReason;
                 juce::Logger::writeToLog(juce::String("[MediaDbIndexer] ") + skipReason);
             }

--- a/magda/daw/ui/panels/content/MediaExplorerContent.cpp
+++ b/magda/daw/ui/panels/content/MediaExplorerContent.cpp
@@ -2153,8 +2153,9 @@ void MediaExplorerContent::fileClicked(const juce::File& file, const juce::Mouse
                         };
 
                         if (newFullPath == fsPath) {
-                            showError("The new parent is the folder's current parent — "
-                                      "nothing to do.");
+                            showError(juce::String::fromUTF8(
+                                "The new parent is the folder's current parent — "
+                                "nothing to do."));
                             return;
                         }
                         std::error_code ec;

--- a/magda/daw/ui/themes/FontManager.cpp
+++ b/magda/daw/ui/themes/FontManager.cpp
@@ -84,7 +84,7 @@ bool FontManager::initialize() {
         notoSansCJKFamily = notoSansCJK->getName();
         DBG("Noto Sans CJK loaded, family=" << notoSansCJKFamily);
     } else {
-        DBG("Failed to load Noto Sans CJK — CJK glyphs will use OS fallback");
+        DBG("Failed to load Noto Sans CJK - CJK glyphs will use OS fallback");
     }
 
     initialized = success;

--- a/magda/daw/ui/views/SessionClipEditor.cpp
+++ b/magda/daw/ui/views/SessionClipEditor.cpp
@@ -213,7 +213,7 @@ void SessionClipEditor::setupHeader() {
     addAndMakeVisible(*lengthLabel_);
 
     // Close button
-    closeButton_ = std::make_unique<juce::TextButton>("✕");
+    closeButton_ = std::make_unique<juce::TextButton>(juce::String::fromUTF8("✕"));
     closeButton_->setColour(juce::TextButton::buttonColourId,
                             DarkTheme::getColour(DarkTheme::BUTTON_NORMAL));
     closeButton_->setColour(juce::TextButton::textColourOffId, DarkTheme::getTextColour());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,8 @@ set(TEST_SOURCES
     test_scale_detection.cpp
     test_step_clock.cpp
     test_string_table.cpp
+    # Guards the juce::String(const char*) ASCII-decode trap (#1858 follow-up)
+    test_non_ascii_string_literals.cpp
     # Arrangement pointer hit tester (#1719)
     test_arrangement_hit_tester.cpp
     # Keyboard clip nudging (#1957)

--- a/tests/test_non_ascii_string_literals.cpp
+++ b/tests/test_non_ascii_string_literals.cpp
@@ -1,0 +1,224 @@
+// Guards a bug class that is invisible until someone looks at the screen.
+//
+// `juce::String(const char*)` decodes through `CharPointer_ASCII`, one byte to
+// one character. A source literal is UTF-8, so an em dash's three bytes become
+// three Latin-1 characters and "Listening — MCP" renders as "Listening â€" MCP".
+// JUCE's own constructor documents this and asserts on it in debug, but the
+// assertion fires far from the literal and nothing fails in a headless build,
+// so these accumulate: this test was written after finding fourteen of them,
+// including a session-clip-editor close button whose entire label was mojibake.
+//
+// The fix at each site is `juce::String::fromUTF8(...)`, or plain ASCII where
+// the text is a log line and the typography was never load-bearing.
+//
+// Scanning source from a test is unusual, and is the point: the defect exists in
+// the source text, produces no compiler diagnostic, and cannot be observed from
+// inside the program. MAGDA_REPO_ROOT is already defined for this target.
+
+#include <juce_core/juce_core.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+/// A literal the loader would misread, with enough context to find it.
+struct Finding {
+    juce::String file;
+    int line = 0;
+    juce::String text;
+};
+
+/**
+ * @brief Every non-ASCII ordinary string literal that is not already decoded.
+ *
+ * Three things are deliberately *not* findings:
+ *
+ * - **Comments.** This codebase writes prose in them and uses em dashes
+ *   throughout; they never reach a `juce::String`.
+ * - **Raw strings** (`R"(...)"`). They are handed to a consumer verbatim — the
+ *   agent system prompts are `const char*` that callers wrap in `fromUTF8`
+ *   themselves — so the bytes survive.
+ * - **Anything already wrapped.** Adjacent literals concatenate before any
+ *   conversion happens, so one `fromUTF8(` covers the whole run and only the
+ *   first literal in it is preceded by the call.
+ * - **Anything marked `utf8-ok`.** A lexical scan cannot see the type a literal
+ *   is assigned to, and `std::string` keeps the bytes exactly as written — so
+ *   two of these are correct as they stand. The marker is deliberately a
+ *   comment a human has to type: it records that someone checked the
+ *   destination, and it greps.
+ */
+std::vector<Finding> scan(const juce::File& file) {
+    std::vector<Finding> findings;
+    const auto source = file.loadFileAsString();
+    const auto* text = source.toRawUTF8();
+    const auto length = static_cast<int>(std::strlen(text));
+
+    const auto lineAt = [&](int offset) {
+        int line = 1;
+        for (int i = 0; i < offset && i < length; ++i)
+            if (text[i] == '\n')
+                ++line;
+        return line;
+    };
+
+    // The marker may sit on the run's own line or the line above it, so a long
+    // wrapped statement does not have to carry it awkwardly inline.
+    const auto isMarkedOk = [&](int offset) {
+        auto lineStart = offset;
+        while (lineStart > 0 && text[lineStart - 1] != '\n')
+            --lineStart;
+        auto previousStart = lineStart > 0 ? lineStart - 1 : 0;
+        while (previousStart > 0 && text[previousStart - 1] != '\n')
+            --previousStart;
+        auto lineEnd = offset;
+        while (lineEnd < length && text[lineEnd] != '\n')
+            ++lineEnd;
+        const std::string window(text + previousStart,
+                                 static_cast<size_t>(lineEnd - previousStart));
+        return window.find("utf8-ok") != std::string::npos;
+    };
+
+    // Byte comparison, not juce::String: that constructor's size argument counts
+    // *characters*, so truncating a prefix at a byte offset lands in the wrong
+    // place as soon as anything earlier in the file is multi-byte — which, in a
+    // file that has non-ASCII literals, it always is.
+    const auto endsWithWrapper = [&](int offset) {
+        auto i = offset;
+        while (i > 0 && (text[i - 1] == ' ' || text[i - 1] == '\t' || text[i - 1] == '\n' ||
+                         text[i - 1] == '\r'))
+            --i;
+        const auto endsWith = [&](const char* suffix) {
+            const auto suffixLength = static_cast<int>(std::strlen(suffix));
+            return i >= suffixLength && std::memcmp(text + i - suffixLength, suffix,
+                                                    static_cast<size_t>(suffixLength)) == 0;
+        };
+        return endsWith("fromUTF8(") || endsWith("CharPointer_UTF8(");
+    };
+
+    for (int i = 0; i < length;) {
+        if (text[i] == '/' && i + 1 < length && text[i + 1] == '/') {
+            while (i < length && text[i] != '\n')
+                ++i;
+            continue;
+        }
+        if (text[i] == '/' && i + 1 < length && text[i + 1] == '*') {
+            i += 2;
+            while (i + 1 < length && !(text[i] == '*' && text[i + 1] == '/'))
+                ++i;
+            i = juce::jmin(length, i + 2);
+            continue;
+        }
+        // A raw string opens with R"delim( and closes with )delim".
+        if (text[i] == 'R' && i + 1 < length && text[i + 1] == '"') {
+            const auto delimiterStart = i + 2;
+            int j = delimiterStart;
+            while (j < length && text[j] != '(')
+                ++j;
+            if (j < length) {
+                const std::string closing =
+                    ")" +
+                    std::string(text + delimiterStart, static_cast<size_t>(j - delimiterStart)) +
+                    "\"";
+                const auto rest = std::string(text + j, static_cast<size_t>(length - j));
+                const auto at = rest.find(closing);
+                i = at == std::string::npos ? length : j + static_cast<int>(at + closing.size());
+                continue;
+            }
+        }
+        if (text[i] == '"') {
+            const auto runStart = i;
+            auto runHasNonAscii = false;
+            while (i < length && text[i] == '"') {
+                auto j = i + 1;
+                auto escaped = false;
+                while (j < length) {
+                    if (escaped)
+                        escaped = false;
+                    else if (text[j] == '\\')
+                        escaped = true;
+                    else if (text[j] == '"' || text[j] == '\n')
+                        break;
+                    ++j;
+                }
+                for (auto b = i + 1; b < j; ++b)
+                    if (static_cast<unsigned char>(text[b]) > 127)
+                        runHasNonAscii = true;
+                i = j + 1;
+
+                // Only whitespace between two literals means they concatenate,
+                // so the run continues.
+                auto k = i;
+                while (k < length && juce::CharacterFunctions::isWhitespace(text[k]))
+                    ++k;
+                if (k < length && text[k] == '"')
+                    i = k;
+                else
+                    break;
+            }
+            if (runHasNonAscii && !endsWithWrapper(runStart) && !isMarkedOk(runStart)) {
+                const std::string excerpt(
+                    text + runStart, static_cast<size_t>(juce::jmin(i, runStart + 60) - runStart));
+                findings.push_back({file.getFileName(), lineAt(runStart),
+                                    juce::String::fromUTF8(excerpt.c_str())});
+            }
+            continue;
+        }
+        ++i;
+    }
+    return findings;
+}
+
+}  // namespace
+
+TEST_CASE("No source literal relies on juce::String decoding UTF-8 as ASCII",
+          "[encoding][source]") {
+    const juce::File root(MAGDA_REPO_ROOT);
+    const auto sources =
+        root.getChildFile("magda").findChildFiles(juce::File::findFiles, true, "*.cpp;*.hpp");
+    REQUIRE_FALSE(sources.isEmpty());
+
+    std::vector<Finding> findings;
+    for (const auto& file : sources)
+        for (auto& finding : scan(file))
+            findings.push_back(std::move(finding));
+
+    if (!findings.empty()) {
+        juce::String report("Non-ASCII string literals that juce::String would misdecode:\n");
+        for (const auto& finding : findings)
+            report << "  " << finding.file << ":" << finding.line << "  " << finding.text << "\n";
+        report << "\nWrap them in juce::String::fromUTF8(...), or use ASCII if the text is a "
+                  "log line.";
+        UNSCOPED_INFO(report.toStdString());
+    }
+    REQUIRE(findings.empty());
+}
+
+TEST_CASE("The scanner recognises what it is supposed to skip", "[encoding][source]") {
+    // Without these the guard above is worth nothing: a scanner that flags
+    // comments would have been deleted on its first false positive, and one that
+    // flags raw strings would have had every agent system prompt rewritten for
+    // no reason.
+    juce::TemporaryFile scratch(".cpp");
+    const auto write = [&scratch](const char* contents) {
+        scratch.getFile().replaceWithText(juce::String::fromUTF8(contents));
+        return scan(scratch.getFile());
+    };
+
+    REQUIRE(write("// a comment — with an em dash\n").empty());
+    REQUIRE(write("/* a block comment — with one */\n").empty());
+    REQUIRE(write("const char* p = R\"X(raw — text)X\";\n").empty());
+    REQUIRE(write("auto s = juce::String::fromUTF8(\"already — wrapped\");\n").empty());
+    REQUIRE(write("auto s = juce::String(juce::CharPointer_UTF8(\"wrapped — too\"));\n").empty());
+    REQUIRE(write("auto s = \"plain ascii\";\n").empty());
+
+    // The run rule: one wrapper covers every literal it concatenates with.
+    REQUIRE(write("auto s = juce::String::fromUTF8(\"first \"\n\"second — dash\");\n").empty());
+
+    // And the thing it must actually catch, including inside a run whose first
+    // literal is innocent.
+    REQUIRE(write("auto s = juce::String(\"bare — dash\");\n").size() == 1);
+    REQUIRE(write("label.setText(\"plain \"\n\"then — dash\");\n").size() == 1);
+}


### PR DESCRIPTION
Found while building #1858 — the MCP settings page rendered `Listening — MCP on port 54655` as `Listening â€ MCP on port 54655`. That one was mine and is fixed there; this is every other instance, plus a guard so the class stops recurring.

## The bug

`juce::String(const char*)` decodes through `CharPointer_ASCII` — one byte, one character. Source literals are UTF-8, so an em dash's three bytes (`E2 80 94`) become three Latin-1 characters. JUCE documents this on the constructor and asserts on it in debug builds, but the assertion fires far from the literal and nothing fails in a headless run, so these accumulate silently.

Visible instances included:

- **`SessionClipEditor`** — the clip editor's close button label was `"✕"`, so the entire button rendered as mojibake
- **`AIChatConsoleContent`** — four context labels separated with `·`
- **`ParameterConfigDialog`** — range editor, AI status, and the "0–100 %" labels
- **`MediaDbBrowserContent`, `MediaExplorerContent`** — em dashes in user-facing error text
- **`ParameterDetector`** — the plugin-parameter classifier's *LLM prompt*, carrying mojibake into every request

## Fixed by destination, not uniformly

**Text a user or a model sees** is wrapped in `juce::String::fromUTF8`, preserving the intended typography.

**Text that only reaches a log** is rewritten in ASCII (`—`→`-`, `→`→`->`). A `DBG` line never needed an em dash, and removing the character removes the bug rather than papering over it.

**Two sites are already correct** and are marked `utf8-ok`: they assign to `std::string`, which keeps the bytes verbatim. A lexical scan cannot see the destination type, so the marker records that a human checked it — and greps.

## The guard

`tests/test_non_ascii_string_literals.cpp` scans the source tree and fails on any unwrapped non-ASCII literal. Scanning source from a test is unusual, and is the point: the defect exists in the source text, produces no compiler diagnostic, and cannot be observed from inside the running program.

What it skips matters as much as what it catches:

- **Comments** — this codebase writes prose with em dashes throughout; they never reach a `juce::String`
- **Raw strings** — the agent system prompts are `const char*` raw strings whose callers already wrap them with `fromUTF8`, so the bytes survive
- **Already-wrapped runs** — adjacent literals concatenate before any conversion, so one `fromUTF8(` covers the whole run

Without those three exclusions a naive scanner would have demanded ~20 pointless rewrites, including rewriting every drummer/sound-design prompt. My first pass did exactly that before I checked the consumers; the second test case in the file pins each exclusion so the scanner cannot regress into that.

Verified by reintroducing the close-button bug and watching the guard fail, then restoring it.

## Testing

Full suite green: 2199 cases, 557,986 assertions. No behaviour changes beyond the rendered text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)