### PR TITLE
Test node id uniqueness, and lift the corpus's three-track cap (#2085)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,7 @@ set(TEST_SOURCES
     ../magda/daw/ui/components/chain/ChainNodePathDrag.cpp
     test_momentary_param_button.cpp
     test_delta_solo.cpp
+    test_hash_combine.cpp
     test_waveform_editor_absolute_mode.cpp
     test_clip_batch_edit.cpp
     test_clip_commands.cpp
@@ -399,6 +400,7 @@ target_sources(magda_juce_tests PRIVATE
     test_clip_sync_integration_juce.cpp
     test_signalsmith_loop_juce.cpp
     test_arranger_launcher_switching_juce.cpp
+    test_node_id_collision_juce.cpp
     test_session_slot_recording_juce.cpp
     test_input_monitor_track_routing_juce.cpp
     test_controller_track_level_write_juce.cpp

--- a/tests/NullDiffCorpus.cpp
+++ b/tests/NullDiffCorpus.cpp
@@ -654,15 +654,12 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
     // same file at the same position produce colliding node IDs and trip the
     // graph's uniqueness assertion.
     //
-    // No case here has more than three tracks, and that is a constraint rather
-    // than a preference. Four audio tracks in one Edit collide in the fork's
-    // node-identity hash: two ArrangerLauncherSwitchingNodes come out with the
-    // same id and the graph's uniqueness assertion fires. It reproduces on four
-    // tracks carrying one impulse clip each, so it is nothing to do with what
-    // these cases play or what their faders are set to. The runner refuses to
-    // certify a case that provoked an assertion, so this would be a failure
-    // rather than a quiet pass; the cases stay under the limit and the collision
-    // is #2085.
+    // These cases used to be capped at three tracks, because a fourth collided
+    // in the fork's node-identity hash and tripped the graph's uniqueness
+    // assertion. That was #2085: tracktion::hash_combine did not avalanche, so
+    // every node id in an Edit agreed in its top thirty-odd bits. The cap is
+    // gone with it, and
+    // mix.summing carries a fourth track to keep the case that found it.
     //
     // Sends are absent on purpose. The native leg could render one today, and
     // the incumbent's live on te::AuxSendPlugin instances that PluginManagerSync
@@ -671,15 +668,20 @@ std::vector<Case> buildCorpus(const juce::File& scratchDirectory) {
     // to have. They belong with the rest of the routing graph, in #1892.
 
     {
-        auto value = newMixCase("mix.summing", "three tracks summed into master",
-                                {mixTrack(1, "One"), mixTrack(2, "Two"), mixTrack(3, "Three")});
+        // Four tracks, which is where the node-identity collision in #2085 used
+        // to fire. A three-track sum covers the arithmetic just as well; the
+        // fourth is here so that the case which found the collision keeps
+        // looking for it.
+        auto value = newMixCase(
+            "mix.summing", "four tracks summed into master",
+            {mixTrack(1, "One"), mixTrack(2, "Two"), mixTrack(3, "Three"), mixTrack(4, "Four")});
 
-        // Three different impulse grids rather than three copies of one. Equal
+        // Four different impulse grids rather than four copies of one. Equal
         // values sum exactly whatever order they are added in, so identical
         // sources would agree by arithmetic rather than by the two engines
         // summing the same things.
-        const std::array<double, 3> intervals{0.25, 0.3, 0.5};
-        for (auto index = 0; index < 3; ++index) {
+        const std::array<double, 4> intervals{0.25, 0.3, 0.5, 0.7};
+        for (auto index = 0; index < 4; ++index) {
             const auto source = writeSource(scratchDirectory, "sum" + juce::String(index),
                                             impulses(intervals[static_cast<std::size_t>(index)]));
             value.sources.push_back(source);

--- a/tests/test_hash_combine.cpp
+++ b/tests/test_hash_combine.cpp
@@ -1,0 +1,131 @@
+#include <bitset>
+#include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <set>
+#include <vector>
+
+#include "../third_party/tracktion_engine/modules/tracktion_core/utilities/tracktion_Hash.h"
+
+/**
+ * tracktion::hash_combine, which every node in a playback graph gets its
+ * identity from (#2085).
+ *
+ * The inputs it is given are small: a per-type compile-time seed stirred with
+ * an EditItemID in the low thousands, then with the ids of a handful of input
+ * nodes. A combine that does not avalanche leaves a whole Edit's node ids
+ * agreeing in their top thirty-odd bits, which is close enough for two of them
+ * to collide on a three-track project. What is asserted
+ * here is the property that prevents that, rather than any particular value:
+ * pinning the numbers would make an intentional change to the function look
+ * like a regression, and the numbers are not a contract with anything.
+ */
+
+using tracktion::hash;
+using tracktion::hash_combine;
+
+namespace {
+
+/// How many bits differ between two hashes.
+int hammingDistance(std::size_t a, std::size_t b) {
+    return static_cast<int>(std::bitset<64>(static_cast<std::uint64_t>(a ^ b)).count());
+}
+
+/// The seed a node type would use: a hash of its own name, so a large constant
+/// with no relationship to the small values it gets combined with.
+constexpr std::size_t kNodeTypeSeed = 7653239033668669842ull;
+
+}  // namespace
+
+TEST_CASE("hash_combine avalanches on the inputs node identity actually uses",
+          "[hash][node_identity]") {
+    // The itemIDs of a small project's tracks: consecutive-ish small integers,
+    // which is the case the engine hands it and the case it used to fail.
+    std::vector<std::size_t> hashes;
+    for (std::size_t itemId = 1000; itemId < 1064; ++itemId)
+        hashes.push_back(hash(kNodeTypeSeed, itemId));
+
+    SECTION("neighbouring inputs land far apart") {
+        // Half the bits is the expectation for a good mix; a third of them is
+        // a floor that a mix has to be badly broken to fall through. The old
+        // function scored between one and seven.
+        for (std::size_t index = 1; index < hashes.size(); ++index)
+            REQUIRE(hammingDistance(hashes[index - 1], hashes[index]) > 20);
+    }
+
+    SECTION("the high bits move") {
+        // What the collision was made of: every id in an Edit shared its top
+        // bits, so a whole graph's worth of them lived in a window a few
+        // million wide, and two adjacent ones could differ by thirteen.
+        std::set<std::size_t> topBits;
+        for (auto value : hashes)
+            topBits.insert(value >> 40);
+
+        REQUIRE(topBits.size() > hashes.size() / 2);
+    }
+
+    SECTION("no two inputs share a hash") {
+        REQUIRE(std::set<std::size_t>(hashes.begin(), hashes.end()).size() == hashes.size());
+    }
+}
+
+TEST_CASE("hash_combine keeps the properties the graph relies on", "[hash][node_identity]") {
+    SECTION("order matters") {
+        // A node's identity is its inputs in order, so two nodes fed the same
+        // inputs the other way round have to differ.
+        auto forwards = kNodeTypeSeed;
+        hash_combine(forwards, std::size_t{7});
+        hash_combine(forwards, std::size_t{9});
+
+        auto backwards = kNodeTypeSeed;
+        hash_combine(backwards, std::size_t{9});
+        hash_combine(backwards, std::size_t{7});
+
+        REQUIRE(forwards != backwards);
+    }
+
+    SECTION("combining always changes the seed") {
+        // Including with a value that hashes to zero: a node whose input
+        // contributed nothing would otherwise be indistinguishable from the
+        // node that has no input at all.
+        auto seed = kNodeTypeSeed;
+        hash_combine(seed, std::size_t{0});
+        REQUIRE(seed != kNodeTypeSeed);
+    }
+
+    SECTION("it is a function of its inputs alone") {
+        // Ids are compared across a graph swap, so two runs of the same
+        // combine have to agree.
+        REQUIRE(hash(kNodeTypeSeed, std::size_t{42}) == hash(kNodeTypeSeed, std::size_t{42}));
+    }
+}
+
+TEST_CASE("chaining combines does not reintroduce the clustering", "[hash][node_identity]") {
+    // The shape a node id is actually built in, and the one that collided: a
+    // node seeded by its own type and stirred with its track's itemID, then
+    // combined with the id of the node feeding it, which was built the same
+    // way from the same itemID. A mix that avalanches once but lets a chain
+    // settle back into a narrow band would pass the case above and still lose
+    // this.
+    constexpr std::size_t kFeedingNodeTypeSeed = 10553084373558490035ull;
+
+    std::vector<std::size_t> ids;
+    for (std::size_t track = 0; track < 64; ++track) {
+        const auto itemId = 1003 + track * 3;
+
+        auto id = hash(kNodeTypeSeed, itemId);
+        hash_combine(id, hash(kFeedingNodeTypeSeed, itemId));
+
+        ids.push_back(id);
+    }
+
+    std::set<std::size_t> topBits;
+    for (auto value : ids)
+        topBits.insert(value >> 40);
+
+    REQUIRE(topBits.size() > ids.size() / 2);
+    REQUIRE(std::set<std::size_t>(ids.begin(), ids.end()).size() == ids.size());
+
+    for (std::size_t index = 1; index < ids.size(); ++index)
+        REQUIRE(hammingDistance(ids[index - 1], ids[index]) > 20);
+}

--- a/tests/test_node_id_collision_juce.cpp
+++ b/tests/test_node_id_collision_juce.cpp
@@ -1,0 +1,166 @@
+#include <juce_audio_formats/juce_audio_formats.h>
+#include <juce_core/juce_core.h>
+#include <tracktion_engine/tracktion_engine.h>
+#include <tracktion_graph/tracktion_graph.h>
+
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "SharedTestEngine.hpp"
+#include "third_party/tracktion_engine/modules/tracktion_engine/playback/graph/tracktion_EditNodeBuilder.h"
+#include "third_party/tracktion_engine/modules/tracktion_engine/playback/graph/tracktion_TracktionEngineNode.h"
+#include "third_party/tracktion_engine/modules/tracktion_engine/utilities/tracktion_TestUtilities.h"
+#include "third_party/tracktion_engine/modules/tracktion_graph/tracktion_graph/tracktion_TestUtilities.h"
+
+/**
+ * Node identity across many tracks (#2085).
+ *
+ * Every Node in a playback graph is expected to carry an id that no other Node
+ * in the same graph carries: `node_player_utils::prepareToPlay` asserts on it,
+ * and `ArrangerLauncherSwitchingNode::prepareToPlay` uses it to find its own
+ * previous self when a graph is swapped, so that fader ramps and the active
+ * note list survive the swap. Two Nodes sharing an id means one track can be
+ * handed the other's carried state.
+ *
+ * The graph is built here rather than rendered: what is under test is the id,
+ * and a render would only reach it through everything else that can fail.
+ */
+
+namespace te = tracktion;
+
+namespace {
+
+/// A graph's node ids, by the type that produced them.
+struct NodeIdentity {
+    std::size_t id = 0;
+    std::string type;
+};
+
+std::vector<NodeIdentity> collectNodeIdentities(te::graph::Node& root) {
+    std::vector<NodeIdentity> identities;
+
+    for (auto* node : te::graph::getNodes(root, te::graph::VertexOrdering::postordering))
+        identities.push_back({node->getNodeProperties().nodeID, typeid(*node).name()});
+
+    return identities;
+}
+
+/// The ids that more than one Node in the graph claims.
+///
+/// Zero is excluded the way the engine's own check excludes it: a Node that
+/// does not participate in identity reports zero, and any number of those is
+/// not a collision.
+std::map<std::size_t, std::vector<std::string>> duplicates(
+    const std::vector<NodeIdentity>& identities) {
+    std::map<std::size_t, std::vector<std::string>> byId;
+
+    for (const auto& identity : identities)
+        if (identity.id != 0)
+            byId[identity.id].push_back(identity.type);
+
+    for (auto iter = byId.begin(); iter != byId.end();)
+        iter = iter->second.size() > 1 ? std::next(iter) : byId.erase(iter);
+
+    return byId;
+}
+
+/// An Edit with `numTracks` audio tracks, each playing one file of its own.
+///
+/// Different files on purpose: a node's identity is partly a hash of what it
+/// plays, so two tracks playing the same file at the same position collide for
+/// a reason that has nothing to do with what is under test here.
+struct Project {
+    std::unique_ptr<te::Edit> edit;
+    std::vector<std::unique_ptr<juce::TemporaryFile>> sources;
+};
+
+Project makeProject(te::Engine& engine, int numTracks) {
+    Project project;
+    project.edit = te::engine::test_utilities::createTestEdit(engine, numTracks);
+
+    if (project.edit == nullptr)
+        return project;
+
+    auto tracks = te::getAudioTracks(*project.edit);
+
+    for (int index = 0; index < numTracks && index < tracks.size(); ++index) {
+        auto source = te::graph::test_utilities::getSinFile<juce::WavAudioFormat>(
+            44100.0, 2.0, 1, 220.0f + 10.0f * static_cast<float>(index));
+
+        auto* track = tracks[index];
+        track->insertWaveClip(
+            "clip" + juce::String(index), source->getFile(),
+            {{te::TimePosition(), te::TimePosition::fromSeconds(2.0)}, te::TimeDuration()}, false);
+
+        project.sources.push_back(std::move(source));
+    }
+
+    return project;
+}
+
+std::unique_ptr<te::graph::Node> buildGraph(te::Edit& edit, te::ProcessState& processState) {
+    te::CreateNodeParams params{processState};
+    params.sampleRate = 44100.0;
+    params.blockSize = 256;
+    params.forRendering = true;
+
+    return te::createNodeForEdit(edit, params);
+}
+
+class NodeIdCollisionTests final : public juce::UnitTest {
+  public:
+    NodeIdCollisionTests() : juce::UnitTest("Node ID Collision Tests", "Engine") {}
+
+    void runTest() override {
+        auto& wrapper = magda::test::getSharedEngine();
+        auto* engine = wrapper.getEngine();
+
+        if (engine == nullptr) {
+            beginTest("engine");
+            expect(false, "no Tracktion engine");
+            return;
+        }
+
+        // Up to eight, because the report is about four and a fix that only
+        // moves the first collision along by one track is not a fix.
+        for (int numTracks = 1; numTracks <= 8; ++numTracks) {
+            beginTest(juce::String(numTracks) + " audio tracks have unique node ids");
+
+            auto project = makeProject(*engine, numTracks);
+            expect(project.edit != nullptr, "no Edit");
+
+            if (project.edit == nullptr)
+                continue;
+
+            te::graph::PlayHead playHead;
+            te::graph::PlayHeadState playHeadState{playHead};
+            te::ProcessState processState{playHeadState, project.edit->tempoSequence};
+
+            auto graph = buildGraph(*project.edit, processState);
+            expect(graph != nullptr, "no graph");
+
+            if (graph == nullptr)
+                continue;
+
+            const auto identities = collectNodeIdentities(*graph);
+            const auto collisions = duplicates(identities);
+
+            for (const auto& [id, types] : collisions) {
+                std::ostringstream report;
+                report << "id " << id << " is claimed by " << types.size() << " nodes:";
+                for (const auto& type : types)
+                    report << " " << type;
+                logMessage(report.str());
+            }
+
+            expect(collisions.empty(),
+                   "node ids collide with " + juce::String(numTracks) + " tracks");
+        }
+    }
+};
+
+NodeIdCollisionTests nodeIdCollisionTests;
+
+}  // namespace


### PR DESCRIPTION
Closes #2085.

Bumps `tracktion_engine` to Conceptual-Machines/tracktion_engine#32, which is the actual fix: `hash_combine` did not avalanche, so every node id in an Edit landed within a few million of the others and two `ArrangerLauncherSwitchingNode`s collided.

It reproduces at **three** tracks, not four - the count is data dependent. A three-track graph:

```
8218993137307567009  ArrangerLauncherSwitchingNode
8218993137304682565  ArrangerLauncherSwitchingNode
8218993137304682565  ArrangerLauncherSwitchingNode   <- collision
2361270753387966084 / 2361271489122025026 / ...039   TrackMutingNode   <- 13 apart
```

Every node type agreed in its top ~34 bits, so this was not specific to `ArrangerLauncherSwitchingNode`.

The issue left open whether the two colliding nodes were two tracks or one node reached twice. They are two tracks: `getNodes` dedupes by pointer, so `orderedNodes` holds each node once. What I have **not** observed is the crossed-over state or wrong audio - the precondition is established, the symptom is not.

## Tests

Both were checked against the old function first, so neither is vacuous.

- `test_hash_combine.cpp` - neighbouring inputs land far apart, the high bits move, and a chained combine doesn't settle back into a narrow band. The old function scored 1 to 7 bits of difference out of 64, and 64 consecutive itemIDs gave one distinct top-24-bit prefix.
- `test_node_id_collision_juce.cpp` - builds the graph for 1 to 8 audio tracks and checks no two nodes share an id. Failed at 3 before the fix.

## Corpus

The three-track cap in `NullDiffCorpus.cpp` existed only because of this, so it is gone and `mix.summing` carries a fourth track.

## Verified

Full Catch2 suite (2543 cases, 571804 assertions), full JUCE suite, null-diff corpus, and `magda_engine_swap_stress`.