### PR TITLE
Make device identity section-aware

### DIFF
--- a/magda/daw/core/ChainNodePath.hpp
+++ b/magda/daw/core/ChainNodePath.hpp
@@ -9,15 +9,6 @@
 namespace magda {
 
 /**
- * @brief Which of a track's two FX lists a path descends into.
- *
- * Encoded as the id of a leading ChainStepType::Segment step. Fx is the
- * implicit default (paths with no Segment step address the main FX chain);
- * post-fx paths carry an explicit Segment(PostFx) step as their first step.
- */
-enum class ChainSegment { Fx, PostFx, MixerAnalysis };
-
-/**
  * @brief Type of element in a chain path step
  *
  * Segment is appended last so the persisted integer values of Rack/Chain/

--- a/magda/daw/core/TypeIds.hpp
+++ b/magda/daw/core/TypeIds.hpp
@@ -6,6 +6,14 @@ namespace magda {
 using DeviceId = int;
 constexpr DeviceId INVALID_DEVICE_ID = -1;
 
+/**
+ * @brief Which independently allocated device-id space a chain belongs to.
+ *
+ * Fx is the implicit default for legacy chain paths. Post-fx and mixer-analysis
+ * paths carry an explicit segment step.
+ */
+enum class ChainSegment { Fx, PostFx, MixerAnalysis };
+
 // Mod identifiers
 using ModId = int;
 constexpr ModId INVALID_MOD_ID = -1;

--- a/magda/engine/exec/EngineDevice.hpp
+++ b/magda/engine/exec/EngineDevice.hpp
@@ -9,11 +9,11 @@
  * @file EngineDevice.hpp
  * @brief The runtime objects a plan's leaf ops stand for.
  *
- * The plan is pure topology: a Device op names a DeviceId, it does not own a
- * plugin, and a ClipAudio op names a track, not a file reader. The host binds
- * the objects and outlives the plans that reference them, which is what lets
- * the differ carry a live instrument across a structural change instead of
- * rebuilding it.
+ * The plan is pure topology: a Device op names a section-aware device identity,
+ * it does not own a plugin, and a ClipAudio op names a track, not a file reader.
+ * The host binds the objects and outlives the plans that reference them, which
+ * is what lets the differ carry a live instrument across a structural change
+ * instead of rebuilding it.
  */
 
 namespace magda::engine {
@@ -86,8 +86,8 @@ struct DeviceBlock {
 /**
  * @brief One device instance behind a Device op.
  *
- * Bound by DeviceId, owned by the host. process() runs on the audio thread:
- * no allocation, no locks, no file or GUI work.
+ * Bound by DeviceKey, owned by the host. process() runs on the audio thread: no
+ * allocation, no locks, no file or GUI work.
  */
 class EngineDevice {
   public:

--- a/magda/engine/exec/PlanBindings.hpp
+++ b/magda/engine/exec/PlanBindings.hpp
@@ -14,16 +14,17 @@ namespace magda::engine {
 /**
  * @brief The runtime objects a plan's leaf ops resolve to.
  *
- * Keyed by model ID, exactly like OpKey, so a binding survives a recompile: the
- * new plan asks for the same DeviceId and gets the same instance back. Nothing
- * here is owned; the host keeps every object alive for as long as any prepared
- * plan can reference it.
+ * Keyed by model identity, exactly like the device-bearing part of OpKey, so a
+ * binding survives a recompile. DeviceId alone is insufficient because the FX,
+ * post-FX and mixer-analysis sections allocate from independent id spaces.
+ * Nothing here is owned; the host keeps every object alive for as long as any
+ * prepared plan can reference it.
  *
  * Lookups happen once, in PlanExecutor::prepare(), which resolves them into a
  * flat per-op table. The audio thread never touches these maps.
  */
 struct PlanBindings {
-    std::unordered_map<DeviceId, EngineDevice*> devices;
+    std::unordered_map<DeviceKey, EngineDevice*, DeviceKeyHash> devices;
 
     /// Arrangement and session playback for a track (ClipAudio / ClipMidi ops).
     std::unordered_map<TrackId, EngineAudioSource*> clipAudio;

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -294,14 +294,13 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                 break;
 
             case OpKind::Device: {
-                const auto found = bindings.devices.find(op.key.deviceId);
+                const auto found = bindings.devices.find(op.key.deviceKey());
                 if (found == bindings.devices.end() || found->second == nullptr) {
                     // Passing audio through is what the current engine does
                     // with a plugin that failed to load, and it keeps the rest
                     // of the chain testable instead of silencing the track.
                     messages.push_back(describe(i) + "no device bound for device " +
-                                       std::to_string(op.key.deviceId) +
-                                       ", it passes audio through");
+                                       toString(op.key.deviceKey()) + ", it passes audio through");
                     break;
                 }
                 deviceForOp_[i] = found->second;

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -299,7 +299,7 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                     // Passing audio through is what the current engine does
                     // with a plugin that failed to load, and it keeps the rest
                     // of the chain testable instead of silencing the track.
-                    messages.push_back(describe(i) + "no device bound for device " +
+                    messages.push_back(describe(i) + "no device bound for " +
                                        toString(op.key.deviceKey()) + ", it passes audio through");
                     break;
                 }

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -205,12 +205,19 @@ class Resolver {
 
 const DeviceInfo* Resolver::findDevice(const TrackInfo& track, const OpKey& key) const {
     if (key.rackId == INVALID_RACK_ID) {
-        if (const auto* device = findDeviceIn(track.chain.fxChainElements, key.deviceId))
-            return device;
-        if (const auto* device = findDeviceIn(track.chain.postFxChainElements, key.deviceId))
-            return device;
-        return findDeviceIn(track.chain.mixerAnalysisElements, key.deviceId);
+        switch (key.segment) {
+            case ChainSegment::Fx:
+                return findDeviceIn(track.chain.fxChainElements, key.deviceId);
+            case ChainSegment::PostFx:
+                return findDeviceIn(track.chain.postFxChainElements, key.deviceId);
+            case ChainSegment::MixerAnalysis:
+                return findDeviceIn(track.chain.mixerAnalysisElements, key.deviceId);
+        }
+        return nullptr;
     }
+
+    if (key.segment != ChainSegment::Fx)
+        return nullptr;
 
     const auto* rack = findRack(track, key.rackId);
     if (rack == nullptr)

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -35,7 +35,8 @@ template <typename Map> void prepareAll(Map& map, const RenderContext& context) 
         object->prepare(context);
 }
 
-void collectDeviceIds(const std::vector<ChainElement>& elements, std::set<DeviceKey>& out);
+void collectDeviceIds(const std::vector<ChainElement>& elements, ChainSegment segment,
+                      std::set<DeviceKey>& out);
 
 void collectDeviceIds(const std::vector<PostFxChainElement>& elements, ChainSegment segment,
                       std::set<DeviceKey>& out) {
@@ -43,13 +44,14 @@ void collectDeviceIds(const std::vector<PostFxChainElement>& elements, ChainSegm
         out.emplace(segment, element.device.id);
 }
 
-void collectDeviceIds(const std::vector<ChainElement>& elements, std::set<DeviceKey>& out) {
+void collectDeviceIds(const std::vector<ChainElement>& elements, ChainSegment segment,
+                      std::set<DeviceKey>& out) {
     for (const auto& element : elements) {
         if (isDevice(element)) {
-            out.emplace(ChainSegment::Fx, getDevice(element).id);
+            out.emplace(segment, getDevice(element).id);
         } else if (isRack(element)) {
             for (const auto& chain : getRack(element).chains)
-                collectDeviceIds(chain.elements, out);
+                collectDeviceIds(chain.elements, segment, out);
         }
     }
 }
@@ -221,7 +223,7 @@ RuntimeStateIds collectRuntimeStateIds(const std::vector<TrackInfo>& tracks,
         ids.tracks.insert(track.id);
         // Every section, and bypass is not consulted anywhere here: a bypassed
         // device is still a device the user owns.
-        collectDeviceIds(track.chain.fxChainElements, ids.devices);
+        collectDeviceIds(track.chain.fxChainElements, ChainSegment::Fx, ids.devices);
         collectDeviceIds(track.chain.postFxChainElements, ChainSegment::PostFx, ids.devices);
         collectDeviceIds(track.chain.mixerAnalysisElements, ChainSegment::MixerAnalysis,
                          ids.devices);

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -35,17 +35,18 @@ template <typename Map> void prepareAll(Map& map, const RenderContext& context) 
         object->prepare(context);
 }
 
-void collectDeviceIds(const std::vector<ChainElement>& elements, std::set<DeviceId>& out);
+void collectDeviceIds(const std::vector<ChainElement>& elements, std::set<DeviceKey>& out);
 
-void collectDeviceIds(const std::vector<PostFxChainElement>& elements, std::set<DeviceId>& out) {
+void collectDeviceIds(const std::vector<PostFxChainElement>& elements, ChainSegment segment,
+                      std::set<DeviceKey>& out) {
     for (const auto& element : elements)
-        out.insert(element.device.id);
+        out.emplace(segment, element.device.id);
 }
 
-void collectDeviceIds(const std::vector<ChainElement>& elements, std::set<DeviceId>& out) {
+void collectDeviceIds(const std::vector<ChainElement>& elements, std::set<DeviceKey>& out) {
     for (const auto& element : elements) {
         if (isDevice(element)) {
-            out.insert(getDevice(element).id);
+            out.emplace(ChainSegment::Fx, getDevice(element).id);
         } else if (isRack(element)) {
             for (const auto& chain : getRack(element).chains)
                 collectDeviceIds(chain.elements, out);
@@ -59,7 +60,7 @@ void collectDeviceIds(const std::vector<ChainElement>& elements, std::set<Device
 /// those two places.
 bool isNamed(const OpKey& key, const RuntimeStateIds& ids) {
     if (key.deviceId != INVALID_DEVICE_ID)
-        return ids.devices.contains(key.deviceId);
+        return ids.devices.contains(key.deviceKey());
     return ids.tracks.contains(key.trackId);
 }
 
@@ -101,9 +102,9 @@ PlanBindings RuntimeStateStore::realise(const RenderPlan& plan, const RenderCont
         switch (op.kind) {
             case OpKind::Device:
                 if (auto* device =
-                        realiseOne(devices_, op.key.deviceId, context,
-                                   [this](DeviceId id) { return factory_.createDevice(id); }))
-                    bindings.devices[op.key.deviceId] = device;
+                        realiseOne(devices_, op.key.deviceKey(), context,
+                                   [this](DeviceKey key) { return factory_.createDevice(key); }))
+                    bindings.devices[op.key.deviceKey()] = device;
                 break;
 
             case OpKind::ClipAudio:
@@ -173,7 +174,7 @@ std::size_t RuntimeStateStore::releaseDeleted(const RenderPlan& livePlan,
     for (const auto& op : livePlan.ops) {
         switch (op.kind) {
             case OpKind::Device:
-                keep.devices.insert(op.key.deviceId);
+                keep.devices.insert(op.key.deviceKey());
                 break;
             case OpKind::ClipAudio:
             case OpKind::ClipMidi:
@@ -186,7 +187,7 @@ std::size_t RuntimeStateStore::releaseDeleted(const RenderPlan& livePlan,
                 // names: the executor holds a pointer to this tap and the audio
                 // thread is writing through it right now.
                 if (op.key.deviceId != INVALID_DEVICE_ID)
-                    keep.devices.insert(op.key.deviceId);
+                    keep.devices.insert(op.key.deviceKey());
                 else
                     keep.tracks.insert(op.key.trackId);
                 break;
@@ -221,8 +222,9 @@ RuntimeStateIds collectRuntimeStateIds(const std::vector<TrackInfo>& tracks,
         // Every section, and bypass is not consulted anywhere here: a bypassed
         // device is still a device the user owns.
         collectDeviceIds(track.chain.fxChainElements, ids.devices);
-        collectDeviceIds(track.chain.postFxChainElements, ids.devices);
-        collectDeviceIds(track.chain.mixerAnalysisElements, ids.devices);
+        collectDeviceIds(track.chain.postFxChainElements, ChainSegment::PostFx, ids.devices);
+        collectDeviceIds(track.chain.mixerAnalysisElements, ChainSegment::MixerAnalysis,
+                         ids.devices);
     };
 
     for (const auto& track : tracks)

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -21,9 +21,9 @@ struct TrackInfo;
  * A plan is topology and nothing else, so it cannot own a plugin instance or a
  * file reader: it is rebuilt every time a device moves, and rebuilding an
  * instrument because a fader was reordered above it is the rebuild-click
- * problem in miniature. The store owns them instead, keyed by model ID the way
- * OpKey is, so the same edit that recompiles the plan leaves the objects it
- * names untouched.
+ * problem in miniature. The store owns them instead, keyed by section-aware
+ * model identity the way OpKey is, so the same edit that recompiles the plan
+ * leaves the objects it names untouched.
  *
  * Everything here runs off the audio thread.
  */
@@ -34,15 +34,15 @@ namespace magda::engine {
  * @brief Makes the runtime objects a plan asks for.
  *
  * Implemented by the host, because the engine has no idea what a device is: it
- * knows a DeviceId, and the host knows which plugin that is. Returning nullptr
- * is allowed and means the object does not exist; the executor reports the
- * op as unbound rather than pretending otherwise.
+ * knows a section-aware DeviceKey, and the host knows which plugin that is.
+ * Returning nullptr is allowed and means the object does not exist; the
+ * executor reports the op as unbound rather than pretending otherwise.
  */
 class RuntimeStateFactory {
   public:
     virtual ~RuntimeStateFactory() = default;
 
-    virtual std::unique_ptr<EngineDevice> createDevice(DeviceId) {
+    virtual std::unique_ptr<EngineDevice> createDevice(DeviceKey) {
         return nullptr;
     }
     virtual std::unique_ptr<EngineAudioSource> createClipAudioSource(TrackId) {
@@ -88,7 +88,7 @@ class RuntimeStateFactory {
  * deletion from the model destroys anything.
  */
 struct RuntimeStateIds {
-    std::set<DeviceId> devices;
+    std::set<DeviceKey> devices;
     std::set<TrackId> tracks;
 };
 
@@ -167,7 +167,7 @@ class RuntimeStateStore {
     RenderContext context_;
     bool hasContext_ = false;
 
-    std::unordered_map<DeviceId, std::unique_ptr<EngineDevice>> devices_;
+    std::unordered_map<DeviceKey, std::unique_ptr<EngineDevice>, DeviceKeyHash> devices_;
     std::unordered_map<TrackId, std::unique_ptr<EngineAudioSource>> clipAudio_;
     std::unordered_map<TrackId, std::unique_ptr<EngineMidiSource>> clipMidi_;
     std::unordered_map<TrackId, std::unique_ptr<EngineAudioSource>> audioInputs_;
@@ -176,7 +176,7 @@ class RuntimeStateStore {
     /// Keyed by the op's whole key, and retained by the model IDs that key
     /// names: a meter is kept while the track or device it reads exists, which
     /// is the same rule everything else here follows read through the one
-    /// binding whose identity is not a bare model ID.
+    /// binding whose identity is the whole op rather than a DeviceKey or TrackId.
     std::map<OpKey, std::unique_ptr<LevelTap>> meters_;
 };
 

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -22,19 +22,14 @@ struct ChainSignal {
     PortRef midi;
 };
 
-/// Where a chain element lives, for op keys. Only the innermost rack and chain
-/// are recorded, on the assumption that device ids are project-unique.
-///
-/// They are not. TrackManager allocates them per section (nextFxDeviceId_,
-/// nextPostFxDeviceId_, nextMixerAnalysisDeviceId_), so one track's FX and
-/// post-FX chains can both hold id 3, and both compile to the same OpKey.
-/// validatePlan rejects the result rather than letting the differ carry one
-/// device's state into the other, so it fails loudly; it still fails. What is
-/// missing is a section discriminator here and in OpKey.
+/// Where a chain element lives, for op keys. Device ids are unique within one
+/// section, not across the three independently allocated section id spaces, so
+/// the section travels with the innermost rack and chain.
 struct ChainSite {
     TrackId trackId = INVALID_TRACK_ID;
     RackId rackId = INVALID_RACK_ID;
     ChainId chainId = INVALID_CHAIN_ID;
+    ChainSegment segment = ChainSegment::Fx;
 };
 
 /// Analysis devices are transparent passthroughs with no gain trim and no
@@ -476,7 +471,8 @@ ChainSignal Compiler::emitDevice(const DeviceInfo& device, const ChainSite& site
     if (producesMidi)
         outputs.push_back(SignalKind::Midi);
 
-    OpKey key{site.trackId, site.rackId, site.chainId, device.id, OpRole::DeviceProcess, 0};
+    OpKey key{site.trackId,          site.rackId, site.chainId, device.id,
+              OpRole::DeviceProcess, 0,           site.segment};
     const auto processOp = addOp(
         OpKind::Device, key, alignInputs(key, OpKind::Device, {signal.audio, midiIn, sidechainIn}),
         std::move(outputs));
@@ -544,8 +540,8 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
     // dry path, which skips those gains entirely. A rack whose chains all go to
     // aux outputs does render silence on the main output, in the engine too.)
     if (rack.chains.empty()) {
-        const OpKey faderKey{site.trackId,      rack.id,           INVALID_CHAIN_ID,
-                             INVALID_DEVICE_ID, OpRole::RackFader, 0};
+        const OpKey faderKey{site.trackId,      rack.id, INVALID_CHAIN_ID, INVALID_DEVICE_ID,
+                             OpRole::RackFader, 0,       site.segment};
         return {
             PortRef{addOp(OpKind::Fader, faderKey, {signal.audio, noInput()}, {SignalKind::Audio}),
                     0},
@@ -566,7 +562,7 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
             continue;
         }
 
-        const ChainSite chainSite{site.trackId, rack.id, chain.id};
+        const ChainSite chainSite{site.trackId, rack.id, chain.id, site.segment};
 
         auto chainSignal = signal;
         if (!chain.bypassed)
@@ -582,8 +578,8 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
         // have to go together. Routing MIDI around the fader would leave
         // whatever a rack nested in this chain generates with no gate at all,
         // because those ops key on the nested rack rather than on this chain.
-        const OpKey faderKey{site.trackId,           rack.id, chain.id, INVALID_DEVICE_ID,
-                             OpRole::RackChainFader, 0};
+        const OpKey faderKey{site.trackId,           rack.id, chain.id,    INVALID_DEVICE_ID,
+                             OpRole::RackChainFader, 0,       site.segment};
         std::vector<SignalKind> faderOutputs{SignalKind::Audio};
         if (generatesMidi)
             faderOutputs.push_back(SignalKind::Midi);
@@ -600,12 +596,12 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
     }
 
     ChainSignal out;
-    const OpKey mixKey{site.trackId,      rack.id,         INVALID_CHAIN_ID,
-                       INVALID_DEVICE_ID, OpRole::RackMix, 0};
+    const OpKey mixKey{site.trackId,    rack.id, INVALID_CHAIN_ID, INVALID_DEVICE_ID,
+                       OpRole::RackMix, 0,       site.segment};
     const auto mixed = emitMix(mixKey, chainAudio);
 
-    const OpKey faderKey{site.trackId,      rack.id,           INVALID_CHAIN_ID,
-                         INVALID_DEVICE_ID, OpRole::RackFader, 0};
+    const OpKey faderKey{site.trackId,      rack.id, INVALID_CHAIN_ID, INVALID_DEVICE_ID,
+                         OpRole::RackFader, 0,       site.segment};
     out.audio = PortRef{addOp(OpKind::Fader, faderKey, {mixed, noInput()}, {SignalKind::Audio}), 0};
 
     if (chainMidi.empty()) {
@@ -614,7 +610,7 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
         out.midi = chainMidi.front();
     } else {
         const OpKey midiKey{site.trackId,        rack.id, INVALID_CHAIN_ID, INVALID_DEVICE_ID,
-                            OpRole::RackMidiMix, 0};
+                            OpRole::RackMidiMix, 0,       site.segment};
         out.midi =
             PortRef{addOp(OpKind::MergeMidi, midiKey,
                           alignInputs(midiKey, OpKind::MergeMidi, chainMidi), {SignalKind::Midi}),
@@ -637,7 +633,7 @@ ChainSignal Compiler::emitElements(const std::vector<ChainElement>& elements, co
 
 void Compiler::emitTrack(const TrackInfo& track) {
     const auto isMaster = track.id == master_.id;
-    const ChainSite site{track.id, INVALID_RACK_ID, INVALID_CHAIN_ID};
+    const ChainSite fxSite{track.id, INVALID_RACK_ID, INVALID_CHAIN_ID, ChainSegment::Fx};
 
     // --- chain head ---
 
@@ -758,12 +754,16 @@ void Compiler::emitTrack(const TrackInfo& track) {
     // Chain power gates the whole insert chain without touching the devices'
     // own bypass flags. Post-FX and mixer analysis sit outside it.
     if (track.chain.enabled)
-        signal = emitElements(track.chain.fxChainElements, site, signal);
+        signal = emitElements(track.chain.fxChainElements, fxSite, signal);
 
+    const ChainSite postFxSite{track.id, INVALID_RACK_ID, INVALID_CHAIN_ID, ChainSegment::PostFx};
     for (const auto& element : track.chain.postFxChainElements)
-        signal = emitDevice(element.device, site, signal);
+        signal = emitDevice(element.device, postFxSite, signal);
+
+    const ChainSite analysisSite{track.id, INVALID_RACK_ID, INVALID_CHAIN_ID,
+                                 ChainSegment::MixerAnalysis};
     for (const auto& element : track.chain.mixerAnalysisElements)
-        signal = emitDevice(element.device, site, signal);
+        signal = emitDevice(element.device, analysisSite, signal);
 
     // --- fader, sends, meter, mute ---
     //

--- a/magda/engine/plan/RenderPlan.cpp
+++ b/magda/engine/plan/RenderPlan.cpp
@@ -2,13 +2,14 @@
 
 #include <algorithm>
 #include <map>
+#include <ostream>
 #include <tuple>
 
 namespace magda::engine {
 
 bool OpKey::operator<(const OpKey& o) const {
-    return std::tie(trackId, rackId, chainId, deviceId, role, index) <
-           std::tie(o.trackId, o.rackId, o.chainId, o.deviceId, o.role, o.index);
+    return std::tie(trackId, rackId, chainId, segment, deviceId, role, index) <
+           std::tie(o.trackId, o.rackId, o.chainId, o.segment, o.deviceId, o.role, o.index);
 }
 
 int arityOf(OpKind kind) {
@@ -141,8 +142,13 @@ std::string toString(const OpKey& key) {
         out += "/R" + std::to_string(key.rackId);
     if (key.chainId != INVALID_CHAIN_ID)
         out += "/C" + std::to_string(key.chainId);
-    if (key.deviceId != INVALID_DEVICE_ID)
+    if (key.deviceId != INVALID_DEVICE_ID) {
+        if (key.segment == ChainSegment::PostFx)
+            out += "/PF";
+        else if (key.segment == ChainSegment::MixerAnalysis)
+            out += "/MA";
         out += "/D" + std::to_string(key.deviceId);
+    }
     out += ":";
     out += toString(key.role);
 
@@ -166,6 +172,20 @@ std::string toString(const OpKey& key) {
     if (key.index != 0)
         out += "#" + std::to_string(key.index);
     return out;
+}
+
+std::string toString(const DeviceKey& key) {
+    std::string out;
+    if (key.segment == ChainSegment::PostFx)
+        out = "PostFx/";
+    else if (key.segment == ChainSegment::MixerAnalysis)
+        out = "MixerAnalysis/";
+    out += "D" + std::to_string(key.deviceId);
+    return out;
+}
+
+std::ostream& operator<<(std::ostream& out, const DeviceKey& key) {
+    return out << toString(key);
 }
 
 namespace {
@@ -269,6 +289,7 @@ std::uint64_t planFingerprint(const RenderPlan& plan) {
         mix(static_cast<std::uint64_t>(op.key.trackId));
         mix(static_cast<std::uint64_t>(op.key.rackId));
         mix(static_cast<std::uint64_t>(op.key.chainId));
+        mix(static_cast<std::uint64_t>(op.key.segment));
         mix(static_cast<std::uint64_t>(op.key.deviceId));
         mix(static_cast<std::uint64_t>(op.key.role));
         mix(static_cast<std::uint64_t>(op.key.index));

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include <iosfwd>
 #include <string>
+#include <tuple>
 #include <vector>
 
+#include "core/ChainNodePath.hpp"
 #include "core/TypeIds.hpp"
 
 /**
@@ -192,6 +196,42 @@ constexpr int crossfadeSlot(int index) {
 enum class LivenessDomain : std::uint8_t { Deterministic, Live };
 
 /**
+ * @brief Stable identity of one device instance in the project model.
+ *
+ * DeviceId is allocated independently for the main FX, post-FX and mixer-
+ * analysis sections. It is unique inside one section, across tracks and rack
+ * chains, but the same integer may name one device in each section. Runtime
+ * ownership therefore needs the section as well as the integer.
+ */
+struct DeviceKey {
+    ChainSegment segment = ChainSegment::Fx;
+    DeviceId deviceId = INVALID_DEVICE_ID;
+
+    DeviceKey() = default;
+    // Keeps the overwhelmingly common main-FX call sites compact.
+    DeviceKey(DeviceId id) : deviceId(id) {}
+    DeviceKey(ChainSegment section, DeviceId id) : segment(section), deviceId(id) {}
+
+    bool operator==(const DeviceKey& o) const {
+        return segment == o.segment && deviceId == o.deviceId;
+    }
+    bool operator!=(const DeviceKey& o) const {
+        return !(*this == o);
+    }
+    bool operator<(const DeviceKey& o) const {
+        return std::tie(segment, deviceId) < std::tie(o.segment, o.deviceId);
+    }
+};
+
+struct DeviceKeyHash {
+    std::size_t operator()(const DeviceKey& key) const noexcept {
+        const auto section = static_cast<std::size_t>(key.segment);
+        const auto device = static_cast<std::size_t>(key.deviceId);
+        return (section << (sizeof(std::size_t) * 4U)) ^ device;
+    }
+};
+
+/**
  * @brief An op's identity across plan swaps.
  *
  * The differ hash-joins old and new plans on this key. It is a flat value type
@@ -207,10 +247,16 @@ struct OpKey {
     OpRole role = OpRole::TrackAudioInput;
     /// Disambiguates repeats of the same role at the same location (send slot).
     int index = 0;
+    /// Which independently allocated device-id space this location belongs to.
+    ChainSegment segment = ChainSegment::Fx;
+
+    DeviceKey deviceKey() const {
+        return DeviceKey{segment, deviceId};
+    }
 
     bool operator==(const OpKey& o) const {
         return trackId == o.trackId && rackId == o.rackId && chainId == o.chainId &&
-               deviceId == o.deviceId && role == o.role && index == o.index;
+               deviceId == o.deviceId && role == o.role && index == o.index && segment == o.segment;
     }
     bool operator!=(const OpKey& o) const {
         return !(*this == o);
@@ -370,7 +416,11 @@ const char* toString(OpRole role);
 const char* toString(SignalKind kind);
 const char* toString(LivenessDomain domain);
 
-/** Canonical key text, e.g. "T1/R4/C5/D7:deviceProcess" or "T-2:trackFader". */
+/** Canonical device identity text, e.g. "D7", "PostFx/D7". */
+std::string toString(const DeviceKey& key);
+std::ostream& operator<<(std::ostream& out, const DeviceKey& key);
+
+/** Canonical key text, e.g. "T1/R4/C5/D7:deviceProcess" or "T1/PF/D7:deviceProcess". */
 std::string toString(const OpKey& key);
 
 }  // namespace magda::engine

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -2,12 +2,12 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <iosfwd>
 #include <string>
 #include <tuple>
 #include <vector>
 
-#include "core/ChainNodePath.hpp"
 #include "core/TypeIds.hpp"
 
 /**
@@ -208,8 +208,7 @@ struct DeviceKey {
     DeviceId deviceId = INVALID_DEVICE_ID;
 
     DeviceKey() = default;
-    // Keeps the overwhelmingly common main-FX call sites compact.
-    DeviceKey(DeviceId id) : deviceId(id) {}
+    explicit DeviceKey(DeviceId id) : deviceId(id) {}
     DeviceKey(ChainSegment section, DeviceId id) : segment(section), deviceId(id) {}
 
     bool operator==(const DeviceKey& o) const {
@@ -225,9 +224,10 @@ struct DeviceKey {
 
 struct DeviceKeyHash {
     std::size_t operator()(const DeviceKey& key) const noexcept {
-        const auto section = static_cast<std::size_t>(key.segment);
-        const auto device = static_cast<std::size_t>(key.deviceId);
-        return (section << (sizeof(std::size_t) * 4U)) ^ device;
+        auto seed = std::hash<DeviceId>{}(key.deviceId);
+        const auto segment = std::hash<unsigned>{}(static_cast<unsigned>(key.segment));
+        seed ^= segment + static_cast<std::size_t>(0x9e3779b9U) + (seed << 6U) + (seed >> 2U);
+        return seed;
     }
 };
 

--- a/tests/NullDiffNativeLeg.cpp
+++ b/tests/NullDiffNativeLeg.cpp
@@ -263,7 +263,7 @@ NativeRender renderNative(const Case& value) {
                 // passing signal is also what it does.
                 auto device = std::make_unique<Passthrough>();
                 device->prepare(context);
-                bindings.devices[op.key.deviceId] = device.get();
+                bindings.devices[op.key.deviceKey()] = device.get();
                 passthroughs.push_back(std::move(device));
                 break;
             }

--- a/tests/PlanGoldenFixtures.cpp
+++ b/tests/PlanGoldenFixtures.cpp
@@ -57,13 +57,15 @@ DeviceInfo instrument(DeviceId id) {
 /// requires it to match one op exactly, so a fixture cannot name a location
 /// that does not exist and get silence instead of a failure.
 engine::OpKey deviceAt(TrackId trackId, DeviceId deviceId, RackId rackId = INVALID_RACK_ID,
-                       ChainId chainId = INVALID_CHAIN_ID) {
+                       ChainId chainId = INVALID_CHAIN_ID,
+                       ChainSegment segment = ChainSegment::Fx) {
     engine::OpKey key;
     key.trackId = trackId;
     key.rackId = rackId;
     key.chainId = chainId;
     key.deviceId = deviceId;
     key.role = engine::OpRole::DeviceProcess;
+    key.segment = segment;
     return key;
 }
 
@@ -184,6 +186,28 @@ Fixture sidechain() {
     return value;
 }
 
+Fixture sectionLocalDeviceIds() {
+    Fixture value;
+    value.name = "section-local-device-ids";
+    value.covers = "the same device id in FX, post-FX and mixer analysis stays three identities";
+    value.tracks = {track(1)};
+    value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(effect(3)));
+    value.tracks[0].chain.postFxChainElements.push_back(PostFxChainElement{effect(3)});
+
+    auto analysis = effect(3);
+    analysis.deviceType = DeviceType::Analysis;
+    value.tracks[0].chain.mixerAnalysisElements.push_back(PostFxChainElement{analysis});
+
+    value.master = master();
+    value.options = withoutMeters();
+    value.deviceLatency = {
+        {deviceAt(1, 3), 16},
+        {deviceAt(1, 3, INVALID_RACK_ID, INVALID_CHAIN_ID, ChainSegment::PostFx), 32},
+        {deviceAt(1, 3, INVALID_RACK_ID, INVALID_CHAIN_ID, ChainSegment::MixerAnalysis), 64},
+    };
+    return value;
+}
+
 Fixture groupRouting() {
     Fixture value;
     value.name = "group-routing";
@@ -264,6 +288,7 @@ std::vector<Fixture> planFixtures() {
     fixtures.push_back(cascadedLatency());
     fixtures.push_back(rackChains());
     fixtures.push_back(sidechain());
+    fixtures.push_back(sectionLocalDeviceIds());
     fixtures.push_back(groupRouting());
     fixtures.push_back(insertDevice());
     fixtures.push_back(removeDevice());

--- a/tests/PlanGoldenFixtures.hpp
+++ b/tests/PlanGoldenFixtures.hpp
@@ -38,9 +38,8 @@ struct Fixture {
     ///
     /// The whole key rather than the device id alone, because a device id does
     /// not identify a device: TrackManager allocates them per section, so one
-    /// track's FX and post-FX chains can both hold id 3. Op keys do not carry
-    /// a section either, which is its own problem and not this file's, but a
-    /// fixture that states where it means is at least not adding to it.
+    /// track's FX and post-FX chains can both hold id 3. OpKey carries that
+    /// section, so a fixture can state which of those devices reports latency.
     ///
     /// The runner requires each entry to match exactly one Device op, which is
     /// what turns a mistyped location into a failure instead of a golden

--- a/tests/goldens/plan/section-local-device-ids.txt
+++ b/tests/goldens/plan/section-local-device-ids.txt
@@ -1,0 +1,43 @@
+# section-local-device-ids
+# the same device id in FX, post-FX and mixer analysis stays three identities
+#
+# Generated. See tests/test_plan_goldens.cpp to regenerate.
+
+== plan ==
+magda-render-plan v1
+ops=15 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/D3:deviceProcess            in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/D3:deviceGain               in=2:0              out=audio       deps=1
+[  4] Device      det   T1/PF/D3:deviceProcess         in=3:0,-,-          out=audio       deps=1
+[  5] Gain        det   T1/PF/D3:deviceGain            in=4:0              out=audio       deps=1
+[  6] Device      det   T1/MA/D3:deviceProcess         in=5:0,-,-          out=audio       deps=1
+[  7] Fader       det   T1:trackFader                  in=6:0,-            out=audio       deps=1
+[  8] Meter       det   T1:trackMeter                  in=7:0              out=audio       deps=1
+[  9] Gain        det   T1:trackMute                   in=8:0              out=audio       deps=1
+[ 10] MixAudio    det   T-2:trackAudioInput            in=9:0              out=audio       deps=1
+[ 11] Fader       det   T-2:trackFader                 in=10:0,-           out=audio       deps=1
+[ 12] Meter       det   T-2:trackMeter                 in=11:0             out=audio       deps=1
+[ 13] Gain        det   T-2:trackMute                  in=12:0             out=audio       deps=1
+[ 14] Output      det   T-2:hardwareOutput             in=13:0             out=-           deps=1
+ready=0
+
+== layout ==
+magda-plan-layout v1
+audioSlots=1 midiSlots=0 outputLatency=112
+[  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
+[  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
+[  2] Device      T1/D3:deviceProcess            lat=16      ports=a0          inplace
+[  3] Gain        T1/D3:deviceGain               lat=16      ports=a0          inplace
+[  4] Device      T1/PF/D3:deviceProcess         lat=48      ports=a0          inplace
+[  5] Gain        T1/PF/D3:deviceGain            lat=48      ports=a0          inplace
+[  6] Device      T1/MA/D3:deviceProcess         lat=112     ports=a0          inplace
+[  7] Fader       T1:trackFader                  lat=112     ports=a0          inplace
+[  8] Meter       T1:trackMeter                  lat=112     ports=a0          inplace
+[  9] Gain        T1:trackMute                   lat=112     ports=a0          inplace
+[ 10] MixAudio    T-2:trackAudioInput            lat=112     ports=a0          inplace
+[ 11] Fader       T-2:trackFader                 lat=112     ports=a0          inplace
+[ 12] Meter       T-2:trackMeter                 lat=112     ports=a0          inplace
+[ 13] Gain        T-2:trackMute                  lat=112     ports=a0          inplace
+[ 14] Output      T-2:hardwareOutput             lat=-       ports=-

--- a/tests/test_engine_session.cpp
+++ b/tests/test_engine_session.cpp
@@ -361,7 +361,7 @@ TEST_CASE("A latency change re-prepares the plan rather than recompiling it",
     session.process(kBlockSize, output);
     CHECK(output.getSample(0, 0) == approx(1.5f));
 
-    auto* device = factory.devicesById[7];
+    auto* device = factory.devicesById[DeviceKey{7}];
     REQUIRE(device != nullptr);
     const auto devicesCreated = ledger.devicesCreated.load();
     device->latency = 16;
@@ -370,7 +370,7 @@ TEST_CASE("A latency change re-prepares the plan rather than recompiling it",
 
     CHECK(session.livePlan() == plan);
     CHECK(ledger.devicesCreated.load() == devicesCreated);
-    CHECK(factory.devicesById[7] == device);
+    CHECK(factory.devicesById[DeviceKey{7}] == device);
 
     // Track 2 now waits for the track the device is on, so the first sixteen
     // samples are the latent track alone and the rest are both.
@@ -474,7 +474,7 @@ TEST_CASE("An object that is already playing is never prepared again", "[engine]
     auto tracks = trackWithEffect(7);
     publish(session, compile(tracks), tracks);
 
-    auto* device = factory.devicesById[7];
+    auto* device = factory.devicesById[DeviceKey{7}];
     REQUIRE(device != nullptr);
     CHECK(device->prepareCalls == 1);
 
@@ -490,7 +490,7 @@ TEST_CASE("An object that is already playing is never prepared again", "[engine]
     CHECK(device->blocksProcessed == 1);
 
     // The one that is new is prepared, exactly once, before it plays anything.
-    auto* added = factory.devicesById[8];
+    auto* added = factory.devicesById[DeviceKey{8}];
     REQUIRE(added != nullptr);
     CHECK(added->prepareCalls == 1);
     CHECK(added->blocksProcessed == 0);
@@ -503,7 +503,7 @@ TEST_CASE("A structural edit does not cut what is in flight", "[engine][session]
     // it over rather than the new one starting it empty.
     Ledger ledger;
     TestFactory factory(ledger);
-    factory.latencyFor[7] = 16;
+    factory.latencyFor[DeviceKey{7}] = 16;
     EngineSession session(factory);
 
     auto tracks = trackWithEffect(7);
@@ -544,7 +544,7 @@ TEST_CASE("A swap carries runtime state that the new plan still names", "[engine
     publish(session, firstPlan, first);
     session.publishValues(resolve(*firstPlan, first));
 
-    auto* device = factory.devicesById[7];
+    auto* device = factory.devicesById[DeviceKey{7}];
     REQUIRE(device != nullptr);
     CHECK(ledger.devicesCreated == 1);
 
@@ -560,7 +560,7 @@ TEST_CASE("A swap carries runtime state that the new plan still names", "[engine
 
     CHECK(ledger.devicesCreated == 2);
     CHECK(ledger.devicesDestroyed == 0);
-    CHECK(factory.devicesById[7] == device);
+    CHECK(factory.devicesById[DeviceKey{7}] == device);
 
     juce::AudioBuffer<float> output(2, kBlockSize);
     session.process(kBlockSize, output);
@@ -675,7 +675,7 @@ TEST_CASE("Bypass and chain power keep the device, deletion destroys it", "[engi
     auto tracks = trackWithEffect(7);
     const auto first = compile(tracks);
     publish(session, first, tracks);
-    auto* device = factory.devicesById[7];
+    auto* device = factory.devicesById[DeviceKey{7}];
     REQUIRE(device != nullptr);
 
     SECTION("bypassed") {
@@ -684,11 +684,11 @@ TEST_CASE("Bypass and chain power keep the device, deletion destroys it", "[engi
         publish(session, compile(bypassed), bypassed);
 
         CHECK(ledger.devicesDestroyed == 0);
-        CHECK(factory.devicesById[7] == device);
+        CHECK(factory.devicesById[DeviceKey{7}] == device);
 
         publish(session, compile(tracks), tracks);
         CHECK(ledger.devicesCreated == 1);
-        CHECK(factory.devicesById[7] == device);
+        CHECK(factory.devicesById[DeviceKey{7}] == device);
     }
 
     SECTION("chain power off") {
@@ -701,7 +701,7 @@ TEST_CASE("Bypass and chain power keep the device, deletion destroys it", "[engi
         powered[0].chain.enabled = true;
         publish(session, compile(powered), powered);
         CHECK(ledger.devicesCreated == 1);
-        CHECK(factory.devicesById[7] == device);
+        CHECK(factory.devicesById[DeviceKey{7}] == device);
     }
 
     SECTION("deleted from the model") {
@@ -733,7 +733,7 @@ TEST_CASE("Model IDs that have moved on cannot retire what the live plan uses",
     session.publishValues(resolve(*plan, tracks));
 
     CHECK(ledger.devicesDestroyed == 0);
-    REQUIRE(factory.devicesById[7] != nullptr);
+    REQUIRE(factory.devicesById[DeviceKey{7}] != nullptr);
 
     juce::AudioBuffer<float> output(2, kBlockSize);
     session.process(kBlockSize, output);
@@ -909,7 +909,7 @@ TEST_CASE("Swapping under a running audio thread never tears", "[engine][session
     CHECK(badBlocks == 0);
     // Device 8 came and went a hundred times; device 7 was named throughout.
     CHECK(ledger.devicesDestroyed > 0);
-    CHECK(factory.devicesById[7] != nullptr);
+    CHECK(factory.devicesById[DeviceKey{7}] != nullptr);
     CHECK(ledger.lastDestroyingThread.load() == std::this_thread::get_id());
 }
 
@@ -1144,7 +1144,7 @@ TEST_CASE("A session on a thread pool renders what a session without one renders
     const auto render = [](magda::engine::RenderThreadPool* pool) {
         Ledger ledger;
         TestFactory factory(ledger);
-        factory.latencyFor[7] = 53;
+        factory.latencyFor[DeviceKey{7}] = 53;
         EngineSession session(factory, pool);
 
         auto tracks = trackWithEffect(7);

--- a/tests/test_engine_session.cpp
+++ b/tests/test_engine_session.cpp
@@ -16,6 +16,7 @@
 using namespace magda;
 using magda::engine::BlockInfo;
 using magda::engine::DeviceBlock;
+using magda::engine::DeviceKey;
 using magda::engine::EngineAudioSource;
 using magda::engine::EngineDevice;
 using magda::engine::EngineSession;
@@ -121,16 +122,16 @@ class TestFactory final : public RuntimeStateFactory {
   public:
     explicit TestFactory(Ledger& ledger) : ledger_(ledger) {}
 
-    std::unique_ptr<EngineDevice> createDevice(DeviceId id) override {
-        auto device = std::make_unique<LedgerDevice>(ledger_, id);
-        device->latency = latencyFor.count(id) != 0 ? latencyFor[id] : 0;
+    std::unique_ptr<EngineDevice> createDevice(DeviceKey key) override {
+        auto device = std::make_unique<LedgerDevice>(ledger_, key.deviceId);
+        device->latency = latencyFor.count(key) != 0 ? latencyFor[key] : 0;
         lastDevice = device.get();
-        devicesById[id] = device.get();
+        devicesById[key] = device.get();
         return device;
     }
 
-    /// What a device reports once it is loaded, per device ID.
-    std::map<DeviceId, int> latencyFor;
+    /// What a device reports once it is loaded, per section-aware identity.
+    std::map<DeviceKey, int> latencyFor;
 
     std::unique_ptr<EngineAudioSource> createClipAudioSource(TrackId) override {
         ++ledger_.sourcesCreated;
@@ -154,7 +155,7 @@ class TestFactory final : public RuntimeStateFactory {
     std::map<magda::engine::OpKey, magda::engine::LevelTap*> metersByKey;
 
     LedgerDevice* lastDevice = nullptr;
-    std::map<DeviceId, LedgerDevice*> devicesById;
+    std::map<DeviceKey, LedgerDevice*> devicesById;
 
   private:
     Ledger& ledger_;
@@ -564,6 +565,73 @@ TEST_CASE("A swap carries runtime state that the new plan still names", "[engine
     juce::AudioBuffer<float> output(2, kBlockSize);
     session.process(kBlockSize, output);
     CHECK(output.getSample(0, 0) == approx(0.25f));
+}
+
+TEST_CASE("Section-local device ids keep distinct values, instances and lifetimes",
+          "[engine][session][device-identity]") {
+    Ledger ledger;
+    TestFactory factory(ledger);
+    EngineSession session(factory);
+
+    auto track = makeTrack(1);
+    auto fx = makeEffect(3);
+    fx.gainValue = 0.5f;
+    track.chain.fxChainElements.push_back(makeDeviceElement(fx));
+
+    auto postFx = makeEffect(3);
+    postFx.gainValue = 0.25f;
+    track.chain.postFxChainElements.push_back(PostFxChainElement{postFx});
+
+    auto analysis = makeEffect(3);
+    analysis.deviceType = DeviceType::Analysis;
+    track.chain.mixerAnalysisElements.push_back(PostFxChainElement{analysis});
+
+    std::vector<TrackInfo> tracks{track};
+    const auto plan = compile(tracks);
+    const auto values = resolve(*plan, tracks);
+
+    // Value lookup follows the same section discriminator as compilation.
+    std::map<ChainSegment, float> gains;
+    for (std::size_t i = 0; i < plan->ops.size(); ++i)
+        if (plan->ops[i].key.role == magda::engine::OpRole::DeviceGain)
+            gains[plan->ops[i].key.segment] = values.ops[i].gainLeft;
+    CHECK(gains[ChainSegment::Fx] == approx(0.5f));
+    CHECK(gains[ChainSegment::PostFx] == approx(0.25f));
+    CHECK_FALSE(gains.contains(ChainSegment::MixerAnalysis));
+
+    REQUIRE(publish(session, plan, tracks).published);
+    CHECK(ledger.devicesCreated == 3);
+
+    const DeviceKey fxKey{ChainSegment::Fx, 3};
+    const DeviceKey postFxKey{ChainSegment::PostFx, 3};
+    const DeviceKey analysisKey{ChainSegment::MixerAnalysis, 3};
+    auto* const fxInstance = factory.devicesById[fxKey];
+    auto* const postFxInstance = factory.devicesById[postFxKey];
+    auto* const analysisInstance = factory.devicesById[analysisKey];
+    REQUIRE(fxInstance != nullptr);
+    REQUIRE(postFxInstance != nullptr);
+    REQUIRE(analysisInstance != nullptr);
+    CHECK(fxInstance != postFxInstance);
+    CHECK(fxInstance != analysisInstance);
+    CHECK(postFxInstance != analysisInstance);
+
+    session.publishValues(values);
+    juce::AudioBuffer<float> output(2, kBlockSize);
+    session.process(kBlockSize, output);
+    // Each test device halves the signal, then the independently resolved FX
+    // and post-FX slot gains apply. Analysis devices have no slot gain.
+    CHECK(output.getSample(0, 0) == approx(1.0f / 64.0f));
+
+    tracks[0].chain.postFxChainElements.clear();
+    REQUIRE(publish(session, compile(tracks), tracks).published);
+    CHECK(ledger.devicesDestroyed == 1);
+    CHECK(factory.devicesById[fxKey] == fxInstance);
+    CHECK(factory.devicesById[analysisKey] == analysisInstance);
+
+    tracks[0].chain.fxChainElements.clear();
+    tracks[0].chain.mixerAnalysisElements.clear();
+    REQUIRE(publish(session, compile(tracks), tracks).published);
+    CHECK(ledger.devicesDestroyed == 3);
 }
 
 TEST_CASE("What a swap drops is destroyed on the publishing thread", "[engine][session]") {

--- a/tests/test_offline_render.cpp
+++ b/tests/test_offline_render.cpp
@@ -159,7 +159,7 @@ struct Harness {
             device->prepare(context);
             decay = device.get();
             devices.push_back(std::move(device));
-            bindings.devices[op.key.deviceId] = decay;
+            bindings.devices[op.key.deviceKey()] = decay;
         }
 
         valueMessages = magda::engine::resolvePlanValues(plan, tracks, master, values);

--- a/tests/test_parallel_executor.cpp
+++ b/tests/test_parallel_executor.cpp
@@ -35,6 +35,7 @@
 using namespace magda;
 using magda::engine::BlockInfo;
 using magda::engine::DeviceBlock;
+using magda::engine::DeviceKey;
 using magda::engine::EngineAudioSource;
 using magda::engine::EngineDevice;
 using magda::engine::EngineMidiSource;
@@ -442,8 +443,8 @@ Scene chainScene() {
     scene.tracks.push_back(track);
 
     scene.bindings.clipAudio[1] = scene.own(std::make_unique<RampSource>(3));
-    scene.bindings.devices[7] = scene.own(std::make_unique<GainDevice>(0.5f));
-    scene.bindings.devices[8] = scene.own(std::make_unique<TallyDevice>());
+    scene.bindings.devices[DeviceKey{7}] = scene.own(std::make_unique<GainDevice>(0.5f));
+    scene.bindings.devices[DeviceKey{8}] = scene.own(std::make_unique<TallyDevice>());
     return scene;
 }
 
@@ -459,7 +460,7 @@ Scene wideScene() {
         scene.tracks.push_back(track);
 
         scene.bindings.clipAudio[id] = scene.own(std::make_unique<RampSource>(id * 7));
-        scene.bindings.devices[100 + id] =
+        scene.bindings.devices[DeviceKey{100 + id}] =
             scene.own(std::make_unique<GainDevice>(0.9f - 0.05f * static_cast<float>(id)));
     }
     return scene;
@@ -481,7 +482,7 @@ Scene sendScene() {
     }
 
     scene.tracks.push_back(aux);
-    scene.bindings.devices[200] = scene.own(std::make_unique<GainDevice>(0.6f));
+    scene.bindings.devices[DeviceKey{200}] = scene.own(std::make_unique<GainDevice>(0.6f));
     return scene;
 }
 
@@ -500,7 +501,7 @@ Scene rackScene() {
         chain.elements.push_back(makeDeviceElement(makeEffect(300 + index)));
         rack->chains.push_back(std::move(chain));
 
-        scene.bindings.devices[300 + index] =
+        scene.bindings.devices[DeviceKey{300 + index}] =
             scene.own(std::make_unique<GainDevice>(0.3f + 0.2f * static_cast<float>(index)));
     }
 
@@ -533,8 +534,8 @@ Scene latencyScene() {
     scene.bindings.clipAudio[1] = scene.own(std::make_unique<RampSource>(11));
     scene.bindings.clipAudio[2] = scene.own(std::make_unique<RampSource>(23));
     scene.bindings.clipAudio[3] = scene.own(std::make_unique<RampSource>(37));
-    scene.bindings.devices[400] = scene.own(std::make_unique<LatentDevice>(37));
-    scene.bindings.devices[401] = scene.own(std::make_unique<LatentDevice>(96));
+    scene.bindings.devices[DeviceKey{400}] = scene.own(std::make_unique<LatentDevice>(37));
+    scene.bindings.devices[DeviceKey{401}] = scene.own(std::make_unique<LatentDevice>(96));
     return scene;
 }
 
@@ -551,8 +552,10 @@ Scene midiScene() {
         scene.bindings.clipAudio[id] = scene.own(std::make_unique<RampSource>(id * 3));
         scene.bindings.clipMidi[id] =
             scene.own(std::make_unique<TimelineNoteSource>(48 + 5 * id, 37 + id));
-        scene.bindings.devices[500 + id] = scene.own(std::make_unique<NoteToDcInstrument>());
-        scene.bindings.devices[600 + id] = scene.own(std::make_unique<GainDevice>(0.75f));
+        scene.bindings.devices[DeviceKey{500 + id}] =
+            scene.own(std::make_unique<NoteToDcInstrument>());
+        scene.bindings.devices[DeviceKey{600 + id}] =
+            scene.own(std::make_unique<GainDevice>(0.75f));
     }
 
     // MIDI out and the raw input passed on with it, so the chain merges two
@@ -567,8 +570,8 @@ Scene midiScene() {
 
     scene.bindings.clipAudio[4] = scene.own(std::make_unique<RampSource>(17));
     scene.bindings.clipMidi[4] = scene.own(std::make_unique<TimelineNoteSource>(72, 29));
-    scene.bindings.devices[700] = scene.own(std::make_unique<ArpDevice>(60));
-    scene.bindings.devices[701] = scene.own(std::make_unique<NoteToDcInstrument>());
+    scene.bindings.devices[DeviceKey{700}] = scene.own(std::make_unique<ArpDevice>(60));
+    scene.bindings.devices[DeviceKey{701}] = scene.own(std::make_unique<NoteToDcInstrument>());
     return scene;
 }
 
@@ -587,11 +590,11 @@ Scene groupScene() {
         scene.tracks.push_back(track);
 
         scene.bindings.clipAudio[id] = scene.own(std::make_unique<RampSource>(id * 29));
-        scene.bindings.devices[810 + id] = scene.own(std::make_unique<TallyDevice>());
+        scene.bindings.devices[DeviceKey{810 + id}] = scene.own(std::make_unique<TallyDevice>());
     }
 
     scene.bindings.clipAudio[5] = scene.own(std::make_unique<RampSource>(53));
-    scene.bindings.devices[800] = scene.own(std::make_unique<GainDevice>(0.8f));
+    scene.bindings.devices[DeviceKey{800}] = scene.own(std::make_unique<GainDevice>(0.8f));
     return scene;
 }
 
@@ -698,7 +701,7 @@ TEST_CASE("Ops on independent branches really do run at the same time",
         scene.tracks.push_back(track);
 
         scene.bindings.clipAudio[id] = scene.own(std::make_unique<RampSource>(id));
-        scene.bindings.devices[900 + id] =
+        scene.bindings.devices[DeviceKey{900 + id}] =
             scene.own(std::make_unique<RendezvousDevice>(meeting, 2));
     }
 
@@ -1008,7 +1011,8 @@ TEST_CASE("How a heavy graph scales across threads", "[.][bench]") {
             for (int slot = 0; slot < kDevicesPerTrack; ++slot) {
                 const DeviceId device = id * 100 + slot;
                 track.chain.fxChainElements.push_back(makeDeviceElement(makeEffect(device)));
-                scene.bindings.devices[device] = scene.own(std::make_unique<BusyDevice>());
+                scene.bindings.devices[DeviceKey{device}] =
+                    scene.own(std::make_unique<BusyDevice>());
             }
             scene.tracks.push_back(track);
             scene.bindings.clipAudio[id] = scene.own(std::make_unique<RampSource>(id));

--- a/tests/test_plan_crossfade.cpp
+++ b/tests/test_plan_crossfade.cpp
@@ -29,6 +29,7 @@
 using namespace magda;
 using magda::engine::BlockInfo;
 using magda::engine::DeviceBlock;
+using magda::engine::DeviceKey;
 using magda::engine::EngineAudioSource;
 using magda::engine::EngineDevice;
 using magda::engine::insertCrossfades;
@@ -165,7 +166,7 @@ struct Bench {
     void bindDevice(DeviceId id, float gain, int latency = 0) {
         owned.push_back(std::make_unique<GainDevice>(gain, latency));
         owned.back()->prepare(context);
-        bindings.devices[id] = owned.back().get();
+        bindings.devices[DeviceKey{id}] = owned.back().get();
     }
 
     RenderPlan compile() const {
@@ -705,7 +706,7 @@ TEST_CASE("A fade produces the latency of the side it is becoming", "[engine][pl
     PlanBindings bindings;
     bindings.clipAudio[1] = &one;
     bindings.clipAudio[2] = &two;
-    bindings.devices[7] = &latent;
+    bindings.devices[DeviceKey{7}] = &latent;
 
     PlanExecutor executor;
     for (const auto& message : executor.prepare(plan, bindings, context))

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -1399,33 +1400,32 @@ TEST_CASE("validatePlan enforces liveness provenance", "[engine][plan][validate]
     }
 }
 
-TEST_CASE("Section-local device ids compile to a plan the differ cannot key",
-          "[engine][plan][compiler]") {
-    // A known incompatibility between the app's model and the engine's op
-    // identity, pinned here so it is measured rather than assumed either way.
-    //
-    // TrackManager allocates device ids per section: nextFxDeviceId_,
-    // nextPostFxDeviceId_ and nextMixerAnalysisDeviceId_ are separate spaces,
-    // so id 3 legitimately exists on one track's FX chain and its post-FX
-    // chain at once. The compiler's ChainSite records only the innermost rack
-    // and chain, on the assumption that device ids are project-unique, so both
-    // devices compile to the same OpKey.
-    //
-    // validatePlan catches it, which is the one good thing here: the differ
-    // hash-joins old and new plans on OpKey, and a duplicate would carry one
-    // device's runtime state into another. So this is a rejected plan rather
-    // than a silently wrong one, and the app can build the model that causes
-    // it today.
-    //
-    // The fix is a section discriminator in ChainSite and OpKey, and it
-    // belongs with the engine migration rather than here.
+TEST_CASE("Section-local device ids have distinct plan identities",
+          "[engine][plan][compiler][device-identity]") {
+    // TrackManager allocates one id space per section. The same integer in all
+    // three sections is therefore an ordinary project, and every process op
+    // must still have the unique key the differ requires.
     std::vector<TrackInfo> tracks{makeTrack(1)};
     tracks[0].chain.fxChainElements.push_back(makeDeviceElement(makeEffect(3)));
     tracks[0].chain.postFxChainElements.push_back(PostFxChainElement{makeEffect(3)});
+    auto analysis = makeEffect(3);
+    analysis.deviceType = DeviceType::Analysis;
+    tracks[0].chain.mixerAnalysisElements.push_back(PostFxChainElement{analysis});
 
     const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
     const auto problems = magda::engine::validatePlan(plan);
 
     INFO(magda::engine::dumpPlan(plan));
-    CHECK_FALSE(problems.empty());
+    REQUIRE(problems.empty());
+
+    std::set<magda::engine::DeviceKey> devices;
+    for (const auto& op : plan.ops)
+        if (op.kind == OpKind::Device)
+            devices.insert(op.key.deviceKey());
+
+    CHECK(devices == std::set<magda::engine::DeviceKey>{
+                         {ChainSegment::Fx, 3},
+                         {ChainSegment::PostFx, 3},
+                         {ChainSegment::MixerAnalysis, 3},
+                     });
 }

--- a/tests/test_render_plan_executor.cpp
+++ b/tests/test_render_plan_executor.cpp
@@ -17,6 +17,7 @@
 using namespace magda;
 using magda::engine::BlockInfo;
 using magda::engine::DeviceBlock;
+using magda::engine::DeviceKey;
 using magda::engine::EngineAudioSource;
 using magda::engine::EngineDevice;
 using magda::engine::EngineMidiSource;
@@ -469,7 +470,7 @@ TEST_CASE("A source renders through a device into the master output", "[engine][
     ConstantSource source(0.5f);
     GainDevice device(0.5f);
     harness.bindings.clipAudio[1] = &source;
-    harness.bindings.devices[7] = &device;
+    harness.bindings.devices[DeviceKey{7}] = &device;
 
     harness.prepareCleanly();
     harness.render();
@@ -522,7 +523,7 @@ TEST_CASE("A device's gain trim scales its output", "[engine][exec]") {
     ConstantSource source(1.0f);
     GainDevice device(1.0f);
     harness.bindings.clipAudio[1] = &source;
-    harness.bindings.devices[7] = &device;
+    harness.bindings.devices[DeviceKey{7}] = &device;
 
     harness.prepareCleanly();
     harness.render();
@@ -776,7 +777,7 @@ TEST_CASE("A rack chain out of the mix contributes neither audio nor MIDI", "[en
         Harness harness({track}, makeMaster());
         harness.bindings.clipAudio[1] = &source;
         harness.bindings.clipMidi[1] = &notes;
-        harness.bindings.devices[8] = &instrument;
+        harness.bindings.devices[DeviceKey{8}] = &instrument;
 
         harness.prepareCleanly();
         harness.render();
@@ -790,7 +791,7 @@ TEST_CASE("A rack chain out of the mix contributes neither audio nor MIDI", "[en
         Harness harness({muted}, makeMaster());
         harness.bindings.clipAudio[1] = &source;
         harness.bindings.clipMidi[1] = &notes;
-        harness.bindings.devices[8] = &instrument;
+        harness.bindings.devices[DeviceKey{8}] = &instrument;
 
         harness.prepareCleanly();
         harness.render();
@@ -808,7 +809,7 @@ TEST_CASE("A rack chain out of the mix contributes neither audio nor MIDI", "[en
         Harness harness({soloed}, makeMaster());
         harness.bindings.clipAudio[1] = &source;
         harness.bindings.clipMidi[1] = &notes;
-        harness.bindings.devices[8] = &instrument;
+        harness.bindings.devices[DeviceKey{8}] = &instrument;
 
         harness.prepareCleanly();
         harness.render();
@@ -872,7 +873,7 @@ TEST_CASE("A rack inside a chain out of the mix stops processing", "[engine][exe
     ConstantSource source(1.0f);
     GainDevice nested(1.0f);
     harness.bindings.clipAudio[1] = &source;
-    harness.bindings.devices[7] = &nested;
+    harness.bindings.devices[DeviceKey{7}] = &nested;
 
     harness.prepareCleanly();
     harness.render();
@@ -897,7 +898,7 @@ TEST_CASE("Values resolved for another plan are not applied", "[engine][exec]") 
     ConstantSource source(1.0f);
     GainDevice device(1.0f);
     harness.bindings.clipAudio[1] = &source;
-    harness.bindings.devices[7] = &device;
+    harness.bindings.devices[DeviceKey{7}] = &device;
     harness.prepareCleanly();
 
     const std::vector<TrackInfo> otherTracks{replaced};
@@ -924,7 +925,7 @@ TEST_CASE("An instrument turns the track's MIDI into audio", "[engine][exec]") {
     NoteToDcInstrument instrument;
     harness.bindings.clipAudio[1] = &audio;
     harness.bindings.clipMidi[1] = &notes;
-    harness.bindings.devices[8] = &instrument;
+    harness.bindings.devices[DeviceKey{8}] = &instrument;
 
     harness.prepareCleanly();
     harness.render();
@@ -950,8 +951,8 @@ TEST_CASE("A MIDI-producing device's output reaches the device after it", "[engi
     NoteToDcInstrument instrument;
     harness.bindings.clipAudio[1] = &audio;
     harness.bindings.clipMidi[1] = &notes;
-    harness.bindings.devices[7] = &arpDevice;
-    harness.bindings.devices[8] = &instrument;
+    harness.bindings.devices[DeviceKey{7}] = &arpDevice;
+    harness.bindings.devices[DeviceKey{8}] = &instrument;
 
     harness.prepareCleanly();
     harness.render();
@@ -1006,7 +1007,7 @@ TEST_CASE("A merge carries everything that reaches it", "[engine][exec]") {
     harness.bindings.clipAudio[1] = &audio;
     harness.bindings.clipMidi[1] = &clips;
     harness.bindings.midiInputs[1] = &live;
-    harness.bindings.devices[8] = &counter;
+    harness.bindings.devices[DeviceKey{8}] = &counter;
 
     harness.prepareCleanly();
     harness.render();
@@ -1042,7 +1043,7 @@ TEST_CASE("An audio sidechain reaches the device that asked for it", "[engine][e
     SidechainProbe probe;
     harness.bindings.clipAudio[2] = &key;
     harness.bindings.clipAudio[1] = &main;
-    harness.bindings.devices[7] = &probe;
+    harness.bindings.devices[DeviceKey{7}] = &probe;
 
     harness.prepareCleanly();
     harness.render();
@@ -1060,7 +1061,7 @@ TEST_CASE("Unbound ops are reported and render silence", "[engine][exec]") {
 
     REQUIRE(messages.size() == 2);
     CHECK(messages[0].find("no clip audio source bound for track 1") != std::string::npos);
-    CHECK(messages[1].find("no device bound for device D7") != std::string::npos);
+    CHECK(messages[1].find("no device bound for D7") != std::string::npos);
 
     harness.render();
     CHECK(harness.outputSample() == approx(0.0f));
@@ -1074,7 +1075,7 @@ TEST_CASE("A device's latency becomes the plan's latency", "[engine][exec][pdc]"
     ImpulseSource source(0.5f);
     LatentDevice device(80);
     harness.bindings.clipAudio[1] = &source;
-    harness.bindings.devices[7] = &device;
+    harness.bindings.devices[DeviceKey{7}] = &device;
 
     harness.prepareCleanly();
     CHECK(harness.executor.latencySamples() == 80);
@@ -1104,7 +1105,7 @@ TEST_CASE("Paths that meet are aligned to the longest of them", "[engine][exec][
         Harness harness({latentTrack, makeTrack(2)}, makeMaster());
         harness.bindings.clipAudio[1] = &loud;
         harness.bindings.clipAudio[2] = &quiet;
-        harness.bindings.devices[7] = &latent;
+        harness.bindings.devices[DeviceKey{7}] = &latent;
 
         harness.prepareCleanly();
         const auto sounding = soundingSamples(renderStream(harness, 3));
@@ -1125,7 +1126,7 @@ TEST_CASE("Paths that meet are aligned to the longest of them", "[engine][exec][
         Harness harness({latentTrack, cleanTrack, makeTrack(3, TrackType::Group)}, makeMaster());
         harness.bindings.clipAudio[1] = &loud;
         harness.bindings.clipAudio[2] = &quiet;
-        harness.bindings.devices[7] = &latent;
+        harness.bindings.devices[DeviceKey{7}] = &latent;
 
         harness.prepareCleanly();
         const auto sounding = soundingSamples(renderStream(harness, 3));
@@ -1143,7 +1144,7 @@ TEST_CASE("Paths that meet are aligned to the longest of them", "[engine][exec][
         Harness harness({latentTrack, makeTrack(2)}, makeMaster());
         harness.bindings.clipAudio[1] = &loud;
         harness.bindings.clipAudio[2] = &quiet;
-        harness.bindings.devices[7] = &latent;
+        harness.bindings.devices[DeviceKey{7}] = &latent;
 
         harness.prepareCleanly();
         const auto sounding = soundingSamples(renderStream(harness, 3));
@@ -1169,8 +1170,8 @@ TEST_CASE("Paths that meet are aligned to the longest of them", "[engine][exec][
         SidechainSumDevice sum;
         harness.bindings.clipAudio[1] = &loud;
         harness.bindings.clipAudio[2] = &quiet;
-        harness.bindings.devices[7] = &sum;
-        harness.bindings.devices[8] = &latent;
+        harness.bindings.devices[DeviceKey{7}] = &sum;
+        harness.bindings.devices[DeviceKey{8}] = &latent;
 
         harness.prepareCleanly();
         const auto sounding = soundingSamples(renderStream(harness, 3));
@@ -1200,7 +1201,7 @@ TEST_CASE("Paths that meet are aligned to the longest of them", "[engine][exec][
 
         Harness harness({track}, makeMaster());
         harness.bindings.clipAudio[1] = &loud;
-        harness.bindings.devices[7] = &latent;
+        harness.bindings.devices[DeviceKey{7}] = &latent;
 
         harness.prepareCleanly();
         const auto sounding = soundingSamples(renderStream(harness, 3));
@@ -1237,8 +1238,8 @@ TEST_CASE("MIDI is aligned against the audio it travels with", "[engine][exec][p
     MidiPositionProbe probe;
     harness.bindings.clipAudio[1] = &audio;
     harness.bindings.clipMidi[1] = &notes;
-    harness.bindings.devices[7] = &latentArp;
-    harness.bindings.devices[8] = &probe;
+    harness.bindings.devices[DeviceKey{7}] = &latentArp;
+    harness.bindings.devices[DeviceKey{8}] = &probe;
 
     harness.prepareCleanly();
     renderStream(harness, 4);
@@ -1281,7 +1282,7 @@ TEST_CASE("Block size does not change what is rendered", "[engine][exec]") {
         RampSource source;
         GainDevice device(0.9f);
         harness.bindings.clipAudio[1] = &source;
-        harness.bindings.devices[7] = &device;
+        harness.bindings.devices[DeviceKey{7}] = &device;
         harness.prepareCleanly();
 
         harness.render(firstBlock, 0);
@@ -1306,7 +1307,7 @@ TEST_CASE("Block size does not change what is rendered", "[engine][exec]") {
         LatentDevice device(37);
         harness.bindings.clipAudio[1] = &ramp;
         harness.bindings.clipAudio[2] = &steady;
-        harness.bindings.devices[7] = &device;
+        harness.bindings.devices[DeviceKey{7}] = &device;
         harness.prepareCleanly();
 
         harness.render(firstBlock, 0);
@@ -1358,8 +1359,8 @@ TEST_CASE("Block size does not change where delayed MIDI lands", "[engine][exec]
         MidiPositionProbe probe;
         harness.bindings.clipAudio[1] = &audio;
         harness.bindings.clipMidi[1] = &notes;
-        harness.bindings.devices[7] = &latent;
-        harness.bindings.devices[8] = &probe;
+        harness.bindings.devices[DeviceKey{7}] = &latent;
+        harness.bindings.devices[DeviceKey{8}] = &probe;
         harness.prepareCleanly();
 
         std::int64_t timelineSample = 0;
@@ -1403,8 +1404,8 @@ TEST_CASE("Block size does not change where delayed MIDI lands", "[engine][exec]
         MidiPositionProbe probe;
         harness.bindings.clipAudio[1] = &audio;
         harness.bindings.clipMidi[1] = &notes;
-        harness.bindings.devices[7] = &latent;
-        harness.bindings.devices[8] = &probe;
+        harness.bindings.devices[DeviceKey{7}] = &latent;
+        harness.bindings.devices[DeviceKey{8}] = &probe;
         harness.prepareCleanly();
 
         std::int64_t timelineSample = 0;
@@ -1447,7 +1448,7 @@ TEST_CASE("What is in flight survives the plan being replaced", "[engine][exec][
     PlanBindings bindings;
     bindings.clipAudio[1] = &silent;
     bindings.clipAudio[2] = &impulse;
-    bindings.devices[7] = &latent;
+    bindings.devices[DeviceKey{7}] = &latent;
 
     const RenderContext context{44100.0, kBlockSize, 2};
     prepareBindings(bindings, context);
@@ -1486,7 +1487,7 @@ TEST_CASE("What is in flight survives the plan being replaced", "[engine][exec][
         // audio in the wrong place; starting again is a few milliseconds of
         // silence, and only one of those is recoverable.
         LatentDevice deeper(120);
-        bindings.devices[7] = &deeper;
+        bindings.devices[DeviceKey{7}] = &deeper;
 
         REQUIRE(second.prepare(plan, bindings, context, &first).empty());
         CHECK(second.carriedDelayLines() == 0);
@@ -1537,8 +1538,8 @@ TEST_CASE("A chain out of the mix silences a nested rack's MIDI too", "[engine][
         Harness harness({build(false)}, makeMaster());
         harness.bindings.clipAudio[1] = &audio;
         harness.bindings.clipMidi[1] = &notes;
-        harness.bindings.devices[7] = &arpDevice;
-        harness.bindings.devices[8] = &instrument;
+        harness.bindings.devices[DeviceKey{7}] = &arpDevice;
+        harness.bindings.devices[DeviceKey{8}] = &instrument;
 
         harness.prepareCleanly();
         harness.render();
@@ -1549,8 +1550,8 @@ TEST_CASE("A chain out of the mix silences a nested rack's MIDI too", "[engine][
         Harness harness({build(true)}, makeMaster());
         harness.bindings.clipAudio[1] = &audio;
         harness.bindings.clipMidi[1] = &notes;
-        harness.bindings.devices[7] = &arpDevice;
-        harness.bindings.devices[8] = &instrument;
+        harness.bindings.devices[DeviceKey{7}] = &arpDevice;
+        harness.bindings.devices[DeviceKey{8}] = &instrument;
 
         harness.prepareCleanly();
         harness.render();

--- a/tests/test_render_plan_executor.cpp
+++ b/tests/test_render_plan_executor.cpp
@@ -1060,7 +1060,7 @@ TEST_CASE("Unbound ops are reported and render silence", "[engine][exec]") {
 
     REQUIRE(messages.size() == 2);
     CHECK(messages[0].find("no clip audio source bound for track 1") != std::string::npos);
-    CHECK(messages[1].find("no device bound for device 7") != std::string::npos);
+    CHECK(messages[1].find("no device bound for device D7") != std::string::npos);
 
     harness.render();
     CHECK(harness.outputSample() == approx(0.0f));


### PR DESCRIPTION
## Summary

- add a section-aware `DeviceKey` and include the chain segment in `OpKey`
- propagate FX, post-FX, and mixer-analysis identity through plan compilation, value resolution, bindings, execution, and runtime-state ownership
- add compiler, session-lifecycle, and plan-golden regression coverage for the same numeric device ID in all three sections

## Root cause

Device IDs are allocated independently for FX, post-FX, and mixer-analysis sections, but the render plan and runtime state used the bare numeric ID as a project-wide identity. Two valid devices such as FX D3 and post-FX D3 therefore compiled to colliding op keys and could not safely participate in plan diffing or runtime-state retention.

## Impact

Valid projects can now use the same numeric device ID in different sections without plan validation failures, incorrect value lookup, binding collisions, or one device inheriting another device's runtime state.

## Validation

- `cmake --build cmake-build-debug --target magda_tests -j2`
- `magda_tests "[engine]"`: 377 test cases and 394,978 assertions passed
- pre-commit formatting and repository checks passed

Closes #2089