### PR TITLE
Pre/post-fader toggle on the post-FX panel (#2094)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -390,6 +390,7 @@
     "toggle.chord_preview_default": "Preview chord track on playback by default",
     "toggle.auto_crossfade_default": "Auto-crossfade new audio clips",
     "toggle.clip_overlap_plays_both": "New clips play through overlaps",
+    "toggle.post_fx_post_fader_default": "New tracks run post-FX after the fader",
     "toggle.show_tooltips": "Show tooltips",
     "button.add_colour": "+ Add Colour",
     "button.browse": "Browse",

--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -277,6 +277,7 @@ void Config::save() {
     root->setProperty("chordPreviewOnByDefault", chordPreviewOnByDefault);
     root->setProperty("autoCrossfadeByDefault", autoCrossfadeByDefault);
     root->setProperty("clipOverlapPlaysBoth", clipOverlapPlaysBoth);
+    root->setProperty("postFxPostFaderByDefault", postFxPostFaderByDefault);
 
     // Clip colour mode
     root->setProperty("clipColourMode", clipColourMode);
@@ -751,6 +752,7 @@ void Config::load() {
     chordPreviewOnByDefault = getBool("chordPreviewOnByDefault", chordPreviewOnByDefault);
     autoCrossfadeByDefault = getBool("autoCrossfadeByDefault", autoCrossfadeByDefault);
     clipOverlapPlaysBoth = getBool("clipOverlapPlaysBoth", clipOverlapPlaysBoth);
+    postFxPostFaderByDefault = getBool("postFxPostFaderByDefault", postFxPostFaderByDefault);
 
     clipColourMode = getInt("clipColourMode", clipColourMode);
 

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -396,6 +396,16 @@ class Config {
         autoCrossfadeByDefault = enabled;
     }
 
+    // Which side of the track fader a NEW track's post-FX stage (and its mixer
+    // analysis rail) starts on (#2094). Per track from then on, via the fader
+    // tag on the post-FX panel. The master track is always pre-fader.
+    bool getPostFxPostFaderByDefault() const {
+        return postFxPostFaderByDefault;
+    }
+    void setPostFxPostFaderByDefault(bool postFader) {
+        postFxPostFaderByDefault = postFader;
+    }
+
     // What NEW clips start with (#2003): whether they play through an overlap
     // rather than the stack silencing one side. Per clip from then on.
     void setClipOverlapPlaysBoth(bool playBoth) {
@@ -1390,6 +1400,9 @@ class Config {
     // New clips play through their overlaps instead of the clip on top owning
     // the span it covers (see #2003).
     bool clipOverlapPlaysBoth = false;
+
+    // New tracks run their post-FX stage after the track fader (see #2094).
+    bool postFxPostFaderByDefault = true;
 
     // Browser filter settings (media explorer)
     bool browserFilterAudio = true;    // Show audio files by default

--- a/magda/daw/core/TrackManager.cpp
+++ b/magda/daw/core/TrackManager.cpp
@@ -361,6 +361,11 @@ TrackId TrackManager::createTrack(const juce::String& name, TrackType type) {
     if (type == TrackType::Chord)
         track.muted = !Config::getInstance().getChordPreviewOnByDefault();
 
+    // Which side of the fader the post-FX stage starts on. Per track from then
+    // on (the fader tag on the post-FX panel); the master track is pinned
+    // pre-fader by the compilers whatever this says.
+    track.chain.postFxPostFader = Config::getInstance().getPostFxPostFaderByDefault();
+
     // Set default routing
     track.audioOutputDevice = "master";  // Audio always routes to master
     track.audioInputDevice = "";         // Audio input disabled by default (enable via UI)

--- a/magda/daw/ui/dialogs/PreferencesDialog.cpp
+++ b/magda/daw/ui/dialogs/PreferencesDialog.cpp
@@ -228,6 +228,8 @@ class GeneralPage : public juce::Component {
                     tr("preferences.toggle.auto_crossfade_default"));
         setupToggle(*this, clipOverlapPlaysBothToggle,
                     tr("preferences.toggle.clip_overlap_plays_both"));
+        setupToggle(*this, postFxPostFaderDefaultToggle,
+                    tr("preferences.toggle.post_fx_post_fader_default"));
 
         setupSectionHeader(*this, languageHeader, tr("preferences.language.header"));
         setupComboLabel(*this, languageLabel, tr("preferences.language.label"));
@@ -324,6 +326,8 @@ class GeneralPage : public juce::Component {
                                                   juce::dontSendNotification);
         autoCrossfadeDefaultToggle.setToggleState(config.getAutoCrossfadeByDefault(),
                                                   juce::dontSendNotification);
+        postFxPostFaderDefaultToggle.setToggleState(config.getPostFxPostFaderByDefault(),
+                                                    juce::dontSendNotification);
 
         languageCombo.clear(juce::dontSendNotification);
         availableLanguages_.clear();
@@ -379,6 +383,10 @@ class GeneralPage : public juce::Component {
         // default above. Existing clips keep whatever they were set to.
         config.setClipOverlapPlaysBoth(clipOverlapPlaysBothToggle.getToggleState());
 
+        // Same shape again: the side of the fader a new track's post-FX stage
+        // starts on (#2094). Existing tracks keep the side they were set to.
+        config.setPostFxPostFaderByDefault(postFxPostFaderDefaultToggle.getToggleState());
+
         int selIdx = languageCombo.getSelectedId() - 1;
         if (selIdx >= 0 && selIdx < static_cast<int>(availableLanguages_.size())) {
             auto newLang = availableLanguages_[selIdx];
@@ -404,9 +412,10 @@ class GeneralPage : public juce::Component {
         constexpr int headerH = 28;
         constexpr int secGap = 12;
 
+        // The Behaviour block is 10 toggles with a 4px gap between them.
         return padding + headerH + 4 + (rowH * 3) + 8 + secGap + headerH + 4 + (rowH * 2) + 4 +
                secGap + headerH + 4 + rowH + secGap + headerH + 4 + rowH + 4 + rowH + secGap +
-               headerH + 4 + rowH + secGap + headerH + 4 + (rowH * 7) + 16 + secGap + headerH + 4 +
+               headerH + 4 + rowH + secGap + headerH + 4 + (rowH * 10) + 36 + secGap + headerH + 4 +
                rowH + 18 + 4 + rowH + padding;
     }
 
@@ -430,8 +439,8 @@ class GeneralPage : public juce::Component {
         constexpr int headerH = 28;
         constexpr int secGap = 12;
 
-        return padding + headerH + 4 + rowH + 4 + rowH   // Layout
-               + secGap + headerH + 4 + (rowH * 7) + 20  // Behaviour
+        return padding + headerH + 4 + rowH + 4 + rowH    // Layout
+               + secGap + headerH + 4 + (rowH * 10) + 36  // Behaviour: 10 toggles, 4px apart
                + padding;
     }
 
@@ -497,6 +506,8 @@ class GeneralPage : public juce::Component {
         autoCrossfadeDefaultToggle.setBounds(bounds.removeFromTop(rowH).reduced(0, 4));
         bounds.removeFromTop(4);
         clipOverlapPlaysBothToggle.setBounds(bounds.removeFromTop(rowH).reduced(0, 4));
+        bounds.removeFromTop(4);
+        postFxPostFaderDefaultToggle.setBounds(bounds.removeFromTop(rowH).reduced(0, 4));
         bounds.removeFromTop(secGap);
 
         // Language
@@ -586,6 +597,8 @@ class GeneralPage : public juce::Component {
         autoCrossfadeDefaultToggle.setBounds(right.removeFromTop(rowH).reduced(0, 4));
         right.removeFromTop(4);
         clipOverlapPlaysBothToggle.setBounds(right.removeFromTop(rowH).reduced(0, 4));
+        right.removeFromTop(4);
+        postFxPostFaderDefaultToggle.setBounds(right.removeFromTop(rowH).reduced(0, 4));
     }
 
     juce::Label zoomHeader, timelineHeader, transportHeader, autoSaveHeader;
@@ -609,6 +622,7 @@ class GeneralPage : public juce::Component {
     juce::ToggleButton chordPreviewDefaultToggle;
     juce::ToggleButton autoCrossfadeDefaultToggle;
     juce::ToggleButton clipOverlapPlaysBothToggle;
+    juce::ToggleButton postFxPostFaderDefaultToggle;
     juce::Label languageLabel;
     juce::ComboBox languageCombo;
     juce::Label restartHint;

--- a/magda/daw/ui/panels/content/PostFxPanelContent.cpp
+++ b/magda/daw/ui/panels/content/PostFxPanelContent.cpp
@@ -130,6 +130,67 @@ class PostFxPanelContent::Container : public juce::Component, public juce::DragA
 };
 
 //==============================================================================
+// FaderSideTag - the clickable state tag sitting below the "+" on the add
+// strip, mirroring the "POSTFX" watermark above it. Reads and toggles
+// TrackChain::postFxPostFader, which moves the whole post-FX section (and the
+// sends with it) across the track fader. Per-device placement is out of scope.
+//==============================================================================
+class PostFxPanelContent::FaderSideTag : public juce::Component, public juce::TooltipClient {
+  public:
+    explicit FaderSideTag(PostFxPanelContent& owner) : owner_(owner) {
+        setMouseCursor(juce::MouseCursor::PointingHandCursor);
+    }
+
+    void paint(juce::Graphics& g) override {
+        // State, not decoration: full alpha, and accented while hovered.
+        g.setColour(hovered_ ? DarkTheme::getColour(DarkTheme::ACCENT_PRIMARY)
+                             : DarkTheme::getSecondaryTextColour());
+        g.setFont(FontManager::getInstance().getUIFont(9.5f));
+        const int lineH = getHeight() / 2;
+        g.drawText(isPostFader() ? "POST" : "PRE", juce::Rectangle<int>(0, 0, getWidth(), lineH),
+                   juce::Justification::centred);
+        g.drawText("FADER", juce::Rectangle<int>(0, lineH, getWidth(), getHeight() - lineH),
+                   juce::Justification::centred);
+    }
+
+    void mouseEnter(const juce::MouseEvent&) override {
+        hovered_ = true;
+        repaint();
+    }
+
+    void mouseExit(const juce::MouseEvent&) override {
+        hovered_ = false;
+        repaint();
+    }
+
+    void mouseDown(const juce::MouseEvent&) override {
+        if (owner_.trackId_ == magda::INVALID_TRACK_ID)
+            return;
+        // The setter notifies trackDevicesChanged, which relays out and repaints.
+        auto& trackManager = magda::TrackManager::getInstance();
+        trackManager.setPostFxPostFader(owner_.trackId_,
+                                        !trackManager.isPostFxPostFader(owner_.trackId_));
+    }
+
+    juce::String getTooltip() override {
+        return isPostFader() ? "Post-FX and sends run after the track fader. Click to move them "
+                               "before the fader."
+                             : "Post-FX and sends run before the track fader. Click to move them "
+                               "after the fader.";
+    }
+
+  private:
+    // Always read through the model - the tag caches no state of its own.
+    bool isPostFader() const {
+        return owner_.trackId_ != magda::INVALID_TRACK_ID &&
+               magda::TrackManager::getInstance().isPostFxPostFader(owner_.trackId_);
+    }
+
+    PostFxPanelContent& owner_;
+    bool hovered_ = false;
+};
+
+//==============================================================================
 // PostFxPanelContent
 //==============================================================================
 PostFxPanelContent::PostFxPanelContent() {
@@ -149,6 +210,9 @@ PostFxPanelContent::PostFxPanelContent() {
     addButton_.setLookAndFeel(&SmallButtonLookAndFeel::getInstance());
     addButton_.onClick = [this]() { showAddDeviceMenu(); };
     container_->addAndMakeVisible(addButton_);
+
+    faderSideTag_ = std::make_unique<FaderSideTag>(*this);
+    container_->addAndMakeVisible(*faderSideTag_);
 
     magda::TrackManager::getInstance().addListener(this);
 }
@@ -182,7 +246,7 @@ void PostFxPanelContent::trackDevicesChanged(magda::TrackId trackId) {
         return;
     rebuildSlots();
     layoutSlots();
-    repaint();
+    repaint();  // covers the tag too: it is a child of the viewed container
 }
 
 void PostFxPanelContent::rebuildSlots() {
@@ -311,7 +375,7 @@ int PostFxPanelContent::appendZoneX() const {
 }
 
 void PostFxPanelContent::layoutSlots() {
-    if (!container_ || !viewport_)
+    if (!container_ || !viewport_ || !faderSideTag_)
         return;
 
     const bool dragActive = dragInsertIndex_ >= 0 || dropInsertIndex_ >= 0;
@@ -336,6 +400,23 @@ void PostFxPanelContent::layoutSlots() {
     addButton_.setBounds(appendX + juce::jmax(0, (APPEND_ZONE_WIDTH - buttonSize) / 2),
                          juce::jmax(0, (contentH - buttonSize) / 2), buttonSize, buttonSize);
     addButton_.toFront(false);
+
+    // Pre/post-fader tag, in the mirror position below the "+". Hidden on the
+    // master track: the native compiler pins the master post-FX stage pre-fader
+    // whatever the flag says, so a toggle there would lie. Dropped entirely when
+    // the strip is too short to hold it clear of the "+".
+    constexpr int tagHeight = 2 * TAG_LINE_HEIGHT;
+    const int stripBottom = contentH - 10;  // matches the strip's .reduced(6, 10)
+    const int roomBelowButton = stripBottom - addButton_.getBottom();
+    const bool showTag = trackId_ != magda::INVALID_TRACK_ID &&
+                         trackId_ != magda::MASTER_TRACK_ID && roomBelowButton >= tagHeight + 4;
+    faderSideTag_->setVisible(showTag);
+    if (showTag) {
+        faderSideTag_->setBounds(appendX,
+                                 addButton_.getBottom() + (roomBelowButton - tagHeight) / 2,
+                                 APPEND_ZONE_WIDTH, tagHeight);
+        faderSideTag_->toFront(false);
+    }
 }
 
 void PostFxPanelContent::paint(juce::Graphics& g) {

--- a/magda/daw/ui/panels/content/PostFxPanelContent.cpp
+++ b/magda/daw/ui/panels/content/PostFxPanelContent.cpp
@@ -165,10 +165,18 @@ class PostFxPanelContent::FaderSideTag : public juce::Component, public juce::To
         repaint();
     }
 
+    // Click semantics a button would give: primary button only, so a right,
+    // middle or navigation click never changes live routing, and the commit
+    // lands on mouseUp so the click can still be cancelled by dragging off.
     void mouseDown(const juce::MouseEvent& e) override {
-        // A right-click on a small control means "show me options", not "do the
-        // thing"; there is no menu here yet, so it should just do nothing.
-        if (owner_.trackId_ == magda::INVALID_TRACK_ID || e.mods.isPopupMenu())
+        armed_ = e.mods.isLeftButtonDown() && !e.mods.isPopupMenu() &&
+                 owner_.trackId_ != magda::INVALID_TRACK_ID;
+    }
+
+    void mouseUp(const juce::MouseEvent& e) override {
+        const bool commit = armed_ && getLocalBounds().contains(e.getPosition());
+        armed_ = false;
+        if (!commit || owner_.trackId_ == magda::INVALID_TRACK_ID)
             return;
         // The setter notifies trackDevicesChanged, which relays out and repaints.
         auto& trackManager = magda::TrackManager::getInstance();
@@ -192,6 +200,7 @@ class PostFxPanelContent::FaderSideTag : public juce::Component, public juce::To
 
     PostFxPanelContent& owner_;
     bool hovered_ = false;
+    bool armed_ = false;  // a primary-button press landed on the tag
 };
 
 //==============================================================================

--- a/magda/daw/ui/panels/content/PostFxPanelContent.cpp
+++ b/magda/daw/ui/panels/content/PostFxPanelContent.cpp
@@ -132,8 +132,10 @@ class PostFxPanelContent::Container : public juce::Component, public juce::DragA
 //==============================================================================
 // FaderSideTag - the clickable state tag sitting below the "+" on the add
 // strip, mirroring the "POSTFX" watermark above it. Reads and toggles
-// TrackChain::postFxPostFader, which moves the whole post-FX section (and the
-// sends with it) across the track fader. Per-device placement is out of scope.
+// TrackChain::postFxPostFader, which moves the whole post-FX section (with the
+// mixer analysis rail) across the track fader. Sends are not affected: they sit
+// on whichever side their own SendInfo::preFader flag says. Per-device
+// placement is out of scope.
 //==============================================================================
 class PostFxPanelContent::FaderSideTag : public juce::Component, public juce::TooltipClient {
   public:
@@ -163,8 +165,10 @@ class PostFxPanelContent::FaderSideTag : public juce::Component, public juce::To
         repaint();
     }
 
-    void mouseDown(const juce::MouseEvent&) override {
-        if (owner_.trackId_ == magda::INVALID_TRACK_ID)
+    void mouseDown(const juce::MouseEvent& e) override {
+        // A right-click on a small control means "show me options", not "do the
+        // thing"; there is no menu here yet, so it should just do nothing.
+        if (owner_.trackId_ == magda::INVALID_TRACK_ID || e.mods.isPopupMenu())
             return;
         // The setter notifies trackDevicesChanged, which relays out and repaints.
         auto& trackManager = magda::TrackManager::getInstance();
@@ -173,10 +177,10 @@ class PostFxPanelContent::FaderSideTag : public juce::Component, public juce::To
     }
 
     juce::String getTooltip() override {
-        return isPostFader() ? "Post-FX and sends run after the track fader. Click to move them "
-                               "before the fader."
-                             : "Post-FX and sends run before the track fader. Click to move them "
-                               "after the fader.";
+        return isPostFader() ? "Post-FX runs after the track fader. Click to move it before the "
+                               "fader."
+                             : "Post-FX runs before the track fader. Click to move it after the "
+                               "fader.";
     }
 
   private:

--- a/magda/daw/ui/panels/content/PostFxPanelContent.hpp
+++ b/magda/daw/ui/panels/content/PostFxPanelContent.hpp
@@ -47,7 +47,9 @@ class PostFxPanelContent : public juce::Component, public magda::TrackManagerLis
 
   private:
     class Container;
+    class FaderSideTag;
     friend class Container;
+    friend class FaderSideTag;
 
     void rebuildSlots();
     void layoutSlots();
@@ -66,6 +68,7 @@ class PostFxPanelContent : public juce::Component, public magda::TrackManagerLis
     std::unique_ptr<Container> container_;
     std::vector<std::unique_ptr<DeviceSlotComponent>> slots_;
     juce::TextButton addButton_;
+    std::unique_ptr<FaderSideTag> faderSideTag_;
 
     // Drag-to-reorder state (driven by the slots' NodeComponent drag callbacks).
     NodeComponent* draggedNode_ = nullptr;
@@ -81,6 +84,7 @@ class PostFxPanelContent : public juce::Component, public magda::TrackManagerLis
     static constexpr int LEFT_PADDING = 8;
     static constexpr int DRAG_PADDING = 24;       // left room for a "before first" indicator
     static constexpr int APPEND_ZONE_WIDTH = 56;  // "+" add strip (matches FX chain)
+    static constexpr int TAG_LINE_HEIGHT = 11;    // one line of the pre/post-fader tag
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PostFxPanelContent)
 };

--- a/manual/docs/fx-chain.md
+++ b/manual/docs/fx-chain.md
@@ -131,9 +131,15 @@ For an **External Instrument**, the track's own MIDI-out and audio-in selectors 
 
 ## Post-FX Section
 
-In addition to the main FX chain, every track and the master have a **post-FX area** — a stage that runs *after* the main chain and *before* the track fader. It is the natural home for meters and analyzers, but any effect can live there.
+In addition to the main FX chain, every track and the master have a **post-FX area**, a stage that runs *after* the main chain. It is the natural home for meters and analyzers, but any effect can live there.
 
 Toggle the post-FX area from the buttons in the track chain header, then drop an [Oscilloscope or Spectrum Analyzer](devices/analysis.md), or any effect, into it. The panel opens automatically when a track has post-FX devices.
+
+### Which side of the fader it runs on
+
+By default the post-FX area runs *after* the track fader, so a meter there reads the level you are actually sending on. The **PRE FADER** / **POST FADER** tag under the **+** button on the panel's add strip shows the current side and switches it for that track. The whole section moves together; sends keep their own pre/post-fader setting either way.
+
+Master is always pre-fader, so the tag does not appear there. To choose the side new tracks start on, use **New tracks run post-FX after the fader** in [Preferences](interface/preferences.md).
 
 !!! note
     Each analyzer kind is unique per track in the post-FX area — one Oscilloscope and one Spectrum Analyzer at most — while regular effects can repeat.

--- a/manual/docs/interface/preferences.md
+++ b/manual/docs/interface/preferences.md
@@ -18,6 +18,7 @@ The dialog is organised into sections; each section is described below.
 - **Panel visibility defaults** — Choose which panels are shown on startup
 - **Behavior settings** — Configure UI interaction preferences
 - **Auto-crossfade new audio clips** - New audio clips overlap into a [crossfade](../clips.md#crossfades) automatically when they meet a neighbour
+- **New tracks run post-FX after the fader** - The side of the track fader a new track's [post-FX section](../fx-chain.md#post-fx-section) starts on. Existing tracks keep their own setting, which you change from the fader tag on the post-FX panel
 - **Duplicate Loop Range: grow / advance** - When you duplicate the loop range, choose whether the loop grows to cover the copy or advances past it
 - **Auto-hide arrangement scrollbars** — Keep the arrangement scrollbars hidden until you hover near them, for a cleaner workspace
 - **Language** — Select the UI language from the dropdown. The list is populated from the locale files (`.json`) shipped in MAGDA's `lang/` folder, so available languages grow as translations are contributed. A restart-required hint appears after switching; the new language takes effect the next time MAGDA launches. See [Localization](../localization.md) for how translations are managed and how to contribute.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -137,6 +137,8 @@ set(TEST_SOURCES
     test_midi_context.cpp
     test_llama_model_manager.cpp
     test_track_reorder.cpp
+    # New tracks take their post-FX fader side from the preference (#2094)
+    test_post_fx_fader_default.cpp
     test_automation_modes.cpp
     test_automation_stepped_targets.cpp
     test_automation_singleton.cpp

--- a/tests/test_post_fx_fader_default.cpp
+++ b/tests/test_post_fx_fader_default.cpp
@@ -1,0 +1,47 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/core/Config.hpp"
+#include "magda/daw/core/TrackManager.hpp"
+
+using namespace magda;
+
+namespace {
+// Config is a singleton loaded from the user's file, so every test here puts
+// back whatever the preference was on the way out.
+struct PostFxDefaultFixture {
+    PostFxDefaultFixture() : previous_(Config::getInstance().getPostFxPostFaderByDefault()) {
+        TrackManager::getInstance().clearAllTracks();
+    }
+    ~PostFxDefaultFixture() {
+        Config::getInstance().setPostFxPostFaderByDefault(previous_);
+        TrackManager::getInstance().clearAllTracks();
+    }
+
+    bool sideOfNewTrack(bool preferPostFader) {
+        Config::getInstance().setPostFxPostFaderByDefault(preferPostFader);
+        const auto trackId = TrackManager::getInstance().createTrack("PostFx", TrackType::Audio);
+        return TrackManager::getInstance().isPostFxPostFader(trackId);
+    }
+
+  private:
+    bool previous_;
+};
+}  // namespace
+
+TEST_CASE("A new track takes its post-FX fader side from the preference", "[tracks][postfx]") {
+    PostFxDefaultFixture fx;
+
+    SECTION("post-fader preference") {
+        REQUIRE(fx.sideOfNewTrack(true));
+    }
+
+    SECTION("pre-fader preference") {
+        REQUIRE_FALSE(fx.sideOfNewTrack(false));
+    }
+}
+
+TEST_CASE("The shipped post-FX default is post-fader", "[tracks][postfx]") {
+    // The flag's own default, which is what a track deserialized from a project
+    // written before the preference existed falls back to.
+    REQUIRE(TrackChain{}.postFxPostFader);
+}

--- a/tests/test_post_fx_fader_order_juce.cpp
+++ b/tests/test_post_fx_fader_order_juce.cpp
@@ -25,6 +25,7 @@
 #include "magda/daw/audio/plugin_manager/PluginManager.hpp"
 #include "magda/daw/audio/plugins/LevelsPlugin.hpp"
 #include "magda/daw/core/ChainNodePath.hpp"
+#include "magda/daw/core/Config.hpp"
 #include "magda/daw/core/TrackManager.hpp"
 #include "magda/daw/engine/TracktionEngineWrapper.hpp"
 
@@ -74,6 +75,15 @@ class PostFxFaderOrderTest final : public juce::UnitTest {
     PostFxFaderOrderTest() : juce::UnitTest("Post-FX Fader Order Tests", "magda") {}
 
     void runTest() override {
+        // New tracks seed their fader side from the preference (#2094), which is
+        // read off the machine's own config file. Pin it so these engine-order
+        // tests do not depend on how the developer running them has it set.
+        const bool previousDefault = Config::getInstance().getPostFxPostFaderByDefault();
+        Config::getInstance().setPostFxPostFaderByDefault(true);
+        const juce::ScopeGuard restoreDefault{[previousDefault] {
+            Config::getInstance().setPostFxPostFaderByDefault(previousDefault);
+        }};
+
         magda::test::runWithCleanJuceState([this] {
             testPostFaderIsDefault();
             testPreFaderPlacesTheStageBeforeTheFader();


### PR DESCRIPTION
Closes #2094.

`TrackChain::postFxPostFader` landed with #2087 and both engines honour it, but nothing in the UI could set it. This adds the missing control.

A small clickable state tag on the post-FX add strip, in the mirror position below the "+" from the "POSTFX" watermark. It reads "POST FADER" or "PRE FADER" straight off `TrackManager::isPostFxPostFader` at paint time (no cached bool on the component) and flips the whole section across the fader on click. The setter already fires `notifyTrackDevicesChanged`, which lands in the panel's existing `trackDevicesChanged` override, so there is no extra refresh plumbing: the repaint there covers the tag, which is a child of the viewed container.

Per-device placement stays out of scope, as agreed on the issue.

Details:

- Hidden on the master track. The native compiler pins the master post-FX stage pre-fader whatever the flag says (`postFxPostFader && !isMaster`), so a toggle there would lie. Explicit `MASTER_TRACK_ID` check, since `getTrack` returns a valid track for it.
- Hidden on `INVALID_TRACK_ID`, mirroring how `addButton_` visibility is handled.
- Dropped rather than crowded when the strip is short: the tag centres in the gap between the bottom of the "+" and the strip's bottom inset, and only shows when that gap is at least 26px (so from roughly 92px of panel content height up). It never overlaps the "+".
- Secondary text colour at full alpha so it reads as state rather than decoration, accent colour on hover, pointing-hand cursor, and a state-dependent tooltip via `TooltipClient::getTooltip`.

UI wiring only; the model behaviour is covered by the #2087 tests. To see it: open the POST-FX side panel on the right of the device area in the bottom panel, the tag sits under the "+" on the add strip.

## Preference for the default

The tag changes one track at a time, which is the wrong grain if you want every track built the other way round. **New tracks run post-FX after the fader** now sits in the Behaviour section of Preferences, next to the other new-clip and new-track defaults, and `createTrack` seeds `TrackChain::postFxPostFader` from it. Existing tracks keep the side they were set to; master stays pre-fader regardless.

While adding the row I found the Behaviour block's preferred-height sums were already two rows behind the toggles laid out there, so the dialog opened shorter than its own content. They now count the rows that are actually there.

Tests: a model-level Catch2 test covers the seeding both ways, and the engine-order JUCE tests pin the preference for their duration, since they create tracks and would otherwise depend on how the machine running them has it set. Manual updated (`fx-chain.md` also still claimed post-FX ran before the fader, which stopped being true with #2087).
