### PR TITLE
Differ property tests over random edit sequences (#2077)

### DIFF
--- a/docs/architecture/native-engine.md
+++ b/docs/architecture/native-engine.md
@@ -668,6 +668,13 @@ how the signal got there, never where it arrives. Where an edge was refused a fa
 line anywhere upstream starts flushed, the step is a declared divergence and the bound does not
 apply, which the property reads off the pass's own report rather than guessing.
 
+That exemption is also how the bound could quietly stop existing, so how often it is reached is
+counted rather than assumed, over the tracks the edit could reach and among those the ones where
+something moved: a track the edit cannot touch renders the constant it rendered before, and a
+flat window meets any bound at all. The deep sweep measures 7111 bounded transients on reached
+tracks, 1647 of them moving, against 10808 exempt, and the ordinary run asserts all three counts
+are non-zero.
+
 The ordinary run sweeps a few hundred sequences of fourteen edits in about eight seconds. The
 deep sweep behind `./magda_tests "[deep]"` is four thousand sequences of forty and takes eight
 minutes; it is what to reach for when the differ or the crossfade pass changes. Both were checked

--- a/docs/architecture/native-engine.md
+++ b/docs/architecture/native-engine.md
@@ -673,9 +673,12 @@ deep sweep behind `./magda_tests "[deep]"` is four thousand sequences of forty a
 minutes; it is what to reach for when the differ or the crossfade pass changes. Both were checked
 against a broken engine before being believed: carrying an op whose inputs had moved, never
 carrying a delay line, one sample too much compensation on every edge, and a fade taking a
-changed op as its old side are each caught, three of them as a sequence of one or two edits.
-Neither sweep has found an engine bug. What they did find, twice, was the harness calling an edit
-unrelated when it was not.
+changed op as its old side are each caught, three of them as a sequence of one or two edits, and
+so are a store that leaks an instance nothing names and a device that reports more latency than
+it delays by. Neither sweep has found an engine bug. What they found instead, three times, was
+the harness: twice calling an edit unrelated when it was not, and once letting a generated device
+claim a latency its own ring could not honour, which would have left every render measuring a
+graph that was misaligned in fact while every latency assertion above it passed.
 
 What the rig still does not cover is the rest of
 [#1896](https://github.com/Conceptual-Machines/magda-core/issues/1896): no case carries a real

--- a/docs/architecture/native-engine.md
+++ b/docs/architecture/native-engine.md
@@ -34,7 +34,7 @@ is. When the two disagree, the headers are right and this file is stale.
 | External plugin hosting and hardware inserts | [#1893](https://github.com/Conceptual-Machines/magda-core/issues/1893) | not started |
 | Clip launcher and session playback | [#1894](https://github.com/Conceptual-Machines/magda-core/issues/1894) | not started |
 | Live input, monitoring, recording | [#1895](https://github.com/Conceptual-Machines/magda-core/issues/1895) | not started |
-| Null-diff validation harness | [#1896](https://github.com/Conceptual-Machines/magda-core/issues/1896) | rig built, 8 slices open |
+| Null-diff validation harness | [#1896](https://github.com/Conceptual-Machines/magda-core/issues/1896) | rig built, 3 of 8 slices done |
 | Cutover: bridge rewrite, dual-engine release | [#1897](https://github.com/Conceptual-Machines/magda-core/issues/1897) | not started |
 
 Engine core, slice by slice: plan IR and compiler ([#2010](https://github.com/Conceptual-Machines/magda-core/issues/2010)),
@@ -56,11 +56,11 @@ warp, beat detection and loop info ([#2038](https://github.com/Conceptual-Machin
 MIDI clips ([#2039](https://github.com/Conceptual-Machines/magda-core/issues/2039)),
 the null-diff corpus ([#2040](https://github.com/Conceptual-Machines/magda-core/issues/2040)).
 
-Validation, slice by slice, all open: whole-project cases and the tiered oracle
+Validation, slice by slice. Done: whole-project cases and the tiered oracle
 ([#2075](https://github.com/Conceptual-Machines/magda-core/issues/2075)),
 plan goldens ([#2076](https://github.com/Conceptual-Machines/magda-core/issues/2076)),
-differ property tests ([#2077](https://github.com/Conceptual-Machines/magda-core/issues/2077)),
-the block-size gate ([#2078](https://github.com/Conceptual-Machines/magda-core/issues/2078)),
+differ property tests ([#2077](https://github.com/Conceptual-Machines/magda-core/issues/2077)).
+Open: the block-size gate ([#2078](https://github.com/Conceptual-Machines/magda-core/issues/2078)),
 migrators ([#2079](https://github.com/Conceptual-Machines/magda-core/issues/2079)),
 the DAWproject cross-check ([#2080](https://github.com/Conceptual-Machines/magda-core/issues/2080)),
 the real-project corpus ([#2081](https://github.com/Conceptual-Machines/magda-core/issues/2081)),
@@ -636,6 +636,47 @@ which wants a `PluginManager` and the device layer behind it, and writing those 
 into the leg would be the second sync the corpus refuses to have. They belong with the rest of
 the routing graph, in [#1892](https://github.com/Conceptual-Machines/magda-core/issues/1892).
 
+**Properties over generated edits**
+([#2077](https://github.com/Conceptual-Machines/magda-core/issues/2077)) are the same argument
+turned on the differ. The corpus compares two engines over projects somebody wrote down; this
+generates the projects instead, because the differ's inputs are pairs of plans and the pairs that
+matter are the ones nobody thought to write. A vocabulary of the edits a user can perform, a
+seeded generator that strings them together against the project as it stands, and every edit
+addressed by the id of what it touches rather than by where that sits, so any subsequence of a
+failing sequence still runs and a failure is shrunk to the edits that caused it before it is
+printed. It lives in `tests/PlanEdit*` and runs in `magda_tests`, since none of it needs a
+`te::Edit`.
+
+Four properties. **Carry** is checked both ways against a signature built from the two plans
+alone, so a differ that carried nothing fails it as surely as one that carried too much, and the
+runtime half of the same decision is predicted from the plans and their layouts and required to
+match the delay lines and fade ramps the executor says it adopted. **Retirement** is that
+`carriedFrom` is a partial injection whose complement is exactly `retired`, and that the store
+destroys an instance only once neither the live plan nor the model names it. **Alignment** is
+that every fan-in has all its inputs arriving at one latency with at least one of them waiting
+for nothing, and that a track no edit reached reports the latency it did before. **The null** is
+the one that catches the most: every track carries an analysis device that keeps what passed
+through it, the sequence is rendered once whole and once with every edit that cannot reach a
+chosen track removed, and the two recordings of that track have to be equal sample for sample,
+across a different number of swaps and a different amount of state carried over them.
+
+What is asserted about the track an edit does change is a bound and a destination rather than a
+null. No sample may move by more than a fade's worth of the transient in one step where the pass
+reported it faded every edge it moved, and once the transient is over the session has to render
+exactly what a session that had just opened the same project renders: carried state may decide
+how the signal got there, never where it arrives. Where an edge was refused a fade, or a delay
+line anywhere upstream starts flushed, the step is a declared divergence and the bound does not
+apply, which the property reads off the pass's own report rather than guessing.
+
+The ordinary run sweeps a few hundred sequences of fourteen edits in about eight seconds. The
+deep sweep behind `./magda_tests "[deep]"` is four thousand sequences of forty and takes eight
+minutes; it is what to reach for when the differ or the crossfade pass changes. Both were checked
+against a broken engine before being believed: carrying an op whose inputs had moved, never
+carrying a delay line, one sample too much compensation on every edge, and a fade taking a
+changed op as its old side are each caught, three of them as a sequence of one or two edits.
+Neither sweep has found an engine bug. What they did find, twice, was the harness calling an edit
+unrelated when it was not.
+
 What the rig still does not cover is the rest of
 [#1896](https://github.com/Conceptual-Machines/magda-core/issues/1896): no case carries a real
 device, because nothing yet runs one under both engines; the interactive paths have no runner;
@@ -666,10 +707,10 @@ Worth knowing before reading the code and wondering where something is:
   engine on rather than with implementing it.
 - **The rest of the validation harness**
   ([#1896](https://github.com/Conceptual-Machines/magda-core/issues/1896)). The rig exists and
-  section 7 describes it. Missing: whole-project cases and the tiers above them (#2075), plan
-  goldens (#2076), differ property tests (#2077), the block-size gate (#2078), the migrators
-  (#2079), the DAWproject cross-check (#2080), a real-project corpus (#2081), and the parity
-  envelope suite that gates cutover (#2082).
+  section 7 describes it, whole-project cases and the tiers above them (#2075), the plan goldens
+  (#2076) and the differ properties (#2077) included. Missing: the block-size gate (#2078), the
+  migrators (#2079), the DAWproject cross-check (#2080), a real-project corpus (#2081), and the
+  parity envelope suite that gates cutover (#2082).
 
 ---
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -275,6 +275,12 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # Plan goldens (#2076). Fixtures and runner both reach into magda_engine.
     list(APPEND TEST_SOURCES PlanGoldenFixtures.cpp)
     list(APPEND TEST_SOURCES test_plan_goldens.cpp)
+    # Differ property tests over random edit sequences (#2077). The vocabulary
+    # and the session the properties publish into are model-only, so they build
+    # here beside the runner rather than needing a te::Edit.
+    list(APPEND TEST_SOURCES PlanEditSequence.cpp)
+    list(APPEND TEST_SOURCES PlanEditHarness.cpp)
+    list(APPEND TEST_SOURCES test_plan_edit_properties.cpp)
     list(APPEND TEST_SOURCES test_engine_session.cpp)
     list(APPEND TEST_SOURCES test_tempo_map.cpp)
     list(APPEND TEST_SOURCES test_transport_clock.cpp)

--- a/tests/PlanEditHarness.cpp
+++ b/tests/PlanEditHarness.cpp
@@ -43,9 +43,11 @@ std::string joined(const std::vector<std::string>& messages) {
 TestDevice::TestDevice(engine::DeviceKey key, float gain, Ledger& ledger)
     : key_(key), gain_(gain), ledger_(ledger) {
     ++ledger_.created;
+    ledger_.alive.insert(key_);
 }
 
 TestDevice::~TestDevice() {
+    ledger_.alive.erase(key_);
     ledger_.destroyed.push_back(key_);
     ledger_.lastDestroyingThread = std::this_thread::get_id();
 }
@@ -56,7 +58,7 @@ void TestDevice::prepare(const engine::RenderContext& context) {
     // re-prepares the plan, never the instance, so the instance has to be able
     // to honour the new number without being told again.
     rings_.assign(static_cast<std::size_t>(context.numChannels),
-                  std::vector<float>(static_cast<std::size_t>(kMaxDeviceLatency + 1), 0.0f));
+                  std::vector<float>(static_cast<std::size_t>(kDeviceRingSamples), 0.0f));
     cursor_ = 0;
 }
 
@@ -90,9 +92,11 @@ void TestDevice::process(engine::DeviceBlock& block) {
 
 CaptureDevice::CaptureDevice(engine::DeviceKey key, Ledger& ledger) : key_(key), ledger_(ledger) {
     ++ledger_.created;
+    ledger_.alive.insert(key_);
 }
 
 CaptureDevice::~CaptureDevice() {
+    ledger_.alive.erase(key_);
     ledger_.destroyed.push_back(key_);
     ledger_.lastDestroyingThread = std::this_thread::get_id();
 }
@@ -227,6 +231,16 @@ Published Harness::publish(const Project& project) {
     for (const auto& [key, device] : factory_.devices) {
         const auto found = project.deviceLatency.find(key);
         device->setLatency(found == project.deviceLatency.end() ? 0 : found->second);
+
+        // The claim this whole harness rests on, checked where it is made
+        // rather than assumed from a constant two files away.
+        if (!device->honoursItsLatency()) {
+            published.failure = "device " + engine::toString(key) + " reports " +
+                                std::to_string(device->latencySamples()) +
+                                " samples of latency and can delay by at most " +
+                                std::to_string(kDeviceRingSamples - 1);
+            return published;
+        }
     }
 
     published.layout = engine::resolveLayout(*plan, deviceLatencyPerOp(*plan, project));
@@ -252,7 +266,11 @@ Published Harness::publish(const Project& project) {
     values_ = std::move(values);
     live_ = std::move(executor);
 
-    store_.releaseDeleted(*plan, engine::collectRuntimeStateIds(project.tracks, project.master));
+    const auto modelIds = engine::collectRuntimeStateIds(project.tracks, project.master);
+    store_.releaseDeleted(*plan, modelIds);
+
+    published.modelDevices = modelIds.devices;
+    published.owned = ledger_.alive;
 
     for (auto i = destroyedBefore; i < ledger_.destroyed.size(); ++i)
         published.destroyed.push_back(ledger_.destroyed[i]);

--- a/tests/PlanEditHarness.cpp
+++ b/tests/PlanEditHarness.cpp
@@ -1,0 +1,309 @@
+#include "PlanEditHarness.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <sstream>
+
+#include "plan/PlanCompiler.hpp"
+
+/**
+ * @file PlanEditHarness.cpp
+ * @brief The session the properties publish into (#2077).
+ */
+
+namespace magda::edits {
+namespace {
+
+/// Distinct enough per device that a chain of them is a level nothing else in
+/// the project lands on by accident, and never so far from unity that eighteen
+/// of them in series leave nothing to measure.
+float gainFor(DeviceId deviceId) {
+    constexpr std::array<float, 4> gains{0.75f, 0.8125f, 0.875f, 0.9375f};
+    return gains[static_cast<std::size_t>(((deviceId % 4) + 4) % 4)];
+}
+
+/// The track a mixer-analysis device belongs to. Device ids are per section and
+/// the harness owns that section outright, so the id is the track.
+TrackId trackOfCapture(const engine::DeviceKey& key) {
+    return key.deviceId - captureDeviceId(0);
+}
+
+std::string joined(const std::vector<std::string>& messages) {
+    std::ostringstream out;
+    for (std::size_t i = 0; i < messages.size(); ++i)
+        out << (i == 0 ? "" : "; ") << messages[i];
+    return out.str();
+}
+
+}  // namespace
+
+// --- the runtime objects -----------------------------------------------------
+
+TestDevice::TestDevice(engine::DeviceKey key, float gain, Ledger& ledger)
+    : key_(key), gain_(gain), ledger_(ledger) {
+    ++ledger_.created;
+}
+
+TestDevice::~TestDevice() {
+    ledger_.destroyed.push_back(key_);
+    ledger_.lastDestroyingThread = std::this_thread::get_id();
+}
+
+void TestDevice::prepare(const engine::RenderContext& context) {
+    // Sized for the largest latency a generated device can report rather than
+    // for the one it reports now: a plugin that changes what it claims
+    // re-prepares the plan, never the instance, so the instance has to be able
+    // to honour the new number without being told again.
+    rings_.assign(static_cast<std::size_t>(context.numChannels),
+                  std::vector<float>(static_cast<std::size_t>(kMaxDeviceLatency + 1), 0.0f));
+    cursor_ = 0;
+}
+
+void TestDevice::process(engine::DeviceBlock& block) {
+    const auto numSamples = block.block.numSamples;
+    const auto channels =
+        std::min(static_cast<std::size_t>(block.audio.getNumChannels()), rings_.size());
+    if (channels == 0)
+        return;
+
+    const auto capacity = static_cast<int>(rings_.front().size());
+    const auto latency = std::clamp(latency_, 0, capacity - 1);
+
+    auto cursor = cursor_;
+    for (std::size_t channel = 0; channel < channels; ++channel) {
+        auto* samples = block.audio.getChannelPointer(channel);
+        auto& ring = rings_[channel];
+        cursor = cursor_;
+
+        for (int sample = 0; sample < numSamples; ++sample) {
+            ring[static_cast<std::size_t>(cursor)] = samples[sample] * gain_;
+            auto read = cursor - latency;
+            if (read < 0)
+                read += capacity;
+            samples[sample] = ring[static_cast<std::size_t>(read)];
+            cursor = (cursor + 1) % capacity;
+        }
+    }
+    cursor_ = cursor;
+}
+
+CaptureDevice::CaptureDevice(engine::DeviceKey key, Ledger& ledger) : key_(key), ledger_(ledger) {
+    ++ledger_.created;
+}
+
+CaptureDevice::~CaptureDevice() {
+    ledger_.destroyed.push_back(key_);
+    ledger_.lastDestroyingThread = std::this_thread::get_id();
+}
+
+void CaptureDevice::process(engine::DeviceBlock& block) {
+    const auto* channel =
+        block.audio.getNumChannels() > 0 ? block.audio.getChannelPointer(0) : nullptr;
+    for (int sample = 0; sample < block.block.numSamples; ++sample)
+        samples.push_back(channel == nullptr ? 0.0f : channel[sample]);
+}
+
+TrackSource::TrackSource(TrackId trackId, Material material) : material_(material) {
+    // Powers of two, so every level and every step of the ramp is exact in
+    // float and a comparison between two runs is an equality rather than a
+    // tolerance.
+    level_ = 0.25f + (0.25f * static_cast<float>(((trackId % 3) + 3) % 3));
+}
+
+void TrackSource::render(const engine::BlockInfo& block, juce::dsp::AudioBlock<float> out) {
+    juce::ignoreUnused(block);
+
+    const auto numSamples = static_cast<int>(out.getNumSamples());
+    for (int sample = 0; sample < numSamples; ++sample) {
+        const auto ramp = static_cast<float>(counter_ % 512) / 512.0f;
+        const auto value = material_ == Material::Constant ? level_ : level_ * (0.5f + ramp);
+        for (std::size_t channel = 0; channel < out.getNumChannels(); ++channel)
+            out.getChannelPointer(channel)[sample] = value;
+        ++counter_;
+    }
+}
+
+std::unique_ptr<engine::EngineDevice> Factory::createDevice(engine::DeviceKey key) {
+    if (key.segment == ChainSegment::MixerAnalysis) {
+        auto capture = std::make_unique<CaptureDevice>(key, ledger_);
+        captures[trackOfCapture(key)] = capture.get();
+        return capture;
+    }
+
+    auto device = std::make_unique<TestDevice>(key, gainFor(key.deviceId), ledger_);
+    devices[key] = device.get();
+    return device;
+}
+
+std::unique_ptr<engine::EngineAudioSource> Factory::createClipAudioSource(TrackId trackId) {
+    return std::make_unique<TrackSource>(trackId, material_);
+}
+
+namespace {
+
+/// A track with an instrument on it compiles a MIDI source, and an op with no
+/// binding is a message the properties would have to allow for. It plays
+/// nothing: what MIDI does to a plan is topology, and topology is what is
+/// being asserted.
+class SilentMidi final : public engine::EngineMidiSource {
+  public:
+    void render(const engine::BlockInfo&, juce::MidiBuffer&) override {}
+};
+
+}  // namespace
+
+std::unique_ptr<engine::EngineMidiSource> Factory::createClipMidiSource(TrackId trackId) {
+    juce::ignoreUnused(trackId);
+    return std::make_unique<SilentMidi>();
+}
+
+std::unique_ptr<engine::LevelTap> Factory::createMeter(const engine::OpKey& key) {
+    juce::ignoreUnused(key);
+    return std::make_unique<engine::LevelTap>();
+}
+
+// --- the harness -------------------------------------------------------------
+
+Harness::Harness(Material material) : factory_(ledger_, material), store_(factory_) {
+    output_.setSize(kNumChannels, kBlockSize);
+    output_.clear();
+}
+
+bool Harness::hasCapture(TrackId trackId) const {
+    return factory_.captures.count(trackId) != 0;
+}
+
+std::vector<float> Harness::capture(TrackId trackId) const {
+    const auto found = factory_.captures.find(trackId);
+    return found == factory_.captures.end() ? std::vector<float>{} : found->second->samples;
+}
+
+Published Harness::publish(const Project& project) {
+    Published published;
+    published.compiled = engine::compileRenderPlan(project.tracks, project.master);
+
+    if (!published.compiled.diagnostics.empty()) {
+        published.failure =
+            "the compiler could not express the model: " + joined(published.compiled.diagnostics);
+        return published;
+    }
+    if (const auto problems = validatePlan(published.compiled); !problems.empty()) {
+        published.failure = "the compiled plan does not validate: " + joined(problems);
+        return published;
+    }
+
+    const auto* previousPlan = livePlan_ == nullptr ? nullptr : livePlan_.get();
+    const auto stillFading = live_ == nullptr ? std::vector<char>{} : live_->unfinishedCrossfades();
+
+    published.faded =
+        previousPlan == nullptr
+            ? engine::CrossfadedPlan{published.compiled, 0, 0}
+            : engine::insertCrossfades(*previousPlan, published.compiled, stillFading);
+    published.diff = previousPlan == nullptr
+                         ? engine::PlanDiff{}
+                         : engine::diffPlans(*previousPlan, published.faded.plan);
+
+    if (const auto problems = validatePlan(published.faded.plan); !problems.empty()) {
+        published.failure = "the crossfaded plan does not validate: " + joined(problems);
+        return published;
+    }
+
+    auto plan = std::make_shared<engine::RenderPlan>(published.faded.plan);
+
+    engine::PlanValues values;
+    if (const auto problems =
+            engine::resolvePlanValues(*plan, project.tracks, project.master, values);
+        !problems.empty()) {
+        published.failure = "values do not resolve: " + joined(problems);
+        return published;
+    }
+
+    auto bindings = store_.realise(*plan, context_);
+
+    // What each instance reports, set after it exists and before the plan is
+    // prepared against it. A device that was already there is told its new
+    // number here, which is the whole of what a latency change is.
+    for (const auto& [key, device] : factory_.devices) {
+        const auto found = project.deviceLatency.find(key);
+        device->setLatency(found == project.deviceLatency.end() ? 0 : found->second);
+    }
+
+    published.layout = engine::resolveLayout(*plan, deviceLatencyPerOp(*plan, project));
+
+    auto executor = std::make_unique<engine::PlanExecutor>();
+    if (const auto problems = executor->prepare(*plan, bindings, context_, live_.get());
+        !problems.empty()) {
+        published.failure = "the plan does not prepare: " + joined(problems);
+        return published;
+    }
+
+    published.carriedDelayLines = executor->carriedDelayLines();
+    published.carriedCrossfades = executor->carriedCrossfades();
+    published.reportedLatency = executor->latencySamples();
+
+    const auto destroyedBefore = ledger_.destroyed.size();
+
+    // The swap, in the order the session does it: the epoch being replaced is
+    // let go of once the new one has taken what it could carry, and what the
+    // model no longer names goes after that.
+    plans_.push_back(plan);
+    livePlan_ = plan;
+    values_ = std::move(values);
+    live_ = std::move(executor);
+
+    store_.releaseDeleted(*plan, engine::collectRuntimeStateIds(project.tracks, project.master));
+
+    for (auto i = destroyedBefore; i < ledger_.destroyed.size(); ++i)
+        published.destroyed.push_back(ledger_.destroyed[i]);
+
+    // A destroyed instance is one nothing may reach again, so the maps that
+    // hand them out have to lose it at the same moment.
+    for (const auto& key : published.destroyed) {
+        factory_.devices.erase(key);
+        if (key.segment == ChainSegment::MixerAnalysis)
+            factory_.captures.erase(key.deviceId - captureDeviceId(0));
+    }
+
+    return published;
+}
+
+void Harness::render(int blocks) {
+    if (live_ == nullptr)
+        return;
+
+    for (int block = 0; block < blocks; ++block) {
+        engine::BlockInfo info;
+        info.numSamples = kBlockSize;
+        info.playing = true;
+        info.startBeat = static_cast<double>(timeline_) / kSampleRate;
+        info.endBeat = static_cast<double>(timeline_ + kBlockSize) / kSampleRate;
+        info.continuous = timeline_ > 0;
+
+        output_.clear();
+        live_->process(values_, info, output_);
+        timeline_ += kBlockSize;
+    }
+}
+
+// --- shared readings ---------------------------------------------------------
+
+std::vector<int> deviceLatencyPerOp(const engine::RenderPlan& plan, const Project& project) {
+    std::vector<int> latency(plan.ops.size(), 0);
+
+    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+        if (plan.ops[i].kind != engine::OpKind::Device)
+            continue;
+        const auto found = project.deviceLatency.find(plan.ops[i].key.deviceKey());
+        if (found != project.deviceLatency.end())
+            latency[i] = found->second;
+    }
+
+    return latency;
+}
+
+int fadeSamples() {
+    return std::max(1, static_cast<int>(std::lround(engine::kCrossfadeSeconds * kSampleRate)));
+}
+
+}  // namespace magda::edits

--- a/tests/PlanEditHarness.hpp
+++ b/tests/PlanEditHarness.hpp
@@ -53,16 +53,22 @@ constexpr double kSampleRate = 44100.0;
 constexpr int kBlockSize = 64;
 constexpr int kNumChannels = 2;
 
-/// The longest a generated device may claim, and the most a generated project
-/// may hold. Between them they bound how long a render has to run before the
-/// last delay line has filled, which is what lets both legs of a comparison
-/// render the same fixed number of blocks.
-constexpr int kMaxDeviceLatency = 32;
+/// What a device delays by when it claims the most a generated one may claim.
+/// The ring is sized from the same constant the generator draws from, so the
+/// number a device reports is always a number it can honour.
+constexpr int kDeviceRingSamples = kMaxDeviceLatency + 1;
 
-/// Where a device instance was destroyed, and which one. The store promises to
-/// destroy nothing the live plan or the model still names, and to do it on the
-/// thread that publishes; both are only checkable from outside the store.
+/// Which device instances exist, which were destroyed and where. The store
+/// promises to destroy nothing the live plan or the model still names, and to
+/// destroy everything neither of them does; the first half is a question about
+/// what it freed and the second is a question about what it did not, so the
+/// live set is kept as well as the list.
 struct Ledger {
+    /// Every instance alive right now, by the identity the store keys on.
+    /// Inserted where one is made and erased where one is destroyed, so the
+    /// store leaking an instance shows up as a key nothing names.
+    std::set<engine::DeviceKey> alive;
+
     std::vector<engine::DeviceKey> destroyed;
     std::thread::id lastDestroyingThread;
     int created = 0;
@@ -92,6 +98,16 @@ class TestDevice final : public engine::EngineDevice {
 
     void setLatency(int samples) {
         latency_ = samples;
+    }
+
+    /// Whether the number it reports is a number it can delay by. A device that
+    /// claimed more than its ring holds would have the plan compensating for
+    /// samples the signal never spent: the alignment properties would go on
+    /// passing, because they read the plan, while every render underneath them
+    /// ran on a graph that was misaligned in fact. The harness refuses to
+    /// publish when this is false rather than leaving it to be noticed.
+    bool honoursItsLatency() const {
+        return latency_ >= 0 && latency_ < kDeviceRingSamples;
     }
 
   private:
@@ -179,6 +195,16 @@ struct Published {
 
     /// Device instances the store destroyed on this publish.
     std::vector<engine::DeviceKey> destroyed;
+
+    /// Device instances the store still owns once the publish is through. What
+    /// it freed is only half the contract; the other half is that it froze
+    /// nothing it should have let go, and a leak is invisible in a list of
+    /// destructions.
+    std::set<engine::DeviceKey> owned;
+
+    /// The device half of the keep-set the store was handed, as the engine's
+    /// own walk of the model produced it rather than as the harness reads it.
+    std::set<engine::DeviceKey> modelDevices;
 };
 
 /**

--- a/tests/PlanEditHarness.hpp
+++ b/tests/PlanEditHarness.hpp
@@ -1,0 +1,243 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "PlanEditSequence.hpp"
+#include "exec/PlanExecutor.hpp"
+#include "exec/PlanLayout.hpp"
+#include "exec/PlanValues.hpp"
+#include "exec/RuntimeStateStore.hpp"
+#include "plan/PlanCrossfade.hpp"
+#include "plan/PlanDiff.hpp"
+
+/**
+ * @file PlanEditHarness.hpp
+ * @brief One project, published over and over, with everything a property
+ *        needs to look at afterwards (#2077).
+ *
+ * This is a session in every respect the differ can see: a runtime store that
+ * owns the instances, a plan compiled and crossfaded against the one before it,
+ * an executor prepared against its predecessor, and the predecessor destroyed
+ * once the new one has taken what it could carry. What it is not is
+ * EngineSession, and the difference is deliberate. The session owns a transport
+ * and a publish protocol that are tested where they live; a property test wants
+ * the timeline to be a number it controls, and it wants the counts the executor
+ * keeps about what it adopted, which are not a session's to report.
+ *
+ * The one thing it copies exactly is the order things happen in, because that
+ * order is a claim: the epoch being replaced is destroyed after the new one has
+ * prepared against it, so every property that renders afterwards is also the
+ * assertion that carrying state across a swap survives the old epoch going away.
+ */
+
+namespace magda::edits {
+
+/// What the sources play, chosen per property rather than once for the harness.
+///
+/// A ramp makes every sample of a track distinguishable from every other, so a
+/// reader that restarted, a delay line that was rebuilt and a fade that ran
+/// where none was called for are all visible in a comparison. A constant makes
+/// the steady state a number, which is what a discontinuity bound has to be
+/// measured against, and it is exactly what a ramp cannot give.
+enum class Material : std::uint8_t { Ramp, Constant };
+
+/// The device properties every harness prepares for.
+constexpr double kSampleRate = 44100.0;
+constexpr int kBlockSize = 64;
+constexpr int kNumChannels = 2;
+
+/// The longest a generated device may claim, and the most a generated project
+/// may hold. Between them they bound how long a render has to run before the
+/// last delay line has filled, which is what lets both legs of a comparison
+/// render the same fixed number of blocks.
+constexpr int kMaxDeviceLatency = 32;
+
+/// Where a device instance was destroyed, and which one. The store promises to
+/// destroy nothing the live plan or the model still names, and to do it on the
+/// thread that publishes; both are only checkable from outside the store.
+struct Ledger {
+    std::vector<engine::DeviceKey> destroyed;
+    std::thread::id lastDestroyingThread;
+    int created = 0;
+};
+
+/// Gain and a delay of exactly the latency it reports, so latency in the plan
+/// is latency in the signal and a compensation error is audible rather than
+/// merely stated. The ring is sized for the largest latency a generated device
+/// can claim, because reporting a new one is a re-prepare of the plan and never
+/// a prepare of the instance.
+class TestDevice final : public engine::EngineDevice {
+  public:
+    TestDevice(engine::DeviceKey key, float gain, Ledger& ledger);
+    ~TestDevice() override;
+
+    TestDevice(const TestDevice&) = delete;
+    TestDevice& operator=(const TestDevice&) = delete;
+    TestDevice(TestDevice&&) = delete;
+    TestDevice& operator=(TestDevice&&) = delete;
+
+    void prepare(const engine::RenderContext& context) override;
+    void process(engine::DeviceBlock& block) override;
+
+    int latencySamples() const override {
+        return latency_;
+    }
+
+    void setLatency(int samples) {
+        latency_ = samples;
+    }
+
+  private:
+    engine::DeviceKey key_;
+    float gain_ = 1.0f;
+    int latency_ = 0;
+    Ledger& ledger_;
+    std::vector<std::vector<float>> rings_;
+    int cursor_ = 0;
+};
+
+/// The analysis device every track carries: transparent, and it keeps what
+/// passed through it. It goes into the ledger like any other device, because it
+/// is one: the model names it, the store owns it, and a track that leaves the
+/// project takes it along.
+class CaptureDevice final : public engine::EngineDevice {
+  public:
+    CaptureDevice(engine::DeviceKey key, Ledger& ledger);
+    ~CaptureDevice() override;
+
+    CaptureDevice(const CaptureDevice&) = delete;
+    CaptureDevice& operator=(const CaptureDevice&) = delete;
+    CaptureDevice(CaptureDevice&&) = delete;
+    CaptureDevice& operator=(CaptureDevice&&) = delete;
+
+    void process(engine::DeviceBlock& block) override;
+
+    std::vector<float> samples;
+
+  private:
+    engine::DeviceKey key_;
+    Ledger& ledger_;
+};
+
+/// A track's material. Counts its own samples rather than reading the block's
+/// position, so a source that was rebuilt mid-sequence would be visible as a
+/// discontinuity rather than silently producing the right thing again.
+class TrackSource final : public engine::EngineAudioSource {
+  public:
+    TrackSource(TrackId trackId, Material material);
+
+    void render(const engine::BlockInfo& block, juce::dsp::AudioBlock<float> out) override;
+
+  private:
+    Material material_;
+    float level_ = 1.0f;
+    int counter_ = 0;
+};
+
+class Factory final : public engine::RuntimeStateFactory {
+  public:
+    Factory(Ledger& ledger, Material material) : ledger_(ledger), material_(material) {}
+
+    std::unique_ptr<engine::EngineDevice> createDevice(engine::DeviceKey key) override;
+    std::unique_ptr<engine::EngineAudioSource> createClipAudioSource(TrackId trackId) override;
+    std::unique_ptr<engine::EngineMidiSource> createClipMidiSource(TrackId trackId) override;
+    std::unique_ptr<engine::LevelTap> createMeter(const engine::OpKey& key) override;
+
+    /// Live instances, so the harness can tell one what to report and a
+    /// property can read what one captured.
+    std::map<engine::DeviceKey, TestDevice*> devices;
+    std::map<TrackId, CaptureDevice*> captures;
+
+  private:
+    Ledger& ledger_;
+    Material material_;
+};
+
+/// Everything one publish produced, for the properties to read.
+struct Published {
+    /// Empty when the publish went through. Anything else is a failure the
+    /// property reports as it stands: a plan that does not compile cleanly is
+    /// not a plan the differ's decisions can be judged against.
+    std::string failure;
+
+    engine::RenderPlan compiled;
+    engine::CrossfadedPlan faded;
+    engine::PlanDiff diff;
+    engine::PreparedLayout layout;
+
+    /// What the executor said it adopted rather than built.
+    int carriedDelayLines = 0;
+    int carriedCrossfades = 0;
+    int reportedLatency = 0;
+
+    /// Device instances the store destroyed on this publish.
+    std::vector<engine::DeviceKey> destroyed;
+};
+
+/**
+ * @brief The project, the epochs it has been through, and the samples they made.
+ */
+class Harness {
+  public:
+    explicit Harness(Material material);
+
+    /// Compile, crossfade, prepare and swap. The plan handed to the executor is
+    /// the crossfaded one, which is what the session publishes and therefore
+    /// what the next diff has to be taken against.
+    Published publish(const Project& project);
+
+    /// Render @p blocks of kBlockSize. The timeline runs on across publishes,
+    /// because it is a property of the session rather than of any plan.
+    void render(int blocks);
+
+    /// What a track's analysis device has seen since the harness was made. By
+    /// value: a track removed by a later edit takes its device with it, and a
+    /// reference into one is a reference into something a publish may destroy.
+    std::vector<float> capture(TrackId trackId) const;
+
+    bool hasCapture(TrackId trackId) const;
+
+    /// The plan the last publish left live, for a property that wants to look
+    /// at what is playing rather than at what was decided.
+    const engine::RenderPlan* livePlan() const {
+        return livePlan_.get();
+    }
+
+    const Ledger& ledger() const {
+        return ledger_;
+    }
+
+  private:
+    Ledger ledger_;
+    Factory factory_;
+    engine::RuntimeStateStore store_;
+    engine::RenderContext context_{kSampleRate, kBlockSize, kNumChannels};
+
+    /// Every plan the harness has published. The executor points into its plan
+    /// and the next crossfade pass reads the one before, so they are kept
+    /// rather than replaced.
+    std::vector<std::shared_ptr<engine::RenderPlan>> plans_;
+    std::shared_ptr<engine::RenderPlan> livePlan_;
+
+    std::unique_ptr<engine::PlanExecutor> live_;
+    engine::PlanValues values_;
+    juce::AudioBuffer<float> output_;
+    std::int64_t timeline_ = 0;
+};
+
+/// Per op: what a Device op's instance reports, and zero everywhere else. The
+/// same numbers the harness gives the instances, so a property comparing its
+/// own layout against the executor's is comparing two readings of one project.
+std::vector<int> deviceLatencyPerOp(const engine::RenderPlan& plan, const Project& project);
+
+/// The samples a fade takes at kSampleRate, which is what the executor builds.
+int fadeSamples();
+
+}  // namespace magda::edits

--- a/tests/PlanEditSequence.cpp
+++ b/tests/PlanEditSequence.cpp
@@ -1,0 +1,1148 @@
+#include "PlanEditSequence.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <utility>
+
+#include "core/RackInfo.hpp"
+#include "plan/TrackRouting.hpp"
+
+/**
+ * @file PlanEditSequence.cpp
+ * @brief The edit vocabulary, and the generator that strings it together (#2077).
+ *
+ * Every edit here is one a user can perform, which is the only reason to have a
+ * vocabulary at all: a generator free to write arbitrary plans would spend its
+ * time on shapes the compiler never emits, and the differ's decisions about
+ * those are nobody's problem.
+ */
+
+namespace magda::edits {
+namespace {
+
+// --- reading and writing the project ----------------------------------------
+
+/// The elements a rack chain holds, wherever the rack is nested.
+std::vector<ChainElement>* chainElements(std::vector<ChainElement>& elements, ChainId chainId) {
+    for (auto& element : elements) {
+        if (!isRack(element))
+            continue;
+
+        auto& rack = getRack(element);
+        for (auto& chain : rack.chains) {
+            if (chain.id == chainId)
+                return &chain.elements;
+            if (auto* found = chainElements(chain.elements, chainId))
+                return found;
+        }
+    }
+    return nullptr;
+}
+
+/// The rack with this id, wherever it is nested, and the list holding it.
+struct RackAt {
+    std::vector<ChainElement>* container = nullptr;
+    std::size_t index = 0;
+    TrackId trackId = INVALID_TRACK_ID;
+};
+
+bool findRackIn(std::vector<ChainElement>& elements, RackId rackId, TrackId trackId, RackAt& out) {
+    for (std::size_t i = 0; i < elements.size(); ++i) {
+        if (!isRack(elements[i]))
+            continue;
+
+        auto& rack = getRack(elements[i]);
+        if (rack.id == rackId) {
+            out = RackAt{&elements, i, trackId};
+            return true;
+        }
+        for (auto& chain : rack.chains)
+            if (findRackIn(chain.elements, rackId, trackId, out))
+                return true;
+    }
+    return false;
+}
+
+bool findRack(Project& project, RackId rackId, RackAt& out) {
+    for (auto& track : project.tracks)
+        if (findRackIn(track.chain.fxChainElements, rackId, track.id, out))
+            return true;
+    return false;
+}
+
+/// The chain with this id, and the rack that owns it.
+struct ChainAt {
+    RackInfo* rack = nullptr;
+    std::size_t index = 0;
+    TrackId trackId = INVALID_TRACK_ID;
+};
+
+bool findChainIn(std::vector<ChainElement>& elements, ChainId chainId, TrackId trackId,
+                 ChainAt& out) {
+    for (auto& element : elements) {
+        if (!isRack(element))
+            continue;
+
+        auto& rack = getRack(element);
+        for (std::size_t i = 0; i < rack.chains.size(); ++i) {
+            if (rack.chains[i].id == chainId) {
+                out = ChainAt{&rack, i, trackId};
+                return true;
+            }
+            if (findChainIn(rack.chains[i].elements, chainId, trackId, out))
+                return true;
+        }
+    }
+    return false;
+}
+
+bool findChain(Project& project, ChainId chainId, ChainAt& out) {
+    for (auto& track : project.tracks)
+        if (findChainIn(track.chain.fxChainElements, chainId, track.id, out))
+            return true;
+    return false;
+}
+
+/// A device of the insert chain, wherever it sits, and the list holding it.
+struct DeviceAt {
+    std::vector<ChainElement>* container = nullptr;
+    std::size_t index = 0;
+    TrackId trackId = INVALID_TRACK_ID;
+};
+
+bool findDeviceIn(std::vector<ChainElement>& elements, DeviceId deviceId, TrackId trackId,
+                  DeviceAt& out) {
+    for (std::size_t i = 0; i < elements.size(); ++i) {
+        if (isDevice(elements[i])) {
+            if (getDevice(elements[i]).id == deviceId) {
+                out = DeviceAt{&elements, i, trackId};
+                return true;
+            }
+            continue;
+        }
+
+        for (auto& chain : getRack(elements[i]).chains)
+            if (findDeviceIn(chain.elements, deviceId, trackId, out))
+                return true;
+    }
+    return false;
+}
+
+bool findDevice(Project& project, DeviceId deviceId, DeviceAt& out) {
+    for (auto& track : project.tracks)
+        if (findDeviceIn(track.chain.fxChainElements, deviceId, track.id, out))
+            return true;
+    return false;
+}
+
+/// Where an edit adds something, or null when the project no longer has it.
+std::vector<ChainElement>* siteElements(Project& project, const Site& site) {
+    for (auto& track : project.tracks) {
+        if (track.id != site.trackId)
+            continue;
+        if (site.chainId == INVALID_CHAIN_ID)
+            return &track.chain.fxChainElements;
+        return chainElements(track.chain.fxChainElements, site.chainId);
+    }
+    return nullptr;
+}
+
+TrackInfo* findTrack(Project& project, TrackId trackId) {
+    for (auto& track : project.tracks)
+        if (track.id == trackId)
+            return &track;
+    return nullptr;
+}
+
+int trackIndex(const Project& project, TrackId trackId) {
+    for (std::size_t i = 0; i < project.tracks.size(); ++i)
+        if (project.tracks[i].id == trackId)
+            return static_cast<int>(i);
+    return -1;
+}
+
+std::size_t clampPosition(int position, std::size_t size) {
+    if (position <= 0)
+        return 0;
+    return std::min(static_cast<std::size_t>(position), size);
+}
+
+// --- what a track holds ------------------------------------------------------
+
+/// Every insert-chain device of a track, nested racks included.
+void collectDevices(const std::vector<ChainElement>& elements,
+                    std::vector<const DeviceInfo*>& out) {
+    for (const auto& element : elements) {
+        if (isDevice(element)) {
+            out.push_back(&getDevice(element));
+            continue;
+        }
+        for (const auto& chain : getRack(element).chains)
+            collectDevices(chain.elements, out);
+    }
+}
+
+std::vector<const DeviceInfo*> devicesOf(const TrackInfo& track) {
+    std::vector<const DeviceInfo*> devices;
+    collectDevices(track.chain.fxChainElements, devices);
+    return devices;
+}
+
+/// Device ids in the insert chain go into one id space, and each flat section
+/// into its own. Latency, and therefore the store's identity for an instance,
+/// follows the same split.
+void collectKeys(const std::vector<ChainElement>& elements, std::set<engine::DeviceKey>& out) {
+    for (const auto& element : elements) {
+        if (isDevice(element)) {
+            out.insert(engine::DeviceKey{ChainSegment::Fx, getDevice(element).id});
+            continue;
+        }
+        for (const auto& chain : getRack(element).chains)
+            collectKeys(chain.elements, out);
+    }
+}
+
+/// A device the harness adds to every track, at the end of it, where what it
+/// sees is what the track contributes to everything downstream.
+DeviceInfo captureDevice(TrackId trackId) {
+    DeviceInfo device;
+    device.id = captureDeviceId(trackId);
+    device.name = "Capture " + juce::String(trackId);
+    device.deviceType = DeviceType::Analysis;
+    return device;
+}
+
+DeviceInfo effect(DeviceId id) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Effect " + juce::String(id);
+    device.deviceType = DeviceType::Effect;
+    return device;
+}
+
+DeviceInfo instrument(DeviceId id) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Instrument " + juce::String(id);
+    device.deviceType = DeviceType::Instrument;
+    device.isInstrument = true;
+    device.canReceiveMidi = true;
+    return device;
+}
+
+TrackInfo audioTrack(TrackId id) {
+    TrackInfo track;
+    track.id = id;
+    track.type = TrackType::Audio;
+    track.name = "Track " + juce::String(id);
+    track.audioOutputDevice = "master";
+    track.chain.mixerAnalysisElements.push_back(PostFxChainElement{captureDevice(id)});
+    return track;
+}
+
+/// Everything a removed track leaves behind: sends aimed at it, routes into it,
+/// and sidechains reading it. A project that kept them would compile with
+/// diagnostics, and the runner treats a diagnostic as a generator that has
+/// drifted rather than as coverage.
+void forgetTrack(Project& project, TrackId gone) {
+    const auto clearSidechains = [gone](std::vector<ChainElement>& elements,
+                                        const auto& self) -> void {
+        for (auto& element : elements) {
+            if (isDevice(element)) {
+                auto& device = getDevice(element);
+                if (device.sidechain.sourceTrackId == gone)
+                    device.sidechain = {};
+                continue;
+            }
+            for (auto& chain : getRack(element).chains)
+                self(chain.elements, self);
+        }
+    };
+
+    for (auto& track : project.tracks) {
+        std::erase_if(track.sends,
+                      [gone](const SendInfo& send) { return send.destTrackId == gone; });
+
+        if (const auto route = engine::parseTrackRoute(track.audioOutputDevice);
+            route.namesTrack() && route.trackId == gone)
+            track.audioOutputDevice = "master";
+
+        clearSidechains(track.chain.fxChainElements, clearSidechains);
+        for (auto* section : {&track.chain.postFxChainElements, &track.chain.mixerAnalysisElements})
+            for (auto& element : *section)
+                if (element.device.sidechain.sourceTrackId == gone)
+                    element.device.sidechain = {};
+    }
+}
+
+/// Latency is remembered per instance, so a device leaving the model takes its
+/// entry with it. Otherwise a device id reused later would arrive latent.
+void forgetLatency(Project& project, const std::vector<ChainElement>& elements) {
+    std::set<engine::DeviceKey> keys;
+    collectKeys(elements, keys);
+    for (const auto& key : keys)
+        project.deviceLatency.erase(key);
+}
+
+// --- the generator -----------------------------------------------------------
+
+/// splitmix64, written out rather than taken from <random>: the standard
+/// distributions are implementation defined, and a seed that reproduces a
+/// failure on one machine and not on another is not a recorded seed.
+class Rng {
+  public:
+    explicit Rng(std::uint64_t seed) : state_(seed) {}
+
+    std::uint64_t next() {
+        state_ += 0x9e3779b97f4a7c15ULL;
+        auto z = state_;
+        z = (z ^ (z >> 30U)) * 0xbf58476d1ce4e5b9ULL;
+        z = (z ^ (z >> 27U)) * 0x94d049bb133111ebULL;
+        return z ^ (z >> 31U);
+    }
+
+    int below(int bound) {
+        return bound <= 0 ? 0 : static_cast<int>(next() % static_cast<std::uint64_t>(bound));
+    }
+
+    bool chance(int percent) {
+        return below(100) < percent;
+    }
+
+    template <typename T> const T& pick(const std::vector<T>& values) {
+        return values[static_cast<std::size_t>(below(static_cast<int>(values.size())))];
+    }
+
+  private:
+    std::uint64_t state_;
+};
+
+/// Every place an element can be added: each track's insert chain, and every
+/// chain of every rack in it.
+void collectSites(const std::vector<ChainElement>& elements, TrackId trackId,
+                  std::vector<Site>& out) {
+    for (const auto& element : elements) {
+        if (!isRack(element))
+            continue;
+        const auto& rack = getRack(element);
+        for (const auto& chain : rack.chains) {
+            out.push_back(Site{trackId, rack.id, chain.id});
+            collectSites(chain.elements, trackId, out);
+        }
+    }
+}
+
+std::vector<Site> sitesOf(const Project& project) {
+    std::vector<Site> sites;
+    for (const auto& track : project.tracks) {
+        sites.push_back(Site{track.id, INVALID_RACK_ID, INVALID_CHAIN_ID});
+        collectSites(track.chain.fxChainElements, track.id, sites);
+    }
+    return sites;
+}
+
+struct Inventory {
+    std::vector<std::pair<DeviceId, TrackId>> devices;
+    std::vector<RackId> racks;
+    std::vector<ChainId> chains;
+};
+
+void collectInventory(const std::vector<ChainElement>& elements, TrackId trackId,
+                      Inventory& inventory) {
+    for (const auto& element : elements) {
+        if (isDevice(element)) {
+            inventory.devices.emplace_back(getDevice(element).id, trackId);
+            continue;
+        }
+        const auto& rack = getRack(element);
+        inventory.racks.push_back(rack.id);
+        for (const auto& chain : rack.chains) {
+            inventory.chains.push_back(chain.id);
+            collectInventory(chain.elements, trackId, inventory);
+        }
+    }
+}
+
+Inventory inventoryOf(const Project& project) {
+    Inventory inventory;
+    for (const auto& track : project.tracks)
+        collectInventory(track.chain.fxChainElements, track.id, inventory);
+    return inventory;
+}
+
+/// Where the tracks a project starts with sit in project order, spaced so a
+/// generated track can land before, between or after them.
+constexpr int kBaseTrackOrder = 100;
+
+/// One past the largest sort key a generated track may take.
+constexpr int kMaxTrackOrder = kBaseTrackOrder * (kNumBaseTracks + 1);
+
+/// Kept small on purpose. The properties are about what an edit does to the
+/// plan around it, and a project with sixty devices makes a shrunk case that
+/// takes longer to read than the code it is about.
+constexpr int kMaxDevices = 18;
+constexpr int kMaxRacks = 4;
+constexpr int kMaxSendsPerTrack = 3;
+
+/// Latencies a generated device reports. Zero most of the time, because a plan
+/// with a delay on every edge is not the common shape, and never so large that
+/// a render property would need a longer settling window than the block budget.
+int pickLatency(Rng& rng) {
+    if (rng.chance(60))
+        return 0;
+    return 1 + rng.below(96);
+}
+
+}  // namespace
+
+// --- text --------------------------------------------------------------------
+
+std::string toString(const Edit& edit) {
+    std::ostringstream out;
+
+    const auto site = [&edit] {
+        std::ostringstream text;
+        text << "T" << edit.site.trackId;
+        if (edit.site.chainId != INVALID_CHAIN_ID)
+            text << "/R" << edit.site.rackId << "/C" << edit.site.chainId;
+        return text.str();
+    };
+
+    switch (edit.kind) {
+        case EditKind::AddDevice:
+            out << "addDevice " << site() << " D" << edit.deviceId << " at " << edit.position
+                << " latency " << edit.latencySamples;
+            break;
+        case EditKind::AddInstrument:
+            out << "addInstrument " << site() << " D" << edit.deviceId << " at " << edit.position;
+            break;
+        case EditKind::RemoveDevice:
+            out << "removeDevice D" << edit.deviceId;
+            break;
+        case EditKind::MoveDevice:
+            out << "moveDevice D" << edit.deviceId << " to " << edit.position;
+            break;
+        case EditKind::BypassDevice:
+            out << "bypassDevice D" << edit.deviceId << " " << (edit.flag ? "on" : "off");
+            break;
+        case EditKind::SetDeviceLatency:
+            out << "setDeviceLatency D" << edit.deviceId << " " << edit.latencySamples;
+            break;
+        case EditKind::AddRack:
+            out << "addRack " << site() << " R" << edit.rackId << " chains C" << edit.chainId
+                << ",C" << (edit.chainId + 1) << " devices D" << edit.deviceId << ",D"
+                << (edit.deviceId + 1) << " at " << edit.position;
+            break;
+        case EditKind::RemoveRack:
+            out << "removeRack R" << edit.rackId;
+            break;
+        case EditKind::AddChain:
+            out << "addChain R" << edit.rackId << " C" << edit.chainId << " device D"
+                << edit.deviceId;
+            break;
+        case EditKind::RemoveChain:
+            out << "removeChain C" << edit.chainId;
+            break;
+        case EditKind::ChainPower:
+            out << "chainPower T" << edit.site.trackId << " " << (edit.flag ? "on" : "off");
+            break;
+        case EditKind::AddSend:
+            out << "addSend T" << edit.site.trackId << " to T" << edit.otherTrackId << " "
+                << (edit.flag ? "pre" : "post");
+            break;
+        case EditKind::RemoveSend:
+            out << "removeSend T" << edit.site.trackId << " slot " << edit.position;
+            break;
+        case EditKind::SetSidechain:
+            out << "setSidechain D" << edit.deviceId << " from ";
+            if (edit.otherTrackId == INVALID_TRACK_ID)
+                out << "none";
+            else
+                out << "T" << edit.otherTrackId;
+            break;
+        case EditKind::AddTrack:
+            out << "addTrack T" << edit.site.trackId << " order " << edit.position;
+            break;
+        case EditKind::RemoveTrack:
+            out << "removeTrack T" << edit.site.trackId;
+            break;
+        case EditKind::RouteTrack:
+            out << "routeTrack T" << edit.site.trackId << " to ";
+            if (edit.otherTrackId == INVALID_TRACK_ID)
+                out << "master";
+            else
+                out << "T" << edit.otherTrackId;
+            break;
+    }
+
+    return out.str();
+}
+
+std::string toString(const std::vector<Edit>& edits) {
+    std::ostringstream out;
+    for (std::size_t i = 0; i < edits.size(); ++i)
+        out << "  [" << (i + 1) << "] " << toString(edits[i]) << "\n";
+    return out.str();
+}
+
+// --- the project -------------------------------------------------------------
+
+Project startingProject() {
+    Project project;
+    for (int i = 0; i < kNumBaseTracks; ++i) {
+        project.tracks.push_back(audioTrack(kFirstBaseTrack + i));
+        project.trackOrder[kFirstBaseTrack + i] = kBaseTrackOrder * (i + 1);
+    }
+
+    project.master = audioTrack(MASTER_TRACK_ID);
+    project.master.type = TrackType::Master;
+    project.master.audioOutputDevice = {};
+    project.master.name = "Master";
+    return project;
+}
+
+bool apply(const Edit& edit, Project& project) {
+    switch (edit.kind) {
+        case EditKind::AddDevice:
+        case EditKind::AddInstrument: {
+            DeviceAt existing;
+            if (findDevice(project, edit.deviceId, existing))
+                return false;
+
+            auto* elements = siteElements(project, edit.site);
+            if (elements == nullptr)
+                return false;
+
+            auto device = edit.kind == EditKind::AddInstrument ? instrument(edit.deviceId)
+                                                               : effect(edit.deviceId);
+            elements->insert(elements->begin() + static_cast<std::ptrdiff_t>(clampPosition(
+                                                     edit.position, elements->size())),
+                             makeDeviceElement(std::move(device)));
+
+            if (edit.latencySamples > 0)
+                project.deviceLatency[engine::DeviceKey{ChainSegment::Fx, edit.deviceId}] =
+                    edit.latencySamples;
+            return true;
+        }
+
+        case EditKind::RemoveDevice: {
+            DeviceAt at;
+            if (!findDevice(project, edit.deviceId, at))
+                return false;
+
+            at.container->erase(at.container->begin() + static_cast<std::ptrdiff_t>(at.index));
+            project.deviceLatency.erase(engine::DeviceKey{ChainSegment::Fx, edit.deviceId});
+            return true;
+        }
+
+        case EditKind::MoveDevice: {
+            DeviceAt at;
+            if (!findDevice(project, edit.deviceId, at))
+                return false;
+
+            auto element = std::move((*at.container)[at.index]);
+            at.container->erase(at.container->begin() + static_cast<std::ptrdiff_t>(at.index));
+            at.container->insert(at.container->begin() + static_cast<std::ptrdiff_t>(clampPosition(
+                                                             edit.position, at.container->size())),
+                                 std::move(element));
+            return true;
+        }
+
+        case EditKind::BypassDevice: {
+            DeviceAt at;
+            if (!findDevice(project, edit.deviceId, at))
+                return false;
+
+            auto& device = getDevice((*at.container)[at.index]);
+            if (device.bypassed == edit.flag)
+                return false;
+            device.bypassed = edit.flag;
+            return true;
+        }
+
+        case EditKind::SetDeviceLatency: {
+            DeviceAt at;
+            if (!findDevice(project, edit.deviceId, at))
+                return false;
+
+            const engine::DeviceKey key{ChainSegment::Fx, edit.deviceId};
+            if (edit.latencySamples <= 0)
+                project.deviceLatency.erase(key);
+            else
+                project.deviceLatency[key] = edit.latencySamples;
+            return true;
+        }
+
+        case EditKind::AddRack: {
+            RackAt existing;
+            if (findRack(project, edit.rackId, existing))
+                return false;
+
+            auto* elements = siteElements(project, edit.site);
+            if (elements == nullptr)
+                return false;
+
+            auto rack = std::make_unique<RackInfo>();
+            rack->id = edit.rackId;
+            rack->name = "Rack " + juce::String(edit.rackId);
+            for (int i = 0; i < 2; ++i) {
+                ChainInfo chain;
+                chain.id = edit.chainId + i;
+                chain.name = "Chain " + juce::String(chain.id);
+                chain.elements.push_back(makeDeviceElement(effect(edit.deviceId + i)));
+                rack->chains.push_back(std::move(chain));
+            }
+
+            elements->insert(elements->begin() + static_cast<std::ptrdiff_t>(clampPosition(
+                                                     edit.position, elements->size())),
+                             ChainElement{std::move(rack)});
+            return true;
+        }
+
+        case EditKind::RemoveRack: {
+            RackAt at;
+            if (!findRack(project, edit.rackId, at))
+                return false;
+
+            for (const auto& chain : getRack((*at.container)[at.index]).chains)
+                forgetLatency(project, chain.elements);
+
+            at.container->erase(at.container->begin() + static_cast<std::ptrdiff_t>(at.index));
+            return true;
+        }
+
+        case EditKind::AddChain: {
+            ChainAt existing;
+            if (findChain(project, edit.chainId, existing))
+                return false;
+
+            RackAt at;
+            if (!findRack(project, edit.rackId, at))
+                return false;
+
+            DeviceAt device;
+            if (findDevice(project, edit.deviceId, device))
+                return false;
+
+            ChainInfo chain;
+            chain.id = edit.chainId;
+            chain.name = "Chain " + juce::String(chain.id);
+            chain.elements.push_back(makeDeviceElement(effect(edit.deviceId)));
+            getRack((*at.container)[at.index]).chains.push_back(std::move(chain));
+            return true;
+        }
+
+        case EditKind::RemoveChain: {
+            ChainAt at;
+            if (!findChain(project, edit.chainId, at))
+                return false;
+
+            // A rack with no chains is a rack the compiler reports rather than
+            // compiles, and it is not what removing a chain in the app does.
+            if (at.rack->chains.size() <= 1)
+                return false;
+
+            forgetLatency(project, at.rack->chains[at.index].elements);
+            at.rack->chains.erase(at.rack->chains.begin() + static_cast<std::ptrdiff_t>(at.index));
+            return true;
+        }
+
+        case EditKind::ChainPower: {
+            auto* track = findTrack(project, edit.site.trackId);
+            if (track == nullptr || track->chain.enabled == edit.flag)
+                return false;
+            track->chain.enabled = edit.flag;
+            return true;
+        }
+
+        case EditKind::AddSend: {
+            auto* track = findTrack(project, edit.site.trackId);
+            if (track == nullptr || findTrack(project, edit.otherTrackId) == nullptr)
+                return false;
+
+            // Later in project order, always: the generator never builds a
+            // routing cycle, so a cycle the compiler broke can never be
+            // mistaken for a property the differ got wrong.
+            if (trackIndex(project, edit.otherTrackId) <= trackIndex(project, edit.site.trackId))
+                return false;
+
+            SendInfo send;
+            send.busIndex = 0;
+            send.level = 0.5f;
+            send.preFader = edit.flag;
+            send.destTrackId = edit.otherTrackId;
+            track->sends.push_back(send);
+            return true;
+        }
+
+        case EditKind::RemoveSend: {
+            auto* track = findTrack(project, edit.site.trackId);
+            if (track == nullptr || edit.position < 0 ||
+                static_cast<std::size_t>(edit.position) >= track->sends.size())
+                return false;
+
+            track->sends.erase(track->sends.begin() + edit.position);
+            return true;
+        }
+
+        case EditKind::SetSidechain: {
+            DeviceAt at;
+            if (!findDevice(project, edit.deviceId, at))
+                return false;
+
+            auto& device = getDevice((*at.container)[at.index]);
+            if (edit.otherTrackId == INVALID_TRACK_ID) {
+                if (!device.sidechain.isActive())
+                    return false;
+                device.sidechain = {};
+                return true;
+            }
+
+            if (findTrack(project, edit.otherTrackId) == nullptr)
+                return false;
+            if (trackIndex(project, edit.otherTrackId) >= trackIndex(project, at.trackId))
+                return false;
+
+            device.sidechain.type = SidechainConfig::Type::Audio;
+            device.sidechain.sourceTrackId = edit.otherTrackId;
+            return true;
+        }
+
+        case EditKind::AddTrack: {
+            if (findTrack(project, edit.site.trackId) != nullptr)
+                return false;
+
+            // By sort key, so that where this track lands depends on the tracks
+            // that are there and not on which edits ran. A position taken as an
+            // index would put it before a track in one run and after it in
+            // another, which changes both what may connect to what and the
+            // order a fan-in sums.
+            const auto key = std::clamp(edit.position, 0, kMaxTrackOrder);
+            project.trackOrder[edit.site.trackId] = key;
+
+            auto at = project.tracks.begin();
+            while (at != project.tracks.end() && std::pair(project.trackOrder[at->id], at->id) <
+                                                     std::pair(key, edit.site.trackId))
+                ++at;
+
+            project.tracks.insert(at, audioTrack(edit.site.trackId));
+            return true;
+        }
+
+        case EditKind::RemoveTrack: {
+            if (edit.site.trackId < kFirstExtraTrack)
+                return false;
+
+            const auto found =
+                std::ranges::find_if(project.tracks, [&edit](const TrackInfo& track) {
+                    return track.id == edit.site.trackId;
+                });
+            if (found == project.tracks.end())
+                return false;
+
+            forgetLatency(project, found->chain.fxChainElements);
+            project.tracks.erase(found);
+            project.trackOrder.erase(edit.site.trackId);
+            forgetTrack(project, edit.site.trackId);
+            return true;
+        }
+
+        case EditKind::RouteTrack: {
+            auto* track = findTrack(project, edit.site.trackId);
+            if (track == nullptr)
+                return false;
+
+            if (edit.otherTrackId == INVALID_TRACK_ID) {
+                if (track->audioOutputDevice == "master")
+                    return false;
+                track->audioOutputDevice = "master";
+                return true;
+            }
+
+            if (findTrack(project, edit.otherTrackId) == nullptr)
+                return false;
+            if (trackIndex(project, edit.otherTrackId) <= trackIndex(project, edit.site.trackId))
+                return false;
+
+            track->audioOutputDevice = "track:" + juce::String(edit.otherTrackId);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+// --- what an edit touches ----------------------------------------------------
+
+std::set<TrackId> touched(const Edit& edit, const Project& before) {
+    auto project = before;  // the lookups below are non-const; nothing is kept
+    std::set<TrackId> tracks;
+
+    const auto ownerOfDevice = [&project](DeviceId deviceId) {
+        DeviceAt at;
+        return findDevice(project, deviceId, at) ? at.trackId : INVALID_TRACK_ID;
+    };
+
+    const auto add = [&tracks](TrackId trackId) {
+        if (trackId != INVALID_TRACK_ID)
+            tracks.insert(trackId);
+    };
+
+    switch (edit.kind) {
+        case EditKind::AddDevice:
+        case EditKind::AddInstrument:
+        case EditKind::AddRack:
+        case EditKind::ChainPower:
+        case EditKind::AddTrack:
+        case EditKind::RemoveTrack:
+            add(edit.site.trackId);
+            break;
+
+        case EditKind::RemoveDevice:
+        case EditKind::MoveDevice:
+        case EditKind::BypassDevice:
+        case EditKind::SetDeviceLatency:
+            add(ownerOfDevice(edit.deviceId));
+            break;
+
+        case EditKind::RemoveRack: {
+            RackAt at;
+            if (findRack(project, edit.rackId, at))
+                add(at.trackId);
+            break;
+        }
+
+        case EditKind::AddChain: {
+            RackAt at;
+            if (findRack(project, edit.rackId, at))
+                add(at.trackId);
+            break;
+        }
+
+        case EditKind::RemoveChain: {
+            ChainAt at;
+            if (findChain(project, edit.chainId, at))
+                add(at.trackId);
+            break;
+        }
+
+        case EditKind::AddSend:
+            add(edit.site.trackId);
+            add(edit.otherTrackId);
+            break;
+
+        case EditKind::RemoveSend: {
+            add(edit.site.trackId);
+            if (const auto* track = findTrack(project, edit.site.trackId);
+                track != nullptr && edit.position >= 0 &&
+                static_cast<std::size_t>(edit.position) < track->sends.size())
+                add(track->sends[static_cast<std::size_t>(edit.position)].destTrackId);
+            break;
+        }
+
+        case EditKind::SetSidechain:
+            add(ownerOfDevice(edit.deviceId));
+            add(edit.otherTrackId);
+            break;
+
+        case EditKind::RouteTrack: {
+            add(edit.site.trackId);
+            add(edit.otherTrackId);
+            if (const auto* track = findTrack(project, edit.site.trackId); track != nullptr)
+                if (const auto route = engine::parseTrackRoute(track->audioOutputDevice);
+                    route.namesTrack())
+                    add(route.trackId);
+            break;
+        }
+    }
+
+    return tracks;
+}
+
+std::set<TrackId> feeds(const Project& project, TrackId target) {
+    std::set<TrackId> reaching{target};
+
+    // Fixed point rather than one pass: a send into a track that is itself
+    // routed into the target is upstream of the target too, and the generator
+    // builds those chains freely.
+    for (bool grew = true; grew;) {
+        grew = false;
+
+        for (const auto& track : project.tracks) {
+            const auto reaches = [&reaching](TrackId trackId) {
+                return trackId != INVALID_TRACK_ID && reaching.contains(trackId);
+            };
+
+            auto upstream = false;
+            for (const auto& send : track.sends)
+                upstream = upstream || reaches(send.destTrackId);
+
+            if (const auto route = engine::parseTrackRoute(track.audioOutputDevice);
+                route.namesTrack())
+                upstream = upstream || reaches(route.trackId);
+            else if (reaching.contains(MASTER_TRACK_ID))
+                upstream = true;
+
+            if (upstream && reaching.insert(track.id).second)
+                grew = true;
+        }
+
+        // A sidechain reads another track into this one, so its source is
+        // upstream of everything this track feeds.
+        for (const auto& track : project.tracks) {
+            if (!reaching.contains(track.id))
+                continue;
+
+            std::vector<const DeviceInfo*> devices = devicesOf(track);
+            for (const auto* section :
+                 {&track.chain.postFxChainElements, &track.chain.mixerAnalysisElements})
+                for (const auto& element : *section)
+                    devices.push_back(&element.device);
+
+            for (const auto* device : devices)
+                if (device->sidechain.isActive() &&
+                    reaching.insert(device->sidechain.sourceTrackId).second)
+                    grew = true;
+        }
+    }
+
+    return reaching;
+}
+
+std::set<engine::DeviceKey> deviceKeys(const Project& project) {
+    std::set<engine::DeviceKey> keys;
+
+    const auto collectTrack = [&keys](const TrackInfo& track) {
+        collectKeys(track.chain.fxChainElements, keys);
+        for (const auto& element : track.chain.postFxChainElements)
+            keys.insert(engine::DeviceKey{ChainSegment::PostFx, element.device.id});
+        for (const auto& element : track.chain.mixerAnalysisElements)
+            keys.insert(engine::DeviceKey{ChainSegment::MixerAnalysis, element.device.id});
+    };
+
+    for (const auto& track : project.tracks)
+        collectTrack(track);
+    collectTrack(project.master);
+    return keys;
+}
+
+// --- the generator -----------------------------------------------------------
+
+std::vector<Edit> generate(std::uint64_t seed, int length) {
+    Rng rng(seed);
+
+    auto project = startingProject();
+    std::vector<Edit> edits;
+    edits.reserve(static_cast<std::size_t>(length));
+
+    DeviceId nextDevice = 10;
+    RackId nextRack = 100;
+    ChainId nextChain = 200;
+
+    const auto trackIds = [&project] {
+        std::vector<TrackId> ids;
+        for (const auto& track : project.tracks)
+            ids.push_back(track.id);
+        return ids;
+    };
+
+    for (int step = 0; step < length; ++step) {
+        const auto sites = sitesOf(project);
+        const auto inventory = inventoryOf(project);
+        const auto ids = trackIds();
+
+        // Chosen against the project as it stands, then written down by id. A
+        // kind with nothing to work on is retried rather than emitted, so a
+        // sequence is mostly edits that did something even before it is shrunk.
+        Edit edit;
+        auto usable = false;
+
+        for (int attempt = 0; attempt < 12 && !usable; ++attempt) {
+            edit = Edit{};
+            const auto kind = static_cast<EditKind>(rng.below(kNumEditKinds));
+            edit.kind = kind;
+
+            switch (kind) {
+                case EditKind::AddDevice:
+                case EditKind::AddInstrument:
+                    if (static_cast<int>(inventory.devices.size()) >= kMaxDevices || sites.empty())
+                        break;
+                    edit.site = rng.pick(sites);
+                    edit.deviceId = nextDevice;
+                    edit.position = rng.below(6);
+                    edit.latencySamples = kind == EditKind::AddDevice ? pickLatency(rng) : 0;
+                    usable = true;
+                    break;
+
+                case EditKind::RemoveDevice:
+                case EditKind::MoveDevice:
+                case EditKind::BypassDevice:
+                case EditKind::SetDeviceLatency:
+                case EditKind::SetSidechain: {
+                    if (inventory.devices.empty())
+                        break;
+                    const auto& [deviceId, trackId] = rng.pick(inventory.devices);
+                    edit.deviceId = deviceId;
+                    edit.site = Site{trackId, INVALID_RACK_ID, INVALID_CHAIN_ID};
+                    edit.position = rng.below(6);
+                    edit.flag = rng.chance(50);
+                    edit.latencySamples = pickLatency(rng);
+                    if (kind == EditKind::SetSidechain) {
+                        const auto index = trackIndex(project, trackId);
+                        edit.otherTrackId =
+                            index > 0 && rng.chance(70)
+                                ? project.tracks[static_cast<std::size_t>(rng.below(index))].id
+                                : INVALID_TRACK_ID;
+                    }
+                    usable = true;
+                    break;
+                }
+
+                case EditKind::AddRack:
+                    if (static_cast<int>(inventory.racks.size()) >= kMaxRacks || sites.empty())
+                        break;
+                    edit.site = rng.pick(sites);
+                    edit.rackId = nextRack;
+                    edit.chainId = nextChain;
+                    edit.deviceId = nextDevice;
+                    edit.position = rng.below(4);
+                    usable = true;
+                    break;
+
+                case EditKind::RemoveRack:
+                    if (inventory.racks.empty())
+                        break;
+                    edit.rackId = rng.pick(inventory.racks);
+                    usable = true;
+                    break;
+
+                case EditKind::AddChain:
+                    if (inventory.racks.empty())
+                        break;
+                    edit.rackId = rng.pick(inventory.racks);
+                    edit.chainId = nextChain;
+                    edit.deviceId = nextDevice;
+                    usable = true;
+                    break;
+
+                case EditKind::RemoveChain:
+                    if (inventory.chains.empty())
+                        break;
+                    edit.chainId = rng.pick(inventory.chains);
+                    usable = true;
+                    break;
+
+                case EditKind::ChainPower:
+                    edit.site = Site{rng.pick(ids), INVALID_RACK_ID, INVALID_CHAIN_ID};
+                    edit.flag = rng.chance(40);
+                    usable = true;
+                    break;
+
+                case EditKind::AddSend: {
+                    if (project.tracks.size() < 2)
+                        break;
+                    const auto from = rng.below(static_cast<int>(project.tracks.size()) - 1);
+                    const auto to =
+                        from + 1 + rng.below(static_cast<int>(project.tracks.size()) - from - 1);
+                    if (project.tracks[static_cast<std::size_t>(from)].sends.size() >=
+                        static_cast<std::size_t>(kMaxSendsPerTrack))
+                        break;
+                    edit.site = Site{project.tracks[static_cast<std::size_t>(from)].id};
+                    edit.otherTrackId = project.tracks[static_cast<std::size_t>(to)].id;
+                    edit.flag = rng.chance(40);
+                    usable = true;
+                    break;
+                }
+
+                case EditKind::RemoveSend: {
+                    std::vector<TrackId> withSends;
+                    for (const auto& track : project.tracks)
+                        if (!track.sends.empty())
+                            withSends.push_back(track.id);
+                    if (withSends.empty())
+                        break;
+                    edit.site = Site{rng.pick(withSends)};
+                    edit.position = rng.below(kMaxSendsPerTrack);
+                    usable = true;
+                    break;
+                }
+
+                case EditKind::AddTrack: {
+                    std::vector<TrackId> missing;
+                    for (int i = 0; i < kNumExtraTracks; ++i)
+                        if (std::ranges::none_of(project.tracks, [i](const TrackInfo& track) {
+                                return track.id == kFirstExtraTrack + i;
+                            }))
+                            missing.push_back(kFirstExtraTrack + i);
+                    if (missing.empty())
+                        break;
+                    edit.site = Site{rng.pick(missing)};
+                    edit.position = rng.below(kMaxTrackOrder);
+                    usable = true;
+                    break;
+                }
+
+                case EditKind::RemoveTrack: {
+                    std::vector<TrackId> removable;
+                    for (const auto& track : project.tracks)
+                        if (track.id >= kFirstExtraTrack)
+                            removable.push_back(track.id);
+                    if (removable.empty())
+                        break;
+                    edit.site = Site{rng.pick(removable)};
+                    usable = true;
+                    break;
+                }
+
+                case EditKind::RouteTrack: {
+                    if (project.tracks.size() < 2)
+                        break;
+                    const auto from = rng.below(static_cast<int>(project.tracks.size()) - 1);
+                    edit.site = Site{project.tracks[static_cast<std::size_t>(from)].id};
+                    if (rng.chance(35)) {
+                        edit.otherTrackId = INVALID_TRACK_ID;
+                    } else {
+                        const auto to =
+                            from + 1 +
+                            rng.below(static_cast<int>(project.tracks.size()) - from - 1);
+                        edit.otherTrackId = project.tracks[static_cast<std::size_t>(to)].id;
+                    }
+                    usable = true;
+                    break;
+                }
+            }
+        }
+
+        if (!usable)
+            continue;
+
+        // The ids an edit brings with it are consumed whether or not the edit
+        // lands, so that no two edits in one sequence can name the same new
+        // device: a shrunk sequence would otherwise depend on which of them
+        // survived.
+        switch (edit.kind) {
+            case EditKind::AddDevice:
+            case EditKind::AddInstrument:
+                ++nextDevice;
+                break;
+            case EditKind::AddRack:
+                ++nextRack;
+                nextChain += 2;
+                nextDevice += 2;
+                break;
+            case EditKind::AddChain:
+                ++nextChain;
+                ++nextDevice;
+                break;
+            default:
+                break;
+        }
+
+        apply(edit, project);
+        edits.push_back(edit);
+    }
+
+    return edits;
+}
+
+}  // namespace magda::edits

--- a/tests/PlanEditSequence.cpp
+++ b/tests/PlanEditSequence.cpp
@@ -390,7 +390,7 @@ constexpr int kMaxSendsPerTrack = 3;
 int pickLatency(Rng& rng) {
     if (rng.chance(60))
         return 0;
-    return 1 + rng.below(96);
+    return 1 + rng.below(kMaxDeviceLatency);
 }
 
 }  // namespace

--- a/tests/PlanEditSequence.hpp
+++ b/tests/PlanEditSequence.hpp
@@ -1,0 +1,227 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "core/TrackInfo.hpp"
+#include "plan/RenderPlan.hpp"
+
+/**
+ * @file PlanEditSequence.hpp
+ * @brief Random structural edit sequences over a project (#2077).
+ *
+ * The differ and the crossfade pass are tested elsewhere by pairs of plans
+ * somebody sat down and wrote, which means they are tested against one reading
+ * of the compatibility matrix. This is the other half: a project, a vocabulary
+ * of edits a user can perform on it, and a generator that strings them together
+ * so the properties are asserted over pairs nobody thought of.
+ *
+ * Two decisions here are what make the failures usable.
+ *
+ * **An edit names what it touches, never where it sits.** A device is addressed
+ * by its id and a rack by its own, so an edit applies to whatever the project
+ * has become, and one that finds nothing simply does nothing. That is what lets
+ * a failing sequence be shrunk: any subsequence of it is still a sequence that
+ * runs, so the shrinker can delete an edit without rewriting the ones after it.
+ * Addressing by index would make every deletion invalidate its successors and
+ * the minimal case would be whatever survived the rewriting.
+ *
+ * **The generator refuses to build a project the compiler cannot express.**
+ * Sends and routes only ever point later in project order, so no sequence
+ * produces a routing cycle, and removing a track takes the sends and routes
+ * that named it with it. The runner asserts the compiler emitted no diagnostics,
+ * which turns a generator that has drifted into a test failure rather than into
+ * a corpus quietly exercising the diagnostic path.
+ *
+ * Nothing here compiles, renders or asserts. It is model values and the edits
+ * between them, so the properties and the shrinker share one definition of what
+ * a sequence is.
+ */
+
+namespace magda::edits {
+
+/// Tracks the generator never removes, so a property has something to follow
+/// from the first edit to the last.
+constexpr TrackId kFirstBaseTrack = 1;
+constexpr int kNumBaseTracks = 3;
+
+/// Tracks the generator may add and remove.
+constexpr TrackId kFirstExtraTrack = kFirstBaseTrack + kNumBaseTracks;
+constexpr int kNumExtraTracks = 3;
+
+/**
+ * @brief The analysis device every track carries, and the id it carries it under.
+ *
+ * The render properties need to hear one track on its own, and a track's own
+ * output is not a port anything hands back: everything meets at the master, and
+ * a residual in a sum says nothing about which term moved. So every track gets
+ * a device in its mixer-analysis section, which is a transparent tap by
+ * construction, and the harness binds it to something that records what passes
+ * through. It sits at the very end of the track, after the fader and after both
+ * flat sections, so what it records is what the track contributes.
+ *
+ * Ids are per section and unique across tracks, which is why this is a function
+ * of the track rather than a constant: two tracks with the same analysis id
+ * would be one runtime instance shared by both.
+ */
+constexpr DeviceId captureDeviceId(TrackId trackId) {
+    return 900 + trackId;
+}
+
+/// Where a device or a rack can be added: a track's insert chain, or one chain
+/// of a rack anywhere inside it.
+struct Site {
+    TrackId trackId = INVALID_TRACK_ID;
+    RackId rackId = INVALID_RACK_ID;
+    ChainId chainId = INVALID_CHAIN_ID;
+
+    bool operator==(const Site& other) const {
+        return trackId == other.trackId && rackId == other.rackId && chainId == other.chainId;
+    }
+};
+
+/**
+ * @brief The project an edit sequence runs over.
+ *
+ * Device latency is here rather than in the model because it is not a model
+ * value: it is what a loaded instance reports, and changing it re-prepares the
+ * plan rather than recompiling it. Keeping it beside the tracks is what lets one
+ * sequence exercise both paths.
+ */
+struct Project {
+    std::vector<TrackInfo> tracks;
+    TrackInfo master;
+    std::map<engine::DeviceKey, int> deviceLatency;
+
+    /// Where each track sits in project order, as a sort key rather than as an
+    /// index. Project order decides two things a property compares across runs:
+    /// which direction a connection may point, and the order a fan-in sums its
+    /// inputs. Both have to be a function of which tracks exist rather than of
+    /// which edits ran, or a sequence with an unrelated track removed would put
+    /// the remaining tracks in a different order and every comparison after it
+    /// would be measuring that instead.
+    std::map<TrackId, int> trackOrder;
+};
+
+/** What a single edit does. */
+enum class EditKind : std::uint8_t {
+    AddDevice,
+    AddInstrument,
+    RemoveDevice,
+    MoveDevice,
+    BypassDevice,
+    SetDeviceLatency,
+    AddRack,
+    RemoveRack,
+    AddChain,
+    RemoveChain,
+    ChainPower,
+    AddSend,
+    RemoveSend,
+    SetSidechain,
+    AddTrack,
+    RemoveTrack,
+    RouteTrack,
+};
+
+/// One past the last edit kind. The generator draws from it and the coverage
+/// test requires every one of them to appear, so a kind added here and nowhere
+/// else is a test failure rather than a hole nobody notices.
+constexpr int kNumEditKinds = static_cast<int>(EditKind::RouteTrack) + 1;
+
+/**
+ * @brief One structural edit, as a value.
+ *
+ * Flat and copyable so a sequence is a vector the shrinker can slice. Only the
+ * fields an edit kind uses are set; the rest stay invalid, and toString prints
+ * only what the kind reads so a printed case is unambiguous.
+ */
+struct Edit {
+    EditKind kind = EditKind::AddDevice;
+
+    Site site;
+
+    /// The object the edit names, wherever the project keeps it.
+    DeviceId deviceId = INVALID_DEVICE_ID;
+    RackId rackId = INVALID_RACK_ID;
+    ChainId chainId = INVALID_CHAIN_ID;
+
+    /// The other end: a send's destination, a sidechain's source, a route's
+    /// destination. INVALID_TRACK_ID means the master, or means none.
+    TrackId otherTrackId = INVALID_TRACK_ID;
+
+    /// Where in its container an added or moved element lands. Clamped on
+    /// application, so a shrunk sequence never addresses past the end. For a
+    /// track it is the sort key of Project::trackOrder rather than an index,
+    /// because where a track lands has to depend on the tracks that exist and
+    /// not on which other edits ran.
+    int position = 0;
+
+    /// Latency in samples, for SetDeviceLatency and for a device as it arrives.
+    int latencySamples = 0;
+
+    /// Bypass on or off, chain power on or off, a send pre or post fader.
+    bool flag = false;
+};
+
+/// Canonical one-line text, so a failing case is something to paste back.
+std::string toString(const Edit& edit);
+
+/// A whole sequence, one edit per line, numbered from one.
+std::string toString(const std::vector<Edit>& edits);
+
+/**
+ * @brief The project every sequence starts from.
+ *
+ * Three audio tracks into the master, each with its capture tap and nothing
+ * else. Deliberately bare: what a sequence covers should come from the edits,
+ * so that a shrunk case is the edits that mattered rather than a starting
+ * project somebody chose.
+ */
+Project startingProject();
+
+/**
+ * @brief Apply @p edit to @p project.
+ *
+ * @return false when the edit found nothing to do, which is not a failure: a
+ *         shrunk sequence is full of edits whose target was removed by the
+ *         deletion that shrank it, and they are what a subsequence means.
+ */
+bool apply(const Edit& edit, Project& project);
+
+/**
+ * @brief A sequence of @p length edits from @p seed.
+ *
+ * Stateful: each edit is chosen against the project as it stands, so the
+ * sequence is mostly edits that do something rather than mostly misses. The
+ * edits it emits are still addressed by id, so the sequence survives being cut
+ * up afterwards.
+ */
+std::vector<Edit> generate(std::uint64_t seed, int length);
+
+/**
+ * @brief The tracks whose plan @p edit can change.
+ *
+ * Both ends of a connection, and the track that owns the object an edit names,
+ * read off @p before because that is where the object still is.
+ */
+std::set<TrackId> touched(const Edit& edit, const Project& before);
+
+/**
+ * @brief Every track whose signal reaches @p target, transitively.
+ *
+ * Sends into it, tracks routed into it, and the sources of any sidechain a
+ * device on it reads. This is what "an unrelated edit" is measured against: an
+ * edit on a track outside this set cannot change a sample of what @p target
+ * produces, and the render properties are the assertion that it does not.
+ */
+std::set<TrackId> feeds(const Project& project, TrackId target);
+
+/// Every device id in @p project, per section, which is what the runtime store
+/// keys instances on.
+std::set<engine::DeviceKey> deviceKeys(const Project& project);
+
+}  // namespace magda::edits

--- a/tests/PlanEditSequence.hpp
+++ b/tests/PlanEditSequence.hpp
@@ -53,6 +53,22 @@ constexpr TrackId kFirstExtraTrack = kFirstBaseTrack + kNumBaseTracks;
 constexpr int kNumExtraTracks = 3;
 
 /**
+ * @brief The most a generated device may claim to delay its output by.
+ *
+ * Here rather than beside the device that honours it, because it is the one
+ * number both ends have to agree on and they are in different layers: the
+ * generator writes it into an edit, and whatever plays that edit has to be able
+ * to delay by it. A device that reported more than it delayed would leave the
+ * plan compensating for samples the signal never spent, which is a graph that
+ * is misaligned in fact while every latency assertion about it passes.
+ *
+ * It also bounds how long a render has to run before the last delay line has
+ * filled, which is what lets both legs of a comparison render the same fixed
+ * number of blocks. Raising it means raising that window too.
+ */
+constexpr int kMaxDeviceLatency = 32;
+
+/**
  * @brief The analysis device every track carries, and the id it carries it under.
  *
  * The render properties need to hear one track on its own, and a track's own

--- a/tests/test_plan_edit_properties.cpp
+++ b/tests/test_plan_edit_properties.cpp
@@ -170,13 +170,19 @@ struct Report {
     std::int64_t samplesCompared = 0;
     int steadyStatesCompared = 0;
 
-    /// Transients the step bound was actually measured over, and transients it
-    /// let through because the pass had refused an edge or something upstream
-    /// started flushed. Counted separately because the exemption is the whole
-    /// way the bound can quietly stop existing: one refused edge anywhere in a
-    /// plan exempts every track in it, so a regression that started reporting
-    /// one would disable the bound while every test stayed green.
+    /// Transients the step bound was measured over, those where the signal
+    /// really did move, and those the bound let through because the pass had
+    /// refused an edge or something upstream started flushed. All three count
+    /// only tracks the edit could reach, because that is the population the
+    /// bound is about: a track it could not reach renders what it rendered
+    /// before, and a flat window meets any bound at all.
+    ///
+    /// Counted because the exemption is how the bound can quietly stop
+    /// existing. One refused edge anywhere in a plan exempts every track in it,
+    /// so a regression that started reporting one per publish would disable the
+    /// whole discontinuity bound while every test stayed green.
     int transientsBounded = 0;
+    int transientsMoved = 0;
     int transientsExempt = 0;
 
     void print(const char* name) const {
@@ -189,7 +195,8 @@ struct Report {
                   << "  instances destroyed=" << instancesDestroyed
                   << " samples compared=" << samplesCompared
                   << " steady states compared=" << steadyStatesCompared << "\n"
-                  << "  transients bounded=" << transientsBounded << " exempt=" << transientsExempt
+                  << "  transients on reached tracks: bounded=" << transientsBounded
+                  << " of which moved=" << transientsMoved << ", exempt=" << transientsExempt
                   << std::endl;
     }
 };
@@ -821,8 +828,28 @@ constexpr float kRunawayLevel = 64.0f;
 /// step moves the whole distance between two samples.
 constexpr int kMaxFadeCascade = 8;
 
-std::optional<std::string> checkStepBounds(TrackId trackId, const std::vector<float>& window,
-                                           float before, bool faded, bool flushed, Report* report) {
+/// One window of one track after one edit, and whether that edit could reach it.
+///
+/// The reach is not a condition on the assertion, which is worth making
+/// everywhere: it is a condition on the counting. A track the edit cannot reach
+/// renders the same constant it rendered before, so its window is flat and the
+/// step loop passes over it without ever being asked a question. Counting those
+/// would let the coverage figure be satisfied entirely by tracks that could not
+/// have moved, while every track that did move was exempt.
+struct Transient {
+    TrackId trackId = INVALID_TRACK_ID;
+    const std::vector<float>* window = nullptr;
+    float before = 0.0f;
+    bool faded = false;
+    bool flushed = false;
+    bool reached = false;
+};
+
+std::optional<std::string> checkStepBounds(const Transient& transient, Report* report) {
+    const auto trackId = transient.trackId;
+    const auto& window = *transient.window;
+    const auto before = transient.before;
+
     if (window.empty())
         return std::nullopt;
 
@@ -838,14 +865,11 @@ std::optional<std::string> checkStepBounds(TrackId trackId, const std::vector<fl
     // A path that starts from silence steps by whatever it was carrying, and
     // an edge the pass refused steps by whatever it had left: both are declared
     // divergences rather than failures, and both are counted where they happen.
-    if (!faded || flushed) {
-        if (report != nullptr)
+    if (!transient.faded || transient.flushed) {
+        if (report != nullptr && transient.reached)
             ++report->transientsExempt;
         return std::nullopt;
     }
-
-    if (report != nullptr)
-        ++report->transientsBounded;
 
     // Measured against the distance the transient itself covers, so that no
     // level has to be known: a ramp spreads that distance over the fade and a
@@ -855,6 +879,16 @@ std::optional<std::string> checkStepBounds(TrackId trackId, const std::vector<fl
     for (const auto value : window) {
         low = std::min(low, value);
         high = std::max(high, value);
+    }
+
+    if (report != nullptr && transient.reached) {
+        ++report->transientsBounded;
+
+        // And of those, the ones where something actually moved. A window that
+        // did not move is a bound met by a signal that was never asked to
+        // change, which is not evidence that the bound holds where it matters.
+        if (high - low > kSteadyTolerance)
+            ++report->transientsMoved;
     }
 
     const auto allowance = ((high - low) * static_cast<float>(kMaxFadeCascade) /
@@ -897,7 +931,11 @@ std::optional<std::string> transientProperty(const std::vector<Edit>& edits, Rep
     }
 
     for (std::size_t step = 0; step < edits.size(); ++step) {
+        // Read before the edit lands, because that is where the object it
+        // names still is.
         const auto beforeTracks = project;
+        const auto touchedTracks = edits::touched(edits[step], project);
+
         if (!edits::apply(edits[step], project))
             continue;
 
@@ -945,9 +983,16 @@ std::optional<std::string> transientProperty(const std::vector<Edit>& edits, Rep
             auto upstream = edits::feeds(beforeTracks, trackId);
             upstream.merge(edits::feeds(project, trackId));
 
-            if (const auto problem =
-                    checkStepBounds(trackId, window, steady[trackId], published.faded.unfaded == 0,
-                                    pathStartsFlushed(upstream, before, published), report))
+            Transient transient;
+            transient.trackId = trackId;
+            transient.window = &window;
+            transient.before = steady[trackId];
+            transient.faded = published.faded.unfaded == 0;
+            transient.flushed = pathStartsFlushed(upstream, before, published);
+            transient.reached = std::ranges::any_of(
+                touchedTracks, [&upstream](TrackId touched) { return upstream.contains(touched); });
+
+            if (const auto problem = checkStepBounds(transient, report))
                 return where + *problem;
 
             if (!window.empty())
@@ -1132,8 +1177,10 @@ TEST_CASE("A swap leaves the track it changed inside its own bounds",
     CHECK(report.steadyStatesCompared > 0);
 
     // The bound is skipped wherever the pass refused an edge, which is most
-    // steps, so the one thing that says it still exists is that it was reached.
+    // steps, so the one thing that says it still exists is that it was reached
+    // on a track the edit could move, and reached there with something moving.
     CHECK(report.transientsBounded > 0);
+    CHECK(report.transientsMoved > 0);
 }
 
 TEST_CASE("The differ properties, swept deeply", "[.][deep][engine][plan][diff][property]") {

--- a/tests/test_plan_edit_properties.cpp
+++ b/tests/test_plan_edit_properties.cpp
@@ -170,6 +170,15 @@ struct Report {
     std::int64_t samplesCompared = 0;
     int steadyStatesCompared = 0;
 
+    /// Transients the step bound was actually measured over, and transients it
+    /// let through because the pass had refused an edge or something upstream
+    /// started flushed. Counted separately because the exemption is the whole
+    /// way the bound can quietly stop existing: one refused edge anywhere in a
+    /// plan exempts every track in it, so a regression that started reporting
+    /// one would disable the bound while every test stayed green.
+    int transientsBounded = 0;
+    int transientsExempt = 0;
+
     void print(const char* name) const {
         std::cout << "magda-differ-properties " << name << "\n"
                   << "  sequences=" << sequences << " publishes=" << publishes << "\n"
@@ -179,7 +188,9 @@ struct Report {
                   << "\n"
                   << "  instances destroyed=" << instancesDestroyed
                   << " samples compared=" << samplesCompared
-                  << " steady states compared=" << steadyStatesCompared << std::endl;
+                  << " steady states compared=" << steadyStatesCompared << "\n"
+                  << "  transients bounded=" << transientsBounded << " exempt=" << transientsExempt
+                  << std::endl;
     }
 };
 
@@ -432,24 +443,46 @@ AdoptionPrediction predictAdoptions(const RenderPlan& before, const PreparedLayo
 
 // --- the plan properties -----------------------------------------------------
 
-std::optional<std::string> checkRetirementLedger(const Published& published, const Project& project,
-                                                 const std::vector<engine::DeviceKey>& destroyed) {
-    if (destroyed.empty())
-        return std::nullopt;
-
-    const auto model = edits::deviceKeys(project);
+/// The whole of what the store owes, as three set relations.
+///
+/// A list of what it destroyed answers only the first of them. The second is
+/// what says it let go of anything at all: an instance neither keep-set names
+/// and that was never destroyed is a leak, and a leak looks exactly like a
+/// careful store from inside a list of destructions.
+std::optional<std::string> checkRetirementLedger(const Published& published,
+                                                 const Project& project) {
+    const auto& model = published.modelDevices;
 
     std::set<engine::DeviceKey> playing;
     for (const auto& op : published.faded.plan.ops)
         if (op.kind == engine::OpKind::Device)
             playing.insert(op.key.deviceKey());
 
-    for (const auto& key : destroyed) {
+    // Nothing reachable was destroyed.
+    for (const auto& key : published.destroyed) {
         if (model.contains(key))
             return "an instance the model still holds was destroyed: " + engine::toString(key);
         if (playing.contains(key))
             return "an instance the live plan still plays was destroyed: " + engine::toString(key);
     }
+
+    // Nothing unreachable was kept.
+    for (const auto& key : published.owned)
+        if (!model.contains(key) && !playing.contains(key))
+            return "an instance nothing names is still owned: " + engine::toString(key);
+
+    // And everything that plays is there to play.
+    for (const auto& key : playing)
+        if (!published.owned.contains(key))
+            return "the live plan plays an instance the store does not own: " +
+                   engine::toString(key);
+
+    // The keep-set the store was handed is the model's devices, and this is the
+    // other reading of the same walk. A disagreement here is not a retirement
+    // bug, but it would make every line above an assertion about the wrong set.
+    if (const auto walked = edits::deviceKeys(project); walked != model)
+        return "the engine's walk of the model and the harness's do not agree on which "
+               "devices exist";
 
     return std::nullopt;
 }
@@ -462,6 +495,8 @@ std::optional<std::string> planProperties(const std::vector<Edit>& edits, Report
     if (!published.failure.empty())
         return "step 0: " + published.failure;
     if (const auto problem = checkAlignment(published.faded.plan, published.layout))
+        return "step 0: " + *problem;
+    if (const auto problem = checkRetirementLedger(published, project))
         return "step 0: " + *problem;
 
     for (std::size_t step = 0; step < edits.size(); ++step) {
@@ -509,7 +544,7 @@ std::optional<std::string> planProperties(const std::vector<Edit>& edits, Report
             return where + "the executor adopted " + std::to_string(published.carriedCrossfades) +
                    " fade ramps and the plans say " + std::to_string(prediction.fadeRamps);
 
-        if (const auto problem = checkRetirementLedger(published, project, published.destroyed))
+        if (const auto problem = checkRetirementLedger(published, project))
             return where + *problem;
 
         if (harness.ledger().lastDestroyingThread != std::thread::id{} &&
@@ -787,7 +822,7 @@ constexpr float kRunawayLevel = 64.0f;
 constexpr int kMaxFadeCascade = 8;
 
 std::optional<std::string> checkStepBounds(TrackId trackId, const std::vector<float>& window,
-                                           float before, bool faded, bool flushed) {
+                                           float before, bool faded, bool flushed, Report* report) {
     if (window.empty())
         return std::nullopt;
 
@@ -803,8 +838,14 @@ std::optional<std::string> checkStepBounds(TrackId trackId, const std::vector<fl
     // A path that starts from silence steps by whatever it was carrying, and
     // an edge the pass refused steps by whatever it had left: both are declared
     // divergences rather than failures, and both are counted where they happen.
-    if (!faded || flushed)
+    if (!faded || flushed) {
+        if (report != nullptr)
+            ++report->transientsExempt;
         return std::nullopt;
+    }
+
+    if (report != nullptr)
+        ++report->transientsBounded;
 
     // Measured against the distance the transient itself covers, so that no
     // level has to be known: a ramp spreads that distance over the fade and a
@@ -906,7 +947,7 @@ std::optional<std::string> transientProperty(const std::vector<Edit>& edits, Rep
 
             if (const auto problem =
                     checkStepBounds(trackId, window, steady[trackId], published.faded.unfaded == 0,
-                                    pathStartsFlushed(upstream, before, published)))
+                                    pathStartsFlushed(upstream, before, published), report))
                 return where + *problem;
 
             if (!window.empty())
@@ -1089,6 +1130,10 @@ TEST_CASE("A swap leaves the track it changed inside its own bounds",
 
     CHECK(report.fadesInserted > 0);
     CHECK(report.steadyStatesCompared > 0);
+
+    // The bound is skipped wherever the pass refused an edge, which is most
+    // steps, so the one thing that says it still exists is that it was reached.
+    CHECK(report.transientsBounded > 0);
 }
 
 TEST_CASE("The differ properties, swept deeply", "[.][deep][engine][plan][diff][property]") {
@@ -1117,6 +1162,70 @@ TEST_CASE("The differ properties, swept deeply", "[.][deep][engine][plan][diff][
 // A property test that cannot fail looks exactly like one that passes, and a
 // generator that has drifted into producing nothing is the most likely way for
 // that to happen. These are what says the sweep above is measuring something.
+
+TEST_CASE("A generated device delays by exactly what it reports",
+          "[engine][plan][diff][property]") {
+    // The premise everything about latency here rests on. A device that
+    // reported more than it delayed would leave the plan compensating for
+    // samples the signal never spent: the alignment property would go on
+    // passing, because it reads the plan, and every render under it would be
+    // running on a graph misaligned in fact. Pinned at the largest latency the
+    // generator can hand out, and at nothing, because both ends of the range
+    // are where a ring gets its arithmetic wrong.
+    for (const auto latency : {0, 1, edits::kMaxDeviceLatency / 2, edits::kMaxDeviceLatency}) {
+        INFO("latency " << latency);
+
+        edits::Ledger ledger;
+        edits::TestDevice device(engine::DeviceKey{ChainSegment::Fx, 4}, 1.0f, ledger);
+        device.setLatency(latency);
+        REQUIRE(device.honoursItsLatency());
+        REQUIRE(device.latencySamples() == latency);
+
+        const engine::RenderContext context{edits::kSampleRate, edits::kBlockSize,
+                                            edits::kNumChannels};
+        device.prepare(context);
+
+        // An impulse, and then enough silence for it to come out however far it
+        // is held. Read across block boundaries, because a ring that wrapped
+        // wrong is a ring that is right for the first block only.
+        constexpr int kBlocks = 4;
+        std::vector<float> stream;
+        juce::AudioBuffer<float> buffer(edits::kNumChannels, edits::kBlockSize);
+
+        for (int block = 0; block < kBlocks; ++block) {
+            buffer.clear();
+            if (block == 0)
+                buffer.setSample(0, 0, 1.0f);
+
+            engine::DeviceBlock deviceBlock;
+            deviceBlock.block.numSamples = edits::kBlockSize;
+            deviceBlock.audio = juce::dsp::AudioBlock<float>(buffer);
+            device.process(deviceBlock);
+
+            for (int sample = 0; sample < edits::kBlockSize; ++sample)
+                stream.push_back(buffer.getSample(0, sample));
+        }
+
+        for (std::size_t sample = 0; sample < stream.size(); ++sample) {
+            INFO("sample " << sample);
+            REQUIRE(stream[sample] == (sample == static_cast<std::size_t>(latency) ? 1.0f : 0.0f));
+        }
+    }
+}
+
+TEST_CASE("The generator never asks for a latency a device cannot honour",
+          "[engine][plan][diff][property]") {
+    // The other end of the same claim, and the one that catches the two
+    // constants drifting apart again: whatever the generator writes into an
+    // edit has to be a number the thing playing it can delay by.
+    for (int seed = 1; seed <= 64; ++seed)
+        for (const auto& edit :
+             edits::generate(static_cast<std::uint64_t>(seed), kSequenceLength)) {
+            INFO(edits::toString(edit));
+            REQUIRE(edit.latencySamples >= 0);
+            REQUIRE(edit.latencySamples <= edits::kMaxDeviceLatency);
+        }
+}
 
 TEST_CASE("The generator covers its own vocabulary", "[engine][plan][diff][property]") {
     std::set<int> kinds;

--- a/tests/test_plan_edit_properties.cpp
+++ b/tests/test_plan_edit_properties.cpp
@@ -1,0 +1,1202 @@
+#include <algorithm>
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "PlanEditHarness.hpp"
+#include "PlanEditSequence.hpp"
+#include "plan/PlanCompiler.hpp"
+#include "plan/PlanDiff.hpp"
+#include "plan/PlanDump.hpp"
+#include "plan/RenderPlan.hpp"
+
+/**
+ * @file test_plan_edit_properties.cpp
+ * @brief What the differ decided, over edit sequences nobody wrote (#2077).
+ *
+ * The differ (#2014) and the crossfade of changed edges across a swap (#2019)
+ * are pinned elsewhere by pairs of plans I sat down and wrote, which pins them
+ * against my reading of the compatibility matrix. The space of pairs is the
+ * space of projects squared, and the failures that matter are the ones nobody
+ * thought to write down. So this generates the pairs instead, and asserts
+ * properties rather than answers.
+ *
+ * ## What is asserted, and why each one is not a restatement of the code
+ *
+ * **State compatibility.** An op carries only when it is the same op computing
+ * the same thing from the same places, which is checkable from the two plans
+ * without asking the differ: build a signature out of the op's kind, its ports,
+ * its arity and the keys of whatever feeds each slot, and require the decision
+ * to agree with it in both directions. Soundness alone would be satisfied by a
+ * differ that carried nothing, so completeness is asserted too: an op whose
+ * signature is unchanged and which did not carry is a failure.
+ *
+ * Then the half a signature cannot see, which is what the decision costs at
+ * runtime. The number of delay lines and fade ramps the executor says it
+ * adopted is predicted from the two plans and their resolved layouts, and
+ * required to match exactly. A differ that carried an op whose delay is now a
+ * different length would pass the signature test and fail this one.
+ *
+ * **Retirement.** carriedFrom is a partial injection from the new plan into the
+ * old one, and `retired` is exactly its complement: every old op is adopted once
+ * or retired once, never both and never neither. What that is worth on the
+ * runtime side is asserted through the store: an instance is destroyed only when
+ * neither the live plan nor the model names it, and always on the publishing
+ * thread. And because the harness lets go of the epoch it replaced as soon as
+ * the new one has prepared against it, every render below is also the assertion
+ * that what was carried outlived the epoch it was carried from.
+ *
+ * **PDC alignment.** Every op that fans in has all its inputs arriving at one
+ * latency, and at least one of them waits for nothing, so compensation is what
+ * the paths required rather than what the pass felt like adding. Across a swap,
+ * a track no edit touched reports the same latency at its own output as it did
+ * before: an edit in one branch that silently moves another is exactly what
+ * this catches.
+ *
+ * **Silence and discontinuity outside the changed region.** The one that catches
+ * the most. Every track carries an analysis device that keeps what passed
+ * through it, and a sequence is rendered twice: once whole, and once with every
+ * edit that cannot reach a chosen track removed. The two recordings of that
+ * track have to be equal sample for sample. Not close: equal. The two runs
+ * publish a different number of plans, swap at different moments and carry
+ * different amounts of state across those swaps, and none of that may cost the
+ * track a sample.
+ *
+ * On the track an edit does touch, what is asserted is a bound and a
+ * destination rather than a null, because the edit is meant to change what it
+ * renders: nothing that is not a number, nothing that has run away, no step
+ * where the pass reported it faded every edge it moved, and, once the transient
+ * is over, exactly what a session that had just started on the same project
+ * renders. That last one is the point of carrying state at all: it may change
+ * how the signal gets there, never where it arrives.
+ *
+ * What is deliberately not asserted there is a level. A fade sits on the edge
+ * the edit moved, which is usually inside the chain, and the rest of the chain
+ * then scales a mixture of two internal signals: the result is routinely
+ * outside the two steady states either side of it, and a bound that said
+ * otherwise would be a bound on a project rather than on the engine.
+ *
+ * ## Failures
+ *
+ * A property that reports "failed after 4000 random edits" has said nothing
+ * actionable, so a failure is shrunk before it is printed: edits are deleted
+ * while the property still fails, and what is printed is the minimal sequence
+ * and the seed that found it. Edits address their targets by id precisely so
+ * that any subsequence of one is still a sequence that runs.
+ *
+ * A seed that has ever failed goes into kRecordedSeeds and is run on every
+ * build, whatever the random sweep happens to draw that day.
+ */
+
+using namespace magda;
+using magda::edits::Edit;
+using magda::edits::EditKind;
+using magda::edits::Harness;
+using magda::edits::Material;
+using magda::edits::Project;
+using magda::edits::Published;
+using magda::engine::OpKey;
+using magda::engine::PlanDiff;
+using magda::engine::PreparedLayout;
+using magda::engine::RenderPlan;
+
+namespace {
+
+// --- how much is run ---------------------------------------------------------
+
+/// Long enough that a plan is several edits away from the one it started as,
+/// short enough that a shrunk failure is something to read.
+constexpr int kSequenceLength = 14;
+
+/// The sweep. The plan properties are a compile and a prepare per step, so they
+/// are run over far more sequences than the render properties, which render
+/// five sessions each.
+constexpr int kPlanSeeds = 240;
+constexpr int kRenderSeeds = 24;
+
+/// Blocks rendered after every step of a sequence, applied or not, so that two
+/// runs of one sequence cover the same stretch of timeline whatever they
+/// published. Long enough for the longest delay a generated project can hold
+/// and a whole fade on top of it; the properties assert that bound rather than
+/// assume it.
+constexpr int kBlocksPerStep = 20;
+
+/// And a window shorter than a fade, so the next edit arrives while the last
+/// one is still ramping. That is the case the stacking in #2019 exists for, and
+/// the only way a running ramp is ever what a swap has to carry.
+constexpr int kBlocksMidFade = 2;
+
+/// Seeds that have failed a property. Each one is a case the sweep found once
+/// and would only find again by chance, so it is run on every build.
+constexpr std::array<std::uint64_t, 0> kRecordedSeeds{};
+
+// --- what a property is ------------------------------------------------------
+
+struct Report;
+
+/// A property is something that can be re-run on any subsequence, which is what
+/// lets the shrinker use the same predicate that failed. The report is optional
+/// because a shrink run is not coverage: it re-runs the same sequence dozens of
+/// times and counting those would make the numbers below say nothing.
+using Property = std::function<std::optional<std::string>(const std::vector<Edit>&, Report*)>;
+
+/// What the shrinker asks, which is only whether it still fails.
+using Predicate = std::function<std::optional<std::string>(const std::vector<Edit>&)>;
+
+/// Counts printed on every run rather than only on a failure. A property test
+/// that has quietly stopped exercising anything looks exactly like one that
+/// passes, and these are what says which it is.
+struct Report {
+    int sequences = 0;
+    int publishes = 0;
+    std::int64_t carried = 0;
+    std::int64_t retired = 0;
+    int fadesInserted = 0;
+    int fadesUnfaded = 0;
+    int delayLinesCarried = 0;
+    int fadeRampsCarried = 0;
+    int instancesDestroyed = 0;
+    std::int64_t samplesCompared = 0;
+    int steadyStatesCompared = 0;
+
+    void print(const char* name) const {
+        std::cout << "magda-differ-properties " << name << "\n"
+                  << "  sequences=" << sequences << " publishes=" << publishes << "\n"
+                  << "  ops carried=" << carried << " retired=" << retired << "\n"
+                  << "  fades inserted=" << fadesInserted << " unfaded=" << fadesUnfaded << "\n"
+                  << "  adopted delay lines=" << delayLinesCarried << " ramps=" << fadeRampsCarried
+                  << "\n"
+                  << "  instances destroyed=" << instancesDestroyed
+                  << " samples compared=" << samplesCompared
+                  << " steady states compared=" << steadyStatesCompared << std::endl;
+    }
+};
+
+std::string describe(const OpKey& key) {
+    return engine::toString(key);
+}
+
+/// Everything about an op that has to be unchanged for its runtime state to
+/// mean the same thing. Producers appear by key rather than by index: an edit
+/// anywhere earlier in the plan moves every op after it, and an identity built
+/// on indices would say every op changed.
+std::string signatureOf(const RenderPlan& plan, std::size_t op) {
+    const auto& node = plan.ops[op];
+
+    std::ostringstream out;
+    out << engine::toString(node.kind) << " outputs=";
+    for (const auto kind : node.outputs)
+        out << engine::toString(kind) << ",";
+
+    out << " inputs=";
+    for (const auto& input : node.inputs) {
+        if (!input.valid()) {
+            out << "none;";
+            continue;
+        }
+        out << describe(plan.ops[static_cast<std::size_t>(input.op)].key) << ":" << input.port
+            << ";";
+    }
+
+    return out.str();
+}
+
+std::map<OpKey, std::size_t> indexByKey(const RenderPlan& plan) {
+    std::map<OpKey, std::size_t> byKey;
+    for (std::size_t i = 0; i < plan.ops.size(); ++i)
+        byKey.emplace(plan.ops[i].key, i);
+    return byKey;
+}
+
+std::size_t flatPort(const PreparedLayout& layout, const engine::PortRef& ref) {
+    return static_cast<std::size_t>(layout.portOffsets[static_cast<std::size_t>(ref.op)] +
+                                    ref.port);
+}
+
+int latencyAt(const PreparedLayout& layout, const engine::PortRef& ref) {
+    return layout.latency.portLatency[flatPort(layout, ref)];
+}
+
+// --- the differ's decisions --------------------------------------------------
+
+std::optional<std::string> checkCarry(const RenderPlan& before, const RenderPlan& after,
+                                      const PlanDiff& diff) {
+    if (diff.carriedFrom.size() != after.ops.size())
+        return "carriedFrom has one entry per op of the new plan, and this one does not";
+
+    const auto beforeByKey = indexByKey(before);
+    std::vector<int> adoptions(before.ops.size(), 0);
+    auto carried = 0;
+
+    for (std::size_t i = 0; i < after.ops.size(); ++i) {
+        const auto from = diff.carriedFrom[i];
+        const auto found = beforeByKey.find(after.ops[i].key);
+        const auto couldCarry = found != beforeByKey.end() &&
+                                signatureOf(before, found->second) == signatureOf(after, i);
+
+        if (from == engine::INVALID_OP_ID) {
+            if (couldCarry)
+                return "an op that was the same op in both plans did not carry: " +
+                       describe(after.ops[i].key);
+            continue;
+        }
+
+        if (from < 0 || static_cast<std::size_t>(from) >= before.ops.size())
+            return "carriedFrom names an op the old plan does not have, at " +
+                   describe(after.ops[i].key);
+
+        const auto source = static_cast<std::size_t>(from);
+        ++adoptions[source];
+        ++carried;
+
+        if (before.ops[source].key != after.ops[i].key)
+            return "state carried between two different locations: " +
+                   describe(before.ops[source].key) + " into " + describe(after.ops[i].key);
+
+        if (signatureOf(before, source) != signatureOf(after, i))
+            return "state carried into an op that computes something else: " +
+                   describe(after.ops[i].key) + "\n    was: " + signatureOf(before, source) +
+                   "\n    now: " + signatureOf(after, i);
+    }
+
+    if (carried != diff.carried)
+        return "the carried count does not match the decisions";
+
+    for (std::size_t i = 0; i < adoptions.size(); ++i)
+        if (adoptions[i] > 1)
+            return "one op's state was carried into two: " + describe(before.ops[i].key);
+
+    // Retirement is the complement of adoption, exactly: an op that is neither
+    // is state nothing will ever free, and one that is both is state two
+    // epochs believe they own.
+    std::vector<engine::OpId> expected;
+    for (std::size_t i = 0; i < adoptions.size(); ++i)
+        if (adoptions[i] == 0)
+            expected.push_back(static_cast<engine::OpId>(i));
+
+    if (diff.retired != expected)
+        return "what was retired is not what nothing adopted";
+
+    return std::nullopt;
+}
+
+// --- latency -----------------------------------------------------------------
+
+std::optional<std::string> checkAlignment(const RenderPlan& plan, const PreparedLayout& layout) {
+    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+        const auto& op = plan.ops[i];
+
+        if (layout.latency.delaySamples[i] != 0 && op.kind != engine::OpKind::Delay)
+            return "something other than a delay was given samples to hold: " + describe(op.key);
+        if (layout.latency.delaySamples[i] < 0)
+            return "a delay was asked to hold a negative number of samples: " + describe(op.key);
+
+        // A fade's two sides are deliberately not aligned: where they differ,
+        // the executor refuses the ramp rather than fading in from a delay
+        // line that starts flushed. That is asserted through the ramp count.
+        if (op.kind == engine::OpKind::Crossfade)
+            continue;
+
+        std::optional<int> arriving;
+        auto connected = 0;
+        auto allThroughDelays = true;
+        auto smallestDelay = std::numeric_limits<int>::max();
+
+        for (const auto& input : op.inputs) {
+            if (!input.valid())
+                continue;
+
+            ++connected;
+            const auto latency = latencyAt(layout, input);
+            if (arriving.has_value() && *arriving != latency)
+                return "the inputs of " + describe(op.key) + " arrive at " +
+                       std::to_string(*arriving) + " and " + std::to_string(latency) + " samples";
+            arriving = latency;
+
+            const auto producer = static_cast<std::size_t>(input.op);
+            if (plan.ops[producer].kind != engine::OpKind::Delay)
+                allThroughDelays = false;
+            else
+                smallestDelay = std::min(smallestDelay, layout.latency.delaySamples[producer]);
+        }
+
+        if (connected >= 2 && allThroughDelays && smallestDelay != 0)
+            return "every path into " + describe(op.key) + " was delayed, so all of them wait " +
+                   std::to_string(smallestDelay) + " samples for nothing";
+    }
+
+    auto longest = 0;
+    for (const auto outputOp : plan.outputOps)
+        for (const auto& input : plan.ops[static_cast<std::size_t>(outputOp)].inputs)
+            if (input.valid())
+                longest = std::max(longest, latencyAt(layout, input));
+
+    if (layout.latency.outputLatency != longest)
+        return "the plan reports " + std::to_string(layout.latency.outputLatency) +
+               " samples of latency and its outputs are fed at " + std::to_string(longest);
+
+    return std::nullopt;
+}
+
+/// The op that records what a track produced, which is also the point its own
+/// latency is read at.
+std::optional<std::size_t> captureOp(const RenderPlan& plan, TrackId trackId) {
+    for (std::size_t i = 0; i < plan.ops.size(); ++i) {
+        const auto& key = plan.ops[i].key;
+        if (plan.ops[i].kind == engine::OpKind::Device &&
+            key.segment == ChainSegment::MixerAnalysis && key.trackId == trackId)
+            return i;
+    }
+    return std::nullopt;
+}
+
+int captureLatency(const RenderPlan& plan, const PreparedLayout& layout, TrackId trackId) {
+    const auto op = captureOp(plan, trackId);
+    if (!op.has_value())
+        return -1;
+    return latencyAt(layout, engine::PortRef{static_cast<engine::OpId>(*op), 0});
+}
+
+// --- what the executor adopted -----------------------------------------------
+
+/// What the executor should say it took over, worked out from the two plans and
+/// their layouts alone. An audio line is adopted when the op carried and the
+/// line is still the same length; a MIDI line has a capacity resolved from the
+/// MIDI graph as well, which is not readable from here, so those are bounded
+/// rather than predicted and the bound is exact wherever a plan has none.
+struct AdoptionPrediction {
+    int audioDelayLines = 0;
+    int midiDelayLines = 0;
+    int fadeRamps = 0;
+};
+
+AdoptionPrediction predictAdoptions(const RenderPlan& before, const PreparedLayout& beforeLayout,
+                                    const RenderPlan& after, const PreparedLayout& afterLayout,
+                                    const PlanDiff& diff) {
+    AdoptionPrediction prediction;
+
+    for (std::size_t i = 0; i < after.ops.size(); ++i) {
+        const auto& op = after.ops[i];
+        const auto from = diff.carriedFrom[i];
+
+        if (op.kind == engine::OpKind::Delay) {
+            const auto samples = afterLayout.latency.delaySamples[i];
+            if (samples <= 0)
+                continue;
+
+            const auto isMidi = op.outputs.front() == engine::SignalKind::Midi;
+            if (isMidi)
+                ++prediction.midiDelayLines;
+
+            if (from == engine::INVALID_OP_ID)
+                continue;
+            if (beforeLayout.latency.delaySamples[static_cast<std::size_t>(from)] != samples)
+                continue;
+
+            if (!isMidi)
+                ++prediction.audioDelayLines;
+            continue;
+        }
+
+        if (op.kind != engine::OpKind::Crossfade || from == engine::INVALID_OP_ID)
+            continue;
+
+        // A fade whose sides do not arrive together never had a ramp, on
+        // either side of the swap, so there is nothing to adopt.
+        const auto sidesAgree = [](const RenderPlan& plan, const PreparedLayout& layout,
+                                   std::size_t op) {
+            const auto& node = plan.ops[op];
+            return node.inputs.size() > 1 && node.inputs[0].valid() && node.inputs[1].valid() &&
+                   latencyAt(layout, node.inputs[0]) == latencyAt(layout, node.inputs[1]);
+        };
+
+        if (sidesAgree(after, afterLayout, i) &&
+            before.ops[static_cast<std::size_t>(from)].kind == engine::OpKind::Crossfade &&
+            sidesAgree(before, beforeLayout, static_cast<std::size_t>(from)))
+            ++prediction.fadeRamps;
+    }
+
+    return prediction;
+}
+
+// --- the plan properties -----------------------------------------------------
+
+std::optional<std::string> checkRetirementLedger(const Published& published, const Project& project,
+                                                 const std::vector<engine::DeviceKey>& destroyed) {
+    if (destroyed.empty())
+        return std::nullopt;
+
+    const auto model = edits::deviceKeys(project);
+
+    std::set<engine::DeviceKey> playing;
+    for (const auto& op : published.faded.plan.ops)
+        if (op.kind == engine::OpKind::Device)
+            playing.insert(op.key.deviceKey());
+
+    for (const auto& key : destroyed) {
+        if (model.contains(key))
+            return "an instance the model still holds was destroyed: " + engine::toString(key);
+        if (playing.contains(key))
+            return "an instance the live plan still plays was destroyed: " + engine::toString(key);
+    }
+
+    return std::nullopt;
+}
+
+std::optional<std::string> planProperties(const std::vector<Edit>& edits, Report* report) {
+    Harness harness(Material::Constant);
+    auto project = edits::startingProject();
+
+    auto published = harness.publish(project);
+    if (!published.failure.empty())
+        return "step 0: " + published.failure;
+    if (const auto problem = checkAlignment(published.faded.plan, published.layout))
+        return "step 0: " + *problem;
+
+    for (std::size_t step = 0; step < edits.size(); ++step) {
+        // Read before the edit lands, because that is where the object it
+        // names still is: an edit that removes a device names no track at all
+        // once the device is gone.
+        const auto beforeTracks = project;
+        const auto touchedTracks = edits::touched(edits[step], project);
+
+        if (!edits::apply(edits[step], project))
+            continue;
+
+        const auto before = published;
+        published = harness.publish(project);
+        const auto where =
+            "step " + std::to_string(step + 1) + " (" + edits::toString(edits[step]) + "): ";
+
+        if (!published.failure.empty())
+            return where + published.failure;
+
+        if (const auto problem =
+                checkCarry(before.faded.plan, published.faded.plan, published.diff))
+            return where + *problem;
+
+        if (const auto problem = checkAlignment(published.faded.plan, published.layout))
+            return where + *problem;
+
+        if (published.reportedLatency != published.layout.latency.outputLatency)
+            return where + "the executor reports " + std::to_string(published.reportedLatency) +
+                   " samples of latency and the layout resolves " +
+                   std::to_string(published.layout.latency.outputLatency);
+
+        const auto prediction =
+            predictAdoptions(before.faded.plan, before.layout, published.faded.plan,
+                             published.layout, published.diff);
+
+        if (published.carriedDelayLines < prediction.audioDelayLines ||
+            published.carriedDelayLines > prediction.audioDelayLines + prediction.midiDelayLines)
+            return where + "the executor adopted " + std::to_string(published.carriedDelayLines) +
+                   " delay lines and the plans say " + std::to_string(prediction.audioDelayLines) +
+                   " audio ones, of " + std::to_string(prediction.midiDelayLines) +
+                   " MIDI lines it could also adopt";
+
+        if (published.carriedCrossfades != prediction.fadeRamps)
+            return where + "the executor adopted " + std::to_string(published.carriedCrossfades) +
+                   " fade ramps and the plans say " + std::to_string(prediction.fadeRamps);
+
+        if (const auto problem = checkRetirementLedger(published, project, published.destroyed))
+            return where + *problem;
+
+        if (harness.ledger().lastDestroyingThread != std::thread::id{} &&
+            harness.ledger().lastDestroyingThread != std::this_thread::get_id())
+            return where + "an instance was destroyed on a thread that does not publish";
+
+        // A track no edit reached keeps the latency it reported. An edit that
+        // moves one branch and silently moves another is the failure this is
+        // the only assertion of.
+        for (int i = 0; i < edits::kNumBaseTracks; ++i) {
+            const auto trackId = edits::kFirstBaseTrack + i;
+            const auto reaching = edits::feeds(beforeTracks, trackId);
+
+            if (std::ranges::any_of(touchedTracks, [&reaching](TrackId touchedTrack) {
+                    return reaching.contains(touchedTrack);
+                }))
+                continue;
+
+            const auto was = captureLatency(before.faded.plan, before.layout, trackId);
+            const auto now = captureLatency(published.faded.plan, published.layout, trackId);
+            if (was != now)
+                return where + "track " + std::to_string(trackId) +
+                       " was not touched and its latency moved from " + std::to_string(was) +
+                       " to " + std::to_string(now);
+        }
+
+        if (report != nullptr) {
+            ++report->publishes;
+            report->carried += published.diff.carried;
+            report->retired += static_cast<std::int64_t>(published.diff.retired.size());
+            report->fadesInserted += published.faded.inserted;
+            report->fadesUnfaded += published.faded.unfaded;
+            report->delayLinesCarried += published.carriedDelayLines;
+            report->fadeRampsCarried += published.carriedCrossfades;
+            report->instancesDestroyed += static_cast<int>(published.destroyed.size());
+        }
+    }
+
+    return std::nullopt;
+}
+
+// --- rendering ---------------------------------------------------------------
+
+/// One run of a sequence. Every step renders the same number of blocks whether
+/// or not its edit was applied, so two runs of one sequence cover the same
+/// stretch of timeline and can be compared sample for sample.
+struct Run {
+    std::string failure;
+    std::map<TrackId, std::vector<float>> captures;
+    std::vector<Published> steps;
+};
+
+Run renderRun(const std::vector<Edit>& edits, const std::vector<char>& mask, Material material,
+              int blocksPerStep) {
+    Run run;
+    Harness harness(material);
+    auto project = edits::startingProject();
+
+    const auto publish = [&](std::size_t step) {
+        auto published = harness.publish(project);
+        if (!published.failure.empty())
+            run.failure = "step " + std::to_string(step) + ": " + published.failure;
+
+        run.steps.push_back(std::move(published));
+    };
+
+    publish(0);
+    if (!run.failure.empty())
+        return run;
+    harness.render(blocksPerStep);
+
+    for (std::size_t step = 0; step < edits.size(); ++step) {
+        if (mask[step] != 0 && edits::apply(edits[step], project)) {
+            publish(step + 1);
+            if (!run.failure.empty())
+                return run;
+        } else {
+            run.steps.push_back(Published{});
+        }
+
+        harness.render(blocksPerStep);
+    }
+
+    for (int i = 0; i < edits::kNumBaseTracks; ++i) {
+        const auto trackId = edits::kFirstBaseTrack + i;
+        run.captures[trackId] = harness.capture(trackId);
+    }
+
+    return run;
+}
+
+/// Which edits of a sequence can reach @p target.
+///
+/// An edit is relevant when it touches a track that ever fed the target, over
+/// every state the whole sequence passes through. A union rather than the state
+/// at the time, because an edit that removes a send is the edit that stops a
+/// track feeding the target, and it is plainly relevant to it.
+///
+/// Then a fixed point over that, because relevance travels along the other end
+/// of an edit as well: a route from the target's source to a third track is
+/// relevant, and it does nothing in a run where the edit that made that third
+/// track was dropped. What a kept edit names has to be kept too, or the two
+/// runs differ in what the kept edits did rather than in what was dropped.
+std::vector<char> relevantTo(const std::vector<Edit>& edits, TrackId target) {
+    auto project = edits::startingProject();
+    auto reaching = edits::feeds(project, target);
+
+    std::vector<std::set<TrackId>> touchedAt;
+    touchedAt.reserve(edits.size());
+
+    for (const auto& edit : edits) {
+        touchedAt.push_back(edits::touched(edit, project));
+        edits::apply(edit, project);
+        for (const auto trackId : edits::feeds(project, target))
+            reaching.insert(trackId);
+    }
+
+    std::vector<char> mask(edits.size(), 0);
+    for (auto grew = true; grew;) {
+        grew = false;
+
+        for (std::size_t step = 0; step < edits.size(); ++step) {
+            if (mask[step] != 0)
+                continue;
+            if (std::ranges::none_of(touchedAt[step], [&reaching](TrackId trackId) {
+                    return reaching.contains(trackId);
+                }))
+                continue;
+
+            mask[step] = 1;
+            grew = true;
+            reaching.insert(touchedAt[step].begin(), touchedAt[step].end());
+        }
+    }
+
+    return mask;
+}
+
+std::optional<std::string> compareCaptures(TrackId trackId, const std::vector<float>& whole,
+                                           const std::vector<float>& without, Report* report) {
+    if (whole.size() != without.size())
+        return "track " + std::to_string(trackId) + " rendered " + std::to_string(whole.size()) +
+               " samples with the unrelated edits and " + std::to_string(without.size()) +
+               " without them";
+
+    for (std::size_t sample = 0; sample < whole.size(); ++sample)
+        if (whole[sample] != without[sample])
+            return "track " + std::to_string(trackId) +
+                   " heard an edit that cannot reach it, at "
+                   "sample " +
+                   std::to_string(sample) + ": " + std::to_string(whole[sample]) + " with it and " +
+                   std::to_string(without[sample]) + " without";
+
+    if (report != nullptr)
+        report->samplesCompared += static_cast<std::int64_t>(whole.size());
+
+    return std::nullopt;
+}
+
+std::optional<std::string> nullPropertyWith(const std::vector<Edit>& edits, Report* report,
+                                            int blocksPerStep) {
+    const std::vector<char> everything(edits.size(), 1);
+    const auto whole = renderRun(edits, everything, Material::Ramp, blocksPerStep);
+    if (!whole.failure.empty())
+        return whole.failure;
+
+    if (report != nullptr)
+        for (const auto& step : whole.steps) {
+            if (step.faded.plan.ops.empty())
+                continue;
+            ++report->publishes;
+            report->carried += step.diff.carried;
+            report->retired += static_cast<std::int64_t>(step.diff.retired.size());
+            report->fadesInserted += step.faded.inserted;
+            report->fadesUnfaded += step.faded.unfaded;
+            report->delayLinesCarried += step.carriedDelayLines;
+            report->fadeRampsCarried += step.carriedCrossfades;
+            report->instancesDestroyed += static_cast<int>(step.destroyed.size());
+        }
+
+    for (int i = 0; i < edits::kNumBaseTracks; ++i) {
+        const auto trackId = edits::kFirstBaseTrack + i;
+        const auto mask = relevantTo(edits, trackId);
+
+        // Nothing was dropped, so there is nothing this comparison could say.
+        if (std::ranges::all_of(mask, [](char kept) { return kept != 0; }))
+            continue;
+
+        const auto without = renderRun(edits, mask, Material::Ramp, blocksPerStep);
+        if (!without.failure.empty())
+            return without.failure;
+
+        if (const auto problem = compareCaptures(trackId, whole.captures.at(trackId),
+                                                 without.captures.at(trackId), report))
+            return *problem;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<std::string> nullProperty(const std::vector<Edit>& edits, Report* report) {
+    return nullPropertyWith(edits, report, kBlocksPerStep);
+}
+
+/// The same assertion with the edits arriving faster than a fade can finish, so
+/// every swap lands on an edge that is still ramping. What is being carried
+/// across the swap is then a running fade rather than a settled plan, and an
+/// unrelated track still has to hear none of it.
+std::optional<std::string> nullMidFadeProperty(const std::vector<Edit>& edits, Report* report) {
+    return nullPropertyWith(edits, report, kBlocksMidFade);
+}
+
+// --- the changed track -------------------------------------------------------
+
+/// Whether anything feeding this track starts from silence after the swap: a
+/// delay line that is new or a different length, or a device that has only just
+/// been made and holds its own latency in samples it has never seen. Either one
+/// is a legitimate reason for the signal to step, and both are readable from
+/// the plans rather than guessed at.
+///
+/// Over everything upstream rather than over the track alone. A plugin that
+/// reports new latency rebuilds the compensation around it, and a track two
+/// sends downstream of that hears the rebuilt line start empty exactly as the
+/// track it happened on does.
+bool pathStartsFlushed(const std::set<TrackId>& upstream, const Published& before,
+                       const Published& now) {
+    for (std::size_t i = 0; i < now.faded.plan.ops.size(); ++i) {
+        const auto& op = now.faded.plan.ops[i];
+        if (!upstream.contains(op.key.trackId))
+            continue;
+
+        const auto from =
+            now.diff.carriedFrom.empty() ? engine::INVALID_OP_ID : now.diff.carriedFrom[i];
+
+        if (op.kind == engine::OpKind::Delay) {
+            const auto samples = now.layout.latency.delaySamples[i];
+            if (samples <= 0)
+                continue;
+            if (from == engine::INVALID_OP_ID ||
+                before.layout.latency.delaySamples[static_cast<std::size_t>(from)] != samples)
+                return true;
+            continue;
+        }
+
+        if (op.kind != engine::OpKind::Device)
+            continue;
+
+        const auto latency =
+            latencyAt(now.layout, engine::PortRef{static_cast<engine::OpId>(i), 0});
+        const auto inputLatency =
+            op.inputs.front().valid() ? latencyAt(now.layout, op.inputs.front()) : 0;
+        if (latency > inputLatency && from == engine::INVALID_OP_ID)
+            return true;
+    }
+
+    return false;
+}
+
+constexpr float kSteadyTolerance = 1.0e-6f;
+
+/// Far above anything the material can reach through a graph whose every gain
+/// is below unity, and far below nothing at all. This is a runaway detector
+/// rather than a level check: what a swap leaves the level at is asserted by
+/// convergence, and where the level goes on the way there is not a number this
+/// can know. A fade sits on the edge the edit moved, which is usually inside
+/// the chain, and what the rest of the chain then does to a mixture of two
+/// internal signals is not bounded by the two steady states either side of it.
+constexpr float kRunawayLevel = 64.0f;
+
+/// How much of a fade may arrive in one sample. A fade is a straight line over
+/// fadeSamples, so one sample moves a fadeSamples-th of the distance it covers;
+/// fades cascaded along a path compound that, and eight is far more of them
+/// than one path ever carries. What this separates is a ramp from a step, and a
+/// step moves the whole distance between two samples.
+constexpr int kMaxFadeCascade = 8;
+
+std::optional<std::string> checkStepBounds(TrackId trackId, const std::vector<float>& window,
+                                           float before, bool faded, bool flushed) {
+    if (window.empty())
+        return std::nullopt;
+
+    for (std::size_t sample = 0; sample < window.size(); ++sample) {
+        const auto value = window[sample];
+        if (!std::isfinite(value))
+            return "track " + std::to_string(trackId) + " rendered something that is not a number";
+        if (std::abs(value) > kRunawayLevel)
+            return "track " + std::to_string(trackId) + " ran away at sample " +
+                   std::to_string(sample) + ": " + std::to_string(value);
+    }
+
+    // A path that starts from silence steps by whatever it was carrying, and
+    // an edge the pass refused steps by whatever it had left: both are declared
+    // divergences rather than failures, and both are counted where they happen.
+    if (!faded || flushed)
+        return std::nullopt;
+
+    // Measured against the distance the transient itself covers, so that no
+    // level has to be known: a ramp spreads that distance over the fade and a
+    // step arrives with all of it at once, whatever the two ends happen to be.
+    auto low = before;
+    auto high = before;
+    for (const auto value : window) {
+        low = std::min(low, value);
+        high = std::max(high, value);
+    }
+
+    const auto allowance = ((high - low) * static_cast<float>(kMaxFadeCascade) /
+                            static_cast<float>(edits::fadeSamples())) +
+                           kSteadyTolerance;
+
+    auto previous = before;
+    for (std::size_t sample = 0; sample < window.size(); ++sample) {
+        if (std::abs(window[sample] - previous) > allowance)
+            return "track " + std::to_string(trackId) + " stepped at sample " +
+                   std::to_string(sample) + ": " + std::to_string(previous) + " to " +
+                   std::to_string(window[sample]) + " covers " +
+                   std::to_string(std::abs(window[sample] - previous) / (high - low)) +
+                   " of the transient in one sample, and every edge that moved was faded";
+        previous = window[sample];
+    }
+
+    return std::nullopt;
+}
+
+/// The changed track, and where a swap leaves it. Rendered with a constant per
+/// track, because a bound is measured against a steady state and a ramp has
+/// none.
+std::optional<std::string> transientProperty(const std::vector<Edit>& edits, Report* report) {
+    Harness harness(Material::Constant);
+    auto project = edits::startingProject();
+
+    auto published = harness.publish(project);
+    if (!published.failure.empty())
+        return "step 0: " + published.failure;
+    harness.render(kBlocksPerStep);
+
+    std::map<TrackId, std::size_t> read;
+    std::map<TrackId, float> steady;
+    for (int i = 0; i < edits::kNumBaseTracks; ++i) {
+        const auto trackId = edits::kFirstBaseTrack + i;
+        const auto samples = harness.capture(trackId);
+        read[trackId] = samples.size();
+        steady[trackId] = samples.empty() ? 0.0f : samples.back();
+    }
+
+    for (std::size_t step = 0; step < edits.size(); ++step) {
+        const auto beforeTracks = project;
+        if (!edits::apply(edits[step], project))
+            continue;
+
+        const auto before = published;
+        published = harness.publish(project);
+        const auto where =
+            "step " + std::to_string(step + 1) + " (" + edits::toString(edits[step]) + "): ";
+        if (!published.failure.empty())
+            return where + published.failure;
+
+        // Every steady state below is read at the end of this window, so the
+        // window has to be longer than everything that is still moving inside
+        // it. Asserted rather than assumed: a project that outgrew it would
+        // turn every reading into one taken mid-transient, and the bounds
+        // would go on passing.
+        const auto needed =
+            published.layout.latency.outputLatency + edits::fadeSamples() + edits::kBlockSize;
+        if (needed > kBlocksPerStep * edits::kBlockSize)
+            return where + "the project needs " + std::to_string(needed) +
+                   " samples to settle and the window is " +
+                   std::to_string(kBlocksPerStep * edits::kBlockSize);
+
+        harness.render(kBlocksPerStep);
+
+        // A session that has just opened this project. What it renders once
+        // everything has filled is what carrying state may not change: state
+        // decides how the signal got there, never where it arrives.
+        Harness fresh(Material::Constant);
+        const auto freshPublish = fresh.publish(project);
+        if (!freshPublish.failure.empty())
+            return where + "on a session that had just started, " + freshPublish.failure;
+        fresh.render(kBlocksPerStep);
+
+        for (int i = 0; i < edits::kNumBaseTracks; ++i) {
+            const auto trackId = edits::kFirstBaseTrack + i;
+            const auto samples = harness.capture(trackId);
+
+            std::vector<float> window(samples.begin() + static_cast<std::ptrdiff_t>(read[trackId]),
+                                      samples.end());
+            read[trackId] = samples.size();
+
+            // Both sides of the edit: a route that has just moved fed this
+            // track a moment ago, and whatever it left flushed is still what
+            // this track is hearing.
+            auto upstream = edits::feeds(beforeTracks, trackId);
+            upstream.merge(edits::feeds(project, trackId));
+
+            if (const auto problem =
+                    checkStepBounds(trackId, window, steady[trackId], published.faded.unfaded == 0,
+                                    pathStartsFlushed(upstream, before, published)))
+                return where + *problem;
+
+            if (!window.empty())
+                steady[trackId] = window.back();
+
+            const auto restarted = fresh.capture(trackId);
+            if (restarted.empty() || window.empty())
+                continue;
+
+            if (window.back() != restarted.back())
+                return where + "track " + std::to_string(trackId) + " settled at " +
+                       std::to_string(window.back()) +
+                       " and a session that had just started settles at " +
+                       std::to_string(restarted.back());
+
+            if (report != nullptr)
+                ++report->steadyStatesCompared;
+        }
+
+        if (report != nullptr) {
+            ++report->publishes;
+            report->carried += published.diff.carried;
+            report->retired += static_cast<std::int64_t>(published.diff.retired.size());
+            report->fadesInserted += published.faded.inserted;
+            report->fadesUnfaded += published.faded.unfaded;
+            report->delayLinesCarried += published.carriedDelayLines;
+            report->fadeRampsCarried += published.carriedCrossfades;
+            report->instancesDestroyed += static_cast<int>(published.destroyed.size());
+        }
+    }
+
+    return std::nullopt;
+}
+
+// --- shrinking ---------------------------------------------------------------
+
+constexpr int kMaxShrinkAttempts = 600;
+
+/// Delta debugging, chunks first and then single edits. A sequence is a vector
+/// of edits that name their targets by id, so any subsequence of it runs; that
+/// is what makes deletion the whole of the shrinking strategy.
+std::vector<Edit> shrink(std::vector<Edit> failing, const Predicate& property) {
+    auto attempts = 0;
+    auto granularity = std::max<std::size_t>(failing.size() / 2, 1);
+
+    while (attempts < kMaxShrinkAttempts) {
+        auto removedAny = false;
+
+        for (std::size_t start = 0; start + granularity <= failing.size();) {
+            if (attempts++ >= kMaxShrinkAttempts)
+                break;
+
+            auto candidate = failing;
+            candidate.erase(candidate.begin() + static_cast<std::ptrdiff_t>(start),
+                            candidate.begin() + static_cast<std::ptrdiff_t>(start + granularity));
+
+            if (property(candidate).has_value()) {
+                failing = std::move(candidate);
+                removedAny = true;
+            } else {
+                ++start;
+            }
+        }
+
+        if (granularity == 1) {
+            if (!removedAny)
+                break;
+        } else {
+            granularity = std::max<std::size_t>(granularity / 2, 1);
+        }
+    }
+
+    return failing;
+}
+
+/// Everything a failure has to say to be worth acting on: what broke, the seed
+/// that found it, and the shortest sequence that still breaks it.
+std::string reportFailure(const char* name, std::uint64_t seed, const std::vector<Edit>& edits,
+                          const Predicate& property) {
+    const auto minimal = shrink(edits, property);
+    const auto failure = property(minimal);
+
+    std::ostringstream out;
+    out << name << " failed\n";
+    out << "  seed " << seed << ", " << edits.size() << " edits shrunk to " << minimal.size()
+        << "\n";
+    out << "  " << (failure.has_value() ? *failure : std::string("(it stopped failing)")) << "\n";
+    out << edits::toString(minimal);
+    out << "  add " << seed << " to kRecordedSeeds in this file\n";
+    return out.str();
+}
+
+/// How far the deep sweep goes, overridable so a hunt can be widened without a
+/// rebuild. Anything unset or nonsense takes the default.
+int fromEnvironment(const char* name, int fallback) {
+    const auto* value = std::getenv(name);
+    if (value == nullptr)
+        return fallback;
+
+    const auto parsed = std::atoi(value);
+    return parsed > 0 ? parsed : fallback;
+}
+
+/// Enough failures to see the shape of a regression, and not so many that the
+/// first one scrolls off the top. A systemic break fails every seed, and four
+/// thousand shrunk sequences is not four thousand times as useful as five.
+constexpr int kMaxReportedFailures = 5;
+
+Report sweep(const char* name, int seeds, const Property& property, int length = kSequenceLength) {
+    Report report;
+    const Predicate predicate = [&property](const std::vector<Edit>& edits) {
+        return property(edits, nullptr);
+    };
+
+    std::vector<std::uint64_t> seedList;
+    seedList.reserve(static_cast<std::size_t>(seeds) + kRecordedSeeds.size());
+    for (int i = 0; i < seeds; ++i)
+        seedList.push_back(static_cast<std::uint64_t>(i) + 1);
+    for (const auto seed : kRecordedSeeds)
+        seedList.push_back(seed);
+
+    auto failures = 0;
+    for (const auto seed : seedList) {
+        const auto edits = edits::generate(seed, length);
+        ++report.sequences;
+
+        if (!property(edits, &report).has_value())
+            continue;
+
+        FAIL_CHECK(reportFailure(name, seed, edits, predicate));
+        if (++failures >= kMaxReportedFailures) {
+            FAIL_CHECK(std::string(name) + ": stopped after " +
+                       std::to_string(kMaxReportedFailures) + " failures, with " +
+                       std::to_string(seedList.size() - report.sequences) + " seeds unswept");
+            break;
+        }
+    }
+
+    report.print(name);
+
+    // Numbers that stay at zero are a property that has stopped exercising the
+    // thing it is named after, which reads exactly like one that passes.
+    CHECK(report.publishes > 0);
+    return report;
+}
+
+}  // namespace
+
+// --- the properties ----------------------------------------------------------
+
+TEST_CASE("What the differ decided over random edit sequences", "[engine][plan][diff][property]") {
+    const auto report = sweep("carry, retirement and alignment", kPlanSeeds, planProperties);
+
+    CHECK(report.carried > 0);
+    CHECK(report.retired > 0);
+    CHECK(report.fadesInserted > 0);
+    CHECK(report.delayLinesCarried > 0);
+    CHECK(report.fadeRampsCarried > 0);
+    CHECK(report.instancesDestroyed > 0);
+}
+
+TEST_CASE("An edit is inaudible on the tracks it cannot reach", "[engine][plan][diff][property]") {
+    const auto report = sweep("null on untouched tracks", kRenderSeeds, nullProperty);
+
+    CHECK(report.samplesCompared > 0);
+    CHECK(report.delayLinesCarried > 0);
+}
+
+TEST_CASE("An edit arriving mid-fade is still inaudible where it cannot reach",
+          "[engine][plan][diff][property]") {
+    const auto report = sweep("null across a running fade", kRenderSeeds, nullMidFadeProperty);
+
+    CHECK(report.samplesCompared > 0);
+    CHECK(report.fadeRampsCarried > 0);
+}
+
+TEST_CASE("A swap leaves the track it changed inside its own bounds",
+          "[engine][plan][diff][property]") {
+    const auto report = sweep("transient bounds and convergence", kRenderSeeds, transientProperty);
+
+    CHECK(report.fadesInserted > 0);
+    CHECK(report.steadyStatesCompared > 0);
+}
+
+TEST_CASE("The differ properties, swept deeply", "[.][deep][engine][plan][diff][property]") {
+    // Hidden, because it is minutes rather than seconds. This is the sweep to
+    // reach for when the differ or the crossfade pass changes, and the one a
+    // recorded seed is expected to come out of:
+    //
+    //     ./magda_tests "[deep]"
+    //     MAGDA_DIFFER_SEQUENCE=60 MAGDA_DIFFER_PLAN_SEEDS=20000 ./magda_tests "[deep]"
+    //
+    // Longer sequences are worth more than more of them: a project fourteen
+    // edits old is a project that still looks like the one it started as, and
+    // the pairs that have never been looked at are further out than that.
+    const auto planSeeds = fromEnvironment("MAGDA_DIFFER_PLAN_SEEDS", 4000);
+    const auto renderSeeds = fromEnvironment("MAGDA_DIFFER_RENDER_SEEDS", 400);
+    const auto length = fromEnvironment("MAGDA_DIFFER_SEQUENCE", 40);
+
+    sweep("deep: carry, retirement and alignment", planSeeds, planProperties, length);
+    sweep("deep: null on untouched tracks", renderSeeds, nullProperty, length);
+    sweep("deep: null across a running fade", renderSeeds, nullMidFadeProperty, length);
+    sweep("deep: transient bounds and convergence", renderSeeds, transientProperty, length);
+}
+
+// --- the harness itself ------------------------------------------------------
+//
+// A property test that cannot fail looks exactly like one that passes, and a
+// generator that has drifted into producing nothing is the most likely way for
+// that to happen. These are what says the sweep above is measuring something.
+
+TEST_CASE("The generator covers its own vocabulary", "[engine][plan][diff][property]") {
+    std::set<int> kinds;
+    auto applied = 0;
+    auto total = 0;
+
+    for (int i = 0; i < 64; ++i) {
+        const auto edits = edits::generate(static_cast<std::uint64_t>(i) + 1, kSequenceLength);
+        auto project = edits::startingProject();
+
+        for (const auto& edit : edits) {
+            kinds.insert(static_cast<int>(edit.kind));
+            ++total;
+            applied += edits::apply(edit, project) ? 1 : 0;
+        }
+    }
+
+    // Every kind of edit, and most of them landing rather than missing: a
+    // generator that mostly names things the project does not have would run
+    // the same three plans over and over.
+    CHECK(kinds.size() == static_cast<std::size_t>(edits::kNumEditKinds));
+    CHECK(applied * 2 > total);
+}
+
+TEST_CASE("A sequence that fails shrinks to the edits that made it fail",
+          "[engine][plan][diff][property]") {
+    const auto edits = edits::generate(1, kSequenceLength);
+    REQUIRE(edits.size() > 2);
+
+    // Fails on nothing but the presence of one particular edit, so the minimal
+    // failing sequence is known: exactly that edit, and nothing else.
+    const auto marker = edits[edits.size() / 2];
+    const Predicate property = [&marker](const std::vector<Edit>& candidate) {
+        return std::ranges::any_of(candidate,
+                                   [&marker](const Edit& edit) {
+                                       return edits::toString(edit) == edits::toString(marker);
+                                   })
+                   ? std::optional<std::string>("the marker is here")
+                   : std::nullopt;
+    };
+
+    const auto minimal = shrink(edits, property);
+    REQUIRE(minimal.size() == 1);
+    CHECK(edits::toString(minimal.front()) == edits::toString(marker));
+}
+
+TEST_CASE("Dropping an edit a track can hear does change what it renders",
+          "[engine][plan][diff][property]") {
+    // The other half of the null property, and the one that says it is looking
+    // at anything: dropping the edits that can reach a track has to change what
+    // that track renders. Without this, a null on the untouched tracks would
+    // also pass if the harness were recording silence.
+    auto differed = 0;
+
+    for (int seed = 1; seed <= 8 && differed == 0; ++seed) {
+        const auto edits = edits::generate(static_cast<std::uint64_t>(seed), kSequenceLength);
+        const std::vector<char> everything(edits.size(), 1);
+        const auto whole = renderRun(edits, everything, Material::Ramp, kBlocksPerStep);
+        REQUIRE(whole.failure.empty());
+
+        for (int i = 0; i < edits::kNumBaseTracks; ++i) {
+            const auto trackId = edits::kFirstBaseTrack + i;
+
+            // The complement of the null property's mask: everything that
+            // could reach this track, and nothing else.
+            const auto relevant = relevantTo(edits, trackId);
+            std::vector<char> unrelatedOnly(edits.size(), 0);
+            for (std::size_t step = 0; step < edits.size(); ++step)
+                unrelatedOnly[step] = relevant[step] != 0 ? 0 : 1;
+
+            if (std::ranges::none_of(relevant, [](char kept) { return kept != 0; }))
+                continue;
+
+            const auto without = renderRun(edits, unrelatedOnly, Material::Ramp, kBlocksPerStep);
+            REQUIRE(without.failure.empty());
+
+            if (whole.captures.at(trackId) != without.captures.at(trackId))
+                ++differed;
+        }
+    }
+
+    CHECK(differed > 0);
+}


### PR DESCRIPTION
Closes #2077. Slice 3 of #1896.

The differ (#2014) and the crossfade of changed edges across a swap (#2019) are pinned today by
pairs of plans I sat down and wrote, which pins them against my reading of the compatibility
matrix. The space of pairs is the space of projects squared, and the failures that matter are the
ones nobody thought to write down. This generates the pairs instead.

## The shape

A vocabulary of the edits a user can perform (devices, racks, chains, sends, sidechains, chain
power, tracks, routing, and a plugin changing the latency it reports), a seeded generator that
strings them together against the project as it stands, and every edit addressed by the id of
what it touches rather than by where that sits. That last part is what makes a failure usable:
any subsequence of a sequence still runs, so a failure is shrunk to the edits that caused it
before it is printed, with the seed beside it.

Nothing here needs a `te::Edit`, so it lives in `magda_tests` next to the other plan tests. The
harness is a session in every respect the differ can see, and deliberately not `EngineSession`:
the properties want the timeline to be a number they control, and they want the counts the
executor keeps about what it adopted. What it copies exactly is the order things happen in, so
every render is also the assertion that carried state outlived the epoch it was carried from.

## The properties

**Carry.** An op carries only when it is the same op computing the same thing from the same
places, which is checkable from the two plans without asking the differ: a signature over the
op's kind, its ports, its arity and the keys feeding each slot. Checked in both directions, so a
differ that carried nothing fails as surely as one that carried too much. Then the half a
signature cannot see: the delay lines and fade ramps the executor says it adopted are predicted
from the two plans and their resolved layouts and required to match.

**Retirement.** `carriedFrom` is a partial injection whose complement is exactly `retired`: every
old op is adopted once or retired once, never both and never neither. On the runtime side, the
store frees an instance only once neither the live plan nor the model names it, and always on the
publishing thread.

**PDC alignment.** Every fan-in has all its inputs arriving at one latency with at least one of
them waiting for nothing, and a track no edit reached reports the latency at its own output that
it did before. An edit in one branch that silently moves another is what that last one catches.

**The null, which catches the most.** Every track carries an analysis device that keeps what
passed through it. The sequence is rendered once whole and once with every edit that cannot reach
a chosen track removed, and the two recordings of that track have to be equal sample for sample.
Not close: equal. The two runs publish a different number of plans, swap at different moments and
carry different amounts of state over those swaps, and none of that may cost the track a sample.
A second variant runs the same assertion with the edits arriving faster than a fade can finish,
so what a swap carries is a running ramp rather than a settled plan.

**On the track an edit does change**, a bound and a destination rather than a null: no step where
the pass reported it faded every edge it moved, and, once the transient is over, exactly what a
session that had just opened the same project renders. Carried state may decide how the signal
got there, never where it arrives. Where an edge was refused a fade, or a delay line anywhere
upstream starts flushed, the step is a declared divergence and the bound does not apply, which
the property reads off the pass's own report rather than guessing.

A level is deliberately not asserted there, and the first draft of this got it wrong. A fade sits
on the edge the edit moved, which is usually inside the chain, and the rest of the chain then
scales a mixture of two internal signals: the result is routinely outside the two steady states
either side of it. A bound that said otherwise would be a bound on a project rather than on the
engine.

## Whether it can fail

A property test that cannot fail looks exactly like one that passes, so the engine was broken
four ways before any of this was believed:

| Mutation | Caught by | Shrunk to |
| --- | --- | --- |
| an op whose inputs moved carries anyway | carry, and audibly by the transient bound | 1 edit |
| a delay line never carries | carry, and audibly by the null | 1 edit |
| every compensation delay one sample too long | alignment | 0 edits |
| a fade takes a changed op as its old side | the transient bound | 5 edits |

Three harness tests carry the same weight: the generator has to cover every edit kind with most
of them landing, the shrinker has to reduce a planted failure to the one edit that plants it, and
dropping the edits a track *can* hear has to change what it renders, without which a null on the
untouched tracks would also pass on silence.

## What it found

No engine bug. The deep sweep is four thousand sequences of forty edits: 137k publishes, 7M carry
decisions, 458k retirements, and 47M samples nulled, all clean. What it did find, twice, was the
harness calling an edit unrelated when it was not, both fixed here: an `addTrack` addressed by
index moved where later tracks landed, and relevance had to be closed over the far end of a kept
edit as well as the near one.

`kRecordedSeeds` is therefore empty. The mechanism is in place and runs on every build, for the
first seed that fails.

## Cost

The ordinary run is a few hundred sequences of fourteen edits, about eight seconds inside a
forty-five second suite. The deep sweep is hidden behind a tag and takes eight minutes:

```
./cmake-build-debug/tests/magda_tests "[deep]"
MAGDA_DIFFER_SEQUENCE=60 MAGDA_DIFFER_PLAN_SEEDS=20000 ./cmake-build-debug/tests/magda_tests "[deep]"
```

It is what to reach for when the differ or the crossfade pass changes. Both sweeps print their
counts on every run rather than only on failure, because a property that has quietly stopped
exercising anything reads exactly like one that passes.

## Testing

- `./cmake-build-debug/tests/magda_tests` green: 2617 passed, 13 skipped, 577652 assertions.
- `./cmake-build-debug/tests/magda_tests "[deep]"` green.
- The four mutations above each verified to fail, and the engine reverted byte for byte.