### PR TITLE
The parameter lane and what a device reads (#2116)

### DIFF
--- a/magda/daw/core/ParameterUtils.cpp
+++ b/magda/daw/core/ParameterUtils.cpp
@@ -28,52 +28,71 @@ float computeSkew(float anchorPosition) {
     return std::log(anchorPosition) / std::log(0.5f);
 }
 
-// True when info.scaleAnchor is set and strictly inside (min, max).
-bool hasValidAnchor(const ParameterInfo& info) {
-    return info.scaleAnchor > info.minValue && info.scaleAnchor < info.maxValue;
+// True when the anchor is set and strictly inside (min, max).
+bool hasValidAnchor(const ParameterDomain& domain) {
+    return domain.scaleAnchor > domain.minValue && domain.scaleAnchor < domain.maxValue;
 }
 
 }  // namespace
 
+ParameterDomain domainOf(const ParameterInfo& info) {
+    ParameterDomain domain;
+    domain.scale = info.scale;
+    domain.minValue = info.minValue;
+    domain.maxValue = info.maxValue;
+    domain.skewFactor = info.skewFactor;
+    domain.scaleAnchor = info.scaleAnchor;
+    domain.choiceCount = static_cast<int>(info.choices.size());
+    return domain;
+}
+
+bool isStepped(const ParameterDomain& domain) {
+    return domain.scale == ParameterScale::Discrete || domain.scale == ParameterScale::Boolean;
+}
+
 float normalizedToReal(float normalized, const ParameterInfo& info) {
+    return normalizedToReal(normalized, domainOf(info));
+}
+
+float normalizedToReal(float normalized, const ParameterDomain& domain) {
     // Clamp input to valid range
     normalized = juce::jlimit(0.0f, 1.0f, normalized);
 
-    switch (info.scale) {
+    switch (domain.scale) {
         case ParameterScale::Linear: {
-            float range = info.maxValue - info.minValue;
-            if (hasValidAnchor(info) && range > 0.0f) {
-                float anchorPos = (info.scaleAnchor - info.minValue) / range;
+            float range = domain.maxValue - domain.minValue;
+            if (hasValidAnchor(domain) && range > 0.0f) {
+                float anchorPos = (domain.scaleAnchor - domain.minValue) / range;
                 float skew = computeSkew(anchorPos);
                 normalized = std::pow(normalized, skew);
             }
-            return info.minValue + normalized * range;
+            return domain.minValue + normalized * range;
         }
 
         case ParameterScale::Logarithmic: {
             // Fallback to linear when log is undefined (non-positive min).
-            if (info.minValue <= 0.0f) {
-                return info.minValue + normalized * (info.maxValue - info.minValue);
+            if (domain.minValue <= 0.0f) {
+                return domain.minValue + normalized * (domain.maxValue - domain.minValue);
             }
-            float logRange = std::log(info.maxValue / info.minValue);
-            if (hasValidAnchor(info)) {
+            float logRange = std::log(domain.maxValue / domain.minValue);
+            if (hasValidAnchor(domain)) {
                 // Place anchor at norm=0.5 in log space by skewing norm first.
-                float anchorLogPos = std::log(info.scaleAnchor / info.minValue) / logRange;
+                float anchorLogPos = std::log(domain.scaleAnchor / domain.minValue) / logRange;
                 float skew = computeSkew(anchorLogPos);
                 normalized = std::pow(normalized, skew);
             }
-            return info.minValue * std::exp(normalized * logRange);
+            return domain.minValue * std::exp(normalized * logRange);
         }
 
         case ParameterScale::Exponential:
-            return std::pow(normalized, info.skewFactor) * (info.maxValue - info.minValue) +
-                   info.minValue;
+            return std::pow(normalized, domain.skewFactor) * (domain.maxValue - domain.minValue) +
+                   domain.minValue;
 
         case ParameterScale::Discrete: {
-            if (info.choices.empty()) {
+            if (domain.choiceCount <= 0) {
                 return 0.0f;
             }
-            int index = static_cast<int>(std::round(normalized * (info.choices.size() - 1)));
+            int index = static_cast<int>(std::round(normalized * (domain.choiceCount - 1)));
             return static_cast<float>(index);
         }
 
@@ -87,22 +106,22 @@ float normalizedToReal(float normalized, const ParameterInfo& info) {
             constexpr float UNITY_DB = 0.0f;
 
             if (normalized <= 0.0f)
-                return info.minValue;
+                return domain.minValue;
             if (normalized >= 1.0f)
-                return info.maxValue;
+                return domain.maxValue;
 
             if (normalized < UNITY_POS) {
                 // Below unity: 0..0.75 maps to minValue..0dB
-                return info.minValue + (normalized / UNITY_POS) * (UNITY_DB - info.minValue);
+                return domain.minValue + (normalized / UNITY_POS) * (UNITY_DB - domain.minValue);
             } else {
                 // Above unity: 0.75..1.0 maps to 0dB..maxValue
-                return UNITY_DB +
-                       ((normalized - UNITY_POS) / (1.0f - UNITY_POS)) * (info.maxValue - UNITY_DB);
+                return UNITY_DB + ((normalized - UNITY_POS) / (1.0f - UNITY_POS)) *
+                                      (domain.maxValue - UNITY_DB);
             }
         }
 
         default:
-            return info.minValue + normalized * (info.maxValue - info.minValue);
+            return domain.minValue + normalized * (domain.maxValue - domain.minValue);
     }
 }
 
@@ -116,14 +135,18 @@ float normalizedFromGain(float gain, const ParameterInfo& info) {
 }
 
 float realToNormalized(float real, const ParameterInfo& info) {
-    switch (info.scale) {
+    return realToNormalized(real, domainOf(info));
+}
+
+float realToNormalized(float real, const ParameterDomain& domain) {
+    switch (domain.scale) {
         case ParameterScale::Linear: {
-            float range = info.maxValue - info.minValue;
+            float range = domain.maxValue - domain.minValue;
             if (range == 0.0f)
                 return 0.0f;
-            float linPos = (real - info.minValue) / range;
-            if (hasValidAnchor(info)) {
-                float anchorPos = (info.scaleAnchor - info.minValue) / range;
+            float linPos = (real - domain.minValue) / range;
+            if (hasValidAnchor(domain)) {
+                float anchorPos = (domain.scaleAnchor - domain.minValue) / range;
                 float skew = computeSkew(anchorPos);
                 // Invert the forward skew (norm -> norm^skew) with norm -> norm^(1/skew).
                 linPos = std::pow(juce::jlimit(0.0f, 1.0f, linPos), 1.0f / skew);
@@ -133,18 +156,18 @@ float realToNormalized(float real, const ParameterInfo& info) {
 
         case ParameterScale::Logarithmic: {
             // Handle edge cases
-            if (info.minValue <= 0.0f || real <= 0.0f) {
-                float range = info.maxValue - info.minValue;
+            if (domain.minValue <= 0.0f || real <= 0.0f) {
+                float range = domain.maxValue - domain.minValue;
                 if (range == 0.0f)
                     return 0.0f;
-                return juce::jlimit(0.0f, 1.0f, (real - info.minValue) / range);
+                return juce::jlimit(0.0f, 1.0f, (real - domain.minValue) / range);
             }
-            float logRange = std::log(info.maxValue / info.minValue);
+            float logRange = std::log(domain.maxValue / domain.minValue);
             if (logRange == 0.0f)
                 return 0.0f;
-            float logPos = std::log(real / info.minValue) / logRange;
-            if (hasValidAnchor(info)) {
-                float anchorLogPos = std::log(info.scaleAnchor / info.minValue) / logRange;
+            float logPos = std::log(real / domain.minValue) / logRange;
+            if (hasValidAnchor(domain)) {
+                float anchorLogPos = std::log(domain.scaleAnchor / domain.minValue) / logRange;
                 float skew = computeSkew(anchorLogPos);
                 logPos = std::pow(juce::jlimit(0.0f, 1.0f, logPos), 1.0f / skew);
             }
@@ -152,19 +175,18 @@ float realToNormalized(float real, const ParameterInfo& info) {
         }
 
         case ParameterScale::Exponential: {
-            float range = info.maxValue - info.minValue;
-            if (range == 0.0f || info.skewFactor == 0.0f)
+            float range = domain.maxValue - domain.minValue;
+            if (range == 0.0f || domain.skewFactor == 0.0f)
                 return 0.0f;
-            float normalized = (real - info.minValue) / range;
-            return juce::jlimit(0.0f, 1.0f, std::pow(normalized, 1.0f / info.skewFactor));
+            float normalized = (real - domain.minValue) / range;
+            return juce::jlimit(0.0f, 1.0f, std::pow(normalized, 1.0f / domain.skewFactor));
         }
 
         case ParameterScale::Discrete: {
-            if (info.choices.empty())
+            if (domain.choiceCount <= 0)
                 return 0.0f;
-            int index = juce::jlimit(0, static_cast<int>(info.choices.size() - 1),
-                                     static_cast<int>(std::round(real)));
-            return static_cast<float>(index) / static_cast<float>(info.choices.size() - 1);
+            int index = juce::jlimit(0, domain.choiceCount - 1, static_cast<int>(std::round(real)));
+            return static_cast<float>(index) / static_cast<float>(domain.choiceCount - 1);
         }
 
         case ParameterScale::Boolean:
@@ -175,26 +197,26 @@ float realToNormalized(float real, const ParameterInfo& info) {
             constexpr float UNITY_POS = 0.75f;
             constexpr float UNITY_DB = 0.0f;
 
-            if (real <= info.minValue)
+            if (real <= domain.minValue)
                 return 0.0f;
-            if (real >= info.maxValue)
+            if (real >= domain.maxValue)
                 return 1.0f;
 
             if (real < UNITY_DB) {
                 // Below unity: minValue..0dB maps to 0..0.75
-                return UNITY_POS * (real - info.minValue) / (UNITY_DB - info.minValue);
+                return UNITY_POS * (real - domain.minValue) / (UNITY_DB - domain.minValue);
             } else {
                 // Above unity: 0dB..maxValue maps to 0.75..1.0
                 return UNITY_POS +
-                       (1.0f - UNITY_POS) * (real - UNITY_DB) / (info.maxValue - UNITY_DB);
+                       (1.0f - UNITY_POS) * (real - UNITY_DB) / (domain.maxValue - UNITY_DB);
             }
         }
 
         default: {
-            float range = info.maxValue - info.minValue;
+            float range = domain.maxValue - domain.minValue;
             if (range == 0.0f)
                 return 0.0f;
-            return juce::jlimit(0.0f, 1.0f, (real - info.minValue) / range);
+            return juce::jlimit(0.0f, 1.0f, (real - domain.minValue) / range);
         }
     }
 }
@@ -251,14 +273,13 @@ float modelToTeValue(ParameterModelValue model, const ParameterInfo& info) {
     return info.teMinValue + normalized.value * teSpan;
 }
 
+float modulationOffset(float modValue, float amount, bool bipolar) {
+    // modValue is 0-1, convert to -1 to +1 if bipolar, then scale by the depth.
+    return (bipolar ? (modValue * 2.0f - 1.0f) : modValue) * amount;
+}
+
 float applyModulation(float baseNormalized, float modValue, float amount, bool bipolar) {
-    // modValue is 0-1, convert to -1 to +1 if bipolar
-    float modOffset = bipolar ? (modValue * 2.0f - 1.0f) : modValue;
-
-    // amount is depth: how much of the mod affects the base
-    float delta = modOffset * amount;
-
-    return juce::jlimit(0.0f, 1.0f, baseNormalized + delta);
+    return juce::jlimit(0.0f, 1.0f, baseNormalized + modulationOffset(modValue, amount, bipolar));
 }
 
 float applyModulations(float baseNormalized,
@@ -266,8 +287,7 @@ float applyModulations(float baseNormalized,
     float result = baseNormalized;
 
     for (const auto& [modValue, amount] : modsAndAmounts) {
-        float modOffset = bipolar ? (modValue * 2.0f - 1.0f) : modValue;
-        result += modOffset * amount;
+        result += modulationOffset(modValue, amount, bipolar);
     }
 
     return juce::jlimit(0.0f, 1.0f, result);

--- a/magda/daw/core/ParameterUtils.hpp
+++ b/magda/daw/core/ParameterUtils.hpp
@@ -12,6 +12,43 @@ namespace magda {
 namespace ParameterUtils {
 
 /**
+ * @brief The part of a ParameterInfo that decides what a normalized position means.
+ *
+ * A flat value type with no heap in it, because the conversion is not only a UI
+ * concern: the native engine resolves a modulated parameter on the audio thread
+ * every block (#2116), where a ParameterInfo cannot go. It carries strings, a
+ * choice list and a shared display provider, none of which the curve reads.
+ *
+ * Split out rather than reimplemented on the engine side. Two implementations of
+ * one curve is a difference nobody sees until a project sounds different in one
+ * engine than the other, so the conversion below is the only one there is and
+ * the ParameterInfo overloads are this one under another name.
+ */
+struct ParameterDomain {
+    ParameterScale scale = ParameterScale::Linear;
+    float minValue = 0.0f;
+    float maxValue = 1.0f;
+    float skewFactor = 1.0f;
+    float scaleAnchor = 0.0f;
+
+    /// Number of entries in the parameter's choice list, for Discrete. Zero
+    /// everywhere else, and Discrete with zero choices converts to 0 the way
+    /// an empty `choices` does.
+    int choiceCount = 0;
+};
+
+/** @brief The conversion domain of @p info. */
+ParameterDomain domainOf(const ParameterInfo& info);
+
+/**
+ * @brief Whether the domain's values are discrete steps rather than a continuum.
+ *
+ * A stepped parameter is never ramped: there is nothing between two of its
+ * values to ramp through.
+ */
+bool isStepped(const ParameterDomain& domain);
+
+/**
  * @brief Convert normalized value (0-1) to real parameter value
  *
  * @param normalized Normalized value in range [0, 1]
@@ -23,6 +60,7 @@ namespace ParameterUtils {
  *   float realHz = normalizedToReal(0.5f, cutoff);  // ~632 Hz (geometric mean)
  */
 float normalizedToReal(float normalized, const ParameterInfo& info);
+float normalizedToReal(float normalized, const ParameterDomain& domain);
 
 /**
  * @brief Convert real parameter value to normalized (0-1)
@@ -36,6 +74,7 @@ float normalizedToReal(float normalized, const ParameterInfo& info);
  *   float norm = realToNormalized(440.0f, cutoff);  // ~0.353
  */
 float realToNormalized(float real, const ParameterInfo& info);
+float realToNormalized(float real, const ParameterDomain& domain);
 
 /**
  * @brief A normalized fader position as the linear gain `TrackManager` stores.
@@ -96,6 +135,21 @@ ParameterNormalizedValue modelToNormalizedValue(ParameterModelValue model,
  * range. Parameters whose model and TE ranges already match pass through.
  */
 float modelToTeValue(ParameterModelValue model, const ParameterInfo& info);
+
+/**
+ * @brief What one modulation link adds to a normalized value.
+ *
+ * The polarity and depth rule on its own, with no base and no clamp, because
+ * the clamp belongs after every contribution has been added rather than after
+ * each one. Both functions below are this plus a sum plus that clamp, and so is
+ * the native engine's per-block resolution (#2116), which cannot call either of
+ * them: one clamps too early and the other wants a vector.
+ *
+ * @param modValue Modulator output (0-1, e.g. LFO value)
+ * @param amount   Modulation depth (-1 to 1)
+ * @param bipolar  If true, modValue 0-1 maps to -1 to +1 before scaling
+ */
+float modulationOffset(float modValue, float amount, bool bipolar);
 
 /**
  * @brief Apply modulation to a base normalized value

--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -72,6 +72,12 @@ add_library(magda_engine STATIC
     exec/RuntimeStateStore.hpp
     exec/EngineSession.hpp
     exec/OfflineRender.hpp
+    param/ParamSpec.cpp
+    param/ParamBlock.cpp
+    param/ParamResolve.cpp
+    param/ParamSpec.hpp
+    param/ParamBlock.hpp
+    param/ParamResolve.hpp
     tap/LevelTap.hpp
     tap/SampleRing.hpp
     transport/TempoMap.cpp
@@ -157,7 +163,7 @@ endforeach()
 # engine's own headers.
 
 set(MAGDA_ENGINE_ALLOWED_QUOTED_PREFIXES
-    "core/" "clip/" "plan/" "exec/" "transport/" "io/" "tap/" "analysis/")
+    "core/" "clip/" "param/" "plan/" "exec/" "transport/" "io/" "tap/" "analysis/")
 
 file(GLOB_RECURSE MAGDA_ENGINE_SOURCES CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"

--- a/magda/engine/exec/EngineDevice.hpp
+++ b/magda/engine/exec/EngineDevice.hpp
@@ -4,6 +4,7 @@
 #include <juce_dsp/juce_dsp.h>
 
 #include "exec/RenderContext.hpp"
+#include "param/ParamBlock.hpp"
 
 /**
  * @file EngineDevice.hpp
@@ -79,6 +80,26 @@ struct DeviceBlock {
     /// Sidechain audio. A zero-channel block when the slot is unconnected, so
     /// devices check getNumChannels() rather than assuming a source.
     juce::dsp::AudioBlock<const float> sidechain;
+
+    /**
+     * @brief The device's parameters, resolved for this block (#2116).
+     *
+     * Indexed the way the device declared them, and already everything the
+     * device could want to know: the stored value, the automation curve over
+     * it and the modifiers linked to it have been resolved into one value
+     * stream per parameter, clamped, quantised, and in the parameter's own
+     * units. A device reads these and has no other way to find out what a
+     * parameter is, which is what keeps the precedence rules in one place
+     * (param/ParamResolve.hpp) rather than in every device.
+     *
+     * Resolved before this call and before the MIDI above is looked at, so an
+     * event at sample zero sees the value automation put there rather than the
+     * one from the block before.
+     *
+     * Empty for a device with no parameters, and for every device until the
+     * table is published against a plan.
+     */
+    DeviceParams params;
 
     BlockInfo block;
 };

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -788,7 +788,15 @@ void PlanExecutor::renderOp(OpId id, const OpValue& value, const BlockInfo& bloc
             if (device == nullptr)
                 break;
 
-            DeviceBlock deviceBlock{audio, &midiIn(op.inputs[1]), deviceMidiOut, {}, block};
+            // No parameters yet: the table a device reads is resolved against a
+            // plan and published with it, which is #2117. Until then a device
+            // is handed an empty window rather than a stale one.
+            DeviceBlock deviceBlock{.audio = audio,
+                                    .midiIn = &midiIn(op.inputs[1]),
+                                    .midiOut = deviceMidiOut,
+                                    .sidechain = {},
+                                    .params = {},
+                                    .block = block};
             if (op.inputs[2].valid())
                 deviceBlock.sidechain = audioIn(op.inputs[2], numSamples);
             device->process(deviceBlock);

--- a/magda/engine/param/ParamBlock.cpp
+++ b/magda/engine/param/ParamBlock.cpp
@@ -1,0 +1,96 @@
+#include "param/ParamBlock.hpp"
+
+#include <algorithm>
+
+namespace magda::engine {
+
+float ParamValues::valueAt(int sampleOffset) const {
+    if (segments_.empty())
+        return 0.0f;
+
+    const auto sample = std::clamp(sampleOffset, 0, std::max(numSamples_ - 1, 0));
+
+    // Linear rather than binary: a parameter carries a handful of segments and
+    // the caller is walking the block in order, so the first one it looks at is
+    // usually the one it wants.
+    std::size_t index = 0;
+    while (index + 1 < segments_.size() && segments_[index + 1].startSample <= sample)
+        ++index;
+
+    const auto& segment = segments_[index];
+    const auto end = index + 1 < segments_.size() ? segments_[index + 1].startSample : numSamples_;
+    const auto span = end - segment.startSample;
+    if (span <= 0)
+        return segment.startValue;
+
+    const auto position =
+        static_cast<float>(sample - segment.startSample) / static_cast<float>(span);
+    return segment.startValue + (segment.endValue - segment.startValue) * position;
+}
+
+ParamValues DeviceParams::operator[](int paramIndex) const {
+    if (paramIndex < 0 || paramIndex >= size())
+        return {};
+
+    const auto offset = static_cast<std::size_t>(paramIndex) * static_cast<std::size_t>(stride_);
+    const auto count = static_cast<std::size_t>(counts_[static_cast<std::size_t>(paramIndex)]);
+    return ParamValues{segments_.subspan(offset, count), numSamples_};
+}
+
+void ResolvedParams::prepare(int numParams, int segmentCapacity) {
+    stride_ = std::max(segmentCapacity, 1);
+    const auto count = static_cast<std::size_t>(std::max(numParams, 0));
+    segments_.assign(count * static_cast<std::size_t>(stride_), ParamSegment{});
+    counts_.assign(count, 0);
+    numSamples_ = 0;
+}
+
+void ResolvedParams::beginBlock(int numSamples) {
+    numSamples_ = numSamples;
+    std::fill(counts_.begin(), counts_.end(), 0);
+}
+
+ParamValues ResolvedParams::operator[](int param) const {
+    if (param < 0 || param >= size())
+        return {};
+
+    const auto offset = static_cast<std::size_t>(param) * static_cast<std::size_t>(stride_);
+    const auto count = static_cast<std::size_t>(counts_[static_cast<std::size_t>(param)]);
+    return ParamValues{std::span<const ParamSegment>{segments_}.subspan(offset, count),
+                       numSamples_};
+}
+
+DeviceParams ResolvedParams::device(int firstParam, int count) const {
+    if (firstParam < 0 || count <= 0 || firstParam + count > size())
+        return {};
+
+    const auto offset = static_cast<std::size_t>(firstParam) * static_cast<std::size_t>(stride_);
+    const auto width = static_cast<std::size_t>(count) * static_cast<std::size_t>(stride_);
+    return DeviceParams{std::span<const ParamSegment>{segments_}.subspan(offset, width),
+                        std::span<const int>{counts_}.subspan(static_cast<std::size_t>(firstParam),
+                                                              static_cast<std::size_t>(count)),
+                        stride_, numSamples_};
+}
+
+ParamSegment* ResolvedParams::slotFor(int param) {
+    if (param < 0 || param >= size())
+        return nullptr;
+
+    return segments_.data() + static_cast<std::size_t>(param) * static_cast<std::size_t>(stride_);
+}
+
+int ResolvedParams::segmentCount(int param) const {
+    if (param < 0 || param >= size())
+        return 0;
+
+    return counts_[static_cast<std::size_t>(param)];
+}
+
+void ResolvedParams::setSegmentCount(int param, int count) {
+    if (param < 0 || param >= size())
+        return;
+
+    counts_[static_cast<std::size_t>(param)] = std::clamp(count, 0, stride_);
+}
+
+}  // namespace magda::engine

--- a/magda/engine/param/ParamBlock.cpp
+++ b/magda/engine/param/ParamBlock.cpp
@@ -20,21 +20,27 @@ float ParamValues::valueAt(int sampleOffset) const {
     const auto& segment = segments_[index];
     const auto end = index + 1 < segments_.size() ? segments_[index + 1].startSample : numSamples_;
     const auto span = end - segment.startSample;
-    if (span <= 0)
-        return segment.startValue;
 
+    // The position first, then the scale, which is the whole reason a segment
+    // stores positions: normalizedToReal clamps its own input, so a ramp that
+    // leaves the range holds at the end of it from the sample it arrives, and a
+    // scale with a curve in it is read along the curve rather than across it.
     const auto position =
-        static_cast<float>(sample - segment.startSample) / static_cast<float>(span);
-    return segment.startValue + (segment.endValue - segment.startValue) * position;
+        span <= 0 ? segment.startValue
+                  : segment.startValue + (segment.endValue - segment.startValue) *
+                                             (static_cast<float>(sample - segment.startSample) /
+                                              static_cast<float>(span));
+    return magda::ParameterUtils::normalizedToReal(position, domain_);
 }
 
 ParamValues DeviceParams::operator[](int paramIndex) const {
     if (paramIndex < 0 || paramIndex >= size())
         return {};
 
-    const auto offset = static_cast<std::size_t>(paramIndex) * static_cast<std::size_t>(stride_);
-    const auto count = static_cast<std::size_t>(counts_[static_cast<std::size_t>(paramIndex)]);
-    return ParamValues{segments_.subspan(offset, count), numSamples_};
+    const auto index = static_cast<std::size_t>(paramIndex);
+    const auto offset = index * static_cast<std::size_t>(stride_);
+    const auto count = static_cast<std::size_t>(counts_[index]);
+    return ParamValues{segments_.subspan(offset, count), domains_[index], numSamples_};
 }
 
 void ResolvedParams::prepare(int numParams, int segmentCapacity) {
@@ -42,6 +48,7 @@ void ResolvedParams::prepare(int numParams, int segmentCapacity) {
     const auto count = static_cast<std::size_t>(std::max(numParams, 0));
     segments_.assign(count * static_cast<std::size_t>(stride_), ParamSegment{});
     counts_.assign(count, 0);
+    domains_.assign(count, magda::ParameterUtils::ParameterDomain{});
     numSamples_ = 0;
 }
 
@@ -54,22 +61,26 @@ ParamValues ResolvedParams::operator[](int param) const {
     if (param < 0 || param >= size())
         return {};
 
-    const auto offset = static_cast<std::size_t>(param) * static_cast<std::size_t>(stride_);
-    const auto count = static_cast<std::size_t>(counts_[static_cast<std::size_t>(param)]);
+    const auto index = static_cast<std::size_t>(param);
+    const auto offset = index * static_cast<std::size_t>(stride_);
+    const auto count = static_cast<std::size_t>(counts_[index]);
     return ParamValues{std::span<const ParamSegment>{segments_}.subspan(offset, count),
-                       numSamples_};
+                       domains_[index], numSamples_};
 }
 
 DeviceParams ResolvedParams::device(int firstParam, int count) const {
     if (firstParam < 0 || count <= 0 || firstParam + count > size())
         return {};
 
-    const auto offset = static_cast<std::size_t>(firstParam) * static_cast<std::size_t>(stride_);
-    const auto width = static_cast<std::size_t>(count) * static_cast<std::size_t>(stride_);
-    return DeviceParams{std::span<const ParamSegment>{segments_}.subspan(offset, width),
-                        std::span<const int>{counts_}.subspan(static_cast<std::size_t>(firstParam),
-                                                              static_cast<std::size_t>(count)),
-                        stride_, numSamples_};
+    const auto first = static_cast<std::size_t>(firstParam);
+    const auto span = static_cast<std::size_t>(count);
+    const auto offset = first * static_cast<std::size_t>(stride_);
+    const auto width = span * static_cast<std::size_t>(stride_);
+    return DeviceParams{
+        std::span<const ParamSegment>{segments_}.subspan(offset, width),
+        std::span<const int>{counts_}.subspan(first, span),
+        std::span<const magda::ParameterUtils::ParameterDomain>{domains_}.subspan(first, span),
+        stride_, numSamples_};
 }
 
 ParamSegment* ResolvedParams::slotFor(int param) {
@@ -91,6 +102,13 @@ void ResolvedParams::setSegmentCount(int param, int count) {
         return;
 
     counts_[static_cast<std::size_t>(param)] = std::clamp(count, 0, stride_);
+}
+
+void ResolvedParams::setDomain(int param, const magda::ParameterUtils::ParameterDomain& domain) {
+    if (param < 0 || param >= size())
+        return;
+
+    domains_[static_cast<std::size_t>(param)] = domain;
 }
 
 }  // namespace magda::engine

--- a/magda/engine/param/ParamBlock.hpp
+++ b/magda/engine/param/ParamBlock.hpp
@@ -1,0 +1,219 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+#include <cstddef>
+#include <span>
+#include <vector>
+
+/**
+ * @file ParamBlock.hpp
+ * @brief What a device reads when it asks what a parameter is right now.
+ *
+ * A parameter is written by several things at once: the stored value a fader or
+ * a control surface sets, the automation curve playing over it, the modifiers
+ * linked to it. None of that reaches a device. What reaches a device is one
+ * resolved value stream per parameter, in the parameter's own units, already
+ * clamped and already quantised, and it is the only thing a device is allowed to
+ * read. Nothing downstream of here can rediscover what automation and modulation
+ * do to each other, because nothing downstream of here is shown them.
+ *
+ * The stream is segments rather than a scalar, and that is what lets "resolved
+ * once per block" and "a ramp inside the block" both be true. A parameter that
+ * does not move is one segment and costs a float; a parameter sweeping under
+ * automation is a handful, and a device that asked for them reads a value per
+ * sample without any of them asking where it came from.
+ *
+ * Resolution itself is ParamResolve.hpp. This is the shape the answer has.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief One stretch of a block over which a parameter moves linearly.
+ *
+ * The value at @ref startSample is @ref startValue, and it travels to
+ * @ref endValue, which is the value at the first sample the next segment covers,
+ * or one past the block's last sample for the final segment. Two segments in a
+ * row therefore meet exactly, and a step is a segment whose start differs from
+ * the previous one's end rather than a pair of points at one sample.
+ *
+ * The values are in the domain of whatever wrote them: an automation lane's
+ * segments carry normalised positions, because that is what a curve stores, and
+ * the resolved stream a device reads carries the parameter's own units. A device
+ * is handed Hz and dB rather than positions, because a normalised position is a
+ * thing the model needs and a number of Hertz is a thing a filter needs.
+ */
+struct ParamSegment {
+    int startSample = 0;
+    float startValue = 0.0f;
+    float endValue = 0.0f;
+};
+
+/**
+ * @brief One parameter's resolved value over one block.
+ *
+ * A view over segments the resolver wrote; it owns nothing and outlives
+ * nothing. Handed to a device inside its DeviceBlock and dead when the block is.
+ */
+class ParamValues {
+  public:
+    ParamValues() = default;
+
+    ParamValues(std::span<const ParamSegment> segments, int numSamples)
+        : segments_(segments), numSamples_(numSamples) {}
+
+    /**
+     * @brief The parameter's value for the block.
+     *
+     * The value at its first sample, which is what the incumbent engine's
+     * parameters take at a block boundary. A device that has not asked for
+     * segments reads this and is no further from the fork than the fork is from
+     * itself.
+     */
+    float value() const {
+        return segments_.empty() ? 0.0f : segments_.front().startValue;
+    }
+
+    /**
+     * @brief The parameter's value at one sample of the block.
+     *
+     * For a device that asked for segment accuracy. Offsets outside the block
+     * clamp to its ends rather than reading off either side of the segments.
+     */
+    float valueAt(int sampleOffset) const;
+
+    /// Whether the parameter holds one value for the whole block. True for
+    /// everything the port produces, since the fork settles parameters at block
+    /// boundaries and nothing opts out of that during the port.
+    bool isConstant() const {
+        return segments_.size() <= 1 &&
+               (segments_.empty() || segments_.front().startValue == segments_.front().endValue);
+    }
+
+    /// No segments at all, which is a parameter nothing resolved. A device
+    /// reading one is a bug upstream of it, not a value it should try to use.
+    bool empty() const {
+        return segments_.empty();
+    }
+
+    std::span<const ParamSegment> segments() const {
+        return segments_;
+    }
+
+    int numSegments() const {
+        return static_cast<int>(segments_.size());
+    }
+
+    int numSamples() const {
+        return numSamples_;
+    }
+
+  private:
+    std::span<const ParamSegment> segments_;
+    int numSamples_ = 0;
+};
+
+/**
+ * @brief The parameters of one device, in the order the device declared them.
+ *
+ * A device indexes its own parameters from zero, the way ParameterInfo's
+ * paramIndex does, and never learns where in the table they sit. The window is
+ * contiguous because a device's parameters are allocated together, which is what
+ * makes this a pair of integers rather than a map.
+ */
+class DeviceParams {
+  public:
+    DeviceParams() = default;
+
+    DeviceParams(std::span<const ParamSegment> segments, std::span<const int> counts, int stride,
+                 int numSamples)
+        : segments_(segments), counts_(counts), stride_(stride), numSamples_(numSamples) {}
+
+    int size() const {
+        return static_cast<int>(counts_.size());
+    }
+
+    /// The device's parameter @p paramIndex. An index the device does not have
+    /// is an empty view: the table is sized from the device's own specs when the
+    /// plan is prepared, so this is a device asking for a parameter it never
+    /// declared.
+    ParamValues operator[](int paramIndex) const;
+
+  private:
+    std::span<const ParamSegment> segments_;
+    std::span<const int> counts_;
+    int stride_ = 0;
+    int numSamples_ = 0;
+};
+
+/**
+ * @brief Every parameter behind one plan, resolved for one block.
+ *
+ * One table, indexed by the parameter ids the plan hands out, with each
+ * parameter's segments in a fixed-width slot of a flat arena. Fixed width
+ * because the arena is allocated once, off the audio thread, and a parameter
+ * that needed to grow mid-block would be an allocation on it.
+ *
+ * The width is a budget, like the MIDI one in EngineDevice.hpp: a parameter
+ * whose automation carries more breakpoints than this keeps the ones it has room
+ * for and rolls the rest into its last segment, which then ramps to where the
+ * curve actually ends. That is a coarser reading of a very busy curve, never a
+ * wrong destination.
+ */
+class ResolvedParams {
+  public:
+    /// Segments per parameter when nothing says otherwise. Sixteen breakpoints
+    /// is a curve moving faster than a block at any usable block size, and a
+    /// parameter that is not automated uses one of them.
+    static constexpr int kDefaultSegmentCapacity = 16;
+
+    /// Off the audio thread, before the first block. Every parameter starts
+    /// empty; a block that resolves nothing hands out empty views rather than
+    /// stale ones.
+    void prepare(int numParams, int segmentCapacity = kDefaultSegmentCapacity);
+
+    /// How many parameters the table holds.
+    int size() const {
+        return static_cast<int>(counts_.size());
+    }
+
+    int segmentCapacity() const {
+        return stride_;
+    }
+
+    /// The block the table currently holds values for. Set by the resolver.
+    int numSamples() const {
+        return numSamples_;
+    }
+
+    /// On the audio thread, at the top of a block, before anything resolves
+    /// into it. Empties every parameter and records the block length, so a
+    /// parameter nobody resolved this block reads as empty rather than as
+    /// whatever it was last block.
+    void beginBlock(int numSamples);
+
+    /// On the audio thread: the values @p param resolved to. Empty for a
+    /// parameter the table does not have.
+    ParamValues operator[](int param) const;
+
+    /// The window a device reads: @p count parameters from @p firstParam.
+    DeviceParams device(int firstParam, int count) const;
+
+    /// Where the resolver writes @p param's segments. Never null for a
+    /// parameter the table has; @ref segmentCapacity() wide.
+    ParamSegment* slotFor(int param);
+
+    /// How many segments @p param currently holds, and what it holds after the
+    /// resolver has written them.
+    int segmentCount(int param) const;
+    void setSegmentCount(int param, int count);
+
+  private:
+    std::vector<ParamSegment> segments_;
+    std::vector<int> counts_;
+    int stride_ = 0;
+    int numSamples_ = 0;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/param/ParamBlock.hpp
+++ b/magda/engine/param/ParamBlock.hpp
@@ -6,6 +6,8 @@
 #include <span>
 #include <vector>
 
+#include "core/ParameterUtils.hpp"
+
 /**
  * @file ParamBlock.hpp
  * @brief What a device reads when it asks what a parameter is right now.
@@ -38,11 +40,20 @@ namespace magda::engine {
  * row therefore meet exactly, and a step is a segment whose start differs from
  * the previous one's end rather than a pair of points at one sample.
  *
- * The values are in the domain of whatever wrote them: an automation lane's
- * segments carry normalised positions, because that is what a curve stores, and
- * the resolved stream a device reads carries the parameter's own units. A device
- * is handed Hz and dB rather than positions, because a normalised position is a
- * thing the model needs and a number of Hertz is a thing a filter needs.
+ * Normalised positions, unclamped, wherever a segment appears: in an automation
+ * lane on the way in, and in the resolved stream on the way out. A device still
+ * reads Hz and dB, because ParamValues converts on the way past, and the two
+ * facts have to go together.
+ *
+ * A segment that carried the parameter's own units could not be read correctly
+ * at any sample but its ends. Interpolating between two converted endpoints is
+ * only the same as converting the interpolated position when the scale is a
+ * straight line: on a logarithmic cutoff sweeping its whole range, the halfway
+ * point is 632 Hz through the scale and 10,010 Hz through the chord across it.
+ * Leaving the values unclamped is the same argument one step further out. A ramp
+ * that leaves the range partway through holds at the top from there on, and a
+ * pair of clamped endpoints describes a slower ramp that arrives at the end
+ * instead, which is a plateau the parameter never had.
  */
 struct ParamSegment {
     int startSample = 0;
@@ -55,13 +66,19 @@ struct ParamSegment {
  *
  * A view over segments the resolver wrote; it owns nothing and outlives
  * nothing. Handed to a device inside its DeviceBlock and dead when the block is.
+ *
+ * The clamp and the scale are applied here rather than by the resolver, at the
+ * position being read rather than at the ends of a segment, which is the only
+ * place either can be applied correctly (see ParamSegment). The device sees the
+ * parameter's own units and no sign of where the arithmetic happened.
  */
 class ParamValues {
   public:
     ParamValues() = default;
 
-    ParamValues(std::span<const ParamSegment> segments, int numSamples)
-        : segments_(segments), numSamples_(numSamples) {}
+    ParamValues(std::span<const ParamSegment> segments,
+                const magda::ParameterUtils::ParameterDomain& domain, int numSamples)
+        : segments_(segments), domain_(domain), numSamples_(numSamples) {}
 
     /**
      * @brief The parameter's value for the block.
@@ -72,7 +89,9 @@ class ParamValues {
      * itself.
      */
     float value() const {
-        return segments_.empty() ? 0.0f : segments_.front().startValue;
+        return segments_.empty()
+                   ? 0.0f
+                   : magda::ParameterUtils::normalizedToReal(segments_.front().startValue, domain_);
     }
 
     /**
@@ -86,6 +105,11 @@ class ParamValues {
     /// Whether the parameter holds one value for the whole block. True for
     /// everything the port produces, since the fork settles parameters at block
     /// boundaries and nothing opts out of that during the port.
+    ///
+    /// Read off the stored positions rather than the values they convert to, so
+    /// a stream that moves only outside the range says it moves. A device using
+    /// this to skip a per-sample read is told to do the work it did not need,
+    /// which is the direction that costs nothing but time.
     bool isConstant() const {
         return segments_.size() <= 1 &&
                (segments_.empty() || segments_.front().startValue == segments_.front().endValue);
@@ -111,6 +135,7 @@ class ParamValues {
 
   private:
     std::span<const ParamSegment> segments_;
+    magda::ParameterUtils::ParameterDomain domain_;
     int numSamples_ = 0;
 };
 
@@ -126,9 +151,14 @@ class DeviceParams {
   public:
     DeviceParams() = default;
 
-    DeviceParams(std::span<const ParamSegment> segments, std::span<const int> counts, int stride,
+    DeviceParams(std::span<const ParamSegment> segments, std::span<const int> counts,
+                 std::span<const magda::ParameterUtils::ParameterDomain> domains, int stride,
                  int numSamples)
-        : segments_(segments), counts_(counts), stride_(stride), numSamples_(numSamples) {}
+        : segments_(segments),
+          counts_(counts),
+          domains_(domains),
+          stride_(stride),
+          numSamples_(numSamples) {}
 
     int size() const {
         return static_cast<int>(counts_.size());
@@ -143,6 +173,7 @@ class DeviceParams {
   private:
     std::span<const ParamSegment> segments_;
     std::span<const int> counts_;
+    std::span<const magda::ParameterUtils::ParameterDomain> domains_;
     int stride_ = 0;
     int numSamples_ = 0;
 };
@@ -155,11 +186,12 @@ class DeviceParams {
  * because the arena is allocated once, off the audio thread, and a parameter
  * that needed to grow mid-block would be an allocation on it.
  *
- * The width is a budget, like the MIDI one in EngineDevice.hpp: a parameter
- * whose automation carries more breakpoints than this keeps the ones it has room
- * for and rolls the rest into its last segment, which then ramps to where the
- * curve actually ends. That is a coarser reading of a very busy curve, never a
- * wrong destination.
+ * The width is a budget, like the MIDI one in EngineDevice.hpp, and a curve with
+ * more breakpoints than fit is coarsened rather than cut off. What that means
+ * differs by what the parameter is, and both readings keep the destination: a
+ * continuous parameter rolls the tail into its last segment, which ramps to
+ * where the curve ends, and a stepped one spends its last slot on the step the
+ * curve ends on, losing the steps in between instead of the arrival.
  */
 class ResolvedParams {
   public:
@@ -209,9 +241,16 @@ class ResolvedParams {
     int segmentCount(int param) const;
     void setSegmentCount(int param, int count);
 
+    /// The scale @p param's stored positions are read through. Written by the
+    /// resolver from the parameter's spec, and travelling with the values
+    /// rather than beside them, because a position without the scale that
+    /// interprets it is not a value at all.
+    void setDomain(int param, const magda::ParameterUtils::ParameterDomain& domain);
+
   private:
     std::vector<ParamSegment> segments_;
     std::vector<int> counts_;
+    std::vector<magda::ParameterUtils::ParameterDomain> domains_;
     int stride_ = 0;
     int numSamples_ = 0;
 };

--- a/magda/engine/param/ParamResolve.cpp
+++ b/magda/engine/param/ParamResolve.cpp
@@ -1,0 +1,130 @@
+#include "param/ParamResolve.hpp"
+
+#include <juce_core/juce_core.h>
+
+#include <algorithm>
+
+namespace magda::engine {
+
+namespace {
+
+/// Everything the links add, before the clamp. A parameter that does not take
+/// modulation adds nothing rather than dropping the links: the links are the
+/// model's, and a block is not where a model edit happens.
+float modulationSum(const ParamSpec& spec, std::span<const ModContribution> links) {
+    if (!spec.modulatable)
+        return 0.0f;
+
+    float offset = 0.0f;
+    for (const auto& link : links)
+        offset += magda::ParameterUtils::modulationOffset(link.value, link.amount, link.bipolar);
+
+    return offset;
+}
+
+}  // namespace
+
+void resolveParam(ResolvedParams& out, int param, const ParamSpec& spec,
+                  const ParamSources& sources) {
+    auto* slot = out.slotFor(param);
+    if (slot == nullptr)
+        return;
+
+    const int numSamples = out.numSamples();
+    const int capacity = out.segmentCapacity();
+    const float offset = modulationSum(spec, sources.modulation);
+    const bool stepped = magda::ParameterUtils::isStepped(spec.domain);
+
+    // The one clamp, and the one conversion out of the normalised domain the
+    // lanes share into the units the device reads.
+    const auto toReal = [&](float normalised) {
+        return magda::ParameterUtils::normalizedToReal(
+            juce::jlimit(0.0f, 1.0f, normalised + offset), spec.domain);
+    };
+
+    // A stepped parameter holds its value across a segment: there is nothing
+    // between two of its values for a ramp to pass through.
+    const auto write = [&](int index, int startSample, float startNormalised, float endNormalised) {
+        const float startValue = toReal(startNormalised);
+        slot[index] =
+            ParamSegment{startSample, startValue, stepped ? startValue : toReal(endNormalised)};
+    };
+
+    const auto& automation = sources.automation;
+
+    const int coverStart =
+        automation.empty() ? 0 : std::clamp(automation.front().startSample, 0, numSamples);
+    // Zero is the common case spelled shortest: an absolute lane covers the
+    // whole block, and only a lane that stops inside one says where.
+    const int coverEnd = automation.empty()
+                             ? 0
+                             : (sources.automationEnd <= 0
+                                    ? numSamples
+                                    : std::clamp(sources.automationEnd, coverStart, numSamples));
+
+    int covered = 0;
+    for (const auto& segment : automation) {
+        if (segment.startSample >= coverEnd)
+            break;
+        ++covered;
+    }
+
+    const bool coversFirstSample = covered > 0 && coverStart == 0;
+
+    // The value the block opens with, which is all a device that reads once for
+    // the block ever sees, and all there is to write when nothing moves.
+    const float openingValue = coversFirstSample ? automation.front().startValue : sources.base;
+
+    if (covered == 0 || !spec.segmentAccurate) {
+        write(0, 0, openingValue, openingValue);
+        out.setSegmentCount(param, 1);
+        return;
+    }
+
+    // The virtual list: the base before the lane, the lane, the base after it.
+    // Never built anywhere, because building it would allocate; walked instead,
+    // which is what the index arithmetic below is for.
+    const int leading = coverStart > 0 ? 1 : 0;
+    const int trailing = coverEnd < numSamples ? 1 : 0;
+    const int total = leading + covered + trailing;
+
+    // Where the block ends up, which is where a list too long for its slot has
+    // to arrive anyway.
+    const float finalNormalised =
+        trailing > 0 ? sources.base : automation[static_cast<std::size_t>(covered - 1)].endValue;
+
+    int written = 0;
+    int index = 0;
+
+    // True when the segment just offered was the last one that fits and more
+    // were coming: it is written as a ramp to where the lane ends instead, and
+    // the rest are rolled into it.
+    const auto offer = [&](int startSample, float startNormalised, float endNormalised) {
+        const bool more = index < total - 1;
+        if (more && written == capacity - 1) {
+            write(written++, startSample, startNormalised, finalNormalised);
+            return false;
+        }
+
+        write(written++, startSample, startNormalised, endNormalised);
+        ++index;
+        return true;
+    };
+
+    bool room = true;
+
+    if (leading > 0)
+        room = offer(0, sources.base, sources.base);
+
+    for (int i = 0; room && i < covered; ++i) {
+        const auto& segment = automation[static_cast<std::size_t>(i)];
+        room = offer(std::max(segment.startSample, 0), segment.startValue, segment.endValue);
+    }
+
+    if (room && trailing > 0)
+        offer(coverEnd, sources.base, sources.base);
+
+    out.setSegmentCount(param, written);
+}
+
+}  // namespace magda::engine

--- a/magda/engine/param/ParamResolve.cpp
+++ b/magda/engine/param/ParamResolve.cpp
@@ -30,24 +30,25 @@ void resolveParam(ResolvedParams& out, int param, const ParamSpec& spec,
     if (slot == nullptr)
         return;
 
+    // The scale travels with the values, because a position is only a value
+    // once something says what it is a position in.
+    out.setDomain(param, spec.domain);
+
     const int numSamples = out.numSamples();
     const int capacity = out.segmentCapacity();
     const float offset = modulationSum(spec, sources.modulation);
     const bool stepped = magda::ParameterUtils::isStepped(spec.domain);
 
-    // The one clamp, and the one conversion out of the normalised domain the
-    // lanes share into the units the device reads.
-    const auto toReal = [&](float normalised) {
-        return magda::ParameterUtils::normalizedToReal(
-            juce::jlimit(0.0f, 1.0f, normalised + offset), spec.domain);
-    };
-
+    // Positions, with the links added and nothing else done to them. The clamp
+    // and the scale are applied where the stream is read, at the position being
+    // asked about rather than at the ends of a segment, which is the only place
+    // either is correct (ParamBlock.hpp says why).
+    //
     // A stepped parameter holds its value across a segment: there is nothing
     // between two of its values for a ramp to pass through.
     const auto write = [&](int index, int startSample, float startNormalised, float endNormalised) {
-        const float startValue = toReal(startNormalised);
-        slot[index] =
-            ParamSegment{startSample, startValue, stepped ? startValue : toReal(endNormalised)};
+        const float start = startNormalised + offset;
+        slot[index] = ParamSegment{startSample, start, stepped ? start : endNormalised + offset};
     };
 
     const auto& automation = sources.automation;
@@ -88,27 +89,46 @@ void resolveParam(ResolvedParams& out, int param, const ParamSpec& spec,
     const int trailing = coverEnd < numSamples ? 1 : 0;
     const int total = leading + covered + trailing;
 
-    // Where the block ends up, which is where a list too long for its slot has
-    // to arrive anyway.
-    const float finalNormalised =
-        trailing > 0 ? sources.base : automation[static_cast<std::size_t>(covered - 1)].endValue;
+    // The last thing in the list, which is where a list too long for its slot
+    // has to arrive whatever it does on the way.
+    const auto& lastCovered = automation[static_cast<std::size_t>(covered - 1)];
+    const int finalStart = trailing > 0 ? coverEnd : std::max(lastCovered.startSample, 0);
+    const float finalStartNormalised = trailing > 0 ? sources.base : lastCovered.startValue;
+    const float finalEndNormalised = trailing > 0 ? sources.base : lastCovered.endValue;
 
     int written = 0;
     int index = 0;
 
-    // True when the segment just offered was the last one that fits and more
-    // were coming: it is written as a ramp to where the lane ends instead, and
-    // the rest are rolled into it.
+    // False when the list has run out of slots. The segment being offered is
+    // the last one that fits and more were coming, so what goes in that slot is
+    // the rest of the list coarsened into one, and the two ways of doing that
+    // are not interchangeable.
+    //
+    // A continuous parameter ramps from here to where the lane ends, which
+    // passes through every value in between and arrives on time. A stepped one
+    // cannot: it has no in-between, and a ramp written for it is flattened to
+    // its own start, which would throw the destination away. It spends the slot
+    // on the step the lane ends on instead, holding the value it already had
+    // until that step arrives. Either way the block ends where the lane says.
+    //
+    // With a single slot there is nothing to spend: the step would land at its
+    // own sample and leave the start of the block reading a value the parameter
+    // does not have yet, so the opening value is kept and the destination is
+    // what goes, which is the reading a device that asked for one value per
+    // block gets anyway.
     const auto offer = [&](int startSample, float startNormalised, float endNormalised) {
         const bool more = index < total - 1;
-        if (more && written == capacity - 1) {
-            write(written++, startSample, startNormalised, finalNormalised);
+        if (more && written == capacity - 1 && (!stepped || written > 0)) {
+            if (stepped)
+                write(written++, finalStart, finalStartNormalised, finalStartNormalised);
+            else
+                write(written++, startSample, startNormalised, finalEndNormalised);
             return false;
         }
 
         write(written++, startSample, startNormalised, endNormalised);
         ++index;
-        return true;
+        return written < capacity;
     };
 
     bool room = true;

--- a/magda/engine/param/ParamResolve.hpp
+++ b/magda/engine/param/ParamResolve.hpp
@@ -35,6 +35,9 @@
  *    domain, with each link's depth and polarity applied at the link.
  *  - One clamp, after every contribution, and then the parameter's own scale.
  *    A device never receives a value outside its range and never has to check.
+ *    Both happen where the stream is read rather than here, at the position
+ *    being asked about rather than at the ends of a segment, which is the only
+ *    place either is correct once a ramp is involved (ParamBlock.hpp).
  *  - A stepped parameter is quantised by the scale, which is where the steps
  *    are, and never ramped, because there is nothing between two of its values.
  *

--- a/magda/engine/param/ParamResolve.hpp
+++ b/magda/engine/param/ParamResolve.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <span>
+
+#include "param/ParamBlock.hpp"
+#include "param/ParamSpec.hpp"
+
+/**
+ * @file ParamResolve.hpp
+ * @brief The lanes writing a parameter, and the one place they are resolved.
+ *
+ * Three things write a parameter and they do not write the same thing.
+ *
+ * The base is what the parameter is: the stored value, moved by a knob, a
+ * control surface, a preset load or a host write. Automation is a curve playing
+ * over it, which covers as much of a block as it covers and no more. Modulation
+ * is what the modifiers linked to the parameter add to whatever the first two
+ * settled on.
+ *
+ * They are separate lanes rather than one value written by turns, and that is
+ * the whole point of the arrangement. The incumbent engine has one value and
+ * several writers, which is why a host write lands on a parameter under an
+ * active modifier and disappears: the modifier writes next and there was only
+ * ever one place to write. Here a host write goes into a lane modulation never
+ * touches, so nothing can overwrite it, and the bug class is gone rather than
+ * patched.
+ *
+ * Precedence, in full:
+ *
+ *  - Automation replaces the base wherever a lane covers the block, and the
+ *    base is what the parameter is everywhere else. A lane that covers half a
+ *    block leaves the other half to the base, which is what an automation clip
+ *    starting mid-block does.
+ *  - Modulation is added to whichever of the two applied, in the normalised
+ *    domain, with each link's depth and polarity applied at the link.
+ *  - One clamp, after every contribution, and then the parameter's own scale.
+ *    A device never receives a value outside its range and never has to check.
+ *  - A stepped parameter is quantised by the scale, which is where the steps
+ *    are, and never ramped, because there is nothing between two of its values.
+ *
+ * Which authority state a lane is in is not decided here. The model owns that
+ * (AutomationStateMachine), and a lane handed to a block is one the model has
+ * already decided is playing; read mode is what the port ships, and write, touch
+ * and latch change what the model does with a gesture rather than what a block
+ * does with a lane.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief What one modulation link adds to a parameter this block.
+ *
+ * Block-rate, because the modifiers it comes from are: the incumbent engine
+ * advances a modifier once per block and every parity case in the corpus is
+ * measured against that. A modifier that ran per sample would be a difference
+ * from the fork on every modulated parameter, which is a decision for after the
+ * port rather than during it.
+ */
+struct ModContribution {
+    /// The modifier's output, 0 to 1. An inactive modifier outputs 0, which is
+    /// what invertOutput exists to make usable for a level curve.
+    float value = 0.0f;
+
+    /// The link's depth, -1 to 1. Per link rather than per modifier, because
+    /// one modifier drives several parameters by different amounts.
+    float amount = 0.0f;
+
+    /// Whether the modifier's 0 to 1 maps to -1 to +1 before the depth is
+    /// applied. Per link, like the depth.
+    bool bipolar = false;
+};
+
+/** @brief The lanes writing one parameter over one block. */
+struct ParamSources {
+    /// The stored value, normalised. What the parameter is where no automation
+    /// covers it.
+    float base = 0.0f;
+
+    /// The curve playing over it, normalised, in this block's sample domain.
+    /// Empty when no lane covers any of the block.
+    std::span<const ParamSegment> automation;
+
+    /// One past the last sample the lane covers. The block length for a lane
+    /// that runs to the end of it, and less for a lane that stops inside it,
+    /// where the base takes over again. Ignored when there is no lane.
+    int automationEnd = 0;
+
+    /// The links reaching this parameter. Empty for a parameter nothing
+    /// modulates, which is almost all of them.
+    std::span<const ModContribution> modulation;
+};
+
+/**
+ * @brief Resolve one parameter's lanes into what its device reads.
+ *
+ * On the audio thread, once per parameter per block, after
+ * ResolvedParams::beginBlock(). Writes into @p out at @p param and touches
+ * nothing else.
+ *
+ * The only place the precedence above is implemented. A device that wanted to
+ * know whether its cutoff came from a curve or a knob would have to be told,
+ * and nothing tells it.
+ */
+void resolveParam(ResolvedParams& out, int param, const ParamSpec& spec,
+                  const ParamSources& sources);
+
+}  // namespace magda::engine

--- a/magda/engine/param/ParamSpec.cpp
+++ b/magda/engine/param/ParamSpec.cpp
@@ -1,0 +1,16 @@
+#include "param/ParamSpec.hpp"
+
+namespace magda::engine {
+
+ParamSpec paramSpecFrom(const magda::ParameterInfo& info) {
+    ParamSpec spec;
+    spec.domain = magda::ParameterUtils::domainOf(info);
+    spec.modulatable = info.modulatable;
+    // segmentAccurate stays false: see the header. A device asks for it; a
+    // ParameterInfo has no opinion about it and never grows one, because the
+    // question is what the device does with the value rather than what the
+    // value is.
+    return spec;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/param/ParamSpec.hpp
+++ b/magda/engine/param/ParamSpec.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "core/ParameterUtils.hpp"
+
+/**
+ * @file ParamSpec.hpp
+ * @brief What one parameter is, as the audio thread needs to know it.
+ *
+ * The model's ParameterInfo says everything about a parameter: its name, its
+ * unit, how to format it, which cell of the grid it draws in. Almost none of
+ * that survives the trip to a render block, and what does is a handful of
+ * numbers saying what a normalised position means. This is those numbers, plus
+ * the two things the engine decides for itself.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief The audio-thread face of one parameter.
+ *
+ * Flat, copyable, no heap. Built off the audio thread by paramSpecFrom() and
+ * read on it by the resolver every block.
+ */
+struct ParamSpec {
+    /// What a normalised position means in this parameter's own units. The
+    /// model's curve, not a copy of it: ParameterUtils owns the conversion and
+    /// this is the part of a ParameterInfo it reads.
+    magda::ParameterUtils::ParameterDomain domain;
+
+    /**
+     * @brief Whether modulation may reach this parameter.
+     *
+     * From ParameterInfo::modulatable. Enforced where the contributions are
+     * added rather than where a link is made, because a link is a model edit
+     * and this is what the block does: a contribution to a parameter that does
+     * not take modulation adds nothing, and the parameter follows its base and
+     * its automation alone.
+     */
+    bool modulatable = true;
+
+    /**
+     * @brief Whether the device reads the value inside the block or once for it.
+     *
+     * Off by default, and that default is a parity decision rather than a
+     * performance one. The incumbent engine settles every parameter at the
+     * block boundary, so a device resolved per sample against a curve the fork
+     * reads once would differ from it by however much the curve moves across a
+     * block, on every automated parameter, in every project. During the port
+     * nothing opts in, and the null-diff corpus is what would say so if
+     * something did.
+     *
+     * What opting in buys is a parameter that ramps rather than steps inside
+     * the block, which matters where the step is audible: a filter cutoff swept
+     * fast, a gain automated at the sample level. It is per parameter because
+     * that is the granularity the cost is paid at.
+     */
+    bool segmentAccurate = false;
+};
+
+/** @brief The spec of the parameter @p info describes. Off the audio thread. */
+ParamSpec paramSpecFrom(const magda::ParameterInfo& info);
+
+}  // namespace magda::engine

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -305,6 +305,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES PlanEditHarness.cpp)
     list(APPEND TEST_SOURCES test_plan_edit_properties.cpp)
     list(APPEND TEST_SOURCES test_engine_session.cpp)
+    # The parameter lane (#2116). The lanes are fed by hand, so the precedence
+    # rules are testable before anything writes them.
+    list(APPEND TEST_SOURCES test_param_lane.cpp)
     list(APPEND TEST_SOURCES test_tempo_map.cpp)
     list(APPEND TEST_SOURCES test_transport_clock.cpp)
     list(APPEND TEST_SOURCES test_click_generator.cpp)

--- a/tests/test_param_lane.cpp
+++ b/tests/test_param_lane.cpp
@@ -1,0 +1,365 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+#include "core/ParameterInfo.hpp"
+#include "param/ParamBlock.hpp"
+#include "param/ParamResolve.hpp"
+#include "param/ParamSpec.hpp"
+
+/**
+ * @file test_param_lane.cpp
+ * @brief The parameter lane and its precedence (#2116).
+ *
+ * The lanes are fed by hand here, which is the point: the sources that will
+ * write them arrive in later slices (automation in #2118, the modifiers in
+ * #2119 and #2120), and the rules about how they combine are settled now, where
+ * a case can put a curve and a modifier and a knob move against each other and
+ * say what the device must hear.
+ */
+
+using magda::engine::DeviceParams;
+using magda::engine::ModContribution;
+using magda::engine::ParamSegment;
+using magda::engine::ParamSources;
+using magda::engine::ParamSpec;
+using magda::engine::paramSpecFrom;
+using magda::engine::ParamValues;
+using magda::engine::ResolvedParams;
+using magda::engine::resolveParam;
+
+namespace {
+
+Catch::Approx approx(float value) {
+    return Catch::Approx(value).margin(1e-5);
+}
+
+/// A parameter reading 0 to 100 of something, so a normalised position and the
+/// value a device reads cannot be confused for each other.
+ParamSpec percentSpec(bool segmentAccurate = false) {
+    ParamSpec spec;
+    spec.domain.scale = magda::ParameterScale::Linear;
+    spec.domain.minValue = 0.0f;
+    spec.domain.maxValue = 100.0f;
+    spec.segmentAccurate = segmentAccurate;
+    return spec;
+}
+
+/// One block's worth of table, holding one parameter.
+struct OneParam {
+    explicit OneParam(int numSamples, int capacity = ResolvedParams::kDefaultSegmentCapacity) {
+        params.prepare(1, capacity);
+        params.beginBlock(numSamples);
+    }
+
+    ParamValues resolve(const ParamSpec& spec, const ParamSources& sources) {
+        resolveParam(params, 0, spec, sources);
+        return params[0];
+    }
+
+    ResolvedParams params;
+};
+
+}  // namespace
+
+TEST_CASE("A parameter with nothing but a base reads its base", "[engine][param]") {
+    OneParam table{512};
+
+    ParamSources sources;
+    sources.base = 0.25f;
+
+    const auto values = table.resolve(percentSpec(), sources);
+
+    REQUIRE(values.numSegments() == 1);
+    CHECK(values.isConstant());
+    CHECK(values.value() == approx(25.0f));
+    CHECK(values.valueAt(511) == approx(25.0f));
+}
+
+TEST_CASE("Automation replaces the base where it covers the block", "[engine][param]") {
+    OneParam table{100};
+
+    const std::vector<ParamSegment> lane{{40, 0.9f, 0.9f}};
+
+    ParamSources sources;
+    sources.base = 0.1f;
+    sources.automation = lane;
+    sources.automationEnd = 80;
+
+    const auto values = table.resolve(percentSpec(/*segmentAccurate=*/true), sources);
+
+    // Base, lane, base: an automation clip starting and stopping inside a block
+    // leaves the parameter to its stored value on either side of itself.
+    REQUIRE(values.numSegments() == 3);
+    CHECK(values.valueAt(0) == approx(10.0f));
+    CHECK(values.valueAt(39) == approx(10.0f));
+    CHECK(values.valueAt(40) == approx(90.0f));
+    CHECK(values.valueAt(79) == approx(90.0f));
+    CHECK(values.valueAt(80) == approx(10.0f));
+    CHECK(values.valueAt(99) == approx(10.0f));
+}
+
+TEST_CASE("An absolute lane covers the whole block without saying so", "[engine][param]") {
+    OneParam table{64};
+
+    const std::vector<ParamSegment> lane{{0, 0.5f, 0.5f}};
+
+    ParamSources sources;
+    sources.base = 0.0f;
+    sources.automation = lane;
+
+    const auto values = table.resolve(percentSpec(/*segmentAccurate=*/true), sources);
+
+    REQUIRE(values.numSegments() == 1);
+    CHECK(values.valueAt(63) == approx(50.0f));
+}
+
+TEST_CASE("A host write under an active modifier is not dropped", "[engine][param]") {
+    // The bug class the two lanes exist to make impossible. In the incumbent
+    // engine a parameter has one value and several writers, so a knob move
+    // under a running LFO is overwritten by the LFO's next write and the user
+    // watches the knob spring back. Here the write lands in a lane the
+    // modulation never touches.
+    OneParam table{256};
+
+    const std::vector<ModContribution> lfo{{/*value=*/1.0f, /*amount=*/0.2f, /*bipolar=*/false}};
+
+    ParamSources sources;
+    sources.base = 0.3f;
+    sources.modulation = lfo;
+
+    CHECK(table.resolve(percentSpec(), sources).value() == approx(50.0f));
+
+    // The knob moves. Nothing else changed.
+    sources.base = 0.6f;
+
+    CHECK(table.resolve(percentSpec(), sources).value() == approx(80.0f));
+}
+
+TEST_CASE("Modulation is summed before the one clamp", "[engine][param]") {
+    OneParam table{32};
+
+    // Individually the first of these leaves the range and the second brings it
+    // back. Clamped per link the answer would be 40; clamped once it is 70,
+    // which is where the parameter actually is.
+    const std::vector<ModContribution> links{{1.0f, 0.8f, false}, {1.0f, -0.6f, false}};
+
+    ParamSources sources;
+    sources.base = 0.5f;
+    sources.modulation = links;
+
+    CHECK(table.resolve(percentSpec(), sources).value() == approx(70.0f));
+}
+
+TEST_CASE("Modulation is clamped into range at the end", "[engine][param]") {
+    OneParam table{32};
+
+    const std::vector<ModContribution> links{{1.0f, 0.9f, false}};
+
+    ParamSources sources;
+    sources.base = 0.8f;
+    sources.modulation = links;
+
+    CHECK(table.resolve(percentSpec(), sources).value() == approx(100.0f));
+}
+
+TEST_CASE("A bipolar link swings either side of the base", "[engine][param]") {
+    OneParam table{32};
+
+    ParamSources sources;
+    sources.base = 0.5f;
+
+    // A bipolar link at a quarter depth reaches a quarter of the range either
+    // side of where the parameter is sitting.
+    const std::vector<ModContribution> low{{0.0f, 0.25f, true}};
+    sources.modulation = low;
+    CHECK(table.resolve(percentSpec(), sources).value() == approx(25.0f));
+
+    const std::vector<ModContribution> high{{1.0f, 0.25f, true}};
+    sources.modulation = high;
+    CHECK(table.resolve(percentSpec(), sources).value() == approx(75.0f));
+}
+
+TEST_CASE("A parameter that takes no modulation ignores its links", "[engine][param]") {
+    OneParam table{32};
+
+    auto spec = percentSpec();
+    spec.modulatable = false;
+
+    const std::vector<ModContribution> links{{1.0f, 1.0f, false}};
+
+    ParamSources sources;
+    sources.base = 0.25f;
+    sources.modulation = links;
+
+    CHECK(table.resolve(spec, sources).value() == approx(25.0f));
+}
+
+TEST_CASE("A device that reads once for the block gets one segment", "[engine][param]") {
+    OneParam table{128};
+
+    const std::vector<ParamSegment> lane{{0, 0.0f, 1.0f}};
+
+    ParamSources sources;
+    sources.automation = lane;
+
+    // Not opted in: the value at the top of the block, held, which is what the
+    // incumbent engine's parameters take at a block boundary.
+    const auto blockRate = table.resolve(percentSpec(), sources);
+    REQUIRE(blockRate.numSegments() == 1);
+    CHECK(blockRate.isConstant());
+    CHECK(blockRate.value() == approx(0.0f));
+    CHECK(blockRate.valueAt(127) == approx(0.0f));
+
+    // Opted in: the same lane, ramped.
+    table.params.beginBlock(128);
+    const auto segmented = table.resolve(percentSpec(/*segmentAccurate=*/true), sources);
+    CHECK(segmented.valueAt(0) == approx(0.0f));
+    CHECK(segmented.valueAt(64) == approx(50.0f));
+    CHECK_FALSE(segmented.isConstant());
+}
+
+TEST_CASE("Consecutive segments meet at the sample they share", "[engine][param]") {
+    OneParam table{100};
+
+    const std::vector<ParamSegment> lane{{0, 0.0f, 0.5f}, {50, 0.5f, 1.0f}};
+
+    ParamSources sources;
+    sources.automation = lane;
+
+    const auto values = table.resolve(percentSpec(/*segmentAccurate=*/true), sources);
+
+    REQUIRE(values.numSegments() == 2);
+    CHECK(values.valueAt(25) == approx(25.0f));
+    CHECK(values.valueAt(49) == approx(49.0f));
+    CHECK(values.valueAt(50) == approx(50.0f));
+    CHECK(values.valueAt(75) == approx(75.0f));
+}
+
+TEST_CASE("Modulation shifts a ramp rather than flattening it", "[engine][param]") {
+    OneParam table{100};
+
+    const std::vector<ParamSegment> lane{{0, 0.0f, 0.5f}};
+    const std::vector<ModContribution> links{{1.0f, 0.25f, false}};
+
+    ParamSources sources;
+    sources.automation = lane;
+    sources.modulation = links;
+
+    const auto values = table.resolve(percentSpec(/*segmentAccurate=*/true), sources);
+
+    CHECK(values.valueAt(0) == approx(25.0f));
+    CHECK(values.valueAt(50) == approx(50.0f));
+}
+
+TEST_CASE("A stepped parameter quantises and never ramps", "[engine][param]") {
+    OneParam table{64};
+
+    ParamSpec spec;
+    spec.domain.scale = magda::ParameterScale::Discrete;
+    spec.domain.choiceCount = 4;
+    spec.segmentAccurate = true;
+
+    const std::vector<ParamSegment> lane{{0, 0.0f, 1.0f}, {32, 1.0f, 1.0f}};
+
+    ParamSources sources;
+    sources.automation = lane;
+
+    const auto values = table.resolve(spec, sources);
+
+    REQUIRE(values.numSegments() == 2);
+    // The first segment would ramp through 1.5 of a choice halfway along if a
+    // ramp were allowed. It holds instead, and the value changes where the
+    // next segment starts.
+    CHECK(values.valueAt(0) == approx(0.0f));
+    CHECK(values.valueAt(31) == approx(0.0f));
+    CHECK(values.valueAt(32) == approx(3.0f));
+}
+
+TEST_CASE("A curve with more breakpoints than its slot arrives where it ends", "[engine][param]") {
+    OneParam table{100, /*capacity=*/4};
+
+    const std::vector<ParamSegment> lane{{0, 0.0f, 0.1f},  {10, 0.1f, 0.2f}, {20, 0.2f, 0.3f},
+                                         {30, 0.3f, 0.4f}, {40, 0.4f, 0.5f}, {50, 0.5f, 0.8f}};
+
+    ParamSources sources;
+    sources.automation = lane;
+
+    const auto values = table.resolve(percentSpec(/*segmentAccurate=*/true), sources);
+
+    REQUIRE(values.numSegments() == 4);
+    // The first three are the curve's own. The fourth carries the rest of it as
+    // one ramp, and it ends where the curve ends rather than wherever it was
+    // cut off.
+    CHECK(values.valueAt(0) == approx(0.0f));
+    CHECK(values.valueAt(20) == approx(20.0f));
+    CHECK(values.segments().back().startSample == 30);
+    CHECK(values.segments().back().endValue == approx(80.0f));
+}
+
+TEST_CASE("A parameter nobody resolved reads as empty", "[engine][param]") {
+    ResolvedParams params;
+    params.prepare(3);
+    params.beginBlock(64);
+
+    ParamSources sources;
+    sources.base = 1.0f;
+    resolveParam(params, 1, percentSpec(), sources);
+
+    CHECK(params[0].empty());
+    CHECK_FALSE(params[1].empty());
+    CHECK(params[2].empty());
+
+    // The next block starts with nothing carried over from this one.
+    params.beginBlock(64);
+    CHECK(params[1].empty());
+}
+
+TEST_CASE("A table hands a device its own parameters and no others", "[engine][param]") {
+    ResolvedParams params;
+    params.prepare(4);
+    params.beginBlock(16);
+
+    const auto spec = percentSpec();
+    for (int i = 0; i < 4; ++i) {
+        ParamSources sources;
+        sources.base = 0.25f * static_cast<float>(i);
+        resolveParam(params, i, spec, sources);
+    }
+
+    const auto device = params.device(/*firstParam=*/1, /*count=*/2);
+
+    REQUIRE(device.size() == 2);
+    CHECK(device[0].value() == approx(25.0f));
+    CHECK(device[1].value() == approx(50.0f));
+
+    // A device asking for a parameter it never declared gets nothing rather
+    // than its neighbour's value.
+    CHECK(device[2].empty());
+    CHECK(device[-1].empty());
+}
+
+TEST_CASE("A spec carries the model parameter's domain", "[engine][param]") {
+    magda::ParameterInfo info(0, "Cutoff", "Hz", 20.0f, 20000.0f, 632.0f,
+                              magda::ParameterScale::Logarithmic);
+    info.modulatable = false;
+
+    const auto spec = paramSpecFrom(info);
+
+    CHECK(spec.domain.scale == magda::ParameterScale::Logarithmic);
+    CHECK(spec.domain.minValue == approx(20.0f));
+    CHECK(spec.domain.maxValue == approx(20000.0f));
+    CHECK_FALSE(spec.modulatable);
+    // Nothing opts into segment accuracy during the port: the incumbent engine
+    // settles a parameter at the block boundary, and a device resolving inside
+    // the block would differ from it on every automated parameter.
+    CHECK_FALSE(spec.segmentAccurate);
+
+    OneParam table{32};
+    ParamSources sources;
+    sources.base = 0.5f;
+
+    // Through the model's own curve, not a copy of it.
+    CHECK(table.resolve(spec, sources).value() ==
+          approx(magda::ParameterUtils::normalizedToReal(0.5f, info)));
+}

--- a/tests/test_param_lane.cpp
+++ b/tests/test_param_lane.cpp
@@ -276,6 +276,55 @@ TEST_CASE("A stepped parameter quantises and never ramps", "[engine][param]") {
     CHECK(values.valueAt(32) == approx(3.0f));
 }
 
+TEST_CASE("A ramp through a nonlinear scale is read along it", "[engine][param]") {
+    OneParam table{128};
+
+    ParamSpec spec;
+    spec.domain.scale = magda::ParameterScale::Logarithmic;
+    spec.domain.minValue = 20.0f;
+    spec.domain.maxValue = 20000.0f;
+    spec.segmentAccurate = true;
+
+    const std::vector<ParamSegment> lane{{0, 0.0f, 1.0f}};
+
+    ParamSources sources;
+    sources.automation = lane;
+
+    const auto values = table.resolve(spec, sources);
+
+    // Halfway along the sweep is halfway along the scale, which is 632 Hz.
+    // Halfway between the converted ends is 10,010 Hz, a different parameter
+    // entirely, and that is what reading a segment of converted values gives.
+    CHECK(values.valueAt(0) == approx(20.0f));
+    CHECK(values.valueAt(64) ==
+          Catch::Approx(magda::ParameterUtils::normalizedToReal(0.5f, spec.domain)).epsilon(0.001));
+    CHECK(values.valueAt(64) < 1000.0f);
+}
+
+TEST_CASE("A ramp pushed out of range holds at the end of it", "[engine][param]") {
+    OneParam table{100};
+
+    // The lane reaches the top at the end of the block on its own; the link
+    // pushes it there at half. Converting the ends and interpolating between
+    // them would arrive at the top only at the end anyway, so the parameter
+    // would spend the second half of the block climbing somewhere it had
+    // already got to.
+    const std::vector<ParamSegment> lane{{0, 0.0f, 1.0f}};
+    const std::vector<ModContribution> links{{1.0f, 0.5f, false}};
+
+    ParamSources sources;
+    sources.automation = lane;
+    sources.modulation = links;
+
+    const auto values = table.resolve(percentSpec(/*segmentAccurate=*/true), sources);
+
+    CHECK(values.valueAt(0) == approx(50.0f));
+    CHECK(values.valueAt(25) == approx(75.0f));
+    CHECK(values.valueAt(50) == approx(100.0f));
+    CHECK(values.valueAt(75) == approx(100.0f));
+    CHECK(values.valueAt(99) == approx(100.0f));
+}
+
 TEST_CASE("A curve with more breakpoints than its slot arrives where it ends", "[engine][param]") {
     OneParam table{100, /*capacity=*/4};
 
@@ -294,7 +343,45 @@ TEST_CASE("A curve with more breakpoints than its slot arrives where it ends", "
     CHECK(values.valueAt(0) == approx(0.0f));
     CHECK(values.valueAt(20) == approx(20.0f));
     CHECK(values.segments().back().startSample == 30);
-    CHECK(values.segments().back().endValue == approx(80.0f));
+    // The stored positions are normalised; 0.8 is the 80 the curve ends at,
+    // and the last sample of the block is a hair short of arriving.
+    CHECK(values.segments().back().endValue == approx(0.8f));
+    CHECK(values.valueAt(99) == Catch::Approx(80.0f).margin(1.0));
+}
+
+TEST_CASE("A stepped lane too long for its slot keeps the step it ends on", "[engine][param]") {
+    ParamSpec spec;
+    spec.domain.scale = magda::ParameterScale::Discrete;
+    spec.domain.choiceCount = 3;
+    spec.segmentAccurate = true;
+
+    const std::vector<ParamSegment> lane{{0, 0.0f, 0.0f}, {30, 0.5f, 0.5f}, {60, 1.0f, 1.0f}};
+
+    ParamSources sources;
+    sources.automation = lane;
+
+    OneParam table{90, /*capacity=*/2};
+    const auto values = table.resolve(spec, sources);
+
+    // A ramp is no use to a parameter with three values and nothing between
+    // them, so the last slot goes on the step the lane ends on. The middle
+    // choice is what is lost, and the parameter still ends the block on the
+    // choice the lane asked for, at the sample it asked for it.
+    REQUIRE(values.numSegments() == 2);
+    CHECK(values.valueAt(0) == approx(0.0f));
+    CHECK(values.valueAt(59) == approx(0.0f));
+    CHECK(values.valueAt(60) == approx(2.0f));
+    CHECK(values.valueAt(89) == approx(2.0f));
+
+    // With one slot there is nothing to spend on the destination, and the
+    // opening value is what a device reading once for the block would have
+    // taken anyway.
+    OneParam single{90, /*capacity=*/1};
+    const auto narrow = single.resolve(spec, sources);
+
+    REQUIRE(narrow.numSegments() == 1);
+    CHECK(narrow.valueAt(0) == approx(0.0f));
+    CHECK(narrow.valueAt(89) == approx(0.0f));
 }
 
 TEST_CASE("A parameter nobody resolved reads as empty", "[engine][param]") {


### PR DESCRIPTION
Closes #2116. Slice 1 of #1891.

The native engine had no parameter concept at all. `EngineDevice::process()` took audio, MIDI and a sidechain, and nothing in the plan or in the value table said what a device's cutoff was. This is the lane the rest of #1891 writes into, and it settles the contract the first comment on #1891 asked for.

## Three lanes, not one value

The base is the stored value: a knob, a control surface, a preset load, a host write. Automation is a curve covering as much of a block as it covers. Modulation is what the links reaching the parameter add on top.

They stay separate all the way to the device. The incumbent engine has one value and several writers, which is why a host write on a parameter under an active modifier disappears: the modifier writes next and there was only ever one place to write. Here the write goes into a lane modulation never touches, so nothing can overwrite it. That case is in the tests by name rather than as a side effect of the design.

## The precedence, in one function

`resolveParam` is the only place any of it is implemented. A device is shown the resolved stream and has no way to ask where a value came from.

- Automation replaces the base wherever a lane covers the block, and the base holds everywhere else, which is what an automation clip starting and stopping inside a block does.
- Links are summed in the normalised domain, each with its own depth and polarity. A parameter that does not take modulation adds nothing rather than dropping its links: the links are the model's, and a block is not where a model edit happens.
- One clamp, after the sum, then the parameter's own scale. Clamped per link, a +0.8 and a -0.6 against a base of 0.5 land at 0.4; clamped once they land at 0.7, which is where the parameter actually is.
- A stepped parameter is quantised by the scale and never ramped, because there is nothing between two of its values to ramp through.
- Authority state is not decided here. The model owns it (`AutomationStateMachine`), a lane reaching a block is one the model has already decided is playing, and read mode is what the port ships.

## Segments, and why nothing opts in yet

Within a block a parameter is constant or linear-ramp segments rather than a scalar, which is what lets "resolved once per block" and "a sample-accurate ramp" both be true instead of contradicting each other.

`ParamSpec::segmentAccurate` is off and nothing sets it during the port. The reason is parity rather than cost: the fork settles a parameter at the block boundary, so a device resolving inside the block would differ from it by however much the curve moves across a block, on every automated parameter, in every project. The corpus would report that as an engine bug and it would be right.

## One curve, not two

Normalised to real is the model's conversion. `ParameterUtils` grows a `ParameterDomain`, the flat part of a `ParameterInfo` the curve actually reads, and `normalizedToReal` / `realToNormalized` become that one under another name. A `ParameterInfo` carries strings, a choice list and a shared display provider and cannot go near a block, and a second implementation of the curve is a difference nobody sees until a project sounds different in one engine than in the other.

`modulationOffset` comes out of `applyModulation` for the same reason: neither existing helper can be called from a block, since one clamps per link and the other wants a `std::vector`.

## Storage

One table per plan, indexed by parameter id, each parameter's segments in a fixed-width slot of an arena allocated off the audio thread. A device reads a contiguous window of it and indexes its own parameters from zero, the way `ParameterInfo::paramIndex` does.

The width is a budget, like the MIDI one in `EngineDevice.hpp`: a curve with more breakpoints than fit keeps the ones there is room for and rolls the rest into its last segment, which then ramps to where the curve actually ends. Coarser on a very busy curve, never a wrong destination, and it is a case.

## What is not here

The table is not published, so the executor hands every device an empty window. Resolution against a live plan, the fingerprint check, `ControlTarget` addressing and the link graph are #2117. The sources that fill the lanes are #2118 through #2121.

## Testing

`make test` green locally: 2703 cases, 588065 assertions, 0 failures. `make test-juce` green. The 16 new cases are model-level Catch2 in `magda_tests` and cost no measurable time.
