### PR TITLE
OSC control surfaces: input path (#1757)

### DIFF
--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -510,6 +510,7 @@ set(MAGDA_JUCE_STACK
     juce::juce_audio_utils
     juce::juce_gui_basics
     juce::juce_gui_extra
+    juce::juce_osc  # OSC control surfaces (#1757); ships with JUCE, no new dependency
     tracktion::tracktion_engine
     juce_llm
 )

--- a/magda/daw/api/CMakeLists.txt
+++ b/magda/daw/api/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(magda_daw PRIVATE
     plugin_api_live.cpp
     device_api_live.cpp
     groove_api_live.cpp
+    osc_command_sink_live.cpp
     remote_api.cpp
     remote_api_projection.cpp
     remote_handlers.cpp

--- a/magda/daw/api/osc_command_sink_live.cpp
+++ b/magda/daw/api/osc_command_sink_live.cpp
@@ -2,6 +2,7 @@
 
 #include "../audio/controllers/ControllerParamWriter.hpp"
 #include "../core/ControlTarget.hpp"
+#include "../core/MixerStripOrder.hpp"
 #include "../core/TrackInfo.hpp"
 #include "focused_api.hpp"
 #include "magda_api.hpp"
@@ -26,23 +27,16 @@ OscCommandSinkLive::~OscCommandSinkLive() = default;
 // ============================================================================
 
 TrackId OscCommandSinkLive::trackAtPosition(int position) const {
-    if (position < 1)
-        return INVALID_TRACK_ID;
-
-    // Mixer visibility rather than the raw track list: the strips the user can
-    // see are the ones a mixer template is counting, and a hidden track would
-    // otherwise consume a fader that appears to do nothing. This is the same
-    // filter `TrackManager::getVisibleTracks` applies, walked through the
-    // facade so the sink has no second route into the model — and so it stops
-    // at the strip it wants rather than building the whole list to index once.
-    int seen = 0;
-    for (const auto& track : api_.tracks().getTracks()) {
-        if (!track.isVisibleIn(ViewMode::Mix))
-            continue;
-        if (++seen == position)
-            return track.id;
-    }
-    return INVALID_TRACK_ID;
+    // The mixer's own rule for what a strip is, not a second approximation of
+    // it: a hidden track, an aux return, or the child of a collapsed group all
+    // take no position, and getting any of them wrong lands a fader on the
+    // strip beside the one the user is looking at.
+    //
+    // Always ViewMode::Mix, even when the user is looking at another view. A
+    // surface's fader 3 must not become a different track because someone
+    // switched to the arrangement — the numbering a template was built against
+    // is the mixer's.
+    return mixerStripAtPosition(api_.tracks().getTracks(), ViewMode::Mix, position);
 }
 
 int OscCommandSinkLive::sendBusForPosition(TrackId trackId, int position) const {

--- a/magda/daw/api/osc_command_sink_live.cpp
+++ b/magda/daw/api/osc_command_sink_live.cpp
@@ -1,0 +1,148 @@
+#include "osc_command_sink_live.hpp"
+
+#include "../audio/controllers/ControllerParamWriter.hpp"
+#include "../core/ControlTarget.hpp"
+#include "../core/TrackInfo.hpp"
+#include "focused_api.hpp"
+#include "magda_api.hpp"
+#include "project_api.hpp"
+#include "track_api.hpp"
+#include "transport_api.hpp"
+
+namespace magda {
+
+using osc::OscCommand;
+using osc::OscCommandKind;
+
+OscCommandSinkLive::OscCommandSinkLive(MagdaApi& api, std::unique_ptr<ControllerParamWriter> writer)
+    : api_(api), writer_(std::move(writer)) {
+    jassert(writer_ != nullptr);
+}
+
+OscCommandSinkLive::~OscCommandSinkLive() = default;
+
+// ============================================================================
+// Addressing
+// ============================================================================
+
+TrackId OscCommandSinkLive::trackAtPosition(int position) const {
+    if (position < 1)
+        return INVALID_TRACK_ID;
+
+    // Mixer visibility rather than the raw track list: the strips the user can
+    // see are the ones a mixer template is counting, and a hidden track would
+    // otherwise consume a fader that appears to do nothing. This is the same
+    // filter `TrackManager::getVisibleTracks` applies, walked through the
+    // facade so the sink has no second route into the model — and so it stops
+    // at the strip it wants rather than building the whole list to index once.
+    int seen = 0;
+    for (const auto& track : api_.tracks().getTracks()) {
+        if (!track.isVisibleIn(ViewMode::Mix))
+            continue;
+        if (++seen == position)
+            return track.id;
+    }
+    return INVALID_TRACK_ID;
+}
+
+int OscCommandSinkLive::sendBusForPosition(TrackId trackId, int position) const {
+    const auto* track = api_.tracks().getTrack(trackId);
+    if (track == nullptr || position < 1 || position > static_cast<int>(track->sends.size()))
+        return -1;
+    return track->sends[static_cast<size_t>(position - 1)].busIndex;
+}
+
+bool OscCommandSinkLive::resolveToggle(float value, bool current) {
+    return value == osc::kOscToggleRequest ? !current : value != 0.0f;
+}
+
+void OscCommandSinkLive::writeLevel(const ControlTarget& target, float value) {
+    // The writer takes a resolved target; these are already concrete, so there
+    // is nothing for the alias/resolver machinery to do first.
+    ResolveResult resolved;
+    resolved.target = target;
+    resolved.resolved = true;
+    writer_->write(resolved, value);
+}
+
+// ============================================================================
+// Applying
+// ============================================================================
+
+void OscCommandSinkLive::apply(const OscCommand& command, float value) {
+    switch (command.kind) {
+        case OscCommandKind::TransportPlay:
+            api_.transport().play();
+            return;
+        case OscCommandKind::TransportStop:
+            api_.transport().stop();
+            return;
+        case OscCommandKind::TransportRecord:
+            api_.transport().setRecording(resolveToggle(value, api_.transport().isRecording()));
+            return;
+        case OscCommandKind::TransportLoop:
+            api_.transport().setLoopEnabled(resolveToggle(value, api_.transport().isLoopEnabled()));
+            return;
+        case OscCommandKind::TransportTempo:
+            // The facade clamps against the project's real tempo range; a
+            // surface sending 0 or 5000 is not this layer's to reinterpret.
+            api_.project().setTempo(value);
+            return;
+        case OscCommandKind::TransportPosition:
+            api_.transport().setPositionBeats(value);
+            return;
+
+        case OscCommandKind::MasterVolume:
+            writeLevel(ControlTarget::trackVolume(MASTER_TRACK_ID), value);
+            return;
+        case OscCommandKind::MasterPan:
+            writeLevel(ControlTarget::trackPan(MASTER_TRACK_ID), value);
+            return;
+
+        case OscCommandKind::FocusedMacro:
+            // OSC numbers macros from 1, the macro array from 0. With nothing
+            // focused this is a no-op inside the facade, which is the right
+            // answer for a knob the user has not pointed at anything yet.
+            api_.focused().setMacroValue(command.index - 1, value);
+            return;
+
+        case OscCommandKind::TrackVolume:
+        case OscCommandKind::TrackPan:
+        case OscCommandKind::TrackMute:
+        case OscCommandKind::TrackSolo:
+        case OscCommandKind::TrackSend:
+            break;  // handled below, once the position has a track behind it
+    }
+
+    const TrackId trackId = trackAtPosition(command.index);
+    if (trackId == INVALID_TRACK_ID)
+        return;  // a template with more strips than the project has tracks
+
+    switch (command.kind) {
+        case OscCommandKind::TrackVolume:
+            writeLevel(ControlTarget::trackVolume(trackId), value);
+            return;
+        case OscCommandKind::TrackPan:
+            writeLevel(ControlTarget::trackPan(trackId), value);
+            return;
+        case OscCommandKind::TrackMute:
+            if (const auto* track = api_.tracks().getTrack(trackId))
+                api_.tracks().setTrackMuted(trackId, resolveToggle(value, track->muted));
+            return;
+        case OscCommandKind::TrackSolo:
+            if (const auto* track = api_.tracks().getTrack(trackId))
+                api_.tracks().setTrackSoloed(trackId, resolveToggle(value, track->soloed));
+            return;
+        case OscCommandKind::TrackSend: {
+            const int bus = sendBusForPosition(trackId, command.subIndex);
+            if (bus >= 0)
+                writeLevel(ControlTarget::sendLevel(trackId, bus), value);
+            return;
+        }
+        default:
+            jassertfalse;  // the first switch returned for every other kind
+            return;
+    }
+}
+
+}  // namespace magda

--- a/magda/daw/api/osc_command_sink_live.hpp
+++ b/magda/daw/api/osc_command_sink_live.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <memory>
+
+#include "../audio/osc/OscRouter.hpp"
+#include "../core/TypeIds.hpp"
+
+namespace magda {
+
+class ControllerParamWriter;
+class MagdaApi;
+struct ControlTarget;
+
+/**
+ * @brief Applies the OSC fixed namespace to the running DAW (#1757).
+ *
+ * The `_live` half of the OSC stack, in the same sense as the rest of this
+ * directory: the routing above it is pure and testable, and this is where it
+ * meets real tracks. Called on the message thread, once per address per drain.
+ *
+ * ## Two paths, deliberately
+ *
+ * Levels — track and master volume and pan, sends — go through
+ * `ControllerParamWriter`, the same writer the MIDI control surfaces use. That
+ * is not reuse for its own sake: the writer maps a normalized value through the
+ * parameter's real range, so an OSC fader, a MIDI fader and an automation curve
+ * at the same position produce the same gain, and its host-write path keeps
+ * working when an LFO or macro is already driving the target.
+ *
+ * Everything else — transport, tempo, mute, solo, focused macros — goes through
+ * `MagdaApi`, because these are states rather than parameter values and the
+ * facade already routes them the way the on-screen controls do. Play in
+ * particular dispatches through the same playhead-aware path as the Play
+ * button, so a tablet and the transport bar cannot disagree about what Play
+ * means.
+ *
+ * ## Addressing
+ *
+ * `/magda/track/{n}` is the nth strip visible in the mixer, and
+ * `/magda/track/{n}/send/{m}` its mth send, both 1-based. Positions rather than
+ * IDs, because IDs are sparse and a template's eight strips are not: deleting a
+ * track renumbers what follows it, which is exactly what a surface showing
+ * eight faders expects. A position with no track behind it is ignored — a
+ * sixteen-strip template pointed at an eight-track project drives eight faders
+ * rather than failing.
+ */
+class OscCommandSinkLive : public osc::OscCommandSink {
+  public:
+    /**
+     * @param api     The facade. Must outlive this sink.
+     * @param writer  Where level writes go. Owned, because the sink is
+     *                constructed once alongside the OSC service and a borrowed
+     *                writer would tie its lifetime to the MIDI router's.
+     */
+    OscCommandSinkLive(MagdaApi& api, std::unique_ptr<ControllerParamWriter> writer);
+    ~OscCommandSinkLive() override;
+
+    OscCommandSinkLive(const OscCommandSinkLive&) = delete;
+    OscCommandSinkLive& operator=(const OscCommandSinkLive&) = delete;
+
+    void apply(const osc::OscCommand& command, float value) override;
+
+  private:
+    /// The TrackId at a 1-based mixer position, or INVALID_TRACK_ID when the
+    /// project has no strip there.
+    TrackId trackAtPosition(int position) const;
+
+    /// The aux bus a track's 1-based nth send uses, or -1 when it has none.
+    /// Sends are addressed by position for the same reason tracks are; bus
+    /// indices are what the model writes through.
+    int sendBusForPosition(TrackId trackId, int position) const;
+
+    /// `value` as a boolean state: a set 0/1, or `current` inverted when the
+    /// surface asked for a flip by sending no argument at all.
+    static bool resolveToggle(float value, bool current);
+
+    void writeLevel(const ControlTarget& target, float value);
+
+    MagdaApi& api_;
+    std::unique_ptr<ControllerParamWriter> writer_;
+};
+
+}  // namespace magda

--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -430,6 +430,10 @@ target_sources(magda_daw PRIVATE
     # Controller routing (issue #1050 -- Phase C)
     controllers/ControllerParamWriter.cpp
     controllers/ControllerRouter.cpp
+    # OSC control surfaces (issue #1757)
+    osc/OscAddress.cpp
+    osc/OscRouter.cpp
+    osc/OscService.cpp
     # Headers (listed for IDE visibility)
     AudioBridge.hpp
     session/SessionClipScheduler.hpp

--- a/magda/daw/audio/controllers/ControllerParamWriter.cpp
+++ b/magda/daw/audio/controllers/ControllerParamWriter.cpp
@@ -40,10 +40,12 @@ void DefaultControllerParamWriter::write(const ResolveResult& resolved, float va
             writeTrackLevel(resolved.target, clamped);
             break;
         case ControlTarget::Kind::SendLevel:
+            writeSendLevel(resolved.target, clamped);
+            break;
         case ControlTarget::Kind::Tempo:
-            // Not reachable from controller bindings yet: no resolver produces
-            // either kind for a control surface. Wire them here alongside
-            // writeTrackLevel when one does.
+            // Not reachable from a control surface yet: OSC sets tempo through
+            // ProjectApi, which is where the project's own limits live. Wire it
+            // here alongside writeTrackLevel when something needs the target.
             break;
     }
 }
@@ -71,6 +73,22 @@ void DefaultControllerParamWriter::writeTrackLevel(const ControlTarget& target, 
     } else {
         trackMgr.setTrackPan(trackId, real);
     }
+}
+
+// Send levels, through TrackManager for the same reason track levels are: the
+// setter keeps TrackInfo in sync and notifies the mixer. The normalized -> dB
+// -> linear-gain mapping is the one AutomationPlaybackEngine applies to the
+// same target kind, so a send driven by a control surface and one driven by a
+// curve land on the same value.
+void DefaultControllerParamWriter::writeSendLevel(const ControlTarget& target, float clamped) {
+    const auto trackId = target.devicePath.trackId;
+    if (trackId == INVALID_TRACK_ID || target.sendBusIndex < 0)
+        return;
+
+    const ParameterInfo info = getParameterInfoForTarget(target);
+    const float real = ParameterUtils::normalizedToReal(clamped, info);
+    TrackManager::getInstance().setSendLevel(trackId, target.sendBusIndex,
+                                             std::pow(10.0f, real / 20.0f));
 }
 
 void DefaultControllerParamWriter::writePluginParam(const ControlTarget& target, float clamped) {

--- a/magda/daw/audio/controllers/ControllerParamWriter.hpp
+++ b/magda/daw/audio/controllers/ControllerParamWriter.hpp
@@ -57,6 +57,7 @@ class DefaultControllerParamWriter : public ControllerParamWriter {
     void writeMacro(const ControlTarget& target, float clamped);
     void writeModParam(const ControlTarget& target, float clamped);
     void writeTrackLevel(const ControlTarget& target, float clamped);
+    void writeSendLevel(const ControlTarget& target, float clamped);
 
     AudioBridge& bridge_;
 };

--- a/magda/daw/audio/osc/OscAddress.cpp
+++ b/magda/daw/audio/osc/OscAddress.cpp
@@ -4,6 +4,61 @@ namespace magda::osc {
 
 namespace {
 
+/// The deepest address in the namespace is `/magda/track/{n}/send/{m}`.
+constexpr int kMaxSegments = 5;
+
+/**
+ * @brief One '/'-delimited component, pointing into the caller's address.
+ *
+ * A view rather than a copy: parsing runs on the receive thread for every
+ * datagram, and splitting into `juce::String`s would allocate once per
+ * component per message — a per-packet cost paid to look at a handful of bytes.
+ */
+struct Segment {
+    const char* data = nullptr;
+    int length = 0;
+
+    bool equals(const char* literal) const {
+        int i = 0;
+        for (; i < length; ++i)
+            if (literal[i] == '\0' || literal[i] != data[i])
+                return false;
+        return literal[i] == '\0';
+    }
+};
+
+/**
+ * @brief Split an address into its components without allocating.
+ *
+ * @return the number of components, -1 when the address is not well formed
+ *         (OSC addresses begin with '/'), or a count above `kMaxSegments` when
+ *         it is deeper than anything in the namespace.
+ *
+ * Bytes are compared raw. A multi-byte UTF-8 sequence matches no literal here
+ * and parses as no digit, which is the answer we want for it anyway.
+ */
+int splitAddress(juce::StringRef address, Segment* out) {
+    const char* cursor = address.text.getAddress();
+    if (cursor == nullptr || *cursor != '/')
+        return -1;
+    ++cursor;
+
+    int count = 0;
+    const char* segmentStart = cursor;
+    for (;; ++cursor) {
+        if (*cursor != '/' && *cursor != '\0')
+            continue;
+        if (count == kMaxSegments)
+            return kMaxSegments + 1;
+        out[count].data = segmentStart;
+        out[count].length = static_cast<int>(cursor - segmentStart);
+        ++count;
+        if (*cursor == '\0')
+            return count;
+        segmentStart = cursor + 1;
+    }
+}
+
 /**
  * @brief Parse a strictly decimal 1-based index, or 0 if it is not one.
  *
@@ -13,18 +68,18 @@ namespace {
  * rejected too, so one address means one thing: "/magda/track/03/volume" is not
  * a second spelling of track 3.
  */
-int parseIndex(const juce::String& token, int maxValue) {
-    if (token.isEmpty() || token.length() > 3)
+int parseIndex(const Segment& token, int maxValue) {
+    if (token.length <= 0 || token.length > 3)
         return 0;
-    if (token[0] == '0')  // covers "0" itself and any leading-zero spelling
+    if (token.data[0] == '0')  // covers "0" itself and any leading-zero spelling
         return 0;
 
     int value = 0;
-    for (int i = 0; i < token.length(); ++i) {
-        const auto c = token[i];
+    for (int i = 0; i < token.length; ++i) {
+        const char c = token.data[i];
         if (c < '0' || c > '9')
             return 0;
-        value = value * 10 + (c - '0');
+        value = (value * 10) + (c - '0');
     }
     return value <= maxValue ? value : 0;
 }
@@ -69,77 +124,75 @@ OscArgKind argKindFor(OscCommandKind kind) {
 // ============================================================================
 
 std::optional<OscCommand> parseOscAddress(juce::StringRef address) {
-    // Split rather than match incrementally: the grammar is three to five
-    // components deep and every branch needs the component count anyway.
-    auto parts = juce::StringArray::fromTokens(juce::String(address), "/", "");
-    // A well-formed OSC address starts with '/', so the first token is empty.
-    if (parts.size() < 3 || parts[0].isNotEmpty())
+    Segment parts[kMaxSegments];
+    const int count = splitAddress(address, parts);
+    if (count < 2 || count > kMaxSegments)
         return std::nullopt;
-    if (parts[1] != "magda")
+    if (!parts[0].equals("magda"))
         return std::nullopt;
 
-    const auto& section = parts[2];
+    const auto& section = parts[1];
 
-    if (section == "transport") {
-        if (parts.size() != 4)
+    if (section.equals("transport")) {
+        if (count != 3)
             return std::nullopt;
-        const auto& leaf = parts[3];
-        if (leaf == "play")
+        const auto& leaf = parts[2];
+        if (leaf.equals("play"))
             return unindexed(OscCommandKind::TransportPlay);
-        if (leaf == "stop")
+        if (leaf.equals("stop"))
             return unindexed(OscCommandKind::TransportStop);
-        if (leaf == "record")
+        if (leaf.equals("record"))
             return unindexed(OscCommandKind::TransportRecord);
-        if (leaf == "loop")
+        if (leaf.equals("loop"))
             return unindexed(OscCommandKind::TransportLoop);
-        if (leaf == "tempo")
+        if (leaf.equals("tempo"))
             return unindexed(OscCommandKind::TransportTempo);
-        if (leaf == "position")
+        if (leaf.equals("position"))
             return unindexed(OscCommandKind::TransportPosition);
         return std::nullopt;
     }
 
-    if (section == "master") {
-        if (parts.size() != 4)
+    if (section.equals("master")) {
+        if (count != 3)
             return std::nullopt;
-        if (parts[3] == "volume")
+        if (parts[2].equals("volume"))
             return unindexed(OscCommandKind::MasterVolume);
-        if (parts[3] == "pan")
+        if (parts[2].equals("pan"))
             return unindexed(OscCommandKind::MasterPan);
         return std::nullopt;
     }
 
-    if (section == "focused") {
+    if (section.equals("focused")) {
         // Only macros today. A second focused address would branch here.
-        if (parts.size() != 5 || parts[3] != "macro")
+        if (count != 4 || !parts[2].equals("macro"))
             return std::nullopt;
-        const int macro = parseIndex(parts[4], kMaxMacroNumber);
+        const int macro = parseIndex(parts[3], kMaxMacroNumber);
         return macro > 0 ? std::optional(OscCommand{OscCommandKind::FocusedMacro, macro, 0})
                          : std::nullopt;
     }
 
-    if (section == "track") {
-        if (parts.size() < 5)
+    if (section.equals("track")) {
+        if (count < 4)
             return std::nullopt;
-        const int track = parseIndex(parts[3], kMaxTrackNumber);
+        const int track = parseIndex(parts[2], kMaxTrackNumber);
         if (track == 0)
             return std::nullopt;
 
-        const auto& leaf = parts[4];
-        if (parts.size() == 5) {
-            if (leaf == "volume")
+        const auto& leaf = parts[3];
+        if (count == 4) {
+            if (leaf.equals("volume"))
                 return OscCommand{OscCommandKind::TrackVolume, track, 0};
-            if (leaf == "pan")
+            if (leaf.equals("pan"))
                 return OscCommand{OscCommandKind::TrackPan, track, 0};
-            if (leaf == "mute")
+            if (leaf.equals("mute"))
                 return OscCommand{OscCommandKind::TrackMute, track, 0};
-            if (leaf == "solo")
+            if (leaf.equals("solo"))
                 return OscCommand{OscCommandKind::TrackSolo, track, 0};
             return std::nullopt;
         }
 
-        if (parts.size() == 6 && leaf == "send") {
-            const int send = parseIndex(parts[5], kMaxSendNumber);
+        if (count == 5 && leaf.equals("send")) {
+            const int send = parseIndex(parts[4], kMaxSendNumber);
             return send > 0 ? std::optional(OscCommand{OscCommandKind::TrackSend, track, send})
                             : std::nullopt;
         }

--- a/magda/daw/audio/osc/OscAddress.cpp
+++ b/magda/daw/audio/osc/OscAddress.cpp
@@ -1,0 +1,212 @@
+#include "osc/OscAddress.hpp"
+
+namespace magda::osc {
+
+namespace {
+
+/**
+ * @brief Parse a strictly decimal 1-based index, or 0 if it is not one.
+ *
+ * Deliberately not `String::getIntValue`, which answers 0 for "abc", 3 for
+ * "3x" and 3 for "3.7" — every one of which would turn a malformed or
+ * pattern-bearing address into a plausible-looking command. Leading zeros are
+ * rejected too, so one address means one thing: "/magda/track/03/volume" is not
+ * a second spelling of track 3.
+ */
+int parseIndex(const juce::String& token, int maxValue) {
+    if (token.isEmpty() || token.length() > 3)
+        return 0;
+    if (token[0] == '0')  // covers "0" itself and any leading-zero spelling
+        return 0;
+
+    int value = 0;
+    for (int i = 0; i < token.length(); ++i) {
+        const auto c = token[i];
+        if (c < '0' || c > '9')
+            return 0;
+        value = value * 10 + (c - '0');
+    }
+    return value <= maxValue ? value : 0;
+}
+
+OscCommand unindexed(OscCommandKind kind) {
+    return OscCommand{kind, 0, 0};
+}
+
+}  // namespace
+
+// ============================================================================
+// Argument conventions
+// ============================================================================
+
+OscArgKind argKindFor(OscCommandKind kind) {
+    switch (kind) {
+        case OscCommandKind::TransportPlay:
+        case OscCommandKind::TransportStop:
+            return OscArgKind::Trigger;
+        case OscCommandKind::TransportRecord:
+        case OscCommandKind::TransportLoop:
+        case OscCommandKind::TrackMute:
+        case OscCommandKind::TrackSolo:
+            return OscArgKind::Toggle;
+        case OscCommandKind::TransportTempo:
+            return OscArgKind::Bpm;
+        case OscCommandKind::TransportPosition:
+            return OscArgKind::Beats;
+        case OscCommandKind::MasterVolume:
+        case OscCommandKind::MasterPan:
+        case OscCommandKind::FocusedMacro:
+        case OscCommandKind::TrackVolume:
+        case OscCommandKind::TrackPan:
+        case OscCommandKind::TrackSend:
+            return OscArgKind::Normalized;
+    }
+    return OscArgKind::Normalized;
+}
+
+// ============================================================================
+// Parsing
+// ============================================================================
+
+std::optional<OscCommand> parseOscAddress(juce::StringRef address) {
+    // Split rather than match incrementally: the grammar is three to five
+    // components deep and every branch needs the component count anyway.
+    auto parts = juce::StringArray::fromTokens(juce::String(address), "/", "");
+    // A well-formed OSC address starts with '/', so the first token is empty.
+    if (parts.size() < 3 || parts[0].isNotEmpty())
+        return std::nullopt;
+    if (parts[1] != "magda")
+        return std::nullopt;
+
+    const auto& section = parts[2];
+
+    if (section == "transport") {
+        if (parts.size() != 4)
+            return std::nullopt;
+        const auto& leaf = parts[3];
+        if (leaf == "play")
+            return unindexed(OscCommandKind::TransportPlay);
+        if (leaf == "stop")
+            return unindexed(OscCommandKind::TransportStop);
+        if (leaf == "record")
+            return unindexed(OscCommandKind::TransportRecord);
+        if (leaf == "loop")
+            return unindexed(OscCommandKind::TransportLoop);
+        if (leaf == "tempo")
+            return unindexed(OscCommandKind::TransportTempo);
+        if (leaf == "position")
+            return unindexed(OscCommandKind::TransportPosition);
+        return std::nullopt;
+    }
+
+    if (section == "master") {
+        if (parts.size() != 4)
+            return std::nullopt;
+        if (parts[3] == "volume")
+            return unindexed(OscCommandKind::MasterVolume);
+        if (parts[3] == "pan")
+            return unindexed(OscCommandKind::MasterPan);
+        return std::nullopt;
+    }
+
+    if (section == "focused") {
+        // Only macros today. A second focused address would branch here.
+        if (parts.size() != 5 || parts[3] != "macro")
+            return std::nullopt;
+        const int macro = parseIndex(parts[4], kMaxMacroNumber);
+        return macro > 0 ? std::optional(OscCommand{OscCommandKind::FocusedMacro, macro, 0})
+                         : std::nullopt;
+    }
+
+    if (section == "track") {
+        if (parts.size() < 5)
+            return std::nullopt;
+        const int track = parseIndex(parts[3], kMaxTrackNumber);
+        if (track == 0)
+            return std::nullopt;
+
+        const auto& leaf = parts[4];
+        if (parts.size() == 5) {
+            if (leaf == "volume")
+                return OscCommand{OscCommandKind::TrackVolume, track, 0};
+            if (leaf == "pan")
+                return OscCommand{OscCommandKind::TrackPan, track, 0};
+            if (leaf == "mute")
+                return OscCommand{OscCommandKind::TrackMute, track, 0};
+            if (leaf == "solo")
+                return OscCommand{OscCommandKind::TrackSolo, track, 0};
+            return std::nullopt;
+        }
+
+        if (parts.size() == 6 && leaf == "send") {
+            const int send = parseIndex(parts[5], kMaxSendNumber);
+            return send > 0 ? std::optional(OscCommand{OscCommandKind::TrackSend, track, send})
+                            : std::nullopt;
+        }
+        return std::nullopt;
+    }
+
+    return std::nullopt;
+}
+
+// ============================================================================
+// Slot mapping
+// ============================================================================
+
+static_assert(static_cast<int>(OscCommandKind::MasterPan) + 1 == kOscUnindexedSlots,
+              "The unindexed kinds must be the leading run of OscCommandKind for the "
+              "identity mapping below to hold");
+
+int oscSlotIndex(const OscCommand& command) {
+    const int kindOrdinal = static_cast<int>(command.kind);
+    if (kindOrdinal < kOscUnindexedSlots)
+        return kindOrdinal;
+
+    if (command.kind == OscCommandKind::FocusedMacro)
+        return kOscUnindexedSlots + command.index - 1;
+
+    const int trackBase = kOscTrackSlotBase + ((command.index - 1) * kOscPerTrackSlots);
+    switch (command.kind) {
+        case OscCommandKind::TrackVolume:
+            return trackBase;
+        case OscCommandKind::TrackPan:
+            return trackBase + 1;
+        case OscCommandKind::TrackMute:
+            return trackBase + 2;
+        case OscCommandKind::TrackSolo:
+            return trackBase + 3;
+        case OscCommandKind::TrackSend:
+            return trackBase + 4 + command.subIndex - 1;
+        default:
+            break;
+    }
+    jassertfalse;  // every kind is covered above
+    return 0;
+}
+
+OscCommand oscCommandForSlot(int slot) {
+    jassert(slot >= 0 && slot < kOscSlotCount);
+
+    if (slot < kOscUnindexedSlots)
+        return unindexed(static_cast<OscCommandKind>(slot));
+
+    if (slot < kOscTrackSlotBase)
+        return OscCommand{OscCommandKind::FocusedMacro, slot - kOscUnindexedSlots + 1, 0};
+
+    const int trackOffset = slot - kOscTrackSlotBase;
+    const int track = (trackOffset / kOscPerTrackSlots) + 1;
+    switch (const int withinTrack = trackOffset % kOscPerTrackSlots) {
+        case 0:
+            return OscCommand{OscCommandKind::TrackVolume, track, 0};
+        case 1:
+            return OscCommand{OscCommandKind::TrackPan, track, 0};
+        case 2:
+            return OscCommand{OscCommandKind::TrackMute, track, 0};
+        case 3:
+            return OscCommand{OscCommandKind::TrackSolo, track, 0};
+        default:
+            return OscCommand{OscCommandKind::TrackSend, track, withinTrack - 4 + 1};
+    }
+}
+
+}  // namespace magda::osc

--- a/magda/daw/audio/osc/OscAddress.hpp
+++ b/magda/daw/audio/osc/OscAddress.hpp
@@ -1,0 +1,185 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <cstdint>
+#include <optional>
+
+namespace magda::osc {
+
+// ============================================================================
+// The fixed namespace (#1757)
+// ============================================================================
+
+/**
+ * @brief MAGDA's built-in OSC address space, parsed into a value type.
+ *
+ * This is the layer that makes a stock TouchOSC mixer template work with no
+ * mapping step: every address below is understood out of the box, so the
+ * surface needs no per-control setup and MAGDA needs no learn gesture. Bindings
+ * to arbitrary parameters are a separate mechanism layered on top; anything
+ * this parser rejects is left for that path rather than being an error.
+ *
+ * | Address                    | Argument         | Meaning                    |
+ * |----------------------------|------------------|----------------------------|
+ * | `/magda/transport/play`    | none or non-zero | start playback             |
+ * | `/magda/transport/stop`    | none or non-zero | stop playback              |
+ * | `/magda/transport/record`  | 0/1, or none     | recording on/off, or flip  |
+ * | `/magda/transport/loop`    | 0/1, or none     | loop on/off, or flip       |
+ * | `/magda/transport/tempo`   | float BPM        | set tempo                  |
+ * | `/magda/transport/position`| float beats      | locate                     |
+ * | `/magda/track/{n}/volume`  | float 0–1        | track fader                |
+ * | `/magda/track/{n}/pan`     | float 0–1        | pan, 0.5 centre            |
+ * | `/magda/track/{n}/mute`    | 0/1, or none     | mute on/off, or flip       |
+ * | `/magda/track/{n}/solo`    | 0/1, or none     | solo on/off, or flip       |
+ * | `/magda/track/{n}/send/{m}`| float 0–1        | send level                 |
+ * | `/magda/master/volume`     | float 0–1        | master fader               |
+ * | `/magda/master/pan`        | float 0–1        | master pan                 |
+ * | `/magda/focused/macro/{k}` | float 0–1        | macro of the focused device|
+ *
+ * `n`, `m` and `k` are 1-based, because that is how surface templates and
+ * mixer strips are numbered. `n` is a position in the mixer's visible track
+ * order rather than a `TrackId`: IDs survive a reload but are sparse — delete
+ * tracks 2 and 3 and the remaining ones are 1, 4, 5 — and a template that
+ * addresses eight strips needs eight dense numbers. Resolving a position to a
+ * track happens at apply time, on the message thread.
+ *
+ * Parsing is deliberately strict: an address carrying a wildcard where the
+ * track number belongs is rejected, and so is `/magda/track/03/volume`. OSC
+ * address *patterns* are a real part of the protocol, and quietly reading one
+ * as an index would mean a surface driving every track at once when its author
+ * meant one — or two spellings of the same strip drifting apart.
+ */
+
+/// Highest 1-based track number the fixed namespace addresses. Positions past
+/// this are ignored rather than clamped — clamping would land a fader on track
+/// 128 because a template was misconfigured. It also bounds the coalescing
+/// table (see `oscSlotIndex`), which is why it is a constant rather than the
+/// live track count: an address is valid or not on its own terms, before
+/// anyone asks whether that track exists.
+inline constexpr int kMaxTrackNumber = 128;
+
+/// Matches `TrackManager::MAX_SENDS_PER_TRACK`, the Tracktion Engine aux limit.
+inline constexpr int kMaxSendNumber = 8;
+
+/// Matches `NUM_MACROS`, the macro count on a device's macro array.
+inline constexpr int kMaxMacroNumber = 16;
+
+enum class OscCommandKind : std::uint8_t {
+    TransportPlay,
+    TransportStop,
+    TransportRecord,
+    TransportLoop,
+    TransportTempo,
+    TransportPosition,
+    MasterVolume,
+    MasterPan,
+    FocusedMacro,
+    TrackVolume,
+    TrackPan,
+    TrackMute,
+    TrackSolo,
+    TrackSend,
+};
+
+/**
+ * @brief What a command does with the argument it is sent, if any.
+ *
+ * The distinction exists because touch surfaces send two different things down
+ * one address. A momentary button sends 1 on press and 0 on release; a toggle
+ * button sends 1 and 0 as the state itself. Reading both the same way would
+ * make releasing the Play button stop the transport.
+ */
+enum class OscArgKind : std::uint8_t {
+    /// Acts on press. No argument, or a non-zero one, fires; a zero argument is
+    /// the release half of a momentary button and does nothing.
+    Trigger,
+    /// A state. 0 or 1 sets it; sending no argument at all flips whatever the
+    /// state currently is, so a momentary button works as well as a toggle.
+    Toggle,
+    /// A float in [0,1], clamped on the way in. What faders, knobs and XY pads
+    /// send.
+    Normalized,
+    /// A float in beats per minute.
+    Bpm,
+    /// A float position in beats — MAGDA's timeline unit everywhere.
+    Beats,
+};
+
+/**
+ * @brief One parsed address from the fixed namespace.
+ *
+ * `index` is the 1-based track or macro number, `subIndex` the 1-based send
+ * number. Both are 0 for kinds that address nothing — transport and master.
+ */
+struct OscCommand {
+    OscCommandKind kind{};
+    int index = 0;
+    int subIndex = 0;
+
+    bool operator==(const OscCommand&) const = default;
+};
+
+/** The argument convention for a kind. Total: every kind has one. */
+OscArgKind argKindFor(OscCommandKind kind);
+
+/**
+ * @brief Parse a fixed-namespace address, or reject it.
+ *
+ * Pure, allocation-light and free of any socket or model dependency, so the
+ * whole grammar is testable without opening a port.
+ *
+ * Returns nullopt for anything outside the namespace: a different prefix, an
+ * unknown leaf, a wildcard, a non-numeric or out-of-range index, or a trailing
+ * component the address does not take. Rejection is not an error — a binding
+ * may still match the address.
+ */
+std::optional<OscCommand> parseOscAddress(juce::StringRef address);
+
+// ============================================================================
+// Coalescing slots
+// ============================================================================
+
+/**
+ * @brief A command's index into the latest-value-wins table.
+ *
+ * The address space is fixed — bounded by the constants above and independent
+ * of how many tracks currently exist — so every command maps to a slot known at
+ * compile time. That is what lets the receive thread coalesce without a map,
+ * a lock, or an allocation: `/magda/track/3/volume` is slot 3's volume whether
+ * or not a third track is there to receive it.
+ *
+ * Always in `[0, kOscSlotCount)` for a command from `parseOscAddress`.
+ */
+int oscSlotIndex(const OscCommand& command);
+
+/**
+ * @brief The command a slot belongs to — the inverse of `oscSlotIndex`.
+ *
+ * Arithmetic rather than a stored table, which is what keeps the coalescing
+ * table free of any per-slot bookkeeping the receive thread would have to
+ * write: it publishes a value and a bit, and the drain recovers the rest.
+ *
+ * `slot` must be in `[0, kOscSlotCount)`.
+ */
+OscCommand oscCommandForSlot(int slot);
+
+/// The six transport kinds and the two master kinds are the first eight
+/// entries of `OscCommandKind`, and take the first eight slots in that order.
+inline constexpr int kOscUnindexedSlots = 8;
+/// Then the focused device's macros, then one block per addressable track:
+/// volume, pan, mute, solo, and one slot per send.
+inline constexpr int kOscTrackSlotBase = kOscUnindexedSlots + kMaxMacroNumber;
+inline constexpr int kOscPerTrackSlots = 4 + kMaxSendNumber;
+inline constexpr int kOscSlotCount = kOscTrackSlotBase + (kMaxTrackNumber * kOscPerTrackSlots);
+
+/**
+ * @brief The value a slot holds when a `Toggle` arrived with no argument.
+ *
+ * Toggles otherwise carry 0 or 1, so a negative sentinel cannot collide with a
+ * real value, and the drain can tell "set it off" from "flip it" out of a
+ * single atomic float.
+ */
+inline constexpr float kOscToggleRequest = -1.0f;
+
+}  // namespace magda::osc

--- a/magda/daw/audio/osc/OscRouter.cpp
+++ b/magda/daw/audio/osc/OscRouter.cpp
@@ -1,0 +1,165 @@
+#include "osc/OscRouter.hpp"
+
+#include <juce_events/juce_events.h>
+
+#include <bit>
+
+namespace magda::osc {
+
+namespace {
+
+/**
+ * @brief The first argument that carries a number, if the message has one.
+ *
+ * Only the first is considered. Surfaces that send several — an XY pad, a
+ * multi-touch fader bank — address each value separately in this namespace, so
+ * a second argument means the sender is speaking a dialect we do not have a
+ * mapping for, and guessing which of its numbers we wanted would be worse than
+ * taking the one it put first.
+ */
+std::optional<float> firstNumericArgument(const juce::OSCMessage& message) {
+    for (const auto& argument : message) {
+        if (argument.isFloat32())
+            return argument.getFloat32();
+        if (argument.isInt32())
+            return static_cast<float>(argument.getInt32());
+        break;
+    }
+    return std::nullopt;
+}
+
+}  // namespace
+
+// ============================================================================
+// Argument extraction
+// ============================================================================
+
+std::optional<float> oscValueFor(const OscCommand& command, const juce::OSCMessage& message) {
+    const auto argument = firstNumericArgument(message);
+
+    switch (argKindFor(command.kind)) {
+        case OscArgKind::Trigger:
+            // A momentary button sends 1 on press and 0 on release. Acting on
+            // the release would make holding Play stop the transport when the
+            // finger came off.
+            if (argument.has_value() && *argument == 0.0f)
+                return std::nullopt;
+            return 1.0f;
+
+        case OscArgKind::Toggle:
+            if (!argument.has_value())
+                return kOscToggleRequest;
+            return *argument != 0.0f ? 1.0f : 0.0f;
+
+        case OscArgKind::Normalized:
+            if (!argument.has_value())
+                return std::nullopt;
+            return juce::jlimit(0.0f, 1.0f, *argument);
+
+        case OscArgKind::Bpm:
+        case OscArgKind::Beats:
+            // Ranges belong to the model, which clamps against the project's
+            // real limits; a tempo of 0 is not this layer's to reinterpret.
+            return argument;
+    }
+    return std::nullopt;
+}
+
+// ============================================================================
+// OscRouter
+// ============================================================================
+
+OscRouter::OscRouter(std::unique_ptr<OscCommandSink> sink)
+    : sink_(std::move(sink)), scheduler_([this]() { postDrain(); }) {
+    jassert(sink_ != nullptr);
+}
+
+OscRouter::~OscRouter() {
+    alive_->store(false, std::memory_order_release);
+}
+
+bool OscRouter::handleMessage(const juce::OSCMessage& message) {
+    const auto command = parseOscAddress(message.getAddressPattern().toString());
+    if (!command.has_value())
+        return false;
+
+    const auto value = oscValueFor(*command, message);
+    if (!value.has_value())
+        return false;
+
+    accepted_.fetch_add(1, std::memory_order_relaxed);
+    submit(*command, *value);
+    return true;
+}
+
+void OscRouter::submit(const OscCommand& command, float value) {
+    const int slot = oscSlotIndex(command);
+    jassert(slot >= 0 && slot < kOscSlotCount);
+
+    // Value first, then the bit that advertises it: a drain that observes the
+    // bit is guaranteed to observe at least this value, and a store it misses
+    // leaves the bit set for the next one.
+    values_[static_cast<size_t>(slot)].store(value, std::memory_order_relaxed);
+    dirty_[static_cast<size_t>(slot / 64)].fetch_or(1ULL << (slot % 64), std::memory_order_release);
+    scheduleDrain();
+}
+
+void OscRouter::scheduleDrain() {
+    bool expected = false;
+    if (!drainScheduled_.compare_exchange_strong(expected, true, std::memory_order_acq_rel))
+        return;  // a drain is already posted and will pick this up
+
+    scheduler_();
+}
+
+void OscRouter::postDrain() {
+    // Headless hosts and any caller already on the message thread apply inline:
+    // there is no loop to post to, and hopping would defer the write forever.
+    auto* manager = juce::MessageManager::getInstanceWithoutCreating();
+    if (manager == nullptr || manager->isThisTheMessageThread()) {
+        drainPending();
+        return;
+    }
+
+    juce::MessageManager::callAsync([this, alive = alive_]() {
+        if (alive->load(std::memory_order_acquire))
+            drainPending();
+    });
+}
+
+void OscRouter::drainPending() {
+    // Released before the walk, not after. A value published while we are
+    // partway through the table has to be able to schedule the next drain —
+    // if it could not, it would sit unapplied until the surface moved again,
+    // which for a fader the user has just let go of means the wrong value
+    // staying on screen.
+    drainScheduled_.store(false, std::memory_order_release);
+
+    for (int word = 0; word < kDirtyWords; ++word) {
+        auto bits = dirty_[static_cast<size_t>(word)].exchange(0, std::memory_order_acquire);
+        while (bits != 0) {
+            const int slot = (word * 64) + std::countr_zero(bits);
+            bits &= bits - 1;
+            sink_->apply(oscCommandForSlot(slot),
+                         values_[static_cast<size_t>(slot)].load(std::memory_order_relaxed));
+        }
+    }
+}
+
+void OscRouter::setSink(std::unique_ptr<OscCommandSink> sink) {
+    jassert(sink != nullptr);
+    if (sink != nullptr)
+        sink_ = std::move(sink);
+}
+
+void OscRouter::setDrainScheduler(std::function<void()> scheduler) {
+    jassert(scheduler != nullptr);
+    if (scheduler != nullptr)
+        scheduler_ = std::move(scheduler);
+}
+
+std::uint64_t OscRouter::acceptedMessageCount() const {
+    return accepted_.load(std::memory_order_relaxed);
+}
+
+}  // namespace magda::osc

--- a/magda/daw/audio/osc/OscRouter.cpp
+++ b/magda/daw/audio/osc/OscRouter.cpp
@@ -234,7 +234,41 @@ void OscRouter::drainOrdered() {
     // than leaving those commands until the surface is touched again.
     if (orderedRead_.load(std::memory_order_relaxed) !=
         orderedWrite_.load(std::memory_order_acquire))
-        scheduleDrain();
+        requestFollowUpDrain();
+}
+
+void OscRouter::requestFollowUpDrain() {
+    bool expected = false;
+    if (!drainScheduled_.compare_exchange_strong(expected, true, std::memory_order_acq_rel))
+        return;  // a drain is already posted and will pick this up
+
+    // Deliberately not `scheduleDrain`, which would run the configured
+    // scheduler — and the default one applies inline when it is already on the
+    // message thread, which here it always is. That would re-enter
+    // `drainPending` one stack level per batch without ever returning to the
+    // event loop, so a sender that keeps the ring non-empty would hold the
+    // message thread and grow the stack: precisely the failure the per-drain
+    // cap exists to prevent. The cap only bounds anything if the remainder
+    // waits its turn behind other events, which means going through the queue.
+    //
+    // Reachable only across threads, and not by much: a producer publishes its
+    // write index before it calls `scheduleDrain`, so a drain that reads the
+    // index inside that gap finds work pending with the scheduled flag still
+    // clear. Rare is not the same as impossible, and stack safety should not
+    // rest on that ordering happening to hold.
+    //
+    // With no message loop there is nothing to post to. A headless host drives
+    // drains itself, so the remainder waits for the next explicit one rather
+    // than recursing here.
+    if (juce::MessageManager::getInstanceWithoutCreating() == nullptr) {
+        drainScheduled_.store(false, std::memory_order_release);
+        return;
+    }
+
+    juce::MessageManager::callAsync([this, alive = alive_]() {
+        if (alive->load(std::memory_order_acquire))
+            drainPending();
+    });
 }
 
 void OscRouter::setSink(std::unique_ptr<OscCommandSink> sink) {

--- a/magda/daw/audio/osc/OscRouter.cpp
+++ b/magda/daw/audio/osc/OscRouter.cpp
@@ -3,29 +3,58 @@
 #include <juce_events/juce_events.h>
 
 #include <bit>
+#include <cmath>
 
 namespace magda::osc {
 
 namespace {
 
 /**
- * @brief The first argument that carries a number, if the message has one.
+ * @brief What the message had to say, which is not the same as what it carried.
+ *
+ * Three outcomes, and the difference between the last two is load-bearing.
+ * `Absent` is a bare message, which for a toggle *is* the request — flip
+ * whatever the state is. `Unusable` is a message that carried something we
+ * cannot read. Collapsing the two would let a surface speaking an unknown
+ * dialect flip a mute by sending a word where a number belongs.
+ */
+enum class ArgumentState : std::uint8_t { Absent, Unusable, Present };
+
+struct MessageArgument {
+    ArgumentState state = ArgumentState::Absent;
+    float value = 0.0f;
+};
+
+/**
+ * @brief The message's first argument, if it is a number we can act on.
  *
  * Only the first is considered. Surfaces that send several — an XY pad, a
  * multi-touch fader bank — address each value separately in this namespace, so
  * a second argument means the sender is speaking a dialect we do not have a
  * mapping for, and guessing which of its numbers we wanted would be worse than
  * taking the one it put first.
+ *
+ * Non-finite values are rejected rather than passed on. A float32 argument is
+ * free to be NaN or an infinity, `jlimit` propagates NaN rather than clamping
+ * it, and this is an unauthenticated UDP port — so without this check a single
+ * stray packet writes NaN into a fader, a pan, a macro, or the playhead.
  */
-std::optional<float> firstNumericArgument(const juce::OSCMessage& message) {
-    for (const auto& argument : message) {
-        if (argument.isFloat32())
-            return argument.getFloat32();
-        if (argument.isInt32())
-            return static_cast<float>(argument.getInt32());
-        break;
-    }
-    return std::nullopt;
+MessageArgument firstNumericArgument(const juce::OSCMessage& message) {
+    if (message.isEmpty())
+        return {ArgumentState::Absent, 0.0f};
+
+    const auto& argument = message[0];
+    float value = 0.0f;
+    if (argument.isFloat32())
+        value = argument.getFloat32();
+    else if (argument.isInt32())
+        value = static_cast<float>(argument.getInt32());
+    else
+        return {ArgumentState::Unusable, 0.0f};
+
+    if (!std::isfinite(value))
+        return {ArgumentState::Unusable, 0.0f};
+    return {ArgumentState::Present, value};
 }
 
 }  // namespace
@@ -37,30 +66,35 @@ std::optional<float> firstNumericArgument(const juce::OSCMessage& message) {
 std::optional<float> oscValueFor(const OscCommand& command, const juce::OSCMessage& message) {
     const auto argument = firstNumericArgument(message);
 
+    if (argument.state == ArgumentState::Unusable)
+        return std::nullopt;
+
     switch (argKindFor(command.kind)) {
         case OscArgKind::Trigger:
             // A momentary button sends 1 on press and 0 on release. Acting on
             // the release would make holding Play stop the transport when the
             // finger came off.
-            if (argument.has_value() && *argument == 0.0f)
+            if (argument.state == ArgumentState::Present && argument.value == 0.0f)
                 return std::nullopt;
             return 1.0f;
 
         case OscArgKind::Toggle:
-            if (!argument.has_value())
+            if (argument.state == ArgumentState::Absent)
                 return kOscToggleRequest;
-            return *argument != 0.0f ? 1.0f : 0.0f;
+            return argument.value != 0.0f ? 1.0f : 0.0f;
 
         case OscArgKind::Normalized:
-            if (!argument.has_value())
+            if (argument.state != ArgumentState::Present)
                 return std::nullopt;
-            return juce::jlimit(0.0f, 1.0f, *argument);
+            return juce::jlimit(0.0f, 1.0f, argument.value);
 
         case OscArgKind::Bpm:
         case OscArgKind::Beats:
             // Ranges belong to the model, which clamps against the project's
             // real limits; a tempo of 0 is not this layer's to reinterpret.
-            return argument;
+            if (argument.state != ArgumentState::Present)
+                return std::nullopt;
+            return argument.value;
     }
     return std::nullopt;
 }
@@ -79,7 +113,12 @@ OscRouter::~OscRouter() {
 }
 
 bool OscRouter::handleMessage(const juce::OSCMessage& message) {
-    const auto command = parseOscAddress(message.getAddressPattern().toString());
+    // Named rather than inlined into the call: the parser reads through the
+    // StringRef into this buffer, so it has to outlive the parse. Copying a
+    // juce::String is a reference-count bump, so this costs no allocation.
+    const auto address = message.getAddressPattern().toString();
+
+    const auto command = parseOscAddress(address);
     if (!command.has_value())
         return false;
 
@@ -93,6 +132,15 @@ bool OscRouter::handleMessage(const juce::OSCMessage& message) {
 }
 
 void OscRouter::submit(const OscCommand& command, float value) {
+    const auto argKind = argKindFor(command.kind);
+    if (argKind == OscArgKind::Trigger || argKind == OscArgKind::Toggle) {
+        // An edge, not a value. Two flips of one toggle have to stay two, and
+        // play and stop have to resolve by arrival rather than by slot number.
+        pushOrdered(command, value);
+        scheduleDrain();
+        return;
+    }
+
     const int slot = oscSlotIndex(command);
     jassert(slot >= 0 && slot < kOscSlotCount);
 
@@ -102,6 +150,23 @@ void OscRouter::submit(const OscCommand& command, float value) {
     values_[static_cast<size_t>(slot)].store(value, std::memory_order_relaxed);
     dirty_[static_cast<size_t>(slot / 64)].fetch_or(1ULL << (slot % 64), std::memory_order_release);
     scheduleDrain();
+}
+
+bool OscRouter::pushOrdered(const OscCommand& command, float value) {
+    const auto write = orderedWrite_.load(std::memory_order_relaxed);
+    const auto read = orderedRead_.load(std::memory_order_acquire);
+    if (write - read >= kOrderedCapacity) {
+        // Dropping the newest keeps what is already queued in order. Nothing a
+        // person can press fills this; a sender that does is flooding, and the
+        // counter is how that becomes visible rather than silent.
+        dropped_.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+
+    ordered_[write & (kOrderedCapacity - 1)] = OrderedCommand{command, value};
+    // Publishes the entry along with the index that advertises it.
+    orderedWrite_.store(write + 1, std::memory_order_release);
+    return true;
 }
 
 void OscRouter::scheduleDrain() {
@@ -144,6 +209,32 @@ void OscRouter::drainPending() {
                          values_[static_cast<size_t>(slot)].load(std::memory_order_relaxed));
         }
     }
+
+    // Values first, then edges. A cue that locates and rolls in one bundle
+    // should locate before the transport acts on it, rather than rolling from
+    // the old position and jumping.
+    drainOrdered();
+}
+
+void OscRouter::drainOrdered() {
+    // Bounded per drain so a sender cannot hold the message thread inside this
+    // loop indefinitely by pushing as fast as it is consumed.
+    for (std::uint32_t applied = 0; applied < kOrderedCapacity; ++applied) {
+        const auto read = orderedRead_.load(std::memory_order_relaxed);
+        if (read == orderedWrite_.load(std::memory_order_acquire))
+            return;
+
+        const auto entry = ordered_[read & (kOrderedCapacity - 1)];
+        orderedRead_.store(read + 1, std::memory_order_release);
+        sink_->apply(entry.command, entry.value);
+    }
+
+    // Hit the cap with work still queued. Whoever pushed the remainder may have
+    // found the drain already scheduled, so ask for the next one here rather
+    // than leaving those commands until the surface is touched again.
+    if (orderedRead_.load(std::memory_order_relaxed) !=
+        orderedWrite_.load(std::memory_order_acquire))
+        scheduleDrain();
 }
 
 void OscRouter::setSink(std::unique_ptr<OscCommandSink> sink) {
@@ -160,6 +251,10 @@ void OscRouter::setDrainScheduler(std::function<void()> scheduler) {
 
 std::uint64_t OscRouter::acceptedMessageCount() const {
     return accepted_.load(std::memory_order_relaxed);
+}
+
+std::uint64_t OscRouter::droppedCommandCount() const {
+    return dropped_.load(std::memory_order_relaxed);
 }
 
 }  // namespace magda::osc

--- a/magda/daw/audio/osc/OscRouter.hpp
+++ b/magda/daw/audio/osc/OscRouter.hpp
@@ -1,0 +1,181 @@
+#pragma once
+
+#include <juce_osc/juce_osc.h>
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+
+#include "osc/OscAddress.hpp"
+
+namespace magda::osc {
+
+// ============================================================================
+// OscCommandSink
+// ============================================================================
+
+/**
+ * @brief Where a drained command is applied.
+ *
+ * The seam between "an OSC message arrived and survived coalescing" and "the
+ * DAW changed", so the routing above it is testable without an engine, a
+ * project, or a socket. `apply` is always called on the message thread.
+ */
+class OscCommandSink {
+  public:
+    virtual ~OscCommandSink() = default;
+
+    /**
+     * @param command  What was addressed.
+     * @param value    Its latest value, in the convention `argKindFor(kind)`
+     *                 names: a normalized level, a BPM, a beat position, 0/1
+     *                 for a set toggle, `kOscToggleRequest` for one to flip, or
+     *                 1 for a trigger that fired.
+     */
+    virtual void apply(const OscCommand& command, float value) = 0;
+};
+
+// ============================================================================
+// Argument extraction
+// ============================================================================
+
+/**
+ * @brief What a message means for the command its address named.
+ *
+ * Returns nullopt when the message should be ignored: the release half of a
+ * momentary button, or a value-carrying address sent without a number to carry
+ * (a bare `/magda/track/1/volume` says nothing about where the fader is).
+ *
+ * Int and float arguments are both accepted because surfaces disagree about
+ * which to send for a button, and a template that works in TouchOSC should not
+ * fail in Open Stage Control over the type tag of a 1.
+ */
+std::optional<float> oscValueFor(const OscCommand& command, const juce::OSCMessage& message);
+
+// ============================================================================
+// OscRouter
+// ============================================================================
+
+/**
+ * @brief Turns a stream of OSC messages into message-thread parameter writes.
+ *
+ * ## Why this coalesces
+ *
+ * A tablet mixer sends continuously while a finger is down — a fader stream at
+ * 100 Hz per control is the normal case, not the adversarial one, and eight
+ * strips moving at once is a chord change. Posting each message to the message
+ * thread would put the DAW's UI thread on the far end of a network firehose,
+ * and posting each one *in order* would mean the user's last fader position
+ * waiting behind several hundred stale ones.
+ *
+ * So the receive thread does not post messages; it publishes values. Every
+ * address in the fixed namespace owns a slot (`oscSlotIndex`), a store into
+ * that slot overwrites whatever had not been applied yet, and the message
+ * thread drains the whole table at once. What lands is the most recent value
+ * per address, at whatever rate the message thread can absorb, and the cost of
+ * a faster surface is finer resolution rather than a longer queue.
+ *
+ * The consequence worth knowing is that values are not applied in arrival
+ * order across different addresses — a drain walks slots. Within one address
+ * order is preserved trivially, because only the latest value exists. This is
+ * the standard control-surface tradeoff and it is why the namespace carries
+ * levels and states rather than anything sequenced.
+ *
+ * ## Threading
+ *
+ * `handleMessage` runs on the OSC receive thread. It allocates nothing, takes
+ * no lock, and touches only atomics — a slow or blocked message thread makes
+ * MAGDA coarser, never the network thread slower. At most one drain is ever
+ * outstanding, whatever the message rate.
+ *
+ * Nothing here touches the audio thread; parameter writes reach it through the
+ * same host-write path the MIDI control surfaces use.
+ */
+class OscRouter {
+  public:
+    explicit OscRouter(std::unique_ptr<OscCommandSink> sink);
+    ~OscRouter();
+
+    OscRouter(const OscRouter&) = delete;
+    OscRouter& operator=(const OscRouter&) = delete;
+
+    /**
+     * @brief Receive-thread entry point.
+     *
+     * @return true when the address was in the fixed namespace and the message
+     *         was accepted. False means the message was not ours — an unknown
+     *         address, or a known one carrying nothing usable — which is
+     *         information for a caller that wants to offer it to bindings, not
+     *         an error.
+     */
+    bool handleMessage(const juce::OSCMessage& message);
+
+    /**
+     * @brief Apply everything pending right now, on the calling thread.
+     *
+     * The message thread reaches this through the scheduled drain. It is public
+     * because tests drive it directly, and because a caller shutting the
+     * service down can flush rather than strand the last fader position.
+     */
+    void drainPending();
+
+    /** Replace the sink. Message thread only, and not while a drain is running. */
+    void setSink(std::unique_ptr<OscCommandSink> sink);
+
+    /**
+     * @brief How a pending drain reaches the message thread.
+     *
+     * Defaults to posting one, or running it inline when the caller is already
+     * on the message thread and when there is no message loop at all — the
+     * headless case, where deferring would mean never applying.
+     *
+     * A test replaces it to hold the drain instead of running it, which is the
+     * only way to observe what coalescing kept: applied inline, every value
+     * lands as it arrives and the table never holds more than one at a time.
+     * Set before any message is handled.
+     */
+    void setDrainScheduler(std::function<void()> scheduler);
+
+    /// Messages accepted since construction, for the settings UI and tests —
+    /// "is anything actually arriving?" is the first question a surface that
+    /// will not talk to MAGDA raises.
+    std::uint64_t acceptedMessageCount() const;
+
+  private:
+    /// 64 slots per word, rounded up.
+    static constexpr int kDirtyWords = (kOscSlotCount + 63) / 64;
+
+    void submit(const OscCommand& command, float value);
+    void scheduleDrain();
+    void postDrain();
+
+    std::unique_ptr<OscCommandSink> sink_;
+    std::function<void()> scheduler_;
+
+    /// Latest unapplied value per address. Written by the receive thread, read
+    /// by the drain; a torn read is impossible and a stale one is corrected by
+    /// the next store, which re-dirties the slot.
+    std::array<std::atomic<float>, kOscSlotCount> values_{};
+
+    /// Which slots have something to apply. A bitmap rather than a queue so the
+    /// receive thread's publish is one `fetch_or` and repeated writes to one
+    /// address cost nothing extra.
+    std::array<std::atomic<std::uint64_t>, kDirtyWords> dirty_{};
+
+    /// Whether a drain is already posted. Cleared at the *start* of the drain,
+    /// not the end: a value published while the drain is walking the table must
+    /// be able to schedule the next one, or it would sit in its slot until the
+    /// surface happened to move again.
+    std::atomic<bool> drainScheduled_{false};
+
+    std::atomic<std::uint64_t> accepted_{0};
+
+    /// Cleared before the object dies so a drain still sitting in the message
+    /// queue completes without touching it.
+    std::shared_ptr<std::atomic<bool>> alive_{std::make_shared<std::atomic<bool>>(true)};
+};
+
+}  // namespace magda::osc

--- a/magda/daw/audio/osc/OscRouter.hpp
+++ b/magda/daw/audio/osc/OscRouter.hpp
@@ -62,7 +62,7 @@ std::optional<float> oscValueFor(const OscCommand& command, const juce::OSCMessa
 /**
  * @brief Turns a stream of OSC messages into message-thread parameter writes.
  *
- * ## Why this coalesces
+ * ## Two kinds of traffic, two paths
  *
  * A tablet mixer sends continuously while a finger is down — a fader stream at
  * 100 Hz per control is the normal case, not the adversarial one, and eight
@@ -71,25 +71,45 @@ std::optional<float> oscValueFor(const OscCommand& command, const juce::OSCMessa
  * and posting each one *in order* would mean the user's last fader position
  * waiting behind several hundred stale ones.
  *
- * So the receive thread does not post messages; it publishes values. Every
- * address in the fixed namespace owns a slot (`oscSlotIndex`), a store into
- * that slot overwrites whatever had not been applied yet, and the message
- * thread drains the whole table at once. What lands is the most recent value
- * per address, at whatever rate the message thread can absorb, and the cost of
- * a faster surface is finer resolution rather than a longer queue.
+ * So a **continuous value** — a level, a tempo, a beat position — is not
+ * posted, it is published. Every address in the fixed namespace owns a slot
+ * (`oscSlotIndex`), a store into that slot overwrites whatever had not been
+ * applied yet, and the message thread drains the whole table at once. What
+ * lands is the most recent value per address, at whatever rate the message
+ * thread can absorb, and the cost of a faster surface is finer resolution
+ * rather than a longer queue.
  *
- * The consequence worth knowing is that values are not applied in arrival
- * order across different addresses — a drain walks slots. Within one address
- * order is preserved trivially, because only the latest value exists. This is
- * the standard control-surface tradeoff and it is why the namespace carries
- * levels and states rather than anything sequenced.
+ * A **discrete command** — a trigger or a toggle — cannot be treated that way,
+ * because it is an edge rather than a value and latest-value-wins is the wrong
+ * algebra for edges. Two bare mute messages are two flips and should cancel;
+ * collapsing them into one slot leaves the track muted. Worse, `play` and
+ * `stop` are two addresses over one state, so resolving them by slot order
+ * rather than arrival order makes a bundle of `[stop, position, play]` — an
+ * ordinary show-control cue, delivered atomically into a single drain — land
+ * stopped. So triggers and toggles go into a small bounded ring in arrival
+ * order instead, which is affordable precisely because they come from fingers
+ * and buttons rather than from a fader stream.
+ *
+ * The drain applies the coalesced values first and the ordered commands after.
+ * That is the useful order for the cue above: the locate lands, then the
+ * transport acts on it, rather than rolling from the old position and jumping.
+ *
+ * What remains is that two *continuous* addresses are not applied in arrival
+ * order relative to each other — a drain walks slots. Within one address order
+ * is preserved trivially, because only the latest value exists. That is the
+ * standard control-surface tradeoff, and with edges moved off this path there
+ * is no longer a pair of addresses whose relative order changes the outcome.
  *
  * ## Threading
  *
- * `handleMessage` runs on the OSC receive thread. It allocates nothing, takes
- * no lock, and touches only atomics — a slow or blocked message thread makes
- * MAGDA coarser, never the network thread slower. At most one drain is ever
- * outstanding, whatever the message rate.
+ * `handleMessage` runs on the OSC receive thread. It takes no lock and, apart
+ * from the one `callAsync` that carries a drain to the message thread, it
+ * allocates nothing: parsing is a scan over the address bytes, and publishing
+ * is a store plus an atomic bit. Because at most one drain is outstanding at a
+ * time, that single allocation is bounded by the drain rate rather than by the
+ * message rate — a surface sending faster cannot make the receive thread
+ * allocate more. A slow or blocked message thread makes MAGDA coarser, never
+ * the network thread slower.
  *
  * Nothing here touches the audio thread; parameter writes reach it through the
  * same host-write path the MIDI control surfaces use.
@@ -144,13 +164,38 @@ class OscRouter {
     /// will not talk to MAGDA raises.
     std::uint64_t acceptedMessageCount() const;
 
+    /// Discrete commands dropped because the ordered ring was full. Non-zero
+    /// means a sender outran the message thread with buttons, which no surface
+    /// driven by fingers can do — so it reads as a flood rather than as use.
+    std::uint64_t droppedCommandCount() const;
+
   private:
     /// 64 slots per word, rounded up.
     static constexpr int kDirtyWords = (kOscSlotCount + 63) / 64;
 
+    /// Depth of the ordered ring, a power of two so the wrap is a mask.
+    ///
+    /// Sized above the whole discrete address space — every track's mute and
+    /// solo, plus the transport's four — so a surface can state-dump every
+    /// button it owns in one bundle and lose none of it. That is the realistic
+    /// worst case; past it, a sender is outrunning the message thread with
+    /// buttons, which fingers cannot do. Bounded so that costs a fixed amount
+    /// of memory and some dropped presses rather than unbounded growth.
+    static constexpr std::uint32_t kOrderedCapacity = 512;
+    static_assert(kOrderedCapacity > (kMaxTrackNumber * 2) + 4,
+                  "the ring must hold one press of every discrete address at once");
+
+    /// Applied in arrival order, ahead of nothing and behind the value table.
+    struct OrderedCommand {
+        OscCommand command;
+        float value = 0.0f;
+    };
+
     void submit(const OscCommand& command, float value);
     void scheduleDrain();
     void postDrain();
+    bool pushOrdered(const OscCommand& command, float value);
+    void drainOrdered();
 
     std::unique_ptr<OscCommandSink> sink_;
     std::function<void()> scheduler_;
@@ -171,7 +216,15 @@ class OscRouter {
     /// surface happened to move again.
     std::atomic<bool> drainScheduled_{false};
 
+    /// Triggers and toggles, in the order they arrived. Single-producer: one
+    /// `OSCReceiver` owns one receive thread, and `handleMessage` is documented
+    /// as that thread's entry point. Single-consumer: the drain.
+    std::array<OrderedCommand, kOrderedCapacity> ordered_{};
+    std::atomic<std::uint32_t> orderedWrite_{0};
+    std::atomic<std::uint32_t> orderedRead_{0};
+
     std::atomic<std::uint64_t> accepted_{0};
+    std::atomic<std::uint64_t> dropped_{0};
 
     /// Cleared before the object dies so a drain still sitting in the message
     /// queue completes without touching it.

--- a/magda/daw/audio/osc/OscRouter.hpp
+++ b/magda/daw/audio/osc/OscRouter.hpp
@@ -125,6 +125,13 @@ class OscRouter {
     /**
      * @brief Receive-thread entry point.
      *
+     * **One caller at a time.** The ordered ring below is single-producer, and
+     * this is the only thing that writes to it. That holds today because a
+     * service owns one `OSCReceiver` and therefore one receive thread, and
+     * because rebinding stops the old thread before the new one starts — but
+     * it is an invariant of this method rather than an accident of the caller,
+     * and a second concurrent caller would corrupt the ring silently.
+     *
      * @return true when the address was in the fixed namespace and the message
      *         was accepted. False means the message was not ours — an unknown
      *         address, or a known one carrying nothing usable — which is
@@ -169,11 +176,10 @@ class OscRouter {
     /// driven by fingers can do — so it reads as a flood rather than as use.
     std::uint64_t droppedCommandCount() const;
 
-  private:
-    /// 64 slots per word, rounded up.
-    static constexpr int kDirtyWords = (kOscSlotCount + 63) / 64;
-
-    /// Depth of the ordered ring, a power of two so the wrap is a mask.
+    /// Depth of the ordered ring, and the most discrete commands one drain
+    /// applies before yielding. Public because it is a characteristic of the
+    /// class rather than an implementation detail: it bounds both how much a
+    /// burst can carry and how long the message thread stays inside a drain.
     ///
     /// Sized above the whole discrete address space — every track's mute and
     /// solo, plus the transport's four — so a surface can state-dump every
@@ -185,6 +191,10 @@ class OscRouter {
     static_assert(kOrderedCapacity > (kMaxTrackNumber * 2) + 4,
                   "the ring must hold one press of every discrete address at once");
 
+  private:
+    /// 64 slots per word, rounded up.
+    static constexpr int kDirtyWords = (kOscSlotCount + 63) / 64;
+
     /// Applied in arrival order, ahead of nothing and behind the value table.
     struct OrderedCommand {
         OscCommand command;
@@ -194,6 +204,7 @@ class OscRouter {
     void submit(const OscCommand& command, float value);
     void scheduleDrain();
     void postDrain();
+    void requestFollowUpDrain();
     bool pushOrdered(const OscCommand& command, float value);
     void drainOrdered();
 

--- a/magda/daw/audio/osc/OscService.cpp
+++ b/magda/daw/audio/osc/OscService.cpp
@@ -1,0 +1,139 @@
+#include "osc/OscService.hpp"
+
+namespace magda::osc {
+
+namespace {
+
+/// How deep a nested bundle is followed before it is treated as hostile.
+/// Bundles legitimately nest one or two levels; a stream that nests further is
+/// either broken or trying to make the receive thread recurse for free.
+constexpr int kMaxBundleDepth = 8;
+
+}  // namespace
+
+OscService::OscService(std::unique_ptr<OscRouter> router) : router_(std::move(router)) {
+    jassert(router_ != nullptr);
+}
+
+OscService::~OscService() {
+    Config::getInstance().removeListener(this);
+    close();
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+bool OscService::applyConfig() {
+    auto& config = Config::getInstance();
+
+    // Registering here rather than in the constructor means a service that is
+    // never started never observes config at all.
+    config.removeListener(this);
+    config.addListener(this);
+
+    if (!config.getOscEnabled()) {
+        close();
+        return false;
+    }
+
+    const int port = config.getOscReceivePort();
+    const auto address = juce::String(config.getOscBindAddress());
+
+    // Already where it should be: leave the socket alone. Rebinding on every
+    // config save would drop whatever a surface was in the middle of sending.
+    //
+    // Compared against what was *asked* for, not what was bound. A configured
+    // port of 0 means "any free port", and the two differ by definition — so
+    // comparing the bound port would find a mismatch every time and rebind on
+    // every unrelated config save.
+    if (isListening() && port == requestedPort_ && address == boundAddress_)
+        return true;
+
+    close();
+    return open(port, address);
+}
+
+void OscService::configChanged() {
+    applyConfig();
+}
+
+// ============================================================================
+// Socket lifecycle
+// ============================================================================
+
+bool OscService::open(int port, const juce::String& address) {
+    jassert(receiver_ == nullptr);
+
+    auto socket = std::make_unique<juce::DatagramSocket>(/*enableBroadcasting*/ false);
+    const bool bound =
+        address.isEmpty() ? socket->bindToPort(port) : socket->bindToPort(port, address);
+    if (!bound) {
+        // Another process holds the port, or the address names no interface on
+        // this machine. Either way there is no half-open state to clean up.
+        DBG("OscService: could not bind " << address << ":" << port);
+        return false;
+    }
+
+    auto receiver = std::make_unique<juce::OSCReceiver>("MAGDA OSC");
+    receiver->addListener(this);
+    if (!receiver->connectToSocket(*socket)) {
+        DBG("OscService: could not start the receive thread on " << address << ":" << port);
+        receiver->removeListener(this);
+        return false;
+    }
+
+    socket_ = std::move(socket);
+    receiver_ = std::move(receiver);
+    requestedPort_ = port;
+    boundPort_ = socket_->getBoundPort();
+    boundAddress_ = address;
+    return true;
+}
+
+void OscService::close() {
+    if (receiver_ != nullptr) {
+        // Stop the thread before the socket it reads through disappears.
+        receiver_->disconnect();
+        receiver_->removeListener(this);
+        receiver_.reset();
+    }
+    socket_.reset();
+    requestedPort_ = 0;
+    boundPort_ = 0;
+    boundAddress_.clear();
+}
+
+void OscService::stop() {
+    close();
+}
+
+int OscService::boundPort() const {
+    return isListening() ? boundPort_ : 0;
+}
+
+// ============================================================================
+// Receive thread
+// ============================================================================
+
+void OscService::oscMessageReceived(const juce::OSCMessage& message) {
+    router_->handleMessage(message);
+}
+
+void OscService::oscBundleReceived(const juce::OSCBundle& bundle) {
+    deliverBundle(bundle, 0);
+}
+
+void OscService::deliverBundle(const juce::OSCBundle& bundle, int depth) {
+    if (depth >= kMaxBundleDepth)
+        return;
+
+    for (const auto& element : bundle) {
+        if (element.isMessage())
+            router_->handleMessage(element.getMessage());
+        else if (element.isBundle())
+            deliverBundle(element.getBundle(), depth + 1);
+    }
+}
+
+}  // namespace magda::osc

--- a/magda/daw/audio/osc/OscService.hpp
+++ b/magda/daw/audio/osc/OscService.hpp
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <juce_osc/juce_osc.h>
+
+#include <memory>
+
+#include "../../core/Config.hpp"
+#include "osc/OscRouter.hpp"
+
+namespace magda::osc {
+
+/**
+ * @brief The UDP listener behind MAGDA's OSC control surfaces (#1757).
+ *
+ * Owns the socket and the receive thread, and hands everything that arrives to
+ * an `OscRouter`. Configuration decides whether it exists at all: with OSC off
+ * — the default — `applyConfig` binds nothing, and there is no state in which
+ * MAGDA holds a port open that the user did not ask for.
+ *
+ * ## The socket is bound here, not by JUCE
+ *
+ * `OSCReceiver::connect(port)` would be one line, but it binds every interface
+ * unconditionally. OSC has no authentication of any kind — the protocol has no
+ * notion of one — so which interfaces the socket answers on is the entire
+ * access control story, and it has to be the user's decision. Binding our own
+ * `DatagramSocket` and handing it over is what makes `oscBindAddress`
+ * meaningful: `127.0.0.1` for a bridge on this machine, `0.0.0.0` for the
+ * tablet on the sofa.
+ *
+ * The socket outlives the receiver deliberately — `connectToSocket` keeps a
+ * non-owning pointer, so the receive thread must be stopped before the socket
+ * it is reading from goes away.
+ *
+ * ## Reacting to settings
+ *
+ * A `ConfigListener`, so switching OSC on, off, or onto another port takes
+ * effect immediately rather than at the next launch — a toggle that needed a
+ * restart would be a worse answer than no toggle. Reapplying is cheap and
+ * idempotent: an unrelated config save leaves an established listener alone
+ * rather than dropping every connected surface.
+ */
+class OscService : private ConfigListener,
+                   private juce::OSCReceiver::Listener<juce::OSCReceiver::RealtimeCallback> {
+  public:
+    explicit OscService(std::unique_ptr<OscRouter> router);
+    ~OscService() override;
+
+    OscService(const OscService&) = delete;
+    OscService& operator=(const OscService&) = delete;
+
+    /**
+     * @brief Bring the listener into line with configuration.
+     *
+     * Opens the socket when OSC is enabled and nothing is listening, closes it
+     * when it is disabled, and rebinds when the port or address changed. Safe
+     * to call repeatedly; the common case is that nothing has changed and
+     * nothing happens.
+     *
+     * @return true when a socket is bound afterwards.
+     */
+    bool applyConfig();
+
+    /** Close the socket and stop the receive thread. Idempotent. */
+    void stop();
+
+    bool isListening() const {
+        return receiver_ != nullptr;
+    }
+
+    /// The bound port, or 0 when not listening.
+    int boundPort() const;
+
+    /// The address actually bound, or empty when not listening.
+    juce::String boundAddress() const {
+        return boundAddress_;
+    }
+
+    OscRouter& router() {
+        return *router_;
+    }
+
+  private:
+    void configChanged() override;
+
+    // Realtime callbacks: these run on the receive thread, not the message
+    // thread. Everything they touch is in OscRouter and lock-free by design.
+    void oscMessageReceived(const juce::OSCMessage& message) override;
+    void oscBundleReceived(const juce::OSCBundle& bundle) override;
+
+    /**
+     * @brief Deliver a bundle's contents, flattening any nesting.
+     *
+     * Bundles arrive whole — JUCE hands realtime listeners the bundle rather
+     * than its messages — and surfaces send them routinely, so ignoring them
+     * would mean a template that works in one editor going silent in another.
+     *
+     * The time tag is not honoured: everything is applied on arrival.
+     * Scheduling a bundle for a future beat is a real OSC feature and a
+     * separate piece of work; treating a timestamped bundle as immediate is the
+     * conservative reading, and matches what the coalescing layer above could
+     * represent anyway.
+     */
+    void deliverBundle(const juce::OSCBundle& bundle, int depth);
+
+    bool open(int port, const juce::String& address);
+    void close();
+
+    std::unique_ptr<OscRouter> router_;
+
+    /// Declared before the receiver so it is destroyed after it: the receive
+    /// thread reads through a non-owning pointer to this socket.
+    std::unique_ptr<juce::DatagramSocket> socket_;
+    std::unique_ptr<juce::OSCReceiver> receiver_;
+
+    /// What configuration asked for, which is not what was bound when it was 0.
+    int requestedPort_ = 0;
+    int boundPort_ = 0;
+    juce::String boundAddress_;
+};
+
+}  // namespace magda::osc

--- a/magda/daw/core/CMakeLists.txt
+++ b/magda/daw/core/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(magda_daw PRIVATE
     AppPaths.cpp
     ChainNodePath.cpp
     ControlTarget.cpp
+    MixerStripOrder.cpp
     UIScale.cpp
     UpdateChecker.cpp
     ViewModeController.cpp

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -236,6 +236,15 @@ void Config::save() {
         root->setProperty("remoteApi", juce::var(remoteObj));
     }
 
+    // OSC control surfaces — nested "osc" object (#1757).
+    {
+        auto* oscObj = new juce::DynamicObject();
+        oscObj->setProperty("enabled", oscEnabled);
+        oscObj->setProperty("receivePort", oscReceivePort);
+        oscObj->setProperty("bindAddress", toJuceString(oscBindAddress));
+        root->setProperty("osc", juce::var(oscObj));
+    }
+
     // Recent projects
     juce::Array<juce::var> recentArray;
     for (const auto& r : recentProjects)
@@ -708,6 +717,23 @@ void Config::load() {
             // Passed through untouched; `RemoteClientRegistry` owns the shape
             // and drops anything it does not recognise.
             remoteApiClients = remoteObj->getProperty("clients");
+        }
+    }
+
+    // OSC — absent means the defaults, which open no socket.
+    if (obj->hasProperty("osc")) {
+        if (auto* oscObj = obj->getProperty("osc").getDynamicObject()) {
+            if (oscObj->hasProperty("enabled"))
+                oscEnabled = oscObj->getProperty("enabled");
+            if (oscObj->hasProperty("receivePort"))
+                oscReceivePort = oscObj->getProperty("receivePort");
+            // An empty stored address would bind nothing at all, so it falls
+            // back to the default rather than silently disabling the listener.
+            if (oscObj->hasProperty("bindAddress")) {
+                auto address = oscObj->getProperty("bindAddress").toString();
+                if (address.isNotEmpty())
+                    oscBindAddress = address.toStdString();
+            }
         }
     }
     recentProjects = getStringArray("recentProjects");

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -493,6 +493,45 @@ class Config {
         remoteApiClients = std::move(clients);
     }
 
+    // OSC control surfaces (issue #1757). Off by default, for the same reason
+    // the remote API is: a DAW should not start listening because it was
+    // installed. Unlike the remote API there is no token to check — OSC is
+    // unauthenticated UDP by design — so the bind address is the whole of the
+    // access control and is a setting rather than a constant.
+    bool getOscEnabled() const {
+        return oscEnabled;
+    }
+    void setOscEnabled(bool enabled) {
+        oscEnabled = enabled;
+    }
+    /// The UDP port MAGDA listens on. 9000 is the TouchOSC / Open Stage Control
+    /// default, so a stock template needs no configuration at either end.
+    int getOscReceivePort() const {
+        return oscReceivePort;
+    }
+    void setOscReceivePort(int port) {
+        oscReceivePort = port;
+    }
+    /**
+     * Which local interface to bind. Two values are meaningful:
+     *
+     *  - `0.0.0.0` — every interface, so a tablet on the same Wi-Fi can reach
+     *    MAGDA. The default, because a phone or tablet running TouchOSC is the
+     *    point of the feature and localhost-only would make it useless.
+     *  - `127.0.0.1` — loopback only, for a bridge or show-control process on
+     *    this machine.
+     *
+     * Anything the OS will bind is accepted; these two are what the settings UI
+     * offers. Bound as-is rather than validated here, so a user with a specific
+     * interface address can name it.
+     */
+    const std::string& getOscBindAddress() const {
+        return oscBindAddress;
+    }
+    void setOscBindAddress(const std::string& address) {
+        oscBindAddress = address;
+    }
+
     // Browser filter settings
     bool getBrowserFilterAudio() const {
         return browserFilterAudio;
@@ -1381,6 +1420,12 @@ class Config {
     /// until something writes one, which reads as "no client has been granted
     /// anything yet".
     juce::var remoteApiClients;
+
+    // OSC control surfaces (#1757). Off, and reachable from the network when
+    // switched on — see the accessors for why the bind default is not loopback.
+    bool oscEnabled = false;
+    int oscReceivePort = 9000;
+    std::string oscBindAddress = "0.0.0.0";
 
     // Export audio settings
     std::string exportFormat = "WAV24";  // WAV16, WAV24, WAV32, FLAC

--- a/magda/daw/core/MixerStripOrder.cpp
+++ b/magda/daw/core/MixerStripOrder.cpp
@@ -1,0 +1,57 @@
+#include "MixerStripOrder.hpp"
+
+namespace magda {
+
+namespace {
+
+const TrackInfo* findTrack(const std::vector<TrackInfo>& tracks, TrackId id) {
+    for (const auto& track : tracks)
+        if (track.id == id)
+            return &track;
+    return nullptr;
+}
+
+}  // namespace
+
+bool isMixerStrip(const TrackInfo& track, const std::vector<TrackInfo>& tracks, ViewMode mode) {
+    if (!track.isVisibleIn(mode))
+        return false;
+
+    // Aux returns are drawn in their own section beside the channel strips, so
+    // they take no position among them.
+    if (track.type == TrackType::Aux)
+        return false;
+
+    if (track.hasParent()) {
+        if (const auto* parent = findTrack(tracks, track.parentId)) {
+            if ((parent->isGroup() || parent->hasChildren()) && parent->isCollapsedIn(mode))
+                return false;
+        }
+    }
+    return true;
+}
+
+std::vector<TrackId> mixerStripOrder(const std::vector<TrackInfo>& tracks, ViewMode mode) {
+    std::vector<TrackId> order;
+    order.reserve(tracks.size());
+    for (const auto& track : tracks)
+        if (isMixerStrip(track, tracks, mode))
+            order.push_back(track.id);
+    return order;
+}
+
+TrackId mixerStripAtPosition(const std::vector<TrackInfo>& tracks, ViewMode mode, int position) {
+    if (position < 1)
+        return INVALID_TRACK_ID;
+
+    int seen = 0;
+    for (const auto& track : tracks) {
+        if (!isMixerStrip(track, tracks, mode))
+            continue;
+        if (++seen == position)
+            return track.id;
+    }
+    return INVALID_TRACK_ID;
+}
+
+}  // namespace magda

--- a/magda/daw/core/MixerStripOrder.hpp
+++ b/magda/daw/core/MixerStripOrder.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <vector>
+
+#include "TrackInfo.hpp"
+#include "TypeIds.hpp"
+#include "ViewModeState.hpp"
+
+namespace magda {
+
+/**
+ * @brief Which tracks the mixer shows as channel strips, and in what order.
+ *
+ * One statement of a rule that two unrelated places need: the mixer, which
+ * builds the strips, and any control surface that addresses a strip by its
+ * position on screen (#1757). Those had drifted — a second, approximate copy of
+ * "what a mixer strip is" meant an OSC fader could land one strip to the left
+ * of the one the user was looking at.
+ *
+ * Three things keep a track out of the run:
+ *
+ *  - it is hidden in this view mode;
+ *  - it is an aux, which the mixer renders in its own section rather than
+ *    inline with the channel strips;
+ *  - its parent group is collapsed, so the mixer is not drawing it at all.
+ *
+ * The master strip is not in here either. It is a separate `TrackInfo` with its
+ * own place in the mixer, and it has its own OSC addresses for the same reason.
+ */
+
+/// True when `track` is drawn as an ordinary channel strip. `tracks` is the
+/// list it belongs to, needed to find its parent.
+bool isMixerStrip(const TrackInfo& track, const std::vector<TrackInfo>& tracks, ViewMode mode);
+
+/// Every strip, in mixer order.
+std::vector<TrackId> mixerStripOrder(const std::vector<TrackInfo>& tracks, ViewMode mode);
+
+/**
+ * @brief The track at a 1-based position in mixer order.
+ *
+ * `INVALID_TRACK_ID` when there is no strip there, which is the ordinary answer
+ * for a surface with more faders than the project has tracks.
+ *
+ * Counts rather than building the list, because a control surface asks this
+ * once per address per drain and the answer is one id.
+ */
+TrackId mixerStripAtPosition(const std::vector<TrackInfo>& tracks, ViewMode mode, int position);
+
+}  // namespace magda

--- a/magda/daw/magda_daw_main.cpp
+++ b/magda/daw/magda_daw_main.cpp
@@ -13,10 +13,13 @@
 #include "../../magda/agents/llm_client_factory.hpp"
 #include "../../magda/agents/llm_presets.hpp"
 #include "api/magda_api_live.hpp"
+#include "api/osc_command_sink_live.hpp"
 #include "api/remote_api_host.hpp"
 #include "api/remote_audit.hpp"
 #include "audio/AudioBridge.hpp"
 #include "audio/AudioThumbnailManager.hpp"
+#include "audio/controllers/ControllerParamWriter.hpp"
+#include "audio/osc/OscService.hpp"
 #include "core/AppPaths.hpp"
 #include "core/ClipManager.hpp"
 #include "core/Config.hpp"
@@ -91,6 +94,10 @@ class MagdaDAWApplication : public JUCEApplication {
     // Remote API (#1856): dispatcher, model bridge and WebSocket transport.
     // Owned here so it is torn down before the managers its bridge listens to.
     std::unique_ptr<magda::remote::RemoteApiHost> remoteApi_;
+    // OSC control surfaces (#1757): the UDP listener and the routing behind it.
+    // Owned here for the same reason as the remote API — it holds a socket
+    // whose receive thread posts work against the model.
+    std::unique_ptr<magda::osc::OscService> oscService_;
     // Latches true once the deferred startup auto-load has fired. The
     // engine's onMidiDevicesReady callback runs on every device-list
     // change, but we only want to auto-load the active script once.
@@ -363,6 +370,21 @@ class MagdaDAWApplication : public JUCEApplication {
                                      magda::remote::redactedFileName(remoteApi_->tokenFile()));
         }
 
+        // 4c. OSC control surfaces (#1757). Also off unless configuration says
+        // otherwise. Needs the AudioBridge for the parameter writer, which is
+        // what makes an OSC fader land exactly where a MIDI one does — so it is
+        // built here rather than earlier, once the engine has one.
+        if (auto* audioBridge = daw_engine_->getAudioBridge()) {
+            auto sink = std::make_unique<magda::OscCommandSinkLive>(
+                daw_engine_->getMagdaApi(),
+                std::make_unique<magda::DefaultControllerParamWriter>(*audioBridge));
+            oscService_ = std::make_unique<magda::osc::OscService>(
+                std::make_unique<magda::osc::OscRouter>(std::move(sink)));
+            if (oscService_->applyConfig())
+                juce::Logger::writeToLog("OSC listening on " + oscService_->boundAddress() + ":" +
+                                         juce::String(oscService_->boundPort()));
+        }
+
         // 5. Dismiss splash screen
         splashScreen_.reset();
 
@@ -485,6 +507,12 @@ class MagdaDAWApplication : public JUCEApplication {
         // bridge is attached to managers that are about to shut down.
         DBG("[0] Remote API shutdown...");
         remoteApi_.reset();
+
+        // Same argument for OSC: its receive thread is posting parameter
+        // writes at whatever rate a surface is sending, and everything those
+        // land on is about to be torn down.
+        DBG("[0b] OSC shutdown...");
+        oscService_.reset();
 
         // Stop timers first to prevent callbacks during destruction
         DBG("[1] ModulatorEngine shutdown...");

--- a/magda/daw/ui/views/MixerView.cpp
+++ b/magda/daw/ui/views/MixerView.cpp
@@ -8,6 +8,7 @@
 #include "../../audio/MeteringBuffer.hpp"
 #include "../../audio/MidiBridge.hpp"
 #include "../../audio/plugins/tracktion/TracktionMagdaDevicePlugin.hpp"
+#include "../../core/MixerStripOrder.hpp"
 #include "../../core/RackInfo.hpp"
 #include "../../engine/AudioEngine.hpp"
 #include "../../engine/PluginWindowManager.hpp"
@@ -1960,22 +1961,12 @@ void MixerView::rebuildChannelStrips() {
     const auto& tracks = TrackManager::getInstance().getTracks();
 
     for (const auto& track : tracks) {
-        // Only show tracks visible in the current view mode
-        if (!track.isVisibleIn(currentViewMode_)) {
+        // Hidden tracks, aux returns (drawn in their own section) and children
+        // of a collapsed group are not strips. The rule lives in one place
+        // because control surfaces address strips by position and have to agree
+        // with what is on screen — see MixerStripOrder.hpp.
+        if (!isMixerStrip(track, tracks, currentViewMode_))
             continue;
-        }
-
-        if (track.type == TrackType::Aux)
-            continue;  // Aux strips handled separately
-
-        // Skip children of collapsed group tracks
-        if (track.hasParent()) {
-            if (auto* parent = TrackManager::getInstance().getTrack(track.parentId)) {
-                if ((parent->isGroup() || parent->hasChildren()) &&
-                    parent->isCollapsedIn(currentViewMode_))
-                    continue;
-            }
-        }
 
         auto strip = std::make_unique<ChannelStrip>(track, audioEngine_, false);
         strip->onClicked = [this](int trackId, bool isMaster) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -172,6 +172,10 @@ set(TEST_SOURCES
     test_automation_alias_targets.cpp
     # Controller data model tests (issue #1050 -- Phase A)
     test_binding_transform.cpp
+    # OSC control surfaces (issue #1757)
+    test_osc_address.cpp
+    test_osc_router.cpp
+    test_osc_command_sink.cpp
     # Controller registry tests (issue #1050 -- Phase B)
     test_controller_registry.cpp
     test_binding_registry.cpp
@@ -377,6 +381,8 @@ target_sources(magda_juce_tests PRIVATE
     test_session_slot_recording_juce.cpp
     test_input_monitor_track_routing_juce.cpp
     test_controller_track_level_write_juce.cpp
+    # OSC control surfaces (issue #1757): a live receive thread and real packets
+    test_osc_service_juce.cpp
     test_track_midi_recording_preview_juce.cpp
     test_timeline_loop_activation_juce.cpp
     test_midi_signal_routing_juce.cpp

--- a/tests/test_controller_track_level_write_juce.cpp
+++ b/tests/test_controller_track_level_write_juce.cpp
@@ -48,6 +48,7 @@ class ControllerTrackLevelWriteTest final : public juce::UnitTest {
             testMasterVolumeWrite();
             testMasterPanWrite();
             testTrackVolumeWrite();
+            testSendLevelWrite();
             testFullScaleAndSilence();
         });
     }
@@ -137,6 +138,46 @@ class ControllerTrackLevelWriteTest final : public juce::UnitTest {
         expect(after->volume > 0.0f, "the write must land on the track");
         expect(tm.getMasterChannel().volume == masterBefore,
                "a track write must not disturb the master channel");
+    }
+
+    void testSendLevelWrite() {
+        beginTest("A send-level write reaches the send (#1757)");
+
+        // SendLevel used to fall through the same bare `break` this file was
+        // written about. OSC is its first caller, and a control surface with a
+        // send fader that silently did nothing would be the same bug again.
+        auto& wrapper = magda::test::getSharedEngine();
+        auto* bridge = wrapper.getAudioBridge();
+        if (bridge == nullptr)
+            return;
+
+        auto& tm = TrackManager::getInstance();
+        const auto source = tm.createTrack("Send Source");
+        const auto destination = tm.createTrack("Reverb Bus");
+        bridge->createAudioTrack(source, "Send Source");
+        bridge->createAudioTrack(destination, "Reverb Bus");
+        tm.addSend(source, destination);
+
+        const auto* withSend = tm.getTrack(source);
+        expect(withSend != nullptr && !withSend->sends.empty(), "the send must have been created");
+        if (withSend == nullptr || withSend->sends.empty())
+            return;
+        const int busIndex = withSend->sends[0].busIndex;
+
+        DefaultControllerParamWriter writer{*bridge};
+        ResolveResult resolved;
+        resolved.target = ControlTarget::sendLevel(source, busIndex);
+        resolved.resolved = true;
+        expect(resolved.ok(), "the send target must resolve");
+
+        writer.write(resolved, 0.25f);
+        const float atQuarter = tm.getTrack(source)->sends[0].level;
+
+        writer.write(resolved, 0.9f);
+        const float atNine = tm.getTrack(source)->sends[0].level;
+
+        expect(atNine > atQuarter, "a higher controller value must raise the send level");
+        expect(atQuarter >= 0.0f, "a send level must never go negative");
     }
 
     void testFullScaleAndSilence() {

--- a/tests/test_osc_address.cpp
+++ b/tests/test_osc_address.cpp
@@ -1,0 +1,183 @@
+#include <catch2/catch_test_macros.hpp>
+#include <set>
+
+#include "../magda/daw/audio/osc/OscAddress.hpp"
+
+using namespace magda::osc;
+
+namespace {
+
+OscCommand parsed(const char* address) {
+    auto command = parseOscAddress(address);
+    REQUIRE(command.has_value());
+    return *command;
+}
+
+void requireRejected(const char* address) {
+    INFO("address: " << address);
+    REQUIRE_FALSE(parseOscAddress(address).has_value());
+}
+
+}  // namespace
+
+// ============================================================================
+// The namespace a stock template speaks
+// ============================================================================
+
+TEST_CASE("Transport addresses parse", "[osc][address]") {
+    REQUIRE(parsed("/magda/transport/play").kind == OscCommandKind::TransportPlay);
+    REQUIRE(parsed("/magda/transport/stop").kind == OscCommandKind::TransportStop);
+    REQUIRE(parsed("/magda/transport/record").kind == OscCommandKind::TransportRecord);
+    REQUIRE(parsed("/magda/transport/loop").kind == OscCommandKind::TransportLoop);
+    REQUIRE(parsed("/magda/transport/tempo").kind == OscCommandKind::TransportTempo);
+    REQUIRE(parsed("/magda/transport/position").kind == OscCommandKind::TransportPosition);
+}
+
+TEST_CASE("Master addresses parse", "[osc][address]") {
+    REQUIRE(parsed("/magda/master/volume").kind == OscCommandKind::MasterVolume);
+    REQUIRE(parsed("/magda/master/pan").kind == OscCommandKind::MasterPan);
+}
+
+TEST_CASE("Track strip addresses carry a 1-based position", "[osc][address]") {
+    const auto volume = parsed("/magda/track/1/volume");
+    REQUIRE(volume.kind == OscCommandKind::TrackVolume);
+    REQUIRE(volume.index == 1);
+    REQUIRE(volume.subIndex == 0);
+
+    REQUIRE(parsed("/magda/track/7/pan").kind == OscCommandKind::TrackPan);
+    REQUIRE(parsed("/magda/track/7/pan").index == 7);
+    REQUIRE(parsed("/magda/track/12/mute").kind == OscCommandKind::TrackMute);
+    REQUIRE(parsed("/magda/track/12/solo").kind == OscCommandKind::TrackSolo);
+
+    const auto send = parsed("/magda/track/3/send/2");
+    REQUIRE(send.kind == OscCommandKind::TrackSend);
+    REQUIRE(send.index == 3);
+    REQUIRE(send.subIndex == 2);
+}
+
+TEST_CASE("Focused macro addresses parse", "[osc][address]") {
+    const auto macro = parsed("/magda/focused/macro/16");
+    REQUIRE(macro.kind == OscCommandKind::FocusedMacro);
+    REQUIRE(macro.index == 16);
+}
+
+// ============================================================================
+// What must not parse
+// ============================================================================
+
+TEST_CASE("Addresses outside the namespace are rejected", "[osc][address]") {
+    requireRejected("/other/transport/play");
+    requireRejected("/magda");
+    requireRejected("/magda/transport");
+    requireRejected("/magda/transport/rewind");
+    requireRejected("/magda/master/width");
+    requireRejected("/magda/focused/param/1");
+    requireRejected("/magda/track/1/gain");
+    requireRejected("");
+    // No leading slash: not a well-formed OSC address, so not ours to accept.
+    requireRejected("magda/transport/play");
+}
+
+TEST_CASE("Trailing components are rejected rather than ignored", "[osc][address]") {
+    // A surface author who appends something we do not understand has a bug,
+    // and silently applying the prefix would hide it behind working faders.
+    requireRejected("/magda/transport/play/now");
+    requireRejected("/magda/master/volume/1");
+    requireRejected("/magda/track/1/volume/2");
+    requireRejected("/magda/track/1/send");
+    requireRejected("/magda/track/1/send/1/extra");
+    requireRejected("/magda/focused/macro");
+    requireRejected("/magda/focused/macro/1/2");
+}
+
+TEST_CASE("Wildcards never resolve to an index", "[osc][address]") {
+    // OSC address patterns are part of the protocol. Reading '*' as a number
+    // would let one message drive every strip at once.
+    requireRejected("/magda/track/*/volume");
+    requireRejected("/magda/track/?/volume");
+    requireRejected("/magda/track/[1-8]/volume");
+    requireRejected("/magda/track/{1,2}/volume");
+    requireRejected("/magda/focused/macro/*");
+}
+
+TEST_CASE("Indices are strict decimals", "[osc][address]") {
+    requireRejected("/magda/track/0/volume");   // 1-based, so 0 addresses nothing
+    requireRejected("/magda/track/01/volume");  // one strip, one spelling
+    requireRejected("/magda/track/-1/volume");
+    requireRejected("/magda/track/1.0/volume");
+    requireRejected("/magda/track/1x/volume");
+    requireRejected("/magda/track/ 1/volume");
+    requireRejected("/magda/track//volume");
+    requireRejected("/magda/track/two/volume");
+}
+
+TEST_CASE("Out-of-range indices are rejected, not clamped", "[osc][address]") {
+    // Clamping would land a misconfigured template's fader on a real track.
+    REQUIRE(parseOscAddress("/magda/track/128/volume").has_value());
+    requireRejected("/magda/track/129/volume");
+    requireRejected("/magda/track/9999/volume");
+
+    REQUIRE(parseOscAddress("/magda/track/1/send/8").has_value());
+    requireRejected("/magda/track/1/send/9");
+
+    REQUIRE(parseOscAddress("/magda/focused/macro/16").has_value());
+    requireRejected("/magda/focused/macro/17");
+}
+
+// ============================================================================
+// Argument conventions
+// ============================================================================
+
+TEST_CASE("Each kind declares how it reads its argument", "[osc][address]") {
+    REQUIRE(argKindFor(OscCommandKind::TransportPlay) == OscArgKind::Trigger);
+    REQUIRE(argKindFor(OscCommandKind::TransportStop) == OscArgKind::Trigger);
+    REQUIRE(argKindFor(OscCommandKind::TransportRecord) == OscArgKind::Toggle);
+    REQUIRE(argKindFor(OscCommandKind::TransportLoop) == OscArgKind::Toggle);
+    REQUIRE(argKindFor(OscCommandKind::TrackMute) == OscArgKind::Toggle);
+    REQUIRE(argKindFor(OscCommandKind::TrackSolo) == OscArgKind::Toggle);
+    REQUIRE(argKindFor(OscCommandKind::TransportTempo) == OscArgKind::Bpm);
+    REQUIRE(argKindFor(OscCommandKind::TransportPosition) == OscArgKind::Beats);
+    REQUIRE(argKindFor(OscCommandKind::TrackVolume) == OscArgKind::Normalized);
+    REQUIRE(argKindFor(OscCommandKind::TrackSend) == OscArgKind::Normalized);
+    REQUIRE(argKindFor(OscCommandKind::MasterVolume) == OscArgKind::Normalized);
+    REQUIRE(argKindFor(OscCommandKind::FocusedMacro) == OscArgKind::Normalized);
+}
+
+// ============================================================================
+// Slot mapping
+// ============================================================================
+
+TEST_CASE("Every address owns a distinct slot", "[osc][address]") {
+    // The coalescing table is only correct if two addresses never share a slot:
+    // a collision would make one fader overwrite another's value.
+    std::set<int> used;
+
+    auto claim = [&used](const OscCommand& command) {
+        const int slot = oscSlotIndex(command);
+        INFO("slot " << slot);
+        REQUIRE(slot >= 0);
+        REQUIRE(slot < kOscSlotCount);
+        REQUIRE(used.insert(slot).second);
+        // And the drain must recover exactly what was addressed.
+        REQUIRE(oscCommandForSlot(slot) == command);
+    };
+
+    for (int kind = 0; kind < kOscUnindexedSlots; ++kind)
+        claim(OscCommand{static_cast<OscCommandKind>(kind), 0, 0});
+
+    for (int macro = 1; macro <= kMaxMacroNumber; ++macro)
+        claim(OscCommand{OscCommandKind::FocusedMacro, macro, 0});
+
+    for (int track = 1; track <= kMaxTrackNumber; ++track) {
+        claim(OscCommand{OscCommandKind::TrackVolume, track, 0});
+        claim(OscCommand{OscCommandKind::TrackPan, track, 0});
+        claim(OscCommand{OscCommandKind::TrackMute, track, 0});
+        claim(OscCommand{OscCommandKind::TrackSolo, track, 0});
+        for (int send = 1; send <= kMaxSendNumber; ++send)
+            claim(OscCommand{OscCommandKind::TrackSend, track, send});
+    }
+
+    // Exactly as many slots as the table is sized for — no dead space, and
+    // nothing addressable left outside it.
+    REQUIRE(static_cast<int>(used.size()) == kOscSlotCount);
+}

--- a/tests/test_osc_command_sink.cpp
+++ b/tests/test_osc_command_sink.cpp
@@ -1,0 +1,267 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <vector>
+
+#include "MockMagdaApi.hpp"
+#include "magda/daw/api/osc_command_sink_live.hpp"
+#include "magda/daw/audio/controllers/ControllerParamWriter.hpp"
+#include "magda/daw/core/ControlTarget.hpp"
+
+using namespace magda;
+using namespace magda::osc;
+using Catch::Approx;
+
+namespace {
+
+/// Captures level writes instead of touching the engine. The mapping from a
+/// normalized value to a real gain is the writer's job and is covered where the
+/// writer is; what matters here is that the right target got the right value.
+class RecordingParamWriter : public ControllerParamWriter {
+  public:
+    struct Write {
+        ControlTarget target;
+        float value = 0.0f;
+    };
+
+    void write(const ResolveResult& resolved, float value) override {
+        writes.push_back({resolved.target, value});
+    }
+
+    std::vector<Write> writes;
+};
+
+struct Fixture {
+    Fixture() {
+        auto owned = std::make_unique<RecordingParamWriter>();
+        writer = owned.get();
+        sink = std::make_unique<OscCommandSinkLive>(api, std::move(owned));
+    }
+
+    /// Adds a track at the end of the mixer, visible by default.
+    TrackId addTrack(const juce::String& name, bool visibleInMix = true) {
+        TrackInfo track;
+        track.id = nextId++;
+        track.name = name;
+        track.viewSettings.setVisible(ViewMode::Mix, visibleInMix);
+        api.tracks_.tracks.push_back(track);
+        return track.id;
+    }
+
+    TrackInfo* track(TrackId id) {
+        for (auto& t : api.tracks_.tracks)
+            if (t.id == id)
+                return &t;
+        return nullptr;
+    }
+
+    void apply(OscCommandKind kind, int index = 0, float value = 0.0f, int subIndex = 0) {
+        sink->apply(OscCommand{kind, index, subIndex}, value);
+    }
+
+    test::MockMagdaApi api;
+    RecordingParamWriter* writer = nullptr;
+    std::unique_ptr<OscCommandSinkLive> sink;
+    TrackId nextId = 1;
+};
+
+}  // namespace
+
+// ============================================================================
+// Transport
+// ============================================================================
+
+TEST_CASE("Transport commands reach the facade", "[osc][sink]") {
+    Fixture f;
+
+    f.apply(OscCommandKind::TransportPlay, 0, 1.0f);
+    REQUIRE(f.api.transport_.playing);
+
+    f.apply(OscCommandKind::TransportStop, 0, 1.0f);
+    REQUIRE_FALSE(f.api.transport_.playing);
+
+    f.apply(OscCommandKind::TransportPosition, 0, 32.5f);
+    REQUIRE(f.api.transport_.positionBeats == Approx(32.5));
+
+    f.apply(OscCommandKind::TransportTempo, 0, 174.0f);
+    REQUIRE(f.api.project_.info.tempo == Approx(174.0));
+}
+
+TEST_CASE("Transport toggles set from a value and flip without one", "[osc][sink]") {
+    Fixture f;
+
+    f.apply(OscCommandKind::TransportLoop, 0, 1.0f);
+    REQUIRE(f.api.transport_.loopEnabled);
+    f.apply(OscCommandKind::TransportLoop, 0, 0.0f);
+    REQUIRE_FALSE(f.api.transport_.loopEnabled);
+
+    // A momentary button sends no argument at all; the state has to flip from
+    // whatever it currently is rather than latching one way.
+    f.apply(OscCommandKind::TransportLoop, 0, kOscToggleRequest);
+    REQUIRE(f.api.transport_.loopEnabled);
+    f.apply(OscCommandKind::TransportLoop, 0, kOscToggleRequest);
+    REQUIRE_FALSE(f.api.transport_.loopEnabled);
+
+    f.apply(OscCommandKind::TransportRecord, 0, kOscToggleRequest);
+    REQUIRE(f.api.transport_.recording);
+}
+
+// ============================================================================
+// Track addressing
+// ============================================================================
+
+TEST_CASE("Track numbers are mixer positions, not ids", "[osc][sink]") {
+    Fixture f;
+    const auto first = f.addTrack("Drums");
+    const auto second = f.addTrack("Bass");
+    const auto third = f.addTrack("Keys");
+
+    f.apply(OscCommandKind::TrackVolume, 1, 0.5f);
+    f.apply(OscCommandKind::TrackVolume, 3, 0.9f);
+
+    REQUIRE(f.writer->writes.size() == 2);
+    REQUIRE(f.writer->writes[0].target.devicePath.trackId == first);
+    REQUIRE(f.writer->writes[1].target.devicePath.trackId == third);
+    REQUIRE(second != INVALID_TRACK_ID);
+}
+
+TEST_CASE("Deleting a track renumbers the ones after it", "[osc][sink]") {
+    // The reason positions are the public namespace at all: ids are sparse
+    // after a delete, and a template's eight faders are not.
+    Fixture f;
+    f.addTrack("Drums");
+    const auto second = f.addTrack("Bass");
+    const auto third = f.addTrack("Keys");
+
+    f.api.tracks_.tracks.erase(f.api.tracks_.tracks.begin());  // delete "Drums"
+
+    f.apply(OscCommandKind::TrackVolume, 1, 0.5f);
+    f.apply(OscCommandKind::TrackVolume, 2, 0.5f);
+
+    REQUIRE(f.writer->writes.size() == 2);
+    REQUIRE(f.writer->writes[0].target.devicePath.trackId == second);
+    REQUIRE(f.writer->writes[1].target.devicePath.trackId == third);
+}
+
+TEST_CASE("Tracks hidden in the mixer take no position", "[osc][sink]") {
+    // A fader that appeared to do nothing because it landed on a strip the
+    // user cannot see would be indistinguishable from a broken template.
+    Fixture f;
+    f.addTrack("Drums");
+    f.addTrack("Hidden", /*visibleInMix*/ false);
+    const auto visible = f.addTrack("Keys");
+
+    f.apply(OscCommandKind::TrackVolume, 2, 0.5f);
+
+    REQUIRE(f.writer->writes.size() == 1);
+    REQUIRE(f.writer->writes[0].target.devicePath.trackId == visible);
+}
+
+TEST_CASE("A position with no track behind it is ignored", "[osc][sink]") {
+    // A sixteen-strip template pointed at a two-track project drives two
+    // faders rather than failing.
+    Fixture f;
+    f.addTrack("Drums");
+
+    f.apply(OscCommandKind::TrackVolume, 9, 0.5f);
+    f.apply(OscCommandKind::TrackMute, 9, 1.0f);
+
+    REQUIRE(f.writer->writes.empty());
+    REQUIRE(f.api.tracks_.muteWrites.empty());
+}
+
+// ============================================================================
+// Track controls
+// ============================================================================
+
+TEST_CASE("Volume and pan become level writes on the right target", "[osc][sink]") {
+    Fixture f;
+    const auto id = f.addTrack("Drums");
+
+    f.apply(OscCommandKind::TrackVolume, 1, 0.62f);
+    f.apply(OscCommandKind::TrackPan, 1, 0.25f);
+
+    REQUIRE(f.writer->writes.size() == 2);
+    REQUIRE(f.writer->writes[0].target.kind == ControlTarget::Kind::TrackVolume);
+    REQUIRE(f.writer->writes[0].target.devicePath.trackId == id);
+    REQUIRE(f.writer->writes[0].value == Approx(0.62f));
+    REQUIRE(f.writer->writes[1].target.kind == ControlTarget::Kind::TrackPan);
+    REQUIRE(f.writer->writes[1].value == Approx(0.25f));
+}
+
+TEST_CASE("Mute and solo set from a value and flip without one", "[osc][sink]") {
+    Fixture f;
+    const auto id = f.addTrack("Drums");
+
+    f.apply(OscCommandKind::TrackMute, 1, 1.0f);
+    REQUIRE(f.api.tracks_.muteWrites.size() == 1);
+    REQUIRE(f.api.tracks_.muteWrites[0].id == id);
+    REQUIRE(f.api.tracks_.muteWrites[0].value);
+
+    // The flip reads the state off the track it is addressing, so seed it.
+    f.track(id)->muted = true;
+    f.apply(OscCommandKind::TrackMute, 1, kOscToggleRequest);
+    REQUIRE(f.api.tracks_.muteWrites.size() == 2);
+    REQUIRE_FALSE(f.api.tracks_.muteWrites[1].value);
+
+    f.apply(OscCommandKind::TrackSolo, 1, kOscToggleRequest);
+    REQUIRE(f.api.tracks_.soloWrites.size() == 1);
+    REQUIRE(f.api.tracks_.soloWrites[0].value);
+}
+
+TEST_CASE("Sends are addressed by position and written by bus", "[osc][sink]") {
+    // Send 1 on the surface is the track's first send. Its aux bus number is
+    // whatever the routing happens to have assigned, and that is what the
+    // model writes through.
+    Fixture f;
+    const auto id = f.addTrack("Drums");
+    f.track(id)->sends.push_back(SendInfo{/*busIndex*/ 4, 1.0f, false, INVALID_TRACK_ID});
+    f.track(id)->sends.push_back(SendInfo{/*busIndex*/ 7, 1.0f, false, INVALID_TRACK_ID});
+
+    f.apply(OscCommandKind::TrackSend, 1, 0.3f, /*subIndex*/ 2);
+
+    REQUIRE(f.writer->writes.size() == 1);
+    REQUIRE(f.writer->writes[0].target.kind == ControlTarget::Kind::SendLevel);
+    REQUIRE(f.writer->writes[0].target.devicePath.trackId == id);
+    REQUIRE(f.writer->writes[0].target.sendBusIndex == 7);
+    REQUIRE(f.writer->writes[0].value == Approx(0.3f));
+}
+
+TEST_CASE("A send the track does not have is ignored", "[osc][sink]") {
+    Fixture f;
+    const auto id = f.addTrack("Drums");
+    f.track(id)->sends.push_back(SendInfo{4, 1.0f, false, INVALID_TRACK_ID});
+
+    f.apply(OscCommandKind::TrackSend, 1, 0.3f, /*subIndex*/ 3);
+
+    REQUIRE(f.writer->writes.empty());
+}
+
+// ============================================================================
+// Master and focused device
+// ============================================================================
+
+TEST_CASE("Master addresses reach the master strip", "[osc][sink]") {
+    Fixture f;
+
+    f.apply(OscCommandKind::MasterVolume, 0, 0.8f);
+    f.apply(OscCommandKind::MasterPan, 0, 0.5f);
+
+    REQUIRE(f.writer->writes.size() == 2);
+    REQUIRE(f.writer->writes[0].target.kind == ControlTarget::Kind::TrackVolume);
+    REQUIRE(f.writer->writes[0].target.devicePath.trackId == MASTER_TRACK_ID);
+    REQUIRE(f.writer->writes[1].target.kind == ControlTarget::Kind::TrackPan);
+    REQUIRE(f.writer->writes[1].target.devicePath.trackId == MASTER_TRACK_ID);
+}
+
+TEST_CASE("Focused macros are numbered from 1 on the wire", "[osc][sink]") {
+    Fixture f;
+
+    f.apply(OscCommandKind::FocusedMacro, 1, 0.4f);
+    f.apply(OscCommandKind::FocusedMacro, 16, 0.9f);
+
+    REQUIRE(f.api.focused_.macroWrites.size() == 2);
+    REQUIRE(f.api.focused_.macroWrites[0].idx == 0);
+    REQUIRE(f.api.focused_.macroWrites[0].value == Approx(0.4f));
+    REQUIRE(f.api.focused_.macroWrites[1].idx == 15);
+}

--- a/tests/test_osc_command_sink.cpp
+++ b/tests/test_osc_command_sink.cpp
@@ -157,6 +157,56 @@ TEST_CASE("Tracks hidden in the mixer take no position", "[osc][sink]") {
     REQUIRE(f.writer->writes[0].target.devicePath.trackId == visible);
 }
 
+TEST_CASE("Aux returns take no position among the strips", "[osc][sink]") {
+    // The mixer draws aux returns in their own section, so an aux mid-list must
+    // not consume a fader — otherwise every strip after it drives the track one
+    // to the left of the one the user is looking at.
+    Fixture f;
+    f.addTrack("Drums");
+    auto& aux = f.api.tracks_.tracks.emplace_back();
+    aux.id = f.nextId++;
+    aux.name = "Reverb";
+    aux.type = TrackType::Aux;
+    aux.viewSettings.setVisible(ViewMode::Mix, true);
+    const auto keys = f.addTrack("Keys");
+
+    f.apply(OscCommandKind::TrackVolume, 2, 0.5f);
+
+    REQUIRE(f.writer->writes.size() == 1);
+    REQUIRE(f.writer->writes[0].target.devicePath.trackId == keys);
+}
+
+TEST_CASE("Children of a collapsed group take no position", "[osc][sink]") {
+    // The mixer is not drawing them, so a fader landing on one is the "appears
+    // to do nothing" case this addressing exists to avoid.
+    Fixture f;
+    const auto group = f.addTrack("Bus");
+    f.track(group)->type = TrackType::Group;
+    f.track(group)->viewSettings.setCollapsed(ViewMode::Mix, true);
+
+    const auto child = f.addTrack("Kick");
+    f.track(child)->parentId = group;
+    f.track(group)->childIds.push_back(child);
+
+    const auto after = f.addTrack("Keys");
+
+    // Strip 1 is the group itself; strip 2 skips its hidden child.
+    f.apply(OscCommandKind::TrackVolume, 1, 0.5f);
+    f.apply(OscCommandKind::TrackVolume, 2, 0.5f);
+
+    REQUIRE(f.writer->writes.size() == 2);
+    REQUIRE(f.writer->writes[0].target.devicePath.trackId == group);
+    REQUIRE(f.writer->writes[1].target.devicePath.trackId == after);
+
+    // Expanded, the child is a strip again and everything after it shifts.
+    f.writer->writes.clear();
+    f.track(group)->viewSettings.setCollapsed(ViewMode::Mix, false);
+    f.apply(OscCommandKind::TrackVolume, 2, 0.5f);
+
+    REQUIRE(f.writer->writes.size() == 1);
+    REQUIRE(f.writer->writes[0].target.devicePath.trackId == child);
+}
+
 TEST_CASE("A position with no track behind it is ignored", "[osc][sink]") {
     // A sixteen-strip template pointed at a two-track project drives two
     // faders rather than failing.

--- a/tests/test_osc_router.cpp
+++ b/tests/test_osc_router.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -171,6 +172,125 @@ TEST_CASE("Toggles set from a value and flip without one", "[osc][router]") {
 }
 
 // ============================================================================
+// Hostile and malformed arguments
+// ============================================================================
+
+TEST_CASE("Non-finite arguments never reach the model", "[osc][router]") {
+    // A float32 argument is free to be NaN or an infinity, and jlimit
+    // propagates NaN rather than clamping it. This is an unauthenticated UDP
+    // port, so one stray packet must not put NaN into a fader or the playhead.
+    HeldRouter r;
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    const float inf = std::numeric_limits<float>::infinity();
+
+    REQUIRE_FALSE(r.router->handleMessage(juce::OSCMessage("/magda/track/1/volume", nan)));
+    REQUIRE_FALSE(r.router->handleMessage(juce::OSCMessage("/magda/track/1/pan", inf)));
+    REQUIRE_FALSE(r.router->handleMessage(juce::OSCMessage("/magda/master/volume", -inf)));
+    REQUIRE_FALSE(r.router->handleMessage(juce::OSCMessage("/magda/transport/position", nan)));
+    REQUIRE_FALSE(r.router->handleMessage(juce::OSCMessage("/magda/transport/tempo", inf)));
+    REQUIRE_FALSE(r.router->handleMessage(juce::OSCMessage("/magda/focused/macro/1", nan)));
+    r.drain();
+
+    REQUIRE(r.applied().empty());
+}
+
+TEST_CASE("An argument we cannot read is not the same as none", "[osc][router]") {
+    // For a toggle, the *absence* of an argument is the request — flip. So a
+    // message carrying something unreadable must be ignored rather than read as
+    // bare, or a surface speaking an unknown dialect flips mutes.
+    HeldRouter r;
+    REQUIRE_FALSE(
+        r.router->handleMessage(juce::OSCMessage("/magda/track/1/mute", juce::String("on"))));
+    REQUIRE_FALSE(
+        r.router->handleMessage(juce::OSCMessage("/magda/transport/record", juce::String("go"))));
+    REQUIRE_FALSE(r.router->handleMessage(
+        juce::OSCMessage("/magda/track/1/mute", std::numeric_limits<float>::quiet_NaN())));
+    r.drain();
+
+    REQUIRE(r.applied().empty());
+}
+
+// ============================================================================
+// Edges keep their order
+// ============================================================================
+
+TEST_CASE("Two flips of one toggle cancel", "[osc][router]") {
+    // A toggle is an edge, not a value. Latest-value-wins would collapse these
+    // into one flip and leave the track muted.
+    HeldRouter r;
+    r.send(juce::OSCMessage("/magda/track/1/mute"));
+    r.send(juce::OSCMessage("/magda/track/1/mute"));
+    r.drain();
+
+    REQUIRE(r.applied().size() == 2);
+    REQUIRE(r.applied()[0].value == Approx(kOscToggleRequest));
+    REQUIRE(r.applied()[1].value == Approx(kOscToggleRequest));
+}
+
+TEST_CASE("A set followed by a flip keeps both", "[osc][router]") {
+    HeldRouter r;
+    r.send(juce::OSCMessage("/magda/track/1/mute", 1.0f));
+    r.send(juce::OSCMessage("/magda/track/1/mute"));
+    r.drain();
+
+    REQUIRE(r.applied().size() == 2);
+    REQUIRE(r.applied()[0].value == Approx(1.0f));
+    REQUIRE(r.applied()[1].value == Approx(kOscToggleRequest));
+}
+
+TEST_CASE("A stop-locate-play cue lands playing at the new position", "[osc][router]") {
+    // The show-control shape: one bundle, delivered atomically into one drain.
+    // Play and stop are two addresses over one state, so resolving them by slot
+    // number rather than arrival would make this land stopped whatever the
+    // sender intended.
+    HeldRouter r;
+    r.send(juce::OSCMessage("/magda/transport/stop"));
+    r.send(juce::OSCMessage("/magda/transport/position", 64.0f));
+    r.send(juce::OSCMessage("/magda/transport/play"));
+    r.drain();
+
+    REQUIRE(r.applied().size() == 3);
+    // The locate first, so the transport rolls from where the cue put it...
+    REQUIRE(r.applied()[0].command.kind == OscCommandKind::TransportPosition);
+    REQUIRE(r.applied()[0].value == Approx(64.0f));
+    // ...then the edges, in the order they were sent.
+    REQUIRE(r.applied()[1].command.kind == OscCommandKind::TransportStop);
+    REQUIRE(r.applied()[2].command.kind == OscCommandKind::TransportPlay);
+}
+
+TEST_CASE("Play then stop lands stopped, and stop then play lands playing", "[osc][router]") {
+    {
+        HeldRouter r;
+        r.send(juce::OSCMessage("/magda/transport/play"));
+        r.send(juce::OSCMessage("/magda/transport/stop"));
+        r.drain();
+        REQUIRE(r.applied().size() == 2);
+        REQUIRE(r.applied()[1].command.kind == OscCommandKind::TransportStop);
+    }
+    {
+        HeldRouter r;
+        r.send(juce::OSCMessage("/magda/transport/stop"));
+        r.send(juce::OSCMessage("/magda/transport/play"));
+        r.drain();
+        REQUIRE(r.applied().size() == 2);
+        REQUIRE(r.applied()[1].command.kind == OscCommandKind::TransportPlay);
+    }
+}
+
+TEST_CASE("A flood of presses is bounded and counted", "[osc][router]") {
+    // Unbounded ordering would be unbounded memory on an unauthenticated port.
+    HeldRouter r;
+    for (int i = 0; i < 5000; ++i)
+        r.send(juce::OSCMessage("/magda/track/1/mute"));
+
+    REQUIRE(r.router->droppedCommandCount() > 0);
+    r.drain();
+    // What survived is bounded, and every drain makes room for more.
+    REQUIRE(r.applied().size() <= 5000);
+    REQUIRE_FALSE(r.applied().empty());
+}
+
+// ============================================================================
 // Coalescing
 // ============================================================================
 
@@ -295,4 +415,7 @@ TEST_CASE("Every fixed-namespace address survives a round trip", "[osc][router]"
 
     r.drain();
     REQUIRE(static_cast<int>(r.applied().size()) == sent);
+    // Every discrete address pressed at once has to fit: this is the state dump
+    // a surface sends on connect, not a flood.
+    REQUIRE(r.router->droppedCommandCount() == 0);
 }

--- a/tests/test_osc_router.cpp
+++ b/tests/test_osc_router.cpp
@@ -277,6 +277,48 @@ TEST_CASE("Play then stop lands stopped, and stop then play lands playing", "[os
     }
 }
 
+TEST_CASE("A drain yields even while commands keep arriving", "[osc][router]") {
+    // The per-drain cap is what stops a sender holding the message thread
+    // inside one drain by pushing as fast as it is consumed. A sink that
+    // re-sends on every apply is that sender, deterministically: without the
+    // cap the loop below never terminates.
+    //
+    // The cap is also why the follow-up drain must be posted rather than run
+    // through the configured scheduler — the default one applies inline when
+    // already on the message thread, which would recurse a stack level per
+    // batch instead of yielding. That path needs two threads to reach, so it
+    // is not reproducible here; what is testable is the bound it protects.
+    class ResendingSink : public OscCommandSink {
+      public:
+        void apply(const OscCommand& command, float value) override {
+            ++applied;
+            if (router != nullptr)
+                router->handleMessage(juce::OSCMessage("/magda/track/1/mute"));
+            juce::ignoreUnused(command, value);
+        }
+
+        OscRouter* router = nullptr;
+        int applied = 0;
+    };
+
+    auto owned = std::make_unique<ResendingSink>();
+    auto* sink = owned.get();
+    OscRouter router(std::move(owned));
+    sink->router = &router;
+    router.setDrainScheduler([]() {});
+
+    router.handleMessage(juce::OSCMessage("/magda/track/1/mute"));
+    router.drainPending();
+
+    // One drain, one batch: it stopped and handed the thread back.
+    REQUIRE(sink->applied == static_cast<int>(OscRouter::kOrderedCapacity));
+
+    // And the remainder the sink queued is still there for the next one.
+    sink->applied = 0;
+    router.drainPending();
+    REQUIRE(sink->applied > 0);
+}
+
 TEST_CASE("A flood of presses is bounded and counted", "[osc][router]") {
     // Unbounded ordering would be unbounded memory on an unauthenticated port.
     HeldRouter r;

--- a/tests/test_osc_router.cpp
+++ b/tests/test_osc_router.cpp
@@ -1,0 +1,298 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <vector>
+
+#include "../magda/daw/audio/osc/OscRouter.hpp"
+
+using namespace magda::osc;
+using Catch::Approx;
+
+namespace {
+
+struct Applied {
+    OscCommand command;
+    float value = 0.0f;
+};
+
+class RecordingSink : public OscCommandSink {
+  public:
+    void apply(const OscCommand& command, float value) override {
+        applied.push_back({command, value});
+    }
+
+    std::vector<Applied> applied;
+};
+
+/**
+ * A router whose drains are held rather than run, so a test can see what the
+ * coalescing table kept. `drain()` releases them one batch at a time.
+ */
+struct HeldRouter {
+    HeldRouter() {
+        auto owned = std::make_unique<RecordingSink>();
+        sink = owned.get();
+        router = std::make_unique<OscRouter>(std::move(owned));
+        router->setDrainScheduler([this]() { ++drainsRequested; });
+    }
+
+    void send(const juce::OSCMessage& message) {
+        router->handleMessage(message);
+    }
+
+    void drain() {
+        router->drainPending();
+    }
+
+    const std::vector<Applied>& applied() const {
+        return sink->applied;
+    }
+
+    /// Look a value up by what it addressed. A drain walks the slot table, so
+    /// what came out is a set rather than a sequence — asserting on position
+    /// would be asserting on the slot layout.
+    float valueFor(OscCommandKind kind, int index = 0, int subIndex = 0) const {
+        for (const auto& entry : sink->applied)
+            if (entry.command == OscCommand{kind, index, subIndex})
+                return entry.value;
+        FAIL("nothing was applied for that command");
+        return 0.0f;
+    }
+
+    RecordingSink* sink = nullptr;
+    std::unique_ptr<OscRouter> router;
+    int drainsRequested = 0;
+};
+
+}  // namespace
+
+// ============================================================================
+// Accepting and applying
+// ============================================================================
+
+TEST_CASE("A fader message reaches the sink", "[osc][router]") {
+    HeldRouter r;
+    REQUIRE(r.router->handleMessage(juce::OSCMessage("/magda/track/3/volume", 0.62f)));
+    r.drain();
+
+    REQUIRE(r.applied().size() == 1);
+    REQUIRE(r.applied()[0].command.kind == OscCommandKind::TrackVolume);
+    REQUIRE(r.applied()[0].command.index == 3);
+    REQUIRE(r.applied()[0].value == Approx(0.62f));
+}
+
+TEST_CASE("Unknown addresses are declined and change nothing", "[osc][router]") {
+    HeldRouter r;
+    // False rather than an error: a binding may still want this address.
+    REQUIRE_FALSE(r.router->handleMessage(juce::OSCMessage("/magda/track/3/gain", 0.5f)));
+    REQUIRE_FALSE(r.router->handleMessage(juce::OSCMessage("/other/thing", 1.0f)));
+    r.drain();
+
+    REQUIRE(r.applied().empty());
+    REQUIRE(r.router->acceptedMessageCount() == 0);
+}
+
+TEST_CASE("Int and float arguments are read the same way", "[osc][router]") {
+    // Surfaces disagree about which type a button's 1 is.
+    HeldRouter r;
+    r.send(juce::OSCMessage("/magda/track/1/mute", 1));
+    r.send(juce::OSCMessage("/magda/track/2/mute", 1.0f));
+    r.drain();
+
+    REQUIRE(r.applied().size() == 2);
+    REQUIRE(r.valueFor(OscCommandKind::TrackMute, 1) == Approx(1.0f));
+    REQUIRE(r.valueFor(OscCommandKind::TrackMute, 2) == Approx(1.0f));
+}
+
+TEST_CASE("Normalized values are clamped, tempo and position are not", "[osc][router]") {
+    HeldRouter r;
+    r.send(juce::OSCMessage("/magda/track/1/volume", 1.7f));
+    r.send(juce::OSCMessage("/magda/track/2/volume", -0.3f));
+    r.send(juce::OSCMessage("/magda/transport/tempo", 174.0f));
+    r.send(juce::OSCMessage("/magda/transport/position", 64.5f));
+    r.drain();
+
+    REQUIRE(r.applied().size() == 4);
+    REQUIRE(r.valueFor(OscCommandKind::TrackVolume, 1) == Approx(1.0f));
+    REQUIRE(r.valueFor(OscCommandKind::TrackVolume, 2) == Approx(0.0f));
+    // Ranges belong to the model, which knows the project's real limits.
+    REQUIRE(r.valueFor(OscCommandKind::TransportTempo) == Approx(174.0f));
+    REQUIRE(r.valueFor(OscCommandKind::TransportPosition) == Approx(64.5f));
+}
+
+TEST_CASE("A value address with no number says nothing", "[osc][router]") {
+    HeldRouter r;
+    REQUIRE_FALSE(r.router->handleMessage(juce::OSCMessage("/magda/track/1/volume")));
+    // A string where a level belongs is not a level.
+    REQUIRE_FALSE(
+        r.router->handleMessage(juce::OSCMessage("/magda/track/1/volume", juce::String("up"))));
+    r.drain();
+
+    REQUIRE(r.applied().empty());
+}
+
+// ============================================================================
+// Momentary buttons vs toggles
+// ============================================================================
+
+TEST_CASE("Releasing a momentary Play button does not act", "[osc][router]") {
+    HeldRouter r;
+    // TouchOSC sends 1 on press and 0 on release down the same address.
+    REQUIRE(r.router->handleMessage(juce::OSCMessage("/magda/transport/play", 1.0f)));
+    REQUIRE_FALSE(r.router->handleMessage(juce::OSCMessage("/magda/transport/play", 0.0f)));
+    r.drain();
+
+    REQUIRE(r.applied().size() == 1);
+    REQUIRE(r.applied()[0].command.kind == OscCommandKind::TransportPlay);
+    REQUIRE(r.applied()[0].value == Approx(1.0f));
+}
+
+TEST_CASE("A bare trigger fires", "[osc][router]") {
+    HeldRouter r;
+    REQUIRE(r.router->handleMessage(juce::OSCMessage("/magda/transport/stop")));
+    r.drain();
+
+    REQUIRE(r.applied().size() == 1);
+    REQUIRE(r.applied()[0].command.kind == OscCommandKind::TransportStop);
+}
+
+TEST_CASE("Toggles set from a value and flip without one", "[osc][router]") {
+    HeldRouter r;
+    r.send(juce::OSCMessage("/magda/track/1/mute", 1.0f));
+    r.send(juce::OSCMessage("/magda/track/2/mute", 0.0f));
+    r.send(juce::OSCMessage("/magda/track/3/mute"));
+    r.drain();
+
+    REQUIRE(r.applied().size() == 3);
+    REQUIRE(r.valueFor(OscCommandKind::TrackMute, 1) == Approx(1.0f));
+    // A toggle's 0 is a state, not a button release, so it must survive.
+    REQUIRE(r.valueFor(OscCommandKind::TrackMute, 2) == Approx(0.0f));
+    REQUIRE(r.valueFor(OscCommandKind::TrackMute, 3) == Approx(kOscToggleRequest));
+}
+
+// ============================================================================
+// Coalescing
+// ============================================================================
+
+TEST_CASE("A fader stream collapses to its latest value", "[osc][router]") {
+    HeldRouter r;
+    for (int i = 0; i <= 100; ++i)
+        r.send(juce::OSCMessage("/magda/track/1/volume", static_cast<float>(i) / 100.0f));
+
+    // 101 messages, one drain request: the message thread is asked to wake once
+    // however fast the surface sends.
+    REQUIRE(r.drainsRequested == 1);
+    REQUIRE(r.router->acceptedMessageCount() == 101);
+    REQUIRE(r.applied().empty());
+
+    r.drain();
+    REQUIRE(r.applied().size() == 1);
+    REQUIRE(r.applied()[0].value == Approx(1.0f));
+}
+
+TEST_CASE("Separate addresses keep separate values", "[osc][router]") {
+    HeldRouter r;
+    for (int i = 0; i < 50; ++i) {
+        r.send(juce::OSCMessage("/magda/track/1/volume", 0.1f * static_cast<float>(i)));
+        r.send(juce::OSCMessage("/magda/track/2/volume", 0.01f * static_cast<float>(i)));
+        r.send(juce::OSCMessage("/magda/master/volume", 0.5f));
+    }
+    r.drain();
+
+    REQUIRE(r.applied().size() == 3);
+    REQUIRE(r.valueFor(OscCommandKind::MasterVolume) == Approx(0.5f));
+    // Track 1's last value was 4.9, clamped; track 2's was 0.49 and was not.
+    REQUIRE(r.valueFor(OscCommandKind::TrackVolume, 1) == Approx(1.0f));
+    REQUIRE(r.valueFor(OscCommandKind::TrackVolume, 2) == Approx(0.49f));
+}
+
+TEST_CASE("A value arriving during a drain is not stranded", "[osc][router]") {
+    // The drain releases its scheduled flag before walking the table rather
+    // than after. The difference only shows for a value published while a drain
+    // is already running — the ordinary case for a surface that never stops
+    // sending. If that value could not schedule the next drain, the last
+    // position of a fader the user has just let go of would sit unapplied until
+    // they touched it again.
+    //
+    // A sink that sends from inside `apply` reproduces exactly that window
+    // without a second thread. It re-sends to a *lower* slot than the one being
+    // applied, which the walk in progress has already passed, so nothing but a
+    // freshly scheduled drain can deliver it.
+    class ResendingSink : public OscCommandSink {
+      public:
+        void apply(const OscCommand& command, float value) override {
+            applied.push_back({command, value});
+            if (router != nullptr && !resent) {
+                resent = true;
+                router->handleMessage(juce::OSCMessage("/magda/track/1/volume", 0.8f));
+            }
+        }
+
+        OscRouter* router = nullptr;
+        bool resent = false;
+        std::vector<Applied> applied;
+    };
+
+    auto owned = std::make_unique<ResendingSink>();
+    auto* sink = owned.get();
+    OscRouter router(std::move(owned));
+    sink->router = &router;
+
+    int drainsRequested = 0;
+    router.setDrainScheduler([&drainsRequested]() { ++drainsRequested; });
+
+    router.handleMessage(juce::OSCMessage("/magda/track/2/volume", 0.2f));
+    REQUIRE(drainsRequested == 1);
+
+    router.drainPending();
+    REQUIRE(sink->applied.size() == 1);  // track 1's value is still in the table
+    REQUIRE(drainsRequested == 2);       // ...and a drain was asked for to collect it
+
+    router.drainPending();
+    REQUIRE(sink->applied.size() == 2);
+    REQUIRE(sink->applied[1].command.index == 1);
+    REQUIRE(sink->applied[1].value == Approx(0.8f));
+}
+
+TEST_CASE("Draining an empty table applies nothing", "[osc][router]") {
+    HeldRouter r;
+    r.drain();
+    r.drain();
+    REQUIRE(r.applied().empty());
+}
+
+// ============================================================================
+// The whole addressable surface
+// ============================================================================
+
+TEST_CASE("Every fixed-namespace address survives a round trip", "[osc][router]") {
+    // One message per addressable control, all pending at once: the widest the
+    // table ever gets, and the check that no two of them collide on a slot.
+    HeldRouter r;
+    int sent = 0;
+
+    auto send = [&](const juce::String& address, float value) {
+        REQUIRE(r.router->handleMessage(juce::OSCMessage(address, value)));
+        ++sent;
+    };
+
+    send("/magda/transport/record", 1.0f);
+    send("/magda/transport/loop", 1.0f);
+    send("/magda/transport/tempo", 128.0f);
+    send("/magda/transport/position", 16.0f);
+    send("/magda/master/volume", 0.8f);
+    send("/magda/master/pan", 0.5f);
+    for (int macro = 1; macro <= kMaxMacroNumber; ++macro)
+        send("/magda/focused/macro/" + juce::String(macro), 0.25f);
+    for (int track = 1; track <= kMaxTrackNumber; ++track) {
+        send("/magda/track/" + juce::String(track) + "/volume", 0.7f);
+        send("/magda/track/" + juce::String(track) + "/pan", 0.5f);
+        send("/magda/track/" + juce::String(track) + "/mute", 0.0f);
+        send("/magda/track/" + juce::String(track) + "/solo", 0.0f);
+        for (int bus = 1; bus <= kMaxSendNumber; ++bus)
+            send("/magda/track/" + juce::String(track) + "/send/" + juce::String(bus), 0.3f);
+    }
+
+    r.drain();
+    REQUIRE(static_cast<int>(r.applied().size()) == sent);
+}

--- a/tests/test_osc_service_juce.cpp
+++ b/tests/test_osc_service_juce.cpp
@@ -1,0 +1,299 @@
+// Socket lifecycle for the OSC control-surface listener (#1757), and the real
+// datagrams that reach it.
+//
+// Lives in the JUCE target rather than magda_tests because juce::OSCReceiver
+// constructs a MessageListener, which asserts without a MessageManager. That is
+// not a detail worth working around: the thing under test here is a live
+// receive thread delivering packets, and the environment it runs in should be
+// the one the app actually has.
+
+#include <juce_core/juce_core.h>
+#include <juce_osc/juce_osc.h>
+
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "magda/daw/audio/osc/OscService.hpp"
+#include "magda/daw/core/Config.hpp"
+
+using namespace magda;
+using namespace magda::osc;
+
+namespace {
+
+/// Config is a process-wide singleton, so a test that changes it has to put it
+/// back or it leaks into whatever runs next.
+struct ScopedOscConfig {
+    ScopedOscConfig(bool enabled, int port, const std::string& address = "127.0.0.1") {
+        auto& config = Config::getInstance();
+        wasEnabled_ = config.getOscEnabled();
+        previousPort_ = config.getOscReceivePort();
+        previousAddress_ = config.getOscBindAddress();
+        config.setOscEnabled(enabled);
+        config.setOscReceivePort(port);
+        config.setOscBindAddress(address);
+    }
+
+    ~ScopedOscConfig() {
+        auto& config = Config::getInstance();
+        config.setOscEnabled(wasEnabled_);
+        config.setOscReceivePort(previousPort_);
+        config.setOscBindAddress(previousAddress_);
+    }
+
+    ScopedOscConfig(const ScopedOscConfig&) = delete;
+    ScopedOscConfig& operator=(const ScopedOscConfig&) = delete;
+
+  private:
+    bool wasEnabled_ = false;
+    int previousPort_ = 0;
+    std::string previousAddress_;
+};
+
+/// Written by whichever thread drains and read by the test, so it carries its
+/// own lock.
+class ThreadSafeSink : public OscCommandSink {
+  public:
+    void apply(const OscCommand& command, float value) override {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        applied_.push_back({command, value});
+    }
+
+    std::vector<std::pair<OscCommand, float>> taken() {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        return applied_;
+    }
+
+  private:
+    std::mutex mutex_;
+    std::vector<std::pair<OscCommand, float>> applied_;
+};
+
+struct Harness {
+    Harness() {
+        auto ownedSink = std::make_unique<ThreadSafeSink>();
+        sink = ownedSink.get();
+        auto ownedRouter = std::make_unique<OscRouter>(std::move(ownedSink));
+        router = ownedRouter.get();
+        // Hold the drains so the test decides when they run, on its own thread.
+        router->setDrainScheduler([]() {});
+        service = std::make_unique<OscService>(std::move(ownedRouter));
+    }
+
+    /// UDP on loopback is effectively immediate; the deadline exists so a
+    /// failure reports rather than hangs.
+    bool waitForAccepted(std::uint64_t count) {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (router->acceptedMessageCount() >= count)
+                return true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        return false;
+    }
+
+    ThreadSafeSink* sink = nullptr;
+    OscRouter* router = nullptr;
+    std::unique_ptr<OscService> service;
+};
+
+/// A port nothing is listening on, found by binding and immediately releasing
+/// one. Racy in principle, free in practice, and the alternative is hardcoding
+/// a number that collides with whatever else the machine is running.
+int findFreePort() {
+    juce::DatagramSocket probe(false);
+    if (!probe.bindToPort(0, "127.0.0.1"))
+        return 0;
+    return probe.getBoundPort();
+}
+
+}  // namespace
+
+class OscServiceTest final : public juce::UnitTest {
+  public:
+    OscServiceTest() : juce::UnitTest("OSC Service Tests", "magda") {}
+
+    void runTest() override {
+        testDisabledOpensNothing();
+        testEnableAndDisable();
+        testUnchangedConfigKeepsSocket();
+        testPortChangeRebinds();
+        testUnbindableAddressLeavesNothingListening();
+        testDatagramReachesSink();
+        testBundlesAreUnpacked();
+        testForeignAddressIsIgnored();
+        testCloseUnderTraffic();
+    }
+
+  private:
+    void testDisabledOpensNothing() {
+        beginTest("With OSC off, no socket is opened");
+
+        const ScopedOscConfig config(false, 0);
+        Harness h;
+
+        expect(!h.service->applyConfig(), "a disabled service must not report a listener");
+        expect(!h.service->isListening(), "a disabled service must hold no socket");
+        expect(h.service->boundPort() == 0);
+    }
+
+    void testEnableAndDisable() {
+        beginTest("Enabling binds a socket and disabling releases it");
+
+        const ScopedOscConfig config(true, 0);
+        Harness h;
+
+        expect(h.service->applyConfig(), "an enabled service must bind");
+        expect(h.service->isListening());
+        // Port 0 asked the OS for a free one; the service reports what it got.
+        expect(h.service->boundPort() > 0, "the bound port must be discoverable");
+        expect(h.service->boundAddress() == "127.0.0.1");
+
+        Config::getInstance().setOscEnabled(false);
+        expect(!h.service->applyConfig(), "disabling must close the listener");
+        expect(!h.service->isListening());
+        expect(h.service->boundPort() == 0);
+    }
+
+    void testUnchangedConfigKeepsSocket() {
+        beginTest("Reapplying unchanged config keeps the established socket");
+
+        // Every config save reaches every listener. Rebinding on each one would
+        // drop a surface mid-gesture because an unrelated setting changed — and
+        // with an ephemeral port configured, comparing the *bound* port against
+        // the configured 0 would find a mismatch every single time.
+        const ScopedOscConfig config(true, 0);
+        Harness h;
+
+        expect(h.service->applyConfig());
+        const int port = h.service->boundPort();
+
+        expect(h.service->applyConfig());
+        expect(h.service->boundPort() == port, "the socket must not have been rebound");
+    }
+
+    void testPortChangeRebinds() {
+        beginTest("Changing the configured port rebinds");
+
+        const int first = findFreePort();
+        const int second = findFreePort();
+        expect(first > 0 && second > 0 && first != second, "the test needs two free ports");
+
+        const ScopedOscConfig config(true, first);
+        Harness h;
+
+        expect(h.service->applyConfig());
+        expect(h.service->boundPort() == first, "the configured port must be the bound one");
+
+        Config::getInstance().setOscReceivePort(second);
+        expect(h.service->applyConfig());
+        expect(h.service->boundPort() == second, "a port change must take effect immediately");
+    }
+
+    void testUnbindableAddressLeavesNothingListening() {
+        beginTest("An address the OS will not bind leaves no listener");
+
+        // The bind address is the whole of OSC's access control, so failing to
+        // bind must fail closed rather than fall back to every interface.
+        const ScopedOscConfig config(true, 0, "203.0.113.1");  // TEST-NET-3
+        Harness h;
+
+        expect(!h.service->applyConfig(), "an unbindable address must not report success");
+        expect(!h.service->isListening(), "and must not leave a socket open anywhere else");
+    }
+
+    void testDatagramReachesSink() {
+        beginTest("A datagram from a surface reaches the sink");
+
+        const ScopedOscConfig config(true, 0);
+        Harness h;
+        expect(h.service->applyConfig());
+
+        juce::OSCSender sender;
+        expect(sender.connect("127.0.0.1", h.service->boundPort()));
+        expect(sender.send(juce::OSCMessage("/magda/track/2/volume", 0.75f)));
+
+        expect(h.waitForAccepted(1), "the receive thread must accept the message");
+        h.router->drainPending();
+
+        const auto applied = h.sink->taken();
+        expect(applied.size() == 1);
+        if (applied.size() == 1) {
+            expect(applied[0].first.kind == OscCommandKind::TrackVolume);
+            expect(applied[0].first.index == 2);
+            expect(std::abs(applied[0].second - 0.75f) < 1.0e-6f);
+        }
+    }
+
+    void testBundlesAreUnpacked() {
+        beginTest("Bundled messages are unpacked");
+
+        // JUCE hands realtime listeners the bundle rather than its messages, so
+        // a service that implemented only the message callback would go silent
+        // against any surface that bundles — and many do by default.
+        const ScopedOscConfig config(true, 0);
+        Harness h;
+        expect(h.service->applyConfig());
+
+        juce::OSCBundle inner;
+        inner.addElement(juce::OSCMessage("/magda/track/3/pan", 0.25f));
+
+        juce::OSCBundle bundle;
+        bundle.addElement(juce::OSCMessage("/magda/track/1/volume", 0.5f));
+        bundle.addElement(inner);  // nesting is legal and has to survive too
+
+        juce::OSCSender sender;
+        expect(sender.connect("127.0.0.1", h.service->boundPort()));
+        expect(sender.send(bundle));
+
+        expect(h.waitForAccepted(2), "both the message and the nested one must arrive");
+        h.router->drainPending();
+        expect(h.sink->taken().size() == 2);
+    }
+
+    void testForeignAddressIsIgnored() {
+        beginTest("A datagram that is not ours changes nothing");
+
+        const ScopedOscConfig config(true, 0);
+        Harness h;
+        expect(h.service->applyConfig());
+
+        juce::OSCSender sender;
+        expect(sender.connect("127.0.0.1", h.service->boundPort()));
+        expect(sender.send(juce::OSCMessage("/someone/else/fader", 0.5f)));
+        // Then one we do understand, so there is a point by which the first
+        // must already have been processed and declined.
+        expect(sender.send(juce::OSCMessage("/magda/master/volume", 0.5f)));
+
+        expect(h.waitForAccepted(1));
+        h.router->drainPending();
+
+        const auto applied = h.sink->taken();
+        expect(applied.size() == 1, "only the address we own may be applied");
+        if (applied.size() == 1)
+            expect(applied[0].first.kind == OscCommandKind::MasterVolume);
+    }
+
+    void testCloseUnderTraffic() {
+        beginTest("Closing while a surface is still sending is not a crash");
+
+        // The receive thread has to stop before the socket it reads through is
+        // released. This is the window where getting that ordering wrong shows.
+        const ScopedOscConfig config(true, 0);
+        Harness h;
+        expect(h.service->applyConfig());
+
+        juce::OSCSender sender;
+        expect(sender.connect("127.0.0.1", h.service->boundPort()));
+        for (int i = 0; i < 200; ++i)
+            sender.send(juce::OSCMessage("/magda/track/1/volume", 0.005f * static_cast<float>(i)));
+
+        h.service->stop();
+        expect(!h.service->isListening());
+    }
+};
+
+static OscServiceTest oscServiceTest;


### PR DESCRIPTION
First slice of #1757. MAGDA listens on UDP and a TouchOSC-style template
drives it, with no mapping step. One-way: feedback, OSC bindings/learn, the
settings UI and the shipped template are later slices.

`juce_osc` was already in the JUCE submodule and just not in the link line,
so this adds no third-party dependency.

## The namespace

Parsed strictly. A wildcard where a track number belongs, a leading zero, an
out-of-range index, or a trailing component are all rejected rather than
coerced — OSC address *patterns* are a real part of the protocol, and quietly
reading one as an index would mean a surface driving every strip at once when
its author meant one.

Track numbers are mixer positions, not `TrackId`s. IDs survive a reload but
are sparse — delete tracks 2 and 3 and the rest are 1, 4, 5 — and a template's
eight faders are not. A position with no track behind it is ignored, so a
sixteen-strip template on an eight-track project drives eight faders rather
than failing.

Momentary buttons and toggles are distinguished, because surfaces send both
down one address: a `Trigger` ignores a zero argument (the release half of a
press), a `Toggle` treats it as a state and flips when sent no argument at
all. Without that, releasing Play would stop the transport.

## Why it coalesces rather than queues

A tablet mixer sends continuously while a finger is down — 100 Hz per control
is the normal case, and eight strips moving at once is a chord change. Posting
each message would put the UI thread on the far end of a network firehose, and
posting them in order would leave the user's last fader position waiting behind
several hundred stale ones.

So the receive thread publishes values instead of posting messages. Every
address owns a preallocated slot, a store is one relaxed write plus a dirty
bit, and the message thread drains the whole table at once. At most one drain
is ever outstanding whatever the rate; the receive thread allocates nothing and
takes no lock, so a blocked message thread makes MAGDA coarser, never the
network thread slower. The tradeoff is that values are not applied in arrival
order *across* addresses, which is why the namespace carries levels and states
rather than anything sequenced.

## Two paths into the model, deliberately

Levels go through `ControllerParamWriter` — the writer the MIDI surfaces
already use — so an OSC fader, a MIDI fader and an automation curve at the same
position produce the same gain, and its host-write path keeps working when an
LFO or macro is already driving the target. Everything else goes through
`MagdaApi`, which routes states the way the on-screen controls do; play in
particular dispatches through the same playhead-aware path as the Play button.

Notably it does **not** route through `RemoteApiService`. That layer guarantees
one undo step per mutation, which is right for scripted edits and wrong here —
a fader sweep would become a hundred undo entries.

## Security posture

OSC is unauthenticated UDP; the protocol has no notion of a credential. So the
bind address is the whole of the access control and is a setting rather than a
constant, and the service binds its own `DatagramSocket` instead of calling
`OSCReceiver::connect`, which binds every interface unconditionally. Off by
default, and a failed bind fails closed rather than falling back to every
interface. Only control values and transport are exposed — no file or project
operations.

## Incidental fix

`SendLevel` shared a bare `break` with `Tempo` in
`DefaultControllerParamWriter::write`, so a resolved send target went through
the whole binding pipeline and did nothing. Same gap
`test_controller_track_level_write_juce.cpp` was written about when the
track-level kinds had it. OSC is the first caller that needs it, so it is
wired, with a test in that file. `Tempo` keeps the fall-through — OSC sets
tempo through `ProjectApi`, where the project's limits live.

## Testing

- `magda_tests`: the address grammar, the coalescer, and the sink against
  `MockMagdaApi`.
- `magda_juce_tests`: socket lifecycle and real datagrams through a live
  receive thread, plus the send-level writer against the shared engine.

Two bugs were found and are now guarded, each verified by reintroducing it and
watching the test fail:

- the drain released its scheduled flag *after* walking the table, stranding
  any value published mid-drain — for a fader just released, the wrong value
  stays on screen until it is touched again;
- the rebind guard compared the configured port against the *bound* one, so an
  ephemeral port rebound on every unrelated config save.

Bundles are unpacked, which is not optional: JUCE hands realtime listeners the
bundle rather than its messages, so implementing only the message callback goes
silent against any surface that bundles — and many do by default.

**Not verified:** no run against a real surface. OSC is off by default and
there is no settings UI until a later slice, so that needs a hand-edited config
file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
