### PR TITLE
Keep test runs out of the developer's settings file (#2105)

### DIFF
--- a/magda/daw/core/AppPaths.cpp
+++ b/magda/daw/core/AppPaths.cpp
@@ -164,6 +164,16 @@ juce::File themesDir() {
 }
 
 juce::File configFile() {
+    // MAGDA_CONFIG_FILE redirects the settings file wholesale. This exists so a
+    // process that is not the user's DAW session -- the test binaries above all
+    // -- cannot write their in-memory Config over the developer's real
+    // settings. Config::save() persists the WHOLE singleton, so one save from a
+    // Config that was never load()ed replaces every preference with defaults.
+    //
+    // Read on every call rather than cached in the resolve() snapshot: config
+    // has to be readable before resolve() has run.
+    if (const auto override_ = envVar("MAGDA_CONFIG_FILE"); override_.isNotEmpty())
+        return juce::File(override_);
     return alwaysOSDefault().getChildFile("config.json");
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -454,8 +454,10 @@ target_sources(magda_juce_tests PRIVATE
     test_clip_nudge_juce.cpp
     test_multiband_curve_view_juce.cpp
     # Keep test runs out of the developer's real config.json (see the copy in
-    # magda_tests): RemoteApiHost persists grants via Config::save().
+    # magda_tests): RemoteApiHost persists grants via Config::save(). The guard
+    # test is duplicated per target because each uses its own framework.
     TestConfigRedirect.cpp
+    test_config_path_redirect_juce.cpp
     # Boolean param cells follow value-only refreshes (#2072 follow-up).
     # ParamSlotComponent builds into magda_daw_app, so the test target needs it
     # and the param helpers it calls into compiled in directly.
@@ -600,6 +602,9 @@ add_test(NAME arrangement_transport_loop_juce
 
 add_test(NAME multiband_curve_view_juce
          COMMAND magda_juce_tests "Multiband Curve View Tests")
+
+add_test(NAME config_path_redirect_juce
+         COMMAND magda_juce_tests "Config Path Redirect Tests")
 
 add_test(NAME param_slot_boolean_sync_juce
          COMMAND magda_juce_tests "Param Slot Boolean Sync Tests")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,6 +120,10 @@ set(TEST_SOURCES
     test_arrangement_hit_tester.cpp
     # Curve-view readout stays inside the plot (#2072)
     test_curve_label_layout.cpp
+    # Keep test runs out of the developer's real config.json. The redirect must
+    # be linked into every test binary, and the guard test proves it took.
+    TestConfigRedirect.cpp
+    test_config_path_redirect.cpp
     # Keyboard clip nudging (#1957)
     test_clip_nudge.cpp
     test_mono_note_processor.cpp
@@ -449,6 +453,9 @@ target_sources(magda_juce_tests PRIVATE
     test_clip_paint_juce.cpp
     test_clip_nudge_juce.cpp
     test_multiband_curve_view_juce.cpp
+    # Keep test runs out of the developer's real config.json (see the copy in
+    # magda_tests): RemoteApiHost persists grants via Config::save().
+    TestConfigRedirect.cpp
     # Boolean param cells follow value-only refreshes (#2072 follow-up).
     # ParamSlotComponent builds into magda_daw_app, so the test target needs it
     # and the param helpers it calls into compiled in directly.

--- a/tests/TestConfigRedirect.cpp
+++ b/tests/TestConfigRedirect.cpp
@@ -1,0 +1,36 @@
+// Keep the test binaries away from the developer's real settings file.
+//
+// Config::save() persists the WHOLE singleton, and no test loads it, so a
+// single save from a test process replaces every preference in
+// ~/Library/MAGDA/config.json with defaults -- API keys included. That is not
+// hypothetical: RemoteApiHost persists client grants by calling Config::save(),
+// so simply constructing one in a test wrote defaults over the real file.
+//
+// This runs before main(), so the redirect is in place no matter which test
+// executes first or how the binary is invoked.
+
+#include <juce_core/juce_core.h>
+
+#include <cstdlib>
+
+namespace {
+
+struct RedirectConfigFile {
+    RedirectConfigFile() {
+        auto dir = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                       .getChildFile("magda-test-config");
+        dir.createDirectory();
+        const auto path = dir.getChildFile("config.json").getFullPathName();
+
+#if JUCE_WINDOWS
+        _putenv_s("MAGDA_CONFIG_FILE", path.toRawUTF8());
+#else
+        setenv("MAGDA_CONFIG_FILE", path.toRawUTF8(), 1);
+#endif
+    }
+};
+
+// Namespace-scope, so it is constructed during static initialisation.
+const RedirectConfigFile redirectConfigFile;
+
+}  // namespace

--- a/tests/TestConfigRedirect.cpp
+++ b/tests/TestConfigRedirect.cpp
@@ -23,7 +23,14 @@ struct RedirectConfigFile {
         // A name per process, not a shared one: two test binaries running at
         // once (ctest does that) must never see each other's settings if a test
         // ever starts reading config back.
-        const auto path = dir.getNonexistentChildFile("config", ".json").getFullPathName();
+        //
+        // A UUID rather than getNonexistentChildFile(): that only checks whether
+        // a candidate exists right now and does not reserve it, so two processes
+        // starting together would both pick the same free name. Nothing writes
+        // the file at this point, so there is no name to reserve -- uniqueness
+        // has to come from the name itself.
+        const auto path =
+            dir.getChildFile("config-" + juce::Uuid().toDashedString() + ".json").getFullPathName();
 
 #if JUCE_WINDOWS
         _putenv_s("MAGDA_CONFIG_FILE", path.toRawUTF8());

--- a/tests/TestConfigRedirect.cpp
+++ b/tests/TestConfigRedirect.cpp
@@ -20,7 +20,10 @@ struct RedirectConfigFile {
         auto dir = juce::File::getSpecialLocation(juce::File::tempDirectory)
                        .getChildFile("magda-test-config");
         dir.createDirectory();
-        const auto path = dir.getChildFile("config.json").getFullPathName();
+        // A name per process, not a shared one: two test binaries running at
+        // once (ctest does that) must never see each other's settings if a test
+        // ever starts reading config back.
+        const auto path = dir.getNonexistentChildFile("config", ".json").getFullPathName();
 
 #if JUCE_WINDOWS
         _putenv_s("MAGDA_CONFIG_FILE", path.toRawUTF8());

--- a/tests/test_app_paths.cpp
+++ b/tests/test_app_paths.cpp
@@ -29,15 +29,20 @@ void unsetEnv(const char* name) {
 
 struct EnvScope {
     EnvScope() {
-        // Snapshot the three knobs and restore on dtor so tests don't leak.
+        // Snapshot the knobs and restore on dtor so tests don't leak.
         snapshot("MAGDA_DATA_DIR", dataPrev);
         snapshot("MAGDA_PRESETS_DIR", presetsPrev);
         snapshot("MAGDA_RENDER_DIR", renderPrev);
+        // MAGDA_CONFIG_FILE is what keeps this binary off the developer's real
+        // config.json, so a test that changes it MUST put it back: leaking an
+        // unset here would leave every later test pointed at the real file.
+        snapshot("MAGDA_CONFIG_FILE", configFilePrev);
     }
     ~EnvScope() {
         restore("MAGDA_DATA_DIR", dataPrev);
         restore("MAGDA_PRESETS_DIR", presetsPrev);
         restore("MAGDA_RENDER_DIR", renderPrev);
+        restore("MAGDA_CONFIG_FILE", configFilePrev);
         // Also reset Config overrides so the next test starts clean.
         magda::Config::getInstance().setDataDir({});
         magda::Config::getInstance().setPresetsDir({});
@@ -59,6 +64,7 @@ struct EnvScope {
     juce::String dataPrev;
     juce::String presetsPrev;
     juce::String renderPrev;
+    juce::String configFilePrev;
 };
 
 }  // namespace
@@ -130,14 +136,29 @@ TEST_CASE("paths subpaths compose under dataDir", "[app_paths]") {
             juce::File("/tmp/magda-subpath-test/param_detector.log"));
 }
 
-TEST_CASE("paths::configFile is anchored to OS default regardless of override", "[app_paths]") {
+TEST_CASE("paths::configFile is anchored to OS default regardless of the data dir", "[app_paths]") {
     EnvScope scope;
+    // The test binary redirects config.json away from the developer's real one
+    // for its whole run; clear that here so this covers the data-dir anchoring
+    // it is actually about.
+    unsetEnv("MAGDA_CONFIG_FILE");
     setEnv("MAGDA_DATA_DIR", "/tmp/magda-anchor-test/data");
     paths::resolve();
 
     auto expected = paths::alwaysOSDefault().getChildFile("config.json");
     REQUIRE(paths::configFile() == expected);
     REQUIRE_FALSE(paths::configFile().getFullPathName().contains("magda-anchor-test"));
+}
+
+TEST_CASE("paths::configFile honours an explicit MAGDA_CONFIG_FILE override", "[app_paths]") {
+    // The one way to move config.json. Test binaries rely on it so a save from
+    // a Config they never loaded cannot replace the developer's settings.
+    EnvScope scope;
+    setEnv("MAGDA_CONFIG_FILE", "/tmp/magda-config-override/config.json");
+    paths::resolve();
+
+    REQUIRE(paths::configFile() == juce::File("/tmp/magda-config-override/config.json"));
+    REQUIRE(paths::configFile() != paths::alwaysOSDefault().getChildFile("config.json"));
 }
 
 TEST_CASE("paths::resolve picks up Config changes between calls", "[app_paths]") {

--- a/tests/test_config_path_redirect.cpp
+++ b/tests/test_config_path_redirect.cpp
@@ -1,0 +1,21 @@
+// The guard that keeps a test run from replacing the developer's settings.
+//
+// Config::save() writes the whole singleton, and no test loads it first, so any
+// save from a test process would overwrite ~/Library/MAGDA/config.json with
+// defaults. TestConfigRedirect.cpp points MAGDA_CONFIG_FILE somewhere
+// disposable before main(); this asserts it actually took, so the protection
+// cannot rot silently.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/core/AppPaths.hpp"
+
+TEST_CASE("Tests never address the real settings file", "[config][config-path]") {
+    const auto configFile = magda::paths::configFile();
+    const auto real = juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
+                          .getChildFile("MAGDA")
+                          .getChildFile("config.json");
+
+    REQUIRE(configFile != real);
+    REQUIRE_FALSE(configFile.getFullPathName().isEmpty());
+}

--- a/tests/test_config_path_redirect_juce.cpp
+++ b/tests/test_config_path_redirect_juce.cpp
@@ -1,0 +1,32 @@
+// The magda_tests half of this guard lives in test_config_path_redirect.cpp.
+// It is Catch2, so it cannot run here, and this target is the one that most
+// needs it: the shared-engine tests live here, where a stray Config::save() is
+// likeliest. Without a guard in this binary, dropping TestConfigRedirect.cpp
+// from the target would silently put it back to writing the developer's real
+// config.json.
+
+#include <juce_core/juce_core.h>
+
+#include "magda/daw/core/AppPaths.hpp"
+
+class ConfigPathRedirectTest final : public juce::UnitTest {
+  public:
+    ConfigPathRedirectTest() : juce::UnitTest("Config Path Redirect Tests", "magda") {}
+
+    void runTest() override {
+        beginTest("Tests never address the real settings file");
+        {
+            const auto configFile = magda::paths::configFile();
+            const auto real =
+                juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
+                    .getChildFile("MAGDA")
+                    .getChildFile("config.json");
+
+            expect(configFile != real,
+                   "Config would be saved over the developer's real settings file");
+            expect(configFile.getFullPathName().isNotEmpty());
+        }
+    }
+};
+
+static ConfigPathRedirectTest configPathRedirectTest;


### PR DESCRIPTION
Closes #2105.

Running the test suite replaced `~/Library/MAGDA/config.json` with defaults -- AI credentials, recent projects, audio device, browser favourites, keyboard bindings, all of it. Silently, on the developer's live settings. It happened twice on my machine in one morning; the API keys were not recoverable.

`Config::save()` serialises the whole singleton, and no test calls `Config::getInstance().load()` first, so in a test process the singleton is default-constructed and any save writes those defaults over the real file. Reaching a save takes nothing deliberate: `RemoteApiHost` persists client grants through `Config::save()` (`remote_api_host.cpp:273`), so constructing one in a test is enough. The wrecked config's `remoteApi.clients` were named `cursor`, `someone-else` and `unknown` -- the fixture names from `tests/test_remote_api_host.cpp`.

`ScopedRemoteApiConfig` already anticipated the hazard in a comment, but restoring the in-memory values on teardown cannot undo a write to disk.

### The fix

`paths::configFile()` honours a `MAGDA_CONFIG_FILE` override -- the one way to move the settings file, which is otherwise deliberately anchored to the OS default because Config has to be read before the data-dir override is known.

Both test binaries link `TestConfigRedirect.cpp`, which points that variable at a scratch file during static initialisation, before any test can run and regardless of how the binary is invoked.

Two guards so this cannot rot:

- `test_config_path_redirect` asserts the redirect actually took, rather than trusting that it did.
- `EnvScope` now snapshots and restores `MAGDA_CONFIG_FILE` alongside the other knobs. Without that, the one test that legitimately clears it -- the data-dir anchoring case -- would leave every later test in the process pointed back at the real file.

`test_app_paths`'s anchoring case keeps testing what it was about (the data dir must not move config.json) and gains a sibling covering the new override.

### Verification

Checksummed the real `config.json` across full runs of both suites: unchanged. Before the fix, `magda_tests` rewrote it every run.
