### PR TITLE
Stop the MCP server losing a refusal it has already sent

### DIFF
--- a/magda/daw/api/remote_mcp_server.cpp
+++ b/magda/daw/api/remote_mcp_server.cpp
@@ -366,18 +366,32 @@ struct RemoteMcpServer::Impl {
     }
 
     /**
-     * @brief Everything that can refuse a client before a handler runs.
+     * @brief Everything that can refuse a client before a handler acts.
+     *
+     * Returns true when the request may proceed; otherwise `response` already
+     * carries the refusal.
      *
      * Validating `Origin` is a MUST in the MCP transport specification, and the
      * reason is DNS rebinding: without it a page the user merely visited could
      * reach this listener from the browser they are already running.
+     *
+     * Deliberately called from each route rather than installed as
+     * cpp-httplib's pre-routing handler, which is the obvious place for it.
+     * Pre-routing runs before the request body is read, so refusing there
+     * leaves an unread POST body in the socket; when the client asked for
+     * `Connection: close` — as a one-shot client does — cpp-httplib skips its
+     * drain and closes anyway, and closing a socket with unread data sends RST
+     * rather than FIN. The refusal is already in the client's receive buffer at
+     * that point, and RST discards it: the client sees a reset connection
+     * instead of the 401 or 403 it was sent, on a race it loses often enough to
+     * matter. Refusing from the route runs after cpp-httplib has consumed the
+     * body, so the close is clean and the status always arrives.
      */
-    httplib::Server::HandlerResponse authorise(const httplib::Request& request,
-                                               httplib::Response& response) {
+    bool authorise(const httplib::Request& request, httplib::Response& response) {
         if (!isAuthorised(juce::String(request.get_header_value("Authorization")),
                           options.bearerToken)) {
             response.status = httplib::StatusCode::Unauthorized_401;
-            return httplib::Server::HandlerResponse::Handled;
+            return false;
         }
 
         if (!isOriginAllowed(request.has_header("Origin"),
@@ -387,10 +401,10 @@ struct RemoteMcpServer::Impl {
             // more use to a developer than a bare 403.
             writeJson(response, httplib::StatusCode::Forbidden_403,
                       jsonRpcError({}, McpError{MCP_INVALID_REQUEST, "Origin not allowed"}));
-            return httplib::Server::HandlerResponse::Handled;
+            return false;
         }
 
-        return httplib::Server::HandlerResponse::Unhandled;
+        return true;
     }
 
     // -----------------------------------------------------------------------
@@ -1154,11 +1168,6 @@ bool RemoteMcpServer::start() {
         return false;
     }
 
-    impl_->server.set_pre_routing_handler(
-        [this](const httplib::Request& request, httplib::Response& response) {
-            return impl_->authorise(request, response);
-        });
-
     impl_->server.set_payload_max_length(impl_->options.maxBodyBytes);
 
     // Sized rather than defaulted. A request handler blocks its pool thread
@@ -1172,15 +1181,18 @@ bool RemoteMcpServer::start() {
 
     impl_->server.Post(kEndpoint,
                        [this](const httplib::Request& request, httplib::Response& response) {
-                           impl_->handlePost(request, response);
+                           if (impl_->authorise(request, response))
+                               impl_->handlePost(request, response);
                        });
     impl_->server.Get(kEndpoint,
                       [this](const httplib::Request& request, httplib::Response& response) {
-                          impl_->handleGet(request, response);
+                          if (impl_->authorise(request, response))
+                              impl_->handleGet(request, response);
                       });
     impl_->server.Delete(kEndpoint,
                          [this](const httplib::Request& request, httplib::Response& response) {
-                             impl_->handleDelete(request, response);
+                             if (impl_->authorise(request, response))
+                                 impl_->handleDelete(request, response);
                          });
 
     // Two different calls, and they are easy to confuse: bind_to_any_port's

--- a/tests/test_remote_mcp_server.cpp
+++ b/tests/test_remote_mcp_server.cpp
@@ -265,6 +265,29 @@ TEST_CASE("A request without a valid token is refused", "[remote][mcp-http][auth
     REQUIRE(sameLength->status == 401);
 }
 
+TEST_CASE("A refusal reaches a client that sent a body and asked for the connection to close",
+          "[remote][mcp-http][auth]") {
+    MessageThreadRelaxation relax;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteMcpServer server(service, testOptions());
+    REQUIRE(server.start());
+
+    // Refusing a request before its body has been read leaves that body unread
+    // in the socket, and closing on unread data sends RST rather than FIN —
+    // which discards the refusal the client had already been sent. A one-shot
+    // client, which is what `httplib::Client` is by default, asks for the close
+    // that triggers it. Any single attempt usually wins the race, so this
+    // asserts over enough of them to catch a server that refuses too early.
+    for (int attempt = 0; attempt < 50; ++attempt) {
+        httplib::Client client(base(server));
+        auto refused =
+            client.Post("/mcp", {}, body(1, "tools/list", modernParams()), "application/json");
+        REQUIRE(refused);
+        REQUIRE(refused->status == 401);
+    }
+}
+
 TEST_CASE("Origin is checked only when the client sends one", "[remote][mcp-http][auth]") {
     MessageThreadRelaxation relax;
     MockMagdaApi api;
@@ -878,11 +901,23 @@ TEST_CASE("A legacy client initializes, subscribes, and is served on its GET str
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     REQUIRE(hub.clientCount() == 1);
 
-    api.transport_.playing = true;
-    service.noteModelChanged(Topic::Transport);
-    service.changes().flush();
+    // A client is in the hub from the moment its stream attaches, which is a
+    // moment before the topics it asked for are registered against it, and
+    // counting clients cannot see that second step. Announcing once can
+    // therefore land in the gap — and the hub publishes against a baseline it
+    // updates whether or not anybody was listening, so that announcement is not
+    // merely early, it is spent: re-announcing the same state is no longer a
+    // change and says nothing. Move the state each round instead, so whichever
+    // round finds the subscription live carries a difference the hub forwards.
+    bool delivered = false;
+    for (int round = 0; round < 100 && !delivered; ++round) {
+        api.transport_.playing = (round % 2) == 0;
+        service.noteModelChanged(Topic::Transport);
+        service.changes().flush();
+        delivered = stream.waitFor(1, std::chrono::milliseconds(50));
+    }
+    REQUIRE(delivered);
 
-    REQUIRE(stream.waitFor(1));
     const auto event = stream.events().front();
     REQUIRE(event["method"].toString() == "notifications/resources/updated");
     REQUIRE(event["params"]["uri"].toString() == "magda://transport");


### PR DESCRIPTION
Fixes the Windows CI failure on dev/0.19.0 ([run 31244320596](https://github.com/Conceptual-Machines/magda-core/actions/runs/31244320596/job/93070315398)). It was not caused by #2052 — it is a race that landed with #2049 and got lucky on its one CI run.

## The refusal that never arrives

`authorise` was installed as cpp-httplib's `pre_routing_handler`, which runs **before the request body is read**. Refusing there leaves an unread POST body in the socket, and a one-shot client — which is what `httplib::Client` is by default — asks for `Connection: close`, so cpp-httplib skips its body drain and closes anyway. Closing a socket with unread data sends RST rather than FIN, and the RST discards the 401 already sitting in the client's receive buffer. The client sees a reset connection instead of the refusal it was sent.

Standalone repro against the same cpp-httplib 0.52.0, 500 requests each:

```
pre-routing 401 (body unread): 104/500 responses lost   ("Failed to read connection")
handler 401 (body consumed):     0/500 responses lost
```

`authorise` now returns `bool` and is called at the top of each route, where the body has already been consumed. The reasoning is in the doc comment, since moving it back to pre-routing is the obvious "cleanup".

**Behaviour change worth knowing:** a path other than `/mcp` is no longer refused with 401 before routing — it answers 404. Only `/mcp` is served, so nothing new is exposed.

## A second, rarer flake

Soaking turned up an unrelated one in the legacy stream test, roughly 3 in 500. A stream counts as a hub client from the moment it attaches, a beat before the topics it asked for are registered against it, and `publishTopicLocked` moves its per-topic baseline whether or not anybody was subscribed. An announcement landing in that gap is not merely early, it is **spent** — re-announcing the same state is no longer a difference, so no amount of waiting recovers it. The test now moves the state each round, so whichever round finds the subscription live carries a difference the hub forwards.

The same window exists in production for a legacy client that subscribes and then opens its GET stream: it can miss one "re-read this URI" nudge for a change that happens during its own connect. `subscribeStream` deliberately passes `snapshot: false` on the reasoning that such a client "either just read the resource or is about to", so this looks benign rather than something to fix here. Closing it properly would mean an atomic `addClient(sink, disconnect, initialTopics)` on `SubscriptionHub`, which the WebSocket transport shares — worth its own change if we want the guarantee.

## Verification

Run on the Windows CI runner itself, from the build tree of the failing commit:

| | before | after |
|---|---|---|
| `[mcp-http]` suite | 7/30 runs failed | 0/160 |
| new auth regression test | 10/10 failed | passes |
| legacy stream test, alone | 3/500 failed | 0/1000 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)