### PR TITLE
DAWproject round trip as an engine-facing cross-check (#2080)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -341,6 +341,13 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # owes nobody block-size invariance. In CI rather than in a nightly, because
     # a gate that runs after the merge is a report rather than a gate.
     list(APPEND TEST_SOURCES test_null_diff_block_size.cpp)
+
+    # The DAWproject cross-check (#2080). Native against native: each corpus
+    # project is exported, reimported, and required to compile to the same plan
+    # and render to the same samples. Model-only because both sides are the
+    # native engine and the export path is plain serialization.
+    list(APPEND TEST_SOURCES DawProjectRoundTrip.cpp)
+    list(APPEND TEST_SOURCES test_dawproject_round_trip.cpp)
 endif()
 
 # Create test executable

--- a/tests/DawProjectRoundTrip.cpp
+++ b/tests/DawProjectRoundTrip.cpp
@@ -1,0 +1,604 @@
+#include "DawProjectRoundTrip.hpp"
+
+#include <algorithm>
+#include <map>
+#include <set>
+#include <utility>
+
+#include "core/SourcePool.hpp"
+#include "magda/daw/project/serialization/DawProjectArchive.hpp"
+#include "magda/daw/project/serialization/ProjectDocument.hpp"
+
+namespace magda::nulldiff {
+
+// =============================================================================
+// The losses
+// =============================================================================
+//
+// Each entry names a field, says why DAWproject cannot hold it, and puts it
+// back. Nothing here is a tolerance: a restore either copies the original's
+// value over an imported default or does nothing, and doing nothing is what the
+// runner fails on.
+//
+// The bar is in the header. A field belongs here when the case sets it and the
+// trip does not bring it back, whether or not anything reads it.
+
+namespace {
+
+/// The clip of @p value named @p name, or nullptr. Names are unique per case
+/// and the runner asserts it, so a second match cannot silently win.
+const ClipInfo* clipNamed(const Case& value, const juce::String& name) {
+    for (const auto& clip : value.clips)
+        if (clip.name == name)
+            return &clip;
+    return nullptr;
+}
+
+/// Walk both cases' primary audio events in matched pairs, applying @p apply.
+///
+/// Matched by clip name rather than by index: the importer's clip order follows
+/// the file, and a restore that paired by position would put one clip's fade on
+/// another the first time that order changed.
+bool forEachAudioEvent(Case& imported, const Case& original,
+                       const std::function<bool(AudioEvent&, const AudioEvent&)>& apply) {
+    bool restored = false;
+
+    for (auto& clip : imported.clips) {
+        auto* event = clip.primaryEvent();
+        if (event == nullptr)
+            continue;
+
+        const auto* source = clipNamed(original, clip.name);
+        if (source == nullptr)
+            continue;
+
+        const auto* sourceEvent = source->primaryEvent();
+        if (sourceEvent == nullptr)
+            continue;
+
+        restored = apply(*event, *sourceEvent) || restored;
+    }
+
+    return restored;
+}
+
+bool forEachClip(Case& imported, const Case& original,
+                 const std::function<bool(ClipInfo&, const ClipInfo&)>& apply) {
+    bool restored = false;
+
+    for (auto& clip : imported.clips)
+        if (const auto* source = clipNamed(original, clip.name))
+            restored = apply(clip, *source) || restored;
+
+    return restored;
+}
+
+Loss fades() {
+    return {.field = "AudioEvent::fadeInSeconds, fadeOutSeconds, fadeInType, fadeOutType, "
+                     "fadeInBehaviour, fadeOutBehaviour",
+            .reason = "a DAWproject clip has no fade of its own. The format puts a level "
+                      "envelope on an automation lane instead, which is a different object "
+                      "with different semantics: it cannot say that this clip's edge is a "
+                      "speed ramp rather than a gain ramp, and it outlives the clip being "
+                      "moved",
+            .restore = [](Case& imported, const Case& original) {
+                return forEachAudioEvent(imported, original,
+                                         [](AudioEvent& event, const AudioEvent& source) {
+                                             if (event.fadeInSeconds == source.fadeInSeconds &&
+                                                 event.fadeOutSeconds == source.fadeOutSeconds &&
+                                                 event.fadeInType == source.fadeInType &&
+                                                 event.fadeOutType == source.fadeOutType &&
+                                                 event.fadeInBehaviour == source.fadeInBehaviour &&
+                                                 event.fadeOutBehaviour == source.fadeOutBehaviour)
+                                                 return false;
+
+                                             event.fadeInSeconds = source.fadeInSeconds;
+                                             event.fadeOutSeconds = source.fadeOutSeconds;
+                                             event.fadeInType = source.fadeInType;
+                                             event.fadeOutType = source.fadeOutType;
+                                             event.fadeInBehaviour = source.fadeInBehaviour;
+                                             event.fadeOutBehaviour = source.fadeOutBehaviour;
+                                             return true;
+                                         });
+            }};
+}
+
+Loss reversed() {
+    return {.field = "AudioEvent::reversed",
+            .reason = "the format has no reverse flag, and its warp markers cannot stand in "
+                      "for one: they map source time onto timeline time monotonically, so a "
+                      "run of them going backwards is not expressible",
+            .restore = [](Case& imported, const Case& original) {
+                return forEachAudioEvent(imported, original,
+                                         [](AudioEvent& event, const AudioEvent& source) {
+                                             if (event.reversed == source.reversed)
+                                                 return false;
+                                             event.reversed = source.reversed;
+                                             return true;
+                                         });
+            }};
+}
+
+Loss speedRatio() {
+    return {.field = "AudioEvent::speedRatio",
+            .reason = "a fixed playback ratio has no attribute in the format. Warp markers "
+                      "could express the same mapping, but MAGDA's exporter writes them only "
+                      "for a beat-locked clip, where the ratio is the tempo's rather than the "
+                      "clip's",
+            .restore = [](Case& imported, const Case& original) {
+                return forEachAudioEvent(imported, original,
+                                         [](AudioEvent& event, const AudioEvent& source) {
+                                             if (event.speedRatio == source.speedRatio)
+                                                 return false;
+                                             event.speedRatio = source.speedRatio;
+                                             return true;
+                                         });
+            }};
+}
+
+Loss stretchMode() {
+    return {.field = "AudioEvent::timeStretchMode",
+            .reason = "which stretcher runs is an engine choice rather than project data, and "
+                      "the format is deliberately host neutral about it. A file naming MAGDA's "
+                      "stretcher would be naming something no other host has",
+            .restore = [](Case& imported, const Case& original) {
+                return forEachAudioEvent(imported, original,
+                                         [](AudioEvent& event, const AudioEvent& source) {
+                                             if (event.timeStretchMode == source.timeStretchMode)
+                                                 return false;
+                                             event.timeStretchMode = source.timeStretchMode;
+                                             return true;
+                                         });
+            }};
+}
+
+Loss pitch() {
+    return {.field = "AudioEvent::analogPitch, transpose",
+            .reason = "the format carries no clip transposition. Analog pitch would not fit "
+                      "one if it did: it folds the interval into the read rate, so it is a "
+                      "property of how the clip is played rather than a number to restore",
+            .restore = [](Case& imported, const Case& original) {
+                return forEachAudioEvent(imported, original,
+                                         [](AudioEvent& event, const AudioEvent& source) {
+                                             if (event.analogPitch == source.analogPitch &&
+                                                 event.transpose == source.transpose)
+                                                 return false;
+                                             event.analogPitch = source.analogPitch;
+                                             event.transpose = source.transpose;
+                                             return true;
+                                         });
+            }};
+}
+
+Loss warp() {
+    return {.field = "AudioEvent::warpEnabled, warpMarkers",
+            .reason = "MAGDA's exporter writes <Warps> only for a beat-locked clip, and then "
+                      "as the two linear markers that carry its tempo interpretation. A clip's "
+                      "own marker list goes out as neither, so it comes back unwarped",
+            .restore = [](Case& imported, const Case& original) {
+                return forEachAudioEvent(imported, original,
+                                         [](AudioEvent& event, const AudioEvent& source) {
+                                             if (event.warpEnabled == source.warpEnabled &&
+                                                 event.warpMarkers == source.warpMarkers)
+                                                 return false;
+                                             event.warpEnabled = source.warpEnabled;
+                                             event.warpMarkers = source.warpMarkers;
+                                             return true;
+                                         });
+            }};
+}
+
+Loss takesAndComp() {
+    return {.field = "AudioClipModel::takes, currentTakeIndex, comp, compActive",
+            .reason = "loop-record takes and a comp assignment are MAGDA's own recording "
+                      "state. The format has one source per clip and no vocabulary for the "
+                      "passes behind it",
+            .restore = [](Case& imported, const Case& original) {
+                return forEachClip(imported, original, [](ClipInfo& clip, const ClipInfo& source) {
+                    if (!clip.isAudio() || !source.isAudio())
+                        return false;
+
+                    auto& audio = clip.audio();
+                    const auto& from = source.audio();
+                    if (audio.takes == from.takes && audio.comp == from.comp &&
+                        audio.currentTakeIndex == from.currentTakeIndex &&
+                        audio.compActive == from.compActive)
+                        return false;
+
+                    audio.takes = from.takes;
+                    audio.comp = from.comp;
+                    audio.currentTakeIndex = from.currentTakeIndex;
+                    audio.compActive = from.compActive;
+                    return true;
+                });
+            }};
+}
+
+Loss controllers() {
+    return {.field = "ClipInfo::midiCCData, midiPitchBendData, MidiNote::pitchExpression",
+            .reason = "the format's <Notes> carries pitch, velocity and duration and nothing "
+                      "else. Continuous controllers, pitch bend and per-note expression have "
+                      "no element to go in",
+            .restore = [](Case& imported, const Case& original) {
+                return forEachClip(imported, original, [](ClipInfo& clip, const ClipInfo& source) {
+                    bool restored = false;
+
+                    if (clip.midiCCData != source.midiCCData) {
+                        clip.midiCCData = source.midiCCData;
+                        restored = true;
+                    }
+                    if (clip.midiPitchBendData != source.midiPitchBendData) {
+                        clip.midiPitchBendData = source.midiPitchBendData;
+                        restored = true;
+                    }
+
+                    // Expression is per note, and the notes themselves did make
+                    // the trip, so it goes back onto them in order rather than
+                    // by replacing the list: a note that came back wrong has to
+                    // stay wrong for the comparison to find it.
+                    const auto notes = std::min(clip.midiNotes.size(), source.midiNotes.size());
+                    for (std::size_t index = 0; index < notes; ++index) {
+                        if (clip.midiNotes[index].pitchExpression ==
+                            source.midiNotes[index].pitchExpression)
+                            continue;
+                        clip.midiNotes[index].pitchExpression =
+                            source.midiNotes[index].pitchExpression;
+                        restored = true;
+                    }
+
+                    return restored;
+                });
+            }};
+}
+
+Loss groove() {
+    return {.field = "ClipInfo::grooveTemplate, grooveStrength",
+            .reason = "a groove names a template in a library the project does not contain, so "
+                      "there is nothing portable to write. The format's own answer is to bake "
+                      "the shifted times into the notes, which is a different clip",
+            .restore = [](Case& imported, const Case& original) {
+                return forEachClip(imported, original, [](ClipInfo& clip, const ClipInfo& source) {
+                    if (clip.grooveTemplate == source.grooveTemplate &&
+                        clip.grooveStrength == source.grooveStrength)
+                        return false;
+                    clip.grooveTemplate = source.grooveTemplate;
+                    clip.grooveStrength = source.grooveStrength;
+                    return true;
+                });
+            }};
+}
+
+Loss internalDevices() {
+    return {.field = "TrackInfo::chain",
+            .reason = "MAGDA's own devices and its racks have no DAWproject representation. The "
+                      "format standardises four dynamics and EQ builtins and otherwise carries "
+                      "VST3 and AU by class id and state chunk, and an internal device is "
+                      "neither: it would come back as a plugin no host could load",
+            .restore = [](Case& imported, const Case& original) {
+                bool restored = false;
+
+                // The whole chain, and only when the count changed. Two things
+                // follow, and both are deliberate.
+                //
+                // Counted rather than compared, because a ChainElement holds a
+                // rack by owning pointer and has no equality. A chain that came
+                // back the right length carrying the wrong devices is therefore
+                // left alone here, which is the correct outcome: the plan dump
+                // prints every device's id and section, so the comparison is
+                // where that belongs rather than in a restore.
+                //
+                // Wholesale, because every device in this corpus is internal
+                // and none of them survives. The day a case carries a VST3
+                // alongside one, restoring the chain would put the exported
+                // device back too and stop comparing what the format did carry.
+                // That case does not exist yet (#1893 brings the first hosted
+                // plugin), and a surgical version written for it now would be
+                // code no test runs.
+                const auto restoreChain = [&restored](TrackInfo& track, const TrackInfo& source) {
+                    if (track.chain.fxChainElements.size() == source.chain.fxChainElements.size() &&
+                        track.chain.postFxChainElements.size() ==
+                            source.chain.postFxChainElements.size())
+                        return;
+
+                    track.chain = source.chain;
+                    restored = true;
+                };
+
+                for (auto& track : imported.tracks)
+                    for (const auto& source : original.tracks)
+                        if (source.name == track.name)
+                            restoreChain(track, source);
+
+                restoreChain(imported.master, original.master);
+                return restored;
+            }};
+}
+
+Loss tempoMap() {
+    return {.field = "Case::tempo",
+            .reason = "the format's <Transport> holds one tempo. Later changes belong on a "
+                      "tempo automation lane, which MAGDA's exporter does not write and its "
+                      "importer does not read, so a project with a tempo change comes back "
+                      "playing its first tempo throughout",
+            .restore = [](Case& imported, const Case& original) {
+                if (imported.tempo.size() == original.tempo.size())
+                    return false;
+                imported.tempo = original.tempo;
+                return true;
+            }};
+}
+
+/// The table. Keyed by case name so that the corpus stays a description of what
+/// the two engines have to agree about, with nothing in it about a file format.
+const std::map<std::string, std::vector<Loss>>& lossTable() {
+    static const std::map<std::string, std::vector<Loss>> table{
+        {"fades.curves", {fades()}},
+        {"fades.speedramp", {fades()}},
+        {"reverse.plain", {reversed()}},
+        {"speed.ratio", {speedRatio()}},
+        {"pitch.analog", {pitch()}},
+        {"tempo.auto", {stretchMode(), tempoMap()}},
+        {"stretch.signalsmith", {speedRatio(), stretchMode()}},
+        {"stretch.soundtouch.normal", {speedRatio(), stretchMode()}},
+        {"stretch.soundtouch.better", {speedRatio(), stretchMode()}},
+        {"stretch.broadband", {speedRatio(), stretchMode()}},
+        {"warp.audio", {warp(), stretchMode()}},
+        {"takes.comp", {takesAndComp()}},
+        {"project.mixed", {internalDevices()}},
+        {"midi.notes", {internalDevices()}},
+        {"midi.cc", {internalDevices(), controllers()}},
+        {"midi.mpe", {internalDevices(), controllers()}},
+        {"midi.fold", {internalDevices(), groove()}},
+        {"midi.offset", {internalDevices()}},
+    };
+
+    return table;
+}
+
+}  // namespace
+
+const std::vector<Loss>& declaredLosses(const std::string& caseName) {
+    static const std::vector<Loss> none;
+
+    const auto& table = lossTable();
+    const auto found = table.find(caseName);
+    return found == table.end() ? none : found->second;
+}
+
+std::vector<std::string> namesWithDeclaredLosses() {
+    std::vector<std::string> names;
+    for (const auto& entry : lossTable())
+        names.push_back(entry.first);
+    return names;
+}
+
+// =============================================================================
+// The trip
+// =============================================================================
+
+namespace {
+
+/// The project half of a case, as the interchange boundary wants it.
+///
+/// The master goes last, after every ordinary track. Not for the importer's
+/// benefit, which reads a channel's role rather than its position, but for the
+/// file's: `destination` is an IDREF to the master's channel, and a reader that
+/// resolved references in one pass would want the tracks that reference it
+/// written first. Ids are not recovered from order either way; see the header.
+ProjectDocument documentFor(const Case& value) {
+    ProjectDocument document;
+    document.info.name = value.name;
+    document.info.tempo = value.startBpm();
+
+    document.tracks = value.tracks;
+    document.tracks.push_back(value.master);
+    document.clips = value.clips;
+
+    return document;
+}
+
+/// Names, mapped to the ids they had before the trip.
+///
+/// Empty when a name repeats, which the caller turns into a refusal: a mapping
+/// that guessed could put a clip on the wrong track and then certify the plan
+/// it compiled to.
+template <typename T>
+std::map<juce::String, decltype(T::id)> idsByName(const std::vector<T>& values) {
+    std::map<juce::String, decltype(T::id)> byName;
+
+    for (const auto& value : values)
+        if (!byName.emplace(value.name, value.id).second)
+            return {};
+
+    return byName;
+}
+
+/// Everything the imported clips play, as the native leg wants to be told it.
+///
+/// Read back out of the pool rather than carried over from the original case.
+/// The archive extracted these files somewhere else under different names and
+/// the importer pooled them there, so a source list copied from the original
+/// would point the render at the files that never made the trip. That is the
+/// one way this harness could report a null it had not earned.
+std::vector<SourceFact> pooledSourcesFor(const std::vector<ClipInfo>& clips, std::string& refusal) {
+    std::vector<SourceFact> sources;
+    std::set<SourceId> seen;
+
+    for (const auto& clip : clips) {
+        const auto* event = clip.primaryEvent();
+        if (event == nullptr || event->sourceId == INVALID_SOURCE_ID)
+            continue;
+        if (!seen.insert(event->sourceId).second)
+            continue;
+
+        const auto* source = SourcePool::getInstance().get(event->sourceId);
+        if (source == nullptr) {
+            refusal = "a clip came back pointing at a source the pool does not have";
+            return {};
+        }
+
+        sources.push_back(
+            {source->id, source->filePath, source->sampleRate, source->durationSeconds});
+    }
+
+    return sources;
+}
+
+/// Imported track ids, mapped back onto the ids the same names went out under.
+std::map<TrackId, TrackId> mapTrackIds(const ProjectDocument& imported,
+                                       const std::vector<TrackInfo>& original,
+                                       std::string& refusal) {
+    const auto byName = idsByName(original);
+    if (byName.empty() && !original.empty()) {
+        refusal = "two of this case's tracks share a name, so ids cannot be mapped back";
+        return {};
+    }
+
+    std::map<TrackId, TrackId> mapped;
+    for (const auto& track : imported.tracks) {
+        const auto found = byName.find(track.name);
+        if (found == byName.end()) {
+            refusal = "a track came back named '" + track.name.toStdString() +
+                      "', which nothing went out under";
+            return {};
+        }
+        mapped[track.id] = found->second;
+    }
+
+    if (mapped.size() != original.size()) {
+        refusal = "the project went out with " + std::to_string(original.size()) +
+                  " tracks and came back with " + std::to_string(mapped.size());
+        return {};
+    }
+
+    return mapped;
+}
+
+/// Split the imported tracks into the shape the compiler takes, renumbering as
+/// they go. The master arrives as an ordinary track whose channel says so.
+bool takeTracks(ProjectDocument& imported, const std::map<TrackId, TrackId>& trackIds, Case& value,
+                std::string& refusal) {
+    bool sawMaster = false;
+
+    for (auto& track : imported.tracks) {
+        track.id = trackIds.at(track.id);
+
+        if (track.type != TrackType::Master) {
+            value.tracks.push_back(std::move(track));
+            continue;
+        }
+
+        if (sawMaster) {
+            refusal = "the project came back with two master tracks";
+            return false;
+        }
+
+        sawMaster = true;
+        value.master = std::move(track);
+    }
+
+    if (!sawMaster) {
+        refusal = "the project came back with no master track";
+        return false;
+    }
+
+    return true;
+}
+
+bool takeClips(ProjectDocument& imported, const std::map<TrackId, TrackId>& trackIds,
+               const Case& original, Case& value, std::string& refusal) {
+    const auto clipIds = idsByName(original.clips);
+    if (clipIds.empty() && !original.clips.empty()) {
+        refusal = "two of this case's clips share a name, so ids cannot be mapped back";
+        return false;
+    }
+
+    for (auto& clip : imported.clips) {
+        const auto track = trackIds.find(clip.trackId);
+        if (track == trackIds.end()) {
+            refusal = "a clip came back on a track that is not in the project";
+            return false;
+        }
+        clip.trackId = track->second;
+
+        const auto id = clipIds.find(clip.name);
+        if (id == clipIds.end()) {
+            refusal = "a clip came back named '" + clip.name.toStdString() +
+                      "', which nothing went out under";
+            return false;
+        }
+        clip.id = id->second;
+
+        value.clips.push_back(std::move(clip));
+    }
+
+    if (value.clips.size() != original.clips.size()) {
+        refusal = "the project went out with " + std::to_string(original.clips.size()) +
+                  " clips and came back with " + std::to_string(value.clips.size());
+        return false;
+    }
+
+    return true;
+}
+
+}  // namespace
+
+RoundTrip exportAndReimport(const Case& original, const juce::File& scratchDirectory) {
+    RoundTrip result;
+
+    scratchDirectory.createDirectory();
+
+    // One archive and one extraction directory per case, named after it. Shared
+    // ones would let a case read the audio the previous case extracted, which
+    // is a null nobody earned, and the names are what make a failure
+    // inspectable afterwards without rerunning anything.
+    const auto archive = scratchDirectory.getChildFile(juce::String(original.name) + ".dawproject");
+    const auto media = scratchDirectory.getChildFile(juce::String(original.name) + "-media");
+    archive.deleteFile();
+    media.deleteRecursively();
+
+    juce::String error;
+    if (!DawProjectArchive::writeToFile(archive, documentFor(original), error)) {
+        result.refusal = "the export refused the project: " + error.toStdString();
+        return result;
+    }
+
+    ProjectDocument imported;
+    if (!DawProjectArchive::readFromFile(archive, imported, error, media)) {
+        result.refusal = "the import refused the archive: " + error.toStdString();
+        return result;
+    }
+
+    auto originalTracks = original.tracks;
+    originalTracks.push_back(original.master);
+
+    const auto trackIds = mapTrackIds(imported, originalTracks, result.refusal);
+    if (!result.refusal.empty())
+        return result;
+
+    // The environment, the beat range, the tier and its allowances are how the
+    // corpus renders a case rather than anything the file has an opinion about,
+    // so they are carried over. Everything the trip is actually about is
+    // cleared and refilled from what came back.
+    result.value = original;
+    result.value.tracks.clear();
+    result.value.clips.clear();
+    result.value.sources.clear();
+    result.value.tempo = {{.beat = 0.0, .bpm = imported.info.tempo}};
+
+    if (!takeTracks(imported, trackIds, result.value, result.refusal))
+        return result;
+    if (!takeClips(imported, trackIds, original, result.value, result.refusal))
+        return result;
+
+    result.value.sources = pooledSourcesFor(result.value.clips, result.refusal);
+    if (!result.refusal.empty())
+        return result;
+
+    for (const auto& loss : declaredLosses(original.name))
+        result.losses.push_back({loss.field, loss.reason, loss.restore(result.value, original)});
+
+    return result;
+}
+
+}  // namespace magda::nulldiff

--- a/tests/DawProjectRoundTrip.cpp
+++ b/tests/DawProjectRoundTrip.cpp
@@ -528,7 +528,23 @@ std::vector<SourceFact> pooledSourcesFor(const std::vector<ClipInfo>& clips,
     return sources;
 }
 
-/// Imported track ids, mapped back onto the ids the same names went out under.
+/**
+ * @brief Imported track ids, mapped back onto the ids the same names went out
+ *        under.
+ *
+ * Both sides of the map have to be one to one, and they are one to one for
+ * different reasons. The values are, because NameClaims hands each original id
+ * out once. The keys are not guaranteed by anything the importer does, so they
+ * are checked here: two imported tracks that came back under distinct names
+ * carrying one id would otherwise collapse to a single entry, and takeTracks
+ * would then look both of them up and give both the same original id. Every
+ * clip on either would follow it.
+ *
+ * That case has no count to fall back on. A map with one entry for two tracks
+ * still leaves every name claimed, so this is the only thing standing between
+ * an import that duplicated an id and a project renumbered into looking
+ * consistent.
+ */
 std::map<TrackId, TrackId> mapTrackIds(const ProjectDocument& imported,
                                        const std::vector<TrackInfo>& original,
                                        std::string& refusal) {
@@ -546,7 +562,12 @@ std::map<TrackId, TrackId> mapTrackIds(const ProjectDocument& imported,
         if (!id.has_value())
             return {};
 
-        mapped[track.id] = *id;
+        if (!mapped.emplace(track.id, *id).second) {
+            refusal = "two tracks came back carrying id " + std::to_string(track.id) +
+                      ", the second of them named '" + track.name.toStdString() +
+                      "', so one would have been mapped onto the other";
+            return {};
+        }
     }
 
     if (!claims.allClaimed(refusal))

--- a/tests/DawProjectRoundTrip.cpp
+++ b/tests/DawProjectRoundTrip.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <map>
+#include <optional>
 #include <set>
 #include <utility>
 
@@ -413,14 +414,89 @@ std::map<juce::String, decltype(T::id)> idsByName(const std::vector<T>& values) 
     return byName;
 }
 
-/// Everything the imported clips play, as the native leg wants to be told it.
-///
-/// Read back out of the pool rather than carried over from the original case.
-/// The archive extracted these files somewhere else under different names and
-/// the importer pooled them there, so a source list copied from the original
-/// would point the render at the files that never made the trip. That is the
-/// one way this harness could report a null it had not earned.
-std::vector<SourceFact> pooledSourcesFor(const std::vector<ClipInfo>& clips, std::string& refusal) {
+/**
+ * @brief The names a case went out under, handed back one at a time.
+ *
+ * Both halves of the mapping need this, and the discipline it enforces is not
+ * the obvious one. Rejecting duplicates in the ORIGINAL is necessary and not
+ * sufficient: an import that returns two tracks called "One" where "One" and
+ * "Two" went out resolves both onto One's id, and a count of what came back
+ * still matches, because two things came back and two went out. The harness
+ * would have turned a track that went missing into a duplicate of its
+ * neighbour, renumbered the pair into a consistent-looking project, and then
+ * compared that against the original. Normalising the exact failure a name
+ * mapping exists to make impossible.
+ *
+ * So a name is claimed rather than looked up, and the two ways that can go
+ * wrong are separate refusals: a name nothing went out under, and a name a
+ * second thing has already taken. Anything left unclaimed at the end did not
+ * come back at all, which is the third.
+ */
+template <typename Id> class NameClaims {
+  public:
+    NameClaims(const char* what, std::map<juce::String, Id> byName)
+        : what_(what), byName_(std::move(byName)) {}
+
+    /// The id @p name went out under, or nothing, with @p refusal set.
+    std::optional<Id> claim(const juce::String& name, std::string& refusal) {
+        const auto found = byName_.find(name);
+        if (found == byName_.end()) {
+            refusal = std::string("a ") + what_ + " came back named '" + name.toStdString() +
+                      "', which nothing went out under";
+            return std::nullopt;
+        }
+
+        if (!claimed_.insert(name).second) {
+            refusal = std::string("two ") + what_ + "s came back named '" + name.toStdString() +
+                      "', so one of them is standing in for something that did not come back";
+            return std::nullopt;
+        }
+
+        return found->second;
+    }
+
+    /// Whether everything that went out came back, naming one thing that did
+    /// not in @p refusal.
+    bool allClaimed(std::string& refusal) const {
+        for (const auto& entry : byName_) {
+            if (claimed_.count(entry.first) > 0)
+                continue;
+
+            refusal =
+                std::string("no ") + what_ + " came back named '" + entry.first.toStdString() + "'";
+            return false;
+        }
+
+        return true;
+    }
+
+  private:
+    const char* what_;
+    std::map<juce::String, Id> byName_;
+    std::set<juce::String> claimed_;
+};
+
+/**
+ * @brief Everything the imported clips play, as the native leg wants to be
+ *        told it.
+ *
+ * Read back out of the pool rather than carried over from the original case.
+ * The archive extracted these files into @p media under their archive-relative
+ * names and the importer pooled them there, so a source list copied from the
+ * original would point the render at the files that never made the trip.
+ *
+ * And every one of them has to be under @p media, which is the half that is not
+ * obvious. The exporter falls back to an absolute `external="true"` reference
+ * for a source it cannot embed, and the importer leaves such a path alone
+ * because there is nothing in the zip to extract. Both are correct behaviour on
+ * their own, and together they hand this back the ORIGINAL file: the clip
+ * resolves, the render nulls, and the case has certified an export that
+ * embedded nothing and an import that extracted nothing. That is the one way
+ * this harness could report a null it had not earned, so a source resolving
+ * outside the extraction directory is a refusal rather than a source.
+ */
+std::vector<SourceFact> pooledSourcesFor(const std::vector<ClipInfo>& clips,
+                                         const juce::File& media, std::string& refusal) {
     std::vector<SourceFact> sources;
     std::set<SourceId> seen;
 
@@ -437,6 +513,14 @@ std::vector<SourceFact> pooledSourcesFor(const std::vector<ClipInfo>& clips, std
             return {};
         }
 
+        if (!juce::File(source->filePath).isAChildOf(media)) {
+            refusal = "a clip came back playing '" + source->filePath.toStdString() +
+                      "', which is not a file this trip extracted: the export embedded it as an "
+                      "external reference, so nothing was written to the archive and nothing was "
+                      "read back out of it";
+            return {};
+        }
+
         sources.push_back(
             {source->id, source->filePath, source->sampleRate, source->durationSeconds});
     }
@@ -448,28 +532,25 @@ std::vector<SourceFact> pooledSourcesFor(const std::vector<ClipInfo>& clips, std
 std::map<TrackId, TrackId> mapTrackIds(const ProjectDocument& imported,
                                        const std::vector<TrackInfo>& original,
                                        std::string& refusal) {
-    const auto byName = idsByName(original);
+    auto byName = idsByName(original);
     if (byName.empty() && !original.empty()) {
         refusal = "two of this case's tracks share a name, so ids cannot be mapped back";
         return {};
     }
 
+    NameClaims<TrackId> claims("track", std::move(byName));
     std::map<TrackId, TrackId> mapped;
+
     for (const auto& track : imported.tracks) {
-        const auto found = byName.find(track.name);
-        if (found == byName.end()) {
-            refusal = "a track came back named '" + track.name.toStdString() +
-                      "', which nothing went out under";
+        const auto id = claims.claim(track.name, refusal);
+        if (!id.has_value())
             return {};
-        }
-        mapped[track.id] = found->second;
+
+        mapped[track.id] = *id;
     }
 
-    if (mapped.size() != original.size()) {
-        refusal = "the project went out with " + std::to_string(original.size()) +
-                  " tracks and came back with " + std::to_string(mapped.size());
+    if (!claims.allClaimed(refusal))
         return {};
-    }
 
     return mapped;
 }
@@ -507,11 +588,13 @@ bool takeTracks(ProjectDocument& imported, const std::map<TrackId, TrackId>& tra
 
 bool takeClips(ProjectDocument& imported, const std::map<TrackId, TrackId>& trackIds,
                const Case& original, Case& value, std::string& refusal) {
-    const auto clipIds = idsByName(original.clips);
+    auto clipIds = idsByName(original.clips);
     if (clipIds.empty() && !original.clips.empty()) {
         refusal = "two of this case's clips share a name, so ids cannot be mapped back";
         return false;
     }
+
+    NameClaims<ClipId> claims("clip", std::move(clipIds));
 
     for (auto& clip : imported.clips) {
         const auto track = trackIds.find(clip.trackId);
@@ -521,24 +604,15 @@ bool takeClips(ProjectDocument& imported, const std::map<TrackId, TrackId>& trac
         }
         clip.trackId = track->second;
 
-        const auto id = clipIds.find(clip.name);
-        if (id == clipIds.end()) {
-            refusal = "a clip came back named '" + clip.name.toStdString() +
-                      "', which nothing went out under";
+        const auto id = claims.claim(clip.name, refusal);
+        if (!id.has_value())
             return false;
-        }
-        clip.id = id->second;
 
+        clip.id = *id;
         value.clips.push_back(std::move(clip));
     }
 
-    if (value.clips.size() != original.clips.size()) {
-        refusal = "the project went out with " + std::to_string(original.clips.size()) +
-                  " clips and came back with " + std::to_string(value.clips.size());
-        return false;
-    }
-
-    return true;
+    return claims.allClaimed(refusal);
 }
 
 }  // namespace
@@ -591,7 +665,7 @@ RoundTrip exportAndReimport(const Case& original, const juce::File& scratchDirec
     if (!takeClips(imported, trackIds, original, result.value, result.refusal))
         return result;
 
-    result.value.sources = pooledSourcesFor(result.value.clips, result.refusal);
+    result.value.sources = pooledSourcesFor(result.value.clips, media, result.refusal);
     if (!result.refusal.empty())
         return result;
 

--- a/tests/DawProjectRoundTrip.hpp
+++ b/tests/DawProjectRoundTrip.hpp
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "NullDiffCase.hpp"
+
+/**
+ * @file DawProjectRoundTrip.hpp
+ * @brief A corpus project through DAWproject and back, as model values (#2080).
+ *
+ * The mechanism only. What is asserted about the result belongs to the runner
+ * (test_dawproject_round_trip.cpp), for the same reason a plan golden's fixture
+ * does not know about its golden file: a round trip that decided what counted
+ * as a successful round trip could be written to succeed.
+ *
+ * The path is the real one, archive included, rather than the XML adapter on
+ * its own. Audio arrives at the importer as a path inside a zip, and it is
+ * DawProjectArchive that extracts it, repoints the event and rescales its
+ * source-domain anchors for whatever rate the extracted file turns out to run
+ * at. A round trip that stopped at the XML would skip all three and then render
+ * whatever the original happened to still have pooled, which is a test of the
+ * corpus rather than of the export.
+ *
+ * ## What comes back, and what is carried over
+ *
+ * A Case is a project plus the environment it is rendered in. Only the project
+ * makes the trip: tracks, the master, and clips. Sample rate, block size, the
+ * beat range, the tier and its allowances are how the corpus renders a case
+ * rather than anything DAWproject has an opinion about, so they are copied
+ * from the original unchanged.
+ *
+ * The groove document is carried over on the same grounds, and it is the one
+ * that could be argued: `Case::grooveXml` is the template library both engines
+ * are handed, not a property of the project, while the clip's reference to a
+ * template by name IS project data and is declared as a loss below.
+ *
+ * ## Identity
+ *
+ * The importer renumbers. Tracks and clips are assigned ids as they are parsed,
+ * so nothing that came out carries the id that went in, and the master arrives
+ * as an ordinary track whose channel says `role="master"`.
+ *
+ * Ids are therefore mapped back by name before anything is compiled, which the
+ * corpus can afford because its track and clip names are unique within a case
+ * (the runner asserts it rather than assuming it). Mapping by name and not by
+ * position is what keeps the mapping from hiding a reordering: the rebuilt case
+ * keeps the imported document's order, so a project whose tracks came back in a
+ * different order compiles to a plan whose ops are in a different order, and
+ * the golden comparison says so.
+ *
+ * A name that matches nothing, or matches twice, is a refusal rather than a
+ * residual. See RoundTrip::refusal.
+ */
+
+namespace magda::nulldiff {
+
+/**
+ * @brief One thing DAWproject cannot carry, declared against the case that
+ *        carries it.
+ *
+ * The bar is one thing and not two: a field this case sets, which went out and
+ * did not come back. Not "a field the format has no attribute for", which would
+ * be a list about DAWproject rather than about this corpus, and not "a field
+ * the engine reads", which would leave a real loss undeclared whenever the
+ * corpus happened to carry it somewhere nothing reads. AudioClipModel::takes is
+ * that second case: neither engine plays a take list, and it is declared here
+ * anyway, because it went out and did not come back.
+ *
+ * Two things change across the trip and are not losses. Ids are reassigned by
+ * the importer, and the trip maps them back before anything is compiled, for
+ * the reasons above. Colours, names and the rest of what the format does carry
+ * come back as they went, so there is nothing to declare.
+ *
+ * @p restore puts the field back from the original and says whether it had to.
+ * That single answer is what keeps the list honest in both directions. The
+ * runner requires every declaration to fire, so a field the adapter starts
+ * carrying turns its declaration into a failure rather than into a comment that
+ * is quietly no longer true; and because the restore touches that field and
+ * nothing else, everything the format was supposed to carry is still being
+ * compared afterwards. That is the "and nothing more" half.
+ */
+struct Loss {
+    /// The model field, spelled as it appears in the header that declares it.
+    std::string field;
+
+    /// Why the format cannot hold it. Read by whoever the failure lands on.
+    std::string reason;
+
+    /// Put @p field back on @p imported from @p original.
+    /// @return whether anything actually had to be restored.
+    std::function<bool(Case& imported, const Case& original)> restore;
+};
+
+/// The losses declared for @p caseName, or an empty list.
+const std::vector<Loss>& declaredLosses(const std::string& caseName);
+
+/// Every case name the loss table has an entry for, so the runner can refuse a
+/// declaration that no longer names a case in the corpus.
+std::vector<std::string> namesWithDeclaredLosses();
+
+/// What one declared loss did on one case.
+struct LossOutcome {
+    std::string field;
+    std::string reason;
+
+    /// False when the restore found nothing to put back, which means the field
+    /// survived the trip and the declaration is stale.
+    bool occurred = false;
+};
+
+struct RoundTrip {
+    /// The reimported project, renumbered back onto the original's ids and with
+    /// every declared loss restored.
+    Case value;
+
+    std::vector<LossOutcome> losses;
+
+    /// Why the trip could not be made at all: an export the schema refused, an
+    /// archive that would not read, a name the mapping could not resolve. Never
+    /// reported as a difference, because a harness failure that reads like an
+    /// engine failure costs somebody a day.
+    std::string refusal;
+};
+
+/**
+ * @brief Export @p original to a .dawproject under @p scratchDirectory,
+ *        reimport it, and rebuild a renderable case from what came back.
+ */
+RoundTrip exportAndReimport(const Case& original, const juce::File& scratchDirectory);
+
+}  // namespace magda::nulldiff

--- a/tests/TextDifference.hpp
+++ b/tests/TextDifference.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <sstream>
+#include <string>
+
+/**
+ * @file TextDifference.hpp
+ * @brief The first line two canonical dumps disagree on.
+ *
+ * Shared by the plan goldens (#2076) and the DAWproject cross-check (#2080),
+ * which compare the same kind of text for the same reason: a failure should
+ * name a decision, not print two documents at each other.
+ */
+
+namespace magda {
+
+/// The first differing line of @p expected and @p actual, or an empty string.
+inline std::string firstDifference(const std::string& expected, const std::string& actual) {
+    std::istringstream expectedLines(expected);
+    std::istringstream actualLines(actual);
+
+    std::string expectedLine;
+    std::string actualLine;
+    int number = 1;
+
+    while (true) {
+        const bool haveExpected = static_cast<bool>(std::getline(expectedLines, expectedLine));
+        const bool haveActual = static_cast<bool>(std::getline(actualLines, actualLine));
+
+        if (!haveExpected && !haveActual)
+            return {};
+
+        std::ostringstream difference;
+        difference << "line " << number << ": ";
+
+        if (!haveExpected) {
+            difference << "expected end, got '" << actualLine << "'";
+            return difference.str();
+        }
+        if (!haveActual) {
+            difference << "expected '" << expectedLine << "', got end";
+            return difference.str();
+        }
+        if (expectedLine != actualLine) {
+            difference << "\n  expected: " << expectedLine << "\n  actual:   " << actualLine;
+            return difference.str();
+        }
+
+        ++number;
+    }
+}
+
+}  // namespace magda

--- a/tests/test_dawproject_round_trip.cpp
+++ b/tests/test_dawproject_round_trip.cpp
@@ -1,0 +1,304 @@
+#include <catch2/catch_test_macros.hpp>
+#include <limits>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "DawProjectRoundTrip.hpp"
+#include "NullDiffCompare.hpp"
+#include "NullDiffNativeLeg.hpp"
+#include "TextDifference.hpp"
+#include "plan/PlanCompiler.hpp"
+#include "plan/PlanDump.hpp"
+
+/**
+ * @file test_dawproject_round_trip.cpp
+ * @brief DAWproject as an engine-facing cross-check (#2080).
+ *
+ * Every corpus project is exported to a .dawproject, reimported, and required
+ * to compile to the same plan and render to the same samples.
+ *
+ * What this catches is not a serialization bug in the ordinary sense.
+ * test_project_document_adapters.cpp already asserts, field by field, that the
+ * round trip preserves what it was asked to preserve, and it does. What it
+ * cannot assert is the facts the engine depends on that nobody thought to put
+ * on the list, because the list was written by reading the model rather than by
+ * rendering it. A property the plan compiler reads and the adapter drops passes
+ * every test in that file today and fails here.
+ *
+ * ## Native against native
+ *
+ * This is a semantic cross-check, not a parity test. Both sides are the native
+ * engine, the fork has no part in it, and the two models are supposed to be the
+ * same model. So the bar is bit identity rather than a floor: there is no
+ * mechanism by which one deterministic graph fed one timeline twice could
+ * produce anything else, and a floor would let a real difference hide under it
+ * until it grew. The corpus's tiers are about what stands between two different
+ * engines and do not apply here; a Spectral case runs the same stretcher primed
+ * the same way on both sides of this comparison, so it owes the same bits as
+ * everything else.
+ *
+ * ## Declared losses
+ *
+ * DAWproject cannot hold everything MAGDA's model holds, and where it cannot,
+ * the case says so: the field, the reason, and a restore that puts it back from
+ * the original before anything is compiled or rendered. See
+ * DawProjectRoundTrip.hpp for why a restore is stronger than simply erasing the
+ * field from both sides.
+ *
+ * Every declaration has to fire. A restore that finds nothing to put back means
+ * the format carried the field after all, and the declaration is a comment that
+ * has stopped being true; it fails here rather than sitting in the table. And
+ * because a restore touches its own field and nothing else, everything the
+ * format was supposed to carry is still under comparison afterwards. A lossy
+ * mapping is a fine thing to have written down and a bad thing to discover.
+ */
+
+using namespace magda;
+using namespace magda::nulldiff;
+
+namespace {
+
+/// Where the corpus's own material lives, per the one-directory-per-test-file
+/// convention the other null-diff runners follow.
+juce::File corpusScratch() {
+    auto root = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                    .getChildFile("magda_null_diff_dawproject");
+    root.createDirectory();
+    return root;
+}
+
+/// Where the archives and the audio extracted back out of them go. A sibling of
+/// the corpus material rather than a child of it, because the exporter embeds
+/// those files and the importer extracts copies under the same names: nesting
+/// the two would put a case's original and its round-tripped copy in one tree,
+/// where the next reader has to work out which is which.
+juce::File tripScratch() {
+    auto root = juce::File::getSpecialLocation(juce::File::tempDirectory)
+                    .getChildFile("magda_null_diff_dawproject_trips");
+    root.createDirectory();
+    return root;
+}
+
+/// Bit identity, written as a level so it goes through the comparator
+/// everything else in the corpus goes through. compareAudio's floor is a linear
+/// threshold and fromDb takes negative infinity to exactly zero, so `nulled()`
+/// here means the peak difference was zero and `firstDivergence` is the first
+/// sample that differed at all.
+constexpr double kBitIdenticalDb = -std::numeric_limits<double>::infinity();
+
+std::string join(const std::vector<std::string>& parts) {
+    std::string joined;
+    for (const auto& part : parts)
+        joined += (joined.empty() ? "" : ", ") + part;
+    return joined;
+}
+
+std::string dumpFor(const Case& value) {
+    engine::CompileOptions options;
+
+    // The same switch the native leg compiles under. A plan compared under
+    // different options from the one that is rendered would be pinning a graph
+    // nothing plays.
+    options.deviceMeters = false;
+
+    return engine::dumpPlan(engine::compileRenderPlan(value.tracks, value.master, options));
+}
+
+/// The captured streams, side by side, as one comparable text.
+///
+/// Compared literally rather than through compareMidi, which exists to hold a
+/// grid sampler against a curve and allows for the slack between two different
+/// engines. There is no slack to allow for here: the same compiler ran twice
+/// over what is supposed to be the same model, so every message has to land on
+/// the same sample carrying the same bytes.
+std::string dumpMidi(const std::map<TrackId, MidiStream>& byTrack) {
+    std::string text;
+
+    for (const auto& [trackId, stream] : byTrack) {
+        text += "T" + std::to_string(trackId) + " events=" + std::to_string(stream.size()) + "\n";
+
+        for (const auto& event : stream)
+            text += "  " + std::to_string(event.sample) + " " + std::to_string(event.status) + " " +
+                    std::to_string(event.data1) + " " + std::to_string(event.data2) + "\n";
+    }
+
+    return text;
+}
+
+/// Every declaration on this case fired.
+///
+/// A restore that found nothing to put back means the format carried the field
+/// after all, so the declaration has stopped being true and says so here rather
+/// than sitting in the table describing a loss that no longer happens.
+bool declarationsHold(const RoundTrip& trip) {
+    bool held = true;
+
+    for (const auto& loss : trip.losses) {
+        INFO("declared loss: " << loss.field);
+        INFO(loss.reason);
+        INFO("nothing had to be restored, so the format carries this field after all and "
+             "the declaration is stale");
+        CHECK(loss.occurred);
+        held = held && loss.occurred;
+    }
+
+    return held;
+}
+
+/// The two models compile to the same graph.
+bool planHolds(const Case& value, const Case& imported) {
+    const auto difference = firstDifference(dumpFor(value), dumpFor(imported));
+
+    INFO("the reimported project compiles to a different plan:\n" << difference);
+    CHECK(difference.empty());
+    return difference.empty();
+}
+
+bool audioHolds(const NativeRender& before, const NativeRender& after, double sampleRate) {
+    AudioCompareOptions options;
+    options.sampleRate = sampleRate;
+    options.floorDb = kBitIdenticalDb;
+
+    const auto residual = compareAudio(before.audio, after.audio, options);
+
+    INFO("audio: peak " << formatDb(residual.peakDb) << ", rms " << formatDb(residual.rmsDb)
+                        << ", first difference at sample " << residual.firstDivergence
+                        << ", length difference " << residual.lengthDifference << " samples");
+    INFO(residual.refusal);
+    CHECK(residual.nulled());
+    return residual.nulled();
+}
+
+bool midiHolds(const NativeRender& before, const NativeRender& after) {
+    const auto difference =
+        firstDifference(dumpMidi(before.midiByTrack), dumpMidi(after.midiByTrack));
+
+    INFO("the reimported project sends different MIDI:\n" << difference);
+    CHECK(difference.empty());
+    return difference.empty();
+}
+
+/// The two models render the same samples, and send the same MIDI where the
+/// case captures any.
+bool renderHolds(const Case& value, const Case& imported) {
+    const auto before = renderNative(value);
+    const auto after = renderNative(imported);
+
+    {
+        INFO("the original would not render: " << before.failure);
+        REQUIRE(before.failure.empty());
+    }
+    {
+        INFO("the reimported project would not render: " << after.failure);
+        REQUIRE(after.failure.empty());
+    }
+
+    bool held = true;
+
+    {
+        // A diagnostic on one side and not the other is a finding whether or
+        // not the audio matched: a snapshot that dropped a clip and a render
+        // that matched it anyway are two bugs, not none.
+        INFO("the two renders reported different diagnostics");
+        CHECK(before.diagnostics == after.diagnostics);
+        held = held && before.diagnostics == after.diagnostics;
+    }
+
+    held = audioHolds(before, after, value.sampleRate) && held;
+
+    if (value.capturesMidi())
+        held = midiHolds(before, after) && held;
+
+    return held;
+}
+
+/// One project through the trip, with everything asserted about it.
+///
+/// Each question is asked inside its own scope so that its context lands on its
+/// own failure and nowhere else. Catch2's INFO lives to the end of the block it
+/// is written in, so a flat body would print "the reimported project compiles
+/// to a different plan:" with nothing after it beside an audio residual, which
+/// reads like two findings where there is one.
+///
+/// @return whether it held.
+bool holds(const Case& value) {
+    INFO(value.name);
+    INFO(value.covers);
+
+    const auto trip = exportAndReimport(value, tripScratch());
+
+    {
+        // Never reported as a difference. An export the schema refused and a
+        // render that came back wrong are different findings, and one reading
+        // like the other is what costs a day.
+        INFO("the round trip could not be made: " << trip.refusal);
+        REQUIRE(trip.refusal.empty());
+    }
+
+    // Written out rather than short circuited: every question is worth an
+    // answer on a case that has already failed one of them, because "the plan
+    // is the same and the audio is not" and "neither is" are different
+    // diagnoses.
+    const auto declarations = declarationsHold(trip);
+    const auto plan = planHolds(value, trip.value);
+    const auto render = renderHolds(value, trip.value);
+
+    return declarations && plan && render;
+}
+
+}  // namespace
+
+TEST_CASE("Every project survives a DAWproject round trip", "[nulldiff][dawproject]") {
+    // No list of known-lossy cases, because there are none: the corpus went
+    // through this on the first run with every declaration in the table already
+    // needed and nothing left over. A suppression list written before anything
+    // needed suppressing is somewhere for a real finding to be filed.
+    std::vector<std::string> failed;
+
+    for (const auto& value : sharedCorpus(corpusScratch()))
+        if (!holds(value))
+            failed.push_back(value.name);
+
+    // The roll call. A run that broke several projects says which in one line
+    // rather than only in the six screens of context above it.
+    INFO("projects that did not survive the trip: " << join(failed));
+    CHECK(failed.empty());
+}
+
+TEST_CASE("Every declared loss names a case in the corpus", "[nulldiff][dawproject]") {
+    // A renamed or deleted case leaves its declarations behind, and a loss
+    // declared against nothing is a paragraph of documentation that nothing
+    // holds to the model.
+    std::set<std::string> corpus;
+    for (const auto& value : sharedCorpus(corpusScratch()))
+        corpus.insert(value.name);
+
+    for (const auto& name : namesWithDeclaredLosses()) {
+        INFO("declared losses for a case that is not in the corpus: " << name);
+        CHECK(corpus.count(name) == 1);
+    }
+}
+
+TEST_CASE("Corpus names are unique within a case", "[nulldiff][dawproject]") {
+    // The round trip maps the importer's fresh ids back onto the originals by
+    // name. Two tracks or two clips sharing one inside a case would make that
+    // mapping a guess, and a guess could put a clip on the wrong track and then
+    // certify the plan it compiled to.
+    for (const auto& value : sharedCorpus(corpusScratch())) {
+        INFO(value.name);
+
+        std::set<juce::String> tracks{value.master.name};
+        for (const auto& track : value.tracks) {
+            INFO("track name: " << track.name);
+            CHECK(tracks.insert(track.name).second);
+        }
+
+        std::set<juce::String> clips;
+        for (const auto& clip : value.clips) {
+            INFO("clip name: " << clip.name);
+            CHECK(clips.insert(clip.name).second);
+        }
+    }
+}

--- a/tests/test_plan_goldens.cpp
+++ b/tests/test_plan_goldens.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "PlanGoldenFixtures.hpp"
+#include "TextDifference.hpp"
 #include "exec/PlanLayoutDump.hpp"
 #include "plan/PlanCompiler.hpp"
 #include "plan/PlanCrossfade.hpp"
@@ -136,34 +137,6 @@ std::string oneTrailingNewline(std::string text) {
     while (!text.empty() && (text.back() == '\n' || text.back() == ' '))
         text.pop_back();
     return text + "\n";
-}
-
-/// The first line that differs, so a failure names a decision rather than
-/// printing two documents at each other.
-std::string firstDifference(const std::string& expected, const std::string& actual) {
-    std::istringstream expectedLines(expected);
-    std::istringstream actualLines(actual);
-
-    std::string expectedLine;
-    std::string actualLine;
-    int number = 1;
-
-    while (true) {
-        const bool haveExpected = static_cast<bool>(std::getline(expectedLines, expectedLine));
-        const bool haveActual = static_cast<bool>(std::getline(actualLines, actualLine));
-
-        if (!haveExpected && !haveActual)
-            return {};
-        if (!haveExpected)
-            return "line " + std::to_string(number) + ": golden ends, got '" + actualLine + "'";
-        if (!haveActual)
-            return "line " + std::to_string(number) + ": expected '" + expectedLine + "', got end";
-        if (expectedLine != actualLine)
-            return "line " + std::to_string(number) + ":\n  expected: " + expectedLine +
-                   "\n  actual:   " + actualLine;
-
-        ++number;
-    }
 }
 
 }  // namespace


### PR DESCRIPTION
Closes #2080. Slice 6 of #1896.

Every corpus project is exported to a `.dawproject`, reimported, and required to compile to the same plan and render to the same samples.

`tests/test_project_document_adapters.cpp` already asserts, field by field, that the round trip preserves what it was asked to preserve, and it does. What it cannot assert is the facts the engine depends on that nobody thought to put on the list, because the list was written by reading the model rather than by rendering it. This asks the model to play instead.

## What it compares

Native against native, so the fork has no part in it and the corpus's tiers do not apply: two renders of what is supposed to be one model owe each other bit identity rather than a floor.

- **The plan**, through `dumpPlan` and the first-difference reporting from the plan goldens (#2076), which is now shared between the two runners rather than copied into both.
- **The audio**, through the corpus comparator (#2075) at a floor of `-inf`, which is bit identity written as a level so it goes through the same comparator everything else does.
- **The MIDI**, literally and per track. `compareMidi` exists to hold a grid sampler against a curve; there is no slack to allow for between two runs of one compiler.
- **The diagnostics**, because a snapshot that dropped a clip and a render that matched it anyway are two bugs, not none.

The trip is the real path, archive included. Audio reaches the importer as a path inside a zip, and it is `DawProjectArchive` that extracts it, repoints the event and rescales its source-domain anchors for whatever rate the extracted file turns out to run at. A round trip that stopped at the XML would skip all three and then render whatever the original still had pooled, which is a test of the corpus rather than of the export.

The importer renumbers, so ids are mapped back by name before anything is compiled. By name and not by position, which is what keeps the mapping from hiding a reordering: the rebuilt case keeps the imported document's order, so a project whose tracks came back in a different order compiles to a plan whose ops are in a different order and the comparison says so. A name that matches nothing, or twice, is a refusal rather than a residual.

## Declared losses

Eighteen cases declare one: fades, reverse, speed ratio, stretch mode, transposition, warp markers, takes and comping, controllers and per-note expression, groove templates, internal devices, and the tempo map past its first point. Each names the field, says why the format cannot hold it, and restores it from the original before anything is compiled.

Restoring rather than erasing from both sides is the choice worth reading. A fades case with its fades erased stops asserting anything about its fades; one with its fades put back still asserts everything else the format was supposed to carry, which is the "and nothing more" half.

Every declaration has to fire. A restore that finds nothing to put back means the format carried the field after all, so a mapping that stops being lossy fails here rather than leaving a paragraph that is quietly no longer true. A second test refuses a declaration against a case name the corpus no longer has.

## On it passing first time

It found no engine-facing bug, which I did not take at face value. Each limb was sabotaged to confirm it has teeth:

| sabotage | what it produced |
|---|---|
| drop the `fades.curves` declaration | audio residual peak −6.0 dB, first difference at sample 0 |
| drop the `midi.cc` declaration | `T1 events=15` against `T1 events=2` |
| drop the `midi.fold` declaration | note-off at sample 9923 against 8820 |
| drop the `project.mixed` declaration | `ops=45` against `ops=23`, and the MIDI capture gone |
| declare a loss on `placement.grid`, which has none | "nothing had to be restored, so the format carries this field after all" |

There is no known-lossy suppression list, because nothing needs suppressing and a list written before it does is somewhere for a real finding to be filed.

## Limitation, stated in the code

`internalDevices` restores a track's chain wholesale. Every device in this corpus is internal and none survives the trip, so that is exact today. The day a case carries a VST3 alongside an internal device, restoring the chain would put the exported device back too and stop comparing what the format did carry. #1893 brings the first hosted plugin and will need that restore to become surgical.

## Testing

`make test` green locally: 2687 cases, 588129 assertions, 0 failures. The new gate is 6.5 s and runs in `magda_tests`, so it is in CI rather than in a nightly.