### PR TITLE
OSC feedback: echo MAGDA's state back to the surface (#2091)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -477,6 +477,18 @@
     "upload_overwrite": "A profile with id \"{0}\" already exists. Replace it?",
     "upload_copy_failed": "Couldn't copy the profile into your controllers folder.",
     "upload_create_dir_failed": "Couldn't create the controllers folder:\n{0}",
-    "upload_success": "Imported profile \"{0}\"."
+    "upload_success": "Imported profile \"{0}\".",
+    "osc.enable": "Listen for OSC",
+    "osc.bind_address": "Listen on",
+    "osc.receive_port": "Receive port",
+    "osc.feedback_host": "Send feedback to",
+    "osc.feedback_port": "Feedback port",
+    "osc.feedback_host_empty": "No feedback",
+    "osc.status_off": "Not listening.",
+    "osc.status_listening": "Listening on {0}:{1}.",
+    "osc.status_bind_failed": "Couldn't open the port. Another application may be using it.",
+    "osc.status_received": "{0} messages received.",
+    "osc.status_feedback_off": "Feedback off. Enter a host to send MAGDA's state back to your surface.",
+    "osc.status_feedback_sent": "{0} feedback messages sent."
   }
 }

--- a/magda/daw/api/CMakeLists.txt
+++ b/magda/daw/api/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(magda_daw PRIVATE
     device_api_live.cpp
     groove_api_live.cpp
     osc_command_sink_live.cpp
+    osc_feedback_live.cpp
     remote_api.cpp
     remote_api_projection.cpp
     remote_handlers.cpp

--- a/magda/daw/api/osc_feedback_live.cpp
+++ b/magda/daw/api/osc_feedback_live.cpp
@@ -1,0 +1,498 @@
+#include "osc_feedback_live.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "../audio/osc/OscRouter.hpp"
+#include "../core/AutomationInfo.hpp"
+#include "../core/Config.hpp"
+#include "../core/ControlTarget.hpp"
+#include "../core/MixerStripOrder.hpp"
+#include "../core/ParameterUtils.hpp"
+#include "../core/TrackInfo.hpp"
+#include "../core/aliases/AliasRegistry.hpp"
+#include "../core/aliases/ChainContext.hpp"
+#include "../core/aliases/ResolverRegistry.hpp"
+#include "../core/aliases/TargetResolver.hpp"
+#include "../core/controllers/BindingRegistry.hpp"
+#include "../core/controllers/BindingTransform.hpp"
+#include "focused_api.hpp"
+#include "magda_api.hpp"
+#include "project_api.hpp"
+#include "track_api.hpp"
+#include "transport_api.hpp"
+
+namespace magda {
+
+using osc::OscCommand;
+using osc::OscCommandKind;
+
+namespace {
+
+/// A bound address is not a slot, so it carries its own change test. The same
+/// tolerance the slot table uses, and for the same reason: a normalized value
+/// that has been through a parameter's real range and back does not land on the
+/// bit pattern it started from.
+constexpr float kBoundEpsilon = 1.0e-4f;
+
+OscCommand unindexed(OscCommandKind kind) {
+    return OscCommand{kind, 0, 0};
+}
+
+/// Linear gain to the normalized fader position, the inverse of what
+/// `DefaultControllerParamWriter::writeTrackLevel` did on the way in.
+float normalizedFromGain(float gain, const ParameterInfo& info) {
+    const float dB = gain > 0.0f ? 20.0f * std::log10(gain) : info.minValue;
+    return ParameterUtils::realToNormalized(dB, info);
+}
+
+}  // namespace
+
+// ============================================================================
+// Tick and ControllerSink
+// ============================================================================
+
+/// The 30 Hz heartbeat, owned rather than inherited so that a projector with no
+/// destination — and a headless one, which has no message loop to drive a timer
+/// anyway — never brings JUCE's timer thread into existence.
+class OscFeedbackProjector::Tick : public juce::Timer {
+  public:
+    Tick(OscFeedbackProjector& owner, int intervalMs) : owner_(owner) {
+        startTimer(intervalMs);
+    }
+
+    ~Tick() override {
+        stopTimer();
+    }
+
+    void timerCallback() override {
+        owner_.tick();
+    }
+
+  private:
+    OscFeedbackProjector& owner_;
+};
+
+/**
+ * The `ControllerFeedbackSink` half. It carries a value, and deliberately
+ * ignores it: what a bound address should show is what its *target* holds now,
+ * and a `FeedbackEvent` names a binding rather than a target, so two OSC
+ * bindings on one parameter would each need looking up anyway. Marking the
+ * bindings dirty and re-reading on the next tick answers both, at the tick rate
+ * a surface can consume rather than at the rate a knob produces.
+ */
+class OscFeedbackProjector::ControllerSink : public ControllerFeedbackSink {
+  public:
+    ControllerSink(OscFeedbackProjector& owner, std::shared_ptr<std::atomic<bool>> alive)
+        : owner_(owner), alive_(std::move(alive)) {}
+
+    void send(const FeedbackEvent&) override {
+        if (alive_->load())
+            owner_.bindingsDirty_ = true;
+    }
+
+  private:
+    OscFeedbackProjector& owner_;
+    std::shared_ptr<std::atomic<bool>> alive_;
+};
+
+// ============================================================================
+// Lifecycle
+// ============================================================================
+
+OscFeedbackProjector::OscFeedbackProjector(MagdaApi& api, remote::ChangeSource& changes,
+                                           osc::OscRouter& router,
+                                           std::unique_ptr<ControllerParamReader> reader,
+                                           std::unique_ptr<osc::OscMessageSink> sink)
+    : api_(api), changes_(changes), router_(router), reader_(std::move(reader)) {
+    if (sink == nullptr) {
+        auto sender = std::make_unique<osc::OscSenderSink>();
+        sender_ = sender.get();
+        sink = std::move(sender);
+    }
+    feedback_ = std::make_unique<osc::OscFeedback>(std::move(sink));
+
+    // The router's drain is on the message thread, same as the tick, so both of
+    // these reach straight into the tables with nothing in between.
+    router_.setFeedbackTap([this](int slot, float value) { feedback_->noteReceived(slot, value); });
+    router_.setBindingFeedbackTap([this](const juce::String& address, float value) {
+        auto& entry = boundEntryFor(address);
+        entry.lastReceived = value;
+        entry.echoed = true;
+    });
+
+    changeToken_ = changes_.addListener(
+        [this](const std::vector<remote::ChangeSource::Change>& changed) { onChanges(changed); });
+
+    Config::getInstance().addListener(this);
+}
+
+OscFeedbackProjector::~OscFeedbackProjector() {
+    alive_->store(false);
+    Config::getInstance().removeListener(this);
+    tick_.reset();
+    changes_.removeListener(changeToken_);
+    router_.setFeedbackTap({});
+    router_.setBindingFeedbackTap({});
+}
+
+void OscFeedbackProjector::configChanged() {
+    applyConfig();
+}
+
+std::unique_ptr<ControllerFeedbackSink> OscFeedbackProjector::makeControllerFeedbackSink() {
+    return std::make_unique<ControllerSink>(*this, alive_);
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+bool OscFeedbackProjector::setDestination(const juce::String& host, int port) {
+    if (sender_ == nullptr)
+        return true;  // a supplied sink is its own destination
+
+    const bool wasConnected = sender_->isConnected();
+
+    if (wasConnected && host == sender_->destinationHost() && port == sender_->destinationPort())
+        return true;
+
+    // Off, and asked to stay off. Reached on every unrelated config save, so it
+    // must not throw away a state it is not changing.
+    if (!wasConnected && host.isEmpty())
+        return false;
+
+    if (!sender_->connect(host, port)) {
+        tick_.reset();
+        // What was last sent described a surface that is no longer being
+        // spoken to, so the next one to be configured starts from a snapshot
+        // rather than from a diff against someone else's state.
+        feedback_->reset();
+        return false;
+    }
+
+    // A different destination is a different surface by definition, and it has
+    // been told nothing.
+    feedback_->reset();
+    requestSnapshot();
+    mixerDirty_ = macrosDirty_ = bindingsDirty_ = true;
+    highestPosition_ = 0;
+    bound_.clear();
+    tick_ = std::make_unique<Tick>(*this, kTickIntervalMs);
+    return true;
+}
+
+bool OscFeedbackProjector::applyConfig() {
+    auto& config = Config::getInstance();
+    // Feedback rides on the listener being on at all: MAGDA answering a surface
+    // it refuses to hear from is a state with no use and one more way for a
+    // socket to be open without the user asking.
+    if (!config.getOscEnabled())
+        return setDestination({}, 0);
+
+    return setDestination(juce::String(config.getOscFeedbackHost()), config.getOscFeedbackPort());
+}
+
+bool OscFeedbackProjector::isSending() const {
+    return sender_ == nullptr || sender_->isConnected();
+}
+
+void OscFeedbackProjector::requestSnapshot() {
+    feedback_->requestSnapshot();
+    mixerDirty_ = macrosDirty_ = bindingsDirty_ = true;
+    for (auto& entry : bound_)
+        entry.hasSent = false;
+}
+
+// ============================================================================
+// The tick
+// ============================================================================
+
+void OscFeedbackProjector::onChanges(const std::vector<remote::ChangeSource::Change>& changed) {
+    for (const auto& change : changed) {
+        switch (change.topic) {
+            case remote::Topic::Tracks:
+                mixerDirty_ = true;
+                // A bound target can be a track level, and a track that has gone
+                // away takes its bindings' resolutions with it.
+                bindingsDirty_ = true;
+                break;
+            case remote::Topic::Devices:
+                macrosDirty_ = true;
+                bindingsDirty_ = true;
+                break;
+            case remote::Topic::Selection:
+                // Which device is focused is a selection, and the focused macros
+                // are addressed by focus rather than by identity.
+                macrosDirty_ = true;
+                bindingsDirty_ = true;
+                break;
+            case remote::Topic::Project:
+                // A project swap and a project save arrive on one topic, and
+                // nothing distinguishes them. Marking everything dirty is right
+                // for both: a swap changes the values and the diff sends them,
+                // a save changes nothing and the diff sends nothing. Resetting
+                // here instead would resend the whole namespace every time the
+                // user pressed save.
+                mixerDirty_ = macrosDirty_ = bindingsDirty_ = true;
+                break;
+            case remote::Topic::Clips:
+            case remote::Topic::Session:
+            case remote::Topic::Automation:
+            case remote::Topic::Meters:
+            case remote::Topic::Playhead:
+                break;
+        }
+    }
+}
+
+void OscFeedbackProjector::tick() {
+    if (!isSending())
+        return;
+
+    // A surface that has just started talking after a silence is most likely a
+    // surface that has just connected, which is the closest thing to "a new
+    // peer" that is observable: JUCE does not report who sent a datagram.
+    const auto accepted = router_.acceptedMessageCount();
+    if (accepted != lastAcceptedCount_) {
+        const auto now = juce::Time::currentTimeMillis();
+        if (lastInboundMs_ != 0 && now - lastInboundMs_ >= kResyncSilenceMs)
+            requestSnapshot();
+        lastInboundMs_ = now;
+        lastAcceptedCount_ = accepted;
+    }
+
+    if (mixerDirty_) {
+        mixerDirty_ = false;
+        projectMixer();
+    }
+    if (macrosDirty_) {
+        macrosDirty_ = false;
+        projectMacros();
+    }
+    if (bindingsDirty_) {
+        bindingsDirty_ = false;
+        projectBindings();
+    }
+
+    // Always. Nothing marks the transport, and the playhead moves without
+    // telling anyone.
+    projectTransport();
+
+    feedback_->flush();
+}
+
+// ============================================================================
+// Projections
+// ============================================================================
+
+void OscFeedbackProjector::projectMixer() {
+    auto& tracks = api_.tracks();
+
+    // The mixer's own rule for what a strip is and where it sits, which is the
+    // rule the input path addresses by. Always ViewMode::Mix: a surface's fader
+    // 3 must not become another track because someone switched view.
+    const auto order = mixerStripOrder(tracks.getTracks(), ViewMode::Mix);
+
+    const int count = std::min(static_cast<int>(order.size()), osc::kMaxTrackNumber);
+    for (int position = 1; position <= count; ++position)
+        projectStrip(position, order[static_cast<size_t>(position - 1)]);
+
+    retirePositionsFrom(count + 1);
+    highestPosition_ = count;
+
+    // The master is not in the strip order — it has its own place in the mixer
+    // and its own addresses for the same reason.
+    if (const auto* master = tracks.getTrack(MASTER_TRACK_ID)) {
+        const auto volumeInfo =
+            getParameterInfoForTarget(ControlTarget::trackVolume(MASTER_TRACK_ID));
+        const auto panInfo = getParameterInfoForTarget(ControlTarget::trackPan(MASTER_TRACK_ID));
+        feedback_->publish(unindexed(OscCommandKind::MasterVolume),
+                           normalizedFromGain(master->volume, volumeInfo));
+        feedback_->publish(unindexed(OscCommandKind::MasterPan),
+                           ParameterUtils::realToNormalized(master->pan, panInfo));
+    }
+}
+
+void OscFeedbackProjector::projectStrip(int position, TrackId trackId) {
+    const auto* track = api_.tracks().getTrack(trackId);
+    if (track == nullptr) {
+        // A position in the order with nothing behind it should not exist, but
+        // if it does the surface is better told nothing than told zero.
+        feedback_->retire(OscCommand{OscCommandKind::TrackVolume, position, 0});
+        feedback_->retire(OscCommand{OscCommandKind::TrackPan, position, 0});
+        feedback_->retire(OscCommand{OscCommandKind::TrackMute, position, 0});
+        feedback_->retire(OscCommand{OscCommandKind::TrackSolo, position, 0});
+        for (int send = 1; send <= osc::kMaxSendNumber; ++send)
+            feedback_->retire(OscCommand{OscCommandKind::TrackSend, position, send});
+        return;
+    }
+
+    const auto volumeInfo = getParameterInfoForTarget(ControlTarget::trackVolume(trackId));
+    const auto panInfo = getParameterInfoForTarget(ControlTarget::trackPan(trackId));
+
+    feedback_->publish(OscCommand{OscCommandKind::TrackVolume, position, 0},
+                       normalizedFromGain(track->volume, volumeInfo));
+    feedback_->publish(OscCommand{OscCommandKind::TrackPan, position, 0},
+                       ParameterUtils::realToNormalized(track->pan, panInfo));
+    feedback_->publish(OscCommand{OscCommandKind::TrackMute, position, 0},
+                       track->muted ? 1.0f : 0.0f);
+    feedback_->publish(OscCommand{OscCommandKind::TrackSolo, position, 0},
+                       track->soloed ? 1.0f : 0.0f);
+
+    // Sends are addressed by position on the track, the way the input path
+    // resolves them, so send 1 is the first one the track has whatever bus it
+    // uses.
+    const int sendCount = std::min(static_cast<int>(track->sends.size()), osc::kMaxSendNumber);
+    for (int send = 1; send <= osc::kMaxSendNumber; ++send) {
+        const OscCommand command{OscCommandKind::TrackSend, position, send};
+        if (send > sendCount) {
+            feedback_->retire(command);
+            continue;
+        }
+        const auto& info = track->sends[static_cast<size_t>(send - 1)];
+        feedback_->publish(
+            command,
+            normalizedFromGain(info.level, getParameterInfoForTarget(
+                                               ControlTarget::sendLevel(trackId, info.busIndex))));
+    }
+}
+
+void OscFeedbackProjector::retirePositionsFrom(int firstUnused) {
+    for (int position = firstUnused; position <= highestPosition_; ++position) {
+        feedback_->retire(OscCommand{OscCommandKind::TrackVolume, position, 0});
+        feedback_->retire(OscCommand{OscCommandKind::TrackPan, position, 0});
+        feedback_->retire(OscCommand{OscCommandKind::TrackMute, position, 0});
+        feedback_->retire(OscCommand{OscCommandKind::TrackSolo, position, 0});
+        for (int send = 1; send <= osc::kMaxSendNumber; ++send)
+            feedback_->retire(OscCommand{OscCommandKind::TrackSend, position, send});
+    }
+}
+
+void OscFeedbackProjector::projectMacros() {
+    auto& focused = api_.focused();
+    const bool hasFocus = focused.hasFocus();
+
+    for (int macro = 1; macro <= osc::kMaxMacroNumber; ++macro) {
+        const OscCommand command{OscCommandKind::FocusedMacro, macro, 0};
+        if (hasFocus)
+            feedback_->publish(command, focused.getMacroValue(macro - 1));
+        else
+            feedback_->retire(command);
+    }
+}
+
+void OscFeedbackProjector::projectTransport() {
+    auto& transport = api_.transport();
+    const bool playing = transport.isPlaying();
+
+    // Play and stop are two addresses over one state. A surface with a lit Play
+    // button and a lit Stop button expects exactly one of them on, so stop is
+    // the complement rather than a second thing to track.
+    feedback_->publish(unindexed(OscCommandKind::TransportPlay), playing ? 1.0f : 0.0f);
+    feedback_->publish(unindexed(OscCommandKind::TransportStop), playing ? 0.0f : 1.0f);
+    feedback_->publish(unindexed(OscCommandKind::TransportRecord),
+                       transport.isRecording() ? 1.0f : 0.0f);
+    feedback_->publish(unindexed(OscCommandKind::TransportLoop),
+                       transport.isLoopEnabled() ? 1.0f : 0.0f);
+    feedback_->publish(unindexed(OscCommandKind::TransportTempo),
+                       static_cast<float>(api_.project().getCurrentProjectInfo().tempo));
+    feedback_->publish(unindexed(OscCommandKind::TransportPosition),
+                       static_cast<float>(transport.getPositionBeats()));
+
+    // The two seek addresses are deltas. There is no state behind them to send,
+    // which is why nothing publishes into their slots.
+}
+
+// ============================================================================
+// Bindings
+// ============================================================================
+
+void OscFeedbackProjector::projectBindings() {
+    if (reader_ == nullptr)
+        return;
+
+    auto& registry = BindingRegistry::getInstance();
+    auto bindings = registry.bindings(BindingScope::Global);
+    auto projectScoped = registry.bindings(BindingScope::Project);
+    bindings.insert(bindings.end(), projectScoped.begin(), projectScoped.end());
+
+    DefaultChainContext ctx;
+    TargetResolver resolver{AliasRegistry::getInstance(), ResolverRegistry::getInstance(), ctx};
+
+    // One address, one value per pass. Several bindings may share an address —
+    // that is a supported shape on the way in, where one fader drives three
+    // parameters — but on the way out they would each want the address at their
+    // own target's position, and sending all three every tick is a permanent
+    // stream of contradictions. The first that resolves is the one the surface
+    // is shown, which is the same one the surface's own value is measured
+    // against.
+    juce::StringArray published;
+
+    for (const auto& binding : bindings) {
+        if (!binding.source.isOsc() || binding.source.oscAddress.isEmpty())
+            continue;
+        if (published.contains(binding.source.oscAddress))
+            continue;
+
+        const auto resolved = resolver.resolve(binding.target);
+        if (!resolved.ok())
+            continue;  // an alias naming nothing right now; it will resolve again
+
+        const auto value = reader_->read(resolved);
+        if (!value)
+            continue;  // a target with no reading — see ControllerParamReader
+
+        published.add(binding.source.oscAddress);
+        publishBinding(binding, *value);
+    }
+
+    // The echo bits belong to the pass that has just read them, exactly as the
+    // slot table's do. A drag that keeps sending keeps setting them; a finger
+    // that lifts leaves the next pass free to send the value once, which is what
+    // tells the surface what MAGDA rounded it to.
+    for (auto& entry : bound_)
+        entry.echoed = false;
+}
+
+OscFeedbackProjector::BoundAddress& OscFeedbackProjector::boundEntryFor(
+    const juce::String& address) {
+    for (auto& candidate : bound_)
+        if (candidate.address == address)
+            return candidate;
+
+    bound_.push_back(BoundAddress{address, 0.0f, 0.0f, false, false});
+    return bound_.back();
+}
+
+void OscFeedbackProjector::publishBinding(const Binding& binding, float targetValue) {
+    // Back out through the binding's own shape, in the reverse of the order the
+    // input path applied it: range, then curve. What is left is where the
+    // surface's control has to sit for a move to produce the value the target
+    // already holds.
+    const float curved = invertRange(binding.range, targetValue);
+    const float position = invertCurve(binding.range.curve, curved);
+
+    auto& entry = boundEntryFor(binding.source.oscAddress);
+
+    // The bound half of the echo rule, and the same rule: a value the surface
+    // just sent is a value it already shows. Without this, a bound fader under
+    // a finger would have its own position sent back to it on every tick of the
+    // drag, which is the chase in its purest form.
+    if (entry.echoed && std::abs(entry.lastReceived - position) <= kBoundEpsilon) {
+        entry.lastSent = position;
+        entry.hasSent = true;
+        return;
+    }
+
+    if (entry.hasSent && std::abs(entry.lastSent - position) <= kBoundEpsilon)
+        return;
+
+    if (!feedback_->sink().send(entry.address, position))
+        return;
+
+    entry.lastSent = position;
+    entry.hasSent = true;
+}
+
+}  // namespace magda

--- a/magda/daw/api/osc_feedback_live.cpp
+++ b/magda/daw/api/osc_feedback_live.cpp
@@ -250,6 +250,13 @@ void OscFeedbackProjector::onChanges(const std::vector<remote::ChangeSource::Cha
                 // rate still costs one binding pass per tick.
                 bindingsDirty_ = true;
                 break;
+            case remote::Topic::Transport:
+                // Nothing to mark dirty, and not an oversight. The transport is
+                // the sampled half: every tick reads it, because nothing marks
+                // this topic when the user presses Play in MAGDA — only a remote
+                // API request named `transport.*` does. Acting on it would be a
+                // second path to the same five reads the tick has already done
+                // by the time this arrives.
             case remote::Topic::Clips:
             case remote::Topic::Session:
             case remote::Topic::Meters:

--- a/magda/daw/api/osc_feedback_live.cpp
+++ b/magda/daw/api/osc_feedback_live.cpp
@@ -39,13 +39,6 @@ OscCommand unindexed(OscCommandKind kind) {
     return OscCommand{kind, 0, 0};
 }
 
-/// Linear gain to the normalized fader position, the inverse of what
-/// `DefaultControllerParamWriter::writeTrackLevel` did on the way in.
-float normalizedFromGain(float gain, const ParameterInfo& info) {
-    const float dB = gain > 0.0f ? 20.0f * std::log10(gain) : info.minValue;
-    return ParameterUtils::realToNormalized(dB, info);
-}
-
 }  // namespace
 
 // ============================================================================
@@ -125,10 +118,12 @@ OscFeedbackProjector::OscFeedbackProjector(MagdaApi& api, remote::ChangeSource& 
         [this](const std::vector<remote::ChangeSource::Change>& changed) { onChanges(changed); });
 
     Config::getInstance().addListener(this);
+    BindingRegistry::getInstance().addListener(this);
 }
 
 OscFeedbackProjector::~OscFeedbackProjector() {
     alive_->store(false);
+    BindingRegistry::getInstance().removeListener(this);
     Config::getInstance().removeListener(this);
     tick_.reset();
     changes_.removeListener(changeToken_);
@@ -138,6 +133,14 @@ OscFeedbackProjector::~OscFeedbackProjector() {
 
 void OscFeedbackProjector::configChanged() {
     applyConfig();
+}
+
+void OscFeedbackProjector::bindingRegistryChanged(BindingScope /*scope*/) {
+    // Both scopes feed one pass, so which one moved does not matter, and
+    // dropping the remembered values is what keeps a re-pointed address from
+    // being diffed against the target it used to name.
+    bound_.clear();
+    bindingsDirty_ = true;
 }
 
 std::unique_ptr<ControllerFeedbackSink> OscFeedbackProjector::makeControllerFeedbackSink() {
@@ -236,9 +239,19 @@ void OscFeedbackProjector::onChanges(const std::vector<remote::ChangeSource::Cha
                 // user pressed save.
                 mixerDirty_ = macrosDirty_ = bindingsDirty_ = true;
                 break;
+            case remote::Topic::Automation:
+                // A curve moving a plain plugin parameter reaches nothing else.
+                // `AutomationPlaybackEngine::currentValueChanged` writes track
+                // levels, macros and mod rates back through `TrackManager` — so
+                // those arrive as Tracks or Devices — but a `PluginParam` has no
+                // such branch, and only the lane is notified. Without this a
+                // bound fader never follows an automated parameter. The tick's
+                // own cadence is the coalescing, so a curve running at block
+                // rate still costs one binding pass per tick.
+                bindingsDirty_ = true;
+                break;
             case remote::Topic::Clips:
             case remote::Topic::Session:
-            case remote::Topic::Automation:
             case remote::Topic::Meters:
             case remote::Topic::Playhead:
                 break;
@@ -256,7 +269,12 @@ void OscFeedbackProjector::tick() {
     const auto accepted = router_.acceptedMessageCount();
     if (accepted != lastAcceptedCount_) {
         const auto now = juce::Time::currentTimeMillis();
-        if (lastInboundMs_ != 0 && now - lastInboundMs_ >= kResyncSilenceMs)
+        // The first packet counts as a resync as much as one after a gap does,
+        // and for a stronger reason: the snapshot sent when the destination was
+        // configured went to a UDP address with nobody behind it yet, and there
+        // is no delivery to have failed. A surface that starts afterwards and
+        // sends its first message is a surface that has been told nothing.
+        if (lastInboundMs_ == 0 || now - lastInboundMs_ >= kResyncSilenceMs)
             requestSnapshot();
         lastInboundMs_ = now;
         lastAcceptedCount_ = accepted;
@@ -308,7 +326,7 @@ void OscFeedbackProjector::projectMixer() {
             getParameterInfoForTarget(ControlTarget::trackVolume(MASTER_TRACK_ID));
         const auto panInfo = getParameterInfoForTarget(ControlTarget::trackPan(MASTER_TRACK_ID));
         feedback_->publish(unindexed(OscCommandKind::MasterVolume),
-                           normalizedFromGain(master->volume, volumeInfo));
+                           ParameterUtils::normalizedFromGain(master->volume, volumeInfo));
         feedback_->publish(unindexed(OscCommandKind::MasterPan),
                            ParameterUtils::realToNormalized(master->pan, panInfo));
     }
@@ -332,7 +350,7 @@ void OscFeedbackProjector::projectStrip(int position, TrackId trackId) {
     const auto panInfo = getParameterInfoForTarget(ControlTarget::trackPan(trackId));
 
     feedback_->publish(OscCommand{OscCommandKind::TrackVolume, position, 0},
-                       normalizedFromGain(track->volume, volumeInfo));
+                       ParameterUtils::normalizedFromGain(track->volume, volumeInfo));
     feedback_->publish(OscCommand{OscCommandKind::TrackPan, position, 0},
                        ParameterUtils::realToNormalized(track->pan, panInfo));
     feedback_->publish(OscCommand{OscCommandKind::TrackMute, position, 0},
@@ -351,9 +369,9 @@ void OscFeedbackProjector::projectStrip(int position, TrackId trackId) {
             continue;
         }
         const auto& info = track->sends[static_cast<size_t>(send - 1)];
-        feedback_->publish(
-            command,
-            normalizedFromGain(info.level, getParameterInfoForTarget(
+        feedback_->publish(command,
+                           ParameterUtils::normalizedFromGain(
+                               info.level, getParameterInfoForTarget(
                                                ControlTarget::sendLevel(trackId, info.busIndex))));
     }
 }

--- a/magda/daw/api/osc_feedback_live.hpp
+++ b/magda/daw/api/osc_feedback_live.hpp
@@ -1,0 +1,232 @@
+#pragma once
+
+#include <juce_events/juce_events.h>
+
+#include <atomic>
+#include <memory>
+#include <vector>
+
+#include "../audio/controllers/ControllerFeedback.hpp"
+#include "../audio/controllers/ControllerParamReader.hpp"
+#include "../audio/osc/OscFeedback.hpp"
+#include "../core/Config.hpp"
+#include "../core/TypeIds.hpp"
+#include "../core/controllers/Binding.hpp"
+#include "remote_changes.hpp"
+
+namespace magda {
+
+class MagdaApi;
+
+namespace osc {
+class OscRouter;
+}
+
+/**
+ * @brief Projects MAGDA's state onto the OSC fixed namespace (#2091).
+ *
+ * The answering half of #1757. Everything below is a projection: it reads the
+ * model, hands the values to `OscFeedback`, and lets the diff there decide what
+ * is actually worth a datagram. Nothing here decides *when* to send, only what
+ * is currently true.
+ *
+ * ## Two halves, published and sampled
+ *
+ * The split is `SubscriptionHub`'s, for the same reason it has one.
+ *
+ * **Published.** Track and master volume, pan, mute, solo and sends, and the
+ * focused device's macros. Every one of those notifies a model listener however
+ * it moved — `TrackManager::setTrackVolume` calls `notifyTrackPropertyChanged`
+ * whether a fader, an OSC message or automation moved it — so `ChangeSource`
+ * says when to re-read them, and a project in which nothing moves costs nothing
+ * per tick. That is what the shared coalescing layer buys here, and it is why
+ * this is built on it rather than beside it.
+ *
+ * **Sampled.** Play, record, loop, tempo and the playhead. None of these reach
+ * `ChangeSource`: `ModelChangeBridge` listens to the model singletons, and
+ * `Topic::Transport` is marked only when a *remote API request* named
+ * `transport.*` ran, so pressing Play in MAGDA is invisible to it. The playhead
+ * has to be sampled regardless, since it moves without notifying anyone, so the
+ * five scalars ride the same tick. Five reads against a facade is what that tick
+ * already costs.
+ *
+ * ## Bound addresses
+ *
+ * A binding's address gets the position its target's value corresponds to, which
+ * is the parameter read back through the binding's own range and curve — the
+ * inverses in `BindingTransform`. Two things drive it: this class's own tick,
+ * which catches the user dragging the on-screen control, and
+ * `ControllerFeedbackSink`, which catches a write that arrived from another
+ * control surface.
+ *
+ * ## Threading
+ *
+ * Message thread throughout. The `ChangeSource` listener is called there, the
+ * timer runs there, and `OscRouter`'s drain — which is where `noteReceived`
+ * comes from — is there too, so `OscFeedback` needs no synchronisation at all.
+ *
+ * The tick is an owned object rather than a base class, the same shape
+ * `SubscriptionHub` gives its sampler. `juce::Timer` holds a
+ * `SharedResourcePointer<TimerThread>`, so *inheriting* one starts JUCE's timer
+ * thread the moment a projector exists — including in a process that has no
+ * message loop to drive it. Owning it means a projector with no destination
+ * costs nothing and a headless one costs nothing at all.
+ */
+class OscFeedbackProjector : private ConfigListener {
+  public:
+    /**
+     * @param api       The facade. Must outlive this.
+     * @param changes   The shared change source (#1857). Must outlive this.
+     * @param router    The router whose applied values are this projector's own
+     *                  echo, and whose message count says when a surface has
+     *                  started talking. Must outlive this.
+     * @param reader    Where a bound target's current value comes from. Null is
+     *                  legal and means the fixed namespace only, which is the
+     *                  headless case: bindings resolve against an engine.
+     * @param sink      Where finished messages go. Null — the application's
+     *                  case — builds an `OscSenderSink` and makes
+     *                  `setDestination` mean what it says. Supplying one instead
+     *                  is how a test observes the projection without opening a
+     *                  socket, and it makes the projector permanently "sending",
+     *                  since there is no destination to configure.
+     */
+    OscFeedbackProjector(MagdaApi& api, remote::ChangeSource& changes, osc::OscRouter& router,
+                         std::unique_ptr<ControllerParamReader> reader,
+                         std::unique_ptr<osc::OscMessageSink> sink = nullptr);
+    ~OscFeedbackProjector() override;
+
+    /// Whether the tick is running. False with no destination configured, which
+    /// is also when this costs nothing.
+    bool isTicking() const {
+        return tick_ != nullptr;
+    }
+
+    OscFeedbackProjector(const OscFeedbackProjector&) = delete;
+    OscFeedbackProjector& operator=(const OscFeedbackProjector&) = delete;
+
+    /// Matches `ChangeSource`'s own flush cadence, which is the rate at which
+    /// the published half can produce anything new.
+    static constexpr int kTickIntervalMs = 33;
+
+    /// Inbound silence long enough that traffic resuming is more likely a
+    /// surface that has just connected than a pause in a gesture. The best
+    /// proxy available for "a new peer appeared", since JUCE does not report
+    /// who sent a datagram.
+    static constexpr int kResyncSilenceMs = 5000;
+
+    /**
+     * @brief Point feedback at a destination and start, or stop it.
+     *
+     * An empty host stops the timer and disconnects, so a MAGDA with feedback
+     * off does no per-tick work at all. A change of destination is a new surface
+     * by definition, so it takes a full snapshot.
+     *
+     * @return true when a destination is connected afterwards.
+     */
+    bool setDestination(const juce::String& host, int port);
+
+    /// Bring the destination into line with `Config`. Safe to call repeatedly.
+    bool applyConfig();
+
+    bool isSending() const;
+
+    /// Send everything the surface could care about on the next tick.
+    void requestSnapshot();
+
+    /**
+     * @brief Project what is dirty and send what changed, on the calling thread.
+     *
+     * What the timer does, once. Public for the same reason
+     * `OscRouter::drainPending` and `SubscriptionHub::sampleNow` are: a host
+     * with no MessageManager has no timer, which is the headless test case, and
+     * driving it directly is the only way to observe what one tick decided.
+     */
+    void tick();
+
+    /// A feedback sink for `ControllerRouter`, so a parameter written by any
+    /// control surface reaches the OSC bindings that address it. Ownership goes
+    /// to the router; it holds a pointer back here and must not outlive this.
+    std::unique_ptr<ControllerFeedbackSink> makeControllerFeedbackSink();
+
+    osc::OscFeedback& feedback() {
+        return *feedback_;
+    }
+
+  private:
+    class ControllerSink;
+    class Tick;
+
+    /// Config changed: the destination may have. Reapplying is idempotent, so
+    /// an unrelated save leaves a connected surface alone.
+    void configChanged() override;
+
+    void onChanges(const std::vector<remote::ChangeSource::Change>& changes);
+
+    /// Track and master strips: volume, pan, mute, solo, sends.
+    void projectMixer();
+    /// The focused device's sixteen macros, or nothing when nothing is focused.
+    void projectMacros();
+    /// Play, record, loop, tempo, position.
+    void projectTransport();
+    /// Every OSC binding's address, at the position its target implies.
+    void projectBindings();
+
+    /// Publish one strip's block at a 1-based mixer position.
+    void projectStrip(int position, TrackId trackId);
+
+    /// Forget the positions between `firstUnused` and the highest position this
+    /// projector has ever published, so a deleted track stops being part of a
+    /// snapshot.
+    void retirePositionsFrom(int firstUnused);
+
+    /// Feed a binding's address, given the value its target currently holds.
+    void publishBinding(const Binding& binding, float targetValue);
+
+    MagdaApi& api_;
+    remote::ChangeSource& changes_;
+    osc::OscRouter& router_;
+
+    std::unique_ptr<ControllerParamReader> reader_;
+    std::unique_ptr<osc::OscFeedback> feedback_;
+    osc::OscSenderSink* sender_ = nullptr;  ///< Owned by `feedback_`.
+    std::unique_ptr<Tick> tick_;
+
+    int changeToken_ = 0;
+
+    /// Set by the change source, consumed by the tick.
+    bool mixerDirty_ = true;
+    bool macrosDirty_ = true;
+    bool bindingsDirty_ = true;
+
+    /// The highest 1-based mixer position ever published, so shrinking the
+    /// project retires what it left behind.
+    int highestPosition_ = 0;
+
+    /// Bound addresses are not slots, so they carry their own copy of what the
+    /// slot table holds: what was last sent, and what arrived from the surface.
+    /// `echoed` is the same bit for the same reason — see `OscFeedback`.
+    struct BoundAddress {
+        juce::String address;
+        float lastSent = 0.0f;
+        float lastReceived = 0.0f;
+        bool hasSent = false;
+        bool echoed = false;
+    };
+    std::vector<BoundAddress> bound_;
+
+    /// The entry for `address`, created if this is the first time it has been
+    /// seen. Linear: bindings number in the tens, and an OSC address is a short
+    /// string, so a map would cost more in allocation than the scan does in
+    /// comparisons.
+    BoundAddress& boundEntryFor(const juce::String& address);
+
+    std::uint64_t lastAcceptedCount_ = 0;
+    juce::int64 lastInboundMs_ = 0;
+
+    /// Cleared before the object dies, so a `ControllerFeedbackSink` still
+    /// installed on the router singleton stops reaching in here rather than
+    /// reaching into a destroyed projector.
+    std::shared_ptr<std::atomic<bool>> alive_{std::make_shared<std::atomic<bool>>(true)};
+};
+
+}  // namespace magda

--- a/magda/daw/api/osc_feedback_live.hpp
+++ b/magda/daw/api/osc_feedback_live.hpp
@@ -12,6 +12,7 @@
 #include "../core/Config.hpp"
 #include "../core/TypeIds.hpp"
 #include "../core/controllers/Binding.hpp"
+#include "../core/controllers/BindingRegistry.hpp"
 #include "remote_changes.hpp"
 
 namespace magda {
@@ -72,7 +73,7 @@ class OscRouter;
  * message loop to drive it. Owning it means a projector with no destination
  * costs nothing and a headless one costs nothing at all.
  */
-class OscFeedbackProjector : private ConfigListener {
+class OscFeedbackProjector : private ConfigListener, private BindingRegistryListener {
   public:
     /**
      * @param api       The facade. Must outlive this.
@@ -159,6 +160,22 @@ class OscFeedbackProjector : private ConfigListener {
     /// Config changed: the destination may have. Reapplying is idempotent, so
     /// an unrelated save leaves a connected surface alone.
     void configChanged() override;
+
+    /**
+     * @brief The bindings in force changed, so what each address shows may have.
+     *
+     * `OscService` already listens for this to rebuild the inbound routes;
+     * without the same listener here, a binding added or learned after the last
+     * tick would drive its target while the address it drives it from stayed
+     * blank until some unrelated edit happened to dirty the pass. OSC learn is
+     * the sharpest case, because its capture is consumed rather than applied, so
+     * nothing moves to notify anyone.
+     *
+     * The remembered values go with it: an address whose binding was re-pointed
+     * is showing the old target's position, and there is nothing to diff a new
+     * target against.
+     */
+    void bindingRegistryChanged(BindingScope scope) override;
 
     void onChanges(const std::vector<remote::ChangeSource::Change>& changes);
 

--- a/magda/daw/audio/CMakeLists.txt
+++ b/magda/daw/audio/CMakeLists.txt
@@ -428,10 +428,12 @@ target_sources(magda_daw PRIVATE
     insert_capture/InsertRenderCaptureService.cpp
     ExternalInsertDeviceEnablement.cpp
     # Controller routing (issue #1050 -- Phase C)
+    controllers/ControllerParamReader.cpp
     controllers/ControllerParamWriter.cpp
     controllers/ControllerRouter.cpp
     # OSC control surfaces (issue #1757)
     osc/OscAddress.cpp
+    osc/OscFeedback.cpp
     osc/OscRouter.cpp
     osc/OscService.cpp
     # Headers (listed for IDE visibility)

--- a/magda/daw/audio/automation/AutomationPlaybackEngine.cpp
+++ b/magda/daw/audio/automation/AutomationPlaybackEngine.cpp
@@ -723,22 +723,27 @@ void AutomationPlaybackEngine::currentValueChanged(te::AutomatableParameter& par
         target.kind == ControlTarget::Kind::TrackPan ||
         target.kind == ControlTarget::Kind::SendLevel) {
         ParameterInfo info = getParameterInfoForTarget(target);
-        float real = ParameterUtils::normalizedToReal(static_cast<float>(normalized), info);
+        const auto position = static_cast<float>(normalized);
 
         auto& trackMgr = TrackManager::getInstance();
         // Scope the re-entrancy flag so AudioBridge can distinguish this
         // automation-driven writeback from user-initiated fader/pan edits.
         AutomationManager::AutomationWriteScope writeScope;
         if (target.kind == ControlTarget::Kind::TrackVolume) {
-            // Target param range is in dB; convert back to linear gain.
-            float gain = std::pow(10.0f, real / 20.0f);
-            trackMgr.setTrackVolume(target.devicePath.trackId, gain, /*fromAutomation=*/true);
+            // Target param range is in dB; TrackManager holds linear gain. The
+            // same shared pair the controller writer and reader use, so a curve
+            // and a fader at one position resolve to one gain.
+            trackMgr.setTrackVolume(target.devicePath.trackId,
+                                    ParameterUtils::gainFromNormalized(position, info),
+                                    /*fromAutomation=*/true);
         } else if (target.kind == ControlTarget::Kind::TrackPan) {
-            trackMgr.setTrackPan(target.devicePath.trackId, real, /*fromAutomation=*/true);
+            trackMgr.setTrackPan(target.devicePath.trackId,
+                                 ParameterUtils::normalizedToReal(position, info),
+                                 /*fromAutomation=*/true);
         } else {
-            // SendLevel: same fader-dB → linear-gain mapping as TrackVolume.
-            float gain = std::pow(10.0f, real / 20.0f);
-            trackMgr.setSendLevel(target.devicePath.trackId, target.sendBusIndex, gain,
+            // SendLevel: same fader-dB to linear-gain mapping as TrackVolume.
+            trackMgr.setSendLevel(target.devicePath.trackId, target.sendBusIndex,
+                                  ParameterUtils::gainFromNormalized(position, info),
                                   /*fromAutomation=*/true);
         }
     } else if (target.kind == ControlTarget::Kind::DeviceMacro) {

--- a/magda/daw/audio/controllers/ControllerParamReader.cpp
+++ b/magda/daw/audio/controllers/ControllerParamReader.cpp
@@ -9,20 +9,6 @@
 
 namespace magda {
 
-namespace {
-
-/// Linear gain back to the normalized position that produced it: the inverse of
-/// `DefaultControllerParamWriter::writeTrackLevel`'s `pow(10, dB/20)`.
-///
-/// Silence has no dB, so it answers the bottom of the fader's range rather than
-/// negative infinity. That is where a fader at zero gain sits.
-float normalizedFromGain(float gain, const ParameterInfo& info) {
-    const float dB = gain > 0.0f ? 20.0f * std::log10(gain) : info.minValue;
-    return ParameterUtils::realToNormalized(dB, info);
-}
-
-}  // namespace
-
 std::optional<float> DefaultControllerParamReader::read(const ResolveResult& resolved) {
     if (!resolved.ok())
         return std::nullopt;
@@ -61,7 +47,7 @@ std::optional<float> DefaultControllerParamReader::readTrackLevel(const ControlT
 
     const ParameterInfo info = getParameterInfoForTarget(target);
     if (target.kind == ControlTarget::Kind::TrackVolume)
-        return normalizedFromGain(track->volume, info);
+        return ParameterUtils::normalizedFromGain(track->volume, info);
     return ParameterUtils::realToNormalized(track->pan, info);
 }
 
@@ -76,7 +62,8 @@ std::optional<float> DefaultControllerParamReader::readSendLevel(const ControlTa
 
     for (const auto& send : track->sends)
         if (send.busIndex == target.sendBusIndex)
-            return normalizedFromGain(send.level, getParameterInfoForTarget(target));
+            return ParameterUtils::normalizedFromGain(send.level,
+                                                      getParameterInfoForTarget(target));
 
     return std::nullopt;
 }

--- a/magda/daw/audio/controllers/ControllerParamReader.cpp
+++ b/magda/daw/audio/controllers/ControllerParamReader.cpp
@@ -1,0 +1,133 @@
+#include "controllers/ControllerParamReader.hpp"
+
+#include <cmath>
+
+#include "../../core/AutomationInfo.hpp"
+#include "../../core/ParameterUtils.hpp"
+#include "../../core/TrackManager.hpp"
+#include "AudioBridge.hpp"
+
+namespace magda {
+
+namespace {
+
+/// Linear gain back to the normalized position that produced it: the inverse of
+/// `DefaultControllerParamWriter::writeTrackLevel`'s `pow(10, dB/20)`.
+///
+/// Silence has no dB, so it answers the bottom of the fader's range rather than
+/// negative infinity. That is where a fader at zero gain sits.
+float normalizedFromGain(float gain, const ParameterInfo& info) {
+    const float dB = gain > 0.0f ? 20.0f * std::log10(gain) : info.minValue;
+    return ParameterUtils::realToNormalized(dB, info);
+}
+
+}  // namespace
+
+std::optional<float> DefaultControllerParamReader::read(const ResolveResult& resolved) {
+    if (!resolved.ok())
+        return std::nullopt;
+
+    switch (resolved.target.kind) {
+        case ControlTarget::Kind::PluginParam:
+            return readPluginParam(resolved.target);
+        case ControlTarget::Kind::DeviceMacro:
+            return readMacro(resolved.target);
+        case ControlTarget::Kind::TrackVolume:
+        case ControlTarget::Kind::TrackPan:
+            return readTrackLevel(resolved.target);
+        case ControlTarget::Kind::SendLevel:
+            return readSendLevel(resolved.target);
+        case ControlTarget::Kind::ModParam:
+        case ControlTarget::Kind::Tempo:
+            // See the header: neither has a reading, for reasons that are about
+            // the target rather than about this being unfinished.
+            return std::nullopt;
+    }
+    return std::nullopt;
+}
+
+// Read from TrackInfo, which is what the writer wrote. The te::AutomatableParameter
+// behind a track fader holds a TE fader *position* rather than the linear gain
+// TrackManager keeps, so inverting through it would convert across two different
+// curves and the round trip would not close.
+std::optional<float> DefaultControllerParamReader::readTrackLevel(const ControlTarget& target) {
+    const auto trackId = target.devicePath.trackId;
+    if (trackId == INVALID_TRACK_ID)
+        return std::nullopt;
+
+    const auto* track = TrackManager::getInstance().getTrack(trackId);
+    if (track == nullptr)
+        return std::nullopt;
+
+    const ParameterInfo info = getParameterInfoForTarget(target);
+    if (target.kind == ControlTarget::Kind::TrackVolume)
+        return normalizedFromGain(track->volume, info);
+    return ParameterUtils::realToNormalized(track->pan, info);
+}
+
+std::optional<float> DefaultControllerParamReader::readSendLevel(const ControlTarget& target) {
+    const auto trackId = target.devicePath.trackId;
+    if (trackId == INVALID_TRACK_ID || target.sendBusIndex < 0)
+        return std::nullopt;
+
+    const auto* track = TrackManager::getInstance().getTrack(trackId);
+    if (track == nullptr)
+        return std::nullopt;
+
+    for (const auto& send : track->sends)
+        if (send.busIndex == target.sendBusIndex)
+            return normalizedFromGain(send.level, getParameterInfoForTarget(target));
+
+    return std::nullopt;
+}
+
+std::optional<float> DefaultControllerParamReader::readMacro(const ControlTarget& target) {
+    if (!target.devicePath.isValid() || target.paramIndex < 0)
+        return std::nullopt;
+
+    // The same path-driven view the unified setter writes through, so track,
+    // rack and device macros all read the one way. Const-qualified deliberately:
+    // the mutable overload is private, and reading has no business with it.
+    const TrackManager& trackMgr = TrackManager::getInstance();
+    const auto node = trackMgr.resolveChainNode(target.devicePath);
+    if (!node.valid() || target.paramIndex >= static_cast<int>(node.macros->size()))
+        return std::nullopt;
+
+    return (*node.macros)[static_cast<size_t>(target.paramIndex)].value;
+}
+
+std::optional<float> DefaultControllerParamReader::readPluginParam(const ControlTarget& target) {
+    auto& trackMgr = TrackManager::getInstance();
+
+    // The writer's own branch, taken on the same condition: a display-mapped
+    // internal parameter never reached TE's value range on the way in, so it
+    // must not be read back through it either.
+    if (const auto* device = trackMgr.getDeviceInChainByPath(target.devicePath)) {
+        if (const auto* info = device->findParameterByIndex(target.paramIndex);
+            info != nullptr && device->format == PluginFormat::Internal &&
+            ParameterUtils::isDisplayMappedInternalValue(*info)) {
+            return ParameterUtils::modelToNormalizedValue(ParameterModelValue{info->currentValue},
+                                                          *info)
+                .value;
+        }
+    }
+
+    auto* param = bridge_.resolveControlTarget(target);
+    if (param == nullptr)
+        return std::nullopt;
+
+    const auto range = param->getValueRange();
+    const float span = static_cast<float>(range.getLength());
+    if (span <= 0.0f)
+        return std::nullopt;
+
+    // The base value rather than the current one. A parameter with an LFO or a
+    // macro on it has a value that moves every block, and echoing that would
+    // both flood the surface and put its fader somewhere the user cannot have
+    // put it. What a control surface owns is the value underneath the
+    // modulation, which is what it wrote.
+    const auto base = static_cast<float>(param->getCurrentBaseValue());
+    return juce::jlimit(0.0f, 1.0f, (base - static_cast<float>(range.getStart())) / span);
+}
+
+}  // namespace magda

--- a/magda/daw/audio/controllers/ControllerParamReader.hpp
+++ b/magda/daw/audio/controllers/ControllerParamReader.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <optional>
+
+#include "../../core/aliases/TargetResolver.hpp"
+
+namespace magda {
+
+// ============================================================================
+// ControllerParamReader (abstract)
+// ============================================================================
+
+/**
+ * @brief Reads back the normalized value at a resolved parameter target.
+ *
+ * The mirror of `ControllerParamWriter`, and deliberately its neighbour rather
+ * than a private helper somewhere: OSC feedback (#2091) has to answer "where
+ * should this fader sit" with the value a write of that position would have
+ * produced, and the only way that stays true is for the two to be read side by
+ * side and change together.
+ *
+ * A target that cannot be read answers `nullopt` rather than a plausible zero.
+ * A surface told 0 puts its fader at the bottom, which is a lie; a surface told
+ * nothing leaves it where it is, which is merely stale.
+ *
+ * Called on the message thread.
+ */
+class ControllerParamReader {
+  public:
+    virtual ~ControllerParamReader() = default;
+
+    /**
+     * @param resolved  Fully resolved device + param index.
+     * @return The target's value as a normalized float in [0,1], or nullopt
+     *         when it has none to give.
+     */
+    virtual std::optional<float> read(const ResolveResult& resolved) = 0;
+};
+
+// ============================================================================
+// DefaultControllerParamReader
+// ============================================================================
+
+class AudioBridge;
+
+/**
+ * @brief The reader that inverts `DefaultControllerParamWriter`, branch for
+ *        branch.
+ *
+ * Each case below is the writer's own case read backwards, and the pairing is
+ * the point:
+ *
+ *  - Track and master volume and pan and send levels come from `TrackInfo`,
+ *    because that is what the writer wrote to. Going to the
+ *    `te::AutomatableParameter` instead would mean converting through TE's
+ *    fader-position curve, which is a different domain from the linear gain
+ *    `TrackManager` holds, and the round trip would not close.
+ *  - Macros are normalized on both sides, so `MacroInfo::value` is the answer
+ *    already.
+ *  - A plugin parameter takes whichever of the writer's two paths its own
+ *    `ParameterInfo` selects: a display-mapped internal parameter inverts
+ *    through `ParameterUtils`, and everything else inverts through the TE
+ *    parameter's value range, which is what the writer mapped it into.
+ *
+ * `ModParam` is the one kind with no reading. Its forward path resolves a
+ * modifier's tempo-sync flag and then writes either a rate in Hz or a discrete
+ * sync-division ordinal, and the ordinal is a rounding that does not invert. No
+ * surface displays a modifier rate, so this answers nullopt rather than growing
+ * a special case for it.
+ *
+ * `Tempo` has no reading either, for the reason the writer has no writing: it is
+ * not reachable from a control surface, and the OSC namespace sets it through
+ * `ProjectApi`.
+ */
+class DefaultControllerParamReader : public ControllerParamReader {
+  public:
+    explicit DefaultControllerParamReader(AudioBridge& bridge) : bridge_(bridge) {}
+
+    std::optional<float> read(const ResolveResult& resolved) override;
+
+  private:
+    static std::optional<float> readTrackLevel(const ControlTarget& target);
+    static std::optional<float> readSendLevel(const ControlTarget& target);
+    static std::optional<float> readMacro(const ControlTarget& target);
+    std::optional<float> readPluginParam(const ControlTarget& target);
+
+    AudioBridge& bridge_;
+};
+
+}  // namespace magda

--- a/magda/daw/audio/controllers/ControllerParamWriter.cpp
+++ b/magda/daw/audio/controllers/ControllerParamWriter.cpp
@@ -64,14 +64,14 @@ void DefaultControllerParamWriter::writeTrackLevel(const ControlTarget& target, 
     // Same normalized -> real conversion the automation engine applies, so a
     // controller fader and an automation curve resolve to identical values.
     const ParameterInfo info = getParameterInfoForTarget(target);
-    const float real = ParameterUtils::normalizedToReal(clamped, info);
 
     auto& trackMgr = TrackManager::getInstance();
     if (target.kind == ControlTarget::Kind::TrackVolume) {
-        // The fader range is in dB; TrackManager expects linear gain.
-        trackMgr.setTrackVolume(trackId, std::pow(10.0f, real / 20.0f));
+        // The fader range is in dB; TrackManager expects linear gain. One home
+        // for that pair, shared with the reader that inverts it.
+        trackMgr.setTrackVolume(trackId, ParameterUtils::gainFromNormalized(clamped, info));
     } else {
-        trackMgr.setTrackPan(trackId, real);
+        trackMgr.setTrackPan(trackId, ParameterUtils::normalizedToReal(clamped, info));
     }
 }
 
@@ -86,9 +86,8 @@ void DefaultControllerParamWriter::writeSendLevel(const ControlTarget& target, f
         return;
 
     const ParameterInfo info = getParameterInfoForTarget(target);
-    const float real = ParameterUtils::normalizedToReal(clamped, info);
     TrackManager::getInstance().setSendLevel(trackId, target.sendBusIndex,
-                                             std::pow(10.0f, real / 20.0f));
+                                             ParameterUtils::gainFromNormalized(clamped, info));
 }
 
 void DefaultControllerParamWriter::writePluginParam(const ControlTarget& target, float clamped) {

--- a/magda/daw/audio/osc/OscAddress.cpp
+++ b/magda/daw/audio/osc/OscAddress.cpp
@@ -217,6 +217,50 @@ std::optional<OscCommand> parseOscAddress(juce::StringRef address) {
 }
 
 // ============================================================================
+// Formatting
+// ============================================================================
+
+juce::String formatOscAddress(const OscCommand& command) {
+    switch (command.kind) {
+        case OscCommandKind::TransportPlay:
+            return "/magda/transport/play";
+        case OscCommandKind::TransportStop:
+            return "/magda/transport/stop";
+        case OscCommandKind::TransportRecord:
+            return "/magda/transport/record";
+        case OscCommandKind::TransportLoop:
+            return "/magda/transport/loop";
+        case OscCommandKind::TransportTempo:
+            return "/magda/transport/tempo";
+        case OscCommandKind::TransportPosition:
+            return "/magda/transport/position";
+        case OscCommandKind::TransportSeekBeats:
+            return "/magda/transport/seek";
+        case OscCommandKind::TransportSeekBars:
+            return "/magda/transport/seek/bars";
+        case OscCommandKind::MasterVolume:
+            return "/magda/master/volume";
+        case OscCommandKind::MasterPan:
+            return "/magda/master/pan";
+        case OscCommandKind::FocusedMacro:
+            return "/magda/focused/macro/" + juce::String(command.index);
+        case OscCommandKind::TrackVolume:
+            return "/magda/track/" + juce::String(command.index) + "/volume";
+        case OscCommandKind::TrackPan:
+            return "/magda/track/" + juce::String(command.index) + "/pan";
+        case OscCommandKind::TrackMute:
+            return "/magda/track/" + juce::String(command.index) + "/mute";
+        case OscCommandKind::TrackSolo:
+            return "/magda/track/" + juce::String(command.index) + "/solo";
+        case OscCommandKind::TrackSend:
+            return "/magda/track/" + juce::String(command.index) + "/send/" +
+                   juce::String(command.subIndex);
+    }
+    jassertfalse;  // every kind is covered above
+    return {};
+}
+
+// ============================================================================
 // Slot mapping
 // ============================================================================
 

--- a/magda/daw/audio/osc/OscAddress.hpp
+++ b/magda/daw/audio/osc/OscAddress.hpp
@@ -146,6 +146,20 @@ OscArgKind argKindFor(OscCommandKind kind);
  */
 std::optional<OscCommand> parseOscAddress(juce::StringRef address);
 
+/**
+ * @brief The address a command is spelled with. The inverse of the parser.
+ *
+ * Feedback (#2091) sends on the address a value is received on, so the spelling
+ * has to come from the same place the grammar does rather than from a second
+ * list of string literals that agrees with it today. `parseOscAddress` of the
+ * result is `command` again, for every command the parser can produce, which is
+ * what the round-trip test asserts over the whole slot space.
+ *
+ * Called on the message thread, once per address that actually changed, so it
+ * builds a `juce::String` rather than writing into a caller's buffer.
+ */
+juce::String formatOscAddress(const OscCommand& command);
+
 // ============================================================================
 // Coalescing slots
 // ============================================================================

--- a/magda/daw/audio/osc/OscFeedback.cpp
+++ b/magda/daw/audio/osc/OscFeedback.cpp
@@ -1,0 +1,182 @@
+#include "osc/OscFeedback.hpp"
+
+#include <bit>
+#include <cmath>
+
+namespace magda::osc {
+
+// ============================================================================
+// OscSenderSink
+// ============================================================================
+
+OscSenderSink::~OscSenderSink() {
+    disconnect();
+}
+
+bool OscSenderSink::connect(const juce::String& host, int port) {
+    if (connected_ && host == host_ && port == port_)
+        return true;
+
+    disconnect();
+
+    if (host.isEmpty() || port <= 0 || port > 65535)
+        return false;
+
+    if (!sender_.connect(host, port))
+        return false;
+
+    host_ = host;
+    port_ = port;
+    connected_ = true;
+    return true;
+}
+
+void OscSenderSink::disconnect() {
+    if (connected_) {
+        sender_.disconnect();
+        connected_ = false;
+    }
+    host_ = {};
+    port_ = 0;
+}
+
+bool OscSenderSink::send(const juce::String& address, float value) {
+    if (!connected_)
+        return false;
+    return sender_.send(juce::OSCMessage(juce::OSCAddressPattern(address), value));
+}
+
+// ============================================================================
+// OscFeedback
+// ============================================================================
+
+OscFeedback::OscFeedback(std::unique_ptr<OscMessageSink> sink) : sink_(std::move(sink)) {
+    jassert(sink_ != nullptr);
+}
+
+OscFeedback::~OscFeedback() = default;
+
+bool OscFeedback::isSendable(const OscCommand& command) {
+    return argKindFor(command.kind) != OscArgKind::Delta;
+}
+
+void OscFeedback::publish(int slot, float value) {
+    jassert(slot >= 0 && slot < kOscSlotCount);
+    if (slot < 0 || slot >= kOscSlotCount)
+        return;
+
+    const auto index = static_cast<std::size_t>(slot);
+    current_[index] = value;
+    set(valid_, slot);
+
+    // Dirty is recomputed rather than latched, so a value that moves away from
+    // what the surface holds and back again between two flushes sends nothing.
+    // The surface is already right; the intermediate value never existed as far
+    // as it is concerned.
+    if (!test(hasSent_, slot) || lastSent_[index] != value)
+        set(dirty_, slot);
+    else
+        clear(dirty_, slot);
+}
+
+void OscFeedback::retire(int slot) {
+    jassert(slot >= 0 && slot < kOscSlotCount);
+    if (slot < 0 || slot >= kOscSlotCount)
+        return;
+
+    clear(valid_, slot);
+    clear(dirty_, slot);
+    clear(hasSent_, slot);
+}
+
+void OscFeedback::noteReceived(int slot, float value) {
+    jassert(slot >= 0 && slot < kOscSlotCount);
+    if (slot < 0 || slot >= kOscSlotCount)
+        return;
+
+    lastReceived_[static_cast<std::size_t>(slot)] = value;
+    set(echoed_, slot);
+}
+
+void OscFeedback::requestSnapshot() {
+    snapshotPending_ = true;
+}
+
+void OscFeedback::reset() {
+    valid_ = {};
+    hasSent_ = {};
+    dirty_ = {};
+    echoed_ = {};
+    snapshotPending_ = false;
+}
+
+int OscFeedback::flush() {
+    const bool snapshot = snapshotPending_;
+    snapshotPending_ = false;
+
+    if (snapshot) {
+        // Everything that has a value, whether or not it has moved since the
+        // surface was last told. A surface that just joined has been told
+        // nothing.
+        for (int word = 0; word < kWords; ++word)
+            dirty_[static_cast<std::size_t>(word)] |= valid_[static_cast<std::size_t>(word)];
+    }
+
+    int sent = 0;
+
+    for (int word = 0; word < kWords; ++word) {
+        auto bits = dirty_[static_cast<std::size_t>(word)];
+        while (bits != 0) {
+            const int slot = (word * 64) + std::countr_zero(bits);
+            bits &= bits - 1;
+
+            const auto index = static_cast<std::size_t>(slot);
+            const auto command = oscCommandForSlot(slot);
+
+            // A delta address has no state behind it. Nothing should ever
+            // publish into one; if something does, it is dropped here rather
+            // than sent, so a rewind button cannot be pressed by feedback.
+            if (!isSendable(command)) {
+                clear(dirty_, slot);
+                continue;
+            }
+
+            // The echo, and the only thing that is not sent for a reason other
+            // than the budget. Recorded as sent anyway: the surface holds this
+            // value, so it is what the next change has to differ from.
+            if (!snapshot && test(echoed_, slot) &&
+                std::abs(current_[index] - lastReceived_[index]) <= kEchoEpsilon) {
+                lastSent_[index] = current_[index];
+                set(hasSent_, slot);
+                clear(dirty_, slot);
+                continue;
+            }
+
+            if (sent >= kMaxMessagesPerFlush) {
+                // Left dirty on purpose. The walk continues so the echo rule
+                // above still runs for the rest of the table before its bits
+                // are cleared below.
+                ++deferred_;
+                continue;
+            }
+
+            if (!sink_->send(formatOscAddress(command), current_[index])) {
+                // No destination. Drop the send but keep the slot dirty, so
+                // configuring one later starts from what is true rather than
+                // from what happened to change after it was configured.
+                continue;
+            }
+
+            lastSent_[index] = current_[index];
+            set(hasSent_, slot);
+            clear(dirty_, slot);
+            ++sent;
+        }
+    }
+
+    echoed_ = {};
+    sent_ += static_cast<std::uint64_t>(sent);
+    return sent;
+}
+
+}  // namespace magda::osc

--- a/magda/daw/audio/osc/OscFeedback.hpp
+++ b/magda/daw/audio/osc/OscFeedback.hpp
@@ -1,0 +1,271 @@
+#pragma once
+
+#include <juce_osc/juce_osc.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "osc/OscAddress.hpp"
+
+namespace magda::osc {
+
+// ============================================================================
+// OscMessageSink
+// ============================================================================
+
+/**
+ * @brief Where a feedback message goes once it has an address and a value.
+ *
+ * The seam between "MAGDA's state changed and the surface should hear about it"
+ * and "a datagram left the machine", so everything above it — the diffing, the
+ * echo rule, the budget — is testable without opening a socket. Called on the
+ * message thread.
+ *
+ * @return false when the message could not be sent, which for UDP means the
+ *         socket is not connected rather than that the surface is not there.
+ */
+class OscMessageSink {
+  public:
+    virtual ~OscMessageSink() = default;
+    virtual bool send(const juce::String& address, float value) = 0;
+};
+
+// ============================================================================
+// OscSenderSink
+// ============================================================================
+
+/**
+ * @brief The sink backed by a real `juce::OSCSender`.
+ *
+ * One socket for the lifetime of the sink, aimed at one destination. There is
+ * no per-peer routing because there is no way to learn a peer:
+ * `juce::OSCReceiver` hands a realtime listener an `OSCMessage` and drops the
+ * datagram's source address inside its own receive loop, and JUCE's OSC parser
+ * is private to the module, so reading the sender would mean reimplementing it.
+ * Feedback therefore goes where configuration says and nowhere else.
+ */
+class OscSenderSink : public OscMessageSink {
+  public:
+    OscSenderSink() = default;
+    ~OscSenderSink() override;
+
+    OscSenderSink(const OscSenderSink&) = delete;
+    OscSenderSink& operator=(const OscSenderSink&) = delete;
+
+    /**
+     * @brief Aim at a destination, replacing any current one.
+     *
+     * An empty host disconnects, which is how feedback is turned off: there is
+     * no separate enable, because a destination is the whole of what feedback
+     * needs to exist.
+     *
+     * @return true when a socket is connected afterwards.
+     */
+    bool connect(const juce::String& host, int port);
+    void disconnect();
+
+    bool isConnected() const {
+        return connected_;
+    }
+
+    juce::String destinationHost() const {
+        return host_;
+    }
+
+    int destinationPort() const {
+        return port_;
+    }
+
+    bool send(const juce::String& address, float value) override;
+
+  private:
+    juce::OSCSender sender_;
+    juce::String host_;
+    int port_ = 0;
+    bool connected_ = false;
+};
+
+// ============================================================================
+// OscFeedback
+// ============================================================================
+
+/**
+ * @brief Echoes MAGDA's state back onto the fixed namespace (#2091).
+ *
+ * A surface that can drive MAGDA but never hears back shows whatever its
+ * template defaulted to: a motorised fader stays where the user left it, and
+ * moving a fader in the app leaves the surface lying about the value. This is
+ * the half that answers.
+ *
+ * ## A projection, diffed
+ *
+ * Callers publish the current value of an address; nothing is sent unless it
+ * differs from the value that address was last told. That one rule covers three
+ * of the requirements at once. "On change" is what the diff means. The rate
+ * limit falls out of the flush cadence, because an address can be sent at most
+ * once per flush however often it was published in between. And latest value
+ * wins by construction, because a slot holds one value.
+ *
+ * The address space is fixed and bounded at compile time (`kOscSlotCount`), so
+ * every address owns a slot and the whole of this is arrays and bitmaps rather
+ * than a map keyed by string.
+ *
+ * ## The echo rule
+ *
+ * A value that has just arrived from the surface is a value the surface already
+ * shows, so sending it back is redundant, and for a control that reports its own
+ * motorised position it is a loop. `noteReceived` records the value and sets a
+ * bit; a flush suppresses a slot whose projected value matches what was received
+ * *and* whose bit is set, then clears every bit.
+ *
+ * The bit is the part that makes this correct rather than merely quiet. Matching
+ * on value alone looks equivalent and is not: a surface sets a fader to 0.62,
+ * the user drags MAGDA's fader to 0.9 and then back to 0.62, and a value-only
+ * rule would suppress the send that brings the surface back from 0.9. Bounding
+ * the suppression to the flush the arrival belongs to is what stops that.
+ *
+ * A suppressed slot is still recorded as sent, so the next value that differs
+ * from it goes out normally. And because the bit is cleared every flush, the
+ * flush after a gesture ends sends the value once — a confirmation rather than
+ * an echo, and where the surface finds out what MAGDA rounded it to.
+ *
+ * ## Snapshots
+ *
+ * `requestSnapshot` sends every slot that has a value, ignoring both the diff
+ * and the echo rule, so a surface that has just joined is correct rather than
+ * blank. Bounded by what the project really has, not by `kMaxTrackNumber`:
+ * `retire` is how a caller says a position no longer addresses anything, and a
+ * retired slot is neither sent nor remembered.
+ *
+ * ## The budget
+ *
+ * A flush sends at most `kMaxMessagesPerFlush`. Only a snapshot of a large
+ * project reaches that, and a snapshot is also the one thing that has to finish,
+ * so what does not fit stays dirty and goes out on the next flush rather than
+ * being dropped. A sixty-track snapshot is three ticks, not one long one.
+ *
+ * ## Threading
+ *
+ * Message thread only, all of it. `noteReceived` is called from
+ * `OscRouter::drainPending`, which is already there, and `flush` from the
+ * projection above it.
+ */
+class OscFeedback {
+  public:
+    explicit OscFeedback(std::unique_ptr<OscMessageSink> sink);
+    ~OscFeedback();
+
+    OscFeedback(const OscFeedback&) = delete;
+    OscFeedback& operator=(const OscFeedback&) = delete;
+
+    /// Above a full snapshot of an ordinary project and well under one of the
+    /// largest the namespace can address, which is the case it exists to split
+    /// across flushes rather than to truncate.
+    static constexpr int kMaxMessagesPerFlush = 192;
+
+    /// How close two values have to be for one to count as the echo of the
+    /// other. Loose enough to absorb a normalized value that has been through a
+    /// parameter's real range and back, tight enough that no gesture a user can
+    /// make lands inside it.
+    static constexpr float kEchoEpsilon = 1.0e-4f;
+
+    /**
+     * @brief State the address at `slot` currently has.
+     *
+     * Cheap to call with an unchanged value, which is the common case: the
+     * projection above re-reads whole blocks rather than tracking which member
+     * of a track moved.
+     */
+    void publish(int slot, float value);
+
+    void publish(const OscCommand& command, float value) {
+        publish(oscSlotIndex(command), value);
+    }
+
+    /// Say that `slot` addresses nothing now — a mixer position past the last
+    /// track. Nothing is sent, and the slot is forgotten, so a snapshot does not
+    /// resurrect the value a deleted track had.
+    void retire(int slot);
+
+    void retire(const OscCommand& command) {
+        retire(oscSlotIndex(command));
+    }
+
+    /// Record a value that arrived from the surface on `slot`. Called by the
+    /// router's drain, on the message thread.
+    void noteReceived(int slot, float value);
+
+    /// Send everything with a value on the next flush, diff and echo rule
+    /// ignored.
+    void requestSnapshot();
+
+    /**
+     * @brief Send what is owed.
+     *
+     * @return how many messages were sent, which is 0 for the ordinary case of
+     *         a project in which nothing moved.
+     */
+    int flush();
+
+    /// Forget every value without sending anything. For a project swap, where
+    /// what was last sent describes state that no longer exists — and where the
+    /// caller wants the surface refreshed rather than diffed against a ghost.
+    void reset();
+
+    OscMessageSink& sink() {
+        return *sink_;
+    }
+
+    /// Messages sent since construction. The settings UI shows it, because
+    /// "is anything going out?" is the first question a silent surface raises.
+    std::uint64_t sentMessageCount() const {
+        return sent_;
+    }
+
+    /// Slot sends postponed by the budget. Non-zero means a snapshot of a large
+    /// project spanned several flushes, which is the design rather than a fault;
+    /// a number that keeps climbing while nothing is moving is not.
+    std::uint64_t deferredMessageCount() const {
+        return deferred_;
+    }
+
+  private:
+    static constexpr int kWords = (kOscSlotCount + 63) / 64;
+
+    static bool test(const std::array<std::uint64_t, kWords>& bits, int slot) {
+        return (bits[static_cast<std::size_t>(slot / 64)] & (1ULL << (slot % 64))) != 0;
+    }
+    static void set(std::array<std::uint64_t, kWords>& bits, int slot) {
+        bits[static_cast<std::size_t>(slot / 64)] |= 1ULL << (slot % 64);
+    }
+    static void clear(std::array<std::uint64_t, kWords>& bits, int slot) {
+        bits[static_cast<std::size_t>(slot / 64)] &= ~(1ULL << (slot % 64));
+    }
+
+    /// True for the two seek addresses, which carry a distance rather than a
+    /// position. There is no state behind them to echo, on the way in or out.
+    static bool isSendable(const OscCommand& command);
+
+    std::unique_ptr<OscMessageSink> sink_;
+
+    std::array<float, kOscSlotCount> current_{};
+    std::array<float, kOscSlotCount> lastSent_{};
+    std::array<float, kOscSlotCount> lastReceived_{};
+
+    /// A value has been published and not retired.
+    std::array<std::uint64_t, kWords> valid_{};
+    /// `lastSent_` means something.
+    std::array<std::uint64_t, kWords> hasSent_{};
+    /// Published and not yet sent.
+    std::array<std::uint64_t, kWords> dirty_{};
+    /// Received since the last flush.
+    std::array<std::uint64_t, kWords> echoed_{};
+
+    bool snapshotPending_ = false;
+    std::uint64_t sent_ = 0;
+    std::uint64_t deferred_ = 0;
+};
+
+}  // namespace magda::osc

--- a/magda/daw/audio/osc/OscRouter.cpp
+++ b/magda/daw/audio/osc/OscRouter.cpp
@@ -405,8 +405,10 @@ void OscRouter::drainPending() {
         while (bits != 0) {
             const int slot = (word * 64) + std::countr_zero(bits);
             bits &= bits - 1;
-            sink_->apply(oscCommandForSlot(slot),
-                         values_[static_cast<size_t>(slot)].load(std::memory_order_relaxed));
+            const auto value = values_[static_cast<size_t>(slot)].load(std::memory_order_relaxed);
+            sink_->apply(oscCommandForSlot(slot), value);
+            if (feedbackTap_)
+                feedbackTap_(slot, value);
         }
     }
 
@@ -434,8 +436,11 @@ void OscRouter::drainBindings() {
         while (bits != 0) {
             const auto index = (word * 64) + static_cast<std::size_t>(std::countr_zero(bits));
             bits &= bits - 1;
-            bindingSink_->apply(routes->entries[index].binding,
-                                routes->values[index].load(std::memory_order_relaxed));
+            const auto& entry = routes->entries[index];
+            const auto value = routes->values[index].load(std::memory_order_relaxed);
+            bindingSink_->apply(entry.binding, value);
+            if (bindingFeedbackTap_)
+                bindingFeedbackTap_(entry.address, value);
         }
     }
 }
@@ -451,6 +456,14 @@ void OscRouter::drainOrdered() {
         const auto entry = ordered_[read & (kOrderedCapacity - 1)];
         orderedRead_.store(read + 1, std::memory_order_release);
         sink_->apply(entry.command, entry.value);
+
+        // A flip request names no state, so the surface that sent it does not
+        // know what it produced and has to hear the answer. A delta has no
+        // state at all. Everything else here is a button that sent the value it
+        // is now showing.
+        if (feedbackTap_ && entry.value != kOscToggleRequest &&
+            argKindFor(entry.command.kind) != OscArgKind::Delta)
+            feedbackTap_(oscSlotIndex(entry.command), entry.value);
     }
 
     // Hit the cap with work still queued. Whoever pushed the remainder may have
@@ -503,6 +516,14 @@ void OscRouter::setSink(std::unique_ptr<OscCommandSink> sink) {
 
 void OscRouter::setBindingSink(std::unique_ptr<OscBindingSink> sink) {
     bindingSink_ = std::move(sink);
+}
+
+void OscRouter::setFeedbackTap(FeedbackTap tap) {
+    feedbackTap_ = std::move(tap);
+}
+
+void OscRouter::setBindingFeedbackTap(BindingFeedbackTap tap) {
+    bindingFeedbackTap_ = std::move(tap);
 }
 
 void OscRouter::setDrainScheduler(std::function<void()> scheduler) {

--- a/magda/daw/audio/osc/OscRouter.hpp
+++ b/magda/daw/audio/osc/OscRouter.hpp
@@ -283,6 +283,38 @@ class OscRouter {
     bool isLearning() const;
 
     /**
+     * @brief Watch the fixed-namespace values this router applies (#2091).
+     *
+     * Called from `drainPending` with the slot and the value that landed, so
+     * feedback can tell its own echo from a change the user made in MAGDA. On
+     * the message thread, inside the drain, once per applied address.
+     *
+     * A toggle sent with no argument is not reported: it asks for a flip rather
+     * than naming a state, so the surface does not know what it produced and has
+     * to be told. Delta addresses are not reported for the same reason they are
+     * never echoed — there is no state behind them.
+     *
+     * Set before any message is handled, and cleared by passing `{}`.
+     */
+    using FeedbackTap = std::function<void(int slot, float value)>;
+    void setFeedbackTap(FeedbackTap tap);
+
+    /**
+     * @brief The same watch, for bound addresses (#2091).
+     *
+     * Separate because a binding is not a slot: it is addressed by the string
+     * the surface sends, and the value reported is the surface's own position
+     * before the binding's mode, curve and range are applied — which is the
+     * quantity feedback has to compare against, since that is what it would
+     * send back.
+     *
+     * Called from `drainPending`, on the message thread, once per applied
+     * binding value.
+     */
+    using BindingFeedbackTap = std::function<void(const juce::String& address, float value)>;
+    void setBindingFeedbackTap(BindingFeedbackTap tap);
+
+    /**
      * @brief How a pending drain reaches the message thread.
      *
      * Defaults to posting one, or running it inline when the caller is already
@@ -361,6 +393,8 @@ class OscRouter {
     std::unique_ptr<OscCommandSink> sink_;
     std::unique_ptr<OscBindingSink> bindingSink_;
     std::function<void()> scheduler_;
+    FeedbackTap feedbackTap_;
+    BindingFeedbackTap bindingFeedbackTap_;
 
     /// Swapped whole on the message thread, read through a shared_ptr copy on
     /// the receive thread. Null until bindings are first published.

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -242,6 +242,8 @@ void Config::save() {
         oscObj->setProperty("enabled", oscEnabled);
         oscObj->setProperty("receivePort", oscReceivePort);
         oscObj->setProperty("bindAddress", toJuceString(oscBindAddress));
+        oscObj->setProperty("feedbackHost", toJuceString(oscFeedbackHost));
+        oscObj->setProperty("feedbackPort", oscFeedbackPort);
         root->setProperty("osc", juce::var(oscObj));
     }
 
@@ -734,6 +736,14 @@ void Config::load() {
                 if (address.isNotEmpty())
                     oscBindAddress = address.toStdString();
             }
+            // The feedback host takes an empty value as written, unlike the
+            // bind address above: empty is what "answer nobody" is spelled as,
+            // so falling back to a default would turn feedback on for a user
+            // who had turned it off.
+            if (oscObj->hasProperty("feedbackHost"))
+                oscFeedbackHost = oscObj->getProperty("feedbackHost").toString().toStdString();
+            if (oscObj->hasProperty("feedbackPort"))
+                oscFeedbackPort = oscObj->getProperty("feedbackPort");
         }
     }
     recentProjects = getStringArray("recentProjects");

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -531,6 +531,31 @@ class Config {
     void setOscBindAddress(const std::string& address) {
         oscBindAddress = address;
     }
+    /**
+     * Where feedback goes (issue #2091), and whether it goes anywhere: an empty
+     * host means MAGDA answers nobody, which is the default.
+     *
+     * A destination rather than a reply-to, because there is nothing to reply
+     * to. `juce::OSCReceiver` hands a listener a parsed message and drops the
+     * datagram's source address inside its own receive loop, so the surface that
+     * sent something is not observable without reimplementing JUCE's OSC parser.
+     * The user names the surface instead, which is also what a TouchOSC template
+     * asks of them at the other end.
+     */
+    const std::string& getOscFeedbackHost() const {
+        return oscFeedbackHost;
+    }
+    void setOscFeedbackHost(const std::string& host) {
+        oscFeedbackHost = host;
+    }
+    /// The port on that host. 9001 is TouchOSC's default receive port, the
+    /// companion of the 9000 above.
+    int getOscFeedbackPort() const {
+        return oscFeedbackPort;
+    }
+    void setOscFeedbackPort(int port) {
+        oscFeedbackPort = port;
+    }
 
     // Browser filter settings
     bool getBrowserFilterAudio() const {
@@ -1426,6 +1451,8 @@ class Config {
     bool oscEnabled = false;
     int oscReceivePort = 9000;
     std::string oscBindAddress = "0.0.0.0";
+    std::string oscFeedbackHost;
+    int oscFeedbackPort = 9001;
 
     // Export audio settings
     std::string exportFormat = "WAV24";  // WAV16, WAV24, WAV32, FLAC

--- a/magda/daw/core/ParameterUtils.cpp
+++ b/magda/daw/core/ParameterUtils.cpp
@@ -106,6 +106,15 @@ float normalizedToReal(float normalized, const ParameterInfo& info) {
     }
 }
 
+float gainFromNormalized(float normalized, const ParameterInfo& info) {
+    return std::pow(10.0f, normalizedToReal(normalized, info) / 20.0f);
+}
+
+float normalizedFromGain(float gain, const ParameterInfo& info) {
+    const float dB = gain > 0.0f ? 20.0f * std::log10(gain) : info.minValue;
+    return realToNormalized(dB, info);
+}
+
 float realToNormalized(float real, const ParameterInfo& info) {
     switch (info.scale) {
         case ParameterScale::Linear: {

--- a/magda/daw/core/ParameterUtils.hpp
+++ b/magda/daw/core/ParameterUtils.hpp
@@ -38,6 +38,26 @@ float normalizedToReal(float normalized, const ParameterInfo& info);
 float realToNormalized(float real, const ParameterInfo& info);
 
 /**
+ * @brief A normalized fader position as the linear gain `TrackManager` stores.
+ *
+ * `TrackInfo::volume` and `SendInfo::level` are linear gains, while the fader
+ * that drives them is a dB scale, so every writer of one from the other does
+ * `pow(10, dB / 20)` after `normalizedToReal`. This is that pair, in one place,
+ * because it had grown four copies: the controller writer, its reader, the OSC
+ * feedback projection, and the automation playback writeback. An inverse only
+ * stays an inverse while both halves are read together.
+ */
+float gainFromNormalized(float normalized, const ParameterInfo& info);
+
+/**
+ * @brief The linear gain as the normalized fader position that produces it.
+ *
+ * Silence has no dB, so a gain of zero answers the bottom of the parameter's
+ * range, which is where a fader at no gain sits.
+ */
+float normalizedFromGain(float gain, const ParameterInfo& info);
+
+/**
  * @brief True when ParameterInfo real/display range matches the value range
  *        stored by the owning Tracktion AutomatableParameter.
  */

--- a/magda/daw/core/TechnicalText.hpp
+++ b/magda/daw/core/TechnicalText.hpp
@@ -39,6 +39,7 @@ enum class TechnicalTextToken {
     Rgb,
     Hex,
     Lua,
+    Osc,
 };
 
 inline juce::String technicalText(TechnicalTextToken token) {
@@ -108,6 +109,8 @@ inline juce::String technicalText(TechnicalTextToken token) {
             return "Hex";
         case TechnicalTextToken::Lua:
             return "Lua";
+        case TechnicalTextToken::Osc:
+            return "OSC";
     }
 
     return {};

--- a/magda/daw/core/controllers/BindingTransform.cpp
+++ b/magda/daw/core/controllers/BindingTransform.cpp
@@ -96,6 +96,44 @@ float applyRange(const BindingRange& range, float normalizedAfterCurve) {
 }
 
 // ============================================================================
+// Inverses
+// ============================================================================
+
+float invertCurve(BindingCurve curve, float y) {
+    y = y < 0.0f ? 0.0f : (y > 1.0f ? 1.0f : y);
+
+    switch (curve) {
+        case BindingCurve::Linear:
+            return y;
+
+        case BindingCurve::Log:
+            // The inverse of log1p(x * (e - 1)), which is the Exp curve itself.
+            return std::expm1(y) / kEMinus1;
+
+        case BindingCurve::Exp:
+            // And its mirror: Exp and Log are each other's inverse.
+            return std::log1p(y * kEMinus1);
+
+        case BindingCurve::SCurve: {
+            // Smoothstep is the cubic 3x^2 - 2x^3, whose one real root in [0,1]
+            // has this closed form. Cheaper and exact where a Newton iteration
+            // would be neither, and it lands exactly on 0, 0.5 and 1.
+            const float clamped = juce::jlimit(-1.0f, 1.0f, 1.0f - 2.0f * y);
+            return 0.5f - std::sin(std::asin(clamped) / 3.0f);
+        }
+    }
+
+    return y;
+}
+
+float invertRange(const BindingRange& range, float ranged) {
+    const float span = range.max - range.min;
+    if (span == 0.0f)
+        return 0.0f;
+    return juce::jlimit(0.0f, 1.0f, (ranged - range.min) / span);
+}
+
+// ============================================================================
 // applyToggle
 // ============================================================================
 

--- a/magda/daw/core/controllers/BindingTransform.hpp
+++ b/magda/daw/core/controllers/BindingTransform.hpp
@@ -51,6 +51,32 @@ float applyCurve(BindingCurve curve, float normalized);
 float applyRange(const BindingRange& range, float normalizedAfterCurve);
 
 // ============================================================================
+// Inverses
+// ============================================================================
+
+/**
+ * @brief Recover the position a control must be at to produce `curved`.
+ *
+ * `invertCurve(c, applyCurve(c, x)) == x` for every curve and every x in
+ * [0,1]. OSC feedback (#2091) needs it: a bound address echoes where the
+ * surface's fader should sit, and what the model holds is the value at the far
+ * end of the curve.
+ *
+ * Every curve here is monotonic on [0,1], so each has one inverse and this is
+ * total rather than a best effort.
+ */
+float invertCurve(BindingCurve curve, float curved);
+
+/**
+ * @brief Recover the normalized-after-curve value that `applyRange` produced.
+ *
+ * A degenerate range — min equal to max — maps every position onto one value
+ * and therefore inverts to none of them. It answers 0, which is the position a
+ * fader sits at when nothing it can do changes anything.
+ */
+float invertRange(const BindingRange& range, float ranged);
+
+// ============================================================================
 // ToggleState
 // ============================================================================
 

--- a/magda/daw/magda_daw_main.cpp
+++ b/magda/daw/magda_daw_main.cpp
@@ -14,11 +14,15 @@
 #include "../../magda/agents/llm_presets.hpp"
 #include "api/magda_api_live.hpp"
 #include "api/osc_command_sink_live.hpp"
+#include "api/osc_feedback_live.hpp"
 #include "api/remote_api_host.hpp"
 #include "api/remote_audit.hpp"
+#include "api/remote_service.hpp"
 #include "audio/AudioBridge.hpp"
 #include "audio/AudioThumbnailManager.hpp"
+#include "audio/controllers/ControllerParamReader.hpp"
 #include "audio/controllers/ControllerParamWriter.hpp"
+#include "audio/controllers/ControllerRouter.hpp"
 #include "audio/osc/OscService.hpp"
 #include "core/AppPaths.hpp"
 #include "core/ClipManager.hpp"
@@ -35,6 +39,7 @@
 #include "magda/scripting/LuaController.hpp"
 #include "magda/scripting/LuaScriptStore.hpp"
 #include "media_db/MediaDbContext.hpp"
+#include "osc_app.hpp"
 #include "project/ProjectManager.hpp"
 #include "scripting_app.hpp"
 #include "ui/dialogs/SplashScreen.hpp"
@@ -98,6 +103,9 @@ class MagdaDAWApplication : public JUCEApplication {
     // Owned here for the same reason as the remote API — it holds a socket
     // whose receive thread posts work against the model.
     std::unique_ptr<magda::osc::OscService> oscService_;
+    // OSC feedback (#2091): the answering half. Declared after the service so
+    // it is destroyed before it — it holds a tap on the service's router.
+    std::unique_ptr<magda::OscFeedbackProjector> oscFeedback_;
     // Latches true once the deferred startup auto-load has fired. The
     // engine's onMidiDevicesReady callback runs on every device-list
     // change, but we only want to auto-load the active script once.
@@ -127,6 +135,16 @@ class MagdaDAWApplication : public JUCEApplication {
     void unloadLuaScript();
     juce::String activeLuaScriptName() const;
     void revealLuaScriptsFolder();
+
+    /// Handles for the OSC section of ControllersDialog (osc_app.hpp), which
+    /// only reads through them. Null before deferred init has run, and after
+    /// shutdown has torn them down.
+    magda::osc::OscService* oscService() noexcept {
+        return oscService_.get();
+    }
+    magda::OscFeedbackProjector* oscFeedback() noexcept {
+        return oscFeedback_.get();
+    }
 
   private:
     // Cancellable deferred init timer — destroyed in shutdown() to prevent
@@ -387,6 +405,25 @@ class MagdaDAWApplication : public JUCEApplication {
             if (oscService_->applyConfig())
                 juce::Logger::writeToLog("OSC listening on " + oscService_->boundAddress() + ":" +
                                          juce::String(oscService_->boundPort()));
+
+            // 4d. OSC feedback (#2091). Built on the remote API's change source,
+            // which is live whether or not the remote API is listening — the
+            // host constructs its dispatcher and model bridge unconditionally
+            // and only `start()` is gated on config. So a surface hears back
+            // from MAGDA with the WebSocket transport switched off.
+            oscFeedback_ = std::make_unique<magda::OscFeedbackProjector>(
+                daw_engine_->getMagdaApi(), remoteApi_->service().changes(), oscService_->router(),
+                std::make_unique<magda::DefaultControllerParamReader>(*audioBridge));
+            if (oscFeedback_->applyConfig())
+                juce::Logger::writeToLog(
+                    "OSC feedback to " +
+                    juce::String(magda::Config::getInstance().getOscFeedbackHost()) + ":" +
+                    juce::String(magda::Config::getInstance().getOscFeedbackPort()));
+
+            // A parameter written by any control surface reaches the OSC
+            // bindings that address the same target.
+            magda::ControllerRouter::getInstance().setFeedbackSink(
+                oscFeedback_->makeControllerFeedbackSink());
         }
 
         // 5. Dismiss splash screen
@@ -505,6 +542,13 @@ class MagdaDAWApplication : public JUCEApplication {
             modelLoadThread_.join();
         if (sampleTaggerLoadThread_.joinable())
             sampleTaggerLoadThread_.join();
+
+        // Feedback first of all: it holds a tap on the OSC router, a listener
+        // on the remote API's change source and a sink on the controller
+        // router, and every one of those outlives it below.
+        DBG("[0] OSC feedback shutdown...");
+        magda::ControllerRouter::getInstance().setFeedbackSink(std::make_unique<magda::NullSink>());
+        oscFeedback_.reset();
 
         // Close the remote API before anything else goes away: it holds live
         // sockets whose threads are calling into the dispatcher, and its model
@@ -878,6 +922,50 @@ void revealLuaScriptsFolder() {
 }
 
 }  // namespace magda::scripting_app
+
+// =============================================================================
+// osc_app.hpp — read-only handles onto the OSC stack for the settings UI
+// =============================================================================
+
+namespace magda::osc_app {
+
+bool isListening() {
+    auto* app = MagdaDAWApplication::getMagdaInstance();
+    auto* service = app != nullptr ? app->oscService() : nullptr;
+    return service != nullptr && service->isListening();
+}
+
+juce::String boundAddress() {
+    auto* app = MagdaDAWApplication::getMagdaInstance();
+    auto* service = app != nullptr ? app->oscService() : nullptr;
+    return service != nullptr ? service->boundAddress() : juce::String();
+}
+
+int boundPort() {
+    auto* app = MagdaDAWApplication::getMagdaInstance();
+    auto* service = app != nullptr ? app->oscService() : nullptr;
+    return service != nullptr ? service->boundPort() : 0;
+}
+
+std::uint64_t acceptedMessageCount() {
+    auto* app = MagdaDAWApplication::getMagdaInstance();
+    auto* service = app != nullptr ? app->oscService() : nullptr;
+    return service != nullptr ? service->router().acceptedMessageCount() : 0;
+}
+
+bool feedbackIsSending() {
+    auto* app = MagdaDAWApplication::getMagdaInstance();
+    auto* feedback = app != nullptr ? app->oscFeedback() : nullptr;
+    return feedback != nullptr && feedback->isSending();
+}
+
+std::uint64_t feedbackSentMessageCount() {
+    auto* app = MagdaDAWApplication::getMagdaInstance();
+    auto* feedback = app != nullptr ? app->oscFeedback() : nullptr;
+    return feedback != nullptr ? feedback->feedback().sentMessageCount() : 0;
+}
+
+}  // namespace magda::osc_app
 
 // JUCE application startup
 START_JUCE_APPLICATION(MagdaDAWApplication)

--- a/magda/daw/osc_app.hpp
+++ b/magda/daw/osc_app.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <cstdint>
+
+// App-level OSC wiring (#1757, #2091).
+//
+// `OscService` and `OscFeedbackProjector` are owned by MagdaDAWApplication,
+// which nothing in the UI layer can see. These read-only accessors are how the
+// OSC section of ControllersDialog answers the two questions a surface that
+// will not talk to MAGDA raises — is anything arriving, and is anything going
+// out — without that section needing visibility into the JUCEApplication
+// subclass. The same shape as `scripting_app`, and for the same reason.
+//
+// Settings are not written through here: both objects are `ConfigListener`s, so
+// writing to `Config` and saving reconfigures them. Implementations live in
+// magda_daw_main.cpp.
+
+namespace magda::osc_app {
+
+/// Whether a socket is bound. False when OSC is off, or when the port was
+/// taken.
+bool isListening();
+
+/// The address and port actually bound, or empty / 0 when not listening. Not
+/// necessarily what was configured: a port of 0 asks the OS to choose.
+juce::String boundAddress();
+int boundPort();
+
+/// Messages accepted since launch. Zero while a surface is misconfigured, which
+/// is the first thing worth knowing about one.
+std::uint64_t acceptedMessageCount();
+
+/// Whether feedback has a destination connected.
+bool feedbackIsSending();
+
+/// Feedback messages sent since launch.
+std::uint64_t feedbackSentMessageCount();
+
+}  // namespace magda::osc_app

--- a/magda/daw/ui/dialogs/ControllersDialog.cpp
+++ b/magda/daw/ui/dialogs/ControllersDialog.cpp
@@ -13,6 +13,7 @@
 #include "core/controllers/ControllerActivation.hpp"
 #include "core/controllers/ControllerProfileRegistry.hpp"
 #include "core/controllers/ControllerRegistry.hpp"
+#include "osc_app.hpp"
 #include "scripting_app.hpp"
 
 namespace magda {
@@ -958,6 +959,191 @@ void LuaScriptsPage::ScriptListModel::paintListBoxItem(int rowNumber, juce::Grap
 }
 
 // =============================================================================
+// OscSurfacesPage (#1757 §4, #2091)
+// =============================================================================
+
+/**
+ * The OSC settings, and the first UI any of them have had: everything below was
+ * reachable only by hand-editing the config file, which made a shipped feature
+ * effectively unavailable.
+ *
+ * Nothing here reconfigures the OSC stack directly. `Config::save` notifies its
+ * listeners, and both `OscService` and `OscFeedbackProjector` are among them, so
+ * a field that loses focus rebinds the socket or re-aims the sender without this
+ * page knowing either exists. What it does know is how to ask them what
+ * happened, through `osc_app`, which is what the status line reports.
+ */
+class OscSurfacesPage : public juce::Component, private juce::Timer {
+  public:
+    OscSurfacesPage() {
+        auto& config = Config::getInstance();
+
+        enable_.setButtonText(tr("controllers.osc.enable"));
+        enable_.setToggleState(config.getOscEnabled(), juce::dontSendNotification);
+        enable_.onClick = [this] {
+            Config::getInstance().setOscEnabled(enable_.getToggleState());
+            commit();
+        };
+        addAndMakeVisible(enable_);
+
+        // The two addresses that mean something are offered, and the field stays
+        // editable: a user with a specific interface can name it.
+        bindAddress_.setEditableText(true);
+        bindAddress_.addItem("0.0.0.0", 1);
+        bindAddress_.addItem("127.0.0.1", 2);
+        bindAddress_.setText(juce::String(config.getOscBindAddress()), juce::dontSendNotification);
+        bindAddress_.onChange = [this] {
+            Config::getInstance().setOscBindAddress(bindAddress_.getText().trim().toStdString());
+            commit();
+        };
+        addAndMakeVisible(bindAddress_);
+        addLabel(bindLabel_, tr("controllers.osc.bind_address"));
+
+        setUpPortField(receivePort_, config.getOscReceivePort(),
+                       [](int port) { Config::getInstance().setOscReceivePort(port); });
+        addLabel(receiveLabel_, tr("controllers.osc.receive_port"));
+
+        feedbackHost_.setTextToShowWhenEmpty(tr("controllers.osc.feedback_host_empty"),
+                                             DarkTheme::getColour(DarkTheme::TEXT_SECONDARY));
+        feedbackHost_.setText(juce::String(config.getOscFeedbackHost()),
+                              juce::dontSendNotification);
+        feedbackHost_.onFocusLost = [this] {
+            Config::getInstance().setOscFeedbackHost(feedbackHost_.getText().trim().toStdString());
+            commit();
+        };
+        feedbackHost_.onReturnKey = [this] { feedbackHost_.giveAwayKeyboardFocus(); };
+        addAndMakeVisible(feedbackHost_);
+        addLabel(feedbackHostLabel_, tr("controllers.osc.feedback_host"));
+
+        setUpPortField(feedbackPort_, config.getOscFeedbackPort(),
+                       [](int port) { Config::getInstance().setOscFeedbackPort(port); });
+        addLabel(feedbackPortLabel_, tr("controllers.osc.feedback_port"));
+
+        status_.setJustificationType(juce::Justification::topLeft);
+        status_.setColour(juce::Label::textColourId,
+                          DarkTheme::getColour(DarkTheme::TEXT_SECONDARY));
+        addAndMakeVisible(status_);
+
+        refreshStatus();
+        startTimer(kStatusIntervalMs);
+    }
+
+    ~OscSurfacesPage() override {
+        stopTimer();
+    }
+
+    void resized() override {
+        auto area = getLocalBounds().reduced(12);
+
+        enable_.setBounds(area.removeFromTop(kRowHeight));
+        area.removeFromTop(kGap);
+
+        layoutRow(area, bindLabel_, bindAddress_);
+        layoutRow(area, receiveLabel_, receivePort_);
+        area.removeFromTop(kGap);
+        layoutRow(area, feedbackHostLabel_, feedbackHost_);
+        layoutRow(area, feedbackPortLabel_, feedbackPort_);
+
+        area.removeFromTop(kGap * 2);
+        status_.setBounds(area);
+    }
+
+  private:
+    static constexpr int kRowHeight = 24;
+    static constexpr int kGap = 8;
+    static constexpr int kLabelWidth = 150;
+    static constexpr int kFieldWidth = 200;
+    static constexpr int kStatusIntervalMs = 1000;
+
+    void addLabel(juce::Label& label, const juce::String& text) {
+        label.setText(text, juce::dontSendNotification);
+        label.setJustificationType(juce::Justification::centredLeft);
+        addAndMakeVisible(label);
+    }
+
+    void layoutRow(juce::Rectangle<int>& area, juce::Label& label, juce::Component& field) {
+        auto row = area.removeFromTop(kRowHeight);
+        label.setBounds(row.removeFromLeft(kLabelWidth));
+        field.setBounds(row.removeFromLeft(kFieldWidth));
+        area.removeFromTop(4);
+    }
+
+    /// A port field, with the same rule at both: a number the OS could bind, or
+    /// the stored value put back. Committing on focus loss rather than on every
+    /// keystroke, so typing "9" on the way to "9001" does not rebind the socket
+    /// to port 9.
+    void setUpPortField(juce::TextEditor& field, int initial, std::function<void(int)> store) {
+        field.setInputRestrictions(5, "0123456789");
+        field.setText(juce::String(initial), juce::dontSendNotification);
+        field.onFocusLost = [this, &field, store = std::move(store)] {
+            const int port = field.getText().getIntValue();
+            if (port > 0 && port <= 65535) {
+                store(port);
+                commit();
+            } else {
+                refreshFields();
+            }
+        };
+        field.onReturnKey = [&field] { field.giveAwayKeyboardFocus(); };
+        addAndMakeVisible(field);
+    }
+
+    /// Persist, which is also what reconfigures: `Config::save` notifies the
+    /// listeners, and the OSC service and the feedback projector are two of them.
+    void commit() {
+        Config::getInstance().save();
+        refreshStatus();
+    }
+
+    void refreshFields() {
+        auto& config = Config::getInstance();
+        receivePort_.setText(juce::String(config.getOscReceivePort()), juce::dontSendNotification);
+        feedbackPort_.setText(juce::String(config.getOscFeedbackPort()),
+                              juce::dontSendNotification);
+    }
+
+    void timerCallback() override {
+        refreshStatus();
+    }
+
+    void refreshStatus() {
+        juce::String text;
+
+        if (osc_app::isListening()) {
+            text << tr("controllers.osc.status_listening")
+                        .replace("{0}", osc_app::boundAddress())
+                        .replace("{1}", juce::String(osc_app::boundPort()))
+                 << "\n"
+                 << tr("controllers.osc.status_received")
+                        .replace("{0}", juce::String(osc_app::acceptedMessageCount()));
+        } else if (Config::getInstance().getOscEnabled()) {
+            // Enabled and not listening means the port was taken, which is the
+            // one failure a user can act on and the one they cannot see.
+            text << tr("controllers.osc.status_bind_failed");
+        } else {
+            text << tr("controllers.osc.status_off");
+        }
+
+        text << "\n\n";
+        if (osc_app::feedbackIsSending())
+            text << tr("controllers.osc.status_feedback_sent")
+                        .replace("{0}", juce::String(osc_app::feedbackSentMessageCount()));
+        else
+            text << tr("controllers.osc.status_feedback_off");
+
+        status_.setText(text, juce::dontSendNotification);
+    }
+
+    juce::ToggleButton enable_;
+    juce::Label bindLabel_, receiveLabel_, feedbackHostLabel_, feedbackPortLabel_;
+    juce::ComboBox bindAddress_;
+    juce::TextEditor receivePort_, feedbackHost_, feedbackPort_;
+    juce::Label status_;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OscSurfacesPage)
+};
+
+// =============================================================================
 // ControllersDialog
 // =============================================================================
 
@@ -966,6 +1152,7 @@ ControllersDialog::ControllersDialog() {
 
     profilesPage_ = std::make_unique<ControllerProfilesPage>();
     scriptsPage_ = std::make_unique<LuaScriptsPage>();
+    oscPage_ = std::make_unique<OscSurfacesPage>();
 
     auto tabBg = DarkTheme::getColour(DarkTheme::PANEL_BACKGROUND);
     tabbedComponent_.addTab(
@@ -976,6 +1163,8 @@ ControllersDialog::ControllersDialog() {
         tr("controllers.tab.scripts")
             .replace("{0}", magda::technicalText(magda::TechnicalTextToken::Lua)),
         tabBg, scriptsPage_.get(), false);
+    tabbedComponent_.addTab(magda::technicalText(magda::TechnicalTextToken::Osc), tabBg,
+                            oscPage_.get(), false);
     addAndMakeVisible(tabbedComponent_);
 
     setSize(560, 512);

--- a/magda/daw/ui/dialogs/ControllersDialog.hpp
+++ b/magda/daw/ui/dialogs/ControllersDialog.hpp
@@ -13,11 +13,12 @@ namespace magda {
 
 class ControllerProfilesPage;
 class LuaScriptsPage;
+class OscSurfacesPage;
 
 /**
- * Two-tab dialog for managing controllers:
+ * Three-tab dialog for managing controllers:
  *
- *   [ MIDI Profiles ] [ Lua Scripts ]
+ *   [ MIDI Profiles ] [ Lua Scripts ] [ OSC ]
  *
  * Profiles tab: list of vendor/uploaded controller profiles bound to MIDI
  *   inputs. Click a row to toggle enabled (one enabled per port), right-
@@ -26,6 +27,11 @@ class LuaScriptsPage;
  * Scripts tab: list of `.lua` files in the per-user scripts folder. Click a
  *   row to make it active (one active script at a time), right-click for
  *   Reveal / Unload. Reload re-runs the active script.
+ *
+ * OSC tab (#1757, #2091): whether MAGDA listens, on which interface and port,
+ *   and where it answers. Every one of those was config-file-only until now,
+ *   which made a shipped feature unreachable for anyone who does not hand-edit
+ *   JSON.
  */
 class ControllersDialog : public juce::Component {
   public:
@@ -41,6 +47,7 @@ class ControllersDialog : public juce::Component {
     juce::TabbedComponent tabbedComponent_{juce::TabbedButtonBar::TabsAtTop};
     std::unique_ptr<ControllerProfilesPage> profilesPage_;
     std::unique_ptr<LuaScriptsPage> scriptsPage_;
+    std::unique_ptr<OscSurfacesPage> oscPage_;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ControllersDialog)
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -178,6 +178,7 @@ set(TEST_SOURCES
     test_osc_router.cpp
     test_osc_command_sink.cpp
     test_osc_bindings.cpp
+    test_osc_feedback.cpp
     # Relative transport seek (#1987)
     test_transport_seek.cpp
     # Controller registry tests (issue #1050 -- Phase B)

--- a/tests/test_osc_feedback.cpp
+++ b/tests/test_osc_feedback.cpp
@@ -1,0 +1,568 @@
+#include <algorithm>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+#include <vector>
+
+#include "MockMagdaApi.hpp"
+#include "magda/daw/api/osc_feedback_live.hpp"
+#include "magda/daw/audio/osc/OscAddress.hpp"
+#include "magda/daw/audio/osc/OscFeedback.hpp"
+#include "magda/daw/audio/osc/OscRouter.hpp"
+#include "magda/daw/core/ParameterInfo.hpp"
+#include "magda/daw/core/ParameterUtils.hpp"
+#include "magda/daw/core/controllers/BindingTransform.hpp"
+
+using namespace magda::osc;
+using Catch::Approx;
+
+namespace {
+
+struct Message {
+    juce::String address;
+    float value = 0.0f;
+};
+
+/// The seam the whole of `OscFeedback` is testable through: no socket, no
+/// destination, and every datagram it would have sent kept in order.
+class CapturingSink : public OscMessageSink {
+  public:
+    bool send(const juce::String& address, float value) override {
+        messages.push_back(Message{address, value});
+        return connected;
+    }
+
+    std::vector<Message> messages;
+    bool connected = true;
+
+    void clear() {
+        messages.clear();
+    }
+
+    int countFor(const char* address) const {
+        return static_cast<int>(
+            std::count_if(messages.begin(), messages.end(),
+                          [address](const Message& m) { return m.address == address; }));
+    }
+
+    const Message* find(const char* address) const {
+        for (const auto& message : messages)
+            if (message.address == address)
+                return &message;
+        return nullptr;
+    }
+};
+
+struct Rig {
+    CapturingSink* sink = nullptr;
+    std::unique_ptr<OscFeedback> feedback;
+
+    Rig() {
+        auto owned = std::make_unique<CapturingSink>();
+        sink = owned.get();
+        feedback = std::make_unique<OscFeedback>(std::move(owned));
+    }
+
+    OscFeedback& operator*() const {
+        return *feedback;
+    }
+    OscFeedback* operator->() const {
+        return feedback.get();
+    }
+};
+
+int slotOf(OscCommandKind kind, int index = 0, int subIndex = 0) {
+    return oscSlotIndex(OscCommand{kind, index, subIndex});
+}
+
+}  // namespace
+
+// ============================================================================
+// The formatter is the parser read backwards
+// ============================================================================
+
+TEST_CASE("Every slot formats to an address that parses back to it", "[osc][feedback]") {
+    for (int slot = 0; slot < kOscSlotCount; ++slot) {
+        const auto command = oscCommandForSlot(slot);
+        const auto address = formatOscAddress(command);
+        INFO("slot " << slot << " -> " << address.toStdString());
+
+        const auto reparsed = parseOscAddress(address);
+        REQUIRE(reparsed.has_value());
+        REQUIRE(*reparsed == command);
+        REQUIRE(oscSlotIndex(*reparsed) == slot);
+    }
+}
+
+TEST_CASE("Addresses are spelled the way a template writes them", "[osc][feedback]") {
+    REQUIRE(formatOscAddress(OscCommand{OscCommandKind::TrackVolume, 3, 0}) ==
+            "/magda/track/3/volume");
+    REQUIRE(formatOscAddress(OscCommand{OscCommandKind::TrackSend, 2, 4}) ==
+            "/magda/track/2/send/4");
+    REQUIRE(formatOscAddress(OscCommand{OscCommandKind::FocusedMacro, 7, 0}) ==
+            "/magda/focused/macro/7");
+    REQUIRE(formatOscAddress(OscCommand{OscCommandKind::TransportSeekBars, 0, 0}) ==
+            "/magda/transport/seek/bars");
+}
+
+// ============================================================================
+// Diffing: an address is sent when it changed, and not otherwise
+// ============================================================================
+
+TEST_CASE("A value sends once and an unchanged republish sends nothing", "[osc][feedback]") {
+    Rig rig;
+    const int slot = slotOf(OscCommandKind::TrackVolume, 3);
+
+    rig->publish(slot, 0.62f);
+    REQUIRE(rig->flush() == 1);
+    REQUIRE(rig.sink->messages.size() == 1);
+    REQUIRE(rig.sink->messages[0].address == "/magda/track/3/volume");
+    REQUIRE(rig.sink->messages[0].value == Approx(0.62f));
+
+    rig->publish(slot, 0.62f);
+    REQUIRE(rig->flush() == 0);
+
+    rig->publish(slot, 0.70f);
+    REQUIRE(rig->flush() == 1);
+    REQUIRE(rig.sink->messages.back().value == Approx(0.70f));
+}
+
+TEST_CASE("A value that returns to what the surface holds before a flush sends nothing",
+          "[osc][feedback]") {
+    Rig rig;
+    const int slot = slotOf(OscCommandKind::TrackPan, 1);
+
+    rig->publish(slot, 0.5f);
+    REQUIRE(rig->flush() == 1);
+
+    // Latest value wins, and the latest value is the one already shown.
+    rig->publish(slot, 0.9f);
+    rig->publish(slot, 0.5f);
+    REQUIRE(rig->flush() == 0);
+}
+
+TEST_CASE("A snapshot resends everything that has a value", "[osc][feedback]") {
+    Rig rig;
+    rig->publish(slotOf(OscCommandKind::TrackVolume, 1), 0.5f);
+    rig->publish(slotOf(OscCommandKind::TrackVolume, 2), 0.25f);
+    rig->publish(slotOf(OscCommandKind::MasterVolume), 0.8f);
+    REQUIRE(rig->flush() == 3);
+
+    rig.sink->clear();
+    REQUIRE(rig->flush() == 0);  // nothing changed
+
+    rig->requestSnapshot();
+    REQUIRE(rig->flush() == 3);
+    REQUIRE(rig.sink->find("/magda/track/1/volume") != nullptr);
+    REQUIRE(rig.sink->find("/magda/track/2/volume") != nullptr);
+    REQUIRE(rig.sink->find("/magda/master/volume") != nullptr);
+}
+
+TEST_CASE("A retired slot stops being part of a snapshot", "[osc][feedback]") {
+    Rig rig;
+    const int slot = slotOf(OscCommandKind::TrackVolume, 4);
+
+    rig->publish(slot, 0.4f);
+    REQUIRE(rig->flush() == 1);
+
+    rig.sink->clear();
+    rig->retire(slot);
+    rig->requestSnapshot();
+    REQUIRE(rig->flush() == 0);
+    REQUIRE(rig.sink->messages.empty());
+}
+
+// ============================================================================
+// Echo suppression, as the two cases that tell it apart from a comparison
+// ============================================================================
+
+TEST_CASE("A value that just arrived from the surface is not sent back", "[osc][feedback]") {
+    Rig rig;
+    const int slot = slotOf(OscCommandKind::TrackVolume, 1);
+
+    rig->noteReceived(slot, 0.62f);
+    rig->publish(slot, 0.62f);
+    REQUIRE(rig->flush() == 0);
+    REQUIRE(rig.sink->messages.empty());
+}
+
+TEST_CASE("A suppressed value is still what the next change is measured against",
+          "[osc][feedback]") {
+    Rig rig;
+    const int slot = slotOf(OscCommandKind::TrackVolume, 1);
+
+    rig->noteReceived(slot, 0.62f);
+    rig->publish(slot, 0.62f);
+    REQUIRE(rig->flush() == 0);
+
+    rig->publish(slot, 0.75f);
+    REQUIRE(rig->flush() == 1);
+    REQUIRE(rig.sink->messages.back().value == Approx(0.75f));
+}
+
+TEST_CASE("Returning to a received value after moving away does send", "[osc][feedback]") {
+    // The case a value-only echo rule gets wrong: the surface put the fader at
+    // 0.62, MAGDA's own fader went to 0.9, and coming back to 0.62 has to reach
+    // the surface or it stays showing 0.9 forever.
+    Rig rig;
+    const int slot = slotOf(OscCommandKind::TrackVolume, 1);
+
+    rig->noteReceived(slot, 0.62f);
+    rig->publish(slot, 0.62f);
+    REQUIRE(rig->flush() == 0);
+
+    rig->publish(slot, 0.9f);
+    REQUIRE(rig->flush() == 1);
+
+    rig->publish(slot, 0.62f);
+    REQUIRE(rig->flush() == 1);
+    REQUIRE(rig.sink->messages.back().value == Approx(0.62f));
+}
+
+TEST_CASE("A snapshot is not suppressed by an echo", "[osc][feedback]") {
+    Rig rig;
+    const int slot = slotOf(OscCommandKind::TrackVolume, 1);
+
+    rig->noteReceived(slot, 0.62f);
+    rig->publish(slot, 0.62f);
+    rig->requestSnapshot();
+    REQUIRE(rig->flush() == 1);
+}
+
+TEST_CASE("A rounded echo is still an echo", "[osc][feedback]") {
+    // A normalized value through a parameter's real range and back does not
+    // return the bit pattern it left as.
+    Rig rig;
+    const int slot = slotOf(OscCommandKind::TrackVolume, 1);
+
+    rig->noteReceived(slot, 0.62f);
+    rig->publish(slot, 0.62f + (OscFeedback::kEchoEpsilon / 2.0f));
+    REQUIRE(rig->flush() == 0);
+}
+
+// ============================================================================
+// Deltas have no state to echo
+// ============================================================================
+
+TEST_CASE("The seek addresses never send", "[osc][feedback]") {
+    Rig rig;
+    rig->publish(slotOf(OscCommandKind::TransportSeekBeats), 4.0f);
+    rig->publish(slotOf(OscCommandKind::TransportSeekBars), 1.0f);
+    rig->requestSnapshot();
+
+    REQUIRE(rig->flush() == 0);
+    REQUIRE(rig.sink->messages.empty());
+}
+
+TEST_CASE("Play and stop are one state over two addresses", "[osc][feedback]") {
+    Rig rig;
+    rig->publish(slotOf(OscCommandKind::TransportPlay), 1.0f);
+    rig->publish(slotOf(OscCommandKind::TransportStop), 0.0f);
+    REQUIRE(rig->flush() == 2);
+
+    REQUIRE(rig.sink->find("/magda/transport/play")->value == Approx(1.0f));
+    REQUIRE(rig.sink->find("/magda/transport/stop")->value == Approx(0.0f));
+}
+
+// ============================================================================
+// The budget defers rather than drops
+// ============================================================================
+
+TEST_CASE("A flush over the cap carries the rest to the next one", "[osc][feedback]") {
+    Rig rig;
+
+    // More addresses than one flush can carry. Volume and pan for the first
+    // tracks rather than volume alone: the cap is above the track count on
+    // purpose, so overflowing it takes more than one member per strip.
+    const int overflow = 20;
+    const int wanted = OscFeedback::kMaxMessagesPerFlush + overflow;
+
+    std::vector<OscCommand> commands;
+    for (int track = 1; track <= kMaxTrackNumber && static_cast<int>(commands.size()) < wanted;
+         ++track) {
+        commands.push_back(OscCommand{OscCommandKind::TrackVolume, track, 0});
+        if (static_cast<int>(commands.size()) < wanted)
+            commands.push_back(OscCommand{OscCommandKind::TrackPan, track, 0});
+    }
+    REQUIRE(static_cast<int>(commands.size()) == wanted);
+
+    for (const auto& command : commands)
+        rig->publish(command, 0.5f);
+
+    REQUIRE(rig->flush() == OscFeedback::kMaxMessagesPerFlush);
+    REQUIRE(rig->deferredMessageCount() == static_cast<std::uint64_t>(overflow));
+
+    REQUIRE(rig->flush() == overflow);
+    REQUIRE(rig->flush() == 0);
+
+    // Every address arrived exactly once across the two flushes: deferred, not
+    // dropped, and not duplicated either.
+    REQUIRE(static_cast<int>(rig.sink->messages.size()) == wanted);
+    for (const auto& command : commands) {
+        const auto address = formatOscAddress(command);
+        INFO(address.toStdString());
+        REQUIRE(rig.sink->countFor(address.toRawUTF8()) == 1);
+    }
+}
+
+TEST_CASE("A send that fails leaves the value owed", "[osc][feedback]") {
+    Rig rig;
+    rig.sink->connected = false;
+
+    const int slot = slotOf(OscCommandKind::TrackVolume, 1);
+    rig->publish(slot, 0.5f);
+    REQUIRE(rig->flush() == 0);
+
+    rig.sink->connected = true;
+    rig.sink->clear();
+    REQUIRE(rig->flush() == 1);
+    REQUIRE(rig.sink->messages[0].value == Approx(0.5f));
+}
+
+TEST_CASE("Reset forgets what the surface was told", "[osc][feedback]") {
+    Rig rig;
+    const int slot = slotOf(OscCommandKind::TrackVolume, 1);
+
+    rig->publish(slot, 0.5f);
+    REQUIRE(rig->flush() == 1);
+
+    rig->reset();
+    rig.sink->clear();
+    rig->publish(slot, 0.5f);
+    REQUIRE(rig->flush() == 1);  // a new surface has been told nothing
+}
+
+// ============================================================================
+// A bound address needs the way back through the binding's own shape
+// ============================================================================
+
+TEST_CASE("Every curve inverts", "[osc][feedback]") {
+    using magda::BindingCurve;
+
+    for (auto curve :
+         {BindingCurve::Linear, BindingCurve::Log, BindingCurve::Exp, BindingCurve::SCurve}) {
+        for (int step = 0; step <= 20; ++step) {
+            const float x = static_cast<float>(step) / 20.0f;
+            const float round = magda::invertCurve(curve, magda::applyCurve(curve, x));
+            INFO("curve " << static_cast<int>(curve) << " at " << x);
+            REQUIRE(round == Approx(x).margin(1.0e-4));
+        }
+    }
+}
+
+TEST_CASE("A range inverts, and a degenerate one answers the bottom", "[osc][feedback]") {
+    magda::BindingRange range;
+    range.min = 0.2f;
+    range.max = 0.8f;
+
+    for (int step = 0; step <= 10; ++step) {
+        const float x = static_cast<float>(step) / 10.0f;
+        REQUIRE(magda::invertRange(range, magda::applyRange(range, x)) == Approx(x).margin(1.0e-5));
+    }
+
+    magda::BindingRange degenerate;
+    degenerate.min = 0.5f;
+    degenerate.max = 0.5f;
+    REQUIRE(magda::invertRange(degenerate, 0.5f) == Approx(0.0f));
+}
+
+// ============================================================================
+// The projection: what the model says, on the addresses that say it
+// ============================================================================
+
+namespace {
+
+/// The router needs somewhere to apply what arrives. Nothing here reads it —
+/// these tests are about the answering direction.
+class DiscardingCommandSink : public OscCommandSink {
+  public:
+    void apply(const OscCommand&, float) override {}
+};
+
+struct ProjectorRig {
+    ProjectorRig() {
+        auto owned = std::make_unique<CapturingSink>();
+        sink = owned.get();
+        router = std::make_unique<OscRouter>(std::make_unique<DiscardingCommandSink>());
+        projector = std::make_unique<magda::OscFeedbackProjector>(api, changes, *router, nullptr,
+                                                                  std::move(owned));
+    }
+
+    /// A track at the end of the mixer, visible, at unity gain and centre.
+    magda::TrackId addTrack(const juce::String& name) {
+        magda::TrackInfo track;
+        track.id = nextId++;
+        track.name = name;
+        track.viewSettings.setVisible(magda::ViewMode::Mix, true);
+        api.tracks_.tracks.push_back(track);
+        return track.id;
+    }
+
+    magda::TrackInfo* track(magda::TrackId id) {
+        for (auto& candidate : api.tracks_.tracks)
+            if (candidate.id == id)
+                return &candidate;
+        return nullptr;
+    }
+
+    /// What `ModelChangeBridge` does when a track property moves. The mock model
+    /// notifies nobody, so a test that edits it says so through the same source
+    /// the projector listens to — `flush` delivers on this thread, which is the
+    /// headless path `ChangeSource` documents.
+    void markTracksChanged() {
+        changes.markChanged(magda::remote::Topic::Tracks, ++revision);
+        changes.flush();
+    }
+
+    magda::test::MockMagdaApi api;
+    magda::remote::ChangeSource changes;
+    CapturingSink* sink = nullptr;
+    std::unique_ptr<OscRouter> router;
+    std::unique_ptr<magda::OscFeedbackProjector> projector;
+    magda::TrackId nextId = 1;
+    magda::remote::Revision revision = magda::remote::INITIAL_REVISION;
+};
+
+/// The normalized fader position a linear gain corresponds to — the same
+/// conversion the writer inverts, restated here so the test does not simply
+/// repeat the projector's arithmetic back at itself.
+float expectedFaderPosition(float gain) {
+    const auto info = magda::ParameterPresets::faderVolume(-1, "Volume");
+    const float dB = 20.0f * std::log10(gain);
+    return magda::ParameterUtils::realToNormalized(dB, info);
+}
+
+}  // namespace
+
+TEST_CASE("A mixer strip's members reach the addresses that name them", "[osc][feedback]") {
+    ProjectorRig rig;
+    const auto first = rig.addTrack("Drums");
+    rig.addTrack("Bass");
+
+    rig.track(first)->volume = 0.5f;  // -6 dB
+    rig.track(first)->pan = -1.0f;
+    rig.track(first)->muted = true;
+
+    rig.markTracksChanged();
+    rig.projector->tick();
+
+    REQUIRE(rig.sink->find("/magda/track/1/volume") != nullptr);
+    REQUIRE(rig.sink->find("/magda/track/1/volume")->value ==
+            Approx(expectedFaderPosition(0.5f)).margin(1.0e-5));
+    REQUIRE(rig.sink->find("/magda/track/1/pan")->value == Approx(0.0f).margin(1.0e-5));
+    REQUIRE(rig.sink->find("/magda/track/1/mute")->value == Approx(1.0f));
+    REQUIRE(rig.sink->find("/magda/track/1/solo")->value == Approx(0.0f));
+    REQUIRE(rig.sink->find("/magda/track/2/volume") != nullptr);
+
+    // A position with no track behind it is silent rather than zeroed.
+    REQUIRE(rig.sink->find("/magda/track/3/volume") == nullptr);
+}
+
+TEST_CASE("A strip's position is the mixer's, not the track's id", "[osc][feedback]") {
+    ProjectorRig rig;
+    rig.addTrack("One");
+    const auto second = rig.addTrack("Two");
+    rig.addTrack("Three");
+
+    // Delete the middle track: the third becomes strip 2, exactly as it does on
+    // screen. A template addressing eight faders needs eight dense numbers.
+    auto& tracks = rig.api.tracks_.tracks;
+    tracks.erase(std::remove_if(tracks.begin(), tracks.end(),
+                                [second](const magda::TrackInfo& t) { return t.id == second; }),
+                 tracks.end());
+    rig.track(3)->volume = 0.25f;
+
+    rig.markTracksChanged();
+    rig.projector->tick();
+
+    REQUIRE(rig.sink->find("/magda/track/2/volume")->value ==
+            Approx(expectedFaderPosition(0.25f)).margin(1.0e-5));
+}
+
+TEST_CASE("A shrinking project retires the strips it no longer has", "[osc][feedback]") {
+    ProjectorRig rig;
+    rig.addTrack("One");
+    rig.addTrack("Two");
+    rig.markTracksChanged();
+    rig.projector->tick();
+    REQUIRE(rig.sink->find("/magda/track/2/volume") != nullptr);
+
+    rig.api.tracks_.tracks.pop_back();
+    rig.sink->clear();
+    rig.projector->requestSnapshot();
+    rig.projector->tick();
+
+    // Strip 1 is resent by the snapshot; strip 2 no longer exists and is not.
+    REQUIRE(rig.sink->find("/magda/track/1/volume") != nullptr);
+    REQUIRE(rig.sink->find("/magda/track/2/volume") == nullptr);
+}
+
+TEST_CASE("Play and stop stay opposite", "[osc][feedback]") {
+    ProjectorRig rig;
+
+    rig.projector->tick();
+    REQUIRE(rig.sink->find("/magda/transport/play")->value == Approx(0.0f));
+    REQUIRE(rig.sink->find("/magda/transport/stop")->value == Approx(1.0f));
+
+    rig.sink->clear();
+    rig.api.transport_.playing = true;
+    rig.projector->tick();
+    REQUIRE(rig.sink->find("/magda/transport/play")->value == Approx(1.0f));
+    REQUIRE(rig.sink->find("/magda/transport/stop")->value == Approx(0.0f));
+}
+
+TEST_CASE("Transport values that did not move are not resent", "[osc][feedback]") {
+    ProjectorRig rig;
+    rig.projector->tick();
+    rig.sink->clear();
+
+    rig.projector->tick();
+    REQUIRE(rig.sink->messages.empty());
+
+    rig.api.transport_.positionBeats = 8.0;
+    rig.projector->tick();
+    REQUIRE(rig.sink->countFor("/magda/transport/position") == 1);
+    REQUIRE(rig.sink->find("/magda/transport/position")->value == Approx(8.0f));
+}
+
+TEST_CASE("The focused device's macros go out, and stop when focus goes", "[osc][feedback]") {
+    ProjectorRig rig;
+    rig.api.focused_.focused = true;
+    rig.api.focused_.macroValues = {0.25f, 0.75f};
+
+    rig.projector->tick();
+    REQUIRE(rig.sink->find("/magda/focused/macro/1")->value == Approx(0.25f));
+    REQUIRE(rig.sink->find("/magda/focused/macro/2")->value == Approx(0.75f));
+
+    rig.api.focused_.focused = false;
+    rig.sink->clear();
+    rig.projector->requestSnapshot();
+    rig.projector->tick();
+    REQUIRE(rig.sink->find("/magda/focused/macro/1") == nullptr);
+}
+
+TEST_CASE("A value the surface set is not projected back at it", "[osc][feedback]") {
+    ProjectorRig rig;
+    const auto first = rig.addTrack("Drums");
+    rig.markTracksChanged();
+    rig.projector->tick();
+    rig.sink->clear();
+
+    // What the router's drain reports after applying a fader move, and the model
+    // state that move produced.
+    const float position = expectedFaderPosition(0.5f);
+    rig.projector->feedback().noteReceived(
+        oscSlotIndex(OscCommand{OscCommandKind::TrackVolume, 1, 0}), position);
+    rig.track(first)->volume = 0.5f;
+
+    rig.markTracksChanged();
+    rig.projector->tick();
+    REQUIRE(rig.sink->find("/magda/track/1/volume") == nullptr);
+
+    // But a move MAGDA makes afterwards does reach the surface.
+    rig.sink->clear();
+    rig.track(first)->volume = 1.0f;
+    rig.markTracksChanged();
+    rig.projector->tick();
+    REQUIRE(rig.sink->find("/magda/track/1/volume") != nullptr);
+}

--- a/tests/test_osc_feedback.cpp
+++ b/tests/test_osc_feedback.cpp
@@ -11,6 +11,7 @@
 #include "magda/daw/audio/osc/OscRouter.hpp"
 #include "magda/daw/core/ParameterInfo.hpp"
 #include "magda/daw/core/ParameterUtils.hpp"
+#include "magda/daw/core/controllers/BindingRegistry.hpp"
 #include "magda/daw/core/controllers/BindingTransform.hpp"
 
 using namespace magda::osc;
@@ -539,6 +540,123 @@ TEST_CASE("The focused device's macros go out, and stop when focus goes", "[osc]
     rig.projector->requestSnapshot();
     rig.projector->tick();
     REQUIRE(rig.sink->find("/magda/focused/macro/1") == nullptr);
+}
+
+TEST_CASE("A surface that starts late is caught up by its first message", "[osc][feedback]") {
+    // The snapshot sent when the destination was configured went to a UDP
+    // address with nobody behind it. Nothing failed and nothing can be
+    // retried, so the first packet from a surface is the first evidence that
+    // there is a surface, and it is owed everything.
+    ProjectorRig rig;
+    rig.addTrack("Drums");
+    rig.markTracksChanged();
+    rig.projector->tick();
+    rig.sink->clear();
+
+    // Nothing has moved, so an ordinary tick says nothing.
+    rig.projector->tick();
+    REQUIRE(rig.sink->messages.empty());
+
+    rig.router->handleMessage(juce::OSCMessage("/magda/track/1/pan", 0.5f));
+    rig.projector->tick();
+
+    REQUIRE(rig.sink->find("/magda/track/1/volume") != nullptr);
+    REQUIRE(rig.sink->find("/magda/transport/play") != nullptr);
+}
+
+TEST_CASE("Steady inbound traffic does not keep resnapshotting", "[osc][feedback]") {
+    ProjectorRig rig;
+    rig.addTrack("Drums");
+    rig.markTracksChanged();
+    rig.router->handleMessage(juce::OSCMessage("/magda/track/1/pan", 0.5f));
+    rig.projector->tick();
+    rig.sink->clear();
+
+    // A second message inside the silence window is a gesture continuing, not
+    // a surface arriving.
+    rig.router->handleMessage(juce::OSCMessage("/magda/track/1/pan", 0.5f));
+    rig.projector->tick();
+    REQUIRE(rig.sink->find("/magda/track/1/volume") == nullptr);
+}
+
+namespace {
+
+/// Stands in for the engine behind a bound target. The reader's own inversions
+/// are covered where the reader is; what these cases are about is *when* the
+/// projector goes looking.
+class StubParamReader : public magda::ControllerParamReader {
+  public:
+    std::optional<float> read(const magda::ResolveResult&) override {
+        return value;
+    }
+
+    float value = 0.0f;
+};
+
+/// A registry the test owns for the length of one case. The registry is a
+/// singleton shared with every other test in the binary, so what a case adds it
+/// takes away again.
+struct ScopedGlobalBinding {
+    explicit ScopedGlobalBinding(const juce::String& address) {
+        binding.id = juce::Uuid();
+        binding.source.kind = magda::BindingSourceKind::Osc;
+        binding.source.oscAddress = address;
+        binding.target = magda::ControlTarget::trackVolume(1);
+        magda::BindingRegistry::getInstance().add(magda::BindingScope::Global, binding);
+    }
+
+    ~ScopedGlobalBinding() {
+        magda::BindingRegistry::getInstance().remove(magda::BindingScope::Global, binding.id);
+    }
+
+    magda::Binding binding;
+};
+
+}  // namespace
+
+TEST_CASE("A binding added after the last tick is projected on the next one", "[osc][feedback]") {
+    // The gap this closes: OscService listens to the registry so the input goes
+    // live, and without the same listener here the address it comes from stays
+    // blank until an unrelated edit happens to dirty the pass. OSC learn is the
+    // sharpest case, since its capture is consumed rather than applied.
+    auto owned = std::make_unique<StubParamReader>();
+    auto* reader = owned.get();
+
+    auto sinkOwned = std::make_unique<CapturingSink>();
+    auto* sink = sinkOwned.get();
+    magda::test::MockMagdaApi api;
+    magda::remote::ChangeSource changes;
+    OscRouter router{std::make_unique<DiscardingCommandSink>()};
+    magda::OscFeedbackProjector projector{api, changes, router, std::move(owned),
+                                          std::move(sinkOwned)};
+
+    reader->value = 0.4f;
+    projector.tick();
+    sink->clear();
+
+    // Nothing is dirty, so an ordinary tick says nothing.
+    projector.tick();
+    REQUIRE(sink->find("/x/fader") == nullptr);
+
+    ScopedGlobalBinding bound{"/x/fader"};
+    projector.tick();
+
+    const auto* message = sink->find("/x/fader");
+    REQUIRE(message != nullptr);
+    REQUIRE(message->value == Approx(0.4f));
+
+    // And it holds still once the surface has been told.
+    sink->clear();
+    projector.tick();
+    REQUIRE(sink->find("/x/fader") == nullptr);
+
+    // A move of the target does reach it.
+    reader->value = 0.9f;
+    changes.markChanged(magda::remote::Topic::Automation, 2);
+    changes.flush();
+    projector.tick();
+    REQUIRE(sink->find("/x/fader") != nullptr);
+    REQUIRE(sink->find("/x/fader")->value == Approx(0.9f));
 }
 
 TEST_CASE("A value the surface set is not projected back at it", "[osc][feedback]") {


### PR DESCRIPTION
Closes #2091. Section 4 of #1757, and the last of it.

The input path and bindings/learn made a surface able to drive MAGDA. Nothing made MAGDA able to answer, so every value a surface showed was whatever its template defaulted to, corrected only by the user's own finger.

## Three things the issue assumed that were not there

Each one moved the design rather than the estimate, so they are worth stating first.

**`OscAddress` did not format.** It parsed, and it mapped a command to a coalescing slot and back, but nothing turned an `OscCommand` into `/magda/track/3/volume`. The inverse already existed in the slot arithmetic, so this adds a formatter beside the parser, with a round-trip test over the whole slot space.

**JUCE will not say who sent a message.** `OSCReceiver`'s realtime listener hands over an `OSCMessage` and nothing else; the datagram's source address is consumed inside JUCE's own receive loop, and the parser is private to `juce_osc`. So "suppress the echo to *that peer*" and "snapshot on the first message from a *new peer*" are not implementable as written. Feedback goes to one configured destination, and the peer-shaped parts are re-derived against what is observable: a snapshot fires when the destination changes, and when inbound traffic resumes after five seconds of silence.

**There was no OSC section in `ControllersDialog`** to put the two new fields beside. Nothing in the UI read `oscEnabled`, `oscReceivePort` or `oscBindAddress`, so what shipped in #2061 and #2062 was unreachable for anyone who does not hand-edit JSON. This adds the tab, which is most of the value: it is what makes the whole of #1757 usable.

## What drives a send

Feedback is a projection of model state onto the fixed namespace, diffed against what was last sent. That framing answers three requirements at once. "On change" is what the diff means; the rate limit falls out of the flush cadence, since an address can be sent at most once per flush however often it was published in between; and latest value wins because a slot holds one value.

The projection splits the way `SubscriptionHub` splits its topics, for the same reason.

**Published:** track and master volume, pan, mute, solo and sends, and the focused device's macros. All of these notify a model listener however they moved, so `ChangeSource` says when to re-read them and a project in which nothing moves costs nothing per tick. That is the shared coalescing layer #1857 built, which already documents OSC feedback as its second consumer.

**Sampled:** play, record, loop, tempo and the playhead, on a 30 Hz tick. None of these reach `ChangeSource`. `ModelChangeBridge` listens to the model singletons and `ProjectManager`, none of which knows the transport is rolling, and `Topic::Transport` is marked only when a remote API request named `transport.*` executed. Pressing Play in MAGDA is invisible to it, which is a real gap in #1857's coverage as well; the honest fix for that is not this issue, and the playhead has to be sampled regardless, so the five scalars ride the same tick.

## Echo suppression is a bit, not a comparison

A value the surface just sent is a value it already shows, so sending it back is redundant, and for a control that reports its own motorised position it is a loop.

A slot is skipped when its projected value matches what arrived **and** the arrival belongs to this flush. The bit is what makes that correct rather than merely quiet: matching on value alone would suppress the send that brings a surface back from 0.9 after the user dragged MAGDA's own fader away from 0.62 and back. One consequence is kept on purpose, which is that the flush after a gesture ends sends the value once. That is a confirmation rather than an echo, and it is where the surface finds out what MAGDA rounded it to.

The same rule covers bound addresses, through a second tap on the router's binding drain. Without it a bound fader under a finger has its own position sent back on every tick of the drag.

## The budget defers rather than drops

A flush sends at most 192 messages. Only a snapshot of a large project reaches that, and a snapshot is also the one thing that has to finish, so what does not fit stays dirty and goes out on the next flush. A sixty-track snapshot is three ticks, not one long one.

## Bound addresses

A binding's address gets the position its target's value corresponds to, which needs the way back from a parameter to a fader. `BindingTransform` grows `invertCurve` and `invertRange`, total for what an OSC binding can be, since the relative modes already fall back to absolute on that path.

Reading the target back is `ControllerParamReader`, which mirrors `DefaultControllerParamWriter` branch for branch and is deliberately its neighbour rather than a private helper: the two only stay true if they are read side by side. Levels come from `TrackInfo` because that is what the writer wrote, not from the TE parameter, whose fader-position curve is a different domain and would not round-trip. `ModParam` has no reading and says why: its sync-division ordinal is a rounding that does not invert, and no surface displays a modifier rate.

## One shape worth flagging

The tick is an owned object rather than a base class. `juce::Timer` holds a `SharedResourcePointer<TimerThread>` as a member, so inheriting one starts JUCE's timer thread the moment a projector exists, including in a process with no message loop to drive it. Owning it means a MAGDA with feedback off does no per-tick work and a headless one brings no thread into existence. `SubscriptionHub` gives its sampler the same shape.

## Tests

`tests/test_osc_feedback.cpp`, 25 cases.

- The formatter round-trips every slot back through the parser.
- Diffing: a value sends once, an unchanged republish sends nothing, and a value that leaves and returns before a flush sends nothing.
- Echo suppression as the two cases that tell it apart from a comparison, plus the rounded-echo and snapshot-overrides cases.
- The budget sends the cap, counts the rest, and delivers every address exactly once across two flushes.
- The projection against `MockMagdaApi` and a capturing sink: a strip's members land on the addresses that name them at the position the writer's conversion implies, a position is the mixer's rather than the track's id, a shrinking project retires the strips it no longer has, focus going away retires the macros, and the echo rule end to end.
- The binding inverses over each curve and a range.

Built locally, full suite green: 2576 passed, 13 skipped, 0 failures. `make format` and `make lint-changed` clean.