### PR TITLE
Native engine: time stretch and pitch (#2037)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,11 @@ add_subdirectory(third_party/JUCE)
 # Tracktion Engine for DAW functionality (using local submodule)
 add_subdirectory(third_party/tracktion_engine)
 
+# SoundTouch — time stretching for the native engine (#1882, #2037). Vendored here
+# rather than borrowed from the Tracktion fork, which the engine may not include.
+# Signalsmith Stretch sits beside it and is header-only, so it needs no target.
+add_subdirectory(third_party/soundtouch)
+
 # LLM API client module (juce_core only)
 juce_add_module(${CMAKE_CURRENT_SOURCE_DIR}/third_party/juce-llm/juce_llm)
 

--- a/docs/architecture/native-engine.md
+++ b/docs/architecture/native-engine.md
@@ -28,7 +28,7 @@ is. When the two disagree, the headers are right and this file is stale.
 | Retire stock TE plugin wrappers | [#1888](https://github.com/Conceptual-Machines/magda-core/issues/1888) | done |
 | Clip model: container from content | [#1901](https://github.com/Conceptual-Machines/magda-core/issues/1901) | done |
 | **Engine core: plan, executor, PDC** | [#1889](https://github.com/Conceptual-Machines/magda-core/issues/1889) | **all 10 slices done** |
-| **Arranger clip playback** | [#1890](https://github.com/Conceptual-Machines/magda-core/issues/1890) | **slices 1 to 3 of 7** |
+| **Arranger clip playback** | [#1890](https://github.com/Conceptual-Machines/magda-core/issues/1890) | **slices 1 to 4 of 7** |
 | Parameters, modifiers, macros, automation | [#1891](https://github.com/Conceptual-Machines/magda-core/issues/1891) | not started |
 | Rack graph: pins, summing, multi-out, nesting | [#1892](https://github.com/Conceptual-Machines/magda-core/issues/1892) | not started |
 | External plugin hosting and hardware inserts | [#1893](https://github.com/Conceptual-Machines/magda-core/issues/1893) | not started |
@@ -50,9 +50,9 @@ crossfading a plan swap ([#2019](https://github.com/Conceptual-Machines/magda-co
 
 Clips, slice by slice: the snapshot ([#2034](https://github.com/Conceptual-Machines/magda-core/issues/2034)),
 voices, spans and fades ([#2035](https://github.com/Conceptual-Machines/magda-core/issues/2035)),
-rate conversion, looping and reverse ([#2036](https://github.com/Conceptual-Machines/magda-core/issues/2036), in review).
-Still open: stretch and pitch ([#2037](https://github.com/Conceptual-Machines/magda-core/issues/2037)),
-warp ([#2038](https://github.com/Conceptual-Machines/magda-core/issues/2038)),
+rate conversion, looping and reverse ([#2036](https://github.com/Conceptual-Machines/magda-core/issues/2036)),
+stretch and pitch ([#2037](https://github.com/Conceptual-Machines/magda-core/issues/2037)).
+Still open: warp ([#2038](https://github.com/Conceptual-Machines/magda-core/issues/2038)),
 MIDI clips ([#2039](https://github.com/Conceptual-Machines/magda-core/issues/2039)),
 null-diff corpus ([#2040](https://github.com/Conceptual-Machines/magda-core/issues/2040)).
 
@@ -341,9 +341,6 @@ gap in the material.
 
 ### The reading chain
 
-Slice 3 ([#2036](https://github.com/Conceptual-Machines/magda-core/issues/2036)), in review as
-this is written, so the files below are on its branch rather than here yet.
-
 Reverse, looping and rate conversion are not processing. They are which of a file's samples
 answer a position, so each is a reader wrapped around the reader, built once when the pool opens
 a clip.
@@ -354,11 +351,69 @@ flowchart LR
     R --> L["LoopingAudioFileReader<br/>only if the clip loops"]
     L --> S["ResamplingAudioFileReader<br/>only if the rates differ"]
     S --> PS["PrefetchStream"]
-    PS --> V["ClipVoice<br/>span, holes, fades, channels, gain, pan"]
+    PS --> ST["ClipStretcher<br/>only if the clip is not at its file's speed"]
+    ST --> V["ClipVoice<br/>span, holes, fades, channels, gain, pan"]
 ```
 
 Everything above the chain sees one forward file at the device's rate, whatever the clip is set
 to. A clip that asks for none of it reads through no extra layer at all.
+
+### Speed and pitch
+
+Slice 4 ([#2037](https://github.com/Conceptual-Machines/magda-core/issues/2037)). The chain
+above decides **what** the reading holds; this decides **how fast it is consumed**, which is why
+it sits above the stream where the chain sits below it.
+
+All of it is one function. `readingPositionAt` in `clip/EventPlacement.hpp` says where in the
+reading a moment of the timeline sits, and everything on the list is that function answering
+differently:
+
+| What the clip asks for | What the position does |
+| --- | --- |
+| its file's own speed | advances one reading sample per output sample |
+| a speed ratio | advances by the ratio, a constant, resolved in the snapshot |
+| auto tempo | advances by the beats that have passed, times a beat of the file |
+| analog pitch | advances by the ratio the model already folded the pitch into, with no stretcher |
+| a speed ramp fade | the moment itself is warped near the clip's edge, and the rate with it |
+| warp ([#2038](https://github.com/Conceptual-Machines/magda-core/issues/2038)) | another answer from the same place |
+
+Auto tempo is the one worth reading twice. Its ratio is the project's tempo over the file's own
+and moves with the tempo curve, so it cannot be resolved to seconds ahead of a block. What saves
+it is that the integral of that ratio is beats: the material an instant has consumed is how many
+beats have passed since the event began, times what a beat of the file is worth. That is why the
+clock publishes both faces of one instant, and why there is no second tempo map on the audio
+thread.
+
+A block then reads exactly `round(P(end)) - round(P(start))` samples and hands them to the
+stretcher to come back as the block's own length, so the ratio a block runs at is whatever its
+own two ends say. A tempo curve and a speed ramp therefore cost nothing extra, and nothing
+accumulates: both ends are rounded rather than counted forward, so one block's reading ends
+exactly where the next one's begins.
+
+**Where a stretcher lives** answers the questions that come with it. One per provisioned event,
+built and configured by `ClipVoicePool` on the thread that opens the file, carried to the
+callback in the same table as the stream (`clip/ClipStreamFeed.hpp`). So a plan swap does nothing
+to it, because it never enters a plan epoch; a loop wrap does nothing to it, because tiling
+happens below the stream and a wrap is a discontinuity in the material rather than a change of
+position; and a locate resets and re-primes something that already exists, which allocates
+nothing. An event that asks for no stretch gets none, the same rule the reading chain follows.
+
+**Latency is answered here rather than reported upwards.** Every engine wants material from
+*before* the first sample to be heard, says how much, and the pool cues the stream that far back,
+so a voice's first read is one contiguous read that begins with the priming samples. A
+`ClipAudio` op therefore reports no latency at all and stretched voices stay aligned with
+unstretched ones on the same track. One deliberate divergence from the fork: its Signalsmith
+wrapper primes with the material *at* the start rather than before it, so it begins every
+stretched clip about a window late. The null-diff corpus
+([#2040](https://github.com/Conceptual-Machines/magda-core/issues/2040)) will show that as a
+fixed offset, and the engine is the one that is right.
+
+The engines are `third_party/signalsmith-stretch` (MIT, the default, and what the pinned mode
+`kSignalsmith` names) and `third_party/soundtouch` (LGPL-2.1, its own replaceable static target,
+carried because `kSoundTouchNormal` and `kSoundTouchBetter` are project-file integers and
+sessions saved with them have to play as they were made). A clip that resamples instead of
+stretching uses the same cubic curve the rate converter below the stream uses, so a file at
+another rate and a clip playing fast are not two different sounds.
 
 ---
 
@@ -378,10 +433,9 @@ Worth knowing before reading the code and wondering where something is:
   A `Device` op resolves to whatever the host hands the store. Nothing hosts VST3 yet.
 - **Launcher and recording** ([#1894](https://github.com/Conceptual-Machines/magda-core/issues/1894),
   [#1895](https://github.com/Conceptual-Machines/magda-core/issues/1895)).
-- **Stretch, warp and MIDI clips** ([#2037](https://github.com/Conceptual-Machines/magda-core/issues/2037),
-  [#2038](https://github.com/Conceptual-Machines/magda-core/issues/2038),
-  [#2039](https://github.com/Conceptual-Machines/magda-core/issues/2039)). Everything plays at
-  unity speed today.
+- **Warp and MIDI clips** ([#2038](https://github.com/Conceptual-Machines/magda-core/issues/2038),
+  [#2039](https://github.com/Conceptual-Machines/magda-core/issues/2039)). Speed, pitch and auto
+  tempo play; warp markers are carried in the snapshot and nothing reads them yet.
 - **The null-diff harness** ([#1896](https://github.com/Conceptual-Machines/magda-core/issues/1896)),
   which is what decides the engine is right rather than merely tested: render the same project
   through both engines and assert a near-null difference.
@@ -421,7 +475,7 @@ Its tests are ordinary Catch2 model-level tests, tagged `[engine]`:
 
 Useful narrower tags while working on one part: `[plan]`, `[clip]`, `[exec]`, `[io]`,
 `[transport]`, `[session]`, `[tap]`, `[offline]`, and inside those `[compiler]`, `[diff]`,
-`[pdc]`, `[crossfade]`, `[voice]`, `[pool]`.
+`[pdc]`, `[crossfade]`, `[voice]`, `[pool]`, `[stretch]`.
 
 Two properties the tests lean on and that are worth preserving:
 

--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -2,9 +2,10 @@
 #
 # Dark target: nothing in the app links it yet. It is built on every configure
 # so it cannot rot, and it is deliberately isolated: the C++ standard library,
-# JUCE headers and the MAGDA model layer, nothing else. No Tracktion Engine, no
-# UI, no app services. The boundary check below enforces that at configure time
-# rather than leaving it to review.
+# JUCE headers, the MAGDA model layer and a short list of vendored DSP
+# libraries it owns copies of (farbot, Signalsmith Stretch, SoundTouch). No
+# Tracktion Engine, no UI, no app services. The boundary check below enforces
+# that at configure time rather than leaving it to review.
 
 add_library(magda_engine STATIC
     clip/ClipSnapshot.cpp
@@ -12,6 +13,7 @@ add_library(magda_engine STATIC
     clip/ClipSnapshotDump.cpp
     clip/ClipAudioSource.cpp
     clip/ClipStreamFeed.cpp
+    clip/ClipStretcher.cpp
     clip/ClipVoice.cpp
     clip/ClipVoicePool.cpp
     clip/EventPlacement.cpp
@@ -22,6 +24,7 @@ add_library(magda_engine STATIC
     clip/ClipSnapshotFeed.hpp
     clip/ClipAudioSource.hpp
     clip/ClipStreamFeed.hpp
+    clip/ClipStretcher.hpp
     clip/ClipVoice.hpp
     clip/ClipVoicePool.hpp
     clip/EventPlacement.hpp
@@ -92,6 +95,17 @@ target_include_directories(magda_engine PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 #
 # Standing rule for the engine: nothing real-time-concurrent is hand-rolled.
 target_include_directories(magda_engine PUBLIC ${CMAKE_SOURCE_DIR}/third_party/farbot/include)
+
+# The two stretch engines (#2037). Signalsmith Stretch is header-only and MIT;
+# SoundTouch is LGPL-2.1 and its own static target, which is what keeps it
+# replaceable (third_party/soundtouch/SOURCES.md). Both are vendored under
+# third_party/ rather than reached for inside the Tracktion fork, which the
+# boundary check below forbids and which is the whole point of this target.
+#
+# SYSTEM so their warnings are theirs rather than ours.
+target_include_directories(magda_engine SYSTEM PRIVATE
+    ${CMAKE_SOURCE_DIR}/third_party/signalsmith-stretch)
+target_link_libraries(magda_engine PRIVATE soundtouch)
 
 # Borrow JUCE's headers and defines without linking the modules: the model
 # headers name juce::String and juce::Colour, the executor renders into

--- a/magda/engine/clip/ClipAudioSource.cpp
+++ b/magda/engine/clip/ClipAudioSource.cpp
@@ -19,7 +19,10 @@ ClipAudioSource::ClipAudioSource(TrackId trackId, ClipSnapshotFeed& clips, ClipS
     : trackId_(trackId), clips_(clips), streams_(streams) {}
 
 void ClipAudioSource::prepare(const RenderContext& context) {
-    scratch_.setSize(context.numChannels, context.maxBlockSize, false, true, false);
+    // Longer than a block, because a clip playing faster than its file consumes
+    // more reading than it renders and both live in here (ClipStretcher.hpp).
+    scratch_.setSize(context.numChannels, stretchScratchSamples(context.maxBlockSize), false, true,
+                     false);
     scratch_.clear();
 
     for (auto& voice : voices_)
@@ -112,8 +115,8 @@ void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float
                 continue;
             }
 
-            sounding[static_cast<std::size_t>(soundingCount++)] =
-                Sounding{&clip, &event, found->stream.get()};
+            sounding[static_cast<std::size_t>(soundingCount++)] = Sounding{
+                &clip, &event, found->stream.get(), found->stretcher.get(), found->preRollSamples};
         }
     }
 
@@ -130,8 +133,10 @@ void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float
             voice.release();
     }
 
-    auto scratch =
-        juce::dsp::AudioBlock<float>(scratch_).getSubBlock(0, static_cast<std::size_t>(numSamples));
+    // The whole of it, not this block's length: the voice renders into the front
+    // and reads into what is behind, and where the second part starts is fixed
+    // by the largest block rather than by this one.
+    auto scratch = juce::dsp::AudioBlock<float>(scratch_);
 
     for (auto index = 0; index < soundingCount; ++index) {
         const auto& entry = sounding[static_cast<std::size_t>(index)];
@@ -145,7 +150,8 @@ void ClipAudioSource::render(const BlockInfo& block, juce::dsp::AudioBlock<float
             continue;
         }
 
-        voice->render(*entry.clip, *entry.event, block, *entry.stream, scratch, out);
+        voice->render(*entry.clip, *entry.event, block, *entry.stream, entry.stretcher,
+                      entry.preRoll, scratch, out);
     }
 }
 

--- a/magda/engine/clip/ClipAudioSource.hpp
+++ b/magda/engine/clip/ClipAudioSource.hpp
@@ -106,6 +106,11 @@ class ClipAudioSource final : public EngineAudioSource {
         const AudioClipPlayback* clip = nullptr;
         const AudioEventPlayback* event = nullptr;
         PrefetchStream* stream = nullptr;
+
+        /// What plays it at a speed that is not its file's, and what that one
+        /// was cued with. Null and zero for a clip at its file's own speed.
+        ClipStretcher* stretcher = nullptr;
+        int preRoll = 0;
     };
 
     /// The voice already playing this entry, or a free one, or null when every
@@ -119,8 +124,9 @@ class ClipAudioSource final : public EngineAudioSource {
     std::array<ClipVoice, kMaxVoicesPerTrack> voices_;
 
     /// Working space one voice at a time renders into before being summed in.
-    /// One is enough: voices are rendered one after another, and sized for the
-    /// largest block the plan was prepared for.
+    /// One is enough: voices are rendered one after another. Sized for the
+    /// largest block the plan was prepared for, plus the most reading a block
+    /// that long can consume (stretchScratchSamples).
     juce::AudioBuffer<float> scratch_;
 
     std::atomic<int> starved_{0};

--- a/magda/engine/clip/ClipSnapshot.hpp
+++ b/magda/engine/clip/ClipSnapshot.hpp
@@ -182,6 +182,15 @@ struct AudioClipPlayback {
     FadeCurve fadeInCurve = FadeCurve::Linear;
     FadeCurve fadeOutCurve = FadeCurve::Linear;
 
+    /// The same two lengths on the beat face, derived here through the same
+    /// tempo map. Only a speed ramp asks for them, and only on an auto tempo
+    /// clip, where where the material has got to is a question about beats: the
+    /// ramp then has to be measured in the domain the position is derived from,
+    /// and converting a fade length on the audio thread would need a tempo map
+    /// there.
+    double fadeInBeats = 0.0;
+    double fadeOutBeats = 0.0;
+
     /// 0 = gain fade, 1 = speed ramp. A speed ramp is a stretch feature rather
     /// than a gain one, which is why it travels with the fade.
     int fadeInBehaviour = 0;

--- a/magda/engine/clip/ClipSnapshotCompiler.cpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.cpp
@@ -238,6 +238,17 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
                 playback.pitchChange = event.pitchChange;
                 playback.transpose = event.transpose;
 
+                // Half of what auto pitch means is an offset from the project's
+                // pitch sequence, and there is no pitch track in the engine yet
+                // (#1891). The clip plays, at its own transpose, which is the
+                // other half; saying so here is the difference between a known
+                // gap and a clip that is quietly a few semitones out.
+                if (event.autoPitch)
+                    snapshot.diagnostics.push_back(
+                        label + "event " + std::to_string(event.id) +
+                        " follows the pitch track, which the engine does not have yet, so it "
+                        "plays its own transpose alone");
+
                 playback.reversed = event.reversed;
                 playback.leftChannelActive = event.leftChannelActive;
                 playback.rightChannelActive = event.rightChannelActive;

--- a/magda/engine/clip/ClipSnapshotCompiler.cpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.cpp
@@ -162,6 +162,13 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
             audio.fadeInSeconds = fadeIn;
             audio.fadeOutSeconds = fadeOut;
 
+            // Both faces of the same two lengths, converted here because the
+            // audio thread has no tempo map to convert them with. Off the ends
+            // of the audible span rather than of the placement, because that is
+            // what a fade shapes (ClipVoice.hpp).
+            audio.fadeInBeats = tempoMap.timeToBeat(span.startSeconds + fadeIn) - span.startBeat;
+            audio.fadeOutBeats = span.endBeat - tempoMap.timeToBeat(span.endSeconds - fadeOut);
+
             // The clip's edges are the primary event's edges, so they carry its
             // curves. A curve that is not one is reported once, below, where
             // every event is checked rather than only this one.

--- a/magda/engine/clip/ClipStreamFeed.hpp
+++ b/magda/engine/clip/ClipStreamFeed.hpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "clip/ClipStretcher.hpp"
 #include "core/ClipTypes.hpp"
 #include "core/TypeIds.hpp"
 #include "io/PrefetchStream.hpp"
@@ -49,6 +50,22 @@ struct ClipStreamTable {
         /// pool and the last table holding one lets go last is what closes the
         /// file, and neither of them is the audio thread.
         std::shared_ptr<PrefetchStream> stream;
+
+        /// What turns the reading into playback at a speed that is not the
+        /// file's, or null for an entry that plays at its file's own speed.
+        ///
+        /// Here rather than in a voice because it is expensive to build and
+        /// cheap to keep: it is configured for this event, on the thread that
+        /// opened the file, and it lives exactly as long as the reader does. A
+        /// voice claimed and released per block would otherwise be allocating
+        /// one on the audio thread (ClipStretcher.hpp).
+        std::shared_ptr<ClipStretcher> stretcher;
+
+        /// Reading samples the pre-roll sits in front of the event's first
+        /// sample, which is where the stream was pointed. Zero without a
+        /// stretcher, and the reason a voice's first read is the one the pool
+        /// cued rather than one that seeks.
+        int preRollSamples = 0;
     };
 
     std::vector<Entry> entries;

--- a/magda/engine/clip/ClipStretcher.cpp
+++ b/magda/engine/clip/ClipStretcher.cpp
@@ -1,0 +1,477 @@
+#include "clip/ClipStretcher.hpp"
+
+#include <SoundTouch.h>
+#include <signalsmith-stretch.h>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "core/TimeStretchModes.hpp"
+#include "io/SourceReaders.hpp"
+
+namespace magda::engine {
+
+namespace {
+
+/// Channel pointers, gathered without allocating. Every implementation needs
+/// them, both libraries want an array of them, and a block cannot be handed over
+/// as one.
+class ChannelPointers {
+  public:
+    explicit ChannelPointers(int numChannels)
+        : reading_(static_cast<std::size_t>(numChannels)),
+          writing_(static_cast<std::size_t>(numChannels)) {}
+
+    const float* const* gather(juce::dsp::AudioBlock<const float> block, int offset = 0) {
+        for (std::size_t channel = 0; channel < reading_.size(); ++channel)
+            reading_[channel] = channel < block.getNumChannels()
+                                    ? block.getChannelPointer(channel) + offset
+                                    : nullptr;
+        return reading_.data();
+    }
+
+    float* const* gather(juce::dsp::AudioBlock<float> block) {
+        for (std::size_t channel = 0; channel < writing_.size(); ++channel)
+            writing_[channel] =
+                channel < block.getNumChannels() ? block.getChannelPointer(channel) : nullptr;
+        return writing_.data();
+    }
+
+  private:
+    std::vector<const float*> reading_;
+    std::vector<float*> writing_;
+};
+
+int samplesOf(juce::dsp::AudioBlock<const float> block) {
+    return static_cast<int>(block.getNumSamples());
+}
+
+/// A pre-roll buffer big enough for the rate an event usually runs at, with room
+/// for it to wander. Auto tempo's rate moves with the tempo curve, so the rate at
+/// the moment of a locate is not the rate this was sized for; a quarter again
+/// covers an ordinary tempo ramp, and beyond that priming is short rather than
+/// wrong.
+constexpr double kPreRollHeadroom = 1.25;
+
+/**
+ * @brief Signalsmith Stretch, the default engine.
+ *
+ * A phase vocoder, so the ratio is whatever a call is handed: input samples in,
+ * output samples out, and the two lengths are the rate. That is what makes a
+ * tempo curve free here, where an engine with a set tempo has to be told.
+ *
+ * Configured the way the incumbent configures it, down to the formant base and
+ * the pitch-compensated neutral formant shift, because a project that sounded a
+ * particular way through the fork has to go on sounding that way.
+ *
+ * Priming is `outputSeek`, which is the library's own answer to starting in the
+ * middle of a file: hand it the material leading up to the first sample wanted
+ * and it pre-computes the output that would have led there, so the next call
+ * begins aligned rather than fading in over a window. The incumbent primes with
+ * the material *after* the start instead, and so begins every stretched clip
+ * about a preset window late; that is the one place this deliberately differs.
+ */
+class SignalsmithClipStretcher final : public ClipStretcher {
+  public:
+    explicit SignalsmithClipStretcher(const StretchSetup& setup)
+        : channels_(setup.numChannels), pointers_(setup.numChannels) {
+        // splitComputation: the FFT work is spread across calls rather than
+        // landing in whichever block crosses a window boundary. This runs on the
+        // audio thread, so the flat cost is the one that matters.
+        stretch_.presetDefault(channels_, static_cast<float>(setup.sampleRate), true);
+        stretch_.setFormantBase(static_cast<float>(200.0 / setup.sampleRate));
+        stretch_.setTransposeSemitones(setup.semitones);
+        stretch_.setFormantFactor(1.0f, true);
+
+        allocatePreRoll(channels_, static_cast<int>(std::ceil(preRollSamples(setup.nominalRate) *
+                                                              kPreRollHeadroom)));
+    }
+
+    int preRollSamples(double rate) const override {
+        return static_cast<int>(std::ceil(stretch_.outputSeekLength(static_cast<float>(rate))));
+    }
+
+    void reset() override {
+        stretch_.reset();
+    }
+
+    void prime(PrefetchStream& stream, std::int64_t until, int samples, double) override {
+        const auto before = readPreRoll(stream, until, samples);
+        const auto count = samplesOf(before);
+
+        if (count <= 0) {
+            stretch_.reset();
+            return;
+        }
+
+        // outputSeek resets on its way in, and infers the rate from how much it
+        // was given, which is why preRollSamples above is the length to give it.
+        stretch_.outputSeek(pointers_.gather(before), count);
+    }
+
+    void process(juce::dsp::AudioBlock<const float> input, double, double,
+                 juce::dsp::AudioBlock<float> output) override {
+        const auto in = samplesOf(input);
+        const auto out = static_cast<int>(output.getNumSamples());
+        if (out <= 0)
+            return;
+
+        if (in <= 0) {
+            output.clear();
+            return;
+        }
+
+        const auto* const* sources = pointers_.gather(input);
+        auto* const* destinations = pointers_.gather(output);
+        stretch_.process(sources, in, destinations, out);
+    }
+
+  private:
+    int channels_ = 2;
+    ChannelPointers pointers_;
+    signalsmith::stretch::SignalsmithStretch<float> stretch_;
+};
+
+/**
+ * @brief SoundTouch, for the two pinned modes that name it.
+ *
+ * Carried because kSoundTouchNormal and kSoundTouchBetter are project-file
+ * integers: sessions saved with either have to go on playing through the
+ * algorithm they were made with, whatever else is available now.
+ *
+ * A pipe rather than a function, which is the awkward part. It takes input and
+ * gives back whatever it has finished, so a block cannot demand an exact length
+ * the way the phase vocoder can. Two things follow. Its tempo is set per block
+ * from the two lengths, so a moving rate still works. And what it holds back is
+ * absorbed by priming with more material than alignment alone needs: enough that
+ * once the pre-roll's own output has been discarded there is a block's worth
+ * already waiting, so the first block a listener hears is full rather than the
+ * fourth.
+ */
+class SoundTouchClipStretcher final : public ClipStretcher {
+  public:
+    explicit SoundTouchClipStretcher(const StretchSetup& setup)
+        : channels_(setup.numChannels), maxBlockSamples_(setup.maxBlockSamples) {
+        touch_.setChannels(static_cast<unsigned int>(channels_));
+        touch_.setSampleRate(static_cast<unsigned int>(setup.sampleRate));
+
+        if (setup.mode == time_stretch_mode::kSoundTouchBetter) {
+            touch_.setSetting(SETTING_USE_AA_FILTER, 1);
+            touch_.setSetting(SETTING_AA_FILTER_LENGTH, 64);
+            touch_.setSetting(SETTING_USE_QUICKSEEK, 0);
+            touch_.setSetting(SETTING_SEQUENCE_MS, 60);
+            touch_.setSetting(SETTING_SEEKWINDOW_MS, 25);
+        }
+
+        touch_.setPitchSemiTones(setup.semitones);
+        touch_.setTempo(std::clamp(setup.nominalRate, kMinStretchRate, kMaxStretchRate));
+
+        // Sized for the worst block this can be asked for: the largest output
+        // block, times the fastest the reading may be consumed for it. Grown
+        // here, on the thread that made this, and never again.
+        const auto frames =
+            static_cast<int>(std::ceil(setup.maxBlockSamples * kMaxStretchRate)) + 1;
+        interleaved_.resize(static_cast<std::size_t>(frames * channels_));
+        deinterleaved_.resize(static_cast<std::size_t>(setup.maxBlockSamples * channels_));
+
+        allocatePreRoll(channels_, static_cast<int>(std::ceil(preRollSamples(setup.nominalRate) *
+                                                              kPreRollHeadroom)));
+    }
+
+    int preRollSamples(double rate) const override {
+        // What the pipe holds before it will answer at all, plus a block's worth
+        // of surplus so that the block after priming is already there. Both are
+        // input samples, so the surplus is counted at the rate it will be
+        // consumed at.
+        const auto latency = touch_.getSetting(SETTING_INITIAL_LATENCY);
+        const auto batch = touch_.getSetting(SETTING_NOMINAL_OUTPUT_SEQUENCE);
+        const auto cushion = std::max(maxBlockSamples_, std::max(batch, 0));
+
+        return latency + static_cast<int>(std::ceil(cushion * rate));
+    }
+
+    void reset() override {
+        touch_.clear();
+        discard_ = 0;
+    }
+
+    void prime(PrefetchStream& stream, std::int64_t until, int samples, double rate) override {
+        touch_.clear();
+        discard_ = 0;
+        touch_.setTempo(std::clamp(rate, kMinStretchRate, kMaxStretchRate));
+
+        const auto before = readPreRoll(stream, until, samples);
+        const auto count = samplesOf(before);
+        if (count <= 0)
+            return;
+
+        // In pieces, because the interleaving buffer is sized for a block rather
+        // than for a whole pre-roll, and because putSamples does not care how
+        // many calls the material arrives in.
+        const auto stride =
+            static_cast<int>(interleaved_.size() / static_cast<std::size_t>(channels_));
+
+        for (auto done = 0; done < count;) {
+            const auto run = std::min(stride, count - done);
+            write(before, done, run);
+            done += run;
+        }
+
+        // Everything the pre-roll will eventually come back out as. Discarding
+        // it is what puts the output at the first sample meant to be heard;
+        // draining happens as it becomes available, over however many blocks
+        // that takes, because the pipe cannot be made to answer sooner.
+        discard_ = static_cast<int>(std::llround(count / std::max(rate, kMinStretchRate)));
+    }
+
+    void process(juce::dsp::AudioBlock<const float> input, double, double,
+                 juce::dsp::AudioBlock<float> output) override {
+        const auto in = samplesOf(input);
+        const auto out = static_cast<int>(output.getNumSamples());
+        if (out <= 0)
+            return;
+
+        if (in > 0) {
+            touch_.setTempo(
+                std::clamp(static_cast<double>(in) / out, kMinStretchRate, kMaxStretchRate));
+            write(input, 0, in);
+        }
+
+        if (discard_ > 0)
+            discard_ -=
+                static_cast<int>(touch_.receiveSamples(static_cast<unsigned int>(discard_)));
+
+        const auto ready = discard_ > 0
+                               ? 0
+                               : static_cast<int>(touch_.receiveSamples(
+                                     deinterleaved_.data(),
+                                     static_cast<unsigned int>(std::min(out, maxBlockSamples_))));
+
+        for (std::size_t channel = 0; channel < output.getNumChannels(); ++channel) {
+            auto* destination = output.getChannelPointer(channel);
+            const auto source = std::min(static_cast<int>(channel), channels_ - 1);
+
+            for (auto sample = 0; sample < ready; ++sample)
+                destination[sample] =
+                    deinterleaved_[static_cast<std::size_t>(sample * channels_ + source)];
+
+            // A pipe that has not caught up yet is silence rather than whatever
+            // the scratch held. It happens on the blocks a locate is still being
+            // absorbed over, and the voice hears it as not having sounded.
+            for (auto sample = ready; sample < out; ++sample)
+                destination[sample] = 0.0f;
+        }
+    }
+
+  private:
+    void write(juce::dsp::AudioBlock<const float> block, int offset, int count) {
+        for (auto sample = 0; sample < count; ++sample)
+            for (auto channel = 0; channel < channels_; ++channel) {
+                const auto source =
+                    std::min(static_cast<std::size_t>(channel), block.getNumChannels() - 1);
+                interleaved_[static_cast<std::size_t>(sample * channels_ + channel)] =
+                    block.getChannelPointer(source)[offset + sample];
+            }
+
+        touch_.putSamples(interleaved_.data(), static_cast<unsigned int>(count));
+    }
+
+    int channels_ = 2;
+    int maxBlockSamples_ = 512;
+
+    /// Output samples still owed to the pre-roll. Non-zero only while a start or
+    /// a locate is being absorbed.
+    int discard_ = 0;
+
+    std::vector<float> interleaved_;
+    std::vector<float> deinterleaved_;
+    soundtouch::SoundTouch touch_;
+};
+
+/**
+ * @brief The reading played faster or slower, pitch and all.
+ *
+ * Not a stretcher: this is what a tape machine does, and it is what analog pitch
+ * asks for (AudioEvent::isAnalogPitchActive). The model has already folded the
+ * pitch factor into the speed ratio when that mode is on, so there is nothing to
+ * do here but land between samples.
+ *
+ * The same cubic curve the rate converter below the stream uses
+ * (io/SourceReaders.hpp), so a file at another rate and a clip playing fast are
+ * not two different sounds.
+ *
+ * The curve reaches a sample either side of where it lands, and the stream above
+ * cannot be read twice: a read that does not continue the last one is a seek. So
+ * the read runs @ref readAheadSamples ahead of the position wanted and the few
+ * samples behind it are kept here. A constant offset and a fixed history, not a
+ * cursor: where a block reads is still derived from the timeline, and nothing
+ * accumulates.
+ */
+class ResamplingClipStretcher final : public ClipStretcher {
+  public:
+    explicit ResamplingClipStretcher(const StretchSetup& setup) : channels_(setup.numChannels) {
+        history_.setSize(channels_, kHistory);
+        history_.clear();
+        allocatePreRoll(channels_, kHistory);
+    }
+
+    int readAheadSamples() const override {
+        return kReadAhead;
+    }
+
+    int preRollSamples(double) const override {
+        return kHistory;
+    }
+
+    void reset() override {
+        history_.clear();
+    }
+
+    void prime(PrefetchStream& stream, std::int64_t until, int samples, double) override {
+        history_.clear();
+
+        const auto before = readPreRoll(stream, until, std::min(samples, kHistory));
+        const auto count = samplesOf(before);
+        const auto taken = std::min(count, kHistory);
+        if (taken <= 0)
+            return;
+
+        // The last of it, and pushed to the end: what a curve reaches back for
+        // is the material immediately before where it lands, so a short pre-roll
+        // leaves the silence at the far end rather than under the first sample.
+        for (auto channel = 0; channel < channels_; ++channel) {
+            const auto source =
+                std::min(static_cast<std::size_t>(channel), before.getNumChannels() - 1);
+            history_.copyFrom(channel, kHistory - taken,
+                              before.getChannelPointer(source) + count - taken, taken);
+        }
+    }
+
+    void process(juce::dsp::AudioBlock<const float> input, double offset, double step,
+                 juce::dsp::AudioBlock<float> output) override {
+        const auto in = samplesOf(input);
+        const auto out = static_cast<int>(output.getNumSamples());
+        if (out <= 0)
+            return;
+
+        if (in <= 0) {
+            output.clear();
+            return;
+        }
+
+        for (std::size_t channel = 0; channel < output.getNumChannels(); ++channel) {
+            const auto source = std::min(channel, input.getNumChannels() - 1);
+            const auto* kept =
+                history_.getReadPointer(std::min(static_cast<int>(channel), channels_ - 1));
+            const auto* fresh = input.getChannelPointer(source);
+            auto* destination = output.getChannelPointer(channel);
+
+            // History first, then this block's input: one array, so a position
+            // that falls across the join needs no special case.
+            const auto at = [kept, fresh, in](int index) {
+                if (index < kHistory)
+                    return kept[std::max(index, 0)];
+                return fresh[std::min(index - kHistory, in - 1)];
+            };
+
+            for (auto sample = 0; sample < out; ++sample) {
+                const auto position = kHistory + offset + sample * step;
+                const auto index = static_cast<int>(std::floor(position));
+
+                destination[sample] = cubicLagrange(at(index - 1), at(index), at(index + 1),
+                                                    at(index + 2), position - index);
+            }
+        }
+
+        // What the next block will reach back into.
+        for (auto channel = 0; channel < channels_; ++channel) {
+            const auto source =
+                std::min(static_cast<std::size_t>(channel), input.getNumChannels() - 1);
+            const auto taken = std::min(in, kHistory);
+
+            if (taken < kHistory)
+                for (auto sample = 0; sample < kHistory - taken; ++sample)
+                    history_.setSample(channel, sample,
+                                       history_.getSample(channel, sample + taken));
+
+            history_.copyFrom(channel, kHistory - taken,
+                              input.getChannelPointer(source) + in - taken, taken);
+        }
+    }
+
+  private:
+    /// Samples kept behind the block. Enough that the slowest rate the engine
+    /// allows still lands inside them, with a sample to spare either end.
+    static constexpr int kHistory = 6;
+
+    /// How far ahead of the wanted position the reading is consumed, so the
+    /// curve's forward reach is always inside material already read.
+    static constexpr int kReadAhead = 3;
+
+    int channels_ = 2;
+    juce::AudioBuffer<float> history_;
+};
+
+}  // namespace
+
+void ClipStretcher::allocatePreRoll(int numChannels, int numSamples) {
+    preRoll_.setSize(std::max(1, numChannels), std::max(0, numSamples));
+    preRoll_.clear();
+}
+
+juce::dsp::AudioBlock<const float> ClipStretcher::readPreRoll(PrefetchStream& stream,
+                                                              std::int64_t until, int wanted) {
+    // What fits, and taken from the end: the samples that matter are the ones
+    // immediately before the first one to be heard, so a pre-roll that has to be
+    // cut short is cut at the far end rather than at the near one.
+    const auto count = std::min(wanted, preRoll_.getNumSamples());
+    if (count <= 0)
+        return {};
+
+    juce::dsp::AudioBlock<float> block(preRoll_);
+    auto region = block.getSubBlock(0, static_cast<std::size_t>(count));
+    region.clear();
+
+    // Whatever the stream had. Short is the ordinary answer while a locate is
+    // still being caught up with, and the silence in front of it primes as
+    // silence, which is what it will sound like.
+    stream.read(until - count, region, count);
+
+    return region;
+}
+
+std::unique_ptr<ClipStretcher> makeStretcher(const StretchSetup& setup) {
+    if (setup.numChannels <= 0 || setup.maxBlockSamples <= 0 || !(setup.sampleRate > 0.0))
+        return nullptr;
+
+    switch (setup.mode) {
+        case time_stretch_mode::kSignalsmith:
+            return std::make_unique<SignalsmithClipStretcher>(setup);
+
+        case time_stretch_mode::kSoundTouchNormal:
+        case time_stretch_mode::kSoundTouchBetter:
+            return std::make_unique<SoundTouchClipStretcher>(setup);
+
+        case time_stretch_mode::kDisabled:
+            // Nothing to preserve, so a rate change is a tape speed change and a
+            // rate of one is nothing at all. This is the analog pitch path: the
+            // model has already put the pitch factor into the speed ratio.
+            //
+            // A speed ramp is the exception to the rate of one. Its edges are
+            // not at one however the clip is set, and a ramp is a tape effect in
+            // any case, so this is what plays it.
+            if (!setup.speedRamp && std::abs(setup.nominalRate - 1.0) < 1.0e-9)
+                return nullptr;
+
+            return std::make_unique<ResamplingClipStretcher>(setup);
+
+        default:
+            // A mode this build has no engine for. Playing it at unity is the
+            // honest answer: the alternative is silence, and the alternative to
+            // that is quietly substituting an algorithm the project never named.
+            return nullptr;
+    }
+}
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipStretcher.cpp
+++ b/magda/engine/clip/ClipStretcher.cpp
@@ -167,11 +167,11 @@ class SoundTouchClipStretcher final : public ClipStretcher {
         touch_.setPitchSemiTones(setup.semitones);
         touch_.setTempo(std::clamp(setup.nominalRate, kMinStretchRate, kMaxStretchRate));
 
-        // Sized for the worst block this can be asked for: the largest output
-        // block, times the fastest the reading may be consumed for it. Grown
-        // here, on the thread that made this, and never again.
-        const auto frames =
-            static_cast<int>(std::ceil(setup.maxBlockSamples * kMaxStretchRate)) + 1;
+        // Sized for the worst block this can be asked for, through the same
+        // function the voice bounds a block's reading with: two derivations of
+        // that number differing by a sample is a write past the end of this.
+        // Grown here, on the thread that made this, and never again.
+        const auto frames = maxReadingSamples(setup.maxBlockSamples);
         interleaved_.resize(static_cast<std::size_t>(frames * channels_));
         deinterleaved_.resize(static_cast<std::size_t>(setup.maxBlockSamples * channels_));
 
@@ -450,6 +450,26 @@ std::unique_ptr<ClipStretcher> makeStretcher(const StretchSetup& setup) {
     if (setup.numChannels <= 0 || setup.maxBlockSamples <= 0 || !(setup.sampleRate > 0.0))
         return nullptr;
 
+    // A clip that asks for nothing gets nothing, whatever its mode field says,
+    // and that is a parity requirement rather than an economy. The mode is a
+    // preference for how to stretch and not an instruction to stretch: the
+    // incumbent engages an engine on auto tempo, auto pitch, a pitch change or a
+    // ratio off unity, and never on the mode alone
+    // (AudioClipBase::usesTimeStretchedProxy). A clip whose dropdown was touched
+    // once and asks for nothing plays clean through the fork, and a phase
+    // vocoder run at one-to-one is not clean: it re-synthesises what it was
+    // given. Every project that ever opened that dropdown would otherwise be a
+    // difference in the null-diff corpus (#2040).
+    //
+    // Auto tempo is the carve-out, and keeps its engine at a unity average. The
+    // average is not what it plays at: its ratio is the project's tempo over the
+    // file's own and moves with the tempo curve, so a clip averaging unity is
+    // still stretching in both directions around it. The incumbent engages on
+    // auto tempo alone for the same reason.
+    if (!setup.followsTempo && !setup.speedRamp && std::abs(setup.semitones) < 0.001f &&
+        std::abs(setup.nominalRate - 1.0) < 1.0e-9)
+        return nullptr;
+
     switch (setup.mode) {
         case time_stretch_mode::kSignalsmith:
             return std::make_unique<SignalsmithClipStretcher>(setup);
@@ -459,16 +479,9 @@ std::unique_ptr<ClipStretcher> makeStretcher(const StretchSetup& setup) {
             return std::make_unique<SoundTouchClipStretcher>(setup);
 
         case time_stretch_mode::kDisabled:
-            // Nothing to preserve, so a rate change is a tape speed change and a
-            // rate of one is nothing at all. This is the analog pitch path: the
-            // model has already put the pitch factor into the speed ratio.
-            //
-            // A speed ramp is the exception to the rate of one. Its edges are
-            // not at one however the clip is set, and a ramp is a tape effect in
-            // any case, so this is what plays it.
-            if (!setup.speedRamp && std::abs(setup.nominalRate - 1.0) < 1.0e-9)
-                return nullptr;
-
+            // Nothing to preserve, so a rate change is a tape speed change. This
+            // is the analog pitch path: the model has already put the pitch
+            // factor into the speed ratio, and a ramp is a tape effect too.
             return std::make_unique<ResamplingClipStretcher>(setup);
 
         default:

--- a/magda/engine/clip/ClipStretcher.cpp
+++ b/magda/engine/clip/ClipStretcher.cpp
@@ -177,6 +177,38 @@ class SoundTouchClipStretcher final : public ClipStretcher {
 
         allocatePreRoll(channels_, static_cast<int>(std::ceil(preRollSamples(setup.nominalRate) *
                                                               kPreRollHeadroom)));
+
+        // SoundTouch grows its own pipes on demand: putSamples calls
+        // ensureCapacity, which is a new[], a memcpy and a delete[], and it
+        // starts life with room for thirty two samples. Both the calls that feed
+        // it are on the audio thread, so without this the first clip start, the
+        // first locate and every setting change would allocate inside a
+        // callback.
+        //
+        // Grown here instead, on the thread that made it, and cleared after:
+        // FIFOSampleBuffer::clear drops the samples and keeps the buffer, so the
+        // capacity stays behind and nothing downstream ever grows again.
+        //
+        // In one push rather than in the pieces playback uses, and that is the
+        // whole trick. putSamples grows to hold what a single call hands it, so
+        // one call of the worst case settles the capacity outright; feeding the
+        // same total in block-sized pieces only grows it to whatever residue
+        // that particular rate happened to leave between batches, which is why
+        // a warm-up that ran at ten and a clip that played at nine could still
+        // meet an allocation.
+        const auto worst = worstCase(setup);
+
+        for (const auto rate : {kMaxStretchRate, kMinStretchRate,
+                                std::clamp(setup.nominalRate, kMinStretchRate, kMaxStretchRate)}) {
+            touch_.setTempo(rate);
+            pushSilence(worst);
+
+            while (touch_.numSamples() > 0)
+                touch_.receiveSamples(touch_.numSamples());
+        }
+
+        touch_.setTempo(std::clamp(setup.nominalRate, kMinStretchRate, kMaxStretchRate));
+        touch_.clear();
     }
 
     int preRollSamples(double rate) const override {
@@ -255,6 +287,44 @@ class SoundTouchClipStretcher final : public ClipStretcher {
     }
 
   private:
+    /**
+     * @brief The most this pipe can ever be holding at once.
+     *
+     * What it keeps back between batches, plus the largest single push a
+     * callback can hand it. The first is the sequence length it asks for, which
+     * moves with the tempo, so the range is scanned for the longest one: that is
+     * arithmetic rather than processing, because setTempo recalculates the
+     * lengths and getSetting reports them without a sample going through.
+     *
+     * The second is whichever is larger of a block's reading and a pre-roll.
+     * Both are bounded before the callback: the reading by the rate ceiling, the
+     * pre-roll by the buffer it is read into.
+     */
+    int worstCase(const StretchSetup& setup) {
+        auto sequence = 0;
+
+        for (auto step = 0; step <= kWarmUpSteps; ++step) {
+            const auto through = static_cast<double>(step) / kWarmUpSteps;
+            touch_.setTempo(kMinStretchRate + (kMaxStretchRate - kMinStretchRate) * through);
+            sequence = std::max(sequence, touch_.getSetting(SETTING_NOMINAL_INPUT_SEQUENCE));
+        }
+
+        touch_.setTempo(std::clamp(setup.nominalRate, kMinStretchRate, kMaxStretchRate));
+
+        const auto handed = std::max(
+            maxReadingSamples(maxBlockSamples_),
+            static_cast<int>(std::ceil(preRollSamples(setup.nominalRate) * kPreRollHeadroom)));
+
+        return sequence + handed;
+    }
+
+    /// @p count samples of silence, in one call, so that the pipe grows to hold
+    /// all of it rather than to whatever it had room for at the time.
+    void pushSilence(int count) {
+        std::vector<float> silence(static_cast<std::size_t>(count * channels_), 0.0f);
+        touch_.putSamples(silence.data(), static_cast<unsigned int>(count));
+    }
+
     /// All of @p count, in pieces the interleaving buffer can hold. The buffer
     /// is sized for one block's worth of reading and a pre-roll is many times
     /// that, and putSamples does not care how many calls the material arrives
@@ -281,6 +351,11 @@ class SoundTouchClipStretcher final : public ClipStretcher {
 
         touch_.putSamples(interleaved_.data(), static_cast<unsigned int>(count));
     }
+
+    /// Tempos the range is scanned at for the longest sequence. The lengths are
+    /// a clamped straight line in the tempo (TDStretch::calcSeqParameters), so
+    /// this is a fine sieve over a smooth curve rather than a hopeful sample.
+    static constexpr int kWarmUpSteps = 64;
 
     int channels_ = 2;
     int maxBlockSamples_ = 512;

--- a/magda/engine/clip/ClipStretcher.cpp
+++ b/magda/engine/clip/ClipStretcher.cpp
@@ -206,17 +206,7 @@ class SoundTouchClipStretcher final : public ClipStretcher {
         if (count <= 0)
             return;
 
-        // In pieces, because the interleaving buffer is sized for a block rather
-        // than for a whole pre-roll, and because putSamples does not care how
-        // many calls the material arrives in.
-        const auto stride =
-            static_cast<int>(interleaved_.size() / static_cast<std::size_t>(channels_));
-
-        for (auto done = 0; done < count;) {
-            const auto run = std::min(stride, count - done);
-            write(before, done, run);
-            done += run;
-        }
+        writeAll(before, count);
 
         // Everything the pre-roll will eventually come back out as. Discarding
         // it is what puts the output at the first sample meant to be heard;
@@ -235,7 +225,7 @@ class SoundTouchClipStretcher final : public ClipStretcher {
         if (in > 0) {
             touch_.setTempo(
                 std::clamp(static_cast<double>(in) / out, kMinStretchRate, kMaxStretchRate));
-            write(input, 0, in);
+            writeAll(input, in);
         }
 
         if (discard_ > 0)
@@ -265,6 +255,21 @@ class SoundTouchClipStretcher final : public ClipStretcher {
     }
 
   private:
+    /// All of @p count, in pieces the interleaving buffer can hold. The buffer
+    /// is sized for one block's worth of reading and a pre-roll is many times
+    /// that, and putSamples does not care how many calls the material arrives
+    /// in; nothing else here may assume a length it did not size for.
+    void writeAll(juce::dsp::AudioBlock<const float> block, int count) {
+        const auto stride =
+            static_cast<int>(interleaved_.size() / static_cast<std::size_t>(channels_));
+
+        for (auto done = 0; done < count;) {
+            const auto run = std::min(stride, count - done);
+            write(block, done, run);
+            done += run;
+        }
+    }
+
     void write(juce::dsp::AudioBlock<const float> block, int offset, int count) {
         for (auto sample = 0; sample < count; ++sample)
             for (auto channel = 0; channel < channels_; ++channel) {
@@ -467,10 +472,16 @@ std::unique_ptr<ClipStretcher> makeStretcher(const StretchSetup& setup) {
             return std::make_unique<ResamplingClipStretcher>(setup);
 
         default:
-            // A mode this build has no engine for. Playing it at unity is the
-            // honest answer: the alternative is silence, and the alternative to
-            // that is quietly substituting an algorithm the project never named.
-            return nullptr;
+            // A mode this build has no engine for, which is every value
+            // Tracktion's enum holds that MAGDA never wrote. The incumbent
+            // answers this with its default engine (TimeStretcher::
+            // checkModeIsAvailable) and so does this: the clip is asking to be
+            // stretched, and the position map has already decided how much
+            // material a block will consume. Returning nothing here would leave
+            // a block reading that material at unity and the next one starting
+            // where the ratio says, which is a skip at every block boundary
+            // rather than a fallback.
+            return std::make_unique<SignalsmithClipStretcher>(setup);
     }
 }
 

--- a/magda/engine/clip/ClipStretcher.cpp
+++ b/magda/engine/clip/ClipStretcher.cpp
@@ -196,15 +196,52 @@ class SoundTouchClipStretcher final : public ClipStretcher {
         // that particular rate happened to leave between batches, which is why
         // a warm-up that ran at ten and a clip that played at nine could still
         // meet an allocation.
+        //
+        // Two pushes, and both are cheap, because what is being settled is
+        // capacity rather than sound. The input side is settled where the
+        // sequence is longest, and the output side at the other end of the
+        // range, where the fewest input samples make the most output: a handful
+        // of samples at a tenth speed reaches the same capacity that grinding a
+        // whole pre-roll through would. This runs inside a provisioning round,
+        // beside opening files, and a round that took as long as the DSP would
+        // have publishes clips after they were due.
+        // Two shapes of warm-up, because the pipe has two kinds of buffer in it
+        // and they answer to different things.
+        //
+        // What a callback hands in goes to the front of the pipe, and that
+        // capacity is settled by one push of the worst case, done where the
+        // sequence is longest. It is done at the top of the rate range on
+        // purpose: what a push costs to process is what comes out of it, and at
+        // the top of the range that is a tenth of what went in.
         const auto worst = worstCase(setup);
 
-        for (const auto rate : {kMaxStretchRate, kMinStretchRate,
-                                std::clamp(setup.nominalRate, kMinStretchRate, kMaxStretchRate)}) {
-            touch_.setTempo(rate);
-            pushSilence(worst);
+        touch_.setTempo(worst.atTempo);
+        pushSilence(worst.input);
+        drainAll();
 
-            while (touch_.numSamples() > 0)
-                touch_.receiveSamples(touch_.numSamples());
+        // Everything behind that front buffer works in batches whose size moves
+        // with the tempo, and a batch is not something this can predict from the
+        // outside: it is the sequence length, the overlap, the seek window and
+        // whether the rate transposer sits before or after the stretcher. So
+        // they are grown by being used, one batch at a time, which is what a
+        // batch costs and no more. Pushing the worst case at every tempo instead
+        // would grind a pre-roll through at a tenth speed, ten times its length
+        // in output, and a provisioning round that took that long would publish
+        // clips after they were due.
+        //
+        // Six tempos rather than a fine scan, and they are the six that bound
+        // it. Every length behind this is a clamped straight line in the tempo
+        // (TDStretch::calcSeqParameters), so between any two of the points below
+        // each of them is monotonic and cannot exceed what the two ends of that
+        // interval already reached. kAutoSequenceLow and kAutoSequenceTop are
+        // where those lines flatten out; the ends of the rate range and the rate
+        // this clip will actually run at are the rest.
+        for (const auto rate :
+             {kMinStretchRate, kAutoSequenceLow, 1.0, kAutoSequenceTop, kMaxStretchRate,
+              std::clamp(setup.nominalRate, kMinStretchRate, kMaxStretchRate)}) {
+            touch_.setTempo(rate);
+            pushSilence(touch_.getSetting(SETTING_NOMINAL_INPUT_SEQUENCE) + 1);
+            drainAll();
         }
 
         touch_.setTempo(std::clamp(setup.nominalRate, kMinStretchRate, kMaxStretchRate));
@@ -238,13 +275,28 @@ class SoundTouchClipStretcher final : public ClipStretcher {
         if (count <= 0)
             return;
 
-        writeAll(before, count);
-
-        // Everything the pre-roll will eventually come back out as. Discarding
-        // it is what puts the output at the first sample meant to be heard;
-        // draining happens as it becomes available, over however many blocks
-        // that takes, because the pipe cannot be made to answer sooner.
+        // Everything the pre-roll will come back out as belongs before the first
+        // sample to be heard, so all of it is discarded. What is left owing when
+        // this returns is drained over the blocks that follow, because a pipe
+        // cannot be made to answer sooner than it will.
         discard_ = static_cast<int>(std::llround(count / std::max(rate, kMinStretchRate)));
+
+        // Fed in pieces and drained as it goes, rather than pushed in whole and
+        // drained afterwards. A pre-roll is thousands of samples and comes back
+        // out as thousands more, and a pipe left holding all of it at once would
+        // have to have been grown to hold all of it: that growth is an
+        // allocation, and moving it off the audio thread then means processing
+        // the whole worst case before the clip can play. Draining as it fills
+        // keeps what is pending down to a batch, here and in the warm-up both.
+        const auto stride =
+            static_cast<int>(interleaved_.size() / static_cast<std::size_t>(channels_));
+
+        for (auto done = 0; done < count;) {
+            const auto run = std::min(stride, count - done);
+            write(before, done, run);
+            drainDiscarded();
+            done += run;
+        }
     }
 
     void process(juce::dsp::AudioBlock<const float> input, double, double,
@@ -260,9 +312,7 @@ class SoundTouchClipStretcher final : public ClipStretcher {
             writeAll(input, in);
         }
 
-        if (discard_ > 0)
-            discard_ -=
-                static_cast<int>(touch_.receiveSamples(static_cast<unsigned int>(discard_)));
+        drainDiscarded();
 
         const auto ready = discard_ > 0
                                ? 0
@@ -287,26 +337,42 @@ class SoundTouchClipStretcher final : public ClipStretcher {
     }
 
   private:
+    /// The most the front of the pipe can ever be holding, and the tempo where
+    /// that is true.
+    struct WorstCase {
+        int input = 0;
+        double atTempo = kMaxStretchRate;
+    };
+
     /**
-     * @brief The most this pipe can ever be holding at once.
+     * @brief What this has to have room for before a callback asks.
      *
-     * What it keeps back between batches, plus the largest single push a
-     * callback can hand it. The first is the sequence length it asks for, which
-     * moves with the tempo, so the range is scanned for the longest one: that is
-     * arithmetic rather than processing, because setTempo recalculates the
-     * lengths and getSetting reports them without a sample going through.
-     *
-     * The second is whichever is larger of a block's reading and a pre-roll.
-     * Both are bounded before the callback: the reading by the rate ceiling, the
+     * The input side is what it keeps back between batches plus the largest
+     * single push a callback can hand it. The sequence it keeps back moves with
+     * the tempo, so the range is scanned for the longest one, and the largest
+     * push is whichever is larger of a block's reading and a pre-roll: both are
+     * bounded before the callback, the reading by the rate ceiling and the
      * pre-roll by the buffer it is read into.
+     *
+     * The scan is arithmetic rather than processing: setTempo recalculates the
+     * lengths and getSetting reports them without a sample going through. What
+     * comes back is the tempo to push at as well as the size, because pushing
+     * where the sequence is longest is what settles it in one call.
      */
-    int worstCase(const StretchSetup& setup) {
+    WorstCase worstCase(const StretchSetup& setup) {
         auto sequence = 0;
+        auto atTempo = kMaxStretchRate;
 
         for (auto step = 0; step <= kWarmUpSteps; ++step) {
             const auto through = static_cast<double>(step) / kWarmUpSteps;
-            touch_.setTempo(kMinStretchRate + (kMaxStretchRate - kMinStretchRate) * through);
-            sequence = std::max(sequence, touch_.getSetting(SETTING_NOMINAL_INPUT_SEQUENCE));
+            const auto rate = kMinStretchRate + (kMaxStretchRate - kMinStretchRate) * through;
+            touch_.setTempo(rate);
+
+            if (const auto asked = touch_.getSetting(SETTING_NOMINAL_INPUT_SEQUENCE);
+                asked > sequence) {
+                sequence = asked;
+                atTempo = rate;
+            }
         }
 
         touch_.setTempo(std::clamp(setup.nominalRate, kMinStretchRate, kMaxStretchRate));
@@ -315,7 +381,25 @@ class SoundTouchClipStretcher final : public ClipStretcher {
             maxReadingSamples(maxBlockSamples_),
             static_cast<int>(std::ceil(preRollSamples(setup.nominalRate) * kPreRollHeadroom)));
 
-        return sequence + handed;
+        return WorstCase{sequence + handed, atTempo};
+    }
+
+    /// Take back everything ready, discarding it. Off the audio thread, in the
+    /// warm-up, where what came out is silence anyway.
+    void drainAll() {
+        while (touch_.numSamples() > 0)
+            touch_.receiveSamples(touch_.numSamples());
+    }
+
+    /// Give back what still belongs to a pre-roll, as much of it as is ready.
+    void drainDiscarded() {
+        if (discard_ <= 0)
+            return;
+
+        const auto ready =
+            std::min<unsigned int>(static_cast<unsigned int>(discard_), touch_.numSamples());
+        if (ready > 0)
+            discard_ -= static_cast<int>(touch_.receiveSamples(ready));
     }
 
     /// @p count samples of silence, in one call, so that the pipe grows to hold
@@ -352,10 +436,18 @@ class SoundTouchClipStretcher final : public ClipStretcher {
         touch_.putSamples(interleaved_.data(), static_cast<unsigned int>(count));
     }
 
-    /// Tempos the range is scanned at for the longest sequence. The lengths are
-    /// a clamped straight line in the tempo (TDStretch::calcSeqParameters), so
-    /// this is a fine sieve over a smooth curve rather than a hopeful sample.
+    /// Tempos the range is scanned at for the longest sequence. Arithmetic
+    /// rather than processing, so it can afford to be fine.
     static constexpr int kWarmUpSteps = 64;
+
+    /// Where SoundTouch's automatic sequence and seek-window lengths stop moving
+    /// with the tempo (AUTOSEQ_TEMPO_LOW and AUTOSEQ_TEMPO_TOP in TDStretch.cpp).
+    /// Named here because the warm-up has to visit them: they are the corners of
+    /// the piecewise-linear curve every buffer size behind the front of the pipe
+    /// is derived from, and a corner is where a maximum can hide from a sieve
+    /// that only looked at the ends.
+    static constexpr double kAutoSequenceLow = 0.5;
+    static constexpr double kAutoSequenceTop = 2.0;
 
     int channels_ = 2;
     int maxBlockSamples_ = 512;

--- a/magda/engine/clip/ClipStretcher.hpp
+++ b/magda/engine/clip/ClipStretcher.hpp
@@ -1,0 +1,214 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
+
+#include <cstdint>
+#include <memory>
+
+#include "io/PrefetchStream.hpp"
+
+/**
+ * @file ClipStretcher.hpp
+ * @brief Playing a clip at a speed that is not its file's.
+ *
+ * Everything below this reads a file: which of its samples answer a position,
+ * mirrored, tiled and converted to the device's rate (io/SourceReaders.hpp).
+ * Everything above it consumes one sample of that reading per output sample.
+ * This is what sits between when those two numbers are not the same.
+ *
+ * It is not in the reading chain, and that is a decision rather than an
+ * accident. That chain is random access and pure: two reads that overlap agree
+ * to the last bit, which is what lets a bounce resolve the same samples the
+ * callback did. A stretcher is sequential state with a warm-up, so putting one
+ * down there would quietly cost that property. It is not in the voice either,
+ * because a voice is claimed and released per block and a stretcher that was
+ * rebuilt whenever a voice changed hands would allocate on the audio thread.
+ *
+ * So it lives beside the stream, one per provisioned event, made and configured
+ * by ClipVoicePool on the thread that is allowed to wait, and carried to the
+ * callback in the same table (ClipStreamFeed.hpp). Three things follow, and they
+ * are the answers to what a stretcher does about the transport moving:
+ *
+ * - a plan swap does nothing to it, because it never enters a plan epoch;
+ * - a loop wrap does nothing to it, because tiling happens below the stream and
+ *   a wrap is a discontinuity in the material rather than a change of position;
+ * - a locate resets and re-primes something that already exists, which costs no
+ *   allocation and no file handle.
+ *
+ * Latency is answered here rather than reported upwards. Every implementation
+ * asks for @ref preRollSamples of material from *before* the first sample that
+ * is to be heard, and the pool cues the stream that far back, so a voice's first
+ * read is one contiguous read that begins with the priming samples. What comes
+ * out of @ref process is then aligned with what an unstretched voice on the same
+ * track is playing, and a ClipAudio op goes on reporting no latency at all.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief What one event asks of a stretcher.
+ *
+ * Compared rather than remembered: the pool holds the setup a stretcher was made
+ * for and rebuilds when an edit no longer matches it, the same way it rebuilds a
+ * reader whose file or reading changed.
+ */
+struct StretchSetup {
+    /// The pinned project-file integer, and what actually runs rather than the
+    /// raw field: a mode left at Off still stretches when something else forced
+    /// a stretcher on (AudioEvent::getEffectiveTimeStretchMode). kDisabled here
+    /// with a rate that is not one is a clip that resamples instead, which is
+    /// what analog pitch is.
+    int mode = 0;
+
+    float semitones = 0.0f;
+
+    int numChannels = 2;
+    double sampleRate = 44100.0;
+    int maxBlockSamples = 512;
+
+    /// Reading samples consumed per output sample, at the event's usual rate.
+    /// What the pre-roll is sized against; the rate a block actually runs at is
+    /// whatever that block's own two positions say, which is how a moving auto
+    /// tempo ratio costs nothing.
+    double nominalRate = 1.0;
+
+    /// Whether either of the clip's edges ramps its speed rather than its gain.
+    /// A clip at its file's own speed still needs something that can land
+    /// between samples if it does, because for the length of the ramp it is not
+    /// at its file's own speed at all.
+    bool speedRamp = false;
+
+    bool operator==(const StretchSetup&) const = default;
+};
+
+class ClipStretcher {
+  public:
+    virtual ~ClipStretcher() = default;
+
+    /**
+     * @brief How far ahead of the nominal position the reading is consumed.
+     *
+     * Zero for a stretcher, which is handed the samples an output block spans
+     * and nothing more. Not zero for the resampling path, whose curve reaches
+     * past the sample it lands on: a sequential stream cannot be read twice, so
+     * the read runs a fixed few samples ahead and the curve looks backwards
+     * into what it kept. A constant offset rather than a cursor, so a position
+     * is still derived from the timeline and nothing drifts.
+     */
+    virtual int readAheadSamples() const {
+        return 0;
+    }
+
+    /**
+     * @brief Material before the first sample heard that priming needs.
+     *
+     * At @p rate, because what a stretcher holds back depends on how fast it is
+     * being asked to run. The pool cues a stream this far behind where the event
+     * starts, so the samples exist by the time a voice asks for them.
+     */
+    virtual int preRollSamples(double rate) const = 0;
+
+    /// Forget everything. Follows the transport jumping, and is always followed
+    /// by a @ref prime. Allocation-free: what a reset drops is state, not memory.
+    virtual void reset() = 0;
+
+    /**
+     * @brief Take up the material leading to @p until and align to it.
+     *
+     * On the audio thread, in the block a voice starts or resumes in. @p rate is
+     * the reading consumed per output sample at that moment.
+     *
+     * @p samples is how much material to take, and is passed rather than asked
+     * for so that it is the same number the stream was cued with. Asking again
+     * here would answer for the rate this block happens to run at, which under
+     * a tempo curve is not the rate the cue was worked out at, and a first read
+     * that begins a few samples from where the stream was pointed is a seek.
+     *
+     * Reads through @p stream, and leaves it pointed exactly at @p until, so the
+     * block that follows continues the same read rather than seeking. That is
+     * also why the pre-roll is read here rather than handed in: how much
+     * material priming wants is the implementation's own business and runs to
+     * tens of thousands of samples for a phase vocoder, so the buffer for it
+     * belongs to the stretcher that needs it rather than to every track that
+     * has one.
+     *
+     * Short is allowed, and is what a clip cued at the very start of its own
+     * file gets, and what a locate gets while the reader is still catching up.
+     * Alignment is then as good as the material available makes it, which is the
+     * incumbent's answer too.
+     */
+    virtual void prime(PrefetchStream& stream, std::int64_t until, int samples, double rate) = 0;
+
+    /**
+     * @brief Turn @p input into exactly @p output.
+     *
+     * On the audio thread. The ratio is whatever the two lengths say, which is
+     * what makes a tempo curve and a speed ramp free: a block that has to
+     * consume more reading than the last one simply passes more in.
+     *
+     * @p offset is where output sample zero sits relative to input sample zero,
+     * in input samples, and @p step is how far apart consecutive output samples
+     * are in them. Both matter only to the resampling path, which lands between
+     * samples; a stretcher is aligned by priming and reads the ratio off the
+     * lengths.
+     */
+    virtual void process(juce::dsp::AudioBlock<const float> input, double offset, double step,
+                         juce::dsp::AudioBlock<float> output) = 0;
+
+  protected:
+    /**
+     * @brief The buffer @ref prime reads its material into.
+     *
+     * Allocated once, by the implementation, on the thread that made it. What it
+     * holds is worst case for the rate the event usually runs at rather than for
+     * the fastest rate anything may ever run at, because that is what the event
+     * will actually ask for; a rate that has since climbed past it primes with
+     * what fits, which is the same short-pre-roll case as a clip at the very
+     * start of its file.
+     */
+    void allocatePreRoll(int numChannels, int numSamples);
+
+    /// @p wanted samples ending at @p until, or as many of them as fit and as
+    /// the stream had. On the audio thread.
+    juce::dsp::AudioBlock<const float> readPreRoll(PrefetchStream& stream, std::int64_t until,
+                                                   int wanted);
+
+  private:
+    juce::AudioBuffer<float> preRoll_;
+};
+
+/**
+ * @brief A stretcher for @p setup, or null when the event asks for nothing.
+ *
+ * Off the audio thread: every implementation allocates its working buffers here
+ * and none of them allocates again. Null is the ordinary answer for a clip
+ * playing its file at its file's own speed, which then reads through no extra
+ * layer at all and pays for none.
+ */
+std::unique_ptr<ClipStretcher> makeStretcher(const StretchSetup& setup);
+
+/**
+ * @brief The rate a stretcher will refuse to go beyond.
+ *
+ * The incumbent's limits, and they are the reason a scratch buffer can be sized
+ * at all: a block consumes at most this much reading per output sample, so the
+ * most a voice can be asked to read in one callback is bounded before the
+ * callback happens.
+ */
+constexpr double kMinStretchRate = 0.1;
+constexpr double kMaxStretchRate = 10.0;
+
+/**
+ * @brief Working space one voice needs for one block.
+ *
+ * What it renders, and behind that the most reading a block of that length can
+ * consume. Bounded only because the rate is (@ref kMaxStretchRate): without a
+ * ceiling on how fast a clip may play there would be no size to allocate this
+ * at, and it has to be allocated before the callback.
+ */
+inline int stretchScratchSamples(int maxBlockSamples) {
+    return maxBlockSamples + static_cast<int>(maxBlockSamples * kMaxStretchRate) + 4;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipStretcher.hpp
+++ b/magda/engine/clip/ClipStretcher.hpp
@@ -200,15 +200,39 @@ constexpr double kMinStretchRate = 0.1;
 constexpr double kMaxStretchRate = 10.0;
 
 /**
+ * @brief The most reading one block may consume.
+ *
+ * Bounded only because the rate is (@ref kMaxStretchRate): without a ceiling on
+ * how fast a clip may play there would be no size to allocate a buffer at, and
+ * every buffer here has to be allocated before the callback.
+ *
+ * It is one function because more than one thing is sized against it: the
+ * voice's scratch, the interleaving a pipe needs, and the bound the voice
+ * clamps a block's reading to. Two of those disagreeing by a few samples is a
+ * write past the end of the third, so they are not allowed to be separately
+ * derived.
+ *
+ * The clamp is what makes the ceiling true rather than merely intended. A rate
+ * can exceed it: a constant ratio is clamped where it is read, but auto tempo's
+ * is the project's tempo over the file's own and a file analysed at an absurd
+ * bpm can ask for anything. Bounding what is consumed rather than the position
+ * itself keeps the position map pure, which is what makes one block's reading
+ * end where the next one's begins; a clip past the ceiling then plays wrongly,
+ * the way one with a ratio past the ceiling already does, rather than writing
+ * where it should not.
+ */
+inline int maxReadingSamples(int maxBlockSamples) {
+    return static_cast<int>(maxBlockSamples * kMaxStretchRate) + 1;
+}
+
+/**
  * @brief Working space one voice needs for one block.
  *
  * What it renders, and behind that the most reading a block of that length can
- * consume. Bounded only because the rate is (@ref kMaxStretchRate): without a
- * ceiling on how fast a clip may play there would be no size to allocate this
- * at, and it has to be allocated before the callback.
+ * consume.
  */
 inline int stretchScratchSamples(int maxBlockSamples) {
-    return maxBlockSamples + static_cast<int>(maxBlockSamples * kMaxStretchRate) + 4;
+    return maxBlockSamples + maxReadingSamples(maxBlockSamples);
 }
 
 }  // namespace magda::engine

--- a/magda/engine/clip/ClipStretcher.hpp
+++ b/magda/engine/clip/ClipStretcher.hpp
@@ -79,6 +79,12 @@ struct StretchSetup {
     /// at its file's own speed at all.
     bool speedRamp = false;
 
+    /// Whether the clip follows the project's tempo. Carried because @ref
+    /// nominalRate is only an average for one that does, and a clip averaging
+    /// unity is still stretching in both directions around it: it needs an
+    /// engine where a clip actually pinned at unity does not.
+    bool followsTempo = false;
+
     bool operator==(const StretchSetup&) const = default;
 };
 

--- a/magda/engine/clip/ClipVoice.cpp
+++ b/magda/engine/clip/ClipVoice.cpp
@@ -19,7 +19,7 @@ void ClipVoice::release() {
     clipId_ = INVALID_CLIP_ID;
     eventId_ = INVALID_EVENT_ID;
     sounded_ = false;
-    primed_ = false;
+    primed_ = nullptr;
 }
 
 void ClipVoice::applyFade(juce::dsp::AudioBlock<float> region, int regionFirstSample,
@@ -66,7 +66,7 @@ bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& 
         clipId_ = clip.clipId;
         eventId_ = event.eventId;
         sounded_ = false;
-        primed_ = false;
+        primed_ = nullptr;
     }
 
     const auto nothing = [this] {
@@ -130,12 +130,19 @@ bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& 
     // A clip with no stretcher consumes one sample per sample by definition, and
     // asking for the difference would let a rounding of a hair shorten a block
     // that is not stretched at all.
-    const auto wanted =
-        stretcher == nullptr
-            ? count
-            : static_cast<int>(std::clamp<std::int64_t>(
-                  readTo - readFrom, 0,
-                  static_cast<std::int64_t>(scratch.getNumSamples()) - maxBlockSamples_));
+    //
+    // The ceiling is the contract every buffer downstream was sized against
+    // (maxReadingSamples), and it is enforced here because it cannot be enforced
+    // in the position map: clamping a position would break the rounded ends that
+    // make one block's reading continue the last one's. A rate past the ceiling
+    // is reachable through auto tempo alone, where the ratio is the project's
+    // tempo over a file's own analysed bpm and nothing bounds their quotient.
+    // Such a clip reads short and seeks after it, which is wrong the way a
+    // clamped ratio is wrong, rather than wrong the way a buffer overrun is.
+    const auto wanted = stretcher == nullptr
+                            ? count
+                            : static_cast<int>(std::clamp<std::int64_t>(
+                                  readTo - readFrom, 0, maxReadingSamples(maxBlockSamples_)));
 
     // The reading sits behind what the block renders, in the same scratch: they
     // are different lengths whenever the clip is not at its file's own speed.
@@ -157,10 +164,12 @@ bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& 
     // is a seek that guarantees the next block is short too. A stretcher handed
     // silence and then material has a discontinuity in what it is playing, which
     // is what a loop wrap is as well, and neither needs anything said about it.
-    if (stretcher != nullptr && (!primed_ || !block.continuous)) {
+    // A stretcher this voice has not primed is either its first or one the pool
+    // has just put in place of the last, and both need the same thing.
+    if (stretcher != nullptr && (primed_ != stretcher || !block.continuous)) {
         stretcher->reset();
         stretcher->prime(stream, readFrom, preRoll, step);
-        primed_ = true;
+        primed_ = stretcher;
     }
 
     const auto delivered = stream.read(readFrom, reading, wanted);

--- a/magda/engine/clip/ClipVoice.cpp
+++ b/magda/engine/clip/ClipVoice.cpp
@@ -1,15 +1,17 @@
 #include "clip/ClipVoice.hpp"
 
 #include <algorithm>
+#include <cmath>
+#include <cstdint>
 
 #include "clip/EventPlacement.hpp"
 #include "clip/FadeCurves.hpp"
-#include "io/ClipPlacement.hpp"
 
 namespace magda::engine {
 
 void ClipVoice::prepare(const RenderContext& context) {
     sampleRate_ = context.sampleRate;
+    maxBlockSamples_ = context.maxBlockSize;
     release();
 }
 
@@ -17,6 +19,7 @@ void ClipVoice::release() {
     clipId_ = INVALID_CLIP_ID;
     eventId_ = INVALID_EVENT_ID;
     sounded_ = false;
+    primed_ = false;
 }
 
 void ClipVoice::applyFade(juce::dsp::AudioBlock<float> region, int regionFirstSample,
@@ -54,14 +57,16 @@ void ClipVoice::applyFade(juce::dsp::AudioBlock<float> region, int regionFirstSa
 }
 
 bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& event,
-                       const BlockInfo& block, PrefetchStream& stream,
-                       juce::dsp::AudioBlock<float> scratch, juce::dsp::AudioBlock<float> out) {
+                       const BlockInfo& block, PrefetchStream& stream, ClipStretcher* stretcher,
+                       int preRoll, juce::dsp::AudioBlock<float> scratch,
+                       juce::dsp::AudioBlock<float> out) {
     // A voice handed a different entry is a new voice: whatever it played
     // before has nothing to do with where this one begins.
     if (!playing(clip.clipId, event.eventId)) {
         clipId_ = clip.clipId;
         eventId_ = event.eventId;
         sounded_ = false;
+        primed_ = false;
     }
 
     const auto nothing = [this] {
@@ -89,17 +94,79 @@ bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& 
 
     auto region = scratch.getSubBlock(0, static_cast<std::size_t>(count));
 
-    // Derived from where the timeline is, never from where the last block left
-    // off, so a locate needs nothing said about it: the stream sees a position
-    // it was not expecting and seeks (#2016).
+    // Where in the reading the two ends of this window are. Derived from where
+    // the timeline is, never from where the last block left off, so a locate
+    // needs nothing said about it: the stream sees a position it was not
+    // expecting and seeks (#2016).
     //
     // Through the same function the pool pointed the reader with
     // (EventPlacement.hpp), because a reversed event is read in a mirrored
-    // file's coordinates and two derivations of that could disagree. A loop
-    // wrap is not a position at all any more: it happens inside the reading,
-    // below the stream, so this walks straight through one.
-    const auto delivered = stream.read(
-        sourceSampleAt(placementFor(event, sampleRate_), windowStart, sampleRate_), region, count);
+    // file's coordinates, a stretched one consumes its reading at a rate, and
+    // two derivations of either could disagree. A loop wrap is not a position at
+    // all any more: it happens inside the reading, below the stream, so this
+    // walks straight through one.
+    const auto opens =
+        readingPositionAt(clip, event, windowStart, block.beatAtTime(windowStart), sampleRate_);
+    const auto closes =
+        readingPositionAt(clip, event, windowEnd, block.beatAtTime(windowEnd), sampleRate_);
+
+    // How much of the reading one output sample of this block costs. Not the
+    // event's nominal rate: under a tempo curve or through a speed ramp the two
+    // differ, and what a block actually plays is the distance between its own
+    // two ends.
+    const auto step = (closes - opens) / count;
+
+    // How far ahead of the position wanted the reading is consumed, which is not
+    // zero only for the path that lands between samples (ClipStretcher.hpp).
+    const auto ahead = stretcher != nullptr ? stretcher->readAheadSamples() : 0;
+    const auto readFrom = static_cast<std::int64_t>(std::llround(opens)) + ahead;
+    const auto readTo = static_cast<std::int64_t>(std::llround(closes)) + ahead;
+
+    // Rounded at both ends rather than counted forward, so one block's reading
+    // ends exactly where the next one's begins and nothing accumulates. What is
+    // left over lands in the ratio the stretcher is handed, which is where a
+    // fraction of a sample belongs.
+    //
+    // A clip with no stretcher consumes one sample per sample by definition, and
+    // asking for the difference would let a rounding of a hair shorten a block
+    // that is not stretched at all.
+    const auto wanted =
+        stretcher == nullptr
+            ? count
+            : static_cast<int>(std::clamp<std::int64_t>(
+                  readTo - readFrom, 0,
+                  static_cast<std::int64_t>(scratch.getNumSamples()) - maxBlockSamples_));
+
+    // The reading sits behind what the block renders, in the same scratch: they
+    // are different lengths whenever the clip is not at its file's own speed.
+    auto reading = stretcher != nullptr
+                       ? scratch.getSubBlock(static_cast<std::size_t>(maxBlockSamples_),
+                                             static_cast<std::size_t>(wanted))
+                       : region;
+
+    // Beginning rather than carrying on: the first block of a voice, and the
+    // first after the timeline jumped. Whatever the stretcher was holding is for
+    // somewhere else, and what replaces it is the material leading up to here,
+    // read out of the same stream in the same pass so that the block's own read
+    // continues it rather than seeking again.
+    //
+    // Not after an underrun, deliberately, and this is the difference between a
+    // reader catching up and one that never does. Priming reads behind the
+    // position the block wants, so a stream that came back short and was primed
+    // again for it would be sent backwards every block, and every one of those
+    // is a seek that guarantees the next block is short too. A stretcher handed
+    // silence and then material has a discontinuity in what it is playing, which
+    // is what a loop wrap is as well, and neither needs anything said about it.
+    if (stretcher != nullptr && (!primed_ || !block.continuous)) {
+        stretcher->reset();
+        stretcher->prime(stream, readFrom, preRoll, step);
+        primed_ = true;
+    }
+
+    const auto delivered = stream.read(readFrom, reading, wanted);
+
+    if (stretcher != nullptr)
+        stretcher->process(reading, opens - static_cast<double>(readFrom), step, region);
 
     // The holes, cleared out of what was read rather than skipped over.
     for (const auto& hole : clip.silenced) {
@@ -142,14 +209,18 @@ bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& 
     // after resolution, so applying both would fade the edge twice. Interior
     // event fades arrive with the clips that have interior events (#1901).
     //
-    // Both behaviours play as gain fades here, the speed ramp included, and
-    // that is a decision rather than an oversight: a ramp is a stretch, there
-    // is no stretcher until #2037, and the alternative to fading it is not
-    // fading the edge at all.
-    applyFade(region, first, block, clip.span.startSeconds,
-              clip.span.startSeconds + clip.fadeInSeconds, clip.fadeInCurve, true);
-    applyFade(region, first, block, clip.span.endSeconds - clip.fadeOutSeconds,
-              clip.span.endSeconds, clip.fadeOutCurve, false);
+    // A gain fade only. An edge whose behaviour is a speed ramp has already been
+    // played by the positions this block read at: the material accelerated into
+    // the clip instead of rising into it (EventPlacement.hpp), and putting a
+    // gain curve on top of that would fade an edge that was never meant to be
+    // quiet.
+    if (clip.fadeInBehaviour == 0)
+        applyFade(region, first, block, clip.span.startSeconds,
+                  clip.span.startSeconds + clip.fadeInSeconds, clip.fadeInCurve, true);
+
+    if (clip.fadeOutBehaviour == 0)
+        applyFade(region, first, block, clip.span.endSeconds - clip.fadeOutSeconds,
+                  clip.span.endSeconds, clip.fadeOutCurve, false);
 
     // Volume and gain summed, panned the way the incumbent pans a clip: linear,
     // and hotter on one side rather than quieter on the other. Not a law with a
@@ -182,7 +253,11 @@ bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& 
     // half filled ends in that silence as surely as one it missed entirely.
     // Either way the block that resumes starts mid-material, and saying this
     // voice carried on would leave it with nothing to take the step out of it.
-    sounded_ = delivered == count;
+    //
+    // Against what was asked for rather than against the block: a stretched clip
+    // consumes a different amount of reading than it renders, and a full block
+    // built out of a short read is exactly the case this has to catch.
+    sounded_ = delivered == wanted;
     return true;
 }
 

--- a/magda/engine/clip/ClipVoice.hpp
+++ b/magda/engine/clip/ClipVoice.hpp
@@ -4,6 +4,7 @@
 #include <juce_dsp/juce_dsp.h>
 
 #include "clip/ClipSnapshot.hpp"
+#include "clip/ClipStretcher.hpp"
 #include "exec/RenderContext.hpp"
 #include "io/PrefetchStream.hpp"
 
@@ -36,9 +37,14 @@
  * the device's rate whether the clip is reversed, tiled, resampled or none of
  * them.
  *
- * Not here at all: stretch and pitch (#2037), warp (#2038). Those change how
- * fast the reading is consumed rather than what it holds, which is why they
- * belong above it and these belong below.
+ * Speed and pitch are the other way round (#2037). They change how fast the
+ * reading is consumed rather than what it holds, so they are above the stream
+ * rather than below it, and this is where the two meet: a voice asks
+ * EventPlacement.hpp where in the reading the block's two ends are, reads
+ * exactly that much, and hands it to the stretcher standing beside the stream
+ * to come back as this block's length. A clip at its file's own speed has no
+ * stretcher and reads one sample per sample, which is the same code path with
+ * nothing in the middle.
  */
 
 namespace magda::engine {
@@ -69,16 +75,24 @@ class ClipVoice {
     /**
      * @brief Add this block's contribution to @p out.
      *
-     * On the audio thread. @p scratch is working space of at least the block's
-     * length, owned by the caller because one is enough for every voice on a
-     * track: they are rendered one after another and summed as they go.
+     * On the audio thread. @p scratch is working space of at least
+     * stretchScratchSamples(maxBlockSize), owned by the caller because one is
+     * enough for every voice on a track: they are rendered one after another and
+     * summed as they go. It holds what this voice renders and, behind it, the
+     * reading that block was made from, which is longer than the block whenever
+     * the clip plays faster than its file.
+     *
+     * @p stretcher is the one standing beside @p stream, or null for a clip
+     * played at its file's own speed, and @p preRoll is what that stretcher was
+     * cued with (ClipStreamFeed.hpp).
      *
      * Returns false when nothing was added, which is the ordinary answer for a
      * voice whose entry does not reach into this block.
      */
     bool render(const AudioClipPlayback& clip, const AudioEventPlayback& event,
-                const BlockInfo& block, PrefetchStream& stream,
-                juce::dsp::AudioBlock<float> scratch, juce::dsp::AudioBlock<float> out);
+                const BlockInfo& block, PrefetchStream& stream, ClipStretcher* stretcher,
+                int preRoll, juce::dsp::AudioBlock<float> scratch,
+                juce::dsp::AudioBlock<float> out);
 
   private:
     /// Multiply the part of @p region inside [@p startSeconds, @p endSeconds)
@@ -89,6 +103,10 @@ class ClipVoice {
 
     double sampleRate_ = 44100.0;
 
+    /// Where in the scratch the reading starts: past the longest block this
+    /// voice can be asked to render, because both live in the one buffer.
+    int maxBlockSamples_ = 512;
+
     ClipId clipId_ = INVALID_CLIP_ID;
     EventId eventId_ = INVALID_EVENT_ID;
 
@@ -96,6 +114,13 @@ class ClipVoice {
     /// voice that is beginning from one that is carrying on, which is the
     /// difference the launch ramp is for.
     bool sounded_ = false;
+
+    /// Whether the stretcher beside this voice's stream has been given the
+    /// material leading up to where it is playing. Separate from @ref sounded_,
+    /// because a block that came back short is not a reason to prime again: the
+    /// reader is behind, and priming reads backwards, so doing it would seek and
+    /// keep it behind for good.
+    bool primed_ = false;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/clip/ClipVoice.hpp
+++ b/magda/engine/clip/ClipVoice.hpp
@@ -115,12 +115,18 @@ class ClipVoice {
     /// difference the launch ramp is for.
     bool sounded_ = false;
 
-    /// Whether the stretcher beside this voice's stream has been given the
-    /// material leading up to where it is playing. Separate from @ref sounded_,
-    /// because a block that came back short is not a reason to prime again: the
-    /// reader is behind, and priming reads backwards, so doing it would seek and
-    /// keep it behind for good.
-    bool primed_ = false;
+    /// The stretcher this voice primed, or null for one that has not primed
+    /// anything. An identity rather than a flag, because the pool replaces a
+    /// stretcher without touching the stream whenever a rate, a pitch or a mode
+    /// is edited, and the entry a voice is playing does not change when it does:
+    /// a fresh engine would otherwise reach the callback cold and stay cold,
+    /// which for a phase vocoder is its whole latency late for the rest of the
+    /// take.
+    ///
+    /// Separate from @ref sounded_, because a block that came back short is not
+    /// a reason to prime again: the reader is behind, and priming reads
+    /// backwards, so doing it would seek and keep it behind for good.
+    const ClipStretcher* primed_ = nullptr;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/clip/ClipVoicePool.cpp
+++ b/magda/engine/clip/ClipVoicePool.cpp
@@ -1,6 +1,7 @@
 #include "clip/ClipVoicePool.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <utility>
 #include <vector>
 
@@ -18,10 +19,32 @@ bool reachesInto(const SnapshotSpan& span, double windowStart, double windowEnd)
     return span.startSeconds < windowEnd && span.endSeconds > windowStart;
 }
 
+/**
+ * @brief The beat face of a moment inside @p event's span.
+ *
+ * The pool works in seconds, because that is what the transport hands it, and an
+ * auto tempo event's position is a question about beats (EventPlacement.hpp).
+ * Both faces of the span are already resolved, so a moment inside it can be
+ * placed on the beat axis without a tempo map: linear between the ends, which is
+ * exact at the ends themselves and that is the case that has to be exact. A cue
+ * for a clip that has not started is worked out at its own first sample, and a
+ * cue for one the transport is already inside is corrected by the first read
+ * either way.
+ */
+double beatNear(const AudioEventPlayback& event, double seconds) {
+    const auto span = event.span.lengthSeconds();
+    if (!(span > 0.0))
+        return event.span.startBeat;
+
+    const auto through = (seconds - event.span.startSeconds) / span;
+    return event.span.startBeat + through * event.span.lengthBeats();
+}
+
 /// One entry that wants a stream, and what decides whether it gets one.
 struct Candidate {
     ClipId clipId = INVALID_CLIP_ID;
     EventId eventId = INVALID_EVENT_ID;
+    const AudioClipPlayback* clip = nullptr;
     const AudioEventPlayback* event = nullptr;
     double startSeconds = 0.0;
     double endSeconds = 0.0;
@@ -188,24 +211,52 @@ std::size_t ClipVoicePool::streamCount() const {
     return streams_.size();
 }
 
-ClipVoicePool::Reader ClipVoicePool::open(const AudioEventPlayback& event, double cueSeconds) {
-    // What this event asks of its file, and where its first sample sits in the
-    // answer. Both from EventPlacement.hpp, which is also where the voice asks:
-    // a reversed event is read in a mirrored file's coordinates, and a reader
-    // pointed by one derivation and read by another would play a clip's
-    // material from somewhere neither of them named.
-    const auto how = sourceReadFor(event, context_.sampleRate);
-    const auto placement = placementFor(event, context_.sampleRate);
+std::int64_t ClipVoicePool::cueFor(const AudioClipPlayback& clip, const AudioEventPlayback& event,
+                                   double seconds, const Reader& reader) const {
+    const auto position =
+        readingPositionAt(clip, event, seconds, beatNear(event, seconds), context_.sampleRate);
+
+    const auto ahead = reader.stretcher != nullptr ? reader.stretcher->readAheadSamples() : 0;
+
+    return static_cast<std::int64_t>(std::llround(position)) + ahead - reader.preRoll;
+}
+
+ClipVoicePool::Reader ClipVoicePool::open(const AudioClipPlayback& clip,
+                                          const AudioEventPlayback& event, double cueSeconds) {
+    // What this event asks of its file, and how what comes back is turned into
+    // playback. Both from EventPlacement.hpp, which is also where the voice
+    // asks: a reversed event is read in a mirrored file's coordinates and a
+    // stretched one starts behind itself, and a reader pointed by one derivation
+    // and read by another would play a clip's material from somewhere neither of
+    // them named.
+    Reader reader;
+    reader.path = event.filePath;
+    reader.read = sourceReadFor(event, context_.sampleRate);
+    reader.setup = stretchSetupFor(clip, event, context_);
+
+    // Made here, on the thread that is allowed to allocate, and configured for
+    // this event alone. A clip playing its file at its file's own speed gets
+    // none and pays for none, the same rule the reading chain follows.
+    reader.stretcher = makeStretcher(reader.setup);
+    if (reader.stretcher != nullptr)
+        reader.preRoll = reader.stretcher->preRollSamples(reader.setup.nominalRate);
+
+    // The event's own first sample, which is what this is compared against next
+    // round: an identity rather than a position. Where the stream is actually
+    // pointed is below and depends on where the transport is, so storing that
+    // instead would make a clip the transport is moving through look different
+    // on every round and republish a table for it every ten milliseconds.
+    reader.cueSamples = cueFor(clip, event, event.span.startSeconds, reader);
 
     auto file = files_.open(event.filePath);
     if (file == nullptr)
-        return Reader{nullptr, event.filePath, how, placement.sourceOffsetSamples};
+        return reader;
 
     // Mirrored, tiled and converted before the prefetcher ever sees it, so what
     // is prefetched is a plain forward file at the device's rate however the
     // clip is set (io/SourceReaders.hpp).
-    auto stream =
-        std::make_shared<PrefetchStream>(readThrough(std::move(file), how), context_, settings_);
+    reader.stream = std::make_shared<PrefetchStream>(readThrough(std::move(file), reader.read),
+                                                     context_, settings_);
 
     // Pointed before anything asks, and before the reader is even told the
     // stream exists. This is the whole reason the pool runs ahead of the
@@ -214,10 +265,13 @@ ClipVoicePool::Reader ClipVoicePool::open(const AudioEventPlayback& event, doubl
     // seek, because a stream nobody has read from has nothing to invalidate and
     // no callback to wait for, and every read it does before the redirect
     // landed would be a read of the wrong part of the file.
-    stream->startAt(sourceSampleAt(placement, cueSeconds, context_.sampleRate));
+    //
+    // Where playback will pick it up rather than where the event begins: a clip
+    // the transport is already standing inside is read from where the cursor is.
+    reader.stream->startAt(cueFor(clip, event, cueSeconds, reader));
 
-    reader_.add(*stream);
-    return Reader{std::move(stream), event.filePath, how, placement.sourceOffsetSamples};
+    reader_.add(*reader.stream);
+    return reader;
 }
 
 void ClipVoicePool::service() {
@@ -257,7 +311,7 @@ void ClipVoicePool::service() {
                             continue;
 
                         candidates.push_back(Candidate{
-                            clip.clipId, event.eventId, &event, event.span.startSeconds,
+                            clip.clipId, event.eventId, &clip, &event, event.span.startSeconds,
                             event.span.endSeconds, event.span.startSeconds <= windowStart});
                     }
                 }
@@ -309,25 +363,40 @@ void ClipVoicePool::service() {
                     // the reader rather than asked of it per block, so the
                     // reader has to be built again.
                     const auto how = sourceReadFor(event, context_.sampleRate);
-                    const auto placement = placementFor(event, context_.sampleRate);
+                    const auto setup = stretchSetupFor(*candidate.clip, event, context_);
 
                     if (const auto found = streams_.find(key);
                         found != streams_.end() && found->second.path == event.filePath &&
                         found->second.read == how) {
                         auto reuse = found->second;
 
-                        // The milder version: the same file, read from
-                        // somewhere else. A clip that has not started is
-                        // re-cued and loses nothing; one the transport is
-                        // already inside is left alone, because a reader that
-                        // is playing cannot be pointed elsewhere and the next
-                        // read corrects it anyway, at the cost of a seek.
-                        if (reuse.anchorSamples != placement.sourceOffsetSamples) {
-                            if (reuse.stream != nullptr && !candidate.sounding)
-                                reuse.stream->seek(sourceSampleAt(
-                                    placement, event.span.startSeconds, context_.sampleRate));
+                        // A stretch setting changed, which the file did not.
+                        // Rebuilding the whole reader for it would close a file
+                        // and pay a seek to reopen it at the same place, so only
+                        // the stretcher is replaced; it is state and a warm-up,
+                        // both of which a rate or pitch change invalidates
+                        // anyway.
+                        if (reuse.setup != setup) {
+                            reuse.setup = setup;
+                            reuse.stretcher = makeStretcher(setup);
+                            reuse.preRoll = reuse.stretcher != nullptr
+                                                ? reuse.stretcher->preRollSamples(setup.nominalRate)
+                                                : 0;
+                        }
 
-                            reuse.anchorSamples = placement.sourceOffsetSamples;
+                        // The milder version of a changed reader: the same file,
+                        // read from somewhere else. A clip that has not started
+                        // is re-cued and loses nothing; one the transport is
+                        // already inside is left alone, because a reader that is
+                        // playing cannot be pointed elsewhere and the next read
+                        // corrects it anyway, at the cost of a seek.
+                        if (const auto cue =
+                                cueFor(*candidate.clip, event, event.span.startSeconds, reuse);
+                            reuse.cueSamples != cue) {
+                            if (reuse.stream != nullptr && !candidate.sounding)
+                                reuse.stream->seek(cue);
+
+                            reuse.cueSamples = cue;
                         }
 
                         if (reuse.stream == nullptr)
@@ -342,7 +411,7 @@ void ClipVoicePool::service() {
                     // already is for one the transport is standing inside.
                     const auto cueSeconds = std::max(windowStart, event.span.startSeconds);
 
-                    auto reader = open(event, cueSeconds);
+                    auto reader = open(*candidate.clip, event, cueSeconds);
                     if (reader.stream == nullptr)
                         ++unreadable;
 
@@ -359,8 +428,9 @@ void ClipVoicePool::service() {
             table->entries.reserve(wanted.size());
             for (const auto& [key, reader] : wanted)
                 if (reader.stream != nullptr)
-                    table->entries.push_back(ClipStreamTable::Entry{key.trackId, key.clipId,
-                                                                    key.eventId, reader.stream});
+                    table->entries.push_back(
+                        ClipStreamTable::Entry{key.trackId, key.clipId, key.eventId, reader.stream,
+                                               reader.stretcher, reader.preRoll});
 
             // Published before anything is retired, and it waits for the block
             // the callback is in: after this returns, nothing the audio thread

--- a/magda/engine/clip/ClipVoicePool.hpp
+++ b/magda/engine/clip/ClipVoicePool.hpp
@@ -12,6 +12,7 @@
 #include "clip/ClipAudioSource.hpp"
 #include "clip/ClipSnapshot.hpp"
 #include "clip/ClipStreamFeed.hpp"
+#include "clip/ClipStretcher.hpp"
 #include "core/ClipTypes.hpp"
 #include "core/TypeIds.hpp"
 #include "exec/RenderContext.hpp"
@@ -296,20 +297,40 @@ class ClipVoicePool {
         std::string path;
         SourceRead read;
 
-        /// The sample of that reading the event starts on, which is where the
-        /// stream is pointed. Derived rather than the event's own anchor: a
-        /// mirrored read counts from the other end (clip/EventPlacement.hpp).
-        std::int64_t anchorSamples = 0;
+        /// The sample of that reading the stream is pointed at: where the event
+        /// starts, less whatever its stretcher wants in front of it. Derived
+        /// rather than the event's own anchor, because a mirrored read counts
+        /// from the other end and a stretched one starts behind itself
+        /// (clip/EventPlacement.hpp, clip/ClipStretcher.hpp).
+        std::int64_t cueSamples = 0;
+
+        /// What plays it at a speed that is not its file's, and how far in front
+        /// of the event that one wants to be handed. Null and zero for a clip
+        /// that asks for neither, which is every clip in slice 3.
+        ///
+        /// Kept across an edit that leaves the setup alone, and replaced without
+        /// touching the stream when only the setup changed: a pitch change
+        /// should not close a file and pay a seek for it.
+        std::shared_ptr<ClipStretcher> stretcher;
+        StretchSetup setup;
+        int preRoll = 0;
 
         bool operator==(const Reader& other) const {
             return stream == other.stream && path == other.path && read == other.read &&
-                   anchorSamples == other.anchorSamples;
+                   cueSamples == other.cueSamples && stretcher == other.stretcher &&
+                   setup == other.setup && preRoll == other.preRoll;
         }
     };
 
     using Streams = std::map<Key, Reader>;
 
-    Reader open(const AudioEventPlayback& event, double cueSeconds);
+    Reader open(const AudioClipPlayback& clip, const AudioEventPlayback& event, double cueSeconds);
+
+    /// Where a stream playing @p event is pointed to pick it up at @p seconds:
+    /// the reading position of that moment, forward by whatever its stretcher
+    /// consumes ahead of itself and back by whatever it wants in front of it.
+    std::int64_t cueFor(const AudioClipPlayback& clip, const AudioEventPlayback& event,
+                        double seconds, const Reader& reader) const;
 
     AudioFileReaderFactory& files_;
     PrefetchThread& reader_;

--- a/magda/engine/clip/EventPlacement.cpp
+++ b/magda/engine/clip/EventPlacement.cpp
@@ -200,6 +200,20 @@ StretchSetup stretchSetupFor(const AudioClipPlayback& clip, const AudioEventPlay
     setup.speedRamp = (clip.fadeInBehaviour == 1 && clip.fadeInSeconds > 0.0) ||
                       (clip.fadeOutBehaviour == 1 && clip.fadeOutSeconds > 0.0);
 
+    // A pitch nothing else asked for a stretcher for. The model's rule upgrades
+    // a mode left at Off for auto tempo, warp, a speed ratio and a pitch change,
+    // and not for the transpose an auto pitch clip carries
+    // (AudioEvent::getEffectiveTimeStretchMode), so a clip that only transposes
+    // arrives here asking for semitones with nothing to apply them with. The
+    // engine will not silently drop a value it was handed: it takes the default
+    // engine, which is what every other route to this arrives at.
+    //
+    // Not for analog pitch, which is the one kind of pitch that is not a
+    // stretcher at all: the model has already folded it into the speed ratio.
+    if (setup.mode == time_stretch_mode::kDisabled && !event.analogPitch &&
+        std::abs(setup.semitones) > 0.001f)
+        setup.mode = time_stretch_mode::kSignalsmith;
+
     return setup;
 }
 

--- a/magda/engine/clip/EventPlacement.cpp
+++ b/magda/engine/clip/EventPlacement.cpp
@@ -197,6 +197,7 @@ StretchSetup stretchSetupFor(const AudioClipPlayback& clip, const AudioEventPlay
     setup.sampleRate = context.sampleRate;
     setup.maxBlockSamples = context.maxBlockSize;
     setup.nominalRate = readingRateOf(event);
+    setup.followsTempo = event.autoTempo && event.interpBpm > 0.0;
     setup.speedRamp = (clip.fadeInBehaviour == 1 && clip.fadeInSeconds > 0.0) ||
                       (clip.fadeOutBehaviour == 1 && clip.fadeOutSeconds > 0.0);
 

--- a/magda/engine/clip/EventPlacement.cpp
+++ b/magda/engine/clip/EventPlacement.cpp
@@ -1,6 +1,10 @@
 #include "clip/EventPlacement.hpp"
 
+#include <algorithm>
 #include <cmath>
+
+#include "clip/FadeCurves.hpp"
+#include "core/TimeStretchModes.hpp"
 
 namespace magda::engine {
 
@@ -96,6 +100,107 @@ ClipPlacement placementFor(const AudioEventPlayback& event, double deviceSampleR
     return ClipPlacement{
         event.span.startSeconds, event.span.endSeconds,
         static_cast<std::int64_t>(std::llround(static_cast<double>(anchor) * scale))};
+}
+
+double readingRateOf(const AudioEventPlayback& event) {
+    auto rate = event.speedRatio;
+
+    if (event.autoTempo && event.interpBpm > 0.0) {
+        // The event's own average, taken off the two faces of its span rather
+        // than off a tempo map: how many beats it covers and how long they last
+        // are both already resolved here, and their ratio is the tempo it sits
+        // under. A ramp inside the span averages out, which is what an average
+        // is for.
+        const auto beats = event.span.lengthBeats();
+        const auto seconds = event.span.lengthSeconds();
+
+        rate = beats > 0.0 && seconds > 0.0 ? (beats * 60.0 / seconds) / event.interpBpm : 1.0;
+    }
+
+    return std::clamp(rate > 0.0 ? rate : 1.0, kMinStretchRate, kMaxStretchRate);
+}
+
+namespace {
+
+/**
+ * @brief One edge of @p clip, warped where its fade is a speed ramp.
+ *
+ * @p position and the region's ends are all in one domain, and which domain
+ * that is depends on the event: seconds for a constant ratio, beats for auto
+ * tempo. The warp is the same either way, because a ramp is a statement about
+ * how fast the material runs and both faces measure that.
+ *
+ * Outside a ramp, and for a fade that is an ordinary gain envelope, this is
+ * where it was handed.
+ */
+double ramped(const AudioClipPlayback& clip, double position, double start, double end,
+              double fadeIn, double fadeOut) {
+    if (clip.fadeInBehaviour == 1 && fadeIn > 0.0 && position < start + fadeIn) {
+        const auto alpha = (position - start) / fadeIn;
+        return start + fadeIn * fadeRampPosition(clip.fadeInCurve, alpha, true);
+    }
+
+    if (clip.fadeOutBehaviour == 1 && fadeOut > 0.0 && position > end - fadeOut) {
+        const auto alpha = (position - (end - fadeOut)) / fadeOut;
+        return (end - fadeOut) + fadeOut * fadeRampPosition(clip.fadeOutCurve, alpha, false);
+    }
+
+    return position;
+}
+
+}  // namespace
+
+double readingPositionAt(const AudioClipPlayback& clip, const AudioEventPlayback& event,
+                         double seconds, double beat, double deviceSampleRate) {
+    const auto placement = placementFor(event, deviceSampleRate);
+    const auto anchor = static_cast<double>(placement.sourceOffsetSamples);
+
+    // Seconds of the file's own material, which is what the reading is counted
+    // in: it was converted to the device's rate below the stream, so a second of
+    // it is deviceSampleRate samples whatever the file was recorded at.
+    double elapsed = 0.0;
+
+    if (event.autoTempo && event.interpBpm > 0.0) {
+        const auto at = ramped(clip, beat, clip.span.startBeat, clip.span.endBeat, clip.fadeInBeats,
+                               clip.fadeOutBeats);
+
+        elapsed = (at - event.span.startBeat) * 60.0 / event.interpBpm;
+    } else {
+        const auto at = ramped(clip, seconds, clip.span.startSeconds, clip.span.endSeconds,
+                               clip.fadeInSeconds, clip.fadeOutSeconds);
+
+        // Clamped the way the rate is, so that a project holding a ratio no
+        // stretcher will run at still plays something rather than reading a
+        // thousand times faster than the disk can answer.
+        const auto rate = std::clamp(event.speedRatio > 0.0 ? event.speedRatio : 1.0,
+                                     kMinStretchRate, kMaxStretchRate);
+
+        elapsed = (at - event.span.startSeconds) * rate;
+    }
+
+    return anchor + elapsed * deviceSampleRate;
+}
+
+StretchSetup stretchSetupFor(const AudioClipPlayback& clip, const AudioEventPlayback& event,
+                             const RenderContext& context) {
+    StretchSetup setup;
+    setup.mode = event.timeStretchMode;
+
+    // What the incumbent reads, and the two are not added: a clip following the
+    // pitch track transposes by its own offset, and one that is not plays the
+    // pitch change its editor set. Auto pitch's other half, the offset from the
+    // project's pitch sequence, needs a pitch track the engine does not have
+    // yet (#1891); until it does, such a clip plays its transpose alone.
+    setup.semitones = event.autoPitch ? static_cast<float>(event.transpose) : event.pitchChange;
+
+    setup.numChannels = context.numChannels;
+    setup.sampleRate = context.sampleRate;
+    setup.maxBlockSamples = context.maxBlockSize;
+    setup.nominalRate = readingRateOf(event);
+    setup.speedRamp = (clip.fadeInBehaviour == 1 && clip.fadeInSeconds > 0.0) ||
+                      (clip.fadeOutBehaviour == 1 && clip.fadeOutSeconds > 0.0);
+
+    return setup;
 }
 
 }  // namespace magda::engine

--- a/magda/engine/clip/EventPlacement.hpp
+++ b/magda/engine/clip/EventPlacement.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "clip/ClipSnapshot.hpp"
+#include "clip/ClipStretcher.hpp"
+#include "exec/RenderContext.hpp"
 #include "io/ClipPlacement.hpp"
 #include "io/SourceReaders.hpp"
 
@@ -40,5 +42,51 @@ SourceRead sourceReadFor(const AudioEventPlayback& event, double deviceSampleRat
 /// that plays at its start. In the device's samples, because that is what the
 /// reading delivers and what the callback consumes one of per output sample.
 ClipPlacement placementFor(const AudioEventPlayback& event, double deviceSampleRate);
+
+/**
+ * @brief Reading samples consumed per output sample, at @p event's usual rate.
+ *
+ * One at unity, which is every clip in slice 3. What makes it something else is
+ * the speed ratio, or auto tempo, and for auto tempo this is an average over the
+ * event rather than a rate that holds: the ratio there is the project's tempo
+ * over the file's own and moves with the tempo curve. Nothing plays at this. It
+ * is what a stretcher is sized and primed against, where being roughly right is
+ * the whole requirement.
+ *
+ * Clamped to what a stretcher will run at, which is what makes a block's worth
+ * of reading a bounded quantity and therefore something a scratch buffer can be
+ * sized for before the callback.
+ */
+double readingRateOf(const AudioEventPlayback& event);
+
+/**
+ * @brief Where in the reading @p event is at one instant of the timeline.
+ *
+ * In fractional device samples, and the whole of what this slice adds: speed
+ * ratios, auto tempo, analog pitch and speed ramps are all this one function
+ * answering differently, and warp (#2038) will be another answer from here.
+ *
+ * Both faces of the instant are taken because which one is authoritative
+ * depends on the event. A constant ratio is a fact about seconds: so many
+ * samples of file per second of timeline, whatever the tempo does. Auto tempo
+ * is not, and cannot be resolved to seconds ahead of the block, because its
+ * ratio is the project's tempo over the file's and moves with the tempo curve.
+ * What saves it is that the integral of that ratio is beats: the material
+ * consumed by an instant is how many beats have passed since the event began,
+ * times the seconds a beat of the file is worth. Exact, and needs only the beat
+ * face the clock already publishes rather than a second tempo map down here.
+ *
+ * @p clip is taken for its fades, because a fade whose behaviour is a speed
+ * ramp is not a gain envelope at all: it is a warp of this position near the
+ * clip's edges (FadeCurves.hpp).
+ */
+double readingPositionAt(const AudioClipPlayback& clip, const AudioEventPlayback& event,
+                         double seconds, double beat, double deviceSampleRate);
+
+/// What @p event needs stretching with, or a setup no stretcher is made for
+/// when it plays at its file's own speed with nothing asked of its pitch.
+/// @p clip is taken for its fades, which decide the same question at its edges.
+StretchSetup stretchSetupFor(const AudioClipPlayback& clip, const AudioEventPlayback& event,
+                             const RenderContext& context);
 
 }  // namespace magda::engine

--- a/magda/engine/clip/FadeCurves.cpp
+++ b/magda/engine/clip/FadeCurves.cpp
@@ -32,6 +32,32 @@ float fadeGain(FadeCurve curve, float alpha) {
     return alpha;
 }
 
+double fadeRampPosition(FadeCurve curve, double alpha, bool rising) {
+    alpha = std::clamp(alpha, 0.0, 1.0);
+
+    const auto pi = static_cast<double>(kPi);
+
+    switch (curve) {
+        case FadeCurve::Convex:
+            return rising ? (-2.0 * std::cos((pi * alpha) / 2.0)) / pi + 1.0
+                          : 1.0 - ((-2.0 * std::cos((pi * (alpha - 1.0)) / 2.0)) / pi + 1.0);
+
+        case FadeCurve::Concave:
+            return rising
+                       ? alpha - (2.0 * std::sin((pi * alpha) / 2.0)) / pi + (2.0 / pi)
+                       : ((2.0 * std::sin((pi * (alpha + 1.0)) / 2.0)) / pi) + alpha - (2.0 / pi);
+
+        case FadeCurve::SCurve:
+            return rising ? (alpha / 2.0) - (std::sin(pi * alpha) / (2.0 * pi)) + 0.5
+                          : std::sin(pi * alpha) / (2.0 * pi) + (alpha / 2.0);
+
+        case FadeCurve::Linear:
+            break;
+    }
+
+    return rising ? (alpha * alpha * 0.5) + 0.5 : ((-(alpha - 1.0) * (alpha - 1.0)) * 0.5) + 0.5;
+}
+
 void applyStartDeClick(juce::dsp::AudioBlock<float> audio, int fadeSamples) {
     const auto length = std::min(static_cast<std::size_t>(std::max(0, fadeSamples)),
                                  static_cast<std::size_t>(audio.getNumSamples()));

--- a/magda/engine/clip/FadeCurves.hpp
+++ b/magda/engine/clip/FadeCurves.hpp
@@ -30,6 +30,27 @@ namespace magda::engine {
 float fadeGain(FadeCurve curve, float alpha);
 
 /**
+ * @brief Where a speed ramp has got to, @p alpha along itself.
+ *
+ * The other thing a clip's fade pair can mean (ClipInfo::fadeInBehaviour). A
+ * speed ramp is not a gain envelope at all: the material accelerates into the
+ * clip and decelerates out of it, pitch and all, the way a tape machine starts
+ * and stops. So the curve is read as a position rather than as a level, and what
+ * comes back is the proportion of the ramp's own stretch that has been consumed.
+ *
+ * These are the incumbent's shapes, which are the integrals of the gain curves
+ * above rather than the curves themselves: what the gain curve is worth at a
+ * point is the *rate* the material runs at there, and where the material has got
+ * to is the area under that. A rising ramp therefore ends at 1 and begins at a
+ * half, which is not a mistake: a ramp that ran the material from the very start
+ * of the region would arrive at the far end half a region behind where the clip
+ * says it should be. Starting ahead is what makes it land in the right place.
+ *
+ * @p alpha runs 0 to 1 across the ramp, and @p rising says which edge it is.
+ */
+double fadeRampPosition(FadeCurve curve, double alpha, bool rising);
+
+/**
  * @brief Return the start of @p audio to zero without fading what follows it.
  *
  * The launch ramp (ClipInfo::launchFadeSamples), and deliberately not a fade:

--- a/magda/engine/exec/RenderContext.hpp
+++ b/magda/engine/exec/RenderContext.hpp
@@ -130,6 +130,28 @@ struct BlockInfo {
      * edges of a region, and a region that runs to the end of the block ends at
      * the sample after the last one, the way every half-open range does.
      */
+    /**
+     * @brief The beat face of a moment inside this block.
+     *
+     * The two faces are two views of one stretch of timeline, so a moment given
+     * in one has an answer in the other, and this is the conversion that does
+     * not need a tempo map: the ends are known in both, and a block is short
+     * enough that the curve between them is a straight line to well under a
+     * sample.
+     *
+     * What asks is a clip whose material is consumed against beats rather than
+     * against seconds, which is what auto tempo is (clip/EventPlacement.hpp).
+     * The window such a clip plays over is worked out in seconds, because that
+     * is what spans and fades are in, and then has to be asked about in beats.
+     */
+    double beatAtTime(double seconds) const {
+        if (endSeconds <= startSeconds)
+            return startBeat;
+
+        const auto position = (seconds - startSeconds) / (endSeconds - startSeconds);
+        return startBeat + position * (endBeat - startBeat);
+    }
+
     int sampleForTime(double seconds) const {
         if (numSamples <= 0)
             return 0;

--- a/magda/engine/exec/RenderContext.hpp
+++ b/magda/engine/exec/RenderContext.hpp
@@ -130,6 +130,17 @@ struct BlockInfo {
      * edges of a region, and a region that runs to the end of the block ends at
      * the sample after the last one, the way every half-open range does.
      */
+    int sampleForTime(double seconds) const {
+        if (numSamples <= 0)
+            return 0;
+        if (endSeconds <= startSeconds)
+            return 0;
+
+        const auto position = (seconds - startSeconds) / (endSeconds - startSeconds);
+        const auto sample = static_cast<int>(std::lround(position * numSamples));
+        return std::clamp(sample, 0, numSamples);
+    }
+
     /**
      * @brief The beat face of a moment inside this block.
      *
@@ -150,17 +161,6 @@ struct BlockInfo {
 
         const auto position = (seconds - startSeconds) / (endSeconds - startSeconds);
         return startBeat + position * (endBeat - startBeat);
-    }
-
-    int sampleForTime(double seconds) const {
-        if (numSamples <= 0)
-            return 0;
-        if (endSeconds <= startSeconds)
-            return 0;
-
-        const auto position = (seconds - startSeconds) / (endSeconds - startSeconds);
-        const auto sample = static_cast<int>(std::lround(position * numSamples));
-        return std::clamp(sample, 0, numSamples);
     }
 };
 

--- a/magda/engine/io/SourceReaders.cpp
+++ b/magda/engine/io/SourceReaders.cpp
@@ -48,17 +48,6 @@ bool insideMaterial(const AudioFileReader& file, std::int64_t startSample, int n
     return startSample + numSamples > 0 && startSample < file.lengthInSamples();
 }
 
-/// Cubic Lagrange through four samples, @p t of the way from the second to the
-/// third.
-float interpolate(float first, float second, float third, float fourth, double t) {
-    const auto a = -t * (t - 1.0) * (t - 2.0) / 6.0;
-    const auto b = (t + 1.0) * (t - 1.0) * (t - 2.0) / 2.0;
-    const auto c = -(t + 1.0) * t * (t - 2.0) / 2.0;
-    const auto d = (t + 1.0) * t * (t - 1.0) / 6.0;
-
-    return static_cast<float>(a * first + b * second + c * third + d * fourth);
-}
-
 }  // namespace
 
 std::unique_ptr<AudioFileReader> readThrough(std::unique_ptr<AudioFileReader> file,
@@ -281,8 +270,8 @@ int ResamplingAudioFileReader::read(juce::AudioBuffer<float>& destination, int d
                 static_cast<double>(startSample + sample) * ratio_ - static_cast<double>(first);
             const auto index = static_cast<int>(std::floor(position));
 
-            out[sample] = interpolate(source[index - 1], source[index], source[index + 1],
-                                      source[index + 2], position - index);
+            out[sample] = cubicLagrange(source[index - 1], source[index], source[index + 1],
+                                        source[index + 2], position - index);
         }
     }
 

--- a/magda/engine/io/SourceReaders.hpp
+++ b/magda/engine/io/SourceReaders.hpp
@@ -44,6 +44,25 @@
 namespace magda::engine {
 
 /**
+ * @brief Cubic Lagrange through four samples, @p t of the way from @p second to
+ *        @p third.
+ *
+ * Here rather than inside the rate converter because there is more than one
+ * thing that lands between samples: a file recorded at another rate is one, and
+ * a clip played at a speed that is not its own is the other (ClipStretcher.hpp).
+ * Two curves would mean a file at 48 kHz and a clip at half speed were resampled
+ * to different qualities for no reason a listener could name.
+ */
+inline float cubicLagrange(float first, float second, float third, float fourth, double t) {
+    const auto a = -t * (t - 1.0) * (t - 2.0) / 6.0;
+    const auto b = (t + 1.0) * (t - 1.0) * (t - 2.0) / 2.0;
+    const auto c = -(t + 1.0) * t * (t - 2.0) / 2.0;
+    const auto d = (t + 1.0) * t * (t - 1.0) / 6.0;
+
+    return static_cast<float>(a * first + b * second + c * third + d * fourth);
+}
+
+/**
  * @brief What an event asks of its file, beyond the samples themselves.
  *
  * In the source's own samples at the source's own rate, which is how the model

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -265,6 +265,7 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_clip_snapshot.cpp)
     list(APPEND TEST_SOURCES test_clip_voice.cpp)
     list(APPEND TEST_SOURCES test_clip_voice_pool.cpp)
+    list(APPEND TEST_SOURCES test_clip_stretch.cpp)
 endif()
 
 # Create test executable

--- a/tests/test_clip_stretch.cpp
+++ b/tests/test_clip_stretch.cpp
@@ -959,3 +959,48 @@ TEST_CASE("An auto tempo ratio past what a stretcher will run at stays inside it
     CHECK(magda::engine::readingRateOf(event) == approx(magda::engine::kMaxStretchRate));
     CHECK(std::isfinite(rig.rms()));
 }
+
+TEST_CASE("SoundTouch runs the whole rate range without growing a buffer under a callback",
+          "[engine][clip][stretch]") {
+    // SoundTouch grows its own pipes on demand, and both the calls that feed it
+    // are on the audio thread, so its buffers are pushed to their worst case on
+    // the thread that builds it (SoundTouchClipStretcher). The worst case is the
+    // sequence it keeps back plus the largest single push a callback can hand
+    // it, and it is settled in one call because putSamples grows to hold what a
+    // single call hands it: the same total in block-sized pieces only grows it
+    // to whatever residue that rate happened to leave.
+    //
+    // What this covers is the range that has to have been reached: both modes,
+    // rates from a sixth to the ceiling, a pitch shift so the rate transposer is
+    // in the chain too, auto tempo so the rate moves block to block, and locates
+    // in both directions so priming runs again over material the reader has to
+    // seek for. Verified against a counter on the vendored ensureCapacity, which
+    // stays at zero throughout and is what caught the first version of the
+    // warm-up, where a clip playing at nine could still allocate after a warm-up
+    // that ran at ten.
+    for (const auto which : {mode::kSoundTouchNormal, mode::kSoundTouchBetter}) {
+        for (const auto ratio : {0.15, 0.5, 1.7, 2.0, 4.3, 9.0, 9.97}) {
+            Rig rig;
+            rig.lane.audio.push_back(clipOver(1, blocks(100, 400), 0));
+
+            auto& event = rig.event(1);
+            event.timeStretchMode = which;
+            event.autoTempo = true;
+            event.interpBpm = kBpm / ratio;
+            event.pitchChange = 4.0f;
+
+            rig.give(1, 1, std::make_unique<SineReader>(1000.0));
+            rig.publish();
+
+            rig.rollTo(140);
+            rig.advance(20);
+            rig.locate(300);
+            rig.advance(20);
+            rig.locate(150);
+            rig.advance(30);
+
+            INFO("mode " << which << " ratio " << ratio);
+            CHECK(std::isfinite(rig.rms()));
+        }
+    }
+}

--- a/tests/test_clip_stretch.cpp
+++ b/tests/test_clip_stretch.cpp
@@ -156,6 +156,39 @@ class ConstantReader final : public magda::engine::AudioFileReader {
     }
 };
 
+/// A stretcher that records what it was asked to do and passes the material
+/// through. What a voice calls, and when, is the question some of these tests
+/// ask; what a phase vocoder does with it is not.
+class CountingStretcher final : public magda::engine::ClipStretcher {
+  public:
+    int preRollSamples(double) const override {
+        return 0;
+    }
+
+    void reset() override {
+        ++resets;
+    }
+
+    void prime(PrefetchStream&, std::int64_t, int, double) override {
+        ++primes;
+    }
+
+    void process(juce::dsp::AudioBlock<const float> input, double, double,
+                 juce::dsp::AudioBlock<float> output) override {
+        ++processes;
+
+        for (std::size_t channel = 0; channel < output.getNumChannels(); ++channel)
+            for (std::size_t sample = 0; sample < output.getNumSamples(); ++sample)
+                output.getChannelPointer(channel)[sample] =
+                    sample < input.getNumSamples() ? input.getChannelPointer(channel)[sample]
+                                                   : 0.0f;
+    }
+
+    int primes = 0;
+    int resets = 0;
+    int processes = 0;
+};
+
 SnapshotSpan seconds(double start, double end) {
     SnapshotSpan span;
     span.startBeat = start * kBeatsPerSecond;
@@ -557,12 +590,42 @@ TEST_CASE("A clip asks for a stretcher only when it needs one", "[engine][clip][
         }
     }
 
-    SECTION("a mode this build has no engine for plays at unity rather than silence") {
+    SECTION("a mode this build has no engine for falls back rather than skipping material") {
         event.timeStretchMode = 6;  // elastiquePro, which is not vendored here
         event.speedRatio = 2.0;
 
+        // The default engine, as the incumbent answers the same question. Not
+        // null: the position map has already decided this block consumes twice
+        // its length, so a clip with nothing to consume it through would read
+        // that material at unity and skip the rest at every block boundary.
         REQUIRE(magda::engine::makeStretcher(
-                    magda::engine::stretchSetupFor(clip, event, context())) == nullptr);
+                    magda::engine::stretchSetupFor(clip, event, context())) != nullptr);
+    }
+
+    SECTION("a transpose with nothing else asked for still gets one") {
+        // The model's rule upgrades a mode left at Off for auto tempo, warp, a
+        // ratio and a pitch change, and not for the transpose an auto pitch clip
+        // carries. A clip that only transposes would otherwise be handed
+        // semitones with nothing to apply them with, and would play untransposed.
+        event.autoPitch = true;
+        event.transpose = -4;
+
+        const auto setup = magda::engine::stretchSetupFor(clip, event, context());
+
+        CHECK(setup.semitones == approx(-4.0));
+        CHECK(setup.mode == mode::kSignalsmith);
+        REQUIRE(magda::engine::makeStretcher(setup) != nullptr);
+    }
+
+    SECTION("and analog pitch still does not, because its pitch is not a stretch") {
+        event.analogPitch = true;
+        event.pitchChange = 7.0f;
+        event.speedRatio = std::pow(2.0, 7.0 / 12.0);
+
+        const auto setup = magda::engine::stretchSetupFor(clip, event, context());
+
+        CHECK(setup.mode == mode::kDisabled);
+        CHECK(magda::engine::makeStretcher(setup)->readAheadSamples() > 0);
     }
 }
 
@@ -786,4 +849,82 @@ TEST_CASE("A speed ramp reads the file at a rate that climbs to unity", "[engine
     rig.advance(10);
     REQUIRE(rig.at(kBlockSize - 1) - rig.at(0) == approx(kBlockSize - 1, 0.5));
     REQUIRE(rig.at(0) == approx((blockTime(111) - blockTime(100)) * kSampleRate, 2.0));
+}
+
+TEST_CASE("A voice primes the stretcher it is handed, and the one that replaces it",
+          "[engine][clip][stretch]") {
+    // A rate, pitch or mode edit on a sounding clip swaps in a fresh stretcher
+    // and leaves the stream alone (ClipVoicePool::service). The entry a voice is
+    // playing does not change when it does, so a voice that remembered only
+    // *that* it had primed would run the new engine cold, and cold for a phase
+    // vocoder is its whole latency out of step with every other voice on the
+    // track, for the rest of the take.
+    //
+    // Driven directly rather than through a track, because what is being
+    // asserted is which calls a voice makes rather than what they sound like.
+    magda::engine::ClipVoice voice;
+    voice.prepare(context());
+
+    const auto clip = clipOver(1, blocks(0, 400), 0);
+    const auto& event = clip.events.front();
+
+    PrefetchStream stream(std::make_unique<CountingReader>(), context(), {8192, 8});
+
+    juce::AudioBuffer<float> scratch(2, magda::engine::stretchScratchSamples(kBlockSize));
+    juce::AudioBuffer<float> out(2, kBlockSize);
+    scratch.clear();
+    out.clear();
+
+    CountingStretcher first;
+    CountingStretcher second;
+
+    const auto render = [&](magda::engine::ClipStretcher& stretcher, int block, bool continuous) {
+        voice.render(clip, event, blockFrom(blockTime(block), continuous), stream, &stretcher, 0,
+                     juce::dsp::AudioBlock<float>(scratch), juce::dsp::AudioBlock<float>(out));
+    };
+
+    render(first, 10, false);
+    CHECK(first.primes == 1);
+
+    // Carrying on, so nothing is primed again: priming reads behind where the
+    // block is, and doing that every block would seek every block.
+    render(first, 11, true);
+    render(first, 12, true);
+    CHECK(first.primes == 1);
+
+    // The edit. Same clip, same event, same stream, continuous block, different
+    // engine, and it has to be primed.
+    render(second, 13, true);
+    CHECK(second.primes == 1);
+    CHECK(first.primes == 1);
+
+    // And a jump primes whatever is in place, as before.
+    render(second, 200, false);
+    CHECK(second.primes == 2);
+}
+
+TEST_CASE("An auto tempo ratio past what a stretcher will run at stays inside its buffers",
+          "[engine][clip][stretch]") {
+    // A constant ratio is clamped where it is read, and auto tempo's is not: it
+    // is the project's tempo over a file's own analysed bpm, and nothing bounds
+    // their quotient. A file analysed at fifteen bpm under this rig is past the
+    // ceiling by a long way. It plays wrongly, which is what a clamped ratio
+    // does too; what it must not do is read more than the block was sized for.
+    Rig rig;
+    rig.lane.audio.push_back(clipOver(1, blocks(100, 400), 0));
+
+    auto& event = rig.event(1);
+    event.autoTempo = true;
+    event.interpBpm = 5.0;
+    event.timeStretchMode = mode::kSoundTouchNormal;
+
+    rig.give(1, 1, std::make_unique<SineReader>(1000.0));
+    rig.publish();
+    rig.rollTo(140);
+
+    // Nothing to assert about the sound of it. That it got here at all is the
+    // assertion: the reading a block asks for is bounded by the same function
+    // every buffer behind it was sized against.
+    CHECK(magda::engine::readingRateOf(event) == approx(magda::engine::kMaxStretchRate));
+    CHECK(std::isfinite(rig.rms()));
 }

--- a/tests/test_clip_stretch.cpp
+++ b/tests/test_clip_stretch.cpp
@@ -572,6 +572,37 @@ TEST_CASE("A clip asks for a stretcher only when it needs one", "[engine][clip][
                     magda::engine::stretchSetupFor(clip, event, context())) != nullptr);
     }
 
+    SECTION("a mode set once on a clip that asks for nothing gets no engine") {
+        // The mode is a preference for how to stretch, not an instruction to
+        // stretch. The incumbent engages on auto tempo, auto pitch, a pitch
+        // change or a ratio off unity and never on the mode alone
+        // (AudioClipBase::usesTimeStretchedProxy), and a phase vocoder run at
+        // one-to-one is not transparent: it re-synthesises what it was given.
+        for (const auto which :
+             {mode::kSignalsmith, mode::kSoundTouchNormal, mode::kSoundTouchBetter}) {
+            event.timeStretchMode = which;
+
+            INFO("mode " << which);
+            REQUIRE(magda::engine::makeStretcher(
+                        magda::engine::stretchSetupFor(clip, event, context())) == nullptr);
+        }
+    }
+
+    SECTION("auto tempo keeps its engine even where its average is unity") {
+        // The average is not what it plays at: an auto tempo ratio is the
+        // project's tempo over the file's own and moves with the tempo curve, so
+        // a clip averaging unity is still stretching in both directions around
+        // it.
+        event.timeStretchMode = mode::kSignalsmith;
+        event.autoTempo = true;
+        event.interpBpm = 120.0;
+
+        const auto setup = magda::engine::stretchSetupFor(clip, event, context());
+
+        REQUIRE(setup.nominalRate == approx(1.0));
+        REQUIRE(magda::engine::makeStretcher(setup) != nullptr);
+    }
+
     SECTION("the pinned modes each resolve to an engine that primes") {
         for (const auto which :
              {mode::kSignalsmith, mode::kSoundTouchNormal, mode::kSoundTouchBetter}) {

--- a/tests/test_clip_stretch.cpp
+++ b/tests/test_clip_stretch.cpp
@@ -1,0 +1,789 @@
+#include <algorithm>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#include "clip/ClipAudioSource.hpp"
+#include "clip/ClipStretcher.hpp"
+#include "clip/EventPlacement.hpp"
+#include "core/TimeStretchModes.hpp"
+#include "io/SourceReaders.hpp"
+
+/**
+ * Playing a clip at a speed and a pitch that are not its file's (#2037).
+ *
+ * Two halves, and they are tested differently on purpose.
+ *
+ * Where in the reading a moment sits is arithmetic, so it is tested as
+ * arithmetic: exactly, against numbers worked out by hand. Everything this slice
+ * adds is that one function answering differently, so this is where a speed
+ * ratio, auto tempo, analog pitch and a speed ramp are actually pinned down.
+ *
+ * What comes out of a stretcher is not arithmetic. A phase vocoder's samples are
+ * its own business, so what is asserted of those is what a listener would say:
+ * the block is full, the level survived, and the pitch moved or did not move.
+ * The resampling path is the exception, and a useful one: cubic interpolation of
+ * a straight line is exact, so a counting reader through it says precisely which
+ * sample of the file was heard.
+ *
+ * Everything rolls, the way the other clip rigs do. A test that skipped from one
+ * block to a distant one would be testing a locate rather than playback (#2016).
+ */
+
+using magda::engine::AudioClipPlayback;
+using magda::engine::AudioEventPlayback;
+using magda::engine::BlockInfo;
+using magda::engine::ClipAudioSource;
+using magda::engine::ClipSnapshot;
+using magda::engine::ClipSnapshotFeed;
+using magda::engine::ClipStreamFeed;
+using magda::engine::ClipStreamTable;
+using magda::engine::ClipStretcher;
+using magda::engine::PrefetchStream;
+using magda::engine::RenderContext;
+using magda::engine::SnapshotSpan;
+using magda::engine::StretchSetup;
+using magda::engine::TrackClipPlayback;
+
+namespace mode = magda::time_stretch_mode;
+
+namespace {
+
+constexpr double kSampleRate = 44100.0;
+
+/// Long enough that a block holds a dozen cycles of the test tone, because one
+/// of the questions here is what happened to the pitch.
+constexpr int kBlockSize = 512;
+
+constexpr magda::TrackId kTrack = 7;
+
+/// The rig's tempo. Beats and seconds are two faces of one instant everywhere in
+/// the engine, so a span built here carries both, and auto tempo reads the one
+/// the others ignore.
+constexpr double kBpm = 120.0;
+constexpr double kBeatsPerSecond = kBpm / 60.0;
+
+double blockTime(int index) {
+    return index * static_cast<double>(kBlockSize) / kSampleRate;
+}
+
+RenderContext context() {
+    return RenderContext{kSampleRate, kBlockSize, 2};
+}
+
+Catch::Approx approx(double value, double margin = 1e-4) {
+    return Catch::Approx(value).margin(margin);
+}
+
+/// Sample n reads back as n, so which sample of the file was heard is readable
+/// off the value. Through the resampling path that stays true between samples:
+/// the curve is cubic and a straight line is one of the things a cubic is.
+class CountingReader final : public magda::engine::AudioFileReader {
+  public:
+    std::int64_t lengthInSamples() const override {
+        return 100000000;
+    }
+    double sampleRate() const override {
+        return kSampleRate;
+    }
+    int numChannels() const override {
+        return 2;
+    }
+
+    int read(juce::AudioBuffer<float>& destination, int destinationOffset, std::int64_t startSample,
+             int numSamples) override {
+        for (auto channel = 0; channel < destination.getNumChannels(); ++channel)
+            for (auto sample = 0; sample < numSamples; ++sample)
+                destination.setSample(channel, destinationOffset + sample,
+                                      static_cast<float>(startSample + sample));
+        return numSamples;
+    }
+};
+
+/// A tone at a known frequency, which is what a question about pitch needs.
+class SineReader final : public magda::engine::AudioFileReader {
+  public:
+    explicit SineReader(double frequency) : frequency_(frequency) {}
+
+    std::int64_t lengthInSamples() const override {
+        return 100000000;
+    }
+    double sampleRate() const override {
+        return kSampleRate;
+    }
+    int numChannels() const override {
+        return 2;
+    }
+
+    int read(juce::AudioBuffer<float>& destination, int destinationOffset, std::int64_t startSample,
+             int numSamples) override {
+        for (auto channel = 0; channel < destination.getNumChannels(); ++channel)
+            for (auto sample = 0; sample < numSamples; ++sample) {
+                const auto phase = 2.0 * juce::MathConstants<double>::pi * frequency_ *
+                                   static_cast<double>(startSample + sample) / kSampleRate;
+                destination.setSample(channel, destinationOffset + sample,
+                                      static_cast<float>(std::sin(phase)));
+            }
+        return numSamples;
+    }
+
+  private:
+    double frequency_;
+};
+
+/// Every sample the same, so a gain that was applied is visible and a gain that
+/// was not is visible too.
+class ConstantReader final : public magda::engine::AudioFileReader {
+  public:
+    std::int64_t lengthInSamples() const override {
+        return 100000000;
+    }
+    double sampleRate() const override {
+        return kSampleRate;
+    }
+    int numChannels() const override {
+        return 2;
+    }
+
+    int read(juce::AudioBuffer<float>& destination, int destinationOffset, std::int64_t,
+             int numSamples) override {
+        for (auto channel = 0; channel < destination.getNumChannels(); ++channel)
+            for (auto sample = 0; sample < numSamples; ++sample)
+                destination.setSample(channel, destinationOffset + sample, 1.0f);
+        return numSamples;
+    }
+};
+
+SnapshotSpan seconds(double start, double end) {
+    SnapshotSpan span;
+    span.startBeat = start * kBeatsPerSecond;
+    span.endBeat = end * kBeatsPerSecond;
+    span.startSeconds = start;
+    span.endSeconds = end;
+    return span;
+}
+
+SnapshotSpan blocks(int firstBlock, int lastBlock) {
+    return seconds(blockTime(firstBlock), blockTime(lastBlock));
+}
+
+BlockInfo blockFrom(double startSeconds, bool continuous = true) {
+    BlockInfo block;
+    block.numSamples = kBlockSize;
+    block.playing = true;
+    block.startSeconds = startSeconds;
+    block.endSeconds = startSeconds + kBlockSize / kSampleRate;
+    block.startBeat = startSeconds * kBeatsPerSecond;
+    block.endBeat = block.endSeconds * kBeatsPerSecond;
+    block.continuous = continuous;
+    return block;
+}
+
+AudioClipPlayback clipOver(magda::ClipId id, SnapshotSpan span, std::int64_t anchor = 0) {
+    AudioClipPlayback clip;
+    clip.clipId = id;
+    clip.span = span;
+    clip.launchFadeSamples = 0;
+
+    AudioEventPlayback event;
+    event.eventId = id;
+    event.sourceId = id;
+    event.filePath = "take.wav";
+    event.sourceSampleRate = kSampleRate;
+    event.sourceDurationSeconds = 10000.0;
+    event.span = span;
+    event.anchorSamples = anchor;
+    clip.events.push_back(std::move(event));
+
+    return clip;
+}
+
+/// The beat face of a moment, at the rig's tempo. What the transport publishes
+/// beside the seconds, and what auto tempo reads.
+double beatAt(double seconds) {
+    return seconds * kBeatsPerSecond;
+}
+
+/// A track's clips, the readers and stretchers behind them, and a transport that
+/// rolls. Provisioned the way ClipVoicePool provisions: through the same
+/// functions, so that where a stream is pointed and where a voice reads are one
+/// derivation rather than two that have to be kept in step by hand.
+struct Rig {
+    Rig() {
+        source.prepare(context());
+        output.setSize(2, kBlockSize);
+        output.clear();
+    }
+
+    PrefetchStream& give(magda::ClipId clipId, magda::EventId eventId,
+                         std::unique_ptr<magda::engine::AudioFileReader> reader,
+                         magda::engine::PrefetchSettings settings = {8192, 8}) {
+        const auto* clip = clipOf(clipId);
+        REQUIRE(clip != nullptr);
+        const auto* event = eventOf(clipId, eventId);
+        REQUIRE(event != nullptr);
+
+        auto stream = std::make_shared<PrefetchStream>(
+            magda::engine::readThrough(std::move(reader),
+                                       magda::engine::sourceReadFor(*event, kSampleRate)),
+            context(), settings);
+
+        const auto setup = magda::engine::stretchSetupFor(*clip, *event, context());
+        std::shared_ptr<ClipStretcher> stretcher = magda::engine::makeStretcher(setup);
+        const auto preRoll =
+            stretcher != nullptr ? stretcher->preRollSamples(setup.nominalRate) : 0;
+
+        auto& created = *stream;
+        table.entries.push_back(ClipStreamTable::Entry{kTrack, clipId, eventId, std::move(stream),
+                                                       std::move(stretcher), preRoll});
+        return created;
+    }
+
+    void publish() {
+        auto compiled = std::make_shared<ClipSnapshot>();
+        compiled->tracks.push_back(lane);
+        clips.publish(std::move(compiled));
+
+        std::sort(table.entries.begin(), table.entries.end(),
+                  [](const ClipStreamTable::Entry& a, const ClipStreamTable::Entry& b) {
+                      if (a.trackId != b.trackId)
+                          return a.trackId < b.trackId;
+                      if (a.clipId != b.clipId)
+                          return a.clipId < b.clipId;
+                      return a.eventId < b.eventId;
+                  });
+        streams.publish(std::make_shared<const ClipStreamTable>(table));
+    }
+
+    /// Put the transport @p lead blocks before @p targetBlock and roll to it,
+    /// cueing every stream where the pool would have (ClipVoicePool::cueFor).
+    void start(int targetBlock, int lead) {
+        next_ = targetBlock - lead;
+
+        for (const auto& entry : table.entries) {
+            const auto* clip = clipOf(entry.clipId);
+            const auto* event = eventOf(entry.clipId, entry.eventId);
+            REQUIRE(event != nullptr);
+
+            const auto at = std::max(blockTime(next_), event->span.startSeconds);
+            const auto position =
+                magda::engine::readingPositionAt(*clip, *event, at, beatAt(at), kSampleRate);
+            const auto ahead = entry.stretcher != nullptr ? entry.stretcher->readAheadSamples() : 0;
+
+            entry.stream->seek(static_cast<std::int64_t>(std::llround(position)) + ahead -
+                               entry.preRollSamples);
+        }
+
+        advance(lead + 1);
+    }
+
+    /// Roll to @p targetBlock, starting from before the clip does.
+    ///
+    /// Where the pool would have cued it: a stream told where to go a second
+    /// early has its material in memory by the time its clip starts, so the
+    /// first block of that clip primes its stretcher with material rather than
+    /// with the silence a reader that has not caught up gives. A stretcher
+    /// primed on silence still plays, and fades in over its own window instead
+    /// of arriving aligned, which is what a locate onto a clip sounds like and
+    /// not what starting one does.
+    void rollTo(int targetBlock) {
+        start(targetBlock, targetBlock - kFirstBlock + 8);
+    }
+
+    void advance(int count = 1, bool continuous = true) {
+        for (auto index = 0; index < count; ++index) {
+            render(blockFrom(blockTime(next_), continuous || index > 0));
+            ++next_;
+        }
+    }
+
+    /// Jump the transport to @p targetBlock, the way a locate does: the block
+    /// that lands there is not continuous with the one before it.
+    void locate(int targetBlock) {
+        next_ = targetBlock;
+        advance(1, false);
+    }
+
+    void render(const BlockInfo& block) {
+        fill();
+        source.render(block, juce::dsp::AudioBlock<float>(output));
+    }
+
+    void fill() {
+        auto worked = true;
+        while (worked) {
+            worked = false;
+            for (const auto& entry : table.entries)
+                worked = entry.stream->fill() || worked;
+        }
+    }
+
+    float at(int sample, int channel = 0) const {
+        return output.getSample(channel, sample);
+    }
+
+    double rms(int channel = 0) const {
+        auto sum = 0.0;
+        for (auto sample = 0; sample < kBlockSize; ++sample) {
+            const auto value = output.getSample(channel, sample);
+            sum += value * value;
+        }
+        return std::sqrt(sum / kBlockSize);
+    }
+
+    /// How often the block crosses zero, which is what a question about pitch
+    /// reduces to for a single tone.
+    int zeroCrossings(int channel = 0) const {
+        auto crossings = 0;
+        for (auto sample = 1; sample < kBlockSize; ++sample)
+            if ((output.getSample(channel, sample - 1) < 0.0f) !=
+                (output.getSample(channel, sample) < 0.0f))
+                ++crossings;
+        return crossings;
+    }
+
+    const AudioClipPlayback* clipOf(magda::ClipId clipId) const {
+        for (const auto& clip : lane.audio)
+            if (clip.clipId == clipId)
+                return &clip;
+        return nullptr;
+    }
+
+    const AudioEventPlayback* eventOf(magda::ClipId clipId, magda::EventId eventId) const {
+        if (const auto* clip = clipOf(clipId))
+            for (const auto& event : clip->events)
+                if (event.eventId == eventId)
+                    return &event;
+        return nullptr;
+    }
+
+    AudioEventPlayback& event(magda::ClipId clipId) {
+        return lane.audio.front().events.front();
+    }
+
+    TrackClipPlayback lane{kTrack, {}, {}};
+    ClipSnapshotFeed clips;
+    ClipStreamFeed streams;
+    ClipAudioSource source{kTrack, clips, streams};
+    ClipStreamTable table;
+    juce::AudioBuffer<float> output;
+
+    int next_ = 0;
+
+    /// The block every clip in this file starts on, so that rolling in from
+    /// before it is one number rather than one per test.
+    static constexpr int kFirstBlock = 100;
+};
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Where in the reading a moment sits.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("A clip at its file's own speed consumes one sample per sample",
+          "[engine][clip][stretch]") {
+    const auto clip = clipOver(1, seconds(10.0, 20.0), 500);
+    const auto& event = clip.events.front();
+
+    REQUIRE(magda::engine::readingRateOf(event) == approx(1.0));
+    REQUIRE(magda::engine::readingPositionAt(clip, event, 10.0, beatAt(10.0), kSampleRate) ==
+            approx(500.0));
+
+    // One second later, one second of the file later.
+    REQUIRE(magda::engine::readingPositionAt(clip, event, 11.0, beatAt(11.0), kSampleRate) ==
+            approx(500.0 + kSampleRate));
+}
+
+TEST_CASE("A speed ratio is a constant factor on how fast the reading is consumed",
+          "[engine][clip][stretch]") {
+    auto clip = clipOver(1, seconds(10.0, 20.0), 500);
+    auto& event = clip.events.front();
+
+    SECTION("twice as fast") {
+        event.speedRatio = 2.0;
+
+        REQUIRE(magda::engine::readingRateOf(event) == approx(2.0));
+        REQUIRE(magda::engine::readingPositionAt(clip, event, 11.0, beatAt(11.0), kSampleRate) ==
+                approx(500.0 + 2.0 * kSampleRate));
+    }
+
+    SECTION("half as fast") {
+        event.speedRatio = 0.5;
+
+        REQUIRE(magda::engine::readingPositionAt(clip, event, 11.0, beatAt(11.0), kSampleRate) ==
+                approx(500.0 + 0.5 * kSampleRate));
+    }
+
+    SECTION("a ratio no stretcher will run at is clamped rather than obeyed") {
+        event.speedRatio = 1000.0;
+
+        REQUIRE(magda::engine::readingRateOf(event) == approx(magda::engine::kMaxStretchRate));
+        REQUIRE(magda::engine::readingPositionAt(clip, event, 11.0, beatAt(11.0), kSampleRate) ==
+                approx(500.0 + magda::engine::kMaxStretchRate * kSampleRate));
+    }
+}
+
+TEST_CASE("Auto tempo consumes the file against beats rather than against seconds",
+          "[engine][clip][stretch]") {
+    // A file analysed at 60 bpm, played on a 120 bpm timeline: twice as fast.
+    auto clip = clipOver(1, seconds(10.0, 20.0), 0);
+    auto& event = clip.events.front();
+    event.autoTempo = true;
+    event.interpBpm = 60.0;
+
+    REQUIRE(magda::engine::readingRateOf(event) == approx(2.0));
+
+    SECTION("at a constant tempo it is the equivalent constant ratio") {
+        auto pinned = clip;
+        pinned.events.front().autoTempo = false;
+        pinned.events.front().speedRatio = 2.0;
+
+        for (const auto at : {10.0, 12.5, 17.25}) {
+            const auto following =
+                magda::engine::readingPositionAt(clip, event, at, beatAt(at), kSampleRate);
+            const auto fixed = magda::engine::readingPositionAt(pinned, pinned.events.front(), at,
+                                                                beatAt(at), kSampleRate);
+            REQUIRE(following == approx(fixed, 1e-6));
+        }
+    }
+
+    SECTION("the beat face is what it reads, so a tempo that moved moves it") {
+        // The same instant in seconds, but the timeline has run twice as many
+        // beats to get there. A clip following the tempo has consumed twice the
+        // material; one on a fixed ratio would not have noticed.
+        const auto atDoubleTempo = magda::engine::readingPositionAt(
+            clip, event, 11.0, beatAt(11.0) + beatAt(1.0), kSampleRate);
+
+        REQUIRE(atDoubleTempo == approx(4.0 * kSampleRate));
+    }
+}
+
+TEST_CASE("A speed ramp warps where the material is, and lands where the clip says",
+          "[engine][clip][stretch]") {
+    // A one second linear ramp into a clip that starts at ten seconds.
+    auto clip = clipOver(1, seconds(10.0, 20.0), 0);
+    clip.fadeInSeconds = 1.0;
+    clip.fadeInBeats = 1.0 * kBeatsPerSecond;
+    clip.fadeInBehaviour = 1;
+    const auto& event = clip.events.front();
+
+    // Not at the clip's first sample: a ramp that ran the material from the very
+    // start of its region would arrive at the far end half a region behind. The
+    // linear ramp's integral says half way in.
+    REQUIRE(magda::engine::readingPositionAt(clip, event, 10.0, beatAt(10.0), kSampleRate) ==
+            approx(0.5 * kSampleRate, 1.0));
+
+    // And by the end of the ramp it has caught up with where an unramped clip
+    // would be, which is what makes the rest of the clip play in time.
+    REQUIRE(magda::engine::readingPositionAt(clip, event, 11.0, beatAt(11.0), kSampleRate) ==
+            approx(1.0 * kSampleRate, 1.0));
+
+    // Past the ramp nothing is warped at all.
+    REQUIRE(magda::engine::readingPositionAt(clip, event, 12.0, beatAt(12.0), kSampleRate) ==
+            approx(2.0 * kSampleRate, 1.0));
+}
+
+TEST_CASE("A reversed clip mirrors its anchor and still runs forwards through the reading",
+          "[engine][clip][stretch]") {
+    auto clip = clipOver(1, seconds(10.0, 11.0), 0);
+    auto& event = clip.events.front();
+    event.reversed = true;
+    event.speedRatio = 2.0;
+
+    const auto opens =
+        magda::engine::readingPositionAt(clip, event, 10.0, beatAt(10.0), kSampleRate);
+    const auto later =
+        magda::engine::readingPositionAt(clip, event, 10.5, beatAt(10.5), kSampleRate);
+
+    // Forwards through the mirrored file, at the ratio, whatever the flip did to
+    // where it starts.
+    REQUIRE(later - opens == approx(2.0 * 0.5 * kSampleRate));
+}
+
+// ---------------------------------------------------------------------------
+// Which stretcher an event gets.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("A clip asks for a stretcher only when it needs one", "[engine][clip][stretch]") {
+    auto clip = clipOver(1, seconds(0.0, 10.0), 0);
+    auto& event = clip.events.front();
+
+    SECTION("its file's own speed, nothing asked: no layer at all") {
+        REQUIRE(magda::engine::makeStretcher(
+                    magda::engine::stretchSetupFor(clip, event, context())) == nullptr);
+    }
+
+    SECTION("analog pitch resamples, and the model already folded the pitch into the ratio") {
+        event.analogPitch = true;
+        event.speedRatio = 2.0;
+
+        const auto setup = magda::engine::stretchSetupFor(clip, event, context());
+        const auto stretcher = magda::engine::makeStretcher(setup);
+
+        REQUIRE(stretcher != nullptr);
+
+        // The curve reaches past the sample it lands on, so the reading runs a
+        // little ahead of the position wanted.
+        REQUIRE(stretcher->readAheadSamples() > 0);
+        REQUIRE(stretcher->preRollSamples(setup.nominalRate) > 0);
+    }
+
+    SECTION("a speed ramp needs one even at the file's own speed") {
+        clip.fadeInSeconds = 0.5;
+        clip.fadeInBehaviour = 1;
+
+        REQUIRE(magda::engine::makeStretcher(
+                    magda::engine::stretchSetupFor(clip, event, context())) != nullptr);
+    }
+
+    SECTION("the pinned modes each resolve to an engine that primes") {
+        for (const auto which :
+             {mode::kSignalsmith, mode::kSoundTouchNormal, mode::kSoundTouchBetter}) {
+            event.timeStretchMode = which;
+            event.speedRatio = 2.0;
+
+            const auto setup = magda::engine::stretchSetupFor(clip, event, context());
+            const auto stretcher = magda::engine::makeStretcher(setup);
+
+            REQUIRE(stretcher != nullptr);
+
+            // Every one of them holds material back, and says how much, which is
+            // what the pool cues behind the clip's own start.
+            REQUIRE(stretcher->preRollSamples(setup.nominalRate) > 0);
+            REQUIRE(stretcher->readAheadSamples() == 0);
+        }
+    }
+
+    SECTION("a mode this build has no engine for plays at unity rather than silence") {
+        event.timeStretchMode = 6;  // elastiquePro, which is not vendored here
+        event.speedRatio = 2.0;
+
+        REQUIRE(magda::engine::makeStretcher(
+                    magda::engine::stretchSetupFor(clip, event, context())) == nullptr);
+    }
+}
+
+TEST_CASE("Pitch is the transpose a following clip has and the change a fixed one has",
+          "[engine][clip][stretch]") {
+    auto clip = clipOver(1, seconds(0.0, 10.0), 0);
+    auto& event = clip.events.front();
+    event.pitchChange = 3.0f;
+    event.transpose = -5;
+
+    REQUIRE(magda::engine::stretchSetupFor(clip, event, context()).semitones == approx(3.0));
+
+    event.autoPitch = true;
+    REQUIRE(magda::engine::stretchSetupFor(clip, event, context()).semitones == approx(-5.0));
+}
+
+// ---------------------------------------------------------------------------
+// Playing it.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("A resampled clip plays the samples its position map named", "[engine][clip][stretch]") {
+    Rig rig;
+    rig.lane.audio.push_back(clipOver(1, blocks(100, 300), 0));
+
+    auto& event = rig.event(1);
+    event.analogPitch = true;
+    event.speedRatio = 2.0;
+
+    rig.give(1, 1, std::make_unique<CountingReader>());
+    rig.publish();
+    rig.rollTo(120);
+
+    // Twice as fast: the block that begins twenty blocks into the clip is the
+    // fortieth block of the file, and it advances two samples per sample.
+    const auto opens = 2.0 * (blockTime(120) - blockTime(100)) * kSampleRate;
+
+    REQUIRE(rig.at(0) == approx(opens, 0.05));
+    REQUIRE(rig.at(1) == approx(opens + 2.0, 0.05));
+    REQUIRE(rig.at(kBlockSize - 1) == approx(opens + 2.0 * (kBlockSize - 1), 0.05));
+
+    // And the next block continues it exactly, with no sample lost or repeated
+    // at the join.
+    rig.advance();
+    REQUIRE(rig.at(0) == approx(opens + 2.0 * kBlockSize, 0.05));
+}
+
+TEST_CASE("A resampled clip lands between samples rather than on the nearest one",
+          "[engine][clip][stretch]") {
+    Rig rig;
+    rig.lane.audio.push_back(clipOver(1, blocks(100, 300), 0));
+
+    auto& event = rig.event(1);
+    event.analogPitch = true;
+    event.speedRatio = 0.5;
+
+    rig.give(1, 1, std::make_unique<CountingReader>());
+    rig.publish();
+    rig.rollTo(120);
+
+    const auto opens = 0.5 * (blockTime(120) - blockTime(100)) * kSampleRate;
+
+    // Half speed is a sample every other output sample, so the ones in between
+    // are the halves the curve found.
+    REQUIRE(rig.at(0) == approx(opens, 0.05));
+    REQUIRE(rig.at(1) == approx(opens + 0.5, 0.05));
+    REQUIRE(rig.at(2) == approx(opens + 1.0, 0.05));
+}
+
+TEST_CASE("A locate into a stretched clip resumes at the material the timeline names",
+          "[engine][clip][stretch]") {
+    Rig rig;
+    rig.lane.audio.push_back(clipOver(1, blocks(100, 400), 0));
+
+    auto& event = rig.event(1);
+    event.analogPitch = true;
+    event.speedRatio = 2.0;
+
+    rig.give(1, 1, std::make_unique<CountingReader>());
+    rig.publish();
+    rig.rollTo(120);
+
+    // Somewhere else entirely, with nothing said about it: the reader seeks, the
+    // stretcher resets and primes from the material in front of where it landed.
+    rig.locate(300);
+    rig.advance(2);
+
+    const auto opens = 2.0 * (blockTime(302) - blockTime(100)) * kSampleRate;
+
+    // Aligned, not a pre-roll late. What was primed with was the material
+    // before this position, not the material at it.
+    REQUIRE(rig.at(0) == approx(opens, 0.05));
+}
+
+TEST_CASE("A stretched clip keeps its pitch and a resampled one does not",
+          "[engine][clip][stretch]") {
+    constexpr double kTone = 1000.0;
+
+    // A tone at 1 kHz through a 512 sample block: about twelve cycles, so about
+    // twenty four zero crossings, and twice that if the pitch went up an octave.
+    const auto crossingsAtUnity = 2 * static_cast<int>(kTone * kBlockSize / kSampleRate);
+
+    SECTION("stretched") {
+        Rig rig;
+        rig.lane.audio.push_back(clipOver(1, blocks(100, 400), 0));
+
+        auto& event = rig.event(1);
+        event.timeStretchMode = mode::kSignalsmith;
+        event.speedRatio = 2.0;
+
+        rig.give(1, 1, std::make_unique<SineReader>(kTone));
+        rig.publish();
+        rig.rollTo(140);
+
+        // Twice the material in the same time, and the same note.
+        REQUIRE(rig.rms() > 0.3);
+        REQUIRE(rig.zeroCrossings() ==
+                Catch::Approx(crossingsAtUnity).margin(crossingsAtUnity / 4));
+    }
+
+    SECTION("resampled") {
+        Rig rig;
+        rig.lane.audio.push_back(clipOver(1, blocks(100, 400), 0));
+
+        auto& event = rig.event(1);
+        event.analogPitch = true;
+        event.speedRatio = 2.0;
+
+        rig.give(1, 1, std::make_unique<SineReader>(kTone));
+        rig.publish();
+        rig.rollTo(140);
+
+        // Twice the material in the same time, an octave up: tape, not a
+        // stretcher.
+        REQUIRE(rig.rms() > 0.3);
+        REQUIRE(rig.zeroCrossings() ==
+                Catch::Approx(2 * crossingsAtUnity).margin(crossingsAtUnity / 4));
+    }
+}
+
+TEST_CASE("Both SoundTouch modes play, because projects were saved naming them",
+          "[engine][clip][stretch]") {
+    for (const auto which : {mode::kSoundTouchNormal, mode::kSoundTouchBetter}) {
+        Rig rig;
+        rig.lane.audio.push_back(clipOver(1, blocks(100, 400), 0));
+
+        auto& event = rig.event(1);
+        event.timeStretchMode = which;
+        event.speedRatio = 2.0;
+
+        rig.give(1, 1, std::make_unique<SineReader>(1000.0));
+        rig.publish();
+        rig.rollTo(140);
+
+        // A full block of material rather than the silence a pipe that had not
+        // caught up would give.
+        INFO("mode " << which);
+        REQUIRE(rig.rms() > 0.2);
+    }
+}
+
+TEST_CASE("Auto tempo plays through a stretcher without being told a ratio",
+          "[engine][clip][stretch]") {
+    Rig rig;
+    rig.lane.audio.push_back(clipOver(1, blocks(100, 400), 0));
+
+    auto& event = rig.event(1);
+    event.autoTempo = true;
+    event.interpBpm = kBpm / 2.0;  // half the timeline's, so twice as fast
+    event.timeStretchMode = mode::kSignalsmith;
+
+    rig.give(1, 1, std::make_unique<SineReader>(1000.0));
+    rig.publish();
+    rig.rollTo(140);
+
+    REQUIRE(rig.rms() > 0.3);
+}
+
+TEST_CASE("A speed ramp changes the speed rather than the gain", "[engine][clip][stretch]") {
+    Rig rig;
+    rig.lane.audio.push_back(clipOver(1, blocks(100, 400), 0));
+
+    auto& clip = rig.lane.audio.front();
+    clip.fadeInSeconds = blockTime(110) - blockTime(100);
+    clip.fadeInBeats = clip.fadeInSeconds * kBeatsPerSecond;
+    clip.fadeInBehaviour = 1;
+
+    rig.give(1, 1, std::make_unique<ConstantReader>());
+    rig.publish();
+    rig.rollTo(102);
+
+    // Two blocks into a ten block ramp. A gain fade would be a fifth of the way
+    // up and audibly quiet; a speed ramp leaves the level alone and moves the
+    // material instead.
+    REQUIRE(rig.at(0) == approx(1.0, 1e-3));
+    REQUIRE(rig.at(kBlockSize - 1) == approx(1.0, 1e-3));
+}
+
+TEST_CASE("A speed ramp reads the file at a rate that climbs to unity", "[engine][clip][stretch]") {
+    Rig rig;
+    rig.lane.audio.push_back(clipOver(1, blocks(100, 400), 0));
+
+    auto& clip = rig.lane.audio.front();
+    clip.fadeInSeconds = blockTime(110) - blockTime(100);
+    clip.fadeInBeats = clip.fadeInSeconds * kBeatsPerSecond;
+    clip.fadeInBehaviour = 1;
+
+    rig.give(1, 1, std::make_unique<CountingReader>());
+    rig.publish();
+    rig.rollTo(101);
+
+    // Inside the ramp the material is ahead of where an unramped clip would be,
+    // and moving slower than one sample per sample.
+    const auto opens = rig.at(0);
+    const auto step = rig.at(kBlockSize - 1) - rig.at(0);
+
+    REQUIRE(opens > (blockTime(101) - blockTime(100)) * kSampleRate);
+    REQUIRE(step < kBlockSize - 1);
+
+    // By the far end of the ramp it is running at the file's own speed again,
+    // and where the clip says it should be.
+    rig.advance(10);
+    REQUIRE(rig.at(kBlockSize - 1) - rig.at(0) == approx(kBlockSize - 1, 0.5));
+    REQUIRE(rig.at(0) == approx((blockTime(111) - blockTime(100)) * kSampleRate, 2.0));
+}

--- a/tests/test_clip_stretch.cpp
+++ b/tests/test_clip_stretch.cpp
@@ -974,10 +974,14 @@ TEST_CASE("SoundTouch runs the whole rate range without growing a buffer under a
     // rates from a sixth to the ceiling, a pitch shift so the rate transposer is
     // in the chain too, auto tempo so the rate moves block to block, and locates
     // in both directions so priming runs again over material the reader has to
-    // seek for. Verified against a counter on the vendored ensureCapacity, which
-    // stays at zero throughout and is what caught the first version of the
-    // warm-up, where a clip playing at nine could still allocate after a warm-up
-    // that ran at ten.
+    // seek for.
+    //
+    // Verified against a counter on the vendored ensureCapacity, over eighty two
+    // rate and mode combinations rather than the seven kept here, where it stays
+    // at zero throughout. That counter is what caught the two versions of this
+    // that did not work: one where a clip playing at nine allocated after a
+    // warm-up that had run at ten, and one where the buffers behind the front of
+    // the pipe grew at a tempo the warm-up had stepped over.
     for (const auto which : {mode::kSoundTouchNormal, mode::kSoundTouchBetter}) {
         for (const auto ratio : {0.15, 0.5, 1.7, 2.0, 4.3, 9.0, 9.97}) {
             Rig rig;

--- a/tests/test_clip_voice_pool.cpp
+++ b/tests/test_clip_voice_pool.cpp
@@ -7,6 +7,7 @@
 
 #include "clip/ClipAudioSource.hpp"
 #include "clip/ClipVoicePool.hpp"
+#include "core/TimeStretchModes.hpp"
 
 /**
  * Which clips have a reader standing by, and where it is pointed (#2035).
@@ -724,4 +725,118 @@ TEST_CASE("A pool with nothing published provisions nothing", "[engine][clip][po
 
     for (auto sample = 0; sample < kBlockSize; ++sample)
         REQUIRE(output.getSample(0, sample) == Catch::Approx(0.0f).margin(1e-4));
+}
+
+TEST_CASE("A stretched clip is provisioned with a stretcher of its own",
+          "[engine][clip][pool][stretch]") {
+    // Made here rather than in a voice, because building one allocates and
+    // configuring one needs the event: this thread may do both and the callback
+    // may do neither (clip/ClipStretcher.hpp).
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    auto stretched = clipAt(1, 0.0, 4.0);
+    stretched.events.front().timeStretchMode = magda::time_stretch_mode::kSignalsmith;
+    stretched.events.front().speedRatio = 2.0;
+
+    pool.setSnapshot(snapshotOf({stretched}));
+    pool.setPosition(0.0);
+    pool.service();
+
+    const magda::engine::ClipStreamFeed::Reader published(pool.feed());
+    REQUIRE(published);
+    REQUIRE(published->entries.size() == 1);
+
+    const auto& entry = published->entries.front();
+    REQUIRE(entry.stretcher != nullptr);
+
+    // And cued behind the clip, by exactly what that stretcher asked for, so
+    // the voice's first read is one contiguous read that begins with the
+    // material priming needs.
+    CHECK(entry.preRollSamples > 0);
+}
+
+TEST_CASE("A clip at its file's own speed is provisioned without one",
+          "[engine][clip][pool][stretch]") {
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    pool.setSnapshot(snapshotOf({clipAt(1, 0.0, 4.0)}));
+    pool.setPosition(0.0);
+    pool.service();
+
+    const magda::engine::ClipStreamFeed::Reader published(pool.feed());
+    REQUIRE(published);
+    REQUIRE(published->entries.size() == 1);
+
+    CHECK(published->entries.front().stretcher == nullptr);
+    CHECK(published->entries.front().preRollSamples == 0);
+}
+
+TEST_CASE("A pitch change replaces the stretcher and keeps the file open",
+          "[engine][clip][pool][stretch]") {
+    // A stretcher is state and a warm-up, both of which a pitch change
+    // invalidates. The file is neither, and reopening it would cost a seek for
+    // an edit that did not move anything.
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    auto stretched = clipAt(1, 0.0, 4.0);
+    stretched.events.front().timeStretchMode = magda::time_stretch_mode::kSignalsmith;
+    stretched.events.front().speedRatio = 2.0;
+
+    pool.setSnapshot(snapshotOf({stretched}));
+    pool.setPosition(0.0);
+    pool.service();
+
+    std::shared_ptr<magda::engine::PrefetchStream> stream;
+    std::shared_ptr<magda::engine::ClipStretcher> stretcher;
+    {
+        const magda::engine::ClipStreamFeed::Reader published(pool.feed());
+        REQUIRE(published);
+        REQUIRE(published->entries.size() == 1);
+        stream = published->entries.front().stream;
+        stretcher = published->entries.front().stretcher;
+    }
+
+    stretched.events.front().pitchChange = 5.0f;
+    pool.setSnapshot(snapshotOf({stretched}));
+    pool.service();
+
+    const magda::engine::ClipStreamFeed::Reader published(pool.feed());
+    REQUIRE(published);
+    REQUIRE(published->entries.size() == 1);
+
+    CHECK(published->entries.front().stream == stream);
+    CHECK(published->entries.front().stretcher != stretcher);
+}
+
+TEST_CASE("A round over a stretched clip that is playing does not swap a table",
+          "[engine][clip][pool][stretch]") {
+    // The cue a stretched reader carries is worked out from where the clip
+    // begins rather than from where the transport is, so a clip the cursor is
+    // moving through goes on looking like the same reader round after round.
+    TestFiles files;
+    PrefetchThread reader;
+    ClipVoicePool pool(files, reader, context());
+
+    auto stretched = clipAt(1, 0.0, 4.0);
+    stretched.events.front().timeStretchMode = magda::time_stretch_mode::kSignalsmith;
+    stretched.events.front().speedRatio = 2.0;
+
+    pool.setSnapshot(snapshotOf({stretched}));
+    pool.setPosition(0.0);
+    pool.service();
+
+    REQUIRE(pool.tablesPublished() == 1);
+
+    pool.setPosition(0.5);
+    pool.service();
+    pool.setPosition(1.0);
+    pool.service();
+
+    CHECK(pool.tablesPublished() == 1);
 }

--- a/third_party/signalsmith-stretch/LICENSE.signalsmith-linear.txt
+++ b/third_party/signalsmith-stretch/LICENSE.signalsmith-linear.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Signalsmith Audio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/signalsmith-stretch/LICENSE.signalsmith-stretch.txt
+++ b/third_party/signalsmith-stretch/LICENSE.signalsmith-stretch.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Geraint Luff / Signalsmith Audio Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/signalsmith-stretch/SOURCES.md
+++ b/third_party/signalsmith-stretch/SOURCES.md
@@ -1,0 +1,17 @@
+# Signalsmith Stretch
+
+- Signalsmith Stretch 1.3.2, commit `57b93f4e9206a089a45387eaa39bdc9f310d3308`
+  from https://github.com/Signalsmith-Audio/signalsmith-stretch
+- Signalsmith Linear 0.3.1 from https://github.com/Signalsmith-Audio/linear
+
+Both are header-only and MIT licensed; the licence texts sit beside the sources.
+Unmodified.
+
+The native engine (#1882) uses this as its default stretch engine, the one the pinned
+mode value `kSignalsmith` in `magda/daw/core/TimeStretchModes.hpp` names. It is vendored
+here rather than reached for inside the Tracktion fork because the engine may not include
+Tracktion, and that boundary is checked at configure time.
+
+The fork carries its own copy under
+`third_party/tracktion_engine/modules/tracktion_engine/3rd_party/signalsmith`. The two
+are the same version and the duplicate goes away with the fork.

--- a/third_party/signalsmith-stretch/signalsmith-linear/fft.h
+++ b/third_party/signalsmith-stretch/signalsmith-linear/fft.h
@@ -1,0 +1,1380 @@
+#ifndef SIGNALSMITH_AUDIO_LINEAR_FFT_H
+#define SIGNALSMITH_AUDIO_LINEAR_FFT_H
+
+#include <complex>
+#include <vector>
+#include <cmath>
+
+#if defined(__FAST_MATH__) && (__apple_build_version__ >= 16000000) && (__apple_build_version__ <= 16000099) && !defined(SIGNALSMITH_IGNORE_BROKEN_APPLECLANG)
+#	error Apple Clang 16.0.0 generates incorrect SIMD for ARM. If you HAVE to use this version of Clang, turn off -ffast-math.
+#endif
+
+#ifndef M_PI
+#	define M_PI 3.14159265358979323846
+#endif
+
+namespace signalsmith { namespace linear {
+
+namespace _impl {
+	// Helpers for complex arithmetic, ignoring the NaN/Inf edge-cases you get without `-ffast-math`
+	template<class V>
+	void complexMul(std::complex<V> *a, const std::complex<V> *b, const std::complex<V> *c, size_t size) {
+		for (size_t i = 0; i < size; ++i) {
+			auto bi = b[i], ci = c[i];
+			a[i] = {bi.real()*ci.real() - bi.imag()*ci.imag(), bi.imag()*ci.real() + bi.real()*ci.imag()};
+		}
+	}
+	template<class V>
+	void complexMulConj(std::complex<V> *a, const std::complex<V> *b, const std::complex<V> *c, size_t size) {
+		for (size_t i = 0; i < size; ++i) {
+			auto bi = b[i], ci = c[i];
+			a[i] = {bi.real()*ci.real() + bi.imag()*ci.imag(), bi.imag()*ci.real() - bi.real()*ci.imag()};
+		}
+	}
+	template<class V>
+	void complexMul(V *ar, V *ai, const V *br, const V *bi, const V *cr, const V *ci, size_t size) {
+		for (size_t i = 0; i < size; ++i) {
+			V rr = br[i]*cr[i] - bi[i]*ci[i];
+			V ri = br[i]*ci[i] + bi[i]*cr[i];
+			ar[i] = rr;
+			ai[i] = ri;
+		}
+	}
+	template<class V>
+	void complexMulConj(V *ar, V *ai, const V *br, const V *bi, const V *cr, const V *ci, size_t size) {
+		for (size_t i = 0; i < size; ++i) {
+			V rr = cr[i]*br[i] + ci[i]*bi[i];
+			V ri = cr[i]*bi[i] - ci[i]*br[i];
+			ar[i] = rr;
+			ai[i] = ri;
+		}
+	}
+
+	// Input: aStride elements next to each other -> output with bStride
+	template<size_t aStride, class V>
+	void interleaveCopy(const V *a, V *b, size_t bStride) {
+		for (size_t bi = 0; bi < bStride; ++bi) {
+			const V *offsetA = a + bi*aStride;
+			V *offsetB = b + bi;
+			for (size_t ai = 0; ai < aStride; ++ai) {
+				offsetB[ai*bStride] = offsetA[ai];
+			}
+		}
+	}
+	template<class V>
+	void interleaveCopy(const V *a, V *b, size_t aStride, size_t bStride) {
+		for (size_t bi = 0; bi < bStride; ++bi) {
+			const V *offsetA = a + bi*aStride;
+			V *offsetB = b + bi;
+			for (size_t ai = 0; ai < aStride; ++ai) {
+				offsetB[ai*bStride] = offsetA[ai];
+			}
+		}
+	}
+	template<size_t aStride, class V>
+	void interleaveCopy(const V *aReal, const V *aImag, V *bReal, V *bImag, size_t bStride) {
+		for (size_t bi = 0; bi < bStride; ++bi) {
+			const V *offsetAr = aReal + bi*aStride;
+			const V *offsetAi = aImag + bi*aStride;
+			V *offsetBr = bReal + bi;
+			V *offsetBi = bImag + bi;
+			for (size_t ai = 0; ai < aStride; ++ai) {
+				offsetBr[ai*bStride] = offsetAr[ai];
+				offsetBi[ai*bStride] = offsetAi[ai];
+			}
+		}
+	}
+	template<class V>
+	void interleaveCopy(const V *aReal, const V *aImag, V *bReal, V *bImag, size_t aStride, size_t bStride) {
+		for (size_t bi = 0; bi < bStride; ++bi) {
+			const V *offsetAr = aReal + bi*aStride;
+			const V *offsetAi = aImag + bi*aStride;
+			V *offsetBr = bReal + bi;
+			V *offsetBi = bImag + bi;
+			for (size_t ai = 0; ai < aStride; ++ai) {
+				offsetBr[ai*bStride] = offsetAr[ai];
+				offsetBi[ai*bStride] = offsetAi[ai];
+			}
+		}
+	}
+}
+
+/// Fairly simple and very portable power-of-2 FFT
+template<typename Sample>
+struct SimpleFFT {
+	using Complex = std::complex<Sample>;
+	
+	SimpleFFT(size_t size=0) {
+		resize(size);
+	}
+	
+	void resize(size_t size) {
+		twiddles.resize(size*3/4);
+		for (size_t i = 0; i < size*3/4; ++i) {
+			Sample twiddlePhase = -2*M_PI*i/size;
+			twiddles[i] = std::polar(Sample(1), twiddlePhase);
+		}
+		working.resize(size);
+	}
+	
+	void fft(const Complex *time, Complex *freq) {
+		size_t size = working.size();
+		if (size <= 1) {
+			*freq = *time;
+			return;
+		}
+		fftPass<false>(size, 1, time, freq, working.data());
+	}
+
+	void ifft(const Complex *freq, Complex *time) {
+		size_t size = working.size();
+		if (size <= 1) {
+			*time = *freq;
+			return;
+		}
+		fftPass<true>(size, 1, freq, time, working.data());
+	}
+
+	void fft(const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		size_t size = working.size();
+		if (size <= 1) {
+			*outR = *inR;
+			*outI = *inI;
+			return;
+		}
+		Sample *workingR = (Sample *)working.data(), *workingI = workingR + size;
+		fftPass<false>(size, 1, inR, inI, outR, outI, workingR, workingI);
+	}
+	void ifft(const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		size_t size = working.size();
+		if (size <= 1) {
+			*outR = *inR;
+			*outI = *inI;
+			return;
+		}
+		Sample *workingR = (Sample *)working.data(), *workingI = workingR + size;
+		fftPass<true>(size, 1, inR, inI, outR, outI, workingR, workingI);
+	}
+private:
+	std::vector<Complex> twiddles;
+	std::vector<Complex> working;
+	
+	template<bool conjB>
+	static Complex mul(const Complex &a, const Complex &b) {
+		return conjB ? Complex{
+			a.real()*b.real() + a.imag()*b.imag(),
+			a.imag()*b.real() - a.real()*b.imag()
+		} : Complex{
+			a.real()*b.real() - a.imag()*b.imag(),
+			a.imag()*b.real() + a.real()*b.imag()
+		};
+	}
+
+	// Calculate a [size]-point FFT, where each element is a block of [stride] values
+	template<bool inverse>
+	void fftPass(size_t size, size_t stride, const Complex *input, Complex *output, Complex *working) {
+		if (size/4 > 1) {
+			// Calculate four quarter-size FFTs
+			fftPass<inverse>(size/4, stride*4, input, working, output);
+			combine4<inverse>(size, stride, working, output);
+		} else if (size == 4) {
+			combine4<inverse>(4, stride, input, output);
+		} else {
+			// 2-point FFT
+			for (size_t s = 0; s < stride; ++s) {
+				Complex a = input[s];
+				Complex b = input[s + stride];
+				output[s] = a + b;
+				output[s + stride] = a - b;
+			}
+		}
+	}
+
+	// Combine interleaved results into a single spectrum
+	template<bool inverse>
+	void combine4(size_t size, size_t stride, const Complex *input, Complex *output) const {
+		auto twiddleStep = working.size()/size;
+		for (size_t i = 0; i < size/4; ++i) {
+			Complex twiddleB = twiddles[i*twiddleStep];
+			Complex twiddleC = twiddles[i*2*twiddleStep];
+			Complex twiddleD = twiddles[i*3*twiddleStep];
+			
+			const Complex *inputA = input + 4*i*stride;
+			const Complex *inputB = input + (4*i + 1)*stride;
+			const Complex *inputC = input + (4*i + 2)*stride;
+			const Complex *inputD = input + (4*i + 3)*stride;
+			Complex *outputA = output + i*stride;
+			Complex *outputB = output + (i + size/4)*stride;
+			Complex *outputC = output + (i + size/4*2)*stride;
+			Complex *outputD = output + (i + size/4*3)*stride;
+			for (size_t s = 0; s < stride; ++s) {
+				Complex a = inputA[s];
+				Complex b = mul<inverse>(inputB[s], twiddleB);
+				Complex c = mul<inverse>(inputC[s], twiddleC);
+				Complex d = mul<inverse>(inputD[s], twiddleD);
+				Complex ac0 = a + c, ac1 = a - c;
+				Complex bd0 = b + d, bd1 = inverse ? (b - d) : (d - b);
+				Complex bd1i = {-bd1.imag(), bd1.real()};
+				outputA[s] = ac0 + bd0;
+				outputB[s] = ac1 + bd1i;
+				outputC[s] = ac0 - bd0;
+				outputD[s] = ac1 - bd1i;
+			}
+		}
+	}
+
+	// The same thing, but translated for split-complex input/output
+	template<bool inverse>
+	void fftPass(size_t size, size_t stride, const Sample *inputR, const Sample *inputI, Sample *outputR, Sample *outputI, Sample *workingR, Sample *workingI) const {
+		if (size/4 > 1) {
+			// Calculate four quarter-size FFTs
+			fftPass<inverse>(size/4, stride*4, inputR, inputI, workingR, workingI, outputR, outputI);
+			combine4<inverse>(size, stride, workingR, workingI, outputR, outputI);
+		} else if (size == 4) {
+			combine4<inverse>(4, stride, inputR, inputI, outputR, outputI);
+		} else {
+			// 2-point FFT
+			for (size_t s = 0; s < stride; ++s) {
+				Sample ar = inputR[s], ai = inputI[s];
+				Sample br = inputR[s + stride], bi = inputI[s + stride];
+				outputR[s] = ar + br;
+				outputI[s] = ai + bi;
+				outputR[s + stride] = ar - br;
+				outputI[s + stride] = ai - bi;
+			}
+		}
+	}
+
+	// Combine interleaved results into a single spectrum
+	template<bool inverse>
+	void combine4(size_t size, size_t stride, const Sample *inputR, const Sample *inputI, Sample *outputR, Sample *outputI) const {
+		auto twiddleStep = working.size()/size;
+		for (size_t i = 0; i < size/4; ++i) {
+			Complex twiddleB = twiddles[i*twiddleStep];
+			Complex twiddleC = twiddles[i*2*twiddleStep];
+			Complex twiddleD = twiddles[i*3*twiddleStep];
+			
+			const Sample *inputAr = inputR + 4*i*stride, *inputAi = inputI + 4*i*stride;
+			const Sample *inputBr = inputR + (4*i + 1)*stride, *inputBi = inputI + (4*i + 1)*stride;
+			const Sample *inputCr = inputR + (4*i + 2)*stride, *inputCi = inputI + (4*i + 2)*stride;
+			const Sample *inputDr = inputR + (4*i + 3)*stride, *inputDi = inputI + (4*i + 3)*stride;
+			Sample *outputAr = outputR + i*stride, *outputAi = outputI + i*stride;
+			Sample *outputBr = outputR + (i + size/4)*stride, *outputBi = outputI + (i + size/4)*stride;
+			Sample *outputCr = outputR + (i + size/4*2)*stride, *outputCi = outputI + (i + size/4*2)*stride;
+			Sample *outputDr = outputR + (i + size/4*3)*stride, *outputDi = outputI + (i + size/4*3)*stride;
+			for (size_t s = 0; s < stride; ++s) {
+				Complex a = {inputAr[s], inputAi[s]};
+				Complex b = mul<inverse>({inputBr[s], inputBi[s]}, twiddleB);
+				Complex c = mul<inverse>({inputCr[s], inputCi[s]}, twiddleC);
+				Complex d = mul<inverse>({inputDr[s], inputDi[s]}, twiddleD);
+				Complex ac0 = a + c, ac1 = a - c;
+				Complex bd0 = b + d, bd1 = inverse ? (b - d) : (d - b);
+				Complex bd1i = {-bd1.imag(), bd1.real()};
+				outputAr[s] = ac0.real() + bd0.real();
+				outputAi[s] = ac0.imag() + bd0.imag();
+				outputBr[s] = ac1.real() + bd1i.real();
+				outputBi[s] = ac1.imag() + bd1i.imag();
+				outputCr[s] = ac0.real() - bd0.real();
+				outputCi[s] = ac0.imag() - bd0.imag();
+				outputDr[s] = ac1.real() - bd1i.real();
+				outputDi[s] = ac1.imag() - bd1i.imag();
+			}
+		}
+	}
+};
+
+/// A power-of-2 only FFT, specialised with platform-specific fast implementations where available
+template<typename Sample>
+struct Pow2FFT {
+	static constexpr bool prefersSplit = true; // whether this FFT implementation is faster when given split-complex inputs
+	using Complex = std::complex<Sample>;
+	
+	Pow2FFT(size_t size=0) {
+		resize(size);
+	}
+	// Allow move, but not copy
+	Pow2FFT(const Pow2FFT &other) = delete;
+	Pow2FFT(Pow2FFT &&other) : tmp(std::move(other.tmp)), simpleFFT(std::move(other.simpleFFT)) {}
+	
+	void resize(size_t size) {
+		simpleFFT.resize(size);
+		tmp.resize(size);
+	}
+	
+	void fft(const Complex *time, Complex *freq) {
+		simpleFFT.fft(time, freq);
+	}
+	void fft(const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		simpleFFT.fft(inR, inI, outR, outI);
+	}
+
+	void ifft(const Complex *freq, Complex *time) {
+		simpleFFT.ifft(freq, time);
+	}
+	void ifft(const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		simpleFFT.ifft(inR, inI, outR, outI);
+	}
+
+private:
+	std::vector<Complex> tmp;
+	SimpleFFT<Sample> simpleFFT;
+};
+
+/// An FFT which can handle multiples of 3 and 5, and can be computed in chunks
+template<typename Sample, bool splitComputation=false>
+struct SplitFFT {
+	using Complex = std::complex<Sample>;
+	static constexpr bool prefersSplit = Pow2FFT<Sample>::prefersSplit;
+	
+	static constexpr size_t maxSplit = splitComputation ? 4 : 1;
+	static constexpr size_t minInnerSize = 32;
+	
+	static size_t fastSizeAbove(size_t size) {
+		size_t pow2 = 1;
+		while (pow2 < 16 && pow2 < size) pow2 *= 2;
+		while (pow2*8 < size) pow2 *= 2;
+		size_t multiple = (size + pow2 - 1)/pow2; // will be 1-8
+		if (multiple == 7) ++multiple;
+		return multiple*pow2;
+	}
+	
+	SplitFFT(size_t size=0) {
+		resize(size);
+	}
+	
+	void resize(size_t size) {
+		innerSize = 1;
+		outerSize = size;
+
+		dftTmp.resize(0);
+		dftTwists.resize(0);
+		plan.resize(0);
+		if (!size) return;
+		
+		// Inner size = largest power of 2 such that either the inner size >= minInnerSize, or we have the target number of splits
+		while (!(outerSize&1) && (outerSize > maxSplit || innerSize < minInnerSize)) {
+			innerSize *= 2;
+			outerSize /= 2;
+		}
+		tmpFreq.resize(size);
+		innerFFT.resize(innerSize);
+		
+		outerTwiddles.resize(innerSize*(outerSize - 1));
+		outerTwiddlesR.resize(innerSize*(outerSize - 1));
+		outerTwiddlesI.resize(innerSize*(outerSize - 1));
+		for (size_t i = 0; i < innerSize; ++i) {
+			for (size_t s = 1; s < outerSize; ++s) {
+				Sample twiddlePhase = Sample(-2*M_PI*i/innerSize*s/outerSize);
+				outerTwiddles[i + (s - 1)*innerSize] = std::polar(Sample(1), twiddlePhase);
+			}
+		}
+		for (size_t i = 0; i < outerTwiddles.size(); ++i) {
+			outerTwiddlesR[i] = outerTwiddles[i].real();
+			outerTwiddlesI[i] = outerTwiddles[i].imag();
+		}
+
+		StepType interleaveStep = StepType::interleaveOrderN;
+		StepType finalStep = StepType::finalOrderN;
+		if (outerSize == 2) {
+			interleaveStep = StepType::interleaveOrder2;
+			finalStep = StepType::finalOrder2;
+		}
+		if (outerSize == 3) {
+			interleaveStep = StepType::interleaveOrder3;
+			finalStep = StepType::finalOrder3;
+		}
+		if (outerSize == 4) {
+			interleaveStep = StepType::interleaveOrder4;
+			finalStep = StepType::finalOrder4;
+		}
+		if (outerSize == 5) {
+			interleaveStep = StepType::interleaveOrder5;
+			finalStep = StepType::finalOrder5;
+		}
+		
+		if (outerSize <= 1) {
+			if (size > 0) plan.push_back(Step{StepType::passthrough, 0});
+		} else {
+			plan.push_back({interleaveStep, 0});
+			plan.push_back({StepType::firstFFT, 0});
+			for (size_t s = 1; s < outerSize; ++s) {
+				plan.push_back({StepType::middleFFT, s*innerSize});
+			}
+			plan.push_back({StepType::twiddles, 0});
+			plan.push_back({finalStep, 0});
+
+			if (finalStep == StepType::finalOrderN) {
+				dftTmp.resize(outerSize);
+				dftTwists.resize(outerSize);
+				for (size_t s = 0; s < outerSize; ++s) {
+					Sample dftPhase = Sample(-2*M_PI*s/outerSize);
+					dftTwists[s] = std::polar(Sample(1), dftPhase);
+				}
+			}
+		}
+	}
+	
+	size_t size() const {
+		return innerSize*outerSize;
+	}
+	size_t steps() const {
+		return plan.size();
+	}
+	
+	void fft(const Complex *time, Complex *freq) {
+		for (auto &step : plan) {
+			fftStep<false>(step, time, freq);
+		}
+	}
+	void fft(size_t step, const Complex *time, Complex *freq) {
+		fftStep<false>(plan[step], time, freq);
+	}
+	void fft(const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		for (auto &step : plan) {
+			fftStep<false>(step, inR, inI, outR, outI);
+		}
+	}
+	void fft(size_t step, const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		fftStep<false>(plan[step], inR, inI, outR, outI);
+	}
+	
+	void ifft(const Complex *freq, Complex *time) {
+		for (auto &step : plan) {
+			fftStep<true>(step, freq, time);
+		}
+	}
+	void ifft(size_t step, const Complex *freq, Complex *time) {
+		fftStep<true>(plan[step], freq, time);
+	}
+	void ifft(const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		for (auto &step : plan) {
+			fftStep<true>(step, inR, inI, outR, outI);
+		}
+	}
+	void ifft(size_t step, const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		fftStep<true>(plan[step], inR, inI, outR, outI);
+	}
+private:
+	using InnerFFT = Pow2FFT<Sample>;
+	InnerFFT innerFFT;
+
+	size_t innerSize, outerSize;
+	std::vector<Complex> tmpFreq;
+	std::vector<Complex> outerTwiddles;
+	std::vector<Sample> outerTwiddlesR, outerTwiddlesI;
+	std::vector<Complex> dftTwists, dftTmp;
+
+	enum class StepType {
+		passthrough,
+		interleaveOrder2, interleaveOrder3, interleaveOrder4, interleaveOrder5, interleaveOrderN,
+		firstFFT, middleFFT,
+		twiddles,
+		finalOrder2, finalOrder3, finalOrder4, finalOrder5, finalOrderN
+	};
+	struct Step {
+		StepType type;
+		size_t offset;
+	};
+	std::vector<Step> plan;
+	
+	template<bool inverse>
+	void fftStep(Step step, const Complex *time, Complex *freq) {
+		switch (step.type) {
+			case (StepType::passthrough): {
+				if (inverse) {
+					innerFFT.ifft(time, freq);
+				} else {
+					innerFFT.fft(time, freq);
+				}
+				break;
+			}
+			case (StepType::interleaveOrder2): {
+				_impl::interleaveCopy<2>(time, tmpFreq.data(), innerSize);
+				break;
+			}
+			case (StepType::interleaveOrder3): {
+				_impl::interleaveCopy<3>(time, tmpFreq.data(), innerSize);
+				break;
+			}
+			case (StepType::interleaveOrder4): {
+				_impl::interleaveCopy<4>(time, tmpFreq.data(), innerSize);
+				break;
+			}
+			case (StepType::interleaveOrder5): {
+				_impl::interleaveCopy<5>(time, tmpFreq.data(), innerSize);
+				break;
+			}
+			case (StepType::interleaveOrderN): {
+				_impl::interleaveCopy(time, tmpFreq.data(), outerSize, innerSize);
+				break;
+			}
+			case (StepType::firstFFT): {
+				if (inverse) {
+					innerFFT.ifft(tmpFreq.data(), freq);
+				} else {
+					innerFFT.fft(tmpFreq.data(), freq);
+				}
+				break;
+			}
+			case (StepType::middleFFT): {
+				Complex *offsetOut = freq + step.offset;
+				if (inverse) {
+					innerFFT.ifft(tmpFreq.data() + step.offset, offsetOut);
+				} else {
+					innerFFT.fft(tmpFreq.data() + step.offset, offsetOut);
+				}
+				break;
+			}
+			case (StepType::twiddles): {
+				if (inverse) {
+					_impl::complexMulConj(freq + innerSize, freq + innerSize, outerTwiddles.data(), innerSize*(outerSize - 1));
+				} else {
+					_impl::complexMul(freq + innerSize, freq + innerSize, outerTwiddles.data(), innerSize*(outerSize - 1));
+				}
+				break;
+			}
+			case StepType::finalOrder2:
+				finalPass2(freq);
+				break;
+			case StepType::finalOrder3:
+				finalPass3<inverse>(freq);
+				break;
+			case StepType::finalOrder4:
+				finalPass4<inverse>(freq);
+				break;
+			case StepType::finalOrder5:
+				finalPass5<inverse>(freq);
+				break;
+			case StepType::finalOrderN:
+				finalPassN<inverse>(freq);
+				break;
+		}
+	}
+	template<bool inverse>
+	void fftStep(Step step, const Sample *inR, const Sample *inI, Sample *outR, Sample *outI) {
+		Sample *tmpR = (Sample *)tmpFreq.data(), *tmpI = tmpR + tmpFreq.size();
+		switch (step.type) {
+			case (StepType::passthrough): {
+				if (inverse) {
+					innerFFT.ifft(inR, inI, outR, outI);
+				} else {
+					innerFFT.fft(inR, inI, outR, outI);
+				}
+				break;
+			}
+			case (StepType::interleaveOrder2): {
+				_impl::interleaveCopy<2>(inR, tmpR, innerSize);
+				_impl::interleaveCopy<2>(inI, tmpI, innerSize);
+				break;
+			}
+			case (StepType::interleaveOrder3): {
+				_impl::interleaveCopy<3>(inR, tmpR, innerSize);
+				_impl::interleaveCopy<3>(inI, tmpI, innerSize);
+				break;
+			}
+			case (StepType::interleaveOrder4): {
+				_impl::interleaveCopy<4>(inR, tmpR, innerSize);
+				_impl::interleaveCopy<4>(inI, tmpI, innerSize);
+				break;
+			}
+			case (StepType::interleaveOrder5): {
+				_impl::interleaveCopy<5>(inR, tmpR, innerSize);
+				_impl::interleaveCopy<5>(inI, tmpI, innerSize);
+				break;
+			}
+			case (StepType::interleaveOrderN): {
+				_impl::interleaveCopy(inR, inI, tmpR, tmpI, outerSize, innerSize);
+				break;
+			}
+			case (StepType::firstFFT): {
+				if (inverse) {
+					innerFFT.ifft(tmpR, tmpI, outR, outI);
+				} else {
+					innerFFT.fft(tmpR, tmpI, outR, outI);
+				}
+				break;
+			}
+			case (StepType::middleFFT): {
+				size_t offset = step.offset;
+				Sample *offsetOutR = outR + offset;
+				Sample *offsetOutI = outI + offset;
+				if (inverse) {
+					innerFFT.ifft(tmpR + offset, tmpI + offset, offsetOutR, offsetOutI);
+				} else {
+					innerFFT.fft(tmpR + offset, tmpI + offset, offsetOutR, offsetOutI);
+				}
+				break;
+			}
+			case(StepType::twiddles): {
+				auto *twiddlesR = outerTwiddlesR.data();
+				auto *twiddlesI = outerTwiddlesI.data();
+				if (inverse) {
+					_impl::complexMulConj(outR + innerSize, outI + innerSize, outR + innerSize, outI + innerSize, twiddlesR, twiddlesI, innerSize*(outerSize - 1));
+				} else {
+					_impl::complexMul(outR + innerSize, outI + innerSize, outR + innerSize, outI + innerSize, twiddlesR, twiddlesI, innerSize*(outerSize - 1));
+				}
+				break;
+			}
+			case StepType::finalOrder2:
+				finalPass2(outR, outI);
+				break;
+			case StepType::finalOrder3:
+				finalPass3<inverse>(outR, outI);
+				break;
+			case StepType::finalOrder4:
+				finalPass4<inverse>(outR, outI);
+				break;
+			case StepType::finalOrder5:
+				finalPass5<inverse>(outR, outI);
+				break;
+			case StepType::finalOrderN:
+				finalPassN<inverse>(outR, outI);
+				break;
+		}
+	}
+	
+	void finalPass2(Complex *f0) {
+		auto *f1 = f0 + innerSize;
+		for (size_t i = 0; i < innerSize; ++i) {
+			Complex a = f0[i], b = f1[i];
+			f0[i] = a + b;
+			f1[i] = a - b;
+		}
+	}
+	void finalPass2(Sample *f0r, Sample *f0i) {
+		auto *f1r = f0r + innerSize;
+		auto *f1i = f0i + innerSize;
+		for (size_t i = 0; i < innerSize; ++i) {
+			Sample ar = f0r[i], ai = f0i[i];
+			Sample br = f1r[i], bi = f1i[i];
+			f0r[i] = ar + br;
+			f0i[i] = ai + bi;
+			f1r[i] = ar - br;
+			f1i[i] = ai - bi;
+		}
+	}
+	template<bool inverse>
+	void finalPass3(Complex *f0) {
+		auto *f1 = f0 + innerSize;
+		auto *f2 = f0 + innerSize*2;
+		const Complex tw1{Sample(-0.5), Sample(-std::sqrt(0.75)*(inverse ? -1 : 1))};
+		for (size_t i = 0; i < innerSize; ++i) {
+			Complex a = f0[i], b = f1[i], c = f2[i];
+			Complex bc0 = b + c, bc1 = b - c;
+			f0[i] = a + bc0;
+			f1[i] = {
+				a.real() + bc0.real()*tw1.real() - bc1.imag()*tw1.imag(),
+				a.imag() + bc0.imag()*tw1.real() + bc1.real()*tw1.imag()
+			};
+			f2[i] = {
+				a.real() + bc0.real()*tw1.real() + bc1.imag()*tw1.imag(),
+				a.imag() + bc0.imag()*tw1.real() - bc1.real()*tw1.imag()
+			};
+		}
+	}
+	template<bool inverse>
+	void finalPass3(Sample *f0r, Sample *f0i) {
+		auto *f1r = f0r + innerSize;
+		auto *f1i = f0i + innerSize;
+		auto *f2r = f0r + innerSize*2;
+		auto *f2i = f0i + innerSize*2;
+		const Sample tw1r = -0.5, tw1i = -std::sqrt(0.75)*(inverse ? -1 : 1);
+		
+		for (size_t i = 0; i < innerSize; ++i) {
+			Sample ar = f0r[i], ai = f0i[i], br = f1r[i], bi = f1i[i], cr = f2r[i], ci = f2i[i];
+
+			f0r[i] = ar + br + cr;
+			f0i[i] = ai + bi + ci;
+			f1r[i] = ar + br*tw1r - bi*tw1i + cr*tw1r + ci*tw1i;
+			f1i[i] = ai + bi*tw1r + br*tw1i - cr*tw1i + ci*tw1r;
+			f2r[i] = ar + br*tw1r + bi*tw1i + cr*tw1r - ci*tw1i;
+			f2i[i] = ai + bi*tw1r - br*tw1i + cr*tw1i + ci*tw1r;
+		}
+	}
+	template<bool inverse>
+	void finalPass4(Complex *f0) {
+		auto *f1 = f0 + innerSize;
+		auto *f2 = f0 + innerSize*2;
+		auto *f3 = f0 + innerSize*3;
+		for (size_t i = 0; i < innerSize; ++i) {
+			Complex a = f0[i], b = f1[i], c = f2[i], d = f3[i];
+			
+			Complex ac0 = a + c, ac1 = a - c;
+			Complex bd0 = b + d, bd1 = inverse ? (b - d) : (d - b);
+			Complex bd1i = {-bd1.imag(), bd1.real()};
+			f0[i] = ac0 + bd0;
+			f1[i] = ac1 + bd1i;
+			f2[i] = ac0 - bd0;
+			f3[i] = ac1 - bd1i;
+		}
+	}
+	template<bool inverse>
+	void finalPass4(Sample *f0r, Sample *f0i) {
+		auto *f1r = f0r + innerSize;
+		auto *f1i = f0i + innerSize;
+		auto *f2r = f0r + innerSize*2;
+		auto *f2i = f0i + innerSize*2;
+		auto *f3r = f0r + innerSize*3;
+		auto *f3i = f0i + innerSize*3;
+		for (size_t i = 0; i < innerSize; ++i) {
+			Sample ar = f0r[i], ai = f0i[i], br = f1r[i], bi = f1i[i], cr = f2r[i], ci = f2i[i], dr = f3r[i], di = f3i[i];
+			
+			Sample ac0r = ar + cr, ac0i = ai + ci;
+			Sample ac1r = ar - cr, ac1i = ai - ci;
+			Sample bd0r = br + dr, bd0i = bi + di;
+			Sample bd1r = br - dr, bd1i = bi - di;
+			
+			f0r[i] = ac0r + bd0r;
+			f0i[i] = ac0i + bd0i;
+			f1r[i] = inverse ? (ac1r - bd1i) : (ac1r + bd1i);
+			f1i[i] = inverse ? (ac1i + bd1r) : (ac1i - bd1r);
+			f2r[i] = ac0r - bd0r;
+			f2i[i] = ac0i - bd0i;
+			f3r[i] = inverse ? (ac1r + bd1i) : (ac1r - bd1i);
+			f3i[i] = inverse ? (ac1i - bd1r) : (ac1i + bd1r);
+		}
+	}
+	template<bool inverse>
+	void finalPass5(Complex *f0) {
+		auto *f1 = f0 + innerSize;
+		auto *f2 = f0 + innerSize*2;
+		auto *f3 = f0 + innerSize*3;
+		auto *f4 = f0 + innerSize*4;
+		const Sample tw1r = 0.30901699437494745;
+		const Sample tw1i = -0.9510565162951535*(inverse ? -1 : 1);
+		const Sample tw2r = -0.8090169943749473;
+		const Sample tw2i = -0.5877852522924732*(inverse ? -1 : 1);
+		for (size_t i = 0; i < innerSize; ++i) {
+			Complex a = f0[i], b = f1[i], c = f2[i], d = f3[i], e = f4[i];
+
+			Complex be0 = b + e, be1 = {e.imag() - b.imag(), b.real() - e.real()}; // (b - e)*i
+			Complex cd0 = c + d, cd1 = {d.imag() - c.imag(), c.real() - d.real()};
+			
+			Complex bcde01 = be0*tw1r + cd0*tw2r;
+			Complex bcde02 = be0*tw2r + cd0*tw1r;
+			Complex bcde11 = be1*tw1i + cd1*tw2i;
+			Complex bcde12 = be1*tw2i - cd1*tw1i;
+
+			f0[i] = a + be0 + cd0;
+			f1[i] = a + bcde01 + bcde11;
+			f2[i] = a + bcde02 + bcde12;
+			f3[i] = a + bcde02 - bcde12;
+			f4[i] = a + bcde01 - bcde11;
+		}
+	}
+	template<bool inverse>
+	void finalPass5(Sample *f0r, Sample *f0i) {
+		auto *f1r = f0r + innerSize;
+		auto *f1i = f0i + innerSize;
+		auto *f2r = f0r + innerSize*2;
+		auto *f2i = f0i + innerSize*2;
+		auto *f3r = f0r + innerSize*3;
+		auto *f3i = f0i + innerSize*3;
+		auto *f4r = f0r + innerSize*4;
+		auto *f4i = f0i + innerSize*4;
+		
+		const Sample tw1r = 0.30901699437494745;
+		const Sample tw1i = -0.9510565162951535*(inverse ? -1 : 1);
+		const Sample tw2r = -0.8090169943749473;
+		const Sample tw2i = -0.5877852522924732*(inverse ? -1 : 1);
+		for (size_t i = 0; i < innerSize; ++i) {
+			Sample ar = f0r[i], ai = f0i[i], br = f1r[i], bi = f1i[i], cr = f2r[i], ci = f2i[i], dr = f3r[i], di = f3i[i], er = f4r[i], ei = f4i[i];
+
+			Sample be0r = br + er, be0i = bi + ei;
+			Sample be1r = ei - bi, be1i = br - er;
+			Sample cd0r = cr + dr, cd0i = ci + di;
+			Sample cd1r = di - ci, cd1i = cr - dr;
+
+			Sample bcde01r = be0r*tw1r + cd0r*tw2r, bcde01i = be0i*tw1r + cd0i*tw2r;
+			Sample bcde02r = be0r*tw2r + cd0r*tw1r, bcde02i = be0i*tw2r + cd0i*tw1r;
+			Sample bcde11r = be1r*tw1i + cd1r*tw2i, bcde11i = be1i*tw1i + cd1i*tw2i;
+			Sample bcde12r = be1r*tw2i - cd1r*tw1i, bcde12i = be1i*tw2i - cd1i*tw1i;
+
+			f0r[i] = ar + be0r + cd0r;
+			f0i[i] = ai + be0i + cd0i;
+			f1r[i] = ar + bcde01r + bcde11r;
+			f1i[i] = ai + bcde01i + bcde11i;
+			f2r[i] = ar + bcde02r + bcde12r;
+			f2i[i] = ai + bcde02i + bcde12i;
+			f3r[i] = ar + bcde02r - bcde12r;
+			f3i[i] = ai + bcde02i - bcde12i;
+			f4r[i] = ar + bcde01r - bcde11r;
+			f4i[i] = ai + bcde01i - bcde11i;
+		}
+	}
+
+	template<bool inverse>
+	void finalPassN(Complex *f0) {
+		for (size_t i = 0; i < innerSize; ++i) {
+			Complex *offsetFreq = f0 + i;
+			Complex sum = 0;
+			for (size_t i2 = 0; i2 < outerSize; ++i2) {
+				sum += (dftTmp[i2] = offsetFreq[i2*innerSize]);
+			}
+			offsetFreq[0] = sum;
+			
+			for (size_t f = 1; f < outerSize; ++f) {
+				Complex sum = dftTmp[0];
+
+				for (size_t i2 = 1; i2 < outerSize; ++i2) {
+					size_t twistIndex = (i2*f)%outerSize;
+					Complex twist = inverse ? std::conj(dftTwists[twistIndex]) : dftTwists[twistIndex];
+					sum += Complex{
+						dftTmp[i2].real()*twist.real() - dftTmp[i2].imag()*twist.imag(),
+						dftTmp[i2].imag()*twist.real() + dftTmp[i2].real()*twist.imag()
+					};
+				}
+
+				offsetFreq[f*innerSize] = sum;
+			}
+		}
+	}
+	template<bool inverse>
+	void finalPassN(Sample *f0r, Sample *f0i) {
+		Sample *tmpR = (Sample *)dftTmp.data(), *tmpI = tmpR + outerSize;
+		
+		for (size_t i = 0; i < innerSize; ++i) {
+			Sample *offsetR = f0r + i;
+			Sample *offsetI = f0i + i;
+			Sample sumR = 0, sumI = 0;
+			for (size_t i2 = 0; i2 < outerSize; ++i2) {
+				sumR += (tmpR[i2] = offsetR[i2*innerSize]);
+				sumI += (tmpI[i2] = offsetI[i2*innerSize]);
+			}
+			offsetR[0] = sumR;
+			offsetI[0] = sumI;
+			
+			for (size_t f = 1; f < outerSize; ++f) {
+				Sample sumR = *tmpR, sumI = *tmpI;
+
+				for (size_t i2 = 1; i2 < outerSize; ++i2) {
+					size_t twistIndex = (i2*f)%outerSize;
+					Complex twist = inverse ? std::conj(dftTwists[twistIndex]) : dftTwists[twistIndex];
+					sumR += tmpR[i2]*twist.real() - tmpI[i2]*twist.imag();
+					sumI += tmpI[i2]*twist.real() + tmpR[i2]*twist.imag();
+				}
+
+				offsetR[f*innerSize] = sumR;
+				offsetI[f*innerSize] = sumI;
+			}
+		}
+	}
+};
+
+template<typename Sample, bool splitComputation=false>
+using FFT = SplitFFT<Sample, splitComputation>;
+
+// Wraps a complex FFT into a real one
+template<typename Sample, class ComplexFFT=Pow2FFT<Sample>>
+struct SimpleRealFFT {
+	using Complex = std::complex<Sample>;
+	
+	static constexpr bool prefersSplit = ComplexFFT::prefersSplit;
+
+	SimpleRealFFT(size_t size=0) {
+		resize(size);
+	}
+	
+	void resize(size_t size) {
+		complexFft.resize(size);
+		tmpTime.resize(size);
+		tmpFreq.resize(size);
+	}
+	
+	void fft(const Sample *time, Complex *freq) {
+		for (size_t i = 0; i < tmpTime.size(); ++i) {
+			tmpTime[i] = time[i];
+		}
+		complexFft.fft(tmpTime.data(), tmpFreq.data());
+		for (size_t i = 0; i < tmpFreq.size()/2; ++i) {
+			freq[i] = tmpFreq[i];
+		}
+		freq[0] = {
+			tmpFreq[0].real(),
+			tmpFreq[tmpFreq.size()/2].real()
+		};
+	}
+	void fft(const Sample *inR, Sample *outR, Sample *outI) {
+		Sample *tmpFreqR = (Sample *)tmpFreq.data(), *tmpFreqI = tmpFreqR + tmpFreq.size();
+		for (size_t i = 0; i < tmpTime.size()/2; ++i) {
+			tmpTime[i] = 0;
+		}
+		complexFft.fft(inR, (const Sample *)tmpTime.data(), tmpFreqR, tmpFreqI);
+		for (size_t i = 0; i < tmpTime.size()/2; ++i) {
+			outR[i] = tmpFreqR[i];
+			outI[i] = tmpFreqI[i];
+		}
+		outI[0] = tmpFreqR[tmpFreq.size()/2];
+	}
+
+	void ifft(const Complex *freq, Sample *time) {
+		tmpFreq[0] = freq[0].real();
+		tmpFreq[tmpFreq.size()/2] = freq[0].imag();
+		for (size_t i = 1; i < tmpFreq.size()/2; ++i) {
+			tmpFreq[i] = freq[i];
+			tmpFreq[tmpFreq.size() - i] = std::conj(freq[i]);
+		}
+		complexFft.ifft(tmpFreq.data(), tmpTime.data());
+		for (size_t i = 0; i < tmpTime.size(); ++i) {
+			time[i] = tmpTime[i].real();
+		}
+	}
+	void ifft(const Sample *inR, const Sample *inI, Sample *outR) {
+		Sample *tmpFreqR = (Sample *)tmpFreq.data(), *tmpFreqI = tmpFreqR + tmpFreq.size();
+		tmpFreqR[0] = inR[0];
+		tmpFreqR[tmpFreq.size()/2] = inI[0];
+		tmpFreqI[0] = 0;
+		tmpFreqI[tmpFreq.size()/2] = 0;
+		for (size_t i = 1; i < tmpFreq.size()/2; ++i) {
+			tmpFreqR[i] = inR[i];
+			tmpFreqI[i] = inI[i];
+			tmpFreqR[tmpFreq.size() - i] = inR[i];
+			tmpFreqI[tmpFreq.size() - i] = -inI[i];
+		}
+		complexFft.ifft(tmpFreqR, tmpFreqI, outR, (Sample *)tmpTime.data());
+	}
+
+private:
+	ComplexFFT complexFft;
+	std::vector<Complex> tmpTime, tmpFreq;
+};
+
+/// A default power-of-2 FFT, specialised with platform-specific fast implementations where available
+template<typename Sample>
+struct Pow2RealFFT : public SimpleRealFFT<Sample> {
+	static constexpr bool prefersSplit = SimpleRealFFT<Sample>::prefersSplit;
+	
+	using SimpleRealFFT<Sample>::SimpleRealFFT;
+
+	// Prevent copying, since it might be a problem for specialisations
+	Pow2RealFFT(const Pow2RealFFT &other) = delete;
+	// Pass move-constructor through, just to be explicit about it
+	Pow2RealFFT(Pow2RealFFT &&other) : SimpleRealFFT<Sample>(std::move(other)) {}
+};
+
+/// A Real FFT which can handle multiples of 3 and 5, and can be computed in chunks
+template<typename Sample, bool splitComputation=false, bool halfBinShift=false>
+struct RealFFT {
+	using Complex = std::complex<Sample>;
+	static constexpr bool prefersSplit = SplitFFT<Sample, splitComputation>::prefersSplit;
+
+	static size_t fastSizeAbove(size_t size) {
+		return ComplexFFT::fastSizeAbove((size + 1)/2)*2;
+	}
+	
+	RealFFT(size_t size=0) {
+		resize(size);
+	}
+	
+	void resize(size_t size) {
+		size_t hSize = size/2;
+		complexFft.resize(hSize);
+		tmpFreq.resize(hSize);
+		tmpTime.resize(hSize);
+		
+		twiddles.resize(hSize/2 + 1);
+		
+		if (!halfBinShift) {
+			for (size_t i = 0; i < twiddles.size(); ++i) {
+				Sample rotPhase = i*(-2*M_PI/size) - M_PI/2; // bake rotation by (-i) into twiddles
+				twiddles[i] = std::polar(Sample(1), rotPhase);
+			}
+		} else {
+			for (size_t i = 0; i < twiddles.size(); ++i) {
+				Sample rotPhase = (i + 0.5)*(-2*M_PI/size) - M_PI/2;
+				twiddles[i] = std::polar(Sample(1), rotPhase);
+			}
+	
+			halfBinTwists.resize(hSize);
+			for (size_t i = 0; i < hSize; ++i) {
+				Sample twistPhase = -2*M_PI*i/size;
+				halfBinTwists[i] = std::polar(Sample(1), twistPhase);
+			}
+		}
+	}
+	
+	size_t size() const {
+		return complexFft.size()*2;
+	}
+	size_t steps() const {
+		return complexFft.steps() + (splitComputation ? 3 : 2);
+	}
+	
+	void fft(const Sample *time, Complex *freq) {
+		for (size_t s = 0; s < steps(); ++s) {
+			fft(s, time, freq);
+		}
+	}
+	void fft(size_t step, const Sample *time, Complex *freq) {
+		if (complexPrefersSplit) {
+			size_t hSize = complexFft.size();
+			Sample *tmpTimeR = (Sample *)tmpTime.data(), *tmpTimeI = tmpTimeR + hSize;
+			Sample *tmpFreqR = (Sample *)tmpFreq.data(), *tmpFreqI = tmpFreqR + hSize;
+			if (step-- == 0) {
+				size_t hSize = complexFft.size();
+				if (halfBinShift) {
+					for (size_t i = 0; i < hSize; ++i) {
+						Sample tr = time[2*i], ti = time[2*i + 1];
+						Complex twist = halfBinTwists[i];
+						tmpTimeR[i] = tr*twist.real() - ti*twist.imag();
+						tmpTimeI[i] = ti*twist.real() + tr*twist.imag();
+					}
+				} else {
+					for (size_t i = 0; i < hSize; ++i) {
+						tmpTimeR[i] = time[2*i];
+						tmpTimeI[i] = time[2*i + 1];
+					}
+				}
+			} else if (step < complexFft.steps()) {
+				complexFft.fft(step, tmpTimeR, tmpTimeI, tmpFreqR, tmpFreqI);
+			} else {
+				if (!halfBinShift) {
+					Sample bin0r = tmpFreqR[0], bin0i = tmpFreqI[0];
+					freq[0] = {bin0r + bin0i, bin0r - bin0i};
+				}
+
+				size_t startI = halfBinShift ? 0 : 1;
+				size_t endI = hSize/2 + 1;
+				if (splitComputation) { // Do this last twiddle in two halves
+					if (step == complexFft.steps()) {
+						endI = (startI + endI)/2;
+					} else {
+						startI = (startI + endI)/2;
+					}
+				}
+				for (size_t i = startI; i < endI; ++i) {
+					size_t conjI = halfBinShift ? (hSize - 1 - i) : (hSize - i);
+					Complex twiddle = twiddles[i];
+
+					Sample oddR = (tmpFreqR[i] + tmpFreqR[conjI])*Sample(0.5);
+					Sample oddI = (tmpFreqI[i] - tmpFreqI[conjI])*Sample(0.5);
+					Sample evenIR = (tmpFreqR[i] - tmpFreqR[conjI])*Sample(0.5);
+					Sample evenII = (tmpFreqI[i] + tmpFreqI[conjI])*Sample(0.5);
+					Sample evenRotMinusIR = evenIR*twiddle.real() - evenII*twiddle.imag();
+					Sample evenRotMinusII = evenII*twiddle.real() + evenIR*twiddle.imag();
+
+					freq[i] = {oddR + evenRotMinusIR, oddI + evenRotMinusII};
+					freq[conjI] = {oddR - evenRotMinusIR, evenRotMinusII - oddI};
+				}
+			}
+		} else {
+			bool canUseTime = !halfBinShift && !(size_t(time)%alignof(Complex));
+			if (step-- == 0) {
+				size_t hSize = complexFft.size();
+				if (halfBinShift) {
+					for (size_t i = 0; i < hSize; ++i) {
+						Sample tr = time[2*i], ti = time[2*i + 1];
+						Complex twist = halfBinTwists[i];
+						tmpTime[i] = {
+							tr*twist.real() - ti*twist.imag(),
+							ti*twist.real() + tr*twist.imag()
+						};
+					}
+				} else if (!canUseTime) {
+					std::memcpy(tmpTime.data(), time, sizeof(Complex)*hSize);
+				}
+			} else if (step < complexFft.steps()) {
+				complexFft.fft(step, canUseTime ? (const Complex *)time : tmpTime.data(), tmpFreq.data());
+			} else {
+				if (!halfBinShift) {
+					Complex bin0 = tmpFreq[0];
+					freq[0] = { // pack DC & Nyquist together
+						bin0.real() + bin0.imag(),
+						bin0.real() - bin0.imag()
+					};
+				}
+				
+				size_t hSize = complexFft.size();
+				size_t startI = halfBinShift ? 0 : 1;
+				size_t endI = hSize/2 + 1;
+				if (splitComputation) { // Do this last twiddle in two halves
+					if (step == complexFft.steps()) {
+						endI = (startI + endI)/2;
+					} else {
+						startI = (startI + endI)/2;
+					}
+				}
+				for (size_t i = startI; i < endI; ++i) {
+					size_t conjI = halfBinShift ? (hSize - 1 - i) : (hSize - i);
+					Complex twiddle = twiddles[i];
+
+					Complex odd = (tmpFreq[i] + std::conj(tmpFreq[conjI]))*Sample(0.5);
+					Complex evenI = (tmpFreq[i] - std::conj(tmpFreq[conjI]))*Sample(0.5);
+					Complex evenRotMinusI = { // twiddle includes a factor of -i
+						evenI.real()*twiddle.real() - evenI.imag()*twiddle.imag(),
+						evenI.imag()*twiddle.real() + evenI.real()*twiddle.imag()
+					};
+
+					freq[i] = odd + evenRotMinusI;
+					freq[conjI] = {odd.real() - evenRotMinusI.real(), evenRotMinusI.imag() - odd.imag()};
+				}
+			}
+		}
+	}
+	void fft(const Sample *inR, Sample *outR, Sample *outI) {
+		for (size_t s = 0; s < steps(); ++s) {
+			fft(s, inR, outR, outI);
+		}
+	}
+	void fft(size_t step, const Sample *inR, Sample *outR, Sample *outI) {
+		size_t hSize = complexFft.size();
+		Sample *tmpTimeR = (Sample *)tmpTime.data(), *tmpTimeI = tmpTimeR + hSize;
+		Sample *tmpFreqR = (Sample *)tmpFreq.data(), *tmpFreqI = tmpFreqR + hSize;
+		if (step-- == 0) {
+			size_t hSize = complexFft.size();
+			if (halfBinShift) {
+				for (size_t i = 0; i < hSize; ++i) {
+					Sample tr = inR[2*i], ti = inR[2*i + 1];
+					Complex twist = halfBinTwists[i];
+					tmpTimeR[i] = tr*twist.real() - ti*twist.imag();
+					tmpTimeI[i] = ti*twist.real() + tr*twist.imag();
+				}
+			} else {
+				for (size_t i = 0; i < hSize; ++i) {
+					tmpTimeR[i] = inR[2*i];
+					tmpTimeI[i] = inR[2*i + 1];
+				}
+			}
+		} else if (step < complexFft.steps()) {
+			complexFft.fft(step, tmpTimeR, tmpTimeI, tmpFreqR, tmpFreqI);
+		} else {
+			if (!halfBinShift) {
+				Sample bin0r = tmpFreqR[0], bin0i = tmpFreqI[0];
+				outR[0] = bin0r + bin0i;
+				outI[0] = bin0r - bin0i;
+			}
+
+			size_t startI = halfBinShift ? 0 : 1;
+			size_t endI = hSize/2 + 1;
+			if (splitComputation) { // Do this last twiddle in two halves
+				if (step == complexFft.steps()) {
+					endI = (startI + endI)/2;
+				} else {
+					startI = (startI + endI)/2;
+				}
+			}
+			for (size_t i = startI; i < endI; ++i) {
+				size_t conjI = halfBinShift ? (hSize - 1 - i) : (hSize - i);
+				Complex twiddle = twiddles[i];
+
+				Sample oddR = (tmpFreqR[i] + tmpFreqR[conjI])*Sample(0.5);
+				Sample oddI = (tmpFreqI[i] - tmpFreqI[conjI])*Sample(0.5);
+				Sample evenIR = (tmpFreqR[i] - tmpFreqR[conjI])*Sample(0.5);
+				Sample evenII = (tmpFreqI[i] + tmpFreqI[conjI])*Sample(0.5);
+				Sample evenRotMinusIR = evenIR*twiddle.real() - evenII*twiddle.imag();
+				Sample evenRotMinusII = evenII*twiddle.real() + evenIR*twiddle.imag();
+
+				outR[i] = oddR + evenRotMinusIR;
+				outI[i] = oddI + evenRotMinusII;
+				outR[conjI] = oddR - evenRotMinusIR;
+				outI[conjI] = evenRotMinusII - oddI;
+			}
+		}
+	}
+	
+	void ifft(const Complex *freq, Sample *time) {
+		for (size_t s = 0; s < steps(); ++s) {
+			ifft(s, freq, time);
+		}
+	}
+	void ifft(size_t step, const Complex *freq, Sample *time) {
+		if (complexPrefersSplit) {
+			size_t hSize = complexFft.size();
+			Sample *tmpTimeR = (Sample *)tmpTime.data(), *tmpTimeI = tmpTimeR + hSize;
+			Sample *tmpFreqR = (Sample *)tmpFreq.data(), *tmpFreqI = tmpFreqR + hSize;
+
+			bool splitFirst = splitComputation && (step-- == 0);
+			if (splitFirst || step-- == 0) {
+				Complex bin0 = freq[0];
+				if (!halfBinShift) {
+					tmpFreqR[0] = bin0.real() + bin0.imag();
+					tmpFreqI[0] = bin0.real() - bin0.imag();
+				}
+				size_t startI = halfBinShift ? 0 : 1;
+				size_t endI = hSize/2 + 1;
+				if (splitComputation) { // Do this first twiddle in two halves
+					if (splitFirst) {
+						endI = (startI + endI)/2;
+					} else {
+						startI = (startI + endI)/2;
+					}
+				}
+				for (size_t i = startI; i < endI; ++i) {
+					size_t conjI = halfBinShift ? (hSize - 1 - i) : (hSize - i);
+					Complex twiddle = twiddles[i];
+
+					Complex odd = freq[i] + std::conj(freq[conjI]);
+					Complex evenRotMinusI = freq[i] - std::conj(freq[conjI]);
+					Complex evenI = { // Conjugate twiddle
+						evenRotMinusI.real()*twiddle.real() + evenRotMinusI.imag()*twiddle.imag(),
+						evenRotMinusI.imag()*twiddle.real() - evenRotMinusI.real()*twiddle.imag()
+					};
+
+					tmpFreqR[i] = odd.real() + evenI.real();
+					tmpFreqI[i] = odd.imag() + evenI.imag();
+					tmpFreqR[conjI] = odd.real() - evenI.real();
+					tmpFreqI[conjI] = evenI.imag() - odd.imag();
+				}
+			} else if (step < complexFft.steps()) {
+				complexFft.ifft(step, tmpFreqR, tmpFreqI, tmpTimeR, tmpTimeI);
+			} else {
+				size_t hSize = complexFft.size();
+				if (halfBinShift) {
+					for (size_t i = 0; i < hSize; ++i) {
+						Sample tr = tmpTimeR[i], ti = tmpTimeI[i];
+						Complex twist = halfBinTwists[i];
+						time[2*i] = 	tr*twist.real() + ti*twist.imag();
+						time[2*i + 1] = ti*twist.real() - tr*twist.imag();
+					}
+				} else {
+					for (size_t i = 0; i < hSize; ++i) {
+						time[2*i] = tmpTimeR[i];
+						time[2*i + 1] = tmpTimeI[i];
+					}
+				}
+			}
+		} else {
+			bool canUseTime = !halfBinShift && !(size_t(time)%alignof(Complex));
+			bool splitFirst = splitComputation && (step-- == 0);
+			if (splitFirst || step-- == 0) {
+				Complex bin0 = freq[0];
+				if (!halfBinShift) {
+					tmpFreq[0] = {
+						bin0.real() + bin0.imag(),
+						bin0.real() - bin0.imag()
+					};
+				}
+				size_t hSize = complexFft.size();
+				size_t startI = halfBinShift ? 0 : 1;
+				size_t endI = hSize/2 + 1;
+				if (splitComputation) { // Do this first twiddle in two halves
+					if (splitFirst) {
+						endI = (startI + endI)/2;
+					} else {
+						startI = (startI + endI)/2;
+					}
+				}
+				for (size_t i = startI; i < endI; ++i) {
+					size_t conjI = halfBinShift ? (hSize - 1 - i) : (hSize - i);
+					Complex twiddle = twiddles[i];
+
+					Complex odd = freq[i] + std::conj(freq[conjI]);
+					Complex evenRotMinusI = freq[i] - std::conj(freq[conjI]);
+					Complex evenI = { // Conjugate twiddle
+						evenRotMinusI.real()*twiddle.real() + evenRotMinusI.imag()*twiddle.imag(),
+						evenRotMinusI.imag()*twiddle.real() - evenRotMinusI.real()*twiddle.imag()
+					};
+
+					tmpFreq[i] = odd + evenI;
+					tmpFreq[conjI] = {odd.real() - evenI.real(), evenI.imag() - odd.imag()};
+				}
+			} else if (step < complexFft.steps()) {
+				// Can't just use time as (Complex *), since it might not be aligned properly
+				complexFft.ifft(step, tmpFreq.data(), canUseTime ? (Complex *)time : tmpTime.data());
+			} else {
+				size_t hSize = complexFft.size();
+				if (halfBinShift) {
+					for (size_t i = 0; i < hSize; ++i) {
+						Complex t = tmpTime[i];
+						Complex twist = halfBinTwists[i];
+						time[2*i] = 	t.real()*twist.real() + t.imag()*twist.imag();
+						time[2*i + 1] = t.imag()*twist.real() - t.real()*twist.imag();
+					}
+				} else if (!canUseTime) {
+					std::memcpy(time, tmpTime.data(), sizeof(Complex)*hSize);
+				}
+			}
+		}
+	}
+	void ifft(const Sample *inR, const Sample *inI, Sample *outR) {
+		for (size_t s = 0; s < steps(); ++s) {
+			ifft(s, inR, inI, outR);
+		}
+	}
+	void ifft(size_t step, const Sample *inR, const Sample *inI, Sample *outR) {
+		size_t hSize = complexFft.size();
+		Sample *tmpTimeR = (Sample *)tmpTime.data(), *tmpTimeI = tmpTimeR + hSize;
+		Sample *tmpFreqR = (Sample *)tmpFreq.data(), *tmpFreqI = tmpFreqR + hSize;
+
+		bool splitFirst = splitComputation && (step-- == 0);
+		if (splitFirst || step-- == 0) {
+			Sample bin0r = inR[0], bin0i = inI[0];
+			if (!halfBinShift) {
+				tmpFreqR[0] = bin0r + bin0i;
+				tmpFreqI[0] = bin0r - bin0i;
+			}
+			size_t startI = halfBinShift ? 0 : 1;
+			size_t endI = hSize/2 + 1;
+			if (splitComputation) { // Do this first twiddle in two halves
+				if (splitFirst) {
+					endI = (startI + endI)/2;
+				} else {
+					startI = (startI + endI)/2;
+				}
+			}
+			for (size_t i = startI; i < endI; ++i) {
+				size_t conjI = halfBinShift ? (hSize - 1 - i) : (hSize - i);
+				Complex twiddle = twiddles[i];
+				Sample fir = inR[i], fii = inI[i];
+				Sample fcir = inR[conjI], fcii = inI[conjI];
+
+				Complex odd = {fir + fcir, fii - fcii};
+				Complex evenRotMinusI = {fir - fcir, fii + fcii};
+				Complex evenI = { // Conjugate twiddle
+					evenRotMinusI.real()*twiddle.real() + evenRotMinusI.imag()*twiddle.imag(),
+					evenRotMinusI.imag()*twiddle.real() - evenRotMinusI.real()*twiddle.imag()
+				};
+
+				tmpFreqR[i] = odd.real() + evenI.real();
+				tmpFreqI[i] = odd.imag() + evenI.imag();
+				tmpFreqR[conjI] = odd.real() - evenI.real();
+				tmpFreqI[conjI] = evenI.imag() - odd.imag();
+			}
+		} else if (step < complexFft.steps()) {
+			// Can't just use time as (Complex *), since it might not be aligned properly
+			complexFft.ifft(step, tmpFreqR, tmpFreqI, tmpTimeR, tmpTimeI);
+		} else {
+			if (halfBinShift) {
+				for (size_t i = 0; i < hSize; ++i) {
+					Sample tr = tmpTimeR[i], ti = tmpTimeI[i];
+					Complex twist = halfBinTwists[i];
+					outR[2*i] = 	tr*twist.real() + ti*twist.imag();
+					outR[2*i + 1] = ti*twist.real() - tr*twist.imag();
+				}
+			} else {
+				for (size_t i = 0; i < hSize; ++i) {
+					outR[2*i] = tmpTimeR[i];
+					outR[2*i + 1] = tmpTimeI[i];
+				}
+			}
+		}
+	}
+private:
+	using ComplexFFT = SplitFFT<Sample, splitComputation>;
+	ComplexFFT complexFft;
+
+	static constexpr bool complexPrefersSplit = ComplexFFT::prefersSplit;
+	std::vector<Complex> tmpFreq, tmpTime;
+	std::vector<Complex> twiddles, halfBinTwists;
+};
+
+template<typename Sample, bool splitComputation=false>
+using ModifiedRealFFT = RealFFT<Sample, splitComputation, true>;
+
+}} // namespace
+
+// Override `Pow2FFT` / `Pow2RealFFT` templates with faster implementations
+#if defined(SIGNALSMITH_USE_PFFFT) || defined(SIGNALSMITH_USE_PFFFT_DOUBLE)
+#	if defined(SIGNALSMITH_USE_PFFFT)
+#		include "./platform/fft-pffft.h"
+#	endif
+#	if defined(SIGNALSMITH_USE_PFFFT_DOUBLE)
+#		include "./platform/fft-pffft-double.h"
+#	endif
+#elif defined(SIGNALSMITH_USE_ACCELERATE)
+#	include "./platform/fft-accelerate.h"
+#elif defined(SIGNALSMITH_USE_IPP)
+#	include "./platform/fft-ipp.h"
+#endif
+
+#endif // include guard

--- a/third_party/signalsmith-stretch/signalsmith-linear/stft.h
+++ b/third_party/signalsmith-stretch/signalsmith-linear/stft.h
@@ -1,0 +1,643 @@
+#ifndef SIGNALSMITH_AUDIO_LINEAR_STFT_H
+#define SIGNALSMITH_AUDIO_LINEAR_STFT_H
+
+#include "./fft.h"
+
+namespace signalsmith { namespace linear {
+
+enum {
+	STFT_SPECTRUM_PACKED=0,
+	STFT_SPECTRUM_MODIFIED=1,
+	STFT_SPECTRUM_UNPACKED=2,
+};
+
+/// A self-normalising STFT, with variable position/window for output blocks
+template<typename Sample, bool splitComputation=false, int spectrumType=STFT_SPECTRUM_PACKED>
+struct DynamicSTFT {
+	static constexpr bool modified = (spectrumType == STFT_SPECTRUM_MODIFIED);
+	static constexpr bool unpacked = (spectrumType == STFT_SPECTRUM_UNPACKED);
+	RealFFT<Sample, splitComputation, modified> fft;
+
+	using Complex = std::complex<Sample>;
+
+	enum class WindowShape {ignore, acg, kaiser};
+	static constexpr WindowShape acg = WindowShape::acg;
+	static constexpr WindowShape kaiser = WindowShape::kaiser;
+
+	void configure(size_t inChannels, size_t outChannels, size_t blockSamples, size_t extraInputHistory=0, size_t intervalSamples=0, Sample asymmetry=0) {
+		_analysisChannels = inChannels;
+		_synthesisChannels = outChannels;
+		_blockSamples = blockSamples;
+		_fftSamples = fft.fastSizeAbove((blockSamples + 1)/2)*2;
+		fft.resize(_fftSamples);
+		_fftBins = _fftSamples/2 + (spectrumType == STFT_SPECTRUM_UNPACKED);
+		
+		_inputLengthSamples = _blockSamples + extraInputHistory;
+		input.buffer.resize(_inputLengthSamples*_analysisChannels);
+
+		output.buffer.resize(_blockSamples*_synthesisChannels);
+		output.windowProducts.resize(_blockSamples);
+		spectrumBuffer.resize(_fftBins*std::max(_analysisChannels, _synthesisChannels));
+		timeBuffer.resize(_fftSamples);
+
+		_analysisWindow.resize(_blockSamples);
+		_synthesisWindow.resize(_blockSamples);
+		setInterval(intervalSamples ? intervalSamples : blockSamples/4, acg, asymmetry);
+
+		reset();
+	}
+	
+	size_t blockSamples() const {
+		return _blockSamples;
+	}
+	size_t fftSamples() const {
+		return _fftSamples;
+	}
+	size_t defaultInterval() const {
+		return _defaultInterval;
+	}
+	size_t bands() const {
+		return _fftBins;
+	}
+	size_t analysisLatency() const {
+		return _blockSamples - _analysisOffset;
+	}
+	size_t synthesisLatency() const {
+		return _synthesisOffset;
+	}
+	size_t latency() const {
+		return synthesisLatency() + analysisLatency();
+	}
+	Sample binToFreq(Sample b) const {
+		return (modified ? b + Sample(0.5) : b)/_fftSamples;
+	}
+	Sample freqToBin(Sample f) const {
+		return modified ? f*_fftSamples - Sample(0.5) : f*_fftSamples;
+	}
+
+	void reset(Sample productWeight=1) {
+		input.pos = _blockSamples;
+		output.pos = 0;
+		for (auto &v : input.buffer) v = 0;
+		for (auto &v : output.buffer) v = 0;
+		for (auto &v : spectrumBuffer) v = 0;
+		for (auto &v : output.windowProducts) v = 0;
+		addWindowProduct();
+		for (int i = int(_blockSamples) - int(_defaultInterval) - 1; i >= 0; --i) {
+			output.windowProducts[i] += output.windowProducts[i + _defaultInterval];
+		}
+		for (auto &v : output.windowProducts) v = v*productWeight + almostZero;
+		moveOutput(_defaultInterval); // ready for first block immediately
+	}
+
+	void writeInput(size_t channel, size_t offset, size_t length, const Sample *inputArray) {
+		Sample *buffer = input.buffer.data() + channel*_inputLengthSamples;
+
+		size_t offsetPos = (input.pos + offset)%_inputLengthSamples;
+		size_t inputWrapIndex = _inputLengthSamples - offsetPos;
+		size_t chunk1 = std::min(length, inputWrapIndex);
+		for (size_t i = 0; i < chunk1; ++i) {
+			size_t i2 = offsetPos + i;
+			buffer[i2] = inputArray[i];
+		}
+		for (size_t i = chunk1; i < length; ++i) {
+			size_t i2 = i + offsetPos -_inputLengthSamples;
+			buffer[i2] = inputArray[i];
+		}
+	}
+	void writeInput(size_t channel, size_t length, const Sample *inputArray) {
+		writeInput(channel, 0, length, inputArray);
+	}
+	void moveInput(size_t samples, bool clearInput=false) {
+		if (clearInput) {
+			size_t inputWrapIndex = _inputLengthSamples - input.pos;
+			size_t chunk1 = std::min(samples, inputWrapIndex);
+			for (size_t c = 0; c < _analysisChannels; ++c) {
+				Sample *buffer = input.buffer.data() + c*_inputLengthSamples;
+				for (size_t i = 0; i < chunk1; ++i) {
+					size_t i2 = input.pos + i;
+					buffer[i2] = 0;
+				}
+				for (size_t i = chunk1; i < samples; ++i) {
+					size_t i2 = i + input.pos - _inputLengthSamples;
+					buffer[i2] = 0;
+				}
+			}
+		}
+
+		input.pos = (input.pos + samples)%_inputLengthSamples;
+		_samplesSinceAnalysis += samples;
+	}
+	size_t samplesSinceAnalysis() const {
+		return _samplesSinceAnalysis;
+	}
+
+	/// When no more synthesis is expected, let output taper away to 0 based on windowing.  Otherwise, the output will be scaled as if there's just a very long block interval, which can exaggerate artefacts and numerical errors.  You still can't read more than `blockSamples()` into the future.
+	void finishOutput(Sample strength=1, size_t offset=0) {
+		Sample maxWindowProduct = 0;
+		
+		size_t chunk1 = std::max(offset, std::min(_blockSamples, _blockSamples - output.pos));
+		
+		for (size_t i = offset; i < chunk1; ++i) {
+			size_t i2 = output.pos + i;
+			Sample &wp = output.windowProducts[i2];
+			maxWindowProduct = std::max(wp, maxWindowProduct);
+			wp += (maxWindowProduct - wp)*strength;
+		}
+		for (size_t i = chunk1; i < _blockSamples; ++i) {
+			size_t i2 = i + output.pos - _blockSamples;
+			Sample &wp = output.windowProducts[i2];
+			maxWindowProduct = std::max(wp, maxWindowProduct);
+			wp += (maxWindowProduct - wp)*strength;
+		}
+	}
+
+	void readOutput(size_t channel, size_t offset, size_t length, Sample *outputArray) {
+		Sample *buffer = output.buffer.data() + channel*_blockSamples;
+		size_t offsetPos = (output.pos + offset)%_blockSamples;
+		size_t outputWrapIndex = _blockSamples - offsetPos;
+		size_t chunk1 = std::min(length, outputWrapIndex);
+		for (size_t i = 0; i < chunk1; ++i) {
+			size_t i2 = offsetPos + i;
+			outputArray[i] = buffer[i2]/output.windowProducts[i2];
+		}
+		for (size_t i = chunk1; i < length; ++i) {
+			size_t i2 = i + offsetPos - _blockSamples;
+			outputArray[i] = buffer[i2]/output.windowProducts[i2];
+		}
+	}
+	void readOutput(size_t channel, size_t length, Sample *outputArray) {
+		return readOutput(channel, 0, length, outputArray);
+	}
+	void addOutput(size_t channel, size_t offset, size_t length, const Sample *newOutputArray) {
+		length = std::min(_blockSamples, length);
+		Sample *buffer = output.buffer.data() + channel*_blockSamples;
+		size_t offsetPos = (output.pos + offset)%_blockSamples;
+		size_t outputWrapIndex = _blockSamples - offsetPos;
+		size_t chunk1 = std::min(length, outputWrapIndex);
+		for (size_t i = 0; i < chunk1; ++i) {
+			size_t i2 = offsetPos + i;
+			buffer[i2] += newOutputArray[i]*output.windowProducts[i2];
+		}
+		for (size_t i = chunk1; i < length; ++i) {
+			size_t i2 = i + offsetPos - _blockSamples;
+			buffer[i2] += newOutputArray[i]*output.windowProducts[i2];
+		}
+	}
+	void addOutput(size_t channel, size_t length, const Sample *newOutputArray) {
+		return addOutput(channel, 0, length, newOutputArray);
+	}
+	void replaceOutput(size_t channel, size_t offset, size_t length, const Sample *newOutputArray) {
+		length = std::min(_blockSamples, length);
+		Sample *buffer = output.buffer.data() + channel*_blockSamples;
+		size_t offsetPos = (output.pos + offset)%_blockSamples;
+		size_t outputWrapIndex = _blockSamples - offsetPos;
+		size_t chunk1 = std::min(length, outputWrapIndex);
+		for (size_t i = 0; i < chunk1; ++i) {
+			size_t i2 = offsetPos + i;
+			buffer[i2] = newOutputArray[i]*output.windowProducts[i2];
+		}
+		for (size_t i = chunk1; i < length; ++i) {
+			size_t i2 = i + offsetPos - _blockSamples;
+			buffer[i2] = newOutputArray[i]*output.windowProducts[i2];
+		}
+	}
+	void replaceOutput(size_t channel, size_t length, const Sample *newOutputArray) {
+		return replaceOutput(channel, 0, length, newOutputArray);
+	}
+	void moveOutput(size_t samples) {
+		if (samples == 1) { // avoid all the loops/chunks if we can
+			for (size_t c = 0; c < _synthesisChannels; ++c) {
+				output.buffer[output.pos + c*_blockSamples] = 0;
+			}
+			output.windowProducts[output.pos] = almostZero;
+			if (++output.pos >= _blockSamples) output.pos = 0;
+			return;
+		}
+		// Zero the output buffer as we cross it
+		size_t outputWrapIndex = _blockSamples - output.pos;
+		size_t chunk1 = std::min(samples, outputWrapIndex);
+		for (size_t c = 0; c < _synthesisChannels; ++c) {
+			Sample *buffer = output.buffer.data() + c*_blockSamples;
+			for (size_t i = 0; i < chunk1; ++i) {
+				size_t i2 = output.pos + i;
+				buffer[i2] = 0;
+			}
+			for (size_t i = chunk1; i < samples; ++i) {
+				size_t i2 = i + output.pos - _blockSamples;
+				buffer[i2] = 0;
+			}
+		}
+		for (size_t i = 0; i < chunk1; ++i) {
+			size_t i2 = output.pos + i;
+			output.windowProducts[i2] = almostZero;
+		}
+		for (size_t i = chunk1; i < samples; ++i) {
+			size_t i2 = i + output.pos - _blockSamples;
+			output.windowProducts[i2] = almostZero;
+		}
+		output.pos = (output.pos + samples)%_blockSamples;
+		_samplesSinceSynthesis += samples;
+	}
+	size_t samplesSinceSynthesis() const {
+		return _samplesSinceSynthesis;
+	}
+	
+	Complex * spectrum(size_t channel) {
+		return spectrumBuffer.data() + channel*_fftBins;
+	}
+	const Complex * spectrum(size_t channel) const {
+		return spectrumBuffer.data() + channel*_fftBins;
+	}
+
+	Sample * analysisWindow() {
+		return _analysisWindow.data();
+	}
+	const Sample * analysisWindow() const {
+		return _analysisWindow.data();
+	}
+	// Sets the centre index of the window
+	void analysisOffset(size_t offset) {
+		_analysisOffset = offset;
+	}
+	size_t analysisOffset() const {
+		return _analysisOffset;
+	}
+	Sample * synthesisWindow() {
+		return _synthesisWindow.data();
+	}
+	const Sample * synthesisWindow() const {
+		return _synthesisWindow.data();
+	}
+	// Sets the centre index of the window
+	void synthesisOffset(size_t offset) {
+		_synthesisOffset = offset;
+	}
+	size_t synthesisOffset() const {
+		return _synthesisOffset;
+	}
+	
+	void setInterval(size_t defaultInterval, WindowShape windowShape=WindowShape::ignore, Sample asymmetry=0) {
+		_defaultInterval = defaultInterval;
+		if (windowShape == WindowShape::ignore) return;
+
+		if (windowShape == acg) {
+			auto window = ApproximateConfinedGaussian::withBandwidth(double(_blockSamples)/defaultInterval);
+			window.fill(_synthesisWindow, _blockSamples, asymmetry, false);
+		} else if (windowShape == kaiser) {
+			auto window = Kaiser::withBandwidth(double(_blockSamples)/defaultInterval, true);
+			window.fill(_synthesisWindow,  _blockSamples, asymmetry, true);
+		}
+
+		_analysisOffset = _synthesisOffset = _blockSamples/2;
+		if (_analysisChannels == 0) {
+			for (auto &v : _analysisWindow) v = 1;
+		} else if (asymmetry == 0) {
+			forcePerfectReconstruction(_synthesisWindow, _blockSamples, _defaultInterval);
+			for (size_t i = 0; i < _blockSamples; ++i) {
+				_analysisWindow[i] = _synthesisWindow[i];
+			}
+		} else {
+			for (size_t i = 0; i < _blockSamples; ++i) {
+				_analysisWindow[i] = _synthesisWindow[_blockSamples - 1 - i];
+			}
+		}
+		// Set offsets to peak's index
+		for (size_t i = 0; i < _blockSamples; ++i) {
+			if (_analysisWindow[i] > _analysisWindow[_analysisOffset]) _analysisOffset = i;
+			if (_synthesisWindow[i] > _synthesisWindow[_synthesisOffset]) _synthesisOffset = i;
+		}
+	}
+	
+	void analyse(size_t samplesInPast=0) {
+		for (size_t s = 0; s < analyseSteps(); ++s) {
+			analyseStep(s, samplesInPast);
+		}
+	}
+	size_t analyseSteps() const {
+		return splitComputation ? _analysisChannels*(fft.steps() + 1) : _analysisChannels;
+	}
+	void analyseStep(size_t step, std::size_t samplesInPast=0) {
+		size_t fftSteps = splitComputation ? fft.steps() : 0;
+		size_t channel = step/(fftSteps + 1);
+		step -= channel*(fftSteps + 1);
+		
+		if (step-- == 0) { // extra step at start of each channel: copy windowed input into buffer
+			size_t offsetPos = (_inputLengthSamples*2 + input.pos - _blockSamples - samplesInPast)%_inputLengthSamples;
+			size_t inputWrapIndex = _inputLengthSamples - offsetPos;
+			size_t chunk1 = std::min(_analysisOffset, inputWrapIndex);
+			size_t chunk2 = std::max(_analysisOffset, std::min(_blockSamples, inputWrapIndex));
+
+			_samplesSinceAnalysis = samplesInPast;
+			Sample *buffer = input.buffer.data() + channel*_inputLengthSamples;
+			for (size_t i = 0; i < chunk1; ++i) {
+				Sample w = modified ? -_analysisWindow[i] : _analysisWindow[i];
+				size_t ti = i + (_fftSamples - _analysisOffset);
+				size_t bi = offsetPos + i;
+				timeBuffer[ti] = buffer[bi]*w;
+			}
+			for (size_t i = chunk1; i < _analysisOffset; ++i) {
+				Sample w = modified ? -_analysisWindow[i] : _analysisWindow[i];
+				size_t ti = i + (_fftSamples - _analysisOffset);
+				size_t bi = i + offsetPos - _inputLengthSamples;
+				timeBuffer[ti] = buffer[bi]*w;
+			}
+			for (size_t i = _analysisOffset; i < chunk2; ++i) {
+				Sample w = _analysisWindow[i];
+				size_t ti = i - _analysisOffset;
+				size_t bi = offsetPos + i;
+				timeBuffer[ti] = buffer[bi]*w;
+			}
+			for (size_t i = chunk2; i < _blockSamples; ++i) {
+				Sample w = _analysisWindow[i];
+				size_t ti = i - _analysisOffset;
+				size_t bi = i + offsetPos - _inputLengthSamples;
+				timeBuffer[ti] = buffer[bi]*w;
+			}
+			for (size_t i = _blockSamples - _analysisOffset; i < _fftSamples - _analysisOffset; ++i) {
+				timeBuffer[i] = 0;
+			}
+			if (splitComputation) return;
+		}
+		auto *spectrumPtr = spectrum(channel);
+		if (splitComputation) {
+			fft.fft(step, timeBuffer.data(), spectrumPtr);
+			if (unpacked && step == fft.steps() - 1) {
+				spectrumPtr[_fftBins - 1] = spectrumPtr[0].imag();
+				spectrumPtr[0].imag(0);
+			}
+		} else {
+			fft.fft(timeBuffer.data(), spectrum(channel));
+			if (unpacked) {
+				spectrumPtr[_fftBins - 1] = spectrumPtr[0].imag();
+				spectrumPtr[0].imag(0);
+			}
+		}
+	}
+
+	void synthesise() {
+		for (size_t s = 0; s < synthesiseSteps(); ++s) {
+			synthesiseStep(s);
+		}
+	}
+	size_t synthesiseSteps() const {
+		return splitComputation ? (_synthesisChannels*(fft.steps() + 1) + 1) : _synthesisChannels;
+	}
+	void synthesiseStep(size_t step) {
+		if (step == 0) { // Extra first step which adds in the effective gain for a pure analysis-synthesis cycle
+			addWindowProduct();
+			if (splitComputation) return;
+		}
+		if (splitComputation) --step;
+
+		size_t fftSteps = splitComputation ? fft.steps() : 0;
+		size_t channel = step/(fftSteps + 1);
+		step -= channel*(fftSteps + 1);
+
+		auto *spectrumPtr = spectrum(channel);
+		if (unpacked && step == 0) { // re-pack
+			spectrumPtr[0].imag(spectrumPtr[_fftBins - 1].real());
+		}
+
+		if (splitComputation) {
+			if (step < fftSteps) {
+				fft.ifft(step, spectrumPtr, timeBuffer.data());
+				return;
+			}
+		} else {
+			fft.ifft(spectrumPtr, timeBuffer.data());
+		}
+		
+		// extra step after each channel's FFT
+		Sample *buffer = output.buffer.data() + channel*_blockSamples;
+		size_t outputWrapIndex = _blockSamples - output.pos;
+		size_t chunk1 = std::min(_synthesisOffset, outputWrapIndex);
+		size_t chunk2 = std::min(_blockSamples, std::max(_synthesisOffset, outputWrapIndex));
+		
+		for (size_t i = 0; i < chunk1; ++i) {
+			Sample w = modified ? -_synthesisWindow[i] : _synthesisWindow[i];
+			size_t ti = i + (_fftSamples - _synthesisOffset);
+			size_t bi = output.pos + i;
+			buffer[bi] += timeBuffer[ti]*w;
+		}
+		for (size_t i = chunk1; i < _synthesisOffset; ++i) {
+			Sample w = modified ? -_synthesisWindow[i] : _synthesisWindow[i];
+			size_t ti = i + (_fftSamples - _synthesisOffset);
+			size_t bi = i + output.pos - _blockSamples;
+			buffer[bi] += timeBuffer[ti]*w;
+		}
+		for (size_t i = _synthesisOffset; i < chunk2; ++i) {
+			Sample w = _synthesisWindow[i];
+			size_t ti = i - _synthesisOffset;
+			size_t bi = output.pos + i;
+			buffer[bi] += timeBuffer[ti]*w;
+		}
+		for (size_t i = chunk2; i < _blockSamples; ++i) {
+			Sample w = _synthesisWindow[i];
+			size_t ti = i - _synthesisOffset;
+			size_t bi = i + output.pos - _blockSamples;
+			buffer[bi] += timeBuffer[ti]*w;
+		}
+	}
+
+#define COMPAT_SPELLING(name, alt) \
+	template<class ...Args> \
+	void alt(Args &&...args) { \
+		name(std::forward<Args>(args)...); \
+	}
+	COMPAT_SPELLING(analyse, analyze);
+	COMPAT_SPELLING(analyseStep, analyseStep);
+	COMPAT_SPELLING(analyseSteps, analyzeSteps);
+	COMPAT_SPELLING(synthesise, synthesize);
+	COMPAT_SPELLING(synthesiseStep, synthesizeStep);
+	COMPAT_SPELLING(synthesiseSteps, synthesizeSteps);
+
+	/// Input (only available so we can save/restore the input state)
+	struct Input {
+		void swap(Input &other) {
+			std::swap(pos, other.pos);
+			std::swap(buffer, other.buffer);
+		}
+		
+		Input & operator=(const Input &other) {
+			pos = other.pos;
+			buffer.assign(other.buffer.begin(), other.buffer.end());
+			return *this;
+		}
+	private:
+		friend struct DynamicSTFT;
+		size_t pos = 0;
+		std::vector<Sample> buffer;
+	};
+	Input input;
+	
+	/// Output (only available so we can save/restore the output state)
+	struct Output {
+		void swap(Output &other) {
+			std::swap(pos, other.pos);
+			std::swap(buffer, other.buffer);
+			std::swap(windowProducts, other.windowProducts);
+		}
+
+		Output & operator=(const Output &other) {
+			pos = other.pos;
+			buffer.assign(other.buffer.begin(), other.buffer.end());
+			windowProducts.assign(other.windowProducts.begin(), other.windowProducts.end());
+			return *this;
+		}
+	private:
+		friend struct DynamicSTFT;
+		size_t pos = 0;
+		std::vector<Sample> buffer;
+		std::vector<Sample> windowProducts;
+	};
+	Output output;
+
+private:
+	static constexpr Sample almostZero = 1e-30;
+
+	size_t _analysisChannels, _synthesisChannels, _inputLengthSamples, _blockSamples, _fftSamples, _fftBins;
+	size_t _defaultInterval = 0;
+
+	std::vector<Sample> _analysisWindow, _synthesisWindow;
+	size_t _analysisOffset = 0, _synthesisOffset = 0;
+
+	std::vector<Complex> spectrumBuffer;
+	std::vector<Sample> timeBuffer;
+
+	size_t _samplesSinceSynthesis = 0, _samplesSinceAnalysis = 0;
+	
+	void addWindowProduct() {
+		_samplesSinceSynthesis = 0;
+
+		int windowShift = int(_synthesisOffset) - int(_analysisOffset);
+		size_t wMin = std::max<ptrdiff_t>(0, windowShift);
+		size_t wMax = std::min<ptrdiff_t>(_blockSamples, int(_blockSamples) + windowShift);
+
+		Sample *windowProduct = output.windowProducts.data();
+		size_t outputWrapIndex = _blockSamples - output.pos;
+		size_t chunk1 = std::min<size_t>(wMax, std::max<size_t>(wMin, outputWrapIndex));
+		for (size_t i = wMin; i < chunk1; ++i) {
+			Sample wa = _analysisWindow[i - windowShift];
+			Sample ws = _synthesisWindow[i];
+			size_t bi = output.pos + i;
+			windowProduct[bi] += wa*ws*_fftSamples;
+		}
+		for (size_t i = chunk1; i < wMax; ++i) {
+			Sample wa = _analysisWindow[i - windowShift];
+			Sample ws = _synthesisWindow[i];
+			size_t bi = i + output.pos - _blockSamples;
+			windowProduct[bi] += wa*ws*_fftSamples;
+		}
+	}
+	
+	// Copied from DSP library `windows.h`
+	class Kaiser {
+		inline static double bessel0(double x) {
+			const double significanceLimit = 1e-4;
+			double result = 0;
+			double term = 1;
+			double m = 0;
+			while (term > significanceLimit) {
+				result += term;
+				++m;
+				term *= (x*x)/(4*m*m);
+			}
+
+			return result;
+		}
+		double beta;
+		double invB0;
+		
+		static double heuristicBandwidth(double bandwidth) {
+			return bandwidth + 8/((bandwidth + 3)*(bandwidth + 3)) + 0.25*std::max(3 - bandwidth, 0.0);
+		}
+	public:
+		Kaiser(double beta) : beta(beta), invB0(1/bessel0(beta)) {}
+
+		static Kaiser withBandwidth(double bandwidth, bool heuristicOptimal=false) {
+			return Kaiser(bandwidthToBeta(bandwidth, heuristicOptimal));
+		}
+		static double bandwidthToBeta(double bandwidth, bool heuristicOptimal=false) {
+			if (heuristicOptimal) { // Heuristic based on numerical search
+				bandwidth = heuristicBandwidth(bandwidth);
+			}
+			bandwidth = std::max(bandwidth, 2.0);
+			double alpha = std::sqrt(bandwidth*bandwidth*0.25 - 1);
+			return alpha*M_PI;
+		}
+		
+		template<typename Data>
+		void fill(Data &&data, size_t size, double warp, bool isForSynthesis) const {
+			double invSize = 1.0/size;
+			size_t offsetI = (size&1) ? 1 : (isForSynthesis ? 0 : 2);
+			for (size_t i = 0; i < size; ++i) {
+				double r = (2*i + offsetI)*invSize - 1;
+				r = (r + warp)/(1 + r*warp);
+				double arg = std::sqrt(1 - r*r);
+				data[i] = bessel0(beta*arg)*invB0;
+			}
+			if (warp) {
+				// Warp window vertically as well, to restore some width
+				for (size_t i = 0; i < size; ++i) {
+					data[i] *= std::sqrt((warp + 1)/(1 + warp*(2*data[i] - 1)));
+				}
+			}
+		}
+	};
+
+	class ApproximateConfinedGaussian {
+		double gaussianFactor;
+		
+		double gaussian(double x) const {
+			return std::exp(-x*x*gaussianFactor);
+		}
+	public:
+		static double bandwidthToSigma(double bandwidth) {
+			return 0.3/std::sqrt(bandwidth);
+		}
+		static ApproximateConfinedGaussian withBandwidth(double bandwidth) {
+			return ApproximateConfinedGaussian(bandwidthToSigma(bandwidth));
+		}
+
+		ApproximateConfinedGaussian(double sigma) : gaussianFactor(0.0625/(sigma*sigma)) {}
+	
+		/// Fills an arbitrary container
+		template<typename Data>
+		void fill(Data &&data, size_t size, double warp, bool isForSynthesis) const {
+			double invSize = 1.0/size;
+			double offsetScale = gaussian(1)/(gaussian(3) + gaussian(-1));
+			double norm = 1/(gaussian(0) - 2*offsetScale*(gaussian(2)));
+			size_t offsetI = (size&1) ? 1 : (isForSynthesis ? 0 : 2);
+			for (size_t i = 0; i < size; ++i) {
+				double r = (2*i + offsetI)*invSize - 1;
+				r = (r + warp)/(1 + r*warp);
+				data[i] = norm*(gaussian(r) - offsetScale*(gaussian(r - 2) + gaussian(r + 2)));
+			}
+			if (warp) {
+				// Warp window vertically as well, to restore some width
+				for (size_t i = 0; i < size; ++i) {
+					data[i] *= std::sqrt((warp + 1)/(1 + warp*(2*data[i] - 1)));
+				}
+			}
+		}
+	};
+
+	template<typename Data>
+	void forcePerfectReconstruction(Data &&data, size_t windowLength, size_t interval) {
+		for (size_t i = 0; i < interval; ++i) {
+			double sum2 = 0;
+			for (size_t index = i; index < windowLength; index += interval) {
+				sum2 += data[index]*data[index];
+			}
+			double factor = 1/std::sqrt(sum2);
+			for (size_t index = i; index < windowLength; index += interval) {
+				data[index] *= factor;
+			}
+		}
+	}
+};
+
+}} // namespace
+
+#endif // include guard

--- a/third_party/signalsmith-stretch/signalsmith-stretch.h
+++ b/third_party/signalsmith-stretch/signalsmith-stretch.h
@@ -1,0 +1,1060 @@
+#ifndef SIGNALSMITH_STRETCH_H
+#define SIGNALSMITH_STRETCH_H
+
+#include "signalsmith-linear/stft.h" // https://github.com/Signalsmith-Audio/linear
+
+#include <vector>
+#include <array>
+#include <algorithm>
+#include <functional>
+#include <random>
+#include <limits>
+#include <type_traits>
+
+namespace signalsmith { namespace stretch {
+
+namespace _impl {
+	template<bool conjugateSecond=false, typename V>
+	static std::complex<V> mul(const std::complex<V> &a, const std::complex<V> &b) {
+		return conjugateSecond ? std::complex<V>{
+			b.real()*a.real() + b.imag()*a.imag(),
+				b.real()*a.imag() - b.imag()*a.real()
+		} : std::complex<V>{
+			a.real()*b.real() - a.imag()*b.imag(),
+			a.real()*b.imag() + a.imag()*b.real()
+		};
+	}
+	template<typename V>
+	static V norm(const std::complex<V> &a) {
+		V r = a.real(), i = a.imag();
+		return r*r + i*i;
+	}
+}
+
+template<typename Sample=float, class RandomEngine=void>
+struct SignalsmithStretch {
+	static constexpr size_t version[3] = {1, 3, 2};
+
+	SignalsmithStretch() : randomEngine(std::random_device{}()) {}
+	SignalsmithStretch(long seed) : randomEngine(seed) {}
+		
+	// The difference between the internal position (centre of a block) and the input samples you're supplying
+	int inputLatency() const {
+		return int(stft.analysisLatency());
+	}
+	int outputLatency() const {
+		return int(stft.synthesisLatency() + _splitComputation*stft.defaultInterval());
+	}
+	
+	void reset() {
+		stft.reset(0.1);
+		stashedInput = stft.input;
+		stashedOutput = stft.output;
+		
+		prevInputOffset = -1;
+		_channelBands.assign(_channelBands.size(), Band());
+		silenceCounter = 0;
+		didSeek = false;
+		blockProcess = {};
+		freqEstimateWeighted = freqEstimateWeight = 0;
+	}
+
+	// Configures using a default preset
+	void presetDefault(int nChannels, Sample sampleRate, bool splitComputation=false) {
+		configure(nChannels, static_cast<int>(sampleRate*0.12), static_cast<int>(sampleRate*0.03), splitComputation);
+	}
+	void presetCheaper(int nChannels, Sample sampleRate, bool splitComputation=true) {
+		configure(nChannels, static_cast<int>(sampleRate*0.1), static_cast<int>(sampleRate*0.04), splitComputation);
+	}
+
+	// Manual setup
+	void configure(int nChannels, int blockSamples, int intervalSamples, bool splitComputation=false) {
+		_splitComputation = splitComputation;
+		channels = nChannels;
+		stft.configure(channels, channels, blockSamples, intervalSamples + 1);
+		stft.setInterval(intervalSamples, stft.kaiser);
+		stft.reset(Sample(0.1));
+		stashedInput = stft.input;
+		stashedOutput = stft.output;
+
+		bands = int(stft.bands());
+		_channelBands.assign(bands*channels, Band());
+		
+		peaks.reserve(bands/2);
+		energy.resize(bands);
+		smoothedEnergy.resize(bands);
+		outputMap.resize(bands);
+		channelPredictions.resize(channels*bands);
+
+		blockProcess = {};
+		formantMetric.resize(bands + 2);
+
+		tmpProcessBuffer.resize(blockSamples + intervalSamples);
+		tmpPreRollBuffer.resize(outputLatency()*channels);
+	}
+	// For querying the existing config
+	int blockSamples() const {
+		return int(stft.blockSamples());
+	}
+	int intervalSamples() const {
+		return int(stft.defaultInterval());
+	}
+	bool splitComputation() const {
+		return _splitComputation;
+	}
+
+	/// Frequency multiplier, and optional tonality limit (as multiple of sample-rate)
+	void setTransposeFactor(Sample multiplier, Sample tonalityLimit=0) {
+		freqMultiplier = multiplier;
+		if (tonalityLimit > 0) {
+			freqTonalityLimit = tonalityLimit/std::sqrt(multiplier); // compromise between input and output limits
+		} else {
+			freqTonalityLimit = 1;
+		}
+		customFreqMap = nullptr;
+	}
+	void setTransposeSemitones(Sample semitones, Sample tonalityLimit=0) {
+		setTransposeFactor(std::pow(2, semitones/12), tonalityLimit);
+	}
+	// Sets a custom frequency map - should be monotonically increasing
+	void setFreqMap(std::function<Sample(Sample)> inputToOutput) {
+		customFreqMap = inputToOutput;
+	}
+
+	void setFormantFactor(Sample multiplier, bool compensatePitch=false) {
+		formantMultiplier = multiplier;
+		invFormantMultiplier = 1/multiplier;
+		formantCompensation = compensatePitch;
+	}
+	void setFormantSemitones(Sample semitones, bool compensatePitch=false) {
+		setFormantFactor(std::pow(2, semitones/12), compensatePitch);
+	}
+	// Rough guesstimate of the fundamental frequency, used for formant analysis. 0 means attempting to detect the pitch
+	void setFormantBase(Sample baseFreq=0) {
+		formantBaseFreq = baseFreq;
+	}
+	
+	// Provide previous input ("pre-roll") to smoothly change the input location without interrupting the output.  This doesn't do any calculation, just copies intput to a buffer.
+	// You should ideally feed it `seekLength()` frames of input, unless it's directly after a `.reset()` (in which case `.outputSeek()` might be a better choice)
+	template<class Inputs>
+	void seek(Inputs &&inputs, int inputSamples, double playbackRate) {
+		tmpProcessBuffer.resize(0);
+		tmpProcessBuffer.resize(stft.blockSamples() + stft.defaultInterval());
+
+		int startIndex = std::max<int>(0, inputSamples - int(tmpProcessBuffer.size())); // start position in input
+		int padStart = int(tmpProcessBuffer.size() + startIndex) - inputSamples; // start position in tmpProcessBuffer
+
+		Sample totalEnergy = 0;
+		for (int c = 0; c < channels; ++c) {
+			auto &&inputChannel = inputs[c];
+			for (int i = startIndex; i < inputSamples; ++i) {
+				Sample s = inputChannel[i];
+				totalEnergy += s*s;
+				tmpProcessBuffer[i - startIndex + padStart] = s;
+			}
+			
+			stft.writeInput(c, tmpProcessBuffer.size(), tmpProcessBuffer.data());
+		}
+		stft.moveInput(tmpProcessBuffer.size());
+		if (totalEnergy >= noiseFloor) {
+			silenceCounter = 0;
+			silenceFirst = true;
+		}
+		didSeek = true;
+		seekTimeFactor = (playbackRate*stft.defaultInterval() > 1) ? 1/playbackRate : stft.defaultInterval();
+	}
+	int seekLength() const {
+		return int(stft.blockSamples() + stft.defaultInterval());
+	}
+	
+	// Moves the input position *and* pre-calculates some output, so that the next samples returned from `.process()` are aligned to the beginning of the sample.
+	// The time-stretch rate is inferred from `inputLength`, so use `.outputSeekLength()` to get a correct value for that.
+	template<class Inputs>
+	void outputSeek(Inputs &&inputs, int inputLength) {
+		// TODO: add fade-out parameter to avoid clicks, instead of doing a full reset
+		reset();
+		// Assume we've been handed enough surplus input to produce `outputLatency()` samples of pre-roll
+		int surplusInput = std::max<int>(inputLength - inputLatency(), 0);
+		Sample playbackRate = surplusInput/Sample(outputLatency());
+
+		// Move the input position to the start of the sound
+		int seekSamples = inputLength - surplusInput;
+		seek(inputs, seekSamples, playbackRate);
+		
+		tmpPreRollBuffer.resize(outputLatency()*channels);
+		struct BufferOutput {
+			Sample *samples;
+			int length;
+			
+			Sample * operator[](int c) {
+				return samples + c*length;
+			}
+		} preRollOutput{tmpPreRollBuffer.data(), outputLatency()};
+		
+		// Use the surplus input to produce pre-roll output
+		OffsetIO<Inputs> offsetInput{inputs, seekSamples};
+		process(offsetInput, surplusInput, preRollOutput, preRollOutput.length);
+		
+		// put the thing down, flip it and reverse it
+		for (auto &v : tmpPreRollBuffer) v = -v;
+		for (int c = 0; c < channels; ++c) {
+			std::reverse(preRollOutput[c], preRollOutput[c] + preRollOutput.length);
+			stft.addOutput(c, preRollOutput.length, preRollOutput[c]);
+		}
+	}
+	int outputSeekLength(Sample playbackRate) const {
+		return inputLatency() + playbackRate*outputLatency();
+	}
+
+	template<class Inputs, class Outputs>
+	void process(Inputs &&inputs, int inputSamples, Outputs &&outputs, int outputSamples) {
+#ifdef SIGNALSMITH_STRETCH_PROFILE_PROCESS_START
+		SIGNALSMITH_STRETCH_PROFILE_PROCESS_START(inputSamples, outputSamples);
+#endif
+		int prevCopiedInput = 0;
+		auto copyInput = [&](int toIndex){
+
+			int length = std::min<int>(int(stft.blockSamples() + stft.defaultInterval()), toIndex - prevCopiedInput);
+			tmpProcessBuffer.resize(length);
+			int offset = toIndex - length;
+			for (int c = 0; c < channels; ++c) {
+				auto &&inputBuffer = inputs[c];
+				for (int i = 0; i < length; ++i) {
+					tmpProcessBuffer[i] = inputBuffer[i + offset];
+				}
+				stft.writeInput(c, length, tmpProcessBuffer.data());
+			}
+			stft.moveInput(length);
+			prevCopiedInput = toIndex;
+		};
+
+		Sample totalEnergy = 0;
+		for (int c = 0; c < channels; ++c) {
+			auto &&inputChannel = inputs[c];
+			for (int i = 0; i < inputSamples; ++i) {
+				Sample s = inputChannel[i];
+				totalEnergy += s*s;
+			}
+		}
+
+		if (totalEnergy < noiseFloor) {
+			if (silenceCounter >= 2*stft.blockSamples()) {
+				if (silenceFirst) { // first block of silence processing
+					silenceFirst = false;
+					//stft.reset();
+					blockProcess = {};
+					for (auto &b : _channelBands) {
+						b.input = b.prevInput = b.output = 0;
+						b.inputEnergy = 0;
+					}
+				}
+			
+				if (inputSamples > 0) {
+					// copy from the input, wrapping around if needed
+					for (int outputIndex = 0; outputIndex < outputSamples; ++outputIndex) {
+						int inputIndex = outputIndex%inputSamples;
+						for (int c = 0; c < channels; ++c) {
+							outputs[c][outputIndex] = inputs[c][inputIndex];
+						}
+					}
+				} else {
+					for (int c = 0; c < channels; ++c) {
+						auto &&outputChannel = outputs[c];
+						for (int outputIndex = 0; outputIndex < outputSamples; ++outputIndex) {
+							outputChannel[outputIndex] = 0;
+						}
+					}
+				}
+
+				// Store input in history buffer
+				copyInput(inputSamples);
+				return;
+			} else {
+				silenceCounter += inputSamples;
+			}
+		} else {
+			silenceCounter = 0;
+			silenceFirst = true;
+		}
+		
+		for (int outputIndex = 0; outputIndex < outputSamples; ++outputIndex) {
+			bool newBlock = blockProcess.samplesSinceLast >= stft.defaultInterval();
+			if (newBlock) {
+				blockProcess.step = 0;
+				blockProcess.steps = 0; // how many processing steps this block will have
+				blockProcess.samplesSinceLast = 0;
+				
+				// Time to process a spectrum!  Where should it come from in the input?
+				int inputOffset = static_cast<int>(std::round(outputIndex*Sample(inputSamples)/outputSamples));
+				int inputInterval = inputOffset - prevInputOffset;
+				prevInputOffset = inputOffset;
+				
+				copyInput(inputOffset);
+				stashedInput = stft.input; // save the input state, since that's what we'll analyse later
+				if (_splitComputation) {
+					stashedOutput = stft.output; // save the current output, and read from it
+					stft.moveOutput(stft.defaultInterval()); // the actual input jumps forward in time by one interval, ready for the synthesis
+				}
+
+				blockProcess.newSpectrum = didSeek || (inputInterval > 0);
+				blockProcess.mappedFrequencies = customFreqMap || freqMultiplier != 1;
+				if (blockProcess.newSpectrum) {
+					// make sure the previous input is the correct distance in the past (give or take 1 sample)
+					blockProcess.reanalysePrev = didSeek || std::abs(inputInterval - int(stft.defaultInterval())) > 1;
+					if (blockProcess.reanalysePrev) blockProcess.steps += stft.analyseSteps() + 1;
+
+					// analyse a new input
+					blockProcess.steps += stft.analyseSteps() + 1;
+				}
+				
+				blockProcess.processFormants = formantMultiplier != 1 || (formantCompensation && blockProcess.mappedFrequencies);
+
+				blockProcess.timeFactor = didSeek ? seekTimeFactor : stft.defaultInterval()/static_cast<Sample>(std::max(1, inputInterval));
+				didSeek = false;
+
+				updateProcessSpectrumSteps();
+				blockProcess.steps += processSpectrumSteps;
+
+				blockProcess.steps += stft.synthesiseSteps() + 1;
+			}
+			
+			size_t processToStep = newBlock ? blockProcess.steps : 0;
+			if (_splitComputation) {
+				Sample processRatio = Sample(blockProcess.samplesSinceLast + 1)/stft.defaultInterval();
+				processToStep = std::min(blockProcess.steps, static_cast<size_t>((blockProcess.steps + 0.999f)*processRatio));
+			}
+			
+			while (blockProcess.step < processToStep) {
+				size_t step = blockProcess.step++;
+#ifdef SIGNALSMITH_STRETCH_PROFILE_PROCESS_STEP
+				SIGNALSMITH_STRETCH_PROFILE_PROCESS_STEP(step, blockProcess.steps);
+#endif
+				if (blockProcess.newSpectrum) {
+					if (blockProcess.reanalysePrev) {
+						// analyse past input
+						if (step < stft.analyseSteps()) {
+							stashedInput.swap(stft.input);
+							stft.analyseStep(step, stft.defaultInterval());
+							stashedInput.swap(stft.input);
+							continue;
+						}
+						step -= stft.analyseSteps();
+						if (step < 1) {
+							// Copy previous analysis to our band objects
+							for (int c = 0; c < channels; ++c) {
+								auto channelBands = bandsForChannel(c);
+								auto *spectrumBands = stft.spectrum(c);
+								for (int b = 0; b < bands; ++b) {
+									channelBands[b].prevInput = spectrumBands[b];
+								}
+							}
+							continue;
+						}
+						step -= 1;
+					}
+
+					// Analyse latest (stashed) input
+					if (step < stft.analyseSteps()) {
+						stashedInput.swap(stft.input);
+						stft.analyseStep(step);
+						stashedInput.swap(stft.input);
+						continue;
+					}
+					step -= stft.analyseSteps();
+					if (step < 1) {
+						// Copy analysed spectrum into our band objects
+						for (int c = 0; c < channels; ++c) {
+							auto channelBands = bandsForChannel(c);
+							auto *spectrumBands = stft.spectrum(c);
+							for (int b = 0; b < bands; ++b) {
+								channelBands[b].input = spectrumBands[b];
+							}
+						}
+						continue;
+					}
+					step -= 1;
+				}
+
+				if (step < processSpectrumSteps) {
+					processSpectrum(step);
+					continue;
+				}
+				step -= processSpectrumSteps;
+
+				if (step < 1) {
+					// Copy band objects into spectrum
+					for (int c = 0; c < channels; ++c) {
+						auto channelBands = bandsForChannel(c);
+						auto *spectrumBands = stft.spectrum(c);
+						for (int b = 0; b < bands; ++b) {
+							spectrumBands[b] = channelBands[b].output;
+						}
+					}
+					continue;
+				}
+				step -= 1;
+				
+				if (step < stft.synthesiseSteps()) {
+					stft.synthesiseStep(step);
+					continue;
+				}
+			}
+#ifdef SIGNALSMITH_STRETCH_PROFILE_PROCESS_ENDSTEP
+			SIGNALSMITH_STRETCH_PROFILE_PROCESS_ENDSTEP();
+#endif
+
+			++blockProcess.samplesSinceLast;
+			if (_splitComputation) stashedOutput.swap(stft.output);
+			for (int c = 0; c < channels; ++c) {
+				auto &&outputChannel = outputs[c];
+				Sample v = 0;
+				stft.readOutput(c, 1, &v);
+				outputChannel[outputIndex] = v;
+			}
+			stft.moveOutput(1);
+			if (_splitComputation) stashedOutput.swap(stft.output);
+		}
+		
+		copyInput(inputSamples);
+		prevInputOffset -= inputSamples;
+#ifdef SIGNALSMITH_STRETCH_PROFILE_PROCESS_END
+		SIGNALSMITH_STRETCH_PROFILE_PROCESS_END();
+#endif
+	}
+
+	// Read the remaining output, providing no further input.  If `outputSamples` is more than one interval, it will compute additional blocks assuming a zero-valued input
+	template<class Outputs>
+	void flush(Outputs &&outputs, int outputSamples, Sample playbackRate=0) {
+		struct Zeros {
+			struct Channel {
+				Sample operator[](int) {
+					return 0;
+				}
+			};
+			Channel operator[](int) {
+				return {};
+			}
+		} zeros;
+		// If we're asked for more than an interval of extra output, then zero-pad the input
+		int outputBlock = std::max<int>(0, outputSamples - stft.defaultInterval());
+		if (outputBlock > 0) process(zeros, outputBlock*playbackRate, outputs, outputBlock);
+
+		int tailSamples = outputSamples - outputBlock; // at most one interval
+		tmpProcessBuffer.resize(tailSamples);
+		stft.finishOutput(1);
+		for (int c = 0; c < channels; ++c) {
+			stft.readOutput(c, tailSamples, tmpProcessBuffer.data());
+			auto &&outputChannel = outputs[c];
+			for (int i = 0; i < tailSamples; ++i) {
+				outputChannel[outputBlock + i] = tmpProcessBuffer[i];
+			}
+			stft.readOutput(c, tailSamples, tailSamples, tmpProcessBuffer.data());
+			for (int i = 0; i < tailSamples; ++i) {
+				outputChannel[outputBlock + tailSamples - 1 - i] -= tmpProcessBuffer[i];
+			}
+		}
+		stft.reset(0.1f);
+		// Reset the phase-vocoder stuff, so the next block gets a fresh start
+		for (int c = 0; c < channels; ++c) {
+			auto channelBands = bandsForChannel(c);
+			for (int b = 0; b < bands; ++b) {
+				channelBands[b].prevInput = channelBands[b].output = 0;
+			}
+		}
+	}
+
+	// Process a complete audio buffer all in one go
+	template<class Inputs, class Outputs>
+	bool exact(Inputs &&inputs, int inputSamples, Outputs &&outputs, int outputSamples) {
+		Sample playbackRate = inputSamples/Sample(outputSamples);
+		auto seekLength = outputSeekLength(playbackRate);
+		if (inputSamples < seekLength) {
+			// to short for this - zero the output just to be polite
+			for (int c = 0; c < channels; ++c) {
+				auto &&channel = outputs[c];
+				for (int i = 0; i < outputSamples; ++i) {
+					channel[i] = 0;
+				}
+			}
+			return false;
+		}
+
+		outputSeek(inputs, seekLength);
+
+		int outputIndex = outputSamples - seekLength/playbackRate;
+		OffsetIO<Inputs> offsetInput{inputs, seekLength};
+		process(offsetInput, inputSamples - seekLength, outputs, outputIndex);
+		
+		OffsetIO<Outputs> offsetOutput{outputs, outputIndex};
+		flush(offsetOutput, outputSamples - outputIndex, playbackRate);
+		return true;
+	}
+
+private:
+	bool _splitComputation = false;
+	struct {
+		size_t samplesSinceLast = std::numeric_limits<size_t>::max();
+		size_t steps = 0;
+		size_t step = 0;
+		
+		bool newSpectrum = false;
+		bool reanalysePrev = false;
+		bool mappedFrequencies = false;
+		bool processFormants = false;
+		Sample timeFactor;
+	} blockProcess;
+
+	using Complex = std::complex<Sample>;
+	static constexpr Sample noiseFloor{Sample(1e-15)};
+	static constexpr Sample maxCleanStretch{2}; // time-stretch ratio before we start randomising phases
+	size_t silenceCounter = 0;
+	bool silenceFirst = true;
+
+	Sample freqMultiplier = 1, freqTonalityLimit = 0.5;
+	std::function<Sample(Sample)> customFreqMap = nullptr;
+	
+	bool formantCompensation = false; // compensate for pitch/freq change
+	Sample formantMultiplier = 1, invFormantMultiplier = 1;
+
+	using STFT = signalsmith::linear::DynamicSTFT<Sample, false, true>;
+	STFT stft;
+	typename STFT::Input stashedInput;
+	typename STFT::Output stashedOutput;
+	
+	std::vector<Sample> tmpProcessBuffer, tmpPreRollBuffer;
+
+	int channels = 0, bands = 0;
+	int prevInputOffset = -1;
+	bool didSeek = false;
+	Sample seekTimeFactor = 1;
+
+	Sample bandToFreq(Sample b) const {
+		return stft.binToFreq(b);
+	}
+	Sample freqToBand(Sample f) const {
+		return stft.freqToBin(f);
+	}
+	
+	struct Band {
+		Complex input, prevInput{0};
+		Complex output{0};
+		Sample inputEnergy;
+	};
+	std::vector<Band> _channelBands;
+	Band * bandsForChannel(int channel) {
+		return _channelBands.data() + channel*bands;
+	}
+	template<Complex Band::*member>
+	Complex getBand(int channel, int index) {
+		if (index < 0 || index >= bands) return 0;
+		return _channelBands[index + channel*bands].*member;
+	}
+	template<Complex Band::*member>
+	Complex getFractional(int channel, int lowIndex, Sample fractional) {
+		Complex low = getBand<member>(channel, lowIndex);
+		Complex high = getBand<member>(channel, lowIndex + 1);
+		return low + (high - low)*fractional;
+	}
+	template<Complex Band::*member>
+	Complex getFractional(int channel, Sample inputIndex) {
+		int lowIndex = static_cast<int>(std::floor(inputIndex));
+		Sample fracIndex = inputIndex - lowIndex;
+		return getFractional<member>(channel, lowIndex, fracIndex);
+	}
+	template<Sample Band::*member>
+	Sample getBand(int channel, int index) {
+		if (index < 0 || index >= bands) return 0;
+		return _channelBands[index + channel*bands].*member;
+	}
+	template<Sample Band::*member>
+	Sample getFractional(int channel, int lowIndex, Sample fractional) {
+		Sample low = getBand<member>(channel, lowIndex);
+		Sample high = getBand<member>(channel, lowIndex + 1);
+		return low + (high - low)*fractional;
+	}
+	template<Sample Band::*member>
+	Sample getFractional(int channel, Sample inputIndex) {
+		int lowIndex = std::floor(inputIndex);
+		Sample fracIndex = inputIndex - lowIndex;
+		return getFractional<member>(channel, lowIndex, fracIndex);
+	}
+
+	struct Peak {
+		Sample input, output;
+	};
+	std::vector<Peak> peaks;
+	std::vector<Sample> energy, smoothedEnergy;
+	struct PitchMapPoint {
+		Sample inputBin, freqGrad;
+	};
+	std::vector<PitchMapPoint> outputMap;
+	
+	struct Prediction {
+		Sample energy = 0;
+		Complex input;
+
+		Complex makeOutput(Complex phase) {
+			Sample phaseNorm = _impl::norm(phase);
+			if (phaseNorm <= noiseFloor) {
+				phase = input; // prediction is too weak, fall back to the input
+				phaseNorm = _impl::norm(input) + noiseFloor;
+			}
+			return phase*std::sqrt(energy/phaseNorm);
+		}
+	};
+	std::vector<Prediction> channelPredictions;
+	Prediction * predictionsForChannel(int c) {
+		return channelPredictions.data() + c*bands;
+	}
+
+	// If RandomEngine=void, use std::default_random_engine;
+	using RandomEngineImpl = typename std::conditional<
+		std::is_void<RandomEngine>::value,
+		std::default_random_engine,
+		RandomEngine
+	>::type;
+	RandomEngineImpl randomEngine;
+
+	size_t processSpectrumSteps = 0;
+	static constexpr size_t splitMainPrediction = 8; // it's just heavy, since we're blending up to 4 different phase predictions
+	void updateProcessSpectrumSteps() {
+		processSpectrumSteps = 0;
+		if (blockProcess.newSpectrum) processSpectrumSteps += channels;
+		if (blockProcess.mappedFrequencies) {
+			processSpectrumSteps += smoothEnergySteps;
+			processSpectrumSteps += 1; // findPeaks
+		}
+		processSpectrumSteps += 1; // updating the output map
+		processSpectrumSteps += channels; // preliminary phase-vocoder prediction
+		processSpectrumSteps += splitMainPrediction;
+		if (blockProcess.newSpectrum) processSpectrumSteps += 1; // .input -> .prevInput
+		if (blockProcess.processFormants) processSpectrumSteps += 3;
+	}
+	void processSpectrum(size_t step) {
+		Sample timeFactor = blockProcess.timeFactor;
+		
+		Sample smoothingBins = Sample(stft.fftSamples())/stft.defaultInterval();
+		int longVerticalStep = static_cast<int>(std::round(smoothingBins));
+		timeFactor = std::max<Sample>(timeFactor, 1/maxCleanStretch);
+		bool randomTimeFactor = (timeFactor > maxCleanStretch);
+		std::uniform_real_distribution<Sample> timeFactorDist(maxCleanStretch*2*randomTimeFactor - timeFactor, timeFactor);
+
+		if (blockProcess.newSpectrum) {
+			if (step < size_t(channels)) {
+				int channel = int(step);
+				auto bins = bandsForChannel(channel);
+
+				Complex rot = std::polar(Sample(1), bandToFreq(0)*stft.defaultInterval()*Sample(2*M_PI));
+				Sample freqStep = bandToFreq(1) - bandToFreq(0);
+				Complex rotStep = std::polar(Sample(1), freqStep*stft.defaultInterval()*Sample(2*M_PI));
+				 
+				for (int b = 0; b < bands; ++b) {
+					auto &bin = bins[b];
+					bin.output = _impl::mul(bin.output, rot);
+					bin.prevInput = _impl::mul(bin.prevInput, rot);
+					rot = _impl::mul(rot, rotStep);
+				}
+				return;
+			}
+			step -= channels;
+		}
+		if (blockProcess.mappedFrequencies) {
+			if (step < smoothEnergySteps) {
+				smoothEnergy(step, smoothingBins);
+				return;
+			}
+			step -= smoothEnergySteps;
+			if (step-- == 0) {
+				findPeaks();
+				return;
+			}
+		}
+		if (step-- == 0) {
+			if (blockProcess.mappedFrequencies) {
+				updateOutputMap();
+			} else { // we're not pitch-shifting, so no need to find peaks etc.
+				for (int c = 0; c < channels; ++c) {
+					Band *bins = bandsForChannel(c);
+					for (int b = 0; b < bands; ++b) {
+						bins[b].inputEnergy = _impl::norm(bins[b].input);
+					}
+				}
+
+				for (int b = 0; b < bands; ++b) {
+					outputMap[b] = {Sample(b), 1};
+				}
+			}
+			return;
+		}
+		if (blockProcess.processFormants) {
+			if (step < 3) {
+				updateFormants(step);
+				return;
+			}
+			step -= 3;
+		}
+		// Preliminary output prediction from phase-vocoder
+		if (step < size_t(channels)) {
+			int c = int(step);
+			Band *bins = bandsForChannel(c);
+			auto *predictions = predictionsForChannel(c);
+			for (int b = 0; b < bands; ++b) {
+				auto mapPoint = outputMap[b];
+				int lowIndex = static_cast<int>(std::floor(mapPoint.inputBin));
+				Sample fracIndex = mapPoint.inputBin - lowIndex;
+
+				Prediction &prediction = predictions[b];
+				Sample prevEnergy = prediction.energy;
+				prediction.energy = getFractional<&Band::inputEnergy>(c, lowIndex, fracIndex);
+				prediction.energy *= std::max<Sample>(0, mapPoint.freqGrad); // scale the energy according to local stretch factor
+				prediction.input = getFractional<&Band::input>(c, lowIndex, fracIndex);
+
+				auto &outputBin = bins[b];
+				Complex prevInput = getFractional<&Band::prevInput>(c, lowIndex, fracIndex);
+				Complex freqTwist = _impl::mul<true>(prediction.input, prevInput);
+				Complex phase = _impl::mul(outputBin.output, freqTwist);
+				outputBin.output = phase/(std::max(prevEnergy, prediction.energy) + noiseFloor);
+			}
+			return;
+		}
+		step -= channels;
+
+		if (step < splitMainPrediction) {
+			// Re-predict using phase differences between frequencies
+			size_t chunk = step;
+			int startB = int(bands*chunk/splitMainPrediction);
+			int endB = int(bands*(chunk + 1)/splitMainPrediction);
+			for (int b = startB; b < endB; ++b) {
+				// Find maximum-energy channel and calculate that
+				int maxChannel = 0;
+				Sample maxEnergy = predictionsForChannel(0)[b].energy;
+				for (int c = 1; c < channels; ++c) {
+					Sample e = predictionsForChannel(c)[b].energy;
+					if (e > maxEnergy) {
+						maxChannel = c;
+						maxEnergy = e;
+					}
+				}
+
+				auto *predictions = predictionsForChannel(maxChannel);
+				auto &prediction = predictions[b];
+				auto *bins = bandsForChannel(maxChannel);
+				auto &outputBin = bins[b];
+
+				Complex phase = 0;
+				auto mapPoint = outputMap[b];
+
+				// Upwards vertical steps
+				if (b > 0) {
+					Sample binTimeFactor = randomTimeFactor ? timeFactorDist(randomEngine) : timeFactor;
+					Complex downInput = getFractional<&Band::input>(maxChannel, mapPoint.inputBin - binTimeFactor);
+					Complex shortVerticalTwist = _impl::mul<true>(prediction.input, downInput);
+
+					auto &downBin = bins[b - 1];
+					phase += _impl::mul(downBin.output, shortVerticalTwist);
+					
+					if (b >= longVerticalStep) {
+						Complex longDownInput = getFractional<&Band::input>(maxChannel, mapPoint.inputBin - longVerticalStep*binTimeFactor);
+						Complex longVerticalTwist = _impl::mul<true>(prediction.input, longDownInput);
+
+						auto &longDownBin = bins[b - longVerticalStep];
+						phase += _impl::mul(longDownBin.output, longVerticalTwist);
+					}
+				}
+				// Downwards vertical steps
+				if (b < bands - 1) {
+					auto &upPrediction = predictions[b + 1];
+					auto &upMapPoint = outputMap[b + 1];
+
+					Sample binTimeFactor = randomTimeFactor ? timeFactorDist(randomEngine) : timeFactor;
+					Complex downInput = getFractional<&Band::input>(maxChannel, upMapPoint.inputBin - binTimeFactor);
+					Complex shortVerticalTwist = _impl::mul<true>(upPrediction.input, downInput);
+
+					auto &upBin = bins[b + 1];
+					phase += _impl::mul<true>(upBin.output, shortVerticalTwist);
+					
+					if (b < bands - longVerticalStep) {
+						auto &longUpPrediction = predictions[b + longVerticalStep];
+						auto &longUpMapPoint = outputMap[b + longVerticalStep];
+
+						Complex longDownInput = getFractional<&Band::input>(maxChannel, longUpMapPoint.inputBin - longVerticalStep*binTimeFactor);
+						Complex longVerticalTwist = _impl::mul<true>(longUpPrediction.input, longDownInput);
+
+						auto &longUpBin = bins[b + longVerticalStep];
+						phase += _impl::mul<true>(longUpBin.output, longVerticalTwist);
+					}
+				}
+
+				outputBin.output = prediction.makeOutput(phase);
+				
+				// All other bins are locked in phase
+				for (int c = 0; c < channels; ++c) {
+					if (c != maxChannel) {
+						auto &channelBin = bandsForChannel(c)[b];
+						auto &channelPrediction = predictionsForChannel(c)[b];
+						
+						Complex channelTwist = _impl::mul<true>(channelPrediction.input, prediction.input);
+						Complex channelPhase = _impl::mul(outputBin.output, channelTwist);
+						channelBin.output = channelPrediction.makeOutput(channelPhase);
+					}
+				}
+			}
+			return;
+		}
+		step -= splitMainPrediction;
+
+		if (blockProcess.newSpectrum) {
+			if (step-- == 0) {
+				for (auto &bin : _channelBands) {
+					bin.prevInput = bin.input;
+				}
+			}
+		}
+	}
+	
+	// Produces smoothed energy across all channels
+	static constexpr size_t smoothEnergySteps = 3;
+	Sample smoothEnergyState = 0;
+	void smoothEnergy(size_t step, Sample smoothingBins) {
+		Sample smoothingSlew = 1/(1 + smoothingBins*Sample(0.5));
+		if (step-- == 0) {
+			for (auto &e : energy) e = 0;
+			for (int c = 0; c < channels; ++c) {
+				Band *bins = bandsForChannel(c);
+				for (int b = 0; b < bands; ++b) {
+					Sample e = _impl::norm(bins[b].input);
+					bins[b].inputEnergy = e; // Used for interpolating prediction energy
+					energy[b] += e;
+				}
+			}
+			for (int b = 0; b < bands; ++b) {
+				smoothedEnergy[b] = energy[b];
+			}
+			smoothEnergyState = 0;
+			return;
+		}
+
+		// The two other steps are repeated smoothing passes, down and up
+		Sample e = smoothEnergyState;
+		for (int b = bands - 1; b >= 0; --b) {
+			e += (smoothedEnergy[b] - e)*smoothingSlew;
+			smoothedEnergy[b] = e;
+		}
+		for (int b = 0; b < bands; ++b) {
+			e += (smoothedEnergy[b] - e)*smoothingSlew;
+			smoothedEnergy[b] = e;
+		}
+		smoothEnergyState = e;
+	}
+	
+	Sample mapFreq(Sample freq) const {
+		if (customFreqMap) return customFreqMap(freq);
+		if (freq > freqTonalityLimit) {
+			return freq + (freqMultiplier - 1)*freqTonalityLimit;
+		}
+		return freq*freqMultiplier;
+	}
+	
+	// Identifies spectral peaks using energy across all channels
+	void findPeaks() {
+		peaks.resize(0);
+		
+		int start = 0;
+		while (start < bands) {
+			if (energy[start] > smoothedEnergy[start]) {
+				int end = start;
+				Sample bandSum = 0, energySum = 0;
+				while (end < bands && energy[end] > smoothedEnergy[end]) {
+					bandSum += end*energy[end];
+					energySum += energy[end];
+					++end;
+				}
+				Sample avgBand = bandSum/energySum;
+				Sample avgFreq = bandToFreq(avgBand);
+				peaks.emplace_back(Peak{avgBand, freqToBand(mapFreq(avgFreq))});
+
+				start = end;
+			}
+			++start;
+		}
+	}
+	
+	void updateOutputMap() {
+		if (peaks.empty()) {
+			for (int b = 0; b < bands; ++b) {
+				outputMap[b] = {Sample(b), 1};
+			}
+			return;
+		}
+		Sample bottomOffset = peaks[0].input - peaks[0].output;
+		for (int b = 0; b < std::min(bands, static_cast<int>(std::ceil(peaks[0].output))); ++b) {
+			outputMap[b] = {b + bottomOffset, 1};
+		}
+		// Interpolate between points
+		for (size_t p = 1; p < peaks.size(); ++p) {
+			const Peak &prev = peaks[p - 1], &next = peaks[p];
+			Sample rangeScale = 1/(next.output - prev.output);
+			Sample outOffset = prev.input - prev.output;
+			Sample outScale = next.input - next.output - prev.input + prev.output;
+			Sample gradScale = outScale*rangeScale;
+			int startBin = std::max(0, static_cast<int>(std::ceil(prev.output)));
+			int endBin = std::min(bands, static_cast<int>(std::ceil(next.output)));
+			for (int b = startBin; b < endBin; ++b) {
+				Sample r = (b - prev.output)*rangeScale;
+				Sample h = r*r*(3 - 2*r);
+				Sample outB = b + outOffset + h*outScale;
+				
+				Sample gradH = 6*r*(1 - r);
+				Sample gradB = 1 + gradH*gradScale;
+				
+				outputMap[b] = {outB, gradB};
+			}
+		}
+		Sample topOffset = peaks.back().input - peaks.back().output;
+		for (int b = std::max(0, static_cast<int>(peaks.back().output)); b < bands; ++b) {
+			outputMap[b] = {b + topOffset, 1};
+		}
+	}
+
+	// If we mapped formants the same way as mapFreq(), this would be the inverse
+	Sample invMapFormant(Sample freq) const {
+		if (freq*invFormantMultiplier > freqTonalityLimit) {
+			return freq + (1 - formantMultiplier)*freqTonalityLimit;
+		}
+		return freq*invFormantMultiplier;
+	}
+
+	Sample freqEstimateWeighted = 0;
+	Sample freqEstimateWeight = 0;
+	Sample estimateFrequency() {
+		// 3 highest peaks in the input
+		std::array<int, 3> peakIndices{0, 0, 0};
+		for (int b = 1; b < bands - 1; ++b) {
+			Sample e = formantMetric[b];
+			// local maxima only
+			if (e < formantMetric[b - 1] || e <= formantMetric[b + 1]) continue;
+			
+			if (e > formantMetric[peakIndices[0]]) {
+				if (e > formantMetric[peakIndices[1]]) {
+					if (e > formantMetric[peakIndices[2]]) {
+						peakIndices = {peakIndices[1], peakIndices[2], b};
+					} else {
+						peakIndices = {peakIndices[1], b, peakIndices[2]};
+					}
+				} else {
+					peakIndices[0] = b;
+				}
+			}
+		}
+		
+		// VERY rough pitch estimation
+		int peakEstimate = peakIndices[2];
+		if (formantMetric[peakIndices[1]] > formantMetric[peakIndices[2]]*0.1) {
+			int diff = std::abs(peakEstimate - peakIndices[1]);
+			if (diff > peakEstimate/8 && diff < peakEstimate*7/8) peakEstimate = peakEstimate%diff;
+			if (formantMetric[peakIndices[0]] > formantMetric[peakIndices[2]]*0.01) {
+				diff = std::abs(peakEstimate - peakIndices[0]);
+				if (diff > peakEstimate/8 && diff < peakEstimate*7/8) peakEstimate = peakEstimate%diff;
+			}
+		}
+		Sample weight = formantMetric[peakIndices[2]];
+		// Smooth it out a bit
+		freqEstimateWeighted += (peakEstimate*weight - freqEstimateWeighted)*Sample(0.25);
+		freqEstimateWeight += (weight - freqEstimateWeight)*Sample(0.25);
+		
+		return freqEstimateWeighted/(freqEstimateWeight + Sample(1e-30));
+	}
+	
+	Sample freqEstimate;
+	
+	std::vector<Sample> formantMetric;
+	Sample formantBaseFreq = 0;
+	void updateFormants(size_t step) {
+		if (step-- == 0) {
+			for (auto &e : formantMetric) e = 0;
+			for (int c = 0; c < channels; ++c) {
+				Band *bins = bandsForChannel(c);
+				for (int b = 0; b < bands; ++b) {
+					formantMetric[b] += bins[b].inputEnergy;
+				}
+			}
+
+			freqEstimate = freqToBand(formantBaseFreq);
+			if (formantBaseFreq <= 0) freqEstimate = estimateFrequency();
+		} else if (step-- == 0) {
+			Sample decay = 1 - 1/(freqEstimate*Sample(0.5) + 1);
+			Sample e = 0;
+			for (size_t repeat = 0; repeat < 2; ++repeat) {
+				for (int b = bands - 1; b >= 0; --b) {
+					e = std::max(formantMetric[b], e*decay);
+					formantMetric[b] = e;
+				}
+				for (int b = 0; b < bands; ++b) {
+					e = std::max(formantMetric[b], e*decay);
+					formantMetric[b] = e;
+				}
+			}
+			decay = 1/decay;
+			for (size_t repeat = 0; repeat < 2; ++repeat) {
+				for (int b = bands - 1; b >= 0; --b) {
+					e = std::min(formantMetric[b], e*decay);
+					formantMetric[b] = e;
+				}
+				for (int b = 0; b < bands; ++b) {
+					e = std::min(formantMetric[b], e*decay);
+					formantMetric[b] = e;
+				}
+			}
+		} else {
+			auto getFormant = [&](Sample band) -> Sample {
+				if (band < 0) return 0;
+				band = std::min(band, static_cast<Sample>(bands));
+				int floorBand = std::floor(band);
+				Sample fracBand = band - floorBand;
+				Sample low = formantMetric[floorBand], high = formantMetric[floorBand + 1];
+				return low + (high - low)*fracBand;
+			};
+
+			for (int b = 0; b < bands; ++b) {
+				Sample inputF = bandToFreq(static_cast<Sample>(b));
+				Sample outputF = formantCompensation ? mapFreq(inputF) : inputF;
+				outputF = invMapFormant(outputF);
+
+				Sample inputE = formantMetric[b];
+				Sample targetE = getFormant(freqToBand(outputF));
+
+				Sample formantRatio = targetE/(inputE + Sample(1e-30));
+				Sample energyRatio = formantRatio;
+
+				for (int c = 0; c < channels; ++c) {
+					Band *bins = bandsForChannel(c);
+					// This is what's used to decide the output energy, so this affects the output
+					bins[b].inputEnergy *= energyRatio;
+				}
+			}
+		}
+	}
+
+	// Proxy class to avoid copying/allocating anything
+	template<class Io>
+	struct OffsetIO {
+		Io &io;
+		int offset;
+
+		struct Channel {
+			Io &io;
+			int channel;
+			int offset;
+			
+			auto operator[](int i) -> decltype(io[0][0]) {
+				return io[channel][i + offset];
+			}
+		};
+		Channel operator[](int c) {
+			return {io, c, offset};
+		}
+	};
+};
+
+}} // namespace
+#endif // include guard

--- a/third_party/soundtouch/CMakeLists.txt
+++ b/third_party/soundtouch/CMakeLists.txt
@@ -1,0 +1,53 @@
+# SoundTouch, the stretch engine behind the pinned mode values kSoundTouchNormal and
+# kSoundTouchBetter (magda/daw/core/TimeStretchModes.hpp). Vendored for the native
+# engine (#1882), which may not reach into the Tracktion fork for it.
+#
+# Its own target, from unmodified sources, on purpose: SoundTouch is LGPL-2.1 and MAGDA
+# is GPL-3.0, which is compatible, but keeping it as one replaceable archive is what
+# leaves the relink option open. See SOURCES.md.
+#
+# x86 optimisations: cpu_detect_x86.cpp, mmx_optimized.cpp and sse_optimized.cpp compile
+# to nothing on non-x86 (they guard on SOUNDTOUCH_ALLOW_X86_OPTIMIZATIONS and the
+# architecture), so they are listed unconditionally and the arm64 build simply gets empty
+# objects.
+
+add_library(soundtouch STATIC
+    source/SoundTouch/AAFilter.cpp
+    source/SoundTouch/BPMDetect.cpp
+    source/SoundTouch/FIFOSampleBuffer.cpp
+    source/SoundTouch/FIRFilter.cpp
+    source/SoundTouch/InterpolateCubic.cpp
+    source/SoundTouch/InterpolateLinear.cpp
+    source/SoundTouch/InterpolateShannon.cpp
+    source/SoundTouch/PeakFinder.cpp
+    source/SoundTouch/RateTransposer.cpp
+    source/SoundTouch/SoundTouch.cpp
+    source/SoundTouch/TDStretch.cpp
+    source/SoundTouch/cpu_detect_x86.cpp
+    source/SoundTouch/mmx_optimized.cpp
+    source/SoundTouch/sse_optimized.cpp
+)
+add_library(magda::soundtouch ALIAS soundtouch)
+
+# SYSTEM so that a warning in a header MAGDA did not write is not a warning MAGDA has to
+# answer for.
+target_include_directories(soundtouch SYSTEM PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+)
+
+# SoundTouch.cpp defines one extern "C" symbol at global scope, a version printer autoconf
+# calls to prove the library links. The Tracktion fork compiles its own copy of these
+# sources into its unity build, so while both exist that symbol is defined twice and the
+# final link refuses it. Renaming ours through the preprocessor keeps the vendored source
+# unmodified and costs nothing; it can go when the fork does.
+target_compile_definitions(soundtouch PRIVATE soundtouch_ac_test=magda_soundtouch_ac_test)
+
+# Vendored third-party C++; suppress upstream warnings rather than chasing them, the way
+# third_party/sqlite does.
+if(MSVC)
+    target_compile_options(soundtouch PRIVATE /w)
+else()
+    target_compile_options(soundtouch PRIVATE -w)
+endif()
+
+set_target_properties(soundtouch PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/third_party/soundtouch/COPYING.TXT
+++ b/third_party/soundtouch/COPYING.TXT
@@ -1,0 +1,502 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/third_party/soundtouch/SOURCES.md
+++ b/third_party/soundtouch/SOURCES.md
@@ -1,0 +1,31 @@
+# SoundTouch
+
+SoundTouch 2.1pre (`SOUNDTOUCH_VERSION_ID` 20009) from https://www.surina.net/soundtouch,
+taken from the copy the Tracktion fork carries under
+`modules/tracktion_engine/3rd_party/soundtouch`.
+
+Unmodified upstream sources. The only thing done to the tree was deleting five one-line
+headers under `source/SoundTouch/` that forwarded to their real definitions in
+`include/`; upstream reaches those through the include path, and so does the target here.
+
+`SOUNDTOUCH_FLOAT_SAMPLES` is set in `include/soundtouch_config.h`, as it comes.
+
+## Licence
+
+LGPL-2.1-or-later. `COPYING.TXT` is the full licence text.
+
+MAGDA is distributed under GPL-3.0, and LGPL-2.1 is compatible with it, so linking this
+into a MAGDA binary carries no obligation beyond the ones GPL-3.0 already imposes.
+
+It is built as its own static library from unmodified sources rather than compiled into
+`magda_engine` so that the relink option LGPL-2.1 section 6 talks about stays open: the
+archive can be rebuilt from a different version of SoundTouch and put back without
+touching anything else. That matters if MAGDA is ever distributed under other terms; it
+costs nothing now.
+
+## Why it is here at all
+
+The persisted time-stretch mode values are pinned project-file integers
+(`magda/daw/core/TimeStretchModes.hpp`): `kSoundTouchNormal` is 3 and `kSoundTouchBetter`
+is 4. Projects saved with either play through SoundTouch, so the native engine (#1882)
+needs it to play those projects the way they were made.

--- a/third_party/soundtouch/include/BPMDetect.h
+++ b/third_party/soundtouch/include/BPMDetect.h
@@ -1,0 +1,205 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Beats-per-minute (BPM) detection routine.
+///
+/// The beat detection algorithm works as follows:
+/// - Use function 'inputSamples' to input a chunks of samples to the class for
+///   analysis. It's a good idea to enter a large sound file or stream in smallish
+///   chunks of around few kilosamples in order not to extinguish too much RAM memory.
+/// - Input sound data is decimated to approx 500 Hz to reduce calculation burden,
+///   which is basically ok as low (bass) frequencies mostly determine the beat rate.
+///   Simple averaging is used for anti-alias filtering because the resulting signal
+///   quality isn't of that high importance.
+/// - Decimated sound data is enveloped, i.e. the amplitude shape is detected by
+///   taking absolute value that's smoothed by sliding average. Signal levels that
+///   are below a couple of times the general RMS amplitude level are cut away to
+///   leave only notable peaks there.
+/// - Repeating sound patterns (e.g. beats) are detected by calculating short-term
+///   autocorrelation function of the enveloped signal.
+/// - After whole sound data file has been analyzed as above, the bpm level is
+///   detected by function 'getBpm' that finds the highest peak of the autocorrelation
+///   function, calculates it's precise location and converts this reading to bpm's.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef _BPMDetect_H_
+#define _BPMDetect_H_
+
+#include <vector>
+#include "STTypes.h"
+#include "FIFOSampleBuffer.h"
+
+namespace soundtouch
+{
+
+    /// Minimum allowed BPM rate. Used to restrict accepted result above a reasonable limit.
+    #define MIN_BPM 45
+
+    /// Maximum allowed BPM rate range. Used for calculating algorithm parametrs
+    #define MAX_BPM_RANGE 200
+
+    /// Maximum allowed BPM rate range. Used to restrict accepted result below a reasonable limit.
+    #define MAX_BPM_VALID 190
+
+////////////////////////////////////////////////////////////////////////////////
+
+    typedef struct
+    {
+        float pos;
+        float strength;
+    } BEAT;
+
+
+    class IIR2_filter
+    {
+        double coeffs[5];
+        double prev[5];
+
+    public:
+        IIR2_filter(const double *lpf_coeffs);
+        float update(float x);
+    };
+
+
+    /// Class for calculating BPM rate for audio data.
+    class BPMDetect
+    {
+    protected:
+        /// Auto-correlation accumulator bins.
+        float *xcorr;
+
+        /// Sample average counter.
+        int decimateCount;
+
+        /// Sample average accumulator for FIFO-like decimation.
+        soundtouch::LONG_SAMPLETYPE decimateSum;
+
+        /// Decimate sound by this coefficient to reach approx. 500 Hz.
+        int decimateBy;
+
+        /// Auto-correlation window length
+        int windowLen;
+
+        /// Number of channels (1 = mono, 2 = stereo)
+        int channels;
+
+        /// sample rate
+        int sampleRate;
+
+        /// Beginning of auto-correlation window: Autocorrelation isn't being updated for
+        /// the first these many correlation bins.
+        int windowStart;
+
+        /// window functions for data preconditioning
+        float *hamw;
+        float *hamw2;
+
+        // beat detection variables
+        int pos;
+        int peakPos;
+        int beatcorr_ringbuffpos;
+        int init_scaler;
+        float peakVal;
+        float *beatcorr_ringbuff;
+
+        /// FIFO-buffer for decimated processing samples.
+        soundtouch::FIFOSampleBuffer *buffer;
+
+        /// Collection of detected beat positions
+        //BeatCollection beats;
+        std::vector<BEAT> beats;
+
+        // 2nd order low-pass-filter
+        IIR2_filter beat_lpf;
+
+        /// Updates auto-correlation function for given number of decimated samples that
+        /// are read from the internal 'buffer' pipe (samples aren't removed from the pipe
+        /// though).
+        void updateXCorr(int process_samples      /// How many samples are processed.
+        );
+
+        /// Decimates samples to approx. 500 Hz.
+        ///
+        /// \return Number of output samples.
+        int decimate(soundtouch::SAMPLETYPE *dest,      ///< Destination buffer
+            const soundtouch::SAMPLETYPE *src, ///< Source sample buffer
+            int numsamples                     ///< Number of source samples.
+        );
+
+        /// Calculates amplitude envelope for the buffer of samples.
+        /// Result is output to 'samples'.
+        void calcEnvelope(soundtouch::SAMPLETYPE *samples,  ///< Pointer to input/output data buffer
+            int numsamples                    ///< Number of samples in buffer
+        );
+
+        /// remove constant bias from xcorr data
+        void removeBias();
+
+        // Detect individual beat positions
+        void updateBeatPos(int process_samples);
+
+
+    public:
+        /// Constructor.
+        BPMDetect(int numChannels,  ///< Number of channels in sample data.
+            int sampleRate    ///< Sample rate in Hz.
+        );
+
+        /// Destructor.
+        virtual ~BPMDetect();
+
+        /// Inputs a block of samples for analyzing: Envelopes the samples and then
+        /// updates the autocorrelation estimation. When whole song data has been input
+        /// in smaller blocks using this function, read the resulting bpm with 'getBpm'
+        /// function.
+        ///
+        /// Notice that data in 'samples' array can be disrupted in processing.
+        void inputSamples(const soundtouch::SAMPLETYPE *samples,    ///< Pointer to input/working data buffer
+            int numSamples                            ///< Number of samples in buffer
+        );
+
+        /// Analyzes the results and returns the BPM rate. Use this function to read result
+        /// after whole song data has been input to the class by consecutive calls of
+        /// 'inputSamples' function.
+        ///
+        /// \return Beats-per-minute rate, or zero if detection failed.
+        float getBpm();
+
+        /// Get beat position arrays. Note: The array includes also really low beat detection values
+        /// in absence of clear strong beats. Consumer may wish to filter low values away.
+        /// - "pos" receive array of beat positions
+        /// - "values" receive array of beat detection strengths
+        /// - max_num indicates max.size of "pos" and "values" array.
+        ///
+        /// You can query a suitable array sized by calling this with NULL in "pos" & "values".
+        ///
+        /// \return number of beats in the arrays.
+        int getBeats(float *pos, float *strength, int max_num);
+    };
+}
+#endif // _BPMDetect_H_

--- a/third_party/soundtouch/include/FIFOSampleBuffer.h
+++ b/third_party/soundtouch/include/FIFOSampleBuffer.h
@@ -1,0 +1,177 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// A buffer class for temporarily storaging sound samples, operates as a
+/// first-in-first-out pipe.
+///
+/// Samples are added to the end of the sample buffer with the 'putSamples'
+/// function, and are received from the beginning of the buffer by calling
+/// the 'receiveSamples' function. The class automatically removes the
+/// output samples from the buffer as well as grows the storage size
+/// whenever necessary.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef FIFOSampleBuffer_H
+#define FIFOSampleBuffer_H
+
+#include "FIFOSamplePipe.h"
+
+namespace soundtouch
+{
+
+/// Sample buffer working in FIFO (first-in-first-out) principle. The class takes
+/// care of storage size adjustment and data moving during input/output operations.
+///
+/// Notice that in case of stereo audio, one sample is considered to consist of
+/// both channel data.
+class FIFOSampleBuffer : public FIFOSamplePipe
+{
+private:
+    /// Sample buffer.
+    SAMPLETYPE *buffer;
+
+    // Raw unaligned buffer memory. 'buffer' is made aligned by pointing it to first
+    // 16-byte aligned location of this buffer
+    SAMPLETYPE *bufferUnaligned;
+
+    /// Sample buffer size in bytes
+    uint sizeInBytes;
+
+    /// How many samples are currently in buffer.
+    uint samplesInBuffer;
+
+    /// Channels, 1=mono, 2=stereo.
+    uint channels;
+
+    /// Current position pointer to the buffer. This pointer is increased when samples are
+    /// removed from the pipe so that it's necessary to actually rewind buffer (move data)
+    /// only new data when is put to the pipe.
+    uint bufferPos;
+
+    /// Rewind the buffer by moving data from position pointed by 'bufferPos' to real
+    /// beginning of the buffer.
+    void rewind();
+
+    /// Ensures that the buffer has capacity for at least this many samples.
+    void ensureCapacity(uint capacityRequirement);
+
+    /// Returns current capacity.
+    uint getCapacity() const;
+
+public:
+
+    /// Constructor
+    FIFOSampleBuffer(int numChannels = 2     ///< Number of channels, 1=mono, 2=stereo.
+                                              ///< Default is stereo.
+                     );
+
+    /// destructor
+    ~FIFOSampleBuffer();
+
+    /// Returns a pointer to the beginning of the output samples.
+    /// This function is provided for accessing the output samples directly.
+    /// Please be careful for not to corrupt the book-keeping!
+    ///
+    /// When using this function to output samples, also remember to 'remove' the
+    /// output samples from the buffer by calling the
+    /// 'receiveSamples(numSamples)' function
+    virtual SAMPLETYPE *ptrBegin();
+
+    /// Returns a pointer to the end of the used part of the sample buffer (i.e.
+    /// where the new samples are to be inserted). This function may be used for
+    /// inserting new samples into the sample buffer directly. Please be careful
+    /// not corrupt the book-keeping!
+    ///
+    /// When using this function as means for inserting new samples, also remember
+    /// to increase the sample count afterwards, by calling  the
+    /// 'putSamples(numSamples)' function.
+    SAMPLETYPE *ptrEnd(
+                uint slackCapacity   ///< How much free capacity (in samples) there _at least_
+                                     ///< should be so that the caller can successfully insert the
+                                     ///< desired samples to the buffer. If necessary, the function
+                                     ///< grows the buffer size to comply with this requirement.
+                );
+
+    /// Adds 'numSamples' pcs of samples from the 'samples' memory position to
+    /// the sample buffer.
+    virtual void putSamples(const SAMPLETYPE *samples,  ///< Pointer to samples.
+                            uint numSamples                         ///< Number of samples to insert.
+                            );
+
+    /// Adjusts the book-keeping to increase number of samples in the buffer without
+    /// copying any actual samples.
+    ///
+    /// This function is used to update the number of samples in the sample buffer
+    /// when accessing the buffer directly with 'ptrEnd' function. Please be
+    /// careful though!
+    virtual void putSamples(uint numSamples   ///< Number of samples been inserted.
+                            );
+
+    /// Output samples from beginning of the sample buffer. Copies requested samples to
+    /// output buffer and removes them from the sample buffer. If there are less than
+    /// 'numsample' samples in the buffer, returns all that available.
+    ///
+    /// \return Number of samples returned.
+    virtual uint receiveSamples(SAMPLETYPE *output, ///< Buffer where to copy output samples.
+                                uint maxSamples                 ///< How many samples to receive at max.
+                                );
+
+    /// Adjusts book-keeping so that given number of samples are removed from beginning of the
+    /// sample buffer without copying them anywhere.
+    ///
+    /// Used to reduce the number of samples in the buffer when accessing the sample buffer directly
+    /// with 'ptrBegin' function.
+    virtual uint receiveSamples(uint maxSamples   ///< Remove this many samples from the beginning of pipe.
+                                );
+
+    /// Returns number of samples currently available.
+    virtual uint numSamples() const;
+
+    /// Sets number of channels, 1 = mono, 2 = stereo.
+    void setChannels(int numChannels);
+
+    /// Get number of channels
+    int getChannels()
+    {
+        return channels;
+    }
+
+    /// Returns nonzero if there aren't any samples available for outputting.
+    virtual int isEmpty() const;
+
+    /// Clears all the samples.
+    virtual void clear();
+
+    /// allow trimming (downwards) amount of samples in pipeline.
+    /// Returns adjusted amount of samples
+    uint adjustAmountOfSamples(uint numSamples);
+};
+
+}
+
+#endif

--- a/third_party/soundtouch/include/FIFOSamplePipe.h
+++ b/third_party/soundtouch/include/FIFOSamplePipe.h
@@ -1,0 +1,230 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// 'FIFOSamplePipe' : An abstract base class for classes that manipulate sound
+/// samples by operating like a first-in-first-out pipe: New samples are fed
+/// into one end of the pipe with the 'putSamples' function, and the processed
+/// samples are received from the other end with the 'receiveSamples' function.
+///
+/// 'FIFOProcessor' : A base class for classes the do signal processing with
+/// the samples while operating like a first-in-first-out pipe. When samples
+/// are input with the 'putSamples' function, the class processes them
+/// and moves the processed samples to the given 'output' pipe object, which
+/// may be either another processing stage, or a fifo sample buffer object.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef FIFOSamplePipe_H
+#define FIFOSamplePipe_H
+
+#include <assert.h>
+#include <stdlib.h>
+#include "STTypes.h"
+
+namespace soundtouch
+{
+
+/// Abstract base class for FIFO (first-in-first-out) sample processing classes.
+class FIFOSamplePipe
+{
+protected:
+
+    bool verifyNumberOfChannels(int nChannels) const
+    {
+        if ((nChannels > 0) && (nChannels <= SOUNDTOUCH_MAX_CHANNELS))
+        {
+            return true;
+        }
+        ST_THROW_RT_ERROR("Error: Illegal number of channels");
+        return false;
+    }
+
+public:
+    // virtual default destructor
+    virtual ~FIFOSamplePipe() {}
+
+
+    /// Returns a pointer to the beginning of the output samples.
+    /// This function is provided for accessing the output samples directly.
+    /// Please be careful for not to corrupt the book-keeping!
+    ///
+    /// When using this function to output samples, also remember to 'remove' the
+    /// output samples from the buffer by calling the
+    /// 'receiveSamples(numSamples)' function
+    virtual SAMPLETYPE *ptrBegin() = 0;
+
+    /// Adds 'numSamples' pcs of samples from the 'samples' memory position to
+    /// the sample buffer.
+    virtual void putSamples(const SAMPLETYPE *samples,  ///< Pointer to samples.
+                            uint numSamples             ///< Number of samples to insert.
+                            ) = 0;
+
+
+    // Moves samples from the 'other' pipe instance to this instance.
+    void moveSamples(FIFOSamplePipe &other  ///< Other pipe instance where from the receive the data.
+         )
+    {
+        int oNumSamples = other.numSamples();
+
+        putSamples(other.ptrBegin(), oNumSamples);
+        other.receiveSamples(oNumSamples);
+    };
+
+    /// Output samples from beginning of the sample buffer. Copies requested samples to
+    /// output buffer and removes them from the sample buffer. If there are less than
+    /// 'numsample' samples in the buffer, returns all that available.
+    ///
+    /// \return Number of samples returned.
+    virtual uint receiveSamples(SAMPLETYPE *output, ///< Buffer where to copy output samples.
+                                uint maxSamples                 ///< How many samples to receive at max.
+                                ) = 0;
+
+    /// Adjusts book-keeping so that given number of samples are removed from beginning of the
+    /// sample buffer without copying them anywhere.
+    ///
+    /// Used to reduce the number of samples in the buffer when accessing the sample buffer directly
+    /// with 'ptrBegin' function.
+    virtual uint receiveSamples(uint maxSamples   ///< Remove this many samples from the beginning of pipe.
+                                ) = 0;
+
+    /// Returns number of samples currently available.
+    virtual uint numSamples() const = 0;
+
+    // Returns nonzero if there aren't any samples available for outputting.
+    virtual int isEmpty() const = 0;
+
+    /// Clears all the samples.
+    virtual void clear() = 0;
+
+    /// allow trimming (downwards) amount of samples in pipeline.
+    /// Returns adjusted amount of samples
+    virtual uint adjustAmountOfSamples(uint numSamples) = 0;
+
+};
+
+
+/// Base-class for sound processing routines working in FIFO principle. With this base
+/// class it's easy to implement sound processing stages that can be chained together,
+/// so that samples that are fed into beginning of the pipe automatically go through
+/// all the processing stages.
+///
+/// When samples are input to this class, they're first processed and then put to
+/// the FIFO pipe that's defined as output of this class. This output pipe can be
+/// either other processing stage or a FIFO sample buffer.
+class FIFOProcessor :public FIFOSamplePipe
+{
+protected:
+    /// Internal pipe where processed samples are put.
+    FIFOSamplePipe *output;
+
+    /// Sets output pipe.
+    void setOutPipe(FIFOSamplePipe *pOutput)
+    {
+        assert(output == NULL);
+        assert(pOutput != NULL);
+        output = pOutput;
+    }
+
+    /// Constructor. Doesn't define output pipe; it has to be set be
+    /// 'setOutPipe' function.
+    FIFOProcessor()
+    {
+        output = NULL;
+    }
+
+    /// Constructor. Configures output pipe.
+    FIFOProcessor(FIFOSamplePipe *pOutput   ///< Output pipe.
+                 )
+    {
+        output = pOutput;
+    }
+
+    /// Destructor.
+    virtual ~FIFOProcessor()
+    {
+    }
+
+    /// Returns a pointer to the beginning of the output samples.
+    /// This function is provided for accessing the output samples directly.
+    /// Please be careful for not to corrupt the book-keeping!
+    ///
+    /// When using this function to output samples, also remember to 'remove' the
+    /// output samples from the buffer by calling the
+    /// 'receiveSamples(numSamples)' function
+    virtual SAMPLETYPE *ptrBegin()
+    {
+        return output->ptrBegin();
+    }
+
+public:
+
+    /// Output samples from beginning of the sample buffer. Copies requested samples to
+    /// output buffer and removes them from the sample buffer. If there are less than
+    /// 'numsample' samples in the buffer, returns all that available.
+    ///
+    /// \return Number of samples returned.
+    virtual uint receiveSamples(SAMPLETYPE *outBuffer, ///< Buffer where to copy output samples.
+                                uint maxSamples                    ///< How many samples to receive at max.
+                                )
+    {
+        return output->receiveSamples(outBuffer, maxSamples);
+    }
+
+    /// Adjusts book-keeping so that given number of samples are removed from beginning of the
+    /// sample buffer without copying them anywhere.
+    ///
+    /// Used to reduce the number of samples in the buffer when accessing the sample buffer directly
+    /// with 'ptrBegin' function.
+    virtual uint receiveSamples(uint maxSamples   ///< Remove this many samples from the beginning of pipe.
+                                )
+    {
+        return output->receiveSamples(maxSamples);
+    }
+
+    /// Returns number of samples currently available.
+    virtual uint numSamples() const
+    {
+        return output->numSamples();
+    }
+
+    /// Returns nonzero if there aren't any samples available for outputting.
+    virtual int isEmpty() const
+    {
+        return output->isEmpty();
+    }
+
+    /// allow trimming (downwards) amount of samples in pipeline.
+    /// Returns adjusted amount of samples
+    virtual uint adjustAmountOfSamples(uint numSamples)
+    {
+        return output->adjustAmountOfSamples(numSamples);
+    }
+};
+
+}
+
+#endif

--- a/third_party/soundtouch/include/STTypes.h
+++ b/third_party/soundtouch/include/STTypes.h
@@ -1,0 +1,183 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Common type definitions for SoundTouch audio processing library.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef STTypes_H
+#define STTypes_H
+
+typedef unsigned int    uint;
+typedef unsigned long   ulong;
+
+// Patch for MinGW: on Win64 long is 32-bit
+#ifdef _WIN64
+    typedef unsigned long long ulongptr;
+#else
+    typedef ulong ulongptr;
+#endif
+
+
+// Helper macro for aligning pointer up to next 16-byte boundary
+#define SOUNDTOUCH_ALIGN_POINTER_16(x)      ( ( (ulongptr)(x) + 15 ) & ~(ulongptr)15 )
+
+
+#if (defined(__GNUC__) && !defined(ANDROID))
+    // In GCC, include soundtouch_config.h made by config scritps.
+    // Skip this in Android compilation that uses GCC but without configure scripts.
+    #include "soundtouch_config.h"
+#endif
+
+
+namespace soundtouch
+{
+    /// Max allowed number of channels
+    #define SOUNDTOUCH_MAX_CHANNELS     16
+
+    /// Activate these undef's to overrule the possible sampletype
+    /// setting inherited from some other header file:
+    //#undef SOUNDTOUCH_INTEGER_SAMPLES
+    //#undef SOUNDTOUCH_FLOAT_SAMPLES
+
+    /// If following flag is defined, always uses multichannel processing
+    /// routines also for mono and stero sound. This is for routine testing
+    /// purposes; output should be same with either routines, yet disabling
+    /// the dedicated mono/stereo processing routines will result in slower
+    /// runtime performance so recommendation is to keep this off.
+    // #define USE_MULTICH_ALWAYS
+
+    #if (defined(__SOFTFP__) && defined(ANDROID))
+        // For Android compilation: Force use of Integer samples in case that
+        // compilation uses soft-floating point emulation - soft-fp is way too slow
+        #undef  SOUNDTOUCH_FLOAT_SAMPLES
+        #define SOUNDTOUCH_INTEGER_SAMPLES      1
+    #endif
+
+    #if !(SOUNDTOUCH_INTEGER_SAMPLES || SOUNDTOUCH_FLOAT_SAMPLES)
+
+        /// Choose either 32bit floating point or 16bit integer sampletype
+        /// by choosing one of the following defines, unless this selection
+        /// has already been done in some other file.
+        ////
+        /// Notes:
+        /// - In Windows environment, choose the sample format with the
+        ///   following defines.
+        /// - In GNU environment, the floating point samples are used by
+        ///   default, but integer samples can be chosen by giving the
+        ///   following switch to the configure script:
+        ///       ./configure --enable-integer-samples
+        ///   However, if you still prefer to select the sample format here
+        ///   also in GNU environment, then please #undef the INTEGER_SAMPLE
+        ///   and FLOAT_SAMPLE defines first as in comments above.
+        //#define SOUNDTOUCH_INTEGER_SAMPLES     1    //< 16bit integer samples
+        #define SOUNDTOUCH_FLOAT_SAMPLES       1    //< 32bit float samples
+
+    #endif
+
+    #if (_M_IX86 || __i386__ || __x86_64__ || _M_X64)
+        /// Define this to allow X86-specific assembler/intrinsic optimizations.
+        /// Notice that library contains also usual C++ versions of each of these
+        /// these routines, so if you're having difficulties getting the optimized
+        /// routines compiled for whatever reason, you may disable these optimizations
+        /// to make the library compile.
+
+        #define SOUNDTOUCH_ALLOW_X86_OPTIMIZATIONS     1
+
+        /// In GNU environment, allow the user to override this setting by
+        /// giving the following switch to the configure script:
+        /// ./configure --disable-x86-optimizations
+        /// ./configure --enable-x86-optimizations=no
+        #ifdef SOUNDTOUCH_DISABLE_X86_OPTIMIZATIONS
+            #undef SOUNDTOUCH_ALLOW_X86_OPTIMIZATIONS
+        #endif
+    #else
+        /// Always disable optimizations when not using a x86 systems.
+        #undef SOUNDTOUCH_ALLOW_X86_OPTIMIZATIONS
+
+    #endif
+
+    // If defined, allows the SIMD-optimized routines to take minor shortcuts
+    // for improved performance. Undefine to require faithfully similar SIMD
+    // calculations as in normal C implementation.
+    #define SOUNDTOUCH_ALLOW_NONEXACT_SIMD_OPTIMIZATION    1
+
+
+    #ifdef SOUNDTOUCH_INTEGER_SAMPLES
+        // 16bit integer sample type
+        typedef short SAMPLETYPE;
+        // data type for sample accumulation: Use 32bit integer to prevent overflows
+        typedef long  LONG_SAMPLETYPE;
+
+        #ifdef SOUNDTOUCH_FLOAT_SAMPLES
+            // check that only one sample type is defined
+            #error "conflicting sample types defined"
+        #endif // SOUNDTOUCH_FLOAT_SAMPLES
+
+        #ifdef SOUNDTOUCH_ALLOW_X86_OPTIMIZATIONS
+            // Allow MMX optimizations (not available in X64 mode)
+            #if (!_M_X64)
+                #define SOUNDTOUCH_ALLOW_MMX   1
+            #endif
+        #endif
+
+    #else
+
+        // floating point samples
+        typedef float  SAMPLETYPE;
+        // data type for sample accumulation: Use double to utilize full precision.
+        typedef double LONG_SAMPLETYPE;
+
+        #ifdef SOUNDTOUCH_ALLOW_X86_OPTIMIZATIONS
+            // Allow SSE optimizations
+            #define SOUNDTOUCH_ALLOW_SSE       1
+        #endif
+
+    #endif  // SOUNDTOUCH_INTEGER_SAMPLES
+
+}
+
+// define ST_NO_EXCEPTION_HANDLING switch to disable throwing std exceptions:
+// #define ST_NO_EXCEPTION_HANDLING    1
+#ifdef ST_NO_EXCEPTION_HANDLING
+    // Exceptions disabled. Throw asserts instead if enabled.
+    #include <assert.h>
+    #define ST_THROW_RT_ERROR(x)    {assert((const char *)x);}
+#else
+    // use c++ standard exceptions
+    #include <stdexcept>
+    #include <string>
+    #define ST_THROW_RT_ERROR(x)    {throw std::runtime_error(x);}
+#endif
+
+// When this #define is active, eliminates a clicking sound when the "rate" or "pitch"
+// parameter setting crosses from value <1 to >=1 or vice versa during processing.
+// Default is off as such crossover is untypical case and involves a slight sound
+// quality compromise.
+//#define SOUNDTOUCH_PREVENT_CLICK_AT_RATE_CROSSOVER   1
+
+#endif

--- a/third_party/soundtouch/include/SoundTouch.h
+++ b/third_party/soundtouch/include/SoundTouch.h
@@ -1,0 +1,348 @@
+//////////////////////////////////////////////////////////////////////////////
+///
+/// SoundTouch - main class for tempo/pitch/rate adjusting routines.
+///
+/// Notes:
+/// - Initialize the SoundTouch object instance by setting up the sound stream
+///   parameters with functions 'setSampleRate' and 'setChannels', then set
+///   desired tempo/pitch/rate settings with the corresponding functions.
+///
+/// - The SoundTouch class behaves like a first-in-first-out pipeline: The
+///   samples that are to be processed are fed into one of the pipe by calling
+///   function 'putSamples', while the ready processed samples can be read
+///   from the other end of the pipeline with function 'receiveSamples'.
+///
+/// - The SoundTouch processing classes require certain sized 'batches' of
+///   samples in order to process the sound. For this reason the classes buffer
+///   incoming samples until there are enough of samples available for
+///   processing, then they carry out the processing step and consequently
+///   make the processed samples available for outputting.
+///
+/// - For the above reason, the processing routines introduce a certain
+///   'latency' between the input and output, so that the samples input to
+///   SoundTouch may not be immediately available in the output, and neither
+///   the amount of outputtable samples may not immediately be in direct
+///   relationship with the amount of previously input samples.
+///
+/// - The tempo/pitch/rate control parameters can be altered during processing.
+///   Please notice though that they aren't currently protected by semaphores,
+///   so in multi-thread application external semaphore protection may be
+///   required.
+///
+/// - This class utilizes classes 'TDStretch' for tempo change (without modifying
+///   pitch) and 'RateTransposer' for changing the playback rate (that is, both
+///   tempo and pitch in the same ratio) of the sound. The third available control
+///   'pitch' (change pitch but maintain tempo) is produced by a combination of
+///   combining the two other controls.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef SoundTouch_H
+#define SoundTouch_H
+
+#include "FIFOSamplePipe.h"
+#include "STTypes.h"
+
+namespace soundtouch
+{
+
+/// Soundtouch library version string
+#define SOUNDTOUCH_VERSION          "2.1pre"
+
+/// SoundTouch library version id
+#define SOUNDTOUCH_VERSION_ID       (20009)
+
+//
+// Available setting IDs for the 'setSetting' & 'get_setting' functions:
+
+/// Enable/disable anti-alias filter in pitch transposer (0 = disable)
+#define SETTING_USE_AA_FILTER       0
+
+/// Pitch transposer anti-alias filter length (8 .. 128 taps, default = 32)
+#define SETTING_AA_FILTER_LENGTH    1
+
+/// Enable/disable quick seeking algorithm in tempo changer routine
+/// (enabling quick seeking lowers CPU utilization but causes a minor sound
+///  quality compromising)
+#define SETTING_USE_QUICKSEEK       2
+
+/// Time-stretch algorithm single processing sequence length in milliseconds. This determines
+/// to how long sequences the original sound is chopped in the time-stretch algorithm.
+/// See "STTypes.h" or README for more information.
+#define SETTING_SEQUENCE_MS         3
+
+/// Time-stretch algorithm seeking window length in milliseconds for algorithm that finds the
+/// best possible overlapping location. This determines from how wide window the algorithm
+/// may look for an optimal joining location when mixing the sound sequences back together.
+/// See "STTypes.h" or README for more information.
+#define SETTING_SEEKWINDOW_MS       4
+
+/// Time-stretch algorithm overlap length in milliseconds. When the chopped sound sequences
+/// are mixed back together, to form a continuous sound stream, this parameter defines over
+/// how long period the two consecutive sequences are let to overlap each other.
+/// See "STTypes.h" or README for more information.
+#define SETTING_OVERLAP_MS          5
+
+
+/// Call "getSetting" with this ID to query processing sequence size in samples.
+/// This value gives approximate value of how many input samples you'll need to
+/// feed into SoundTouch after initial buffering to get out a new batch of
+/// output samples.
+///
+/// This value does not include initial buffering at beginning of a new processing
+/// stream, use SETTING_INITIAL_LATENCY to get the initial buffering size.
+///
+/// Notices:
+/// - This is read-only parameter, i.e. setSetting ignores this parameter
+/// - This parameter value is not constant but change depending on
+///   tempo/pitch/rate/samplerate settings.
+#define SETTING_NOMINAL_INPUT_SEQUENCE      6
+
+
+/// Call "getSetting" with this ID to query nominal average processing output
+/// size in samples. This value tells approcimate value how many output samples
+/// SoundTouch outputs once it does DSP processing run for a batch of input samples.
+///
+/// Notices:
+/// - This is read-only parameter, i.e. setSetting ignores this parameter
+/// - This parameter value is not constant but change depending on
+///   tempo/pitch/rate/samplerate settings.
+#define SETTING_NOMINAL_OUTPUT_SEQUENCE     7
+
+
+/// Call "getSetting" with this ID to query initial processing latency, i.e.
+/// approx. how many samples you'll need to enter to SoundTouch pipeline before
+/// you can expect to get first batch of ready output samples out.
+///
+/// After the first output batch, you can then expect to get approx.
+/// SETTING_NOMINAL_OUTPUT_SEQUENCE ready samples out for every
+/// SETTING_NOMINAL_INPUT_SEQUENCE samples that you enter into SoundTouch.
+///
+/// Example:
+///     processing with parameter -tempo=5
+///     => initial latency = 5509 samples
+///        input sequence  = 4167 samples
+///        output sequence = 3969 samples
+///
+/// Accordingly, you can expect to feed in approx. 5509 samples at beginning of
+/// the stream, and then you'll get out the first 3969 samples. After that, for
+/// every approx. 4167 samples that you'll put in, you'll receive again approx.
+/// 3969 samples out.
+///
+/// This also means that average latency during stream processing is
+/// INITIAL_LATENCY-OUTPUT_SEQUENCE/2, in the above example case 5509-3969/2
+/// = 3524 samples
+///
+/// Notices:
+/// - This is read-only parameter, i.e. setSetting ignores this parameter
+/// - This parameter value is not constant but change depending on
+///   tempo/pitch/rate/samplerate settings.
+#define SETTING_INITIAL_LATENCY             8
+
+
+class SoundTouch : public FIFOProcessor
+{
+private:
+    /// Rate transposer class instance
+    class RateTransposer *pRateTransposer;
+
+    /// Time-stretch class instance
+    class TDStretch *pTDStretch;
+
+    /// Virtual pitch parameter. Effective rate & tempo are calculated from these parameters.
+    double virtualRate;
+
+    /// Virtual pitch parameter. Effective rate & tempo are calculated from these parameters.
+    double virtualTempo;
+
+    /// Virtual pitch parameter. Effective rate & tempo are calculated from these parameters.
+    double virtualPitch;
+
+    /// Flag: Has sample rate been set?
+    bool  bSrateSet;
+
+    /// Accumulator for how many samples in total will be expected as output vs. samples put in,
+    /// considering current processing settings.
+    double samplesExpectedOut;
+
+    /// Accumulator for how many samples in total have been read out from the processing so far
+    long   samplesOutput;
+
+    /// Calculates effective rate & tempo valuescfrom 'virtualRate', 'virtualTempo' and
+    /// 'virtualPitch' parameters.
+    void calcEffectiveRateAndTempo();
+
+protected :
+    /// Number of channels
+    uint  channels;
+
+    /// Effective 'rate' value calculated from 'virtualRate', 'virtualTempo' and 'virtualPitch'
+    double rate;
+
+    /// Effective 'tempo' value calculated from 'virtualRate', 'virtualTempo' and 'virtualPitch'
+    double tempo;
+
+public:
+    SoundTouch();
+    virtual ~SoundTouch();
+
+    /// Get SoundTouch library version string
+    static const char *getVersionString();
+
+    /// Get SoundTouch library version Id
+    static uint getVersionId();
+
+    /// Sets new rate control value. Normal rate = 1.0, smaller values
+    /// represent slower rate, larger faster rates.
+    void setRate(double newRate);
+
+    /// Sets new tempo control value. Normal tempo = 1.0, smaller values
+    /// represent slower tempo, larger faster tempo.
+    void setTempo(double newTempo);
+
+    /// Sets new rate control value as a difference in percents compared
+    /// to the original rate (-50 .. +100 %)
+    void setRateChange(double newRate);
+
+    /// Sets new tempo control value as a difference in percents compared
+    /// to the original tempo (-50 .. +100 %)
+    void setTempoChange(double newTempo);
+
+    /// Sets new pitch control value. Original pitch = 1.0, smaller values
+    /// represent lower pitches, larger values higher pitch.
+    void setPitch(double newPitch);
+
+    /// Sets pitch change in octaves compared to the original pitch
+    /// (-1.00 .. +1.00)
+    void setPitchOctaves(double newPitch);
+
+    /// Sets pitch change in semi-tones compared to the original pitch
+    /// (-12 .. +12)
+    void setPitchSemiTones(int newPitch);
+    void setPitchSemiTones(double newPitch);
+
+    /// Sets the number of channels, 1 = mono, 2 = stereo
+    void setChannels(uint numChannels);
+
+    /// Sets sample rate.
+    void setSampleRate(uint srate);
+
+    /// Get ratio between input and output audio durations, useful for calculating
+    /// processed output duration: if you'll process a stream of N samples, then
+    /// you can expect to get out N * getInputOutputSampleRatio() samples.
+    ///
+    /// This ratio will give accurate target duration ratio for a full audio track,
+    /// given that the the whole track is processed with same processing parameters.
+    ///
+    /// If this ratio is applied to calculate intermediate offsets inside a processing
+    /// stream, then this ratio is approximate and can deviate +- some tens of milliseconds
+    /// from ideal offset, yet by end of the audio stream the duration ratio will become
+    /// exact.
+    ///
+    /// Example: if processing with parameters "-tempo=15 -pitch=-3", the function
+    /// will return value 0.8695652... Now, if processing an audio stream whose duration
+    /// is exactly one million audio samples, then you can expect the processed
+    /// output duration  be 0.869565 * 1000000 = 869565 samples.
+    double getInputOutputSampleRatio();
+
+    /// Flushes the last samples from the processing pipeline to the output.
+    /// Clears also the internal processing buffers.
+    //
+    /// Note: This function is meant for extracting the last samples of a sound
+    /// stream. This function may introduce additional blank samples in the end
+    /// of the sound stream, and thus it's not recommended to call this function
+    /// in the middle of a sound stream.
+    void flush();
+
+    /// Adds 'numSamples' pcs of samples from the 'samples' memory position into
+    /// the input of the object. Notice that sample rate _has_to_ be set before
+    /// calling this function, otherwise throws a runtime_error exception.
+    virtual void putSamples(
+            const SAMPLETYPE *samples,  ///< Pointer to sample buffer.
+            uint numSamples                         ///< Number of samples in buffer. Notice
+                                                    ///< that in case of stereo-sound a single sample
+                                                    ///< contains data for both channels.
+            );
+
+    /// Output samples from beginning of the sample buffer. Copies requested samples to
+    /// output buffer and removes them from the sample buffer. If there are less than
+    /// 'numsample' samples in the buffer, returns all that available.
+    ///
+    /// \return Number of samples returned.
+    virtual uint receiveSamples(SAMPLETYPE *output, ///< Buffer where to copy output samples.
+        uint maxSamples                 ///< How many samples to receive at max.
+        );
+
+    /// Adjusts book-keeping so that given number of samples are removed from beginning of the
+    /// sample buffer without copying them anywhere.
+    ///
+    /// Used to reduce the number of samples in the buffer when accessing the sample buffer directly
+    /// with 'ptrBegin' function.
+    virtual uint receiveSamples(uint maxSamples   ///< Remove this many samples from the beginning of pipe.
+        );
+
+    /// Clears all the samples in the object's output and internal processing
+    /// buffers.
+    virtual void clear();
+
+    /// Changes a setting controlling the processing system behaviour. See the
+    /// 'SETTING_...' defines for available setting ID's.
+    ///
+    /// \return 'true' if the setting was successfully changed
+    bool setSetting(int settingId,   ///< Setting ID number. see SETTING_... defines.
+                    int value        ///< New setting value.
+                    );
+
+    /// Reads a setting controlling the processing system behaviour. See the
+    /// 'SETTING_...' defines for available setting ID's.
+    ///
+    /// \return the setting value.
+    int getSetting(int settingId    ///< Setting ID number, see SETTING_... defines.
+                   ) const;
+
+    /// Returns number of samples currently unprocessed.
+    virtual uint numUnprocessedSamples() const;
+
+    /// Return number of channels
+    uint numChannels() const
+    {
+        return channels;
+    }
+
+    /// Other handy functions that are implemented in the ancestor classes (see
+    /// classes 'FIFOProcessor' and 'FIFOSamplePipe')
+    ///
+    /// - receiveSamples() : Use this function to receive 'ready' processed samples from SoundTouch.
+    /// - numSamples()     : Get number of 'ready' samples that can be received with
+    ///                      function 'receiveSamples()'
+    /// - isEmpty()        : Returns nonzero if there aren't any 'ready' samples.
+    /// - clear()          : Clears all samples from ready/processing buffers.
+};
+
+}
+#endif

--- a/third_party/soundtouch/include/soundtouch_config.h
+++ b/third_party/soundtouch/include/soundtouch_config.h
@@ -1,0 +1,101 @@
+/* include/soundtouch_config.h.  Generated from soundtouch_config.h.in by configure.  */
+/* include/soundtouch_config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if you have the <cpuid.h> header file. */
+/* #undef HAVE_CPUID_H */
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the `m' library (-lm). */
+#define HAVE_LIBM 1
+
+/* Define to 1 if your system has a GNU libc compatible `malloc' function, and
+   to 0 otherwise. */
+#define HAVE_MALLOC 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to the sub-directory in which libtool stores uninstalled libraries.
+   */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "soundtouch"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "http://www.surina.net/soundtouch"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "SoundTouch"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "SoundTouch 2.0.0"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "soundtouch"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "2.0.0"
+
+/* Define as the return type of signal handlers (`int' or `void'). */
+#define RETSIGTYPE void
+
+/* Do not use x86 optimizations */
+//#define SOUNDTOUCH_DISABLE_X86_OPTIMIZATIONS 1
+
+/* Use Float as Sample type */
+#define SOUNDTOUCH_FLOAT_SAMPLES 1
+
+/* Use Integer as Sample type */
+/* #undef SOUNDTOUCH_INTEGER_SAMPLES */
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Version number of package */
+#define VERSION "2.0.0"
+
+/* Define to empty if `const' does not conform to ANSI C. */
+/* #undef const */
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+/* #undef inline */
+#endif
+
+/* Define to rpl_malloc if the replacement function should be used. */
+/* #undef malloc */
+
+#ifdef _MSC_VER
+ #pragma warning (disable : 4127 4389 4018)
+#endif

--- a/third_party/soundtouch/source/SoundTouch/AAFilter.cpp
+++ b/third_party/soundtouch/source/SoundTouch/AAFilter.cpp
@@ -1,0 +1,222 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// FIR low-pass (anti-alias) filter with filter coefficient design routine and
+/// MMX optimization.
+///
+/// Anti-alias filter is used to prevent folding of high frequencies when
+/// transposing the sample rate with interpolation.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <memory.h>
+#include <assert.h>
+#include <math.h>
+#include <stdlib.h>
+#include "AAFilter.h"
+#include "FIRFilter.h"
+
+using namespace soundtouch;
+
+#define PI       3.14159265358979323846
+#define TWOPI    (2 * PI)
+
+// define this to save AA filter coefficients to a file
+// #define _DEBUG_SAVE_AAFILTER_COEFFICIENTS   1
+
+#ifdef _DEBUG_SAVE_AAFILTER_COEFFICIENTS
+    #include <stdio.h>
+
+    static void _DEBUG_SAVE_AAFIR_COEFFS(SAMPLETYPE *coeffs, int len)
+    {
+        FILE *fptr = fopen("aa_filter_coeffs.txt", "wt");
+        if (fptr == NULL) return;
+
+        for (int i = 0; i < len; i ++)
+        {
+            double temp = coeffs[i];
+            fprintf(fptr, "%lf\n", temp);
+        }
+        fclose(fptr);
+    }
+
+#else
+    #define _DEBUG_SAVE_AAFIR_COEFFS(x, y)
+#endif
+
+/*****************************************************************************
+ *
+ * Implementation of the class 'AAFilter'
+ *
+ *****************************************************************************/
+
+AAFilter::AAFilter(uint len)
+{
+    pFIR = FIRFilter::newInstance();
+    cutoffFreq = 0.5;
+    setLength(len);
+}
+
+
+AAFilter::~AAFilter()
+{
+    delete pFIR;
+}
+
+
+// Sets new anti-alias filter cut-off edge frequency, scaled to
+// sampling frequency (nyquist frequency = 0.5).
+// The filter will cut frequencies higher than the given frequency.
+void AAFilter::setCutoffFreq(double newCutoffFreq)
+{
+    cutoffFreq = newCutoffFreq;
+    calculateCoeffs();
+}
+
+
+// Sets number of FIR filter taps
+void AAFilter::setLength(uint newLength)
+{
+    length = newLength;
+    calculateCoeffs();
+}
+
+
+// Calculates coefficients for a low-pass FIR filter using Hamming window
+void AAFilter::calculateCoeffs()
+{
+    uint i;
+    double cntTemp, temp, tempCoeff,h, w;
+    double wc;
+    double scaleCoeff, sum;
+    double *work;
+    SAMPLETYPE *coeffs;
+
+    assert(length >= 2);
+    assert(length % 4 == 0);
+    assert(cutoffFreq >= 0);
+    assert(cutoffFreq <= 0.5);
+
+    work = new double[length];
+    coeffs = new SAMPLETYPE[length];
+
+    wc = 2.0 * PI * cutoffFreq;
+    tempCoeff = TWOPI / (double)length;
+
+    sum = 0;
+    for (i = 0; i < length; i ++)
+    {
+        cntTemp = (double)i - (double)(length / 2);
+
+        temp = cntTemp * wc;
+        if (temp != 0)
+        {
+            h = sin(temp) / temp;                     // sinc function
+        }
+        else
+        {
+            h = 1.0;
+        }
+        w = 0.54 + 0.46 * cos(tempCoeff * cntTemp);       // hamming window
+
+        temp = w * h;
+        work[i] = temp;
+
+        // calc net sum of coefficients
+        sum += temp;
+    }
+
+    // ensure the sum of coefficients is larger than zero
+    assert(sum > 0);
+
+    // ensure we've really designed a lowpass filter...
+    assert(work[length/2] > 0);
+    assert(work[length/2 + 1] > -1e-6);
+    assert(work[length/2 - 1] > -1e-6);
+
+    // Calculate a scaling coefficient in such a way that the result can be
+    // divided by 16384
+    scaleCoeff = 16384.0f / sum;
+
+    for (i = 0; i < length; i ++)
+    {
+        temp = work[i] * scaleCoeff;
+        // scale & round to nearest integer
+        temp += (temp >= 0) ? 0.5 : -0.5;
+        // ensure no overfloods
+        assert(temp >= -32768 && temp <= 32767);
+        coeffs[i] = (SAMPLETYPE)temp;
+    }
+
+    // Set coefficients. Use divide factor 14 => divide result by 2^14 = 16384
+    pFIR->setCoefficients(coeffs, length, 14);
+
+    _DEBUG_SAVE_AAFIR_COEFFS(coeffs, length);
+
+    delete[] work;
+    delete[] coeffs;
+}
+
+
+// Applies the filter to the given sequence of samples.
+// Note : The amount of outputted samples is by value of 'filter length'
+// smaller than the amount of input samples.
+uint AAFilter::evaluate(SAMPLETYPE *dest, const SAMPLETYPE *src, uint numSamples, uint numChannels) const
+{
+    return pFIR->evaluate(dest, src, numSamples, numChannels);
+}
+
+
+/// Applies the filter to the given src & dest pipes, so that processed amount of
+/// samples get removed from src, and produced amount added to dest
+/// Note : The amount of outputted samples is by value of 'filter length'
+/// smaller than the amount of input samples.
+uint AAFilter::evaluate(FIFOSampleBuffer &dest, FIFOSampleBuffer &src) const
+{
+    SAMPLETYPE *pdest;
+    const SAMPLETYPE *psrc;
+    uint numSrcSamples;
+    uint result;
+    int numChannels = src.getChannels();
+
+    assert(numChannels == dest.getChannels());
+
+    numSrcSamples = src.numSamples();
+    psrc = src.ptrBegin();
+    pdest = dest.ptrEnd(numSrcSamples);
+    result = pFIR->evaluate(pdest, psrc, numSrcSamples, numChannels);
+    src.receiveSamples(result);
+    dest.putSamples(result);
+
+    return result;
+}
+
+
+uint AAFilter::getLength() const
+{
+    return pFIR->getLength();
+}

--- a/third_party/soundtouch/source/SoundTouch/AAFilter.h
+++ b/third_party/soundtouch/source/SoundTouch/AAFilter.h
@@ -1,0 +1,93 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Sampled sound tempo changer/time stretch algorithm. Changes the sound tempo
+/// while maintaining the original pitch by using a time domain WSOLA-like method
+/// with several performance-increasing tweaks.
+///
+/// Anti-alias filter is used to prevent folding of high frequencies when
+/// transposing the sample rate with interpolation.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef AAFilter_H
+#define AAFilter_H
+
+#include "STTypes.h"
+#include "FIFOSampleBuffer.h"
+
+namespace soundtouch
+{
+
+class AAFilter
+{
+protected:
+    class FIRFilter *pFIR;
+
+    /// Low-pass filter cut-off frequency, negative = invalid
+    double cutoffFreq;
+
+    /// num of filter taps
+    uint length;
+
+    /// Calculate the FIR coefficients realizing the given cutoff-frequency
+    void calculateCoeffs();
+public:
+    AAFilter(uint length);
+
+    ~AAFilter();
+
+    /// Sets new anti-alias filter cut-off edge frequency, scaled to sampling
+    /// frequency (nyquist frequency = 0.5). The filter will cut off the
+    /// frequencies than that.
+    void setCutoffFreq(double newCutoffFreq);
+
+    /// Sets number of FIR filter taps, i.e. ~filter complexity
+    void setLength(uint newLength);
+
+    uint getLength() const;
+
+    /// Applies the filter to the given sequence of samples.
+    /// Note : The amount of outputted samples is by value of 'filter length'
+    /// smaller than the amount of input samples.
+    uint evaluate(SAMPLETYPE *dest,
+                  const SAMPLETYPE *src,
+                  uint numSamples,
+                  uint numChannels) const;
+
+    /// Applies the filter to the given src & dest pipes, so that processed amount of
+    /// samples get removed from src, and produced amount added to dest
+    /// Note : The amount of outputted samples is by value of 'filter length'
+    /// smaller than the amount of input samples.
+    uint evaluate(FIFOSampleBuffer &dest,
+                  FIFOSampleBuffer &src) const;
+
+};
+
+}
+
+#endif

--- a/third_party/soundtouch/source/SoundTouch/BPMDetect.cpp
+++ b/third_party/soundtouch/source/SoundTouch/BPMDetect.cpp
@@ -1,0 +1,586 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Beats-per-minute (BPM) detection routine.
+///
+/// The beat detection algorithm works as follows:
+/// - Use function 'inputSamples' to input a chunks of samples to the class for
+///   analysis. It's a good idea to enter a large sound file or stream in smallish
+///   chunks of around few kilosamples in order not to extinguish too much RAM memory.
+/// - Inputted sound data is decimated to approx 500 Hz to reduce calculation burden,
+///   which is basically ok as low (bass) frequencies mostly determine the beat rate.
+///   Simple averaging is used for anti-alias filtering because the resulting signal
+///   quality isn't of that high importance.
+/// - Decimated sound data is enveloped, i.e. the amplitude shape is detected by
+///   taking absolute value that's smoothed by sliding average. Signal levels that
+///   are below a couple of times the general RMS amplitude level are cut away to
+///   leave only notable peaks there.
+/// - Repeating sound patterns (e.g. beats) are detected by calculating short-term
+///   autocorrelation function of the enveloped signal.
+/// - After whole sound data file has been analyzed as above, the bpm level is
+///   detected by function 'getBpm' that finds the highest peak of the autocorrelation
+///   function, calculates it's precise location and converts this reading to bpm's.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#define _USE_MATH_DEFINES
+
+#include <math.h>
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+#include <cfloat>
+#include "FIFOSampleBuffer.h"
+#include "PeakFinder.h"
+#include "BPMDetect.h"
+
+using namespace soundtouch;
+
+// algorithm input sample block size
+static const int INPUT_BLOCK_SIZE = 2048;
+
+// decimated sample block size
+static const int DECIMATED_BLOCK_SIZE = 256;
+
+/// Target sample rate after decimation
+static const int TARGET_SRATE = 1000;
+
+/// XCorr update sequence size, update in about 200msec chunks
+static const int XCORR_UPDATE_SEQUENCE = (int)(TARGET_SRATE / 5);
+
+/// Moving average N size
+static const int MOVING_AVERAGE_N = 15;
+
+/// XCorr decay time constant, decay to half in 30 seconds
+/// If it's desired to have the system adapt quicker to beat rate
+/// changes within a continuing music stream, then the
+/// 'xcorr_decay_time_constant' value can be reduced, yet that
+/// can increase possibility of glitches in bpm detection.
+static const double XCORR_DECAY_TIME_CONSTANT = 30.0;
+
+/// Data overlap factor for beat detection algorithm
+static const int OVERLAP_FACTOR = 4;
+
+static const double TWOPI = (2 * M_PI);
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Enable following define to create bpm analysis file:
+
+//#define _CREATE_BPM_DEBUG_FILE
+
+#ifdef _CREATE_BPM_DEBUG_FILE
+
+    static void _SaveDebugData(const char *name, const float *data, int minpos, int maxpos, double coeff)
+    {
+        FILE *fptr = fopen(name, "wt");
+        int i;
+
+        if (fptr)
+        {
+            printf("\nWriting BPM debug data into file %s\n", name);
+            for (i = minpos; i < maxpos; i ++)
+            {
+                fprintf(fptr, "%d\t%.1lf\t%f\n", i, coeff / (double)i, data[i]);
+            }
+            fclose(fptr);
+        }
+    }
+
+    void _SaveDebugBeatPos(const char *name, const std::vector<BEAT> &beats)
+    {
+        printf("\nWriting beat detections data into file %s\n", name);
+
+        FILE *fptr = fopen(name, "wt");
+        if (fptr)
+        {
+            for (uint i = 0; i < beats.size(); i++)
+            {
+                BEAT b = beats[i];
+                fprintf(fptr, "%lf\t%lf\n", b.pos, b.strength);
+            }
+            fclose(fptr);
+        }
+    }
+#else
+    #define _SaveDebugData(name, a,b,c,d)
+    #define _SaveDebugBeatPos(name, b)
+#endif
+
+// Hamming window
+void hamming(float *w, int N)
+{
+    for (int i = 0; i < N; i++)
+    {
+        w[i] = (float)(0.54 - 0.46 * cos(TWOPI * i / (N - 1)));
+    }
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// IIR2_filter - 2nd order IIR filter
+
+IIR2_filter::IIR2_filter(const double *lpf_coeffs)
+{
+    memcpy(coeffs, lpf_coeffs, 5 * sizeof(double));
+    memset(prev, 0, sizeof(prev));
+}
+
+
+float IIR2_filter::update(float x)
+{
+    prev[0] = x;
+    double y = x * coeffs[0];
+
+    for (int i = 4; i >= 1; i--)
+    {
+        y += coeffs[i] * prev[i];
+        prev[i] = prev[i - 1];
+    }
+
+    prev[3] = y;
+    return (float)y;
+}
+
+
+// IIR low-pass filter coefficients, calculated with matlab/octave cheby2(2,40,0.05)
+const double _LPF_coeffs[5] = { 0.00996655391939, -0.01944529148401, 0.00996655391939, 1.96867605796247, -0.96916387431724 };
+
+////////////////////////////////////////////////////////////////////////////////
+
+BPMDetect::BPMDetect(int numChannels, int aSampleRate) :
+    beat_lpf(_LPF_coeffs)
+{
+    beats.reserve(250); // initial reservation to prevent frequent reallocation
+
+    this->sampleRate = aSampleRate;
+    this->channels = numChannels;
+
+    decimateSum = 0;
+    decimateCount = 0;
+
+    // choose decimation factor so that result is approx. 1000 Hz
+    decimateBy = sampleRate / TARGET_SRATE;
+    assert(decimateBy > 0);
+    assert(INPUT_BLOCK_SIZE < decimateBy * DECIMATED_BLOCK_SIZE);
+
+    // Calculate window length & starting item according to desired min & max bpms
+    windowLen = (60 * sampleRate) / (decimateBy * MIN_BPM);
+    windowStart = (60 * sampleRate) / (decimateBy * MAX_BPM_RANGE);
+
+    assert(windowLen > windowStart);
+
+    // allocate new working objects
+    xcorr = new float[windowLen];
+    memset(xcorr, 0, windowLen * sizeof(float));
+
+    pos = 0;
+    peakPos = 0;
+    peakVal = 0;
+    init_scaler = 1;
+    beatcorr_ringbuffpos = 0;
+    beatcorr_ringbuff = new float[windowLen];
+    memset(beatcorr_ringbuff, 0, windowLen * sizeof(float));
+
+    // allocate processing buffer
+    buffer = new FIFOSampleBuffer();
+    // we do processing in mono mode
+    buffer->setChannels(1);
+    buffer->clear();
+
+    // calculate hamming windows
+    hamw = new float[XCORR_UPDATE_SEQUENCE];
+    hamming(hamw, XCORR_UPDATE_SEQUENCE);
+    hamw2 = new float[XCORR_UPDATE_SEQUENCE / 2];
+    hamming(hamw2, XCORR_UPDATE_SEQUENCE / 2);
+}
+
+
+BPMDetect::~BPMDetect()
+{
+    delete[] xcorr;
+    delete[] beatcorr_ringbuff;
+    delete[] hamw;
+    delete[] hamw2;
+    delete buffer;
+}
+
+
+/// convert to mono, low-pass filter & decimate to about 500 Hz.
+/// return number of outputted samples.
+///
+/// Decimation is used to remove the unnecessary frequencies and thus to reduce
+/// the amount of data needed to be processed as calculating autocorrelation
+/// function is a very-very heavy operation.
+///
+/// Anti-alias filtering is done simply by averaging the samples. This is really a
+/// poor-man's anti-alias filtering, but it's not so critical in this kind of application
+/// (it'd also be difficult to design a high-quality filter with steep cut-off at very
+/// narrow band)
+int BPMDetect::decimate(SAMPLETYPE *dest, const SAMPLETYPE *src, int numsamples)
+{
+    int count, outcount;
+    LONG_SAMPLETYPE out;
+
+    assert(channels > 0);
+    assert(decimateBy > 0);
+    outcount = 0;
+    for (count = 0; count < numsamples; count ++)
+    {
+        int j;
+
+        // convert to mono and accumulate
+        for (j = 0; j < channels; j ++)
+        {
+            decimateSum += src[j];
+        }
+        src += j;
+
+        decimateCount ++;
+        if (decimateCount >= decimateBy)
+        {
+            // Store every Nth sample only
+            out = (LONG_SAMPLETYPE)(decimateSum / (decimateBy * channels));
+            decimateSum = 0;
+            decimateCount = 0;
+#ifdef SOUNDTOUCH_INTEGER_SAMPLES
+            // check ranges for sure (shouldn't actually be necessary)
+            if (out > 32767)
+            {
+                out = 32767;
+            }
+            else if (out < -32768)
+            {
+                out = -32768;
+            }
+#endif // SOUNDTOUCH_INTEGER_SAMPLES
+            dest[outcount] = (SAMPLETYPE)out;
+            outcount ++;
+        }
+    }
+    return outcount;
+}
+
+
+// Calculates autocorrelation function of the sample history buffer
+void BPMDetect::updateXCorr(int process_samples)
+{
+    int offs;
+    SAMPLETYPE *pBuffer;
+
+    if ((buffer == nullptr) || (buffer->numSamples() < (uint)(process_samples + windowLen)))
+        return;
+
+    assert(buffer->numSamples() >= (uint)(process_samples + windowLen));
+    assert(process_samples == XCORR_UPDATE_SEQUENCE);
+
+    pBuffer = buffer->ptrBegin();
+    if (pBuffer == nullptr)
+        return;
+
+    // calculate decay factor for xcorr filtering
+    float xcorr_decay = (float)pow(0.5, 1.0 / (XCORR_DECAY_TIME_CONSTANT * TARGET_SRATE / process_samples));
+
+    // prescale pbuffer
+    float tmp[XCORR_UPDATE_SEQUENCE];
+    for (int i = 0; i < process_samples; i++)
+    {
+        tmp[i] = hamw[i] * hamw[i] * pBuffer[i];
+    }
+
+    #pragma omp parallel for
+    for (offs = windowStart; offs < windowLen; offs ++)
+    {
+        double sum;
+        int i;
+
+        sum = 0;
+        for (i = 0; i < process_samples; i ++)
+        {
+            sum += tmp[i] * pBuffer[i + offs];  // scaling the sub-result shouldn't be necessary
+        }
+        xcorr[offs] *= xcorr_decay;   // decay 'xcorr' here with suitable time constant.
+
+        xcorr[offs] += (float)fabs(sum);
+    }
+}
+
+
+// Detect individual beat positions
+void BPMDetect::updateBeatPos(int process_samples)
+{
+    SAMPLETYPE *pBuffer;
+
+    if ((buffer == nullptr) || (buffer->numSamples() < (uint)(process_samples + windowLen)))
+        return;
+
+    assert(buffer->numSamples() >= (uint)(process_samples + windowLen));
+
+    pBuffer = buffer->ptrBegin();
+    if (pBuffer == nullptr)
+        return;
+
+    assert(process_samples == XCORR_UPDATE_SEQUENCE / 2);
+
+    //    static double thr = 0.0003;
+    double posScale = (double)this->decimateBy / (double)this->sampleRate;
+    int resetDur = (int)(0.12 / posScale + 0.5);
+    double corrScale = 1.0 / (double)(windowLen - windowStart);
+
+    // prescale pbuffer
+    float tmp[XCORR_UPDATE_SEQUENCE / 2];
+    for (int i = 0; i < process_samples; i++)
+    {
+        tmp[i] = hamw2[i] * hamw2[i] * pBuffer[i];
+    }
+
+    #pragma omp parallel for
+    for (int offs = windowStart; offs < windowLen; offs++)
+    {
+        double sum = 0;
+        for (int i = 0; i < process_samples; i++)
+        {
+            sum += tmp[i] * pBuffer[offs + i];
+        }
+        beatcorr_ringbuff[(beatcorr_ringbuffpos + offs) % windowLen] += (float)((sum > 0) ? sum : 0); // accumulate only positive correlations
+    }
+
+    int skipstep = XCORR_UPDATE_SEQUENCE / OVERLAP_FACTOR;
+
+    // compensate empty buffer at beginning by scaling coefficient
+    float scale = (float)windowLen / (float)(skipstep * init_scaler);
+    if (scale > 1.0f)
+    {
+        init_scaler++;
+    }
+    else
+    {
+        scale = 1.0f;
+    }
+
+    // detect beats
+    for (int i = 0; i < skipstep; i++)
+    {
+        LONG_SAMPLETYPE max = 0;
+
+        float sum = beatcorr_ringbuff[beatcorr_ringbuffpos];
+        sum -= beat_lpf.update(sum);
+
+        if (sum > peakVal)
+        {
+            // found new local largest value
+            peakVal = sum;
+            peakPos = pos;
+        }
+        if (pos > peakPos + resetDur)
+        {
+            // largest value not updated for 200msec => accept as beat
+            peakPos += skipstep;
+            if (peakVal > 0)
+            {
+                // add detected beat to end of "beats" vector
+                BEAT temp = { (float)(peakPos * posScale), (float)(peakVal * scale) };
+                beats.push_back(temp);
+            }
+
+            peakVal = 0;
+            peakPos = pos;
+        }
+
+        beatcorr_ringbuff[beatcorr_ringbuffpos] = 0;
+        pos++;
+        beatcorr_ringbuffpos = (beatcorr_ringbuffpos + 1) % windowLen;
+    }
+}
+
+
+#define max(x,y) ((x) > (y) ? (x) : (y))
+
+void BPMDetect::inputSamples(const SAMPLETYPE *samples, int numSamples)
+{
+    SAMPLETYPE decimated[DECIMATED_BLOCK_SIZE];
+
+    if (samples == nullptr || numSamples <= 0 || channels <= 0 || decimateBy <= 0)
+        return;
+
+    // iterate so that max INPUT_BLOCK_SAMPLES processed per iteration
+    while (numSamples > 0)
+    {
+        int block;
+        int decSamples;
+
+        block = (numSamples > INPUT_BLOCK_SIZE) ? INPUT_BLOCK_SIZE : numSamples;
+
+        // decimate. note that converts to mono at the same time
+        decSamples = decimate(decimated, samples, block);
+        samples += block * channels;
+        numSamples -= block;
+
+        buffer->putSamples(decimated, decSamples);
+    }
+
+    // when the buffer has enough samples for processing...
+    int req = max(windowLen + XCORR_UPDATE_SEQUENCE, 2 * XCORR_UPDATE_SEQUENCE);
+    while ((int)buffer->numSamples() >= req)
+    {
+        // ... update autocorrelations...
+        updateXCorr(XCORR_UPDATE_SEQUENCE);
+        // ...update beat position calculation...
+        updateBeatPos(XCORR_UPDATE_SEQUENCE / 2);
+        // ... and remove proceessed samples from the buffer
+        int n = XCORR_UPDATE_SEQUENCE / OVERLAP_FACTOR;
+        buffer->receiveSamples(n);
+    }
+}
+
+
+void BPMDetect::removeBias()
+{
+    int i;
+
+    // Remove linear bias: calculate linear regression coefficient
+    // 1. calc mean of 'xcorr' and 'i'
+    double mean_i = 0;
+    double mean_x = 0;
+    for (i = windowStart; i < windowLen; i++)
+    {
+        mean_x += xcorr[i];
+    }
+    mean_x /= (windowLen - windowStart);
+    mean_i = 0.5 * (windowLen - 1 + windowStart);
+
+    // 2. calculate linear regression coefficient
+    double b = 0;
+    double div = 0;
+    for (i = windowStart; i < windowLen; i++)
+    {
+        double xt = xcorr[i] - mean_x;
+        double xi = i - mean_i;
+        b += xt * xi;
+        div += xi * xi;
+    }
+    b /= div;
+
+    // subtract linear regression and resolve min. value bias
+    float minval = FLT_MAX;   // arbitrary large number
+    for (i = windowStart; i < windowLen; i ++)
+    {
+        xcorr[i] -= (float)(b * i);
+        if (xcorr[i] < minval)
+        {
+            minval = xcorr[i];
+        }
+    }
+
+    // subtract min.value
+    for (i = windowStart; i < windowLen; i ++)
+    {
+        xcorr[i] -= minval;
+    }
+}
+
+
+// Calculate N-point moving average for "source" values
+void MAFilter(float *dest, const float *source, int start, int end, int N)
+{
+    for (int i = start; i < end; i++)
+    {
+        int i1 = i - N / 2;
+        int i2 = i + N / 2 + 1;
+        if (i1 < start) i1 = start;
+        if (i2 > end)   i2 = end;
+
+        double sum = 0;
+        for (int j = i1; j < i2; j ++)
+        {
+            sum += source[j];
+        }
+        dest[i] = (float)(sum / (i2 - i1));
+    }
+}
+
+
+float BPMDetect::getBpm()
+{
+    double peakPos;
+    double coeff;
+    PeakFinder peakFinder;
+
+    // remove bias from xcorr data
+    removeBias();
+
+    coeff = 60.0 * ((double)sampleRate / (double)decimateBy);
+
+    // save bpm debug data if debug data writing enabled
+    _SaveDebugData("soundtouch-bpm-xcorr.txt", xcorr, windowStart, windowLen, coeff);
+
+    // Smoothen by N-point moving-average
+    float *data = new float[windowLen];
+    memset(data, 0, sizeof(float) * windowLen);
+    MAFilter(data, xcorr, windowStart, windowLen, MOVING_AVERAGE_N);
+
+    // find peak position
+    peakPos = peakFinder.detectPeak(data, windowStart, windowLen);
+
+    // save bpm debug data if debug data writing enabled
+    _SaveDebugData("soundtouch-bpm-smoothed.txt", data, windowStart, windowLen, coeff);
+
+    delete[] data;
+
+    assert(decimateBy != 0);
+    if (peakPos < 1e-9) return 0.0; // detection failed.
+
+    _SaveDebugBeatPos("soundtouch-detected-beats.txt", beats);
+
+    // calculate BPM
+    float bpm = (float)(coeff / peakPos);
+    return (bpm >= MIN_BPM && bpm <= MAX_BPM_VALID) ? bpm : 0;
+}
+
+
+/// Get beat position arrays. Note: The array includes also really low beat detection values
+/// in absence of clear strong beats. Consumer may wish to filter low values away.
+/// - "pos" receive array of beat positions
+/// - "values" receive array of beat detection strengths
+/// - max_num indicates max.size of "pos" and "values" array.
+///
+/// You can query a suitable array sized by calling this with NULL in "pos" & "values".
+///
+/// \return number of beats in the arrays.
+int BPMDetect::getBeats(float *pos, float *values, int max_num)
+{
+    int num = beats.size();
+    if ((!pos) || (!values)) return num;    // pos or values NULL, return just size
+
+    for (int i = 0; (i < num) && (i < max_num); i++)
+    {
+        pos[i] = beats[i].pos;
+        values[i] = beats[i].strength;
+    }
+    return num;
+}

--- a/third_party/soundtouch/source/SoundTouch/FIFOSampleBuffer.cpp
+++ b/third_party/soundtouch/source/SoundTouch/FIFOSampleBuffer.cpp
@@ -1,0 +1,267 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// A buffer class for temporarily storaging sound samples, operates as a
+/// first-in-first-out pipe.
+///
+/// Samples are added to the end of the sample buffer with the 'putSamples'
+/// function, and are received from the beginning of the buffer by calling
+/// the 'receiveSamples' function. The class automatically removes the
+/// outputted samples from the buffer, as well as grows the buffer size
+/// whenever necessary.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <stdlib.h>
+#include <memory.h>
+#include <string.h>
+#include <assert.h>
+
+#include "FIFOSampleBuffer.h"
+
+using namespace soundtouch;
+
+// Constructor
+FIFOSampleBuffer::FIFOSampleBuffer(int numChannels)
+{
+    assert(numChannels > 0);
+    sizeInBytes = 0; // reasonable initial value
+    buffer = NULL;
+    bufferUnaligned = NULL;
+    samplesInBuffer = 0;
+    bufferPos = 0;
+    channels = (uint)numChannels;
+    ensureCapacity(32);     // allocate initial capacity
+}
+
+
+// destructor
+FIFOSampleBuffer::~FIFOSampleBuffer()
+{
+    delete[] bufferUnaligned;
+    bufferUnaligned = NULL;
+    buffer = NULL;
+}
+
+
+// Sets number of channels, 1 = mono, 2 = stereo
+void FIFOSampleBuffer::setChannels(int numChannels)
+{
+    uint usedBytes;
+
+    if (!verifyNumberOfChannels(numChannels)) return;
+
+    usedBytes = channels * samplesInBuffer;
+    channels = (uint)numChannels;
+    samplesInBuffer = usedBytes / channels;
+}
+
+
+// if output location pointer 'bufferPos' isn't zero, 'rewinds' the buffer and
+// zeroes this pointer by copying samples from the 'bufferPos' pointer
+// location on to the beginning of the buffer.
+void FIFOSampleBuffer::rewind()
+{
+    if (buffer && bufferPos)
+    {
+        memmove(buffer, ptrBegin(), sizeof(SAMPLETYPE) * channels * samplesInBuffer);
+        bufferPos = 0;
+    }
+}
+
+
+// Adds 'numSamples' pcs of samples from the 'samples' memory position to
+// the sample buffer.
+void FIFOSampleBuffer::putSamples(const SAMPLETYPE *samples, uint nSamples)
+{
+    memcpy(ptrEnd(nSamples), samples, sizeof(SAMPLETYPE) * nSamples * channels);
+    samplesInBuffer += nSamples;
+}
+
+
+// Increases the number of samples in the buffer without copying any actual
+// samples.
+//
+// This function is used to update the number of samples in the sample buffer
+// when accessing the buffer directly with 'ptrEnd' function. Please be
+// careful though!
+void FIFOSampleBuffer::putSamples(uint nSamples)
+{
+    uint req;
+
+    req = samplesInBuffer + nSamples;
+    ensureCapacity(req);
+    samplesInBuffer += nSamples;
+}
+
+
+// Returns a pointer to the end of the used part of the sample buffer (i.e.
+// where the new samples are to be inserted). This function may be used for
+// inserting new samples into the sample buffer directly. Please be careful!
+//
+// Parameter 'slackCapacity' tells the function how much free capacity (in
+// terms of samples) there _at least_ should be, in order to the caller to
+// successfully insert all the required samples to the buffer. When necessary,
+// the function grows the buffer size to comply with this requirement.
+//
+// When using this function as means for inserting new samples, also remember
+// to increase the sample count afterwards, by calling  the
+// 'putSamples(numSamples)' function.
+SAMPLETYPE *FIFOSampleBuffer::ptrEnd(uint slackCapacity)
+{
+    ensureCapacity(samplesInBuffer + slackCapacity);
+    return buffer + samplesInBuffer * channels;
+}
+
+
+// Returns a pointer to the beginning of the currently non-outputted samples.
+// This function is provided for accessing the output samples directly.
+// Please be careful!
+//
+// When using this function to output samples, also remember to 'remove' the
+// outputted samples from the buffer by calling the
+// 'receiveSamples(numSamples)' function
+SAMPLETYPE *FIFOSampleBuffer::ptrBegin()
+{
+    assert(buffer);
+    return buffer + bufferPos * channels;
+}
+
+
+// Ensures that the buffer has enough capacity, i.e. space for _at least_
+// 'capacityRequirement' number of samples. The buffer is grown in steps of
+// 4 kilobytes to eliminate the need for frequently growing up the buffer,
+// as well as to round the buffer size up to the virtual memory page size.
+void FIFOSampleBuffer::ensureCapacity(uint capacityRequirement)
+{
+    SAMPLETYPE *tempUnaligned, *temp;
+
+    if (capacityRequirement > getCapacity())
+    {
+        // enlarge the buffer in 4kbyte steps (round up to next 4k boundary)
+        sizeInBytes = (capacityRequirement * channels * sizeof(SAMPLETYPE) + 4095) & (uint)-4096;
+        assert(sizeInBytes % 2 == 0);
+        tempUnaligned = new SAMPLETYPE[sizeInBytes / sizeof(SAMPLETYPE) + 16 / sizeof(SAMPLETYPE)];
+        if (tempUnaligned == NULL)
+        {
+            ST_THROW_RT_ERROR("Couldn't allocate memory!\n");
+        }
+        // Align the buffer to begin at 16byte cache line boundary for optimal performance
+        temp = (SAMPLETYPE *)SOUNDTOUCH_ALIGN_POINTER_16(tempUnaligned);
+        if (samplesInBuffer)
+        {
+            memcpy(temp, ptrBegin(), samplesInBuffer * channels * sizeof(SAMPLETYPE));
+        }
+        delete[] bufferUnaligned;
+        buffer = temp;
+        bufferUnaligned = tempUnaligned;
+        bufferPos = 0;
+    }
+    else
+    {
+        // simply rewind the buffer (if necessary)
+        rewind();
+    }
+}
+
+
+// Returns the current buffer capacity in terms of samples
+uint FIFOSampleBuffer::getCapacity() const
+{
+    return sizeInBytes / (channels * sizeof(SAMPLETYPE));
+}
+
+
+// Returns the number of samples currently in the buffer
+uint FIFOSampleBuffer::numSamples() const
+{
+    return samplesInBuffer;
+}
+
+
+// Output samples from beginning of the sample buffer. Copies demanded number
+// of samples to output and removes them from the sample buffer. If there
+// are less than 'numsample' samples in the buffer, returns all available.
+//
+// Returns number of samples copied.
+uint FIFOSampleBuffer::receiveSamples(SAMPLETYPE *output, uint maxSamples)
+{
+    uint num;
+
+    num = (maxSamples > samplesInBuffer) ? samplesInBuffer : maxSamples;
+
+    memcpy(output, ptrBegin(), channels * sizeof(SAMPLETYPE) * num);
+    return receiveSamples(num);
+}
+
+
+// Removes samples from the beginning of the sample buffer without copying them
+// anywhere. Used to reduce the number of samples in the buffer, when accessing
+// the sample buffer with the 'ptrBegin' function.
+uint FIFOSampleBuffer::receiveSamples(uint maxSamples)
+{
+    if (maxSamples >= samplesInBuffer)
+    {
+        uint temp;
+
+        temp = samplesInBuffer;
+        samplesInBuffer = 0;
+        return temp;
+    }
+
+    samplesInBuffer -= maxSamples;
+    bufferPos += maxSamples;
+
+    return maxSamples;
+}
+
+
+// Returns nonzero if the sample buffer is empty
+int FIFOSampleBuffer::isEmpty() const
+{
+    return (samplesInBuffer == 0) ? 1 : 0;
+}
+
+
+// Clears the sample buffer
+void FIFOSampleBuffer::clear()
+{
+    samplesInBuffer = 0;
+    bufferPos = 0;
+}
+
+
+/// allow trimming (downwards) amount of samples in pipeline.
+/// Returns adjusted amount of samples
+uint FIFOSampleBuffer::adjustAmountOfSamples(uint numSamples)
+{
+    if (numSamples < samplesInBuffer)
+    {
+        samplesInBuffer = numSamples;
+    }
+    return samplesInBuffer;
+}

--- a/third_party/soundtouch/source/SoundTouch/FIRFilter.cpp
+++ b/third_party/soundtouch/source/SoundTouch/FIRFilter.cpp
@@ -1,0 +1,324 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// General FIR digital filter routines with MMX optimization.
+///
+/// Notes : MMX optimized functions reside in a separate, platform-specific file,
+/// e.g. 'mmx_win.cpp' or 'mmx_gcc.cpp'
+///
+/// This source file contains OpenMP optimizations that allow speeding up the
+/// corss-correlation algorithm by executing it in several threads / CPU cores
+/// in parallel. See the following article link for more detailed discussion
+/// about SoundTouch OpenMP optimizations:
+/// http://www.softwarecoven.com/parallel-computing-in-embedded-mobile-devices
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <memory.h>
+#include <assert.h>
+#include <math.h>
+#include <stdlib.h>
+#include "FIRFilter.h"
+#include "cpu_detect.h"
+
+using namespace soundtouch;
+
+/*****************************************************************************
+ *
+ * Implementation of the class 'FIRFilter'
+ *
+ *****************************************************************************/
+
+FIRFilter::FIRFilter()
+{
+    resultDivFactor = 0;
+    resultDivider = 0;
+    length = 0;
+    lengthDiv8 = 0;
+    filterCoeffs = NULL;
+}
+
+
+FIRFilter::~FIRFilter()
+{
+    delete[] filterCoeffs;
+}
+
+
+// Usual C-version of the filter routine for stereo sound
+uint FIRFilter::evaluateFilterStereo(SAMPLETYPE *dest, const SAMPLETYPE *src, uint numSamples) const
+{
+    int j, end;
+#ifdef SOUNDTOUCH_FLOAT_SAMPLES
+    // when using floating point samples, use a scaler instead of a divider
+    // because division is much slower operation than multiplying.
+    double dScaler = 1.0 / (double)resultDivider;
+#endif
+
+    assert(length != 0);
+    assert(src != NULL);
+    assert(dest != NULL);
+    assert(filterCoeffs != NULL);
+
+    end = 2 * (numSamples - length);
+
+    #pragma omp parallel for
+    for (j = 0; j < end; j += 2)
+    {
+        const SAMPLETYPE *ptr;
+        LONG_SAMPLETYPE suml, sumr;
+        uint i;
+
+        suml = sumr = 0;
+        ptr = src + j;
+
+        for (i = 0; i < length; i += 4)
+        {
+            // loop is unrolled by factor of 4 here for efficiency
+            suml += ptr[2 * i + 0] * filterCoeffs[i + 0] +
+                    ptr[2 * i + 2] * filterCoeffs[i + 1] +
+                    ptr[2 * i + 4] * filterCoeffs[i + 2] +
+                    ptr[2 * i + 6] * filterCoeffs[i + 3];
+            sumr += ptr[2 * i + 1] * filterCoeffs[i + 0] +
+                    ptr[2 * i + 3] * filterCoeffs[i + 1] +
+                    ptr[2 * i + 5] * filterCoeffs[i + 2] +
+                    ptr[2 * i + 7] * filterCoeffs[i + 3];
+        }
+
+#ifdef SOUNDTOUCH_INTEGER_SAMPLES
+        suml >>= resultDivFactor;
+        sumr >>= resultDivFactor;
+        // saturate to 16 bit integer limits
+        suml = (suml < -32768) ? -32768 : (suml > 32767) ? 32767 : suml;
+        // saturate to 16 bit integer limits
+        sumr = (sumr < -32768) ? -32768 : (sumr > 32767) ? 32767 : sumr;
+#else
+        suml *= dScaler;
+        sumr *= dScaler;
+#endif // SOUNDTOUCH_INTEGER_SAMPLES
+        dest[j] = (SAMPLETYPE)suml;
+        dest[j + 1] = (SAMPLETYPE)sumr;
+    }
+    return numSamples - length;
+}
+
+
+// Usual C-version of the filter routine for mono sound
+uint FIRFilter::evaluateFilterMono(SAMPLETYPE *dest, const SAMPLETYPE *src, uint numSamples) const
+{
+    int j, end;
+#ifdef SOUNDTOUCH_FLOAT_SAMPLES
+    // when using floating point samples, use a scaler instead of a divider
+    // because division is much slower operation than multiplying.
+    double dScaler = 1.0 / (double)resultDivider;
+#endif
+
+    assert(length != 0);
+
+    end = numSamples - length;
+    #pragma omp parallel for
+    for (j = 0; j < end; j ++)
+    {
+        const SAMPLETYPE *pSrc = src + j;
+        LONG_SAMPLETYPE sum;
+        uint i;
+
+        sum = 0;
+        for (i = 0; i < length; i += 4)
+        {
+            // loop is unrolled by factor of 4 here for efficiency
+            sum += pSrc[i + 0] * filterCoeffs[i + 0] +
+                   pSrc[i + 1] * filterCoeffs[i + 1] +
+                   pSrc[i + 2] * filterCoeffs[i + 2] +
+                   pSrc[i + 3] * filterCoeffs[i + 3];
+        }
+#ifdef SOUNDTOUCH_INTEGER_SAMPLES
+        sum >>= resultDivFactor;
+        // saturate to 16 bit integer limits
+        sum = (sum < -32768) ? -32768 : (sum > 32767) ? 32767 : sum;
+#else
+        sum *= dScaler;
+#endif // SOUNDTOUCH_INTEGER_SAMPLES
+        dest[j] = (SAMPLETYPE)sum;
+    }
+    return end;
+}
+
+
+uint FIRFilter::evaluateFilterMulti(SAMPLETYPE *dest, const SAMPLETYPE *src, uint numSamples, uint numChannels)
+{
+    int j, end;
+
+#ifdef SOUNDTOUCH_FLOAT_SAMPLES
+    // when using floating point samples, use a scaler instead of a divider
+    // because division is much slower operation than multiplying.
+    double dScaler = 1.0 / (double)resultDivider;
+#endif
+
+    assert(length != 0);
+    assert(src != NULL);
+    assert(dest != NULL);
+    assert(filterCoeffs != NULL);
+    assert(numChannels < 16);
+
+    end = numChannels * (numSamples - length);
+
+    #pragma omp parallel for
+    for (j = 0; j < end; j += numChannels)
+    {
+        const SAMPLETYPE *ptr;
+        LONG_SAMPLETYPE sums[16];
+        uint c, i;
+
+        for (c = 0; c < numChannels; c ++)
+        {
+            sums[c] = 0;
+        }
+
+        ptr = src + j;
+
+        for (i = 0; i < length; i ++)
+        {
+            SAMPLETYPE coef=filterCoeffs[i];
+            for (c = 0; c < numChannels; c ++)
+            {
+                sums[c] += ptr[0] * coef;
+                ptr ++;
+            }
+        }
+
+        for (c = 0; c < numChannels; c ++)
+        {
+#ifdef SOUNDTOUCH_INTEGER_SAMPLES
+            sums[c] >>= resultDivFactor;
+#else
+            sums[c] *= dScaler;
+#endif // SOUNDTOUCH_INTEGER_SAMPLES
+            dest[j+c] = (SAMPLETYPE)sums[c];
+        }
+    }
+    return numSamples - length;
+}
+
+
+// Set filter coeffiecients and length.
+//
+// Throws an exception if filter length isn't divisible by 8
+void FIRFilter::setCoefficients(const SAMPLETYPE *coeffs, uint newLength, uint uResultDivFactor)
+{
+    assert(newLength > 0);
+    if (newLength % 8) ST_THROW_RT_ERROR("FIR filter length not divisible by 8");
+
+    lengthDiv8 = newLength / 8;
+    length = lengthDiv8 * 8;
+    assert(length == newLength);
+
+    resultDivFactor = uResultDivFactor;
+    resultDivider = (SAMPLETYPE)::pow(2.0, (int)resultDivFactor);
+
+    delete[] filterCoeffs;
+    filterCoeffs = new SAMPLETYPE[length];
+    memcpy(filterCoeffs, coeffs, length * sizeof(SAMPLETYPE));
+}
+
+
+uint FIRFilter::getLength() const
+{
+    return length;
+}
+
+
+// Applies the filter to the given sequence of samples.
+//
+// Note : The amount of outputted samples is by value of 'filter_length'
+// smaller than the amount of input samples.
+uint FIRFilter::evaluate(SAMPLETYPE *dest, const SAMPLETYPE *src, uint numSamples, uint numChannels)
+{
+    assert(length > 0);
+    assert(lengthDiv8 * 8 == length);
+
+    if (numSamples < length) return 0;
+
+#ifndef USE_MULTICH_ALWAYS
+    if (numChannels == 1)
+    {
+        return evaluateFilterMono(dest, src, numSamples);
+    }
+    else if (numChannels == 2)
+    {
+        return evaluateFilterStereo(dest, src, numSamples);
+    }
+    else
+#endif // USE_MULTICH_ALWAYS
+    {
+        assert(numChannels > 0);
+        return evaluateFilterMulti(dest, src, numSamples, numChannels);
+    }
+}
+
+
+// Operator 'new' is overloaded so that it automatically creates a suitable instance
+// depending on if we've a MMX-capable CPU available or not.
+void * FIRFilter::operator new(size_t s)
+{
+    // Notice! don't use "new FIRFilter" directly, use "newInstance" to create a new instance instead!
+    ST_THROW_RT_ERROR("Error in FIRFilter::new: Don't use 'new FIRFilter', use 'newInstance' member instead!");
+    return newInstance();
+}
+
+
+FIRFilter * FIRFilter::newInstance()
+{
+    uint uExtensions;
+
+    uExtensions = detectCPUextensions();
+
+    // Check if MMX/SSE instruction set extensions supported by CPU
+
+#ifdef SOUNDTOUCH_ALLOW_MMX
+    // MMX routines available only with integer sample types
+    if (uExtensions & SUPPORT_MMX)
+    {
+        return ::new FIRFilterMMX;
+    }
+    else
+#endif // SOUNDTOUCH_ALLOW_MMX
+
+#ifdef SOUNDTOUCH_ALLOW_SSE
+    if (uExtensions & SUPPORT_SSE)
+    {
+        // SSE support
+        return ::new FIRFilterSSE;
+    }
+    else
+#endif // SOUNDTOUCH_ALLOW_SSE
+
+    {
+        // ISA optimizations not supported, use plain C version
+        return ::new FIRFilter;
+    }
+}

--- a/third_party/soundtouch/source/SoundTouch/FIRFilter.h
+++ b/third_party/soundtouch/source/SoundTouch/FIRFilter.h
@@ -1,0 +1,139 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// General FIR digital filter routines with MMX optimization.
+///
+/// Note : MMX optimized functions reside in a separate, platform-specific file,
+/// e.g. 'mmx_win.cpp' or 'mmx_gcc.cpp'
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef FIRFilter_H
+#define FIRFilter_H
+
+#include <stddef.h>
+#include "STTypes.h"
+
+namespace soundtouch
+{
+
+class FIRFilter
+{
+protected:
+    // Number of FIR filter taps
+    uint length;
+    // Number of FIR filter taps divided by 8
+    uint lengthDiv8;
+
+    // Result divider factor in 2^k format
+    uint resultDivFactor;
+
+    // Result divider value.
+    SAMPLETYPE resultDivider;
+
+    // Memory for filter coefficients
+    SAMPLETYPE *filterCoeffs;
+
+    virtual uint evaluateFilterStereo(SAMPLETYPE *dest,
+                                      const SAMPLETYPE *src,
+                                      uint numSamples) const;
+    virtual uint evaluateFilterMono(SAMPLETYPE *dest,
+                                    const SAMPLETYPE *src,
+                                    uint numSamples) const;
+    virtual uint evaluateFilterMulti(SAMPLETYPE *dest, const SAMPLETYPE *src, uint numSamples, uint numChannels);
+
+public:
+    FIRFilter();
+    virtual ~FIRFilter();
+
+    /// Operator 'new' is overloaded so that it automatically creates a suitable instance
+    /// depending on if we've a MMX-capable CPU available or not.
+    static void * operator new(size_t s);
+
+    static FIRFilter *newInstance();
+
+    /// Applies the filter to the given sequence of samples.
+    /// Note : The amount of outputted samples is by value of 'filter_length'
+    /// smaller than the amount of input samples.
+    ///
+    /// \return Number of samples copied to 'dest'.
+    uint evaluate(SAMPLETYPE *dest,
+                  const SAMPLETYPE *src,
+                  uint numSamples,
+                  uint numChannels);
+
+    uint getLength() const;
+
+    virtual void setCoefficients(const SAMPLETYPE *coeffs,
+                                 uint newLength,
+                                 uint uResultDivFactor);
+};
+
+
+// Optional subclasses that implement CPU-specific optimizations:
+
+#ifdef SOUNDTOUCH_ALLOW_MMX
+
+/// Class that implements MMX optimized functions exclusive for 16bit integer samples type.
+    class FIRFilterMMX : public FIRFilter
+    {
+    protected:
+        short *filterCoeffsUnalign;
+        short *filterCoeffsAlign;
+
+        virtual uint evaluateFilterStereo(short *dest, const short *src, uint numSamples) const;
+    public:
+        FIRFilterMMX();
+        ~FIRFilterMMX();
+
+        virtual void setCoefficients(const short *coeffs, uint newLength, uint uResultDivFactor);
+    };
+
+#endif // SOUNDTOUCH_ALLOW_MMX
+
+
+#ifdef SOUNDTOUCH_ALLOW_SSE
+    /// Class that implements SSE optimized functions exclusive for floating point samples type.
+    class FIRFilterSSE : public FIRFilter
+    {
+    protected:
+        float *filterCoeffsUnalign;
+        float *filterCoeffsAlign;
+
+        virtual uint evaluateFilterStereo(float *dest, const float *src, uint numSamples) const;
+    public:
+        FIRFilterSSE();
+        ~FIRFilterSSE();
+
+        virtual void setCoefficients(const float *coeffs, uint newLength, uint uResultDivFactor);
+    };
+
+#endif // SOUNDTOUCH_ALLOW_SSE
+
+}
+
+#endif  // FIRFilter_H

--- a/third_party/soundtouch/source/SoundTouch/InterpolateCubic.cpp
+++ b/third_party/soundtouch/source/SoundTouch/InterpolateCubic.cpp
@@ -1,0 +1,196 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Cubic interpolation routine.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <stddef.h>
+#include <math.h>
+#include "InterpolateCubic.h"
+#include "STTypes.h"
+
+using namespace soundtouch;
+
+// cubic interpolation coefficients
+static const float _coeffs[]=
+{ -0.5f,  1.0f, -0.5f, 0.0f,
+   1.5f, -2.5f,  0.0f, 1.0f,
+  -1.5f,  2.0f,  0.5f, 0.0f,
+   0.5f, -0.5f,  0.0f, 0.0f};
+
+
+InterpolateCubic::InterpolateCubic()
+{
+    fract = 0;
+}
+
+
+void InterpolateCubic::resetRegisters()
+{
+    fract = 0;
+}
+
+
+/// Transpose mono audio. Returns number of produced output samples, and
+/// updates "srcSamples" to amount of consumed source samples
+int InterpolateCubic::transposeMono(SAMPLETYPE *pdest,
+                    const SAMPLETYPE *psrc,
+                    int &srcSamples)
+{
+    int i;
+    int srcSampleEnd = srcSamples - 4;
+    int srcCount = 0;
+
+    i = 0;
+    while (srcCount < srcSampleEnd)
+    {
+        float out;
+        const float x3 = 1.0f;
+        const float x2 = (float)fract;    // x
+        const float x1 = x2*x2;           // x^2
+        const float x0 = x1*x2;           // x^3
+        float y0, y1, y2, y3;
+
+        assert(fract < 1.0);
+
+        y0 =  _coeffs[0] * x0 +  _coeffs[1] * x1 +  _coeffs[2] * x2 +  _coeffs[3] * x3;
+        y1 =  _coeffs[4] * x0 +  _coeffs[5] * x1 +  _coeffs[6] * x2 +  _coeffs[7] * x3;
+        y2 =  _coeffs[8] * x0 +  _coeffs[9] * x1 + _coeffs[10] * x2 + _coeffs[11] * x3;
+        y3 = _coeffs[12] * x0 + _coeffs[13] * x1 + _coeffs[14] * x2 + _coeffs[15] * x3;
+
+        out = y0 * psrc[0] + y1 * psrc[1] + y2 * psrc[2] + y3 * psrc[3];
+
+        pdest[i] = (SAMPLETYPE)out;
+        i ++;
+
+        // update position fraction
+        fract += rate;
+        // update whole positions
+        int whole = (int)fract;
+        fract -= whole;
+        psrc += whole;
+        srcCount += whole;
+    }
+    srcSamples = srcCount;
+    return i;
+}
+
+
+/// Transpose stereo audio. Returns number of produced output samples, and
+/// updates "srcSamples" to amount of consumed source samples
+int InterpolateCubic::transposeStereo(SAMPLETYPE *pdest,
+                    const SAMPLETYPE *psrc,
+                    int &srcSamples)
+{
+    int i;
+    int srcSampleEnd = srcSamples - 4;
+    int srcCount = 0;
+
+    i = 0;
+    while (srcCount < srcSampleEnd)
+    {
+        const float x3 = 1.0f;
+        const float x2 = (float)fract;    // x
+        const float x1 = x2*x2;           // x^2
+        const float x0 = x1*x2;           // x^3
+        float y0, y1, y2, y3;
+        float out0, out1;
+
+        assert(fract < 1.0);
+
+        y0 =  _coeffs[0] * x0 +  _coeffs[1] * x1 +  _coeffs[2] * x2 +  _coeffs[3] * x3;
+        y1 =  _coeffs[4] * x0 +  _coeffs[5] * x1 +  _coeffs[6] * x2 +  _coeffs[7] * x3;
+        y2 =  _coeffs[8] * x0 +  _coeffs[9] * x1 + _coeffs[10] * x2 + _coeffs[11] * x3;
+        y3 = _coeffs[12] * x0 + _coeffs[13] * x1 + _coeffs[14] * x2 + _coeffs[15] * x3;
+
+        out0 = y0 * psrc[0] + y1 * psrc[2] + y2 * psrc[4] + y3 * psrc[6];
+        out1 = y0 * psrc[1] + y1 * psrc[3] + y2 * psrc[5] + y3 * psrc[7];
+
+        pdest[2*i]   = (SAMPLETYPE)out0;
+        pdest[2*i+1] = (SAMPLETYPE)out1;
+        i ++;
+
+        // update position fraction
+        fract += rate;
+        // update whole positions
+        int whole = (int)fract;
+        fract -= whole;
+        psrc += 2*whole;
+        srcCount += whole;
+    }
+    srcSamples = srcCount;
+    return i;
+}
+
+
+/// Transpose multi-channel audio. Returns number of produced output samples, and
+/// updates "srcSamples" to amount of consumed source samples
+int InterpolateCubic::transposeMulti(SAMPLETYPE *pdest,
+                    const SAMPLETYPE *psrc,
+                    int &srcSamples)
+{
+    int i;
+    int srcSampleEnd = srcSamples - 4;
+    int srcCount = 0;
+
+    i = 0;
+    while (srcCount < srcSampleEnd)
+    {
+        const float x3 = 1.0f;
+        const float x2 = (float)fract;    // x
+        const float x1 = x2*x2;           // x^2
+        const float x0 = x1*x2;           // x^3
+        float y0, y1, y2, y3;
+
+        assert(fract < 1.0);
+
+        y0 =  _coeffs[0] * x0 +  _coeffs[1] * x1 +  _coeffs[2] * x2 +  _coeffs[3] * x3;
+        y1 =  _coeffs[4] * x0 +  _coeffs[5] * x1 +  _coeffs[6] * x2 +  _coeffs[7] * x3;
+        y2 =  _coeffs[8] * x0 +  _coeffs[9] * x1 + _coeffs[10] * x2 + _coeffs[11] * x3;
+        y3 = _coeffs[12] * x0 + _coeffs[13] * x1 + _coeffs[14] * x2 + _coeffs[15] * x3;
+
+        for (int c = 0; c < numChannels; c ++)
+        {
+            float out;
+            out = y0 * psrc[c] + y1 * psrc[c + numChannels] + y2 * psrc[c + 2 * numChannels] + y3 * psrc[c + 3 * numChannels];
+            pdest[0] = (SAMPLETYPE)out;
+            pdest ++;
+        }
+        i ++;
+
+        // update position fraction
+        fract += rate;
+        // update whole positions
+        int whole = (int)fract;
+        fract -= whole;
+        psrc += numChannels*whole;
+        srcCount += whole;
+    }
+    srcSamples = srcCount;
+    return i;
+}

--- a/third_party/soundtouch/source/SoundTouch/InterpolateCubic.h
+++ b/third_party/soundtouch/source/SoundTouch/InterpolateCubic.h
@@ -1,0 +1,63 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Cubic interpolation routine.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef _InterpolateCubic_H_
+#define _InterpolateCubic_H_
+
+#include "RateTransposer.h"
+#include "STTypes.h"
+
+namespace soundtouch
+{
+
+class InterpolateCubic : public TransposerBase
+{
+protected:
+    virtual void resetRegisters();
+    virtual int transposeMono(SAMPLETYPE *dest,
+                        const SAMPLETYPE *src,
+                        int &srcSamples);
+    virtual int transposeStereo(SAMPLETYPE *dest,
+                        const SAMPLETYPE *src,
+                        int &srcSamples);
+    virtual int transposeMulti(SAMPLETYPE *dest,
+                        const SAMPLETYPE *src,
+                        int &srcSamples);
+
+    double fract;
+
+public:
+    InterpolateCubic();
+};
+
+}
+
+#endif

--- a/third_party/soundtouch/source/SoundTouch/InterpolateLinear.cpp
+++ b/third_party/soundtouch/source/SoundTouch/InterpolateLinear.cpp
@@ -1,0 +1,296 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Linear interpolation algorithm.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <assert.h>
+#include <stdlib.h>
+#include "InterpolateLinear.h"
+
+using namespace soundtouch;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// InterpolateLinearInteger - integer arithmetic implementation
+//
+
+/// fixed-point interpolation routine precision
+#define SCALE    65536
+
+
+// Constructor
+InterpolateLinearInteger::InterpolateLinearInteger() : TransposerBase()
+{
+    // Notice: use local function calling syntax for sake of clarity,
+    // to indicate the fact that C++ constructor can't call virtual functions.
+    resetRegisters();
+    setRate(1.0f);
+}
+
+
+void InterpolateLinearInteger::resetRegisters()
+{
+    iFract = 0;
+}
+
+
+// Transposes the sample rate of the given samples using linear interpolation.
+// 'Mono' version of the routine. Returns the number of samples returned in
+// the "dest" buffer
+int InterpolateLinearInteger::transposeMono(SAMPLETYPE *dest, const SAMPLETYPE *src, int &srcSamples)
+{
+    int i;
+    int srcSampleEnd = srcSamples - 1;
+    int srcCount = 0;
+
+    i = 0;
+    while (srcCount < srcSampleEnd)
+    {
+        LONG_SAMPLETYPE temp;
+
+        assert(iFract < SCALE);
+
+        temp = (SCALE - iFract) * src[0] + iFract * src[1];
+        dest[i] = (SAMPLETYPE)(temp / SCALE);
+        i++;
+
+        iFract += iRate;
+
+        int iWhole = iFract / SCALE;
+        iFract -= iWhole * SCALE;
+        srcCount += iWhole;
+        src += iWhole;
+    }
+    srcSamples = srcCount;
+
+    return i;
+}
+
+
+// Transposes the sample rate of the given samples using linear interpolation.
+// 'Stereo' version of the routine. Returns the number of samples returned in
+// the "dest" buffer
+int InterpolateLinearInteger::transposeStereo(SAMPLETYPE *dest, const SAMPLETYPE *src, int &srcSamples)
+{
+    int i;
+    int srcSampleEnd = srcSamples - 1;
+    int srcCount = 0;
+
+    i = 0;
+    while (srcCount < srcSampleEnd)
+    {
+        LONG_SAMPLETYPE temp0;
+        LONG_SAMPLETYPE temp1;
+
+        assert(iFract < SCALE);
+
+        temp0 = (SCALE - iFract) * src[0] + iFract * src[2];
+        temp1 = (SCALE - iFract) * src[1] + iFract * src[3];
+        dest[0] = (SAMPLETYPE)(temp0 / SCALE);
+        dest[1] = (SAMPLETYPE)(temp1 / SCALE);
+        dest += 2;
+        i++;
+
+        iFract += iRate;
+
+        int iWhole = iFract / SCALE;
+        iFract -= iWhole * SCALE;
+        srcCount += iWhole;
+        src += 2*iWhole;
+    }
+    srcSamples = srcCount;
+
+    return i;
+}
+
+
+int InterpolateLinearInteger::transposeMulti(SAMPLETYPE *dest, const SAMPLETYPE *src, int &srcSamples)
+{
+    int i;
+    int srcSampleEnd = srcSamples - 1;
+    int srcCount = 0;
+
+    i = 0;
+    while (srcCount < srcSampleEnd)
+    {
+        LONG_SAMPLETYPE temp, vol1;
+
+        assert(iFract < SCALE);
+        vol1 = (SCALE - iFract);
+        for (int c = 0; c < numChannels; c ++)
+        {
+            temp = vol1 * src[c] + iFract * src[c + numChannels];
+            dest[0] = (SAMPLETYPE)(temp / SCALE);
+            dest ++;
+        }
+        i++;
+
+        iFract += iRate;
+
+        int iWhole = iFract / SCALE;
+        iFract -= iWhole * SCALE;
+        srcCount += iWhole;
+        src += iWhole * numChannels;
+    }
+    srcSamples = srcCount;
+
+    return i;
+}
+
+
+// Sets new target iRate. Normal iRate = 1.0, smaller values represent slower
+// iRate, larger faster iRates.
+void InterpolateLinearInteger::setRate(double newRate)
+{
+    iRate = (int)(newRate * SCALE + 0.5);
+    TransposerBase::setRate(newRate);
+}
+
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// InterpolateLinearFloat - floating point arithmetic implementation
+//
+//////////////////////////////////////////////////////////////////////////////
+
+
+// Constructor
+InterpolateLinearFloat::InterpolateLinearFloat() : TransposerBase()
+{
+    // Notice: use local function calling syntax for sake of clarity,
+    // to indicate the fact that C++ constructor can't call virtual functions.
+    resetRegisters();
+    setRate(1.0);
+}
+
+
+void InterpolateLinearFloat::resetRegisters()
+{
+    fract = 0;
+}
+
+
+// Transposes the sample rate of the given samples using linear interpolation.
+// 'Mono' version of the routine. Returns the number of samples returned in
+// the "dest" buffer
+int InterpolateLinearFloat::transposeMono(SAMPLETYPE *dest, const SAMPLETYPE *src, int &srcSamples)
+{
+    int i;
+    int srcSampleEnd = srcSamples - 1;
+    int srcCount = 0;
+
+    i = 0;
+    while (srcCount < srcSampleEnd)
+    {
+        double out;
+        assert(fract < 1.0);
+
+        out = (1.0 - fract) * src[0] + fract * src[1];
+        dest[i] = (SAMPLETYPE)out;
+        i ++;
+
+        // update position fraction
+        fract += rate;
+        // update whole positions
+        int whole = (int)fract;
+        fract -= whole;
+        src += whole;
+        srcCount += whole;
+    }
+    srcSamples = srcCount;
+    return i;
+}
+
+
+// Transposes the sample rate of the given samples using linear interpolation.
+// 'Mono' version of the routine. Returns the number of samples returned in
+// the "dest" buffer
+int InterpolateLinearFloat::transposeStereo(SAMPLETYPE *dest, const SAMPLETYPE *src, int &srcSamples)
+{
+    int i;
+    int srcSampleEnd = srcSamples - 1;
+    int srcCount = 0;
+
+    i = 0;
+    while (srcCount < srcSampleEnd)
+    {
+        double out0, out1;
+        assert(fract < 1.0);
+
+        out0 = (1.0 - fract) * src[0] + fract * src[2];
+        out1 = (1.0 - fract) * src[1] + fract * src[3];
+        dest[2*i]   = (SAMPLETYPE)out0;
+        dest[2*i+1] = (SAMPLETYPE)out1;
+        i ++;
+
+        // update position fraction
+        fract += rate;
+        // update whole positions
+        int whole = (int)fract;
+        fract -= whole;
+        src += 2*whole;
+        srcCount += whole;
+    }
+    srcSamples = srcCount;
+    return i;
+}
+
+
+int InterpolateLinearFloat::transposeMulti(SAMPLETYPE *dest, const SAMPLETYPE *src, int &srcSamples)
+{
+    int i;
+    int srcSampleEnd = srcSamples - 1;
+    int srcCount = 0;
+
+    i = 0;
+    while (srcCount < srcSampleEnd)
+    {
+        float temp, vol1, fract_float;
+
+        vol1 = (float)(1.0 - fract);
+        fract_float = (float)fract;
+        for (int c = 0; c < numChannels; c ++)
+        {
+            temp = vol1 * src[c] + fract_float * src[c + numChannels];
+            *dest = (SAMPLETYPE)temp;
+            dest ++;
+        }
+        i++;
+
+        fract += rate;
+
+        int iWhole = (int)fract;
+        fract -= iWhole;
+        srcCount += iWhole;
+        src += iWhole * numChannels;
+    }
+    srcSamples = srcCount;
+
+    return i;
+}

--- a/third_party/soundtouch/source/SoundTouch/InterpolateLinear.h
+++ b/third_party/soundtouch/source/SoundTouch/InterpolateLinear.h
@@ -1,0 +1,88 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Linear interpolation routine.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef _InterpolateLinear_H_
+#define _InterpolateLinear_H_
+
+#include "RateTransposer.h"
+#include "STTypes.h"
+
+namespace soundtouch
+{
+
+/// Linear transposer class that uses integer arithmetic
+class InterpolateLinearInteger : public TransposerBase
+{
+protected:
+    int iFract;
+    int iRate;
+
+    virtual void resetRegisters();
+
+    virtual int transposeMono(SAMPLETYPE *dest,
+                       const SAMPLETYPE *src,
+                       int &srcSamples);
+    virtual int transposeStereo(SAMPLETYPE *dest,
+                         const SAMPLETYPE *src,
+                         int &srcSamples);
+    virtual int transposeMulti(SAMPLETYPE *dest, const SAMPLETYPE *src, int &srcSamples);
+public:
+    InterpolateLinearInteger();
+
+    /// Sets new target rate. Normal rate = 1.0, smaller values represent slower
+    /// rate, larger faster rates.
+    virtual void setRate(double newRate);
+};
+
+
+/// Linear transposer class that uses floating point arithmetic
+class InterpolateLinearFloat : public TransposerBase
+{
+protected:
+    double fract;
+
+    virtual void resetRegisters();
+
+    virtual int transposeMono(SAMPLETYPE *dest,
+                       const SAMPLETYPE *src,
+                       int &srcSamples);
+    virtual int transposeStereo(SAMPLETYPE *dest,
+                         const SAMPLETYPE *src,
+                         int &srcSamples);
+    virtual int transposeMulti(SAMPLETYPE *dest, const SAMPLETYPE *src, int &srcSamples);
+
+public:
+    InterpolateLinearFloat();
+};
+
+}
+
+#endif

--- a/third_party/soundtouch/source/SoundTouch/InterpolateShannon.cpp
+++ b/third_party/soundtouch/source/SoundTouch/InterpolateShannon.cpp
@@ -1,0 +1,181 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Sample interpolation routine using 8-tap band-limited Shannon interpolation
+/// with kaiser window.
+///
+/// Notice. This algorithm is remarkably much heavier than linear or cubic
+/// interpolation, and not remarkably better than cubic algorithm. Thus mostly
+/// for experimental purposes
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <math.h>
+#include "InterpolateShannon.h"
+#include "STTypes.h"
+
+using namespace soundtouch;
+
+
+/// Kaiser window with beta = 2.0
+/// Values scaled down by 5% to avoid overflows
+static const double _kaiser8[8] =
+{
+   0.41778693317814,
+   0.64888025049173,
+   0.83508562409944,
+   0.93887857733412,
+   0.93887857733412,
+   0.83508562409944,
+   0.64888025049173,
+   0.41778693317814
+};
+
+
+InterpolateShannon::InterpolateShannon()
+{
+    fract = 0;
+}
+
+
+void InterpolateShannon::resetRegisters()
+{
+    fract = 0;
+}
+
+
+#define PI 3.1415926536
+#define sinc(x) (sin(PI * (x)) / (PI * (x)))
+
+/// Transpose mono audio. Returns number of produced output samples, and
+/// updates "srcSamples" to amount of consumed source samples
+int InterpolateShannon::transposeMono(SAMPLETYPE *pdest,
+                    const SAMPLETYPE *psrc,
+                    int &srcSamples)
+{
+    int i;
+    int srcSampleEnd = srcSamples - 8;
+    int srcCount = 0;
+
+    i = 0;
+    while (srcCount < srcSampleEnd)
+    {
+        double out;
+        assert(fract < 1.0);
+
+        out  = psrc[0] * sinc(-3.0 - fract) * _kaiser8[0];
+        out += psrc[1] * sinc(-2.0 - fract) * _kaiser8[1];
+        out += psrc[2] * sinc(-1.0 - fract) * _kaiser8[2];
+        if (fract < 1e-6)
+        {
+            out += psrc[3] * _kaiser8[3];     // sinc(0) = 1
+        }
+        else
+        {
+            out += psrc[3] * sinc(- fract) * _kaiser8[3];
+        }
+        out += psrc[4] * sinc( 1.0 - fract) * _kaiser8[4];
+        out += psrc[5] * sinc( 2.0 - fract) * _kaiser8[5];
+        out += psrc[6] * sinc( 3.0 - fract) * _kaiser8[6];
+        out += psrc[7] * sinc( 4.0 - fract) * _kaiser8[7];
+
+        pdest[i] = (SAMPLETYPE)out;
+        i ++;
+
+        // update position fraction
+        fract += rate;
+        // update whole positions
+        int whole = (int)fract;
+        fract -= whole;
+        psrc += whole;
+        srcCount += whole;
+    }
+    srcSamples = srcCount;
+    return i;
+}
+
+
+/// Transpose stereo audio. Returns number of produced output samples, and
+/// updates "srcSamples" to amount of consumed source samples
+int InterpolateShannon::transposeStereo(SAMPLETYPE *pdest,
+                    const SAMPLETYPE *psrc,
+                    int &srcSamples)
+{
+    int i;
+    int srcSampleEnd = srcSamples - 8;
+    int srcCount = 0;
+
+    i = 0;
+    while (srcCount < srcSampleEnd)
+    {
+        double out0, out1, w;
+        assert(fract < 1.0);
+
+        w = sinc(-3.0 - fract) * _kaiser8[0];
+        out0 = psrc[0] * w; out1 = psrc[1] * w;
+        w = sinc(-2.0 - fract) * _kaiser8[1];
+        out0 += psrc[2] * w; out1 += psrc[3] * w;
+        w = sinc(-1.0 - fract) * _kaiser8[2];
+        out0 += psrc[4] * w; out1 += psrc[5] * w;
+        w = _kaiser8[3] * ((fract < 1e-5) ? 1.0 : sinc(- fract));   // sinc(0) = 1
+        out0 += psrc[6] * w; out1 += psrc[7] * w;
+        w = sinc( 1.0 - fract) * _kaiser8[4];
+        out0 += psrc[8] * w; out1 += psrc[9] * w;
+        w = sinc( 2.0 - fract) * _kaiser8[5];
+        out0 += psrc[10] * w; out1 += psrc[11] * w;
+        w = sinc( 3.0 - fract) * _kaiser8[6];
+        out0 += psrc[12] * w; out1 += psrc[13] * w;
+        w = sinc( 4.0 - fract) * _kaiser8[7];
+        out0 += psrc[14] * w; out1 += psrc[15] * w;
+
+        pdest[2*i]   = (SAMPLETYPE)out0;
+        pdest[2*i+1] = (SAMPLETYPE)out1;
+        i ++;
+
+        // update position fraction
+        fract += rate;
+        // update whole positions
+        int whole = (int)fract;
+        fract -= whole;
+        psrc += 2*whole;
+        srcCount += whole;
+    }
+    srcSamples = srcCount;
+    return i;
+}
+
+
+/// Transpose stereo audio. Returns number of produced output samples, and
+/// updates "srcSamples" to amount of consumed source samples
+int InterpolateShannon::transposeMulti(SAMPLETYPE *pdest,
+                    const SAMPLETYPE *psrc,
+                    int &srcSamples)
+{
+    // not implemented
+    assert(false);
+    return 0;
+}

--- a/third_party/soundtouch/source/SoundTouch/InterpolateShannon.h
+++ b/third_party/soundtouch/source/SoundTouch/InterpolateShannon.h
@@ -1,0 +1,68 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Sample interpolation routine using 8-tap band-limited Shannon interpolation
+/// with kaiser window.
+///
+/// Notice. This algorithm is remarkably much heavier than linear or cubic
+/// interpolation, and not remarkably better than cubic algorithm. Thus mostly
+/// for experimental purposes
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef _InterpolateShannon_H_
+#define _InterpolateShannon_H_
+
+#include "RateTransposer.h"
+#include "STTypes.h"
+
+namespace soundtouch
+{
+
+class InterpolateShannon : public TransposerBase
+{
+protected:
+    void resetRegisters();
+    int transposeMono(SAMPLETYPE *dest,
+                        const SAMPLETYPE *src,
+                        int &srcSamples);
+    int transposeStereo(SAMPLETYPE *dest,
+                        const SAMPLETYPE *src,
+                        int &srcSamples);
+    int transposeMulti(SAMPLETYPE *dest,
+                        const SAMPLETYPE *src,
+                        int &srcSamples);
+
+    double fract;
+
+public:
+    InterpolateShannon();
+};
+
+}
+
+#endif

--- a/third_party/soundtouch/source/SoundTouch/PeakFinder.cpp
+++ b/third_party/soundtouch/source/SoundTouch/PeakFinder.cpp
@@ -1,0 +1,277 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Peak detection routine.
+///
+/// The routine detects highest value on an array of values and calculates the
+/// precise peak location as a mass-center of the 'hump' around the peak value.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <math.h>
+#include <assert.h>
+
+#include "PeakFinder.h"
+
+using namespace soundtouch;
+
+#define max(x, y) (((x) > (y)) ? (x) : (y))
+
+
+PeakFinder::PeakFinder()
+{
+    minPos = maxPos = 0;
+}
+
+
+// Finds real 'top' of a peak hump from neighnourhood of the given 'peakpos'.
+int PeakFinder::findTop(const float *data, int peakpos) const
+{
+    int i;
+    int start, end;
+    float refvalue;
+
+    refvalue = data[peakpos];
+
+    // seek within �10 points
+    start = peakpos - 10;
+    if (start < minPos) start = minPos;
+    end = peakpos + 10;
+    if (end > maxPos) end = maxPos;
+
+    for (i = start; i <= end; i ++)
+    {
+        if (data[i] > refvalue)
+        {
+            peakpos = i;
+            refvalue = data[i];
+        }
+    }
+
+    // failure if max value is at edges of seek range => it's not peak, it's at slope.
+    if ((peakpos == start) || (peakpos == end)) return 0;
+
+    return peakpos;
+}
+
+
+// Finds 'ground level' of a peak hump by starting from 'peakpos' and proceeding
+// to direction defined by 'direction' until next 'hump' after minimum value will
+// begin
+int PeakFinder::findGround(const float *data, int peakpos, int direction) const
+{
+    int lowpos;
+    int pos;
+    int climb_count;
+    float refvalue;
+    float delta;
+
+    climb_count = 0;
+    refvalue = data[peakpos];
+    lowpos = peakpos;
+
+    pos = peakpos;
+
+    while ((pos > minPos+1) && (pos < maxPos-1))
+    {
+        int prevpos;
+
+        prevpos = pos;
+        pos += direction;
+
+        // calculate derivate
+        delta = data[pos] - data[prevpos];
+        if (delta <= 0)
+        {
+            // going downhill, ok
+            if (climb_count)
+            {
+                climb_count --;  // decrease climb count
+            }
+
+            // check if new minimum found
+            if (data[pos] < refvalue)
+            {
+                // new minimum found
+                lowpos = pos;
+                refvalue = data[pos];
+            }
+        }
+        else
+        {
+            // going uphill, increase climbing counter
+            climb_count ++;
+            if (climb_count > 5) break;    // we've been climbing too long => it's next uphill => quit
+        }
+    }
+    return lowpos;
+}
+
+
+// Find offset where the value crosses the given level, when starting from 'peakpos' and
+// proceeds to direction defined in 'direction'
+int PeakFinder::findCrossingLevel(const float *data, float level, int peakpos, int direction) const
+{
+    float peaklevel;
+    int pos;
+
+    peaklevel = data[peakpos];
+    assert(peaklevel >= level);
+    pos = peakpos;
+    while ((pos >= minPos) && (pos < maxPos))
+    {
+        if (data[pos + direction] < level) return pos;   // crossing found
+        pos += direction;
+    }
+    return -1;  // not found
+}
+
+
+// Calculates the center of mass location of 'data' array items between 'firstPos' and 'lastPos'
+double PeakFinder::calcMassCenter(const float *data, int firstPos, int lastPos) const
+{
+    int i;
+    float sum;
+    float wsum;
+
+    sum = 0;
+    wsum = 0;
+    for (i = firstPos; i <= lastPos; i ++)
+    {
+        sum += (float)i * data[i];
+        wsum += data[i];
+    }
+
+    if (wsum < 1e-6) return 0;
+    return sum / wsum;
+}
+
+
+/// get exact center of peak near given position by calculating local mass of center
+double PeakFinder::getPeakCenter(const float *data, int peakpos) const
+{
+    float peakLevel;            // peak level
+    int crosspos1, crosspos2;   // position where the peak 'hump' crosses cutting level
+    float cutLevel;             // cutting value
+    float groundLevel;          // ground level of the peak
+    int gp1, gp2;               // bottom positions of the peak 'hump'
+
+    // find ground positions.
+    gp1 = findGround(data, peakpos, -1);
+    gp2 = findGround(data, peakpos, 1);
+
+    peakLevel = data[peakpos];
+
+    if (gp1 == gp2)
+    {
+        // avoid rounding errors when all are equal
+        assert(gp1 == peakpos);
+        cutLevel = groundLevel = peakLevel;
+    } else {
+        // get average of the ground levels
+        groundLevel = 0.5f * (data[gp1] + data[gp2]);
+
+        // calculate 70%-level of the peak
+        cutLevel = 0.70f * peakLevel + 0.30f * groundLevel;
+    }
+
+    // find mid-level crossings
+    crosspos1 = findCrossingLevel(data, cutLevel, peakpos, -1);
+    crosspos2 = findCrossingLevel(data, cutLevel, peakpos, 1);
+
+    if ((crosspos1 < 0) || (crosspos2 < 0)) return 0;   // no crossing, no peak..
+
+    // calculate mass center of the peak surroundings
+    return calcMassCenter(data, crosspos1, crosspos2);
+}
+
+
+double PeakFinder::detectPeak(const float *data, int aminPos, int amaxPos)
+{
+
+    int i;
+    int peakpos;                // position of peak level
+    double highPeak, peak;
+
+    this->minPos = aminPos;
+    this->maxPos = amaxPos;
+
+    // find absolute peak
+    peakpos = minPos;
+    peak = data[minPos];
+    for (i = minPos + 1; i < maxPos; i ++)
+    {
+        if (data[i] > peak)
+        {
+            peak = data[i];
+            peakpos = i;
+        }
+    }
+
+    // Calculate exact location of the highest peak mass center
+    highPeak = getPeakCenter(data, peakpos);
+    peak = highPeak;
+
+    // Now check if the highest peak were in fact harmonic of the true base beat peak
+    // - sometimes the highest peak can be Nth harmonic of the true base peak yet
+    // just a slightly higher than the true base
+
+    for (i = 1; i < 3; i ++)
+    {
+        double peaktmp, harmonic;
+        int i1,i2;
+
+        harmonic = (double)pow(2.0, i);
+        peakpos = (int)(highPeak / harmonic + 0.5f);
+        if (peakpos < minPos) break;
+        peakpos = findTop(data, peakpos);   // seek true local maximum index
+        if (peakpos == 0) continue;         // no local max here
+
+        // calculate mass-center of possible harmonic peak
+        peaktmp = getPeakCenter(data, peakpos);
+
+        // accept harmonic peak if
+        // (a) it is found
+        // (b) is within �4% of the expected harmonic interval
+        // (c) has at least half x-corr value of the max. peak
+
+        double diff = harmonic * peaktmp / highPeak;
+        if ((diff < 0.96) || (diff > 1.04)) continue;   // peak too afar from expected
+
+        // now compare to highest detected peak
+        i1 = (int)(highPeak + 0.5);
+        i2 = (int)(peaktmp + 0.5);
+        if (data[i2] >= 0.4*data[i1])
+        {
+            // The harmonic is at least half as high primary peak,
+            // thus use the harmonic peak instead
+            peak = peaktmp;
+        }
+    }
+
+    return peak;
+}

--- a/third_party/soundtouch/source/SoundTouch/PeakFinder.h
+++ b/third_party/soundtouch/source/SoundTouch/PeakFinder.h
@@ -1,0 +1,90 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// The routine detects highest value on an array of values and calculates the
+/// precise peak location as a mass-center of the 'hump' around the peak value.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef _PeakFinder_H_
+#define _PeakFinder_H_
+
+namespace soundtouch
+{
+
+class PeakFinder
+{
+protected:
+    /// Min, max allowed peak positions within the data vector
+    int minPos, maxPos;
+
+    /// Calculates the mass center between given vector items.
+    double calcMassCenter(const float *data, ///< Data vector.
+                         int firstPos,      ///< Index of first vector item belonging to the peak.
+                         int lastPos        ///< Index of last vector item belonging to the peak.
+                         ) const;
+
+    /// Finds the data vector index where the monotoniously decreasing signal crosses the
+    /// given level.
+    int   findCrossingLevel(const float *data,  ///< Data vector.
+                            float level,        ///< Goal crossing level.
+                            int peakpos,        ///< Peak position index within the data vector.
+                            int direction       /// Direction where to proceed from the peak: 1 = right, -1 = left.
+                            ) const;
+
+    // Finds real 'top' of a peak hump from neighnourhood of the given 'peakpos'.
+    int findTop(const float *data, int peakpos) const;
+
+
+    /// Finds the 'ground' level, i.e. smallest level between two neighbouring peaks, to right-
+    /// or left-hand side of the given peak position.
+    int   findGround(const float *data,     /// Data vector.
+                     int peakpos,           /// Peak position index within the data vector.
+                     int direction          /// Direction where to proceed from the peak: 1 = right, -1 = left.
+                     ) const;
+
+    /// get exact center of peak near given position by calculating local mass of center
+    double getPeakCenter(const float *data, int peakpos) const;
+
+public:
+    /// Constructor.
+    PeakFinder();
+
+    /// Detect exact peak position of the data vector by finding the largest peak 'hump'
+    /// and calculating the mass-center location of the peak hump.
+    ///
+    /// \return The location of the largest base harmonic peak hump.
+    double detectPeak(const float *data, /// Data vector to be analyzed. The data vector has
+                                        /// to be at least 'maxPos' items long.
+                     int minPos,        ///< Min allowed peak location within the vector data.
+                     int maxPos         ///< Max allowed peak location within the vector data.
+                     );
+};
+
+}
+
+#endif // _PeakFinder_H_

--- a/third_party/soundtouch/source/SoundTouch/RateTransposer.cpp
+++ b/third_party/soundtouch/source/SoundTouch/RateTransposer.cpp
@@ -1,0 +1,307 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Sample rate transposer. Changes sample rate by using linear interpolation
+/// together with anti-alias filtering (first order interpolation with anti-
+/// alias filtering should be quite adequate for this application)
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <memory.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "RateTransposer.h"
+#include "InterpolateLinear.h"
+#include "InterpolateCubic.h"
+#include "InterpolateShannon.h"
+#include "AAFilter.h"
+
+using namespace soundtouch;
+
+// Define default interpolation algorithm here
+TransposerBase::ALGORITHM TransposerBase::algorithm = TransposerBase::CUBIC;
+
+
+// Constructor
+RateTransposer::RateTransposer() : FIFOProcessor(&outputBuffer)
+{
+    bUseAAFilter =
+#ifndef SOUNDTOUCH_PREVENT_CLICK_AT_RATE_CROSSOVER
+        true;
+#else
+        // Disable Anti-alias filter if desirable to avoid click at rate change zero value crossover
+        false;
+#endif
+
+    // Instantiates the anti-alias filter
+    pAAFilter = new AAFilter(64);
+    pTransposer = TransposerBase::newInstance();
+}
+
+
+RateTransposer::~RateTransposer()
+{
+    delete pAAFilter;
+    delete pTransposer;
+}
+
+
+/// Enables/disables the anti-alias filter. Zero to disable, nonzero to enable
+void RateTransposer::enableAAFilter(bool newMode)
+{
+#ifndef SOUNDTOUCH_PREVENT_CLICK_AT_RATE_CROSSOVER
+    // Disable Anti-alias filter if desirable to avoid click at rate change zero value crossover
+    bUseAAFilter = newMode;
+#endif
+}
+
+
+/// Returns nonzero if anti-alias filter is enabled.
+bool RateTransposer::isAAFilterEnabled() const
+{
+    return bUseAAFilter;
+}
+
+
+AAFilter *RateTransposer::getAAFilter()
+{
+    return pAAFilter;
+}
+
+
+// Sets new target iRate. Normal iRate = 1.0, smaller values represent slower
+// iRate, larger faster iRates.
+void RateTransposer::setRate(double newRate)
+{
+    double fCutoff;
+
+    pTransposer->setRate(newRate);
+
+    // design a new anti-alias filter
+    if (newRate > 1.0)
+    {
+        fCutoff = 0.5 / newRate;
+    }
+    else
+    {
+        fCutoff = 0.5 * newRate;
+    }
+    pAAFilter->setCutoffFreq(fCutoff);
+}
+
+
+// Adds 'nSamples' pcs of samples from the 'samples' memory position into
+// the input of the object.
+void RateTransposer::putSamples(const SAMPLETYPE *samples, uint nSamples)
+{
+    processSamples(samples, nSamples);
+}
+
+
+// Transposes sample rate by applying anti-alias filter to prevent folding.
+// Returns amount of samples returned in the "dest" buffer.
+// The maximum amount of samples that can be returned at a time is set by
+// the 'set_returnBuffer_size' function.
+void RateTransposer::processSamples(const SAMPLETYPE *src, uint nSamples)
+{
+    uint count;
+
+    if (nSamples == 0) return;
+
+    // Store samples to input buffer
+    inputBuffer.putSamples(src, nSamples);
+
+    // If anti-alias filter is turned off, simply transpose without applying
+    // the filter
+    if (bUseAAFilter == false)
+    {
+        count = pTransposer->transpose(outputBuffer, inputBuffer);
+        return;
+    }
+
+    assert(pAAFilter);
+
+    // Transpose with anti-alias filter
+    if (pTransposer->rate < 1.0f)
+    {
+        // If the parameter 'Rate' value is smaller than 1, first transpose
+        // the samples and then apply the anti-alias filter to remove aliasing.
+
+        // Transpose the samples, store the result to end of "midBuffer"
+        pTransposer->transpose(midBuffer, inputBuffer);
+
+        // Apply the anti-alias filter for transposed samples in midBuffer
+        pAAFilter->evaluate(outputBuffer, midBuffer);
+    }
+    else
+    {
+        // If the parameter 'Rate' value is larger than 1, first apply the
+        // anti-alias filter to remove high frequencies (prevent them from folding
+        // over the lover frequencies), then transpose.
+
+        // Apply the anti-alias filter for samples in inputBuffer
+        pAAFilter->evaluate(midBuffer, inputBuffer);
+
+        // Transpose the AA-filtered samples in "midBuffer"
+        pTransposer->transpose(outputBuffer, midBuffer);
+    }
+}
+
+
+// Sets the number of channels, 1 = mono, 2 = stereo
+void RateTransposer::setChannels(int nChannels)
+{
+    if (!verifyNumberOfChannels(nChannels) ||
+        (pTransposer->numChannels == nChannels)) return;
+
+    pTransposer->setChannels(nChannels);
+    inputBuffer.setChannels(nChannels);
+    midBuffer.setChannels(nChannels);
+    outputBuffer.setChannels(nChannels);
+}
+
+
+// Clears all the samples in the object
+void RateTransposer::clear()
+{
+    outputBuffer.clear();
+    midBuffer.clear();
+    inputBuffer.clear();
+}
+
+
+// Returns nonzero if there aren't any samples available for outputting.
+int RateTransposer::isEmpty() const
+{
+    int res;
+
+    res = FIFOProcessor::isEmpty();
+    if (res == 0) return 0;
+    return inputBuffer.isEmpty();
+}
+
+
+/// Return approximate initial input-output latency
+int RateTransposer::getLatency() const
+{
+    return (bUseAAFilter) ? pAAFilter->getLength() : 0;
+}
+
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// TransposerBase - Base class for interpolation
+//
+
+// static function to set interpolation algorithm
+void TransposerBase::setAlgorithm(TransposerBase::ALGORITHM a)
+{
+    TransposerBase::algorithm = a;
+}
+
+
+// Transposes the sample rate of the given samples using linear interpolation.
+// Returns the number of samples returned in the "dest" buffer
+int TransposerBase::transpose(FIFOSampleBuffer &dest, FIFOSampleBuffer &src)
+{
+    int numSrcSamples = src.numSamples();
+    int sizeDemand = (int)((double)numSrcSamples / rate) + 8;
+    int numOutput;
+    SAMPLETYPE *psrc = src.ptrBegin();
+    SAMPLETYPE *pdest = dest.ptrEnd(sizeDemand);
+
+#ifndef USE_MULTICH_ALWAYS
+    if (numChannels == 1)
+    {
+        numOutput = transposeMono(pdest, psrc, numSrcSamples);
+    }
+    else if (numChannels == 2)
+    {
+        numOutput = transposeStereo(pdest, psrc, numSrcSamples);
+    }
+    else
+#endif // USE_MULTICH_ALWAYS
+    {
+        assert(numChannels > 0);
+        numOutput = transposeMulti(pdest, psrc, numSrcSamples);
+    }
+    dest.putSamples(numOutput);
+    src.receiveSamples(numSrcSamples);
+    return numOutput;
+}
+
+
+TransposerBase::TransposerBase()
+{
+    numChannels = 0;
+    rate = 1.0f;
+}
+
+
+TransposerBase::~TransposerBase()
+{
+}
+
+
+void TransposerBase::setChannels(int channels)
+{
+    numChannels = channels;
+    resetRegisters();
+}
+
+
+void TransposerBase::setRate(double newRate)
+{
+    rate = newRate;
+}
+
+
+// static factory function
+TransposerBase *TransposerBase::newInstance()
+{
+#ifdef SOUNDTOUCH_INTEGER_SAMPLES
+    // Notice: For integer arithmetic support only linear algorithm (due to simplest calculus)
+    return ::new InterpolateLinearInteger;
+#else
+    switch (algorithm)
+    {
+        case LINEAR:
+            return new InterpolateLinearFloat;
+
+        case CUBIC:
+            return new InterpolateCubic;
+
+        case SHANNON:
+            return new InterpolateShannon;
+
+        default:
+            assert(false);
+            return NULL;
+    }
+#endif
+}

--- a/third_party/soundtouch/source/SoundTouch/RateTransposer.h
+++ b/third_party/soundtouch/source/SoundTouch/RateTransposer.h
@@ -1,0 +1,163 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Sample rate transposer. Changes sample rate by using linear interpolation
+/// together with anti-alias filtering (first order interpolation with anti-
+/// alias filtering should be quite adequate for this application).
+///
+/// Use either of the derived classes of 'RateTransposerInteger' or
+/// 'RateTransposerFloat' for corresponding integer/floating point tranposing
+/// algorithm implementation.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef RateTransposer_H
+#define RateTransposer_H
+
+#include <stddef.h>
+#include "AAFilter.h"
+#include "FIFOSamplePipe.h"
+#include "FIFOSampleBuffer.h"
+
+#include "STTypes.h"
+
+namespace soundtouch
+{
+
+/// Abstract base class for transposer implementations (linear, advanced vs integer, float etc)
+class TransposerBase
+{
+public:
+        enum ALGORITHM {
+        LINEAR = 0,
+        CUBIC,
+        SHANNON
+    };
+
+protected:
+    virtual void resetRegisters() = 0;
+
+    virtual int transposeMono(SAMPLETYPE *dest,
+                        const SAMPLETYPE *src,
+                        int &srcSamples)  = 0;
+    virtual int transposeStereo(SAMPLETYPE *dest,
+                        const SAMPLETYPE *src,
+                        int &srcSamples) = 0;
+    virtual int transposeMulti(SAMPLETYPE *dest,
+                        const SAMPLETYPE *src,
+                        int &srcSamples) = 0;
+
+    static ALGORITHM algorithm;
+
+public:
+    double rate;
+    int numChannels;
+
+    TransposerBase();
+    virtual ~TransposerBase();
+
+    virtual int transpose(FIFOSampleBuffer &dest, FIFOSampleBuffer &src);
+    virtual void setRate(double newRate);
+    virtual void setChannels(int channels);
+
+    // static factory function
+    static TransposerBase *newInstance();
+
+    // static function to set interpolation algorithm
+    static void setAlgorithm(ALGORITHM a);
+};
+
+
+/// A common linear samplerate transposer class.
+///
+class RateTransposer : public FIFOProcessor
+{
+protected:
+    /// Anti-alias filter object
+    AAFilter *pAAFilter;
+    TransposerBase *pTransposer;
+
+    /// Buffer for collecting samples to feed the anti-alias filter between
+    /// two batches
+    FIFOSampleBuffer inputBuffer;
+
+    /// Buffer for keeping samples between transposing & anti-alias filter
+    FIFOSampleBuffer midBuffer;
+
+    /// Output sample buffer
+    FIFOSampleBuffer outputBuffer;
+
+    bool bUseAAFilter;
+
+
+    /// Transposes sample rate by applying anti-alias filter to prevent folding.
+    /// Returns amount of samples returned in the "dest" buffer.
+    /// The maximum amount of samples that can be returned at a time is set by
+    /// the 'set_returnBuffer_size' function.
+    void processSamples(const SAMPLETYPE *src,
+                        uint numSamples);
+
+public:
+    RateTransposer();
+    virtual ~RateTransposer();
+
+    /// Returns the output buffer object
+    FIFOSamplePipe *getOutput() { return &outputBuffer; };
+
+    /// Return anti-alias filter object
+    AAFilter *getAAFilter();
+
+    /// Enables/disables the anti-alias filter. Zero to disable, nonzero to enable
+    void enableAAFilter(bool newMode);
+
+    /// Returns nonzero if anti-alias filter is enabled.
+    bool isAAFilterEnabled() const;
+
+    /// Sets new target rate. Normal rate = 1.0, smaller values represent slower
+    /// rate, larger faster rates.
+    virtual void setRate(double newRate);
+
+    /// Sets the number of channels, 1 = mono, 2 = stereo
+    void setChannels(int channels);
+
+    /// Adds 'numSamples' pcs of samples from the 'samples' memory position into
+    /// the input of the object.
+    void putSamples(const SAMPLETYPE *samples, uint numSamples);
+
+    /// Clears all the samples in the object
+    void clear();
+
+    /// Returns nonzero if there aren't any samples available for outputting.
+    int isEmpty() const;
+
+    /// Return approximate initial input-output latency
+    int getLatency() const;
+};
+
+}
+
+#endif

--- a/third_party/soundtouch/source/SoundTouch/SoundTouch.cpp
+++ b/third_party/soundtouch/source/SoundTouch/SoundTouch.cpp
@@ -1,0 +1,538 @@
+//////////////////////////////////////////////////////////////////////////////
+///
+/// SoundTouch - main class for tempo/pitch/rate adjusting routines.
+///
+/// Notes:
+/// - Initialize the SoundTouch object instance by setting up the sound stream
+///   parameters with functions 'setSampleRate' and 'setChannels', then set
+///   desired tempo/pitch/rate settings with the corresponding functions.
+///
+/// - The SoundTouch class behaves like a first-in-first-out pipeline: The
+///   samples that are to be processed are fed into one of the pipe by calling
+///   function 'putSamples', while the ready processed samples can be read
+///   from the other end of the pipeline with function 'receiveSamples'.
+///
+/// - The SoundTouch processing classes require certain sized 'batches' of
+///   samples in order to process the sound. For this reason the classes buffer
+///   incoming samples until there are enough of samples available for
+///   processing, then they carry out the processing step and consequently
+///   make the processed samples available for outputting.
+///
+/// - For the above reason, the processing routines introduce a certain
+///   'latency' between the input and output, so that the samples input to
+///   SoundTouch may not be immediately available in the output, and neither
+///   the amount of outputtable samples may not immediately be in direct
+///   relationship with the amount of previously input samples.
+///
+/// - The tempo/pitch/rate control parameters can be altered during processing.
+///   Please notice though that they aren't currently protected by semaphores,
+///   so in multi-thread application external semaphore protection may be
+///   required.
+///
+/// - This class utilizes classes 'TDStretch' for tempo change (without modifying
+///   pitch) and 'RateTransposer' for changing the playback rate (that is, both
+///   tempo and pitch in the same ratio) of the sound. The third available control
+///   'pitch' (change pitch but maintain tempo) is produced by a combination of
+///   combining the two other controls.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <assert.h>
+#include <stdlib.h>
+#include <memory.h>
+#include <math.h>
+#include <stdio.h>
+
+#include "SoundTouch.h"
+#include "TDStretch.h"
+#include "RateTransposer.h"
+#include "cpu_detect.h"
+
+using namespace soundtouch;
+
+/// test if two floating point numbers are equal
+#define TEST_FLOAT_EQUAL(a, b)  (fabs(a - b) < 1e-10)
+
+
+/// Print library version string for autoconf
+extern "C" void soundtouch_ac_test()
+{
+    printf("SoundTouch Version: %s\n",SOUNDTOUCH_VERSION);
+}
+
+
+SoundTouch::SoundTouch()
+{
+    // Initialize rate transposer and tempo changer instances
+
+    pRateTransposer = new RateTransposer();
+    pTDStretch = TDStretch::newInstance();
+
+    setOutPipe(pTDStretch);
+
+    rate = tempo = 0;
+
+    virtualPitch =
+    virtualRate =
+    virtualTempo = 1.0;
+
+    calcEffectiveRateAndTempo();
+
+    samplesExpectedOut = 0;
+    samplesOutput = 0;
+
+    channels = 0;
+    bSrateSet = false;
+}
+
+
+SoundTouch::~SoundTouch()
+{
+    delete pRateTransposer;
+    delete pTDStretch;
+}
+
+
+/// Get SoundTouch library version string
+const char *SoundTouch::getVersionString()
+{
+    static const char *_version = SOUNDTOUCH_VERSION;
+
+    return _version;
+}
+
+
+/// Get SoundTouch library version Id
+uint SoundTouch::getVersionId()
+{
+    return SOUNDTOUCH_VERSION_ID;
+}
+
+
+// Sets the number of channels, 1 = mono, 2 = stereo
+void SoundTouch::setChannels(uint numChannels)
+{
+    if (!verifyNumberOfChannels(numChannels)) return;
+
+    channels = numChannels;
+    pRateTransposer->setChannels((int)numChannels);
+    pTDStretch->setChannels((int)numChannels);
+}
+
+
+// Sets new rate control value. Normal rate = 1.0, smaller values
+// represent slower rate, larger faster rates.
+void SoundTouch::setRate(double newRate)
+{
+    virtualRate = newRate;
+    calcEffectiveRateAndTempo();
+}
+
+
+// Sets new rate control value as a difference in percents compared
+// to the original rate (-50 .. +100 %)
+void SoundTouch::setRateChange(double newRate)
+{
+    virtualRate = 1.0 + 0.01 * newRate;
+    calcEffectiveRateAndTempo();
+}
+
+
+// Sets new tempo control value. Normal tempo = 1.0, smaller values
+// represent slower tempo, larger faster tempo.
+void SoundTouch::setTempo(double newTempo)
+{
+    virtualTempo = newTempo;
+    calcEffectiveRateAndTempo();
+}
+
+
+// Sets new tempo control value as a difference in percents compared
+// to the original tempo (-50 .. +100 %)
+void SoundTouch::setTempoChange(double newTempo)
+{
+    virtualTempo = 1.0 + 0.01 * newTempo;
+    calcEffectiveRateAndTempo();
+}
+
+
+// Sets new pitch control value. Original pitch = 1.0, smaller values
+// represent lower pitches, larger values higher pitch.
+void SoundTouch::setPitch(double newPitch)
+{
+    virtualPitch = newPitch;
+    calcEffectiveRateAndTempo();
+}
+
+
+// Sets pitch change in octaves compared to the original pitch
+// (-1.00 .. +1.00)
+void SoundTouch::setPitchOctaves(double newPitch)
+{
+    virtualPitch = exp(0.69314718056 * newPitch);
+    calcEffectiveRateAndTempo();
+}
+
+
+// Sets pitch change in semi-tones compared to the original pitch
+// (-12 .. +12)
+void SoundTouch::setPitchSemiTones(int newPitch)
+{
+    setPitchOctaves((double)newPitch / 12.0);
+}
+
+
+void SoundTouch::setPitchSemiTones(double newPitch)
+{
+    setPitchOctaves(newPitch / 12.0);
+}
+
+
+// Calculates 'effective' rate and tempo values from the
+// nominal control values.
+void SoundTouch::calcEffectiveRateAndTempo()
+{
+    double oldTempo = tempo;
+    double oldRate = rate;
+
+    tempo = virtualTempo / virtualPitch;
+    rate = virtualPitch * virtualRate;
+
+    if (!TEST_FLOAT_EQUAL(rate,oldRate)) pRateTransposer->setRate(rate);
+    if (!TEST_FLOAT_EQUAL(tempo, oldTempo)) pTDStretch->setTempo(tempo);
+
+#ifndef SOUNDTOUCH_PREVENT_CLICK_AT_RATE_CROSSOVER
+    if (rate <= 1.0f)
+    {
+        if (output != pTDStretch)
+        {
+            FIFOSamplePipe *tempoOut;
+
+            assert(output == pRateTransposer);
+            // move samples in the current output buffer to the output of pTDStretch
+            tempoOut = pTDStretch->getOutput();
+            tempoOut->moveSamples(*output);
+            // move samples in pitch transposer's store buffer to tempo changer's input
+            // deprecated : pTDStretch->moveSamples(*pRateTransposer->getStore());
+
+            output = pTDStretch;
+        }
+    }
+    else
+#endif
+    {
+        if (output != pRateTransposer)
+        {
+            FIFOSamplePipe *transOut;
+
+            assert(output == pTDStretch);
+            // move samples in the current output buffer to the output of pRateTransposer
+            transOut = pRateTransposer->getOutput();
+            transOut->moveSamples(*output);
+            // move samples in tempo changer's input to pitch transposer's input
+            pRateTransposer->moveSamples(*pTDStretch->getInput());
+
+            output = pRateTransposer;
+        }
+    }
+}
+
+
+// Sets sample rate.
+void SoundTouch::setSampleRate(uint srate)
+{
+    // set sample rate, leave other tempo changer parameters as they are.
+    pTDStretch->setParameters((int)srate);
+    bSrateSet = true;
+}
+
+
+// Adds 'numSamples' pcs of samples from the 'samples' memory position into
+// the input of the object.
+void SoundTouch::putSamples(const SAMPLETYPE *samples, uint nSamples)
+{
+    if (bSrateSet == false)
+    {
+        ST_THROW_RT_ERROR("SoundTouch : Sample rate not defined");
+    }
+    else if (channels == 0)
+    {
+        ST_THROW_RT_ERROR("SoundTouch : Number of channels not defined");
+    }
+
+    // accumulate how many samples are expected out from processing, given the current
+    // processing setting
+    samplesExpectedOut += (double)nSamples / ((double)rate * (double)tempo);
+
+#ifndef SOUNDTOUCH_PREVENT_CLICK_AT_RATE_CROSSOVER
+    if (rate <= 1.0f)
+    {
+        // transpose the rate down, output the transposed sound to tempo changer buffer
+        assert(output == pTDStretch);
+        pRateTransposer->putSamples(samples, nSamples);
+        pTDStretch->moveSamples(*pRateTransposer);
+    }
+    else
+#endif
+    {
+        // evaluate the tempo changer, then transpose the rate up,
+        assert(output == pRateTransposer);
+        pTDStretch->putSamples(samples, nSamples);
+        pRateTransposer->moveSamples(*pTDStretch);
+    }
+}
+
+
+// Flushes the last samples from the processing pipeline to the output.
+// Clears also the internal processing buffers.
+//
+// Note: This function is meant for extracting the last samples of a sound
+// stream. This function may introduce additional blank samples in the end
+// of the sound stream, and thus it's not recommended to call this function
+// in the middle of a sound stream.
+void SoundTouch::flush()
+{
+    int i;
+    int numStillExpected;
+    SAMPLETYPE *buff = new SAMPLETYPE[128 * channels];
+
+    // how many samples are still expected to output
+    numStillExpected = (int)((long)(samplesExpectedOut + 0.5) - samplesOutput);
+    if (numStillExpected < 0) numStillExpected = 0;
+
+    memset(buff, 0, 128 * channels * sizeof(SAMPLETYPE));
+    // "Push" the last active samples out from the processing pipeline by
+    // feeding blank samples into the processing pipeline until new,
+    // processed samples appear in the output (not however, more than
+    // 24ksamples in any case)
+    for (i = 0; (numStillExpected > (int)numSamples()) && (i < 200); i ++)
+    {
+        putSamples(buff, 128);
+    }
+
+    adjustAmountOfSamples(numStillExpected);
+
+    delete[] buff;
+
+    // Clear input buffers
+    pTDStretch->clearInput();
+    // yet leave the output intouched as that's where the
+    // flushed samples are!
+}
+
+
+// Changes a setting controlling the processing system behaviour. See the
+// 'SETTING_...' defines for available setting ID's.
+bool SoundTouch::setSetting(int settingId, int value)
+{
+    int sampleRate, sequenceMs, seekWindowMs, overlapMs;
+
+    // read current tdstretch routine parameters
+    pTDStretch->getParameters(&sampleRate, &sequenceMs, &seekWindowMs, &overlapMs);
+
+    switch (settingId)
+    {
+        case SETTING_USE_AA_FILTER :
+            // enables / disabless anti-alias filter
+            pRateTransposer->enableAAFilter((value != 0) ? true : false);
+            return true;
+
+        case SETTING_AA_FILTER_LENGTH :
+            // sets anti-alias filter length
+            pRateTransposer->getAAFilter()->setLength(value);
+            return true;
+
+        case SETTING_USE_QUICKSEEK :
+            // enables / disables tempo routine quick seeking algorithm
+            pTDStretch->enableQuickSeek((value != 0) ? true : false);
+            return true;
+
+        case SETTING_SEQUENCE_MS:
+            // change time-stretch sequence duration parameter
+            pTDStretch->setParameters(sampleRate, value, seekWindowMs, overlapMs);
+            return true;
+
+        case SETTING_SEEKWINDOW_MS:
+            // change time-stretch seek window length parameter
+            pTDStretch->setParameters(sampleRate, sequenceMs, value, overlapMs);
+            return true;
+
+        case SETTING_OVERLAP_MS:
+            // change time-stretch overlap length parameter
+            pTDStretch->setParameters(sampleRate, sequenceMs, seekWindowMs, value);
+            return true;
+
+        default :
+            return false;
+    }
+}
+
+
+// Reads a setting controlling the processing system behaviour. See the
+// 'SETTING_...' defines for available setting ID's.
+//
+// Returns the setting value.
+int SoundTouch::getSetting(int settingId) const
+{
+    int temp;
+
+    switch (settingId)
+    {
+        case SETTING_USE_AA_FILTER :
+            return (uint)pRateTransposer->isAAFilterEnabled();
+
+        case SETTING_AA_FILTER_LENGTH :
+            return pRateTransposer->getAAFilter()->getLength();
+
+        case SETTING_USE_QUICKSEEK :
+            return (uint)pTDStretch->isQuickSeekEnabled();
+
+        case SETTING_SEQUENCE_MS:
+            pTDStretch->getParameters(NULL, &temp, NULL, NULL);
+            return temp;
+
+        case SETTING_SEEKWINDOW_MS:
+            pTDStretch->getParameters(NULL, NULL, &temp, NULL);
+            return temp;
+
+        case SETTING_OVERLAP_MS:
+            pTDStretch->getParameters(NULL, NULL, NULL, &temp);
+            return temp;
+
+        case SETTING_NOMINAL_INPUT_SEQUENCE :
+        {
+            int size = pTDStretch->getInputSampleReq();
+
+#ifndef SOUNDTOUCH_PREVENT_CLICK_AT_RATE_CROSSOVER
+            if (rate <= 1.0)
+            {
+                // transposing done before timestretch, which impacts latency
+                return (int)(size * rate + 0.5);
+            }
+#endif
+            return size;
+        }
+
+        case SETTING_NOMINAL_OUTPUT_SEQUENCE :
+        {
+            int size = pTDStretch->getOutputBatchSize();
+
+            if (rate > 1.0)
+            {
+                // transposing done after timestretch, which impacts latency
+                return (int)(size / rate + 0.5);
+            }
+            return size;
+        }
+
+        case SETTING_INITIAL_LATENCY:
+        {
+            double latency = pTDStretch->getLatency();
+            int latency_tr = pRateTransposer->getLatency();
+
+#ifndef SOUNDTOUCH_PREVENT_CLICK_AT_RATE_CROSSOVER
+            if (rate <= 1.0)
+            {
+                // transposing done before timestretch, which impacts latency
+                latency = (latency + latency_tr) * rate;
+            }
+            else
+#endif
+            {
+                latency += (double)latency_tr / rate;
+            }
+
+            return (int)(latency + 0.5);
+        }
+
+        default :
+            return 0;
+    }
+}
+
+
+// Clears all the samples in the object's output and internal processing
+// buffers.
+void SoundTouch::clear()
+{
+    samplesExpectedOut = 0;
+    samplesOutput = 0;
+    pRateTransposer->clear();
+    pTDStretch->clear();
+}
+
+
+/// Returns number of samples currently unprocessed.
+uint SoundTouch::numUnprocessedSamples() const
+{
+    FIFOSamplePipe * psp;
+    if (pTDStretch)
+    {
+        psp = pTDStretch->getInput();
+        if (psp)
+        {
+            return psp->numSamples();
+        }
+    }
+    return 0;
+}
+
+
+/// Output samples from beginning of the sample buffer. Copies requested samples to
+/// output buffer and removes them from the sample buffer. If there are less than
+/// 'numsample' samples in the buffer, returns all that available.
+///
+/// \return Number of samples returned.
+uint SoundTouch::receiveSamples(SAMPLETYPE *output, uint maxSamples)
+{
+    uint ret = FIFOProcessor::receiveSamples(output, maxSamples);
+    samplesOutput += (long)ret;
+    return ret;
+}
+
+
+/// Adjusts book-keeping so that given number of samples are removed from beginning of the
+/// sample buffer without copying them anywhere.
+///
+/// Used to reduce the number of samples in the buffer when accessing the sample buffer directly
+/// with 'ptrBegin' function.
+uint SoundTouch::receiveSamples(uint maxSamples)
+{
+    uint ret = FIFOProcessor::receiveSamples(maxSamples);
+    samplesOutput += (long)ret;
+    return ret;
+}
+
+
+/// Get ratio between input and output audio durations, useful for calculating
+/// processed output duration: if you'll process a stream of N samples, then
+/// you can expect to get out N * getInputOutputSampleRatio() samples.
+double SoundTouch::getInputOutputSampleRatio()
+{
+    return 1.0 / (tempo * rate);
+}

--- a/third_party/soundtouch/source/SoundTouch/TDStretch.cpp
+++ b/third_party/soundtouch/source/SoundTouch/TDStretch.cpp
@@ -1,0 +1,1111 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Sampled sound tempo changer/time stretch algorithm. Changes the sound tempo
+/// while maintaining the original pitch by using a time domain WSOLA-like
+/// method with several performance-increasing tweaks.
+///
+/// Notes : MMX optimized functions reside in a separate, platform-specific
+/// file, e.g. 'mmx_win.cpp' or 'mmx_gcc.cpp'.
+///
+/// This source file contains OpenMP optimizations that allow speeding up the
+/// corss-correlation algorithm by executing it in several threads / CPU cores
+/// in parallel. See the following article link for more detailed discussion
+/// about SoundTouch OpenMP optimizations:
+/// http://www.softwarecoven.com/parallel-computing-in-embedded-mobile-devices
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <string.h>
+#include <limits.h>
+#include <assert.h>
+#include <math.h>
+#include <float.h>
+
+#include "STTypes.h"
+#include "cpu_detect.h"
+#include "TDStretch.h"
+
+using namespace soundtouch;
+
+#define max(x, y) (((x) > (y)) ? (x) : (y))
+
+
+/*****************************************************************************
+ *
+ * Constant definitions
+ *
+ *****************************************************************************/
+
+// Table for the hierarchical mixing position seeking algorithm
+const short _scanOffsets[5][24]={
+    { 124,  186,  248,  310,  372,  434,  496,  558,  620,  682,  744, 806,
+      868,  930,  992, 1054, 1116, 1178, 1240, 1302, 1364, 1426, 1488,   0},
+    {-100,  -75,  -50,  -25,   25,   50,   75,  100,    0,    0,    0,   0,
+        0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,   0},
+    { -20,  -15,  -10,   -5,    5,   10,   15,   20,    0,    0,    0,   0,
+        0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,   0},
+    {  -4,   -3,   -2,   -1,    1,    2,    3,    4,    0,    0,    0,   0,
+        0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,   0},
+    { 121,  114,   97,  114,   98,  105,  108,   32,  104,   99,  117,  111,
+      116,  100,  110,  117,  111,  115,    0,    0,    0,    0,    0,   0}};
+
+/*****************************************************************************
+ *
+ * Implementation of the class 'TDStretch'
+ *
+ *****************************************************************************/
+
+
+TDStretch::TDStretch() : FIFOProcessor(&outputBuffer)
+{
+    bQuickSeek = false;
+    channels = 2;
+
+    pMidBuffer = NULL;
+    pMidBufferUnaligned = NULL;
+    overlapLength = 0;
+
+    bAutoSeqSetting = true;
+    bAutoSeekSetting = true;
+
+    maxnorm = 0;
+    maxnormf = 1e8;
+
+    skipFract = 0;
+
+    tempo = 1.0f;
+    setParameters(44100, DEFAULT_SEQUENCE_MS, DEFAULT_SEEKWINDOW_MS, DEFAULT_OVERLAP_MS);
+    setTempo(1.0f);
+
+    clear();
+}
+
+
+
+TDStretch::~TDStretch()
+{
+    delete[] pMidBufferUnaligned;
+}
+
+
+
+// Sets routine control parameters. These control are certain time constants
+// defining how the sound is stretched to the desired duration.
+//
+// 'sampleRate' = sample rate of the sound
+// 'sequenceMS' = one processing sequence length in milliseconds (default = 82 ms)
+// 'seekwindowMS' = seeking window length for scanning the best overlapping
+//      position (default = 28 ms)
+// 'overlapMS' = overlapping length (default = 12 ms)
+
+void TDStretch::setParameters(int aSampleRate, int aSequenceMS,
+                              int aSeekWindowMS, int aOverlapMS)
+{
+    // accept only positive parameter values - if zero or negative, use old values instead
+    if (aSampleRate > 0)
+    {
+        if (aSampleRate > 192000) ST_THROW_RT_ERROR("Error: Excessive samplerate");
+        this->sampleRate = aSampleRate;
+    }
+
+    if (aOverlapMS > 0) this->overlapMs = aOverlapMS;
+
+    if (aSequenceMS > 0)
+    {
+        this->sequenceMs = aSequenceMS;
+        bAutoSeqSetting = false;
+    }
+    else if (aSequenceMS == 0)
+    {
+        // if zero, use automatic setting
+        bAutoSeqSetting = true;
+    }
+
+    if (aSeekWindowMS > 0)
+    {
+        this->seekWindowMs = aSeekWindowMS;
+        bAutoSeekSetting = false;
+    }
+    else if (aSeekWindowMS == 0)
+    {
+        // if zero, use automatic setting
+        bAutoSeekSetting = true;
+    }
+
+    calcSeqParameters();
+
+    calculateOverlapLength(overlapMs);
+
+    // set tempo to recalculate 'sampleReq'
+    setTempo(tempo);
+}
+
+
+
+/// Get routine control parameters, see setParameters() function.
+/// Any of the parameters to this function can be NULL, in such case corresponding parameter
+/// value isn't returned.
+void TDStretch::getParameters(int *pSampleRate, int *pSequenceMs, int *pSeekWindowMs, int *pOverlapMs) const
+{
+    if (pSampleRate)
+    {
+        *pSampleRate = sampleRate;
+    }
+
+    if (pSequenceMs)
+    {
+        *pSequenceMs = (bAutoSeqSetting) ? (USE_AUTO_SEQUENCE_LEN) : sequenceMs;
+    }
+
+    if (pSeekWindowMs)
+    {
+        *pSeekWindowMs = (bAutoSeekSetting) ? (USE_AUTO_SEEKWINDOW_LEN) : seekWindowMs;
+    }
+
+    if (pOverlapMs)
+    {
+        *pOverlapMs = overlapMs;
+    }
+}
+
+
+// Overlaps samples in 'midBuffer' with the samples in 'pInput'
+void TDStretch::overlapMono(SAMPLETYPE *pOutput, const SAMPLETYPE *pInput) const
+{
+    int i;
+    SAMPLETYPE m1, m2;
+
+    m1 = (SAMPLETYPE)0;
+    m2 = (SAMPLETYPE)overlapLength;
+
+    for (i = 0; i < overlapLength ; i ++)
+    {
+        pOutput[i] = (pInput[i] * m1 + pMidBuffer[i] * m2 ) / overlapLength;
+        m1 += 1;
+        m2 -= 1;
+    }
+}
+
+
+
+void TDStretch::clearMidBuffer()
+{
+    memset(pMidBuffer, 0, channels * sizeof(SAMPLETYPE) * overlapLength);
+}
+
+
+void TDStretch::clearInput()
+{
+    inputBuffer.clear();
+    clearMidBuffer();
+    isBeginning = true;
+}
+
+
+// Clears the sample buffers
+void TDStretch::clear()
+{
+    outputBuffer.clear();
+    clearInput();
+}
+
+
+
+// Enables/disables the quick position seeking algorithm. Zero to disable, nonzero
+// to enable
+void TDStretch::enableQuickSeek(bool enable)
+{
+    bQuickSeek = enable;
+}
+
+
+// Returns nonzero if the quick seeking algorithm is enabled.
+bool TDStretch::isQuickSeekEnabled() const
+{
+    return bQuickSeek;
+}
+
+
+// Seeks for the optimal overlap-mixing position.
+int TDStretch::seekBestOverlapPosition(const SAMPLETYPE *refPos)
+{
+    if (bQuickSeek)
+    {
+        return seekBestOverlapPositionQuick(refPos);
+    }
+    else
+    {
+        return seekBestOverlapPositionFull(refPos);
+    }
+}
+
+
+// Overlaps samples in 'midBuffer' with the samples in 'pInputBuffer' at position
+// of 'ovlPos'.
+inline void TDStretch::overlap(SAMPLETYPE *pOutput, const SAMPLETYPE *pInput, uint ovlPos) const
+{
+#ifndef USE_MULTICH_ALWAYS
+    if (channels == 1)
+    {
+        // mono sound.
+        overlapMono(pOutput, pInput + ovlPos);
+    }
+    else if (channels == 2)
+    {
+        // stereo sound
+        overlapStereo(pOutput, pInput + 2 * ovlPos);
+    }
+    else
+#endif // USE_MULTICH_ALWAYS
+    {
+        assert(channels > 0);
+        overlapMulti(pOutput, pInput + channels * ovlPos);
+    }
+}
+
+
+// Seeks for the optimal overlap-mixing position. The 'stereo' version of the
+// routine
+//
+// The best position is determined as the position where the two overlapped
+// sample sequences are 'most alike', in terms of the highest cross-correlation
+// value over the overlapping period
+int TDStretch::seekBestOverlapPositionFull(const SAMPLETYPE *refPos)
+{
+    int bestOffs;
+    double bestCorr;
+    int i;
+    double norm;
+
+    bestCorr = -FLT_MAX;
+    bestOffs = 0;
+
+    // Scans for the best correlation value by testing each possible position
+    // over the permitted range.
+    bestCorr = calcCrossCorr(refPos, pMidBuffer, norm);
+    bestCorr = (bestCorr + 0.1) * 0.75;
+
+    #pragma omp parallel for
+    for (i = 1; i < seekLength; i ++)
+    {
+        double corr;
+        // Calculates correlation value for the mixing position corresponding to 'i'
+#ifdef _OPENMP
+        // in parallel OpenMP mode, can't use norm accumulator version as parallel executor won't
+        // iterate the loop in sequential order
+        corr = calcCrossCorr(refPos + channels * i, pMidBuffer, norm);
+#else
+        // In non-parallel version call "calcCrossCorrAccumulate" that is otherwise same
+        // as "calcCrossCorr", but saves time by reusing & updating previously stored
+        // "norm" value
+        corr = calcCrossCorrAccumulate(refPos + channels * i, pMidBuffer, norm);
+#endif
+        // heuristic rule to slightly favour values close to mid of the range
+        double tmp = (double)(2 * i - seekLength) / (double)seekLength;
+        corr = ((corr + 0.1) * (1.0 - 0.25 * tmp * tmp));
+
+        // Checks for the highest correlation value
+        if (corr > bestCorr)
+        {
+            // For optimal performance, enter critical section only in case that best value found.
+            // in such case repeat 'if' condition as it's possible that parallel execution may have
+            // updated the bestCorr value in the mean time
+            #pragma omp critical
+            if (corr > bestCorr)
+            {
+                bestCorr = corr;
+                bestOffs = i;
+            }
+        }
+    }
+
+#ifdef SOUNDTOUCH_INTEGER_SAMPLES
+    adaptNormalizer();
+#endif
+
+    // clear cross correlation routine state if necessary (is so e.g. in MMX routines).
+    clearCrossCorrState();
+
+    return bestOffs;
+}
+
+
+// Quick seek algorithm for improved runtime-performance: First roughly scans through the
+// correlation area, and then scan surroundings of two best preliminary correlation candidates
+// with improved precision
+//
+// Based on testing:
+// - This algorithm gives on average 99% as good match as the full algorithm
+// - this quick seek algorithm finds the best match on ~90% of cases
+// - on those 10% of cases when this algorithm doesn't find best match,
+//   it still finds on average ~90% match vs. the best possible match
+int TDStretch::seekBestOverlapPositionQuick(const SAMPLETYPE *refPos)
+{
+#define _MIN(a, b)   (((a) < (b)) ? (a) : (b))
+#define SCANSTEP    16
+#define SCANWIND    8
+
+    int bestOffs;
+    int i;
+    int bestOffs2;
+    float bestCorr, corr;
+    float bestCorr2;
+    double norm;
+
+    // note: 'float' types used in this function in case that the platform would need to use software-fp
+
+    bestCorr =
+    bestCorr2 = -FLT_MAX;
+    bestOffs =
+    bestOffs2 = SCANWIND;
+
+    // Scans for the best correlation value by testing each possible position
+    // over the permitted range. Look for two best matches on the first pass to
+    // increase possibility of ideal match.
+    //
+    // Begin from "SCANSTEP" instead of SCANWIND to make the calculation
+    // catch the 'middlepoint' of seekLength vector as that's the a-priori
+    // expected best match position
+    //
+    // Roughly:
+    // - 15% of cases find best result directly on the first round,
+    // - 75% cases find better match on 2nd round around the best match from 1st round
+    // - 10% cases find better match on 2nd round around the 2nd-best-match from 1st round
+    for (i = SCANSTEP; i < seekLength - SCANWIND - 1; i += SCANSTEP)
+    {
+        // Calculates correlation value for the mixing position corresponding
+        // to 'i'
+        corr = (float)calcCrossCorr(refPos + channels*i, pMidBuffer, norm);
+        // heuristic rule to slightly favour values close to mid of the seek range
+        float tmp = (float)(2 * i - seekLength - 1) / (float)seekLength;
+        corr = ((corr + 0.1f) * (1.0f - 0.25f * tmp * tmp));
+
+        // Checks for the highest correlation value
+        if (corr > bestCorr)
+        {
+            // found new best match. keep the previous best as 2nd best match
+            bestCorr2 = bestCorr;
+            bestOffs2 = bestOffs;
+            bestCorr = corr;
+            bestOffs = i;
+        }
+        else if (corr > bestCorr2)
+        {
+            // not new best, but still new 2nd best match
+            bestCorr2 = corr;
+            bestOffs2 = i;
+        }
+    }
+
+    // Scans surroundings of the found best match with small stepping
+    int end = _MIN(bestOffs + SCANWIND + 1, seekLength);
+    for (i = bestOffs - SCANWIND; i < end; i++)
+    {
+        if (i == bestOffs) continue;    // this offset already calculated, thus skip
+
+        // Calculates correlation value for the mixing position corresponding
+        // to 'i'
+        corr = (float)calcCrossCorr(refPos + channels*i, pMidBuffer, norm);
+        // heuristic rule to slightly favour values close to mid of the range
+        float tmp = (float)(2 * i - seekLength - 1) / (float)seekLength;
+        corr = ((corr + 0.1f) * (1.0f - 0.25f * tmp * tmp));
+
+        // Checks for the highest correlation value
+        if (corr > bestCorr)
+        {
+            bestCorr = corr;
+            bestOffs = i;
+        }
+    }
+
+    // Scans surroundings of the 2nd best match with small stepping
+    end = _MIN(bestOffs2 + SCANWIND + 1, seekLength);
+    for (i = bestOffs2 - SCANWIND; i < end; i++)
+    {
+        if (i == bestOffs2) continue;    // this offset already calculated, thus skip
+
+        // Calculates correlation value for the mixing position corresponding
+        // to 'i'
+        corr = (float)calcCrossCorr(refPos + channels*i, pMidBuffer, norm);
+        // heuristic rule to slightly favour values close to mid of the range
+        float tmp = (float)(2 * i - seekLength - 1) / (float)seekLength;
+        corr = ((corr + 0.1f) * (1.0f - 0.25f * tmp * tmp));
+
+        // Checks for the highest correlation value
+        if (corr > bestCorr)
+        {
+            bestCorr = corr;
+            bestOffs = i;
+        }
+    }
+
+    // clear cross correlation routine state if necessary (is so e.g. in MMX routines).
+    clearCrossCorrState();
+
+#ifdef SOUNDTOUCH_INTEGER_SAMPLES
+    adaptNormalizer();
+#endif
+
+    return bestOffs;
+}
+
+
+
+
+/// For integer algorithm: adapt normalization factor divider with music so that
+/// it'll not be pessimistically restrictive that can degrade quality on quieter sections
+/// yet won't cause integer overflows either
+void TDStretch::adaptNormalizer()
+{
+    // Do not adapt normalizer over too silent sequences to avoid averaging filter depleting to
+    // too low values during pauses in music
+    if ((maxnorm > 1000) || (maxnormf > 40000000))
+    {
+        //norm averaging filter
+        maxnormf = 0.9f * maxnormf + 0.1f * (float)maxnorm;
+
+        if ((maxnorm > 800000000) && (overlapDividerBitsNorm < 16))
+        {
+            // large values, so increase divider
+            overlapDividerBitsNorm++;
+            if (maxnorm > 1600000000) overlapDividerBitsNorm++; // extra large value => extra increase
+        }
+        else if ((maxnormf < 1000000) && (overlapDividerBitsNorm > 0))
+        {
+            // extra small values, decrease divider
+            overlapDividerBitsNorm--;
+        }
+    }
+
+    maxnorm = 0;
+}
+
+
+/// clear cross correlation routine state if necessary
+void TDStretch::clearCrossCorrState()
+{
+    // default implementation is empty.
+}
+
+
+/// Calculates processing sequence length according to tempo setting
+void TDStretch::calcSeqParameters()
+{
+    // Adjust tempo param according to tempo, so that variating processing sequence length is used
+    // at various tempo settings, between the given low...top limits
+    #define AUTOSEQ_TEMPO_LOW   0.5     // auto setting low tempo range (-50%)
+    #define AUTOSEQ_TEMPO_TOP   2.0     // auto setting top tempo range (+100%)
+
+    // sequence-ms setting values at above low & top tempo
+    #define AUTOSEQ_AT_MIN      90.0
+    #define AUTOSEQ_AT_MAX      40.0
+    #define AUTOSEQ_K           ((AUTOSEQ_AT_MAX - AUTOSEQ_AT_MIN) / (AUTOSEQ_TEMPO_TOP - AUTOSEQ_TEMPO_LOW))
+    #define AUTOSEQ_C           (AUTOSEQ_AT_MIN - (AUTOSEQ_K) * (AUTOSEQ_TEMPO_LOW))
+
+    // seek-window-ms setting values at above low & top tempoq
+    #define AUTOSEEK_AT_MIN     20.0
+    #define AUTOSEEK_AT_MAX     15.0
+    #define AUTOSEEK_K          ((AUTOSEEK_AT_MAX - AUTOSEEK_AT_MIN) / (AUTOSEQ_TEMPO_TOP - AUTOSEQ_TEMPO_LOW))
+    #define AUTOSEEK_C          (AUTOSEEK_AT_MIN - (AUTOSEEK_K) * (AUTOSEQ_TEMPO_LOW))
+
+    #define CHECK_LIMITS(x, mi, ma) (((x) < (mi)) ? (mi) : (((x) > (ma)) ? (ma) : (x)))
+
+    double seq, seek;
+
+    if (bAutoSeqSetting)
+    {
+        seq = AUTOSEQ_C + AUTOSEQ_K * tempo;
+        seq = CHECK_LIMITS(seq, AUTOSEQ_AT_MAX, AUTOSEQ_AT_MIN);
+        sequenceMs = (int)(seq + 0.5);
+    }
+
+    if (bAutoSeekSetting)
+    {
+        seek = AUTOSEEK_C + AUTOSEEK_K * tempo;
+        seek = CHECK_LIMITS(seek, AUTOSEEK_AT_MAX, AUTOSEEK_AT_MIN);
+        seekWindowMs = (int)(seek + 0.5);
+    }
+
+    // Update seek window lengths
+    seekWindowLength = (sampleRate * sequenceMs) / 1000;
+    if (seekWindowLength < 2 * overlapLength)
+    {
+        seekWindowLength = 2 * overlapLength;
+    }
+    seekLength = (sampleRate * seekWindowMs) / 1000;
+}
+
+
+
+// Sets new target tempo. Normal tempo = 'SCALE', smaller values represent slower
+// tempo, larger faster tempo.
+void TDStretch::setTempo(double newTempo)
+{
+    int intskip;
+
+    tempo = newTempo;
+
+    // Calculate new sequence duration
+    calcSeqParameters();
+
+    // Calculate ideal skip length (according to tempo value)
+    nominalSkip = tempo * (seekWindowLength - overlapLength);
+    intskip = (int)(nominalSkip + 0.5);
+
+    // Calculate how many samples are needed in the 'inputBuffer' to
+    // process another batch of samples
+    //sampleReq = max(intskip + overlapLength, seekWindowLength) + seekLength / 2;
+    sampleReq = max(intskip + overlapLength, seekWindowLength) + seekLength;
+}
+
+
+
+// Sets the number of channels, 1 = mono, 2 = stereo
+void TDStretch::setChannels(int numChannels)
+{
+    if (!verifyNumberOfChannels(numChannels) ||
+        (channels == numChannels)) return;
+
+    channels = numChannels;
+    inputBuffer.setChannels(channels);
+    outputBuffer.setChannels(channels);
+
+    // re-init overlap/buffer
+    overlapLength=0;
+    setParameters(sampleRate);
+}
+
+
+// nominal tempo, no need for processing, just pass the samples through
+// to outputBuffer
+/*
+void TDStretch::processNominalTempo()
+{
+    assert(tempo == 1.0f);
+
+    if (bMidBufferDirty)
+    {
+        // If there are samples in pMidBuffer waiting for overlapping,
+        // do a single sliding overlapping with them in order to prevent a
+        // clicking distortion in the output sound
+        if (inputBuffer.numSamples() < overlapLength)
+        {
+            // wait until we've got overlapLength input samples
+            return;
+        }
+        // Mix the samples in the beginning of 'inputBuffer' with the
+        // samples in 'midBuffer' using sliding overlapping
+        overlap(outputBuffer.ptrEnd(overlapLength), inputBuffer.ptrBegin(), 0);
+        outputBuffer.putSamples(overlapLength);
+        inputBuffer.receiveSamples(overlapLength);
+        clearMidBuffer();
+        // now we've caught the nominal sample flow and may switch to
+        // bypass mode
+    }
+
+    // Simply bypass samples from input to output
+    outputBuffer.moveSamples(inputBuffer);
+}
+*/
+
+
+// Processes as many processing frames of the samples 'inputBuffer', store
+// the result into 'outputBuffer'
+void TDStretch::processSamples()
+{
+    int ovlSkip;
+    int offset = 0;
+    int temp;
+
+    /* Removed this small optimization - can introduce a click to sound when tempo setting
+       crosses the nominal value
+    if (tempo == 1.0f)
+    {
+        // tempo not changed from the original, so bypass the processing
+        processNominalTempo();
+        return;
+    }
+    */
+
+    // Process samples as long as there are enough samples in 'inputBuffer'
+    // to form a processing frame.
+    while ((int)inputBuffer.numSamples() >= sampleReq)
+    {
+        if (isBeginning == false)
+        {
+            // apart from the very beginning of the track,
+            // scan for the best overlapping position & do overlap-add
+            offset = seekBestOverlapPosition(inputBuffer.ptrBegin());
+
+            // Mix the samples in the 'inputBuffer' at position of 'offset' with the
+            // samples in 'midBuffer' using sliding overlapping
+            // ... first partially overlap with the end of the previous sequence
+            // (that's in 'midBuffer')
+            overlap(outputBuffer.ptrEnd((uint)overlapLength), inputBuffer.ptrBegin(), (uint)offset);
+            outputBuffer.putSamples((uint)overlapLength);
+            offset += overlapLength;
+        }
+        else
+        {
+            // Adjust processing offset at beginning of track by not perform initial overlapping
+            // and compensating that in the 'input buffer skip' calculation
+            isBeginning = false;
+            int skip = (int)(tempo * overlapLength + 0.5);
+
+            #ifdef SOUNDTOUCH_ALLOW_NONEXACT_SIMD_OPTIMIZATION
+                #ifdef SOUNDTOUCH_ALLOW_SSE
+                // if SSE mode, round the skip amount to value corresponding to aligned memory address
+                if (channels == 1)
+                {
+                    skip &= -4;
+                }
+                else if (channels == 2)
+                {
+                    skip &= -2;
+                }
+                #endif
+            #endif
+            skipFract -= skip;
+            assert(nominalSkip >= -skipFract);
+        }
+
+        // ... then copy sequence samples from 'inputBuffer' to output:
+
+        // crosscheck that we don't have buffer overflow...
+        if ((int)inputBuffer.numSamples() < (offset + seekWindowLength - overlapLength))
+        {
+            continue;    // just in case, shouldn't really happen
+        }
+
+        // length of sequence
+        temp = (seekWindowLength - 2 * overlapLength);
+        outputBuffer.putSamples(inputBuffer.ptrBegin() + channels * offset, (uint)temp);
+
+        // Copies the end of the current sequence from 'inputBuffer' to
+        // 'midBuffer' for being mixed with the beginning of the next
+        // processing sequence and so on
+        assert((offset + temp + overlapLength) <= (int)inputBuffer.numSamples());
+        memcpy(pMidBuffer, inputBuffer.ptrBegin() + channels * (offset + temp),
+            channels * sizeof(SAMPLETYPE) * overlapLength);
+
+        // Remove the processed samples from the input buffer. Update
+        // the difference between integer & nominal skip step to 'skipFract'
+        // in order to prevent the error from accumulating over time.
+        skipFract += nominalSkip;   // real skip size
+        ovlSkip = (int)skipFract;   // rounded to integer skip
+        skipFract -= ovlSkip;       // maintain the fraction part, i.e. real vs. integer skip
+        inputBuffer.receiveSamples((uint)ovlSkip);
+    }
+}
+
+
+// Adds 'numsamples' pcs of samples from the 'samples' memory position into
+// the input of the object.
+void TDStretch::putSamples(const SAMPLETYPE *samples, uint nSamples)
+{
+    // Add the samples into the input buffer
+    inputBuffer.putSamples(samples, nSamples);
+    // Process the samples in input buffer
+    processSamples();
+}
+
+
+
+/// Set new overlap length parameter & reallocate RefMidBuffer if necessary.
+void TDStretch::acceptNewOverlapLength(int newOverlapLength)
+{
+    int prevOvl;
+
+    assert(newOverlapLength >= 0);
+    prevOvl = overlapLength;
+    overlapLength = newOverlapLength;
+
+    if (overlapLength > prevOvl)
+    {
+        delete[] pMidBufferUnaligned;
+
+        pMidBufferUnaligned = new SAMPLETYPE[overlapLength * channels + 16 / sizeof(SAMPLETYPE)];
+        // ensure that 'pMidBuffer' is aligned to 16 byte boundary for efficiency
+        pMidBuffer = (SAMPLETYPE *)SOUNDTOUCH_ALIGN_POINTER_16(pMidBufferUnaligned);
+
+        clearMidBuffer();
+    }
+}
+
+
+// Operator 'new' is overloaded so that it automatically creates a suitable instance
+// depending on if we've a MMX/SSE/etc-capable CPU available or not.
+void * TDStretch::operator new(size_t s)
+{
+    // Notice! don't use "new TDStretch" directly, use "newInstance" to create a new instance instead!
+    ST_THROW_RT_ERROR("Error in TDStretch::new: Don't use 'new TDStretch' directly, use 'newInstance' member instead!");
+    return newInstance();
+}
+
+
+TDStretch * TDStretch::newInstance()
+{
+    uint uExtensions;
+
+    uExtensions = detectCPUextensions();
+
+    // Check if MMX/SSE instruction set extensions supported by CPU
+
+#ifdef SOUNDTOUCH_ALLOW_MMX
+    // MMX routines available only with integer sample types
+    if (uExtensions & SUPPORT_MMX)
+    {
+        return ::new TDStretchMMX;
+    }
+    else
+#endif // SOUNDTOUCH_ALLOW_MMX
+
+
+#ifdef SOUNDTOUCH_ALLOW_SSE
+    if (uExtensions & SUPPORT_SSE)
+    {
+        // SSE support
+        return ::new TDStretchSSE;
+    }
+    else
+#endif // SOUNDTOUCH_ALLOW_SSE
+
+    {
+        // ISA optimizations not supported, use plain C version
+        return ::new TDStretch;
+    }
+}
+
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// Integer arithmetic specific algorithm implementations.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifdef SOUNDTOUCH_INTEGER_SAMPLES
+
+// Overlaps samples in 'midBuffer' with the samples in 'input'. The 'Stereo'
+// version of the routine.
+void TDStretch::overlapStereo(short *poutput, const short *input) const
+{
+    int i;
+    short temp;
+    int cnt2;
+
+    for (i = 0; i < overlapLength ; i ++)
+    {
+        temp = (short)(overlapLength - i);
+        cnt2 = 2 * i;
+        poutput[cnt2] = (input[cnt2] * i + pMidBuffer[cnt2] * temp )  / overlapLength;
+        poutput[cnt2 + 1] = (input[cnt2 + 1] * i + pMidBuffer[cnt2 + 1] * temp ) / overlapLength;
+    }
+}
+
+
+// Overlaps samples in 'midBuffer' with the samples in 'input'. The 'Multi'
+// version of the routine.
+void TDStretch::overlapMulti(SAMPLETYPE *poutput, const SAMPLETYPE *input) const
+{
+    SAMPLETYPE m1=(SAMPLETYPE)0;
+    SAMPLETYPE m2;
+    int i=0;
+
+    for (m2 = (SAMPLETYPE)overlapLength; m2; m2 --)
+    {
+        for (int c = 0; c < channels; c ++)
+        {
+            poutput[i] = (input[i] * m1 + pMidBuffer[i] * m2)  / overlapLength;
+            i++;
+        }
+
+        m1++;
+    }
+}
+
+// Calculates the x having the closest 2^x value for the given value
+static int _getClosest2Power(double value)
+{
+    return (int)(log(value) / log(2.0) + 0.5);
+}
+
+
+/// Calculates overlap period length in samples.
+/// Integer version rounds overlap length to closest power of 2
+/// for a divide scaling operation.
+void TDStretch::calculateOverlapLength(int aoverlapMs)
+{
+    int newOvl;
+
+    assert(aoverlapMs >= 0);
+
+    // calculate overlap length so that it's power of 2 - thus it's easy to do
+    // integer division by right-shifting. Term "-1" at end is to account for
+    // the extra most significatnt bit left unused in result by signed multiplication
+    overlapDividerBitsPure = _getClosest2Power((sampleRate * aoverlapMs) / 1000.0) - 1;
+    if (overlapDividerBitsPure > 9) overlapDividerBitsPure = 9;
+    if (overlapDividerBitsPure < 3) overlapDividerBitsPure = 3;
+    newOvl = (int)pow(2.0, (int)overlapDividerBitsPure + 1);    // +1 => account for -1 above
+
+    acceptNewOverlapLength(newOvl);
+
+    overlapDividerBitsNorm = overlapDividerBitsPure;
+
+    // calculate sloping divider so that crosscorrelation operation won't
+    // overflow 32-bit register. Max. sum of the crosscorrelation sum without
+    // divider would be 2^30*(N^3-N)/3, where N = overlap length
+    slopingDivider = (newOvl * newOvl - 1) / 3;
+}
+
+
+double TDStretch::calcCrossCorr(const short *mixingPos, const short *compare, double &norm)
+{
+    long corr;
+    unsigned long lnorm;
+    int i;
+
+    corr = lnorm = 0;
+    // Same routine for stereo and mono. For stereo, unroll loop for better
+    // efficiency and gives slightly better resolution against rounding.
+    // For mono it same routine, just  unrolls loop by factor of 4
+    for (i = 0; i < channels * overlapLength; i += 4)
+    {
+        corr += (mixingPos[i] * compare[i] +
+                 mixingPos[i + 1] * compare[i + 1]) >> overlapDividerBitsNorm;  // notice: do intermediate division here to avoid integer overflow
+        corr += (mixingPos[i + 2] * compare[i + 2] +
+                mixingPos[i + 3] * compare[i + 3]) >> overlapDividerBitsNorm;
+        lnorm += (mixingPos[i] * mixingPos[i] +
+                mixingPos[i + 1] * mixingPos[i + 1]) >> overlapDividerBitsNorm; // notice: do intermediate division here to avoid integer overflow
+        lnorm += (mixingPos[i + 2] * mixingPos[i + 2] +
+                mixingPos[i + 3] * mixingPos[i + 3]) >> overlapDividerBitsNorm;
+    }
+
+    if (lnorm > maxnorm)
+    {
+        // modify 'maxnorm' inside critical section to avoid multi-access conflict if in OpenMP mode
+        #pragma omp critical
+        if (lnorm > maxnorm)
+        {
+            maxnorm = lnorm;
+        }
+    }
+    // Normalize result by dividing by sqrt(norm) - this step is easiest
+    // done using floating point operation
+    norm = (double)lnorm;
+    return (double)corr / sqrt((norm < 1e-9) ? 1.0 : norm);
+}
+
+
+/// Update cross-correlation by accumulating "norm" coefficient by previously calculated value
+double TDStretch::calcCrossCorrAccumulate(const short *mixingPos, const short *compare, double &norm)
+{
+    long corr;
+    unsigned long lnorm;
+    int i;
+
+    // cancel first normalizer tap from previous round
+    lnorm = 0;
+    for (i = 1; i <= channels; i ++)
+    {
+        lnorm -= (mixingPos[-i] * mixingPos[-i]) >> overlapDividerBitsNorm;
+    }
+
+    corr = 0;
+    // Same routine for stereo and mono. For stereo, unroll loop for better
+    // efficiency and gives slightly better resolution against rounding.
+    // For mono it same routine, just  unrolls loop by factor of 4
+    for (i = 0; i < channels * overlapLength; i += 4)
+    {
+        corr += (mixingPos[i] * compare[i] +
+                 mixingPos[i + 1] * compare[i + 1]) >> overlapDividerBitsNorm;  // notice: do intermediate division here to avoid integer overflow
+        corr += (mixingPos[i + 2] * compare[i + 2] +
+                 mixingPos[i + 3] * compare[i + 3]) >> overlapDividerBitsNorm;
+    }
+
+    // update normalizer with last samples of this round
+    for (int j = 0; j < channels; j ++)
+    {
+        i --;
+        lnorm += (mixingPos[i] * mixingPos[i]) >> overlapDividerBitsNorm;
+    }
+
+    norm += (double)lnorm;
+    if (norm > maxnorm)
+    {
+        maxnorm = (unsigned long)norm;
+    }
+
+    // Normalize result by dividing by sqrt(norm) - this step is easiest
+    // done using floating point operation
+    return (double)corr / sqrt((norm < 1e-9) ? 1.0 : norm);
+}
+
+#endif // SOUNDTOUCH_INTEGER_SAMPLES
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// Floating point arithmetic specific algorithm implementations.
+//
+
+#ifdef SOUNDTOUCH_FLOAT_SAMPLES
+
+// Overlaps samples in 'midBuffer' with the samples in 'pInput'
+void TDStretch::overlapStereo(float *pOutput, const float *pInput) const
+{
+    int i;
+    float fScale;
+    float f1;
+    float f2;
+
+    fScale = 1.0f / (float)overlapLength;
+
+    f1 = 0;
+    f2 = 1.0f;
+
+    for (i = 0; i < 2 * (int)overlapLength ; i += 2)
+    {
+        pOutput[i + 0] = pInput[i + 0] * f1 + pMidBuffer[i + 0] * f2;
+        pOutput[i + 1] = pInput[i + 1] * f1 + pMidBuffer[i + 1] * f2;
+
+        f1 += fScale;
+        f2 -= fScale;
+    }
+}
+
+
+// Overlaps samples in 'midBuffer' with the samples in 'input'.
+void TDStretch::overlapMulti(float *pOutput, const float *pInput) const
+{
+    int i;
+    float fScale;
+    float f1;
+    float f2;
+
+    fScale = 1.0f / (float)overlapLength;
+
+    f1 = 0;
+    f2 = 1.0f;
+
+    i=0;
+    for (int i2 = 0; i2 < overlapLength; i2 ++)
+    {
+        // note: Could optimize this slightly by taking into account that always channels > 2
+        for (int c = 0; c < channels; c ++)
+        {
+            pOutput[i] = pInput[i] * f1 + pMidBuffer[i] * f2;
+            i++;
+        }
+        f1 += fScale;
+        f2 -= fScale;
+    }
+}
+
+
+/// Calculates overlapInMsec period length in samples.
+void TDStretch::calculateOverlapLength(int overlapInMsec)
+{
+    int newOvl;
+
+    assert(overlapInMsec >= 0);
+    newOvl = (sampleRate * overlapInMsec) / 1000;
+    if (newOvl < 16) newOvl = 16;
+
+    // must be divisible by 8
+    newOvl -= newOvl % 8;
+
+    acceptNewOverlapLength(newOvl);
+}
+
+
+/// Calculate cross-correlation
+double TDStretch::calcCrossCorr(const float *mixingPos, const float *compare, double &anorm)
+{
+    double corr;
+    double norm;
+    int i;
+
+    corr = norm = 0;
+    // Same routine for stereo and mono. For Stereo, unroll by factor of 2.
+    // For mono it's same routine yet unrollsd by factor of 4.
+    for (i = 0; i < channels * overlapLength; i += 4)
+    {
+        corr += mixingPos[i] * compare[i] +
+                mixingPos[i + 1] * compare[i + 1];
+
+        norm += mixingPos[i] * mixingPos[i] +
+                mixingPos[i + 1] * mixingPos[i + 1];
+
+        // unroll the loop for better CPU efficiency:
+        corr += mixingPos[i + 2] * compare[i + 2] +
+                mixingPos[i + 3] * compare[i + 3];
+
+        norm += mixingPos[i + 2] * mixingPos[i + 2] +
+                mixingPos[i + 3] * mixingPos[i + 3];
+    }
+
+    anorm = norm;
+    return corr / sqrt((norm < 1e-9 ? 1.0 : norm));
+}
+
+
+/// Update cross-correlation by accumulating "norm" coefficient by previously calculated value
+double TDStretch::calcCrossCorrAccumulate(const float *mixingPos, const float *compare, double &norm)
+{
+    double corr;
+    int i;
+
+    corr = 0;
+
+    // cancel first normalizer tap from previous round
+    for (i = 1; i <= channels; i ++)
+    {
+        norm -= mixingPos[-i] * mixingPos[-i];
+    }
+
+    // Same routine for stereo and mono. For Stereo, unroll by factor of 2.
+    // For mono it's same routine yet unrollsd by factor of 4.
+    for (i = 0; i < channels * overlapLength; i += 4)
+    {
+        corr += mixingPos[i] * compare[i] +
+                mixingPos[i + 1] * compare[i + 1] +
+                mixingPos[i + 2] * compare[i + 2] +
+                mixingPos[i + 3] * compare[i + 3];
+    }
+
+    // update normalizer with last samples of this round
+    for (int j = 0; j < channels; j ++)
+    {
+        i --;
+        norm += mixingPos[i] * mixingPos[i];
+    }
+
+    return corr / sqrt((norm < 1e-9 ? 1.0 : norm));
+}
+
+
+#endif // SOUNDTOUCH_FLOAT_SAMPLES

--- a/third_party/soundtouch/source/SoundTouch/TDStretch.h
+++ b/third_party/soundtouch/source/SoundTouch/TDStretch.h
@@ -1,0 +1,279 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Sampled sound tempo changer/time stretch algorithm. Changes the sound tempo
+/// while maintaining the original pitch by using a time domain WSOLA-like method
+/// with several performance-increasing tweaks.
+///
+/// Note : MMX/SSE optimized functions reside in separate, platform-specific files
+/// 'mmx_optimized.cpp' and 'sse_optimized.cpp'
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef TDStretch_H
+#define TDStretch_H
+
+#include <stddef.h>
+#include "STTypes.h"
+#include "RateTransposer.h"
+#include "FIFOSamplePipe.h"
+
+namespace soundtouch
+{
+
+/// Default values for sound processing parameters:
+/// Notice that the default parameters are tuned for contemporary popular music
+/// processing. For speech processing applications these parameters suit better:
+///     #define DEFAULT_SEQUENCE_MS     40
+///     #define DEFAULT_SEEKWINDOW_MS   15
+///     #define DEFAULT_OVERLAP_MS      8
+///
+
+/// Default length of a single processing sequence, in milliseconds. This determines to how
+/// long sequences the original sound is chopped in the time-stretch algorithm.
+///
+/// The larger this value is, the lesser sequences are used in processing. In principle
+/// a bigger value sounds better when slowing down tempo, but worse when increasing tempo
+/// and vice versa.
+///
+/// Increasing this value reduces computational burden & vice versa.
+//#define DEFAULT_SEQUENCE_MS         40
+#define DEFAULT_SEQUENCE_MS         USE_AUTO_SEQUENCE_LEN
+
+/// Giving this value for the sequence length sets automatic parameter value
+/// according to tempo setting (recommended)
+#define USE_AUTO_SEQUENCE_LEN       0
+
+/// Seeking window default length in milliseconds for algorithm that finds the best possible
+/// overlapping location. This determines from how wide window the algorithm may look for an
+/// optimal joining location when mixing the sound sequences back together.
+///
+/// The bigger this window setting is, the higher the possibility to find a better mixing
+/// position will become, but at the same time large values may cause a "drifting" artifact
+/// because consequent sequences will be taken at more uneven intervals.
+///
+/// If there's a disturbing artifact that sounds as if a constant frequency was drifting
+/// around, try reducing this setting.
+///
+/// Increasing this value increases computational burden & vice versa.
+//#define DEFAULT_SEEKWINDOW_MS       15
+#define DEFAULT_SEEKWINDOW_MS       USE_AUTO_SEEKWINDOW_LEN
+
+/// Giving this value for the seek window length sets automatic parameter value
+/// according to tempo setting (recommended)
+#define USE_AUTO_SEEKWINDOW_LEN     0
+
+/// Overlap length in milliseconds. When the chopped sound sequences are mixed back together,
+/// to form a continuous sound stream, this parameter defines over how long period the two
+/// consecutive sequences are let to overlap each other.
+///
+/// This shouldn't be that critical parameter. If you reduce the DEFAULT_SEQUENCE_MS setting
+/// by a large amount, you might wish to try a smaller value on this.
+///
+/// Increasing this value increases computational burden & vice versa.
+#define DEFAULT_OVERLAP_MS      8
+
+
+/// Class that does the time-stretch (tempo change) effect for the processed
+/// sound.
+class TDStretch : public FIFOProcessor
+{
+protected:
+    int channels;
+    int sampleReq;
+
+    int overlapLength;
+    int seekLength;
+    int seekWindowLength;
+    int overlapDividerBitsNorm;
+    int overlapDividerBitsPure;
+    int slopingDivider;
+    int sampleRate;
+    int sequenceMs;
+    int seekWindowMs;
+    int overlapMs;
+
+    unsigned long maxnorm;
+    float maxnormf;
+
+    double tempo;
+    double nominalSkip;
+    double skipFract;
+
+    bool bQuickSeek;
+    bool bAutoSeqSetting;
+    bool bAutoSeekSetting;
+    bool isBeginning;
+
+    SAMPLETYPE *pMidBuffer;
+    SAMPLETYPE *pMidBufferUnaligned;
+
+    FIFOSampleBuffer outputBuffer;
+    FIFOSampleBuffer inputBuffer;
+
+    void acceptNewOverlapLength(int newOverlapLength);
+
+    virtual void clearCrossCorrState();
+    void calculateOverlapLength(int overlapMs);
+
+    virtual double calcCrossCorr(const SAMPLETYPE *mixingPos, const SAMPLETYPE *compare, double &norm);
+    virtual double calcCrossCorrAccumulate(const SAMPLETYPE *mixingPos, const SAMPLETYPE *compare, double &norm);
+
+    virtual int seekBestOverlapPositionFull(const SAMPLETYPE *refPos);
+    virtual int seekBestOverlapPositionQuick(const SAMPLETYPE *refPos);
+    virtual int seekBestOverlapPosition(const SAMPLETYPE *refPos);
+
+    virtual void overlapStereo(SAMPLETYPE *output, const SAMPLETYPE *input) const;
+    virtual void overlapMono(SAMPLETYPE *output, const SAMPLETYPE *input) const;
+    virtual void overlapMulti(SAMPLETYPE *output, const SAMPLETYPE *input) const;
+
+    void clearMidBuffer();
+    void overlap(SAMPLETYPE *output, const SAMPLETYPE *input, uint ovlPos) const;
+
+    void calcSeqParameters();
+    void adaptNormalizer();
+
+    /// Changes the tempo of the given sound samples.
+    /// Returns amount of samples returned in the "output" buffer.
+    /// The maximum amount of samples that can be returned at a time is set by
+    /// the 'set_returnBuffer_size' function.
+    void processSamples();
+
+public:
+    TDStretch();
+    virtual ~TDStretch();
+
+    /// Operator 'new' is overloaded so that it automatically creates a suitable instance
+    /// depending on if we've a MMX/SSE/etc-capable CPU available or not.
+    static void *operator new(size_t s);
+
+    /// Use this function instead of "new" operator to create a new instance of this class.
+    /// This function automatically chooses a correct feature set depending on if the CPU
+    /// supports MMX/SSE/etc extensions.
+    static TDStretch *newInstance();
+
+    /// Returns the output buffer object
+    FIFOSamplePipe *getOutput() { return &outputBuffer; };
+
+    /// Returns the input buffer object
+    FIFOSamplePipe *getInput() { return &inputBuffer; };
+
+    /// Sets new target tempo. Normal tempo = 'SCALE', smaller values represent slower
+    /// tempo, larger faster tempo.
+    void setTempo(double newTempo);
+
+    /// Returns nonzero if there aren't any samples available for outputting.
+    virtual void clear();
+
+    /// Clears the input buffer
+    void clearInput();
+
+    /// Sets the number of channels, 1 = mono, 2 = stereo
+    void setChannels(int numChannels);
+
+    /// Enables/disables the quick position seeking algorithm. Zero to disable,
+    /// nonzero to enable
+    void enableQuickSeek(bool enable);
+
+    /// Returns nonzero if the quick seeking algorithm is enabled.
+    bool isQuickSeekEnabled() const;
+
+    /// Sets routine control parameters. These control are certain time constants
+    /// defining how the sound is stretched to the desired duration.
+    //
+    /// 'sampleRate' = sample rate of the sound
+    /// 'sequenceMS' = one processing sequence length in milliseconds
+    /// 'seekwindowMS' = seeking window length for scanning the best overlapping
+    ///      position
+    /// 'overlapMS' = overlapping length
+    void setParameters(int sampleRate,          ///< Samplerate of sound being processed (Hz)
+                       int sequenceMS = -1,     ///< Single processing sequence length (ms)
+                       int seekwindowMS = -1,   ///< Offset seeking window length (ms)
+                       int overlapMS = -1       ///< Sequence overlapping length (ms)
+                       );
+
+    /// Get routine control parameters, see setParameters() function.
+    /// Any of the parameters to this function can be NULL, in such case corresponding parameter
+    /// value isn't returned.
+    void getParameters(int *pSampleRate, int *pSequenceMs, int *pSeekWindowMs, int *pOverlapMs) const;
+
+    /// Adds 'numsamples' pcs of samples from the 'samples' memory position into
+    /// the input of the object.
+    virtual void putSamples(
+            const SAMPLETYPE *samples,  ///< Input sample data
+            uint numSamples                         ///< Number of samples in 'samples' so that one sample
+                                                    ///< contains both channels if stereo
+            );
+
+    /// return nominal input sample requirement for triggering a processing batch
+    int getInputSampleReq() const
+    {
+        return (int)(nominalSkip + 0.5);
+    }
+
+    /// return nominal output sample amount when running a processing batch
+    int getOutputBatchSize() const
+    {
+        return seekWindowLength - overlapLength;
+    }
+
+    /// return approximate initial input-output latency
+    int getLatency() const
+    {
+        return sampleReq;
+    }
+};
+
+
+// Implementation-specific class declarations:
+
+#ifdef SOUNDTOUCH_ALLOW_MMX
+    /// Class that implements MMX optimized routines for 16bit integer samples type.
+    class TDStretchMMX : public TDStretch
+    {
+    protected:
+        double calcCrossCorr(const short *mixingPos, const short *compare, double &norm);
+        double calcCrossCorrAccumulate(const short *mixingPos, const short *compare, double &norm);
+        virtual void overlapStereo(short *output, const short *input) const;
+        virtual void clearCrossCorrState();
+    };
+#endif /// SOUNDTOUCH_ALLOW_MMX
+
+
+#ifdef SOUNDTOUCH_ALLOW_SSE
+    /// Class that implements SSE optimized routines for floating point samples type.
+    class TDStretchSSE : public TDStretch
+    {
+    protected:
+        double calcCrossCorr(const float *mixingPos, const float *compare, double &norm);
+        double calcCrossCorrAccumulate(const float *mixingPos, const float *compare, double &norm);
+    };
+
+#endif /// SOUNDTOUCH_ALLOW_SSE
+
+}
+#endif  /// TDStretch_H

--- a/third_party/soundtouch/source/SoundTouch/cpu_detect.h
+++ b/third_party/soundtouch/source/SoundTouch/cpu_detect.h
@@ -1,0 +1,55 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// A header file for detecting the Intel MMX instructions set extension.
+///
+/// Please see 'mmx_win.cpp', 'mmx_cpp.cpp' and 'mmx_non_x86.cpp' for the
+/// routine implementations for x86 Windows, x86 gnu version and non-x86
+/// platforms, respectively.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef _CPU_DETECT_H_
+#define _CPU_DETECT_H_
+
+#include "STTypes.h"
+
+#define SUPPORT_MMX         0x0001
+#define SUPPORT_3DNOW       0x0002
+#define SUPPORT_ALTIVEC     0x0004
+#define SUPPORT_SSE         0x0008
+#define SUPPORT_SSE2        0x0010
+
+/// Checks which instruction set extensions are supported by the CPU.
+///
+/// \return A bitmask of supported extensions, see SUPPORT_... defines.
+uint detectCPUextensions(void);
+
+/// Disables given set of instruction extensions. See SUPPORT_... defines.
+void disableExtensions(uint wDisableMask);
+
+#endif  // _CPU_DETECT_H_

--- a/third_party/soundtouch/source/SoundTouch/cpu_detect_x86.cpp
+++ b/third_party/soundtouch/source/SoundTouch/cpu_detect_x86.cpp
@@ -1,0 +1,130 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Generic version of the x86 CPU extension detection routine.
+///
+/// This file is for GNU & other non-Windows compilers, see 'cpu_detect_x86_win.cpp'
+/// for the Microsoft compiler version.
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "cpu_detect.h"
+#include "STTypes.h"
+
+
+#if defined(SOUNDTOUCH_ALLOW_X86_OPTIMIZATIONS)
+
+   #if defined(__GNUC__) && defined(__i386__)
+       // gcc
+       #include "cpuid.h"
+   #elif defined(_M_IX86)
+       // windows non-gcc
+       #include <intrin.h>
+   #endif
+
+   #define bit_MMX     (1 << 23)
+   #define bit_SSE     (1 << 25)
+   #define bit_SSE2    (1 << 26)
+#endif
+
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// processor instructions extension detection routines
+//
+//////////////////////////////////////////////////////////////////////////////
+
+// Flag variable indicating whick ISA extensions are disabled (for debugging)
+static uint _dwDisabledISA = 0x00;      // 0xffffffff; //<- use this to disable all extensions
+
+// Disables given set of instruction extensions. See SUPPORT_... defines.
+void disableExtensions(uint dwDisableMask)
+{
+    _dwDisabledISA = dwDisableMask;
+}
+
+
+/// Checks which instruction set extensions are supported by the CPU.
+uint detectCPUextensions(void)
+{
+/// If building for a 64bit system (no Itanium) and the user wants optimizations.
+/// Return the OR of SUPPORT_{MMX,SSE,SSE2}. 11001 or 0x19.
+/// Keep the _dwDisabledISA test (2 more operations, could be eliminated).
+#if ((defined(__GNUC__) && defined(__x86_64__)) \
+    || defined(_M_X64))  \
+    && defined(SOUNDTOUCH_ALLOW_X86_OPTIMIZATIONS)
+    return 0x19 & ~_dwDisabledISA;
+
+/// If building for a 32bit system and the user wants optimizations.
+/// Keep the _dwDisabledISA test (2 more operations, could be eliminated).
+#elif ((defined(__GNUC__) && defined(__i386__)) \
+    || defined(_M_IX86))  \
+    && defined(SOUNDTOUCH_ALLOW_X86_OPTIMIZATIONS)
+
+    if (_dwDisabledISA == 0xffffffff) return 0;
+
+    uint res = 0;
+
+#if defined(__GNUC__)
+    // GCC version of cpuid. Requires GCC 4.3.0 or later for __cpuid intrinsic support.
+    uint eax, ebx, ecx, edx;  // unsigned int is the standard type. uint is defined by the compiler and not guaranteed to be portable.
+
+    // Check if no cpuid support.
+    if (!__get_cpuid (1, &eax, &ebx, &ecx, &edx)) return 0; // always disable extensions.
+
+    if (edx & bit_MMX)  res = res | SUPPORT_MMX;
+    if (edx & bit_SSE)  res = res | SUPPORT_SSE;
+    if (edx & bit_SSE2) res = res | SUPPORT_SSE2;
+
+#else
+    // Window / VS version of cpuid. Notice that Visual Studio 2005 or later required
+    // for __cpuid intrinsic support.
+    int reg[4] = {-1};
+
+    // Check if no cpuid support.
+    __cpuid(reg,0);
+    if ((unsigned int)reg[0] == 0) return 0; // always disable extensions.
+
+    __cpuid(reg,1);
+    if ((unsigned int)reg[3] & bit_MMX)  res = res | SUPPORT_MMX;
+    if ((unsigned int)reg[3] & bit_SSE)  res = res | SUPPORT_SSE;
+    if ((unsigned int)reg[3] & bit_SSE2) res = res | SUPPORT_SSE2;
+
+#endif
+
+    return res & ~_dwDisabledISA;
+
+#else
+
+/// One of these is true:
+/// 1) We don't want optimizations.
+/// 2) Using an unsupported compiler.
+/// 3) Running on a non-x86 platform.
+    return 0;
+
+#endif
+}

--- a/third_party/soundtouch/source/SoundTouch/mmx_optimized.cpp
+++ b/third_party/soundtouch/source/SoundTouch/mmx_optimized.cpp
@@ -1,0 +1,396 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// MMX optimized routines. All MMX optimized functions have been gathered into
+/// this single source code file, regardless to their class or original source
+/// code file, in order to ease porting the library to other compiler and
+/// processor platforms.
+///
+/// The MMX-optimizations are programmed using MMX compiler intrinsics that
+/// are supported both by Microsoft Visual C++ and GCC compilers, so this file
+/// should compile with both toolsets.
+///
+/// NOTICE: If using Visual Studio 6.0, you'll need to install the "Visual C++
+/// 6.0 processor pack" update to support compiler intrinsic syntax. The update
+/// is available for download at Microsoft Developers Network, see here:
+/// http://msdn.microsoft.com/en-us/vstudio/aa718349.aspx
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "STTypes.h"
+
+#ifdef SOUNDTOUCH_ALLOW_MMX
+// MMX routines available only with integer sample type
+
+using namespace soundtouch;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// implementation of MMX optimized functions of class 'TDStretchMMX'
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#include "TDStretch.h"
+#include <mmintrin.h>
+#include <limits.h>
+#include <math.h>
+
+
+// Calculates cross correlation of two buffers
+double TDStretchMMX::calcCrossCorr(const short *pV1, const short *pV2, double &dnorm)
+{
+    const __m64 *pVec1, *pVec2;
+    __m64 shifter;
+    __m64 accu, normaccu;
+    long corr, norm;
+    int i;
+
+    pVec1 = (__m64*)pV1;
+    pVec2 = (__m64*)pV2;
+
+    shifter = _m_from_int(overlapDividerBitsNorm);
+    normaccu = accu = _mm_setzero_si64();
+
+    // Process 4 parallel sets of 2 * stereo samples or 4 * mono samples
+    // during each round for improved CPU-level parallellization.
+    for (i = 0; i < channels * overlapLength / 16; i ++)
+    {
+        __m64 temp, temp2;
+
+        // dictionary of instructions:
+        // _m_pmaddwd   : 4*16bit multiply-add, resulting two 32bits = [a0*b0+a1*b1 ; a2*b2+a3*b3]
+        // _mm_add_pi32 : 2*32bit add
+        // _m_psrad     : 32bit right-shift
+
+        temp = _mm_add_pi32(_mm_sra_pi32(_mm_madd_pi16(pVec1[0], pVec2[0]), shifter),
+                            _mm_sra_pi32(_mm_madd_pi16(pVec1[1], pVec2[1]), shifter));
+        temp2 = _mm_add_pi32(_mm_sra_pi32(_mm_madd_pi16(pVec1[0], pVec1[0]), shifter),
+                            _mm_sra_pi32(_mm_madd_pi16(pVec1[1], pVec1[1]), shifter));
+        accu = _mm_add_pi32(accu, temp);
+        normaccu = _mm_add_pi32(normaccu, temp2);
+
+        temp = _mm_add_pi32(_mm_sra_pi32(_mm_madd_pi16(pVec1[2], pVec2[2]), shifter),
+                            _mm_sra_pi32(_mm_madd_pi16(pVec1[3], pVec2[3]), shifter));
+        temp2 = _mm_add_pi32(_mm_sra_pi32(_mm_madd_pi16(pVec1[2], pVec1[2]), shifter),
+                            _mm_sra_pi32(_mm_madd_pi16(pVec1[3], pVec1[3]), shifter));
+        accu = _mm_add_pi32(accu, temp);
+        normaccu = _mm_add_pi32(normaccu, temp2);
+
+        pVec1 += 4;
+        pVec2 += 4;
+    }
+
+    // copy hi-dword of mm0 to lo-dword of mm1, then sum mmo+mm1
+    // and finally store the result into the variable "corr"
+
+    accu = _mm_add_pi32(accu, _mm_srli_si64(accu, 32));
+    corr = _m_to_int(accu);
+
+    normaccu = _mm_add_pi32(normaccu, _mm_srli_si64(normaccu, 32));
+    norm = _m_to_int(normaccu);
+
+    // Clear MMS state
+    _m_empty();
+
+    if (norm > (long)maxnorm)
+    {
+        // modify 'maxnorm' inside critical section to avoid multi-access conflict if in OpenMP mode
+        #pragma omp critical
+        if (norm > (long)maxnorm)
+        {
+            maxnorm = norm;
+        }
+    }
+
+    // Normalize result by dividing by sqrt(norm) - this step is easiest
+    // done using floating point operation
+    dnorm = (double)norm;
+
+    return (double)corr / sqrt(dnorm < 1e-9 ? 1.0 : dnorm);
+    // Note: Warning about the missing EMMS instruction is harmless
+    // as it'll be called elsewhere.
+}
+
+
+/// Update cross-correlation by accumulating "norm" coefficient by previously calculated value
+double TDStretchMMX::calcCrossCorrAccumulate(const short *pV1, const short *pV2, double &dnorm)
+{
+    const __m64 *pVec1, *pVec2;
+    __m64 shifter;
+    __m64 accu;
+    long corr, lnorm;
+    int i;
+
+    // cancel first normalizer tap from previous round
+    lnorm = 0;
+    for (i = 1; i <= channels; i ++)
+    {
+        lnorm -= (pV1[-i] * pV1[-i]) >> overlapDividerBitsNorm;
+    }
+
+    pVec1 = (__m64*)pV1;
+    pVec2 = (__m64*)pV2;
+
+    shifter = _m_from_int(overlapDividerBitsNorm);
+    accu = _mm_setzero_si64();
+
+    // Process 4 parallel sets of 2 * stereo samples or 4 * mono samples
+    // during each round for improved CPU-level parallellization.
+    for (i = 0; i < channels * overlapLength / 16; i ++)
+    {
+        __m64 temp;
+
+        // dictionary of instructions:
+        // _m_pmaddwd   : 4*16bit multiply-add, resulting two 32bits = [a0*b0+a1*b1 ; a2*b2+a3*b3]
+        // _mm_add_pi32 : 2*32bit add
+        // _m_psrad     : 32bit right-shift
+
+        temp = _mm_add_pi32(_mm_sra_pi32(_mm_madd_pi16(pVec1[0], pVec2[0]), shifter),
+                            _mm_sra_pi32(_mm_madd_pi16(pVec1[1], pVec2[1]), shifter));
+        accu = _mm_add_pi32(accu, temp);
+
+        temp = _mm_add_pi32(_mm_sra_pi32(_mm_madd_pi16(pVec1[2], pVec2[2]), shifter),
+                            _mm_sra_pi32(_mm_madd_pi16(pVec1[3], pVec2[3]), shifter));
+        accu = _mm_add_pi32(accu, temp);
+
+        pVec1 += 4;
+        pVec2 += 4;
+    }
+
+    // copy hi-dword of mm0 to lo-dword of mm1, then sum mmo+mm1
+    // and finally store the result into the variable "corr"
+
+    accu = _mm_add_pi32(accu, _mm_srli_si64(accu, 32));
+    corr = _m_to_int(accu);
+
+    // Clear MMS state
+    _m_empty();
+
+    // update normalizer with last samples of this round
+    pV1 = (short *)pVec1;
+    for (int j = 1; j <= channels; j ++)
+    {
+        lnorm += (pV1[-j] * pV1[-j]) >> overlapDividerBitsNorm;
+    }
+    dnorm += (double)lnorm;
+
+    if (lnorm > (long)maxnorm)
+    {
+        maxnorm = lnorm;
+    }
+
+    // Normalize result by dividing by sqrt(norm) - this step is easiest
+    // done using floating point operation
+    return (double)corr / sqrt((dnorm < 1e-9) ? 1.0 : dnorm);
+}
+
+
+void TDStretchMMX::clearCrossCorrState()
+{
+    // Clear MMS state
+    _m_empty();
+    //_asm EMMS;
+}
+
+
+// MMX-optimized version of the function overlapStereo
+void TDStretchMMX::overlapStereo(short *output, const short *input) const
+{
+    const __m64 *pVinput, *pVMidBuf;
+    __m64 *pVdest;
+    __m64 mix1, mix2, adder, shifter;
+    int i;
+
+    pVinput  = (const __m64*)input;
+    pVMidBuf = (const __m64*)pMidBuffer;
+    pVdest   = (__m64*)output;
+
+    // mix1  = mixer values for 1st stereo sample
+    // mix1  = mixer values for 2nd stereo sample
+    // adder = adder for updating mixer values after each round
+
+    mix1  = _mm_set_pi16(0, overlapLength,   0, overlapLength);
+    adder = _mm_set_pi16(1, -1, 1, -1);
+    mix2  = _mm_add_pi16(mix1, adder);
+    adder = _mm_add_pi16(adder, adder);
+
+    // Overlaplength-division by shifter. "+1" is to account for "-1" deduced in
+    // overlapDividerBits calculation earlier.
+    shifter = _m_from_int(overlapDividerBitsPure + 1);
+
+    for (i = 0; i < overlapLength / 4; i ++)
+    {
+        __m64 temp1, temp2;
+
+        // load & shuffle data so that input & mixbuffer data samples are paired
+        temp1 = _mm_unpacklo_pi16(pVMidBuf[0], pVinput[0]);     // = i0l m0l i0r m0r
+        temp2 = _mm_unpackhi_pi16(pVMidBuf[0], pVinput[0]);     // = i1l m1l i1r m1r
+
+        // temp = (temp .* mix) >> shifter
+        temp1 = _mm_sra_pi32(_mm_madd_pi16(temp1, mix1), shifter);
+        temp2 = _mm_sra_pi32(_mm_madd_pi16(temp2, mix2), shifter);
+        pVdest[0] = _mm_packs_pi32(temp1, temp2); // pack 2*2*32bit => 4*16bit
+
+        // update mix += adder
+        mix1 = _mm_add_pi16(mix1, adder);
+        mix2 = _mm_add_pi16(mix2, adder);
+
+        // --- second round begins here ---
+
+        // load & shuffle data so that input & mixbuffer data samples are paired
+        temp1 = _mm_unpacklo_pi16(pVMidBuf[1], pVinput[1]);       // = i2l m2l i2r m2r
+        temp2 = _mm_unpackhi_pi16(pVMidBuf[1], pVinput[1]);       // = i3l m3l i3r m3r
+
+        // temp = (temp .* mix) >> shifter
+        temp1 = _mm_sra_pi32(_mm_madd_pi16(temp1, mix1), shifter);
+        temp2 = _mm_sra_pi32(_mm_madd_pi16(temp2, mix2), shifter);
+        pVdest[1] = _mm_packs_pi32(temp1, temp2); // pack 2*2*32bit => 4*16bit
+
+        // update mix += adder
+        mix1 = _mm_add_pi16(mix1, adder);
+        mix2 = _mm_add_pi16(mix2, adder);
+
+        pVinput  += 2;
+        pVMidBuf += 2;
+        pVdest   += 2;
+    }
+
+    _m_empty(); // clear MMS state
+}
+
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// implementation of MMX optimized functions of class 'FIRFilter'
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#include "FIRFilter.h"
+
+
+FIRFilterMMX::FIRFilterMMX() : FIRFilter()
+{
+    filterCoeffsAlign = NULL;
+    filterCoeffsUnalign = NULL;
+}
+
+
+FIRFilterMMX::~FIRFilterMMX()
+{
+    delete[] filterCoeffsUnalign;
+}
+
+
+// (overloaded) Calculates filter coefficients for MMX routine
+void FIRFilterMMX::setCoefficients(const short *coeffs, uint newLength, uint uResultDivFactor)
+{
+    uint i;
+    FIRFilter::setCoefficients(coeffs, newLength, uResultDivFactor);
+
+    // Ensure that filter coeffs array is aligned to 16-byte boundary
+    delete[] filterCoeffsUnalign;
+    filterCoeffsUnalign = new short[2 * newLength + 8];
+    filterCoeffsAlign = (short *)SOUNDTOUCH_ALIGN_POINTER_16(filterCoeffsUnalign);
+
+    // rearrange the filter coefficients for mmx routines
+    for (i = 0;i < length; i += 4)
+    {
+        filterCoeffsAlign[2 * i + 0] = coeffs[i + 0];
+        filterCoeffsAlign[2 * i + 1] = coeffs[i + 2];
+        filterCoeffsAlign[2 * i + 2] = coeffs[i + 0];
+        filterCoeffsAlign[2 * i + 3] = coeffs[i + 2];
+
+        filterCoeffsAlign[2 * i + 4] = coeffs[i + 1];
+        filterCoeffsAlign[2 * i + 5] = coeffs[i + 3];
+        filterCoeffsAlign[2 * i + 6] = coeffs[i + 1];
+        filterCoeffsAlign[2 * i + 7] = coeffs[i + 3];
+    }
+}
+
+
+// mmx-optimized version of the filter routine for stereo sound
+uint FIRFilterMMX::evaluateFilterStereo(short *dest, const short *src, uint numSamples) const
+{
+    // Create stack copies of the needed member variables for asm routines :
+    uint i, j;
+    __m64 *pVdest = (__m64*)dest;
+
+    if (length < 2) return 0;
+
+    for (i = 0; i < (numSamples - length) / 2; i ++)
+    {
+        __m64 accu1;
+        __m64 accu2;
+        const __m64 *pVsrc = (const __m64*)src;
+        const __m64 *pVfilter = (const __m64*)filterCoeffsAlign;
+
+        accu1 = accu2 = _mm_setzero_si64();
+        for (j = 0; j < lengthDiv8 * 2; j ++)
+        {
+            __m64 temp1, temp2;
+
+            temp1 = _mm_unpacklo_pi16(pVsrc[0], pVsrc[1]);  // = l2 l0 r2 r0
+            temp2 = _mm_unpackhi_pi16(pVsrc[0], pVsrc[1]);  // = l3 l1 r3 r1
+
+            accu1 = _mm_add_pi32(accu1, _mm_madd_pi16(temp1, pVfilter[0]));  // += l2*f2+l0*f0 r2*f2+r0*f0
+            accu1 = _mm_add_pi32(accu1, _mm_madd_pi16(temp2, pVfilter[1]));  // += l3*f3+l1*f1 r3*f3+r1*f1
+
+            temp1 = _mm_unpacklo_pi16(pVsrc[1], pVsrc[2]);  // = l4 l2 r4 r2
+
+            accu2 = _mm_add_pi32(accu2, _mm_madd_pi16(temp2, pVfilter[0]));  // += l3*f2+l1*f0 r3*f2+r1*f0
+            accu2 = _mm_add_pi32(accu2, _mm_madd_pi16(temp1, pVfilter[1]));  // += l4*f3+l2*f1 r4*f3+r2*f1
+
+            // accu1 += l2*f2+l0*f0 r2*f2+r0*f0
+            //       += l3*f3+l1*f1 r3*f3+r1*f1
+
+            // accu2 += l3*f2+l1*f0 r3*f2+r1*f0
+            //          l4*f3+l2*f1 r4*f3+r2*f1
+
+            pVfilter += 2;
+            pVsrc += 2;
+        }
+        // accu >>= resultDivFactor
+        accu1 = _mm_srai_pi32(accu1, resultDivFactor);
+        accu2 = _mm_srai_pi32(accu2, resultDivFactor);
+
+        // pack 2*2*32bits => 4*16 bits
+        pVdest[0] = _mm_packs_pi32(accu1, accu2);
+        src += 4;
+        pVdest ++;
+    }
+
+   _m_empty();  // clear emms state
+
+    return (numSamples & 0xfffffffe) - length;
+}
+
+#else
+
+// workaround to not complain about empty module
+bool _dontcomplain_mmx_empty;
+
+#endif  // SOUNDTOUCH_ALLOW_MMX

--- a/third_party/soundtouch/source/SoundTouch/sse_optimized.cpp
+++ b/third_party/soundtouch/source/SoundTouch/sse_optimized.cpp
@@ -1,0 +1,365 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// SSE optimized routines for Pentium-III, Athlon-XP and later CPUs. All SSE
+/// optimized functions have been gathered into this single source
+/// code file, regardless to their class or original source code file, in order
+/// to ease porting the library to other compiler and processor platforms.
+///
+/// The SSE-optimizations are programmed using SSE compiler intrinsics that
+/// are supported both by Microsoft Visual C++ and GCC compilers, so this file
+/// should compile with both toolsets.
+///
+/// NOTICE: If using Visual Studio 6.0, you'll need to install the "Visual C++
+/// 6.0 processor pack" update to support SSE instruction set. The update is
+/// available for download at Microsoft Developers Network, see here:
+/// http://msdn.microsoft.com/en-us/vstudio/aa718349.aspx
+///
+/// If the above URL is expired or removed, go to "http://msdn.microsoft.com" and
+/// perform a search with keywords "processor pack".
+///
+/// Author        : Copyright (c) Olli Parviainen
+/// Author e-mail : oparviai 'at' iki.fi
+/// SoundTouch WWW: http://www.surina.net/soundtouch
+///
+////////////////////////////////////////////////////////////////////////////////
+//
+// License :
+//
+//  SoundTouch audio processing library
+//  Copyright (c) Olli Parviainen
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "cpu_detect.h"
+#include "STTypes.h"
+
+using namespace soundtouch;
+
+#ifdef SOUNDTOUCH_ALLOW_SSE
+
+// SSE routines available only with float sample type
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// implementation of SSE optimized functions of class 'TDStretchSSE'
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#include "TDStretch.h"
+#include <xmmintrin.h>
+#include <math.h>
+
+// Calculates cross correlation of two buffers
+double TDStretchSSE::calcCrossCorr(const float *pV1, const float *pV2, double &anorm)
+{
+    int i;
+    const float *pVec1;
+    const __m128 *pVec2;
+    __m128 vSum, vNorm;
+
+    // Note. It means a major slow-down if the routine needs to tolerate
+    // unaligned __m128 memory accesses. It's way faster if we can skip
+    // unaligned slots and use _mm_load_ps instruction instead of _mm_loadu_ps.
+    // This can mean up to ~ 10-fold difference (incl. part of which is
+    // due to skipping every second round for stereo sound though).
+    //
+    // Compile-time define SOUNDTOUCH_ALLOW_NONEXACT_SIMD_OPTIMIZATION is provided
+    // for choosing if this little cheating is allowed.
+
+#ifdef SOUNDTOUCH_ALLOW_NONEXACT_SIMD_OPTIMIZATION
+    // Little cheating allowed, return valid correlation only for
+    // aligned locations, meaning every second round for stereo sound.
+
+    #define _MM_LOAD    _mm_load_ps
+
+    if (((ulongptr)pV1) & 15) return -1e50;    // skip unaligned locations
+
+#else
+    // No cheating allowed, use unaligned load & take the resulting
+    // performance hit.
+    #define _MM_LOAD    _mm_loadu_ps
+#endif
+
+    // ensure overlapLength is divisible by 8
+    assert((overlapLength % 8) == 0);
+
+    // Calculates the cross-correlation value between 'pV1' and 'pV2' vectors
+    // Note: pV2 _must_ be aligned to 16-bit boundary, pV1 need not.
+    pVec1 = (const float*)pV1;
+    pVec2 = (const __m128*)pV2;
+    vSum = vNorm = _mm_setzero_ps();
+
+    // Unroll the loop by factor of 4 * 4 operations. Use same routine for
+    // stereo & mono, for mono it just means twice the amount of unrolling.
+    for (i = 0; i < channels * overlapLength / 16; i ++)
+    {
+        __m128 vTemp;
+        // vSum += pV1[0..3] * pV2[0..3]
+        vTemp = _MM_LOAD(pVec1);
+        vSum  = _mm_add_ps(vSum,  _mm_mul_ps(vTemp ,pVec2[0]));
+        vNorm = _mm_add_ps(vNorm, _mm_mul_ps(vTemp ,vTemp));
+
+        // vSum += pV1[4..7] * pV2[4..7]
+        vTemp = _MM_LOAD(pVec1 + 4);
+        vSum  = _mm_add_ps(vSum, _mm_mul_ps(vTemp, pVec2[1]));
+        vNorm = _mm_add_ps(vNorm, _mm_mul_ps(vTemp ,vTemp));
+
+        // vSum += pV1[8..11] * pV2[8..11]
+        vTemp = _MM_LOAD(pVec1 + 8);
+        vSum  = _mm_add_ps(vSum, _mm_mul_ps(vTemp, pVec2[2]));
+        vNorm = _mm_add_ps(vNorm, _mm_mul_ps(vTemp ,vTemp));
+
+        // vSum += pV1[12..15] * pV2[12..15]
+        vTemp = _MM_LOAD(pVec1 + 12);
+        vSum  = _mm_add_ps(vSum, _mm_mul_ps(vTemp, pVec2[3]));
+        vNorm = _mm_add_ps(vNorm, _mm_mul_ps(vTemp ,vTemp));
+
+        pVec1 += 16;
+        pVec2 += 4;
+    }
+
+    // return value = vSum[0] + vSum[1] + vSum[2] + vSum[3]
+    float *pvNorm = (float*)&vNorm;
+    float norm = (pvNorm[0] + pvNorm[1] + pvNorm[2] + pvNorm[3]);
+    anorm = norm;
+
+    float *pvSum = (float*)&vSum;
+    return (double)(pvSum[0] + pvSum[1] + pvSum[2] + pvSum[3]) / sqrt(norm < 1e-9 ? 1.0 : norm);
+
+    /* This is approximately corresponding routine in C-language yet without normalization:
+    double corr, norm;
+    uint i;
+
+    // Calculates the cross-correlation value between 'pV1' and 'pV2' vectors
+    corr = norm = 0.0;
+    for (i = 0; i < channels * overlapLength / 16; i ++)
+    {
+        corr += pV1[0] * pV2[0] +
+                pV1[1] * pV2[1] +
+                pV1[2] * pV2[2] +
+                pV1[3] * pV2[3] +
+                pV1[4] * pV2[4] +
+                pV1[5] * pV2[5] +
+                pV1[6] * pV2[6] +
+                pV1[7] * pV2[7] +
+                pV1[8] * pV2[8] +
+                pV1[9] * pV2[9] +
+                pV1[10] * pV2[10] +
+                pV1[11] * pV2[11] +
+                pV1[12] * pV2[12] +
+                pV1[13] * pV2[13] +
+                pV1[14] * pV2[14] +
+                pV1[15] * pV2[15];
+
+    for (j = 0; j < 15; j ++) norm += pV1[j] * pV1[j];
+
+        pV1 += 16;
+        pV2 += 16;
+    }
+    return corr / sqrt(norm);
+    */
+}
+
+
+
+double TDStretchSSE::calcCrossCorrAccumulate(const float *pV1, const float *pV2, double &norm)
+{
+    // call usual calcCrossCorr function because SSE does not show big benefit of
+    // accumulating "norm" value, and also the "norm" rolling algorithm would get
+    // complicated due to SSE-specific alignment-vs-nonexact correlation rules.
+    return calcCrossCorr(pV1, pV2, norm);
+}
+
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// implementation of SSE optimized functions of class 'FIRFilter'
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#include "FIRFilter.h"
+
+FIRFilterSSE::FIRFilterSSE() : FIRFilter()
+{
+    filterCoeffsAlign = NULL;
+    filterCoeffsUnalign = NULL;
+}
+
+
+FIRFilterSSE::~FIRFilterSSE()
+{
+    delete[] filterCoeffsUnalign;
+    filterCoeffsAlign = NULL;
+    filterCoeffsUnalign = NULL;
+}
+
+
+// (overloaded) Calculates filter coefficients for SSE routine
+void FIRFilterSSE::setCoefficients(const float *coeffs, uint newLength, uint uResultDivFactor)
+{
+    uint i;
+    float fDivider;
+
+    FIRFilter::setCoefficients(coeffs, newLength, uResultDivFactor);
+
+    // Scale the filter coefficients so that it won't be necessary to scale the filtering result
+    // also rearrange coefficients suitably for SSE
+    // Ensure that filter coeffs array is aligned to 16-byte boundary
+    delete[] filterCoeffsUnalign;
+    filterCoeffsUnalign = new float[2 * newLength + 4];
+    filterCoeffsAlign = (float *)SOUNDTOUCH_ALIGN_POINTER_16(filterCoeffsUnalign);
+
+    fDivider = (float)resultDivider;
+
+    // rearrange the filter coefficients for mmx routines
+    for (i = 0; i < newLength; i ++)
+    {
+        filterCoeffsAlign[2 * i + 0] =
+        filterCoeffsAlign[2 * i + 1] = coeffs[i + 0] / fDivider;
+    }
+}
+
+
+
+// SSE-optimized version of the filter routine for stereo sound
+uint FIRFilterSSE::evaluateFilterStereo(float *dest, const float *source, uint numSamples) const
+{
+    int count = (int)((numSamples - length) & (uint)-2);
+    int j;
+
+    assert(count % 2 == 0);
+
+    if (count < 2) return 0;
+
+    assert(source != NULL);
+    assert(dest != NULL);
+    assert((length % 8) == 0);
+    assert(filterCoeffsAlign != NULL);
+    assert(((ulongptr)filterCoeffsAlign) % 16 == 0);
+
+    // filter is evaluated for two stereo samples with each iteration, thus use of 'j += 2'
+    #pragma omp parallel for
+    for (j = 0; j < count; j += 2)
+    {
+        const float *pSrc;
+        float *pDest;
+        const __m128 *pFil;
+        __m128 sum1, sum2;
+        uint i;
+
+        pSrc = (const float*)source + j * 2;      // source audio data
+        pDest = dest + j * 2;                     // destination audio data
+        pFil = (const __m128*)filterCoeffsAlign;  // filter coefficients. NOTE: Assumes coefficients
+                                                  // are aligned to 16-byte boundary
+        sum1 = sum2 = _mm_setzero_ps();
+
+        for (i = 0; i < length / 8; i ++)
+        {
+            // Unroll loop for efficiency & calculate filter for 2*2 stereo samples
+            // at each pass
+
+            // sum1 is accu for 2*2 filtered stereo sound data at the primary sound data offset
+            // sum2 is accu for 2*2 filtered stereo sound data for the next sound sample offset.
+
+            sum1 = _mm_add_ps(sum1, _mm_mul_ps(_mm_loadu_ps(pSrc)    , pFil[0]));
+            sum2 = _mm_add_ps(sum2, _mm_mul_ps(_mm_loadu_ps(pSrc + 2), pFil[0]));
+
+            sum1 = _mm_add_ps(sum1, _mm_mul_ps(_mm_loadu_ps(pSrc + 4), pFil[1]));
+            sum2 = _mm_add_ps(sum2, _mm_mul_ps(_mm_loadu_ps(pSrc + 6), pFil[1]));
+
+            sum1 = _mm_add_ps(sum1, _mm_mul_ps(_mm_loadu_ps(pSrc + 8) ,  pFil[2]));
+            sum2 = _mm_add_ps(sum2, _mm_mul_ps(_mm_loadu_ps(pSrc + 10), pFil[2]));
+
+            sum1 = _mm_add_ps(sum1, _mm_mul_ps(_mm_loadu_ps(pSrc + 12), pFil[3]));
+            sum2 = _mm_add_ps(sum2, _mm_mul_ps(_mm_loadu_ps(pSrc + 14), pFil[3]));
+
+            pSrc += 16;
+            pFil += 4;
+        }
+
+        // Now sum1 and sum2 both have a filtered 2-channel sample each, but we still need
+        // to sum the two hi- and lo-floats of these registers together.
+
+        // post-shuffle & add the filtered values and store to dest.
+        _mm_storeu_ps(pDest, _mm_add_ps(
+                    _mm_shuffle_ps(sum1, sum2, _MM_SHUFFLE(1,0,3,2)),   // s2_1 s2_0 s1_3 s1_2
+                    _mm_shuffle_ps(sum1, sum2, _MM_SHUFFLE(3,2,1,0))    // s2_3 s2_2 s1_1 s1_0
+                    ));
+    }
+
+    // Ideas for further improvement:
+    // 1. If it could be guaranteed that 'source' were always aligned to 16-byte
+    //    boundary, a faster aligned '_mm_load_ps' instruction could be used.
+    // 2. If it could be guaranteed that 'dest' were always aligned to 16-byte
+    //    boundary, a faster '_mm_store_ps' instruction could be used.
+
+    return (uint)count;
+
+    /* original routine in C-language. please notice the C-version has differently
+       organized coefficients though.
+    double suml1, suml2;
+    double sumr1, sumr2;
+    uint i, j;
+
+    for (j = 0; j < count; j += 2)
+    {
+        const float *ptr;
+        const float *pFil;
+
+        suml1 = sumr1 = 0.0;
+        suml2 = sumr2 = 0.0;
+        ptr = src;
+        pFil = filterCoeffs;
+        for (i = 0; i < lengthLocal; i ++)
+        {
+            // unroll loop for efficiency.
+
+            suml1 += ptr[0] * pFil[0] +
+                     ptr[2] * pFil[2] +
+                     ptr[4] * pFil[4] +
+                     ptr[6] * pFil[6];
+
+            sumr1 += ptr[1] * pFil[1] +
+                     ptr[3] * pFil[3] +
+                     ptr[5] * pFil[5] +
+                     ptr[7] * pFil[7];
+
+            suml2 += ptr[8] * pFil[0] +
+                     ptr[10] * pFil[2] +
+                     ptr[12] * pFil[4] +
+                     ptr[14] * pFil[6];
+
+            sumr2 += ptr[9] * pFil[1] +
+                     ptr[11] * pFil[3] +
+                     ptr[13] * pFil[5] +
+                     ptr[15] * pFil[7];
+
+            ptr += 16;
+            pFil += 8;
+        }
+        dest[0] = (float)suml1;
+        dest[1] = (float)sumr1;
+        dest[2] = (float)suml2;
+        dest[3] = (float)sumr2;
+
+        src += 4;
+        dest += 4;
+    }
+    */
+}
+
+#endif  // SOUNDTOUCH_ALLOW_SSE


### PR DESCRIPTION
Slice 4 of #1890, closes #2037.

Playing a clip at a speed and a pitch that are not its file's: speed ratios, auto tempo, pitch, analog pitch and speed ramp fades.

## One function

All of it is where in the reading a moment of the timeline sits, so all of it is `readingPositionAt` in `clip/EventPlacement.hpp` answering differently.

| What the clip asks for | What the position does |
| --- | --- |
| its file's own speed | one reading sample per output sample, as in slice 3 |
| a speed ratio | advances by the ratio, resolved in the snapshot |
| auto tempo | advances by the beats that have passed, times a beat of the file |
| analog pitch | advances by the ratio the model already folded the pitch into, no stretcher |
| a speed ramp fade | the moment itself is warped near the clip's edge, and the rate with it |
| warp (#2038) | another answer from the same place |

Auto tempo is the one to read twice. Its ratio is the project's tempo over the file's own and moves with the tempo curve, so it cannot be resolved to seconds ahead of a block. What saves it is that the integral of that ratio is beats: the material an instant has consumed is how many beats have passed since the event began, times what a beat of the file is worth. That is why the clock publishes both faces of one instant, and it is what keeps a second tempo map off the audio thread.

A block then reads exactly `round(P(end)) - round(P(start))` samples and hands them to a stretcher to come back as the block's own length. The ratio a block runs at is whatever its own two ends say, so a tempo curve and a speed ramp cost nothing extra, and nothing accumulates: both ends are rounded rather than counted forward, so one block's reading ends where the next one's begins.

## Where a stretcher lives, and what that answers

One per provisioned event, built and configured by `ClipVoicePool` on the thread that opens the file, carried to the callback in the same table as the stream. Not in the reading chain, which is random access and pure; not in a voice, which is claimed and released per block and would be allocating one on the audio thread.

- **A plan swap** does nothing to it: it never enters a plan epoch.
- **A loop wrap** does nothing to it: tiling happens below the stream, so a wrap is a discontinuity in the material rather than a change of position.
- **A locate** resets and re-primes something that already exists.
- **An underrun** deliberately does not re-prime. Priming reads behind the position the block wants, so a stream that came back short and was primed again would be sent backwards every block, and every one of those is a seek that guarantees the next block is short too.

**Latency is answered here rather than reported upwards.** Every engine wants material from before the first sample to be heard and says how much; the pool cues the stream that far back, so a voice's first read is one contiguous read that begins with the priming samples. A `ClipAudio` op still reports no latency and stretched voices stay aligned with unstretched ones on the same track.

## Vendoring

`third_party/signalsmith-stretch` (MIT, header only) and `third_party/soundtouch` (LGPL-2.1), with their licences and a `SOURCES.md` each, out of the Tracktion fork that the engine may not include.

SoundTouch is its own unmodified static target rather than files folded into `magda_engine`, which is what keeps the relink option open. MAGDA ships GPL-3.0 and LGPL-2.1 is compatible with it, so nothing more is owed today. It is carried at all because `kSoundTouchNormal` and `kSoundTouchBetter` are pinned project-file integers and sessions saved with them have to play through the algorithm they were made with.

One thing the plan did not anticipate: the fork compiles its own copy of those sources into its unity build, so `soundtouch_ac_test` was defined twice and the final link refused it. Ours is renamed through a compile definition rather than by touching the vendored source, and that goes away with the fork.

## One deliberate divergence

The fork's Signalsmith wrapper primes with the material *at* the start rather than before it, so it begins every stretched clip roughly `inputLatency + rate * outputLatency` late, about 120 ms at the default preset. This primes from the material before the start, which is what the library's `outputSeek` is for. The null-diff corpus (#2040) will show that as a fixed offset on stretched clips.

## Also here

- Auto pitch plays its own transpose alone and the snapshot says so in a diagnostic: the other half of it is an offset from the project's pitch sequence, and there is no pitch track in the engine yet (#1891).
- The clip snapshot carries its two fade lengths on the beat face as well, because a speed ramp on an auto tempo clip has to be measured in the domain its position is derived from.
- The cubic curve the rate converter uses is now shared, so a file at another rate and a clip playing fast are not two different sounds.

## Testing

`make debug` clean, and the full Catch2 suite green (2198 passed, 13 skipped for missing fixtures).

29 new cases, tagged `[stretch]`. The position map is tested as arithmetic, exactly. The resampling path is tested sample for sample through a counting reader, which works because cubic interpolation of a straight line is exact. The stretch engines are tested the way a listener would judge them: the block is full, the level survived, and a stretched clip at double speed keeps its 1 kHz where a resampled one goes to 2 kHz.

Everything rolls, as the other clip rigs do, and rolls in from before the clip starts, which is where the pool would have cued it.