### PR TITLE
Publish a plan's parameters, and say what links to what (#2117)

### DIFF
--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -74,10 +74,18 @@ add_library(magda_engine STATIC
     exec/OfflineRender.hpp
     param/ParamSpec.cpp
     param/ParamBlock.cpp
+    param/ParamKey.cpp
     param/ParamResolve.cpp
+    param/ParamTable.cpp
+    param/ParamTableCompiler.cpp
+    param/ParamTableDump.cpp
     param/ParamSpec.hpp
     param/ParamBlock.hpp
+    param/ParamKey.hpp
     param/ParamResolve.hpp
+    param/ParamTable.hpp
+    param/ParamTableCompiler.hpp
+    param/ParamTableDump.hpp
     tap/LevelTap.hpp
     tap/SampleRing.hpp
     transport/TempoMap.cpp

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -38,8 +38,14 @@ EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> p
     // Read only: it is live until the swap below, and it is this thread's own
     // handle on it that keeps it alive long enough to be read at all.
     const auto bindings = store_.realise(*prepared->plan, context);
+    // The parameter table travels inside the values (#2117), and the executor
+    // needs it here rather than at the first block: it is what the per-op
+    // windows and the block's own room are sized from. A table published later
+    // for the same plan has the same shape by construction, since both were
+    // resolved from one model against one plan.
     auto messages = prepared->executor.prepare(*prepared->plan, bindings, context,
-                                               live_ == nullptr ? nullptr : &live_->executor);
+                                               live_ == nullptr ? nullptr : &live_->executor,
+                                               prepared->values.params.get());
     if (!prepared->executor.isPrepared())
         return {false, std::move(messages)};
 

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -78,6 +78,10 @@ EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> p
 
     // Only now: until the swap, the epoch this replaces was the one rendering,
     // and anything the new one took over from it is shared rather than copied.
+    // Guarded because the escalation path in publishValues() passes this very
+    // set back in.
+    if (&modelIds != &lastModelIds_)
+        lastModelIds_ = modelIds;
     live_ = std::move(prepared);
     livePlan_ = live_->plan;
 
@@ -90,8 +94,32 @@ EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> p
     return {true, std::move(messages)};
 }
 
-void EngineSession::publishValues(PlanValues values) {
-    values_.nonRealtimeReplace(std::move(values));
+EngineSession::Result EngineSession::publishValues(PlanValues values) {
+    // Nothing playing: there is nothing to check against and nothing rendering
+    // them yet, and the plan that arrives next brings its own.
+    if (live_ == nullptr) {
+        values_.nonRealtimeReplace(std::move(values));
+        return {true, {}};
+    }
+
+    if (!live_->executor.appliesValues(values))
+        return {false,
+                {"these values were resolved against a different plan, so they are not "
+                 "published: the plan they belong to has to be published with them"}};
+
+    if (live_->executor.fitsParameters(values)) {
+        values_.nonRealtimeReplace(std::move(values));
+        return {true, {}};
+    }
+
+    // The parameter set changed without the plan changing. See the header: this
+    // is a structural publish wearing a mixer-speed call, and the live plan is
+    // the plan it is published on.
+    auto result = publish(livePlan_, live_->context, lastModelIds_, std::move(values));
+    result.messages.emplace_back(
+        "the parameters changed shape without the plan changing, so this values publish was "
+        "republished as a structural one");
+    return result;
 }
 
 void EngineSession::publishTransport(TransportSnapshot transport) {

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -100,9 +100,31 @@ class EngineSession {
     Result publish(std::shared_ptr<const RenderPlan> plan, const RenderContext& context,
                    const RuntimeStateIds& modelIds, PlanValues values);
 
-    /// On the publishing thread. Values change at mixer speed rather than
-    /// structural speed, so they travel on their own.
-    void publishValues(PlanValues values);
+    /**
+     * @brief Newer values for the plan that is playing.
+     *
+     * On the publishing thread. Values change at mixer speed rather than
+     * structural speed, so they travel on their own.
+     *
+     * The parameter table rides along with them (#2117), and it can change
+     * shape without the plan changing at all: linking a macro for the first
+     * time gives it a parameter, and linking one more thing to the parameter
+     * that already had the most widens the room a block gathers contributions
+     * in. Neither is visible to the fingerprint, and neither fits what the live
+     * epoch allocated.
+     *
+     * So a publish of that shape is escalated here into a structural one, on
+     * the plan that is already playing. It costs a prepare and a swap, which is
+     * what a structural edit costs, and it is what a link edit is: rare, human
+     * speed, and not something to make a block pay for. The alternative is a
+     * table nothing can render and a project whose parameters quietly stop
+     * following the model.
+     *
+     * Values that belong to another plan are refused rather than escalated:
+     * republishing the live plan with them would refuse them a second time,
+     * one layer further in.
+     */
+    Result publishValues(PlanValues values);
 
     /**
      * @brief Tempo, loop, metronome and where the transport has been asked to
@@ -249,6 +271,12 @@ class EngineSession {
     /// which is a property of the session rather than of any plan, and a plan
     /// swap must not move it.
     TransportClock clock_;
+
+    /// What the model held at the last publish. Kept so a values publish that
+    /// has to become a structural one has the set to publish with: retention
+    /// only ever extends, so the worst a set from a moment ago can cost is a
+    /// dormant object its retirement.
+    RuntimeStateIds lastModelIds_;
 
     /// This thread's own handle on the epoch that is rendering. Held because
     /// the next publish prepares against it: the differ needs the plan it was

--- a/magda/engine/exec/ParallelPlanExecutor.cpp
+++ b/magda/engine/exec/ParallelPlanExecutor.cpp
@@ -48,7 +48,8 @@ ParallelPlanExecutor::~ParallelPlanExecutor() {
 std::vector<std::string> ParallelPlanExecutor::prepare(const RenderPlan& plan,
                                                        const PlanBindings& bindings,
                                                        const RenderContext& context,
-                                                       const ParallelPlanExecutor* previous) {
+                                                       const ParallelPlanExecutor* previous,
+                                                       const ParamTable* params) {
     // Everything below reallocates what a worker still finishing the last block
     // would read, so this comes first, the same as at destruction.
     letGoOfPool();
@@ -56,8 +57,8 @@ std::vector<std::string> ParallelPlanExecutor::prepare(const RenderPlan& plan,
     plan_ = nullptr;
     outputOps_.clear();
 
-    auto messages =
-        core_.prepare(plan, bindings, context, previous != nullptr ? &previous->core_ : nullptr);
+    auto messages = core_.prepare(plan, bindings, context,
+                                  previous != nullptr ? &previous->core_ : nullptr, params);
     if (!core_.isPrepared())
         return messages;
 
@@ -187,6 +188,10 @@ void ParallelPlanExecutor::process(const PlanValues& values, const BlockInfo& re
     const auto start = core_.beginBlock(values, requestedBlock, output);
     if (!start.render || plan_ == nullptr)
         return;
+
+    // Before any worker starts: a device reads its parameters, and every op
+    // that could be one is about to become runnable.
+    core_.resolveParameters(values, start.block.numSamples);
 
     block_ = start.block;
     values_ = &values;

--- a/magda/engine/exec/ParallelPlanExecutor.hpp
+++ b/magda/engine/exec/ParallelPlanExecutor.hpp
@@ -91,6 +91,10 @@ class ParallelPlanExecutor final : private RenderThreadPool::Job {
         return core_;
     }
 
+    bool fitsParameters(const PlanValues& values) const {
+        return core_.fitsParameters(values);
+    }
+
     int latencySamples() const {
         return core_.latencySamples();
     }

--- a/magda/engine/exec/ParallelPlanExecutor.hpp
+++ b/magda/engine/exec/ParallelPlanExecutor.hpp
@@ -68,7 +68,8 @@ class ParallelPlanExecutor final : private RenderThreadPool::Job {
      */
     std::vector<std::string> prepare(const RenderPlan& plan, const PlanBindings& bindings,
                                      const RenderContext& context,
-                                     const ParallelPlanExecutor* previous = nullptr);
+                                     const ParallelPlanExecutor* previous = nullptr,
+                                     const ParamTable* params = nullptr);
 
     /**
      * @brief Render one block into @p output. On the audio thread.

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -644,10 +644,19 @@ PlanExecutor::BlockStart PlanExecutor::beginBlock(const PlanValues& values,
 }
 
 void PlanExecutor::resolveParameters(const PlanValues& values, int numSamples) {
-    if (!appliesValues(values) || values.params == nullptr) {
-        // Empty rather than stale: a device asking for a parameter gets a
-        // window of nothing, and nothing is what it had before a table was
-        // ever published.
+    // Two shapes have to match, and neither is something appliesValues can
+    // see: it compares the plan's fingerprint and its op count, and a link
+    // edit changes neither. A macro gaining its first link grows the table by
+    // a slot, and a link added to the parameter that already had the most
+    // widens the room one parameter's contributions are gathered in. Both
+    // arrive on a table that belongs to this plan and neither fits what was
+    // allocated for it.
+    //
+    // Empty rather than stale, and empty rather than partly applied: a device
+    // gets a window of nothing, which is what it had before a table was ever
+    // published, and the session escalates a publish of this shape into a
+    // structural one so the emptiness lasts a block rather than for ever.
+    if (!appliesValues(values) || values.params == nullptr || !fitsParameters(values)) {
         paramValues_.beginBlock(numSamples);
         return;
     }

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -223,7 +223,8 @@ void PlanExecutor::reset() {
 
 std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const PlanBindings& bindings,
                                                const RenderContext& context,
-                                               const PlanExecutor* previous) {
+                                               const PlanExecutor* previous,
+                                               const ParamTable* params) {
     reset();
 
     std::vector<std::string> messages;
@@ -245,6 +246,22 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
     midiSourceForOp_.assign(numOps, nullptr);
     meterForOp_.assign(numOps, nullptr);
     midiTapForOp_.assign(numOps, nullptr);
+    paramWindowForOp_.assign(numOps, ParamTable::DeviceWindow{});
+
+    // The parameters of the table this plan is published with (#2117). Sized
+    // here, on this thread, so the block that resolves them allocates nothing,
+    // and looked up here so the block that reads them hashes nothing. A plan
+    // published without a table renders devices with no parameters, which is
+    // what every render did before there was a table at all.
+    if (params != nullptr) {
+        paramValues_.prepare(params->size());
+        paramScratch_.assign(static_cast<std::size_t>(std::max(params->maxLinksPerParam, 0)),
+                             ModContribution{});
+
+        for (std::size_t i = 0; i < numOps; ++i)
+            if (plan.ops[i].kind == OpKind::Device)
+                paramWindowForOp_[i] = params->windowFor(plan.ops[i].key.deviceKey());
+    }
 
     const auto describe = [&plan](std::size_t index) {
         return "op " + std::to_string(index) + " (" + toString(plan.ops[index].kind) + " " +
@@ -626,9 +643,22 @@ PlanExecutor::BlockStart PlanExecutor::beginBlock(const PlanValues& values,
     return start;
 }
 
+void PlanExecutor::resolveParameters(const PlanValues& values, int numSamples) {
+    if (!appliesValues(values) || values.params == nullptr) {
+        // Empty rather than stale: a device asking for a parameter gets a
+        // window of nothing, and nothing is what it had before a table was
+        // ever published.
+        paramValues_.beginBlock(numSamples);
+        return;
+    }
+
+    resolveParams(*values.params, paramValues_, paramScratch_, numSamples);
+}
+
 void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedBlock,
                            juce::AudioBuffer<float>& output) {
     const auto start = beginBlock(values, requestedBlock, output);
+    resolveParameters(values, start.block.numSamples);
     if (!start.render)
         return;
 
@@ -791,11 +821,12 @@ void PlanExecutor::renderOp(OpId id, const OpValue& value, const BlockInfo& bloc
             // No parameters yet: the table a device reads is resolved against a
             // plan and published with it, which is #2117. Until then a device
             // is handed an empty window rather than a stale one.
+            const auto window = paramWindowForOp_[static_cast<std::size_t>(i)];
             DeviceBlock deviceBlock{.audio = audio,
                                     .midiIn = &midiIn(op.inputs[1]),
                                     .midiOut = deviceMidiOut,
                                     .sidechain = {},
-                                    .params = {},
+                                    .params = paramValues_.device(window.first, window.count),
                                     .block = block};
             if (op.inputs[2].valid())
                 deviceBlock.sidechain = audioIn(op.inputs[2], numSamples);

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -219,6 +219,10 @@ void PlanExecutor::reset() {
     meterForOp_.clear();
     boundMeterCount_ = 0;
     midiTapForOp_.clear();
+    paramWindowForOp_.clear();
+    paramScratch_.clear();
+    paramValues_.prepare(0);
+    paramLayout_ = 0;
 }
 
 std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const PlanBindings& bindings,
@@ -247,6 +251,7 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
     meterForOp_.assign(numOps, nullptr);
     midiTapForOp_.assign(numOps, nullptr);
     paramWindowForOp_.assign(numOps, ParamTable::DeviceWindow{});
+    paramLayout_ = 0;
 
     // The parameters of the table this plan is published with (#2117). Sized
     // here, on this thread, so the block that resolves them allocates nothing,
@@ -254,6 +259,7 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
     // published without a table renders devices with no parameters, which is
     // what every render did before there was a table at all.
     if (params != nullptr) {
+        paramLayout_ = params->layoutFingerprint;
         paramValues_.prepare(params->size());
         paramScratch_.assign(static_cast<std::size_t>(std::max(params->maxLinksPerParam, 0)),
                              ModContribution{});

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -364,6 +364,23 @@ class PlanExecutor {
      * Anything else renders at unity, which is why what publishes an epoch
      * checks this before letting it play rather than after.
      */
+    /**
+     * @brief Whether the table @p values carries fits what was prepared for it.
+     *
+     * The other half of applicable, and the half a fingerprint cannot answer.
+     * A link edit changes no op and no plan, so a table that gained a
+     * parameter or a link travels on a values publish, matches the plan, and
+     * does not fit the room allocated for it. Asked here so the publisher and
+     * the block get one answer: the publisher escalates such a publish into a
+     * structural one, and the block that meets one anyway renders empty rather
+     * than stale.
+     */
+    bool fitsParameters(const PlanValues& values) const {
+        return values.params == nullptr ||
+               (values.params->size() == paramValues_.size() &&
+                values.params->maxLinksPerParam <= static_cast<int>(paramScratch_.size()));
+    }
+
     bool appliesValues(const PlanValues& values) const {
         return plan_ != nullptr && values.planFingerprint == planFingerprint_ &&
                values.ops.size() == plan_->ops.size();

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -354,6 +354,35 @@ class PlanExecutor {
     }
 
     /**
+     * @brief Whether the table @p values carries fits what was prepared for it.
+     *
+     * The other half of applicable, and the half the plan's fingerprint cannot
+     * answer. A link edit changes no op and no plan, so a table that gained a
+     * parameter, moved one, or grew the room a block gathers contributions in
+     * travels on a values publish, matches the plan, and does not fit what was
+     * allocated for it.
+     *
+     * Three things, because there are three ways to not fit. The layout says
+     * the parameter at an index is still the one that index was resolved for,
+     * which a count cannot: a macro that stopped being used in one scope and
+     * started being used in another leaves the count alone and moves every
+     * device window after it, and the windows are cached here from the table
+     * the plan was prepared with. The count says the answers are the right size
+     * for it. The link width says a parameter's contributions all fit, since
+     * the block gathers them into room found before it started.
+     *
+     * Asked here so the publisher and the block get one answer: the publisher
+     * escalates such a publish into a structural one, and a block that meets
+     * one anyway renders empty rather than stale or half-applied.
+     */
+    bool fitsParameters(const PlanValues& values) const {
+        return values.params == nullptr ||
+               (values.params->layoutFingerprint == paramLayout_ &&
+                values.params->size() == paramValues_.size() &&
+                values.params->maxLinksPerParam <= static_cast<int>(paramScratch_.size()));
+    }
+
+    /**
      * @brief Whether process() would apply @p values rather than ignore them.
      *
      * The one definition of applicable, so that a caller deciding which table
@@ -364,23 +393,6 @@ class PlanExecutor {
      * Anything else renders at unity, which is why what publishes an epoch
      * checks this before letting it play rather than after.
      */
-    /**
-     * @brief Whether the table @p values carries fits what was prepared for it.
-     *
-     * The other half of applicable, and the half a fingerprint cannot answer.
-     * A link edit changes no op and no plan, so a table that gained a
-     * parameter or a link travels on a values publish, matches the plan, and
-     * does not fit the room allocated for it. Asked here so the publisher and
-     * the block get one answer: the publisher escalates such a publish into a
-     * structural one, and the block that meets one anyway renders empty rather
-     * than stale.
-     */
-    bool fitsParameters(const PlanValues& values) const {
-        return values.params == nullptr ||
-               (values.params->size() == paramValues_.size() &&
-                values.params->maxLinksPerParam <= static_cast<int>(paramScratch_.size()));
-    }
-
     bool appliesValues(const PlanValues& values) const {
         return plan_ != nullptr && values.planFingerprint == planFingerprint_ &&
                values.ops.size() == plan_->ops.size();
@@ -493,8 +505,14 @@ class PlanExecutor {
     std::vector<ModContribution> paramScratch_;
 
     /// Per op: the window of the table a Device op's device reads, resolved
-    /// once here so the audio thread never hashes a DeviceKey.
+    /// once here so the audio thread never hashes a DeviceKey. Cached from one
+    /// table's layout, which is what paramLayout_ below is for.
     std::vector<ParamTable::DeviceWindow> paramWindowForOp_;
+
+    /// Identity of the layout those windows were cached from. A table with
+    /// another one puts different parameters at the same indices, and the
+    /// windows would hand a device its neighbour's slots.
+    std::uint64_t paramLayout_ = 0;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -12,6 +12,7 @@
 #include "exec/PlanLayout.hpp"
 #include "exec/PlanValues.hpp"
 #include "exec/RenderContext.hpp"
+#include "param/ParamResolve.hpp"
 #include "plan/PlanDiff.hpp"
 #include "plan/RenderPlan.hpp"
 
@@ -196,7 +197,8 @@ class PlanExecutor {
      */
     std::vector<std::string> prepare(const RenderPlan& plan, const PlanBindings& bindings,
                                      const RenderContext& context,
-                                     const PlanExecutor* previous = nullptr);
+                                     const PlanExecutor* previous = nullptr,
+                                     const ParamTable* params = nullptr);
 
     /// Forget the prepared plan and everything sized for it. Off the audio
     /// thread. Every prepare starts here, so a plan that is refused leaves
@@ -237,6 +239,21 @@ class PlanExecutor {
      */
     BlockStart beginBlock(const PlanValues& values, const BlockInfo& requested,
                           juce::AudioBuffer<float>& output) const;
+
+    /**
+     * @brief Resolve the block's parameters, before any op runs (#2117).
+     *
+     * On the audio thread, after beginBlock and before anything is rendered,
+     * from both executors: a device reads what its parameters are and the
+     * answer has to be there when it does.
+     *
+     * The table travels with the values, so what makes one applicable makes the
+     * other applicable. A table that does not belong to this plan leaves every
+     * parameter empty rather than resolved against the wrong addresses, and a
+     * device is handed a window of nothing, which is what it would have had
+     * before any table was published at all.
+     */
+    void resolveParameters(const PlanValues& values, int numSamples);
 
     /**
      * @brief Render one op of the prepared plan.
@@ -451,6 +468,16 @@ class PlanExecutor {
     /// Where a MergeMidi op publishes what reached it, or nullptr. See
     /// PlanBindings::midiTaps.
     std::vector<MidiTap*> midiTapForOp_;
+
+    /// This block's parameter values, and the room the resolver gathers one
+    /// parameter's links in. Sized at prepare from the table the plan was
+    /// published with, so the block that fills them allocates nothing.
+    ResolvedParams paramValues_;
+    std::vector<ModContribution> paramScratch_;
+
+    /// Per op: the window of the table a Device op's device reads, resolved
+    /// once here so the audio thread never hashes a DeviceKey.
+    std::vector<ParamTable::DeviceWindow> paramWindowForOp_;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -7,6 +7,7 @@
 
 #include "core/RackInfo.hpp"
 #include "core/TrackInfo.hpp"
+#include "param/ParamTableCompiler.hpp"
 #include "plan/TrackRouting.hpp"
 
 namespace magda::engine {
@@ -480,7 +481,22 @@ void applyLinearPanLaw(float gain, float pan, float& left, float& right) {
 std::vector<std::string> resolvePlanValues(const RenderPlan& plan,
                                            const std::vector<TrackInfo>& tracks,
                                            const TrackInfo& master, PlanValues& values) {
-    return Resolver(plan, tracks, master).run(values);
+    auto messages = Resolver(plan, tracks, master).run(values);
+
+    // The parameters travel with the values (#2117), so one call resolves the
+    // model into everything the plan reads and the two cannot be published out
+    // of step with each other. Rebuilt whole rather than patched, the way the
+    // op values are: a fader move re-resolves a project's parameters as well,
+    // which is a vector and a topological sort off the audio thread.
+    auto params = std::make_shared<ParamTable>(compileParamTable(plan, tracks, master));
+
+    // Reported here as well as carried on the table, because the caller that
+    // logs one of these is the caller that logs the other, and a diagnostic
+    // nobody prints is a diagnostic nobody reads.
+    messages.insert(messages.end(), params->diagnostics.begin(), params->diagnostics.end());
+
+    values.params = std::move(params);
+    return messages;
 }
 
 }  // namespace magda::engine

--- a/magda/engine/exec/PlanValues.hpp
+++ b/magda/engine/exec/PlanValues.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
+#include "param/ParamTable.hpp"
 #include "plan/RenderPlan.hpp"
 
 namespace magda {
@@ -63,6 +65,26 @@ inline constexpr OpValue kUnityValue{};
 struct PlanValues {
     std::uint64_t planFingerprint = 0;
     std::vector<OpValue> ops;
+
+    /**
+     * @brief The parameters behind the same plan (#2117).
+     *
+     * The other half of what a plan reads out of the model, and it travels here
+     * rather than beside it because the two answer one question at two
+     * granularities: what a mixer move did to an op, and what a knob, a macro
+     * or a modifier did to a device's own parameters. Both are resolved off the
+     * audio thread against one plan, both are published whole, and a device
+     * hearing one of them from a previous plan is the same bug either way.
+     *
+     * Shared rather than owned, so a fader move that changed no parameter
+     * republishes the pointer it already had, and so a table outlives the
+     * publish that replaced it for exactly as long as the audio thread is still
+     * inside it.
+     *
+     * Null for a plan resolved without one, which is every test that is not
+     * about parameters and every render of a project that has none.
+     */
+    std::shared_ptr<const ParamTable> params;
 };
 
 /**

--- a/magda/engine/exec/PlanValues.hpp
+++ b/magda/engine/exec/PlanValues.hpp
@@ -76,10 +76,17 @@ struct PlanValues {
      * audio thread against one plan, both are published whole, and a device
      * hearing one of them from a previous plan is the same bug either way.
      *
-     * Shared rather than owned, so a fader move that changed no parameter
-     * republishes the pointer it already had, and so a table outlives the
-     * publish that replaced it for exactly as long as the audio thread is still
-     * inside it.
+     * Shared rather than owned so that a table outlives the publish that
+     * replaced it for exactly as long as the audio thread is still inside it,
+     * and so that holding one costs a pointer wherever it is held.
+     *
+     * A fresh one per publish, for now: resolvePlanValues compiles the table
+     * every time it resolves the op values, so a fader move pays the model walk
+     * and the topological sort as well. That is a vector and a sort off the
+     * audio thread at the speed a mouse moves, which is affordable and not
+     * free. Reusing the previous table when the compile would be identical is
+     * what the shared pointer leaves room for; deciding that needs something
+     * that says the model has not changed, and nothing says it yet.
      *
      * Null for a plan resolved without one, which is every test that is not
      * about parameters and every render of a project that has none.

--- a/magda/engine/param/ParamBlock.cpp
+++ b/magda/engine/param/ParamBlock.cpp
@@ -68,6 +68,18 @@ ParamValues ResolvedParams::operator[](int param) const {
                        domains_[index], numSamples_};
 }
 
+float ResolvedParams::sourceValue(int param) const {
+    if (param < 0 || param >= size())
+        return 0.0f;
+
+    const auto index = static_cast<std::size_t>(param);
+    if (counts_[index] == 0)
+        return 0.0f;
+
+    return juce::jlimit(0.0f, 1.0f,
+                        segments_[index * static_cast<std::size_t>(stride_)].startValue);
+}
+
 DeviceParams ResolvedParams::device(int firstParam, int count) const {
     if (firstParam < 0 || count <= 0 || firstParam + count > size())
         return {};

--- a/magda/engine/param/ParamBlock.hpp
+++ b/magda/engine/param/ParamBlock.hpp
@@ -229,6 +229,20 @@ class ResolvedParams {
     /// parameter the table does not have.
     ParamValues operator[](int param) const;
 
+    /**
+     * @brief What a link reading @p param as its source gets.
+     *
+     * The position the parameter opens the block at, clamped into range: a
+     * macro is a source between nothing and everything whatever the arithmetic
+     * that produced it did, and a source is read once per block because that is
+     * what a modulation contribution is.
+     *
+     * Zero for a parameter that has not resolved yet, which the resolution
+     * order exists to make unreachable: a source is resolved before whatever
+     * reads it.
+     */
+    float sourceValue(int param) const;
+
     /// The window a device reads: @p count parameters from @p firstParam.
     DeviceParams device(int firstParam, int count) const;
 

--- a/magda/engine/param/ParamKey.cpp
+++ b/magda/engine/param/ParamKey.cpp
@@ -1,0 +1,174 @@
+#include "param/ParamKey.hpp"
+
+#include <tuple>
+
+namespace magda::engine {
+
+namespace {
+
+/// The section a path descends into. Post-fx and mixer-analysis paths say so in
+/// their first step; everything else is the main FX chain.
+ChainSegment segmentOf(const magda::ChainNodePath& path) {
+    if (path.isPostFx())
+        return ChainSegment::PostFx;
+    if (path.isMixerAnalysis())
+        return ChainSegment::MixerAnalysis;
+    return ChainSegment::Fx;
+}
+
+/// The rack a path ends in or passes through last, which is what owns a macro
+/// at rack scope.
+RackId lastRackOf(const magda::ChainNodePath& path) {
+    for (auto step = path.steps.rbegin(); step != path.steps.rend(); ++step)
+        if (step->type == magda::ChainStepType::Rack)
+            return step->id;
+    return INVALID_RACK_ID;
+}
+
+/// The scope a path names, filled into @p key. False when the path names
+/// something that owns neither macros nor modifiers, which a chain does not:
+/// macros and mods live on tracks, racks and devices, and a chain is the thing
+/// between two of them.
+bool fillScope(const magda::ChainNodePath& path, ParamKey& key) {
+    key.trackId = path.trackId;
+
+    switch (path.getType()) {
+        case magda::ChainNodeType::Track:
+            key.scope = ParamKey::Scope::Track;
+            return true;
+
+        case magda::ChainNodeType::Rack:
+            key.scope = ParamKey::Scope::Rack;
+            key.rackId = lastRackOf(path);
+            return key.rackId != INVALID_RACK_ID;
+
+        case magda::ChainNodeType::TopLevelDevice:
+        case magda::ChainNodeType::Device:
+            key.scope = ParamKey::Scope::Device;
+            key.rackId = lastRackOf(path);
+            key.device = DeviceKey{segmentOf(path), path.getDeviceId()};
+            return key.device.deviceId != INVALID_DEVICE_ID;
+
+        case magda::ChainNodeType::Chain:
+        case magda::ChainNodeType::None:
+            return false;
+    }
+    return false;
+}
+
+}  // namespace
+
+bool ParamKey::operator==(const ParamKey& o) const {
+    return kind == o.kind && scope == o.scope && trackId == o.trackId && rackId == o.rackId &&
+           device == o.device && modId == o.modId && index == o.index;
+}
+
+bool ParamKey::operator<(const ParamKey& o) const {
+    return std::tie(trackId, rackId, device, kind, scope, modId, index) <
+           std::tie(o.trackId, o.rackId, o.device, o.kind, o.scope, o.modId, o.index);
+}
+
+std::size_t ParamKeyHash::operator()(const ParamKey& key) const noexcept {
+    auto mix = [](std::size_t seed, std::size_t value) {
+        return seed ^ (value + static_cast<std::size_t>(0x9e3779b9U) + (seed << 6U) + (seed >> 2U));
+    };
+
+    std::size_t seed = DeviceKeyHash{}(key.device);
+    seed = mix(seed, static_cast<std::size_t>(key.kind));
+    seed = mix(seed, static_cast<std::size_t>(key.scope));
+    seed = mix(seed, static_cast<std::size_t>(key.trackId));
+    seed = mix(seed, static_cast<std::size_t>(key.rackId));
+    seed = mix(seed, static_cast<std::size_t>(key.modId));
+    seed = mix(seed, static_cast<std::size_t>(key.index));
+    return seed;
+}
+
+std::optional<ParamKey> paramKeyFor(const magda::ControlTarget& target) {
+    ParamKey key;
+
+    switch (target.kind) {
+        case magda::ControlTarget::Kind::PluginParam:
+            key.kind = ParamKey::Kind::DeviceParam;
+            if (!fillScope(target.devicePath, key) || key.scope != ParamKey::Scope::Device)
+                return std::nullopt;
+            if (target.paramIndex < 0)
+                return std::nullopt;
+            key.index = target.paramIndex;
+            return key;
+
+        case magda::ControlTarget::Kind::DeviceMacro:
+            key.kind = ParamKey::Kind::Macro;
+            if (!fillScope(target.devicePath, key))
+                return std::nullopt;
+            if (target.paramIndex < 0)
+                return std::nullopt;
+            key.index = target.paramIndex;
+            return key;
+
+        case magda::ControlTarget::Kind::ModParam:
+            key.kind = ParamKey::Kind::ModParam;
+            if (!fillScope(target.devicePath, key))
+                return std::nullopt;
+            if (target.modId == INVALID_MOD_ID || target.modParamIndex < 0)
+                return std::nullopt;
+            key.modId = target.modId;
+            key.index = target.modParamIndex;
+            return key;
+
+        // Real targets that this table does not carry. The mixer values are
+        // resolved into PlanValues, off the audio thread, and the tempo belongs
+        // to the transport.
+        case magda::ControlTarget::Kind::TrackVolume:
+        case magda::ControlTarget::Kind::TrackPan:
+        case magda::ControlTarget::Kind::SendLevel:
+        case magda::ControlTarget::Kind::Tempo:
+            return std::nullopt;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<ParamKey> modifierKeyFor(const magda::ControlTarget& target) {
+    if (target.kind != magda::ControlTarget::Kind::ModParam)
+        return std::nullopt;
+
+    auto key = paramKeyFor(target);
+    if (!key.has_value())
+        return std::nullopt;
+
+    key->index = -1;
+    return key;
+}
+
+std::string toString(const ParamKey& key) {
+    std::string text = "T" + std::to_string(key.trackId);
+
+    switch (key.scope) {
+        case ParamKey::Scope::Track:
+            break;
+        case ParamKey::Scope::Rack:
+            text += "/R" + std::to_string(key.rackId);
+            break;
+        case ParamKey::Scope::Device:
+            text += "/" + toString(key.device);
+            break;
+    }
+
+    switch (key.kind) {
+        case ParamKey::Kind::DeviceParam:
+            text += ":param" + std::to_string(key.index);
+            break;
+        case ParamKey::Kind::Macro:
+            text += ":macro" + std::to_string(key.index);
+            break;
+        case ParamKey::Kind::ModParam:
+            text += ":mod" + std::to_string(key.modId);
+            if (key.index >= 0)
+                text += ".param" + std::to_string(key.index);
+            break;
+    }
+
+    return text;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/param/ParamKey.hpp
+++ b/magda/engine/param/ParamKey.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "core/ControlTarget.hpp"
+#include "core/TypeIds.hpp"
+#include "plan/RenderPlan.hpp"
+
+/**
+ * @file ParamKey.hpp
+ * @brief Where a parameter lives, as the engine addresses it.
+ *
+ * The model addresses a parameter with a ControlTarget: a path through the
+ * track, rack and chain hierarchy, plus whatever the kind needs. Every consumer
+ * in MAGDA speaks it, which is what makes it the right thing to translate from
+ * and the wrong thing to carry into a block. It holds a vector of steps, so it
+ * allocates, and it says where a parameter is by describing the walk to it.
+ *
+ * This is the same address flattened, the way OpKey is the flattened form of a
+ * model location for the plan. No heap, comparable and hashable, and it names
+ * the owner rather than the route: a device by its DeviceKey, a macro or a
+ * modifier by the scope that owns it.
+ */
+
+namespace magda::engine {
+
+/** Index of a parameter inside a ParamTable. */
+using ParamId = int;
+constexpr ParamId INVALID_PARAM_ID = -1;
+
+/** @brief What a parameter is, and whose it is. */
+struct ParamKey {
+    enum class Kind : std::uint8_t {
+        DeviceParam,  ///< a device's own parameter, by its declared index
+        Macro,        ///< a macro knob belonging to the scope named below
+        ModParam,     ///< one parameter of a modifier belonging to that scope
+    };
+
+    /// Who owns the macro or modifier. Always Device for a device parameter.
+    enum class Scope : std::uint8_t { Track, Rack, Device };
+
+    Kind kind = Kind::DeviceParam;
+    Scope scope = Scope::Device;
+
+    /// The track the owner is on. Set whatever the scope is, because a rack and
+    /// a device are somewhere as well as being something, and a key that says
+    /// where reads as an address rather than as an integer.
+    TrackId trackId = INVALID_TRACK_ID;
+
+    RackId rackId = INVALID_RACK_ID;
+    DeviceKey device;
+
+    /// The modifier, for Kind::ModParam. A modifier addressed as a source
+    /// rather than as a set of parameters leaves @ref index at -1: it names the
+    /// modifier itself, which is a thing that produces a value rather than a
+    /// value something can write.
+    ModId modId = INVALID_MOD_ID;
+
+    /// The device's parameter index, the macro's index, or the modifier
+    /// parameter's index.
+    int index = 0;
+
+    bool operator==(const ParamKey& o) const;
+    bool operator!=(const ParamKey& o) const {
+        return !(*this == o);
+    }
+    bool operator<(const ParamKey& o) const;
+};
+
+struct ParamKeyHash {
+    std::size_t operator()(const ParamKey& key) const noexcept;
+};
+
+/**
+ * @brief The parameter a ControlTarget names.
+ *
+ * The one translation between the model's address and the engine's, so a target
+ * that resolves differently in two places is not a thing that can happen.
+ *
+ * Empty for a target the parameter table does not carry, which is not the same
+ * as a target that is wrong: a track volume is a real target that the value
+ * table resolves rather than this one, and a tempo is a real target that
+ * belongs to the transport. What to say about the difference is the caller's,
+ * since only the caller knows whether it is reporting or asking.
+ */
+std::optional<ParamKey> paramKeyFor(const magda::ControlTarget& target);
+
+/// The modifier a ControlTarget's scope and modId name, as a source: the same
+/// key with no parameter index. Empty when the target names no modifier.
+std::optional<ParamKey> modifierKeyFor(const magda::ControlTarget& target);
+
+/// Canonical text, e.g. "T1/D7:param3", "T1/R4:macro0", "T1:mod2.param0".
+std::string toString(const ParamKey& key);
+
+}  // namespace magda::engine

--- a/magda/engine/param/ParamResolve.cpp
+++ b/magda/engine/param/ParamResolve.cpp
@@ -147,4 +147,53 @@ void resolveParam(ResolvedParams& out, int param, const ParamSpec& spec,
     out.setSegmentCount(param, written);
 }
 
+void resolveParams(const ParamTable& table, ResolvedParams& out, std::span<ModContribution> scratch,
+                   int numSamples) {
+    // Indexed by the same ParamId, so a size that disagrees is two things
+    // prepared against different plans. Refused whole: half a table of
+    // parameters is a project with some of its values from somewhere else.
+    if (table.size() != out.size())
+        return;
+
+    out.beginBlock(numSamples);
+
+    for (const auto param : table.order) {
+        if (param < 0 || param >= table.size())
+            continue;
+
+        const auto index = static_cast<std::size_t>(param);
+        const auto links = table.linksFor(param);
+
+        std::size_t used = 0;
+        for (const auto& link : links) {
+            if (used >= scratch.size())
+                break;
+
+            float value = 0.0f;
+            switch (link.source.kind) {
+                case ParamSourceRef::Kind::Parameter:
+                    // Already resolved: that is what the order is for.
+                    value = out.sourceValue(link.source.index);
+                    break;
+
+                case ParamSourceRef::Kind::Modifier:
+                    if (link.source.index >= 0 &&
+                        link.source.index < static_cast<int>(table.modifiers.size()))
+                        value = table.modifiers[static_cast<std::size_t>(link.source.index)].value;
+                    break;
+            }
+
+            scratch[used++] = ModContribution{value, link.amount, link.bipolar};
+        }
+
+        ParamSources sources;
+        sources.base = table.base[index];
+        sources.modulation = scratch.first(used);
+
+        // No automation yet: the lanes are baked in #2118, and until they are
+        // every parameter is its base plus whatever is linked to it.
+        resolveParam(out, param, table.specs[index], sources);
+    }
+}
+
 }  // namespace magda::engine

--- a/magda/engine/param/ParamResolve.cpp
+++ b/magda/engine/param/ParamResolve.cpp
@@ -149,13 +149,17 @@ void resolveParam(ResolvedParams& out, int param, const ParamSpec& spec,
 
 void resolveParams(const ParamTable& table, ResolvedParams& out, std::span<ModContribution> scratch,
                    int numSamples) {
+    // Emptied first, and then refused. A table that does not fit is not a
+    // reason to keep rendering last block's values: those were resolved for a
+    // parameter set this one no longer has, and a device reading them would be
+    // holding a frozen project rather than an unresolved one.
+    out.beginBlock(numSamples);
+
     // Indexed by the same ParamId, so a size that disagrees is two things
-    // prepared against different plans. Refused whole: half a table of
+    // prepared against different tables. Refused whole: half a table of
     // parameters is a project with some of its values from somewhere else.
     if (table.size() != out.size())
         return;
-
-    out.beginBlock(numSamples);
 
     for (const auto param : table.order) {
         if (param < 0 || param >= table.size())

--- a/magda/engine/param/ParamResolve.hpp
+++ b/magda/engine/param/ParamResolve.hpp
@@ -4,6 +4,7 @@
 
 #include "param/ParamBlock.hpp"
 #include "param/ParamSpec.hpp"
+#include "param/ParamTable.hpp"
 
 /**
  * @file ParamResolve.hpp
@@ -106,5 +107,27 @@ struct ParamSources {
  */
 void resolveParam(ResolvedParams& out, int param, const ParamSpec& spec,
                   const ParamSources& sources);
+
+/**
+ * @brief Resolve every parameter of @p table for one block (#2117).
+ *
+ * On the audio thread, once per block, before any device runs. Walks the
+ * table's resolution order, so a macro driving a macro driving a device
+ * parameter needs no second pass: whatever a parameter reads has already been
+ * resolved when it is reached.
+ *
+ * @p scratch is where one parameter's contributions are gathered, and it has to
+ * hold ParamTable::maxLinksPerParam of them. Passed in rather than owned
+ * because this runs on the audio thread and the room has to have been found
+ * before the block started; a parameter with more links than there is room for
+ * keeps the ones that fit, which cannot happen against a scratch sized from the
+ * table it is used with.
+ *
+ * A table whose size does not match what @p out was prepared for is refused
+ * whole rather than resolved partly: the two are indexed by the same ParamId,
+ * and a mismatch means they were prepared against different plans.
+ */
+void resolveParams(const ParamTable& table, ResolvedParams& out, std::span<ModContribution> scratch,
+                   int numSamples);
 
 }  // namespace magda::engine

--- a/magda/engine/param/ParamTable.cpp
+++ b/magda/engine/param/ParamTable.cpp
@@ -1,0 +1,19 @@
+#include "param/ParamTable.hpp"
+
+#include <algorithm>
+
+namespace magda::engine {
+
+std::span<const ParamLink> ParamTable::linksFor(ParamId param) const {
+    if (param < 0 || param + 1 >= static_cast<ParamId>(linkOffsets.size()))
+        return {};
+
+    const auto first = static_cast<std::size_t>(linkOffsets[static_cast<std::size_t>(param)]);
+    const auto last = static_cast<std::size_t>(linkOffsets[static_cast<std::size_t>(param) + 1]);
+    if (last <= first || last > links.size())
+        return {};
+
+    return std::span<const ParamLink>{links}.subspan(first, last - first);
+}
+
+}  // namespace magda::engine

--- a/magda/engine/param/ParamTable.cpp
+++ b/magda/engine/param/ParamTable.cpp
@@ -4,6 +4,33 @@
 
 namespace magda::engine {
 
+std::uint64_t paramLayoutFingerprint(const std::vector<ParamKey>& keys) {
+    // FNV-1a, as the plan's fingerprint is: it has to separate layouts that
+    // differ, and it runs off the audio thread once per compile.
+    std::uint64_t hash = 14695981039346656037ULL;
+    const auto mix = [&hash](std::uint64_t value) {
+        for (int byte = 0; byte < 8; ++byte) {
+            hash ^= (value >> (byte * 8)) & 0xff;
+            hash *= 1099511628211ULL;
+        }
+    };
+
+    mix(keys.size());
+
+    for (const auto& key : keys) {
+        mix(static_cast<std::uint64_t>(key.kind));
+        mix(static_cast<std::uint64_t>(key.scope));
+        mix(static_cast<std::uint64_t>(key.trackId));
+        mix(static_cast<std::uint64_t>(key.rackId));
+        mix(static_cast<std::uint64_t>(key.device.segment));
+        mix(static_cast<std::uint64_t>(key.device.deviceId));
+        mix(static_cast<std::uint64_t>(key.modId));
+        mix(static_cast<std::uint64_t>(key.index));
+    }
+
+    return hash;
+}
+
 std::span<const ParamLink> ParamTable::linksFor(ParamId param) const {
     if (param < 0 || param + 1 >= static_cast<ParamId>(linkOffsets.size()))
         return {};

--- a/magda/engine/param/ParamTable.hpp
+++ b/magda/engine/param/ParamTable.hpp
@@ -115,6 +115,23 @@ struct ParamTable {
     /// resolver needs to gather one parameter's contributions.
     int maxLinksPerParam = 0;
 
+    /**
+     * @brief Identity of the layout: which parameter is at which ParamId.
+     *
+     * What the plan's fingerprint is to the op values, one level down. A table
+     * is read by index, and by windows of indices, and two tables of the same
+     * size can still put different parameters at the same address: a macro that
+     * stopped being used in one scope and started being used in another leaves
+     * the count alone and moves every device window after it. Anything holding
+     * an index resolved against one table has to be able to tell that the other
+     * is not it.
+     *
+     * Over the keys in order, and nothing else. Values, links and the
+     * resolution order all change without moving a parameter, and a fingerprint
+     * that moved with them would turn every knob into a structural edit.
+     */
+    std::uint64_t layoutFingerprint = 0;
+
     /** Where one device's parameters sit in the table. */
     struct DeviceWindow {
         ParamId first = 0;
@@ -153,5 +170,15 @@ struct ParamTable {
         return found == deviceWindows.end() ? DeviceWindow{} : found->second;
     }
 };
+
+/**
+ * @brief The layout fingerprint of a sequence of keys.
+ *
+ * Exposed because the thing that has to agree about a layout is not always the
+ * thing that built it: an executor prepared against one table meets another,
+ * and the question it asks is whether the parameter at an index is still the
+ * parameter that index was resolved for.
+ */
+std::uint64_t paramLayoutFingerprint(const std::vector<ParamKey>& keys);
 
 }  // namespace magda::engine

--- a/magda/engine/param/ParamTable.hpp
+++ b/magda/engine/param/ParamTable.hpp
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "param/ParamKey.hpp"
+#include "param/ParamSpec.hpp"
+
+/**
+ * @file ParamTable.hpp
+ * @brief Every parameter behind one plan, and what writes each of them.
+ *
+ * The plan is topology and carries no values (RenderPlan.hpp). PlanValues is
+ * what a mixer move can touch, resolved per op. This is the third of the three:
+ * what a device reads, resolved per parameter, and it is where a parameter's
+ * scale, its stored value and the links reaching it are settled against the
+ * plan they belong to.
+ *
+ * Built off the audio thread, published with the values, and read on the audio
+ * thread by ParamResolve.hpp, which turns it into the value streams devices
+ * see. Immutable once published, like everything else that crosses that line.
+ *
+ * Fingerprinted against the plan for the same reason PlanValues is: parameters
+ * are addressed by index, and a table resolved against a plan that has since
+ * been swapped would put one device's cutoff on another.
+ */
+
+namespace magda::engine {
+
+/** @brief Where one link's modulation comes from. */
+struct ParamSourceRef {
+    enum class Kind : std::uint8_t {
+        Parameter,  ///< another parameter's own value, which is what a macro is
+        Modifier,   ///< a modifier's output
+    };
+
+    Kind kind = Kind::Parameter;
+
+    /// A ParamId, or an index into ParamTable::modifiers.
+    int index = INVALID_PARAM_ID;
+
+    bool operator==(const ParamSourceRef& o) const = default;
+};
+
+/** @brief One thing writing one parameter's modulation lane. */
+struct ParamLink {
+    ParamSourceRef source;
+
+    /// Depth and polarity, per link rather than per source: one macro drives
+    /// several parameters by different amounts and in different directions, and
+    /// that is where MAGDA keeps them.
+    float amount = 0.0f;
+    bool bipolar = false;
+};
+
+/**
+ * @brief One modifier instance, as the thing links read.
+ *
+ * Its value is the model's own for now, which is a constant for the duration of
+ * a block and a constant for the duration of a publish. The engines that make
+ * it move arrive in #2119 and #2120; what is settled here is that a modifier is
+ * a source with an identity, so a link can name one and the resolution order
+ * can account for one.
+ */
+struct ParamModifier {
+    /// The modifier itself: its owner's scope and its id, with no parameter
+    /// index (see ParamKey::modId).
+    ParamKey key;
+
+    /// Its output, 0 to 1, as the model last saw it.
+    float value = 0.0f;
+};
+
+/**
+ * @brief The parameters of one plan, with their scales, values and links.
+ *
+ * Flat and index-parallel: a ParamId indexes keys, specs and base alike. Links
+ * are stored once, in one vector, with each parameter's own in a half-open
+ * range of it.
+ */
+struct ParamTable {
+    /// The plan this was resolved against. Zero for a table belonging to no
+    /// plan, which is what a test that resolves parameters on their own has.
+    std::uint64_t planFingerprint = 0;
+
+    std::vector<ParamKey> keys;
+    std::vector<ParamSpec> specs;
+
+    /// The stored value, normalised. What a knob, a control surface or a host
+    /// write moves, and what the parameter is where no automation covers it.
+    std::vector<float> base;
+
+    /// Links reaching parameter i: links[linkOffsets[i], linkOffsets[i + 1]).
+    /// One vector rather than one per parameter, because almost no parameter
+    /// has a link and a vector each would be an allocation each.
+    std::vector<ParamLink> links;
+    std::vector<int> linkOffsets;
+
+    std::vector<ParamModifier> modifiers;
+
+    /**
+     * @brief The order parameters resolve in.
+     *
+     * A permutation of every ParamId, arranged so that anything a parameter
+     * reads has already been resolved when it is. A macro driving a macro
+     * driving a device parameter therefore needs no second pass and no fixed
+     * point, and the audio thread walks a vector.
+     */
+    std::vector<ParamId> order;
+
+    /// The most links any one parameter has, which is how much room the block
+    /// resolver needs to gather one parameter's contributions.
+    int maxLinksPerParam = 0;
+
+    /** Where one device's parameters sit in the table. */
+    struct DeviceWindow {
+        ParamId first = 0;
+        int count = 0;
+    };
+
+    /// Contiguous per device and indexed from zero by the device's own
+    /// parameter index, which is what lets a device be handed a window.
+    std::unordered_map<DeviceKey, DeviceWindow, DeviceKeyHash> deviceWindows;
+
+    /// What the model asked for that this could not express, in the order it
+    /// was met. Never a silent drop, exactly as the plan compiler's are.
+    std::vector<std::string> diagnostics;
+
+    /// Parameters by their key. Built with the table, because both the link
+    /// resolution that fills it and the lane binding that will read it (#2118)
+    /// ask the same question.
+    std::unordered_map<ParamKey, ParamId, ParamKeyHash> byKey;
+
+    int size() const {
+        return static_cast<int>(keys.size());
+    }
+
+    /// The parameter @p key names, or INVALID_PARAM_ID.
+    ParamId find(const ParamKey& key) const {
+        const auto found = byKey.find(key);
+        return found == byKey.end() ? INVALID_PARAM_ID : found->second;
+    }
+
+    /// The links reaching @p param, empty when nothing modulates it.
+    std::span<const ParamLink> linksFor(ParamId param) const;
+
+    /// Where @p device's parameters are, or a window of nothing.
+    DeviceWindow windowFor(const DeviceKey& device) const {
+        const auto found = deviceWindows.find(device);
+        return found == deviceWindows.end() ? DeviceWindow{} : found->second;
+    }
+};
+
+}  // namespace magda::engine

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -1,0 +1,476 @@
+#include "param/ParamTableCompiler.hpp"
+
+#include <algorithm>
+#include <queue>
+#include <set>
+
+#include "core/RackInfo.hpp"
+#include "core/TrackInfo.hpp"
+
+namespace magda::engine {
+
+namespace {
+
+/// A parameter index past this is a device misreporting rather than a device
+/// with a great many parameters. The table allocates a slot per index up to the
+/// highest one a device declares, so without a ceiling the model would be
+/// deciding how much the engine allocates.
+constexpr int kMaxDeviceParamIndex = 4096;
+
+/// What a macro knob is: a position between nothing and everything, with the
+/// meaning of both left to whatever it is linked to.
+ParamSpec macroSpec() {
+    ParamSpec spec;
+    spec.domain.scale = magda::ParameterScale::Linear;
+    spec.domain.minValue = 0.0f;
+    spec.domain.maxValue = 1.0f;
+    return spec;
+}
+
+/// A link as this pass needs it, whichever kind of source it came from.
+struct PendingLink {
+    ParamSourceRef source;
+    std::string sourceName;
+    magda::ControlTarget target;
+    float amount = 0.0f;
+    bool bipolar = false;
+};
+
+/// One thing in the model that owns parameters: a track, a rack, or a device.
+/// Collected first and allocated second, because whether a macro is worth a
+/// slot depends on what every other node's links point at.
+struct Node {
+    ParamKey scope;
+    const magda::MacroArray* macros = nullptr;
+    const magda::ModArray* mods = nullptr;
+    const magda::DeviceInfo* device = nullptr;
+};
+
+class Builder {
+  public:
+    ParamTable run(const RenderPlan& plan, const std::vector<magda::TrackInfo>& tracks,
+                   const magda::TrackInfo& master);
+
+  private:
+    ParamId add(const ParamKey& key, const ParamSpec& spec, float base);
+
+    void walkTrack(const magda::TrackInfo& track);
+    void walkRack(const magda::RackInfo& rack, magda::TrackId trackId);
+    void walkElements(const std::vector<magda::ChainElement>& elements, magda::TrackId trackId,
+                      magda::RackId rackId);
+    void walkFlat(const std::vector<magda::PostFxChainElement>& elements, magda::TrackId trackId,
+                  ChainSegment segment);
+
+    void collectTargets();
+    void allocate();
+    void allocateDevice(const Node& node);
+    void allocateMacros(const Node& node);
+    void allocateMods(const Node& node);
+
+    void resolveLinks();
+    void orderAndBreakCycles();
+    void flattenLinks();
+
+    void diagnose(const std::string& what) {
+        table_.diagnostics.push_back(what);
+    }
+
+    ParamTable table_;
+    std::vector<Node> nodes_;
+    std::vector<PendingLink> pending_;
+
+    /// Every parameter something links to, whether or not it exists. What makes
+    /// a macro worth a slot: one with no links of its own that a modifier
+    /// drives is a macro the project uses.
+    std::set<ParamKey> targeted_;
+
+    /// Per parameter, until the cycle pass has decided which survive.
+    std::vector<std::vector<ParamLink>> perParam_;
+};
+
+ParamId Builder::add(const ParamKey& key, const ParamSpec& spec, float base) {
+    const auto existing = table_.byKey.find(key);
+    if (existing != table_.byKey.end()) {
+        // Two things in the model claiming one address. The plan compiler
+        // refuses a duplicate OpKey for the same reason: an address that names
+        // two things is an address that names neither.
+        diagnose(toString(key) + ": two parameters claim this address; the second is ignored");
+        return existing->second;
+    }
+
+    const auto id = static_cast<ParamId>(table_.keys.size());
+    table_.keys.push_back(key);
+    table_.specs.push_back(spec);
+    table_.base.push_back(base);
+    perParam_.emplace_back();
+    table_.byKey.emplace(key, id);
+    return id;
+}
+
+void Builder::allocateMacros(const Node& node) {
+    if (node.macros == nullptr)
+        return;
+
+    for (std::size_t i = 0; i < node.macros->size(); ++i) {
+        const auto& macro = (*node.macros)[i];
+
+        ParamKey key = node.scope;
+        key.kind = ParamKey::Kind::Macro;
+        key.index = static_cast<int>(i);
+
+        // Every scope in the model comes with sixteen macros whether or not
+        // anything uses them, and a project of any size would otherwise spend
+        // most of its table on knobs with nothing behind them. A macro is worth
+        // a slot when it drives something or something drives it; the rest are
+        // stored values the model keeps and the engine has no use for.
+        //
+        // An automation lane targeting one is the third way to be worth a slot,
+        // and it lands with the lanes (#2118).
+        if (macro.links.empty() && targeted_.count(key) == 0)
+            continue;
+
+        // The macro's own value is a parameter like any other: it is stored, a
+        // knob moves it, and an automation lane will play over it.
+        const auto id = add(key, macroSpec(), macro.value);
+
+        for (const auto& link : macro.links)
+            pending_.push_back(PendingLink{ParamSourceRef{ParamSourceRef::Kind::Parameter, id},
+                                           toString(key), link.target, link.amount, link.bipolar});
+    }
+}
+
+void Builder::allocateMods(const Node& node) {
+    if (node.mods == nullptr)
+        return;
+
+    for (const auto& mod : *node.mods) {
+        ParamKey key = node.scope;
+        key.kind = ParamKey::Kind::ModParam;
+        key.modId = mod.id;
+        key.index = -1;
+
+        // The model's own reading of the modifier, which is a constant until
+        // the engines land (#2119, #2120). The two rules that are already
+        // invariants rather than implementation get applied here: an inactive
+        // modifier outputs nothing, and a curve drawn as a level is applied as
+        // its complement.
+        const float output = mod.enabled ? (mod.invertOutput ? 1.0f - mod.value : mod.value) : 0.0f;
+
+        const auto index = static_cast<int>(table_.modifiers.size());
+        table_.modifiers.push_back(ParamModifier{key, output});
+
+        for (const auto& link : mod.links) {
+            // A link the model keeps but does not apply. Not a diagnostic: it
+            // is a stored amount waiting to be switched back on.
+            if (!link.enabled)
+                continue;
+
+            pending_.push_back(PendingLink{ParamSourceRef{ParamSourceRef::Kind::Modifier, index},
+                                           toString(key), link.target, link.amount, link.bipolar});
+        }
+    }
+}
+
+void Builder::allocateDevice(const Node& node) {
+    if (node.device == nullptr)
+        return;
+
+    const auto& device = *node.device;
+    const auto& scope = node.scope;
+
+    // A device's parameters are one index space: its own, plus whatever its
+    // wrapper injected, which addresses the same slots.
+    int highest = -1;
+    const auto scan = [&](const std::vector<magda::ParameterInfo>& list) {
+        for (const auto& info : list) {
+            if (info.paramIndex < 0 || info.paramIndex > kMaxDeviceParamIndex) {
+                diagnose(toString(scope) + ": parameter index " + std::to_string(info.paramIndex) +
+                         " is out of range and is ignored");
+                continue;
+            }
+            highest = std::max(highest, info.paramIndex);
+        }
+    };
+    scan(device.parameters);
+    scan(device.wrapperParameters);
+
+    const auto find = [&](int index) -> const magda::ParameterInfo* {
+        for (const auto* list : {&device.parameters, &device.wrapperParameters})
+            for (const auto& info : *list)
+                if (info.paramIndex == index)
+                    return &info;
+        return nullptr;
+    };
+
+    // Every index from zero, so a device reads its own parameters by the index
+    // it declared them at rather than by where they landed in the table. A gap
+    // is a slot nothing declared and nothing reads.
+    const auto first = static_cast<ParamId>(table_.keys.size());
+    int gaps = 0;
+    for (int index = 0; index <= highest; ++index) {
+        ParamKey key = scope;
+        key.kind = ParamKey::Kind::DeviceParam;
+        key.index = index;
+
+        const auto* info = find(index);
+        if (info == nullptr) {
+            ++gaps;
+            add(key, ParamSpec{}, 0.0f);
+            continue;
+        }
+
+        // The model's own inverse, rather than a straight read of the range:
+        // an external plugin's stored value and its display range are not the
+        // same number, and only ParameterUtils knows which parameters those
+        // are.
+        const auto normalised = magda::ParameterUtils::modelToNormalizedValue(
+            magda::ParameterModelValue{info->currentValue}, *info);
+        add(key, paramSpecFrom(*info), normalised.value);
+    }
+
+    if (gaps > 0)
+        diagnose(toString(scope) + ": parameter indices are not contiguous, so " +
+                 std::to_string(gaps) + " slot(s) of the window belong to no parameter");
+
+    if (highest >= 0)
+        table_.deviceWindows.emplace(scope.device, ParamTable::DeviceWindow{first, highest + 1});
+}
+
+void Builder::walkElements(const std::vector<magda::ChainElement>& elements, magda::TrackId trackId,
+                           magda::RackId rackId) {
+    for (const auto& element : elements) {
+        if (magda::isDevice(element)) {
+            const auto& device = magda::getDevice(element);
+            Node node;
+            node.scope.scope = ParamKey::Scope::Device;
+            node.scope.trackId = trackId;
+            node.scope.rackId = rackId;
+            node.scope.device = DeviceKey{ChainSegment::Fx, device.id};
+            node.macros = &device.macros;
+            node.mods = &device.mods;
+            node.device = &device;
+            nodes_.push_back(node);
+        } else if (magda::isRack(element)) {
+            walkRack(magda::getRack(element), trackId);
+        }
+    }
+}
+
+void Builder::walkFlat(const std::vector<magda::PostFxChainElement>& elements,
+                       magda::TrackId trackId, ChainSegment segment) {
+    for (const auto& element : elements) {
+        Node node;
+        node.scope.scope = ParamKey::Scope::Device;
+        node.scope.trackId = trackId;
+        node.scope.device = DeviceKey{segment, element.device.id};
+        node.macros = &element.device.macros;
+        node.mods = &element.device.mods;
+        node.device = &element.device;
+        nodes_.push_back(node);
+    }
+}
+
+void Builder::walkRack(const magda::RackInfo& rack, magda::TrackId trackId) {
+    Node node;
+    node.scope.scope = ParamKey::Scope::Rack;
+    node.scope.trackId = trackId;
+    node.scope.rackId = rack.id;
+    node.macros = &rack.macros;
+    node.mods = &rack.mods;
+    nodes_.push_back(node);
+
+    for (const auto& chain : rack.chains)
+        walkElements(chain.elements, trackId, rack.id);
+}
+
+void Builder::walkTrack(const magda::TrackInfo& track) {
+    Node node;
+    node.scope.scope = ParamKey::Scope::Track;
+    node.scope.trackId = track.id;
+    node.macros = &track.macros;
+    node.mods = &track.mods;
+    nodes_.push_back(node);
+
+    walkElements(track.chain.fxChainElements, track.id, INVALID_RACK_ID);
+    walkFlat(track.chain.postFxChainElements, track.id, ChainSegment::PostFx);
+    walkFlat(track.chain.mixerAnalysisElements, track.id, ChainSegment::MixerAnalysis);
+}
+
+void Builder::collectTargets() {
+    const auto note = [&](const magda::ControlTarget& target) {
+        if (const auto key = paramKeyFor(target))
+            targeted_.insert(*key);
+    };
+
+    for (const auto& node : nodes_) {
+        if (node.macros != nullptr)
+            for (const auto& macro : *node.macros)
+                for (const auto& link : macro.links)
+                    note(link.target);
+
+        if (node.mods != nullptr)
+            for (const auto& mod : *node.mods)
+                for (const auto& link : mod.links)
+                    if (link.enabled)
+                        note(link.target);
+    }
+}
+
+void Builder::allocate() {
+    for (const auto& node : nodes_) {
+        // Devices first within a node, so a device's window is contiguous.
+        allocateDevice(node);
+        allocateMacros(node);
+        allocateMods(node);
+    }
+}
+
+void Builder::resolveLinks() {
+    for (const auto& pending : pending_) {
+        const auto key = paramKeyFor(pending.target);
+        if (!key.has_value()) {
+            // A target this table does not carry rather than a target that is
+            // wrong. Both mixer values and the tempo are resolved elsewhere;
+            // what is missing is the crossing, and it is named so a project
+            // that relies on one is a report rather than a silence.
+            diagnose(pending.sourceName + ": links to " +
+                     std::string(magda::toString(pending.target.kind)) +
+                     ", which the parameter table does not carry yet");
+            continue;
+        }
+
+        if (key->kind == ParamKey::Kind::ModParam) {
+            diagnose(pending.sourceName + ": links to " + toString(*key) +
+                     ", and a modifier's own parameters arrive with the engines that define "
+                     "them (#2119)");
+            continue;
+        }
+
+        const auto id = table_.find(*key);
+        if (id == INVALID_PARAM_ID) {
+            diagnose(pending.sourceName + ": links to " + toString(*key) +
+                     ", which the project does not have");
+            continue;
+        }
+
+        if (!table_.specs[static_cast<std::size_t>(id)].modulatable) {
+            diagnose(pending.sourceName + ": links to " + toString(*key) +
+                     ", which takes no modulation");
+            continue;
+        }
+
+        perParam_[static_cast<std::size_t>(id)].push_back(
+            ParamLink{pending.source, pending.amount, pending.bipolar});
+    }
+}
+
+void Builder::orderAndBreakCycles() {
+    const auto count = static_cast<std::size_t>(table_.size());
+
+    // What each parameter waits for, and who waits for it. A modifier source
+    // contributes the modifier's own parameters, which is nothing until they
+    // exist; the loop is written for what it will be rather than for what it is
+    // today, because the order it produces is the thing that has to stay right.
+    std::vector<int> waitingOn(count, 0);
+    std::vector<std::vector<ParamId>> consumers(count);
+
+    for (std::size_t target = 0; target < count; ++target) {
+        for (const auto& link : perParam_[target]) {
+            if (link.source.kind != ParamSourceRef::Kind::Parameter)
+                continue;
+            const auto source = static_cast<std::size_t>(link.source.index);
+            if (source >= count)
+                continue;
+
+            consumers[source].push_back(static_cast<ParamId>(target));
+            ++waitingOn[target];
+        }
+    }
+
+    // Ascending id among everything that is ready, so the order is a property
+    // of the model rather than of how the container happened to iterate.
+    std::priority_queue<ParamId, std::vector<ParamId>, std::greater<>> ready;
+    for (std::size_t i = 0; i < count; ++i)
+        if (waitingOn[i] == 0)
+            ready.push(static_cast<ParamId>(i));
+
+    table_.order.reserve(count);
+    while (!ready.empty()) {
+        const auto id = ready.top();
+        ready.pop();
+        table_.order.push_back(id);
+
+        for (const auto consumer : consumers[static_cast<std::size_t>(id)])
+            if (--waitingOn[static_cast<std::size_t>(consumer)] == 0)
+                ready.push(consumer);
+    }
+
+    if (table_.order.size() == count)
+        return;
+
+    // Whatever is left waits on something that is itself waiting: a cycle, and
+    // there is no order that satisfies it. The links that close it are the ones
+    // between the survivors, and dropping them is the only reading that leaves
+    // every parameter with a value. A parameter is worth more than the link
+    // that made it impossible.
+    std::vector<char> stuck(count, 0);
+    for (std::size_t i = 0; i < count; ++i)
+        stuck[i] = waitingOn[i] > 0 ? 1 : 0;
+
+    for (std::size_t target = 0; target < count; ++target) {
+        if (stuck[target] == 0)
+            continue;
+
+        auto& links = perParam_[target];
+        const auto removed = std::remove_if(links.begin(), links.end(), [&](const ParamLink& link) {
+            return link.source.kind == ParamSourceRef::Kind::Parameter &&
+                   static_cast<std::size_t>(link.source.index) < count &&
+                   stuck[static_cast<std::size_t>(link.source.index)] != 0;
+        });
+
+        if (removed != links.end()) {
+            diagnose(toString(table_.keys[target]) +
+                     ": part of a modulation cycle; the links inside it are dropped");
+            links.erase(removed, links.end());
+        }
+
+        table_.order.push_back(static_cast<ParamId>(target));
+    }
+}
+
+void Builder::flattenLinks() {
+    table_.linkOffsets.reserve(perParam_.size() + 1);
+    table_.linkOffsets.push_back(0);
+
+    for (const auto& links : perParam_) {
+        table_.links.insert(table_.links.end(), links.begin(), links.end());
+        table_.linkOffsets.push_back(static_cast<int>(table_.links.size()));
+        table_.maxLinksPerParam = std::max(table_.maxLinksPerParam, static_cast<int>(links.size()));
+    }
+}
+
+ParamTable Builder::run(const RenderPlan& plan, const std::vector<magda::TrackInfo>& tracks,
+                        const magda::TrackInfo& master) {
+    table_.planFingerprint = planFingerprint(plan);
+
+    for (const auto& track : tracks)
+        walkTrack(track);
+    walkTrack(master);
+
+    collectTargets();
+    allocate();
+    resolveLinks();
+    orderAndBreakCycles();
+    flattenLinks();
+
+    return std::move(table_);
+}
+
+}  // namespace
+
+ParamTable compileParamTable(const RenderPlan& plan, const std::vector<magda::TrackInfo>& tracks,
+                             const magda::TrackInfo& master) {
+    return Builder{}.run(plan, tracks, master);
+}
+
+}  // namespace magda::engine

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -566,6 +566,8 @@ ParamTable Builder::run(const RenderPlan& plan, const std::vector<magda::TrackIn
     orderAndBreakCycles();
     flattenLinks();
 
+    table_.layoutFingerprint = paramLayoutFingerprint(table_.keys);
+
     return std::move(table_);
 }
 

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -364,36 +364,158 @@ void Builder::resolveLinks() {
     }
 }
 
+/// Strongly connected components of the link graph, by Tarjan, iteratively.
+///
+/// Iteratively because the depth is the length of a chain of macros driving
+/// macros, which is a number a project decides rather than the engine, and a
+/// recursion that deep is the model choosing how much stack the compiler uses.
+///
+/// Returns one component id per node. Two nodes share one exactly when each can
+/// reach the other, which is what a cycle is.
+std::vector<int> stronglyConnectedComponents(const std::vector<std::vector<int>>& edges) {
+    const auto count = edges.size();
+
+    std::vector<int> index(count, -1);
+    std::vector<int> lowlink(count, 0);
+    std::vector<char> onStack(count, 0);
+    std::vector<int> component(count, -1);
+    std::vector<int> stack;
+    std::vector<std::pair<std::size_t, std::size_t>> work;
+
+    int nextIndex = 0;
+    int nextComponent = 0;
+
+    for (std::size_t root = 0; root < count; ++root) {
+        if (index[root] >= 0)
+            continue;
+
+        work.push_back({root, 0});
+        while (!work.empty()) {
+            auto& [node, edge] = work.back();
+
+            if (edge == 0) {
+                index[node] = nextIndex;
+                lowlink[node] = nextIndex;
+                ++nextIndex;
+                stack.push_back(static_cast<int>(node));
+                onStack[node] = 1;
+            }
+
+            if (edge < edges[node].size()) {
+                const auto next = static_cast<std::size_t>(edges[node][edge]);
+                ++edge;
+
+                if (index[next] < 0) {
+                    work.push_back({next, 0});
+                } else if (onStack[next] != 0) {
+                    lowlink[node] = std::min(lowlink[node], index[next]);
+                }
+                continue;
+            }
+
+            // Every edge walked: this node is finished, and it closes a
+            // component when nothing under it reached back past it.
+            if (lowlink[node] == index[node]) {
+                while (true) {
+                    const auto member = static_cast<std::size_t>(stack.back());
+                    stack.pop_back();
+                    onStack[member] = 0;
+                    component[member] = nextComponent;
+                    if (member == node)
+                        break;
+                }
+                ++nextComponent;
+            }
+
+            const auto finished = node;
+            work.pop_back();
+            if (!work.empty())
+                lowlink[work.back().first] =
+                    std::min(lowlink[work.back().first], lowlink[finished]);
+        }
+    }
+
+    return component;
+}
+
 void Builder::orderAndBreakCycles() {
     const auto count = static_cast<std::size_t>(table_.size());
 
-    // What each parameter waits for, and who waits for it. A modifier source
-    // contributes the modifier's own parameters, which is nothing until they
-    // exist; the loop is written for what it will be rather than for what it is
-    // today, because the order it produces is the thing that has to stay right.
-    std::vector<int> waitingOn(count, 0);
-    std::vector<std::vector<ParamId>> consumers(count);
-
-    for (std::size_t target = 0; target < count; ++target) {
+    // What each parameter reads. A modifier source contributes the modifier's
+    // own parameters, which is nothing until they exist; the loop is written for
+    // what it will be rather than for what it is today, because the order it
+    // produces is the thing that has to stay right.
+    std::vector<std::vector<int>> consumers(count);
+    const auto forEachDependency = [&](std::size_t target, const auto& visit) {
         for (const auto& link : perParam_[target]) {
             if (link.source.kind != ParamSourceRef::Kind::Parameter)
                 continue;
             const auto source = static_cast<std::size_t>(link.source.index);
-            if (source >= count)
-                continue;
-
-            consumers[source].push_back(static_cast<ParamId>(target));
-            ++waitingOn[target];
+            if (source < count)
+                visit(source);
         }
+    };
+
+    for (std::size_t target = 0; target < count; ++target)
+        forEachDependency(target, [&](std::size_t source) {
+            consumers[source].push_back(static_cast<int>(target));
+        });
+
+    // A cycle is a component with more than one parameter in it, or a parameter
+    // that reads itself. Only the links inside such a component are dropped:
+    // everything hanging off a cycle waits on it too, and a parameter that
+    // merely reads a cycle member has done nothing wrong. Once the cycle's own
+    // links are gone its members resolve at their base, and the link that reads
+    // one of them is honoured against that.
+    const auto component = stronglyConnectedComponents(consumers);
+
+    std::vector<int> componentSize(count, 0);
+    for (const auto id : component)
+        if (id >= 0)
+            ++componentSize[static_cast<std::size_t>(id)];
+
+    for (std::size_t target = 0; target < count; ++target) {
+        auto& links = perParam_[target];
+        const auto removed = std::remove_if(links.begin(), links.end(), [&](const ParamLink& link) {
+            if (link.source.kind != ParamSourceRef::Kind::Parameter)
+                return false;
+
+            const auto source = static_cast<std::size_t>(link.source.index);
+            if (source >= count || component[source] != component[target])
+                return false;
+
+            return source == target ||
+                   componentSize[static_cast<std::size_t>(component[target])] > 1;
+        });
+
+        if (removed == links.end())
+            continue;
+
+        diagnose(toString(table_.keys[target]) +
+                 ": part of a modulation cycle; the links inside it are dropped");
+        links.erase(removed, links.end());
     }
 
-    // Ascending id among everything that is ready, so the order is a property
-    // of the model rather than of how the container happened to iterate.
+    // With the cycles broken there is an order, and it is the same walk either
+    // way: ascending id among everything that is ready, so the order is a
+    // property of the model rather than of how a container iterated.
+    std::vector<int> waitingOn(count, 0);
+    for (std::size_t target = 0; target < count; ++target)
+        forEachDependency(target, [&](std::size_t) { ++waitingOn[target]; });
+
+    for (auto& list : consumers)
+        list.clear();
+    for (std::size_t target = 0; target < count; ++target)
+        forEachDependency(target, [&](std::size_t source) {
+            consumers[source].push_back(static_cast<int>(target));
+        });
+
     std::priority_queue<ParamId, std::vector<ParamId>, std::greater<>> ready;
     for (std::size_t i = 0; i < count; ++i)
         if (waitingOn[i] == 0)
             ready.push(static_cast<ParamId>(i));
 
+    table_.order.clear();
     table_.order.reserve(count);
     while (!ready.empty()) {
         const auto id = ready.top();
@@ -408,34 +530,15 @@ void Builder::orderAndBreakCycles() {
     if (table_.order.size() == count)
         return;
 
-    // Whatever is left waits on something that is itself waiting: a cycle, and
-    // there is no order that satisfies it. The links that close it are the ones
-    // between the survivors, and dropping them is the only reading that leaves
-    // every parameter with a value. A parameter is worth more than the link
-    // that made it impossible.
-    std::vector<char> stuck(count, 0);
+    // Unreachable: every cycle was broken above, and a graph without one has a
+    // topological order. Reported and completed rather than asserted, because
+    // the alternative is a table whose order is missing parameters, which the
+    // block resolver would read as parameters nobody resolved.
     for (std::size_t i = 0; i < count; ++i)
-        stuck[i] = waitingOn[i] > 0 ? 1 : 0;
-
-    for (std::size_t target = 0; target < count; ++target) {
-        if (stuck[target] == 0)
-            continue;
-
-        auto& links = perParam_[target];
-        const auto removed = std::remove_if(links.begin(), links.end(), [&](const ParamLink& link) {
-            return link.source.kind == ParamSourceRef::Kind::Parameter &&
-                   static_cast<std::size_t>(link.source.index) < count &&
-                   stuck[static_cast<std::size_t>(link.source.index)] != 0;
-        });
-
-        if (removed != links.end()) {
-            diagnose(toString(table_.keys[target]) +
-                     ": part of a modulation cycle; the links inside it are dropped");
-            links.erase(removed, links.end());
+        if (waitingOn[i] > 0) {
+            diagnose(toString(table_.keys[i]) + ": still waits on something after the cycle pass");
+            table_.order.push_back(static_cast<ParamId>(i));
         }
-
-        table_.order.push_back(static_cast<ParamId>(target));
-    }
 }
 
 void Builder::flattenLinks() {

--- a/magda/engine/param/ParamTableCompiler.hpp
+++ b/magda/engine/param/ParamTableCompiler.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <vector>
+
+#include "param/ParamTable.hpp"
+#include "plan/RenderPlan.hpp"
+
+namespace magda {
+struct TrackInfo;
+}
+
+/**
+ * @file ParamTableCompiler.hpp
+ * @brief The model's parameters, resolved into the table a plan reads.
+ *
+ * Runs off the audio thread beside resolvePlanValues, over the same model, and
+ * the division between the two is what each answers. The value table answers
+ * what a mixer move did to an op. This answers what a device's own parameters
+ * are: their scales, their stored values, and the macros and modifiers wired to
+ * them.
+ *
+ * Walks the model rather than the plan, and takes the plan for its fingerprint
+ * and its devices. A parameter belonging to something the plan does not carry
+ * is still resolved and simply read by nobody, which is cheaper than working out
+ * whether it is reachable and safer than guessing wrong.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief Compile every parameter of @p tracks and @p master against @p plan.
+ *
+ * @param plan    the plan the table is fingerprinted against
+ * @param tracks  every non-master track, as passed to compileRenderPlan
+ * @param master  the master track
+ *
+ * Diagnostics ride on the table (ParamTable::diagnostics): a link naming
+ * something that does not exist, a target this table does not carry, a link to
+ * a parameter that takes no modulation, and a cycle. Nothing is dropped in
+ * silence, and nothing is refused: a table with diagnostics still renders,
+ * minus whatever the diagnostic describes.
+ */
+ParamTable compileParamTable(const RenderPlan& plan, const std::vector<magda::TrackInfo>& tracks,
+                             const magda::TrackInfo& master);
+
+}  // namespace magda::engine

--- a/magda/engine/param/ParamTableDump.cpp
+++ b/magda/engine/param/ParamTableDump.cpp
@@ -1,0 +1,105 @@
+#include "param/ParamTableDump.hpp"
+
+#include <iomanip>
+#include <sstream>
+
+#include "plan/DumpFormat.hpp"
+
+namespace magda::engine {
+
+namespace {
+
+using dump_format::padded;
+using dump_format::rightAligned;
+using dump_format::writeLine;
+
+std::string number(float value) {
+    std::ostringstream out;
+    out << std::fixed << std::setprecision(3) << value;
+    return out.str();
+}
+
+/// The scale, short enough to sit in a column: what a position means, which is
+/// the part of a spec a reader is checking.
+std::string domainText(const magda::ParameterUtils::ParameterDomain& domain) {
+    const auto range = "[" + number(domain.minValue) + "," + number(domain.maxValue) + "]";
+
+    switch (domain.scale) {
+        case magda::ParameterScale::Linear:
+            return "lin" + range;
+        case magda::ParameterScale::Logarithmic:
+            return "log" + range;
+        case magda::ParameterScale::Exponential:
+            return "exp" + range;
+        case magda::ParameterScale::Discrete:
+            return "step[" + std::to_string(domain.choiceCount) + "]";
+        case magda::ParameterScale::Boolean:
+            return "bool";
+        case magda::ParameterScale::FaderDB:
+            return "fader" + range;
+    }
+    return "?" + range;
+}
+
+}  // namespace
+
+std::string dumpParamTable(const ParamTable& table) {
+    std::ostringstream out;
+
+    out << "magda-param-table v1\n";
+    out << "params=" << table.size() << " modifiers=" << table.modifiers.size()
+        << " links=" << table.links.size() << "\n";
+
+    for (int param = 0; param < table.size(); ++param) {
+        const auto index = static_cast<std::size_t>(param);
+        const auto links = table.linksFor(param);
+
+        std::ostringstream line;
+        line << "[" << rightAligned(param, 3) << "] " << padded(toString(table.keys[index]), 28)
+             << " " << padded(domainText(table.specs[index].domain), 16) << " "
+             << "base=" << number(table.base[index]) << "  links=" << links.size();
+
+        if (!table.specs[index].modulatable)
+            line << " fixed";
+        if (table.specs[index].segmentAccurate)
+            line << " segmented";
+
+        writeLine(out, line.str());
+
+        for (const auto& link : links) {
+            std::ostringstream detail;
+            const auto source =
+                link.source.kind == ParamSourceRef::Kind::Parameter ? "param" : "mod";
+            detail << "      <- " << source << "[" << rightAligned(link.source.index, 3) << "]"
+                   << " amount=" << number(link.amount) << " bipolar=" << (link.bipolar ? 1 : 0);
+            writeLine(out, detail.str());
+        }
+    }
+
+    if (!table.modifiers.empty()) {
+        out << "modifiers:\n";
+        for (std::size_t i = 0; i < table.modifiers.size(); ++i) {
+            std::ostringstream line;
+            line << "[" << rightAligned(static_cast<int>(i), 3) << "] "
+                 << padded(toString(table.modifiers[i].key), 28) << " "
+                 << "value=" << number(table.modifiers[i].value);
+            writeLine(out, line.str());
+        }
+    }
+
+    std::ostringstream order;
+    order << "order:";
+    for (const auto param : table.order)
+        order << " " << param;
+    writeLine(out, order.str());
+
+    if (!table.diagnostics.empty()) {
+        out << "diagnostics:\n";
+        for (const auto& message : table.diagnostics)
+            writeLine(out, "  " + message);
+    }
+
+    return out.str();
+}
+
+}  // namespace magda::engine

--- a/magda/engine/param/ParamTableDump.hpp
+++ b/magda/engine/param/ParamTableDump.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+
+#include "param/ParamTable.hpp"
+
+namespace magda::engine {
+
+/**
+ * @brief Render a parameter table as canonical text.
+ *
+ * The table's testable surface, and the third dump the goldens compare (#2076)
+ * beside the plan and its layout. Deterministic and diff-friendly: one line per
+ * parameter in table order, fixed columns, no addresses.
+ *
+ * Shape:
+ * @code
+ * magda-param-table v1
+ * params=3 modifiers=1 links=1
+ * [  0] T1:macro0            lin[0,1]        base=0.500  links=0
+ * [  1] T1/D7:param0         log[20,20000]   base=0.250  links=1
+ *       <- param[  0] amount=0.500 bipolar=0
+ * modifiers:
+ * [  0] T1:mod0              value=0.000
+ * order: 0 1 2
+ * @endcode
+ *
+ * Values are printed to three decimals, which is finer than any of them are
+ * edited at and coarser than the last bit of a float: a golden that changed
+ * because an unrelated arithmetic order moved a value by an ulp would be a
+ * golden nobody could read.
+ */
+std::string dumpParamTable(const ParamTable& table);
+
+}  // namespace magda::engine

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -308,6 +308,8 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # The parameter lane (#2116). The lanes are fed by hand, so the precedence
     # rules are testable before anything writes them.
     list(APPEND TEST_SOURCES test_param_lane.cpp)
+    # The parameter table (#2117): addressing, the link graph and publication.
+    list(APPEND TEST_SOURCES test_param_table.cpp)
     list(APPEND TEST_SOURCES test_tempo_map.cpp)
     list(APPEND TEST_SOURCES test_transport_clock.cpp)
     list(APPEND TEST_SOURCES test_click_generator.cpp)

--- a/tests/PlanGoldenFixtures.cpp
+++ b/tests/PlanGoldenFixtures.cpp
@@ -43,6 +43,19 @@ DeviceInfo effect(DeviceId id) {
     return device;
 }
 
+/// An effect with parameters, for the fixture that pins the parameter table
+/// rather than the graph. Ranges that read 0 to 100 so a normalised position
+/// and the value a device is handed are not the same number in the golden.
+DeviceInfo effectWithParameters(DeviceId id, int numParameters) {
+    auto device = effect(id);
+    for (int index = 0; index < numParameters; ++index) {
+        ParameterInfo info(index, "P" + juce::String(index), "%", 0.0f, 100.0f, 0.0f);
+        info.currentValue = 25.0f * static_cast<float>(index);
+        device.parameters.push_back(info);
+    }
+    return device;
+}
+
 DeviceInfo instrument(DeviceId id) {
     DeviceInfo device;
     device.id = id;
@@ -208,6 +221,42 @@ Fixture sectionLocalDeviceIds() {
     return value;
 }
 
+/// The parameter table's own fixture (#2117). Everything the plan fixtures do
+/// not have: parameters with scales, a macro driving one, a modifier driving
+/// another, and a macro driving a macro, which is what the resolution order is
+/// for.
+Fixture parameterLinks() {
+    Fixture value;
+    value.name = "parameter-links";
+    value.covers = "macros, modifiers and the order a chain of them resolves in";
+
+    auto device = effectWithParameters(7, 3);
+    device.macros = createDefaultMacros(1);
+    device.macros[0].value = 0.25f;
+    device.macros[0].links.push_back(
+        MacroLink{ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 2), 0.5f, true});
+
+    value.tracks = {track(1)};
+    value.tracks[0].chain.fxChainElements.push_back(makeDeviceElement(device));
+
+    value.tracks[0].macros = createDefaultMacros(2);
+    value.tracks[0].macros[0].value = 1.0f;
+    value.tracks[0].macros[0].links.push_back(
+        MacroLink{ControlTarget::deviceMacro(ChainNodePath::trackLevel(1), 1), 0.5f, false});
+    value.tracks[0].macros[1].value = 0.5f;
+    value.tracks[0].macros[1].links.push_back(
+        MacroLink{ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0), 1.0f, false});
+
+    value.tracks[0].mods = createDefaultMods(1);
+    value.tracks[0].mods[0].value = 0.75f;
+    value.tracks[0].mods[0].links.push_back(ModLink{
+        ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 1), 0.5f, true, true});
+
+    value.master = master();
+    value.options = withoutMeters();
+    return value;
+}
+
 Fixture groupRouting() {
     Fixture value;
     value.name = "group-routing";
@@ -290,6 +339,7 @@ std::vector<Fixture> planFixtures() {
     fixtures.push_back(sidechain());
     fixtures.push_back(sectionLocalDeviceIds());
     fixtures.push_back(groupRouting());
+    fixtures.push_back(parameterLinks());
     fixtures.push_back(insertDevice());
     fixtures.push_back(removeDevice());
     fixtures.push_back(reorderDevices());

--- a/tests/goldens/plan/bare-track.txt
+++ b/tests/goldens/plan/bare-track.txt
@@ -31,3 +31,8 @@ audioSlots=1 midiSlots=0 outputLatency=0
 [  7] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
 [  8] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
 [  9] Output      T-2:hardwareOutput             lat=-       ports=-
+
+== params ==
+magda-param-table v1
+params=0 modifiers=0 links=0
+order:

--- a/tests/goldens/plan/cascaded-latency.txt
+++ b/tests/goldens/plan/cascaded-latency.txt
@@ -57,3 +57,8 @@ audioSlots=3 midiSlots=0 outputLatency=176
 [ 20] Meter       T-2:trackMeter                 lat=176     ports=a2          inplace
 [ 21] Gain        T-2:trackMute                  lat=176     ports=a2          inplace
 [ 22] Output      T-2:hardwareOutput             lat=-       ports=-
+
+== params ==
+magda-param-table v1
+params=0 modifiers=0 links=0
+order:

--- a/tests/goldens/plan/device-chain.txt
+++ b/tests/goldens/plan/device-chain.txt
@@ -43,3 +43,8 @@ audioSlots=1 midiSlots=0 outputLatency=0
 [ 13] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
 [ 14] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
 [ 15] Output      T-2:hardwareOutput             lat=-       ports=-
+
+== params ==
+magda-param-table v1
+params=0 modifiers=0 links=0
+order:

--- a/tests/goldens/plan/edit-insert-device.txt
+++ b/tests/goldens/plan/edit-insert-device.txt
@@ -54,6 +54,11 @@ audioSlots=2 midiSlots=0 outputLatency=0
 [ 19] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
 [ 20] Output      T-2:hardwareOutput             lat=-       ports=-
 
+== params ==
+magda-param-table v1
+params=0 modifiers=0 links=0
+order:
+
 == edited plan ==
 magda-render-plan v1
 ops=23 outputs=1

--- a/tests/goldens/plan/edit-remove-device.txt
+++ b/tests/goldens/plan/edit-remove-device.txt
@@ -40,6 +40,11 @@ audioSlots=1 midiSlots=0 outputLatency=0
 [ 12] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
 [ 13] Output      T-2:hardwareOutput             lat=-       ports=-
 
+== params ==
+magda-param-table v1
+params=0 modifiers=0 links=0
+order:
+
 == edited plan ==
 magda-render-plan v1
 ops=12 outputs=1

--- a/tests/goldens/plan/edit-reorder-devices.txt
+++ b/tests/goldens/plan/edit-reorder-devices.txt
@@ -40,6 +40,11 @@ audioSlots=1 midiSlots=0 outputLatency=0
 [ 12] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
 [ 13] Output      T-2:hardwareOutput             lat=-       ports=-
 
+== params ==
+magda-param-table v1
+params=0 modifiers=0 links=0
+order:
+
 == edited plan ==
 magda-render-plan v1
 ops=14 outputs=1

--- a/tests/goldens/plan/fan-in.txt
+++ b/tests/goldens/plan/fan-in.txt
@@ -49,3 +49,8 @@ audioSlots=2 midiSlots=0 outputLatency=64
 [ 16] Meter       T-2:trackMeter                 lat=64      ports=a0          inplace
 [ 17] Gain        T-2:trackMute                  lat=64      ports=a0          inplace
 [ 18] Output      T-2:hardwareOutput             lat=-       ports=-
+
+== params ==
+magda-param-table v1
+params=0 modifiers=0 links=0
+order:

--- a/tests/goldens/plan/group-routing.txt
+++ b/tests/goldens/plan/group-routing.txt
@@ -43,3 +43,8 @@ audioSlots=1 midiSlots=0 outputLatency=0
 [ 13] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
 [ 14] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
 [ 15] Output      T-2:hardwareOutput             lat=-       ports=-
+
+== params ==
+magda-param-table v1
+params=0 modifiers=0 links=0
+order:

--- a/tests/goldens/plan/instrument-track.txt
+++ b/tests/goldens/plan/instrument-track.txt
@@ -51,3 +51,8 @@ audioSlots=1 midiSlots=2 outputLatency=0
 [ 17] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
 [ 18] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
 [ 19] Output      T-2:hardwareOutput             lat=-       ports=-
+
+== params ==
+magda-param-table v1
+params=0 modifiers=0 links=0
+order:

--- a/tests/goldens/plan/parameter-links.txt
+++ b/tests/goldens/plan/parameter-links.txt
@@ -1,0 +1,54 @@
+# parameter-links
+# macros, modifiers and the order a chain of them resolves in
+#
+# Generated. See tests/test_plan_goldens.cpp to regenerate.
+
+== plan ==
+magda-render-plan v1
+ops=12 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/D7:deviceProcess            in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/D7:deviceGain               in=2:0              out=audio       deps=1
+[  4] Fader       det   T1:trackFader                  in=3:0,-            out=audio       deps=1
+[  5] Meter       det   T1:trackMeter                  in=4:0              out=audio       deps=1
+[  6] Gain        det   T1:trackMute                   in=5:0              out=audio       deps=1
+[  7] MixAudio    det   T-2:trackAudioInput            in=6:0              out=audio       deps=1
+[  8] Fader       det   T-2:trackFader                 in=7:0,-            out=audio       deps=1
+[  9] Meter       det   T-2:trackMeter                 in=8:0              out=audio       deps=1
+[ 10] Gain        det   T-2:trackMute                  in=9:0              out=audio       deps=1
+[ 11] Output      det   T-2:hardwareOutput             in=10:0             out=-           deps=1
+ready=0
+
+== layout ==
+magda-plan-layout v1
+audioSlots=1 midiSlots=0 outputLatency=0
+[  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
+[  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
+[  2] Device      T1/D7:deviceProcess            lat=0       ports=a0          inplace
+[  3] Gain        T1/D7:deviceGain               lat=0       ports=a0          inplace
+[  4] Fader       T1:trackFader                  lat=0       ports=a0          inplace
+[  5] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
+[  6] Gain        T1:trackMute                   lat=0       ports=a0          inplace
+[  7] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
+[  8] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
+[  9] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
+[ 10] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
+[ 11] Output      T-2:hardwareOutput             lat=-       ports=-
+
+== params ==
+magda-param-table v1
+params=6 modifiers=1 links=4
+[  0] T1:macro0                    lin[0.000,1.000] base=1.000  links=0
+[  1] T1:macro1                    lin[0.000,1.000] base=0.500  links=1
+      <- param[  0] amount=0.500 bipolar=0
+[  2] T1/D7:param0                 lin[0.000,100.000] base=0.000  links=1
+      <- param[  1] amount=1.000 bipolar=0
+[  3] T1/D7:param1                 lin[0.000,100.000] base=0.250  links=1
+      <- mod[  0] amount=0.500 bipolar=1
+[  4] T1/D7:param2                 lin[0.000,100.000] base=0.500  links=1
+      <- param[  5] amount=0.500 bipolar=1
+[  5] T1/D7:macro0                 lin[0.000,1.000] base=0.250  links=0
+modifiers:
+[  0] T1:mod0                      value=0.750
+order: 0 1 2 3 5 4

--- a/tests/goldens/plan/rack-chains.txt
+++ b/tests/goldens/plan/rack-chains.txt
@@ -51,3 +51,8 @@ audioSlots=3 midiSlots=0 outputLatency=48
 [ 17] Meter       T-2:trackMeter                 lat=48      ports=a1          inplace
 [ 18] Gain        T-2:trackMute                  lat=48      ports=a1          inplace
 [ 19] Output      T-2:hardwareOutput             lat=-       ports=-
+
+== params ==
+magda-param-table v1
+params=0 modifiers=0 links=0
+order:

--- a/tests/goldens/plan/section-local-device-ids.txt
+++ b/tests/goldens/plan/section-local-device-ids.txt
@@ -41,3 +41,8 @@ audioSlots=1 midiSlots=0 outputLatency=112
 [ 12] Meter       T-2:trackMeter                 lat=112     ports=a0          inplace
 [ 13] Gain        T-2:trackMute                  lat=112     ports=a0          inplace
 [ 14] Output      T-2:hardwareOutput             lat=-       ports=-
+
+== params ==
+magda-param-table v1
+params=0 modifiers=0 links=0
+order:

--- a/tests/goldens/plan/sidechain.txt
+++ b/tests/goldens/plan/sidechain.txt
@@ -53,3 +53,8 @@ audioSlots=3 midiSlots=0 outputLatency=0
 [ 18] Meter       T-2:trackMeter                 lat=0       ports=a1          inplace
 [ 19] Gain        T-2:trackMute                  lat=0       ports=a1          inplace
 [ 20] Output      T-2:hardwareOutput             lat=-       ports=-
+
+== params ==
+magda-param-table v1
+params=0 modifiers=0 links=0
+order:

--- a/tests/test_param_table.cpp
+++ b/tests/test_param_table.cpp
@@ -589,3 +589,67 @@ TEST_CASE("A values publish that changes the parameter shape becomes a structura
     session.process(64, output);
     CHECK(device->firstValue == approx(100.0f));
 }
+
+TEST_CASE("A table of the same size at different addresses is a structural change",
+          "[engine][param][table]") {
+    // The shape that a count cannot see. Two tracks, each with a device and a
+    // macro; the macro that is used moves from the first track to the second.
+    // The table has the same number of parameters and the same widest link
+    // list, and every device window after the change has moved.
+    auto first = makeTrack(1);
+    first.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7, 1)));
+    first.macros[0].value = 1.0f;
+    first.macros[0].links.push_back(
+        MacroLink{ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0), 1.0f, false});
+
+    auto second = makeTrack(2);
+    second.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(8, 1)));
+
+    std::vector<TrackInfo> tracks{first, second};
+    const auto master = makeMaster();
+    const auto plan =
+        std::make_shared<const magda::engine::RenderPlan>(compileRenderPlan(tracks, master));
+
+    magda::engine::PlanValues values;
+    magda::engine::resolvePlanValues(*plan, tracks, master, values);
+
+    RecordingFactory factory;
+    magda::engine::EngineSession session(factory);
+    const magda::engine::RenderContext context{44100.0, 64, 2};
+    REQUIRE(
+        session
+            .publish(plan, context, magda::engine::collectRuntimeStateIds(tracks, master), values)
+            .published);
+
+    juce::AudioBuffer<float> output(2, 64);
+    session.process(64, output);
+
+    auto* early = factory.devices[magda::engine::DeviceKey{ChainSegment::Fx, 7}];
+    auto* late = factory.devices[magda::engine::DeviceKey{ChainSegment::Fx, 8}];
+    REQUIRE(early != nullptr);
+    REQUIRE(late != nullptr);
+    CHECK(early->firstValue == approx(100.0f));
+    CHECK(late->firstValue == approx(0.0f));
+
+    tracks[0].macros[0].links.clear();
+    tracks[1].macros[0].value = 1.0f;
+    tracks[1].macros[0].links.push_back(
+        MacroLink{ControlTarget::pluginParam(ChainNodePath::topLevelDevice(2, 8), 0), 1.0f, false});
+
+    magda::engine::PlanValues moved;
+    magda::engine::resolvePlanValues(*plan, tracks, master, moved);
+    REQUIRE(moved.params->size() == values.params->size());
+    REQUIRE(moved.params->maxLinksPerParam == values.params->maxLinksPerParam);
+    REQUIRE(moved.params->layoutFingerprint != values.params->layoutFingerprint);
+
+    const auto result = session.publishValues(moved);
+    CHECK(result.published);
+    CHECK_FALSE(result.messages.empty());
+
+    session.process(64, output);
+
+    // Each device reads its own parameter rather than the one that used to sit
+    // at its index.
+    CHECK(early->firstValue == approx(0.0f));
+    CHECK(late->firstValue == approx(100.0f));
+}

--- a/tests/test_param_table.cpp
+++ b/tests/test_param_table.cpp
@@ -236,6 +236,36 @@ TEST_CASE("A modulation cycle is reported and broken", "[engine][param][table]")
     CHECK_FALSE(values[table.find(trackMacro(1, 0))].empty());
 }
 
+TEST_CASE("Breaking a cycle costs the cycle and not what hangs off it", "[engine][param][table]") {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7, 1)));
+
+    // Two macros driving each other, and one of them also driving a device
+    // parameter. The device parameter waits on the cycle without being in one:
+    // once the cycle's own links are gone, macro 1 sits at its stored value and
+    // the link reading it is perfectly answerable.
+    track.macros[0].value = 1.0f;
+    track.macros[0].links.push_back(
+        MacroLink{ControlTarget::deviceMacro(ChainNodePath::trackLevel(1), 1), 1.0f, false});
+    track.macros[1].value = 0.5f;
+    track.macros[1].links.push_back(
+        MacroLink{ControlTarget::deviceMacro(ChainNodePath::trackLevel(1), 0), 1.0f, false});
+    track.macros[1].links.push_back(
+        MacroLink{ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0), 1.0f, false});
+
+    const auto table = tableFor({track});
+
+    const auto param = table.find(deviceParam(1, 7, 0));
+    REQUIRE(param != INVALID_PARAM_ID);
+    CHECK(table.linksFor(param).size() == 1);
+    CHECK(resolved(table)[param].value() == approx(50.0f));
+
+    // And the diagnostic names the parameters that are actually in the cycle.
+    CHECK(mentions(table, "T1:macro0: part of a modulation cycle"));
+    CHECK(mentions(table, "T1:macro1: part of a modulation cycle"));
+    CHECK_FALSE(mentions(table, "T1/D7:param0: part of a modulation cycle"));
+}
+
 TEST_CASE("A link the table cannot carry is reported rather than dropped",
           "[engine][param][table]") {
     SECTION("a target this table does not resolve") {
@@ -479,4 +509,83 @@ TEST_CASE("A published table reaches the device that reads it", "[engine][param]
     // that reads 0 to 100, resolved on the audio thread out of a table that
     // travelled with the values.
     CHECK(device->firstValue == approx(50.0f));
+}
+
+TEST_CASE("A refused table renders empty rather than stale", "[engine][param][table]") {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7, 1)));
+    track.macros[0].value = 1.0f;
+    track.macros[0].links.push_back(
+        MacroLink{ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0), 1.0f, false});
+
+    const auto table = tableFor({track});
+
+    ResolvedParams values;
+    values.prepare(table.size());
+    std::vector<ModContribution> scratch(
+        static_cast<std::size_t>(std::max(table.maxLinksPerParam, 1)));
+
+    resolveParams(table, values, scratch, 64);
+    REQUIRE_FALSE(values[0].empty());
+
+    // A table of another shape is refused, and what the last block resolved
+    // goes with it: those values belong to a parameter set this table does not
+    // have, and a device reading them would be holding a frozen project.
+    ParamTable other;
+    other.keys.resize(table.size() + 1);
+    other.specs.resize(table.size() + 1);
+    other.base.resize(table.size() + 1, 0.0f);
+    other.linkOffsets.assign(table.size() + 2, 0);
+
+    resolveParams(other, values, scratch, 64);
+    for (int param = 0; param < values.size(); ++param)
+        CHECK(values[param].empty());
+}
+
+TEST_CASE("A values publish that changes the parameter shape becomes a structural one",
+          "[engine][param][table]") {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7, 1)));
+
+    std::vector<TrackInfo> tracks{track};
+    const auto master = makeMaster();
+    const auto plan =
+        std::make_shared<const magda::engine::RenderPlan>(compileRenderPlan(tracks, master));
+
+    magda::engine::PlanValues values;
+    magda::engine::resolvePlanValues(*plan, tracks, master, values);
+
+    RecordingFactory factory;
+    magda::engine::EngineSession session(factory);
+    const magda::engine::RenderContext context{44100.0, 64, 2};
+
+    REQUIRE(
+        session
+            .publish(plan, context, magda::engine::collectRuntimeStateIds(tracks, master), values)
+            .published);
+
+    juce::AudioBuffer<float> output(2, 64);
+    session.process(64, output);
+
+    auto* device = factory.devices[magda::engine::DeviceKey{ChainSegment::Fx, 7}];
+    REQUIRE(device != nullptr);
+    REQUIRE(device->firstValue == approx(0.0f));
+
+    // Linking a macro for the first time gives it a parameter. The plan does
+    // not change, so this is a values publish by every test the fingerprint can
+    // make, and the table it carries does not fit the room the epoch allocated.
+    tracks[0].macros[0].value = 1.0f;
+    tracks[0].macros[0].links.push_back(
+        MacroLink{ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0), 1.0f, false});
+
+    magda::engine::PlanValues linked;
+    magda::engine::resolvePlanValues(*plan, tracks, master, linked);
+    REQUIRE(linked.params->size() == values.params->size() + 1);
+
+    const auto result = session.publishValues(linked);
+    CHECK(result.published);
+    CHECK_FALSE(result.messages.empty());
+
+    session.process(64, output);
+    CHECK(device->firstValue == approx(100.0f));
 }

--- a/tests/test_param_table.cpp
+++ b/tests/test_param_table.cpp
@@ -1,0 +1,482 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/RackInfo.hpp"
+#include "core/TrackInfo.hpp"
+#include "exec/EngineSession.hpp"
+#include "param/ParamResolve.hpp"
+#include "param/ParamTableCompiler.hpp"
+#include "param/ParamTableDump.hpp"
+#include "plan/PlanCompiler.hpp"
+
+/**
+ * @file test_param_table.cpp
+ * @brief Addressing, the link graph and publication (#2117).
+ *
+ * The lane itself is #2116's; what is asserted here is that the right parameter
+ * is at the right address, that a macro reaches what it is linked to, that the
+ * order a chain of them resolves in is the order that makes each of them right,
+ * and that everything the model can ask for and this cannot do is said out loud.
+ */
+
+using namespace magda;
+using magda::engine::compileParamTable;
+using magda::engine::compileRenderPlan;
+using magda::engine::dumpParamTable;
+using magda::engine::INVALID_PARAM_ID;
+using magda::engine::ModContribution;
+using magda::engine::ParamKey;
+using magda::engine::paramKeyFor;
+using magda::engine::ParamTable;
+using magda::engine::ResolvedParams;
+using magda::engine::resolveParams;
+
+namespace {
+
+Catch::Approx approx(float value) {
+    return Catch::Approx(value).margin(1e-5);
+}
+
+TrackInfo makeTrack(TrackId id) {
+    TrackInfo track;
+    track.id = id;
+    track.name = "Track " + juce::String(id);
+    track.audioOutputDevice = "master";
+    track.macros = createDefaultMacros(2);
+    track.mods = createDefaultMods(0);
+    return track;
+}
+
+TrackInfo makeMaster() {
+    auto master = makeTrack(MASTER_TRACK_ID);
+    master.type = TrackType::Master;
+    master.audioOutputDevice = {};
+    return master;
+}
+
+/// A device whose parameters read 0 to 100, so a normalised position and the
+/// value a device is handed cannot be mistaken for each other.
+DeviceInfo makeDevice(DeviceId id, int numParameters = 2) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Effect " + juce::String(id);
+    device.deviceType = DeviceType::Effect;
+    device.macros = createDefaultMacros(2);
+    device.mods = createDefaultMods(0);
+
+    for (int index = 0; index < numParameters; ++index) {
+        ParameterInfo info(index, "P" + juce::String(index), "%", 0.0f, 100.0f, 0.0f);
+        info.currentValue = 0.0f;
+        device.parameters.push_back(info);
+    }
+
+    return device;
+}
+
+/// The table for one project, compiled against its own plan.
+ParamTable tableFor(std::vector<TrackInfo> tracks, TrackInfo master = makeMaster()) {
+    const auto plan = compileRenderPlan(tracks, master);
+    return compileParamTable(plan, tracks, master);
+}
+
+/// One block resolved out of a table, with the room the resolver needs.
+ResolvedParams resolved(const ParamTable& table, int numSamples = 64) {
+    ResolvedParams values;
+    values.prepare(table.size());
+
+    std::vector<ModContribution> scratch(
+        static_cast<std::size_t>(std::max(table.maxLinksPerParam, 1)));
+    resolveParams(table, values, scratch, numSamples);
+    return values;
+}
+
+ParamKey deviceParam(TrackId track, DeviceId device, int index,
+                     ChainSegment segment = ChainSegment::Fx) {
+    ParamKey key;
+    key.kind = ParamKey::Kind::DeviceParam;
+    key.scope = ParamKey::Scope::Device;
+    key.trackId = track;
+    key.device = magda::engine::DeviceKey{segment, device};
+    key.index = index;
+    return key;
+}
+
+ParamKey trackMacro(TrackId track, int index) {
+    ParamKey key;
+    key.kind = ParamKey::Kind::Macro;
+    key.scope = ParamKey::Scope::Track;
+    key.trackId = track;
+    key.index = index;
+    return key;
+}
+
+bool mentions(const ParamTable& table, const std::string& fragment) {
+    for (const auto& message : table.diagnostics)
+        if (message.find(fragment) != std::string::npos)
+            return true;
+    return false;
+}
+
+}  // namespace
+
+TEST_CASE("A device's parameters are a window indexed from zero", "[engine][param][table]") {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7, 3)));
+
+    const auto table = tableFor({track});
+
+    const auto window = table.windowFor(magda::engine::DeviceKey{ChainSegment::Fx, 7});
+    REQUIRE(window.count == 3);
+    CHECK(table.find(deviceParam(1, 7, 0)) == window.first);
+    CHECK(table.find(deviceParam(1, 7, 2)) == window.first + 2);
+
+    const auto values = resolved(table);
+    const auto device = values.device(window.first, window.count);
+    REQUIRE(device.size() == 3);
+    CHECK(device[0].value() == approx(0.0f));
+}
+
+TEST_CASE("One device id in two sections is two parameters", "[engine][param][table]") {
+    // The collision #2089 found in the plan, asked of the table: the FX and
+    // post-FX sections allocate device ids independently, so the section is
+    // half of a device's identity here too.
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7, 1)));
+
+    PostFxChainElement postFx;
+    postFx.device = makeDevice(7, 1);
+    track.chain.postFxChainElements.push_back(postFx);
+
+    const auto table = tableFor({track});
+
+    const auto fx = table.find(deviceParam(1, 7, 0, ChainSegment::Fx));
+    const auto post = table.find(deviceParam(1, 7, 0, ChainSegment::PostFx));
+    REQUIRE(fx != INVALID_PARAM_ID);
+    REQUIRE(post != INVALID_PARAM_ID);
+    CHECK(fx != post);
+}
+
+TEST_CASE("A macro reaches the parameter it is linked to", "[engine][param][table]") {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7, 1)));
+    track.macros[0].value = 0.5f;
+    track.macros[0].links.push_back(
+        MacroLink{ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0), 0.5f, false});
+
+    const auto table = tableFor({track});
+    REQUIRE(table.diagnostics.empty());
+
+    const auto param = table.find(deviceParam(1, 7, 0));
+    REQUIRE(param != INVALID_PARAM_ID);
+    REQUIRE(table.linksFor(param).size() == 1);
+
+    // Base 0, macro at half, depth a half: a quarter of the way up a range that
+    // reads 0 to 100.
+    const auto values = resolved(table);
+    CHECK(values[param].value() == approx(25.0f));
+}
+
+TEST_CASE("A macro driving a macro resolves in the order that makes both right",
+          "[engine][param][table]") {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7, 1)));
+
+    // Macro 0 drives macro 1, and macro 1 drives the device. Read the other way
+    // round in one pass, the device would see macro 1 as it was stored rather
+    // than as macro 0 leaves it.
+    track.macros[0].value = 1.0f;
+    track.macros[0].links.push_back(
+        MacroLink{ControlTarget::deviceMacro(ChainNodePath::trackLevel(1), 1), 0.5f, false});
+    track.macros[1].value = 0.0f;
+    track.macros[1].links.push_back(
+        MacroLink{ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0), 1.0f, false});
+
+    const auto table = tableFor({track});
+    REQUIRE(table.diagnostics.empty());
+
+    const auto first = table.find(trackMacro(1, 0));
+    const auto second = table.find(trackMacro(1, 1));
+    const auto param = table.find(deviceParam(1, 7, 0));
+
+    // The order is the claim: the source before whatever reads it.
+    const auto position = [&](magda::engine::ParamId id) {
+        return std::find(table.order.begin(), table.order.end(), id) - table.order.begin();
+    };
+    CHECK(position(first) < position(second));
+    CHECK(position(second) < position(param));
+
+    const auto values = resolved(table);
+    CHECK(values[second].value() == approx(0.5f));
+    CHECK(values[param].value() == approx(50.0f));
+}
+
+TEST_CASE("A modulation cycle is reported and broken", "[engine][param][table]") {
+    auto track = makeTrack(1);
+    track.macros[0].links.push_back(
+        MacroLink{ControlTarget::deviceMacro(ChainNodePath::trackLevel(1), 1), 1.0f, false});
+    track.macros[1].links.push_back(
+        MacroLink{ControlTarget::deviceMacro(ChainNodePath::trackLevel(1), 0), 1.0f, false});
+
+    const auto table = tableFor({track});
+
+    CHECK(mentions(table, "modulation cycle"));
+
+    // Every parameter still resolves, and every parameter is still in the
+    // order: a link that cannot be honoured costs the link rather than the
+    // parameters it was between.
+    CHECK(static_cast<int>(table.order.size()) == table.size());
+    CHECK(table.linksFor(table.find(trackMacro(1, 0))).empty());
+    CHECK(table.linksFor(table.find(trackMacro(1, 1))).empty());
+
+    const auto values = resolved(table);
+    CHECK_FALSE(values[table.find(trackMacro(1, 0))].empty());
+}
+
+TEST_CASE("A link the table cannot carry is reported rather than dropped",
+          "[engine][param][table]") {
+    SECTION("a target this table does not resolve") {
+        auto track = makeTrack(1);
+        track.macros[0].links.push_back(MacroLink{ControlTarget::trackVolume(1), 1.0f, false});
+
+        const auto table = tableFor({track});
+        CHECK(mentions(table, "does not carry yet"));
+    }
+
+    SECTION("a parameter the project does not have") {
+        auto track = makeTrack(1);
+        track.macros[0].links.push_back(MacroLink{
+            ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 99), 0), 1.0f, false});
+
+        const auto table = tableFor({track});
+        CHECK(mentions(table, "which the project does not have"));
+    }
+
+    SECTION("a modifier parameter, which arrives with the engines") {
+        auto track = makeTrack(1);
+        track.macros[0].links.push_back(
+            MacroLink{ControlTarget::modParam(ChainNodePath::trackLevel(1), 0, 0), 1.0f, false});
+
+        const auto table = tableFor({track});
+        CHECK(mentions(table, "#2119"));
+    }
+}
+
+TEST_CASE("A modifier is a source with the model's own reading", "[engine][param][table]") {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7, 1)));
+    track.mods = createDefaultMods(1);
+    track.mods[0].value = 0.25f;
+    track.mods[0].links.push_back(ModLink{
+        ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0), 1.0f, false, true});
+
+    SECTION("running") {
+        const auto table = tableFor({track});
+        REQUIRE(table.modifiers.size() == 1);
+        CHECK(table.modifiers.front().value == approx(0.25f));
+
+        const auto values = resolved(table);
+        CHECK(values[table.find(deviceParam(1, 7, 0))].value() == approx(25.0f));
+    }
+
+    SECTION("switched off, which is not the same as sitting at zero") {
+        track.mods[0].enabled = false;
+
+        const auto table = tableFor({track});
+        CHECK(table.modifiers.front().value == approx(0.0f));
+        CHECK(resolved(table)[table.find(deviceParam(1, 7, 0))].value() == approx(0.0f));
+    }
+
+    SECTION("drawn as a level, applied as its complement") {
+        track.mods[0].invertOutput = true;
+
+        const auto table = tableFor({track});
+        CHECK(table.modifiers.front().value == approx(0.75f));
+    }
+
+    SECTION("a link the model keeps but does not apply") {
+        track.mods[0].links[0].enabled = false;
+
+        const auto table = tableFor({track});
+        CHECK(table.linksFor(table.find(deviceParam(1, 7, 0))).empty());
+        CHECK(table.diagnostics.empty());
+    }
+}
+
+TEST_CASE("A macro nothing uses is not worth a slot", "[engine][param][table]") {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7, 1)));
+
+    // Every scope in the model comes with macros whether or not anything uses
+    // them, and a project of any size would spend most of its table on knobs
+    // with nothing behind them.
+    const auto bare = tableFor({track});
+    CHECK(bare.find(trackMacro(1, 0)) == INVALID_PARAM_ID);
+
+    // Driven by something rather than driving something: still a parameter,
+    // because a modifier writing to it needs somewhere to write.
+    track.mods = createDefaultMods(1);
+    track.mods[0].links.push_back(
+        ModLink{ControlTarget::deviceMacro(ChainNodePath::trackLevel(1), 0), 1.0f, false, true});
+
+    const auto driven = tableFor({track});
+    CHECK(driven.find(trackMacro(1, 0)) != INVALID_PARAM_ID);
+    CHECK(driven.diagnostics.empty());
+}
+
+TEST_CASE("A macro inside a rack addresses the device inside it", "[engine][param][table]") {
+    RackInfo rack;
+    rack.id = 4;
+    rack.macros = createDefaultMacros(1);
+    rack.mods = createDefaultMods(0);
+
+    ChainInfo chain;
+    chain.id = 10;
+    chain.elements.push_back(makeDeviceElement(makeDevice(90, 1)));
+    rack.chains.push_back(std::move(chain));
+
+    rack.macros[0].value = 1.0f;
+    rack.macros[0].links.push_back(MacroLink{
+        ControlTarget::pluginParam(ChainNodePath::chainDevice(1, 4, 10, 90), 0), 1.0f, false});
+
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
+
+    const auto table = tableFor({track});
+    REQUIRE(table.diagnostics.empty());
+
+    ParamKey key = deviceParam(1, 90, 0);
+    key.rackId = 4;
+
+    const auto param = table.find(key);
+    REQUIRE(param != INVALID_PARAM_ID);
+    CHECK(resolved(table)[param].value() == approx(100.0f));
+}
+
+TEST_CASE("An address the model cannot mean resolves to nothing", "[engine][param][table]") {
+    CHECK_FALSE(paramKeyFor(ControlTarget::trackVolume(1)).has_value());
+    CHECK_FALSE(paramKeyFor(ControlTarget::sendLevel(1, 0)).has_value());
+    CHECK_FALSE(paramKeyFor(ControlTarget::tempo()).has_value());
+
+    // A chain owns no macros and no modifiers: they live on tracks, racks and
+    // devices, and a chain is what sits between two of them.
+    CHECK_FALSE(
+        paramKeyFor(ControlTarget::deviceMacro(ChainNodePath::chain(1, 4, 10), 0)).has_value());
+
+    const auto device =
+        paramKeyFor(ControlTarget::pluginParam(ChainNodePath::postFxDevice(1, 7), 3));
+    REQUIRE(device.has_value());
+    CHECK(device->device.segment == ChainSegment::PostFx);
+    CHECK(device->index == 3);
+}
+
+TEST_CASE("A table belongs to the plan it was resolved against", "[engine][param][table]") {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7, 1)));
+
+    const std::vector<TrackInfo> tracks{track};
+    const auto master = makeMaster();
+    const auto plan = compileRenderPlan(tracks, master);
+    const auto table = compileParamTable(plan, tracks, master);
+
+    CHECK(table.planFingerprint == planFingerprint(plan));
+
+    // Answers prepared for a different size are refused whole rather than
+    // resolved partly: the two are indexed by the same ParamId.
+    ResolvedParams values;
+    values.prepare(table.size() + 1);
+    values.beginBlock(32);
+
+    std::vector<ModContribution> scratch(1);
+    resolveParams(table, values, scratch, 32);
+    CHECK(values[0].empty());
+}
+
+TEST_CASE("The table dumps as canonical text", "[engine][param][table]") {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7, 1)));
+    track.macros[0].value = 0.5f;
+    track.macros[0].links.push_back(
+        MacroLink{ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0), 0.5f, false});
+
+    const auto text = dumpParamTable(tableFor({track}));
+
+    CHECK(text.find("magda-param-table v1") == 0);
+    CHECK(text.find("T1:macro0") != std::string::npos);
+    CHECK(text.find("T1/D7:param0") != std::string::npos);
+    CHECK(text.find("amount=0.500") != std::string::npos);
+    CHECK(text.find("order:") != std::string::npos);
+
+    // Twice from one model is twice the same text, which is what a golden
+    // needs of it.
+    CHECK(dumpParamTable(tableFor({track})) == text);
+}
+
+namespace {
+
+/// A device that reports what its first parameter was worth when it ran, which
+/// is the only way to ask whether the table reached the audio thread at all.
+class RecordingDevice final : public magda::engine::EngineDevice {
+  public:
+    void process(magda::engine::DeviceBlock& block) override {
+        sawParameters = block.params.size();
+        firstValue = block.params[0].value();
+    }
+
+    int sawParameters = -1;
+    float firstValue = -1.0f;
+};
+
+class RecordingFactory final : public magda::engine::RuntimeStateFactory {
+  public:
+    std::unique_ptr<magda::engine::EngineDevice> createDevice(
+        magda::engine::DeviceKey key) override {
+        auto device = std::make_unique<RecordingDevice>();
+        devices[key] = device.get();
+        return device;
+    }
+
+    std::map<magda::engine::DeviceKey, RecordingDevice*> devices;
+};
+
+}  // namespace
+
+TEST_CASE("A published table reaches the device that reads it", "[engine][param][table]") {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7, 1)));
+    track.macros[0].value = 1.0f;
+    track.macros[0].links.push_back(
+        MacroLink{ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0), 0.5f, false});
+
+    const std::vector<TrackInfo> tracks{track};
+    const auto master = makeMaster();
+    const auto plan =
+        std::make_shared<const magda::engine::RenderPlan>(compileRenderPlan(tracks, master));
+
+    magda::engine::PlanValues values;
+    magda::engine::resolvePlanValues(*plan, tracks, master, values);
+    REQUIRE(values.params != nullptr);
+
+    RecordingFactory factory;
+    magda::engine::EngineSession session(factory);
+
+    const magda::engine::RenderContext context{44100.0, 64, 2};
+    const auto result = session.publish(
+        plan, context, magda::engine::collectRuntimeStateIds(tracks, master), values);
+    REQUIRE(result.published);
+
+    juce::AudioBuffer<float> output(2, 64);
+    session.process(64, output);
+
+    auto* device = factory.devices[magda::engine::DeviceKey{ChainSegment::Fx, 7}];
+    REQUIRE(device != nullptr);
+    CHECK(device->sawParameters == 1);
+
+    // Base at nothing, macro at everything, depth a half: halfway up a range
+    // that reads 0 to 100, resolved on the audio thread out of a table that
+    // travelled with the values.
+    CHECK(device->firstValue == approx(50.0f));
+}

--- a/tests/test_plan_goldens.cpp
+++ b/tests/test_plan_goldens.cpp
@@ -10,6 +10,8 @@
 #include "PlanGoldenFixtures.hpp"
 #include "TextDifference.hpp"
 #include "exec/PlanLayoutDump.hpp"
+#include "param/ParamTableCompiler.hpp"
+#include "param/ParamTableDump.hpp"
 #include "plan/PlanCompiler.hpp"
 #include "plan/PlanCrossfade.hpp"
 #include "plan/PlanDiff.hpp"
@@ -111,6 +113,14 @@ std::string renderGolden(const goldens::Fixture& fixture) {
     out << "== plan ==\n" << engine::dumpPlan(plan) << "\n";
     out << "== layout ==\n"
         << engine::dumpPlanLayout(plan, deviceLatencyPerOp(plan, fixture.deviceLatency)) << "\n";
+
+    // The parameters resolved against the same plan (#2117). Here rather than
+    // in a file of their own for the reason the layout is: a model change moves
+    // the graph and the parameters at once, and two files would make one
+    // decision look like two regressions.
+    out << "== params ==\n"
+        << engine::dumpParamTable(engine::compileParamTable(plan, fixture.tracks, fixture.master))
+        << "\n";
 
     if (fixture.editedTracks.empty())
         return out.str();


### PR DESCRIPTION
Closes #2117. Slice 2 of #1891.

#2116 built the lane a device reads and left nothing filling it. This is where the values come from, how a link finds the parameter it drives, and how both reach the audio thread.

## Addressing

The model addresses a parameter with a `ControlTarget`: a path through the track, rack and chain hierarchy. Every consumer in MAGDA speaks it, which makes it the right thing to translate from and the wrong thing to carry into a block, since it holds a vector of steps and says where a parameter is by describing the walk to it.

`ParamKey` is that address flattened, the way `OpKey` is a model location flattened for the plan: no heap, comparable, hashable, and it names the owner rather than the route. `paramKeyFor` is the one translation between the two, so a target that resolves differently in two places is not a thing that can happen.

## Publication

The table is compiled off the audio thread beside the op values, over the same model, against the same plan, and it travels **inside** `PlanValues` rather than beside it. A fader move and a knob move are then one publish, one fingerprint and one thing that can go out of step with a plan swap rather than two. It is a `shared_ptr`, so a fader move that changed no parameter republishes the pointer it already had.

The executor sizes its per-block room and its per-op device windows when the plan is prepared, and resolves the whole table at the top of every block, before any op runs. Both executors, through one call: the reference one and the parallel one have to agree about when a parameter is settled, and a second answer would be a race.

An end-to-end case publishes a project through `EngineSession` and asserts what the device saw on the audio thread: a macro at full, a link at half depth, a parameter reading 0 to 100, and 50 arriving inside `process()`.

## Links, and the order they resolve in

A link is what a macro or a modifier does to a parameter, with the depth and polarity MAGDA keeps per link. Sources resolve in a topological order baked with the table, so a macro driving a macro driving a device parameter is one pass rather than a fixed point, and the golden pins the order rather than the arithmetic.

A cycle is broken where it is found: the links inside it are dropped, with a diagnostic, and every parameter still resolves. A parameter is worth more than the link that made it impossible.

## What is worth a slot

Every scope in the model comes with sixteen macros whether or not anything is wired to them. A project of any size would spend most of its table on knobs with nothing behind them, so a macro is carried when it drives something or something drives it — the second half matters, because a macro a modifier writes to needs somewhere to be written.

Modifiers are sources with an identity and the model's own reading of their output, constant until the engines land in #2119 and #2120. Two things that are already invariants rather than implementation are applied here: an inactive modifier outputs nothing, and a curve drawn as a level is applied as its complement.

## Reported rather than dropped

Three things the model can ask for and this cannot do:

- **the mixer values**, which `PlanValues` resolves per op. Nothing can move them faster than a publish yet, so it costs nothing today; #2118 is where a lane makes them move per block, and the crossover is written into that issue.
- **the tempo**, which belongs to the transport.
- **a modifier's own parameters**, which arrive with the engines that define them. The rate's scale is the modifier's knowledge, and duplicating it here to be replaced in two slices is how two answers to one question start.

## Goldens

The dump joins the plan goldens as a third section (#2076), with a `parameter-links` fixture carrying the parameters, macros, modifier and macro-to-macro chain the graph fixtures have no reason to have. Existing goldens gain five lines each.

## Testing

`make test` green locally: 2719 cases, 588139 assertions, 0 failures. `make test-juce` green. Twenty new cases across `test_param_table.cpp` and the goldens.
