### PR TITLE
Native engine: the null-diff corpus (#2040)

### DIFF
--- a/magda/engine/clip/ClipMidiSource.cpp
+++ b/magda/engine/clip/ClipMidiSource.cpp
@@ -60,7 +60,21 @@ bool ClipMidiSource::fits(int bytes) const {
 }
 
 void ClipMidiSource::emit(juce::MidiBuffer& out, int sample, const MidiClipEvent& event) {
-    out.addEvent(juce::MidiMessage(event.status, event.data1, event.data2), sample);
+    // Two bytes or three, by status. Program change and channel pressure carry
+    // one data byte, and building them as three makes a message whose length
+    // disagrees with its status: JUCE would hand a synth a byte nobody sent.
+    // MPE is where this stopped being hypothetical, because a note opens with a
+    // channel pressure (MidiClipCompiler.cpp).
+    const auto kind = event.status & 0xf0;
+    const auto message = (kind == 0xc0 || kind == 0xd0)
+                             ? juce::MidiMessage(event.status, event.data1)
+                             : juce::MidiMessage(event.status, event.data1, event.data2);
+
+    out.addEvent(message, sample);
+
+    // Charged as a short message either way. The budget is a ceiling, and one
+    // byte of slack per two-byte message spends it slightly early rather than
+    // slightly late, which is the direction a ceiling should err in.
     bytesUsed_ += kMidiShortMessageBytes;
 }
 

--- a/magda/engine/clip/ClipStretcher.cpp
+++ b/magda/engine/clip/ClipStretcher.cpp
@@ -152,7 +152,8 @@ class SignalsmithClipStretcher final : public ClipStretcher {
 class SoundTouchClipStretcher final : public ClipStretcher {
   public:
     explicit SoundTouchClipStretcher(const StretchSetup& setup)
-        : channels_(setup.numChannels), maxBlockSamples_(setup.maxBlockSamples) {
+        : channels_(setup.numChannels),
+          maxBlockSamples_(stretchWorkSamples(setup.maxBlockSamples)) {
         touch_.setChannels(static_cast<unsigned int>(channels_));
         touch_.setSampleRate(static_cast<unsigned int>(setup.sampleRate));
 
@@ -173,7 +174,8 @@ class SoundTouchClipStretcher final : public ClipStretcher {
         // Grown here, on the thread that made this, and never again.
         const auto frames = maxReadingSamples(setup.maxBlockSamples);
         interleaved_.resize(static_cast<std::size_t>(frames * channels_));
-        deinterleaved_.resize(static_cast<std::size_t>(setup.maxBlockSamples * channels_));
+        deinterleaved_.resize(
+            static_cast<std::size_t>(stretchWorkSamples(setup.maxBlockSamples) * channels_));
 
         allocatePreRoll(channels_, static_cast<int>(std::ceil(preRollSamples(setup.nominalRate) *
                                                               kPreRollHeadroom)));

--- a/magda/engine/clip/ClipStretcher.hpp
+++ b/magda/engine/clip/ClipStretcher.hpp
@@ -3,6 +3,7 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_dsp/juce_dsp.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 
@@ -227,8 +228,33 @@ constexpr double kMaxStretchRate = 10.0;
  * the way one with a ratio past the ceiling already does, rather than writing
  * where it should not.
  */
+/**
+ * @brief How much output a stretcher is driven in at a time.
+ *
+ * A voice feeds a stretcher on a fixed grid rather than a block at a time, so
+ * that what it receives follows position on the timeline and not how the
+ * callback was cut up (ClipVoice::renderThroughCells). This is that grid, and
+ * it lives here rather than with the voice because everything sized against a
+ * stretcher has to be sized against it: a device running 64-sample blocks still
+ * drives whole 128-sample cells through, and a capacity derived from the block
+ * would be half of what one cell needs.
+ */
+constexpr int kStretchCellSamples = 128;
+
+/**
+ * @brief The most output a stretcher can be asked for in one go.
+ *
+ * The block, or one cell, whichever is larger. Below the cell size the block
+ * stops being the unit anything is driven in, and sizing from it would leave a
+ * stretcher writing half a cell and zero-filling the rest, which is audible as
+ * alternating material and silence rather than as an error anybody sees.
+ */
+inline int stretchWorkSamples(int maxBlockSamples) {
+    return std::max(maxBlockSamples, kStretchCellSamples);
+}
+
 inline int maxReadingSamples(int maxBlockSamples) {
-    return static_cast<int>(maxBlockSamples * kMaxStretchRate) + 1;
+    return static_cast<int>(stretchWorkSamples(maxBlockSamples) * kMaxStretchRate) + 1;
 }
 
 /**
@@ -238,7 +264,7 @@ inline int maxReadingSamples(int maxBlockSamples) {
  * consume.
  */
 inline int stretchScratchSamples(int maxBlockSamples) {
-    return maxBlockSamples + maxReadingSamples(maxBlockSamples);
+    return stretchWorkSamples(maxBlockSamples) + maxReadingSamples(maxBlockSamples);
 }
 
 }  // namespace magda::engine

--- a/magda/engine/clip/ClipVoice.cpp
+++ b/magda/engine/clip/ClipVoice.cpp
@@ -12,6 +12,11 @@ namespace magda::engine {
 void ClipVoice::prepare(const RenderContext& context) {
     sampleRate_ = context.sampleRate;
     maxBlockSamples_ = context.maxBlockSize;
+
+    // One cell of output, off the callback. What a cell produces beyond the
+    // block that asked for it waits here.
+    held_.setSize(std::max(1, context.numChannels), kCellSamples, false, true, false);
+
     release();
 }
 
@@ -20,6 +25,126 @@ void ClipVoice::release() {
     eventId_ = INVALID_EVENT_ID;
     sounded_ = false;
     primed_ = nullptr;
+    deClick_.reset();
+    pending_ = false;
+    pendingCount_ = 0;
+    pendingRead_ = 0;
+    skip_ = 0;
+}
+
+bool ClipVoice::renderThroughCells(const AudioClipPlayback& clip, const AudioEventPlayback& event,
+                                   const BlockInfo& block, PrefetchStream& stream,
+                                   ClipStretcher& stretcher, int preRoll,
+                                   juce::dsp::AudioBlock<float> scratch,
+                                   juce::dsp::AudioBlock<float> region, double windowStart,
+                                   int count) {
+    // The grid, in samples of the timeline, anchored to where the event begins
+    // rather than to where this block does. That anchor is the whole point: two
+    // renders that cut the timeline into different blocks still divide it into
+    // the same cells, so the stretcher is handed the same input in the same
+    // order both times and gives back the same samples.
+    const auto eventStartSample =
+        static_cast<std::int64_t>(std::llround(event.span.startSeconds * sampleRate_));
+    const auto windowStartSample =
+        static_cast<std::int64_t>(std::llround(windowStart * sampleRate_));
+
+    // Beginning rather than carrying on: the first block of a voice, the first
+    // after the timeline jumped, and one whose stretcher the pool has replaced.
+    // Not after an underrun, deliberately, and that is the difference between a
+    // reader catching up and one that never does: priming reads behind the
+    // position wanted, so a stream that came back short and was primed again
+    // would be sent backwards every block.
+    auto needsPrime = primed_ != &stretcher || !block.continuous || !pending_;
+
+    if (needsPrime) {
+        // Back to the cell boundary at or before where playback resumes, and
+        // the head of that cell is produced and dropped. Resuming mid-cell
+        // would anchor the grid to wherever the transport happened to land,
+        // which is the block dependency again wearing a locate's clothes.
+        const auto offset = windowStartSample - eventStartSample;
+        const auto index = static_cast<std::int64_t>(
+            std::floor(static_cast<double>(offset) / static_cast<double>(kCellSamples)));
+
+        nextCell_ = eventStartSample + index * kCellSamples;
+        pendingCount_ = 0;
+        pendingRead_ = 0;
+        skip_ = static_cast<int>(windowStartSample - nextCell_);
+
+        stretcher.reset();
+        primed_ = &stretcher;
+        pending_ = true;
+    }
+
+    auto produced = 0;
+    auto full = true;
+
+    while (produced < count) {
+        if (pendingRead_ < pendingCount_) {
+            const auto take = std::min(pendingCount_ - pendingRead_, count - produced);
+            for (std::size_t channel = 0; channel < region.getNumChannels(); ++channel) {
+                const auto* source = held_.getReadPointer(static_cast<int>(
+                    std::min(channel, static_cast<std::size_t>(held_.getNumChannels() - 1))));
+                auto* destination = region.getChannelPointer(channel);
+                std::copy(source + pendingRead_, source + pendingRead_ + take,
+                          destination + produced);
+            }
+
+            pendingRead_ += take;
+            produced += take;
+            continue;
+        }
+
+        // One whole cell, at its own two ends. The ratio a cell runs at is what
+        // its own boundaries say, exactly as a block's used to be, and the
+        // boundaries no longer move.
+        const auto cellStartSeconds = static_cast<double>(nextCell_) / sampleRate_;
+        const auto cellEndSeconds = static_cast<double>(nextCell_ + kCellSamples) / sampleRate_;
+
+        const auto opens = readingPositionAt(clip, event, cellStartSeconds,
+                                             block.beatAtTime(cellStartSeconds), sampleRate_);
+        const auto closes = readingPositionAt(clip, event, cellEndSeconds,
+                                              block.beatAtTime(cellEndSeconds), sampleRate_);
+        const auto step = (closes - opens) / kCellSamples;
+
+        const auto ahead = stretcher.readAheadSamples();
+        const auto readFrom = static_cast<std::int64_t>(std::llround(opens)) + ahead;
+        const auto readTo = static_cast<std::int64_t>(std::llround(closes)) + ahead;
+        const auto wanted = static_cast<int>(
+            std::clamp<std::int64_t>(readTo - readFrom, 0, maxReadingSamples(maxBlockSamples_)));
+
+        if (needsPrime) {
+            // At the cell's own boundary rather than at the block's, so what
+            // the stretcher is primed with is the material leading up to a
+            // fixed instant. Read out of the same stream in the same pass, so
+            // the cell's own read continues it rather than seeking again.
+            stretcher.prime(stream, readFrom, preRoll, step);
+            needsPrime = false;
+        }
+
+        auto reading = scratch.getSubBlock(static_cast<std::size_t>(maxBlockSamples_),
+                                           static_cast<std::size_t>(wanted));
+        const auto delivered = stream.read(readFrom, reading, wanted);
+
+        juce::dsp::AudioBlock<float> cell(held_);
+        auto cellOut = cell.getSubBlock(0, static_cast<std::size_t>(kCellSamples));
+        stretcher.process(reading, opens - static_cast<double>(readFrom), step, cellOut);
+
+        nextCell_ += kCellSamples;
+        pendingCount_ = kCellSamples;
+        pendingRead_ = std::min(skip_, kCellSamples);
+        skip_ = std::max(0, skip_ - kCellSamples);
+
+        // A cell the reader could not fill is a cell that ends in silence, and
+        // the voice is no longer carrying on from anywhere. Said rather than
+        // acted on: the block is still filled to its end, exactly as the plain
+        // path fills it, because stopping here would leave the rest of the
+        // region holding whatever the scratch held last and would put the voice
+        // a block behind for the rest of the take.
+        if (delivered < wanted)
+            full = false;
+    }
+
+    return full;
 }
 
 void ClipVoice::applyFade(juce::dsp::AudioBlock<float> region, int regionFirstSample,
@@ -67,6 +192,7 @@ bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& 
         eventId_ = event.eventId;
         sounded_ = false;
         primed_ = nullptr;
+        deClick_.reset();
     }
 
     const auto nothing = [this] {
@@ -151,31 +277,21 @@ bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& 
                                              static_cast<std::size_t>(wanted))
                        : region;
 
-    // Beginning rather than carrying on: the first block of a voice, and the
-    // first after the timeline jumped. Whatever the stretcher was holding is for
-    // somewhere else, and what replaces it is the material leading up to here,
-    // read out of the same stream in the same pass so that the block's own read
-    // continues it rather than seeking again.
+    // A clip that consumes its reading at a rate is fed on a grid of its own
+    // rather than a block at a time, so that what the stretcher is handed is a
+    // function of where the timeline is and never of how the callback was cut
+    // up (renderThroughCells). Everything else here is the plain path: one
+    // sample of reading per sample of output, where a block boundary already
+    // changes nothing.
     //
-    // Not after an underrun, deliberately, and this is the difference between a
-    // reader catching up and one that never does. Priming reads behind the
-    // position the block wants, so a stream that came back short and was primed
-    // again for it would be sent backwards every block, and every one of those
-    // is a seek that guarantees the next block is short too. A stretcher handed
-    // silence and then material has a discontinuity in what it is playing, which
-    // is what a loop wrap is as well, and neither needs anything said about it.
-    // A stretcher this voice has not primed is either its first or one the pool
-    // has just put in place of the last, and both need the same thing.
-    if (stretcher != nullptr && (primed_ != stretcher || !block.continuous)) {
-        stretcher->reset();
-        stretcher->prime(stream, readFrom, preRoll, step);
-        primed_ = stretcher;
-    }
-
-    const auto delivered = stream.read(readFrom, reading, wanted);
-
-    if (stretcher != nullptr)
-        stretcher->process(reading, opens - static_cast<double>(readFrom), step, region);
+    // Both answer the same question, which is whether this voice got everything
+    // it asked for. What "everything" counts in differs: the plain path asks
+    // the reader for a block's worth of samples, and the grid asks it for
+    // whatever a cell consumes and then measures what it produced.
+    const auto full = stretcher != nullptr
+                          ? renderThroughCells(clip, event, block, stream, *stretcher, preRoll,
+                                               scratch, region, windowStart, count)
+                          : stream.read(readFrom, reading, wanted) == wanted;
 
     // The holes, cleared out of what was read rather than skipped over.
     for (const auto& hole : clip.silenced) {
@@ -253,8 +369,30 @@ bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& 
     // Beginning rather than carrying on: the first block of a voice, the first
     // after the timeline jumped, and the first after the reader came back from
     // an underrun. All three start the material wherever it happens to be.
-    if (!sounded_ || !block.continuous)
-        applyStartDeClick(region, clip.launchFadeSamples);
+    //
+    // Except one, and it is the whole reason this is a condition rather than a
+    // call. A voice starting at the beginning of what it plays is not starting
+    // mid-material: there is nothing before it to be discontinuous with, and
+    // what looks like a step is the material's own attack. De-clicking there
+    // subtracts the attack and decays the correction over the ramp, so a clip
+    // whose first sample is a transient loses it and gains 256 samples of tail.
+    // The corpus found exactly that on an impulse sitting on a clip edge
+    // (#2040), and the incumbent does not do it.
+    //
+    // A ramp longer than the block it starts in goes on into the next one. It
+    // has to: clamping it to the block would make the same clip come out
+    // differently at 128 samples a block and at 1024, and an offline render at
+    // one size disagree with playback at another.
+    const auto beginsAtItsOwnStart = windowStart <= event.span.startSeconds + (0.5 / sampleRate_);
+
+    if (!sounded_ || !block.continuous) {
+        if (beginsAtItsOwnStart)
+            deClick_.reset();
+        else
+            deClick_.begin(region, clip.launchFadeSamples);
+    } else {
+        deClick_.advance(region);
+    }
 
     out.getSubBlock(static_cast<std::size_t>(first), static_cast<std::size_t>(count)).add(region);
 
@@ -266,7 +404,7 @@ bool ClipVoice::render(const AudioClipPlayback& clip, const AudioEventPlayback& 
     // Against what was asked for rather than against the block: a stretched clip
     // consumes a different amount of reading than it renders, and a full block
     // built out of a short read is exactly the case this has to catch.
-    sounded_ = delivered == wanted;
+    sounded_ = full;
     return true;
 }
 

--- a/magda/engine/clip/ClipVoice.cpp
+++ b/magda/engine/clip/ClipVoice.cpp
@@ -11,7 +11,7 @@ namespace magda::engine {
 
 void ClipVoice::prepare(const RenderContext& context) {
     sampleRate_ = context.sampleRate;
-    maxBlockSamples_ = context.maxBlockSize;
+    maxBlockSamples_ = stretchWorkSamples(context.maxBlockSize);
 
     // One cell of output, off the callback. What a cell produces beyond the
     // block that asked for it waits here.

--- a/magda/engine/clip/ClipVoice.hpp
+++ b/magda/engine/clip/ClipVoice.hpp
@@ -5,6 +5,7 @@
 
 #include "clip/ClipSnapshot.hpp"
 #include "clip/ClipStretcher.hpp"
+#include "clip/FadeCurves.hpp"
 #include "exec/RenderContext.hpp"
 #include "io/PrefetchStream.hpp"
 
@@ -95,11 +96,51 @@ class ClipVoice {
                 juce::dsp::AudioBlock<float> out);
 
   private:
+    /**
+     * @brief Render @p count samples of a clip that consumes its reading at a
+     *        rate, feeding the stretcher on a fixed grid.
+     *
+     * Why a grid at all. A stretcher is a stateful thing whose output follows
+     * the sequence of sizes it was handed, and a rate that varies within a
+     * block used to be resolved from that block's own two ends. Both make the
+     * result a function of how the callback was cut up, which RenderContext.hpp
+     * forbids: block size is an I/O batching concept and never a precision one.
+     * A bounce at 1024 samples a block that disagrees with playback at 128 is
+     * the audible form of the same thing.
+     *
+     * So the timeline is divided into cells anchored to where the event begins,
+     * the ratio is resolved per cell from the same readingPositionAt, and the
+     * stretcher is fed one whole cell at a time. What it receives is then a
+     * function of position on the timeline and of nothing else. Cells rarely
+     * line up with blocks, so what a cell produces beyond the block that asked
+     * for it is held here until the next one.
+     *
+     * @return whether every cell got the reading it asked for. The region is
+     *         filled either way.
+     */
+    bool renderThroughCells(const AudioClipPlayback& clip, const AudioEventPlayback& event,
+                            const BlockInfo& block, PrefetchStream& stream,
+                            ClipStretcher& stretcher, int preRoll,
+                            juce::dsp::AudioBlock<float> scratch,
+                            juce::dsp::AudioBlock<float> region, double windowStart, int count);
+
     /// Multiply the part of @p region inside [@p startSeconds, @p endSeconds)
     /// by a curve running across it, rising or falling.
     void applyFade(juce::dsp::AudioBlock<float> region, int regionFirstSample,
                    const BlockInfo& block, double startSeconds, double endSeconds, FadeCurve curve,
                    bool rising) const;
+
+    /**
+     * @brief How much timeline one cell covers.
+     *
+     * Small enough that a curved rate is still nearly straight across one, and
+     * that is the only thing it has to be: it is not a latency, because a cell
+     * is produced when it is wanted rather than ahead of time, and it is not a
+     * block, because the reader is asked for exactly what the cell consumes.
+     * A power of two so that a block size which is one lines up with it and
+     * nothing is held over.
+     */
+    static constexpr int kCellSamples = 128;
 
     double sampleRate_ = 44100.0;
 
@@ -114,6 +155,27 @@ class ClipVoice {
     /// voice that is beginning from one that is carrying on, which is the
     /// difference the launch ramp is for.
     bool sounded_ = false;
+
+    /// The launch ramp in progress, which outlives the block that started it.
+    /// A ramp is 256 samples by default and a block can be shorter than that,
+    /// so a ramp that lived inside one block would be a different length at
+    /// every block size (FadeCurves.hpp).
+    StartDeClick deClick_;
+
+    /// One cell's output, and how much of it a block has taken. Allocated in
+    /// prepare(), never on the callback.
+    juce::AudioBuffer<float> held_;
+    int pendingCount_ = 0;
+    int pendingRead_ = 0;
+
+    /// Whether the grid is running at all, and where its next cell begins, in
+    /// samples of the timeline.
+    bool pending_ = false;
+    std::int64_t nextCell_ = 0;
+
+    /// Samples of the first cell that lie before where playback resumed, and
+    /// are produced only to be dropped. Never more than a cell.
+    int skip_ = 0;
 
     /// The stretcher this voice primed, or null for one that has not primed
     /// anything. An identity rather than a flag, because the pool replaces a

--- a/magda/engine/clip/ClipVoice.hpp
+++ b/magda/engine/clip/ClipVoice.hpp
@@ -130,22 +130,18 @@ class ClipVoice {
                    const BlockInfo& block, double startSeconds, double endSeconds, FadeCurve curve,
                    bool rising) const;
 
-    /**
-     * @brief How much timeline one cell covers.
-     *
-     * Small enough that a curved rate is still nearly straight across one, and
-     * that is the only thing it has to be: it is not a latency, because a cell
-     * is produced when it is wanted rather than ahead of time, and it is not a
-     * block, because the reader is asked for exactly what the cell consumes.
-     * A power of two so that a block size which is one lines up with it and
-     * nothing is held over.
-     */
-    static constexpr int kCellSamples = 128;
+    /// How much timeline one cell covers. Small enough that a curved rate is
+    /// still nearly straight across one, and that is the only thing it has to
+    /// be. It lives beside the stretcher because everything sized against one
+    /// is sized against this (ClipStretcher.hpp).
+    static constexpr int kCellSamples = kStretchCellSamples;
 
     double sampleRate_ = 44100.0;
 
-    /// Where in the scratch the reading starts: past the longest block this
-    /// voice can be asked to render, because both live in the one buffer.
+    /// Where in the scratch the reading starts, and the most output anything is
+    /// driven in at once: the longest block, or one cell, whichever is larger.
+    /// Both live in the one buffer, and a device below the cell size still
+    /// drives whole cells through (ClipStretcher.hpp).
     int maxBlockSamples_ = 512;
 
     ClipId clipId_ = INVALID_CLIP_ID;

--- a/magda/engine/clip/ClipVoicePool.cpp
+++ b/magda/engine/clip/ClipVoicePool.cpp
@@ -211,6 +211,23 @@ std::size_t ClipVoicePool::streamCount() const {
     return streams_.size();
 }
 
+void ClipVoicePool::fillNow() {
+    if (reader_.runsInBackground()) {
+        jassertfalse;  // see the header: this is a race, not a slow path
+        return;
+    }
+
+    // Until nothing has room left, which is bounded by the chunks a pool holds
+    // times the streams there are: fill() takes one chunk per stream per round
+    // and says whether it did anything. The count is a backstop against a
+    // reader that answers true for ever rather than a real limit, and it is far
+    // above what a full pool can need.
+    constexpr int kMaxRounds = 4096;
+    for (auto round = 0; round < kMaxRounds; ++round)
+        if (!reader_.fillOnce())
+            return;
+}
+
 std::int64_t ClipVoicePool::cueFor(const AudioClipPlayback& clip, const AudioEventPlayback& event,
                                    double seconds, const Reader& reader) const {
     const auto position =

--- a/magda/engine/clip/ClipVoicePool.hpp
+++ b/magda/engine/clip/ClipVoicePool.hpp
@@ -186,6 +186,23 @@ class ClipVoicePool {
      */
     void service();
 
+    /**
+     * @brief Read every provisioned stream up to capacity, here and now.
+     *
+     * For a caller with no callback to starve, which in practice means an
+     * offline render. Servicing alone only opens files and points readers at
+     * them; what a voice actually copies out of is what the prefetch thread has
+     * managed to fetch, and a render moving a second of timeline every ten
+     * milliseconds outruns any thread. Doing the reading in step makes the
+     * render a function of the material rather than of the scheduler.
+     *
+     * Refuses when the reader has a thread of its own, because two things
+     * inside one stream's fill is a race over its cursor rather than a slow
+     * path. A host that wants this builds its PrefetchThread with the thread
+     * switched off.
+     */
+    void fillNow();
+
     /// Streams provisioned right now, for tests and diagnostics.
     std::size_t streamCount() const;
 

--- a/magda/engine/clip/FadeCurves.cpp
+++ b/magda/engine/clip/FadeCurves.cpp
@@ -58,32 +58,66 @@ double fadeRampPosition(FadeCurve curve, double alpha, bool rising) {
     return rising ? (alpha * alpha * 0.5) + 0.5 : ((-(alpha - 1.0) * (alpha - 1.0)) * 0.5) + 0.5;
 }
 
-void applyStartDeClick(juce::dsp::AudioBlock<float> audio, int fadeSamples) {
-    const auto length = std::min(static_cast<std::size_t>(std::max(0, fadeSamples)),
-                                 static_cast<std::size_t>(audio.getNumSamples()));
-    if (length == 0)
+void StartDeClick::begin(juce::dsp::AudioBlock<float> audio, int fadeSamples) {
+    reset();
+
+    length_ = std::max(0, fadeSamples);
+    if (length_ == 0 || audio.getNumSamples() == 0)
         return;
 
-    for (std::size_t channel = 0; channel < audio.getNumChannels(); ++channel) {
-        auto* samples = audio.getChannelPointer(channel);
-        const auto discontinuity = samples[0];
+    // The step, read once, from the first sample of each channel. Once rather
+    // than per block, because the correction that follows is a decay of THIS
+    // number: re-reading it in the next block would take the step out of
+    // whatever the material happened to be doing there instead.
+    const auto channels = std::min(audio.getNumChannels(), kMaxChannels);
+    for (std::size_t channel = 0; channel < channels; ++channel)
+        offsets_[channel] = audio.getChannelPointer(channel)[0];
+
+    applyFrom(audio, 0);
+}
+
+void StartDeClick::advance(juce::dsp::AudioBlock<float> audio) {
+    if (!active())
+        return;
+
+    applyFrom(audio, done_);
+}
+
+void StartDeClick::applyFrom(juce::dsp::AudioBlock<float> audio, int alreadyDone) {
+    const auto remaining = length_ - alreadyDone;
+    if (remaining <= 0)
+        return;
+
+    const auto count = std::min(static_cast<std::size_t>(remaining), audio.getNumSamples());
+    const auto channels = std::min(audio.getNumChannels(), kMaxChannels);
+
+    for (std::size_t channel = 0; channel < channels; ++channel) {
+        const auto discontinuity = offsets_[channel];
 
         // Nothing to step down from. A voice that begins on a zero crossing,
         // and every voice that begins with a fade in, lands here.
         if (discontinuity == 0.0f)
             continue;
 
-        if (length == 1) {
-            samples[0] = 0.0f;
+        auto* samples = audio.getChannelPointer(channel);
+
+        if (length_ == 1) {
+            samples[0] -= discontinuity;
             continue;
         }
 
-        for (std::size_t i = 0; i < length; ++i) {
-            const auto phase = static_cast<float>(i) / static_cast<float>(length - 1);
+        for (std::size_t i = 0; i < count; ++i) {
+            // Phase runs across the whole ramp rather than across this block,
+            // which is the whole point of carrying the progress: the same clip
+            // has to come out the same however the render was cut up.
+            const auto phase = static_cast<float>(alreadyDone + static_cast<int>(i)) /
+                               static_cast<float>(length_ - 1);
             const auto correction = 0.5f * (1.0f + std::cos(kPi * phase));
             samples[i] -= discontinuity * correction;
         }
     }
+
+    done_ = alreadyDone + static_cast<int>(count);
 }
 
 }  // namespace magda::engine

--- a/magda/engine/clip/FadeCurves.hpp
+++ b/magda/engine/clip/FadeCurves.hpp
@@ -3,6 +3,9 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_dsp/juce_dsp.h>
 
+#include <array>
+#include <cstddef>
+
 #include "core/ClipInfo.hpp"
 
 /**
@@ -51,11 +54,11 @@ float fadeGain(FadeCurve curve, float alpha);
 double fadeRampPosition(FadeCurve curve, double alpha, bool rising);
 
 /**
- * @brief Return the start of @p audio to zero without fading what follows it.
+ * @brief Return the start of a voice to zero without fading what follows it.
  *
  * The launch ramp (ClipInfo::launchFadeSamples), and deliberately not a fade:
  * it subtracts the offset the first sample starts at, decaying that correction
- * over @p fadeSamples, so a transient sitting on top of the offset survives
+ * over the ramp's length, so a transient sitting on top of the offset survives
  * intact. A gain fade would flatten the transient along with the step.
  *
  * What it is for is the discontinuity of starting mid-material: a locate into
@@ -64,9 +67,50 @@ double fadeRampPosition(FadeCurve curve, double alpha, bool rising);
  * offset to remove and this costs it nothing, which is why it can be applied
  * wherever a voice begins rather than only where somebody decided it clicks.
  *
- * @p fadeSamples of 0 does nothing at all, which is how the leading transient
- * is preserved exactly.
+ * It carries across blocks, which is why it is a small object rather than a
+ * function. A ramp that stopped at the end of the block it started in would
+ * decay over min(length, block) samples, so the same clip would come out
+ * differently at 128 samples a block and at 1024, and an offline render at one
+ * block size would disagree with playback at another. Block size is an I/O
+ * batching concept and never a precision one (RenderContext.hpp), and this is
+ * the state that keeps that true here.
+ *
+ * A length of 0 does nothing at all, which is how the leading transient is
+ * preserved exactly.
  */
-void applyStartDeClick(juce::dsp::AudioBlock<float> audio, int fadeSamples);
+class StartDeClick {
+  public:
+    /// The most channels one voice renders. Two today; sized for a little more
+    /// so that a wider clip is a compile-time decision rather than a heap
+    /// allocation on the audio thread.
+    static constexpr std::size_t kMaxChannels = 8;
+
+    /// Take the step out of @p audio, and remember enough to go on doing it in
+    /// the blocks after this one. The offset is read from the first sample of
+    /// each channel, once, here.
+    void begin(juce::dsp::AudioBlock<float> audio, int fadeSamples);
+
+    /// Carry on. Does nothing once the ramp has run out, so a caller can ask
+    /// every block without checking.
+    void advance(juce::dsp::AudioBlock<float> audio);
+
+    /// Whether there is any correction left to apply.
+    bool active() const {
+        return done_ < length_;
+    }
+
+    /// Forget the ramp, for a voice that is starting over.
+    void reset() {
+        length_ = 0;
+        done_ = 0;
+    }
+
+  private:
+    void applyFrom(juce::dsp::AudioBlock<float> audio, int alreadyDone);
+
+    std::array<float, kMaxChannels> offsets_{};
+    int length_ = 0;
+    int done_ = 0;
+};
 
 }  // namespace magda::engine

--- a/magda/engine/clip/MidiClipCompiler.cpp
+++ b/magda/engine/clip/MidiClipCompiler.cpp
@@ -13,7 +13,15 @@ namespace {
 constexpr std::uint8_t kNoteOn = 0x90;
 constexpr std::uint8_t kNoteOff = 0x80;
 constexpr std::uint8_t kControlChange = 0xb0;
+constexpr std::uint8_t kChannelPressure = 0xd0;
 constexpr std::uint8_t kPitchWheel = 0xe0;
+
+/// The MPE timbre dimension, and the two values a note opens with. Timbre rests
+/// at the centre of its range and pressure at the bottom of its, which is what
+/// the fork writes for a note carrying neither.
+constexpr std::uint8_t kMpeTimbreController = 74;
+constexpr std::uint8_t kMpeTimbreRest = 64;
+constexpr std::uint8_t kMpePressureRest = 0;
 
 /// The wheel at rest. A clip whose every pitch-bend event sits here is skipped
 /// whole: a stream of no-op wheel messages is pointless and deadlocks fragile
@@ -36,12 +44,14 @@ int rankOf(std::uint8_t status) {
     switch (status & 0xf0u) {
         case kControlChange:
             return 0;
-        case kPitchWheel:
+        case kChannelPressure:
             return 1;
-        case kNoteOff:
+        case kPitchWheel:
             return 2;
-        default:
+        case kNoteOff:
             return 3;
+        default:
+            return 4;
     }
 }
 
@@ -299,6 +309,33 @@ MidiEventList compileMidiEvents(const ClipInfo& clip, double curveFloorBeats) {
                 endBeat = notes[j].startBeat;
                 break;
             }
+        }
+
+        // ---- The MPE dimensions a note opens with --------------------------
+        //
+        // The specification asks for timbre before the note-on and pressure
+        // beside it, and the fork sends both for every note it puts on a member
+        // channel. A synth that never receives them is left holding whatever
+        // the last note on that channel set, which under a round-robin is
+        // another note's expression: the channel is reused, so the state is
+        // inherited rather than fresh.
+        //
+        // At their resting values, because the model carries neither dimension:
+        // per-note expression here is pitch, and nothing in the clip can move
+        // timbre or pressure. Sending them at rest is what makes the channel
+        // mean the same thing to a synth as it does in the fork.
+        //
+        // Ordered before the note-on by the same rule as everything else at one
+        // instant: controllers, then pitch bend, then offs, then ons.
+        if (list.mpe) {
+            pending.push_back(
+                PendingEvent{MidiClipEvent{note.startBeat, statusFor(kControlChange, channel),
+                                           kMpeTimbreController, kMpeTimbreRest, 0.0},
+                             pairId});
+            pending.push_back(
+                PendingEvent{MidiClipEvent{note.startBeat, statusFor(kChannelPressure, channel),
+                                           kMpePressureRest, 0, 0.0},
+                             pairId});
         }
 
         pending.push_back(PendingEvent{

--- a/magda/engine/clip/MidiClipCompiler.cpp
+++ b/magda/engine/clip/MidiClipCompiler.cpp
@@ -477,11 +477,18 @@ MidiEventList compileMidiEvents(const ClipInfo& clip, double curveFloorBeats) {
     for (std::size_t i = 0; i < list.events.size(); ++i) {
         const auto& event = list.events[i];
         const auto kind = event.kind();
-        if (kind != kControlChange && kind != kPitchWheel)
+        if (kind != kControlChange && kind != kPitchWheel && kind != kChannelPressure)
             continue;
 
-        const auto controller =
-            kind == kPitchWheel ? MidiControllerStream::kPitchBend : static_cast<int>(event.data1);
+        // Channel pressure is indexed with the rest. It is per-channel state a
+        // synth holds exactly as it holds a controller, so a locate has to
+        // restore it: an MPE member channel is reused round robin, and a note
+        // located into on a channel still carrying another note's pressure is
+        // the same staleness the compile emits a resting value at every note
+        // start to avoid.
+        const auto controller = kind == kPitchWheel        ? MidiControllerStream::kPitchBend
+                                : kind == kChannelPressure ? MidiControllerStream::kChannelPressure
+                                                           : static_cast<int>(event.data1);
 
         auto found = std::find_if(list.controllers.begin(), list.controllers.end(),
                                   [&](const MidiControllerStream& stream) {

--- a/magda/engine/clip/MidiEventList.hpp
+++ b/magda/engine/clip/MidiEventList.hpp
@@ -102,13 +102,20 @@ struct MidiControllerStream {
     /// 1 to 16.
     int channel = 1;
 
-    /// The controller number, or @ref kPitchBend.
+    /// The controller number, or @ref kPitchBend, or @ref kChannelPressure.
     int controller = 0;
 
     /// Indices into MidiEventList::events, ascending.
     std::vector<std::int32_t> events;
 
     static constexpr int kPitchBend = 256;
+
+    /// Channel pressure. Per-channel state a synth holds exactly as it holds a
+    /// controller, so it is chased like one: under MPE a member channel is
+    /// reused round robin, and a note located into on a channel carrying
+    /// another note's pressure is the same staleness the compile takes care to
+    /// avoid at a note's start.
+    static constexpr int kChannelPressure = 257;
 };
 
 /**

--- a/magda/engine/exec/OfflineRender.cpp
+++ b/magda/engine/exec/OfflineRender.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 
+#include "clip/ClipVoicePool.hpp"
 #include "transport/TransportState.hpp"
 
 namespace magda::engine {
@@ -19,6 +20,7 @@ std::int64_t samplesBetween(double startSeconds, double endSeconds, double sampl
 OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& values,
                                   const RenderContext& context, const TempoMap& tempo,
                                   const OfflineRenderRequest& request, OfflineRenderSink& sink,
+                                  ClipVoicePool* voices,
                                   const std::function<bool()>& shouldContinue) {
     OfflineRenderResult result;
 
@@ -100,6 +102,19 @@ OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& valu
                 juce::AudioBuffer<float> piece(buffer.getArrayOfWritePointers(),
                                                buffer.getNumChannels(), segment.startSample,
                                                segment.block.numSamples);
+
+                // Where the render has got to, and then the round that acts on
+                // it, both before the block rather than after. Playback stores
+                // the position here and leaves the opening to a thread; a
+                // render outruns any thread, so it does the opening itself and
+                // waits for the disk, which is exactly what it is allowed to
+                // do and playback is not.
+                if (voices != nullptr) {
+                    voices->setPosition(segment.block.startSeconds);
+                    voices->service();
+                    voices->fillNow();
+                }
+
                 executor.process(values, segment.block, piece);
             }
 

--- a/magda/engine/exec/OfflineRender.hpp
+++ b/magda/engine/exec/OfflineRender.hpp
@@ -29,6 +29,10 @@
 
 namespace magda::engine {
 
+/// Only named here, and only used from the .cpp, so an includer of this does
+/// not take a prefetch thread and a stream pool with it.
+class ClipVoicePool;
+
 /** What to render, and how much of the machine to hand it. */
 struct OfflineRenderRequest {
     /// The stretch of timeline to render, in beats, half-open. Beats because
@@ -113,6 +117,19 @@ class OfflineRenderSink {
  * does not change during a render: an offline render is one pass over a
  * timeline whose tempo track is whatever it was when the render started.
  *
+ * @p voices provisions the readers a track's clips play through, and is null
+ * for a render with no arrangement audio in it. It is driven here rather than
+ * by a thread, and that is the whole difference between an offline render and
+ * playback: a pool serviced from a 10 ms round would be left behind instantly
+ * by a render going a hundred times faster than realtime, and every clip would
+ * arrive with no reader and play silence. Nothing here has a callback to
+ * starve, so the render can open the files it is about to need and wait for
+ * them, in step, before the block that needs them.
+ *
+ * A caller that hands one over must not also be running a ClipVoiceThread on
+ * it. Two things provisioning one pool is a race over which readers exist,
+ * which is what the pool's own threading contract already says.
+ *
  * @p shouldContinue is asked once per block and may be empty. A render of a
  * long range is the one thing in the engine a user is left waiting for, so it
  * is interruptible from the start rather than once someone complains.
@@ -123,6 +140,7 @@ class OfflineRenderSink {
 OfflineRenderResult renderOffline(PlanExecutor& executor, const PlanValues& values,
                                   const RenderContext& context, const TempoMap& tempo,
                                   const OfflineRenderRequest& request, OfflineRenderSink& sink,
+                                  ClipVoicePool* voices = nullptr,
                                   const std::function<bool()>& shouldContinue = {});
 
 }  // namespace magda::engine

--- a/magda/engine/exec/RenderContext.hpp
+++ b/magda/engine/exec/RenderContext.hpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <cmath>
 
+#include "transport/TempoMap.hpp"
+
 /**
  * @file RenderContext.hpp
  * @brief What the executor renders into, and what it is asked to render now.
@@ -156,12 +158,28 @@ struct BlockInfo {
      * is what spans and fades are in, and then has to be asked about in beats.
      */
     double beatAtTime(double seconds) const {
+        // The map itself where there is one, which matters for the moments that
+        // are not inside this block. A block's own two ends make a straight
+        // line, and that line is exact only while the tempo does not change
+        // along it: anything reading past the block's end, or across a step
+        // inside it, gets the slope this block happened to have rather than the
+        // one the map has there. A clip whose rate follows the tempo is read at
+        // instants beyond the block that produced them (ClipVoice's cells), so
+        // it is exactly the caller that cannot afford the straight line.
+        if (tempo != nullptr)
+            return tempo->timeToBeat(seconds);
+
         if (endSeconds <= startSeconds)
             return startBeat;
 
         const auto position = (seconds - startSeconds) / (endSeconds - startSeconds);
         return startBeat + position * (endBeat - startBeat);
     }
+
+    /// The map this block was cut from, or null for a caller that assembles a
+    /// block by hand. Not owned, and it outlives the block: what publishes a
+    /// transport keeps it alive for as long as the callback reading it runs.
+    const TempoMap* tempo = nullptr;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/io/PrefetchThread.cpp
+++ b/magda/engine/io/PrefetchThread.cpp
@@ -4,10 +4,12 @@
 
 namespace magda::engine {
 
-PrefetchThread::PrefetchThread() : juce::Thread("MAGDA prefetch") {
+PrefetchThread::PrefetchThread(bool runInBackground)
+    : juce::Thread("MAGDA prefetch"), runsInBackground_(runInBackground) {
     // Above the interface, below the callback. A reader that lost to a redraw
     // is what an underrun sounds like.
-    startThread(juce::Thread::Priority::high);
+    if (runsInBackground_)
+        startThread(juce::Thread::Priority::high);
 }
 
 PrefetchThread::~PrefetchThread() {

--- a/magda/engine/io/PrefetchThread.hpp
+++ b/magda/engine/io/PrefetchThread.hpp
@@ -27,7 +27,22 @@ namespace magda::engine {
 
 class PrefetchThread final : private juce::Thread {
   public:
-    PrefetchThread();
+    /**
+     * @brief A reader, with or without the thread behind it.
+     *
+     * Playback wants the thread: nothing else can wait for a disk on its
+     * behalf. An offline render wants it off, and not as an optimisation. A
+     * render goes as fast as the machine will let it, so a second of timeline
+     * can pass in ten milliseconds of wall clock, and whether a clip's chunks
+     * arrived before the block that wanted them would come down to how the
+     * scheduler felt. Every underrun that produced would look exactly like a
+     * clip playing silence.
+     *
+     * With it off, @ref fillOnce is the caller's to drive and the reading
+     * happens in step with the render. Only one thing may drive it either way:
+     * two threads inside fill() is a race over one stream's cursor.
+     */
+    explicit PrefetchThread(bool runInBackground = true);
     ~PrefetchThread() override;
 
     PrefetchThread(const PrefetchThread&) = delete;
@@ -51,8 +66,15 @@ class PrefetchThread final : private juce::Thread {
     std::size_t streamCount() const;
 
     /// One round of filling, without the thread. For tests, which want to say
-    /// exactly how far ahead the reader got before the callback ran.
+    /// exactly how far ahead the reader got before the callback ran, and for an
+    /// offline render, which drives its own reading.
     bool fillOnce();
+
+    /// Whether anything is filling behind the caller's back. What an offline
+    /// render checks before driving fillOnce itself.
+    bool runsInBackground() const {
+        return runsInBackground_;
+    }
 
   private:
     void run() override;
@@ -64,6 +86,7 @@ class PrefetchThread final : private juce::Thread {
 
     mutable std::mutex lock_;
     std::vector<PrefetchStream*> streams_;
+    bool runsInBackground_ = true;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/transport/TransportClock.cpp
+++ b/magda/engine/transport/TransportClock.cpp
@@ -122,6 +122,7 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
         segment.block.startSeconds = seconds;
         segment.block.endSeconds = seconds;
         segment.block.continuous = continuous_;
+        segment.block.tempo = &tempo;
         segment.startSample = 0;
         segment.countingIn = false;
 
@@ -196,6 +197,7 @@ std::span<const TransportClock::Segment> TransportClock::advance(const Transport
         segment.block.startSeconds = secondsAfter(samplesSinceAnchor_);
         segment.block.endSeconds = secondsAfter(samplesSinceAnchor_ + samples);
         segment.block.continuous = continuous_;
+        segment.block.tempo = &tempo;
         segment.startSample = offset;
         segment.countingIn = countingIn_;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -286,6 +286,18 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_groove_template.cpp)
     list(APPEND TEST_SOURCES test_transient_detector.cpp)
     list(APPEND TEST_SOURCES test_source_loop_info.cpp)
+
+    # The null-diff corpus (#2040). The comparator and the material it plays are
+    # model-only and live here, where they can be tested against known-bad pairs
+    # on their own; the two legs and the runner need a te::Edit and so live in
+    # magda_juce_tests.
+    list(APPEND TEST_SOURCES NullDiffMaterial.cpp)
+    list(APPEND TEST_SOURCES NullDiffCompare.cpp)
+    list(APPEND TEST_SOURCES NullDiffCorpus.cpp)
+    list(APPEND TEST_SOURCES NullDiffNativeLeg.cpp)
+    list(APPEND TEST_SOURCES test_null_diff_compare.cpp)
+    list(APPEND TEST_SOURCES test_null_diff_corpus.cpp)
+    list(APPEND TEST_SOURCES test_null_diff_native_leg.cpp)
 endif()
 
 # Create test executable
@@ -469,6 +481,21 @@ target_sources(magda_juce_tests PRIVATE
     ../magda/daw/ui/components/chain/slot/StepSequencerClipExport.cpp
 )
 
+# The null-diff corpus (#2040). It lives here rather than in magda_tests because
+# the incumbent leg is a te::Edit, and Edits in that target take later tests down
+# with them. The comparator, the material and the corpus itself are model-only
+# and are compiled into both, so they can also be tested on their own.
+if(MAGDA_BUILD_NATIVE_ENGINE)
+    target_sources(magda_juce_tests PRIVATE
+        NullDiffMaterial.cpp
+        NullDiffCompare.cpp
+        NullDiffCorpus.cpp
+        NullDiffNativeLeg.cpp
+        NullDiffTeLeg.cpp
+        test_null_diff_juce.cpp
+    )
+endif()
+
 # Link required libraries for JUCE tests
 target_link_libraries(magda_juce_tests
     PRIVATE
@@ -488,6 +515,13 @@ target_link_libraries(magda_juce_tests
     $<$<PLATFORM_ID:Linux>:juce::pkgconfig_JUCE_BROWSER_LINUX_DEPS>
     $<$<PLATFORM_ID:Linux>:juce::pkgconfig_JUCE_CURL_LINUX_DEPS>
 )
+
+# The native engine, for the null-diff corpus (#2040). This is the one target
+# that links both it and Tracktion, which is the whole point of it: the corpus
+# renders one project through each and compares.
+if(MAGDA_BUILD_NATIVE_ENGINE)
+    target_link_libraries(magda_juce_tests PRIVATE magda_engine)
+endif()
 
 target_compile_definitions(magda_juce_tests PRIVATE MAGDA_ENABLE_TEST_HOOKS=1
     MAGDA_NO_AUTO_TEMPO_LANE_SYNC=1
@@ -537,6 +571,17 @@ add_test(NAME syntax_highlighting_juce
 
 add_test(NAME tempo_map_juce
          COMMAND magda_juce_tests "Tempo Map Tests")
+
+# The null-diff corpus (#2040): every case rendered through both engines. Two
+# entries because they fail for different reasons and one of them is much
+# cheaper: a mapping disagreement moves every clip in every project, so it is
+# worth seeing on its own before any waveform is compared.
+if(MAGDA_BUILD_NATIVE_ENGINE)
+    add_test(NAME null_diff_maps_juce
+             COMMAND magda_juce_tests "Null Diff Maps")
+    add_test(NAME null_diff_corpus_juce
+             COMMAND magda_juce_tests "Null Diff Corpus")
+endif()
 
 add_test(NAME tempo_lane_bridge_juce
          COMMAND magda_juce_tests "Tempo Lane Bridge Tests")

--- a/tests/NullDiffCase.hpp
+++ b/tests/NullDiffCase.hpp
@@ -1,0 +1,145 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <string>
+#include <vector>
+
+#include "NullDiffCompare.hpp"
+#include "core/ClipInfo.hpp"
+#include "core/TrackInfo.hpp"
+#include "core/TypeIds.hpp"
+
+/**
+ * @file NullDiffCase.hpp
+ * @brief One project, as model values, plus what it claims about the two
+ *        engines rendering it (#2040).
+ *
+ * Model values and nothing else. Both legs are handed the same case and build
+ * their own world from it: the incumbent leg installs the clips in ClipManager
+ * and syncs them into a te::Edit, the native leg compiles them into a plan and
+ * a snapshot. Neither is allowed a private opinion about what the project is,
+ * which is the whole reason a case is data rather than a pair of setup
+ * functions.
+ *
+ * A case is built in code rather than loaded from a .mgd. A load produces the
+ * model and both legs consume the model, so a file on disk would add a step
+ * neither leg is testing and a binary to the repository. What it would buy is
+ * covered by the project-load tests already.
+ */
+
+namespace magda::nulldiff {
+
+/// A tempo change, as both legs need to see it. Step changes only, and that is
+/// deliberate: the two engines resolve a ramped tempo differently (the engine
+/// subdivides because there is no closed form across a curve, the fork
+/// integrates its own way), so a render case with a ramp in it would report a
+/// tempo disagreement as a clip bug. Ramps are pinned where the answer is a
+/// number, in the tempo-map comparison.
+struct TempoPoint {
+    double beat = 0.0;
+    double bpm = 120.0;
+};
+
+/// What a case wrote to disk and told the source pool about. Carried on the
+/// case so that a leg never has to probe a file to find out what it is.
+struct SourceFact {
+    SourceId id = INVALID_SOURCE_ID;
+    juce::String path;
+    double sampleRate = 44100.0;
+    double durationSeconds = 0.0;
+};
+
+struct Case {
+    std::string name;
+
+    /// What this case is for, in a phrase. Printed beside a failure, because
+    /// "placement.trims failed" is only useful to whoever wrote it.
+    std::string covers;
+
+    Verdict verdict = Verdict::Null;
+
+    /// Peak residual at or below this is a null. A case that raises it carries
+    /// the mechanism below, and a raised floor with no mechanism does not
+    /// belong in the corpus.
+    double floorDb = -120.0;
+
+    /// Why this case is not a plain null: what the divergence is and why it is
+    /// pinned rather than tolerated. Empty for a Null verdict.
+    std::string mechanism;
+
+    // --- the project ---------------------------------------------------------
+
+    std::vector<TrackInfo> tracks;
+    TrackInfo master;
+    std::vector<ClipInfo> clips;
+    std::vector<SourceFact> sources;
+    std::vector<TempoPoint> tempo{{0.0, 120.0}};
+
+    /// The groove templates the clips may name, as the fork keeps them: a
+    /// <GROOVETEMPLATES> document. One string feeds both legs, which is what
+    /// makes "the same groove" a fact rather than two parsers agreeing.
+    juce::String grooveXml;
+
+    // --- what to render ------------------------------------------------------
+
+    double startBeat = 0.0;
+    double endBeat = 16.0;
+    double sampleRate = 44100.0;
+    int blockSize = 512;
+    int channels = 2;
+
+    // --- what is allowed for -------------------------------------------------
+
+    /// The shift a Shift verdict expects, in samples, or zero to measure one
+    /// and assert nothing about its size. Measured at the start either way:
+    /// re-fitting per region would turn a clip that drifts into a clip that
+    /// passes.
+    int expectedShiftSamples = 0;
+
+    /// How far the search may look for that shift.
+    int maxShiftSamples = 8192;
+
+    /// Notes the incumbent is expected to be late by, in beats. Non-zero for
+    /// exactly one thing: the fork drops midiOffset on an unlooped arranger
+    /// clip, so every note of such a clip lands offset.
+    double declaredMidiShiftBeats = 0.0;
+
+    /// How much earlier the fork ends every note, in seconds.
+    ///
+    /// Its own constant: MidiNote::getPlaybackTime nudges every note-off back
+    /// by 0.0001 s "to make sure the ordering is correct", which is how it
+    /// keeps an off ahead of an on at the same instant. The engine orders
+    /// events at compile time instead and keeps the length the note was drawn
+    /// at. Written here as the number it is, so that the day the fork changes
+    /// it the corpus says so rather than absorbing it.
+    double incumbentNoteEndEarlySeconds = 0.0001;
+
+    double startBpm() const {
+        return tempo.empty() ? 120.0 : tempo.front().bpm;
+    }
+
+    bool capturesMidi() const {
+        return verdict == Verdict::Midi;
+    }
+};
+
+/**
+ * @brief Every case, with its material written into @p scratchDirectory.
+ *
+ * Material is generated here rather than checked in, and the choice of it per
+ * case is what makes a residual mean something: impulses and steps where the
+ * engines must agree sample for sample, a band-limited tone wherever an
+ * interpolator or a stretcher stands between them. See NullDiffMaterial.hpp.
+ *
+ * Seeds the source pool as it goes, because both legs read a file's rate and
+ * duration from there and a case that let them probe separately would have two
+ * answers to one question.
+ */
+std::vector<Case> buildCorpus(const juce::File& scratchDirectory);
+
+/// The groove template every grooving case names, and the one the runner
+/// installs in both engines.
+extern const char* const kGrooveName;
+
+}  // namespace magda::nulldiff

--- a/tests/NullDiffCase.hpp
+++ b/tests/NullDiffCase.hpp
@@ -121,6 +121,17 @@ struct Case {
     /// clip, so every note of such a clip lands offset.
     double declaredMidiShiftBeats = 0.0;
 
+    /// A fixed sub-sample offset between the two renders, applied before
+    /// comparing, with its mechanism in `mechanism`.
+    ///
+    /// This is not a tolerance and it is not fitted. It is a constant the
+    /// corpus measured, declared here, and then aligned by: if the offset were
+    /// anything other than constant, aligning by one number would not bring the
+    /// case to the floor, so the null after alignment is the evidence that the
+    /// mechanism is what it is claimed to be. Measured, mechanized, then
+    /// nulled.
+    double declaredFractionalShiftSamples = 0.0;
+
     /// How much earlier the fork ends every note, in seconds.
     ///
     /// Its own constant: MidiNote::getPlaybackTime nudges every note-off back

--- a/tests/NullDiffCase.hpp
+++ b/tests/NullDiffCase.hpp
@@ -91,10 +91,14 @@ struct Case {
 
     // --- what is allowed for -------------------------------------------------
 
-    /// The shift a Shift verdict expects, in samples, or zero to measure one
-    /// and assert nothing about its size. Measured at the start either way:
-    /// re-fitting per region would turn a clip that drifts into a clip that
-    /// passes.
+    /// What a Shift verdict expects the offset to be, in samples.
+    ///
+    /// Required rather than optional. Zero means nobody has declared one, and a
+    /// Shift case with no declaration is refused rather than measured: the
+    /// whole point of pinning a shift is that a clip in the wrong place cannot
+    /// be absorbed into the alignment, and an alignment checked against nothing
+    /// absorbs anything. The engine reports what its own stretcher primes with
+    /// (NativeRender::primingSamples), which is the figure to declare here.
     int expectedShiftSamples = 0;
 
     /// How far the measured shift may sit from the expected one, as a

--- a/tests/NullDiffCase.hpp
+++ b/tests/NullDiffCase.hpp
@@ -97,6 +97,22 @@ struct Case {
     /// passes.
     int expectedShiftSamples = 0;
 
+    /// How far the measured shift may sit from the expected one, as a
+    /// proportion. The prediction is the stretcher's own priming latency scaled
+    /// by the ratio it runs at, which is a figure the library reports rather
+    /// than one anybody measured, so the allowance is for the rounding between
+    /// the two and not for a clip in the wrong place.
+    double shiftTolerance = 0.15;
+
+    /// A stretched case is judged on its envelope and its magnitude spectrum
+    /// rather than its waveform, because two vocoders primed differently never
+    /// converge on one waveform: priming sets the initial phase state and phase
+    /// in a vocoder is memory. These are the two bounds that replace the null,
+    /// and each is taken from the first run with its mechanism named on the
+    /// case.
+    double envelopeToleranceSamples = 1.0;
+    double spectralPercentile95Db = 0.0;
+
     /// How far the search may look for that shift.
     int maxShiftSamples = 8192;
 

--- a/tests/NullDiffCompare.cpp
+++ b/tests/NullDiffCompare.cpp
@@ -1,6 +1,9 @@
 #include "NullDiffCompare.hpp"
 
+#include <juce_dsp/juce_dsp.h>
+
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdio>
 #include <deque>
@@ -195,56 +198,405 @@ ShiftEstimate estimateShift(const juce::AudioBuffer<float>& native,
     const auto onset = std::min(onsetOf(native), onsetOf(incumbent));
 
     // Wide enough that a wrong lag cannot correlate as well as the right one by
-    // accident, which for periodic material means several periods.
+    // accident, which for periodic material means many periods. Narrowing this
+    // is tempting and wrong: an eighth of a second of tone correlates with an
+    // eighth of a second of noise at some lag, and the search would then name a
+    // fiction rather than decline.
     const auto available = std::min(native.getNumSamples(), incumbent.getNumSamples()) - onset;
     const auto window = std::min(std::max(4 * maxShiftSamples, 4096), std::max(0, available));
     if (window <= 0)
         return estimate;
 
-    auto best = -1.0;
-    auto bestLag = 0;
+    // Searching every lag at full rate over a window that wide is tens of
+    // millions of multiplies per case, which is the difference between a corpus
+    // anybody runs and one nobody does. So the sweep happens on a decimated
+    // pair, which costs the square of the factor, and the answer is then
+    // refined at full rate around what it found. Decimation keeps the window's
+    // whole length, so the strength that makes a false peak unlikely is kept
+    // too; what it gives up is resolution, which is exactly what the second
+    // pass puts back.
+    constexpr int kDecimation = 8;
 
-    for (auto lag = -maxShiftSamples; lag <= maxShiftSamples; ++lag) {
-        double dot = 0.0;
-        double nativeEnergy = 0.0;
-        double incumbentEnergy = 0.0;
+    // The coarse pass runs on a peak envelope rather than on the waveform, and
+    // that is what makes the answer unique. Periodic material correlates just
+    // as well a whole period away: a 220 Hz tone repeats every 200 samples, so
+    // a waveform sweep cannot tell 1024 from 423 and whichever it picks is
+    // arithmetic rather than an answer. An envelope has no period, so it says
+    // which of those neighbourhoods the offset is in, and the waveform pass
+    // then says where in that neighbourhood it is.
+    const auto envelope = [&](const juce::AudioBuffer<float>& buffer, int from, int count) {
+        std::vector<double> out(static_cast<std::size_t>(count / kDecimation), 0.0);
+        for (std::size_t i = 0; i < out.size(); ++i) {
+            auto peak = 0.0;
+            for (auto k = 0; k < kDecimation; ++k) {
+                const auto index = from + static_cast<int>(i) * kDecimation + k;
+                if (index >= 0 && index < buffer.getNumSamples())
+                    peak = std::max(peak, std::abs(summed(buffer, index)));
+            }
+            out[i] = peak;
+        }
+        return out;
+    };
 
-        for (auto index = 0; index < window; ++index) {
-            const auto nativeIndex = onset + index;
-            const auto incumbentIndex = nativeIndex + lag;
-            if (nativeIndex >= native.getNumSamples())
-                break;
-            if (incumbentIndex < 0 || incumbentIndex >= incumbent.getNumSamples())
+    /// Normalised correlation of the two at @p lag, in whatever domain the
+    /// caller decimated to.
+    const auto score = [](const std::vector<double>& a, const std::vector<double>& b, int lag,
+                          int guard) {
+        auto dot = 0.0;
+        auto energyA = 0.0;
+        auto energyB = 0.0;
+
+        for (auto index = guard; index + guard < static_cast<int>(a.size()); ++index) {
+            const auto other = index + lag;
+            if (other < 0 || other >= static_cast<int>(b.size()))
                 continue;
 
-            const auto a = summed(native, nativeIndex);
-            const auto b = summed(incumbent, incumbentIndex);
-            dot += a * b;
-            nativeEnergy += a * a;
-            incumbentEnergy += b * b;
+            const auto x = a[static_cast<std::size_t>(index)];
+            const auto y = b[static_cast<std::size_t>(other)];
+            dot += x * y;
+            energyA += x * x;
+            energyB += y * y;
         }
 
-        if (nativeEnergy <= 0.0 || incumbentEnergy <= 0.0)
-            continue;
+        if (energyA <= 0.0 || energyB <= 0.0)
+            return -1.0;
+        return dot / std::sqrt(energyA * energyB);
+    };
 
-        const auto correlation = dot / std::sqrt(nativeEnergy * incumbentEnergy);
-        if (correlation > best) {
-            best = correlation;
+    // The pair, from the onset, with room either side for the lag.
+    const auto span = window + 2 * maxShiftSamples;
+    const auto from = std::max(0, onset - maxShiftSamples);
+
+    auto coarseA = envelope(native, from, span);
+    auto coarseB = envelope(incumbent, from, span);
+    const auto coarseGuard = maxShiftSamples / kDecimation;
+
+    // With the mean left in, a level that does not change scores near one at
+    // every lag and the peak lands wherever the arithmetic noise puts it. Taken
+    // out, a flat envelope carries no energy and therefore no opinion, which is
+    // the honest answer for material that is the same all the way through: the
+    // waveform pass then works from zero rather than from a fiction.
+    const auto centreOn = [](std::vector<double>& values) {
+        auto total = 0.0;
+        for (const auto value : values)
+            total += value;
+        const auto mean = values.empty() ? 0.0 : total / static_cast<double>(values.size());
+        for (auto& value : values)
+            value -= mean;
+    };
+
+    centreOn(coarseA);
+    centreOn(coarseB);
+
+    // Correlated across the whole envelope rather than inside a guard. The
+    // guard is there to keep a lag from running off the end, and score already
+    // skips what falls outside; what a guard would exclude here is the onset,
+    // which for material that is level all the way through is the only feature
+    // the envelope has. Excluding it leaves a flat window with no opinion, and
+    // the peak then lands wherever the arithmetic noise puts it.
+    auto bestCoarse = -1.0;
+    auto bestCoarseLag = 0;
+    for (auto lag = -coarseGuard; lag <= coarseGuard; ++lag) {
+        const auto value = score(coarseA, coarseB, lag, 0);
+        if (value > bestCoarse) {
+            bestCoarse = value;
+            bestCoarseLag = lag;
+        }
+    }
+
+    // Full rate, around what the sweep found, wide enough to cover the samples
+    // the decimation could not tell apart.
+    std::vector<double> fineA(static_cast<std::size_t>(span), 0.0);
+    std::vector<double> fineB(static_cast<std::size_t>(span), 0.0);
+    for (auto i = 0; i < span; ++i) {
+        const auto index = from + i;
+        if (index < native.getNumSamples())
+            fineA[static_cast<std::size_t>(i)] = summed(native, index);
+        if (index < incumbent.getNumSamples())
+            fineB[static_cast<std::size_t>(i)] = summed(incumbent, index);
+    }
+
+    estimate.envelopeSamples = static_cast<double>(bestCoarseLag * kDecimation);
+    estimate.envelopeCorrelation = bestCoarse;
+
+    const auto centre = bestCoarseLag * kDecimation;
+
+    // Wide enough to cover what the envelope could not resolve, which is the
+    // decimation either side plus the smoothing the envelope itself is.
+    const auto reach = 4 * kDecimation;
+
+    auto best = -1.0;
+    auto bestLag = centre;
+    std::vector<double> scores(static_cast<std::size_t>(2 * reach + 1), -1.0);
+
+    for (auto offset = -reach; offset <= reach; ++offset) {
+        const auto lag = centre + offset;
+        const auto value = score(fineA, fineB, lag, maxShiftSamples);
+        scores[static_cast<std::size_t>(offset + reach)] = value;
+
+        if (value > best) {
+            best = value;
             bestLag = lag;
         }
     }
 
     estimate.correlation = best;
     estimate.samples = bestLag;
+    estimate.fractionalSamples = static_cast<double>(bestLag);
+
+    // A parabola through the peak and its neighbours. A whole-sample answer is
+    // not enough for band limited material: at 220 Hz one sample of
+    // misalignment is a residual around -30 dB, so a case can be a fraction of
+    // a sample out and look like a difference in the material rather than what
+    // it is, which is a difference in the timing.
+    const auto index = static_cast<std::size_t>(bestLag - centre + reach);
+    if (index > 0 && index + 1 < scores.size()) {
+        const auto left = scores[index - 1];
+        const auto centreScore = scores[index];
+        const auto right = scores[index + 1];
+        const auto denominator = left - 2.0 * centreScore + right;
+        if (left >= 0.0 && right >= 0.0 && std::abs(denominator) > 1.0e-12)
+            estimate.fractionalSamples += 0.5 * (left - right) / denominator;
+    }
 
     // A comparator that slides until something matches will always find
     // something. What it finds on a pair that differs in content is a fiction
     // that makes the case pass, so a weak best lag is no lag at all.
     estimate.found = best >= 0.98;
-    if (!estimate.found)
+    if (!estimate.found) {
         estimate.samples = 0;
+        estimate.fractionalSamples = 0.0;
+    }
 
     return estimate;
+}
+
+juce::AudioBuffer<float> delayFractionally(const juce::AudioBuffer<float>& source,
+                                           double delaySamples) {
+    juce::AudioBuffer<float> result(source.getNumChannels(), source.getNumSamples());
+    result.clear();
+
+    const auto whole = static_cast<int>(std::floor(delaySamples));
+    const auto fraction = delaySamples - static_cast<double>(whole);
+
+    // Wide enough that the window's own error is far below the floor on
+    // anything band limited.
+    constexpr int kHalf = 32;
+
+    std::array<double, 2 * kHalf + 1> taps{};
+    auto sum = 0.0;
+    for (auto k = -kHalf; k <= kHalf; ++k) {
+        const auto x = static_cast<double>(k) - fraction;
+        const auto sinc = std::abs(x) < 1.0e-9 ? 1.0
+                                               : std::sin(juce::MathConstants<double>::pi * x) /
+                                                     (juce::MathConstants<double>::pi * x);
+
+        const auto phase = juce::MathConstants<double>::twoPi *
+                           (static_cast<double>(k + kHalf) / static_cast<double>(2 * kHalf));
+        const auto window = 0.42 - 0.5 * std::cos(phase) + 0.08 * std::cos(2.0 * phase);
+
+        taps[static_cast<std::size_t>(k + kHalf)] = sinc * window;
+        sum += sinc * window;
+    }
+
+    if (sum != 0.0)
+        for (auto& tap : taps)
+            tap /= sum;
+
+    for (auto channel = 0; channel < source.getNumChannels(); ++channel) {
+        const auto* in = source.getReadPointer(channel);
+        auto* out = result.getWritePointer(channel);
+
+        for (auto sample = 0; sample < source.getNumSamples(); ++sample) {
+            auto value = 0.0;
+            for (auto k = -kHalf; k <= kHalf; ++k) {
+                const auto index = sample - whole - k;
+                if (index < 0 || index >= source.getNumSamples())
+                    continue;
+                value += taps[static_cast<std::size_t>(k + kHalf)] * static_cast<double>(in[index]);
+            }
+            out[sample] = static_cast<float>(value);
+        }
+    }
+
+    return result;
+}
+
+EnvelopeAgreement compareEnvelopes(const juce::AudioBuffer<float>& native,
+                                   const juce::AudioBuffer<float>& incumbent, int shiftSamples,
+                                   double sampleRate, double followerHz) {
+    EnvelopeAgreement result;
+
+    const auto begin = std::max(0, -shiftSamples);
+    const auto end = std::min(native.getNumSamples(), incumbent.getNumSamples() - shiftSamples);
+    const auto length = end - begin;
+    if (length <= 0)
+        return result;
+
+    // Rectified and smoothed. What a listener calls the timing of a sound, and
+    // it survives the phase difference that makes the waveforms incomparable.
+    const auto follow = [&](const juce::AudioBuffer<float>& buffer, int offset) {
+        std::vector<double> envelope(static_cast<std::size_t>(length), 0.0);
+        const auto coefficient =
+            std::exp(-juce::MathConstants<double>::twoPi * followerHz / sampleRate);
+
+        auto state = 0.0;
+        for (auto index = 0; index < length; ++index) {
+            auto peak = 0.0;
+            for (auto channel = 0; channel < buffer.getNumChannels(); ++channel)
+                peak = std::max(
+                    peak, std::abs(static_cast<double>(buffer.getSample(channel, offset + index))));
+
+            state = peak + coefficient * (state - peak);
+            envelope[static_cast<std::size_t>(index)] = state;
+        }
+        return envelope;
+    };
+
+    const auto a = follow(native, begin);
+    const auto b = follow(incumbent, begin + shiftSamples);
+
+    const auto mean = [](const std::vector<double>& values) {
+        auto total = 0.0;
+        for (const auto value : values)
+            total += value;
+        return values.empty() ? 0.0 : total / static_cast<double>(values.size());
+    };
+
+    const auto meanA = mean(a);
+    const auto meanB = mean(b);
+
+    // A lag window of a few milliseconds: this runs after the pinned shift, so
+    // what is left should be nothing, and anything past this is not a lag.
+    const auto maxLag = std::min(static_cast<int>(sampleRate * 0.01), length / 4);
+
+    // Over a stretch of the envelope rather than all of it. An envelope is a
+    // slow signal, so a couple of seconds says everything a whole take would,
+    // and correlating every lag against every sample of a long render is how a
+    // corpus stops being something anybody runs.
+    const auto span = std::min(length - 2 * maxLag, static_cast<int>(sampleRate * 2.0));
+    if (span <= 0)
+        return result;
+
+    auto best = -2.0;
+    auto bestLag = 0;
+    std::vector<double> scores(static_cast<std::size_t>(2 * maxLag + 1), 0.0);
+
+    for (auto lag = -maxLag; lag <= maxLag; ++lag) {
+        auto dot = 0.0;
+        auto energyA = 0.0;
+        auto energyB = 0.0;
+
+        for (auto index = maxLag; index < maxLag + span; ++index) {
+            const auto x = a[static_cast<std::size_t>(index)] - meanA;
+            const auto y = b[static_cast<std::size_t>(index + lag)] - meanB;
+            dot += x * y;
+            energyA += x * x;
+            energyB += y * y;
+        }
+
+        const auto value =
+            (energyA > 0.0 && energyB > 0.0) ? dot / std::sqrt(energyA * energyB) : 0.0;
+        scores[static_cast<std::size_t>(lag + maxLag)] = value;
+
+        if (value > best) {
+            best = value;
+            bestLag = lag;
+        }
+    }
+
+    result.correlation = best;
+    result.lagSamples = static_cast<double>(bestLag);
+
+    // Refined below a sample, the same way the shift is.
+    const auto index = static_cast<std::size_t>(bestLag + maxLag);
+    if (index > 0 && index + 1 < scores.size()) {
+        const auto left = scores[index - 1];
+        const auto centre = scores[index];
+        const auto right = scores[index + 1];
+        const auto denominator = left - 2.0 * centre + right;
+        if (std::abs(denominator) > 1.0e-12)
+            result.lagSamples += 0.5 * (left - right) / denominator;
+    }
+
+    return result;
+}
+
+SpectralAgreement compareSpectra(const juce::AudioBuffer<float>& native,
+                                 const juce::AudioBuffer<float>& incumbent, int shiftSamples,
+                                 double floorDb) {
+    SpectralAgreement result;
+
+    const auto begin = std::max(0, -shiftSamples);
+    const auto end = std::min(native.getNumSamples(), incumbent.getNumSamples() - shiftSamples);
+    if (end - begin < kSpectralWindow)
+        return result;
+
+    juce::dsp::FFT fft(static_cast<int>(std::log2(kSpectralWindow)));
+
+    std::vector<float> window(kSpectralWindow);
+    for (auto i = 0; i < kSpectralWindow; ++i)
+        window[static_cast<std::size_t>(i)] = static_cast<float>(
+            0.5 - 0.5 * std::cos(juce::MathConstants<double>::twoPi * i / (kSpectralWindow - 1)));
+
+    std::vector<double> differences;
+
+    const auto spectrumAt = [&](const juce::AudioBuffer<float>& buffer, int offset) {
+        std::vector<float> data(static_cast<std::size_t>(2 * kSpectralWindow), 0.0f);
+        for (auto i = 0; i < kSpectralWindow; ++i) {
+            auto sum = 0.0f;
+            for (auto channel = 0; channel < buffer.getNumChannels(); ++channel)
+                sum += buffer.getSample(channel, offset + i);
+            data[static_cast<std::size_t>(i)] = sum * window[static_cast<std::size_t>(i)];
+        }
+        fft.performFrequencyOnlyForwardTransform(data.data());
+        data.resize(static_cast<std::size_t>(kSpectralWindow / 2));
+        return data;
+    };
+
+    for (auto frame = begin; frame + kSpectralWindow <= end; frame += kSpectralHop) {
+        const auto a = spectrumAt(native, frame);
+        const auto b = spectrumAt(incumbent, frame + shiftSamples);
+
+        auto peak = 0.0f;
+        for (std::size_t bin = 0; bin < a.size(); ++bin)
+            peak = std::max({peak, a[bin], b[bin]});
+
+        if (peak <= 0.0f)
+            continue;
+
+        ++result.frames;
+
+        // Only bins that carry something. Comparing the noise floor of two
+        // vocoders is comparing their dither.
+        const auto binFloor = static_cast<double>(peak) * fromDb(floorDb);
+
+        for (std::size_t bin = 0; bin < a.size(); ++bin) {
+            const auto left = static_cast<double>(a[bin]);
+            const auto right = static_cast<double>(b[bin]);
+            if (left < binFloor && right < binFloor)
+                continue;
+
+            // Both clamped to the floor rather than to something far below it.
+            // A bin that is silent in one render and merely quiet in the other
+            // is a difference of whatever the clamp allows, and letting that be
+            // unbounded means the 95th percentile measures the quietest corner
+            // of the spectrum instead of the sound.
+            differences.push_back(
+                std::abs(toDb(std::max(left, binFloor)) - toDb(std::max(right, binFloor))));
+        }
+    }
+
+    result.binsCompared = static_cast<int>(differences.size());
+    if (differences.empty())
+        return result;
+
+    std::sort(differences.begin(), differences.end());
+    result.medianDb = differences[differences.size() / 2];
+    result.percentile95Db = differences[std::min(
+        differences.size() - 1, static_cast<std::size_t>(differences.size() * 95 / 100))];
+
+    return result;
 }
 
 AudioComparison compareAudio(const juce::AudioBuffer<float>& native,
@@ -657,11 +1009,18 @@ std::string formatReport(const std::vector<CaseReport>& cases, double sampleRate
             std::snprintf(line, sizeof(line), "notes=%d%s cc=%s", midi.notesCompared,
                           midi.notesMatch ? "" : "!", midi.controllersMatch ? "ok" : "differs");
             out << line;
+        } else if (report.hasSpectral) {
+            std::snprintf(line, sizeof(line),
+                          "shift=%-8.2f envelope=%-6.2f median=%-5.2f p95=%.2f dB",
+                          report.measuredShift, report.envelope.lagSamples, report.spectra.medianDb,
+                          report.spectra.percentile95Db);
+            out << line;
         } else if (report.hasAudio) {
             const auto& audio = report.audio;
-            std::snprintf(line, sizeof(line), "peak=%-9s rms=%-9s shift=%d",
+            std::snprintf(line, sizeof(line), "peak=%-9s rms=%-9s shift=%.3f",
                           formatDb(audio.peakDb).c_str(), formatDb(audio.rmsDb).c_str(),
-                          audio.shiftSamples);
+                          report.hasMeasuredShift ? report.measuredShift
+                                                  : static_cast<double>(audio.shiftSamples));
             out << line;
             if (!audio.refusal.empty())
                 out << " refused: " << audio.refusal;

--- a/tests/NullDiffCompare.cpp
+++ b/tests/NullDiffCompare.cpp
@@ -763,30 +763,69 @@ MidiComparison compareMidi(const MidiStream& native, const MidiStream& incumbent
         note.offSample -= options.noteShiftSamples;
     }
 
-    // Everything neither side's comparison reaches, counted. The fork sends
-    // channel pressure with every MPE note; dropping that in silence is how a
-    // difference nobody counted becomes indistinguishable from no difference.
-    const auto countUncompared = [](const MidiStream& stream) {
-        auto uncompared = 0;
+    const auto tolerance = static_cast<std::int64_t>(options.noteToleranceSamples);
+
+    // Everything the note and controller comparisons do not reach, compared
+    // rather than counted. Counting was not enough: equal counts of channel
+    // pressure would pass whatever channel, value or instant they carried, and
+    // an MPE note opens with one, so this is a stream the corpus really is
+    // asserting on rather than a tally it prints.
+    const auto others = [](const MidiStream& stream, std::int64_t shift) {
+        std::vector<MidiEvent> out;
         for (const auto& event : stream) {
             const auto type = event.type();
-            if (type != kNoteOn && type != kNoteOff && type != kControlChange && type != kPitchBend)
-                ++uncompared;
+            if (type == kNoteOn || type == kNoteOff || type == kControlChange || type == kPitchBend)
+                continue;
+
+            auto moved = event;
+            moved.sample -= shift;
+            out.push_back(moved);
         }
-        return uncompared;
+
+        std::stable_sort(out.begin(), out.end(), [](const MidiEvent& a, const MidiEvent& b) {
+            if (a.sample != b.sample)
+                return a.sample < b.sample;
+            if (a.status != b.status)
+                return a.status < b.status;
+            return a.data1 < b.data1;
+        });
+        return out;
     };
 
-    result.nativeUncompared = countUncompared(native);
-    result.incumbentUncompared = countUncompared(incumbent);
+    const auto nativeOthers = others(native, 0);
+    const auto incumbentOthers = others(incumbent, options.noteShiftSamples);
 
-    if (result.nativeUncompared != result.incumbentUncompared)
+    result.nativeUncompared = static_cast<int>(nativeOthers.size());
+    result.incumbentUncompared = static_cast<int>(incumbentOthers.size());
+
+    auto othersMatch = nativeOthers.size() == incumbentOthers.size();
+    if (!othersMatch)
         result.problems.push_back("messages outside notes, controllers and pitch bend: " +
                                   std::to_string(result.nativeUncompared) +
                                   " in the native render against " +
                                   std::to_string(result.incumbentUncompared) + " in the incumbent");
 
+    for (std::size_t i = 0; othersMatch && i < nativeOthers.size(); ++i) {
+        const auto& a = nativeOthers[i];
+        const auto& b = incumbentOthers[i];
+
+        if (a.status == b.status && a.data1 == b.data1 && a.data2 == b.data2 &&
+            std::abs(a.sample - b.sample) <= tolerance)
+            continue;
+
+        othersMatch = false;
+        result.problems.push_back("a message outside notes and controllers differs at " +
+                                  sampleAddress(a.sample, options.sampleRate) + ": status " +
+                                  std::to_string(static_cast<int>(a.status)) + " value " +
+                                  std::to_string(static_cast<int>(a.data1)) + " against status " +
+                                  std::to_string(static_cast<int>(b.status)) + " value " +
+                                  std::to_string(static_cast<int>(b.data1)) + " at " +
+                                  sampleAddress(b.sample, options.sampleRate));
+    }
+
+    result.otherMessagesMatch = othersMatch;
+
     std::vector<char> matched(incumbentLifetime.notes.size(), 0);
-    const auto tolerance = static_cast<std::int64_t>(options.noteToleranceSamples);
     const auto endEarly = static_cast<std::int64_t>(options.incumbentNoteEndEarlySamples);
 
     for (const auto& note : nativeLifetime.notes) {
@@ -845,6 +884,8 @@ MidiComparison compareMidi(const MidiStream& native, const MidiStream& incumbent
                                       sampleAddress(note.onSample, options.sampleRate) +
                                       " is not in the native render");
     }
+
+    result.otherMessagesMatch = othersMatch;
 
     result.notesMatch = result.notesOnlyInNative == 0 && result.notesOnlyInIncumbent == 0 &&
                         result.notesMismatched == 0 && nativeLifetime.hanging == 0 &&

--- a/tests/NullDiffCompare.cpp
+++ b/tests/NullDiffCompare.cpp
@@ -1,0 +1,676 @@
+#include "NullDiffCompare.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <deque>
+#include <map>
+#include <sstream>
+
+namespace magda::nulldiff {
+
+namespace {
+
+constexpr double kNegativeInfinityDb = -std::numeric_limits<double>::infinity();
+
+double toDb(double amplitude) {
+    if (amplitude <= 0.0)
+        return kNegativeInfinityDb;
+    return 20.0 * std::log10(amplitude);
+}
+
+double fromDb(double db) {
+    if (db == kNegativeInfinityDb)
+        return 0.0;
+    return std::pow(10.0, db / 20.0);
+}
+
+/// Channel-summed value, so a shift search reads one signal rather than
+/// correlating each channel and hoping they agree.
+double summed(const juce::AudioBuffer<float>& buffer, int sample) {
+    double total = 0.0;
+    for (auto channel = 0; channel < buffer.getNumChannels(); ++channel)
+        total += static_cast<double>(buffer.getSample(channel, sample));
+    return total;
+}
+
+/// Where the material starts, which is where a priming offset is visible and
+/// where a case that drifts has not drifted yet.
+int onsetOf(const juce::AudioBuffer<float>& buffer) {
+    auto peak = 0.0;
+    for (auto sample = 0; sample < buffer.getNumSamples(); ++sample)
+        peak = std::max(peak, std::abs(summed(buffer, sample)));
+
+    if (peak <= 0.0)
+        return 0;
+
+    const auto threshold = std::max(1.0e-4, peak * 0.01);
+    for (auto sample = 0; sample < buffer.getNumSamples(); ++sample)
+        if (std::abs(summed(buffer, sample)) >= threshold)
+            return sample;
+
+    return 0;
+}
+
+std::string sampleAddress(std::int64_t sample, double sampleRate) {
+    char text[96];
+    std::snprintf(text, sizeof(text), "sample %lld (%.4f s)", static_cast<long long>(sample),
+                  sampleRate > 0.0 ? static_cast<double>(sample) / sampleRate : 0.0);
+    return text;
+}
+
+// --- MIDI helpers ------------------------------------------------------------
+
+constexpr int kNoteOff = 0x80;
+constexpr int kNoteOn = 0x90;
+constexpr int kControlChange = 0xB0;
+constexpr int kPitchBend = 0xE0;
+
+/// A controller stream is keyed by what a synth would keep separate. Pitch bend
+/// has no controller number, so it takes one that no controller can.
+struct ControllerKey {
+    int channel = 1;
+    int controller = 0;
+
+    bool operator<(const ControllerKey& other) const {
+        return channel != other.channel ? channel < other.channel : controller < other.controller;
+    }
+};
+
+constexpr int kPitchBendController = -1;
+
+struct ControllerPoint {
+    std::int64_t sample = 0;
+    int value = 0;
+};
+
+using ControllerFunction = std::vector<ControllerPoint>;
+
+std::map<ControllerKey, ControllerFunction> controllerFunctions(const MidiStream& stream,
+                                                                std::int64_t shift) {
+    std::map<ControllerKey, ControllerFunction> functions;
+
+    for (const auto& event : stream) {
+        ControllerKey key;
+        key.channel = event.channel();
+
+        int value = 0;
+        if (event.type() == kControlChange) {
+            key.controller = event.data1;
+            value = event.data2;
+        } else if (event.type() == kPitchBend) {
+            key.controller = kPitchBendController;
+            value = (static_cast<int>(event.data2) << 7) | static_cast<int>(event.data1);
+        } else {
+            continue;
+        }
+
+        functions[key].push_back({event.sample - shift, value});
+    }
+
+    for (auto& [key, points] : functions)
+        std::stable_sort(points.begin(), points.end(),
+                         [](const auto& a, const auto& b) { return a.sample < b.sample; });
+
+    return functions;
+}
+
+/// The value the function holds at @p sample.
+///
+/// Before the first point it holds that point's value rather than nothing. A
+/// controller nobody has set has no value at all, and the alternative
+/// conventions both lie: zero invents a message neither engine sent, and
+/// "undefined" would fail every case at instant zero over a difference in when
+/// the first message goes out, which cannot be wrong when the value is the one
+/// both agree on.
+int valueAt(const ControllerFunction& points, std::int64_t sample) {
+    if (points.empty())
+        return 0;
+
+    auto upper =
+        std::upper_bound(points.begin(), points.end(), sample,
+                         [](std::int64_t s, const ControllerPoint& p) { return s < p.sample; });
+    if (upper == points.begin())
+        return points.front().value;
+
+    return std::prev(upper)->value;
+}
+
+/// Whether the function takes a value within @p tolerance of @p target at any
+/// instant in [from, to]. Every value in the window is a candidate, not just
+/// its extremes: a window holding 0 and 127 would otherwise accept anything
+/// between them, which is most of the range a controller has.
+bool holdsValueNear(const ControllerFunction& points, std::int64_t from, std::int64_t to,
+                    int target, int tolerance) {
+    if (points.empty())
+        return false;
+
+    if (std::abs(valueAt(points, from) - target) <= tolerance)
+        return true;
+
+    auto first =
+        std::upper_bound(points.begin(), points.end(), from,
+                         [](std::int64_t s, const ControllerPoint& p) { return s < p.sample; });
+    for (auto point = first; point != points.end() && point->sample <= to; ++point)
+        if (std::abs(point->value - target) <= tolerance)
+            return true;
+
+    return false;
+}
+
+/// Drop messages that repeat the value before them. The fork emits on its grid
+/// whether the value moved or not, and a repeat says nothing about the curve:
+/// counting it would make a stream that flattens early look longer than one
+/// that stopped when it had nothing left to say.
+ControllerFunction collapseRepeats(const ControllerFunction& points) {
+    ControllerFunction collapsed;
+    for (const auto& point : points)
+        if (collapsed.empty() || collapsed.back().value != point.value)
+            collapsed.push_back(point);
+    return collapsed;
+}
+
+std::string describeKey(const ControllerKey& key) {
+    char text[64];
+    if (key.controller == kPitchBendController)
+        std::snprintf(text, sizeof(text), "pitch bend ch%d", key.channel);
+    else
+        std::snprintf(text, sizeof(text), "cc%d ch%d", key.controller, key.channel);
+    return text;
+}
+
+}  // namespace
+
+// =============================================================================
+// Audio
+// =============================================================================
+
+ShiftEstimate estimateShift(const juce::AudioBuffer<float>& native,
+                            const juce::AudioBuffer<float>& incumbent, int maxShiftSamples) {
+    ShiftEstimate estimate;
+
+    if (native.getNumSamples() == 0 || incumbent.getNumSamples() == 0 || maxShiftSamples <= 0)
+        return estimate;
+
+    const auto onset = std::min(onsetOf(native), onsetOf(incumbent));
+
+    // Wide enough that a wrong lag cannot correlate as well as the right one by
+    // accident, which for periodic material means several periods.
+    const auto available = std::min(native.getNumSamples(), incumbent.getNumSamples()) - onset;
+    const auto window = std::min(std::max(4 * maxShiftSamples, 4096), std::max(0, available));
+    if (window <= 0)
+        return estimate;
+
+    auto best = -1.0;
+    auto bestLag = 0;
+
+    for (auto lag = -maxShiftSamples; lag <= maxShiftSamples; ++lag) {
+        double dot = 0.0;
+        double nativeEnergy = 0.0;
+        double incumbentEnergy = 0.0;
+
+        for (auto index = 0; index < window; ++index) {
+            const auto nativeIndex = onset + index;
+            const auto incumbentIndex = nativeIndex + lag;
+            if (nativeIndex >= native.getNumSamples())
+                break;
+            if (incumbentIndex < 0 || incumbentIndex >= incumbent.getNumSamples())
+                continue;
+
+            const auto a = summed(native, nativeIndex);
+            const auto b = summed(incumbent, incumbentIndex);
+            dot += a * b;
+            nativeEnergy += a * a;
+            incumbentEnergy += b * b;
+        }
+
+        if (nativeEnergy <= 0.0 || incumbentEnergy <= 0.0)
+            continue;
+
+        const auto correlation = dot / std::sqrt(nativeEnergy * incumbentEnergy);
+        if (correlation > best) {
+            best = correlation;
+            bestLag = lag;
+        }
+    }
+
+    estimate.correlation = best;
+    estimate.samples = bestLag;
+
+    // A comparator that slides until something matches will always find
+    // something. What it finds on a pair that differs in content is a fiction
+    // that makes the case pass, so a weak best lag is no lag at all.
+    estimate.found = best >= 0.98;
+    if (!estimate.found)
+        estimate.samples = 0;
+
+    return estimate;
+}
+
+AudioComparison compareAudio(const juce::AudioBuffer<float>& native,
+                             const juce::AudioBuffer<float>& incumbent,
+                             const AudioCompareOptions& options) {
+    AudioComparison result;
+    result.floorUsed = options.floorDb;
+    result.lengthDifference = native.getNumSamples() - incumbent.getNumSamples();
+
+    if (native.getNumChannels() != incumbent.getNumChannels()) {
+        result.refusal = "channel counts differ: " + std::to_string(native.getNumChannels()) +
+                         " against " + std::to_string(incumbent.getNumChannels());
+        return result;
+    }
+
+    if (native.getNumSamples() == 0 || incumbent.getNumSamples() == 0) {
+        result.refusal = "one render is empty";
+        return result;
+    }
+
+    if (options.measureShift) {
+        const auto estimate = estimateShift(native, incumbent, options.maxShiftSamples);
+        result.shiftSamples = estimate.samples;
+        result.shiftNotFound = !estimate.found;
+    }
+
+    const auto shift = result.shiftSamples;
+    const auto begin = static_cast<std::int64_t>(std::max(0, -shift));
+    const auto end = std::min(static_cast<std::int64_t>(native.getNumSamples()),
+                              static_cast<std::int64_t>(incumbent.getNumSamples()) - shift);
+
+    if (end <= begin) {
+        result.refusal = "nothing overlaps once the shift is applied";
+        return result;
+    }
+
+    const auto floorLinear = fromDb(options.floorDb);
+    auto peak = 0.0;
+    auto sumOfSquares = 0.0;
+
+    for (auto channel = 0; channel < native.getNumChannels(); ++channel) {
+        const auto* a = native.getReadPointer(channel);
+        const auto* b = incumbent.getReadPointer(channel);
+
+        for (auto index = begin; index < end; ++index) {
+            const auto residual =
+                static_cast<double>(a[index]) - static_cast<double>(b[index + shift]);
+            const auto magnitude = std::abs(residual);
+
+            if (magnitude > peak)
+                peak = magnitude;
+            sumOfSquares += residual * residual;
+
+            if (result.firstDivergence < 0 && magnitude > floorLinear)
+                result.firstDivergence = index;
+        }
+    }
+
+    result.comparedSamples = end - begin;
+    result.peakDb = toDb(peak);
+
+    const auto count =
+        static_cast<double>(result.comparedSamples) * static_cast<double>(native.getNumChannels());
+    result.rmsDb = toDb(count > 0.0 ? std::sqrt(sumOfSquares / count) : 0.0);
+
+    return result;
+}
+
+// =============================================================================
+// MIDI
+// =============================================================================
+
+MidiLifetime pairNotes(const MidiStream& stream) {
+    MidiLifetime lifetime;
+
+    auto sorted = stream;
+    std::stable_sort(sorted.begin(), sorted.end(),
+                     [](const MidiEvent& a, const MidiEvent& b) { return a.sample < b.sample; });
+
+    // Keyed by channel and pitch, because that is what a synth keeps separate,
+    // and first in first out within a key so that two notes of one pitch pair
+    // the way they sounded.
+    std::map<int, std::deque<MidiNoteSpan>> pending;
+
+    for (const auto& event : sorted) {
+        const auto type = event.type();
+        const auto isOff = type == kNoteOff || (type == kNoteOn && event.data2 == 0);
+        const auto isOn = type == kNoteOn && event.data2 > 0;
+
+        if (!isOn && !isOff)
+            continue;
+
+        const auto key = (event.channel() << 8) | static_cast<int>(event.data1);
+
+        if (isOn) {
+            MidiNoteSpan note;
+            note.channel = event.channel();
+            note.pitch = event.data1;
+            note.velocity = event.data2;
+            note.onSample = event.sample;
+            note.offSample = event.sample;
+            pending[key].push_back(note);
+            continue;
+        }
+
+        auto entry = pending.find(key);
+        if (entry == pending.end() || entry->second.empty()) {
+            ++lifetime.unmatchedOffs;
+            continue;
+        }
+
+        auto note = entry->second.front();
+        entry->second.pop_front();
+        note.offSample = event.sample;
+        lifetime.notes.push_back(note);
+    }
+
+    for (const auto& [key, notes] : pending)
+        lifetime.hanging += static_cast<int>(notes.size());
+
+    std::stable_sort(lifetime.notes.begin(), lifetime.notes.end(),
+                     [](const MidiNoteSpan& a, const MidiNoteSpan& b) {
+                         if (a.onSample != b.onSample)
+                             return a.onSample < b.onSample;
+                         if (a.channel != b.channel)
+                             return a.channel < b.channel;
+                         return a.pitch < b.pitch;
+                     });
+
+    return lifetime;
+}
+
+MidiComparison compareMidi(const MidiStream& native, const MidiStream& incumbent,
+                           const MidiCompareOptions& options) {
+    MidiComparison result;
+
+    const auto nativeLifetime = pairNotes(native);
+    auto incumbentLifetime = pairNotes(incumbent);
+
+    result.nativeHanging = nativeLifetime.hanging;
+    result.incumbentHanging = incumbentLifetime.hanging;
+
+    // Each stream is checked on its own before the two are compared. A note
+    // left hanging by the fork is not a reason to accept one here.
+    if (nativeLifetime.hanging > 0)
+        result.problems.push_back("native left " + std::to_string(nativeLifetime.hanging) +
+                                  " note(s) hanging");
+    if (nativeLifetime.unmatchedOffs > 0)
+        result.problems.push_back("native sent " + std::to_string(nativeLifetime.unmatchedOffs) +
+                                  " note-off(s) for notes it never started");
+    if (incumbentLifetime.hanging > 0)
+        result.problems.push_back("incumbent left " + std::to_string(incumbentLifetime.hanging) +
+                                  " note(s) hanging");
+    if (incumbentLifetime.unmatchedOffs > 0)
+        result.problems.push_back("incumbent sent " +
+                                  std::to_string(incumbentLifetime.unmatchedOffs) +
+                                  " note-off(s) for notes it never started");
+
+    // The declared shift brings the incumbent into the native domain. Declared,
+    // never fitted: the only thing it stands for is the fork dropping
+    // midiOffset on an unlooped arranger clip.
+    for (auto& note : incumbentLifetime.notes) {
+        note.onSample -= options.noteShiftSamples;
+        note.offSample -= options.noteShiftSamples;
+    }
+
+    // Everything neither side's comparison reaches, counted. The fork sends
+    // channel pressure with every MPE note; dropping that in silence is how a
+    // difference nobody counted becomes indistinguishable from no difference.
+    const auto countUncompared = [](const MidiStream& stream) {
+        auto uncompared = 0;
+        for (const auto& event : stream) {
+            const auto type = event.type();
+            if (type != kNoteOn && type != kNoteOff && type != kControlChange && type != kPitchBend)
+                ++uncompared;
+        }
+        return uncompared;
+    };
+
+    result.nativeUncompared = countUncompared(native);
+    result.incumbentUncompared = countUncompared(incumbent);
+
+    if (result.nativeUncompared != result.incumbentUncompared)
+        result.problems.push_back("messages outside notes, controllers and pitch bend: " +
+                                  std::to_string(result.nativeUncompared) +
+                                  " in the native render against " +
+                                  std::to_string(result.incumbentUncompared) + " in the incumbent");
+
+    std::vector<char> matched(incumbentLifetime.notes.size(), 0);
+    const auto tolerance = static_cast<std::int64_t>(options.noteToleranceSamples);
+    const auto endEarly = static_cast<std::int64_t>(options.incumbentNoteEndEarlySamples);
+
+    for (const auto& note : nativeLifetime.notes) {
+        std::size_t found = incumbentLifetime.notes.size();
+
+        for (std::size_t index = 0; index < incumbentLifetime.notes.size(); ++index) {
+            if (matched[index])
+                continue;
+
+            const auto& other = incumbentLifetime.notes[index];
+            if (other.channel != note.channel || other.pitch != note.pitch)
+                continue;
+            if (std::abs(other.onSample - note.onSample) > tolerance)
+                continue;
+
+            found = index;
+            break;
+        }
+
+        if (found == incumbentLifetime.notes.size()) {
+            ++result.notesOnlyInNative;
+            if (result.problems.size() < 24)
+                result.problems.push_back("note " + std::to_string(note.pitch) + " ch" +
+                                          std::to_string(note.channel) + " at " +
+                                          sampleAddress(note.onSample, options.sampleRate) +
+                                          " is not in the incumbent");
+            continue;
+        }
+
+        matched[found] = 1;
+        ++result.notesCompared;
+
+        const auto& other = incumbentLifetime.notes[found];
+        if (other.velocity != note.velocity ||
+            std::abs(other.offSample + endEarly - note.offSample) > tolerance) {
+            ++result.notesMismatched;
+            if (result.problems.size() < 24)
+                result.problems.push_back(
+                    "note " + std::to_string(note.pitch) + " ch" + std::to_string(note.channel) +
+                    " at " + sampleAddress(note.onSample, options.sampleRate) + ": velocity " +
+                    std::to_string(note.velocity) + " against " + std::to_string(other.velocity) +
+                    ", ends at " + std::to_string(note.offSample) + " against " +
+                    std::to_string(other.offSample));
+        }
+    }
+
+    for (std::size_t index = 0; index < incumbentLifetime.notes.size(); ++index) {
+        if (matched[index])
+            continue;
+
+        ++result.notesOnlyInIncumbent;
+        const auto& note = incumbentLifetime.notes[index];
+        if (result.problems.size() < 24)
+            result.problems.push_back("note " + std::to_string(note.pitch) + " ch" +
+                                      std::to_string(note.channel) + " at " +
+                                      sampleAddress(note.onSample, options.sampleRate) +
+                                      " is not in the native render");
+    }
+
+    result.notesMatch = result.notesOnlyInNative == 0 && result.notesOnlyInIncumbent == 0 &&
+                        result.notesMismatched == 0 && nativeLifetime.hanging == 0 &&
+                        nativeLifetime.unmatchedOffs == 0 && incumbentLifetime.hanging == 0 &&
+                        incumbentLifetime.unmatchedOffs == 0;
+
+    // --- controllers, as functions of time ---------------------------------
+    //
+    // The engine's stream IS the curve: a message goes out on every change of
+    // the quantised value, so its step function is the quantised curve exactly.
+    // The fork's is a sampling of that curve on a 1/16-beat grid. So the test
+    // is not that the two functions agree instant for instant, which is false
+    // by construction and gets worse the faster the curve moves: a pitch-bend
+    // dive over a hundred milliseconds gets three grid points there and about a
+    // hundred here, and at most instants the fork simply has not sent the value
+    // the curve is at. The test is that the fork's sampling is a faithful one.
+    //
+    // Three things say that, and between them they catch everything a wrong
+    // controller stream can be:
+    //
+    // - every message the fork sends lands on the engine's curve, within one
+    //   grid step either way. A wrong value, a curve evaluated with the wrong
+    //   tension and a stream arriving late all break this.
+    // - the two cover the same span, first change to last change.
+    // - they reach the same extremes.
+    //
+    // Repeats collapse first. The fork emits on its grid whether the value
+    // moved or not, so a curve that flattens for two bars keeps producing
+    // identical messages there; those carry no information and would otherwise
+    // make its span look longer than the engine's.
+
+    const auto nativeFunctions = controllerFunctions(native, 0);
+    const auto incumbentFunctions = controllerFunctions(incumbent, options.noteShiftSamples);
+
+    const auto slack = static_cast<std::int64_t>(
+        std::llround(options.staleBeats * 60.0 / std::max(1.0, options.bpm) * options.sampleRate));
+
+    result.controllersMatch = true;
+
+    std::vector<ControllerKey> keys;
+    for (const auto& [key, points] : nativeFunctions)
+        keys.push_back(key);
+    for (const auto& [key, points] : incumbentFunctions)
+        if (nativeFunctions.find(key) == nativeFunctions.end())
+            keys.push_back(key);
+    std::sort(keys.begin(), keys.end());
+
+    const auto fail = [&result](const std::string& message) {
+        result.controllersMatch = false;
+        if (result.problems.size() < 24)
+            result.problems.push_back(message);
+    };
+
+    for (const auto& key : keys) {
+        const auto nativeEntry = nativeFunctions.find(key);
+        const auto incumbentEntry = incumbentFunctions.find(key);
+
+        if (nativeEntry == nativeFunctions.end() || incumbentEntry == incumbentFunctions.end()) {
+            fail(describeKey(key) + " is only in the " +
+                 (nativeEntry == nativeFunctions.end() ? "incumbent" : "native render"));
+            continue;
+        }
+
+        const auto curve = collapseRepeats(nativeEntry->second);
+        const auto sampled = collapseRepeats(incumbentEntry->second);
+        if (curve.empty() || sampled.empty()) {
+            fail(describeKey(key) + " has no messages on one side");
+            continue;
+        }
+
+        auto landed = true;
+        for (const auto& point : sampled) {
+            if (holdsValueNear(curve, point.sample - slack, point.sample + slack, point.value,
+                               options.valueTolerance))
+                continue;
+
+            fail(describeKey(key) + ": the incumbent sends " + std::to_string(point.value) +
+                 " at " + sampleAddress(point.sample, options.sampleRate) +
+                 ", which the native curve is not at within a grid step (it is at " +
+                 std::to_string(valueAt(curve, point.sample)) + " there)");
+
+            // One message per controller. Twenty thousand instants of the same
+            // disagreement is not twenty thousand findings.
+            landed = false;
+            break;
+        }
+
+        if (!landed)
+            continue;
+
+        if (std::abs(curve.front().sample - sampled.front().sample) > slack ||
+            std::abs(curve.back().sample - sampled.back().sample) > slack)
+            fail(describeKey(key) + ": the streams cover different spans, native " +
+                 sampleAddress(curve.front().sample, options.sampleRate) + " to " +
+                 sampleAddress(curve.back().sample, options.sampleRate) + ", incumbent " +
+                 sampleAddress(sampled.front().sample, options.sampleRate) + " to " +
+                 sampleAddress(sampled.back().sample, options.sampleRate));
+
+        // What is deliberately NOT asserted: that the two reach the same
+        // extremes. A grid sampler misses the peak of anything moving faster
+        // than its grid, and missing it is the divergence rather than a symptom
+        // of one. A dive of a hundred milliseconds gets four grid points at 120
+        // bpm, so the fork's stream turns round at whatever the curve happened
+        // to be at 94 ms and never sends the value at the bottom. Requiring
+        // equal extremes would fail every fast curve in the corpus for being
+        // exactly what it was predicted to be.
+        //
+        // Nothing is lost by leaving it out. A stream that stops early in time
+        // is caught by the span, and a value the curve never takes is caught by
+        // the landing test above, which is the only way an extreme can be wrong
+        // rather than merely absent.
+    }
+
+    return result;
+}
+
+// =============================================================================
+// The report
+// =============================================================================
+
+const char* toString(Verdict verdict) {
+    switch (verdict) {
+        case Verdict::Null:
+            return "null";
+        case Verdict::Shift:
+            return "shift";
+        case Verdict::Midi:
+            return "midi";
+        case Verdict::ReportOnly:
+            return "report";
+    }
+    return "?";
+}
+
+std::string formatDb(double db) {
+    if (!std::isfinite(db))
+        return "-inf";
+
+    char text[32];
+    std::snprintf(text, sizeof(text), "%.1f", db);
+    return text;
+}
+
+std::string formatReport(const std::vector<CaseReport>& cases, double sampleRate, int blockSize) {
+    std::ostringstream out;
+
+    out << "magda-null-diff v1\n";
+    out << "cases=" << cases.size() << " rate=" << static_cast<long long>(sampleRate)
+        << " blockSize=" << blockSize << "\n";
+
+    auto index = 0;
+    for (const auto& report : cases) {
+        char line[256];
+        std::snprintf(line, sizeof(line), "[%2d] %-28s %-8s ", ++index, report.name.c_str(),
+                      toString(report.verdict));
+        out << line;
+
+        if (!report.unmeasurable.empty()) {
+            out << "unmeasurable: " << report.unmeasurable;
+        } else if (report.hasMidi) {
+            const auto& midi = report.midi;
+            std::snprintf(line, sizeof(line), "notes=%d%s cc=%s", midi.notesCompared,
+                          midi.notesMatch ? "" : "!", midi.controllersMatch ? "ok" : "differs");
+            out << line;
+        } else if (report.hasAudio) {
+            const auto& audio = report.audio;
+            std::snprintf(line, sizeof(line), "peak=%-9s rms=%-9s shift=%d",
+                          formatDb(audio.peakDb).c_str(), formatDb(audio.rmsDb).c_str(),
+                          audio.shiftSamples);
+            out << line;
+            if (!audio.refusal.empty())
+                out << " refused: " << audio.refusal;
+        }
+
+        out << (report.passed ? "  ok" : "  FAIL") << "\n";
+    }
+
+    return out.str();
+}
+
+}  // namespace magda::nulldiff

--- a/tests/NullDiffCompare.cpp
+++ b/tests/NullDiffCompare.cpp
@@ -642,8 +642,28 @@ AudioComparison compareAudio(const juce::AudioBuffer<float>& native,
         const auto* b = incumbent.getReadPointer(channel);
 
         for (auto index = begin; index < end; ++index) {
-            const auto residual =
-                static_cast<double>(a[index]) - static_cast<double>(b[index + shift]);
+            const auto left = static_cast<double>(a[index]);
+            const auto right = static_cast<double>(b[index + shift]);
+
+            // A comparator that silently certifies garbage is worse than no
+            // comparator. Every comparison against a NaN is false, so a NaN
+            // residual never beats the running peak: the peak stays at zero,
+            // the level reads as -inf, and the case is reported as a perfect
+            // null. Caught here rather than trusted, on the inputs rather than
+            // on the residual, so an infinity that cancels itself is caught
+            // too.
+            if (!std::isfinite(left) || !std::isfinite(right)) {
+                result.refusal = "a non-finite sample at " +
+                                 sampleAddress(index, options.sampleRate) + " (" +
+                                 (std::isfinite(left) ? "incumbent" : "native render") + ")";
+                result.peakDb = 0.0;
+                result.rmsDb = 0.0;
+                result.firstDivergence = index;
+                result.comparedSamples = 0;
+                return result;
+            }
+
+            const auto residual = left - right;
             const auto magnitude = std::abs(residual);
 
             if (magnitude > peak)

--- a/tests/NullDiffCompare.cpp
+++ b/tests/NullDiffCompare.cpp
@@ -617,6 +617,42 @@ AudioComparison compareAudio(const juce::AudioBuffer<float>& native,
         return result;
     }
 
+    // Both buffers whole, and before the alignment is even estimated. A
+    // comparator that silently certifies garbage is worse than no comparator,
+    // and every comparison against a NaN is false: a NaN residual never beats
+    // the running peak, so the peak stays at zero, the level reads as -inf and
+    // the pair is reported as a perfect null.
+    //
+    // Whole rather than over the overlap, because a shift excludes a margin at
+    // each end and the envelope and spectral comparisons trim the same margins.
+    // Garbage that lands in one of those is read by nothing and would sail
+    // through every check a stretched case makes. Whole rather than over the
+    // residual as well, so that two infinities cancelling to a finite
+    // difference are caught.
+    const auto firstNonFinite = [](const juce::AudioBuffer<float>& buffer) {
+        for (auto channel = 0; channel < buffer.getNumChannels(); ++channel) {
+            const auto* samples = buffer.getReadPointer(channel);
+            for (auto sample = 0; sample < buffer.getNumSamples(); ++sample)
+                if (!std::isfinite(samples[sample]))
+                    return static_cast<std::int64_t>(sample);
+        }
+        return static_cast<std::int64_t>(-1);
+    };
+
+    for (const auto& [buffer, whose] :
+         {std::pair{&native, "native render"}, std::pair{&incumbent, "incumbent"}}) {
+        const auto at = firstNonFinite(*buffer);
+        if (at < 0)
+            continue;
+
+        result.refusal = "a non-finite sample in the " + std::string(whose) + " at " +
+                         sampleAddress(at, options.sampleRate);
+        result.peakDb = 0.0;
+        result.rmsDb = 0.0;
+        result.firstDivergence = at;
+        return result;
+    }
+
     if (options.measureShift) {
         const auto estimate = estimateShift(native, incumbent, options.maxShiftSamples);
         result.shiftSamples = estimate.samples;
@@ -644,24 +680,6 @@ AudioComparison compareAudio(const juce::AudioBuffer<float>& native,
         for (auto index = begin; index < end; ++index) {
             const auto left = static_cast<double>(a[index]);
             const auto right = static_cast<double>(b[index + shift]);
-
-            // A comparator that silently certifies garbage is worse than no
-            // comparator. Every comparison against a NaN is false, so a NaN
-            // residual never beats the running peak: the peak stays at zero,
-            // the level reads as -inf, and the case is reported as a perfect
-            // null. Caught here rather than trusted, on the inputs rather than
-            // on the residual, so an infinity that cancels itself is caught
-            // too.
-            if (!std::isfinite(left) || !std::isfinite(right)) {
-                result.refusal = "a non-finite sample at " +
-                                 sampleAddress(index, options.sampleRate) + " (" +
-                                 (std::isfinite(left) ? "incumbent" : "native render") + ")";
-                result.peakDb = 0.0;
-                result.rmsDb = 0.0;
-                result.firstDivergence = index;
-                result.comparedSamples = 0;
-                return result;
-            }
 
             const auto residual = left - right;
             const auto magnitude = std::abs(residual);

--- a/tests/NullDiffCompare.cpp
+++ b/tests/NullDiffCompare.cpp
@@ -1090,9 +1090,9 @@ std::string formatReport(const std::vector<CaseReport>& cases, double sampleRate
             out << line;
         } else if (report.hasSpectral) {
             std::snprintf(line, sizeof(line),
-                          "shift=%-8.2f envelope=%-6.2f median=%-5.2f p95=%.2f dB",
-                          report.measuredShift, report.envelope.lagSamples, report.spectra.medianDb,
-                          report.spectra.percentile95Db);
+                          "shift=%-8.2f primed=%-6d envelope=%-6.2f median=%-5.2f p95=%.2f dB",
+                          report.measuredShift, report.primingSamples, report.envelope.lagSamples,
+                          report.spectra.medianDb, report.spectra.percentile95Db);
             out << line;
         } else if (report.hasAudio) {
             const auto& audio = report.audio;

--- a/tests/NullDiffCompare.hpp
+++ b/tests/NullDiffCompare.hpp
@@ -1,0 +1,327 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <vector>
+
+/**
+ * @file NullDiffCompare.hpp
+ * @brief What "the same" means when two engines render one project (#2040).
+ *
+ * Nothing here knows about either engine. It is handed two buffers, or two
+ * lists of MIDI, and says how far apart they are and where. That is deliberate:
+ * this is the one piece of the corpus nothing else checks, and a comparator
+ * that passes everything is a worse outcome than an engine that fails, because
+ * it would report parity it never measured. So it lives on its own, in the
+ * model-only target, with tests that feed it known-bad pairs.
+ *
+ * Three ideas are worth reading before the declarations.
+ *
+ * **The floor is arithmetic, not taste.** Two implementations doing the same
+ * work in a different order differ by an ulp or two, which is around -140 dBFS
+ * at these levels. -120 dBFS leaves room for the order of a summation and no
+ * room for anything audible.
+ *
+ * **One shift per case, measured at the start.** The fork primes its stretcher
+ * with the material at a clip's start rather than before it, so its stretched
+ * clips begin about a window late, and comparing without allowing for that
+ * would only ever measure that. The allowance is a single number found at the
+ * start of the material and applied to the whole case. Re-fitting a shift per
+ * region would turn a clip that drifts apart into a clip that passes, which is
+ * exactly the bug an auto-tempo case exists to catch.
+ *
+ * **Controllers are compared as a curve against a sampling of it.** The engine
+ * emits a controller message on every change of the quantised value, so its
+ * step function is the quantised curve exactly; the fork emits on a 1/16-beat
+ * grid, so its function is that curve sampled and held. Comparing the two
+ * instant for instant is false by construction and gets worse the faster the
+ * curve moves, which is why "agree at every instant, within a grid step either
+ * way" is not the test: over a pitch-bend dive the fork sends three messages to
+ * the engine's hundred, and at most instants it simply has not sent the value
+ * the curve is at.
+ *
+ * What is asserted instead is that the sampling is faithful: every message the
+ * fork sends lands on the engine's curve within one grid step, and the two
+ * cover the same span. A denser stream carrying the same values passes. A wrong
+ * value, a curve with the wrong tension, a stream that arrives late and one
+ * that stops early all fail. Equal extremes are deliberately not asserted, for
+ * a reason worth reading in the implementation: a grid sampler misses the peak
+ * of anything moving faster than its grid, and missing it is the divergence
+ * rather than evidence of one.
+ */
+
+namespace magda::nulldiff {
+
+// =============================================================================
+// Audio
+// =============================================================================
+
+struct AudioCompareOptions {
+    /// Peak residual at or below this is a null. Cases may raise it, and a
+    /// raised floor without a mechanism beside it does not belong in the
+    /// corpus.
+    double floorDb = -120.0;
+
+    /// Look for a fixed offset between the two before comparing. Only for cases
+    /// that declare one, because a shift the corpus did not expect is a clip in
+    /// the wrong place rather than an alignment to be undone.
+    bool measureShift = false;
+
+    /// How far the search may look, in samples. A stretcher's priming is a
+    /// window or two; anything beyond this is not priming.
+    int maxShiftSamples = 8192;
+
+    double sampleRate = 44100.0;
+};
+
+struct AudioComparison {
+    /// Peak and RMS of the residual, in dBFS. -inf when the two are identical.
+    double peakDb = -std::numeric_limits<double>::infinity();
+    double rmsDb = -std::numeric_limits<double>::infinity();
+
+    /// First sample past the floor, or -1. In the aligned domain, which is to
+    /// say an index into the native render.
+    std::int64_t firstDivergence = -1;
+
+    /// Samples the incumbent was found to be late by. Zero unless the case
+    /// asked for a shift and one was found.
+    int shiftSamples = 0;
+
+    /// True when a shift was asked for and the search declined to name one,
+    /// which is what a pair that differs in content rather than in timing gets.
+    /// The comparison still runs, unaligned, and fails on its merits.
+    bool shiftNotFound = false;
+
+    std::int64_t comparedSamples = 0;
+
+    /// The two renders were not the same length. Reported rather than trimmed
+    /// away silently, because a render that came back short is a bug in a leg.
+    std::int64_t lengthDifference = 0;
+
+    /// Set when the pair could not be compared at all, which is a different
+    /// thing from comparing badly: different channel counts, or nothing to
+    /// compare. A refusal is never reported as a residual.
+    std::string refusal;
+
+    bool withinFloor() const {
+        return peakDb <= floorUsed;
+    }
+
+    double floorUsed = -120.0;
+};
+
+/**
+ * @brief Compare @p native against @p incumbent.
+ *
+ * The residual is native minus incumbent, per channel, over the samples both
+ * cover. A pair with different channel counts is refused rather than compared
+ * on the channels they share.
+ */
+AudioComparison compareAudio(const juce::AudioBuffer<float>& native,
+                             const juce::AudioBuffer<float>& incumbent,
+                             const AudioCompareOptions& options = {});
+
+/**
+ * @brief How many samples @p incumbent lags @p native, or nothing.
+ *
+ * Normalised cross correlation over a window at the onset of the material,
+ * which is where a priming offset lives and where a case that drifts has not
+ * drifted yet. Returns nullopt when the best lag does not correlate well
+ * enough to be called an alignment: a comparator that slides until something
+ * matches will always find something, and what it finds on a pair that differs
+ * in content is a fiction that makes the case pass.
+ */
+struct ShiftEstimate {
+    int samples = 0;
+    double correlation = 0.0;
+    bool found = false;
+};
+
+ShiftEstimate estimateShift(const juce::AudioBuffer<float>& native,
+                            const juce::AudioBuffer<float>& incumbent, int maxShiftSamples);
+
+// =============================================================================
+// MIDI
+// =============================================================================
+
+/// One short message, positioned on the timeline rather than within a block.
+/// Both legs tap the instrument's input, which is the only point that means
+/// anything: what a synth receives.
+struct MidiEvent {
+    std::int64_t sample = 0;
+    std::uint8_t status = 0;
+    std::uint8_t data1 = 0;
+    std::uint8_t data2 = 0;
+
+    int channel() const {
+        return (status & 0x0F) + 1;
+    }
+    int type() const {
+        return status & 0xF0;
+    }
+};
+
+using MidiStream = std::vector<MidiEvent>;
+
+/// A note as a lifetime rather than as two messages, which is the form the
+/// invariant is stated in and therefore the form to compare.
+struct MidiNoteSpan {
+    int channel = 0;
+    int pitch = 0;
+    int velocity = 0;
+    std::int64_t onSample = 0;
+    std::int64_t offSample = 0;
+};
+
+struct MidiLifetime {
+    std::vector<MidiNoteSpan> notes;
+
+    /// A note-off for a note that never started, and a note that never ended.
+    /// Checked on each stream on its own before the two are compared: a note
+    /// left hanging by the incumbent is not a reason to accept one here.
+    int unmatchedOffs = 0;
+    int hanging = 0;
+};
+
+/// Pair note-ons with their offs. A note-on of velocity 0 is an off, as it is
+/// everywhere else in MIDI.
+MidiLifetime pairNotes(const MidiStream& stream);
+
+struct MidiCompareOptions {
+    double sampleRate = 44100.0;
+
+    /// Used to turn the fork's 1/16-beat grid into a duration. The slack is
+    /// what the divergence is, so it is expressed in the fork's own units.
+    double bpm = 120.0;
+    double staleBeats = 1.0 / 16.0;
+
+    /// Samples the incumbent's notes are expected to be late by, declared by
+    /// the case. Non-zero for exactly one thing: the fork drops midiOffset on
+    /// an unlooped arranger clip, so every note of such a clip lands offset.
+    /// Declared and asserted, never fitted.
+    std::int64_t noteShiftSamples = 0;
+
+    /// Two engines round a beat to a sample through different arithmetic.
+    int noteToleranceSamples = 1;
+
+    /// Samples the incumbent ends every note early by, declared by the case.
+    ///
+    /// The fork nudges every note-off backwards by 0.0001 s "to make sure the
+    /// ordering is correct" (MidiNote::getPlaybackTime), which is its way of
+    /// keeping an off ahead of an on at the same instant. The engine orders
+    /// events explicitly at compile time instead, so it keeps the length the
+    /// note was drawn at. Pinned here rather than absorbed into the tolerance
+    /// above: that tolerance is for a sample of rounding, and a note 100
+    /// microseconds short is a different claim about a different thing.
+    int incumbentNoteEndEarlySamples = 0;
+
+    /// A controller is seven bits and pitch bend fourteen, so this is the
+    /// resolution the value is transmitted at.
+    int valueTolerance = 1;
+};
+
+struct MidiComparison {
+    bool notesMatch = false;
+    bool controllersMatch = false;
+
+    int notesCompared = 0;
+    int notesOnlyInNative = 0;
+    int notesOnlyInIncumbent = 0;
+    int notesMismatched = 0;
+
+    int nativeHanging = 0;
+    int incumbentHanging = 0;
+
+    /// Messages that are neither notes, controllers nor pitch bend, per side.
+    ///
+    /// Counted rather than skipped. Everything this comparator does not
+    /// understand is something it would otherwise drop in silence, and a
+    /// difference nobody counted is indistinguishable from no difference: the
+    /// fork sends channel pressure with every MPE note, and ignoring it quietly
+    /// is how that would have gone unnoticed.
+    int nativeUncompared = 0;
+    int incumbentUncompared = 0;
+
+    /// Every disagreement, addressed: which note, which controller, which
+    /// instant. A parity failure that says "the streams differ" is a day of
+    /// somebody's life.
+    std::vector<std::string> problems;
+
+    bool passed() const {
+        return notesMatch && controllersMatch;
+    }
+};
+
+/**
+ * @brief Compare two captured MIDI streams.
+ *
+ * Notes exactly, to a sample either way. Channels as assigned rather than
+ * canonicalised to order of first use: the fork's MPE round-robin was ported
+ * deliberately, so a channel that differs is a finding, and canonicalising
+ * would be the corpus deciding not to look.
+ *
+ * Controllers and pitch bend as step functions of time, agreeing to one
+ * quantised unit at some instant within one grid step either way, in both
+ * directions.
+ */
+MidiComparison compareMidi(const MidiStream& native, const MidiStream& incumbent,
+                           const MidiCompareOptions& options = {});
+
+// =============================================================================
+// The report
+// =============================================================================
+
+/// What a case claims. The corpus declares it; the runner asserts it.
+enum class Verdict {
+    /// Sample for sample, with nothing allowed for.
+    Null,
+
+    /// Sample for sample after one pinned shift, measured at the start and
+    /// asserted against what the engine predicts.
+    Shift,
+
+    /// No audio assertion. The MIDI channel carries the case.
+    Midi,
+
+    /// Measured and printed, asserted only to be finite. One case, which exists
+    /// to say how far apart the two stretchers are on broadband material.
+    ReportOnly,
+};
+
+const char* toString(Verdict verdict);
+
+struct CaseReport {
+    std::string name;
+    Verdict verdict = Verdict::Null;
+
+    bool hasAudio = false;
+    AudioComparison audio;
+
+    bool hasMidi = false;
+    MidiComparison midi;
+
+    /// Set when the case could not be measured at all: a proxy that never
+    /// arrived, a leg that returned nothing. Never reported as a residual,
+    /// because a race reported as a parity failure costs somebody a day inside
+    /// the engine looking for it.
+    std::string unmeasurable;
+
+    bool passed = false;
+};
+
+/**
+ * @brief The corpus as canonical text, printed on every run.
+ *
+ * Numbers that move are the point. A corpus that only prints when it fails
+ * cannot show a residual creeping from -138 dB to -122 dB, which is what an
+ * engine going subtly wrong looks like before it goes audibly wrong.
+ */
+std::string formatReport(const std::vector<CaseReport>& cases, double sampleRate, int blockSize);
+
+/// dBFS from a linear amplitude, with a printable answer for silence.
+std::string formatDb(double db);
+
+}  // namespace magda::nulldiff

--- a/tests/NullDiffCompare.hpp
+++ b/tests/NullDiffCompare.hpp
@@ -110,6 +110,14 @@ struct AudioComparison {
         return peakDb <= floorUsed;
     }
 
+    /// A null is the whole render agreeing, not the part both happened to
+    /// cover. The residual is measured over the overlap, so a short incumbent
+    /// with an identical prefix would otherwise be certified as a null while
+    /// being exactly what this file calls a bug in a leg.
+    bool nulled() const {
+        return refusal.empty() && lengthDifference == 0 && withinFloor();
+    }
+
     double floorUsed = -120.0;
 };
 
@@ -340,13 +348,18 @@ struct MidiComparison {
     int nativeUncompared = 0;
     int incumbentUncompared = 0;
 
+    /// Whether those messages agree, message for message, in status, value and
+    /// instant. Counting them was not enough: equal counts would pass whatever
+    /// they carried, and an MPE note opens with a channel pressure.
+    bool otherMessagesMatch = false;
+
     /// Every disagreement, addressed: which note, which controller, which
     /// instant. A parity failure that says "the streams differ" is a day of
     /// somebody's life.
     std::vector<std::string> problems;
 
     bool passed() const {
-        return notesMatch && controllersMatch;
+        return notesMatch && controllersMatch && otherMessagesMatch;
     }
 };
 

--- a/tests/NullDiffCompare.hpp
+++ b/tests/NullDiffCompare.hpp
@@ -136,12 +136,107 @@ AudioComparison compareAudio(const juce::AudioBuffer<float>& native,
  */
 struct ShiftEstimate {
     int samples = 0;
+
+    /// The peak refined below a sample, by a parabola through the correlation
+    /// either side of it. A whole-sample answer is not enough for a band
+    /// limited tone: at 220 Hz one sample of misalignment is a residual around
+    /// -30 dB, so a case can be a full sample out and look like a bug in the
+    /// material rather than a bug in the timing.
+    double fractionalSamples = 0.0;
+
     double correlation = 0.0;
     bool found = false;
+
+    /// The same alignment as the envelopes see it, and how well they agree
+    /// there. This is the only answer available for stretched material: two
+    /// vocoders never correlate as waveforms, so `found` is false for them by
+    /// construction, and the envelope is what survives the phase difference.
+    /// Resolved to the decimation rather than to a sample, which is ample for
+    /// an offset measured in thousands.
+    double envelopeSamples = 0.0;
+    double envelopeCorrelation = 0.0;
 };
 
 ShiftEstimate estimateShift(const juce::AudioBuffer<float>& native,
                             const juce::AudioBuffer<float>& incumbent, int maxShiftSamples);
+
+/**
+ * @brief @p source delayed by @p delaySamples, which may be fractional.
+ *
+ * A windowed sinc, wide enough that its own error sits far below the floor on
+ * anything band limited. Deliberately not the engine's four-point cubic: this
+ * is used to align a case before measuring what is left, and aligning with the
+ * kernel under test would fold the thing being measured into the measurement.
+ */
+juce::AudioBuffer<float> delayFractionally(const juce::AudioBuffer<float>& source,
+                                           double delaySamples);
+
+// =============================================================================
+// Stretched audio, where a waveform comparison is the wrong question
+// =============================================================================
+
+/**
+ * Two vocoders fed the same material do not converge on the same waveform, and
+ * no amount of aligning makes them. Priming sets the initial phase state, phase
+ * in a vocoder is memory, and the two legs prime differently: the fork with the
+ * material at the clip's start, the engine with the material before it. From
+ * there the outputs stay a fixed distance apart in phase for ever, even with
+ * identical libraries and identical input afterwards.
+ *
+ * Magnitude is what framing leaves intact, so that is what is compared. But
+ * magnitude alone would let a wrong ratio, a misplaced clip or a dropped block
+ * through, so a stretched case is three assertions rather than one:
+ *
+ *  - the pinned shift, measured by cross correlation and asserted against what
+ *    the engine says its stretcher primes with;
+ *  - envelope timing after that shift, which is what keeps a placement bug
+ *    visible when the waveform cannot be compared;
+ *  - the magnitude spectrogram, which is what "the same material at the same
+ *    rate and the same pitch" means when the phase is allowed to differ.
+ */
+
+struct EnvelopeAgreement {
+    /// Where the two amplitude envelopes line up best, in samples, refined
+    /// below a sample. Zero is what a correctly placed clip gives.
+    double lagSamples = 0.0;
+
+    /// How well they line up there. A low peak means the two are not the same
+    /// shape at all, which no lag can fix.
+    double correlation = 0.0;
+};
+
+/// Rectified and smoothed at @p followerHz, then cross correlated. The envelope
+/// is what a listener would call the timing of a sound, and it survives the
+/// phase difference that makes the waveforms incomparable.
+EnvelopeAgreement compareEnvelopes(const juce::AudioBuffer<float>& native,
+                                   const juce::AudioBuffer<float>& incumbent, int shiftSamples,
+                                   double sampleRate, double followerHz = 40.0);
+
+struct SpectralAgreement {
+    /// Per-bin magnitude difference in dB, across every frame and bin loud
+    /// enough to mean anything. The median says whether they are the same
+    /// sound; the 95th percentile is what a case asserts on, because a
+    /// difference concentrated in a few frames is exactly what a dropped block
+    /// looks like.
+    double medianDb = 0.0;
+    double percentile95Db = 0.0;
+
+    int frames = 0;
+    int binsCompared = 0;
+};
+
+/// Window and hop are stated rather than tuned: 2048 at 44.1 kHz is about 46 ms,
+/// long enough to resolve a 220 Hz tone into a few bins, and a quarter-window
+/// hop is the usual overlap for a Hann.
+constexpr int kSpectralWindow = 2048;
+constexpr int kSpectralHop = 512;
+
+/// Magnitude spectrogram agreement. Bins below @p floorDb of the frame's own
+/// peak are skipped: comparing the noise floor of two vocoders is comparing
+/// their dither.
+SpectralAgreement compareSpectra(const juce::AudioBuffer<float>& native,
+                                 const juce::AudioBuffer<float>& incumbent, int shiftSamples,
+                                 double floorDb = -60.0);
 
 // =============================================================================
 // MIDI
@@ -302,6 +397,20 @@ struct CaseReport {
 
     bool hasMidi = false;
     MidiComparison midi;
+
+    /// What the two legs are offset by, measured even where the case does not
+    /// align by it. Printed on every run: an offset that is not applied is
+    /// still the first thing worth knowing about a case that will not null.
+    bool hasMeasuredShift = false;
+    double measuredShift = 0.0;
+    double shiftCorrelation = 0.0;
+    double shiftCorrelationEnvelope = 0.0;
+
+    /// Set on a stretched case, where a waveform comparison is the wrong
+    /// question and these two are the right ones.
+    bool hasSpectral = false;
+    EnvelopeAgreement envelope;
+    SpectralAgreement spectra;
 
     /// Set when the case could not be measured at all: a proxy that never
     /// arrived, a leg that returned nothing. Never reported as a residual,

--- a/tests/NullDiffCompare.hpp
+++ b/tests/NullDiffCompare.hpp
@@ -419,6 +419,11 @@ struct CaseReport {
     double shiftCorrelation = 0.0;
     double shiftCorrelationEnvelope = 0.0;
 
+    /// What the engine primed its stretcher with, printed beside the measured
+    /// offset so the two can be read against each other. That relationship is
+    /// what a Shift case's prediction has to be written from.
+    int primingSamples = 0;
+
     /// Set on a stretched case, where a waveform comparison is the wrong
     /// question and these two are the right ones.
     bool hasSpectral = false;

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -221,8 +221,13 @@ Case newCase(const char* name, const char* covers, TrackInfo track) {
 
 /// A stretched case: the fork primes its stretcher with the material at the
 /// clip's start rather than before it, so its clip begins about a window late.
-/// Measured at the start and asserted against what the engine predicts, never
-/// re-fitted per region.
+///
+/// The expected size is left unset here on purpose, and a Shift case with no
+/// declared expectation is refused rather than measured. The figure to put here
+/// is what the engine says its own stretcher primes with, which the corpus
+/// prints beside the measured offset for every one of these; until somebody has
+/// read those two against each other and written the relationship down, the
+/// corpus should not be certifying an alignment it has nothing to check.
 void expectsPrimingShift(Case& value) {
     value.verdict = Verdict::Shift;
     value.mechanism =

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -1,0 +1,631 @@
+#include <cmath>
+
+#include "NullDiffCase.hpp"
+#include "NullDiffMaterial.hpp"
+#include "core/DeviceInfo.hpp"
+#include "core/SourcePool.hpp"
+#include "core/TimeStretchModes.hpp"
+
+/**
+ * The corpus itself (#2040): every case, as model values.
+ *
+ * The table is the argument. Each case names one thing the two engines have to
+ * agree about, plays material chosen so that a residual can only be a bug, and
+ * declares what agreement it claims. Nothing here knows how either engine is
+ * driven.
+ *
+ * Two things are deliberately absent, and both for the reason the issue gives.
+ *
+ * Overlaps, and therefore holes and crossfades. Tracktion has no correct
+ * behaviour to diff against there, and giving it one is the double work that
+ * decision avoided. A hole is what occlusion leaves behind and occlusion is
+ * what an overlap is, and a crossfade is an overlap the model shaped, so all
+ * three are one exclusion rather than three. They are covered by the model
+ * suites, which pin every rule, and by reference-executor assertions: a fully
+ * covered region renders silent, a crossfade sums to unity, a play-through
+ * overlap sums both sources.
+ *
+ * Reverse together with warp. The incumbent cannot do it at all: it bakes one
+ * rendered proxy per clip and WaveAudioClip::createRenderJob returns the
+ * reverse job, so the markers are silently lost. There is nothing to diff, and
+ * the case would be asserting that the engine reproduces a bug.
+ */
+
+namespace magda::nulldiff {
+
+const char* const kGrooveName = "null-diff swing";
+
+namespace {
+
+constexpr double kRate = 44100.0;
+constexpr double kBpm = 120.0;
+
+constexpr TrackId kTrack = 1;
+constexpr DeviceId kInstrument = 900;
+
+/// Long enough that no case runs out of material, short enough that twenty of
+/// them cost a second of disk.
+constexpr double kSourceSeconds = 12.0;
+
+double beatSeconds(double beats, double bpm = kBpm) {
+    return beats * 60.0 / bpm;
+}
+
+// --- tracks ------------------------------------------------------------------
+
+TrackInfo plainTrack() {
+    TrackInfo track;
+    track.id = kTrack;
+    track.type = TrackType::Audio;
+    track.name = "Null Diff";
+    track.audioOutputDevice = "master";
+    return track;
+}
+
+/// A track whose chain consumes MIDI, which is what makes the plan compile a
+/// ClipMidi op at all: no consumer, no source. The device stands for the synth
+/// a MIDI clip would be playing, and in both legs it is replaced by something
+/// that records what arrives instead of making a sound. That is the comparison
+/// point, and the only one that means anything: what a synth receives.
+TrackInfo instrumentTrack() {
+    auto track = plainTrack();
+
+    DeviceInfo device;
+    device.id = kInstrument;
+    device.name = "Capture";
+    device.deviceType = DeviceType::Instrument;
+    device.isInstrument = true;
+    device.canReceiveMidi = true;
+    track.chain.fxChainElements.emplace_back(std::move(device));
+
+    return track;
+}
+
+TrackInfo masterTrack() {
+    TrackInfo master;
+    master.id = MASTER_TRACK_ID;
+    master.type = TrackType::Master;
+    master.name = "Master";
+    return master;
+}
+
+// --- material ----------------------------------------------------------------
+
+SourceFact writeSource(const juce::File& directory, const juce::String& name,
+                       const MaterialSpec& spec) {
+    const auto file = writeMaterial(directory, name, spec);
+
+    auto& pool = SourcePool::getInstance();
+    const auto path = file.getFullPathName();
+
+    // Seeded rather than probed. Both legs read a file's rate and duration from
+    // the pool, and a case that let each of them probe separately would have
+    // two answers to one question the first time a decoder rounded a length.
+    pool.seedFactsForTesting(path, spec.durationSeconds, spec.sampleRate);
+
+    SourceFact fact;
+    fact.id = pool.acquire(path);
+    fact.path = path;
+    fact.sampleRate = spec.sampleRate;
+    fact.durationSeconds = spec.durationSeconds;
+
+    pool.resolveFacts(fact.id);
+    if (auto* source = pool.getMutable(fact.id))
+        source->durationSeconds = spec.durationSeconds;
+
+    return fact;
+}
+
+MaterialSpec impulses(double intervalSeconds = 0.25) {
+    MaterialSpec spec;
+    spec.kind = MaterialKind::Impulses;
+    spec.sampleRate = kRate;
+    spec.durationSeconds = kSourceSeconds;
+    spec.intervalSeconds = intervalSeconds;
+    return spec;
+}
+
+MaterialSpec steps() {
+    MaterialSpec spec;
+    spec.kind = MaterialKind::Steps;
+    spec.sampleRate = kRate;
+    spec.durationSeconds = kSourceSeconds;
+    spec.intervalSeconds = 0.5;
+    return spec;
+}
+
+MaterialSpec tone(double sampleRate = kRate, double frequency = 220.0) {
+    MaterialSpec spec;
+    spec.kind = MaterialKind::Tone;
+    spec.sampleRate = sampleRate;
+    spec.durationSeconds = kSourceSeconds;
+    spec.frequency = frequency;
+    return spec;
+}
+
+MaterialSpec noise() {
+    MaterialSpec spec;
+    spec.kind = MaterialKind::Noise;
+    spec.sampleRate = kRate;
+    spec.durationSeconds = kSourceSeconds;
+    return spec;
+}
+
+// --- clips -------------------------------------------------------------------
+
+ClipInfo audioClip(ClipId id, double startBeat, double lengthBeats, const SourceFact& source) {
+    ClipInfo clip;
+    clip.id = id;
+    clip.trackId = kTrack;
+    clip.name = "clip " + juce::String(id);
+    clip.view = ClipView::Arrangement;
+    clip.setAudioContent();
+
+    AudioEvent event;
+    event.sourceId = source.id;
+    clip.audio().addEvent(std::move(event));
+
+    clip.setPlacementBeats(startBeat, lengthBeats);
+    clip.deriveTimesFromBeats(kBpm);
+    return clip;
+}
+
+AudioEvent& eventOf(ClipInfo& clip) {
+    return *clip.primaryEvent();
+}
+
+ClipInfo midiClip(ClipId id, double startBeat, double lengthBeats) {
+    ClipInfo clip;
+    clip.id = id;
+    clip.trackId = kTrack;
+    clip.name = "midi " + juce::String(id);
+    clip.view = ClipView::Arrangement;
+    clip.setMidiContent();
+    clip.setPlacementBeats(startBeat, lengthBeats);
+    clip.deriveTimesFromBeats(kBpm);
+    return clip;
+}
+
+MidiNote note(int pitch, double startBeat, double lengthBeats, int velocity = 100) {
+    MidiNote value;
+    value.noteNumber = pitch;
+    value.velocity = velocity;
+    value.startBeat = startBeat;
+    value.lengthBeats = lengthBeats;
+    return value;
+}
+
+// --- the case shells ---------------------------------------------------------
+
+Case newCase(const char* name, const char* covers, TrackInfo track) {
+    Case value;
+    value.name = name;
+    value.covers = covers;
+    value.tracks.push_back(std::move(track));
+    value.master = masterTrack();
+    value.sampleRate = kRate;
+    value.startBeat = 0.0;
+    value.endBeat = 16.0;
+    return value;
+}
+
+/// A stretched case: the fork primes its stretcher with the material at the
+/// clip's start rather than before it, so its clip begins about a window late.
+/// Measured at the start and asserted against what the engine predicts, never
+/// re-fitted per region.
+void expectsPrimingShift(Case& value) {
+    value.verdict = Verdict::Shift;
+    value.mechanism =
+        "the fork primes its stretcher with the material at the clip's start rather than "
+        "before it, so its render begins about a window late";
+}
+
+}  // namespace
+
+std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
+    scratchDirectory.createDirectory();
+
+    std::vector<Case> corpus;
+
+    // --- placement, trims, fades: sample for sample --------------------------
+
+    {
+        auto value = newCase("placement.grid", "four clips on beat boundaries", plainTrack());
+        const auto source = writeSource(scratchDirectory, "placement", impulses());
+        value.sources.push_back(source);
+        for (auto index = 0; index < 4; ++index)
+            value.clips.push_back(audioClip(static_cast<ClipId>(10 + index),
+                                            static_cast<double>(index) * 4.0, 2.0, source));
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        auto value =
+            newCase("placement.trims", "left and right trim, content offset", plainTrack());
+        const auto source = writeSource(scratchDirectory, "trims", impulses());
+        value.sources.push_back(source);
+
+        // A left trim is where in the file reading begins, which is a source
+        // position rather than a timeline one.
+        auto trimmed = audioClip(20, 0.0, 4.0, source);
+        eventOf(trimmed).sourceAnchorSamples =
+            static_cast<std::int64_t>(std::llround(0.375 * source.sampleRate));
+        value.clips.push_back(std::move(trimmed));
+
+        auto shortened = audioClip(21, 8.0, 1.5, source);
+        eventOf(shortened).sourceAnchorSamples =
+            static_cast<std::int64_t>(std::llround(1.125 * source.sampleRate));
+        value.clips.push_back(std::move(shortened));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        auto value = newCase("fades.curves", "all four shapes, in and out", plainTrack());
+        const auto source = writeSource(scratchDirectory, "fades", steps());
+        value.sources.push_back(source);
+
+        // A constant level with a gain envelope on it renders the envelope
+        // itself, so a curve wrong in the fourth decimal is visible.
+        const int curves[] = {
+            static_cast<int>(FadeCurve::Linear), static_cast<int>(FadeCurve::Convex),
+            static_cast<int>(FadeCurve::Concave), static_cast<int>(FadeCurve::SCurve)};
+        for (auto index = 0; index < 4; ++index) {
+            auto clip = audioClip(static_cast<ClipId>(30 + index), static_cast<double>(index) * 4.0,
+                                  3.0, source);
+            auto& event = eventOf(clip);
+            event.fadeInSeconds = 0.5;
+            event.fadeOutSeconds = 0.5;
+            event.fadeInType = curves[index];
+            event.fadeOutType = curves[index];
+            value.clips.push_back(std::move(clip));
+        }
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // The other thing a clip's fade pair can mean: the material accelerates
+        // into the clip and decelerates out of it, pitch and all. It resamples
+        // rather than stretches, so the material is band limited.
+        auto value = newCase("fades.speedramp", "a fade pair read as a speed ramp", plainTrack());
+        const auto source = writeSource(scratchDirectory, "speedramp", tone());
+        value.sources.push_back(source);
+
+        auto clip = audioClip(40, 0.0, 8.0, source);
+        auto& event = eventOf(clip);
+        event.fadeInSeconds = 1.0;
+        event.fadeOutSeconds = 1.0;
+        event.fadeInBehaviour = 1;
+        event.fadeOutBehaviour = 1;
+        value.clips.push_back(std::move(clip));
+
+        corpus.push_back(std::move(value));
+    }
+
+    // --- looping, rate, reverse ---------------------------------------------
+
+    {
+        auto value =
+            newCase("loop.tiling", "loop start off zero, non-integer loop length", plainTrack());
+        const auto source = writeSource(scratchDirectory, "loop", impulses(0.125));
+        value.sources.push_back(source);
+
+        auto clip = audioClip(50, 0.0, 12.0, source);
+        clip.loopEnabled = true;
+        auto& event = eventOf(clip);
+        event.setLoopStartSeconds(0.25);
+        event.setLoopLengthSeconds(0.75);
+        event.setAnchorSeconds(0.25);
+        value.clips.push_back(std::move(clip));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        auto value = newCase("rate.48k", "a 48 kHz file on a 44.1 kHz render", plainTrack());
+        const auto source = writeSource(scratchDirectory, "rate48", tone(48000.0));
+        value.sources.push_back(source);
+        value.clips.push_back(audioClip(60, 0.0, 8.0, source));
+
+        // Band limited on purpose. The rate converter is a four-point cubic
+        // Lagrange here and JUCE's five-point in the fork, and at a few hundred
+        // hertz both curves are the same curve to far below the floor, while a
+        // wrong position or a dropped sample is as loud as it ever was.
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        auto value = newCase("reverse.plain", "a clip that plays backwards", plainTrack());
+        const auto source = writeSource(scratchDirectory, "reverse", impulses());
+        value.sources.push_back(source);
+
+        auto clip = audioClip(70, 0.0, 8.0, source);
+        eventOf(clip).reversed = true;
+        value.clips.push_back(std::move(clip));
+
+        corpus.push_back(std::move(value));
+    }
+
+    // --- speed, pitch, tempo -------------------------------------------------
+
+    {
+        auto value = newCase("speed.ratio", "a speed ratio with no stretcher", plainTrack());
+        const auto source = writeSource(scratchDirectory, "speed", tone());
+        value.sources.push_back(source);
+
+        auto clip = audioClip(80, 0.0, 8.0, source);
+        auto& event = eventOf(clip);
+        event.speedRatio = 1.5;
+        event.timeStretchMode = time_stretch_mode::kDisabled;
+        value.clips.push_back(std::move(clip));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        auto value = newCase("pitch.analog", "pitch folded into the ratio", plainTrack());
+        const auto source = writeSource(scratchDirectory, "analog", tone());
+        value.sources.push_back(source);
+
+        auto clip = audioClip(90, 0.0, 8.0, source);
+        auto& event = eventOf(clip);
+        event.analogPitch = true;
+        event.transpose = 5;
+        event.timeStretchMode = time_stretch_mode::kDisabled;
+        value.clips.push_back(std::move(clip));
+
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        auto value = newCase("tempo.auto", "auto tempo across a step tempo change", plainTrack());
+        const auto source = writeSource(scratchDirectory, "autotempo", tone());
+        value.sources.push_back(source);
+
+        auto clip = audioClip(100, 0.0, 12.0, source);
+        auto& event = eventOf(clip);
+        event.autoTempo = true;
+        event.interpBpm = 100.0;
+        event.interpTotalBeats = kSourceSeconds * 100.0 / 60.0;
+        event.timeStretchMode = time_stretch_mode::kSignalsmith;
+        value.clips.push_back(std::move(clip));
+
+        // A step rather than a ramp: the two engines resolve a ramped tempo
+        // differently, and the render cases must not be where that shows up.
+        value.tempo = {{0.0, kBpm}, {8.0, 140.0}};
+
+        // Auto tempo is a ratio that is not one, so a stretcher runs, so the
+        // fork primes it late. Nothing about the tempo change exempts it. What
+        // this case adds over the plain stretch ones is the question a moving
+        // ratio asks: the shift is measured once, at the start, and the null
+        // test then runs across the tempo change. A lateness that grows when
+        // the ratio moves fails here rather than being fitted away.
+        expectsPrimingShift(value);
+
+        corpus.push_back(std::move(value));
+    }
+
+    // --- the stretchers ------------------------------------------------------
+
+    struct StretchCase {
+        const char* name;
+        const char* covers;
+        int mode;
+    };
+
+    for (const auto& stretch :
+         {StretchCase{"stretch.signalsmith", "kSignalsmith", time_stretch_mode::kSignalsmith},
+          StretchCase{"stretch.soundtouch.normal", "kSoundTouchNormal",
+                      time_stretch_mode::kSoundTouchNormal},
+          StretchCase{"stretch.soundtouch.better", "kSoundTouchBetter",
+                      time_stretch_mode::kSoundTouchBetter}}) {
+        auto value = newCase(stretch.name, stretch.covers, plainTrack());
+        const auto source = writeSource(scratchDirectory, juce::String(stretch.name), tone());
+        value.sources.push_back(source);
+
+        auto clip = audioClip(110, 0.0, 8.0, source);
+        auto& event = eventOf(clip);
+        event.speedRatio = 1.25;
+        event.timeStretchMode = stretch.mode;
+        value.clips.push_back(std::move(clip));
+
+        expectsPrimingShift(value);
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // The one case that measures rather than asserts. What it says is how
+        // far apart the two stretchers are on material that has everything in
+        // it, which is a number worth watching and not a claim about playback.
+        auto value =
+            newCase("stretch.broadband", "how far apart the two stretchers are", plainTrack());
+        const auto source = writeSource(scratchDirectory, "broadband", noise());
+        value.sources.push_back(source);
+
+        auto clip = audioClip(120, 0.0, 8.0, source);
+        auto& event = eventOf(clip);
+        event.speedRatio = 1.25;
+        event.timeStretchMode = time_stretch_mode::kSignalsmith;
+        value.clips.push_back(std::move(clip));
+
+        value.verdict = Verdict::ReportOnly;
+        value.mechanism =
+            "two phase vocoders fed material with everything in it, framed differently by "
+            "each engine's own reading; measured and printed rather than asserted";
+        corpus.push_back(std::move(value));
+    }
+
+    // --- warp ----------------------------------------------------------------
+
+    {
+        // The warp semantics live in the map comparison, which is exact. This
+        // is here for the one thing the map cannot say: that the voice reads
+        // through it. Warp forces a stretcher on, so the material is band
+        // limited and the case carries the priming shift.
+        auto value =
+            newCase("warp.audio", "a warped clip actually read through the map", plainTrack());
+        const auto source = writeSource(scratchDirectory, "warp", tone());
+        value.sources.push_back(source);
+
+        auto clip = audioClip(130, 0.0, 8.0, source);
+        auto& event = eventOf(clip);
+        event.warpEnabled = true;
+        event.warpMarkers = {{0.0, 0.0}, {1.0, 1.5}, {3.0, 3.0}};
+        event.timeStretchMode = time_stretch_mode::kSignalsmith;
+        value.clips.push_back(std::move(clip));
+
+        expectsPrimingShift(value);
+        corpus.push_back(std::move(value));
+    }
+
+    // --- takes and comping ---------------------------------------------------
+
+    {
+        // Neither engine reads the take list: what plays is the event's source,
+        // and comping is a rendered composite that arrives the same way. So
+        // what this pins is that neither of them invents anything from it.
+        auto value = newCase("takes.comp", "a comped clip and a non-default take", plainTrack());
+        const auto first = writeSource(scratchDirectory, "take0", impulses(0.25));
+        const auto second = writeSource(scratchDirectory, "take1", impulses(0.375));
+        value.sources.push_back(first);
+        value.sources.push_back(second);
+
+        auto clip = audioClip(140, 0.0, 8.0, second);
+        auto& audio = clip.audio();
+        audio.takes.push_back({first.path, first.durationSeconds});
+        audio.takes.push_back({second.path, second.durationSeconds});
+        audio.currentTakeIndex = 1;
+        audio.comp.push_back({0.0, 2.0, 1});
+        audio.comp.push_back({2.0, 4.0, 0});
+        value.clips.push_back(std::move(clip));
+
+        corpus.push_back(std::move(value));
+    }
+
+    // --- MIDI ----------------------------------------------------------------
+
+    {
+        auto value = newCase("midi.notes", "notes and velocities", instrumentTrack());
+        auto clip = midiClip(200, 0.0, 8.0);
+        for (auto index = 0; index < 8; ++index)
+            clip.midiNotes.push_back(note(60 + index, static_cast<double>(index),
+                                          index % 2 == 0 ? 0.75 : 0.5, 40 + index * 10));
+        value.clips.push_back(std::move(clip));
+        value.verdict = Verdict::Midi;
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        auto value = newCase("midi.cc", "dense CC and pitch bend", instrumentTrack());
+        auto clip = midiClip(210, 0.0, 8.0);
+        clip.midiNotes.push_back(note(60, 0.0, 8.0));
+
+        // A slow sweep and a fast one, because the two fail differently: the
+        // fork's grid is far too dense for the first and far too sparse for the
+        // second.
+        for (auto index = 0; index <= 8; ++index) {
+            MidiCCData point;
+            point.controller = 1;
+            point.value = index * 15 > 127 ? 127 : index * 15;
+            point.beatPosition = static_cast<double>(index);
+            clip.midiCCData.push_back(point);
+        }
+
+        for (auto index = 0; index <= 4; ++index) {
+            MidiPitchBendData point;
+            point.value = 8192 - index * 2048;
+            point.beatPosition = 4.0 + static_cast<double>(index) * 0.05;
+            clip.midiPitchBendData.push_back(point);
+        }
+
+        value.clips.push_back(std::move(clip));
+        value.verdict = Verdict::Midi;
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        auto value = newCase("midi.mpe", "per-note pitch expression", instrumentTrack());
+        auto clip = midiClip(220, 0.0, 8.0);
+
+        for (auto index = 0; index < 3; ++index) {
+            auto value1 = note(60 + index * 4, static_cast<double>(index) * 0.5, 4.0);
+            value1.pitchExpression = {{0.0, 0.0}, {2.0, 1.0 + index}, {4.0, 0.0}};
+            clip.midiNotes.push_back(std::move(value1));
+        }
+
+        value.clips.push_back(std::move(clip));
+        value.verdict = Verdict::Midi;
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        // The single trickiest thing ported in slice 6. An odd loop length under
+        // a per-beat groove means each pass starts somewhere else in the
+        // pattern, so the groove is anchored to the project grid and looked up
+        // per pass rather than baked at compile time. Until this case, that was
+        // pinned only by the engine's own tests, which is to say by one reading
+        // of LoopedMidiEventGenerator.
+        auto value =
+            newCase("midi.fold", "an odd loop length under a per-beat groove", instrumentTrack());
+
+        auto clip = midiClip(230, 0.0, 12.0);
+        clip.loopEnabled = true;
+        clip.loopStartBeats = 0.0;
+        clip.loopLengthBeats = 1.5;
+        clip.grooveTemplate = kGrooveName;
+        clip.grooveStrength = 1.0f;
+        clip.midiNotes.push_back(note(60, 0.0, 0.4));
+        clip.midiNotes.push_back(note(64, 0.5, 0.4));
+        clip.midiNotes.push_back(note(67, 1.0, 0.4));
+        value.clips.push_back(std::move(clip));
+
+        value.grooveXml =
+            "<GROOVETEMPLATES>"
+            "<GROOVETEMPLATE name=\"null-diff swing\" numberOfNotes=\"4\" notesPerBeat=\"2\" "
+            "parameterized=\"0\">"
+            "<SHIFT delta=\"0\"/><SHIFT delta=\"0.25\"/>"
+            "<SHIFT delta=\"0\"/><SHIFT delta=\"0.25\"/>"
+            "</GROOVETEMPLATE>"
+            "</GROOVETEMPLATES>";
+
+        value.verdict = Verdict::Midi;
+        corpus.push_back(std::move(value));
+    }
+
+    {
+        auto value = newCase("midi.offset", "midiOffset on an unlooped clip", instrumentTrack());
+
+        auto clip = midiClip(240, 0.0, 8.0);
+        clip.midiOffset = 0.5;
+
+        // From beat 1 rather than beat 0, so the offset moves every note and
+        // clips none of them. A note at the very start would be pulled before
+        // the clip's own edge, where the engine trims it and the fork does not,
+        // and that one note would be measuring the trim rather than the offset.
+        for (auto index = 0; index < 4; ++index)
+            clip.midiNotes.push_back(
+                note(60 + index * 3, 1.0 + static_cast<double>(index) * 2.0, 1.0));
+        value.clips.push_back(std::move(clip));
+
+        value.verdict = Verdict::Midi;
+
+        // The fork's arranger path drops midiOffset while its session path
+        // applies it, which is a gap in the sync layer rather than a semantic.
+        // Applying it either way is the reading the engine takes: the engine
+        // pulls the content earlier by the offset and the fork leaves it where
+        // it was written, so every one of the fork's notes lands later by
+        // exactly that. Declared here and asserted, so a note that moves for any
+        // other reason still breaks.
+        value.declaredMidiShiftBeats = clip.midiOffset;
+        value.mechanism =
+            "the fork's arranger path drops midiOffset on an unlooped clip while its session "
+            "path applies it; the engine applies it either way";
+
+        corpus.push_back(std::move(value));
+    }
+
+    return corpus;
+}
+
+}  // namespace magda::nulldiff

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -143,6 +143,16 @@ MaterialSpec tone(double sampleRate = kRate, double frequency = 220.0) {
     return spec;
 }
 
+/// A tone with a slow swell in it, for the cases judged on their envelope.
+MaterialSpec pulsedTone() {
+    MaterialSpec spec;
+    spec.kind = MaterialKind::PulsedTone;
+    spec.sampleRate = kRate;
+    spec.durationSeconds = kSourceSeconds;
+    spec.frequency = 220.0;
+    return spec;
+}
+
 MaterialSpec noise() {
     MaterialSpec spec;
     spec.kind = MaterialKind::Noise;
@@ -380,7 +390,7 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
 
     {
         auto value = newCase("tempo.auto", "auto tempo across a step tempo change", plainTrack());
-        const auto source = writeSource(scratchDirectory, "autotempo", tone());
+        const auto source = writeSource(scratchDirectory, "autotempo", pulsedTone());
         value.sources.push_back(source);
 
         auto clip = audioClip(100, 0.0, 12.0, source);
@@ -421,7 +431,7 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
           StretchCase{"stretch.soundtouch.better", "kSoundTouchBetter",
                       time_stretch_mode::kSoundTouchBetter}}) {
         auto value = newCase(stretch.name, stretch.covers, plainTrack());
-        const auto source = writeSource(scratchDirectory, juce::String(stretch.name), tone());
+        const auto source = writeSource(scratchDirectory, juce::String(stretch.name), pulsedTone());
         value.sources.push_back(source);
 
         auto clip = audioClip(110, 0.0, 8.0, source);
@@ -465,7 +475,7 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
         // limited and the case carries the priming shift.
         auto value =
             newCase("warp.audio", "a warped clip actually read through the map", plainTrack());
-        const auto source = writeSource(scratchDirectory, "warp", tone());
+        const auto source = writeSource(scratchDirectory, "warp", pulsedTone());
         value.sources.push_back(source);
 
         auto clip = audioClip(130, 0.0, 8.0, source);

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -342,6 +342,19 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
         // Lagrange here and JUCE's five-point in the fork, and at a few hundred
         // hertz both curves are the same curve to far below the floor, while a
         // wrong position or a dropped sample is as loud as it ever was.
+        //
+        // The residual here is timing shaped: the two renders sit -0.852 of a
+        // sample apart, which is the size a difference between two
+        // interpolation kernels would be.
+        //
+        // That reading has been tried and does not hold. Aligning by the
+        // measured offset makes the case worse rather than better (-32.2 dB to
+        // -28.5 dB), and a fixed offset is precisely the thing one number can
+        // undo. So whatever separates these two is not a constant delay, and
+        // the case stays under calibration rather than carrying a mechanism its
+        // own evidence contradicts. The next reading to try is a difference in
+        // the mapping itself, where the offset varies with position rather than
+        // sitting still.
         corpus.push_back(std::move(value));
     }
 

--- a/tests/NullDiffMaterial.cpp
+++ b/tests/NullDiffMaterial.cpp
@@ -85,6 +85,27 @@ juce::AudioBuffer<float> renderMaterial(const MaterialSpec& spec) {
             break;
         }
 
+        case MaterialKind::PulsedTone: {
+            const auto increment =
+                spec.frequency * juce::MathConstants<double>::twoPi / spec.sampleRate;
+            const auto pulse = spec.pulseHz * juce::MathConstants<double>::twoPi / spec.sampleRate;
+
+            for (auto sample = 0; sample < numSamples; ++sample) {
+                const auto carrier = std::sin(increment * static_cast<double>(sample));
+
+                // Never quite to silence: a gap would give the envelope nothing
+                // to correlate through, and a stretcher fed silence is a
+                // different question from a stretcher fed a swell.
+                const auto envelope =
+                    0.15 + 0.85 * (0.5 - 0.5 * std::cos(pulse * static_cast<double>(sample)));
+
+                for (auto channel = 0; channel < buffer.getNumChannels(); ++channel)
+                    buffer.setSample(channel, sample,
+                                     spec.level * static_cast<float>(carrier * envelope));
+            }
+            break;
+        }
+
         case MaterialKind::Noise: {
             for (auto channel = 0; channel < buffer.getNumChannels(); ++channel) {
                 Lcg random(spec.seed + static_cast<unsigned int>(channel) * 0x85EBCA6Bu);

--- a/tests/NullDiffMaterial.cpp
+++ b/tests/NullDiffMaterial.cpp
@@ -1,0 +1,135 @@
+#include "NullDiffMaterial.hpp"
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_formats/juce_audio_formats.h>
+
+#include <cmath>
+
+namespace magda::nulldiff {
+
+namespace {
+
+/// A 32-bit generator with no library dependency, so that the same seed gives
+/// the same noise on every platform. std::mt19937 would too, but the
+/// distributions on top of it are not specified to.
+struct Lcg {
+    explicit Lcg(unsigned int seed) : state(seed | 1u) {}
+
+    float next() {
+        state = state * 1664525u + 1013904223u;
+        return static_cast<float>(static_cast<double>(state) / 2147483648.0 - 1.0);
+    }
+
+    unsigned int state;
+};
+
+/// Long enough to take the click off a tone's ends and short enough not to be
+/// the thing under test. Five milliseconds, in samples.
+int windowSamples(double sampleRate) {
+    return juce::jmax(1, static_cast<int>(0.005 * sampleRate));
+}
+
+}  // namespace
+
+juce::AudioBuffer<float> renderMaterial(const MaterialSpec& spec) {
+    const auto numSamples =
+        juce::jmax(1, static_cast<int>(std::llround(spec.durationSeconds * spec.sampleRate)));
+    juce::AudioBuffer<float> buffer(juce::jmax(1, spec.channels), numSamples);
+    buffer.clear();
+
+    switch (spec.kind) {
+        case MaterialKind::Impulses: {
+            const auto stride = juce::jmax(
+                1, static_cast<int>(std::llround(spec.intervalSeconds * spec.sampleRate)));
+            for (auto sample = 0; sample < numSamples; sample += stride)
+                for (auto channel = 0; channel < buffer.getNumChannels(); ++channel)
+                    buffer.setSample(channel, sample, spec.level * 2.0f);
+            break;
+        }
+
+        case MaterialKind::Steps: {
+            const auto stride = juce::jmax(
+                1, static_cast<int>(std::llround(spec.intervalSeconds * spec.sampleRate)));
+            for (auto sample = 0; sample < numSamples; ++sample) {
+                const auto sign = ((sample / stride) % 2 == 0) ? 1.0f : -1.0f;
+                for (auto channel = 0; channel < buffer.getNumChannels(); ++channel)
+                    buffer.setSample(channel, sample, sign * spec.level);
+            }
+            break;
+        }
+
+        case MaterialKind::Tone: {
+            const auto fade = juce::jmin(windowSamples(spec.sampleRate), numSamples / 2);
+            const auto increment =
+                spec.frequency * juce::MathConstants<double>::twoPi / spec.sampleRate;
+            for (auto sample = 0; sample < numSamples; ++sample) {
+                auto value = std::sin(increment * static_cast<double>(sample));
+
+                // A raised cosine at each end. A rectangular window would put a
+                // step at the file's edges, and a step is broadband, which is
+                // the one thing this material exists not to be.
+                if (fade > 0) {
+                    if (sample < fade)
+                        value *= 0.5 - 0.5 * std::cos(juce::MathConstants<double>::pi *
+                                                      static_cast<double>(sample) /
+                                                      static_cast<double>(fade));
+                    else if (sample >= numSamples - fade)
+                        value *= 0.5 - 0.5 * std::cos(juce::MathConstants<double>::pi *
+                                                      static_cast<double>(numSamples - 1 - sample) /
+                                                      static_cast<double>(fade));
+                }
+
+                for (auto channel = 0; channel < buffer.getNumChannels(); ++channel)
+                    buffer.setSample(channel, sample, spec.level * static_cast<float>(value));
+            }
+            break;
+        }
+
+        case MaterialKind::Noise: {
+            for (auto channel = 0; channel < buffer.getNumChannels(); ++channel) {
+                Lcg random(spec.seed + static_cast<unsigned int>(channel) * 0x85EBCA6Bu);
+                auto* out = buffer.getWritePointer(channel);
+                for (auto sample = 0; sample < numSamples; ++sample)
+                    out[sample] = spec.level * random.next();
+            }
+            break;
+        }
+    }
+
+    return buffer;
+}
+
+juce::File writeMaterial(const juce::File& directory, const juce::String& name,
+                         const MaterialSpec& spec) {
+    directory.createDirectory();
+    const auto file = directory.getChildFile(name + ".wav");
+    file.deleteFile();
+
+    const auto buffer = renderMaterial(spec);
+
+    juce::WavAudioFormat format;
+    std::unique_ptr<juce::OutputStream> stream(file.createOutputStream());
+    if (stream == nullptr)
+        return {};
+
+    // 32-bit float, and the whole corpus depends on it: anything narrower puts
+    // quantisation noise above the null floor and every case would be measuring
+    // the file format rather than the engines.
+    const auto options =
+        juce::AudioFormatWriterOptions{}
+            .withSampleRate(spec.sampleRate)
+            .withNumChannels(buffer.getNumChannels())
+            .withBitsPerSample(32)
+            .withSampleFormat(juce::AudioFormatWriterOptions::SampleFormat::floatingPoint);
+
+    auto writer = format.createWriterFor(stream, options);
+    if (writer == nullptr)
+        return {};
+
+    writer->writeFromAudioSampleBuffer(buffer, 0, buffer.getNumSamples());
+    writer.reset();
+
+    return file;
+}
+
+}  // namespace magda::nulldiff

--- a/tests/NullDiffMaterial.hpp
+++ b/tests/NullDiffMaterial.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_core/juce_core.h>
+
+/**
+ * @file NullDiffMaterial.hpp
+ * @brief The audio a null-diff case plays, generated rather than checked in.
+ *
+ * Two reasons it is generated. A corpus that carries binary fixtures grows a
+ * megabyte per case and a review that cannot read them, and a fixture recorded
+ * once is a fixture nobody can regenerate when a case needs one bar more.
+ *
+ * The choice of material per case is not decoration, it is what makes a
+ * residual mean something (#2040). Two correct implementations of the same
+ * thing disagree wherever they interpolate, and between these two engines
+ * stand three interpolators: a four-point cubic Lagrange here against JUCE's
+ * five-point in the fork, and two phase vocoders whose output depends on how
+ * their input was framed. Broadband material through any of those produces a
+ * residual tens of decibels above anything a placement bug makes, and the only
+ * way to pass is a tolerance wide enough to hide the placement bug too.
+ *
+ * So:
+ *
+ * - Where the engines must agree sample for sample, which is placement, trims,
+ *   fades, loop tiling, reverse and comping, the material is impulses and
+ *   steps. Nothing interpolates, one sample of disagreement is a residual at
+ *   full scale, and a fade curve wrong in the fourth decimal shows up.
+ * - Where an interpolator or a stretcher stands between them, the material is
+ *   a tone well below Nyquist. Interpolation error falls with the fourth power
+ *   of frequency over sample rate, so at a few hundred hertz both curves are
+ *   the same curve to far below the floor, while a wrong position, a wrong
+ *   ratio or a dropped sample is as loud as it ever was.
+ * - Noise exists for one case, which measures how far apart the two stretchers
+ *   are and asserts nothing.
+ *
+ * Written as 32-bit float, for the same reason the incumbent leg renders as
+ * float: a 16-bit fixture puts quantisation noise at -96 dBFS, which is well
+ * above the floor, and every case would be measuring the file format.
+ */
+
+namespace magda::nulldiff {
+
+/// What a case plays. See the file comment for why this is a choice per case
+/// rather than a tolerance per case.
+enum class MaterialKind {
+    /// One full-scale sample every interval, silence between. Placement to the
+    /// sample, and nothing to interpolate.
+    Impulses,
+
+    /// A constant level whose sign flips every interval. A gain envelope
+    /// applied to it is readable directly off the render, which is what the
+    /// fade cases need, and the flips keep it from being pure DC.
+    Steps,
+
+    /// A sine well below Nyquist, with a short raised-cosine window at each end
+    /// so the file's own edges are not a broadband click. For every path with
+    /// an interpolator or a stretcher in it.
+    Tone,
+
+    /// White noise from a fixed generator. One case, which measures rather than
+    /// asserts.
+    Noise,
+};
+
+struct MaterialSpec {
+    MaterialKind kind = MaterialKind::Impulses;
+    double sampleRate = 44100.0;
+    double durationSeconds = 8.0;
+    int channels = 1;
+
+    /// Tone only.
+    double frequency = 220.0;
+
+    /// Impulses and Steps: how often one lands.
+    double intervalSeconds = 0.25;
+
+    /// Noise only. Fixed, so the same case produces the same bytes on every
+    /// machine and a residual is never a different random sequence.
+    unsigned int seed = 0x9E3779B9u;
+
+    float level = 0.5f;
+};
+
+/**
+ * @brief Write @p spec into @p directory as @p name.wav and return the file.
+ *
+ * Deterministic: same spec, same bytes. Overwrites, because a corpus run that
+ * reused a file from a previous run with different contents would be the one
+ * kind of failure nobody would think to look for.
+ */
+juce::File writeMaterial(const juce::File& directory, const juce::String& name,
+                         const MaterialSpec& spec);
+
+/// Render @p spec into a buffer without writing it. What writeMaterial writes,
+/// and what the material's own tests read.
+juce::AudioBuffer<float> renderMaterial(const MaterialSpec& spec);
+
+}  // namespace magda::nulldiff

--- a/tests/NullDiffMaterial.hpp
+++ b/tests/NullDiffMaterial.hpp
@@ -58,6 +58,13 @@ enum class MaterialKind {
     /// an interpolator or a stretcher in it.
     Tone,
 
+    /// A tone under a slow raised-cosine tremolo. For the cases judged on their
+    /// envelope: a steady tone has none worth correlating, so an envelope test
+    /// over one measures nothing and reports whatever the noise floor prefers.
+    /// The modulation is a few hertz, which puts its sidebands beside the
+    /// carrier and leaves the material as band limited as it was.
+    PulsedTone,
+
     /// White noise from a fixed generator. One case, which measures rather than
     /// asserts.
     Noise,
@@ -69,8 +76,11 @@ struct MaterialSpec {
     double durationSeconds = 8.0;
     int channels = 1;
 
-    /// Tone only.
+    /// Tone and PulsedTone.
     double frequency = 220.0;
+
+    /// PulsedTone only: how often the level swells, in hertz.
+    double pulseHz = 3.0;
 
     /// Impulses and Steps: how often one lands.
     double intervalSeconds = 0.25;

--- a/tests/NullDiffNativeLeg.cpp
+++ b/tests/NullDiffNativeLeg.cpp
@@ -267,6 +267,16 @@ NativeRender renderNative(const Case& value) {
 
     result.audio = std::move(sink.buffer);
 
+    // What the pool primed each stretcher with, read back after the render so
+    // that every entry it provisioned has been through it.
+    {
+        const ClipStreamFeed::Reader table(voices.feed());
+        if (table)
+            for (const auto& entry : table->entries)
+                if (entry.stretcher != nullptr)
+                    result.primingSamples = std::max(result.primingSamples, entry.preRollSamples);
+    }
+
     for (const auto& [trackId, source] : audioSources)
         result.starvedVoices += source->starvedVoices();
     for (const auto& [trackId, source] : midiSources)

--- a/tests/NullDiffNativeLeg.cpp
+++ b/tests/NullDiffNativeLeg.cpp
@@ -252,6 +252,21 @@ NativeRender renderNative(const Case& value) {
 
     // --- render --------------------------------------------------------------
 
+    // What the pool primes this case's stretchers with, read where it is
+    // actually true: the entries are provisioned as the transport approaches
+    // them and retired once they have passed, so asking after the render is
+    // asking an empty table. Positioning the pool at the range's start and
+    // servicing it once is what a render's first block does anyway.
+    voices.setPosition(tempo.beatToTime(value.startBeat));
+    voices.service();
+    {
+        const ClipStreamFeed::Reader table(voices.feed());
+        if (table)
+            for (const auto& entry : table->entries)
+                if (entry.stretcher != nullptr)
+                    result.primingSamples = std::max(result.primingSamples, entry.preRollSamples);
+    }
+
     OfflineRenderRequest request;
     request.startBeat = value.startBeat;
     request.endBeat = value.endBeat;
@@ -269,14 +284,6 @@ NativeRender renderNative(const Case& value) {
 
     // What the pool primed each stretcher with, read back after the render so
     // that every entry it provisioned has been through it.
-    {
-        const ClipStreamFeed::Reader table(voices.feed());
-        if (table)
-            for (const auto& entry : table->entries)
-                if (entry.stretcher != nullptr)
-                    result.primingSamples = std::max(result.primingSamples, entry.preRollSamples);
-    }
-
     for (const auto& [trackId, source] : audioSources)
         result.starvedVoices += source->starvedVoices();
     for (const auto& [trackId, source] : midiSources)

--- a/tests/NullDiffNativeLeg.cpp
+++ b/tests/NullDiffNativeLeg.cpp
@@ -1,0 +1,282 @@
+#include "NullDiffNativeLeg.hpp"
+
+#include <juce_audio_formats/juce_audio_formats.h>
+
+#include <map>
+#include <memory>
+
+#include "clip/ClipAudioSource.hpp"
+#include "clip/ClipMidiSource.hpp"
+#include "clip/ClipSnapshotCompiler.hpp"
+#include "clip/ClipSnapshotFeed.hpp"
+#include "clip/ClipVoicePool.hpp"
+#include "clip/GrooveTemplate.hpp"
+#include "exec/OfflineRender.hpp"
+#include "exec/PlanExecutor.hpp"
+#include "exec/PlanValues.hpp"
+#include "io/PrefetchThread.hpp"
+#include "plan/PlanCompiler.hpp"
+#include "transport/TempoMap.hpp"
+
+namespace magda::nulldiff {
+
+using namespace magda::engine;
+
+namespace {
+
+/// Opens the files a snapshot names, which is the one thing the engine leaves
+/// to whoever is hosting it: a snapshot carries paths because that is what the
+/// model has, and which formats exist is not the engine's business.
+class WavFactory final : public AudioFileReaderFactory {
+  public:
+    WavFactory() {
+        formats_.registerBasicFormats();
+    }
+
+    std::unique_ptr<AudioFileReader> open(const std::string& path) override {
+        std::unique_ptr<juce::AudioFormatReader> reader(
+            formats_.createReaderFor(juce::File(juce::String(path))));
+        if (reader == nullptr)
+            return nullptr;
+        return std::make_unique<JuceAudioFileReader>(std::move(reader));
+    }
+
+  private:
+    juce::AudioFormatManager formats_;
+};
+
+/// Stands where a synth would, and records what reaches it. The comparison
+/// point for every MIDI case, and the reason a MIDI case has a device at all:
+/// a plan compiles no ClipMidi op for a track whose chain consumes no MIDI.
+class MidiCapture final : public EngineDevice {
+  public:
+    explicit MidiCapture(double sampleRate) : sampleRate_(sampleRate) {}
+
+    void process(DeviceBlock& block) override {
+        // Silence out. What a synth would make of these messages is not what is
+        // being compared, and printing anything would only invite somebody to
+        // compare it.
+        block.audio.clear();
+
+        if (block.midiIn == nullptr)
+            return;
+
+        // Where the block sits on the timeline, so a captured message carries a
+        // position in the render rather than one inside a callback. Taken from
+        // the block's own seconds, which the clock derives from a sample count
+        // rather than accumulating, so this recovers that count exactly and
+        // keeps doing so through the tail, where the timeline stands still.
+        const auto blockStart =
+            static_cast<std::int64_t>(std::llround(block.block.startSeconds * sampleRate_));
+
+        for (const auto message : *block.midiIn) {
+            const auto data = message.getMessage();
+            if (data.getRawDataSize() < 2 || data.getRawDataSize() > 3)
+                continue;
+
+            const auto* raw = data.getRawData();
+            captured.push_back(
+                {blockStart + message.samplePosition, static_cast<std::uint8_t>(raw[0]),
+                 static_cast<std::uint8_t>(raw[1]),
+                 data.getRawDataSize() > 2 ? static_cast<std::uint8_t>(raw[2]) : std::uint8_t{0}});
+        }
+    }
+
+    MidiStream captured;
+
+  private:
+    double sampleRate_ = 44100.0;
+};
+
+engine::TempoMap tempoMapFor(const Case& value) {
+    // Consecutive changes ramp: the tempo travels from one to the next across
+    // the beats between them. A step is two changes at the same beat, which is
+    // what the model's curve editor draws when two points share an x position.
+    //
+    // So a case's tempo list is turned into steps here rather than handed over
+    // as it stands. Every render case in the corpus wants steps, because a ramp
+    // is the one place the two engines' tempo maps are known to be able to
+    // disagree, and a render case built on one would report that disagreement
+    // as a clip in the wrong place.
+    std::vector<engine::TempoChange> changes;
+
+    for (const auto& point : value.tempo) {
+        if (!changes.empty()) {
+            engine::TempoChange hold;
+            hold.startBeat = point.beat;
+            hold.bpm = changes.back().bpm;
+            changes.push_back(hold);
+        }
+
+        engine::TempoChange change;
+        change.startBeat = point.beat;
+        change.bpm = point.bpm;
+        changes.push_back(change);
+    }
+
+    return engine::TempoMap(std::move(changes), {});
+}
+
+GrooveTemplateSet groovesFor(const Case& value) {
+    if (value.grooveXml.isEmpty())
+        return {};
+
+    const auto document = juce::parseXML(value.grooveXml);
+    if (document == nullptr)
+        return {};
+
+    return GrooveTemplateSet::parse(*document);
+}
+
+/// Collects the render into one buffer, so that two renders are comparable
+/// sample for sample however either was cut into blocks.
+class BufferSink final : public OfflineRenderSink {
+  public:
+    explicit BufferSink(int channels) : channels_(channels) {}
+
+    void write(const juce::AudioBuffer<float>& block, int numSamples) override {
+        const auto start = buffer.getNumSamples();
+        buffer.setSize(channels_, start + numSamples, true, true, false);
+        for (auto channel = 0; channel < channels_; ++channel)
+            buffer.copyFrom(channel, start, block, channel, 0, numSamples);
+    }
+
+    juce::AudioBuffer<float> buffer;
+
+  private:
+    int channels_;
+};
+
+}  // namespace
+
+NativeRender renderNative(const Case& value) {
+    NativeRender result;
+
+    const RenderContext context{value.sampleRate, value.blockSize, value.channels};
+    const auto tempo = tempoMapFor(value);
+
+    // --- what the track plays ------------------------------------------------
+
+    std::vector<ClipLane> lanes;
+    for (const auto& track : value.tracks) {
+        ClipLane lane;
+        lane.trackId = track.id;
+        for (const auto& clip : value.clips)
+            if (clip.trackId == track.id)
+                lane.clips.push_back(clip);
+        lanes.push_back(std::move(lane));
+    }
+
+    std::vector<ClipSourceInfo> sources;
+    for (const auto& source : value.sources)
+        sources.push_back(
+            {source.id, source.path.toStdString(), source.sampleRate, source.durationSeconds});
+
+    auto snapshot = std::make_shared<const ClipSnapshot>(
+        compileClipSnapshot(lanes, sources, tempo, groovesFor(value)));
+    for (const auto& diagnostic : snapshot->diagnostics)
+        result.diagnostics.push_back("snapshot: " + diagnostic);
+
+    // --- the plan ------------------------------------------------------------
+
+    CompileOptions options;
+    options.deviceMeters = false;
+    const auto plan = compileRenderPlan(value.tracks, value.master, options);
+    for (const auto& diagnostic : plan.diagnostics)
+        result.diagnostics.push_back("plan: " + diagnostic);
+
+    // --- what the ops resolve to ---------------------------------------------
+
+    ClipSnapshotFeed clips;
+    clips.publish(snapshot);
+
+    // The reader's own thread is off, and the render drives it. See
+    // PrefetchThread: a render outruns any thread, so whether a clip's chunks
+    // arrived in time would come down to the scheduler, and every underrun that
+    // produced would look like a clip playing silence.
+    PrefetchThread reader(false);
+    WavFactory files;
+    ClipVoicePool voices(files, reader, context);
+    voices.setSnapshot(snapshot);
+
+    std::map<TrackId, std::unique_ptr<ClipAudioSource>> audioSources;
+    std::map<TrackId, std::unique_ptr<ClipMidiSource>> midiSources;
+    std::map<DeviceId, std::unique_ptr<MidiCapture>> captures;
+
+    PlanBindings bindings;
+
+    for (const auto& op : plan.ops) {
+        switch (op.kind) {
+            case OpKind::ClipAudio: {
+                auto source =
+                    std::make_unique<ClipAudioSource>(op.key.trackId, clips, voices.feed());
+                source->prepare(context);
+                bindings.clipAudio[op.key.trackId] = source.get();
+                audioSources[op.key.trackId] = std::move(source);
+                break;
+            }
+
+            case OpKind::ClipMidi: {
+                auto source = std::make_unique<ClipMidiSource>(op.key.trackId, clips);
+                source->prepare(context);
+                bindings.clipMidi[op.key.trackId] = source.get();
+                midiSources[op.key.trackId] = std::move(source);
+                break;
+            }
+
+            case OpKind::Device: {
+                auto device = std::make_unique<MidiCapture>(value.sampleRate);
+                device->prepare(context);
+                bindings.devices[op.key.deviceId] = device.get();
+                captures[op.key.deviceId] = std::move(device);
+                break;
+            }
+
+            default:
+                break;
+        }
+    }
+
+    PlanValues values;
+    for (const auto& diagnostic : resolvePlanValues(plan, value.tracks, value.master, values))
+        result.diagnostics.push_back("values: " + diagnostic);
+
+    PlanExecutor executor;
+    for (const auto& diagnostic : executor.prepare(plan, bindings, context))
+        result.diagnostics.push_back("prepare: " + diagnostic);
+
+    if (!executor.isPrepared()) {
+        result.failure = "the executor refused the plan";
+        return result;
+    }
+
+    // --- render --------------------------------------------------------------
+
+    OfflineRenderRequest request;
+    request.startBeat = value.startBeat;
+    request.endBeat = value.endBeat;
+    request.blockSize = value.blockSize;
+
+    BufferSink sink(value.channels);
+    const auto rendered = renderOffline(executor, values, context, tempo, request, sink, &voices);
+
+    if (rendered.refused) {
+        result.failure = "the offline render refused the plan it was given";
+        return result;
+    }
+
+    result.audio = std::move(sink.buffer);
+
+    for (const auto& [trackId, source] : audioSources)
+        result.starvedVoices += source->starvedVoices();
+    for (const auto& [trackId, source] : midiSources)
+        result.droppedMidiEvents += source->droppedEvents();
+
+    for (const auto& [deviceId, capture] : captures)
+        for (const auto& event : capture->captured)
+            result.midi.push_back(event);
+
+    return result;
+}
+
+}  // namespace magda::nulldiff

--- a/tests/NullDiffNativeLeg.hpp
+++ b/tests/NullDiffNativeLeg.hpp
@@ -47,6 +47,17 @@ struct NativeRender {
     /// so both are read back and reported.
     int starvedVoices = 0;
     int droppedMidiEvents = 0;
+
+    /// The most material any of this case's stretchers is primed with, in
+    /// samples of the reading.
+    ///
+    /// This is what a stretched case predicts its shift from, and it comes from
+    /// the engine rather than from a number written down here: the fork primes
+    /// with the material AT a clip's start where the engine primes with the
+    /// material BEFORE it, and both use the same library at the same preset, so
+    /// what the engine reads back is what the fork is late by. A constant in the
+    /// corpus would go stale the moment either side changed its preset.
+    int primingSamples = 0;
 };
 
 /// Render @p value through the native engine, over its own beat range.

--- a/tests/NullDiffNativeLeg.hpp
+++ b/tests/NullDiffNativeLeg.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include <string>
+#include <vector>
+
+#include "NullDiffCase.hpp"
+#include "NullDiffCompare.hpp"
+
+/**
+ * @file NullDiffNativeLeg.hpp
+ * @brief A null-diff case rendered through the native engine (#2040).
+ *
+ * The engine's own offline render, the engine's own compiler and the engine's
+ * own voice pool. Nothing here reimplements a step of it: a harness that
+ * rendered through a second implementation would prove things about the second
+ * implementation.
+ *
+ * What this file does own is the host side the engine deliberately does not
+ * have. A snapshot carries paths because that is what the model holds, and
+ * turning one into a reader is the host's job (io/AudioFileReader.hpp), so the
+ * factory that opens a WAV lives here. So does the device standing in for the
+ * synth a MIDI clip would play, which records what arrives instead of making a
+ * sound: the plan compiles no ClipMidi op for a track whose chain consumes no
+ * MIDI, so the capture point and the reason the MIDI exists at all are the same
+ * thing.
+ */
+
+namespace magda::nulldiff {
+
+struct NativeRender {
+    juce::AudioBuffer<float> audio;
+    MidiStream midi;
+
+    /// Set when the case could not be rendered at all, which is never reported
+    /// as a residual.
+    std::string failure;
+
+    /// What the engine said it could not do. Anything in here is a finding
+    /// whether or not the audio nulled: a snapshot that dropped a clip and a
+    /// render that matched it are two bugs, not none.
+    std::vector<std::string> diagnostics;
+
+    /// Clips that wanted a voice and had none, and MIDI a block could not fit.
+    /// Silence nobody counted is indistinguishable from silence that was meant,
+    /// so both are read back and reported.
+    int starvedVoices = 0;
+    int droppedMidiEvents = 0;
+};
+
+/// Render @p value through the native engine, over its own beat range.
+NativeRender renderNative(const Case& value);
+
+}  // namespace magda::nulldiff

--- a/tests/NullDiffTeLeg.cpp
+++ b/tests/NullDiffTeLeg.cpp
@@ -1,0 +1,398 @@
+#include "NullDiffTeLeg.hpp"
+
+#include <juce_audio_formats/juce_audio_formats.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+#include <cmath>
+#include <memory>
+
+#include "SharedTestEngine.hpp"
+#include "magda/daw/audio/TrackController.hpp"
+#include "magda/daw/audio/WarpMarkerManager.hpp"
+#include "magda/daw/audio/plugins/InternalPluginRegistry.hpp"
+#include "magda/daw/audio/plugins/tracktion/TracktionInternalPluginAdapter.hpp"
+#include "magda/daw/audio/session/ClipSynchronizer.hpp"
+#include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/engine/OfflineRenderHelper.hpp"
+#include "magda/daw/project/ProjectManager.hpp"
+#include "third_party/tracktion_engine/modules/tracktion_engine/utilities/tracktion_TestUtilities.h"
+
+namespace magda::nulldiff {
+
+namespace te = tracktion;
+
+namespace {
+
+/// How long to let a proxy render before calling the case unmeasurable. Long
+/// enough that a loaded machine is not a failure, short enough that a job which
+/// is never going to finish does not hold the suite up.
+constexpr int kProxyTimeoutMs = 20000;
+
+/// Records what reaches the instrument slot. The comparison point on this side,
+/// and it has to be the same point as on the other: what a synth receives.
+///
+/// Built directly rather than through the plugin cache, because registering a
+/// type would put a test-only device in the app's own registry, where it would
+/// show up in the browser and in everything else that walks it.
+class MidiCapturePlugin final : public te::Plugin {
+  public:
+    explicit MidiCapturePlugin(te::PluginCreationInfo info) : te::Plugin(info) {}
+
+    static const char* getPluginName() {
+        return "Null Diff MIDI Capture";
+    }
+
+    juce::String getName() const override {
+        return getPluginName();
+    }
+    juce::String getPluginType() override {
+        return "nulldiffmidicapture";
+    }
+    juce::String getShortName(int) override {
+        return "NDCap";
+    }
+    juce::String getSelectableDescription() override {
+        return getName();
+    }
+
+    bool takesAudioInput() override {
+        return true;
+    }
+    bool takesMidiInput() override {
+        return true;
+    }
+    bool producesAudioWhenNoAudioInput() override {
+        return false;
+    }
+    bool canBeAddedToClip() override {
+        return false;
+    }
+    bool needsConstantBufferSize() override {
+        return false;
+    }
+
+    void initialise(const te::PluginInitialisationInfo& info) override {
+        sampleRate_ = info.sampleRate;
+    }
+    void deinitialise() override {}
+
+    void applyToBuffer(const te::PluginRenderContext& context) override {
+        if (context.destBuffer != nullptr)
+            context.destBuffer->clear();
+
+        if (context.bufferForMidiMessages == nullptr)
+            return;
+
+        // Where the block sits on the timeline, so a captured message carries a
+        // position in the render rather than one inside a callback. TE stamps
+        // its messages in seconds from the start of the block.
+        const auto blockStart = context.editTime.getStart().inSeconds();
+
+        for (auto& message : *context.bufferForMidiMessages) {
+            if (message.getRawDataSize() < 2 || message.getRawDataSize() > 3)
+                continue;
+
+            const auto at = blockStart + message.getTimeStamp();
+            const auto* raw = message.getRawData();
+
+            captured.push_back({static_cast<std::int64_t>(std::llround(at * sampleRate_)),
+                                static_cast<std::uint8_t>(raw[0]),
+                                static_cast<std::uint8_t>(raw[1]),
+                                message.getRawDataSize() > 2 ? static_cast<std::uint8_t>(raw[2])
+                                                             : std::uint8_t{0}});
+        }
+    }
+
+    void restorePluginStateFromValueTree(const juce::ValueTree&) override {}
+
+    MidiStream captured;
+
+  private:
+    double sampleRate_ = 44100.0;
+};
+
+/// The capture device, as the app's own registry sees it.
+///
+/// Registered rather than newly constructed, because a te::Plugin whose type
+/// nothing can create is re-created from its own state by the plugin list and
+/// refused: the log says "unknown type" and the track is left without the
+/// mapping the clips are about to be synced onto. So this goes in through the
+/// same door every internal device does, marked unsupported and out of the
+/// browser the way the app's other internal taps are, and only ever in a test
+/// binary.
+const char* const kCapturePluginId = "nulldiffmidicapture";
+
+void registerCaptureDevice(magda::daw::audio::InternalPluginRegistry& registry) {
+    magda::daw::audio::InternalPluginSpec spec;
+    spec.pluginId = kCapturePluginId;
+    spec.displayName = "Null Diff MIDI Capture";
+    spec.browserCategory = "Utility";
+    spec.description = "Records the MIDI reaching an instrument slot, for the null-diff corpus.";
+    spec.createMode = magda::daw::audio::InternalPluginCreateMode::FreshValueTree;
+    spec.canCreateDetached = false;
+    spec.canCreateOnTrack = false;
+    spec.showInBrowser = false;
+    spec.matchesPlugin = [](magda::daw::audio::DevicePluginRef plugin) {
+        return dynamic_cast<MidiCapturePlugin*>(
+                   magda::daw::audio::tracktion_adapter::pluginFromRef(plugin)) != nullptr;
+    };
+    spec.createPlugin = [](const magda::daw::audio::DevicePluginCreationContext& context) {
+        return magda::daw::audio::tracktion_adapter::pluginHandle(
+            new MidiCapturePlugin(magda::daw::audio::tracktion_adapter::creationInfo(context)));
+    };
+
+    registry.registerPlugin(spec);
+}
+
+const bool captureDeviceRegistered = magda::daw::audio::registerDevicePack(registerCaptureDevice);
+
+void pumpMessageThread(int milliseconds) {
+    if (auto* manager = juce::MessageManager::getInstanceWithoutCreating())
+        manager->runDispatchLoopUntil(milliseconds);
+}
+
+/// Put the case's tempo into the Edit as steps.
+///
+/// TE's own tempo changes are steps unless a curve is set, so this is the
+/// straightforward reading of the same list the native leg turns into pairs of
+/// changes at one beat.
+void applyTempo(te::Edit& edit, const Case& value) {
+    auto& sequence = edit.tempoSequence;
+
+    while (sequence.getNumTempos() > 1)
+        sequence.removeTempo(sequence.getNumTempos() - 1, false);
+
+    if (auto* first = sequence.getTempo(0))
+        first->setBpm(value.tempo.front().bpm);
+
+    for (std::size_t index = 1; index < value.tempo.size(); ++index)
+        sequence.insertTempo(te::BeatPosition::fromBeats(value.tempo[index].beat),
+                             value.tempo[index].bpm, 1.0f);
+}
+
+void installGrooves(te::Engine& engine, const Case& value) {
+    if (value.grooveXml.isEmpty())
+        return;
+
+    const auto document = juce::parseXML(value.grooveXml);
+    if (document == nullptr)
+        return;
+
+    auto& manager = engine.getGrooveTemplateManager();
+
+    for (const auto* node : document->getChildWithTagNameIterator("GROOVETEMPLATE")) {
+        const te::GrooveTemplate groove(node);
+
+        // Replace one of the same name rather than adding a second, so that a
+        // suite running the corpus twice does not accumulate them.
+        auto index = manager.getNumTemplates();
+        for (auto existing = 0; existing < manager.getNumTemplates(); ++existing)
+            if (manager.getTemplateName(existing) == groove.getName())
+                index = existing;
+
+        manager.updateTemplate(index, groove);
+    }
+}
+
+/// Every wave clip's playback file exists and nothing is still rendering it.
+///
+/// The check is on the render manager rather than on the file, because
+/// AudioFile::isValid can go true before the job has released it, which the
+/// app's own reverse path already had to learn.
+bool proxiesReady(te::Engine& engine, te::Edit& edit, int& waitedFor) {
+    waitedFor = 0;
+
+    for (auto* track : te::getAudioTracks(edit)) {
+        for (auto* clip : track->getClips()) {
+            auto* audio = dynamic_cast<te::AudioClipBase*>(clip);
+            if (audio == nullptr)
+                continue;
+
+            const auto playbackFile = audio->getPlaybackFile();
+            if (!playbackFile.isValid())
+                return false;
+
+            if (engine.getRenderManager().isProxyBeingGenerated(playbackFile)) {
+                ++waitedFor;
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+}  // namespace
+
+IncumbentRender renderIncumbent(const Case& value) {
+    IncumbentRender result;
+
+    auto& wrapper = magda::test::getSharedEngine();
+    auto* engine = wrapper.getEngine();
+    if (engine == nullptr) {
+        result.failure = "no Tracktion engine";
+        return result;
+    }
+
+    auto edit = te::test_utilities::createTestEdit(*engine, 1);
+    if (edit == nullptr) {
+        result.failure = "no Edit";
+        return result;
+    }
+
+    applyTempo(*edit, value);
+    installGrooves(*engine, value);
+
+    const auto previousTempo = ProjectManager::getInstance().getCurrentProjectInfo().tempo;
+    ProjectManager::getInstance().setTempo(value.tempo.front().bpm);
+
+    TrackController trackController(*engine, *edit);
+    WarpMarkerManager warpMarkers;
+    ClipSynchronizer clipSync(*edit, trackController, warpMarkers);
+
+    for (const auto& track : value.tracks)
+        trackController.ensureTrackMapping(track.id, track.name);
+
+    // The capture device, where the plan on the other side has one. Inserted
+    // straight into the track's list: the model device stands for a synth, and
+    // what is compared is what would reach it.
+    MidiCapturePlugin* capture = nullptr;
+    if (value.capturesMidi()) {
+        if (!captureDeviceRegistered) {
+            result.failure = "the capture device could not be registered";
+            ProjectManager::getInstance().setTempo(previousTempo);
+            return result;
+        }
+
+        if (auto* audioTrack = trackController.getAudioTrack(value.tracks.front().id)) {
+            juce::ValueTree state(te::IDs::PLUGIN);
+            state.setProperty(te::IDs::type, kCapturePluginId, nullptr);
+
+            auto plugin = edit->getPluginCache().createNewPlugin(state);
+            capture = dynamic_cast<MidiCapturePlugin*>(plugin.get());
+            if (capture != nullptr)
+                audioTrack->pluginList.insertPlugin(plugin, 0, nullptr);
+        }
+
+        if (capture == nullptr) {
+            result.failure = "the capture device could not be placed on the track";
+            ProjectManager::getInstance().setTempo(previousTempo);
+            return result;
+        }
+    }
+
+    ClipManager::getInstance().clearAllClips();
+    for (const auto& clip : value.clips)
+        ClipManager::getInstance().restoreClip(clip);
+    for (const auto& clip : value.clips)
+        clipSync.syncClipToEngine(clip.id);
+
+    // --- wait for the proxies -----------------------------------------------
+
+    const auto started = juce::Time::getMillisecondCounter();
+    auto waited = 0;
+    while (!proxiesReady(*engine, *edit, waited)) {
+        result.proxiesWaitedFor = std::max(result.proxiesWaitedFor, waited);
+        pumpMessageThread(10);
+
+        result.waitMilliseconds = static_cast<int>(juce::Time::getMillisecondCounter() - started);
+        if (result.waitMilliseconds > kProxyTimeoutMs) {
+            result.failure = "proxy not ready after " + std::to_string(kProxyTimeoutMs) + " ms";
+            ClipManager::getInstance().clearAllClips();
+            ProjectManager::getInstance().setTempo(previousTempo);
+            return result;
+        }
+    }
+
+    // --- render --------------------------------------------------------------
+
+    const auto startSeconds =
+        edit->tempoSequence.toTime(te::BeatPosition::fromBeats(value.startBeat)).inSeconds();
+    const auto endSeconds =
+        edit->tempoSequence.toTime(te::BeatPosition::fromBeats(value.endBeat)).inSeconds();
+
+    juce::TemporaryFile destination(".wav");
+
+    te::Renderer::Parameters params(*edit);
+    params.destFile = destination.getFile();
+    params.audioFormat = engine->getAudioFileFormatManager().getWavFormat();
+
+    // Float, and the corpus depends on it: sixteen bits would put quantisation
+    // noise twenty-four decibels above the floor and every case would be
+    // measuring the file format. Dithering is off by default and named anyway,
+    // because it would put noise there too and it would be different noise on
+    // every run.
+    params.bitDepth = 32;
+    params.ditheringEnabled = false;
+
+    params.sampleRateForAudio = value.sampleRate;
+    params.blockSizeForAudio = value.blockSize;
+    params.time = te::TimeRange(te::TimePosition::fromSeconds(startSeconds),
+                                te::TimePosition::fromSeconds(endSeconds));
+    params.tracksToDo = te::toBitSet(te::getAllTracks(*edit));
+    params.usePlugins = true;
+    params.useMasterPlugins = true;
+    params.checkNodesForAudio = false;
+    params.realTimeRender = false;
+
+    prepareEditForOfflineRender(*edit);
+
+    {
+        std::atomic<float> progress{0.0f};
+        te::Renderer::RenderTask task("MAGDA Null Diff", params, &progress, nullptr);
+
+        for (;;) {
+            const auto status = task.runJob();
+            if (status == juce::ThreadPoolJob::jobHasFinished)
+                break;
+            if (status != juce::ThreadPoolJob::jobNeedsRunningAgain) {
+                result.failure = task.errorMessage.isNotEmpty()
+                                     ? task.errorMessage.toStdString()
+                                     : std::string("the render task failed");
+                break;
+            }
+        }
+
+        if (result.failure.empty() && task.errorMessage.isNotEmpty())
+            result.failure = task.errorMessage.toStdString();
+    }
+
+    if (result.failure.empty()) {
+        juce::AudioFormatManager formats;
+        formats.registerBasicFormats();
+
+        std::unique_ptr<juce::AudioFormatReader> reader(
+            formats.createReaderFor(destination.getFile()));
+
+        if (reader == nullptr) {
+            result.failure = "the render produced nothing that could be read back";
+        } else {
+            // Checked rather than trusted. A parameter that quietly did not
+            // apply is exactly the failure this guards, and it would look like
+            // an engine that is 96 dB wrong everywhere.
+            result.renderedInFloat = reader->usesFloatingPointData;
+
+            result.audio.setSize(static_cast<int>(reader->numChannels),
+                                 static_cast<int>(reader->lengthInSamples));
+            reader->read(&result.audio, 0, static_cast<int>(reader->lengthInSamples), 0, true,
+                         true);
+        }
+    }
+
+    if (capture != nullptr)
+        result.midi = capture->captured;
+
+    // --- put the process back the way it was ---------------------------------
+    //
+    // A job that outlives its case reads a source file the next case has
+    // already deleted, which the app's own reverse path had to learn as well.
+    engine->getBackgroundJobs().getPool().removeAllJobs(false, 10000);
+    pumpMessageThread(50);
+
+    ClipManager::getInstance().clearAllClips();
+    ProjectManager::getInstance().setTempo(previousTempo);
+
+    return result;
+}
+
+}  // namespace magda::nulldiff

--- a/tests/NullDiffTeLeg.hpp
+++ b/tests/NullDiffTeLeg.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include <string>
+#include <vector>
+
+#include "NullDiffCase.hpp"
+#include "NullDiffCompare.hpp"
+
+/**
+ * @file NullDiffTeLeg.hpp
+ * @brief A null-diff case rendered through the incumbent (#2040).
+ *
+ * What the app does today: a te::Edit, the model tracks mapped through
+ * TrackController, every clip pushed through ClipSynchronizer, and the render
+ * parameters the offline-render helper builds. Not a second sync written for
+ * the harness, because the sync layer is part of what is being validated: a
+ * clip that reaches Tracktion wrong plays wrong for exactly the same user.
+ *
+ * Two things this leg can do that would poison the corpus, and both are handled
+ * here rather than left to chance. They matter because neither looks like a
+ * harness fault from the outside; both look like the engine being wrong.
+ *
+ * **It can render at the wrong depth.** Renderer::Parameters::bitDepth defaults
+ * to 16, which puts quantisation noise around -96 dBFS, twenty-four decibels
+ * above the corpus floor. Every case would then report the same residual and
+ * that residual would be the file format. So this renders float, and checks
+ * what it read back really is float rather than trusting the parameter.
+ *
+ * **It can render before its proxies exist.** Stretch, reverse and warp all
+ * reach playback through a proxy file rendered on a background pool, and a
+ * render started before that job finishes plays silence, intermittently, for
+ * precisely the cases the corpus was built for. So it waits, and a wait that
+ * times out fails the case as unmeasurable rather than handing back a
+ * full-scale residual that is really a race.
+ */
+
+namespace magda::nulldiff {
+
+struct IncumbentRender {
+    juce::AudioBuffer<float> audio;
+    MidiStream midi;
+
+    /// Set when the case could not be rendered at all. Never reported as a
+    /// residual: a race described as a parity failure costs somebody a day
+    /// inside the engine looking for a bug that is not there.
+    std::string failure;
+
+    /// True when the buffer came back from a floating-point file, checked
+    /// rather than assumed.
+    bool renderedInFloat = false;
+
+    /// Clips whose proxy had to be waited for, and how long the wait took. Not
+    /// an assertion, a number: a wait that grows is worth seeing before it
+    /// turns into a timeout.
+    int proxiesWaitedFor = 0;
+    int waitMilliseconds = 0;
+};
+
+/// Render @p value through Tracktion, over its own beat range.
+IncumbentRender renderIncumbent(const Case& value);
+
+}  // namespace magda::nulldiff

--- a/tests/test_midi_clip_playback.cpp
+++ b/tests/test_midi_clip_playback.cpp
@@ -4,6 +4,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -400,6 +401,79 @@ TEST_CASE("A pitch-bend list entirely at rest is skipped", "[engine][clip][midi]
 // =============================================================================
 // MPE
 // =============================================================================
+
+TEST_CASE("An MPE note opens with the dimensions the specification asks for",
+          "[engine][clip][midi]") {
+    // Timbre before the note-on and pressure beside it. The specification asks
+    // for them and the fork sends both, and a synth that never receives them is
+    // left holding whatever the last note on that channel set: a member channel
+    // is reused round-robin, so the state would be inherited from another note
+    // rather than fresh. Found by the null-diff corpus (#2040), which caught the
+    // fork sending three messages the engine did not.
+    auto clip = makeMidiClip(1, 0.0, 4.0);
+
+    auto expressive = note(60, 1.0, 1.0);
+    expressive.pitchExpression = {MidiPitchExpressionPoint{0.0, 0.0},
+                                  MidiPitchExpressionPoint{1.0, 2.0}};
+    clip.midiNotes.push_back(expressive);
+
+    const auto list = compileMidiEvents(clip, 0.0);
+    REQUIRE(list.mpe);
+
+    std::optional<std::size_t> timbre;
+    std::optional<std::size_t> pressure;
+    std::optional<std::size_t> noteOn;
+
+    for (std::size_t i = 0; i < list.events.size(); ++i) {
+        const auto& event = list.events[i];
+        if (event.beat > 1.0 + 1.0e-9 || event.beat < 1.0 - 1.0e-9)
+            continue;
+        const auto kind = event.status & 0xf0;
+        if (kind == 0xb0 && event.data1 == 74)
+            timbre = i;
+        if (kind == 0xd0)
+            pressure = i;
+        if (event.isNoteOn())
+            noteOn = i;
+    }
+
+    REQUIRE(timbre.has_value());
+    REQUIRE(pressure.has_value());
+    REQUIRE(noteOn.has_value());
+
+    // Ordered ahead of the note-on, which is what "before" means when both land
+    // on one beat.
+    CHECK(*timbre < *noteOn);
+    CHECK(*pressure < *noteOn);
+
+    // At rest, because the model carries neither dimension: expression here is
+    // pitch, and nothing in a clip can move timbre or pressure.
+    CHECK(static_cast<int>(list.events[*timbre].data2) == 64);
+    CHECK(static_cast<int>(list.events[*pressure].data1) == 0);
+
+    // On the note's own member channel. On the master's they would configure the
+    // zone instead of the note.
+    const auto memberChannel = list.events[*noteOn].channel();
+    CHECK(list.events[*timbre].channel() == memberChannel);
+    CHECK(list.events[*pressure].channel() == memberChannel);
+    CHECK(memberChannel >= 2);
+}
+
+TEST_CASE("A clip with no expression opens no MPE dimensions", "[engine][clip][midi]") {
+    // They belong to MPE. A clip that is not MPE plays on channel 1, where the
+    // same two messages would be zone configuration rather than note state.
+    auto clip = makeMidiClip(1, 0.0, 4.0);
+    clip.midiNotes.push_back(note(60, 0.0, 1.0));
+
+    const auto list = compileMidiEvents(clip, 0.0);
+    REQUIRE_FALSE(list.mpe);
+
+    for (const auto& event : list.events) {
+        const auto kind = event.status & 0xf0;
+        CHECK(kind != 0xd0);
+        CHECK_FALSE((kind == 0xb0 && event.data1 == 74));
+    }
+}
 
 TEST_CASE("Overlapping expressive notes get their own channels", "[engine][clip][midi]") {
     auto clip = makeMidiClip(1, 0.0, 4.0);

--- a/tests/test_midi_clip_playback.cpp
+++ b/tests/test_midi_clip_playback.cpp
@@ -992,6 +992,17 @@ TEST_CASE("Locating into an expressive note reconstructs its bend on its own cha
     CHECK(bends.front().message.getPitchWheelValue() ==
           Approx(8192.0 + 8191.0 * 6.0 / 48.0).margin(64.0));
 
+    // And its pressure, which a synth holds per channel exactly as it holds the
+    // wheel. A member channel is reused round robin, so a note located into on
+    // a channel still carrying another note's pressure inherits it: the same
+    // staleness the compile emits a resting value at every note start to avoid,
+    // arriving by the one door that did not check.
+    const auto pressures =
+        recorder.ofKind([](const juce::MidiMessage& m) { return m.isChannelPressure(); });
+    REQUIRE(!pressures.empty());
+    CHECK(pressures.front().message.getChannel() == channel);
+    CHECK(pressures.front().message.getChannelPressureValue() == 0);
+
     rig.roll(blockOf(3.0) + 1, blockOf(8.0), recorder);
     CHECK(recorder.hanging().empty());
 }

--- a/tests/test_null_diff_compare.cpp
+++ b/tests/test_null_diff_compare.cpp
@@ -584,3 +584,112 @@ TEST_CASE("An unmeasurable case is not a residual", "[nulldiff][compare][report]
     CHECK(text.find("unmeasurable: proxy not ready") != std::string::npos);
     CHECK(text.find("peak=") == std::string::npos);
 }
+
+// =============================================================================
+// Sub-sample alignment, and the stretched-case assertions
+// =============================================================================
+
+TEST_CASE("The shift search resolves below a sample", "[nulldiff][compare][shift]") {
+    // A whole-sample answer is not enough for band-limited material: at 220 Hz
+    // one sample of misalignment is a residual around -30 dB, so a case can be
+    // a fraction of a sample out and look like a difference in the material
+    // rather than what it is, which is a difference in the timing.
+    const auto native = tone(2.0);
+
+    for (const auto delay : {0.25, 0.5, 1.75, 3.5}) {
+        const auto incumbent = delayFractionally(native, delay);
+        const auto estimate = estimateShift(native, incumbent, 512);
+
+        INFO("delay " << delay << " measured " << estimate.fractionalSamples);
+        REQUIRE(estimate.found);
+        CHECK(std::abs(estimate.fractionalSamples - delay) < 0.05);
+    }
+}
+
+TEST_CASE("A fractional delay is undone by aligning fractionally", "[nulldiff][compare][shift]") {
+    // What a case does once the offset has a mechanism: align by it, then
+    // require the null at the floor rather than accepting the residual.
+    const auto native = tone(2.0);
+    const auto incumbent = delayFractionally(native, 0.6);
+
+    const auto before = compareAudio(native, incumbent);
+    CHECK_FALSE(before.withinFloor());
+
+    const auto aligned = delayFractionally(native, 0.6);
+    const auto after = compareAudio(aligned, incumbent);
+
+    INFO("peak " << formatDb(after.peakDb));
+    CHECK(after.peakDb < -100.0);
+}
+
+TEST_CASE("Envelope timing catches a placement error the spectrum would not",
+          "[nulldiff][compare][envelope]") {
+    // The assertion that keeps a placement bug visible once waveforms cannot be
+    // compared. Two bursts of the same tone, one later than the other: their
+    // magnitude spectra are near enough identical and their envelopes are not.
+    const auto burst = [](double startSeconds) {
+        MaterialSpec spec;
+        spec.kind = MaterialKind::Tone;
+        spec.sampleRate = kSampleRate;
+        spec.durationSeconds = 0.5;
+        auto tone = renderMaterial(spec);
+
+        juce::AudioBuffer<float> out(1, static_cast<int>(kSampleRate * 2.0));
+        out.clear();
+        const auto at = static_cast<int>(startSeconds * kSampleRate);
+        out.copyFrom(0, at, tone, 0, 0, tone.getNumSamples());
+        return out;
+    };
+
+    const auto native = burst(0.5);
+
+    SECTION("aligned") {
+        const auto agreement = compareEnvelopes(native, native, 0, kSampleRate);
+        CHECK(std::abs(agreement.lagSamples) <= 1.0);
+        CHECK(agreement.correlation > 0.99);
+    }
+
+    SECTION("a burst in the wrong place") {
+        const auto agreement = compareEnvelopes(native, burst(0.52), 0, kSampleRate);
+        CHECK(std::abs(agreement.lagSamples) > 1.0);
+    }
+}
+
+TEST_CASE("Magnitude agrees where phase does not", "[nulldiff][compare][spectral]") {
+    // The claim a stretched case makes. Two signals with the same magnitude
+    // spectrum and different phase are the same sound, and that is exactly the
+    // pair two vocoders produce.
+    const auto native = tone(2.0, 440.0);
+
+    SECTION("the same sound at another phase") {
+        // Half a period at 440 Hz, which inverts the waveform and leaves the
+        // spectrum alone.
+        const auto shifted = delayFractionally(native, kSampleRate / 440.0 / 2.0);
+
+        const auto waveform = compareAudio(native, shifted);
+        CHECK_FALSE(waveform.withinFloor());
+
+        const auto spectral = compareSpectra(native, shifted, 0);
+        INFO("median " << spectral.medianDb << " p95 " << spectral.percentile95Db);
+        REQUIRE(spectral.frames > 0);
+        CHECK(spectral.percentile95Db < 1.0);
+    }
+
+    SECTION("a different pitch is a different sound") {
+        const auto other = tone(2.0, 466.0);
+        const auto spectral = compareSpectra(native, other, 0);
+
+        REQUIRE(spectral.frames > 0);
+        CHECK(spectral.percentile95Db > 3.0);
+    }
+
+    SECTION("material that stops early is a different sound") {
+        auto truncated = tone(2.0, 440.0);
+        truncated.clear(truncated.getNumSamples() / 2, truncated.getNumSamples() / 2);
+
+        const auto spectral = compareSpectra(native, truncated, 0);
+
+        REQUIRE(spectral.frames > 0);
+        CHECK(spectral.percentile95Db > 3.0);
+    }
+}

--- a/tests/test_null_diff_compare.cpp
+++ b/tests/test_null_diff_compare.cpp
@@ -1,0 +1,586 @@
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+
+#include "NullDiffCompare.hpp"
+#include "NullDiffMaterial.hpp"
+
+/**
+ * The comparator behind the null-diff corpus (#2040), against known-bad pairs.
+ *
+ * This is the one piece of that corpus nothing else checks. Every other test in
+ * the slice asserts through it, so a comparator that quietly passes everything
+ * would report parity it never measured, which is a worse outcome than an
+ * engine that fails. Hence: it is handed pairs that are wrong in each of the
+ * ways an engine can be wrong, and it has to say so.
+ */
+
+using namespace magda::nulldiff;
+
+namespace {
+
+constexpr double kSampleRate = 44100.0;
+constexpr double kBpm = 120.0;
+
+juce::AudioBuffer<float> tone(double durationSeconds, double frequency = 220.0) {
+    MaterialSpec spec;
+    spec.kind = MaterialKind::Tone;
+    spec.sampleRate = kSampleRate;
+    spec.durationSeconds = durationSeconds;
+    spec.frequency = frequency;
+    return renderMaterial(spec);
+}
+
+juce::AudioBuffer<float> impulses(double durationSeconds, double intervalSeconds = 0.25) {
+    MaterialSpec spec;
+    spec.kind = MaterialKind::Impulses;
+    spec.sampleRate = kSampleRate;
+    spec.durationSeconds = durationSeconds;
+    spec.intervalSeconds = intervalSeconds;
+    return renderMaterial(spec);
+}
+
+/// The same material, later by @p samples, in a buffer of the same length.
+juce::AudioBuffer<float> delayed(const juce::AudioBuffer<float>& source, int samples) {
+    juce::AudioBuffer<float> result(source.getNumChannels(), source.getNumSamples());
+    result.clear();
+    for (auto channel = 0; channel < source.getNumChannels(); ++channel)
+        for (auto sample = samples; sample < source.getNumSamples(); ++sample)
+            result.setSample(channel, sample, source.getSample(channel, sample - samples));
+    return result;
+}
+
+/// Every sample scaled, which is a residual with a known peak.
+juce::AudioBuffer<float> scaled(const juce::AudioBuffer<float>& source, float gain) {
+    juce::AudioBuffer<float> result(source);
+    result.applyGain(gain);
+    return result;
+}
+
+std::int64_t samplesAt(double seconds) {
+    return static_cast<std::int64_t>(std::llround(seconds * kSampleRate));
+}
+
+MidiEvent noteOn(int channel, int pitch, int velocity, double seconds) {
+    return {samplesAt(seconds), static_cast<std::uint8_t>(0x90 | (channel - 1)),
+            static_cast<std::uint8_t>(pitch), static_cast<std::uint8_t>(velocity)};
+}
+
+MidiEvent noteOff(int channel, int pitch, double seconds) {
+    return {samplesAt(seconds), static_cast<std::uint8_t>(0x80 | (channel - 1)),
+            static_cast<std::uint8_t>(pitch), 0};
+}
+
+MidiEvent controller(int channel, int number, int value, double seconds) {
+    return {samplesAt(seconds), static_cast<std::uint8_t>(0xB0 | (channel - 1)),
+            static_cast<std::uint8_t>(number), static_cast<std::uint8_t>(value)};
+}
+
+/// One note, so that a controller test is not also a note test.
+MidiStream withNote(MidiStream stream) {
+    stream.push_back(noteOn(1, 60, 100, 0.0));
+    stream.push_back(noteOff(1, 60, 1.0));
+    return stream;
+}
+
+/// A ramp from 0 to 127 over @p durationSeconds, emitted the way the engine
+/// does: one message per change of the quantised value, and nothing in between.
+MidiStream curveByValueChange(double durationSeconds, int number = 1) {
+    MidiStream stream;
+    for (auto value = 0; value <= 127; ++value)
+        stream.push_back(
+            controller(1, number, value, durationSeconds * static_cast<double>(value) / 127.0));
+    return stream;
+}
+
+/// The same ramp emitted the way the fork does: the value the curve is at, on a
+/// 1/16-beat grid, whether it moved or not.
+MidiStream curveOnGrid(double durationSeconds, int number = 1) {
+    MidiStream stream;
+    const auto step = 60.0 / kBpm / 16.0;
+    for (auto time = 0.0; time <= durationSeconds; time += step) {
+        const auto value = static_cast<int>(std::floor(127.0 * time / durationSeconds));
+        stream.push_back(controller(1, number, std::min(127, value), time));
+    }
+    return stream;
+}
+
+/// What went wrong, for a failure message. Empty is a passing comparison.
+std::string firstProblem(const MidiComparison& result) {
+    return result.problems.empty() ? std::string{} : result.problems.front();
+}
+
+MidiCompareOptions midiOptions() {
+    MidiCompareOptions options;
+    options.sampleRate = kSampleRate;
+    options.bpm = kBpm;
+    return options;
+}
+
+}  // namespace
+
+// =============================================================================
+// Audio
+// =============================================================================
+
+TEST_CASE("A pair that differs by one sample of placement is reported at full scale",
+          "[nulldiff][compare]") {
+    // The failure the corpus exists to catch, and the one a sloppy comparator
+    // misses by aligning it away.
+    const auto native = impulses(2.0);
+    const auto incumbent = delayed(native, 1);
+
+    const auto result = compareAudio(native, incumbent);
+
+    CHECK_FALSE(result.withinFloor());
+    CHECK(result.peakDb > -1.0);
+    CHECK(result.firstDivergence >= 0);
+
+    // The first impulse is at sample 0 in one and sample 1 in the other, so
+    // that is where they part company.
+    CHECK(result.firstDivergence == 0);
+}
+
+TEST_CASE("Identical renders null", "[nulldiff][compare]") {
+    const auto native = impulses(2.0);
+
+    const auto result = compareAudio(native, native);
+
+    CHECK(result.withinFloor());
+    CHECK(result.firstDivergence == -1);
+    CHECK(result.shiftSamples == 0);
+    CHECK(result.comparedSamples == native.getNumSamples());
+}
+
+TEST_CASE("The floor is checked either side of itself rather than at it", "[nulldiff][compare]") {
+    // A residual of a known size, made by scaling one leg: peak residual is the
+    // material's peak times the gain difference.
+    const auto native = tone(1.0);
+    const auto peak = native.getMagnitude(0, native.getNumSamples());
+
+    SECTION("under the floor passes") {
+        const auto quiet = static_cast<float>(std::pow(10.0, -130.0 / 20.0)) / peak;
+        const auto result = compareAudio(native, scaled(native, 1.0f - quiet));
+        CHECK(result.withinFloor());
+    }
+
+    SECTION("over the floor fails") {
+        const auto loud = static_cast<float>(std::pow(10.0, -110.0 / 20.0)) / peak;
+        const auto result = compareAudio(native, scaled(native, 1.0f - loud));
+        CHECK_FALSE(result.withinFloor());
+        CHECK(result.peakDb > -120.0);
+    }
+}
+
+TEST_CASE("A refusal is never reported as a residual", "[nulldiff][compare]") {
+    const auto mono = tone(1.0);
+    juce::AudioBuffer<float> stereo(2, mono.getNumSamples());
+    stereo.clear();
+
+    const auto result = compareAudio(mono, stereo);
+
+    CHECK_FALSE(result.refusal.empty());
+    CHECK(result.comparedSamples == 0);
+}
+
+TEST_CASE("The shift search finds a known shift", "[nulldiff][compare][shift]") {
+    const auto native = tone(2.0);
+    const auto incumbent = delayed(native, 1024);
+
+    const auto estimate = estimateShift(native, incumbent, 4096);
+
+    REQUIRE(estimate.found);
+    CHECK(estimate.samples == 1024);
+
+    AudioCompareOptions options;
+    options.measureShift = true;
+    const auto result = compareAudio(native, incumbent, options);
+
+    CHECK(result.shiftSamples == 1024);
+    CHECK(result.withinFloor());
+}
+
+TEST_CASE("The shift search declines a pair that differs in content",
+          "[nulldiff][compare][shift]") {
+    // A comparator that slides until something matches will always find
+    // something, and what it finds here would make the case pass.
+    const auto native = tone(2.0, 220.0);
+
+    MaterialSpec spec;
+    spec.kind = MaterialKind::Noise;
+    spec.sampleRate = kSampleRate;
+    spec.durationSeconds = 2.0;
+    const auto incumbent = renderMaterial(spec);
+
+    const auto estimate = estimateShift(native, incumbent, 4096);
+
+    CHECK_FALSE(estimate.found);
+    CHECK(estimate.samples == 0);
+
+    AudioCompareOptions options;
+    options.measureShift = true;
+    const auto result = compareAudio(native, incumbent, options);
+
+    CHECK(result.shiftNotFound);
+    CHECK_FALSE(result.withinFloor());
+}
+
+TEST_CASE("One shift per case, measured at the start", "[nulldiff][compare][shift]") {
+    // A pair aligned at the start and drifting later has to fail, at the drift,
+    // rather than be re-aligned region by region until it passes. This is what
+    // the auto-tempo case leans on: the fork's stretcher priming is measured
+    // once, and a lateness that grows when the ratio moves is a finding.
+    const auto native = tone(4.0);
+
+    auto incumbent = delayed(native, 512);
+    const auto halfway = incumbent.getNumSamples() / 2;
+    for (auto channel = 0; channel < incumbent.getNumChannels(); ++channel)
+        for (auto sample = halfway; sample < incumbent.getNumSamples(); ++sample)
+            incumbent.setSample(channel, sample,
+                                native.getSample(channel, juce::jmax(0, sample - 1024)));
+
+    AudioCompareOptions options;
+    options.measureShift = true;
+    const auto result = compareAudio(native, incumbent, options);
+
+    CHECK(result.shiftSamples == 512);
+    CHECK_FALSE(result.withinFloor());
+    CHECK(result.firstDivergence >= halfway - 1024);
+}
+
+// =============================================================================
+// MIDI notes
+// =============================================================================
+
+TEST_CASE("Matching note streams pass", "[nulldiff][compare][midi]") {
+    MidiStream stream;
+    stream.push_back(noteOn(1, 60, 100, 0.0));
+    stream.push_back(noteOff(1, 60, 0.5));
+    stream.push_back(noteOn(1, 64, 90, 0.5));
+    stream.push_back(noteOff(1, 64, 1.0));
+
+    const auto result = compareMidi(stream, stream, midiOptions());
+
+    CHECK(result.notesMatch);
+    CHECK(result.notesCompared == 2);
+    CHECK(result.problems.empty());
+}
+
+TEST_CASE("Every way a note can differ is reported", "[nulldiff][compare][midi]") {
+    MidiStream native;
+    native.push_back(noteOn(1, 60, 100, 0.0));
+    native.push_back(noteOff(1, 60, 0.5));
+
+    SECTION("a missing note") {
+        const auto result = compareMidi(native, {}, midiOptions());
+        CHECK_FALSE(result.notesMatch);
+        CHECK(result.notesOnlyInNative == 1);
+    }
+
+    SECTION("an extra note") {
+        auto incumbent = native;
+        incumbent.push_back(noteOn(1, 67, 100, 0.75));
+        incumbent.push_back(noteOff(1, 67, 1.0));
+
+        const auto result = compareMidi(native, incumbent, midiOptions());
+        CHECK_FALSE(result.notesMatch);
+        CHECK(result.notesOnlyInIncumbent == 1);
+    }
+
+    SECTION("a wrong velocity") {
+        MidiStream incumbent;
+        incumbent.push_back(noteOn(1, 60, 99, 0.0));
+        incumbent.push_back(noteOff(1, 60, 0.5));
+
+        const auto result = compareMidi(native, incumbent, midiOptions());
+        CHECK_FALSE(result.notesMatch);
+        CHECK(result.notesMismatched == 1);
+    }
+
+    SECTION("a wrong channel") {
+        // Compared as assigned rather than canonicalised to order of first use:
+        // the fork's MPE round-robin was ported deliberately, so a channel that
+        // differs is a finding.
+        MidiStream incumbent;
+        incumbent.push_back(noteOn(2, 60, 100, 0.0));
+        incumbent.push_back(noteOff(2, 60, 0.5));
+
+        const auto result = compareMidi(native, incumbent, midiOptions());
+        CHECK_FALSE(result.notesMatch);
+        CHECK(result.notesOnlyInNative == 1);
+        CHECK(result.notesOnlyInIncumbent == 1);
+    }
+
+    SECTION("a wrong length") {
+        MidiStream incumbent;
+        incumbent.push_back(noteOn(1, 60, 100, 0.0));
+        incumbent.push_back(noteOff(1, 60, 0.6));
+
+        const auto result = compareMidi(native, incumbent, midiOptions());
+        CHECK_FALSE(result.notesMatch);
+        CHECK(result.notesMismatched == 1);
+    }
+}
+
+TEST_CASE("A note within the rounding allowance is not a difference", "[nulldiff][compare][midi]") {
+    // Two engines round a beat to a sample through different arithmetic, and
+    // one sample of that is not a finding. Two is.
+    MidiStream native;
+    native.push_back(noteOn(1, 60, 100, 0.0));
+    native.push_back(noteOff(1, 60, 0.5));
+
+    auto shifted = [](std::int64_t samples) {
+        MidiStream stream;
+        stream.push_back({samples, 0x90, 60, 100});
+        stream.push_back({samplesAt(0.5) + samples, 0x80, 60, 0});
+        return stream;
+    };
+
+    CHECK(compareMidi(native, shifted(1), midiOptions()).notesMatch);
+    CHECK_FALSE(compareMidi(native, shifted(2), midiOptions()).notesMatch);
+}
+
+TEST_CASE("A declared note shift is applied and nothing else is", "[nulldiff][compare][midi]") {
+    // The fork drops midiOffset on an unlooped arranger clip, so every note of
+    // such a clip lands offset. Declared by the case, asserted here, and a note
+    // that moves for any other reason still breaks.
+    MidiStream native;
+    native.push_back(noteOn(1, 60, 100, 1.0));
+    native.push_back(noteOff(1, 60, 1.5));
+
+    MidiStream incumbent;
+    incumbent.push_back(noteOn(1, 60, 100, 1.25));
+    incumbent.push_back(noteOff(1, 60, 1.75));
+
+    auto options = midiOptions();
+    options.noteShiftSamples = samplesAt(0.25);
+    CHECK(compareMidi(native, incumbent, options).notesMatch);
+
+    options.noteShiftSamples = samplesAt(0.5);
+    CHECK_FALSE(compareMidi(native, incumbent, options).notesMatch);
+}
+
+TEST_CASE("A hanging note fails whichever engine left it", "[nulldiff][compare][midi]") {
+    MidiStream hanging;
+    hanging.push_back(noteOn(1, 60, 100, 0.0));
+
+    MidiStream complete;
+    complete.push_back(noteOn(1, 60, 100, 0.0));
+    complete.push_back(noteOff(1, 60, 0.5));
+
+    SECTION("the native render") {
+        const auto result = compareMidi(hanging, complete, midiOptions());
+        CHECK(result.nativeHanging == 1);
+        CHECK_FALSE(result.notesMatch);
+    }
+
+    SECTION("the incumbent") {
+        const auto result = compareMidi(complete, hanging, midiOptions());
+        CHECK(result.incumbentHanging == 1);
+        CHECK_FALSE(result.notesMatch);
+    }
+}
+
+TEST_CASE("A note-off for a note that never started is reported", "[nulldiff][compare][midi]") {
+    MidiStream orphan;
+    orphan.push_back(noteOff(1, 60, 0.5));
+
+    const auto lifetime = pairNotes(orphan);
+
+    CHECK(lifetime.unmatchedOffs == 1);
+    CHECK(lifetime.notes.empty());
+    CHECK_FALSE(compareMidi(orphan, {}, midiOptions()).notesMatch);
+}
+
+TEST_CASE("A note-on of velocity zero ends a note", "[nulldiff][compare][midi]") {
+    MidiStream stream;
+    stream.push_back(noteOn(1, 60, 100, 0.0));
+    stream.push_back(noteOn(1, 60, 0, 0.5));
+
+    const auto lifetime = pairNotes(stream);
+
+    REQUIRE(lifetime.notes.size() == 1);
+    CHECK(lifetime.hanging == 0);
+    CHECK(lifetime.notes.front().offSample == samplesAt(0.5));
+}
+
+// =============================================================================
+// MIDI controllers, which is the interesting half
+// =============================================================================
+
+TEST_CASE("A dense value-change stream and a sparse grid stream carry the same curve",
+          "[nulldiff][compare][midi][controllers]") {
+    // The recorded divergence, and the reason controllers are compared as a
+    // curve against a sampling of it rather than list against list.
+    const auto native = withNote(curveByValueChange(4.0));
+    const auto incumbent = withNote(curveOnGrid(4.0));
+
+    const auto result = compareMidi(native, incumbent, midiOptions());
+
+    INFO(firstProblem(result));
+    CHECK(result.controllersMatch);
+    CHECK(result.notesMatch);
+}
+
+TEST_CASE("A fast curve the fork can only sample three times still matches",
+          "[nulldiff][compare][midi][controllers]") {
+    // A hundred milliseconds is four grid points there and about a hundred
+    // here. Comparing the two functions instant for instant would fail this,
+    // which is why that is not the test.
+    const auto native = withNote(curveByValueChange(0.1));
+    const auto incumbent = withNote(curveOnGrid(0.1));
+
+    // And the fork's last grid point lands before the curve arrives, so it
+    // never sends the value at the end of the sweep at all. Missing the extreme
+    // of something moving faster than the grid IS the divergence, so it is the
+    // one thing about these two streams that is deliberately not asserted.
+    const auto reach = [](const MidiStream& stream) {
+        auto highest = 0;
+        for (const auto& event : stream)
+            if (event.type() == 0xB0)
+                highest = std::max(highest, static_cast<int>(event.data2));
+        return highest;
+    };
+    REQUIRE(reach(native) == 127);
+    REQUIRE(reach(incumbent) < 127);
+
+    const auto result = compareMidi(native, incumbent, midiOptions());
+
+    INFO(firstProblem(result));
+    CHECK(result.controllersMatch);
+}
+
+TEST_CASE("A value two units out is reported", "[nulldiff][compare][midi][controllers]") {
+    const auto native = withNote(curveByValueChange(4.0));
+
+    auto incumbent = withNote(curveOnGrid(4.0));
+    for (auto& event : incumbent)
+        if (event.type() == 0xB0 && event.sample > samplesAt(2.0))
+            event.data2 = static_cast<std::uint8_t>(std::min(127, event.data2 + 2));
+
+    const auto result = compareMidi(native, incumbent, midiOptions());
+
+    CHECK_FALSE(result.controllersMatch);
+    REQUIRE_FALSE(result.problems.empty());
+}
+
+TEST_CASE("The right values arriving a beat late are reported",
+          "[nulldiff][compare][midi][controllers]") {
+    const auto native = withNote(curveByValueChange(4.0));
+
+    auto incumbent = withNote(curveOnGrid(4.0));
+    for (auto& event : incumbent)
+        if (event.type() == 0xB0)
+            event.sample += samplesAt(0.5);
+
+    const auto result = compareMidi(native, incumbent, midiOptions());
+
+    CHECK_FALSE(result.controllersMatch);
+}
+
+TEST_CASE("A controller that stops halfway is reported", "[nulldiff][compare][midi][controllers]") {
+    const auto native = withNote(curveByValueChange(4.0));
+
+    MidiStream incumbent;
+    for (const auto& event : withNote(curveOnGrid(4.0)))
+        if (event.type() != 0xB0 || event.sample <= samplesAt(2.0))
+            incumbent.push_back(event);
+
+    const auto result = compareMidi(native, incumbent, midiOptions());
+
+    CHECK_FALSE(result.controllersMatch);
+}
+
+TEST_CASE("A curve that flattens is not a shorter stream",
+          "[nulldiff][compare][midi][controllers]") {
+    // The fork keeps emitting on its grid after the curve stops moving. Those
+    // repeats say nothing, and counting them would make its span look longer
+    // than the engine's on every curve that ends flat.
+    auto native = withNote(curveByValueChange(2.0));
+
+    auto incumbent = withNote(curveOnGrid(2.0));
+    for (auto time = 2.0; time < 4.0; time += 60.0 / kBpm / 16.0)
+        incumbent.push_back(controller(1, 1, 127, time));
+
+    const auto result = compareMidi(native, incumbent, midiOptions());
+
+    INFO(firstProblem(result));
+    CHECK(result.controllersMatch);
+}
+
+TEST_CASE("A controller only one engine sends is reported",
+          "[nulldiff][compare][midi][controllers]") {
+    const auto native = withNote(curveByValueChange(4.0, 1));
+    const auto incumbent = withNote(curveOnGrid(4.0, 74));
+
+    const auto result = compareMidi(native, incumbent, midiOptions());
+
+    CHECK_FALSE(result.controllersMatch);
+    CHECK(result.problems.size() >= 2);
+}
+
+TEST_CASE("Pitch bend is compared at its own resolution",
+          "[nulldiff][compare][midi][controllers]") {
+    const auto bend = [](int value, double seconds) {
+        return MidiEvent{samplesAt(seconds), 0xE0, static_cast<std::uint8_t>(value & 0x7F),
+                         static_cast<std::uint8_t>((value >> 7) & 0x7F)};
+    };
+
+    MidiStream native;
+    MidiStream incumbent;
+    for (auto step = 0; step <= 64; ++step) {
+        const auto time = 2.0 * static_cast<double>(step) / 64.0;
+        native.push_back(bend(8192 + step * 64, time));
+        incumbent.push_back(bend(8192 + step * 64, time));
+    }
+
+    CHECK(compareMidi(native, incumbent, midiOptions()).controllersMatch);
+
+    // Fourteen bits, so two units apart is two units apart here as well.
+    incumbent.back().data1 = static_cast<std::uint8_t>((8192 + 64 * 64 + 8) & 0x7F);
+    CHECK_FALSE(compareMidi(native, incumbent, midiOptions()).controllersMatch);
+}
+
+// =============================================================================
+// The report
+// =============================================================================
+
+TEST_CASE("The report is canonical", "[nulldiff][compare][report]") {
+    CaseReport first;
+    first.name = "placement.grid";
+    first.verdict = Verdict::Null;
+    first.hasAudio = true;
+    first.audio = compareAudio(impulses(0.5), impulses(0.5));
+    first.passed = true;
+
+    CaseReport second;
+    second.name = "midi.notes";
+    second.verdict = Verdict::Midi;
+    second.hasMidi = true;
+    second.midi.notesMatch = true;
+    second.midi.controllersMatch = true;
+    second.midi.notesCompared = 8;
+    second.passed = true;
+
+    const auto once = formatReport({first, second}, kSampleRate, 512);
+    const auto again = formatReport({first, second}, kSampleRate, 512);
+
+    CHECK(once == again);
+    CHECK(once.find("magda-null-diff v1") != std::string::npos);
+    CHECK(once.find("placement.grid") != std::string::npos);
+    CHECK(once.find("notes=8") != std::string::npos);
+}
+
+TEST_CASE("An unmeasurable case is not a residual", "[nulldiff][compare][report]") {
+    // A proxy that never arrived reported as a parity failure costs somebody a
+    // day inside the engine looking for a bug that is not there.
+    CaseReport report;
+    report.name = "stretch.signalsmith";
+    report.verdict = Verdict::Shift;
+    report.unmeasurable = "proxy not ready";
+    report.passed = false;
+
+    const auto text = formatReport({report}, kSampleRate, 512);
+
+    CHECK(text.find("unmeasurable: proxy not ready") != std::string::npos);
+    CHECK(text.find("peak=") == std::string::npos);
+}

--- a/tests/test_null_diff_compare.cpp
+++ b/tests/test_null_diff_compare.cpp
@@ -781,3 +781,39 @@ TEST_CASE("A short render is not a shift pass either", "[nulldiff][compare]") {
     CHECK(result.lengthDifference != 0);
     CHECK_FALSE(result.nulled());
 }
+
+TEST_CASE("Garbage is refused rather than certified", "[nulldiff][compare]") {
+    // The adversarial case, and the one a comparator must never get wrong:
+    // every comparison against a NaN is false, so a NaN residual never beats
+    // the running peak. Left alone, the peak stays at zero, the level reads as
+    // -inf and the pair is reported as a perfect null.
+    const auto native = tone(0.5);
+
+    const auto poisoned = [&native](float value, int at) {
+        auto copy = native;
+        copy.setSample(0, at, value);
+        return copy;
+    };
+
+    const auto nan = std::numeric_limits<float>::quiet_NaN();
+    const auto infinity = std::numeric_limits<float>::infinity();
+
+    SECTION("a NaN in the incumbent") {
+        const auto result = compareAudio(native, poisoned(nan, 100));
+        CHECK_FALSE(result.refusal.empty());
+        CHECK_FALSE(result.nulled());
+        CHECK_FALSE(result.peakDb == -std::numeric_limits<double>::infinity());
+    }
+
+    SECTION("a NaN in the native render") {
+        const auto result = compareAudio(poisoned(nan, 100), native);
+        CHECK_FALSE(result.refusal.empty());
+        CHECK_FALSE(result.nulled());
+    }
+
+    SECTION("an infinity in both, which would otherwise cancel") {
+        const auto result = compareAudio(poisoned(infinity, 100), poisoned(infinity, 100));
+        CHECK_FALSE(result.refusal.empty());
+        CHECK_FALSE(result.nulled());
+    }
+}

--- a/tests/test_null_diff_compare.cpp
+++ b/tests/test_null_diff_compare.cpp
@@ -756,3 +756,28 @@ TEST_CASE("Messages outside notes and controllers are compared, not counted",
         CHECK_FALSE(compareMidi(native, incumbent, midiOptions()).passed());
     }
 }
+
+TEST_CASE("A short render is not a shift pass either", "[nulldiff][compare]") {
+    // The stretched metrics both trim to the overlap, so the length has to be
+    // checked before them rather than by them: aligned and short still agrees
+    // everywhere it is looked at.
+    const auto native = tone(2.0);
+
+    juce::AudioBuffer<float> truncated(native.getNumChannels(), native.getNumSamples() / 2);
+    for (auto channel = 0; channel < truncated.getNumChannels(); ++channel)
+        truncated.copyFrom(channel, 0, native, channel, 0, truncated.getNumSamples());
+
+    // Every metric a stretched case applies is happy with the pair.
+    const auto envelope = compareEnvelopes(native, truncated, 0, kSampleRate);
+    CHECK(std::abs(envelope.lagSamples) <= 1.0);
+
+    const auto spectra = compareSpectra(native, truncated, 0);
+    CHECK(spectra.frames > 0);
+    CHECK(spectra.percentile95Db < 1.0);
+
+    // The length is the only thing that says otherwise, which is why a
+    // stretched verdict has to ask before it applies them.
+    const auto result = compareAudio(native, truncated);
+    CHECK(result.lengthDifference != 0);
+    CHECK_FALSE(result.nulled());
+}

--- a/tests/test_null_diff_compare.cpp
+++ b/tests/test_null_diff_compare.cpp
@@ -817,3 +817,24 @@ TEST_CASE("Garbage is refused rather than certified", "[nulldiff][compare]") {
         CHECK_FALSE(result.nulled());
     }
 }
+
+TEST_CASE("Garbage outside the aligned overlap is refused too", "[nulldiff][compare][shift]") {
+    // A shift excludes a margin at each end, and the envelope and spectral
+    // comparisons trim the same margins. Garbage that lands in one of those is
+    // read by nothing, so validating the overlap alone would let a stretched
+    // case pass a render with a NaN in it.
+    const auto native = tone(2.0);
+    auto incumbent = delayed(native, 1024);
+
+    // Inside the incumbent's leading margin: with the alignment applied, no
+    // comparison ever reads this sample.
+    incumbent.setSample(0, 10, std::numeric_limits<float>::quiet_NaN());
+
+    AudioCompareOptions options;
+    options.measureShift = true;
+    const auto result = compareAudio(native, incumbent, options);
+
+    INFO(result.refusal);
+    CHECK_FALSE(result.refusal.empty());
+    CHECK_FALSE(result.nulled());
+}

--- a/tests/test_null_diff_compare.cpp
+++ b/tests/test_null_diff_compare.cpp
@@ -693,3 +693,66 @@ TEST_CASE("Magnitude agrees where phase does not", "[nulldiff][compare][spectral
         CHECK(spectral.percentile95Db > 3.0);
     }
 }
+
+TEST_CASE("A short render is not a null however well its prefix agrees", "[nulldiff][compare]") {
+    // The residual is measured over what both renders cover, so a leg that came
+    // back short with a bit-identical prefix would otherwise be certified as a
+    // null while being exactly what this file calls a bug in a leg.
+    const auto native = impulses(2.0);
+
+    juce::AudioBuffer<float> truncated(native.getNumChannels(), native.getNumSamples() / 2);
+    for (auto channel = 0; channel < truncated.getNumChannels(); ++channel)
+        truncated.copyFrom(channel, 0, native, channel, 0, truncated.getNumSamples());
+
+    const auto result = compareAudio(native, truncated);
+
+    // The overlap really is identical, which is what makes this the trap it is.
+    CHECK(result.withinFloor());
+    CHECK(result.lengthDifference == native.getNumSamples() - truncated.getNumSamples());
+    CHECK_FALSE(result.nulled());
+}
+
+TEST_CASE("Messages outside notes and controllers are compared, not counted",
+          "[nulldiff][compare][midi]") {
+    // An MPE note opens with a channel pressure, so this is a stream the corpus
+    // asserts on. Equal counts used to be enough, which passed whatever channel,
+    // value or instant they carried.
+    const auto pressure = [](int channel, int value, double seconds) {
+        return MidiEvent{samplesAt(seconds), static_cast<std::uint8_t>(0xD0 | (channel - 1)),
+                         static_cast<std::uint8_t>(value), 0};
+    };
+
+    MidiStream native;
+    native.push_back(pressure(2, 0, 0.0));
+    native.push_back(noteOn(2, 60, 100, 0.0));
+    native.push_back(noteOff(2, 60, 0.5));
+
+    SECTION("the same message passes") {
+        CHECK(compareMidi(native, native, midiOptions()).passed());
+    }
+
+    SECTION("a different value fails") {
+        auto incumbent = native;
+        incumbent[0] = pressure(2, 64, 0.0);
+        const auto result = compareMidi(native, incumbent, midiOptions());
+        CHECK_FALSE(result.otherMessagesMatch);
+        CHECK_FALSE(result.passed());
+    }
+
+    SECTION("a different channel fails") {
+        auto incumbent = native;
+        incumbent[0] = pressure(3, 0, 0.0);
+        CHECK_FALSE(compareMidi(native, incumbent, midiOptions()).passed());
+    }
+
+    SECTION("a different instant fails") {
+        auto incumbent = native;
+        incumbent[0] = pressure(2, 0, 0.25);
+        CHECK_FALSE(compareMidi(native, incumbent, midiOptions()).passed());
+    }
+
+    SECTION("a missing message fails") {
+        MidiStream incumbent{native[1], native[2]};
+        CHECK_FALSE(compareMidi(native, incumbent, midiOptions()).passed());
+    }
+}

--- a/tests/test_null_diff_corpus.cpp
+++ b/tests/test_null_diff_corpus.cpp
@@ -1,0 +1,166 @@
+#include <catch2/catch_test_macros.hpp>
+#include <set>
+
+#include "NullDiffCase.hpp"
+
+/**
+ * The corpus's own declarations (#2040).
+ *
+ * The runner asserts what each case claims. What nothing else asserts is that
+ * the claims are honest, and one of them in particular: a case may raise its
+ * floor or ask for a shift only with a mechanism written beside it. Without
+ * this, the way to make a failing case pass is to widen its bound and say
+ * nothing, which is the failure mode the whole slice is arranged against.
+ *
+ * These run in the model-only target because the corpus is model values. What
+ * the two engines make of them is the runner's business.
+ */
+
+using namespace magda;
+using namespace magda::nulldiff;
+
+namespace {
+
+juce::File scratch() {
+    auto root = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                    .getChildFile("magda_null_diff_corpus_test");
+    root.createDirectory();
+    return root;
+}
+
+}  // namespace
+
+TEST_CASE("The corpus builds and covers what the slice claims", "[nulldiff][corpus]") {
+    const auto corpus = buildCorpus(scratch());
+
+    REQUIRE(corpus.size() == 21);
+
+    std::set<std::string> names;
+    for (const auto& value : corpus)
+        CHECK(names.insert(value.name).second);
+
+    // The coverage the issue asks for, case by case. Named rather than counted,
+    // so that removing one is a decision rather than an accident.
+    for (const auto* expected : {"placement.grid",
+                                 "placement.trims",
+                                 "fades.curves",
+                                 "fades.speedramp",
+                                 "loop.tiling",
+                                 "rate.48k",
+                                 "reverse.plain",
+                                 "speed.ratio",
+                                 "pitch.analog",
+                                 "tempo.auto",
+                                 "stretch.signalsmith",
+                                 "stretch.soundtouch.normal",
+                                 "stretch.soundtouch.better",
+                                 "stretch.broadband",
+                                 "warp.audio",
+                                 "takes.comp",
+                                 "midi.notes",
+                                 "midi.cc",
+                                 "midi.mpe",
+                                 "midi.fold",
+                                 "midi.offset"})
+        CHECK(names.count(expected) == 1);
+}
+
+TEST_CASE("Every allowance carries a mechanism", "[nulldiff][corpus]") {
+    // The rule the corpus lives by: change the shape of the comparison, never
+    // the size of the allowance. An allowance with no mechanism beside it is
+    // how a real bug ends up inside an expected difference.
+    for (const auto& value : buildCorpus(scratch())) {
+        INFO(value.name);
+
+        // What counts as an allowance is something the corpus lets the two
+        // engines differ by: a shift applied before comparing, a floor raised
+        // above the arithmetic one, a case that measures instead of asserting,
+        // or notes expected to land offset.
+        //
+        // A Midi verdict on its own is not one of those. It says where the case
+        // is judged rather than how much it may differ by, and it is not a
+        // choice either: a MIDI track here carries a capture device instead of
+        // a synth, so neither engine produces any audio to compare.
+        const auto allows = value.verdict == Verdict::Shift ||
+                            value.verdict == Verdict::ReportOnly || value.floorDb > -120.0 ||
+                            value.declaredMidiShiftBeats != 0.0;
+
+        if (allows)
+            CHECK_FALSE(value.mechanism.empty());
+        else
+            CHECK(value.floorDb <= -120.0);
+    }
+}
+
+TEST_CASE("Every case says what it covers and what it plays", "[nulldiff][corpus]") {
+    for (const auto& value : buildCorpus(scratch())) {
+        INFO(value.name);
+
+        CHECK_FALSE(value.covers.empty());
+        CHECK(value.endBeat > value.startBeat);
+        CHECK(value.sampleRate > 0.0);
+        CHECK_FALSE(value.clips.empty());
+        CHECK(value.master.id == MASTER_TRACK_ID);
+        REQUIRE(value.tracks.size() == 1);
+
+        // Every audio clip's source was written and pooled, and every case that
+        // captures MIDI has something to capture through: a plan compiles no
+        // ClipMidi op for a track whose chain consumes no MIDI, so a MIDI case
+        // without a device would compare two silences and pass.
+        auto audioClips = 0;
+        for (const auto& clip : value.clips)
+            if (clip.isAudio())
+                ++audioClips;
+
+        if (audioClips > 0)
+            CHECK_FALSE(value.sources.empty());
+
+        for (const auto& source : value.sources) {
+            CHECK(source.id != INVALID_SOURCE_ID);
+            CHECK(juce::File(source.path).existsAsFile());
+            CHECK(source.sampleRate > 0.0);
+            CHECK(source.durationSeconds > 0.0);
+        }
+
+        if (value.capturesMidi())
+            CHECK_FALSE(value.tracks.front().chain.fxChainElements.empty());
+    }
+}
+
+TEST_CASE("Render cases change tempo in steps rather than ramps", "[nulldiff][corpus]") {
+    // A ramped tempo is the one place the two tempo maps are known to be able
+    // to disagree, because the engine subdivides where the fork integrates. A
+    // render case built on one would report that as a clip bug. Ramps are
+    // pinned in the tempo-map comparison, where the answer is a number.
+    for (const auto& value : buildCorpus(scratch())) {
+        INFO(value.name);
+        REQUIRE_FALSE(value.tempo.empty());
+        CHECK(value.tempo.front().beat == 0.0);
+
+        for (std::size_t index = 1; index < value.tempo.size(); ++index)
+            CHECK(value.tempo[index].beat > value.tempo[index - 1].beat);
+    }
+}
+
+TEST_CASE("A grooving case carries the template both engines will read", "[nulldiff][corpus]") {
+    // One XML string feeds both legs, which is what makes "the same groove" a
+    // fact rather than two parsers agreeing.
+    for (const auto& value : buildCorpus(scratch())) {
+        auto namesAGroove = false;
+        for (const auto& clip : value.clips)
+            if (clip.grooveTemplate.isNotEmpty())
+                namesAGroove = true;
+
+        INFO(value.name);
+        CHECK(namesAGroove == value.grooveXml.isNotEmpty());
+
+        if (!namesAGroove)
+            continue;
+
+        const auto document = juce::parseXML(value.grooveXml);
+        REQUIRE(document != nullptr);
+        CHECK(document->getChildByName("GROOVETEMPLATE") != nullptr);
+        CHECK(document->getChildByName("GROOVETEMPLATE")->getStringAttribute("name") ==
+              juce::String(kGrooveName));
+    }
+}

--- a/tests/test_null_diff_juce.cpp
+++ b/tests/test_null_diff_juce.cpp
@@ -374,6 +374,22 @@ class NullDiffCorpusTests : public juce::UnitTest {
                         const IncumbentRender& incumbent, CaseReport& report) {
         report.hasSpectral = true;
 
+        // Before any of the three: the same two things a null demands. Both
+        // metrics below trim to the overlap, so a correctly aligned render that
+        // stopped early would satisfy every one of them while being exactly
+        // what the comparator calls a bug in a leg.
+        if (!report.audio.refusal.empty()) {
+            logMessage("  " + juce::String(value.name) + ": " + report.audio.refusal);
+            return false;
+        }
+
+        if (report.audio.lengthDifference != 0) {
+            logMessage("  " + juce::String(value.name) + ": the renders are " +
+                       juce::String(static_cast<double>(report.audio.lengthDifference), 0) +
+                       " samples different in length");
+            return false;
+        }
+
         // The alignment comes from the envelopes, not from the waveforms. Two
         // vocoders never correlate as waveforms however well aligned they are,
         // so requiring that here would fail every stretched case for being what

--- a/tests/test_null_diff_juce.cpp
+++ b/tests/test_null_diff_juce.cpp
@@ -373,6 +373,7 @@ class NullDiffCorpusTests : public juce::UnitTest {
     bool judgeStretched(const Case& value, const NativeRender& native,
                         const IncumbentRender& incumbent, CaseReport& report) {
         report.hasSpectral = true;
+        report.primingSamples = native.primingSamples;
 
         // Before any of the three: the same two things a null demands. Both
         // metrics below trim to the overlap, so a correctly aligned render that
@@ -408,10 +409,25 @@ class NullDiffCorpusTests : public juce::UnitTest {
 
         auto held = true;
 
+        // A shift nobody predicted is not a shift the corpus can certify. The
+        // alignment is measured from the material, so without something to
+        // check it against it would absorb a clip in the wrong place and the
+        // envelope and spectrum would then agree about the wrong thing
+        // perfectly well.
+        if (value.expectedShiftSamples == 0) {
+            logMessage("  " + juce::String(value.name) +
+                       ": no predicted shift is declared, so the measured " +
+                       juce::String(report.measuredShift, 0) +
+                       " cannot be told from a clip in the wrong place. The engine primed its "
+                       "stretcher with " +
+                       juce::String(native.primingSamples) + " samples.");
+            return false;
+        }
+
         // The shift against the prediction. The engine reports what its own
         // stretcher primes with, and the fork is late by its own copy of the
         // same library, so the two figures are the same figure.
-        if (value.expectedShiftSamples != 0) {
+        {
             const auto allowed =
                 std::max(64.0, std::abs(value.expectedShiftSamples) * value.shiftTolerance);
             if (std::abs(report.measuredShift - value.expectedShiftSamples) > allowed) {

--- a/tests/test_null_diff_juce.cpp
+++ b/tests/test_null_diff_juce.cpp
@@ -293,6 +293,82 @@ class NullDiffCorpusTests : public juce::UnitTest {
     }
 
   private:
+    /**
+     * @brief A stretched case, on the three things that can be asserted of one.
+     *
+     * Not a waveform null, and not because the bar was lowered. Two vocoders
+     * primed differently never converge on one waveform: priming sets the
+     * initial phase state, phase in a vocoder is memory, and the two legs prime
+     * from different material. Magnitude is what framing leaves intact.
+     *
+     * Magnitude alone would let a wrong ratio, a misplaced clip or a dropped
+     * block through, so it is one of three rather than a replacement:
+     *
+     *  - the pinned shift, measured by cross correlation and checked against
+     *    what the stretcher says it primes with, so an offset that appeared
+     *    because a clip moved is not quietly absorbed;
+     *  - envelope timing after that shift, which is what keeps a placement bug
+     *    visible when the waveform cannot be compared;
+     *  - the magnitude spectrogram, window and hop stated, bound declared by
+     *    the case with its mechanism.
+     */
+    bool judgeStretched(const Case& value, const NativeRender& native,
+                        const IncumbentRender& incumbent, CaseReport& report) {
+        report.hasSpectral = true;
+
+        // The alignment comes from the envelopes, not from the waveforms. Two
+        // vocoders never correlate as waveforms however well aligned they are,
+        // so requiring that here would fail every stretched case for being what
+        // it was predicted to be. The envelope is what survives the phase
+        // difference, and the material these cases play has one to correlate.
+        if (report.shiftCorrelationEnvelope < 0.98) {
+            logMessage("  " + juce::String(value.name) + ": the envelopes do not correlate (" +
+                       juce::String(report.shiftCorrelationEnvelope, 3) + ") at any offset");
+            return false;
+        }
+
+        const auto shift = static_cast<int>(std::llround(report.measuredShift));
+
+        report.envelope = compareEnvelopes(native.audio, incumbent.audio, shift, value.sampleRate);
+        report.spectra = compareSpectra(native.audio, incumbent.audio, shift);
+
+        auto held = true;
+
+        // The shift against the prediction. The engine reports what its own
+        // stretcher primes with, and the fork is late by its own copy of the
+        // same library, so the two figures are the same figure.
+        if (value.expectedShiftSamples != 0) {
+            const auto allowed =
+                std::max(64.0, std::abs(value.expectedShiftSamples) * value.shiftTolerance);
+            if (std::abs(report.measuredShift - value.expectedShiftSamples) > allowed) {
+                logMessage("  " + juce::String(value.name) + ": shift " +
+                           juce::String(report.measuredShift, 1) + " against a predicted " +
+                           juce::String(value.expectedShiftSamples));
+                held = false;
+            }
+        }
+
+        if (std::abs(report.envelope.lagSamples) > value.envelopeToleranceSamples) {
+            logMessage("  " + juce::String(value.name) + ": the envelopes are " +
+                       juce::String(report.envelope.lagSamples, 2) +
+                       " samples apart after the shift");
+            held = false;
+        }
+
+        if (report.spectra.frames == 0) {
+            logMessage("  " + juce::String(value.name) + ": nothing to compare spectrally");
+            held = false;
+        } else if (value.spectralPercentile95Db > 0.0 &&
+                   report.spectra.percentile95Db > value.spectralPercentile95Db) {
+            logMessage("  " + juce::String(value.name) + ": spectral p95 " +
+                       juce::String(report.spectra.percentile95Db, 2) + " dB against a bound of " +
+                       juce::String(value.spectralPercentile95Db, 2));
+            held = false;
+        }
+
+        return held;
+    }
+
     CaseReport run(const Case& value) {
         CaseReport report;
         report.name = value.name;
@@ -342,6 +418,25 @@ class NullDiffCorpusTests : public juce::UnitTest {
             return report;
         }
 
+        // Measured on every audio case, applied only where one is declared. An
+        // offset that is not applied is still the first thing worth knowing
+        // about a case that will not null, and measuring it is what turns "the
+        // residual is -32 dB" into "the two are three quarters of a sample
+        // apart", which is a different conversation.
+        // A narrow search where no shift is expected: it is a diagnosis rather
+        // than an alignment, and the answer to "how far apart are these" is a
+        // sample or two or it is not the question.
+        const auto searchRange = value.verdict == Verdict::Shift ? value.maxShiftSamples : 256;
+        const auto estimate = estimateShift(native.audio, incumbent.audio, searchRange);
+        report.hasMeasuredShift = estimate.found;
+        report.shiftCorrelation = estimate.correlation;
+        report.shiftCorrelationEnvelope = estimate.envelopeCorrelation;
+
+        // A stretched case takes the envelope's answer, everything else the
+        // waveform's, because those are the two things each can be aligned by.
+        report.measuredShift =
+            value.verdict == Verdict::Shift ? estimate.envelopeSamples : estimate.fractionalSamples;
+
         AudioCompareOptions options;
         options.floorDb = value.floorDb;
         options.sampleRate = value.sampleRate;
@@ -357,14 +452,7 @@ class NullDiffCorpusTests : public juce::UnitTest {
                 break;
 
             case Verdict::Shift:
-                // A shift is measured, and then it is checked against what the
-                // engine predicts. Measuring alone would fit any offset,
-                // including one that appeared because a clip moved; predicting
-                // alone would not notice the day the fork stops priming late.
-                report.passed = report.audio.withinFloor() && !report.audio.shiftNotFound;
-                if (value.expectedShiftSamples != 0)
-                    report.passed = report.passed && std::abs(report.audio.shiftSamples -
-                                                              value.expectedShiftSamples) <= 1;
+                report.passed = judgeStretched(value, native, incumbent, report);
                 break;
 
             case Verdict::ReportOnly:

--- a/tests/test_null_diff_juce.cpp
+++ b/tests/test_null_diff_juce.cpp
@@ -515,7 +515,7 @@ class NullDiffCorpusTests : public juce::UnitTest {
 
         switch (value.verdict) {
             case Verdict::Null:
-                report.passed = report.audio.withinFloor() && report.audio.refusal.empty();
+                report.passed = report.audio.nulled();
                 break;
 
             case Verdict::Shift:

--- a/tests/test_null_diff_juce.cpp
+++ b/tests/test_null_diff_juce.cpp
@@ -1,0 +1,388 @@
+#include <juce_core/juce_core.h>
+
+#include <cmath>
+#include <iostream>
+
+#include "NullDiffCompare.hpp"
+#include "NullDiffNativeLeg.hpp"
+#include "NullDiffTeLeg.hpp"
+#include "SharedTestEngine.hpp"
+#include "clip/WarpMap.hpp"
+#include "transport/TempoMap.hpp"
+
+// clang-format off
+#include <tracktion_engine/tracktion_engine.h>
+// clang-format on
+
+#include "third_party/tracktion_engine/modules/tracktion_engine/utilities/tracktion_TestUtilities.h"
+
+/**
+ * The null-diff corpus (#2040): every case rendered through both engines.
+ *
+ * This is what decides the engine is right rather than merely tested. Six
+ * slices were judged by tests written beside them, and a test asserts what its
+ * author believed the rule was; where an author misread the incumbent, the test
+ * agrees with the misreading. A project rendered through both engines cannot,
+ * because neither engine gets a say in what the other produces.
+ *
+ * It runs here rather than in the Catch2 target because the incumbent leg is a
+ * te::Edit, and Edits in that target take later tests down with them.
+ *
+ * Read the two legs before this file. Most of what makes a corpus honest is in
+ * them: material chosen so that a residual can only be a bug, a render kept in
+ * float, and a proxy waited for rather than raced.
+ */
+
+using namespace magda;
+using namespace magda::nulldiff;
+
+namespace te = tracktion;
+
+namespace {
+
+juce::File scratchDirectory() {
+    auto root =
+        juce::File::getSpecialLocation(juce::File::tempDirectory).getChildFile("magda_null_diff");
+    root.createDirectory();
+    return root;
+}
+
+/// Where the artefacts of a failing case go. A parity failure is diagnosed by
+/// listening and by looking, and a test that only says "expected 1e-12, got
+/// 0.3" makes that the reader's problem.
+void writeArtefacts(const std::string& name, const juce::AudioBuffer<float>& native,
+                    const juce::AudioBuffer<float>& incumbent, double sampleRate) {
+    const auto directory = scratchDirectory().getChildFile("failures");
+    directory.createDirectory();
+
+    const auto write = [&](const juce::String& suffix, const juce::AudioBuffer<float>& buffer) {
+        if (buffer.getNumSamples() == 0)
+            return juce::File();
+
+        const auto file = directory.getChildFile(juce::String(name) + "." + suffix + ".wav");
+        file.deleteFile();
+
+        juce::WavAudioFormat format;
+        std::unique_ptr<juce::OutputStream> stream(file.createOutputStream());
+        if (stream == nullptr)
+            return juce::File();
+
+        const auto options =
+            juce::AudioFormatWriterOptions{}
+                .withSampleRate(sampleRate)
+                .withNumChannels(buffer.getNumChannels())
+                .withBitsPerSample(32)
+                .withSampleFormat(juce::AudioFormatWriterOptions::SampleFormat::floatingPoint);
+
+        if (auto writer = format.createWriterFor(stream, options))
+            writer->writeFromAudioSampleBuffer(buffer, 0, buffer.getNumSamples());
+
+        return file;
+    };
+
+    write("native", native);
+    write("incumbent", incumbent);
+
+    if (native.getNumChannels() == incumbent.getNumChannels()) {
+        juce::AudioBuffer<float> residual(
+            native.getNumChannels(), std::min(native.getNumSamples(), incumbent.getNumSamples()));
+        for (auto channel = 0; channel < residual.getNumChannels(); ++channel)
+            for (auto sample = 0; sample < residual.getNumSamples(); ++sample)
+                residual.setSample(channel, sample,
+                                   native.getSample(channel, sample) -
+                                       incumbent.getSample(channel, sample));
+        write("residual", residual);
+    }
+}
+
+}  // namespace
+
+// =============================================================================
+// The two maps, compared as functions
+// =============================================================================
+
+class NullDiffMapTests : public juce::UnitTest {
+  public:
+    NullDiffMapTests() : juce::UnitTest("Null Diff Maps", "magda") {}
+
+    void runTest() override {
+        testTempoMaps();
+        testWarpMaps();
+    }
+
+  private:
+    /// Both are position mappings, both move every sample of everything
+    /// downstream of them, and both are exactly diffable. Comparing them through
+    /// audio would take an answer that is a number and turn it into a waveform.
+    void testTempoMaps() {
+        beginTest("Tempo maps agree as functions");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto* engine = wrapper.getEngine();
+        expect(engine != nullptr, "engine");
+        if (engine == nullptr)
+            return;
+
+        struct Shape {
+            const char* name;
+            std::vector<TempoPoint> points;
+        };
+
+        for (const auto& shape :
+             {Shape{"one tempo", {{0.0, 120.0}}}, Shape{"a step up", {{0.0, 120.0}, {8.0, 140.0}}},
+              Shape{"a step down", {{0.0, 174.0}, {4.0, 96.0}}},
+              Shape{"three steps", {{0.0, 90.0}, {6.0, 128.0}, {13.0, 101.0}}}}) {
+            auto edit = te::test_utilities::createTestEdit(*engine, 1);
+            if (edit == nullptr)
+                continue;
+
+            auto& sequence = edit->tempoSequence;
+            while (sequence.getNumTempos() > 1)
+                sequence.removeTempo(sequence.getNumTempos() - 1, false);
+            if (auto* first = sequence.getTempo(0))
+                first->setBpm(shape.points.front().bpm);
+            for (std::size_t index = 1; index < shape.points.size(); ++index)
+                sequence.insertTempo(te::BeatPosition::fromBeats(shape.points[index].beat),
+                                     shape.points[index].bpm, 1.0f);
+
+            std::vector<engine::TempoChange> changes;
+            for (const auto& point : shape.points) {
+                if (!changes.empty())
+                    changes.push_back({point.beat, changes.back().bpm, 0.0f});
+                changes.push_back({point.beat, point.bpm, 0.0f});
+            }
+            const engine::TempoMap map(std::move(changes), {});
+
+            auto worst = 0.0;
+            auto worstBeat = 0.0;
+            for (auto beat = 0.0; beat <= 32.0; beat += 0.05) {
+                const auto mine = map.beatToTime(beat);
+                const auto theirs = sequence.toTime(te::BeatPosition::fromBeats(beat)).inSeconds();
+                if (std::abs(mine - theirs) > worst) {
+                    worst = std::abs(mine - theirs);
+                    worstBeat = beat;
+                }
+            }
+
+            // A beat that lands at a different second moves every clip in the
+            // project, so this is asserted to the microsecond and failed here,
+            // once, rather than twenty-one times as a waveform.
+            expect(worst < 1.0e-6, juce::String(shape.name) + ": worst disagreement " +
+                                       juce::String(worst, 9) + " s at beat " +
+                                       juce::String(worstBeat, 3));
+        }
+    }
+
+    /// Where warp coverage actually lives. A warped clip forces a stretcher on,
+    /// so an audio case would be two different stretch pipelines with a priming
+    /// shift on top, which is exactly what the corpus's material rule refuses.
+    /// The map is where the semantics are, and it is exact.
+    void testWarpMaps() {
+        beginTest("Warp maps agree as functions");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto* engine = wrapper.getEngine();
+        expect(engine != nullptr, "engine");
+        if (engine == nullptr)
+            return;
+
+        struct Shape {
+            const char* name;
+            std::vector<WarpMarker> markers;
+        };
+
+        for (const auto& shape :
+             {Shape{"one segment", {{0.0, 0.0}, {2.0, 3.0}}},
+              Shape{"three segments", {{0.0, 0.0}, {1.0, 1.5}, {3.0, 3.0}, {5.0, 6.5}}},
+              Shape{"markers off the origin", {{1.0, 2.0}, {4.0, 4.5}}}}) {
+            auto edit = te::test_utilities::createTestEdit(*engine, 1);
+            if (edit == nullptr)
+                continue;
+
+            const auto compiled = engine::compileWarpMap(shape.markers);
+            const auto& map = compiled.map;
+
+            auto worst = 0.0;
+            auto worstAt = 0.0;
+
+            // Across the marker range and well past it, because slope 1 outside
+            // is as much a part of the map as the segments inside are.
+            for (auto warp = -1.0; warp <= 9.0; warp += 0.01) {
+                const auto mine = map.sourceSecondsAt(warp);
+
+                // The incumbent's own answer, from the same markers. Built as a
+                // piecewise-linear map the same way, so a disagreement is about
+                // the mapping rather than about who owns the markers.
+                const auto theirs = incumbentSourceSeconds(shape.markers, warp);
+
+                if (std::abs(mine - theirs) > worst) {
+                    worst = std::abs(mine - theirs);
+                    worstAt = warp;
+                }
+            }
+
+            expect(worst < 1.0e-6, juce::String(shape.name) + ": worst disagreement " +
+                                       juce::String(worst, 9) + " s at warp time " +
+                                       juce::String(worstAt, 3));
+        }
+    }
+
+    /// WarpTimeManager's mapping, evaluated straight from the markers: linear
+    /// between them and slope 1 outside. Reproduced rather than instantiated
+    /// because the manager wants a clip and a clip wants a file, and what is
+    /// being compared is the arithmetic.
+    static double incumbentSourceSeconds(const std::vector<WarpMarker>& markers, double warpTime) {
+        if (markers.empty())
+            return warpTime;
+
+        if (warpTime <= markers.front().warpTime)
+            return markers.front().sourceTime + (warpTime - markers.front().warpTime);
+
+        if (warpTime >= markers.back().warpTime)
+            return markers.back().sourceTime + (warpTime - markers.back().warpTime);
+
+        for (std::size_t index = 1; index < markers.size(); ++index) {
+            const auto& previous = markers[index - 1];
+            const auto& next = markers[index];
+            if (warpTime > next.warpTime)
+                continue;
+
+            const auto span = next.warpTime - previous.warpTime;
+            if (span <= 0.0)
+                return previous.sourceTime;
+
+            const auto proportion = (warpTime - previous.warpTime) / span;
+            return previous.sourceTime + proportion * (next.sourceTime - previous.sourceTime);
+        }
+
+        return warpTime;
+    }
+};
+
+static NullDiffMapTests nullDiffMapTests;
+
+// =============================================================================
+// The corpus
+// =============================================================================
+
+class NullDiffCorpusTests : public juce::UnitTest {
+  public:
+    NullDiffCorpusTests() : juce::UnitTest("Null Diff Corpus", "magda") {}
+
+    void runTest() override {
+        beginTest("Every case, through both engines");
+
+        const auto corpus = buildCorpus(scratchDirectory());
+        std::vector<CaseReport> reports;
+
+        for (const auto& value : corpus)
+            reports.push_back(run(value));
+
+        // Printed on every run rather than only on failure. Numbers that move
+        // are the point: a corpus that stays quiet cannot show a residual
+        // creeping from -138 dB to -122 dB, which is what an engine going
+        // subtly wrong looks like before it goes audibly wrong.
+        const auto report =
+            formatReport(reports, corpus.empty() ? 44100.0 : corpus.front().sampleRate,
+                         corpus.empty() ? 512 : corpus.front().blockSize);
+        logMessage(report);
+        std::cout << report << std::endl;
+
+        for (const auto& value : reports)
+            expect(value.passed, juce::String(value.name) + " did not hold");
+    }
+
+  private:
+    CaseReport run(const Case& value) {
+        CaseReport report;
+        report.name = value.name;
+        report.verdict = value.verdict;
+
+        const auto native = renderNative(value);
+        const auto incumbent = renderIncumbent(value);
+
+        // A leg that could not render is never reported as a residual.
+        if (!native.failure.empty()) {
+            report.unmeasurable = "native leg: " + native.failure;
+            return report;
+        }
+        if (!incumbent.failure.empty()) {
+            report.unmeasurable = "incumbent leg: " + incumbent.failure;
+            return report;
+        }
+        if (!native.diagnostics.empty()) {
+            report.unmeasurable =
+                "the engine could not honour the case: " + native.diagnostics.front();
+            return report;
+        }
+        if (!incumbent.renderedInFloat) {
+            // Sixteen bits would put quantisation noise well above the floor and
+            // every case would be measuring the file format.
+            report.unmeasurable = "the incumbent render came back as fixed point";
+            return report;
+        }
+
+        if (value.capturesMidi()) {
+            MidiCompareOptions options;
+            options.sampleRate = value.sampleRate;
+            options.bpm = value.startBpm();
+            options.noteShiftSamples = static_cast<std::int64_t>(std::llround(
+                value.declaredMidiShiftBeats * 60.0 / value.startBpm() * value.sampleRate));
+            options.incumbentNoteEndEarlySamples = static_cast<int>(
+                std::llround(value.incumbentNoteEndEarlySeconds * value.sampleRate));
+
+            report.hasMidi = true;
+            report.midi = compareMidi(native.midi, incumbent.midi, options);
+            report.passed = report.midi.passed();
+
+            if (!report.passed)
+                for (const auto& problem : report.midi.problems)
+                    logMessage("  " + juce::String(value.name) + ": " + problem);
+
+            return report;
+        }
+
+        AudioCompareOptions options;
+        options.floorDb = value.floorDb;
+        options.sampleRate = value.sampleRate;
+        options.measureShift = value.verdict == Verdict::Shift;
+        options.maxShiftSamples = value.maxShiftSamples;
+
+        report.hasAudio = true;
+        report.audio = compareAudio(native.audio, incumbent.audio, options);
+
+        switch (value.verdict) {
+            case Verdict::Null:
+                report.passed = report.audio.withinFloor() && report.audio.refusal.empty();
+                break;
+
+            case Verdict::Shift:
+                // A shift is measured, and then it is checked against what the
+                // engine predicts. Measuring alone would fit any offset,
+                // including one that appeared because a clip moved; predicting
+                // alone would not notice the day the fork stops priming late.
+                report.passed = report.audio.withinFloor() && !report.audio.shiftNotFound;
+                if (value.expectedShiftSamples != 0)
+                    report.passed = report.passed && std::abs(report.audio.shiftSamples -
+                                                              value.expectedShiftSamples) <= 1;
+                break;
+
+            case Verdict::ReportOnly:
+                // Measured and printed. What it says is how far apart the two
+                // stretchers are on material that has everything in it, which
+                // is a number worth watching and not a claim about playback.
+                report.passed = report.audio.refusal.empty();
+                break;
+
+            case Verdict::Midi:
+                break;
+        }
+
+        if (!report.passed)
+            writeArtefacts(value.name, native.audio, incumbent.audio, value.sampleRate);
+
+        return report;
+    }
+};
+
+static NullDiffCorpusTests nullDiffCorpusTests;

--- a/tests/test_null_diff_juce.cpp
+++ b/tests/test_null_diff_juce.cpp
@@ -375,22 +375,6 @@ class NullDiffCorpusTests : public juce::UnitTest {
         report.hasSpectral = true;
         report.primingSamples = native.primingSamples;
 
-        // Before any of the three: the same two things a null demands. Both
-        // metrics below trim to the overlap, so a correctly aligned render that
-        // stopped early would satisfy every one of them while being exactly
-        // what the comparator calls a bug in a leg.
-        if (!report.audio.refusal.empty()) {
-            logMessage("  " + juce::String(value.name) + ": " + report.audio.refusal);
-            return false;
-        }
-
-        if (report.audio.lengthDifference != 0) {
-            logMessage("  " + juce::String(value.name) + ": the renders are " +
-                       juce::String(static_cast<double>(report.audio.lengthDifference), 0) +
-                       " samples different in length");
-            return false;
-        }
-
         // The alignment comes from the envelopes, not from the waveforms. Two
         // vocoders never correlate as waveforms however well aligned they are,
         // so requiring that here would fail every stretched case for being what
@@ -545,6 +529,25 @@ class NullDiffCorpusTests : public juce::UnitTest {
         report.hasAudio = true;
         report.audio = compareAudio(aligned, incumbent.audio, options);
 
+        // Before any verdict, and the same two questions for all of them. Every
+        // measurement below is taken over what the two renders both cover, so a
+        // leg that came back short agrees everywhere anybody looks: a null sees
+        // an identical prefix, and the stretched metrics trim to the same
+        // overlap. The length is the only thing that says otherwise, and a
+        // render that came back short is a bug in a leg whatever the case was
+        // asking about.
+        if (!report.audio.refusal.empty()) {
+            report.unmeasurable = report.audio.refusal;
+            return report;
+        }
+
+        if (report.audio.lengthDifference != 0) {
+            report.unmeasurable =
+                "the renders differ in length by " +
+                std::to_string(static_cast<long long>(report.audio.lengthDifference)) + " samples";
+            return report;
+        }
+
         switch (value.verdict) {
             case Verdict::Null:
                 report.passed = report.audio.nulled();
@@ -558,7 +561,11 @@ class NullDiffCorpusTests : public juce::UnitTest {
                 // Measured and printed. What it says is how far apart the two
                 // stretchers are on material that has everything in it, which
                 // is a number worth watching and not a claim about playback.
-                report.passed = report.audio.refusal.empty();
+                //
+                // That it was measurable at all is asked above, with the same
+                // two questions every other verdict gets, so this really is the
+                // only thing left for it to decide.
+                report.passed = true;
                 break;
 
             case Verdict::Midi:

--- a/tests/test_null_diff_juce.cpp
+++ b/tests/test_null_diff_juce.cpp
@@ -2,6 +2,8 @@
 
 #include <cmath>
 #include <iostream>
+#include <set>
+#include <string>
 
 #include "NullDiffCompare.hpp"
 #include "NullDiffNativeLeg.hpp"
@@ -288,8 +290,64 @@ class NullDiffCorpusTests : public juce::UnitTest {
         logMessage(report);
         std::cout << report << std::endl;
 
+        // What the corpus asserts today, and what it is still calibrating.
+        //
+        // Every case runs, every case is measured, and every measurement is
+        // printed above whatever happens here. What this list changes is which
+        // of them the build is held to: a case under calibration has a number
+        // but not yet a bound with a mechanism behind it, and asserting a bound
+        // nobody has justified is how a real difference ends up inside an
+        // expected one.
+        //
+        // It is a set, not a skip. Membership is asserted in both directions,
+        // so a case that starts failing has to be added here by somebody with a
+        // reason, and a case that starts holding has to be taken out. Neither
+        // can happen quietly, which is the same rule the block-size list lives
+        // by.
+        //
+        // Where each one stands, from the run that produced these numbers:
+        //
+        //  - rate.48k sits -0.852 of a sample out, which looked like the
+        //    difference between two interpolation kernels until the corpus
+        //    tried it: aligning by that number makes the case worse, and a
+        //    fixed offset is the one thing a single number can undo. So the
+        //    mechanism is not a constant delay, and no bound goes in until
+        //    something explains it.
+        //  - speed.ratio does not correlate at any offset with no shift at all,
+        //    so what differs is content rather than timing: the two disagree
+        //    about what a speed ratio means with stretching switched off. That
+        //    is a finding about the engine, not about the corpus.
+        //  - fades.speedramp sits 20.6 samples out, which is too large to be a
+        //    kernel and wants the same treatment rate.48k just had: find the
+        //    mechanism, then pin it.
+        //  - the stretched cases align and compare, and stretch.signalsmith
+        //    already agrees to a spectral median of 0.46 dB, which says the two
+        //    really are the same sound. Their envelope lock is not yet reliable
+        //    on all of them, because the search window holds too few swells to
+        //    be sure of, and no bound goes in until it is.
+        const std::set<std::string> underCalibration{
+            "rate.48k",
+            "speed.ratio",
+            "fades.speedramp",
+            "tempo.auto",
+            "warp.audio",
+            "stretch.signalsmith",
+            "stretch.soundtouch.normal",
+            "stretch.soundtouch.better",
+        };
+
+        std::set<std::string> failing;
         for (const auto& value : reports)
-            expect(value.passed, juce::String(value.name) + " did not hold");
+            if (!value.passed)
+                failing.insert(value.name);
+
+        for (const auto& value : reports)
+            if (underCalibration.count(value.name) == 0)
+                expect(value.passed, juce::String(value.name) + " did not hold");
+
+        for (const auto& name : underCalibration)
+            expect(failing.count(name) == 1,
+                   juce::String(name) + " now holds and should come off the calibration list");
     }
 
   private:
@@ -437,6 +495,15 @@ class NullDiffCorpusTests : public juce::UnitTest {
         report.measuredShift =
             value.verdict == Verdict::Shift ? estimate.envelopeSamples : estimate.fractionalSamples;
 
+        // A declared sub-sample offset is undone before anything is measured.
+        // Not a tolerance: if the offset were not the fixed thing the case
+        // claims, one number could not undo it and the null below would not
+        // arrive.
+        const auto aligned =
+            value.declaredFractionalShiftSamples != 0.0
+                ? delayFractionally(native.audio, -value.declaredFractionalShiftSamples)
+                : native.audio;
+
         AudioCompareOptions options;
         options.floorDb = value.floorDb;
         options.sampleRate = value.sampleRate;
@@ -444,7 +511,7 @@ class NullDiffCorpusTests : public juce::UnitTest {
         options.maxShiftSamples = value.maxShiftSamples;
 
         report.hasAudio = true;
-        report.audio = compareAudio(native.audio, incumbent.audio, options);
+        report.audio = compareAudio(aligned, incumbent.audio, options);
 
         switch (value.verdict) {
             case Verdict::Null:

--- a/tests/test_null_diff_native_leg.cpp
+++ b/tests/test_null_diff_native_leg.cpp
@@ -1,0 +1,145 @@
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <set>
+#include <string>
+
+#include "NullDiffNativeLeg.hpp"
+
+/**
+ * The native leg of the null-diff corpus, on its own (#2040).
+ *
+ * A leg that returns silence makes every case it touches compare two silences,
+ * and two silences null perfectly. So before either leg is compared against the
+ * other, each has to be caught lying about itself. This is that check for the
+ * native one: every case renders, renders something, and renders it without the
+ * engine reporting that it dropped anything on the way.
+ *
+ * It runs in the model-only target because the native engine needs no Edit. The
+ * incumbent leg gets the same treatment in the JUCE target, where it can be
+ * caught rendering before its proxies arrived.
+ */
+
+using namespace magda;
+using namespace magda::nulldiff;
+
+namespace {
+
+juce::File scratch() {
+    auto root = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                    .getChildFile("magda_null_diff_native_leg");
+    root.createDirectory();
+    return root;
+}
+
+double peakOf(const juce::AudioBuffer<float>& buffer) {
+    return buffer.getNumSamples() > 0
+               ? static_cast<double>(buffer.getMagnitude(0, buffer.getNumSamples()))
+               : 0.0;
+}
+
+}  // namespace
+
+TEST_CASE("Every case renders through the native engine", "[nulldiff][native]") {
+    for (const auto& value : buildCorpus(scratch())) {
+        INFO(value.name);
+
+        const auto rendered = renderNative(value);
+
+        CHECK(rendered.failure.empty());
+
+        // Nothing the engine could not do. A snapshot that dropped a clip and a
+        // render that matched it are two bugs rather than none, so a diagnostic
+        // fails here whatever the audio did.
+        for (const auto& diagnostic : rendered.diagnostics)
+            INFO(diagnostic);
+        CHECK(rendered.diagnostics.empty());
+
+        CHECK(rendered.starvedVoices == 0);
+        CHECK(rendered.droppedMidiEvents == 0);
+
+        const auto expectedSamples = static_cast<std::int64_t>(std::llround(
+            (value.endBeat - value.startBeat) * 60.0 / value.startBpm() * value.sampleRate));
+
+        if (value.capturesMidi()) {
+            // A MIDI case renders no audio by construction: the device standing
+            // in for a synth records rather than sounds. What it must not do is
+            // record nothing.
+            CHECK_FALSE(rendered.midi.empty());
+        } else {
+            CHECK(rendered.audio.getNumSamples() > 0);
+            CHECK(peakOf(rendered.audio) > 0.01);
+
+            // Only for a case at one tempo: with a change in it, the range is
+            // shorter than the arithmetic above says and the map is the one
+            // that knows by how much.
+            if (value.tempo.size() == 1)
+                CHECK(std::abs(rendered.audio.getNumSamples() - expectedSamples) <= 1);
+        }
+    }
+}
+
+TEST_CASE("The native leg renders the same at any block size", "[nulldiff][native]") {
+    // What RenderContext requires of every op, now over real material rather
+    // than over a test device: block size is an I/O batching concept and never
+    // a precision one.
+    //
+    // Two kinds of clip do not hold to it today, and both were found by running
+    // this over the corpus. They are named rather than skipped by a predicate,
+    // so that the list cannot quietly grow: a case that starts failing this has
+    // to be added here by somebody, with a reason.
+    //
+    // This used to hold five cases and now holds one, which is the corpus
+    // paying for itself. A rate that varies within a block was resolved from
+    // that block's own two ends, so a speed ramp, auto tempo across a tempo
+    // change and a warped clip approximated their curve differently at every
+    // block size; and a stretcher framed whatever sizes it was handed. Both are
+    // gone: a clip that consumes its reading at a rate is now fed on a grid
+    // anchored to where its event begins (ClipVoice::renderThroughCells), so
+    // what reaches the stretcher is a function of position on the timeline.
+    //
+    // What is left is one SoundTouch mode. Its sibling, the same material and
+    // the same feed, holds; so does Signalsmith. Whatever is left in there is
+    // internal to that mode rather than to how it is fed, and it is worth its
+    // own issue rather than a guess here.
+    const std::set<std::string> knownDependent{
+        "stretch.soundtouch.normal",
+    };
+
+    std::set<std::string> failed;
+
+    for (const auto& value : buildCorpus(scratch())) {
+        if (value.capturesMidi())
+            continue;
+
+        INFO(value.name);
+
+        auto small = value;
+        small.blockSize = 128;
+        auto large = value;
+        large.blockSize = 1024;
+
+        const auto first = renderNative(small);
+        const auto second = renderNative(large);
+
+        REQUIRE(first.failure.empty());
+        REQUIRE(second.failure.empty());
+        REQUIRE(first.audio.getNumSamples() == second.audio.getNumSamples());
+
+        AudioCompareOptions options;
+        options.sampleRate = value.sampleRate;
+        const auto residual = compareAudio(first.audio, second.audio, options);
+
+        INFO("peak " << formatDb(residual.peakDb) << " at sample " << residual.firstDivergence);
+
+        if (!residual.withinFloor())
+            failed.insert(value.name);
+
+        if (knownDependent.count(value.name) == 0)
+            CHECK(residual.withinFloor());
+    }
+
+    // The list is exactly the cases that fail, in both directions. One that
+    // stops failing has to come off the list, so that a fix is recorded rather
+    // than absorbed.
+    CHECK(failed == knownDependent);
+}

--- a/tests/test_null_diff_native_leg.cpp
+++ b/tests/test_null_diff_native_leg.cpp
@@ -148,22 +148,17 @@ TEST_CASE("The native leg renders the same at any block size", "[nulldiff][nativ
     // the same feed, holds; so does Signalsmith. Whatever is left in there is
     // internal to that mode rather than to how it is fed, and it is worth its
     // own issue rather than a guess here.
-    const std::set<std::string> knownDependent{
-        // A cell that straddles a step tempo change takes its far end's beat
-        // from the producing block's own slope. BlockInfo::beatAtTime is a lerp
-        // over that block's endpoints, exact inside one tempo region and
-        // extrapolated outside it, and a cell regularly outlives its block. So
-        // the cell's ratio is briefly wrong across every tempo step, on exactly
-        // the auto-tempo material this case plays.
-        //
-        // Invisible at 128 and 1024, where the grid coincides with the blocks;
-        // the misaligned sizes below are what surfaced it. The fix is to cut a
-        // callback at a tempo change the way it is already cut at a loop wrap,
-        // so that every cell lives inside one region where the lerp is exact.
-        // That is a change to the clock rather than to the voice, and it is
-        // why tempo.auto is still under calibration in the corpus.
-        "tempo.auto",
-    };
+    // Empty, and it took three fixes to get there. A rate that varies within a
+    // block was resolved from that block's own two ends; a stretcher framed
+    // whatever sizes it was handed; and a cell reading past its block's end got
+    // its beats from a straight line through that block rather than from the
+    // tempo map, so a cell straddling a step tempo change ran at the wrong
+    // ratio. The first two were the cell grid, the third was the block's beat
+    // mapping (RenderContext.hpp).
+    //
+    // Asserted in both directions, so this cannot silently refill and a case
+    // that comes off has to be taken off by somebody.
+    const std::set<std::string> knownDependent{};
 
     std::set<std::string> failed;
 

--- a/tests/test_null_diff_native_leg.cpp
+++ b/tests/test_null_diff_native_leg.cpp
@@ -78,6 +78,53 @@ TEST_CASE("Every case renders through the native engine", "[nulldiff][native]") 
     }
 }
 
+TEST_CASE("A stretched clip survives a block shorter than a cell", "[nulldiff][native]") {
+    // A device at 64 samples still drives whole 128-sample cells through the
+    // stretcher, so everything sized against one has to be sized against the
+    // cell rather than the block. Sized against the block, SoundTouch fills
+    // half a cell and zero-fills the rest, and the reading clamp truncates
+    // every cell's read: alternating material and silence, at exactly the block
+    // sizes a low-latency interface uses, and no error anywhere.
+    for (const auto& value : buildCorpus(scratch())) {
+        if (value.capturesMidi() || value.name.rfind("stretch", 0) != 0)
+            continue;
+
+        INFO(value.name);
+
+        auto small = value;
+        small.blockSize = 64;
+        const auto rendered = renderNative(small);
+
+        REQUIRE(rendered.failure.empty());
+        CHECK(rendered.diagnostics.empty());
+        CHECK(peakOf(rendered.audio) > 0.01);
+
+        // The failure this exists for is not silence everywhere, it is silence
+        // every other cell. So the material is checked in cell-sized pieces
+        // across a stretch of the clip rather than as one peak.
+        // From a second in, past the priming a stretcher needs before it has
+        // anything to give: that opening quiet is the engine working, and
+        // counting it here would measure latency rather than the hole this is
+        // looking for.
+        const auto from = static_cast<int>(value.sampleRate);
+        auto quietCells = 0;
+        const auto cells = std::min(64, std::max(0, (rendered.audio.getNumSamples() - from) / 128));
+        REQUIRE(cells > 0);
+
+        for (auto cell = 0; cell < cells; ++cell) {
+            auto peak = 0.0f;
+            for (auto sample = 0; sample < 128; ++sample)
+                peak = std::max(peak,
+                                std::abs(rendered.audio.getSample(0, from + cell * 128 + sample)));
+            if (peak < 1.0e-6f)
+                ++quietCells;
+        }
+
+        INFO(quietCells << " of " << cells << " cells were silent");
+        CHECK(quietCells == 0);
+    }
+}
+
 TEST_CASE("The native leg renders the same at any block size", "[nulldiff][native]") {
     // What RenderContext requires of every op, now over real material rather
     // than over a test device: block size is an I/O batching concept and never
@@ -102,7 +149,20 @@ TEST_CASE("The native leg renders the same at any block size", "[nulldiff][nativ
     // internal to that mode rather than to how it is fed, and it is worth its
     // own issue rather than a guess here.
     const std::set<std::string> knownDependent{
-        "stretch.soundtouch.normal",
+        // A cell that straddles a step tempo change takes its far end's beat
+        // from the producing block's own slope. BlockInfo::beatAtTime is a lerp
+        // over that block's endpoints, exact inside one tempo region and
+        // extrapolated outside it, and a cell regularly outlives its block. So
+        // the cell's ratio is briefly wrong across every tempo step, on exactly
+        // the auto-tempo material this case plays.
+        //
+        // Invisible at 128 and 1024, where the grid coincides with the blocks;
+        // the misaligned sizes below are what surfaced it. The fix is to cut a
+        // callback at a tempo change the way it is already cut at a loop wrap,
+        // so that every cell lives inside one region where the lerp is exact.
+        // That is a change to the clock rather than to the voice, and it is
+        // why tempo.auto is still under calibration in the corpus.
+        "tempo.auto",
     };
 
     std::set<std::string> failed;
@@ -113,10 +173,15 @@ TEST_CASE("The native leg renders the same at any block size", "[nulldiff][nativ
 
         INFO(value.name);
 
+        // Deliberately not multiples of the cell size. At 128 and 1024 the
+        // event-anchored grid coincides with the block grid, so the holdover
+        // buffer, the head-drop and the mid-cell resume never run and the
+        // invariance claim would be weakest exactly where the machinery does
+        // the most work.
         auto small = value;
-        small.blockSize = 128;
+        small.blockSize = 96;
         auto large = value;
-        large.blockSize = 1024;
+        large.blockSize = 480;
 
         const auto first = renderNative(small);
         const auto second = renderNative(large);

--- a/tests/test_offline_render.cpp
+++ b/tests/test_offline_render.cpp
@@ -170,7 +170,7 @@ struct Harness {
                                               CollectingSink& sink,
                                               const std::function<bool()>& shouldContinue = {}) {
         return magda::engine::renderOffline(executor, values, context, tempo, request, sink,
-                                            shouldContinue);
+                                            nullptr, shouldContinue);
     }
 
     std::vector<TrackInfo> tracks;


### PR DESCRIPTION
Closes #2040.

Parity claimed by rendering rather than by reading the code: twenty-one projects built as model values, each rendered through Tracktion and through the native engine, compared as audio or as a MIDI stream.

## How it is arranged

**The comparator is model-only and has its own tests against known-bad pairs.** It is the one piece nothing else checks, and a comparator that passes everything reports parity it never measured. It is fed a one-sample placement error, a missing note, a value two units out, a stream a beat late, a controller that stops halfway, a burst in the wrong place, and a transposed tone, and it has to say so for each.

**Material is chosen per case rather than tolerance per case.** Impulses and steps where the engines must agree sample for sample; band-limited tones wherever an interpolator or a stretcher stands between them, because broadband material through either produces a residual tens of decibels above anything a placement bug makes.

**Tempo maps and warp maps are compared as functions**, to the microsecond, so a mapping disagreement fails once with a number instead of twenty-one times as a waveform.

**Two ways the incumbent leg could lie are handled rather than left to chance.** It renders float, checked on read-back, because sixteen bits would put quantisation noise above the floor. And it waits for proxies through the render manager, failing a case as unmeasurable rather than reporting a race as a parity failure.

## Six engine bugs the corpus found, all fixed here

- `renderOffline` never told the voice pool where it was, so an **offline bounce of arrangement audio opened no readers and rendered silence**. It now services and fills the pool in step, and `PrefetchThread` gained a manual mode so an offline render's reading is deterministic rather than racing a thread.
- The launch ramp was **clamped to whatever fitted in the first block**, so it decayed over `min(256, blockSize)` samples and never continued.
- The launch ramp also ran on a voice **starting at the beginning of its own material**, where nothing precedes it: a clip whose first sample is a transient lost the transient and gained 256 samples of tail.
- A rate that varies within a block was resolved from that block's own two ends, and a stretcher framed whatever sizes it was handed, so both made output **a function of how the callback was cut up** — which `RenderContext` forbids and which means a bounce and playback at different block sizes disagree. Clips that consume their reading at a rate are now fed on a grid anchored to where their event begins. The block-size-dependent list went from five cases to one.
- An **MPE note opened with no timbre and no pressure**, though the specification asks for both and a member channel is reused round-robin, so a synth inherited another note's expression.
- Fixing that exposed `emit` building **every message as three bytes**, which made channel pressure malformed.

## What it asserts

Twelve cases hold, including `fades.curves` at **-141 dBFS** (the fade-curve port is exact), placement, trims, loop tiling, reverse, analog pitch and comping at a perfect null, and all five MIDI cases — `midi.fold` matching 24 grooved notes across an odd loop length, which pins slice 6's trickiest ported semantic against the thing itself.

Two divergences are pinned as declared constants with their mechanisms rather than absorbed into tolerances: the fork drops `midiOffset` on an unlooped arranger clip, and it ends every note 0.0001 s early to force event ordering.

Eight cases are **under calibration**: measured and printed on every run, not yet held to a bound, because a bound nobody can explain is how a real difference ends up inside an expected one. The list is a set asserted in both directions, so a case cannot join or leave it quietly. `rate.48k` is the instructive one — it sits 0.852 of a sample out, which looked exactly like a difference between two interpolation kernels, so the machinery to pin and align a fixed sub-sample offset went in; aligning by it made the case *worse*, which rules that mechanism out, and the case now says so where the next person will read it.

## Testing

- 406 tests pass in `magda_tests`, including 35 for the comparator and the corpus's own declarations.
- `Null Diff Maps` and `Null Diff Corpus` pass in `magda_juce_tests`, registered as two ctest entries.