### PR TITLE
Remote API: permissions, audit, and cross-transport conformance (#1860)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ about the document rather than about its quality.
 | [tracktion-parameter-writes.md](architecture/tracktion-parameter-writes.md) | why host parameter writes go through `setParameterFromHost` |
 | [remote-api-contract.md](architecture/remote-api-contract.md) | the remote API's surface |
 | [remote-api-transport.md](architecture/remote-api-transport.md) | the WebSocket transport behind it |
+| [remote-api-permissions.md](architecture/remote-api-permissions.md) | what a remote client may do, and what is recorded about it |
 | [dual-mode-system.md](architecture/dual-mode-system.md) | arrangement and session, and what switches between them |
 | [chord-suggestion-pipeline.md](architecture/chord-suggestion-pipeline.md) | how a chord suggestion is arrived at |
 | [beat-migration-remaining.md](architecture/beat-migration-remaining.md) | beats as the authoritative domain, and what still holds seconds |

--- a/docs/architecture/remote-api-contract.md
+++ b/docs/architecture/remote-api-contract.md
@@ -28,15 +28,30 @@ must satisfy the range in the operation's JSON Schema. Responses use one of:
 }
 ```
 
-`system.describe` exposes the version, operation catalogue, access mode, and
-shared input/output schemas. A transport may add its own correlation or
-framing metadata outside these envelopes, but it must not change the contract
-payload.
+`system.describe` exposes the version, operation catalogue, access mode,
+required scope, and shared input/output schemas. A transport may add its own
+correlation or framing metadata outside these envelopes, but it must not change
+the contract payload.
+
+Every operation declares one of five scopes — `read`, `edit`, `transport`,
+`session`, `hardware-midi` — and a client that has not been granted it is
+refused with `permission_denied` before its input is even validated. The default
+for a client MAGDA has not seen is `read` alone. What that model does and does
+not protect against is
+[remote-api-permissions.md](remote-api-permissions.md); adding an operation
+means adding it to the scope table there, and the registry refuses to start with
+a write that has not been.
 
 Two transports carry this today. WebSocket wraps it in JSON-RPC over a socket;
 MCP projects operations into tools and read operations into `magda://` resources
 — see [remote-api-mcp.md](remote-api-mcp.md). Both consume this registry, and
 neither declares an operation or a schema of its own.
+
+Both also want to know who is calling, so the user can grant them different
+things. A WebSocket client names itself in the upgrade's query string
+(`ws://127.0.0.1:51734/rpc?client=my-tool`); an MCP client uses
+`clientInfo.name`. Sending nothing is allowed and means anonymous, which is
+read-only.
 
 ## Subscriptions
 
@@ -104,6 +119,11 @@ Subscribing to `meters` or `playhead` costs nothing until asked for: nothing
 samples them otherwise.
 
 ## Deliberately excluded data
+
+Two separate mechanisms keep data out of the remote API, and they answer
+different questions. Scopes decide *who may ask*; the exclusions below decide
+*what exists to be asked for* — they hold for every client, at every scope, and
+there is no permission that reveals them.
 
 DTO fields are allow-listed. In particular, the remote API does not expose:
 

--- a/docs/architecture/remote-api-permissions.md
+++ b/docs/architecture/remote-api-permissions.md
@@ -1,0 +1,322 @@
+# Remote API permissions, auditing, and limits
+
+What a remote client is allowed to do, how the user changes it, and what MAGDA
+records about it. Issue #1860. The surface being protected is in
+[remote-api-contract.md](remote-api-contract.md); the socket underneath it is in
+[remote-api-transport.md](remote-api-transport.md).
+
+Everything here applies identically to the WebSocket API and the MCP endpoint.
+That is the point of the layering: both are transports over one
+`RemoteApiService`, and the permission check lives in the dispatcher rather than
+in either adapter, so there is one answer to "may this client do this" and one
+place it can be wrong.
+
+## What this is, and what it is not
+
+**It is** the user's intent about a named client, recorded so a well-behaved one
+cannot exceed it by accident, and so the user can see what has been asking for
+what.
+
+**It is not** a sandbox, and it is not a defence against a hostile process on the
+machine. Three facts, stated plainly because a reader who assumes otherwise will
+build on it wrongly:
+
+1. Admission is the per-run bearer token, and nothing else.
+2. That token lives in `remote-api-<pid>.json` beside MAGDA's other app data.
+   It is written owner-only, which stops *other users* reading it — but every
+   process running as this user can.
+3. The client's name is self-declared. A caller holding the token can claim any
+   name and receive whatever that name was granted.
+
+So a process that can read your home directory can already do anything the
+remote API can do. Per-client secrets would not change that: they would be
+published in the same readable file for the same reason — a client has to be
+able to find its credential without configuration.
+
+What the model *does* buy is real, and it is the thing that actually goes wrong
+in practice: an AI assistant you gave read access does not silently delete a
+track, a monitoring script cannot start the transport, and when something is
+refused you can see it, understand it, and grant it in one place.
+
+If MAGDA ever binds anywhere but loopback, none of this is sufficient and the
+threat model has to be rewritten before that happens.
+
+## Scopes
+
+Five words, shared by both transports. An operation requires exactly one.
+
+| Scope | Covers |
+| --- | --- |
+| `read` | Every read operation, and subscribing to any topic. Every client has this — it is what being admitted means. |
+| `edit` | Project content: tempo, time signature, tracks, clips, notes, devices, racks, automation, and the user's selection. |
+| `transport` | The timeline: play, stop, record-arm, loop, seek. |
+| `session` | Launching and stopping session clips and scenes. |
+| `hardware-midi` | Physical MIDI ports, including SysEx. |
+
+The split is by what a user would regret, not by which manager the code calls.
+Driving the transport is separate from editing because a remote that only starts
+and stops playback is a thing people want and it must not also be able to delete
+a track. Session launch is neither: a performance controller firing scenes
+changes no project content and does not move the playhead.
+
+`selection.set` is an `edit`. It changes nothing durable, but it changes what the
+user is looking at and what their next keystroke acts on, which is not something
+a read-only client should reach.
+
+**`hardware-midi` has no operations yet.** The registry exposes no hardware MIDI
+surface. The scope is declared now because grants are persisted: a word invented
+later would read as "not granted" on every existing client — the correct answer,
+but only if the word already exists when those grants are written. It also gives
+the settings UI a stable place to show the permission before there is anything
+behind it. When a MIDI-out or SysEx operation lands, it declares this scope and
+the enforcement already works.
+
+### Where the mapping lives
+
+`OperationRegistry`, in one contiguous table (`kWriteScopes` in
+`remote_api.cpp`). One table rather than an argument on forty declarations,
+because the question a reviewer needs to answer is not "does this operation
+declare a scope" but "is the whole division of the API into scopes the one we
+meant" — and that is only answerable by reading the policy in one piece.
+
+Reads are absent from the table: `read` is the descriptor default. Writes are
+never absent — one that is keeps the default, and the registry constructor turns
+that into a startup failure. `test_remote_permissions.cpp` asserts the same
+property in release builds, where `jassert` is a no-op.
+
+`system.describe` publishes `requiredScope` per operation, so a client can tell
+the user what to grant *before* it tries something rather than after being
+refused.
+
+## Clients and grants
+
+A client names itself:
+
+- **WebSocket** — a query parameter on the upgrade:
+  `ws://127.0.0.1:51734/rpc?client=cursor`
+- **MCP** — `clientInfo.name`, in `params._meta` for a modern request or in the
+  `initialize` params for a legacy one, where it is recorded on the session and
+  reused for every later request.
+
+The name is normalised — lowercased, trimmed, reduced to letters, digits, dots
+and hyphens, and capped at 64 characters — so `Cursor`, `cursor `, and `cursor`
+are one client rather than three rows to grant separately. A caller that declares
+nothing is `unknown`, which is a real entry rather than a rejection: refusing
+would break every conforming MCP host that does not send `clientInfo` and every
+WebSocket library whose user did not know about `?client=`. Anonymous callers
+share one read-only bucket.
+
+Using `clientInfo` at all is worth a note, because the MCP specification tells
+servers not to act on it. That rule is about *authorisation*: a server must not
+decide who may connect from a field the client wrote. MAGDA does not, and here it
+cannot — admission was the bearer token, before any of this ran. The name decides
+which of the user's own grants applies to a caller that is already inside, which
+is the only way a user can say "my editor may edit, my monitoring script may not"
+about two processes presenting the same token.
+
+**A client MAGDA has not seen starts read-only.** It is registered the moment it
+first asks for anything, so it appears in the settings list — read-only —
+straight away rather than only once the user goes looking.
+
+**Grants persist**, in `config.json` under `remoteApi.clients`:
+
+```json
+"remoteApi": {
+  "enabled": true,
+  "clients": [
+    {"name": "cursor", "scopes": ["read", "edit"], "firstSeenMs": 1754000000000}
+  ]
+}
+```
+
+No credential is in there — the token is per-run and lives elsewhere — so this
+file being copied between machines or committed by accident grants nothing that
+is not already the user's decision. Unknown scope names are dropped on load
+rather than rejected, so a config from a newer MAGDA downgrades to the scopes
+this build understands.
+
+### Revocation is immediate
+
+The grant is looked up **per request**, not cached on the connection. That is the
+entire mechanism: there is no per-connection copy to go stale, so changing a
+grant in the settings dialog applies to the client's very next request, on the
+socket it is already holding, with nothing to restart.
+
+The permission check also runs *before* the idempotency cache. A cached response
+is a previous success, and replaying one to a client whose grant has since been
+withdrawn would be the single path where revocation did not take effect.
+
+## Ordering, and why
+
+Inside `RemoteApiService::dispatch`:
+
+1. Shutdown check.
+2. Operation lookup — unknown names fail here.
+3. Transport-scoped check — a subscription method that reached the dispatcher.
+4. **Permission.**
+5. Input validation.
+6. Idempotency cache.
+7. Deadline, then the hop to the message thread.
+
+Permission is before validation because a client that may not call something has
+no business learning the shape of its input: a refusal that varied with whether
+the payload was well formed would be an oracle for the schema.
+
+A refusal is `permission_denied` and says which scope would have allowed it — not
+`unknown_operation`. Hiding an operation from a client that may not call it would
+be obscurity over a socket that already required a bearer token to reach, and it
+would make the failure indistinguishable from a typo.
+
+On the wire:
+
+| Transport | Shape |
+| --- | --- |
+| WebSocket | JSON-RPC error, code `-32006`, `error.data.code` = `"permission_denied"` |
+| MCP `tools/call` | `isError: true` with the MAGDA envelope in `content[0].text` — a model can act on it |
+| MCP `resources/read` | JSON-RPC error, code `-32023` |
+
+`test_remote_permission_conformance.cpp` drives one table of vectors through both
+transports and asserts they agree, so the two cannot drift.
+
+## The audit log
+
+Bounded, in memory, 512 entries. Each carries: time, client, connection id,
+transport, operation, request id, outcome, and a short reason.
+
+Outcomes are `ok`, `denied`, `failed`, `connected`, `disconnected`, `rejected`.
+Connection lifecycle uses the pseudo-operations `connection.open`,
+`connection.close`, and `connection.rejected` so it shares one table with
+requests rather than needing two views interleaved by timestamp.
+
+**In memory and nowhere else.** A file would outlive the session that produced
+it, would need rotation and a retention policy, and would put a description of
+the user's editing session on disk permanently. For a loopback control socket
+that is a liability, not a feature.
+
+The dispatcher records what it ran; the transports record what it never saw —
+connections opening, closing, and being refused before they became requests.
+
+**Not exposed over the remote API.** A client that could read it would learn what
+every other client is doing.
+
+### What is never recorded
+
+- Request input, or response results. A request's input is whatever a client
+  chose to send and its result is a projection of the user's project; neither
+  belongs in a buffer the settings UI displays and a user may screenshot into a
+  bug report.
+- Error *messages*. A validation failure quotes the offending value, so the log
+  keeps the error **code** instead.
+- Tokens. `registerRemoteSecret` masks the live token wherever it appears, and a
+  `Bearer <credential>` is masked by shape as well, for a value MAGDA never held
+  and therefore never registered.
+- File paths. The startup log names the discovery file rather than its path —
+  the directory it lives in is the user's home directory.
+
+The redaction is applied once, inside `RemoteAuditLog::record`, rather than at
+each call site where each new one is a chance to forget.
+
+The `Bearer` shape rule masks the following word only when it *looks* like a
+credential — at least 16 characters from RFC 7235's `token68` set. Without that,
+"invalid or missing bearer token" would redact to "…bearer \*\*\*", which is how
+a heuristic meant to protect the log ends up destroying it. It cannot be exact
+and does not need to be: the real guarantee is that MAGDA never builds a message
+out of a credential, and registered secrets cover the values it does hold.
+
+## Limits
+
+Per transport, enforced before a request reaches the dispatcher.
+
+| Limit | WebSocket | MCP |
+| --- | --- | --- |
+| Payload | 256 KB per frame | 256 KB per body |
+| Concurrency | 8 in flight per connection | 8 concurrent requests, server-wide |
+| Rate | 50 req/s per connection, bursting to the in-flight cap | 50 req/s per remote address |
+| Connections | 8 | 4 streams, 8 legacy sessions |
+| Queue | 32 replies + 64 events per connection | 64-entry outbox per stream |
+| Deadline | 10 s, lowerable per request | 10 s, lowerable per request |
+
+Rate limiting is applied to *every* inbound frame, including one too malformed to
+have a method — parsing costs work and every reply costs memory, so a client that
+floods garbage runs out of allowance exactly like one that floods valid requests.
+
+Queue overflow drops rather than buffers. A client that sends without reading
+fills its socket buffer and parks the writer; without a cap the queue would grow
+for as long as it kept talking. A dropped subscription event is not a lost
+update: the hub marks the subscriber behind and answers with a fresh snapshot
+rather than the deltas it missed.
+
+None of these are permissions and none are per-client. They bound what one
+connection can cost everyone else; scopes decide what it is allowed to ask for.
+
+## Token rotation
+
+Settings ▸ AI ▸ Remote ▸ **Rotate token**. A new credential is generated, the
+discovery record is rewritten, and every connected client is disconnected —
+because a token that still admitted the sessions it replaced would not have been
+revoked.
+
+It is implemented as a listener restart rather than a swap in place. Both servers
+read `bearerToken` from an immutable options copy taken at construction; making it
+mutable would mean comparing against a value changing under the comparing thread,
+for the one operation where being half-applied is worst. Rebuilding guarantees
+every existing connection is gone: they were admitted by a token that no longer
+exists.
+
+A well-behaved client re-reads the discovery record and reconnects on its own.
+The `magda-mcp` bridge does this on every request, so an MCP host survives
+rotation without noticing.
+
+## The settings UI
+
+Two tabs, because turning the endpoint on and saying what a client may do are
+separate decisions made at different times.
+
+**Remote** — the enable toggle (applied immediately, not on OK), endpoint status
+and port, token rotation, and the MCP host configuration snippet composed from
+the running install.
+
+**Clients** — a row per client MAGDA has heard from, with a checkbox per scope,
+whether it is connected and over which transport, **Disconnect**, and **Forget**.
+Underneath, a tail of the audit log, so "why did my assistant say it could not do
+that" has an answer on the same screen as the checkbox that fixes it.
+
+`read` is shown ticked and disabled: a row granting nothing would be
+indistinguishable from a client that was never granted, while still being one
+that can connect. **Forget** drops the stored grant — the client returns to
+read-only on its next request but is not disconnected. **Disconnect** closes
+every connection that client holds; over WebSocket the socket itself goes within
+one read timeout, but no further request from it executes from the moment it is
+marked.
+
+The page reads live state on a one-second timer rather than from notifications,
+because what it displays changes on transport threads and a UI repainting from
+those would need a hop per event for no benefit at that resolution. Rows are
+rebuilt only when the set of client names changes — recreating a row under the
+pointer would swallow the click about to land on one of its checkboxes.
+
+## Adding a scope
+
+1. Add the enum value and its wire name to `remote_scopes.hpp/.cpp`, and bump
+   `SCOPE_COUNT`. The `static_assert` on the naming table catches a value with no
+   name.
+2. Add the operations that require it to `kWriteScopes` in `remote_api.cpp`.
+3. Add a row to the scope table above, and vectors to
+   `test_remote_permission_conformance.cpp`.
+
+Existing grants read the new scope as "not granted", which is the correct answer
+and needs no migration. The settings UI picks it up from `allScopeValues()`
+without changes.
+
+## Testing
+
+| File | Covers |
+| --- | --- |
+| `test_remote_permissions.cpp` | The vocabulary, the registry, enforcement in the dispatcher, the audit log, and redaction |
+| `test_remote_permission_conformance.cpp` | One table of vectors through both transports over real sockets, plus revocation, disconnection, anonymity, and fail-closed behaviour |
+| `test_remote_websocket_server.cpp`, `test_remote_mcp_server.cpp` | Transport behaviour, using a permissive registry so permissions are not the variable |
+
+A transport configured without a registry refuses **everything**, reads included.
+That is deliberate: a third transport that forgot to consult the registry should
+refuse every request loudly on its first test run, not hand out the project
+silently and pass.

--- a/docs/remote-api-mcp.md
+++ b/docs/remote-api-mcp.md
@@ -36,6 +36,46 @@ there is nothing to look up.
 
 Everything below is what that page is doing, for anyone wiring it by hand.
 
+### Letting it do more than read
+
+A client that connects for the first time can **read only**. If your host reports
+that it cannot create a track or start playback, that is not a bug — nothing has
+been granted yet.
+
+**AI Settings → Clients** lists everything that has connected, by the name it
+gave. Tick what you want it to be able to do:
+
+| Permission | Lets the client |
+|---|---|
+| `read` | Inspect the project. Always on. |
+| `edit` | Change tempo, tracks, clips, notes, devices, and automation. |
+| `transport` | Play, stop, record-arm, loop, and seek. |
+| `session` | Launch and stop session clips and scenes. |
+| `hardware-midi` | Reach physical MIDI ports. Nothing uses it yet. |
+
+Changes apply to the client's next request — there is nothing to restart and no
+need to reconnect. The same page shows what each client has been doing, so a
+refusal and the checkbox that fixes it are on one screen, and lets you disconnect
+a client or forget its permissions entirely.
+
+Grants are remembered between launches, keyed by the name the client reports —
+`clientInfo.name` for an MCP host. Two clients that report the same name are one
+entry. A client that reports nothing is listed as `unknown`, shares one
+read-only entry with every other anonymous caller, and can be granted like any
+other.
+
+Worth knowing what this is: the permissions record *your* intent about a named
+client, so one you trusted to read cannot quietly start editing. They are not a
+sandbox. Anything that can read your home directory can read the token file and
+reach the API — see
+[remote-api-permissions.md](architecture/remote-api-permissions.md) for the
+threat model in full.
+
+**Rotate token** on the Remote page throws the current credential away and
+disconnects everything using it. The bridge re-reads the discovery record on
+every request, so an MCP host configured through it survives rotation without
+noticing.
+
 ### Where the bridge lives
 
 The build stages `magda-mcp` beside the MAGDA executable, which is the one

--- a/magda/daw/api/CMakeLists.txt
+++ b/magda/daw/api/CMakeLists.txt
@@ -18,6 +18,9 @@ target_sources(magda_daw PRIVATE
     remote_api.cpp
     remote_api_projection.cpp
     remote_handlers.cpp
+    remote_scopes.cpp
+    remote_clients.cpp
+    remote_audit.cpp
     remote_service.cpp
     remote_changes.cpp
     remote_model_bridge_live.cpp
@@ -58,6 +61,9 @@ target_sources(magda_daw PRIVATE
     groove_api_live.hpp
     remote_api.hpp
     remote_handlers.hpp
+    remote_scopes.hpp
+    remote_clients.hpp
+    remote_audit.hpp
     remote_service.hpp
     remote_changes.hpp
     remote_model_bridge.hpp

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -803,6 +803,8 @@ juce::String toString(ErrorCode code) {
             return "invalid_request";
         case ErrorCode::UnknownOperation:
             return "unknown_operation";
+        case ErrorCode::PermissionDenied:
+            return "permission_denied";
         case ErrorCode::ValidationFailed:
             return "validation_failed";
         case ErrorCode::NotFound:
@@ -1385,8 +1387,10 @@ OperationRegistry::OperationRegistry() {
         // schema, which has to stay valid for anything the model can hold.
         input = input.clone();
         applyRequestLimits(input);
-        operations_.push_back({juce::String(name), juce::String(summary), access, std::move(input),
-                               std::move(output), handler});
+        // `requiredScope` is deliberately left at its `read` default here and
+        // set from the policy table below, not passed in. See the comment there.
+        operations_.push_back({juce::String(name), juce::String(summary), access, Scope::Read,
+                               std::move(input), std::move(output), handler});
     };
 
     add("system.describe", "List the API version and every available operation",
@@ -1663,8 +1667,10 @@ OperationRegistry::OperationRegistry() {
                                      juce::var output) {
         input = input.clone();
         applyRequestLimits(input);
+        // `read`, like any other read: subscribing pushes the same projections
+        // the read operations return, so it cannot need less.
         operations_.push_back({juce::String(name), juce::String(summary), OperationAccess::Read,
-                               std::move(input), std::move(output), nullptr, true});
+                               Scope::Read, std::move(input), std::move(output), nullptr, true});
     };
 
     addTransportScoped(
@@ -1680,16 +1686,104 @@ OperationRegistry::OperationRegistry() {
                        "Re-send a complete snapshot for the subscribed topics",
                        topicSelectionSchema(), subscriptionResultSchema(true));
 
+    // -----------------------------------------------------------------------
+    // Permission policy (#1860)
+    //
+    // One table rather than an argument on forty multi-line `add` calls,
+    // because the thing a reviewer needs to check is not "does this operation
+    // declare a scope" but "is the *whole* division of the API into scopes the
+    // one we meant" — and that is a question you can only answer by reading the
+    // policy contiguously. `docs/remote-api-permissions.md` mirrors this list,
+    // and the conformance test compares the two.
+    //
+    // Reads are absent by design: `read` is the descriptor default and every
+    // client has it, so listing fifteen operations to say "yes, readable" would
+    // bury the fifteen decisions that actually matter. Writes are never absent —
+    // one that is keeps the `read` default, which the check below turns into a
+    // startup failure rather than a client discovering it can edit.
+    // -----------------------------------------------------------------------
+    struct ScopePolicy {
+        const char* operation;
+        Scope scope;
+    };
+    static constexpr ScopePolicy kWriteScopes[] = {
+        // Project content. Selection is here rather than in a scope of its own:
+        // it changes what the user is looking at and what their next keystroke
+        // acts on, which is not something a read-only client should reach.
+        {"project.setTempo", Scope::Edit},
+        {"project.setTimeSignature", Scope::Edit},
+        {"tracks.create", Scope::Edit},
+        {"tracks.update", Scope::Edit},
+        {"tracks.delete", Scope::Edit},
+        {"clips.createMidi", Scope::Edit},
+        {"clips.addMidiNote", Scope::Edit},
+        {"clips.delete", Scope::Edit},
+        {"racks.create", Scope::Edit},
+        {"racks.remove", Scope::Edit},
+        {"racks.setBypassed", Scope::Edit},
+        {"selection.set", Scope::Edit},
+        {"automation.createLane", Scope::Edit},
+        {"automation.addPoint", Scope::Edit},
+        {"automation.clearLane", Scope::Edit},
+
+        // The timeline. Separable from editing because a remote that only
+        // starts and stops playback is a thing people actually want, and it
+        // must not also be able to delete a track.
+        {"transport.play", Scope::Transport},
+        {"transport.stop", Scope::Transport},
+        {"transport.setRecording", Scope::Transport},
+        {"transport.setLoopEnabled", Scope::Transport},
+        {"transport.seek", Scope::Transport},
+
+        // Clip launching. Neither editing nor the timeline transport: a
+        // performance controller firing scenes changes no project content and
+        // does not move the playhead.
+        {"session.launchClip", Scope::Session},
+        {"session.stopClip", Scope::Session},
+        {"session.stopTrack", Scope::Session},
+        {"session.stopAll", Scope::Session},
+        {"session.launchScene", Scope::Session},
+    };
+
+    for (const auto& [name, scope] : kWriteScopes) {
+        const auto found =
+            std::find_if(operations_.begin(), operations_.end(),
+                         [&](const OperationDescriptor& op) { return op.name == name; });
+        // A policy entry naming an operation that does not exist is a rename
+        // that updated one side. Silently ignoring it would leave the renamed
+        // operation on the `read` default, which the check below catches — but
+        // this says which end is wrong.
+        if (found == operations_.end()) {
+            jassertfalse;
+            juce::Logger::writeToLog(juce::String("Remote API scope policy names an unknown "
+                                                  "operation: ") +
+                                     name);
+            continue;
+        }
+        found->requiredScope = scope;
+    }
+
     // A declared operation with no implementation is a startup failure, not a
     // runtime surprise. Before handlers lived on the descriptor there was
     // nothing to catch it, and the registry advertised 36 operations that
     // `system.describe` would happily list and no transport could execute. A
     // transport-scoped operation is the one legitimate exception: its
     // implementation lives in the adapter, so there is nothing to point at here.
+    //
+    // The scope check beside it is the same kind of guarantee for the same kind
+    // of mistake: a write that never reached the policy table above would be
+    // callable by every read-only client, and nothing else in the system would
+    // notice.
     for (const auto& operation : operations_) {
         jassert(operation.transportScoped == (operation.handler == nullptr));
         if (!operation.transportScoped && operation.handler == nullptr)
             juce::Logger::writeToLog("Remote API operation has no handler: " + operation.name);
+
+        const bool writeNeedsMoreThanRead =
+            operation.access == OperationAccess::Read || operation.requiredScope != Scope::Read;
+        jassert(writeNeedsMoreThanRead);
+        if (!writeNeedsMoreThanRead)
+            juce::Logger::writeToLog("Remote API write operation has no scope: " + operation.name);
     }
 }
 
@@ -1717,6 +1811,10 @@ juce::var OperationRegistry::describe() const {
         object->setProperty("name", operation.name);
         object->setProperty("summary", operation.summary);
         object->setProperty("access", operation.access == OperationAccess::Read ? "read" : "write");
+        // The scope a caller needs, so a client can tell "I may not do this"
+        // apart from "this does not exist" before it tries, and can present the
+        // user with what to grant rather than with a refusal.
+        object->setProperty("requiredScope", scopeName(operation.requiredScope));
         object->setProperty("inputSchema", operation.inputSchema.clone());
         object->setProperty("outputSchema", operation.outputSchema.clone());
         // Always present rather than only when true: a client deciding whether

--- a/magda/daw/api/remote_api.hpp
+++ b/magda/daw/api/remote_api.hpp
@@ -11,6 +11,7 @@
 #include "../core/ChainNodePath.hpp"
 #include "../core/ClipTypes.hpp"
 #include "../core/TypeIds.hpp"
+#include "remote_scopes.hpp"
 
 namespace magda {
 
@@ -35,6 +36,17 @@ inline constexpr std::string_view API_VERSION = "1.0";
 enum class ErrorCode {
     InvalidRequest,
     UnknownOperation,
+    /**
+     * The operation is real and the request is well formed, but this client's
+     * grant does not cover it (#1860).
+     *
+     * Distinct from `UnknownOperation` on purpose. Hiding an operation a client
+     * may not call would be security through obscurity over a socket that
+     * already required a bearer token to reach, and it would make the failure
+     * indistinguishable from a typo — so a client that asks for something beyond
+     * its grant is told exactly that, and which scope would have allowed it.
+     */
+    PermissionDenied,
     ValidationFailed,
     NotFound,
     Conflict,
@@ -325,20 +337,54 @@ struct AutomationLaneDto {
 enum class OperationAccess { Read, Write };
 
 /**
- * @brief Per-request identity, limits, and concurrency expectations.
+ * @brief Per-request identity, permission, limits, and concurrency expectations.
  *
  * Populated by the transport adapter and passed unchanged through dispatch to
- * the handler. Scopes are carried but not enforced here — enforcement is #1860;
- * recording them now means adapters do not change shape when it lands.
+ * the handler.
  */
 struct RequestContext {
+    /**
+     * The transport's own handle for the caller — `ws:3:7`, `mcp:sess-…`.
+     *
+     * Unique per connection, issued by the transport, and never anything the
+     * client asserted about itself. It scopes the idempotency cache, so two
+     * clients that both number their requests from 1 cannot replay each other's
+     * writes.
+     */
     juce::String clientId;
+    /**
+     * What the client says it is: `cursor`, `claude-code`. Normalised, and the
+     * key its grant is stored under (#1860).
+     *
+     * Self-declared, which is exactly as much as it sounds like. It records the
+     * user's intent about a named client so a well-behaved one cannot exceed it
+     * by accident; it is not proof of anything, because the bearer token that
+     * admitted this request is readable by every process running as the user.
+     * `clientId` is the transport's identifier and this is the client's claim,
+     * and they are kept apart so nothing conflates the two.
+     */
+    juce::String clientName;
+    /// `websocket` or `mcp`, for the audit record.
+    juce::String transport;
     /// Idempotency key. Repeating a completed write with the same id returns
     /// the first response instead of applying the mutation twice.
     juce::String requestId;
     /// Optimistic concurrency: reject the write if the project has moved on.
     std::optional<Revision> expectedRevision;
-    std::vector<juce::String> scopes;
+    /**
+     * What this caller may reach. Empty by default, which denies everything.
+     *
+     * Fail-closed is the point: a transport that forgot to fill this in refuses
+     * every request loudly on its first test run, where one that defaulted to
+     * full access would hand out the project silently and pass. Both adapters
+     * populate it per request from `RemoteClientRegistry`, which is what makes
+     * revoking a grant take effect on the next request rather than the next
+     * restart.
+     *
+     * In-process callers that are not a remote client at all — the subscription
+     * hub's snapshot projections, tests — set it explicitly.
+     */
+    ScopeSet scopes;
     /// Absolute deadline. Work still queued when it passes fails with Timeout
     /// rather than executing late.
     std::optional<std::chrono::steady_clock::time_point> deadline;
@@ -396,6 +442,22 @@ struct OperationDescriptor {
     juce::String name;
     juce::String summary;
     OperationAccess access = OperationAccess::Read;
+    /**
+     * The one scope a client needs to call this (#1860).
+     *
+     * One rather than a set, because every operation this API has belongs to
+     * exactly one thing the user would decide about, and a set would invite
+     * combinations nobody can reason about from a settings checkbox. It sits on
+     * the descriptor for the same reason `handler` does: a transport cannot
+     * reach a different permission than the one declared, and there is one place
+     * to look.
+     *
+     * Defaults to `Read`, which is the safe default only because it is paired
+     * with a registry-wide assertion that every write declares something else —
+     * a new write operation that forgets this is caught at startup rather than
+     * by a client discovering it can edit.
+     */
+    Scope requiredScope = Scope::Read;
     juce::var inputSchema;
     juce::var outputSchema;
     /**

--- a/magda/daw/api/remote_api_host.cpp
+++ b/magda/daw/api/remote_api_host.cpp
@@ -1,9 +1,13 @@
 #include "remote_api_host.hpp"
 
+#include <juce_events/juce_events.h>
+
 #include <random>
 
 #include "AppPaths.hpp"
 #include "Config.hpp"
+#include "remote_audit.hpp"
+#include "remote_clients.hpp"
 #include "remote_mcp_server.hpp"
 #include "remote_model_bridge.hpp"
 #include "remote_service.hpp"
@@ -173,21 +177,68 @@ RemoteApiHost* activeHost() {
 }
 
 RemoteApiHost::RemoteApiHost(MagdaApi& api, AudioEngine* engine)
-    : service_(std::make_unique<RemoteApiService>(api)),
+    : audit_(std::make_unique<RemoteAuditLog>()),
+      clients_(std::make_unique<RemoteClientRegistry>()),
+      service_(std::make_unique<RemoteApiService>(api)),
       bridge_(std::make_unique<ModelChangeBridge>(*service_)),
       subscriptions_(std::make_unique<SubscriptionHub>(api, *service_)) {
     if (engine != nullptr)
         subscriptions_->setMeterSource(makeLiveMeterSource(*engine));
+
+    service_->setAuditLog(audit_.get());
+
+    // Grants are restored before the change handler is installed, so loading
+    // them does not immediately write them back out again.
+    clients_->loadGrantsFromJson(Config::getInstance().getRemoteApiClients());
+    clients_->setChangeHandler([this] { persistGrants(); });
+
     activeHostInstance = this;
 }
 
 RemoteApiHost::~RemoteApiHost() {
     stop();
+
+    // Before the members go: the handler captures `this` and the registry is
+    // free to notify from a transport thread, so leaving it installed while the
+    // object unwinds is a call into a half-destroyed host. `stop()` has already
+    // joined the transports, so nothing can be mid-notification here.
+    if (clients_ != nullptr)
+        clients_->setChangeHandler(nullptr);
+    if (service_ != nullptr)
+        service_->setAuditLog(nullptr);
+
     // Only if we are still the registered one. Tests construct hosts in
     // sequence, and an earlier one destructing after a later one was registered
     // must not clear the later one's registration.
     if (activeHostInstance == this)
         activeHostInstance = nullptr;
+}
+
+void RemoteApiHost::persistGrants() {
+    // Snapshotted here, applied possibly later, and deliberately capturing no
+    // `this`: the host may be destroyed between the two, and the queued write
+    // needs nothing from it.
+    auto grants = clients_->grantsToJson();
+    auto apply = [grants = std::move(grants)] {
+        auto& config = Config::getInstance();
+        config.setRemoteApiClients(grants);
+        config.save();
+    };
+
+    // `Config` is a singleton with no internal locking, and `save()` reads every
+    // member of it while the settings pages write them. This is reached from a
+    // transport thread whenever a client MAGDA has not seen registers itself, so
+    // writing from here would race the UI over the whole config file — for a
+    // change that is not urgent by any measure.
+    //
+    // Inline when there is no message loop to post to, which is the headless
+    // case: a test or a console host, where nothing else is writing config.
+    if (juce::MessageManager::existsAndIsCurrentThread() ||
+        juce::MessageManager::getInstanceWithoutCreating() == nullptr) {
+        apply();
+        return;
+    }
+    juce::MessageManager::callAsync(std::move(apply));
 }
 
 bool RemoteApiHost::start() {
@@ -217,15 +268,23 @@ bool RemoteApiHost::start() {
         return false;
     }
 
+    // The token is a credential that will appear in headers this process logs
+    // around. Registering it means any line that quotes one is masked before it
+    // reaches the audit log or the app log.
+    registerRemoteSecret(token_);
+
     RemoteWebSocketServer::Options options;
     options.bearerToken = token_;
     options.port = config.getRemoteApiPort();
+    options.clients = clients_.get();
+    options.audit = audit_.get();
     for (const auto& origin : config.getRemoteApiAllowedOrigins())
         options.allowedOrigins.push_back(juce::String::fromUTF8(origin.c_str()));
 
     server_ = std::make_unique<RemoteWebSocketServer>(*service_, options, subscriptions_.get());
     if (!server_->start()) {
         server_.reset();
+        forgetRemoteSecret(token_);
         token_ = {};
         return false;
     }
@@ -239,6 +298,8 @@ bool RemoteApiHost::start() {
     mcpOptions.bearerToken = token_;
     mcpOptions.port = config.getRemoteApiMcpPort();
     mcpOptions.allowedOrigins = options.allowedOrigins;
+    mcpOptions.clients = clients_.get();
+    mcpOptions.audit = audit_.get();
 
     mcpServer_ = std::make_unique<RemoteMcpServer>(*service_, mcpOptions, subscriptions_.get());
     if (!mcpServer_->start()) {
@@ -249,13 +310,16 @@ bool RemoteApiHost::start() {
     // A running listener whose token nobody can read is useless and still a
     // listener, so a failure to publish takes the servers down with it.
     if (!writeTokenFile(tokenFile(), token_, server_->boundPort(), mcpPort())) {
-        DBG("RemoteApiHost: could not write " + tokenFile().getFullPathName());
+        // The name, not the path. This line goes to the app log, which users
+        // paste into bug reports, and the directory is their home directory.
+        DBG("RemoteApiHost: could not write " + redactedFileName(tokenFile()));
         if (mcpServer_ != nullptr) {
             mcpServer_->stop();
             mcpServer_.reset();
         }
         server_->stop();
         server_.reset();
+        forgetRemoteSecret(token_);
         token_ = {};
         return false;
     }
@@ -285,7 +349,32 @@ void RemoteApiHost::stopListening() {
     // would advertise a port that is no longer listening and a credential that
     // no longer works.
     tokenFile().deleteFile();
+    forgetRemoteSecret(token_);
     token_ = {};
+
+    // Connections were tracked by the servers that have just gone. Anything
+    // still listed refers to a socket that no longer exists — a settings table
+    // showing phantom clients, with a disconnect button that would answer
+    // false. Grants are untouched: those are the user's decisions, not
+    // per-run state.
+    if (clients_ != nullptr) {
+        for (const auto& client : clients_->connections())
+            clients_->noteDisconnected(client.connectionId);
+    }
+}
+
+bool RemoteApiHost::rotateToken() {
+    if (!isRunning())
+        return false;
+
+    // A restart rather than a swap of the credential in place. Both servers
+    // read `bearerToken` from an immutable Options copy taken at construction,
+    // and making it mutable would mean a live comparison against a value
+    // changing under the comparing thread — for the one operation where being
+    // half-applied is worst. Rebuilding is what guarantees every existing
+    // connection is gone: they were admitted by a token that no longer exists.
+    stopListening();
+    return start();
 }
 
 void RemoteApiHost::stop() {
@@ -328,6 +417,14 @@ RemoteApiService& RemoteApiHost::service() {
 
 SubscriptionHub& RemoteApiHost::subscriptions() {
     return *subscriptions_;
+}
+
+RemoteClientRegistry& RemoteApiHost::clients() {
+    return *clients_;
+}
+
+RemoteAuditLog& RemoteApiHost::audit() {
+    return *audit_;
 }
 
 }  // namespace remote

--- a/magda/daw/api/remote_api_host.cpp
+++ b/magda/daw/api/remote_api_host.cpp
@@ -215,13 +215,38 @@ RemoteApiHost::~RemoteApiHost() {
 }
 
 void RemoteApiHost::persistGrants() {
-    // Snapshotted here, applied possibly later, and deliberately capturing no
-    // `this`: the host may be destroyed between the two, and the queued write
-    // needs nothing from it.
+    // Read before taking the writer's lock: `grantsToJson` takes the registry's,
+    // and holding two is worth avoiding even where the order happens to be safe.
     auto grants = clients_->grantsToJson();
-    auto apply = [grants = std::move(grants)] {
+
+    auto writer = grantWriter_;
+    {
+        const std::lock_guard<std::mutex> lock(writer->mutex);
+        writer->latest = std::move(grants);
+        // Already a write on its way. It reads `latest` when it runs, so it will
+        // carry this change too — and posting a second task would be how the
+        // older of two snapshots ends up applied last.
+        //
+        // That reordering is the reason this is a slot rather than a captured
+        // value: a transport thread can snapshot, the user can then revoke a
+        // scope in the settings dialog and have it saved inline, and the
+        // transport's older snapshot would land afterwards and put the revoked
+        // grant back — silently, and permanently, because config is what the
+        // next launch reads.
+        if (writer->posted)
+            return;
+        writer->posted = true;
+    }
+
+    auto apply = [writer] {
+        juce::var latest;
+        {
+            const std::lock_guard<std::mutex> lock(writer->mutex);
+            latest = writer->latest;
+            writer->posted = false;
+        }
         auto& config = Config::getInstance();
-        config.setRemoteApiClients(grants);
+        config.setRemoteApiClients(latest);
         config.save();
     };
 
@@ -229,7 +254,8 @@ void RemoteApiHost::persistGrants() {
     // member of it while the settings pages write them. This is reached from a
     // transport thread whenever a client MAGDA has not seen registers itself, so
     // writing from here would race the UI over the whole config file — for a
-    // change that is not urgent by any measure.
+    // change that is not urgent by any measure. Hopping also gives the
+    // coalescing above one thread to serialise on.
     //
     // Inline when there is no message loop to post to, which is the headless
     // case: a test or a console host, where nothing else is writing config.
@@ -238,7 +264,15 @@ void RemoteApiHost::persistGrants() {
         apply();
         return;
     }
-    juce::MessageManager::callAsync(std::move(apply));
+
+    // The task captures only the shared slot, so it is safe for it to outlive
+    // this host. If the loop is already quitting it is dropped, and the grant
+    // is not persisted — the same outcome as the process being killed a moment
+    // earlier, and not something worth a synchronous write on shutdown.
+    if (!juce::MessageManager::callAsync(apply)) {
+        const std::lock_guard<std::mutex> lock(writer->mutex);
+        writer->posted = false;
+    }
 }
 
 bool RemoteApiHost::start() {

--- a/magda/daw/api/remote_api_host.cpp
+++ b/magda/daw/api/remote_api_host.cpp
@@ -247,6 +247,22 @@ void RemoteApiHost::persistGrants() {
     }
 
     auto apply = [writer] {
+        // Held across the whole write, not just the read of `latest`.
+        //
+        // On the message-thread path there is only ever one of these in flight,
+        // but the inline path below has no such guarantee: clearing `posted` and
+        // then writing unlocked lets a second transport thread walk in, see
+        // `posted` false, and run its own apply while this one is still inside
+        // `Config::save()`. Two threads then write a singleton that has no
+        // locking of its own — which is exactly the situation the hop exists to
+        // avoid, reintroduced on the path that cannot hop.
+        //
+        // Taken before `mutex` and never the other way round. `persistGrants`
+        // only ever takes `mutex`, so a recorder is never blocked behind a file
+        // write; it just leaves a newer `latest` for whoever is inside here to
+        // pick up.
+        const std::lock_guard<std::mutex> applying(writer->applyMutex);
+
         juce::var latest;
         {
             const std::lock_guard<std::mutex> lock(writer->mutex);

--- a/magda/daw/api/remote_api_host.cpp
+++ b/magda/daw/api/remote_api_host.cpp
@@ -177,7 +177,7 @@ RemoteApiHost* activeHost() {
 }
 
 RemoteApiHost::RemoteApiHost(MagdaApi& api, AudioEngine* engine)
-    : audit_(std::make_unique<RemoteAuditLog>()),
+    : audit_(std::make_shared<RemoteAuditLog>()),
       clients_(std::make_unique<RemoteClientRegistry>()),
       service_(std::make_unique<RemoteApiService>(api)),
       bridge_(std::make_unique<ModelChangeBridge>(*service_)),
@@ -185,7 +185,7 @@ RemoteApiHost::RemoteApiHost(MagdaApi& api, AudioEngine* engine)
     if (engine != nullptr)
         subscriptions_->setMeterSource(makeLiveMeterSource(*engine));
 
-    service_->setAuditLog(audit_.get());
+    service_->setAuditLog(audit_);
 
     // Grants are restored before the change handler is installed, so loading
     // them does not immediately write them back out again.
@@ -215,14 +215,22 @@ RemoteApiHost::~RemoteApiHost() {
 }
 
 void RemoteApiHost::persistGrants() {
-    // Read before taking the writer's lock: `grantsToJson` takes the registry's,
-    // and holding two is worth avoiding even where the order happens to be safe.
-    auto grants = clients_->grantsToJson();
-
     auto writer = grantWriter_;
     {
         const std::lock_guard<std::mutex> lock(writer->mutex);
-        writer->latest = std::move(grants);
+        // Snapshotted *under* this lock, not before it. Reading first and
+        // storing second leaves the same reordering one level down: a thread
+        // can read A, be preempted while another reads B and stores it, then
+        // resume and overwrite `latest` with the older A — and, seeing a write
+        // already posted, return. The task then persists A and the revocation
+        // that produced B is undone.
+        //
+        // Serialising the read with the store is what makes `latest` actually
+        // the latest. It costs holding the registry's lock inside this one,
+        // which is safe in this order and only this order: the registry always
+        // notifies after releasing its own lock, so nothing ever takes these two
+        // the other way round.
+        writer->latest = clients_->grantsToJson();
         // Already a write on its way. It reads `latest` when it runs, so it will
         // carry this change too — and posting a second task would be how the
         // older of two snapshots ends up applied last.
@@ -311,7 +319,7 @@ bool RemoteApiHost::start() {
     options.bearerToken = token_;
     options.port = config.getRemoteApiPort();
     options.clients = clients_.get();
-    options.audit = audit_.get();
+    options.audit = audit_;
     for (const auto& origin : config.getRemoteApiAllowedOrigins())
         options.allowedOrigins.push_back(juce::String::fromUTF8(origin.c_str()));
 
@@ -333,7 +341,7 @@ bool RemoteApiHost::start() {
     mcpOptions.port = config.getRemoteApiMcpPort();
     mcpOptions.allowedOrigins = options.allowedOrigins;
     mcpOptions.clients = clients_.get();
-    mcpOptions.audit = audit_.get();
+    mcpOptions.audit = audit_;
 
     mcpServer_ = std::make_unique<RemoteMcpServer>(*service_, mcpOptions, subscriptions_.get());
     if (!mcpServer_->start()) {

--- a/magda/daw/api/remote_api_host.hpp
+++ b/magda/daw/api/remote_api_host.hpp
@@ -13,6 +13,8 @@ namespace remote {
 
 class ModelChangeBridge;
 class RemoteApiService;
+class RemoteAuditLog;
+class RemoteClientRegistry;
 class RemoteMcpServer;
 class RemoteWebSocketServer;
 class SubscriptionHub;
@@ -121,6 +123,23 @@ class RemoteApiHost {
      */
     void stopListening();
 
+    /**
+     * @brief Throw the current credential away and issue a new one (#1860).
+     *
+     * Every connected client is disconnected, because that is what rotation
+     * means: a token that still admitted the sessions it was replacing would
+     * not have been revoked. Clients reconnect by re-reading the discovery
+     * record, which this rewrites before returning — so a well-behaved one
+     * recovers on its own and a stale copy of the old token never works again.
+     *
+     * A no-op returning false when nothing is listening: there is no credential
+     * to rotate, and minting one without a listener would publish a record for
+     * a port nobody is answering on.
+     *
+     * Message thread only, like `start()`.
+     */
+    bool rotateToken();
+
     bool isRunning() const;
 
     /// The WebSocket port actually bound, or 0 when not running.
@@ -143,11 +162,34 @@ class RemoteApiHost {
     /// not two.
     SubscriptionHub& subscriptions();
 
+    /**
+     * @brief Who may do what, and who is connected right now (#1860).
+     *
+     * Shared by both transports and edited by the settings dialog. Outlives the
+     * listeners deliberately: a grant is the user's decision about a client, and
+     * switching the feature off and on again must not silently forget it.
+     */
+    RemoteClientRegistry& clients();
+
+    /// What remote clients have done this run. Bounded and in memory only.
+    RemoteAuditLog& audit();
+
   private:
+    /// Mirror the registry's grants into the config file. Wired as the
+    /// registry's change handler, so a grant made in the settings dialog and one
+    /// created by a client connecting for the first time are persisted by the
+    /// same path.
+    void persistGrants();
     // Declaration order is destruction order reversed, and it is load-bearing:
     // a transport's connections deregister from the hub, the hub listens to the
     // service's change source, and the bridge writes into the service. Each has
     // to outlive the thing that talks to it.
+    //
+    // The audit log and the client registry come first because both transports
+    // hold raw pointers to them and the dispatcher holds one to the log — so
+    // they have to be the last two standing.
+    std::unique_ptr<RemoteAuditLog> audit_;
+    std::unique_ptr<RemoteClientRegistry> clients_;
     std::unique_ptr<RemoteApiService> service_;
     std::unique_ptr<ModelChangeBridge> bridge_;
     std::unique_ptr<SubscriptionHub> subscriptions_;

--- a/magda/daw/api/remote_api_host.hpp
+++ b/magda/daw/api/remote_api_host.hpp
@@ -213,10 +213,15 @@ class RemoteApiHost {
     // service's change source, and the bridge writes into the service. Each has
     // to outlive the thing that talks to it.
     //
-    // The audit log and the client registry come first because both transports
-    // hold raw pointers to them and the dispatcher holds one to the log — so
-    // they have to be the last two standing.
-    std::unique_ptr<RemoteAuditLog> audit_;
+    // The client registry comes first because both transports hold a raw
+    // pointer to it, so it has to outlive them.
+    //
+    // The audit log is a `shared_ptr` rather than a `unique_ptr` because
+    // declaration order is not enough for it: a dispatch completion carrying it
+    // can still be queued on the message thread when this whole object is
+    // destroyed, and ordering members only decides what happens *inside* the
+    // destructor. Whoever still holds a share keeps it alive.
+    std::shared_ptr<RemoteAuditLog> audit_;
     std::unique_ptr<RemoteClientRegistry> clients_;
     std::unique_ptr<RemoteApiService> service_;
     std::unique_ptr<ModelChangeBridge> bridge_;

--- a/magda/daw/api/remote_api_host.hpp
+++ b/magda/daw/api/remote_api_host.hpp
@@ -203,7 +203,13 @@ class RemoteApiHost {
      * reaching into it.
      */
     struct GrantWriter {
+        /// Guards `latest` and `posted`. Held briefly, never across I/O.
         std::mutex mutex;
+        /// Serialises the config write itself. Separate from `mutex` so a
+        /// transport thread recording a newer grant is never blocked behind a
+        /// file save — it leaves `latest` for whoever is inside the write to
+        /// pick up. Always taken before `mutex`, never after.
+        std::mutex applyMutex;
         juce::var latest;
         bool posted = false;
     };

--- a/magda/daw/api/remote_api_host.hpp
+++ b/magda/daw/api/remote_api_host.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 
 #include "remote_api.hpp"
 
@@ -175,11 +176,38 @@ class RemoteApiHost {
     RemoteAuditLog& audit();
 
   private:
-    /// Mirror the registry's grants into the config file. Wired as the
-    /// registry's change handler, so a grant made in the settings dialog and one
-    /// created by a client connecting for the first time are persisted by the
-    /// same path.
+    /**
+     * @brief Mirror the registry's grants into the config file.
+     *
+     * Wired as the registry's change handler, so a grant made in the settings
+     * dialog and one created by a client connecting for the first time are
+     * persisted by the same path — which means this is called from transport
+     * threads as well as the message thread.
+     */
     void persistGrants();
+
+    /**
+     * @brief The pending config write, shared by every thread that asks for one.
+     *
+     * A slot rather than a value captured per call, because the writes have to
+     * be ordered and there is more than one writer. A transport thread can
+     * snapshot the grants, the user can then revoke a scope and have that saved,
+     * and the transport's older snapshot would otherwise land last and restore
+     * what was just revoked — in the file the next launch reads.
+     *
+     * Whoever finds `posted` false owns the hop; everyone after simply replaces
+     * `latest`, which the pending task re-reads when it runs. So the newest
+     * state always wins and a burst of changes costs one write.
+     *
+     * Held by `shared_ptr` so a queued write can outlive this host without
+     * reaching into it.
+     */
+    struct GrantWriter {
+        std::mutex mutex;
+        juce::var latest;
+        bool posted = false;
+    };
+    std::shared_ptr<GrantWriter> grantWriter_ = std::make_shared<GrantWriter>();
     // Declaration order is destruction order reversed, and it is load-bearing:
     // a transport's connections deregister from the hub, the hub listens to the
     // service's change source, and the bridge writes into the service. Each has

--- a/magda/daw/api/remote_audit.cpp
+++ b/magda/daw/api/remote_audit.cpp
@@ -1,0 +1,229 @@
+#include "remote_audit.hpp"
+
+#include <algorithm>
+#include <utility>
+
+namespace magda::remote {
+namespace {
+
+/// Registered secrets, and the lock over them. A plain function-local static
+/// rather than a member of anything: redaction has to be reachable from log
+/// sites that have no access to the host, which is the point of it.
+std::mutex& secretsMutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
+std::vector<juce::String>& secrets() {
+    static std::vector<juce::String> values;
+    return values;
+}
+
+constexpr const char* kMask = "***";
+
+/**
+ * How long a `Bearer` value has to be before it is treated as a credential.
+ *
+ * Sixteen, because MAGDA's own token is sixty-four hex characters and no
+ * English word this appears next to in a MAGDA message is that long. The
+ * boundary is a judgement, not a rule — see `redactSecrets`.
+ */
+constexpr int kMinimumCredentialLength = 16;
+
+/// The characters a bearer credential is built from — RFC 7235's `token68`.
+/// `.` is in the set because JWTs are built from it; the cost is that a
+/// credential ending a sentence takes the full stop into the mask with it,
+/// which is the harmless direction to be wrong in.
+bool isCredentialCharacter(juce::juce_wchar character) {
+    return juce::CharacterFunctions::isLetterOrDigit(character) || character == '-' ||
+           character == '.' || character == '_' || character == '~' || character == '+' ||
+           character == '/' || character == '=';
+}
+
+}  // namespace
+
+juce::String toString(AuditOutcome outcome) {
+    switch (outcome) {
+        case AuditOutcome::Ok:
+            return "ok";
+        case AuditOutcome::Denied:
+            return "denied";
+        case AuditOutcome::Failed:
+            return "failed";
+        case AuditOutcome::Connected:
+            return "connected";
+        case AuditOutcome::Disconnected:
+            return "disconnected";
+        case AuditOutcome::Rejected:
+            return "rejected";
+    }
+    return "unknown";
+}
+
+juce::var AuditEntry::toJson() const {
+    auto* object = new juce::DynamicObject();
+    object->setProperty("timestampMs", timestampMs);
+    object->setProperty("client", client);
+    object->setProperty("connectionId", connectionId);
+    object->setProperty("transport", transport);
+    object->setProperty("operation", operation);
+    object->setProperty("requestId", requestId);
+    object->setProperty("outcome", magda::remote::toString(outcome));
+    object->setProperty("detail", detail);
+    return juce::var(object);
+}
+
+// ===========================================================================
+// RemoteAuditLog
+// ===========================================================================
+
+RemoteAuditLog::RemoteAuditLog(std::size_t capacity)
+    : capacity_(capacity == 0 ? DEFAULT_CAPACITY : capacity) {}
+
+void RemoteAuditLog::record(AuditEntry entry) {
+    if (entry.timestampMs == 0)
+        entry.timestampMs = juce::Time::getCurrentTime().toMilliseconds();
+    // Unconditional, at the one point every entry passes through. Redacting at
+    // the call sites instead would mean each new one is a chance to forget.
+    entry.detail = redactSecrets(entry.detail);
+
+    const std::lock_guard<std::mutex> lock(mutex_);
+    entries_.push_back(std::move(entry));
+    ++totalRecorded_;
+    while (entries_.size() > capacity_)
+        entries_.pop_front();
+}
+
+std::vector<AuditEntry> RemoteAuditLog::entries() const {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return {entries_.begin(), entries_.end()};
+}
+
+std::vector<AuditEntry> RemoteAuditLog::recent(std::size_t count) const {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    const auto take = std::min(count, entries_.size());
+    return {entries_.end() - static_cast<std::ptrdiff_t>(take), entries_.end()};
+}
+
+std::vector<AuditEntry> RemoteAuditLog::forClient(const juce::String& clientName) const {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<AuditEntry> result;
+    for (const auto& entry : entries_) {
+        if (entry.client == clientName)
+            result.push_back(entry);
+    }
+    return result;
+}
+
+void RemoteAuditLog::clear() {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    entries_.clear();
+    // `totalRecorded_` deliberately survives: it is the "did anything change"
+    // cursor the UI polls, and resetting it would make a clear look like no
+    // change at all.
+}
+
+std::size_t RemoteAuditLog::size() const {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return entries_.size();
+}
+
+std::size_t RemoteAuditLog::capacity() const {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return capacity_;
+}
+
+void RemoteAuditLog::setCapacity(std::size_t capacity) {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    capacity_ = capacity == 0 ? DEFAULT_CAPACITY : capacity;
+    while (entries_.size() > capacity_)
+        entries_.pop_front();
+}
+
+std::uint64_t RemoteAuditLog::totalRecorded() const {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return totalRecorded_;
+}
+
+// ===========================================================================
+// Redaction
+// ===========================================================================
+
+void registerRemoteSecret(const juce::String& secret) {
+    // Short values are refused rather than registered. A one- or two-character
+    // "secret" would match somewhere in almost every message and turn the whole
+    // log into asterisks — and nothing MAGDA generates is that short, so a value
+    // this small is a bug at the call site.
+    if (secret.length() < 8)
+        return;
+
+    const std::lock_guard<std::mutex> lock(secretsMutex());
+    auto& values = secrets();
+    if (std::find(values.begin(), values.end(), secret) == values.end())
+        values.push_back(secret);
+}
+
+void forgetRemoteSecret(const juce::String& secret) {
+    const std::lock_guard<std::mutex> lock(secretsMutex());
+    auto& values = secrets();
+    values.erase(std::remove(values.begin(), values.end(), secret), values.end());
+}
+
+void forgetAllRemoteSecrets() {
+    const std::lock_guard<std::mutex> lock(secretsMutex());
+    secrets().clear();
+}
+
+juce::String redactSecrets(const juce::String& text) {
+    if (text.isEmpty())
+        return text;
+
+    juce::String result = text;
+    {
+        const std::lock_guard<std::mutex> lock(secretsMutex());
+        for (const auto& secret : secrets())
+            result = result.replace(secret, kMask, false);
+    }
+
+    // Then by shape, for a credential MAGDA never held: a client's own
+    // `Authorization` header, echoed into a rejection reason. Case-insensitive
+    // because the scheme is, per RFC 7235.
+    //
+    // The word after "bearer" is only masked when it *looks* like a credential
+    // — long enough, and drawn from the character set a token uses. Without
+    // that, "invalid or missing bearer token" redacts to "…bearer ***", which
+    // is how a heuristic meant to protect the log ends up destroying it. This
+    // cannot be tight enough to be exact, and it does not have to be: the real
+    // guarantee is that MAGDA never builds a message out of a credential in the
+    // first place, and registered secrets above cover the values it does hold.
+    for (int from = 0;;) {
+        const auto at = result.indexOfIgnoreCase(from, "bearer ");
+        if (at < 0)
+            break;
+
+        const auto valueStart = at + 7;
+        auto valueEnd = valueStart;
+        while (valueEnd < result.length() && isCredentialCharacter(result[valueEnd]))
+            ++valueEnd;
+
+        // Advance unconditionally, whatever was found: a "bearer" with nothing
+        // credential-shaped after it must not leave `from` where it was, or
+        // this scans the same position for ever.
+        const auto length = valueEnd - valueStart;
+        if (length < kMinimumCredentialLength) {
+            from = valueStart;
+            continue;
+        }
+
+        result = result.substring(0, valueStart) + kMask + result.substring(valueEnd);
+        from = valueStart + static_cast<int>(std::string_view(kMask).size());
+    }
+
+    return result;
+}
+
+juce::String redactedFileName(const juce::File& file) {
+    return file == juce::File() ? juce::String() : file.getFileName();
+}
+
+}  // namespace magda::remote

--- a/magda/daw/api/remote_audit.hpp
+++ b/magda/daw/api/remote_audit.hpp
@@ -1,0 +1,178 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <vector>
+
+namespace magda {
+namespace remote {
+
+/// How one audited request or connection ended.
+enum class AuditOutcome {
+    /// The operation ran and succeeded.
+    Ok,
+    /// Refused because the client's grant did not cover it. The one outcome
+    /// that is about permission rather than correctness, and the reason the
+    /// settings UI can show "this client tried to edit" without the user having
+    /// to read a log file.
+    Denied,
+    /// Reached the dispatcher and came back an error — validation, not found,
+    /// conflict, timeout. `detail` carries the MAGDA error code.
+    Failed,
+    /// A connection opened.
+    Connected,
+    /// A connection closed.
+    Disconnected,
+    /// Refused before it became a request at all: bad token, bad Origin, over a
+    /// limit. `detail` says which.
+    Rejected,
+};
+
+juce::String toString(AuditOutcome outcome);
+
+/**
+ * @brief One line of the record (#1860).
+ *
+ * Deliberately six fixed fields and a short reason, and deliberately no payload.
+ * A request's input is whatever a client chose to send and its result is a
+ * projection of the user's project; neither belongs in a buffer that the
+ * settings UI displays and that a user may screenshot into a bug report. What is
+ * here is enough to answer "who did what, and did it work" — which is what an
+ * audit log is for — and nothing more.
+ */
+struct AuditEntry {
+    /// Wall clock, milliseconds since the epoch. Wall clock rather than a
+    /// steady clock precisely because this is shown to a person.
+    juce::int64 timestampMs = 0;
+    /// Normalised client name, the same key the grant is stored under.
+    juce::String client;
+    /// The transport's connection handle, so two connections from one client
+    /// stay distinguishable.
+    juce::String connectionId;
+    /// `websocket` or `mcp`.
+    juce::String transport;
+    /// The operation name, or a `connection.*` pseudo-operation for lifecycle.
+    juce::String operation;
+    /// The client's own request id when it sent one. Empty is normal.
+    juce::String requestId;
+    AuditOutcome outcome = AuditOutcome::Ok;
+    /// A short, already-redacted reason. Never a payload.
+    juce::String detail;
+
+    bool operator==(const AuditEntry&) const = default;
+
+    /// For the settings UI and for tests. Not a wire format — the audit log is
+    /// not exposed over the remote API, because a client that could read it
+    /// would learn what every other client is doing.
+    juce::var toJson() const;
+};
+
+/// Pseudo-operations, so connection lifecycle and requests share one table
+/// rather than needing two views that have to be interleaved by timestamp.
+inline constexpr const char* AUDIT_CONNECTION_OPEN = "connection.open";
+inline constexpr const char* AUDIT_CONNECTION_CLOSE = "connection.close";
+inline constexpr const char* AUDIT_CONNECTION_REJECTED = "connection.rejected";
+
+/**
+ * @brief A bounded, in-memory record of what remote clients did.
+ *
+ * In memory and nowhere else. A file would outlive the session that produced it,
+ * would need rotation and a retention policy, and would put a description of the
+ * user's editing session on disk permanently — for a local control socket, that
+ * is a liability rather than a feature. The ring holds enough to diagnose what
+ * just happened, which is the case that actually arises.
+ *
+ * Safe from any thread: entries arrive on transport threads and on the message
+ * thread, and the settings UI reads from the message thread.
+ */
+class RemoteAuditLog {
+  public:
+    static constexpr std::size_t DEFAULT_CAPACITY = 512;
+
+    explicit RemoteAuditLog(std::size_t capacity = DEFAULT_CAPACITY);
+
+    RemoteAuditLog(const RemoteAuditLog&) = delete;
+    RemoteAuditLog& operator=(const RemoteAuditLog&) = delete;
+
+    /// Stamps `timestampMs` when the caller left it at zero, redacts `detail`,
+    /// and drops the oldest entry when full.
+    void record(AuditEntry entry);
+
+    /// Oldest first.
+    std::vector<AuditEntry> entries() const;
+
+    /// The most recent `count`, newest last. What the settings UI shows.
+    std::vector<AuditEntry> recent(std::size_t count) const;
+
+    /// Entries for one client, oldest first.
+    std::vector<AuditEntry> forClient(const juce::String& clientName) const;
+
+    void clear();
+
+    std::size_t size() const;
+    std::size_t capacity() const;
+    void setCapacity(std::size_t capacity);
+
+    /// How many entries have ever been recorded, including those aged out.
+    /// A UI polls this to know whether anything changed without copying the
+    /// buffer, and it makes silent loss visible: `totalRecorded() > size()`
+    /// means the window no longer covers the whole session.
+    std::uint64_t totalRecorded() const;
+
+  private:
+    mutable std::mutex mutex_;
+    std::deque<AuditEntry> entries_;
+    std::size_t capacity_;
+    std::uint64_t totalRecorded_ = 0;
+};
+
+// ===========================================================================
+// Redaction
+// ===========================================================================
+
+/**
+ * @brief Register a value that must never reach a log line or an error message.
+ *
+ * The bearer token and the path of the file it is published in. Registration is
+ * exact-match replacement rather than pattern matching, which is the only way to
+ * do this without false positives: a heuristic that scrubbed anything
+ * token-shaped would also scrub plugin ids and project names, and one that
+ * scrubbed anything path-shaped would mangle ordinary prose.
+ *
+ * Idempotent. Safe from any thread.
+ */
+void registerRemoteSecret(const juce::String& secret);
+
+/// Stop masking a value — a rotated token, or one whose listener has closed.
+void forgetRemoteSecret(const juce::String& secret);
+
+/// Every registered secret, for tests.
+void forgetAllRemoteSecrets();
+
+/**
+ * @brief Mask registered secrets, and any `Bearer …` credential, in `text`.
+ *
+ * Applied to every audit `detail` automatically, and available to any code
+ * about to log something that passed near a credential. `Bearer` is handled by
+ * shape as well as by registration, because a client's own malformed
+ * `Authorization` header is a value MAGDA never held and therefore never
+ * registered — and echoing it back into a log is exactly the accident this
+ * exists to prevent.
+ */
+juce::String redactSecrets(const juce::String& text);
+
+/**
+ * @brief A file named without saying where it lives.
+ *
+ * `remote-api-4021.json` rather than the full path. For log lines that need to
+ * identify a file to a user who can find it, without writing the account name
+ * and directory layout of the machine into a buffer that ends up in bug reports.
+ */
+juce::String redactedFileName(const juce::File& file);
+
+}  // namespace remote
+}  // namespace magda

--- a/magda/daw/api/remote_clients.cpp
+++ b/magda/daw/api/remote_clients.cpp
@@ -1,0 +1,264 @@
+#include "remote_clients.hpp"
+
+#include <algorithm>
+#include <utility>
+
+namespace magda::remote {
+namespace {
+
+juce::int64 nowMs() {
+    return juce::Time::getCurrentTime().toMilliseconds();
+}
+
+}  // namespace
+
+RemoteClientRegistry::RemoteClientRegistry() = default;
+RemoteClientRegistry::~RemoteClientRegistry() = default;
+
+// ===========================================================================
+// Grants
+// ===========================================================================
+
+ScopeSet RemoteClientRegistry::scopesFor(const juce::String& clientName) {
+    const auto key = normaliseClientName(clientName).toStdString();
+
+    bool created = false;
+    ScopeSet scopes;
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        auto found = grants_.find(key);
+        if (found == grants_.end()) {
+            ClientGrant grant;
+            grant.name = juce::String(key);
+            grant.scopes = defaultClientScopes();
+            grant.firstSeenMs = nowMs();
+            grant.lastSeenMs = grant.firstSeenMs;
+            found = grants_.emplace(key, std::move(grant)).first;
+            created = true;
+        } else {
+            found->second.lastSeenMs = nowMs();
+        }
+        scopes = found->second.scopes;
+    }
+
+    // Only a new client is worth waking the UI and the config writer for.
+    // `lastSeenMs` moves on every request, and persisting that would rewrite the
+    // config file at request rate for no benefit anyone can see.
+    if (created)
+        notifyChanged();
+
+    return scopes;
+}
+
+std::optional<ScopeSet> RemoteClientRegistry::peekScopes(const juce::String& clientName) const {
+    const auto key = normaliseClientName(clientName).toStdString();
+    const std::lock_guard<std::mutex> lock(mutex_);
+    const auto found = grants_.find(key);
+    if (found == grants_.end())
+        return std::nullopt;
+    return found->second.scopes;
+}
+
+void RemoteClientRegistry::setScopes(const juce::String& clientName, ScopeSet scopes) {
+    const auto key = normaliseClientName(clientName).toStdString();
+    // Forced rather than validated. A caller asking for a grant without `read`
+    // means "this client may write but not look", which no operation set
+    // expresses and which would leave a settings row showing an empty grant that
+    // still admitted the client.
+    scopes.add(Scope::Read);
+
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        auto& grant = grants_[key];
+        if (grant.name.isEmpty()) {
+            grant.name = juce::String(key);
+            grant.firstSeenMs = nowMs();
+        }
+        if (grant.scopes == scopes)
+            return;  // Nothing changed; do not churn the config file.
+        grant.scopes = scopes;
+    }
+
+    notifyChanged();
+}
+
+void RemoteClientRegistry::forget(const juce::String& clientName) {
+    const auto key = normaliseClientName(clientName).toStdString();
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        if (grants_.erase(key) == 0)
+            return;
+    }
+    notifyChanged();
+}
+
+std::vector<ClientGrant> RemoteClientRegistry::grants() const {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<ClientGrant> result;
+    result.reserve(grants_.size());
+    for (const auto& [key, grant] : grants_)
+        result.push_back(grant);
+    return result;
+}
+
+// ===========================================================================
+// Live connections
+// ===========================================================================
+
+void RemoteClientRegistry::noteConnected(ConnectedClient client) {
+    client.name = normaliseClientName(client.name);
+    if (client.connectedAtMs == 0)
+        client.connectedAtMs = nowMs();
+
+    const std::lock_guard<std::mutex> lock(mutex_);
+    // Replace rather than append on a repeated id. A transport that reuses one
+    // would otherwise leave a phantom row that no disconnect could clear,
+    // because `noteDisconnected` removes a single entry.
+    const auto found = std::find_if(connections_.begin(), connections_.end(),
+                                    [&](const ConnectedClient& existing) {
+                                        return existing.connectionId == client.connectionId;
+                                    });
+    if (found != connections_.end())
+        *found = std::move(client);
+    else
+        connections_.push_back(std::move(client));
+}
+
+void RemoteClientRegistry::noteDisconnected(const juce::String& connectionId) {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    connections_.erase(std::remove_if(connections_.begin(), connections_.end(),
+                                      [&](const ConnectedClient& client) {
+                                          return client.connectionId == connectionId;
+                                      }),
+                       connections_.end());
+}
+
+std::vector<ConnectedClient> RemoteClientRegistry::connections() const {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return connections_;
+}
+
+int RemoteClientRegistry::connectionCount() const {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return static_cast<int>(connections_.size());
+}
+
+void RemoteClientRegistry::setDisconnectHandler(const juce::String& transport,
+                                                DisconnectHandler handler) {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    if (handler)
+        disconnectHandlers_[transport.toStdString()] = std::move(handler);
+    else
+        disconnectHandlers_.erase(transport.toStdString());
+}
+
+bool RemoteClientRegistry::disconnect(const juce::String& connectionId) {
+    DisconnectHandler handler;
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        const auto found = std::find_if(
+            connections_.begin(), connections_.end(),
+            [&](const ConnectedClient& client) { return client.connectionId == connectionId; });
+        if (found == connections_.end())
+            return false;
+
+        const auto owner = disconnectHandlers_.find(found->transport.toStdString());
+        if (owner == disconnectHandlers_.end())
+            return false;
+        handler = owner->second;
+    }
+
+    // Outside the lock: closing a connection ends with the transport calling
+    // `noteDisconnected`, which takes this same non-recursive mutex. Whether
+    // that happens on this thread or the connection's own is the transport's
+    // business, and holding the lock across it would deadlock on the first
+    // transport that answered synchronously.
+    return handler(connectionId);
+}
+
+int RemoteClientRegistry::disconnectClient(const juce::String& clientName) {
+    const auto name = normaliseClientName(clientName);
+
+    // Snapshot the ids under the lock, close outside it, for the reason above.
+    std::vector<juce::String> ids;
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        for (const auto& client : connections_) {
+            if (client.name == name)
+                ids.push_back(client.connectionId);
+        }
+    }
+
+    int closed = 0;
+    for (const auto& id : ids) {
+        if (disconnect(id))
+            ++closed;
+    }
+    return closed;
+}
+
+// ===========================================================================
+// Persistence
+// ===========================================================================
+
+juce::var RemoteClientRegistry::grantsToJson() const {
+    juce::Array<juce::var> array;
+    for (const auto& grant : grants()) {
+        auto* entry = new juce::DynamicObject();
+        entry->setProperty("name", grant.name);
+        entry->setProperty("scopes", scopesToJson(grant.scopes));
+        if (grant.firstSeenMs != 0)
+            entry->setProperty("firstSeenMs", grant.firstSeenMs);
+        if (grant.lastSeenMs != 0)
+            entry->setProperty("lastSeenMs", grant.lastSeenMs);
+        array.add(juce::var(entry));
+    }
+    return array;
+}
+
+void RemoteClientRegistry::loadGrantsFromJson(const juce::var& value) {
+    std::map<std::string, ClientGrant> loaded;
+    if (const auto* array = value.getArray()) {
+        for (const auto& entry : *array) {
+            const auto name = normaliseClientName(entry["name"].toString());
+            // An entry whose name was absent or unusable normalises to
+            // `unknown` — a real bucket, so this is a merge rather than a skip.
+            // Merging keeps the last grant to name it rather than silently
+            // dropping one of two rows that collided.
+            auto& grant = loaded[name.toStdString()];
+            grant.name = name;
+            grant.scopes = scopesFromJson(entry["scopes"]);
+            grant.scopes.add(Scope::Read);
+            grant.firstSeenMs = static_cast<juce::int64>(entry["firstSeenMs"]);
+            grant.lastSeenMs = static_cast<juce::int64>(entry["lastSeenMs"]);
+        }
+    }
+
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        grants_ = std::move(loaded);
+    }
+    // Deliberately silent. This runs during startup, from the same code that
+    // would answer the notification by writing the config back out — which would
+    // rewrite the file with what was just read from it.
+}
+
+void RemoteClientRegistry::setChangeHandler(std::function<void()> onChanged) {
+    const std::lock_guard<std::mutex> lock(changeHandlerMutex_);
+    onChanged_ = std::move(onChanged);
+}
+
+void RemoteClientRegistry::notifyChanged() {
+    std::function<void()> handler;
+    {
+        const std::lock_guard<std::mutex> lock(changeHandlerMutex_);
+        handler = onChanged_;
+    }
+    // Copied and called outside both locks: a handler is free to read grants
+    // back, which takes `mutex_`, and free to replace itself, which takes
+    // `changeHandlerMutex_`.
+    if (handler)
+        handler();
+}
+
+}  // namespace magda::remote

--- a/magda/daw/api/remote_clients.hpp
+++ b/magda/daw/api/remote_clients.hpp
@@ -1,0 +1,190 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "remote_scopes.hpp"
+
+namespace magda {
+namespace remote {
+
+/// The two transport names, spelled once. They key the disconnect handlers, so
+/// a mismatch between what a server registers and what a connection reports is
+/// a disconnect button that silently does nothing.
+inline constexpr const char* TRANSPORT_WEBSOCKET = "websocket";
+inline constexpr const char* TRANSPORT_MCP = "mcp";
+
+/// What a client was granted, and when it was last seen. Persisted.
+struct ClientGrant {
+    /// Normalised — see `normaliseClientName`. The key, not a display field.
+    juce::String name;
+    ScopeSet scopes = defaultClientScopes();
+    /// Wall-clock milliseconds, for the settings table. Zero when unknown,
+    /// which is what a grant restored from an older config looks like.
+    juce::int64 firstSeenMs = 0;
+    juce::int64 lastSeenMs = 0;
+
+    bool operator==(const ClientGrant&) const = default;
+};
+
+/// One live connection. Not persisted: this is gone when MAGDA stops.
+struct ConnectedClient {
+    /// The transport's own handle for this connection, unique for the run —
+    /// `ws:3:7`, `mcp:sess-…`. What `disconnect()` takes, and deliberately not
+    /// the client name: a client may hold several connections and the user may
+    /// want to drop one.
+    juce::String connectionId;
+    /// Normalised declared name. Several connections can share one.
+    juce::String name;
+    /// `websocket` or `mcp`.
+    juce::String transport;
+    juce::int64 connectedAtMs = 0;
+    /// The grant as it stood when this connection was admitted. Shown in the
+    /// settings table; never used to authorise, because a grant revoked since
+    /// then has to take effect on the next request rather than the next
+    /// connection.
+    ScopeSet scopesAtConnect;
+
+    bool operator==(const ConnectedClient&) const = default;
+};
+
+/**
+ * @brief Who has connected, and what the user let them do (#1860).
+ *
+ * One instance per running MAGDA, owned by `RemoteApiHost` and shared by both
+ * transports — the same reason the dispatcher is shared. Two registries would be
+ * two answers to "may this client edit", and the settings UI would be editing
+ * one of them.
+ *
+ * ## Grants outlive connections
+ *
+ * A grant is keyed by the client's normalised name and persists across restarts,
+ * because the alternative is asking the user to re-grant on every launch, which
+ * teaches them to click yes without reading. A connection is per-run state that
+ * exists only to be listed and disconnected.
+ *
+ * Looking a grant up is therefore what happens on *every request*, not at
+ * connect time. That is the whole mechanism behind "revoking a client takes
+ * effect without restart": there is no per-connection copy of the permission to
+ * go stale.
+ *
+ * ## Threading
+ *
+ * Every method is safe from any thread and takes one mutex. Requests arrive on
+ * transport threads and the settings UI edits from the message thread, so this
+ * is not optional.
+ *
+ * `onChanged` is invoked outside the lock, on whichever thread caused the
+ * change. It exists so the host can persist to config and the UI can repaint;
+ * a listener that needs the message thread must hop for itself.
+ */
+class RemoteClientRegistry {
+  public:
+    /// Closes one live connection. Registered by each transport for its own
+    /// connections, and called with a `connectionId` that transport issued.
+    using DisconnectHandler = std::function<bool(const juce::String& connectionId)>;
+
+    RemoteClientRegistry();
+    ~RemoteClientRegistry();
+
+    RemoteClientRegistry(const RemoteClientRegistry&) = delete;
+    RemoteClientRegistry& operator=(const RemoteClientRegistry&) = delete;
+
+    // -----------------------------------------------------------------------
+    // Grants
+    // -----------------------------------------------------------------------
+
+    /**
+     * @brief What `clientName` may do, registering it read-only on first sight.
+     *
+     * The hot path: called once per request by both transports. Registering here
+     * rather than at connect time is what puts a client in the settings list the
+     * moment it asks for anything, including a client that connected before the
+     * user opened the dialog.
+     *
+     * `clientName` is normalised for the caller, so a transport may pass through
+     * whatever the client declared.
+     */
+    ScopeSet scopesFor(const juce::String& clientName);
+
+    /// The same lookup without creating an entry, for a caller that is only
+    /// displaying. Nothing when the name has never been seen.
+    std::optional<ScopeSet> peekScopes(const juce::String& clientName) const;
+
+    /// Grant exactly this set. `read` is forced on: a client that is connected
+    /// at all can read, and a row in the settings table that grants nothing
+    /// would be indistinguishable from one that was never granted.
+    void setScopes(const juce::String& clientName, ScopeSet scopes);
+
+    /// Drop the stored grant. The client reverts to read-only the next time it
+    /// asks for anything; it does not disconnect.
+    void forget(const juce::String& clientName);
+
+    /// Every grant, by name.
+    std::vector<ClientGrant> grants() const;
+
+    // -----------------------------------------------------------------------
+    // Live connections
+    // -----------------------------------------------------------------------
+
+    void noteConnected(ConnectedClient client);
+    void noteDisconnected(const juce::String& connectionId);
+
+    /// Open connections, in connection order.
+    std::vector<ConnectedClient> connections() const;
+    int connectionCount() const;
+
+    /**
+     * @brief Register how to close a transport's connections.
+     *
+     * Keyed by transport name so `disconnect()` can route a connection id to the
+     * server that owns it. Passing an empty handler deregisters, which every
+     * transport must do before it is destroyed.
+     */
+    void setDisconnectHandler(const juce::String& transport, DisconnectHandler handler);
+
+    /// Close one connection. False when the id is not live, or when the
+    /// transport that owns it has already gone away.
+    bool disconnect(const juce::String& connectionId);
+
+    /// Close every connection this client holds. Returns how many were closed.
+    int disconnectClient(const juce::String& clientName);
+
+    // -----------------------------------------------------------------------
+    // Persistence
+    // -----------------------------------------------------------------------
+
+    /// Grants only — connections are per-run and are not written anywhere.
+    juce::var grantsToJson() const;
+
+    /// Replaces every grant. Unknown scope names are dropped rather than
+    /// rejected, so a config from a newer build loads with the scopes this one
+    /// understands instead of failing shut.
+    void loadGrantsFromJson(const juce::var& value);
+
+    /// Called after any grant change, outside the lock. One at a time.
+    void setChangeHandler(std::function<void()> onChanged);
+
+  private:
+    void notifyChanged();
+
+    mutable std::mutex mutex_;
+    /// Ordered so the settings table and the config file are both stable
+    /// between runs rather than reordered by hash seeding.
+    std::map<std::string, ClientGrant> grants_;
+    std::vector<ConnectedClient> connections_;
+    std::map<std::string, DisconnectHandler> disconnectHandlers_;
+
+    std::mutex changeHandlerMutex_;
+    std::function<void()> onChanged_;
+};
+
+}  // namespace remote
+}  // namespace magda

--- a/magda/daw/api/remote_mcp.cpp
+++ b/magda/daw/api/remote_mcp.cpp
@@ -5,6 +5,7 @@
 #include <limits>
 #include <utility>
 
+#include "remote_clients.hpp"
 #include "remote_service.hpp"
 #include "remote_subscriptions.hpp"
 
@@ -147,6 +148,8 @@ int resourceReadCodeFor(ErrorCode code) {
         case ErrorCode::InvalidRequest:
         case ErrorCode::UnknownOperation:
             return MCP_INVALID_PARAMS;
+        case ErrorCode::PermissionDenied:
+            return MCP_PERMISSION_DENIED;
         case ErrorCode::Conflict:
         case ErrorCode::Timeout:
         case ErrorCode::Cancelled:
@@ -820,6 +823,9 @@ void McpEndpoint::readResource(const Call& call, Completion onComplete) {
 std::optional<RequestContext> McpEndpoint::requestContext(const Call& call, McpError& error) const {
     RequestContext context;
     context.clientId = call.clientId;
+    context.clientName = call.clientName;
+    context.transport = TRANSPORT_MCP;
+    context.scopes = call.scopes;
     context.deadline =
         std::chrono::steady_clock::now() + std::chrono::milliseconds(options_.defaultDeadlineMs);
 

--- a/magda/daw/api/remote_mcp.cpp
+++ b/magda/daw/api/remote_mcp.cpp
@@ -141,6 +141,19 @@ juce::var idInput(const char* field, int id) {
  * resource that is not there — `-32002` said that in earlier revisions and is
  * now forbidden to emit — and `-32603` for anything internal.
  */
+/**
+ * @brief Whether a method is answered from the catalogue rather than dispatched.
+ *
+ * These three describe the API surface: what tools exist, what resources exist,
+ * and what their schemas are. They never touch the model, which is why they
+ * return before a `RequestContext` is ever built — and why the scope they need
+ * has to be checked at that point rather than downstream.
+ */
+bool isCatalogueMethod(const juce::String& method) {
+    return method == "tools/list" || method == "resources/list" ||
+           method == "resources/templates/list";
+}
+
 int resourceReadCodeFor(ErrorCode code) {
     switch (code) {
         case ErrorCode::NotFound:
@@ -601,6 +614,24 @@ void McpEndpoint::handle(const Call& call, Completion onComplete) {
             return;
         }
         onComplete(McpReply::ok(initializeResult(call.protocolVersion)));
+        return;
+    }
+
+    // The catalogue methods answer from this object without ever reaching
+    // `requestContext` or the dispatcher, so nothing downstream would check a
+    // scope for them (#1860). Without this they stayed readable with no registry
+    // configured at all, which contradicts the fail-closed rule the rest of the
+    // permission model is built on — and lets a client that may do nothing
+    // enumerate the whole operation surface and its schemas.
+    //
+    // `server/discover` and `initialize` above are deliberately not gated: they
+    // are how a client learns this endpoint exists and negotiates a protocol
+    // version, they carry no catalogue and no project data, and a client that
+    // could not complete a handshake could not be told why it was refused.
+    if (isCatalogueMethod(call.method) && !call.scopes.has(Scope::Read)) {
+        onComplete(McpReply::fail(MCP_PERMISSION_DENIED,
+                                  call.method + " requires the 'read' permission, which this "
+                                                "client has not been granted"));
         return;
     }
 

--- a/magda/daw/api/remote_mcp.hpp
+++ b/magda/daw/api/remote_mcp.hpp
@@ -121,6 +121,11 @@ inline constexpr int MCP_INTERNAL_ERROR = -32603;
 inline constexpr int MCP_HEADER_MISMATCH = -32020;
 inline constexpr int MCP_MISSING_CLIENT_CAPABILITY = -32021;
 inline constexpr int MCP_UNSUPPORTED_PROTOCOL_VERSION = -32022;
+/// A resource read the client's grant does not cover (#1860). Implementation-
+/// defined because MCP has no permission code of its own, and deliberately not
+/// `-32602`: "you may not read this" and "you asked for this wrongly" send a
+/// client to two different places, and only one of them is the settings dialog.
+inline constexpr int MCP_PERMISSION_DENIED = -32023;
 
 // ---------------------------------------------------------------------------
 // Reserved `_meta` keys
@@ -247,6 +252,26 @@ class McpEndpoint {
         McpEra era = McpEra::Modern;
         juce::String protocolVersion;
         juce::String clientId;
+        /**
+         * What the client says it is, normalised — the key its grant is stored
+         * under (#1860).
+         *
+         * This is `clientInfo.name`, and using it at all needs saying, because
+         * the comment above says the specification tells servers not to act on
+         * `clientInfo`. That rule is about *authorisation*: a server must not
+         * decide who may connect from a field the client wrote. It does not,
+         * and here it cannot — admission was the bearer token, before this
+         * struct existed. What the name decides is which of the user's own
+         * grants applies to a caller that is already inside, which is the only
+         * way a user can say "my editor may edit, my monitoring script may not"
+         * about two processes that present the same token.
+         *
+         * `clientId` remains the transport's identifier and is never this.
+         */
+        juce::String clientName;
+        /// What that grant covers, as of this request. Resolved per call by the
+        /// transport, so a revocation applies to the next one.
+        ScopeSet scopes;
         /// Scopes the idempotency key so two clients cannot collide in it. Empty
         /// disables caching for this call — see `requestContext`.
         juce::String idempotencyScope;

--- a/magda/daw/api/remote_mcp_server.cpp
+++ b/magda/daw/api/remote_mcp_server.cpp
@@ -33,6 +33,8 @@
 #include <unordered_map>
 #include <utility>
 
+#include "remote_audit.hpp"
+#include "remote_clients.hpp"
 #include "remote_http_auth.hpp"
 #include "remote_service.hpp"
 #include "remote_subscriptions.hpp"
@@ -159,13 +161,22 @@ juce::String generateSessionId() {
  * resource.
  */
 struct EventStream {
-    EventStream(int outboxCapacity, juce::var streamSubscriptionId)
-        : capacity(outboxCapacity), subscriptionId(std::move(streamSubscriptionId)) {}
+    EventStream(int outboxCapacity, juce::var streamSubscriptionId, juce::String streamHandle,
+                juce::String streamClientName)
+        : capacity(outboxCapacity),
+          subscriptionId(std::move(streamSubscriptionId)),
+          handle(std::move(streamHandle)),
+          clientName(std::move(streamClientName)) {}
 
     enum class Take { Frame, KeepAlive, Closed };
 
     const int capacity;
     const juce::var subscriptionId;
+    /// `mcp:stream:<n>` — what the settings UI disconnects, and what this
+    /// stream is called in the client registry and the audit log.
+    const juce::String handle;
+    /// Normalised declared name of whoever opened it.
+    const juce::String clientName;
 
     mutable std::mutex mutex;
     std::condition_variable ready;
@@ -294,6 +305,11 @@ struct EventStream {
 struct Session {
     juce::String id;
     juce::String protocolVersion;
+    /// Normalised `clientInfo.name` from the `initialize` that created this
+    /// session. Recorded once and reused, because a legacy client sends
+    /// `clientInfo` only in the handshake — re-reading it per request would
+    /// leave every later one anonymous.
+    juce::String clientName;
     std::chrono::steady_clock::time_point lastSeen;
     /// URIs the client has subscribed to, whether or not a stream is attached.
     std::vector<juce::String> subscribedUris;
@@ -328,6 +344,9 @@ struct RemoteMcpServer::Impl {
     std::atomic<int> port{0};
 
     std::atomic<int> inFlight{0};
+    /// Names streams uniquely for this server's lifetime, so the settings UI's
+    /// disconnect cannot address a stream that has already been replaced.
+    std::atomic<juce::uint64> nextStreamId{1};
 
     mutable std::mutex streamMutex;
     std::vector<std::shared_ptr<EventStream>> streams;
@@ -376,6 +395,8 @@ struct RemoteMcpServer::Impl {
                                                httplib::Response& response) {
         if (!isAuthorised(juce::String(request.get_header_value("Authorization")),
                           options.bearerToken)) {
+            // The reason, never the credential.
+            auditRefusal("invalid or missing bearer token");
             response.status = httplib::StatusCode::Unauthorized_401;
             return httplib::Server::HandlerResponse::Handled;
         }
@@ -383,6 +404,7 @@ struct RemoteMcpServer::Impl {
         if (!isOriginAllowed(request.has_header("Origin"),
                              juce::String(request.get_header_value("Origin")),
                              options.allowedOrigins)) {
+            auditRefusal("origin not allowed");
             // The spec allows a JSON-RPC error body with no id here, and one is
             // more use to a developer than a bare 403.
             writeJson(response, httplib::StatusCode::Forbidden_403,
@@ -399,73 +421,200 @@ struct RemoteMcpServer::Impl {
 
     /// Drop sessions nobody has touched. A client is told to DELETE when it is
     /// done; one that crashes never does, and a session holds a subscription.
-    void collectIdleSessionsLocked() {
+    /// Collected ids are returned rather than dropped, so the caller can
+    /// deregister them from the client registry outside the session lock.
+    void collectIdleSessionsLocked(std::vector<juce::String>& collected) {
         const auto now = std::chrono::steady_clock::now();
         const auto limit = std::chrono::seconds(options.sessionIdleSeconds);
         for (auto it = sessions.begin(); it != sessions.end();) {
             const auto attached = it->second.stream != nullptr && !it->second.stream->isClosed();
-            if (!attached && now - it->second.lastSeen > limit)
+            if (!attached && now - it->second.lastSeen > limit) {
+                collected.push_back(it->second.id);
                 it = sessions.erase(it);
-            else
+            } else {
                 ++it;
+            }
         }
     }
 
-    std::optional<juce::String> createSession(const juce::String& version) {
-        const std::lock_guard<std::mutex> lock(sessionMutex);
-        collectIdleSessionsLocked();
-        if (static_cast<int>(sessions.size()) >= options.maxSessions)
-            return std::nullopt;
+    std::optional<juce::String> createSession(const juce::String& version,
+                                              const juce::String& clientName) {
+        std::vector<juce::String> collected;
+        juce::String id;
+        {
+            const std::lock_guard<std::mutex> lock(sessionMutex);
+            collectIdleSessionsLocked(collected);
+            if (static_cast<int>(sessions.size()) >= options.maxSessions) {
+                // Still report the sessions that were just collected, or the
+                // settings list keeps showing connections that have gone.
+                noteSessionsClosed(collected);
+                return std::nullopt;
+            }
 
-        Session session;
-        session.id = generateSessionId();
-        session.protocolVersion = version;
-        session.lastSeen = std::chrono::steady_clock::now();
-        const auto id = session.id;
-        sessions.emplace(id.toStdString(), std::move(session));
+            Session session;
+            session.id = generateSessionId();
+            session.protocolVersion = version;
+            session.clientName = clientName;
+            session.lastSeen = std::chrono::steady_clock::now();
+            id = session.id;
+            sessions.emplace(id.toStdString(), std::move(session));
+        }
+
+        noteSessionsClosed(collected);
+        noteSessionOpen(id, clientName);
         return id;
     }
 
-    /// The negotiated version for a live session, touching its idle clock.
-    std::optional<juce::String> touchSession(const juce::String& id) {
+    /// A live session's negotiated version and client, touching its idle clock.
+    struct SessionState {
+        juce::String protocolVersion;
+        juce::String clientName;
+    };
+
+    std::optional<SessionState> touchSession(const juce::String& id) {
         const std::lock_guard<std::mutex> lock(sessionMutex);
         const auto it = sessions.find(id.toStdString());
         if (it == sessions.end())
             return std::nullopt;
         it->second.lastSeen = std::chrono::steady_clock::now();
-        return it->second.protocolVersion;
+        return SessionState{it->second.protocolVersion, it->second.clientName};
     }
 
     bool deleteSession(const juce::String& id) {
         std::shared_ptr<EventStream> stream;
+        juce::String clientName;
         {
             const std::lock_guard<std::mutex> lock(sessionMutex);
             const auto it = sessions.find(id.toStdString());
             if (it == sessions.end())
                 return false;
             stream = it->second.stream;
+            clientName = it->second.clientName;
             sessions.erase(it);
         }
         // Outside the lock: closing wakes the provider thread, which may be in
         // the middle of taking a frame.
         if (stream != nullptr)
             releaseStream(stream);
+        noteSessionClosed(id, clientName);
         return true;
+    }
+
+    // -----------------------------------------------------------------------
+    // Client registry and audit
+    // -----------------------------------------------------------------------
+
+    /// `mcp:<sessionId>` — the same string `Call::clientId` carries, so the
+    /// audit log, the idempotency cache, and the disconnect button all name a
+    /// session the same way.
+    static juce::String handleForSession(const juce::String& sessionId) {
+        return "mcp:" + sessionId;
+    }
+
+    void noteSessionOpen(const juce::String& sessionId, const juce::String& clientName) {
+        if (options.clients != nullptr) {
+            ConnectedClient record;
+            record.connectionId = handleForSession(sessionId);
+            record.name = clientName;
+            record.transport = TRANSPORT_MCP;
+            record.scopesAtConnect = options.clients->scopesFor(clientName);
+            options.clients->noteConnected(std::move(record));
+        }
+        audit(clientName, handleForSession(sessionId), AUDIT_CONNECTION_OPEN,
+              AuditOutcome::Connected, "session");
+    }
+
+    void noteSessionClosed(const juce::String& sessionId, const juce::String& clientName) {
+        if (options.clients != nullptr)
+            options.clients->noteDisconnected(handleForSession(sessionId));
+        audit(clientName, handleForSession(sessionId), AUDIT_CONNECTION_CLOSE,
+              AuditOutcome::Disconnected, "session");
+    }
+
+    /// Idle collection has no client name to hand — the session is already
+    /// gone — so these are reported without one.
+    void noteSessionsClosed(const std::vector<juce::String>& sessionIds) {
+        for (const auto& id : sessionIds)
+            noteSessionClosed(id, {});
+    }
+
+    void audit(const juce::String& clientName, const juce::String& connectionId,
+               const juce::String& operation, AuditOutcome outcome,
+               const juce::String& detail = {}) const {
+        if (options.audit == nullptr)
+            return;
+        AuditEntry entry;
+        entry.client = clientName;
+        entry.connectionId = connectionId;
+        entry.transport = TRANSPORT_MCP;
+        entry.operation = operation;
+        entry.outcome = outcome;
+        entry.detail = detail;
+        options.audit->record(std::move(entry));
+    }
+
+    void auditRefusal(const juce::String& reason) const {
+        audit({}, {}, AUDIT_CONNECTION_REJECTED, AuditOutcome::Rejected, reason);
+    }
+
+    /**
+     * @brief Close one MCP connection by handle, for the settings UI.
+     *
+     * A session handle drops the session and its stream; a stream handle closes
+     * the stream. Both are prompt — unlike the WebSocket, there is no reader
+     * blocked in a socket to wait for.
+     */
+    bool disconnectByHandle(const juce::String& handle) {
+        std::shared_ptr<EventStream> target;
+        {
+            const std::lock_guard<std::mutex> lock(streamMutex);
+            const auto found = std::find_if(
+                streams.begin(), streams.end(),
+                [&](const std::shared_ptr<EventStream>& s) { return s->handle == handle; });
+            if (found != streams.end())
+                target = *found;
+        }
+        if (target != nullptr) {
+            releaseStream(target);
+            return true;
+        }
+
+        // Not a stream, so it is a session — whose id is the handle minus the
+        // prefix `handleForSession` added.
+        if (!handle.startsWith("mcp:"))
+            return false;
+        return deleteSession(handle.substring(4));
     }
 
     // -----------------------------------------------------------------------
     // Streams
     // -----------------------------------------------------------------------
 
-    std::shared_ptr<EventStream> claimStream(const juce::var& subscriptionId) {
-        const std::lock_guard<std::mutex> lock(streamMutex);
-        if (static_cast<int>(streams.size()) >= options.maxStreams)
-            return nullptr;
-        // Sized against the connection's own reading. Each entry is one short
-        // "re-read this URI" line, so the cap is about how far behind a client
-        // may fall rather than about memory.
-        auto stream = std::make_shared<EventStream>(64, subscriptionId);
-        streams.push_back(stream);
+    std::shared_ptr<EventStream> claimStream(const juce::var& subscriptionId,
+                                             const juce::String& clientName) {
+        std::shared_ptr<EventStream> stream;
+        {
+            const std::lock_guard<std::mutex> lock(streamMutex);
+            if (static_cast<int>(streams.size()) >= options.maxStreams)
+                return nullptr;
+            // Sized against the connection's own reading. Each entry is one
+            // short "re-read this URI" line, so the cap is about how far behind
+            // a client may fall rather than about memory.
+            stream = std::make_shared<EventStream>(
+                64, subscriptionId, "mcp:stream:" + juce::String(nextStreamId.fetch_add(1)),
+                clientName);
+            streams.push_back(stream);
+        }
+
+        if (options.clients != nullptr) {
+            ConnectedClient record;
+            record.connectionId = stream->handle;
+            record.name = clientName;
+            record.transport = TRANSPORT_MCP;
+            record.scopesAtConnect = options.clients->scopesFor(clientName);
+            options.clients->noteConnected(std::move(record));
+        }
+        audit(clientName, stream->handle, AUDIT_CONNECTION_OPEN, AuditOutcome::Connected, "stream");
         return stream;
     }
 
@@ -551,8 +700,15 @@ struct RemoteMcpServer::Impl {
         }
         stream->close();
 
-        const std::lock_guard<std::mutex> lock(streamMutex);
-        streams.erase(std::remove(streams.begin(), streams.end(), stream), streams.end());
+        {
+            const std::lock_guard<std::mutex> lock(streamMutex);
+            streams.erase(std::remove(streams.begin(), streams.end(), stream), streams.end());
+        }
+
+        if (options.clients != nullptr)
+            options.clients->noteDisconnected(stream->handle);
+        audit(stream->clientName, stream->handle, AUDIT_CONNECTION_CLOSE,
+              AuditOutcome::Disconnected, "stream");
     }
 
     /// Attach the response's chunked body to a stream and drain it until the
@@ -608,10 +764,28 @@ struct RemoteMcpServer::Impl {
         McpEra era = McpEra::Modern;
         juce::String version;
         juce::String sessionId;
+        /// Normalised declared name: from `_meta` for a modern request, from
+        /// the session for a legacy one. Never empty — `normaliseClientName`
+        /// answers `unknown` for a caller that said nothing.
+        juce::String clientName;
         /// True when this request created the session, which is the one response
         /// that has to carry `Mcp-Session-Id`.
         bool mintedSession = false;
     };
+
+    /**
+     * @brief The name a modern request declares, from `_meta`.
+     *
+     * Optional in the specification and optional here: a request without it is
+     * `unknown`, which is a client entry like any other rather than a refusal.
+     * Refusing would break every conforming host that simply does not send it.
+     */
+    static juce::String modernClientName(const juce::var& params) {
+        const auto meta = params["_meta"];
+        if (meta.getDynamicObject() == nullptr)
+            return normaliseClientName({});
+        return normaliseClientName(meta[MCP_META_CLIENT_INFO]["name"].toString());
+    }
 
     /**
      * @brief Decide which revision of the protocol this request is speaking.
@@ -635,6 +809,7 @@ struct RemoteMcpServer::Impl {
             if (eraForVersion(declared) == McpEra::Modern) {
                 resolution.era = McpEra::Modern;
                 resolution.version = declared;
+                resolution.clientName = modernClientName(params);
                 return std::nullopt;
             }
             // A legacy version named in `_meta` is a client mixing the two
@@ -645,8 +820,13 @@ struct RemoteMcpServer::Impl {
         if (method == "initialize") {
             resolution.era = McpEra::Legacy;
             resolution.version = negotiateLegacyVersion(params);
-            const auto minted = createSession(resolution.version);
+            // The legacy handshake carries `clientInfo` at the top of `params`
+            // rather than in `_meta`, and carries it exactly once — which is
+            // why the session keeps it.
+            resolution.clientName = normaliseClientName(params["clientInfo"]["name"].toString());
+            const auto minted = createSession(resolution.version, resolution.clientName);
             if (!minted) {
+                auditRefusal("too many open sessions");
                 return McpError{MCP_INTERNAL_ERROR,
                                 "too many open sessions",
                                 {},
@@ -669,7 +849,8 @@ struct RemoteMcpServer::Impl {
                                 httplib::StatusCode::NotFound_404};
             }
             resolution.era = McpEra::Legacy;
-            resolution.version = *known;
+            resolution.version = known->protocolVersion;
+            resolution.clientName = known->clientName;
             resolution.sessionId = header;
             return std::nullopt;
         }
@@ -822,8 +1003,22 @@ struct RemoteMcpServer::Impl {
             return;
         }
 
+        // A stream pushes the same projections the read operations return, so
+        // opening one cannot need less than reading does. Checked here because
+        // this path never reaches the dispatcher.
+        if (!call.scopes.has(Scope::Read)) {
+            audit(call.clientName, call.clientId, call.method, AuditOutcome::Denied,
+                  scopeName(Scope::Read));
+            writeJson(response, httplib::StatusCode::OK_200,
+                      jsonRpcError(id, McpError{MCP_PERMISSION_DENIED,
+                                                "subscriptions/listen requires the 'read' "
+                                                "permission, which this client has not been "
+                                                "granted"}));
+            return;
+        }
+
         const auto filter = endpoint.parseListenFilter(call.params);
-        auto stream = claimStream(id);
+        auto stream = claimStream(id, call.clientName);
         if (stream == nullptr) {
             writeJson(response, httplib::StatusCode::ServiceUnavailable_503,
                       jsonRpcError(id, McpError{MCP_INTERNAL_ERROR,
@@ -909,6 +1104,7 @@ struct RemoteMcpServer::Impl {
 
     void handlePost(const httplib::Request& request, httplib::Response& response) {
         if (!admit()) {
+            auditRefusal("rate limit exceeded");
             writeJson(response, httplib::StatusCode::TooManyRequests_429,
                       jsonRpcError({}, McpError{MCP_INVALID_REQUEST, "Rate limit exceeded"}));
             return;
@@ -1017,11 +1213,18 @@ struct RemoteMcpServer::Impl {
         call.params = params;
         call.era = resolution.era;
         call.protocolVersion = resolution.version;
-        // The transport's own name for the caller. Never `clientInfo`, which is
-        // self-reported and which the specification says not to act on.
-        call.clientId = resolution.sessionId.isNotEmpty() ? "mcp:" + resolution.sessionId
+        // The transport's own name for the caller — never `clientInfo`, which
+        // the specification says not to authorise on, and which this does not:
+        // admission was the bearer token, before any of this ran.
+        call.clientId = resolution.sessionId.isNotEmpty() ? handleForSession(resolution.sessionId)
                                                           : juce::String("mcp:stateless");
         call.idempotencyScope = resolution.sessionId;
+        // The client's own claim, kept separate from the id above, and used for
+        // one thing: choosing which of the user's grants applies (#1860).
+        // Resolved per request so revoking one takes effect on the next.
+        call.clientName = resolution.clientName;
+        call.scopes =
+            options.clients != nullptr ? options.clients->scopesFor(call.clientName) : ScopeSet{};
 
         switch (routeFor(method, resolution.era)) {
             case McpRouting::Stream:
@@ -1054,12 +1257,26 @@ struct RemoteMcpServer::Impl {
             response.status = httplib::StatusCode::MethodNotAllowed_405;
             return;
         }
-        if (!touchSession(sessionId)) {
+        const auto session = touchSession(sessionId);
+        if (!session) {
             response.status = httplib::StatusCode::NotFound_404;
             return;
         }
 
-        auto stream = claimStream({});
+        // The same read gate the modern `subscriptions/listen` path applies. A
+        // bare GET carries no body to answer with, so a client denied here sees
+        // a 403 rather than a JSON-RPC error.
+        const auto scopes = options.clients != nullptr
+                                ? options.clients->scopesFor(session->clientName)
+                                : ScopeSet{};
+        if (!scopes.has(Scope::Read)) {
+            audit(session->clientName, handleForSession(sessionId), "resources.stream",
+                  AuditOutcome::Denied, scopeName(Scope::Read));
+            response.status = httplib::StatusCode::Forbidden_403;
+            return;
+        }
+
+        auto stream = claimStream({}, session->clientName);
         if (stream == nullptr) {
             response.status = httplib::StatusCode::ServiceUnavailable_503;
             return;
@@ -1183,6 +1400,14 @@ bool RemoteMcpServer::start() {
                              impl_->handleDelete(request, response);
                          });
 
+    // Registered before the listener opens and cleared in stop(), so the
+    // settings UI can never route a disconnect to a server that has gone away.
+    if (impl_->options.clients != nullptr) {
+        impl_->options.clients->setDisconnectHandler(
+            TRANSPORT_MCP,
+            [this](const juce::String& handle) { return impl_->disconnectByHandle(handle); });
+    }
+
     // Two different calls, and they are easy to confuse: bind_to_any_port's
     // second parameter is socket flags, not a port.
     const auto address = impl_->options.address.toStdString();
@@ -1213,6 +1438,11 @@ void RemoteMcpServer::stop() {
     if (!impl_->running.exchange(false))
         return;
 
+    // First, so nothing can route a disconnect into a server that is tearing
+    // its streams and sessions down.
+    if (impl_->options.clients != nullptr)
+        impl_->options.clients->setDisconnectHandler(TRANSPORT_MCP, nullptr);
+
     // Streams first. Each is a pool thread parked in its content provider, and
     // closing the outbox is what wakes it — `server.stop()` alone would leave
     // them waiting on a condition variable nobody was going to notify.
@@ -1221,12 +1451,22 @@ void RemoteMcpServer::stop() {
         const std::lock_guard<std::mutex> lock(impl_->streamMutex);
         live = impl_->streams;
     }
+    // `releaseStream` deregisters each from the client registry, so the
+    // settings list empties as the streams close rather than keeping rows for
+    // connections that no longer exist.
     for (const auto& stream : live)
         impl_->releaseStream(stream);
 
     {
-        const std::lock_guard<std::mutex> lock(impl_->sessionMutex);
-        impl_->sessions.clear();
+        std::vector<juce::String> closed;
+        {
+            const std::lock_guard<std::mutex> lock(impl_->sessionMutex);
+            closed.reserve(impl_->sessions.size());
+            for (const auto& [key, session] : impl_->sessions)
+                closed.push_back(session.id);
+            impl_->sessions.clear();
+        }
+        impl_->noteSessionsClosed(closed);
     }
 
     impl_->server.stop();

--- a/magda/daw/api/remote_mcp_server.cpp
+++ b/magda/daw/api/remote_mcp_server.cpp
@@ -557,6 +557,9 @@ struct RemoteMcpServer::Impl {
                const juce::String& detail = {}) const {
         if (options.audit == nullptr)
             return;
+        // Every MCP audit happens on a pool thread inside a live request, so
+        // this one needs no ownership dance — the shared_ptr in `options` is
+        // what keeps the log alive, and nothing here outlives the server.
         AuditEntry entry;
         entry.client = clientName;
         entry.connectionId = connectionId;

--- a/magda/daw/api/remote_mcp_server.hpp
+++ b/magda/daw/api/remote_mcp_server.hpp
@@ -10,6 +10,8 @@ namespace magda {
 namespace remote {
 
 class RemoteApiService;
+class RemoteAuditLog;
+class RemoteClientRegistry;
 class SubscriptionHub;
 
 /**
@@ -71,6 +73,21 @@ class SubscriptionHub;
  * Closing the stream is the cancellation. `Last-Event-ID` resumption is not
  * offered and event ids are not emitted, because a stream of "re-read this URI"
  * has nothing to replay.
+ *
+ * ## Who is connecting
+ *
+ * The client names itself in `clientInfo.name` — in `params._meta` for a modern
+ * request, or in the `initialize` params for a legacy one, where it is recorded
+ * on the session and reused for every later request on it. Normalised, that name
+ * is the key its permissions are stored under (#1860); a request that carries
+ * none is `unknown` and read-only.
+ *
+ * What "connected" means here is narrower than it is over WebSocket, and it has
+ * to be: modern MCP is stateless, so a client that POSTs one tool call has no
+ * connection to list or to disconnect. What the settings UI shows is therefore
+ * the two things that genuinely persist — legacy sessions and open notification
+ * streams. A stateless caller still appears in the client list, with its grant,
+ * because that list is keyed by name rather than by connection.
  *
  * ## Threading
  *
@@ -149,6 +166,19 @@ class RemoteMcpServer {
 
         /// Reported in `server/discover` and `initialize`.
         juce::String serverVersion{"1.0"};
+
+        /**
+         * Where per-client grants are looked up (#1860).
+         *
+         * Null means no permission model, which refuses everything rather than
+         * allowing it: `RequestContext::scopes` defaults to empty. Must outlive
+         * this server.
+         */
+        RemoteClientRegistry* clients = nullptr;
+
+        /// Where connections and refusals are recorded. Null disables auditing
+        /// for this transport. Must outlive this server.
+        RemoteAuditLog* audit = nullptr;
     };
 
     /// `subscriptions` is optional: without one the server does not advertise

--- a/magda/daw/api/remote_mcp_server.hpp
+++ b/magda/daw/api/remote_mcp_server.hpp
@@ -176,9 +176,10 @@ class RemoteMcpServer {
          */
         RemoteClientRegistry* clients = nullptr;
 
-        /// Where connections and refusals are recorded. Null disables auditing
-        /// for this transport. Must outlive this server.
-        RemoteAuditLog* audit = nullptr;
+        /// Where connections and refusals are recorded. Empty disables auditing
+        /// for this transport. Shared ownership, for the same reason the
+        /// WebSocket transport holds it that way.
+        std::shared_ptr<RemoteAuditLog> audit;
     };
 
     /// `subscriptions` is optional: without one the server does not advertise

--- a/magda/daw/api/remote_scopes.cpp
+++ b/magda/daw/api/remote_scopes.cpp
@@ -1,0 +1,144 @@
+#include "remote_scopes.hpp"
+
+#include <algorithm>
+
+namespace magda::remote {
+namespace {
+
+struct ScopeNaming {
+    Scope scope;
+    const char* name;
+};
+
+/// The one table. `scopeName` and `scopeFromName` both read it, so a new scope
+/// cannot be added to one direction and forgotten in the other.
+constexpr ScopeNaming kScopeNames[] = {
+    {Scope::Read, "read"},
+    {Scope::Edit, "edit"},
+    {Scope::Transport, "transport"},
+    {Scope::Session, "session"},
+    {Scope::HardwareMidi, "hardware-midi"},
+};
+
+static_assert(std::size(kScopeNames) == SCOPE_COUNT,
+              "every Scope needs a wire name, and no name may outlive its Scope");
+
+}  // namespace
+
+juce::String scopeName(Scope scope) {
+    for (const auto& entry : kScopeNames) {
+        if (entry.scope == scope)
+            return entry.name;
+    }
+    jassertfalse;  // A Scope with no name, which the static_assert should have caught.
+    return {};
+}
+
+std::optional<Scope> scopeFromName(const juce::String& name) {
+    for (const auto& entry : kScopeNames) {
+        if (name == entry.name)
+            return entry.scope;
+    }
+    return std::nullopt;
+}
+
+const std::vector<Scope>& allScopeValues() {
+    static const std::vector<Scope> values = [] {
+        std::vector<Scope> result;
+        result.reserve(SCOPE_COUNT);
+        for (const auto& entry : kScopeNames)
+            result.push_back(entry.scope);
+        return result;
+    }();
+    return values;
+}
+
+ScopeSet allScopes() {
+    ScopeSet result;
+    for (const auto scope : allScopeValues())
+        result.add(scope);
+    return result;
+}
+
+ScopeSet defaultClientScopes() {
+    return ScopeSet{Scope::Read};
+}
+
+std::vector<juce::String> scopeNames(ScopeSet scopes) {
+    std::vector<juce::String> names;
+    for (const auto scope : allScopeValues()) {
+        if (scopes.has(scope))
+            names.push_back(scopeName(scope));
+    }
+    return names;
+}
+
+juce::var scopesToJson(ScopeSet scopes) {
+    juce::Array<juce::var> array;
+    for (const auto& name : scopeNames(scopes))
+        array.add(name);
+    return array;
+}
+
+ScopeSet scopesFromJson(const juce::var& value) {
+    ScopeSet result;
+    if (const auto* array = value.getArray()) {
+        for (const auto& entry : *array) {
+            if (const auto scope = scopeFromName(entry.toString()))
+                result.add(*scope);
+        }
+    }
+    return result;
+}
+
+juce::String describeScopes(ScopeSet scopes) {
+    const auto names = scopeNames(scopes);
+    if (names.empty())
+        return "none";
+
+    juce::String result;
+    for (std::size_t index = 0; index < names.size(); ++index) {
+        if (index > 0)
+            result += ", ";
+        result += names[index];
+    }
+    return result;
+}
+
+juce::String normaliseClientName(const juce::String& name) {
+    juce::String result;
+    result.preallocateBytes(static_cast<std::size_t>(MAX_CLIENT_NAME_LENGTH));
+
+    // Deliberately a permit-list rather than a strip-list. This string ends up
+    // as a config key, a settings table row, and an audit field, and the set of
+    // characters that are awkward in at least one of those is much larger and
+    // much less obvious than the set that is fine in all three.
+    bool lastWasSeparator = false;
+    for (auto character = name.getCharPointer(); !character.isEmpty(); ++character) {
+        const auto letter = juce::CharacterFunctions::toLowerCase(*character);
+        if (juce::CharacterFunctions::isLetterOrDigit(letter) || letter == '.') {
+            result += letter;
+            lastWasSeparator = false;
+            continue;
+        }
+        // Runs of anything else collapse to one hyphen, and a leading one is
+        // dropped: `Claude Code (v2)` is `claude-code-v2`, not
+        // `claude-code--v2-`.
+        if (!lastWasSeparator && result.isNotEmpty())
+            result += '-';
+        lastWasSeparator = true;
+    }
+
+    while (result.endsWithChar('-'))
+        result = result.dropLastCharacters(1);
+
+    if (result.length() > MAX_CLIENT_NAME_LENGTH) {
+        result = result.substring(0, MAX_CLIENT_NAME_LENGTH);
+        while (result.endsWithChar('-'))
+            result = result.dropLastCharacters(1);
+    }
+
+    return result.isEmpty() ? juce::String(ANONYMOUS_CLIENT) : result;
+}
+
+}  // namespace magda::remote

--- a/magda/daw/api/remote_scopes.hpp
+++ b/magda/daw/api/remote_scopes.hpp
@@ -1,0 +1,199 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <optional>
+#include <vector>
+
+namespace magda {
+namespace remote {
+
+/**
+ * @brief What a remote client is allowed to reach (#1860).
+ *
+ * Five words, shared by every transport, and the whole vocabulary: a grant is a
+ * set of these, an operation requires exactly one of them, and enforcement is a
+ * set-membership test in `RemoteApiService`. Adding a sixth means adding it here
+ * and nowhere else.
+ *
+ * The split is by *what the user would regret*, not by which manager the code
+ * happens to call. Editing the project and driving the transport are separable
+ * because a remote that only starts and stops playback is a thing people
+ * genuinely want, and it must not also be able to delete a track. Session launch
+ * is separate from both because a performance controller firing clips is not
+ * editing anything and is not the timeline transport either.
+ *
+ * ## What these are, and are not
+ *
+ * They are the user's intent about a *named* client, recorded so a well-behaved
+ * one cannot exceed it by accident. They are not a security boundary against a
+ * hostile process on the same machine: admission is the per-run bearer token,
+ * that token lives in a file any process running as the user can read, and the
+ * client's name is self-declared. A caller holding the token can claim any name
+ * and get whatever that name was granted.
+ *
+ * That is a deliberate position rather than an oversight — per-client secrets
+ * would be published in the same readable file and would buy nothing — and it is
+ * documented in `docs/remote-api-permissions.md` so nobody mistakes this for
+ * sandboxing.
+ */
+enum class Scope {
+    /// Read anything the API projects. Every client has this; it is what being
+    /// admitted at all means.
+    Read,
+    /// Change project content: tempo, tracks, clips, notes, devices, racks,
+    /// automation, and the user's selection.
+    Edit,
+    /// Drive the timeline: play, stop, record-arm, loop, seek.
+    Transport,
+    /// Launch and stop session clips and scenes.
+    Session,
+    /**
+     * Reach physical MIDI ports, including SysEx.
+     *
+     * No operation requires this today — the registry exposes no hardware MIDI
+     * surface yet. It is declared now because grants are persisted: a scope
+     * invented later would silently read as "not granted" on every existing
+     * client, which is the correct answer, but only if the word already exists
+     * when those grants are written. It also gives the settings UI a stable
+     * place to show the permission before there is anything behind it.
+     */
+    HardwareMidi,
+};
+
+inline constexpr std::size_t SCOPE_COUNT = 5;
+
+/**
+ * @brief A set of scopes, as bits.
+ *
+ * Small enough to sit in `RequestContext` by value and be compared without
+ * allocating, which matters: a grant is looked up and copied on every single
+ * request so that revoking one takes effect on the next one rather than at the
+ * next restart.
+ */
+class ScopeSet {
+  public:
+    constexpr ScopeSet() = default;
+
+    constexpr ScopeSet(std::initializer_list<Scope> scopes) {
+        for (const auto scope : scopes)
+            add(scope);
+    }
+
+    constexpr ScopeSet& add(Scope scope) {
+        bits_ |= bit(scope);
+        return *this;
+    }
+
+    constexpr ScopeSet& remove(Scope scope) {
+        bits_ &= static_cast<std::uint32_t>(~bit(scope));
+        return *this;
+    }
+
+    constexpr ScopeSet& set(Scope scope, bool granted) {
+        return granted ? add(scope) : remove(scope);
+    }
+
+    constexpr bool has(Scope scope) const {
+        return (bits_ & bit(scope)) != 0;
+    }
+
+    constexpr bool empty() const {
+        return bits_ == 0;
+    }
+
+    /// Whether this grant covers everything `required` asks for.
+    constexpr bool containsAll(ScopeSet required) const {
+        return (bits_ & required.bits_) == required.bits_;
+    }
+
+    constexpr std::uint32_t bits() const {
+        return bits_;
+    }
+
+    /**
+     * @brief Rebuild from a stored bit pattern, discarding bits that name
+     *        nothing.
+     *
+     * The mask is not defensive clutter: these are persisted, and a config file
+     * written by a newer MAGDA — or edited by hand — must not be able to set a
+     * bit this build has no name for and would then carry around as an
+     * unexplainable grant.
+     */
+    static constexpr ScopeSet fromBits(std::uint32_t bits) {
+        ScopeSet result;
+        result.bits_ = bits & ((1u << SCOPE_COUNT) - 1u);
+        return result;
+    }
+
+    friend constexpr bool operator==(ScopeSet, ScopeSet) = default;
+
+  private:
+    static constexpr std::uint32_t bit(Scope scope) {
+        return 1u << static_cast<unsigned>(scope);
+    }
+
+    std::uint32_t bits_ = 0;
+};
+
+/// The wire and config spelling: `read`, `edit`, `transport`, `session`,
+/// `hardware-midi`. Stable — it appears in `system.describe`, in the config
+/// file, and in the audit log.
+juce::String scopeName(Scope scope);
+
+/// The reverse, for config and for anything a client sends. Nothing for a word
+/// this build does not know, which callers must treat as "not granted" rather
+/// than as a reason to fail.
+std::optional<Scope> scopeFromName(const juce::String& name);
+
+/// Every scope, in declaration order.
+const std::vector<Scope>& allScopeValues();
+
+ScopeSet allScopes();
+
+/**
+ * @brief What a client MAGDA has never seen before starts with.
+ *
+ * Read-only, which is #1860's stated default and the only one that makes the
+ * settings UI meaningful: if a new client arrived able to edit, granting would
+ * be something the user did after the damage rather than before it.
+ */
+ScopeSet defaultClientScopes();
+
+std::vector<juce::String> scopeNames(ScopeSet scopes);
+
+/// A JSON array of names, for `system.describe` and the config file.
+juce::var scopesToJson(ScopeSet scopes);
+
+/// The inverse. Unknown names are ignored rather than rejected, so a config
+/// written by a newer build downgrades to the scopes this one understands.
+ScopeSet scopesFromJson(const juce::var& value);
+
+/// `read, edit` — for a log line or a settings row, never for the wire.
+juce::String describeScopes(ScopeSet scopes);
+
+/**
+ * @brief The key a self-declared client name is stored and matched under.
+ *
+ * Trimmed, lowercased, capped, and reduced to a conservative character set, so
+ * `Cursor`, `cursor `, and `cursor` are one client rather than three rows the
+ * user has to grant separately. Anything that survives none of that — an empty
+ * name, or one that was entirely punctuation — becomes `unknown`, which is a
+ * real client entry like any other: it collects every caller that did not
+ * identify itself, and stays read-only until the user says otherwise.
+ */
+juce::String normaliseClientName(const juce::String& name);
+
+/// The bucket for callers that declared nothing.
+inline constexpr const char* ANONYMOUS_CLIENT = "unknown";
+
+/// The longest a normalised client name may be. Names are shown in a settings
+/// table and written to a config file; neither wants an unbounded string a
+/// client chose.
+inline constexpr int MAX_CLIENT_NAME_LENGTH = 64;
+
+}  // namespace remote
+}  // namespace magda

--- a/magda/daw/api/remote_service.cpp
+++ b/magda/daw/api/remote_service.cpp
@@ -162,6 +162,23 @@ void RemoteApiService::dispatch(const juce::String& operationName, const juce::v
     jassert(onComplete != nullptr);
     const auto revision = currentRevision();
 
+    // Every exit from here on is audited, so the record cannot be missing the
+    // requests that failed — which are the ones anybody actually reads it for.
+    // Wrapping rather than calling `record` at each `return` also keeps the
+    // exactly-once callback promise: there is one place that completes.
+    //
+    // The log pointer is captured by value and `this` is not captured at all.
+    // This wrapper travels into work queued on the message thread and runs
+    // *outside* the execution lock — deliberately, so a callback may re-dispatch
+    // — which means it can outlive the service the way any queued completion
+    // can. Reaching back through `this` for the log would be the one place that
+    // survives `shutdown()` and then dereferences a destroyed dispatcher.
+    onComplete = [log = auditLog(), operationName, context,
+                  inner = std::move(onComplete)](Response response) mutable {
+        recordAudit(log, operationName, context, response);
+        inner(std::move(response));
+    };
+
     if (shutdown_.load(std::memory_order_acquire)) {
         onComplete(
             Response::failure(ErrorCode::Cancelled, "remote API service is shut down", revision));
@@ -184,6 +201,24 @@ void RemoteApiService::dispatch(const juce::String& operationName, const juce::v
                                      operationName +
                                          " is handled by the transport, and this transport "
                                          "does not support subscriptions",
+                                     revision));
+        return;
+    }
+
+    // Permission before validation, and before the idempotency cache (#1860).
+    //
+    // Before validation because a client that may not call something has no
+    // business learning the shape of its input — a refusal that varied with
+    // whether the payload was well formed would be an oracle for the schema.
+    //
+    // Before the cache because a cached response is a previous *success*, and
+    // replaying one to a client whose grant has since been revoked would be the
+    // single case where revocation did not take effect immediately.
+    if (!context.scopes.has(operation->requiredScope)) {
+        onComplete(Response::failure(ErrorCode::PermissionDenied,
+                                     operationName + " requires the '" +
+                                         scopeName(operation->requiredScope) +
+                                         "' permission, which this client has not been granted",
                                      revision));
         return;
     }
@@ -466,6 +501,52 @@ ChangeSource& RemoteApiService::changes() {
 
 const ChangeSource& RemoteApiService::changes() const {
     return changes_;
+}
+
+void RemoteApiService::setAuditLog(RemoteAuditLog* log) {
+    audit_.store(log, std::memory_order_release);
+}
+
+RemoteAuditLog* RemoteApiService::auditLog() const {
+    return audit_.load(std::memory_order_acquire);
+}
+
+void RemoteApiService::recordAudit(RemoteAuditLog* log, const juce::String& operationName,
+                                   const RequestContext& context, const Response& response) {
+    if (log == nullptr)
+        return;
+
+    // A request with no declared client is an in-process caller — the
+    // subscription hub projecting a snapshot, or a test. Recording those would
+    // bury the remote traffic the log exists to show under MAGDA talking to
+    // itself.
+    if (context.clientName.isEmpty())
+        return;
+
+    AuditEntry entry;
+    entry.client = context.clientName;
+    entry.connectionId = context.clientId;
+    entry.transport = context.transport;
+    entry.operation = operationName;
+    entry.requestId = context.requestId;
+
+    if (response.ok) {
+        entry.outcome = AuditOutcome::Ok;
+    } else if (response.error.code == ErrorCode::PermissionDenied) {
+        entry.outcome = AuditOutcome::Denied;
+        // The scope that would have allowed it, and nothing else. The client
+        // gets a sentence; the log gets the one word the user would act on.
+        if (const auto* operation = OperationRegistry::instance().find(operationName))
+            entry.detail = scopeName(operation->requiredScope);
+    } else {
+        entry.outcome = AuditOutcome::Failed;
+        // The code, never `response.error.message`: a validation failure's
+        // message quotes the offending value, which is client input and may be
+        // anything at all.
+        entry.detail = toString(response.error.code);
+    }
+
+    log->record(std::move(entry));
 }
 
 void RemoteApiService::setIdempotencyCacheCapacity(std::size_t capacity) {

--- a/magda/daw/api/remote_service.cpp
+++ b/magda/daw/api/remote_service.cpp
@@ -167,12 +167,12 @@ void RemoteApiService::dispatch(const juce::String& operationName, const juce::v
     // Wrapping rather than calling `record` at each `return` also keeps the
     // exactly-once callback promise: there is one place that completes.
     //
-    // The log pointer is captured by value and `this` is not captured at all.
-    // This wrapper travels into work queued on the message thread and runs
-    // *outside* the execution lock — deliberately, so a callback may re-dispatch
-    // — which means it can outlive the service the way any queued completion
-    // can. Reaching back through `this` for the log would be the one place that
-    // survives `shutdown()` and then dereferences a destroyed dispatcher.
+    // The log is captured as an owning `shared_ptr` and `this` is not captured
+    // at all. This wrapper travels into work queued on the message thread and
+    // runs *outside* the execution lock — deliberately, so a callback may
+    // re-dispatch — which means it can outlive not just this service but the
+    // whole host. A borrowed pointer would be dangling by then; ownership is
+    // what makes the write safe rather than merely likely to be.
     onComplete = [log = auditLog(), operationName, context,
                   inner = std::move(onComplete)](Response response) mutable {
         recordAudit(log, operationName, context, response);
@@ -503,16 +503,19 @@ const ChangeSource& RemoteApiService::changes() const {
     return changes_;
 }
 
-void RemoteApiService::setAuditLog(RemoteAuditLog* log) {
-    audit_.store(log, std::memory_order_release);
+void RemoteApiService::setAuditLog(std::shared_ptr<RemoteAuditLog> log) {
+    const std::lock_guard<std::mutex> lock(auditMutex_);
+    audit_ = std::move(log);
 }
 
-RemoteAuditLog* RemoteApiService::auditLog() const {
-    return audit_.load(std::memory_order_acquire);
+std::shared_ptr<RemoteAuditLog> RemoteApiService::auditLog() const {
+    const std::lock_guard<std::mutex> lock(auditMutex_);
+    return audit_;
 }
 
-void RemoteApiService::recordAudit(RemoteAuditLog* log, const juce::String& operationName,
-                                   const RequestContext& context, const Response& response) {
+void RemoteApiService::recordAudit(const std::shared_ptr<RemoteAuditLog>& log,
+                                   const juce::String& operationName, const RequestContext& context,
+                                   const Response& response) {
     if (log == nullptr)
         return;
 

--- a/magda/daw/api/remote_service.hpp
+++ b/magda/daw/api/remote_service.hpp
@@ -176,13 +176,16 @@ class RemoteApiService {
     /**
      * @brief Where every dispatched request is recorded (#1860).
      *
-     * Optional and null by default, so a test or a headless host pays nothing
+     * Optional and empty by default, so a test or a headless host pays nothing
      * for it. Set once, by `RemoteApiHost`, before any transport starts.
      *
-     * The log must outlive this service *and any work queued against it* — a
-     * dispatch completion carries the pointer and may run after `shutdown()`.
-     * `RemoteApiHost` guarantees that by declaring the log before the service,
-     * so it is the last of the two destroyed.
+     * Shared ownership rather than a borrowed pointer, and that is not
+     * defensive: a dispatch completion carries the log and runs on the message
+     * thread, so it can still be queued when the host is destroyed and run
+     * afterwards. Declaring the log before the service only orders destruction
+     * *within* the host — it cannot help work that outlives the whole
+     * destructor. Holding a `shared_ptr` keeps the log alive for exactly as long
+     * as something might still write to it.
      *
      * Auditing here rather than in each adapter is the same argument as
      * enforcing scopes here: two transports would otherwise produce two
@@ -191,8 +194,8 @@ class RemoteApiService {
      * this cannot see — connections opening, closing, and being refused before
      * they became requests.
      */
-    void setAuditLog(RemoteAuditLog* log);
-    RemoteAuditLog* auditLog() const;
+    void setAuditLog(std::shared_ptr<RemoteAuditLog> log);
+    std::shared_ptr<RemoteAuditLog> auditLog() const;
 
   private:
     struct CachedResponse {
@@ -239,8 +242,9 @@ class RemoteApiService {
      * queue after `shutdown()`. Touching a member from there is the one way an
      * audit line could dereference a destroyed dispatcher.
      */
-    static void recordAudit(RemoteAuditLog* log, const juce::String& operationName,
-                            const RequestContext& context, const Response& response);
+    static void recordAudit(const std::shared_ptr<RemoteAuditLog>& log,
+                            const juce::String& operationName, const RequestContext& context,
+                            const Response& response);
 
     std::shared_ptr<ExecutionState> currentState() const;
     void retireState();
@@ -275,9 +279,11 @@ class RemoteApiService {
     std::vector<CachedResponse> cache_;
     std::size_t cacheCapacity_ = 256;
 
-    /// Set before the transports start and never afterwards, so reading it on a
-    /// transport thread needs no lock beyond the atomic itself.
-    std::atomic<RemoteAuditLog*> audit_{nullptr};
+    /// Set before the transports start and cleared on the way out. Guarded
+    /// rather than atomic because it is a `shared_ptr`: the point is that a
+    /// reader takes an owning copy, which an atomic pointer cannot give it.
+    mutable std::mutex auditMutex_;
+    std::shared_ptr<RemoteAuditLog> audit_;
 };
 
 }  // namespace remote

--- a/magda/daw/api/remote_service.hpp
+++ b/magda/daw/api/remote_service.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "remote_api.hpp"
+#include "remote_audit.hpp"
 #include "remote_changes.hpp"
 
 namespace magda {
@@ -172,6 +173,27 @@ class RemoteApiService {
     /// Idempotency cache capacity, in completed write responses.
     void setIdempotencyCacheCapacity(std::size_t capacity);
 
+    /**
+     * @brief Where every dispatched request is recorded (#1860).
+     *
+     * Optional and null by default, so a test or a headless host pays nothing
+     * for it. Set once, by `RemoteApiHost`, before any transport starts.
+     *
+     * The log must outlive this service *and any work queued against it* — a
+     * dispatch completion carries the pointer and may run after `shutdown()`.
+     * `RemoteApiHost` guarantees that by declaring the log before the service,
+     * so it is the last of the two destroyed.
+     *
+     * Auditing here rather than in each adapter is the same argument as
+     * enforcing scopes here: two transports would otherwise produce two
+     * differently-shaped records of the same operation, and a third would
+     * produce none until someone noticed. What the adapters do record is what
+     * this cannot see — connections opening, closing, and being refused before
+     * they became requests.
+     */
+    void setAuditLog(RemoteAuditLog* log);
+    RemoteAuditLog* auditLog() const;
+
   private:
     struct CachedResponse {
         juce::String key;
@@ -205,6 +227,21 @@ class RemoteApiService {
     Response execute(const OperationDescriptor& operation, const juce::var& input,
                      const RequestContext& context);
 
+    /**
+     * @brief One audit line for a completed dispatch.
+     *
+     * Records nothing when `log` is null, and nothing about the request's input
+     * or its result either way.
+     *
+     * Static, and takes the log rather than reading `audit_`, because the
+     * completion that calls it can outlive this object: it is invoked outside
+     * the execution lock, from work that may still be sitting in the message
+     * queue after `shutdown()`. Touching a member from there is the one way an
+     * audit line could dereference a destroyed dispatcher.
+     */
+    static void recordAudit(RemoteAuditLog* log, const juce::String& operationName,
+                            const RequestContext& context, const Response& response);
+
     std::shared_ptr<ExecutionState> currentState() const;
     void retireState();
 
@@ -237,6 +274,10 @@ class RemoteApiService {
     mutable std::mutex cacheMutex_;
     std::vector<CachedResponse> cache_;
     std::size_t cacheCapacity_ = 256;
+
+    /// Set before the transports start and never afterwards, so reading it on a
+    /// transport thread needs no lock beyond the atomic itself.
+    std::atomic<RemoteAuditLog*> audit_{nullptr};
 };
 
 }  // namespace remote

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -33,6 +33,8 @@
 #include <thread>
 #include <utility>
 
+#include "remote_audit.hpp"
+#include "remote_clients.hpp"
 #include "remote_http_auth.hpp"
 #include "remote_service.hpp"
 #include "remote_subscriptions.hpp"
@@ -94,6 +96,10 @@ constexpr int kConflict = -32002;
 constexpr int kTimeout = -32003;
 constexpr int kCancelled = -32004;
 constexpr int kTooManyRequests = -32005;
+/// Refused by the client's grant (#1860). Its own code rather than one of the
+/// standard four, because a client should be able to tell "ask the user to grant
+/// this" apart from "I sent something wrong" without parsing a message.
+constexpr int kPermissionDenied = -32006;
 
 /**
  * MAGDA's error taxonomy onto JSON-RPC's.
@@ -110,6 +116,8 @@ int jsonRpcCodeFor(ErrorCode code) {
             return kInvalidRequest;
         case ErrorCode::UnknownOperation:
             return kMethodNotFound;
+        case ErrorCode::PermissionDenied:
+            return kPermissionDenied;
         case ErrorCode::ValidationFailed:
             return kInvalidParams;
         case ErrorCode::NotFound:
@@ -244,10 +252,12 @@ juce::String idempotencyKeyFor(const juce::var& id) {
  * its payload rather than reaching for a stack frame that has returned.
  */
 struct Connection {
-    Connection(httplib::ws::WebSocket& webSocket, int identifier, int maxQueued, int maxEvents,
-               double burst)
+    Connection(httplib::ws::WebSocket& webSocket, int identifier, juce::String handleId,
+               juce::String declaredName, int maxQueued, int maxEvents, double burst)
         : socket(webSocket),
           id(identifier),
+          handle(std::move(handleId)),
+          clientName(std::move(declaredName)),
           maxQueuedReplies(maxQueued),
           maxQueuedEvents(maxEvents),
           tokens(burst),
@@ -255,6 +265,13 @@ struct Connection {
 
     httplib::ws::WebSocket& socket;
     const int id;
+    /// `ws:<generation>:<id>` — this connection's name in the idempotency
+    /// cache, the client registry, and the audit log. Computed once so those
+    /// three cannot drift apart.
+    const juce::String handle;
+    /// Normalised, from the upgrade query string. Never empty: an absent or
+    /// unusable name becomes `unknown`.
+    const juce::String clientName;
     const int maxQueuedReplies;
     const int maxQueuedEvents;
 
@@ -458,6 +475,62 @@ struct RemoteWebSocketServer::Impl {
         return static_cast<int>(live.size());
     }
 
+    /// One audit line about a connection. The dispatcher records the operations
+    /// it ran; this records what it never saw — refusals, and the subscription
+    /// methods the hub answers without going through it.
+    void audit(const std::shared_ptr<Connection>& connection, const juce::String& operation,
+               const juce::String& requestId, AuditOutcome outcome,
+               const juce::String& detail = {}) const {
+        if (options.audit == nullptr)
+            return;
+        AuditEntry entry;
+        entry.client = connection != nullptr ? connection->clientName : juce::String();
+        entry.connectionId = connection != nullptr ? connection->handle : juce::String();
+        entry.transport = TRANSPORT_WEBSOCKET;
+        entry.operation = operation;
+        entry.requestId = requestId;
+        entry.outcome = outcome;
+        entry.detail = detail;
+        options.audit->record(std::move(entry));
+    }
+
+    /// A refusal that happened before there was a connection to attribute it to.
+    void auditRefusal(const juce::String& reason) const {
+        if (options.audit == nullptr)
+            return;
+        AuditEntry entry;
+        entry.transport = TRANSPORT_WEBSOCKET;
+        entry.operation = AUDIT_CONNECTION_REJECTED;
+        entry.outcome = AuditOutcome::Rejected;
+        entry.detail = reason;
+        options.audit->record(std::move(entry));
+    }
+
+    /**
+     * @brief Close one connection by handle, for the settings UI's disconnect.
+     *
+     * Marking is all that is available and all that is needed. The reader owns
+     * the socket, so no other thread may close it; but `markClosed` empties the
+     * outbox and the read loop tests it after every read, so from this instant
+     * no further request from that client executes. The socket itself goes
+     * within one read timeout.
+     */
+    bool disconnectByHandle(const juce::String& handle) {
+        std::shared_ptr<Connection> target;
+        {
+            const std::lock_guard<std::mutex> lock(liveMutex);
+            const auto found =
+                std::find_if(live.begin(), live.end(), [&](const std::shared_ptr<Connection>& c) {
+                    return c->handle == handle;
+                });
+            if (found == live.end())
+                return false;
+            target = *found;
+        }
+        target->markClosed();
+        return true;
+    }
+
     /**
      * @brief Claim a slot and register, or refuse — as one indivisible step.
      *
@@ -496,6 +569,10 @@ struct RemoteWebSocketServer::Impl {
                                                httplib::Response& response) {
         if (!isAuthorised(juce::String(request.get_header_value("Authorization")),
                           options.bearerToken)) {
+            // The reason, never the credential. `redactSecrets` would mask a
+            // `Bearer …` value anyway; not building the string in the first
+            // place is the version that cannot be got wrong later.
+            auditRefusal("invalid or missing bearer token");
             response.status = httplib::StatusCode::Unauthorized_401;
             return httplib::Server::HandlerResponse::Handled;
         }
@@ -506,6 +583,7 @@ struct RemoteWebSocketServer::Impl {
         if (!isOriginAllowed(request.has_header("Origin"),
                              juce::String(request.get_header_value("Origin")),
                              options.allowedOrigins)) {
+            auditRefusal("origin not allowed");
             response.status = httplib::StatusCode::Forbidden_403;
             return httplib::Server::HandlerResponse::Handled;
         }
@@ -516,6 +594,7 @@ struct RemoteWebSocketServer::Impl {
         // leaked. Reserving here would mean handing a slot to a request that
         // several cpp-httplib paths never deliver to a handler.
         if (connectionCount() >= options.maxConnections) {
+            auditRefusal("connection limit reached");
             response.status = httplib::StatusCode::ServiceUnavailable_503;
             return httplib::Server::HandlerResponse::Handled;
         }
@@ -604,12 +683,33 @@ struct RemoteWebSocketServer::Impl {
             return;
         }
 
+        // Looked up per request, never cached on the connection. That is the
+        // whole of "revoking a client takes effect without restart": there is no
+        // copy of the grant to go stale between here and the settings dialog.
+        const auto scopes = options.clients != nullptr
+                                ? options.clients->scopesFor(connection->clientName)
+                                : ScopeSet{};
+
         // Answered here rather than by the dispatcher: what a connection watches
         // is state only the connection has. The names and schemas still come
         // from the shared registry, which the hub validates against. The hub
         // makes its own hop to the message thread for the part that reads the
         // model, so this completes the same way a dispatch does.
         if (SubscriptionHub::isSubscriptionMethod(method)) {
+            // Checked here because the hub is reached without going through the
+            // dispatcher, so nothing else would check it. A subscription pushes
+            // the same projections the read operations return, and it would be a
+            // strange permission model where a client denied `tracks.list` could
+            // subscribe to `tracks` and be sent the answer anyway.
+            if (!scopes.has(Scope::Read)) {
+                audit(connection, method, idKey, AuditOutcome::Denied, scopeName(Scope::Read));
+                connection->complete(replyFor(
+                    id, Response::failure(ErrorCode::PermissionDenied,
+                                          method + " requires the 'read' permission, which this "
+                                                   "client has not been granted",
+                                          service.currentRevision())));
+                return;
+            }
             if (subscriptions == nullptr) {
                 connection->complete(
                     replyFor(id, Response::failure(ErrorCode::InvalidRequest,
@@ -618,15 +718,21 @@ struct RemoteWebSocketServer::Impl {
                 return;
             }
             subscriptions->handle(connection->subscriber, method, params,
-                                  [connection, id](Response response) {
+                                  [this, connection, id, method, idKey](Response response) {
+                                      audit(connection, method, idKey,
+                                            response.ok ? AuditOutcome::Ok : AuditOutcome::Failed,
+                                            response.ok ? juce::String()
+                                                        : toString(response.error.code));
                                       connection->complete(replyFor(id, response));
                                   });
             return;
         }
 
         RequestContext context;
-        context.clientId =
-            "ws:" + juce::String(listenerGeneration) + ":" + juce::String(connection->id);
+        context.clientId = connection->handle;
+        context.clientName = connection->clientName;
+        context.transport = TRANSPORT_WEBSOCKET;
+        context.scopes = scopes;
         // Scoped by connection so two clients reusing id 1 do not collide in the
         // dispatcher's idempotency cache, and typed so that one client's numeric
         // 1 and string "1" — different requests under JSON-RPC — cannot either.
@@ -677,17 +783,36 @@ struct RemoteWebSocketServer::Impl {
      * Runs on a thread cpp-httplib owns. The writer thread it starts is joined
      * before this returns, because `socket` lives on this stack frame.
      */
-    void runConnection(httplib::ws::WebSocket& socket) {
+    void runConnection(httplib::ws::WebSocket& socket, const juce::String& declaredName) {
+        const auto identifier = nextConnectionId.fetch_add(1);
+        const auto handle =
+            "ws:" + juce::String(listenerGeneration) + ":" + juce::String(identifier);
+
         auto connection = std::make_shared<Connection>(
-            socket, nextConnectionId.fetch_add(1), options.maxQueuedRepliesPerConnection,
-            options.maxQueuedEventsPerConnection, options.maxInFlightPerConnection);
+            socket, identifier, handle, normaliseClientName(declaredName),
+            options.maxQueuedRepliesPerConnection, options.maxQueuedEventsPerConnection,
+            options.maxInFlightPerConnection);
 
         if (!registerConnection(connection)) {
             // Lost a race for the last slot. Closing from here is safe because
             // this is the connection's own thread, the only one allowed to read.
+            auditRefusal("connection limit reached");
             socket.close(httplib::ws::CloseStatus::PolicyViolation, "connection limit reached");
             return;
         }
+
+        if (options.clients != nullptr) {
+            ConnectedClient record;
+            record.connectionId = connection->handle;
+            record.name = connection->clientName;
+            record.transport = TRANSPORT_WEBSOCKET;
+            // Registers the client if this is the first MAGDA has heard of it,
+            // so it appears in the settings list — read-only — the moment it
+            // connects rather than only once it asks for something.
+            record.scopesAtConnect = options.clients->scopesFor(connection->clientName);
+            options.clients->noteConnected(std::move(record));
+        }
+        audit(connection, AUDIT_CONNECTION_OPEN, {}, AuditOutcome::Connected);
 
         // The hub holds the connection alive for as long as it is registered,
         // which costs nothing: `Connection` refers to the socket but never
@@ -767,6 +892,10 @@ struct RemoteWebSocketServer::Impl {
             const std::lock_guard<std::mutex> lock(liveMutex);
             live.erase(std::remove(live.begin(), live.end(), connection), live.end());
         }
+
+        if (options.clients != nullptr)
+            options.clients->noteDisconnected(connection->handle);
+        audit(connection, AUDIT_CONNECTION_CLOSE, {}, AuditOutcome::Disconnected);
     }
 };
 
@@ -807,9 +936,23 @@ bool RemoteWebSocketServer::start() {
     // this design exists to avoid. A dead peer is caught by the read timeout.
     impl_->server.set_websocket_ping_interval(kPingIntervalSeconds);
 
-    impl_->server.WebSocket(kEndpoint, [this](const httplib::Request&, httplib::ws::WebSocket& ws) {
-        impl_->runConnection(ws);
-    });
+    // `?client=<name>` is how a client says who it is (#1860). Read here rather
+    // than from a first message so the connection can be listed and attributed
+    // from the moment it opens — including one that connects and then says
+    // nothing, which is exactly the connection a user wants to see and be able
+    // to drop.
+    impl_->server.WebSocket(
+        kEndpoint, [this](const httplib::Request& request, httplib::ws::WebSocket& ws) {
+            impl_->runConnection(ws, juce::String(request.get_param_value("client")));
+        });
+
+    // Registered before the listener opens and cleared in stop(), so the
+    // settings UI can never route a disconnect to a server that has gone away.
+    if (impl_->options.clients != nullptr) {
+        impl_->options.clients->setDisconnectHandler(
+            TRANSPORT_WEBSOCKET,
+            [this](const juce::String& handle) { return impl_->disconnectByHandle(handle); });
+    }
 
     // Two different calls, and they are easy to confuse: bind_to_any_port's
     // second parameter is socket flags, not a port, so passing a configured port
@@ -841,6 +984,11 @@ bool RemoteWebSocketServer::start() {
 void RemoteWebSocketServer::stop() {
     if (!impl_->running.exchange(false))
         return;
+
+    // First, so nothing can route a disconnect into a server that is tearing
+    // its connections down.
+    if (impl_->options.clients != nullptr)
+        impl_->options.clients->setDisconnectHandler(TRANSPORT_WEBSOCKET, nullptr);
 
     // Only mark the connections; do not touch their sockets. `close()` writes a
     // Close frame and then reads, waiting for the peer's echo, so calling it

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -447,6 +447,40 @@ struct Connection {
     }
 };
 
+namespace {
+
+/**
+ * @brief One audit line, written through a log pointer rather than a server.
+ *
+ * Free rather than a member of `Impl`, so a completion that outlives this
+ * server can still record without reaching back through it. The subscription
+ * hub answers on the message thread, so a reply can be produced after `stop()`
+ * — during a token rotation, say — has destroyed the server that queued it.
+ * That is the same shape `RemoteApiService` completions have, and the same
+ * reason they carry the log by value.
+ *
+ * `connection` is a `shared_ptr`, so the client fields stay valid regardless.
+ * The log's lifetime is `RemoteApiHost`'s to guarantee: it declares the log
+ * before both transports, so it is destroyed after them.
+ */
+void recordAudit(RemoteAuditLog* log, const std::shared_ptr<Connection>& connection,
+                 const juce::String& operation, const juce::String& requestId, AuditOutcome outcome,
+                 const juce::String& detail) {
+    if (log == nullptr)
+        return;
+    AuditEntry entry;
+    entry.client = connection != nullptr ? connection->clientName : juce::String();
+    entry.connectionId = connection != nullptr ? connection->handle : juce::String();
+    entry.transport = TRANSPORT_WEBSOCKET;
+    entry.operation = operation;
+    entry.requestId = requestId;
+    entry.outcome = outcome;
+    entry.detail = detail;
+    log->record(std::move(entry));
+}
+
+}  // namespace
+
 // ===========================================================================
 // Impl
 // ===========================================================================
@@ -481,17 +515,7 @@ struct RemoteWebSocketServer::Impl {
     void audit(const std::shared_ptr<Connection>& connection, const juce::String& operation,
                const juce::String& requestId, AuditOutcome outcome,
                const juce::String& detail = {}) const {
-        if (options.audit == nullptr)
-            return;
-        AuditEntry entry;
-        entry.client = connection != nullptr ? connection->clientName : juce::String();
-        entry.connectionId = connection != nullptr ? connection->handle : juce::String();
-        entry.transport = TRANSPORT_WEBSOCKET;
-        entry.operation = operation;
-        entry.requestId = requestId;
-        entry.outcome = outcome;
-        entry.detail = detail;
-        options.audit->record(std::move(entry));
+        recordAudit(options.audit, connection, operation, requestId, outcome, detail);
     }
 
     /// A refusal that happened before there was a connection to attribute it to.
@@ -717,14 +741,18 @@ struct RemoteWebSocketServer::Impl {
                                                    service.currentRevision())));
                 return;
             }
-            subscriptions->handle(connection->subscriber, method, params,
-                                  [this, connection, id, method, idKey](Response response) {
-                                      audit(connection, method, idKey,
-                                            response.ok ? AuditOutcome::Ok : AuditOutcome::Failed,
-                                            response.ok ? juce::String()
-                                                        : toString(response.error.code));
-                                      connection->complete(replyFor(id, response));
-                                  });
+            // The log by value, never `this`: the hub completes on the message
+            // thread, so this can run after `stop()` has destroyed the server —
+            // during a token rotation, which tears both listeners down while
+            // connections are live. Everything else it needs is copied.
+            subscriptions->handle(
+                connection->subscriber, method, params,
+                [log = options.audit, connection, id, method, idKey](Response response) {
+                    recordAudit(log, connection, method, idKey,
+                                response.ok ? AuditOutcome::Ok : AuditOutcome::Failed,
+                                response.ok ? juce::String() : toString(response.error.code));
+                    connection->complete(replyFor(id, response));
+                });
             return;
         }
 

--- a/magda/daw/api/remote_websocket_server.cpp
+++ b/magda/daw/api/remote_websocket_server.cpp
@@ -459,13 +459,14 @@ namespace {
  * That is the same shape `RemoteApiService` completions have, and the same
  * reason they carry the log by value.
  *
- * `connection` is a `shared_ptr`, so the client fields stay valid regardless.
- * The log's lifetime is `RemoteApiHost`'s to guarantee: it declares the log
- * before both transports, so it is destroyed after them.
+ * `connection` is a `shared_ptr` so the client fields stay valid regardless,
+ * and the log is one too: declaration order inside the host would only order
+ * destruction *within* it, which is no help to a completion that runs after the
+ * whole host has gone. Owning a share keeps the log alive exactly that long.
  */
-void recordAudit(RemoteAuditLog* log, const std::shared_ptr<Connection>& connection,
-                 const juce::String& operation, const juce::String& requestId, AuditOutcome outcome,
-                 const juce::String& detail) {
+void recordAudit(const std::shared_ptr<RemoteAuditLog>& log,
+                 const std::shared_ptr<Connection>& connection, const juce::String& operation,
+                 const juce::String& requestId, AuditOutcome outcome, const juce::String& detail) {
     if (log == nullptr)
         return;
     AuditEntry entry;

--- a/magda/daw/api/remote_websocket_server.hpp
+++ b/magda/daw/api/remote_websocket_server.hpp
@@ -244,10 +244,13 @@ class RemoteWebSocketServer {
          */
         RemoteClientRegistry* clients = nullptr;
 
-        /// Where connections and refusals are recorded. Null disables auditing
-        /// for this transport; the dispatcher's own record is separate. Must
-        /// outlive this server.
-        RemoteAuditLog* audit = nullptr;
+        /// Where connections and refusals are recorded. Empty disables auditing
+        /// for this transport; the dispatcher's own record is separate.
+        ///
+        /// Shared ownership, because a subscription completion carries it onto
+        /// the message thread and can run after this server — and after the
+        /// whole host — is gone.
+        std::shared_ptr<RemoteAuditLog> audit;
     };
 
     /// `subscriptions` is optional: without one the four `subscriptions.*`

--- a/magda/daw/api/remote_websocket_server.hpp
+++ b/magda/daw/api/remote_websocket_server.hpp
@@ -10,6 +10,8 @@ namespace magda {
 namespace remote {
 
 class RemoteApiService;
+class RemoteAuditLog;
+class RemoteClientRegistry;
 class SubscriptionHub;
 
 /**
@@ -76,6 +78,27 @@ class SubscriptionHub;
  * Events share the reply queue, so a mutation's reply and the event describing
  * it arrive in the order they were produced, but they hold a separate budget:
  * see `Options::maxQueuedEventsPerConnection`.
+ *
+ * ## Who is connecting
+ *
+ * A client names itself in the upgrade request's query string:
+ *
+ *     ws://127.0.0.1:51734/rpc?client=cursor
+ *
+ * The name is normalised and becomes the key its permissions are stored under
+ * (#1860). A client that sends none is `unknown`, which is a real entry rather
+ * than a rejection — it collects every anonymous caller and stays read-only
+ * until the user says otherwise.
+ *
+ * The query string, rather than a header or a first message: it survives every
+ * WebSocket client library without one needing to support custom headers on the
+ * handshake, it is available before the 101 so the connection can be listed the
+ * moment it opens, and it costs a client one URL parameter.
+ *
+ * This is a claim, not a credential. Admission is the bearer token; the name
+ * only decides which of the user's grants applies. A caller holding the token
+ * can claim any name, which is not a hole this transport could close — the token
+ * is in a file every process running as the user can read.
  *
  * ## Threading
  *
@@ -206,6 +229,25 @@ class RemoteWebSocketServer {
         /// How long a request may wait before the dispatcher abandons it. A
         /// client may ask for less via `meta.deadlineMs`, never for more.
         int defaultDeadlineMs = 10'000;
+
+        /**
+         * Where per-client grants are looked up, and where live connections are
+         * listed for the settings UI (#1860).
+         *
+         * Null means no permission model, which is *not* the same as full
+         * access: `RequestContext::scopes` defaults to empty, so a server
+         * configured without a registry refuses every operation. That is the
+         * intended reading of "disabled means disabled" — a transport with
+         * nothing to consult cannot be the one that decides to allow.
+         *
+         * Must outlive this server.
+         */
+        RemoteClientRegistry* clients = nullptr;
+
+        /// Where connections and refusals are recorded. Null disables auditing
+        /// for this transport; the dispatcher's own record is separate. Must
+        /// outlive this server.
+        RemoteAuditLog* audit = nullptr;
     };
 
     /// `subscriptions` is optional: without one the four `subscriptions.*`

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -228,6 +228,11 @@ void Config::save() {
         for (const auto& origin : remoteApiAllowedOrigins)
             originArray.add(toJuceString(origin));
         remoteObj->setProperty("allowedOrigins", originArray);
+        // Per-client grants (#1860). Written only once something has been
+        // granted, so an install that never used the remote API keeps a config
+        // file without an empty array in it.
+        if (remoteApiClients.isArray() && remoteApiClients.getArray()->size() > 0)
+            remoteObj->setProperty("clients", remoteApiClients);
         root->setProperty("remoteApi", juce::var(remoteObj));
     }
 
@@ -700,6 +705,9 @@ void Config::load() {
             if (const auto* origins = remoteObj->getProperty("allowedOrigins").getArray())
                 for (const auto& origin : *origins)
                     remoteApiAllowedOrigins.push_back(origin.toString().toStdString());
+            // Passed through untouched; `RemoteClientRegistry` owns the shape
+            // and drops anything it does not recognise.
+            remoteApiClients = remoteObj->getProperty("clients");
         }
     }
     recentProjects = getStringArray("recentProjects");

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -472,6 +472,26 @@ class Config {
     void setRemoteApiAllowedOrigins(const std::vector<std::string>& origins) {
         remoteApiAllowedOrigins = origins;
     }
+    /**
+     * Per-client permission grants (issue #1860), as the JSON array
+     * `RemoteClientRegistry` reads and writes.
+     *
+     * Stored opaquely rather than as typed fields, because the shape belongs to
+     * the registry and the scope vocabulary is its to extend. Config's job here
+     * is to persist and return it unchanged.
+     *
+     * A missing entry is not a permission — it is the absence of one, and a
+     * client MAGDA has not seen starts read-only. So there is nothing dangerous
+     * about this array being absent, hand-edited, or copied between machines:
+     * the worst it can do is grant a name the user already chose to grant, and
+     * the token that lets anyone use it is not in here.
+     */
+    const juce::var& getRemoteApiClients() const {
+        return remoteApiClients;
+    }
+    void setRemoteApiClients(juce::var clients) {
+        remoteApiClients = std::move(clients);
+    }
 
     // Browser filter settings
     bool getBrowserFilterAudio() const {
@@ -1357,6 +1377,10 @@ class Config {
     int remoteApiPort = 0;     // 0 = ephemeral; the token file carries the real one
     int remoteApiMcpPort = 0;  // likewise, for the MCP endpoint (#1858)
     std::vector<std::string> remoteApiAllowedOrigins;
+    /// Array of `{name, scopes, firstSeenMs, lastSeenMs}` — see #1860. Void
+    /// until something writes one, which reads as "no client has been granted
+    /// anything yet".
+    juce::var remoteApiClients;
 
     // Export audio settings
     std::string exportFormat = "WAV24";  // WAV16, WAV24, WAV32, FLAC

--- a/magda/daw/magda_daw_main.cpp
+++ b/magda/daw/magda_daw_main.cpp
@@ -14,6 +14,7 @@
 #include "../../magda/agents/llm_presets.hpp"
 #include "api/magda_api_live.hpp"
 #include "api/remote_api_host.hpp"
+#include "api/remote_audit.hpp"
 #include "audio/AudioBridge.hpp"
 #include "audio/AudioThumbnailManager.hpp"
 #include "core/AppPaths.hpp"
@@ -354,9 +355,13 @@ class MagdaDAWApplication : public JUCEApplication {
         // remote API touches it.
         remoteApi_ = std::make_unique<magda::remote::RemoteApiHost>(daw_engine_->getMagdaApi(),
                                                                     daw_engine_.get());
-        if (remoteApi_->start())
+        if (remoteApi_->start()) {
+            // The file's name, not its path (#1860). This line goes to the app
+            // log, which users paste into bug reports, and the directory it
+            // lives in is their home directory.
             juce::Logger::writeToLog("Remote API token written to " +
-                                     remoteApi_->tokenFile().getFullPathName());
+                                     magda::remote::redactedFileName(remoteApi_->tokenFile()));
+        }
 
         // 5. Dismiss splash screen
         splashScreen_.reset();

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -18,6 +18,8 @@
 #include "../../../agents/model_downloader.hpp"
 #include "../../../agents/openai_url.hpp"
 #include "../../api/remote_api_host.hpp"
+#include "../../api/remote_audit.hpp"
+#include "../../api/remote_clients.hpp"
 #include "../../core/AppPaths.hpp"
 #include "../../core/Config.hpp"
 #include "../../media_db/MediaDbContext.hpp"
@@ -2500,6 +2502,16 @@ class AISettingsDialog::RemoteApiPage : public juce::Component, private juce::Ti
         styleLabel(statusLabel_, 11.0f);
         addAndMakeVisible(statusLabel_);
 
+        // Rotation is not a routine action, so it asks first and says what it
+        // costs. Every connected client was admitted by the credential being
+        // thrown away, so every one of them is dropped — a well-behaved client
+        // re-reads the discovery record and reconnects on its own, but a user
+        // who pressed this by accident would otherwise watch their session
+        // silently disconnect with no explanation.
+        rotateButton_.setButtonText("Rotate token");
+        rotateButton_.onClick = [this]() { confirmRotate(); };
+        addAndMakeVisible(rotateButton_);
+
         configCaption_.setText("MCP host configuration", juce::dontSendNotification);
         styleLabel(configCaption_);
         addAndMakeVisible(configCaption_);
@@ -2548,7 +2560,9 @@ class AISettingsDialog::RemoteApiPage : public juce::Component, private juce::Ti
         blurbLabel_.setBounds(bounds.removeFromTop(56));
         bounds.removeFromTop(8);
 
-        enableToggle_.setBounds(bounds.removeFromTop(rowH));
+        auto toggleRow = bounds.removeFromTop(rowH);
+        rotateButton_.setBounds(toggleRow.removeFromRight(110).reduced(0, 1));
+        enableToggle_.setBounds(toggleRow);
         bounds.removeFromTop(2);
         statusLabel_.setBounds(bounds.removeFromTop(18));
         bounds.removeFromTop(12);
@@ -2582,6 +2596,42 @@ class AISettingsDialog::RemoteApiPage : public juce::Component, private juce::Ti
             copiedAt_ = juce::Time();
         }
         refresh();
+    }
+
+    void confirmRotate() {
+        auto* host = magda::remote::activeHost();
+        if (host == nullptr || !host->isRunning())
+            return;
+
+        const auto connected = host->clients().connectionCount();
+        auto message =
+            juce::String("A new token is generated and the old one stops working immediately.");
+        if (connected > 0) {
+            message += juce::String::fromUTF8(" ") +
+                       (connected == 1 ? juce::String("One client is connected and will be "
+                                                      "disconnected.")
+                                       : juce::String(connected) +
+                                             " clients are connected and will be disconnected.");
+        }
+        message += " Clients that read the token file find the new one by themselves.";
+
+        juce::AlertWindow::showAsync(juce::MessageBoxOptions()
+                                         .withIconType(juce::MessageBoxIconType::QuestionIcon)
+                                         .withTitle("Rotate the remote API token?")
+                                         .withMessage(message)
+                                         .withButton("Rotate")
+                                         .withButton("Cancel"),
+                                     [this](int result) {
+                                         if (result != 1)
+                                             return;
+                                         // Re-fetched rather than captured: this callback runs
+                                         // after the dialog returns, and the host can be gone by
+                                         // then — the user may have switched the feature off while
+                                         // the box was up.
+                                         if (auto* live = magda::remote::activeHost())
+                                             live->rotateToken();
+                                         refresh();
+                                     });
     }
 
     void applyEnabled(bool enabled) {
@@ -2729,16 +2779,342 @@ class AISettingsDialog::RemoteApiPage : public juce::Component, private juce::Ti
 
         // Nothing worth copying when the path is a placeholder.
         copyButton_.setEnabled(haveBridge);
+
+        // Nothing to rotate when nothing is listening: there is no live
+        // credential, and minting one would publish a record for a closed port.
+        rotateButton_.setEnabled(running);
     }
 
     juce::Label blurbLabel_;
     juce::ToggleButton enableToggle_;
+    juce::TextButton rotateButton_;
     juce::Label statusLabel_;
     juce::Label configCaption_;
     juce::TextEditor configField_;
     juce::TextButton copyButton_;
     juce::Label hintLabel_;
     juce::Time copiedAt_;
+};
+
+// ============================================================================
+// RemoteClientsPage — who may do what, and what they have done (#1860)
+//
+// The permission model is only worth having if the user can see and change it,
+// and this is the only place that is true. Two halves: a row per client MAGDA
+// has heard from, with a checkbox per scope; and a tail of the audit log
+// underneath, so "why did my assistant say it could not do that" has an answer
+// on the same screen as the checkbox that fixes it.
+//
+// Everything here reads live state through `activeHost()` and refreshes on a
+// timer rather than on notifications, because the things it displays change on
+// transport threads and a UI that repainted from those would need a hop per
+// event for no benefit at one second's resolution.
+// ============================================================================
+
+class AISettingsDialog::RemoteClientsPage : public juce::Component, private juce::Timer {
+  public:
+    RemoteClientsPage() {
+        blurbLabel_.setFont(FontManager::getInstance().getUIFont(12.0f));
+        blurbLabel_.setColour(juce::Label::textColourId, DarkTheme::getTextColour());
+        blurbLabel_.setJustificationType(juce::Justification::topLeft);
+        blurbLabel_.setText(
+            "A client that connects for the first time can only read. Tick what you want it to be "
+            "able to do; changes apply to its next request, with nothing to restart.",
+            juce::dontSendNotification);
+        addAndMakeVisible(blurbLabel_);
+
+        clientsViewport_.setViewedComponent(&clientsHolder_, false);
+        clientsViewport_.setScrollBarsShown(true, false);
+        addAndMakeVisible(clientsViewport_);
+
+        emptyLabel_.setFont(FontManager::getInstance().getUIFont(11.0f));
+        emptyLabel_.setColour(juce::Label::textColourId, DarkTheme::getColour(DarkTheme::TEXT_DIM));
+        emptyLabel_.setJustificationType(juce::Justification::centred);
+        emptyLabel_.setText("No client has connected yet.", juce::dontSendNotification);
+        addAndMakeVisible(emptyLabel_);
+
+        activityCaption_.setText("Recent activity", juce::dontSendNotification);
+        styleLabel(activityCaption_);
+        addAndMakeVisible(activityCaption_);
+
+        activityView_.setMultiLine(true, false);
+        activityView_.setReadOnly(true);
+        activityView_.setFont(juce::Font(juce::FontOptions(
+            juce::Font::getDefaultMonospacedFontName(), 11.0f, juce::Font::plain)));
+        styleEditor(activityView_, "");
+        addAndMakeVisible(activityView_);
+
+        rebuild();
+        startTimer(1000);
+    }
+
+    ~RemoteClientsPage() override {
+        stopTimer();
+    }
+
+    void resized() override {
+        auto bounds = getLocalBounds().reduced(12);
+        blurbLabel_.setBounds(bounds.removeFromTop(40));
+        bounds.removeFromTop(8);
+
+        // The activity tail takes a fixed share off the bottom; the client list
+        // gets whatever is left, which is the part that grows with use.
+        auto activity = bounds.removeFromBottom(juce::jmin(140, bounds.getHeight() / 2));
+        activityView_.setBounds(activity);
+        bounds.removeFromBottom(4);
+        activityCaption_.setBounds(bounds.removeFromBottom(20));
+        bounds.removeFromBottom(8);
+
+        clientsViewport_.setBounds(bounds);
+        emptyLabel_.setBounds(bounds);
+        layoutRows();
+    }
+
+  private:
+    /// One client: its name, whether it is connected, and a checkbox per scope.
+    class ClientRow : public juce::Component {
+      public:
+        static constexpr int HEIGHT = 46;
+
+        explicit ClientRow(juce::String clientName) : name_(std::move(clientName)) {
+            nameLabel_.setText(name_, juce::dontSendNotification);
+            nameLabel_.setFont(FontManager::getInstance().getUIFont(12.0f));
+            nameLabel_.setColour(juce::Label::textColourId,
+                                 DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
+            addAndMakeVisible(nameLabel_);
+
+            statusLabel_.setFont(FontManager::getInstance().getUIFont(10.0f));
+            statusLabel_.setColour(juce::Label::textColourId,
+                                   DarkTheme::getColour(DarkTheme::TEXT_DIM));
+            addAndMakeVisible(statusLabel_);
+
+            for (const auto scope : magda::remote::allScopeValues()) {
+                auto toggle = std::make_unique<juce::ToggleButton>();
+                toggle->setButtonText(magda::remote::scopeName(scope));
+                toggle->setColour(juce::ToggleButton::textColourId,
+                                  DarkTheme::getColour(DarkTheme::TEXT_PRIMARY));
+                toggle->setColour(juce::ToggleButton::tickColourId,
+                                  DarkTheme::getColour(DarkTheme::ACCENT_PRIMARY));
+                // `read` is what being admitted means, so it is shown ticked
+                // and cannot be cleared — a row granting nothing at all would
+                // be indistinguishable from a client that was never granted,
+                // while still being one that can connect.
+                if (scope == magda::remote::Scope::Read) {
+                    toggle->setToggleState(true, juce::dontSendNotification);
+                    toggle->setEnabled(false);
+                } else {
+                    toggle->onClick = [this]() { commitScopes(); };
+                }
+                addAndMakeVisible(*toggle);
+                toggles_.push_back(std::move(toggle));
+            }
+
+            disconnectButton_.setButtonText("Disconnect");
+            disconnectButton_.onClick = [this]() {
+                if (auto* host = magda::remote::activeHost())
+                    host->clients().disconnectClient(name_);
+            };
+            addAndMakeVisible(disconnectButton_);
+
+            forgetButton_.setButtonText("Forget");
+            forgetButton_.onClick = [this]() {
+                if (auto* host = magda::remote::activeHost())
+                    host->clients().forget(name_);
+            };
+            addAndMakeVisible(forgetButton_);
+        }
+
+        const juce::String& clientName() const {
+            return name_;
+        }
+
+        /// Push current state in. Called every tick, so it must not fight the
+        /// user: a toggle is only written when it actually differs.
+        void update(magda::remote::ScopeSet scopes, int connections,
+                    const juce::String& transports) {
+            const auto& values = magda::remote::allScopeValues();
+            for (std::size_t index = 0; index < toggles_.size() && index < values.size(); ++index) {
+                const auto granted = scopes.has(values[index]);
+                if (toggles_[index]->getToggleState() != granted)
+                    toggles_[index]->setToggleState(granted, juce::dontSendNotification);
+            }
+
+            const auto connected = connections > 0;
+            statusLabel_.setText(connected ? juce::String::fromUTF8("Connected — ") + transports
+                                           : juce::String("Not connected"),
+                                 juce::dontSendNotification);
+            statusLabel_.setColour(juce::Label::textColourId,
+                                   connected ? DarkTheme::getColour(DarkTheme::ACCENT_PRIMARY)
+                                             : DarkTheme::getColour(DarkTheme::TEXT_DIM));
+            disconnectButton_.setEnabled(connected);
+        }
+
+        void resized() override {
+            auto bounds = getLocalBounds().reduced(6, 4);
+
+            auto header = bounds.removeFromTop(18);
+            forgetButton_.setBounds(header.removeFromRight(64).reduced(0, 1));
+            header.removeFromRight(4);
+            disconnectButton_.setBounds(header.removeFromRight(84).reduced(0, 1));
+            header.removeFromRight(8);
+            nameLabel_.setBounds(header.removeFromLeft(juce::jmin(160, header.getWidth() / 2)));
+            statusLabel_.setBounds(header);
+
+            bounds.removeFromTop(2);
+            auto row = bounds.removeFromTop(18);
+            const auto each =
+                toggles_.empty() ? 0 : row.getWidth() / static_cast<int>(toggles_.size());
+            for (auto& toggle : toggles_)
+                toggle->setBounds(row.removeFromLeft(each));
+        }
+
+        void paint(juce::Graphics& g) override {
+            g.setColour(DarkTheme::getColour(DarkTheme::BACKGROUND_ALT));
+            g.fillRoundedRectangle(getLocalBounds().toFloat().reduced(1.0f), 3.0f);
+        }
+
+      private:
+        void commitScopes() {
+            auto* host = magda::remote::activeHost();
+            if (host == nullptr)
+                return;
+
+            magda::remote::ScopeSet scopes;
+            const auto& values = magda::remote::allScopeValues();
+            for (std::size_t index = 0; index < toggles_.size() && index < values.size(); ++index)
+                scopes.set(values[index], toggles_[index]->getToggleState());
+            // `setScopes` forces `read` back on and persists, so this is the
+            // whole of applying a change — there is no separate save step, and
+            // the next request the client makes reads the new grant.
+            host->clients().setScopes(name_, scopes);
+        }
+
+        const juce::String name_;
+        juce::Label nameLabel_;
+        juce::Label statusLabel_;
+        std::vector<std::unique_ptr<juce::ToggleButton>> toggles_;
+        juce::TextButton disconnectButton_;
+        juce::TextButton forgetButton_;
+    };
+
+    void timerCallback() override {
+        rebuild();
+    }
+
+    /**
+     * @brief Reconcile the rows with the registry, and refresh the activity tail.
+     *
+     * Rows are rebuilt only when the *set* of client names changes, not on every
+     * tick: recreating a row under the pointer would swallow the click that was
+     * about to land on one of its checkboxes.
+     */
+    void rebuild() {
+        auto* host = magda::remote::activeHost();
+        if (host == nullptr) {
+            if (!rows_.empty()) {
+                rows_.clear();
+                clientsHolder_.removeAllChildren();
+            }
+            emptyLabel_.setText("The remote API is not available in this session.",
+                                juce::dontSendNotification);
+            emptyLabel_.setVisible(true);
+            return;
+        }
+
+        const auto grants = host->clients().grants();
+        const auto connections = host->clients().connections();
+
+        juce::StringArray names;
+        for (const auto& grant : grants)
+            names.add(grant.name);
+
+        if (names != rowNames_) {
+            rowNames_ = names;
+            rows_.clear();
+            clientsHolder_.removeAllChildren();
+            for (const auto& name : rowNames_) {
+                auto row = std::make_unique<ClientRow>(name);
+                clientsHolder_.addAndMakeVisible(*row);
+                rows_.push_back(std::move(row));
+            }
+            layoutRows();
+        }
+
+        emptyLabel_.setVisible(rows_.empty());
+        emptyLabel_.setText("No client has connected yet.", juce::dontSendNotification);
+
+        for (const auto& grant : grants) {
+            auto* row = rowFor(grant.name);
+            if (row == nullptr)
+                continue;
+
+            int count = 0;
+            juce::StringArray transports;
+            for (const auto& connection : connections) {
+                if (connection.name != grant.name)
+                    continue;
+                ++count;
+                transports.addIfNotAlreadyThere(connection.transport);
+            }
+            row->update(grant.scopes, count, transports.joinIntoString(", "));
+        }
+
+        refreshActivity(host->audit());
+    }
+
+    ClientRow* rowFor(const juce::String& name) {
+        for (auto& row : rows_) {
+            if (row->clientName() == name)
+                return row.get();
+        }
+        return nullptr;
+    }
+
+    void layoutRows() {
+        const auto width = juce::jmax(0, clientsViewport_.getMaximumVisibleWidth());
+        int y = 0;
+        for (auto& row : rows_) {
+            row->setBounds(0, y, width, ClientRow::HEIGHT);
+            y += ClientRow::HEIGHT + 4;
+        }
+        clientsHolder_.setSize(width, y);
+    }
+
+    void refreshActivity(const magda::remote::RemoteAuditLog& log) {
+        // Cheap change detection: the counter only moves when something was
+        // recorded, so a quiet session never rebuilds this string.
+        const auto recorded = log.totalRecorded();
+        if (recorded == shownActivity_)
+            return;
+        shownActivity_ = recorded;
+
+        juce::StringArray lines;
+        for (const auto& entry : log.recent(kActivityLines)) {
+            const auto time = juce::Time(entry.timestampMs).toString(false, true, false, true);
+            auto line = time + "  " + entry.client + "  " + entry.operation + "  " +
+                        magda::remote::toString(entry.outcome);
+            if (entry.detail.isNotEmpty())
+                line += " (" + entry.detail + ")";
+            lines.add(line);
+        }
+
+        activityView_.setText(lines.joinIntoString("\n"), juce::dontSendNotification);
+        // Newest last, so show the end.
+        activityView_.moveCaretToEnd();
+    }
+
+    static constexpr std::size_t kActivityLines = 200;
+
+    juce::Label blurbLabel_;
+    juce::Viewport clientsViewport_;
+    juce::Component clientsHolder_;
+    juce::Label emptyLabel_;
+    std::vector<std::unique_ptr<ClientRow>> rows_;
+    juce::StringArray rowNames_;
+
+    juce::Label activityCaption_;
+    juce::TextEditor activityView_;
+    std::uint64_t shownActivity_ = 0;
 };
 
 // ============================================================================
@@ -2765,6 +3141,7 @@ AISettingsDialog::AISettingsDialog() {
     modelDownloadsPage_ = std::make_unique<ModelDownloadsPage>(
         *localPage_, samplePage_.get(), stemsPage_.get(), commandModelPage_.get());
     remoteApiPage_ = std::make_unique<RemoteApiPage>();
+    remoteClientsPage_ = std::make_unique<RemoteClientsPage>();
 
     // Wire config page to sibling pages
     configPage_->cloudPage = cloudPage_.get();
@@ -2775,6 +3152,10 @@ AISettingsDialog::AISettingsDialog() {
     tabbedComponent_.addTab("Config", tabBg, configPage_.get(), false);
     tabbedComponent_.addTab("Models", tabBg, modelDownloadsPage_.get(), false);
     tabbedComponent_.addTab("Remote", tabBg, remoteApiPage_.get(), false);
+    // Beside "Remote" rather than inside it: turning the endpoint on and saying
+    // what a client may do are separate decisions, made at different times, and
+    // the second one grows a row per client while the first stays one switch.
+    tabbedComponent_.addTab("Clients", tabBg, remoteClientsPage_.get(), false);
 
     // Refresh config combos when switching to Config tab
     tabbedComponent_.onTabChanged = [this](int tabIndex) {

--- a/magda/daw/ui/dialogs/AISettingsDialog.cpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.cpp
@@ -3024,9 +3024,18 @@ class AISettingsDialog::RemoteClientsPage : public juce::Component, private juce
         const auto grants = host->clients().grants();
         const auto connections = host->clients().connections();
 
+        // The union of the two, not just the grants. `forget()` drops a grant
+        // without disconnecting — deliberately, since the client reverts to
+        // read-only rather than being cut off — and a list built from grants
+        // alone would make that row vanish while its client was still
+        // connected, leaving no way to disconnect it until it happened to ask
+        // for something and recreate its entry.
         juce::StringArray names;
         for (const auto& grant : grants)
-            names.add(grant.name);
+            names.addIfNotAlreadyThere(grant.name);
+        for (const auto& connection : connections)
+            names.addIfNotAlreadyThere(connection.name);
+        names.sort(false);
 
         if (names != rowNames_) {
             rowNames_ = names;
@@ -3043,20 +3052,30 @@ class AISettingsDialog::RemoteClientsPage : public juce::Component, private juce
         emptyLabel_.setVisible(rows_.empty());
         emptyLabel_.setText("No client has connected yet.", juce::dontSendNotification);
 
-        for (const auto& grant : grants) {
-            auto* row = rowFor(grant.name);
-            if (row == nullptr)
-                continue;
+        // Driven by the rows rather than by the grants, because a row can exist
+        // without one: a client that was forgotten while still connected keeps
+        // its row until it disconnects. It shows the read-only default, which is
+        // what it will actually get on its next request.
+        for (const auto& row : rows_) {
+            const auto& name = row->clientName();
+
+            auto scopes = magda::remote::defaultClientScopes();
+            for (const auto& grant : grants) {
+                if (grant.name == name) {
+                    scopes = grant.scopes;
+                    break;
+                }
+            }
 
             int count = 0;
             juce::StringArray transports;
             for (const auto& connection : connections) {
-                if (connection.name != grant.name)
+                if (connection.name != name)
                     continue;
                 ++count;
                 transports.addIfNotAlreadyThere(connection.transport);
             }
-            row->update(grant.scopes, count, transports.joinIntoString(", "));
+            row->update(scopes, count, transports.joinIntoString(", "));
         }
 
         refreshActivity(host->audit());

--- a/magda/daw/ui/dialogs/AISettingsDialog.hpp
+++ b/magda/daw/ui/dialogs/AISettingsDialog.hpp
@@ -11,6 +11,7 @@ namespace magda {
  *  - Config: preset or per-agent provider mapping (references configured providers)
  *  - Models: embedded, sample-analysis, and stem-separation models
  *  - Remote: the MCP endpoint and WebSocket API an external AI host connects to
+ *  - Clients: what each remote client is allowed to do, and what they have done
  */
 class AISettingsDialog : public juce::Component {
   public:
@@ -33,6 +34,7 @@ class AISettingsDialog : public juce::Component {
     class CommandModelPage;
     class ModelDownloadsPage;
     class RemoteApiPage;
+    class RemoteClientsPage;
 
     class TabComponent : public juce::TabbedComponent {
       public:
@@ -53,6 +55,7 @@ class AISettingsDialog : public juce::Component {
     std::unique_ptr<CommandModelPage> commandModelPage_;
     std::unique_ptr<ModelDownloadsPage> modelDownloadsPage_;
     std::unique_ptr<RemoteApiPage> remoteApiPage_;
+    std::unique_ptr<RemoteClientsPage> remoteClientsPage_;
 
     juce::TextButton okBtn_{"OK"};
     juce::TextButton cancelBtn_{"Cancel"};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -195,6 +195,8 @@ set(TEST_SOURCES
     # Lua bindings tests (issue #30 — bind MagdaApi)
     test_magda_api_lua_bindings.cpp
     test_remote_api_contract.cpp
+    test_remote_permissions.cpp
+    test_remote_permission_conformance.cpp
     test_remote_service.cpp
     test_remote_changes.cpp
     test_remote_subscriptions.cpp

--- a/tests/RemoteTestScopes.hpp
+++ b/tests/RemoteTestScopes.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "magda/daw/api/remote_api.hpp"
+#include "magda/daw/api/remote_clients.hpp"
+
+namespace magda::test {
+
+/**
+ * @brief A request context standing in for a client the user granted everything.
+ *
+ * `RequestContext::scopes` is empty by default and empty denies everything
+ * (#1860), which is the behaviour the permission tests exist to pin down. Every
+ * *other* remote test is about revisions, idempotency, deadlines, or schemas,
+ * and would otherwise have to restate a full grant at each call site — burying
+ * the thing each test is actually asserting under permission setup that is never
+ * the point.
+ *
+ * So: tests that care about permissions build their own context or registry, and
+ * tests that do not use this. A test that accidentally relied on it to paper
+ * over a missing grant would still fail, because it asks for every scope rather
+ * than skipping the check.
+ */
+inline remote::RequestContext fullyGrantedContext() {
+    remote::RequestContext context;
+    context.scopes = remote::allScopes();
+    return context;
+}
+
+/**
+ * @brief A client registry that grants every scope to everyone.
+ *
+ * The transport equivalent of the above, for the WebSocket and MCP server tests:
+ * both refuse everything without a registry, so a server under test needs one
+ * before it can answer anything at all.
+ *
+ * It is a real `RemoteClientRegistry` with a real grant rather than a bypass,
+ * so what these tests drive is the same lookup production uses. Owned by the
+ * caller and must outlive the server.
+ */
+inline void grantEverything(remote::RemoteClientRegistry& registry,
+                            const juce::String& clientName = remote::ANONYMOUS_CLIENT) {
+    registry.setScopes(clientName, remote::allScopes());
+}
+
+/**
+ * @brief A shared registry granting everything to the anonymous client.
+ *
+ * The default a transport test's options point at, so tests about framing,
+ * limits, and lifecycle do not each have to declare a registry and outlive their
+ * server with it. Permission tests pass their own instead, which is why the
+ * option is a parameter rather than something baked into the server.
+ *
+ * `unknown` is the name a client that sends no identity gets, and none of these
+ * tests send one — so granting that one entry is what makes the whole file's
+ * traffic admissible.
+ *
+ * A function-local static in an inline function: one instance across every test
+ * translation unit, constructed on first use and destroyed after the last test.
+ * Sharing is safe because the servers under test register and clear their
+ * disconnect handlers by transport name in `start()` and `stop()`, and Catch2
+ * runs test cases one at a time.
+ */
+inline remote::RemoteClientRegistry& permissiveRegistry() {
+    static remote::RemoteClientRegistry registry;
+    static const bool granted = [] {
+        // Grants are keyed by the name the client declares, so this has to name
+        // the clients these tests actually are. `unknown` covers the WebSocket
+        // tests, which send no `?client=`; `catch2` is the `clientInfo.name`
+        // the MCP tests send.
+        //
+        // A name missing from this list does not silently pass: it gets the
+        // read-only default, so its reads work and its writes come back
+        // `permission_denied` — which is a clear failure pointing here rather
+        // than a mysterious one.
+        grantEverything(registry, remote::ANONYMOUS_CLIENT);
+        grantEverything(registry, "catch2");
+        return true;
+    }();
+    juce::ignoreUnused(granted);
+    return registry;
+}
+
+}  // namespace magda::test

--- a/tests/test_remote_api_host.cpp
+++ b/tests/test_remote_api_host.cpp
@@ -4,10 +4,14 @@
 #include <httplib.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <chrono>
 #include <string>
+#include <thread>
 
 #include "MockMagdaApi.hpp"
+#include "RemoteTestScopes.hpp"
 #include "magda/daw/api/remote_api_host.hpp"
+#include "magda/daw/api/remote_clients.hpp"
 #include "magda/daw/api/remote_service.hpp"
 #include "magda/daw/core/Config.hpp"
 
@@ -18,6 +22,7 @@
 
 using namespace magda;
 using namespace magda::remote;
+using magda::test::fullyGrantedContext;
 using magda::test::MockMagdaApi;
 
 namespace {
@@ -34,27 +39,47 @@ struct ScopedRemoteApiConfig {
         wasEnabled_ = config.getRemoteApiEnabled();
         previousPort_ = config.getRemoteApiPort();
         previousMcpPort_ = config.getRemoteApiMcpPort();
+        // Grants too (#1860): a host persists them on every change, so a test
+        // that connects a client would otherwise leave its grant behind in the
+        // developer's real config file.
+        previousClients_ = config.getRemoteApiClients();
         config.setRemoteApiEnabled(enabled);
         config.setRemoteApiPort(0);
         config.setRemoteApiMcpPort(0);
+        config.setRemoteApiClients({});
     }
     ~ScopedRemoteApiConfig() {
         auto& config = Config::getInstance();
         config.setRemoteApiEnabled(wasEnabled_);
         config.setRemoteApiPort(previousPort_);
         config.setRemoteApiMcpPort(previousMcpPort_);
+        config.setRemoteApiClients(previousClients_);
     }
 
   private:
     bool wasEnabled_ = false;
     int previousPort_ = 0;
     int previousMcpPort_ = 0;
+    juce::var previousClients_;
 };
 
 juce::var readTokenFile(const juce::File& file) {
     juce::var parsed;
     REQUIRE(juce::JSON::parse(file.loadFileAsString(), parsed).wasOk());
     return parsed;
+}
+
+/// Poll until `predicate` holds, or give up. For state a connection's own
+/// thread publishes shortly after the client sees the handshake succeed.
+template <typename Predicate>
+bool waitFor(Predicate predicate, std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (predicate())
+            return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return predicate();
 }
 
 }  // namespace
@@ -243,7 +268,7 @@ TEST_CASE("Turning the remote API off and on again leaves it working",
     // distinction.
     REQUIRE_FALSE(host.service().isShutdown());
     const auto response = host.service().dispatchSync(
-        "project.get", juce::var(new juce::DynamicObject()), RequestContext{});
+        "project.get", juce::var(new juce::DynamicObject()), fullyGrantedContext());
     REQUIRE(response.ok);
 
     // And a fresh credential, because the old one was withdrawn.
@@ -259,6 +284,13 @@ TEST_CASE("Restarting the listeners voids cached request identities", "[remote][
     api.project_.info.tempo = 120.0;
     RemoteApiHost host(api);
     REQUIRE(host.start());
+
+    // A client MAGDA has not seen is read-only (#1860), and these clients send
+    // no `?client=`, so they are all `unknown`. Granting edit up front is what
+    // the user would have done in the settings dialog; without it every write
+    // below would come back `permission_denied` and the test would be measuring
+    // the permission model rather than identity reuse.
+    host.clients().setScopes(ANONYMOUS_CLIENT, allScopes());
 
     // Driven through real sockets, because the identity under test is the one
     // the transport builds. A hand-written context would assert whatever shape
@@ -314,7 +346,7 @@ TEST_CASE("A client-supplied idempotency key still dedupes across a restart",
     // restart: that is what makes a retry safe when the endpoint went away
     // mid-request. Clearing the shared cache on restart would have broken this
     // — the retry would apply the write a second time.
-    RequestContext context;
+    auto context = fullyGrantedContext();
     context.clientId = "mcp:stateless";
     context.requestId = "mcp::0f7c1a2b-3d4e-5f60-8a9b-cbd0e1f23456";
 
@@ -393,7 +425,7 @@ TEST_CASE("The token file is readable only by its owner", "[remote][host][auth]"
     RemoteApiHost host(api);
     REQUIRE(host.start());
 
-    struct stat info {};
+    struct stat info{};
     REQUIRE(stat(host.tokenFile().getFullPathName().toRawUTF8(), &info) == 0);
 
     // A credential every account on the machine can read is not a credential.
@@ -447,4 +479,148 @@ TEST_CASE("Each run generates its own token", "[remote][host][auth]") {
     // Per run, not per install: a token that survived a restart would outlive
     // the reason anyone was trusted with it.
     REQUIRE(readTokenFile(second.tokenFile())["token"].toString() != first);
+}
+
+// ===========================================================================
+// Permissions, at the level the application actually assembles them (#1860)
+// ===========================================================================
+
+TEST_CASE("A brand-new client reaches a real host read-only", "[remote][host][permissions]") {
+    MessageThreadRelaxation relax;
+    ScopedRemoteApiConfig config(true);
+
+    MockMagdaApi api;
+    api.project_.info.tempo = 120.0;
+    RemoteApiHost host(api);
+    REQUIRE(host.start());
+
+    const auto token = readTokenFile(host.tokenFile())["token"].toString();
+    const auto endpoint =
+        "ws://127.0.0.1:" + juce::String(host.boundPort()).toStdString() + "/rpc?client=probe";
+
+    const auto send = [&](httplib::ws::WebSocketClient& client, const juce::String& method,
+                          juce::var params) {
+        auto* request = new juce::DynamicObject();
+        request->setProperty("jsonrpc", "2.0");
+        request->setProperty("id", 1);
+        request->setProperty("method", method);
+        request->setProperty("params", params);
+        REQUIRE(client.send(juce::JSON::toString(juce::var(request), true).toStdString()));
+        std::string reply;
+        REQUIRE(client.read(reply) == httplib::ws::ReadResult::Text);
+        juce::var parsed;
+        REQUIRE(juce::JSON::parse(juce::String(reply), parsed).wasOk());
+        return parsed;
+    };
+
+    httplib::ws::WebSocketClient client(endpoint,
+                                        {{"Authorization", "Bearer " + token.toStdString()}});
+    REQUIRE(client.connect());
+
+    // Reads work out of the box, so a client is useful the moment it connects.
+    const auto read = send(client, "project.get", juce::var(new juce::DynamicObject()));
+    REQUIRE(read["error"].isVoid());
+
+    // Writes do not, and say which permission is missing.
+    //
+    // Held as a `var`, not as the raw pointer: `juce::var` takes ownership of a
+    // `DynamicObject*` by reference count, so wrapping the same pointer twice
+    // frees it after the first request and sends whatever lands in that memory
+    // next with the second.
+    juce::var params(new juce::DynamicObject());
+    params.getDynamicObject()->setProperty("tempo", 140.0);
+    const auto write = send(client, "project.setTempo", params);
+    REQUIRE(write["error"]["data"]["code"].toString() == "permission_denied");
+    REQUIRE(api.project_.info.tempo == 120.0);
+
+    // It is listed and connected, so the user has something to grant.
+    REQUIRE(host.clients().peekScopes("probe").has_value());
+    REQUIRE(host.clients().connectionCount() == 1);
+
+    // Granting applies to the next request on the socket it is already holding.
+    host.clients().setScopes("probe", ScopeSet{Scope::Read, Scope::Edit});
+    const auto granted = send(client, "project.setTempo", params);
+    REQUIRE(granted["error"].isVoid());
+    REQUIRE(api.project_.info.tempo == 140.0);
+}
+
+TEST_CASE("Grants outlive the host that recorded them", "[remote][host][permissions]") {
+    // The user's decision about a client is not per-run state: a toggle they set
+    // once must not be forgotten because MAGDA restarted, or the permission
+    // prompt becomes something they learn to click through.
+    MessageThreadRelaxation relax;
+    ScopedRemoteApiConfig config(true);
+
+    MockMagdaApi api;
+    {
+        RemoteApiHost host(api);
+        host.clients().setScopes("cursor", ScopeSet{Scope::Read, Scope::Transport});
+    }
+
+    // The grant reached config on the way out…
+    REQUIRE(Config::getInstance().getRemoteApiClients().isArray());
+
+    // …and a fresh host loads it rather than starting the client over.
+    RemoteApiHost restored(api);
+    REQUIRE(restored.clients().scopesFor("cursor") == ScopeSet{Scope::Read, Scope::Transport});
+    REQUIRE(restored.clients().scopesFor("someone-else") == defaultClientScopes());
+}
+
+TEST_CASE("Rotating the token invalidates the old one and drops its clients",
+          "[remote][host][permissions]") {
+    MessageThreadRelaxation relax;
+    ScopedRemoteApiConfig config(true);
+
+    MockMagdaApi api;
+    RemoteApiHost host(api);
+    REQUIRE(host.start());
+
+    const auto before = readTokenFile(host.tokenFile())["token"].toString();
+    const auto endpointFor = [&] {
+        return "ws://127.0.0.1:" + juce::String(host.boundPort()).toStdString() + "/rpc";
+    };
+
+    {
+        httplib::ws::WebSocketClient client(endpointFor(),
+                                            {{"Authorization", "Bearer " + before.toStdString()}});
+        REQUIRE(client.connect());
+        // `connect()` returns once the 101 is written, which is a moment before
+        // the server's own thread has registered the connection. Waiting for
+        // the registry rather than asserting on it immediately is the
+        // difference between testing rotation and testing that race.
+        REQUIRE(waitFor([&] { return host.clients().connectionCount() == 1; }));
+
+        REQUIRE(host.rotateToken());
+    }
+
+    // A new credential, published where a client will look for it.
+    const auto after = readTokenFile(host.tokenFile())["token"].toString();
+    REQUIRE(after.isNotEmpty());
+    REQUIRE(after != before);
+    REQUIRE(host.isRunning());
+
+    // Nothing admitted by the old one is still connected — a token that left its
+    // own sessions running would not have been revoked.
+    REQUIRE(host.clients().connectionCount() == 0);
+
+    // And the old one no longer opens anything.
+    httplib::ws::WebSocketClient stale(endpointFor(),
+                                       {{"Authorization", "Bearer " + before.toStdString()}});
+    REQUIRE_FALSE(stale.connect());
+
+    httplib::ws::WebSocketClient fresh(endpointFor(),
+                                       {{"Authorization", "Bearer " + after.toStdString()}});
+    REQUIRE(fresh.connect());
+}
+
+TEST_CASE("Rotation is refused when nothing is listening", "[remote][host][permissions]") {
+    // There is no credential to rotate, and minting one would publish a record
+    // for a port nobody is answering on.
+    MessageThreadRelaxation relax;
+    ScopedRemoteApiConfig config(false);
+
+    MockMagdaApi api;
+    RemoteApiHost host(api);
+    REQUIRE_FALSE(host.rotateToken());
+    REQUIRE_FALSE(host.tokenFile().existsAsFile());
 }

--- a/tests/test_remote_mcp.cpp
+++ b/tests/test_remote_mcp.cpp
@@ -33,6 +33,26 @@ juce::var object(std::initializer_list<std::pair<const char*, juce::var>> fields
     return result;
 }
 
+/**
+ * @brief The fields every call here shares.
+ *
+ * Assigned by name rather than positionally. `Call` is a plain aggregate, so a
+ * braced list silently re-maps when a field is inserted — which is exactly what
+ * happened when `clientName` and `scopes` landed in the middle of it (#1860) and
+ * `idempotencyScope` quietly became the client's name.
+ *
+ * `scopes` is every scope: these tests are about how operations project into
+ * tools and resources, not about who may call them. The permission behaviour has
+ * its own files.
+ */
+void fillCommon(McpEndpoint::Call& call, const juce::String& method, juce::var params) {
+    call.method = method;
+    call.params = std::move(params);
+    call.clientId = "mcp-test";
+    call.clientName = "mcp-test";
+    call.scopes = allScopes();
+}
+
 /// A modern-era call carrying the `_meta` every 2026-07-28 request must have.
 McpEndpoint::Call modernCall(const juce::String& method, juce::var params = {}) {
     if (params.getDynamicObject() == nullptr)
@@ -43,13 +63,24 @@ McpEndpoint::Call modernCall(const juce::String& method, juce::var params = {}) 
                        {MCP_META_CLIENT_CAPABILITIES, juce::var(new juce::DynamicObject())}});
         params.getDynamicObject()->setProperty("_meta", meta);
     }
-    return {method, params, McpEra::Modern, "2026-07-28", "mcp-test", {}};
+
+    McpEndpoint::Call call;
+    fillCommon(call, method, std::move(params));
+    call.era = McpEra::Modern;
+    call.protocolVersion = "2026-07-28";
+    return call;
 }
 
 McpEndpoint::Call legacyCall(const juce::String& method, juce::var params = {}) {
     if (params.getDynamicObject() == nullptr)
         params = juce::var(new juce::DynamicObject());
-    return {method, params, McpEra::Legacy, "2025-11-25", "mcp-test", "session-1"};
+
+    McpEndpoint::Call call;
+    fillCommon(call, method, std::move(params));
+    call.era = McpEra::Legacy;
+    call.protocolVersion = "2025-11-25";
+    call.idempotencyScope = "session-1";
+    return call;
 }
 
 /// Runs one call to completion. Dispatch is inline here, so this is synchronous.

--- a/tests/test_remote_mcp_bridge.cpp
+++ b/tests/test_remote_mcp_bridge.cpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "MockMagdaApi.hpp"
+#include "RemoteTestScopes.hpp"
 #include "magda/daw/api/remote_mcp_server.hpp"
 #include "magda/daw/api/remote_service.hpp"
 #include "magda/daw/api/remote_subscriptions.hpp"
@@ -196,6 +197,10 @@ void writeRecord(const juce::File& dataDir, int port, const juce::String& token)
 RemoteMcpServer::Options serverOptions() {
     RemoteMcpServer::Options options;
     options.bearerToken = kToken;
+    // Without a registry the endpoint refuses everything, reads included
+    // (#1860), and these tests are about whether the bridge relays a call at
+    // all rather than about who may make it.
+    options.clients = &magda::test::permissiveRegistry();
     return options;
 }
 

--- a/tests/test_remote_mcp_server.cpp
+++ b/tests/test_remote_mcp_server.cpp
@@ -20,12 +20,15 @@
 #include <vector>
 
 #include "MockMagdaApi.hpp"
+#include "RemoteTestScopes.hpp"
+#include "magda/daw/api/remote_clients.hpp"
 #include "magda/daw/api/remote_mcp_server.hpp"
 #include "magda/daw/api/remote_service.hpp"
 #include "magda/daw/api/remote_subscriptions.hpp"
 
 using namespace magda;
 using namespace magda::remote;
+using magda::test::fullyGrantedContext;
 using magda::test::MockMagdaApi;
 
 namespace {
@@ -43,13 +46,18 @@ struct MessageThreadRelaxation {
     ScopedMessageThreadAssertionDisabler disabler;
 };
 
-RemoteMcpServer::Options testOptions() {
+/// `clients` defaults to the shared permissive registry: without one, every
+/// request is refused before it reaches the protocol behaviour these tests are
+/// about (#1860). The permission tests pass their own.
+RemoteMcpServer::Options testOptions(
+    RemoteClientRegistry& clients = magda::test::permissiveRegistry()) {
     RemoteMcpServer::Options options;
     options.bearerToken = kToken;
     options.allowedOrigins = {kOrigin};
     // Short enough that a stream test does not sit waiting for one, long enough
     // that comments do not swamp the events being asserted.
     options.keepAliveIntervalMs = 250;
+    options.clients = &clients;
     return options;
 }
 
@@ -481,8 +489,8 @@ TEST_CASE("A tool call and a resource read return the same projection",
 
     // And the same operation dispatched directly, which is what the WebSocket
     // transport puts in its `result`.
-    const auto direct =
-        service.dispatchSync("project.get", juce::var(new juce::DynamicObject()), RequestContext{});
+    const auto direct = service.dispatchSync("project.get", juce::var(new juce::DynamicObject()),
+                                             fullyGrantedContext());
     REQUIRE(direct.ok);
     REQUIRE(juce::JSON::toString(direct.result, true) ==
             juce::JSON::toString(viaTool.json["result"]["structuredContent"], true));

--- a/tests/test_remote_model_bridge.cpp
+++ b/tests/test_remote_model_bridge.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "MockMagdaApi.hpp"
+#include "RemoteTestScopes.hpp"
 #include "magda/daw/api/remote_model_bridge.hpp"
 #include "magda/daw/api/remote_service.hpp"
 #include "magda/daw/core/ClipManager.hpp"
@@ -12,6 +13,7 @@
 
 using namespace magda;
 using namespace magda::remote;
+using magda::test::fullyGrantedContext;
 using magda::test::MockMagdaApi;
 
 namespace {
@@ -69,7 +71,7 @@ TEST_CASE("A locally committed change makes a client's expected revision stale",
     const auto clientView = fixture.service.currentRevision();
     TrackManager::getInstance().createTrack("Meanwhile", TrackType::Audio);
 
-    RequestContext context;
+    auto context = fullyGrantedContext();
     context.expectedRevision = clientView;
     Response response;
     fixture.service.dispatch(

--- a/tests/test_remote_permission_conformance.cpp
+++ b/tests/test_remote_permission_conformance.cpp
@@ -17,8 +17,11 @@
 
 #include <httplib.h>
 
+#include <atomic>
 #include <catch2/catch_test_macros.hpp>
+#include <chrono>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "MockMagdaApi.hpp"
@@ -495,4 +498,93 @@ TEST_CASE("A refused connection is recorded without its credential",
     REQUIRE(sawRejection);
 
     forgetAllRemoteSecrets();
+}
+
+TEST_CASE("Permission decisions hold up under concurrent load",
+          "[remote][permissions][conformance][load]") {
+    // Enforcement reads a grant on every request from every connection at once,
+    // while the settings dialog may be rewriting that grant from another thread.
+    // The property under test is not throughput — the dispatcher serialises
+    // handlers anyway — but that the answer is always one of the two correct
+    // ones, and that a revocation is never overtaken by a request that started
+    // before it.
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.project_.info.tempo = 120.0;
+    RemoteApiService service(api);
+    RemoteClientRegistry registry;
+    RemoteAuditLog log;
+    service.setAuditLog(&log);
+
+    constexpr int kClients = 4;
+    constexpr int kRequestsEach = 40;
+
+    RemoteWebSocketServer::Options options;
+    options.bearerToken = kToken;
+    options.clients = &registry;
+    options.audit = &log;
+    options.maxConnections = kClients + 2;
+    // Above what the loop below can generate, so a refusal here would be the
+    // rate limiter rather than the permission model — a different test.
+    options.maxRequestsPerSecond = 10'000.0;
+    RemoteWebSocketServer server(service, options);
+    REQUIRE(server.start());
+
+    registry.setScopes(kClient, ScopeSet{Scope::Read, Scope::Edit});
+
+    std::atomic<int> allowed{0};
+    std::atomic<int> denied{0};
+    std::atomic<int> unexpected{0};
+
+    std::vector<std::thread> workers;
+    workers.reserve(kClients);
+    for (int worker = 0; worker < kClients; ++worker) {
+        workers.emplace_back([&] {
+            httplib::ws::WebSocketClient client(
+                wsEndpoint(server), {{"Authorization", std::string("Bearer ") + kToken}});
+            if (!client.connect()) {
+                unexpected.fetch_add(1);
+                return;
+            }
+
+            const Vector write{"write", "project.setTempo", object({{"tempo", 130.0}}),
+                               ScopeSet{Scope::Read, Scope::Edit}, true};
+            for (int index = 0; index < kRequestsEach; ++index) {
+                const auto outcome = runOverWebSocket(client, write);
+                if (outcome.allowed)
+                    allowed.fetch_add(1);
+                else if (outcome.errorCode == "permission_denied")
+                    denied.fetch_add(1);
+                else
+                    // Anything else — a timeout, a conflict, a dropped reply —
+                    // means the load itself broke something, which is exactly
+                    // what this is watching for.
+                    unexpected.fetch_add(1);
+            }
+        });
+    }
+
+    // Flip the grant back and forth underneath them. Every request must land on
+    // one side or the other, never in between.
+    for (int flip = 0; flip < 20; ++flip) {
+        registry.setScopes(kClient, (flip % 2) == 0 ? defaultClientScopes()
+                                                    : ScopeSet{Scope::Read, Scope::Edit});
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    registry.setScopes(kClient, ScopeSet{Scope::Read, Scope::Edit});
+
+    for (auto& worker : workers)
+        worker.join();
+
+    REQUIRE(unexpected.load() == 0);
+    REQUIRE(allowed.load() + denied.load() == kClients * kRequestsEach);
+    // Both outcomes actually occurred, or the flipping above proved nothing.
+    REQUIRE(allowed.load() > 0);
+    REQUIRE(denied.load() > 0);
+
+    // Every one of them is in the record, and none of them carries a payload.
+    const auto entries = log.forClient(kClient);
+    REQUIRE(entries.size() >= static_cast<std::size_t>(kClients * kRequestsEach));
+    for (const auto& entry : entries)
+        REQUIRE_FALSE(entry.detail.contains("130"));
 }

--- a/tests/test_remote_permission_conformance.cpp
+++ b/tests/test_remote_permission_conformance.cpp
@@ -459,6 +459,91 @@ TEST_CASE("A transport with no registry refuses everything rather than allowing 
     const auto outcome = runOverWebSocket(client, read);
     REQUIRE_FALSE(outcome.allowed);
     REQUIRE(outcome.errorCode == "permission_denied");
+
+    // MCP too, and not only its dispatched surface. `tools/list` and the two
+    // resource listings are answered from the endpoint's own catalogue without
+    // ever building a RequestContext, so they were readable with no registry
+    // configured at all — the whole operation surface and its schemas, handed to
+    // a client entitled to nothing. Fail-closed has to mean these as well.
+    RemoteMcpServer::Options mcpOptions;
+    mcpOptions.bearerToken = kToken;
+    // Deliberately no `clients` here either.
+    RemoteMcpServer mcpServer(service, mcpOptions);
+    REQUIRE(mcpServer.start());
+
+    httplib::Client mcpClient("http://127.0.0.1:" + std::to_string(mcpServer.boundPort()));
+
+    const auto catalogueCall = [&](const juce::String& method) {
+        auto* request = new juce::DynamicObject();
+        request->setProperty("jsonrpc", "2.0");
+        request->setProperty("id", 1);
+        request->setProperty("method", method);
+        request->setProperty("params", mcpParams(emptyObject()));
+
+        const httplib::Headers headers = {{"Authorization", std::string("Bearer ") + kToken},
+                                          {"MCP-Protocol-Version", kMcpVersion},
+                                          {"Mcp-Method", method.toStdString()}};
+        auto result = mcpClient.Post("/mcp", headers,
+                                     juce::JSON::toString(juce::var(request), true).toStdString(),
+                                     "application/json");
+        REQUIRE(result);
+        juce::var parsed;
+        REQUIRE(juce::JSON::parse(juce::String(result->body), parsed).wasOk());
+        return parsed;
+    };
+
+    for (const auto* method : {"tools/list", "resources/list", "resources/templates/list"}) {
+        INFO("method: " << method);
+        const auto reply = catalogueCall(method);
+        REQUIRE_FALSE(reply["error"].isVoid());
+        REQUIRE(static_cast<int>(reply["error"]["code"]) == MCP_PERMISSION_DENIED);
+        // Nothing leaked alongside the refusal.
+        REQUIRE(reply["result"].isVoid());
+    }
+
+    // And the dispatched surface, for the same server.
+    const Vector mcpRead{"read", "project.get", emptyObject(), ScopeSet{}, false};
+    const auto mcpOutcome = runOverMcp(mcpClient, mcpRead);
+    REQUIRE_FALSE(mcpOutcome.allowed);
+    REQUIRE(mcpOutcome.errorCode == "permission_denied");
+}
+
+TEST_CASE("The catalogue is readable by an ordinary client", "[remote][permissions][conformance]") {
+    // The other half of the gate above: `read` is the default every client has,
+    // so requiring it must not have made the catalogue unreachable for anyone
+    // who simply connected.
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteClientRegistry registry;
+
+    RemoteMcpServer::Options mcpOptions;
+    mcpOptions.bearerToken = kToken;
+    mcpOptions.clients = &registry;
+    RemoteMcpServer mcpServer(service, mcpOptions);
+    REQUIRE(mcpServer.start());
+
+    httplib::Client mcpClient("http://127.0.0.1:" + std::to_string(mcpServer.boundPort()));
+
+    auto* request = new juce::DynamicObject();
+    request->setProperty("jsonrpc", "2.0");
+    request->setProperty("id", 1);
+    request->setProperty("method", "tools/list");
+    request->setProperty("params", mcpParams(emptyObject()));
+
+    const httplib::Headers headers = {{"Authorization", std::string("Bearer ") + kToken},
+                                      {"MCP-Protocol-Version", kMcpVersion},
+                                      {"Mcp-Method", "tools/list"}};
+    auto result = mcpClient.Post("/mcp", headers,
+                                 juce::JSON::toString(juce::var(request), true).toStdString(),
+                                 "application/json");
+    REQUIRE(result);
+    juce::var parsed;
+    REQUIRE(juce::JSON::parse(juce::String(result->body), parsed).wasOk());
+
+    REQUIRE(parsed["error"].isVoid());
+    REQUIRE(parsed["result"]["tools"].getArray() != nullptr);
+    REQUIRE_FALSE(parsed["result"]["tools"].getArray()->isEmpty());
 }
 
 TEST_CASE("A refused connection is recorded without its credential",

--- a/tests/test_remote_permission_conformance.cpp
+++ b/tests/test_remote_permission_conformance.cpp
@@ -300,20 +300,20 @@ TEST_CASE("Both transports attribute a request to the name the client declared",
     MockMagdaApi api;
     RemoteApiService service(api);
     RemoteClientRegistry registry;
-    RemoteAuditLog log;
-    service.setAuditLog(&log);
+    auto log = std::make_shared<RemoteAuditLog>();
+    service.setAuditLog(log);
 
     RemoteWebSocketServer::Options wsOptions;
     wsOptions.bearerToken = kToken;
     wsOptions.clients = &registry;
-    wsOptions.audit = &log;
+    wsOptions.audit = log;
     RemoteWebSocketServer wsServer(service, wsOptions);
     REQUIRE(wsServer.start());
 
     RemoteMcpServer::Options mcpOptions;
     mcpOptions.bearerToken = kToken;
     mcpOptions.clients = &registry;
-    mcpOptions.audit = &log;
+    mcpOptions.audit = log;
     RemoteMcpServer mcpServer(service, mcpOptions);
     REQUIRE(mcpServer.start());
 
@@ -336,7 +336,7 @@ TEST_CASE("Both transports attribute a request to the name the client declared",
 
     // And both transports named it the same way in the record.
     juce::StringArray transports;
-    for (const auto& entry : log.forClient(kClient))
+    for (const auto& entry : log->forClient(kClient))
         transports.addIfNotAlreadyThere(entry.transport);
     REQUIRE(transports.contains(TRANSPORT_WEBSOCKET));
     REQUIRE(transports.contains(TRANSPORT_MCP));
@@ -596,7 +596,7 @@ TEST_CASE("A refused connection is recorded without its credential",
     MockMagdaApi api;
     RemoteApiService service(api);
     RemoteClientRegistry registry;
-    RemoteAuditLog log;
+    auto log = std::make_shared<RemoteAuditLog>();
 
     forgetAllRemoteSecrets();
     registerRemoteSecret(kToken);
@@ -604,7 +604,7 @@ TEST_CASE("A refused connection is recorded without its credential",
     RemoteWebSocketServer::Options wsOptions;
     wsOptions.bearerToken = kToken;
     wsOptions.clients = &registry;
-    wsOptions.audit = &log;
+    wsOptions.audit = log;
     RemoteWebSocketServer server(service, wsOptions);
     REQUIRE(server.start());
 
@@ -615,7 +615,7 @@ TEST_CASE("A refused connection is recorded without its credential",
     }
 
     bool sawRejection = false;
-    for (const auto& entry : log.entries()) {
+    for (const auto& entry : log->entries()) {
         if (entry.outcome != AuditOutcome::Rejected)
             continue;
         sawRejection = true;
@@ -642,8 +642,8 @@ TEST_CASE("Permission decisions hold up under concurrent load",
     api.project_.info.tempo = 120.0;
     RemoteApiService service(api);
     RemoteClientRegistry registry;
-    RemoteAuditLog log;
-    service.setAuditLog(&log);
+    auto log = std::make_shared<RemoteAuditLog>();
+    service.setAuditLog(log);
 
     constexpr int kClients = 4;
     constexpr int kGrantedRound = 15;
@@ -655,7 +655,7 @@ TEST_CASE("Permission decisions hold up under concurrent load",
     RemoteWebSocketServer::Options options;
     options.bearerToken = kToken;
     options.clients = &registry;
-    options.audit = &log;
+    options.audit = log;
     options.maxConnections = kClients + 2;
     // Above what the rounds below can generate, so a refusal here would be the
     // rate limiter rather than the permission model — a different test.
@@ -795,21 +795,54 @@ TEST_CASE("Permission decisions hold up under concurrent load",
 
     // Round 2 ran entirely without it.
     REQUIRE(rounds.allParked(kClients));
+
+    // Round 3 is the actual concurrency: the grant has to be moving *while* the
+    // requests run. Releasing the workers and then starting to toggle on this
+    // thread does not achieve that — if this thread is descheduled at the
+    // handover, the workers can finish the whole round before a single write
+    // lands, and the test passes having exercised nothing.
+    //
+    // So the flipper is its own thread, started first, and the workers are not
+    // released until it has demonstrably flipped at least once.
+    std::atomic<bool> flipping{true};
+    std::atomic<int> flips{0};
+    std::thread flipper([&] {
+        while (flipping.load()) {
+            registry.setScopes(kClient, ScopeSet{Scope::Read, Scope::Edit});
+            registry.setScopes(kClient, defaultClientScopes());
+            flips.fetch_add(1);
+            // Yielding rather than spinning flat out: on a two-core runner this
+            // would otherwise compete with the workers it exists to interfere
+            // with, which is the opposite of the point.
+            std::this_thread::yield();
+        }
+    });
+    // Joined however this test leaves, for the same reason the workers are.
+    struct FlipperGuard {
+        std::atomic<bool>& flipping;
+        std::thread& thread;
+        ~FlipperGuard() {
+            flipping.store(false);
+            if (thread.joinable())
+                thread.join();
+        }
+    } flipperGuard{flipping, flipper};
+
+    const auto flipDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+    while (flips.load() == 0 && std::chrono::steady_clock::now() < flipDeadline)
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    REQUIRE(flips.load() > 0);
+
+    const auto flipsBefore = flips.load();
     rounds.openRound(2);
 
-    // Round 3 is the actual concurrency: the grant moves continuously while the
-    // requests run. It contributes to neither bound below — its whole job is to
-    // exercise the per-request lookup racing a writer, and to fail loudly if
-    // that produces anything other than one of the two valid answers.
-    const auto racingDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(60);
-    while (allowed.load() + denied.load() + unexpected.load() < kTotal &&
-           std::chrono::steady_clock::now() < racingDeadline) {
-        registry.setScopes(kClient, ScopeSet{Scope::Read, Scope::Edit});
-        registry.setScopes(kClient, defaultClientScopes());
-        // Yielding rather than spinning flat out: on a two-core runner this
-        // thread would otherwise compete with the workers it is waiting for.
-        std::this_thread::yield();
-    }
+    // Every worker parks again at the end of the round, so this returns only
+    // once the racing requests are done — with the flipper still running
+    // throughout, rather than stopped early by a counter this thread was racing.
+    REQUIRE(rounds.allParked(kClients));
+    // The flipper kept working for the whole round, so the requests in it really
+    // did run against a moving grant.
+    REQUIRE(flips.load() > flipsBefore);
     rounds.openRound(3);
 
     for (auto& thread : pool.threads)
@@ -823,7 +856,7 @@ TEST_CASE("Permission decisions hold up under concurrent load",
     REQUIRE(denied.load() >= kClients * kRevokedRound);
 
     // Every one of them is in the record, and none of them carries a payload.
-    const auto entries = log.forClient(kClient);
+    const auto entries = log->forClient(kClient);
     REQUIRE(entries.size() >= static_cast<std::size_t>(kClients * kRequestsEach));
     for (const auto& entry : entries)
         REQUIRE_FALSE(entry.detail.contains("130"));

--- a/tests/test_remote_permission_conformance.cpp
+++ b/tests/test_remote_permission_conformance.cpp
@@ -535,6 +535,9 @@ TEST_CASE("Permission decisions hold up under concurrent load",
     std::atomic<int> allowed{0};
     std::atomic<int> denied{0};
     std::atomic<int> unexpected{0};
+    /// Requests finished, of any outcome. What the grant flipping below is
+    /// paced against, so the test does not depend on how fast the machine is.
+    std::atomic<int> completed{0};
 
     std::vector<std::thread> workers;
     workers.reserve(kClients);
@@ -560,27 +563,60 @@ TEST_CASE("Permission decisions hold up under concurrent load",
                     // means the load itself broke something, which is exactly
                     // what this is watching for.
                     unexpected.fetch_add(1);
+                completed.fetch_add(1);
             }
         });
     }
 
-    // Flip the grant back and forth underneath them. Every request must land on
-    // one side or the other, never in between.
-    for (int flip = 0; flip < 20; ++flip) {
-        registry.setScopes(kClient, (flip % 2) == 0 ? defaultClientScopes()
-                                                    : ScopeSet{Scope::Read, Scope::Edit});
-        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    // Flip the grant underneath them, anchored on their observed progress rather
+    // than on a sleep.
+    //
+    // The first version of this slept between flips and then asserted that both
+    // outcomes had occurred — which is a coincidence, not a property. On a
+    // machine where the requests outran the flipping, every one of them saw the
+    // same grant and the assertion failed with nothing wrong. Waiting for a
+    // quarter of the work to finish before revoking makes both halves
+    // guaranteed: those requests were allowed, and the three quarters that start
+    // afterwards cannot have been.
+    const auto total = kClients * kRequestsEach;
+    const auto waitForProgress = [&](int target) {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+        while (completed.load() < target && std::chrono::steady_clock::now() < deadline)
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        return completed.load() >= target;
+    };
+
+    REQUIRE(waitForProgress(total / 4));
+    registry.setScopes(kClient, defaultClientScopes());
+
+    // Hold it revoked until another quarter has gone through, so those requests
+    // are provably denied rather than probably denied.
+    REQUIRE(waitForProgress(total / 2));
+
+    // Only then start moving it, so the concurrent read-vs-write race on the
+    // grant is exercised too rather than only the two steady states. Bounded by
+    // the same deadline: a stalled worker should fail this test, not hang it.
+    const auto flipUntil = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+    while (completed.load() < total && std::chrono::steady_clock::now() < flipUntil) {
+        registry.setScopes(kClient, ScopeSet{Scope::Read, Scope::Edit});
+        registry.setScopes(kClient, defaultClientScopes());
+        // Yielding rather than spinning flat out: on a two-core runner this
+        // thread would otherwise compete with the workers it is waiting for.
+        // The loop's exit is progress-based, so this cannot affect the outcome.
+        std::this_thread::yield();
     }
-    registry.setScopes(kClient, ScopeSet{Scope::Read, Scope::Edit});
 
     for (auto& worker : workers)
         worker.join();
 
     REQUIRE(unexpected.load() == 0);
-    REQUIRE(allowed.load() + denied.load() == kClients * kRequestsEach);
-    // Both outcomes actually occurred, or the flipping above proved nothing.
-    REQUIRE(allowed.load() > 0);
-    REQUIRE(denied.load() > 0);
+    REQUIRE(allowed.load() + denied.load() == total);
+    // Both outcomes provably occurred rather than probably: the first quarter
+    // ran with the grant in place and the second with it withdrawn, and each
+    // was waited for rather than slept through. The margin absorbs the handful
+    // of requests already in flight when a flip lands.
+    REQUIRE(allowed.load() >= (total / 4) - kClients);
+    REQUIRE(denied.load() >= (total / 4) - kClients);
 
     // Every one of them is in the record, and none of them carries a payload.
     const auto entries = log.forClient(kClient);

--- a/tests/test_remote_permission_conformance.cpp
+++ b/tests/test_remote_permission_conformance.cpp
@@ -1,0 +1,498 @@
+// Cross-transport conformance (#1860).
+//
+// The acceptance criterion this file exists for is "WebSocket and MCP pass the
+// same operation test vectors". The risk it guards against is not that either
+// transport is wrong on its own — each has its own suite for that — but that
+// they drift: one refuses a read-only client's write and the other does not, or
+// they report the same refusal in shapes a client cannot tell apart.
+//
+// So the vectors are declared once, as data, and every one of them is driven
+// through both transports over real loopback sockets. A case added here is
+// automatically a case for both; a transport that grows its own opinion about a
+// vector fails here rather than in a bug report.
+//
+// Each transport is reached the way a real client reaches it — a WebSocket
+// upgrade with `?client=`, an HTTP POST with `clientInfo` in `_meta` — because
+// the identity plumbing is exactly what would otherwise differ between them.
+
+#include <httplib.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+#include <vector>
+
+#include "MockMagdaApi.hpp"
+#include "RemoteTestScopes.hpp"
+#include "magda/daw/api/remote_audit.hpp"
+#include "magda/daw/api/remote_clients.hpp"
+#include "magda/daw/api/remote_mcp_server.hpp"
+#include "magda/daw/api/remote_service.hpp"
+#include "magda/daw/api/remote_websocket_server.hpp"
+
+using namespace magda;
+using namespace magda::remote;
+using magda::test::MockMagdaApi;
+
+namespace {
+
+constexpr const char* kToken = "conformance-token-51ab";
+constexpr const char* kClient = "conformance";
+constexpr const char* kMcpVersion = "2026-07-28";
+
+struct MessageThreadRelaxation {
+    ScopedMessageThreadAssertionDisabler disabler;
+};
+
+juce::var object(std::initializer_list<std::pair<const char*, juce::var>> fields) {
+    auto* result = new juce::DynamicObject();
+    for (const auto& [key, value] : fields)
+        result->setProperty(key, value);
+    return result;
+}
+
+juce::var emptyObject() {
+    return juce::var(new juce::DynamicObject());
+}
+
+/**
+ * @brief One operation, and what a client holding `granted` should see.
+ *
+ * `granted` is the whole grant, not the missing piece, because that is what a
+ * user actually configures — and a vector written the other way round would
+ * stop describing a real configuration the moment scopes were split further.
+ */
+struct Vector {
+    const char* name;
+    const char* operation;
+    juce::var input;
+    ScopeSet granted;
+    bool expectAllowed;
+};
+
+std::vector<Vector> vectors() {
+    const auto read = defaultClientScopes();
+    return {
+        {"a read is allowed with the default grant", "project.get", emptyObject(), read, true},
+        {"a read is allowed with a write grant too", "tracks.list", emptyObject(),
+         ScopeSet{Scope::Read, Scope::Edit}, true},
+
+        {"an edit is refused without the edit scope", "project.setTempo",
+         object({{"tempo", 132.0}}), read, false},
+        {"an edit is allowed with it", "project.setTempo", object({{"tempo", 132.0}}),
+         ScopeSet{Scope::Read, Scope::Edit}, true},
+        {"an edit is refused by a transport grant", "project.setTempo", object({{"tempo", 132.0}}),
+         ScopeSet{Scope::Read, Scope::Transport}, false},
+
+        {"transport control is refused without the transport scope", "transport.play",
+         emptyObject(), read, false},
+        {"transport control is allowed with it", "transport.play", emptyObject(),
+         ScopeSet{Scope::Read, Scope::Transport}, true},
+        {"transport control is refused by an edit grant", "transport.stop", emptyObject(),
+         ScopeSet{Scope::Read, Scope::Edit}, false},
+
+        {"session launch is refused without the session scope", "session.stopAll", emptyObject(),
+         read, false},
+        {"session launch is allowed with it", "session.stopAll", emptyObject(),
+         ScopeSet{Scope::Read, Scope::Session}, true},
+        {"session launch is refused by an edit grant", "session.stopAll", emptyObject(),
+         ScopeSet{Scope::Read, Scope::Edit}, false},
+
+        {"selection is an edit", "selection.set", emptyObject(), read, false},
+        {"automation is an edit", "automation.listLanes", emptyObject(), read, true},
+    };
+}
+
+/// What a transport reported back, reduced to the two things both must agree on.
+struct Outcome {
+    bool allowed = false;
+    /// MAGDA's own error code — `permission_denied` when refused. Always
+    /// present in both wire formats, which is the point: a client should not
+    /// have to learn each transport's numbering to tell why it failed.
+    juce::String errorCode;
+};
+
+// ---------------------------------------------------------------------------
+// WebSocket
+// ---------------------------------------------------------------------------
+
+std::string wsEndpoint(const RemoteWebSocketServer& server) {
+    return "ws://127.0.0.1:" + std::to_string(server.boundPort()) + "/rpc?client=" + kClient;
+}
+
+Outcome runOverWebSocket(httplib::ws::WebSocketClient& client, const Vector& testCase) {
+    auto* request = new juce::DynamicObject();
+    request->setProperty("jsonrpc", "2.0");
+    request->setProperty("id", 1);
+    request->setProperty("method", testCase.operation);
+    request->setProperty("params", testCase.input);
+    REQUIRE(client.send(juce::JSON::toString(juce::var(request), true).toStdString()));
+
+    std::string reply;
+    REQUIRE(client.read(reply) == httplib::ws::ReadResult::Text);
+    juce::var parsed;
+    REQUIRE(juce::JSON::parse(juce::String(reply), parsed).wasOk());
+
+    Outcome outcome;
+    outcome.allowed = parsed["error"].isVoid();
+    if (!outcome.allowed)
+        outcome.errorCode = parsed["error"]["data"]["code"].toString();
+    return outcome;
+}
+
+// ---------------------------------------------------------------------------
+// MCP
+// ---------------------------------------------------------------------------
+
+juce::var mcpParams(juce::var params) {
+    if (params.getDynamicObject() == nullptr)
+        params = emptyObject();
+    params.getDynamicObject()->setProperty(
+        "_meta", object({{MCP_META_PROTOCOL_VERSION, kMcpVersion},
+                         {MCP_META_CLIENT_INFO, object({{"name", kClient}, {"version", "1.0"}})},
+                         {MCP_META_CLIENT_CAPABILITIES, emptyObject()}}));
+    return params;
+}
+
+Outcome runOverMcp(httplib::Client& client, const Vector& testCase) {
+    const auto params =
+        mcpParams(object({{"name", testCase.operation}, {"arguments", testCase.input}}));
+
+    auto* request = new juce::DynamicObject();
+    request->setProperty("jsonrpc", "2.0");
+    request->setProperty("id", 1);
+    request->setProperty("method", "tools/call");
+    request->setProperty("params", params);
+
+    httplib::Headers headers = {{"Authorization", std::string("Bearer ") + kToken},
+                                {"MCP-Protocol-Version", kMcpVersion},
+                                {"Mcp-Method", "tools/call"},
+                                {"Mcp-Name", testCase.operation}};
+
+    auto result =
+        client.Post("/mcp", headers, juce::JSON::toString(juce::var(request), true).toStdString(),
+                    "application/json");
+    REQUIRE(result);
+
+    juce::var parsed;
+    REQUIRE(juce::JSON::parse(juce::String(result->body), parsed).wasOk());
+
+    Outcome outcome;
+    // A tool failure is an execution error carrying the MAGDA envelope, not a
+    // JSON-RPC failure — that is deliberate (a model can act on it), and it is
+    // why this reads `isError` rather than `error`.
+    outcome.allowed = !static_cast<bool>(parsed["result"]["isError"]);
+    if (!outcome.allowed) {
+        const auto* content = parsed["result"]["content"].getArray();
+        REQUIRE(content != nullptr);
+        REQUIRE_FALSE(content->isEmpty());
+        juce::var envelope;
+        REQUIRE(juce::JSON::parse((*content)[0]["text"].toString(), envelope).wasOk());
+        outcome.errorCode = envelope["code"].toString();
+    }
+    return outcome;
+}
+
+}  // namespace
+
+TEST_CASE("Both transports enforce the same scopes on the same operations",
+          "[remote][permissions][conformance]") {
+    const MessageThreadRelaxation relaxation;
+
+    for (const auto& testCase : vectors()) {
+        INFO("vector: " << testCase.name);
+
+        // A fresh service, registry, and pair of listeners per vector. Sharing
+        // them would let one vector's mutation decide the next one's outcome,
+        // and the grants under test differ per vector anyway.
+        MockMagdaApi api;
+        RemoteApiService service(api);
+        RemoteClientRegistry registry;
+        registry.setScopes(kClient, testCase.granted);
+
+        RemoteWebSocketServer::Options wsOptions;
+        wsOptions.bearerToken = kToken;
+        wsOptions.clients = &registry;
+        RemoteWebSocketServer wsServer(service, wsOptions);
+        REQUIRE(wsServer.start());
+
+        RemoteMcpServer::Options mcpOptions;
+        mcpOptions.bearerToken = kToken;
+        mcpOptions.clients = &registry;
+        RemoteMcpServer mcpServer(service, mcpOptions);
+        REQUIRE(mcpServer.start());
+
+        Outcome overWebSocket;
+        {
+            httplib::ws::WebSocketClient client(
+                wsEndpoint(wsServer), {{"Authorization", std::string("Bearer ") + kToken}});
+            REQUIRE(client.connect());
+            overWebSocket = runOverWebSocket(client, testCase);
+        }
+
+        httplib::Client mcpClient("http://127.0.0.1:" + std::to_string(mcpServer.boundPort()));
+        const auto overMcp = runOverMcp(mcpClient, testCase);
+
+        // The vector's own expectation, on each transport…
+        REQUIRE(overWebSocket.allowed == testCase.expectAllowed);
+        REQUIRE(overMcp.allowed == testCase.expectAllowed);
+        // …and, whatever it was, the same answer from both. Asserted separately
+        // because it is the property that survives someone changing a vector's
+        // expectation without noticing they changed only one transport.
+        REQUIRE(overWebSocket.allowed == overMcp.allowed);
+
+        if (!testCase.expectAllowed) {
+            REQUIRE(overWebSocket.errorCode == "permission_denied");
+            REQUIRE(overMcp.errorCode == "permission_denied");
+        }
+    }
+}
+
+TEST_CASE("Both transports attribute a request to the name the client declared",
+          "[remote][permissions][conformance]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteClientRegistry registry;
+    RemoteAuditLog log;
+    service.setAuditLog(&log);
+
+    RemoteWebSocketServer::Options wsOptions;
+    wsOptions.bearerToken = kToken;
+    wsOptions.clients = &registry;
+    wsOptions.audit = &log;
+    RemoteWebSocketServer wsServer(service, wsOptions);
+    REQUIRE(wsServer.start());
+
+    RemoteMcpServer::Options mcpOptions;
+    mcpOptions.bearerToken = kToken;
+    mcpOptions.clients = &registry;
+    mcpOptions.audit = &log;
+    RemoteMcpServer mcpServer(service, mcpOptions);
+    REQUIRE(mcpServer.start());
+
+    const Vector read{"read", "project.get", emptyObject(), defaultClientScopes(), true};
+    {
+        httplib::ws::WebSocketClient client(wsEndpoint(wsServer),
+                                            {{"Authorization", std::string("Bearer ") + kToken}});
+        REQUIRE(client.connect());
+        REQUIRE(runOverWebSocket(client, read).allowed);
+    }
+    httplib::Client mcpClient("http://127.0.0.1:" + std::to_string(mcpServer.boundPort()));
+    REQUIRE(runOverMcp(mcpClient, read).allowed);
+
+    // One client, seen over two transports, is one entry in the settings list —
+    // which is the whole reason grants are keyed by declared name rather than
+    // by connection.
+    const auto grants = registry.grants();
+    REQUIRE(grants.size() == 1);
+    REQUIRE(grants.front().name == kClient);
+
+    // And both transports named it the same way in the record.
+    juce::StringArray transports;
+    for (const auto& entry : log.forClient(kClient))
+        transports.addIfNotAlreadyThere(entry.transport);
+    REQUIRE(transports.contains(TRANSPORT_WEBSOCKET));
+    REQUIRE(transports.contains(TRANSPORT_MCP));
+}
+
+TEST_CASE("An unnamed client is the anonymous one on both transports",
+          "[remote][permissions][conformance]") {
+    // Refusing an anonymous client outright would break every conforming MCP
+    // host that simply does not send `clientInfo`, and every WebSocket library
+    // whose user did not know about `?client=`. They get a shared, read-only
+    // bucket instead.
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteClientRegistry registry;
+
+    RemoteWebSocketServer::Options wsOptions;
+    wsOptions.bearerToken = kToken;
+    wsOptions.clients = &registry;
+    RemoteWebSocketServer wsServer(service, wsOptions);
+    REQUIRE(wsServer.start());
+
+    {
+        httplib::ws::WebSocketClient client(
+            "ws://127.0.0.1:" + std::to_string(wsServer.boundPort()) + "/rpc",
+            {{"Authorization", std::string("Bearer ") + kToken}});
+        REQUIRE(client.connect());
+
+        const Vector read{"read", "project.get", emptyObject(), defaultClientScopes(), true};
+        REQUIRE(runOverWebSocket(client, read).allowed);
+
+        const Vector write{"write", "project.setTempo", object({{"tempo", 140.0}}),
+                           defaultClientScopes(), false};
+        const auto refused = runOverWebSocket(client, write);
+        REQUIRE_FALSE(refused.allowed);
+        REQUIRE(refused.errorCode == "permission_denied");
+    }
+
+    REQUIRE(registry.grants().size() == 1);
+    REQUIRE(registry.grants().front().name == ANONYMOUS_CLIENT);
+}
+
+TEST_CASE("Revoking a grant takes effect on the next request, with no reconnect",
+          "[remote][permissions][conformance]") {
+    // The acceptance criterion in its most direct form: the client stays
+    // connected across the revocation and simply stops being able to write.
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.project_.info.tempo = 120.0;
+    RemoteApiService service(api);
+    RemoteClientRegistry registry;
+    registry.setScopes(kClient, ScopeSet{Scope::Read, Scope::Edit});
+
+    RemoteWebSocketServer::Options wsOptions;
+    wsOptions.bearerToken = kToken;
+    wsOptions.clients = &registry;
+    RemoteWebSocketServer server(service, wsOptions);
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(wsEndpoint(server),
+                                        {{"Authorization", std::string("Bearer ") + kToken}});
+    REQUIRE(client.connect());
+
+    const Vector write{"write", "project.setTempo", object({{"tempo", 140.0}}),
+                       ScopeSet{Scope::Read, Scope::Edit}, true};
+    REQUIRE(runOverWebSocket(client, write).allowed);
+    REQUIRE(api.project_.info.tempo == 140.0);
+
+    registry.setScopes(kClient, defaultClientScopes());
+
+    const auto refused = runOverWebSocket(client, write);
+    REQUIRE_FALSE(refused.allowed);
+    REQUIRE(refused.errorCode == "permission_denied");
+    REQUIRE(api.project_.info.tempo == 140.0);
+
+    // Granting again is equally immediate, on the same socket.
+    registry.setScopes(kClient, ScopeSet{Scope::Read, Scope::Edit});
+    REQUIRE(runOverWebSocket(client, write).allowed);
+}
+
+TEST_CASE("Disconnecting a client stops it executing anything further",
+          "[remote][permissions][conformance]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.project_.info.tempo = 120.0;
+    RemoteApiService service(api);
+    RemoteClientRegistry registry;
+    registry.setScopes(kClient, allScopes());
+
+    RemoteWebSocketServer::Options wsOptions;
+    wsOptions.bearerToken = kToken;
+    wsOptions.clients = &registry;
+    RemoteWebSocketServer server(service, wsOptions);
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(wsEndpoint(server),
+                                        {{"Authorization", std::string("Bearer ") + kToken}});
+    REQUIRE(client.connect());
+
+    const Vector write{"write", "project.setTempo", object({{"tempo", 140.0}}), allScopes(), true};
+    REQUIRE(runOverWebSocket(client, write).allowed);
+    REQUIRE(api.project_.info.tempo == 140.0);
+
+    REQUIRE(registry.connectionCount() == 1);
+    REQUIRE(registry.disconnectClient(kClient) == 1);
+
+    // The socket closes within a read timeout, but the effect that matters is
+    // immediate: a request sent after the disconnect is never executed, whether
+    // the frame lands before the reader notices or the send fails outright.
+    auto* request = new juce::DynamicObject();
+    request->setProperty("jsonrpc", "2.0");
+    request->setProperty("id", 2);
+    request->setProperty("method", "project.setTempo");
+    request->setProperty("params", object({{"tempo", 90.0}}));
+    client.send(juce::JSON::toString(juce::var(request), true).toStdString());
+
+    std::string reply;
+    client.read(reply);
+    REQUIRE(api.project_.info.tempo == 140.0);
+}
+
+TEST_CASE("Neither transport opens a listener without a credential",
+          "[remote][permissions][conformance]") {
+    // "Disabled means disabled", asserted for both: there is no configuration
+    // that produces an anonymous listener on either port.
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteClientRegistry registry;
+
+    RemoteWebSocketServer::Options wsOptions;
+    wsOptions.clients = &registry;
+    RemoteWebSocketServer wsServer(service, wsOptions);
+    REQUIRE_FALSE(wsServer.start());
+    REQUIRE(wsServer.boundPort() == 0);
+
+    RemoteMcpServer::Options mcpOptions;
+    mcpOptions.clients = &registry;
+    RemoteMcpServer mcpServer(service, mcpOptions);
+    REQUIRE_FALSE(mcpServer.start());
+    REQUIRE(mcpServer.boundPort() == 0);
+}
+
+TEST_CASE("A transport with no registry refuses everything rather than allowing it",
+          "[remote][permissions][conformance]") {
+    // Fail closed, and the reason it matters: a third transport that forgot to
+    // consult the registry should refuse every request loudly on its first test
+    // run, not hand out the project silently and pass.
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    RemoteWebSocketServer::Options wsOptions;
+    wsOptions.bearerToken = kToken;
+    // Deliberately no `clients`.
+    RemoteWebSocketServer server(service, wsOptions);
+    REQUIRE(server.start());
+
+    httplib::ws::WebSocketClient client(wsEndpoint(server),
+                                        {{"Authorization", std::string("Bearer ") + kToken}});
+    REQUIRE(client.connect());
+
+    const Vector read{"read", "project.get", emptyObject(), ScopeSet{}, false};
+    const auto outcome = runOverWebSocket(client, read);
+    REQUIRE_FALSE(outcome.allowed);
+    REQUIRE(outcome.errorCode == "permission_denied");
+}
+
+TEST_CASE("A refused connection is recorded without its credential",
+          "[remote][permissions][conformance]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteClientRegistry registry;
+    RemoteAuditLog log;
+
+    forgetAllRemoteSecrets();
+    registerRemoteSecret(kToken);
+
+    RemoteWebSocketServer::Options wsOptions;
+    wsOptions.bearerToken = kToken;
+    wsOptions.clients = &registry;
+    wsOptions.audit = &log;
+    RemoteWebSocketServer server(service, wsOptions);
+    REQUIRE(server.start());
+
+    {
+        httplib::ws::WebSocketClient client(
+            wsEndpoint(server), {{"Authorization", std::string("Bearer ") + kToken + "-wrong"}});
+        REQUIRE_FALSE(client.connect());
+    }
+
+    bool sawRejection = false;
+    for (const auto& entry : log.entries()) {
+        if (entry.outcome != AuditOutcome::Rejected)
+            continue;
+        sawRejection = true;
+        REQUIRE(entry.operation == AUDIT_CONNECTION_REJECTED);
+        // The reason, and nothing that could be a credential.
+        REQUIRE(entry.detail.contains("token"));
+        REQUIRE_FALSE(entry.detail.contains(kToken));
+    }
+    REQUIRE(sawRejection);
+
+    forgetAllRemoteSecrets();
+}

--- a/tests/test_remote_permission_conformance.cpp
+++ b/tests/test_remote_permission_conformance.cpp
@@ -20,6 +20,8 @@
 #include <atomic>
 #include <catch2/catch_test_macros.hpp>
 #include <chrono>
+#include <condition_variable>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -136,6 +138,48 @@ Outcome runOverWebSocket(httplib::ws::WebSocketClient& client, const Vector& tes
     REQUIRE(juce::JSON::parse(juce::String(reply), parsed).wasOk());
 
     Outcome outcome;
+    outcome.allowed = parsed["error"].isVoid();
+    if (!outcome.allowed)
+        outcome.errorCode = parsed["error"]["data"]["code"].toString();
+    return outcome;
+}
+
+/// The same round trip, with no Catch2 macros in it.
+///
+/// `runOverWebSocket` asserts as it goes, which is right for a single-threaded
+/// test and wrong for the load one: Catch2's assertion macros are not
+/// thread-safe, and four workers driving them concurrently is undefined
+/// behaviour that happens to look like a passing test. This reports failure in
+/// its return value instead, and the load test asserts on the totals from the
+/// main thread once the workers are joined.
+struct RawOutcome {
+    /// False when the exchange itself failed — nothing was sent, nothing came
+    /// back, or what came back was not JSON.
+    bool answered = false;
+    bool allowed = false;
+    juce::String errorCode;
+};
+
+RawOutcome sendWrite(httplib::ws::WebSocketClient& client) {
+    auto* request = new juce::DynamicObject();
+    request->setProperty("jsonrpc", "2.0");
+    request->setProperty("id", 1);
+    request->setProperty("method", "project.setTempo");
+    request->setProperty("params", object({{"tempo", 130.0}}));
+
+    RawOutcome outcome;
+    if (!client.send(juce::JSON::toString(juce::var(request), true).toStdString()))
+        return outcome;
+
+    std::string reply;
+    if (client.read(reply) != httplib::ws::ReadResult::Text)
+        return outcome;
+
+    juce::var parsed;
+    if (!juce::JSON::parse(juce::String(reply), parsed).wasOk())
+        return outcome;
+
+    outcome.answered = true;
     outcome.allowed = parsed["error"].isVoid();
     if (!outcome.allowed)
         outcome.errorCode = parsed["error"]["data"]["code"].toString();
@@ -602,14 +646,18 @@ TEST_CASE("Permission decisions hold up under concurrent load",
     service.setAuditLog(&log);
 
     constexpr int kClients = 4;
-    constexpr int kRequestsEach = 40;
+    constexpr int kGrantedRound = 15;
+    constexpr int kRevokedRound = 15;
+    constexpr int kRacingRound = 10;
+    constexpr int kRequestsEach = kGrantedRound + kRevokedRound + kRacingRound;
+    constexpr int kTotal = kClients * kRequestsEach;
 
     RemoteWebSocketServer::Options options;
     options.bearerToken = kToken;
     options.clients = &registry;
     options.audit = &log;
     options.maxConnections = kClients + 2;
-    // Above what the loop below can generate, so a refusal here would be the
+    // Above what the rounds below can generate, so a refusal here would be the
     // rate limiter rather than the permission model — a different test.
     options.maxRequestsPerSecond = 10'000.0;
     RemoteWebSocketServer server(service, options);
@@ -620,88 +668,159 @@ TEST_CASE("Permission decisions hold up under concurrent load",
     std::atomic<int> allowed{0};
     std::atomic<int> denied{0};
     std::atomic<int> unexpected{0};
-    /// Requests finished, of any outcome. What the grant flipping below is
-    /// paced against, so the test does not depend on how fast the machine is.
-    std::atomic<int> completed{0};
 
-    std::vector<std::thread> workers;
-    workers.reserve(kClients);
+    /**
+     * @brief The rounds, and the barrier between them.
+     *
+     * Polling a progress counter is not enough, and the earlier version of this
+     * test proved it twice: a sleep-paced one flaked on CI, and the counter-paced
+     * replacement was still wrong, because "a quarter of the work has finished"
+     * does not mean the main thread *resumes* at that boundary — it can wake with
+     * the workers nearly done and have almost nothing left to deny.
+     *
+     * So the grant only ever moves while every worker is parked here. A request
+     * therefore belongs to the round it was issued in, by construction, and the
+     * bounds below are arithmetic rather than a race the test usually wins.
+     */
+    struct Rounds {
+        std::mutex mutex;
+        std::condition_variable cv;
+        int open = 0;     ///< The highest round workers may run.
+        int waiting = 0;  ///< Workers parked at the current boundary.
+        bool aborted = false;
+
+        /// Worker: park until `round` opens. False means give up — the main
+        /// thread has abandoned the test and is trying to join.
+        bool await(int round) {
+            std::unique_lock<std::mutex> lock(mutex);
+            ++waiting;
+            cv.notify_all();
+            cv.wait(lock, [&] { return aborted || open >= round; });
+            return !aborted;
+        }
+
+        /// Main: block until every worker is parked, so nothing is mid-request.
+        bool allParked(int count) {
+            std::unique_lock<std::mutex> lock(mutex);
+            return cv.wait_for(lock, std::chrono::seconds(60),
+                               [&] { return aborted || waiting >= count; });
+        }
+
+        void openRound(int round) {
+            {
+                const std::lock_guard<std::mutex> lock(mutex);
+                open = round;
+                waiting = 0;
+            }
+            cv.notify_all();
+        }
+
+        void abort() {
+            {
+                const std::lock_guard<std::mutex> lock(mutex);
+                aborted = true;
+            }
+            cv.notify_all();
+        }
+    } rounds;
+
+    /**
+     * @brief Owns the workers, and joins them however this test leaves.
+     *
+     * A failed `REQUIRE` throws, and unwinding past a `std::thread` that is
+     * still joinable calls `std::terminate` — turning a legible assertion
+     * failure into a process abort with no output. Aborting first is what makes
+     * the join safe: workers parked at a barrier that will now never open would
+     * otherwise deadlock the join they are being joined by.
+     */
+    struct WorkerPool {
+        Rounds& rounds;
+        std::vector<std::thread> threads;
+
+        ~WorkerPool() {
+            rounds.abort();
+            for (auto& thread : threads)
+                if (thread.joinable())
+                    thread.join();
+        }
+    } pool{rounds, {}};
+
+    pool.threads.reserve(kClients);
     for (int worker = 0; worker < kClients; ++worker) {
-        workers.emplace_back([&] {
+        pool.threads.emplace_back([&] {
+            // No Catch2 macros on this thread. `REQUIRE` is not thread-safe, so
+            // the worker records into atomics and every assertion is made on the
+            // main thread once the workers have been joined.
             httplib::ws::WebSocketClient client(
                 wsEndpoint(server), {{"Authorization", std::string("Bearer ") + kToken}});
-            if (!client.connect()) {
+            const auto connected = client.connect();
+            if (!connected)
                 unexpected.fetch_add(1);
-                return;
-            }
 
-            const Vector write{"write", "project.setTempo", object({{"tempo", 130.0}}),
-                               ScopeSet{Scope::Read, Scope::Edit}, true};
-            for (int index = 0; index < kRequestsEach; ++index) {
-                const auto outcome = runOverWebSocket(client, write);
-                if (outcome.allowed)
-                    allowed.fetch_add(1);
-                else if (outcome.errorCode == "permission_denied")
-                    denied.fetch_add(1);
-                else
-                    // Anything else — a timeout, a conflict, a dropped reply —
-                    // means the load itself broke something, which is exactly
-                    // what this is watching for.
-                    unexpected.fetch_add(1);
-                completed.fetch_add(1);
-            }
+            const auto round = [&](int count) {
+                for (int index = 0; index < count && connected; ++index) {
+                    const auto outcome = sendWrite(client);
+                    if (!outcome.answered)
+                        unexpected.fetch_add(1);
+                    else if (outcome.allowed)
+                        allowed.fetch_add(1);
+                    else if (outcome.errorCode == "permission_denied")
+                        denied.fetch_add(1);
+                    else
+                        // A timeout, a conflict, a dropped reply — the load
+                        // itself broke something, which is what this watches for.
+                        unexpected.fetch_add(1);
+                }
+            };
+
+            round(kGrantedRound);
+            if (!rounds.await(1))
+                return;
+            round(kRevokedRound);
+            if (!rounds.await(2))
+                return;
+            round(kRacingRound);
+            // Parking here too, so the main thread knows the racing round is
+            // over and can stop flipping before it starts asserting.
+            rounds.await(3);
         });
     }
 
-    // Flip the grant underneath them, anchored on their observed progress rather
-    // than on a sleep.
-    //
-    // The first version of this slept between flips and then asserted that both
-    // outcomes had occurred — which is a coincidence, not a property. On a
-    // machine where the requests outran the flipping, every one of them saw the
-    // same grant and the assertion failed with nothing wrong. Waiting for a
-    // quarter of the work to finish before revoking makes both halves
-    // guaranteed: those requests were allowed, and the three quarters that start
-    // afterwards cannot have been.
-    const auto total = kClients * kRequestsEach;
-    const auto waitForProgress = [&](int target) {
-        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
-        while (completed.load() < target && std::chrono::steady_clock::now() < deadline)
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        return completed.load() >= target;
-    };
-
-    REQUIRE(waitForProgress(total / 4));
+    // Round 1 ran entirely with the grant in place. Every worker is now parked,
+    // so nothing is in flight and the revoke below cannot be read by a request
+    // that already started.
+    REQUIRE(rounds.allParked(kClients));
     registry.setScopes(kClient, defaultClientScopes());
+    rounds.openRound(1);
 
-    // Hold it revoked until another quarter has gone through, so those requests
-    // are provably denied rather than probably denied.
-    REQUIRE(waitForProgress(total / 2));
+    // Round 2 ran entirely without it.
+    REQUIRE(rounds.allParked(kClients));
+    rounds.openRound(2);
 
-    // Only then start moving it, so the concurrent read-vs-write race on the
-    // grant is exercised too rather than only the two steady states. Bounded by
-    // the same deadline: a stalled worker should fail this test, not hang it.
-    const auto flipUntil = std::chrono::steady_clock::now() + std::chrono::seconds(30);
-    while (completed.load() < total && std::chrono::steady_clock::now() < flipUntil) {
+    // Round 3 is the actual concurrency: the grant moves continuously while the
+    // requests run. It contributes to neither bound below — its whole job is to
+    // exercise the per-request lookup racing a writer, and to fail loudly if
+    // that produces anything other than one of the two valid answers.
+    const auto racingDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(60);
+    while (allowed.load() + denied.load() + unexpected.load() < kTotal &&
+           std::chrono::steady_clock::now() < racingDeadline) {
         registry.setScopes(kClient, ScopeSet{Scope::Read, Scope::Edit});
         registry.setScopes(kClient, defaultClientScopes());
         // Yielding rather than spinning flat out: on a two-core runner this
         // thread would otherwise compete with the workers it is waiting for.
-        // The loop's exit is progress-based, so this cannot affect the outcome.
         std::this_thread::yield();
     }
+    rounds.openRound(3);
 
-    for (auto& worker : workers)
-        worker.join();
+    for (auto& thread : pool.threads)
+        thread.join();
 
     REQUIRE(unexpected.load() == 0);
-    REQUIRE(allowed.load() + denied.load() == total);
-    // Both outcomes provably occurred rather than probably: the first quarter
-    // ran with the grant in place and the second with it withdrawn, and each
-    // was waited for rather than slept through. The margin absorbs the handful
-    // of requests already in flight when a flip lands.
-    REQUIRE(allowed.load() >= (total / 4) - kClients);
-    REQUIRE(denied.load() >= (total / 4) - kClients);
+    REQUIRE(allowed.load() + denied.load() == kTotal);
+    // Arithmetic, not a race: round 1 is all-allowed and round 2 all-denied
+    // because the grant only moved while every worker was parked between them.
+    REQUIRE(allowed.load() >= kClients * kGrantedRound);
+    REQUIRE(denied.load() >= kClients * kRevokedRound);
 
     // Every one of them is in the record, and none of them carries a payload.
     const auto entries = log.forClient(kClient);

--- a/tests/test_remote_permission_conformance.cpp
+++ b/tests/test_remote_permission_conformance.cpp
@@ -722,7 +722,33 @@ TEST_CASE("Permission decisions hold up under concurrent load",
             }
             cv.notify_all();
         }
+
+        bool isAborted() {
+            const std::lock_guard<std::mutex> lock(mutex);
+            return aborted;
+        }
     } rounds;
+
+    /**
+     * @brief The grant writer that races round 3, and the proof that it did.
+     *
+     * `flips` alone is not evidence. Sampling it on the main thread around the
+     * round leaves a gap at each end — a flip landing between the sample and the
+     * release, with the flipper then descheduled for the whole round, satisfies
+     * "the count moved" while nothing raced anything.
+     *
+     * So the observation is made by the workers, over their own requests:
+     * each reads the counter either side of its racing round, and a worker that
+     * saw it move was demonstrably issuing requests while the grant was being
+     * rewritten. That is the property, asserted directly, with no window for the
+     * main thread to race.
+     */
+    struct Racing {
+        std::atomic<bool> running{true};
+        std::atomic<int> flips{0};
+        /// Workers that saw `flips` move across their own racing round.
+        std::atomic<int> observedConcurrent{0};
+    } racing;
 
     /**
      * @brief Owns the workers, and joins them however this test leaves.
@@ -779,7 +805,30 @@ TEST_CASE("Permission decisions hold up under concurrent load",
             round(kRevokedRound);
             if (!rounds.await(2))
                 return;
+
+            // Give the flipper a moment to get going, so the round does not
+            // start against a writer that has not woken yet. Best effort, and
+            // deliberately brief: this thread is not in `read()` while it waits,
+            // and the server pings every second and drops a client that stops
+            // answering — so a long wait here would kill the connection and turn
+            // a diagnosable failure into forty unexplained transport errors. In
+            // the healthy case the flipper is already spinning and this costs
+            // nothing; if it expires, `observedConcurrent` below is what reports
+            // the problem, and it says exactly what went wrong.
+            const auto flipDeadline =
+                std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+            while (racing.flips.load() == 0 && !rounds.isAborted() &&
+                   std::chrono::steady_clock::now() < flipDeadline)
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+            // Either side of this worker's own requests: if the counter moved
+            // between them, the grant was provably being rewritten while this
+            // worker was issuing them.
+            const auto flipsBefore = racing.flips.load();
             round(kRacingRound);
+            if (racing.flips.load() > flipsBefore)
+                racing.observedConcurrent.fetch_add(1);
+
             // Parking here too, so the main thread knows the racing round is
             // over and can stop flipping before it starts asserting.
             rounds.await(3);
@@ -797,20 +846,14 @@ TEST_CASE("Permission decisions hold up under concurrent load",
     REQUIRE(rounds.allParked(kClients));
 
     // Round 3 is the actual concurrency: the grant has to be moving *while* the
-    // requests run. Releasing the workers and then starting to toggle on this
-    // thread does not achieve that — if this thread is descheduled at the
-    // handover, the workers can finish the whole round before a single write
-    // lands, and the test passes having exercised nothing.
-    //
-    // So the flipper is its own thread, started first, and the workers are not
-    // released until it has demonstrably flipped at least once.
-    std::atomic<bool> flipping{true};
-    std::atomic<int> flips{0};
+    // requests run. The flipper is its own thread, started before the round is
+    // released — releasing the workers and only then toggling on this thread
+    // would let a deschedule at the handover produce a round that raced nothing.
     std::thread flipper([&] {
-        while (flipping.load()) {
+        while (racing.running.load()) {
             registry.setScopes(kClient, ScopeSet{Scope::Read, Scope::Edit});
             registry.setScopes(kClient, defaultClientScopes());
-            flips.fetch_add(1);
+            racing.flips.fetch_add(1);
             // Yielding rather than spinning flat out: on a two-core runner this
             // would otherwise compete with the workers it exists to interfere
             // with, which is the opposite of the point.
@@ -819,30 +862,20 @@ TEST_CASE("Permission decisions hold up under concurrent load",
     });
     // Joined however this test leaves, for the same reason the workers are.
     struct FlipperGuard {
-        std::atomic<bool>& flipping;
+        Racing& racing;
         std::thread& thread;
         ~FlipperGuard() {
-            flipping.store(false);
+            racing.running.store(false);
             if (thread.joinable())
                 thread.join();
         }
-    } flipperGuard{flipping, flipper};
+    } flipperGuard{racing, flipper};
 
-    const auto flipDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
-    while (flips.load() == 0 && std::chrono::steady_clock::now() < flipDeadline)
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    REQUIRE(flips.load() > 0);
-
-    const auto flipsBefore = flips.load();
     rounds.openRound(2);
 
     // Every worker parks again at the end of the round, so this returns only
-    // once the racing requests are done — with the flipper still running
-    // throughout, rather than stopped early by a counter this thread was racing.
+    // once the racing requests are done, with the flipper still running.
     REQUIRE(rounds.allParked(kClients));
-    // The flipper kept working for the whole round, so the requests in it really
-    // did run against a moving grant.
-    REQUIRE(flips.load() > flipsBefore);
     rounds.openRound(3);
 
     for (auto& thread : pool.threads)
@@ -854,6 +887,12 @@ TEST_CASE("Permission decisions hold up under concurrent load",
     // because the grant only moved while every worker was parked between them.
     REQUIRE(allowed.load() >= kClients * kGrantedRound);
     REQUIRE(denied.load() >= kClients * kRevokedRound);
+    // And round 3 raced something: at least one worker saw the grant rewritten
+    // between its own first and last racing request. Asserted from the worker's
+    // own observation rather than from a counter sampled around the round on
+    // this thread, which leaves a gap at each end that a descheduled flipper
+    // can slip through while the count still moves.
+    REQUIRE(racing.observedConcurrent.load() > 0);
 
     // Every one of them is in the record, and none of them carries a payload.
     const auto entries = log->forClient(kClient);

--- a/tests/test_remote_permissions.cpp
+++ b/tests/test_remote_permissions.cpp
@@ -481,15 +481,15 @@ TEST_CASE("A dispatched request is recorded with its outcome", "[remote][permiss
     const MessageThreadRelaxation relaxation;
     MockMagdaApi api;
     RemoteApiService service(api);
-    RemoteAuditLog log;
-    service.setAuditLog(&log);
+    auto log = std::make_shared<RemoteAuditLog>();
+    service.setAuditLog(log);
 
     auto context = contextWith(defaultClientScopes(), "cursor");
     context.requestId = "req-7";
     run(service, "project.get", emptyInput(), context);
     run(service, "project.setTempo", object({{"tempo", 140.0}}), context);
 
-    const auto entries = log.entries();
+    const auto entries = log->entries();
     REQUIRE(entries.size() == 2);
 
     REQUIRE(entries[0].client == "cursor");
@@ -513,13 +513,13 @@ TEST_CASE("A failure is recorded by code, never by message", "[remote][permissio
     const MessageThreadRelaxation relaxation;
     MockMagdaApi api;
     RemoteApiService service(api);
-    RemoteAuditLog log;
-    service.setAuditLog(&log);
+    auto log = std::make_shared<RemoteAuditLog>();
+    service.setAuditLog(log);
 
     run(service, "project.setTempo", object({{"tempo", "not-a-number"}}),
         contextWith(ScopeSet{Scope::Read, Scope::Edit}, "cursor"));
 
-    const auto entries = log.entries();
+    const auto entries = log->entries();
     REQUIRE(entries.size() == 1);
     REQUIRE(entries[0].outcome == AuditOutcome::Failed);
     REQUIRE(entries[0].detail == "validation_failed");
@@ -532,47 +532,47 @@ TEST_CASE("In-process callers are not audited", "[remote][permissions][audit]") 
     const MessageThreadRelaxation relaxation;
     MockMagdaApi api;
     RemoteApiService service(api);
-    RemoteAuditLog log;
-    service.setAuditLog(&log);
+    auto log = std::make_shared<RemoteAuditLog>();
+    service.setAuditLog(log);
 
     run(service, "project.get", emptyInput(), magda::test::fullyGrantedContext());
-    REQUIRE(log.entries().empty());
+    REQUIRE(log->entries().empty());
 }
 
 TEST_CASE("The audit log is bounded and says when it lost entries",
           "[remote][permissions][audit]") {
-    RemoteAuditLog log(4);
+    auto log = std::make_shared<RemoteAuditLog>(4);
     for (int index = 0; index < 10; ++index) {
         AuditEntry entry;
         entry.client = "cursor";
         entry.operation = "project.get";
         entry.detail = juce::String(index);
-        log.record(entry);
+        log->record(entry);
     }
 
-    REQUIRE(log.size() == 4);
-    REQUIRE(log.totalRecorded() == 10);
+    REQUIRE(log->size() == 4);
+    REQUIRE(log->totalRecorded() == 10);
     // Oldest dropped, newest kept.
-    REQUIRE(log.entries().front().detail == "6");
-    REQUIRE(log.entries().back().detail == "9");
+    REQUIRE(log->entries().front().detail == "6");
+    REQUIRE(log->entries().back().detail == "9");
 
-    REQUIRE(log.recent(2).size() == 2);
-    REQUIRE(log.recent(2).back().detail == "9");
+    REQUIRE(log->recent(2).size() == 2);
+    REQUIRE(log->recent(2).back().detail == "9");
     // Asking for more than there is returns what there is.
-    REQUIRE(log.recent(100).size() == 4);
+    REQUIRE(log->recent(100).size() == 4);
 }
 
 TEST_CASE("Entries can be read back for one client", "[remote][permissions][audit]") {
-    RemoteAuditLog log;
+    auto log = std::make_shared<RemoteAuditLog>();
     for (const auto* name : {"cursor", "monitor", "cursor"}) {
         AuditEntry entry;
         entry.client = name;
         entry.operation = "project.get";
-        log.record(entry);
+        log->record(entry);
     }
-    REQUIRE(log.forClient("cursor").size() == 2);
-    REQUIRE(log.forClient("monitor").size() == 1);
-    REQUIRE(log.forClient("nobody").empty());
+    REQUIRE(log->forClient("cursor").size() == 2);
+    REQUIRE(log->forClient("monitor").size() == 1);
+    REQUIRE(log->forClient("nobody").empty());
 }
 
 // ===========================================================================
@@ -633,14 +633,14 @@ TEST_CASE("An audit detail is redacted on the way in", "[remote][permissions][re
     const juce::String token = "abcdef0123456789";
     registerRemoteSecret(token);
 
-    RemoteAuditLog log;
+    auto log = std::make_shared<RemoteAuditLog>();
     AuditEntry entry;
     entry.client = "cursor";
     entry.operation = "connection.rejected";
     entry.detail = "token " + token + " refused";
-    log.record(entry);
+    log->record(entry);
 
-    REQUIRE_FALSE(log.entries().front().detail.contains(token));
+    REQUIRE_FALSE(log->entries().front().detail.contains(token));
     forgetAllRemoteSecrets();
 }
 

--- a/tests/test_remote_permissions.cpp
+++ b/tests/test_remote_permissions.cpp
@@ -1,0 +1,654 @@
+// The permission model (#1860): scopes, grants, revocation, and the audit log.
+//
+// Three layers, tested where each one lives:
+//
+//  - `remote_scopes`: the vocabulary, and the normalisation that decides two
+//    spellings of a client name are one client.
+//  - `RemoteClientRegistry`: grants, defaults, connections, disconnection.
+//  - `RemoteApiService`: the enforcement itself, and what it records.
+//
+// What the *transports* do with all of this — the query parameter, `clientInfo`,
+// and whether a denial survives the round trip — is in
+// test_remote_permission_conformance.cpp, which drives both of them over real
+// sockets against the same table of cases.
+
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+#include <vector>
+
+#include "MockMagdaApi.hpp"
+#include "RemoteTestScopes.hpp"
+#include "magda/daw/api/remote_audit.hpp"
+#include "magda/daw/api/remote_clients.hpp"
+#include "magda/daw/api/remote_service.hpp"
+
+using namespace magda;
+using namespace magda::remote;
+using magda::test::MockMagdaApi;
+
+namespace {
+
+struct MessageThreadRelaxation {
+    ScopedMessageThreadAssertionDisabler disabler;
+};
+
+juce::var emptyInput() {
+    return juce::var(new juce::DynamicObject());
+}
+
+juce::var object(std::initializer_list<std::pair<const char*, juce::var>> fields) {
+    auto* result = new juce::DynamicObject();
+    for (const auto& [key, value] : fields)
+        result->setProperty(key, value);
+    return result;
+}
+
+/// One operation, run to completion. Dispatch executes inline with no message
+/// thread to hop to, so this is synchronous.
+Response run(RemoteApiService& service, const juce::String& name, const juce::var& input,
+             const RequestContext& context) {
+    Response captured;
+    int completions = 0;
+    service.dispatch(name, input, context, [&](Response response) {
+        captured = std::move(response);
+        ++completions;
+    });
+    REQUIRE(completions == 1);
+    return captured;
+}
+
+RequestContext contextWith(ScopeSet scopes, const juce::String& client = "test-client") {
+    RequestContext context;
+    context.clientId = "ws:1:1";
+    context.clientName = client;
+    context.transport = TRANSPORT_WEBSOCKET;
+    context.scopes = scopes;
+    return context;
+}
+
+}  // namespace
+
+// ===========================================================================
+// The vocabulary
+// ===========================================================================
+
+TEST_CASE("Every scope round-trips through its wire name", "[remote][permissions][scopes]") {
+    for (const auto scope : allScopeValues()) {
+        const auto name = scopeName(scope);
+        REQUIRE(name.isNotEmpty());
+        REQUIRE(scopeFromName(name) == scope);
+    }
+    REQUIRE(allScopeValues().size() == SCOPE_COUNT);
+}
+
+TEST_CASE("An unknown scope name is nothing rather than a guess", "[remote][permissions][scopes]") {
+    // The forwards-compatibility rule: a config written by a newer MAGDA loads
+    // with the scopes this build understands instead of failing shut or, worse,
+    // mapping an unrecognised word onto whichever scope happened to be first.
+    REQUIRE_FALSE(scopeFromName("admin").has_value());
+    REQUIRE_FALSE(scopeFromName("").has_value());
+    REQUIRE_FALSE(scopeFromName("READ").has_value());
+}
+
+TEST_CASE("A scope set is a set", "[remote][permissions][scopes]") {
+    ScopeSet scopes;
+    REQUIRE(scopes.empty());
+    REQUIRE_FALSE(scopes.has(Scope::Read));
+
+    scopes.add(Scope::Read).add(Scope::Edit);
+    REQUIRE(scopes.has(Scope::Read));
+    REQUIRE(scopes.has(Scope::Edit));
+    REQUIRE_FALSE(scopes.has(Scope::Session));
+
+    scopes.remove(Scope::Edit);
+    REQUIRE_FALSE(scopes.has(Scope::Edit));
+
+    REQUIRE(allScopes().containsAll(ScopeSet{Scope::Edit, Scope::Session}));
+    REQUIRE_FALSE(ScopeSet{Scope::Read}.containsAll(ScopeSet{Scope::Read, Scope::Edit}));
+}
+
+TEST_CASE("Stored bits cannot grant a scope this build has no name for",
+          "[remote][permissions][scopes]") {
+    // Grants are persisted, so the bit pattern is an input from a file. A bit
+    // above the known set would otherwise become a permission nothing could
+    // display, revoke, or explain.
+    const auto restored = ScopeSet::fromBits(0xFFFFFFFFu);
+    REQUIRE(restored == allScopes());
+}
+
+TEST_CASE("Scopes serialise as names and survive the round trip", "[remote][permissions][scopes]") {
+    const ScopeSet original{Scope::Read, Scope::Transport};
+    const auto json = scopesToJson(original);
+    REQUIRE(json.isArray());
+    REQUIRE(json.getArray()->size() == 2);
+    REQUIRE(scopesFromJson(json) == original);
+
+    // Unknown names are dropped, known ones kept — a mixed array from a newer
+    // build downgrades rather than failing.
+    juce::Array<juce::var> mixed;
+    mixed.add("edit");
+    mixed.add("teleport");
+    REQUIRE(scopesFromJson(juce::var(mixed)) == ScopeSet{Scope::Edit});
+}
+
+TEST_CASE("Client names normalise to one key per client", "[remote][permissions][scopes]") {
+    REQUIRE(normaliseClientName("Cursor") == "cursor");
+    REQUIRE(normaliseClientName("  cursor  ") == "cursor");
+    REQUIRE(normaliseClientName("Claude Code (v2)") == "claude-code-v2");
+    REQUIRE(normaliseClientName("claude.code") == "claude.code");
+
+    // Anything that survives none of it becomes the anonymous bucket, which is
+    // a real client entry rather than a rejection.
+    REQUIRE(normaliseClientName("") == ANONYMOUS_CLIENT);
+    REQUIRE(normaliseClientName("!!!") == ANONYMOUS_CLIENT);
+
+    // Bounded: this ends up in a config file and a settings table.
+    const juce::String long_(std::string(500, 'a'));
+    REQUIRE(normaliseClientName(long_).length() == MAX_CLIENT_NAME_LENGTH);
+}
+
+// ===========================================================================
+// The registry
+// ===========================================================================
+
+TEST_CASE("A client MAGDA has never seen is read-only", "[remote][permissions][registry]") {
+    RemoteClientRegistry registry;
+    REQUIRE_FALSE(registry.peekScopes("cursor").has_value());
+
+    const auto scopes = registry.scopesFor("cursor");
+    REQUIRE(scopes == defaultClientScopes());
+    REQUIRE(scopes.has(Scope::Read));
+    REQUIRE_FALSE(scopes.has(Scope::Edit));
+
+    // Asking registered it, which is what puts a client in the settings list
+    // the moment it connects rather than only once the user goes looking.
+    REQUIRE(registry.peekScopes("cursor").has_value());
+    REQUIRE(registry.grants().size() == 1);
+}
+
+TEST_CASE("Granting a scope takes effect on the next lookup", "[remote][permissions][registry]") {
+    RemoteClientRegistry registry;
+    REQUIRE(registry.scopesFor("cursor") == defaultClientScopes());
+
+    registry.setScopes("cursor", ScopeSet{Scope::Edit});
+    const auto scopes = registry.scopesFor("cursor");
+    REQUIRE(scopes.has(Scope::Edit));
+    // `read` is forced on: a grant without it would describe a client that may
+    // write but not look, which no operation set expresses.
+    REQUIRE(scopes.has(Scope::Read));
+
+    registry.setScopes("cursor", ScopeSet{});
+    REQUIRE(registry.scopesFor("cursor") == ScopeSet{Scope::Read});
+}
+
+TEST_CASE("Two spellings of a name are one client", "[remote][permissions][registry]") {
+    RemoteClientRegistry registry;
+    registry.setScopes("Cursor", ScopeSet{Scope::Edit});
+    REQUIRE(registry.scopesFor("cursor").has(Scope::Edit));
+    REQUIRE(registry.scopesFor("  CURSOR ").has(Scope::Edit));
+    REQUIRE(registry.grants().size() == 1);
+}
+
+TEST_CASE("Forgetting a client returns it to read-only", "[remote][permissions][registry]") {
+    RemoteClientRegistry registry;
+    registry.setScopes("cursor", allScopes());
+    registry.forget("cursor");
+
+    REQUIRE(registry.grants().empty());
+    REQUIRE(registry.scopesFor("cursor") == defaultClientScopes());
+}
+
+TEST_CASE("Grants persist as JSON and reload", "[remote][permissions][registry]") {
+    RemoteClientRegistry saved;
+    saved.setScopes("cursor", ScopeSet{Scope::Edit, Scope::Transport});
+    saved.setScopes("monitor", ScopeSet{});
+
+    const auto json = saved.grantsToJson();
+
+    RemoteClientRegistry loaded;
+    loaded.loadGrantsFromJson(json);
+    REQUIRE(loaded.grants().size() == 2);
+    REQUIRE(loaded.scopesFor("cursor") == ScopeSet{Scope::Read, Scope::Edit, Scope::Transport});
+    REQUIRE(loaded.scopesFor("monitor") == ScopeSet{Scope::Read});
+}
+
+TEST_CASE("A hand-edited or newer grants file loads without granting nonsense",
+          "[remote][permissions][registry]") {
+    juce::Array<juce::var> entries;
+    entries.add(object({{"name", "cursor"}, {"scopes", [] {
+                                                 juce::Array<juce::var> names;
+                                                 names.add("edit");
+                                                 names.add("root");  // not a scope
+                                                 return juce::var(names);
+                                             }()}}));
+    // No name at all: normalises to the anonymous bucket rather than being
+    // dropped silently.
+    entries.add(object({{"scopes", juce::var(juce::Array<juce::var>{})}}));
+
+    RemoteClientRegistry registry;
+    registry.loadGrantsFromJson(juce::var(entries));
+
+    REQUIRE(registry.scopesFor("cursor") == ScopeSet{Scope::Read, Scope::Edit});
+    REQUIRE(registry.scopesFor(ANONYMOUS_CLIENT) == ScopeSet{Scope::Read});
+}
+
+TEST_CASE("Loading grants does not fire the change handler", "[remote][permissions][registry]") {
+    // Otherwise startup would answer the notification by writing the config file
+    // back out with exactly what it just read from it.
+    RemoteClientRegistry registry;
+    int changes = 0;
+    registry.setChangeHandler([&] { ++changes; });
+
+    juce::Array<juce::var> entries;
+    entries.add(object({{"name", "cursor"}, {"scopes", scopesToJson(allScopes())}}));
+    registry.loadGrantsFromJson(juce::var(entries));
+
+    REQUIRE(changes == 0);
+    registry.setScopes("cursor", ScopeSet{Scope::Edit});
+    REQUIRE(changes == 1);
+}
+
+TEST_CASE("A grant set to what it already is changes nothing", "[remote][permissions][registry]") {
+    // The config file is rewritten from the change handler, so a no-op write
+    // would churn the user's disk every time the settings page repainted.
+    RemoteClientRegistry registry;
+    registry.setScopes("cursor", ScopeSet{Scope::Edit});
+
+    int changes = 0;
+    registry.setChangeHandler([&] { ++changes; });
+    registry.setScopes("cursor", ScopeSet{Scope::Edit});
+    REQUIRE(changes == 0);
+
+    registry.setScopes("cursor", ScopeSet{Scope::Session});
+    REQUIRE(changes == 1);
+}
+
+TEST_CASE("Connections are listed and disconnected by handle", "[remote][permissions][registry]") {
+    RemoteClientRegistry registry;
+
+    ConnectedClient first;
+    first.connectionId = "ws:1:1";
+    first.name = "cursor";
+    first.transport = TRANSPORT_WEBSOCKET;
+    registry.noteConnected(first);
+
+    ConnectedClient second;
+    second.connectionId = "ws:1:2";
+    second.name = "cursor";
+    second.transport = TRANSPORT_WEBSOCKET;
+    registry.noteConnected(second);
+
+    REQUIRE(registry.connectionCount() == 2);
+
+    std::vector<juce::String> closed;
+    registry.setDisconnectHandler(TRANSPORT_WEBSOCKET, [&](const juce::String& handle) {
+        closed.push_back(handle);
+        registry.noteDisconnected(handle);
+        return true;
+    });
+
+    REQUIRE(registry.disconnect("ws:1:1"));
+    REQUIRE(closed.size() == 1);
+    REQUIRE(registry.connectionCount() == 1);
+
+    // A handle that is not live is not an error to ask about; it is simply not
+    // there any more, which is the common case when a settings row is clicked
+    // a moment after the client went away.
+    REQUIRE_FALSE(registry.disconnect("ws:1:1"));
+}
+
+TEST_CASE("Disconnecting a client closes every connection it holds",
+          "[remote][permissions][registry]") {
+    RemoteClientRegistry registry;
+    for (int index = 1; index <= 3; ++index) {
+        ConnectedClient client;
+        client.connectionId = "ws:1:" + juce::String(index);
+        client.name = index == 3 ? "other" : "cursor";
+        client.transport = TRANSPORT_WEBSOCKET;
+        registry.noteConnected(client);
+    }
+
+    registry.setDisconnectHandler(TRANSPORT_WEBSOCKET, [&](const juce::String& handle) {
+        registry.noteDisconnected(handle);
+        return true;
+    });
+
+    REQUIRE(registry.disconnectClient("cursor") == 2);
+    REQUIRE(registry.connectionCount() == 1);
+    REQUIRE(registry.connections().front().name == "other");
+}
+
+TEST_CASE("A connection whose transport has gone cannot be disconnected",
+          "[remote][permissions][registry]") {
+    // What the settings dialog hits if the user switches the remote API off
+    // between the list being drawn and the button being pressed.
+    RemoteClientRegistry registry;
+    ConnectedClient client;
+    client.connectionId = "ws:1:1";
+    client.name = "cursor";
+    client.transport = TRANSPORT_WEBSOCKET;
+    registry.noteConnected(client);
+
+    REQUIRE_FALSE(registry.disconnect("ws:1:1"));
+}
+
+// ===========================================================================
+// Enforcement
+// ===========================================================================
+
+TEST_CASE("A read-only client can read", "[remote][permissions][service]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.project_.info.tempo = 128.0;
+    RemoteApiService service(api);
+
+    const auto response =
+        run(service, "project.get", emptyInput(), contextWith(defaultClientScopes()));
+    REQUIRE(response.ok);
+    REQUIRE(static_cast<double>(response.result["tempo"]) == 128.0);
+}
+
+TEST_CASE("A read-only client cannot mutate", "[remote][permissions][service]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    api.project_.info.tempo = 120.0;
+    RemoteApiService service(api);
+
+    const auto response = run(service, "project.setTempo", object({{"tempo", 140.0}}),
+                              contextWith(defaultClientScopes()));
+
+    REQUIRE_FALSE(response.ok);
+    REQUIRE(response.error.code == ErrorCode::PermissionDenied);
+    // The scope that would have allowed it, by name — a client should be able
+    // to tell the user what to grant rather than just that it failed.
+    REQUIRE(response.error.message.contains("edit"));
+    // And nothing happened.
+    REQUIRE(api.project_.info.tempo == 120.0);
+}
+
+TEST_CASE("Each write scope admits only its own operations", "[remote][permissions][service]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    struct Case {
+        const char* operation;
+        juce::var input;
+        Scope required;
+    };
+    const std::vector<Case> cases = {
+        {"project.setTempo", object({{"tempo", 130.0}}), Scope::Edit},
+        {"transport.play", emptyInput(), Scope::Transport},
+        {"session.stopAll", emptyInput(), Scope::Session},
+    };
+
+    for (const auto& testCase : cases) {
+        // Granted: it runs. Whether the handler then succeeds is not this
+        // test's business — only that it was not refused for permission.
+        const auto allowed = run(service, testCase.operation, testCase.input,
+                                 contextWith(ScopeSet{Scope::Read, testCase.required}));
+        REQUIRE(allowed.error.code != ErrorCode::PermissionDenied);
+
+        // Every other write scope: refused. This is the property that makes the
+        // split worth having — a transport grant must not become an edit grant.
+        for (const auto other : allScopeValues()) {
+            if (other == testCase.required || other == Scope::Read)
+                continue;
+            const auto refused = run(service, testCase.operation, testCase.input,
+                                     contextWith(ScopeSet{Scope::Read, other}));
+            REQUIRE_FALSE(refused.ok);
+            REQUIRE(refused.error.code == ErrorCode::PermissionDenied);
+        }
+    }
+}
+
+TEST_CASE("Permission is checked before the input is validated", "[remote][permissions][service]") {
+    // A refusal that varied with whether the payload was well formed would be
+    // an oracle for a schema the client is not allowed to reach.
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    const auto garbage = run(service, "project.setTempo", object({{"nonsense", true}}),
+                             contextWith(defaultClientScopes()));
+    REQUIRE(garbage.error.code == ErrorCode::PermissionDenied);
+
+    // With the scope, the same payload fails validation — so the two checks are
+    // genuinely in this order rather than the input happening to be valid.
+    const auto validated = run(service, "project.setTempo", object({{"nonsense", true}}),
+                               contextWith(ScopeSet{Scope::Read, Scope::Edit}));
+    REQUIRE(validated.error.code == ErrorCode::ValidationFailed);
+}
+
+TEST_CASE("A revoked grant is not replayed out of the idempotency cache",
+          "[remote][permissions][service]") {
+    // The one path where revocation could fail to take effect immediately: a
+    // cached response is a previous success, and replaying one to a client
+    // whose grant has since been withdrawn would hand it the answer anyway.
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+
+    auto granted = contextWith(ScopeSet{Scope::Read, Scope::Edit});
+    granted.requestId = "retry-1";
+    const auto first = run(service, "project.setTempo", object({{"tempo", 130.0}}), granted);
+    REQUIRE(first.ok);
+
+    auto revoked = contextWith(defaultClientScopes());
+    revoked.requestId = "retry-1";
+    const auto replay = run(service, "project.setTempo", object({{"tempo", 130.0}}), revoked);
+    REQUIRE_FALSE(replay.ok);
+    REQUIRE(replay.error.code == ErrorCode::PermissionDenied);
+}
+
+TEST_CASE("Every declared write requires more than read", "[remote][permissions][registry]") {
+    // The guarantee behind the scope policy table: an operation added without a
+    // policy entry keeps the `read` default, and would then be callable by every
+    // read-only client. Nothing else in the system would notice.
+    for (const auto& operation : OperationRegistry::instance().operations()) {
+        if (operation.access == OperationAccess::Write) {
+            INFO("operation: " << operation.name);
+            REQUIRE(operation.requiredScope != Scope::Read);
+        }
+    }
+}
+
+TEST_CASE("system.describe publishes the scope each operation needs",
+          "[remote][permissions][registry]") {
+    // A client should be able to present the user with what to grant before it
+    // tries something, rather than after being refused.
+    const auto described = OperationRegistry::instance().describe();
+    const auto* operations = described["operations"].getArray();
+    REQUIRE(operations != nullptr);
+
+    bool sawWrite = false;
+    for (const auto& entry : *operations) {
+        const auto scope = entry["requiredScope"].toString();
+        REQUIRE(scopeFromName(scope).has_value());
+        if (entry["name"].toString() == "transport.play") {
+            REQUIRE(scope == "transport");
+            sawWrite = true;
+        }
+    }
+    REQUIRE(sawWrite);
+}
+
+// ===========================================================================
+// The audit log
+// ===========================================================================
+
+TEST_CASE("A dispatched request is recorded with its outcome", "[remote][permissions][audit]") {
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteAuditLog log;
+    service.setAuditLog(&log);
+
+    auto context = contextWith(defaultClientScopes(), "cursor");
+    context.requestId = "req-7";
+    run(service, "project.get", emptyInput(), context);
+    run(service, "project.setTempo", object({{"tempo", 140.0}}), context);
+
+    const auto entries = log.entries();
+    REQUIRE(entries.size() == 2);
+
+    REQUIRE(entries[0].client == "cursor");
+    REQUIRE(entries[0].transport == TRANSPORT_WEBSOCKET);
+    REQUIRE(entries[0].connectionId == "ws:1:1");
+    REQUIRE(entries[0].operation == "project.get");
+    REQUIRE(entries[0].requestId == "req-7");
+    REQUIRE(entries[0].outcome == AuditOutcome::Ok);
+    REQUIRE(entries[0].timestampMs > 0);
+
+    REQUIRE(entries[1].operation == "project.setTempo");
+    REQUIRE(entries[1].outcome == AuditOutcome::Denied);
+    // The scope that would have allowed it — the one word a user would act on.
+    REQUIRE(entries[1].detail == "edit");
+}
+
+TEST_CASE("A failure is recorded by code, never by message", "[remote][permissions][audit]") {
+    // A validation message quotes the offending value, which is client input
+    // and may be anything at all — including something the client should not
+    // have sent and the user should not have in a buffer they may screenshot.
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteAuditLog log;
+    service.setAuditLog(&log);
+
+    run(service, "project.setTempo", object({{"tempo", "not-a-number"}}),
+        contextWith(ScopeSet{Scope::Read, Scope::Edit}, "cursor"));
+
+    const auto entries = log.entries();
+    REQUIRE(entries.size() == 1);
+    REQUIRE(entries[0].outcome == AuditOutcome::Failed);
+    REQUIRE(entries[0].detail == "validation_failed");
+    REQUIRE_FALSE(entries[0].detail.contains("not-a-number"));
+}
+
+TEST_CASE("In-process callers are not audited", "[remote][permissions][audit]") {
+    // The subscription hub projecting a snapshot and the tests themselves would
+    // otherwise bury the remote traffic the log exists to show.
+    const MessageThreadRelaxation relaxation;
+    MockMagdaApi api;
+    RemoteApiService service(api);
+    RemoteAuditLog log;
+    service.setAuditLog(&log);
+
+    run(service, "project.get", emptyInput(), magda::test::fullyGrantedContext());
+    REQUIRE(log.entries().empty());
+}
+
+TEST_CASE("The audit log is bounded and says when it lost entries",
+          "[remote][permissions][audit]") {
+    RemoteAuditLog log(4);
+    for (int index = 0; index < 10; ++index) {
+        AuditEntry entry;
+        entry.client = "cursor";
+        entry.operation = "project.get";
+        entry.detail = juce::String(index);
+        log.record(entry);
+    }
+
+    REQUIRE(log.size() == 4);
+    REQUIRE(log.totalRecorded() == 10);
+    // Oldest dropped, newest kept.
+    REQUIRE(log.entries().front().detail == "6");
+    REQUIRE(log.entries().back().detail == "9");
+
+    REQUIRE(log.recent(2).size() == 2);
+    REQUIRE(log.recent(2).back().detail == "9");
+    // Asking for more than there is returns what there is.
+    REQUIRE(log.recent(100).size() == 4);
+}
+
+TEST_CASE("Entries can be read back for one client", "[remote][permissions][audit]") {
+    RemoteAuditLog log;
+    for (const auto* name : {"cursor", "monitor", "cursor"}) {
+        AuditEntry entry;
+        entry.client = name;
+        entry.operation = "project.get";
+        log.record(entry);
+    }
+    REQUIRE(log.forClient("cursor").size() == 2);
+    REQUIRE(log.forClient("monitor").size() == 1);
+    REQUIRE(log.forClient("nobody").empty());
+}
+
+// ===========================================================================
+// Redaction
+// ===========================================================================
+
+TEST_CASE("A registered secret never survives into a log line",
+          "[remote][permissions][redaction]") {
+    forgetAllRemoteSecrets();
+    const juce::String token = "9f3a1c7e5b2d8406";
+    registerRemoteSecret(token);
+
+    const auto redacted = redactSecrets("connecting with token " + token + " to the endpoint");
+    REQUIRE_FALSE(redacted.contains(token));
+    REQUIRE(redacted.contains("***"));
+
+    forgetRemoteSecret(token);
+    REQUIRE(redactSecrets(token).contains(token));
+    forgetAllRemoteSecrets();
+}
+
+TEST_CASE("A bearer credential MAGDA never held is still masked",
+          "[remote][permissions][redaction]") {
+    // A client's own malformed `Authorization` header, echoed into a rejection
+    // reason: not a value MAGDA generated, so not one it could have registered.
+    forgetAllRemoteSecrets();
+    const auto redacted = redactSecrets("rejected Authorization: Bearer sk-live-abcdef123456 here");
+    REQUIRE_FALSE(redacted.contains("sk-live-abcdef123456"));
+    REQUIRE(redacted.contains("Bearer ***"));
+    // The text either side survives, or the log stops being diagnosable.
+    REQUIRE(redacted.contains("rejected"));
+    REQUIRE(redacted.contains("here"));
+}
+
+TEST_CASE("Redaction terminates on a bearer scheme with nothing after it",
+          "[remote][permissions][redaction]") {
+    forgetAllRemoteSecrets();
+    // The empty-value case is what would otherwise scan the same position for
+    // ever, because there is nothing to replace and therefore nothing to
+    // advance past.
+    REQUIRE(redactSecrets("Bearer ").contains("Bearer"));
+    REQUIRE(redactSecrets("Bearer  Bearer ").isNotEmpty());
+}
+
+TEST_CASE("A secret too short to be one is refused", "[remote][permissions][redaction]") {
+    // A one- or two-character "secret" matches somewhere in almost every
+    // message and would turn the whole log into asterisks.
+    forgetAllRemoteSecrets();
+    registerRemoteSecret("ab");
+    REQUIRE(redactSecrets("a table of absolute values").contains("table"));
+    forgetAllRemoteSecrets();
+}
+
+TEST_CASE("An audit detail is redacted on the way in", "[remote][permissions][redaction]") {
+    // At the one point every entry passes through, rather than at each call
+    // site — where each new one is a chance to forget.
+    forgetAllRemoteSecrets();
+    const juce::String token = "abcdef0123456789";
+    registerRemoteSecret(token);
+
+    RemoteAuditLog log;
+    AuditEntry entry;
+    entry.client = "cursor";
+    entry.operation = "connection.rejected";
+    entry.detail = "token " + token + " refused";
+    log.record(entry);
+
+    REQUIRE_FALSE(log.entries().front().detail.contains(token));
+    forgetAllRemoteSecrets();
+}
+
+TEST_CASE("A file is named without saying where it lives", "[remote][permissions][redaction]") {
+    const auto file = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                          .getChildFile("remote-api-4021.json");
+    const auto named = redactedFileName(file);
+    REQUIRE(named == "remote-api-4021.json");
+    REQUIRE_FALSE(named.contains(juce::File::getSeparatorString()));
+    REQUIRE(redactedFileName(juce::File()).isEmpty());
+}

--- a/tests/test_remote_service.cpp
+++ b/tests/test_remote_service.cpp
@@ -5,10 +5,12 @@
 #include <vector>
 
 #include "MockMagdaApi.hpp"
+#include "RemoteTestScopes.hpp"
 #include "magda/daw/api/remote_service.hpp"
 
 using namespace magda;
 using namespace magda::remote;
+using magda::test::fullyGrantedContext;
 using magda::test::MockMagdaApi;
 
 namespace {
@@ -34,7 +36,7 @@ juce::var object(std::initializer_list<std::pair<const char*, juce::var>> fields
 /// Runs one operation to completion and returns the response. Dispatch executes
 /// inline when there is no message thread to hop to, so this is synchronous.
 Response run(RemoteApiService& service, const juce::String& name, const juce::var& input,
-             RequestContext context = {}) {
+             RequestContext context = fullyGrantedContext()) {
     Response captured;
     int completions = 0;
     service.dispatch(name, input, context, [&](Response response) {
@@ -186,7 +188,7 @@ TEST_CASE("A stale expected revision is rejected as a conflict", "[remote][servi
 
     REQUIRE(run(service, "project.setTempo", object({{"tempo", 90.0}})).ok);
 
-    RequestContext stale;
+    auto stale = fullyGrantedContext();
     stale.expectedRevision = INITIAL_REVISION;  // what the client saw before the write above
     const auto response = run(service, "project.setTempo", object({{"tempo", 140.0}}), stale);
 
@@ -195,7 +197,7 @@ TEST_CASE("A stale expected revision is rejected as a conflict", "[remote][servi
     REQUIRE(api.project_.info.tempo == 90.0);
 
     // The matching revision succeeds, so a client can recover by re-reading.
-    RequestContext current;
+    auto current = fullyGrantedContext();
     current.expectedRevision = service.currentRevision();
     REQUIRE(run(service, "project.setTempo", object({{"tempo", 140.0}}), current).ok);
     REQUIRE(api.project_.info.tempo == 140.0);
@@ -206,7 +208,7 @@ TEST_CASE("Retrying a completed write does not apply it twice", "[remote][servic
     MockMagdaApi api;
     RemoteApiService service(api);
 
-    RequestContext context;
+    auto context = fullyGrantedContext();
     context.clientId = "client-a";
     context.requestId = "req-1";
 
@@ -232,10 +234,10 @@ TEST_CASE("Idempotency keys are scoped per client", "[remote][service][idempoten
     MockMagdaApi api;
     RemoteApiService service(api);
 
-    RequestContext first;
+    auto first = fullyGrantedContext();
     first.clientId = "client-a";
     first.requestId = "req-1";
-    RequestContext second;
+    auto second = fullyGrantedContext();
     second.clientId = "client-b";
     second.requestId = "req-1";  // same id, different client
 
@@ -253,7 +255,7 @@ TEST_CASE("Reads are not served from the idempotency cache", "[remote][service][
     api.project_.info.tempo = 120.0;
     RemoteApiService service(api);
 
-    RequestContext context;
+    auto context = fullyGrantedContext();
     context.clientId = "client-a";
     context.requestId = "req-read";
 
@@ -274,7 +276,7 @@ TEST_CASE("The idempotency cache is bounded", "[remote][service][idempotency]") 
     service.setIdempotencyCacheCapacity(2);
 
     const auto writeWithId = [&](const juce::String& requestId, double tempo) {
-        RequestContext context;
+        auto context = fullyGrantedContext();
         context.clientId = "client-a";
         context.requestId = requestId;
         return run(service, "project.setTempo", object({{"tempo", tempo}}), context);
@@ -314,7 +316,7 @@ TEST_CASE("Concurrent retries of one request id apply the mutation once",
     workers.reserve(threadCount);
     for (int worker = 0; worker < threadCount; ++worker) {
         workers.emplace_back([&] {
-            RequestContext context;
+            auto context = fullyGrantedContext();
             context.clientId = "client-a";
             context.requestId = "req-1";
             service.dispatch("project.setTempo", object({{"tempo", 90.0}}), context,
@@ -396,7 +398,7 @@ TEST_CASE("An expired deadline fails with timeout instead of executing late",
     MockMagdaApi api;
     RemoteApiService service(api);
 
-    RequestContext context;
+    auto context = fullyGrantedContext();
     context.deadline = std::chrono::steady_clock::now() - std::chrono::milliseconds(1);
 
     const auto response = run(service, "project.setTempo", object({{"tempo", 90.0}}), context);
@@ -441,7 +443,7 @@ TEST_CASE("Replacing the project invalidates outstanding revisions",
 
     // A client holding the pre-swap revision is now stale by construction,
     // rather than writing into a project that no longer exists.
-    RequestContext context;
+    auto context = fullyGrantedContext();
     context.expectedRevision = before;
     const auto response = run(service, "project.setTempo", object({{"tempo", 90.0}}), context);
     REQUIRE_FALSE(response.ok);
@@ -453,7 +455,7 @@ TEST_CASE("Replacing the project clears the idempotency cache", "[remote][servic
     MockMagdaApi api;
     RemoteApiService service(api);
 
-    RequestContext context;
+    auto context = fullyGrantedContext();
     context.clientId = "client-a";
     context.requestId = "req-1";
     REQUIRE(run(service, "project.setTempo", object({{"tempo", 90.0}}), context).ok);
@@ -508,7 +510,7 @@ TEST_CASE("dispatchSync returns the response directly", "[remote][service]") {
     api.project_.info.tempo = 111.0;
     RemoteApiService service(api);
 
-    const auto response = service.dispatchSync("project.get", emptyInput(), {});
+    const auto response = service.dispatchSync("project.get", emptyInput(), fullyGrantedContext());
 
     REQUIRE(response.ok);
     REQUIRE(static_cast<double>(response.result["tempo"]) == 111.0);
@@ -553,7 +555,7 @@ TEST_CASE("Continuous motion notifies without bumping the revision", "[remote][s
 
     // And a write with the pre-motion revision still succeeds, which is the
     // property that makes remote control usable during playback.
-    RequestContext context;
+    auto context = fullyGrantedContext();
     context.expectedRevision = INITIAL_REVISION;
     const ScopedMessageThreadAssertionDisabler disabler;
     REQUIRE(run(service, "project.setTempo", object({{"tempo", 90.0}}), context).ok);
@@ -614,7 +616,7 @@ TEST_CASE("Concurrent dispatch from many threads keeps revisions unique",
     for (int worker = 0; worker < threadCount; ++worker) {
         workers.emplace_back([&, worker] {
             for (int index = 0; index < perThread; ++index) {
-                RequestContext context;
+                auto context = fullyGrantedContext();
                 context.clientId = "client-" + juce::String(worker);
                 context.requestId = juce::String(index);
                 service.dispatch("project.setTempo", object({{"tempo", 100.0}}), context,

--- a/tests/test_remote_service_live_juce.cpp
+++ b/tests/test_remote_service_live_juce.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <vector>
 
+#include "RemoteTestScopes.hpp"
 #include "magda/daw/api/magda_api_live.hpp"
 #include "magda/daw/api/remote_model_bridge.hpp"
 #include "magda/daw/api/remote_service.hpp"
@@ -24,6 +25,7 @@ namespace {
 
 using namespace magda;
 using namespace magda::remote;
+using magda::test::fullyGrantedContext;
 
 juce::var object(std::initializer_list<std::pair<const char*, juce::var>> fields) {
     auto* result = new juce::DynamicObject();
@@ -299,7 +301,7 @@ class RemoteServiceLiveTest final : public juce::UnitTest {
             expect(
                 fixture.run("tracks.create", object({{"name", "Moved on"}, {"type", "audio"}})).ok);
 
-            RequestContext context;
+            auto context = fullyGrantedContext();
             context.expectedRevision = stale;
             // A read is safe at any revision; only writes are gated.
             const auto response = fixture.run("tracks.list", object({}), context);
@@ -337,7 +339,7 @@ class RemoteServiceLiveTest final : public juce::UnitTest {
         }
 
         Response run(const juce::String& name, const juce::var& input,
-                     RequestContext context = {}) {
+                     RequestContext context = fullyGrantedContext()) {
             Response captured;
             service.dispatch(name, input, context,
                              [&captured](Response response) { captured = std::move(response); });

--- a/tests/test_remote_websocket_live_juce.cpp
+++ b/tests/test_remote_websocket_live_juce.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "magda/daw/api/magda_api_live.hpp"
+#include "magda/daw/api/remote_clients.hpp"
 #include "magda/daw/api/remote_model_bridge.hpp"
 #include "magda/daw/api/remote_service.hpp"
 #include "magda/daw/api/remote_subscriptions.hpp"
@@ -216,6 +217,11 @@ class RemoteWebSocketLiveTest final : public juce::UnitTest {
         RemoteApiService service{api};
         std::unique_ptr<ModelChangeBridge> bridge;
         std::unique_ptr<SubscriptionHub> subscriptions;
+        /// Declared before `server`, which holds a pointer to it. Without a
+        /// registry the transport refuses everything, subscribing included
+        /// (#1860), and these tests are about live model behaviour rather than
+        /// about who is allowed to watch it.
+        RemoteClientRegistry clients;
         std::unique_ptr<RemoteWebSocketServer> server;
 
         Fixture() {
@@ -229,8 +235,12 @@ class RemoteWebSocketLiveTest final : public juce::UnitTest {
             hubOptions.samplingIntervalMs = 10;
             subscriptions = std::make_unique<SubscriptionHub>(api, service, hubOptions);
 
+            // These clients send no `?client=`, so they are all `unknown`.
+            clients.setScopes(ANONYMOUS_CLIENT, allScopes());
+
             RemoteWebSocketServer::Options options;
             options.bearerToken = kToken;
+            options.clients = &clients;
             server = std::make_unique<RemoteWebSocketServer>(service, options, subscriptions.get());
             server->start();
         }

--- a/tests/test_remote_websocket_server.cpp
+++ b/tests/test_remote_websocket_server.cpp
@@ -15,6 +15,8 @@
 #include <vector>
 
 #include "MockMagdaApi.hpp"
+#include "RemoteTestScopes.hpp"
+#include "magda/daw/api/remote_clients.hpp"
 #include "magda/daw/api/remote_service.hpp"
 #include "magda/daw/api/remote_subscriptions.hpp"
 #include "magda/daw/api/remote_websocket_server.hpp"
@@ -37,10 +39,15 @@ struct MessageThreadRelaxation {
     ScopedMessageThreadAssertionDisabler disabler;
 };
 
-RemoteWebSocketServer::Options testOptions() {
+/// `clients` defaults to the shared permissive registry: without one, every
+/// request is refused before it reaches the transport behaviour these tests are
+/// about (#1860). The permission tests pass their own.
+RemoteWebSocketServer::Options testOptions(
+    RemoteClientRegistry& clients = magda::test::permissiveRegistry()) {
     RemoteWebSocketServer::Options options;
     options.bearerToken = kToken;
     options.allowedOrigins = {kOrigin};
+    options.clients = &clients;
     return options;
 }
 


### PR DESCRIPTION
Closes #1860.

Remote clients could do anything the token holder could. This adds the permission model that makes the settings UI worth opening.

## Scopes

`read`, `edit`, `transport`, `session`, `hardware-midi` — declared once per operation in a contiguous policy table in `remote_api.cpp`, enforced in `RemoteApiService` so both transports get one answer rather than two.

The split is by what a user would regret, not by which manager the code calls. Driving the transport is separable from editing because a remote that only starts and stops playback is a thing people want and must not also be able to delete a track. Session launch is neither.

Two orderings are load-bearing. Permission is checked **before input validation**, so a client that may not call something cannot use the refusal as an oracle for a schema it is not allowed to reach. And **before the idempotency cache**, so a revoked grant cannot be handed a replayed success — the one path where revocation would otherwise not take effect.

A write with no policy entry keeps the `read` default. The registry constructor turns that into a startup failure, and a test re-checks it in release builds where `jassert` is a no-op.

## Identity and grants

A client names itself — `?client=name` on the WebSocket upgrade, `clientInfo.name` for MCP. Normalised, so `Cursor` / `cursor ` / `cursor` are one entry. Read-only on first sight, and registered the moment it asks for anything so it appears in the settings list straight away.

The grant is looked up **per request**, never cached on the connection. That is the entire mechanism behind "revoking takes effect without restart": there is no copy to go stale, so a change applies to the next request on the socket the client is already holding.

Grants persist under `remoteApi.clients` in config. No credential is in there.

## Also in scope

- **Audit log** — bounded, in memory, 512 entries: time, client, connection, transport, operation, request id, outcome, short reason. No payloads, and failures recorded by error *code* rather than message, because a validation message quotes the offending value.
- **Redaction** — registered secrets plus a `Bearer` shape rule, applied once inside `record` rather than at each call site. The startup log now names the discovery file instead of its path.
- **Token rotation** — implemented as a listener restart, which is what guarantees every existing connection is gone: they were admitted by a token that no longer exists.
- **Settings UI** — rotation on the Remote tab; a new **Clients** tab with a scope checkbox per client, connected state and transport, disconnect, forget, and the recent-activity tail, so a refusal and the checkbox that fixes it are on one screen.

## What this is not

A sandbox, and the docs lead with that. The token is the security boundary, it lives in a file any process running as the user can read, and the client name is self-declared — a token holder can claim any name and get whatever it was granted. Per-client secrets would be published in the same readable file and buy nothing.

What the model does buy is the thing that actually goes wrong: an assistant you gave read access does not silently delete a track, and when something is refused you can see it and grant it in one place. `docs/architecture/remote-api-permissions.md` states the threat model in full.

## `hardware-midi` has no operations yet

The registry exposes no hardware MIDI surface. The scope is declared now because grants are persisted: a word invented later reads as "not granted" on every existing client — the correct answer, but only if the word already exists when those grants are written.

## Bugs found and fixed along the way

- Inserting fields into the middle of `McpEndpoint::Call` silently re-mapped positional aggregate init in `test_remote_mcp.cpp`, so `idempotencyScope` became the client name. The helpers now assign by name.
- The audit wrapper originally captured `this`; a completion running after `shutdown()` would have dereferenced a destroyed dispatcher. It now carries the log pointer by value.
- `persistGrants` was reachable from a transport thread when a new client registered itself, and `Config::save()` reads the whole unlocked singleton. It now hops to the message thread, capturing a snapshot rather than `this`.

## Tests

- `test_remote_permissions.cpp` — vocabulary, registry, enforcement, audit, redaction.
- `test_remote_permission_conformance.cpp` — one vector table driven through **both** transports over real sockets, asserting they agree; plus revocation without reconnect, disconnect, anonymity, fail-closed with no registry, and a concurrent-load case that flips the grant underneath four clients.
- Host-level coverage for rotation, grant persistence across a restart, and a brand-new client being read-only end to end.

A transport configured without a registry refuses **everything**, reads included — so a future transport that forgets to consult it fails loudly on its first test run rather than handing out the project silently.

## Verification

Full Catch2 suite green (2294 passed, 13 skipped, 0 failed). Both live JUCE suites green. Debug and release builds clean. Load case run three times for flakiness.

Two caveats:

- **Limits** (payload, rate, concurrency, queue) were already implemented by #1856/#1858. This documents and tabulates them; it does not add new ones.
- **Packaging** verified on macOS only. The change adds no new artifacts — only sources compiled into `magda_daw` — so there is nothing to stage differently, but Linux and Windows will only be confirmed by CI. The Clients tab compiles in debug and release but has not been seen rendered in a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)