### PR TITLE
Post-FX fader boundary: one contract both engines read (#2087)

### DIFF
--- a/magda/daw/audio/AudioBridge.cpp
+++ b/magda/daw/audio/AudioBridge.cpp
@@ -742,8 +742,8 @@ te::Plugin::Ptr AudioBridge::addLevelMeterToTrack(TrackId trackId) {
     return pluginManager_.addLevelMeterToTrack(trackId);
 }
 
-void AudioBridge::ensureVolumePluginPosition(te::AudioTrack* track) const {
-    pluginManager_.ensureVolumePluginPosition(track);
+void AudioBridge::ensureVolumePluginPosition(TrackId trackId, te::AudioTrack* track) const {
+    pluginManager_.ensureVolumePluginPosition(trackId, track);
 }
 
 // =============================================================================

--- a/magda/daw/audio/AudioBridge.hpp
+++ b/magda/daw/audio/AudioBridge.hpp
@@ -288,7 +288,7 @@ class AudioBridge : public TrackManagerListener, public ClipManagerListener, pub
      * @brief Ensure VolumeAndPanPlugin is at the correct position (near end of chain)
      * @param track The Tracktion Engine audio track
      */
-    void ensureVolumePluginPosition(te::AudioTrack* track) const;
+    void ensureVolumePluginPosition(TrackId trackId, te::AudioTrack* track) const;
 
     // =========================================================================
     // Track Mapping

--- a/magda/daw/audio/plugin_manager/PluginManager.hpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.hpp
@@ -183,6 +183,12 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener,
      * @brief Ensure VolumeAndPanPlugin is at the correct position (near end of chain)
      * @param track The Tracktion Engine audio track
      */
+    /// Append everything after the fx tree to `desiredOrder`, grouped so that
+    /// every pre-fader plugin precedes every post-fader one. Shared by the
+    /// ordinary and multi-out sync paths, which each used to carry their own.
+    void appendStripOrder(TrackId trackId, const TrackInfo& trackInfo, te::AudioTrack& track,
+                          std::vector<te::Plugin*>& desiredOrder) const;
+
     void ensureVolumePluginPosition(TrackId trackId, te::AudioTrack* track) const;
 
     /// The plugins on `trackId` that belong after the track fader: the post-FX

--- a/magda/daw/audio/plugin_manager/PluginManager.hpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.hpp
@@ -183,7 +183,12 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener,
      * @brief Ensure VolumeAndPanPlugin is at the correct position (near end of chain)
      * @param track The Tracktion Engine audio track
      */
-    void ensureVolumePluginPosition(te::AudioTrack* track) const;
+    void ensureVolumePluginPosition(TrackId trackId, te::AudioTrack* track) const;
+
+    /// The plugins on `trackId` that belong after the track fader: the post-FX
+    /// stage and mixer-analysis rail when the chain is post-fader, plus the
+    /// always-on measurement tap, which is post-fader unconditionally.
+    std::unordered_set<te::Plugin*> collectPostFaderPlugins(TrackId trackId) const;
 
     /**
      * @brief Callback invoked when a plugin fails to load

--- a/magda/daw/audio/plugin_manager/PluginManager.hpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.hpp
@@ -183,6 +183,11 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener,
      * @brief Ensure VolumeAndPanPlugin is at the correct position (near end of chain)
      * @param track The Tracktion Engine audio track
      */
+    /// Bring the track's AuxSendPlugins into line with `TrackInfo::sends`.
+    /// Shared by the ordinary and multi-out sync paths; the multi-out one used
+    /// to return before this ran and so never created a send at all.
+    void reconcileSends(const TrackInfo& trackInfo, te::AudioTrack& track);
+
     /// Append everything after the fx tree to `desiredOrder`, grouped so that
     /// every pre-fader plugin precedes every post-fader one. Shared by the
     /// ordinary and multi-out sync paths, which each used to carry their own.

--- a/magda/daw/audio/plugin_manager/PluginManager.hpp
+++ b/magda/daw/audio/plugin_manager/PluginManager.hpp
@@ -186,9 +186,11 @@ class PluginManager : public daw::audio::DrumGridPlugin::Listener,
     void ensureVolumePluginPosition(TrackId trackId, te::AudioTrack* track) const;
 
     /// The plugins on `trackId` that belong after the track fader: the post-FX
-    /// stage and mixer-analysis rail when the chain is post-fader, plus the
-    /// always-on measurement tap, which is post-fader unconditionally.
-    std::unordered_set<te::Plugin*> collectPostFaderPlugins(TrackId trackId) const;
+    /// stage and mixer-analysis rail when the chain is post-fader, the track's
+    /// post-fader aux sends, and the always-on measurement tap, which is
+    /// post-fader unconditionally.
+    std::unordered_set<te::Plugin*> collectPostFaderPlugins(TrackId trackId,
+                                                            te::AudioTrack& track) const;
 
     /**
      * @brief Callback invoked when a plugin fails to load

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -831,9 +831,11 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
         removeSidechainMonitor(trackId);
 
     // Create TE plugins for post-FX devices (flat list, no racks/instruments).
-    // Inserted at -1 (append); the reorder pass below places them after the fx
-    // tree and ensureVolumePluginPosition keeps the fader after them, so the
-    // final order is [fx..., postFx..., mixerAnalysis..., VolumeAndPan, LevelMeter].
+    // Inserted at -1 (append); the reorder pass below sequences them, and which
+    // side of VolumeAndPan they land on is TrackChain::postFxPostFader (#2087):
+    //
+    //   post-fader: [fx..., VolumeAndPan, postFx..., mixerAnalysis..., LevelMeter]
+    //   pre-fader:  [fx..., postFx..., mixerAnalysis..., VolumeAndPan, LevelMeter]
     auto loadFlatSection = [&](const std::vector<PostFxChainElement>& section, auto pathBuilder) {
         for (const auto& elem : section) {
             const auto& device = elem.device;
@@ -967,7 +969,7 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
 
     // Ensure VolumeAndPan is near the end of the chain (before LevelMeter)
     // This is the track's fader control - it should come AFTER audio sources
-    ensureVolumePluginPosition(teTrack);
+    ensureVolumePluginPosition(trackId, teTrack);
 
     // Ensure LevelMeter is at the end of the plugin chain for metering
     addLevelMeterToTrack(trackId);
@@ -1430,7 +1432,7 @@ void PluginManager::pollAsyncPluginLoad(const ChainNodePath& devicePath, te::Plu
     });
 }
 
-void PluginManager::ensureVolumePluginPosition(te::AudioTrack* track) const {
+void PluginManager::ensureVolumePluginPosition(TrackId trackId, te::AudioTrack* track) const {
     if (!track)
         return;
 
@@ -1466,26 +1468,91 @@ void PluginManager::ensureVolumePluginPosition(te::AudioTrack* track) const {
     if (volPanIndex < 0)
         return;
 
-    // Check if there are any non-utility plugins after VolumeAndPan.
-    // VolumeAndPan is the track fader — it must come AFTER all audio-producing
-    // plugins (instruments, racks, FX, sends) and only before LevelMeter.
-    bool needsMove = false;
-    for (int i = volPanIndex + 1; i < plugins.size(); ++i) {
-        if (!dynamic_cast<te::LevelMeterPlugin*>(plugins[i])) {
-            needsMove = true;
+    // What legitimately belongs after the fader (#2087). Until now the answer
+    // was "only LevelMeter", which is why the fader was hoisted past everything
+    // else and why the post-FX stage could never actually be post-fader.
+    const auto postFaderPlugins = collectPostFaderPlugins(trackId);
+
+    // Where the fader goes: immediately before the first plugin that belongs
+    // after it, or at the end when nothing does.
+    int firstPostFader = -1;
+    for (int i = 0; i < plugins.size(); ++i) {
+        if (plugins[i] == volPanRaw)
+            continue;
+        if (postFaderPlugins.count(plugins[i]) != 0) {
+            firstPostFader = i;
             break;
         }
     }
 
-    if (!needsMove)
-        return;
+    if (firstPostFader < 0) {
+        // Nothing post-fader: the fader is last but for the meter, which is the
+        // rule this function has always enforced.
+        bool needsMove = false;
+        for (int i = volPanIndex + 1; i < plugins.size(); ++i) {
+            if (!dynamic_cast<te::LevelMeterPlugin*>(plugins[i])) {
+                needsMove = true;
+                break;
+            }
+        }
+        if (!needsMove)
+            return;
 
-    // Move VolumeAndPan to the end of the list.
-    // addLevelMeterToTrack() runs right after this and ensures LevelMeter
-    // is always the very last plugin, so the final order will be:
-    // [instruments, FX, sends, ..., VolumeAndPan, LevelMeter]
+        // addLevelMeterToTrack() runs right after this and ensures LevelMeter is
+        // always the very last plugin, so the final order will be:
+        // [instruments, FX, sends, ..., VolumeAndPan, LevelMeter]
+        volPanPlugin->removeFromParent();
+        plugins.insertPlugin(volPanPlugin, -1, nullptr);
+        return;
+    }
+
+    if (volPanIndex == firstPostFader - 1)
+        return;  // already immediately before the post-fader run
+
+    // Recompute the anchor after the removal rather than adjusting the index by
+    // hand: removing the fader shifts everything after it down by one only when
+    // the fader was earlier in the list, and getting that wrong puts the fader
+    // one slot inside its own post-fader run.
+    auto* anchor = plugins[firstPostFader];
     volPanPlugin->removeFromParent();
-    plugins.insertPlugin(volPanPlugin, -1, nullptr);
+    const int insertAt = plugins.indexOf(anchor);
+    plugins.insertPlugin(volPanPlugin, insertAt, nullptr);
+}
+
+std::unordered_set<te::Plugin*> PluginManager::collectPostFaderPlugins(TrackId trackId) const {
+    std::unordered_set<te::Plugin*> result;
+
+    const auto* trackInfo = TrackManager::getInstance().getTrack(trackId);
+    if (trackInfo == nullptr)
+        return result;
+
+    // The always-on measurement tap, which the mixing agent and MixAnalysisService
+    // read. PluginManagerMeasurement appends it last and says "Post-fader" while
+    // doing so; before this it was hoisted above the fader on the next chain sync,
+    // so both of those were reading pre-fader audio. Included here rather than
+    // left to the post-FX flag because it is post-fader unconditionally and its
+    // placement should not depend on whether the user happens to own a post-FX
+    // device.
+    if (auto tap = trackMeasurementTaps_.find(trackId); tap != trackMeasurementTaps_.end()) {
+        if (tap->second)
+            result.insert(tap->second.get());
+    }
+
+    if (!trackInfo->chain.postFxPostFader)
+        return result;
+
+    auto addSection = [&](const std::vector<PostFxChainElement>& section, auto pathBuilder) {
+        for (const auto& elem : section) {
+            juce::ScopedLock lock(pluginLock_);
+            auto it = findSyncedDevice(pathBuilder(trackId, elem.device.id));
+            if (it != syncedDevices_.end() && it->second.plugin)
+                result.insert(it->second.plugin.get());
+        }
+    };
+    addSection(trackInfo->chain.postFxChainElements, &ChainNodePath::postFxDevice);
+    addSection(trackInfo->chain.mixerAnalysisElements, &ChainNodePath::mixerAnalysisDevice);
+
+    return result;
 }
 
 // =============================================================================
@@ -1742,7 +1809,7 @@ void PluginManager::syncMultiOutTrack(TrackId trackId, const TrackInfo& trackInf
     }
 
     // Ensure VolumeAndPan and LevelMeter are present
-    ensureVolumePluginPosition(teTrack);
+    ensureVolumePluginPosition(trackId, teTrack);
     addLevelMeterToTrack(trackId);
 
     if (pluginOrderChanged)

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -892,58 +892,7 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
             }
         }
 
-        // The rest of the strip, in the order the native compiler emits it:
-        //
-        //   fx -> [postFx, mixerAnalysis if pre-fader] -> preFaderSends
-        //      -> fader -> [postFx, mixerAnalysis if post-fader] -> postFaderSends
-        //
-        // The fader is not in this list; ensureVolumePluginPosition slots it in
-        // afterwards, immediately before the first plugin that belongs after it.
-        // That only lands correctly if everything pre-fader precedes everything
-        // post-fader here, which is what the two groups below are for.
-        auto appendSection = [&](const std::vector<PostFxChainElement>& section, auto pathBuilder) {
-            juce::ScopedLock lock(pluginLock_);
-            for (const auto& elem : section) {
-                auto it = findSyncedDevice(pathBuilder(trackId, elem.device.id));
-                if (it != syncedDevices_.end() && it->second.plugin &&
-                    teTrack->pluginList.indexOf(it->second.plugin.get()) >= 0)
-                    desiredOrder.push_back(it->second.plugin.get());
-            }
-        };
-        auto appendStage = [&] {
-            appendSection(trackInfo->chain.postFxChainElements, &ChainNodePath::postFxDevice);
-            appendSection(trackInfo->chain.mixerAnalysisElements,
-                          &ChainNodePath::mixerAnalysisDevice);
-        };
-
-        // Sends are sequenced here for the first time. They used to be appended
-        // and left alone, which was harmless only because the fader was hoisted
-        // past everything: every send ended up above it whatever SendInfo::preFader
-        // said, so TE has never honoured that flag while the native compiler has
-        // always split on it. Leaving them unsequenced now would be worse than
-        // inconsistent — the fader lands before the first post-fader plugin, so
-        // whether a send sat above or below it would depend on whether the track
-        // happened to own a post-FX device.
-        auto appendSends = [&](bool preFader) {
-            for (const auto& send : trackInfo->sends) {
-                if (send.preFader != preFader)
-                    continue;
-                for (int i = 0; i < teTrack->pluginList.size(); ++i) {
-                    if (auto* aux = dynamic_cast<te::AuxSendPlugin*>(teTrack->pluginList[i]);
-                        aux != nullptr && aux->getBusNumber() == send.busIndex) {
-                        desiredOrder.push_back(aux);
-                        break;
-                    }
-                }
-            }
-        };
-
-        if (!trackInfo->chain.postFxPostFader)
-            appendStage();
-        appendSends(/*preFader=*/true);
-        if (trackInfo->chain.postFxPostFader)
-            appendStage();
-        appendSends(/*preFader=*/false);
+        appendStripOrder(trackId, *trackInfo, *teTrack, desiredOrder);
 
         // Walk the desired order and move each plugin to its correct position
         // using ValueTree::moveChild on the plugin list's state.
@@ -1468,6 +1417,64 @@ void PluginManager::pollAsyncPluginLoad(const ChainNodePath& devicePath, te::Plu
     });
 }
 
+void PluginManager::appendStripOrder(TrackId trackId, const TrackInfo& trackInfo,
+                                     te::AudioTrack& track,
+                                     std::vector<te::Plugin*>& desiredOrder) const {
+    // Everything after the fx tree, in the order the native compiler emits it:
+    //
+    //   fx -> [postFx, mixerAnalysis if pre-fader] -> preFaderSends
+    //      -> fader -> [postFx, mixerAnalysis if post-fader] -> postFaderSends
+    //
+    // The fader is not in this list; ensureVolumePluginPosition slots it in
+    // afterwards, immediately before the first plugin that belongs after it.
+    // That only lands correctly if everything pre-fader precedes everything
+    // post-fader here, which is what the grouping below is for.
+    //
+    // Shared by syncTrackPlugins and syncMultiOutTrack because it was not:
+    // the multi-out path carried its own copy that sequenced the stage and
+    // nothing else, so a multi-out track got the fader placed against a set the
+    // ordering pass had never arranged for.
+    auto appendSection = [&](const std::vector<PostFxChainElement>& section, auto pathBuilder) {
+        const juce::ScopedLock lock(pluginLock_);
+        for (const auto& elem : section) {
+            auto it = findSyncedDevice(pathBuilder(trackId, elem.device.id));
+            if (it != syncedDevices_.end() && it->second.plugin &&
+                track.pluginList.indexOf(it->second.plugin.get()) >= 0)
+                desiredOrder.push_back(it->second.plugin.get());
+        }
+    };
+    auto appendStage = [&] {
+        appendSection(trackInfo.chain.postFxChainElements, &ChainNodePath::postFxDevice);
+        appendSection(trackInfo.chain.mixerAnalysisElements, &ChainNodePath::mixerAnalysisDevice);
+    };
+
+    // Sends are sequenced here for the first time. They used to be appended and
+    // left alone, which was harmless only because the fader was hoisted past
+    // everything: every send ended up above it whatever SendInfo::preFader said,
+    // so TE has never honoured that flag while the native compiler has always
+    // split on it.
+    auto appendSends = [&](bool preFader) {
+        for (const auto& send : trackInfo.sends) {
+            if (send.preFader != preFader)
+                continue;
+            for (int i = 0; i < track.pluginList.size(); ++i) {
+                if (auto* aux = dynamic_cast<te::AuxSendPlugin*>(track.pluginList[i]);
+                    aux != nullptr && aux->getBusNumber() == send.busIndex) {
+                    desiredOrder.push_back(aux);
+                    break;
+                }
+            }
+        }
+    };
+
+    if (!trackInfo.chain.postFxPostFader)
+        appendStage();
+    appendSends(/*preFader=*/true);
+    if (trackInfo.chain.postFxPostFader)
+        appendStage();
+    appendSends(/*preFader=*/false);
+}
+
 void PluginManager::ensureVolumePluginPosition(TrackId trackId, te::AudioTrack* track) const {
     if (!track)
         return;
@@ -1808,18 +1815,7 @@ void PluginManager::syncMultiOutTrack(TrackId trackId, const TrackInfo& trackInf
                 }
             }
         }
-        auto appendSection = [&](const std::vector<PostFxChainElement>& section, auto pathBuilder) {
-            for (const auto& elem : section) {
-                const auto devicePath = pathBuilder(trackId, elem.device.id);
-                juce::ScopedLock lock(pluginLock_);
-                auto it = findSyncedDevice(devicePath);
-                if (it != syncedDevices_.end() && it->second.plugin &&
-                    teTrack->pluginList.indexOf(it->second.plugin.get()) >= 0)
-                    desiredOrder.push_back(it->second.plugin.get());
-            }
-        };
-        appendSection(trackInfo.chain.postFxChainElements, &ChainNodePath::postFxDevice);
-        appendSection(trackInfo.chain.mixerAnalysisElements, &ChainNodePath::mixerAnalysisDevice);
+        appendStripOrder(trackId, trackInfo, *teTrack, desiredOrder);
 
         auto& listState = teTrack->pluginList.state;
         for (size_t i = 0; i < desiredOrder.size(); ++i) {

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -892,22 +892,58 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
             }
         }
 
-        // Post-FX devices come after the fx tree but before the fader; mixer-
-        // analysis devices come after post-FX. Append both groups so the move
-        // below sequences them last (the fader and meter are then pushed past
-        // them by ensureVolumePluginPosition).
+        // The rest of the strip, in the order the native compiler emits it:
+        //
+        //   fx -> [postFx, mixerAnalysis if pre-fader] -> preFaderSends
+        //      -> fader -> [postFx, mixerAnalysis if post-fader] -> postFaderSends
+        //
+        // The fader is not in this list; ensureVolumePluginPosition slots it in
+        // afterwards, immediately before the first plugin that belongs after it.
+        // That only lands correctly if everything pre-fader precedes everything
+        // post-fader here, which is what the two groups below are for.
         auto appendSection = [&](const std::vector<PostFxChainElement>& section, auto pathBuilder) {
+            juce::ScopedLock lock(pluginLock_);
             for (const auto& elem : section) {
-                const auto devicePath = pathBuilder(trackId, elem.device.id);
-                juce::ScopedLock lock(pluginLock_);
-                auto it = findSyncedDevice(devicePath);
+                auto it = findSyncedDevice(pathBuilder(trackId, elem.device.id));
                 if (it != syncedDevices_.end() && it->second.plugin &&
                     teTrack->pluginList.indexOf(it->second.plugin.get()) >= 0)
                     desiredOrder.push_back(it->second.plugin.get());
             }
         };
-        appendSection(trackInfo->chain.postFxChainElements, &ChainNodePath::postFxDevice);
-        appendSection(trackInfo->chain.mixerAnalysisElements, &ChainNodePath::mixerAnalysisDevice);
+        auto appendStage = [&] {
+            appendSection(trackInfo->chain.postFxChainElements, &ChainNodePath::postFxDevice);
+            appendSection(trackInfo->chain.mixerAnalysisElements,
+                          &ChainNodePath::mixerAnalysisDevice);
+        };
+
+        // Sends are sequenced here for the first time. They used to be appended
+        // and left alone, which was harmless only because the fader was hoisted
+        // past everything: every send ended up above it whatever SendInfo::preFader
+        // said, so TE has never honoured that flag while the native compiler has
+        // always split on it. Leaving them unsequenced now would be worse than
+        // inconsistent — the fader lands before the first post-fader plugin, so
+        // whether a send sat above or below it would depend on whether the track
+        // happened to own a post-FX device.
+        auto appendSends = [&](bool preFader) {
+            for (const auto& send : trackInfo->sends) {
+                if (send.preFader != preFader)
+                    continue;
+                for (int i = 0; i < teTrack->pluginList.size(); ++i) {
+                    if (auto* aux = dynamic_cast<te::AuxSendPlugin*>(teTrack->pluginList[i]);
+                        aux != nullptr && aux->getBusNumber() == send.busIndex) {
+                        desiredOrder.push_back(aux);
+                        break;
+                    }
+                }
+            }
+        };
+
+        if (!trackInfo->chain.postFxPostFader)
+            appendStage();
+        appendSends(/*preFader=*/true);
+        if (trackInfo->chain.postFxPostFader)
+            appendStage();
+        appendSends(/*preFader=*/false);
 
         // Walk the desired order and move each plugin to its correct position
         // using ValueTree::moveChild on the plugin list's state.
@@ -1471,7 +1507,7 @@ void PluginManager::ensureVolumePluginPosition(TrackId trackId, te::AudioTrack* 
     // What legitimately belongs after the fader (#2087). Until now the answer
     // was "only LevelMeter", which is why the fader was hoisted past everything
     // else and why the post-FX stage could never actually be post-fader.
-    const auto postFaderPlugins = collectPostFaderPlugins(trackId);
+    const auto postFaderPlugins = collectPostFaderPlugins(trackId, *track);
 
     // Where the fader goes: immediately before the first plugin that belongs
     // after it, or at the end when nothing does.
@@ -1519,7 +1555,8 @@ void PluginManager::ensureVolumePluginPosition(TrackId trackId, te::AudioTrack* 
     plugins.insertPlugin(volPanPlugin, insertAt, nullptr);
 }
 
-std::unordered_set<te::Plugin*> PluginManager::collectPostFaderPlugins(TrackId trackId) const {
+std::unordered_set<te::Plugin*> PluginManager::collectPostFaderPlugins(
+    TrackId trackId, te::AudioTrack& track) const {
     std::unordered_set<te::Plugin*> result;
 
     const auto* trackInfo = TrackManager::getInstance().getTrack(trackId);
@@ -1533,17 +1570,34 @@ std::unordered_set<te::Plugin*> PluginManager::collectPostFaderPlugins(TrackId t
     // left to the post-FX flag because it is post-fader unconditionally and its
     // placement should not depend on whether the user happens to own a post-FX
     // device.
+    //
+    // Unlocked, like every other access to this map: it is written and read on
+    // the message thread only (see PluginManagerMeasurement.cpp). The lock below
+    // is for syncedDevices_, which the async plugin-load path also touches.
     if (auto tap = trackMeasurementTaps_.find(trackId); tap != trackMeasurementTaps_.end()) {
         if (tap->second)
             result.insert(tap->second.get());
     }
 
+    // A post-fader send taps the fader's output, which is what "post-fader"
+    // means and what the native compiler has always done. TE never honoured the
+    // flag because the fader was hoisted past every send regardless; it does now.
+    for (const auto& send : trackInfo->sends) {
+        if (send.preFader)
+            continue;
+        for (int i = 0; i < track.pluginList.size(); ++i)
+            if (auto* aux = dynamic_cast<te::AuxSendPlugin*>(track.pluginList[i]);
+                aux != nullptr && aux->getBusNumber() == send.busIndex)
+                result.insert(aux);
+    }
+
     if (!trackInfo->chain.postFxPostFader)
         return result;
 
+    // One critical section for the whole walk rather than one per device.
+    const juce::ScopedLock lock(pluginLock_);
     auto addSection = [&](const std::vector<PostFxChainElement>& section, auto pathBuilder) {
         for (const auto& elem : section) {
-            juce::ScopedLock lock(pluginLock_);
             auto it = findSyncedDevice(pathBuilder(trackId, elem.device.id));
             if (it != syncedDevices_.end() && it->second.plugin)
                 result.insert(it->second.plugin.get());

--- a/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
+++ b/magda/daw/audio/plugin_manager/PluginManagerSync.cpp
@@ -729,62 +729,7 @@ void PluginManager::syncTrackPlugins(TrackId trackId) {
         }
     }
 
-    // Sync sends: ensure AuxSendPlugins match TrackInfo::sends
-    {
-        // Collect existing AuxSendPlugin bus numbers
-        std::vector<int> existingSendBuses;
-        for (int i = 0; i < teTrack->pluginList.size(); ++i) {
-            if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(teTrack->pluginList[i])) {
-                existingSendBuses.push_back(auxSend->getBusNumber());
-            }
-        }
-
-        // Collect desired bus numbers from TrackInfo
-        std::vector<int> desiredBuses;
-        for (const auto& send : trackInfo->sends) {
-            desiredBuses.push_back(send.busIndex);
-        }
-
-        // Remove AuxSendPlugins that are no longer needed
-        for (int i = teTrack->pluginList.size() - 1; i >= 0; --i) {
-            if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(teTrack->pluginList[i])) {
-                int bus = auxSend->getBusNumber();
-                if (std::find(desiredBuses.begin(), desiredBuses.end(), bus) ==
-                    desiredBuses.end()) {
-                    auxSend->deleteFromParent();
-                }
-            }
-        }
-
-        // Add missing AuxSendPlugins
-        for (const auto& send : trackInfo->sends) {
-            bool exists = std::find(existingSendBuses.begin(), existingSendBuses.end(),
-                                    send.busIndex) != existingSendBuses.end();
-            if (!exists) {
-                auto sendPlugin =
-                    edit_.getPluginCache().createNewPlugin(te::AuxSendPlugin::xmlTypeName, {});
-                if (sendPlugin) {
-                    if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(sendPlugin.get())) {
-                        auxSend->busNumber = send.busIndex;
-                        auxSend->setGainDb(juce::Decibels::gainToDecibels(send.level));
-                    }
-                    teTrack->pluginList.insertPlugin(sendPlugin, -1, nullptr);
-                }
-            }
-        }
-
-        // Update send levels for existing sends
-        for (const auto& send : trackInfo->sends) {
-            for (int i = 0; i < teTrack->pluginList.size(); ++i) {
-                if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(teTrack->pluginList[i])) {
-                    if (auxSend->getBusNumber() == send.busIndex) {
-                        auxSend->setGainDb(juce::Decibels::gainToDecibels(send.level));
-                        break;
-                    }
-                }
-            }
-        }
-    }
+    reconcileSends(*trackInfo, *teTrack);
 
     // Register DrumGrid pad plugins in syncedDevices_ before macro/mod sync.
     // Drum Grid device macros can target pad samplers, and those targets must
@@ -1417,6 +1362,63 @@ void PluginManager::pollAsyncPluginLoad(const ChainNodePath& devicePath, te::Plu
     });
 }
 
+void PluginManager::reconcileSends(const TrackInfo& trackInfo, te::AudioTrack& track) {
+    // Make the track's AuxSendPlugins match TrackInfo::sends: drop the buses
+    // that went away, create the ones that appeared, and refresh the levels.
+    //
+    // Shared with syncMultiOutTrack, which returns from syncTrackPlugins long
+    // before this used to run. A multi-out track therefore had no send plugins
+    // at all while the native compiler emitted its sends from the same model,
+    // so the two engines disagreed about whether the sends existed - which
+    // appendStripOrder could not show, because it can only order plugins that
+    // are already there.
+    std::vector<int> existingSendBuses;
+    for (int i = 0; i < track.pluginList.size(); ++i)
+        if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(track.pluginList[i]))
+            existingSendBuses.push_back(auxSend->getBusNumber());
+
+    std::vector<int> desiredBuses;
+    desiredBuses.reserve(trackInfo.sends.size());
+    for (const auto& send : trackInfo.sends)
+        desiredBuses.push_back(send.busIndex);
+
+    for (int i = track.pluginList.size() - 1; i >= 0; --i) {
+        if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(track.pluginList[i])) {
+            const int bus = auxSend->getBusNumber();
+            if (std::find(desiredBuses.begin(), desiredBuses.end(), bus) == desiredBuses.end())
+                auxSend->deleteFromParent();
+        }
+    }
+
+    for (const auto& send : trackInfo.sends) {
+        const bool exists = std::find(existingSendBuses.begin(), existingSendBuses.end(),
+                                      send.busIndex) != existingSendBuses.end();
+        if (exists)
+            continue;
+        auto sendPlugin =
+            edit_.getPluginCache().createNewPlugin(te::AuxSendPlugin::xmlTypeName, {});
+        if (!sendPlugin)
+            continue;
+        if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(sendPlugin.get())) {
+            auxSend->busNumber = send.busIndex;
+            auxSend->setGainDb(juce::Decibels::gainToDecibels(send.level));
+        }
+        // Appended; appendStripOrder sequences it onto the right side of the
+        // fader afterwards.
+        track.pluginList.insertPlugin(sendPlugin, -1, nullptr);
+    }
+
+    for (const auto& send : trackInfo.sends) {
+        for (int i = 0; i < track.pluginList.size(); ++i) {
+            if (auto* auxSend = dynamic_cast<te::AuxSendPlugin*>(track.pluginList[i]);
+                auxSend != nullptr && auxSend->getBusNumber() == send.busIndex) {
+                auxSend->setGainDb(juce::Decibels::gainToDecibels(send.level));
+                break;
+            }
+        }
+    }
+}
+
 void PluginManager::appendStripOrder(TrackId trackId, const TrackInfo& trackInfo,
                                      te::AudioTrack& track,
                                      std::vector<te::Plugin*>& desiredOrder) const {
@@ -1697,41 +1699,44 @@ void PluginManager::syncMultiOutTrack(TrackId trackId, const TrackInfo& trackInf
             pluginsToDelete[i]->deleteFromParent();
     }
 
-    // Look up the output pair's actual pin mapping
-    auto* device = TrackManager::getInstance().getDevice(link.sourceTrackId, link.sourceDeviceId);
-    if (!device || !device->multiOut.isMultiOut)
-        return;
+    // The output pair's rack instance is what carries the multi-out routing.
+    // A guarded block rather than the three early returns it used to be: none of
+    // the sync below depends on the instance, so returning here gated a child
+    // track's fx devices, post-FX stage, sends, ordering and fader placement on
+    // multi-out plumbing that has nothing to do with any of them. A source
+    // device that has not finished loading is enough to hit it, and the track
+    // then had none of its chain (#2087 review).
+    //
+    // Declared out here because the ordering pass below anchors the first user
+    // plugin after it when there is one.
+    te::Plugin::Ptr rackInstance;
+    if (auto* device =
+            TrackManager::getInstance().getDevice(link.sourceTrackId, link.sourceDeviceId);
+        device != nullptr && device->multiOut.isMultiOut && link.outputPairIndex >= 0 &&
+        link.outputPairIndex < static_cast<int>(device->multiOut.outputPairs.size())) {
+        auto& outPair = device->multiOut.outputPairs[static_cast<size_t>(link.outputPairIndex)];
 
-    if (link.outputPairIndex < 0 ||
-        link.outputPairIndex >= static_cast<int>(device->multiOut.outputPairs.size()))
-        return;
-
-    auto& outPair = device->multiOut.outputPairs[static_cast<size_t>(link.outputPairIndex)];
-
-    // Restore pair state from the existing multi-out track (needed after project load,
-    // since the async plugin callback rebuilds pairs with active=false before tracks are restored)
-    if (!outPair.active || outPair.trackId != trackId) {
-        outPair.active = true;
-        outPair.trackId = trackId;
-    }
-
-    // Get or create the RackInstance for this output pair
-    auto rackInstance = instrumentRackManager_.createOutputInstance(
-        link.sourceDeviceId, link.outputPairIndex, outPair.firstPin, outPair.numChannels);
-    if (!rackInstance)
-        return;
-
-    // Check if rack instance is already on the track
-    bool alreadyOnTrack = false;
-    for (int i = 0; i < teTrack->pluginList.size(); ++i) {
-        if (teTrack->pluginList[i] == rackInstance.get()) {
-            alreadyOnTrack = true;
-            break;
+        // Restore pair state from the existing multi-out track (needed after project load,
+        // since the async plugin callback rebuilds pairs with active=false before tracks are
+        // restored)
+        if (!outPair.active || outPair.trackId != trackId) {
+            outPair.active = true;
+            outPair.trackId = trackId;
         }
-    }
 
-    if (!alreadyOnTrack) {
-        teTrack->pluginList.insertPlugin(rackInstance, -1, nullptr);
+        rackInstance = instrumentRackManager_.createOutputInstance(
+            link.sourceDeviceId, link.outputPairIndex, outPair.firstPin, outPair.numChannels);
+        if (rackInstance) {
+            bool alreadyOnTrack = false;
+            for (int i = 0; i < teTrack->pluginList.size(); ++i) {
+                if (teTrack->pluginList[i] == rackInstance.get()) {
+                    alreadyOnTrack = true;
+                    break;
+                }
+            }
+            if (!alreadyOnTrack)
+                teTrack->pluginList.insertPlugin(rackInstance, -1, nullptr);
+        }
     }
 
     // Sync user-added FX devices from chainElements (same as normal track path)
@@ -1799,6 +1804,10 @@ void PluginManager::syncMultiOutTrack(TrackId trackId, const TrackInfo& trackInf
     };
     loadFlatSection(trackInfo.chain.postFxChainElements, &ChainNodePath::postFxDevice);
     loadFlatSection(trackInfo.chain.mixerAnalysisElements, &ChainNodePath::mixerAnalysisDevice);
+
+    // Sends, on the same terms as an ordinary track. Before ordering, because
+    // appendStripOrder can only place plugins that already exist.
+    reconcileSends(trackInfo, *teTrack);
 
     // Reorder TE plugins to match the MAGDA chain element order (same as syncTrackPlugins)
     bool pluginOrderChanged = false;

--- a/magda/daw/core/TrackChain.hpp
+++ b/magda/daw/core/TrackChain.hpp
@@ -11,12 +11,15 @@ namespace magda {
  * @brief A single element in a track's post-FX chain.
  *
  * Post-FX is flat by design: a linear list of effect / analysis devices that
- * run after the main FX chain (but before the track fader - it is post-FX, not
- * post-fader). It is never an instrument (nothing generates sound at this
- * stage) and never a rack (no parallel routing in the post-FX stage). Making it
- * a distinct type from ChainElement encodes those invariants structurally -
- * there is no "is post-fx" flag and no runtime placement check; the type system
- * simply cannot represent a rack or a nested structure here.
+ * run after the main FX chain. It is never an instrument (nothing generates
+ * sound at this stage) and never a rack (no parallel routing in the post-FX
+ * stage). Making it a distinct type from ChainElement encodes those invariants
+ * structurally - there is no "is post-fx" flag and no runtime placement check;
+ * the type system simply cannot represent a rack or a nested structure here.
+ *
+ * These are ordinary devices: they process audio and they render. The section
+ * exists for the things #730 asked for - dithering, final limiting, metering -
+ * so "does nothing to the signal" was never what post-FX meant.
  */
 struct PostFxChainElement {
     DeviceInfo device;
@@ -30,16 +33,38 @@ struct PostFxChainElement {
  *                        (ChainElement), reusing all existing nesting,
  *                        deep-copy, sync-flatten and path-resolution machinery.
  * - postFxChainElements: the post-FX stage. A flat list of devices that runs
- *                        after the main FX chain but still before the fader
- *                        (post-FX, not post-fader).
+ *                        after the main FX chain, on whichever side of the
+ *                        fader `postFxPostFader` says.
  *
- * The track fader (VolumeAndPan) is not modelled as a node. The intended
- * routing (sync not yet implemented) is:
- *   flatten(fxChainElements) -> postFxChainElements -> VolumeAndPan -> LevelMeter
+ * The track fader (VolumeAndPan) is not modelled as a node. The routing is:
+ *
+ *   post-fader (default):
+ *     flatten(fx) -> VolumeAndPan -> postFx -> mixerAnalysis -> LevelMeter
+ *   pre-fader:
+ *     flatten(fx) -> postFx -> mixerAnalysis -> VolumeAndPan -> LevelMeter
  */
 struct TrackChain {
-    std::vector<ChainElement> fxChainElements;            // main / pre-fader (tree)
-    std::vector<PostFxChainElement> postFxChainElements;  // post-fader (flat)
+    std::vector<ChainElement> fxChainElements;            // main insert chain (tree)
+    std::vector<PostFxChainElement> postFxChainElements;  // post-FX stage (flat)
+
+    /**
+     * Which side of the track fader the post-FX stage sits on (#2087).
+     *
+     * The name "post-FX" has always meant *after the FX chain*; where it sat
+     * relative to the fader was left open. #1335 shipped it pre-fader and
+     * `de7a0b7c` recorded the fader boundary as deferred, but the panel and
+     * several comments went on calling the section post-fader, so the two
+     * readings have been live side by side ever since. This is the flag that
+     * decides, rather than an ordering each engine hardcodes and drifts on.
+     *
+     * Default post-fader, which is what the section is called and what makes a
+     * meter dropped in here read the signal leaving the track. A project that
+     * wants its post-FX processing to feed the fader turns it off, one switch
+     * for the whole chain. Per-device placement is the v1 upgrade; the
+     * compilers already partition on a value rather than on a constant, so it
+     * is a widening rather than a rewrite.
+     */
+    bool postFxPostFader = true;
 
     // Chain power (the track chain header's power button + the track
     // inspector's enable switch). When off, every insert-chain device is
@@ -82,6 +107,7 @@ struct TrackChain {
         postFxChainElements = other.postFxChainElements;
         mixerAnalysisElements = other.mixerAnalysisElements;
         enabled = other.enabled;
+        postFxPostFader = other.postFxPostFader;
     }
 };
 

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -2301,6 +2301,23 @@ void TrackManager::setChainEnabled(TrackId trackId, bool enabled) {
     notifyTrackDevicesChanged(trackId);
 }
 
+void TrackManager::setPostFxPostFader(TrackId trackId, bool postFader) {
+    auto* track = getTrack(trackId);
+    if (!track || track->chain.postFxPostFader == postFader)
+        return;
+    track->chain.postFxPostFader = postFader;
+
+    // A devices-changed notification rather than a property one: this moves
+    // plugins across the fader, which is a change to the shape of the chain and
+    // is what PluginManager's reorder pass keys off.
+    notifyTrackDevicesChanged(trackId);
+}
+
+bool TrackManager::isPostFxPostFader(TrackId trackId) const {
+    const auto* track = getTrack(trackId);
+    return track == nullptr ? true : track->chain.postFxPostFader;
+}
+
 DeviceInfo* TrackManager::getDevice(TrackId trackId, DeviceId deviceId) {
     if (auto* track = getTrack(trackId)) {
         for (auto& element : track->chain.fxChainElements) {

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -468,6 +468,11 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     bool isChainEnabled(TrackId trackId) const;
     void setChainEnabled(TrackId trackId, bool enabled);
 
+    /// Which side of the fader the whole post-FX stage sits on (#2087). One
+    /// switch per chain; per-device placement is the v1 upgrade.
+    void setPostFxPostFader(TrackId trackId, bool postFader);
+    bool isPostFxPostFader(TrackId trackId) const;
+
     /** @brief A device's engine enablement: its own bypassed flag combined
         with the owning track's chain power (insert-chain devices only). */
     bool isDeviceEffectivelyEnabled(const ChainNodePath& devicePath,

--- a/magda/daw/project/serialization/TrackSerializer.cpp
+++ b/magda/daw/project/serialization/TrackSerializer.cpp
@@ -136,6 +136,7 @@ juce::var ProjectSerializer::serializeTrackInfo(const TrackInfo& track) {
         postFxArray.add(serializeDeviceInfo(element.device));
     }
     obj->setProperty("postFxChainElements", juce::var(postFxArray));
+    obj->setProperty("postFxPostFader", track.chain.postFxPostFader);
 
     // Mixer-analysis section: rail-managed mini oscilloscope / spectrum devices.
     // Persist their per-device pluginState so UI settings (e.g. trace colour)
@@ -289,6 +290,15 @@ bool ProjectSerializer::deserializeTrackInfo(const juce::var& json, TrackInfo& o
     // Missing in projects saved before the chain power flag -> default true
     if (!obj->getProperty("chainEnabled").isVoid())
         outTrack.chain.enabled = static_cast<bool>(obj->getProperty("chainEnabled"));
+
+    // Missing in projects saved before the fader boundary existed (#2087) ->
+    // default post-fader, same as a new track. Those projects were compiled
+    // pre-fader, so a post-FX processor in one moves below the fader on load and
+    // the track sounds different. That is the fix rather than a regression: the
+    // section is post-fader now, and the switch below is how a project says
+    // otherwise.
+    if (!obj->getProperty("postFxPostFader").isVoid())
+        outTrack.chain.postFxPostFader = static_cast<bool>(obj->getProperty("postFxPostFader"));
 
     auto chainVar = obj->getProperty("chainElements");
     if (chainVar.isArray()) {

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -756,14 +756,25 @@ void Compiler::emitTrack(const TrackInfo& track) {
     if (track.chain.enabled)
         signal = emitElements(track.chain.fxChainElements, fxSite, signal);
 
-    const ChainSite postFxSite{track.id, INVALID_RACK_ID, INVALID_CHAIN_ID, ChainSegment::PostFx};
-    for (const auto& element : track.chain.postFxChainElements)
-        signal = emitDevice(element.device, postFxSite, signal);
+    // The post-FX stage and the mixer-analysis rail sit on whichever side of the
+    // fader the chain says (#2087). Emitted through one lambda called from one
+    // of two places rather than duplicated, so the two sides cannot drift into
+    // meaning different things.
+    auto emitPostFx = [&](ChainSignal in) {
+        const ChainSite postFxSite{track.id, INVALID_RACK_ID, INVALID_CHAIN_ID,
+                                   ChainSegment::PostFx};
+        for (const auto& element : track.chain.postFxChainElements)
+            in = emitDevice(element.device, postFxSite, in);
 
-    const ChainSite analysisSite{track.id, INVALID_RACK_ID, INVALID_CHAIN_ID,
-                                 ChainSegment::MixerAnalysis};
-    for (const auto& element : track.chain.mixerAnalysisElements)
-        signal = emitDevice(element.device, analysisSite, signal);
+        const ChainSite analysisSite{track.id, INVALID_RACK_ID, INVALID_CHAIN_ID,
+                                     ChainSegment::MixerAnalysis};
+        for (const auto& element : track.chain.mixerAnalysisElements)
+            in = emitDevice(element.device, analysisSite, in);
+        return in;
+    };
+
+    if (!track.chain.postFxPostFader)
+        signal = emitPostFx(signal);
 
     // --- fader, sends, meter, mute ---
     //
@@ -807,6 +818,17 @@ void Compiler::emitTrack(const TrackInfo& track) {
     const OpKey faderKey{track.id,          INVALID_RACK_ID,    INVALID_CHAIN_ID,
                          INVALID_DEVICE_ID, OpRole::TrackFader, 0};
     PortRef out{addOp(OpKind::Fader, faderKey, {signal.audio, noInput()}, {SignalKind::Audio}), 0};
+
+    // Post-fader, the stage runs between the fader and the post-fader sends, so
+    // a send tapped after the fader carries the post-FX processing with it and a
+    // meter dropped in here reads what leaves the track. The sidechain tap and
+    // the mute stay downstream of it either way, which is what keeps this from
+    // changing where a compressor keyed off this track listens.
+    if (track.chain.postFxPostFader) {
+        signal.audio = out;
+        signal = emitPostFx(signal);
+        out = signal.audio;
+    }
 
     emitSends(false, out);
 

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -760,6 +760,15 @@ void Compiler::emitTrack(const TrackInfo& track) {
     // fader the chain says (#2087). Emitted through one lambda called from one
     // of two places rather than duplicated, so the two sides cannot drift into
     // meaning different things.
+    // The master is pre-fader in both engines whatever the flag says, because
+    // Tracktion cannot represent anything else: `createMasterPluginNode` builds
+    // the whole of `getMasterPluginList()` and only then wraps it in
+    // `getMasterVolumePlugin()`, so a plugin after the master fader would need a
+    // change to TE's own graph builder. Honouring the flag here and not there
+    // would make the master the one place the two engines disagree, which is the
+    // failure this whole contract exists to prevent. See #2087.
+    const bool stagePostFader = track.chain.postFxPostFader && !isMaster;
+
     auto emitPostFx = [&](ChainSignal in) {
         const ChainSite postFxSite{track.id, INVALID_RACK_ID, INVALID_CHAIN_ID,
                                    ChainSegment::PostFx};
@@ -773,7 +782,7 @@ void Compiler::emitTrack(const TrackInfo& track) {
         return in;
     };
 
-    if (!track.chain.postFxPostFader)
+    if (!stagePostFader)
         signal = emitPostFx(signal);
 
     // --- fader, sends, meter, mute ---
@@ -824,7 +833,7 @@ void Compiler::emitTrack(const TrackInfo& track) {
     // meter dropped in here reads what leaves the track. The sidechain tap and
     // the mute stay downstream of it either way, which is what keeps this from
     // changing where a compressor keyed off this track listens.
-    if (track.chain.postFxPostFader) {
+    if (stagePostFader) {
         signal.audio = out;
         signal = emitPostFx(signal);
         out = signal.audio;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -417,6 +417,7 @@ target_sources(magda_juce_tests PRIVATE
     test_controller_track_level_write_juce.cpp
     # OSC control surfaces (issue #1757): a live receive thread and real packets
     test_osc_service_juce.cpp
+    test_post_fx_fader_order_juce.cpp
     test_track_midi_recording_preview_juce.cpp
     test_timeline_loop_activation_juce.cpp
     test_midi_signal_routing_juce.cpp

--- a/tests/goldens/plan/section-local-device-ids.txt
+++ b/tests/goldens/plan/section-local-device-ids.txt
@@ -10,10 +10,10 @@ ops=15 outputs=1
 [  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
 [  2] Device      det   T1/D3:deviceProcess            in=1:0,-,-          out=audio       deps=1
 [  3] Gain        det   T1/D3:deviceGain               in=2:0              out=audio       deps=1
-[  4] Device      det   T1/PF/D3:deviceProcess         in=3:0,-,-          out=audio       deps=1
-[  5] Gain        det   T1/PF/D3:deviceGain            in=4:0              out=audio       deps=1
-[  6] Device      det   T1/MA/D3:deviceProcess         in=5:0,-,-          out=audio       deps=1
-[  7] Fader       det   T1:trackFader                  in=6:0,-            out=audio       deps=1
+[  4] Fader       det   T1:trackFader                  in=3:0,-            out=audio       deps=1
+[  5] Device      det   T1/PF/D3:deviceProcess         in=4:0,-,-          out=audio       deps=1
+[  6] Gain        det   T1/PF/D3:deviceGain            in=5:0              out=audio       deps=1
+[  7] Device      det   T1/MA/D3:deviceProcess         in=6:0,-,-          out=audio       deps=1
 [  8] Meter       det   T1:trackMeter                  in=7:0              out=audio       deps=1
 [  9] Gain        det   T1:trackMute                   in=8:0              out=audio       deps=1
 [ 10] MixAudio    det   T-2:trackAudioInput            in=9:0              out=audio       deps=1
@@ -30,10 +30,10 @@ audioSlots=1 midiSlots=0 outputLatency=112
 [  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
 [  2] Device      T1/D3:deviceProcess            lat=16      ports=a0          inplace
 [  3] Gain        T1/D3:deviceGain               lat=16      ports=a0          inplace
-[  4] Device      T1/PF/D3:deviceProcess         lat=48      ports=a0          inplace
-[  5] Gain        T1/PF/D3:deviceGain            lat=48      ports=a0          inplace
-[  6] Device      T1/MA/D3:deviceProcess         lat=112     ports=a0          inplace
-[  7] Fader       T1:trackFader                  lat=112     ports=a0          inplace
+[  4] Fader       T1:trackFader                  lat=16      ports=a0          inplace
+[  5] Device      T1/PF/D3:deviceProcess         lat=48      ports=a0          inplace
+[  6] Gain        T1/PF/D3:deviceGain            lat=48      ports=a0          inplace
+[  7] Device      T1/MA/D3:deviceProcess         lat=112     ports=a0          inplace
 [  8] Meter       T1:trackMeter                  lat=112     ports=a0          inplace
 [  9] Gain        T1:trackMute                   lat=112     ports=a0          inplace
 [ 10] MixAudio    T-2:trackAudioInput            lat=112     ports=a0          inplace

--- a/tests/test_midi_signal_routing_juce.cpp
+++ b/tests/test_midi_signal_routing_juce.cpp
@@ -969,8 +969,13 @@ class MidiSignalRoutingTest final : public juce::UnitTest {
         expect(faderIdx >= 0, "VolumeAndPan fader must be on the track");
         expect(meterIdx >= 0, "LevelMeter must be on the track");
         expect(fxIdx < postFxIdx, "FX must come before post-FX");
-        expect(postFxIdx < faderIdx, "Post-FX must come before the fader");
-        expect(faderIdx < meterIdx, "Fader must come before the meter");
+        // Post-fader by default since #2087, which is the fader boundary
+        // de7a0b7c deferred. Which side the stage sits on is now
+        // TrackChain::postFxPostFader; both placements are covered in
+        // test_post_fx_fader_order_juce.cpp, and the native engine's half of the
+        // same contract in test_render_plan_compiler.cpp.
+        expect(faderIdx < postFxIdx, "Post-FX must come after the fader");
+        expect(postFxIdx < meterIdx, "The meter stays last");
 
         // Removing the post-FX device must drop its TE plugin.
         trackManager.removeDeviceFromChainByPath(postFxPath);

--- a/tests/test_post_fx_fader_order_juce.cpp
+++ b/tests/test_post_fx_fader_order_juce.cpp
@@ -80,6 +80,7 @@ class PostFxFaderOrderTest final : public juce::UnitTest {
             testTogglingMovesTheStage();
             testTheFaderReachesAPostFaderMeter();
             testSendsSitOnTheSideTheirFlagNames();
+            testMultiOutTrackGetsItsSendsToo();
         });
     }
 
@@ -375,6 +376,83 @@ class PostFxFaderOrderTest final : public juce::UnitTest {
         const int faderWithStage = faderIndex(*teTrack);
         expect(sendIndex(0) < faderWithStage, "a pre-fader send stays above the fader");
         expect(faderWithStage < sendIndex(1), "a post-fader send stays below it");
+    }
+
+    /// A multi-out track takes its own sync path, which returned from
+    /// syncTrackPlugins long before the send reconciliation ran. It therefore
+    /// had no AuxSendPlugins at all, while the native compiler emitted its sends
+    /// from the same model: the two engines disagreed about whether the sends
+    /// existed, not merely about where they sat. Ordering could not surface that,
+    /// because it can only place plugins that are already there.
+    void testMultiOutTrackGetsItsSendsToo() {
+        beginTest("A multi-out track's sends exist and straddle the fader");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto* bridge = wrapper.getAudioBridge();
+        if (bridge == nullptr)
+            return;
+
+        auto& tm = TrackManager::getInstance();
+
+        // A real multi-out child, built the way the model builds one: the source
+        // instrument declares its output pairs and activating one creates the
+        // child track and its link. A hand-made link is not enough — the sync
+        // path resolves the source device and returns early without it.
+        const auto sourceId = tm.createTrack("Source", TrackType::Audio);
+        DeviceInfo instrument;
+        instrument.name = "MultiOutSynth";
+        instrument.format = PluginFormat::Internal;
+        instrument.pluginId = "multisynth";
+        instrument.isInstrument = true;
+        instrument.multiOut.isMultiOut = true;
+        instrument.multiOut.totalOutputChannels = 4;
+        instrument.multiOut.outputPairs = {
+            {0, "Main 1-2", false, INVALID_TRACK_ID, 1, 2},
+            {1, "Out 3-4", false, INVALID_TRACK_ID, 3, 2},
+        };
+        const auto deviceId = tm.addDeviceToTrack(sourceId, instrument);
+        const auto trackId = tm.activateMultiOutPair(sourceId, deviceId, 1);
+        expect(trackId != INVALID_TRACK_ID, "the multi-out child must be created");
+        if (trackId == INVALID_TRACK_ID)
+            return;
+
+        auto* trackInfo = tm.getTrack(trackId);
+        expect(trackInfo != nullptr, "the child must exist in the model");
+        if (trackInfo == nullptr)
+            return;
+        expect(trackInfo->type == TrackType::MultiOut, "the child must take the multi-out path");
+
+        SendInfo pre;
+        pre.busIndex = 0;
+        pre.preFader = true;
+        SendInfo post;
+        post.busIndex = 1;
+        post.preFader = false;
+        trackInfo->sends.push_back(pre);
+        trackInfo->sends.push_back(post);
+
+        bridge->syncTrackPlugins(trackId);
+        auto* teTrack = bridge->getAudioTrack(trackId);
+        expect(teTrack != nullptr, "the track must reach the engine");
+        if (teTrack == nullptr)
+            return;
+
+        auto sendIndex = [&](int busIndex) {
+            for (int i = 0; i < teTrack->pluginList.size(); ++i)
+                if (auto* aux =
+                        dynamic_cast<tracktion::engine::AuxSendPlugin*>(teTrack->pluginList[i]);
+                    aux != nullptr && aux->getBusNumber() == busIndex)
+                    return i;
+            return -1;
+        };
+
+        expect(sendIndex(0) >= 0, "the pre-fader send must exist on a multi-out track");
+        expect(sendIndex(1) >= 0, "the post-fader send must exist on a multi-out track");
+
+        const int fader = faderIndex(*teTrack);
+        expect(fader >= 0, "the track must have a fader");
+        expect(sendIndex(0) < fader, "a pre-fader send taps above the fader");
+        expect(fader < sendIndex(1), "a post-fader send taps below it");
     }
 };
 

--- a/tests/test_post_fx_fader_order_juce.cpp
+++ b/tests/test_post_fx_fader_order_juce.cpp
@@ -1,0 +1,176 @@
+// The fader boundary on the Tracktion side (#2087).
+//
+// `de7a0b7c` introduced the post-FX stage and recorded "post-fader audio routing
+// (the fader boundary in PluginManagerSync)" as deferred. Until it landed,
+// `ensureVolumePluginPosition` treated `LevelMeterPlugin` as the only thing that
+// legitimately follows the fader and hoisted the fader past everything else, so
+// a meter dropped into post-FX read pre-fader audio and the always-on
+// measurement tap was demoted below the fader on the sync after it was
+// installed.
+//
+// The native engine's half of the same contract is asserted in
+// test_render_plan_compiler.cpp, against the plan rather than a plugin list.
+// Both have to agree, which is why the ordering is stated as a rule about the
+// fader rather than as an index in either.
+//
+// Lives in the JUCE target because it asserts on a real tracktion::engine::AudioTrack's
+// pluginList, which needs the shared engine.
+
+#include <juce_core/juce_core.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+#include "JuceTestStateGuard.hpp"
+#include "SharedTestEngine.hpp"
+#include "magda/daw/audio/AudioBridge.hpp"
+#include "magda/daw/audio/plugin_manager/PluginManager.hpp"
+#include "magda/daw/core/ChainNodePath.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+#include "magda/daw/engine/TracktionEngineWrapper.hpp"
+
+using namespace magda;
+
+namespace {
+
+/// The fader's own VolumeAndPanPlugin index, or -1. A Utility device is also a
+/// VolumeAndPanPlugin, so the first one from the end that TE owns is not a safe
+/// answer; the track fader is the one TE created with the track, which is the
+/// only one present in these fixtures.
+int faderIndex(tracktion::engine::AudioTrack& track) {
+    for (int i = 0; i < track.pluginList.size(); ++i)
+        if (dynamic_cast<tracktion::engine::VolumeAndPanPlugin*>(track.pluginList[i]) != nullptr)
+            return i;
+    return -1;
+}
+
+/// Index of the plugin the given device path is synced to, or -1. Identity by
+/// path rather than by name: a TE plugin reports the plugin's own name, not the
+/// DeviceInfo name the model gave it.
+int indexOfDevice(tracktion::engine::AudioTrack& track, PluginManager& pluginManager,
+                  const ChainNodePath& path) {
+    for (int i = 0; i < track.pluginList.size(); ++i)
+        if (pluginManager.getDevicePathForPlugin(track.pluginList[i]) == path)
+            return i;
+    return -1;
+}
+
+DeviceInfo makePostFxDevice() {
+    DeviceInfo device;
+    device.name = "Post Delay";
+    device.manufacturer = "MAGDA";
+    device.pluginId = "delay";
+    device.deviceType = DeviceType::Effect;
+    device.format = PluginFormat::Internal;
+    return device;
+}
+
+}  // namespace
+
+class PostFxFaderOrderTest final : public juce::UnitTest {
+  public:
+    PostFxFaderOrderTest() : juce::UnitTest("Post-FX Fader Order Tests", "magda") {}
+
+    void runTest() override {
+        magda::test::runWithCleanJuceState([this] {
+            testPostFaderIsDefault();
+            testPreFaderPlacesTheStageBeforeTheFader();
+            testTogglingMovesTheStage();
+        });
+    }
+
+  private:
+    struct Fixture {
+        TrackId trackId = INVALID_TRACK_ID;
+        tracktion::engine::AudioTrack* teTrack = nullptr;
+        AudioBridge* bridge = nullptr;
+        ChainNodePath devicePath;
+
+        int deviceIndex() const {
+            return indexOfDevice(*teTrack, bridge->getPluginManager(), devicePath);
+        }
+        int fader() const {
+            return faderIndex(*teTrack);
+        }
+        void resync() const {
+            bridge->syncTrackPlugins(trackId);
+        }
+    };
+
+    Fixture makeTrackWithPostFxDevice() {
+        Fixture f;
+        auto& wrapper = magda::test::getSharedEngine();
+        f.bridge = wrapper.getAudioBridge();
+        if (f.bridge == nullptr)
+            return f;
+
+        auto& tm = TrackManager::getInstance();
+        f.trackId = tm.createTrack("PostFx", TrackType::Audio);
+        const auto deviceId = tm.addDeviceToPostFx(f.trackId, makePostFxDevice());
+        f.devicePath = ChainNodePath::postFxDevice(f.trackId, deviceId);
+        f.bridge->syncTrackPlugins(f.trackId);
+        f.teTrack = f.bridge->getAudioTrack(f.trackId);
+        return f;
+    }
+
+    void testPostFaderIsDefault() {
+        beginTest("A post-FX device sits after the fader by default");
+
+        auto f = makeTrackWithPostFxDevice();
+        expect(f.teTrack != nullptr, "the track must reach the engine");
+        if (f.teTrack == nullptr)
+            return;
+
+        expect(TrackManager::getInstance().getTrack(f.trackId)->chain.postFxPostFader,
+               "a new chain is post-fader");
+
+        expect(f.fader() >= 0, "the track must have a fader");
+        expect(f.deviceIndex() >= 0, "the post-FX device must reach the plugin list");
+        expect(f.fader() < f.deviceIndex(), "the fader must come before the post-FX device");
+    }
+
+    void testPreFaderPlacesTheStageBeforeTheFader() {
+        beginTest("A pre-fader chain puts the stage back above the fader");
+
+        auto f = makeTrackWithPostFxDevice();
+        if (f.teTrack == nullptr)
+            return;
+
+        TrackManager::getInstance().setPostFxPostFader(f.trackId, false);
+        f.resync();
+
+        expect(f.fader() >= 0 && f.deviceIndex() >= 0, "both must be present");
+        expect(f.deviceIndex() < f.fader(), "a pre-fader stage feeds the fader");
+    }
+
+    void testTogglingMovesTheStage() {
+        beginTest("Toggling moves the stage across the fader and back");
+
+        auto f = makeTrackWithPostFxDevice();
+        if (f.teTrack == nullptr)
+            return;
+
+        auto& tm = TrackManager::getInstance();
+
+        tm.setPostFxPostFader(f.trackId, false);
+        f.resync();
+        expect(f.deviceIndex() < f.fader(), "pre-fader after the first toggle");
+
+        tm.setPostFxPostFader(f.trackId, true);
+        f.resync();
+        expect(f.fader() < f.deviceIndex(), "post-fader after toggling back");
+
+        // The meter stays last whichever side the stage is on: it is what TE
+        // reads for the track's own level display, and a stage that got between
+        // the meter and the output would make the two disagree.
+        const int meter = [&] {
+            for (int i = 0; i < f.teTrack->pluginList.size(); ++i)
+                if (dynamic_cast<tracktion::engine::LevelMeterPlugin*>(f.teTrack->pluginList[i]) !=
+                    nullptr)
+                    return i;
+            return -1;
+        }();
+        if (meter >= 0)
+            expect(meter == f.teTrack->pluginList.size() - 1, "the level meter stays last");
+    }
+};
+
+static PostFxFaderOrderTest postFxFaderOrderTest;

--- a/tests/test_post_fx_fader_order_juce.cpp
+++ b/tests/test_post_fx_fader_order_juce.cpp
@@ -79,6 +79,7 @@ class PostFxFaderOrderTest final : public juce::UnitTest {
             testPreFaderPlacesTheStageBeforeTheFader();
             testTogglingMovesTheStage();
             testTheFaderReachesAPostFaderMeter();
+            testSendsSitOnTheSideTheirFlagNames();
         });
     }
 
@@ -304,6 +305,76 @@ class PostFxFaderOrderTest final : public juce::UnitTest {
         expect(preFaderAtSilence.bufferPeak < 0.01f, "the fader still silences the track output");
         expect(preFaderAtSilence.meterDb > preFaderAtUnity.meterDb - 1.0f,
                "a pre-fader meter reads the same whatever the fader does");
+    }
+
+    /// Sends are sequenced across the fader by their own flag now. They used to
+    /// be appended and never moved, which only looked consistent because the
+    /// fader was hoisted past everything: every send ended up above it whatever
+    /// SendInfo::preFader said, while the native compiler has always split on it.
+    ///
+    /// Pinned because a send crossing the fader is as audible as the meter fix
+    /// this PR is about, and because without the sequencing the side a send
+    /// lands on depends on whether the track owns a post-FX device.
+    void testSendsSitOnTheSideTheirFlagNames() {
+        beginTest("A send sits on the side of the fader its flag names");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto* bridge = wrapper.getAudioBridge();
+        if (bridge == nullptr)
+            return;
+
+        auto& tm = TrackManager::getInstance();
+        const auto trackId = tm.createTrack("Sends", TrackType::Audio);
+
+        SendInfo pre;
+        pre.busIndex = 0;
+        pre.preFader = true;
+        SendInfo post;
+        post.busIndex = 1;
+        post.preFader = false;
+
+        auto* trackInfo = tm.getTrack(trackId);
+        expect(trackInfo != nullptr, "the track must exist in the model");
+        if (trackInfo == nullptr)
+            return;
+        trackInfo->sends.push_back(pre);
+        trackInfo->sends.push_back(post);
+
+        bridge->syncTrackPlugins(trackId);
+        auto* teTrack = bridge->getAudioTrack(trackId);
+        expect(teTrack != nullptr, "the track must reach the engine");
+        if (teTrack == nullptr)
+            return;
+
+        auto sendIndex = [&](int busIndex) {
+            for (int i = 0; i < teTrack->pluginList.size(); ++i)
+                if (auto* aux =
+                        dynamic_cast<tracktion::engine::AuxSendPlugin*>(teTrack->pluginList[i]);
+                    aux != nullptr && aux->getBusNumber() == busIndex)
+                    return i;
+            return -1;
+        };
+
+        const int fader = faderIndex(*teTrack);
+        expect(fader >= 0, "the track must have a fader");
+        expect(sendIndex(0) >= 0 && sendIndex(1) >= 0, "both sends must reach the plugin list");
+        expect(sendIndex(0) < fader, "a pre-fader send taps above the fader");
+        expect(fader < sendIndex(1), "a post-fader send taps below it");
+
+        // And the side must not depend on the post-FX stage being occupied,
+        // which is the failure mode the sequencing exists to rule out.
+        DeviceInfo levels;
+        levels.name = "Levels";
+        levels.manufacturer = "MAGDA";
+        levels.pluginId = daw::audio::LevelsPlugin::xmlTypeName;
+        levels.deviceType = DeviceType::Analysis;
+        levels.format = PluginFormat::Internal;
+        tm.addDeviceToPostFx(trackId, levels);
+        bridge->syncTrackPlugins(trackId);
+
+        const int faderWithStage = faderIndex(*teTrack);
+        expect(sendIndex(0) < faderWithStage, "a pre-fader send stays above the fader");
+        expect(faderWithStage < sendIndex(1), "a post-fader send stays below it");
     }
 };
 

--- a/tests/test_post_fx_fader_order_juce.cpp
+++ b/tests/test_post_fx_fader_order_juce.cpp
@@ -23,6 +23,7 @@
 #include "SharedTestEngine.hpp"
 #include "magda/daw/audio/AudioBridge.hpp"
 #include "magda/daw/audio/plugin_manager/PluginManager.hpp"
+#include "magda/daw/audio/plugins/LevelsPlugin.hpp"
 #include "magda/daw/core/ChainNodePath.hpp"
 #include "magda/daw/core/TrackManager.hpp"
 #include "magda/daw/engine/TracktionEngineWrapper.hpp"
@@ -30,6 +31,9 @@
 using namespace magda;
 
 namespace {
+
+constexpr double kSampleRate = 48000.0;
+constexpr int kBlockSize = 512;
 
 /// The fader's own VolumeAndPanPlugin index, or -1. A Utility device is also a
 /// VolumeAndPanPlugin, so the first one from the end that TE owns is not a safe
@@ -74,6 +78,7 @@ class PostFxFaderOrderTest final : public juce::UnitTest {
             testPostFaderIsDefault();
             testPreFaderPlacesTheStageBeforeTheFader();
             testTogglingMovesTheStage();
+            testTheFaderReachesAPostFaderMeter();
         });
     }
 
@@ -170,6 +175,135 @@ class PostFxFaderOrderTest final : public juce::UnitTest {
         }();
         if (meter >= 0)
             expect(meter == f.teTrack->pluginList.size() - 1, "the level meter stays last");
+    }
+
+    /// The acceptance criterion the ordering assertions above are a proxy for:
+    /// pull the fader down and the reading has to follow it.
+    ///
+    /// Driven by walking the synced plugin list in order and applying each
+    /// plugin to one buffer, which is what a linear TE plugin list does to a
+    /// block. That keeps the test on the real ordering the sync produced rather
+    /// than on a graph assembled here, and it needs no transport or render.
+    void testTheFaderReachesAPostFaderMeter() {
+        beginTest("A post-fader Levels device follows the track fader");
+
+        auto& wrapper = magda::test::getSharedEngine();
+        auto* bridge = wrapper.getAudioBridge();
+        if (bridge == nullptr)
+            return;
+
+        auto& tm = TrackManager::getInstance();
+        const auto trackId = tm.createTrack("Levels", TrackType::Audio);
+
+        DeviceInfo levels;
+        levels.name = "Levels";
+        levels.manufacturer = "MAGDA";
+        levels.pluginId = daw::audio::LevelsPlugin::xmlTypeName;
+        levels.deviceType = DeviceType::Analysis;
+        levels.format = PluginFormat::Internal;
+        const auto levelsId = tm.addDeviceToPostFx(trackId, levels);
+
+        bridge->syncTrackPlugins(trackId);
+        auto* teTrack = bridge->getAudioTrack(trackId);
+        expect(teTrack != nullptr, "the track must reach the engine");
+        if (teTrack == nullptr)
+            return;
+
+        auto plugin = bridge->getPlugin(ChainNodePath::postFxDevice(trackId, levelsId));
+        auto* levelsPlugin = dynamic_cast<daw::audio::LevelsPlugin*>(plugin.get());
+        expect(levelsPlugin != nullptr, "the Levels device must reach the engine");
+        if (levelsPlugin == nullptr)
+            return;
+
+        // Measurement is gated on the meter being on screen.
+        levelsPlugin->setActive(true);
+
+        auto* fader = dynamic_cast<tracktion::engine::VolumeAndPanPlugin*>(
+            teTrack->pluginList[faderIndex(*teTrack)]);
+        expect(fader != nullptr, "the track must have a fader");
+        if (fader == nullptr)
+            return;
+
+        for (int i = 0; i < teTrack->pluginList.size(); ++i) {
+            tracktion::engine::PluginInitialisationInfo info;
+            info.startTime = tracktion::TimePosition();
+            info.sampleRate = kSampleRate;
+            info.blockSizeSamples = kBlockSize;
+            teTrack->pluginList[i]->baseClassInitialise(info);
+        }
+
+        // One block of full-scale DC through the plugin list in order, which is
+        // what TE does to a block for a linear list. DC rather than a tone
+        // because the assertion is about how much signal survives the fader, and
+        // a constant makes the sample peak the gain itself.
+        auto runBlock = [&] {
+            juce::AudioBuffer<float> buffer(2, kBlockSize);
+            for (int ch = 0; ch < buffer.getNumChannels(); ++ch)
+                juce::FloatVectorOperations::fill(buffer.getWritePointer(ch), 1.0f, kBlockSize);
+
+            tracktion::engine::MidiMessageArray midi;
+            tracktion::engine::PluginRenderContext context(
+                &buffer, juce::AudioChannelSet::stereo(), 0, kBlockSize, &midi, 0.0,
+                tracktion::TimeRange(), true, false, false, true);
+
+            for (int i = 0; i < teTrack->pluginList.size(); ++i)
+                teTrack->pluginList[i]->applyToBuffer(context);
+
+            return buffer.getMagnitude(0, kBlockSize);
+        };
+
+        struct Reading {
+            float bufferPeak = 0.0f;
+            float meterDb = 0.0f;
+        };
+
+        auto readAt = [&](float sliderPos) {
+            fader->setSliderPos(sliderPos);
+
+            // The fader ramps its gain across a block rather than stepping, so
+            // the first block after a move still peaks at the old gain. Settle
+            // it, then reset the meter and measure one clean block.
+            for (int warmUp = 0; warmUp < 8; ++warmUp)
+                runBlock();
+
+            levelsPlugin->requestReset();
+            Reading reading;
+            reading.bufferPeak = runBlock();
+            reading.meterDb = levelsPlugin->getSnapshot().samplePeakDb;
+            return reading;
+        };
+
+        const auto atUnity = readAt(tracktion::engine::decibelsToVolumeFaderPosition(0.0f));
+        const auto atSilence = readAt(0.0f);
+
+        // The buffer assertion first: if the fader is not attenuating at all
+        // then the meter reading says nothing about where it sits.
+        expect(atUnity.bufferPeak > 0.5f, "at unity the signal must survive the fader");
+        expect(atSilence.bufferPeak < 0.01f, "at the bottom the fader must silence the signal");
+
+        expect(atUnity.meterDb > -6.0f, "at unity the meter must see the signal");
+        expect(atSilence.meterDb < atUnity.meterDb - 40.0f,
+               "pulling the fader to silence must take the signal out of the meter");
+
+        // And the other direction, which is what makes the assertion above mean
+        // something: put the stage back above the fader and the meter stops
+        // following it. This is the reported bug, reproduced on demand.
+        tm.setPostFxPostFader(trackId, false);
+        bridge->syncTrackPlugins(trackId);
+        for (int i = 0; i < teTrack->pluginList.size(); ++i) {
+            tracktion::engine::PluginInitialisationInfo info;
+            info.startTime = tracktion::TimePosition();
+            info.sampleRate = kSampleRate;
+            info.blockSizeSamples = kBlockSize;
+            teTrack->pluginList[i]->baseClassInitialise(info);
+        }
+
+        const auto preFaderAtUnity = readAt(tracktion::engine::decibelsToVolumeFaderPosition(0.0f));
+        const auto preFaderAtSilence = readAt(0.0f);
+
+        expect(preFaderAtSilence.bufferPeak < 0.01f, "the fader still silences the track output");
+        expect(preFaderAtSilence.meterDb > preFaderAtUnity.meterDb - 1.0f,
+               "a pre-fader meter reads the same whatever the fader does");
     }
 };
 

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -1499,6 +1499,27 @@ TEST_CASE("The post-FX stage sits on the side of the fader the chain says",
         CHECK(inputOp(plan, taps.front(), 0) != deviceOutput(plan, 8));
     }
 
+    SECTION("the master stays pre-fader whatever the flag says") {
+        // Tracktion cannot represent a post-fader master stage:
+        // createMasterPluginNode builds the whole of getMasterPluginList() and
+        // only then wraps it in getMasterVolumePlugin(). Honouring the flag here
+        // and not there would make the master the one place the engines
+        // disagree, which is the failure this contract exists to prevent.
+        auto master = makeMaster();
+        master.chain.postFxPostFader = true;
+        master.chain.postFxChainElements.push_back(PostFxChainElement{makeEffect(11)});
+
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        const auto plan = magda::engine::compileRenderPlan(tracks, master, withoutDeviceMeters());
+        requireWellFormed(plan);
+
+        // Two faders: track 1's, then the master's. The master's post-FX device
+        // must feed the second, not read from it.
+        const auto faders = opsWithRole(plan, OpRole::TrackFader);
+        REQUIRE(faders.size() == 2);
+        CHECK(inputOp(plan, faders.back(), 0) == deviceOutput(plan, 11));
+    }
+
     SECTION("the mixer-analysis rail follows the post-FX stage") {
         std::vector<TrackInfo> tracks{makeTrack(1)};
         auto analysis = makeEffect(9);

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -87,6 +87,30 @@ magda::engine::OpId rawInputOp(const RenderPlan& plan, magda::engine::OpId op, s
     return slot >= inputs.size() ? magda::engine::INVALID_OP_ID : inputs[slot].op;
 }
 
+/// The op a device's audio actually leaves by. A non-transparent device emits a
+/// process op and then its wet/dry gain, so the next stage reads the gain;
+/// a transparent tap (analysis devices) emits the process op alone.
+magda::engine::OpId deviceOutput(const RenderPlan& plan, DeviceId deviceId) {
+    auto found = magda::engine::INVALID_OP_ID;
+    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+        const auto& key = plan.ops[i].key;
+        if (key.deviceId == deviceId &&
+            (key.role == OpRole::DeviceProcess || key.role == OpRole::DeviceGain))
+            found = static_cast<magda::engine::OpId>(i);
+    }
+    return found;
+}
+
+/// The op feeding a device's audio input.
+magda::engine::OpId deviceInput(const RenderPlan& plan, DeviceId deviceId) {
+    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+        const auto& key = plan.ops[i].key;
+        if (key.deviceId == deviceId && key.role == OpRole::DeviceProcess)
+            return inputOp(plan, static_cast<magda::engine::OpId>(i), 0);
+    }
+    return magda::engine::INVALID_OP_ID;
+}
+
 /// Every fixture must compile to a structurally sound plan; this is asserted
 /// alongside whatever each test is actually about.
 void requireWellFormed(const RenderPlan& plan) {
@@ -1397,6 +1421,96 @@ TEST_CASE("validatePlan enforces liveness provenance", "[engine][plan][validate]
         plan.ops.push_back(input);
 
         CHECK(magda::engine::validatePlan(plan).empty());
+    }
+}
+
+TEST_CASE("The post-FX stage sits on the side of the fader the chain says",
+          "[engine][plan][compiler][postfx]") {
+    // The routing contract behind #2087, asserted as reachability rather than as
+    // op indices: what matters is which signal each stage reads, not where the
+    // compiler happened to emit it.
+    auto build = [](bool postFader) {
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        tracks[0].chain.postFxPostFader = postFader;
+        tracks[0].chain.postFxChainElements.push_back(PostFxChainElement{makeEffect(8)});
+        return magda::engine::compileRenderPlan(tracks, makeMaster(), withoutDeviceMeters());
+    };
+
+    SECTION("post-fader by default: the fader feeds the post-FX device") {
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        CHECK(tracks[0].chain.postFxPostFader);
+    }
+
+    SECTION("post-fader: the device reads the fader, and the meter reads the device") {
+        const auto plan = build(true);
+        requireWellFormed(plan);
+
+        // Track 1's fader is the first; the master has one too.
+        const auto trackFader = opsWithRole(plan, OpRole::TrackFader).front();
+        const auto meter = opsWithRole(plan, OpRole::TrackMeter).front();
+
+        CHECK(deviceInput(plan, 8) == trackFader);
+        CHECK(inputOp(plan, meter, 0) == deviceOutput(plan, 8));
+    }
+
+    SECTION("pre-fader: the device feeds the fader instead") {
+        const auto plan = build(false);
+        requireWellFormed(plan);
+
+        const auto trackFader = opsWithRole(plan, OpRole::TrackFader).front();
+        CHECK(inputOp(plan, trackFader, 0) == deviceOutput(plan, 8));
+    }
+
+    SECTION("post-fader: a post-fader send carries the post-FX processing") {
+        // "Post-fader" has to mean after everything in the channel strip, or a
+        // send and the track output disagree about what the track sounds like.
+        std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+        tracks[0].chain.postFxChainElements.push_back(PostFxChainElement{makeEffect(8)});
+        SendInfo send;
+        send.busIndex = 0;
+        send.preFader = false;
+        send.destTrackId = 2;
+        tracks[0].sends.push_back(send);
+
+        const auto plan =
+            magda::engine::compileRenderPlan(tracks, makeMaster(), withoutDeviceMeters());
+        requireWellFormed(plan);
+
+        const auto taps = opsWithRole(plan, OpRole::SendTap);
+        REQUIRE(taps.size() == 1);
+        CHECK(inputOp(plan, taps.front(), 0) == deviceOutput(plan, 8));
+    }
+
+    SECTION("post-fader: a pre-fader send does not") {
+        std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+        tracks[0].chain.postFxChainElements.push_back(PostFxChainElement{makeEffect(8)});
+        SendInfo send;
+        send.busIndex = 0;
+        send.preFader = true;
+        send.destTrackId = 2;
+        tracks[0].sends.push_back(send);
+
+        const auto plan =
+            magda::engine::compileRenderPlan(tracks, makeMaster(), withoutDeviceMeters());
+        requireWellFormed(plan);
+
+        const auto taps = opsWithRole(plan, OpRole::SendTap);
+        REQUIRE(taps.size() == 1);
+        CHECK(inputOp(plan, taps.front(), 0) != deviceOutput(plan, 8));
+    }
+
+    SECTION("the mixer-analysis rail follows the post-FX stage") {
+        std::vector<TrackInfo> tracks{makeTrack(1)};
+        auto analysis = makeEffect(9);
+        analysis.deviceType = DeviceType::Analysis;
+        tracks[0].chain.mixerAnalysisElements.push_back(PostFxChainElement{analysis});
+
+        const auto plan =
+            magda::engine::compileRenderPlan(tracks, makeMaster(), withoutDeviceMeters());
+        requireWellFormed(plan);
+
+        const auto trackFader = opsWithRole(plan, OpRole::TrackFader).front();
+        CHECK(deviceInput(plan, 9) == trackFader);
     }
 }
 


### PR DESCRIPTION
Closes #2087.

The Levels analyzer kept showing a track's signal with the fader pulled to `-inf`, and clip gain still moved the reading, because the post-FX stage was compiled before the fader. In both engines.

## What was actually there

Worth stating, because the naming has been misleading for two releases.

`de7a0b7c`, the commit that introduced the section, ends with: "Post-fader audio routing (the fader boundary in PluginManagerSync) and the post-fx panel UI are **deferred**." #1335 stated the shipped routing as `flatten(fx) -> postFx -> VolumeAndPan -> LevelMeter`, and #730 asked for the section so users could put "dithering, final limiting, metering" after the FX chain. So "post-FX" meant *after the FX chain*, the fader boundary was a known gap, and the stage has always held real processing that renders.

What drifted is the wording. `PostFxPanelContent.hpp:18`, `TrackChain.hpp:15` and `TrackManager.cpp:2071/2094` all call it post-fader; only `TrackChain.hpp:34` said what was true. This PR is the deferred boundary, plus the switch that says which side.

## The contract

`TrackChain::postFxPostFader`, default true, read by both compilers rather than an ordering each hardcodes and drifts on:

```
post-fader (default):  fx -> preFaderSends -> Fader -> postFx -> mixerAnalysis -> postFaderSends -> Meter -> Mute
pre-fader:             fx -> postFx -> mixerAnalysis -> preFaderSends -> Fader -> postFaderSends -> Meter -> Mute
```

One switch per chain. Per-device placement is the v1 upgrade; both compilers already partition on a value rather than a constant, so widening it is a widening rather than a rewrite.

**Native.** `PlanCompiler` emits the post-FX stage and the mixer-analysis rail through one lambda called from one of two places, so the two sides cannot come to mean different things. Post-fader it runs between the fader and the post-fader sends, which keeps the sidechain tap and the mute downstream of it and leaves where a keyed compressor listens unchanged. A post-fader send therefore carries the post-FX processing and a pre-fader send does not, which is asserted both ways.

**Tracktion.** `ensureVolumePluginPosition` treated `LevelMeterPlugin` as the only thing that legitimately follows the fader and hoisted the fader past everything else. That is what made a post-fader stage unrepresentable. It now places the fader against a set of plugins that belong after it.

## A second thing that set was hiding

`PluginManagerMeasurement.cpp:62` appends the always-on `TrackMeasurementPlugin` at the end of the chain, commented "Post-fader: append at the very end of the chain (after volume/pan and TE's level meter)". The next chain sync hoisted the fader past it, so it was pre-fader from that moment on — and it is what the mixing agent and `MixAnalysisService` read.

It is in the post-fader set here, unconditionally rather than under the post-FX flag, because its placement should not depend on whether the user happens to own a post-FX device. Same root cause, one line, and leaving it would have left an inconsistency keyed on an unrelated fact.

## Behaviour change, for the release notes

**The post-FX stage.** A project saved before this compiled its stage pre-fader and loads with it below the fader. A meter there starts telling the truth. A processor there now takes the fader's output, so the track sounds different. `postFxPostFader: false` is how a project asks for the old routing back — though not yet from the UI, which is #2094.

**Post-fader sends.** `SendInfo::preFader` is read by `PlanCompiler` and by nothing else: on the TE side the flag is serialized, round-tripped through DAWproject, and then ignored when the `AuxSendPlugin` is placed. Sends were appended and never sequenced, which looked consistent only because the fader was hoisted past them all, so every send tapped pre-fader audio whatever its flag said. They are sequenced by the flag now, so a post-fader send follows the fader for the first time — which is what it has always claimed to do. Sends default to post-fader, so this reaches any project using one.

## Tests

- **Plan ordering** as reachability rather than op indices: which signal each stage reads, on both placements, plus the send tap on each side of the boundary and the mixer-analysis rail following the stage.
- **Tracktion plugin-list ordering** across a toggle, in the JUCE target, identifying devices by path rather than by name.
- **Observable level behaviour**, which is the acceptance criterion the ordering assertions stand in for: a block of full-scale DC walked through the synced plugin list in order, read off the `LevelsPlugin` snapshot at unity and at silence. Two things that shape it: the fader ramps its gain across a block rather than stepping, so the reading is taken after the ramp settles; and the buffer peak is asserted alongside the meter, because if the fader is not attenuating at all then the meter reading says nothing about which side of it the meter sits on.
- **The negative case**, which is what makes the rest mean anything: with the stage put back pre-fader, the meter reads the same whatever the fader does. The reported bug, reproduced on demand.
- The old pre-fader assertion in `test_midi_signal_routing_juce.cpp` updated to the new contract.
- Plan golden regenerated. The diff is the fader moving up four ops; total latency unchanged.

Built locally. Catch2 2580 passed / 13 skipped / 0 failed, JUCE target all passed, `make format` and `make lint-changed` clean.

## Follow-up

#2094 — the toggle has no UI, so putting the stage back pre-fader currently means hand-editing the project file.
