### PR TITLE
Native engine: warp markers, beat detection and loop info (#2038)

### DIFF
--- a/docs/architecture/native-engine.md
+++ b/docs/architecture/native-engine.md
@@ -28,7 +28,7 @@ is. When the two disagree, the headers are right and this file is stale.
 | Retire stock TE plugin wrappers | [#1888](https://github.com/Conceptual-Machines/magda-core/issues/1888) | done |
 | Clip model: container from content | [#1901](https://github.com/Conceptual-Machines/magda-core/issues/1901) | done |
 | **Engine core: plan, executor, PDC** | [#1889](https://github.com/Conceptual-Machines/magda-core/issues/1889) | **all 10 slices done** |
-| **Arranger clip playback** | [#1890](https://github.com/Conceptual-Machines/magda-core/issues/1890) | **slices 1 to 4 of 7** |
+| **Arranger clip playback** | [#1890](https://github.com/Conceptual-Machines/magda-core/issues/1890) | **slices 1 to 5 of 7** |
 | Parameters, modifiers, macros, automation | [#1891](https://github.com/Conceptual-Machines/magda-core/issues/1891) | not started |
 | Rack graph: pins, summing, multi-out, nesting | [#1892](https://github.com/Conceptual-Machines/magda-core/issues/1892) | not started |
 | External plugin hosting and hardware inserts | [#1893](https://github.com/Conceptual-Machines/magda-core/issues/1893) | not started |
@@ -51,9 +51,9 @@ crossfading a plan swap ([#2019](https://github.com/Conceptual-Machines/magda-co
 Clips, slice by slice: the snapshot ([#2034](https://github.com/Conceptual-Machines/magda-core/issues/2034)),
 voices, spans and fades ([#2035](https://github.com/Conceptual-Machines/magda-core/issues/2035)),
 rate conversion, looping and reverse ([#2036](https://github.com/Conceptual-Machines/magda-core/issues/2036)),
-stretch and pitch ([#2037](https://github.com/Conceptual-Machines/magda-core/issues/2037)).
-Still open: warp ([#2038](https://github.com/Conceptual-Machines/magda-core/issues/2038)),
-MIDI clips ([#2039](https://github.com/Conceptual-Machines/magda-core/issues/2039)),
+stretch and pitch ([#2037](https://github.com/Conceptual-Machines/magda-core/issues/2037)),
+warp, beat detection and loop info ([#2038](https://github.com/Conceptual-Machines/magda-core/issues/2038)).
+Still open: MIDI clips ([#2039](https://github.com/Conceptual-Machines/magda-core/issues/2039)),
 null-diff corpus ([#2040](https://github.com/Conceptual-Machines/magda-core/issues/2040)).
 
 ---
@@ -375,7 +375,7 @@ differently:
 | auto tempo | advances by the beats that have passed, times a beat of the file |
 | analog pitch | advances by the ratio the model already folded the pitch into, with no stretcher |
 | a speed ramp fade | the moment itself is warped near the clip's edge, and the rate with it |
-| warp ([#2038](https://github.com/Conceptual-Machines/magda-core/issues/2038)) | another answer from the same place |
+| warp markers | advances through a compiled map whose rate changes at every marker |
 
 Auto tempo is the one worth reading twice. Its ratio is the project's tempo over the file's own
 and moves with the tempo curve, so it cannot be resolved to seconds ahead of a block. What saves
@@ -383,6 +383,46 @@ it is that the integral of that ratio is beats: the material an instant has cons
 beats have passed since the event began, times what a beat of the file is worth. That is why the
 clock publishes both faces of one instant, and why there is no second tempo map on the audio
 thread.
+
+### Warp
+
+Slice 5 ([#2038](https://github.com/Conceptual-Machines/magda-core/issues/2038)), and it added
+no machinery at all below the position map: the voice, the stretchers and the reading chain are
+untouched by it. A block already asks `readingPositionAt` at both its ends and hands the
+difference to the stretcher, so a ratio that changes at every marker costs nothing that a moving
+auto-tempo ratio did not already cost.
+
+The model holds warp as `(sourceTime, warpTime)` pairs, piecewise linear, slope 1 outside the
+marker range. That direction answers where a bit of file lands musically, which is what the
+editors ask. Playback asks the inverse, so `clip/WarpMap.hpp` compiles one: sorted, strictly
+increasing on both sides, and with whatever could not be part of a monotonic map dropped at
+compile time with a diagnostic rather than divided by on the audio thread.
+
+Three things compose with it, and each is decided in one place:
+
+- **Reverse** stays a coordinate change, as it is everywhere else in this layer. The map is not
+  mirrored; a reversed event walks it backwards from the far end of what it reads and mirrors the
+  answer. Mirroring the map instead would need the length of the region the event reads, which is
+  itself an answer from the map. The incumbent cannot do reverse and warp together at all -- it
+  bakes warp into a rendered proxy file and can only bake one thing per clip, so
+  `WaveAudioClip::createRenderJob` returns the reverse job and the markers are silently lost.
+- **Looping** is the one case where the reading chain cannot do its own tiling. Folding below the
+  stream works because the reading advances linearly, and under warp it does not: a position that
+  had already been through the map would fold in the wrong domain and every pass after the first
+  would play straight. So a warped loop folds in warp time, above the map, and the tiling below is
+  switched off. The reading then saws back at each wrap rather than climbing, which costs one seek
+  per pass.
+- **Stretcher sizing** reads the map's steepest segment rather than its average. A warped event
+  has no single rate, and the pre-roll has to cover the fastest stretch of it.
+
+Where the markers come from when the user has not placed them is the other half of the slice.
+`analysis/TransientDetector.hpp` is the incumbent's detector reproduced coefficient for
+coefficient -- envelope followers, a differentiator, a threshold from the sensitivity, a spacing
+rule -- because a detector that found different transients would move every auto-detected marker
+in every project that already has one. `io/SourceLoopInfo.hpp` is the third piece and is not an
+analysis at all: a file's own tempo and beat count are an acid chunk that JUCE already parses, so
+what the model seeds its interpretation from is a parse over a metadata map, testable without a
+file.
 
 A block then reads exactly `round(P(end)) - round(P(start))` samples and hands them to the
 stretcher to come back as the block's own length, so the ratio a block runs at is whatever its
@@ -433,9 +473,11 @@ Worth knowing before reading the code and wondering where something is:
   A `Device` op resolves to whatever the host hands the store. Nothing hosts VST3 yet.
 - **Launcher and recording** ([#1894](https://github.com/Conceptual-Machines/magda-core/issues/1894),
   [#1895](https://github.com/Conceptual-Machines/magda-core/issues/1895)).
-- **Warp and MIDI clips** ([#2038](https://github.com/Conceptual-Machines/magda-core/issues/2038),
-  [#2039](https://github.com/Conceptual-Machines/magda-core/issues/2039)). Speed, pitch and auto
-  tempo play; warp markers are carried in the snapshot and nothing reads them yet.
+- **MIDI clips** ([#2039](https://github.com/Conceptual-Machines/magda-core/issues/2039)). Audio
+  clips play; a `ClipMidi` op is compiled and produces nothing yet.
+- **Wiring the two analyses to the model.** The native transient detector and loop-info parse
+  exist and are tested; `WarpMarkerManager` and the clip model still get both from Tracktion.
+  Swapping them over belongs with switching the engine on rather than with implementing it.
 - **The null-diff harness** ([#1896](https://github.com/Conceptual-Machines/magda-core/issues/1896)),
   which is what decides the engine is right rather than merely tested: render the same project
   through both engines and assert a near-null difference.

--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(magda_engine STATIC
     clip/ClipVoicePool.cpp
     clip/EventPlacement.cpp
     clip/FadeCurves.cpp
+    clip/WarpMap.cpp
     clip/ClipSnapshot.hpp
     clip/ClipSnapshotCompiler.hpp
     clip/ClipSnapshotDump.hpp
@@ -29,6 +30,7 @@ add_library(magda_engine STATIC
     clip/ClipVoicePool.hpp
     clip/EventPlacement.hpp
     clip/FadeCurves.hpp
+    clip/WarpMap.hpp
     plan/RenderPlan.cpp
     plan/PlanCompiler.cpp
     plan/PlanDiff.cpp
@@ -66,7 +68,11 @@ add_library(magda_engine STATIC
     transport/TransportState.hpp
     transport/TransportClock.hpp
     transport/ClickGenerator.hpp
+    analysis/TransientDetector.cpp
+    analysis/TransientDetector.hpp
     io/AudioFileReader.cpp
+    io/SourceLoopInfo.cpp
+    io/SourceLoopInfo.hpp
     io/PrefetchStream.cpp
     io/PrefetchThread.cpp
     io/SourceReaders.cpp
@@ -137,7 +143,8 @@ endforeach()
 # Engine. Quoted includes may only reach the model layer ("core/...") or the
 # engine's own headers.
 
-set(MAGDA_ENGINE_ALLOWED_QUOTED_PREFIXES "core/" "clip/" "plan/" "exec/" "transport/" "io/" "tap/")
+set(MAGDA_ENGINE_ALLOWED_QUOTED_PREFIXES
+    "core/" "clip/" "plan/" "exec/" "transport/" "io/" "tap/" "analysis/")
 
 file(GLOB_RECURSE MAGDA_ENGINE_SOURCES CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"

--- a/magda/engine/analysis/TransientDetector.cpp
+++ b/magda/engine/analysis/TransientDetector.cpp
@@ -144,7 +144,15 @@ std::vector<double> detectTransients(AudioFileReader& reader,
     // from. Placing the marker where the sound starts rather than where the
     // detector noticed is the difference between a warped beat landing on the
     // grid and landing just behind it.
-    const auto rewind = static_cast<int>(sampleRate * 0.0005);
+    //
+    // Rounded up, which is not a preference. The incumbent truncates after the
+    // subtraction (`int (i - sampleRate * 0.0005)`), and for a whole-numbered i
+    // that is the same as subtracting the rounded-up rewind: at 44100 its
+    // effective rewind is 23 samples, not the 22 that truncating the rewind on
+    // its own would give. Reproducing this detector exactly is the whole
+    // argument for having written it this way, and one sample is a marker that
+    // moved.
+    const auto rewind = static_cast<int>(std::ceil(sampleRate * 0.0005));
 
     int countdown = 0;
 

--- a/magda/engine/analysis/TransientDetector.cpp
+++ b/magda/engine/analysis/TransientDetector.cpp
@@ -1,0 +1,184 @@
+#include "analysis/TransientDetector.hpp"
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace magda::engine {
+
+namespace {
+
+/// The incumbent reads in chunks of this, and where a trigger's rewind lands is
+/// measured from the start of one. Matching it is what keeps a detected marker
+/// in the same place rather than half a millisecond from it.
+constexpr int kBlockSamples = 32768;
+
+/// A one-pole follower with separate attack and release, where 1 is instant and
+/// 0 never moves. The incumbent's, coefficient for coefficient.
+class EnvelopeFollower {
+  public:
+    void setCoefficients(float attack, float release) noexcept {
+        attack_ = attack;
+        release_ = release;
+    }
+
+    void process(float* samples, int numSamples) noexcept {
+        for (int i = 0; i < numSamples; ++i) {
+            const auto in = std::abs(samples[i]);
+
+            if (envelope_ < in)
+                envelope_ += attack_ * (in - envelope_);
+            else if (envelope_ > in)
+                envelope_ -= release_ * (envelope_ - in);
+
+            samples[i] = envelope_;
+        }
+    }
+
+  private:
+    float envelope_ = 0.0f;
+    float attack_ = 1.0f;
+    float release_ = 1.0f;
+};
+
+/// Sample-to-sample difference. What turns a smoothed envelope into something
+/// that peaks where the envelope was climbing fastest, which is the onset.
+class Differentiator {
+  public:
+    void process(float* samples, int numSamples) noexcept {
+        for (int i = 0; i < numSamples; ++i) {
+            const auto current = samples[i];
+            samples[i] = current - last_;
+            last_ = current;
+        }
+    }
+
+  private:
+    float last_ = 0.0f;
+};
+
+/// The file's own peak, which the threshold is relative to. A quiet recording
+/// and a loud one have the same transients, and a fixed threshold would find
+/// them only in the second.
+float peakOf(AudioFileReader& reader, juce::AudioBuffer<float>& block, std::int64_t totalSamples) {
+    float peak = 0.0f;
+
+    for (std::int64_t at = 0; at < totalSamples; at += kBlockSamples) {
+        const auto count =
+            static_cast<int>(std::min<std::int64_t>(kBlockSamples, totalSamples - at));
+
+        if (reader.read(block, 0, at, count) <= 0)
+            continue;
+
+        const auto range =
+            juce::FloatVectorOperations::findMinAndMax(block.getReadPointer(0), count);
+        peak = std::max(peak, std::max(std::abs(range.getStart()), std::abs(range.getEnd())));
+    }
+
+    return peak;
+}
+
+/// Thin @p transients until none are closer together than @p spacing.
+///
+/// Backwards, keeping the later of any pair, and repeated because one pass can
+/// leave a new pair adjacent where it removed what sat between them. The
+/// incumbent gives up after ten passes and so does this: what it is thinning is
+/// a detector's own retriggers, and a file that still has them after ten rounds
+/// has something the spacing rule was never going to fix.
+void thin(std::vector<double>& transients, double spacing) {
+    if (transients.size() < 2)
+        return;
+
+    for (int pass = 0; pass < 10; ++pass) {
+        const auto before = transients.size();
+        auto last = transients.back();
+
+        for (int i = static_cast<int>(transients.size()) - 2; i >= 0; --i) {
+            const auto at = transients[static_cast<std::size_t>(i)];
+
+            if (last - at < spacing)
+                transients.erase(transients.begin() + i);
+            else
+                last = at;
+        }
+
+        if (transients.size() == before)
+            return;
+    }
+}
+
+}  // namespace
+
+std::vector<double> detectTransients(AudioFileReader& reader,
+                                     const TransientDetectionSettings& settings) {
+    std::vector<double> transients;
+
+    const auto sampleRate = reader.sampleRate();
+    const auto totalSamples = reader.lengthInSamples();
+
+    if (!(sampleRate > 0.0) || totalSamples <= 0)
+        return transients;
+
+    // One channel, which is what the reader hands the file's first through and
+    // what the incumbent detects on. A transient is in every channel of a
+    // recording that has one.
+    juce::AudioBuffer<float> block(1, kBlockSamples);
+
+    const auto peak = peakOf(reader, block, totalSamples);
+    const auto scale = peak > 0.0f ? 1.0f / peak : 1.0f;
+
+    EnvelopeFollower followers[3];
+    for (auto& follower : followers)
+        follower.setCoefficients(1.0f, 0.002f);
+
+    Differentiator differentiator;
+
+    const auto threshold = juce::Decibels::decibelsToGain(
+        -10.0f - std::clamp(settings.sensitivity, 0.0f, 1.0f) * 30.0f);
+    const auto lockout = static_cast<int>(sampleRate * settings.retriggerSeconds);
+
+    // Half a millisecond, because what crosses the threshold is the differential
+    // of a smoothed envelope and that peaks a little after the attack it came
+    // from. Placing the marker where the sound starts rather than where the
+    // detector noticed is the difference between a warped beat landing on the
+    // grid and landing just behind it.
+    const auto rewind = static_cast<int>(sampleRate * 0.0005);
+
+    int countdown = 0;
+
+    for (std::int64_t at = 0; at < totalSamples; at += kBlockSamples) {
+        const auto count =
+            static_cast<int>(std::min<std::int64_t>(kBlockSamples, totalSamples - at));
+
+        reader.read(block, 0, at, count);
+
+        auto* samples = block.getWritePointer(0);
+        juce::FloatVectorOperations::multiply(samples, scale, count);
+
+        followers[0].process(samples, count);
+        followers[1].process(samples, count);
+        differentiator.process(samples, count);
+        followers[2].process(samples, count);
+
+        for (int i = 0; i < count; ++i) {
+            if (countdown > 0)
+                --countdown;
+
+            if (samples[i] > threshold) {
+                if (countdown == 0)
+                    transients.push_back(static_cast<double>(at + std::max(0, i - rewind)) /
+                                         sampleRate);
+
+                countdown = lockout;
+            }
+        }
+    }
+
+    thin(transients, settings.minimumSpacingSeconds);
+
+    return transients;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/analysis/TransientDetector.hpp
+++ b/magda/engine/analysis/TransientDetector.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <vector>
+
+#include "io/AudioFileReader.hpp"
+
+/**
+ * @file TransientDetector.hpp
+ * @brief Where a source's beats are, when the user has not said.
+ *
+ * Warp markers come from somewhere. A user places them, or `autoDetectBeats`
+ * puts them at the transients this finds, and the second is what a loop dropped
+ * onto a track gets before anyone has opened it. MAGDA gets this from Tracktion
+ * today (`WarpTimeManager::detectTransients`), which is why it is here: an
+ * analysis is a thing the engine does, not a thing it binds to.
+ *
+ * Not on the audio thread, and not incrementally: it reads a whole file and
+ * returns a vector. Two passes over it, because the detection is threshold
+ * based and the threshold is relative to the file's own peak, so the peak has to
+ * be known before the first sample is judged.
+ *
+ * The algorithm is the incumbent's, reproduced rather than improved. It is
+ * cheap and entirely in the time domain: a pair of envelope followers, a
+ * differentiator, another follower, and a threshold with a retrigger lockout.
+ * Improving on it is a separate argument from replacing it, and a detector that
+ * found different transients would move every auto-detected marker in every
+ * project that already has one.
+ */
+
+namespace magda::engine {
+
+struct TransientDetectionSettings {
+    /// 0 finds few, 1 finds many. The model's `AudioEvent::beatSensitivity`,
+    /// and it maps to a threshold of `-10 - sensitivity * 30` dB, which is the
+    /// incumbent's mapping.
+    float sensitivity = 0.5f;
+
+    /// Transients closer together than this are thinned until none are. The
+    /// incumbent's 100 ms, and the reason a detected downbeat does not arrive
+    /// as three markers a millisecond apart.
+    double minimumSpacingSeconds = 0.1;
+
+    /// How long after a trigger the detector will not fire again. The
+    /// incumbent's 50 ms.
+    double retriggerSeconds = 0.05;
+
+    bool operator==(const TransientDetectionSettings&) const = default;
+};
+
+/**
+ * @brief Transient positions in @p reader, in seconds from its start.
+ *
+ * Ascending, and never closer together than
+ * @ref TransientDetectionSettings::minimumSpacingSeconds.
+ *
+ * Reads @p reader from the beginning twice and leaves it wherever the second
+ * pass ended. Empty for a file with no samples, no rate, or nothing above the
+ * threshold in it -- a silent file has no transients, and that is an answer
+ * rather than a failure.
+ */
+std::vector<double> detectTransients(AudioFileReader& reader,
+                                     const TransientDetectionSettings& settings);
+
+}  // namespace magda::engine

--- a/magda/engine/clip/ClipSnapshot.hpp
+++ b/magda/engine/clip/ClipSnapshot.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "clip/WarpMap.hpp"
 #include "core/ClipInfo.hpp"
 #include "core/TypeIds.hpp"
 
@@ -118,8 +119,12 @@ struct AudioEventPlayback {
     /// has already forced a stretcher on (AudioEvent::isAnalogPitchActive).
     bool analogPitch = false;
 
-    bool warpEnabled = false;
-    std::vector<WarpMarker> warpMarkers;
+    /// Compiled and inverted, never the model's marker list (WarpMap.hpp).
+    /// Empty is identity, which is both "warp is off" and "warp is on and there
+    /// are no markers": the two describe the same playback and nothing
+    /// downstream has to tell them apart. Already mirrored where the event is
+    /// reversed, so the audio thread does one lookup whichever way it plays.
+    WarpMap warp;
 
     bool autoPitch = false;
     int autoPitchMode = 0;

--- a/magda/engine/clip/ClipSnapshot.hpp
+++ b/magda/engine/clip/ClipSnapshot.hpp
@@ -119,11 +119,26 @@ struct AudioEventPlayback {
     /// has already forced a stretcher on (AudioEvent::isAnalogPitchActive).
     bool analogPitch = false;
 
+    /// Whether the event warps at all, which is not the same question as
+    /// whether @ref warp bends anything.
+    ///
+    /// Warp with no markers is identity as a map and is still warp as an
+    /// interpretation: the model puts such an event in the beat domain at its
+    /// own bpm and forces a stretcher on it
+    /// (AudioEvent::sourceInstantToTimelineBeats,
+    /// AudioEvent::getEffectiveTimeStretchMode). Reading that off the map being
+    /// empty would play it on the seconds face instead, which is a clip that
+    /// stops following the tempo the moment its last marker is deleted.
+    bool warpEnabled = false;
+
     /// Compiled and inverted, never the model's marker list (WarpMap.hpp).
-    /// Empty is identity, which is both "warp is off" and "warp is on and there
-    /// are no markers": the two describe the same playback and nothing
-    /// downstream has to tell them apart. Already mirrored where the event is
-    /// reversed, so the audio thread does one lookup whichever way it plays.
+    /// Empty is the identity lookup, which is what an event with no markers and
+    /// one with none left after the compile both get.
+    ///
+    /// In the model's own coordinates, forwards. Reverse is not baked in: it is
+    /// a coordinate change that EventPlacement.hpp resolves per lookup, because
+    /// mirroring the map would need the length of the region the event reads
+    /// and that is itself an answer from the map.
     WarpMap warp;
 
     bool autoPitch = false;

--- a/magda/engine/clip/ClipSnapshotCompiler.cpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.cpp
@@ -231,11 +231,19 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
                 playback.speedRatio = event.speedRatio;
                 playback.timeStretchMode = event.getEffectiveTimeStretchMode();
                 playback.analogPitch = event.isAnalogPitchActive();
-                // Inverted, mirrored where the event is reversed, and known to
-                // be invertible before anything plays it (WarpMap.hpp). A
-                // marker that cannot be part of a monotonic map is dropped
-                // here; saying how many is the difference between a clip whose
-                // timing is not what its editor shows and one that says so.
+                // Inverted, and known to be invertible before anything plays it
+                // (WarpMap.hpp). Nothing here mirrors it for a reversed event:
+                // reverse stays a read-time coordinate change in
+                // EventPlacement.hpp. A marker that cannot be part of a
+                // monotonic map is dropped here; saying how many is the
+                // difference between a clip whose timing is not what its editor
+                // shows and one that says so.
+                //
+                // The flag travels beside the map because an event that warps
+                // with no markers is still a warped event: identity as a map,
+                // and on the beat face with a stretcher as an interpretation.
+                playback.warpEnabled = event.warpEnabled;
+
                 if (event.warpEnabled) {
                     auto warp = compileWarpMap(event.warpMarkers);
                     playback.warp = std::move(warp.map);

--- a/magda/engine/clip/ClipSnapshotCompiler.cpp
+++ b/magda/engine/clip/ClipSnapshotCompiler.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <unordered_map>
 
+#include "clip/ClipStretcher.hpp"
 #include "core/ClipFades.hpp"
 #include "core/ClipOcclusion.hpp"
 
@@ -230,8 +231,32 @@ ClipSnapshot compileClipSnapshot(const std::vector<ClipLane>& lanes,
                 playback.speedRatio = event.speedRatio;
                 playback.timeStretchMode = event.getEffectiveTimeStretchMode();
                 playback.analogPitch = event.isAnalogPitchActive();
-                playback.warpEnabled = event.warpEnabled;
-                playback.warpMarkers = event.warpMarkers;
+                // Inverted, mirrored where the event is reversed, and known to
+                // be invertible before anything plays it (WarpMap.hpp). A
+                // marker that cannot be part of a monotonic map is dropped
+                // here; saying how many is the difference between a clip whose
+                // timing is not what its editor shows and one that says so.
+                if (event.warpEnabled) {
+                    auto warp = compileWarpMap(event.warpMarkers);
+                    playback.warp = std::move(warp.map);
+
+                    if (warp.droppedMarkers > 0)
+                        snapshot.diagnostics.push_back(
+                            label + "event " + std::to_string(event.id) + " has " +
+                            std::to_string(warp.droppedMarkers) +
+                            " warp marker(s) that do not run forwards, so they are dropped and "
+                            "that stretch of the clip plays at its neighbours' rate");
+
+                    // The steepest segment is what the clip actually asks to be
+                    // played at somewhere inside it, and a stretcher will not go
+                    // there (ClipStretcher.hpp). The average the pre-roll is
+                    // sized against would not notice.
+                    if (playback.warp.maxSourcePerWarp() > kMaxStretchRate)
+                        snapshot.diagnostics.push_back(
+                            label + "event " + std::to_string(event.id) +
+                            " has warp markers asking for a rate past what a stretcher will run "
+                            "at, so that stretch of it plays at the limit instead");
+                }
 
                 playback.autoPitch = event.autoPitch;
                 playback.autoPitchMode = event.autoPitchMode;

--- a/magda/engine/clip/ClipSnapshotDump.cpp
+++ b/magda/engine/clip/ClipSnapshotDump.cpp
@@ -65,10 +65,11 @@ void dumpEvent(std::ostringstream& out, const AudioEventPlayback& event) {
 
     if (event.autoTempo)
         out << " auto-tempo";
-    // Points rather than markers: what the clip plays is the compiled map, and
-    // a dump that echoed the model's count would hide exactly the case the
-    // compile diagnoses, where the two differ.
-    if (!event.warp.empty())
+    // Off the flag, because a warped event with nothing left in its map is
+    // still warped and still plays on the beat face. Points rather than
+    // markers: what the clip plays is the compiled map, and a dump echoing the
+    // model's count would hide exactly the case the compile diagnoses.
+    if (event.warpEnabled)
         out << " warp=" << event.warp.points.size()
             << " warp-max=" << fixed(event.warp.maxSourcePerWarp(), 3);
     if (event.analogPitch)

--- a/magda/engine/clip/ClipSnapshotDump.cpp
+++ b/magda/engine/clip/ClipSnapshotDump.cpp
@@ -65,8 +65,12 @@ void dumpEvent(std::ostringstream& out, const AudioEventPlayback& event) {
 
     if (event.autoTempo)
         out << " auto-tempo";
-    if (event.warpEnabled)
-        out << " warp=" << event.warpMarkers.size();
+    // Points rather than markers: what the clip plays is the compiled map, and
+    // a dump that echoed the model's count would hide exactly the case the
+    // compile diagnoses, where the two differ.
+    if (!event.warp.empty())
+        out << " warp=" << event.warp.points.size()
+            << " warp-max=" << fixed(event.warp.maxSourcePerWarp(), 3);
     if (event.analogPitch)
         out << " analog-pitch";
     if (event.autoPitch)

--- a/magda/engine/clip/EventPlacement.cpp
+++ b/magda/engine/clip/EventPlacement.cpp
@@ -22,16 +22,154 @@ std::int64_t samplesIn(double seconds, double rate) {
     return static_cast<std::int64_t>(std::llround(seconds * rate));
 }
 
-/// Source samples the event reads, which is the stretch a mirrored read turns
-/// about. One per output sample, at unity speed: what makes this a different
-/// number is the stretcher, and it arrives with one (#2037).
+/// Whether the event's position is derived from the beat face rather than the
+/// seconds one. Auto tempo is the obvious case and warp is the other: the model
+/// hands both of them source-beat processing at the event's own interpretation
+/// (AudioEvent::sourceInstantToTimelineBeats), so playback has to read the same
+/// face the model wrote.
+bool usesBeatFace(const AudioEventPlayback& event) {
+    return (event.autoTempo || !event.warp.empty()) && event.interpBpm > 0.0;
+}
+
+/// The constant ratio, clamped the way the rate is, so that a project holding a
+/// ratio no stretcher will run at still plays something rather than reading a
+/// thousand times faster than the disk can answer.
+double constantRate(const AudioEventPlayback& event) {
+    return std::clamp(event.speedRatio > 0.0 ? event.speedRatio : 1.0, kMinStretchRate,
+                      kMaxStretchRate);
+}
+
+/**
+ * @brief The event's whole extent, in the domain warp markers measure.
+ *
+ * Which is seconds of the file's own material before warp bends them: the map's
+ * warp side. An unwarped event has no bending, so this is simply the material
+ * it reads, and the two uses collapse into one number.
+ *
+ * Exact rather than clamped-average, because the reversed anchor is derived
+ * from it: an event whose far end is off by a stretch factor starts playing
+ * somewhere it was never placed.
+ */
+double warpExtentSecondsOf(const AudioEventPlayback& event) {
+    if (usesBeatFace(event))
+        return event.span.lengthBeats() * 60.0 / event.interpBpm;
+
+    return event.span.lengthSeconds() * constantRate(event);
+}
+
+/// Source seconds the event reads, which is the stretch a mirrored read turns
+/// about. Its warped extent through the map, because what the file gives up to
+/// fill a warped event is not the extent itself but the map's image of it.
+double regionSecondsOf(const AudioEventPlayback& event, double sourceRate) {
+    const auto extent = warpExtentSecondsOf(event);
+
+    if (event.warp.empty() || !(sourceRate > 0.0))
+        return extent;
+
+    const auto anchorSeconds = static_cast<double>(event.anchorSamples) / sourceRate;
+    const auto anchorWarp = event.warp.sourceToWarpSeconds(anchorSeconds);
+
+    return event.warp.sourceSecondsAt(anchorWarp + extent) - anchorSeconds;
+}
+
 std::int64_t regionOf(const AudioEventPlayback& event, double sourceRate) {
-    return samplesIn(event.span.lengthSeconds(), sourceRate);
+    return samplesIn(regionSecondsOf(event, sourceRate), sourceRate);
 }
 
 std::int64_t floorMod(std::int64_t value, std::int64_t modulus) {
     const auto remainder = value % modulus;
     return remainder < 0 ? remainder + modulus : remainder;
+}
+
+double floorMod(double value, double modulus) {
+    const auto remainder = std::fmod(value, modulus);
+    return remainder < 0.0 ? remainder + modulus : remainder;
+}
+
+/**
+ * @brief A warped event's loop region, measured in warp time.
+ *
+ * Warp is the one thing that cannot let the reading chain do its own tiling.
+ * Everywhere else a loop is folded below the stream, so a position climbs
+ * forever and a wrap is not a position change at all (io/SourceReaders.hpp);
+ * that works because the reading advances linearly, and under warp it does not.
+ * A second pass through a warped loop has to bend the same way the first did,
+ * and folding a position that has already been through the map would put the
+ * fold in the wrong domain: the map would go on extending at slope 1 past the
+ * loop's end and every pass after the first would play straight.
+ *
+ * So a warped loop folds here, in warp time, and @ref sourceReadFor leaves the
+ * tiling below switched off. The reading position then saws back at each wrap
+ * instead of climbing, which the stream reads as a seek -- one per pass, which
+ * is what a warped loop costs and is bounded.
+ *
+ * Inactive when the event does not loop, does not warp, or has no region.
+ */
+struct WarpLoop {
+    bool active = false;
+    double startWarp = 0.0;
+    double lengthWarp = 0.0;
+};
+
+WarpLoop warpLoopOf(const AudioEventPlayback& event, double sourceRate) {
+    WarpLoop loop;
+
+    if (event.warp.empty() || !event.loopEnabled || !(sourceRate > 0.0))
+        return loop;
+
+    // The model's rule for a loop with no length of its own: the event's own
+    // stretch of the file (AudioEvent::loopLengthSamples).
+    const auto length =
+        event.loopLengthSamples > 0 ? event.loopLengthSamples : regionOf(event, sourceRate);
+    if (length <= 0)
+        return loop;
+
+    const auto startSeconds = static_cast<double>(event.loopStartSamples) / sourceRate;
+    const auto endSeconds = static_cast<double>(event.loopStartSamples + length) / sourceRate;
+
+    loop.startWarp = event.warp.sourceToWarpSeconds(startSeconds);
+    loop.lengthWarp = event.warp.sourceToWarpSeconds(endSeconds) - loop.startWarp;
+    loop.active = loop.lengthWarp > 0.0;
+
+    return loop;
+}
+
+/**
+ * @brief Where a warped event is in its reading, @p elapsedWarp into itself.
+ *
+ * In fractional device samples, and the one place warp is resolved: both the
+ * anchor the pool cues with and the position a block reads at come from here,
+ * with different elapsed values, so the two cannot disagree about a map.
+ *
+ * Reverse walks the map backwards from the far end of what the event reads.
+ * That is what playing the material backwards means with the bending left in
+ * place: each stretch of file keeps the rate its markers gave it and is heard
+ * in the opposite order. The answer is then mirrored into the reading's own
+ * coordinates, exactly as an unwarped reversed event's anchor is.
+ */
+double warpedReadingSample(const AudioEventPlayback& event, double elapsedWarp, double sourceRate,
+                           double deviceSampleRate) {
+    const auto anchorSeconds = static_cast<double>(event.anchorSamples) / sourceRate;
+    const auto anchorWarp = event.warp.sourceToWarpSeconds(anchorSeconds);
+
+    auto at = event.reversed ? anchorWarp + warpExtentSecondsOf(event) - elapsedWarp
+                             : anchorWarp + elapsedWarp;
+
+    if (const auto loop = warpLoopOf(event, sourceRate); loop.active)
+        at = loop.startWarp + floorMod(at - loop.startWarp, loop.lengthWarp);
+
+    const auto source = event.warp.sourceSecondsAt(at) * sourceRate;
+
+    // Into the mirrored file's coordinates, which is what the reading delivers
+    // for a reversed event. No loop variant: the fold above has already put the
+    // position inside the region, so mirroring the file mirrors the region with
+    // it.
+    const auto inReading =
+        event.reversed
+            ? static_cast<double>(samplesIn(event.sourceDurationSeconds, sourceRate)) - 1.0 - source
+            : source;
+
+    return inReading * (sourceRate > 0.0 ? deviceSampleRate / sourceRate : 1.0);
 }
 
 }  // namespace
@@ -45,7 +183,9 @@ SourceRead sourceReadFor(const AudioEventPlayback& event, double deviceSampleRat
     how.deviceSampleRate = deviceSampleRate;
     how.reversed = event.reversed;
 
-    if (event.loopEnabled) {
+    // Not for a warped event: its loop folds in warp time, above the map, and
+    // tiling here as well would fold it twice (WarpLoop).
+    if (event.loopEnabled && event.warp.empty()) {
         // A loop with no length of its own is the event's own stretch of the
         // file. The model's rule for the field rather than a default chosen
         // here (AudioEvent::loopLengthSamples).
@@ -71,6 +211,15 @@ SourceRead sourceReadFor(const AudioEventPlayback& event, double deviceSampleRat
 ClipPlacement placementFor(const AudioEventPlayback& event, double deviceSampleRate) {
     const auto sourceRate = sourceRateOf(event, deviceSampleRate);
     const auto how = sourceReadFor(event, deviceSampleRate);
+
+    // A warped event's start is its map evaluated at no elapsed, which is the
+    // same function a block reads through. Derived rather than mirrored here,
+    // because the map already answers reverse and looping and a second
+    // derivation of either could disagree with it.
+    if (!event.warp.empty())
+        return ClipPlacement{event.span.startSeconds, event.span.endSeconds,
+                             static_cast<std::int64_t>(std::llround(
+                                 warpedReadingSample(event, 0.0, sourceRate, deviceSampleRate)))};
 
     auto anchor = event.anchorSamples;
 
@@ -105,7 +254,7 @@ ClipPlacement placementFor(const AudioEventPlayback& event, double deviceSampleR
 double readingRateOf(const AudioEventPlayback& event) {
     auto rate = event.speedRatio;
 
-    if (event.autoTempo && event.interpBpm > 0.0) {
+    if (usesBeatFace(event)) {
         // The event's own average, taken off the two faces of its span rather
         // than off a tempo map: how many beats it covers and how long they last
         // are both already resolved here, and their ratio is the tempo it sits
@@ -116,6 +265,14 @@ double readingRateOf(const AudioEventPlayback& event) {
 
         rate = beats > 0.0 && seconds > 0.0 ? (beats * 60.0 / seconds) / event.interpBpm : 1.0;
     }
+
+    // The steepest the map runs anywhere, not its average. A warped event has
+    // no single rate -- that is what warp is -- and what a stretcher is sized
+    // and primed against has to cover the fastest stretch of it rather than the
+    // one it spends the most time at. The clamp below is what keeps that
+    // bounded.
+    if (!event.warp.empty())
+        rate *= event.warp.maxSourcePerWarp();
 
     return std::clamp(rate > 0.0 ? rate : 1.0, kMinStretchRate, kMaxStretchRate);
 }
@@ -152,15 +309,15 @@ double ramped(const AudioClipPlayback& clip, double position, double start, doub
 
 double readingPositionAt(const AudioClipPlayback& clip, const AudioEventPlayback& event,
                          double seconds, double beat, double deviceSampleRate) {
-    const auto placement = placementFor(event, deviceSampleRate);
-    const auto anchor = static_cast<double>(placement.sourceOffsetSamples);
-
     // Seconds of the file's own material, which is what the reading is counted
     // in: it was converted to the device's rate below the stream, so a second of
     // it is deviceSampleRate samples whatever the file was recorded at.
+    //
+    // Under warp this is what the markers measure rather than what is read: the
+    // map turns the one into the other, and it is the only thing that can.
     double elapsed = 0.0;
 
-    if (event.autoTempo && event.interpBpm > 0.0) {
+    if (usesBeatFace(event)) {
         const auto at = ramped(clip, beat, clip.span.startBeat, clip.span.endBeat, clip.fadeInBeats,
                                clip.fadeOutBeats);
 
@@ -169,16 +326,16 @@ double readingPositionAt(const AudioClipPlayback& clip, const AudioEventPlayback
         const auto at = ramped(clip, seconds, clip.span.startSeconds, clip.span.endSeconds,
                                clip.fadeInSeconds, clip.fadeOutSeconds);
 
-        // Clamped the way the rate is, so that a project holding a ratio no
-        // stretcher will run at still plays something rather than reading a
-        // thousand times faster than the disk can answer.
-        const auto rate = std::clamp(event.speedRatio > 0.0 ? event.speedRatio : 1.0,
-                                     kMinStretchRate, kMaxStretchRate);
-
-        elapsed = (at - event.span.startSeconds) * rate;
+        elapsed = (at - event.span.startSeconds) * constantRate(event);
     }
 
-    return anchor + elapsed * deviceSampleRate;
+    if (!event.warp.empty())
+        return warpedReadingSample(event, elapsed, sourceRateOf(event, deviceSampleRate),
+                                   deviceSampleRate);
+
+    const auto placement = placementFor(event, deviceSampleRate);
+
+    return static_cast<double>(placement.sourceOffsetSamples) + elapsed * deviceSampleRate;
 }
 
 StretchSetup stretchSetupFor(const AudioClipPlayback& clip, const AudioEventPlayback& event,
@@ -197,7 +354,10 @@ StretchSetup stretchSetupFor(const AudioClipPlayback& clip, const AudioEventPlay
     setup.sampleRate = context.sampleRate;
     setup.maxBlockSamples = context.maxBlockSize;
     setup.nominalRate = readingRateOf(event);
-    setup.followsTempo = event.autoTempo && event.interpBpm > 0.0;
+    // Warp counts as following as much as auto tempo does. The flag means the
+    // rate moves inside the event, so the nominal above is an approximation and
+    // a clip averaging unity is still stretching in both directions around it.
+    setup.followsTempo = usesBeatFace(event) || !event.warp.empty();
     setup.speedRamp = (clip.fadeInBehaviour == 1 && clip.fadeInSeconds > 0.0) ||
                       (clip.fadeOutBehaviour == 1 && clip.fadeOutSeconds > 0.0);
 

--- a/magda/engine/clip/EventPlacement.cpp
+++ b/magda/engine/clip/EventPlacement.cpp
@@ -27,8 +27,13 @@ std::int64_t samplesIn(double seconds, double rate) {
 /// hands both of them source-beat processing at the event's own interpretation
 /// (AudioEvent::sourceInstantToTimelineBeats), so playback has to read the same
 /// face the model wrote.
+///
+/// Off the flag rather than off the map having points in it. A warped event
+/// with no markers bends nothing and is still interpreted at its own bpm, so
+/// reading this off the map would drop such a clip onto the seconds face and
+/// stop it following the tempo the moment its last marker was deleted.
 bool usesBeatFace(const AudioEventPlayback& event) {
-    return (event.autoTempo || !event.warp.empty()) && event.interpBpm > 0.0;
+    return (event.autoTempo || event.warpEnabled) && event.interpBpm > 0.0;
 }
 
 /// The constant ratio, clamped the way the rate is, so that a project holding a
@@ -357,7 +362,7 @@ StretchSetup stretchSetupFor(const AudioClipPlayback& clip, const AudioEventPlay
     // Warp counts as following as much as auto tempo does. The flag means the
     // rate moves inside the event, so the nominal above is an approximation and
     // a clip averaging unity is still stretching in both directions around it.
-    setup.followsTempo = usesBeatFace(event) || !event.warp.empty();
+    setup.followsTempo = usesBeatFace(event) || event.warpEnabled;
     setup.speedRamp = (clip.fadeInBehaviour == 1 && clip.fadeInSeconds > 0.0) ||
                       (clip.fadeOutBehaviour == 1 && clip.fadeOutSeconds > 0.0);
 

--- a/magda/engine/clip/WarpMap.cpp
+++ b/magda/engine/clip/WarpMap.cpp
@@ -98,27 +98,23 @@ WarpCompileResult compileWarpMap(const std::vector<WarpMarker>& markers) {
     // function of. Storage order is not guaranteed either way
     // (AudioEvent::warpedSourceSeconds says so), so this is a sort rather than
     // a check.
+    //
+    // Ties on the warp side DESCENDING, which is the whole trick below. Two
+    // markers on one instant of the file cannot both be kept -- the source side
+    // has to increase strictly too, or a segment has no span and an infinite
+    // rate -- and ordering such a pair backwards is what makes a plain
+    // increasing subsequence unable to take both of them. So the second
+    // dimension is enforced by the sort rather than by a pass of its own, and
+    // the sort is fully determined: nothing here depends on what order the
+    // model happened to store two coincident markers in.
     std::sort(sorted.begin(), sorted.end(), [](const WarpMap::Point& a, const WarpMap::Point& b) {
-        return a.sourceSeconds < b.sourceSeconds;
+        if (a.sourceSeconds != b.sourceSeconds)
+            return a.sourceSeconds < b.sourceSeconds;
+
+        return a.warpSeconds > b.warpSeconds;
     });
 
-    // Coincident on the source side first. Two markers on one instant of the
-    // file are a segment with no span, which is an infinite rate; the earlier
-    // one is kept so that which survives does not depend on the order they were
-    // stored in.
-    std::vector<WarpMap::Point> distinct;
-    distinct.reserve(sorted.size());
-
-    for (const auto& point : sorted) {
-        if (!distinct.empty() && point.sourceSeconds <= distinct.back().sourceSeconds) {
-            ++result.droppedMarkers;
-            continue;
-        }
-
-        distinct.push_back(point);
-    }
-
-    // Then the largest set of them that runs forwards on the warp side too.
+    // The largest set of them that runs forwards on the warp side.
     //
     // Largest, rather than whatever a single forward pass happens to keep. A
     // greedy pass anchors on whatever it saw first, so one marker dragged far
@@ -128,17 +124,22 @@ WarpCompileResult compileWarpMap(const std::vector<WarpMarker>& markers) {
     // offending marker costs should be itself, and that is a longest increasing
     // subsequence.
     //
-    // Deterministic: ties resolve towards the subsequence with the smallest
-    // tail, so two compiles of one marker list keep the same markers.
+    // Over everything rather than over a deduplicated list, and that is not
+    // tidiness. Collapsing coincident markers first means guessing which of a
+    // pair to keep before knowing what either can chain to, and neither guess
+    // is safe: for markers at (0,5), (1,50), (1,2), (2,60), keeping the smaller
+    // warp strands both neighbours and yields two points where keeping the
+    // larger yields three. The descending tie above lets the subsequence choose
+    // for itself, and what it chooses is optimal.
     constexpr auto kNone = std::numeric_limits<std::size_t>::max();
 
     std::vector<std::size_t> tails;  // tails[k]: index ending the best run of length k+1
-    std::vector<std::size_t> previous(distinct.size(), kNone);
+    std::vector<std::size_t> previous(sorted.size(), kNone);
 
-    for (std::size_t i = 0; i < distinct.size(); ++i) {
-        const auto at = std::lower_bound(tails.begin(), tails.end(), distinct[i].warpSeconds,
+    for (std::size_t i = 0; i < sorted.size(); ++i) {
+        const auto at = std::lower_bound(tails.begin(), tails.end(), sorted[i].warpSeconds,
                                          [&](std::size_t candidate, double value) {
-                                             return distinct[candidate].warpSeconds < value;
+                                             return sorted[candidate].warpSeconds < value;
                                          });
 
         const auto length = static_cast<std::size_t>(at - tails.begin());
@@ -157,9 +158,9 @@ WarpCompileResult compileWarpMap(const std::vector<WarpMarker>& markers) {
 
     for (auto index = tails.empty() ? kNone : tails.back(), slot = tails.size(); index != kNone;
          index = previous[index])
-        points[--slot] = distinct[index];
+        points[--slot] = sorted[index];
 
-    result.droppedMarkers += static_cast<int>(distinct.size() - points.size());
+    result.droppedMarkers += static_cast<int>(sorted.size() - points.size());
 
     return result;
 }

--- a/magda/engine/clip/WarpMap.cpp
+++ b/magda/engine/clip/WarpMap.cpp
@@ -1,0 +1,124 @@
+#include "clip/WarpMap.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace magda::engine {
+
+namespace {
+
+/// Interpolate between two points, on whichever side @p from names.
+///
+/// One function for both directions because the two are the same arithmetic
+/// over a pair that is sorted in both coordinates, and writing it twice is how
+/// the forward and the inverse come to disagree by a rounding.
+double between(double value, double fromLow, double fromHigh, double toLow, double toHigh) {
+    const auto span = fromHigh - fromLow;
+    if (!(span > 0.0))
+        return toLow;
+
+    return toLow + ((value - fromLow) / span) * (toHigh - toLow);
+}
+
+}  // namespace
+
+double WarpMap::sourceSecondsAt(double warpSeconds) const noexcept {
+    if (points.empty())
+        return warpSeconds;
+
+    const auto& first = points.front();
+    if (warpSeconds <= first.warpSeconds)
+        return first.sourceSeconds + (warpSeconds - first.warpSeconds);
+
+    const auto& last = points.back();
+    if (warpSeconds >= last.warpSeconds)
+        return last.sourceSeconds + (warpSeconds - last.warpSeconds);
+
+    const auto above = std::upper_bound(
+        points.begin(), points.end(), warpSeconds,
+        [](double value, const Point& point) { return value < point.warpSeconds; });
+    const auto below = above - 1;
+
+    return between(warpSeconds, below->warpSeconds, above->warpSeconds, below->sourceSeconds,
+                   above->sourceSeconds);
+}
+
+double WarpMap::sourceToWarpSeconds(double sourceSeconds) const noexcept {
+    if (points.empty())
+        return sourceSeconds;
+
+    const auto& first = points.front();
+    if (sourceSeconds <= first.sourceSeconds)
+        return first.warpSeconds + (sourceSeconds - first.sourceSeconds);
+
+    const auto& last = points.back();
+    if (sourceSeconds >= last.sourceSeconds)
+        return last.warpSeconds + (sourceSeconds - last.sourceSeconds);
+
+    const auto above = std::upper_bound(
+        points.begin(), points.end(), sourceSeconds,
+        [](double value, const Point& point) { return value < point.sourceSeconds; });
+    const auto below = above - 1;
+
+    return between(sourceSeconds, below->sourceSeconds, above->sourceSeconds, below->warpSeconds,
+                   above->warpSeconds);
+}
+
+double WarpMap::maxSourcePerWarp() const noexcept {
+    // One, not zero: outside the markers the map runs at slope 1, and every map
+    // has an outside.
+    double steepest = 1.0;
+
+    for (std::size_t i = 1; i < points.size(); ++i) {
+        const auto sourceSpan = points[i].sourceSeconds - points[i - 1].sourceSeconds;
+        const auto warpSpan = points[i].warpSeconds - points[i - 1].warpSeconds;
+
+        if (warpSpan > 0.0)
+            steepest = std::max(steepest, sourceSpan / warpSpan);
+    }
+
+    return steepest;
+}
+
+WarpCompileResult compileWarpMap(const std::vector<WarpMarker>& markers) {
+    WarpCompileResult result;
+
+    std::vector<WarpMap::Point> sorted;
+    sorted.reserve(markers.size());
+
+    for (const auto& marker : markers) {
+        if (std::isfinite(marker.sourceTime) && std::isfinite(marker.warpTime))
+            sorted.push_back({marker.sourceTime, marker.warpTime});
+        else
+            ++result.droppedMarkers;
+    }
+
+    // By source time, because that is the side the model's own map is a
+    // function of. Storage order is not guaranteed either way
+    // (AudioEvent::warpedSourceSeconds says so), so this is a sort rather than
+    // a check.
+    std::sort(sorted.begin(), sorted.end(), [](const WarpMap::Point& a, const WarpMap::Point& b) {
+        return a.sourceSeconds < b.sourceSeconds;
+    });
+
+    auto& points = result.map.points;
+    points.reserve(sorted.size());
+
+    for (const auto& point : sorted) {
+        // Strictly increasing on both sides. Equal on either is a segment with
+        // no span, which is an infinite rate one way and a zero-divide the
+        // other; decreasing is a map with no inverse. Both are the user having
+        // dragged a marker past its neighbour, and both cost that marker.
+        if (!points.empty() && (point.sourceSeconds <= points.back().sourceSeconds ||
+                                point.warpSeconds <= points.back().warpSeconds)) {
+            ++result.droppedMarkers;
+            continue;
+        }
+
+        points.push_back(point);
+    }
+
+    return result;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/clip/WarpMap.cpp
+++ b/magda/engine/clip/WarpMap.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 namespace magda::engine {
 
@@ -101,22 +102,64 @@ WarpCompileResult compileWarpMap(const std::vector<WarpMarker>& markers) {
         return a.sourceSeconds < b.sourceSeconds;
     });
 
-    auto& points = result.map.points;
-    points.reserve(sorted.size());
+    // Coincident on the source side first. Two markers on one instant of the
+    // file are a segment with no span, which is an infinite rate; the earlier
+    // one is kept so that which survives does not depend on the order they were
+    // stored in.
+    std::vector<WarpMap::Point> distinct;
+    distinct.reserve(sorted.size());
 
     for (const auto& point : sorted) {
-        // Strictly increasing on both sides. Equal on either is a segment with
-        // no span, which is an infinite rate one way and a zero-divide the
-        // other; decreasing is a map with no inverse. Both are the user having
-        // dragged a marker past its neighbour, and both cost that marker.
-        if (!points.empty() && (point.sourceSeconds <= points.back().sourceSeconds ||
-                                point.warpSeconds <= points.back().warpSeconds)) {
+        if (!distinct.empty() && point.sourceSeconds <= distinct.back().sourceSeconds) {
             ++result.droppedMarkers;
             continue;
         }
 
-        points.push_back(point);
+        distinct.push_back(point);
     }
+
+    // Then the largest set of them that runs forwards on the warp side too.
+    //
+    // Largest, rather than whatever a single forward pass happens to keep. A
+    // greedy pass anchors on whatever it saw first, so one marker dragged far
+    // ahead of its neighbours survives and every marker it cleared is dropped
+    // behind it: markers at warp 0, 100, 1, 2, 3 would cost four of the five
+    // when dropping the one at 100 leaves a perfectly good map. What an
+    // offending marker costs should be itself, and that is a longest increasing
+    // subsequence.
+    //
+    // Deterministic: ties resolve towards the subsequence with the smallest
+    // tail, so two compiles of one marker list keep the same markers.
+    constexpr auto kNone = std::numeric_limits<std::size_t>::max();
+
+    std::vector<std::size_t> tails;  // tails[k]: index ending the best run of length k+1
+    std::vector<std::size_t> previous(distinct.size(), kNone);
+
+    for (std::size_t i = 0; i < distinct.size(); ++i) {
+        const auto at = std::lower_bound(tails.begin(), tails.end(), distinct[i].warpSeconds,
+                                         [&](std::size_t candidate, double value) {
+                                             return distinct[candidate].warpSeconds < value;
+                                         });
+
+        const auto length = static_cast<std::size_t>(at - tails.begin());
+
+        if (length > 0)
+            previous[i] = tails[length - 1];
+
+        if (at == tails.end())
+            tails.push_back(i);
+        else
+            *at = i;
+    }
+
+    auto& points = result.map.points;
+    points.resize(tails.size());
+
+    for (auto index = tails.empty() ? kNone : tails.back(), slot = tails.size(); index != kNone;
+         index = previous[index])
+        points[--slot] = distinct[index];
+
+    result.droppedMarkers += static_cast<int>(distinct.size() - points.size());
 
     return result;
 }

--- a/magda/engine/clip/WarpMap.hpp
+++ b/magda/engine/clip/WarpMap.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <vector>
+
+#include "core/ClipInfo.hpp"
+
+/**
+ * @file WarpMap.hpp
+ * @brief A clip's own musical time, compiled into something playable.
+ *
+ * The model holds warp as `(sourceTime, warpTime)` pairs in source seconds,
+ * piecewise linear between them and carrying on at slope 1 outside the marker
+ * range (`AudioEvent::warpedSourceSeconds`). That direction answers "where does
+ * this bit of file land musically", which is what the editors and the loop
+ * region's beat views ask.
+ *
+ * Playback asks the other one. At an instant of the timeline the material has
+ * reached some warp time, and what a reader needs is the source second sitting
+ * there. So the map is inverted here, once, at compile time, and what reaches
+ * the audio thread is a vector that is sorted in both coordinates and known to
+ * be invertible.
+ *
+ * Known, rather than assumed. A marker list that doubles back has no inverse at
+ * all, and the two places that could discover it are a compile that can say so
+ * and a callback that would divide by a negative span. It is discovered here:
+ * @ref compileWarpMap drops what it cannot invert and says how much it dropped.
+ *
+ * The map stays in the model's own coordinates -- the file as it sits on disk,
+ * forwards -- and reverse is not baked into it. Reverse is a coordinate change
+ * that EventPlacement.hpp already owns, and a reversed event walks this map
+ * backwards from the far end of what it reads and mirrors the answer. Mirroring
+ * the map here instead would need the length of the region the event reads,
+ * which is itself an answer from the map, and the two would define each other.
+ *
+ * The incumbent cannot do reverse and warp together at all: it bakes warp into
+ * a rendered proxy file and can only bake one thing per clip, so a reversed
+ * warped clip there silently loses its markers
+ * (`WaveAudioClip::createRenderJob` returns the reverse job before it ever
+ * reaches the warp one). Computing both live has no such constraint.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief The inverted map: warp time to source time, and back.
+ *
+ * Empty is identity, which is what an event with warp off compiles to and what
+ * makes every caller warp-agnostic. Non-empty is strictly increasing in both
+ * coordinates, so either direction is a binary search and a lerp.
+ */
+struct WarpMap {
+    struct Point {
+        double sourceSeconds = 0.0;
+        double warpSeconds = 0.0;
+
+        bool operator==(const Point&) const = default;
+    };
+
+    /// Sorted ascending, strictly increasing in both coordinates. Never holds a
+    /// pair whose span is zero on either side.
+    std::vector<Point> points;
+
+    bool empty() const noexcept {
+        return points.empty();
+    }
+
+    /// The source second heard at @p warpSeconds. Slope 1 outside the range,
+    /// offset by the nearest point, which is the model's rule.
+    double sourceSecondsAt(double warpSeconds) const noexcept;
+
+    /// The warp time @p sourceSeconds lands at. The model's own direction, and
+    /// needed at playback for one thing: the event's anchor is a source
+    /// position and its elapsed is warp time, so the two have to be brought
+    /// into one domain before they can be added.
+    double sourceToWarpSeconds(double sourceSeconds) const noexcept;
+
+    /**
+     * @brief The steepest source-per-warp any segment runs at, and never below 1.
+     *
+     * What a stretcher is sized against. A warped event's rate is not one
+     * number -- that is the whole point of it -- so what the pre-roll and the
+     * diagnostics need is the worst of them. Never below 1 because the map
+     * carries on at slope 1 outside its markers, so every map has a stretch
+     * that runs at unity.
+     */
+    double maxSourcePerWarp() const noexcept;
+
+    bool operator==(const WarpMap&) const = default;
+};
+
+/**
+ * @brief What compiling one event's markers produced, and what it cost.
+ *
+ * The count is for a diagnostic. A dropped marker is a marker the user placed
+ * and cannot hear, so the compile says how many rather than leaving the clip
+ * quietly playing a map that is not the one on screen.
+ */
+struct WarpCompileResult {
+    WarpMap map;
+    int droppedMarkers = 0;
+};
+
+/**
+ * @brief Compile @p markers into an invertible map.
+ *
+ * Sorts by source time and drops what does not strictly increase on both sides.
+ *
+ * A marker that does not increase is dropped rather than the whole map being
+ * refused: the rest of them still describe something, and a user who dragged
+ * one marker past its neighbour should lose that marker rather than the clip's
+ * timing. Coincident markers go the same way, which is what keeps every
+ * segment's span positive and the lookup free of a zero divide.
+ */
+WarpCompileResult compileWarpMap(const std::vector<WarpMarker>& markers);
+
+}  // namespace magda::engine

--- a/magda/engine/clip/WarpMap.hpp
+++ b/magda/engine/clip/WarpMap.hpp
@@ -103,14 +103,17 @@ struct WarpCompileResult {
 /**
  * @brief Compile @p markers into an invertible map.
  *
- * Sorts by source time, collapses markers sharing an instant of the file, and
- * keeps the largest set of what is left that runs forwards on the warp side.
+ * Sorts by source time and keeps the largest set of markers that runs forwards
+ * on both sides at once.
  *
  * Largest rather than first-come. A marker the user dragged past its
  * neighbours should cost itself, and a single forward pass does not deliver
  * that: it anchors on whatever it saw first, so one marker flung far ahead
  * survives and every marker behind it is dropped. What is kept here is a
  * longest increasing subsequence, so the offending marker is the one that goes.
+ *
+ * Which markers those are does not depend on the order the model stored them
+ * in, including for two markers sharing one instant of the file.
  *
  * The whole map is never refused. The markers that remain still describe
  * something, and a clip that loses its timing entirely is a worse answer than

--- a/magda/engine/clip/WarpMap.hpp
+++ b/magda/engine/clip/WarpMap.hpp
@@ -103,13 +103,18 @@ struct WarpCompileResult {
 /**
  * @brief Compile @p markers into an invertible map.
  *
- * Sorts by source time and drops what does not strictly increase on both sides.
+ * Sorts by source time, collapses markers sharing an instant of the file, and
+ * keeps the largest set of what is left that runs forwards on the warp side.
  *
- * A marker that does not increase is dropped rather than the whole map being
- * refused: the rest of them still describe something, and a user who dragged
- * one marker past its neighbour should lose that marker rather than the clip's
- * timing. Coincident markers go the same way, which is what keeps every
- * segment's span positive and the lookup free of a zero divide.
+ * Largest rather than first-come. A marker the user dragged past its
+ * neighbours should cost itself, and a single forward pass does not deliver
+ * that: it anchors on whatever it saw first, so one marker flung far ahead
+ * survives and every marker behind it is dropped. What is kept here is a
+ * longest increasing subsequence, so the offending marker is the one that goes.
+ *
+ * The whole map is never refused. The markers that remain still describe
+ * something, and a clip that loses its timing entirely is a worse answer than
+ * one that loses a marker.
  */
 WarpCompileResult compileWarpMap(const std::vector<WarpMarker>& markers);
 

--- a/magda/engine/io/SourceLoopInfo.cpp
+++ b/magda/engine/io/SourceLoopInfo.cpp
@@ -14,16 +14,27 @@ std::optional<juce::String> valueOf(const juce::StringPairArray& metadata, const
     return value.isNotEmpty() ? std::optional<juce::String>(value) : std::nullopt;
 }
 
-std::optional<double> doubleOf(const juce::StringPairArray& metadata, const char* key) {
+/// @p key's value when it is a number worth having, and nothing otherwise.
+///
+/// Zero counts as nothing, and that is what makes this usable against a real
+/// file rather than only against a hand-built map. JUCE writes every acid field
+/// whenever a file has an acid chunk at all
+/// (`WavAudioFormat::AcidChunk::addToMetadata`), zeros included, so a loop that
+/// carries a beat count and no tempo arrives with `acidTempo` set to "0". Read
+/// as a value that would engage the field and block the beat count below from
+/// ever being turned into one.
+std::optional<double> positiveDoubleOf(const juce::StringPairArray& metadata, const char* key) {
     if (const auto value = valueOf(metadata, key))
-        return value->getDoubleValue();
+        if (const auto number = value->getDoubleValue(); number > 0.0)
+            return number;
 
     return std::nullopt;
 }
 
-std::optional<int> intOf(const juce::StringPairArray& metadata, const char* key) {
+std::optional<int> positiveIntOf(const juce::StringPairArray& metadata, const char* key) {
     if (const auto value = valueOf(metadata, key))
-        return value->getIntValue();
+        if (const auto number = value->getIntValue(); number > 0)
+            return number;
 
     return std::nullopt;
 }
@@ -36,10 +47,10 @@ SourceLoopInfo loopInfoFrom(const juce::StringPairArray& metadata, double sample
 
     // ---- The acid chunk, which is what loop libraries write ----------------
 
-    info.numBeats = doubleOf(metadata, juce::WavAudioFormat::acidBeats);
-    info.numerator = intOf(metadata, juce::WavAudioFormat::acidNumerator);
-    info.denominator = intOf(metadata, juce::WavAudioFormat::acidDenominator);
-    info.bpm = doubleOf(metadata, juce::WavAudioFormat::acidTempo);
+    info.numBeats = positiveDoubleOf(metadata, juce::WavAudioFormat::acidBeats);
+    info.numerator = positiveIntOf(metadata, juce::WavAudioFormat::acidNumerator);
+    info.denominator = positiveIntOf(metadata, juce::WavAudioFormat::acidDenominator);
+    info.bpm = positiveDoubleOf(metadata, juce::WavAudioFormat::acidTempo);
 
     if (const auto oneShot = valueOf(metadata, juce::WavAudioFormat::acidOneShot))
         info.oneShot = *oneShot == "1";
@@ -48,29 +59,38 @@ SourceLoopInfo loopInfoFrom(const juce::StringPairArray& metadata, double sample
     // anything. A note that has not been marked as set is not a note, which is
     // the chunk's own rule rather than a caution taken here.
     if (metadata[juce::WavAudioFormat::acidRootSet] == "1")
-        info.rootNote = intOf(metadata, juce::WavAudioFormat::acidRootNote);
+        info.rootNote = positiveIntOf(metadata, juce::WavAudioFormat::acidRootNote);
 
     // ---- The plainer keys AIFF and the fork's own files use -----------------
 
     if (!info.bpm)
-        info.bpm = doubleOf(metadata, "tempo");
+        info.bpm = positiveDoubleOf(metadata, "tempo");
 
     if (!info.numBeats)
-        info.numBeats = doubleOf(metadata, "beat count");
+        info.numBeats = positiveDoubleOf(metadata, "beat count");
 
+    // Numerator before the slash, which is how a time signature is written and
+    // NOT how the fork reads one: tracktion_LoopInfo.cpp assigns the left side
+    // to the denominator and the right to the numerator, so a 6/8 file becomes
+    // 8/6 there. Diverging deliberately -- none of these fields reaches the
+    // audio, so nothing in the null-diff corpus moves for it, and reproducing a
+    // swap would only spread it.
     if (const auto timeSignature = valueOf(metadata, "time signature")) {
+        if (!info.numerator)
+            info.numerator = timeSignature->upToFirstOccurrenceOf("/", false, false).getIntValue();
         if (!info.denominator)
             info.denominator =
-                timeSignature->upToFirstOccurrenceOf("/", false, false).getIntValue();
-        if (!info.numerator)
-            info.numerator = timeSignature->fromFirstOccurrenceOf("/", false, false).getIntValue();
+                timeSignature->fromFirstOccurrenceOf("/", false, false).getIntValue();
     }
 
-    // The smpl chunk's root, for a file with no acid chunk at all. Zero is what
-    // JUCE returns for a key it does not hold, and it is also a legal note, so
-    // the key's presence is what decides rather than its value.
+    // The smpl chunk's root, for a file with no acid chunk at all. Note zero
+    // reads as absent, which is the fork's own treatment of this key.
     if (!info.rootNote)
-        info.rootNote = intOf(metadata, "MidiUnityNote");
+        info.rootNote = positiveIntOf(metadata, "MidiUnityNote");
+
+    // Not read: the "key signature" string, which the fork also turns into a
+    // root note. That needs a note-name parser the engine has not got, and what
+    // the model seeds from here is the tempo and the beat count.
 
     // ---- What the file left to be worked out -------------------------------
 
@@ -78,10 +98,15 @@ SourceLoopInfo loopInfoFrom(const juce::StringPairArray& metadata, double sample
                                      ? static_cast<double>(lengthInSamples) / sampleRate
                                      : 0.0;
 
-    if (!info.bpm && info.numBeats && *info.numBeats > 0.0 && durationSeconds > 0.0)
+    // Beats over minutes. The fork's beat-count branch writes
+    // `beats / duration / 60` here, which is a genuine bug in it -- four beats
+    // over two seconds seeds 0.03 bpm rather than 120 -- and one worth not
+    // reproducing: a tempo that wrong is a clip that will not stretch to any
+    // sensible length.
+    if (!info.bpm && info.numBeats && durationSeconds > 0.0)
         info.bpm = (*info.numBeats * 60.0) / durationSeconds;
 
-    if (!info.numBeats && info.bpm && *info.bpm > 0.0 && durationSeconds > 0.0)
+    if (!info.numBeats && info.bpm && durationSeconds > 0.0)
         info.numBeats = (durationSeconds / 60.0) * *info.bpm;
 
     return info;

--- a/magda/engine/io/SourceLoopInfo.cpp
+++ b/magda/engine/io/SourceLoopInfo.cpp
@@ -1,0 +1,90 @@
+#include "io/SourceLoopInfo.hpp"
+
+#include <juce_audio_formats/juce_audio_formats.h>
+
+namespace magda::engine {
+
+namespace {
+
+/// @p key's value, or nothing when the file did not write it. An empty string
+/// counts as not written: a writer that emitted the key and left it blank said
+/// no more than one that left it out.
+std::optional<juce::String> valueOf(const juce::StringPairArray& metadata, const char* key) {
+    const auto value = metadata[key];
+    return value.isNotEmpty() ? std::optional<juce::String>(value) : std::nullopt;
+}
+
+std::optional<double> doubleOf(const juce::StringPairArray& metadata, const char* key) {
+    if (const auto value = valueOf(metadata, key))
+        return value->getDoubleValue();
+
+    return std::nullopt;
+}
+
+std::optional<int> intOf(const juce::StringPairArray& metadata, const char* key) {
+    if (const auto value = valueOf(metadata, key))
+        return value->getIntValue();
+
+    return std::nullopt;
+}
+
+}  // namespace
+
+SourceLoopInfo loopInfoFrom(const juce::StringPairArray& metadata, double sampleRate,
+                            std::int64_t lengthInSamples) {
+    SourceLoopInfo info;
+
+    // ---- The acid chunk, which is what loop libraries write ----------------
+
+    info.numBeats = doubleOf(metadata, juce::WavAudioFormat::acidBeats);
+    info.numerator = intOf(metadata, juce::WavAudioFormat::acidNumerator);
+    info.denominator = intOf(metadata, juce::WavAudioFormat::acidDenominator);
+    info.bpm = doubleOf(metadata, juce::WavAudioFormat::acidTempo);
+
+    if (const auto oneShot = valueOf(metadata, juce::WavAudioFormat::acidOneShot))
+        info.oneShot = *oneShot == "1";
+
+    // The chunk carries a root note and a flag saying whether it means
+    // anything. A note that has not been marked as set is not a note, which is
+    // the chunk's own rule rather than a caution taken here.
+    if (metadata[juce::WavAudioFormat::acidRootSet] == "1")
+        info.rootNote = intOf(metadata, juce::WavAudioFormat::acidRootNote);
+
+    // ---- The plainer keys AIFF and the fork's own files use -----------------
+
+    if (!info.bpm)
+        info.bpm = doubleOf(metadata, "tempo");
+
+    if (!info.numBeats)
+        info.numBeats = doubleOf(metadata, "beat count");
+
+    if (const auto timeSignature = valueOf(metadata, "time signature")) {
+        if (!info.denominator)
+            info.denominator =
+                timeSignature->upToFirstOccurrenceOf("/", false, false).getIntValue();
+        if (!info.numerator)
+            info.numerator = timeSignature->fromFirstOccurrenceOf("/", false, false).getIntValue();
+    }
+
+    // The smpl chunk's root, for a file with no acid chunk at all. Zero is what
+    // JUCE returns for a key it does not hold, and it is also a legal note, so
+    // the key's presence is what decides rather than its value.
+    if (!info.rootNote)
+        info.rootNote = intOf(metadata, "MidiUnityNote");
+
+    // ---- What the file left to be worked out -------------------------------
+
+    const auto durationSeconds = sampleRate > 0.0 && lengthInSamples > 0
+                                     ? static_cast<double>(lengthInSamples) / sampleRate
+                                     : 0.0;
+
+    if (!info.bpm && info.numBeats && *info.numBeats > 0.0 && durationSeconds > 0.0)
+        info.bpm = (*info.numBeats * 60.0) / durationSeconds;
+
+    if (!info.numBeats && info.bpm && *info.bpm > 0.0 && durationSeconds > 0.0)
+        info.numBeats = (durationSeconds / 60.0) * *info.bpm;
+
+    return info;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/io/SourceLoopInfo.cpp
+++ b/magda/engine/io/SourceLoopInfo.cpp
@@ -39,6 +39,15 @@ std::optional<int> positiveIntOf(const juce::StringPairArray& metadata, const ch
     return std::nullopt;
 }
 
+/// @p key's value whatever it is, for the one field that has something else
+/// saying whether it means anything.
+std::optional<int> intOf(const juce::StringPairArray& metadata, const char* key) {
+    if (const auto value = valueOf(metadata, key))
+        return value->getIntValue();
+
+    return std::nullopt;
+}
+
 }  // namespace
 
 SourceLoopInfo loopInfoFrom(const juce::StringPairArray& metadata, double sampleRate,
@@ -57,9 +66,11 @@ SourceLoopInfo loopInfoFrom(const juce::StringPairArray& metadata, double sample
 
     // The chunk carries a root note and a flag saying whether it means
     // anything. A note that has not been marked as set is not a note, which is
-    // the chunk's own rule rather than a caution taken here.
+    // the chunk's own rule rather than a caution taken here -- and the flag is
+    // the whole of the rule, so a marked-as-set zero is note 0 rather than a
+    // silence. Raw here for that reason, where every other field filters.
     if (metadata[juce::WavAudioFormat::acidRootSet] == "1")
-        info.rootNote = positiveIntOf(metadata, juce::WavAudioFormat::acidRootNote);
+        info.rootNote = intOf(metadata, juce::WavAudioFormat::acidRootNote);
 
     // ---- The plainer keys AIFF and the fork's own files use -----------------
 

--- a/magda/engine/io/SourceLoopInfo.hpp
+++ b/magda/engine/io/SourceLoopInfo.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <cstdint>
+#include <optional>
+
+/**
+ * @file SourceLoopInfo.hpp
+ * @brief What a file says about its own tempo, before anyone interprets it.
+ *
+ * The model seeds an event's interpretation from this and then owns it:
+ * `AudioEvent::seedInterpretation` takes a beat count and a bpm, and never
+ * overwrites what the user set. Where those two came from was Tracktion
+ * (`te::LoopInfo`), and it is not an analysis at all -- the fork reads them out
+ * of `juce::AudioFormatReader::metadataValues`, the acid chunk that loop
+ * libraries write and that JUCE's `WavAudioFormat` already parses.
+ *
+ * So this is a parse, and it lives beside the reader rather than inside it for
+ * the reason the reader interface gives for being as narrow as it is: what
+ * decoded the file is the host's business. Taking a metadata map rather than a
+ * file also means the whole thing is testable by handing it one, with no
+ * fixture on a disk and no format to register.
+ *
+ * Every field is optional, and that is the point of it. "The file says nothing"
+ * and "the file says 120" are different answers, and the model's seeding rule
+ * depends on telling them apart: a value that defaulted would overwrite an
+ * interpretation the user had already chosen.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief A source's own account of its musical shape.
+ *
+ * Unset means the file did not say, and unset is never filled in with a
+ * default: the model's seeding rule leaves what the user set alone, and it can
+ * only do that if it can tell a silence from a value.
+ *
+ * @ref bpm is the one derived field, and only when it has to be. A file that
+ * wrote its tempo is believed; one that wrote only a beat count has its tempo
+ * worked out from how long it is, which is what acid loops expect and what the
+ * incumbent does for all of them. Preferring the written value where there is
+ * one is the difference between seeding 174 and seeding 173.98.
+ */
+struct SourceLoopInfo {
+    std::optional<double> bpm;
+    std::optional<double> numBeats;
+    std::optional<int> numerator;
+    std::optional<int> denominator;
+
+    /// MIDI note number the material is in, when the file says its root was
+    /// set. A file carrying a root note it has not marked as valid is treated
+    /// as not having one, which is the acid chunk's own rule.
+    std::optional<int> rootNote;
+
+    /// A hit rather than a loop. Nothing musical should be read off its length.
+    std::optional<bool> oneShot;
+
+    bool operator==(const SourceLoopInfo&) const = default;
+};
+
+/**
+ * @brief Read @p metadata for what the file said about its tempo.
+ *
+ * @p sampleRate and @p lengthInSamples are what a beat count is turned into a
+ * bpm with when the file gave a count and no tempo, which is the common case:
+ * acid loops carry their beat count and leave the tempo to be worked out from
+ * how long they are. Pass zero for either and that inference is skipped rather
+ * than guessed.
+ */
+SourceLoopInfo loopInfoFrom(const juce::StringPairArray& metadata, double sampleRate,
+                            std::int64_t lengthInSamples);
+
+}  // namespace magda::engine

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -272,6 +272,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_clip_voice.cpp)
     list(APPEND TEST_SOURCES test_clip_voice_pool.cpp)
     list(APPEND TEST_SOURCES test_clip_stretch.cpp)
+    list(APPEND TEST_SOURCES test_clip_warp.cpp)
+    list(APPEND TEST_SOURCES test_transient_detector.cpp)
+    list(APPEND TEST_SOURCES test_source_loop_info.cpp)
 endif()
 
 # Create test executable

--- a/tests/test_clip_warp.cpp
+++ b/tests/test_clip_warp.cpp
@@ -186,6 +186,39 @@ TEST_CASE("Compiling refuses what it cannot invert", "[engine][clip][warp]") {
         REQUIRE(flung.map.points.back().warpSeconds == approx(3.0));
     }
 
+    SECTION("which of two markers on one instant survives is whichever chains") {
+        // Coincident on the source side, so at most one can be kept: keeping
+        // both would be a segment with no span and an infinite rate. Which one
+        // is not a guess that can be made before knowing what either reaches.
+        //
+        // Here the larger warp is the one that chains, and collapsing to the
+        // smaller first would strand both its neighbours and keep two points
+        // where three are available.
+        const auto pair =
+            magda::engine::compileWarpMap({{0.0, 5.0}, {1.0, 50.0}, {1.0, 2.0}, {2.0, 60.0}});
+
+        REQUIRE(pair.droppedMarkers == 1);
+        REQUIRE(pair.map.points.size() == 3);
+        REQUIRE(pair.map.points[1].warpSeconds == approx(50.0));
+
+        // And the other way round, where the smaller is the one that chains.
+        const auto other =
+            magda::engine::compileWarpMap({{0.0, 1.0}, {1.0, 50.0}, {1.0, 2.0}, {2.0, 3.0}});
+
+        REQUIRE(other.droppedMarkers == 1);
+        REQUIRE(other.map.points.size() == 3);
+        REQUIRE(other.map.points[1].warpSeconds == approx(2.0));
+    }
+
+    SECTION("and does not depend on the order they were stored in") {
+        const auto forwards =
+            magda::engine::compileWarpMap({{0.0, 5.0}, {1.0, 50.0}, {1.0, 2.0}, {2.0, 60.0}});
+        const auto backwards =
+            magda::engine::compileWarpMap({{2.0, 60.0}, {1.0, 2.0}, {1.0, 50.0}, {0.0, 5.0}});
+
+        REQUIRE(forwards.map == backwards.map);
+    }
+
     SECTION("compiling one list twice keeps the same markers") {
         const std::vector<magda::WarpMarker> awkward{
             {0.0, 0.0}, {1.0, 100.0}, {2.0, 1.0}, {3.0, 2.0}, {4.0, 3.0}};

--- a/tests/test_clip_warp.cpp
+++ b/tests/test_clip_warp.cpp
@@ -7,6 +7,7 @@
 #include "clip/ClipStretcher.hpp"
 #include "clip/EventPlacement.hpp"
 #include "clip/WarpMap.hpp"
+#include "exec/RenderContext.hpp"
 #include "io/SourceReaders.hpp"
 
 /**
@@ -94,6 +95,7 @@ AudioClipPlayback warpedClip(std::int64_t anchor = 0,
     event.span = clip.span;
     event.anchorSamples = anchor;
     event.interpBpm = kBpm;
+    event.warpEnabled = true;
     event.warp = magda::engine::compileWarpMap(warp).map;
 
     clip.events.push_back(std::move(event));
@@ -170,6 +172,26 @@ TEST_CASE("Compiling refuses what it cannot invert", "[engine][clip][warp]") {
 
         REQUIRE(backwards.droppedMarkers == 1);
         REQUIRE(backwards.map.points.size() == 2);
+    }
+
+    SECTION("one marker flung forwards costs itself and not the rest") {
+        // A greedy pass would anchor on the marker at warp 100 and drop the
+        // three behind it. What should go is the one marker that is wrong.
+        const auto flung = magda::engine::compileWarpMap(
+            {{0.0, 0.0}, {1.0, 100.0}, {2.0, 1.0}, {3.0, 2.0}, {4.0, 3.0}});
+
+        REQUIRE(flung.droppedMarkers == 1);
+        REQUIRE(flung.map.points.size() == 4);
+        REQUIRE(flung.map.points[1].warpSeconds == approx(1.0));
+        REQUIRE(flung.map.points.back().warpSeconds == approx(3.0));
+    }
+
+    SECTION("compiling one list twice keeps the same markers") {
+        const std::vector<magda::WarpMarker> awkward{
+            {0.0, 0.0}, {1.0, 100.0}, {2.0, 1.0}, {3.0, 2.0}, {4.0, 3.0}};
+
+        REQUIRE(magda::engine::compileWarpMap(awkward).map ==
+                magda::engine::compileWarpMap(awkward).map);
     }
 
     SECTION("two markers at one instant collapse") {
@@ -315,9 +337,75 @@ TEST_CASE("A warped loop bends the same way on every pass", "[engine][clip][warp
     }
 }
 
+TEST_CASE("Warp with no markers is still warp", "[engine][clip][warp]") {
+    // Identity as a map, and an interpretation as far as the model is
+    // concerned: the event stays on the beat face at its own bpm and still
+    // wants a stretcher. Deleting the last marker off a clip must not quietly
+    // stop it following the tempo.
+    auto clip = warpedClip(0, {});
+    auto& event = clip.events.front();
+    event.interpBpm = kBpm / 2.0;  // half the timeline's, so twice as fast
+
+    REQUIRE(event.warp.empty());
+    REQUIRE(event.warpEnabled);
+    REQUIRE(magda::engine::readingRateOf(event) == approx(2.0));
+    REQUIRE(readingAt(clip, 1.0) == approx(atSourceSecond(2.0)));
+
+    SECTION("and it still asks for a stretcher that can follow") {
+        const magda::engine::RenderContext context{kSampleRate, 512, 2};
+        REQUIRE(magda::engine::stretchSetupFor(clip, event, context).followsTempo);
+    }
+}
+
+TEST_CASE("A warp second is not a timeline second when the file disagrees",
+          "[engine][clip][warp]") {
+    // The rig above interprets the file at the timeline's own tempo, which
+    // makes the beat-face conversion a multiply by one and hides a units slip.
+    // Here the file is read at half the timeline's tempo, so a timeline second
+    // is two warp seconds and the map is walked twice as fast.
+    auto clip = warpedClip();
+    auto& event = clip.events.front();
+    event.interpBpm = kBpm / 2.0;
+
+    // Half a second of timeline is one warp second, which is source second two.
+    REQUIRE(readingAt(clip, 0.5) == approx(atSourceSecond(2.0)));
+
+    // And one and a half is warp three, the last marker.
+    REQUIRE(readingAt(clip, 1.5) == approx(atSourceSecond(3.0)));
+}
+
+TEST_CASE("A reversed warped loop composes both", "[engine][clip][warp]") {
+    auto clip = warpedClip();
+    auto& event = clip.events.front();
+    event.reversed = true;
+    event.loopEnabled = true;
+    event.loopStartSamples = 0;
+    event.loopLengthSamples = static_cast<std::int64_t>(atSourceSecond(2.0));
+
+    SECTION("it repeats on the loop's warped length") {
+        REQUIRE(readingAt(clip, 1.5) == approx(readingAt(clip, 0.5)));
+        REQUIRE(readingAt(clip, 3.25) == approx(readingAt(clip, 0.25)));
+    }
+
+    SECTION("and every position is still in the mirrored file") {
+        const auto mirrored = [](double sourceSeconds) {
+            return atSourceSecond(10000.0) - 1.0 - atSourceSecond(sourceSeconds);
+        };
+
+        // Warp folds into [0, 1); walking backwards from the far end lands at
+        // warp 0 exactly, which is source zero.
+        REQUIRE(readingAt(clip, 0.0) == approx(mirrored(0.0)));
+    }
+
+    SECTION("the reading chain still does not tile it a second time") {
+        REQUIRE(magda::engine::sourceReadFor(event, kSampleRate).loopLengthSamples == 0);
+    }
+}
+
 TEST_CASE("An unwarped event is untouched by any of this", "[engine][clip][warp]") {
     auto clip = warpedClip(500, {});
     auto& event = clip.events.front();
+    event.warpEnabled = false;
 
     REQUIRE(event.warp.empty());
     REQUIRE(magda::engine::readingPositionAt(clip, event, 11.0, beatAt(11.0), kSampleRate) ==

--- a/tests/test_clip_warp.cpp
+++ b/tests/test_clip_warp.cpp
@@ -1,0 +1,334 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <vector>
+
+#include "clip/ClipSnapshot.hpp"
+#include "clip/ClipStretcher.hpp"
+#include "clip/EventPlacement.hpp"
+#include "clip/WarpMap.hpp"
+#include "io/SourceReaders.hpp"
+
+/**
+ * A clip's own musical time, and where it stops agreeing with its file's
+ * (#2038).
+ *
+ * All arithmetic, and tested as arithmetic: against numbers worked out by hand
+ * rather than against another run of the same code. Warp adds no new machinery
+ * below the position map -- the voice, the stretcher and the reading chain are
+ * untouched by this slice -- so what there is to get wrong is entirely here.
+ *
+ * The rig's map bends the file in two directions at once, which is what makes
+ * the numbers below readable. Two source seconds are squeezed into one warp
+ * second, so that stretch plays at double speed; the one source second after it
+ * is stretched over two, so that stretch plays at half. Everything past the last
+ * marker runs at the file's own rate, which is the model's rule and the reason a
+ * clip with one marker is still a clip.
+ */
+
+using magda::engine::AudioClipPlayback;
+using magda::engine::AudioEventPlayback;
+using magda::engine::SnapshotSpan;
+using magda::engine::WarpMap;
+
+namespace {
+
+constexpr double kSampleRate = 44100.0;
+constexpr double kBpm = 120.0;
+constexpr double kBeatsPerSecond = kBpm / 60.0;
+
+Catch::Approx approx(double value, double margin = 1e-4) {
+    return Catch::Approx(value).margin(margin);
+}
+
+SnapshotSpan seconds(double start, double end) {
+    SnapshotSpan span;
+    span.startBeat = start * kBeatsPerSecond;
+    span.endBeat = end * kBeatsPerSecond;
+    span.startSeconds = start;
+    span.endSeconds = end;
+    return span;
+}
+
+double beatAt(double seconds) {
+    return seconds * kBeatsPerSecond;
+}
+
+/// Source seconds turned into the position a reading is counted in, which at
+/// the rig's rates is one sample of the device per sample of the file.
+double atSourceSecond(double seconds) {
+    return seconds * kSampleRate;
+}
+
+/**
+ * @brief The rig's map: (0,0), (2,1), (3,3).
+ *
+ * Source 0 to 2 over warp 0 to 1, so that stretch is consumed at twice the
+ * rate; source 2 to 3 over warp 1 to 3, so the next is consumed at half. Past
+ * source 3 the map carries on at slope 1.
+ */
+std::vector<magda::WarpMarker> markers() {
+    return {{0.0, 0.0}, {2.0, 1.0}, {3.0, 3.0}};
+}
+
+/**
+ * @brief A clip whose interpretation makes a warp second a timeline second.
+ *
+ * The event is on the beat face, as every warped event is, so its elapsed is
+ * beats over its own bpm. Interpreting the file at the timeline's own tempo
+ * makes those two the same number, which keeps every expectation below a fact
+ * about the map rather than about a tempo conversion.
+ */
+AudioClipPlayback warpedClip(std::int64_t anchor = 0,
+                             const std::vector<magda::WarpMarker>& warp = markers()) {
+    AudioClipPlayback clip;
+    clip.clipId = 1;
+    clip.span = seconds(10.0, 20.0);
+
+    AudioEventPlayback event;
+    event.eventId = 1;
+    event.sourceId = 1;
+    event.filePath = "take.wav";
+    event.sourceSampleRate = kSampleRate;
+    event.sourceDurationSeconds = 10000.0;
+    event.span = clip.span;
+    event.anchorSamples = anchor;
+    event.interpBpm = kBpm;
+    event.warp = magda::engine::compileWarpMap(warp).map;
+
+    clip.events.push_back(std::move(event));
+    return clip;
+}
+
+/// Where the clip is reading, @p elapsed timeline seconds into itself.
+double readingAt(const AudioClipPlayback& clip, double elapsed) {
+    const auto at = clip.span.startSeconds + elapsed;
+    return magda::engine::readingPositionAt(clip, clip.events.front(), at, beatAt(at), kSampleRate);
+}
+
+}  // namespace
+
+TEST_CASE("An empty map is the identity", "[engine][clip][warp]") {
+    WarpMap map;
+
+    REQUIRE(map.empty());
+    REQUIRE(map.sourceSecondsAt(3.5) == approx(3.5));
+    REQUIRE(map.sourceToWarpSeconds(3.5) == approx(3.5));
+    REQUIRE(map.maxSourcePerWarp() == approx(1.0));
+}
+
+TEST_CASE("The compiled map is exact at its markers and linear between them",
+          "[engine][clip][warp]") {
+    const auto map = magda::engine::compileWarpMap(markers()).map;
+
+    SECTION("at the markers") {
+        REQUIRE(map.sourceSecondsAt(0.0) == approx(0.0));
+        REQUIRE(map.sourceSecondsAt(1.0) == approx(2.0));
+        REQUIRE(map.sourceSecondsAt(3.0) == approx(3.0));
+    }
+
+    SECTION("between them") {
+        REQUIRE(map.sourceSecondsAt(0.5) == approx(1.0));
+        REQUIRE(map.sourceSecondsAt(2.0) == approx(2.5));
+    }
+
+    SECTION("outside them the file runs at its own rate") {
+        REQUIRE(map.sourceSecondsAt(-1.0) == approx(-1.0));
+        REQUIRE(map.sourceSecondsAt(5.0) == approx(5.0));
+    }
+
+    SECTION("the forward direction is the model's own") {
+        // AudioEvent::warpedSourceSeconds, which the editors read.
+        REQUIRE(map.sourceToWarpSeconds(1.0) == approx(0.5));
+        REQUIRE(map.sourceToWarpSeconds(2.5) == approx(2.0));
+        REQUIRE(map.sourceToWarpSeconds(9.0) == approx(9.0));
+    }
+
+    SECTION("one composed with the other is the identity") {
+        for (const auto at : {0.25, 1.5, 2.75, 4.0})
+            REQUIRE(map.sourceSecondsAt(map.sourceToWarpSeconds(at)) == approx(at));
+    }
+
+    SECTION("the steepest segment is what a stretcher is sized against") {
+        REQUIRE(map.maxSourcePerWarp() == approx(2.0));
+    }
+}
+
+TEST_CASE("Compiling refuses what it cannot invert", "[engine][clip][warp]") {
+    SECTION("markers arrive in whatever order they were stored in") {
+        const auto shuffled = magda::engine::compileWarpMap({{3.0, 3.0}, {0.0, 0.0}, {2.0, 1.0}});
+
+        REQUIRE(shuffled.droppedMarkers == 0);
+        REQUIRE(shuffled.map.points.size() == 3);
+        REQUIRE(shuffled.map.sourceSecondsAt(1.0) == approx(2.0));
+    }
+
+    SECTION("a marker dragged back past its neighbour is dropped, not obeyed") {
+        // Source climbs, warp does not: there is no source second that plays at
+        // warp 2, and asking would divide by a negative span.
+        const auto backwards = magda::engine::compileWarpMap({{0.0, 0.0}, {2.0, 3.0}, {3.0, 2.0}});
+
+        REQUIRE(backwards.droppedMarkers == 1);
+        REQUIRE(backwards.map.points.size() == 2);
+    }
+
+    SECTION("two markers at one instant collapse") {
+        const auto coincident = magda::engine::compileWarpMap({{0.0, 0.0}, {2.0, 1.0}, {2.0, 1.5}});
+
+        REQUIRE(coincident.droppedMarkers == 1);
+        REQUIRE(coincident.map.points.size() == 2);
+    }
+
+    SECTION("what is not a number never reaches the audio thread") {
+        const auto broken =
+            magda::engine::compileWarpMap({{0.0, 0.0}, {std::nan(""), 1.0}, {3.0, std::nan("")}});
+
+        REQUIRE(broken.droppedMarkers == 2);
+        REQUIRE(broken.map.points.size() == 1);
+    }
+}
+
+TEST_CASE("A warped clip consumes its file at the rate its markers ask for",
+          "[engine][clip][warp]") {
+    const auto clip = warpedClip();
+
+    SECTION("the squeezed stretch plays at double speed") {
+        REQUIRE(readingAt(clip, 0.0) == approx(atSourceSecond(0.0)));
+        REQUIRE(readingAt(clip, 0.5) == approx(atSourceSecond(1.0)));
+        REQUIRE(readingAt(clip, 1.0) == approx(atSourceSecond(2.0)));
+    }
+
+    SECTION("the stretched one plays at half") {
+        REQUIRE(readingAt(clip, 2.0) == approx(atSourceSecond(2.5)));
+        REQUIRE(readingAt(clip, 3.0) == approx(atSourceSecond(3.0)));
+    }
+
+    SECTION("past the last marker it plays at the file's own rate") {
+        REQUIRE(readingAt(clip, 4.0) == approx(atSourceSecond(4.0)));
+        REQUIRE(readingAt(clip, 5.0) == approx(atSourceSecond(5.0)));
+    }
+
+    SECTION("the position only ever moves forwards") {
+        auto last = readingAt(clip, 0.0);
+
+        for (double at = 0.05; at < 9.0; at += 0.05) {
+            const auto now = readingAt(clip, at);
+            REQUIRE(now > last);
+            last = now;
+        }
+    }
+}
+
+TEST_CASE("Warp sizes a stretcher against its steepest stretch, not its average",
+          "[engine][clip][warp]") {
+    const auto clip = warpedClip();
+
+    REQUIRE(magda::engine::readingRateOf(clip.events.front()) == approx(2.0));
+}
+
+TEST_CASE("Trimming a clip's head leaves its markers pinned to the file", "[engine][clip][warp]") {
+    // Reading begins one source second in, which is halfway through the
+    // squeezed stretch: warp 0.5. What plays from there is what played from
+    // there before the trim, rather than the map sliding with the anchor.
+    const auto clip = warpedClip(static_cast<std::int64_t>(atSourceSecond(1.0)));
+
+    REQUIRE(readingAt(clip, 0.0) == approx(atSourceSecond(1.0)));
+    REQUIRE(readingAt(clip, 0.5) == approx(atSourceSecond(2.0)));
+
+    // Warp 2.0, which is halfway through the stretched segment rather than
+    // halfway through the second the trim removed.
+    REQUIRE(readingAt(clip, 1.5) == approx(atSourceSecond(2.5)));
+}
+
+TEST_CASE("Where the pool cues a warped clip is where its first block reads",
+          "[engine][clip][warp]") {
+    for (const auto anchor : {0.0, 1.0, 2.5}) {
+        const auto clip = warpedClip(static_cast<std::int64_t>(atSourceSecond(anchor)));
+        const auto placement = magda::engine::placementFor(clip.events.front(), kSampleRate);
+
+        REQUIRE(static_cast<double>(placement.sourceOffsetSamples) ==
+                approx(readingAt(clip, 0.0), 1.0));
+    }
+}
+
+TEST_CASE("A reversed warped clip keeps its markers", "[engine][clip][warp]") {
+    // The incumbent cannot do this at all: it bakes warp into a proxy file and
+    // returns the reverse job before it reaches the warp one, so a reversed
+    // warped clip there plays unwarped.
+    auto clip = warpedClip();
+    auto& event = clip.events.front();
+    event.reversed = true;
+
+    // The mirrored file's own coordinates, which is what the reading delivers.
+    const auto mirrored = [](double sourceSeconds) {
+        return atSourceSecond(10000.0) - 1.0 - atSourceSecond(sourceSeconds);
+    };
+
+    SECTION("the first thing heard is the far end of what it reads") {
+        // Ten warp seconds of event, and past marker three the map runs at
+        // slope 1, so its far end is source second ten.
+        REQUIRE(readingAt(clip, 0.0) == approx(mirrored(10.0)));
+    }
+
+    SECTION("the bend is heard in the opposite order") {
+        REQUIRE(readingAt(clip, 7.0) == approx(mirrored(3.0)));
+        REQUIRE(readingAt(clip, 8.0) == approx(mirrored(2.5)));
+        REQUIRE(readingAt(clip, 9.0) == approx(mirrored(2.0)));
+        REQUIRE(readingAt(clip, 9.5) == approx(mirrored(1.0)));
+    }
+
+    SECTION("the reading still only moves forwards") {
+        auto last = readingAt(clip, 0.0);
+
+        for (double at = 0.05; at < 9.9; at += 0.05) {
+            const auto now = readingAt(clip, at);
+            REQUIRE(now > last);
+            last = now;
+        }
+    }
+}
+
+TEST_CASE("A warped loop bends the same way on every pass", "[engine][clip][warp]") {
+    auto clip = warpedClip();
+    auto& event = clip.events.front();
+    event.loopEnabled = true;
+    event.loopStartSamples = 0;
+    event.loopLengthSamples = static_cast<std::int64_t>(atSourceSecond(2.0));
+
+    // Source 0 to 2 is warp 0 to 1, so the loop is one warp second long.
+    SECTION("the second pass reads what the first did") {
+        REQUIRE(readingAt(clip, 1.5) == approx(readingAt(clip, 0.5)));
+        REQUIRE(readingAt(clip, 2.25) == approx(readingAt(clip, 0.25)));
+        REQUIRE(readingAt(clip, 5.75) == approx(readingAt(clip, 0.75)));
+    }
+
+    SECTION("and it is still the warped reading, not a straight one") {
+        REQUIRE(readingAt(clip, 0.25) == approx(atSourceSecond(0.5)));
+        REQUIRE(readingAt(clip, 1.25) == approx(atSourceSecond(0.5)));
+    }
+
+    SECTION("the reading chain does not tile it a second time") {
+        // Folding happens in warp time, above the map. Tiling below the stream
+        // as well would fold a position that had already been folded.
+        const auto how = magda::engine::sourceReadFor(event, kSampleRate);
+        REQUIRE(how.loopLengthSamples == 0);
+    }
+}
+
+TEST_CASE("An unwarped event is untouched by any of this", "[engine][clip][warp]") {
+    auto clip = warpedClip(500, {});
+    auto& event = clip.events.front();
+
+    REQUIRE(event.warp.empty());
+    REQUIRE(magda::engine::readingPositionAt(clip, event, 11.0, beatAt(11.0), kSampleRate) ==
+            approx(500.0 + kSampleRate));
+
+    SECTION("including one that loops, which still tiles below the stream") {
+        event.loopEnabled = true;
+        event.loopStartSamples = 0;
+        event.loopLengthSamples = static_cast<std::int64_t>(atSourceSecond(2.0));
+
+        const auto how = magda::engine::sourceReadFor(event, kSampleRate);
+        REQUIRE(how.loopLengthSamples == static_cast<std::int64_t>(atSourceSecond(2.0)));
+    }
+}

--- a/tests/test_source_loop_info.cpp
+++ b/tests/test_source_loop_info.cpp
@@ -117,6 +117,17 @@ TEST_CASE("A root note counts only when the file marked it as set", "[engine][io
         REQUIRE(*info.rootNote == 60);
     }
 
+    SECTION("a marked-as-set zero is note zero, not a silence") {
+        // The flag is the whole of the chunk's rule, and 0 is a legal note.
+        metadata.set(juce::WavAudioFormat::acidRootSet, "1");
+        metadata.set(juce::WavAudioFormat::acidRootNote, "0");
+
+        const auto info = loopInfoFrom(metadata, kSampleRate, kTwoSeconds);
+
+        REQUIRE(info.rootNote.has_value());
+        REQUIRE(*info.rootNote == 0);
+    }
+
     SECTION("a file with no acid chunk falls back to its sampler chunk") {
         juce::StringPairArray sampler;
         sampler.set("MidiUnityNote", "48");

--- a/tests/test_source_loop_info.cpp
+++ b/tests/test_source_loop_info.cpp
@@ -1,0 +1,189 @@
+#include <juce_audio_formats/juce_audio_formats.h>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "io/SourceLoopInfo.hpp"
+
+/**
+ * What a file says about its own tempo (#2038).
+ *
+ * The model seeds an event's interpretation from this and then owns it, and the
+ * seeding rule is that it never overwrites what the user set. That rule only
+ * works if "the file said nothing" is distinguishable from "the file said
+ * zero", which is why every field is optional and why most of what is below is
+ * about absence rather than about values.
+ *
+ * A metadata map rather than a file, because that is all the parse ever sees.
+ * No fixture, no format to register, and the acid chunks a loop library writes
+ * are reproducible here exactly.
+ */
+
+using magda::engine::loopInfoFrom;
+
+namespace {
+
+constexpr double kSampleRate = 44100.0;
+
+/// Two seconds, which at four beats is 120 bpm.
+constexpr std::int64_t kTwoSeconds = 88200;
+
+Catch::Approx approx(double value) {
+    return Catch::Approx(value).margin(1e-6);
+}
+
+juce::StringPairArray acid(double beats, const char* tempo = nullptr) {
+    juce::StringPairArray metadata;
+    metadata.set(juce::WavAudioFormat::acidBeats, juce::String(beats));
+
+    if (tempo != nullptr)
+        metadata.set(juce::WavAudioFormat::acidTempo, tempo);
+
+    return metadata;
+}
+
+}  // namespace
+
+TEST_CASE("A file that says nothing is read as having said nothing", "[engine][io][loop-info]") {
+    const auto info = loopInfoFrom({}, kSampleRate, kTwoSeconds);
+
+    REQUIRE_FALSE(info.bpm.has_value());
+    REQUIRE_FALSE(info.numBeats.has_value());
+    REQUIRE_FALSE(info.numerator.has_value());
+    REQUIRE_FALSE(info.denominator.has_value());
+    REQUIRE_FALSE(info.rootNote.has_value());
+    REQUIRE_FALSE(info.oneShot.has_value());
+}
+
+TEST_CASE("An acid chunk's beat count becomes a tempo", "[engine][io][loop-info]") {
+    const auto info = loopInfoFrom(acid(4.0), kSampleRate, kTwoSeconds);
+
+    REQUIRE(info.numBeats.has_value());
+    REQUIRE(*info.numBeats == approx(4.0));
+    REQUIRE(info.bpm.has_value());
+    REQUIRE(*info.bpm == approx(120.0));
+}
+
+TEST_CASE("A tempo the file wrote is believed over one worked out from its length",
+          "[engine][io][loop-info]") {
+    // Four beats over two seconds is 120, but the file says 174, and a file
+    // that wrote its tempo knows something a division does not.
+    const auto info = loopInfoFrom(acid(4.0, "174"), kSampleRate, kTwoSeconds);
+
+    REQUIRE(*info.bpm == approx(174.0));
+    REQUIRE(*info.numBeats == approx(4.0));
+}
+
+TEST_CASE("A tempo with no beat count gives one", "[engine][io][loop-info]") {
+    juce::StringPairArray metadata;
+    metadata.set(juce::WavAudioFormat::acidTempo, "120");
+
+    const auto info = loopInfoFrom(metadata, kSampleRate, kTwoSeconds);
+
+    REQUIRE(*info.bpm == approx(120.0));
+    REQUIRE(*info.numBeats == approx(4.0));
+}
+
+TEST_CASE("Nothing is inferred without a length to infer it from", "[engine][io][loop-info]") {
+    SECTION("no rate") {
+        const auto info = loopInfoFrom(acid(4.0), 0.0, kTwoSeconds);
+
+        REQUIRE(*info.numBeats == approx(4.0));
+        REQUIRE_FALSE(info.bpm.has_value());
+    }
+
+    SECTION("no samples") {
+        const auto info = loopInfoFrom(acid(4.0), kSampleRate, 0);
+
+        REQUIRE(*info.numBeats == approx(4.0));
+        REQUIRE_FALSE(info.bpm.has_value());
+    }
+}
+
+TEST_CASE("A root note counts only when the file marked it as set", "[engine][io][loop-info]") {
+    juce::StringPairArray metadata = acid(4.0);
+    metadata.set(juce::WavAudioFormat::acidRootNote, "60");
+
+    SECTION("unset means there is no root, whatever the note field holds") {
+        REQUIRE_FALSE(loopInfoFrom(metadata, kSampleRate, kTwoSeconds).rootNote.has_value());
+    }
+
+    SECTION("set means there is") {
+        metadata.set(juce::WavAudioFormat::acidRootSet, "1");
+
+        const auto info = loopInfoFrom(metadata, kSampleRate, kTwoSeconds);
+
+        REQUIRE(info.rootNote.has_value());
+        REQUIRE(*info.rootNote == 60);
+    }
+
+    SECTION("a file with no acid chunk falls back to its sampler chunk") {
+        juce::StringPairArray sampler;
+        sampler.set("MidiUnityNote", "48");
+
+        const auto info = loopInfoFrom(sampler, kSampleRate, kTwoSeconds);
+
+        REQUIRE(info.rootNote.has_value());
+        REQUIRE(*info.rootNote == 48);
+    }
+}
+
+TEST_CASE("A one shot says so rather than being guessed at", "[engine][io][loop-info]") {
+    juce::StringPairArray metadata = acid(4.0);
+
+    SECTION("absent") {
+        REQUIRE_FALSE(loopInfoFrom(metadata, kSampleRate, kTwoSeconds).oneShot.has_value());
+    }
+
+    SECTION("set") {
+        metadata.set(juce::WavAudioFormat::acidOneShot, "1");
+
+        const auto info = loopInfoFrom(metadata, kSampleRate, kTwoSeconds);
+
+        REQUIRE(info.oneShot.has_value());
+        REQUIRE(*info.oneShot);
+    }
+
+    SECTION("written and false") {
+        metadata.set(juce::WavAudioFormat::acidOneShot, "0");
+
+        const auto info = loopInfoFrom(metadata, kSampleRate, kTwoSeconds);
+
+        REQUIRE(info.oneShot.has_value());
+        REQUIRE_FALSE(*info.oneShot);
+    }
+}
+
+TEST_CASE("Time signatures come off either spelling", "[engine][io][loop-info]") {
+    SECTION("the acid chunk's two fields") {
+        juce::StringPairArray metadata = acid(4.0);
+        metadata.set(juce::WavAudioFormat::acidNumerator, "3");
+        metadata.set(juce::WavAudioFormat::acidDenominator, "4");
+
+        const auto info = loopInfoFrom(metadata, kSampleRate, kTwoSeconds);
+
+        REQUIRE(*info.numerator == 3);
+        REQUIRE(*info.denominator == 4);
+    }
+
+    SECTION("the plainer one AIFF writes") {
+        juce::StringPairArray metadata;
+        metadata.set("time signature", "6/8");
+
+        const auto info = loopInfoFrom(metadata, kSampleRate, kTwoSeconds);
+
+        REQUIRE(*info.denominator == 6);
+        REQUIRE(*info.numerator == 8);
+    }
+}
+
+TEST_CASE("An empty value said no more than a missing key", "[engine][io][loop-info]") {
+    juce::StringPairArray metadata;
+    metadata.set(juce::WavAudioFormat::acidBeats, "");
+    metadata.set(juce::WavAudioFormat::acidTempo, "");
+
+    const auto info = loopInfoFrom(metadata, kSampleRate, kTwoSeconds);
+
+    REQUIRE_FALSE(info.bpm.has_value());
+    REQUIRE_FALSE(info.numBeats.has_value());
+}

--- a/tests/test_source_loop_info.cpp
+++ b/tests/test_source_loop_info.cpp
@@ -166,15 +166,47 @@ TEST_CASE("Time signatures come off either spelling", "[engine][io][loop-info]")
         REQUIRE(*info.denominator == 4);
     }
 
-    SECTION("the plainer one AIFF writes") {
+    SECTION("the plainer one AIFF writes, numerator first") {
+        // The fork reads this one backwards (tracktion_LoopInfo.cpp assigns the
+        // left side to the denominator), and 6/8 is 6 over 8 everywhere else.
         juce::StringPairArray metadata;
         metadata.set("time signature", "6/8");
 
         const auto info = loopInfoFrom(metadata, kSampleRate, kTwoSeconds);
 
-        REQUIRE(*info.denominator == 6);
-        REQUIRE(*info.numerator == 8);
+        REQUIRE(*info.numerator == 6);
+        REQUIRE(*info.denominator == 8);
     }
+}
+
+TEST_CASE("A zero acid field says no more than a missing one", "[engine][io][loop-info]") {
+    // What a real file looks like: JUCE writes every acid field whenever a file
+    // has an acid chunk at all, zeros included, so a loop carrying a beat count
+    // and no tempo arrives with acidTempo set to "0".
+    juce::StringPairArray metadata;
+    metadata.set(juce::WavAudioFormat::acidBeats, "4");
+    metadata.set(juce::WavAudioFormat::acidTempo, "0");
+    metadata.set(juce::WavAudioFormat::acidNumerator, "0");
+    metadata.set(juce::WavAudioFormat::acidDenominator, "0");
+
+    const auto info = loopInfoFrom(metadata, kSampleRate, kTwoSeconds);
+
+    REQUIRE(*info.numBeats == approx(4.0));
+    REQUIRE(info.bpm.has_value());
+    REQUIRE(*info.bpm == approx(120.0));
+    REQUIRE_FALSE(info.numerator.has_value());
+    REQUIRE_FALSE(info.denominator.has_value());
+}
+
+TEST_CASE("A tempo with no beats works the same way round", "[engine][io][loop-info]") {
+    juce::StringPairArray metadata;
+    metadata.set(juce::WavAudioFormat::acidBeats, "0");
+    metadata.set(juce::WavAudioFormat::acidTempo, "120");
+
+    const auto info = loopInfoFrom(metadata, kSampleRate, kTwoSeconds);
+
+    REQUIRE(*info.bpm == approx(120.0));
+    REQUIRE(*info.numBeats == approx(4.0));
 }
 
 TEST_CASE("An empty value said no more than a missing key", "[engine][io][loop-info]") {

--- a/tests/test_transient_detector.cpp
+++ b/tests/test_transient_detector.cpp
@@ -29,8 +29,10 @@ namespace {
 constexpr double kSampleRate = 44100.0;
 
 /// Half a millisecond, which is how far back a trigger is placed from where the
-/// differentiated envelope crossed the threshold.
-constexpr int kRewindSamples = 22;
+/// differentiated envelope crossed the threshold. Rounded up, because the
+/// incumbent truncates after subtracting it rather than before: at 44100 the
+/// effective rewind is 23 samples, not 22.
+constexpr int kRewindSamples = 23;
 
 Catch::Approx approx(double value, double margin = 1e-4) {
     return Catch::Approx(value).margin(margin);

--- a/tests/test_transient_detector.cpp
+++ b/tests/test_transient_detector.cpp
@@ -1,0 +1,187 @@
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include <algorithm>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+#include "analysis/TransientDetector.hpp"
+
+/**
+ * Where a source's beats are, when the user has not said (#2038).
+ *
+ * Against a computed reader rather than a fixture, which is what the reader
+ * interface is narrow for: a click train whose impulses are at sample positions
+ * this file chose is a file whose right answer is known exactly, and no
+ * filesystem is involved in asking.
+ *
+ * The detector is the incumbent's, reproduced coefficient for coefficient, so
+ * what is asserted here is what that algorithm does rather than what a better
+ * one might: transients land on the attacks, quiet ones need sensitivity to be
+ * found, and nothing survives closer together than the spacing rule allows.
+ */
+
+using magda::engine::detectTransients;
+using magda::engine::TransientDetectionSettings;
+
+namespace {
+
+constexpr double kSampleRate = 44100.0;
+
+/// Half a millisecond, which is how far back a trigger is placed from where the
+/// differentiated envelope crossed the threshold.
+constexpr int kRewindSamples = 22;
+
+Catch::Approx approx(double value, double margin = 1e-4) {
+    return Catch::Approx(value).margin(margin);
+}
+
+/// Impulses at chosen positions and silence everywhere else. An attack with no
+/// body is the hardest thing to place and the easiest to check.
+class ClickReader final : public magda::engine::AudioFileReader {
+  public:
+    struct Click {
+        std::int64_t at = 0;
+        float amplitude = 1.0f;
+    };
+
+    ClickReader(std::vector<Click> clicks, std::int64_t length)
+        : clicks_(std::move(clicks)), length_(length) {}
+
+    std::int64_t lengthInSamples() const override {
+        return length_;
+    }
+    double sampleRate() const override {
+        return kSampleRate;
+    }
+    int numChannels() const override {
+        return 1;
+    }
+
+    int read(juce::AudioBuffer<float>& destination, int destinationOffset, std::int64_t startSample,
+             int numSamples) override {
+        destination.clear(destinationOffset, numSamples);
+
+        for (const auto& click : clicks_) {
+            const auto offset = click.at - startSample;
+
+            if (offset >= 0 && offset < numSamples)
+                for (auto channel = 0; channel < destination.getNumChannels(); ++channel)
+                    destination.setSample(channel, destinationOffset + static_cast<int>(offset),
+                                          click.amplitude);
+        }
+
+        return numSamples;
+    }
+
+  private:
+    std::vector<Click> clicks_;
+    std::int64_t length_;
+};
+
+/// Where a click at @p sample is expected to be reported.
+double expected(std::int64_t sample) {
+    return static_cast<double>(std::max<std::int64_t>(0, sample - kRewindSamples)) / kSampleRate;
+}
+
+}  // namespace
+
+TEST_CASE("A click train is found where its clicks are", "[engine][analysis]") {
+    ClickReader reader({{44100}, {88200}, {132300}}, 200000);
+
+    const auto transients = detectTransients(reader, {});
+
+    REQUIRE(transients.size() == 3);
+    REQUIRE(transients[0] == approx(expected(44100)));
+    REQUIRE(transients[1] == approx(expected(88200)));
+    REQUIRE(transients[2] == approx(expected(132300)));
+}
+
+TEST_CASE("A file with nothing in it has no transients", "[engine][analysis]") {
+    SECTION("silence") {
+        ClickReader reader({}, 200000);
+        REQUIRE(detectTransients(reader, {}).empty());
+    }
+
+    SECTION("no samples at all") {
+        ClickReader reader({{44100}}, 0);
+        REQUIRE(detectTransients(reader, {}).empty());
+    }
+}
+
+TEST_CASE("Sensitivity decides how quiet a transient may be", "[engine][analysis]") {
+    // Threshold runs from -10 dB at zero to -40 dB at one, against the file's
+    // own peak, so each of these needs more sensitivity than the last.
+    ClickReader reader({{44100, 1.0f}, {88200, 0.1f}, {132300, 0.02f}}, 200000);
+
+    TransientDetectionSettings settings;
+
+    settings.sensitivity = 0.0f;
+    const auto few = detectTransients(reader, settings);
+
+    settings.sensitivity = 0.5f;
+    const auto some = detectTransients(reader, settings);
+
+    settings.sensitivity = 1.0f;
+    const auto many = detectTransients(reader, settings);
+
+    REQUIRE(few.size() == 1);
+    REQUIRE(some.size() == 2);
+    REQUIRE(many.size() == 3);
+}
+
+TEST_CASE("A quiet recording has the same transients as a loud one", "[engine][analysis]") {
+    // The threshold is relative to the file's own peak, which is the whole
+    // reason there is a pass over it before anything is judged.
+    ClickReader loud({{44100, 1.0f}, {88200, 1.0f}}, 200000);
+    ClickReader quiet({{44100, 0.02f}, {88200, 0.02f}}, 200000);
+
+    REQUIRE(detectTransients(loud, {}).size() == detectTransients(quiet, {}).size());
+}
+
+TEST_CASE("Transients closer together than the spacing rule are thinned", "[engine][analysis]") {
+    SECTION("two inside the retrigger lockout only fire once") {
+        // 30 ms apart, and the detector will not fire again for 50.
+        //
+        // In fact for rather longer than 50: the lockout is re-armed by every
+        // sample over the threshold, and the last follower's release keeps an
+        // impulse over it for about 1400 samples, so an attack shuts the
+        // detector for something closer to 80 ms. Worth knowing rather than
+        // worth changing -- the spacing rule below is what actually decides
+        // what survives, and the incumbent has this property too.
+        ClickReader reader({{44100}, {44100 + 1323}}, 200000);
+
+        const auto transients = detectTransients(reader, {});
+
+        REQUIRE(transients.size() == 1);
+        REQUIRE(transients[0] == approx(expected(44100)));
+    }
+
+    SECTION("two past the lockout but inside the spacing keep the later") {
+        // 113 ms apart, which clears the lockout above, against a spacing rule
+        // of 150: both fire, and the thinning pass drops the first.
+        ClickReader reader({{44100}, {44100 + 5000}}, 200000);
+
+        TransientDetectionSettings settings;
+        settings.minimumSpacingSeconds = 0.15;
+
+        const auto transients = detectTransients(reader, settings);
+
+        REQUIRE(transients.size() == 1);
+        REQUIRE(transients[0] == approx(expected(44100 + 5000)));
+    }
+
+    SECTION("two beyond the spacing both survive") {
+        ClickReader reader({{44100}, {44100 + 8820}}, 200000);
+
+        REQUIRE(detectTransients(reader, {}).size() == 2);
+    }
+}
+
+TEST_CASE("Detection is deterministic", "[engine][analysis]") {
+    // Cached per source and per sensitivity by whoever calls this, which is only
+    // sound if two runs over one file agree.
+    ClickReader reader({{44100}, {88200}, {132300}}, 200000);
+
+    REQUIRE(detectTransients(reader, {}) == detectTransients(reader, {}));
+}


### PR DESCRIPTION
Slice 5 of #1890, after slice 4. Closes #2038.

Where a clip's own musical time comes from, and where it stops agreeing with the file's.

## Warp adds nothing below the position map

Slice 4 turned playback into one function. The voice already asks `readingPositionAt` at both ends of a block and hands the difference to the stretcher, so a ratio that changes at every marker costs nothing that a moving auto-tempo ratio did not. `ClipVoice`, the stretchers, the pool, the stream and the reading chain are untouched by this slice.

Signalsmith has no warp-marker API and does not need one: `process(inputs, inputSamples, outputs, outputSamples)` takes the ratio per call. Tracktion does not push markers into a stretcher either; `AudioSegmentList` chops the clip into constant-ratio segments.

`clip/WarpMap` compiles the model's `(sourceTime, warpTime)` pairs into the inverse playback needs: sorted, strictly increasing on both sides, coincident markers collapsed, and anything that cannot be part of a monotonic map dropped at compile time with a counted diagnostic rather than divided by on the audio thread. The snapshot carries that instead of the raw marker vector. A binary search rather than a cursor, because a locate breaks sequential stepping and a reversed read walks the map the other way.

## Reverse and warp compose, which the incumbent cannot

The fork bakes warp into a rendered proxy file and can only bake one thing per clip: `WaveAudioClip::createRenderJob` checks `getIsReversed()` first and returns the reverse job before it ever reaches the warp one, so a reversed warped clip there plays reversed and unwarped and its markers are silently lost. That is a constraint of the proxy architecture, not a semantic, and computing both live has no such constraint.

The map is **not** mirrored at compile time. A reversed event walks it backwards from the far end of what it reads and mirrors the answer, exactly as an unwarped reversed event's anchor is mirrored. Mirroring the map instead would need the length of the region the event reads, which is itself an answer from the map, and the two would define each other.

Removing that circularity fixes something older with it: `regionOf` was the event's span at unity, so slice 4 already placed a reversed **stretched** clip's anchor with the wrong region length. It is now the exact material the event consumes, warp and rate included.

## A warped loop folds in warp time

The one case where the reading chain cannot do its own tiling. Folding below the stream works because the reading advances linearly, and under warp it does not: a position that had already been through the map would fold in the wrong domain, the map would go on extending at slope 1 past the loop's end, and every pass after the first would play straight.

So a warped loop folds above the map and `sourceReadFor` leaves the tiling below switched off. The reading saws back at each wrap instead of climbing, which the stream reads as a seek: one per pass, bounded. This is reachable rather than theoretical, since a session clip dropped from the media DB with saved markers both loops and warps.

Stretcher sizing reads the map's steepest segment rather than its average, because a warped event has no single rate.

## The two analyses

**`analysis/TransientDetector`** is the fork's detector reproduced coefficient for coefficient: a normalise pass, two one-pole followers, a differentiator, a third follower, a threshold at `-10 - sensitivity * 30` dB, a retrigger lockout and a spacing rule. Time domain, not spectral. Reproduced rather than improved, because a detector that found different transients would move every auto-detected marker in every project that already has one.

**`io/SourceLoopInfo`** is not an analysis at all. The fork reads a source's tempo and beat count out of `juce::AudioFormatReader::metadataValues` -- the acid chunk that JUCE's `WavAudioFormat` already parses -- so this is a parse over a metadata map, testable with no fixture and no format registered. Every field is optional because the model's seeding rule (never overwrite what the user set) depends on telling a silence from a value.

Neither is wired to the model yet. `WarpMarkerManager` and the clip model still get both from Tracktion; swapping them over belongs with switching the engine on rather than with implementing it.

## Tests

`tests/test_clip_warp.cpp`, `tests/test_transient_detector.cpp`, `tests/test_source_loop_info.cpp`. All arithmetic, against numbers worked out by hand rather than against another run of the same code, and against computed readers rather than fixtures.

Full suite: 2305 cases, 560k assertions, 13 pre-existing Spleeter model-file skips.