### PR TITLE
Keep EQ curve readouts inside the plot, and the Enabled checkbox in sync (#2072)

### DIFF
--- a/magda/daw/audio/plugins/compiled/MagdaEqCompiledPlugin.cpp
+++ b/magda/daw/audio/plugins/compiled/MagdaEqCompiledPlugin.cpp
@@ -476,7 +476,8 @@ const CompiledPluginSpec& getMagdaEqSpec() {
         .displayName = "EQ",
         .browserCategory = "EQ",
         .description = "Built-in 8-band parametric equaliser. Per-band Enabled skips inactive "
-                       "biquads; Type selects "
+                       "biquads, and double-clicking a band's dot on the curve toggles it; "
+                       "Type selects "
                        "<b>HP</b>, <b>LowShelf</b>, <b>Bell</b>, <b>HighShelf</b>, "
                        "<b>LP</b>, or <b>Notch</b>. "
                        "MAGDA-owned RBJ biquads drive audio and share coefficient math with "

--- a/magda/daw/ui/components/chain/compiled/CompiledEqCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledEqCurveView.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 
+#include "../../../utils/CurveLabelLayout.hpp"
 #include "audio/plugins/compiled/MagdaEqCompiledPlugin.hpp"
 #include "core/GestureRouter.hpp"
 #include "ui/themes/DarkTheme.hpp"
@@ -412,7 +413,7 @@ void CompiledEqCurveView::paint(juce::Graphics& g) {
         g.setColour(DarkTheme::getColour(DarkTheme::TEXT_PRIMARY).withAlpha(0.85f));
         g.drawFittedText(
             juce::String(b + 1),
-            juce::Rectangle<int>(static_cast<int>(dotX) - 5, static_cast<int>(dotY) - 16, 10, 12),
+            CurveLabelLayout::centredIn(plotArea_, dotX, dotY - 16.0f, 10.0f, 12.0f).toNearestInt(),
             juce::Justification::centred, 1);
 
         // Live readout above the dot for the active band — freq + gain (or
@@ -424,10 +425,11 @@ void CompiledEqCurveView::paint(juce::Graphics& g) {
                     : (juce::String(bandTypeShortName(band.type)) + "  " +
                        frequencyReadout(band.freq));
             g.setColour(DarkTheme::getColour(DarkTheme::TEXT_PRIMARY).withAlpha(0.9f));
-            g.drawFittedText(label,
-                             juce::Rectangle<int>(static_cast<int>(dotX) - 60,
-                                                  static_cast<int>(plotArea_.getY()) + 2, 120, 14),
-                             juce::Justification::centred, 1);
+            g.drawFittedText(
+                label,
+                CurveLabelLayout::centredIn(plotArea_, dotX, plotArea_.getY() + 2.0f, 120.0f, 14.0f)
+                    .toNearestInt(),
+                juce::Justification::centred, 1);
         }
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledEqCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledEqCurveView.cpp
@@ -226,6 +226,20 @@ constexpr float kHitRadiusPx = 12.0f;
 constexpr float kCollapseButtonSize = 18.0f;
 constexpr float kCollapseButtonMargin = 4.0f;
 
+// The active band's live readout owns a strip along the top of the plot. The
+// per-band number rides above its dot and must stay out of that strip, so both
+// are laid out from the same numbers.
+constexpr float kReadoutTopInset = 2.0f;
+constexpr float kReadoutHeight = 14.0f;
+constexpr float kReadoutWidth = 120.0f;
+constexpr float kBandNumberWidth = 10.0f;
+constexpr float kBandNumberHeight = 12.0f;
+constexpr float kBandNumberGap = 6.0f;
+
+float readoutStripBottom(juce::Rectangle<float> plotArea) {
+    return plotArea.getY() + kReadoutTopInset + kReadoutHeight;
+}
+
 bool bandGainAffectsCurve(magda::daw::audio::compiled::MagdaEqCompiledPlugin::BandType t) {
     using BandType = magda::daw::audio::compiled::MagdaEqCompiledPlugin::BandType;
     return t == BandType::Bell || t == BandType::LowShelf || t == BandType::HighShelf;
@@ -414,11 +428,16 @@ void CompiledEqCurveView::paint(juce::Graphics& g) {
             g.drawEllipse(dotX - dotRadius, dotY - dotRadius, dotRadius * 2.0f, dotRadius * 2.0f,
                           isActive ? 1.4f : 1.0f);
         }
+        // Band number, above the dot. The readout strip is only spoken for
+        // while the band is active, so an inactive band's number may use it.
         g.setColour(DarkTheme::getColour(DarkTheme::TEXT_PRIMARY).withAlpha(0.85f));
-        g.drawFittedText(
-            juce::String(b + 1),
-            CurveLabelLayout::centredIn(plotArea_, dotX, dotY - 16.0f, 10.0f, 12.0f).toNearestInt(),
-            juce::Justification::centred, 1);
+        g.drawFittedText(juce::String(b + 1),
+                         CurveLabelLayout::aboveAnchor(plotArea_, dotX, dotY, kBandNumberWidth,
+                                                       kBandNumberHeight, kBandNumberGap,
+                                                       isActive ? readoutStripBottom(plotArea_)
+                                                                : plotArea_.getY())
+                             .toNearestInt(),
+                         juce::Justification::centred, 1);
 
         // Live readout above the dot for the active band — freq + gain (or
         // Q for the no-gain types). Keeps the user oriented while dragging.
@@ -429,11 +448,12 @@ void CompiledEqCurveView::paint(juce::Graphics& g) {
                     : (juce::String(bandTypeShortName(band.type)) + "  " +
                        frequencyReadout(band.freq));
             g.setColour(DarkTheme::getColour(DarkTheme::TEXT_PRIMARY).withAlpha(0.9f));
-            g.drawFittedText(
-                label,
-                CurveLabelLayout::centredIn(plotArea_, dotX, plotArea_.getY() + 2.0f, 120.0f, 14.0f)
-                    .toNearestInt(),
-                juce::Justification::centred, 1);
+            g.drawFittedText(label,
+                             CurveLabelLayout::centredIn(plotArea_, dotX,
+                                                         plotArea_.getY() + kReadoutTopInset,
+                                                         kReadoutWidth, kReadoutHeight)
+                                 .toNearestInt(),
+                             juce::Justification::centred, 1);
         }
     }
 

--- a/magda/daw/ui/components/chain/compiled/CompiledEqCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledEqCurveView.cpp
@@ -265,14 +265,18 @@ void CompiledEqCurveView::resampleFromDevice() {
     using Eq = magda::daw::audio::compiled::MagdaEqCompiledPlugin;
 
     for (int band = 0; band < Eq::kBandCount; ++band) {
+        // Every slot falls back to what is already cached, never to a fixed
+        // default: a snapshot that omits a slot must leave the view showing
+        // the last known state rather than silently reading the band as
+        // disabled (or as a Bell).
         BandSnapshot snap;
-        snap.enabled =
-            valueForSlot(deviceSnapshot_, Eq::bandSlot(band, Eq::kBandEnabledOffset), 0.0f) >= 0.5f;
+        snap.enabled = valueForSlot(deviceSnapshot_, Eq::bandSlot(band, Eq::kBandEnabledOffset),
+                                    bands_[band].enabled ? 1.0f : 0.0f) >= 0.5f;
         const int typeIndex =
             juce::jlimit(0, Eq::kBandTypeCount - 1,
                          static_cast<int>(std::round(
                              valueForSlot(deviceSnapshot_, Eq::bandSlot(band, Eq::kBandTypeOffset),
-                                          static_cast<float>(BandType::Bell)))));
+                                          static_cast<float>(bands_[band].type)))));
         snap.type = static_cast<BandType>(typeIndex);
         snap.freq = valueForSlot(deviceSnapshot_, Eq::bandSlot(band, Eq::kBandFreqOffset),
                                  bands_[band].freq);

--- a/magda/daw/ui/components/chain/compiled/CompiledMultibandCurveView.cpp
+++ b/magda/daw/ui/components/chain/compiled/CompiledMultibandCurveView.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 
+#include "../../../utils/CurveLabelLayout.hpp"
 #include "audio/plugins/compiled/MagdaMultibandCompiledPlugin.hpp"
 #include "core/GestureRouter.hpp"
 #include "ui/themes/DarkTheme.hpp"
@@ -841,7 +842,9 @@ void CompiledMultibandCurveView::paint(juce::Graphics& g) {
 
         g.setColour(colour.withAlpha(rangeActive ? 0.95f : 0.35f));
         g.drawText(rangeText + " dB",
-                   juce::Rectangle<float>(cx - 28.0f, (yUpper + yLower) * 0.5f - 6.0f, 56.0f, 12.0f)
+                   CurveLabelLayout::centredIn(
+                       juce::Rectangle<float>(x0, plot.getY(), x1 - x0, plot.getHeight()), cx,
+                       ((yUpper + yLower) * 0.5f) - 6.0f, 56.0f, 12.0f)
                        .toNearestInt(),
                    juce::Justification::centred);
 
@@ -881,10 +884,10 @@ void CompiledMultibandCurveView::paint(juce::Graphics& g) {
                                   ? juce::String(hz / 1000.0f, 2) + " kHz"
                                   : juce::String(static_cast<int>(std::round(hz))) + " Hz";
             g.setFont(11.0f);
-            g.drawText(
-                text,
-                juce::Rectangle<float>(x - 32.0f, plot.getY() + 2.0f, 64.0f, 14.0f).toNearestInt(),
-                juce::Justification::centred);
+            g.drawText(text,
+                       CurveLabelLayout::centredIn(plot, x, plot.getY() + 2.0f, 64.0f, 14.0f)
+                           .toNearestInt(),
+                       juce::Justification::centred);
         }
     };
     drawXo(lowX, Handle::LowXo, lowXoHz_);

--- a/magda/daw/ui/components/chain/params/ParamSlotComponent.cpp
+++ b/magda/daw/ui/components/chain/params/ParamSlotComponent.cpp
@@ -463,6 +463,12 @@ void ParamSlotComponent::setParamValue(double value) {
     // selection is driven explicitly) showing a stale choice until the whole
     // parameter list is rebuilt.
     syncDiscreteSelection(value);
+    syncBooleanToggle(value);
+}
+
+void ParamSlotComponent::syncBooleanToggle(double value) {
+    if (boolToggle_ && boolToggle_->isVisible())
+        boolToggle_->setToggleState(value >= 0.5, juce::dontSendNotification);
 }
 
 void ParamSlotComponent::syncDiscreteSelection(double value) {

--- a/magda/daw/ui/components/chain/params/ParamSlotComponent.hpp
+++ b/magda/daw/ui/components/chain/params/ParamSlotComponent.hpp
@@ -203,6 +203,11 @@ class ParamSlotComponent : public juce::Component,
     // Called from setParamValue so automation echoes move the widget, not just
     // the underlying slider.
     void syncDiscreteSelection(double value);
+    // Same for the boolean toggle: its tick is set once when the widget is
+    // configured, so without this a write from anywhere else (a device's own
+    // curve view, automation, a macro) leaves the checkbox showing the old
+    // state until the parameter list is rebuilt.
+    void syncBooleanToggle(double value);
     // Push a param's help text onto every widget that can own the mouse, since
     // JUCE resolves tooltips from the component under the pointer only.
     void applyTooltip(const juce::String& tooltip);

--- a/magda/daw/ui/utils/CurveLabelLayout.hpp
+++ b/magda/daw/ui/utils/CurveLabelLayout.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <juce_graphics/juce_graphics.h>
+
+#include <algorithm>
+
+/**
+ * @brief Label placement helpers shared by the device curve views.
+ *
+ * Curve views draw live readouts that track a dot or a handle. Centring a
+ * fixed-width box on the tracked x is fine in the middle of the plot but hangs
+ * over the border once the handle nears either end, so every such box goes
+ * through here instead of being positioned by hand.
+ */
+namespace magda::daw::ui::CurveLabelLayout {
+
+/**
+ * Centre a label box on `centreX` while keeping it inside `area`.
+ *
+ * As the tracked point approaches either end the box stops following it and
+ * slides along the edge instead of spilling past the border. The same clamp
+ * applies vertically, for labels that ride above a dot near the top of the
+ * plot. A box larger than the plot shrinks to fit rather than overflowing on
+ * both sides.
+ *
+ * @param area    Plot rectangle the label must stay inside
+ * @param centreX Preferred horizontal centre (typically the dot/handle x)
+ * @param y       Preferred top edge of the label box
+ * @param width   Preferred label width
+ * @param height  Label height
+ * @return The clamped label box
+ */
+inline juce::Rectangle<float> centredIn(juce::Rectangle<float> area, float centreX, float y,
+                                        float width, float height) {
+    const float w = std::min(width, area.getWidth());
+    const float h = std::min(height, area.getHeight());
+    const float left = juce::jlimit(area.getX(), area.getRight() - w, centreX - (w * 0.5f));
+    const float top = juce::jlimit(area.getY(), area.getBottom() - h, y);
+    return {left, top, w, h};
+}
+
+}  // namespace magda::daw::ui::CurveLabelLayout

--- a/magda/daw/ui/utils/CurveLabelLayout.hpp
+++ b/magda/daw/ui/utils/CurveLabelLayout.hpp
@@ -39,4 +39,30 @@ inline juce::Rectangle<float> centredIn(juce::Rectangle<float> area, float centr
     return {left, top, w, h};
 }
 
+/**
+ * Place a label that rides above an anchor point, flipping below it when the
+ * spot above is not available.
+ *
+ * The anchor is a dot or a handle the label belongs to. Near the top of the
+ * plot there is no room above it, and for an active band the live readout
+ * already owns that strip, so the label goes under the anchor instead of
+ * overpainting either. The result is clamped by centredIn.
+ *
+ * @param area        Plot rectangle the label must stay inside
+ * @param centreX     Preferred horizontal centre (the dot/handle x)
+ * @param anchorY     The dot/handle centre y
+ * @param width       Preferred label width
+ * @param height      Label height
+ * @param gap         Clearance between the anchor and the nearest label edge
+ * @param reservedTop Bottom edge of a strip at the top of `area` that
+ *                    something else owns; pass area.getY() when nothing is
+ * @return The chosen label box
+ */
+inline juce::Rectangle<float> aboveAnchor(juce::Rectangle<float> area, float centreX, float anchorY,
+                                          float width, float height, float gap, float reservedTop) {
+    const float above = anchorY - gap - height;
+    const float below = anchorY + gap;
+    return centredIn(area, centreX, above >= reservedTop ? above : below, width, height);
+}
+
 }  // namespace magda::daw::ui::CurveLabelLayout

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -447,6 +447,16 @@ target_sources(magda_juce_tests PRIVATE
     test_clip_paint_juce.cpp
     test_clip_nudge_juce.cpp
     test_multiband_curve_view_juce.cpp
+    # Boolean param cells follow value-only refreshes (#2072 follow-up).
+    # ParamSlotComponent builds into magda_daw_app, so the test target needs it
+    # and the param helpers it calls into compiled in directly.
+    test_param_slot_boolean_sync_juce.cpp
+    ../magda/daw/ui/components/chain/params/ParamSlotComponent.cpp
+    ../magda/daw/ui/components/chain/params/ParamWidgetSetup.cpp
+    ../magda/daw/ui/components/chain/params/ParamLinkResolver.cpp
+    ../magda/daw/ui/components/chain/params/ParamLinkMenu.cpp
+    ../magda/daw/ui/components/chain/params/ModulationBakeAction.cpp
+    ../magda/daw/ui/components/chain/params/ParamModulationPainter.cpp
     test_timeline_extreme_zoom_paint_juce.cpp
     test_repaint_invariance_juce.cpp
     test_arrange_beat_native_juce.cpp
@@ -581,6 +591,9 @@ add_test(NAME arrangement_transport_loop_juce
 
 add_test(NAME multiband_curve_view_juce
          COMMAND magda_juce_tests "Multiband Curve View Tests")
+
+add_test(NAME param_slot_boolean_sync_juce
+         COMMAND magda_juce_tests "Param Slot Boolean Sync Tests")
 
 add_test(NAME timeline_extreme_zoom_paint_juce
          COMMAND magda_juce_tests "Timeline Extreme Zoom Paint Tests")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -118,6 +118,8 @@ set(TEST_SOURCES
     test_non_ascii_string_literals.cpp
     # Arrangement pointer hit tester (#1719)
     test_arrangement_hit_tester.cpp
+    # Curve-view readout stays inside the plot (#2072)
+    test_curve_label_layout.cpp
     # Keyboard clip nudging (#1957)
     test_clip_nudge.cpp
     test_mono_note_processor.cpp

--- a/tests/test_curve_label_layout.cpp
+++ b/tests/test_curve_label_layout.cpp
@@ -6,6 +6,7 @@
 
 #include "magda/daw/ui/utils/CurveLabelLayout.hpp"
 
+using magda::daw::ui::CurveLabelLayout::aboveAnchor;
 using magda::daw::ui::CurveLabelLayout::centredIn;
 
 namespace {
@@ -88,4 +89,63 @@ TEST_CASE("Curve label is clamped vertically as well", "[ui][curve-label]") {
     const auto low = centredIn(kPlot, kPlot.getCentreX(), kPlot.getBottom() + 4.0f, 10.0f, 12.0f);
     REQUIRE(low.getBottom() == kPlot.getBottom());
     REQUIRE(containedIn(low, kPlot));
+}
+
+// The EQ band number: 10x12, 6px clear of the dot, with the active band's
+// readout occupying the top 16px of the plot.
+namespace {
+
+constexpr float kNumberWidth = 10.0f;
+constexpr float kNumberHeight = 12.0f;
+constexpr float kNumberGap = 6.0f;
+
+juce::Rectangle<float> numberFor(float dotY, bool bandIsActive) {
+    const float readoutBottom = kPlot.getY() + 2.0f + 14.0f;
+    return aboveAnchor(kPlot, kPlot.getCentreX(), dotY, kNumberWidth, kNumberHeight, kNumberGap,
+                       bandIsActive ? readoutBottom : kPlot.getY());
+}
+
+}  // namespace
+
+TEST_CASE("Anchored label sits above its dot when there is room", "[ui][curve-label]") {
+    const float dotY = kPlot.getCentreY();
+
+    for (const bool active : {false, true}) {
+        const auto box = numberFor(dotY, active);
+        REQUIRE(box.getBottom() == dotY - kNumberGap);
+        REQUIRE(containedIn(box, kPlot));
+    }
+}
+
+TEST_CASE("Anchored label flips below its dot rather than leaving the plot", "[ui][curve-label]") {
+    // A band at max gain puts its dot on the top edge.
+    const auto box = numberFor(kPlot.getY(), false);
+    REQUIRE(box.getY() == kPlot.getY() + kNumberGap);
+    REQUIRE(containedIn(box, kPlot));
+}
+
+TEST_CASE("Anchored label keeps clear of the active band's readout", "[ui][curve-label]") {
+    const float readoutBottom = kPlot.getY() + 2.0f + 14.0f;
+
+    SECTION("a dot high enough to collide pushes the number below") {
+        // Above-placement would land inside the readout strip even though it
+        // is still inside the plot, so it must flip.
+        const float dotY = readoutBottom + kNumberGap + kNumberHeight - 1.0f;
+        const auto box = numberFor(dotY, true);
+        REQUIRE(box.getY() == dotY + kNumberGap);
+        REQUIRE(box.getY() >= readoutBottom);
+    }
+
+    SECTION("the same dot keeps the upper spot when the band is idle") {
+        const float dotY = readoutBottom + kNumberGap + kNumberHeight - 1.0f;
+        const auto box = numberFor(dotY, false);
+        REQUIRE(box.getBottom() == dotY - kNumberGap);
+    }
+
+    SECTION("a dot just clear of the strip still sits above") {
+        const float dotY = readoutBottom + kNumberGap + kNumberHeight;
+        const auto box = numberFor(dotY, true);
+        REQUIRE(box.getY() == readoutBottom);
+        REQUIRE(box.getBottom() == dotY - kNumberGap);
+    }
 }

--- a/tests/test_curve_label_layout.cpp
+++ b/tests/test_curve_label_layout.cpp
@@ -1,0 +1,91 @@
+// Tests for the curve-view label clamp (#2072): readouts that track a dot or a
+// handle must stay inside the plot instead of hanging over the border once the
+// tracked point nears either end. Pure geometry, runs headless.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/ui/utils/CurveLabelLayout.hpp"
+
+using magda::daw::ui::CurveLabelLayout::centredIn;
+
+namespace {
+
+// Stands in for an EQ plot area: 8px inset inside a 300x120 view.
+const juce::Rectangle<float> kPlot{8.0f, 8.0f, 284.0f, 104.0f};
+
+// The EQ readout box: 120 wide, parked just under the top edge of the plot.
+juce::Rectangle<float> readoutAt(float dotX) {
+    return centredIn(kPlot, dotX, kPlot.getY() + 2.0f, 120.0f, 14.0f);
+}
+
+bool containedIn(juce::Rectangle<float> box, juce::Rectangle<float> area) {
+    return box.getX() >= area.getX() && box.getRight() <= area.getRight() &&
+           box.getY() >= area.getY() && box.getBottom() <= area.getBottom();
+}
+
+}  // namespace
+
+TEST_CASE("Curve label centres on the tracked point away from the edges", "[ui][curve-label]") {
+    const float centreX = kPlot.getCentreX();
+    const auto box = readoutAt(centreX);
+
+    REQUIRE(box.getWidth() == 120.0f);
+    REQUIRE(box.getCentreX() == centreX);
+    REQUIRE(box.getY() == kPlot.getY() + 2.0f);
+    REQUIRE(containedIn(box, kPlot));
+}
+
+TEST_CASE("Curve label stops at the plot edges instead of following the dot", "[ui][curve-label]") {
+    SECTION("dot at the low end of the frequency range") {
+        const auto box = readoutAt(kPlot.getX());
+        REQUIRE(containedIn(box, kPlot));
+        REQUIRE(box.getX() == kPlot.getX());
+        REQUIRE(box.getWidth() == 120.0f);
+    }
+
+    SECTION("dot at the high end of the frequency range") {
+        const auto box = readoutAt(kPlot.getRight());
+        REQUIRE(containedIn(box, kPlot));
+        REQUIRE(box.getRight() == kPlot.getRight());
+        REQUIRE(box.getWidth() == 120.0f);
+    }
+
+    SECTION("dot past the edge still leaves the box inside") {
+        REQUIRE(containedIn(readoutAt(kPlot.getX() - 500.0f), kPlot));
+        REQUIRE(containedIn(readoutAt(kPlot.getRight() + 500.0f), kPlot));
+    }
+}
+
+TEST_CASE("Curve label slides continuously as the dot approaches an edge", "[ui][curve-label]") {
+    // Inside the clamp zone the box must stay put rather than jump: two dots
+    // 1px apart near the edge share the same box, and the handover from
+    // tracking to sliding happens exactly where the centred box first touches
+    // the border.
+    const float firstTracked = kPlot.getX() + 60.0f;  // half of 120
+    REQUIRE(readoutAt(firstTracked).getX() == kPlot.getX());
+    REQUIRE(readoutAt(firstTracked + 1.0f).getX() == kPlot.getX() + 1.0f);
+    REQUIRE(readoutAt(firstTracked - 1.0f).getX() == kPlot.getX());
+}
+
+TEST_CASE("Curve label shrinks when the plot is narrower than the box", "[ui][curve-label]") {
+    // A collapsed or very narrow device panel must not produce a box that
+    // overflows on both sides.
+    const juce::Rectangle<float> narrow{8.0f, 8.0f, 40.0f, 10.0f};
+    const auto box = centredIn(narrow, narrow.getCentreX(), narrow.getY() + 2.0f, 120.0f, 14.0f);
+
+    REQUIRE(box.getWidth() == narrow.getWidth());
+    REQUIRE(box.getHeight() == narrow.getHeight());
+    REQUIRE(containedIn(box, narrow));
+}
+
+TEST_CASE("Curve label is clamped vertically as well", "[ui][curve-label]") {
+    // The EQ band number rides 16px above its dot; at max gain the dot sits on
+    // the top edge, which would otherwise put the number outside the view.
+    const auto box = centredIn(kPlot, kPlot.getCentreX(), kPlot.getY() - 16.0f, 10.0f, 12.0f);
+    REQUIRE(box.getY() == kPlot.getY());
+    REQUIRE(containedIn(box, kPlot));
+
+    const auto low = centredIn(kPlot, kPlot.getCentreX(), kPlot.getBottom() + 4.0f, 10.0f, 12.0f);
+    REQUIRE(low.getBottom() == kPlot.getBottom());
+    REQUIRE(containedIn(low, kPlot));
+}

--- a/tests/test_param_slot_boolean_sync_juce.cpp
+++ b/tests/test_param_slot_boolean_sync_juce.cpp
@@ -1,0 +1,79 @@
+// A boolean parameter's checkbox must follow value-only refreshes, not just
+// full widget rebuilds (#2072 follow-up). The EQ writes Band N Enabled from
+// its own curve view on double-click; the grid cell for that parameter is
+// refreshed through ParamSlotComponent::setParamValue, which moved the slider
+// and the discrete widgets but left the toggle showing the old tick.
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "magda/daw/ui/components/chain/params/ParamSlotComponent.hpp"
+
+namespace {
+
+using Slot = magda::daw::ui::ParamSlotComponent;
+
+magda::ParameterInfo booleanParam(float currentValue) {
+    magda::ParameterInfo param;
+    param.paramIndex = 0;
+    param.name = "Band 1 Enabled";
+    param.scale = magda::ParameterScale::Boolean;
+    param.minValue = 0.0f;
+    param.maxValue = 1.0f;
+    param.currentValue = currentValue;
+    return param;
+}
+
+// The toggle is a private member, so assert on what the cell actually shows:
+// its visible ToggleButton child.
+const juce::ToggleButton* visibleToggleIn(const juce::Component& slot) {
+    for (int i = 0; i < slot.getNumChildComponents(); ++i) {
+        if (const auto* toggle = dynamic_cast<const juce::ToggleButton*>(slot.getChildComponent(i)))
+            if (toggle->isVisible())
+                return toggle;
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+class ParamSlotBooleanSyncTest final : public juce::UnitTest {
+  public:
+    ParamSlotBooleanSyncTest() : juce::UnitTest("Param Slot Boolean Sync Tests", "magda") {}
+
+    void runTest() override {
+        beginTest("Toggle starts from the parameter's current value");
+        {
+            Slot slot{0};
+            slot.setParameterInfo(booleanParam(1.0f));
+
+            const auto* toggle = visibleToggleIn(slot);
+            expect(toggle != nullptr, "A boolean param must show a toggle");
+            if (toggle != nullptr)
+                expect(toggle->getToggleState(), "A param that is on must start ticked");
+        }
+
+        beginTest("Toggle follows a value-only refresh");
+        {
+            Slot slot{0};
+            slot.setParameterInfo(booleanParam(0.0f));
+
+            const auto* toggle = visibleToggleIn(slot);
+            expect(toggle != nullptr, "A boolean param must show a toggle");
+            if (toggle == nullptr)
+                return;
+
+            expect(!toggle->getToggleState(), "A param that is off must start unticked");
+
+            // What a write from the device's own curve view lands on.
+            slot.setParamValue(1.0);
+            expect(toggle->getToggleState(),
+                   "Enabling the band elsewhere must tick the grid checkbox");
+
+            slot.setParamValue(0.0);
+            expect(!toggle->getToggleState(),
+                   "Disabling the band elsewhere must clear the grid checkbox");
+        }
+    }
+};
+
+static ParamSlotBooleanSyncTest paramSlotBooleanSyncTest;


### PR DESCRIPTION
Closes #2072.

### The readout ran outside the plot

The EQ's live readout was a fixed 120-wide box centred on the band dot with nothing clamping it, so once `dotX` came within 60 px of either edge the box hung over the border: below roughly 35 Hz or above 10 kHz the text spilled outside the view.

New `magda/daw/ui/utils/CurveLabelLayout.hpp` holds the one helper every curve view now positions its readouts with. `centredIn` centres a box on the tracked point but clamps it into the plot, so near an edge the box slides along the border instead of following the dot out of view. The clamp applies vertically too, and a box larger than the plot shrinks to fit rather than overflowing both sides.

Applied to:

- the EQ readout, and the per-band number, which rides 16 px above its dot and so was drawn above the view entirely at max gain
- `CompiledMultibandCurveView`, which the issue flagged as drawing its readout the same way: the crossover readout is clamped to the plot, the range readout to its own band

### The Enabled checkbox did not follow the curve

Separate defect found while documenting the double-click gesture. Double-clicking a band on the curve writes `Band N Enabled`, but the grid cell for it kept showing the old tick.

`ParamSlotComponent`'s toggle state was only ever set in `configureBoolToggle`, which runs when the widget is configured. Both value-only refresh paths — `ParamHostComponent::updateParameterValues` and the single-param echo in `DeviceParameterChangeHandler` — land in `setParamValue`, which re-pointed the slider and the discrete widgets but not the toggle. The comment already in that function describes the identical bug for discrete widgets; Boolean had been missed.

`setParamValue` now calls a new `syncBooleanToggle`, so any writer moves the checkbox: a device's own curve view, automation, a macro, a control surface.

### Also in here

- `CompiledEqCurveView::resampleFromDevice` fell back to `false` for `enabled` and `Bell` for `type` while `freq`/`gain`/`q` fell back to the cached value, so a `DeviceInfo` snapshot omitting those slots read every band as a disabled Bell. All five now fall back to what is cached.
- The EQ's catalog description mentions the double-click gesture. Worded as a toggle rather than an enable, since `mouseDoubleClick` flips the state — double-clicking an active band switches it off again.

### Tests

- `tests/test_curve_label_layout.cpp` (Catch2): centre tracking, both edges, the handover from tracking to sliding, narrow plots, the vertical clamp.
- `tests/test_param_slot_boolean_sync_juce.cpp` (JUCE target, where `ParamSlotComponent` links): initial tick, and the toggle following a value-only refresh in both directions. Verified it fails without the fix (`Enabling the band elsewhere must tick the grid checkbox`).

Both suites green locally: 2637 Catch2 cases, all JUCE suites.
