### PR TITLE
Remember the browser view and panel tabs between sessions (#2103)

### DIFF
--- a/magda/daw/core/Config.cpp
+++ b/magda/daw/core/Config.cpp
@@ -81,6 +81,25 @@ void Config::save() {
     root->setProperty("rightPanelWidth", rightPanelWidth);
     root->setProperty("bottomPanelHeight", bottomPanelHeight);
 
+    // Panel tab layout (front tab + left-to-right order, by content-type id)
+    {
+        auto writeTabs = [](const PanelTabsConfig& tabs) {
+            auto* panelObj = new juce::DynamicObject();
+            panelObj->setProperty("active", toJuceString(tabs.activeTab));
+            juce::Array<juce::var> orderArray;
+            for (const auto& id : tabs.tabOrder)
+                orderArray.add(toJuceString(id));
+            panelObj->setProperty("order", orderArray);
+            return juce::var(panelObj);
+        };
+
+        auto* panelTabsObj = new juce::DynamicObject();
+        panelTabsObj->setProperty("left", writeTabs(leftPanelTabs));
+        panelTabsObj->setProperty("right", writeTabs(rightPanelTabs));
+        panelTabsObj->setProperty("bottom", writeTabs(bottomPanelTabs));
+        root->setProperty("panelTabs", juce::var(panelTabsObj));
+    }
+
     // Language
     root->setProperty("language", toJuceString(language));
 
@@ -201,6 +220,7 @@ void Config::save() {
     root->setProperty("browserTreeView", browserTreeView);
     root->setProperty("browserDefaultDirectory", toJuceString(browserDefaultDirectory));
     root->setProperty("browserLastView", toJuceString(browserLastView));
+    root->setProperty("pluginBrowserViewMode", toJuceString(pluginBrowserViewMode));
     root->setProperty("sampleTaggerModelsDir", toJuceString(sampleTaggerModelsDir));
     root->setProperty("commandModelModelsDir", toJuceString(commandModelModelsDir));
     root->setProperty("loadSampleTaggerOnStartup", loadSampleTaggerOnStartup);
@@ -447,6 +467,24 @@ void Config::load() {
     rightPanelWidth = getInt("rightPanelWidth", rightPanelWidth);
     bottomPanelHeight = getInt("bottomPanelHeight", bottomPanelHeight);
 
+    // Panel tab layout. Absent (a config written before this shipped) leaves
+    // the members empty, which PanelController reads as "use the defaults".
+    if (auto* panelTabsObj = obj->getProperty("panelTabs").getDynamicObject()) {
+        auto readTabs = [panelTabsObj](const char* key, PanelTabsConfig& out) {
+            auto* panelObj = panelTabsObj->getProperty(key).getDynamicObject();
+            if (panelObj == nullptr)
+                return;
+            out.activeTab = panelObj->getProperty("active").toString().toStdString();
+            out.tabOrder.clear();
+            if (const auto* orderArray = panelObj->getProperty("order").getArray())
+                for (const auto& id : *orderArray)
+                    out.tabOrder.push_back(id.toString().toStdString());
+        };
+        readTabs("left", leftPanelTabs);
+        readTabs("right", rightPanelTabs);
+        readTabs("bottom", bottomPanelTabs);
+    }
+
     language = getString("language", language);
     scrollbarOnLeft = getBool("scrollbarOnLeft", scrollbarOnLeft);
     arrangementScrollbarsAutoHide =
@@ -690,6 +728,7 @@ void Config::load() {
     browserTreeView = getBool("browserTreeView", browserTreeView);
     browserDefaultDirectory = getString("browserDefaultDirectory", browserDefaultDirectory);
     browserLastView = getString("browserLastView", browserLastView);
+    pluginBrowserViewMode = getString("pluginBrowserViewMode", pluginBrowserViewMode);
     sampleTaggerModelsDir = getString("sampleTaggerModelsDir", sampleTaggerModelsDir);
     commandModelModelsDir = getString("commandModelModelsDir", commandModelModelsDir);
     loadSampleTaggerOnStartup = getBool("loadSampleTaggerOnStartup", loadSampleTaggerOnStartup);

--- a/magda/daw/core/Config.hpp
+++ b/magda/daw/core/Config.hpp
@@ -181,6 +181,37 @@ class Config {
         bottomPanelHeight = height;
     }
 
+    // Panel tab layout, restored by PanelController on startup. Content types
+    // are stable string ids ("pluginBrowser", "inspector", …) rather than tab
+    // indices, so changing the enum or the default tab list later cannot
+    // silently repoint a saved setting. An empty field means "use the
+    // built-in default", which is also what an unknown id falls back to.
+    struct PanelTabsConfig {
+        std::string activeTab;              // content-type id of the front tab
+        std::vector<std::string> tabOrder;  // content-type ids, left to right
+    };
+
+    const PanelTabsConfig& getLeftPanelTabs() const {
+        return leftPanelTabs;
+    }
+    void setLeftPanelTabs(PanelTabsConfig tabs) {
+        leftPanelTabs = std::move(tabs);
+    }
+
+    const PanelTabsConfig& getRightPanelTabs() const {
+        return rightPanelTabs;
+    }
+    void setRightPanelTabs(PanelTabsConfig tabs) {
+        rightPanelTabs = std::move(tabs);
+    }
+
+    const PanelTabsConfig& getBottomPanelTabs() const {
+        return bottomPanelTabs;
+    }
+    void setBottomPanelTabs(PanelTabsConfig tabs) {
+        bottomPanelTabs = std::move(tabs);
+    }
+
     // Layout Configuration
     bool getScrollbarOnLeft() const {
         return scrollbarOnLeft;
@@ -605,6 +636,18 @@ class Config {
     }
     void setBrowserLastView(const std::string& view) {
         browserLastView = view;
+    }
+
+    // Grouping the plugin browser restores on startup: "category",
+    // "manufacturer", "format", "favorites" or "folders". A stable id rather
+    // than the combo box's item number, so reordering that menu later cannot
+    // repoint an existing setting; an unrecognised value falls back to
+    // "category".
+    std::string getPluginBrowserViewMode() const {
+        return pluginBrowserViewMode;
+    }
+    void setPluginBrowserViewMode(const std::string& mode) {
+        pluginBrowserViewMode = mode;
     }
 
     // User-chosen location for the Sample Tagger ONNX bundle. Empty
@@ -1297,6 +1340,11 @@ class Config {
     int rightPanelWidth = 0;
     int bottomPanelHeight = 0;
 
+    // Panel tab layout (empty = use getDefaultPanelStates())
+    PanelTabsConfig leftPanelTabs;
+    PanelTabsConfig rightPanelTabs;
+    PanelTabsConfig bottomPanelTabs;
+
     // Track deletion settings
     bool confirmTrackDelete = true;  // Show confirmation dialog before deleting a track
 
@@ -1418,6 +1466,9 @@ class Config {
     // "filesystem" → file browser at browserDefaultDirectory.
     // "library"    → DB browser (sample library).
     std::string browserLastView = "filesystem";
+
+    // Which grouping the plugin browser should restore on startup (see accessor).
+    std::string pluginBrowserViewMode = "category";
 
     // Optional override for the Sample Tagger ONNX bundle location.
     // Empty = use the default dataDir/MediaDB/models.

--- a/magda/daw/ui/panels/content/PanelContent.cpp
+++ b/magda/daw/ui/panels/content/PanelContent.cpp
@@ -1,5 +1,7 @@
 #include "PanelContent.hpp"
 
+#include <array>
+
 #include "core/StringTable.hpp"
 
 namespace magda::daw::ui {
@@ -62,6 +64,48 @@ juce::String getContentTypeIcon(PanelContentType type) {
             return "Properties";
     }
     return "Unknown";
+}
+
+namespace {
+// One row per content type. Ids are written to config.json, so they are frozen
+// once shipped: rename a PanelContentType and the id here has to stay put.
+struct ContentTypeIdEntry {
+    PanelContentType type;
+    const char* id;
+};
+
+constexpr std::array<ContentTypeIdEntry, 14> kContentTypeIds{{
+    {PanelContentType::Empty, "empty"},
+    {PanelContentType::PluginBrowser, "pluginBrowser"},
+    {PanelContentType::MediaExplorer, "mediaExplorer"},
+    {PanelContentType::PresetBrowser, "presetBrowser"},
+    {PanelContentType::Inspector, "inspector"},
+    {PanelContentType::AIChatConsole, "aiChatConsole"},
+    {PanelContentType::ScriptingConsole, "scriptingConsole"},
+    {PanelContentType::TrackChain, "trackChain"},
+    {PanelContentType::PianoRoll, "pianoRoll"},
+    {PanelContentType::WaveformEditor, "waveformEditor"},
+    {PanelContentType::DrumGridClipView, "drumGridClipView"},
+    {PanelContentType::ChordClipView, "chordClipView"},
+    {PanelContentType::AutomationClipEditor, "automationClipEditor"},
+    {PanelContentType::AudioClipProperties, "audioClipProperties"},
+}};
+}  // namespace
+
+juce::String getContentTypeId(PanelContentType type) {
+    for (const auto& entry : kContentTypeIds) {
+        if (entry.type == type)
+            return entry.id;
+    }
+    return {};
+}
+
+std::optional<PanelContentType> contentTypeFromId(const juce::String& id) {
+    for (const auto& entry : kContentTypeIds) {
+        if (id == entry.id)
+            return entry.type;
+    }
+    return std::nullopt;
 }
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/panels/content/PanelContent.cpp
+++ b/magda/daw/ui/panels/content/PanelContent.cpp
@@ -66,46 +66,79 @@ juce::String getContentTypeIcon(PanelContentType type) {
     return "Unknown";
 }
 
-namespace {
-// One row per content type. Ids are written to config.json, so they are frozen
-// once shipped: rename a PanelContentType and the id here has to stay put.
-struct ContentTypeIdEntry {
-    PanelContentType type;
-    const char* id;
-};
-
-constexpr std::array<ContentTypeIdEntry, 14> kContentTypeIds{{
-    {PanelContentType::Empty, "empty"},
-    {PanelContentType::PluginBrowser, "pluginBrowser"},
-    {PanelContentType::MediaExplorer, "mediaExplorer"},
-    {PanelContentType::PresetBrowser, "presetBrowser"},
-    {PanelContentType::Inspector, "inspector"},
-    {PanelContentType::AIChatConsole, "aiChatConsole"},
-    {PanelContentType::ScriptingConsole, "scriptingConsole"},
-    {PanelContentType::TrackChain, "trackChain"},
-    {PanelContentType::PianoRoll, "pianoRoll"},
-    {PanelContentType::WaveformEditor, "waveformEditor"},
-    {PanelContentType::DrumGridClipView, "drumGridClipView"},
-    {PanelContentType::ChordClipView, "chordClipView"},
-    {PanelContentType::AutomationClipEditor, "automationClipEditor"},
-    {PanelContentType::AudioClipProperties, "audioClipProperties"},
-}};
-}  // namespace
-
+// Ids are written to config.json, so they are frozen once shipped: renaming a
+// PanelContentType must not change the id it maps to here.
+//
+// Deliberately a switch with no default, so adding a content type without
+// giving it an id is a -Wswitch warning rather than a silent persistence hole.
+// An unmapped type would serialise as an empty id, which reads back as "tab
+// this build does not know" and quietly sorts to the end of the saved order.
 juce::String getContentTypeId(PanelContentType type) {
-    for (const auto& entry : kContentTypeIds) {
-        if (entry.type == type)
-            return entry.id;
+    switch (type) {
+        case PanelContentType::Empty:
+            return "empty";
+        case PanelContentType::PluginBrowser:
+            return "pluginBrowser";
+        case PanelContentType::MediaExplorer:
+            return "mediaExplorer";
+        case PanelContentType::PresetBrowser:
+            return "presetBrowser";
+        case PanelContentType::Inspector:
+            return "inspector";
+        case PanelContentType::AIChatConsole:
+            return "aiChatConsole";
+        case PanelContentType::ScriptingConsole:
+            return "scriptingConsole";
+        case PanelContentType::TrackChain:
+            return "trackChain";
+        case PanelContentType::PianoRoll:
+            return "pianoRoll";
+        case PanelContentType::WaveformEditor:
+            return "waveformEditor";
+        case PanelContentType::DrumGridClipView:
+            return "drumGridClipView";
+        case PanelContentType::ChordClipView:
+            return "chordClipView";
+        case PanelContentType::AutomationClipEditor:
+            return "automationClipEditor";
+        case PanelContentType::AudioClipProperties:
+            return "audioClipProperties";
     }
     return {};
 }
 
 std::optional<PanelContentType> contentTypeFromId(const juce::String& id) {
-    for (const auto& entry : kContentTypeIds) {
-        if (id == entry.id)
-            return entry.type;
+    if (id.isEmpty())
+        return std::nullopt;
+
+    // Reverse lookup runs through getContentTypeId, so the id strings have
+    // exactly one definition and the two directions cannot disagree. The list
+    // of types below is the one thing a new content type has to be added to
+    // here; forgetting it costs that tab its saved position (it reverts to the
+    // default one) rather than corrupting anything. test_panel_tab_persistence
+    // round-trips every entry.
+    for (auto type : allContentTypes()) {
+        if (id == getContentTypeId(type))
+            return type;
     }
     return std::nullopt;
+}
+
+std::array<PanelContentType, 14> allContentTypes() {
+    return {PanelContentType::Empty,
+            PanelContentType::PluginBrowser,
+            PanelContentType::MediaExplorer,
+            PanelContentType::PresetBrowser,
+            PanelContentType::Inspector,
+            PanelContentType::AIChatConsole,
+            PanelContentType::ScriptingConsole,
+            PanelContentType::TrackChain,
+            PanelContentType::PianoRoll,
+            PanelContentType::WaveformEditor,
+            PanelContentType::DrumGridClipView,
+            PanelContentType::ChordClipView,
+            PanelContentType::AutomationClipEditor,
+            PanelContentType::AudioClipProperties};
 }
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/panels/content/PanelContent.hpp
+++ b/magda/daw/ui/panels/content/PanelContent.hpp
@@ -2,6 +2,8 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
+#include <optional>
+
 namespace magda::daw::ui {
 
 /**
@@ -127,5 +129,15 @@ juce::String getContentTypeName(PanelContentType type);
 
 /** Get the icon name for a content type (not translated). */
 juce::String getContentTypeIcon(PanelContentType type);
+
+/** Stable id for a content type, used to persist panel layout in Config.
+ *  Never derived from the enum's numeric value, so reordering PanelContentType
+ *  cannot silently repoint a saved setting. */
+juce::String getContentTypeId(PanelContentType type);
+
+/** Resolve a stable content-type id back to its enum value. Returns nullopt
+ *  for an id this build does not know, so a config written by a different
+ *  build degrades to the defaults instead of failing to open. */
+std::optional<PanelContentType> contentTypeFromId(const juce::String& id);
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/panels/content/PanelContent.hpp
+++ b/magda/daw/ui/panels/content/PanelContent.hpp
@@ -2,6 +2,7 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
+#include <array>
 #include <optional>
 
 namespace magda::daw::ui {
@@ -139,5 +140,9 @@ juce::String getContentTypeId(PanelContentType type);
  *  for an id this build does not know, so a config written by a different
  *  build degrades to the defaults instead of failing to open. */
 std::optional<PanelContentType> contentTypeFromId(const juce::String& id);
+
+/** Every PanelContentType, in declaration order. Backs the reverse id lookup;
+ *  a new content type belongs here as well as in getContentTypeId. */
+std::array<PanelContentType, 14> allContentTypes();
 
 }  // namespace magda::daw::ui

--- a/magda/daw/ui/panels/content/PluginBrowserContent.cpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.cpp
@@ -19,6 +19,7 @@
 #include "audio/plugins/StepSequencerPlugin.hpp"
 #include "audio/plugins/compiled/CompiledPluginRegistry.hpp"
 #include "core/AppPaths.hpp"
+#include "core/Config.hpp"
 #include "core/DeviceInfo.hpp"
 #include "core/PluginAlias.hpp"
 #include "core/PluginPreferences.hpp"
@@ -391,6 +392,40 @@ class PluginBrowserContent::FolderTreeItem : public CategoryTreeItem {
 //==============================================================================
 // PluginBrowserContent
 //==============================================================================
+std::string PluginBrowserContent::viewModeId(ViewMode mode) {
+    switch (mode) {
+        case ViewMode::ByCategory:
+            return "category";
+        case ViewMode::ByManufacturer:
+            return "manufacturer";
+        case ViewMode::ByFormat:
+            return "format";
+        case ViewMode::Favorites:
+            return "favorites";
+        case ViewMode::Folders:
+            return "folders";
+    }
+    return "category";
+}
+
+PluginBrowserContent::ViewMode PluginBrowserContent::viewModeFromId(const std::string& id) {
+    for (auto mode : {ViewMode::ByCategory, ViewMode::ByManufacturer, ViewMode::ByFormat,
+                      ViewMode::Favorites, ViewMode::Folders}) {
+        if (viewModeId(mode) == id)
+            return mode;
+    }
+    return ViewMode::ByCategory;  // Unknown id (older or newer config)
+}
+
+void PluginBrowserContent::saveViewMode() const {
+    auto& config = magda::Config::getInstance();
+    const auto id = viewModeId(currentViewMode_);
+    if (config.getPluginBrowserViewMode() != id) {
+        config.setPluginBrowserViewMode(id);
+        config.save();
+    }
+}
+
 PluginBrowserContent::PluginBrowserContent() {
     setName("Plugin Browser");
 
@@ -399,16 +434,19 @@ PluginBrowserContent::PluginBrowserContent() {
     searchBox_.onTextChange = [this]() { filterBySearch(searchBox_.getText()); };
     addAndMakeVisible(searchBox_);
 
-    // Setup view mode selector
+    // Setup view mode selector, opening on the grouping the user last chose
     viewModeSelector_.addItem("By Category", 1);
     viewModeSelector_.addItem("By Manufacturer", 2);
     viewModeSelector_.addItem("By Format", 3);
     viewModeSelector_.addItem("Favorites", 4);
     viewModeSelector_.addItem("Folders", 5);
-    viewModeSelector_.setSelectedId(1, juce::dontSendNotification);
+    currentViewMode_ = viewModeFromId(magda::Config::getInstance().getPluginBrowserViewMode());
+    viewModeSelector_.setSelectedId(static_cast<int>(currentViewMode_) + 1,
+                                    juce::dontSendNotification);
     viewModeSelector_.setLookAndFeel(&SmallComboBoxLookAndFeel::getInstance());
     viewModeSelector_.onChange = [this]() {
         currentViewMode_ = static_cast<ViewMode>(viewModeSelector_.getSelectedId() - 1);
+        saveViewMode();
         rebuildTree();
     };
     addAndMakeVisible(viewModeSelector_);

--- a/magda/daw/ui/panels/content/PluginBrowserContent.hpp
+++ b/magda/daw/ui/panels/content/PluginBrowserContent.hpp
@@ -116,6 +116,13 @@ class PluginBrowserContent : public PanelContent,
     };
     ViewMode currentViewMode_ = ViewMode::ByCategory;
 
+    // View mode persistence (#2103). Config stores a stable id per mode, not
+    // the combo box's item number, so reordering the menu later cannot
+    // repoint an existing setting.
+    static std::string viewModeId(ViewMode mode);
+    static ViewMode viewModeFromId(const std::string& id);
+    void saveViewMode() const;
+
     // Plugin data
     std::vector<PluginBrowserInfo> plugins_;
     magda::AudioEngine* engine_ = nullptr;  // For plugin scanning

--- a/magda/daw/ui/panels/state/PanelController.cpp
+++ b/magda/daw/ui/panels/state/PanelController.cpp
@@ -1,15 +1,127 @@
 #include "PanelController.hpp"
 
 #include <algorithm>
+#include <string>
+
+#include "core/Config.hpp"
 
 namespace magda::daw::ui {
+
+namespace {
+
+std::vector<std::string> toContentTypeIds(const std::vector<PanelContentType>& tabs) {
+    std::vector<std::string> ids;
+    ids.reserve(tabs.size());
+    for (auto type : tabs)
+        ids.push_back(getContentTypeId(type).toStdString());
+    return ids;
+}
+
+}  // namespace
+
+void applyPersistedTabOrder(PanelState& panel, const std::vector<std::string>& savedOrder) {
+    if (savedOrder.empty())
+        return;
+
+    std::vector<PanelContentType> ordered;
+    ordered.reserve(panel.tabs.size());
+
+    for (const auto& id : savedOrder) {
+        auto type = contentTypeFromId(juce::String(id));
+        if (!type.has_value() || !panel.hasContentType(*type))
+            continue;
+        if (std::find(ordered.begin(), ordered.end(), *type) == ordered.end())
+            ordered.push_back(*type);
+    }
+
+    for (auto type : panel.tabs) {
+        if (std::find(ordered.begin(), ordered.end(), type) == ordered.end())
+            ordered.push_back(type);
+    }
+
+    panel.tabs = std::move(ordered);
+}
+
+void applyPersistedActiveTab(PanelState& panel, const std::string& savedActiveTab) {
+    if (savedActiveTab.empty())
+        return;
+
+    auto type = contentTypeFromId(juce::String(savedActiveTab));
+    if (!type.has_value())
+        return;
+
+    const int index = panel.getTabIndex(*type);
+    if (index >= 0)
+        panel.activeTabIndex = index;
+}
 
 PanelController& PanelController::getInstance() {
     static PanelController instance;
     return instance;
 }
 
-PanelController::PanelController() : state_(getDefaultPanelStates()) {}
+PanelController::PanelController() : state_(getDefaultPanelStates()) {
+    restoreFromConfig();
+}
+
+void PanelController::restoreFromConfig() {
+    const auto& config = magda::Config::getInstance();
+
+    applyPersistedTabOrder(state_.leftPanel, config.getLeftPanelTabs().tabOrder);
+    applyPersistedTabOrder(state_.rightPanel, config.getRightPanelTabs().tabOrder);
+    applyPersistedTabOrder(state_.bottomPanel, config.getBottomPanelTabs().tabOrder);
+
+    // Only the side panels restore a front tab. The bottom panel's active tab
+    // is derived from the selection (BottomPanel::updateEditorContent), so
+    // restoring one would put a clip editor in front with no clip behind it
+    // until the user next selects something.
+    applyPersistedActiveTab(state_.leftPanel, config.getLeftPanelTabs().activeTab);
+    applyPersistedActiveTab(state_.rightPanel, config.getRightPanelTabs().activeTab);
+}
+
+void PanelController::persistToConfig(PanelLocation location) {
+    auto& config = magda::Config::getInstance();
+    const auto& panel = state_.getPanel(location);
+
+    magda::Config::PanelTabsConfig tabs;
+    tabs.tabOrder = toContentTypeIds(panel.tabs);
+    // See restoreFromConfig: the bottom panel's front tab is not restored, so
+    // there is nothing worth writing for it either.
+    if (location != PanelLocation::Bottom)
+        tabs.activeTab = getContentTypeId(panel.getActiveContentType()).toStdString();
+
+    const auto& stored = [&]() -> const magda::Config::PanelTabsConfig& {
+        switch (location) {
+            case PanelLocation::Left:
+                return config.getLeftPanelTabs();
+            case PanelLocation::Right:
+                return config.getRightPanelTabs();
+            case PanelLocation::Bottom:
+                return config.getBottomPanelTabs();
+        }
+        return config.getLeftPanelTabs();  // Fallback
+    }();
+
+    // Collapse and resize also land here, and the bottom panel retargets its
+    // editor on every clip click. None of those change what is stored, and
+    // save() writes the whole settings file, so bail before touching disk.
+    if (stored.activeTab == tabs.activeTab && stored.tabOrder == tabs.tabOrder)
+        return;
+
+    switch (location) {
+        case PanelLocation::Left:
+            config.setLeftPanelTabs(std::move(tabs));
+            break;
+        case PanelLocation::Right:
+            config.setRightPanelTabs(std::move(tabs));
+            break;
+        case PanelLocation::Bottom:
+            config.setBottomPanelTabs(std::move(tabs));
+            break;
+    }
+
+    config.save();
+}
 
 void PanelController::dispatch(const PanelEvent& event) {
     std::visit(
@@ -70,6 +182,11 @@ void PanelController::removeListener(PanelStateListener* listener) {
 }
 
 void PanelController::notifyPanelChanged(PanelLocation location) {
+    // Every mutation funnels through here, so this is the one place that has
+    // to remember to write the layout back. persistToConfig ignores the calls
+    // that did not touch the tab order or the front tab.
+    persistToConfig(location);
+
     const auto& panelState = state_.getPanel(location);
     for (auto* listener : listeners_) {
         listener->panelStateChanged(location, panelState);

--- a/magda/daw/ui/panels/state/PanelController.cpp
+++ b/magda/daw/ui/panels/state/PanelController.cpp
@@ -23,6 +23,11 @@ void applyPersistedTabOrder(PanelState& panel, const std::vector<std::string>& s
     if (savedOrder.empty())
         return;
 
+    // activeTabIndex is a position, so it means something different once the
+    // tabs move under it. Remember what is actually in front and resolve the
+    // index again afterwards, the same way handleReorderTabs does.
+    const auto activeType = panel.getActiveContentType();
+
     std::vector<PanelContentType> ordered;
     ordered.reserve(panel.tabs.size());
 
@@ -40,6 +45,10 @@ void applyPersistedTabOrder(PanelState& panel, const std::vector<std::string>& s
     }
 
     panel.tabs = std::move(ordered);
+
+    panel.activeTabIndex = panel.getTabIndex(activeType);
+    if (panel.activeTabIndex < 0)
+        panel.activeTabIndex = 0;
 }
 
 void applyPersistedActiveTab(PanelState& panel, const std::string& savedActiveTab) {

--- a/magda/daw/ui/panels/state/PanelController.hpp
+++ b/magda/daw/ui/panels/state/PanelController.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <vector>
 
 #include "PanelEvents.hpp"
@@ -34,6 +35,25 @@ class PanelStateListener {
         juce::ignoreUnused(location, collapsed);
     }
 };
+
+/**
+ * @brief Reorder a panel's tabs to follow a persisted order.
+ *
+ * Content-type ids this build does not know, and ids for tabs the panel does
+ * not offer, are dropped; tabs the saved order never mentions are appended in
+ * their default position. A layout written by a build with a different tab set
+ * therefore still opens, with every tab this build has.
+ *
+ * An empty saved order leaves the panel untouched.
+ */
+void applyPersistedTabOrder(PanelState& panel, const std::vector<std::string>& savedOrder);
+
+/**
+ * @brief Bring a persisted front tab forward, if this build still has that tab.
+ *
+ * An empty or unrecognised id leaves the panel's default front tab in place.
+ */
+void applyPersistedActiveTab(PanelState& panel, const std::string& savedActiveTab);
 
 /**
  * @brief Singleton controller for managing panel state
@@ -118,6 +138,16 @@ class PanelController {
 
     AllPanelStates state_;
     std::vector<PanelStateListener*> listeners_;
+
+    /** Overlay the tab order and front tab persisted in Config onto the
+     *  defaults already in state_. Anything the config does not name, or
+     *  names with an id this build does not know, keeps its default. */
+    void restoreFromConfig();
+
+    /** Write this panel's tab order and front tab back to Config and flush.
+     *  No-op when nothing the config holds has actually changed, so the
+     *  selection-driven bottom panel does not write on every clip click. */
+    void persistToConfig(PanelLocation location);
 
     void notifyPanelChanged(PanelLocation location);
     void notifyActiveTabChanged(PanelLocation location);

--- a/magda/daw/ui/windows/MainWindow.cpp
+++ b/magda/daw/ui/windows/MainWindow.cpp
@@ -1316,7 +1316,10 @@ MainWindow::MainComponent::~MainComponent() {
     // Drop the menu bar's reference to our command manager before it dies.
     MenuManager::getInstance().setCommandManager(nullptr);
 
-    // Save panel collapse state and sizes to Config for persistence
+    // Save panel collapse state and sizes to Config for persistence. The
+    // save() is not optional: nothing else flushes Config on the way out, and
+    // the app ends in _exit(), so without it these writes only ever reached
+    // the in-memory singleton and every session started on the defaults.
     auto& config = Config::getInstance();
     config.setLeftPanelCollapsed(leftPanelCollapsed);
     config.setRightPanelCollapsed(rightPanelCollapsed);
@@ -1324,6 +1327,7 @@ MainWindow::MainComponent::~MainComponent() {
     config.setLeftPanelWidth(leftPanelWidth);
     config.setRightPanelWidth(rightPanelWidth);
     config.setBottomPanelHeight(bottomPanelHeight);
+    config.save();
 
     // Remove command manager key listener before destruction
     removeKeyListener(commandManager.getKeyMappings());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,6 +120,11 @@ set(TEST_SOURCES
     test_arrangement_hit_tester.cpp
     # Curve-view readout stays inside the plot (#2072)
     test_curve_label_layout.cpp
+    # Panel tab layout survives a restart (#2103). The panel sources live in
+    # magda_daw_app rather than the magda_daw library, so pull them in directly.
+    test_panel_tab_persistence.cpp
+    ../magda/daw/ui/panels/state/PanelController.cpp
+    ../magda/daw/ui/panels/content/PanelContent.cpp
     # Keep test runs out of the developer's real config.json. The redirect must
     # be linked into every test binary, and the guard test proves it took.
     TestConfigRedirect.cpp
@@ -510,6 +515,8 @@ target_sources(magda_juce_tests PRIVATE
     ../magda/daw/ui/dialogs/AISettingsDialog.cpp
     ../magda/daw/ui/interaction/ArrangementCursorMap.cpp
     ../magda/daw/ui/panels/state/PanelController.cpp
+    # PanelController persists its tab layout by content-type id, which lives here
+    ../magda/daw/ui/panels/content/PanelContent.cpp
     ../magda/daw/ui/components/common/BarsBeatsTicksLabel.cpp
     ../magda/daw/ui/components/common/ValueLabelControl.cpp
     ../magda/daw/ui/components/common/DraggableValueLabel.cpp

--- a/tests/test_panel_tab_persistence.cpp
+++ b/tests/test_panel_tab_persistence.cpp
@@ -24,6 +24,17 @@ PanelState leftPanelDefaults() {
     return panel;
 }
 
+// The shipped bottom panel: Empty in front, then the clip editors. Its front
+// tab is deliberately never persisted, so a reorder must not shift it.
+PanelState bottomPanelDefaults() {
+    PanelState panel;
+    panel.location = magda::daw::ui::PanelLocation::Bottom;
+    panel.tabs = {PanelContentType::Empty, PanelContentType::PianoRoll,
+                  PanelContentType::DrumGridClipView, PanelContentType::TrackChain};
+    panel.activeTabIndex = 0;
+    return panel;
+}
+
 std::vector<std::string> idsOf(const PanelState& panel) {
     std::vector<std::string> ids;
     for (auto type : panel.tabs)
@@ -72,6 +83,32 @@ TEST_CASE("The front tab follows the tab it names, not the index it had", "[pane
     CHECK(panel.getActiveContentType() == PanelContentType::MediaExplorer);
 }
 
+TEST_CASE("Reordering carries the front tab with it, not the index it sat at", "[panels]") {
+    auto panel = leftPanelDefaults();
+    panel.activeTabIndex = 1;  // Samples in front
+
+    // No saved front tab to fall back on, so the reorder alone has to keep
+    // Samples in front rather than leaving index 1 pointing at Plugins.
+    applyPersistedTabOrder(panel, {"mediaExplorer", "pluginBrowser"});
+
+    CHECK(panel.getActiveContentType() == PanelContentType::MediaExplorer);
+    CHECK(panel.activeTabIndex == 0);
+}
+
+TEST_CASE("A reordered bottom panel still opens on Empty", "[panels]") {
+    auto panel = bottomPanelDefaults();
+
+    // The bottom panel's front tab is never persisted, so applyPersistedTabOrder
+    // is the only thing that runs on it. Moving Empty off index 0 must not
+    // leave an editor in front with nothing selected behind it.
+    applyPersistedTabOrder(panel, {"trackChain", "pianoRoll", "drumGridClipView", "empty"});
+
+    CHECK(idsOf(panel) ==
+          std::vector<std::string>{"trackChain", "pianoRoll", "drumGridClipView", "empty"});
+    CHECK(panel.getActiveContentType() == PanelContentType::Empty);
+    CHECK(panel.activeTabIndex == 3);
+}
+
 TEST_CASE("An unknown saved id is ignored rather than opening an empty panel", "[panels]") {
     auto panel = leftPanelDefaults();
 
@@ -80,9 +117,12 @@ TEST_CASE("An unknown saved id is ignored rather than opening an empty panel", "
     applyPersistedTabOrder(panel, {"somethingFromAnotherBuild", "pianoRoll", "mediaExplorer"});
     applyPersistedActiveTab(panel, "somethingFromAnotherBuild");
 
-    // Only the known, in-panel tab was honoured; the rest keep their defaults.
+    // Only the known, in-panel tab was honoured for the order. With no usable
+    // front tab to restore, the default one stays in front -- at its new
+    // position, not at the index it used to hold.
     CHECK(idsOf(panel) == std::vector<std::string>{"mediaExplorer", "pluginBrowser"});
-    CHECK(panel.getActiveContentType() == PanelContentType::MediaExplorer);
+    CHECK(panel.getActiveContentType() == PanelContentType::PluginBrowser);
+    CHECK(panel.activeTabIndex == 1);
 }
 
 TEST_CASE("A tab the saved order never mentions is kept, not dropped", "[panels]") {

--- a/tests/test_panel_tab_persistence.cpp
+++ b/tests/test_panel_tab_persistence.cpp
@@ -4,11 +4,14 @@
 // Pure state manipulation, no Config and no UI.
 
 #include <catch2/catch_test_macros.hpp>
+#include <set>
 
 #include "magda/daw/ui/panels/state/PanelController.hpp"
 
+using magda::daw::ui::allContentTypes;
 using magda::daw::ui::applyPersistedActiveTab;
 using magda::daw::ui::applyPersistedTabOrder;
+using magda::daw::ui::contentTypeFromId;
 using magda::daw::ui::getContentTypeId;
 using magda::daw::ui::PanelContentType;
 using magda::daw::ui::PanelState;
@@ -43,6 +46,25 @@ std::vector<std::string> idsOf(const PanelState& panel) {
 }
 
 }  // namespace
+
+TEST_CASE("Every content type has a unique id that round-trips", "[panels]") {
+    // The ids go to config.json, so a type that serialises to nothing, or two
+    // that collide, would silently lose a tab's saved position.
+    std::set<std::string> seen;
+
+    for (auto type : allContentTypes()) {
+        const auto id = getContentTypeId(type);
+        INFO("content type id: " << id);
+        CHECK(id.isNotEmpty());
+        CHECK(seen.insert(id.toStdString()).second);
+        CHECK(contentTypeFromId(id) == type);
+    }
+}
+
+TEST_CASE("An id no build ever wrote resolves to nothing", "[panels]") {
+    CHECK(contentTypeFromId("") == std::nullopt);
+    CHECK(contentTypeFromId("somethingFromAnotherBuild") == std::nullopt);
+}
 
 TEST_CASE("An empty saved layout leaves the panel defaults alone", "[panels]") {
     auto panel = leftPanelDefaults();

--- a/tests/test_panel_tab_persistence.cpp
+++ b/tests/test_panel_tab_persistence.cpp
@@ -1,0 +1,111 @@
+// Tests for restoring a persisted panel tab layout (#2103). The panel's tab
+// order and front tab are saved as stable content-type ids, so the restore has
+// to survive a config written by a build whose tab set differs from this one.
+// Pure state manipulation, no Config and no UI.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "magda/daw/ui/panels/state/PanelController.hpp"
+
+using magda::daw::ui::applyPersistedActiveTab;
+using magda::daw::ui::applyPersistedTabOrder;
+using magda::daw::ui::getContentTypeId;
+using magda::daw::ui::PanelContentType;
+using magda::daw::ui::PanelState;
+
+namespace {
+
+// The shipped left panel: Plugins then Samples, Plugins in front.
+PanelState leftPanelDefaults() {
+    PanelState panel;
+    panel.location = magda::daw::ui::PanelLocation::Left;
+    panel.tabs = {PanelContentType::PluginBrowser, PanelContentType::MediaExplorer};
+    panel.activeTabIndex = 0;
+    return panel;
+}
+
+std::vector<std::string> idsOf(const PanelState& panel) {
+    std::vector<std::string> ids;
+    for (auto type : panel.tabs)
+        ids.push_back(getContentTypeId(type).toStdString());
+    return ids;
+}
+
+}  // namespace
+
+TEST_CASE("An empty saved layout leaves the panel defaults alone", "[panels]") {
+    auto panel = leftPanelDefaults();
+
+    applyPersistedTabOrder(panel, {});
+    applyPersistedActiveTab(panel, "");
+
+    CHECK(idsOf(panel) == std::vector<std::string>{"pluginBrowser", "mediaExplorer"});
+    CHECK(panel.activeTabIndex == 0);
+}
+
+TEST_CASE("A saved order reorders the panel's tabs", "[panels]") {
+    auto panel = leftPanelDefaults();
+
+    applyPersistedTabOrder(panel, {"mediaExplorer", "pluginBrowser"});
+
+    CHECK(idsOf(panel) == std::vector<std::string>{"mediaExplorer", "pluginBrowser"});
+}
+
+TEST_CASE("A saved front tab is brought forward", "[panels]") {
+    auto panel = leftPanelDefaults();
+
+    applyPersistedActiveTab(panel, "mediaExplorer");
+
+    CHECK(panel.getActiveContentType() == PanelContentType::MediaExplorer);
+}
+
+TEST_CASE("The front tab follows the tab it names, not the index it had", "[panels]") {
+    auto panel = leftPanelDefaults();
+
+    // Saved with Samples in front, and the order reversed since. The front tab
+    // has to end up on Samples, which is now index 0, not on whatever index 1
+    // holds.
+    applyPersistedTabOrder(panel, {"mediaExplorer", "pluginBrowser"});
+    applyPersistedActiveTab(panel, "mediaExplorer");
+
+    CHECK(panel.activeTabIndex == 0);
+    CHECK(panel.getActiveContentType() == PanelContentType::MediaExplorer);
+}
+
+TEST_CASE("An unknown saved id is ignored rather than opening an empty panel", "[panels]") {
+    auto panel = leftPanelDefaults();
+
+    // A tab from a build this one does not have, plus a tab that exists but
+    // does not belong to this panel.
+    applyPersistedTabOrder(panel, {"somethingFromAnotherBuild", "pianoRoll", "mediaExplorer"});
+    applyPersistedActiveTab(panel, "somethingFromAnotherBuild");
+
+    // Only the known, in-panel tab was honoured; the rest keep their defaults.
+    CHECK(idsOf(panel) == std::vector<std::string>{"mediaExplorer", "pluginBrowser"});
+    CHECK(panel.getActiveContentType() == PanelContentType::MediaExplorer);
+}
+
+TEST_CASE("A tab the saved order never mentions is kept, not dropped", "[panels]") {
+    auto panel = leftPanelDefaults();
+
+    // A config from before Samples existed in this panel.
+    applyPersistedTabOrder(panel, {"pluginBrowser"});
+
+    CHECK(idsOf(panel) == std::vector<std::string>{"pluginBrowser", "mediaExplorer"});
+}
+
+TEST_CASE("A duplicated saved id does not duplicate the tab", "[panels]") {
+    auto panel = leftPanelDefaults();
+
+    applyPersistedTabOrder(panel, {"mediaExplorer", "mediaExplorer", "pluginBrowser"});
+
+    CHECK(idsOf(panel) == std::vector<std::string>{"mediaExplorer", "pluginBrowser"});
+}
+
+TEST_CASE("A front tab the panel does not offer leaves the default in front", "[panels]") {
+    auto panel = leftPanelDefaults();
+
+    applyPersistedActiveTab(panel, "pianoRoll");
+
+    CHECK(panel.getActiveContentType() == PanelContentType::PluginBrowser);
+}


### PR DESCRIPTION
The plugin browser reopened on By Category every launch, so a user who had sorted their plugins into folders had to re-pick Folders each time. The panel tab layout was worse off: PanelController only ever held getDefaultPanelStates() and had no load or save path at all, so both the front tab and the tab order were gone on the next start.

Config now carries a pluginBrowserViewMode string and a panelTabs object holding each panel's front tab and tab order. Both store stable content-type ids ("pluginBrowser", "folders") rather than combo box item numbers or tab indices, so reordering a menu or the tab enum later cannot silently repoint an existing setting. Restoring is deliberately forgiving: an id this build does not know is dropped, and a tab the saved order never mentions is appended in its default position, so a config from another build still opens with every tab this build has.

The bottom panel restores its tab order but not its front tab. That one is derived from the selection, so restoring it would put a clip editor in front with no clip behind it until the user next clicked something.

Also flushes Config when MainComponent goes away. It was already writing panel collapse state and sizes there, but nothing saved on the way out and the app ends in _exit(), so those writes only ever reached the in-memory singleton -- config.json on disk still had every panel size at 0 after months of use.