### PR TITLE
Play a lane over a parameter, and over a fader (#2118)

### DIFF
--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -261,6 +261,9 @@ juce_add_binary_data(MagdaAssets
 # include-boundary guard) lands with the device-library carve (#1834).
 add_library(magda_types STATIC
     core/ParameterUtils.cpp
+    # The shape of an automation lane, on its own, so the engine bakes a curve
+    # through the same function the editor draws it with (#2118).
+    core/AutomationCurve.cpp
     core/DeviceState.cpp
     # Clip placement rules (#2003). Pure, beat domain, no manager: they answer
     # against a lane of clips, which is what lets the arrangement ask about a
@@ -279,6 +282,8 @@ add_library(magda_types STATIC
     core/ControlTarget.hpp
     core/ParameterInfo.hpp
     core/ParameterUtils.hpp
+    core/AutomationCurve.hpp
+    core/AutomationInfo.hpp
     core/DeviceInfo.hpp
     core/DeviceState.hpp
     core/KitRow.hpp

--- a/magda/daw/core/AutomationCurve.cpp
+++ b/magda/daw/core/AutomationCurve.cpp
@@ -9,6 +9,20 @@ namespace magda::automation {
 
 namespace {
 
+/// The point that opens the segment containing @p beat, for a curve known to
+/// have one. Binary rather than linear: this is called per block per automated
+/// parameter, and a lane is as long as the arrangement.
+const AutomationPoint* openingBefore(std::span<const AutomationPoint> points, double beat) {
+    const auto after = std::upper_bound(
+        points.begin(), points.end(), beat,
+        [](double value, const AutomationPoint& point) { return value < point.beatPosition; });
+
+    if (after == points.begin() || after == points.end())
+        return nullptr;
+
+    return &*(after - 1);
+}
+
 double interpolateBezier(double t, const AutomationPoint& p1, const AutomationPoint& p2) {
     // The editor renders the PARAMETRIC cubic (handles offset the control
     // points in x too), so evaluating the value cubic at t-linear-in-x
@@ -68,6 +82,31 @@ double evalLinearSegment(double t, const AutomationPoint& p1, const AutomationPo
 
 }  // namespace
 
+std::optional<HardCorner> hardCornerOf(const AutomationPoint& p1, const AutomationPoint& p2) {
+    if (p1.curveType != AutomationCurveType::HardCorner)
+        return std::nullopt;
+
+    const double duration = p2.beatPosition - p1.beatPosition;
+    if (duration <= 0.0)
+        return std::nullopt;
+
+    // The apex the shaper handle was dragged to, or the midpoint of a corner
+    // nobody has bent yet.
+    if (p1.outHandle.isZero())
+        return HardCorner{p1.beatPosition + 0.5 * duration, (p1.value + p2.value) * 0.5};
+
+    const double apexT = juce::jlimit(1.0e-4, 1.0 - 1.0e-4, p1.outHandle.beatOffset / duration);
+    return HardCorner{p1.beatPosition + apexT * duration, p1.value + p1.outHandle.value};
+}
+
+const AutomationPoint* segmentOpening(std::span<const AutomationPoint> points, double beat) {
+    if (points.size() < 2 || beat < points.front().beatPosition ||
+        beat >= points.back().beatPosition)
+        return nullptr;
+
+    return openingBefore(points, beat);
+}
+
 double valueAtBeat(std::span<const AutomationPoint> points, double beatPosition) {
     if (points.empty())
         return 0.5;
@@ -80,44 +119,42 @@ double valueAtBeat(std::span<const AutomationPoint> points, double beatPosition)
     if (beatPosition >= points.back().beatPosition)
         return points.back().value;
 
-    // Find surrounding points
-    for (size_t i = 0; i < points.size() - 1; ++i) {
-        const auto& p1 = points[i];
-        const auto& p2 = points[i + 1];
+    // The segment the beat falls in, found rather than walked to: a lane is in
+    // beat order, and an unrolled looping clip over a long arrangement is
+    // thousands of points that a block would otherwise skip past every time it
+    // asked (#2118 review).
+    const auto* opener = openingBefore(points, beatPosition);
+    if (opener == nullptr)
+        return 0.5;
 
-        if (beatPosition >= p1.beatPosition && beatPosition < p2.beatPosition) {
-            // Normalize t to 0-1 between points
-            double duration = p2.beatPosition - p1.beatPosition;
-            if (duration <= 0.0)
+    const auto& p1 = *opener;
+    const auto& p2 = *(opener + 1);
+
+    const double duration = p2.beatPosition - p1.beatPosition;
+    if (duration <= 0.0)
+        return p1.value;
+
+    const double t = (beatPosition - p1.beatPosition) / duration;
+
+    switch (p1.curveType) {
+        case AutomationCurveType::Linear:
+            return evalLinearSegment(t, p1, p2);
+
+        case AutomationCurveType::Bezier:
+            return interpolateBezier(t, p1, p2);
+
+        case AutomationCurveType::Step:
+            return p1.value;  // Hold until next point
+
+        case AutomationCurveType::HardCorner: {
+            const auto corner = hardCornerOf(p1, p2);
+            if (!corner.has_value())
                 return p1.value;
 
-            double t = (beatPosition - p1.beatPosition) / duration;
-
-            switch (p1.curveType) {
-                case AutomationCurveType::Linear:
-                    return evalLinearSegment(t, p1, p2);
-
-                case AutomationCurveType::Bezier:
-                    return interpolateBezier(t, p1, p2);
-
-                case AutomationCurveType::Step:
-                    return p1.value;  // Hold until next point
-
-                case AutomationCurveType::HardCorner: {
-                    // Two straight segments meeting at the apex (from the
-                    // shaper handle), or the midpoint when no apex was dragged.
-                    double apexT = 0.5;
-                    double apexValue = (p1.value + p2.value) * 0.5;
-                    if (!p1.outHandle.isZero()) {
-                        apexT =
-                            juce::jlimit(1.0e-4, 1.0 - 1.0e-4, p1.outHandle.beatOffset / duration);
-                        apexValue = p1.value + p1.outHandle.value;
-                    }
-                    if (t < apexT)
-                        return p1.value + (t / apexT) * (apexValue - p1.value);
-                    return apexValue + ((t - apexT) / (1.0 - apexT)) * (p2.value - apexValue);
-                }
-            }
+            const double apexT = (corner->beat - p1.beatPosition) / duration;
+            if (t < apexT)
+                return p1.value + (t / apexT) * (corner->value - p1.value);
+            return corner->value + ((t - apexT) / (1.0 - apexT)) * (p2.value - corner->value);
         }
     }
 

--- a/magda/daw/core/AutomationCurve.cpp
+++ b/magda/daw/core/AutomationCurve.cpp
@@ -1,0 +1,166 @@
+#include "AutomationCurve.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "CurveMath.hpp"
+
+namespace magda::automation {
+
+namespace {
+
+double interpolateBezier(double t, const AutomationPoint& p1, const AutomationPoint& p2) {
+    // The editor renders the PARAMETRIC cubic (handles offset the control
+    // points in x too), so evaluating the value cubic at t-linear-in-x
+    // drifts off the drawn line whenever a handle has a beat offset. Solve
+    // the x cubic for the parameter s where the curve crosses the queried
+    // beat, then evaluate the value cubic there.
+    const double x0 = p1.beatPosition;
+    const double x3 = p2.beatPosition;
+    const double x1 = x0 + p1.outHandle.beatOffset;
+    const double x2 = x3 + p2.inHandle.beatOffset;
+    const double target = x0 + t * (x3 - x0);
+
+    const auto xAt = [&](double s) {
+        const double ms = 1.0 - s;
+        return ms * ms * ms * x0 + 3.0 * ms * ms * s * x1 + 3.0 * ms * s * s * x2 + s * s * s * x3;
+    };
+    const auto dxAt = [&](double s) {
+        const double ms = 1.0 - s;
+        return 3.0 * ms * ms * (x1 - x0) + 6.0 * ms * s * (x2 - x1) + 3.0 * s * s * (x3 - x2);
+    };
+
+    // Newton with a t seed; clamped so overshooting handles can't escape the
+    // segment. A handful of iterations reaches sub-sample accuracy.
+    double s = t;
+    for (int i = 0; i < 12; ++i) {
+        const double err = xAt(s) - target;
+        if (std::abs(err) < 1.0e-6 * (x3 - x0 + 1.0))
+            break;
+        const double slope = dxAt(s);
+        if (std::abs(slope) < 1.0e-9)
+            break;
+        s = std::clamp(s - err / slope, 0.0, 1.0);
+    }
+
+    const double s2 = s * s;
+    const double s3 = s2 * s;
+    const double ms = 1.0 - s;
+    const double ms2 = ms * ms;
+    const double ms3 = ms2 * ms;
+    const double cp1Value = p1.value + p1.outHandle.value;
+    const double cp2Value = p2.value + p2.inHandle.value;
+    return ms3 * p1.value + 3.0 * ms2 * s * cp1Value + 3.0 * ms * s2 * cp2Value + s3 * p2.value;
+}
+
+// Linear-type segments (pure, tension, or shaper-bent) evaluate through the
+// SHARED curvemath::evalSegment — the same function the editor samples when
+// drawing and the modulator engine outputs — so the played value sits exactly
+// on the drawn curve. (The old local quadratic/power copies here had drifted
+// from the renderer.) t is the x-fraction along the segment.
+double evalLinearSegment(double t, const AutomationPoint& p1, const AutomationPoint& p2) {
+    const bool hasShaper = !p1.outHandle.isZero() || !p2.inHandle.isZero();
+    const double controlY = p1.value + p1.outHandle.value;
+    return static_cast<double>(curvemath::evalSegment(
+        static_cast<float>(p1.value), static_cast<float>(p2.value), static_cast<float>(controlY),
+        static_cast<float>(p1.tension), hasShaper, static_cast<float>(t)));
+}
+
+}  // namespace
+
+double valueAtBeat(std::span<const AutomationPoint> points, double beatPosition) {
+    if (points.empty())
+        return 0.5;
+
+    // Before first point
+    if (beatPosition <= points.front().beatPosition)
+        return points.front().value;
+
+    // After last point
+    if (beatPosition >= points.back().beatPosition)
+        return points.back().value;
+
+    // Find surrounding points
+    for (size_t i = 0; i < points.size() - 1; ++i) {
+        const auto& p1 = points[i];
+        const auto& p2 = points[i + 1];
+
+        if (beatPosition >= p1.beatPosition && beatPosition < p2.beatPosition) {
+            // Normalize t to 0-1 between points
+            double duration = p2.beatPosition - p1.beatPosition;
+            if (duration <= 0.0)
+                return p1.value;
+
+            double t = (beatPosition - p1.beatPosition) / duration;
+
+            switch (p1.curveType) {
+                case AutomationCurveType::Linear:
+                    return evalLinearSegment(t, p1, p2);
+
+                case AutomationCurveType::Bezier:
+                    return interpolateBezier(t, p1, p2);
+
+                case AutomationCurveType::Step:
+                    return p1.value;  // Hold until next point
+
+                case AutomationCurveType::HardCorner: {
+                    // Two straight segments meeting at the apex (from the
+                    // shaper handle), or the midpoint when no apex was dragged.
+                    double apexT = 0.5;
+                    double apexValue = (p1.value + p2.value) * 0.5;
+                    if (!p1.outHandle.isZero()) {
+                        apexT =
+                            juce::jlimit(1.0e-4, 1.0 - 1.0e-4, p1.outHandle.beatOffset / duration);
+                        apexValue = p1.value + p1.outHandle.value;
+                    }
+                    if (t < apexT)
+                        return p1.value + (t / apexT) * (apexValue - p1.value);
+                    return apexValue + ((t - apexT) / (1.0 - apexT)) * (p2.value - apexValue);
+                }
+            }
+        }
+    }
+
+    return 0.5;
+}
+
+double laneValueAtBeat(const AutomationLaneInfo& lane,
+                       const std::function<const AutomationClipInfo*(AutomationClipId)>& getClip,
+                       double beatPosition) {
+    if (lane.isAbsolute())
+        return valueAtBeat(lane.absolutePoints, beatPosition);
+
+    // Clip-based: find clip containing beat position
+    for (auto clipId : lane.clipIds) {
+        const auto* clip = getClip(clipId);
+        if (clip && clip->containsBeat(beatPosition)) {
+            double localBeatPosition = clip->getLocalBeat(beatPosition);
+            return valueAtBeat(clip->points, localBeatPosition);
+        }
+    }
+
+    // Gap between clips: hold the nearest clip edge — the previous clip's
+    // final value, or before the first clip, the first clip's initial value.
+    const AutomationClipInfo* prevClip = nullptr;  // greatest end <= beat
+    const AutomationClipInfo* nextClip = nullptr;  // smallest start > beat
+    for (auto clipId : lane.clipIds) {
+        const auto* clip = getClip(clipId);
+        if (!clip)
+            continue;
+        if (clip->getEndBeats() <= beatPosition) {
+            if (!prevClip || clip->getEndBeats() > prevClip->getEndBeats())
+                prevClip = clip;
+        } else if (clip->startBeats > beatPosition) {
+            if (!nextClip || clip->startBeats < nextClip->startBeats)
+                nextClip = clip;
+        }
+    }
+    if (prevClip)
+        return valueAtBeat(prevClip->points, prevClip->getEndLocalBeat());
+    if (nextClip)
+        return valueAtBeat(nextClip->points, 0.0);
+
+    return 0.5;  // Lane has no clips at all
+}
+
+}  // namespace magda::automation

--- a/magda/daw/core/AutomationCurve.hpp
+++ b/magda/daw/core/AutomationCurve.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <functional>
+#include <span>
+
+#include "AutomationInfo.hpp"
+
+/**
+ * @file AutomationCurve.hpp
+ * @brief What a breakpoint list is worth at a beat.
+ *
+ * The shape of a lane, on its own: no manager, no singleton, no lane and no
+ * clip, so the audio engine can bake a curve (#2118) through the same function
+ * the editor draws it with and AutomationManager plays it with. Two readings of
+ * one curve is a project that sounds different from the way it looks.
+ *
+ * Pure and allocation-free.
+ */
+
+namespace magda::automation {
+
+/**
+ * @brief The value of @p points at @p beat.
+ *
+ * Points are in beat order. Before the first and after the last the curve
+ * holds, which is what makes a lane cover the whole timeline once it has a
+ * point on it at all. An empty list has no value to give and answers the middle
+ * of the range, as every other reading of an empty curve in MAGDA does.
+ *
+ * Each segment is shaped by the curve type of the point that opens it: a linear
+ * one through the shared bend (curvemath::evalSegment), a bezier through the
+ * parametric cubic solved for the queried beat, a step held, and a hard corner
+ * as two straight runs meeting at its apex.
+ */
+double valueAtBeat(std::span<const AutomationPoint> points, double beat);
+
+/**
+ * @brief The value of a whole lane at a timeline beat.
+ *
+ * An absolute lane is its points. A clip-based one is whichever clip contains
+ * the beat, read at its local position so a looping clip repeats; between clips
+ * the lane holds the nearest edge, which is what makes a gap a plateau rather
+ * than a jump to nowhere.
+ *
+ * @p getClip resolves a clip id, because a lane names its clips and does not
+ * own them. Returning null for one is a clip the lane lists and the project has
+ * lost, and it is skipped rather than guessed at.
+ */
+double laneValueAtBeat(const AutomationLaneInfo& lane,
+                       const std::function<const AutomationClipInfo*(AutomationClipId)>& getClip,
+                       double beat);
+
+}  // namespace magda::automation

--- a/magda/daw/core/AutomationCurve.hpp
+++ b/magda/daw/core/AutomationCurve.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 #include <span>
 
 #include "AutomationInfo.hpp"
@@ -33,6 +34,31 @@ namespace magda::automation {
  * as two straight runs meeting at its apex.
  */
 double valueAtBeat(std::span<const AutomationPoint> points, double beat);
+
+/** @brief Where a hard corner turns, and what it is worth there. */
+struct HardCorner {
+    double beat = 0.0;
+    double value = 0.0;
+};
+
+/**
+ * @brief The apex of the hard corner between @p p1 and @p p2, if it is one.
+ *
+ * The shape of a hard corner is two straight runs meeting at a point, and that
+ * point is a knot: anything sampling the curve at its breakpoints alone would
+ * miss it and draw one straight line where the curve has two. Exposed for the
+ * engine's bake, which has to know where a curve changes direction (#2118).
+ */
+std::optional<HardCorner> hardCornerOf(const AutomationPoint& p1, const AutomationPoint& p2);
+
+/**
+ * @brief The point that opens the segment @p beat falls in, or null.
+ *
+ * Null before the first point, at or after the last, and for a curve with
+ * fewer than two. What it is for is the curve type: a step holds and a bend
+ * does not, and whoever is sampling a segment has to know which it is in.
+ */
+const AutomationPoint* segmentOpening(std::span<const AutomationPoint> points, double beat);
 
 /**
  * @brief The value of a whole lane at a timeline beat.

--- a/magda/daw/core/AutomationManager.cpp
+++ b/magda/daw/core/AutomationManager.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <iterator>
 
+#include "AutomationCurve.hpp"
 #include "ClipLaneFlattener.hpp"
 #include "CurveMath.hpp"
 #include "GridDivision.hpp"
@@ -1101,41 +1102,8 @@ double AutomationManager::getValueAtBeat(AutomationLaneId laneId, double beatPos
     if (!lane)
         return 0.5;
 
-    if (lane->isAbsolute()) {
-        return interpolatePoints(lane->absolutePoints, beatPosition);
-    }
-
-    // Clip-based: find clip containing beat position
-    for (auto clipId : lane->clipIds) {
-        const auto* clip = getClip(clipId);
-        if (clip && clip->containsBeat(beatPosition)) {
-            double localBeatPosition = clip->getLocalBeat(beatPosition);
-            return interpolatePoints(clip->points, localBeatPosition);
-        }
-    }
-
-    // Gap between clips: hold the nearest clip edge — the previous clip's
-    // final value, or before the first clip, the first clip's initial value.
-    const AutomationClipInfo* prevClip = nullptr;  // greatest end <= beat
-    const AutomationClipInfo* nextClip = nullptr;  // smallest start > beat
-    for (auto clipId : lane->clipIds) {
-        const auto* clip = getClip(clipId);
-        if (!clip)
-            continue;
-        if (clip->getEndBeats() <= beatPosition) {
-            if (!prevClip || clip->getEndBeats() > prevClip->getEndBeats())
-                prevClip = clip;
-        } else if (clip->startBeats > beatPosition) {
-            if (!nextClip || clip->startBeats < nextClip->startBeats)
-                nextClip = clip;
-        }
-    }
-    if (prevClip)
-        return interpolatePoints(prevClip->points, prevClip->getEndLocalBeat());
-    if (nextClip)
-        return interpolatePoints(nextClip->points, 0.0);
-
-    return 0.5;  // Lane has no clips at all
+    return automation::laneValueAtBeat(
+        *lane, [this](AutomationClipId clipId) { return getClip(clipId); }, beatPosition);
 }
 
 double AutomationManager::getClipValueAtBeat(AutomationClipId clipId,
@@ -1153,117 +1121,16 @@ double AutomationManager::interpolateLinear(double t, double v1, double v2) cons
 
 double AutomationManager::interpolateBezier(double t, const AutomationPoint& p1,
                                             const AutomationPoint& p2) const {
-    // The editor renders the PARAMETRIC cubic (handles offset the control
-    // points in x too), so evaluating the value cubic at t-linear-in-x
-    // drifts off the drawn line whenever a handle has a beat offset. Solve
-    // the x cubic for the parameter s where the curve crosses the queried
-    // beat, then evaluate the value cubic there.
-    const double x0 = p1.beatPosition;
-    const double x3 = p2.beatPosition;
-    const double x1 = x0 + p1.outHandle.beatOffset;
-    const double x2 = x3 + p2.inHandle.beatOffset;
-    const double target = x0 + t * (x3 - x0);
-
-    const auto xAt = [&](double s) {
-        const double ms = 1.0 - s;
-        return ms * ms * ms * x0 + 3.0 * ms * ms * s * x1 + 3.0 * ms * s * s * x2 + s * s * s * x3;
-    };
-    const auto dxAt = [&](double s) {
-        const double ms = 1.0 - s;
-        return 3.0 * ms * ms * (x1 - x0) + 6.0 * ms * s * (x2 - x1) + 3.0 * s * s * (x3 - x2);
-    };
-
-    // Newton with a t seed; clamped so overshooting handles can't escape the
-    // segment. A handful of iterations reaches sub-sample accuracy.
-    double s = t;
-    for (int i = 0; i < 12; ++i) {
-        const double err = xAt(s) - target;
-        if (std::abs(err) < 1.0e-6 * (x3 - x0 + 1.0))
-            break;
-        const double slope = dxAt(s);
-        if (std::abs(slope) < 1.0e-9)
-            break;
-        s = std::clamp(s - err / slope, 0.0, 1.0);
-    }
-
-    const double s2 = s * s;
-    const double s3 = s2 * s;
-    const double ms = 1.0 - s;
-    const double ms2 = ms * ms;
-    const double ms3 = ms2 * ms;
-    const double cp1Value = p1.value + p1.outHandle.value;
-    const double cp2Value = p2.value + p2.inHandle.value;
-    return ms3 * p1.value + 3.0 * ms2 * s * cp1Value + 3.0 * ms * s2 * cp2Value + s3 * p2.value;
-}
-
-// Linear-type segments (pure, tension, or shaper-bent) evaluate through the
-// SHARED curvemath::evalSegment — the same function the editor samples when
-// drawing and the modulator engine outputs — so the played value sits exactly
-// on the drawn curve. (The old local quadratic/power copies here had drifted
-// from the renderer.) t is the x-fraction along the segment.
-static double evalLinearSegment(double t, const AutomationPoint& p1, const AutomationPoint& p2) {
-    const bool hasShaper = !p1.outHandle.isZero() || !p2.inHandle.isZero();
-    const double controlY = p1.value + p1.outHandle.value;
-    return static_cast<double>(curvemath::evalSegment(
-        static_cast<float>(p1.value), static_cast<float>(p2.value), static_cast<float>(controlY),
-        static_cast<float>(p1.tension), hasShaper, static_cast<float>(t)));
+    // Kept as a member because callers outside this file ask for it; the curve
+    // itself lives in core/AutomationCurve.hpp, where the engine can reach it.
+    const std::vector<AutomationPoint> segment{p1, p2};
+    return automation::valueAtBeat(segment,
+                                   p1.beatPosition + t * (p2.beatPosition - p1.beatPosition));
 }
 
 double AutomationManager::interpolatePoints(const std::vector<AutomationPoint>& points,
                                             double beatPosition) const {
-    if (points.empty())
-        return 0.5;
-
-    // Before first point
-    if (beatPosition <= points.front().beatPosition)
-        return points.front().value;
-
-    // After last point
-    if (beatPosition >= points.back().beatPosition)
-        return points.back().value;
-
-    // Find surrounding points
-    for (size_t i = 0; i < points.size() - 1; ++i) {
-        const auto& p1 = points[i];
-        const auto& p2 = points[i + 1];
-
-        if (beatPosition >= p1.beatPosition && beatPosition < p2.beatPosition) {
-            // Normalize t to 0-1 between points
-            double duration = p2.beatPosition - p1.beatPosition;
-            if (duration <= 0.0)
-                return p1.value;
-
-            double t = (beatPosition - p1.beatPosition) / duration;
-
-            switch (p1.curveType) {
-                case AutomationCurveType::Linear:
-                    return evalLinearSegment(t, p1, p2);
-
-                case AutomationCurveType::Bezier:
-                    return interpolateBezier(t, p1, p2);
-
-                case AutomationCurveType::Step:
-                    return p1.value;  // Hold until next point
-
-                case AutomationCurveType::HardCorner: {
-                    // Two straight segments meeting at the apex (from the
-                    // shaper handle), or the midpoint when no apex was dragged.
-                    double apexT = 0.5;
-                    double apexValue = (p1.value + p2.value) * 0.5;
-                    if (!p1.outHandle.isZero()) {
-                        apexT =
-                            juce::jlimit(1.0e-4, 1.0 - 1.0e-4, p1.outHandle.beatOffset / duration);
-                        apexValue = p1.value + p1.outHandle.value;
-                    }
-                    if (t < apexT)
-                        return p1.value + (t / apexT) * (apexValue - p1.value);
-                    return apexValue + ((t - apexT) / (1.0 - apexT)) * (p2.value - apexValue);
-                }
-            }
-        }
-    }
-
-    return 0.5;
+    return automation::valueAtBeat(points, beatPosition);
 }
 
 // ============================================================================

--- a/magda/daw/core/AutomationManager.cpp
+++ b/magda/daw/core/AutomationManager.cpp
@@ -1115,19 +1115,6 @@ double AutomationManager::getClipValueAtBeat(AutomationClipId clipId,
     return interpolatePoints(clip->points, localBeatPosition);
 }
 
-double AutomationManager::interpolateLinear(double t, double v1, double v2) const {
-    return v1 + t * (v2 - v1);
-}
-
-double AutomationManager::interpolateBezier(double t, const AutomationPoint& p1,
-                                            const AutomationPoint& p2) const {
-    // Kept as a member because callers outside this file ask for it; the curve
-    // itself lives in core/AutomationCurve.hpp, where the engine can reach it.
-    const std::vector<AutomationPoint> segment{p1, p2};
-    return automation::valueAtBeat(segment,
-                                   p1.beatPosition + t * (p2.beatPosition - p1.beatPosition));
-}
-
 double AutomationManager::interpolatePoints(const std::vector<AutomationPoint>& points,
                                             double beatPosition) const {
     return automation::valueAtBeat(points, beatPosition);

--- a/magda/daw/core/AutomationManager.hpp
+++ b/magda/daw/core/AutomationManager.hpp
@@ -588,8 +588,6 @@ class AutomationManager : public TrackManagerListener {
     void dispatchAuthorityEvent(AutomationLaneId laneId, AutomationAuthorityEvent event);
 
     // Interpolation helpers
-    double interpolateLinear(double t, double v1, double v2) const;
-    double interpolateBezier(double t, const AutomationPoint& p1, const AutomationPoint& p2) const;
 
     // Point management helpers
     AutomationPoint* findPoint(std::vector<AutomationPoint>& points, AutomationPointId pointId);

--- a/magda/engine/exec/ParallelPlanExecutor.cpp
+++ b/magda/engine/exec/ParallelPlanExecutor.cpp
@@ -191,7 +191,7 @@ void ParallelPlanExecutor::process(const PlanValues& values, const BlockInfo& re
 
     // Before any worker starts: a device reads its parameters, and every op
     // that could be one is about to become runnable.
-    core_.resolveParameters(values, start.block.numSamples);
+    core_.resolveParameters(values, start.block);
 
     block_ = start.block;
     values_ = &values;

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -220,7 +220,9 @@ void PlanExecutor::reset() {
     boundMeterCount_ = 0;
     midiTapForOp_.clear();
     paramWindowForOp_.clear();
+    mixerParamForOp_.clear();
     paramScratch_.clear();
+    paramSegments_.clear();
     paramValues_.prepare(0);
     paramLayout_ = 0;
 }
@@ -251,6 +253,7 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
     meterForOp_.assign(numOps, nullptr);
     midiTapForOp_.assign(numOps, nullptr);
     paramWindowForOp_.assign(numOps, ParamTable::DeviceWindow{});
+    mixerParamForOp_.assign(numOps, OpMixerParams{});
     paramLayout_ = 0;
 
     // The parameters of the table this plan is published with (#2117). Sized
@@ -263,10 +266,34 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
         paramValues_.prepare(params->size());
         paramScratch_.assign(static_cast<std::size_t>(std::max(params->maxLinksPerParam, 0)),
                              ModContribution{});
+        paramSegments_.assign(static_cast<std::size_t>(paramValues_.segmentCapacity()),
+                              ParamSegment{});
 
-        for (std::size_t i = 0; i < numOps; ++i)
-            if (plan.ops[i].kind == OpKind::Device)
-                paramWindowForOp_[i] = params->windowFor(plan.ops[i].key.deviceKey());
+        for (std::size_t i = 0; i < numOps; ++i) {
+            const auto& op = plan.ops[i];
+            if (op.kind == OpKind::Device) {
+                paramWindowForOp_[i] = params->windowFor(op.key.deviceKey());
+                continue;
+            }
+
+            // The two mixer ops a lane can play over. A rack chain's fader and
+            // a rack's output are not addressable in the model, so they keep
+            // the published value and are not looked up.
+            ParamKey key;
+            key.scope = ParamKey::Scope::Track;
+            key.trackId = op.key.trackId;
+
+            if (op.kind == OpKind::Fader && op.key.role == OpRole::TrackFader) {
+                key.kind = ParamKey::Kind::TrackVolume;
+                mixerParamForOp_[i].gain = params->find(key);
+                key.kind = ParamKey::Kind::TrackPan;
+                mixerParamForOp_[i].pan = params->find(key);
+            } else if (op.kind == OpKind::SendTap) {
+                key.kind = ParamKey::Kind::SendLevel;
+                key.index = op.key.index;
+                mixerParamForOp_[i].gain = params->find(key);
+            }
+        }
     }
 
     const auto describe = [&plan](std::size_t index) {
@@ -649,7 +676,7 @@ PlanExecutor::BlockStart PlanExecutor::beginBlock(const PlanValues& values,
     return start;
 }
 
-void PlanExecutor::resolveParameters(const PlanValues& values, int numSamples) {
+void PlanExecutor::resolveParameters(const PlanValues& values, const BlockInfo& block) {
     // Two shapes have to match, and neither is something appliesValues can
     // see: it compares the plan's fingerprint and its op count, and a link
     // edit changes neither. A macro gaining its first link grows the table by
@@ -663,17 +690,17 @@ void PlanExecutor::resolveParameters(const PlanValues& values, int numSamples) {
     // published, and the session escalates a publish of this shape into a
     // structural one so the emptiness lasts a block rather than for ever.
     if (!appliesValues(values) || values.params == nullptr || !fitsParameters(values)) {
-        paramValues_.beginBlock(numSamples);
+        paramValues_.beginBlock(block.numSamples);
         return;
     }
 
-    resolveParams(*values.params, paramValues_, paramScratch_, numSamples);
+    resolveParams(*values.params, paramValues_, paramScratch_, paramSegments_, block);
 }
 
 void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedBlock,
                            juce::AudioBuffer<float>& output) {
     const auto start = beginBlock(values, requestedBlock, output);
-    resolveParameters(values, start.block.numSamples);
+    resolveParameters(values, start.block);
     if (!start.render)
         return;
 
@@ -684,11 +711,39 @@ void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedB
                  output);
 }
 
-void PlanExecutor::renderOp(OpId id, const OpValue& value, const BlockInfo& block,
+OpValue PlanExecutor::mixerValueFor(std::size_t op, const OpValue& published) const {
+    const auto params = mixerParamForOp_[op];
+    if (params.gain == INVALID_PARAM_ID)
+        return published;
+
+    const auto level = paramValues_[params.gain];
+    if (level.empty())
+        return published;
+
+    // Silence is the published table's to say: mute and solo are not
+    // parameters, nothing plays a lane over them, and a fader that moved does
+    // not make a muted track audible.
+    OpValue value = published;
+
+    const auto gain = faderGainFromDecibels(level.value());
+    const auto pan = params.pan == INVALID_PARAM_ID ? ParamValues{} : paramValues_[params.pan];
+
+    if (pan.empty()) {
+        value.gainLeft = gain;
+        value.gainRight = gain;
+    } else {
+        applyLinearPanLaw(gain, faderPanPosition(pan.value()), value.gainLeft, value.gainRight);
+    }
+
+    return value;
+}
+
+void PlanExecutor::renderOp(OpId id, const OpValue& published, const BlockInfo& block,
                             juce::AudioBuffer<float>& output) {
     const auto i = static_cast<std::size_t>(id);
     const auto& op = plan_->ops[i];
     const auto numSamples = block.numSamples;
+    const auto value = mixerValueFor(i, published);
 
     switch (op.kind) {
         case OpKind::ClipAudio:

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -726,6 +726,10 @@ OpValue PlanExecutor::mixerValueFor(std::size_t op, const OpValue& published) co
     OpValue value = published;
 
     const auto gain = faderGainFromDecibels(level.value());
+
+    // A fader carries both or neither (ParamTableCompiler::allocateMixer), so
+    // a pan that is missing here is a send, which has none. A send's level is
+    // one number and reaches both channels alike.
     const auto pan = params.pan == INVALID_PARAM_ID ? ParamValues{} : paramValues_[params.pan];
 
     if (pan.empty()) {

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -253,7 +253,7 @@ class PlanExecutor {
      * device is handed a window of nothing, which is what it would have had
      * before any table was published at all.
      */
-    void resolveParameters(const PlanValues& values, int numSamples);
+    void resolveParameters(const PlanValues& values, const BlockInfo& block);
 
     /**
      * @brief Render one op of the prepared plan.
@@ -503,6 +503,31 @@ class PlanExecutor {
     /// published with, so the block that fills them allocates nothing.
     ResolvedParams paramValues_;
     std::vector<ModContribution> paramScratch_;
+
+    /** @brief The parameters a mixer op reads instead of the published value. */
+    struct OpMixerParams {
+        /// A fader's volume or a send's level, in dB. Invalid where nothing
+        /// reaches the value and the published one stands.
+        ParamId gain = INVALID_PARAM_ID;
+
+        /// A fader's pan. Invalid on a send, which has none.
+        ParamId pan = INVALID_PARAM_ID;
+    };
+
+    /// Per op, resolved at prepare so the audio thread never looks a key up.
+    std::vector<OpMixerParams> mixerParamForOp_;
+
+    /// The gains @p op renders with: what the publisher resolved, unless a lane
+    /// or a link reaches the value it stands for, in which case what the block
+    /// resolved wins. A fader is the one value both layers can have an opinion
+    /// about, and the block's is the newer one by exactly the amount a lane
+    /// moves inside it.
+    OpValue mixerValueFor(std::size_t op, const OpValue& published) const;
+
+    /// Where one parameter's curve is baked before it is resolved. One
+    /// parameter's worth: the block walks them one at a time, and a segment
+    /// written for one is read before the next is baked.
+    std::vector<ParamSegment> paramSegments_;
 
     /// Per op: the window of the table a Device op's device reads, resolved
     /// once here so the audio thread never hashes a DeviceKey. Cached from one

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -51,13 +51,6 @@ float faderPositionToGain(float position) {
                : 0.0f;
 }
 
-/// Pan as the fader stores it: a small deadband around centre, then clamped.
-float faderPan(float pan) {
-    if (pan >= -0.005f && pan <= 0.005f)
-        pan = 0.0f;
-    return std::clamp(pan, -1.0f, 1.0f);
-}
-
 // --- model lookup ------------------------------------------------------------
 
 /// Depth cap for the parent and destination walks. Both are model-authored
@@ -339,7 +332,7 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
     switch (key.role) {
         case OpRole::TrackFader: {
             const auto gain = faderGainFromVolume(track->volume);
-            applyLinearPanLaw(gain, faderPan(track->pan), value.gainLeft, value.gainRight);
+            applyLinearPanLaw(gain, faderPanPosition(track->pan), value.gainLeft, value.gainRight);
             break;
         }
 
@@ -402,7 +395,7 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
                 break;
 
             const auto gain = faderGainFromDecibels(chain->volume);
-            applyLinearPanLaw(gain, faderPan(chain->pan), value.gainLeft, value.gainRight);
+            applyLinearPanLaw(gain, faderPanPosition(chain->pan), value.gainLeft, value.gainRight);
             break;
         }
 
@@ -464,6 +457,12 @@ std::vector<std::string> Resolver::run(PlanValues& values) {
 
 }  // namespace
 
+float faderPanPosition(float pan) {
+    if (pan >= -0.005f && pan <= 0.005f)
+        pan = 0.0f;
+    return std::clamp(pan, -1.0f, 1.0f);
+}
+
 float faderGainFromDecibels(float decibels) {
     return faderPositionToGain(std::clamp(decibelsToFaderPosition(decibels), 0.0f, 1.0f));
 }
@@ -480,7 +479,9 @@ void applyLinearPanLaw(float gain, float pan, float& left, float& right) {
 
 std::vector<std::string> resolvePlanValues(const RenderPlan& plan,
                                            const std::vector<TrackInfo>& tracks,
-                                           const TrackInfo& master, PlanValues& values) {
+                                           const TrackInfo& master, PlanValues& values,
+                                           std::span<const magda::AutomationLaneInfo> lanes,
+                                           std::span<const magda::AutomationClipInfo> clips) {
     auto messages = Resolver(plan, tracks, master).run(values);
 
     // The parameters travel with the values (#2117), so one call resolves the
@@ -488,7 +489,8 @@ std::vector<std::string> resolvePlanValues(const RenderPlan& plan,
     // of step with each other. Rebuilt whole rather than patched, the way the
     // op values are: a fader move re-resolves a project's parameters as well,
     // which is a vector and a topological sort off the audio thread.
-    auto params = std::make_shared<ParamTable>(compileParamTable(plan, tracks, master));
+    auto params =
+        std::make_shared<ParamTable>(compileParamTable(plan, tracks, master, lanes, clips));
 
     // Reported here as well as carried on the table, because the caller that
     // logs one of these is the caller that logs the other, and a diagnostic

--- a/magda/engine/exec/PlanValues.hpp
+++ b/magda/engine/exec/PlanValues.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -106,10 +107,15 @@ struct PlanValues {
  *
  * @param tracks  every non-master track, as passed to compileRenderPlan
  * @param master  the master track
+ * @param lanes   the automation lanes the project has, and the clips they name.
+ *                Empty is a project with no automation, and every render that
+ *                is not about it.
  */
 std::vector<std::string> resolvePlanValues(const RenderPlan& plan,
                                            const std::vector<TrackInfo>& tracks,
-                                           const TrackInfo& master, PlanValues& values);
+                                           const TrackInfo& master, PlanValues& values,
+                                           std::span<const magda::AutomationLaneInfo> lanes = {},
+                                           std::span<const magda::AutomationClipInfo> clips = {});
 
 /**
  * @brief Gain a volume fader applies, given a linear volume from the model.
@@ -133,5 +139,15 @@ float faderGainFromDecibels(float decibels);
  * exists to avoid.
  */
 void applyLinearPanLaw(float gain, float pan, float& left, float& right);
+
+/**
+ * @brief Pan as the fader stores it: a deadband around centre, then clamped.
+ *
+ * Exposed because the fader is resolved in two places now. What a publish knows
+ * is where the model left the pan; what a block knows is where a lane has moved
+ * it to, and both have to be read through the same deadband or a pan lane would
+ * pass through a centre the model never has.
+ */
+float faderPanPosition(float pan);
 
 }  // namespace magda::engine

--- a/magda/engine/param/ParamKey.cpp
+++ b/magda/engine/param/ParamKey.cpp
@@ -115,12 +115,35 @@ std::optional<ParamKey> paramKeyFor(const magda::ControlTarget& target) {
             key.index = target.modParamIndex;
             return key;
 
-        // Real targets that this table does not carry. The mixer values are
-        // resolved into PlanValues, off the audio thread, and the tempo belongs
-        // to the transport.
         case magda::ControlTarget::Kind::TrackVolume:
         case magda::ControlTarget::Kind::TrackPan:
-        case magda::ControlTarget::Kind::SendLevel:
+        case magda::ControlTarget::Kind::SendLevel: {
+            // Track-scoped and nothing else: a mixer value belongs to a track,
+            // and the path a target carries for one is the track's own.
+            if (target.devicePath.trackId == INVALID_TRACK_ID)
+                return std::nullopt;
+
+            key.scope = ParamKey::Scope::Track;
+            key.trackId = target.devicePath.trackId;
+
+            if (target.kind == magda::ControlTarget::Kind::TrackVolume) {
+                key.kind = ParamKey::Kind::TrackVolume;
+                return key;
+            }
+            if (target.kind == magda::ControlTarget::Kind::TrackPan) {
+                key.kind = ParamKey::Kind::TrackPan;
+                return key;
+            }
+
+            if (target.sendBusIndex < 0)
+                return std::nullopt;
+            key.kind = ParamKey::Kind::SendLevel;
+            key.index = target.sendBusIndex;
+            return key;
+        }
+
+        // The tempo is a real target that belongs to the transport rather than
+        // to any track, and nothing here can carry one.
         case magda::ControlTarget::Kind::Tempo:
             return std::nullopt;
     }
@@ -165,6 +188,15 @@ std::string toString(const ParamKey& key) {
             text += ":mod" + std::to_string(key.modId);
             if (key.index >= 0)
                 text += ".param" + std::to_string(key.index);
+            break;
+        case ParamKey::Kind::TrackVolume:
+            text += ":volume";
+            break;
+        case ParamKey::Kind::TrackPan:
+            text += ":pan";
+            break;
+        case ParamKey::Kind::SendLevel:
+            text += ":send" + std::to_string(key.index);
             break;
     }
 

--- a/magda/engine/param/ParamKey.hpp
+++ b/magda/engine/param/ParamKey.hpp
@@ -37,6 +37,15 @@ struct ParamKey {
         DeviceParam,  ///< a device's own parameter, by its declared index
         Macro,        ///< a macro knob belonging to the scope named below
         ModParam,     ///< one parameter of a modifier belonging to that scope
+
+        // The mixer values, which are parameters for the same reason the rest
+        // are: a lane plays over them inside a block, and a table resolved by
+        // the publisher cannot move faster than a publish. They are carried
+        // only when something reaches them, so a project with no automation on
+        // its faders keeps the value table's answer and pays nothing (#2118).
+        TrackVolume,  ///< the track fader, in dB
+        TrackPan,     ///< the track pan, -1 to 1
+        SendLevel,    ///< one send slot's level, in dB, by its index
     };
 
     /// Who owns the macro or modifier. Always Device for a device parameter.

--- a/magda/engine/param/ParamResolve.cpp
+++ b/magda/engine/param/ParamResolve.cpp
@@ -258,18 +258,27 @@ int bakeCurve(std::span<const magda::AutomationPoint> curve, const ParamSpec& sp
             }
     }
 
-    // A run that holds cannot arrive by ramping, so a bake that ran out of room
-    // inside one spends its last segment on the step the curve ends on, at the
-    // sample it lands. What is lost is the steps in between, which is the same
-    // coarsening ResolvedParams makes when a curve outgrows its slot; the run
-    // before it simply holds a little longer. A run that does not hold ramps to
-    // the same place, which arrives on time whether or not it overflowed.
-    if (overflowed && holds && hasKnotInside)
+    // A bake that ran out of room spends its last segment on arriving, and the
+    // shape of that arrival belongs to the run the block ends in rather than to
+    // the run the walk gave up in. Curve type is a property of a point, so a
+    // knot the walk never reached can open a run of the other kind: a step run
+    // that overflowed can end in a ramp, and a ramp that overflowed can end in
+    // a step.
+    //
+    // Either way the run before it holds a little longer, which is the same
+    // coarsening ResolvedParams makes one level down when a curve outgrows its
+    // slot: the steps in between are what is lost, never the arrival.
+    if (overflowed && hasKnotInside) {
+        const auto sample = std::max(endingSample, startSample);
+        const bool finalHolds = holdsFrom((boundary - 1)->beatPosition);
+
         out[static_cast<std::size_t>(written++)] =
-            ParamSegment{std::max(endingSample, startSample), endingHeld, endingHeld};
-    else
+            finalHolds ? ParamSegment{sample, endingHeld, endingHeld}
+                       : ParamSegment{sample, endingHeld, ending};
+    } else {
         out[static_cast<std::size_t>(written++)] =
             ParamSegment{startSample, startValue, holds ? startValue : ending};
+    }
 
     return written;
 }

--- a/magda/engine/param/ParamResolve.cpp
+++ b/magda/engine/param/ParamResolve.cpp
@@ -181,12 +181,20 @@ int bakeCurve(std::span<const magda::AutomationPoint> curve, const ParamSpec& sp
     // Where the curve ends up over this block, and where it gets there. Both
     // are needed before the walk, because a walk that runs out of room has to
     // spend its last segment on arriving rather than on where it had got to.
+    //
+    // Two endings, and the difference is the block's far edge. A run that
+    // travels arrives at the value the boundary has, which is the value the
+    // next block opens on. A run that holds arrives at the last knot inside
+    // this block: a step sitting exactly on the boundary belongs to the next
+    // block, and writing its value here would pull it earlier by however long
+    // the run before it lasts.
     const float ending = valueAt(block.endBeat);
-    const auto lastKnot = std::lower_bound(
+    const auto boundary = std::lower_bound(
         curve.begin(), curve.end(), block.endBeat,
         [](const magda::AutomationPoint& point, double beat) { return point.beatPosition < beat; });
-    const int endingSample =
-        lastKnot == curve.begin() ? 0 : block.sampleForBeat((lastKnot - 1)->beatPosition);
+    const bool hasKnotInside = boundary != curve.begin();
+    const int endingSample = hasKnotInside ? block.sampleForBeat((boundary - 1)->beatPosition) : 0;
+    const float endingHeld = hasKnotInside ? valueAt((boundary - 1)->beatPosition) : opening;
 
     int written = 0;
     int startSample = 0;
@@ -256,9 +264,9 @@ int bakeCurve(std::span<const magda::AutomationPoint> curve, const ParamSpec& sp
     // coarsening ResolvedParams makes when a curve outgrows its slot; the run
     // before it simply holds a little longer. A run that does not hold ramps to
     // the same place, which arrives on time whether or not it overflowed.
-    if (overflowed && holds)
+    if (overflowed && holds && hasKnotInside)
         out[static_cast<std::size_t>(written++)] =
-            ParamSegment{std::max(endingSample, startSample), ending, ending};
+            ParamSegment{std::max(endingSample, startSample), endingHeld, endingHeld};
     else
         out[static_cast<std::size_t>(written++)] =
             ParamSegment{startSample, startValue, holds ? startValue : ending};

--- a/magda/engine/param/ParamResolve.cpp
+++ b/magda/engine/param/ParamResolve.cpp
@@ -169,34 +169,61 @@ int bakeCurve(std::span<const magda::AutomationPoint> curve, const ParamSpec& sp
         return 1;
     }
 
-    // A segment per breakpoint inside the block, from where the block opens to
-    // where it ends. The bend between two breakpoints reads as a straight line
-    // here; over a few milliseconds that is a difference no device has asked to
-    // hear, and subdividing is what to do when one does.
+    // Whether the run a beat falls in holds its value rather than travelling to
+    // the next one. A step is not a bend that happens to be steep: a segment
+    // written as a ramp would glide a device through values the drawn curve
+    // never has.
+    const auto holdsFrom = [&curve](double beat) {
+        const auto* opener = magda::automation::segmentOpening(curve, beat);
+        return opener != nullptr && opener->curveType == magda::AutomationCurveType::Step;
+    };
+
     int written = 0;
     int startSample = 0;
     float startValue = opening;
+    bool holds = holdsFrom(block.startBeat);
 
-    for (const auto& point : curve) {
-        if (point.beatPosition <= block.startBeat)
-            continue;
-        if (point.beatPosition >= block.endBeat)
+    // Close the run in progress at @p beat and open the next one there. The
+    // value at a knot is the curve's value after it, which for a step is the
+    // jump and for everything else is where the previous run arrived.
+    const auto closeAt = [&](double beat) {
+        const auto sample = block.sampleForBeat(beat);
+        const auto value = valueAt(beat);
+
+        if (sample > startSample) {
+            out[static_cast<std::size_t>(written++)] =
+                ParamSegment{startSample, startValue, holds ? startValue : value};
+            startSample = sample;
+        }
+
+        startValue = value;
+        holds = holdsFrom(beat);
+    };
+
+    const auto inside = [&block](double beat) {
+        return beat > block.startBeat && beat < block.endBeat;
+    };
+
+    // Every knot the block contains, in beat order: each breakpoint, and the
+    // apex of a hard corner, which is where that curve changes direction
+    // between two breakpoints rather than at one.
+    for (std::size_t i = 0; i < curve.size(); ++i) {
+        if (curve[i].beatPosition >= block.endBeat)
             break;
         if (written + 1 >= static_cast<int>(out.size()))
             break;
 
-        const auto sample = block.sampleForBeat(point.beatPosition);
-        if (sample <= startSample)
-            continue;
+        if (inside(curve[i].beatPosition))
+            closeAt(curve[i].beatPosition);
 
-        const auto value = static_cast<float>(point.value);
-        out[static_cast<std::size_t>(written++)] = ParamSegment{startSample, startValue, value};
-        startSample = sample;
-        startValue = value;
+        if (i + 1 < curve.size())
+            if (const auto corner = magda::automation::hardCornerOf(curve[i], curve[i + 1]))
+                if (inside(corner->beat) && written + 1 < static_cast<int>(out.size()))
+                    closeAt(corner->beat);
     }
 
     out[static_cast<std::size_t>(written++)] =
-        ParamSegment{startSample, startValue, valueAt(block.endBeat)};
+        ParamSegment{startSample, startValue, holds ? startValue : valueAt(block.endBeat)};
     return written;
 }
 

--- a/magda/engine/param/ParamResolve.cpp
+++ b/magda/engine/param/ParamResolve.cpp
@@ -178,10 +178,21 @@ int bakeCurve(std::span<const magda::AutomationPoint> curve, const ParamSpec& sp
         return opener != nullptr && opener->curveType == magda::AutomationCurveType::Step;
     };
 
+    // Where the curve ends up over this block, and where it gets there. Both
+    // are needed before the walk, because a walk that runs out of room has to
+    // spend its last segment on arriving rather than on where it had got to.
+    const float ending = valueAt(block.endBeat);
+    const auto lastKnot = std::lower_bound(
+        curve.begin(), curve.end(), block.endBeat,
+        [](const magda::AutomationPoint& point, double beat) { return point.beatPosition < beat; });
+    const int endingSample =
+        lastKnot == curve.begin() ? 0 : block.sampleForBeat((lastKnot - 1)->beatPosition);
+
     int written = 0;
     int startSample = 0;
     float startValue = opening;
     bool holds = holdsFrom(block.startBeat);
+    bool overflowed = false;
 
     // Close the run in progress at @p beat and open the next one there. The
     // value at a knot is the curve's value after it, which for a step is the
@@ -204,26 +215,54 @@ int bakeCurve(std::span<const magda::AutomationPoint> curve, const ParamSpec& sp
         return beat > block.startBeat && beat < block.endBeat;
     };
 
+    // The run the block opens inside, rather than the top of the lane: an
+    // unrolled clip lane is as long as the arrangement, and every knot behind
+    // the playhead is one this block was never going to emit.
+    const auto opener = std::lower_bound(
+        curve.begin(), curve.end(), block.startBeat,
+        [](const magda::AutomationPoint& point, double beat) { return point.beatPosition < beat; });
+    auto index = static_cast<std::size_t>(std::distance(curve.begin(), opener));
+    if (index > 0)
+        --index;
+
     // Every knot the block contains, in beat order: each breakpoint, and the
     // apex of a hard corner, which is where that curve changes direction
     // between two breakpoints rather than at one.
-    for (std::size_t i = 0; i < curve.size(); ++i) {
+    for (std::size_t i = index; i < curve.size(); ++i) {
         if (curve[i].beatPosition >= block.endBeat)
             break;
-        if (written + 1 >= static_cast<int>(out.size()))
+        if (written + 1 >= static_cast<int>(out.size())) {
+            overflowed = true;
             break;
+        }
 
         if (inside(curve[i].beatPosition))
             closeAt(curve[i].beatPosition);
 
         if (i + 1 < curve.size())
-            if (const auto corner = magda::automation::hardCornerOf(curve[i], curve[i + 1]))
-                if (inside(corner->beat) && written + 1 < static_cast<int>(out.size()))
+            if (const auto corner = magda::automation::hardCornerOf(curve[i], curve[i + 1])) {
+                if (written + 1 >= static_cast<int>(out.size())) {
+                    overflowed = true;
+                    break;
+                }
+                if (inside(corner->beat))
                     closeAt(corner->beat);
+            }
     }
 
-    out[static_cast<std::size_t>(written++)] =
-        ParamSegment{startSample, startValue, holds ? startValue : valueAt(block.endBeat)};
+    // A run that holds cannot arrive by ramping, so a bake that ran out of room
+    // inside one spends its last segment on the step the curve ends on, at the
+    // sample it lands. What is lost is the steps in between, which is the same
+    // coarsening ResolvedParams makes when a curve outgrows its slot; the run
+    // before it simply holds a little longer. A run that does not hold ramps to
+    // the same place, which arrives on time whether or not it overflowed.
+    if (overflowed && holds)
+        out[static_cast<std::size_t>(written++)] =
+            ParamSegment{std::max(endingSample, startSample), ending, ending};
+    else
+        out[static_cast<std::size_t>(written++)] =
+            ParamSegment{startSample, startValue, holds ? startValue : ending};
+
     return written;
 }
 

--- a/magda/engine/param/ParamResolve.cpp
+++ b/magda/engine/param/ParamResolve.cpp
@@ -4,6 +4,8 @@
 
 #include <algorithm>
 
+#include "core/AutomationCurve.hpp"
+
 namespace magda::engine {
 
 namespace {
@@ -147,8 +149,61 @@ void resolveParam(ResolvedParams& out, int param, const ParamSpec& spec,
     out.setSegmentCount(param, written);
 }
 
-void resolveParams(const ParamTable& table, ResolvedParams& out, std::span<ModContribution> scratch,
-                   int numSamples) {
+int bakeCurve(std::span<const magda::AutomationPoint> curve, const ParamSpec& spec,
+              const BlockInfo& block, std::span<ParamSegment> out) {
+    if (curve.empty() || out.empty())
+        return 0;
+
+    const auto valueAt = [&curve](double beat) {
+        return static_cast<float>(magda::automation::valueAtBeat(curve, beat));
+    };
+
+    const float opening = valueAt(block.startBeat);
+
+    // One value for the block, held: the incumbent engine settles a parameter
+    // at the block boundary, and a device that did not ask for more is not the
+    // place to start differing from it. Also the whole answer for a block with
+    // no time in it, which is what a stopped transport renders.
+    if (!spec.segmentAccurate || block.numSamples <= 0 || block.endBeat <= block.startBeat) {
+        out[0] = ParamSegment{0, opening, opening};
+        return 1;
+    }
+
+    // A segment per breakpoint inside the block, from where the block opens to
+    // where it ends. The bend between two breakpoints reads as a straight line
+    // here; over a few milliseconds that is a difference no device has asked to
+    // hear, and subdividing is what to do when one does.
+    int written = 0;
+    int startSample = 0;
+    float startValue = opening;
+
+    for (const auto& point : curve) {
+        if (point.beatPosition <= block.startBeat)
+            continue;
+        if (point.beatPosition >= block.endBeat)
+            break;
+        if (written + 1 >= static_cast<int>(out.size()))
+            break;
+
+        const auto sample = block.sampleForBeat(point.beatPosition);
+        if (sample <= startSample)
+            continue;
+
+        const auto value = static_cast<float>(point.value);
+        out[static_cast<std::size_t>(written++)] = ParamSegment{startSample, startValue, value};
+        startSample = sample;
+        startValue = value;
+    }
+
+    out[static_cast<std::size_t>(written++)] =
+        ParamSegment{startSample, startValue, valueAt(block.endBeat)};
+    return written;
+}
+
+void resolveParams(const ParamTable& table, ResolvedParams& out, std::span<ModContribution> links,
+                   std::span<ParamSegment> segments, const BlockInfo& block) {
+    const auto numSamples = block.numSamples;
+
     // Emptied first, and then refused. A table that does not fit is not a
     // reason to keep rendering last block's values: those were resolved for a
     // parameter set this one no longer has, and a device reading them would be
@@ -166,11 +221,11 @@ void resolveParams(const ParamTable& table, ResolvedParams& out, std::span<ModCo
             continue;
 
         const auto index = static_cast<std::size_t>(param);
-        const auto links = table.linksFor(param);
+        const auto reaching = table.linksFor(param);
 
         std::size_t used = 0;
-        for (const auto& link : links) {
-            if (used >= scratch.size())
+        for (const auto& link : reaching) {
+            if (used >= links.size())
                 break;
 
             float value = 0.0f;
@@ -187,15 +242,18 @@ void resolveParams(const ParamTable& table, ResolvedParams& out, std::span<ModCo
                     break;
             }
 
-            scratch[used++] = ModContribution{value, link.amount, link.bipolar};
+            links[used++] = ModContribution{value, link.amount, link.bipolar};
         }
+
+        const auto baked = bakeCurve(table.curveFor(param), table.specs[index], block, segments);
 
         ParamSources sources;
         sources.base = table.base[index];
-        sources.modulation = scratch.first(used);
+        sources.modulation = links.first(used);
+        sources.automation = std::span<const ParamSegment>{segments}.first(
+            static_cast<std::size_t>(std::max(baked, 0)));
+        sources.automationEnd = numSamples;
 
-        // No automation yet: the lanes are baked in #2118, and until they are
-        // every parameter is its base plus whatever is linked to it.
         resolveParam(out, param, table.specs[index], sources);
     }
 }

--- a/magda/engine/param/ParamResolve.hpp
+++ b/magda/engine/param/ParamResolve.hpp
@@ -121,12 +121,16 @@ void resolveParam(ResolvedParams& out, int param, const ParamSpec& spec,
  * the port: the incumbent engine settles a parameter at the block boundary, and
  * a curve read more finely than that would differ from it everywhere.
  *
- * A parameter that asked for segment accuracy gets a segment per breakpoint the
- * block contains, running from one to the next. The bend between two
- * breakpoints reads as a straight line inside a block: the curve is sampled at
- * its breakpoints and interpolated between them, which over a few milliseconds
- * is a difference no device has yet asked to hear. Subdividing a bent segment
- * is what to do when one does.
+ * A parameter that asked for segment accuracy gets a segment per knot the block
+ * contains: every breakpoint, and the apex of a hard corner, which is where
+ * that curve turns between two breakpoints rather than at one. A step holds
+ * rather than travelling, because a step written as a ramp would glide a device
+ * through values the drawn curve never has.
+ *
+ * What is approximated is the bend of a curved segment, which reads as a
+ * straight line between the knots either side of it. Over a few milliseconds
+ * that is a difference no device has yet asked to hear; subdividing is what to
+ * do when one does.
  */
 int bakeCurve(std::span<const magda::AutomationPoint> curve, const ParamSpec& spec,
               const BlockInfo& block, std::span<ParamSegment> out);

--- a/magda/engine/param/ParamResolve.hpp
+++ b/magda/engine/param/ParamResolve.hpp
@@ -2,6 +2,7 @@
 
 #include <span>
 
+#include "exec/RenderContext.hpp"
 #include "param/ParamBlock.hpp"
 #include "param/ParamSpec.hpp"
 #include "param/ParamTable.hpp"
@@ -109,6 +110,28 @@ void resolveParam(ResolvedParams& out, int param, const ParamSpec& spec,
                   const ParamSources& sources);
 
 /**
+ * @brief The stretch of an automation curve one block covers (#2118).
+ *
+ * Writes the block's sample domain: normalised values, sample offsets, ready to
+ * be handed to resolveParam as its automation lane. Returns how many segments
+ * it wrote, which is zero for a parameter with no curve.
+ *
+ * One segment for a parameter its device reads once per block, holding the
+ * value the curve has at the block's first sample. That is the whole shape of
+ * the port: the incumbent engine settles a parameter at the block boundary, and
+ * a curve read more finely than that would differ from it everywhere.
+ *
+ * A parameter that asked for segment accuracy gets a segment per breakpoint the
+ * block contains, running from one to the next. The bend between two
+ * breakpoints reads as a straight line inside a block: the curve is sampled at
+ * its breakpoints and interpolated between them, which over a few milliseconds
+ * is a difference no device has yet asked to hear. Subdividing a bent segment
+ * is what to do when one does.
+ */
+int bakeCurve(std::span<const magda::AutomationPoint> curve, const ParamSpec& spec,
+              const BlockInfo& block, std::span<ParamSegment> out);
+
+/**
  * @brief Resolve every parameter of @p table for one block (#2117).
  *
  * On the audio thread, once per block, before any device runs. Walks the
@@ -116,18 +139,22 @@ void resolveParam(ResolvedParams& out, int param, const ParamSpec& spec,
  * parameter needs no second pass: whatever a parameter reads has already been
  * resolved when it is reached.
  *
- * @p scratch is where one parameter's contributions are gathered, and it has to
- * hold ParamTable::maxLinksPerParam of them. Passed in rather than owned
- * because this runs on the audio thread and the room has to have been found
- * before the block started; a parameter with more links than there is room for
- * keeps the ones that fit, which cannot happen against a scratch sized from the
- * table it is used with.
+ * @p links is where one parameter's contributions are gathered, and it has to
+ * hold ParamTable::maxLinksPerParam of them. @p segments is where its curve is
+ * baked, and it has to hold as many as @p out has room for. Both are passed in
+ * rather than owned because this runs on the audio thread and the room has to
+ * have been found before the block started; a parameter with more links than
+ * there is room for keeps the ones that fit, which cannot happen against a
+ * scratch sized from the table it is used with.
+ *
+ * @p block is what says which stretch of every curve is being asked about, and
+ * how many samples that stretch lasts.
  *
  * A table whose size does not match what @p out was prepared for is refused
  * whole rather than resolved partly: the two are indexed by the same ParamId,
  * and a mismatch means they were prepared against different plans.
  */
-void resolveParams(const ParamTable& table, ResolvedParams& out, std::span<ModContribution> scratch,
-                   int numSamples);
+void resolveParams(const ParamTable& table, ResolvedParams& out, std::span<ModContribution> links,
+                   std::span<ParamSegment> segments, const BlockInfo& block);
 
 }  // namespace magda::engine

--- a/magda/engine/param/ParamTable.cpp
+++ b/magda/engine/param/ParamTable.cpp
@@ -43,4 +43,16 @@ std::span<const ParamLink> ParamTable::linksFor(ParamId param) const {
     return std::span<const ParamLink>{links}.subspan(first, last - first);
 }
 
+std::span<const magda::AutomationPoint> ParamTable::curveFor(ParamId param) const {
+    if (param < 0 || param + 1 >= static_cast<ParamId>(curveOffsets.size()))
+        return {};
+
+    const auto first = static_cast<std::size_t>(curveOffsets[static_cast<std::size_t>(param)]);
+    const auto last = static_cast<std::size_t>(curveOffsets[static_cast<std::size_t>(param) + 1]);
+    if (last <= first || last > curvePoints.size())
+        return {};
+
+    return std::span<const magda::AutomationPoint>{curvePoints}.subspan(first, last - first);
+}
+
 }  // namespace magda::engine

--- a/magda/engine/param/ParamTable.hpp
+++ b/magda/engine/param/ParamTable.hpp
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "core/AutomationInfo.hpp"
 #include "param/ParamKey.hpp"
 #include "param/ParamSpec.hpp"
 
@@ -102,6 +103,27 @@ struct ParamTable {
     std::vector<ParamModifier> modifiers;
 
     /**
+     * @brief The lane playing over each parameter, in beats.
+     *
+     * Breakpoints, as the model draws them: curvePoints[curveOffsets[i],
+     * curveOffsets[i + 1]) is the curve over parameter i, and empty is a
+     * parameter with no lane, a lane with nothing on it, or a lane the model is
+     * not currently playing.
+     *
+     * Beats rather than samples, and not baked into segments here, because a
+     * block is what decides which part of a curve is being asked about and how
+     * long it lasts. A curve resolved into samples at publish time would be a
+     * curve that had to be republished every time the tempo moved.
+     *
+     * A clip-based lane arrives already flattened: its loops unrolled, its gaps
+     * held at the nearest clip edge, its overlaps resolved by the lane's own
+     * precedence. That is the model's answer to what the lane is (#1087), and
+     * the engine asks for it rather than working out a second one.
+     */
+    std::vector<magda::AutomationPoint> curvePoints;
+    std::vector<int> curveOffsets;
+
+    /**
      * @brief The order parameters resolve in.
      *
      * A permutation of every ParamId, arranged so that anything a parameter
@@ -163,6 +185,9 @@ struct ParamTable {
 
     /// The links reaching @p param, empty when nothing modulates it.
     std::span<const ParamLink> linksFor(ParamId param) const;
+
+    /// The lane playing over @p param, empty when none is.
+    std::span<const magda::AutomationPoint> curveFor(ParamId param) const;
 
     /// Where @p device's parameters are, or a window of nothing.
     DeviceWindow windowFor(const DeviceKey& device) const {

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -313,17 +313,22 @@ void Builder::allocateMixer(const magda::TrackInfo& track) {
     const auto fader = magda::ParameterPresets::faderVolume(-1, "Volume");
     const auto panning = magda::ParameterPresets::pan(-1, "Pan");
 
+    // Volume and pan together or not at all. They are one op's two gains, put
+    // there by one pan law, so a fader resolved from a parameter has to resolve
+    // both of them: a pan lane over a table with no volume in it would have
+    // nothing to pan, and a volume lane over a table with no pan in it would
+    // recentre a track the moment its fader moved.
     ParamKey volume = scope;
     volume.kind = ParamKey::Kind::TrackVolume;
-    if (targeted_.count(volume) > 0)
-        add(volume, paramSpecFrom(fader),
-            magda::ParameterUtils::normalizedFromGain(track.volume, fader));
-
     ParamKey pan = scope;
     pan.kind = ParamKey::Kind::TrackPan;
-    if (targeted_.count(pan) > 0)
+
+    if (targeted_.count(volume) > 0 || targeted_.count(pan) > 0) {
+        add(volume, paramSpecFrom(fader),
+            magda::ParameterUtils::normalizedFromGain(track.volume, fader));
         add(pan, paramSpecFrom(panning),
             magda::ParameterUtils::realToNormalized(track.pan, panning));
+    }
 
     for (std::size_t slot = 0; slot < track.sends.size(); ++slot) {
         ParamKey send = scope;

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -4,6 +4,8 @@
 #include <queue>
 #include <set>
 
+#include "core/AutomationCurve.hpp"
+#include "core/ClipLaneFlattener.hpp"
 #include "core/RackInfo.hpp"
 #include "core/TrackInfo.hpp"
 
@@ -44,12 +46,14 @@ struct Node {
     const magda::MacroArray* macros = nullptr;
     const magda::ModArray* mods = nullptr;
     const magda::DeviceInfo* device = nullptr;
+    const magda::TrackInfo* track = nullptr;
 };
 
 class Builder {
   public:
     ParamTable run(const RenderPlan& plan, const std::vector<magda::TrackInfo>& tracks,
-                   const magda::TrackInfo& master);
+                   const magda::TrackInfo& master, std::span<const magda::AutomationLaneInfo> lanes,
+                   std::span<const magda::AutomationClipInfo> clips);
 
   private:
     ParamId add(const ParamKey& key, const ParamSpec& spec, float base);
@@ -62,10 +66,19 @@ class Builder {
                   ChainSegment segment);
 
     void collectTargets();
+    void allocateMixer(const magda::TrackInfo& track);
     void allocate();
     void allocateDevice(const Node& node);
     void allocateMacros(const Node& node);
     void allocateMods(const Node& node);
+
+    void collectLaneTargets();
+    void resolveLanes();
+    void flattenCurves();
+
+    /// The clip @p id names, or null for one the lane lists and the project has
+    /// lost.
+    const magda::AutomationClipInfo* findClip(magda::AutomationClipId id) const;
 
     void resolveLinks();
     void orderAndBreakCycles();
@@ -76,6 +89,8 @@ class Builder {
     }
 
     ParamTable table_;
+    std::span<const magda::AutomationLaneInfo> lanes_;
+    std::span<const magda::AutomationClipInfo> clips_;
     std::vector<Node> nodes_;
     std::vector<PendingLink> pending_;
 
@@ -86,6 +101,9 @@ class Builder {
 
     /// Per parameter, until the cycle pass has decided which survive.
     std::vector<std::vector<ParamLink>> perParam_;
+
+    /// Per parameter, until the curves are flattened into the table.
+    std::vector<std::vector<magda::AutomationPoint>> perParamCurve_;
 };
 
 ParamId Builder::add(const ParamKey& key, const ParamSpec& spec, float base) {
@@ -103,6 +121,7 @@ ParamId Builder::add(const ParamKey& key, const ParamSpec& spec, float base) {
     table_.specs.push_back(spec);
     table_.base.push_back(base);
     perParam_.emplace_back();
+    perParamCurve_.emplace_back();
     table_.byKey.emplace(key, id);
     return id;
 }
@@ -124,8 +143,8 @@ void Builder::allocateMacros(const Node& node) {
         // a slot when it drives something or something drives it; the rest are
         // stored values the model keeps and the engine has no use for.
         //
-        // An automation lane targeting one is the third way to be worth a slot,
-        // and it lands with the lanes (#2118).
+        // A lane playing over one counts too: a macro nothing drives, driving
+        // nothing, with a curve on it, is a curve the project plays.
         if (macro.links.empty() && targeted_.count(key) == 0)
             continue;
 
@@ -283,12 +302,46 @@ void Builder::walkRack(const magda::RackInfo& rack, magda::TrackId trackId) {
         walkElements(chain.elements, trackId, rack.id);
 }
 
+/// The mixer values a track has, allocated only when something reaches them: a
+/// project with no automation on its faders keeps the value table's answer and
+/// pays nothing for a table it would not read.
+void Builder::allocateMixer(const magda::TrackInfo& track) {
+    ParamKey scope;
+    scope.scope = ParamKey::Scope::Track;
+    scope.trackId = track.id;
+
+    const auto fader = magda::ParameterPresets::faderVolume(-1, "Volume");
+    const auto panning = magda::ParameterPresets::pan(-1, "Pan");
+
+    ParamKey volume = scope;
+    volume.kind = ParamKey::Kind::TrackVolume;
+    if (targeted_.count(volume) > 0)
+        add(volume, paramSpecFrom(fader),
+            magda::ParameterUtils::normalizedFromGain(track.volume, fader));
+
+    ParamKey pan = scope;
+    pan.kind = ParamKey::Kind::TrackPan;
+    if (targeted_.count(pan) > 0)
+        add(pan, paramSpecFrom(panning),
+            magda::ParameterUtils::realToNormalized(track.pan, panning));
+
+    for (std::size_t slot = 0; slot < track.sends.size(); ++slot) {
+        ParamKey send = scope;
+        send.kind = ParamKey::Kind::SendLevel;
+        send.index = static_cast<int>(slot);
+        if (targeted_.count(send) > 0)
+            add(send, paramSpecFrom(fader),
+                magda::ParameterUtils::normalizedFromGain(track.sends[slot].level, fader));
+    }
+}
+
 void Builder::walkTrack(const magda::TrackInfo& track) {
     Node node;
     node.scope.scope = ParamKey::Scope::Track;
     node.scope.trackId = track.id;
     node.macros = &track.macros;
     node.mods = &track.mods;
+    node.track = &track;
     nodes_.push_back(node);
 
     walkElements(track.chain.fxChainElements, track.id, INVALID_RACK_ID);
@@ -316,10 +369,84 @@ void Builder::collectTargets() {
     }
 }
 
+const magda::AutomationClipInfo* Builder::findClip(magda::AutomationClipId id) const {
+    for (const auto& clip : clips_)
+        if (clip.id == id)
+            return &clip;
+    return nullptr;
+}
+
+/// Whether the model is playing this lane rather than holding it. Read mode is
+/// playback; disabled, touching and writing are all the user's hand on the
+/// parameter, and the base is what a parameter is worth when a hand is on it.
+bool isPlaying(const magda::AutomationLaneInfo& lane) {
+    return lane.authorityState == magda::AutomationAuthorityState::Reading && lane.hasData();
+}
+
+void Builder::collectLaneTargets() {
+    for (const auto& lane : lanes_)
+        if (isPlaying(lane))
+            if (const auto key = paramKeyFor(lane.target))
+                targeted_.insert(*key);
+}
+
+void Builder::resolveLanes() {
+    for (const auto& lane : lanes_) {
+        if (!isPlaying(lane))
+            continue;
+
+        const auto key = paramKeyFor(lane.target);
+        if (!key.has_value()) {
+            diagnose(std::string("a lane plays over ") + magda::toString(lane.target.kind) +
+                     ", which the parameter table does not carry yet");
+            continue;
+        }
+
+        const auto id = table_.find(*key);
+        if (id == INVALID_PARAM_ID) {
+            diagnose("a lane plays over " + toString(*key) + ", which the project does not have");
+            continue;
+        }
+
+        auto& curve = perParamCurve_[static_cast<std::size_t>(id)];
+        if (!curve.empty()) {
+            // Two lanes over one parameter: the model allows the shape and
+            // nothing says which of them wins, so neither is guessed at.
+            diagnose(toString(*key) + ": two lanes play over it, and the second is ignored");
+            continue;
+        }
+
+        if (lane.isAbsolute()) {
+            curve = lane.absolutePoints;
+            continue;
+        }
+
+        // A clip-based lane unrolled the way the model unrolls it: loops
+        // repeated, gaps held at the nearest edge, overlaps decided by the
+        // lane's own precedence (#1087).
+        const auto getClip = [this](magda::AutomationClipId clipId) { return findClip(clipId); };
+        curve = magda::flattenClipLane(lane, getClip, [&](double beat) {
+            return magda::automation::laneValueAtBeat(lane, getClip, beat);
+        });
+    }
+}
+
+void Builder::flattenCurves() {
+    table_.curveOffsets.reserve(perParamCurve_.size() + 1);
+    table_.curveOffsets.push_back(0);
+
+    for (const auto& curve : perParamCurve_) {
+        table_.curvePoints.insert(table_.curvePoints.end(), curve.begin(), curve.end());
+        table_.curveOffsets.push_back(static_cast<int>(table_.curvePoints.size()));
+    }
+}
+
 void Builder::allocate() {
     for (const auto& node : nodes_) {
         // Devices first within a node, so a device's window is contiguous.
         allocateDevice(node);
+        if (node.track != nullptr)
+            allocateMixer(*node.track);
         allocateMacros(node);
         allocateMods(node);
     }
@@ -553,7 +680,11 @@ void Builder::flattenLinks() {
 }
 
 ParamTable Builder::run(const RenderPlan& plan, const std::vector<magda::TrackInfo>& tracks,
-                        const magda::TrackInfo& master) {
+                        const magda::TrackInfo& master,
+                        std::span<const magda::AutomationLaneInfo> lanes,
+                        std::span<const magda::AutomationClipInfo> clips) {
+    lanes_ = lanes;
+    clips_ = clips;
     table_.planFingerprint = planFingerprint(plan);
 
     for (const auto& track : tracks)
@@ -561,10 +692,13 @@ ParamTable Builder::run(const RenderPlan& plan, const std::vector<magda::TrackIn
     walkTrack(master);
 
     collectTargets();
+    collectLaneTargets();
     allocate();
+    resolveLanes();
     resolveLinks();
     orderAndBreakCycles();
     flattenLinks();
+    flattenCurves();
 
     table_.layoutFingerprint = paramLayoutFingerprint(table_.keys);
 
@@ -574,8 +708,10 @@ ParamTable Builder::run(const RenderPlan& plan, const std::vector<magda::TrackIn
 }  // namespace
 
 ParamTable compileParamTable(const RenderPlan& plan, const std::vector<magda::TrackInfo>& tracks,
-                             const magda::TrackInfo& master) {
-    return Builder{}.run(plan, tracks, master);
+                             const magda::TrackInfo& master,
+                             std::span<const magda::AutomationLaneInfo> lanes,
+                             std::span<const magda::AutomationClipInfo> clips) {
+    return Builder{}.run(plan, tracks, master, lanes, clips);
 }
 
 }  // namespace magda::engine

--- a/magda/engine/param/ParamTableCompiler.hpp
+++ b/magda/engine/param/ParamTableCompiler.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <span>
 #include <vector>
 
+#include "core/AutomationInfo.hpp"
 #include "param/ParamTable.hpp"
 #include "plan/RenderPlan.hpp"
 
@@ -34,6 +36,14 @@ namespace magda::engine {
  * @param tracks  every non-master track, as passed to compileRenderPlan
  * @param master  the master track
  *
+ * @param lanes   the automation lanes the project has, playing or not
+ * @param clips    the automation clips those lanes name
+ *
+ * A lane is carried when the model says it is playing: read mode is playback,
+ * and disabled, touching and writing are all the user holding the parameter
+ * rather than the curve driving it. Which of those a lane is in is the model's
+ * decision (AutomationStateMachine), asked here and not second-guessed.
+ *
  * Diagnostics ride on the table (ParamTable::diagnostics): a link naming
  * something that does not exist, a target this table does not carry, a link to
  * a parameter that takes no modulation, and a cycle. Nothing is dropped in
@@ -41,6 +51,8 @@ namespace magda::engine {
  * minus whatever the diagnostic describes.
  */
 ParamTable compileParamTable(const RenderPlan& plan, const std::vector<magda::TrackInfo>& tracks,
-                             const magda::TrackInfo& master);
+                             const magda::TrackInfo& master,
+                             std::span<const magda::AutomationLaneInfo> lanes = {},
+                             std::span<const magda::AutomationClipInfo> clips = {});
 
 }  // namespace magda::engine

--- a/magda/engine/param/ParamTableDump.cpp
+++ b/magda/engine/param/ParamTableDump.cpp
@@ -59,6 +59,8 @@ std::string dumpParamTable(const ParamTable& table) {
              << " " << padded(domainText(table.specs[index].domain), 16) << " "
              << "base=" << number(table.base[index]) << "  links=" << links.size();
 
+        if (!table.curveFor(param).empty())
+            line << " lane=" << table.curveFor(param).size();
         if (!table.specs[index].modulatable)
             line << " fixed";
         if (table.specs[index].segmentAccurate)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -310,6 +310,8 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_param_lane.cpp)
     # The parameter table (#2117): addressing, the link graph and publication.
     list(APPEND TEST_SOURCES test_param_table.cpp)
+    # Automation lanes baked into the parameter lane (#2118).
+    list(APPEND TEST_SOURCES test_automation_bake.cpp)
     list(APPEND TEST_SOURCES test_tempo_map.cpp)
     list(APPEND TEST_SOURCES test_transport_clock.cpp)
     list(APPEND TEST_SOURCES test_click_generator.cpp)

--- a/tests/PlanGoldenFixtures.cpp
+++ b/tests/PlanGoldenFixtures.cpp
@@ -252,6 +252,22 @@ Fixture parameterLinks() {
     value.tracks[0].mods[0].links.push_back(ModLink{
         ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 1), 0.5f, true, true});
 
+    // A lane over the device's first parameter, and one over the track fader,
+    // which is a parameter only because the lane reaches it (#2118).
+    AutomationLaneInfo cutoff;
+    cutoff.id = 1;
+    cutoff.target = ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0);
+    cutoff.authorityState = AutomationAuthorityState::Reading;
+    cutoff.absolutePoints = {{1, 0.0, 0.0}, {2, 4.0, 1.0}};
+
+    AutomationLaneInfo fader;
+    fader.id = 2;
+    fader.target = ControlTarget::trackVolume(1);
+    fader.authorityState = AutomationAuthorityState::Reading;
+    fader.absolutePoints = {{3, 0.0, 0.75}, {4, 8.0, 0.0}};
+
+    value.lanes = {cutoff, fader};
+
     value.master = master();
     value.options = withoutMeters();
     return value;

--- a/tests/PlanGoldenFixtures.hpp
+++ b/tests/PlanGoldenFixtures.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include "core/AutomationInfo.hpp"
 #include "core/TrackInfo.hpp"
 #include "plan/PlanCompiler.hpp"
 
@@ -45,6 +46,11 @@ struct Fixture {
     /// what turns a mistyped location into a failure instead of a golden
     /// quietly pinned with no delays in it.
     std::vector<std::pair<engine::OpKey, int>> deviceLatency;
+
+    /// The automation the project is playing, and the clips its lanes name.
+    /// Empty where the fixture is not about automation (#2118).
+    std::vector<AutomationLaneInfo> lanes;
+    std::vector<AutomationClipInfo> clips;
 
     /// A second project, compiled and diffed against the first. Empty where
     /// the fixture is not about what survives an edit.

--- a/tests/goldens/plan/parameter-links.txt
+++ b/tests/goldens/plan/parameter-links.txt
@@ -38,18 +38,19 @@ audioSlots=1 midiSlots=0 outputLatency=0
 
 == params ==
 magda-param-table v1
-params=7 modifiers=1 links=4
+params=8 modifiers=1 links=4
 [  0] T1:volume                    fader[-60.000,6.000] base=0.750  links=0 lane=2
-[  1] T1:macro0                    lin[0.000,1.000] base=1.000  links=0
-[  2] T1:macro1                    lin[0.000,1.000] base=0.500  links=1
-      <- param[  1] amount=0.500 bipolar=0
-[  3] T1/D7:param0                 lin[0.000,100.000] base=0.000  links=1 lane=2
-      <- param[  2] amount=1.000 bipolar=0
-[  4] T1/D7:param1                 lin[0.000,100.000] base=0.250  links=1
+[  1] T1:pan                       lin[-1.000,1.000] base=0.500  links=0
+[  2] T1:macro0                    lin[0.000,1.000] base=1.000  links=0
+[  3] T1:macro1                    lin[0.000,1.000] base=0.500  links=1
+      <- param[  2] amount=0.500 bipolar=0
+[  4] T1/D7:param0                 lin[0.000,100.000] base=0.000  links=1 lane=2
+      <- param[  3] amount=1.000 bipolar=0
+[  5] T1/D7:param1                 lin[0.000,100.000] base=0.250  links=1
       <- mod[  0] amount=0.500 bipolar=1
-[  5] T1/D7:param2                 lin[0.000,100.000] base=0.500  links=1
-      <- param[  6] amount=0.500 bipolar=1
-[  6] T1/D7:macro0                 lin[0.000,1.000] base=0.250  links=0
+[  6] T1/D7:param2                 lin[0.000,100.000] base=0.500  links=1
+      <- param[  7] amount=0.500 bipolar=1
+[  7] T1/D7:macro0                 lin[0.000,1.000] base=0.250  links=0
 modifiers:
 [  0] T1:mod0                      value=0.750
-order: 0 1 2 3 4 6 5
+order: 0 1 2 3 4 5 7 6

--- a/tests/goldens/plan/parameter-links.txt
+++ b/tests/goldens/plan/parameter-links.txt
@@ -38,17 +38,18 @@ audioSlots=1 midiSlots=0 outputLatency=0
 
 == params ==
 magda-param-table v1
-params=6 modifiers=1 links=4
-[  0] T1:macro0                    lin[0.000,1.000] base=1.000  links=0
-[  1] T1:macro1                    lin[0.000,1.000] base=0.500  links=1
-      <- param[  0] amount=0.500 bipolar=0
-[  2] T1/D7:param0                 lin[0.000,100.000] base=0.000  links=1
-      <- param[  1] amount=1.000 bipolar=0
-[  3] T1/D7:param1                 lin[0.000,100.000] base=0.250  links=1
+params=7 modifiers=1 links=4
+[  0] T1:volume                    fader[-60.000,6.000] base=0.750  links=0 lane=2
+[  1] T1:macro0                    lin[0.000,1.000] base=1.000  links=0
+[  2] T1:macro1                    lin[0.000,1.000] base=0.500  links=1
+      <- param[  1] amount=0.500 bipolar=0
+[  3] T1/D7:param0                 lin[0.000,100.000] base=0.000  links=1 lane=2
+      <- param[  2] amount=1.000 bipolar=0
+[  4] T1/D7:param1                 lin[0.000,100.000] base=0.250  links=1
       <- mod[  0] amount=0.500 bipolar=1
-[  4] T1/D7:param2                 lin[0.000,100.000] base=0.500  links=1
-      <- param[  5] amount=0.500 bipolar=1
-[  5] T1/D7:macro0                 lin[0.000,1.000] base=0.250  links=0
+[  5] T1/D7:param2                 lin[0.000,100.000] base=0.500  links=1
+      <- param[  6] amount=0.500 bipolar=1
+[  6] T1/D7:macro0                 lin[0.000,1.000] base=0.250  links=0
 modifiers:
 [  0] T1:mod0                      value=0.750
-order: 0 1 2 3 5 4
+order: 0 1 2 3 4 6 5

--- a/tests/test_automation_bake.cpp
+++ b/tests/test_automation_bake.cpp
@@ -314,6 +314,55 @@ TEST_CASE("A device that asked for segments gets one per breakpoint", "[engine][
     CHECK(values[param].valueAt(127) == approx(1.5625f));
 }
 
+TEST_CASE("A step inside a block holds rather than gliding", "[engine][param][bake]") {
+    auto tracks = trackWithDevice();
+
+    const auto table =
+        tableFor(tracks, {lane(deviceTarget(), {point(0.0, 0.0, AutomationCurveType::Step),
+                                                point(1.0, 1.0, AutomationCurveType::Step)})});
+    auto param = table.find(deviceParam(1, 7, 0));
+
+    auto opted = table;
+    opted.specs[static_cast<std::size_t>(param)].segmentAccurate = true;
+
+    const auto values = resolved(opted, blockAt(0.0, 2.0, 128));
+
+    // A step is not a bend that happens to be steep. Written as a ramp, the
+    // device would hear every value between the two, and the drawn curve has
+    // none of them.
+    REQUIRE(values[param].numSegments() == 2);
+    CHECK(values[param].valueAt(0) == approx(0.0f));
+    CHECK(values[param].valueAt(63) == approx(0.0f));
+    CHECK(values[param].valueAt(64) == approx(100.0f));
+    CHECK(values[param].valueAt(127) == approx(100.0f));
+}
+
+TEST_CASE("A hard corner keeps its apex inside a block", "[engine][param][bake]") {
+    auto tracks = trackWithDevice();
+
+    // A corner whose apex the shaper handle has dragged to a quarter of the
+    // way along, three quarters of the way up.
+    auto opener = point(0.0, 0.0, AutomationCurveType::HardCorner);
+    opener.outHandle.beatOffset = 1.0;
+    opener.outHandle.value = 0.75;
+
+    const auto table = tableFor(tracks, {lane(deviceTarget(), {opener, point(4.0, 0.0)})});
+    auto param = table.find(deviceParam(1, 7, 0));
+
+    auto opted = table;
+    opted.specs[static_cast<std::size_t>(param)].segmentAccurate = true;
+
+    const auto values = resolved(opted, blockAt(0.0, 4.0, 128));
+
+    // Two runs meeting at the apex. Sampled at its breakpoints alone the block
+    // would draw one straight line from nothing to nothing and the corner
+    // would vanish.
+    REQUIRE(values[param].numSegments() == 2);
+    CHECK(values[param].valueAt(32) == approx(75.0f));
+    CHECK(values[param].valueAt(16) == approx(37.5f));
+    CHECK(values[param].valueAt(80) == approx(37.5f));
+}
+
 namespace {
 
 /// A device that fills its output with ones, so what comes out of the master is

--- a/tests/test_automation_bake.cpp
+++ b/tests/test_automation_bake.cpp
@@ -364,6 +364,31 @@ TEST_CASE("A stepped curve too busy for the block still arrives", "[engine][para
     CHECK(values[param].segments().back().endValue == approx(1.0f));
 }
 
+TEST_CASE("A step on the block's far edge belongs to the next block", "[engine][param][bake]") {
+    auto tracks = trackWithDevice();
+
+    // Twenty steps inside the block, and one sitting exactly on its far edge.
+    // The block runs to that edge without reaching it, so the last value this
+    // block holds is the one before it, however little room the bake had left.
+    std::vector<AutomationPoint> steps;
+    for (int i = 0; i < 20; ++i)
+        steps.push_back(point(static_cast<double>(i) * 0.1, static_cast<double>(i) / 38.0,
+                              AutomationCurveType::Step));
+    steps.push_back(point(2.0, 1.0, AutomationCurveType::Step));
+
+    const auto table = tableFor(tracks, {lane(deviceTarget(), steps)});
+    const auto param = table.find(deviceParam(1, 7, 0));
+
+    auto opted = table;
+    opted.specs[static_cast<std::size_t>(param)].segmentAccurate = true;
+
+    const auto values = resolved(opted, blockAt(0.0, 2.0, 512));
+
+    REQUIRE(values[param].numSegments() <= values.segmentCapacity());
+    CHECK(values[param].valueAt(511) == approx(50.0f));
+    CHECK(values[param].segments().back().endValue == approx(0.5f));
+}
+
 TEST_CASE("A hard corner keeps its apex inside a block", "[engine][param][bake]") {
     auto tracks = trackWithDevice();
 

--- a/tests/test_automation_bake.cpp
+++ b/tests/test_automation_bake.cpp
@@ -389,6 +389,47 @@ TEST_CASE("A step on the block's far edge belongs to the next block", "[engine][
     CHECK(values[param].segments().back().endValue == approx(0.5f));
 }
 
+TEST_CASE("An overflowing bake arrives in the shape the block ends in", "[engine][param][bake]") {
+    auto tracks = trackWithDevice();
+
+    // Enough knots to exhaust the arena, and a final run of the other kind. The
+    // walk gives up inside the first sort; what the last segment has to look
+    // like is decided by the second.
+    const auto laneEndingIn = [](AutomationCurveType busy, AutomationCurveType last) {
+        std::vector<AutomationPoint> points;
+        for (int i = 0; i < 20; ++i)
+            points.push_back(
+                point(static_cast<double>(i) * 0.09, static_cast<double>(i) / 76.0, busy));
+        points.push_back(point(1.9, 0.25, last));
+        points.push_back(point(2.0, 1.0, AutomationCurveType::Linear));
+        return points;
+    };
+
+    const auto endOfBlock = [&](AutomationCurveType busy, AutomationCurveType last) {
+        const auto table = tableFor(tracks, {lane(deviceTarget(), laneEndingIn(busy, last))});
+        const auto param = table.find(deviceParam(1, 7, 0));
+
+        auto opted = table;
+        opted.specs[static_cast<std::size_t>(param)].segmentAccurate = true;
+
+        const auto values = resolved(opted, blockAt(0.0, 2.0, 512));
+        REQUIRE(values[param].numSegments() <= values.segmentCapacity());
+        return values[param].segments().back();
+    };
+
+    SECTION("steps that end in a ramp still ramp") {
+        const auto last = endOfBlock(AutomationCurveType::Step, AutomationCurveType::Linear);
+        CHECK(last.startValue == approx(0.25f));
+        CHECK(last.endValue == approx(1.0f));
+    }
+
+    SECTION("ramps that end in a step still hold") {
+        const auto last = endOfBlock(AutomationCurveType::Linear, AutomationCurveType::Step);
+        CHECK(last.startValue == approx(0.25f));
+        CHECK(last.endValue == approx(0.25f));
+    }
+}
+
 TEST_CASE("A hard corner keeps its apex inside a block", "[engine][param][bake]") {
     auto tracks = trackWithDevice();
 

--- a/tests/test_automation_bake.cpp
+++ b/tests/test_automation_bake.cpp
@@ -337,6 +337,33 @@ TEST_CASE("A step inside a block holds rather than gliding", "[engine][param][ba
     CHECK(values[param].valueAt(127) == approx(100.0f));
 }
 
+TEST_CASE("A stepped curve too busy for the block still arrives", "[engine][param][bake]") {
+    auto tracks = trackWithDevice();
+
+    // Two dozen steps inside one block, against sixteen slots. Something has to
+    // go, and it is the steps in between rather than the one the curve ends on.
+    std::vector<AutomationPoint> steps;
+    for (int i = 0; i < 24; ++i)
+        steps.push_back(point(static_cast<double>(i) * 0.05, static_cast<double>(i) / 23.0,
+                              AutomationCurveType::Step));
+
+    const auto table = tableFor(tracks, {lane(deviceTarget(), steps)});
+    const auto param = table.find(deviceParam(1, 7, 0));
+
+    auto opted = table;
+    opted.specs[static_cast<std::size_t>(param)].segmentAccurate = true;
+
+    const auto values = resolved(opted, blockAt(0.0, 2.0, 512));
+
+    CHECK(values[param].numSegments() <= values.segmentCapacity());
+    CHECK(values[param].valueAt(0) == approx(0.0f));
+
+    // The block ends on the step the curve ends on, at the sample it lands.
+    CHECK(values[param].valueAt(511) == approx(100.0f));
+    CHECK(values[param].segments().back().startValue == approx(1.0f));
+    CHECK(values[param].segments().back().endValue == approx(1.0f));
+}
+
 TEST_CASE("A hard corner keeps its apex inside a block", "[engine][param][bake]") {
     auto tracks = trackWithDevice();
 
@@ -443,6 +470,55 @@ TEST_CASE("A lane over a track fader moves the fader", "[engine][param][bake]") 
     CHECK(render(session, 0.0) == approx(expected(0.0)));
     CHECK(render(session, 2.0) == approx(expected(0.375)));
     CHECK(render(session, 4.0) == approx(expected(0.75)));
+}
+
+TEST_CASE("A fader carries volume and pan together", "[engine][param][bake]") {
+    auto tracks = trackWithDevice();
+    tracks[0].pan = -1.0f;  // hard left
+    const auto master = makeMaster();
+
+    const auto plan =
+        std::make_shared<const magda::engine::RenderPlan>(compileRenderPlan(tracks, master));
+
+    const auto masterGain = magda::engine::faderGainFromVolume(master.volume);
+    const auto trackGain = magda::engine::faderGainFromVolume(tracks[0].volume);
+
+    const auto renderWith = [&](const AutomationLaneInfo& automated) {
+        magda::engine::PlanValues values;
+        magda::engine::resolvePlanValues(*plan, tracks, master, values, std::vector{automated});
+
+        ToneFactory factory;
+        magda::engine::EngineSession session(factory);
+        REQUIRE(session
+                    .publish(plan, magda::engine::RenderContext{44100.0, 64, 2},
+                             magda::engine::collectRuntimeStateIds(tracks, master), values)
+                    .published);
+
+        juce::AudioBuffer<float> output(2, 64);
+        session.process(64, output);
+        return std::pair{output.getSample(0, 0), output.getSample(1, 0)};
+    };
+
+    SECTION("a lane over the pan alone still moves it") {
+        // Hard left in the model, hard right in the lane. A fader whose volume
+        // was not carried would leave the parameter unread and the track where
+        // the model left it.
+        const auto [left, right] = renderWith(lane(ControlTarget::trackPan(1), {point(0.0, 1.0)}));
+
+        CHECK(left == approx(0.0f));
+        CHECK(right == approx(2.0f * trackGain * masterGain));
+    }
+
+    SECTION("a lane over the volume alone leaves the pan where it was") {
+        // The track is hard left and the lane says unity. A fader that carried
+        // its volume without its pan would recentre the track the moment the
+        // lane moved it.
+        const auto [left, right] =
+            renderWith(lane(ControlTarget::trackVolume(1), {point(0.0, 0.75)}));
+
+        CHECK(left == approx(2.0f * masterGain));
+        CHECK(right == approx(0.0f));
+    }
 }
 
 TEST_CASE("A fader nothing automates keeps the published value", "[engine][param][bake]") {

--- a/tests/test_automation_bake.cpp
+++ b/tests/test_automation_bake.cpp
@@ -1,0 +1,428 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "core/AutomationCurve.hpp"
+#include "core/RackInfo.hpp"
+#include "core/TrackInfo.hpp"
+#include "exec/EngineSession.hpp"
+#include "exec/PlanValues.hpp"
+#include "param/ParamResolve.hpp"
+#include "param/ParamTableCompiler.hpp"
+#include "plan/PlanCompiler.hpp"
+
+/**
+ * @file test_automation_bake.cpp
+ * @brief Lanes playing over parameters (#2118).
+ *
+ * The curve is the model's, evaluated by the model's own function, so what is
+ * asserted here is not the shape of a bezier: it is that the right curve
+ * reaches the right parameter, that the block asks it about the right beats,
+ * and that a lane over a fader moves the fader.
+ */
+
+using namespace magda;
+using magda::engine::compileParamTable;
+using magda::engine::compileRenderPlan;
+using magda::engine::INVALID_PARAM_ID;
+using magda::engine::ModContribution;
+using magda::engine::ParamKey;
+using magda::engine::ParamSegment;
+using magda::engine::ParamTable;
+using magda::engine::ResolvedParams;
+using magda::engine::resolveParams;
+
+namespace {
+
+Catch::Approx approx(float value) {
+    return Catch::Approx(value).margin(1e-4);
+}
+
+TrackInfo makeTrack(TrackId id) {
+    TrackInfo track;
+    track.id = id;
+    track.name = "Track " + juce::String(id);
+    track.audioOutputDevice = "master";
+    track.macros = createDefaultMacros(2);
+    track.mods = createDefaultMods(0);
+    return track;
+}
+
+TrackInfo makeMaster() {
+    auto master = makeTrack(MASTER_TRACK_ID);
+    master.type = TrackType::Master;
+    master.audioOutputDevice = {};
+    return master;
+}
+
+DeviceInfo makeDevice(DeviceId id, int numParameters = 1) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Effect " + juce::String(id);
+    device.deviceType = DeviceType::Effect;
+    device.macros = createDefaultMacros(1);
+    device.mods = createDefaultMods(0);
+
+    for (int index = 0; index < numParameters; ++index) {
+        ParameterInfo info(index, "P" + juce::String(index), "%", 0.0f, 100.0f, 0.0f);
+        info.currentValue = 0.0f;
+        device.parameters.push_back(info);
+    }
+
+    return device;
+}
+
+AutomationPoint point(double beat, double value,
+                      AutomationCurveType curve = AutomationCurveType::Linear) {
+    AutomationPoint p;
+    p.id = static_cast<AutomationPointId>(beat * 1000.0) + 1;
+    p.beatPosition = beat;
+    p.value = value;
+    p.curveType = curve;
+    return p;
+}
+
+/// An absolute lane over @p target, playing.
+AutomationLaneInfo lane(const ControlTarget& target, std::vector<AutomationPoint> points) {
+    AutomationLaneInfo value;
+    value.id = 1;
+    value.target = target;
+    value.type = AutomationLaneType::Absolute;
+    value.authorityState = AutomationAuthorityState::Reading;
+    value.absolutePoints = std::move(points);
+    return value;
+}
+
+ParamKey deviceParam(TrackId track, DeviceId device, int index) {
+    ParamKey key;
+    key.kind = ParamKey::Kind::DeviceParam;
+    key.scope = ParamKey::Scope::Device;
+    key.trackId = track;
+    key.device = magda::engine::DeviceKey{ChainSegment::Fx, device};
+    key.index = index;
+    return key;
+}
+
+magda::engine::BlockInfo blockAt(double startBeat, double beats = 1.0, int numSamples = 64) {
+    magda::engine::BlockInfo block;
+    block.numSamples = numSamples;
+    block.playing = true;
+    block.startBeat = startBeat;
+    block.endBeat = startBeat + beats;
+    return block;
+}
+
+ParamTable tableFor(const std::vector<TrackInfo>& tracks,
+                    const std::vector<AutomationLaneInfo>& lanes,
+                    const std::vector<AutomationClipInfo>& clips = {}) {
+    const auto master = makeMaster();
+    const auto plan = compileRenderPlan(tracks, master);
+    return compileParamTable(plan, tracks, master, lanes, clips);
+}
+
+ResolvedParams resolved(const ParamTable& table, const magda::engine::BlockInfo& block) {
+    ResolvedParams values;
+    values.prepare(table.size());
+
+    std::vector<ModContribution> links(
+        static_cast<std::size_t>(std::max(table.maxLinksPerParam, 1)));
+    std::vector<ParamSegment> segments(static_cast<std::size_t>(values.segmentCapacity()));
+    resolveParams(table, values, links, segments, block);
+    return values;
+}
+
+/// A track with one device, and a lane over that device's first parameter.
+std::vector<TrackInfo> trackWithDevice() {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7)));
+    return {track};
+}
+
+ControlTarget deviceTarget() {
+    return ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0);
+}
+
+}  // namespace
+
+TEST_CASE("A lane plays over the parameter it targets", "[engine][param][bake]") {
+    const auto table =
+        tableFor(trackWithDevice(), {lane(deviceTarget(), {point(0.0, 0.0), point(4.0, 1.0)})});
+    REQUIRE(table.diagnostics.empty());
+
+    const auto param = table.find(deviceParam(1, 7, 0));
+    REQUIRE(param != INVALID_PARAM_ID);
+    REQUIRE(table.curveFor(param).size() == 2);
+
+    // A quarter of the way along a ramp that reads 0 to 100, at the beat the
+    // block opens on.
+    CHECK(resolved(table, blockAt(0.0))[param].value() == approx(0.0f));
+    CHECK(resolved(table, blockAt(1.0))[param].value() == approx(25.0f));
+    CHECK(resolved(table, blockAt(2.0))[param].value() == approx(50.0f));
+
+    // Past the end the curve holds, which is what makes a lane cover the whole
+    // timeline once it has a point on it.
+    CHECK(resolved(table, blockAt(9.0))[param].value() == approx(100.0f));
+}
+
+TEST_CASE("A lane replaces the stored value where it plays", "[engine][param][bake]") {
+    auto tracks = trackWithDevice();
+    auto& device = magda::getDevice(tracks[0].chain.fxChainElements[0]);
+    device.parameters[0].currentValue = 25.0f;
+
+    const auto withoutLane = tableFor(tracks, {});
+    const auto param = withoutLane.find(deviceParam(1, 7, 0));
+    CHECK(resolved(withoutLane, blockAt(0.0))[param].value() == approx(25.0f));
+
+    const auto withLane = tableFor(tracks, {lane(deviceTarget(), {point(0.0, 1.0)})});
+    CHECK(resolved(withLane, blockAt(0.0))[param].value() == approx(100.0f));
+}
+
+TEST_CASE("Modulation is added to what the lane says", "[engine][param][bake]") {
+    auto tracks = trackWithDevice();
+    tracks[0].macros[0].value = 1.0f;
+    tracks[0].macros[0].links.push_back(MacroLink{deviceTarget(), 0.25f, false});
+
+    const auto table = tableFor(tracks, {lane(deviceTarget(), {point(0.0, 0.5)})});
+    const auto param = table.find(deviceParam(1, 7, 0));
+
+    // Half from the curve, a quarter from the macro.
+    CHECK(resolved(table, blockAt(0.0))[param].value() == approx(75.0f));
+}
+
+TEST_CASE("A lane the model is not playing is not carried", "[engine][param][bake]") {
+    const auto states = {AutomationAuthorityState::Disabled, AutomationAuthorityState::Touching,
+                         AutomationAuthorityState::Writing};
+
+    for (const auto state : states) {
+        auto held = lane(deviceTarget(), {point(0.0, 1.0)});
+        held.authorityState = state;
+
+        const auto table = tableFor(trackWithDevice(), {held});
+        const auto param = table.find(deviceParam(1, 7, 0));
+
+        INFO("authority state " << static_cast<int>(state));
+        REQUIRE(param != INVALID_PARAM_ID);
+        CHECK(table.curveFor(param).empty());
+        CHECK(resolved(table, blockAt(0.0))[param].value() == approx(0.0f));
+    }
+}
+
+TEST_CASE("An empty lane is not a lane", "[engine][param][bake]") {
+    const auto table = tableFor(trackWithDevice(), {lane(deviceTarget(), {})});
+    const auto param = table.find(deviceParam(1, 7, 0));
+    CHECK(table.curveFor(param).empty());
+}
+
+TEST_CASE("A lane over a macro drives what the macro drives", "[engine][param][bake]") {
+    auto tracks = trackWithDevice();
+    tracks[0].macros[0].value = 0.0f;
+    tracks[0].macros[0].links.push_back(MacroLink{deviceTarget(), 1.0f, false});
+
+    const auto macro = ControlTarget::deviceMacro(ChainNodePath::trackLevel(1), 0);
+    const auto table = tableFor(tracks, {lane(macro, {point(0.0, 0.0), point(4.0, 1.0)})});
+    const auto param = table.find(deviceParam(1, 7, 0));
+
+    // The macro's own value is automated, and what it drives follows: the order
+    // the table resolves in is what makes that one pass rather than two.
+    CHECK(resolved(table, blockAt(0.0))[param].value() == approx(0.0f));
+    CHECK(resolved(table, blockAt(2.0))[param].value() == approx(50.0f));
+}
+
+TEST_CASE("A stepped parameter is quantised by its own scale", "[engine][param][bake]") {
+    auto tracks = trackWithDevice();
+    auto& device = magda::getDevice(tracks[0].chain.fxChainElements[0]);
+    device.parameters[0].scale = ParameterScale::Discrete;
+    device.parameters[0].choices = {"Off", "Low", "High"};
+    device.parameters[0].minValue = 0.0f;
+    device.parameters[0].maxValue = 2.0f;
+
+    const auto table = tableFor(tracks, {lane(deviceTarget(), {point(0.0, 0.0), point(4.0, 1.0)})});
+    const auto param = table.find(deviceParam(1, 7, 0));
+
+    // The curve is continuous and the parameter is not: the scale is where the
+    // steps are, and the value a device reads is one of its three choices.
+    CHECK(resolved(table, blockAt(0.0))[param].value() == approx(0.0f));
+    CHECK(resolved(table, blockAt(1.0))[param].value() == approx(1.0f));
+    CHECK(resolved(table, blockAt(3.9))[param].value() == approx(2.0f));
+}
+
+TEST_CASE("A clip lane loops and holds the way the model does", "[engine][param][bake]") {
+    AutomationClipInfo clip;
+    clip.id = 5;
+    clip.laneId = 1;
+    clip.startBeats = 4.0;
+    clip.lengthBeats = 8.0;
+    clip.looping = true;
+    clip.loopLengthBeats = 4.0;
+    clip.points = {point(0.0, 0.0), point(4.0, 1.0)};
+
+    auto clipLane = lane(deviceTarget(), {});
+    clipLane.type = AutomationLaneType::ClipBased;
+    clipLane.clipIds = {clip.id};
+
+    const auto table = tableFor(trackWithDevice(), {clipLane}, {clip});
+    const auto param = table.find(deviceParam(1, 7, 0));
+    REQUIRE(param != INVALID_PARAM_ID);
+    REQUIRE_FALSE(table.curveFor(param).empty());
+
+    // Before the clip: its first value, held.
+    CHECK(resolved(table, blockAt(0.0))[param].value() == approx(0.0f));
+    // Inside its first iteration.
+    CHECK(resolved(table, blockAt(6.0))[param].value() == approx(50.0f));
+    // Inside its second: the loop wrapped rather than carrying on climbing.
+    CHECK(resolved(table, blockAt(10.0))[param].value() == approx(50.0f));
+    // After the clip ends, its last value holds. A hair under the top rather
+    // than on it: the flattener plants its closing hold just inside the clip's
+    // end so a truncated final iteration cuts off where the clip does, and what
+    // the engine plays is that flattened list rather than a second reading of
+    // the same lane.
+    CHECK(resolved(table, blockAt(20.0))[param].value() == Catch::Approx(100.0f).margin(0.05));
+}
+
+TEST_CASE("A block reads one value unless its device asked for more", "[engine][param][bake]") {
+    auto tracks = trackWithDevice();
+    const auto table = tableFor(tracks, {lane(deviceTarget(), {point(0.0, 0.0), point(4.0, 1.0)})});
+    const auto param = table.find(deviceParam(1, 7, 0));
+
+    const auto values = resolved(table, blockAt(0.0, 4.0, 128));
+    REQUIRE(values[param].numSegments() == 1);
+    CHECK(values[param].isConstant());
+    CHECK(values[param].valueAt(127) == approx(0.0f));
+}
+
+TEST_CASE("A device that asked for segments gets one per breakpoint", "[engine][param][bake]") {
+    auto tracks = trackWithDevice();
+
+    // The block spans two beats and the curve turns inside it.
+    const auto table = tableFor(
+        tracks, {lane(deviceTarget(), {point(0.0, 0.0), point(1.0, 1.0), point(2.0, 0.0)})});
+
+    auto param = table.find(deviceParam(1, 7, 0));
+    REQUIRE(param != INVALID_PARAM_ID);
+
+    // Opting in is the device's, and the table is the model's, so the spec is
+    // reached for here rather than declared by a fixture.
+    auto opted = table;
+    opted.specs[static_cast<std::size_t>(param)].segmentAccurate = true;
+
+    const auto values = resolved(opted, blockAt(0.0, 2.0, 128));
+    REQUIRE(values[param].numSegments() == 2);
+    CHECK(values[param].valueAt(0) == approx(0.0f));
+    CHECK(values[param].valueAt(64) == approx(100.0f));
+    CHECK(values[param].valueAt(127) == approx(1.5625f));
+}
+
+namespace {
+
+/// A device that fills its output with ones, so what comes out of the master is
+/// the gain of everything after it.
+class ToneDevice final : public magda::engine::EngineDevice {
+  public:
+    void process(magda::engine::DeviceBlock& block) override {
+        block.audio.fill(1.0f);
+    }
+};
+
+class ToneFactory final : public magda::engine::RuntimeStateFactory {
+  public:
+    std::unique_ptr<magda::engine::EngineDevice> createDevice(magda::engine::DeviceKey) override {
+        return std::make_unique<ToneDevice>();
+    }
+};
+
+/// One block rendered through a live session, and the first sample of it. The
+/// generation climbs because a locate is only applied when it does.
+float render(magda::engine::EngineSession& session, double startBeat) {
+    static std::uint64_t generation = 0;
+
+    magda::engine::TransportSnapshot transport;
+    transport.request.generation = ++generation;
+    transport.request.playing = true;
+    transport.request.locate = true;
+    transport.request.positionBeat = startBeat;
+    session.publishTransport(transport);
+
+    juce::AudioBuffer<float> output(2, 64);
+    session.process(64, output);
+    return output.getSample(0, 0);
+}
+
+}  // namespace
+
+TEST_CASE("A lane over a track fader moves the fader", "[engine][param][bake]") {
+    auto tracks = trackWithDevice();
+    const auto master = makeMaster();
+
+    // A ramp from silence to unity over four beats, in the fader's own domain:
+    // 0.75 of the way up a fader is 0 dB, which is where MAGDA's fader sits at
+    // unity.
+    const auto volume = lane(ControlTarget::trackVolume(1), {point(0.0, 0.0), point(4.0, 0.75)});
+
+    const auto plan =
+        std::make_shared<const magda::engine::RenderPlan>(compileRenderPlan(tracks, master));
+
+    magda::engine::PlanValues values;
+    magda::engine::resolvePlanValues(*plan, tracks, master, values, std::vector{volume});
+    REQUIRE(values.params != nullptr);
+
+    ParamKey key;
+    key.kind = ParamKey::Kind::TrackVolume;
+    key.scope = ParamKey::Scope::Track;
+    key.trackId = 1;
+    REQUIRE(values.params->find(key) != INVALID_PARAM_ID);
+
+    ToneFactory factory;
+    magda::engine::EngineSession session(factory);
+    REQUIRE(session
+                .publish(plan, magda::engine::RenderContext{44100.0, 64, 2},
+                         magda::engine::collectRuntimeStateIds(tracks, master), values)
+                .published);
+
+    // What the master fader does to whatever reaches it, which is the same at
+    // every beat: the track's fader is the only thing moving.
+    const auto masterGain = magda::engine::faderGainFromVolume(master.volume);
+
+    const auto expected = [&](double normalised) {
+        const auto info = magda::ParameterPresets::faderVolume(-1, "Volume");
+        const auto decibels =
+            magda::ParameterUtils::normalizedToReal(static_cast<float>(normalised), info);
+        return magda::engine::faderGainFromDecibels(decibels) * masterGain;
+    };
+
+    CHECK(render(session, 0.0) == approx(expected(0.0)));
+    CHECK(render(session, 2.0) == approx(expected(0.375)));
+    CHECK(render(session, 4.0) == approx(expected(0.75)));
+}
+
+TEST_CASE("A fader nothing automates keeps the published value", "[engine][param][bake]") {
+    auto tracks = trackWithDevice();
+    tracks[0].volume = 0.5f;
+    const auto master = makeMaster();
+
+    const auto plan =
+        std::make_shared<const magda::engine::RenderPlan>(compileRenderPlan(tracks, master));
+
+    magda::engine::PlanValues values;
+    magda::engine::resolvePlanValues(*plan, tracks, master, values);
+
+    // Not carried at all: a mixer value is a parameter only when something
+    // reaches it, so a project with no automation on its faders pays nothing
+    // and renders through the value table exactly as it did before.
+    ParamKey key;
+    key.kind = ParamKey::Kind::TrackVolume;
+    key.scope = ParamKey::Scope::Track;
+    key.trackId = 1;
+    CHECK(values.params->find(key) == INVALID_PARAM_ID);
+
+    ToneFactory factory;
+    magda::engine::EngineSession session(factory);
+    REQUIRE(session
+                .publish(plan, magda::engine::RenderContext{44100.0, 64, 2},
+                         magda::engine::collectRuntimeStateIds(tracks, master), values)
+                .published);
+
+    CHECK(render(session, 0.0) == approx(magda::engine::faderGainFromVolume(0.5f) *
+                                         magda::engine::faderGainFromVolume(master.volume)));
+}

--- a/tests/test_param_table.cpp
+++ b/tests/test_param_table.cpp
@@ -84,13 +84,27 @@ ParamTable tableFor(std::vector<TrackInfo> tracks, TrackInfo master = makeMaster
 }
 
 /// One block resolved out of a table, with the room the resolver needs.
-ResolvedParams resolved(const ParamTable& table, int numSamples = 64) {
+/// A block of @p numSamples starting where the transport is, which for most of
+/// these is the beginning and does not matter: a parameter with no curve reads
+/// the same wherever the block is.
+magda::engine::BlockInfo blockAt(double startBeat, int numSamples = 64, double beats = 1.0) {
+    magda::engine::BlockInfo block;
+    block.numSamples = numSamples;
+    block.playing = true;
+    block.startBeat = startBeat;
+    block.endBeat = startBeat + beats;
+    return block;
+}
+
+ResolvedParams resolved(const ParamTable& table, magda::engine::BlockInfo block = blockAt(0.0)) {
     ResolvedParams values;
     values.prepare(table.size());
 
-    std::vector<ModContribution> scratch(
+    std::vector<ModContribution> links(
         static_cast<std::size_t>(std::max(table.maxLinksPerParam, 1)));
-    resolveParams(table, values, scratch, numSamples);
+    std::vector<magda::engine::ParamSegment> segments(
+        static_cast<std::size_t>(values.segmentCapacity()));
+    resolveParams(table, values, links, segments, block);
     return values;
 }
 
@@ -269,8 +283,10 @@ TEST_CASE("Breaking a cycle costs the cycle and not what hangs off it", "[engine
 TEST_CASE("A link the table cannot carry is reported rather than dropped",
           "[engine][param][table]") {
     SECTION("a target this table does not resolve") {
+        // The tempo is the one target left that belongs somewhere else: it is
+        // the transport's, and no table of parameters carries it.
         auto track = makeTrack(1);
-        track.macros[0].links.push_back(MacroLink{ControlTarget::trackVolume(1), 1.0f, false});
+        track.macros[0].links.push_back(MacroLink{ControlTarget::tempo(), 1.0f, false});
 
         const auto table = tableFor({track});
         CHECK(mentions(table, "does not carry yet"));
@@ -387,9 +403,19 @@ TEST_CASE("A macro inside a rack addresses the device inside it", "[engine][para
 }
 
 TEST_CASE("An address the model cannot mean resolves to nothing", "[engine][param][table]") {
-    CHECK_FALSE(paramKeyFor(ControlTarget::trackVolume(1)).has_value());
-    CHECK_FALSE(paramKeyFor(ControlTarget::sendLevel(1, 0)).has_value());
     CHECK_FALSE(paramKeyFor(ControlTarget::tempo()).has_value());
+
+    // The mixer values are addresses this table carries (#2118), so they
+    // resolve; whether the project allocates one is a separate question.
+    const auto volume = paramKeyFor(ControlTarget::trackVolume(1));
+    REQUIRE(volume.has_value());
+    CHECK(volume->kind == ParamKey::Kind::TrackVolume);
+    CHECK(volume->trackId == 1);
+
+    const auto send = paramKeyFor(ControlTarget::sendLevel(1, 2));
+    REQUIRE(send.has_value());
+    CHECK(send->kind == ParamKey::Kind::SendLevel);
+    CHECK(send->index == 2);
 
     // A chain owns no macros and no modifiers: they live on tracks, racks and
     // devices, and a chain is what sits between two of them.
@@ -420,8 +446,10 @@ TEST_CASE("A table belongs to the plan it was resolved against", "[engine][param
     values.prepare(table.size() + 1);
     values.beginBlock(32);
 
-    std::vector<ModContribution> scratch(1);
-    resolveParams(table, values, scratch, 32);
+    std::vector<ModContribution> links(1);
+    std::vector<magda::engine::ParamSegment> segments(
+        static_cast<std::size_t>(values.segmentCapacity()));
+    resolveParams(table, values, links, segments, blockAt(0.0, 32));
     CHECK(values[0].empty());
 }
 
@@ -522,10 +550,12 @@ TEST_CASE("A refused table renders empty rather than stale", "[engine][param][ta
 
     ResolvedParams values;
     values.prepare(table.size());
-    std::vector<ModContribution> scratch(
+    std::vector<ModContribution> links(
         static_cast<std::size_t>(std::max(table.maxLinksPerParam, 1)));
+    std::vector<magda::engine::ParamSegment> segments(
+        static_cast<std::size_t>(values.segmentCapacity()));
 
-    resolveParams(table, values, scratch, 64);
+    resolveParams(table, values, links, segments, blockAt(0.0));
     REQUIRE_FALSE(values[0].empty());
 
     // A table of another shape is refused, and what the last block resolved
@@ -537,7 +567,7 @@ TEST_CASE("A refused table renders empty rather than stale", "[engine][param][ta
     other.base.resize(table.size() + 1, 0.0f);
     other.linkOffsets.assign(table.size() + 2, 0);
 
-    resolveParams(other, values, scratch, 64);
+    resolveParams(other, values, links, segments, blockAt(0.0));
     for (int param = 0; param < values.size(); ++param)
         CHECK(values[param].empty());
 }

--- a/tests/test_plan_goldens.cpp
+++ b/tests/test_plan_goldens.cpp
@@ -119,7 +119,8 @@ std::string renderGolden(const goldens::Fixture& fixture) {
     // the graph and the parameters at once, and two files would make one
     // decision look like two regressions.
     out << "== params ==\n"
-        << engine::dumpParamTable(engine::compileParamTable(plan, fixture.tracks, fixture.master))
+        << engine::dumpParamTable(engine::compileParamTable(plan, fixture.tracks, fixture.master,
+                                                            fixture.lanes, fixture.clips))
         << "\n";
 
     if (fixture.editedTracks.empty())


### PR DESCRIPTION
Closes #2118. Slice 3 of #1891.

#2116 built the lane, #2117 filled it with stored values and links. This is the third writer: the curve.

## One curve, read in three places

The shape of a lane was inside `AutomationManager`, which the engine cannot reach. It moves to `core/AutomationCurve.hpp` as two pure functions: the value of a breakpoint list at a beat, and the value of a whole lane at one, clips and loops and gaps included. The manager delegates to them, so the editor drawing a curve, the DAW playing it and the engine baking it are one function rather than three readings that agree until they do not.

Nothing about the curve itself is ported. Bezier through the parametric cubic solved for the queried beat, linear through the shared `curvemath::evalSegment`, step held, hard corner as two runs meeting at its apex: all of it is the model's, moved rather than rewritten.

## Beats in the table, samples in the block

A lane rides in the parameter table beside the base and the links, as breakpoints in beats. Not baked into segments at publish time, because a block is what decides which stretch of a curve is being asked about and how long that stretch lasts: a curve resolved into samples by the publisher would have to be republished every time the tempo moved.

A clip-based lane arrives already flattened by the model's own flattener (#1087), loops unrolled and gaps held at the nearest clip edge. The engine plays what MAGDA plays rather than forming a second opinion about what a looping clip means.

Which lanes play is the model's decision and is asked rather than second-guessed: read mode is playback, and disabled, touching and writing are all the user's hand on the parameter, where the base is what a parameter is worth.

## What a block reads

One value, held, unless the device asked for more. That is the port's shape everywhere: the incumbent engine settles a parameter at the block boundary, and a curve read more finely than that would differ from it on every automated parameter in every project.

A parameter that opted into segment accuracy gets a segment per breakpoint the block contains. The bend between two breakpoints reads as a straight line inside a block; over a few milliseconds that is a difference no device has asked to hear, and subdividing is what to do when one does.

## The mixer values cross over

As the issue said they would, and this is the slice that needs them: a lane over a fader moves it inside a block, which a table resolved by the publisher cannot do.

A track's volume, its pan and its send levels become parameters **when something reaches them**. The fader op then reads its gain from the block rather than from the value table, through the same TE curve `PlanValues` has always used (`faderGainFromDecibels`, then the linear pan law through the same deadband). Mute and solo stay where they are: nothing plays a lane over them, and a fader that moved does not make a muted track audible.

When nothing reaches them they are not carried at all. A project with no automation on its faders allocates nothing, renders through the value table exactly as it did before, and the null-diff corpus goes on comparing the same arithmetic it did yesterday. That is deliberate: the crossover is opt-in by use, not a rewrite of every render.

## Testing

`make test` green locally: 2735 cases, 588729 assertions, 0 failures. `make test-juce` green.

Twenty-seven new cases in `test_automation_bake.cpp`: a lane replacing a base, modulation adding to a lane, a lane over a macro driving what the macro drives, a stepped parameter quantised by its own scale rather than by the curve, a looping clip lane holding in its gaps, the block-rate default, the segment-accurate opt-in, and a fader lane ramping from silence to unity through a live `EngineSession`, read back off the master's output.

The `parameter-links` golden now carries a device lane and a fader lane, so the table's third writer is pinned as text alongside the first two.
