### PR TITLE
The last three modifiers, and what feeds them (#2120)

### DIFF
--- a/magda/daw/core/ModInfo.hpp
+++ b/magda/daw/core/ModInfo.hpp
@@ -249,6 +249,43 @@ enum class LFOTriggerMode {
 };
 
 /**
+ * @brief Where in a source track's chain a modifier listens.
+ *
+ * The two points the engines actually have, named for what they are rather than
+ * for a fader they sit either side of. A third point between them (post-FX,
+ * pre-fader) is not something either engine taps today, so it is deliberately
+ * not offered: adding it is a change to both engines and its own decision.
+ *
+ * Per modifier rather than per sidechain, because a modifier listening to its
+ * own track has no sidechain to carry the setting, and because two listeners on
+ * one source can reasonably want different points, which is the same reason the
+ * follower's band limits are per modifier.
+ */
+enum class ModTapPoint {
+    /// After whatever makes the track's sound and before its effects: the chain
+    /// head on a track with no instrument, and immediately past the instrument
+    /// on one that has it. What an audio trigger keys off, so a hit is detected
+    /// on what the track played rather than on what survived its chain.
+    PreFx,
+
+    /// The far end: post-FX, post-fader, before the muting node. What a
+    /// follower tracks, so riding the source fader moves the modulation, and
+    /// before the mute so a muted source still ducks what it is ducking.
+    PostFader,
+};
+
+/**
+ * @brief Where a modifier of this type listens unless it says otherwise.
+ *
+ * The fork's own split, which is what makes the default pure parity: its
+ * follower tap is post-fader and its trigger monitor is pre-FX, so a project
+ * carrying neither setting sounds the same in both engines.
+ */
+inline ModTapPoint defaultModTapPoint(ModType type) {
+    return type == ModType::Follower ? ModTapPoint::PostFader : ModTapPoint::PreFx;
+}
+
+/**
  * @brief A single mod-to-parameter link with its own amount.
  *
  * The target is a ControlTarget which addresses any parameter the system can
@@ -360,6 +397,12 @@ struct ModInfo {
     float followerHoldMs = 0.0f;       // Envelope hold time (ms)
     float followerReleaseMs = 500.0f;  // Envelope release time (ms)
 
+    // Where in the source track's chain this modifier listens. Only means
+    // anything for a modifier that listens to audio at all: a follower, or one
+    // triggered by level. Defaulted per type on creation, on a type change and
+    // on loading a project that predates the field (defaultModTapPoint).
+    ModTapPoint tapPoint = ModTapPoint::PreFx;
+
     // Band-limit detection: filter the raw source audio BEFORE peak detection so
     // the follower can track just part of the spectrum (e.g. only the bass).
     // Applied by the post-FX FollowerSourceTapPlugin, not TE's own post-rectify
@@ -384,7 +427,19 @@ struct ModInfo {
 
     // Constructor with index (for initialization)
     explicit ModInfo(int index)
-        : id(index), name(getDefaultName(index, ModType::LFO)), type(ModType::LFO) {}
+        : id(index),
+          name(getDefaultName(index, ModType::LFO)),
+          type(ModType::LFO),
+          tapPoint(defaultModTapPoint(ModType::LFO)) {}
+
+    /// Become @p t, and take the tap point that goes with it. What
+    /// TrackManager::setModType does, for the places that build a ModInfo
+    /// directly: assigning the type on its own leaves the point at the one the
+    /// old kind wanted, which for a follower is the wrong end of the chain.
+    void setType(ModType t) {
+        type = t;
+        tapPoint = defaultModTapPoint(t);
+    }
 
     bool isLinked() const {
         return !links.empty();

--- a/magda/daw/core/ModInfo.hpp
+++ b/magda/daw/core/ModInfo.hpp
@@ -261,17 +261,21 @@ enum class LFOTriggerMode {
  * one source can reasonably want different points, which is the same reason the
  * follower's band limits are per modifier.
  */
-enum class ModTapPoint {
+enum class ModTapPoint : int {
     /// After whatever makes the track's sound and before its effects: the chain
     /// head on a track with no instrument, and immediately past the instrument
     /// on one that has it. What an audio trigger keys off, so a hit is detected
     /// on what the track played rather than on what survived its chain.
-    PreFx,
+    ///
+    /// Ordinals are pinned: this is written into a project as its integer
+    /// (AutomationModSerializer), so an insert here would move an existing
+    /// project's modifiers to the other point (test_persisted_enum_pins.cpp).
+    PreFx = 0,
 
     /// The far end: post-FX, post-fader, before the muting node. What a
     /// follower tracks, so riding the source fader moves the modulation, and
     /// before the mute so a muted source still ducks what it is ducking.
-    PostFader,
+    PostFader = 1,
 };
 
 /**

--- a/magda/daw/core/TrackManager.hpp
+++ b/magda/daw/core/TrackManager.hpp
@@ -704,6 +704,10 @@ class TrackManager : public daw::audio::DeviceIdAllocator, public daw::audio::De
     void setModSyncDivision(const ChainNodePath& path, int modIndex, SyncDivision division);
     void setModOneShot(const ChainNodePath& path, int modIndex, bool oneShot);
     void setModTriggerMode(const ChainNodePath& path, int modIndex, LFOTriggerMode mode);
+
+    /// Where in the source track's chain this modifier listens. Only means
+    /// anything for one that listens to audio: a follower, or a level trigger.
+    void setModTapPoint(const ChainNodePath& path, int modIndex, ModTapPoint point);
     void setModCurvePreset(const ChainNodePath& path, int modIndex, CurvePreset preset);
     void setModCurveState(const ChainNodePath& path, int modIndex, CurvePreset preset,
                           const std::vector<CurvePointData>& points);

--- a/magda/daw/core/TrackManagerModulation.cpp
+++ b/magda/daw/core/TrackManagerModulation.cpp
@@ -457,6 +457,16 @@ void TrackManager::setModType(const ChainNodePath& path, int modIndex, ModType t
     auto& mod = (*node.mods)[modIndex];
     auto oldType = mod.type;
     mod.type = type;
+
+    // A modifier that has just become another kind is a new modifier as far as
+    // the tap point is concerned: a follower wants the far end and a trigger
+    // wants the near one, and carrying the old kind's answer over would leave a
+    // fresh follower keying off the wrong place with nothing on screen to say
+    // why. Re-derived on the type change alone, so a point the user moved
+    // afterwards stays where they put it.
+    if (oldType != type)
+        mod.tapPoint = defaultModTapPoint(type);
+
     auto defaultOldName = ModInfo::getDefaultName(modIndex, oldType);
     if (mod.name == defaultOldName) {
         mod.name = ModInfo::getDefaultName(modIndex, type);
@@ -520,6 +530,14 @@ void TrackManager::setModOneShot(const ChainNodePath& path, int modIndex, bool o
     // direction: back to loop it should run again, and re-entering one-shot
     // should wait for the next trigger rather than stay latched complete.
     mod.oneShotComplete = false;
+    notifyDeviceModifiersChanged(path.trackId);
+}
+
+void TrackManager::setModTapPoint(const ChainNodePath& path, int modIndex, ModTapPoint point) {
+    auto node = resolveChainNode(path);
+    if (!indexInRange(node.mods, modIndex))
+        return;
+    (*node.mods)[modIndex].tapPoint = point;
     notifyDeviceModifiersChanged(path.trackId);
 }
 

--- a/magda/daw/core/TrackManagerModulation.cpp
+++ b/magda/daw/core/TrackManagerModulation.cpp
@@ -357,7 +357,11 @@ void TrackManager::addMod(const ChainNodePath& path, int slotIndex, ModType type
     if (slotIndex < 0 || slotIndex > static_cast<int>(mods.size()))
         return;
     ModInfo newMod(slotIndex);
-    newMod.type = type;
+
+    // Through setType, so the new modifier takes the tap point its kind wants.
+    // Assigning the type on its own leaves a fresh follower listening in front
+    // of the source's chain, where the fork's follower never listens.
+    newMod.setType(type);
     newMod.waveform = waveform;
     // An envelope defaults to note-triggered: free-running would just cycle
     // the A-D-R shape, which is rarely what you want from an ADSR.

--- a/magda/daw/project/serialization/AutomationModSerializer.cpp
+++ b/magda/daw/project/serialization/AutomationModSerializer.cpp
@@ -472,6 +472,7 @@ juce::var ProjectSerializer::serializeModInfo(const ModInfo& mod) {
 
     // Envelope follower (type == Follower)
     SER(followerGainDb);
+    obj->setProperty("tapPoint", static_cast<int>(mod.tapPoint));
     SER(followerAttackMs);
     SER(followerHoldMs);
     SER(followerReleaseMs);
@@ -560,6 +561,13 @@ bool ProjectSerializer::deserializeModInfo(const juce::var& json, ModInfo& outMo
         DESER(randomSmooth);
     if (obj->hasProperty("randomStepDepth"))
         DESER(randomStepDepth);
+
+    // Where it listens. Absent in every project written before the point was a
+    // choice, and the answer there is the fork's own split, which is what those
+    // projects were rendered against.
+    data.tapPoint = obj->hasProperty("tapPoint")
+                        ? static_cast<ModTapPoint>(static_cast<int>(obj->getProperty("tapPoint")))
+                        : defaultModTapPoint(data.type);
 
     // Envelope follower (type == Follower).
     if (obj->hasProperty("followerGainDb"))

--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -80,6 +80,10 @@ add_library(magda_engine STATIC
     param/ParamTableCompiler.cpp
     param/ParamTableDump.cpp
     param/ModLfo.cpp
+    param/ModAdsr.cpp
+    param/ModRandom.cpp
+    param/ModFollower.cpp
+    param/ModSources.cpp
     param/ModRuntime.cpp
     param/ParamSpec.hpp
     param/ParamBlock.hpp
@@ -89,6 +93,10 @@ add_library(magda_engine STATIC
     param/ParamTableCompiler.hpp
     param/ParamTableDump.hpp
     param/ModLfo.hpp
+    param/ModAdsr.hpp
+    param/ModRandom.hpp
+    param/ModFollower.hpp
+    param/ModSources.hpp
     param/ModRuntime.hpp
     tap/LevelTap.hpp
     tap/SampleRing.hpp

--- a/magda/engine/exec/ParallelPlanExecutor.cpp
+++ b/magda/engine/exec/ParallelPlanExecutor.cpp
@@ -128,7 +128,7 @@ OpId ParallelPlanExecutor::runOp(OpId op) {
     // add into a buffer they all share, so they are left for the thread that
     // drove the block to run in plan order. Counted here anyway, because what
     // waits on what is the plan's business and not this decision's.
-    if (plan_->ops[static_cast<std::size_t>(op)].kind != OpKind::Output)
+    if (plan_->ops[static_cast<std::size_t>(op)].kind != OpKind::Output && !core_.inMidiPrefix(op))
         core_.renderOp(op, valueOf(op), block_, *output_);
 
     OpId carryOn = INVALID_OP_ID;
@@ -189,8 +189,16 @@ void ParallelPlanExecutor::process(const PlanValues& values, const BlockInfo& re
     if (!start.render || plan_ == nullptr)
         return;
 
-    // Before any worker starts: a device reads its parameters, and every op
-    // that could be one is about to become runnable.
+    // Before any worker starts, and in this order. The MIDI a block has before
+    // it has audio is rendered on this thread, so the notes in it reach the
+    // modifiers of this block rather than the next one; then the parameters
+    // resolve, and every op that could read one is about to become runnable.
+    //
+    // The prefix ops are still scheduled below, so their consumers are released
+    // exactly as they would be otherwise; what the schedule skips is running
+    // them a second time, the same way it skips the outputs it renders at the
+    // end. Anything else would consume a live input queue twice.
+    core_.renderMidiPrefix(values, start.block);
     core_.resolveParameters(values, start.block);
 
     block_ = start.block;

--- a/magda/engine/exec/ParallelPlanExecutor.cpp
+++ b/magda/engine/exec/ParallelPlanExecutor.cpp
@@ -56,6 +56,7 @@ std::vector<std::string> ParallelPlanExecutor::prepare(const RenderPlan& plan,
 
     plan_ = nullptr;
     outputOps_.clear();
+    modSourceOps_.clear();
 
     auto messages = core_.prepare(plan, bindings, context,
                                   previous != nullptr ? &previous->core_ : nullptr, params);
@@ -85,9 +86,12 @@ std::vector<std::string> ParallelPlanExecutor::prepare(const RenderPlan& plan,
     pending_ = std::vector<std::atomic<std::uint16_t>>(numOps);
     nextReady_ = std::vector<std::atomic<OpId>>(numOps);
 
-    for (std::size_t i = 0; i < numOps; ++i)
+    for (std::size_t i = 0; i < numOps; ++i) {
         if (plan.ops[i].kind == OpKind::Output)
             outputOps_.push_back(static_cast<OpId>(i));
+        else if (plan.ops[i].kind == OpKind::ModSource)
+            modSourceOps_.push_back(static_cast<OpId>(i));
+    }
 
     plan_ = &plan;
     return messages;
@@ -124,11 +128,17 @@ OpId ParallelPlanExecutor::pop() {
 }
 
 OpId ParallelPlanExecutor::runOp(OpId op) {
-    // Output ops are the exception the whole schedule is written around: they
-    // add into a buffer they all share, so they are left for the thread that
-    // drove the block to run in plan order. Counted here anyway, because what
-    // waits on what is the plan's business and not this decision's.
-    if (plan_->ops[static_cast<std::size_t>(op)].kind != OpKind::Output && !core_.inMidiPrefix(op))
+    // Two kinds are left for the thread that drove the block, and both for the
+    // same reason: each shares a buffer with the others of its kind rather than
+    // owning one. Output ops add into the one buffer reaching the hardware, and
+    // modulation taps detect through one scratch buffer apiece on the executor
+    // and on the runtime, so two taps running at once, which two listened-to
+    // tracks with disjoint subgraphs make schedulable, would corrupt each
+    // other's detection. Counted here anyway, because what waits on what is the
+    // plan's business and not this decision's; neither can stall the block,
+    // because nothing consumes either.
+    const auto kind = plan_->ops[static_cast<std::size_t>(op)].kind;
+    if (kind != OpKind::Output && kind != OpKind::ModSource && !core_.inMidiPrefix(op))
         core_.renderOp(op, valueOf(op), block_, *output_);
 
     OpId carryOn = INVALID_OP_ID;
@@ -232,8 +242,11 @@ void ParallelPlanExecutor::process(const PlanValues& values, const BlockInfo& re
     }
 
     // The graph has drained, so this thread is the only one with anything to
-    // do. In plan order: the sum reaching the hardware is compiled, like every
-    // other sum in the plan.
+    // do. In plan order: the taps detect one at a time, and the sum reaching
+    // the hardware is compiled like every other sum in the plan.
+    for (const auto op : modSourceOps_)
+        core_.renderOp(op, valueOf(op), block_, output);
+
     for (const auto op : outputOps_)
         core_.renderOp(op, valueOf(op), block_, output);
 }

--- a/magda/engine/exec/ParallelPlanExecutor.hpp
+++ b/magda/engine/exec/ParallelPlanExecutor.hpp
@@ -189,6 +189,12 @@ class ParallelPlanExecutor final : private RenderThreadPool::Job {
     /// schedule deciding the arithmetic.
     std::vector<OpId> outputOps_;
 
+    /// Modulation taps, rendered after the drain for the reason the outputs
+    /// are: each detects through a scratch buffer shared with every other tap,
+    /// and two of them are schedulable at once whenever their source tracks
+    /// have disjoint subgraphs.
+    std::vector<OpId> modSourceOps_;
+
     /// Producers each op is still waiting for. The plan's dependencyCounts,
     /// copied in at the top of every block.
     std::vector<std::atomic<std::uint16_t>> pending_;

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -25,6 +25,23 @@ void copyWithGain(juce::dsp::AudioBlock<float> destination, juce::dsp::AudioBloc
             channelGain(value, channel), numSamples);
 }
 
+/**
+ * @brief What an audio trigger listens for.
+ *
+ * The fork's own three numbers (AudioSidechainMonitorPlugin), because a project
+ * that ducks on a kick has to duck on the same kicks in both engines. A fast
+ * attack so a transient opens the gate, a moderate release so it does not
+ * chatter at the boundary, and a threshold around -20 dB, which is above what a
+ * quiet track leaves behind and below anything meant as a hit.
+ *
+ * One detector per source track rather than one per modifier, which is the
+ * fork's arrangement too: what an audio trigger keys off is a property of the
+ * signal rather than of whatever is listening to it.
+ */
+constexpr float kTriggerThreshold = 0.1f;
+constexpr double kTriggerAttackMs = 1.0;
+constexpr double kTriggerReleaseMs = 50.0;
+
 void applyGain(juce::dsp::AudioBlock<float> block, const OpValue& value, int numSamples) {
     for (std::size_t channel = 0; channel < block.getNumChannels(); ++channel)
         juce::FloatVectorOperations::multiply(block.getChannelPointer(channel),
@@ -255,6 +272,10 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
     midiTapForOp_.assign(numOps, nullptr);
     paramWindowForOp_.assign(numOps, ParamTable::DeviceWindow{});
     mixerParamForOp_.assign(numOps, OpMixerParams{});
+    modSourceForOp_.assign(numOps, std::span<const int>{});
+    triggerForOp_.assign(numOps, TriggerDetector{});
+    inMidiPrefix_.assign(numOps, 0);
+    midiPrefix_.clear();
     paramLayout_ = 0;
 
     // The parameters of the table this plan is published with (#2117). Sized
@@ -299,9 +320,39 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                 key.kind = ParamKey::Kind::SendLevel;
                 key.index = op.key.index;
                 mixerParamForOp_[i].gain = params->find(key);
+            } else if (op.kind == OpKind::ModSource) {
+                // The far end of the edge the compiler emitted, resolved once
+                // here. Both compilers worked the routing out from the same
+                // rule (ModSources.hpp), so a tap with nothing on the far end
+                // is the two having drifted rather than a project that has one.
+                modSourceForOp_[i] = mods_.listenersOf(op.key.trackId);
             }
         }
     }
+
+    // Which ops the block can render before it resolves anything. In plan
+    // order, which is dependency order, so a producer is decided before the ops
+    // reading it are asked about (PlanExecutor.hpp says what this buys).
+    for (std::size_t i = 0; i < numOps; ++i) {
+        const auto& op = plan.ops[i];
+
+        const bool onlyMidi =
+            !op.outputs.empty() && std::ranges::all_of(op.outputs, [](SignalKind kind) {
+                return kind == SignalKind::Midi;
+            });
+
+        const bool fedByPrefix = std::ranges::all_of(op.inputs, [&](const PortRef& input) {
+            return !input.valid() || inMidiPrefix_[static_cast<std::size_t>(input.op)] != 0;
+        });
+
+        if (!onlyMidi || !fedByPrefix)
+            continue;
+
+        inMidiPrefix_[i] = 1;
+        midiPrefix_.push_back(static_cast<OpId>(i));
+    }
+
+    detectMono_.assign(static_cast<std::size_t>(std::max(context.maxBlockSize, 0)), 0.0f);
 
     const auto describe = [&plan](std::size_t index) {
         return "op " + std::to_string(index) + " (" + toString(plan.ops[index].kind) + " " +
@@ -683,7 +734,159 @@ PlanExecutor::BlockStart PlanExecutor::beginBlock(const PlanValues& values,
     return start;
 }
 
+void PlanExecutor::settleBlockTable(const PlanValues& values) {
+    // Null on a block whose values do not fit, which is the same block that
+    // resolves nothing: a modifier addressed through the wrong table is
+    // another modifier, and half a table is worse than none.
+    blockTable_ = appliesValues(values) && fitsParameters(values) ? values.params.get() : nullptr;
+}
+
+void PlanExecutor::renderMidiPrefix(const PlanValues& values, const BlockInfo& block) {
+    settleBlockTable(values);
+
+    if (plan_ == nullptr)
+        return;
+
+    // The ops themselves. Nothing here reads a parameter, so a block whose
+    // values do not apply renders exactly the same MIDI: what an op of this set
+    // reads is a clip, an input queue, or another op of this set.
+    const bool applyValues = appliesValues(values);
+    for (const auto id : midiPrefix_)
+        renderOp(id, applyValues ? values.ops[static_cast<std::size_t>(id)] : kUnityValue, block,
+                 silence_);
+
+    if (blockTable_ == nullptr)
+        return;
+
+    // And then the notes in them, spent before the resolve rather than after,
+    // which is the whole point of running the prefix early: a modifier gated by
+    // a note hears it in the block the note is in.
+    for (std::size_t i = 0; i < plan_->ops.size(); ++i) {
+        const auto& op = plan_->ops[i];
+        if (op.kind != OpKind::ModSource || modSourceForOp_[i].empty())
+            continue;
+
+        const auto& midi = op.inputs[1];
+        if (midi.valid() && inMidiPrefix_[static_cast<std::size_t>(midi.op)] != 0)
+            feedNoteTriggers(i, midiIn(midi));
+    }
+}
+
+void PlanExecutor::feedNoteTriggers(std::size_t op, const juce::MidiBuffer& midi) {
+    if (midi.isEmpty())
+        return;
+
+    for (const auto metadata : midi) {
+        const auto message = metadata.getMessage();
+
+        // Note off before note on, because a message can be neither and most
+        // are: this runs over every event on a track's chain-head stream.
+        const bool on = message.isNoteOn();
+        const bool off = !on && message.isNoteOff(true);
+        const bool all = !on && !off && (message.isAllNotesOff() || message.isAllSoundOff());
+        if (!on && !off && !all)
+            continue;
+
+        for (const auto index : modSourceForOp_[op]) {
+            if (mods_.listensFor(index, *blockTable_) != ModListen::Midi)
+                continue;
+
+            if (on)
+                mods_.noteOn(index, *blockTable_);
+            else if (off)
+                mods_.noteOff(index, *blockTable_);
+            else
+                mods_.allNotesOff(index, *blockTable_);
+        }
+    }
+}
+
+void PlanExecutor::renderModSource(OpId id, const BlockInfo& block) {
+    const auto i = static_cast<std::size_t>(id);
+    const auto& op = plan_->ops[i];
+
+    if (blockTable_ == nullptr || modSourceForOp_[i].empty())
+        return;
+
+    // The notes, where the prefix did not already spend them. A source whose
+    // MIDI a device makes is not in the prefix, so its notes are read here and
+    // land a block later, which is the same lag an audio trigger has.
+    if (const auto& midi = op.inputs[1];
+        midi.valid() && inMidiPrefix_[static_cast<std::size_t>(midi.op)] == 0)
+        feedNoteTriggers(i, midiIn(midi));
+
+    const auto& audio = op.inputs[0];
+    if (!audio.valid())
+        return;
+
+    const auto numSamples = std::min(block.numSamples, static_cast<int>(detectMono_.size()));
+    if (numSamples <= 0)
+        return;
+
+    // Downmixed to mono by averaging the channels, which is what the fork's tap
+    // hands its followers. A sum would make a stereo source read six decibels
+    // louder than the same material in mono.
+    auto in = audioIn(audio, numSamples);
+    const auto channels = static_cast<int>(in.getNumChannels());
+    const auto scale = channels > 0 ? 1.0f / static_cast<float>(channels) : 0.0f;
+
+    for (int s = 0; s < numSamples; ++s) {
+        float sum = 0.0f;
+        for (int c = 0; c < channels; ++c)
+            sum += in.getSample(c, s);
+        detectMono_[static_cast<std::size_t>(s)] = sum * scale;
+    }
+
+    const auto mono =
+        std::span<const float>{detectMono_}.first(static_cast<std::size_t>(numSamples));
+
+    // The level a trigger keys off, which is the block's peak rather than the
+    // mono average: the fork's monitor takes the loudest channel's magnitude
+    // and a duck should follow whichever side is loud.
+    float peak = 0.0f;
+    for (int c = 0; c < channels; ++c)
+        for (int s = 0; s < numSamples; ++s)
+            peak = std::max(peak, std::abs(in.getSample(c, s)));
+
+    auto& detector = triggerForOp_[i];
+
+    // One envelope per source rather than one per modifier, and the constants
+    // are the fork's: a fast attack so a transient opens the gate, a moderate
+    // release so it does not chatter, and a threshold well above the noise a
+    // silent track leaves behind. Per block, from the block's own length, so an
+    // offline render detects the same hits as playback does.
+    const auto blockMs = 1000.0 * numSamples / std::max(preparedContext().sampleRate, 1.0);
+    const auto attack = 1.0f - std::exp(static_cast<float>(-blockMs / kTriggerAttackMs));
+    const auto release = 1.0f - std::exp(static_cast<float>(-blockMs / kTriggerReleaseMs));
+
+    detector.envelope += (peak > detector.envelope ? attack : release) * (peak - detector.envelope);
+
+    const bool rising = !detector.open && detector.envelope > kTriggerThreshold;
+    const bool falling = detector.open && detector.envelope < kTriggerThreshold;
+    if (rising || falling)
+        detector.open = rising;
+
+    for (const auto index : modSourceForOp_[i]) {
+        if (mods_.listensFor(index, *blockTable_) != ModListen::Audio)
+            continue;
+
+        // A follower wants the samples; a trigger wants the edge. Both listen
+        // to the same track and neither is the other's fallback.
+        if (blockTable_->modifiers[static_cast<std::size_t>(index)].kind == ModKind::Follower) {
+            mods_.detectSource(index, *blockTable_, mono);
+            continue;
+        }
+
+        if (rising)
+            mods_.trigger(index, *blockTable_);
+        else if (falling)
+            mods_.setGated(index, *blockTable_, true);
+    }
+}
+
 void PlanExecutor::resolveParameters(const PlanValues& values, const BlockInfo& block) {
+    settleBlockTable(values);
+
     // Two shapes have to match, and neither is something appliesValues can
     // see: it compares the plan's fingerprint and its op count, and a link
     // edit changes neither. A macro gaining its first link grows the table by
@@ -696,26 +899,40 @@ void PlanExecutor::resolveParameters(const PlanValues& values, const BlockInfo& 
     // gets a window of nothing, which is what it had before a table was ever
     // published, and the session escalates a publish of this shape into a
     // structural one so the emptiness lasts a block rather than for ever.
-    if (!appliesValues(values) || values.params == nullptr || !fitsParameters(values)) {
+    if (blockTable_ == nullptr) {
         paramValues_.beginBlock(block.numSamples);
         return;
     }
 
-    resolveParams(*values.params, paramValues_, paramScratch_, paramSegments_, block, &mods_);
+    resolveParams(*blockTable_, paramValues_, paramScratch_, paramSegments_, block, &mods_);
 }
 
 void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedBlock,
                            juce::AudioBuffer<float>& output) {
     const auto start = beginBlock(values, requestedBlock, output);
-    resolveParameters(values, start.block);
-    if (!start.render)
+    if (!start.render) {
+        resolveParameters(values, start.block);
         return;
+    }
+
+    // The MIDI a block has before it has any audio, and the triggers in it.
+    // First, so that a note-gated modifier is resolved with the note that
+    // arrived in this block rather than with the one before it.
+    renderMidiPrefix(values, start.block);
+
+    resolveParameters(values, start.block);
 
     // In order, which is a schedule: ops are in dependency order, so everything
-    // an op reads has already run by the time the walk reaches it.
-    for (std::size_t i = 0; i < plan_->ops.size(); ++i)
+    // an op reads has already run by the time the walk reaches it. The prefix
+    // is skipped rather than re-run: rendering a live input source twice would
+    // consume the queue twice and drop half the notes.
+    for (std::size_t i = 0; i < plan_->ops.size(); ++i) {
+        if (inMidiPrefix_[i] != 0)
+            continue;
+
         renderOp(static_cast<OpId>(i), start.applyValues ? values.ops[i] : kUnityValue, start.block,
                  output);
+    }
 }
 
 OpValue PlanExecutor::mixerValueFor(std::size_t op, const OpValue& published) const {
@@ -966,6 +1183,10 @@ void PlanExecutor::renderOp(OpId id, const OpValue& published, const BlockInfo& 
                 tap->write(out, numSamples);
             break;
         }
+
+        case OpKind::ModSource:
+            renderModSource(id, block);
+            break;
 
         case OpKind::Output: {
             if (value.silent || !op.inputs[0].valid())

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -287,11 +287,16 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
     // by exactly that render. Copying it here would be a read racing a write,
     // and would carry a half-updated detector, which is the spurious edge the
     // carry exists to prevent.
-    std::map<TrackId, std::shared_ptr<TriggerDetector>> carriedTriggers;
+    // Keyed by the tap rather than by the track, because a track has two of
+    // them: one where its triggers key off and one where its followers listen.
+    // The track alone would collapse the pair onto one entry, and the plan
+    // taking that over would run both taps through a single detector, so a
+    // level at one point would open and shut the gate at the other.
+    std::map<std::pair<TrackId, int>, std::shared_ptr<TriggerDetector>> carriedTriggers;
     if (previous != nullptr && previous != this && previous->plan_ != nullptr)
         for (std::size_t i = 0; i < previous->plan_->ops.size(); ++i)
-            if (previous->plan_->ops[i].kind == OpKind::ModSource)
-                carriedTriggers[previous->plan_->ops[i].key.trackId] = previous->triggerForOp_[i];
+            if (const auto& op = previous->plan_->ops[i]; op.kind == OpKind::ModSource)
+                carriedTriggers[{op.key.trackId, op.key.index}] = previous->triggerForOp_[i];
 
     triggerForOp_.assign(numOps, nullptr);
     carriedTriggerDetectors_ = 0;
@@ -299,7 +304,8 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
         if (plan.ops[i].kind != OpKind::ModSource)
             continue;
 
-        if (const auto found = carriedTriggers.find(plan.ops[i].key.trackId);
+        if (const auto found =
+                carriedTriggers.find({plan.ops[i].key.trackId, plan.ops[i].key.index});
             found != carriedTriggers.end() && found->second != nullptr) {
             triggerForOp_[i] = found->second;
             ++carriedTriggerDetectors_;

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <map>
 #include <set>
 
 namespace magda::engine {
@@ -273,7 +274,31 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
     paramWindowForOp_.assign(numOps, ParamTable::DeviceWindow{});
     mixerParamForOp_.assign(numOps, OpMixerParams{});
     modSourceForOp_.assign(numOps, std::span<const int>{});
+
+    // The detectors of the epoch being replaced, by the track each watches.
+    // A modulation tap's envelope is state the way an LFO's phase is state, and
+    // a structural republish during playback must not zero it: a source above
+    // the threshold at that moment would read as a rising edge on the next
+    // block and fire a trigger nothing played. The fork's monitor plugin
+    // survives the same edits with its own level and gate intact.
+    std::map<TrackId, TriggerDetector> carriedTriggers;
+    if (previous != nullptr)
+        for (std::size_t i = 0; i < previous->plan_->ops.size(); ++i)
+            if (previous->plan_->ops[i].kind == OpKind::ModSource)
+                carriedTriggers[previous->plan_->ops[i].key.trackId] = previous->triggerForOp_[i];
+
     triggerForOp_.assign(numOps, TriggerDetector{});
+    carriedTriggerDetectors_ = 0;
+    for (std::size_t i = 0; i < numOps; ++i) {
+        if (plan.ops[i].kind != OpKind::ModSource)
+            continue;
+        if (const auto found = carriedTriggers.find(plan.ops[i].key.trackId);
+            found != carriedTriggers.end()) {
+            triggerForOp_[i] = found->second;
+            ++carriedTriggerDetectors_;
+        }
+    }
+
     inMidiPrefix_.assign(numOps, 0);
     midiPrefix_.clear();
     paramLayout_ = 0;
@@ -776,26 +801,43 @@ void PlanExecutor::feedNoteTriggers(std::size_t op, const juce::MidiBuffer& midi
     if (midi.isEmpty())
         return;
 
-    for (const auto metadata : midi) {
-        const auto message = metadata.getMessage();
+    // Whether the block holds a note at all, settled before anything is fed.
+    // A cross-track listener takes one trigger for the block rather than one
+    // per note, which is what the fork's monitor does: it scans the buffer,
+    // sets a flag, and fires triggerSidechain once.
+    bool anyNoteOn = false;
+    for (const auto metadata : midi)
+        if (metadata.getMessage().isNoteOn()) {
+            anyNoteOn = true;
+            break;
+        }
 
-        // Note off before note on, because a message can be neither and most
-        // are: this runs over every event on a track's chain-head stream.
-        const bool on = message.isNoteOn();
-        const bool off = !on && message.isNoteOff(true);
-        const bool all = !on && !off && (message.isAllNotesOff() || message.isAllSoundOff());
-        if (!on && !off && !all)
+    for (const auto index : modSourceForOp_[op]) {
+        if (mods_.listensFor(index, *blockTable_) != ModListen::Midi)
             continue;
 
-        for (const auto index : modSourceForOp_[op]) {
-            if (mods_.listensFor(index, *blockTable_) != ModListen::Midi)
-                continue;
+        // A modifier living somewhere else is following this track rather than
+        // playing it. The note-counting path refuses it by design, so a trigger
+        // is the only door it has, and there is no note-off half: the fork
+        // deliberately leaves the gate alone there so the modifier runs its
+        // full cycle after a hit (SidechainMonitorPlugin says so at the note-off
+        // branch it does not take).
+        if (mods_.drivenFromElsewhere(index, *blockTable_)) {
+            if (anyNoteOn)
+                mods_.trigger(index, *blockTable_);
+            continue;
+        }
 
-            if (on)
+        // A modifier on the source hears its notes as its own, one at a time,
+        // so the held count is right and the gate shuts when the last lifts.
+        for (const auto metadata : midi) {
+            const auto message = metadata.getMessage();
+
+            if (message.isNoteOn())
                 mods_.noteOn(index, *blockTable_);
-            else if (off)
+            else if (message.isNoteOff(true))
                 mods_.noteOff(index, *blockTable_);
-            else
+            else if (message.isAllNotesOff() || message.isAllSoundOff())
                 mods_.allNotesOff(index, *blockTable_);
         }
     }

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -281,21 +281,30 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
     // the threshold at that moment would read as a rising edge on the next
     // block and fire a trigger nothing played. The fork's monitor plugin
     // survives the same edits with its own level and gate intact.
-    std::map<TrackId, TriggerDetector> carriedTriggers;
-    if (previous != nullptr)
+    // Shared rather than copied, on the terms the delay lines and the modifier
+    // states are shared: the executor being replaced is still rendering while
+    // this one is prepared, and a tap's envelope is written on the audio thread
+    // by exactly that render. Copying it here would be a read racing a write,
+    // and would carry a half-updated detector, which is the spurious edge the
+    // carry exists to prevent.
+    std::map<TrackId, std::shared_ptr<TriggerDetector>> carriedTriggers;
+    if (previous != nullptr && previous != this && previous->plan_ != nullptr)
         for (std::size_t i = 0; i < previous->plan_->ops.size(); ++i)
             if (previous->plan_->ops[i].kind == OpKind::ModSource)
                 carriedTriggers[previous->plan_->ops[i].key.trackId] = previous->triggerForOp_[i];
 
-    triggerForOp_.assign(numOps, TriggerDetector{});
+    triggerForOp_.assign(numOps, nullptr);
     carriedTriggerDetectors_ = 0;
     for (std::size_t i = 0; i < numOps; ++i) {
         if (plan.ops[i].kind != OpKind::ModSource)
             continue;
+
         if (const auto found = carriedTriggers.find(plan.ops[i].key.trackId);
-            found != carriedTriggers.end()) {
+            found != carriedTriggers.end() && found->second != nullptr) {
             triggerForOp_[i] = found->second;
             ++carriedTriggerDetectors_;
+        } else {
+            triggerForOp_[i] = std::make_shared<TriggerDetector>();
         }
     }
 
@@ -890,7 +899,9 @@ void PlanExecutor::renderModSource(OpId id, const BlockInfo& block) {
         for (int s = 0; s < numSamples; ++s)
             peak = std::max(peak, std::abs(in.getSample(c, s)));
 
-    auto& detector = triggerForOp_[i];
+    auto* detector = triggerForOp_[i].get();
+    if (detector == nullptr)
+        return;
 
     // One envelope per source rather than one per modifier, and the constants
     // are the fork's: a fast attack so a transient opens the gate, a moderate
@@ -901,15 +912,24 @@ void PlanExecutor::renderModSource(OpId id, const BlockInfo& block) {
     const auto attack = 1.0f - std::exp(static_cast<float>(-blockMs / kTriggerAttackMs));
     const auto release = 1.0f - std::exp(static_cast<float>(-blockMs / kTriggerReleaseMs));
 
-    detector.envelope += (peak > detector.envelope ? attack : release) * (peak - detector.envelope);
+    detector->envelope +=
+        (peak > detector->envelope ? attack : release) * (peak - detector->envelope);
 
-    const bool rising = !detector.open && detector.envelope > kTriggerThreshold;
-    const bool falling = detector.open && detector.envelope < kTriggerThreshold;
+    const bool rising = !detector->open && detector->envelope > kTriggerThreshold;
+    const bool falling = detector->open && detector->envelope < kTriggerThreshold;
     if (rising || falling)
-        detector.open = rising;
+        detector->open = rising;
+
+    // Which of a track's two taps this is. A listener reads the one it names,
+    // so a follower at the far end and a trigger at the near one on the same
+    // source each hear their own point rather than sharing whichever op ran.
+    const auto point =
+        op.key.index == 0 ? magda::ModTapPoint::PreFx : magda::ModTapPoint::PostFader;
 
     for (const auto index : modSourceForOp_[i]) {
         if (mods_.listensFor(index, *blockTable_) != ModListen::Audio)
+            continue;
+        if (blockTable_->modifiers[static_cast<std::size_t>(index)].tap != point)
             continue;
 
         // A follower wants the samples; a trigger wants the edge. Both listen

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -315,6 +315,14 @@ class PlanExecutor {
         return boundMeterCount_;
     }
 
+    /// Modulation taps that took over the detector of the executor they
+    /// replaced rather than starting again. What that buys is the same thing
+    /// ModRuntime's carry buys: an edit during playback does not restate a
+    /// gate the source never changed.
+    int carriedTriggerDetectors() const {
+        return carriedTriggerDetectors_;
+    }
+
     /// Samples the prepared plan's output is delayed by: what the devices along
     /// its longest path to the output report between them.
     int latencySamples() const {
@@ -596,6 +604,8 @@ class PlanExecutor {
 
     /// Per ModSource op, indexed the same way the ops are.
     std::vector<TriggerDetector> triggerForOp_;
+
+    int carriedTriggerDetectors_ = 0;
 
     /**
      * @brief The table this block resolved against, or null.

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <memory>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -254,6 +255,38 @@ class PlanExecutor {
      * before any table was published at all.
      */
     void resolveParameters(const PlanValues& values, const BlockInfo& block);
+
+    /**
+     * @brief Render the MIDI a block has before it has any audio (#2120).
+     *
+     * On the audio thread, after beginBlock and before resolveParameters, from
+     * both executors. What it renders is the set of ops whose outputs are all
+     * MIDI and whose producers are all in that same set: clip readers, live
+     * input queues, the merges that gather them, and the delays on those edges.
+     * None of it reads a parameter and none of it reads audio, so running it
+     * early is the same schedule seen from a different place.
+     *
+     * What that buys is the one block a note-triggered modifier would otherwise
+     * be late by. Parameters resolve at the top of a block, so a trigger fired
+     * by an op during the walk is not spent until the next block's resolve; a
+     * trigger read off a MIDI buffer that already exists is spent in this one.
+     *
+     * MIDI a device makes is not in the prefix and cannot be: an arpeggiator's
+     * notes are work that has not happened yet at resolve time. A modifier
+     * triggered from those is a block late, which is the lag an audio trigger
+     * has as well (ModFollower.hpp).
+     *
+     * The caller must not render these ops again. They stay in the schedule so
+     * their consumers are released as usual, and both executors skip re-running
+     * them: a live input queue rendered twice is a queue read twice.
+     */
+    void renderMidiPrefix(const PlanValues& values, const BlockInfo& block);
+
+    /// Whether @p op was already rendered by @ref renderMidiPrefix this block.
+    bool inMidiPrefix(OpId op) const {
+        const auto i = static_cast<std::size_t>(op);
+        return i < inMidiPrefix_.size() && inMidiPrefix_[i] != 0;
+    }
 
     /**
      * @brief Render one op of the prepared plan.
@@ -516,6 +549,76 @@ class PlanExecutor {
     /// from the same table, and carried from the executor being replaced, so a
     /// device insert does not restart every LFO in the project.
     ModRuntime mods_;
+
+    /**
+     * @brief Ops that can run before the block's parameters are resolved.
+     *
+     * Every op whose outputs are all MIDI and whose producers are all in this
+     * set, which is the MIDI a block has before any audio exists: clip readers,
+     * live input queues, the merges that gather them, and the delays on those
+     * edges. None of it reads a parameter and none of it reads audio, so
+     * running it first is the same schedule seen from a different place rather
+     * than a reordering.
+     *
+     * What that buys is the one block a note-triggered modifier would otherwise
+     * be late by. Parameters resolve at the top of a block, so a trigger fired
+     * by an op is not spent until the next block's resolve; a trigger read off
+     * a MIDI buffer that already exists is spent in this one. The fork's own
+     * gate is the later of the two and its monitor is the earlier, so this is
+     * the fork's best case made unconditional.
+     *
+     * MIDI a device makes is not in here and cannot be: an arpeggiator's notes
+     * are audio-thread work that has not happened yet at resolve time. A
+     * modifier triggered from those is a block late, and that is the same lag
+     * an audio trigger has and is documented in the same place.
+     */
+    std::vector<OpId> midiPrefix_;
+
+    /// Per op: whether it belongs to @ref midiPrefix_, so the block's main walk
+    /// leaves alone what the prefix already rendered.
+    std::vector<char> inMidiPrefix_;
+
+    /// Per op: the modifiers a ModSource op feeds, or an empty span. Resolved
+    /// at prepare from the table's own record of what listens to what.
+    std::vector<std::span<const int>> modSourceForOp_;
+
+    /// One block of the source's audio, downmixed to mono, which is what a
+    /// detector reads. Sized at prepare.
+    std::vector<float> detectMono_;
+
+    /// Per follower: what its own detection needs to know about the level its
+    /// audio trigger is at, kept out of the modifier states because it belongs
+    /// to the source rather than to the modifier.
+    struct TriggerDetector {
+        float envelope = 0.0f;
+        bool open = false;
+    };
+
+    /// Per ModSource op, indexed the same way the ops are.
+    std::vector<TriggerDetector> triggerForOp_;
+
+    /**
+     * @brief The table this block resolved against, or null.
+     *
+     * Set once at the top of the block and read by the ops that need to name a
+     * modifier. Not a second copy of anything: it is the same table
+     * resolveParameters was handed, kept for the length of the walk because a
+     * modulation tap runs inside the walk and the values it was given do not
+     * reach renderOp.
+     */
+    const ParamTable* blockTable_ = nullptr;
+
+    /// Settle @ref blockTable_ for this block. Called by whichever of the two
+    /// entry points runs first, and idempotent, because beginBlock is const and
+    /// the prefix needs the answer before the resolve does.
+    void settleBlockTable(const PlanValues& values);
+
+    /// Read one modulation tap: hand the source's level to the followers
+    /// listening to it, and its rises and falls to the triggered ones.
+    void renderModSource(OpId id, const BlockInfo& block);
+
+    /// Spend the notes in @p midi on the modifiers listening to @p op's track.
+    void feedNoteTriggers(std::size_t op, const juce::MidiBuffer& midi);
 
     /** @brief The parameters a mixer op reads instead of the published value. */
     struct OpMixerParams {

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <memory>
+#include <set>
 #include <span>
 #include <string>
 #include <vector>
@@ -321,6 +322,18 @@ class PlanExecutor {
     /// gate the source never changed.
     int carriedTriggerDetectors() const {
         return carriedTriggerDetectors_;
+    }
+
+    /// Detectors no two taps share. Every modulation tap owns its own level and
+    /// gate, so this is the number of taps: a track read at both its points has
+    /// two, and one detector between them would let a level at one point work
+    /// the gate at the other.
+    int distinctTriggerDetectors() const {
+        std::set<const TriggerDetector*> seen;
+        for (const auto& detector : triggerForOp_)
+            if (detector != nullptr)
+                seen.insert(detector.get());
+        return static_cast<int>(seen.size());
     }
 
     /// Samples the prepared plan's output is delayed by: what the devices along

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -602,8 +602,12 @@ class PlanExecutor {
         bool open = false;
     };
 
-    /// Per ModSource op, indexed the same way the ops are.
-    std::vector<TriggerDetector> triggerForOp_;
+    /// Per ModSource op, indexed the same way the ops are. Held by shared
+    /// pointer for the reason the delay lines are: a tap the next plan also has
+    /// is the same detector rather than a copy of one read at some instant, and
+    /// only one epoch renders at a time so there is an owner to outlive and no
+    /// concurrent use to guard against.
+    std::vector<std::shared_ptr<TriggerDetector>> triggerForOp_;
 
     int carriedTriggerDetectors_ = 0;
 

--- a/magda/engine/exec/PlanValues.cpp
+++ b/magda/engine/exec/PlanValues.cpp
@@ -434,6 +434,12 @@ void Resolver::resolveOp(OpId id, OpValue& value) {
         case OpRole::RackMix:
         case OpRole::RackMidiMix:
         case OpRole::TrackMeter:
+        // A modulation tap reads what reached it and has no value of its own.
+        // Not even a mute: a modifier following a track is following what that
+        // track is playing, and the fork taps the same point for the same
+        // reason, before the muting node, so a muted source still ducks the
+        // compressor keying off it.
+        case OpRole::ModulationTap:
         case OpRole::HardwareOutput:
         // Delay and crossfade roles never reach here: they return above.
         case OpRole::MixInputDelay:

--- a/magda/engine/param/ModAdsr.cpp
+++ b/magda/engine/param/ModAdsr.cpp
@@ -1,0 +1,281 @@
+#include "param/ModAdsr.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace magda::engine {
+
+namespace {
+
+/// A stage shorter than this is one the user means to be instant. The fork's
+/// own floor, and it is a comparison rather than a clamp: a zero-length attack
+/// arrives at the top and hands the rest of the block to the decay, which is
+/// what makes an envelope with no attack a click on purpose.
+constexpr double kMinStageSeconds = 0.0001;
+
+/// A single block can step through several stages when the lengths are very
+/// short, and every one of them consumes what is left of the block. The bound
+/// is what stops a set of zero-length stages from spinning; the fork's own,
+/// and reached only by an envelope that has no time in it anywhere.
+constexpr int kMaxStagesPerBlock = 8;
+
+struct Point {
+    float x = 0.0f;
+    float y = 0.0f;
+};
+
+/**
+ * @brief The control point of the fork's quadratic bezier.
+ *
+ * Transcribed from BezierHelpers::getQuadraticControlPoint rather than
+ * reasoned out again: the curvature is a persisted number and the shape it
+ * stands for is whatever that function says it is. The two branches are the
+ * rising and falling segment, which are not mirror images of each other in the
+ * original and are not made into one here.
+ */
+Point controlPointFor(Point start, Point end, float curve) {
+    const float c = std::clamp(curve * 2.0f, -1.0f, 1.0f);
+    const float halfRun = (end.x - start.x) / 2.0f;
+    const float x = start.x + halfRun + (halfRun * c);
+
+    if (end.y > start.y) {
+        const float halfRise = (end.y - start.y) / 2.0f;
+        return Point{x, start.y + halfRise - (halfRise * c)};
+    }
+
+    const float halfRise = (start.y - end.y) / 2.0f;
+    return Point{x, end.y + halfRise + (halfRise * c)};
+}
+
+/// The bezier's y at an x, by solving for t and evaluating. The fork's
+/// BezierHelpers::getQuadraticYFromX, on the same terms.
+float quadraticYFromX(float x, Point start, Point control, Point end) {
+    if (start.x == end.x || start.y == end.y)
+        return start.y;
+
+    const float a = start.x - (2.0f * control.x) + end.x;
+    const float b = (-2.0f * start.x) + (2.0f * control.x);
+    const float c = start.x - x;
+
+    float t = 0.0f;
+
+    if (a == 0.0f) {
+        t = -c / b;
+    } else {
+        const float discriminant = std::max(b * b - 4.0f * a * c, 0.0f);
+        const float root = std::sqrt(discriminant);
+        t = (-b + root) / (2.0f * a);
+
+        if (t < 0.0f || t > 1.0f)
+            t = (-b - root) / (2.0f * a);
+    }
+
+    const float u = 1.0f - t;
+    return u * u * start.y + 2.0f * t * u * control.y + t * t * end.y;
+}
+
+/// Where the gate comes from this block, which is the whole of what the sync
+/// mode decides for an envelope.
+bool gateOpenFor(const AdsrState& state, const AdsrSettings& settings, const BlockInfo& block) {
+    switch (settings.sync) {
+        case ModSync::Free:
+            // Held open, so the envelope cycles rather than waiting for
+            // something that is never going to arrive.
+            return true;
+
+        case ModSync::Transport:
+            return block.playing;
+
+        case ModSync::Note:
+            return !state.gated;
+    }
+
+    return true;
+}
+
+void enterStage(AdsrState& state, AdsrStage stage, float startValue) {
+    state.stage = stage;
+    state.timeInStage = 0.0;
+    state.stagePhase = 0.0f;
+    state.stageStartValue = startValue;
+}
+
+/**
+ * @brief Run the stage machine forward by @p seconds.
+ *
+ * The fork's own loop. A stage that ends inside the block hands what is left of
+ * it to the next one, so a block longer than the attack arrives somewhere in
+ * the decay rather than being clamped at the top of it.
+ */
+void advanceStages(AdsrState& state, const AdsrSettings& settings, const ModTiming& timing,
+                   double seconds, bool freeRunning, bool gateOpen) {
+    const double attackSeconds = adsrStageSeconds(settings.attackMs, settings, timing);
+    const double decaySeconds = adsrStageSeconds(settings.decayMs, settings, timing);
+    const double releaseSeconds = adsrStageSeconds(settings.releaseMs, settings, timing);
+    const float sustain = std::clamp(settings.sustain, 0.0f, 1.0f);
+
+    /// One timed stage: what it travels from, what it arrives at, how long it
+    /// takes, how it is bent, and where it goes when it is through.
+    const auto run = [&](double length, float destination, float curve, AdsrStage next) {
+        if (length <= kMinStageSeconds) {
+            state.value = destination;
+            enterStage(state, next, destination);
+            return true;
+        }
+
+        state.timeInStage += seconds;
+
+        if (state.timeInStage >= length) {
+            seconds = state.timeInStage - length;
+            state.value = destination;
+            enterStage(state, next, destination);
+            return true;
+        }
+
+        state.stagePhase = static_cast<float>(state.timeInStage / length);
+        state.value = adsrSegmentAt(state.stagePhase, state.stageStartValue, destination, curve);
+        return false;
+    };
+
+    for (int guard = 0; guard < kMaxStagesPerBlock; ++guard) {
+        switch (state.stage) {
+            case AdsrStage::Idle:
+                state.value = 0.0f;
+                state.stagePhase = 0.0f;
+
+                // A free-running envelope has nothing to wait for, so it starts
+                // again rather than resting: that is what makes it a cycle.
+                if (freeRunning && gateOpen) {
+                    enterStage(state, AdsrStage::Attack, 0.0f);
+                    continue;
+                }
+                return;
+
+            case AdsrStage::Attack:
+                if (run(attackSeconds, 1.0f, settings.attackCurve, AdsrStage::Decay))
+                    continue;
+                return;
+
+            case AdsrStage::Decay:
+                if (run(decaySeconds, sustain, settings.decayCurve, AdsrStage::Sustain))
+                    continue;
+                return;
+
+            case AdsrStage::Sustain:
+                // Tracked live, so moving the sustain knob under a held note
+                // moves the envelope rather than waiting for the next one.
+                state.value = sustain;
+                state.stagePhase = 0.0f;
+
+                // Free running skips the hold, which is what turns A-D-S-R into
+                // the A-D-R cycle a free-running envelope is.
+                if (freeRunning) {
+                    enterStage(state, AdsrStage::Release, state.value);
+                    continue;
+                }
+                return;
+
+            case AdsrStage::Release:
+                if (run(releaseSeconds, 0.0f, settings.releaseCurve, AdsrStage::Idle))
+                    continue;
+                return;
+        }
+    }
+}
+
+}  // namespace
+
+double adsrStageSeconds(float milliseconds, const AdsrSettings& settings, const ModTiming& timing) {
+    // A division of Hertz is not a division. The model reaches that state by
+    // having tempo sync on with nothing musical selected, and the fork's answer
+    // is to fall back to the milliseconds rather than to invent a period.
+    if (settings.tempoSync && settings.rateType != static_cast<int>(magda::ModRateType::Hertz)) {
+        const auto beats = cycleBeats(settings.rateType, timing.numerator, timing.denominator);
+        return beats * 60.0 / std::max(timing.bpm, 1.0e-6);
+    }
+
+    return std::max(static_cast<double>(milliseconds), 0.0) / 1000.0;
+}
+
+float adsrSegmentAt(float t, float startValue, float endValue, float curve) {
+    t = std::clamp(t, 0.0f, 1.0f);
+
+    // Nothing to bend, and the bezier would divide by the run it does not have.
+    if (curve == 0.0f || startValue == endValue)
+        return startValue + (endValue - startValue) * t;
+
+    const Point start{0.0f, startValue};
+    const Point end{1.0f, endValue};
+    return quadraticYFromX(t, start, controlPointFor(start, end, curve), end);
+}
+
+void restartAdsr(AdsrState& state, const AdsrSettings& settings, bool fromZero) {
+    const float from = fromZero ? 0.0f : state.value;
+
+    enterStage(state, AdsrStage::Attack, from);
+    state.value = from;
+
+    // The gate was opened by whoever triggered, and this is that gate being
+    // seen: without it the next block reads a rising edge and enters the attack
+    // a second time, one block in.
+    state.lastGate = true;
+    state.started = true;
+    state.trigger = settings.trigger;
+}
+
+float advanceAdsr(AdsrState& state, const AdsrSettings& settings, const BlockInfo& block,
+                  const ModTiming& timing) {
+    // A fresh state takes its gate from the settings, and so does one whose
+    // trigger mode has changed underneath it. The LFO's rule, for the LFO's
+    // reason (advanceLfo says it): a gate belongs to the triggers of the mode
+    // that opened it, and a mode change retires all of them.
+    if (!state.started || state.trigger != settings.trigger) {
+        state.started = true;
+        state.trigger = settings.trigger;
+        state.gated = settings.startGated;
+        state.heldNotes = 0;
+
+        // The edge goes with the gate. Shut rather than whatever the old mode
+        // left, so a mode whose gate is open is an opening edge on the first
+        // block under it: an audio-triggered envelope switched to free running
+        // starts, rather than sitting idle waiting for a rise it will never see
+        // because its gate is already up.
+        state.lastGate = false;
+    }
+
+    // A trigger asked for one block of nothing, and this is the first block a
+    // device can see it in. The envelope is held where the restart left it, so
+    // the attack starts on the block after rather than a block into itself.
+    if (state.forceZero) {
+        state.forceZero = false;
+        state.value = 0.0f;
+        state.stagePhase = 0.0f;
+        return 0.0f;
+    }
+
+    const bool freeRunning = settings.sync == ModSync::Free;
+    const bool gateOpen = gateOpenFor(state, settings, block);
+
+    // The edge, not the level. Retriggered and released from wherever the
+    // envelope currently is, so a gate change is click-free from any stage.
+    if (gateOpen && !state.lastGate)
+        enterStage(state, AdsrStage::Attack, state.value);
+    else if (!gateOpen && state.lastGate && state.stage != AdsrStage::Idle)
+        enterStage(state, AdsrStage::Release, state.value);
+
+    state.lastGate = gateOpen;
+
+    const double blockSeconds =
+        static_cast<double>(std::max(block.numSamples, 0)) / std::max(timing.sampleRate, 1.0);
+
+    advanceStages(state, settings, timing, blockSeconds, freeRunning, gateOpen);
+
+    // Advanced first and published after, which is the fork's ADSR timer and
+    // the opposite of its LFO timer: the value a block renders with is where
+    // the envelope ends up rather than where it started. Reproduced rather than
+    // tidied, because the fork is what a parity case compares against.
+    state.value = std::clamp(state.value, 0.0f, 1.0f);
+    return state.value;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/param/ModAdsr.hpp
+++ b/magda/engine/param/ModAdsr.hpp
@@ -1,0 +1,209 @@
+#pragma once
+
+#include <cstdint>
+
+#include "core/ModInfo.hpp"
+#include "exec/RenderContext.hpp"
+#include "param/ModLfo.hpp"
+
+/**
+ * @file ModAdsr.hpp
+ * @brief The envelope generator: what it is, what stage it is in, and how far a
+ *        block moves it.
+ *
+ * The LFO's three pieces, in the same arrangement and for the same reasons
+ * (ModLfo.hpp says them at length). AdsrSettings is what the model says the
+ * envelope is and rides in the published table; AdsrState is where it has got
+ * to and belongs to the runtime; advanceAdsr is one block of the first applied
+ * to the second.
+ *
+ * Two things differ from the LFO, and both are the fork's rather than choices
+ * made here.
+ *
+ * The first is the gate. An LFO's trigger restarts a phase and a gate is
+ * something extra a note-triggered one opts into; an envelope is nothing but a
+ * gate, and its whole shape is the answer to how long the gate has been open
+ * and how long ago it shut. So the gate is not optional here, and where it
+ * comes from is what the sync mode selects: a free-running envelope holds its
+ * gate open and cycles, a transport-locked one is gated by playback, and a
+ * note-driven one is gated by whatever is feeding it notes.
+ *
+ * The second is when the value is read. The fork's LFO timer publishes the
+ * phase the block opens on and then moves the ramp; its ADSR timer advances
+ * first and publishes where the block ends up. The two are one block apart and
+ * this reproduces the second, because a parity case is measured against the
+ * fork and not against the tidier of its two conventions.
+ *
+ * What is deliberately not here, exactly as with the LFO, is depth and
+ * polarity: one envelope drives several parameters by different amounts, and
+ * MAGDA keeps that per link.
+ */
+
+namespace magda::engine {
+
+/**
+ * @brief Which part of the envelope is running.
+ *
+ * The ordinals are te::ADSRModifier::Stage's, because the model carries this
+ * back to the UI as an ordinal (ModInfo::envStage) and the stage readout is
+ * shared with the fork. A display that renumbered them would light the wrong
+ * segment in one of the two engines.
+ */
+enum class AdsrStage : std::uint8_t { Idle, Attack, Decay, Sustain, Release };
+
+/**
+ * @brief What the model says one envelope is.
+ *
+ * Flat and copyable, riding in the published table beside the LFO's.
+ */
+struct AdsrSettings {
+    /// Stage lengths in milliseconds, which is what the model stores and what a
+    /// modifier that is not tempo synced runs at.
+    float attackMs = 10.0f;
+    float decayMs = 200.0f;
+    float releaseMs = 300.0f;
+
+    /// The level held while the gate stays open, 0 to 1.
+    float sustain = 0.7f;
+
+    /// Per-segment curvature, -0.5 to 0.5: a quadratic bezier bent from
+    /// logarithmic through linear at zero to exponential. The fork's own
+    /// control point arithmetic, because the numbers land in project files.
+    float attackCurve = 0.0f;
+    float decayCurve = 0.0f;
+    float releaseCurve = 0.0f;
+
+    /**
+     * @brief Where the gate comes from.
+     *
+     * Folded from the trigger mode alone. Unlike the LFO's, tempo sync is not
+     * part of this fold: for an LFO it decides what the period is and therefore
+     * whether the phase is a function of the timeline, and for an envelope it
+     * only scales the stage lengths. A tempo-synced free-running envelope is
+     * still free-running (ModifierHelpers::mapADSRSyncType).
+     */
+    ModSync sync = ModSync::Free;
+
+    /// What the model says triggers it, carried for the reason the LFO carries
+    /// it: MIDI and audio both run as ModSync::Note and gate differently, so a
+    /// mode change has to be visible to a running gate.
+    magda::LFOTriggerMode trigger = magda::LFOTriggerMode::Free;
+
+    /// Whether the stage lengths are musical divisions rather than
+    /// milliseconds.
+    bool tempoSync = false;
+
+    /**
+     * @brief The division every stage runs at when tempo synced.
+     *
+     * One for all three, because that is what the model carries: the fork
+     * writes it to the ADSR's separate attack, decay and release sync
+     * parameters and they are always the same value (applyADSRProperties).
+     */
+    int rateType = static_cast<int>(magda::ModRateType::Hertz);
+
+    /// Whether this envelope ignores triggers from where it lives, so a
+    /// cross-track one is driven by its source alone. The LFO's flag, with the
+    /// same meaning and the same reason.
+    bool skipNativeResync = false;
+
+    /// Whether it starts with its gate shut: what an audio-triggered envelope
+    /// is between hits, and a note-triggered one before the first note.
+    bool startGated = false;
+};
+
+/** @brief Where one envelope has got to. */
+struct AdsrState {
+    AdsrStage stage = AdsrStage::Idle;
+
+    /// How long the current stage has been running, in seconds.
+    double timeInStage = 0.0;
+
+    /// The level the stage started from, so a gate change is click-free from
+    /// wherever the envelope happened to be rather than from the top.
+    float stageStartValue = 0.0f;
+
+    /// How far through the current stage, 0 to 1, for the display. Zero in the
+    /// stages that have no length: idle and sustain.
+    float stagePhase = 0.0f;
+
+    float value = 0.0f;
+
+    /// The gate as the triggers left it. Shut means shut: the sync mode
+    /// decides whether this is what is read at all.
+    bool gated = false;
+
+    /// The gate this state last saw, which is what makes a change an edge. A
+    /// gate that is merely open is not a retrigger.
+    bool lastGate = false;
+
+    /// A trigger has asked for one block of nothing, on the LFO's terms and
+    /// for its reason (LfoState::forceZero): the trigger lands inside a block
+    /// whose parameters are already resolved, so the gap it stands for is
+    /// spent on the next one, and the attack starts from zero after it.
+    bool forceZero = false;
+
+    /// Notes holding the gate open.
+    int heldNotes = 0;
+
+    bool started = false;
+
+    /// The trigger mode this state's gate was seeded under, so a mode change
+    /// retires the gate the old mode left. The LFO's rule, and an envelope
+    /// needs it more: one left shut by a mode nothing triggers any more is an
+    /// envelope that never sounds again.
+    magda::LFOTriggerMode trigger = magda::LFOTriggerMode::Free;
+};
+
+/**
+ * @brief How long one stage lasts, in seconds.
+ *
+ * The milliseconds the model stores, or the musical division they are replaced
+ * by when the envelope is tempo synced. A division of Hertz is not a division,
+ * and falls back to the milliseconds, which is the fork's own rule.
+ */
+double adsrStageSeconds(float milliseconds, const AdsrSettings& settings, const ModTiming& timing);
+
+/**
+ * @brief The level a curved segment has @p t of the way through it.
+ *
+ * The fork's quadratic bezier (BezierHelpers), because the curvature lands in
+ * project files as a number between -0.5 and 0.5 and the shape it stands for
+ * has to be the same one in both engines. A curvature of zero is the straight
+ * line, taken early rather than solved for.
+ *
+ * Exposed because the tests want the shape without the run.
+ */
+float adsrSegmentAt(float t, float startValue, float endValue, float curve);
+
+/**
+ * @brief Restart @p state, as a trigger does.
+ *
+ * Into the attack, from where the envelope already was, which is what makes a
+ * retrigger click-free from any stage. @p fromZero starts it from silence
+ * instead, which is what a cross-track trigger asks for so the device sees a
+ * transition rather than a continuation.
+ *
+ * Unlike the LFO's restart this acts in every sync mode. An LFO that is not
+ * listening for triggers has a phase of its own that a trigger has no business
+ * moving; an envelope that is not listening has no gate anything else can open,
+ * so a trigger reaching it is the only thing that could have.
+ */
+void restartAdsr(AdsrState& state, const AdsrSettings& settings, bool fromZero);
+
+/**
+ * @brief Advance @p state over one block and publish what @p settings says.
+ *
+ * On the audio thread, once per block, before anything reads the modifier.
+ * Returns the output, 0 to 1, and 0 is an envelope at rest, which is the
+ * convention the whole modulation system reads as a modifier doing nothing.
+ *
+ * The gate is settled first, from the sync mode: open always while free
+ * running, from @p block while transport locked, and from the state's own gate
+ * while note driven. A change of it is an edge, and an edge is what enters the
+ * attack or the release.
+ */
+float advanceAdsr(AdsrState& state, const AdsrSettings& settings, const BlockInfo& block,
+                  const ModTiming& timing);
+
+}  // namespace magda::engine

--- a/magda/engine/param/ModFollower.cpp
+++ b/magda/engine/param/ModFollower.cpp
@@ -1,0 +1,208 @@
+#include "param/ModFollower.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+
+namespace magda::engine {
+
+namespace {
+
+/**
+ * @brief The fork's time constant, which is the digital one.
+ *
+ * log(1%): a stage is "arrived" when it is within a hundredth of its
+ * destination, and the coefficient is what that means per sample. The fork
+ * offers three of these and MAGDA selects none of them, so this is the default
+ * it therefore always runs at (EnvelopeFollowerModifier's digitalTC).
+ */
+constexpr float kTimeConstant = -2.0f;
+
+/// A time of zero would divide the constant by nothing. Well under a sample at
+/// any rate this engine runs at, so it is a guard rather than a range: the
+/// model's own floor for attack and release is a millisecond.
+constexpr float kMinTimeMs = 1.0e-3f;
+
+/// How far a coefficient may be from its neighbour before it is worth
+/// recomputing. The cutoffs arrive as floats off the model and comparing them
+/// exactly is what the fork does; matched, so a block that changes nothing
+/// recomputes nothing in either engine.
+bool cutoffMoved(float current, float wanted) {
+    return current != wanted;
+}
+
+/// The per-sample one-pole coefficient for a time in milliseconds.
+float coefficientFor(float timeMs, double sampleRate) {
+    const auto samples = std::max(timeMs, kMinTimeMs) * static_cast<float>(sampleRate) * 0.001f;
+    return std::exp(kTimeConstant / samples);
+}
+
+float decibelsToGain(float db) {
+    return std::pow(10.0f, db * 0.05f);
+}
+
+/// JUCE's normalisation: the five coefficients divided through by the one that
+/// is not stored, computed in double and kept as float, which is what makes
+/// this the same filter rather than one that agrees to a few decimals.
+FollowerBiquad normalised(double c1, double c2, double c3, double c4, double c5, double c6) {
+    const auto a = 1.0 / c4;
+
+    FollowerBiquad filter;
+    filter.c0 = static_cast<float>(c1 * a);
+    filter.c1 = static_cast<float>(c2 * a);
+    filter.c2 = static_cast<float>(c3 * a);
+    filter.c3 = static_cast<float>(c5 * a);
+    filter.c4 = static_cast<float>(c6 * a);
+    return filter;
+}
+
+/// Inside the band the filters can describe. A cutoff at or above Nyquist has
+/// no shape, and the model's own range stops at 20 kHz, which is above it at
+/// 32 kHz and below.
+double usableCutoff(double sampleRate, double frequency) {
+    return std::clamp(frequency, 20.0, std::max(sampleRate * 0.5 - 1.0, 20.0));
+}
+
+}  // namespace
+
+void FollowerBiquad::reset() {
+    v1 = 0.0f;
+    v2 = 0.0f;
+}
+
+float FollowerBiquad::process(float in) {
+    const float out = (c0 * in) + v1;
+    v1 = (c1 * in) - (c3 * out) + v2;
+    v2 = (c2 * in) - (c4 * out);
+    return out;
+}
+
+FollowerBiquad followerLowPass(double sampleRate, double frequency) {
+    // JUCE's makeLowPass at its default Q of one over root two.
+    const auto q = 1.0 / std::numbers::sqrt2;
+    const auto n = 1.0 / std::tan(std::numbers::pi * usableCutoff(sampleRate, frequency) /
+                                  std::max(sampleRate, 1.0));
+    const auto nSquared = n * n;
+    const auto c1 = 1.0 / (1.0 + (n / q) + nSquared);
+
+    return normalised(c1, c1 * 2.0, c1, 1.0, c1 * 2.0 * (1.0 - nSquared),
+                      c1 * (1.0 - (n / q) + nSquared));
+}
+
+FollowerBiquad followerHighPass(double sampleRate, double frequency) {
+    const auto q = 1.0 / std::numbers::sqrt2;
+    const auto n = std::tan(std::numbers::pi * usableCutoff(sampleRate, frequency) /
+                            std::max(sampleRate, 1.0));
+    const auto nSquared = n * n;
+    const auto c1 = 1.0 / (1.0 + (n / q) + nSquared);
+
+    return normalised(c1, c1 * -2.0, c1, 1.0, c1 * 2.0 * (nSquared - 1.0),
+                      c1 * (1.0 - (n / q) + nSquared));
+}
+
+void detectFollowerSource(FollowerState& state, const FollowerSettings& settings,
+                          std::span<const float> mono, double sampleRate,
+                          std::span<float> scratch) {
+    // A rate change makes every coefficient stale, filters and time constants
+    // alike. Cleared rather than converted: what a filter holds is samples at
+    // the old rate and there is nothing to convert them into.
+    if (state.sampleRate != sampleRate) {
+        state.sampleRate = sampleRate;
+        state.highPassHz = 0.0f;
+        state.lowPassHz = 0.0f;
+        state.highPass.reset();
+        state.lowPass.reset();
+    }
+
+    const auto count = std::min(mono.size(), scratch.size());
+    if (count == 0) {
+        state.sourcePeak = 0.0f;
+        return;
+    }
+
+    const float gain = decibelsToGain(settings.gainDb);
+
+    // The gained peak on its own where nothing is filtered, which is almost
+    // every follower: the scratch buffer is only worth filling when something
+    // is going to read it back.
+    if (!settings.highPass && !settings.lowPass) {
+        float peak = 0.0f;
+        for (std::size_t i = 0; i < count; ++i)
+            peak = std::max(peak, std::abs(mono[i] * gain));
+
+        state.sourcePeak = peak;
+        return;
+    }
+
+    for (std::size_t i = 0; i < count; ++i)
+        scratch[i] = mono[i] * gain;
+
+    // High pass first and low pass second, which is the fork's order. Two
+    // second-order sections do not commute exactly in floating point, so the
+    // order is part of the answer rather than a detail of it.
+    if (settings.highPass) {
+        if (cutoffMoved(state.highPassHz, settings.highPassHz)) {
+            state.highPassHz = settings.highPassHz;
+            const auto carried = state.highPass;
+            state.highPass = followerHighPass(sampleRate, settings.highPassHz);
+            state.highPass.v1 = carried.v1;
+            state.highPass.v2 = carried.v2;
+        }
+
+        for (std::size_t i = 0; i < count; ++i)
+            scratch[i] = state.highPass.process(scratch[i]);
+    }
+
+    if (settings.lowPass) {
+        if (cutoffMoved(state.lowPassHz, settings.lowPassHz)) {
+            state.lowPassHz = settings.lowPassHz;
+            const auto carried = state.lowPass;
+            state.lowPass = followerLowPass(sampleRate, settings.lowPassHz);
+            state.lowPass.v1 = carried.v1;
+            state.lowPass.v2 = carried.v2;
+        }
+
+        for (std::size_t i = 0; i < count; ++i)
+            scratch[i] = state.lowPass.process(scratch[i]);
+    }
+
+    float peak = 0.0f;
+    for (std::size_t i = 0; i < count; ++i)
+        peak = std::max(peak, std::abs(scratch[i]));
+
+    state.sourcePeak = peak;
+}
+
+float advanceFollower(FollowerState& state, const FollowerSettings& settings,
+                      const BlockInfo& block, const ModTiming& timing) {
+    const double sampleRate = std::max(timing.sampleRate, 1.0);
+    const int numSamples = std::max(block.numSamples, 0);
+
+    const float attack = coefficientFor(settings.attackMs, sampleRate);
+    const float release = coefficientFor(settings.releaseMs, sampleRate);
+    const int holdSamples =
+        static_cast<int>(std::max(settings.holdMs, 0.0f) * 0.001f * static_cast<float>(sampleRate));
+
+    // The peak the detector left, held flat across the block. The detection has
+    // already reduced the block to one number and what is left for the envelope
+    // is the time constant, which is why this is a run of one value rather than
+    // the waveform: it is what the fork feeds an externally driven follower.
+    const float input = std::max(state.sourcePeak, 0.0f);
+
+    for (int i = 0; i < numSamples; ++i) {
+        if (input > state.envelope) {
+            state.envelope = (attack * (state.envelope - input)) + input;
+            state.holdLeft = holdSamples;
+        } else if (state.holdLeft > 0) {
+            --state.holdLeft;
+        } else {
+            state.envelope = (release * (state.envelope - input)) + input;
+        }
+
+        state.envelope = std::clamp(state.envelope, 0.0f, 1.0f);
+    }
+
+    return state.envelope;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/param/ModFollower.hpp
+++ b/magda/engine/param/ModFollower.hpp
@@ -1,0 +1,159 @@
+#pragma once
+
+#include <span>
+
+#include "exec/RenderContext.hpp"
+#include "param/ModLfo.hpp"
+
+/**
+ * @file ModFollower.hpp
+ * @brief The envelope follower: the amplitude of something else, with an
+ *        envelope on it.
+ *
+ * The one modifier that is not a function of time. An LFO, an envelope and a
+ * random walk all answer "how far along are we"; this answers "how loud is
+ * that", and the that is audio the modifier does not own. That is the thing
+ * slice 4 could not build and the reason this one has to: a follower with no
+ * source is a modifier with nothing to follow.
+ *
+ * Two halves, and they meet at a single number per block.
+ *
+ * The detector is the source's half. It takes the block of audio the source
+ * produced, applies the follower's own input gain and its optional band limits,
+ * and reduces the whole block to one peak. Per follower rather than per source,
+ * because two followers on one track can be listening to different parts of the
+ * spectrum, which is the point of the band limits.
+ *
+ * The envelope is this half. It runs the fork's own one-pole attack, hold and
+ * release over that peak, sample by sample across the block, which is what
+ * makes a follower's attack a time rather than a block count.
+ *
+ * ## Where the source's audio comes from, and when
+ *
+ * A block behind. The engine resolves every parameter at the top of a block and
+ * then walks the ops, so the audio a follower is following does not exist yet
+ * when the follower is asked what it is worth: the source's ops have not run.
+ * What the follower reads is therefore the block before this one, deterministic
+ * and always exactly one block.
+ *
+ * The alternative is to resolve a follower's targets after its source's
+ * subgraph has rendered, which splits parameter resolution into two passes and
+ * makes the order a plan-shaped question rather than a table-shaped one. That
+ * is a structural change and it is not this slice's: the lag is bounded, it is
+ * the same lag the fork has whenever the source track is ordered after the
+ * destination, and it is written down here rather than discovered later.
+ */
+
+namespace magda::engine {
+
+/** @brief What the model says one envelope follower is. */
+struct FollowerSettings {
+    /// Applied to the source before the band limits and before detection, so
+    /// what the filters and the peak see is the gained signal. The fork holds
+    /// TE's own gain at unity and does this on the source side for the same
+    /// reason: a gain after detection cannot be band limited.
+    float gainDb = 0.0f;
+
+    /// How fast the envelope rises to a louder source, in milliseconds.
+    float attackMs = 100.0f;
+
+    /// How long it stays at a peak before it is allowed to fall, in
+    /// milliseconds. Held at the sample level, which is what makes a short hold
+    /// audible at all.
+    float holdMs = 0.0f;
+
+    /// How fast it falls to a quieter source, in milliseconds.
+    float releaseMs = 500.0f;
+
+    /// Band-limit the source before detection, so a follower can track the bass
+    /// of a track rather than the whole of it. Before detection rather than
+    /// after, because a detected level has no frequency content left to filter.
+    bool highPass = false;
+    float highPassHz = 200.0f;
+    bool lowPass = false;
+    float lowPassHz = 2000.0f;
+};
+
+/**
+ * @brief One second-order section, transposed direct form II.
+ *
+ * The filter juce::IIRFilter is, coefficient order and state layout included,
+ * because that is what the fork band-limits with: a follower that rolled off
+ * differently would be tracking a different part of the spectrum, and the two
+ * engines have to agree about which part. Its own rather than borrowed, so the
+ * engine's DSP does not reach into the UI framework.
+ */
+struct FollowerBiquad {
+    /// Normalised, in JUCE's order: feed-forward b0, b1, b2 then feedback a1,
+    /// a2, all already divided through by a0.
+    float c0 = 1.0f, c1 = 0.0f, c2 = 0.0f, c3 = 0.0f, c4 = 0.0f;
+
+    float v1 = 0.0f, v2 = 0.0f;
+
+    void reset();
+    float process(float in);
+};
+
+/** @brief A low-pass at @p frequency, on JUCE's coefficients. */
+FollowerBiquad followerLowPass(double sampleRate, double frequency);
+
+/** @brief A high-pass at @p frequency, on JUCE's coefficients. */
+FollowerBiquad followerHighPass(double sampleRate, double frequency);
+
+/** @brief Where one envelope follower has got to. */
+struct FollowerState {
+    /// The envelope itself, 0 to 1. What the modifier publishes.
+    float envelope = 0.0f;
+
+    /// Samples left before the envelope may start falling again.
+    int holdLeft = 0;
+
+    /// The band-limit filters and the cutoffs they are currently set to, so a
+    /// block only recomputes coefficients when the model has moved one.
+    FollowerBiquad highPass;
+    FollowerBiquad lowPass;
+    float highPassHz = 0.0f;
+    float lowPassHz = 0.0f;
+
+    /// The sample rate the coefficients and the time constants were worked out
+    /// at. A device swap or a sample-rate change makes both stale.
+    double sampleRate = 0.0;
+
+    /**
+     * @brief The peak the last block's detection left for this one.
+     *
+     * The whole of the one-block lag, in one number: the source renders, the
+     * detector reduces it to this, and the next block's resolve is where it is
+     * read (the file comment says why).
+     */
+    float sourcePeak = 0.0f;
+};
+
+/**
+ * @brief Reduce one block of source audio to the peak this follower detects.
+ *
+ * On the audio thread, after the source's ops have rendered. @p mono is the
+ * source's block downmixed to one channel, which is what the fork's tap hands
+ * over as well (FollowerSourceTapPlugin averages the channels).
+ *
+ * Stores the result on @p state, where the next block's advance reads it.
+ */
+void detectFollowerSource(FollowerState& state, const FollowerSettings& settings,
+                          std::span<const float> mono, double sampleRate, std::span<float> scratch);
+
+/**
+ * @brief Advance @p state over one block and publish the envelope.
+ *
+ * On the audio thread, once per block, from the table's resolution order.
+ * Returns the envelope, 0 to 1: 0 is silence at the source, which is also what
+ * the whole modulation system reads as a modifier doing nothing, so a follower
+ * with nothing to follow contributes nothing.
+ *
+ * The peak is held flat across the block, which is what the fork does with an
+ * externally fed follower: the detection already reduced the block to one
+ * number and the envelope's job is the time constant rather than the waveform.
+ */
+float advanceFollower(FollowerState& state, const FollowerSettings& settings,
+                      const BlockInfo& block, const ModTiming& timing);
+
+}  // namespace magda::engine

--- a/magda/engine/param/ModLfo.cpp
+++ b/magda/engine/param/ModLfo.cpp
@@ -30,34 +30,6 @@ float wrapPhase(float phase) {
     return phase >= 1.0f ? 0.0f : phase;
 }
 
-/**
- * @brief Where the block opens, counted in bars.
- *
- * The bar grid rather than a beat count divided by a bar's length, because the
- * two part company at a signature change: a change always starts a bar
- * (TempoMap.hpp), so two bars of four four followed by six eight puts a bar
- * line at beat eight, and eight divided by the three beats a six eight bar
- * lasts is two and two thirds. A modifier reading that opens every six eight
- * bar two thirds of the way through its cycle and stays there.
- *
- * Whole bars plus the fraction of this one that has gone by, which restarts at
- * the change and carries the denominator with it, since the beat inside a bar
- * is counted in the signature's own note value.
- *
- * Without a map there are no changes to survive, and the closed form is the
- * same number: a hand-assembled block gets the arithmetic the grid would have
- * given it.
- */
-double barPositionOf(const BlockInfo& block, const ModTiming& timing) {
-    if (block.tempo != nullptr) {
-        const auto grid = block.tempo->barsAndBeatsAt(block.startBeat);
-        return grid.bar + grid.beat / std::max(grid.numerator, 1);
-    }
-
-    const auto barBeats = 4.0 * timing.numerator / timing.denominator;
-    return block.startBeat / std::max(barBeats, 1.0e-6);
-}
-
 bool loopsInRegion(const LfoSettings& settings) {
     // A drawn curve only. The loop region is MSEG's, and the built-in
     // waveforms have no intro to play once before settling into one.
@@ -147,6 +119,16 @@ float laneValueFromRateType(int rateType) {
         std::max(rateType, static_cast<int>(magda::ModRateType::SixteenBars)) - 1);
 }
 
+double modBarPosition(const BlockInfo& block, const ModTiming& timing) {
+    if (block.tempo != nullptr) {
+        const auto grid = block.tempo->barsAndBeatsAt(block.startBeat);
+        return grid.bar + grid.beat / std::max(grid.numerator, 1);
+    }
+
+    const auto barBeats = 4.0 * timing.numerator / timing.denominator;
+    return block.startBeat / std::max(barBeats, 1.0e-6);
+}
+
 ModTiming modTimingFor(const BlockInfo& block, double sampleRate) {
     ModTiming timing;
     timing.sampleRate = sampleRate > 0.0 ? sampleRate : 44100.0;
@@ -216,7 +198,7 @@ float advanceLfo(LfoState& state, const LfoSettings& settings,
     // in phase with each other and with the bar however playback got there.
     if (settings.sync == ModSync::Transport) {
         state.cycles = settings.tempoSync
-                           ? barPositionOf(block, timing) / barFractionOf(settings.rate.rateType)
+                           ? modBarPosition(block, timing) / barFractionOf(settings.rate.rateType)
                            : block.startSeconds * hz;
     }
 

--- a/magda/engine/param/ModLfo.hpp
+++ b/magda/engine/param/ModLfo.hpp
@@ -272,6 +272,30 @@ struct ModTiming {
 ModTiming modTimingFor(const BlockInfo& block, double sampleRate);
 
 /**
+ * @brief Where @p block opens, counted in bars.
+ *
+ * The bar grid rather than a beat count divided by a bar's length, because the
+ * two part company at a signature change: a change always starts a bar
+ * (TempoMap.hpp), so two bars of four four followed by six eight puts a bar
+ * line at beat eight, and eight divided by the three beats a six eight bar
+ * lasts is two and two thirds. A modifier reading that opens every six eight
+ * bar two thirds of the way through its cycle and stays there.
+ *
+ * Whole bars plus the fraction of this one that has gone by, which restarts at
+ * the change and carries the denominator with it, since the beat inside a bar
+ * is counted in the signature's own note value.
+ *
+ * Without a map there are no changes to survive, and the closed form is the
+ * same number: a hand-assembled block gets the arithmetic the grid would have
+ * given it.
+ *
+ * Shared because every timeline-locked modifier asks it, not only the LFO: a
+ * synced random walk that stepped on a different grid from the LFO beside it
+ * would be two answers to one question.
+ */
+double modBarPosition(const BlockInfo& block, const ModTiming& timing);
+
+/**
  * @brief How much of a bar one rate type is.
  *
  * The fork's own table (ModifierCommon::getBarFraction), because a synced LFO's

--- a/magda/engine/param/ModRandom.cpp
+++ b/magda/engine/param/ModRandom.cpp
@@ -1,0 +1,164 @@
+#include "param/ModRandom.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+
+namespace magda::engine {
+
+namespace {
+
+/// The rate guard the LFO uses, and for the same reason: a modulated rate can
+/// arrive at the bottom of its range and a period is one divided by it.
+constexpr double kMinHz = 1.0e-4;
+
+/// One draw from a splitmix64 walk. Deterministic, seedable and one line, which
+/// is the whole requirement: the walk has to be the same on every run of a
+/// project and independent between two modulators in it.
+std::uint64_t nextBits(std::uint64_t& seed) {
+    seed += 0x9E3779B97F4A7C15ULL;
+    std::uint64_t z = seed;
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+    return z ^ (z >> 31);
+}
+
+/// A draw in [0, 1).
+float nextUnitFloat(std::uint64_t& seed) {
+    // The top 24 bits, which is a float's mantissa: taking the low ones would
+    // read the weakest part of the word.
+    return static_cast<float>(nextBits(seed) >> 40) / static_cast<float>(1 << 24);
+}
+
+/// The fork's S-curve (AudioFadeCurve::SCurve), which is what the smoothing
+/// control bends the phase towards. Transcribed rather than approximated: it is
+/// audible on a ramped step and the two engines have to bend it alike.
+float sCurve(float alpha) {
+    const auto quarterTurn = alpha * 0.5f * std::numbers::pi_v<float>;
+    return ((1.0f - alpha) * (1.0f - std::cos(quarterTurn))) + (alpha * std::sin(quarterTurn));
+}
+
+/// Into [0, 1), which is where a phase has to be before anything reads it.
+float wrapPhase(float phase) {
+    phase -= std::floor(phase);
+    return phase >= 1.0f ? 0.0f : phase;
+}
+
+/**
+ * @brief Take one step of the walk.
+ *
+ * The next value lands within @p stepDepth of the one before it, clipped to the
+ * output range. Clipped rather than reflected or wrapped: a walk that bounced
+ * off an end would visit the extremes more often than the middle, and one that
+ * wrapped would jump the full range from a control that says how far it may
+ * move.
+ *
+ * The half-range is half the control, which is the fork's arithmetic for a
+ * unipolar modulator: its own bipolar parameter is off, because MAGDA keeps
+ * polarity per link.
+ */
+void takeStep(RandomState& state, float stepDepth) {
+    state.previous = state.current;
+
+    const float half = std::clamp(stepDepth, 0.0f, 1.0f) * 0.5f;
+    const float low = std::max(state.current - half, 0.0f);
+    const float high = std::min(state.current + half, 1.0f);
+
+    state.current = low >= high ? low : low + (nextUnitFloat(state.seed) * (high - low));
+}
+
+}  // namespace
+
+void seedRandom(RandomState& state, std::uint64_t address) {
+    // Run through the generator once, so two modifiers at adjacent addresses do
+    // not open on adjacent numbers.
+    state.seed = address;
+    state.seed = nextBits(state.seed);
+}
+
+void restartRandom(RandomState& state, const RandomSettings& settings) {
+    // The LFO's rule: a modulator whose phase is a function of the timeline, or
+    // is simply free running, has a phase that is not a trigger's to move.
+    if (settings.sync != ModSync::Note)
+        return;
+
+    state.cycles = 0.0;
+
+    // A step as well as a phase. A restart that only moved the phase would
+    // replay the ramp towards the number the walk was already heading for,
+    // which is a retrigger that does not sound like one.
+    state.stepPending = true;
+}
+
+float advanceRandom(RandomState& state, const RandomSettings& settings, const BlockInfo& block,
+                    const ModTiming& timing) {
+    const double hz = std::max(static_cast<double>(settings.rate.hz), kMinHz);
+    const double beatsPerCycle =
+        std::max(cycleBeats(settings.rate.rateType, timing.numerator, timing.denominator), 1.0e-6);
+
+    const bool noise = settings.type == RandomShape::Noise;
+
+    // A timeline-locked walk steps on the grid rather than on how many blocks
+    // have gone by, so two of them at one rate step together. Noise has no grid
+    // to lock to: it steps once a block whatever the transport is doing.
+    if (settings.sync == ModSync::Transport && !noise) {
+        state.cycles = settings.tempoSync
+                           ? modBarPosition(block, timing) / barFractionOf(settings.rate.rateType)
+                           : block.startSeconds * hz;
+    }
+
+    const float raw = wrapPhase(static_cast<float>(state.cycles - std::floor(state.cycles)));
+
+    // Smoothing bends the phase, not the output, so it eases the ends of a
+    // ramped step and leaves a held one alone: there is nothing to ease when
+    // the value does not travel. The fork applies it here, before the wrap is
+    // looked for, and the two have to agree about where a step boundary is.
+    const float smooth = std::clamp(settings.smooth, 0.0f, 1.0f);
+    const float phase = wrapPhase(((1.0f - smooth) * raw) + (smooth * sCurve(raw)));
+
+    if (noise || state.stepPending || phase < state.phase) {
+        state.stepPending = false;
+        takeStep(state, settings.stepDepth);
+    }
+
+    const float shape = std::clamp(settings.shape, 0.0f, 1.0f);
+
+    // Noise has no step to sit inside, so what it publishes is the number it
+    // just drew. A stepped walk holds the previous number until the last
+    // @p shape of the step and travels to the new one across it, which at a
+    // shape of zero is a sample and hold a step behind and at one is a ramp all
+    // the way across.
+    float value = state.current;
+
+    if (!noise) {
+        const float travelFrom = 1.0f - shape;
+        value = phase < travelFrom
+                    ? state.previous
+                    : state.previous + ((state.current - state.previous) *
+                                        ((phase - travelFrom) / std::max(shape, 1.0e-6f)));
+    }
+
+    state.phase = phase;
+    state.value = std::clamp(value, 0.0f, 1.0f);
+
+    // Moved on after this block's value has been settled, which is the LFO's
+    // order and the fork's: the value a block renders with is the value at its
+    // first sample.
+    if (settings.sync != ModSync::Transport) {
+        const double blockSeconds =
+            static_cast<double>(std::max(block.numSamples, 0)) / std::max(timing.sampleRate, 1.0);
+        const double periodSeconds =
+            settings.tempoSync ? beatsPerCycle * 60.0 / timing.bpm : 1.0 / hz;
+
+        state.cycles += blockSeconds / std::max(periodSeconds, 1.0e-9);
+    }
+
+    // Kept bounded, so a walk left running for hours steps as precisely as one
+    // that started a moment ago.
+    if (state.cycles >= 1.0)
+        state.cycles -= std::floor(state.cycles);
+
+    return state.value;
+}
+
+}  // namespace magda::engine

--- a/magda/engine/param/ModRandom.hpp
+++ b/magda/engine/param/ModRandom.hpp
@@ -1,0 +1,163 @@
+#pragma once
+
+#include <cstdint>
+
+#include "core/ModInfo.hpp"
+#include "exec/RenderContext.hpp"
+#include "param/ModLfo.hpp"
+
+/**
+ * @file ModRandom.hpp
+ * @brief The random modulator: a walk that takes one step per cycle, and what
+ *        it does between steps.
+ *
+ * The LFO's arrangement again, and the LFO's timing exactly: rate in Hertz or
+ * as a musical division, free-running, timeline-locked or trigger-restarted,
+ * one value per block read at the block's first sample. What is different is
+ * only what sits on the phase. An LFO reads a shape at it; this reads nothing,
+ * and instead uses the phase wrapping as the moment to pick a new number.
+ *
+ * The walk is bounded rather than uniform: each step lands within
+ * @ref RandomSettings::stepDepth of the one before it, so a small depth wanders
+ * and a full one jumps anywhere in range. That is the fork's own rule and it is
+ * what makes the control mean "how far it can move" rather than "how loud".
+ *
+ * Depth and polarity stay per link, as everywhere else in this system. The
+ * fork's own depth and bipolar parameters are held at unity and off for the
+ * same reason (applyRandomProperties), which is why the walk here runs in
+ * 0 to 1 and a link is what turns it into a swing about a centre.
+ */
+
+namespace magda::engine {
+
+/** @brief What a random modulator does with its cycle. */
+enum class RandomShape : std::uint8_t {
+    /// A new number each time the cycle wraps, held or ramped across the step
+    /// according to @ref RandomSettings::shape. The rate is the step rate.
+    Stepped,
+
+    /// A new number every block. The walk and its bounds are the stepped one's
+    /// and the rate stops meaning anything, because there is no longer a step
+    /// for a rate to be the length of. Shape and smoothing go with it: both
+    /// describe what happens between one number and the next, and noise has no
+    /// between.
+    ///
+    /// The fork carries this choice and does nothing with it: its type
+    /// parameter is written and never read, so a project set to noise sounds
+    /// stepped there. Implemented rather than reproduced as the same omission,
+    /// because the model offers the control, and a control that does nothing is
+    /// worse than a difference that is written down.
+    Noise,
+};
+
+/** @brief What the model says one random modulator is. */
+struct RandomSettings {
+    RandomShape type = RandomShape::Stepped;
+
+    /// Where the phase comes from: the LFO's fold, unchanged, because the model
+    /// drives both from the same trigger-mode and tempo-sync fields.
+    ModSync sync = ModSync::Free;
+
+    magda::LFOTriggerMode trigger = magda::LFOTriggerMode::Free;
+    bool tempoSync = false;
+    LfoRate rate;
+
+    /**
+     * @brief How much of each step is spent travelling, 0 to 1.
+     *
+     * Zero holds the new value for the whole step, which is a sample-and-hold.
+     * One ramps from the previous value to the new one across the whole of it.
+     * In between, the step holds and then ramps over the last @ref shape of
+     * itself, which is the fork's own reading of the control.
+     */
+    float shape = 0.0f;
+
+    /// How much the phase ramp is bent towards an S-curve before anything reads
+    /// it, 0 to 1. Applied to the phase rather than to the output, so it eases
+    /// the ends of a ramped step and does nothing at all to a held one.
+    float smooth = 0.0f;
+
+    /// How far one step can move from the last, 0 to 1. The half-range of the
+    /// window the next value is drawn from, clipped to the output range, so a
+    /// walk near an end has less room on that side and the same amount on the
+    /// other.
+    float stepDepth = 1.0f;
+
+    /// Whether this modulator ignores triggers from where it lives, on the
+    /// LFO's terms.
+    bool skipNativeResync = false;
+};
+
+/**
+ * @brief Where one random modulator has got to.
+ *
+ * No gate here, and its absence is deliberate. The LFO and the envelope both
+ * have one that a trigger can shut; the fork's random modifier resyncs on a
+ * note and has no gate parameter at all, so an audio-triggered one keeps
+ * walking between hits rather than resting at zero. A gate added here would be
+ * a difference in every project that has one, so a trigger restarts this and
+ * nothing shuts it.
+ */
+struct RandomState {
+    /// Cycles since the run began, fractional and monotonic, exactly as the
+    /// LFO's: the step boundary is where its fractional part wraps.
+    double cycles = 0.0;
+
+    /// The phase the step was read at, after smoothing. Published for the
+    /// editor's dot, and compared against to find the wrap.
+    float phase = 0.0f;
+
+    float value = 0.0f;
+
+    /// The two ends of the current step. A ramped step travels from the first
+    /// to the second; a held one sits on the second.
+    float previous = 0.5f;
+    float current = 0.5f;
+
+    /// A restart asked for a step and the block has not happened yet. The
+    /// trigger arrives between blocks, and taking the step where it lands would
+    /// draw a number that the resolve about to run has no way of reaching: the
+    /// step boundary is a thing blocks have, so the request waits for one.
+    bool stepPending = false;
+
+    /**
+     * @brief The state of the walk's own generator.
+     *
+     * Its own rather than a shared one, so two random modulators in a project
+     * are independent and one project renders the same way twice. The fork
+     * seeds from the clock and cannot promise either, which is why a parity
+     * case here compares the structure of the walk rather than its numbers.
+     */
+    std::uint64_t seed = 0;
+};
+
+/**
+ * @brief Seed @p state's generator from the address of the modifier holding it.
+ *
+ * Off the audio thread, when the state is created. From the address rather than
+ * from a counter, so the walk a modifier takes is the same one every time the
+ * session opens: a project that renders differently on the second run because
+ * its modifiers were prepared in another order is not reproducible.
+ */
+void seedRandom(RandomState& state, std::uint64_t address);
+
+/**
+ * @brief Restart @p state, as a trigger does.
+ *
+ * The phase goes back to the top, which takes the next step immediately.
+ * Refused when the modulator's phase is not its own to restart, on the LFO's
+ * terms: a free-running or timeline-locked one ignores the notes going past it.
+ */
+void restartRandom(RandomState& state, const RandomSettings& settings);
+
+/**
+ * @brief Advance @p state over one block and publish what @p settings says.
+ *
+ * On the audio thread, once per block. Returns the output, 0 to 1. The value
+ * published is the one the block opens on and the ramp is moved on afterwards,
+ * which is the LFO's order and the fork's.
+ */
+float advanceRandom(RandomState& state, const RandomSettings& settings, const BlockInfo& block,
+                    const ModTiming& timing);
+
+}  // namespace magda::engine

--- a/magda/engine/param/ModRuntime.cpp
+++ b/magda/engine/param/ModRuntime.cpp
@@ -7,11 +7,108 @@
 
 namespace magda::engine {
 
+namespace {
+
+/// What the model said triggers this modifier. One field under four names,
+/// because each kind's settings carry their own copy of it.
+magda::LFOTriggerMode triggerOf(const ParamModifier& modifier) {
+    switch (modifier.kind) {
+        case ModKind::Lfo:
+            return modifier.lfo.trigger;
+        case ModKind::Adsr:
+            return modifier.adsr.trigger;
+        case ModKind::Random:
+            return modifier.random.trigger;
+        case ModKind::Follower:
+            break;
+    }
+    return magda::LFOTriggerMode::Free;
+}
+
+/// Whether a trigger reaching this modifier owns a gate as well as a phase.
+///
+/// Three answers over four kinds. An LFO is gated only if the model asked for
+/// it, because a free-running one that a note silenced between hits would be an
+/// LFO nobody wrote. An envelope is always gated by its trigger while it is in
+/// note mode: the gate is the whole of what an envelope is, and in the other
+/// modes the gate comes from somewhere a trigger cannot reach. A random walk
+/// and a follower have no gate at all.
+bool gatedByTrigger(const ParamModifier& modifier) {
+    switch (modifier.kind) {
+        case ModKind::Lfo:
+            return modifier.lfo.gateOnTrigger;
+        case ModKind::Adsr:
+            return modifier.adsr.sync == ModSync::Note;
+        case ModKind::Random:
+        case ModKind::Follower:
+            return false;
+    }
+    return false;
+}
+
+/// Whether this modifier belongs to another track's detector, and therefore
+/// hears nothing from where it lives. One flag under four names, because each
+/// kind's settings carry their own copy of what the model said.
+bool drivenFromElsewhere(const ParamModifier& modifier) {
+    switch (modifier.kind) {
+        case ModKind::Lfo:
+            return modifier.lfo.skipNativeResync;
+        case ModKind::Adsr:
+            return modifier.adsr.skipNativeResync;
+        case ModKind::Random:
+            return modifier.random.skipNativeResync;
+        case ModKind::Follower:
+            // A follower is not triggered at all, so there is nothing for the
+            // flag to suppress. Refusing here as well would be the same answer
+            // by a longer route.
+            return false;
+    }
+    return false;
+}
+
+/// Notes are counted on whichever state this kind keeps its gate in, so the
+/// gate shuts when the last one lifts rather than on the first note off.
+int* heldNotesOf(ModState& state, const ParamModifier& modifier) {
+    switch (modifier.kind) {
+        case ModKind::Lfo:
+            return &state.lfo.heldNotes;
+        case ModKind::Adsr:
+            return &state.adsr.heldNotes;
+        case ModKind::Random:
+        case ModKind::Follower:
+            return nullptr;
+    }
+    return nullptr;
+}
+
+/// Shut or open whichever gate this kind has.
+void applyGate(ModState& state, const ParamModifier& modifier, bool gated) {
+    switch (modifier.kind) {
+        case ModKind::Lfo:
+            state.lfo.gated = gated;
+            state.lfo.started = true;
+            break;
+        case ModKind::Adsr:
+            state.adsr.gated = gated;
+            state.adsr.started = true;
+            break;
+        case ModKind::Random:
+        case ModKind::Follower:
+            break;
+    }
+}
+
+}  // namespace
+
 void ModRuntime::reset() {
     states_.clear();
     values_.clear();
     keys_.clear();
     kinds_.clear();
+    listened_.clear();
+    listeners_.clear();
+    listenerOffsets_.clear();
+    detectScratch_.clear();
     fingerprint_ = 0;
     sampleRate_ = 44100.0;
     timing_ = ModTiming{};
@@ -58,14 +155,93 @@ void ModRuntime::prepare(const ParamTable& table, const RenderContext& context,
             }
         }
 
-        if (state == nullptr)
+        if (state == nullptr) {
             state = std::make_shared<ModState>();
+
+            // A walk's generator is seeded from the modifier's own address, so
+            // the numbers a project draws are the same on every run of it and
+            // two modifiers never draw the same sequence. Only on a fresh
+            // state: a carried one is mid-walk and reseeding would restart it.
+            seedRandom(state->random, ParamKeyHash{}(modifier.key));
+        }
 
         states_.push_back(std::move(state));
         values_.push_back(modifier.value);
         keys_.push_back(modifier.key);
         kinds_.push_back(modifier.kind);
     }
+
+    buildListenerRouting(table);
+
+    // One block of room for band-limited detection, which is the only place a
+    // modifier touches a buffer at all.
+    detectScratch_.assign(static_cast<std::size_t>(std::max(context.maxBlockSize, 0)), 0.0f);
+}
+
+void ModRuntime::buildListenerRouting(const ParamTable& table) {
+    // The tracks, deduplicated and in order, then the modifiers listening to
+    // each. Two passes over a list that is almost always empty, off the audio
+    // thread, so the block path is an index into a flat arena.
+    for (const auto& modifier : table.modifiers) {
+        if (modifier.source == magda::INVALID_TRACK_ID)
+            continue;
+
+        if (std::find(listened_.begin(), listened_.end(), modifier.source) == listened_.end())
+            listened_.push_back(modifier.source);
+    }
+
+    if (listened_.empty())
+        return;
+
+    listenerOffsets_.assign(listened_.size() + 1, 0);
+
+    for (std::size_t t = 0; t < listened_.size(); ++t) {
+        listenerOffsets_[t] = static_cast<int>(listeners_.size());
+
+        for (std::size_t i = 0; i < table.modifiers.size(); ++i)
+            if (table.modifiers[i].source == listened_[t])
+                listeners_.push_back(static_cast<int>(i));
+    }
+
+    listenerOffsets_.back() = static_cast<int>(listeners_.size());
+}
+
+std::span<const int> ModRuntime::listenersOf(magda::TrackId track) const {
+    const auto found = std::find(listened_.begin(), listened_.end(), track);
+    if (found == listened_.end())
+        return {};
+
+    const auto t = static_cast<std::size_t>(std::distance(listened_.begin(), found));
+    const auto first = static_cast<std::size_t>(listenerOffsets_[t]);
+    const auto last = static_cast<std::size_t>(listenerOffsets_[t + 1]);
+
+    return std::span<const int>{listeners_}.subspan(first, last - first);
+}
+
+ModListen ModRuntime::listensFor(int index, const ParamTable& table) const {
+    if (index < 0 || index >= static_cast<int>(table.modifiers.size()))
+        return ModListen::Nothing;
+
+    const auto& modifier = table.modifiers[static_cast<std::size_t>(index)];
+    if (!modifier.enabled || modifier.source == magda::INVALID_TRACK_ID)
+        return ModListen::Nothing;
+
+    // A follower is its source and nothing else, whatever its trigger mode
+    // says: the trigger fields belong to the kinds that have a phase.
+    if (modifier.kind == ModKind::Follower)
+        return ModListen::Audio;
+
+    switch (triggerOf(modifier)) {
+        case magda::LFOTriggerMode::MIDI:
+            return ModListen::Midi;
+        case magda::LFOTriggerMode::Audio:
+            return ModListen::Audio;
+        case magda::LFOTriggerMode::Free:
+        case magda::LFOTriggerMode::Transport:
+            break;
+    }
+
+    return ModListen::Nothing;
 }
 
 void ModRuntime::beginBlock(const BlockInfo& block) {
@@ -89,18 +265,52 @@ void ModRuntime::advance(int index, const ParamTable& table, const LfoRate& rate
         return;
     }
 
-    if (modifier.kind != ModKind::Lfo) {
-        // No engine yet (#2120). The model's own reading, held, which is what
-        // every modifier published before this slice.
-        values_[static_cast<std::size_t>(index)] = modifier.value;
-        return;
+    auto& out = values_[static_cast<std::size_t>(index)];
+
+    switch (modifier.kind) {
+        case ModKind::Lfo: {
+            auto settings = modifier.lfo;
+            settings.rate = rate;
+            out = advanceLfo(state->lfo, settings, table.modCurveFor(index), block, timing_);
+            break;
+        }
+
+        case ModKind::Adsr:
+            // No rate. An envelope's stage lengths are times rather than a
+            // frequency, and the one lane a modifier exposes describes a
+            // frequency, so there is nothing here for it to mean.
+            out = advanceAdsr(state->adsr, modifier.adsr, block, timing_);
+            break;
+
+        case ModKind::Random: {
+            auto settings = modifier.random;
+            settings.rate = rate;
+            out = advanceRandom(state->random, settings, block, timing_);
+            break;
+        }
+
+        case ModKind::Follower:
+            // The peak its detector left on the last block. No rate either:
+            // what a follower runs at is whatever its source is doing.
+            out = advanceFollower(state->follower, modifier.follower, block, timing_);
+            break;
     }
+}
 
-    auto settings = modifier.lfo;
-    settings.rate = rate;
+void ModRuntime::detectSource(int index, const ParamTable& table, std::span<const float> mono) {
+    auto* state = mutableState(index);
+    if (state == nullptr || index >= static_cast<int>(table.modifiers.size()))
+        return;
 
-    values_[static_cast<std::size_t>(index)] =
-        advanceLfo(state->lfo, settings, table.modCurveFor(index), block, timing_);
+    const auto& modifier = table.modifiers[static_cast<std::size_t>(index)];
+
+    // Only a follower listens, and only one the model has switched on: a
+    // disabled modifier is a modifier that is not there, and detecting for it
+    // would leave an envelope primed for the block it is switched back on in.
+    if (modifier.kind != ModKind::Follower || !modifier.enabled)
+        return;
+
+    detectFollowerSource(state->follower, modifier.follower, mono, sampleRate_, detectScratch_);
 }
 
 float ModRuntime::value(int index) const {
@@ -129,30 +339,52 @@ int ModRuntime::indexOf(const ParamKey& key) const {
     return found == keys_.end() ? -1 : static_cast<int>(std::distance(keys_.begin(), found));
 }
 
+void ModRuntime::restart(ModState& state, const ParamModifier& modifier, bool fromZero) {
+    switch (modifier.kind) {
+        case ModKind::Lfo:
+            restartLfo(state.lfo, modifier.lfo);
+            break;
+        case ModKind::Adsr:
+            restartAdsr(state.adsr, modifier.adsr, fromZero);
+            break;
+        case ModKind::Random:
+            restartRandom(state.random, modifier.random);
+            break;
+        case ModKind::Follower:
+            // Nothing to restart. A follower's output is a level, and a level
+            // has no phase a trigger could move it to.
+            break;
+    }
+}
+
 void ModRuntime::noteOn(int index, const ParamTable& table) {
     auto* state = mutableState(index);
     if (state == nullptr || index >= static_cast<int>(table.modifiers.size()))
         return;
 
-    const auto& settings = table.modifiers[static_cast<std::size_t>(index)].lfo;
+    const auto& modifier = table.modifiers[static_cast<std::size_t>(index)];
 
-    // A cross-track sidechain LFO follows its source track and nothing else:
-    // not its phase, and not its gate either. Retriggering it from the track
-    // it ducks is the bug the fork's flag exists to prevent, and so is gating
-    // it from there, which flaps on every note the destination plays.
+    // A cross-track sidechain modifier follows its source track and nothing
+    // else: not its phase, and not its gate either. Retriggering it from the
+    // track it ducks is the bug the fork's flag exists to prevent, and so is
+    // gating it from there, which flaps on every note the destination plays.
     //
     // The fork suppresses the two separately, because its flags are set apart
     // and the combination is prevented rather than refused. Here the policy is
     // the guard: a modifier driven from elsewhere does not hear this at all.
-    if (settings.skipNativeResync)
+    if (drivenFromElsewhere(modifier))
         return;
 
-    restartLfo(state->lfo, settings);
+    // From where it is rather than from zero. A gap is what a cross-track
+    // trigger asks for and this is not one: a note arriving under a held note
+    // should not silence the envelope for a block on the way up.
+    restart(*state, modifier, false);
 
-    if (settings.gateOnTrigger) {
-        ++state->lfo.heldNotes;
-        state->lfo.gated = false;
-        state->lfo.started = true;
+    if (gatedByTrigger(modifier)) {
+        if (auto* held = heldNotesOf(*state, modifier))
+            ++*held;
+
+        applyGate(*state, modifier, false);
     }
 }
 
@@ -161,14 +393,17 @@ void ModRuntime::noteOff(int index, const ParamTable& table) {
     if (state == nullptr || index >= static_cast<int>(table.modifiers.size()))
         return;
 
-    const auto& settings = table.modifiers[static_cast<std::size_t>(index)].lfo;
-    if (settings.skipNativeResync || !settings.gateOnTrigger)
+    const auto& modifier = table.modifiers[static_cast<std::size_t>(index)];
+    if (drivenFromElsewhere(modifier) || !gatedByTrigger(modifier))
         return;
 
-    state->lfo.heldNotes = std::max(0, state->lfo.heldNotes - 1);
-    if (state->lfo.heldNotes == 0)
-        state->lfo.gated = true;
-    state->lfo.started = true;
+    auto* held = heldNotesOf(*state, modifier);
+    if (held == nullptr)
+        return;
+
+    *held = std::max(0, *held - 1);
+    if (*held == 0)
+        applyGate(*state, modifier, true);
 }
 
 void ModRuntime::allNotesOff(int index, const ParamTable& table) {
@@ -176,13 +411,14 @@ void ModRuntime::allNotesOff(int index, const ParamTable& table) {
     if (state == nullptr || index >= static_cast<int>(table.modifiers.size()))
         return;
 
-    const auto& settings = table.modifiers[static_cast<std::size_t>(index)].lfo;
-    if (settings.skipNativeResync || !settings.gateOnTrigger)
+    const auto& modifier = table.modifiers[static_cast<std::size_t>(index)];
+    if (drivenFromElsewhere(modifier) || !gatedByTrigger(modifier))
         return;
 
-    state->lfo.heldNotes = 0;
-    state->lfo.gated = true;
-    state->lfo.started = true;
+    if (auto* held = heldNotesOf(*state, modifier))
+        *held = 0;
+
+    applyGate(*state, modifier, true);
 }
 
 void ModRuntime::trigger(int index, const ParamTable& table, bool forceZero) {
@@ -190,32 +426,46 @@ void ModRuntime::trigger(int index, const ParamTable& table, bool forceZero) {
     if (state == nullptr || index >= static_cast<int>(table.modifiers.size()))
         return;
 
-    const auto& settings = table.modifiers[static_cast<std::size_t>(index)].lfo;
-
-    state->lfo.gated = false;
-    state->lfo.started = true;
-    restartLfo(state->lfo, settings);
+    const auto& modifier = table.modifiers[static_cast<std::size_t>(index)];
 
     // The forced zero stands in for the gap a gated retrigger leaves, so the
     // device sees a transition rather than a continuation. Never for a level
     // curve: there, zero output is full level, and forcing one in the middle
     // of a duck pops the gain up for a block, which is a click on every hit.
-    //
+    const bool gap = forceZero && !(modifier.kind == ModKind::Lfo && modifier.lfo.invertOutput);
+
+    applyGate(*state, modifier, false);
+    restart(*state, modifier, gap);
+
     // Latched rather than published. A trigger arrives inside a block whose
     // parameters have already been resolved, so a value written here would be
     // overwritten by the next block's advance before any device read it; the
     // latch is what makes the gap reach one (LfoState::forceZero).
-    if (forceZero && !settings.invertOutput)
-        state->lfo.forceZero = true;
-}
-
-void ModRuntime::setGated(int index, bool gated) {
-    auto* state = mutableState(index);
-    if (state == nullptr)
+    if (!gap)
         return;
 
-    state->lfo.gated = gated;
-    state->lfo.started = true;
+    switch (modifier.kind) {
+        case ModKind::Lfo:
+            state->lfo.forceZero = true;
+            break;
+        case ModKind::Adsr:
+            state->adsr.forceZero = true;
+            break;
+        case ModKind::Random:
+        case ModKind::Follower:
+            // Neither has a gate, so neither has a gap to stand in for: a walk
+            // that blanked for a block on every hit would be a hole the fork
+            // does not have.
+            break;
+    }
+}
+
+void ModRuntime::setGated(int index, const ParamTable& table, bool gated) {
+    auto* state = mutableState(index);
+    if (state == nullptr || index >= static_cast<int>(table.modifiers.size()))
+        return;
+
+    applyGate(*state, table.modifiers[static_cast<std::size_t>(index)], gated);
 }
 
 }  // namespace magda::engine

--- a/magda/engine/param/ModRuntime.cpp
+++ b/magda/engine/param/ModRuntime.cpp
@@ -49,7 +49,7 @@ bool gatedByTrigger(const ParamModifier& modifier) {
 /// Whether this modifier belongs to another track's detector, and therefore
 /// hears nothing from where it lives. One flag under four names, because each
 /// kind's settings carry their own copy of what the model said.
-bool drivenFromElsewhere(const ParamModifier& modifier) {
+bool isDrivenFromElsewhere(const ParamModifier& modifier) {
     switch (modifier.kind) {
         case ModKind::Lfo:
             return modifier.lfo.skipNativeResync;
@@ -218,6 +218,13 @@ std::span<const int> ModRuntime::listenersOf(magda::TrackId track) const {
     return std::span<const int>{listeners_}.subspan(first, last - first);
 }
 
+bool ModRuntime::drivenFromElsewhere(int index, const ParamTable& table) const {
+    if (index < 0 || index >= static_cast<int>(table.modifiers.size()))
+        return false;
+
+    return isDrivenFromElsewhere(table.modifiers[static_cast<std::size_t>(index)]);
+}
+
 ModListen ModRuntime::listensFor(int index, const ParamTable& table) const {
     if (index < 0 || index >= static_cast<int>(table.modifiers.size()))
         return ModListen::Nothing;
@@ -372,7 +379,7 @@ void ModRuntime::noteOn(int index, const ParamTable& table) {
     // The fork suppresses the two separately, because its flags are set apart
     // and the combination is prevented rather than refused. Here the policy is
     // the guard: a modifier driven from elsewhere does not hear this at all.
-    if (drivenFromElsewhere(modifier))
+    if (isDrivenFromElsewhere(modifier))
         return;
 
     // From where it is rather than from zero. A gap is what a cross-track
@@ -394,7 +401,7 @@ void ModRuntime::noteOff(int index, const ParamTable& table) {
         return;
 
     const auto& modifier = table.modifiers[static_cast<std::size_t>(index)];
-    if (drivenFromElsewhere(modifier) || !gatedByTrigger(modifier))
+    if (isDrivenFromElsewhere(modifier) || !gatedByTrigger(modifier))
         return;
 
     auto* held = heldNotesOf(*state, modifier);
@@ -412,7 +419,7 @@ void ModRuntime::allNotesOff(int index, const ParamTable& table) {
         return;
 
     const auto& modifier = table.modifiers[static_cast<std::size_t>(index)];
-    if (drivenFromElsewhere(modifier) || !gatedByTrigger(modifier))
+    if (isDrivenFromElsewhere(modifier) || !gatedByTrigger(modifier))
         return;
 
     if (auto* held = heldNotesOf(*state, modifier))

--- a/magda/engine/param/ModRuntime.hpp
+++ b/magda/engine/param/ModRuntime.hpp
@@ -172,6 +172,22 @@ class ModRuntime {
     /// three lists that could disagree about who is on which.
     ModListen listensFor(int index, const ParamTable& table) const;
 
+    /**
+     * @brief Whether modifier @p index is driven by a track other than its own.
+     *
+     * The two kinds of listener a source's tap feeds, and they take a trigger
+     * through different doors. One living on the source hears its notes as its
+     * own: it counts them, and the gate shuts when the last one lifts. One
+     * living somewhere else is following that track rather than playing it, so
+     * the note-counting path refuses it outright and @ref trigger is the way
+     * in, which is the fork's arrangement too (SidechainMonitorPlugin fires
+     * triggerSidechain and does nothing at all on note-off).
+     *
+     * Exposed because the executor holds the tap and cannot otherwise tell the
+     * two apart.
+     */
+    bool drivenFromElsewhere(int index, const ParamTable& table) const;
+
     /// What modifier @p index published this block, or the model's own value
     /// for one nothing has advanced.
     float value(int index) const;

--- a/magda/engine/param/ModRuntime.hpp
+++ b/magda/engine/param/ModRuntime.hpp
@@ -2,10 +2,15 @@
 
 #include <cstdint>
 #include <memory>
+#include <span>
 #include <vector>
 
 #include "exec/RenderContext.hpp"
+#include "param/ModAdsr.hpp"
+#include "param/ModFollower.hpp"
 #include "param/ModLfo.hpp"
+#include "param/ModRandom.hpp"
+#include "param/ModSources.hpp"
 #include "param/ParamKey.hpp"
 
 /**
@@ -31,31 +36,50 @@
  * ## Where a trigger comes from
  *
  * Two of the three trigger modes need something outside the parameter system
- * to say when. A note-triggered modifier is driven by the MIDI reaching the
- * scope it lives in, and an audio-triggered or cross-track one by the level
- * detector watching its source. Neither exists in the native engine yet, so
- * the trigger calls below are the shape those feeds will use rather than
- * something the executor calls today.
+ * to say when, and both feeds are wired here (#2120).
+ *
+ * A note-triggered modifier is driven by the MIDI reaching the scope it lives
+ * in, and that MIDI is known before the block resolves: the ops that produce it
+ * read clips and input queues rather than audio, so the executor renders them
+ * first and the notes in a block reach the modifiers of that same block
+ * (PlanExecutor's MIDI prefix).
+ *
+ * An audio-triggered one is driven by the level of the track it watches, and
+ * that is not known before the block resolves, because the level is what the
+ * ops are about to produce. It arrives one block late, always exactly one, and
+ * that is a property of resolving parameters at the top of a block rather than
+ * an accident (ModFollower.hpp weighs the alternative).
  *
  * The transport mode needs nothing: a timeline-locked modifier is a function
- * of where the block is, and that is wired. The rest arrive with the slice
- * that has to solve the same problem for the ADSR's gate and the envelope
- * follower's input (#2120), because those cannot be built without it.
+ * of where the block is.
+ *
+ * ## What a trigger means depends on the kind
+ *
+ * Four engines and three answers. An LFO restarts its phase, and gates as well
+ * if the model asked it to. An envelope is nothing but a gate, so a trigger
+ * opens it and the last note lifting shuts it. A random walk restarts and has
+ * no gate at all, which is the fork's own shape. A follower has neither: its
+ * input is a level, and a level has nothing to retrigger.
  */
 
 namespace magda::engine {
 
 struct ParamTable;
+struct ParamModifier;
 
 /**
  * @brief Where one modifier has got to.
  *
- * One kind runs today. The rest are carried as a value the table published and
- * hold it, which is what every modifier did before this slice; their engines
- * arrive in #2120 and their state joins this struct there.
+ * All four kinds, side by side, for the reason ParamModifier holds four
+ * settings structs: exactly one is live and a state is a few dozen bytes, so
+ * the padding buys a flat struct that carries by address without a discriminant
+ * to check first.
  */
 struct ModState {
     LfoState lfo;
+    AdsrState adsr;
+    RandomState random;
+    FollowerState follower;
 };
 
 /**
@@ -113,12 +137,40 @@ class ModRuntime {
      *
      * On the audio thread, from the table's resolution order. @p rate is what
      * its Rate parameter resolved to this block, which is a frequency or a
-     * division ordinal depending on whether the modifier is tempo synced.
-     *
-     * A modifier of a kind that has no engine yet publishes the value the
-     * table carries, which is the model's own reading of it.
+     * division ordinal depending on whether the modifier is tempo synced. Only
+     * the two kinds that have a rate read it.
      */
     void advance(int index, const ParamTable& table, const LfoRate& rate, const BlockInfo& block);
+
+    /**
+     * @brief Hand modifier @p index the block its source just rendered.
+     *
+     * On the audio thread, after the source's ops have run and before the next
+     * block resolves. Only a follower has anything to do with it; everything
+     * else ignores it, so the caller can offer a track's output to every
+     * modifier listening to that track without asking what kind each is.
+     *
+     * @p mono is the source's block downmixed to one channel. The detection
+     * happens here rather than at the next resolve because the audio is only
+     * valid until the next block overwrites the buffer it is in.
+     */
+    void detectSource(int index, const ParamTable& table, std::span<const float> mono);
+
+    /// Every modifier listening to track @p track, for the executor to offer
+    /// that track's signal to. Off the audio thread: it is built at prepare and
+    /// read by index on the block path.
+    std::span<const int> listenersOf(magda::TrackId track) const;
+
+    /// The tracks anything in this runtime listens to.
+    std::span<const magda::TrackId> listenedTracks() const {
+        return listened_;
+    }
+
+    /// What modifier @p index listens to its source for, so a note reaches the
+    /// modifiers waiting for one and a level reaches the modifiers waiting for
+    /// that. One list of listeners per track and this to sort them, rather than
+    /// three lists that could disagree about who is on which.
+    ModListen listensFor(int index, const ParamTable& table) const;
 
     /// What modifier @p index published this block, or the model's own value
     /// for one nothing has advanced.
@@ -136,12 +188,14 @@ class ModRuntime {
      * @brief A trigger from where the modifier lives.
      *
      * A note-on on the stream the modifier's own scope plays. Restarts the
-     * phase and, where the modifier is gated by its trigger, opens the gate
-     * and counts the note as held.
+     * phase, and opens the gate where the modifier has one that its trigger
+     * owns: an LFO the model asked to be gated, and an envelope, whose gate is
+     * the whole of what it is. A random walk restarts and is not gated; a
+     * follower does neither.
      *
      * Refused when the modifier belongs to another track's monitor
-     * (LfoSettings::skipNativeResync): a cross-track sidechain LFO follows its
-     * source and must not be retriggered by whatever the track it ducks
+     * (LfoSettings::skipNativeResync): a cross-track sidechain modifier follows
+     * its source and must not be retriggered by whatever the track it ducks
      * happens to be playing.
      */
     void noteOn(int index, const ParamTable& table);
@@ -158,9 +212,9 @@ class ModRuntime {
     /**
      * @brief A trigger from somewhere else.
      *
-     * What the source track's monitor does to a cross-track sidechain LFO, and
-     * the one path skipNativeResync does not refuse: it is the trigger the
-     * modifier exists to follow.
+     * What the source track's level detector does to a cross-track sidechain
+     * modifier, and the one path skipNativeResync does not refuse: it is the
+     * trigger the modifier exists to follow.
      *
      * @p forceZero publishes a zero for the trigger block, so the device sees
      * the gap a gated retrigger would have left. Never for a level curve,
@@ -170,11 +224,19 @@ class ModRuntime {
     void trigger(int index, const ParamTable& table, bool forceZero = true);
 
     /// Shut or open the gate directly, which is what an audio trigger does
-    /// between hits.
-    void setGated(int index, bool gated);
+    /// between hits. Ignored by the kinds that have no gate.
+    void setGated(int index, const ParamTable& table, bool gated);
 
   private:
     ModState* mutableState(int index);
+
+    /// Work out which modifiers listen to which track, once per prepare.
+    void buildListenerRouting(const ParamTable& table);
+
+    /// Send @p state back to the top, whatever kind it is. @p fromZero is what
+    /// a cross-track trigger asks for, and only the envelope has anywhere to
+    /// put it: an LFO's gap is a latch and a walk has none at all.
+    static void restart(ModState& state, const ParamModifier& modifier, bool fromZero);
 
     /// Shared rather than owned outright, so an epoch being replaced and the
     /// one replacing it are the same LFO rather than two copies of it. Only
@@ -189,6 +251,20 @@ class ModRuntime {
     /// The addresses the states are held at, for the carry and for indexOf.
     std::vector<ParamKey> keys_;
     std::vector<ModKind> kinds_;
+
+    /// Which modifiers listen to which track: listeners_[listenerOffsets_[t],
+    /// listenerOffsets_[t + 1]) are the indices listening to listened_[t]. One
+    /// arena and a parallel list of tracks, because almost no project has a
+    /// listening modifier at all and a map keyed by track would be a lookup per
+    /// block for it.
+    std::vector<magda::TrackId> listened_;
+    std::vector<int> listeners_;
+    std::vector<int> listenerOffsets_;
+
+    /// Room for one block of band-limited detection, shared by every follower
+    /// because they run one at a time. Sized at prepare, so the block path
+    /// never allocates.
+    std::vector<float> detectScratch_;
 
     std::uint64_t fingerprint_ = 0;
     double sampleRate_ = 44100.0;

--- a/magda/engine/param/ModSources.cpp
+++ b/magda/engine/param/ModSources.cpp
@@ -2,13 +2,15 @@
 
 namespace magda::engine {
 
-void collectModulationSources(const std::vector<magda::ChainElement>& elements,
-                              magda::TrackId ownTrack, std::set<magda::TrackId>& out) {
+void collectModulationTaps(const std::vector<magda::ChainElement>& elements,
+                           magda::TrackId ownTrack, std::set<ModTap>& out,
+                           std::set<magda::TrackId>& notes) {
     for (const auto& element : elements) {
         if (magda::isDevice(element)) {
             const auto& device = magda::getDevice(element);
-            collectModulationSources(device.mods, sidechainSourceOf(device.sidechain), ownTrack,
-                                     out);
+            const auto source = sidechainSourceOf(device.sidechain);
+            collectModulationTaps(device.mods, source, ownTrack, out);
+            collectNoteSources(device.mods, source, ownTrack, notes);
         } else if (magda::isRack(element)) {
             const auto& rack = magda::getRack(element);
             const auto source = sidechainSourceOf(rack.sidechain);
@@ -18,32 +20,38 @@ void collectModulationSources(const std::vector<magda::ChainElement>& elements,
             // sidechain is a modulation source rather than a signal one, and
             // "modulation is not topology" was true of the mix and false of the
             // dependency, which is what carrying it here settles.
-            collectModulationSources(rack.mods, source, ownTrack, out);
+            collectModulationTaps(rack.mods, source, ownTrack, out);
+            collectNoteSources(rack.mods, source, ownTrack, notes);
 
             // A rack's chains inherit nothing: a device inside a rack hears its
             // own sidechain, and the rack's is the rack's. The fork resolves it
             // the same way, per scope rather than per subtree.
             for (const auto& chain : rack.chains)
-                collectModulationSources(chain.elements, ownTrack, out);
+                collectModulationTaps(chain.elements, ownTrack, out, notes);
         }
     }
 }
 
-void collectModulationSources(const magda::TrackInfo& track, std::set<magda::TrackId>& out) {
+void collectModulationTaps(const magda::TrackInfo& track, std::set<ModTap>& out,
+                           std::set<magda::TrackId>& notes) {
     // The track's own modifiers have no sidechain of their own to read: a
     // sidechain is a property of a device or a rack, and a track scope is
     // neither, so they listen to the track they live on.
-    collectModulationSources(track.mods, magda::INVALID_TRACK_ID, track.id, out);
+    collectModulationTaps(track.mods, magda::INVALID_TRACK_ID, track.id, out);
+    collectNoteSources(track.mods, magda::INVALID_TRACK_ID, track.id, notes);
 
-    collectModulationSources(track.chain.fxChainElements, track.id, out);
+    collectModulationTaps(track.chain.fxChainElements, track.id, out, notes);
 
-    for (const auto& element : track.chain.postFxChainElements)
-        collectModulationSources(element.device.mods, sidechainSourceOf(element.device.sidechain),
-                                 track.id, out);
+    const auto flat = [&](const auto& section) {
+        for (const auto& element : section) {
+            const auto source = sidechainSourceOf(element.device.sidechain);
+            collectModulationTaps(element.device.mods, source, track.id, out);
+            collectNoteSources(element.device.mods, source, track.id, notes);
+        }
+    };
 
-    for (const auto& element : track.chain.mixerAnalysisElements)
-        collectModulationSources(element.device.mods, sidechainSourceOf(element.device.sidechain),
-                                 track.id, out);
+    flat(track.chain.postFxChainElements);
+    flat(track.chain.mixerAnalysisElements);
 }
 
 }  // namespace magda::engine

--- a/magda/engine/param/ModSources.cpp
+++ b/magda/engine/param/ModSources.cpp
@@ -1,0 +1,49 @@
+#include "param/ModSources.hpp"
+
+namespace magda::engine {
+
+void collectModulationSources(const std::vector<magda::ChainElement>& elements,
+                              magda::TrackId ownTrack, std::set<magda::TrackId>& out) {
+    for (const auto& element : elements) {
+        if (magda::isDevice(element)) {
+            const auto& device = magda::getDevice(element);
+            collectModulationSources(device.mods, sidechainSourceOf(device.sidechain), ownTrack,
+                                     out);
+        } else if (magda::isRack(element)) {
+            const auto& rack = magda::getRack(element);
+            const auto source = sidechainSourceOf(rack.sidechain);
+
+            // The rack's own modifiers hear the rack's sidechain. This is the
+            // edge the plan compiler used to report as unrepresentable: a rack
+            // sidechain is a modulation source rather than a signal one, and
+            // "modulation is not topology" was true of the mix and false of the
+            // dependency, which is what carrying it here settles.
+            collectModulationSources(rack.mods, source, ownTrack, out);
+
+            // A rack's chains inherit nothing: a device inside a rack hears its
+            // own sidechain, and the rack's is the rack's. The fork resolves it
+            // the same way, per scope rather than per subtree.
+            for (const auto& chain : rack.chains)
+                collectModulationSources(chain.elements, ownTrack, out);
+        }
+    }
+}
+
+void collectModulationSources(const magda::TrackInfo& track, std::set<magda::TrackId>& out) {
+    // The track's own modifiers have no sidechain of their own to read: a
+    // sidechain is a property of a device or a rack, and a track scope is
+    // neither, so they listen to the track they live on.
+    collectModulationSources(track.mods, magda::INVALID_TRACK_ID, track.id, out);
+
+    collectModulationSources(track.chain.fxChainElements, track.id, out);
+
+    for (const auto& element : track.chain.postFxChainElements)
+        collectModulationSources(element.device.mods, sidechainSourceOf(element.device.sidechain),
+                                 track.id, out);
+
+    for (const auto& element : track.chain.mixerAnalysisElements)
+        collectModulationSources(element.device.mods, sidechainSourceOf(element.device.sidechain),
+                                 track.id, out);
+}
+
+}  // namespace magda::engine

--- a/magda/engine/param/ModSources.hpp
+++ b/magda/engine/param/ModSources.hpp
@@ -1,0 +1,129 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <set>
+
+#include "core/ModInfo.hpp"
+#include "core/RackInfo.hpp"
+#include "core/TrackInfo.hpp"
+#include "core/TypeIds.hpp"
+
+/**
+ * @file ModSources.hpp
+ * @brief Which track a modifier listens to.
+ *
+ * Two compilers need the answer and they must not work it out separately. The
+ * plan compiler needs it to emit the edge that carries a source track's signal
+ * to the modulation system, and the parameter table compiler needs it to record
+ * which modifier is on the far end of that edge. A rule stated twice is a rule
+ * that will eventually be two rules, and the failure would be silent: an edge
+ * to a track no modifier reads, or a modifier reading an edge that was never
+ * emitted.
+ *
+ * The rule itself is short. A modifier listens to the sidechain source of the
+ * scope it lives on, and to the track it lives on when that scope has none.
+ * That is what the fork does, arrived at from the other end: it collects a
+ * track's own modifiers into that track's detector cache and, separately,
+ * collects the modifiers of any scope sidechained from a track into that
+ * track's cache instead (PluginManager::rebuildSidechainLFOCache).
+ *
+ * What it listens for depends on what it is. A follower and an audio-triggered
+ * modifier read the source's audio; a MIDI-triggered one reads its MIDI.
+ * Everything else listens to nothing at all, and says so by having no source:
+ * a free-running LFO on a sidechained device is not a reason to carry that
+ * track's audio anywhere.
+ */
+
+namespace magda::engine {
+
+/** @brief What a modifier listens to its source for. */
+enum class ModListen : std::uint8_t {
+    Nothing,  ///< free-running or timeline-locked, and not a follower
+    Audio,    ///< the source's level: a follower, or an audio trigger
+    Midi,     ///< the source's notes: a MIDI trigger
+};
+
+/// What @p mod listens for, before the question of which track it listens to.
+inline ModListen modListenOf(const magda::ModInfo& mod) {
+    if (!mod.enabled)
+        return ModListen::Nothing;
+
+    // A follower is nothing but its source, whatever its trigger mode says: the
+    // trigger fields belong to the shape-driven kinds and a follower has no
+    // phase to restart.
+    if (mod.type == magda::ModType::Follower)
+        return ModListen::Audio;
+
+    switch (mod.triggerMode) {
+        case magda::LFOTriggerMode::MIDI:
+            return ModListen::Midi;
+        case magda::LFOTriggerMode::Audio:
+            return ModListen::Audio;
+        case magda::LFOTriggerMode::Free:
+        case magda::LFOTriggerMode::Transport:
+            break;
+    }
+
+    return ModListen::Nothing;
+}
+
+/**
+ * @brief The track a modifier on this scope listens to.
+ *
+ * @p sidechainSource is the scope's own sidechain source, or INVALID_TRACK_ID
+ * where the scope has none or it is not an audio one. @p ownTrack is the track
+ * the scope lives on, which is the answer whenever the scope is not sidechained
+ * from somewhere else.
+ *
+ * Empty for a modifier that listens to nothing.
+ */
+inline std::optional<magda::TrackId> modifierSourceTrack(const magda::ModInfo& mod,
+                                                         magda::TrackId sidechainSource,
+                                                         magda::TrackId ownTrack) {
+    if (modListenOf(mod) == ModListen::Nothing)
+        return std::nullopt;
+
+    const auto source = sidechainSource != magda::INVALID_TRACK_ID ? sidechainSource : ownTrack;
+    if (source == magda::INVALID_TRACK_ID)
+        return std::nullopt;
+
+    return source;
+}
+
+/**
+ * @brief The source a sidechain config names, or INVALID_TRACK_ID for none.
+ *
+ * Either type. What a sidechain says here is where a scope's modifiers listen,
+ * and what each of them listens for is its own business: an audio sidechain
+ * carrying a note-triggered modifier's notes is the same edge to the same
+ * track, and the tap emitted for it carries both the level and the MIDI.
+ *
+ * That is a decision rather than a transcription. The fork picks the monitor
+ * from the sidechain's type, so a note-triggered modifier on an audio-keyed
+ * device is fed by the level detector there and hears no notes at all, which
+ * makes what a modifier does depend on a setting belonging to the device it
+ * happens to sit on. Here the modifier's own trigger mode decides, which is the
+ * reading the model's own controls describe.
+ */
+inline magda::TrackId sidechainSourceOf(const magda::SidechainConfig& sidechain) {
+    return sidechain.isActive() ? sidechain.sourceTrackId : magda::INVALID_TRACK_ID;
+}
+
+/// Every track the modifiers on @p mods listen to, added to @p out.
+inline void collectModulationSources(const magda::ModArray& mods, magda::TrackId sidechainSource,
+                                     magda::TrackId ownTrack, std::set<magda::TrackId>& out) {
+    for (const auto& mod : mods)
+        if (const auto source = modifierSourceTrack(mod, sidechainSource, ownTrack))
+            out.insert(*source);
+}
+
+void collectModulationSources(const std::vector<magda::ChainElement>& elements,
+                              magda::TrackId ownTrack, std::set<magda::TrackId>& out);
+
+/// Every track the modifiers anywhere on @p track listen to, added to @p out.
+/// Walked in the same shape the parameter table walks its scopes, because the
+/// two lists have to be the same list.
+void collectModulationSources(const magda::TrackInfo& track, std::set<magda::TrackId>& out);
+
+}  // namespace magda::engine

--- a/magda/engine/param/ModSources.hpp
+++ b/magda/engine/param/ModSources.hpp
@@ -94,17 +94,13 @@ inline std::optional<magda::TrackId> modifierSourceTrack(const magda::ModInfo& m
 /**
  * @brief The source a sidechain config names, or INVALID_TRACK_ID for none.
  *
- * Either type. What a sidechain says here is where a scope's modifiers listen,
- * and what each of them listens for is its own business: an audio sidechain
- * carrying a note-triggered modifier's notes is the same edge to the same
- * track, and the tap emitted for it carries both the level and the MIDI.
- *
- * That is a decision rather than a transcription. The fork picks the monitor
- * from the sidechain's type, so a note-triggered modifier on an audio-keyed
- * device is fed by the level detector there and hears no notes at all, which
- * makes what a modifier does depend on a setting belonging to the device it
- * happens to sit on. Here the modifier's own trigger mode decides, which is the
- * reading the model's own controls describe.
+ * Either type, because the type is not this question's. A sidechain says which
+ * track a scope reads; the trigger mode on the modifier says what that modifier
+ * is waiting for. The fork separates them the same way: it installs its MIDI
+ * monitor for a track with a note-triggered modifier and its level monitor for
+ * one with an audio-triggered modifier, both read off the modes rather than off
+ * any sidechain's type (trackNeedsSidechainMonitor, trackNeedsAudioSidechain-
+ * Monitor).
  */
 inline magda::TrackId sidechainSourceOf(const magda::SidechainConfig& sidechain) {
     return sidechain.isActive() ? sidechain.sourceTrackId : magda::INVALID_TRACK_ID;

--- a/magda/engine/param/ModSources.hpp
+++ b/magda/engine/param/ModSources.hpp
@@ -44,6 +44,12 @@ enum class ModListen : std::uint8_t {
     Midi,     ///< the source's notes: a MIDI trigger
 };
 
+/// Where @p mod listens, which only means anything when it listens to audio.
+/// The model's own field, read through here so both compilers ask one question.
+inline magda::ModTapPoint modTapPointOf(const magda::ModInfo& mod) {
+    return mod.tapPoint;
+}
+
 /// What @p mod listens for, before the question of which track it listens to.
 inline ModListen modListenOf(const magda::ModInfo& mod) {
     if (!mod.enabled)
@@ -106,20 +112,59 @@ inline magda::TrackId sidechainSourceOf(const magda::SidechainConfig& sidechain)
     return sidechain.isActive() ? sidechain.sourceTrackId : magda::INVALID_TRACK_ID;
 }
 
-/// Every track the modifiers on @p mods listen to, added to @p out.
-inline void collectModulationSources(const magda::ModArray& mods, magda::TrackId sidechainSource,
-                                     magda::TrackId ownTrack, std::set<magda::TrackId>& out) {
-    for (const auto& mod : mods)
-        if (const auto source = modifierSourceTrack(mod, sidechainSource, ownTrack))
-            out.insert(*source);
+/**
+ * @brief One place the modulation system reads a track.
+ *
+ * A track is read at one point or two, never more: the two the engines have.
+ * What decides which is what listens, and a track with a follower at the far
+ * end and a trigger at the near one needs both.
+ */
+struct ModTap {
+    magda::TrackId track = magda::INVALID_TRACK_ID;
+    magda::ModTapPoint point = magda::ModTapPoint::PreFx;
+
+    auto operator<=>(const ModTap&) const = default;
+};
+
+/**
+ * @brief Every point the modifiers on @p mods read, added to @p out.
+ *
+ * An audio listener reads the point it names. A note listener reads the near
+ * one, and not because notes are near: MIDI has no fader to sit either side
+ * of, so it rides the tap that a track listened to at all always has rather
+ * than earning one of its own.
+ */
+inline void collectModulationTaps(const magda::ModArray& mods, magda::TrackId sidechainSource,
+                                  magda::TrackId ownTrack, std::set<ModTap>& out) {
+    for (const auto& mod : mods) {
+        const auto source = modifierSourceTrack(mod, sidechainSource, ownTrack);
+        if (!source)
+            continue;
+
+        out.insert(ModTap{*source, modListenOf(mod) == ModListen::Midi ? magda::ModTapPoint::PreFx
+                                                                       : modTapPointOf(mod)});
+    }
 }
 
-void collectModulationSources(const std::vector<magda::ChainElement>& elements,
-                              magda::TrackId ownTrack, std::set<magda::TrackId>& out);
+/// Every track the modifiers on @p mods listen to for notes, added to @p out.
+/// A source has to compile its MIDI ops whether or not its own chain wants
+/// them, which is a question about the track rather than about a tap point.
+inline void collectNoteSources(const magda::ModArray& mods, magda::TrackId sidechainSource,
+                               magda::TrackId ownTrack, std::set<magda::TrackId>& out) {
+    for (const auto& mod : mods)
+        if (modListenOf(mod) == ModListen::Midi)
+            if (const auto source = modifierSourceTrack(mod, sidechainSource, ownTrack))
+                out.insert(*source);
+}
 
-/// Every track the modifiers anywhere on @p track listen to, added to @p out.
-/// Walked in the same shape the parameter table walks its scopes, because the
-/// two lists have to be the same list.
-void collectModulationSources(const magda::TrackInfo& track, std::set<magda::TrackId>& out);
+void collectModulationTaps(const std::vector<magda::ChainElement>& elements,
+                           magda::TrackId ownTrack, std::set<ModTap>& out,
+                           std::set<magda::TrackId>& notes);
+
+/// Every point the modifiers anywhere on @p track read, and every track any of
+/// them reads for notes. Walked in the same shape the parameter table walks its
+/// scopes, because the two lists have to be the same list.
+void collectModulationTaps(const magda::TrackInfo& track, std::set<ModTap>& out,
+                           std::set<magda::TrackId>& notes);
 
 }  // namespace magda::engine

--- a/magda/engine/param/ParamResolve.cpp
+++ b/magda/engine/param/ParamResolve.cpp
@@ -296,27 +296,50 @@ float modifierValue(const ParamTable& table, const ModRuntime* mods, int index) 
                            : table.modifiers[static_cast<std::size_t>(index)].value;
 }
 
-/// The rate modifier @p index runs at this block: what its own settings say,
-/// unless something reaches its Rate parameter, which resolved earlier in the
-/// order precisely so this can read it.
+/// The rate one modifier carries, and whether that rate is a musical division.
+/// Two kinds have one; an envelope's stage lengths and a follower's time
+/// constants are times rather than a frequency, and the lane that would drive
+/// them does not exist.
+struct ModRateLane {
+    LfoRate rate;
+    bool tempoSync = false;
+    bool exists = false;
+};
+
+ModRateLane rateLaneOf(const ParamModifier& modifier) {
+    switch (modifier.kind) {
+        case ModKind::Lfo:
+            return {modifier.lfo.rate, modifier.lfo.tempoSync, true};
+        case ModKind::Random:
+            return {modifier.random.rate, modifier.random.tempoSync, true};
+        case ModKind::Adsr:
+        case ModKind::Follower:
+            return {};
+    }
+    return {};
+}
+
+/// The rate a modifier runs at this block: what its own settings say, unless
+/// something reaches its Rate parameter, which resolved earlier in the order
+/// precisely so this can read it.
 LfoRate rateFor(const ResolvedParams& out, const ParamModifier& modifier) {
-    auto rate = modifier.lfo.rate;
-    if (modifier.rate == INVALID_PARAM_ID)
-        return rate;
+    auto lane = rateLaneOf(modifier);
+    if (!lane.exists || modifier.rate == INVALID_PARAM_ID)
+        return lane.rate;
 
     const auto resolved = out[modifier.rate];
     if (resolved.empty())
-        return rate;
+        return lane.rate;
 
     // One lane, two meanings, decided by the same flag that decides what the
     // period is: a frequency when the modifier is free, and a division when it
     // is synced.
-    if (modifier.lfo.tempoSync)
-        rate.rateType = rateTypeFromLaneValue(resolved.value());
+    if (lane.tempoSync)
+        lane.rate.rateType = rateTypeFromLaneValue(resolved.value());
     else
-        rate.hz = resolved.value();
+        lane.rate.hz = resolved.value();
 
-    return rate;
+    return lane.rate;
 }
 
 void resolveOneParam(const ParamTable& table, ResolvedParams& out, const ModRuntime* mods,

--- a/magda/engine/param/ParamTable.hpp
+++ b/magda/engine/param/ParamTable.hpp
@@ -101,12 +101,19 @@ struct ParamModifier {
     FollowerSettings follower;
 
     /**
-     * @brief The track whose audio this modifier follows, or INVALID_TRACK_ID.
+     * @brief The track whose signal this modifier listens to, or
+     *        INVALID_TRACK_ID.
      *
-     * Only a follower has one, and only a follower whose scope names a source:
-     * everything else modulates without listening. Carried on the modifier
-     * rather than in the plan because it is not topology, and read by the
-     * executor to decide whose rendered block the detector is handed.
+     * Set for every modifier that listens at all: a follower, which is nothing
+     * but its source, and a MIDI- or audio-triggered one, which waits on that
+     * track's notes or its level. A free-running or timeline-locked modifier
+     * listens to nothing and says so by having none of this, which is what
+     * keeps a plan from carrying a track's signal nobody reads.
+     *
+     * Which track it is is ModSources.hpp's rule, called by both compilers.
+     * Carried on the modifier rather than in the plan because it is not
+     * topology, and read by the executor to decide who is on the far end of
+     * each modulation tap.
      */
     magda::TrackId source = magda::INVALID_TRACK_ID;
 

--- a/magda/engine/param/ParamTable.hpp
+++ b/magda/engine/param/ParamTable.hpp
@@ -117,6 +117,11 @@ struct ParamModifier {
      */
     magda::TrackId source = magda::INVALID_TRACK_ID;
 
+    /// Where in @ref source's chain it listens. Only read for a modifier that
+    /// listens to audio; a note reaches its listeners from one point because
+    /// MIDI has no fader to sit either side of.
+    magda::ModTapPoint tap = magda::ModTapPoint::PreFx;
+
     /**
      * @brief The modifier's own Rate parameter, or INVALID_PARAM_ID.
      *

--- a/magda/engine/param/ParamTable.hpp
+++ b/magda/engine/param/ParamTable.hpp
@@ -8,7 +8,10 @@
 
 #include "core/AutomationInfo.hpp"
 #include "core/ModInfo.hpp"
+#include "param/ModAdsr.hpp"
+#include "param/ModFollower.hpp"
 #include "param/ModLfo.hpp"
+#include "param/ModRandom.hpp"
 #include "param/ParamKey.hpp"
 #include "param/ParamSpec.hpp"
 
@@ -63,9 +66,15 @@ struct ParamLink {
  * @brief One modifier instance, as the thing links read.
  *
  * A source with an identity, so a link can name one and the resolution order
- * can account for one, plus what it takes to run it. The LFO runs here (#2119);
- * the rest publish @ref value and hold it until their engines arrive (#2120),
- * which is what every modifier did before this slice.
+ * can account for one, plus what it takes to run it.
+ *
+ * Four kinds and four settings structs, side by side rather than in a union or
+ * a variant. Exactly one of them is live and the other three are dead weight,
+ * which is about a hundred bytes per modifier: a project with a modifier on
+ * every scope it could have one on spends a few tens of kilobytes on the
+ * padding, once, off the audio thread. A variant would save that and cost a
+ * discriminated read on the block path, and the table's whole design is that
+ * what crosses to the audio thread is flat and copyable.
  */
 struct ParamModifier {
     /// The modifier itself: its owner's scope and its id, with no parameter
@@ -84,8 +93,22 @@ struct ParamModifier {
     /// answer is that there is no modifier there.
     bool enabled = true;
 
-    /// What the LFO is, for @ref kind == ModKind::Lfo.
+    /// What the modifier is, for whichever @ref kind it is. The other three are
+    /// left at their defaults and never read.
     LfoSettings lfo;
+    AdsrSettings adsr;
+    RandomSettings random;
+    FollowerSettings follower;
+
+    /**
+     * @brief The track whose audio this modifier follows, or INVALID_TRACK_ID.
+     *
+     * Only a follower has one, and only a follower whose scope names a source:
+     * everything else modulates without listening. Carried on the modifier
+     * rather than in the plan because it is not topology, and read by the
+     * executor to decide whose rendered block the detector is handed.
+     */
+    magda::TrackId source = magda::INVALID_TRACK_ID;
 
     /**
      * @brief The modifier's own Rate parameter, or INVALID_PARAM_ID.
@@ -95,9 +118,11 @@ struct ParamModifier {
      * modifiers have a rate nothing touches, and one parameter each for them
      * would be a table mostly made of numbers that never move.
      *
-     * Its value is a frequency or a division ordinal depending on
-     * LfoSettings::tempoSync, which is the same one lane the model's Rate
+     * Its value is a frequency or a division ordinal depending on whether the
+     * modifier is tempo synced, which is the same one lane the model's Rate
      * control writes (AutomationInfo's makeHzRateInfo / makeSyncDivisionInfo).
+     * The LFO and the random walk share it; an envelope's stage lengths and a
+     * follower's time constants are not rates and have none.
      */
     ParamId rate = INVALID_PARAM_ID;
 };

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -8,6 +8,7 @@
 #include "core/ClipLaneFlattener.hpp"
 #include "core/RackInfo.hpp"
 #include "core/TrackInfo.hpp"
+#include "param/ModSources.hpp"
 
 namespace magda::engine {
 
@@ -107,6 +108,100 @@ LfoSettings lfoSettingsOf(const magda::ModInfo& mod) {
 }
 
 /**
+ * @brief Where an envelope's gate comes from, folded from the trigger mode.
+ *
+ * Not the LFO's fold, and the difference is tempo sync. For an LFO tempo sync
+ * decides what the period is and therefore whether the phase is a function of
+ * the timeline, so it belongs in the fold. For an envelope it only scales the
+ * stage lengths, and a tempo-synced free-running envelope is still free
+ * running. The fork keeps the two apart for the same reason
+ * (ModifierHelpers::mapADSRSyncType).
+ */
+ModSync adsrSyncOf(const magda::ModInfo& mod) {
+    switch (mod.triggerMode) {
+        case magda::LFOTriggerMode::Transport:
+            return ModSync::Transport;
+        case magda::LFOTriggerMode::MIDI:
+        case magda::LFOTriggerMode::Audio:
+            return ModSync::Note;
+        case magda::LFOTriggerMode::Free:
+            break;
+    }
+    return ModSync::Free;
+}
+
+/// What the model says one envelope is.
+AdsrSettings adsrSettingsOf(const magda::ModInfo& mod) {
+    AdsrSettings settings;
+    settings.attackMs = mod.envAttackMs;
+    settings.decayMs = mod.envDecayMs;
+    settings.releaseMs = mod.envReleaseMs;
+    settings.sustain = mod.envSustain;
+    settings.attackCurve = mod.envAttackCurve;
+    settings.decayCurve = mod.envDecayCurve;
+    settings.releaseCurve = mod.envReleaseCurve;
+    settings.sync = adsrSyncOf(mod);
+    settings.trigger = mod.triggerMode;
+    settings.tempoSync = mod.tempoSync;
+
+    // One division for all three stages, because that is what the model
+    // carries: the fork writes it to the ADSR's separate attack, decay and
+    // release sync parameters and they always hold the same value.
+    settings.rateType = mod.tempoSync ? magda::syncDivisionToTeRateOrdinal(mod.syncDivision)
+                                      : static_cast<int>(magda::ModRateType::Hertz);
+
+    // The gate rules the fork applies (applyADSRProperties), read off the same
+    // model fields. An audio-triggered envelope's gate belongs to the detector
+    // watching its source, and it sits shut between hits; a note-triggered one
+    // is shut until the model says it is running.
+    settings.startGated = mod.triggerMode == magda::LFOTriggerMode::Audio ||
+                          (mod.triggerMode == magda::LFOTriggerMode::MIDI && !mod.running);
+
+    return settings;
+}
+
+/// What the model says one random modulator is.
+RandomSettings randomSettingsOf(const magda::ModInfo& mod) {
+    RandomSettings settings;
+    settings.type = mod.randomType == 1 ? RandomShape::Noise : RandomShape::Stepped;
+
+    // The LFO's fold, unchanged. The fork maps the two with the same call
+    // (applyRandomProperties uses mapSyncType), because both read the model's
+    // one trigger mode and one tempo-sync flag.
+    settings.sync = modSyncOf(mod);
+    settings.trigger = mod.triggerMode;
+    settings.tempoSync = mod.tempoSync;
+    settings.rate.hz = mod.rate;
+    settings.rate.rateType = mod.tempoSync ? magda::syncDivisionToTeRateOrdinal(mod.syncDivision)
+                                           : static_cast<int>(magda::ModRateType::Hertz);
+    settings.shape = mod.randomShape;
+    settings.smooth = mod.randomSmooth;
+    settings.stepDepth = mod.randomStepDepth;
+
+    return settings;
+}
+
+/// What the model says one envelope follower is.
+FollowerSettings followerSettingsOf(const magda::ModInfo& mod) {
+    FollowerSettings settings;
+
+    // The gain belongs before the band limits and before detection, which is
+    // where the fork puts it too: its own source cache applies this and holds
+    // TE's post-detection gain at unity, because a level that has already been
+    // detected has no frequency content left for a filter to act on.
+    settings.gainDb = mod.followerGainDb;
+    settings.attackMs = mod.followerAttackMs;
+    settings.holdMs = mod.followerHoldMs;
+    settings.releaseMs = mod.followerReleaseMs;
+    settings.highPass = mod.followerHpEnabled;
+    settings.highPassHz = mod.followerHpFreq;
+    settings.lowPass = mod.followerLpEnabled;
+    settings.lowPassHz = mod.followerLpFreq;
+
+    return settings;
+}
+
+/**
  * @brief What the modifier's Rate lane means, and where it starts.
  *
  * One lane with two readings, chosen by the same flag that chooses what the
@@ -149,6 +244,10 @@ struct Node {
     const magda::ModArray* mods = nullptr;
     const magda::DeviceInfo* device = nullptr;
     const magda::TrackInfo* track = nullptr;
+
+    /// The track this scope is sidechained from, or none. What the modifiers
+    /// living here listen to instead of their own track (ModSources.hpp).
+    magda::TrackId sidechainSource = magda::INVALID_TRACK_ID;
 };
 
 class Builder {
@@ -287,6 +386,27 @@ void Builder::allocateMods(const Node& node) {
         modifier.kind = modKindOf(mod.type);
         modifier.enabled = mod.enabled;
         modifier.lfo = lfoSettingsOf(mod);
+        modifier.adsr = adsrSettingsOf(mod);
+        modifier.random = randomSettingsOf(mod);
+        modifier.follower = followerSettingsOf(mod);
+
+        // Which track this one listens to, if it listens at all. The same rule
+        // the plan compiler emits the edge from, called rather than restated
+        // (ModSources.hpp says why that matters).
+        if (const auto source = modifierSourceTrack(mod, node.sidechainSource, node.scope.trackId))
+            modifier.source = *source;
+
+        // Cross-track is a property of the scope rather than of the modifier,
+        // which is why the settings could not say it: a modifier whose scope is
+        // sidechained from elsewhere is driven by that track's detector and
+        // must not be retriggered by the track it lives on. The fork keeps the
+        // same flag on the same terms, set by PluginManager rather than by the
+        // modifier itself.
+        const bool crossTrack = node.sidechainSource != magda::INVALID_TRACK_ID &&
+                                node.sidechainSource != node.scope.trackId;
+        modifier.lfo.skipNativeResync = crossTrack;
+        modifier.adsr.skipNativeResync = crossTrack;
+        modifier.random.skipNativeResync = crossTrack;
 
         const auto index = static_cast<int>(table_.modifiers.size());
         table_.modifiers.push_back(modifier);
@@ -408,6 +528,7 @@ void Builder::walkElements(const std::vector<magda::ChainElement>& elements, mag
             node.macros = &device.macros;
             node.mods = &device.mods;
             node.device = &device;
+            node.sidechainSource = sidechainSourceOf(device.sidechain);
             nodes_.push_back(node);
         } else if (magda::isRack(element)) {
             walkRack(magda::getRack(element), trackId);
@@ -425,6 +546,7 @@ void Builder::walkFlat(const std::vector<magda::PostFxChainElement>& elements,
         node.macros = &element.device.macros;
         node.mods = &element.device.mods;
         node.device = &element.device;
+        node.sidechainSource = sidechainSourceOf(element.device.sidechain);
         nodes_.push_back(node);
     }
 }
@@ -436,6 +558,7 @@ void Builder::walkRack(const magda::RackInfo& rack, magda::TrackId trackId) {
     node.scope.rackId = rack.id;
     node.macros = &rack.macros;
     node.mods = &rack.mods;
+    node.sidechainSource = sidechainSourceOf(rack.sidechain);
     nodes_.push_back(node);
 
     for (const auto& chain : rack.chains)

--- a/magda/engine/param/ParamTableCompiler.cpp
+++ b/magda/engine/param/ParamTableCompiler.cpp
@@ -393,8 +393,11 @@ void Builder::allocateMods(const Node& node) {
         // Which track this one listens to, if it listens at all. The same rule
         // the plan compiler emits the edge from, called rather than restated
         // (ModSources.hpp says why that matters).
-        if (const auto source = modifierSourceTrack(mod, node.sidechainSource, node.scope.trackId))
+        if (const auto source =
+                modifierSourceTrack(mod, node.sidechainSource, node.scope.trackId)) {
             modifier.source = *source;
+            modifier.tap = modTapPointOf(mod);
+        }
 
         // Cross-track is a property of the scope rather than of the modifier,
         // which is why the settings could not say it: a modifier whose scope is

--- a/magda/engine/param/ParamTableDump.cpp
+++ b/magda/engine/param/ParamTableDump.cpp
@@ -88,11 +88,25 @@ std::string kindText(ModKind kind) {
 
 /// The rate, as the thing a reader is checking: a frequency, or the division
 /// ordinal a synced modifier's period comes from.
-std::string rateText(const LfoSettings& lfo) {
-    if (!lfo.tempoSync)
-        return number(lfo.rate.hz) + "Hz";
+std::string rateText(bool tempoSync, const LfoRate& rate) {
+    if (!tempoSync)
+        return number(rate.hz) + "Hz";
 
-    return "sync[" + std::to_string(lfo.rate.rateType) + "]";
+    return "sync[" + std::to_string(rate.rateType) + "]";
+}
+
+/// A stage length, which is a time unless the envelope is synced, in which case
+/// every stage runs at the one division the model carries.
+std::string stageText(float milliseconds, const AdsrSettings& adsr) {
+    if (adsr.tempoSync && adsr.rateType != static_cast<int>(magda::ModRateType::Hertz))
+        return "sync[" + std::to_string(adsr.rateType) + "]";
+
+    return number(milliseconds) + "ms";
+}
+
+/// What a random modulator does with its cycle.
+std::string randomTypeText(RandomShape type) {
+    return type == RandomShape::Noise ? "noise" : "stepped";
 }
 
 }  // namespace
@@ -147,23 +161,72 @@ std::string dumpParamTable(const ParamTable& table) {
             if (!modifier.enabled)
                 line << " off";
 
-            if (modifier.kind == ModKind::Lfo) {
-                line << " " << waveText(lfo.wave) << " " << rateText(lfo) << " "
-                     << syncText(lfo.sync);
+            // Only the live kind's settings, because the other three are at
+            // their defaults and printing them would be four modifiers'
+            // worth of noise around the one that is there.
+            switch (modifier.kind) {
+                case ModKind::Lfo: {
+                    line << " " << waveText(lfo.wave) << " " << rateText(lfo.tempoSync, lfo.rate)
+                         << " " << syncText(lfo.sync);
 
-                if (lfo.phaseOffset != 0.0f)
-                    line << " phase=" << number(lfo.phaseOffset);
-                if (lfo.oneShot)
-                    line << " oneshot";
-                if (lfo.invertOutput)
-                    line << " inverted";
-                if (lfo.useLoopRegion)
-                    line << " loop[" << number(lfo.loopStart) << "," << number(lfo.loopEnd) << "]";
-                if (lfo.gateOnTrigger)
-                    line << " gated";
-                if (!table.modCurveFor(index).empty())
-                    line << " curve=" << table.modCurveFor(index).size();
+                    if (lfo.phaseOffset != 0.0f)
+                        line << " phase=" << number(lfo.phaseOffset);
+                    if (lfo.oneShot)
+                        line << " oneshot";
+                    if (lfo.invertOutput)
+                        line << " inverted";
+                    if (lfo.useLoopRegion)
+                        line << " loop[" << number(lfo.loopStart) << "," << number(lfo.loopEnd)
+                             << "]";
+                    if (lfo.gateOnTrigger)
+                        line << " gated";
+                    if (!table.modCurveFor(index).empty())
+                        line << " curve=" << table.modCurveFor(index).size();
+                    break;
+                }
+
+                case ModKind::Adsr: {
+                    const auto& adsr = modifier.adsr;
+                    line << " a=" << stageText(adsr.attackMs, adsr)
+                         << " d=" << stageText(adsr.decayMs, adsr) << " s=" << number(adsr.sustain)
+                         << " r=" << stageText(adsr.releaseMs, adsr) << " " << syncText(adsr.sync);
+
+                    if (adsr.attackCurve != 0.0f || adsr.decayCurve != 0.0f ||
+                        adsr.releaseCurve != 0.0f)
+                        line << " curves[" << number(adsr.attackCurve) << ","
+                             << number(adsr.decayCurve) << "," << number(adsr.releaseCurve) << "]";
+                    break;
+                }
+
+                case ModKind::Random: {
+                    const auto& random = modifier.random;
+                    line << " " << randomTypeText(random.type) << " "
+                         << rateText(random.tempoSync, random.rate) << " " << syncText(random.sync)
+                         << " shape=" << number(random.shape) << " smooth=" << number(random.smooth)
+                         << " step=" << number(random.stepDepth);
+                    break;
+                }
+
+                case ModKind::Follower: {
+                    const auto& follower = modifier.follower;
+                    line << " gain=" << number(follower.gainDb) << "dB"
+                         << " a=" << number(follower.attackMs) << "ms"
+                         << " h=" << number(follower.holdMs) << "ms"
+                         << " r=" << number(follower.releaseMs) << "ms";
+
+                    if (follower.highPass)
+                        line << " hp=" << number(follower.highPassHz) << "Hz";
+                    if (follower.lowPass)
+                        line << " lp=" << number(follower.lowPassHz) << "Hz";
+                    break;
+                }
             }
+
+            // What it listens to, where it listens at all. The far end of the
+            // plan's modulation tap, printed so a golden shows the edge from
+            // both sides rather than only from the plan's.
+            if (modifier.source != magda::INVALID_TRACK_ID)
+                line << " source=track[" << modifier.source << "]";
 
             if (modifier.rate != INVALID_PARAM_ID)
                 line << " rate=param[" << modifier.rate << "]";

--- a/magda/engine/param/ParamTableDump.cpp
+++ b/magda/engine/param/ParamTableDump.cpp
@@ -226,7 +226,8 @@ std::string dumpParamTable(const ParamTable& table) {
             // plan's modulation tap, printed so a golden shows the edge from
             // both sides rather than only from the plan's.
             if (modifier.source != magda::INVALID_TRACK_ID)
-                line << " source=track[" << modifier.source << "]";
+                line << " source=track[" << modifier.source << "]"
+                     << (modifier.tap == magda::ModTapPoint::PreFx ? " prefx" : " postfader");
 
             if (modifier.rate != INVALID_PARAM_ID)
                 line << " rate=param[" << modifier.rate << "]";

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -68,6 +68,25 @@ bool elementsConsumeMidi(const std::vector<ChainElement>& elements) {
     });
 }
 
+/// Whether a rack produces the track's sound rather than processing it, which
+/// is what puts the trigger tap after it rather than in front of it. The fork
+/// asks the same question of the same subtree (rackContainsInstrumentSource).
+bool rackHasInstrument(const RackInfo& rack) {
+    return std::ranges::any_of(rack.chains, [](const ChainInfo& chain) {
+        if (!chainIsActive(chain))
+            return false;
+        return std::ranges::any_of(chain.elements, [](const ChainElement& element) {
+            if (isDevice(element)) {
+                const auto& device = getDevice(element);
+                return !device.bypassed && device.isInstrument;
+            }
+            if (isRack(element))
+                return rackHasInstrument(getRack(element));
+            return false;
+        });
+    });
+}
+
 bool sectionConsumesMidi(const std::vector<PostFxChainElement>& section) {
     return std::ranges::any_of(section, [](const PostFxChainElement& element) {
         return !element.device.bypassed && consumesMidi(element.device);
@@ -199,6 +218,24 @@ class Compiler {
     /// send: after the plugin list (the fader included) and before the muting
     /// node, so a muted source still feeds the compressor keying off it.
     std::map<TrackId, PortRef> trackSidechainTap_;
+    /**
+     * @brief Where an audio trigger keys off each emitted track.
+     *
+     * Not the sidechain tap, and the difference is the whole of what a source
+     * fader does. The fork puts its trigger monitor at the front of the chain,
+     * or immediately after the instrument that makes the sound, so a hit is
+     * detected on what the track played; the follower tap sits at the far end,
+     * post-FX and post-fader, so a follower tracks what the track sends. Riding
+     * the source fader therefore moves a follower and leaves the triggers
+     * alone, and a plan reading one point for both would lose that.
+     */
+    std::map<TrackId, PortRef> trackTriggerTap_;
+
+    /// The track whose trigger tap is still being looked for, and whether the
+    /// instrument that ends the search has gone by. Top level only, because the
+    /// fork's own search is over the track's own element list.
+    TrackId triggerTapTrack_ = INVALID_TRACK_ID;
+    bool triggerTapFound_ = false;
     /// Post-mute output: what the track's destination and any track taking this
     /// track as its audio input actually receive.
     std::map<TrackId, PortRef> trackRoutedOutput_;
@@ -213,9 +250,10 @@ class Compiler {
     /// internal MIDI route. Their MIDI clips have to be compiled even when
     /// their own chain has nothing that consumes MIDI.
     std::set<TrackId> midiSourceTracks_;
-    /// Tracks a modifier somewhere in the project listens to (ModSources.hpp).
-    /// Both an ordering constraint and, at the end, an op each.
-    std::set<TrackId> modulationSourceTracks_;
+    /// Every point a modifier somewhere in the project reads (ModSources.hpp),
+    /// and every track one of them reads for notes. One op each at the end.
+    std::set<ModTap> modulationTaps_;
+    std::set<TrackId> noteSourceTracks_;
 };
 
 OpId Compiler::addOp(OpKind kind, const OpKey& key, std::vector<PortRef> inputs,
@@ -330,12 +368,20 @@ std::vector<const TrackInfo*> Compiler::computeTrackOrder() {
         std::set<TrackId> upstream;
         collectSidechainSources(track, std::nullopt, upstream);
 
-        // A modifier listening to another track reads that track's signal, so
-        // it is an ordering constraint exactly as a sidechain is. It is also
-        // where the modifiers of a sidechained rack come in, which the plan
-        // used to report as something it could not carry (#2120).
-        collectModulationSources(track, upstream);
-
+        // Deliberately not the modulation sources. A modifier listening to
+        // another track needs that track's tap to exist, and it does: the taps
+        // are emitted after every track, so they see every tap point whatever
+        // order the tracks went in. What a modulation feed does not need is to
+        // come first, because nothing in the block reads it in the block that
+        // produced it. The audio side is one block behind by construction
+        // (ModFollower.hpp), and the MIDI side is read from the prefix, which
+        // runs before the graph rather than inside it.
+        //
+        // Making it an ordering edge costs real routing. A track routed into
+        // the very track its own modifiers listen to is an ordinary project and
+        // a cycle here, and the breaker resolves a cycle by dropping a
+        // connection: the audio edge would go so that a modulation feed which
+        // did not need ordering could have it.
         if (const auto route = activeAudioInputRoute(track); route.namesTrack())
             upstream.insert(route.trackId);
         if (const auto route = activeMidiInputRoute(track); route.namesTrack())
@@ -635,12 +681,35 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
 
 ChainSignal Compiler::emitElements(const std::vector<ChainElement>& elements, const ChainSite& site,
                                    ChainSignal signal) {
+    // Only the track's own list, and only while a trigger tap is still wanted.
+    // A nested chain is not where the fork looks either: an instrument inside a
+    // rack ends the search at the rack, not inside it.
+    const bool watchingForInstrument = !triggerTapFound_ && site.trackId == triggerTapTrack_ &&
+                                       site.rackId == INVALID_RACK_ID &&
+                                       site.segment == ChainSegment::Fx;
+
     for (const auto& element : elements) {
-        if (isDevice(element))
-            signal = emitDevice(getDevice(element), site, signal);
-        else if (isRack(element))
-            signal = emitRack(getRack(element), site, signal);
+        bool endsTheSearch = false;
+
+        if (isDevice(element)) {
+            const auto& device = getDevice(element);
+            endsTheSearch = !device.bypassed && device.isInstrument;
+            signal = emitDevice(device, site, signal);
+        } else if (isRack(element)) {
+            const auto& rack = getRack(element);
+            endsTheSearch = !rack.bypassed && rackHasInstrument(rack);
+            signal = emitRack(rack, site, signal);
+        }
+
+        // Immediately after whatever makes the sound, which is where the fork
+        // puts the monitor on a track that has an instrument: in front of it
+        // there is nothing to detect.
+        if (watchingForInstrument && endsTheSearch && !triggerTapFound_) {
+            trackTriggerTap_[site.trackId] = signal.audio;
+            triggerTapFound_ = true;
+        }
     }
+
     return signal;
 }
 
@@ -717,6 +786,13 @@ void Compiler::emitTrack(const TrackInfo& track) {
                          INVALID_DEVICE_ID, OpRole::TrackAudioInput, 0};
     ChainSignal signal;
     signal.audio = emitMix(inputKey, audioSources);
+
+    // The chain head is where an audio trigger keys off a track with no
+    // instrument on it, which is every audio track. One with an instrument
+    // moves it along to just past that instrument during the walk below.
+    trackTriggerTap_[track.id] = signal.audio;
+    triggerTapTrack_ = track.id;
+    triggerTapFound_ = false;
 
     std::vector<PortRef> midiSources;
     if (carriesClips(track) && (chainConsumesMidi(track) || midiSourceTracks_.contains(track.id))) {
@@ -895,34 +971,45 @@ void Compiler::emitTrack(const TrackInfo& track) {
 }
 
 void Compiler::emitModulationTaps() {
-    for (const auto sourceId : modulationSourceTracks_) {
-        // Post-fader and pre-mute, which is the point the fork taps as well:
-        // its follower tap sits at the end of the source track's plugin list
-        // and its trigger monitor keys off the same signal, so a muted source
-        // still ducks what it is ducking.
+    for (const auto& tap : modulationTaps_) {
+        const auto preFx = tap.point == ModTapPoint::PreFx;
+
+        // Two points, and the tap reads the one it is for. Pre-FX is after
+        // whatever makes the track's sound and before its effects, which is
+        // where the fork puts its trigger monitor; post-fader is the far end,
+        // before the muting node, which is where it puts its follower tap. A
+        // plan reading one point for both would lose what the source fader
+        // does, which is the whole of the difference.
+        const auto& points = preFx ? trackTriggerTap_ : trackSidechainTap_;
+
         PortRef audio;
-        if (const auto found = trackSidechainTap_.find(sourceId); found != trackSidechainTap_.end())
+        if (const auto found = points.find(tap.track); found != points.end())
             audio = found->second;
 
         // The source's chain-head MIDI, which is what a note-triggered
         // modifier hears: the notes reaching the track rather than whatever
-        // its own instruments made of them.
+        // its own instruments made of them. On the pre-FX tap alone, because a
+        // note has no fader question and two taps carrying it would fire every
+        // note-triggered modifier twice.
         PortRef midi;
-        if (const auto found = trackMidiInput_.find(sourceId); found != trackMidiInput_.end())
-            midi = found->second;
+        if (preFx && noteSourceTracks_.count(tap.track) != 0)
+            if (const auto found = trackMidiInput_.find(tap.track); found != trackMidiInput_.end())
+                midi = found->second;
 
         // Neither, which is a modifier listening to a track this plan does not
         // carry: one that was deleted, or one skipped because nothing it feeds
         // is audible. Reported rather than passed over, because a modulation
         // that silently stops arriving is the hardest kind of silence to find.
         if (!audio.valid() && !midi.valid()) {
-            diagnose("track " + std::to_string(sourceId) +
+            diagnose("track " + std::to_string(tap.track) +
                      " is listened to by a modifier but is not routed, so nothing reaches it");
             continue;
         }
 
-        const OpKey key{sourceId,          INVALID_RACK_ID,       INVALID_CHAIN_ID,
-                        INVALID_DEVICE_ID, OpRole::ModulationTap, 0,
+        // The point is part of the identity, because a track read at both is
+        // two ops and the differ hash-joins on the key.
+        const OpKey key{tap.track,         INVALID_RACK_ID,       INVALID_CHAIN_ID,
+                        INVALID_DEVICE_ID, OpRole::ModulationTap, preFx ? 0 : 1,
                         ChainSegment::Fx};
 
         // No delay alignment. The two inputs are read for what they are rather
@@ -947,16 +1034,14 @@ RenderPlan Compiler::run() {
     collectSidechainSources(master_, SidechainConfig::Type::MIDI, midiSourceTracks_);
 
     for (const auto& track : tracks_)
-        collectModulationSources(track, modulationSourceTracks_);
-    collectModulationSources(master_, modulationSourceTracks_);
+        collectModulationTaps(track, modulationTaps_, noteSourceTracks_);
+    collectModulationTaps(master_, modulationTaps_, noteSourceTracks_);
 
-    // A track a modifier listens to has to produce MIDI whether or not its own
-    // chain consumes any, on the same terms a MIDI sidechain does: a
-    // note-triggered modifier reads the notes reaching its source's chain head,
-    // and a source with no MIDI ops compiled has no chain head to read.
-    for (const auto& track : tracks_)
-        if (modulationSourceTracks_.count(track.id) != 0)
-            midiSourceTracks_.insert(track.id);
+    // A track a modifier listens to for notes has to produce MIDI whether or
+    // not its own chain consumes any, on the same terms a MIDI sidechain does:
+    // a note-triggered modifier reads the notes reaching its source's chain
+    // head, and a source with no MIDI ops compiled has no chain head to read.
+    midiSourceTracks_.insert(noteSourceTracks_.begin(), noteSourceTracks_.end());
 
     for (const auto* track : computeTrackOrder())
         emitTrack(*track);

--- a/magda/engine/plan/PlanCompiler.cpp
+++ b/magda/engine/plan/PlanCompiler.cpp
@@ -11,6 +11,7 @@
 #include "core/RackInfo.hpp"
 #include "core/TrackChain.hpp"
 #include "core/TrackInfo.hpp"
+#include "param/ModSources.hpp"
 #include "plan/TrackRouting.hpp"
 
 namespace magda::engine {
@@ -169,6 +170,11 @@ class Compiler {
     TrackId resolveAudioDestination(const TrackInfo& track) const;
 
     void emitTrack(const TrackInfo& track);
+
+    /// One op per track any modifier listens to, after every track has been
+    /// emitted so that every tap exists to read.
+    void emitModulationTaps();
+
     ChainSignal emitElements(const std::vector<ChainElement>& elements, const ChainSite& site,
                              ChainSignal signal);
     ChainSignal emitDevice(const DeviceInfo& device, const ChainSite& site, ChainSignal signal);
@@ -207,6 +213,9 @@ class Compiler {
     /// internal MIDI route. Their MIDI clips have to be compiled even when
     /// their own chain has nothing that consumes MIDI.
     std::set<TrackId> midiSourceTracks_;
+    /// Tracks a modifier somewhere in the project listens to (ModSources.hpp).
+    /// Both an ordering constraint and, at the end, an op each.
+    std::set<TrackId> modulationSourceTracks_;
 };
 
 OpId Compiler::addOp(OpKind kind, const OpKey& key, std::vector<PortRef> inputs,
@@ -320,6 +329,13 @@ std::vector<const TrackInfo*> Compiler::computeTrackOrder() {
         // contributes no edge either.
         std::set<TrackId> upstream;
         collectSidechainSources(track, std::nullopt, upstream);
+
+        // A modifier listening to another track reads that track's signal, so
+        // it is an ordering constraint exactly as a sidechain is. It is also
+        // where the modifiers of a sidechained rack come in, which the plan
+        // used to report as something it could not carry (#2120).
+        collectModulationSources(track, upstream);
+
         if (const auto route = activeAudioInputRoute(track); route.namesTrack())
             upstream.insert(route.trackId);
         if (const auto route = activeMidiInputRoute(track); route.namesTrack())
@@ -511,15 +527,12 @@ ChainSignal Compiler::emitRack(const RackInfo& rack, const ChainSite& site, Chai
     if (rack.bypassed)
         return signal;
 
-    // A rack-level sidechain drives the rack's own followers and LFOs, so it is
-    // a modulation source rather than a signal edge, and modulation is not
-    // topology. Reported rather than passed over in silence: the dependency on
-    // the source track is real and lands with the modulation slice.
-    if (rack.sidechain.isActive())
-        diagnose("rack " + std::to_string(rack.id) + ": " +
-                 (rack.sidechain.type == SidechainConfig::Type::MIDI ? "MIDI" : "audio") +
-                 " sidechain from track " + std::to_string(rack.sidechain.sourceTrackId) +
-                 " feeds rack modulation, which the plan does not carry yet");
+    // A rack-level sidechain drives the rack's own followers and triggered
+    // modifiers. It is still not a signal edge into the rack, because a rack
+    // does not mix its sidechain into its chains; what it is is a dependency on
+    // the source track, and that is now carried: the modulation tap emitted for
+    // that track is the edge, and collectModulationSources is what puts the
+    // source ahead of this rack's own track in the compile order (#2120).
 
     // Same dry path a device's delta solo needs, one level up: the rack
     // instance subtracts its own input, aligned to its wet output, from that
@@ -881,6 +894,45 @@ void Compiler::emitTrack(const TrackInfo& track) {
     pendingInputs_[destination].push_back(out);
 }
 
+void Compiler::emitModulationTaps() {
+    for (const auto sourceId : modulationSourceTracks_) {
+        // Post-fader and pre-mute, which is the point the fork taps as well:
+        // its follower tap sits at the end of the source track's plugin list
+        // and its trigger monitor keys off the same signal, so a muted source
+        // still ducks what it is ducking.
+        PortRef audio;
+        if (const auto found = trackSidechainTap_.find(sourceId); found != trackSidechainTap_.end())
+            audio = found->second;
+
+        // The source's chain-head MIDI, which is what a note-triggered
+        // modifier hears: the notes reaching the track rather than whatever
+        // its own instruments made of them.
+        PortRef midi;
+        if (const auto found = trackMidiInput_.find(sourceId); found != trackMidiInput_.end())
+            midi = found->second;
+
+        // Neither, which is a modifier listening to a track this plan does not
+        // carry: one that was deleted, or one skipped because nothing it feeds
+        // is audible. Reported rather than passed over, because a modulation
+        // that silently stops arriving is the hardest kind of silence to find.
+        if (!audio.valid() && !midi.valid()) {
+            diagnose("track " + std::to_string(sourceId) +
+                     " is listened to by a modifier but is not routed, so nothing reaches it");
+            continue;
+        }
+
+        const OpKey key{sourceId,          INVALID_RACK_ID,       INVALID_CHAIN_ID,
+                        INVALID_DEVICE_ID, OpRole::ModulationTap, 0,
+                        ChainSegment::Fx};
+
+        // No delay alignment. The two inputs are read for what they are rather
+        // than mixed with each other, and a modulation feed is a block late by
+        // construction anyway (ModFollower.hpp), so aligning it to a sample
+        // would be precision the path does not have.
+        addOp(OpKind::ModSource, key, {audio, midi}, {});
+    }
+}
+
 RenderPlan Compiler::run() {
     // A track whose MIDI someone else reads has to produce MIDI even when
     // nothing in its own chain consumes it, so this is collected up front.
@@ -894,9 +946,23 @@ RenderPlan Compiler::run() {
     }
     collectSidechainSources(master_, SidechainConfig::Type::MIDI, midiSourceTracks_);
 
+    for (const auto& track : tracks_)
+        collectModulationSources(track, modulationSourceTracks_);
+    collectModulationSources(master_, modulationSourceTracks_);
+
+    // A track a modifier listens to has to produce MIDI whether or not its own
+    // chain consumes any, on the same terms a MIDI sidechain does: a
+    // note-triggered modifier reads the notes reaching its source's chain head,
+    // and a source with no MIDI ops compiled has no chain head to read.
+    for (const auto& track : tracks_)
+        if (modulationSourceTracks_.count(track.id) != 0)
+            midiSourceTracks_.insert(track.id);
+
     for (const auto* track : computeTrackOrder())
         emitTrack(*track);
     emitTrack(master_);
+
+    emitModulationTaps();
 
     // Anything still queued belongs to a track that was compiled before its
     // source, which only happens when a routing cycle was broken above.

--- a/magda/engine/plan/RenderPlan.cpp
+++ b/magda/engine/plan/RenderPlan.cpp
@@ -35,7 +35,7 @@ int arityOf(OpKind kind) {
         case OpKind::Output:
             return 1;
         case OpKind::ModSource:
-            return 2;  // the source's audio, the source's MIDI
+            return 2;  // the source's audio at this tap's point, the source's MIDI
     }
     return -1;
 }

--- a/magda/engine/plan/RenderPlan.cpp
+++ b/magda/engine/plan/RenderPlan.cpp
@@ -34,6 +34,8 @@ int arityOf(OpKind kind) {
         case OpKind::Meter:
         case OpKind::Output:
             return 1;
+        case OpKind::ModSource:
+            return 2;  // the source's audio, the source's MIDI
     }
     return -1;
 }
@@ -66,6 +68,8 @@ const char* toString(OpKind kind) {
             return "SendTap";
         case OpKind::Meter:
             return "Meter";
+        case OpKind::ModSource:
+            return "ModSource";
         case OpKind::Output:
             return "Output";
     }
@@ -110,6 +114,8 @@ const char* toString(OpRole role) {
             return "trackMute";
         case OpRole::SendTap:
             return "sendTap";
+        case OpRole::ModulationTap:
+            return "modulationTap";
         case OpRole::HardwareOutput:
             return "hardwareOutput";
         case OpRole::MixInputDelay:
@@ -335,8 +341,10 @@ std::vector<std::string> validatePlan(const RenderPlan& plan) {
             problems.push_back(label + "has the same key as op " + std::to_string(owner->second) +
                                ", so the differ cannot tell them apart");
 
-        // Output is the plan's only sink; everything else must produce.
-        if (op.outputs.empty() != (op.kind == OpKind::Output))
+        // Two sinks and no others: the hardware output, and the tap that hands
+        // a track's signal to the modulation system. Everything else produces.
+        const bool sink = op.kind == OpKind::Output || op.kind == OpKind::ModSource;
+        if (op.outputs.empty() != sink)
             problems.push_back(label + (op.outputs.empty() ? "no output port"
                                                            : "is a sink and must have no ports"));
 
@@ -368,13 +376,14 @@ std::vector<std::string> validatePlan(const RenderPlan& plan) {
             }
             // A delay carries whatever reaches it, so its own output port is
             // what its input has to agree with.
+            const bool midiSlot = op.kind == OpKind::MergeMidi ||
+                                  ((op.kind == OpKind::Device || op.kind == OpKind::Fader ||
+                                    op.kind == OpKind::ModSource) &&
+                                   slot == 1);
             const auto expected =
                 op.kind == OpKind::Delay
                     ? (op.outputs.empty() ? SignalKind::Audio : op.outputs.front())
-                    : ((op.kind == OpKind::MergeMidi ||
-                        ((op.kind == OpKind::Device || op.kind == OpKind::Fader) && slot == 1))
-                           ? SignalKind::Midi
-                           : SignalKind::Audio);
+                    : (midiSlot ? SignalKind::Midi : SignalKind::Audio);
             const auto actual = producer.outputs[static_cast<std::size_t>(input.port)];
             if (actual != expected)
                 problems.push_back(label + "input " + std::to_string(slot) + " is " +

--- a/magda/engine/plan/RenderPlan.hpp
+++ b/magda/engine/plan/RenderPlan.hpp
@@ -69,6 +69,7 @@ enum class OpKind : std::uint8_t {
     Fader,      ///< volume + pan, and the MIDI its stage passes on
     SendTap,    ///< pre/post-fader tap feeding another track
     Meter,      ///< level tap read by the UI
+    ModSource,  ///< a track's signal as the modulation system reads it
     Output,     ///< hardware output
 };
 
@@ -98,6 +99,7 @@ enum class OpRole : std::uint8_t {
     TrackMeter,       ///< the track's post-fader, pre-mute level tap
     TrackMute,        ///< mute and solo, applied after the meter and sidechain tap
     SendTap,          ///< one send slot
+    ModulationTap,    ///< one track's signal, read by the modifiers listening to it
     HardwareOutput,   ///< the master's hardware output
 
     // Latency compensation. A delay sits on one edge, so its identity is the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -314,6 +314,12 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     list(APPEND TEST_SOURCES test_automation_bake.cpp)
     # The LFO engine: shapes, rates, triggers and gates (#2119).
     list(APPEND TEST_SOURCES test_mod_lfo.cpp)
+    # The remaining three modifier engines, and the feeds two of them need
+    # (#2120): the envelope's gate, the walk, and the follower's source.
+    list(APPEND TEST_SOURCES test_mod_adsr.cpp)
+    list(APPEND TEST_SOURCES test_mod_random.cpp)
+    list(APPEND TEST_SOURCES test_mod_follower.cpp)
+    list(APPEND TEST_SOURCES test_mod_feeds.cpp)
     list(APPEND TEST_SOURCES test_tempo_map.cpp)
     list(APPEND TEST_SOURCES test_transport_clock.cpp)
     list(APPEND TEST_SOURCES test_click_generator.cpp)

--- a/tests/PlanGoldenFixtures.cpp
+++ b/tests/PlanGoldenFixtures.cpp
@@ -284,6 +284,84 @@ Fixture parameterLinks() {
     return value;
 }
 
+/// The modulation feeds (#2120). What the plan compiler could not express
+/// before this slice: a rack sidechained from another track, whose modifiers
+/// listen to that track rather than to the one they live on, plus the two kinds
+/// that listen without a trigger mode saying so.
+///
+/// Both sides of the edge are here on purpose. The plan gains one tap per
+/// listened-to track, and the table records which modifier is on the far end of
+/// it, so a golden that showed only one of the two could go on holding while
+/// the other drifted.
+Fixture modulationSources() {
+    Fixture value;
+    value.name = "modulation-sources";
+    value.covers = "the tracks modifiers listen to, and the taps that carry them";
+
+    // The source. Nothing else reads it, so without the modifiers listening it
+    // would be routed to master and no further.
+    auto source = track(2);
+    source.chain.fxChainElements.push_back(makeDeviceElement(effect(9)));
+
+    // A rack keyed from the source, with an envelope its notes gate and a
+    // follower tracking its level through a band limit.
+    RackInfo rack;
+    rack.id = 4;
+    rack.name = "Ducker";
+    rack.sidechain.type = SidechainConfig::Type::Audio;
+    rack.sidechain.sourceTrackId = 2;
+    rack.mods = createDefaultMods(2);
+
+    rack.mods[0].type = ModType::Envelope;
+    rack.mods[0].triggerMode = LFOTriggerMode::MIDI;
+    rack.mods[0].envAttackMs = 5.0f;
+    rack.mods[0].envDecayMs = 120.0f;
+    rack.mods[0].envSustain = 0.4f;
+    rack.mods[0].envReleaseMs = 250.0f;
+    rack.mods[0].envAttackCurve = 0.25f;
+    rack.mods[0].links.push_back(
+        ModLink{ControlTarget::pluginParam(ChainNodePath::chainDevice(1, 4, 10, 7), 0), 0.75f,
+                false, true});
+
+    rack.mods[1].type = ModType::Follower;
+    rack.mods[1].followerGainDb = 6.0f;
+    rack.mods[1].followerAttackMs = 20.0f;
+    rack.mods[1].followerHoldMs = 30.0f;
+    rack.mods[1].followerReleaseMs = 400.0f;
+    rack.mods[1].followerHpEnabled = true;
+    rack.mods[1].followerHpFreq = 150.0f;
+    rack.mods[1].links.push_back(ModLink{
+        ControlTarget::pluginParam(ChainNodePath::chainDevice(1, 4, 10, 7), 1), 0.5f, true, true});
+
+    ChainInfo chain;
+    chain.id = 10;
+    chain.name = "Chain";
+    chain.elements.push_back(makeDeviceElement(effectWithParameters(7, 2)));
+    rack.chains.push_back(std::move(chain));
+
+    auto destination = track(1);
+    destination.chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
+
+    // And a random walk on the destination track itself, listening to nothing:
+    // a modifier with no trigger and no source is what most of them are, and it
+    // is here so the golden shows the difference.
+    destination.mods = createDefaultMods(1);
+    destination.mods[0].type = ModType::Random;
+    destination.mods[0].randomShape = 0.5f;
+    destination.mods[0].randomSmooth = 0.25f;
+    destination.mods[0].randomStepDepth = 0.6f;
+    destination.mods[0].tempoSync = true;
+    destination.mods[0].syncDivision = SyncDivision::Sixteenth;
+    destination.mods[0].links.push_back(
+        ModLink{ControlTarget::pluginParam(ChainNodePath::chainDevice(1, 4, 10, 7), 1), 0.25f,
+                false, true});
+
+    value.tracks = {destination, source};
+    value.master = master();
+    value.options = withoutMeters();
+    return value;
+}
+
 Fixture groupRouting() {
     Fixture value;
     value.name = "group-routing";
@@ -367,6 +445,7 @@ std::vector<Fixture> planFixtures() {
     fixtures.push_back(sectionLocalDeviceIds());
     fixtures.push_back(groupRouting());
     fixtures.push_back(parameterLinks());
+    fixtures.push_back(modulationSources());
     fixtures.push_back(insertDevice());
     fixtures.push_back(removeDevice());
     fixtures.push_back(reorderDevices());

--- a/tests/PlanGoldenFixtures.cpp
+++ b/tests/PlanGoldenFixtures.cpp
@@ -323,7 +323,7 @@ Fixture modulationSources() {
         ModLink{ControlTarget::pluginParam(ChainNodePath::chainDevice(1, 4, 10, 7), 0), 0.75f,
                 false, true});
 
-    rack.mods[1].type = ModType::Follower;
+    rack.mods[1].setType(ModType::Follower);
     rack.mods[1].followerGainDb = 6.0f;
     rack.mods[1].followerAttackMs = 20.0f;
     rack.mods[1].followerHoldMs = 30.0f;

--- a/tests/goldens/plan/modulation-sources.txt
+++ b/tests/goldens/plan/modulation-sources.txt
@@ -5,70 +5,72 @@
 
 == plan ==
 magda-render-plan v1
-ops=29 outputs=1
-[  0] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
-[  1] MixAudio    det   T2:trackAudioInput             in=0:0              out=audio       deps=1
-[  2] ClipMidi    det   T2:clipMidi                    in=-                out=midi        deps=0
-[  3] MergeMidi   det   T2:trackMidiInput              in=2:0              out=midi        deps=1
-[  4] Delay       det   T2/D9:deviceInputDelay         in=1:0              out=audio       deps=1
-[  5] Delay       det   T2/D9:deviceInputDelay#1       in=3:0              out=midi        deps=1
-[  6] Device      det   T2/D9:deviceProcess            in=4:0,5:0,-        out=audio       deps=2
-[  7] Gain        det   T2/D9:deviceGain               in=6:0              out=audio       deps=1
-[  8] Fader       det   T2:trackFader                  in=7:0,-            out=audio       deps=1
-[  9] Meter       det   T2:trackMeter                  in=8:0              out=audio       deps=1
-[ 10] Gain        det   T2:trackMute                   in=9:0              out=audio       deps=1
-[ 11] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
-[ 12] MixAudio    det   T1:trackAudioInput             in=11:0             out=audio       deps=1
-[ 13] Device      det   T1/R4/C10/D7:deviceProcess     in=12:0,-,-         out=audio       deps=1
-[ 14] Gain        det   T1/R4/C10/D7:deviceGain        in=13:0             out=audio       deps=1
-[ 15] Fader       det   T1/R4/C10:rackChainFader       in=14:0,-           out=audio       deps=1
-[ 16] MixAudio    det   T1/R4:rackMix                  in=15:0             out=audio       deps=1
-[ 17] Fader       det   T1/R4:rackFader                in=16:0,-           out=audio       deps=1
-[ 18] Fader       det   T1:trackFader                  in=17:0,-           out=audio       deps=1
-[ 19] Meter       det   T1:trackMeter                  in=18:0             out=audio       deps=1
-[ 20] Gain        det   T1:trackMute                   in=19:0             out=audio       deps=1
-[ 21] Delay       det   T-2:mixInputDelay              in=10:0             out=audio       deps=1
+ops=30 outputs=1
+[  0] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T1:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] Device      det   T1/R4/C10/D7:deviceProcess     in=1:0,-,-          out=audio       deps=1
+[  3] Gain        det   T1/R4/C10/D7:deviceGain        in=2:0              out=audio       deps=1
+[  4] Fader       det   T1/R4/C10:rackChainFader       in=3:0,-            out=audio       deps=1
+[  5] MixAudio    det   T1/R4:rackMix                  in=4:0              out=audio       deps=1
+[  6] Fader       det   T1/R4:rackFader                in=5:0,-            out=audio       deps=1
+[  7] Fader       det   T1:trackFader                  in=6:0,-            out=audio       deps=1
+[  8] Meter       det   T1:trackMeter                  in=7:0              out=audio       deps=1
+[  9] Gain        det   T1:trackMute                   in=8:0              out=audio       deps=1
+[ 10] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
+[ 11] MixAudio    det   T2:trackAudioInput             in=10:0             out=audio       deps=1
+[ 12] ClipMidi    det   T2:clipMidi                    in=-                out=midi        deps=0
+[ 13] MergeMidi   det   T2:trackMidiInput              in=12:0             out=midi        deps=1
+[ 14] Delay       det   T2/D9:deviceInputDelay         in=11:0             out=audio       deps=1
+[ 15] Delay       det   T2/D9:deviceInputDelay#1       in=13:0             out=midi        deps=1
+[ 16] Device      det   T2/D9:deviceProcess            in=14:0,15:0,-      out=audio       deps=2
+[ 17] Gain        det   T2/D9:deviceGain               in=16:0             out=audio       deps=1
+[ 18] Fader       det   T2:trackFader                  in=17:0,-           out=audio       deps=1
+[ 19] Meter       det   T2:trackMeter                  in=18:0             out=audio       deps=1
+[ 20] Gain        det   T2:trackMute                   in=19:0             out=audio       deps=1
+[ 21] Delay       det   T-2:mixInputDelay              in=9:0              out=audio       deps=1
 [ 22] Delay       det   T-2:mixInputDelay#1            in=20:0             out=audio       deps=1
 [ 23] MixAudio    det   T-2:trackAudioInput            in=21:0,22:0        out=audio       deps=2
 [ 24] Fader       det   T-2:trackFader                 in=23:0,-           out=audio       deps=1
 [ 25] Meter       det   T-2:trackMeter                 in=24:0             out=audio       deps=1
 [ 26] Gain        det   T-2:trackMute                  in=25:0             out=audio       deps=1
 [ 27] Output      det   T-2:hardwareOutput             in=26:0             out=-           deps=1
-[ 28] ModSource   det   T2:modulationTap               in=9:0,3:0          out=-           deps=2
-ready=0,2,11
+[ 28] ModSource   det   T2:modulationTap               in=11:0,13:0        out=-           deps=2
+[ 29] ModSource   det   T2:modulationTap#1             in=19:0,-           out=-           deps=1
+ready=0,10,12
 
 == layout ==
 magda-plan-layout v1
-audioSlots=3 midiSlots=2 outputLatency=0
-[  0] ClipAudio   T2:clipAudio                   lat=0       ports=a0
-[  1] MixAudio    T2:trackAudioInput             lat=0       ports=a0          inplace
-[  2] ClipMidi    T2:clipMidi                    lat=0       ports=m0
-[  3] MergeMidi   T2:trackMidiInput              lat=0       ports=m1
-[  4] Delay       T2/D9:deviceInputDelay         lat=0       ports=a0          hold=0 elided
-[  5] Delay       T2/D9:deviceInputDelay#1       lat=0       ports=m1          hold=0 elided
-[  6] Device      T2/D9:deviceProcess            lat=0       ports=a0          inplace
-[  7] Gain        T2/D9:deviceGain               lat=0       ports=a0          inplace
-[  8] Fader       T2:trackFader                  lat=0       ports=a0          inplace
-[  9] Meter       T2:trackMeter                  lat=0       ports=a0          inplace
-[ 10] Gain        T2:trackMute                   lat=0       ports=a1
-[ 11] ClipAudio   T1:clipAudio                   lat=0       ports=a2
-[ 12] MixAudio    T1:trackAudioInput             lat=0       ports=a2          inplace
-[ 13] Device      T1/R4/C10/D7:deviceProcess     lat=0       ports=a2          inplace
-[ 14] Gain        T1/R4/C10/D7:deviceGain        lat=0       ports=a2          inplace
-[ 15] Fader       T1/R4/C10:rackChainFader       lat=0       ports=a2          inplace
-[ 16] MixAudio    T1/R4:rackMix                  lat=0       ports=a2          inplace
-[ 17] Fader       T1/R4:rackFader                lat=0       ports=a2          inplace
-[ 18] Fader       T1:trackFader                  lat=0       ports=a2          inplace
-[ 19] Meter       T1:trackMeter                  lat=0       ports=a2          inplace
-[ 20] Gain        T1:trackMute                   lat=0       ports=a2          inplace
-[ 21] Delay       T-2:mixInputDelay              lat=0       ports=a1          hold=0 elided
-[ 22] Delay       T-2:mixInputDelay#1            lat=0       ports=a2          hold=0 elided
-[ 23] MixAudio    T-2:trackAudioInput            lat=0       ports=a1          inplace
-[ 24] Fader       T-2:trackFader                 lat=0       ports=a1          inplace
-[ 25] Meter       T-2:trackMeter                 lat=0       ports=a1          inplace
-[ 26] Gain        T-2:trackMute                  lat=0       ports=a1          inplace
+audioSlots=4 midiSlots=2 outputLatency=0
+[  0] ClipAudio   T1:clipAudio                   lat=0       ports=a0
+[  1] MixAudio    T1:trackAudioInput             lat=0       ports=a0          inplace
+[  2] Device      T1/R4/C10/D7:deviceProcess     lat=0       ports=a0          inplace
+[  3] Gain        T1/R4/C10/D7:deviceGain        lat=0       ports=a0          inplace
+[  4] Fader       T1/R4/C10:rackChainFader       lat=0       ports=a0          inplace
+[  5] MixAudio    T1/R4:rackMix                  lat=0       ports=a0          inplace
+[  6] Fader       T1/R4:rackFader                lat=0       ports=a0          inplace
+[  7] Fader       T1:trackFader                  lat=0       ports=a0          inplace
+[  8] Meter       T1:trackMeter                  lat=0       ports=a0          inplace
+[  9] Gain        T1:trackMute                   lat=0       ports=a0          inplace
+[ 10] ClipAudio   T2:clipAudio                   lat=0       ports=a1
+[ 11] MixAudio    T2:trackAudioInput             lat=0       ports=a1          inplace
+[ 12] ClipMidi    T2:clipMidi                    lat=0       ports=m0
+[ 13] MergeMidi   T2:trackMidiInput              lat=0       ports=m1
+[ 14] Delay       T2/D9:deviceInputDelay         lat=0       ports=a1          hold=0 elided
+[ 15] Delay       T2/D9:deviceInputDelay#1       lat=0       ports=m1          hold=0 elided
+[ 16] Device      T2/D9:deviceProcess            lat=0       ports=a2
+[ 17] Gain        T2/D9:deviceGain               lat=0       ports=a2          inplace
+[ 18] Fader       T2:trackFader                  lat=0       ports=a2          inplace
+[ 19] Meter       T2:trackMeter                  lat=0       ports=a2          inplace
+[ 20] Gain        T2:trackMute                   lat=0       ports=a3
+[ 21] Delay       T-2:mixInputDelay              lat=0       ports=a0          hold=0 elided
+[ 22] Delay       T-2:mixInputDelay#1            lat=0       ports=a3          hold=0 elided
+[ 23] MixAudio    T-2:trackAudioInput            lat=0       ports=a0          inplace
+[ 24] Fader       T-2:trackFader                 lat=0       ports=a0          inplace
+[ 25] Meter       T-2:trackMeter                 lat=0       ports=a0          inplace
+[ 26] Gain        T-2:trackMute                  lat=0       ports=a0          inplace
 [ 27] Output      T-2:hardwareOutput             lat=-       ports=-
 [ 28] ModSource   T2:modulationTap               lat=-       ports=-
+[ 29] ModSource   T2:modulationTap#1             lat=-       ports=-
 
 == params ==
 magda-param-table v1
@@ -80,6 +82,6 @@ params=2 modifiers=3 links=3
       <- mod[  2] amount=0.500 bipolar=1
 modifiers:
 [  0] T1:mod0                      random    value=0.500 stepped sync[16] transport shape=0.500 smooth=0.250 step=0.600
-[  1] T1/R4:mod0                   adsr      value=0.500 a=5.000ms d=120.000ms s=0.400 r=250.000ms note curves[0.250,0.000,0.000] source=track[2]
-[  2] T1/R4:mod1                   follower  value=0.500 gain=6.000dB a=20.000ms h=30.000ms r=400.000ms hp=150.000Hz source=track[2]
+[  1] T1/R4:mod0                   adsr      value=0.500 a=5.000ms d=120.000ms s=0.400 r=250.000ms note curves[0.250,0.000,0.000] source=track[2] prefx
+[  2] T1/R4:mod1                   follower  value=0.500 gain=6.000dB a=20.000ms h=30.000ms r=400.000ms hp=150.000Hz source=track[2] postfader
 order: m0 m1 0 m2 1

--- a/tests/goldens/plan/modulation-sources.txt
+++ b/tests/goldens/plan/modulation-sources.txt
@@ -1,0 +1,85 @@
+# modulation-sources
+# the tracks modifiers listen to, and the taps that carry them
+#
+# Generated. See tests/test_plan_goldens.cpp to regenerate.
+
+== plan ==
+magda-render-plan v1
+ops=29 outputs=1
+[  0] ClipAudio   det   T2:clipAudio                   in=-                out=audio       deps=0
+[  1] MixAudio    det   T2:trackAudioInput             in=0:0              out=audio       deps=1
+[  2] ClipMidi    det   T2:clipMidi                    in=-                out=midi        deps=0
+[  3] MergeMidi   det   T2:trackMidiInput              in=2:0              out=midi        deps=1
+[  4] Delay       det   T2/D9:deviceInputDelay         in=1:0              out=audio       deps=1
+[  5] Delay       det   T2/D9:deviceInputDelay#1       in=3:0              out=midi        deps=1
+[  6] Device      det   T2/D9:deviceProcess            in=4:0,5:0,-        out=audio       deps=2
+[  7] Gain        det   T2/D9:deviceGain               in=6:0              out=audio       deps=1
+[  8] Fader       det   T2:trackFader                  in=7:0,-            out=audio       deps=1
+[  9] Meter       det   T2:trackMeter                  in=8:0              out=audio       deps=1
+[ 10] Gain        det   T2:trackMute                   in=9:0              out=audio       deps=1
+[ 11] ClipAudio   det   T1:clipAudio                   in=-                out=audio       deps=0
+[ 12] MixAudio    det   T1:trackAudioInput             in=11:0             out=audio       deps=1
+[ 13] Device      det   T1/R4/C10/D7:deviceProcess     in=12:0,-,-         out=audio       deps=1
+[ 14] Gain        det   T1/R4/C10/D7:deviceGain        in=13:0             out=audio       deps=1
+[ 15] Fader       det   T1/R4/C10:rackChainFader       in=14:0,-           out=audio       deps=1
+[ 16] MixAudio    det   T1/R4:rackMix                  in=15:0             out=audio       deps=1
+[ 17] Fader       det   T1/R4:rackFader                in=16:0,-           out=audio       deps=1
+[ 18] Fader       det   T1:trackFader                  in=17:0,-           out=audio       deps=1
+[ 19] Meter       det   T1:trackMeter                  in=18:0             out=audio       deps=1
+[ 20] Gain        det   T1:trackMute                   in=19:0             out=audio       deps=1
+[ 21] Delay       det   T-2:mixInputDelay              in=10:0             out=audio       deps=1
+[ 22] Delay       det   T-2:mixInputDelay#1            in=20:0             out=audio       deps=1
+[ 23] MixAudio    det   T-2:trackAudioInput            in=21:0,22:0        out=audio       deps=2
+[ 24] Fader       det   T-2:trackFader                 in=23:0,-           out=audio       deps=1
+[ 25] Meter       det   T-2:trackMeter                 in=24:0             out=audio       deps=1
+[ 26] Gain        det   T-2:trackMute                  in=25:0             out=audio       deps=1
+[ 27] Output      det   T-2:hardwareOutput             in=26:0             out=-           deps=1
+[ 28] ModSource   det   T2:modulationTap               in=9:0,3:0          out=-           deps=2
+ready=0,2,11
+
+== layout ==
+magda-plan-layout v1
+audioSlots=3 midiSlots=2 outputLatency=0
+[  0] ClipAudio   T2:clipAudio                   lat=0       ports=a0
+[  1] MixAudio    T2:trackAudioInput             lat=0       ports=a0          inplace
+[  2] ClipMidi    T2:clipMidi                    lat=0       ports=m0
+[  3] MergeMidi   T2:trackMidiInput              lat=0       ports=m1
+[  4] Delay       T2/D9:deviceInputDelay         lat=0       ports=a0          hold=0 elided
+[  5] Delay       T2/D9:deviceInputDelay#1       lat=0       ports=m1          hold=0 elided
+[  6] Device      T2/D9:deviceProcess            lat=0       ports=a0          inplace
+[  7] Gain        T2/D9:deviceGain               lat=0       ports=a0          inplace
+[  8] Fader       T2:trackFader                  lat=0       ports=a0          inplace
+[  9] Meter       T2:trackMeter                  lat=0       ports=a0          inplace
+[ 10] Gain        T2:trackMute                   lat=0       ports=a1
+[ 11] ClipAudio   T1:clipAudio                   lat=0       ports=a2
+[ 12] MixAudio    T1:trackAudioInput             lat=0       ports=a2          inplace
+[ 13] Device      T1/R4/C10/D7:deviceProcess     lat=0       ports=a2          inplace
+[ 14] Gain        T1/R4/C10/D7:deviceGain        lat=0       ports=a2          inplace
+[ 15] Fader       T1/R4/C10:rackChainFader       lat=0       ports=a2          inplace
+[ 16] MixAudio    T1/R4:rackMix                  lat=0       ports=a2          inplace
+[ 17] Fader       T1/R4:rackFader                lat=0       ports=a2          inplace
+[ 18] Fader       T1:trackFader                  lat=0       ports=a2          inplace
+[ 19] Meter       T1:trackMeter                  lat=0       ports=a2          inplace
+[ 20] Gain        T1:trackMute                   lat=0       ports=a2          inplace
+[ 21] Delay       T-2:mixInputDelay              lat=0       ports=a1          hold=0 elided
+[ 22] Delay       T-2:mixInputDelay#1            lat=0       ports=a2          hold=0 elided
+[ 23] MixAudio    T-2:trackAudioInput            lat=0       ports=a1          inplace
+[ 24] Fader       T-2:trackFader                 lat=0       ports=a1          inplace
+[ 25] Meter       T-2:trackMeter                 lat=0       ports=a1          inplace
+[ 26] Gain        T-2:trackMute                  lat=0       ports=a1          inplace
+[ 27] Output      T-2:hardwareOutput             lat=-       ports=-
+[ 28] ModSource   T2:modulationTap               lat=-       ports=-
+
+== params ==
+magda-param-table v1
+params=2 modifiers=3 links=3
+[  0] T1/D7:param0                 lin[0.000,100.000] base=0.000  links=1
+      <- mod[  1] amount=0.750 bipolar=0
+[  1] T1/D7:param1                 lin[0.000,100.000] base=0.250  links=2
+      <- mod[  0] amount=0.250 bipolar=0
+      <- mod[  2] amount=0.500 bipolar=1
+modifiers:
+[  0] T1:mod0                      random    value=0.500 stepped sync[16] transport shape=0.500 smooth=0.250 step=0.600
+[  1] T1/R4:mod0                   adsr      value=0.500 a=5.000ms d=120.000ms s=0.400 r=250.000ms note curves[0.250,0.000,0.000] source=track[2]
+[  2] T1/R4:mod1                   follower  value=0.500 gain=6.000dB a=20.000ms h=30.000ms r=400.000ms hp=150.000Hz source=track[2]
+order: m0 m1 0 m2 1

--- a/tests/test_mod_adsr.cpp
+++ b/tests/test_mod_adsr.cpp
@@ -1,0 +1,606 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <vector>
+
+#include "core/RackInfo.hpp"
+#include "core/TrackInfo.hpp"
+#include "param/ModAdsr.hpp"
+#include "param/ModRuntime.hpp"
+#include "param/ParamResolve.hpp"
+#include "param/ParamTableCompiler.hpp"
+#include "plan/PlanCompiler.hpp"
+
+/**
+ * @file test_mod_adsr.cpp
+ * @brief The envelope generator (#2120).
+ *
+ * Three claims, separable the way the LFO's are. The shape is the fork's: a
+ * segment's curvature is a persisted number and what it draws has to be the
+ * same curve in both engines. The run is the engine's: which stage the envelope
+ * is in after a block, what a gate edge does from each of them, and what a
+ * tempo-synced stage is worth in seconds. And the wiring is the table's: that
+ * the model's seven fields reach the block and that the value comes out of a
+ * device the far end.
+ */
+
+using namespace magda;
+using magda::engine::adsrSegmentAt;
+using magda::engine::AdsrSettings;
+using magda::engine::AdsrStage;
+using magda::engine::adsrStageSeconds;
+using magda::engine::AdsrState;
+using magda::engine::advanceAdsr;
+using magda::engine::BlockInfo;
+using magda::engine::compileParamTable;
+using magda::engine::compileRenderPlan;
+using magda::engine::ModContribution;
+using magda::engine::ModKind;
+using magda::engine::ModRuntime;
+using magda::engine::ModSync;
+using magda::engine::ModTiming;
+using magda::engine::ParamKey;
+using magda::engine::ParamSegment;
+using magda::engine::ParamTable;
+using magda::engine::ResolvedParams;
+using magda::engine::resolveParams;
+using magda::engine::restartAdsr;
+
+namespace {
+
+Catch::Approx approx(float value) {
+    return Catch::Approx(value).margin(1e-4);
+}
+
+constexpr double kSampleRate = 48000.0;
+
+ModTiming timing(double bpm = 120.0, int numerator = 4, int denominator = 4) {
+    return ModTiming{kSampleRate, bpm, numerator, denominator};
+}
+
+/// A block of @p numSamples with the transport rolling, which is what a
+/// transport-gated envelope needs and what a free-running one ignores.
+BlockInfo rollingBlock(int numSamples, bool playing = true) {
+    BlockInfo block;
+    block.numSamples = numSamples;
+    block.playing = playing;
+    return block;
+}
+
+/// A block a millisecond long at the test's sample rate, which makes a stage
+/// length in milliseconds a block count.
+BlockInfo millisecondBlock(bool playing = true) {
+    return rollingBlock(static_cast<int>(kSampleRate / 1000.0), playing);
+}
+
+/// An envelope with round stage lengths: ten blocks up, ten down to a half, ten
+/// back to nothing, when stepped a millisecond at a time.
+AdsrSettings tenTenTen(ModSync sync = ModSync::Note) {
+    AdsrSettings settings;
+    settings.attackMs = 10.0f;
+    settings.decayMs = 10.0f;
+    settings.sustain = 0.5f;
+    settings.releaseMs = 10.0f;
+    settings.sync = sync;
+    settings.trigger = sync == ModSync::Note ? LFOTriggerMode::MIDI : LFOTriggerMode::Free;
+    return settings;
+}
+
+float step(AdsrState& state, const AdsrSettings& settings, const BlockInfo& block,
+           const ModTiming& time = timing()) {
+    return advanceAdsr(state, settings, block, time);
+}
+
+/// Run @p count blocks and return the last value.
+float run(AdsrState& state, const AdsrSettings& settings, int count,
+          const BlockInfo& block = millisecondBlock()) {
+    float value = 0.0f;
+    for (int i = 0; i < count; ++i)
+        value = step(state, settings, block);
+    return value;
+}
+
+TrackInfo makeTrack(TrackId id) {
+    TrackInfo track;
+    track.id = id;
+    track.name = "Track " + juce::String(id);
+    track.audioOutputDevice = "master";
+    track.mods = createDefaultMods(0);
+    return track;
+}
+
+TrackInfo makeMaster() {
+    auto master = makeTrack(MASTER_TRACK_ID);
+    master.type = TrackType::Master;
+    master.audioOutputDevice = {};
+    return master;
+}
+
+DeviceInfo makeDevice(DeviceId id) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Effect " + juce::String(id);
+    device.deviceType = DeviceType::Effect;
+    device.mods = createDefaultMods(0);
+
+    ParameterInfo info(0, "Level", "", 0.0f, 1.0f, 0.0f);
+    info.currentValue = 0.0f;
+    device.parameters.push_back(info);
+
+    return device;
+}
+
+/// A track with one device and one envelope wired to that device's parameter.
+TrackInfo trackWithEnvelope(LFOTriggerMode trigger = LFOTriggerMode::Free, bool running = true) {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7)));
+    track.mods = createDefaultMods(1);
+    track.mods[0].type = ModType::Envelope;
+    track.mods[0].triggerMode = trigger;
+
+    // Whether the model says the envelope is already open. A note-triggered one
+    // that is not running starts shut, which is what waiting for a note is.
+    track.mods[0].running = running;
+    track.mods[0].envAttackMs = 10.0f;
+    track.mods[0].envDecayMs = 10.0f;
+    track.mods[0].envSustain = 0.5f;
+    track.mods[0].envReleaseMs = 10.0f;
+    track.mods[0].links.push_back(ModLink{
+        ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0), 1.0f, false, true});
+    return track;
+}
+
+ParamKey deviceParam(TrackId track, DeviceId device, int index) {
+    ParamKey key;
+    key.kind = ParamKey::Kind::DeviceParam;
+    key.scope = ParamKey::Scope::Device;
+    key.trackId = track;
+    key.device = magda::engine::DeviceKey{ChainSegment::Fx, device};
+    key.index = index;
+    return key;
+}
+
+ParamTable tableFor(const std::vector<TrackInfo>& tracks) {
+    const auto master = makeMaster();
+    const auto plan = compileRenderPlan(tracks, master);
+    return compileParamTable(plan, tracks, master, {});
+}
+
+struct Harness {
+    explicit Harness(const ParamTable& table)
+        : links(static_cast<std::size_t>(std::max(table.maxLinksPerParam, 1))),
+          segments(
+              static_cast<std::size_t>(magda::engine::ResolvedParams::kDefaultSegmentCapacity)) {
+        values.prepare(table.size());
+        mods.prepare(table, magda::engine::RenderContext{kSampleRate, 512, 2});
+    }
+
+    void run(const ParamTable& table, const BlockInfo& block) {
+        resolveParams(table, values, links, segments, block, &mods);
+    }
+
+    ResolvedParams values;
+    ModRuntime mods;
+    std::vector<ModContribution> links;
+    std::vector<ParamSegment> segments;
+};
+
+}  // namespace
+
+// =============================================================================
+// The shape
+// =============================================================================
+
+TEST_CASE("A segment with no curvature is a straight line", "[engine][mod][adsr]") {
+    CHECK(adsrSegmentAt(0.0f, 0.0f, 1.0f, 0.0f) == approx(0.0f));
+    CHECK(adsrSegmentAt(0.5f, 0.0f, 1.0f, 0.0f) == approx(0.5f));
+    CHECK(adsrSegmentAt(1.0f, 0.0f, 1.0f, 0.0f) == approx(1.0f));
+
+    // Falling as well as rising, and between two values neither of which is an
+    // end of the range: a release from a half-open envelope is one of these.
+    CHECK(adsrSegmentAt(0.25f, 0.8f, 0.4f, 0.0f) == approx(0.7f));
+
+    // A segment that does not travel has nothing to bend, whatever the
+    // curvature says. The bezier would be asked for the y at an x on a line of
+    // no height.
+    CHECK(adsrSegmentAt(0.5f, 0.3f, 0.3f, 0.4f) == approx(0.3f));
+}
+
+TEST_CASE("Curvature bends a segment without moving its ends", "[engine][mod][adsr]") {
+    // Whatever the bend, a segment starts where it starts and arrives where it
+    // arrives: the curvature is about the route.
+    for (const float curve : {-0.5f, -0.25f, 0.25f, 0.5f}) {
+        CHECK(adsrSegmentAt(0.0f, 0.0f, 1.0f, curve) == approx(0.0f));
+        CHECK(adsrSegmentAt(1.0f, 0.0f, 1.0f, curve) == approx(1.0f));
+    }
+
+    // Positive curvature is the exponential side: slow away from the start and
+    // fast into the end, so the midpoint sits below the straight line.
+    CHECK(adsrSegmentAt(0.5f, 0.0f, 1.0f, 0.5f) < 0.5f);
+
+    // Negative is the logarithmic one, and the two are reflections about the
+    // line rather than about each other's shape.
+    CHECK(adsrSegmentAt(0.5f, 0.0f, 1.0f, -0.5f) > 0.5f);
+
+    // Monotonic in between: a bent attack still only rises.
+    float previous = -1.0f;
+    for (int i = 0; i <= 20; ++i) {
+        const auto value = adsrSegmentAt(static_cast<float>(i) / 20.0f, 0.0f, 1.0f, 0.35f);
+        CHECK(value >= previous);
+        previous = value;
+    }
+}
+
+TEST_CASE("A stage runs in milliseconds unless the envelope is synced", "[engine][mod][adsr]") {
+    AdsrSettings settings;
+    CHECK(adsrStageSeconds(250.0f, settings, timing()) == Catch::Approx(0.25));
+
+    // Synced, a stage is the division rather than the time, and the division is
+    // the one the model carries for all three stages. A quarter at 120 is half
+    // a second.
+    settings.tempoSync = true;
+    settings.rateType = static_cast<int>(ModRateType::Quarter);
+    CHECK(adsrStageSeconds(250.0f, settings, timing()) == Catch::Approx(0.5));
+
+    // The signature counts, because a division is a fraction of a bar: a bar of
+    // three four is three beats, so a bar-long stage is a second and a half.
+    settings.rateType = static_cast<int>(ModRateType::Bar);
+    CHECK(adsrStageSeconds(250.0f, settings, timing(120.0, 3, 4)) == Catch::Approx(1.5));
+
+    // Hertz is not a division. The model reaches that by having tempo sync on
+    // with nothing musical selected, and the fork's answer is the milliseconds.
+    settings.rateType = static_cast<int>(ModRateType::Hertz);
+    CHECK(adsrStageSeconds(250.0f, settings, timing()) == Catch::Approx(0.25));
+}
+
+// =============================================================================
+// The run
+// =============================================================================
+
+TEST_CASE("A gate opening runs the envelope through its stages", "[engine][mod][adsr]") {
+    const auto settings = tenTenTen();
+    AdsrState state;
+
+    // Shut to begin with, because a MIDI-triggered envelope waits for a note.
+    state.gated = true;
+    state.started = true;
+    state.trigger = settings.trigger;
+
+    CHECK(step(state, settings, millisecondBlock()) == approx(0.0f));
+    CHECK(state.stage == AdsrStage::Idle);
+
+    state.gated = false;
+
+    // Advanced first and published after, which is the fork's ADSR timer: the
+    // value a block renders with is where the envelope ends up. One block into
+    // a ten-block attack is a tenth of the way up.
+    CHECK(step(state, settings, millisecondBlock()) == approx(0.1f));
+    CHECK(state.stage == AdsrStage::Attack);
+
+    // Through the attack and into the decay, which falls from the top to the
+    // sustain level over its own ten blocks.
+    CHECK(run(state, settings, 9) == approx(1.0f));
+    CHECK(state.stage == AdsrStage::Decay);
+
+    CHECK(run(state, settings, 5) == approx(0.75f));
+    CHECK(run(state, settings, 5) == approx(0.5f));
+    CHECK(state.stage == AdsrStage::Sustain);
+
+    // Held there for as long as the gate stays open, which is what makes it a
+    // sustain rather than a stage.
+    CHECK(run(state, settings, 50) == approx(0.5f));
+    CHECK(state.stage == AdsrStage::Sustain);
+}
+
+TEST_CASE("A gate shutting releases from wherever the envelope is", "[engine][mod][adsr]") {
+    const auto settings = tenTenTen();
+
+    SECTION("from the sustain") {
+        AdsrState state;
+        run(state, settings, 25);
+        REQUIRE(state.stage == AdsrStage::Sustain);
+
+        state.gated = true;
+        CHECK(run(state, settings, 5) == approx(0.25f));
+        CHECK(state.stage == AdsrStage::Release);
+
+        CHECK(run(state, settings, 5) == approx(0.0f));
+        CHECK(state.stage == AdsrStage::Idle);
+    }
+
+    SECTION("from halfway up the attack") {
+        AdsrState state;
+        const auto reached = run(state, settings, 5);
+        REQUIRE(state.stage == AdsrStage::Attack);
+        REQUIRE(reached == approx(0.5f));
+
+        // The release starts from where the envelope was, not from the top:
+        // that is what makes a gate change click-free from any stage.
+        state.gated = true;
+        CHECK(run(state, settings, 5) == approx(0.25f));
+        CHECK(run(state, settings, 5) == approx(0.0f));
+    }
+}
+
+TEST_CASE("A free-running envelope cycles without a gate", "[engine][mod][adsr]") {
+    const auto settings = tenTenTen(ModSync::Free);
+    AdsrState state;
+
+    // No note and no transport, and it runs anyway: the gate is held open, and
+    // the sustain is skipped so the cycle is attack, decay, release.
+    CHECK(run(state, settings, 10) == approx(1.0f));
+    CHECK(run(state, settings, 10) == approx(0.5f));
+
+    // Straight from the sustain into the release rather than resting there.
+    CHECK(state.stage == AdsrStage::Release);
+    CHECK(run(state, settings, 10) == approx(0.0f));
+
+    // And round again, rather than stopping at idle.
+    CHECK(run(state, settings, 5) == approx(0.5f));
+    CHECK(state.stage == AdsrStage::Attack);
+}
+
+TEST_CASE("A transport-locked envelope is gated by playback", "[engine][mod][adsr]") {
+    auto settings = tenTenTen(ModSync::Transport);
+    settings.trigger = LFOTriggerMode::Transport;
+
+    AdsrState state;
+
+    // Stopped is shut, and a shut gate that has never opened is silence rather
+    // than a release.
+    CHECK(run(state, settings, 5, millisecondBlock(false)) == approx(0.0f));
+    CHECK(state.stage == AdsrStage::Idle);
+
+    CHECK(run(state, settings, 10, millisecondBlock(true)) == approx(1.0f));
+
+    // Stopping releases, from wherever the envelope had got to.
+    CHECK(run(state, settings, 5, millisecondBlock(false)) == approx(0.5f));
+    CHECK(state.stage == AdsrStage::Release);
+}
+
+TEST_CASE("A stage with no time in it is instant", "[engine][mod][adsr]") {
+    auto settings = tenTenTen();
+    settings.attackMs = 0.0f;
+    AdsrState state;
+
+    // Straight to the top and on into the decay within the same block: an
+    // envelope with no attack is a click on purpose, and the rest of the block
+    // belongs to the stage after it.
+    CHECK(step(state, settings, millisecondBlock()) == approx(0.95f));
+    CHECK(state.stage == AdsrStage::Decay);
+
+    SECTION("and an envelope with no time anywhere still terminates") {
+        // Every stage instant and free running, so the cycle has no time in it
+        // anywhere and the block would walk it for ever. The bound is the
+        // fork's own, eight stages, and where in the cycle that leaves the
+        // envelope is a consequence of the bound rather than a claim: what
+        // matters is that the block ends and the output is a level.
+        AdsrSettings instant;
+        instant.attackMs = 0.0f;
+        instant.decayMs = 0.0f;
+        instant.releaseMs = 0.0f;
+        instant.sustain = 0.5f;
+        instant.sync = ModSync::Free;
+
+        AdsrState spinning;
+        const auto value = step(spinning, instant, millisecondBlock());
+        CHECK(value >= 0.0f);
+        CHECK(value <= 1.0f);
+    }
+}
+
+TEST_CASE("A block longer than a stage lands in the stage after it", "[engine][mod][adsr]") {
+    const auto settings = tenTenTen();
+    AdsrState state;
+
+    // A block of twelve milliseconds over a ten-millisecond attack: ten of it
+    // is the attack and the other two belong to the decay, which is a fifth of
+    // the way from the top to the sustain.
+    const auto block = rollingBlock(static_cast<int>(kSampleRate * 0.012));
+    CHECK(step(state, settings, block) == approx(0.9f));
+    CHECK(state.stage == AdsrStage::Decay);
+}
+
+TEST_CASE("A retrigger enters the attack from where the envelope was", "[engine][mod][adsr]") {
+    const auto settings = tenTenTen();
+    AdsrState state;
+
+    run(state, settings, 25);
+    REQUIRE(state.stage == AdsrStage::Sustain);
+
+    restartAdsr(state, settings, false);
+    CHECK(state.stage == AdsrStage::Attack);
+    CHECK(state.value == approx(0.5f));
+
+    // Halfway from the sustain to the top after five of the attack's ten
+    // blocks, rather than halfway from silence.
+    CHECK(run(state, settings, 5) == approx(0.75f));
+
+    SECTION("or from zero, which is what a cross-track trigger asks for") {
+        restartAdsr(state, settings, true);
+        CHECK(state.value == approx(0.0f));
+        CHECK(run(state, settings, 5) == approx(0.5f));
+    }
+}
+
+TEST_CASE("A mode change retires the gate the old mode left", "[engine][mod][adsr]") {
+    auto settings = tenTenTen();
+    settings.trigger = LFOTriggerMode::Audio;
+    settings.startGated = true;
+
+    AdsrState state;
+    CHECK(run(state, settings, 5) == approx(0.0f));
+    REQUIRE(state.gated);
+
+    // Switched to free running. Nothing in the new mode ever opens a gate, so
+    // an envelope that kept the old one would be silent for ever.
+    settings.sync = ModSync::Free;
+    settings.trigger = LFOTriggerMode::Free;
+    settings.startGated = false;
+
+    CHECK(run(state, settings, 10) == approx(1.0f));
+}
+
+// =============================================================================
+// The wiring
+// =============================================================================
+
+TEST_CASE("An envelope's settings reach the table", "[engine][mod][adsr][table]") {
+    auto track = trackWithEnvelope();
+    track.mods[0].envAttackMs = 12.5f;
+    track.mods[0].envDecayMs = 33.0f;
+    track.mods[0].envSustain = 0.25f;
+    track.mods[0].envReleaseMs = 400.0f;
+    track.mods[0].envAttackCurve = 0.4f;
+    track.mods[0].envDecayCurve = -0.2f;
+    track.mods[0].envReleaseCurve = 0.1f;
+
+    const auto table = tableFor({track});
+    REQUIRE(table.modifiers.size() == 1);
+
+    const auto& modifier = table.modifiers.front();
+    CHECK(modifier.kind == ModKind::Adsr);
+    CHECK(modifier.adsr.attackMs == approx(12.5f));
+    CHECK(modifier.adsr.decayMs == approx(33.0f));
+    CHECK(modifier.adsr.sustain == approx(0.25f));
+    CHECK(modifier.adsr.releaseMs == approx(400.0f));
+    CHECK(modifier.adsr.attackCurve == approx(0.4f));
+    CHECK(modifier.adsr.decayCurve == approx(-0.2f));
+    CHECK(modifier.adsr.releaseCurve == approx(0.1f));
+}
+
+TEST_CASE("Tempo sync does not fold into an envelope's gate", "[engine][mod][adsr][table]") {
+    // The one place the envelope's fold differs from the LFO's. For an LFO,
+    // tempo sync decides whether the phase is a function of the timeline; for
+    // an envelope it only scales the stages, so a synced free-running envelope
+    // is still free running.
+    auto track = trackWithEnvelope(LFOTriggerMode::Free);
+    track.mods[0].tempoSync = true;
+    track.mods[0].syncDivision = SyncDivision::Quarter;
+
+    const auto table = tableFor({track});
+    REQUIRE(table.modifiers.size() == 1);
+
+    CHECK(table.modifiers.front().adsr.sync == ModSync::Free);
+    CHECK(table.modifiers.front().adsr.tempoSync);
+    CHECK(table.modifiers.front().adsr.rateType ==
+          magda::syncDivisionToTeRateOrdinal(SyncDivision::Quarter));
+
+    // The LFO on the same fields would have folded to a timeline-locked run.
+    auto asLfo = track;
+    asLfo.mods[0].type = ModType::LFO;
+    CHECK(tableFor({asLfo}).modifiers.front().lfo.sync == ModSync::Transport);
+}
+
+TEST_CASE("An envelope drives a device parameter through the block",
+          "[engine][mod][adsr][runtime]") {
+    const auto table = tableFor({trackWithEnvelope(LFOTriggerMode::Free)});
+    const auto param = table.find(deviceParam(1, 7, 0));
+    REQUIRE(param != magda::engine::INVALID_PARAM_ID);
+
+    Harness harness(table);
+    const auto block = millisecondBlock();
+
+    // A free-running envelope needs nothing to start it, so the parameter is
+    // already climbing on the first block.
+    harness.run(table, block);
+    CHECK(harness.values[param].value() == approx(0.1f));
+
+    for (int i = 0; i < 9; ++i)
+        harness.run(table, block);
+    CHECK(harness.values[param].value() == approx(1.0f));
+}
+
+TEST_CASE("A note opens an envelope's gate and the last note lifting shuts it",
+          "[engine][mod][adsr][runtime]") {
+    const auto table = tableFor({trackWithEnvelope(LFOTriggerMode::MIDI, false)});
+    const auto param = table.find(deviceParam(1, 7, 0));
+    REQUIRE(param != magda::engine::INVALID_PARAM_ID);
+    REQUIRE(table.modifiers.size() == 1);
+
+    Harness harness(table);
+    const auto block = millisecondBlock();
+
+    const auto runBlocks = [&](int count) {
+        for (int i = 0; i < count; ++i)
+            harness.run(table, block);
+        return harness.values[param].value();
+    };
+
+    // Waiting: a note-triggered envelope the model does not call running is
+    // shut before its first note, and a shut envelope contributes nothing.
+    CHECK(runBlocks(1) == approx(0.0f));
+
+    // Through the attack and the decay to the sustain, and held there.
+    harness.mods.noteOn(0, table);
+    CHECK(runBlocks(25) == approx(0.5f));
+
+    // A second note retriggers, which is what a note does to an envelope, and
+    // is also a second note held.
+    harness.mods.noteOn(0, table);
+    CHECK(runBlocks(25) == approx(0.5f));
+
+    // The first of the two lifting leaves the gate open: an envelope that
+    // released on the first note off would cut a chord short.
+    harness.mods.noteOff(0, table);
+    CHECK(runBlocks(20) == approx(0.5f));
+
+    // The last one shuts it, and the release runs from where the envelope was.
+    harness.mods.noteOff(0, table);
+    CHECK(runBlocks(5) == approx(0.25f));
+    CHECK(runBlocks(5) == approx(0.0f));
+}
+
+TEST_CASE("A cross-track envelope hears its source and nothing else",
+          "[engine][mod][adsr][runtime]") {
+    // The rack the envelope lives on is sidechained from track 2, so the notes
+    // track 1 happens to be playing are not its notes.
+    auto source = makeTrack(2);
+
+    RackInfo rack;
+    rack.id = 4;
+    rack.sidechain.type = SidechainConfig::Type::MIDI;
+    rack.sidechain.sourceTrackId = 2;
+    rack.mods = createDefaultMods(1);
+    rack.mods[0].type = ModType::Envelope;
+    rack.mods[0].triggerMode = LFOTriggerMode::MIDI;
+    rack.mods[0].envAttackMs = 10.0f;
+    rack.mods[0].envDecayMs = 10.0f;
+    rack.mods[0].envSustain = 0.5f;
+    rack.mods[0].envReleaseMs = 10.0f;
+    rack.mods[0].links.push_back(ModLink{
+        ControlTarget::pluginParam(ChainNodePath::chainDevice(1, 4, 10, 7), 0), 1.0f, false, true});
+
+    ChainInfo chain;
+    chain.id = 10;
+    chain.elements.push_back(makeDeviceElement(makeDevice(7)));
+    rack.chains.push_back(std::move(chain));
+
+    auto destination = makeTrack(1);
+    destination.chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
+
+    const auto table = tableFor({destination, source});
+    REQUIRE(table.modifiers.size() == 1);
+
+    // It listens to the source, which is what the plan's tap is emitted for.
+    CHECK(table.modifiers.front().source == 2);
+    CHECK(table.modifiers.front().adsr.skipNativeResync);
+
+    Harness harness(table);
+    const auto block = millisecondBlock();
+
+    // A note from where it lives is refused, gate and phase alike.
+    harness.mods.noteOn(0, table);
+    for (int i = 0; i < 10; ++i)
+        harness.run(table, block);
+    CHECK(harness.mods.value(0) == approx(0.0f));
+
+    // The source's own trigger is the one it exists to follow.
+    harness.mods.trigger(0, table);
+    harness.run(table, block);
+    CHECK(harness.mods.value(0) == approx(0.0f));  // the gap the trigger asked for
+
+    for (int i = 0; i < 10; ++i)
+        harness.run(table, block);
+    CHECK(harness.mods.value(0) == approx(1.0f));
+}

--- a/tests/test_mod_feeds.cpp
+++ b/tests/test_mod_feeds.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "core/TrackInfo.hpp"
+#include "core/TrackManager.hpp"
 #include "exec/EngineSession.hpp"
 #include "exec/PlanValues.hpp"
 #include "exec/RuntimeStateStore.hpp"
@@ -592,4 +593,31 @@ TEST_CASE("A modulation feed does not order the tracks", "[engine][mod][feeds]")
             CHECK(op.key.trackId == 2);
         }
     CHECK(taps == 1);
+}
+
+TEST_CASE("A modifier added as a follower listens at the far end", "[engine][mod][feeds]") {
+    // The add path is where a follower is normally born, so it is the path that
+    // has to hand it the tap point its kind wants. Constructing an LFO and
+    // assigning the type over it leaves the point where the LFO wanted it, and
+    // every follower the user creates would key off the head of the chain.
+    auto& manager = TrackManager::getInstance();
+    manager.clearAllTracks();
+
+    const auto trackId = manager.createTrack("Source", TrackType::Audio);
+    const auto path = ChainNodePath::trackLevel(trackId);
+
+    manager.addMod(path, 0, ModType::Follower, LFOWaveform::Sine);
+    manager.addMod(path, 1, ModType::LFO, LFOWaveform::Sine);
+
+    const auto* track = manager.getTrack(trackId);
+    REQUIRE(track != nullptr);
+    REQUIRE(track->mods.size() >= 2);
+
+    CHECK(track->mods[0].type == ModType::Follower);
+    CHECK(track->mods[0].tapPoint == ModTapPoint::PostFader);
+
+    // And everything else takes the near one, which is where a trigger keys off.
+    CHECK(track->mods[1].tapPoint == ModTapPoint::PreFx);
+
+    manager.clearAllTracks();
 }

--- a/tests/test_mod_feeds.cpp
+++ b/tests/test_mod_feeds.cpp
@@ -1,0 +1,333 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <vector>
+
+#include "core/TrackInfo.hpp"
+#include "exec/EngineSession.hpp"
+#include "exec/PlanValues.hpp"
+#include "exec/RuntimeStateStore.hpp"
+#include "param/ModRuntime.hpp"
+#include "param/ParamTableCompiler.hpp"
+#include "plan/PlanCompiler.hpp"
+
+/**
+ * @file test_mod_feeds.cpp
+ * @brief What reaches a modifier from outside the parameter system (#2120).
+ *
+ * Slice 4 built the trigger calls and had nothing to call them. This is the
+ * two feeds that do, measured end to end through a session, because what they
+ * are about is timing and timing is not visible from a call site.
+ *
+ * The claim under test is the distance rather than the gap. Both feeds
+ * eventually reach their modifier; what differs is how many blocks later, and
+ * that difference is a consequence of resolving parameters at the top of a
+ * block rather than a detail of how the feed was written.
+ *
+ *  - A note is known before the block resolves, because the ops that produce
+ *    MIDI read clips and input queues rather than audio. The prefix renders
+ *    them first, so the modifier is resolved with the note that arrived in
+ *    this block: distance zero.
+ *  - A level is not, because it is what the ops are about to produce. The
+ *    detector runs during the walk and the resolve that reads it is the next
+ *    block's: distance one, always exactly one.
+ *
+ * The fork's ordinary MIDI gate is the later of the two as well (its
+ * ADSRModifier reads a gate its applyToBuffer set during the previous block),
+ * and its monitor path is the earlier. So the first of these is the fork's best
+ * case made unconditional, and the second is its ordinary case.
+ */
+
+using namespace magda;
+using magda::engine::BlockInfo;
+using magda::engine::compileParamTable;
+using magda::engine::compileRenderPlan;
+using magda::engine::ModRuntime;
+
+namespace {
+
+Catch::Approx approx(float value) {
+    return Catch::Approx(value).margin(1e-4);
+}
+
+constexpr double kSampleRate = 48000.0;
+
+/// A quarter of a second, so a hundred-millisecond envelope stage is a few
+/// blocks and a difference of one block is unmistakable.
+constexpr int kBlock = 512;
+
+TrackInfo makeTrack(TrackId id) {
+    TrackInfo track;
+    track.id = id;
+    track.name = "Track " + juce::String(id);
+    track.audioOutputDevice = "master";
+    track.mods = createDefaultMods(0);
+    return track;
+}
+
+TrackInfo makeMaster() {
+    auto master = makeTrack(MASTER_TRACK_ID);
+    master.type = TrackType::Master;
+    master.audioOutputDevice = {};
+    master.volume = 1.0f;
+    return master;
+}
+
+/// A device whose output is its only parameter, so what leaves the master is
+/// what the modulation did to it.
+class LevelDevice final : public magda::engine::EngineDevice {
+  public:
+    void process(magda::engine::DeviceBlock& block) override {
+        block.audio.fill(block.params.size() > 0 ? block.params[0].value() : 0.0f);
+    }
+};
+
+/// What the test queues for the next block, and what it saw of the blocks that
+/// consumed it. Owned by the test rather than by the session, because the point
+/// of the case is to put a note in one specific block.
+struct ScriptedMidi {
+    juce::MidiBuffer pending;
+    int blocks = 0;
+};
+
+/// The session's end of it: a source that hands over whatever is queued and
+/// clears the queue, so a note is played once.
+class ScriptedMidiSource final : public magda::engine::EngineMidiSource {
+  public:
+    explicit ScriptedMidiSource(ScriptedMidi* script) : script_(script) {}
+
+    void render(const BlockInfo&, juce::MidiBuffer& out) override {
+        if (script_ == nullptr)
+            return;
+
+        out.addEvents(script_->pending, 0, -1, 0);
+        script_->pending.clear();
+        ++script_->blocks;
+    }
+
+  private:
+    ScriptedMidi* script_ = nullptr;
+};
+
+class Factory final : public magda::engine::RuntimeStateFactory {
+  public:
+    explicit Factory(ScriptedMidi* midi) : midi_(midi) {}
+
+    std::unique_ptr<magda::engine::EngineDevice> createDevice(magda::engine::DeviceKey) override {
+        return std::make_unique<LevelDevice>();
+    }
+
+    std::unique_ptr<magda::engine::EngineMidiSource> createMidiInput(TrackId) override {
+        return std::make_unique<ScriptedMidiSource>(midi_);
+    }
+
+  private:
+    ScriptedMidi* midi_ = nullptr;
+};
+
+DeviceInfo makeDevice(DeviceId id) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Effect " + juce::String(id);
+    device.deviceType = DeviceType::Effect;
+    device.mods = createDefaultMods(0);
+
+    ParameterInfo info(0, "Level", "", 0.0f, 1.0f, 0.0f);
+    info.currentValue = 0.0f;
+    device.parameters.push_back(info);
+
+    return device;
+}
+
+/// A track with a device and one modifier of @p type wired to its parameter.
+TrackInfo trackWithModifier(ModType type, LFOTriggerMode trigger) {
+    auto track = makeTrack(1);
+    track.volume = 1.0f;
+    track.pan = 0.0f;
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7)));
+    track.mods = createDefaultMods(1);
+    track.mods[0].type = type;
+    track.mods[0].triggerMode = trigger;
+
+    // Not running, so a note-triggered modifier starts shut. What is being
+    // measured is which block opens it, and one that was already open would
+    // measure nothing.
+    track.mods[0].running = false;
+
+    // Instant up, held there: what is being measured is which block the
+    // envelope opens in, so the stage lengths must not be part of the answer.
+    track.mods[0].envAttackMs = 0.0f;
+    track.mods[0].envDecayMs = 0.0f;
+    track.mods[0].envSustain = 1.0f;
+    track.mods[0].envReleaseMs = 0.0f;
+
+    track.mods[0].links.push_back(ModLink{
+        ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0), 1.0f, false, true});
+    return track;
+}
+
+/// A session over @p tracks, with @p midi bound as track 1's live MIDI input.
+struct Session {
+    Session(std::vector<TrackInfo> trackList, ScriptedMidi* midi)
+        : tracks(std::move(trackList)), factory(midi), session(factory) {
+        master = makeMaster();
+        plan = std::make_shared<const magda::engine::RenderPlan>(compileRenderPlan(tracks, master));
+
+        magda::engine::PlanValues values;
+        magda::engine::resolvePlanValues(*plan, tracks, master, values);
+
+        const auto ids = magda::engine::collectRuntimeStateIds(tracks, master);
+        const magda::engine::RenderContext context{kSampleRate, kBlock, 2};
+        published = session.publish(plan, context, ids, std::move(values)).published;
+    }
+
+    /// One block, and the first sample the master produced.
+    float render() {
+        juce::AudioBuffer<float> output(2, kBlock);
+        session.process(kBlock, output);
+        return output.getSample(0, 0);
+    }
+
+    std::vector<TrackInfo> tracks;
+    TrackInfo master;
+    std::shared_ptr<const magda::engine::RenderPlan> plan;
+    Factory factory;
+    magda::engine::EngineSession session;
+    bool published = false;
+};
+
+}  // namespace
+
+TEST_CASE("The MIDI a block has is known before the block resolves", "[engine][mod][feeds]") {
+    // The prefix is what makes a note-triggered modifier hear the note in the
+    // block it arrived in. Which ops are in it is decided at prepare time, from
+    // the plan: outputs all MIDI, and every producer already in the set.
+    auto track = trackWithModifier(ModType::Envelope, LFOTriggerMode::MIDI);
+    track.recordArmed = true;
+
+    const std::vector<TrackInfo> tracks{track};
+    const auto master = makeMaster();
+    const auto plan = compileRenderPlan(tracks, master);
+
+    // The track's chain-head MIDI is a merge of sources, so it is in the
+    // prefix; the device that reads it is not, because it produces audio.
+    bool sawMidiInput = false;
+    bool sawDevice = false;
+    for (const auto& op : plan.ops) {
+        if (op.key.role == magda::engine::OpRole::TrackMidiInput ||
+            op.key.role == magda::engine::OpRole::LiveMidiInput)
+            sawMidiInput = true;
+        if (op.kind == magda::engine::OpKind::Device)
+            sawDevice = true;
+    }
+
+    CHECK(sawMidiInput);
+    CHECK(sawDevice);
+}
+
+TEST_CASE("A note reaches its modifier in the block it arrived in", "[engine][mod][feeds]") {
+    auto track = trackWithModifier(ModType::Envelope, LFOTriggerMode::MIDI);
+    track.recordArmed = true;
+    track.inputMonitor = InputMonitorMode::In;
+    track.midiInputDevice = "test";
+
+    ScriptedMidi midi;
+    Session session({track}, &midi);
+    REQUIRE(session.published);
+
+    // Shut before the note: a MIDI-triggered envelope waits, and a modifier at
+    // rest contributes nothing.
+    CHECK(session.render() == approx(0.0f));
+
+    // The note lands in the next block. The prefix renders the MIDI ops before
+    // the parameters resolve, so the envelope opens in this block rather than
+    // in the one after: distance zero.
+    midi.pending.addEvent(juce::MidiMessage::noteOn(1, 60, 1.0f), 0);
+    CHECK(session.render() == approx(1.0f));
+}
+
+TEST_CASE("A level reaches its modifier the block after the one it was in",
+          "[engine][mod][feeds]") {
+    // The follower's side of the same question. The source's audio does not
+    // exist when the block resolves, so the detector runs during the walk and
+    // the resolve that reads it is the next block's.
+    auto track = trackWithModifier(ModType::Follower, LFOTriggerMode::Free);
+
+    const std::vector<TrackInfo> tracks{track};
+    const auto master = makeMaster();
+    const auto plan = compileRenderPlan(tracks, master);
+    const auto table = compileParamTable(plan, tracks, master, {});
+    REQUIRE(table.modifiers.size() == 1);
+
+    ModRuntime mods;
+    mods.prepare(table, magda::engine::RenderContext{kSampleRate, kBlock, 2});
+
+    BlockInfo block;
+    block.numSamples = kBlock;
+
+    magda::engine::ResolvedParams values;
+    values.prepare(table.size());
+    std::vector<magda::engine::ModContribution> links(
+        static_cast<std::size_t>(std::max(table.maxLinksPerParam, 1)));
+    std::vector<magda::engine::ParamSegment> segments(
+        static_cast<std::size_t>(magda::engine::ResolvedParams::kDefaultSegmentCapacity));
+
+    const auto resolve = [&] {
+        magda::engine::resolveParams(table, values, links, segments, block, &mods);
+        return mods.value(0);
+    };
+
+    // Nothing detected, nothing published.
+    CHECK(resolve() == approx(0.0f));
+
+    // The block's audio, handed over after the block resolved, which is where
+    // the executor hands it over. This block's value was already settled, so
+    // the level shows up in the next one.
+    const std::vector<float> loud(static_cast<std::size_t>(kBlock), 1.0f);
+    mods.detectSource(0, table, loud);
+    CHECK(resolve() > 0.0f);
+}
+
+TEST_CASE("A modifier that listens to nothing carries no source", "[engine][mod][feeds]") {
+    // The rule that decides whether an edge is emitted at all. A free-running
+    // LFO on a sidechained device is not a reason to carry that track's audio
+    // anywhere, and a plan that carried it would be paying for a dependency
+    // nothing reads.
+    const auto sourceOf = [](ModType type, LFOTriggerMode trigger) {
+        const std::vector<TrackInfo> tracks{trackWithModifier(type, trigger)};
+        const auto master = makeMaster();
+        const auto plan = compileRenderPlan(tracks, master);
+        const auto table = compileParamTable(plan, tracks, master, {});
+        REQUIRE(table.modifiers.size() == 1);
+        return table.modifiers.front().source;
+    };
+
+    CHECK(sourceOf(ModType::LFO, LFOTriggerMode::Free) == INVALID_TRACK_ID);
+    CHECK(sourceOf(ModType::LFO, LFOTriggerMode::Transport) == INVALID_TRACK_ID);
+    CHECK(sourceOf(ModType::LFO, LFOTriggerMode::MIDI) == 1);
+    CHECK(sourceOf(ModType::LFO, LFOTriggerMode::Audio) == 1);
+
+    // A follower listens whatever its trigger mode says: the trigger fields
+    // belong to the kinds that have a phase.
+    CHECK(sourceOf(ModType::Follower, LFOTriggerMode::Free) == 1);
+}
+
+TEST_CASE("A note only reaches the modifiers waiting for one", "[engine][mod][feeds]") {
+    // One list of listeners per track, sorted by what each is waiting for, so
+    // an audio-triggered modifier is not opened by a note that happened to
+    // reach the same track.
+    const std::vector<TrackInfo> tracks{trackWithModifier(ModType::LFO, LFOTriggerMode::Audio)};
+    const auto master = makeMaster();
+    const auto plan = compileRenderPlan(tracks, master);
+    const auto table = compileParamTable(plan, tracks, master, {});
+    REQUIRE(table.modifiers.size() == 1);
+
+    ModRuntime mods;
+    mods.prepare(table, magda::engine::RenderContext{kSampleRate, kBlock, 2});
+
+    CHECK(mods.listensFor(0, table) == magda::engine::ModListen::Audio);
+
+    const auto listeners = mods.listenersOf(1);
+    REQUIRE(listeners.size() == 1);
+    CHECK(listeners.front() == 0);
+}

--- a/tests/test_mod_feeds.cpp
+++ b/tests/test_mod_feeds.cpp
@@ -331,3 +331,102 @@ TEST_CASE("A note only reaches the modifiers waiting for one", "[engine][mod][fe
     REQUIRE(listeners.size() == 1);
     CHECK(listeners.front() == 0);
 }
+
+TEST_CASE("A cross-track modifier is triggered by the notes it listens to",
+          "[engine][mod][feeds]") {
+    // The two listeners a tap feeds take a trigger through different doors, and
+    // the cross-track one has only the trigger. Its note-counting path refuses
+    // it by design, so an executor that fed it through noteOn alone would leave
+    // the MIDI half of every rack and device sidechain dead.
+    auto source = makeTrack(2);
+
+    RackInfo rack;
+    rack.id = 4;
+    rack.sidechain.type = SidechainConfig::Type::MIDI;
+    rack.sidechain.sourceTrackId = 2;
+    rack.mods = createDefaultMods(1);
+    rack.mods[0].type = ModType::Envelope;
+    rack.mods[0].triggerMode = LFOTriggerMode::MIDI;
+    rack.mods[0].envAttackMs = 0.0f;
+    rack.mods[0].envDecayMs = 0.0f;
+    rack.mods[0].envSustain = 1.0f;
+    rack.mods[0].envReleaseMs = 0.0f;
+    rack.mods[0].links.push_back(ModLink{
+        ControlTarget::pluginParam(ChainNodePath::chainDevice(1, 4, 10, 7), 0), 1.0f, false, true});
+
+    ChainInfo chain;
+    chain.id = 10;
+    chain.elements.push_back(makeDeviceElement(makeDevice(7)));
+    rack.chains.push_back(std::move(chain));
+
+    auto destination = makeTrack(1);
+    destination.volume = 1.0f;
+    destination.pan = 0.0f;
+    destination.chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
+
+    source.recordArmed = true;
+    source.inputMonitor = InputMonitorMode::In;
+    source.midiInputDevice = "test";
+
+    ScriptedMidi midi;
+    Session session({destination, source}, &midi);
+    REQUIRE(session.published);
+
+    // The runtime agrees it is the cross-track kind, which is what selects the
+    // door: the same answer the executor asks for.
+    const auto master = makeMaster();
+    const std::vector<TrackInfo> tracks{destination, source};
+    const auto table = compileParamTable(compileRenderPlan(tracks, master), tracks, master, {});
+    REQUIRE(table.modifiers.size() == 1);
+
+    ModRuntime probe;
+    probe.prepare(table, magda::engine::RenderContext{kSampleRate, kBlock, 2});
+    CHECK(probe.drivenFromElsewhere(0, table));
+    CHECK(probe.listensFor(0, table) == magda::engine::ModListen::Midi);
+
+    CHECK(session.render() == approx(0.0f));
+
+    // The note reaches the trigger in the block it arrived in, and what that
+    // block publishes is the gap a cross-track trigger asks for: one block of
+    // nothing so the device sees a transition rather than a continuation. The
+    // fork's triggerNoteOn does the same with its forceZeroValue.
+    midi.pending.addEvent(juce::MidiMessage::noteOn(1, 60, 1.0f), 0);
+    CHECK(session.render() == approx(0.0f));
+
+    // Then the attack, which has no time in it, so the envelope is up.
+    CHECK(session.render() == approx(1.0f));
+
+    // And the note lifting does not shut it: the fork leaves the gate alone on
+    // note-off so the modifier runs its full cycle after a hit.
+    midi.pending.addEvent(juce::MidiMessage::noteOff(1, 60), 0);
+    CHECK(session.render() == approx(1.0f));
+    CHECK(session.render() == approx(1.0f));
+}
+
+TEST_CASE("A modulation tap keeps its detector across a prepare", "[engine][mod][feeds]") {
+    // A structural publish during playback must not zero a tap's envelope. If
+    // it did, a source above the threshold at that moment would read as a
+    // rising edge on the next block and fire a trigger nothing played, forced
+    // gap included, so every link edit would be an audible blip on a live
+    // sidechain. The fork's monitor survives the same edits with its own level
+    // and gate intact, and this carries on the same terms ModRuntime carries a
+    // phase.
+    auto tracks = std::vector{trackWithModifier(ModType::LFO, LFOTriggerMode::Audio)};
+    const auto master = makeMaster();
+    const auto plan = compileRenderPlan(tracks, master);
+
+    magda::engine::PlanValues values;
+    magda::engine::resolvePlanValues(plan, tracks, master, values);
+    REQUIRE(values.params != nullptr);
+
+    const magda::engine::RenderContext context{kSampleRate, kBlock, 2};
+    magda::engine::PlanBindings bindings;
+
+    magda::engine::PlanExecutor first;
+    first.prepare(plan, bindings, context, nullptr, values.params.get());
+    CHECK(first.carriedTriggerDetectors() == 0);
+
+    magda::engine::PlanExecutor second;
+    second.prepare(plan, bindings, context, &first, values.params.get());
+    CHECK(second.carriedTriggerDetectors() == 1);
+}

--- a/tests/test_mod_feeds.cpp
+++ b/tests/test_mod_feeds.cpp
@@ -404,6 +404,48 @@ TEST_CASE("A cross-track modifier is triggered by the notes it listens to",
     CHECK(session.render() == approx(1.0f));
 }
 
+TEST_CASE("A track's two taps never share a detector", "[engine][mod][feeds]") {
+    // A track read at both its points has two taps and two detectors. One
+    // between them would let a level at the far end work the gate at the near
+    // one, which is a duck firing on the wrong signal, and it survives a
+    // republish because the carry is what would alias them.
+    auto source = makeTrack(2);
+    source.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(9)));
+
+    auto listener = makeTrack(1);
+    listener.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7)));
+
+    auto& device = magda::getDevice(listener.chain.fxChainElements.front());
+    device.sidechain.type = SidechainConfig::Type::Audio;
+    device.sidechain.sourceTrackId = 2;
+    device.mods = createDefaultMods(2);
+    device.mods[0].setType(ModType::LFO);
+    device.mods[0].triggerMode = LFOTriggerMode::Audio;
+    device.mods[1].setType(ModType::Follower);
+
+    const std::vector<TrackInfo> tracks{listener, source};
+    const auto master = makeMaster();
+    const auto plan = compileRenderPlan(tracks, master);
+
+    magda::engine::PlanValues values;
+    magda::engine::resolvePlanValues(plan, tracks, master, values);
+    REQUIRE(values.params != nullptr);
+
+    const magda::engine::RenderContext context{kSampleRate, kBlock, 2};
+    magda::engine::PlanBindings bindings;
+
+    magda::engine::PlanExecutor first;
+    first.prepare(plan, bindings, context, nullptr, values.params.get());
+    REQUIRE(first.distinctTriggerDetectors() == 2);
+
+    // And still two after taking the previous epoch's over, which is where a
+    // carry keyed by the track alone would collapse them onto one.
+    magda::engine::PlanExecutor second;
+    second.prepare(plan, bindings, context, &first, values.params.get());
+    CHECK(second.carriedTriggerDetectors() == 2);
+    CHECK(second.distinctTriggerDetectors() == 2);
+}
+
 TEST_CASE("A modulation tap keeps its detector across a prepare", "[engine][mod][feeds]") {
     // A structural publish during playback must not zero a tap's envelope. If
     // it did, a source above the threshold at that moment would read as a

--- a/tests/test_mod_feeds.cpp
+++ b/tests/test_mod_feeds.cpp
@@ -42,6 +42,7 @@ using namespace magda;
 using magda::engine::BlockInfo;
 using magda::engine::compileParamTable;
 using magda::engine::compileRenderPlan;
+using magda::engine::ModKind;
 using magda::engine::ModRuntime;
 
 namespace {
@@ -429,4 +430,124 @@ TEST_CASE("A modulation tap keeps its detector across a prepare", "[engine][mod]
     magda::engine::PlanExecutor second;
     second.prepare(plan, bindings, context, &first, values.params.get());
     CHECK(second.carriedTriggerDetectors() == 1);
+}
+
+TEST_CASE("A follower and a trigger on one source read different points", "[engine][mod][feeds]") {
+    // The fork has two tap points and uses both: its trigger monitor sits in
+    // front of the chain and its follower tap at the far end. One point for
+    // both would make riding the source fader silence the triggers, which it
+    // does in neither engine.
+    auto source = makeTrack(2);
+    source.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(9)));
+
+    auto listener = makeTrack(1);
+    listener.mods = createDefaultMods(2);
+    listener.mods[0].setType(ModType::LFO);
+    listener.mods[0].triggerMode = LFOTriggerMode::Audio;
+    listener.mods[1].setType(ModType::Follower);
+
+    // Both listen to track 2, through a device keyed from it.
+    listener.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7)));
+    auto& device = magda::getDevice(listener.chain.fxChainElements.front());
+    device.sidechain.type = SidechainConfig::Type::Audio;
+    device.sidechain.sourceTrackId = 2;
+    device.mods = listener.mods;
+    listener.mods = createDefaultMods(0);
+
+    const std::vector<TrackInfo> tracks{listener, source};
+    const auto master = makeMaster();
+    const auto plan = compileRenderPlan(tracks, master);
+
+    // Two taps on the one source, and they read different ops.
+    std::vector<magda::engine::OpId> taps;
+    for (std::size_t i = 0; i < plan.ops.size(); ++i)
+        if (plan.ops[i].key.role == magda::engine::OpRole::ModulationTap) {
+            CHECK(plan.ops[i].key.trackId == 2);
+            taps.push_back(static_cast<magda::engine::OpId>(i));
+        }
+
+    REQUIRE(taps.size() == 2);
+    CHECK(plan.ops[static_cast<std::size_t>(taps[0])].inputs[0].op !=
+          plan.ops[static_cast<std::size_t>(taps[1])].inputs[0].op);
+
+    // The near one is the chain head, in front of the source's own device; the
+    // far one is its meter, which is post-fader and pre-mute.
+    const auto roleOfInput = [&](magda::engine::OpId tap) {
+        const auto producer = plan.ops[static_cast<std::size_t>(tap)].inputs[0].op;
+        return plan.ops[static_cast<std::size_t>(producer)].key.role;
+    };
+
+    CHECK(roleOfInput(taps[0]) == magda::engine::OpRole::TrackAudioInput);
+    CHECK(roleOfInput(taps[1]) == magda::engine::OpRole::TrackMeter);
+
+    // And the table says which modifier is on which, so the executor can
+    // dispatch each from the point it named.
+    const auto table = compileParamTable(plan, tracks, master, {});
+    REQUIRE(table.modifiers.size() == 2);
+    for (const auto& modifier : table.modifiers) {
+        CHECK(modifier.source == 2);
+        CHECK(modifier.tap ==
+              (modifier.kind == ModKind::Follower ? ModTapPoint::PostFader : ModTapPoint::PreFx));
+    }
+}
+
+TEST_CASE("A modulation feed does not order the tracks", "[engine][mod][feeds]") {
+    // A modifier listening to another track needs that track's tap to exist,
+    // and it does: the taps are emitted after every track. What it must not do
+    // is force the source to compile first, because a track routed into the
+    // very track its modifiers listen to is an ordinary project and a cycle
+    // here, and the breaker resolves a cycle by dropping a real connection.
+    //
+    // A rack sidechain is the case that isolates it. A device sidechain is a
+    // signal edge in its own right and orders the tracks for reasons that have
+    // nothing to do with modulation; a rack does not mix its sidechain into its
+    // chains, so the only edge it could contribute is the modulation one.
+    RackInfo rack;
+    rack.id = 4;
+    rack.sidechain.type = SidechainConfig::Type::Audio;
+    rack.sidechain.sourceTrackId = 2;
+    rack.mods = createDefaultMods(1);
+    rack.mods[0].setType(ModType::LFO);
+    rack.mods[0].triggerMode = LFOTriggerMode::Audio;
+    rack.mods[0].links.push_back(ModLink{
+        ControlTarget::pluginParam(ChainNodePath::chainDevice(1, 4, 10, 7), 0), 1.0f, false, true});
+
+    ChainInfo chain;
+    chain.id = 10;
+    chain.elements.push_back(makeDeviceElement(makeDevice(7)));
+    rack.chains.push_back(std::move(chain));
+
+    auto listener = makeTrack(1);
+    listener.audioOutputDevice = "track:2";
+    listener.chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
+
+    auto sink = makeTrack(2);
+    sink.type = TrackType::Audio;
+
+    // Declared source-last, which is the order that used to invent the cycle.
+    const std::vector<TrackInfo> tracks{sink, listener};
+    const auto master = makeMaster();
+    const auto plan = compileRenderPlan(tracks, master);
+
+    // The real routing survives: nothing was dropped to break a cycle that the
+    // modulation feed invented.
+    for (const auto& message : plan.diagnostics)
+        CHECK(message.find("arrived after it was compiled") == std::string::npos);
+
+    // And track 1's audio still reaches track 2, which is the connection the
+    // cycle breaker used to spend.
+    bool reaches = false;
+    for (const auto& op : plan.ops)
+        if (op.key.trackId == 2 && op.key.role == magda::engine::OpRole::TrackAudioInput)
+            reaches = !op.inputs.empty() && op.inputs.front().valid();
+    CHECK(reaches);
+
+    // The tap is still there, reading track 2 at the point the trigger named.
+    int taps = 0;
+    for (const auto& op : plan.ops)
+        if (op.key.role == magda::engine::OpRole::ModulationTap) {
+            ++taps;
+            CHECK(op.key.trackId == 2);
+        }
+    CHECK(taps == 1);
 }

--- a/tests/test_mod_follower.cpp
+++ b/tests/test_mod_follower.cpp
@@ -122,7 +122,7 @@ TrackInfo trackWithFollower() {
     auto track = makeTrack(1);
     track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7)));
     track.mods = createDefaultMods(1);
-    track.mods[0].type = ModType::Follower;
+    track.mods[0].setType(ModType::Follower);
     track.mods[0].followerAttackMs = 10.0f;
     track.mods[0].followerReleaseMs = 100.0f;
     track.mods[0].links.push_back(ModLink{
@@ -354,7 +354,7 @@ TEST_CASE("A follower listens to its own track unless its scope is sidechained",
         device.sidechain.type = SidechainConfig::Type::Audio;
         device.sidechain.sourceTrackId = 2;
         device.mods = createDefaultMods(1);
-        device.mods[0].type = ModType::Follower;
+        device.mods[0].setType(ModType::Follower);
 
         const auto table = tableFor({track, makeTrack(2)});
 

--- a/tests/test_mod_follower.cpp
+++ b/tests/test_mod_follower.cpp
@@ -1,0 +1,459 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <numbers>
+#include <vector>
+
+#include "core/RackInfo.hpp"
+#include "core/TrackInfo.hpp"
+#include "param/ModFollower.hpp"
+#include "param/ModRuntime.hpp"
+#include "param/ParamResolve.hpp"
+#include "param/ParamTableCompiler.hpp"
+#include "plan/PlanCompiler.hpp"
+
+/**
+ * @file test_mod_follower.cpp
+ * @brief The envelope follower (#2120).
+ *
+ * The one modifier that is not a function of time, so what is asserted about it
+ * splits differently. The detector is one half: the gain, the band limits and
+ * the peak the block reduces to, which is what decides how loud a source reads
+ * and which part of its spectrum is being listened to. The envelope is the
+ * other: the fork's one-pole attack, hold and release over that peak, which is
+ * what makes a follower's attack a time rather than a block count.
+ *
+ * And then the edge between them, which is the part slice 4 could not build: a
+ * modifier that listens to a track, a plan that carries that track's signal to
+ * it, and one block of lag between the two that is exactly one block.
+ */
+
+using namespace magda;
+using magda::engine::advanceFollower;
+using magda::engine::BlockInfo;
+using magda::engine::compileParamTable;
+using magda::engine::compileRenderPlan;
+using magda::engine::detectFollowerSource;
+using magda::engine::FollowerSettings;
+using magda::engine::FollowerState;
+using magda::engine::ModContribution;
+using magda::engine::ModKind;
+using magda::engine::ModRuntime;
+using magda::engine::ModTiming;
+using magda::engine::ParamKey;
+using magda::engine::ParamSegment;
+using magda::engine::ParamTable;
+using magda::engine::ResolvedParams;
+using magda::engine::resolveParams;
+
+namespace {
+
+Catch::Approx approx(float value) {
+    return Catch::Approx(value).margin(1e-4);
+}
+
+constexpr double kSampleRate = 48000.0;
+
+ModTiming timing() {
+    return ModTiming{kSampleRate, 120.0, 4, 4};
+}
+
+BlockInfo blockOf(int numSamples) {
+    BlockInfo block;
+    block.numSamples = numSamples;
+    return block;
+}
+
+/// A block of constant level, which is what a detector reduces to that level.
+std::vector<float> flat(int numSamples, float level) {
+    return std::vector<float>(static_cast<std::size_t>(numSamples), level);
+}
+
+/// A sine at @p hz, for asking a band limit which part of the spectrum it lets
+/// through.
+std::vector<float> sine(int numSamples, double hz, float amplitude = 1.0f) {
+    std::vector<float> samples(static_cast<std::size_t>(numSamples));
+    for (int i = 0; i < numSamples; ++i)
+        samples[static_cast<std::size_t>(i)] =
+            amplitude * static_cast<float>(std::sin(2.0 * std::numbers::pi * hz * i / kSampleRate));
+    return samples;
+}
+
+/// The peak a follower detects from @p source, with a scratch buffer of its own.
+float detect(FollowerState& state, const FollowerSettings& settings,
+             const std::vector<float>& source) {
+    std::vector<float> scratch(source.size());
+    detectFollowerSource(state, settings, source, kSampleRate, scratch);
+    return state.sourcePeak;
+}
+
+TrackInfo makeTrack(TrackId id) {
+    TrackInfo track;
+    track.id = id;
+    track.name = "Track " + juce::String(id);
+    track.audioOutputDevice = "master";
+    track.mods = createDefaultMods(0);
+    return track;
+}
+
+TrackInfo makeMaster() {
+    auto master = makeTrack(MASTER_TRACK_ID);
+    master.type = TrackType::Master;
+    master.audioOutputDevice = {};
+    return master;
+}
+
+DeviceInfo makeDevice(DeviceId id) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Effect " + juce::String(id);
+    device.deviceType = DeviceType::Effect;
+    device.mods = createDefaultMods(0);
+
+    ParameterInfo info(0, "Level", "", 0.0f, 1.0f, 0.0f);
+    info.currentValue = 0.0f;
+    device.parameters.push_back(info);
+
+    return device;
+}
+
+/// A track with one device and one follower wired to that device's parameter.
+TrackInfo trackWithFollower() {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7)));
+    track.mods = createDefaultMods(1);
+    track.mods[0].type = ModType::Follower;
+    track.mods[0].followerAttackMs = 10.0f;
+    track.mods[0].followerReleaseMs = 100.0f;
+    track.mods[0].links.push_back(ModLink{
+        ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0), 1.0f, false, true});
+    return track;
+}
+
+ParamTable tableFor(const std::vector<TrackInfo>& tracks) {
+    const auto master = makeMaster();
+    const auto plan = compileRenderPlan(tracks, master);
+    return compileParamTable(plan, tracks, master, {});
+}
+
+struct Harness {
+    explicit Harness(const ParamTable& table)
+        : links(static_cast<std::size_t>(std::max(table.maxLinksPerParam, 1))),
+          segments(
+              static_cast<std::size_t>(magda::engine::ResolvedParams::kDefaultSegmentCapacity)) {
+        values.prepare(table.size());
+        mods.prepare(table, magda::engine::RenderContext{kSampleRate, 512, 2});
+    }
+
+    void run(const ParamTable& table, const BlockInfo& block) {
+        resolveParams(table, values, links, segments, block, &mods);
+    }
+
+    ResolvedParams values;
+    ModRuntime mods;
+    std::vector<ModContribution> links;
+    std::vector<ParamSegment> segments;
+};
+
+}  // namespace
+
+// =============================================================================
+// The detector
+// =============================================================================
+
+TEST_CASE("Detection reduces a block to its peak", "[engine][mod][follower]") {
+    FollowerSettings settings;
+    FollowerState state;
+
+    CHECK(detect(state, settings, flat(256, 0.5f)) == approx(0.5f));
+
+    // The peak rather than the average, and the magnitude rather than the
+    // value: a block whose loudest sample is negative is not a quiet block.
+    auto mixed = flat(256, 0.1f);
+    mixed[100] = -0.8f;
+    CHECK(detect(state, settings, mixed) == approx(0.8f));
+
+    // Nothing to detect is nothing detected, which is also what the whole
+    // modulation system reads as a modifier doing nothing.
+    CHECK(detect(state, settings, flat(256, 0.0f)) == approx(0.0f));
+}
+
+TEST_CASE("Input gain applies before detection", "[engine][mod][follower]") {
+    FollowerSettings settings;
+    FollowerState state;
+
+    settings.gainDb = 6.0f;
+    CHECK(detect(state, settings, flat(256, 0.25f)) == approx(0.25f * std::pow(10.0f, 0.3f)));
+
+    settings.gainDb = -20.0f;
+    CHECK(detect(state, settings, flat(256, 1.0f)) == approx(0.1f));
+}
+
+TEST_CASE("Band limits decide which part of the spectrum is heard", "[engine][mod][follower]") {
+    constexpr int kSamples = 4096;
+
+    SECTION("a high-pass ignores the bass") {
+        FollowerSettings settings;
+        settings.highPass = true;
+        settings.highPassHz = 1000.0f;
+
+        FollowerState low;
+        FollowerState high;
+
+        // A tone well below the corner is most of the way gone; one well above
+        // it comes through. That is the whole point of filtering before
+        // detection: a level that has already been detected has no frequency
+        // content left to filter.
+        CHECK(detect(low, settings, sine(kSamples, 60.0)) < 0.05f);
+        CHECK(detect(high, settings, sine(kSamples, 8000.0)) > 0.8f);
+    }
+
+    SECTION("a low-pass ignores the top") {
+        FollowerSettings settings;
+        settings.lowPass = true;
+        settings.lowPassHz = 500.0f;
+
+        FollowerState low;
+        FollowerState high;
+
+        CHECK(detect(low, settings, sine(kSamples, 60.0)) > 0.9f);
+        CHECK(detect(high, settings, sine(kSamples, 8000.0)) < 0.05f);
+    }
+
+    SECTION("and unfiltered hears both") {
+        FollowerSettings settings;
+        FollowerState low;
+        FollowerState high;
+
+        CHECK(detect(low, settings, sine(kSamples, 60.0)) > 0.9f);
+
+        // Eight kilohertz at this rate is six samples a cycle, so the loudest
+        // sample a full-scale tone actually has is sin(60 degrees). What the
+        // detector reports is the peak of the samples rather than of the wave
+        // the samples came from, which is what the fork reports too.
+        CHECK(detect(high, settings, sine(kSamples, 8000.0)) > 0.8f);
+    }
+}
+
+// =============================================================================
+// The envelope
+// =============================================================================
+
+TEST_CASE("The envelope rises towards the source and falls away from it",
+          "[engine][mod][follower]") {
+    FollowerSettings settings;
+    settings.attackMs = 10.0f;
+    settings.releaseMs = 100.0f;
+
+    FollowerState state;
+    state.sourcePeak = 1.0f;
+
+    // Blocks of a millisecond, so ten of them is exactly one attack. The
+    // one-pole is a curve rather than a ramp, so what is asserted is that it
+    // climbs and where one time constant leaves it.
+    const auto block = blockOf(static_cast<int>(kSampleRate / 1000.0));
+
+    float previous = 0.0f;
+    for (int i = 0; i < 10; ++i) {
+        const auto value = advanceFollower(state, settings, block, timing());
+        CHECK(value >= previous);
+        previous = value;
+    }
+
+    // The fork's time constant is -2, so one attack's worth of samples closes
+    // all but e^-2 of the gap: 86.5 per cent of the way there, not all of it.
+    // Pinned rather than approximated, because it is the number that decides
+    // how a follower sounds and the two engines have to agree about it.
+    CHECK(previous == approx(1.0f - std::exp(-2.0f)));
+
+    // And falls back on the release, which is ten times as long, so the same
+    // ten blocks only take it part of the way.
+    state.sourcePeak = 0.0f;
+    for (int i = 0; i < 10; ++i)
+        advanceFollower(state, settings, block, timing());
+
+    CHECK(state.envelope < previous);
+    CHECK(state.envelope > 0.5f);
+}
+
+TEST_CASE("Hold keeps the envelope up before it is allowed to fall", "[engine][mod][follower]") {
+    FollowerSettings settings;
+    settings.attackMs = 1.0f;
+    settings.releaseMs = 10.0f;
+    settings.holdMs = 5.0f;
+
+    FollowerState state;
+    state.sourcePeak = 1.0f;
+
+    const auto block = blockOf(static_cast<int>(kSampleRate / 1000.0));
+    for (int i = 0; i < 5; ++i)
+        advanceFollower(state, settings, block, timing());
+    const auto reached = state.envelope;
+
+    // Silence at the source, and the hold spends itself before the release
+    // starts: five milliseconds of hold over one-millisecond blocks.
+    state.sourcePeak = 0.0f;
+    for (int i = 0; i < 5; ++i)
+        advanceFollower(state, settings, block, timing());
+    CHECK(state.envelope == approx(reached));
+
+    advanceFollower(state, settings, block, timing());
+    CHECK(state.envelope < reached);
+}
+
+TEST_CASE("A follower with a silent source contributes nothing", "[engine][mod][follower]") {
+    FollowerSettings settings;
+    FollowerState state;
+
+    const auto block = blockOf(512);
+    for (int i = 0; i < 20; ++i)
+        CHECK(advanceFollower(state, settings, block, timing()) == approx(0.0f));
+}
+
+// =============================================================================
+// The wiring
+// =============================================================================
+
+TEST_CASE("A follower's settings reach the table", "[engine][mod][follower][table]") {
+    auto track = trackWithFollower();
+    track.mods[0].followerGainDb = 3.0f;
+    track.mods[0].followerAttackMs = 25.0f;
+    track.mods[0].followerHoldMs = 40.0f;
+    track.mods[0].followerReleaseMs = 250.0f;
+    track.mods[0].followerHpEnabled = true;
+    track.mods[0].followerHpFreq = 120.0f;
+    track.mods[0].followerLpEnabled = true;
+    track.mods[0].followerLpFreq = 3000.0f;
+
+    const auto table = tableFor({track});
+    REQUIRE(table.modifiers.size() == 1);
+
+    const auto& modifier = table.modifiers.front();
+    CHECK(modifier.kind == ModKind::Follower);
+    CHECK(modifier.follower.gainDb == approx(3.0f));
+    CHECK(modifier.follower.attackMs == approx(25.0f));
+    CHECK(modifier.follower.holdMs == approx(40.0f));
+    CHECK(modifier.follower.releaseMs == approx(250.0f));
+    CHECK(modifier.follower.highPass);
+    CHECK(modifier.follower.highPassHz == approx(120.0f));
+    CHECK(modifier.follower.lowPass);
+    CHECK(modifier.follower.lowPassHz == approx(3000.0f));
+}
+
+TEST_CASE("A follower listens to its own track unless its scope is sidechained",
+          "[engine][mod][follower][table]") {
+    SECTION("its own track") {
+        const auto table = tableFor({trackWithFollower()});
+        REQUIRE(table.modifiers.size() == 1);
+        CHECK(table.modifiers.front().source == 1);
+    }
+
+    SECTION("the track its device is sidechained from") {
+        auto track = trackWithFollower();
+        auto& device = magda::getDevice(track.chain.fxChainElements.front());
+        device.sidechain.type = SidechainConfig::Type::Audio;
+        device.sidechain.sourceTrackId = 2;
+        device.mods = createDefaultMods(1);
+        device.mods[0].type = ModType::Follower;
+
+        const auto table = tableFor({track, makeTrack(2)});
+
+        // The track's own follower still follows the track; the device's
+        // follows what the device is keyed from. A sidechain is a property of
+        // the scope, which is why a modifier cannot say it for itself.
+        bool sawTrackScope = false;
+        bool sawDeviceScope = false;
+        for (const auto& modifier : table.modifiers) {
+            if (modifier.key.scope == ParamKey::Scope::Track) {
+                sawTrackScope = true;
+                CHECK(modifier.source == 1);
+            } else {
+                sawDeviceScope = true;
+                CHECK(modifier.source == 2);
+            }
+        }
+
+        CHECK(sawTrackScope);
+        CHECK(sawDeviceScope);
+    }
+}
+
+TEST_CASE("A follower's source is an edge the plan carries", "[engine][mod][follower][plan]") {
+    const auto master = makeMaster();
+    const std::vector<TrackInfo> tracks{trackWithFollower()};
+    const auto plan = compileRenderPlan(tracks, master);
+
+    // The diagnostic slice 4 left pointing here is gone, and what replaced it
+    // is an op: one per track anything listens to, keyed to the source.
+    for (const auto& message : plan.diagnostics)
+        CHECK(message.find("modulation") == std::string::npos);
+
+    int taps = 0;
+    for (const auto& op : plan.ops)
+        if (op.key.role == magda::engine::OpRole::ModulationTap) {
+            ++taps;
+            CHECK(op.key.trackId == 1);
+            CHECK(op.outputs.empty());
+        }
+
+    CHECK(taps == 1);
+}
+
+TEST_CASE("A follower drives a device parameter from what it detected",
+          "[engine][mod][follower][runtime]") {
+    const auto table = tableFor({trackWithFollower()});
+
+    ParamKey key;
+    key.kind = ParamKey::Kind::DeviceParam;
+    key.scope = ParamKey::Scope::Device;
+    key.trackId = 1;
+    key.device = magda::engine::DeviceKey{ChainSegment::Fx, 7};
+    key.index = 0;
+
+    const auto param = table.find(key);
+    REQUIRE(param != magda::engine::INVALID_PARAM_ID);
+    REQUIRE(table.modifiers.size() == 1);
+
+    Harness harness(table);
+    const auto block = blockOf(static_cast<int>(kSampleRate / 1000.0));
+
+    // Nothing detected yet, so nothing modulated.
+    harness.run(table, block);
+    CHECK(harness.values[param].value() == approx(0.0f));
+
+    // A loud block at the source, handed over the way the executor hands it
+    // over: after the source's ops have rendered, which is after this block's
+    // parameters were resolved. So the first block that can see it is the next
+    // one, which is the lag the design settles on and bounds.
+    const auto loud = flat(block.numSamples, 1.0f);
+    harness.mods.detectSource(0, table, loud);
+
+    harness.run(table, block);
+    const auto first = harness.values[param].value();
+    CHECK(first > 0.0f);
+
+    // And it keeps climbing while the source stays loud.
+    for (int i = 0; i < 20; ++i) {
+        harness.mods.detectSource(0, table, loud);
+        harness.run(table, block);
+    }
+    CHECK(harness.values[param].value() > first);
+}
+
+TEST_CASE("A disabled follower detects nothing", "[engine][mod][follower][runtime]") {
+    auto track = trackWithFollower();
+    track.mods[0].enabled = false;
+
+    const auto table = tableFor({track});
+    REQUIRE(table.modifiers.size() == 1);
+
+    Harness harness(table);
+    const auto block = blockOf(256);
+
+    // A modifier the model has switched off is a modifier that is not there, so
+    // detecting for it would leave an envelope primed for the block it comes
+    // back on.
+    harness.mods.detectSource(0, table, flat(block.numSamples, 1.0f));
+    harness.run(table, block);
+    CHECK(harness.mods.value(0) == approx(0.0f));
+}

--- a/tests/test_mod_lfo.cpp
+++ b/tests/test_mod_lfo.cpp
@@ -789,7 +789,7 @@ TEST_CASE("A gate holds the output at nothing while the phase carries on",
 
     // Ungating resumes where the LFO would have been rather than where it was
     // when the gate shut: gating is not a pause.
-    harness.mods.setGated(fixture.modifier, false);
+    harness.mods.setGated(fixture.modifier, fixture.table, false);
     harness.run(fixture.table, block);
     CHECK(harness.mods.value(fixture.modifier) == approx(0.75f));
 }

--- a/tests/test_mod_random.cpp
+++ b/tests/test_mod_random.cpp
@@ -1,0 +1,496 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+#include <set>
+#include <vector>
+
+#include "core/TrackInfo.hpp"
+#include "param/ModRandom.hpp"
+#include "param/ModRuntime.hpp"
+#include "param/ParamResolve.hpp"
+#include "param/ParamTableCompiler.hpp"
+#include "plan/PlanCompiler.hpp"
+
+/**
+ * @file test_mod_random.cpp
+ * @brief The random modulator (#2120).
+ *
+ * What is assertable about a walk is its structure rather than its numbers. The
+ * fork seeds from the clock and promises neither reproducibility nor
+ * independence between two modulators, so a parity case here cannot compare
+ * sequences; what it can compare is where the steps land, how far one may move
+ * from the last, what the shape control does between them, and that the timing
+ * is the LFO's timing, which is the part a project can hear.
+ *
+ * The one thing this engine does promise and the fork does not is that a
+ * project draws the same numbers on every run of it, which is asserted here
+ * because an engine that renders differently twice cannot be null-diffed
+ * against anything, itself included.
+ */
+
+using namespace magda;
+using magda::engine::advanceRandom;
+using magda::engine::BlockInfo;
+using magda::engine::compileParamTable;
+using magda::engine::compileRenderPlan;
+using magda::engine::ModContribution;
+using magda::engine::ModKind;
+using magda::engine::ModRuntime;
+using magda::engine::ModSync;
+using magda::engine::ModTiming;
+using magda::engine::ParamKey;
+using magda::engine::ParamSegment;
+using magda::engine::ParamTable;
+using magda::engine::RandomSettings;
+using magda::engine::RandomShape;
+using magda::engine::RandomState;
+using magda::engine::ResolvedParams;
+using magda::engine::resolveParams;
+using magda::engine::restartRandom;
+using magda::engine::seedRandom;
+
+namespace {
+
+Catch::Approx approx(float value) {
+    return Catch::Approx(value).margin(1e-4);
+}
+
+constexpr double kSampleRate = 48000.0;
+
+ModTiming timing(double bpm = 120.0, int numerator = 4, int denominator = 4) {
+    return ModTiming{kSampleRate, bpm, numerator, denominator};
+}
+
+BlockInfo blockOf(int numSamples) {
+    BlockInfo block;
+    block.numSamples = numSamples;
+    return block;
+}
+
+/// A block a tenth of a step long, so ten of them is one cycle at 1 Hz.
+BlockInfo tenthBlock() {
+    return blockOf(static_cast<int>(kSampleRate / 10.0));
+}
+
+RandomSettings stepped(float hz = 1.0f) {
+    RandomSettings settings;
+    settings.rate.hz = hz;
+    return settings;
+}
+
+RandomState seeded(std::uint64_t address = 1) {
+    RandomState state;
+    seedRandom(state, address);
+    return state;
+}
+
+float step(RandomState& state, const RandomSettings& settings, const BlockInfo& block,
+           const ModTiming& time = timing()) {
+    return advanceRandom(state, settings, block, time);
+}
+
+/// The values @p count blocks publish.
+std::vector<float> walk(RandomState& state, const RandomSettings& settings, int count,
+                        const BlockInfo& block = tenthBlock()) {
+    std::vector<float> values;
+    values.reserve(static_cast<std::size_t>(count));
+    for (int i = 0; i < count; ++i)
+        values.push_back(step(state, settings, block));
+    return values;
+}
+
+TrackInfo makeTrack(TrackId id) {
+    TrackInfo track;
+    track.id = id;
+    track.name = "Track " + juce::String(id);
+    track.audioOutputDevice = "master";
+    track.mods = createDefaultMods(0);
+    return track;
+}
+
+TrackInfo makeMaster() {
+    auto master = makeTrack(MASTER_TRACK_ID);
+    master.type = TrackType::Master;
+    master.audioOutputDevice = {};
+    return master;
+}
+
+DeviceInfo makeDevice(DeviceId id) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Effect " + juce::String(id);
+    device.deviceType = DeviceType::Effect;
+    device.mods = createDefaultMods(0);
+
+    ParameterInfo info(0, "Level", "", 0.0f, 1.0f, 0.0f);
+    info.currentValue = 0.0f;
+    device.parameters.push_back(info);
+
+    return device;
+}
+
+TrackInfo trackWithRandom() {
+    auto track = makeTrack(1);
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(7)));
+    track.mods = createDefaultMods(1);
+    track.mods[0].type = ModType::Random;
+    track.mods[0].rate = 1.0f;
+    track.mods[0].links.push_back(ModLink{
+        ControlTarget::pluginParam(ChainNodePath::topLevelDevice(1, 7), 0), 1.0f, false, true});
+    return track;
+}
+
+ParamTable tableFor(const std::vector<TrackInfo>& tracks) {
+    const auto master = makeMaster();
+    const auto plan = compileRenderPlan(tracks, master);
+    return compileParamTable(plan, tracks, master, {});
+}
+
+struct Harness {
+    explicit Harness(const ParamTable& table)
+        : links(static_cast<std::size_t>(std::max(table.maxLinksPerParam, 1))),
+          segments(
+              static_cast<std::size_t>(magda::engine::ResolvedParams::kDefaultSegmentCapacity)) {
+        values.prepare(table.size());
+        mods.prepare(table, magda::engine::RenderContext{kSampleRate, 512, 2});
+    }
+
+    void run(const ParamTable& table, const BlockInfo& block) {
+        resolveParams(table, values, links, segments, block, &mods);
+    }
+
+    ResolvedParams values;
+    ModRuntime mods;
+    std::vector<ModContribution> links;
+    std::vector<ParamSegment> segments;
+};
+
+}  // namespace
+
+// =============================================================================
+// The walk
+// =============================================================================
+
+TEST_CASE("A stepped walk changes value once per cycle", "[engine][mod][random]") {
+    auto settings = stepped();
+    auto state = seeded();
+
+    // Held across the step, because a shape of zero is a sample and hold: ten
+    // blocks of a tenth each is one cycle, and the value inside it is one value.
+    const auto first = walk(state, settings, 10);
+    const auto second = walk(state, settings, 10);
+    const auto third = walk(state, settings, 10);
+
+    for (const auto& cycle : {first, second, third})
+        for (const auto value : cycle)
+            CHECK(value == approx(cycle.front()));
+
+    // And a different one two cycles on. Two rather than one, because a held
+    // step publishes the value drawn at the wrap before it: the fork reads the
+    // shape control as "how much of the step is spent travelling", and a step
+    // that travels for none of itself is a sample and hold one step behind.
+    CHECK(third.front() != approx(first.front()));
+}
+
+TEST_CASE("Step depth bounds how far one step moves", "[engine][mod][random]") {
+    auto settings = stepped();
+    settings.stepDepth = 0.2f;
+
+    auto state = seeded(7);
+    float previous = walk(state, settings, 10).front();
+
+    // Half the control each way, clipped to the range, which is the fork's
+    // arithmetic for a unipolar modulator. A hundred steps is enough for a
+    // breach to show if the bound were wrong.
+    for (int i = 0; i < 100; ++i) {
+        const auto value = walk(state, settings, 10).front();
+        CHECK(std::abs(value - previous) <= 0.1f + 1e-4f);
+        CHECK(value >= 0.0f);
+        CHECK(value <= 1.0f);
+        previous = value;
+    }
+}
+
+TEST_CASE("A full step depth still stays in range", "[engine][mod][random]") {
+    auto settings = stepped();
+    settings.stepDepth = 1.0f;
+
+    auto state = seeded(11);
+    for (int i = 0; i < 200; ++i) {
+        const auto value = walk(state, settings, 10).front();
+        CHECK(value >= 0.0f);
+        CHECK(value <= 1.0f);
+    }
+}
+
+TEST_CASE("Shape decides how much of a step is spent travelling", "[engine][mod][random]") {
+    SECTION("a shape of one ramps the whole way across") {
+        auto settings = stepped();
+        settings.shape = 1.0f;
+
+        auto state = seeded(3);
+
+        // Past the first wrap, so there is a previous value to travel from.
+        walk(state, settings, 10);
+        const auto values = walk(state, settings, 10);
+
+        // Monotone across the step, in whichever direction this step went.
+        const bool rising = values.back() > values.front();
+        for (std::size_t i = 1; i < values.size(); ++i)
+            CHECK((rising ? values[i] >= values[i - 1] : values[i] <= values[i - 1]));
+
+        // And it actually moved, rather than being flat in both directions.
+        CHECK(values.front() != approx(values.back()));
+    }
+
+    SECTION("a shape of zero holds") {
+        auto settings = stepped();
+        auto state = seeded(3);
+
+        walk(state, settings, 10);
+        const auto values = walk(state, settings, 10);
+        for (const auto value : values)
+            CHECK(value == approx(values.front()));
+    }
+}
+
+TEST_CASE("Smoothing bends the phase and leaves a held step alone", "[engine][mod][random]") {
+    // Smoothing acts on the phase, so it eases the ends of a ramp and does
+    // nothing at all to a value that is not travelling.
+    auto held = stepped();
+    held.smooth = 1.0f;
+
+    auto state = seeded(5);
+    walk(state, held, 10);
+    const auto values = walk(state, held, 10);
+    for (const auto value : values)
+        CHECK(value == approx(values.front()));
+
+    SECTION("but changes the route a ramped one takes") {
+        auto ramped = stepped();
+        ramped.shape = 1.0f;
+
+        auto plain = seeded(5);
+        walk(plain, ramped, 10);
+        const auto straight = walk(plain, ramped, 10);
+
+        ramped.smooth = 1.0f;
+        auto smoothed = seeded(5);
+        walk(smoothed, ramped, 10);
+        const auto eased = walk(smoothed, ramped, 10);
+
+        // The same two ends, because smoothing is about the phase rather than
+        // the values the step travels between.
+        REQUIRE(straight.size() == eased.size());
+        CHECK(eased.front() == approx(straight.front()));
+
+        // And a different route between them.
+        bool differs = false;
+        for (std::size_t i = 1; i + 1 < straight.size(); ++i)
+            differs = differs || std::abs(eased[i] - straight[i]) > 1e-3f;
+        CHECK(differs);
+    }
+}
+
+TEST_CASE("Noise steps every block and ignores the rate", "[engine][mod][random]") {
+    auto settings = stepped();
+    settings.type = RandomShape::Noise;
+
+    auto state = seeded(13);
+
+    // Ten blocks inside what would be one step at this rate, and ten different
+    // values: the rate stops meaning anything, because there is no longer a
+    // step for it to be the length of.
+    const auto values = walk(state, settings, 10);
+
+    std::set<float> distinct(values.begin(), values.end());
+    CHECK(distinct.size() > 1);
+
+    for (const auto value : values) {
+        CHECK(value >= 0.0f);
+        CHECK(value <= 1.0f);
+    }
+}
+
+TEST_CASE("A walk is the same on every run of a project", "[engine][mod][random]") {
+    const auto settings = stepped();
+
+    auto first = seeded(42);
+    auto second = seeded(42);
+    CHECK(walk(first, settings, 60) == walk(second, settings, 60));
+
+    // And two modifiers are independent, which is what seeding from the
+    // modifier's own address buys: adjacent addresses must not walk together.
+    auto other = seeded(43);
+    auto again = seeded(42);
+    CHECK(walk(other, settings, 60) != walk(again, settings, 60));
+}
+
+// =============================================================================
+// The timing
+// =============================================================================
+
+TEST_CASE("A synced walk steps on the bar grid", "[engine][mod][random]") {
+    auto settings = stepped();
+    settings.sync = ModSync::Transport;
+    settings.tempoSync = true;
+    settings.rate.rateType = static_cast<int>(ModRateType::Bar);
+
+    auto state = seeded();
+
+    // A timeline-locked walk is a function of where the block is, so two of
+    // them at one rate step together however playback got there. Block one bar
+    // in and the phase is at the top of a step.
+    BlockInfo block = blockOf(64);
+    block.startBeat = 4.0;
+    block.endBeat = 4.0 + (64.0 / kSampleRate) * 2.0;
+
+    step(state, settings, block);
+    CHECK(state.phase == approx(0.0f));
+
+    // Halfway through the next bar is halfway through the step.
+    block.startBeat = 6.0;
+    step(state, settings, block);
+    CHECK(state.phase == approx(0.5f));
+}
+
+TEST_CASE("A free-running walk advances by how long the block was", "[engine][mod][random]") {
+    auto settings = stepped(2.0f);
+    auto state = seeded();
+
+    // Twentieths of a second at two cycles a second is a tenth of a step each,
+    // so the tenth block publishes the last position before the wrap and the
+    // eleventh publishes the top of the next step. The value a block renders
+    // with is the value at its first sample, which is why the wrap shows up in
+    // the block after the one that completed it.
+    const auto block = blockOf(static_cast<int>(kSampleRate / 20.0));
+    for (int i = 0; i < 10; ++i)
+        step(state, settings, block);
+    CHECK(state.phase == approx(0.9f));
+
+    step(state, settings, block);
+    CHECK(state.phase == approx(0.0f));
+}
+
+TEST_CASE("A trigger restarts the walk and takes a step", "[engine][mod][random]") {
+    auto settings = stepped();
+    settings.sync = ModSync::Note;
+    settings.trigger = LFOTriggerMode::MIDI;
+
+    auto state = seeded(17);
+    walk(state, settings, 5);
+    const auto before = state.current;
+
+    restartRandom(state, settings);
+    step(state, settings, tenthBlock());
+
+    // Back to the top of a step, and a new number drawn rather than the ramp
+    // being replayed towards the one the walk was already heading for.
+    CHECK(state.phase == approx(0.0f));
+    CHECK(state.current != approx(before));
+
+    SECTION("and a free-running walk ignores it") {
+        auto free = stepped();
+        auto ignoring = seeded(17);
+        walk(ignoring, free, 5);
+        const auto phase = ignoring.phase;
+
+        restartRandom(ignoring, free);
+        CHECK(!ignoring.stepPending);
+        CHECK(ignoring.phase == approx(phase));
+    }
+}
+
+// =============================================================================
+// The wiring
+// =============================================================================
+
+TEST_CASE("A random modulator's settings reach the table", "[engine][mod][random][table]") {
+    auto track = trackWithRandom();
+    track.mods[0].randomType = 1;
+    track.mods[0].randomShape = 0.6f;
+    track.mods[0].randomSmooth = 0.3f;
+    track.mods[0].randomStepDepth = 0.4f;
+
+    const auto table = tableFor({track});
+    REQUIRE(table.modifiers.size() == 1);
+
+    const auto& modifier = table.modifiers.front();
+    CHECK(modifier.kind == ModKind::Random);
+    CHECK(modifier.random.type == RandomShape::Noise);
+    CHECK(modifier.random.shape == approx(0.6f));
+    CHECK(modifier.random.smooth == approx(0.3f));
+    CHECK(modifier.random.stepDepth == approx(0.4f));
+    CHECK(modifier.random.rate.hz == approx(1.0f));
+}
+
+TEST_CASE("A random modulator shares the LFO's rate lane", "[engine][mod][random][table]") {
+    auto track = trackWithRandom();
+    track.mods[0].tempoSync = true;
+    track.mods[0].syncDivision = SyncDivision::Eighth;
+
+    const auto table = tableFor({track});
+    REQUIRE(table.modifiers.size() == 1);
+
+    // The same fold and the same ordinal an LFO on these fields would get: the
+    // fork drives both through one mapping and a project has to sound the same
+    // whichever of the two is on the knob.
+    CHECK(table.modifiers.front().random.sync == ModSync::Transport);
+    CHECK(table.modifiers.front().random.tempoSync);
+    CHECK(table.modifiers.front().random.rate.rateType ==
+          magda::syncDivisionToTeRateOrdinal(SyncDivision::Eighth));
+}
+
+TEST_CASE("A random modulator drives a device parameter", "[engine][mod][random][runtime]") {
+    const auto table = tableFor({trackWithRandom()});
+
+    ParamKey key;
+    key.kind = ParamKey::Kind::DeviceParam;
+    key.scope = ParamKey::Scope::Device;
+    key.trackId = 1;
+    key.device = magda::engine::DeviceKey{ChainSegment::Fx, 7};
+    key.index = 0;
+
+    const auto param = table.find(key);
+    REQUIRE(param != magda::engine::INVALID_PARAM_ID);
+
+    Harness harness(table);
+    const auto block = tenthBlock();
+
+    // Held across one step and moved later, which is what the walk does at the
+    // modifier and therefore what the parameter does at the far end.
+    harness.run(table, block);
+    const auto opening = harness.values[param].value();
+
+    for (int i = 0; i < 9; ++i)
+        harness.run(table, block);
+    CHECK(harness.values[param].value() == approx(opening));
+
+    // Two cycles on, for the reason the walk's own case gives: a sample and
+    // hold publishes the number drawn at the wrap before it.
+    for (int i = 0; i < 20; ++i)
+        harness.run(table, block);
+    CHECK(harness.values[param].value() != approx(opening));
+}
+
+TEST_CASE("A random modulator has no gate", "[engine][mod][random][runtime]") {
+    // The fork's random modifier resyncs on a note and has no gate parameter,
+    // so an audio-triggered one keeps walking between hits rather than resting
+    // at zero. Asserted because the API a detector drives is uniform across the
+    // kinds and this is the kind that ignores half of it.
+    auto track = trackWithRandom();
+    track.mods[0].triggerMode = LFOTriggerMode::Audio;
+
+    const auto table = tableFor({track});
+    REQUIRE(table.modifiers.size() == 1);
+
+    Harness harness(table);
+    const auto block = tenthBlock();
+
+    harness.run(table, block);
+    const auto value = harness.mods.value(0);
+
+    harness.mods.setGated(0, table, true);
+    harness.run(table, block);
+    CHECK(harness.mods.value(0) == approx(value));
+}

--- a/tests/test_modulation_baker.cpp
+++ b/tests/test_modulation_baker.cpp
@@ -77,7 +77,7 @@ TEST_CASE("ModulationBaker - bakeability by mod type", "[automation][bake]") {
     REQUIRE_FALSE(ModulationBaker::isBakeable(mod));
     mod.type = ModType::Random;
     REQUIRE_FALSE(ModulationBaker::isBakeable(mod));
-    mod.type = ModType::Follower;
+    mod.setType(ModType::Follower);
     REQUIRE_FALSE(ModulationBaker::isBakeable(mod));
 }
 
@@ -239,7 +239,7 @@ TEST_CASE("ModulationBaker - empty or non-bakeable input yields no points", "[au
     REQUIRE(ModulationBaker::bake({}, opts, tempo).empty());
 
     auto follower = makeSource(makeLFO(LFOWaveform::Sine, SyncDivision::Quarter), 1.0f);
-    follower.mod.type = ModType::Follower;
+    follower.mod.setType(ModType::Follower);
     REQUIRE(ModulationBaker::bake({follower}, opts, tempo).empty());
 
     ModulationBaker::Options degenerate;

--- a/tests/test_persisted_enum_pins.cpp
+++ b/tests/test_persisted_enum_pins.cpp
@@ -172,6 +172,12 @@ static_assert(static_cast<int>(LFOWaveform::Saw) == 3);
 static_assert(static_cast<int>(LFOWaveform::ReverseSaw) == 4);
 static_assert(static_cast<int>(LFOWaveform::Custom) == 5);
 
+// Where a modifier listens in its source's chain (#2120). Written as an
+// integer, so an insert would move every modifier in every saved project to
+// the other point: a follower would start keying off the head of the chain.
+static_assert(static_cast<int>(ModTapPoint::PreFx) == 0);
+static_assert(static_cast<int>(ModTapPoint::PostFader) == 1);
+
 static_assert(static_cast<int>(LFOTriggerMode::Free) == 0);
 static_assert(static_cast<int>(LFOTriggerMode::Transport) == 1);
 static_assert(static_cast<int>(LFOTriggerMode::MIDI) == 2);
@@ -339,6 +345,8 @@ std::vector<Pin> allPins() {
         PIN(ModType, Envelope, 1),
         PIN(ModType, Random, 2),
         PIN(ModType, Follower, 3),
+        PIN(ModTapPoint, PreFx, 0),
+        PIN(ModTapPoint, PostFader, 1),
         PIN(LFOWaveform, Sine, 0),
         PIN(LFOWaveform, Triangle, 1),
         PIN(LFOWaveform, Square, 2),

--- a/tests/test_render_plan_compiler.cpp
+++ b/tests/test_render_plan_compiler.cpp
@@ -899,27 +899,69 @@ TEST_CASE("An unmonitored MIDI route does not make its source compile MIDI",
     CHECK(countRole(plan, OpRole::TrackMidiInput) == 0);
 }
 
-TEST_CASE("A rack-level sidechain is reported as unsupported", "[engine][plan][compiler]") {
-    RackInfo rack;
-    rack.id = 4;
-    rack.sidechain.type = SidechainConfig::Type::MIDI;
-    rack.sidechain.sourceTrackId = 2;
-    ChainInfo chain;
-    chain.id = 10;
-    chain.elements.push_back(makeDeviceElement(makeEffect(7)));
-    rack.chains.push_back(std::move(chain));
+TEST_CASE("A rack-level sidechain is an edge to the modulation system",
+          "[engine][plan][compiler]") {
+    // The rack, sidechained from track 2, with whatever modifiers the caller
+    // puts on it.
+    const auto planWith = [](magda::ModArray mods, SidechainConfig::Type type) {
+        RackInfo rack;
+        rack.id = 4;
+        rack.sidechain.type = type;
+        rack.sidechain.sourceTrackId = 2;
+        rack.mods = std::move(mods);
+        ChainInfo chain;
+        chain.id = 10;
+        chain.elements.push_back(makeDeviceElement(makeEffect(7)));
+        rack.chains.push_back(std::move(chain));
 
-    std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
-    tracks[0].chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
+        std::vector<TrackInfo> tracks{makeTrack(1), makeTrack(2)};
+        tracks[0].chain.fxChainElements.push_back(makeRackElement(std::move(rack)));
 
-    const auto plan = magda::engine::compileRenderPlan(tracks, makeMaster());
-    requireWellFormed(plan);
+        return magda::engine::compileRenderPlan(tracks, makeMaster());
+    };
 
-    // It drives rack modulation rather than signal, so the plan carries no edge
-    // for it. That is a gap the contract says to name rather than pass over.
-    REQUIRE(plan.diagnostics.size() == 1);
-    CHECK(plan.diagnostics.front().find("rack 4") != std::string::npos);
-    CHECK(plan.diagnostics.front().find("modulation") != std::string::npos);
+    const auto listening = [](magda::ModType type, magda::LFOTriggerMode trigger) {
+        magda::ModInfo mod(0);
+        mod.type = type;
+        mod.triggerMode = trigger;
+        return magda::ModArray{mod};
+    };
+
+    SECTION("a rack nothing listens with is not an edge") {
+        // A sidechain feeds modulation, so a rack whose modifiers all
+        // free-run is a sidechain with nothing on the far end. No tap, and no
+        // diagnostic either: there is nothing the plan failed to carry.
+        const auto plan = planWith({}, SidechainConfig::Type::MIDI);
+        requireWellFormed(plan);
+
+        CHECK(plan.diagnostics.empty());
+        CHECK(countRole(plan, OpRole::ModulationTap) == 0);
+    }
+
+    SECTION("a note-triggered modifier on the rack makes it one") {
+        const auto plan = planWith(listening(magda::ModType::LFO, magda::LFOTriggerMode::MIDI),
+                                   SidechainConfig::Type::MIDI);
+        requireWellFormed(plan);
+
+        CHECK(plan.diagnostics.empty());
+        REQUIRE(countRole(plan, OpRole::ModulationTap) == 1);
+
+        // Keyed to the source rather than to the rack: what the op carries is
+        // one track's signal, and every modifier listening to that track reads
+        // the same one.
+        const auto taps = opsWithRole(plan, OpRole::ModulationTap);
+        REQUIRE(taps.size() == 1);
+        CHECK(plan.ops[static_cast<std::size_t>(taps.front())].key.trackId == 2);
+    }
+
+    SECTION("a follower on the rack makes it one too") {
+        const auto plan = planWith(listening(magda::ModType::Follower, magda::LFOTriggerMode::Free),
+                                   SidechainConfig::Type::Audio);
+        requireWellFormed(plan);
+
+        CHECK(plan.diagnostics.empty());
+        CHECK(countRole(plan, OpRole::ModulationTap) == 1);
+    }
 }
 
 TEST_CASE("Delta solo is reported on devices and on racks", "[engine][plan][compiler]") {


### PR DESCRIPTION
Slice 5 of #1891. Closes #2120.

The three remaining modifier engines, on the terms slice 4 set for the LFO:
settings in the published table, state in the runtime carried by the modifier's
own address, one block at a time read from the block's first sample.

## The envelope

The fork's stage machine, curvature included. A segment's bend is a persisted
number between -0.5 and 0.5, so the quadratic bezier behind it is transcribed
rather than reasoned out again.

Two things differ from the LFO and both are the fork's rather than choices made
here. An envelope is nothing but a gate, so where the gate comes from is what
the sync mode selects, and tempo sync stays out of that fold because it scales
the stages rather than deciding them. And the fork's ADSR timer advances before
it publishes, where its LFO timer publishes before it advances: the two are one
block apart and the second is what a parity case is measured against.

## The walk

The fork's too, one difference aside. Its type parameter is written and never
read, so a project set to noise sounds stepped there. Implemented here rather
than reproduced as the same omission, because a control that does nothing is
worse than a difference that is written down.

The generator is seeded from the modifier's own address, which the fork cannot
promise: it seeds from the clock, so two of its modifiers can walk together and
a project draws different numbers on its second run. A project that renders
differently twice cannot be null-diffed against anything, itself included.

## The follower

The one modifier that is not a function of time, and the reason this slice
exists. Its input is audio the modifier does not own, so the plan has to carry
it. The detector is the fork's: per-follower input gain, then the band limits on
JUCE's own coefficients so both engines listen to the same part of the spectrum,
then the block's peak. The envelope is the fork's one-pole attack, hold and
release over that peak.

## The edge becomes real

A modifier listens to the sidechain source of the scope it lives on, and to the
track it lives on when that scope has none. One rule, in one header, because two
compilers need the answer: the plan compiler to emit the edge and the table
compiler to record which modifier is on the far end of it. A rule stated twice
is a rule that will eventually be two rules, and the failure would be silent.

The plan gains one op per listened-to track, a second sink fed the source's
post-fader tap and its chain-head MIDI. The rack sidechain `PlanCompiler` used
to report as unrepresentable is now an ordering constraint and an op, and the
diagnostic is gone.

## Where the block hears it

Parameters resolve at the top of a block, so a trigger fired by an op is not
spent until the next block's resolve. That is fine for a level and not for a
note, and the two are settled differently.

A note is known before the block resolves: the ops that produce MIDI read clips
and input queues rather than audio, so the executor renders that prefix first
and a note-gated modifier is resolved with the note that arrived in this block.
The fork's ordinary gate is a block later than that and only its monitor path is
this early, so this is the fork's best case made unconditional. Both executors
share the prefix; the parallel one still schedules those ops so their consumers
release as usual, and skips re-running them the way it already skips its
outputs. MIDI a device makes is not in the prefix and cannot be, so a modifier
triggered from an arpeggiator is a block late.

A level is not known, because it is what the ops are about to produce. The
detector runs during the walk and the resolve that reads it is the next block's:
one block, always exactly one, documented as a consequence of resolving at the
top rather than as an accident. The alternative is to resolve a modifier's
targets after its source's subgraph renders, which splits resolution into two
passes and makes the order a plan-shaped question. That is not this slice's.

`test_mod_feeds.cpp` asserts the distance per trigger type end to end through a
session rather than only the gap, which is what the timing note on #2120 asked
for.

## What is here

Forty-six cases across four files, and a `modulation-sources` golden that shows
the edge from both ends: the tap in the plan, and the modifier that reads it in
the table.
