### PR TITLE
Make the LFO turn (#2119)

### DIFF
--- a/magda/daw/CMakeLists.txt
+++ b/magda/daw/CMakeLists.txt
@@ -264,6 +264,10 @@ add_library(magda_types STATIC
     # The shape of an automation lane, on its own, so the engine bakes a curve
     # through the same function the editor draws it with (#2118).
     core/AutomationCurve.cpp
+    # The shape of a modulator's cycle, on the same terms: the editor's preview,
+    # the fork's audio snapshot and the native engine's LFO read one curve
+    # rather than three (#2119).
+    core/ModCurve.cpp
     core/DeviceState.cpp
     # Clip placement rules (#2003). Pure, beat domain, no manager: they answer
     # against a lane of clips, which is what lets the arrangement ask about a
@@ -284,6 +288,7 @@ add_library(magda_types STATIC
     core/ParameterUtils.hpp
     core/AutomationCurve.hpp
     core/AutomationInfo.hpp
+    core/ModCurve.hpp
     core/DeviceInfo.hpp
     core/DeviceState.hpp
     core/KitRow.hpp

--- a/magda/daw/audio/modifiers/CurveSnapshot.hpp
+++ b/magda/daw/audio/modifiers/CurveSnapshot.hpp
@@ -4,8 +4,9 @@
 #include <array>
 #include <atomic>
 #include <cmath>
+#include <span>
 
-#include "../../core/CurveMath.hpp"
+#include "../../core/ModCurve.hpp"
 #include "../../core/ModInfo.hpp"
 
 namespace magda {
@@ -19,16 +20,9 @@ namespace magda {
 struct CurveSnapshot {
     static constexpr int kMaxPoints = 64;
 
-    struct Point {
-        float phase = 0.0f;
-        float value = 0.5f;
-        float tension = 0.0f;
-        int curveType = 0;
-        float inHandleX = 0.0f;
-        float inHandleY = 0.0f;
-        float outHandleX = 0.0f;
-        float outHandleY = 0.0f;
-    };
+    /// The model's own point, so the snapshot is a fixed-size copy of the
+    /// drawn curve rather than a second description of one.
+    using Point = CurvePointData;
 
     std::array<Point, kMaxPoints> points{};
     int count = 0;
@@ -46,35 +40,19 @@ struct CurveSnapshot {
     float loopStart = 0.0f;
     float loopEnd = 1.0f;
 
+    /// The drawn points, as a span the shared reading takes.
+    std::span<const Point> drawn() const {
+        return {points.data(), static_cast<size_t>(count)};
+    }
+
     /**
      * @brief Generate a preset curve value (no custom points).
      *
-     * Same logic as ModulatorEngine::generateCurvePreset — pure math, no
-     * allocations, safe for audio thread.
+     * The model's own reading (core/ModCurve.hpp): pure math, no allocations,
+     * safe for the audio thread.
      */
     static float evaluatePreset(CurvePreset p, float phase) {
-        constexpr float PI = 3.14159265359f;
-        switch (p) {
-            case CurvePreset::Triangle:
-                return (phase < 0.5f) ? phase * 2.0f : 2.0f - phase * 2.0f;
-            case CurvePreset::Sine:
-                return (std::sin(2.0f * PI * phase) + 1.0f) * 0.5f;
-            case CurvePreset::RampUp:
-                return phase;
-            case CurvePreset::RampDown:
-                return 1.0f - phase;
-            case CurvePreset::SCurve: {
-                float t = phase;
-                return t * t * (3.0f - 2.0f * t);
-            }
-            case CurvePreset::Exponential:
-                return (std::exp(phase * 3.0f) - 1.0f) / (std::exp(3.0f) - 1.0f);
-            case CurvePreset::Logarithmic:
-                return std::log(1.0f + phase * (std::exp(1.0f) - 1.0f));
-            case CurvePreset::Custom:
-            default:
-                return phase;
-        }
+        return magda::modcurve::preset(p, phase);
     }
 
     /**
@@ -85,9 +63,7 @@ struct CurveSnapshot {
      * (which would interpolate from the last point back toward the first).
      */
     float endValue() const {
-        if (count > 0)
-            return points[static_cast<size_t>(count - 1)].value;
-        return evaluatePreset(preset, 1.0f);
+        return magda::modcurve::endValue(LFOWaveform::Custom, preset, drawn());
     }
 
     /**
@@ -104,118 +80,11 @@ struct CurveSnapshot {
     /**
      * @brief Evaluate the curve at a given phase.
      *
-     * If custom points exist, uses tension-based interpolation (same as
-     * ModulatorEngine::evaluateCurvePoints). Otherwise falls back to
-     * generating the preset curve mathematically.
+     * The model's own reading (core/ModCurve.hpp), so the editor's preview,
+     * this snapshot and the native engine's LFO all draw one curve.
      */
     float evaluate(float phase) const {
-        if (count == 0)
-            return evaluatePreset(preset, phase);
-        if (count == 1)
-            return points[0].value;
-
-        const Point* p1 = nullptr;
-        const Point* p2 = nullptr;
-
-        for (int i = 0; i < count; ++i) {
-            if (points[static_cast<size_t>(i)].phase > phase) {
-                if (i == 0) {
-                    p1 = &points[static_cast<size_t>(count - 1)];
-                    p2 = &points[0];
-                } else {
-                    p1 = &points[static_cast<size_t>(i - 1)];
-                    p2 = &points[static_cast<size_t>(i)];
-                }
-                break;
-            }
-        }
-
-        if (!p1) {
-            p1 = &points[static_cast<size_t>(count - 1)];
-            p2 = &points[0];
-        }
-
-        // Step: the segment holds p1's value until the next point (sample &
-        // hold / rectangular steps).
-        constexpr int kStepCurveType = 2;
-        if (p1->curveType == kStepCurveType)
-            return p1->value;
-
-        float phaseSpan;
-        float localPhase;
-        if (p2->phase < p1->phase) {
-            phaseSpan = (1.0f - p1->phase) + p2->phase;
-            if (phase >= p1->phase)
-                localPhase = phase - p1->phase;
-            else
-                localPhase = (1.0f - p1->phase) + phase;
-        } else {
-            phaseSpan = p2->phase - p1->phase;
-            localPhase = phase - p1->phase;
-        }
-
-        float t = (phaseSpan > 0.0001f) ? (localPhase / phaseSpan) : 0.0f;
-        t = std::clamp(t, 0.0f, 1.0f);
-
-        float tension = p1->tension;
-        auto applyTension = [tension](float input) {
-            if (std::abs(tension) < 0.001f)
-                return input;
-            if (tension > 0)
-                return std::pow(input, 1.0f + tension * 2.0f);
-            return 1.0f - std::pow(1.0f - input, 1.0f - tension * 2.0f);
-        };
-
-        auto getShaper = [&]() {
-            struct Shaper {
-                float t = 0.5f;
-                float value = 0.5f;
-                bool stored = false;
-            };
-
-            constexpr float kHandleEpsilon = 0.000001f;
-            const bool hasStoredShaper =
-                p2->phase > p1->phase && (std::abs(p1->outHandleX) > kHandleEpsilon ||
-                                          std::abs(p1->outHandleY) > kHandleEpsilon ||
-                                          std::abs(p2->inHandleX) > kHandleEpsilon ||
-                                          std::abs(p2->inHandleY) > kHandleEpsilon);
-
-            if (hasStoredShaper) {
-                const float shaperPhase =
-                    std::clamp(p1->phase + p1->outHandleX, p1->phase, p2->phase);
-                const float shaperT = (p2->phase - p1->phase > 0.0001f)
-                                          ? ((shaperPhase - p1->phase) / (p2->phase - p1->phase))
-                                          : 0.5f;
-                return Shaper{std::clamp(shaperT, 0.001f, 0.999f),
-                              std::clamp(p1->value + p1->outHandleY, 0.0f, 1.0f), true};
-            }
-
-            constexpr float cornerT = 0.5f;
-            return Shaper{cornerT, p1->value + applyTension(cornerT) * (p2->value - p1->value),
-                          false};
-        };
-
-        constexpr int kHardCornerCurveType = 3;
-        if (p1->curveType == kHardCornerCurveType) {
-            const auto shaper = getShaper();
-            if (t <= shaper.t) {
-                const float u = t / shaper.t;
-                return p1->value + u * (shaper.value - p1->value);
-            }
-            const float u = (t - shaper.t) / (1.0f - shaper.t);
-            return shaper.value + u * (p2->value - shaper.value);
-        }
-
-        // Linear segment: shared bounded power warp so the audio output matches
-        // exactly what the curve editor draws (see core/CurveMath.hpp).
-        constexpr float kLinearHandleEps = 0.000001f;
-        const bool hasStoredShaper =
-            p2->phase > p1->phase && (std::abs(p1->outHandleX) > kLinearHandleEps ||
-                                      std::abs(p1->outHandleY) > kLinearHandleEps ||
-                                      std::abs(p2->inHandleX) > kLinearHandleEps ||
-                                      std::abs(p2->inHandleY) > kLinearHandleEps);
-        return magda::curvemath::evalSegment(p1->value, p2->value, p1->value + p1->outHandleY,
-                                             tension, hasStoredShaper, t);
+        return magda::modcurve::shapeAt(LFOWaveform::Custom, preset, drawn(), phase);
     }
 };
 
@@ -266,18 +135,8 @@ struct CurveSnapshotHolder {
         back->count =
             std::min(static_cast<int>(modInfo.curvePoints.size()), CurveSnapshot::kMaxPoints);
 
-        for (int i = 0; i < back->count; ++i) {
-            const auto& src = modInfo.curvePoints[static_cast<size_t>(i)];
-            auto& dst = back->points[static_cast<size_t>(i)];
-            dst.phase = src.phase;
-            dst.value = src.value;
-            dst.tension = src.tension;
-            dst.curveType = src.curveType;
-            dst.inHandleX = src.inHandleX;
-            dst.inHandleY = src.inHandleY;
-            dst.outHandleX = src.outHandleX;
-            dst.outHandleY = src.outHandleY;
-        }
+        for (int i = 0; i < back->count; ++i)
+            back->points[static_cast<size_t>(i)] = modInfo.curvePoints[static_cast<size_t>(i)];
 
         // Swap: audio thread will now read from the newly written buffer
         active.store(back, std::memory_order_release);

--- a/magda/daw/core/AutomationInfo.cpp
+++ b/magda/daw/core/AutomationInfo.cpp
@@ -61,45 +61,15 @@ juce::String getModParamDisplayName(int modParamIndex) {
     return "Param " + juce::String(modParamIndex);
 }
 
+/// The two readings of a modulator's Rate lane, which are the model's own
+/// (ParameterPresets) so the editor, the fork and the native engine read one
+/// description of it rather than three.
 ParameterInfo makeHzRateInfo(const juce::String& name) {
-    // Logarithmic Hz scale, range chosen so the geometric centre
-    // (sqrt(min*max)) lands on 1 Hz — the natural musical mid for
-    // an LFO. 0.05..20 means lane mid = 1 Hz; the slider uses the
-    // same range so the slider position and lane curve agree.
-    ParameterInfo info = ParameterPresets::frequency(0, name, 0.05f, 20.0f);
-    info.teMinValue = 0.05f;
-    info.teMaxValue = 20.0f;
-    info.defaultValue = 1.0f;
-    return info;
+    return ParameterPresets::modRateHz(name);
 }
 
 ParameterInfo makeSyncDivisionInfo(const juce::String& name) {
-    // TE's RateType enum is ordered slow → fast (hertz=0, sixteenBars=1, ...,
-    // sixtyFourthT=23). MAGDA's slider exposes 16 Bars..1/32T (TE ordinals
-    // 1..20) and doesn't expose Hertz as a sync division — Hz is the rate
-    // parameter (modParamIndex 0), not a sync setting. The lane therefore
-    // drops the TE-ordinal-0 ("Hertz") slot and stores a 0-based display
-    // index instead; the manager / playback writeback shift by ±1 at the TE
-    // boundary so the lane never resolves "Hertz" at the bottom edge.
-    // labelTicks names only the plain divisions to keep the axis legible —
-    // dotted / triplet still appear in value→string lookup via `choices`.
-    ParameterInfo info;
-    info.paramIndex = 1;
-    info.name = name;
-    info.unit = "";
-    info.minValue = 0.0f;
-    info.maxValue = 19.0f;
-    info.teMinValue = 1.0f;
-    info.teMaxValue = 20.0f;
-    info.defaultValue = 9.0f;  // quarter (TE ordinal 10 - 1)
-    info.scale = ParameterScale::Discrete;
-    info.displayFormat = DisplayFormat::Default;
-    info.choices = {"16 Bars", "8 Bars", "4 Bars", "2 Bars", "1 Bar", "1/2.", "1/2",
-                    "1/2T",    "1/4.",   "1/4",    "1/4T",   "1/8.",  "1/8",  "1/8T",
-                    "1/16.",   "1/16",   "1/16T",  "1/32.",  "1/32",  "1/32T"};
-    info.labelTicks = {{0.0f, "16 Bars"}, {2.0f, "4 Bars"}, {4.0f, "1 Bar"}, {6.0f, "1/2"},
-                       {9.0f, "1/4"},     {12.0f, "1/8"},   {15.0f, "1/16"}, {18.0f, "1/32"}};
-    return info;
+    return ParameterPresets::modRateSyncDivision(name);
 }
 
 ParameterInfo makeTempoInfo(const juce::String& name) {

--- a/magda/daw/core/ModCurve.cpp
+++ b/magda/daw/core/ModCurve.cpp
@@ -1,0 +1,170 @@
+#include "ModCurve.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "CurveMath.hpp"
+
+namespace magda::modcurve {
+
+namespace {
+
+constexpr float kPi = 3.14159265359f;
+
+/// The curve types a drawn point can open its run with. Stored as an int on
+/// CurvePointData because the editor writes it from a menu index.
+constexpr int kStepCurveType = 2;
+constexpr int kHardCornerCurveType = 3;
+
+/// A handle this small is a handle nobody dragged. Below it the run is shaped
+/// by its tension scalar alone, which is what a point the user has only bent
+/// carries.
+constexpr float kHandleEpsilon = 0.000001f;
+
+bool hasDraggedHandle(const CurvePointData& from, const CurvePointData& to) {
+    return to.phase > from.phase &&
+           (std::abs(from.outHandleX) > kHandleEpsilon ||
+            std::abs(from.outHandleY) > kHandleEpsilon || std::abs(to.inHandleX) > kHandleEpsilon ||
+            std::abs(to.inHandleY) > kHandleEpsilon);
+}
+
+}  // namespace
+
+float waveform(LFOWaveform wave, float phase) {
+    switch (wave) {
+        case LFOWaveform::Sine:
+            return (std::sin(2.0f * kPi * phase) + 1.0f) * 0.5f;
+        case LFOWaveform::Triangle:
+            return (phase < 0.5f) ? phase * 2.0f : 2.0f - phase * 2.0f;
+        case LFOWaveform::Square:
+            return phase < 0.5f ? 1.0f : 0.0f;
+        case LFOWaveform::Saw:
+            return phase;
+        case LFOWaveform::ReverseSaw:
+            return 1.0f - phase;
+        case LFOWaveform::Custom:
+            // Nothing drawn and no preset to fall back on from here. Triangle
+            // is what the curve editor opens on, so it is what a Custom
+            // waveform asked about on its own answers with.
+            return (phase < 0.5f) ? phase * 2.0f : 2.0f - phase * 2.0f;
+    }
+    return 0.5f;
+}
+
+float preset(CurvePreset shape, float phase) {
+    switch (shape) {
+        case CurvePreset::Triangle:
+            return (phase < 0.5f) ? phase * 2.0f : 2.0f - phase * 2.0f;
+        case CurvePreset::Sine:
+            return (std::sin(2.0f * kPi * phase) + 1.0f) * 0.5f;
+        case CurvePreset::RampUp:
+            return phase;
+        case CurvePreset::RampDown:
+            return 1.0f - phase;
+        case CurvePreset::SCurve:
+            return phase * phase * (3.0f - 2.0f * phase);
+        case CurvePreset::Exponential:
+            return (std::exp(phase * 3.0f) - 1.0f) / (std::exp(3.0f) - 1.0f);
+        case CurvePreset::Logarithmic:
+            return std::log(1.0f + phase * (std::exp(1.0f) - 1.0f));
+        case CurvePreset::Custom:
+            break;
+    }
+    return phase;
+}
+
+float points(std::span<const CurvePointData> curve, float phase) {
+    if (curve.empty())
+        return 0.5f;
+    if (curve.size() == 1)
+        return curve[0].value;
+
+    // The run @p phase falls in. Past the last point it is the run that closes
+    // the cycle, from the last point back round to the first.
+    const CurvePointData* from = nullptr;
+    const CurvePointData* to = nullptr;
+
+    for (std::size_t i = 0; i < curve.size(); ++i) {
+        if (curve[i].phase > phase) {
+            from = i == 0 ? &curve.back() : &curve[i - 1];
+            to = i == 0 ? &curve.front() : &curve[i];
+            break;
+        }
+    }
+
+    if (from == nullptr) {
+        from = &curve.back();
+        to = &curve.front();
+    }
+
+    // A step holds until the next point, which is what sample and hold is.
+    if (from->curveType == kStepCurveType)
+        return from->value;
+
+    float span = 0.0f;
+    float local = 0.0f;
+
+    if (to->phase < from->phase) {
+        // The wrapping run, which is as long as what is left of the cycle plus
+        // what has begun of the next one.
+        span = (1.0f - from->phase) + to->phase;
+        local = phase >= from->phase ? phase - from->phase : (1.0f - from->phase) + phase;
+    } else {
+        span = to->phase - from->phase;
+        local = phase - from->phase;
+    }
+
+    const float t = std::clamp(span > 0.0001f ? local / span : 0.0f, 0.0f, 1.0f);
+    const float tension = from->tension;
+
+    const auto applyTension = [tension](float input) {
+        if (std::abs(tension) < 0.001f)
+            return input;
+        if (tension > 0.0f)
+            return std::pow(input, 1.0f + tension * 2.0f);
+        return 1.0f - std::pow(1.0f - input, 1.0f - tension * 2.0f);
+    };
+
+    if (from->curveType == kHardCornerCurveType) {
+        // Two straight runs meeting at a corner, and where the corner is
+        // depends on whether the user has dragged the handle that sets it.
+        float cornerT = 0.5f;
+        float cornerValue = from->value + applyTension(0.5f) * (to->value - from->value);
+
+        if (hasDraggedHandle(*from, *to)) {
+            const float cornerPhase =
+                std::clamp(from->phase + from->outHandleX, from->phase, to->phase);
+            const float raw = (to->phase - from->phase > 0.0001f)
+                                  ? ((cornerPhase - from->phase) / (to->phase - from->phase))
+                                  : 0.5f;
+            cornerT = std::clamp(raw, 0.001f, 0.999f);
+            cornerValue = std::clamp(from->value + from->outHandleY, 0.0f, 1.0f);
+        }
+
+        if (t <= cornerT)
+            return from->value + (t / cornerT) * (cornerValue - from->value);
+
+        return cornerValue + ((t - cornerT) / (1.0f - cornerT)) * (to->value - cornerValue);
+    }
+
+    // A bend, through the shared warp, so what is heard is what is drawn.
+    return magda::curvemath::evalSegment(from->value, to->value, from->value + from->outHandleY,
+                                         tension, hasDraggedHandle(*from, *to), t);
+}
+
+float shapeAt(LFOWaveform wave, CurvePreset shape, std::span<const CurvePointData> curve,
+              float phase) {
+    if (wave != LFOWaveform::Custom)
+        return waveform(wave, phase);
+
+    return curve.empty() ? preset(shape, phase) : points(curve, phase);
+}
+
+float endValue(LFOWaveform wave, CurvePreset shape, std::span<const CurvePointData> curve) {
+    if (wave != LFOWaveform::Custom)
+        return waveform(wave, 1.0f);
+
+    return curve.empty() ? preset(shape, 1.0f) : curve.back().value;
+}
+
+}  // namespace magda::modcurve

--- a/magda/daw/core/ModCurve.hpp
+++ b/magda/daw/core/ModCurve.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <span>
+
+#include "ModInfo.hpp"
+
+/**
+ * @file ModCurve.hpp
+ * @brief The shape a modulator has at a phase, read in one place.
+ *
+ * A modulator's cycle is drawn once and read three times: by the editor's
+ * preview, by the fork's lock-free snapshot on the audio thread, and by the
+ * native engine's LFO (#2119). Three readings of one curve is three chances for
+ * the dot, the sound and the render to disagree, so the arithmetic lives here
+ * and the three of them call it.
+ *
+ * Pure: no allocation, no locks, no state. Safe on the audio thread, which is
+ * what lets the snapshot delegate rather than keep its own copy.
+ *
+ * Phase in, 0 to 1, and level out, 0 to 1. What a level means is the caller's:
+ * ModInfo::invertOutput turns a drawn level into the attenuation a device
+ * receives, and that happens where the modulator's output is applied rather
+ * than here, because the curve the user drew is the one this returns.
+ */
+
+namespace magda::modcurve {
+
+/** @brief One cycle of a built-in waveform. */
+float waveform(LFOWaveform wave, float phase);
+
+/** @brief One cycle of a curve preset, for a custom curve with nothing drawn on it. */
+float preset(CurvePreset shape, float phase);
+
+/**
+ * @brief One cycle of a drawn curve.
+ *
+ * The points are in phase order and the curve wraps: a phase past the last
+ * point is in the run that closes the cycle at the first. Each point carries
+ * how the run leaving it is shaped, which is a step, a hard corner, or a bend
+ * whose tension and handles are read through magda::curvemath so the audible
+ * curve is the drawn one.
+ *
+ * An empty list has no shape to report and answers the middle, which is what a
+ * modulator with a Custom waveform and no points would otherwise have to
+ * invent for itself.
+ */
+float points(std::span<const CurvePointData> points, float phase);
+
+/**
+ * @brief The level a modulator of this shape has at @p phase.
+ *
+ * The whole question in one call: a built-in waveform, or a drawn curve, or the
+ * preset behind a Custom waveform nobody has drawn on yet.
+ */
+float shapeAt(LFOWaveform wave, CurvePreset shape, std::span<const CurvePointData> points,
+              float phase);
+
+/**
+ * @brief Where a cycle ends, which is what a one-shot holds once it is through.
+ *
+ * The last drawn point's own value rather than the curve read just short of 1:
+ * reading near the end of the cycle interpolates back towards the first point,
+ * which is the run that closes the loop and not a place a one-shot ever
+ * arrives at.
+ */
+float endValue(LFOWaveform wave, CurvePreset shape, std::span<const CurvePointData> points);
+
+}  // namespace magda::modcurve

--- a/magda/daw/core/ModulatorEngine.hpp
+++ b/magda/daw/core/ModulatorEngine.hpp
@@ -6,7 +6,7 @@
 #include <functional>
 #include <memory>
 
-#include "CurveMath.hpp"
+#include "ModCurve.hpp"
 #include "ModInfo.hpp"
 
 namespace magda {
@@ -146,211 +146,24 @@ class ModulatorEngine {
 
     /**
      * @brief Generate waveform value for given phase
-     * @param waveform The waveform type
-     * @param phase Current phase (0.0 to 1.0)
-     * @return Output value (0.0 to 1.0)
+     *
+     * The model's own reading (core/ModCurve.hpp), so the visual sim, the
+     * audio snapshot and the native engine's LFO all draw one shape.
      */
     static float generateWaveform(LFOWaveform waveform, float phase) {
-        constexpr float PI = 3.14159265359f;
-
-        switch (waveform) {
-            case LFOWaveform::Sine:
-                return (std::sin(2.0f * PI * phase) + 1.0f) * 0.5f;
-
-            case LFOWaveform::Triangle:
-                return (phase < 0.5f) ? phase * 2.0f : 2.0f - phase * 2.0f;
-
-            case LFOWaveform::Square:
-                return phase < 0.5f ? 1.0f : 0.0f;
-
-            case LFOWaveform::Saw:
-                return phase;
-
-            case LFOWaveform::ReverseSaw:
-                return 1.0f - phase;
-
-            case LFOWaveform::Custom:
-                // For Custom, default to triangle - use generateCurvePreset for full support
-                return (phase < 0.5f) ? phase * 2.0f : 2.0f - phase * 2.0f;
-
-            default:
-                return 0.5f;
-        }
+        return modcurve::waveform(waveform, phase);
     }
 
-    /**
-     * @brief Generate curve preset value for given phase
-     * @param preset The curve preset type
-     * @param phase Current phase (0.0 to 1.0)
-     * @return Output value (0.0 to 1.0)
-     */
+    /** @brief Generate curve preset value for given phase. */
     static float generateCurvePreset(CurvePreset preset, float phase) {
-        constexpr float PI = 3.14159265359f;
-
-        switch (preset) {
-            case CurvePreset::Triangle:
-                return (phase < 0.5f) ? phase * 2.0f : 2.0f - phase * 2.0f;
-
-            case CurvePreset::Sine:
-                return (std::sin(2.0f * PI * phase) + 1.0f) * 0.5f;
-
-            case CurvePreset::RampUp:
-                return phase;
-
-            case CurvePreset::RampDown:
-                return 1.0f - phase;
-
-            case CurvePreset::SCurve: {
-                // Smooth S-curve using smoothstep
-                float t = phase;
-                return t * t * (3.0f - 2.0f * t);
-            }
-
-            case CurvePreset::Exponential:
-                // Exponential rise
-                return (std::exp(phase * 3.0f) - 1.0f) / (std::exp(3.0f) - 1.0f);
-
-            case CurvePreset::Logarithmic:
-                // Logarithmic rise
-                return std::log(1.0f + phase * (std::exp(1.0f) - 1.0f));
-
-            case CurvePreset::Custom:
-            default:
-                // Custom uses curve points - default to linear ramp
-                return phase;
-        }
+        return modcurve::preset(preset, phase);
     }
 
-    /**
-     * @brief Evaluate curve points at given phase using tension-based interpolation
-     * @param points The curve points sorted by phase
-     * @param phase Current phase (0.0 to 1.0)
-     * @return Output value (0.0 to 1.0)
-     */
+    /** @brief Evaluate drawn curve points at given phase. */
     static float evaluateCurvePoints(const std::vector<CurvePointData>& points, float phase) {
-        if (points.empty()) {
-            return 0.5f;  // Default to center
-        }
-        if (points.size() == 1) {
-            return points[0].value;
-        }
-
-        // Find bracketing points (curve loops, so we may wrap around)
-        const CurvePointData* p1 = nullptr;
-        const CurvePointData* p2 = nullptr;
-
-        for (size_t i = 0; i < points.size(); ++i) {
-            if (points[i].phase > phase) {
-                if (i == 0) {
-                    // Before first point - wrap from last point
-                    p1 = &points.back();
-                    p2 = &points[0];
-                } else {
-                    p1 = &points[i - 1];
-                    p2 = &points[i];
-                }
-                break;
-            }
-        }
-
-        // If we didn't find a bracket, we're after the last point - wrap to first
-        if (!p1) {
-            p1 = &points.back();
-            p2 = &points.front();
-        }
-
-        // Step: hold p1's value until the next point (sample & hold / steps).
-        constexpr int kStepCurveType = 2;
-        if (p1->curveType == kStepCurveType)
-            return p1->value;
-
-        // Calculate interpolation t value
-        float phaseSpan;
-        float localPhase;
-        if (p2->phase < p1->phase) {
-            // Wrapping case
-            phaseSpan = (1.0f - p1->phase) + p2->phase;
-            if (phase >= p1->phase) {
-                localPhase = phase - p1->phase;
-            } else {
-                localPhase = (1.0f - p1->phase) + phase;
-            }
-        } else {
-            phaseSpan = p2->phase - p1->phase;
-            localPhase = phase - p1->phase;
-        }
-
-        float t = (phaseSpan > 0.0001f) ? (localPhase / phaseSpan) : 0.0f;
-        t = std::clamp(t, 0.0f, 1.0f);
-
-        // Apply tension-based interpolation (same formula as CurveEditorBase)
-        float tension = p1->tension;
-        auto applyTension = [tension](float input) {
-            if (std::abs(tension) < 0.001f)
-                return input;
-            if (tension > 0)
-                return std::pow(input, 1.0f + tension * 2.0f);
-            return 1.0f - std::pow(1.0f - input, 1.0f - tension * 2.0f);
-        };
-
-        auto getShaper = [&]() {
-            struct Shaper {
-                float t = 0.5f;
-                float value = 0.5f;
-                bool stored = false;
-            };
-
-            constexpr float kHandleEpsilon = 0.000001f;
-            const bool hasStoredShaper =
-                p2->phase > p1->phase && (std::abs(p1->outHandleX) > kHandleEpsilon ||
-                                          std::abs(p1->outHandleY) > kHandleEpsilon ||
-                                          std::abs(p2->inHandleX) > kHandleEpsilon ||
-                                          std::abs(p2->inHandleY) > kHandleEpsilon);
-
-            if (hasStoredShaper) {
-                const float shaperPhase =
-                    std::clamp(p1->phase + p1->outHandleX, p1->phase, p2->phase);
-                const float shaperT = (p2->phase - p1->phase > 0.0001f)
-                                          ? ((shaperPhase - p1->phase) / (p2->phase - p1->phase))
-                                          : 0.5f;
-                return Shaper{std::clamp(shaperT, 0.001f, 0.999f),
-                              std::clamp(p1->value + p1->outHandleY, 0.0f, 1.0f), true};
-            }
-
-            constexpr float cornerT = 0.5f;
-            return Shaper{cornerT, p1->value + applyTension(cornerT) * (p2->value - p1->value),
-                          false};
-        };
-
-        constexpr int kHardCornerCurveType = 3;
-        if (p1->curveType == kHardCornerCurveType) {
-            const auto shaper = getShaper();
-            if (t <= shaper.t) {
-                const float u = t / shaper.t;
-                return p1->value + u * (shaper.value - p1->value);
-            }
-            const float u = (t - shaper.t) / (1.0f - shaper.t);
-            return shaper.value + u * (p2->value - shaper.value);
-        }
-
-        // Linear segment: shared bounded power warp so the engine output matches
-        // exactly what the curve editor draws (see core/CurveMath.hpp).
-        constexpr float kLinearHandleEps = 0.000001f;
-        const bool hasStoredShaper =
-            p2->phase > p1->phase && (std::abs(p1->outHandleX) > kLinearHandleEps ||
-                                      std::abs(p1->outHandleY) > kLinearHandleEps ||
-                                      std::abs(p2->inHandleX) > kLinearHandleEps ||
-                                      std::abs(p2->inHandleY) > kLinearHandleEps);
-        return magda::curvemath::evalSegment(p1->value, p2->value, p1->value + p1->outHandleY,
-                                             tension, hasStoredShaper, t);
+        return modcurve::points(points, phase);
     }
 
-    /**
-     * @brief Generate waveform value for a mod (handles Custom waveforms with curve points)
-     * @param mod The modulator info
-     * @param phase Current phase (0.0 to 1.0)
-     * @return Output value (0.0 to 1.0)
-     */
     /**
      * @brief Return the end-of-cycle value for oneshot mode.
      *
@@ -358,23 +171,12 @@ class ModulatorEngine {
      * interpolation), or the preset value at phase 1.0 for non-custom waveforms.
      */
     static float generateOneShotEndValue(const ModInfo& mod) {
-        if (mod.waveform == LFOWaveform::Custom) {
-            if (!mod.curvePoints.empty())
-                return mod.curvePoints.back().value;
-            return generateCurvePreset(mod.curvePreset, 1.0f);
-        }
-        return generateWaveform(mod.waveform, 1.0f);
+        return modcurve::endValue(mod.waveform, mod.curvePreset, mod.curvePoints);
     }
 
+    /** @brief Waveform value for a mod, handling Custom waveforms with curve points. */
     static float generateWaveformForMod(const ModInfo& mod, float phase) {
-        if (mod.waveform == LFOWaveform::Custom) {
-            if (!mod.curvePoints.empty()) {
-                return evaluateCurvePoints(mod.curvePoints, phase);
-            }
-            // Fallback to preset if no custom points
-            return generateCurvePreset(mod.curvePreset, phase);
-        }
-        return generateWaveform(mod.waveform, phase);
+        return modcurve::shapeAt(mod.waveform, mod.curvePreset, mod.curvePoints, phase);
     }
 
   private:

--- a/magda/daw/core/ParameterInfo.hpp
+++ b/magda/daw/core/ParameterInfo.hpp
@@ -413,6 +413,59 @@ inline ParameterInfo pan(int index, const juce::String& name) {
     return info;
 }
 
+/**
+ * @brief A modulator's Rate, as a frequency.
+ *
+ * What the Rate control writes and what a lane over it stores, so the slider
+ * position and the curve agree, and so the native engine reads a lane back
+ * through the same description that normalised it (#2119).
+ *
+ * The range is chosen so the geometric centre (sqrt(min * max)) lands on 1 Hz,
+ * which is the natural musical mid for an LFO.
+ */
+inline ParameterInfo modRateHz(const juce::String& name = "Rate") {
+    ParameterInfo info = frequency(0, name, 0.05f, 20.0f);
+    info.teMinValue = 0.05f;
+    info.teMaxValue = 20.0f;
+    info.defaultValue = 1.0f;
+    return info;
+}
+
+/**
+ * @brief The same Rate, as a musical division.
+ *
+ * ModRateType is ordered slow to fast with Hertz at zero, and Hertz is not a
+ * division: it is the other reading of this same control. So the lane drops
+ * that slot and counts from the first real division instead, which is why the
+ * value stored here is the ordinal minus one and why nothing can resolve to
+ * "not synced at all" by running to the bottom of its range.
+ *
+ * MAGDA exposes 16 Bars down to 1/32 T. The ordinals past those exist so a
+ * value written by an imported project still round-trips (ModInfo.hpp).
+ *
+ * labelTicks names only the plain divisions, to keep the axis legible; the
+ * dotted and triplet ones still appear in the value-to-string lookup.
+ */
+inline ParameterInfo modRateSyncDivision(const juce::String& name = "Rate") {
+    ParameterInfo info;
+    info.paramIndex = 1;
+    info.name = name;
+    info.unit = "";
+    info.minValue = 0.0f;
+    info.maxValue = 19.0f;
+    info.teMinValue = 1.0f;
+    info.teMaxValue = 20.0f;
+    info.defaultValue = 9.0f;  // quarter, which is ordinal 10 counted from 1
+    info.scale = ParameterScale::Discrete;
+    info.displayFormat = DisplayFormat::Default;
+    info.choices = {"16 Bars", "8 Bars", "4 Bars", "2 Bars", "1 Bar", "1/2.", "1/2",
+                    "1/2T",    "1/4.",   "1/4",    "1/4T",   "1/8.",  "1/8",  "1/8T",
+                    "1/16.",   "1/16",   "1/16T",  "1/32.",  "1/32",  "1/32T"};
+    info.labelTicks = {{0.0f, "16 Bars"}, {2.0f, "4 Bars"}, {4.0f, "1 Bar"}, {6.0f, "1/2"},
+                       {9.0f, "1/4"},     {12.0f, "1/8"},   {15.0f, "1/16"}, {18.0f, "1/32"}};
+    return info;
+}
+
 }  // namespace ParameterPresets
 
 }  // namespace magda

--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -79,6 +79,8 @@ add_library(magda_engine STATIC
     param/ParamTable.cpp
     param/ParamTableCompiler.cpp
     param/ParamTableDump.cpp
+    param/ModLfo.cpp
+    param/ModRuntime.cpp
     param/ParamSpec.hpp
     param/ParamBlock.hpp
     param/ParamKey.hpp
@@ -86,6 +88,8 @@ add_library(magda_engine STATIC
     param/ParamTable.hpp
     param/ParamTableCompiler.hpp
     param/ParamTableDump.hpp
+    param/ModLfo.hpp
+    param/ModRuntime.hpp
     tap/LevelTap.hpp
     tap/SampleRing.hpp
     transport/TempoMap.cpp

--- a/magda/engine/exec/ParallelPlanExecutor.hpp
+++ b/magda/engine/exec/ParallelPlanExecutor.hpp
@@ -122,6 +122,9 @@ class ParallelPlanExecutor final : private RenderThreadPool::Job {
     int carriedCrossfades() const {
         return core_.carriedCrossfades();
     }
+    int carriedModifiers() const {
+        return core_.carriedModifiers();
+    }
     bool isPrepared() const {
         return plan_ != nullptr;
     }

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -224,6 +224,7 @@ void PlanExecutor::reset() {
     paramScratch_.clear();
     paramSegments_.clear();
     paramValues_.prepare(0);
+    mods_.reset();
     paramLayout_ = 0;
 }
 
@@ -268,6 +269,12 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                              ModContribution{});
         paramSegments_.assign(static_cast<std::size_t>(paramValues_.segmentCapacity()),
                               ParamSegment{});
+
+        // The modifier engines, and whatever the epoch being replaced has
+        // already turned. Shared rather than copied: the audio thread is still
+        // inside that executor until the swap, so an LFO carried across one
+        // goes on from where it is rather than from where it was read.
+        mods_.prepare(*params, context, previous == nullptr ? nullptr : &previous->mods_);
 
         for (std::size_t i = 0; i < numOps; ++i) {
             const auto& op = plan.ops[i];
@@ -694,7 +701,7 @@ void PlanExecutor::resolveParameters(const PlanValues& values, const BlockInfo& 
         return;
     }
 
-    resolveParams(*values.params, paramValues_, paramScratch_, paramSegments_, block);
+    resolveParams(*values.params, paramValues_, paramScratch_, paramSegments_, block, &mods_);
 }
 
 void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedBlock,

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -334,6 +334,13 @@ class PlanExecutor {
         return carriedCrossfades_;
     }
 
+    /// Modifiers this executor took over mid-cycle from the one it replaced.
+    /// An LFO that did not restart because a device was inserted somewhere
+    /// else in the project (#2119).
+    int carriedModifiers() const {
+        return mods_.carried();
+    }
+
     /// True once a valid plan has been prepared.
     bool isPrepared() const {
         return plan_ != nullptr;
@@ -379,7 +386,8 @@ class PlanExecutor {
         return values.params == nullptr ||
                (values.params->layoutFingerprint == paramLayout_ &&
                 values.params->size() == paramValues_.size() &&
-                values.params->maxLinksPerParam <= static_cast<int>(paramScratch_.size()));
+                values.params->maxLinksPerParam <= static_cast<int>(paramScratch_.size()) &&
+                values.params->modifierFingerprint == mods_.fingerprint());
     }
 
     /**
@@ -503,6 +511,11 @@ class PlanExecutor {
     /// published with, so the block that fills them allocates nothing.
     ResolvedParams paramValues_;
     std::vector<ModContribution> paramScratch_;
+
+    /// Where the modifiers of this plan have got to (#2119). Sized at prepare
+    /// from the same table, and carried from the executor being replaced, so a
+    /// device insert does not restart every LFO in the project.
+    ModRuntime mods_;
 
     /** @brief The parameters a mixer op reads instead of the published value. */
     struct OpMixerParams {

--- a/magda/engine/param/ModLfo.cpp
+++ b/magda/engine/param/ModLfo.cpp
@@ -151,9 +151,18 @@ void restartLfo(LfoState& state, const LfoSettings& settings) {
 float advanceLfo(LfoState& state, const LfoSettings& settings,
                  std::span<const magda::CurvePointData> curve, const BlockInfo& block,
                  const ModTiming& timing) {
-    if (!state.started) {
+    // A fresh state takes its gate from the settings, and so does one whose
+    // trigger mode has changed underneath it: the gate belongs to the triggers
+    // of the mode that opened it, and a mode change retires all of them. An
+    // audio-triggered LFO sits shut between hits, and switching it to free
+    // running would otherwise leave it shut for ever, because nothing in the
+    // new mode ever opens a gate. The held-note count goes with it, for the
+    // same reason.
+    if (!state.started || state.trigger != settings.trigger) {
         state.started = true;
+        state.trigger = settings.trigger;
         state.gated = settings.startGated;
+        state.heldNotes = 0;
     }
 
     // A latch belongs to the setting that made it. Turning one-shot off clears

--- a/magda/engine/param/ModLfo.cpp
+++ b/magda/engine/param/ModLfo.cpp
@@ -100,8 +100,12 @@ double barFractionOf(int rateType) {
     return 1.0;
 }
 
-double cycleBeats(int rateType, int numerator) {
-    return barFractionOf(rateType) * std::max(numerator, 1);
+double cycleBeats(int rateType, int numerator, int denominator) {
+    // A bar in quarter notes, which is what a beat is here. The signature's
+    // own note value is the denominator's, so six eight is three quarter notes
+    // rather than six.
+    const auto barBeats = 4.0 * std::max(numerator, 1) / std::max(denominator, 1);
+    return barFractionOf(rateType) * barBeats;
 }
 
 int rateTypeFromLaneValue(float laneValue) {
@@ -123,13 +127,16 @@ ModTiming modTimingFor(const BlockInfo& block, double sampleRate) {
     // what it gets is what a session that has never seen a transport renders
     // at: 120 in four four, which is the same default TransportState holds.
     if (block.tempo != nullptr) {
+        const auto signature = block.tempo->barsAndBeatsAt(block.startBeat);
         timing.bpm = block.tempo->bpmAt(block.startBeat);
-        timing.numerator = block.tempo->barsAndBeatsAt(block.startBeat).numerator;
+        timing.numerator = signature.numerator;
+        timing.denominator = signature.denominator;
     }
 
     if (!(timing.bpm > 0.0))
         timing.bpm = 120.0;
     timing.numerator = std::max(timing.numerator, 1);
+    timing.denominator = std::max(timing.denominator, 1);
 
     return timing;
 }
@@ -174,7 +181,7 @@ float advanceLfo(LfoState& state, const LfoSettings& settings,
 
     const double hz = std::max(static_cast<double>(settings.rate.hz), kMinHz);
     const double beatsPerCycle =
-        std::max(cycleBeats(settings.rate.rateType, timing.numerator), 1.0e-6);
+        std::max(cycleBeats(settings.rate.rateType, timing.numerator, timing.denominator), 1.0e-6);
 
     // A timeline-locked LFO is a function of where the block is rather than of
     // how many blocks have gone by, which is what puts two of them at one rate

--- a/magda/engine/param/ModLfo.cpp
+++ b/magda/engine/param/ModLfo.cpp
@@ -215,13 +215,24 @@ float advanceLfo(LfoState& state, const LfoSettings& settings,
     if (state.gated)
         value = 0.0f;
 
+    // A trigger asked for one block of nothing, and this is the first block a
+    // device can see (LfoState::forceZero). The phase is published where the
+    // restart put it, so the editor's dot is already back at the top, and it
+    // is not advanced, so the shape resumes from its start on the next block
+    // rather than a block into itself.
+    const bool zeroed = state.forceZero;
+    if (zeroed) {
+        state.forceZero = false;
+        value = 0.0f;
+    }
+
     state.phase = phase;
     state.value = value;
 
     // Moved on for the next block, after this one's value has been settled,
     // which is the order the fork's timer uses: the value a block renders with
     // is the value at its first sample.
-    if (settings.sync != ModSync::Transport && !holding) {
+    if (settings.sync != ModSync::Transport && !holding && !zeroed) {
         const double blockSeconds =
             static_cast<double>(std::max(block.numSamples, 0)) / timing.sampleRate;
         const double periodSeconds =

--- a/magda/engine/param/ModLfo.cpp
+++ b/magda/engine/param/ModLfo.cpp
@@ -1,0 +1,248 @@
+#include "param/ModLfo.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "core/ModCurve.hpp"
+
+namespace magda::engine {
+
+namespace {
+
+/// A rate this low is a period longer than any session, and it is what a
+/// modulated rate arriving at the bottom of its range would otherwise divide
+/// by. Well below MAGDA's own slider (0.05 Hz) and the fork's (0.01 Hz), so it
+/// is a guard rather than a range.
+constexpr double kMinHz = 1.0e-4;
+
+/// A loop region narrower than this is a region the user has collapsed rather
+/// than one they want repeated, and dividing the cycle by it would spin.
+constexpr float kMinLoopLength = 1.0e-4f;
+
+/// The fractional part, for a position that is only ever positive here.
+double fractionOf(double cycles) {
+    return cycles - std::floor(cycles);
+}
+
+/// Into [0, 1), which is where a phase has to be before a shape is read at it.
+float wrapPhase(float phase) {
+    phase -= std::floor(phase);
+    return phase >= 1.0f ? 0.0f : phase;
+}
+
+bool loopsInRegion(const LfoSettings& settings) {
+    // A drawn curve only. The loop region is MSEG's, and the built-in
+    // waveforms have no intro to play once before settling into one.
+    return settings.wave == magda::LFOWaveform::Custom && settings.useLoopRegion &&
+           (settings.loopEnd - settings.loopStart) > kMinLoopLength;
+}
+
+}  // namespace
+
+double barFractionOf(int rateType) {
+    constexpr double dot = 1.5;
+    constexpr double triplet = 2.0 / 3.0;
+
+    switch (static_cast<magda::ModRateType>(rateType)) {
+        case magda::ModRateType::SixteenBars:
+            return 16.0;
+        case magda::ModRateType::EightBars:
+            return 8.0;
+        case magda::ModRateType::FourBars:
+            return 4.0;
+        case magda::ModRateType::TwoBars:
+            return 2.0;
+        case magda::ModRateType::Bar:
+            return 1.0;
+        case magda::ModRateType::DottedHalf:
+            return 1.0 / 2.0 * dot;
+        case magda::ModRateType::Half:
+            return 1.0 / 2.0;
+        case magda::ModRateType::TripletHalf:
+            return 1.0 / 2.0 * triplet;
+        case magda::ModRateType::DottedQuarter:
+            return 1.0 / 4.0 * dot;
+        case magda::ModRateType::Quarter:
+            return 1.0 / 4.0;
+        case magda::ModRateType::TripletQuarter:
+            return 1.0 / 4.0 * triplet;
+        case magda::ModRateType::DottedEighth:
+            return 1.0 / 8.0 * dot;
+        case magda::ModRateType::Eighth:
+            return 1.0 / 8.0;
+        case magda::ModRateType::TripletEighth:
+            return 1.0 / 8.0 * triplet;
+        case magda::ModRateType::DottedSixteenth:
+            return 1.0 / 16.0 * dot;
+        case magda::ModRateType::Sixteenth:
+            return 1.0 / 16.0;
+        case magda::ModRateType::TripletSixteenth:
+            return 1.0 / 16.0 * triplet;
+        case magda::ModRateType::DottedThirtySecond:
+            return 1.0 / 32.0 * dot;
+        case magda::ModRateType::ThirtySecond:
+            return 1.0 / 32.0;
+        case magda::ModRateType::TripletThirtySecond:
+            return 1.0 / 32.0 * triplet;
+        case magda::ModRateType::DottedSixtyFourth:
+            return 1.0 / 64.0 * dot;
+        case magda::ModRateType::SixtyFourth:
+            return 1.0 / 64.0;
+        case magda::ModRateType::TripletSixtyFourth:
+            return 1.0 / 64.0 * triplet;
+        case magda::ModRateType::Hertz:
+            break;
+    }
+
+    // Hertz is not a division, and neither is an ordinal from a project this
+    // build does not know. A bar is what a modifier with no division falls
+    // back to, which is the fork's answer as well.
+    return 1.0;
+}
+
+double cycleBeats(int rateType, int numerator) {
+    return barFractionOf(rateType) * std::max(numerator, 1);
+}
+
+int rateTypeFromLaneValue(float laneValue) {
+    const auto shifted = static_cast<int>(std::lround(laneValue)) + 1;
+    return std::clamp(shifted, static_cast<int>(magda::ModRateType::SixteenBars),
+                      static_cast<int>(magda::ModRateType::TripletSixtyFourth));
+}
+
+float laneValueFromRateType(int rateType) {
+    return static_cast<float>(
+        std::max(rateType, static_cast<int>(magda::ModRateType::SixteenBars)) - 1);
+}
+
+ModTiming modTimingFor(const BlockInfo& block, double sampleRate) {
+    ModTiming timing;
+    timing.sampleRate = sampleRate > 0.0 ? sampleRate : 44100.0;
+
+    // The map where there is one. A block assembled by hand carries none, and
+    // what it gets is what a session that has never seen a transport renders
+    // at: 120 in four four, which is the same default TransportState holds.
+    if (block.tempo != nullptr) {
+        timing.bpm = block.tempo->bpmAt(block.startBeat);
+        timing.numerator = block.tempo->barsAndBeatsAt(block.startBeat).numerator;
+    }
+
+    if (!(timing.bpm > 0.0))
+        timing.bpm = 120.0;
+    timing.numerator = std::max(timing.numerator, 1);
+
+    return timing;
+}
+
+float lfoShapeAt(const LfoSettings& settings, std::span<const magda::CurvePointData> curve,
+                 float phase) {
+    return magda::modcurve::shapeAt(settings.wave, settings.preset, curve, phase);
+}
+
+void restartLfo(LfoState& state, const LfoSettings& settings) {
+    if (settings.sync != ModSync::Note)
+        return;
+
+    state.cycles = 0.0;
+    state.completed = false;
+    state.started = true;
+}
+
+float advanceLfo(LfoState& state, const LfoSettings& settings,
+                 std::span<const magda::CurvePointData> curve, const BlockInfo& block,
+                 const ModTiming& timing) {
+    if (!state.started) {
+        state.started = true;
+        state.gated = settings.startGated;
+    }
+
+    // A latch belongs to the setting that made it. Turning one-shot off clears
+    // it, so turning it back on plays the cycle again rather than resuming a
+    // hold from before, which is what the fork's snapshot does on the same
+    // edit (CurveSnapshotHolder::update).
+    if (!settings.oneShot)
+        state.completed = false;
+
+    const double hz = std::max(static_cast<double>(settings.rate.hz), kMinHz);
+    const double beatsPerCycle =
+        std::max(cycleBeats(settings.rate.rateType, timing.numerator), 1.0e-6);
+
+    // A timeline-locked LFO is a function of where the block is rather than of
+    // how many blocks have gone by, which is what puts two of them at one rate
+    // in phase with each other and with the bar however playback got there.
+    if (settings.sync == ModSync::Transport) {
+        state.cycles =
+            settings.tempoSync ? block.startBeat / beatsPerCycle : block.startSeconds * hz;
+    }
+
+    const double cycles = state.cycles;
+    const bool looping = loopsInRegion(settings);
+    const bool holding = settings.oneShot && !looping && (state.completed || cycles >= 1.0);
+
+    float phase = 0.0f;
+    float shape = 0.0f;
+
+    if (holding) {
+        // Through, and parked where the cycle ended. The phase is published at
+        // the end rather than wherever the ramp would have got to, because
+        // that is where the curve the user can see is being held.
+        state.completed = true;
+        phase = 1.0f;
+        shape = magda::modcurve::endValue(settings.wave, settings.preset, curve);
+    } else if (looping) {
+        // The intro plays once and the region repeats from there. Read off the
+        // cumulative position rather than the wrapped phase, because which of
+        // the two it is depends on how many cycles have gone by.
+        const double length = static_cast<double>(settings.loopEnd - settings.loopStart);
+        const double start = static_cast<double>(settings.loopStart);
+        const double effective =
+            cycles < start ? cycles : start + std::fmod(cycles - start, length);
+
+        phase = wrapPhase(static_cast<float>(effective));
+        shape = lfoShapeAt(settings, curve, phase);
+    } else {
+        phase = wrapPhase(static_cast<float>(fractionOf(cycles)) + settings.phaseOffset);
+        shape = lfoShapeAt(settings, curve, phase);
+    }
+
+    // A curve drawn as a level is applied as the amount it takes away, so that
+    // an inactive modifier, which outputs 0, means "no attenuation" rather
+    // than "silence" (see LfoSettings::invertOutput).
+    float value = settings.invertOutput ? 1.0f - shape : shape;
+
+    // The gate is the last word, and it is flat zero rather than a floor: the
+    // whole modulation system reads 0 as a modifier doing nothing.
+    if (state.gated)
+        value = 0.0f;
+
+    state.phase = phase;
+    state.value = value;
+
+    // Moved on for the next block, after this one's value has been settled,
+    // which is the order the fork's timer uses: the value a block renders with
+    // is the value at its first sample.
+    if (settings.sync != ModSync::Transport && !holding) {
+        const double blockSeconds =
+            static_cast<double>(std::max(block.numSamples, 0)) / timing.sampleRate;
+        const double periodSeconds =
+            settings.tempoSync ? beatsPerCycle * 60.0 / timing.bpm : 1.0 / hz;
+
+        state.cycles += blockSeconds / std::max(periodSeconds, 1.0e-9);
+    }
+
+    // Kept bounded, so an LFO left running for hours is as precise as one that
+    // started a moment ago. A one-shot is the exception: how far past the end
+    // it is is the whole question it answers.
+    if (looping) {
+        const double length = static_cast<double>(settings.loopEnd - settings.loopStart);
+        const double start = static_cast<double>(settings.loopStart);
+        if (state.cycles >= start + length)
+            state.cycles = start + std::fmod(state.cycles - start, length);
+    } else if (!settings.oneShot && state.cycles >= 1.0) {
+        state.cycles = fractionOf(state.cycles);
+    }
+
+    return value;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/param/ModLfo.cpp
+++ b/magda/engine/param/ModLfo.cpp
@@ -30,6 +30,34 @@ float wrapPhase(float phase) {
     return phase >= 1.0f ? 0.0f : phase;
 }
 
+/**
+ * @brief Where the block opens, counted in bars.
+ *
+ * The bar grid rather than a beat count divided by a bar's length, because the
+ * two part company at a signature change: a change always starts a bar
+ * (TempoMap.hpp), so two bars of four four followed by six eight puts a bar
+ * line at beat eight, and eight divided by the three beats a six eight bar
+ * lasts is two and two thirds. A modifier reading that opens every six eight
+ * bar two thirds of the way through its cycle and stays there.
+ *
+ * Whole bars plus the fraction of this one that has gone by, which restarts at
+ * the change and carries the denominator with it, since the beat inside a bar
+ * is counted in the signature's own note value.
+ *
+ * Without a map there are no changes to survive, and the closed form is the
+ * same number: a hand-assembled block gets the arithmetic the grid would have
+ * given it.
+ */
+double barPositionOf(const BlockInfo& block, const ModTiming& timing) {
+    if (block.tempo != nullptr) {
+        const auto grid = block.tempo->barsAndBeatsAt(block.startBeat);
+        return grid.bar + grid.beat / std::max(grid.numerator, 1);
+    }
+
+    const auto barBeats = 4.0 * timing.numerator / timing.denominator;
+    return block.startBeat / std::max(barBeats, 1.0e-6);
+}
+
 bool loopsInRegion(const LfoSettings& settings) {
     // A drawn curve only. The loop region is MSEG's, and the built-in
     // waveforms have no intro to play once before settling into one.
@@ -187,8 +215,9 @@ float advanceLfo(LfoState& state, const LfoSettings& settings,
     // how many blocks have gone by, which is what puts two of them at one rate
     // in phase with each other and with the bar however playback got there.
     if (settings.sync == ModSync::Transport) {
-        state.cycles =
-            settings.tempoSync ? block.startBeat / beatsPerCycle : block.startSeconds * hz;
+        state.cycles = settings.tempoSync
+                           ? barPositionOf(block, timing) / barFractionOf(settings.rate.rateType)
+                           : block.startSeconds * hz;
     }
 
     const double cycles = state.cycles;

--- a/magda/engine/param/ModLfo.hpp
+++ b/magda/engine/param/ModLfo.hpp
@@ -189,6 +189,22 @@ struct LfoState {
     /// A one-shot that has played through and is holding its end value.
     bool completed = false;
 
+    /**
+     * @brief A trigger has asked for one block of nothing.
+     *
+     * The gap a gated retrigger would have left, so a device sees a transition
+     * rather than a continuation. Latched rather than written straight to the
+     * output, because a trigger arrives inside a block whose parameters have
+     * already been resolved: the block after it is the first one a device can
+     * see, and a value written at the moment of the trigger would be
+     * overwritten before anything read it.
+     *
+     * The block that spends it holds the phase as well, so the shape resumes
+     * from its start on the block after. That is the fork's own sequence, one
+     * block later, which is the same block the trigger itself is late by.
+     */
+    bool forceZero = false;
+
     /// Notes holding the gate open. The gate shuts when the last one lifts,
     /// which is what makes a note-triggered LFO read as an envelope.
     int heldNotes = 0;

--- a/magda/engine/param/ModLfo.hpp
+++ b/magda/engine/param/ModLfo.hpp
@@ -100,6 +100,16 @@ struct LfoSettings {
 
     ModSync sync = ModSync::Free;
 
+    /**
+     * @brief What the model says triggers it, before the fold into @ref sync.
+     *
+     * Carried as well as folded, because the fold is lossy in the one place it
+     * matters: MIDI and audio both run as ModSync::Note and gate differently,
+     * so the gate cannot be reconciled against the folded form. A mode change
+     * is the one edit that has to reach a running LFO's gate (LfoState::gated).
+     */
+    magda::LFOTriggerMode trigger = magda::LFOTriggerMode::Free;
+
     /// Whether the rate is a musical division rather than a frequency. What
     /// the Rate parameter means depends on it, which is why the two travel
     /// together.
@@ -220,6 +230,22 @@ struct LfoState {
      * fighting the note that had just opened it.
      */
     bool started = false;
+
+    /**
+     * @brief The trigger mode this state's gate was seeded under.
+     *
+     * The one edit a running gate has to hear. A gate belongs to the triggers
+     * of the mode that opened it, and a mode change retires all of them: an
+     * audio-triggered LFO sits shut between hits, and switching it to free
+     * running would otherwise leave it shut for ever, because nothing in the
+     * new mode ever opens a gate.
+     *
+     * Compared rather than re-applied, so an ordinary publish leaves the gate
+     * where the last note put it. The fork gets the same effect by re-applying
+     * unconditionally, which it can afford because its gate is not also where
+     * a held note is counted.
+     */
+    magda::LFOTriggerMode trigger = magda::LFOTriggerMode::Free;
 };
 
 /**
@@ -254,8 +280,24 @@ double barFractionOf(int rateType);
 /**
  * @brief How many beats one cycle of a tempo-synced LFO lasts.
  *
- * The bar fraction times the signature's own beats, which is what makes a
- * "1 Bar" LFO a bar long whatever the signature is.
+ * The bar fraction times the signature's numerator, and the numerator alone:
+ * the denominator is not read here because it is not read in the fork either.
+ * No TE modifier looks at one, and a TE beat is a quarter note exactly as a
+ * beat is here, so a modifier's "bar" is the numerator counted in quarter
+ * notes rather than in the signature's own note value.
+ *
+ * In four four the two readings agree and nothing shows. In six eight they do
+ * not: a bar is three quarter notes, and this says six, so a "1 Bar" LFO runs
+ * two written bars long. Transport sync inherits the same reading, and takes
+ * the numerator at the block's own position, so a signature change moves the
+ * phase rather than continuing it.
+ *
+ * Kept because it is the fork's, not because it is right. Every synced
+ * modifier in every project in anything but an x/4 signature is placed by this
+ * arithmetic, and correcting it during the port would move all of them: the
+ * null-diff corpus would report the difference and the user would hear it.
+ * Changing it is a decision about the incumbent's behaviour, taken once, for
+ * both engines at the same time (#2128).
  */
 double cycleBeats(int rateType, int numerator);
 

--- a/magda/engine/param/ModLfo.hpp
+++ b/magda/engine/param/ModLfo.hpp
@@ -253,14 +253,19 @@ struct LfoState {
  *
  * The sample rate, because a free-running LFO advances by how long the block
  * lasted rather than by how far the timeline moved, and the two are different
- * things while the transport is stopped. The tempo and the signature, because
- * a musical division is a fraction of a bar and a bar is neither of those on
- * its own.
+ * things while the transport is stopped. The tempo and the whole signature,
+ * because a musical division is a fraction of a bar and a bar is none of those
+ * on its own.
  */
 struct ModTiming {
     double sampleRate = 44100.0;
     double bpm = 120.0;
+
+    /// The signature at the block's first beat. Both halves of it, because a
+    /// bar is the numerator counted in the denominator's note value and either
+    /// on its own describes the wrong bar.
     int numerator = 4;
+    int denominator = 4;
 };
 
 /** @brief The tempo and signature @p block opens on, read off its map. */
@@ -280,26 +285,19 @@ double barFractionOf(int rateType);
 /**
  * @brief How many beats one cycle of a tempo-synced LFO lasts.
  *
- * The bar fraction times the signature's numerator, and the numerator alone:
- * the denominator is not read here because it is not read in the fork either.
- * No TE modifier looks at one, and a TE beat is a quarter note exactly as a
- * beat is here, so a modifier's "bar" is the numerator counted in quarter
- * notes rather than in the signature's own note value.
+ * The bar fraction times the length of a bar, and a bar is the signature's
+ * numerator counted in its own note value: `numerator * 4 / denominator`
+ * quarter notes, because a beat is a quarter note here and everywhere else in
+ * the engine. A bar of six eight is three of them, not six.
  *
- * In four four the two readings agree and nothing shows. In six eight they do
- * not: a bar is three quarter notes, and this says six, so a "1 Bar" LFO runs
- * two written bars long. Transport sync inherits the same reading, and takes
- * the numerator at the block's own position, so a signature change moves the
- * phase rather than continuing it.
- *
- * Kept because it is the fork's, not because it is right. Every synced
- * modifier in every project in anything but an x/4 signature is placed by this
- * arithmetic, and correcting it during the port would move all of them: the
- * null-diff corpus would report the difference and the user would hear it.
- * Changing it is a decision about the incumbent's behaviour, taken once, for
- * both engines at the same time (#2128).
+ * The fork used to count the numerator in quarter notes, so a "1 Bar" modifier
+ * in six eight ran two written bars long and every other division was out by
+ * the same ratio. The four TE modifiers are patched to match this rather than
+ * this being bent to match them: an engine being replaced is not a reason to
+ * carry its arithmetic forward, and the two agreeing is what keeps the
+ * null-diff corpus meaningful (#2128).
  */
-double cycleBeats(int rateType, int numerator);
+double cycleBeats(int rateType, int numerator, int denominator);
 
 /**
  * @brief The rate ordinal a Rate lane's value stands for, and back again.

--- a/magda/engine/param/ModLfo.hpp
+++ b/magda/engine/param/ModLfo.hpp
@@ -1,0 +1,298 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+
+#include "core/ModInfo.hpp"
+#include "exec/RenderContext.hpp"
+
+/**
+ * @file ModLfo.hpp
+ * @brief The LFO: what it is, where it has got to, and how far a block moves it.
+ *
+ * A modifier was a number until now. Slice 2 gave it an identity so a link
+ * could name one, and the value it published was whatever the model last saw,
+ * which is a value that does not move between publishes. This is the engine
+ * that makes it move.
+ *
+ * Three pieces, and they are separate on purpose. LfoSettings is what the
+ * model says the LFO is, which travels in the published table and is immutable
+ * for as long as that table is. LfoState is where the LFO has got to, which
+ * belongs to the runtime rather than to the table: a knob move republishes the
+ * table many times a second and an LFO that restarted on each of them would
+ * never finish a cycle. advanceLfo is one block of the first applied to the
+ * second.
+ *
+ * Block rate, once per block, from the block's first sample, because that is
+ * what the incumbent does: TE advances a modifier timer at the top of the
+ * block and every plugin reading it that block reads one value. A modifier
+ * that ran per sample would differ from the fork on every modulated parameter
+ * in every project, which is a decision for after the port.
+ *
+ * What is deliberately not here is depth and polarity. One LFO drives several
+ * parameters by different amounts and in different directions, and MAGDA keeps
+ * that per link; it is applied where the contributions are summed
+ * (ParamResolve.hpp) and the LFO knows nothing about it. The incumbent holds
+ * TE's own depth, offset and bipolar parameters at unity for the same reason.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief What drives a modifier's output.
+ *
+ * Only the LFO runs during this slice. The rest are named so a table can
+ * describe a modifier the engine cannot yet advance, which reads its model
+ * value and holds it, exactly as every modifier did before this slice; they
+ * arrive in #2120.
+ */
+enum class ModKind : std::uint8_t { Lfo, Adsr, Random, Follower };
+
+/**
+ * @brief Where a modifier's phase comes from.
+ *
+ * The model says trigger mode and tempo sync separately, and the fork folds
+ * the two into one choice (ModifierHelpers::mapSyncType). Folded here as well,
+ * and for the same reason: what actually differs is whether the phase is a
+ * function of the timeline, a ramp of its own, or a ramp of its own that
+ * something restarts.
+ */
+enum class ModSync : std::uint8_t {
+    /// A ramp of its own, advanced by however long the block was. Keeps
+    /// running with the transport stopped, because the graph is still
+    /// processing and the LFO is still moving.
+    Free,
+
+    /// A function of where the timeline is, so two LFOs at one rate are in
+    /// phase with each other and with the bar however playback got there.
+    /// Standing still while the transport is stopped is the same statement.
+    Transport,
+
+    /// A ramp of its own, restarted by a trigger. What a note-triggered LFO
+    /// is, and what a cross-track sidechain LFO is.
+    Note,
+};
+
+/** @brief The rate of one modifier, as the block reads it. */
+struct LfoRate {
+    /// Cycles per second, when the modifier is not tempo synced.
+    float hz = 1.0f;
+
+    /// A ModRateType ordinal, when it is. The persisted ordinal rather than a
+    /// division of MAGDA's own, because it is what lands in project files
+    /// through the Rate lane, so the divisions are a mapping rather than a
+    /// decision (ModInfo.hpp says so at the enum).
+    int rateType = static_cast<int>(magda::ModRateType::Hertz);
+};
+
+/**
+ * @brief What the model says one LFO is.
+ *
+ * Flat and copyable: it rides in the published table, and the drawn curve
+ * rides beside it in the table's own arena rather than in here, because a
+ * vector per modifier would be an allocation per modifier.
+ */
+struct LfoSettings {
+    magda::LFOWaveform wave = magda::LFOWaveform::Sine;
+
+    /// The shape behind a Custom waveform with nothing drawn on it yet.
+    magda::CurvePreset preset = magda::CurvePreset::Triangle;
+
+    ModSync sync = ModSync::Free;
+
+    /// Whether the rate is a musical division rather than a frequency. What
+    /// the Rate parameter means depends on it, which is why the two travel
+    /// together.
+    bool tempoSync = false;
+
+    LfoRate rate;
+
+    /// Added to the phase before the shape is read, 0 to 1.
+    float phaseOffset = 0.0f;
+
+    /// Play one cycle and hold what it ended on. A sustain loop overrides it:
+    /// the region repeats rather than the cycle finishing.
+    bool oneShot = false;
+
+    /**
+     * @brief Whether the drawn curve is a level rather than an amount.
+     *
+     * An inactive modifier outputs 0, which is the engine convention every
+     * gate and every untriggered LFO relies on. A curve drawn as an audible
+     * level therefore has to be applied as its complement, or idle would read
+     * as silence: the Sidechain device draws the gain shape the user hears and
+     * the engine receives the duck.
+     */
+    bool invertOutput = false;
+
+    /// The sustain loop of a drawn curve: the intro [0, loopStart) plays once
+    /// and [loopStart, loopEnd] repeats from there.
+    bool useLoopRegion = false;
+    float loopStart = 0.0f;
+    float loopEnd = 1.0f;
+
+    /**
+     * @brief Whether this LFO ignores triggers from where it lives.
+     *
+     * A cross-track sidechain LFO is driven by the source track alone: the
+     * track it modulates must not retrigger its phase or slam its gate on
+     * every note it happens to be playing. The fork learned this the hard way,
+     * with a flag that was set at creation and not restated when a source was
+     * picked later, so the destination track went on retriggering an LFO that
+     * had stopped being its own.
+     */
+    bool skipNativeResync = false;
+
+    /**
+     * @brief Whether triggers gate the output as well as restarting the phase.
+     *
+     * A note-triggered LFO behaves like an envelope: silent between notes,
+     * running while one is held. Off for a cross-track LFO, whose idle state
+     * is the one-shot hold or a free-running loop rather than nothing at all.
+     */
+    bool gateOnTrigger = false;
+
+    /// Whether the LFO starts with its gate shut. What an audio-triggered LFO
+    /// is between hits, and what a note-triggered one is before the first note.
+    bool startGated = false;
+};
+
+/**
+ * @brief Where one LFO has got to.
+ *
+ * Owned by the runtime and carried across publishes and plan swaps, so a knob
+ * move, a link edit or a device insert leaves the phase where it was.
+ */
+struct LfoState {
+    /**
+     * @brief Cycles since the run began, fractional and monotonic.
+     *
+     * The phase is its fractional part, and everything that needs to know how
+     * far through the LFO is rather than where in the cycle it is asks this:
+     * a one-shot is through when it reaches one, and a sustain loop folds it
+     * back into the region. A transport-locked LFO derives it from the
+     * timeline instead of accumulating it.
+     */
+    double cycles = 0.0;
+
+    /// What the last block published, for the UI and for the read-back taps
+    /// (#2122). The phase is the position the shape was read at, so a looped
+    /// curve reports where in the loop it is rather than the raw sweep.
+    float phase = 0.0f;
+    float value = 0.0f;
+
+    /// Output held at zero. Not a pause: the phase goes on advancing
+    /// underneath, so ungating resumes where the LFO would have been rather
+    /// than where it was when the gate shut.
+    bool gated = false;
+
+    /// A one-shot that has played through and is holding its end value.
+    bool completed = false;
+
+    /// Notes holding the gate open. The gate shuts when the last one lifts,
+    /// which is what makes a note-triggered LFO read as an envelope.
+    int heldNotes = 0;
+
+    /**
+     * @brief Whether this state has run at all.
+     *
+     * A fresh LFO takes its gate from LfoSettings::startGated on its first
+     * block; after that the gate belongs to the triggers. The fork re-asserts
+     * it from the model on every property update, because a TE modifier's gate
+     * cannot be reached from the message thread any other way; here the gate
+     * lives beside the phase, so a publish that re-asserted it would be
+     * fighting the note that had just opened it.
+     */
+    bool started = false;
+};
+
+/**
+ * @brief What one block needs to know about time that the block itself cannot say.
+ *
+ * The sample rate, because a free-running LFO advances by how long the block
+ * lasted rather than by how far the timeline moved, and the two are different
+ * things while the transport is stopped. The tempo and the signature, because
+ * a musical division is a fraction of a bar and a bar is neither of those on
+ * its own.
+ */
+struct ModTiming {
+    double sampleRate = 44100.0;
+    double bpm = 120.0;
+    int numerator = 4;
+};
+
+/** @brief The tempo and signature @p block opens on, read off its map. */
+ModTiming modTimingFor(const BlockInfo& block, double sampleRate);
+
+/**
+ * @brief How much of a bar one rate type is.
+ *
+ * The fork's own table (ModifierCommon::getBarFraction), because a synced LFO's
+ * period has to be the same number of beats in both engines or every synced
+ * project drifts. Note that these are fractions of a bar rather than of a whole
+ * note: "1/2" is half a bar, which is a half note in four four and three
+ * quarters of one in three four.
+ */
+double barFractionOf(int rateType);
+
+/**
+ * @brief How many beats one cycle of a tempo-synced LFO lasts.
+ *
+ * The bar fraction times the signature's own beats, which is what makes a
+ * "1 Bar" LFO a bar long whatever the signature is.
+ */
+double cycleBeats(int rateType, int numerator);
+
+/**
+ * @brief The rate ordinal a Rate lane's value stands for, and back again.
+ *
+ * The lane counts from the first musical division rather than from the
+ * enumeration's own zero, because zero is Hertz and Hertz is not a division: a
+ * synced modifier whose lane ran to the bottom of its range would otherwise
+ * resolve to "not synced at all". The model's Rate control stores the shifted
+ * index (AutomationInfo::makeSyncDivisionInfo) and this is the same shift on
+ * the engine's side of the same lane.
+ */
+int rateTypeFromLaneValue(float laneValue);
+float laneValueFromRateType(int rateType);
+
+/**
+ * @brief The level @p settings has at @p phase, before gating and inversion.
+ *
+ * The model's own reading of the shape (core/ModCurve.hpp). Exposed because
+ * the read-back taps and the tests both want the shape without the run.
+ */
+float lfoShapeAt(const LfoSettings& settings, std::span<const magda::CurvePointData> curve,
+                 float phase);
+
+/**
+ * @brief Restart @p state, as a trigger does.
+ *
+ * The phase goes back to the top and a finished one-shot plays again. A
+ * free-running or timeline-locked LFO is not restarted at all, which is the
+ * fork's rule as well: resync only acts when the sync type is note, so an LFO
+ * that is not listening for a trigger ignores the notes going past it.
+ *
+ * Whether a trigger is one this LFO listens to is the caller's question rather
+ * than this one's: LfoSettings::skipNativeResync says the LFO belongs to
+ * another track's monitor, and that is about where a trigger came from.
+ */
+void restartLfo(LfoState& state, const LfoSettings& settings);
+
+/**
+ * @brief Advance @p state over one block and publish what @p settings says.
+ *
+ * On the audio thread, once per block, before anything reads the modifier.
+ * Returns the output: 0 to 1, inverted where the curve is a level, and 0 flat
+ * while the gate is shut, which is the convention that makes an inactive
+ * modifier mean "doing nothing" everywhere it is read.
+ *
+ * The value published is the one the block opens on, and the ramp is moved on
+ * afterwards, which is the order the fork's timer uses and therefore the order
+ * a parity case is measured against.
+ */
+float advanceLfo(LfoState& state, const LfoSettings& settings,
+                 std::span<const magda::CurvePointData> curve, const BlockInfo& block,
+                 const ModTiming& timing);
+
+}  // namespace magda::engine

--- a/magda/engine/param/ModRuntime.cpp
+++ b/magda/engine/param/ModRuntime.cpp
@@ -1,0 +1,213 @@
+#include "param/ModRuntime.hpp"
+
+#include <algorithm>
+#include <unordered_map>
+
+#include "param/ParamTable.hpp"
+
+namespace magda::engine {
+
+void ModRuntime::reset() {
+    states_.clear();
+    values_.clear();
+    keys_.clear();
+    kinds_.clear();
+    fingerprint_ = 0;
+    sampleRate_ = 44100.0;
+    timing_ = ModTiming{};
+    carried_ = 0;
+}
+
+void ModRuntime::prepare(const ParamTable& table, const RenderContext& context,
+                         const ModRuntime* previous) {
+    reset();
+
+    sampleRate_ = context.sampleRate > 0.0 ? context.sampleRate : 44100.0;
+    fingerprint_ = table.modifierFingerprint;
+    timing_.sampleRate = sampleRate_;
+
+    const auto count = table.modifiers.size();
+    states_.reserve(count);
+    values_.reserve(count);
+    keys_.reserve(count);
+    kinds_.reserve(count);
+
+    // What the previous epoch holds, by address. Built rather than scanned
+    // because a project with sixteen modifiers per scope has plenty of them,
+    // and this runs once per prepare rather than once per block.
+    std::unordered_map<ParamKey, std::size_t, ParamKeyHash> adoptable;
+    if (previous != nullptr) {
+        adoptable.reserve(previous->keys_.size());
+        for (std::size_t i = 0; i < previous->keys_.size(); ++i)
+            adoptable.emplace(previous->keys_[i], i);
+    }
+
+    for (const auto& modifier : table.modifiers) {
+        std::shared_ptr<ModState> state;
+
+        if (previous != nullptr) {
+            const auto found = adoptable.find(modifier.key);
+
+            // The same address and the same kind. A modifier the user has
+            // switched from one type to another is a different engine at that
+            // address, and the phase of the one it replaced means nothing to
+            // it.
+            if (found != adoptable.end() && previous->kinds_[found->second] == modifier.kind) {
+                state = previous->states_[found->second];
+                ++carried_;
+            }
+        }
+
+        if (state == nullptr)
+            state = std::make_shared<ModState>();
+
+        states_.push_back(std::move(state));
+        values_.push_back(modifier.value);
+        keys_.push_back(modifier.key);
+        kinds_.push_back(modifier.kind);
+    }
+}
+
+void ModRuntime::beginBlock(const BlockInfo& block) {
+    timing_ = modTimingFor(block, sampleRate_);
+}
+
+void ModRuntime::advance(int index, const ParamTable& table, const LfoRate& rate,
+                         const BlockInfo& block) {
+    auto* state = mutableState(index);
+    if (state == nullptr || index >= static_cast<int>(table.modifiers.size()))
+        return;
+
+    const auto& modifier = table.modifiers[static_cast<std::size_t>(index)];
+
+    // A modifier the model has switched off is not a modifier that outputs
+    // nothing: it is a modifier that is not there. Its links are not carried
+    // (ParamTableCompiler), so what this publishes is only ever read by the
+    // taps, and zero is what an absent modifier reads as.
+    if (!modifier.enabled) {
+        values_[static_cast<std::size_t>(index)] = 0.0f;
+        return;
+    }
+
+    if (modifier.kind != ModKind::Lfo) {
+        // No engine yet (#2120). The model's own reading, held, which is what
+        // every modifier published before this slice.
+        values_[static_cast<std::size_t>(index)] = modifier.value;
+        return;
+    }
+
+    auto settings = modifier.lfo;
+    settings.rate = rate;
+
+    values_[static_cast<std::size_t>(index)] =
+        advanceLfo(state->lfo, settings, table.modCurveFor(index), block, timing_);
+}
+
+float ModRuntime::value(int index) const {
+    if (index < 0 || index >= static_cast<int>(values_.size()))
+        return 0.0f;
+
+    return values_[static_cast<std::size_t>(index)];
+}
+
+const ModState* ModRuntime::state(int index) const {
+    if (index < 0 || index >= static_cast<int>(states_.size()))
+        return nullptr;
+
+    return states_[static_cast<std::size_t>(index)].get();
+}
+
+ModState* ModRuntime::mutableState(int index) {
+    if (index < 0 || index >= static_cast<int>(states_.size()))
+        return nullptr;
+
+    return states_[static_cast<std::size_t>(index)].get();
+}
+
+int ModRuntime::indexOf(const ParamKey& key) const {
+    const auto found = std::find(keys_.begin(), keys_.end(), key);
+    return found == keys_.end() ? -1 : static_cast<int>(std::distance(keys_.begin(), found));
+}
+
+void ModRuntime::noteOn(int index, const ParamTable& table) {
+    auto* state = mutableState(index);
+    if (state == nullptr || index >= static_cast<int>(table.modifiers.size()))
+        return;
+
+    const auto& settings = table.modifiers[static_cast<std::size_t>(index)].lfo;
+
+    // A cross-track sidechain LFO follows its source track and nothing else.
+    // Retriggering it from the track it ducks is the bug the fork's flag
+    // exists to prevent: the phase restarts against the sidechain rhythm and
+    // the gate flaps on every note the destination happens to play.
+    if (settings.skipNativeResync && !settings.gateOnTrigger)
+        return;
+
+    if (!settings.skipNativeResync)
+        restartLfo(state->lfo, settings);
+
+    if (settings.gateOnTrigger) {
+        ++state->lfo.heldNotes;
+        state->lfo.gated = false;
+        state->lfo.started = true;
+    }
+}
+
+void ModRuntime::noteOff(int index, const ParamTable& table) {
+    auto* state = mutableState(index);
+    if (state == nullptr || index >= static_cast<int>(table.modifiers.size()))
+        return;
+
+    if (!table.modifiers[static_cast<std::size_t>(index)].lfo.gateOnTrigger)
+        return;
+
+    state->lfo.heldNotes = std::max(0, state->lfo.heldNotes - 1);
+    if (state->lfo.heldNotes == 0)
+        state->lfo.gated = true;
+    state->lfo.started = true;
+}
+
+void ModRuntime::allNotesOff(int index, const ParamTable& table) {
+    auto* state = mutableState(index);
+    if (state == nullptr || index >= static_cast<int>(table.modifiers.size()))
+        return;
+
+    if (!table.modifiers[static_cast<std::size_t>(index)].lfo.gateOnTrigger)
+        return;
+
+    state->lfo.heldNotes = 0;
+    state->lfo.gated = true;
+    state->lfo.started = true;
+}
+
+void ModRuntime::trigger(int index, const ParamTable& table, bool forceZero) {
+    auto* state = mutableState(index);
+    if (state == nullptr || index >= static_cast<int>(table.modifiers.size()))
+        return;
+
+    const auto& settings = table.modifiers[static_cast<std::size_t>(index)].lfo;
+
+    state->lfo.gated = false;
+    state->lfo.started = true;
+    restartLfo(state->lfo, settings);
+
+    // The forced zero stands in for the gap a gated retrigger leaves, so the
+    // device sees a transition rather than a continuation. Never for a level
+    // curve: there, zero output is full level, and forcing one in the middle
+    // of a duck pops the gain up for a block, which is a click on every hit.
+    if (forceZero && !settings.invertOutput) {
+        state->lfo.value = 0.0f;
+        values_[static_cast<std::size_t>(index)] = 0.0f;
+    }
+}
+
+void ModRuntime::setGated(int index, bool gated) {
+    auto* state = mutableState(index);
+    if (state == nullptr)
+        return;
+
+    state->lfo.gated = gated;
+    state->lfo.started = true;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/param/ModRuntime.cpp
+++ b/magda/engine/param/ModRuntime.cpp
@@ -136,15 +136,18 @@ void ModRuntime::noteOn(int index, const ParamTable& table) {
 
     const auto& settings = table.modifiers[static_cast<std::size_t>(index)].lfo;
 
-    // A cross-track sidechain LFO follows its source track and nothing else.
-    // Retriggering it from the track it ducks is the bug the fork's flag
-    // exists to prevent: the phase restarts against the sidechain rhythm and
-    // the gate flaps on every note the destination happens to play.
-    if (settings.skipNativeResync && !settings.gateOnTrigger)
+    // A cross-track sidechain LFO follows its source track and nothing else:
+    // not its phase, and not its gate either. Retriggering it from the track
+    // it ducks is the bug the fork's flag exists to prevent, and so is gating
+    // it from there, which flaps on every note the destination plays.
+    //
+    // The fork suppresses the two separately, because its flags are set apart
+    // and the combination is prevented rather than refused. Here the policy is
+    // the guard: a modifier driven from elsewhere does not hear this at all.
+    if (settings.skipNativeResync)
         return;
 
-    if (!settings.skipNativeResync)
-        restartLfo(state->lfo, settings);
+    restartLfo(state->lfo, settings);
 
     if (settings.gateOnTrigger) {
         ++state->lfo.heldNotes;
@@ -158,7 +161,8 @@ void ModRuntime::noteOff(int index, const ParamTable& table) {
     if (state == nullptr || index >= static_cast<int>(table.modifiers.size()))
         return;
 
-    if (!table.modifiers[static_cast<std::size_t>(index)].lfo.gateOnTrigger)
+    const auto& settings = table.modifiers[static_cast<std::size_t>(index)].lfo;
+    if (settings.skipNativeResync || !settings.gateOnTrigger)
         return;
 
     state->lfo.heldNotes = std::max(0, state->lfo.heldNotes - 1);
@@ -172,7 +176,8 @@ void ModRuntime::allNotesOff(int index, const ParamTable& table) {
     if (state == nullptr || index >= static_cast<int>(table.modifiers.size()))
         return;
 
-    if (!table.modifiers[static_cast<std::size_t>(index)].lfo.gateOnTrigger)
+    const auto& settings = table.modifiers[static_cast<std::size_t>(index)].lfo;
+    if (settings.skipNativeResync || !settings.gateOnTrigger)
         return;
 
     state->lfo.heldNotes = 0;
@@ -195,10 +200,13 @@ void ModRuntime::trigger(int index, const ParamTable& table, bool forceZero) {
     // device sees a transition rather than a continuation. Never for a level
     // curve: there, zero output is full level, and forcing one in the middle
     // of a duck pops the gain up for a block, which is a click on every hit.
-    if (forceZero && !settings.invertOutput) {
-        state->lfo.value = 0.0f;
-        values_[static_cast<std::size_t>(index)] = 0.0f;
-    }
+    //
+    // Latched rather than published. A trigger arrives inside a block whose
+    // parameters have already been resolved, so a value written here would be
+    // overwritten by the next block's advance before any device read it; the
+    // latch is what makes the gap reach one (LfoState::forceZero).
+    if (forceZero && !settings.invertOutput)
+        state->lfo.forceZero = true;
 }
 
 void ModRuntime::setGated(int index, bool gated) {

--- a/magda/engine/param/ModRuntime.hpp
+++ b/magda/engine/param/ModRuntime.hpp
@@ -1,0 +1,196 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "exec/RenderContext.hpp"
+#include "param/ModLfo.hpp"
+#include "param/ParamKey.hpp"
+
+/**
+ * @file ModRuntime.hpp
+ * @brief The modifiers of one plan, and where each of them has got to.
+ *
+ * The table says what a modifier is; this says where it is. The two are apart
+ * because they live at different speeds: a table is republished every time a
+ * knob moves, and an LFO that restarted on each of those would never finish a
+ * cycle. So the settings travel with the values and the phase stays here,
+ * carried from one epoch to the next by the modifier's own address.
+ *
+ * Carried by sharing rather than by copying. The executor being replaced is
+ * still rendering while the next one is prepared, so its states are taken by
+ * reference the way a delay line is: an LFO whose modifier survives a device
+ * insert goes on turning through the swap rather than resuming from wherever
+ * it was read at.
+ *
+ * Prepared off the audio thread, advanced on it, once per modifier per block,
+ * from inside the table's resolution order so that anything a modifier reads
+ * has already been resolved when it runs (ParamResolve.hpp).
+ *
+ * ## Where a trigger comes from
+ *
+ * Two of the three trigger modes need something outside the parameter system
+ * to say when. A note-triggered modifier is driven by the MIDI reaching the
+ * scope it lives in, and an audio-triggered or cross-track one by the level
+ * detector watching its source. Neither exists in the native engine yet, so
+ * the trigger calls below are the shape those feeds will use rather than
+ * something the executor calls today.
+ *
+ * The transport mode needs nothing: a timeline-locked modifier is a function
+ * of where the block is, and that is wired. The rest arrive with the slice
+ * that has to solve the same problem for the ADSR's gate and the envelope
+ * follower's input (#2120), because those cannot be built without it.
+ */
+
+namespace magda::engine {
+
+struct ParamTable;
+
+/**
+ * @brief Where one modifier has got to.
+ *
+ * One kind runs today. The rest are carried as a value the table published and
+ * hold it, which is what every modifier did before this slice; their engines
+ * arrive in #2120 and their state joins this struct there.
+ */
+struct ModState {
+    LfoState lfo;
+};
+
+/**
+ * @brief The modifier engines behind one plan.
+ *
+ * Indexed the way ParamTable::modifiers is, because a link names a modifier by
+ * that index and the block has no time to look one up.
+ */
+class ModRuntime {
+  public:
+    /**
+     * @brief Size for @p table and adopt what @p previous already had.
+     *
+     * Off the audio thread, when a plan is prepared. A modifier the previous
+     * runtime holds at the same address and of the same kind keeps its state,
+     * shared rather than copied; everything else starts fresh.
+     *
+     * @p previous may be null, which is a session's first plan.
+     */
+    void prepare(const ParamTable& table, const RenderContext& context,
+                 const ModRuntime* previous = nullptr);
+
+    /// Forget everything. Off the audio thread; every prepare starts here.
+    void reset();
+
+    int size() const {
+        return static_cast<int>(states_.size());
+    }
+
+    /// Modifiers this runtime took over from the one it replaced, rather than
+    /// starting again. What the address-keyed carry bought, in other words:
+    /// every one of these is an LFO that did not restart on the edit.
+    int carried() const {
+        return carried_;
+    }
+
+    /**
+     * @brief Identity of the modifier list this was sized for.
+     *
+     * What ParamTable::layoutFingerprint is to the parameters. A table with
+     * another one puts different modifiers at the same indices, so the state
+     * kept here would be another LFO's phase and a link would read another
+     * modifier's output.
+     */
+    std::uint64_t fingerprint() const {
+        return fingerprint_;
+    }
+
+    /// Settle what this block is, before any modifier is advanced. On the
+    /// audio thread, once per block.
+    void beginBlock(const BlockInfo& block);
+
+    /**
+     * @brief Advance modifier @p index over the block and publish its output.
+     *
+     * On the audio thread, from the table's resolution order. @p rate is what
+     * its Rate parameter resolved to this block, which is a frequency or a
+     * division ordinal depending on whether the modifier is tempo synced.
+     *
+     * A modifier of a kind that has no engine yet publishes the value the
+     * table carries, which is the model's own reading of it.
+     */
+    void advance(int index, const ParamTable& table, const LfoRate& rate, const BlockInfo& block);
+
+    /// What modifier @p index published this block, or the model's own value
+    /// for one nothing has advanced.
+    float value(int index) const;
+
+    /// Where modifier @p index has got to, for the read-back taps and the
+    /// tests. Null for an index this runtime does not have.
+    const ModState* state(int index) const;
+
+    /// The modifier at @p key, or -1. Off the audio thread: it is a scan, and
+    /// what asks is a caller holding an address rather than an index.
+    int indexOf(const ParamKey& key) const;
+
+    /**
+     * @brief A trigger from where the modifier lives.
+     *
+     * A note-on on the stream the modifier's own scope plays. Restarts the
+     * phase and, where the modifier is gated by its trigger, opens the gate
+     * and counts the note as held.
+     *
+     * Refused when the modifier belongs to another track's monitor
+     * (LfoSettings::skipNativeResync): a cross-track sidechain LFO follows its
+     * source and must not be retriggered by whatever the track it ducks
+     * happens to be playing.
+     */
+    void noteOn(int index, const ParamTable& table);
+
+    /// The other half of it: the gate shuts when the last held note lifts.
+    void noteOff(int index, const ParamTable& table);
+
+    /// Every held note at once, which is what an all-notes-off is.
+    void allNotesOff(int index, const ParamTable& table);
+
+    /**
+     * @brief A trigger from somewhere else.
+     *
+     * What the source track's monitor does to a cross-track sidechain LFO, and
+     * the one path skipNativeResync does not refuse: it is the trigger the
+     * modifier exists to follow.
+     *
+     * @p forceZero publishes a zero for the trigger block, so the device sees
+     * the gap a gated retrigger would have left. Never for a level curve,
+     * where zero output is full level and forcing one would pop the gain up
+     * for a block in the middle of a duck.
+     */
+    void trigger(int index, const ParamTable& table, bool forceZero = true);
+
+    /// Shut or open the gate directly, which is what an audio trigger does
+    /// between hits.
+    void setGated(int index, bool gated);
+
+  private:
+    ModState* mutableState(int index);
+
+    /// Shared rather than owned outright, so an epoch being replaced and the
+    /// one replacing it are the same LFO rather than two copies of it. Only
+    /// one epoch renders at a time, so there is an owner to outlive and no
+    /// concurrent use to guard against.
+    std::vector<std::shared_ptr<ModState>> states_;
+
+    /// What each modifier published this block. Filled by advance(), and by
+    /// the table's own value for a kind with no engine yet.
+    std::vector<float> values_;
+
+    /// The addresses the states are held at, for the carry and for indexOf.
+    std::vector<ParamKey> keys_;
+    std::vector<ModKind> kinds_;
+
+    std::uint64_t fingerprint_ = 0;
+    double sampleRate_ = 44100.0;
+    ModTiming timing_;
+    int carried_ = 0;
+};
+
+}  // namespace magda::engine

--- a/magda/engine/param/ModRuntime.hpp
+++ b/magda/engine/param/ModRuntime.hpp
@@ -147,9 +147,12 @@ class ModRuntime {
     void noteOn(int index, const ParamTable& table);
 
     /// The other half of it: the gate shuts when the last held note lifts.
+    /// Refused on the same terms, because a gate that only one half of the
+    /// pair could reach would latch open on the first note it heard.
     void noteOff(int index, const ParamTable& table);
 
-    /// Every held note at once, which is what an all-notes-off is.
+    /// Every held note at once, which is what an all-notes-off is. Refused on
+    /// the same terms again.
     void allNotesOff(int index, const ParamTable& table);
 
     /**

--- a/magda/engine/param/ParamResolve.cpp
+++ b/magda/engine/param/ParamResolve.cpp
@@ -283,15 +283,90 @@ int bakeCurve(std::span<const magda::AutomationPoint> curve, const ParamSpec& sp
     return written;
 }
 
-void resolveParams(const ParamTable& table, ResolvedParams& out, std::span<ModContribution> links,
-                   std::span<ParamSegment> segments, const BlockInfo& block) {
-    const auto numSamples = block.numSamples;
+namespace {
 
+/// What a link reading modifier @p index gets. The runtime's, where there is
+/// one; otherwise the model's own reading, which is what every modifier
+/// published before it had an engine.
+float modifierValue(const ParamTable& table, const ModRuntime* mods, int index) {
+    if (index < 0 || index >= static_cast<int>(table.modifiers.size()))
+        return 0.0f;
+
+    return mods != nullptr ? mods->value(index)
+                           : table.modifiers[static_cast<std::size_t>(index)].value;
+}
+
+/// The rate modifier @p index runs at this block: what its own settings say,
+/// unless something reaches its Rate parameter, which resolved earlier in the
+/// order precisely so this can read it.
+LfoRate rateFor(const ResolvedParams& out, const ParamModifier& modifier) {
+    auto rate = modifier.lfo.rate;
+    if (modifier.rate == INVALID_PARAM_ID)
+        return rate;
+
+    const auto resolved = out[modifier.rate];
+    if (resolved.empty())
+        return rate;
+
+    // One lane, two meanings, decided by the same flag that decides what the
+    // period is: a frequency when the modifier is free, and a division when it
+    // is synced.
+    if (modifier.lfo.tempoSync)
+        rate.rateType = rateTypeFromLaneValue(resolved.value());
+    else
+        rate.hz = resolved.value();
+
+    return rate;
+}
+
+void resolveOneParam(const ParamTable& table, ResolvedParams& out, const ModRuntime* mods,
+                     std::span<ModContribution> links, std::span<ParamSegment> segments,
+                     const BlockInfo& block, ParamId param) {
+    const auto index = static_cast<std::size_t>(param);
+    const auto reaching = table.linksFor(param);
+
+    std::size_t used = 0;
+    for (const auto& link : reaching) {
+        if (used >= links.size())
+            break;
+
+        float value = 0.0f;
+        switch (link.source.kind) {
+            case ParamSourceRef::Kind::Parameter:
+                // Already resolved: that is what the order is for.
+                value = out.sourceValue(link.source.index);
+                break;
+
+            case ParamSourceRef::Kind::Modifier:
+                // Already advanced, for the same reason.
+                value = modifierValue(table, mods, link.source.index);
+                break;
+        }
+
+        links[used++] = ModContribution{value, link.amount, link.bipolar};
+    }
+
+    const auto baked = bakeCurve(table.curveFor(param), table.specs[index], block, segments);
+
+    ParamSources sources;
+    sources.base = table.base[index];
+    sources.modulation = links.first(used);
+    sources.automation =
+        std::span<const ParamSegment>{segments}.first(static_cast<std::size_t>(std::max(baked, 0)));
+    sources.automationEnd = block.numSamples;
+
+    resolveParam(out, param, table.specs[index], sources);
+}
+
+}  // namespace
+
+void resolveParams(const ParamTable& table, ResolvedParams& out, std::span<ModContribution> links,
+                   std::span<ParamSegment> segments, const BlockInfo& block, ModRuntime* mods) {
     // Emptied first, and then refused. A table that does not fit is not a
     // reason to keep rendering last block's values: those were resolved for a
     // parameter set this one no longer has, and a device reading them would be
     // holding a frozen project rather than an unresolved one.
-    out.beginBlock(numSamples);
+    out.beginBlock(block.numSamples);
 
     // Indexed by the same ParamId, so a size that disagrees is two things
     // prepared against different tables. Refused whole: half a table of
@@ -299,45 +374,34 @@ void resolveParams(const ParamTable& table, ResolvedParams& out, std::span<ModCo
     if (table.size() != out.size())
         return;
 
-    for (const auto param : table.order) {
-        if (param < 0 || param >= table.size())
-            continue;
+    // The modifier list is indexed the same way, and a runtime sized for a
+    // different one holds another modifier's phase at every index. Rather than
+    // refuse the whole block over it, the modifiers fall back to the values
+    // the table carries, which is what they published before they could move.
+    const bool runnable =
+        mods != nullptr && mods->size() == static_cast<int>(table.modifiers.size());
+    if (runnable)
+        mods->beginBlock(block);
 
-        const auto index = static_cast<std::size_t>(param);
-        const auto reaching = table.linksFor(param);
+    // Nothing behind the modifiers, so what a link reads is the table's own
+    // value rather than an index into a runtime sized for another list.
+    const ModRuntime* reading = runnable ? mods : nullptr;
 
-        std::size_t used = 0;
-        for (const auto& link : reaching) {
-            if (used >= links.size())
+    for (const auto& step : table.order) {
+        switch (step.kind) {
+            case ParamStep::Kind::Parameter:
+                if (step.index >= 0 && step.index < table.size())
+                    resolveOneParam(table, out, reading, links, segments, block, step.index);
                 break;
 
-            float value = 0.0f;
-            switch (link.source.kind) {
-                case ParamSourceRef::Kind::Parameter:
-                    // Already resolved: that is what the order is for.
-                    value = out.sourceValue(link.source.index);
-                    break;
-
-                case ParamSourceRef::Kind::Modifier:
-                    if (link.source.index >= 0 &&
-                        link.source.index < static_cast<int>(table.modifiers.size()))
-                        value = table.modifiers[static_cast<std::size_t>(link.source.index)].value;
-                    break;
-            }
-
-            links[used++] = ModContribution{value, link.amount, link.bipolar};
+            case ParamStep::Kind::Modifier:
+                if (runnable && step.index >= 0 &&
+                    step.index < static_cast<int>(table.modifiers.size())) {
+                    const auto& modifier = table.modifiers[static_cast<std::size_t>(step.index)];
+                    mods->advance(step.index, table, rateFor(out, modifier), block);
+                }
+                break;
         }
-
-        const auto baked = bakeCurve(table.curveFor(param), table.specs[index], block, segments);
-
-        ParamSources sources;
-        sources.base = table.base[index];
-        sources.modulation = links.first(used);
-        sources.automation = std::span<const ParamSegment>{segments}.first(
-            static_cast<std::size_t>(std::max(baked, 0)));
-        sources.automationEnd = numSamples;
-
-        resolveParam(out, param, table.specs[index], sources);
     }
 }
 

--- a/magda/engine/param/ParamResolve.hpp
+++ b/magda/engine/param/ParamResolve.hpp
@@ -3,6 +3,7 @@
 #include <span>
 
 #include "exec/RenderContext.hpp"
+#include "param/ModRuntime.hpp"
 #include "param/ParamBlock.hpp"
 #include "param/ParamSpec.hpp"
 #include "param/ParamTable.hpp"
@@ -140,8 +141,13 @@ int bakeCurve(std::span<const magda::AutomationPoint> curve, const ParamSpec& sp
  *
  * On the audio thread, once per block, before any device runs. Walks the
  * table's resolution order, so a macro driving a macro driving a device
- * parameter needs no second pass: whatever a parameter reads has already been
+ * parameter needs no second pass: whatever a step reads has already been
  * resolved when it is reached.
+ *
+ * The order covers the modifiers too (#2119), which is what lets a macro drive
+ * an LFO's rate while the LFO drives a cutoff, in the same single pass. @p mods
+ * is where their phase lives; without one, every modifier reads the value the
+ * table carries, which is the model's own and does not move between publishes.
  *
  * @p links is where one parameter's contributions are gathered, and it has to
  * hold ParamTable::maxLinksPerParam of them. @p segments is where its curve is
@@ -159,6 +165,7 @@ int bakeCurve(std::span<const magda::AutomationPoint> curve, const ParamSpec& sp
  * and a mismatch means they were prepared against different plans.
  */
 void resolveParams(const ParamTable& table, ResolvedParams& out, std::span<ModContribution> links,
-                   std::span<ParamSegment> segments, const BlockInfo& block);
+                   std::span<ParamSegment> segments, const BlockInfo& block,
+                   ModRuntime* mods = nullptr);
 
 }  // namespace magda::engine

--- a/magda/engine/param/ParamTable.cpp
+++ b/magda/engine/param/ParamTable.cpp
@@ -4,20 +4,20 @@
 
 namespace magda::engine {
 
-std::uint64_t paramLayoutFingerprint(const std::vector<ParamKey>& keys) {
-    // FNV-1a, as the plan's fingerprint is: it has to separate layouts that
-    // differ, and it runs off the audio thread once per compile.
-    std::uint64_t hash = 14695981039346656037ULL;
-    const auto mix = [&hash](std::uint64_t value) {
+namespace {
+
+/// FNV-1a, as the plan's fingerprint is: it has to separate layouts that
+/// differ, and it runs off the audio thread once per compile.
+class Fingerprint {
+  public:
+    void mix(std::uint64_t value) {
         for (int byte = 0; byte < 8; ++byte) {
-            hash ^= (value >> (byte * 8)) & 0xff;
-            hash *= 1099511628211ULL;
+            hash_ ^= (value >> (byte * 8)) & 0xff;
+            hash_ *= 1099511628211ULL;
         }
-    };
+    }
 
-    mix(keys.size());
-
-    for (const auto& key : keys) {
+    void mix(const ParamKey& key) {
         mix(static_cast<std::uint64_t>(key.kind));
         mix(static_cast<std::uint64_t>(key.scope));
         mix(static_cast<std::uint64_t>(key.trackId));
@@ -28,7 +28,34 @@ std::uint64_t paramLayoutFingerprint(const std::vector<ParamKey>& keys) {
         mix(static_cast<std::uint64_t>(key.index));
     }
 
-    return hash;
+    std::uint64_t value() const {
+        return hash_;
+    }
+
+  private:
+    std::uint64_t hash_ = 14695981039346656037ULL;
+};
+
+}  // namespace
+
+std::uint64_t paramLayoutFingerprint(const std::vector<ParamKey>& keys) {
+    Fingerprint hash;
+    hash.mix(keys.size());
+
+    for (const auto& key : keys)
+        hash.mix(key);
+
+    return hash.value();
+}
+
+std::uint64_t paramModifierFingerprint(const std::vector<ParamModifier>& modifiers) {
+    Fingerprint hash;
+    hash.mix(modifiers.size());
+
+    for (const auto& modifier : modifiers)
+        hash.mix(modifier.key);
+
+    return hash.value();
 }
 
 std::span<const ParamLink> ParamTable::linksFor(ParamId param) const {
@@ -53,6 +80,20 @@ std::span<const magda::AutomationPoint> ParamTable::curveFor(ParamId param) cons
         return {};
 
     return std::span<const magda::AutomationPoint>{curvePoints}.subspan(first, last - first);
+}
+
+std::span<const magda::CurvePointData> ParamTable::modCurveFor(int modifier) const {
+    if (modifier < 0 || modifier + 1 >= static_cast<int>(modCurveOffsets.size()))
+        return {};
+
+    const auto first =
+        static_cast<std::size_t>(modCurveOffsets[static_cast<std::size_t>(modifier)]);
+    const auto last =
+        static_cast<std::size_t>(modCurveOffsets[static_cast<std::size_t>(modifier) + 1]);
+    if (last <= first || last > modCurvePoints.size())
+        return {};
+
+    return std::span<const magda::CurvePointData>{modCurvePoints}.subspan(first, last - first);
 }
 
 }  // namespace magda::engine

--- a/magda/engine/param/ParamTable.cpp
+++ b/magda/engine/param/ParamTable.cpp
@@ -52,8 +52,16 @@ std::uint64_t paramModifierFingerprint(const std::vector<ParamModifier>& modifie
     Fingerprint hash;
     hash.mix(modifiers.size());
 
-    for (const auto& modifier : modifiers)
+    for (const auto& modifier : modifiers) {
         hash.mix(modifier.key);
+
+        // The kind as well as the address, because the model changes one
+        // without moving the other: switching a modifier from an LFO to a
+        // random is an edit in place, and it would otherwise travel as a
+        // values publish that the runtime is never re-prepared for. The engine
+        // behind an address is structural even when the address is not.
+        hash.mix(static_cast<std::uint64_t>(modifier.kind));
+    }
 
     return hash.value();
 }

--- a/magda/engine/param/ParamTable.hpp
+++ b/magda/engine/param/ParamTable.hpp
@@ -7,6 +7,8 @@
 #include <vector>
 
 #include "core/AutomationInfo.hpp"
+#include "core/ModInfo.hpp"
+#include "param/ModLfo.hpp"
 #include "param/ParamKey.hpp"
 #include "param/ParamSpec.hpp"
 
@@ -60,19 +62,65 @@ struct ParamLink {
 /**
  * @brief One modifier instance, as the thing links read.
  *
- * Its value is the model's own for now, which is a constant for the duration of
- * a block and a constant for the duration of a publish. The engines that make
- * it move arrive in #2119 and #2120; what is settled here is that a modifier is
- * a source with an identity, so a link can name one and the resolution order
- * can account for one.
+ * A source with an identity, so a link can name one and the resolution order
+ * can account for one, plus what it takes to run it. The LFO runs here (#2119);
+ * the rest publish @ref value and hold it until their engines arrive (#2120),
+ * which is what every modifier did before this slice.
  */
 struct ParamModifier {
     /// The modifier itself: its owner's scope and its id, with no parameter
     /// index (see ParamKey::modId).
     ParamKey key;
 
-    /// Its output, 0 to 1, as the model last saw it.
+    /// Its output, 0 to 1, as the model last saw it. What a kind with no
+    /// engine publishes, and what a block with no runtime behind it reads.
     float value = 0.0f;
+
+    ModKind kind = ModKind::Lfo;
+
+    /// A modifier the model has switched off contributes nothing at all: its
+    /// links are not carried, because a bipolar link reading an output of zero
+    /// would push its parameter down by the link's own depth, and the model's
+    /// answer is that there is no modifier there.
+    bool enabled = true;
+
+    /// What the LFO is, for @ref kind == ModKind::Lfo.
+    LfoSettings lfo;
+
+    /**
+     * @brief The modifier's own Rate parameter, or INVALID_PARAM_ID.
+     *
+     * Carried only when something reaches it: a lane playing over the rate, or
+     * a macro or another modifier driving it. The overwhelming majority of
+     * modifiers have a rate nothing touches, and one parameter each for them
+     * would be a table mostly made of numbers that never move.
+     *
+     * Its value is a frequency or a division ordinal depending on
+     * LfoSettings::tempoSync, which is the same one lane the model's Rate
+     * control writes (AutomationInfo's makeHzRateInfo / makeSyncDivisionInfo).
+     */
+    ParamId rate = INVALID_PARAM_ID;
+};
+
+/**
+ * @brief One step of the order a block resolves in.
+ *
+ * Two kinds of thing resolve, and they depend on each other in both
+ * directions: a parameter reads the modifiers linked to it, and a modifier
+ * reads the Rate parameter driving it. One order over both is what lets a
+ * macro drive an LFO's rate while the LFO drives a cutoff, in one pass, with
+ * no second look and no fixed point.
+ */
+struct ParamStep {
+    enum class Kind : std::uint8_t {
+        Parameter,  ///< resolve the parameter at @ref index
+        Modifier,   ///< advance the modifier at @ref index
+    };
+
+    Kind kind = Kind::Parameter;
+    int index = 0;
+
+    bool operator==(const ParamStep&) const = default;
 };
 
 /**
@@ -103,6 +151,17 @@ struct ParamTable {
     std::vector<ParamModifier> modifiers;
 
     /**
+     * @brief The curves drawn on the modifiers, in one arena.
+     *
+     * modCurvePoints[modCurveOffsets[i], modCurveOffsets[i + 1]) is the cycle
+     * modifier i has drawn on it, and empty is a modifier playing a built-in
+     * waveform, which is almost all of them. One arena rather than a vector
+     * each, for the reason the links have one.
+     */
+    std::vector<magda::CurvePointData> modCurvePoints;
+    std::vector<int> modCurveOffsets;
+
+    /**
      * @brief The lane playing over each parameter, in beats.
      *
      * Breakpoints, as the model draws them: curvePoints[curveOffsets[i],
@@ -124,14 +183,15 @@ struct ParamTable {
     std::vector<int> curveOffsets;
 
     /**
-     * @brief The order parameters resolve in.
+     * @brief The order the block resolves in.
      *
-     * A permutation of every ParamId, arranged so that anything a parameter
-     * reads has already been resolved when it is. A macro driving a macro
-     * driving a device parameter therefore needs no second pass and no fixed
-     * point, and the audio thread walks a vector.
+     * Every parameter and every modifier, once each, arranged so that anything
+     * a step reads has already been resolved when it is reached. A macro
+     * driving an LFO's rate while the LFO drives a device parameter therefore
+     * needs no second pass and no fixed point, and the audio thread walks a
+     * vector.
      */
-    std::vector<ParamId> order;
+    std::vector<ParamStep> order;
 
     /// The most links any one parameter has, which is how much room the block
     /// resolver needs to gather one parameter's contributions.
@@ -153,6 +213,17 @@ struct ParamTable {
      * that moved with them would turn every knob into a structural edit.
      */
     std::uint64_t layoutFingerprint = 0;
+
+    /**
+     * @brief Identity of the modifier list: which modifier is at which index.
+     *
+     * What @ref layoutFingerprint is to the parameters, and needed separately
+     * because modifiers are not parameters: a scope gaining a page of them
+     * moves every modifier after it without touching a key, and the runtime
+     * holding each one's phase is indexed the same way. Without it a values
+     * publish would hand one LFO's phase to another.
+     */
+    std::uint64_t modifierFingerprint = 0;
 
     /** Where one device's parameters sit in the table. */
     struct DeviceWindow {
@@ -189,6 +260,10 @@ struct ParamTable {
     /// The lane playing over @p param, empty when none is.
     std::span<const magda::AutomationPoint> curveFor(ParamId param) const;
 
+    /// The cycle drawn on modifier @p modifier, empty when it plays a built-in
+    /// waveform.
+    std::span<const magda::CurvePointData> modCurveFor(int modifier) const;
+
     /// Where @p device's parameters are, or a window of nothing.
     DeviceWindow windowFor(const DeviceKey& device) const {
         const auto found = deviceWindows.find(device);
@@ -205,5 +280,14 @@ struct ParamTable {
  * parameter that index was resolved for.
  */
 std::uint64_t paramLayoutFingerprint(const std::vector<ParamKey>& keys);
+
+/**
+ * @brief The modifier fingerprint of a modifier list.
+ *
+ * Exposed for the same reason the layout's is: the thing holding a modifier's
+ * phase was prepared against one list and has to be able to tell that the
+ * table it meets is not it.
+ */
+std::uint64_t paramModifierFingerprint(const std::vector<ParamModifier>& modifiers);
 
 }  // namespace magda::engine

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -78,6 +78,7 @@ LfoSettings lfoSettingsOf(const magda::ModInfo& mod) {
     settings.wave = mod.waveform;
     settings.preset = mod.curvePreset;
     settings.sync = modSyncOf(mod);
+    settings.trigger = mod.triggerMode;
     settings.tempoSync = mod.tempoSync;
     settings.rate.hz = mod.rate;
     settings.rate.rateType = mod.tempoSync ? magda::syncDivisionToTeRateOrdinal(mod.syncDivision)

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -19,6 +19,10 @@ namespace {
 /// deciding how much the engine allocates.
 constexpr int kMaxDeviceParamIndex = 4096;
 
+/// The one parameter a modifier exposes: its Rate, which the model addresses
+/// as ControlTarget::modParam(scope, modId, 0).
+constexpr int kModRateParamIndex = 0;
+
 /// What a macro knob is: a position between nothing and everything, with the
 /// meaning of both left to whatever it is linked to.
 ParamSpec macroSpec() {
@@ -27,6 +31,103 @@ ParamSpec macroSpec() {
     spec.domain.minValue = 0.0f;
     spec.domain.maxValue = 1.0f;
     return spec;
+}
+
+/// Which engine drives a modifier of this type.
+ModKind modKindOf(magda::ModType type) {
+    switch (type) {
+        case magda::ModType::LFO:
+            return ModKind::Lfo;
+        case magda::ModType::Envelope:
+            return ModKind::Adsr;
+        case magda::ModType::Random:
+            return ModKind::Random;
+        case magda::ModType::Follower:
+            return ModKind::Follower;
+    }
+    return ModKind::Lfo;
+}
+
+/**
+ * @brief Where a modifier's phase comes from, folded from what the model says.
+ *
+ * The model keeps the trigger mode and the tempo-sync flag apart, and the fork
+ * folds the two into one sync type (ModifierHelpers::mapSyncType). Folded the
+ * same way here, so a project sounds the same in both engines:
+ *
+ *  - a MIDI or audio trigger is a run something restarts, whether or not it is
+ *    also tempo synced;
+ *  - a transport trigger, and tempo sync on its own, are both a run locked to
+ *    the timeline, which is what makes a synced LFO agree with the bar;
+ *  - everything else free-runs at its own frequency.
+ */
+ModSync modSyncOf(const magda::ModInfo& mod) {
+    if (mod.triggerMode == magda::LFOTriggerMode::MIDI ||
+        mod.triggerMode == magda::LFOTriggerMode::Audio)
+        return ModSync::Note;
+
+    if (mod.tempoSync || mod.triggerMode == magda::LFOTriggerMode::Transport)
+        return ModSync::Transport;
+
+    return ModSync::Free;
+}
+
+/// What the model says one LFO is.
+LfoSettings lfoSettingsOf(const magda::ModInfo& mod) {
+    LfoSettings settings;
+    settings.wave = mod.waveform;
+    settings.preset = mod.curvePreset;
+    settings.sync = modSyncOf(mod);
+    settings.tempoSync = mod.tempoSync;
+    settings.rate.hz = mod.rate;
+    settings.rate.rateType = mod.tempoSync ? magda::syncDivisionToTeRateOrdinal(mod.syncDivision)
+                                           : static_cast<int>(magda::ModRateType::Hertz);
+    settings.phaseOffset = mod.phaseOffset;
+    settings.oneShot = mod.oneShot;
+    settings.invertOutput = mod.invertOutput;
+    settings.useLoopRegion = mod.useLoopRegion;
+    settings.loopStart = mod.loopStart;
+    settings.loopEnd = mod.loopEnd;
+
+    // Which triggers this LFO listens to, and whether they gate it. Both are
+    // the fork's rules read off the same model fields (applyLFOProperties):
+    // a note-triggered LFO is gated by its own held notes so it reads as an
+    // envelope, and an audio-triggered one sits shut between hits.
+    //
+    // Cross-track sidechain is the one thing the model cannot say here. It is
+    // a property of the device the modifier drives rather than of the modifier
+    // (PluginManager owns it in the fork), so it is left off and set by
+    // whoever knows, which is the same place that will feed the triggers.
+    settings.gateOnTrigger = mod.triggerMode == magda::LFOTriggerMode::MIDI;
+    settings.startGated = mod.triggerMode == magda::LFOTriggerMode::Audio ||
+                          (mod.triggerMode == magda::LFOTriggerMode::MIDI && !mod.running);
+
+    return settings;
+}
+
+/**
+ * @brief What the modifier's Rate lane means, and where it starts.
+ *
+ * One lane with two readings, chosen by the same flag that chooses what the
+ * period is: a frequency while the modifier free-runs, and a division ordinal
+ * while it is synced. The model's own two descriptions of that lane, because
+ * they are what a curve drawn over it was normalised against, and a second
+ * copy of the numbers here would be a lane the engine read differently from
+ * the editor that drew it.
+ */
+ParamSpec modRateSpec(const magda::ModInfo& mod) {
+    return paramSpecFrom(mod.tempoSync ? magda::ParameterPresets::modRateSyncDivision()
+                                       : magda::ParameterPresets::modRateHz());
+}
+
+/// Where that lane sits before anything moves it, normalised.
+float modRateBase(const magda::ModInfo& mod) {
+    const auto spec = modRateSpec(mod);
+    const auto real =
+        mod.tempoSync ? laneValueFromRateType(magda::syncDivisionToTeRateOrdinal(mod.syncDivision))
+                      : mod.rate;
+
+    return magda::ParameterUtils::realToNormalized(real, spec.domain);
 }
 
 /// A link as this pass needs it, whichever kind of source it came from.
@@ -104,6 +205,10 @@ class Builder {
 
     /// Per parameter, until the curves are flattened into the table.
     std::vector<std::vector<magda::AutomationPoint>> perParamCurve_;
+
+    /// Per modifier, on the same terms: the cycle drawn on it, or nothing for
+    /// one playing a built-in waveform.
+    std::vector<std::vector<magda::CurvePointData>> modCurve_;
 };
 
 ParamId Builder::add(const ParamKey& key, const ParamSpec& spec, float base) {
@@ -168,15 +273,49 @@ void Builder::allocateMods(const Node& node) {
         key.modId = mod.id;
         key.index = -1;
 
-        // The model's own reading of the modifier, which is a constant until
-        // the engines land (#2119, #2120). The two rules that are already
-        // invariants rather than implementation get applied here: an inactive
-        // modifier outputs nothing, and a curve drawn as a level is applied as
-        // its complement.
+        // The model's own reading of the modifier. What a kind with no engine
+        // publishes and holds, and what a block with no runtime behind it
+        // reads. The two rules that are invariants rather than implementation
+        // are applied here as well: an inactive modifier outputs nothing, and
+        // a curve drawn as a level is applied as its complement.
         const float output = mod.enabled ? (mod.invertOutput ? 1.0f - mod.value : mod.value) : 0.0f;
 
+        ParamModifier modifier;
+        modifier.key = key;
+        modifier.value = output;
+        modifier.kind = modKindOf(mod.type);
+        modifier.enabled = mod.enabled;
+        modifier.lfo = lfoSettingsOf(mod);
+
         const auto index = static_cast<int>(table_.modifiers.size());
-        table_.modifiers.push_back(ParamModifier{key, output});
+        table_.modifiers.push_back(modifier);
+
+        // The drawn cycle, where there is one. Copied into the table's own
+        // arena for the reason the automation curves are: an audio thread
+        // cannot go looking in the model, and the model is free to change
+        // underneath the block that is playing it.
+        modCurve_.emplace_back();
+        if (mod.waveform == magda::LFOWaveform::Custom)
+            modCurve_.back() = mod.curvePoints;
+
+        // Its Rate parameter, when something reaches it: a macro or another
+        // modifier driving it, or a lane playing over it. Nothing reaches the
+        // rate of almost any modifier, and a parameter each for the rest would
+        // be a table mostly made of numbers that never move.
+        ParamKey rateKey = key;
+        rateKey.index = kModRateParamIndex;
+
+        if (targeted_.count(rateKey) != 0)
+            table_.modifiers.back().rate = add(rateKey, modRateSpec(mod), modRateBase(mod));
+
+        // A modifier the model has switched off has no links at all rather
+        // than links from a source that outputs zero. The fork creates no
+        // modifier for one, so nothing is assigned and nothing contributes;
+        // carrying the links instead would push every bipolar target down by
+        // the link's own depth, which is a modifier doing something while
+        // switched off.
+        if (!mod.enabled)
+            continue;
 
         for (const auto& link : mod.links) {
             // A link the model keeps but does not apply. Not a diagnostic: it
@@ -444,6 +583,14 @@ void Builder::flattenCurves() {
         table_.curvePoints.insert(table_.curvePoints.end(), curve.begin(), curve.end());
         table_.curveOffsets.push_back(static_cast<int>(table_.curvePoints.size()));
     }
+
+    table_.modCurveOffsets.reserve(modCurve_.size() + 1);
+    table_.modCurveOffsets.push_back(0);
+
+    for (const auto& curve : modCurve_) {
+        table_.modCurvePoints.insert(table_.modCurvePoints.end(), curve.begin(), curve.end());
+        table_.modCurveOffsets.push_back(static_cast<int>(table_.modCurvePoints.size()));
+    }
 }
 
 void Builder::allocate() {
@@ -471,10 +618,9 @@ void Builder::resolveLinks() {
             continue;
         }
 
-        if (key->kind == ParamKey::Kind::ModParam) {
+        if (key->kind == ParamKey::Kind::ModParam && key->index != kModRateParamIndex) {
             diagnose(pending.sourceName + ": links to " + toString(*key) +
-                     ", and a modifier's own parameters arrive with the engines that define "
-                     "them (#2119)");
+                     ", and Rate is the only parameter a modifier has");
             continue;
         }
 
@@ -571,34 +717,58 @@ std::vector<int> stronglyConnectedComponents(const std::vector<std::vector<int>>
 }
 
 void Builder::orderAndBreakCycles() {
-    const auto count = static_cast<std::size_t>(table_.size());
+    // Two kinds of node in one graph, because they depend on each other in
+    // both directions: a parameter reads the modifiers linked to it, and a
+    // modifier reads the Rate parameter driving it. Parameters first, then the
+    // modifiers, so a node id is an index into one or the other.
+    const auto params = static_cast<std::size_t>(table_.size());
+    const auto mods = table_.modifiers.size();
+    const auto count = params + mods;
 
-    // What each parameter reads. A modifier source contributes the modifier's
-    // own parameters, which is nothing until they exist; the loop is written for
-    // what it will be rather than for what it is today, because the order it
-    // produces is the thing that has to stay right.
-    std::vector<std::vector<int>> consumers(count);
-    const auto forEachDependency = [&](std::size_t target, const auto& visit) {
-        for (const auto& link : perParam_[target]) {
-            if (link.source.kind != ParamSourceRef::Kind::Parameter)
-                continue;
-            const auto source = static_cast<std::size_t>(link.source.index);
-            if (source < count)
-                visit(source);
+    const auto nodeForMod = [params](std::size_t modifier) { return params + modifier; };
+
+    // What each node reads.
+    const auto forEachDependency = [&](std::size_t node, const auto& visit) {
+        if (node < params) {
+            for (const auto& link : perParam_[node]) {
+                const auto source = static_cast<std::size_t>(link.source.index);
+                switch (link.source.kind) {
+                    case ParamSourceRef::Kind::Parameter:
+                        if (source < params)
+                            visit(source);
+                        break;
+                    case ParamSourceRef::Kind::Modifier:
+                        if (source < mods)
+                            visit(nodeForMod(source));
+                        break;
+                }
+            }
+            return;
         }
+
+        const auto rate = table_.modifiers[node - params].rate;
+        if (rate != INVALID_PARAM_ID && static_cast<std::size_t>(rate) < params)
+            visit(static_cast<std::size_t>(rate));
     };
 
-    for (std::size_t target = 0; target < count; ++target)
-        forEachDependency(target, [&](std::size_t source) {
-            consumers[source].push_back(static_cast<int>(target));
-        });
+    std::vector<std::vector<int>> consumers(count);
+    const auto buildConsumers = [&] {
+        for (auto& list : consumers)
+            list.clear();
+        for (std::size_t node = 0; node < count; ++node)
+            forEachDependency(node, [&](std::size_t source) {
+                consumers[source].push_back(static_cast<int>(node));
+            });
+    };
 
-    // A cycle is a component with more than one parameter in it, or a parameter
-    // that reads itself. Only the links inside such a component are dropped:
+    buildConsumers();
+
+    // A cycle is a component with more than one node in it, or a node that
+    // reads itself. Only what is inside such a component is dropped:
     // everything hanging off a cycle waits on it too, and a parameter that
     // merely reads a cycle member has done nothing wrong. Once the cycle's own
-    // links are gone its members resolve at their base, and the link that reads
-    // one of them is honoured against that.
+    // edges are gone its members resolve at their base, and the link that
+    // reads one of them is honoured against that.
     const auto component = stronglyConnectedComponents(consumers);
 
     std::vector<int> componentSize(count, 0);
@@ -606,18 +776,28 @@ void Builder::orderAndBreakCycles() {
         if (id >= 0)
             ++componentSize[static_cast<std::size_t>(id)];
 
-    for (std::size_t target = 0; target < count; ++target) {
+    const auto insideCycle = [&](std::size_t node, std::size_t source) {
+        if (component[source] != component[node])
+            return false;
+        return source == node || componentSize[static_cast<std::size_t>(component[node])] > 1;
+    };
+
+    const auto describe = [&](std::size_t node) {
+        return node < params ? toString(table_.keys[node])
+                             : toString(table_.modifiers[node - params].key);
+    };
+
+    for (std::size_t target = 0; target < params; ++target) {
         auto& links = perParam_[target];
         const auto removed = std::remove_if(links.begin(), links.end(), [&](const ParamLink& link) {
-            if (link.source.kind != ParamSourceRef::Kind::Parameter)
-                return false;
-
             const auto source = static_cast<std::size_t>(link.source.index);
-            if (source >= count || component[source] != component[target])
-                return false;
-
-            return source == target ||
-                   componentSize[static_cast<std::size_t>(component[target])] > 1;
+            switch (link.source.kind) {
+                case ParamSourceRef::Kind::Parameter:
+                    return source < params && insideCycle(target, source);
+                case ParamSourceRef::Kind::Modifier:
+                    return source < mods && insideCycle(target, nodeForMod(source));
+            }
+            return false;
         });
 
         if (removed == links.end())
@@ -628,33 +808,50 @@ void Builder::orderAndBreakCycles() {
         links.erase(removed, links.end());
     }
 
+    // A modifier whose own rate is inside the cycle stops reading it and runs
+    // at what the model stored, which is the same answer one level up: the
+    // parameter survives, and only the edge that made it impossible goes.
+    for (std::size_t modifier = 0; modifier < mods; ++modifier) {
+        auto& rate = table_.modifiers[modifier].rate;
+        if (rate == INVALID_PARAM_ID || static_cast<std::size_t>(rate) >= params)
+            continue;
+
+        if (!insideCycle(nodeForMod(modifier), static_cast<std::size_t>(rate)))
+            continue;
+
+        diagnose(describe(nodeForMod(modifier)) +
+                 ": its rate is part of a modulation cycle, so it runs at the stored one");
+        rate = INVALID_PARAM_ID;
+    }
+
     // With the cycles broken there is an order, and it is the same walk either
-    // way: ascending id among everything that is ready, so the order is a
+    // way: ascending node among everything that is ready, so the order is a
     // property of the model rather than of how a container iterated.
     std::vector<int> waitingOn(count, 0);
-    for (std::size_t target = 0; target < count; ++target)
-        forEachDependency(target, [&](std::size_t) { ++waitingOn[target]; });
+    for (std::size_t node = 0; node < count; ++node)
+        forEachDependency(node, [&](std::size_t) { ++waitingOn[node]; });
 
-    for (auto& list : consumers)
-        list.clear();
-    for (std::size_t target = 0; target < count; ++target)
-        forEachDependency(target, [&](std::size_t source) {
-            consumers[source].push_back(static_cast<int>(target));
-        });
+    buildConsumers();
 
-    std::priority_queue<ParamId, std::vector<ParamId>, std::greater<>> ready;
+    const auto step = [&](std::size_t node) {
+        return node < params
+                   ? ParamStep{ParamStep::Kind::Parameter, static_cast<int>(node)}
+                   : ParamStep{ParamStep::Kind::Modifier, static_cast<int>(node - params)};
+    };
+
+    std::priority_queue<int, std::vector<int>, std::greater<>> ready;
     for (std::size_t i = 0; i < count; ++i)
         if (waitingOn[i] == 0)
-            ready.push(static_cast<ParamId>(i));
+            ready.push(static_cast<int>(i));
 
     table_.order.clear();
     table_.order.reserve(count);
     while (!ready.empty()) {
-        const auto id = ready.top();
+        const auto node = static_cast<std::size_t>(ready.top());
         ready.pop();
-        table_.order.push_back(id);
+        table_.order.push_back(step(node));
 
-        for (const auto consumer : consumers[static_cast<std::size_t>(id)])
+        for (const auto consumer : consumers[node])
             if (--waitingOn[static_cast<std::size_t>(consumer)] == 0)
                 ready.push(consumer);
     }
@@ -664,12 +861,12 @@ void Builder::orderAndBreakCycles() {
 
     // Unreachable: every cycle was broken above, and a graph without one has a
     // topological order. Reported and completed rather than asserted, because
-    // the alternative is a table whose order is missing parameters, which the
-    // block resolver would read as parameters nobody resolved.
+    // the alternative is an order missing things the block would then read as
+    // resolved by nobody.
     for (std::size_t i = 0; i < count; ++i)
         if (waitingOn[i] > 0) {
-            diagnose(toString(table_.keys[i]) + ": still waits on something after the cycle pass");
-            table_.order.push_back(static_cast<ParamId>(i));
+            diagnose(describe(i) + ": still waits on something after the cycle pass");
+            table_.order.push_back(step(i));
         }
 }
 
@@ -706,6 +903,7 @@ ParamTable Builder::run(const RenderPlan& plan, const std::vector<magda::TrackIn
     flattenCurves();
 
     table_.layoutFingerprint = paramLayoutFingerprint(table_.keys);
+    table_.modifierFingerprint = paramModifierFingerprint(table_.modifiers);
 
     return std::move(table_);
 }

--- a/magda/engine/param/ParamTableDump.cpp
+++ b/magda/engine/param/ParamTableDump.cpp
@@ -41,6 +41,60 @@ std::string domainText(const magda::ParameterUtils::ParameterDomain& domain) {
     return "?" + range;
 }
 
+std::string waveText(magda::LFOWaveform wave) {
+    switch (wave) {
+        case magda::LFOWaveform::Sine:
+            return "sine";
+        case magda::LFOWaveform::Triangle:
+            return "triangle";
+        case magda::LFOWaveform::Square:
+            return "square";
+        case magda::LFOWaveform::Saw:
+            return "saw";
+        case magda::LFOWaveform::ReverseSaw:
+            return "revsaw";
+        case magda::LFOWaveform::Custom:
+            return "custom";
+    }
+    return "?";
+}
+
+std::string syncText(ModSync sync) {
+    switch (sync) {
+        case ModSync::Free:
+            return "free";
+        case ModSync::Transport:
+            return "transport";
+        case ModSync::Note:
+            return "note";
+    }
+    return "?";
+}
+
+/// What kind of engine drives it, for a table where only one of them runs.
+std::string kindText(ModKind kind) {
+    switch (kind) {
+        case ModKind::Lfo:
+            return "lfo";
+        case ModKind::Adsr:
+            return "adsr";
+        case ModKind::Random:
+            return "random";
+        case ModKind::Follower:
+            return "follower";
+    }
+    return "?";
+}
+
+/// The rate, as the thing a reader is checking: a frequency, or the division
+/// ordinal a synced modifier's period comes from.
+std::string rateText(const LfoSettings& lfo) {
+    if (!lfo.tempoSync)
+        return number(lfo.rate.hz) + "Hz";
+
+    return "sync[" + std::to_string(lfo.rate.rateType) + "]";
+}
+
 }  // namespace
 
 std::string dumpParamTable(const ParamTable& table) {
@@ -81,18 +135,47 @@ std::string dumpParamTable(const ParamTable& table) {
     if (!table.modifiers.empty()) {
         out << "modifiers:\n";
         for (std::size_t i = 0; i < table.modifiers.size(); ++i) {
+            const auto& modifier = table.modifiers[i];
+            const auto& lfo = modifier.lfo;
+            const auto index = static_cast<int>(i);
+
             std::ostringstream line;
-            line << "[" << rightAligned(static_cast<int>(i), 3) << "] "
-                 << padded(toString(table.modifiers[i].key), 28) << " "
-                 << "value=" << number(table.modifiers[i].value);
+            line << "[" << rightAligned(index, 3) << "] " << padded(toString(modifier.key), 28)
+                 << " " << padded(kindText(modifier.kind), 9)
+                 << " value=" << number(modifier.value);
+
+            if (!modifier.enabled)
+                line << " off";
+
+            if (modifier.kind == ModKind::Lfo) {
+                line << " " << waveText(lfo.wave) << " " << rateText(lfo) << " "
+                     << syncText(lfo.sync);
+
+                if (lfo.phaseOffset != 0.0f)
+                    line << " phase=" << number(lfo.phaseOffset);
+                if (lfo.oneShot)
+                    line << " oneshot";
+                if (lfo.invertOutput)
+                    line << " inverted";
+                if (lfo.useLoopRegion)
+                    line << " loop[" << number(lfo.loopStart) << "," << number(lfo.loopEnd) << "]";
+                if (lfo.gateOnTrigger)
+                    line << " gated";
+                if (!table.modCurveFor(index).empty())
+                    line << " curve=" << table.modCurveFor(index).size();
+            }
+
+            if (modifier.rate != INVALID_PARAM_ID)
+                line << " rate=param[" << modifier.rate << "]";
+
             writeLine(out, line.str());
         }
     }
 
     std::ostringstream order;
     order << "order:";
-    for (const auto param : table.order)
-        order << " " << param;
+    for (const auto& step : table.order)
+        order << " " << (step.kind == ParamStep::Kind::Modifier ? "m" : "") << step.index;
     writeLine(out, order.str());
 
     if (!table.diagnostics.empty()) {

--- a/magda/engine/transport/TempoMap.cpp
+++ b/magda/engine/transport/TempoMap.cpp
@@ -299,7 +299,7 @@ BarsAndBeats TempoMap::barsAndBeatsAt(double beat) const {
 
     return {section.signatureStartBar + static_cast<int>(bars),
             (sinceSignature - bars * barBeats) / tickBeatsOf(section.denominator),
-            section.numerator};
+            section.numerator, section.denominator};
 }
 
 BeatTick TempoMap::tickAtOrAfter(double beat) const {

--- a/magda/engine/transport/TempoMap.hpp
+++ b/magda/engine/transport/TempoMap.hpp
@@ -66,6 +66,7 @@ struct BarsAndBeats {
     double beat = 0.0;
 
     int numerator = 4;
+    int denominator = 4;
 };
 
 /**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -312,6 +312,8 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_param_table.cpp)
     # Automation lanes baked into the parameter lane (#2118).
     list(APPEND TEST_SOURCES test_automation_bake.cpp)
+    # The LFO engine: shapes, rates, triggers and gates (#2119).
+    list(APPEND TEST_SOURCES test_mod_lfo.cpp)
     list(APPEND TEST_SOURCES test_tempo_map.cpp)
     list(APPEND TEST_SOURCES test_transport_clock.cpp)
     list(APPEND TEST_SOURCES test_click_generator.cpp)

--- a/tests/PlanGoldenFixtures.cpp
+++ b/tests/PlanGoldenFixtures.cpp
@@ -247,10 +247,21 @@ Fixture parameterLinks() {
     value.tracks[0].macros[1].links.push_back(
         MacroLink{ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0), 1.0f, false});
 
+    // A tempo-synced LFO with a drawn cycle, driving a device parameter, with
+    // its own rate driven by a macro (#2119). The rate link is what puts the
+    // modifier inside the resolution order rather than beside it.
     value.tracks[0].mods = createDefaultMods(1);
     value.tracks[0].mods[0].value = 0.75f;
+    value.tracks[0].mods[0].waveform = LFOWaveform::Custom;
+    value.tracks[0].mods[0].tempoSync = true;
+    value.tracks[0].mods[0].syncDivision = SyncDivision::Half;
+    value.tracks[0].mods[0].phaseOffset = 0.25f;
+    value.tracks[0].mods[0].curvePoints = {{0.0f, 0.0f}, {0.5f, 1.0f}};
     value.tracks[0].mods[0].links.push_back(ModLink{
         ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 1), 0.5f, true, true});
+
+    value.tracks[0].macros[1].links.push_back(
+        MacroLink{ControlTarget::modParam(ChainNodePath::trackLevel(1), 0, 0), 0.25f, false});
 
     // A lane over the device's first parameter, and one over the track fader,
     // which is a parameter only because the lane reaches it (#2118).

--- a/tests/goldens/plan/parameter-links.txt
+++ b/tests/goldens/plan/parameter-links.txt
@@ -38,19 +38,21 @@ audioSlots=1 midiSlots=0 outputLatency=0
 
 == params ==
 magda-param-table v1
-params=8 modifiers=1 links=4
+params=9 modifiers=1 links=5
 [  0] T1:volume                    fader[-60.000,6.000] base=0.750  links=0 lane=2
 [  1] T1:pan                       lin[-1.000,1.000] base=0.500  links=0
 [  2] T1:macro0                    lin[0.000,1.000] base=1.000  links=0
 [  3] T1:macro1                    lin[0.000,1.000] base=0.500  links=1
       <- param[  2] amount=0.500 bipolar=0
-[  4] T1/D7:param0                 lin[0.000,100.000] base=0.000  links=1 lane=2
+[  4] T1:mod0.param0               step[20]         base=0.316  links=1
+      <- param[  3] amount=0.250 bipolar=0
+[  5] T1/D7:param0                 lin[0.000,100.000] base=0.000  links=1 lane=2
       <- param[  3] amount=1.000 bipolar=0
-[  5] T1/D7:param1                 lin[0.000,100.000] base=0.250  links=1
+[  6] T1/D7:param1                 lin[0.000,100.000] base=0.250  links=1
       <- mod[  0] amount=0.500 bipolar=1
-[  6] T1/D7:param2                 lin[0.000,100.000] base=0.500  links=1
-      <- param[  7] amount=0.500 bipolar=1
-[  7] T1/D7:macro0                 lin[0.000,1.000] base=0.250  links=0
+[  7] T1/D7:param2                 lin[0.000,100.000] base=0.500  links=1
+      <- param[  8] amount=0.500 bipolar=1
+[  8] T1/D7:macro0                 lin[0.000,1.000] base=0.250  links=0
 modifiers:
-[  0] T1:mod0                      value=0.750
-order: 0 1 2 3 4 5 7 6
+[  0] T1:mod0                      lfo       value=0.750 custom sync[7] transport phase=0.250 curve=2 rate=param[4]
+order: 0 1 2 3 4 5 8 7 m0 6

--- a/tests/test_mod_lfo.cpp
+++ b/tests/test_mod_lfo.cpp
@@ -14,6 +14,7 @@
 #include "param/ParamResolve.hpp"
 #include "param/ParamTableCompiler.hpp"
 #include "plan/PlanCompiler.hpp"
+#include "transport/TempoMap.hpp"
 
 /**
  * @file test_mod_lfo.cpp
@@ -44,6 +45,7 @@ using magda::engine::ModKind;
 using magda::engine::ModRuntime;
 using magda::engine::ModSync;
 using magda::engine::ModTiming;
+using magda::engine::modTimingFor;
 using magda::engine::ParamKey;
 using magda::engine::ParamSegment;
 using magda::engine::ParamStep;
@@ -367,6 +369,38 @@ TEST_CASE("A tempo-synced LFO's period is a fraction of a bar", "[engine][mod][l
 
         CHECK(step(state, settings, blockAt(1.5, 1.0, 512), {}, timing(120.0, 3, 4)) ==
               approx(0.5f));
+    }
+
+    SECTION("the bar grid survives a signature change") {
+        // A change always starts a bar, so two bars of four four followed by
+        // six eight puts a bar line at beat eight. Counting beats and dividing
+        // by a bar's length gives 8/3 there, which would open every six eight
+        // bar two thirds of the way through the cycle and stay that way.
+        const magda::engine::TempoMap map({{0.0, 120.0}}, {{0.0, 4, 4}, {8.0, 6, 8}});
+
+        LfoSettings settings;
+        settings.wave = LFOWaveform::Saw;
+        settings.sync = ModSync::Transport;
+        settings.tempoSync = true;
+        settings.rate.rateType = static_cast<int>(ModRateType::Bar);
+
+        const auto atBeat = [&](double beat) {
+            auto block = blockAt(beat, 0.5, 512);
+            block.tempo = &map;
+            LfoState state;
+            return step(state, settings, block, {}, modTimingFor(block, kSampleRate));
+        };
+
+        // Every bar line opens a cycle: the two four four bars, then the six
+        // eight ones, which are three quarter notes each.
+        CHECK(atBeat(0.0) == approx(0.0f));
+        CHECK(atBeat(4.0) == approx(0.0f));
+        CHECK(atBeat(8.0) == approx(0.0f));
+        CHECK(atBeat(11.0) == approx(0.0f));
+
+        // And halfway through one is halfway through the cycle.
+        CHECK(atBeat(2.0) == approx(0.5f));
+        CHECK(atBeat(9.5) == approx(0.5f));
     }
 
     SECTION("in six eight a bar is three beats, not six") {

--- a/tests/test_mod_lfo.cpp
+++ b/tests/test_mod_lfo.cpp
@@ -1,0 +1,964 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#include "core/ModCurve.hpp"
+#include "core/RackInfo.hpp"
+#include "core/TrackInfo.hpp"
+#include "exec/EngineSession.hpp"
+#include "exec/PlanValues.hpp"
+#include "param/ModLfo.hpp"
+#include "param/ModRuntime.hpp"
+#include "param/ParamResolve.hpp"
+#include "param/ParamTableCompiler.hpp"
+#include "plan/PlanCompiler.hpp"
+
+/**
+ * @file test_mod_lfo.cpp
+ * @brief The LFO engine (#2119).
+ *
+ * Three claims, and they are separable on purpose. The shape is the model's
+ * own, so what is asserted about it is that the engine reads the same curve the
+ * editor draws rather than what a bezier does. The run is the engine's: where
+ * the phase is after a block, what a division is worth in beats, what a trigger
+ * does and what a gate does. And the wiring is the table's: that a modifier's
+ * settings reach the block, that its rate can be driven, and that the value
+ * comes out of a device the far end.
+ */
+
+using namespace magda;
+using magda::engine::advanceLfo;
+using magda::engine::barFractionOf;
+using magda::engine::BlockInfo;
+using magda::engine::compileParamTable;
+using magda::engine::compileRenderPlan;
+using magda::engine::cycleBeats;
+using magda::engine::INVALID_PARAM_ID;
+using magda::engine::LfoRate;
+using magda::engine::LfoSettings;
+using magda::engine::LfoState;
+using magda::engine::ModContribution;
+using magda::engine::ModKind;
+using magda::engine::ModRuntime;
+using magda::engine::ModSync;
+using magda::engine::ModTiming;
+using magda::engine::ParamKey;
+using magda::engine::ParamSegment;
+using magda::engine::ParamStep;
+using magda::engine::ParamTable;
+using magda::engine::ResolvedParams;
+using magda::engine::resolveParams;
+using magda::engine::restartLfo;
+
+namespace {
+
+Catch::Approx approx(float value) {
+    return Catch::Approx(value).margin(1e-4);
+}
+
+constexpr double kSampleRate = 48000.0;
+
+ModTiming timing(double bpm = 120.0, int numerator = 4) {
+    return ModTiming{kSampleRate, bpm, numerator};
+}
+
+/// A block of @p numSamples that does not move the timeline, which is what a
+/// free-running LFO is measured against: its ramp is real time rather than
+/// musical time, and a stopped transport still turns it.
+BlockInfo stoppedBlock(int numSamples) {
+    BlockInfo block;
+    block.numSamples = numSamples;
+    return block;
+}
+
+/// A block sitting at @p startBeat, with the seconds face of the same instant
+/// worked out at @p bpm, the way the transport's clock would.
+BlockInfo blockAt(double startBeat, double beats, int numSamples, double bpm = 120.0) {
+    BlockInfo block;
+    block.numSamples = numSamples;
+    block.playing = true;
+    block.startBeat = startBeat;
+    block.endBeat = startBeat + beats;
+    block.startSeconds = startBeat * 60.0 / bpm;
+    block.endSeconds = block.endBeat * 60.0 / bpm;
+    return block;
+}
+
+LfoSettings freeRunning(float hz, LFOWaveform wave = LFOWaveform::Saw) {
+    LfoSettings settings;
+    settings.wave = wave;
+    settings.sync = ModSync::Free;
+    settings.rate.hz = hz;
+    return settings;
+}
+
+/// One block of @p settings, and the output it published.
+float step(LfoState& state, const LfoSettings& settings, const BlockInfo& block,
+           std::span<const CurvePointData> curve = {}, const ModTiming& time = timing()) {
+    return advanceLfo(state, settings, curve, block, time);
+}
+
+TrackInfo makeTrack(TrackId id) {
+    TrackInfo track;
+    track.id = id;
+    track.name = "Track " + juce::String(id);
+    track.audioOutputDevice = "master";
+    track.macros = createDefaultMacros(2);
+    track.mods = createDefaultMods(0);
+    return track;
+}
+
+TrackInfo makeMaster() {
+    auto master = makeTrack(MASTER_TRACK_ID);
+    master.type = TrackType::Master;
+    master.audioOutputDevice = {};
+    return master;
+}
+
+DeviceInfo makeDevice(DeviceId id, float base = 0.0f) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Effect " + juce::String(id);
+    device.deviceType = DeviceType::Effect;
+    device.macros = createDefaultMacros(1);
+    device.mods = createDefaultMods(0);
+
+    ParameterInfo info(0, "Level", "", 0.0f, 1.0f, 0.0f);
+    info.currentValue = base;
+    device.parameters.push_back(info);
+
+    return device;
+}
+
+/// A track with one device and one LFO wired to that device's only parameter.
+TrackInfo trackWithLfo(float amount = 1.0f, bool bipolar = false, float base = 0.0f) {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7, base)));
+    track.mods = createDefaultMods(1);
+    track.mods[0].waveform = LFOWaveform::Saw;
+    track.mods[0].rate = 1.0f;
+    track.mods[0].links.push_back(ModLink{
+        ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0), amount, bipolar, true});
+    return track;
+}
+
+ParamKey deviceParam(TrackId track, DeviceId device, int index) {
+    ParamKey key;
+    key.kind = ParamKey::Kind::DeviceParam;
+    key.scope = ParamKey::Scope::Device;
+    key.trackId = track;
+    key.device = magda::engine::DeviceKey{ChainSegment::Fx, device};
+    key.index = index;
+    return key;
+}
+
+ParamKey modRate(TrackId track, ModId mod) {
+    ParamKey key;
+    key.kind = ParamKey::Kind::ModParam;
+    key.scope = ParamKey::Scope::Track;
+    key.trackId = track;
+    key.modId = mod;
+    key.index = 0;
+    return key;
+}
+
+ParamTable tableFor(const std::vector<TrackInfo>& tracks,
+                    const std::vector<AutomationLaneInfo>& lanes = {}) {
+    const auto master = makeMaster();
+    const auto plan = compileRenderPlan(tracks, master);
+    return compileParamTable(plan, tracks, master, lanes);
+}
+
+/// Everything one block needs to resolve a table, kept together so a test can
+/// run several blocks over one runtime and watch the phase move.
+struct Harness {
+    explicit Harness(const ParamTable& table)
+        : links(static_cast<std::size_t>(std::max(table.maxLinksPerParam, 1))),
+          segments(
+              static_cast<std::size_t>(magda::engine::ResolvedParams::kDefaultSegmentCapacity)) {
+        values.prepare(table.size());
+        mods.prepare(table, magda::engine::RenderContext{kSampleRate, 512, 2});
+    }
+
+    void run(const ParamTable& table, const BlockInfo& block) {
+        resolveParams(table, values, links, segments, block, &mods);
+    }
+
+    ResolvedParams values;
+    ModRuntime mods;
+    std::vector<ModContribution> links;
+    std::vector<ParamSegment> segments;
+};
+
+bool mentions(const ParamTable& table, const std::string& text) {
+    for (const auto& message : table.diagnostics)
+        if (message.find(text) != std::string::npos)
+            return true;
+    return false;
+}
+
+}  // namespace
+
+// =============================================================================
+// The shape
+// =============================================================================
+
+TEST_CASE("Every waveform is read at the same points in the cycle", "[engine][mod][lfo]") {
+    const auto at = [](LFOWaveform wave, float phase) {
+        LfoState state;
+        auto settings = freeRunning(1.0f, wave);
+        settings.phaseOffset = phase;
+        // A block with no samples in it cannot advance anything, so what comes
+        // out is the shape at the phase and nothing else.
+        return step(state, settings, stoppedBlock(0));
+    };
+
+    SECTION("sine rises from the middle") {
+        CHECK(at(LFOWaveform::Sine, 0.0f) == approx(0.5f));
+        CHECK(at(LFOWaveform::Sine, 0.25f) == approx(1.0f));
+        CHECK(at(LFOWaveform::Sine, 0.5f) == approx(0.5f));
+        CHECK(at(LFOWaveform::Sine, 0.75f) == approx(0.0f));
+    }
+
+    SECTION("triangle peaks halfway") {
+        CHECK(at(LFOWaveform::Triangle, 0.0f) == approx(0.0f));
+        CHECK(at(LFOWaveform::Triangle, 0.5f) == approx(1.0f));
+        CHECK(at(LFOWaveform::Triangle, 0.75f) == approx(0.5f));
+    }
+
+    SECTION("square is high for the first half") {
+        CHECK(at(LFOWaveform::Square, 0.0f) == approx(1.0f));
+        CHECK(at(LFOWaveform::Square, 0.49f) == approx(1.0f));
+        CHECK(at(LFOWaveform::Square, 0.5f) == approx(0.0f));
+    }
+
+    SECTION("saw climbs and reverse saw falls") {
+        CHECK(at(LFOWaveform::Saw, 0.25f) == approx(0.25f));
+        CHECK(at(LFOWaveform::ReverseSaw, 0.25f) == approx(0.75f));
+    }
+}
+
+TEST_CASE("A drawn cycle is read through the model's own curve", "[engine][mod][lfo]") {
+    LfoSettings settings = freeRunning(1.0f, LFOWaveform::Custom);
+
+    // A step and a ramp, which is a shape the built-in waveforms cannot make
+    // and which the fork reads through the same function.
+    std::vector<CurvePointData> curve(3);
+    curve[0] = CurvePointData{0.0f, 0.0f};
+    curve[0].curveType = 2;  // Step: holds until the next point
+    curve[1] = CurvePointData{0.5f, 1.0f};
+    curve[2] = CurvePointData{0.75f, 0.0f};
+
+    const auto at = [&](float phase) {
+        LfoState state;
+        auto shaped = settings;
+        shaped.phaseOffset = phase;
+        return step(state, shaped, stoppedBlock(0), curve);
+    };
+
+    CHECK(at(0.25f) == approx(0.0f));
+    CHECK(at(0.5f) == approx(1.0f));
+    CHECK(at(0.625f) == approx(magda::modcurve::points(curve, 0.625f)));
+}
+
+TEST_CASE("A custom waveform with nothing drawn on it falls back to its preset",
+          "[engine][mod][lfo]") {
+    LfoState state;
+    auto settings = freeRunning(1.0f, LFOWaveform::Custom);
+    settings.preset = CurvePreset::RampDown;
+    settings.phaseOffset = 0.25f;
+
+    CHECK(step(state, settings, stoppedBlock(0)) == approx(0.75f));
+}
+
+// =============================================================================
+// The run
+// =============================================================================
+
+TEST_CASE("A free-running LFO advances by how long the block lasted", "[engine][mod][lfo]") {
+    LfoState state;
+    const auto settings = freeRunning(2.0f);  // two cycles a second
+
+    // A quarter of a second at 48k, which is half a cycle at 2 Hz.
+    const auto block = stoppedBlock(12000);
+
+    CHECK(step(state, settings, block) == approx(0.0f));
+    CHECK(step(state, settings, block) == approx(0.5f));
+    CHECK(step(state, settings, block) == approx(0.0f));
+}
+
+TEST_CASE("A free-running LFO keeps turning while the transport is stopped", "[engine][mod][lfo]") {
+    LfoState state;
+    const auto settings = freeRunning(1.0f);
+
+    // The block does not move the timeline at all, which is what a stopped
+    // transport renders. The graph is still processing, so the LFO still moves.
+    const auto block = stoppedBlock(12000);
+    step(state, settings, block);
+
+    CHECK(step(state, settings, block) == approx(0.25f));
+}
+
+TEST_CASE("A transport-locked LFO is a function of where the block is", "[engine][mod][lfo]") {
+    auto settings = freeRunning(1.0f);
+    settings.sync = ModSync::Transport;
+
+    // Half a second in at 1 Hz is halfway through the cycle, whatever was
+    // rendered before it: two LFOs at one rate agree however playback got here.
+    LfoState fresh;
+    CHECK(step(fresh, settings, blockAt(1.0, 0.5, 512)) == approx(0.5f));
+
+    LfoState played;
+    step(played, settings, blockAt(0.0, 0.5, 512));
+    CHECK(step(played, settings, blockAt(1.0, 0.5, 512)) == approx(0.5f));
+}
+
+TEST_CASE("A tempo-synced LFO's period is a fraction of a bar", "[engine][mod][lfo]") {
+    SECTION("the ordinals are the ones a project stores") {
+        CHECK(barFractionOf(static_cast<int>(ModRateType::Bar)) == Catch::Approx(1.0));
+        CHECK(barFractionOf(static_cast<int>(ModRateType::FourBars)) == Catch::Approx(4.0));
+        CHECK(barFractionOf(static_cast<int>(ModRateType::Half)) == Catch::Approx(0.5));
+        CHECK(barFractionOf(static_cast<int>(ModRateType::DottedQuarter)) ==
+              Catch::Approx(0.25 * 1.5));
+        CHECK(barFractionOf(static_cast<int>(ModRateType::TripletEighth)) ==
+              Catch::Approx(0.125 * 2.0 / 3.0));
+
+        // Hertz is not a division, and neither is an ordinal from the future.
+        CHECK(barFractionOf(static_cast<int>(ModRateType::Hertz)) == Catch::Approx(1.0));
+        CHECK(barFractionOf(9999) == Catch::Approx(1.0));
+    }
+
+    SECTION("a bar is the signature's own bar") {
+        CHECK(cycleBeats(static_cast<int>(ModRateType::Bar), 4) == Catch::Approx(4.0));
+        CHECK(cycleBeats(static_cast<int>(ModRateType::Bar), 3) == Catch::Approx(3.0));
+        CHECK(cycleBeats(static_cast<int>(ModRateType::Half), 4) == Catch::Approx(2.0));
+    }
+
+    SECTION("locked to the bar line") {
+        LfoState state;
+        LfoSettings settings;
+        settings.wave = LFOWaveform::Saw;
+        settings.sync = ModSync::Transport;
+        settings.tempoSync = true;
+        settings.rate.rateType = static_cast<int>(ModRateType::Bar);
+
+        CHECK(step(state, settings, blockAt(0.0, 1.0, 512)) == approx(0.0f));
+        CHECK(step(state, settings, blockAt(2.0, 1.0, 512)) == approx(0.5f));
+        CHECK(step(state, settings, blockAt(4.0, 1.0, 512)) == approx(0.0f));
+        CHECK(step(state, settings, blockAt(5.0, 1.0, 512)) == approx(0.25f));
+    }
+
+    SECTION("in three four a bar is three beats") {
+        LfoState state;
+        LfoSettings settings;
+        settings.wave = LFOWaveform::Saw;
+        settings.sync = ModSync::Transport;
+        settings.tempoSync = true;
+        settings.rate.rateType = static_cast<int>(ModRateType::Bar);
+
+        CHECK(step(state, settings, blockAt(1.5, 1.0, 512), {}, timing(120.0, 3)) == approx(0.5f));
+    }
+
+    SECTION("free-running, the period is that many beats at this tempo") {
+        LfoState state;
+        LfoSettings settings;
+        settings.wave = LFOWaveform::Saw;
+        settings.sync = ModSync::Free;
+        settings.tempoSync = true;
+        settings.rate.rateType = static_cast<int>(ModRateType::Bar);
+
+        // A bar at 120 in four four is two seconds, so half a second is a
+        // quarter of the way through.
+        const auto block = stoppedBlock(24000);
+        step(state, settings, block);
+        CHECK(step(state, settings, block) == approx(0.25f));
+    }
+}
+
+TEST_CASE("The phase offset moves where the cycle is read", "[engine][mod][lfo]") {
+    LfoState state;
+    auto settings = freeRunning(1.0f);
+    settings.phaseOffset = 0.25f;
+
+    CHECK(step(state, settings, stoppedBlock(12000)) == approx(0.25f));
+    CHECK(step(state, settings, stoppedBlock(12000)) == approx(0.5f));
+}
+
+TEST_CASE("A one-shot plays through and holds where it ended", "[engine][mod][lfo]") {
+    LfoState state;
+    auto settings = freeRunning(1.0f, LFOWaveform::Triangle);
+    settings.sync = ModSync::Note;
+    settings.oneShot = true;
+
+    const auto quarter = stoppedBlock(12000);
+
+    CHECK(step(state, settings, quarter) == approx(0.0f));
+    CHECK(step(state, settings, quarter) == approx(0.5f));
+    CHECK(step(state, settings, quarter) == approx(1.0f));
+    CHECK(step(state, settings, quarter) == approx(0.5f));
+
+    // Through. A triangle ends where it started, and that is what is held
+    // rather than the wrap-around value the cycle would carry on into.
+    CHECK(step(state, settings, quarter) == approx(0.0f));
+    CHECK(state.completed);
+    CHECK(state.phase == approx(1.0f));
+    CHECK(step(state, settings, quarter) == approx(0.0f));
+
+    SECTION("and a trigger plays it again") {
+        restartLfo(state, settings);
+        CHECK_FALSE(state.completed);
+        CHECK(step(state, settings, quarter) == approx(0.0f));
+        CHECK(step(state, settings, quarter) == approx(0.5f));
+    }
+}
+
+TEST_CASE("A sustain loop plays the intro once and then repeats the region", "[engine][mod][lfo]") {
+    LfoState state;
+    auto settings = freeRunning(1.0f, LFOWaveform::Custom);
+    settings.oneShot = true;
+    settings.useLoopRegion = true;
+    settings.loopStart = 0.5f;
+    settings.loopEnd = 0.75f;
+
+    // A straight ramp, so the value reads back as the position in the cycle.
+    std::vector<CurvePointData> curve(2);
+    curve[0] = CurvePointData{0.0f, 0.0f};
+    curve[1] = CurvePointData{1.0f, 1.0f};
+
+    const auto eighth = stoppedBlock(6000);
+
+    CHECK(step(state, settings, eighth, curve) == approx(0.0f));
+    CHECK(step(state, settings, eighth, curve) == approx(0.125f));
+    CHECK(step(state, settings, eighth, curve) == approx(0.25f));
+    CHECK(step(state, settings, eighth, curve) == approx(0.375f));
+
+    // Into the region, and back to its start rather than on past its end.
+    CHECK(step(state, settings, eighth, curve) == approx(0.5f));
+    CHECK(step(state, settings, eighth, curve) == approx(0.625f));
+    CHECK(step(state, settings, eighth, curve) == approx(0.5f));
+    CHECK(step(state, settings, eighth, curve) == approx(0.625f));
+
+    // A loop sustains rather than finishing, so the one-shot never latches.
+    CHECK_FALSE(state.completed);
+}
+
+TEST_CASE("A level curve is applied as the amount it takes away", "[engine][mod][lfo]") {
+    auto settings = freeRunning(1.0f, LFOWaveform::Saw);
+    settings.invertOutput = true;
+    settings.phaseOffset = 0.25f;
+
+    LfoState state;
+    CHECK(step(state, settings, stoppedBlock(0)) == approx(0.75f));
+
+    SECTION("and a shut gate is still nothing rather than everything") {
+        // The convention the whole modulation system reads: an inactive
+        // modifier outputs 0, which for a level curve means no attenuation.
+        state.gated = true;
+        CHECK(step(state, settings, stoppedBlock(0)) == approx(0.0f));
+    }
+}
+
+// =============================================================================
+// Triggers and gates
+// =============================================================================
+
+namespace {
+
+/// A table with one note-triggered LFO on track 1, and its index.
+struct Triggered {
+    ParamTable table;
+    int modifier = 0;
+};
+
+Triggered triggered(LFOTriggerMode mode, bool skipNativeResync = false) {
+    auto track = trackWithLfo();
+    track.mods[0].triggerMode = mode;
+
+    Triggered value;
+    value.table = tableFor({track});
+    value.table.modifiers[0].lfo.skipNativeResync = skipNativeResync;
+
+    // By address rather than by position, which is how anything holding a
+    // modifier rather than an index finds it.
+    ParamKey key = modRate(1, 0);
+    key.index = -1;
+
+    ModRuntime runtime;
+    runtime.prepare(value.table, magda::engine::RenderContext{kSampleRate, 512, 2});
+    value.modifier = runtime.indexOf(key);
+    return value;
+}
+
+}  // namespace
+
+TEST_CASE("A note-triggered LFO restarts on a note and rests between them",
+          "[engine][mod][lfo][trigger]") {
+    auto fixture = triggered(LFOTriggerMode::MIDI);
+    REQUIRE(fixture.modifier >= 0);
+
+    Harness harness(fixture.table);
+
+    const auto param = fixture.table.find(deviceParam(1, 7, 0));
+    REQUIRE(param != INVALID_PARAM_ID);
+
+    const auto block = stoppedBlock(12000);  // a quarter second, a quarter cycle at 1 Hz
+
+    // Nothing has played, so the gate is shut and the modifier is doing
+    // nothing at all.
+    harness.run(fixture.table, block);
+    CHECK(harness.mods.value(fixture.modifier) == approx(0.0f));
+    CHECK(harness.values[param].value() == approx(0.0f));
+
+    harness.mods.noteOn(fixture.modifier, fixture.table);
+    harness.run(fixture.table, block);
+    CHECK(harness.mods.value(fixture.modifier) == approx(0.0f));
+    harness.run(fixture.table, block);
+    CHECK(harness.mods.value(fixture.modifier) == approx(0.25f));
+
+    SECTION("a second note restarts the phase") {
+        harness.mods.noteOn(fixture.modifier, fixture.table);
+        harness.run(fixture.table, block);
+        CHECK(harness.mods.value(fixture.modifier) == approx(0.0f));
+    }
+
+    SECTION("the gate shuts when the last held note lifts") {
+        // A second note held on top of the first, so lifting one is not
+        // lifting them all. Two blocks on, the saw is a quarter of the way up,
+        // which is a value a shut gate could not produce.
+        harness.mods.noteOn(fixture.modifier, fixture.table);
+        harness.mods.noteOff(fixture.modifier, fixture.table);
+
+        harness.run(fixture.table, block);
+        harness.run(fixture.table, block);
+        CHECK(harness.mods.value(fixture.modifier) == approx(0.25f));
+
+        harness.mods.noteOff(fixture.modifier, fixture.table);
+        harness.run(fixture.table, block);
+        CHECK(harness.mods.value(fixture.modifier) == approx(0.0f));
+        CHECK(harness.values[param].value() == approx(0.0f));
+    }
+
+    SECTION("an all-notes-off drops every held note at once") {
+        harness.mods.noteOn(fixture.modifier, fixture.table);
+        harness.run(fixture.table, block);
+        harness.run(fixture.table, block);
+        REQUIRE(harness.mods.value(fixture.modifier) == approx(0.25f));
+
+        harness.mods.allNotesOff(fixture.modifier, fixture.table);
+        harness.run(fixture.table, block);
+        CHECK(harness.mods.value(fixture.modifier) == approx(0.0f));
+    }
+}
+
+TEST_CASE("A cross-track LFO ignores the track it modulates", "[engine][mod][lfo][trigger]") {
+    auto fixture = triggered(LFOTriggerMode::MIDI, /*skipNativeResync=*/true);
+    fixture.table.modifiers[0].lfo.gateOnTrigger = false;
+    fixture.table.modifiers[0].lfo.startGated = false;
+
+    Harness harness(fixture.table);
+    const auto block = stoppedBlock(12000);
+
+    harness.run(fixture.table, block);
+    harness.run(fixture.table, block);
+    REQUIRE(harness.mods.value(fixture.modifier) == approx(0.25f));
+
+    SECTION("a note on its own track does nothing") {
+        harness.mods.noteOn(fixture.modifier, fixture.table);
+        harness.run(fixture.table, block);
+        CHECK(harness.mods.value(fixture.modifier) == approx(0.5f));
+    }
+
+    SECTION("a trigger from its source restarts it") {
+        harness.mods.trigger(fixture.modifier, fixture.table);
+        harness.run(fixture.table, block);
+        CHECK(harness.mods.value(fixture.modifier) == approx(0.0f));
+    }
+}
+
+TEST_CASE("A forced zero stands in for the gap a gated retrigger leaves",
+          "[engine][mod][lfo][trigger]") {
+    auto fixture = triggered(LFOTriggerMode::Audio);
+    fixture.table.modifiers[0].lfo.startGated = false;
+
+    Harness harness(fixture.table);
+    const auto block = stoppedBlock(12000);
+    harness.run(fixture.table, block);
+    harness.run(fixture.table, block);
+    REQUIRE(harness.mods.value(fixture.modifier) == approx(0.25f));
+
+    harness.mods.trigger(fixture.modifier, fixture.table, /*forceZero=*/true);
+    CHECK(harness.mods.value(fixture.modifier) == approx(0.0f));
+
+    SECTION("but never on a level curve, where zero is full level") {
+        fixture.table.modifiers[0].lfo.invertOutput = true;
+        harness.run(fixture.table, block);
+        const auto before = harness.mods.value(fixture.modifier);
+
+        harness.mods.trigger(fixture.modifier, fixture.table, /*forceZero=*/true);
+        CHECK(harness.mods.value(fixture.modifier) == approx(before));
+    }
+}
+
+TEST_CASE("An LFO that is not listening for a trigger ignores one", "[engine][mod][lfo][trigger]") {
+    for (const auto sync : {ModSync::Free, ModSync::Transport}) {
+        LfoState state;
+        auto settings = freeRunning(1.0f);
+        settings.sync = sync;
+
+        state.cycles = 0.5;
+        restartLfo(state, settings);
+        CHECK(state.cycles == Catch::Approx(0.5));
+    }
+}
+
+TEST_CASE("A gate holds the output at nothing while the phase carries on",
+          "[engine][mod][lfo][trigger]") {
+    auto fixture = triggered(LFOTriggerMode::Audio);
+    Harness harness(fixture.table);
+    const auto block = stoppedBlock(12000);
+
+    // Audio-triggered LFOs sit shut between hits.
+    harness.run(fixture.table, block);
+    CHECK(harness.mods.value(fixture.modifier) == approx(0.0f));
+
+    harness.run(fixture.table, block);
+    harness.run(fixture.table, block);
+    CHECK(harness.mods.value(fixture.modifier) == approx(0.0f));
+
+    // Ungating resumes where the LFO would have been rather than where it was
+    // when the gate shut: gating is not a pause.
+    harness.mods.setGated(fixture.modifier, false);
+    harness.run(fixture.table, block);
+    CHECK(harness.mods.value(fixture.modifier) == approx(0.75f));
+}
+
+// =============================================================================
+// The table
+// =============================================================================
+
+TEST_CASE("A modifier's settings reach the table", "[engine][mod][lfo][table]") {
+    auto track = trackWithLfo();
+    track.mods[0].waveform = LFOWaveform::Custom;
+    track.mods[0].curvePoints = {{0.0f, 0.0f}, {0.5f, 1.0f}};
+    track.mods[0].tempoSync = true;
+    track.mods[0].syncDivision = SyncDivision::Eighth;
+    track.mods[0].phaseOffset = 0.125f;
+    track.mods[0].oneShot = true;
+    track.mods[0].invertOutput = true;
+
+    const auto table = tableFor({track});
+    REQUIRE(table.modifiers.size() == 1);
+
+    const auto& modifier = table.modifiers[0];
+    CHECK(modifier.kind == ModKind::Lfo);
+    CHECK(modifier.lfo.wave == LFOWaveform::Custom);
+    CHECK(modifier.lfo.tempoSync);
+    CHECK(modifier.lfo.rate.rateType == static_cast<int>(ModRateType::Eighth));
+    CHECK(modifier.lfo.phaseOffset == approx(0.125f));
+    CHECK(modifier.lfo.oneShot);
+    CHECK(modifier.lfo.invertOutput);
+
+    // Tempo sync on its own locks the LFO to the timeline, which is the fork's
+    // own folding of trigger mode and sync flag into one sync type.
+    CHECK(modifier.lfo.sync == ModSync::Transport);
+    CHECK(table.modCurveFor(0).size() == 2);
+}
+
+TEST_CASE("A modifier the model has switched off has no links at all",
+          "[engine][mod][lfo][table]") {
+    // Halfway up, so a contribution that pushed the parameter down would show
+    // rather than being clamped away at the bottom of the range.
+    auto track = trackWithLfo(0.5f, /*bipolar=*/true, /*base=*/0.5f);
+    track.mods[0].enabled = false;
+
+    const auto table = tableFor({track});
+    const auto param = table.find(deviceParam(1, 7, 0));
+    REQUIRE(param != INVALID_PARAM_ID);
+
+    // A bipolar link reading an output of zero would push its parameter down
+    // by the link's own depth, which is a switched-off modifier doing
+    // something. The fork creates no modifier for one, so nothing contributes.
+    CHECK(table.linksFor(param).empty());
+
+    Harness harness(table);
+    harness.run(table, stoppedBlock(64));
+    CHECK(harness.values[param].value() == approx(0.5f));
+}
+
+TEST_CASE("A modifier's rate is carried only when something reaches it",
+          "[engine][mod][lfo][table]") {
+    SECTION("nothing does") {
+        const auto table = tableFor({trackWithLfo()});
+        REQUIRE(table.modifiers.size() == 1);
+        CHECK(table.modifiers[0].rate == INVALID_PARAM_ID);
+        CHECK(table.find(modRate(1, 0)) == INVALID_PARAM_ID);
+    }
+
+    SECTION("a macro drives it") {
+        auto track = trackWithLfo();
+        track.macros[0].value = 0.0f;
+        track.macros[0].links.push_back(
+            MacroLink{ControlTarget::modParam(ChainNodePath::trackLevel(1), 0, 0), 1.0f, false});
+
+        const auto table = tableFor({track});
+        REQUIRE(table.diagnostics.empty());
+
+        const auto rate = table.find(modRate(1, 0));
+        REQUIRE(rate != INVALID_PARAM_ID);
+        CHECK(table.modifiers[0].rate == rate);
+
+        // And the modifier resolves after it: that is what the order is for.
+        const auto position = [&](const ParamStep& step) {
+            return std::find(table.order.begin(), table.order.end(), step) - table.order.begin();
+        };
+        CHECK(position(ParamStep{ParamStep::Kind::Parameter, rate}) <
+              position(ParamStep{ParamStep::Kind::Modifier, 0}));
+        CHECK(position(ParamStep{ParamStep::Kind::Modifier, 0}) <
+              position(ParamStep{ParamStep::Kind::Parameter, table.find(deviceParam(1, 7, 0))}));
+    }
+
+    SECTION("a lane plays over it") {
+        auto track = trackWithLfo();
+
+        AutomationLaneInfo lane;
+        lane.id = 1;
+        lane.target = ControlTarget::modParam(ChainNodePath::trackLevel(1), 0, 0);
+        lane.type = AutomationLaneType::Absolute;
+        lane.authorityState = AutomationAuthorityState::Reading;
+        lane.absolutePoints = {{1, 0.0, 0.5}, {2, 4.0, 1.0}};
+
+        const auto table = tableFor({track}, {lane});
+        CHECK(table.find(modRate(1, 0)) != INVALID_PARAM_ID);
+    }
+}
+
+TEST_CASE("A driven rate changes how fast the LFO turns", "[engine][mod][lfo][table]") {
+    auto track = trackWithLfo();
+    track.mods[0].rate = 1.0f;
+    track.macros[0].value = 1.0f;
+    track.macros[0].links.push_back(
+        MacroLink{ControlTarget::modParam(ChainNodePath::trackLevel(1), 0, 0), 1.0f, false});
+
+    const auto table = tableFor({track});
+    const auto rate = table.find(modRate(1, 0));
+    REQUIRE(rate != INVALID_PARAM_ID);
+
+    Harness harness(table);
+    const auto block = stoppedBlock(4800);  // a tenth of a second
+
+    harness.run(table, block);
+    // The macro is at the top of its range, so the rate is the top of the
+    // lane's: 20 Hz, which is two whole cycles in a tenth of a second.
+    CHECK(harness.values[rate].value() == approx(20.0f));
+
+    harness.run(table, block);
+    CHECK(harness.mods.value(0) == approx(0.0f));
+}
+
+TEST_CASE("A cycle through a modifier's rate is broken where it is found",
+          "[engine][mod][lfo][table]") {
+    auto track = trackWithLfo();
+
+    // The LFO drives a macro, and that macro drives the LFO's own rate.
+    track.mods[0].links.push_back(
+        ModLink{ControlTarget::deviceMacro(ChainNodePath::trackLevel(1), 0), 0.5f, false, true});
+    track.macros[0].links.push_back(
+        MacroLink{ControlTarget::modParam(ChainNodePath::trackLevel(1), 0, 0), 1.0f, false});
+
+    const auto table = tableFor({track});
+    CHECK(mentions(table, "modulation cycle"));
+
+    // The rate parameter survives; only the edge that made it impossible goes.
+    CHECK(table.find(modRate(1, 0)) != INVALID_PARAM_ID);
+    CHECK(table.modifiers[0].rate == INVALID_PARAM_ID);
+    CHECK(table.order.size() == static_cast<std::size_t>(table.size()) + table.modifiers.size());
+}
+
+TEST_CASE("The modifier fingerprint moves when the list does", "[engine][mod][lfo][table]") {
+    const auto one = tableFor({trackWithLfo()});
+
+    auto grown = trackWithLfo();
+    grown.mods = createDefaultMods(2);
+    grown.mods[0] = trackWithLfo().mods[0];
+    const auto two = tableFor({grown});
+
+    CHECK(one.modifierFingerprint != two.modifierFingerprint);
+
+    // And it does not move when only a value does, which is what stops a knob
+    // turn from restarting every LFO in the project.
+    auto turned = trackWithLfo();
+    turned.mods[0].rate = 4.0f;
+    CHECK(tableFor({turned}).modifierFingerprint == one.modifierFingerprint);
+}
+
+// =============================================================================
+// The runtime
+// =============================================================================
+
+TEST_CASE("An LFO carries its phase across a prepare", "[engine][mod][lfo][runtime]") {
+    const auto table = tableFor({trackWithLfo()});
+    const magda::engine::RenderContext context{kSampleRate, 512, 2};
+
+    ModRuntime first;
+    first.prepare(table, context);
+
+    std::vector<ModContribution> links(1);
+    std::vector<ParamSegment> segments(magda::engine::ResolvedParams::kDefaultSegmentCapacity);
+    ResolvedParams values;
+    values.prepare(table.size());
+
+    const auto block = stoppedBlock(12000);
+    resolveParams(table, values, links, segments, block, &first);
+    resolveParams(table, values, links, segments, block, &first);
+    REQUIRE(first.value(0) == approx(0.25f));
+
+    ModRuntime second;
+    second.prepare(table, context, &first);
+    resolveParams(table, values, links, segments, block, &second);
+    CHECK(second.value(0) == approx(0.5f));
+
+    SECTION("but not when the modifier has become something else") {
+        auto changed = table;
+        changed.modifiers[0].kind = ModKind::Adsr;
+
+        ModRuntime third;
+        third.prepare(changed, context, &first);
+        REQUIRE(third.state(0) != nullptr);
+        CHECK(third.state(0)->lfo.cycles == Catch::Approx(0.0));
+    }
+}
+
+TEST_CASE("An executor takes over the modifiers of the one it replaces",
+          "[engine][mod][lfo][runtime]") {
+    auto tracks = std::vector{trackWithLfo()};
+    const auto master = makeMaster();
+    const auto plan = compileRenderPlan(tracks, master);
+
+    magda::engine::PlanValues values;
+    magda::engine::resolvePlanValues(plan, tracks, master, values);
+    REQUIRE(values.params != nullptr);
+
+    const magda::engine::RenderContext context{kSampleRate, 512, 2};
+    magda::engine::PlanBindings bindings;
+
+    // The device op has no binding here, which prepare reports and carries on
+    // from: what is being pinned is the carry, not the render.
+    magda::engine::PlanExecutor first;
+    first.prepare(plan, bindings, context, nullptr, values.params.get());
+    CHECK(first.carriedModifiers() == 0);
+
+    magda::engine::PlanExecutor second;
+    second.prepare(plan, bindings, context, &first, values.params.get());
+    CHECK(second.carriedModifiers() == 1);
+
+    SECTION("but not one that has become something else") {
+        auto changed = *values.params;
+        changed.modifiers[0].kind = ModKind::Random;
+
+        magda::engine::PlanExecutor third;
+        third.prepare(plan, bindings, context, &first, &changed);
+        CHECK(third.carriedModifiers() == 0);
+    }
+}
+
+TEST_CASE("A runtime sized for another list leaves the modifiers where they were",
+          "[engine][mod][lfo][runtime]") {
+    const auto table = tableFor({trackWithLfo()});
+
+    // A runtime that holds nothing, meeting a table with a modifier in it.
+    ModRuntime mismatched;
+
+    ResolvedParams values;
+    values.prepare(table.size());
+    std::vector<ModContribution> links(1);
+    std::vector<ParamSegment> segments(magda::engine::ResolvedParams::kDefaultSegmentCapacity);
+
+    resolveParams(table, values, links, segments, stoppedBlock(512), &mismatched);
+
+    // The model's own reading, held, which is what a modifier published before
+    // it had an engine at all.
+    const auto param = table.find(deviceParam(1, 7, 0));
+    CHECK(values[param].value() == approx(table.modifiers[0].value));
+}
+
+// =============================================================================
+// End to end
+// =============================================================================
+
+namespace {
+
+/// A device whose output is its only parameter, so what leaves the master is
+/// what the modulation did to it.
+class LevelDevice final : public magda::engine::EngineDevice {
+  public:
+    void process(magda::engine::DeviceBlock& block) override {
+        block.audio.fill(block.params.size() > 0 ? block.params[0].value() : 0.0f);
+    }
+};
+
+class LevelFactory final : public magda::engine::RuntimeStateFactory {
+  public:
+    std::unique_ptr<magda::engine::EngineDevice> createDevice(magda::engine::DeviceKey) override {
+        return std::make_unique<LevelDevice>();
+    }
+};
+
+}  // namespace
+
+TEST_CASE("An LFO moves a device parameter through a live session", "[engine][mod][lfo][session]") {
+    auto track = trackWithLfo();
+    track.mods[0].rate = 2.0f;  // two cycles a second
+    track.volume = 1.0f;
+    track.pan = 0.0f;
+
+    std::vector<TrackInfo> tracks{track};
+    auto master = makeMaster();
+    master.volume = 1.0f;
+
+    const auto plan =
+        std::make_shared<const magda::engine::RenderPlan>(compileRenderPlan(tracks, master));
+
+    magda::engine::PlanValues values;
+    magda::engine::resolvePlanValues(*plan, tracks, master, values);
+    REQUIRE(values.params != nullptr);
+    REQUIRE(values.params->modifiers.size() == 1);
+
+    LevelFactory factory;
+    magda::engine::EngineSession session(factory);
+
+    // Blocks of a quarter of a second, which at 2 Hz is half a cycle each.
+    constexpr int kBlock = 12000;
+    const auto ids = magda::engine::collectRuntimeStateIds(tracks, master);
+    const magda::engine::RenderContext context{kSampleRate, kBlock, 2};
+    REQUIRE(session.publish(plan, context, ids, values).published);
+
+    const auto gain = magda::engine::faderGainFromVolume(track.volume) *
+                      magda::engine::faderGainFromVolume(master.volume);
+
+    const auto render = [&] {
+        juce::AudioBuffer<float> output(2, kBlock);
+        session.process(kBlock, output);
+        return output.getSample(0, 0);
+    };
+
+    // A saw from nothing, half a cycle at a time: 0, then halfway up.
+    CHECK(render() == approx(0.0f));
+    CHECK(render() == approx(0.5f * gain));
+    CHECK(render() == approx(0.0f));
+
+    SECTION("and goes on turning through a structural republish") {
+        REQUIRE(render() == approx(0.5f * gain));
+
+        magda::engine::PlanValues republished;
+        magda::engine::resolvePlanValues(*plan, tracks, master, republished);
+        const auto result = session.publish(plan, context, ids, std::move(republished));
+        REQUIRE(result.published);
+
+        // Where it was, plus the block: an LFO carried across a swap is the
+        // same LFO rather than a copy of one read at some instant.
+        CHECK(render() == approx(0.0f));
+        CHECK(render() == approx(0.5f * gain));
+    }
+}

--- a/tests/test_mod_lfo.cpp
+++ b/tests/test_mod_lfo.cpp
@@ -570,6 +570,22 @@ TEST_CASE("A cross-track LFO ignores the track it modulates", "[engine][mod][lfo
         CHECK(harness.mods.value(fixture.modifier) == approx(0.5f));
     }
 
+    SECTION("nor does one that would otherwise gate it") {
+        // The fork prevents this pairing by setting its two flags apart rather
+        // than by refusing it. Refusing it here is what keeps the destination
+        // track's notes off a cross-track LFO's gate whatever sets the flags.
+        auto gating = fixture.table;
+        gating.modifiers[0].lfo.gateOnTrigger = true;
+
+        harness.mods.noteOn(fixture.modifier, gating);
+        harness.run(gating, block);
+        CHECK(harness.mods.value(fixture.modifier) == approx(0.5f));
+
+        harness.mods.noteOff(fixture.modifier, gating);
+        harness.run(gating, block);
+        CHECK(harness.mods.value(fixture.modifier) == approx(0.75f));
+    }
+
     SECTION("a trigger from its source restarts it") {
         harness.mods.trigger(fixture.modifier, fixture.table);
         harness.run(fixture.table, block);
@@ -588,16 +604,51 @@ TEST_CASE("A forced zero stands in for the gap a gated retrigger leaves",
     harness.run(fixture.table, block);
     REQUIRE(harness.mods.value(fixture.modifier) == approx(0.25f));
 
+    // The trigger lands inside a block whose parameters are already resolved,
+    // so the gap is published on the next one and the shape starts over on the
+    // one after: the fork's own sequence, late by the block the trigger is.
     harness.mods.trigger(fixture.modifier, fixture.table, /*forceZero=*/true);
+
+    harness.run(fixture.table, block);
     CHECK(harness.mods.value(fixture.modifier) == approx(0.0f));
 
+    harness.run(fixture.table, block);
+    CHECK(harness.mods.value(fixture.modifier) == approx(0.0f));
+
+    harness.run(fixture.table, block);
+    CHECK(harness.mods.value(fixture.modifier) == approx(0.25f));
+
+    SECTION("and the gap is a gap in a shape that does not open at nothing") {
+        // A saw opens at zero either way, so it cannot tell a gap from a
+        // restart. A sine opens halfway up, and the gap is the whole point.
+        auto sine = fixture.table;
+        sine.modifiers[0].lfo.wave = LFOWaveform::Sine;
+
+        harness.run(sine, block);
+        REQUIRE(harness.mods.value(fixture.modifier) != approx(0.0f));
+
+        harness.mods.trigger(fixture.modifier, sine, /*forceZero=*/true);
+        harness.run(sine, block);
+        CHECK(harness.mods.value(fixture.modifier) == approx(0.0f));
+
+        harness.run(sine, block);
+        CHECK(harness.mods.value(fixture.modifier) == approx(0.5f));
+    }
+
     SECTION("but never on a level curve, where zero is full level") {
-        fixture.table.modifiers[0].lfo.invertOutput = true;
-        harness.run(fixture.table, block);
+        auto level = fixture.table;
+        level.modifiers[0].lfo.invertOutput = true;
+
+        harness.run(level, block);
         const auto before = harness.mods.value(fixture.modifier);
 
-        harness.mods.trigger(fixture.modifier, fixture.table, /*forceZero=*/true);
-        CHECK(harness.mods.value(fixture.modifier) == approx(before));
+        harness.mods.trigger(fixture.modifier, level, /*forceZero=*/true);
+        harness.run(level, block);
+
+        // Restarted, and never zero on the way: forcing full level in the
+        // middle of a duck is a click on every hit.
+        CHECK(harness.mods.value(fixture.modifier) == approx(1.0f));
+        CHECK(before != approx(0.0f));
     }
 }
 
@@ -791,6 +842,17 @@ TEST_CASE("The modifier fingerprint moves when the list does", "[engine][mod][lf
     auto turned = trackWithLfo();
     turned.mods[0].rate = 4.0f;
     CHECK(tableFor({turned}).modifierFingerprint == one.modifierFingerprint);
+
+    SECTION("and a modifier that becomes another kind is a different list") {
+        // The model switches a type in place, at the same address, so nothing
+        // else about the table moves. Without the kind in here it would travel
+        // as a values publish that the runtime is never re-prepared for, and
+        // switching away and back would resume the phase of the modifier that
+        // had been replaced.
+        auto retyped = trackWithLfo();
+        retyped.mods[0].type = ModType::Random;
+        CHECK(tableFor({retyped}).modifierFingerprint != one.modifierFingerprint);
+    }
 }
 
 // =============================================================================

--- a/tests/test_mod_lfo.cpp
+++ b/tests/test_mod_lfo.cpp
@@ -361,6 +361,27 @@ TEST_CASE("A tempo-synced LFO's period is a fraction of a bar", "[engine][mod][l
         CHECK(step(state, settings, blockAt(1.5, 1.0, 512), {}, timing(120.0, 3)) == approx(0.5f));
     }
 
+    SECTION("and the denominator is not read, because the fork does not read one") {
+        // Pinned rather than endorsed. A bar of six eight is three quarter
+        // notes, and this counts six, so a "1 Bar" LFO runs two written bars
+        // long. No TE modifier reads a denominator and a TE beat is a quarter
+        // note, so this is what every synced modifier in every x/8 project is
+        // already placed by; correcting it during the port would move all of
+        // them at once. See cycleBeats and #2128.
+        CHECK(cycleBeats(static_cast<int>(ModRateType::Bar), 6) == Catch::Approx(6.0));
+
+        LfoState state;
+        LfoSettings settings;
+        settings.wave = LFOWaveform::Saw;
+        settings.sync = ModSync::Transport;
+        settings.tempoSync = true;
+        settings.rate.rateType = static_cast<int>(ModRateType::Bar);
+
+        // Three quarter notes in is one written bar of six eight, and half a
+        // cycle rather than a whole one.
+        CHECK(step(state, settings, blockAt(3.0, 1.0, 512), {}, timing(120.0, 6)) == approx(0.5f));
+    }
+
     SECTION("free-running, the period is that many beats at this tempo") {
         LfoState state;
         LfoSettings settings;
@@ -649,6 +670,52 @@ TEST_CASE("A forced zero stands in for the gap a gated retrigger leaves",
         // middle of a duck is a click on every hit.
         CHECK(harness.mods.value(fixture.modifier) == approx(1.0f));
         CHECK(before != approx(0.0f));
+    }
+}
+
+TEST_CASE("Changing the trigger mode retires the gate the old one left",
+          "[engine][mod][lfo][trigger]") {
+    // An audio-triggered LFO sits shut between hits, and a trigger mode is a
+    // values publish rather than a structural one, so the runtime is never
+    // re-prepared for it. Without reconciling, switching to free running would
+    // leave the gate shut for ever: nothing in the new mode ever opens one.
+    auto fixture = triggered(LFOTriggerMode::Audio);
+    Harness harness(fixture.table);
+    const auto block = stoppedBlock(12000);
+
+    harness.run(fixture.table, block);
+    harness.run(fixture.table, block);
+    REQUIRE(harness.mods.value(fixture.modifier) == approx(0.0f));
+
+    auto freed = fixture.table;
+    freed.modifiers[0].lfo.trigger = LFOTriggerMode::Free;
+    freed.modifiers[0].lfo.sync = ModSync::Free;
+    freed.modifiers[0].lfo.startGated = false;
+    freed.modifiers[0].lfo.gateOnTrigger = false;
+
+    harness.run(freed, block);
+    CHECK(harness.mods.value(fixture.modifier) == approx(0.5f));
+
+    SECTION("and the held notes with it") {
+        auto midi = freed;
+        midi.modifiers[0].lfo.trigger = LFOTriggerMode::MIDI;
+        midi.modifiers[0].lfo.sync = ModSync::Note;
+        midi.modifiers[0].lfo.gateOnTrigger = true;
+        midi.modifiers[0].lfo.startGated = true;
+
+        // Shut again on the mode change, and one note-off cannot open it by
+        // taking a count left over from the mode before.
+        harness.run(midi, block);
+        CHECK(harness.mods.value(fixture.modifier) == approx(0.0f));
+
+        harness.mods.noteOff(fixture.modifier, midi);
+        harness.run(midi, block);
+        CHECK(harness.mods.value(fixture.modifier) == approx(0.0f));
+
+        harness.mods.noteOn(fixture.modifier, midi);
+        harness.run(midi, block);
+        harness.run(midi, block);
+        CHECK(harness.mods.value(fixture.modifier) == approx(0.25f));
     }
 }
 

--- a/tests/test_mod_lfo.cpp
+++ b/tests/test_mod_lfo.cpp
@@ -60,8 +60,8 @@ Catch::Approx approx(float value) {
 
 constexpr double kSampleRate = 48000.0;
 
-ModTiming timing(double bpm = 120.0, int numerator = 4) {
-    return ModTiming{kSampleRate, bpm, numerator};
+ModTiming timing(double bpm = 120.0, int numerator = 4, int denominator = 4) {
+    return ModTiming{kSampleRate, bpm, numerator, denominator};
 }
 
 /// A block of @p numSamples that does not move the timeline, which is what a
@@ -331,9 +331,16 @@ TEST_CASE("A tempo-synced LFO's period is a fraction of a bar", "[engine][mod][l
     }
 
     SECTION("a bar is the signature's own bar") {
-        CHECK(cycleBeats(static_cast<int>(ModRateType::Bar), 4) == Catch::Approx(4.0));
-        CHECK(cycleBeats(static_cast<int>(ModRateType::Bar), 3) == Catch::Approx(3.0));
-        CHECK(cycleBeats(static_cast<int>(ModRateType::Half), 4) == Catch::Approx(2.0));
+        CHECK(cycleBeats(static_cast<int>(ModRateType::Bar), 4, 4) == Catch::Approx(4.0));
+        CHECK(cycleBeats(static_cast<int>(ModRateType::Bar), 3, 4) == Catch::Approx(3.0));
+        CHECK(cycleBeats(static_cast<int>(ModRateType::Half), 4, 4) == Catch::Approx(2.0));
+
+        // The denominator counts. A bar of six eight is three quarter notes,
+        // and a beat is a quarter note, so it is three beats rather than six.
+        CHECK(cycleBeats(static_cast<int>(ModRateType::Bar), 6, 8) == Catch::Approx(3.0));
+        CHECK(cycleBeats(static_cast<int>(ModRateType::Bar), 3, 8) == Catch::Approx(1.5));
+        CHECK(cycleBeats(static_cast<int>(ModRateType::Bar), 12, 8) == Catch::Approx(6.0));
+        CHECK(cycleBeats(static_cast<int>(ModRateType::Bar), 2, 2) == Catch::Approx(4.0));
     }
 
     SECTION("locked to the bar line") {
@@ -358,18 +365,14 @@ TEST_CASE("A tempo-synced LFO's period is a fraction of a bar", "[engine][mod][l
         settings.tempoSync = true;
         settings.rate.rateType = static_cast<int>(ModRateType::Bar);
 
-        CHECK(step(state, settings, blockAt(1.5, 1.0, 512), {}, timing(120.0, 3)) == approx(0.5f));
+        CHECK(step(state, settings, blockAt(1.5, 1.0, 512), {}, timing(120.0, 3, 4)) ==
+              approx(0.5f));
     }
 
-    SECTION("and the denominator is not read, because the fork does not read one") {
-        // Pinned rather than endorsed. A bar of six eight is three quarter
-        // notes, and this counts six, so a "1 Bar" LFO runs two written bars
-        // long. No TE modifier reads a denominator and a TE beat is a quarter
-        // note, so this is what every synced modifier in every x/8 project is
-        // already placed by; correcting it during the port would move all of
-        // them at once. See cycleBeats and #2128.
-        CHECK(cycleBeats(static_cast<int>(ModRateType::Bar), 6) == Catch::Approx(6.0));
-
+    SECTION("in six eight a bar is three beats, not six") {
+        // The fork used to count the numerator in quarter notes, so a "1 Bar"
+        // modifier here ran two written bars long. Both engines read the
+        // denominator now (#2128).
         LfoState state;
         LfoSettings settings;
         settings.wave = LFOWaveform::Saw;
@@ -377,9 +380,14 @@ TEST_CASE("A tempo-synced LFO's period is a fraction of a bar", "[engine][mod][l
         settings.tempoSync = true;
         settings.rate.rateType = static_cast<int>(ModRateType::Bar);
 
-        // Three quarter notes in is one written bar of six eight, and half a
-        // cycle rather than a whole one.
-        CHECK(step(state, settings, blockAt(3.0, 1.0, 512), {}, timing(120.0, 6)) == approx(0.5f));
+        // A bar and a half in, which is halfway through the second cycle.
+        CHECK(step(state, settings, blockAt(4.5, 0.5, 512), {}, timing(120.0, 6, 8)) ==
+              approx(0.5f));
+
+        // And the bar line itself opens a cycle.
+        LfoState onTheBar;
+        CHECK(step(onTheBar, settings, blockAt(3.0, 0.5, 512), {}, timing(120.0, 6, 8)) ==
+              approx(0.0f));
     }
 
     SECTION("free-running, the period is that many beats at this tempo") {

--- a/tests/test_param_table.cpp
+++ b/tests/test_param_table.cpp
@@ -31,6 +31,7 @@ using magda::engine::INVALID_PARAM_ID;
 using magda::engine::ModContribution;
 using magda::engine::ParamKey;
 using magda::engine::paramKeyFor;
+using magda::engine::ParamStep;
 using magda::engine::ParamTable;
 using magda::engine::ResolvedParams;
 using magda::engine::resolveParams;
@@ -218,7 +219,8 @@ TEST_CASE("A macro driving a macro resolves in the order that makes both right",
 
     // The order is the claim: the source before whatever reads it.
     const auto position = [&](magda::engine::ParamId id) {
-        return std::find(table.order.begin(), table.order.end(), id) - table.order.begin();
+        const auto step = magda::engine::ParamStep{ParamStep::Kind::Parameter, id};
+        return std::find(table.order.begin(), table.order.end(), step) - table.order.begin();
     };
     CHECK(position(first) < position(second));
     CHECK(position(second) < position(param));
@@ -301,13 +303,23 @@ TEST_CASE("A link the table cannot carry is reported rather than dropped",
         CHECK(mentions(table, "which the project does not have"));
     }
 
-    SECTION("a modifier parameter, which arrives with the engines") {
+    SECTION("a modifier parameter that is not the rate") {
         auto track = makeTrack(1);
+        track.mods = createDefaultMods(1);
         track.macros[0].links.push_back(
-            MacroLink{ControlTarget::modParam(ChainNodePath::trackLevel(1), 0, 0), 1.0f, false});
+            MacroLink{ControlTarget::modParam(ChainNodePath::trackLevel(1), 0, 3), 1.0f, false});
 
         const auto table = tableFor({track});
-        CHECK(mentions(table, "#2119"));
+        CHECK(mentions(table, "Rate is the only parameter a modifier has"));
+    }
+
+    SECTION("the rate of a modifier the project does not have") {
+        auto track = makeTrack(1);
+        track.macros[0].links.push_back(
+            MacroLink{ControlTarget::modParam(ChainNodePath::trackLevel(1), 4, 0), 1.0f, false});
+
+        const auto table = tableFor({track});
+        CHECK(mentions(table, "which the project does not have"));
     }
 }
 


### PR DESCRIPTION
Slice 4 of #1891. Closes #2119.

A modifier has been a source with an identity and a value the model last saw,
which is a value that does not move between publishes. This is the engine that
moves it.

## The shape stays the model's

On the terms slice 3 took the automation curve: the modulator's cycle moves out
into `core/ModCurve.hpp`, and the editor's preview, the fork's lock-free audio
snapshot and the native LFO all read one function rather than three copies of
one. `ModulatorEngine` and `CurveSnapshot` become callers.

The Rate lane's two descriptions move into `ParameterPresets` for the same
reason. A lane read back through a second copy of its own numbers is a lane the
engine and the editor quietly disagree about.

## The run is the engine's

Six waveforms and the drawn curve with its tension, its per-point kind and its
sustain loop. A rate in Hz, or a musical division that is a fraction of a bar
and therefore three beats long in three four. Phase offset, one-shot holding
what the cycle ended on, and `invertOutput`, without which an idle Sidechain
reads as silence rather than as no attenuation.

Trigger modes and both retrigger paths, including the skip-resync a cross-track
LFO needs so the track it ducks stops retriggering it.

Block rate, from the block's first sample, which is where the fork settles a
modifier and therefore what a parity case is measured against.

## Where the phase lives

The settings travel in the published table, which is republished every time a
knob moves. The phase stays in the executor, keyed by the modifier's own address
and shared with the epoch being replaced rather than copied out of it, the way a
delay line is. An LFO goes on turning through a knob turn, a link edit and a
device insert somewhere else in the project.

## Modifiers join the resolution order

They depend on parameters in both directions: a link reads a modifier, and a
modifier reads the Rate parameter driving it. One order over both kinds of node
means a macro driving an LFO's rate while the LFO drives a cutoff is one pass,
with no fixed point, and a cycle through a modifier's rate is broken where it is
found. That is the diagnostic slice 2 left pointing here.

`modifierFingerprint` protects the runtime's indexing the way `layoutFingerprint`
protects the parameters': a scope gaining a page of modifiers moves every one
after it without touching a key, and a values publish of that shape escalates
into a structural one rather than handing one LFO's phase to another.

## What is not wired, and why

Two of the three trigger modes have nothing feeding them yet. A note-triggered
modifier needs the MIDI reaching its scope; an audio-triggered one needs a level
detector. Neither exists in the native engine, so the trigger calls are the
shape those feeds will use and are exercised directly rather than end to end.

The transport mode needs no feed and is wired: a timeline-locked modifier is a
function of where the block is. The rest arrive with the slice that cannot avoid
the same problem for the ADSR's gate (#2120).

## One defect fixed on the way

A modifier the model had switched off carried its links with an output of zero,
and a bipolar link reading zero pushes its parameter down by the link's own
depth: a switched-off modifier doing something. The fork creates no modifier for
one at all, so now neither does the table.

## Testing

26 cases in `tests/test_mod_lfo.cpp`, from the shape at a phase through to an
LFO moving a device parameter out of the master of a live session and going on
turning across a structural republish. Full suite green (588,461 assertions),
app builds.
