### PR TITLE
Relative transport seek (#1987)

### DIFF
--- a/magda/daw/api/osc_command_sink_live.cpp
+++ b/magda/daw/api/osc_command_sink_live.cpp
@@ -1,5 +1,6 @@
 #include "osc_command_sink_live.hpp"
 
+#include <algorithm>
 #include <cmath>
 
 #include "../audio/controllers/ControllerParamWriter.hpp"
@@ -20,6 +21,14 @@ namespace magda {
 
 using osc::OscCommand;
 using osc::OscCommandKind;
+
+namespace {
+
+/// TransportApi's bound, as a float, so an OSC argument can be clamped before
+/// it is rounded rather than after.
+constexpr float kMaxSeekBars = static_cast<float>(TransportApi::kMaxBarOffset);
+
+}  // namespace
 
 OscCommandSinkLive::OscCommandSinkLive(MagdaApi& api, std::unique_ptr<ControllerParamWriter> writer)
     : api_(api), writer_(std::move(writer)) {
@@ -95,12 +104,23 @@ void OscCommandSinkLive::apply(const OscCommand& command, float value) {
             api_.transport().seekBeats(value);
             return;
         case OscCommandKind::TransportSeekBars:
+            // Clamped before it is rounded, not after. A float reaches 3.4e38
+            // and llround is a domain error past about 9.2e18: the result is
+            // unspecified, and on x86 and ARM it is LLONG_MIN for either sign,
+            // so a huge *positive* delta would seek to the start of the
+            // project. That is reachable from the network, since OSC is
+            // unauthenticated UDP. Clamping first makes the facade's own bound
+            // the thing that decides, on every platform.
+            //
             // Rounded rather than truncated, so a surface that sends its
             // integers as floats and lands on 0.999999 still moves a bar.
-            // llround rather than lround, and no narrowing: the facade bounds
-            // the count, so a surface sending 1e30 gets one end of the project
-            // rather than whatever the conversion happened to produce.
-            api_.transport().seekBars(std::llround(value));
+            //
+            // NaN first, because a clamp does not catch it: every comparison
+            // against it is false, so it would pass straight through to the
+            // same domain error the clamp is here to prevent.
+            if (!std::isfinite(value))
+                return;
+            api_.transport().seekBars(std::llround(std::clamp(value, -kMaxSeekBars, kMaxSeekBars)));
             return;
 
         case OscCommandKind::MasterVolume:

--- a/magda/daw/api/osc_command_sink_live.cpp
+++ b/magda/daw/api/osc_command_sink_live.cpp
@@ -97,7 +97,10 @@ void OscCommandSinkLive::apply(const OscCommand& command, float value) {
         case OscCommandKind::TransportSeekBars:
             // Rounded rather than truncated, so a surface that sends its
             // integers as floats and lands on 0.999999 still moves a bar.
-            api_.transport().seekBars(static_cast<int>(std::lround(value)));
+            // llround rather than lround, and no narrowing: the facade bounds
+            // the count, so a surface sending 1e30 gets one end of the project
+            // rather than whatever the conversion happened to produce.
+            api_.transport().seekBars(std::llround(value));
             return;
 
         case OscCommandKind::MasterVolume:

--- a/magda/daw/api/osc_command_sink_live.cpp
+++ b/magda/daw/api/osc_command_sink_live.cpp
@@ -1,5 +1,7 @@
 #include "osc_command_sink_live.hpp"
 
+#include <cmath>
+
 #include "../audio/controllers/ControllerParamWriter.hpp"
 #include "../core/ControlTarget.hpp"
 #include "../core/MixerStripOrder.hpp"
@@ -88,6 +90,14 @@ void OscCommandSinkLive::apply(const OscCommand& command, float value) {
             return;
         case OscCommandKind::TransportPosition:
             api_.transport().setPositionBeats(value);
+            return;
+        case OscCommandKind::TransportSeekBeats:
+            api_.transport().seekBeats(value);
+            return;
+        case OscCommandKind::TransportSeekBars:
+            // Rounded rather than truncated, so a surface that sends its
+            // integers as floats and lands on 0.999999 still moves a bar.
+            api_.transport().seekBars(static_cast<int>(std::lround(value)));
             return;
 
         case OscCommandKind::MasterVolume:

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -1582,6 +1582,14 @@ OperationRegistry::OperationRegistry() {
             "required":["positionBeats"],"additionalProperties":false
         })json"),
         transportSchema());
+    add("transport.seekRelative", "Move the transport by beats or bars, clamped at zero",
+        OperationAccess::Write, &handlers::transportSeekRelative, operationInputSchema(R"json({
+            "type":"object",
+            "properties":{"deltaBeats":{"type":"number"},"deltaBars":{"type":"integer"}},
+            "oneOf":[{"required":["deltaBeats"]},{"required":["deltaBars"]}],
+            "additionalProperties":false
+        })json"),
+        transportSchema());
 
     add("session.get", "Get occupied session slots and play states", OperationAccess::Read,
         &handlers::sessionGet, emptyObjectSchema(), sessionSchema());
@@ -1734,6 +1742,7 @@ OperationRegistry::OperationRegistry() {
         {"transport.setRecording", Scope::Transport},
         {"transport.setLoopEnabled", Scope::Transport},
         {"transport.seek", Scope::Transport},
+        {"transport.seekRelative", Scope::Transport},
 
         // Clip launching. Neither editing nor the timeline transport: a
         // performance controller firing scenes changes no project content and

--- a/magda/daw/api/remote_api.cpp
+++ b/magda/daw/api/remote_api.cpp
@@ -54,9 +54,10 @@ void applyIntegerBounds(juce::var schema, const juce::String& propertyName = {})
     if (!items.isVoid())
         applyIntegerBounds(items, propertyName);
 
-    if (auto* alternatives = object->getProperty("anyOf").getArray())
-        for (auto& alternative : *alternatives)
-            applyIntegerBounds(alternative, propertyName);
+    for (const char* keyword : {"anyOf", "oneOf"})
+        if (auto* alternatives = object->getProperty(keyword).getArray())
+            for (auto& alternative : *alternatives)
+                applyIntegerBounds(alternative, propertyName);
 }
 
 // Blanket DoS caps for request payloads. Response schemas must stay valid for
@@ -81,9 +82,10 @@ void applyRequestLimits(juce::var schema) {
     if (!items.isVoid())
         applyRequestLimits(items);
 
-    if (auto* alternatives = object->getProperty("anyOf").getArray())
-        for (auto& alternative : *alternatives)
-            applyRequestLimits(alternative);
+    for (const char* keyword : {"anyOf", "oneOf"})
+        if (auto* alternatives = object->getProperty(keyword).getArray())
+            for (auto& alternative : *alternatives)
+                applyRequestLimits(alternative);
 }
 
 juce::var parseSchema(const char* json) {
@@ -632,6 +634,43 @@ void validateValue(const juce::var& value, const juce::var& schema, const juce::
         addIssue(issues, path, "any_of", "Value does not match any allowed schema");
         issues.insert(issues.end(), branchIssues.begin(), branchIssues.end());
         return;
+    }
+
+    // Exactly one branch, where anyOf wants at least one. Implemented rather
+    // than ignored: an unknown keyword is silently dropped here, so a schema
+    // that declared oneOf would advertise a constraint nothing enforced, and
+    // both "neither field" and "both fields" would reach the handler.
+    if (auto* alternatives = schemaObject->getProperty("oneOf").getArray()) {
+        int matches = 0;
+        std::vector<ValidationIssue> branchIssues;
+
+        for (int index = 0; index < alternatives->size(); ++index) {
+            std::vector<ValidationIssue> candidateIssues;
+            validateValue(value, (*alternatives)[index],
+                          path + "<oneOf:" + juce::String(index) + ">", candidateIssues);
+            if (candidateIssues.empty())
+                ++matches;
+            else
+                branchIssues.insert(branchIssues.end(), candidateIssues.begin(),
+                                    candidateIssues.end());
+        }
+
+        // Only a failure ends validation here. Unlike anyOf, whose branches
+        // stand for the whole schema, oneOf sits beside properties, required
+        // and additionalProperties on the same object -- returning on success
+        // would skip every one of them, so the exclusivity would be enforced
+        // and the field bounds silently would not.
+        if (matches != 1) {
+            if (matches == 0) {
+                addIssue(issues, path, "one_of", "Value does not match any allowed schema");
+                issues.insert(issues.end(), branchIssues.begin(), branchIssues.end());
+            } else {
+                addIssue(issues, path, "one_of",
+                         "Value matches " + juce::String(matches) +
+                             " allowed schemas, but must match exactly one");
+            }
+            return;
+        }
     }
 
     const auto declaredType = schemaObject->getProperty("type");
@@ -1585,7 +1624,10 @@ OperationRegistry::OperationRegistry() {
     add("transport.seekRelative", "Move the transport by beats or bars, clamped at zero",
         OperationAccess::Write, &handlers::transportSeekRelative, operationInputSchema(R"json({
             "type":"object",
-            "properties":{"deltaBeats":{"type":"number"},"deltaBars":{"type":"integer"}},
+            "properties":{
+                "deltaBeats":{"type":"number"},
+                "deltaBars":{"type":"integer","minimum":-1000000,"maximum":1000000}
+            },
             "oneOf":[{"required":["deltaBeats"]},{"required":["deltaBars"]}],
             "additionalProperties":false
         })json"),

--- a/magda/daw/api/remote_handlers.cpp
+++ b/magda/daw/api/remote_handlers.cpp
@@ -615,7 +615,7 @@ HandlerResult transportSeek(MagdaApi& api, const juce::var& input, const Request
 // that once for every surface.
 HandlerResult transportSeekRelative(MagdaApi& api, const juce::var& input, const RequestContext&) {
     if (input.hasProperty("deltaBars"))
-        api.transport().seekBars(static_cast<int>(input["deltaBars"]));
+        api.transport().seekBars(static_cast<juce::int64>(input["deltaBars"]));
     else
         api.transport().seekBeats(static_cast<double>(input["deltaBeats"]));
 

--- a/magda/daw/api/remote_handlers.cpp
+++ b/magda/daw/api/remote_handlers.cpp
@@ -608,6 +608,20 @@ HandlerResult transportSeek(MagdaApi& api, const juce::var& input, const Request
     return HandlerResult::ok(toJson(makeTransportDto(api)));
 }
 
+// Relative seeking (#1987). One operation rather than two, because a caller
+// binding a rewind button wants "back one bar" or "back a beat and a half" and
+// the difference is which field it sends, not which endpoint it calls. Both
+// clamp at zero and the bar form follows the meter, because TransportApi does
+// that once for every surface.
+HandlerResult transportSeekRelative(MagdaApi& api, const juce::var& input, const RequestContext&) {
+    if (input.hasProperty("deltaBars"))
+        api.transport().seekBars(static_cast<int>(input["deltaBars"]));
+    else
+        api.transport().seekBeats(static_cast<double>(input["deltaBeats"]));
+
+    return HandlerResult::ok(toJson(makeTransportDto(api)));
+}
+
 // ===========================================================================
 // Session
 // ===========================================================================

--- a/magda/daw/api/remote_handlers.hpp
+++ b/magda/daw/api/remote_handlers.hpp
@@ -64,6 +64,7 @@ HandlerResult transportStop(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult transportSetRecording(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult transportSetLoopEnabled(MagdaApi&, const juce::var&, const RequestContext&);
 HandlerResult transportSeek(MagdaApi&, const juce::var&, const RequestContext&);
+HandlerResult transportSeekRelative(MagdaApi&, const juce::var&, const RequestContext&);
 
 // Session
 HandlerResult sessionGet(MagdaApi&, const juce::var&, const RequestContext&);

--- a/magda/daw/api/transport_api.hpp
+++ b/magda/daw/api/transport_api.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+
 namespace magda {
 
 /**
@@ -35,6 +37,38 @@ class TransportApi {
     /** Edit position in beats. Returns 0 if no edit is loaded. */
     virtual double getPositionBeats() const = 0;
     virtual void setPositionBeats(double beats) = 0;
+
+    /**
+     * The beat position `deltaBars` bars from `beats`, keeping the offset
+     * within the bar and following any meter changes in between.
+     *
+     * The one thing relative seeking needs that absolute positioning does not:
+     * how long a bar is, which is a property of the project rather than of the
+     * caller. Implementations answer it; `seekBars` below is written once on
+     * top. Returns `beats` unchanged when there is no edit to ask.
+     */
+    virtual double beatsAtBarOffset(double beats, int deltaBars) const = 0;
+
+    // ------------------------------------------------------------------
+    // Relative seeking (#1987)
+    //
+    // Concrete rather than virtual, and here rather than in any one caller.
+    // Rewind and fast-forward buttons are relative by nature, and three
+    // surfaces need them — Lua scripts, the remote API's transport
+    // operations, and the OSC namespace. Written as read-modify-write at each
+    // of those, the clamp at zero and the bar length get re-derived three
+    // times and drift three ways.
+    // ------------------------------------------------------------------
+
+    /** Move the playhead `delta` beats, clamped at zero. */
+    void seekBeats(double delta) {
+        setPositionBeats(std::max(0.0, getPositionBeats() + delta));
+    }
+
+    /** Move the playhead `deltaBars` bars, meter-aware, clamped at zero. */
+    void seekBars(int deltaBars) {
+        setPositionBeats(std::max(0.0, beatsAtBarOffset(getPositionBeats(), deltaBars)));
+    }
 };
 
 }  // namespace magda

--- a/magda/daw/api/transport_api.hpp
+++ b/magda/daw/api/transport_api.hpp
@@ -65,9 +65,30 @@ class TransportApi {
         setPositionBeats(std::max(0.0, getPositionBeats() + delta));
     }
 
-    /** Move the playhead `deltaBars` bars, meter-aware, clamped at zero. */
-    void seekBars(int deltaBars) {
-        setPositionBeats(std::max(0.0, beatsAtBarOffset(getPositionBeats(), deltaBars)));
+    /**
+     * The furthest one seek moves, in bars.
+     *
+     * Past any real project by a wide margin — a million bars of 4/4 is about
+     * thirty days of music at 120 bpm — and small enough that adding it to a
+     * bar number cannot overflow an int.
+     */
+    static constexpr int kMaxBarOffset = 1000000;
+
+    /**
+     * Move the playhead `deltaBars` bars, meter-aware, clamped at zero.
+     *
+     * Takes a 64-bit count and bounds it here rather than at each caller.
+     * Every surface reads its number from somewhere outside MAGDA — a Lua
+     * integer, a JSON number, an OSC float — and narrowing to int at three
+     * different edges is three chances to do it wrong. Anything past the
+     * bound is a seek to one end of the project or the other, which is what
+     * clamping gives.
+     */
+    void seekBars(long long deltaBars) {
+        const auto bounded = static_cast<int>(std::clamp<long long>(
+            deltaBars, -static_cast<long long>(kMaxBarOffset), kMaxBarOffset));
+
+        setPositionBeats(std::max(0.0, beatsAtBarOffset(getPositionBeats(), bounded)));
     }
 };
 

--- a/magda/daw/api/transport_api.hpp
+++ b/magda/daw/api/transport_api.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
 
 namespace magda {
 
@@ -60,8 +61,19 @@ class TransportApi {
     // times and drift three ways.
     // ------------------------------------------------------------------
 
-    /** Move the playhead `delta` beats, clamped at zero. */
+    /**
+     * Move the playhead `delta` beats, clamped at zero.
+     *
+     * A non-finite delta moves nothing. The clamp cannot catch one: every
+     * comparison against NaN is false, so `std::max(0.0, NaN)` is 0 and a
+     * single bad number would send the playhead to the start of the project.
+     * Every surface takes its delta from outside MAGDA — a Lua number, a JSON
+     * number, an OSC float — so it is refused here rather than at each of them.
+     */
     void seekBeats(double delta) {
+        if (!std::isfinite(delta))
+            return;
+
         setPositionBeats(std::max(0.0, getPositionBeats() + delta));
     }
 
@@ -88,7 +100,11 @@ class TransportApi {
         const auto bounded = static_cast<int>(std::clamp<long long>(
             deltaBars, -static_cast<long long>(kMaxBarOffset), kMaxBarOffset));
 
-        setPositionBeats(std::max(0.0, beatsAtBarOffset(getPositionBeats(), bounded)));
+        const auto target = beatsAtBarOffset(getPositionBeats(), bounded);
+        if (!std::isfinite(target))
+            return;
+
+        setPositionBeats(std::max(0.0, target));
     }
 };
 

--- a/magda/daw/api/transport_api_live.cpp
+++ b/magda/daw/api/transport_api_live.cpp
@@ -81,4 +81,27 @@ void TransportApiLive::setPositionBeats(double beats) {
     e->getTransport().setPosition(t);
 }
 
+double TransportApiLive::beatsAtBarOffset(double beats, int deltaBars) const {
+    auto* e = edit();
+    if (!e || deltaBars == 0)
+        return beats;
+
+    // Through bars-and-beats rather than by multiplying out a bar length,
+    // because a bar is only a fixed number of beats when the meter is. The
+    // sequence walks whatever time signatures lie between the two points, so
+    // crossing a 4/4 to 7/8 change lands where the bar line actually is, and
+    // the offset within the bar is carried across untouched.
+    const auto here = e->tempoSequence.toTime(te::BeatPosition::fromBeats(beats));
+    auto barsAndBeats = e->tempoSequence.toBarsAndBeats(here);
+    barsAndBeats.bars += deltaBars;
+
+    // Before the start of the timeline there are no bars to count, and the
+    // sequence has nothing to answer with. The caller clamps at zero anyway;
+    // this keeps the conversion from being asked a question with no answer.
+    if (barsAndBeats.bars < 0)
+        return 0.0;
+
+    return e->tempoSequence.toBeats(barsAndBeats).inBeats();
+}
+
 }  // namespace magda

--- a/magda/daw/api/transport_api_live.cpp
+++ b/magda/daw/api/transport_api_live.cpp
@@ -2,6 +2,9 @@
 
 #include <tracktion_engine/tracktion_engine.h>
 
+#include <algorithm>
+#include <limits>
+
 namespace magda {
 
 namespace te = tracktion;
@@ -93,13 +96,21 @@ double TransportApiLive::beatsAtBarOffset(double beats, int deltaBars) const {
     // the offset within the bar is carried across untouched.
     const auto here = e->tempoSequence.toTime(te::BeatPosition::fromBeats(beats));
     auto barsAndBeats = e->tempoSequence.toBarsAndBeats(here);
-    barsAndBeats.bars += deltaBars;
+
+    // Widened for the addition. `deltaBars` is bounded by seekBars, but the bar
+    // number it lands on comes from the playhead, so this is where two numbers
+    // MAGDA did not choose together meet — and int + int is the one place that
+    // is undefined rather than merely wrong.
+    const auto target = static_cast<long long>(barsAndBeats.bars) + deltaBars;
 
     // Before the start of the timeline there are no bars to count, and the
     // sequence has nothing to answer with. The caller clamps at zero anyway;
     // this keeps the conversion from being asked a question with no answer.
-    if (barsAndBeats.bars < 0)
+    if (target < 0)
         return 0.0;
+
+    barsAndBeats.bars =
+        static_cast<int>(std::min(target, static_cast<long long>(std::numeric_limits<int>::max())));
 
     return e->tempoSequence.toBeats(barsAndBeats).inBeats();
 }

--- a/magda/daw/api/transport_api_live.hpp
+++ b/magda/daw/api/transport_api_live.hpp
@@ -60,6 +60,7 @@ class TransportApiLive : public TransportApi {
     void setLoopEnabled(bool enabled) override;
     double getPositionBeats() const override;
     void setPositionBeats(double beats) override;
+    double beatsAtBarOffset(double beats, int deltaBars) const override;
 
   private:
     tracktion::Edit* edit() const {

--- a/magda/daw/audio/osc/OscAddress.cpp
+++ b/magda/daw/audio/osc/OscAddress.cpp
@@ -108,6 +108,9 @@ OscArgKind argKindFor(OscCommandKind kind) {
             return OscArgKind::Bpm;
         case OscCommandKind::TransportPosition:
             return OscArgKind::Beats;
+        case OscCommandKind::TransportSeekBeats:
+        case OscCommandKind::TransportSeekBars:
+            return OscArgKind::Delta;
         case OscCommandKind::MasterVolume:
         case OscCommandKind::MasterPan:
         case OscCommandKind::FocusedMacro:
@@ -134,6 +137,15 @@ std::optional<OscCommand> parseOscAddress(juce::StringRef address) {
     const auto& section = parts[1];
 
     if (section.equals("transport")) {
+        // The one transport address with a component of its own: bars are a
+        // different unit rather than a different command, so they hang off
+        // seek instead of taking a leaf name that has to be read as one word.
+        if (count == 4) {
+            if (parts[2].equals("seek") && parts[3].equals("bars"))
+                return unindexed(OscCommandKind::TransportSeekBars);
+            return std::nullopt;
+        }
+
         if (count != 3)
             return std::nullopt;
         const auto& leaf = parts[2];
@@ -149,6 +161,8 @@ std::optional<OscCommand> parseOscAddress(juce::StringRef address) {
             return unindexed(OscCommandKind::TransportTempo);
         if (leaf.equals("position"))
             return unindexed(OscCommandKind::TransportPosition);
+        if (leaf.equals("seek"))
+            return unindexed(OscCommandKind::TransportSeekBeats);
         return std::nullopt;
     }
 

--- a/magda/daw/audio/osc/OscAddress.hpp
+++ b/magda/daw/audio/osc/OscAddress.hpp
@@ -28,6 +28,8 @@ namespace magda::osc {
  * | `/magda/transport/loop`    | 0/1, or none     | loop on/off, or flip       |
  * | `/magda/transport/tempo`   | float BPM        | set tempo                  |
  * | `/magda/transport/position`| float beats      | locate                     |
+ * | `/magda/transport/seek`    | float beats      | move by, clamped at zero   |
+ * | `/magda/transport/seek/bars`| int bars        | move by, meter-aware       |
  * | `/magda/track/{n}/volume`  | float 0–1        | track fader                |
  * | `/magda/track/{n}/pan`     | float 0–1        | pan, 0.5 centre            |
  * | `/magda/track/{n}/mute`    | 0/1, or none     | mute on/off, or flip       |
@@ -72,6 +74,8 @@ enum class OscCommandKind : std::uint8_t {
     TransportLoop,
     TransportTempo,
     TransportPosition,
+    TransportSeekBeats,
+    TransportSeekBars,
     MasterVolume,
     MasterPan,
     FocusedMacro,
@@ -104,6 +108,12 @@ enum class OscArgKind : std::uint8_t {
     Bpm,
     /// A float position in beats — MAGDA's timeline unit everywhere.
     Beats,
+    /// A distance rather than a position: how far to move from wherever the
+    /// playhead is. Unlike every other value here it must not be coalesced,
+    /// because two rewind presses are two bars and latest-value-wins would
+    /// make them one. It rides the ordered ring with the triggers and toggles
+    /// for that reason — an edge that happens to carry a magnitude.
+    Delta,
 };
 
 /**
@@ -164,9 +174,13 @@ int oscSlotIndex(const OscCommand& command);
  */
 OscCommand oscCommandForSlot(int slot);
 
-/// The six transport kinds and the two master kinds are the first eight
-/// entries of `OscCommandKind`, and take the first eight slots in that order.
-inline constexpr int kOscUnindexedSlots = 8;
+/// The eight transport kinds and the two master kinds are the first ten
+/// entries of `OscCommandKind`, and take the first ten slots in that order.
+///
+/// The two seek kinds never publish into their slots -- they are `Delta` and
+/// go to the ordered ring -- but they keep them anyway, so that "a kind's slot
+/// is its ordinal" stays true of the whole enum rather than of most of it.
+inline constexpr int kOscUnindexedSlots = 10;
 /// Then the focused device's macros, then one block per addressable track:
 /// volume, pan, mute, solo, and one slot per send.
 inline constexpr int kOscTrackSlotBase = kOscUnindexedSlots + kMaxMacroNumber;

--- a/magda/daw/audio/osc/OscRouter.cpp
+++ b/magda/daw/audio/osc/OscRouter.cpp
@@ -151,6 +151,16 @@ std::optional<float> oscValueFor(const OscCommand& command, const juce::OSCMessa
                 return std::nullopt;
             return juce::jlimit(0.0f, 1.0f, argument.value);
 
+        case OscArgKind::Delta:
+            // A distance, and a zero one is a no-op rather than a release
+            // edge: nothing here is momentary. Sent bare it says nothing about
+            // how far, so there is nothing to do.
+            if (argument.state != ArgumentState::Present)
+                return std::nullopt;
+            if (argument.value == 0.0f)
+                return std::nullopt;
+            return argument.value;
+
         case OscArgKind::Bpm:
         case OscArgKind::Beats:
             // Ranges belong to the model, which clamps against the project's
@@ -315,9 +325,17 @@ void OscRouter::updateBindings(const std::vector<Binding>& bindings) {
 
 void OscRouter::submit(const OscCommand& command, float value) {
     const auto argKind = argKindFor(command.kind);
-    if (argKind == OscArgKind::Trigger || argKind == OscArgKind::Toggle) {
+    if (argKind == OscArgKind::Trigger || argKind == OscArgKind::Toggle ||
+        argKind == OscArgKind::Delta) {
         // An edge, not a value. Two flips of one toggle have to stay two, and
         // play and stop have to resolve by arrival rather than by slot number.
+        //
+        // A relative seek is the same shape for a different reason: it says
+        // how far to move rather than where to be, so two presses of a rewind
+        // button are two bars and coalescing them into one slot would silently
+        // make them one. It also has to land relative to the position a locate
+        // in the same bundle just set, which arrival order gives it and a slot
+        // walk does not.
         pushOrdered(command, value);
         scheduleDrain();
         return;

--- a/magda/daw/audio/osc/OscRouter.cpp
+++ b/magda/daw/audio/osc/OscRouter.cpp
@@ -157,7 +157,7 @@ std::optional<float> oscValueFor(const OscCommand& command, const juce::OSCMessa
             // how far, so there is nothing to do.
             if (argument.state != ArgumentState::Present)
                 return std::nullopt;
-            if (argument.value == 0.0f)
+            if (argument.value == 0.0f || !std::isfinite(argument.value))
                 return std::nullopt;
             return argument.value;
 

--- a/magda/scripting/MagdaApiLuaBindings.cpp
+++ b/magda/scripting/MagdaApiLuaBindings.cpp
@@ -893,7 +893,7 @@ int lua_transport_seek_beats(lua_State* L) {
 }
 
 int lua_transport_seek_bars(lua_State* L) {
-    getApi(L)->transport().seekBars(static_cast<int>(luaL_checkinteger(L, 1)));
+    getApi(L)->transport().seekBars(static_cast<long long>(luaL_checkinteger(L, 1)));
     return 0;
 }
 

--- a/magda/scripting/MagdaApiLuaBindings.cpp
+++ b/magda/scripting/MagdaApiLuaBindings.cpp
@@ -881,6 +881,22 @@ int lua_transport_set_position_beats(lua_State* L) {
     return 0;
 }
 
+// Relative seeking (#1987). Rewind and fast-forward buttons are relative by
+// nature, and every script that built one out of position_beats +
+// set_position_beats re-implemented the clamp at zero, and had to know the
+// meter to move by a bar. Both live on TransportApi now, so these are two
+// lines and the remote and OSC surfaces get the same behaviour.
+
+int lua_transport_seek_beats(lua_State* L) {
+    getApi(L)->transport().seekBeats(luaL_checknumber(L, 1));
+    return 0;
+}
+
+int lua_transport_seek_bars(lua_State* L) {
+    getApi(L)->transport().seekBars(static_cast<int>(luaL_checkinteger(L, 1)));
+    return 0;
+}
+
 // ---- focused ---------------------------------------------------------------
 
 int lua_focused_has_focus(lua_State* L) {
@@ -1055,6 +1071,8 @@ const FnReg kTransportFns[] = {
     {"set_loop_enabled", lua_transport_set_loop_enabled},
     {"position_beats", lua_transport_position_beats},
     {"set_position_beats", lua_transport_set_position_beats},
+    {"seek_beats", lua_transport_seek_beats},
+    {"seek_bars", lua_transport_seek_bars},
     {nullptr, nullptr},
 };
 

--- a/manual/docs/reference/lua-scripting.md
+++ b/manual/docs/reference/lua-scripting.md
@@ -85,8 +85,8 @@ Every function below lives under the global `magda` table. All are message-threa
 `seek_beats` and `seek_bars` are the relative pair. They exist because a
 transport button is relative by nature: it says "back one bar", not "go to bar
 seven". Written with `set_position_beats` instead, every script re-derives the
-same two things — the clamp at the start of the project, and how many beats a
-bar is, which in 7/8 is not four.
+same two things — the clamp at the start of the project, and how long a bar
+is, which stops being four beats the moment the project is not in four.
 
 ```lua
 function on_midi(event)

--- a/manual/docs/reference/lua-scripting.md
+++ b/manual/docs/reference/lua-scripting.md
@@ -77,6 +77,64 @@ Every function below lives under the global `magda` table. All are message-threa
 | `magda.transport.set_loop_enabled(enabled)` | — | |
 | `magda.transport.position_beats()` | number | Current playhead position, in beats |
 | `magda.transport.set_position_beats(beats)` | — | Move the playhead |
+| `magda.transport.seek_beats(delta)` | — | Move the playhead by `delta` beats. Stops at the start of the project |
+| `magda.transport.seek_bars(delta)` | — | Move the playhead by `delta` bars, using the project's meter. Stops at the start of the project |
+
+#### Rewind and fast-forward buttons
+
+`seek_beats` and `seek_bars` are the relative pair. They exist because a
+transport button is relative by nature: it says "back one bar", not "go to bar
+seven". Written with `set_position_beats` instead, every script re-derives the
+same two things — the clamp at the start of the project, and how many beats a
+bar is, which in 7/8 is not four.
+
+```lua
+function on_midi(event)
+  -- MCU rewind and fast forward, as an Arturia KeyLab sends them.
+  if event.type ~= "note_on" then return end
+
+  if event.number == 0x5B then
+    magda.transport.seek_bars(-1)
+  elseif event.number == 0x5C then
+    magda.transport.seek_bars(1)
+  end
+end
+```
+
+**Holding the button to scrub.** These buttons are usually held rather than
+tapped. MAGDA has no auto-repeat of its own, so the script drives it: remember
+which direction is held, and move on each tick.
+
+```lua
+local scrub = 0
+local BEATS_PER_SECOND = 8
+
+function on_midi(event)
+  if event.number ~= 0x5B and event.number ~= 0x5C then return end
+
+  if event.type == "note_off" then
+    scrub = 0
+  elseif event.type == "note_on" then
+    scrub = (event.number == 0x5B) and -1 or 1
+  end
+end
+
+function on_tick(dt)
+  if scrub ~= 0 then
+    magda.transport.seek_beats(scrub * BEATS_PER_SECOND * dt)
+  end
+end
+```
+
+Scale by `dt` rather than moving a fixed amount per tick: ticks arrive at about
+30 Hz, so a fixed beat per tick is thirty beats a second and the shuttle rate
+would change if that rate ever did. `BEATS_PER_SECOND` is then the number to
+tune, and it means what it says.
+
+A surface that repeats note-on while a button is held needs no `on_tick` at
+all — seek on each repeat and drop the `scrub` variable. Every repeat moves the
+playhead, because a relative seek is an edge rather than a value and nothing
+coalesces it away.
 
 ### `magda.project`
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -410,6 +410,7 @@ target_sources(magda_juce_tests PRIVATE
     test_signalsmith_loop_juce.cpp
     test_arranger_launcher_switching_juce.cpp
     test_node_id_collision_juce.cpp
+    test_transport_seek_juce.cpp
     test_session_slot_recording_juce.cpp
     test_input_monitor_track_routing_juce.cpp
     test_controller_track_level_write_juce.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -178,6 +178,8 @@ set(TEST_SOURCES
     test_osc_router.cpp
     test_osc_command_sink.cpp
     test_osc_bindings.cpp
+    # Relative transport seek (#1987)
+    test_transport_seek.cpp
     # Controller registry tests (issue #1050 -- Phase B)
     test_controller_registry.cpp
     test_binding_registry.cpp

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -1007,6 +1007,15 @@ class MockTransportApi : public TransportApi {
     void setPositionBeats(double b) override {
         positionBeats = b;
     }
+
+    /// A fixed meter, so a test that seeks by bars gets an arithmetic answer.
+    /// Set it to something else to check that seeking follows the meter rather
+    /// than assuming four.
+    double beatsPerBar = 4.0;
+
+    double beatsAtBarOffset(double beats, int deltaBars) const override {
+        return beats + (beatsPerBar * deltaBars);
+    }
 };
 
 class MockMidiApi : public MidiApi {

--- a/tests/MockMagdaApi.hpp
+++ b/tests/MockMagdaApi.hpp
@@ -1013,7 +1013,12 @@ class MockTransportApi : public TransportApi {
     /// than assuming four.
     double beatsPerBar = 4.0;
 
+    /// The last offset seekBars passed down, so a test can see what the
+    /// facade's clamp did to an out-of-range one.
+    mutable int lastBarOffset = 0;
+
     double beatsAtBarOffset(double beats, int deltaBars) const override {
+        lastBarOffset = deltaBars;
         return beats + (beatsPerBar * deltaBars);
     }
 };

--- a/tests/test_osc_address.cpp
+++ b/tests/test_osc_address.cpp
@@ -181,3 +181,20 @@ TEST_CASE("Every address owns a distinct slot", "[osc][address]") {
     // nothing addressable left outside it.
     REQUIRE(static_cast<int>(used.size()) == kOscSlotCount);
 }
+
+TEST_CASE("The relative seek addresses parse", "[osc][address]") {
+    REQUIRE(parsed("/magda/transport/seek").kind == OscCommandKind::TransportSeekBeats);
+    REQUIRE(parsed("/magda/transport/seek/bars").kind == OscCommandKind::TransportSeekBars);
+
+    // A distance, not a position, and that is what keeps it off the coalescing
+    // table: two presses of a rewind button are two bars.
+    REQUIRE(argKindFor(OscCommandKind::TransportSeekBeats) == OscArgKind::Delta);
+    REQUIRE(argKindFor(OscCommandKind::TransportSeekBars) == OscArgKind::Delta);
+
+    // `bars` is a unit hanging off seek rather than a leaf of its own, so
+    // neither half of it stands alone and no other transport address takes a
+    // fourth component.
+    REQUIRE_FALSE(parseOscAddress("/magda/transport/bars").has_value());
+    REQUIRE_FALSE(parseOscAddress("/magda/transport/seek/beats").has_value());
+    REQUIRE_FALSE(parseOscAddress("/magda/transport/position/bars").has_value());
+}

--- a/tests/test_osc_command_sink.cpp
+++ b/tests/test_osc_command_sink.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -314,4 +315,38 @@ TEST_CASE("Focused macros are numbered from 1 on the wire", "[osc][sink]") {
     REQUIRE(f.api.focused_.macroWrites[0].idx == 0);
     REQUIRE(f.api.focused_.macroWrites[0].value == Approx(0.4f));
     REQUIRE(f.api.focused_.macroWrites[1].idx == 15);
+}
+
+TEST_CASE("A seek argument no bar count can hold is bounded, not wrapped", "[osc][sink]") {
+    // OSC is unauthenticated UDP, so the argument is whatever a packet says.
+    // A float reaches 3.4e38 and llround is a domain error past about 9.2e18 —
+    // unspecified, and LLONG_MIN for either sign on x86 and ARM, which would
+    // send a huge *forward* seek to the start of the project.
+    Fixture f;
+    f.api.transport_.positionBeats = 64.0;
+    f.api.transport_.beatsPerBar = 4.0;
+
+    f.apply(OscCommandKind::TransportSeekBars, 0, 1.0e30f);
+    REQUIRE(f.api.transport_.lastBarOffset == magda::TransportApi::kMaxBarOffset);
+    REQUIRE(f.api.transport_.positionBeats > 64.0);
+
+    f.api.transport_.positionBeats = 64.0;
+    f.apply(OscCommandKind::TransportSeekBars, 0, -1.0e30f);
+    REQUIRE(f.api.transport_.lastBarOffset == -magda::TransportApi::kMaxBarOffset);
+    REQUIRE(f.api.transport_.positionBeats == Approx(0.0));
+}
+
+TEST_CASE("A non-finite seek argument moves nothing", "[osc][sink]") {
+    // A clamp cannot catch NaN — every comparison against it is false, so it
+    // would reach the same domain error the clamp exists to prevent.
+    Fixture f;
+    f.api.transport_.positionBeats = 32.0;
+
+    for (const auto value :
+         {std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::infinity(),
+          -std::numeric_limits<float>::infinity()}) {
+        f.apply(OscCommandKind::TransportSeekBars, 0, value);
+        f.apply(OscCommandKind::TransportSeekBeats, 0, value);
+        REQUIRE(f.api.transport_.positionBeats == Approx(32.0));
+    }
 }

--- a/tests/test_osc_router.cpp
+++ b/tests/test_osc_router.cpp
@@ -37,8 +37,8 @@ struct HeldRouter {
         router->setDrainScheduler([this]() { ++drainsRequested; });
     }
 
-    void send(const juce::OSCMessage& message) {
-        router->handleMessage(message);
+    bool send(const juce::OSCMessage& message) {
+        return router->handleMessage(message);
     }
 
     void drain() {
@@ -460,4 +460,52 @@ TEST_CASE("Every fixed-namespace address survives a round trip", "[osc][router]"
     // Every discrete address pressed at once has to fit: this is the state dump
     // a surface sends on connect, not a flood.
     REQUIRE(r.router->droppedCommandCount() == 0);
+}
+
+TEST_CASE("Repeated seeks all survive the drain", "[osc][router]") {
+    // The reason a relative seek is not a coalesced value. Three presses of a
+    // rewind button are three bars; latest-value-wins would keep one of them
+    // and the playhead would move a third of the way the user asked for.
+    //
+    // A locate in the same breath is the opposite: it says where to be, so
+    // only the last one matters and it is still coalesced.
+    HeldRouter r;
+    r.send(juce::OSCMessage("/magda/transport/seek/bars", -1.0f));
+    r.send(juce::OSCMessage("/magda/transport/seek/bars", -1.0f));
+    r.send(juce::OSCMessage("/magda/transport/seek/bars", -1.0f));
+    r.drain();
+
+    REQUIRE(r.applied().size() == 3);
+    for (const auto& entry : r.applied()) {
+        REQUIRE(entry.command.kind == OscCommandKind::TransportSeekBars);
+        REQUIRE(entry.value == Approx(-1.0f));
+    }
+}
+
+TEST_CASE("A seek lands after the locate it was sent with", "[osc][router]") {
+    // Both in one bundle: the locate is a position and the seek is a distance
+    // from wherever the playhead ended up, so the seek has to see the locate's
+    // result. The drain applies coalesced values before ordered ones, which is
+    // what puts them in that order.
+    HeldRouter r;
+    r.send(juce::OSCMessage("/magda/transport/seek", 2.5f));
+    r.send(juce::OSCMessage("/magda/transport/position", 64.0f));
+    r.drain();
+
+    REQUIRE(r.applied().size() == 2);
+    REQUIRE(r.applied()[0].command.kind == OscCommandKind::TransportPosition);
+    REQUIRE(r.applied()[1].command.kind == OscCommandKind::TransportSeekBeats);
+    REQUIRE(r.applied()[1].value == Approx(2.5f));
+}
+
+TEST_CASE("A seek with nothing to carry is declined", "[osc][router]") {
+    // A bare address says nothing about how far, and a zero delta says to move
+    // nowhere. Neither is a release edge to be swallowed silently — there is
+    // simply nothing to do, and applying either would be inventing a distance.
+    HeldRouter r;
+    REQUIRE_FALSE(r.send(juce::OSCMessage("/magda/transport/seek")));
+    REQUIRE_FALSE(r.send(juce::OSCMessage("/magda/transport/seek/bars", 0.0f)));
+    r.drain();
+
+    REQUIRE(r.applied().empty());
 }

--- a/tests/test_osc_router.cpp
+++ b/tests/test_osc_router.cpp
@@ -509,3 +509,16 @@ TEST_CASE("A seek with nothing to carry is declined", "[osc][router]") {
 
     REQUIRE(r.applied().empty());
 }
+
+TEST_CASE("A non-finite seek is declined at the router", "[osc][router]") {
+    // Refused where the packet is read, so nothing downstream has to hold a
+    // value that cannot be rounded.
+    HeldRouter r;
+    REQUIRE_FALSE(
+        r.send(juce::OSCMessage("/magda/transport/seek", std::numeric_limits<float>::quiet_NaN())));
+    REQUIRE_FALSE(r.send(
+        juce::OSCMessage("/magda/transport/seek/bars", std::numeric_limits<float>::infinity())));
+    r.drain();
+
+    REQUIRE(r.applied().empty());
+}

--- a/tests/test_remote_api_contract.cpp
+++ b/tests/test_remote_api_contract.cpp
@@ -221,6 +221,41 @@ TEST_CASE("Remote API input validation returns structured issues",
         REQUIRE(error->issues.front().code == "unknown_field");
     }
 
+    SECTION("exactly one of deltaBeats and deltaBars") {
+        // transport.seekRelative is the first schema to use oneOf, and the
+        // validator ignores keywords it does not implement — so an advertised
+        // constraint that is not enforced would let both of these through to
+        // the handler, where "neither" is a silent no-op and "both" silently
+        // prefers one.
+        const auto* operation = registry.find("transport.seekRelative");
+        REQUIRE(operation != nullptr);
+
+        REQUIRE_FALSE(
+            validateOperationInput(*operation, object({{"deltaBeats", 2.5}})).has_value());
+        REQUIRE_FALSE(validateOperationInput(*operation, object({{"deltaBars", -1}})).has_value());
+
+        const auto neither = validateOperationInput(*operation, object({}));
+        REQUIRE(neither.has_value());
+        REQUIRE(neither->issues.front().code == "one_of");
+
+        const auto both =
+            validateOperationInput(*operation, object({{"deltaBeats", 2.5}, {"deltaBars", -1}}));
+        REQUIRE(both.has_value());
+        REQUIRE(both->issues.front().code == "one_of");
+    }
+
+    SECTION("bar offsets are bounded") {
+        // The count is narrowed on the way to the tempo sequence, so a value
+        // no project can mean is refused at the edge rather than clamped
+        // silently somewhere behind it.
+        const auto* operation = registry.find("transport.seekRelative");
+        REQUIRE(operation != nullptr);
+
+        const auto error = validateOperationInput(*operation, object({{"deltaBars", 2000000000}}));
+        REQUIRE(error.has_value());
+        REQUIRE(error->issues.front().code == "maximum");
+    }
+
     SECTION("NaN and Infinity") {
         const auto* operation = registry.find("transport.seek");
         REQUIRE(operation != nullptr);

--- a/tests/test_transport_seek.cpp
+++ b/tests/test_transport_seek.cpp
@@ -119,3 +119,18 @@ TEST_CASE("An out-of-range bar offset is bounded before it is narrowed", "[trans
     // Bounded on the way in, and still clamped at zero on the way out.
     CHECK(transport.positionBeats == Approx(0.0));
 }
+
+TEST_CASE("A non-finite delta moves nothing", "[transport][seek][api]") {
+    // The clamp at zero cannot catch it: every comparison against NaN is
+    // false, so std::max(0.0, NaN) is 0 and one bad number from any surface
+    // would send the playhead to the start of the project.
+    MockTransportApi transport;
+    transport.positionBeats = 32.0;
+
+    for (const auto delta :
+         {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::infinity(),
+          -std::numeric_limits<double>::infinity()}) {
+        transport.seekBeats(delta);
+        CHECK(transport.positionBeats == Approx(32.0));
+    }
+}

--- a/tests/test_transport_seek.cpp
+++ b/tests/test_transport_seek.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <limits>
 
 #include "MockMagdaApi.hpp"
 
@@ -62,15 +63,17 @@ TEST_CASE("Seeking by bars asks the project how long a bar is", "[transport][see
 }
 
 TEST_CASE("Seeking by bars follows the meter rather than assuming four", "[transport][seek][api]") {
-    // The other thing scripts were rebuilding: in 7/8 a bar is 3.5 beats, and
-    // a script that hard-codes four rewinds to somewhere that is not a bar
-    // line. Asking the facade is the whole point of `seekBars` existing.
+    // The other thing scripts were rebuilding. A script that hard-codes four
+    // rewinds to somewhere that is not a bar line the moment the project is
+    // not in four, so the length comes from the project. What a bar is worth
+    // in a given meter is the project's answer rather than this test's - here
+    // it is simply not four.
     MockTransportApi transport;
-    transport.positionBeats = 7.0;
-    transport.beatsPerBar = 3.5;
+    transport.positionBeats = 14.0;
+    transport.beatsPerBar = 7.0;
 
     transport.seekBars(-1);
-    CHECK(transport.positionBeats == Approx(3.5));
+    CHECK(transport.positionBeats == Approx(7.0));
 
     transport.seekBars(-1);
     CHECK(transport.positionBeats == Approx(0.0));
@@ -94,4 +97,25 @@ TEST_CASE("A zero bar offset leaves the playhead alone", "[transport][seek][api]
 
     transport.seekBars(0);
     CHECK(transport.positionBeats == Approx(5.25));
+}
+
+TEST_CASE("An out-of-range bar offset is bounded before it is narrowed", "[transport][seek][api]") {
+    // Every surface reads this number from outside MAGDA — a Lua integer, a
+    // JSON number, an OSC float — so the count arrives 64-bit and is bounded
+    // here rather than narrowed at three different edges. Past the bound the
+    // answer is one end of the project, which is what a clamp gives.
+    MockTransportApi transport;
+    transport.positionBeats = 16.0;
+    transport.beatsPerBar = 4.0;
+
+    transport.seekBars(std::numeric_limits<long long>::max());
+    CHECK(transport.lastBarOffset == magda::TransportApi::kMaxBarOffset);
+    CHECK(transport.positionBeats == Approx(16.0 + (4.0 * magda::TransportApi::kMaxBarOffset)));
+
+    transport.positionBeats = 16.0;
+    transport.seekBars(std::numeric_limits<long long>::min());
+    CHECK(transport.lastBarOffset == -magda::TransportApi::kMaxBarOffset);
+
+    // Bounded on the way in, and still clamped at zero on the way out.
+    CHECK(transport.positionBeats == Approx(0.0));
 }

--- a/tests/test_transport_seek.cpp
+++ b/tests/test_transport_seek.cpp
@@ -1,0 +1,97 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "MockMagdaApi.hpp"
+
+/**
+ * @file test_transport_seek.cpp
+ * @brief Relative transport seeking (#1987).
+ *
+ * `seekBeats` and `seekBars` are concrete on `TransportApi` rather than
+ * virtual, so this exercises the implementation every surface shares: the Lua
+ * bindings, the remote API's `transport.seekRelative`, and the OSC namespace's
+ * `/magda/transport/seek` all reach the code under test here.
+ *
+ * What an implementation supplies is `beatsAtBarOffset` — how long a bar is,
+ * which is the project's business. The mock answers with a fixed meter so the
+ * arithmetic is checkable; the live one walks the tempo sequence.
+ */
+
+using Catch::Approx;
+using magda::test::MockTransportApi;
+
+TEST_CASE("Seeking by beats moves relative to where the playhead is", "[transport][seek][api]") {
+    MockTransportApi transport;
+    transport.positionBeats = 8.0;
+
+    transport.seekBeats(4.0);
+    CHECK(transport.positionBeats == Approx(12.0));
+
+    transport.seekBeats(-1.5);
+    CHECK(transport.positionBeats == Approx(10.5));
+
+    // Zero is a legal ask and a no-op, not a special case for callers to guard.
+    transport.seekBeats(0.0);
+    CHECK(transport.positionBeats == Approx(10.5));
+}
+
+TEST_CASE("Seeking never lands before the start of the timeline", "[transport][seek][api]") {
+    // The clamp every script was writing by hand. A rewind button held down at
+    // the top of a project has to stop at zero rather than run negative, and
+    // that is not a decision each of three surfaces should be making.
+    MockTransportApi transport;
+    transport.positionBeats = 2.0;
+
+    transport.seekBeats(-10.0);
+    CHECK(transport.positionBeats == Approx(0.0));
+
+    transport.seekBeats(-10.0);
+    CHECK(transport.positionBeats == Approx(0.0));
+}
+
+TEST_CASE("Seeking by bars asks the project how long a bar is", "[transport][seek][api]") {
+    MockTransportApi transport;
+    transport.positionBeats = 0.0;
+    transport.beatsPerBar = 4.0;
+
+    transport.seekBars(2);
+    CHECK(transport.positionBeats == Approx(8.0));
+
+    transport.seekBars(-1);
+    CHECK(transport.positionBeats == Approx(4.0));
+}
+
+TEST_CASE("Seeking by bars follows the meter rather than assuming four", "[transport][seek][api]") {
+    // The other thing scripts were rebuilding: in 7/8 a bar is 3.5 beats, and
+    // a script that hard-codes four rewinds to somewhere that is not a bar
+    // line. Asking the facade is the whole point of `seekBars` existing.
+    MockTransportApi transport;
+    transport.positionBeats = 7.0;
+    transport.beatsPerBar = 3.5;
+
+    transport.seekBars(-1);
+    CHECK(transport.positionBeats == Approx(3.5));
+
+    transport.seekBars(-1);
+    CHECK(transport.positionBeats == Approx(0.0));
+}
+
+TEST_CASE("Seeking back by bars clamps at zero too", "[transport][seek][api]") {
+    MockTransportApi transport;
+    transport.positionBeats = 4.0;
+    transport.beatsPerBar = 4.0;
+
+    transport.seekBars(-8);
+    CHECK(transport.positionBeats == Approx(0.0));
+}
+
+TEST_CASE("A zero bar offset leaves the playhead alone", "[transport][seek][api]") {
+    // Mid-bar on purpose: a no-op has to be a no-op rather than a quiet snap
+    // to the nearest bar line, which is a different feature and not this one.
+    MockTransportApi transport;
+    transport.positionBeats = 5.25;
+    transport.beatsPerBar = 4.0;
+
+    transport.seekBars(0);
+    CHECK(transport.positionBeats == Approx(5.25));
+}

--- a/tests/test_transport_seek_juce.cpp
+++ b/tests/test_transport_seek_juce.cpp
@@ -1,0 +1,156 @@
+#include <juce_core/juce_core.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+#include "SharedTestEngine.hpp"
+#include "magda/daw/api/transport_api_live.hpp"
+#include "third_party/tracktion_engine/modules/tracktion_engine/utilities/tracktion_TestUtilities.h"
+
+/**
+ * Bar-aware seeking against a real tempo sequence (#1987).
+ *
+ * `TransportApi::seekBars` is shared by every surface and covered against the
+ * mock in test_transport_seek.cpp, but the mock answers with a fixed number of
+ * beats per bar. What that cannot reach is the thing `seekBars` exists for:
+ * `TransportApiLive::beatsAtBarOffset` walking a sequence whose meter changes,
+ * so a rewind across a time-signature change lands where the bar line actually
+ * is rather than a fixed distance back.
+ *
+ * It lives in the JUCE target because it needs an Edit.
+ */
+
+namespace te = tracktion;
+
+namespace {
+
+/// A transport reading `edit`, wired the way MagdaApiLive wires one.
+magda::TransportApiLive transportFor(te::Edit& edit) {
+    magda::TransportApiLive transport;
+    transport.setEditGetter([&edit] { return &edit; });
+    return transport;
+}
+
+/// Put a time signature at `beat`, which is how a meter change is expressed.
+void setTimeSig(te::Edit& edit, double beat, int numerator, int denominator) {
+    auto timeSig = edit.tempoSequence.insertTimeSig(te::BeatPosition::fromBeats(beat));
+    timeSig->numerator = numerator;
+    timeSig->denominator = denominator;
+}
+
+}  // namespace
+
+class TransportSeekBarsTests final : public juce::UnitTest {
+  public:
+    TransportSeekBarsTests() : juce::UnitTest("Transport Seek Bars Tests", "magda") {}
+
+    void runTest() override {
+        auto& wrapper = magda::test::getSharedEngine();
+        auto* engine = wrapper.getEngine();
+
+        if (engine == nullptr) {
+            beginTest("engine");
+            expect(false, "no Tracktion engine");
+            return;
+        }
+
+        beginTest("In 4/4 a bar is four beats");
+        {
+            auto edit = te::engine::test_utilities::createTestEdit(*engine, 1);
+            expect(edit != nullptr, "no Edit");
+            if (edit == nullptr)
+                return;
+
+            auto transport = transportFor(*edit);
+            transport.setPositionBeats(12.0);
+
+            transport.seekBars(-1);
+            expectWithinAbsoluteError(transport.getPositionBeats(), 8.0, 1.0e-6);
+
+            transport.seekBars(2);
+            expectWithinAbsoluteError(transport.getPositionBeats(), 16.0, 1.0e-6);
+        }
+
+        beginTest("A bar is as long as the meter says, not as long as the last one was");
+        {
+            // 4/4 from the top, 7/8 from beat 8. The sequence counts a bar of
+            // 7/8 as seven beats, so the bars run 0-4, 4-8, 8-15, 15-22 - the
+            // point being that they stop being four apart, which is the whole
+            // reason seekBars asks the project rather than multiplying.
+            auto edit = te::engine::test_utilities::createTestEdit(*engine, 1);
+            expect(edit != nullptr, "no Edit");
+            if (edit == nullptr)
+                return;
+
+            setTimeSig(*edit, 8.0, 7, 8);
+
+            auto transport = transportFor(*edit);
+
+            // One bar back from the top of the second 7/8 bar is seven beats,
+            // not four.
+            transport.setPositionBeats(15.0);
+            transport.seekBars(-1);
+            expectWithinAbsoluteError(transport.getPositionBeats(), 8.0, 1.0e-6);
+
+            // And one more crosses the change, where a bar is four again.
+            transport.seekBars(-1);
+            expectWithinAbsoluteError(transport.getPositionBeats(), 4.0, 1.0e-6);
+
+            // Forward over the same change, for the same reason in reverse.
+            transport.seekBars(2);
+            expectWithinAbsoluteError(transport.getPositionBeats(), 15.0, 1.0e-6);
+        }
+
+        beginTest("The offset within the bar is carried across");
+        {
+            // Not on a bar line: seeking by bars moves by bars, it does not
+            // quietly snap. Half a bar into bar three of 4/4 is beat 10, and a
+            // bar back is beat 6.
+            auto edit = te::engine::test_utilities::createTestEdit(*engine, 1);
+            expect(edit != nullptr, "no Edit");
+            if (edit == nullptr)
+                return;
+
+            auto transport = transportFor(*edit);
+            transport.setPositionBeats(10.0);
+
+            transport.seekBars(-1);
+            expectWithinAbsoluteError(transport.getPositionBeats(), 6.0, 1.0e-6);
+        }
+
+        beginTest("Seeking back past the start stops at the start");
+        {
+            auto edit = te::engine::test_utilities::createTestEdit(*engine, 1);
+            expect(edit != nullptr, "no Edit");
+            if (edit == nullptr)
+                return;
+
+            auto transport = transportFor(*edit);
+            transport.setPositionBeats(4.0);
+
+            transport.seekBars(-100);
+            expectWithinAbsoluteError(transport.getPositionBeats(), 0.0, 1.0e-6);
+        }
+
+        beginTest("An enormous offset is bounded rather than overflowing");
+        {
+            // The count arrives from outside MAGDA on every surface, so the
+            // facade bounds it before it reaches the addition inside
+            // beatsAtBarOffset. Forward lands somewhere far away; back lands at
+            // zero. Neither is undefined, which is the point.
+            auto edit = te::engine::test_utilities::createTestEdit(*engine, 1);
+            expect(edit != nullptr, "no Edit");
+            if (edit == nullptr)
+                return;
+
+            auto transport = transportFor(*edit);
+            transport.setPositionBeats(8.0);
+
+            transport.seekBars(std::numeric_limits<long long>::min());
+            expectWithinAbsoluteError(transport.getPositionBeats(), 0.0, 1.0e-6);
+
+            transport.seekBars(std::numeric_limits<long long>::max());
+            expectGreaterThan(transport.getPositionBeats(), 0.0);
+        }
+    }
+};
+
+static TransportSeekBarsTests transportSeekBarsTests;


### PR DESCRIPTION
Closes #1987. Built to the shape agreed in [the comment on the issue](https://github.com/Conceptual-Machines/magda-core/issues/1987#issuecomment-5162727654): the primitive lands on `TransportApi`, and Lua, the remote API and OSC all delegate.

`seekBeats(delta)` and `seekBars(deltaBars)` are **concrete** on the facade, not virtual. Written as read-modify-write at each caller, the clamp at zero and the bar length get re-derived three times and drift three ways.

The single thing an implementation supplies is `beatsAtBarOffset(beats, deltaBars)` — how long a bar is, which is the project's business and not the caller's.

## The live implementation goes through bars-and-beats, not multiplication

A bar is only a fixed number of beats when the meter is. `TransportApiLive` converts to `tempo::BarsAndBeats`, adds the bar count, and converts back, so crossing a 4/4 into 7/8 lands where the bar line actually is and the offset within the bar carries across untouched.

## Surfaces

| | |
|---|---|
| **Lua** | `magda.transport.seek_beats(delta)` · `magda.transport.seek_bars(delta)` |
| **Remote** | `transport.seekRelative`, taking `deltaBeats` **or** `deltaBars` |
| **OSC** | `/magda/transport/seek` (beats) · `/magda/transport/seek/bars` |

One remote operation rather than two: a caller binding a rewind button is picking a unit, not an endpoint.

## OSC needed a new argument kind, and this is the interesting part

Every continuous value in the OSC namespace is coalesced latest-value-wins. That is correct for a *position* — the last one is where you want to be — and wrong for a *distance*: three presses of a rewind button are three bars, and one slot would keep one of them.

So `OscArgKind::Delta` rides the ordered ring alongside the triggers and toggles. The router's own comment already made this distinction for edges; a relative seek is an edge that happens to carry a magnitude. It also gets the ordering right for free: a seek sent in the same bundle as a locate lands *after* it, which is what a relative move needs.

`kOscUnindexedSlots` goes 8 → 10. The two seek kinds never publish into their slots, but keeping them means "a kind's slot is its ordinal" stays true of the whole enum — and the existing exhaustiveness test enforces that.

## Tests

- `test_transport_seek.cpp` — the shared implementation: relative movement, the clamp at zero for both units, and that `seekBars` follows a 7/8 meter rather than assuming four.
- `test_osc_router.cpp` — three repeated seeks all survive the drain (the coalescing point), a seek lands after the locate it was bundled with, and a bare or zero delta is declined without falling through to bindings.
- `test_osc_address.cpp` — both addresses parse, both are `Delta`, and `bars` is a unit under `seek` rather than a leaf of its own.

## Docs

The manual gets both calls, the KeyLab rewind/fast-forward example the issue was raised about, and the hold-to-scrub pattern — scaled by `on_tick`'s `dt` rather than a fixed amount per tick, since ticks are ~30 Hz and a beat per tick is thirty beats a second.

Verified: 2558 cases, 571849 assertions.