### PR TITLE
Plan goldens in CI (#2076)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 assets/fonts/NotoSansCJKsc-Regular.otf filter=lfs diff=lfs merge=lfs -text
+
+# Plan goldens (#2076) are compared byte for byte against text the test
+# generates with LF endings. A checkout that translated them to CRLF would fail
+# every fixture on its first line, so they are never translated.
+tests/goldens/plan/*.txt text eol=lf

--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -45,22 +45,26 @@ add_library(magda_engine STATIC
     plan/PlanDiff.cpp
     plan/PlanCrossfade.cpp
     plan/PlanDump.cpp
+    plan/PlanDiffDump.cpp
     plan/RenderPlan.hpp
     plan/PlanCompiler.hpp
     plan/PlanDiff.hpp
     plan/PlanCrossfade.hpp
     plan/PlanDump.hpp
+    plan/PlanDiffDump.hpp
     plan/TrackRouting.hpp
     exec/PlanExecutor.cpp
     exec/ParallelPlanExecutor.cpp
     exec/RenderThreadPool.cpp
     exec/PlanLayout.cpp
+    exec/PlanLayoutDump.cpp
     exec/PlanValues.cpp
     exec/RuntimeStateStore.cpp
     exec/EngineSession.cpp
     exec/OfflineRender.cpp
     exec/PlanExecutor.hpp
     exec/PlanLayout.hpp
+    exec/PlanLayoutDump.hpp
     exec/PlanValues.hpp
     exec/PlanBindings.hpp
     exec/EngineDevice.hpp

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -353,11 +353,16 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
         if (const auto* device = deviceForOp_[i]; device != nullptr)
             deviceLatency[i] = device->latencySamples();
 
-    portOffsets_ = portOffsetsOf(plan);
-    const auto latency = resolvePlanLatency(plan, portOffsets_, deviceLatency);
-    latencySamples_ = latency.outputLatency;
+    // Through resolveLayout rather than the three passes inline, because the
+    // plan goldens (#2076) pin what a prepare resolves and have to be resolving
+    // it the same way. Two callers running the same three lines is how a step
+    // added to one of them silently stops being pinned by the other.
+    const auto prepared = resolveLayout(plan, deviceLatency);
+    const auto& latency = prepared.latency;
+    const auto& layout = prepared.buffers;
 
-    const auto layout = assignBuffers(plan, portOffsets_, latency.delaySamples);
+    portOffsets_ = prepared.portOffsets;
+    latencySamples_ = latency.outputLatency;
     portSlots_ = layout.portSlots;
     writesInPlace_ = layout.writesInPlace;
 

--- a/magda/engine/exec/PlanLayout.cpp
+++ b/magda/engine/exec/PlanLayout.cpp
@@ -315,4 +315,12 @@ BufferLayout assignBuffers(const RenderPlan& plan, const std::vector<int>& portO
     return layout;
 }
 
+PreparedLayout resolveLayout(const RenderPlan& plan, const std::vector<int>& deviceLatency) {
+    PreparedLayout prepared;
+    prepared.portOffsets = portOffsetsOf(plan);
+    prepared.latency = resolvePlanLatency(plan, prepared.portOffsets, deviceLatency);
+    prepared.buffers = assignBuffers(plan, prepared.portOffsets, prepared.latency.delaySamples);
+    return prepared;
+}
+
 }  // namespace magda::engine

--- a/magda/engine/exec/PlanLayout.hpp
+++ b/magda/engine/exec/PlanLayout.hpp
@@ -95,4 +95,26 @@ struct BufferLayout {
 BufferLayout assignBuffers(const RenderPlan& plan, const std::vector<int>& portOffsets,
                            const std::vector<int>& delaySamples);
 
+/**
+ * @brief Everything a prepare resolves, in the order it has to be resolved.
+ *
+ * The three passes above run one after another and each takes the one before
+ * it, so every caller ran the same three lines. Two of them doing it
+ * separately is how a step added here reaches the executor and not the golden
+ * that is supposed to be pinning it.
+ */
+struct PreparedLayout {
+    std::vector<int> portOffsets;
+    PlanLatency latency;
+    BufferLayout buffers;
+};
+
+/**
+ * @brief Resolve @p plan against the latency its bound instances report.
+ *
+ * @param deviceLatency  per op: what a Device op's bound instance reports, and
+ *                       zero everywhere else.
+ */
+PreparedLayout resolveLayout(const RenderPlan& plan, const std::vector<int>& deviceLatency);
+
 }  // namespace magda::engine

--- a/magda/engine/exec/PlanLayoutDump.cpp
+++ b/magda/engine/exec/PlanLayoutDump.cpp
@@ -2,21 +2,14 @@
 
 #include <sstream>
 
+#include "plan/DumpFormat.hpp"
+
 namespace magda::engine {
 namespace {
 
-std::string padded(std::string text, std::size_t width) {
-    if (text.size() < width)
-        text.append(width - text.size(), ' ');
-    return text;
-}
-
-std::string rightAligned(int value, std::size_t width) {
-    auto text = std::to_string(value);
-    if (text.size() < width)
-        text.insert(text.begin(), static_cast<long>(width - text.size()), ' ');
-    return text;
-}
+using dump_format::padded;
+using dump_format::rightAligned;
+using dump_format::writeLine;
 
 /// An op's output ports, as the arena and slot each renders into.
 std::string describePorts(const RenderPlan& plan, const BufferLayout& layout,
@@ -42,7 +35,7 @@ std::string describePorts(const RenderPlan& plan, const BufferLayout& layout,
 ///
 /// An op with no output ports has no latency to report rather than a latency
 /// of zero, and printing zero for it would read as "nothing reaches this",
-/// which of the hardware output is the opposite of true.
+/// which for the hardware output is the opposite of true.
 std::string describeLatency(const RenderPlan& plan, const PlanLatency& latency,
                             const std::vector<int>& portOffsets, std::size_t op) {
     if (plan.ops[op].outputs.empty())
@@ -52,20 +45,15 @@ std::string describeLatency(const RenderPlan& plan, const PlanLatency& latency,
     return port < latency.portLatency.size() ? std::to_string(latency.portLatency[port]) : "-";
 }
 
-/// Trailing spaces would not survive the repo's whitespace hook, which would
-/// rewrite every golden the first time one was committed.
-void writeTrimmed(std::ostringstream& out, std::string line) {
-    while (!line.empty() && line.back() == ' ')
-        line.pop_back();
-    out << line << "\n";
-}
-
 }  // namespace
 
 std::string dumpPlanLayout(const RenderPlan& plan, const std::vector<int>& deviceLatency) {
-    const auto portOffsets = portOffsetsOf(plan);
-    const auto latency = resolvePlanLatency(plan, portOffsets, deviceLatency);
-    const auto layout = assignBuffers(plan, portOffsets, latency.delaySamples);
+    // The same call PlanExecutor::prepare makes, which is what makes the
+    // golden pin the path the engine runs rather than a copy of it.
+    const auto prepared = resolveLayout(plan, deviceLatency);
+    const auto& portOffsets = prepared.portOffsets;
+    const auto& latency = prepared.latency;
+    const auto& layout = prepared.buffers;
 
     std::ostringstream out;
     out << "magda-plan-layout v1\n";
@@ -90,7 +78,7 @@ std::string dumpPlanLayout(const RenderPlan& plan, const std::vector<int>& devic
         if (i < layout.elided.size() && layout.elided[i] != 0)
             line << " elided";
 
-        writeTrimmed(out, line.str());
+        writeLine(out, line.str());
     }
 
     return out.str();

--- a/magda/engine/exec/PlanLayoutDump.cpp
+++ b/magda/engine/exec/PlanLayoutDump.cpp
@@ -1,0 +1,99 @@
+#include "exec/PlanLayoutDump.hpp"
+
+#include <sstream>
+
+namespace magda::engine {
+namespace {
+
+std::string padded(std::string text, std::size_t width) {
+    if (text.size() < width)
+        text.append(width - text.size(), ' ');
+    return text;
+}
+
+std::string rightAligned(int value, std::size_t width) {
+    auto text = std::to_string(value);
+    if (text.size() < width)
+        text.insert(text.begin(), static_cast<long>(width - text.size()), ' ');
+    return text;
+}
+
+/// An op's output ports, as the arena and slot each renders into.
+std::string describePorts(const RenderPlan& plan, const BufferLayout& layout,
+                          const std::vector<int>& portOffsets, std::size_t op) {
+    const auto& outputs = plan.ops[op].outputs;
+    if (outputs.empty())
+        return "-";
+
+    std::string text;
+    for (std::size_t i = 0; i < outputs.size(); ++i) {
+        if (i > 0)
+            text += ",";
+
+        const auto port = static_cast<std::size_t>(portOffsets[op]) + i;
+        text += outputs[i] == SignalKind::Midi ? "m" : "a";
+        text += std::to_string(layout.portSlots[port]);
+    }
+    return text;
+}
+
+/// The latency reaching an op's first output port, which is the number that
+/// says where in the graph a delay had to go.
+///
+/// An op with no output ports has no latency to report rather than a latency
+/// of zero, and printing zero for it would read as "nothing reaches this",
+/// which of the hardware output is the opposite of true.
+std::string describeLatency(const RenderPlan& plan, const PlanLatency& latency,
+                            const std::vector<int>& portOffsets, std::size_t op) {
+    if (plan.ops[op].outputs.empty())
+        return "-";
+
+    const auto port = static_cast<std::size_t>(portOffsets[op]);
+    return port < latency.portLatency.size() ? std::to_string(latency.portLatency[port]) : "-";
+}
+
+/// Trailing spaces would not survive the repo's whitespace hook, which would
+/// rewrite every golden the first time one was committed.
+void writeTrimmed(std::ostringstream& out, std::string line) {
+    while (!line.empty() && line.back() == ' ')
+        line.pop_back();
+    out << line << "\n";
+}
+
+}  // namespace
+
+std::string dumpPlanLayout(const RenderPlan& plan, const std::vector<int>& deviceLatency) {
+    const auto portOffsets = portOffsetsOf(plan);
+    const auto latency = resolvePlanLatency(plan, portOffsets, deviceLatency);
+    const auto layout = assignBuffers(plan, portOffsets, latency.delaySamples);
+
+    std::ostringstream out;
+    out << "magda-plan-layout v1\n";
+    out << "audioSlots=" << layout.numAudioSlots << " midiSlots=" << layout.numMidiSlots
+        << " outputLatency=" << latency.outputLatency << "\n";
+
+    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+        const auto& op = plan.ops[i];
+
+        std::ostringstream line;
+        line << "[" << rightAligned(static_cast<int>(i), 3) << "] " << padded(toString(op.kind), 11)
+             << " " << padded(toString(op.key), 30)
+             << " lat=" << padded(describeLatency(plan, latency, portOffsets, i), 7)
+             << " ports=" << padded(describePorts(plan, layout, portOffsets, i), 11);
+
+        // Only where set: a fixture that provokes neither should say nothing
+        // about them rather than print two columns of zeroes.
+        if (op.kind == OpKind::Delay)
+            line << " hold=" << latency.delaySamples[i];
+        if (i < layout.writesInPlace.size() && layout.writesInPlace[i] != 0)
+            line << " inplace";
+        if (i < layout.elided.size() && layout.elided[i] != 0)
+            line << " elided";
+
+        writeTrimmed(out, line.str());
+    }
+
+    return out.str();
+}
+
+}  // namespace magda::engine

--- a/magda/engine/exec/PlanLayoutDump.hpp
+++ b/magda/engine/exec/PlanLayoutDump.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "exec/PlanLayout.hpp"
+#include "plan/RenderPlan.hpp"
+
+namespace magda::engine {
+
+/**
+ * @brief Render a prepared plan's latency and buffer assignment as canonical text.
+ *
+ * The counterpart to dumpPlan for the two decisions that are not in the plan:
+ * how many samples each delay holds, and which arena slot each port renders
+ * into. Both follow from binding a plan to the instances behind it, so both
+ * are pinned against the device latencies they were resolved with rather than
+ * on their own.
+ *
+ * Shape:
+ * @code
+ * magda-plan-layout v1
+ * audioSlots=3 midiSlots=1 outputLatency=64
+ * [  0] ClipAudio    T1:clipAudio        lat=0     ports=a0
+ * [  1] Delay        T-2:mixInputDelay   lat=64    ports=a1        hold=64
+ * ...
+ * @endcode
+ *
+ * A port reads `a<slot>` or `m<slot>` for the arena it indexes. `inplace` and
+ * `elided` are printed only where set, so a fixture that provokes neither
+ * prints nothing about them.
+ */
+std::string dumpPlanLayout(const RenderPlan& plan, const std::vector<int>& deviceLatency);
+
+}  // namespace magda::engine

--- a/magda/engine/plan/DumpFormat.hpp
+++ b/magda/engine/plan/DumpFormat.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <sstream>
+#include <string>
+
+/**
+ * @file DumpFormat.hpp
+ * @brief Column formatting shared by the canonical dumps.
+ *
+ * Internal to the dumps. Three of them print the same fixed columns, and their
+ * output is compared against checked-in goldens (#2076), so a column that
+ * drifted in one and not the others would rewrite every golden and read as a
+ * change to the thing being dumped.
+ */
+
+namespace magda::engine::dump_format {
+
+/// Left-aligned in a fixed column.
+inline std::string padded(std::string text, std::size_t width) {
+    if (text.size() < width)
+        text.append(width - text.size(), ' ');
+    return text;
+}
+
+/// Right-aligned in a fixed column, for indices.
+inline std::string rightAligned(int value, std::size_t width) {
+    auto text = std::to_string(value);
+    if (text.size() < width)
+        text.insert(text.begin(), static_cast<long>(width - text.size()), ' ');
+    return text;
+}
+
+/// Write one line, without the trailing spaces a padded last column leaves.
+///
+/// Trailing whitespace would not survive the repo's pre-commit hook, which
+/// would rewrite every golden the first time one was committed and leave every
+/// run afterwards comparing against a file it did not write.
+inline void writeLine(std::ostringstream& out, std::string line) {
+    while (!line.empty() && line.back() == ' ')
+        line.pop_back();
+    out << line << "\n";
+}
+
+}  // namespace magda::engine::dump_format

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -23,8 +23,14 @@ struct ChainSignal {
 };
 
 /// Where a chain element lives, for op keys. Only the innermost rack and chain
-/// are recorded: device ids are project-unique, so deeper nesting needs no
-/// further qualification.
+/// are recorded, on the assumption that device ids are project-unique.
+///
+/// They are not. TrackManager allocates them per section (nextFxDeviceId_,
+/// nextPostFxDeviceId_, nextMixerAnalysisDeviceId_), so one track's FX and
+/// post-FX chains can both hold id 3, and both compile to the same OpKey.
+/// validatePlan rejects the result rather than letting the differ carry one
+/// device's state into the other, so it fails loudly; it still fails. What is
+/// missing is a section discriminator here and in OpKey.
 struct ChainSite {
     TrackId trackId = INVALID_TRACK_ID;
     RackId rackId = INVALID_RACK_ID;

--- a/magda/engine/plan/PlanDiffDump.cpp
+++ b/magda/engine/plan/PlanDiffDump.cpp
@@ -2,21 +2,14 @@
 
 #include <sstream>
 
+#include "plan/DumpFormat.hpp"
+
 namespace magda::engine {
 namespace {
 
-std::string padded(std::string text, std::size_t width) {
-    if (text.size() < width)
-        text.append(width - text.size(), ' ');
-    return text;
-}
-
-std::string rightAligned(int value, std::size_t width) {
-    auto text = std::to_string(value);
-    if (text.size() < width)
-        text.insert(text.begin(), static_cast<long>(width - text.size()), ' ');
-    return text;
-}
+using dump_format::padded;
+using dump_format::rightAligned;
+using dump_format::writeLine;
 
 }  // namespace
 
@@ -38,13 +31,7 @@ std::string dumpPlanDiff(const RenderPlan& oldPlan, const RenderPlan& newPlan,
         if (from != INVALID_OP_ID)
             line << " from=" << toString(oldPlan.ops[static_cast<std::size_t>(from)].key);
 
-        // Trailing spaces would not survive the repo's whitespace hook, which
-        // would rewrite every golden the first time one was committed.
-        auto text = line.str();
-        while (!text.empty() && text.back() == ' ')
-            text.pop_back();
-
-        out << text << "\n";
+        writeLine(out, line.str());
     }
 
     for (const auto op : diff.retired)

--- a/magda/engine/plan/PlanDiffDump.cpp
+++ b/magda/engine/plan/PlanDiffDump.cpp
@@ -1,0 +1,56 @@
+#include "plan/PlanDiffDump.hpp"
+
+#include <sstream>
+
+namespace magda::engine {
+namespace {
+
+std::string padded(std::string text, std::size_t width) {
+    if (text.size() < width)
+        text.append(width - text.size(), ' ');
+    return text;
+}
+
+std::string rightAligned(int value, std::size_t width) {
+    auto text = std::to_string(value);
+    if (text.size() < width)
+        text.insert(text.begin(), static_cast<long>(width - text.size()), ' ');
+    return text;
+}
+
+}  // namespace
+
+std::string dumpPlanDiff(const RenderPlan& oldPlan, const RenderPlan& newPlan,
+                         const PlanDiff& diff) {
+    std::ostringstream out;
+    out << "magda-plan-diff v1\n";
+    out << "ops=" << newPlan.ops.size() << " carried=" << diff.carried
+        << " retired=" << diff.retired.size() << "\n";
+
+    for (std::size_t i = 0; i < newPlan.ops.size(); ++i) {
+        const auto from = i < diff.carriedFrom.size() ? diff.carriedFrom[i] : INVALID_OP_ID;
+
+        std::ostringstream line;
+        line << "[" << rightAligned(static_cast<int>(i), 3) << "] "
+             << padded(from == INVALID_OP_ID ? "new" : "carry", 7) << " "
+             << padded(toString(newPlan.ops[i].key), 30);
+
+        if (from != INVALID_OP_ID)
+            line << " from=" << toString(oldPlan.ops[static_cast<std::size_t>(from)].key);
+
+        // Trailing spaces would not survive the repo's whitespace hook, which
+        // would rewrite every golden the first time one was committed.
+        auto text = line.str();
+        while (!text.empty() && text.back() == ' ')
+            text.pop_back();
+
+        out << text << "\n";
+    }
+
+    for (const auto op : diff.retired)
+        out << "retired " << toString(oldPlan.ops[static_cast<std::size_t>(op)].key) << "\n";
+
+    return out.str();
+}
+
+}  // namespace magda::engine

--- a/magda/engine/plan/PlanDiffDump.hpp
+++ b/magda/engine/plan/PlanDiffDump.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <string>
+
+#include "plan/PlanDiff.hpp"
+#include "plan/RenderPlan.hpp"
+
+namespace magda::engine {
+
+/**
+ * @brief Render a diff between two plans as canonical text.
+ *
+ * What the differ decided, by op key rather than by op index: an op that
+ * carried says which key it carried from, and a retired op says which key went
+ * away. Indices move whenever anything is inserted ahead of an op, so a golden
+ * written in terms of them would churn on edits that carried everything
+ * correctly.
+ *
+ * Shape:
+ * @code
+ * magda-plan-diff v1
+ * ops=13 carried=12 retired=1
+ * [  0] carry   T1:clipAudio                   from=T1:clipAudio
+ * [  2] new     T1/D9:deviceProcess
+ * retired T1/D7:deviceProcess
+ * @endcode
+ */
+std::string dumpPlanDiff(const RenderPlan& oldPlan, const RenderPlan& newPlan,
+                         const PlanDiff& diff);
+
+}  // namespace magda::engine

--- a/magda/engine/plan/PlanDump.cpp
+++ b/magda/engine/plan/PlanDump.cpp
@@ -2,21 +2,13 @@
 
 #include <sstream>
 
+#include "plan/DumpFormat.hpp"
+
 namespace magda::engine {
 namespace {
 
-std::string padded(std::string text, std::size_t width) {
-    if (text.size() < width)
-        text.append(width - text.size(), ' ');
-    return text;
-}
-
-std::string rightAligned(int value, std::size_t width) {
-    auto text = std::to_string(value);
-    if (text.size() < width)
-        text.insert(text.begin(), static_cast<long>(width - text.size()), ' ');
-    return text;
-}
+using dump_format::padded;
+using dump_format::rightAligned;
 
 std::string describeInputs(const PlanOp& op) {
     if (op.inputs.empty())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,8 +70,6 @@ set(TEST_SOURCES
     test_momentary_param_button.cpp
     test_delta_solo.cpp
     test_hash_combine.cpp
-    PlanGoldenFixtures.cpp
-    test_plan_goldens.cpp
     test_waveform_editor_absolute_mode.cpp
     test_clip_batch_edit.cpp
     test_clip_commands.cpp
@@ -270,6 +268,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_plan_layout.cpp)
     list(APPEND TEST_SOURCES test_plan_diff.cpp)
     list(APPEND TEST_SOURCES test_plan_crossfade.cpp)
+    # Plan goldens (#2076). Fixtures and runner both reach into magda_engine.
+    list(APPEND TEST_SOURCES PlanGoldenFixtures.cpp)
+    list(APPEND TEST_SOURCES test_plan_goldens.cpp)
     list(APPEND TEST_SOURCES test_engine_session.cpp)
     list(APPEND TEST_SOURCES test_tempo_map.cpp)
     list(APPEND TEST_SOURCES test_transport_clock.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,8 @@ set(TEST_SOURCES
     test_momentary_param_button.cpp
     test_delta_solo.cpp
     test_hash_combine.cpp
+    PlanGoldenFixtures.cpp
+    test_plan_goldens.cpp
     test_waveform_editor_absolute_mode.cpp
     test_clip_batch_edit.cpp
     test_clip_commands.cpp
@@ -340,6 +342,10 @@ target_compile_definitions(magda_tests
     PRIVATE
     MAGDA_REPO_ROOT="${CMAKE_SOURCE_DIR}"
     MAGDA_AUDIO_FIXTURES_DIR="${CMAKE_SOURCE_DIR}/tests/fixtures/audio"
+    # Plan goldens (#2076) live in the source tree, so an intended change to
+    # the compiler shows up as a reviewable diff rather than a rewritten
+    # build artefact.
+    MAGDA_PLAN_GOLDEN_DIR="${CMAKE_SOURCE_DIR}/tests/goldens/plan"
     # The shared test engine must NOT auto-wire the live Tempo lane sync: it
     # attaches to the AutomationManager singleton and would perturb other tests.
     # TempoLaneSync is tested directly in test_tempo_lane_sync_juce.cpp instead.

--- a/tests/PlanGoldenFixtures.cpp
+++ b/tests/PlanGoldenFixtures.cpp
@@ -55,7 +55,7 @@ DeviceInfo instrument(DeviceId id) {
 
 /// Where a device sits, as the key its process op will carry. The runner
 /// requires it to match one op exactly, so a fixture cannot name a location
-/// that does not exist and get silence.
+/// that does not exist and get silence instead of a failure.
 engine::OpKey deviceAt(TrackId trackId, DeviceId deviceId, RackId rackId = INVALID_RACK_ID,
                        ChainId chainId = INVALID_CHAIN_ID) {
     engine::OpKey key;

--- a/tests/PlanGoldenFixtures.cpp
+++ b/tests/PlanGoldenFixtures.cpp
@@ -53,6 +53,20 @@ DeviceInfo instrument(DeviceId id) {
     return device;
 }
 
+/// Where a device sits, as the key its process op will carry. The runner
+/// requires it to match one op exactly, so a fixture cannot name a location
+/// that does not exist and get silence.
+engine::OpKey deviceAt(TrackId trackId, DeviceId deviceId, RackId rackId = INVALID_RACK_ID,
+                       ChainId chainId = INVALID_CHAIN_ID) {
+    engine::OpKey key;
+    key.trackId = trackId;
+    key.rackId = rackId;
+    key.chainId = chainId;
+    key.deviceId = deviceId;
+    key.role = engine::OpRole::DeviceProcess;
+    return key;
+}
+
 /// Device meters off unless a fixture is about them: they are three ops per
 /// slot and they bury everything else in the dump.
 engine::CompileOptions withoutMeters() {
@@ -107,7 +121,7 @@ Fixture fanIn() {
 
     // The unequal path the delays exist for. Only the device on track 1
     // reports latency, so track 2 is the one that has to be held back.
-    value.deviceLatency = {{7, 64}};
+    value.deviceLatency = {{deviceAt(1, 7), 64}};
     return value;
 }
 
@@ -126,7 +140,7 @@ Fixture cascadedLatency() {
 
     // Three different numbers, so a dump that summed them in the wrong order
     // would not land on the right total by luck.
-    value.deviceLatency = {{7, 32}, {8, 128}, {9, 16}};
+    value.deviceLatency = {{deviceAt(1, 7), 32}, {deviceAt(1, 8), 128}, {deviceAt(2, 9), 16}};
     return value;
 }
 
@@ -150,7 +164,7 @@ Fixture rackChains() {
     value.options = withoutMeters();
 
     // Unequal chains, so the rack's own mix has something to align.
-    value.deviceLatency = {{10, 48}};
+    value.deviceLatency = {{deviceAt(1, 10, 5, 10), 48}};
     return value;
 }
 

--- a/tests/PlanGoldenFixtures.cpp
+++ b/tests/PlanGoldenFixtures.cpp
@@ -1,0 +1,260 @@
+#include "PlanGoldenFixtures.hpp"
+
+#include <memory>
+#include <utility>
+
+#include "core/RackInfo.hpp"
+
+/**
+ * @file PlanGoldenFixtures.cpp
+ * @brief The projects the plan compiler is pinned against (#2076).
+ *
+ * Each fixture names one decision the compiler makes and builds the smallest
+ * project that forces it. Small on purpose: a golden's whole value is that a
+ * human can read the diff and say whether the change was meant, and a fixture
+ * with four tracks of everything produces a diff nobody reads.
+ *
+ * They are model values only. Nothing here compiles, dumps or compares.
+ */
+
+namespace magda::goldens {
+namespace {
+
+TrackInfo track(TrackId id, TrackType type = TrackType::Audio) {
+    TrackInfo value;
+    value.id = id;
+    value.type = type;
+    value.name = "Track " + juce::String(id);
+    value.audioOutputDevice = "master";
+    return value;
+}
+
+TrackInfo master() {
+    auto value = track(MASTER_TRACK_ID, TrackType::Master);
+    value.audioOutputDevice = {};
+    return value;
+}
+
+DeviceInfo effect(DeviceId id) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Effect " + juce::String(id);
+    device.deviceType = DeviceType::Effect;
+    return device;
+}
+
+DeviceInfo instrument(DeviceId id) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Instrument " + juce::String(id);
+    device.deviceType = DeviceType::Instrument;
+    device.isInstrument = true;
+    device.canReceiveMidi = true;
+    return device;
+}
+
+/// Device meters off unless a fixture is about them: they are three ops per
+/// slot and they bury everything else in the dump.
+engine::CompileOptions withoutMeters() {
+    engine::CompileOptions options;
+    options.deviceMeters = false;
+    return options;
+}
+
+// --- the fixtures ------------------------------------------------------------
+
+Fixture bareTrack() {
+    Fixture value;
+    value.name = "bare-track";
+    value.covers = "one audio track into master: the smallest whole plan there is";
+    value.tracks = {track(1)};
+    value.master = master();
+    value.options = withoutMeters();
+    return value;
+}
+
+Fixture deviceChain() {
+    Fixture value;
+    value.name = "device-chain";
+    value.covers = "chain order, and the three ops a device slot compiles to";
+    value.tracks = {track(1)};
+    value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect(7)));
+    value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect(8)));
+    value.master = master();
+    return value;
+}
+
+Fixture instrumentTrack() {
+    Fixture value;
+    value.name = "instrument-track";
+    value.covers = "a MIDI clip reaching an instrument, and the audio leaving it";
+    value.tracks = {track(1)};
+    value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(instrument(3)));
+    value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect(7)));
+    value.master = master();
+    value.options = withoutMeters();
+    return value;
+}
+
+Fixture fanIn() {
+    Fixture value;
+    value.name = "fan-in";
+    value.covers = "two tracks meeting at master: where the delays go, and in what order";
+    value.tracks = {track(1), track(2)};
+    value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect(7)));
+    value.master = master();
+    value.options = withoutMeters();
+
+    // The unequal path the delays exist for. Only the device on track 1
+    // reports latency, so track 2 is the one that has to be held back.
+    value.deviceLatency = {{7, 64}};
+    return value;
+}
+
+Fixture cascadedLatency() {
+    Fixture value;
+    value.name = "cascaded-latency";
+    value.covers = "latency accumulating along a chain, and a send arriving carrying it";
+    value.tracks = {track(1), track(2, TrackType::Aux)};
+    value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect(7)));
+    value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect(8)));
+    value.tracks[0].sends.push_back(SendInfo{0, 0.5f, false, 2});
+    value.tracks[1].auxBusIndex = 0;
+    value.tracks[1].chain.fxChainElements.push_back(makeDeviceElement(effect(9)));
+    value.master = master();
+    value.options = withoutMeters();
+
+    // Three different numbers, so a dump that summed them in the wrong order
+    // would not land on the right total by luck.
+    value.deviceLatency = {{7, 32}, {8, 128}, {9, 16}};
+    return value;
+}
+
+Fixture rackChains() {
+    Fixture value;
+    value.name = "rack-chains";
+    value.covers = "two parallel chains, their mix, and the fader over it";
+
+    auto rack = std::make_unique<RackInfo>();
+    rack->id = 5;
+    for (const ChainId chainId : {ChainId{10}, ChainId{11}}) {
+        ChainInfo chain;
+        chain.id = chainId;
+        chain.elements.push_back(makeDeviceElement(effect(static_cast<DeviceId>(chainId))));
+        rack->chains.push_back(std::move(chain));
+    }
+
+    value.tracks = {track(1)};
+    value.tracks[0].chain.fxChainElements.push_back(ChainElement{std::move(rack)});
+    value.master = master();
+    value.options = withoutMeters();
+
+    // Unequal chains, so the rack's own mix has something to align.
+    value.deviceLatency = {{10, 48}};
+    return value;
+}
+
+Fixture sidechain() {
+    Fixture value;
+    value.name = "sidechain";
+    value.covers = "a device's key input, taken from another track";
+
+    auto compressor = effect(7);
+    compressor.sidechain.type = SidechainConfig::Type::Audio;
+    compressor.sidechain.sourceTrackId = 2;
+
+    value.tracks = {track(1), track(2)};
+    value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(compressor));
+    value.master = master();
+    value.options = withoutMeters();
+    return value;
+}
+
+Fixture groupRouting() {
+    Fixture value;
+    value.name = "group-routing";
+    value.covers = "a track routed to a group rather than to master";
+    value.tracks = {track(1), track(2, TrackType::Group)};
+    value.tracks[0].audioOutputDevice = "track:2";
+    value.tracks[1].chain.fxChainElements.push_back(makeDeviceElement(effect(7)));
+    value.master = master();
+    value.options = withoutMeters();
+    return value;
+}
+
+/// An edit that keeps everything it can. The differ's job is to carry every op
+/// the edit did not touch, so the fixture that pins it has to have plenty for
+/// it to get wrong: a device inserted ahead of others moves every index behind
+/// it, and an index-keyed differ would report them all as new.
+Fixture insertDevice() {
+    Fixture value;
+    value.name = "edit-insert-device";
+    value.covers = "op identity across an insert: what carries when indices all move";
+    value.tracks = {track(1), track(2)};
+    value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect(7)));
+    value.tracks[1].chain.fxChainElements.push_back(makeDeviceElement(effect(8)));
+    value.master = master();
+    value.options = withoutMeters();
+
+    value.editedTracks = value.tracks;
+    value.editedTracks[0].chain.fxChainElements.insert(
+        value.editedTracks[0].chain.fxChainElements.begin(), makeDeviceElement(effect(9)));
+    return value;
+}
+
+/// An edit that retires something. A removed device's ops have nowhere to
+/// carry to, and the track behind it re-routes onto what is left.
+Fixture removeDevice() {
+    Fixture value;
+    value.name = "edit-remove-device";
+    value.covers = "op identity across a removal: what retires, and what re-routes";
+    value.tracks = {track(1)};
+    value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect(7)));
+    value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect(8)));
+    value.master = master();
+    value.options = withoutMeters();
+
+    value.editedTracks = value.tracks;
+    value.editedTracks[0].chain.fxChainElements.erase(
+        value.editedTracks[0].chain.fxChainElements.begin());
+    return value;
+}
+
+/// An edit that moves an audio edge, which is what the crossfade pass exists
+/// for (#2019). Reordering two devices moves what feeds what without adding or
+/// removing anything, so every fade in the golden is a fade the pass chose.
+Fixture reorderDevices() {
+    Fixture value;
+    value.name = "edit-reorder-devices";
+    value.covers = "the fades a moved edge earns, and the ops they become";
+    value.tracks = {track(1)};
+    value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect(7)));
+    value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect(8)));
+    value.master = master();
+    value.options = withoutMeters();
+
+    value.editedTracks = value.tracks;
+    std::swap(value.editedTracks[0].chain.fxChainElements[0],
+              value.editedTracks[0].chain.fxChainElements[1]);
+    return value;
+}
+
+}  // namespace
+
+std::vector<Fixture> planFixtures() {
+    std::vector<Fixture> fixtures;
+    fixtures.push_back(bareTrack());
+    fixtures.push_back(deviceChain());
+    fixtures.push_back(instrumentTrack());
+    fixtures.push_back(fanIn());
+    fixtures.push_back(cascadedLatency());
+    fixtures.push_back(rackChains());
+    fixtures.push_back(sidechain());
+    fixtures.push_back(groupRouting());
+    fixtures.push_back(insertDevice());
+    fixtures.push_back(removeDevice());
+    fixtures.push_back(reorderDevices());
+    return fixtures;
+}
+
+}  // namespace magda::goldens

--- a/tests/PlanGoldenFixtures.hpp
+++ b/tests/PlanGoldenFixtures.hpp
@@ -15,11 +15,11 @@ namespace magda::goldens {
  * how, belongs to the runner: a fixture that knew about its own golden file
  * would be a fixture that could be written to make one pass.
  *
- * `deviceLatency` is per device id rather than per op, because a fixture is
- * written before the plan exists and op indices are the compiler's answer, not
- * the fixture's question. Anything not named here reports zero, so a fixture
- * that is not about latency writes nothing and gets a plan with no delays that
- * hold anything.
+ * `deviceLatency` is keyed by where a device sits rather than by op index,
+ * because a fixture is written before the plan exists and op indices are the
+ * compiler's answer, not the fixture's question. Anything not named here
+ * reports zero, so a fixture that is not about latency writes nothing and gets
+ * a plan with no delays that hold anything.
  */
 struct Fixture {
     /// Names the golden file, so it has to be unique and stable. Renaming one
@@ -34,8 +34,15 @@ struct Fixture {
     TrackInfo master;
     engine::CompileOptions options;
 
-    /// Device latencies in samples, as `{deviceId, samples}`.
-    std::vector<std::pair<DeviceId, int>> deviceLatency;
+    /// Device latencies in samples, keyed by the device's whole location.
+    ///
+    /// A DeviceId alone does not say which device: it is allocated per
+    /// section, so the same one can appear on an FX slot and a post-FX slot,
+    /// and a fixture keyed on it would quietly give both the same latency and
+    /// pin a golden for a graph it did not describe. The runner requires each
+    /// entry to match exactly one Device op, so a location that names nothing
+    /// fails rather than contributing nothing.
+    std::vector<std::pair<engine::OpKey, int>> deviceLatency;
 
     /// A second project, compiled and diffed against the first. Empty where
     /// the fixture is not about what survives an edit.

--- a/tests/PlanGoldenFixtures.hpp
+++ b/tests/PlanGoldenFixtures.hpp
@@ -36,12 +36,15 @@ struct Fixture {
 
     /// Device latencies in samples, keyed by the op the latency belongs to.
     ///
-    /// The whole key rather than the device id alone. Device ids are
-    /// project-unique, so the id would in fact be enough today, but a fixture
-    /// stating where it means makes that an assumption the fixture does not
-    /// depend on. The runner requires each entry to match exactly one Device
-    /// op, which is what turns a mistyped location into a failure instead of a
-    /// golden quietly pinned with no delays in it.
+    /// The whole key rather than the device id alone, because a device id does
+    /// not identify a device: TrackManager allocates them per section, so one
+    /// track's FX and post-FX chains can both hold id 3. Op keys do not carry
+    /// a section either, which is its own problem and not this file's, but a
+    /// fixture that states where it means is at least not adding to it.
+    ///
+    /// The runner requires each entry to match exactly one Device op, which is
+    /// what turns a mistyped location into a failure instead of a golden
+    /// quietly pinned with no delays in it.
     std::vector<std::pair<engine::OpKey, int>> deviceLatency;
 
     /// A second project, compiled and diffed against the first. Empty where

--- a/tests/PlanGoldenFixtures.hpp
+++ b/tests/PlanGoldenFixtures.hpp
@@ -34,14 +34,14 @@ struct Fixture {
     TrackInfo master;
     engine::CompileOptions options;
 
-    /// Device latencies in samples, keyed by the device's whole location.
+    /// Device latencies in samples, keyed by the op the latency belongs to.
     ///
-    /// A DeviceId alone does not say which device: it is allocated per
-    /// section, so the same one can appear on an FX slot and a post-FX slot,
-    /// and a fixture keyed on it would quietly give both the same latency and
-    /// pin a golden for a graph it did not describe. The runner requires each
-    /// entry to match exactly one Device op, so a location that names nothing
-    /// fails rather than contributing nothing.
+    /// The whole key rather than the device id alone. Device ids are
+    /// project-unique, so the id would in fact be enough today, but a fixture
+    /// stating where it means makes that an assumption the fixture does not
+    /// depend on. The runner requires each entry to match exactly one Device
+    /// op, which is what turns a mistyped location into a failure instead of a
+    /// golden quietly pinned with no delays in it.
     std::vector<std::pair<engine::OpKey, int>> deviceLatency;
 
     /// A second project, compiled and diffed against the first. Empty where

--- a/tests/PlanGoldenFixtures.hpp
+++ b/tests/PlanGoldenFixtures.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "core/TrackInfo.hpp"
+#include "plan/PlanCompiler.hpp"
+
+namespace magda::goldens {
+
+/**
+ * @brief One project the plan compiler is pinned against.
+ *
+ * A fixture is model values and nothing else. What gets dumped from it, and
+ * how, belongs to the runner: a fixture that knew about its own golden file
+ * would be a fixture that could be written to make one pass.
+ *
+ * `deviceLatency` is per device id rather than per op, because a fixture is
+ * written before the plan exists and op indices are the compiler's answer, not
+ * the fixture's question. Anything not named here reports zero, so a fixture
+ * that is not about latency writes nothing and gets a plan with no delays that
+ * hold anything.
+ */
+struct Fixture {
+    /// Names the golden file, so it has to be unique and stable. Renaming one
+    /// orphans its file, which the runner reports rather than ignores.
+    std::string name;
+
+    /// What the fixture is for, printed into the golden so the file explains
+    /// itself to whoever a failing diff lands on.
+    std::string covers;
+
+    std::vector<TrackInfo> tracks;
+    TrackInfo master;
+    engine::CompileOptions options;
+
+    /// Device latencies in samples, as `{deviceId, samples}`.
+    std::vector<std::pair<DeviceId, int>> deviceLatency;
+
+    /// A second project, compiled and diffed against the first. Empty where
+    /// the fixture is not about what survives an edit.
+    std::vector<TrackInfo> editedTracks;
+};
+
+/** Every fixture, in the order their goldens are written. */
+std::vector<Fixture> planFixtures();
+
+}  // namespace magda::goldens

--- a/tests/goldens/plan/bare-track.txt
+++ b/tests/goldens/plan/bare-track.txt
@@ -1,0 +1,33 @@
+# bare-track
+# one audio track into master: the smallest whole plan there is
+#
+# Generated. See tests/test_plan_goldens.cpp to regenerate.
+
+== plan ==
+magda-render-plan v1
+ops=10 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Fader       det   T1:trackFader                  in=1:0,-            out=audio       deps=1
+[  3] Meter       det   T1:trackMeter                  in=2:0              out=audio       deps=1
+[  4] Gain        det   T1:trackMute                   in=3:0              out=audio       deps=1
+[  5] MixAudio    det   T-2:trackAudioInput            in=4:0              out=audio       deps=1
+[  6] Fader       det   T-2:trackFader                 in=5:0,-            out=audio       deps=1
+[  7] Meter       det   T-2:trackMeter                 in=6:0              out=audio       deps=1
+[  8] Gain        det   T-2:trackMute                  in=7:0              out=audio       deps=1
+[  9] Output      det   T-2:hardwareOutput             in=8:0              out=-           deps=1
+ready=0
+
+== layout ==
+magda-plan-layout v1
+audioSlots=1 midiSlots=0 outputLatency=0
+[  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
+[  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
+[  2] Fader       T1:trackFader                  lat=0       ports=a0          inplace
+[  3] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
+[  4] Gain        T1:trackMute                   lat=0       ports=a0          inplace
+[  5] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
+[  6] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
+[  7] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
+[  8] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
+[  9] Output      T-2:hardwareOutput             lat=-       ports=-

--- a/tests/goldens/plan/cascaded-latency.txt
+++ b/tests/goldens/plan/cascaded-latency.txt
@@ -1,0 +1,59 @@
+# cascaded-latency
+# latency accumulating along a chain, and a send arriving carrying it
+#
+# Generated. See tests/test_plan_goldens.cpp to regenerate.
+
+== plan ==
+magda-render-plan v1
+ops=23 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
+[  4] Device      det   T1/D8:deviceProcess            in=3:0,-,-          out=audio       deps=1
+[  5] Gain        det   T1/D8:deviceGain               in=4:0              out=audio       deps=1
+[  6] Fader       det   T1:trackFader                  in=5:0,-            out=audio       deps=1
+[  7] SendTap     det   T1:sendTap                     in=6:0              out=audio       deps=1
+[  8] Meter       det   T1:trackMeter                  in=6:0              out=audio       deps=1
+[  9] Gain        det   T1:trackMute                   in=8:0              out=audio       deps=1
+[ 10] MixAudio    det   T2:trackAudioInput             in=7:0              out=audio       deps=1
+[ 11] Device      det   T2/D9:deviceProcess            in=10:0,-,-         out=audio       deps=1
+[ 12] Gain        det   T2/D9:deviceGain               in=11:0             out=audio       deps=1
+[ 13] Fader       det   T2:trackFader                  in=12:0,-           out=audio       deps=1
+[ 14] Meter       det   T2:trackMeter                  in=13:0             out=audio       deps=1
+[ 15] Gain        det   T2:trackMute                   in=14:0             out=audio       deps=1
+[ 16] Delay       det   T-2:mixInputDelay              in=9:0              out=audio       deps=1
+[ 17] Delay       det   T-2:mixInputDelay#1            in=15:0             out=audio       deps=1
+[ 18] MixAudio    det   T-2:trackAudioInput            in=16:0,17:0        out=audio       deps=2
+[ 19] Fader       det   T-2:trackFader                 in=18:0,-           out=audio       deps=1
+[ 20] Meter       det   T-2:trackMeter                 in=19:0             out=audio       deps=1
+[ 21] Gain        det   T-2:trackMute                  in=20:0             out=audio       deps=1
+[ 22] Output      det   T-2:hardwareOutput             in=21:0             out=-           deps=1
+ready=0
+
+== layout ==
+magda-plan-layout v1
+audioSlots=3 midiSlots=0 outputLatency=176
+[  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
+[  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
+[  2] Device      T1/D7:deviceProcess            lat=32      ports=a0          inplace
+[  3] Gain        T1/D7:deviceGain               lat=32      ports=a0          inplace
+[  4] Device      T1/D8:deviceProcess            lat=160     ports=a0          inplace
+[  5] Gain        T1/D8:deviceGain               lat=160     ports=a0          inplace
+[  6] Fader       T1:trackFader                  lat=160     ports=a0          inplace
+[  7] SendTap     T1:sendTap                     lat=160     ports=a1
+[  8] Meter       T1:trackMeter                  lat=160     ports=a2
+[  9] Gain        T1:trackMute                   lat=160     ports=a2          inplace
+[ 10] MixAudio    T2:trackAudioInput             lat=160     ports=a1          inplace
+[ 11] Device      T2/D9:deviceProcess            lat=176     ports=a1          inplace
+[ 12] Gain        T2/D9:deviceGain               lat=176     ports=a1          inplace
+[ 13] Fader       T2:trackFader                  lat=176     ports=a1          inplace
+[ 14] Meter       T2:trackMeter                  lat=176     ports=a1          inplace
+[ 15] Gain        T2:trackMute                   lat=176     ports=a1          inplace
+[ 16] Delay       T-2:mixInputDelay              lat=176     ports=a2          hold=16 inplace
+[ 17] Delay       T-2:mixInputDelay#1            lat=176     ports=a1          hold=0 elided
+[ 18] MixAudio    T-2:trackAudioInput            lat=176     ports=a2          inplace
+[ 19] Fader       T-2:trackFader                 lat=176     ports=a2          inplace
+[ 20] Meter       T-2:trackMeter                 lat=176     ports=a2          inplace
+[ 21] Gain        T-2:trackMute                  lat=176     ports=a2          inplace
+[ 22] Output      T-2:hardwareOutput             lat=-       ports=-

--- a/tests/goldens/plan/device-chain.txt
+++ b/tests/goldens/plan/device-chain.txt
@@ -1,0 +1,45 @@
+# device-chain
+# chain order, and the three ops a device slot compiles to
+#
+# Generated. See tests/test_plan_goldens.cpp to regenerate.
+
+== plan ==
+magda-render-plan v1
+ops=16 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
+[  4] Meter       det   T1/D7:deviceMeter              in=3:0              out=audio       deps=1
+[  5] Device      det   T1/D8:deviceProcess            in=4:0,-,-          out=audio       deps=1
+[  6] Gain        det   T1/D8:deviceGain               in=5:0              out=audio       deps=1
+[  7] Meter       det   T1/D8:deviceMeter              in=6:0              out=audio       deps=1
+[  8] Fader       det   T1:trackFader                  in=7:0,-            out=audio       deps=1
+[  9] Meter       det   T1:trackMeter                  in=8:0              out=audio       deps=1
+[ 10] Gain        det   T1:trackMute                   in=9:0              out=audio       deps=1
+[ 11] MixAudio    det   T-2:trackAudioInput            in=10:0             out=audio       deps=1
+[ 12] Fader       det   T-2:trackFader                 in=11:0,-           out=audio       deps=1
+[ 13] Meter       det   T-2:trackMeter                 in=12:0             out=audio       deps=1
+[ 14] Gain        det   T-2:trackMute                  in=13:0             out=audio       deps=1
+[ 15] Output      det   T-2:hardwareOutput             in=14:0             out=-           deps=1
+ready=0
+
+== layout ==
+magda-plan-layout v1
+audioSlots=1 midiSlots=0 outputLatency=0
+[  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
+[  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
+[  2] Device      T1/D7:deviceProcess            lat=0       ports=a0          inplace
+[  3] Gain        T1/D7:deviceGain               lat=0       ports=a0          inplace
+[  4] Meter       T1/D7:deviceMeter              lat=0       ports=a0          inplace
+[  5] Device      T1/D8:deviceProcess            lat=0       ports=a0          inplace
+[  6] Gain        T1/D8:deviceGain               lat=0       ports=a0          inplace
+[  7] Meter       T1/D8:deviceMeter              lat=0       ports=a0          inplace
+[  8] Fader       T1:trackFader                  lat=0       ports=a0          inplace
+[  9] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
+[ 10] Gain        T1:trackMute                   lat=0       ports=a0          inplace
+[ 11] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
+[ 12] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
+[ 13] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
+[ 14] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
+[ 15] Output      T-2:hardwareOutput             lat=-       ports=-

--- a/tests/goldens/plan/edit-insert-device.txt
+++ b/tests/goldens/plan/edit-insert-device.txt
@@ -1,0 +1,141 @@
+# edit-insert-device
+# op identity across an insert: what carries when indices all move
+#
+# Generated. See tests/test_plan_goldens.cpp to regenerate.
+
+== plan ==
+magda-render-plan v1
+ops=21 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
+[  4] Fader       det   T1:trackFader                  in=3:0,-            out=audio       deps=1
+[  5] Meter       det   T1:trackMeter                  in=4:0              out=audio       deps=1
+[  6] Gain        det   T1:trackMute                   in=5:0              out=audio       deps=1
+[  7] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
+[  8] MixAudio    det   T2:trackAudioInput             in=7:0              out=audio       deps=1
+[  9] Device      det   T2/D8:deviceProcess            in=8:0,-,-          out=audio       deps=1
+[ 10] Gain        det   T2/D8:deviceGain               in=9:0              out=audio       deps=1
+[ 11] Fader       det   T2:trackFader                  in=10:0,-           out=audio       deps=1
+[ 12] Meter       det   T2:trackMeter                  in=11:0             out=audio       deps=1
+[ 13] Gain        det   T2:trackMute                   in=12:0             out=audio       deps=1
+[ 14] Delay       det   T-2:mixInputDelay              in=6:0              out=audio       deps=1
+[ 15] Delay       det   T-2:mixInputDelay#1            in=13:0             out=audio       deps=1
+[ 16] MixAudio    det   T-2:trackAudioInput            in=14:0,15:0        out=audio       deps=2
+[ 17] Fader       det   T-2:trackFader                 in=16:0,-           out=audio       deps=1
+[ 18] Meter       det   T-2:trackMeter                 in=17:0             out=audio       deps=1
+[ 19] Gain        det   T-2:trackMute                  in=18:0             out=audio       deps=1
+[ 20] Output      det   T-2:hardwareOutput             in=19:0             out=-           deps=1
+ready=0,7
+
+== layout ==
+magda-plan-layout v1
+audioSlots=2 midiSlots=0 outputLatency=0
+[  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
+[  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
+[  2] Device      T1/D7:deviceProcess            lat=0       ports=a0          inplace
+[  3] Gain        T1/D7:deviceGain               lat=0       ports=a0          inplace
+[  4] Fader       T1:trackFader                  lat=0       ports=a0          inplace
+[  5] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
+[  6] Gain        T1:trackMute                   lat=0       ports=a0          inplace
+[  7] ClipAudio   T2:clipAudio                   lat=0       ports=a1
+[  8] MixAudio    T2:trackAudioInput             lat=0       ports=a1          inplace
+[  9] Device      T2/D8:deviceProcess            lat=0       ports=a1          inplace
+[ 10] Gain        T2/D8:deviceGain               lat=0       ports=a1          inplace
+[ 11] Fader       T2:trackFader                  lat=0       ports=a1          inplace
+[ 12] Meter       T2:trackMeter                  lat=0       ports=a1          inplace
+[ 13] Gain        T2:trackMute                   lat=0       ports=a1          inplace
+[ 14] Delay       T-2:mixInputDelay              lat=0       ports=a0          hold=0 elided
+[ 15] Delay       T-2:mixInputDelay#1            lat=0       ports=a1          hold=0 elided
+[ 16] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
+[ 17] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
+[ 18] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
+[ 19] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
+[ 20] Output      T-2:hardwareOutput             lat=-       ports=-
+
+== edited plan ==
+magda-render-plan v1
+ops=23 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/D9:deviceProcess            in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/D9:deviceGain               in=2:0              out=audio       deps=1
+[  4] Device      det   T1/D7:deviceProcess            in=3:0,-,-          out=audio       deps=1
+[  5] Gain        det   T1/D7:deviceGain               in=4:0              out=audio       deps=1
+[  6] Fader       det   T1:trackFader                  in=5:0,-            out=audio       deps=1
+[  7] Meter       det   T1:trackMeter                  in=6:0              out=audio       deps=1
+[  8] Gain        det   T1:trackMute                   in=7:0              out=audio       deps=1
+[  9] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
+[ 10] MixAudio    det   T2:trackAudioInput             in=9:0              out=audio       deps=1
+[ 11] Device      det   T2/D8:deviceProcess            in=10:0,-,-         out=audio       deps=1
+[ 12] Gain        det   T2/D8:deviceGain               in=11:0             out=audio       deps=1
+[ 13] Fader       det   T2:trackFader                  in=12:0,-           out=audio       deps=1
+[ 14] Meter       det   T2:trackMeter                  in=13:0             out=audio       deps=1
+[ 15] Gain        det   T2:trackMute                   in=14:0             out=audio       deps=1
+[ 16] Delay       det   T-2:mixInputDelay              in=8:0              out=audio       deps=1
+[ 17] Delay       det   T-2:mixInputDelay#1            in=15:0             out=audio       deps=1
+[ 18] MixAudio    det   T-2:trackAudioInput            in=16:0,17:0        out=audio       deps=2
+[ 19] Fader       det   T-2:trackFader                 in=18:0,-           out=audio       deps=1
+[ 20] Meter       det   T-2:trackMeter                 in=19:0             out=audio       deps=1
+[ 21] Gain        det   T-2:trackMute                  in=20:0             out=audio       deps=1
+[ 22] Output      det   T-2:hardwareOutput             in=21:0             out=-           deps=1
+ready=0,9
+
+== diff ==
+magda-plan-diff v1
+ops=23 carried=20 retired=1
+[  0] carry   T1:clipAudio                   from=T1:clipAudio
+[  1] carry   T1:trackAudioInput             from=T1:trackAudioInput
+[  2] new     T1/D9:deviceProcess
+[  3] new     T1/D9:deviceGain
+[  4] new     T1/D7:deviceProcess
+[  5] carry   T1/D7:deviceGain               from=T1/D7:deviceGain
+[  6] carry   T1:trackFader                  from=T1:trackFader
+[  7] carry   T1:trackMeter                  from=T1:trackMeter
+[  8] carry   T1:trackMute                   from=T1:trackMute
+[  9] carry   T2:clipAudio                   from=T2:clipAudio
+[ 10] carry   T2:trackAudioInput             from=T2:trackAudioInput
+[ 11] carry   T2/D8:deviceProcess            from=T2/D8:deviceProcess
+[ 12] carry   T2/D8:deviceGain               from=T2/D8:deviceGain
+[ 13] carry   T2:trackFader                  from=T2:trackFader
+[ 14] carry   T2:trackMeter                  from=T2:trackMeter
+[ 15] carry   T2:trackMute                   from=T2:trackMute
+[ 16] carry   T-2:mixInputDelay              from=T-2:mixInputDelay
+[ 17] carry   T-2:mixInputDelay#1            from=T-2:mixInputDelay#1
+[ 18] carry   T-2:trackAudioInput            from=T-2:trackAudioInput
+[ 19] carry   T-2:trackFader                 from=T-2:trackFader
+[ 20] carry   T-2:trackMeter                 from=T-2:trackMeter
+[ 21] carry   T-2:trackMute                  from=T-2:trackMute
+[ 22] carry   T-2:hardwareOutput             from=T-2:hardwareOutput
+retired T1/D7:deviceProcess
+
+== crossfaded ==
+inserted=1 unfaded=0
+magda-render-plan v1
+ops=24 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/D9:deviceProcess            in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/D9:deviceGain               in=2:0              out=audio       deps=1
+[  4] Crossfade   det   T1/D7:edgeCrossfade(deviceProcess slot 0) in=1:0,3:0          out=audio       deps=2
+[  5] Device      det   T1/D7:deviceProcess            in=4:0,-,-          out=audio       deps=1
+[  6] Gain        det   T1/D7:deviceGain               in=5:0              out=audio       deps=1
+[  7] Fader       det   T1:trackFader                  in=6:0,-            out=audio       deps=1
+[  8] Meter       det   T1:trackMeter                  in=7:0              out=audio       deps=1
+[  9] Gain        det   T1:trackMute                   in=8:0              out=audio       deps=1
+[ 10] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
+[ 11] MixAudio    det   T2:trackAudioInput             in=10:0             out=audio       deps=1
+[ 12] Device      det   T2/D8:deviceProcess            in=11:0,-,-         out=audio       deps=1
+[ 13] Gain        det   T2/D8:deviceGain               in=12:0             out=audio       deps=1
+[ 14] Fader       det   T2:trackFader                  in=13:0,-           out=audio       deps=1
+[ 15] Meter       det   T2:trackMeter                  in=14:0             out=audio       deps=1
+[ 16] Gain        det   T2:trackMute                   in=15:0             out=audio       deps=1
+[ 17] Delay       det   T-2:mixInputDelay              in=9:0              out=audio       deps=1
+[ 18] Delay       det   T-2:mixInputDelay#1            in=16:0             out=audio       deps=1
+[ 19] MixAudio    det   T-2:trackAudioInput            in=17:0,18:0        out=audio       deps=2
+[ 20] Fader       det   T-2:trackFader                 in=19:0,-           out=audio       deps=1
+[ 21] Meter       det   T-2:trackMeter                 in=20:0             out=audio       deps=1
+[ 22] Gain        det   T-2:trackMute                  in=21:0             out=audio       deps=1
+[ 23] Output      det   T-2:hardwareOutput             in=22:0             out=-           deps=1
+ready=0,10

--- a/tests/goldens/plan/edit-remove-device.txt
+++ b/tests/goldens/plan/edit-remove-device.txt
@@ -1,0 +1,95 @@
+# edit-remove-device
+# op identity across a removal: what retires, and what re-routes
+#
+# Generated. See tests/test_plan_goldens.cpp to regenerate.
+
+== plan ==
+magda-render-plan v1
+ops=14 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
+[  4] Device      det   T1/D8:deviceProcess            in=3:0,-,-          out=audio       deps=1
+[  5] Gain        det   T1/D8:deviceGain               in=4:0              out=audio       deps=1
+[  6] Fader       det   T1:trackFader                  in=5:0,-            out=audio       deps=1
+[  7] Meter       det   T1:trackMeter                  in=6:0              out=audio       deps=1
+[  8] Gain        det   T1:trackMute                   in=7:0              out=audio       deps=1
+[  9] MixAudio    det   T-2:trackAudioInput            in=8:0              out=audio       deps=1
+[ 10] Fader       det   T-2:trackFader                 in=9:0,-            out=audio       deps=1
+[ 11] Meter       det   T-2:trackMeter                 in=10:0             out=audio       deps=1
+[ 12] Gain        det   T-2:trackMute                  in=11:0             out=audio       deps=1
+[ 13] Output      det   T-2:hardwareOutput             in=12:0             out=-           deps=1
+ready=0
+
+== layout ==
+magda-plan-layout v1
+audioSlots=1 midiSlots=0 outputLatency=0
+[  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
+[  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
+[  2] Device      T1/D7:deviceProcess            lat=0       ports=a0          inplace
+[  3] Gain        T1/D7:deviceGain               lat=0       ports=a0          inplace
+[  4] Device      T1/D8:deviceProcess            lat=0       ports=a0          inplace
+[  5] Gain        T1/D8:deviceGain               lat=0       ports=a0          inplace
+[  6] Fader       T1:trackFader                  lat=0       ports=a0          inplace
+[  7] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
+[  8] Gain        T1:trackMute                   lat=0       ports=a0          inplace
+[  9] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
+[ 10] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
+[ 11] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
+[ 12] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
+[ 13] Output      T-2:hardwareOutput             lat=-       ports=-
+
+== edited plan ==
+magda-render-plan v1
+ops=12 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/D8:deviceProcess            in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/D8:deviceGain               in=2:0              out=audio       deps=1
+[  4] Fader       det   T1:trackFader                  in=3:0,-            out=audio       deps=1
+[  5] Meter       det   T1:trackMeter                  in=4:0              out=audio       deps=1
+[  6] Gain        det   T1:trackMute                   in=5:0              out=audio       deps=1
+[  7] MixAudio    det   T-2:trackAudioInput            in=6:0              out=audio       deps=1
+[  8] Fader       det   T-2:trackFader                 in=7:0,-            out=audio       deps=1
+[  9] Meter       det   T-2:trackMeter                 in=8:0              out=audio       deps=1
+[ 10] Gain        det   T-2:trackMute                  in=9:0              out=audio       deps=1
+[ 11] Output      det   T-2:hardwareOutput             in=10:0             out=-           deps=1
+ready=0
+
+== diff ==
+magda-plan-diff v1
+ops=12 carried=11 retired=3
+[  0] carry   T1:clipAudio                   from=T1:clipAudio
+[  1] carry   T1:trackAudioInput             from=T1:trackAudioInput
+[  2] new     T1/D8:deviceProcess
+[  3] carry   T1/D8:deviceGain               from=T1/D8:deviceGain
+[  4] carry   T1:trackFader                  from=T1:trackFader
+[  5] carry   T1:trackMeter                  from=T1:trackMeter
+[  6] carry   T1:trackMute                   from=T1:trackMute
+[  7] carry   T-2:trackAudioInput            from=T-2:trackAudioInput
+[  8] carry   T-2:trackFader                 from=T-2:trackFader
+[  9] carry   T-2:trackMeter                 from=T-2:trackMeter
+[ 10] carry   T-2:trackMute                  from=T-2:trackMute
+[ 11] carry   T-2:hardwareOutput             from=T-2:hardwareOutput
+retired T1/D7:deviceProcess
+retired T1/D7:deviceGain
+retired T1/D8:deviceProcess
+
+== crossfaded ==
+inserted=0 unfaded=1
+magda-render-plan v1
+ops=12 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/D8:deviceProcess            in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/D8:deviceGain               in=2:0              out=audio       deps=1
+[  4] Fader       det   T1:trackFader                  in=3:0,-            out=audio       deps=1
+[  5] Meter       det   T1:trackMeter                  in=4:0              out=audio       deps=1
+[  6] Gain        det   T1:trackMute                   in=5:0              out=audio       deps=1
+[  7] MixAudio    det   T-2:trackAudioInput            in=6:0              out=audio       deps=1
+[  8] Fader       det   T-2:trackFader                 in=7:0,-            out=audio       deps=1
+[  9] Meter       det   T-2:trackMeter                 in=8:0              out=audio       deps=1
+[ 10] Gain        det   T-2:trackMute                  in=9:0              out=audio       deps=1
+[ 11] Output      det   T-2:hardwareOutput             in=10:0             out=-           deps=1
+ready=0

--- a/tests/goldens/plan/edit-reorder-devices.txt
+++ b/tests/goldens/plan/edit-reorder-devices.txt
@@ -1,0 +1,102 @@
+# edit-reorder-devices
+# the fades a moved edge earns, and the ops they become
+#
+# Generated. See tests/test_plan_goldens.cpp to regenerate.
+
+== plan ==
+magda-render-plan v1
+ops=14 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
+[  4] Device      det   T1/D8:deviceProcess            in=3:0,-,-          out=audio       deps=1
+[  5] Gain        det   T1/D8:deviceGain               in=4:0              out=audio       deps=1
+[  6] Fader       det   T1:trackFader                  in=5:0,-            out=audio       deps=1
+[  7] Meter       det   T1:trackMeter                  in=6:0              out=audio       deps=1
+[  8] Gain        det   T1:trackMute                   in=7:0              out=audio       deps=1
+[  9] MixAudio    det   T-2:trackAudioInput            in=8:0              out=audio       deps=1
+[ 10] Fader       det   T-2:trackFader                 in=9:0,-            out=audio       deps=1
+[ 11] Meter       det   T-2:trackMeter                 in=10:0             out=audio       deps=1
+[ 12] Gain        det   T-2:trackMute                  in=11:0             out=audio       deps=1
+[ 13] Output      det   T-2:hardwareOutput             in=12:0             out=-           deps=1
+ready=0
+
+== layout ==
+magda-plan-layout v1
+audioSlots=1 midiSlots=0 outputLatency=0
+[  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
+[  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
+[  2] Device      T1/D7:deviceProcess            lat=0       ports=a0          inplace
+[  3] Gain        T1/D7:deviceGain               lat=0       ports=a0          inplace
+[  4] Device      T1/D8:deviceProcess            lat=0       ports=a0          inplace
+[  5] Gain        T1/D8:deviceGain               lat=0       ports=a0          inplace
+[  6] Fader       T1:trackFader                  lat=0       ports=a0          inplace
+[  7] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
+[  8] Gain        T1:trackMute                   lat=0       ports=a0          inplace
+[  9] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
+[ 10] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
+[ 11] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
+[ 12] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
+[ 13] Output      T-2:hardwareOutput             lat=-       ports=-
+
+== edited plan ==
+magda-render-plan v1
+ops=14 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/D8:deviceProcess            in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/D8:deviceGain               in=2:0              out=audio       deps=1
+[  4] Device      det   T1/D7:deviceProcess            in=3:0,-,-          out=audio       deps=1
+[  5] Gain        det   T1/D7:deviceGain               in=4:0              out=audio       deps=1
+[  6] Fader       det   T1:trackFader                  in=5:0,-            out=audio       deps=1
+[  7] Meter       det   T1:trackMeter                  in=6:0              out=audio       deps=1
+[  8] Gain        det   T1:trackMute                   in=7:0              out=audio       deps=1
+[  9] MixAudio    det   T-2:trackAudioInput            in=8:0              out=audio       deps=1
+[ 10] Fader       det   T-2:trackFader                 in=9:0,-            out=audio       deps=1
+[ 11] Meter       det   T-2:trackMeter                 in=10:0             out=audio       deps=1
+[ 12] Gain        det   T-2:trackMute                  in=11:0             out=audio       deps=1
+[ 13] Output      det   T-2:hardwareOutput             in=12:0             out=-           deps=1
+ready=0
+
+== diff ==
+magda-plan-diff v1
+ops=14 carried=11 retired=3
+[  0] carry   T1:clipAudio                   from=T1:clipAudio
+[  1] carry   T1:trackAudioInput             from=T1:trackAudioInput
+[  2] new     T1/D8:deviceProcess
+[  3] carry   T1/D8:deviceGain               from=T1/D8:deviceGain
+[  4] new     T1/D7:deviceProcess
+[  5] carry   T1/D7:deviceGain               from=T1/D7:deviceGain
+[  6] new     T1:trackFader
+[  7] carry   T1:trackMeter                  from=T1:trackMeter
+[  8] carry   T1:trackMute                   from=T1:trackMute
+[  9] carry   T-2:trackAudioInput            from=T-2:trackAudioInput
+[ 10] carry   T-2:trackFader                 from=T-2:trackFader
+[ 11] carry   T-2:trackMeter                 from=T-2:trackMeter
+[ 12] carry   T-2:trackMute                  from=T-2:trackMute
+[ 13] carry   T-2:hardwareOutput             from=T-2:hardwareOutput
+retired T1/D7:deviceProcess
+retired T1/D8:deviceProcess
+retired T1:trackFader
+
+== crossfaded ==
+inserted=1 unfaded=2
+magda-render-plan v1
+ops=15 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/D8:deviceProcess            in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/D8:deviceGain               in=2:0              out=audio       deps=1
+[  4] Crossfade   det   T1/D7:edgeCrossfade(deviceProcess slot 0) in=1:0,3:0          out=audio       deps=2
+[  5] Device      det   T1/D7:deviceProcess            in=4:0,-,-          out=audio       deps=1
+[  6] Gain        det   T1/D7:deviceGain               in=5:0              out=audio       deps=1
+[  7] Fader       det   T1:trackFader                  in=6:0,-            out=audio       deps=1
+[  8] Meter       det   T1:trackMeter                  in=7:0              out=audio       deps=1
+[  9] Gain        det   T1:trackMute                   in=8:0              out=audio       deps=1
+[ 10] MixAudio    det   T-2:trackAudioInput            in=9:0              out=audio       deps=1
+[ 11] Fader       det   T-2:trackFader                 in=10:0,-           out=audio       deps=1
+[ 12] Meter       det   T-2:trackMeter                 in=11:0             out=audio       deps=1
+[ 13] Gain        det   T-2:trackMute                  in=12:0             out=audio       deps=1
+[ 14] Output      det   T-2:hardwareOutput             in=13:0             out=-           deps=1
+ready=0

--- a/tests/goldens/plan/fan-in.txt
+++ b/tests/goldens/plan/fan-in.txt
@@ -1,0 +1,51 @@
+# fan-in
+# two tracks meeting at master: where the delays go, and in what order
+#
+# Generated. See tests/test_plan_goldens.cpp to regenerate.
+
+== plan ==
+magda-render-plan v1
+ops=19 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
+[  4] Fader       det   T1:trackFader                  in=3:0,-            out=audio       deps=1
+[  5] Meter       det   T1:trackMeter                  in=4:0              out=audio       deps=1
+[  6] Gain        det   T1:trackMute                   in=5:0              out=audio       deps=1
+[  7] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
+[  8] MixAudio    det   T2:trackAudioInput             in=7:0              out=audio       deps=1
+[  9] Fader       det   T2:trackFader                  in=8:0,-            out=audio       deps=1
+[ 10] Meter       det   T2:trackMeter                  in=9:0              out=audio       deps=1
+[ 11] Gain        det   T2:trackMute                   in=10:0             out=audio       deps=1
+[ 12] Delay       det   T-2:mixInputDelay              in=6:0              out=audio       deps=1
+[ 13] Delay       det   T-2:mixInputDelay#1            in=11:0             out=audio       deps=1
+[ 14] MixAudio    det   T-2:trackAudioInput            in=12:0,13:0        out=audio       deps=2
+[ 15] Fader       det   T-2:trackFader                 in=14:0,-           out=audio       deps=1
+[ 16] Meter       det   T-2:trackMeter                 in=15:0             out=audio       deps=1
+[ 17] Gain        det   T-2:trackMute                  in=16:0             out=audio       deps=1
+[ 18] Output      det   T-2:hardwareOutput             in=17:0             out=-           deps=1
+ready=0,7
+
+== layout ==
+magda-plan-layout v1
+audioSlots=2 midiSlots=0 outputLatency=64
+[  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
+[  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
+[  2] Device      T1/D7:deviceProcess            lat=64      ports=a0          inplace
+[  3] Gain        T1/D7:deviceGain               lat=64      ports=a0          inplace
+[  4] Fader       T1:trackFader                  lat=64      ports=a0          inplace
+[  5] Meter       T1:trackMeter                  lat=64      ports=a0          inplace
+[  6] Gain        T1:trackMute                   lat=64      ports=a0          inplace
+[  7] ClipAudio   T2:clipAudio                   lat=0       ports=a1
+[  8] MixAudio    T2:trackAudioInput             lat=0       ports=a1          inplace
+[  9] Fader       T2:trackFader                  lat=0       ports=a1          inplace
+[ 10] Meter       T2:trackMeter                  lat=0       ports=a1          inplace
+[ 11] Gain        T2:trackMute                   lat=0       ports=a1          inplace
+[ 12] Delay       T-2:mixInputDelay              lat=64      ports=a0          hold=0 elided
+[ 13] Delay       T-2:mixInputDelay#1            lat=64      ports=a1          hold=64 inplace
+[ 14] MixAudio    T-2:trackAudioInput            lat=64      ports=a0          inplace
+[ 15] Fader       T-2:trackFader                 lat=64      ports=a0          inplace
+[ 16] Meter       T-2:trackMeter                 lat=64      ports=a0          inplace
+[ 17] Gain        T-2:trackMute                  lat=64      ports=a0          inplace
+[ 18] Output      T-2:hardwareOutput             lat=-       ports=-

--- a/tests/goldens/plan/group-routing.txt
+++ b/tests/goldens/plan/group-routing.txt
@@ -1,0 +1,45 @@
+# group-routing
+# a track routed to a group rather than to master
+#
+# Generated. See tests/test_plan_goldens.cpp to regenerate.
+
+== plan ==
+magda-render-plan v1
+ops=16 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Fader       det   T1:trackFader                  in=1:0,-            out=audio       deps=1
+[  3] Meter       det   T1:trackMeter                  in=2:0              out=audio       deps=1
+[  4] Gain        det   T1:trackMute                   in=3:0              out=audio       deps=1
+[  5] MixAudio    det   T2:trackAudioInput             in=4:0              out=audio       deps=1
+[  6] Device      det   T2/D7:deviceProcess            in=5:0,-,-          out=audio       deps=1
+[  7] Gain        det   T2/D7:deviceGain               in=6:0              out=audio       deps=1
+[  8] Fader       det   T2:trackFader                  in=7:0,-            out=audio       deps=1
+[  9] Meter       det   T2:trackMeter                  in=8:0              out=audio       deps=1
+[ 10] Gain        det   T2:trackMute                   in=9:0              out=audio       deps=1
+[ 11] MixAudio    det   T-2:trackAudioInput            in=10:0             out=audio       deps=1
+[ 12] Fader       det   T-2:trackFader                 in=11:0,-           out=audio       deps=1
+[ 13] Meter       det   T-2:trackMeter                 in=12:0             out=audio       deps=1
+[ 14] Gain        det   T-2:trackMute                  in=13:0             out=audio       deps=1
+[ 15] Output      det   T-2:hardwareOutput             in=14:0             out=-           deps=1
+ready=0
+
+== layout ==
+magda-plan-layout v1
+audioSlots=1 midiSlots=0 outputLatency=0
+[  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
+[  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
+[  2] Fader       T1:trackFader                  lat=0       ports=a0          inplace
+[  3] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
+[  4] Gain        T1:trackMute                   lat=0       ports=a0          inplace
+[  5] MixAudio    T2:trackAudioInput             lat=0       ports=a0          inplace
+[  6] Device      T2/D7:deviceProcess            lat=0       ports=a0          inplace
+[  7] Gain        T2/D7:deviceGain               lat=0       ports=a0          inplace
+[  8] Fader       T2:trackFader                  lat=0       ports=a0          inplace
+[  9] Meter       T2:trackMeter                  lat=0       ports=a0          inplace
+[ 10] Gain        T2:trackMute                   lat=0       ports=a0          inplace
+[ 11] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
+[ 12] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
+[ 13] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
+[ 14] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
+[ 15] Output      T-2:hardwareOutput             lat=-       ports=-

--- a/tests/goldens/plan/instrument-track.txt
+++ b/tests/goldens/plan/instrument-track.txt
@@ -1,0 +1,53 @@
+# instrument-track
+# a MIDI clip reaching an instrument, and the audio leaving it
+#
+# Generated. See tests/test_plan_goldens.cpp to regenerate.
+
+== plan ==
+magda-render-plan v1
+ops=20 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] ClipMidi    det   T1:clipMidi                    in=-                out=midi        deps=0
+[  3] MergeMidi   det   T1:trackMidiInput              in=2:0              out=midi        deps=1
+[  4] Delay       det   T1/D3:deviceInputDelay         in=1:0              out=audio       deps=1
+[  5] Delay       det   T1/D3:deviceInputDelay#1       in=3:0              out=midi        deps=1
+[  6] Device      det   T1/D3:deviceProcess            in=4:0,5:0,-        out=audio       deps=2
+[  7] Gain        det   T1/D3:deviceGain               in=6:0              out=audio       deps=1
+[  8] Delay       det   T1/D7:deviceInputDelay         in=7:0              out=audio       deps=1
+[  9] Delay       det   T1/D7:deviceInputDelay#1       in=3:0              out=midi        deps=1
+[ 10] Device      det   T1/D7:deviceProcess            in=8:0,9:0,-        out=audio       deps=2
+[ 11] Gain        det   T1/D7:deviceGain               in=10:0             out=audio       deps=1
+[ 12] Fader       det   T1:trackFader                  in=11:0,-           out=audio       deps=1
+[ 13] Meter       det   T1:trackMeter                  in=12:0             out=audio       deps=1
+[ 14] Gain        det   T1:trackMute                   in=13:0             out=audio       deps=1
+[ 15] MixAudio    det   T-2:trackAudioInput            in=14:0             out=audio       deps=1
+[ 16] Fader       det   T-2:trackFader                 in=15:0,-           out=audio       deps=1
+[ 17] Meter       det   T-2:trackMeter                 in=16:0             out=audio       deps=1
+[ 18] Gain        det   T-2:trackMute                  in=17:0             out=audio       deps=1
+[ 19] Output      det   T-2:hardwareOutput             in=18:0             out=-           deps=1
+ready=0,2
+
+== layout ==
+magda-plan-layout v1
+audioSlots=1 midiSlots=2 outputLatency=0
+[  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
+[  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
+[  2] ClipMidi    T1:clipMidi                    lat=0       ports=m0
+[  3] MergeMidi   T1:trackMidiInput              lat=0       ports=m1
+[  4] Delay       T1/D3:deviceInputDelay         lat=0       ports=a0          hold=0 elided
+[  5] Delay       T1/D3:deviceInputDelay#1       lat=0       ports=m1          hold=0 elided
+[  6] Device      T1/D3:deviceProcess            lat=0       ports=a0          inplace
+[  7] Gain        T1/D3:deviceGain               lat=0       ports=a0          inplace
+[  8] Delay       T1/D7:deviceInputDelay         lat=0       ports=a0          hold=0 elided
+[  9] Delay       T1/D7:deviceInputDelay#1       lat=0       ports=m1          hold=0 elided
+[ 10] Device      T1/D7:deviceProcess            lat=0       ports=a0          inplace
+[ 11] Gain        T1/D7:deviceGain               lat=0       ports=a0          inplace
+[ 12] Fader       T1:trackFader                  lat=0       ports=a0          inplace
+[ 13] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
+[ 14] Gain        T1:trackMute                   lat=0       ports=a0          inplace
+[ 15] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
+[ 16] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
+[ 17] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
+[ 18] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
+[ 19] Output      T-2:hardwareOutput             lat=-       ports=-

--- a/tests/goldens/plan/rack-chains.txt
+++ b/tests/goldens/plan/rack-chains.txt
@@ -1,0 +1,53 @@
+# rack-chains
+# two parallel chains, their mix, and the fader over it
+#
+# Generated. See tests/test_plan_goldens.cpp to regenerate.
+
+== plan ==
+magda-render-plan v1
+ops=20 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/R5/C10/D10:deviceProcess    in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/R5/C10/D10:deviceGain       in=2:0              out=audio       deps=1
+[  4] Fader       det   T1/R5/C10:rackChainFader       in=3:0,-            out=audio       deps=1
+[  5] Device      det   T1/R5/C11/D11:deviceProcess    in=1:0,-,-          out=audio       deps=1
+[  6] Gain        det   T1/R5/C11/D11:deviceGain       in=5:0              out=audio       deps=1
+[  7] Fader       det   T1/R5/C11:rackChainFader       in=6:0,-            out=audio       deps=1
+[  8] Delay       det   T1/R5:mixInputDelay            in=4:0              out=audio       deps=1
+[  9] Delay       det   T1/R5:mixInputDelay#1          in=7:0              out=audio       deps=1
+[ 10] MixAudio    det   T1/R5:rackMix                  in=8:0,9:0          out=audio       deps=2
+[ 11] Fader       det   T1/R5:rackFader                in=10:0,-           out=audio       deps=1
+[ 12] Fader       det   T1:trackFader                  in=11:0,-           out=audio       deps=1
+[ 13] Meter       det   T1:trackMeter                  in=12:0             out=audio       deps=1
+[ 14] Gain        det   T1:trackMute                   in=13:0             out=audio       deps=1
+[ 15] MixAudio    det   T-2:trackAudioInput            in=14:0             out=audio       deps=1
+[ 16] Fader       det   T-2:trackFader                 in=15:0,-           out=audio       deps=1
+[ 17] Meter       det   T-2:trackMeter                 in=16:0             out=audio       deps=1
+[ 18] Gain        det   T-2:trackMute                  in=17:0             out=audio       deps=1
+[ 19] Output      det   T-2:hardwareOutput             in=18:0             out=-           deps=1
+ready=0
+
+== layout ==
+magda-plan-layout v1
+audioSlots=3 midiSlots=0 outputLatency=48
+[  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
+[  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
+[  2] Device      T1/R5/C10/D10:deviceProcess    lat=48      ports=a1
+[  3] Gain        T1/R5/C10/D10:deviceGain       lat=48      ports=a1          inplace
+[  4] Fader       T1/R5/C10:rackChainFader       lat=48      ports=a1          inplace
+[  5] Device      T1/R5/C11/D11:deviceProcess    lat=0       ports=a2
+[  6] Gain        T1/R5/C11/D11:deviceGain       lat=0       ports=a2          inplace
+[  7] Fader       T1/R5/C11:rackChainFader       lat=0       ports=a2          inplace
+[  8] Delay       T1/R5:mixInputDelay            lat=48      ports=a1          hold=0 elided
+[  9] Delay       T1/R5:mixInputDelay#1          lat=48      ports=a2          hold=48 inplace
+[ 10] MixAudio    T1/R5:rackMix                  lat=48      ports=a1          inplace
+[ 11] Fader       T1/R5:rackFader                lat=48      ports=a1          inplace
+[ 12] Fader       T1:trackFader                  lat=48      ports=a1          inplace
+[ 13] Meter       T1:trackMeter                  lat=48      ports=a1          inplace
+[ 14] Gain        T1:trackMute                   lat=48      ports=a1          inplace
+[ 15] MixAudio    T-2:trackAudioInput            lat=48      ports=a1          inplace
+[ 16] Fader       T-2:trackFader                 lat=48      ports=a1          inplace
+[ 17] Meter       T-2:trackMeter                 lat=48      ports=a1          inplace
+[ 18] Gain        T-2:trackMute                  lat=48      ports=a1          inplace
+[ 19] Output      T-2:hardwareOutput             lat=-       ports=-

--- a/tests/goldens/plan/sidechain.txt
+++ b/tests/goldens/plan/sidechain.txt
@@ -1,0 +1,55 @@
+# sidechain
+# a device's key input, taken from another track
+#
+# Generated. See tests/test_plan_goldens.cpp to regenerate.
+
+== plan ==
+magda-render-plan v1
+ops=21 outputs=1
+[  0] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T2:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Fader       det   T2:trackFader                  in=1:0,-            out=audio       deps=1
+[  3] Meter       det   T2:trackMeter                  in=2:0              out=audio       deps=1
+[  4] Gain        det   T2:trackMute                   in=3:0              out=audio       deps=1
+[  5] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  6] MixAudio    det   T1:trackAudioInput             in=5:0              out=audio       deps=1
+[  7] Delay       det   T1/D7:deviceInputDelay         in=6:0              out=audio       deps=1
+[  8] Delay       det   T1/D7:deviceInputDelay#2       in=3:0              out=audio       deps=1
+[  9] Device      det   T1/D7:deviceProcess            in=7:0,-,8:0        out=audio       deps=2
+[ 10] Gain        det   T1/D7:deviceGain               in=9:0              out=audio       deps=1
+[ 11] Fader       det   T1:trackFader                  in=10:0,-           out=audio       deps=1
+[ 12] Meter       det   T1:trackMeter                  in=11:0             out=audio       deps=1
+[ 13] Gain        det   T1:trackMute                   in=12:0             out=audio       deps=1
+[ 14] Delay       det   T-2:mixInputDelay              in=4:0              out=audio       deps=1
+[ 15] Delay       det   T-2:mixInputDelay#1            in=13:0             out=audio       deps=1
+[ 16] MixAudio    det   T-2:trackAudioInput            in=14:0,15:0        out=audio       deps=2
+[ 17] Fader       det   T-2:trackFader                 in=16:0,-           out=audio       deps=1
+[ 18] Meter       det   T-2:trackMeter                 in=17:0             out=audio       deps=1
+[ 19] Gain        det   T-2:trackMute                  in=18:0             out=audio       deps=1
+[ 20] Output      det   T-2:hardwareOutput             in=19:0             out=-           deps=1
+ready=0,5
+
+== layout ==
+magda-plan-layout v1
+audioSlots=3 midiSlots=0 outputLatency=0
+[  0] ClipAudio   T2:clipAudio                   lat=0       ports=a0
+[  1] MixAudio    T2:trackAudioInput             lat=0       ports=a0          inplace
+[  2] Fader       T2:trackFader                  lat=0       ports=a0          inplace
+[  3] Meter       T2:trackMeter                  lat=0       ports=a0          inplace
+[  4] Gain        T2:trackMute                   lat=0       ports=a1
+[  5] ClipAudio   T1:clipAudio                   lat=0       ports=a2
+[  6] MixAudio    T1:trackAudioInput             lat=0       ports=a2          inplace
+[  7] Delay       T1/D7:deviceInputDelay         lat=0       ports=a2          hold=0 elided
+[  8] Delay       T1/D7:deviceInputDelay#2       lat=0       ports=a0          hold=0 elided
+[  9] Device      T1/D7:deviceProcess            lat=0       ports=a2          inplace
+[ 10] Gain        T1/D7:deviceGain               lat=0       ports=a2          inplace
+[ 11] Fader       T1:trackFader                  lat=0       ports=a2          inplace
+[ 12] Meter       T1:trackMeter                  lat=0       ports=a2          inplace
+[ 13] Gain        T1:trackMute                   lat=0       ports=a2          inplace
+[ 14] Delay       T-2:mixInputDelay              lat=0       ports=a1          hold=0 elided
+[ 15] Delay       T-2:mixInputDelay#1            lat=0       ports=a2          hold=0 elided
+[ 16] MixAudio    T-2:trackAudioInput            lat=0       ports=a1          inplace
+[ 17] Fader       T-2:trackFader                 lat=0       ports=a1          inplace
+[ 18] Meter       T-2:trackMeter                 lat=0       ports=a1          inplace
+[ 19] Gain        T-2:trackMute                  lat=0       ports=a1          inplace
+[ 20] Output      T-2:hardwareOutput             lat=-       ports=-

--- a/tests/test_plan_goldens.cpp
+++ b/tests/test_plan_goldens.cpp
@@ -1,0 +1,232 @@
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "PlanGoldenFixtures.hpp"
+#include "exec/PlanLayoutDump.hpp"
+#include "plan/PlanCompiler.hpp"
+#include "plan/PlanCrossfade.hpp"
+#include "plan/PlanDiff.hpp"
+#include "plan/PlanDiffDump.hpp"
+#include "plan/PlanDump.hpp"
+#include "plan/RenderPlan.hpp"
+
+/**
+ * @file test_plan_goldens.cpp
+ * @brief The plan compiler's decisions, pinned as checked-in text (#2076).
+ *
+ * A render says the output is wrong. A golden says which of the compiler's
+ * decisions changed, before any audio exists, and a diff of two canonical
+ * dumps is readable in a way a waveform is not.
+ *
+ * ## Regenerating
+ *
+ * When a change to the plan is intended:
+ *
+ *     MAGDA_UPDATE_PLAN_GOLDENS=1 ./magda_tests "[goldens]"
+ *
+ * That rewrites every file under tests/goldens/plan and passes. The diff is
+ * then the reviewable artefact, which is the entire point: a golden that is
+ * regenerated without being read has stopped being a test, so the rewrite is
+ * deliberately not something a normal run can do.
+ *
+ * ## What is in a golden, and what is kept out
+ *
+ * Only decisions. No addresses, no timings, no allocation or iteration order,
+ * and nothing keyed on an op index across plans: the diff section prints op
+ * keys, because inserting one device ahead of another moves every index behind
+ * it and a golden written in indices would churn on an edit that carried
+ * correctly.
+ *
+ * Stability is pinned rather than assumed. Every fixture is compiled twice in
+ * this process and the two dumps compared, and the files themselves are the
+ * cross-process half of the same check: each was written by a different run of
+ * a different build than the one asserting it now.
+ */
+
+using namespace magda;
+using magda::engine::RenderPlan;
+
+namespace {
+
+const char* const kGoldenDir = MAGDA_PLAN_GOLDEN_DIR;
+
+bool regenerating() {
+    const auto* flag = std::getenv("MAGDA_UPDATE_PLAN_GOLDENS");
+    return flag != nullptr && *flag != '\0' && std::string(flag) != "0";
+}
+
+juce::File goldenFile(const std::string& name) {
+    return juce::File(kGoldenDir).getChildFile(juce::String(name) + ".txt");
+}
+
+/// Device latency per op, which is what the layout pass takes. The fixture
+/// names devices; only Device ops carry one, and everything else is zero.
+std::vector<int> deviceLatencyPerOp(const RenderPlan& plan,
+                                    const std::vector<std::pair<DeviceId, int>>& byDevice) {
+    std::map<DeviceId, int> lookup;
+    for (const auto& [device, samples] : byDevice)
+        lookup[device] = samples;
+
+    std::vector<int> latency(plan.ops.size(), 0);
+    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+        if (plan.ops[i].kind != magda::engine::OpKind::Device)
+            continue;
+
+        const auto found = lookup.find(plan.ops[i].key.deviceId);
+        if (found != lookup.end())
+            latency[i] = found->second;
+    }
+    return latency;
+}
+
+/// Everything a fixture pins, as one document.
+///
+/// One file per fixture rather than one per section: a change that moves an op
+/// moves it in the plan, the layout and the diff at once, and three files
+/// would make one decision look like three regressions.
+std::string renderGolden(const goldens::Fixture& fixture) {
+    std::ostringstream out;
+    out << "# " << fixture.name << "\n";
+    out << "# " << fixture.covers << "\n";
+    out << "#\n";
+    out << "# Generated. See tests/test_plan_goldens.cpp to regenerate.\n\n";
+
+    const auto plan = engine::compileRenderPlan(fixture.tracks, fixture.master, fixture.options);
+
+    out << "== plan ==\n" << engine::dumpPlan(plan) << "\n";
+    out << "== layout ==\n"
+        << engine::dumpPlanLayout(plan, deviceLatencyPerOp(plan, fixture.deviceLatency)) << "\n";
+
+    if (fixture.editedTracks.empty())
+        return out.str();
+
+    const auto edited =
+        engine::compileRenderPlan(fixture.editedTracks, fixture.master, fixture.options);
+
+    out << "== edited plan ==\n" << engine::dumpPlan(edited) << "\n";
+    out << "== diff ==\n"
+        << engine::dumpPlanDiff(plan, edited, engine::diffPlans(plan, edited)) << "\n";
+
+    const auto faded = engine::insertCrossfades(plan, edited);
+    out << "== crossfaded ==\n"
+        << "inserted=" << faded.inserted << " unfaded=" << faded.unfaded << "\n"
+        << engine::dumpPlan(faded.plan);
+
+    return out.str();
+}
+
+/// Exactly one newline at the end, because the repo's end-of-file hook would
+/// otherwise rewrite the goldens the first time one was committed and every
+/// run after that would compare against a file it did not write.
+std::string oneTrailingNewline(std::string text) {
+    while (!text.empty() && (text.back() == '\n' || text.back() == ' '))
+        text.pop_back();
+    return text + "\n";
+}
+
+/// The first line that differs, so a failure names a decision rather than
+/// printing two documents at each other.
+std::string firstDifference(const std::string& expected, const std::string& actual) {
+    std::istringstream expectedLines(expected);
+    std::istringstream actualLines(actual);
+
+    std::string expectedLine;
+    std::string actualLine;
+    int number = 1;
+
+    while (true) {
+        const bool haveExpected = static_cast<bool>(std::getline(expectedLines, expectedLine));
+        const bool haveActual = static_cast<bool>(std::getline(actualLines, actualLine));
+
+        if (!haveExpected && !haveActual)
+            return {};
+        if (!haveExpected)
+            return "line " + std::to_string(number) + ": golden ends, got '" + actualLine + "'";
+        if (!haveActual)
+            return "line " + std::to_string(number) + ": expected '" + expectedLine + "', got end";
+        if (expectedLine != actualLine)
+            return "line " + std::to_string(number) + ":\n  expected: " + expectedLine +
+                   "\n  actual:   " + actualLine;
+
+        ++number;
+    }
+}
+
+}  // namespace
+
+TEST_CASE("Plan goldens hold", "[engine][plan][goldens]") {
+    const auto fixtures = goldens::planFixtures();
+    REQUIRE_FALSE(fixtures.empty());
+
+    for (const auto& fixture : fixtures) {
+        const auto file = goldenFile(fixture.name);
+        const auto actual = oneTrailingNewline(renderGolden(fixture));
+
+        if (regenerating()) {
+            file.getParentDirectory().createDirectory();
+
+            // Line endings named rather than defaulted: replaceWithText writes
+            // CRLF unless told otherwise, and a golden regenerated on one
+            // platform has to be the file every other platform asserts.
+            REQUIRE(file.replaceWithText(juce::String(actual), false, false, "\n"));
+            continue;
+        }
+
+        INFO("fixture: " << fixture.name);
+        INFO("golden: " << file.getFullPathName());
+
+        if (!file.existsAsFile()) {
+            FAIL_CHECK("no golden: regenerate with MAGDA_UPDATE_PLAN_GOLDENS=1");
+            continue;
+        }
+
+        const auto expected = file.loadFileAsString().toStdString();
+        const auto difference = firstDifference(expected, actual);
+
+        INFO(difference);
+        CHECK(difference.empty());
+    }
+}
+
+TEST_CASE("Every golden on disk belongs to a fixture", "[engine][plan][goldens]") {
+    // A renamed or deleted fixture leaves its file behind, and a stale golden
+    // is a file nothing asserts that still looks like coverage.
+    std::set<std::string> expected;
+    for (const auto& fixture : goldens::planFixtures())
+        expected.insert(fixture.name + ".txt");
+
+    for (const auto& file :
+         juce::File(kGoldenDir).findChildFiles(juce::File::findFiles, false, "*.txt")) {
+        const auto name = file.getFileName().toStdString();
+        INFO("orphan golden: " << name);
+        CHECK(expected.count(name) == 1);
+    }
+}
+
+TEST_CASE("A fixture compiles to the same text twice in one process",
+          "[engine][plan][goldens][determinism]") {
+    // The other half of the stability the goldens depend on. The files pin the
+    // cross-process case by existing; this pins the case a single run could
+    // still get wrong, where a dump reads back allocation or iteration order.
+    for (const auto& fixture : goldens::planFixtures()) {
+        INFO("fixture: " << fixture.name);
+        CHECK(oneTrailingNewline(renderGolden(fixture)) ==
+              oneTrailingNewline(renderGolden(fixture)));
+    }
+}
+
+TEST_CASE("Fixture names are unique", "[engine][plan][goldens]") {
+    // Two fixtures with one name means one golden file, silently written twice
+    // and asserted against whichever ran last.
+    std::set<std::string> seen;
+    for (const auto& fixture : goldens::planFixtures()) {
+        INFO("fixture: " << fixture.name);
+        CHECK(seen.insert(fixture.name).second);
+    }
+}

--- a/tests/test_plan_goldens.cpp
+++ b/tests/test_plan_goldens.cpp
@@ -65,23 +65,31 @@ juce::File goldenFile(const std::string& name) {
     return juce::File(kGoldenDir).getChildFile(juce::String(name) + ".txt");
 }
 
-/// Device latency per op, which is what the layout pass takes. The fixture
-/// names devices; only Device ops carry one, and everything else is zero.
+/// Device latency per op, which is what the layout pass takes.
+///
+/// Each entry has to match exactly one op. A fixture names a device by where
+/// it sits, and a location that matches nothing is a fixture describing a
+/// project it did not build: it would compile fine, print a golden with no
+/// delays in it, and pin the wrong graph forever.
 std::vector<int> deviceLatencyPerOp(const RenderPlan& plan,
-                                    const std::vector<std::pair<DeviceId, int>>& byDevice) {
-    std::map<DeviceId, int> lookup;
-    for (const auto& [device, samples] : byDevice)
-        lookup[device] = samples;
-
+                                    const std::vector<std::pair<engine::OpKey, int>>& byLocation) {
     std::vector<int> latency(plan.ops.size(), 0);
-    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
-        if (plan.ops[i].kind != magda::engine::OpKind::Device)
-            continue;
 
-        const auto found = lookup.find(plan.ops[i].key.deviceId);
-        if (found != lookup.end())
-            latency[i] = found->second;
+    for (const auto& [key, samples] : byLocation) {
+        int matches = 0;
+
+        for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+            if (plan.ops[i].kind != engine::OpKind::Device || plan.ops[i].key != key)
+                continue;
+
+            latency[i] = samples;
+            ++matches;
+        }
+
+        INFO("device latency for " << engine::toString(key));
+        REQUIRE(matches == 1);
     }
+
     return latency;
 }
 

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -1399,15 +1399,26 @@ TEST_CASE("validatePlan enforces liveness provenance", "[engine][plan][validate]
     }
 }
 
-TEST_CASE("Device ids are project-unique, and the plan says so when they are not",
+TEST_CASE("Section-local device ids compile to a plan the differ cannot key",
           "[engine][plan][compiler]") {
-    // The compiler's ChainSite records only the innermost rack and chain,
-    // explicitly because device ids are project-unique; nothing in an op key
-    // says which section a device sat in. So the invariant has to hold, and
-    // this is the test that it is caught rather than assumed: two sections of
-    // one track reusing an id produce two ops the differ cannot tell apart,
-    // and carrying one op's runtime state into another is exactly the failure
-    // OpKey exists to prevent.
+    // A known incompatibility between the app's model and the engine's op
+    // identity, pinned here so it is measured rather than assumed either way.
+    //
+    // TrackManager allocates device ids per section: nextFxDeviceId_,
+    // nextPostFxDeviceId_ and nextMixerAnalysisDeviceId_ are separate spaces,
+    // so id 3 legitimately exists on one track's FX chain and its post-FX
+    // chain at once. The compiler's ChainSite records only the innermost rack
+    // and chain, on the assumption that device ids are project-unique, so both
+    // devices compile to the same OpKey.
+    //
+    // validatePlan catches it, which is the one good thing here: the differ
+    // hash-joins old and new plans on OpKey, and a duplicate would carry one
+    // device's runtime state into another. So this is a rejected plan rather
+    // than a silently wrong one, and the app can build the model that causes
+    // it today.
+    //
+    // The fix is a section discriminator in ChainSite and OpKey, and it
+    // belongs with the engine migration rather than here.
     std::vector<TrackInfo> tracks{makeTrack(1)};
     tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(3)));
     tracks[0].chain.postFxChainElements.push_back(PostFxChainElement{makeEffect(3)});

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -1398,3 +1398,23 @@ TEST_CASE("validatePlan enforces liveness provenance", "[engine][plan][validate]
         CHECK(magda::engine::validatePlan(plan).empty());
     }
 }
+
+TEST_CASE("Device ids are project-unique, and the plan says so when they are not",
+          "[engine][plan][compiler]") {
+    // The compiler's ChainSite records only the innermost rack and chain,
+    // explicitly because device ids are project-unique; nothing in an op key
+    // says which section a device sat in. So the invariant has to hold, and
+    // this is the test that it is caught rather than assumed: two sections of
+    // one track reusing an id produce two ops the differ cannot tell apart,
+    // and carrying one op's runtime state into another is exactly the failure
+    // OpKey exists to prevent.
+    std::vector<TrackInfo> tracks{makeTrack(1)};
+    tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(3)));
+    tracks[0].chain.postFxChainElements.push_back(PostFxChainElement{makeEffect(3)});
+
+    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
+    const auto problems = magda::engine::validatePlan(plan);
+
+    INFO(magda::engine::dumpPlan(plan));
+    CHECK_FALSE(problems.empty());
+}


### PR DESCRIPTION
Closes #2076. Slice 2 of #1896.

Eleven fixtures in `tests/goldens/plan`, one file each: the compiled plan, the layout it prepares to, and for the edit fixtures the edited plan, the diff, and the crossfaded result.

Regenerate with `MAGDA_UPDATE_PLAN_GOLDENS=1 ./magda_tests "[goldens]"`. A normal run cannot rewrite them, which is the point - the diff is the reviewable artefact, and a golden that gets regenerated without being read has stopped being a test.

CI already runs `magda_tests` bare, so the goldens fail the existing job on an unintended change. No new entry needed.

## Two dumps that did not exist

`dumpPlan` was already there. Buffer assignment and latency could not be pinned without these:

- `dumpPlanLayout` - delay hold, port slots, in-place writes and elided delays, against the device latencies they were resolved with.
- `dumpPlanDiff` - what carried and what retired, by **op key** rather than op index. Inserting a device moves every index behind it, so an index-keyed golden would churn on an edit that carried correctly.

## Stability

Pinned, not assumed. Every fixture compiles twice in-process and the two dumps are compared; the files are the cross-process half, since each was written by a different run than the one asserting it.

Two more tests keep the corpus honest: fixture names must be unique, and every file on disk must belong to a fixture - a renamed fixture cannot leave a stale golden behind that still looks like coverage.

## What the fixtures cover

`bare-track`, `device-chain`, `instrument-track`, `fan-in`, `cascaded-latency`, `rack-chains`, `sidechain`, `group-routing`, and three edits: `edit-insert-device`, `edit-remove-device`, `edit-reorder-devices` (the last one is the crossfade case from #2019 - reordering moves an edge without adding or removing anything, so every fade in the golden is one the pass chose).

## Note on the trailing-whitespace handling

Both new dumps trim trailing spaces and the writer names its line endings explicitly. Without that, the repo's whitespace hook and JUCE's CRLF default each rewrite every golden on first commit, and every run afterwards compares against a file it did not write. Both were hit and fixed rather than reasoned about.

## Verified

Full Catch2 suite: 2547 cases, 571846 assertions. A deliberately corrupted golden fails with the offending line named.