### PR TITLE
TrackApi: address racks and chains by path (#1993)

### DIFF
--- a/magda/daw/api/track_api.hpp
+++ b/magda/daw/api/track_api.hpp
@@ -2,7 +2,9 @@
 
 #include <vector>
 
+#include "../core/ChainNodePath.hpp"
 #include "../core/DeviceInfo.hpp"
+#include "../core/RackInfo.hpp"
 #include "../core/TrackInfo.hpp"
 #include "../core/TrackTypes.hpp"
 #include "../core/TypeIds.hpp"
@@ -41,8 +43,56 @@ class TrackApi {
     virtual DeviceId addDeviceToChain(TrackId trackId, RackId rackId, ChainId chainId,
                                       const DeviceInfo& device) = 0;
 
+    // ------------------------------------------------------------------
+    // Racks and chains, by path (#1993)
+    //
+    // A `(trackId, rackId, chainId)` triple names exactly one level of
+    // nesting, and the model nests arbitrarily — `Track > Rack > Chain >
+    // Rack > Chain > Device`. So the triple-based surface below cannot
+    // address anything inside a nested rack: there is no triple that names
+    // the inner chain. A remote or agent caller could reach a *device* at
+    // depth (`DevicePathDto` has carried a full route since #1991) but not
+    // the chain containing it, so "add a chain to this rack" stopped working
+    // at depth two.
+    //
+    // These are the same operations addressed by `ChainNodePath`, which is
+    // the route the UI has always used. The names deliberately mirror
+    // `TrackManager`'s own — this facade is a view onto it, and inventing a
+    // third vocabulary for the same calls would be one more mapping to hold
+    // in your head.
+    //
+    // The triple-based methods below are kept as shims over these, so there
+    // is one implementation rather than two that can drift, and the agent
+    // DSL — whose grammar is inherently one-rack-at-a-time — keeps working
+    // unchanged.
+    // ------------------------------------------------------------------
+
+    virtual RackId addRackToChainByPath(const ChainNodePath& chainPath,
+                                        const juce::String& name) = 0;
+    virtual void removeRackFromChainByPath(const ChainNodePath& rackPath) = 0;
+    virtual const RackInfo* getRackByPath(const ChainNodePath& rackPath) const = 0;
+    virtual void setRackBypassedByPath(const ChainNodePath& rackPath, bool bypassed) = 0;
+    virtual void setRackVolume(const ChainNodePath& rackPath, float volumeDb) = 0;
+
+    virtual ChainId addChainToRack(const ChainNodePath& rackPath, const juce::String& name) = 0;
+    virtual void removeChainByPath(const ChainNodePath& chainPath) = 0;
+    virtual const ChainInfo* getChainByPath(const ChainNodePath& chainPath) const = 0;
+    virtual void setChainOutput(const ChainNodePath& chainPath, int outputIndex) = 0;
+    virtual void setChainMuted(const ChainNodePath& chainPath, bool muted) = 0;
+    virtual void setChainBypassed(const ChainNodePath& chainPath, bool bypassed) = 0;
+    virtual void setChainSolo(const ChainNodePath& chainPath, bool solo) = 0;
+    virtual void setChainVolume(const ChainNodePath& chainPath, float volumeDb) = 0;
+    virtual void setChainPan(const ChainNodePath& chainPath, float pan) = 0;
+    virtual void setChainName(const ChainNodePath& chainPath, const juce::String& name) = 0;
+
+    virtual DeviceId addDeviceToChainByPath(const ChainNodePath& chainPath,
+                                            const DeviceInfo& device) = 0;
+
     // Focused top-level rack and chain management surface for command agents.
     // IDs are stable model IDs, surfaced in the command-state snapshot.
+    //
+    // Every one of these is a shim over the path form above, addressing depth
+    // one: `(t, r, c)` is `ChainNodePath::chain(t, r, c)`.
     virtual RackId addRackToTrack(TrackId trackId, const juce::String& name) = 0;
     virtual void removeRackFromTrack(TrackId trackId, RackId rackId) = 0;
     virtual const RackInfo* getRack(TrackId trackId, RackId rackId) const = 0;

--- a/magda/daw/api/track_api_live.cpp
+++ b/magda/daw/api/track_api_live.cpp
@@ -70,70 +70,151 @@ DeviceId TrackApiLive::addDeviceToTrack(TrackId trackId, const DeviceInfo& devic
 
 DeviceId TrackApiLive::addDeviceToChain(TrackId trackId, RackId rackId, ChainId chainId,
                                         const DeviceInfo& device) {
-    return TrackManager::getInstance().addDeviceToChain(trackId, rackId, chainId, device);
+    return addDeviceToChainByPath(ChainNodePath::chain(trackId, rackId, chainId), device);
 }
 
+// ---------------------------------------------------------------------------
+// Path-addressed racks and chains (#1993)
+//
+// Straight forwards to the `TrackManager` methods the UI already uses. Nothing
+// is implemented here that was not reachable before — the model always
+// supported arbitrary nesting; it was only the facade that could not name it.
+// ---------------------------------------------------------------------------
+
+RackId TrackApiLive::addRackToChainByPath(const ChainNodePath& chainPath,
+                                          const juce::String& name) {
+    return TrackManager::getInstance().addRackToChainByPath(chainPath, name);
+}
+
+void TrackApiLive::removeRackFromChainByPath(const ChainNodePath& rackPath) {
+    TrackManager::getInstance().removeRackFromChainByPath(rackPath);
+}
+
+const RackInfo* TrackApiLive::getRackByPath(const ChainNodePath& rackPath) const {
+    return TrackManager::getInstance().getRackByPath(rackPath);
+}
+
+void TrackApiLive::setRackBypassedByPath(const ChainNodePath& rackPath, bool bypassed) {
+    TrackManager::getInstance().setRackBypassedByPath(rackPath, bypassed);
+}
+
+void TrackApiLive::setRackVolume(const ChainNodePath& rackPath, float volumeDb) {
+    TrackManager::getInstance().setRackVolume(rackPath, volumeDb);
+}
+
+ChainId TrackApiLive::addChainToRack(const ChainNodePath& rackPath, const juce::String& name) {
+    return TrackManager::getInstance().addChainToRack(rackPath, name);
+}
+
+void TrackApiLive::removeChainByPath(const ChainNodePath& chainPath) {
+    TrackManager::getInstance().removeChainByPath(chainPath);
+}
+
+const ChainInfo* TrackApiLive::getChainByPath(const ChainNodePath& chainPath) const {
+    return TrackManager::getInstance().getChainByPath(chainPath);
+}
+
+void TrackApiLive::setChainOutput(const ChainNodePath& chainPath, int outputIndex) {
+    TrackManager::getInstance().setChainOutput(chainPath, outputIndex);
+}
+
+void TrackApiLive::setChainMuted(const ChainNodePath& chainPath, bool muted) {
+    TrackManager::getInstance().setChainMuted(chainPath, muted);
+}
+
+void TrackApiLive::setChainBypassed(const ChainNodePath& chainPath, bool bypassed) {
+    TrackManager::getInstance().setChainBypassed(chainPath, bypassed);
+}
+
+void TrackApiLive::setChainSolo(const ChainNodePath& chainPath, bool solo) {
+    TrackManager::getInstance().setChainSolo(chainPath, solo);
+}
+
+void TrackApiLive::setChainVolume(const ChainNodePath& chainPath, float volumeDb) {
+    TrackManager::getInstance().setChainVolume(chainPath, volumeDb);
+}
+
+void TrackApiLive::setChainPan(const ChainNodePath& chainPath, float pan) {
+    TrackManager::getInstance().setChainPan(chainPath, pan);
+}
+
+void TrackApiLive::setChainName(const ChainNodePath& chainPath, const juce::String& name) {
+    TrackManager::getInstance().setChainName(chainPath, name);
+}
+
+DeviceId TrackApiLive::addDeviceToChainByPath(const ChainNodePath& chainPath,
+                                              const DeviceInfo& device) {
+    return TrackManager::getInstance().addDeviceToChainByPath(chainPath, device);
+}
+
+// ---------------------------------------------------------------------------
+// Triple-addressed surface — shims over the path form, at depth one
+// ---------------------------------------------------------------------------
+
 RackId TrackApiLive::addRackToTrack(TrackId trackId, const juce::String& name) {
+    // Not a shim: a *top-level* rack lives in the track's own FX chain rather
+    // than inside another rack's chain, so there is no chain path to add it to.
+    // `addRackToChainByPath` is how you nest one; this is how you start.
     return TrackManager::getInstance().addRackToTrack(trackId, name);
 }
 
 void TrackApiLive::removeRackFromTrack(TrackId trackId, RackId rackId) {
-    TrackManager::getInstance().removeRackFromTrack(trackId, rackId);
+    removeRackFromChainByPath(ChainNodePath::rack(trackId, rackId));
 }
 
 const RackInfo* TrackApiLive::getRack(TrackId trackId, RackId rackId) const {
-    return TrackManager::getInstance().getRack(trackId, rackId);
+    return getRackByPath(ChainNodePath::rack(trackId, rackId));
 }
 
 void TrackApiLive::setRackBypassed(TrackId trackId, RackId rackId, bool bypassed) {
-    TrackManager::getInstance().setRackBypassed(trackId, rackId, bypassed);
+    setRackBypassedByPath(ChainNodePath::rack(trackId, rackId), bypassed);
 }
 
 void TrackApiLive::setRackVolume(TrackId trackId, RackId rackId, float volumeDb) {
-    TrackManager::getInstance().setRackVolume(trackId, rackId, volumeDb);
+    setRackVolume(ChainNodePath::rack(trackId, rackId), volumeDb);
 }
 
 ChainId TrackApiLive::addChainToRack(TrackId trackId, RackId rackId, const juce::String& name) {
-    return TrackManager::getInstance().addChainToRack(ChainNodePath::rack(trackId, rackId), name);
+    return addChainToRack(ChainNodePath::rack(trackId, rackId), name);
 }
 
 void TrackApiLive::removeChainFromRack(TrackId trackId, RackId rackId, ChainId chainId) {
-    TrackManager::getInstance().removeChainFromRack(trackId, rackId, chainId);
+    removeChainByPath(ChainNodePath::chain(trackId, rackId, chainId));
 }
 
 const ChainInfo* TrackApiLive::getChain(TrackId trackId, RackId rackId, ChainId chainId) const {
-    return TrackManager::getInstance().getChain(trackId, rackId, chainId);
+    return getChainByPath(ChainNodePath::chain(trackId, rackId, chainId));
 }
 
 void TrackApiLive::setChainOutput(TrackId trackId, RackId rackId, ChainId chainId,
                                   int outputIndex) {
-    TrackManager::getInstance().setChainOutput(trackId, rackId, chainId, outputIndex);
+    setChainOutput(ChainNodePath::chain(trackId, rackId, chainId), outputIndex);
 }
 
 void TrackApiLive::setChainMuted(TrackId trackId, RackId rackId, ChainId chainId, bool muted) {
-    TrackManager::getInstance().setChainMuted(trackId, rackId, chainId, muted);
+    setChainMuted(ChainNodePath::chain(trackId, rackId, chainId), muted);
 }
 
 void TrackApiLive::setChainBypassed(TrackId trackId, RackId rackId, ChainId chainId,
                                     bool bypassed) {
-    TrackManager::getInstance().setChainBypassed(trackId, rackId, chainId, bypassed);
+    setChainBypassed(ChainNodePath::chain(trackId, rackId, chainId), bypassed);
 }
 
 void TrackApiLive::setChainSolo(TrackId trackId, RackId rackId, ChainId chainId, bool solo) {
-    TrackManager::getInstance().setChainSolo(trackId, rackId, chainId, solo);
+    setChainSolo(ChainNodePath::chain(trackId, rackId, chainId), solo);
 }
 
 void TrackApiLive::setChainVolume(TrackId trackId, RackId rackId, ChainId chainId, float volumeDb) {
-    TrackManager::getInstance().setChainVolume(trackId, rackId, chainId, volumeDb);
+    setChainVolume(ChainNodePath::chain(trackId, rackId, chainId), volumeDb);
 }
 
 void TrackApiLive::setChainPan(TrackId trackId, RackId rackId, ChainId chainId, float pan) {
-    TrackManager::getInstance().setChainPan(trackId, rackId, chainId, pan);
+    setChainPan(ChainNodePath::chain(trackId, rackId, chainId), pan);
 }
 
 void TrackApiLive::setChainName(TrackId trackId, RackId rackId, ChainId chainId,
                                 const juce::String& name) {
-    TrackManager::getInstance().setChainName(trackId, rackId, chainId, name);
+    setChainName(ChainNodePath::chain(trackId, rackId, chainId), name);
 }
 
 const DeviceInfo* TrackApiLive::getPrimaryInstrument(TrackId trackId) const {

--- a/magda/daw/api/track_api_live.hpp
+++ b/magda/daw/api/track_api_live.hpp
@@ -28,6 +28,27 @@ class TrackApiLive : public TrackApi {
     DeviceId addDeviceToTrack(TrackId trackId, const DeviceInfo& device) override;
     DeviceId addDeviceToChain(TrackId trackId, RackId rackId, ChainId chainId,
                               const DeviceInfo& device) override;
+
+    // Path-addressed racks and chains (#1993). These are the implementations;
+    // the triple-based overrides below are shims over them.
+    RackId addRackToChainByPath(const ChainNodePath& chainPath, const juce::String& name) override;
+    void removeRackFromChainByPath(const ChainNodePath& rackPath) override;
+    const RackInfo* getRackByPath(const ChainNodePath& rackPath) const override;
+    void setRackBypassedByPath(const ChainNodePath& rackPath, bool bypassed) override;
+    void setRackVolume(const ChainNodePath& rackPath, float volumeDb) override;
+    ChainId addChainToRack(const ChainNodePath& rackPath, const juce::String& name) override;
+    void removeChainByPath(const ChainNodePath& chainPath) override;
+    const ChainInfo* getChainByPath(const ChainNodePath& chainPath) const override;
+    void setChainOutput(const ChainNodePath& chainPath, int outputIndex) override;
+    void setChainMuted(const ChainNodePath& chainPath, bool muted) override;
+    void setChainBypassed(const ChainNodePath& chainPath, bool bypassed) override;
+    void setChainSolo(const ChainNodePath& chainPath, bool solo) override;
+    void setChainVolume(const ChainNodePath& chainPath, float volumeDb) override;
+    void setChainPan(const ChainNodePath& chainPath, float pan) override;
+    void setChainName(const ChainNodePath& chainPath, const juce::String& name) override;
+    DeviceId addDeviceToChainByPath(const ChainNodePath& chainPath,
+                                    const DeviceInfo& device) override;
+
     RackId addRackToTrack(TrackId trackId, const juce::String& name) override;
     void removeRackFromTrack(TrackId trackId, RackId rackId) override;
     const RackInfo* getRack(TrackId trackId, RackId rackId) const override;

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -2635,12 +2635,16 @@ const ChainInfo* TrackManager::getChain(TrackId trackId, RackId rackId, ChainId 
     return nullptr;
 }
 
+void TrackManager::setChainOutput(const ChainNodePath& chainPath, int outputIndex) {
+    if (auto* chain = getChainByPath(chainPath)) {
+        chain->outputIndex = outputIndex;
+        notifyTrackDevicesChanged(chainPath.trackId);
+    }
+}
+
 void TrackManager::setChainOutput(TrackId trackId, RackId rackId, ChainId chainId,
                                   int outputIndex) {
-    if (auto* chain = getChain(trackId, rackId, chainId)) {
-        chain->outputIndex = outputIndex;
-        notifyTrackDevicesChanged(trackId);
-    }
+    setChainOutput(ChainNodePath::chain(trackId, rackId, chainId), outputIndex);
 }
 
 void TrackManager::setChainMuted(TrackId trackId, RackId rackId, ChainId chainId, bool muted) {
@@ -2679,15 +2683,19 @@ void TrackManager::setChainPan(TrackId trackId, RackId rackId, ChainId chainId, 
     }
 }
 
-void TrackManager::setChainName(TrackId trackId, RackId rackId, ChainId chainId,
-                                const juce::String& name) {
-    if (auto* chain = getChain(trackId, rackId, chainId)) {
+void TrackManager::setChainName(const ChainNodePath& chainPath, const juce::String& name) {
+    if (auto* chain = getChainByPath(chainPath)) {
         auto trimmed = name.trim();
         if (trimmed.isEmpty() || trimmed == chain->name)
             return;
         chain->name = trimmed;
-        notifyTrackPropertyChanged(trackId);
+        notifyTrackPropertyChanged(chainPath.trackId);
     }
+}
+
+void TrackManager::setChainName(TrackId trackId, RackId rackId, ChainId chainId,
+                                const juce::String& name) {
+    setChainName(ChainNodePath::chain(trackId, rackId, chainId), name);
 }
 
 void TrackManager::setRackVolume(TrackId trackId, RackId rackId, float volume) {

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -2431,42 +2431,55 @@ RackInfo* TrackManager::getRackByPath(const ChainNodePath& rackPath) {
     RackInfo* currentRack = nullptr;
     ChainInfo* currentChain = nullptr;
 
+    // A step that resolves to nothing ends the walk. This used to leave the
+    // previous `currentRack` in place and carry on, which made a broken path
+    // resolve to whatever it had passed through — so `outer > missingChain >
+    // missingRack` answered with `outer`. Worse, a missed Chain step left
+    // `currentChain` null, so the *next* Rack step searched the track's
+    // top-level list again and `outer > missingChain > someOtherTopLevelRack`
+    // answered with that unrelated rack.
+    //
+    // Every path-based rack mutator resolves through here, so that was a write
+    // landing silently on a node the caller never named. Failing closed is the
+    // only answer that cannot do that.
+    //
+    // Deliberately unchanged: a path that resolves *completely* but ends on a
+    // Chain or Device step still returns the enclosing rack rather than
+    // nothing. That leniency is long-standing, callers may rely on it, and it
+    // is a different question — #2057.
     for (const auto& step : rackPath.steps) {
         switch (step.type) {
             case ChainStepType::Rack: {
-                if (currentChain == nullptr) {
-                    // Top-level rack in track's chainElements
-                    for (auto& element : track->chain.fxChainElements) {
-                        if (magda::isRack(element)) {
-                            if (magda::getRack(element).id == step.id) {
-                                currentRack = &magda::getRack(element);
-                                break;
-                            }
-                        }
-                    }
-                } else {
-                    // Nested rack within a chain
-                    for (auto& element : currentChain->elements) {
-                        if (magda::isRack(element)) {
-                            if (magda::getRack(element).id == step.id) {
-                                currentRack = &magda::getRack(element);
-                                currentChain = nullptr;  // Reset chain context
-                                break;
-                            }
-                        }
+                // Top-level racks live in the track's own FX list; a nested one
+                // lives in the chain the previous step reached.
+                auto& elements =
+                    currentChain != nullptr ? currentChain->elements : track->chain.fxChainElements;
+                RackInfo* found = nullptr;
+                for (auto& element : elements) {
+                    if (magda::isRack(element) && magda::getRack(element).id == step.id) {
+                        found = &magda::getRack(element);
+                        break;
                     }
                 }
+                if (found == nullptr)
+                    return nullptr;
+                currentRack = found;
+                currentChain = nullptr;  // Reset chain context
                 break;
             }
             case ChainStepType::Chain: {
-                if (currentRack != nullptr) {
-                    for (auto& chain : currentRack->chains) {
-                        if (chain.id == step.id) {
-                            currentChain = &chain;
-                            break;
-                        }
+                if (currentRack == nullptr)
+                    return nullptr;
+                ChainInfo* found = nullptr;
+                for (auto& chain : currentRack->chains) {
+                    if (chain.id == step.id) {
+                        found = &chain;
+                        break;
                     }
                 }
+                if (found == nullptr)
+                    return nullptr;
+                currentChain = found;
                 break;
             }
             case ChainStepType::Device:

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -2443,13 +2443,40 @@ RackInfo* TrackManager::getRackByPath(const ChainNodePath& rackPath) {
     // landing silently on a node the caller never named. Failing closed is the
     // only answer that cannot do that.
     //
+    // The structure has to hold as well as the ids. Racks contain chains and
+    // chains contain racks, so a route alternates `Rack > Chain > Rack > Chain`;
+    // a step that cannot follow the one before it describes a route the model
+    // has no way to express. Checking only that each id resolves is not enough,
+    // because two consecutive steps of the same kind then move sideways through
+    // the tree using ids that all genuinely exist:
+    //
+    //   rack(A).withRack(B)            — B is a *sibling* top-level rack, and
+    //                                    with `currentChain` null the second
+    //                                    Rack step searched the track list
+    //                                    again and found it.
+    //   rack(R).withChain(c1).withChain(c2)
+    //                                  — c2 is a sibling chain of c1 in the
+    //                                    same rack, reached by a route that
+    //                                    never went through anything.
+    //
+    // Both resolved, and every path-based rack mutator would then write to a
+    // node on the other side of the tree from the one the caller named.
+    //
     // Deliberately unchanged: a path that resolves *completely* but ends on a
     // Chain or Device step still returns the enclosing rack rather than
-    // nothing. That leniency is long-standing, callers may rely on it, and it
-    // is a different question — #2057.
-    for (const auto& step : rackPath.steps) {
+    // nothing. That is a terminal-type leniency on a route that does exist,
+    // which is a different question — #2057.
+    for (std::size_t index = 0; index < rackPath.steps.size(); ++index) {
+        const auto& step = rackPath.steps[index];
+        const bool isLast = index + 1 == rackPath.steps.size();
+
         switch (step.type) {
             case ChainStepType::Rack: {
+                // Valid at track level, or immediately inside a chain. A Rack
+                // straight after a Rack is the sideways move above.
+                if (currentRack != nullptr && currentChain == nullptr)
+                    return nullptr;
+
                 // Top-level racks live in the track's own FX list; a nested one
                 // lives in the chain the previous step reached.
                 auto& elements =
@@ -2468,8 +2495,11 @@ RackInfo* TrackManager::getRackByPath(const ChainNodePath& rackPath) {
                 break;
             }
             case ChainStepType::Chain: {
-                if (currentRack == nullptr)
+                // Only ever directly inside a rack. A Chain after a Chain would
+                // hop between siblings.
+                if (currentRack == nullptr || currentChain != nullptr)
                     return nullptr;
+
                 ChainInfo* found = nullptr;
                 for (auto& chain : currentRack->chains) {
                     if (chain.id == step.id) {
@@ -2483,10 +2513,16 @@ RackInfo* TrackManager::getRackByPath(const ChainNodePath& rackPath) {
                 break;
             }
             case ChainStepType::Device:
-                // Devices don't contain racks, skip
+                // A leaf. Devices contain nothing, so nothing may follow one.
+                if (!isLast)
+                    return nullptr;
                 break;
             case ChainStepType::Segment:
-                // Segment steps don't affect rack traversal
+                // Only ever leads a path — it selects which of the track's FX
+                // lists to descend into, which is not a question that can be
+                // asked twice or part way down.
+                if (index != 0)
+                    return nullptr;
                 break;
         }
     }
@@ -2566,6 +2602,16 @@ void TrackManager::removeChainByPath(const ChainNodePath& chainPath) {
 
 ChainInfo* TrackManager::getChainByPath(const ChainNodePath& chainPath) {
     if (chainPath.steps.empty() || chainPath.steps.back().type != ChainStepType::Chain)
+        return nullptr;
+
+    // A chain hangs directly off a rack, so the step before it has to be one.
+    // Checking the prefix through `getRackByPath` is not enough on its own: for
+    // `rack > chain1 > chain2` the prefix `rack > chain1` is a perfectly legal
+    // route, and the search below would then find `chain2` sitting beside
+    // `chain1` in that same rack — a sibling reached by a path that never
+    // descended into anything.
+    if (chainPath.steps.size() < 2 ||
+        chainPath.steps[chainPath.steps.size() - 2].type != ChainStepType::Rack)
         return nullptr;
 
     const ChainId chainId = chainPath.steps.back().id;

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -2428,6 +2428,12 @@ RackInfo* TrackManager::getRackByPath(const ChainNodePath& rackPath) {
         return nullptr;
     }
 
+    // Track-level and legacy top-level-device paths cannot name an enclosing
+    // rack. Reject contradictory paths too (for example, a top-level device id
+    // combined with rack steps) instead of silently ignoring one representation.
+    if (rackPath.isTrackLevel || rackPath.topLevelDeviceId != INVALID_DEVICE_ID)
+        return nullptr;
+
     RackInfo* currentRack = nullptr;
     ChainInfo* currentChain = nullptr;
 
@@ -2463,9 +2469,11 @@ RackInfo* TrackManager::getRackByPath(const ChainNodePath& rackPath) {
     // node on the other side of the tree from the one the caller named.
     //
     // Deliberately unchanged: a path that resolves *completely* but ends on a
-    // Chain or Device step still returns the enclosing rack rather than
+    // Chain or nested Device step still returns the enclosing rack rather than
     // nothing. That is a terminal-type leniency on a route that does exist,
-    // which is a different question — #2057.
+    // which is a different question — #2057. A Device step therefore still has
+    // to name a real device in the current chain before this lookup may return
+    // that enclosing rack.
     for (std::size_t index = 0; index < rackPath.steps.size(); ++index) {
         const auto& step = rackPath.steps[index];
         const bool isLast = index + 1 == rackPath.steps.size();
@@ -2512,18 +2520,26 @@ RackInfo* TrackManager::getRackByPath(const ChainNodePath& rackPath) {
                 currentChain = found;
                 break;
             }
-            case ChainStepType::Device:
-                // A leaf. Devices contain nothing, so nothing may follow one.
-                if (!isLast)
+            case ChainStepType::Device: {
+                // A nested device is a leaf directly inside the current chain.
+                // Validate both the parent and the id before preserving the
+                // #2057 behavior of returning its enclosing rack.
+                if (!isLast || currentChain == nullptr)
+                    return nullptr;
+                const auto found = std::find_if(
+                    currentChain->elements.begin(), currentChain->elements.end(),
+                    [&step](const ChainElement& element) {
+                        return magda::isDevice(element) && magda::getDevice(element).id == step.id;
+                    });
+                if (found == currentChain->elements.end())
                     return nullptr;
                 break;
+            }
             case ChainStepType::Segment:
-                // Only ever leads a path — it selects which of the track's FX
-                // lists to descend into, which is not a question that can be
-                // asked twice or part way down.
-                if (index != 0)
-                    return nullptr;
-                break;
+                // Explicit segments select the flat post-fx or mixer-analysis
+                // lists (the main FX segment is implicit). None can contain a
+                // rack, so a segmented path has no answer in this resolver.
+                return nullptr;
         }
     }
 

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -486,6 +486,13 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     void setChainSolo(const ChainNodePath& chainPath, bool solo);
     void setChainVolume(const ChainNodePath& chainPath, float volume);
     void setChainPan(const ChainNodePath& chainPath, float pan);
+    // These two completed the set (#1993). Every other chain setter already had
+    // a path form; without them the facade could reach a nested chain's mute and
+    // volume but not its name or output, which is not a line anyone would have
+    // drawn on purpose. The triple-based forms above now delegate here, so there
+    // is one body rather than two that can drift.
+    void setChainOutput(const ChainNodePath& chainPath, int outputIndex);
+    void setChainName(const ChainNodePath& chainPath, const juce::String& name);
     void setChainExpanded(TrackId trackId, RackId rackId, ChainId chainId, bool expanded);
     void setRackVolume(TrackId trackId, RackId rackId, float volume);
     void setRackVolume(const ChainNodePath& rackPath, float volume);

--- a/magda/daw/core/TrackManagerDevices.cpp
+++ b/magda/daw/core/TrackManagerDevices.cpp
@@ -434,34 +434,23 @@ void TrackManager::setDeviceInChainBypassed(TrackId trackId, RackId rackId, Chai
 }
 
 // Helper to get chain from a path that ends with Chain step
+/**
+ * @brief The chain a path names, or nothing.
+ *
+ * Delegates rather than resolving again. This was a second copy of
+ * `TrackManager::getChainByPath` — same "drop the last step, resolve the rack,
+ * search its chains" body — and the two drifted the moment one of them learned
+ * something the other did not: the structural guards added for #1993 went into
+ * `getChainByPath`, so `rack > chain1 > chain2` was refused there and still
+ * resolved to the sibling `chain2` here.
+ *
+ * That mattered because this copy is the one `getDeviceInChainByPath` uses, and
+ * device paths are the surface a remote client supplies verbatim
+ * (`toChainNodePath` builds them from whatever steps arrive). One body means
+ * one set of rules for both.
+ */
 static ChainInfo* getChainFromPath(TrackManager& tm, const ChainNodePath& chainPath) {
-    if (chainPath.steps.empty())
-        return nullptr;
-
-    // Extract chainId from the last step (should be Chain type)
-    ChainId chainId = INVALID_CHAIN_ID;
-    if (chainPath.steps.back().type == ChainStepType::Chain) {
-        chainId = chainPath.steps.back().id;
-    } else {
-        return nullptr;
-    }
-
-    // Build the parent rack path
-    ChainNodePath rackPath;
-    rackPath.trackId = chainPath.trackId;
-    for (size_t i = 0; i < chainPath.steps.size() - 1; ++i) {
-        rackPath.steps.push_back(chainPath.steps[i]);
-    }
-
-    // Get the parent rack and find the chain
-    if (auto* rack = tm.getRackByPath(rackPath)) {
-        for (auto& c : rack->chains) {
-            if (c.id == chainId) {
-                return &c;
-            }
-        }
-    }
-    return nullptr;
+    return tm.getChainByPath(chainPath);
 }
 
 static std::vector<ChainElement>* getElementContainerForChainPath(TrackManager& tm,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -208,6 +208,8 @@ set(TEST_SOURCES
     test_remote_websocket_server.cpp
     test_remote_api_host.cpp
     test_device_api.cpp
+    # Rack and chain addressing at depth through the facade (issue #1993)
+    test_track_api_nested_racks.cpp
     test_automation_api_surface.cpp
     # Lua controller tests (issue #592 — MIDI dispatch)
     test_lua_controller.cpp
@@ -389,6 +391,8 @@ target_sources(magda_juce_tests PRIVATE
     test_midi_bridge_note_events_juce.cpp
     test_section_scoped_device_ids_juce.cpp
     test_remote_service_live_juce.cpp
+    # Path-addressed racks/chains against the real TrackManager (issue #1993)
+    test_track_api_nested_racks_live_juce.cpp
     test_remote_websocket_live_juce.cpp
     test_clip_inspector_juce.cpp
     test_multi_clip_resize_preview_juce.cpp
@@ -557,6 +561,10 @@ add_test(NAME convolution_device_juce
 # an initialised message system to be valid.
 add_test(NAME remote_service_live_juce
          COMMAND magda_juce_tests "Remote Service Live")
+
+# The facade's path-addressed rack/chain surface against the real TrackManager.
+add_test(NAME track_api_nested_racks_live_juce
+         COMMAND magda_juce_tests "Track API Nested Racks Live")
 
 # Both test executables link magda_daw, which links ONNX Runtime. On Windows the
 # loader only searches the exe's directory, the cwd, and PATH, so without a copy

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -428,34 +428,53 @@ class MockTrackApi : public TrackApi {
         if (track == nullptr)
             return nullptr;
 
+        // Mirrors `TrackManager::getRackByPath` step for step, including its
+        // structural rules: a route alternates `Rack > Chain > Rack > Chain`,
+        // a Device is a leaf, and a Segment only ever leads. Two consecutive
+        // steps of the same kind move sideways through the tree on ids that all
+        // exist, which is a route the model cannot express — see the long note
+        // on the model's copy for the shapes that used to resolve.
         RackInfo* rack = nullptr;
         ChainInfo* chain = nullptr;
-        for (const auto& step : rackPath.steps) {
+        for (std::size_t index = 0; index < rackPath.steps.size(); ++index) {
+            const auto& step = rackPath.steps[index];
+            const bool isLast = index + 1 == rackPath.steps.size();
+
             if (step.type == ChainStepType::Rack) {
+                if (rack != nullptr && chain == nullptr)
+                    return nullptr;
                 // A rack sits either directly in the track's FX list or inside
                 // the chain reached by the previous step.
                 auto& elements = chain != nullptr ? chain->elements : track->chain.fxChainElements;
-                rack = nullptr;
+                RackInfo* found = nullptr;
                 for (auto& element : elements) {
                     if (magda::isRack(element) && magda::getRack(element).id == step.id) {
-                        rack = &magda::getRack(element);
+                        found = &magda::getRack(element);
                         break;
                     }
                 }
-                chain = nullptr;
-                if (rack == nullptr)
+                if (found == nullptr)
                     return nullptr;
+                rack = found;
+                chain = nullptr;
             } else if (step.type == ChainStepType::Chain) {
-                if (rack == nullptr)
+                if (rack == nullptr || chain != nullptr)
                     return nullptr;
-                chain = nullptr;
+                ChainInfo* found = nullptr;
                 for (auto& candidate : rack->chains) {
                     if (candidate.id == step.id) {
-                        chain = &candidate;
+                        found = &candidate;
                         break;
                     }
                 }
-                if (chain == nullptr)
+                if (found == nullptr)
+                    return nullptr;
+                chain = found;
+            } else if (step.type == ChainStepType::Device) {
+                if (!isLast)
+                    return nullptr;
+            } else if (step.type == ChainStepType::Segment) {
+                if (index != 0)
                     return nullptr;
             }
         }
@@ -473,6 +492,13 @@ class MockTrackApi : public TrackApi {
 
     ChainInfo* resolveChain(const ChainNodePath& chainPath) {
         if (chainPath.steps.empty() || chainPath.steps.back().type != ChainStepType::Chain)
+            return nullptr;
+        // A chain hangs directly off a rack. Resolving the prefix is not enough
+        // by itself — for `rack > chain1 > chain2` the prefix is legal, and the
+        // search below would find `chain2` beside `chain1` in the same rack.
+        // Mirrors the same guard in `TrackManager::getChainByPath`.
+        if (chainPath.steps.size() < 2 ||
+            chainPath.steps[chainPath.steps.size() - 2].type != ChainStepType::Rack)
             return nullptr;
         auto* rack = resolveRack(chainPath.parent());
         if (rack == nullptr)

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -406,32 +406,275 @@ class MockTrackApi : public TrackApi {
         deviceWrites.push_back({trackId, device});
         return nextDeviceId++;
     }
-    DeviceId addDeviceToChain(TrackId, RackId, ChainId, const DeviceInfo&) override {
-        return INVALID_DEVICE_ID;
+    // -----------------------------------------------------------------------
+    // Racks and chains
+    //
+    // A real nested tree, held in `TrackInfo::chain.fxChainElements` exactly
+    // as `TrackManager` holds it, resolved by walking `ChainNodePath` the same
+    // way `getRackByPath` does.
+    //
+    // Every one of these used to return `INVALID_*_ID` or nullptr. That made
+    // the mock agree with a facade that could not address nested racks (#1993)
+    // — it had nothing to disagree with — so the gap was invisible from the
+    // tests. Modelling it properly is what stops it coming back: a facade that
+    // silently loses depth now fails here rather than in a bug report.
+    // -----------------------------------------------------------------------
+
+    RackId nextRackId = 1;
+    ChainId nextChainId = 1;
+
+    RackInfo* resolveRack(const ChainNodePath& rackPath) {
+        auto* track = getTrack(rackPath.trackId);
+        if (track == nullptr)
+            return nullptr;
+
+        RackInfo* rack = nullptr;
+        ChainInfo* chain = nullptr;
+        for (const auto& step : rackPath.steps) {
+            if (step.type == ChainStepType::Rack) {
+                // A rack sits either directly in the track's FX list or inside
+                // the chain reached by the previous step.
+                auto& elements = chain != nullptr ? chain->elements : track->chain.fxChainElements;
+                rack = nullptr;
+                for (auto& element : elements) {
+                    if (magda::isRack(element) && magda::getRack(element).id == step.id) {
+                        rack = &magda::getRack(element);
+                        break;
+                    }
+                }
+                chain = nullptr;
+                if (rack == nullptr)
+                    return nullptr;
+            } else if (step.type == ChainStepType::Chain) {
+                if (rack == nullptr)
+                    return nullptr;
+                chain = nullptr;
+                for (auto& candidate : rack->chains) {
+                    if (candidate.id == step.id) {
+                        chain = &candidate;
+                        break;
+                    }
+                }
+                if (chain == nullptr)
+                    return nullptr;
+            }
+        }
+        // The deepest rack traversed, whatever the last step was — so a *chain*
+        // path answers with that chain's parent rack rather than with nothing.
+        //
+        // That is `TrackManager::getRackByPath`'s behaviour, and matching it is
+        // the point of this mock. Guarding on the last step type here instead
+        // read better and was wrong: the two resolvers then disagreed, and a
+        // test written against the mock encoded the mock's opinion rather than
+        // the model's. Whether the real one *should* be this lenient is a
+        // separate question from whether the mock should lie about it.
+        return rack;
     }
-    RackId addRackToTrack(TrackId, const juce::String&) override {
-        return INVALID_RACK_ID;
-    }
-    void removeRackFromTrack(TrackId, RackId) override {}
-    const RackInfo* getRack(TrackId, RackId) const override {
+
+    ChainInfo* resolveChain(const ChainNodePath& chainPath) {
+        if (chainPath.steps.empty() || chainPath.steps.back().type != ChainStepType::Chain)
+            return nullptr;
+        auto* rack = resolveRack(chainPath.parent());
+        if (rack == nullptr)
+            return nullptr;
+        for (auto& chain : rack->chains) {
+            if (chain.id == chainPath.steps.back().id)
+                return &chain;
+        }
         return nullptr;
     }
-    void setRackBypassed(TrackId, RackId, bool) override {}
-    void setRackVolume(TrackId, RackId, float) override {}
-    ChainId addChainToRack(TrackId, RackId, const juce::String&) override {
-        return INVALID_CHAIN_ID;
+
+    RackId addRackToChainByPath(const ChainNodePath& chainPath, const juce::String& name) override {
+        auto* chain = resolveChain(chainPath);
+        if (chain == nullptr)
+            return INVALID_RACK_ID;
+        RackInfo rack;
+        rack.id = nextRackId++;
+        rack.name = name;
+        // A new rack comes with one chain, like the real thing — otherwise a
+        // test that nests two racks has nowhere to put the second.
+        ChainInfo defaultChain;
+        defaultChain.id = nextChainId++;
+        defaultChain.name = "Chain 1";
+        rack.chains.push_back(std::move(defaultChain));
+        const auto id = rack.id;
+        chain->elements.push_back(makeRackElement(std::move(rack)));
+        return id;
     }
-    void removeChainFromRack(TrackId, RackId, ChainId) override {}
-    const ChainInfo* getChain(TrackId, RackId, ChainId) const override {
-        return nullptr;
+
+    void removeRackFromChainByPath(const ChainNodePath& rackPath) override {
+        if (rackPath.steps.empty() || rackPath.steps.back().type != ChainStepType::Rack)
+            return;
+        const auto rackId = rackPath.steps.back().id;
+        const auto parent = rackPath.parent();
+
+        std::vector<ChainElement>* elements = nullptr;
+        if (parent.steps.empty()) {
+            if (auto* track = getTrack(parent.trackId))
+                elements = &track->chain.fxChainElements;
+        } else if (auto* chain = resolveChain(parent)) {
+            elements = &chain->elements;
+        }
+        if (elements == nullptr)
+            return;
+
+        elements->erase(std::remove_if(elements->begin(), elements->end(),
+                                       [rackId](const ChainElement& element) {
+                                           return magda::isRack(element) &&
+                                                  magda::getRack(element).id == rackId;
+                                       }),
+                        elements->end());
     }
-    void setChainOutput(TrackId, RackId, ChainId, int) override {}
-    void setChainMuted(TrackId, RackId, ChainId, bool) override {}
-    void setChainBypassed(TrackId, RackId, ChainId, bool) override {}
-    void setChainSolo(TrackId, RackId, ChainId, bool) override {}
-    void setChainVolume(TrackId, RackId, ChainId, float) override {}
-    void setChainPan(TrackId, RackId, ChainId, float) override {}
-    void setChainName(TrackId, RackId, ChainId, const juce::String&) override {}
+
+    const RackInfo* getRackByPath(const ChainNodePath& rackPath) const override {
+        return const_cast<MockTrackApi*>(this)->resolveRack(rackPath);
+    }
+
+    void setRackBypassedByPath(const ChainNodePath& rackPath, bool bypassed) override {
+        if (auto* rack = resolveRack(rackPath))
+            rack->bypassed = bypassed;
+    }
+
+    void setRackVolume(const ChainNodePath& rackPath, float volumeDb) override {
+        if (auto* rack = resolveRack(rackPath))
+            rack->volume = volumeDb;
+    }
+
+    ChainId addChainToRack(const ChainNodePath& rackPath, const juce::String& name) override {
+        auto* rack = resolveRack(rackPath);
+        if (rack == nullptr)
+            return INVALID_CHAIN_ID;
+        ChainInfo chain;
+        chain.id = nextChainId++;
+        chain.name = name;
+        const auto id = chain.id;
+        rack->chains.push_back(std::move(chain));
+        return id;
+    }
+
+    void removeChainByPath(const ChainNodePath& chainPath) override {
+        if (chainPath.steps.empty() || chainPath.steps.back().type != ChainStepType::Chain)
+            return;
+        const auto chainId = chainPath.steps.back().id;
+        if (auto* rack = resolveRack(chainPath.parent())) {
+            auto& chains = rack->chains;
+            chains.erase(std::remove_if(chains.begin(), chains.end(),
+                                        [chainId](const ChainInfo& c) { return c.id == chainId; }),
+                         chains.end());
+        }
+    }
+
+    const ChainInfo* getChainByPath(const ChainNodePath& chainPath) const override {
+        return const_cast<MockTrackApi*>(this)->resolveChain(chainPath);
+    }
+
+    void setChainOutput(const ChainNodePath& chainPath, int outputIndex) override {
+        if (auto* chain = resolveChain(chainPath))
+            chain->outputIndex = outputIndex;
+    }
+    void setChainMuted(const ChainNodePath& chainPath, bool muted) override {
+        if (auto* chain = resolveChain(chainPath))
+            chain->muted = muted;
+    }
+    void setChainBypassed(const ChainNodePath& chainPath, bool bypassed) override {
+        if (auto* chain = resolveChain(chainPath))
+            chain->bypassed = bypassed;
+    }
+    void setChainSolo(const ChainNodePath& chainPath, bool solo) override {
+        if (auto* chain = resolveChain(chainPath))
+            chain->solo = solo;
+    }
+    void setChainVolume(const ChainNodePath& chainPath, float volumeDb) override {
+        if (auto* chain = resolveChain(chainPath))
+            chain->volume = volumeDb;
+    }
+    void setChainPan(const ChainNodePath& chainPath, float pan) override {
+        if (auto* chain = resolveChain(chainPath))
+            chain->pan = pan;
+    }
+    void setChainName(const ChainNodePath& chainPath, const juce::String& name) override {
+        if (auto* chain = resolveChain(chainPath))
+            chain->name = name;
+    }
+
+    DeviceId addDeviceToChainByPath(const ChainNodePath& chainPath,
+                                    const DeviceInfo& device) override {
+        auto* chain = resolveChain(chainPath);
+        if (chain == nullptr)
+            return INVALID_DEVICE_ID;
+        DeviceInfo copy = device;
+        copy.id = nextDeviceId++;
+        const auto id = copy.id;
+        chain->elements.push_back(ChainElement{std::move(copy)});
+        return id;
+    }
+
+    RackId addRackToTrack(TrackId trackId, const juce::String& name) override {
+        auto* track = getTrack(trackId);
+        if (track == nullptr)
+            return INVALID_RACK_ID;
+        RackInfo rack;
+        rack.id = nextRackId++;
+        rack.name = name;
+        ChainInfo defaultChain;
+        defaultChain.id = nextChainId++;
+        defaultChain.name = "Chain 1";
+        rack.chains.push_back(std::move(defaultChain));
+        const auto id = rack.id;
+        track->chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
+        return id;
+    }
+
+    // The triple-based surface, as shims — the same shape `TrackApiLive` uses,
+    // so a test driving either form exercises one model.
+    DeviceId addDeviceToChain(TrackId trackId, RackId rackId, ChainId chainId,
+                              const DeviceInfo& device) override {
+        return addDeviceToChainByPath(ChainNodePath::chain(trackId, rackId, chainId), device);
+    }
+    void removeRackFromTrack(TrackId trackId, RackId rackId) override {
+        removeRackFromChainByPath(ChainNodePath::rack(trackId, rackId));
+    }
+    const RackInfo* getRack(TrackId trackId, RackId rackId) const override {
+        return getRackByPath(ChainNodePath::rack(trackId, rackId));
+    }
+    void setRackBypassed(TrackId trackId, RackId rackId, bool bypassed) override {
+        setRackBypassedByPath(ChainNodePath::rack(trackId, rackId), bypassed);
+    }
+    void setRackVolume(TrackId trackId, RackId rackId, float volumeDb) override {
+        setRackVolume(ChainNodePath::rack(trackId, rackId), volumeDb);
+    }
+    ChainId addChainToRack(TrackId trackId, RackId rackId, const juce::String& name) override {
+        return addChainToRack(ChainNodePath::rack(trackId, rackId), name);
+    }
+    void removeChainFromRack(TrackId trackId, RackId rackId, ChainId chainId) override {
+        removeChainByPath(ChainNodePath::chain(trackId, rackId, chainId));
+    }
+    const ChainInfo* getChain(TrackId trackId, RackId rackId, ChainId chainId) const override {
+        return getChainByPath(ChainNodePath::chain(trackId, rackId, chainId));
+    }
+    void setChainOutput(TrackId trackId, RackId rackId, ChainId chainId, int outputIndex) override {
+        setChainOutput(ChainNodePath::chain(trackId, rackId, chainId), outputIndex);
+    }
+    void setChainMuted(TrackId trackId, RackId rackId, ChainId chainId, bool muted) override {
+        setChainMuted(ChainNodePath::chain(trackId, rackId, chainId), muted);
+    }
+    void setChainBypassed(TrackId trackId, RackId rackId, ChainId chainId, bool bypassed) override {
+        setChainBypassed(ChainNodePath::chain(trackId, rackId, chainId), bypassed);
+    }
+    void setChainSolo(TrackId trackId, RackId rackId, ChainId chainId, bool solo) override {
+        setChainSolo(ChainNodePath::chain(trackId, rackId, chainId), solo);
+    }
+    void setChainVolume(TrackId trackId, RackId rackId, ChainId chainId, float volumeDb) override {
+        setChainVolume(ChainNodePath::chain(trackId, rackId, chainId), volumeDb);
+    }
+    void setChainPan(TrackId trackId, RackId rackId, ChainId chainId, float pan) override {
+        setChainPan(ChainNodePath::chain(trackId, rackId, chainId), pan);
+    }
+    void setChainName(TrackId trackId, RackId rackId, ChainId chainId,
+                      const juce::String& name) override {
+        setChainName(ChainNodePath::chain(trackId, rackId, chainId), name);
+    }
+
     const DeviceInfo* getPrimaryInstrument(TrackId) const override {
         return nullptr;
     }

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -427,6 +427,8 @@ class MockTrackApi : public TrackApi {
         auto* track = getTrack(rackPath.trackId);
         if (track == nullptr)
             return nullptr;
+        if (rackPath.isTrackLevel || rackPath.topLevelDeviceId != INVALID_DEVICE_ID)
+            return nullptr;
 
         // Mirrors `TrackManager::getRackByPath` step for step, including its
         // structural rules: a route alternates `Rack > Chain > Rack > Chain`,
@@ -471,11 +473,17 @@ class MockTrackApi : public TrackApi {
                     return nullptr;
                 chain = found;
             } else if (step.type == ChainStepType::Device) {
-                if (!isLast)
+                if (!isLast || chain == nullptr)
+                    return nullptr;
+                const auto found = std::find_if(chain->elements.begin(), chain->elements.end(),
+                                                [&step](const ChainElement& element) {
+                                                    return magda::isDevice(element) &&
+                                                           magda::getDevice(element).id == step.id;
+                                                });
+                if (found == chain->elements.end())
                     return nullptr;
             } else if (step.type == ChainStepType::Segment) {
-                if (index != 0)
-                    return nullptr;
+                return nullptr;
             }
         }
         // The deepest rack traversed, whatever the last step was — so a *chain*

--- a/tests/test_track_api_nested_racks.cpp
+++ b/tests/test_track_api_nested_racks.cpp
@@ -223,7 +223,7 @@ TEST_CASE("An unresolvable path yields nothing rather than the wrong node",
     // chain's parent. Pinned because it is surprising, and because the live
     // test caught the mock disagreeing with `TrackManager` about it — not
     // because it is obviously the right rule. Tightening it would change
-    // long-standing behaviour well outside this facade.
+    // long-standing behaviour well outside this facade — tracked as #2057.
     REQUIRE(api.tracks().getRackByPath(top.chainPath()) ==
             api.tracks().getRackByPath(top.rackPath()));
 

--- a/tests/test_track_api_nested_racks.cpp
+++ b/tests/test_track_api_nested_racks.cpp
@@ -247,3 +247,47 @@ TEST_CASE("An unresolvable path yields nothing rather than the wrong node",
     REQUIRE(api.tracks().getRackByPath(top.rackPath())->volume != -24.0f);
     REQUIRE(api.tracks().getRackByPath(top.rackPath())->chains.size() == chainsBefore);
 }
+
+TEST_CASE("A structurally impossible route is refused, even with real ids",
+          "[track-api][racks][nesting]") {
+    // Harder than a missing id: every step here names something real, and only
+    // the shape is wrong. The model alternates `Rack > Chain > Rack > Chain`,
+    // so two consecutive steps of the same kind walk sideways through the tree
+    // on ids that all resolve — which is how a write reaches a node on the
+    // other side of it. The live suite asserts the same shapes against the real
+    // resolver.
+    MockMagdaApi api;
+    const auto top = makeTopLevel(api);
+    const auto rackB = api.tracks().addRackToTrack(top.track, "B");
+    REQUIRE(rackB != INVALID_RACK_ID);
+
+    // Rack after Rack: `rackB` is a sibling, not a child.
+    REQUIRE(api.tracks().getRackByPath(top.rackPath().withRack(rackB)) == nullptr);
+
+    // Chain after Chain: siblings within one rack.
+    const auto secondChain = api.tracks().addChainToRack(top.rackPath(), "Second");
+    REQUIRE(secondChain != INVALID_CHAIN_ID);
+    REQUIRE(api.tracks().getChainByPath(top.chainPath().withChain(secondChain)) == nullptr);
+    REQUIRE(api.tracks().getRackByPath(top.chainPath().withChain(secondChain)) == nullptr);
+
+    // A device is a leaf; nothing follows it.
+    DeviceInfo device;
+    device.name = "Leaf";
+    const auto deviceId = api.tracks().addDeviceToChainByPath(top.chainPath(), device);
+    REQUIRE(api.tracks().getRackByPath(top.chainPath().withDevice(deviceId).withRack(rackB)) ==
+            nullptr);
+
+    // A Segment only ever leads a path.
+    auto trailingSegment = top.rackPath();
+    trailingSegment.steps.push_back(
+        {ChainStepType::Segment, static_cast<int>(ChainSegment::PostFx)});
+    REQUIRE(api.tracks().getRackByPath(trailingSegment) == nullptr);
+
+    // And the sideways write lands nowhere.
+    const auto* siblingBefore = api.tracks().getRackByPath(ChainNodePath::rack(top.track, rackB));
+    REQUIRE(siblingBefore != nullptr);
+    const auto volumeBefore = siblingBefore->volume;
+    api.tracks().setRackVolume(top.rackPath().withRack(rackB), -24.0f);
+    REQUIRE(api.tracks().getRackByPath(ChainNodePath::rack(top.track, rackB))->volume ==
+            volumeBefore);
+}

--- a/tests/test_track_api_nested_racks.cpp
+++ b/tests/test_track_api_nested_racks.cpp
@@ -227,8 +227,23 @@ TEST_CASE("An unresolvable path yields nothing rather than the wrong node",
     REQUIRE(api.tracks().getRackByPath(top.chainPath()) ==
             api.tracks().getRackByPath(top.rackPath()));
 
+    // A path whose *middle* step is broken resolves to nothing, rather than to
+    // something it merely walked through on the way. The live suite is what
+    // pins this against the real resolver — this mock always failed closed, and
+    // `TrackManager` did not, so the agreement here is the thing that used to be
+    // a lie. See `test_track_api_nested_racks_live_juce.cpp`.
+    REQUIRE(api.tracks().getRackByPath(top.rackPath().withChain(9999).withRack(9998)) == nullptr);
+
     // Writing through an unresolvable path changes nothing rather than
     // asserting or landing somewhere else.
     api.tracks().setChainName(ChainNodePath::chain(top.track, top.rack, 9999), "Nowhere");
     REQUIRE(api.tracks().getChainByPath(top.chainPath())->name != "Nowhere");
+
+    const auto* outerBefore = api.tracks().getRackByPath(top.rackPath());
+    REQUIRE(outerBefore != nullptr);
+    const auto chainsBefore = outerBefore->chains.size();
+    api.tracks().setRackVolume(top.rackPath().withChain(9999).withRack(9998), -24.0f);
+    api.tracks().addChainToRack(top.rackPath().withChain(9999).withRack(9998), "Nowhere");
+    REQUIRE(api.tracks().getRackByPath(top.rackPath())->volume != -24.0f);
+    REQUIRE(api.tracks().getRackByPath(top.rackPath())->chains.size() == chainsBefore);
 }

--- a/tests/test_track_api_nested_racks.cpp
+++ b/tests/test_track_api_nested_racks.cpp
@@ -1,0 +1,234 @@
+// Racks and chains at depth, through the facade (#1993).
+//
+// `TrackApi` addressed racks and chains by a `(trackId, rackId, chainId)`
+// triple, which names exactly one level of nesting. The model nests
+// arbitrarily — `Track > Rack > Chain > Rack > Chain > Device` — so nothing
+// inside a nested rack was reachable through the facade at all: there is no
+// triple that names the inner chain. A caller could already address a *device*
+// at depth, because `DevicePathDto` has carried a full route since #1991, but
+// not the chain containing it, so "add a chain to this rack" stopped working at
+// depth two.
+//
+// These drive `MockTrackApi`, which models the same nested tree `TrackManager`
+// holds and resolves paths the same way. That is deliberate: the mock used to
+// stub every rack and chain method to `INVALID_*_ID`, which agreed with a
+// facade that could not reach depth, so the gap was invisible from here.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "MockMagdaApi.hpp"
+
+using namespace magda;
+using magda::test::MockMagdaApi;
+
+namespace {
+
+/// `Track > Rack > Chain`, the shallowest thing worth nesting into.
+struct TopLevel {
+    TrackId track = INVALID_TRACK_ID;
+    RackId rack = INVALID_RACK_ID;
+    ChainId chain = INVALID_CHAIN_ID;
+
+    ChainNodePath rackPath() const {
+        return ChainNodePath::rack(track, rack);
+    }
+    ChainNodePath chainPath() const {
+        return ChainNodePath::chain(track, rack, chain);
+    }
+};
+
+TopLevel makeTopLevel(MockMagdaApi& api) {
+    TopLevel built;
+    built.track = api.tracks().createTrack("Bus", TrackType::Audio);
+    built.rack = api.tracks().addRackToTrack(built.track, "Outer");
+    REQUIRE(built.rack != INVALID_RACK_ID);
+
+    // A new rack comes with one chain, so this is the chain to nest into.
+    const auto* rack = api.tracks().getRackByPath(built.rackPath());
+    REQUIRE(rack != nullptr);
+    REQUIRE_FALSE(rack->chains.empty());
+    built.chain = rack->chains.front().id;
+    return built;
+}
+
+}  // namespace
+
+TEST_CASE("A rack can be created inside a chain", "[track-api][racks][nesting]") {
+    MockMagdaApi api;
+    const auto top = makeTopLevel(api);
+
+    const auto innerRack = api.tracks().addRackToChainByPath(top.chainPath(), "Inner");
+    REQUIRE(innerRack != INVALID_RACK_ID);
+    REQUIRE(innerRack != top.rack);
+
+    // Reachable by the route that names it, and by nothing shorter.
+    const auto innerPath = top.chainPath().withRack(innerRack);
+    const auto* found = api.tracks().getRackByPath(innerPath);
+    REQUIRE(found != nullptr);
+    REQUIRE(found->name == "Inner");
+
+    // The triple-based surface cannot see it: `(track, innerRack)` asks for a
+    // top-level rack with that id, and there is none. This is the limitation
+    // the path form exists to lift, asserted rather than described.
+    REQUIRE(api.tracks().getRack(top.track, innerRack) == nullptr);
+}
+
+TEST_CASE("A chain can be created inside a nested rack", "[track-api][racks][nesting]") {
+    MockMagdaApi api;
+    const auto top = makeTopLevel(api);
+    const auto innerRack = api.tracks().addRackToChainByPath(top.chainPath(), "Inner");
+    const auto innerRackPath = top.chainPath().withRack(innerRack);
+
+    // The operation the issue names: at depth two this had no expressible form.
+    const auto innerChain = api.tracks().addChainToRack(innerRackPath, "Deep");
+    REQUIRE(innerChain != INVALID_CHAIN_ID);
+
+    const auto innerChainPath = innerRackPath.withChain(innerChain);
+    const auto* chain = api.tracks().getChainByPath(innerChainPath);
+    REQUIRE(chain != nullptr);
+    REQUIRE(chain->name == "Deep");
+
+    // Depth is four steps: Rack > Chain > Rack > Chain.
+    REQUIRE(innerChainPath.depth() == 4);
+}
+
+TEST_CASE("A device can be added to a chain inside a nested rack", "[track-api][racks][nesting]") {
+    MockMagdaApi api;
+    const auto top = makeTopLevel(api);
+    const auto innerRack = api.tracks().addRackToChainByPath(top.chainPath(), "Inner");
+    const auto innerRackPath = top.chainPath().withRack(innerRack);
+    const auto innerChain = api.tracks().addChainToRack(innerRackPath, "Deep");
+    const auto innerChainPath = innerRackPath.withChain(innerChain);
+
+    DeviceInfo device;
+    device.name = "Reverb";
+    const auto deviceId = api.tracks().addDeviceToChainByPath(innerChainPath, device);
+    REQUIRE(deviceId != INVALID_DEVICE_ID);
+
+    const auto* chain = api.tracks().getChainByPath(innerChainPath);
+    REQUIRE(chain != nullptr);
+    REQUIRE(chain->elements.size() == 1);
+    REQUIRE(magda::isDevice(chain->elements.front()));
+    REQUIRE(magda::getDevice(chain->elements.front()).name == "Reverb");
+}
+
+TEST_CASE("Every chain setter reaches a nested chain", "[track-api][racks][nesting]") {
+    // The whole setter surface, not a sample: the gap was that *some* of these
+    // had a path form and some did not, and a caller has no way to know which
+    // until one silently does nothing. `setChainOutput` and `setChainName` are
+    // the two that had none before this change.
+    MockMagdaApi api;
+    const auto top = makeTopLevel(api);
+    const auto innerRack = api.tracks().addRackToChainByPath(top.chainPath(), "Inner");
+    const auto innerChainPath = top.chainPath().withRack(innerRack).withChain(
+        api.tracks().addChainToRack(top.chainPath().withRack(innerRack), "Deep"));
+
+    auto& tracks = api.tracks();
+    tracks.setChainName(innerChainPath, "Renamed");
+    tracks.setChainOutput(innerChainPath, 3);
+    tracks.setChainMuted(innerChainPath, true);
+    tracks.setChainBypassed(innerChainPath, true);
+    tracks.setChainSolo(innerChainPath, true);
+    tracks.setChainVolume(innerChainPath, -6.0f);
+    tracks.setChainPan(innerChainPath, -0.5f);
+
+    const auto* chain = tracks.getChainByPath(innerChainPath);
+    REQUIRE(chain != nullptr);
+    REQUIRE(chain->name == "Renamed");
+    REQUIRE(chain->outputIndex == 3);
+    REQUIRE(chain->muted);
+    REQUIRE(chain->bypassed);
+    REQUIRE(chain->solo);
+    REQUIRE(chain->volume == -6.0f);
+    REQUIRE(chain->pan == -0.5f);
+}
+
+TEST_CASE("Rack setters reach a nested rack", "[track-api][racks][nesting]") {
+    MockMagdaApi api;
+    const auto top = makeTopLevel(api);
+    const auto innerRack = api.tracks().addRackToChainByPath(top.chainPath(), "Inner");
+    const auto innerRackPath = top.chainPath().withRack(innerRack);
+
+    api.tracks().setRackBypassedByPath(innerRackPath, true);
+    api.tracks().setRackVolume(innerRackPath, -3.0f);
+
+    const auto* rack = api.tracks().getRackByPath(innerRackPath);
+    REQUIRE(rack != nullptr);
+    REQUIRE(rack->bypassed);
+    REQUIRE(rack->volume == -3.0f);
+
+    // And the outer rack is untouched — a path that resolved to the wrong level
+    // would be the failure mode worth catching.
+    const auto* outer = api.tracks().getRackByPath(top.rackPath());
+    REQUIRE(outer != nullptr);
+    REQUIRE_FALSE(outer->bypassed);
+}
+
+TEST_CASE("A nested chain and rack can be removed", "[track-api][racks][nesting]") {
+    MockMagdaApi api;
+    const auto top = makeTopLevel(api);
+    const auto innerRack = api.tracks().addRackToChainByPath(top.chainPath(), "Inner");
+    const auto innerRackPath = top.chainPath().withRack(innerRack);
+    const auto innerChain = api.tracks().addChainToRack(innerRackPath, "Deep");
+    const auto innerChainPath = innerRackPath.withChain(innerChain);
+
+    REQUIRE(api.tracks().getChainByPath(innerChainPath) != nullptr);
+    api.tracks().removeChainByPath(innerChainPath);
+    REQUIRE(api.tracks().getChainByPath(innerChainPath) == nullptr);
+    // Its rack survives the loss of one of its chains.
+    REQUIRE(api.tracks().getRackByPath(innerRackPath) != nullptr);
+
+    api.tracks().removeRackFromChainByPath(innerRackPath);
+    REQUIRE(api.tracks().getRackByPath(innerRackPath) == nullptr);
+    // The rack it was nested in is still there.
+    REQUIRE(api.tracks().getRackByPath(top.rackPath()) != nullptr);
+}
+
+TEST_CASE("The triple-based surface is the path form at depth one", "[track-api][racks][nesting]") {
+    // The triples are kept as shims rather than removed, because the agent DSL
+    // addresses one rack at a time by design. This pins the equivalence they
+    // rest on: `(t, r, c)` is `ChainNodePath::chain(t, r, c)` and nothing else.
+    MockMagdaApi api;
+    const auto top = makeTopLevel(api);
+
+    api.tracks().setChainName(top.track, top.rack, top.chain, "Via triple");
+    REQUIRE(api.tracks().getChainByPath(top.chainPath())->name == "Via triple");
+
+    api.tracks().setChainName(top.chainPath(), "Via path");
+    REQUIRE(api.tracks().getChain(top.track, top.rack, top.chain)->name == "Via path");
+
+    // Both lookups answer with the same object.
+    REQUIRE(api.tracks().getChain(top.track, top.rack, top.chain) ==
+            api.tracks().getChainByPath(top.chainPath()));
+    REQUIRE(api.tracks().getRack(top.track, top.rack) ==
+            api.tracks().getRackByPath(top.rackPath()));
+}
+
+TEST_CASE("An unresolvable path yields nothing rather than the wrong node",
+          "[track-api][racks][nesting]") {
+    MockMagdaApi api;
+    const auto top = makeTopLevel(api);
+
+    // A rack id that exists at another level, a chain id that does not exist,
+    // and a path whose last step is the wrong kind. Each must be a miss: the
+    // dangerous failure for a path resolver is answering with a near neighbour.
+    REQUIRE(api.tracks().getRackByPath(ChainNodePath::rack(top.track, 9999)) == nullptr);
+    REQUIRE(api.tracks().getChainByPath(ChainNodePath::chain(top.track, top.rack, 9999)) ==
+            nullptr);
+    REQUIRE(api.tracks().getChainByPath(top.rackPath()) == nullptr);
+    REQUIRE(api.tracks().getRackByPath(ChainNodePath::rack(9999, top.rack)) == nullptr);
+
+    // Asking for a *rack* with a chain path is lenient rather than a miss: the
+    // resolver answers with the deepest rack it walked through, which is that
+    // chain's parent. Pinned because it is surprising, and because the live
+    // test caught the mock disagreeing with `TrackManager` about it — not
+    // because it is obviously the right rule. Tightening it would change
+    // long-standing behaviour well outside this facade.
+    REQUIRE(api.tracks().getRackByPath(top.chainPath()) ==
+            api.tracks().getRackByPath(top.rackPath()));
+
+    // Writing through an unresolvable path changes nothing rather than
+    // asserting or landing somewhere else.
+    api.tracks().setChainName(ChainNodePath::chain(top.track, top.rack, 9999), "Nowhere");
+    REQUIRE(api.tracks().getChainByPath(top.chainPath())->name != "Nowhere");
+}

--- a/tests/test_track_api_nested_racks.cpp
+++ b/tests/test_track_api_nested_racks.cpp
@@ -274,14 +274,24 @@ TEST_CASE("A structurally impossible route is refused, even with real ids",
     DeviceInfo device;
     device.name = "Leaf";
     const auto deviceId = api.tracks().addDeviceToChainByPath(top.chainPath(), device);
+    const auto validDevicePath = top.chainPath().withDevice(deviceId);
+    REQUIRE(api.tracks().getRackByPath(validDevicePath) ==
+            api.tracks().getRackByPath(top.rackPath()));
+    REQUIRE(api.tracks().getRackByPath(top.chainPath().withDevice(9999)) == nullptr);
+    REQUIRE(api.tracks().getRackByPath(top.rackPath().withDevice(deviceId)) == nullptr);
     REQUIRE(api.tracks().getRackByPath(top.chainPath().withDevice(deviceId).withRack(rackB)) ==
             nullptr);
 
-    // A Segment only ever leads a path.
+    // A Segment selects a flat section that cannot contain racks. It is invalid
+    // both after a rack and before a real main-FX rack.
     auto trailingSegment = top.rackPath();
     trailingSegment.steps.push_back(
         {ChainStepType::Segment, static_cast<int>(ChainSegment::PostFx)});
     REQUIRE(api.tracks().getRackByPath(trailingSegment) == nullptr);
+    auto segmentedRack = top.rackPath();
+    segmentedRack.steps.insert(segmentedRack.steps.begin(),
+                               {ChainStepType::Segment, static_cast<int>(ChainSegment::PostFx)});
+    REQUIRE(api.tracks().getRackByPath(segmentedRack) == nullptr);
 
     // And the sideways write lands nowhere.
     const auto* siblingBefore = api.tracks().getRackByPath(ChainNodePath::rack(top.track, rackB));
@@ -290,4 +300,9 @@ TEST_CASE("A structurally impossible route is refused, even with real ids",
     api.tracks().setRackVolume(top.rackPath().withRack(rackB), -24.0f);
     REQUIRE(api.tracks().getRackByPath(ChainNodePath::rack(top.track, rackB))->volume ==
             volumeBefore);
+
+    const auto outerVolume = api.tracks().getRackByPath(top.rackPath())->volume;
+    api.tracks().setRackVolume(top.chainPath().withDevice(9999), -24.0f);
+    api.tracks().setRackVolume(segmentedRack, -24.0f);
+    REQUIRE(api.tracks().getRackByPath(top.rackPath())->volume == outerVolume);
 }

--- a/tests/test_track_api_nested_racks_live_juce.cpp
+++ b/tests/test_track_api_nested_racks_live_juce.cpp
@@ -245,6 +245,47 @@ class TrackApiNestedRacksLiveTest final : public juce::UnitTest {
             expect(!afterB->bypassed);
             expect(afterB->chains.size() == chainsB);
         }
+
+        beginTest("A device is not reachable through a sideways route either");
+        {
+            // Device paths are the ones a remote client supplies verbatim —
+            // `toChainNodePath` builds them from whatever steps arrive — so a
+            // malformed route here reaches a real device in a part of the tree
+            // the caller never named.
+            //
+            // Worth its own case because the device resolver went through a
+            // *second* copy of the chain lookup, which did not learn the
+            // structural guards when `getChainByPath` did. Both now share one
+            // body.
+            Fixture fixture;
+            TrackManager& model = TrackManager::getInstance();
+            TrackApiLive api;
+
+            const auto track = api.createTrack("Bus", TrackType::Audio);
+            const auto rackId = api.addRackToTrack(track, "Outer");
+            const auto rackPath = ChainNodePath::rack(track, rackId);
+            const auto chain1 = api.getRackByPath(rackPath)->chains.front().id;
+            const auto chain2 = api.addChainToRack(rackPath, "Second");
+
+            // A real device, in the second chain.
+            DeviceInfo device;
+            device.name = "Hidden";
+            const auto deviceId = api.addDeviceToChainByPath(rackPath.withChain(chain2), device);
+            expect(deviceId != INVALID_DEVICE_ID);
+
+            // Reachable by its own route.
+            const auto realRoute = rackPath.withChain(chain2).withDevice(deviceId);
+            expect(model.getDeviceInChainByPath(realRoute) != nullptr);
+
+            // Not by one that hops from its sibling chain into it.
+            const auto sideways = rackPath.withChain(chain1).withChain(chain2).withDevice(deviceId);
+            expect(model.getDeviceInChainByPath(sideways) == nullptr);
+
+            // Nor by one that claims it sits directly under a doubled rack step.
+            const auto doubledRack =
+                rackPath.withRack(rackId).withChain(chain2).withDevice(deviceId);
+            expect(model.getDeviceInChainByPath(doubledRack) == nullptr);
+        }
     }
 
   private:

--- a/tests/test_track_api_nested_racks_live_juce.cpp
+++ b/tests/test_track_api_nested_racks_live_juce.cpp
@@ -154,6 +154,42 @@ class TrackApiNestedRacksLiveTest final : public juce::UnitTest {
             // tightening it would reach well beyond this facade. Tracked as #2057.
             expect(api.getRackByPath(chainPath) == api.getRackByPath(rackPath));
 
+            // A path whose *middle* step is broken must not resolve to
+            // something it merely passed through. This is the case the mock
+            // could not catch: it failed closed at the first miss while the
+            // real resolver carried the last rack it had seen forward, so a
+            // write through `outer > missingChain > missingRack` landed on
+            // `outer` — a mutation of a node the caller never named.
+            const auto brokenMiddle = rackPath.withChain(9999).withRack(9998);
+            expect(api.getRackByPath(brokenMiddle) == nullptr);
+
+            // And the nastier shape: the trailing step names a rack that really
+            // does exist, just somewhere else entirely. The missed chain step
+            // used to leave the traversal at track level, so this resolved to
+            // that unrelated top-level rack.
+            const auto secondTopLevel = api.addRackToTrack(track, "Elsewhere");
+            const auto brokenToElsewhere = rackPath.withChain(9999).withRack(secondTopLevel);
+            expect(api.getRackByPath(brokenToElsewhere) == nullptr);
+
+            // The writes that resolve through it are therefore no-ops rather
+            // than misdirected. `setRackVolume` is the clearest: it is new
+            // facade surface in this change, so the blast radius was new too.
+            const auto* outerBefore = api.getRackByPath(rackPath);
+            expect(outerBefore != nullptr);
+            const auto volumeBefore = outerBefore->volume;
+            const auto bypassedBefore = outerBefore->bypassed;
+
+            api.setRackVolume(brokenMiddle, -24.0f);
+            api.setRackBypassedByPath(brokenMiddle, true);
+            const auto chainsBefore = api.getRackByPath(rackPath)->chains.size();
+            api.addChainToRack(brokenMiddle, "Should not appear");
+
+            const auto* outerAfter = api.getRackByPath(rackPath);
+            expect(outerAfter != nullptr);
+            expectWithinAbsoluteError(outerAfter->volume, volumeBefore, 0.001f);
+            expect(outerAfter->bypassed == bypassedBefore);
+            expect(outerAfter->chains.size() == chainsBefore);
+
             api.setChainName(ChainNodePath::chain(track, rackId, 9999), "Nowhere");
             expect(api.getChainByPath(chainPath)->name != "Nowhere");
         }

--- a/tests/test_track_api_nested_racks_live_juce.cpp
+++ b/tests/test_track_api_nested_racks_live_juce.cpp
@@ -193,6 +193,58 @@ class TrackApiNestedRacksLiveTest final : public juce::UnitTest {
             api.setChainName(ChainNodePath::chain(track, rackId, 9999), "Nowhere");
             expect(api.getChainByPath(chainPath)->name != "Nowhere");
         }
+
+        beginTest("A structurally impossible route is refused, even with real ids");
+        {
+            // The harder case than a missing id: every step below names
+            // something that genuinely exists, and only the *shape* is wrong.
+            // Rejecting a miss is not enough, because two consecutive steps of
+            // the same kind walk sideways through the tree on ids that resolve.
+            Fixture fixture;
+            TrackApiLive api;
+
+            const auto track = api.createTrack("Bus", TrackType::Audio);
+            const auto rackA = api.addRackToTrack(track, "A");
+            const auto rackB = api.addRackToTrack(track, "B");
+            const auto pathA = ChainNodePath::rack(track, rackA);
+            const auto pathB = ChainNodePath::rack(track, rackB);
+
+            // Rack after Rack. `rackB` is a *sibling* of `rackA`, not inside
+            // it — with the chain context cleared, the second step used to
+            // search the track list again and find it.
+            expect(api.getRackByPath(pathA.withRack(rackB)) == nullptr);
+
+            // Chain after Chain. Two chains in one rack; the second is a
+            // sibling of the first, reached by a route that passes through
+            // nothing.
+            const auto chain1 = api.getRackByPath(pathA)->chains.front().id;
+            const auto chain2 = api.addChainToRack(pathA, "Second");
+            expect(chain2 != INVALID_CHAIN_ID);
+            expect(api.getChainByPath(pathA.withChain(chain1).withChain(chain2)) == nullptr);
+            expect(api.getRackByPath(pathA.withChain(chain1).withChain(chain2)) == nullptr);
+
+            // A device is a leaf; nothing follows it.
+            DeviceInfo device;
+            device.name = "Leaf";
+            const auto deviceId = api.addDeviceToChainByPath(pathA.withChain(chain1), device);
+            expect(deviceId != INVALID_DEVICE_ID);
+            expect(api.getRackByPath(
+                       pathA.withChain(chain1).withDevice(deviceId).withRack(rackB)) == nullptr);
+
+            // And the writes that resolve through it leave both racks alone,
+            // rather than landing on the sibling the route wandered into.
+            const auto volumeB = api.getRackByPath(pathB)->volume;
+            const auto chainsB = api.getRackByPath(pathB)->chains.size();
+            api.setRackVolume(pathA.withRack(rackB), -24.0f);
+            api.setRackBypassedByPath(pathA.withRack(rackB), true);
+            api.addChainToRack(pathA.withRack(rackB), "Should not appear");
+
+            const auto* afterB = api.getRackByPath(pathB);
+            expect(afterB != nullptr);
+            expectWithinAbsoluteError(afterB->volume, volumeB, 0.001f);
+            expect(!afterB->bypassed);
+            expect(afterB->chains.size() == chainsB);
+        }
     }
 
   private:

--- a/tests/test_track_api_nested_racks_live_juce.cpp
+++ b/tests/test_track_api_nested_racks_live_juce.cpp
@@ -1,0 +1,177 @@
+#include <juce_core/juce_core.h>
+
+#include "magda/daw/api/track_api_live.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+
+// The facade's path-addressed rack and chain surface (#1993), driven against the
+// real `TrackManager` rather than a mock.
+//
+// test_track_api_nested_racks.cpp covers the same operations through
+// `MockTrackApi`, which is worth having — it is what stops the mock quietly
+// agreeing with a facade that has lost depth again. But a mock I wrote passing
+// tests I wrote proves the mock, not the forwarding. These run the same shapes
+// through `TrackApiLive`, so what is asserted is that the real model answers.
+//
+// They live in the JUCE target because `TrackManager` is a singleton whose
+// notifications assume an initialised message system.
+
+namespace {
+
+using namespace magda;
+
+class TrackApiNestedRacksLiveTest final : public juce::UnitTest {
+  public:
+    TrackApiNestedRacksLiveTest() : juce::UnitTest("Track API Nested Racks Live", "magda") {}
+
+    void runTest() override {
+        beginTest("A chain and a device are reachable inside a nested rack");
+        {
+            Fixture fixture;
+            TrackApiLive api;
+
+            const auto track = api.createTrack("Bus", TrackType::Audio);
+            const auto outerRack = api.addRackToTrack(track, "Outer");
+            expect(outerRack != INVALID_RACK_ID);
+
+            const auto outerRackPath = ChainNodePath::rack(track, outerRack);
+            const auto* rack = api.getRackByPath(outerRackPath);
+            expect(rack != nullptr);
+            expect(!rack->chains.empty());
+            const auto outerChainPath = outerRackPath.withChain(rack->chains.front().id);
+
+            // Nest a rack inside that chain, then a chain inside *that* rack.
+            // This is the shape the triple-based surface could not name.
+            const auto innerRack = api.addRackToChainByPath(outerChainPath, "Inner");
+            expect(innerRack != INVALID_RACK_ID);
+            const auto innerRackPath = outerChainPath.withRack(innerRack);
+            expect(api.getRackByPath(innerRackPath) != nullptr);
+
+            const auto innerChain = api.addChainToRack(innerRackPath, "Deep");
+            expect(innerChain != INVALID_CHAIN_ID);
+            const auto innerChainPath = innerRackPath.withChain(innerChain);
+
+            const auto* deep = api.getChainByPath(innerChainPath);
+            expect(deep != nullptr);
+            expectEquals(deep->name, juce::String("Deep"));
+
+            // And a device inside it.
+            DeviceInfo device;
+            device.name = "Reverb";
+            const auto deviceId = api.addDeviceToChainByPath(innerChainPath, device);
+            expect(deviceId != INVALID_DEVICE_ID);
+
+            const auto* withDevice = api.getChainByPath(innerChainPath);
+            expect(withDevice != nullptr);
+            expect(withDevice->elements.size() == 1);
+            expect(magda::isDevice(withDevice->elements.front()));
+
+            // The triple form cannot see the inner rack, because there is no
+            // triple that names it — the limitation this issue is about.
+            expect(api.getRack(track, innerRack) == nullptr);
+        }
+
+        beginTest("The two setters that had no path form reach a nested chain");
+        {
+            // `setChainOutput` and `setChainName` were triple-only on
+            // TrackManager, so the facade could reach a nested chain's mute and
+            // volume but not its name or output. Both are new path forms, so
+            // unlike the rest of this surface they are not merely forwarded.
+            Fixture fixture;
+            TrackApiLive api;
+
+            const auto track = api.createTrack("Bus", TrackType::Audio);
+            const auto outerRack = api.addRackToTrack(track, "Outer");
+            const auto outerRackPath = ChainNodePath::rack(track, outerRack);
+            const auto outerChainPath =
+                outerRackPath.withChain(api.getRackByPath(outerRackPath)->chains.front().id);
+            const auto innerRackPath =
+                outerChainPath.withRack(api.addRackToChainByPath(outerChainPath, "Inner"));
+            const auto innerChainPath =
+                innerRackPath.withChain(api.addChainToRack(innerRackPath, "Deep"));
+
+            api.setChainName(innerChainPath, "Renamed");
+            api.setChainOutput(innerChainPath, 2);
+            api.setChainVolume(innerChainPath, -6.0f);
+
+            const auto* chain = api.getChainByPath(innerChainPath);
+            expect(chain != nullptr);
+            expectEquals(chain->name, juce::String("Renamed"));
+            expectEquals(chain->outputIndex, 2);
+            expectWithinAbsoluteError(chain->volume, -6.0f, 0.001f);
+
+            // The outer chain is untouched: a path resolving one level off would
+            // be the quiet failure worth catching.
+            const auto* outer = api.getChainByPath(outerChainPath);
+            expect(outer != nullptr);
+            expect(outer->name != "Renamed");
+            expectEquals(outer->outputIndex, 0);
+        }
+
+        beginTest("The triple form and the path form address the same chain");
+        {
+            // The triples are kept as shims over the path surface, so this is
+            // the equivalence the whole arrangement rests on.
+            Fixture fixture;
+            TrackApiLive api;
+
+            const auto track = api.createTrack("Bus", TrackType::Audio);
+            const auto rackId = api.addRackToTrack(track, "Outer");
+            const auto rackPath = ChainNodePath::rack(track, rackId);
+            const auto chainId = api.getRackByPath(rackPath)->chains.front().id;
+            const auto chainPath = rackPath.withChain(chainId);
+
+            api.setChainName(track, rackId, chainId, "Via triple");
+            expectEquals(api.getChainByPath(chainPath)->name, juce::String("Via triple"));
+
+            api.setChainName(chainPath, "Via path");
+            expectEquals(api.getChain(track, rackId, chainId)->name, juce::String("Via path"));
+
+            expect(api.getChain(track, rackId, chainId) == api.getChainByPath(chainPath));
+            expect(api.getRack(track, rackId) == api.getRackByPath(rackPath));
+        }
+
+        beginTest("An unresolvable path changes nothing");
+        {
+            Fixture fixture;
+            TrackApiLive api;
+
+            const auto track = api.createTrack("Bus", TrackType::Audio);
+            const auto rackId = api.addRackToTrack(track, "Outer");
+            const auto rackPath = ChainNodePath::rack(track, rackId);
+            const auto chainId = api.getRackByPath(rackPath)->chains.front().id;
+            const auto chainPath = rackPath.withChain(chainId);
+
+            expect(api.getRackByPath(ChainNodePath::rack(track, 9999)) == nullptr);
+            expect(api.getChainByPath(ChainNodePath::chain(track, rackId, 9999)) == nullptr);
+            // Asking for a chain with a rack path is a miss.
+            expect(api.getChainByPath(rackPath) == nullptr);
+
+            // The other direction is not. `getRackByPath` returns the deepest
+            // rack it walked through regardless of the final step, so a chain
+            // path answers with that chain's parent rack. Long-standing
+            // `TrackManager` behaviour, pinned here because it is surprising —
+            // this test is what caught the mock disagreeing about it, and
+            // tightening it would reach well beyond this facade.
+            expect(api.getRackByPath(chainPath) == api.getRackByPath(rackPath));
+
+            api.setChainName(ChainNodePath::chain(track, rackId, 9999), "Nowhere");
+            expect(api.getChainByPath(chainPath)->name != "Nowhere");
+        }
+    }
+
+  private:
+    /// TrackManager is a process-wide singleton, so a test that adds tracks has
+    /// to clear them or it leaks into whatever runs next.
+    struct Fixture {
+        Fixture() {
+            TrackManager::getInstance().clearAllTracks();
+        }
+        ~Fixture() {
+            TrackManager::getInstance().clearAllTracks();
+        }
+    };
+};
+
+TrackApiNestedRacksLiveTest trackApiNestedRacksLiveTest;
+
+}  // namespace

--- a/tests/test_track_api_nested_racks_live_juce.cpp
+++ b/tests/test_track_api_nested_racks_live_juce.cpp
@@ -151,7 +151,7 @@ class TrackApiNestedRacksLiveTest final : public juce::UnitTest {
             // path answers with that chain's parent rack. Long-standing
             // `TrackManager` behaviour, pinned here because it is surprising —
             // this test is what caught the mock disagreeing about it, and
-            // tightening it would reach well beyond this facade.
+            // tightening it would reach well beyond this facade. Tracked as #2057.
             expect(api.getRackByPath(chainPath) == api.getRackByPath(rackPath));
 
             api.setChainName(ChainNodePath::chain(track, rackId, 9999), "Nowhere");

--- a/tests/test_track_api_nested_racks_live_juce.cpp
+++ b/tests/test_track_api_nested_racks_live_juce.cpp
@@ -228,22 +228,39 @@ class TrackApiNestedRacksLiveTest final : public juce::UnitTest {
             device.name = "Leaf";
             const auto deviceId = api.addDeviceToChainByPath(pathA.withChain(chain1), device);
             expect(deviceId != INVALID_DEVICE_ID);
+            const auto validDevicePath = pathA.withChain(chain1).withDevice(deviceId);
+            expect(api.getRackByPath(validDevicePath) == api.getRackByPath(pathA));
+            const auto missingDevicePath = pathA.withChain(chain1).withDevice(9999);
+            expect(api.getRackByPath(missingDevicePath) == nullptr);
+            expect(api.getRackByPath(pathA.withDevice(deviceId)) == nullptr);
             expect(api.getRackByPath(
                        pathA.withChain(chain1).withDevice(deviceId).withRack(rackB)) == nullptr);
+
+            // An explicit Segment selects a flat section, so it cannot lead to
+            // a rack in the main FX list even when that rack id exists.
+            auto segmentedRack = pathA;
+            segmentedRack.steps.insert(
+                segmentedRack.steps.begin(),
+                {ChainStepType::Segment, static_cast<int>(ChainSegment::PostFx)});
+            expect(api.getRackByPath(segmentedRack) == nullptr);
 
             // And the writes that resolve through it leave both racks alone,
             // rather than landing on the sibling the route wandered into.
             const auto volumeB = api.getRackByPath(pathB)->volume;
             const auto chainsB = api.getRackByPath(pathB)->chains.size();
+            const auto volumeA = api.getRackByPath(pathA)->volume;
             api.setRackVolume(pathA.withRack(rackB), -24.0f);
             api.setRackBypassedByPath(pathA.withRack(rackB), true);
             api.addChainToRack(pathA.withRack(rackB), "Should not appear");
+            api.setRackVolume(missingDevicePath, -24.0f);
+            api.setRackVolume(segmentedRack, -24.0f);
 
             const auto* afterB = api.getRackByPath(pathB);
             expect(afterB != nullptr);
             expectWithinAbsoluteError(afterB->volume, volumeB, 0.001f);
             expect(!afterB->bypassed);
             expect(afterB->chains.size() == chainsB);
+            expectWithinAbsoluteError(api.getRackByPath(pathA)->volume, volumeA, 0.001f);
         }
 
         beginTest("A device is not reachable through a sideways route either");


### PR DESCRIPTION
Closes #1993.

## The gap

Every rack and chain operation on the facade took a `(trackId, rackId, chainId)` triple, which names exactly one level of nesting. The model nests arbitrarily — `Track > Rack > Chain > Rack > Chain > Device` — so nothing inside a nested rack was reachable through `TrackApi` at all: there is no triple that names the inner chain.

A caller could already address a *device* at depth, since `DevicePathDto` has carried a full route since #1991 — but not the chain containing it. So "add a chain to this rack" stopped working at depth two, and the remote API's `racks.create` still describes itself as creating a *top-level* rack.

## The change

`ChainNodePath` overloads for the whole rack and chain surface, forwarding to the `TrackManager` methods the UI has always used. Mostly surfacing what already existed.

The names deliberately mirror TrackManager's own (`getRackByPath`, `removeChainByPath`, `addDeviceToChainByPath`, and plain overloads where TrackManager overloads). This facade is a view onto it, and inventing a third vocabulary for the same calls would be one more mapping to hold in your head.

**Two of them had nothing to forward to.** The issue says TrackManager "already has a path-based equivalent for every one of these" — it did not. `setChainOutput` and `setChainName` were triple-only, so the facade could otherwise reach a nested chain's mute and volume but not its name or output, which is not a line anyone would have drawn on purpose. Both now have path forms on TrackManager, with the triple versions delegating so there is one body rather than two that can drift.

**The triples are kept as shims** at depth one rather than removed. The agent DSL is their only substantial consumer and its grammar is inherently one-rack-at-a-time; migrating it means changing that grammar, which is its own piece of work. `(t, r, c)` is `ChainNodePath::chain(t, r, c)` and the tests pin that equivalence.

## The mock was part of the problem

`MockTrackApi` stubbed every rack and chain method to `INVALID_*_ID` or `nullptr`. That agreed perfectly with a facade that could not reach depth — it had nothing to disagree with — so the gap was invisible from the tests. It now holds the same nested tree `TrackManager` holds and resolves paths the same way.

## Tests, and what the second suite caught

Two halves, and the second earned its place immediately:

- `test_track_api_nested_racks.cpp` — the facade's shape through the mock.
- `test_track_api_nested_racks_live_juce.cpp` — the same shapes through `TrackApiLive` against the real `TrackManager`.

The live suite exists because a mock I wrote passing tests I wrote proves the mock, not the forwarding. **It failed on first run.** `TrackManager::getRackByPath` returns the deepest rack it walked through regardless of the final step, so a *chain* path answers with that chain's parent rack rather than nothing — and I had written the mock to the tidier rule. The mock-only test had encoded my opinion rather than the model's behaviour.

The mock now matches the model, and both suites pin the real semantics with a comment saying it is surprising. `TrackManager` itself is unchanged: that leniency is long-standing, `getRackByPath` is called from the UI, the chain editor, sidechain wiring, and preset application, and some of those may pass a deeper path deliberately. Tracked as #2057.

## Verification

Full Catch2 suite green (2326 passed, 13 skipped). Both new suites green. `Remote Service Live` still green. Release build clean.

## Follow-ups, not in scope

- **#2057** — whether `getRackByPath` should reject a non-rack path, or be renamed to say what it does. Also covers the asymmetry with `getChainByPath`, which is strict.
- **The remote API is now narrower than the facade.** `racks.*` still takes ids and still says "top-level"; widening it to a `DevicePathDto`-style route is the natural next step and what #701 wanted. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)