### PR TITLE
Read a value back, without simulating one (#2122)

### DIFF
--- a/magda/engine/CMakeLists.txt
+++ b/magda/engine/CMakeLists.txt
@@ -100,6 +100,7 @@ add_library(magda_engine STATIC
     param/ModRuntime.hpp
     tap/LevelTap.hpp
     tap/SampleRing.hpp
+    tap/ValueTap.hpp
     transport/TempoMap.cpp
     transport/TransportClock.cpp
     transport/ClickGenerator.cpp

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -85,13 +85,18 @@ EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> p
     live_ = std::move(prepared);
     livePlan_ = live_->plan;
 
+    // Values this plan has nowhere to publish from, taken back now that it is
+    // the one rendering. Here rather than at prepare, because until the swap
+    // the epoch being replaced was still writing them, and a tap cleared under
+    // it would be counting from one again by its next block (#2122).
+    live_->executor.clearUnboundValueTaps();
+
     // Safe only now: before the swap, everything about to be destroyed was
     // still reachable from the plan the audio thread was rendering. The plan
     // that is live goes in as well, so what it names survives however stale
-    // the caller's model IDs turn out to be.
-    // The table goes in beside the plan, because a plan does not name a
-    // parameter and the value taps are keyed by one: it is what says which of
-    // them the audio thread can now reach (#2122).
+    // the caller's model IDs turn out to be. The table goes in beside it,
+    // because a plan does not name a parameter and the value taps are keyed by
+    // one: it is what says which of them the audio thread can now reach.
     store_.releaseDeleted(*livePlan_, modelIds, live_->values.params.get());
 
     return {true, std::move(messages)};

--- a/magda/engine/exec/EngineSession.cpp
+++ b/magda/engine/exec/EngineSession.cpp
@@ -89,7 +89,10 @@ EngineSession::Result EngineSession::publish(std::shared_ptr<const RenderPlan> p
     // still reachable from the plan the audio thread was rendering. The plan
     // that is live goes in as well, so what it names survives however stale
     // the caller's model IDs turn out to be.
-    store_.releaseDeleted(*livePlan_, modelIds);
+    // The table goes in beside the plan, because a plan does not name a
+    // parameter and the value taps are keyed by one: it is what says which of
+    // them the audio thread can now reach (#2122).
+    store_.releaseDeleted(*livePlan_, modelIds, live_->values.params.get());
 
     return {true, std::move(messages)};
 }

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -199,15 +199,30 @@ class EngineSession {
      * @brief Where @p key's value is published, or nullptr (#2122).
      *
      * What a host collects after asking for a value through
-     * RuntimeStateFactory::valuesToTap(). The lookup is on the publishing
-     * thread; the tap it hands back is readable from any thread, and is what a
-     * knob under modulation, a modifier editor, and a touch or latch gesture
-     * all draw from.
+     * RuntimeStateFactory::valuesToTap(). What it hands back is where a knob
+     * under modulation, a modifier editor, and a touch or latch gesture all
+     * draw from.
      *
-     * Good until the next publish. See RuntimeStateStore::valueTap().
+     * Both the lookup and the pointer belong to the publishing thread, and that
+     * is a lifetime rather than a convention: the next publish can destroy the
+     * tap outright, on that thread, with nothing deferring the reclamation. A
+     * cached pointer read from a paint or animation thread is a use-after-free
+     * waiting for an edit. Fetch it here, use it before returning to the
+     * message loop, and ask again after every publish; read() is safe from
+     * wherever it is called for exactly as long as the pointer is.
+     *
+     * See RuntimeStateStore::valueTap() for what null means, which is not the
+     * same as the tap being unbound.
      */
     ValueTap* valueTap(const ParamKey& key) const {
         return store_.valueTap(key);
+    }
+
+    /// Values the live plan found somewhere to publish from, which is not the
+    /// number of taps the store holds: a key the parameter table does not carry
+    /// has a tap and is never written through it. On the publishing thread.
+    int boundValueTapCount() const {
+        return live_ == nullptr ? 0 : live_->executor.boundValueTapCount();
     }
 
     /// The plan currently published, or null. On the publishing thread.

--- a/magda/engine/exec/EngineSession.hpp
+++ b/magda/engine/exec/EngineSession.hpp
@@ -195,6 +195,21 @@ class EngineSession {
         return store_.size();
     }
 
+    /**
+     * @brief Where @p key's value is published, or nullptr (#2122).
+     *
+     * What a host collects after asking for a value through
+     * RuntimeStateFactory::valuesToTap(). The lookup is on the publishing
+     * thread; the tap it hands back is readable from any thread, and is what a
+     * knob under modulation, a modifier editor, and a touch or latch gesture
+     * all draw from.
+     *
+     * Good until the next publish. See RuntimeStateStore::valueTap().
+     */
+    ValueTap* valueTap(const ParamKey& key) const {
+        return store_.valueTap(key);
+    }
+
     /// The plan currently published, or null. On the publishing thread.
     std::shared_ptr<const RenderPlan> livePlan() const {
         return livePlan_;

--- a/magda/engine/exec/ParallelPlanExecutor.hpp
+++ b/magda/engine/exec/ParallelPlanExecutor.hpp
@@ -101,6 +101,9 @@ class ParallelPlanExecutor final : private RenderThreadPool::Job {
     int boundMeterCount() const {
         return core_.boundMeterCount();
     }
+    int boundValueTapCount() const {
+        return core_.boundValueTapCount();
+    }
     int audioBufferCount() const {
         return core_.audioBufferCount();
     }

--- a/magda/engine/exec/ParallelPlanExecutor.hpp
+++ b/magda/engine/exec/ParallelPlanExecutor.hpp
@@ -104,6 +104,9 @@ class ParallelPlanExecutor final : private RenderThreadPool::Job {
     int boundValueTapCount() const {
         return core_.boundValueTapCount();
     }
+    void clearUnboundValueTaps() {
+        core_.clearUnboundValueTaps();
+    }
     int audioBufferCount() const {
         return core_.audioBufferCount();
     }

--- a/magda/engine/exec/PlanBindings.hpp
+++ b/magda/engine/exec/PlanBindings.hpp
@@ -5,9 +5,11 @@
 
 #include "core/TypeIds.hpp"
 #include "exec/EngineDevice.hpp"
+#include "param/ParamKey.hpp"
 #include "plan/RenderPlan.hpp"
 #include "tap/LevelTap.hpp"
 #include "tap/MidiTap.hpp"
+#include "tap/ValueTap.hpp"
 
 namespace magda::engine {
 
@@ -66,6 +68,28 @@ struct PlanBindings {
      * observing, and an unbound op is not reported.
      */
     std::map<OpKey, MidiTap*> midiTaps;
+
+    /**
+     * @brief Where a value is published for whoever is drawing it (#2122).
+     *
+     * Keyed by ParamKey rather than by OpKey, which is the one difference from
+     * the two above and follows from what is being read: a meter is a place in
+     * the signal and this is a number in the parameter system. One map for both
+     * of the numbers, because the key already says which: a key with a
+     * parameter index is a parameter's resolved position, and a modifier key
+     * with none is that modifier's output (ParamKey.hpp).
+     *
+     * Optional in the same way and for the same reason. A host binds what it is
+     * drawing, which is a device editor's worth of parameters out of a
+     * project's thousands, and a value nobody has asked about publishes nothing
+     * and is not reported.
+     *
+     * Resolved against the table the plan is prepared with, so a key the table
+     * does not carry binds nothing. That is not an error either: a host may ask
+     * for a parameter that has since been deleted, and the answer is that
+     * nothing writes to it.
+     */
+    std::map<ParamKey, ValueTap*> valueTaps;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/exec/PlanBindings.hpp
+++ b/magda/engine/exec/PlanBindings.hpp
@@ -85,9 +85,13 @@ struct PlanBindings {
      * and is not reported.
      *
      * Resolved against the table the plan is prepared with, so a key the table
-     * does not carry binds nothing. That is not an error either: a host may ask
-     * for a parameter that has since been deleted, and the answer is that
-     * nothing writes to it.
+     * does not carry binds nothing. That is not an error either, and it is not
+     * rare: the table carries a mixer value, a macro or a modifier's rate only
+     * while something reaches it, so an unautomated fader with nothing linked
+     * to it has no publisher at all. The tap reads no writes, which is what
+     * tells a host the engine does not move this value and the model's own is
+     * the answer (ValueTap.hpp). A parameter that has since been deleted lands
+     * in the same place by the same route.
      */
     std::map<ParamKey, ValueTap*> valueTaps;
 };

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -371,23 +371,31 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                 modSourceForOp_[i] = mods_.listenersOf(op.key.trackId);
             }
         }
+    }
 
-        // The values a host asked to read back, resolved to the indices the
-        // block already has (#2122). A key with a parameter index is a
-        // parameter of the table; a modifier key has none and is looked for in
-        // the runtime, which is where the output it names is published.
-        //
-        // A key neither of them has binds nothing and is not reported, which is
-        // the ordinary answer rather than a fault: the table carries a mixer
-        // value, a macro or a modifier's rate only while something reaches it,
-        // so a host drawing an unautomated fader is asking about a number the
-        // engine does not move. It is kept anyway, because the swap has to
-        // clear it: a tap that used to be published and now is not would
-        // otherwise freeze where the last plan left it.
-        for (const auto& [key, tap] : bindings.valueTaps) {
-            if (tap == nullptr)
-                continue;
+    // The values a host asked to read back, resolved to the indices the block
+    // already has (#2122). A key with a parameter index is a parameter of the
+    // table; a modifier key has none and is looked for in the runtime, which is
+    // where the output it names is published.
+    //
+    // A key neither the table nor the runtime has binds nothing and is not
+    // reported, which is the ordinary answer rather than a fault: the table
+    // carries a mixer value, a macro or a modifier's rate only while something
+    // reaches it, so a host drawing an unautomated fader is asking about a
+    // number the engine does not move. It is kept anyway, because the swap has
+    // to clear it: a tap that used to be published and now is not would
+    // otherwise freeze where the last plan left it.
+    //
+    // Outside the block above rather than inside it, because a plan published
+    // with no table at all is the same situation seen from further away. It
+    // publishes nothing, so every tap the bindings offered is one of these; a
+    // loop that only ran when there was a table would leave them all frozen at
+    // whatever the last plan that had one wrote.
+    for (const auto& [key, tap] : bindings.valueTaps) {
+        if (tap == nullptr)
+            continue;
 
+        if (params != nullptr) {
             if (const auto param = params->find(key); param != INVALID_PARAM_ID) {
                 paramTaps_.push_back(BoundValueTap{param, tap});
                 continue;
@@ -397,9 +405,9 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                 modTaps_.push_back(BoundValueTap{modifier, tap});
                 continue;
             }
-
-            unboundTaps_.push_back(tap);
         }
+
+        unboundTaps_.push_back(tap);
     }
 
     // Which ops the block can render before it resolves anything. In plan

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -239,6 +239,7 @@ void PlanExecutor::reset() {
     midiTapForOp_.clear();
     paramTaps_.clear();
     modTaps_.clear();
+    unboundTaps_.clear();
     paramWindowForOp_.clear();
     mixerParamForOp_.clear();
     paramScratch_.clear();
@@ -376,9 +377,13 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
         // parameter of the table; a modifier key has none and is looked for in
         // the runtime, which is where the output it names is published.
         //
-        // A key neither of them has binds nothing and is not reported: the
-        // bindings are what a window is drawing, and a window outlives the
-        // device it was opened on by however long it takes to shut.
+        // A key neither of them has binds nothing and is not reported, which is
+        // the ordinary answer rather than a fault: the table carries a mixer
+        // value, a macro or a modifier's rate only while something reaches it,
+        // so a host drawing an unautomated fader is asking about a number the
+        // engine does not move. It is kept anyway, because the swap has to
+        // clear it: a tap that used to be published and now is not would
+        // otherwise freeze where the last plan left it.
         for (const auto& [key, tap] : bindings.valueTaps) {
             if (tap == nullptr)
                 continue;
@@ -388,8 +393,12 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                 continue;
             }
 
-            if (const auto modifier = mods_.indexOf(key); modifier >= 0)
+            if (const auto modifier = mods_.indexOf(key); modifier >= 0) {
                 modTaps_.push_back(BoundValueTap{modifier, tap});
+                continue;
+            }
+
+            unboundTaps_.push_back(tap);
         }
     }
 
@@ -997,6 +1006,11 @@ void PlanExecutor::resolveParameters(const PlanValues& values, const BlockInfo& 
 
     resolveParams(*blockTable_, paramValues_, paramScratch_, paramSegments_, block, &mods_);
     publishValueTaps();
+}
+
+void PlanExecutor::clearUnboundValueTaps() {
+    for (auto* tap : unboundTaps_)
+        tap->clear();
 }
 
 void PlanExecutor::publishValueTaps() {

--- a/magda/engine/exec/PlanExecutor.cpp
+++ b/magda/engine/exec/PlanExecutor.cpp
@@ -237,6 +237,8 @@ void PlanExecutor::reset() {
     meterForOp_.clear();
     boundMeterCount_ = 0;
     midiTapForOp_.clear();
+    paramTaps_.clear();
+    modTaps_.clear();
     paramWindowForOp_.clear();
     mixerParamForOp_.clear();
     paramScratch_.clear();
@@ -367,6 +369,27 @@ std::vector<std::string> PlanExecutor::prepare(const RenderPlan& plan, const Pla
                 // is the two having drifted rather than a project that has one.
                 modSourceForOp_[i] = mods_.listenersOf(op.key.trackId);
             }
+        }
+
+        // The values a host asked to read back, resolved to the indices the
+        // block already has (#2122). A key with a parameter index is a
+        // parameter of the table; a modifier key has none and is looked for in
+        // the runtime, which is where the output it names is published.
+        //
+        // A key neither of them has binds nothing and is not reported: the
+        // bindings are what a window is drawing, and a window outlives the
+        // device it was opened on by however long it takes to shut.
+        for (const auto& [key, tap] : bindings.valueTaps) {
+            if (tap == nullptr)
+                continue;
+
+            if (const auto param = params->find(key); param != INVALID_PARAM_ID) {
+                paramTaps_.push_back(BoundValueTap{param, tap});
+                continue;
+            }
+
+            if (const auto modifier = mods_.indexOf(key); modifier >= 0)
+                modTaps_.push_back(BoundValueTap{modifier, tap});
         }
     }
 
@@ -973,6 +996,24 @@ void PlanExecutor::resolveParameters(const PlanValues& values, const BlockInfo& 
     }
 
     resolveParams(*blockTable_, paramValues_, paramScratch_, paramSegments_, block, &mods_);
+    publishValueTaps();
+}
+
+void PlanExecutor::publishValueTaps() {
+    // The position the parameter opens the block at, clamped, which is the same
+    // answer a link reading it as a source gets. A knob draws where the value
+    // is at the boundary for the same reason a device reads it there: that is
+    // where the fork settles a parameter, and what is being drawn is what is
+    // being heard.
+    for (const auto& bound : paramTaps_)
+        bound.tap->write(paramValues_.sourceValue(bound.index));
+
+    // The modifier's own output rather than anything downstream of it, so a
+    // modifier editor animates the shape the modifier made and not the depth
+    // some link applied to it. The depth belongs to the link, and a parameter
+    // tap is where its effect shows.
+    for (const auto& bound : modTaps_)
+        bound.tap->write(mods_.value(bound.index));
 }
 
 void PlanExecutor::process(const PlanValues& values, const BlockInfo& requestedBlock,

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -316,6 +316,14 @@ class PlanExecutor {
         return boundMeterCount_;
     }
 
+    /// Value taps this plan's table found a home for (#2122): a parameter the
+    /// table carries, or a modifier the runtime holds. A key the bindings
+    /// offered and the table does not have is not one of these and is not an
+    /// error; it is a host asking about something this project no longer has.
+    int boundValueTapCount() const {
+        return static_cast<int>(paramTaps_.size() + modTaps_.size());
+    }
+
     /// Modulation taps that took over the detector of the executor they
     /// replaced rather than starting again. What that buys is the same thing
     /// ModRuntime's carry buys: an edit during playback does not restate a
@@ -560,6 +568,27 @@ class PlanExecutor {
     /// PlanBindings::midiTaps.
     std::vector<MidiTap*> midiTapForOp_;
 
+    /** @brief One value the block publishes for whoever is drawing it (#2122). */
+    struct BoundValueTap {
+        /// A ParamId, or an index into the modifier runtime.
+        int index = 0;
+        ValueTap* tap = nullptr;
+    };
+
+    /// Compact rather than one slot per parameter, which is the difference
+    /// between these and the per-op bindings above. A plan has hundreds of ops
+    /// and a host binds a good fraction of the meters; a table has a parameter
+    /// per parameter of every device in the project and a host draws the few
+    /// dozen it has on screen. A vector the length of the table would be
+    /// thousands of nulls walked every block to find them.
+    ///
+    /// Resolved at prepare against the table the plan was prepared with, so the
+    /// block never looks a key up, and safe to hold by index for exactly as
+    /// long as the windows are: a table whose layout differs is refused whole
+    /// (see fitsParameters).
+    std::vector<BoundValueTap> paramTaps_;
+    std::vector<BoundValueTap> modTaps_;
+
     /// This block's parameter values, and the room the resolver gathers one
     /// parameter's links in. Sized at prepare from the table the plan was
     /// published with, so the block that fills them allocates nothing.
@@ -643,6 +672,22 @@ class PlanExecutor {
     /// Read one modulation tap: hand the source's level to the followers
     /// listening to it, and its rises and falls to the triggered ones.
     void renderModSource(OpId id, const BlockInfo& block);
+
+    /**
+     * @brief Publish what this block settled, to whoever is watching (#2122).
+     *
+     * On the audio thread, at the end of the resolve and nowhere else: that is
+     * the moment both numbers exist and the last moment they are still the
+     * block's own rather than something a device has since been handed.
+     *
+     * A block that resolved no table publishes nothing at all, rather than
+     * publishing the zeros an empty table would answer with. The values a host
+     * is drawing then hold, which is what they do whenever nothing is
+     * rendering; slamming every watched knob to zero for the one block a
+     * mismatched table takes to be replaced would be a visible fault reporting
+     * an invisible one.
+     */
+    void publishValueTaps();
 
     /// Spend the notes in @p midi on the modifiers listening to @p op's track.
     void feedNoteTriggers(std::size_t op, const juce::MidiBuffer& midi);

--- a/magda/engine/exec/PlanExecutor.hpp
+++ b/magda/engine/exec/PlanExecutor.hpp
@@ -319,10 +319,30 @@ class PlanExecutor {
     /// Value taps this plan's table found a home for (#2122): a parameter the
     /// table carries, or a modifier the runtime holds. A key the bindings
     /// offered and the table does not have is not one of these and is not an
-    /// error; it is a host asking about something this project no longer has.
+    /// error; it is a host asking about a value this project does not move.
     int boundValueTapCount() const {
         return static_cast<int>(paramTaps_.size() + modTaps_.size());
     }
+
+    /**
+     * @brief Take back what this plan no longer publishes (#2122).
+     *
+     * Off the audio thread, and only after the swap that made this plan live.
+     * Every tap the bindings offered and this table found no home for is
+     * cleared, so a host reads no writes at all rather than a value frozen
+     * where the last plan left it.
+     *
+     * That is not a rare case. A lane deleted off a fader takes that fader out
+     * of the parameter table, because a mixer value is carried only while
+     * something reaches it; without this the tap would sit at the last
+     * automated position under a count that never moves again, which the header
+     * tells hosts to read as an engine that has stopped.
+     *
+     * After the swap rather than at prepare, because until the swap the epoch
+     * being replaced is still rendering: a tap cleared while it is still being
+     * written would be counting from one again by the next block.
+     */
+    void clearUnboundValueTaps();
 
     /// Modulation taps that took over the detector of the executor they
     /// replaced rather than starting again. What that buys is the same thing
@@ -588,6 +608,11 @@ class PlanExecutor {
     /// (see fitsParameters).
     std::vector<BoundValueTap> paramTaps_;
     std::vector<BoundValueTap> modTaps_;
+
+    /// The other side of those two: taps the bindings offered that this table
+    /// has nowhere to publish from. Kept so the swap can clear them, which is
+    /// the only thing anything does with them.
+    std::vector<ValueTap*> unboundTaps_;
 
     /// This block's parameter values, and the room the resolver gathers one
     /// parameter's links in. Sized at prepare from the table the plan was

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -261,18 +261,21 @@ std::size_t RuntimeStateStore::releaseDeleted(const RenderPlan& livePlan,
     }
 
     // The live table first and unconditionally, on the same reading the plan
-    // gets above: a tap the table carries is one the executor holds a pointer
-    // to and the audio thread writes through every block, whatever the caller
-    // believes the model still holds.
-    for (auto entry = valueTaps_.begin(); entry != valueTaps_.end();) {
-        if ((liveTable != nullptr && carries(*liveTable, entry->first)) ||
-            isNamed(entry->first, keep)) {
-            ++entry;
-            continue;
-        }
-        entry = valueTaps_.erase(entry);
-        ++removed;
-    }
+    // gets above. A tap the table carries may be one the executor holds a
+    // pointer to and the audio thread writes through every block, whatever the
+    // caller believes the model still holds; it is only "may be" because the
+    // executor binds the keys the host last asked for rather than every key the
+    // table has, and this is the side to be wrong on.
+    //
+    // The model rule behind it keeps a tap the host has stopped asking about
+    // until the device or track it names goes, so a session accumulates a map
+    // node and one word per parameter ever displayed. Bounded by the project's
+    // own parameter count, and what it buys is that a window closed and
+    // reopened is reading the same tap rather than one starting from zero.
+    removed += std::erase_if(valueTaps_, [&](const auto& entry) {
+        return !((liveTable != nullptr && carries(*liveTable, entry.first)) ||
+                 isNamed(entry.first, keep));
+    });
 
     return removed;
 }

--- a/magda/engine/exec/RuntimeStateStore.cpp
+++ b/magda/engine/exec/RuntimeStateStore.cpp
@@ -4,6 +4,7 @@
 
 #include "core/RackInfo.hpp"
 #include "core/TrackInfo.hpp"
+#include "param/ParamTable.hpp"
 
 namespace magda::engine {
 namespace {
@@ -64,6 +65,36 @@ bool isNamed(const OpKey& key, const RuntimeStateIds& ids) {
     if (key.deviceId != INVALID_DEVICE_ID)
         return ids.devices.contains(key.deviceKey());
     return ids.tracks.contains(key.trackId);
+}
+
+/// Whether a value tap's key still names something the model holds. A device
+/// parameter, and a macro or a modifier at device scope, live and die with the
+/// device; everything at track scope, with the track.
+///
+/// A rack scope is retained by its track, which is coarser than the rest and
+/// deliberately so: RuntimeStateIds names devices and tracks, a rack is neither,
+/// and what the coarser rule costs is two atomics per deleted rack held until
+/// the track goes. A third ID set that only this would read costs more.
+bool isNamed(const ParamKey& key, const RuntimeStateIds& ids) {
+    if (key.scope == ParamKey::Scope::Device)
+        return ids.devices.contains(key.device);
+    return ids.tracks.contains(key.trackId);
+}
+
+/// Whether @p table carries the value @p key names, which is what decides
+/// whether the audio thread can reach the tap bound to it. Parameters answer
+/// from the index the table is built around; a modifier taken as a source has
+/// no parameter index and is looked for among the modifiers, which are tens
+/// where the parameters are thousands.
+bool carries(const ParamTable& table, const ParamKey& key) {
+    if (table.find(key) != INVALID_PARAM_ID)
+        return true;
+
+    for (const auto& modifier : table.modifiers)
+        if (modifier.key == key)
+            return true;
+
+    return false;
 }
 
 /// Entries whose key nothing in `named` holds any more.
@@ -153,6 +184,22 @@ PlanBindings RuntimeStateStore::realise(const RenderPlan& plan, const RenderCont
         }
     }
 
+    // The values the host wants read back (#2122). Off the host's list rather
+    // than off the table, because the list is the few dozen a window is drawing
+    // and the table is every parameter in the project.
+    //
+    // Bound whether or not the current table carries the key: a host may ask
+    // for a parameter that has since been deleted, and what happens then is
+    // that nothing ever writes to the tap, which is what PlanBindings says an
+    // unbound value does anyway. Deciding it here would be a second answer to a
+    // question the executor already has to ask against the table it prepared.
+    for (const auto& key : factory_.valuesToTap()) {
+        auto& tap = valueTaps_[key];
+        if (tap == nullptr)
+            tap = std::make_unique<ValueTap>();
+        bindings.valueTaps[key] = tap.get();
+    }
+
     return bindings;
 }
 
@@ -168,7 +215,8 @@ LevelTap* RuntimeStateStore::realiseMeter(const OpKey& key) {
 }
 
 std::size_t RuntimeStateStore::releaseDeleted(const RenderPlan& livePlan,
-                                              const RuntimeStateIds& modelIds) {
+                                              const RuntimeStateIds& modelIds,
+                                              const ParamTable* liveTable) {
     // The plan's own IDs go in first and unconditionally. Everything it names
     // is reachable from the audio thread this instant, whatever the caller
     // believes the model still holds.
@@ -212,6 +260,20 @@ std::size_t RuntimeStateStore::releaseDeleted(const RenderPlan& livePlan,
         ++removed;
     }
 
+    // The live table first and unconditionally, on the same reading the plan
+    // gets above: a tap the table carries is one the executor holds a pointer
+    // to and the audio thread writes through every block, whatever the caller
+    // believes the model still holds.
+    for (auto entry = valueTaps_.begin(); entry != valueTaps_.end();) {
+        if ((liveTable != nullptr && carries(*liveTable, entry->first)) ||
+            isNamed(entry->first, keep)) {
+            ++entry;
+            continue;
+        }
+        entry = valueTaps_.erase(entry);
+        ++removed;
+    }
+
     return removed;
 }
 
@@ -236,9 +298,14 @@ RuntimeStateIds collectRuntimeStateIds(const std::vector<TrackInfo>& tracks,
     return ids;
 }
 
+ValueTap* RuntimeStateStore::valueTap(const ParamKey& key) const {
+    const auto found = valueTaps_.find(key);
+    return found == valueTaps_.end() ? nullptr : found->second.get();
+}
+
 std::size_t RuntimeStateStore::size() const {
     return devices_.size() + clipAudio_.size() + clipMidi_.size() + audioInputs_.size() +
-           midiInputs_.size() + meters_.size();
+           midiInputs_.size() + meters_.size() + valueTaps_.size();
 }
 
 }  // namespace magda::engine

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -9,6 +9,7 @@
 #include "exec/PlanBindings.hpp"
 #include "plan/RenderPlan.hpp"
 #include "tap/LevelTap.hpp"
+#include "tap/ValueTap.hpp"
 
 namespace magda {
 struct TrackInfo;
@@ -29,6 +30,8 @@ struct TrackInfo;
  */
 
 namespace magda::engine {
+
+struct ParamTable;
 
 /**
  * @brief Makes the runtime objects a plan asks for.
@@ -73,6 +76,35 @@ class RuntimeStateFactory {
      */
     virtual std::unique_ptr<LevelTap> createMeter(const OpKey&) {
         return nullptr;
+    }
+
+    /**
+     * @brief The values the host wants read back (#2122).
+     *
+     * Asked once per plan publish, off the audio thread. Every key returned
+     * gets a ValueTap it can read at whatever rate it draws: a parameter's key
+     * for the position that parameter resolved to, a modifier's for the output
+     * that modifier published.
+     *
+     * Shaped as one question rather than as a createValueTap() beside the
+     * others, which is the one asymmetry here and is a matter of how many there
+     * are. A plan has hundreds of ops and a host with a mixer open wants a
+     * meter on a good fraction of them, so asking op by op costs about what the
+     * answers are worth. A table has a parameter per parameter of every device
+     * in the project, which is thousands, and a host wants the few dozen it has
+     * on screen: asking one by one would be thousands of declines per edit to
+     * find them. So the host says what it wants and the store makes them.
+     *
+     * The store makes them, rather than this handing back instances, because a
+     * ValueTap is not a thing the engine needs the host's help to build. The
+     * methods above exist because the engine has no idea what a device or a
+     * file reader is; it knows exactly what a tap on a number is.
+     *
+     * Returning nothing is the ordinary answer. An offline render wants none of
+     * these, and neither does a session whose windows are all shut.
+     */
+    virtual std::vector<ParamKey> valuesToTap() {
+        return {};
     }
 };
 
@@ -147,8 +179,33 @@ class RuntimeStateStore {
      *
      * Call only after the swap, with the plan that is now live. Destructors
      * run on the calling thread.
+     *
+     * @p liveTable is the parameter table that plan is rendering with, and it
+     * is to the value taps what the plan is to everything else: the one thing
+     * that says which of them the audio thread can reach. A plan does not name
+     * a parameter, so nothing else here could answer it. Null is a session
+     * rendering without a table, where no value tap is reachable at all.
      */
-    std::size_t releaseDeleted(const RenderPlan& livePlan, const RuntimeStateIds& modelIds);
+    std::size_t releaseDeleted(const RenderPlan& livePlan, const RuntimeStateIds& modelIds,
+                               const ParamTable* liveTable = nullptr);
+
+    /**
+     * @brief The tap publishing @p key, or nullptr (#2122).
+     *
+     * The other half of valuesToTap(): the host says which values it wants read
+     * back and this is where it collects them. Off the audio thread; what it
+     * hands back is readable from any thread, which is the whole point of it.
+     *
+     * Null until a publish has been through, because that is when the taps are
+     * made: a window that opens between two of them is drawing a value nothing
+     * has offered yet, and it gets one at the next publish rather than never.
+     *
+     * Good until the next publish, like every other pointer the store hands
+     * out. A tap whose device has been deleted goes when the plan that named it
+     * stops being live, and a caller holding one across that has a pointer to
+     * nothing; asking again is how a holder finds out.
+     */
+    ValueTap* valueTap(const ParamKey& key) const;
 
     /// Objects currently owned, for tests and diagnostics.
     std::size_t size() const;
@@ -178,6 +235,13 @@ class RuntimeStateStore {
     /// is the same rule everything else here follows read through the one
     /// binding whose identity is the whole op rather than a DeviceKey or TrackId.
     std::map<OpKey, std::unique_ptr<LevelTap>> meters_;
+
+    /// The values the host has asked to read back, kept across publishes for
+    /// the reason everything else here is: an edit elsewhere in the project
+    /// must not restate a number something is watching. Retained by the model
+    /// IDs its key names, and by the live table, which is the only thing that
+    /// says whether the audio thread can reach one.
+    std::map<ParamKey, std::unique_ptr<ValueTap>> valueTaps_;
 };
 
 }  // namespace magda::engine

--- a/magda/engine/exec/RuntimeStateStore.hpp
+++ b/magda/engine/exec/RuntimeStateStore.hpp
@@ -86,6 +86,12 @@ class RuntimeStateFactory {
      * for the position that parameter resolved to, a modifier's for the output
      * that modifier published.
      *
+     * A modifier is named by its key with no parameter index, which means
+     * `index = -1` and not the default a hand-built ParamKey carries: index 0
+     * is the modifier's own Rate parameter, so a key left at its default asks
+     * about the rate rather than the output. modifierKeyFor() builds the right
+     * shape from a ControlTarget and is the way to avoid choosing.
+     *
      * Shaped as one question rather than as a createValueTap() beside the
      * others, which is the one asymmetry here and is a matter of how many there
      * are. A plan has hundreds of ops and a host with a mixer open wants a
@@ -185,9 +191,16 @@ class RuntimeStateStore {
      * that says which of them the audio thread can reach. A plan does not name
      * a parameter, so nothing else here could answer it. Null is a session
      * rendering without a table, where no value tap is reachable at all.
+     *
+     * Required rather than defaulted, for the reason the plan is passed rather
+     * than trusted to the caller's IDs. Omitting it would leave eviction to the
+     * model IDs alone, and a tap the live table carries but the ID set does not
+     * name would be destroyed while the executor still holds its pointer: the
+     * next block writes through freed memory, on the audio thread. A keep that
+     * cannot be waived must not be possible to leave out.
      */
     std::size_t releaseDeleted(const RenderPlan& livePlan, const RuntimeStateIds& modelIds,
-                               const ParamTable* liveTable = nullptr);
+                               const ParamTable* liveTable);
 
     /**
      * @brief The tap publishing @p key, or nullptr (#2122).
@@ -196,9 +209,14 @@ class RuntimeStateStore {
      * back and this is where it collects them. Off the audio thread; what it
      * hands back is readable from any thread, which is the whole point of it.
      *
-     * Null until a publish has been through, because that is when the taps are
-     * made: a window that opens between two of them is drawing a value nothing
-     * has offered yet, and it gets one at the next publish rather than never.
+     * Null until a publish has been attempted, because that is when the taps
+     * are made: a window that opens between two of them is drawing a value
+     * nothing has offered yet, and it gets one at the next publish rather than
+     * never. Attempted rather than succeeded, since the taps are realised
+     * before a plan is known to prepare; non-null therefore says the store has
+     * one, not that anything is publishing through it. What answers that is the
+     * tap's own count, where zero means nothing in the engine moves this value
+     * and the model's own is the answer (ValueTap.hpp).
      *
      * Good until the next publish, like every other pointer the store hands
      * out. A tap whose device has been deleted goes when the plan that named it

--- a/magda/engine/tap/ValueTap.hpp
+++ b/magda/engine/tap/ValueTap.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <atomic>
+#include <bit>
 #include <cstdint>
-#include <cstring>
 
 /**
  * @file ValueTap.hpp
@@ -61,6 +61,27 @@
  * wants to know whether the engine is running at all can ask the value it is
  * already reading rather than the transport.
  *
+ * ## What no writes means
+ *
+ * A count of zero is the one reading with a meaning of its own: nothing in the
+ * engine publishes this value, so the model's own is the answer and the tap is
+ * not part of it. That is not only the moment before the first block. The
+ * parameter table carries a mixer value, a macro or a modifier's rate only when
+ * something reaches it, because a project's faders and its sixteen macros per
+ * scope are overwhelmingly numbers nothing moves; a tap on one of those has no
+ * publisher and says so.
+ *
+ * Which means it has to be able to go back. A lane deleted off a fader takes
+ * that fader out of the table, and a tap left counting from before would freeze
+ * at the last automated position while claiming the engine had stopped. So a
+ * publish that binds nothing to a tap clears it (see @ref clear), and the host
+ * reads what is true: the engine has no opinion, ask the model.
+ *
+ * The count therefore never wraps to zero on its own. Thirty-three days of
+ * continuous rendering at 96 kHz and 64 samples a block is not a number to
+ * dismiss for an installation, and reaching it must not turn a live parameter
+ * into one nothing publishes.
+ *
  * ## Why the two of them are one word
  *
  * The count is what a reader gates a repaint on, so a reading that pairs one
@@ -89,16 +110,16 @@ class ValueTap {
   public:
     /** @brief The value, and how many blocks have published one. */
     struct Reading {
-        /// Normalised, 0 to 1. Zero before any block has published, which is a
-        /// tap that has been bound and not yet written rather than a parameter
-        /// whose value is zero; @ref writes is what tells those apart.
+        /// Normalised, 0 to 1. Zero where nothing has published, which is not a
+        /// parameter whose value is zero; @ref writes is what tells those
+        /// apart.
         float value = 0.0f;
 
-        /// Blocks published since the tap was made. Wraps, and is meant to be
-        /// compared with the last one seen rather than read as a total: a
-        /// reader asking whether this differs from what it drew last frame gets
-        /// the right answer across the wrap, and one asking how many blocks
-        /// have gone by does not.
+        /// Blocks published. Zero means nothing in the engine publishes this
+        /// value and the model's own is the answer; anything else is meant to
+        /// be compared with the last count seen rather than read as a total.
+        /// It wraps past its own maximum without passing through zero, so the
+        /// comparison stays right and the zero keeps its one meaning.
         std::uint32_t writes = 0;
     };
 
@@ -137,25 +158,52 @@ class ValueTap {
      */
     void write(float value) {
         const auto writes = unpack(state_.load(std::memory_order_relaxed)).writes;
-        state_.store(pack(value, writes + 1), std::memory_order_release);
+        state_.store(pack(value, nextWriteCount(writes)), std::memory_order_release);
+    }
+
+    /**
+     * @brief Back to nothing published. Off the audio thread.
+     *
+     * For a tap the engine has stopped having an opinion about: a publish that
+     * bound it to nothing, because what it names is no longer a value the
+     * parameter table carries. The alternative is a tap frozen at its last
+     * value under a count that has stopped moving, which a host reads as an
+     * engine that has stopped rather than as a value it now owns outright.
+     *
+     * Only ever after the swap that made such a plan live. A tap cleared while
+     * the epoch it replaces is still rendering would be written again by that
+     * epoch's next block and left counting from one.
+     */
+    void clear() {
+        state_.store(0, std::memory_order_release);
+    }
+
+    /**
+     * @brief The count after @p writes.
+     *
+     * Public because it is a rule of the contract above rather than an
+     * implementation detail: the count skips zero on the way round, so the one
+     * reading that means "nothing publishes this" cannot be reached by a rig
+     * that has simply been up for a long time. Thirty-three days of continuous
+     * rendering at 96 kHz and 64 samples a block is not a number to dismiss for
+     * an installation, and it is not a number a test can reach either, which is
+     * the other half of why this is nameable.
+     */
+    static constexpr std::uint32_t nextWriteCount(std::uint32_t writes) {
+        return writes + 1 == 0 ? 1 : writes + 1;
     }
 
   private:
     /// The count in the high half, the float's bits in the low one. A zeroed
     /// word is therefore no writes and a value of zero, which is what a tap
-    /// nothing has published reads as.
-    static std::uint64_t pack(float value, std::uint32_t writes) {
-        std::uint32_t bits = 0;
-        std::memcpy(&bits, &value, sizeof(bits));
-        return (static_cast<std::uint64_t>(writes) << 32U) | bits;
+    /// nothing publishes reads as.
+    static constexpr std::uint64_t pack(float value, std::uint32_t writes) {
+        return (static_cast<std::uint64_t>(writes) << 32U) | std::bit_cast<std::uint32_t>(value);
     }
 
-    static Reading unpack(std::uint64_t state) {
-        Reading reading;
-        const auto bits = static_cast<std::uint32_t>(state & 0xFFFFFFFFULL);
-        std::memcpy(&reading.value, &bits, sizeof(bits));
-        reading.writes = static_cast<std::uint32_t>(state >> 32U);
-        return reading;
+    static constexpr Reading unpack(std::uint64_t state) {
+        return Reading{std::bit_cast<float>(static_cast<std::uint32_t>(state & 0xFFFFFFFFULL)),
+                       static_cast<std::uint32_t>(state >> 32U)};
     }
 
     std::atomic<std::uint64_t> state_{0};

--- a/magda/engine/tap/ValueTap.hpp
+++ b/magda/engine/tap/ValueTap.hpp
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <cstring>
 
 /**
  * @file ValueTap.hpp
@@ -60,12 +61,31 @@
  * wants to know whether the engine is running at all can ask the value it is
  * already reading rather than the transport.
  *
+ * ## Why the two of them are one word
+ *
+ * The count is what a reader gates a repaint on, so a reading that pairs one
+ * block's count with another block's value is not a stale frame but a value
+ * that never arrives. Read the value first and a reader can see the old value
+ * beside the new count: it redraws with the old one, and at the next poll the
+ * count has not moved again, so it decides nothing changed and the value it
+ * never drew stays undrawn until something else writes. Read the count first
+ * and the mirror image happens, with the fresher value thrown away for a count
+ * that had not caught up. Neither order is a repaint's worth of wrong.
+ *
+ * So they are not two atomics. A float and a 32-bit count fit in one 64-bit
+ * word, which every platform this builds for stores and loads in one
+ * instruction, and a reading is then always one block's own: one store on the
+ * audio thread, one load off it, no sequence lock and nothing to retry.
+ *
  * One writer, the audio thread. Any number of readers.
  */
 
 namespace magda::engine {
 
 class ValueTap {
+    static_assert(std::atomic<std::uint64_t>::is_always_lock_free,
+                  "a value tap is written on the audio thread and must not take a lock");
+
   public:
     /** @brief The value, and how many blocks have published one. */
     struct Reading {
@@ -88,22 +108,17 @@ class ValueTap {
      * Off the audio thread, from as many readers as like, as often as they
      * like. Nothing is consumed and nothing is reset.
      *
-     * The two fields are loaded one after the other rather than together, and
-     * the order is deliberate: the value first, so a count that arrives from a
-     * later block than the value came from reads as a change that has already
-     * been drawn. That costs a repaint of a value that had not moved yet, once,
-     * and the other order would cost a change that never showed at all.
+     * One load, so the pair is one block's own: the count belongs to the block
+     * that wrote the value beside it, and a reader gating a repaint on the
+     * count is gating on the value it is about to draw.
      */
     Reading read() const {
-        Reading reading;
-        reading.value = value_.load(std::memory_order_acquire);
-        reading.writes = writes_.load(std::memory_order_acquire);
-        return reading;
+        return unpack(state_.load(std::memory_order_acquire));
     }
 
     /// Just the value, for a reader that only draws it.
     float value() const {
-        return value_.load(std::memory_order_acquire);
+        return read().value;
     }
 
     /**
@@ -114,15 +129,36 @@ class ValueTap {
      * Unconditional rather than only on a change, because the count is of
      * blocks published and a tap that fell silent on a value that stopped
      * moving would be indistinguishable from one whose engine had stopped.
+     *
+     * The count comes off the word this is about to replace rather than out of
+     * a counter of its own, which is what makes the pair inseparable. Loading
+     * it needs no ordering and no compare-and-swap: there is one writer, and it
+     * is the only thing that ever changes this.
      */
     void write(float value) {
-        value_.store(value, std::memory_order_release);
-        writes_.fetch_add(1, std::memory_order_release);
+        const auto writes = unpack(state_.load(std::memory_order_relaxed)).writes;
+        state_.store(pack(value, writes + 1), std::memory_order_release);
     }
 
   private:
-    std::atomic<float> value_{0.0f};
-    std::atomic<std::uint32_t> writes_{0};
+    /// The count in the high half, the float's bits in the low one. A zeroed
+    /// word is therefore no writes and a value of zero, which is what a tap
+    /// nothing has published reads as.
+    static std::uint64_t pack(float value, std::uint32_t writes) {
+        std::uint32_t bits = 0;
+        std::memcpy(&bits, &value, sizeof(bits));
+        return (static_cast<std::uint64_t>(writes) << 32U) | bits;
+    }
+
+    static Reading unpack(std::uint64_t state) {
+        Reading reading;
+        const auto bits = static_cast<std::uint32_t>(state & 0xFFFFFFFFULL);
+        std::memcpy(&reading.value, &bits, sizeof(bits));
+        reading.writes = static_cast<std::uint32_t>(state >> 32U);
+        return reading;
+    }
+
+    std::atomic<std::uint64_t> state_{0};
 };
 
 }  // namespace magda::engine

--- a/magda/engine/tap/ValueTap.hpp
+++ b/magda/engine/tap/ValueTap.hpp
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+/**
+ * @file ValueTap.hpp
+ * @brief What a block settled a value at, for whoever draws it.
+ *
+ * The third tap, and the one that reads back rather than measures (#2122). A
+ * LevelTap answers how loud a point in the signal was and a MidiTap answers
+ * what reached one; this answers what a number is. Two numbers, in fact, and
+ * they are the same shape, so they are the same tap:
+ *
+ *  - what a modifier published this block, which is what a modifier editor
+ *    animates, and
+ *  - what a parameter resolved to once its base, its lane and its links had
+ *    been settled against each other, which is what a device UI draws when
+ *    something is modulating a knob, and what touch and latch would read at the
+ *    moment a gesture starts.
+ *
+ * A normalised position, 0 to 1, in both cases. The parameter's own units are a
+ * function of that position and its scale, and the scale belongs to the model,
+ * which already has it; a tap that converted would be a second place the
+ * conversion could be wrong.
+ *
+ * Bound by ParamKey, because that is the address of both: a modifier taken as a
+ * source is a key with no parameter index and a parameter is a key with one,
+ * and neither needs anything the other does not have (ParamKey.hpp).
+ *
+ * Owned by the host, for the reason a LevelTap is: it outlives the plans that
+ * reference it, so an edit somewhere else in the project does not restate a
+ * value something was reading.
+ *
+ * ## Why it is not a meter
+ *
+ * A read here is not destructive, and that is the whole of the difference. A
+ * meter reports the loudest thing since it was last looked at because a
+ * transient falling between two frames is a transient it must not miss. A
+ * position has nothing of the kind to miss: what a knob draws is where the value
+ * is, and where it was halfway between two frames is not a fact anybody is owed.
+ * So the value stands until a block replaces it, any number of readers get the
+ * same answer rather than taking it from each other, and a reader arriving late
+ * reads the current position rather than a zero.
+ *
+ * ## Nothing simulates it
+ *
+ * A tap holds while the engine is not rendering, and holding is the right
+ * answer: an LFO nothing is advancing is not turning, and an editor that
+ * animated one anyway would be drawing a second LFO that agrees with the audible
+ * one by accident and diverges from it under every retrigger. That second LFO is
+ * what the incumbent engine needs, because there the value is polled off the
+ * engine at frame rate and a poll between two audio callbacks has nothing to
+ * report. Here the value is published by the block that produced it, so the
+ * simulation has nothing left to do and does not survive the port.
+ *
+ * @ref Reading::writes is what distinguishes a value that is holding from a
+ * value that is not moving. It counts blocks published rather than changes, so
+ * an editor with nothing to redraw has something to stop on, and a UI that
+ * wants to know whether the engine is running at all can ask the value it is
+ * already reading rather than the transport.
+ *
+ * One writer, the audio thread. Any number of readers.
+ */
+
+namespace magda::engine {
+
+class ValueTap {
+  public:
+    /** @brief The value, and how many blocks have published one. */
+    struct Reading {
+        /// Normalised, 0 to 1. Zero before any block has published, which is a
+        /// tap that has been bound and not yet written rather than a parameter
+        /// whose value is zero; @ref writes is what tells those apart.
+        float value = 0.0f;
+
+        /// Blocks published since the tap was made. Wraps, and is meant to be
+        /// compared with the last one seen rather than read as a total: a
+        /// reader asking whether this differs from what it drew last frame gets
+        /// the right answer across the wrap, and one asking how many blocks
+        /// have gone by does not.
+        std::uint32_t writes = 0;
+    };
+
+    /**
+     * @brief What the last block to publish settled the value at.
+     *
+     * Off the audio thread, from as many readers as like, as often as they
+     * like. Nothing is consumed and nothing is reset.
+     *
+     * The two fields are loaded one after the other rather than together, and
+     * the order is deliberate: the value first, so a count that arrives from a
+     * later block than the value came from reads as a change that has already
+     * been drawn. That costs a repaint of a value that had not moved yet, once,
+     * and the other order would cost a change that never showed at all.
+     */
+    Reading read() const {
+        Reading reading;
+        reading.value = value_.load(std::memory_order_acquire);
+        reading.writes = writes_.load(std::memory_order_acquire);
+        return reading;
+    }
+
+    /// Just the value, for a reader that only draws it.
+    float value() const {
+        return value_.load(std::memory_order_acquire);
+    }
+
+    /**
+     * @brief Publish what this block settled the value at. Audio thread.
+     *
+     * Once per block per tap, from where the value was settled: a modifier's
+     * output as it was advanced, a parameter's position as it was resolved.
+     * Unconditional rather than only on a change, because the count is of
+     * blocks published and a tap that fell silent on a value that stopped
+     * moving would be indistinguishable from one whose engine had stopped.
+     */
+    void write(float value) {
+        value_.store(value, std::memory_order_release);
+        writes_.fetch_add(1, std::memory_order_release);
+    }
+
+  private:
+    std::atomic<float> value_{0.0f};
+    std::atomic<std::uint32_t> writes_{0};
+};
+
+}  // namespace magda::engine

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -323,6 +323,9 @@ if(MAGDA_BUILD_NATIVE_ENGINE)
     # Macros at track, rack and device scope (#2121): which array a path
     # names, nested racks, and a macro reaching a modifier's rate.
     list(APPEND TEST_SOURCES test_param_macros.cpp)
+    # What the UI reads back (#2122): the modifier's output and the parameter's
+    # resolved value, published by the block that produced them.
+    list(APPEND TEST_SOURCES test_value_taps.cpp)
     list(APPEND TEST_SOURCES test_tempo_map.cpp)
     list(APPEND TEST_SOURCES test_transport_clock.cpp)
     list(APPEND TEST_SOURCES test_click_generator.cpp)

--- a/tests/EngineSessionScaffold.hpp
+++ b/tests/EngineSessionScaffold.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <memory>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "core/AutomationInfo.hpp"
+#include "core/TrackInfo.hpp"
+#include "exec/EngineSession.hpp"
+#include "exec/PlanValues.hpp"
+#include "exec/RuntimeStateStore.hpp"
+#include "plan/PlanCompiler.hpp"
+
+namespace magda::test {
+
+/**
+ * @file EngineSessionScaffold.hpp
+ * @brief What every test that drives a live EngineSession needs first.
+ *
+ * Compiling a plan, resolving its values, collecting the model's IDs and
+ * publishing the four of them together is a protocol rather than a call, and a
+ * test that is about a modifier or a tap has no business restating it. Every
+ * copy of it is a place that has to be edited in lockstep when the protocol
+ * changes, and there were two before this existed.
+ *
+ * Deliberately not a fixture class. What each test wants around the session
+ * differs (its own devices, its own factory, its own idea of an edit), and a
+ * base class would have to guess at all of it; what they share is the tracks
+ * they start from, the MIDI they script, and the publish itself.
+ */
+
+/// A plain track feeding the master, with no macros and no modifiers.
+inline TrackInfo makeTrack(TrackId id) {
+    TrackInfo track;
+    track.id = id;
+    track.name = "Track " + juce::String(id);
+    track.audioOutputDevice = "master";
+    track.mods = createDefaultMods(0);
+    return track;
+}
+
+/// The master at unity, so what leaves it is what reached it.
+inline TrackInfo makeMaster() {
+    auto master = makeTrack(MASTER_TRACK_ID);
+    master.type = TrackType::Master;
+    master.audioOutputDevice = {};
+    master.volume = 1.0f;
+    return master;
+}
+
+/**
+ * @brief What a test queues for the next block, and what it saw of the blocks
+ *        that consumed it.
+ *
+ * Owned by the test rather than by the session, because the point of scripting
+ * MIDI at all is to put a note in one named block.
+ */
+struct ScriptedMidi {
+    juce::MidiBuffer pending;
+    int blocks = 0;
+};
+
+/// The session's end of it: hands over whatever is queued and clears the queue,
+/// so a note is played once.
+class ScriptedMidiSource final : public magda::engine::EngineMidiSource {
+  public:
+    explicit ScriptedMidiSource(ScriptedMidi* script) : script_(script) {}
+
+    void render(const magda::engine::BlockInfo&, juce::MidiBuffer& out) override {
+        if (script_ == nullptr)
+            return;
+
+        out.addEvents(script_->pending, 0, -1, 0);
+        script_->pending.clear();
+        ++script_->blocks;
+    }
+
+  private:
+    ScriptedMidi* script_ = nullptr;
+};
+
+/** @brief The plan a publish compiled, and whether the session took it. */
+struct PublishedPlan {
+    std::shared_ptr<const magda::engine::RenderPlan> plan;
+    bool published = false;
+};
+
+/**
+ * @brief Compile @p tracks and @p master and publish them to @p session.
+ *
+ * The whole protocol in one call: the plan, the values resolved against it, the
+ * IDs of what the model holds, and the context they are all rendered under. A
+ * second call with a different track list is what an edit looks like from the
+ * outside.
+ *
+ * @p lanes is the automation the project has, and empty is a project with none.
+ * It belongs here rather than beside it because a lane is what puts a mixer
+ * value in the parameter table at all, so a test about one publishes it with
+ * the tracks or does not have it.
+ */
+inline PublishedPlan publishProject(magda::engine::EngineSession& session,
+                                    const std::vector<TrackInfo>& tracks, const TrackInfo& master,
+                                    const magda::engine::RenderContext& context,
+                                    std::span<const AutomationLaneInfo> lanes = {}) {
+    PublishedPlan result;
+    result.plan = std::make_shared<const magda::engine::RenderPlan>(
+        magda::engine::compileRenderPlan(tracks, master));
+
+    magda::engine::PlanValues values;
+    magda::engine::resolvePlanValues(*result.plan, tracks, master, values, lanes);
+
+    const auto ids = magda::engine::collectRuntimeStateIds(tracks, master);
+    result.published = session.publish(result.plan, context, ids, std::move(values)).published;
+    return result;
+}
+
+}  // namespace magda::test

--- a/tests/PlanEditHarness.cpp
+++ b/tests/PlanEditHarness.cpp
@@ -267,7 +267,7 @@ Published Harness::publish(const Project& project) {
     live_ = std::move(executor);
 
     const auto modelIds = engine::collectRuntimeStateIds(project.tracks, project.master);
-    store_.releaseDeleted(*plan, modelIds);
+    store_.releaseDeleted(*plan, modelIds, nullptr);
 
     published.modelDevices = modelIds.devices;
     published.owned = ledger_.alive;

--- a/tests/test_mod_feeds.cpp
+++ b/tests/test_mod_feeds.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include "EngineSessionScaffold.hpp"
 #include "core/TrackInfo.hpp"
 #include "core/TrackManager.hpp"
 #include "exec/EngineSession.hpp"
@@ -58,22 +59,10 @@ constexpr double kSampleRate = 48000.0;
 /// blocks and a difference of one block is unmistakable.
 constexpr int kBlock = 512;
 
-TrackInfo makeTrack(TrackId id) {
-    TrackInfo track;
-    track.id = id;
-    track.name = "Track " + juce::String(id);
-    track.audioOutputDevice = "master";
-    track.mods = createDefaultMods(0);
-    return track;
-}
-
-TrackInfo makeMaster() {
-    auto master = makeTrack(MASTER_TRACK_ID);
-    master.type = TrackType::Master;
-    master.audioOutputDevice = {};
-    master.volume = 1.0f;
-    return master;
-}
+using magda::test::makeMaster;
+using magda::test::makeTrack;
+using magda::test::ScriptedMidi;
+using magda::test::ScriptedMidiSource;
 
 /// A device whose output is its only parameter, so what leaves the master is
 /// what the modulation did to it.
@@ -82,33 +71,6 @@ class LevelDevice final : public magda::engine::EngineDevice {
     void process(magda::engine::DeviceBlock& block) override {
         block.audio.fill(block.params.size() > 0 ? block.params[0].value() : 0.0f);
     }
-};
-
-/// What the test queues for the next block, and what it saw of the blocks that
-/// consumed it. Owned by the test rather than by the session, because the point
-/// of the case is to put a note in one specific block.
-struct ScriptedMidi {
-    juce::MidiBuffer pending;
-    int blocks = 0;
-};
-
-/// The session's end of it: a source that hands over whatever is queued and
-/// clears the queue, so a note is played once.
-class ScriptedMidiSource final : public magda::engine::EngineMidiSource {
-  public:
-    explicit ScriptedMidiSource(ScriptedMidi* script) : script_(script) {}
-
-    void render(const BlockInfo&, juce::MidiBuffer& out) override {
-        if (script_ == nullptr)
-            return;
-
-        out.addEvents(script_->pending, 0, -1, 0);
-        script_->pending.clear();
-        ++script_->blocks;
-    }
-
-  private:
-    ScriptedMidi* script_ = nullptr;
 };
 
 class Factory final : public magda::engine::RuntimeStateFactory {
@@ -173,14 +135,10 @@ struct Session {
     Session(std::vector<TrackInfo> trackList, ScriptedMidi* midi)
         : tracks(std::move(trackList)), factory(midi), session(factory) {
         master = makeMaster();
-        plan = std::make_shared<const magda::engine::RenderPlan>(compileRenderPlan(tracks, master));
-
-        magda::engine::PlanValues values;
-        magda::engine::resolvePlanValues(*plan, tracks, master, values);
-
-        const auto ids = magda::engine::collectRuntimeStateIds(tracks, master);
         const magda::engine::RenderContext context{kSampleRate, kBlock, 2};
-        published = session.publish(plan, context, ids, std::move(values)).published;
+        auto result = magda::test::publishProject(session, tracks, master, context);
+        plan = std::move(result.plan);
+        published = result.published;
     }
 
     /// One block, and the first sample the master produced.

--- a/tests/test_value_taps.cpp
+++ b/tests/test_value_taps.cpp
@@ -183,6 +183,19 @@ struct Session {
         return result.published;
     }
 
+    /// The same plan again, with values that carry no parameter table. What a
+    /// caller resolving its own values without one publishes, and what every
+    /// render did before there was a table at all.
+    bool publishWithoutTable() {
+        magda::engine::PlanValues values;
+        magda::engine::resolvePlanValues(*plan, tracks, master, values);
+        values.params.reset();
+
+        const magda::engine::RenderContext context{kSampleRate, kBlock, 2};
+        const auto ids = magda::engine::collectRuntimeStateIds(tracks, master);
+        return session.publish(plan, context, ids, std::move(values)).published;
+    }
+
     void render() {
         juce::AudioBuffer<float> output(2, kBlock);
         session.process(kBlock, output);
@@ -422,6 +435,34 @@ TEST_CASE("A block with no table it fits leaves the taps holding", "[engine][tap
 }
 
 // --- what the store does with them
+
+TEST_CASE("A plan published with no table at all publishes no values either",
+          "[engine][tap][value]") {
+    const auto track = trackWithEnvelope(/*storedValue=*/0.25f, /*amount=*/0.5f);
+    const auto param = deviceParam(0);
+
+    ScriptedMidi midi;
+    Session session({track}, {param}, &midi);
+    REQUIRE(session.published);
+
+    midi.pending.addEvent(juce::MidiMessage::noteOn(1, 60, 1.0f), 0);
+    session.render();
+    REQUIRE(session.writes(param) > 0);
+    REQUIRE(session.read(param) == approx(0.75f));
+
+    // The same plan, published with values that carry no table. Nothing
+    // resolves, so nothing publishes, and every tap the bindings offered is one
+    // this plan has nowhere to write from: the same case as a key the table
+    // dropped, seen from further away. Left out of the clear, they would hold
+    // the last automated value under a stalled count for as long as the session
+    // ran.
+    REQUIRE(session.publishWithoutTable());
+    session.render();
+
+    CHECK(session.boundValueTaps() == 0);
+    CHECK(session.writes(param) == 0);
+    CHECK(session.read(param) == approx(0.0f));
+}
 
 TEST_CASE("A value tap outlives the plans that reference it", "[engine][tap][value]") {
     auto track = trackWithEnvelope(/*storedValue=*/0.25f, /*amount=*/0.5f);

--- a/tests/test_value_taps.cpp
+++ b/tests/test_value_taps.cpp
@@ -1,13 +1,14 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
+#include <span>
 #include <vector>
 
+#include "EngineSessionScaffold.hpp"
 #include "core/TrackInfo.hpp"
 #include "exec/EngineSession.hpp"
 #include "exec/PlanValues.hpp"
 #include "exec/RuntimeStateStore.hpp"
-#include "param/ParamTableCompiler.hpp"
 #include "plan/PlanCompiler.hpp"
 #include "tap/ValueTap.hpp"
 
@@ -31,9 +32,12 @@
  */
 
 using namespace magda;
-using magda::engine::compileRenderPlan;
 using magda::engine::ParamKey;
 using magda::engine::ValueTap;
+using magda::test::makeMaster;
+using magda::test::makeTrack;
+using magda::test::ScriptedMidi;
+using magda::test::ScriptedMidiSource;
 
 namespace {
 
@@ -46,23 +50,6 @@ constexpr int kBlock = 512;
 
 constexpr TrackId kTrack = 1;
 constexpr DeviceId kDevice = 7;
-
-TrackInfo makeTrack(TrackId id) {
-    TrackInfo track;
-    track.id = id;
-    track.name = "Track " + juce::String(id);
-    track.audioOutputDevice = "master";
-    track.mods = createDefaultMods(0);
-    return track;
-}
-
-TrackInfo makeMaster() {
-    auto master = makeTrack(MASTER_TRACK_ID);
-    master.type = TrackType::Master;
-    master.audioOutputDevice = {};
-    master.volume = 1.0f;
-    return master;
-}
 
 /// A device with one parameter reading 0 to 1, so a normalised position and the
 /// value the device is handed are the same number and a case says one thing.
@@ -149,27 +136,6 @@ class NullDevice final : public magda::engine::EngineDevice {
     void process(magda::engine::DeviceBlock&) override {}
 };
 
-/// What a case queues for the next block. Owned by the case rather than by the
-/// session, because the point of one is to put a note in a named block.
-struct ScriptedMidi {
-    juce::MidiBuffer pending;
-};
-
-class ScriptedMidiSource final : public magda::engine::EngineMidiSource {
-  public:
-    explicit ScriptedMidiSource(ScriptedMidi* script) : script_(script) {}
-
-    void render(const magda::engine::BlockInfo&, juce::MidiBuffer& out) override {
-        if (script_ == nullptr)
-            return;
-        out.addEvents(script_->pending, 0, -1, 0);
-        script_->pending.clear();
-    }
-
-  private:
-    ScriptedMidi* script_ = nullptr;
-};
-
 /// A host that wants a fixed set of values read back, which is what having a
 /// window open amounts to.
 class Factory final : public magda::engine::RuntimeStateFactory {
@@ -204,22 +170,29 @@ struct Session {
 
     /// Publish @p trackList as the project, which is what an edit amounts to.
     bool publish(const std::vector<TrackInfo>& trackList) {
-        auto compiled =
-            std::make_shared<const magda::engine::RenderPlan>(compileRenderPlan(trackList, master));
+        return publishWithLanes(trackList, {});
+    }
 
-        magda::engine::PlanValues values;
-        magda::engine::resolvePlanValues(*compiled, trackList, master, values);
-
-        const auto ids = magda::engine::collectRuntimeStateIds(trackList, master);
+    /// The same, with the automation the project has. A lane is the only way a
+    /// mixer value reaches the parameter table at all.
+    bool publishWithLanes(const std::vector<TrackInfo>& trackList,
+                          std::span<const AutomationLaneInfo> lanes) {
         const magda::engine::RenderContext context{kSampleRate, kBlock, 2};
-        const auto result = session.publish(compiled, context, ids, std::move(values));
-        plan = std::move(compiled);
+        auto result = magda::test::publishProject(session, trackList, master, context, lanes);
+        plan = std::move(result.plan);
         return result.published;
     }
 
     void render() {
         juce::AudioBuffer<float> output(2, kBlock);
         session.process(kBlock, output);
+    }
+
+    /// Values the live plan found somewhere to publish from, which is not the
+    /// number of taps: a key the table does not carry has one and is never
+    /// written.
+    int boundValueTaps() const {
+        return session.boundValueTapCount();
     }
 
     /// What a window would do: ask for the tap by the key it asked to have
@@ -308,6 +281,20 @@ TEST_CASE("A value tap's count belongs to the value beside it", "[engine][tap][v
     }
 }
 
+TEST_CASE("A value tap's count wraps past its maximum without passing through zero",
+          "[engine][tap][value]") {
+    // Zero is the reading that says nothing in the engine publishes this value
+    // and the model's own is the answer, so a count that reached it by counting
+    // would hand a host a live parameter wearing that sign. Thirty-three days
+    // at 96 kHz and 64 samples a block gets there, which is a rig left running
+    // rather than a hypothetical, and is not a number a test can render its way
+    // to: the rule is asserted where it is decided.
+    STATIC_REQUIRE(ValueTap::nextWriteCount(0) == 1);
+    STATIC_REQUIRE(ValueTap::nextWriteCount(41) == 42);
+    STATIC_REQUIRE(ValueTap::nextWriteCount(0xFFFFFFFEU) == 0xFFFFFFFFU);
+    STATIC_REQUIRE(ValueTap::nextWriteCount(0xFFFFFFFFU) == 1);
+}
+
 TEST_CASE("A value tap that has published nothing reads as nothing", "[engine][tap][value]") {
     const ValueTap tap;
 
@@ -348,6 +335,10 @@ TEST_CASE("A parameter tap publishes what the block resolved, not what is stored
     ScriptedMidi midi;
     Session session({track}, {param, mod}, &midi);
     REQUIRE(session.published);
+
+    // Both found a home: the parameter in the table, the modifier in the
+    // runtime beside it.
+    CHECK(session.boundValueTaps() == 2);
 
     session.render();
     CHECK(session.read(param) == approx(0.25f));
@@ -399,6 +390,7 @@ TEST_CASE("A value the table does not carry is bound to nothing rather than refu
     auto* tap = session.tapFor(missing);
     REQUIRE(tap != nullptr);
     CHECK(tap->read().writes == 0);
+    CHECK(session.boundValueTaps() == 0);
 }
 
 TEST_CASE("A block with no table it fits leaves the taps holding", "[engine][tap][value]") {
@@ -458,6 +450,50 @@ TEST_CASE("A value tap outlives the plans that reference it", "[engine][tap][val
     CHECK(session.tapFor(param) == before);
     CHECK(before->read().value == approx(reading.value));
     CHECK(before->read().writes == reading.writes);
+
+    // And still being written, which keeping the object does not prove: a
+    // republish that left the map alone and stopped re-binding would freeze
+    // every open window from the first edit onwards and pass everything above.
+    session.render();
+    CHECK(before->read().writes > reading.writes);
+    CHECK(before->read().value == approx(0.75f));
+}
+
+TEST_CASE("A value the engine stops publishing goes back to publishing nothing",
+          "[engine][tap][value]") {
+    // The lane is what puts a fader in the parameter table at all: a mixer
+    // value is carried only while something reaches it. So this is a fader that
+    // is automated, watched, and then has its automation taken away.
+    auto track = trackWithEnvelope(/*storedValue=*/0.25f, /*amount=*/0.5f);
+    const auto fader = trackVolume(kTrack);
+
+    AutomationLaneInfo lane;
+    lane.id = 1;
+    lane.target = ControlTarget::trackVolume(kTrack);
+    lane.type = AutomationLaneType::Absolute;
+    lane.authorityState = AutomationAuthorityState::Reading;
+    lane.absolutePoints = {AutomationPoint{1, 0.0, 0.4}, AutomationPoint{2, 4.0, 0.4}};
+
+    const std::vector<AutomationLaneInfo> lanes{lane};
+
+    ScriptedMidi midi;
+    Session session({track}, {fader}, &midi);
+    REQUIRE(session.published);
+    REQUIRE(session.publishWithLanes(session.tracks, lanes));
+
+    session.render();
+    const auto automated = session.writes(fader);
+    REQUIRE(automated > 0);
+
+    // The lane goes. The fader leaves the table with it, so nothing publishes
+    // the value any more and the tap has to say so: left counting from before,
+    // it would hold the last automated position under a stalled count, which
+    // this header tells a host to read as an engine that has stopped.
+    REQUIRE(session.publish(session.tracks));
+    session.render();
+
+    CHECK(session.writes(fader) == 0);
+    CHECK(session.read(fader) == approx(0.0f));
 }
 
 TEST_CASE("A value tap goes when what it names does", "[engine][tap][value]") {

--- a/tests/test_value_taps.cpp
+++ b/tests/test_value_taps.cpp
@@ -1,0 +1,463 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <vector>
+
+#include "core/TrackInfo.hpp"
+#include "exec/EngineSession.hpp"
+#include "exec/PlanValues.hpp"
+#include "exec/RuntimeStateStore.hpp"
+#include "param/ParamTableCompiler.hpp"
+#include "plan/PlanCompiler.hpp"
+#include "tap/ValueTap.hpp"
+
+/**
+ * @file test_value_taps.cpp
+ * @brief What the UI reads back (#2122).
+ *
+ * The engine publishes two numbers a window wants and cannot work out for
+ * itself: what a modifier's output did this block, and what a parameter
+ * resolved to once its base, its lane and its links had been settled against
+ * each other. Both come out of the same tap, bound by the same key, published
+ * at the one moment both exist.
+ *
+ * What is asserted here is the whole of that path, and one thing that is not on
+ * it: nothing simulates a modifier. The incumbent engine keeps a MAGDA-side
+ * copy of the random modulator turning so its editor animates between audio
+ * callbacks, because there the value is polled at frame rate and a poll between
+ * two callbacks has nothing to report. Here the block publishes what it
+ * produced, so a tap that is not moving is an engine that is not rendering, and
+ * that is the honest answer rather than a gap to paper over.
+ */
+
+using namespace magda;
+using magda::engine::compileRenderPlan;
+using magda::engine::ParamKey;
+using magda::engine::ValueTap;
+
+namespace {
+
+Catch::Approx approx(float value) {
+    return Catch::Approx(value).margin(1e-4);
+}
+
+constexpr double kSampleRate = 48000.0;
+constexpr int kBlock = 512;
+
+constexpr TrackId kTrack = 1;
+constexpr DeviceId kDevice = 7;
+
+TrackInfo makeTrack(TrackId id) {
+    TrackInfo track;
+    track.id = id;
+    track.name = "Track " + juce::String(id);
+    track.audioOutputDevice = "master";
+    track.mods = createDefaultMods(0);
+    return track;
+}
+
+TrackInfo makeMaster() {
+    auto master = makeTrack(MASTER_TRACK_ID);
+    master.type = TrackType::Master;
+    master.audioOutputDevice = {};
+    master.volume = 1.0f;
+    return master;
+}
+
+/// A device with one parameter reading 0 to 1, so a normalised position and the
+/// value the device is handed are the same number and a case says one thing.
+DeviceInfo makeDevice(DeviceId id, float storedValue) {
+    DeviceInfo device;
+    device.id = id;
+    device.name = "Effect " + juce::String(id);
+    device.deviceType = DeviceType::Effect;
+    device.mods = createDefaultMods(0);
+
+    ParameterInfo info(0, "Level", "", 0.0f, 1.0f, 0.0f);
+    info.currentValue = storedValue;
+    device.parameters.push_back(info);
+
+    return device;
+}
+
+/// A track whose one modifier is an envelope waiting for a note, linked to the
+/// device's one parameter at @p amount.
+///
+/// An envelope rather than an LFO because what is being read back is a value
+/// rather than a shape: it is shut until a note arrives and fully open
+/// immediately after, so a tap either saw the block or did not.
+TrackInfo trackWithEnvelope(float storedValue, float amount) {
+    auto track = makeTrack(kTrack);
+    track.volume = 1.0f;
+    track.pan = 0.0f;
+    track.recordArmed = true;
+    track.inputMonitor = InputMonitorMode::In;
+    track.midiInputDevice = "test";
+    track.chain.fxChainElements.push_back(makeDeviceElement(makeDevice(kDevice, storedValue)));
+
+    track.mods = createDefaultMods(1);
+    track.mods[0].type = ModType::Envelope;
+    track.mods[0].triggerMode = LFOTriggerMode::MIDI;
+    track.mods[0].running = false;
+    track.mods[0].envAttackMs = 0.0f;
+    track.mods[0].envDecayMs = 0.0f;
+    track.mods[0].envSustain = 1.0f;
+    track.mods[0].envReleaseMs = 0.0f;
+    track.mods[0].links.push_back(
+        ModLink{ControlTarget::pluginParam(ChainNodePath::topLevelDevice(kTrack, kDevice), 0),
+                amount, /*bipolar=*/false, /*enabled=*/true});
+
+    return track;
+}
+
+// --- keys, spelled out rather than built, so a case says the address it means
+
+ParamKey deviceParam(int index) {
+    ParamKey key;
+    key.kind = ParamKey::Kind::DeviceParam;
+    key.scope = ParamKey::Scope::Device;
+    key.trackId = kTrack;
+    key.device = magda::engine::DeviceKey{ChainSegment::Fx, kDevice};
+    key.index = index;
+    return key;
+}
+
+/// The modifier itself, taken as a source: the same address with no parameter
+/// index, which is how a modifier is named everywhere in the engine.
+ParamKey modifierKey(ModId id) {
+    ParamKey key;
+    key.kind = ParamKey::Kind::ModParam;
+    key.scope = ParamKey::Scope::Track;
+    key.trackId = kTrack;
+    key.modId = id;
+    key.index = -1;
+    return key;
+}
+
+ParamKey trackVolume(TrackId track) {
+    ParamKey key;
+    key.kind = ParamKey::Kind::TrackVolume;
+    key.scope = ParamKey::Scope::Track;
+    key.trackId = track;
+    return key;
+}
+
+/// A device that reads nothing and writes nothing. What the ops do with the
+/// signal is not what these cases are about.
+class NullDevice final : public magda::engine::EngineDevice {
+  public:
+    void process(magda::engine::DeviceBlock&) override {}
+};
+
+/// What a case queues for the next block. Owned by the case rather than by the
+/// session, because the point of one is to put a note in a named block.
+struct ScriptedMidi {
+    juce::MidiBuffer pending;
+};
+
+class ScriptedMidiSource final : public magda::engine::EngineMidiSource {
+  public:
+    explicit ScriptedMidiSource(ScriptedMidi* script) : script_(script) {}
+
+    void render(const magda::engine::BlockInfo&, juce::MidiBuffer& out) override {
+        if (script_ == nullptr)
+            return;
+        out.addEvents(script_->pending, 0, -1, 0);
+        script_->pending.clear();
+    }
+
+  private:
+    ScriptedMidi* script_ = nullptr;
+};
+
+/// A host that wants a fixed set of values read back, which is what having a
+/// window open amounts to.
+class Factory final : public magda::engine::RuntimeStateFactory {
+  public:
+    Factory(std::vector<ParamKey> wanted, ScriptedMidi* midi)
+        : wanted_(std::move(wanted)), midi_(midi) {}
+
+    std::unique_ptr<magda::engine::EngineDevice> createDevice(magda::engine::DeviceKey) override {
+        return std::make_unique<NullDevice>();
+    }
+
+    std::unique_ptr<magda::engine::EngineMidiSource> createMidiInput(TrackId) override {
+        return midi_ == nullptr ? nullptr : std::make_unique<ScriptedMidiSource>(midi_);
+    }
+
+    std::vector<ParamKey> valuesToTap() override {
+        return wanted_;
+    }
+
+  private:
+    std::vector<ParamKey> wanted_;
+    ScriptedMidi* midi_ = nullptr;
+};
+
+/// A session over @p trackList, having asked for @p wanted to be read back.
+struct Session {
+    Session(std::vector<TrackInfo> trackList, std::vector<ParamKey> wanted, ScriptedMidi* midi)
+        : tracks(std::move(trackList)), factory(std::move(wanted), midi), session(factory) {
+        master = makeMaster();
+        published = publish(tracks);
+    }
+
+    /// Publish @p trackList as the project, which is what an edit amounts to.
+    bool publish(const std::vector<TrackInfo>& trackList) {
+        auto compiled =
+            std::make_shared<const magda::engine::RenderPlan>(compileRenderPlan(trackList, master));
+
+        magda::engine::PlanValues values;
+        magda::engine::resolvePlanValues(*compiled, trackList, master, values);
+
+        const auto ids = magda::engine::collectRuntimeStateIds(trackList, master);
+        const magda::engine::RenderContext context{kSampleRate, kBlock, 2};
+        const auto result = session.publish(compiled, context, ids, std::move(values));
+        plan = std::move(compiled);
+        return result.published;
+    }
+
+    void render() {
+        juce::AudioBuffer<float> output(2, kBlock);
+        session.process(kBlock, output);
+    }
+
+    /// What a window would do: ask for the tap by the key it asked to have
+    /// tapped, and read it.
+    ValueTap* tapFor(const ParamKey& key) const {
+        return session.valueTap(key);
+    }
+
+    float read(const ParamKey& key) const {
+        auto* tap = tapFor(key);
+        REQUIRE(tap != nullptr);
+        return tap->value();
+    }
+
+    std::uint32_t writes(const ParamKey& key) const {
+        auto* tap = tapFor(key);
+        REQUIRE(tap != nullptr);
+        return tap->read().writes;
+    }
+
+    std::vector<TrackInfo> tracks;
+    TrackInfo master;
+    std::shared_ptr<const magda::engine::RenderPlan> plan;
+    Factory factory;
+    magda::engine::EngineSession session;
+    bool published = false;
+};
+
+}  // namespace
+
+// --- the tap itself
+
+TEST_CASE("A value tap holds what the last block published", "[engine][tap][value]") {
+    ValueTap tap;
+    tap.write(0.25f);
+    tap.write(0.75f);
+
+    CHECK(tap.value() == approx(0.75f));
+}
+
+TEST_CASE("Reading a value tap does not consume it", "[engine][tap][value]") {
+    ValueTap tap;
+    tap.write(0.4f);
+
+    // The difference between this and a meter, and the reason it is not one: a
+    // position is where the value is, so two readers are owed the same answer
+    // and a reader arriving late is owed the current one rather than a zero.
+    CHECK(tap.read().value == approx(0.4f));
+    CHECK(tap.read().value == approx(0.4f));
+    CHECK(tap.value() == approx(0.4f));
+}
+
+TEST_CASE("A value tap counts the blocks that published it", "[engine][tap][value]") {
+    ValueTap tap;
+    REQUIRE(tap.read().writes == 0);
+
+    tap.write(0.5f);
+    const auto first = tap.read().writes;
+
+    // The same value again is still a block: what the count answers is whether
+    // anything is rendering, and a tap that fell silent on a value that had
+    // stopped moving would be indistinguishable from one whose engine had gone
+    // away.
+    tap.write(0.5f);
+    const auto second = tap.read().writes;
+
+    CHECK(first == 1);
+    CHECK(second == 2);
+    CHECK(tap.value() == approx(0.5f));
+}
+
+// --- what the engine publishes through them
+
+TEST_CASE("A modifier tap publishes the modifier's own output", "[engine][tap][value]") {
+    const auto track = trackWithEnvelope(/*storedValue=*/0.0f, /*amount=*/1.0f);
+    const auto mod = modifierKey(track.mods[0].id);
+
+    ScriptedMidi midi;
+    Session session({track}, {mod}, &midi);
+    REQUIRE(session.published);
+
+    // Shut before the note: a MIDI-triggered envelope waits, and a modifier at
+    // rest outputs nothing.
+    session.render();
+    CHECK(session.read(mod) == approx(0.0f));
+
+    midi.pending.addEvent(juce::MidiMessage::noteOn(1, 60, 1.0f), 0);
+    session.render();
+    CHECK(session.read(mod) == approx(1.0f));
+}
+
+TEST_CASE("A parameter tap publishes what the block resolved, not what is stored",
+          "[engine][tap][value]") {
+    // Half a link's worth of envelope on top of a stored quarter: two numbers
+    // that cannot be mistaken for each other, and neither of them is what the
+    // model holds.
+    const auto track = trackWithEnvelope(/*storedValue=*/0.25f, /*amount=*/0.5f);
+    const auto param = deviceParam(0);
+    const auto mod = modifierKey(track.mods[0].id);
+
+    ScriptedMidi midi;
+    Session session({track}, {param, mod}, &midi);
+    REQUIRE(session.published);
+
+    session.render();
+    CHECK(session.read(param) == approx(0.25f));
+    CHECK(session.read(mod) == approx(0.0f));
+
+    midi.pending.addEvent(juce::MidiMessage::noteOn(1, 60, 1.0f), 0);
+    session.render();
+
+    // The parameter carries the link's depth and the modifier does not: what a
+    // knob draws is where the value went, and what a modifier editor draws is
+    // the shape the modifier made, whatever any link did with it.
+    CHECK(session.read(param) == approx(0.75f));
+    CHECK(session.read(mod) == approx(1.0f));
+}
+
+TEST_CASE("A value nobody asked about publishes nothing", "[engine][tap][value]") {
+    const auto track = trackWithEnvelope(/*storedValue=*/0.25f, /*amount=*/0.5f);
+
+    // The host asks for the modifier and not for the parameter, which is a
+    // modifier editor open over a device panel that is shut.
+    const auto mod = modifierKey(track.mods[0].id);
+
+    ScriptedMidi midi;
+    Session session({track}, {mod}, &midi);
+    REQUIRE(session.published);
+
+    session.render();
+
+    CHECK(session.tapFor(mod) != nullptr);
+    CHECK(session.tapFor(deviceParam(0)) == nullptr);
+}
+
+TEST_CASE("A value the table does not carry is bound to nothing rather than refused",
+          "[engine][tap][value]") {
+    const auto track = trackWithEnvelope(/*storedValue=*/0.25f, /*amount=*/0.5f);
+
+    // A parameter index the device does not have, which is a window that
+    // outlived the thing it was opened on. The publish goes through and the tap
+    // exists; what it never gets is a block.
+    const auto missing = deviceParam(99);
+
+    ScriptedMidi midi;
+    Session session({track}, {missing}, &midi);
+    REQUIRE(session.published);
+
+    session.render();
+    session.render();
+
+    auto* tap = session.tapFor(missing);
+    REQUIRE(tap != nullptr);
+    CHECK(tap->read().writes == 0);
+}
+
+TEST_CASE("A block with no table it fits leaves the taps holding", "[engine][tap][value]") {
+    const auto track = trackWithEnvelope(/*storedValue=*/0.25f, /*amount=*/0.5f);
+    const auto param = deviceParam(0);
+
+    ScriptedMidi midi;
+    Session session({track}, {param}, &midi);
+    REQUIRE(session.published);
+
+    midi.pending.addEvent(juce::MidiMessage::noteOn(1, 60, 1.0f), 0);
+    session.render();
+    REQUIRE(session.read(param) == approx(0.75f));
+
+    // Values with no table at all, which is what a publish resolved before
+    // there was one looks like. The block resolves nothing, so it publishes
+    // nothing: a watched knob slammed to zero for the block a mismatched table
+    // takes to be replaced would be a visible fault reporting an invisible one.
+    magda::engine::PlanValues empty;
+    magda::engine::resolvePlanValues(*session.plan, session.tracks, session.master, empty);
+    empty.params.reset();
+    REQUIRE(session.session.publishValues(std::move(empty)).published);
+
+    const auto before = session.writes(param);
+    session.render();
+
+    CHECK(session.read(param) == approx(0.75f));
+    CHECK(session.writes(param) == before);
+}
+
+// --- what the store does with them
+
+TEST_CASE("A value tap outlives the plans that reference it", "[engine][tap][value]") {
+    auto track = trackWithEnvelope(/*storedValue=*/0.25f, /*amount=*/0.5f);
+    const auto param = deviceParam(0);
+
+    ScriptedMidi midi;
+    Session session({track}, {param}, &midi);
+    REQUIRE(session.published);
+
+    midi.pending.addEvent(juce::MidiMessage::noteOn(1, 60, 1.0f), 0);
+    session.render();
+
+    auto* before = session.tapFor(param);
+    REQUIRE(before != nullptr);
+    const auto reading = before->read();
+
+    // An edit somewhere else in the project: a second track, which recompiles
+    // the plan and republishes the table without touching this parameter.
+    auto tracks = session.tracks;
+    tracks.push_back(makeTrack(2));
+    REQUIRE(session.publish(tracks));
+
+    // The same tap, still holding what the last block put in it. A new one
+    // would read as the value having jumped to zero on an edit that did not
+    // touch it.
+    CHECK(session.tapFor(param) == before);
+    CHECK(before->read().value == approx(reading.value));
+    CHECK(before->read().writes == reading.writes);
+}
+
+TEST_CASE("A value tap goes when what it names does", "[engine][tap][value]") {
+    const auto track = trackWithEnvelope(/*storedValue=*/0.25f, /*amount=*/0.5f);
+    const auto param = deviceParam(0);
+
+    ScriptedMidi midi;
+    Session session({track}, {param, trackVolume(kTrack)}, &midi);
+    REQUIRE(session.published);
+    session.render();
+
+    REQUIRE(session.tapFor(param) != nullptr);
+    REQUIRE(session.tapFor(trackVolume(kTrack)) != nullptr);
+
+    // The device is deleted. The host is still asking for its parameter,
+    // because the window it had open has not been told yet; what stops the tap
+    // from being remade is that the table no longer carries the key and the
+    // model no longer holds the device.
+    auto stripped = session.tracks;
+    stripped[0].chain.fxChainElements.clear();
+    REQUIRE(session.publish(stripped));
+
+    CHECK(session.tapFor(param) == nullptr);
+
+    // The track is still there, so its own value is still tapped: eviction
+    // follows what the model holds rather than what the plan happens to use.
+    CHECK(session.tapFor(trackVolume(kTrack)) != nullptr);
+}

--- a/tests/test_value_taps.cpp
+++ b/tests/test_value_taps.cpp
@@ -291,6 +291,31 @@ TEST_CASE("A value tap counts the blocks that published it", "[engine][tap][valu
     CHECK(tap.value() == approx(0.5f));
 }
 
+TEST_CASE("A value tap's count belongs to the value beside it", "[engine][tap][value]") {
+    ValueTap tap;
+
+    // The pair is what a reader gates a repaint on, so the two halves coming
+    // from different blocks is not a stale frame: a count that has moved past
+    // the value it arrived with means the reader draws the older one and then
+    // decides, at the next poll, that nothing has changed since. The value it
+    // never drew would stay undrawn until something else wrote.
+    for (std::uint32_t written = 1; written <= 8; ++written) {
+        tap.write(static_cast<float>(written) / 8.0f);
+
+        const auto reading = tap.read();
+        CHECK(reading.writes == written);
+        CHECK(reading.value == approx(static_cast<float>(reading.writes) / 8.0f));
+    }
+}
+
+TEST_CASE("A value tap that has published nothing reads as nothing", "[engine][tap][value]") {
+    const ValueTap tap;
+
+    const auto reading = tap.read();
+    CHECK(reading.writes == 0);
+    CHECK(reading.value == approx(0.0f));
+}
+
 // --- what the engine publishes through them
 
 TEST_CASE("A modifier tap publishes the modifier's own output", "[engine][tap][value]") {


### PR DESCRIPTION
Closes #2122.

What the UI reads back: the two numbers a window wants and cannot work out for itself. What a modifier's output did this block, and what a parameter resolved to once its base, its lane and its links had been settled against each other. The second is what a device UI draws when something is modulating a knob, and what touch and latch will read at the moment a gesture starts.

## The tap

`magda/engine/tap/ValueTap.hpp`, the sibling of `LevelTap` and `MidiTap`, with the one difference that matters: a read is not destructive. A meter reports the loudest thing since it was last looked at because a transient falling between two frames must not go missing. A position has nothing of the kind to miss, so the value stands until a block replaces it, any number of readers get the same answer rather than taking it from each other, and a reader arriving late gets the current position rather than a zero.

It carries a count of blocks published beside the value, which is what tells a value that is holding from a value that is not moving. The two are one 64-bit word rather than two atomics, and that is not an optimisation: the count is what a reader gates a repaint on, so a reading pairing one block's count with another block's value is not a stale frame but a value that never arrives. Read the value first and the reader draws the old one, then finds the count unmoved at the next poll, decides nothing changed, and never draws the new one. Read the count first and the mirror image happens. One store on the audio thread, one load off it, no sequence lock and nothing to retry.

Bound by `ParamKey` rather than by `OpKey`, which is the one difference from the two existing taps and follows from what is being read: a meter is a place in the signal and this is a number in the parameter system. One map for both numbers, because the key already says which: a key with a parameter index is a parameter's resolved position, and a modifier key with none is that modifier's output.

## How a host gets one

`RuntimeStateFactory::valuesToTap()` returns the keys the host wants read back; the store makes the taps and `EngineSession::valueTap(key)` hands them out. One question rather than a `createValueTap` beside its neighbours, and the asymmetry is a matter of how many there are: a plan has hundreds of ops and a host with a mixer open wants a meter on a good fraction of them, so asking op by op costs about what the answers are worth. A table has a parameter for every parameter of every device in the project, and a host wants the few dozen it has on screen. Asking one by one would be thousands of declines per edit to find them.

The store makes them rather than the factory handing back instances, because a `ValueTap` is not a thing the engine needs the host's help to build. The other factory methods exist because the engine has no idea what a device or a file reader is; it knows exactly what a tap on a number is.

Eviction takes the live `ParamTable` alongside the live plan, because a plan does not name a parameter and nothing else could say which taps the audio thread can reach. A rack scope is retained by its track, which is coarser than the rest: `RuntimeStateIds` names devices and tracks, a rack is neither, and what the coarser rule costs is one word per deleted rack held until the track goes.

## Where it publishes

At the end of `PlanExecutor::resolveParameters`, which both executors call, and which is the one moment both numbers exist and the last moment they are still the block's own rather than something a device has since been handed. Bound taps are held in compact lists resolved at prepare, so the block hashes nothing and walks tens of entries rather than thousands of nulls.

A block whose table does not fit publishes nothing at all rather than the zeros an empty table answers with. The watched values then hold, which is what they do whenever nothing is rendering; slamming every watched knob to zero for the one block a mismatched table takes to be replaced would be a visible fault reporting an invisible one.

## Nothing simulates a modifier

The third bullet of the issue. The incumbent engine keeps a MAGDA-side copy of the random modulator turning inside `TrackManager::updateAllMods`, so its editor preview animates between audio-thread updates: there the value is polled at frame rate and a poll landing between two callbacks has nothing to report. Here the block publishes what it produced, so a tap that is not moving is an engine that is not rendering, and that is the honest answer rather than a gap to paper over.

That simulation stays exactly where it is. It drives the engine that still ships, and removing it now would break the modifier editors in the live product; what the issue asks is that it not be ported, and it is not.

## The tests

`tests/test_value_taps.cpp`, twelve cases:

- the tap itself: holding the last block's value, surviving repeated reads, counting blocks rather than changes, reading as nothing before anything publishes
- the count belonging to the value beside it across successive writes, which is the pair that must not come apart
- a modifier tap publishing the modifier's own output, shut before the note and open after it
- a parameter tap publishing what the block resolved and not what is stored: a quarter stored plus half a link's worth of envelope reads 0.75 while the modifier beside it reads 1.0, so the link's depth is visibly on one and not the other
- a value nobody asked about having no tap at all
- a key the table does not carry bound to nothing rather than refused, which is a window that outlived what it was opened on
- a block with no table it fits leaving the taps holding, value and count both
- a tap surviving an unrelated structural edit as the same object with the same reading, and going when the device it names is deleted while the track's own value stays

## Verified

`make test`: 2843 cases, 589,811 assertions, all passing.

## Notes

- `docs/architecture/native-engine.md` section 8 still says automation curves, modifiers and macros do not exist in the engine. Stale since the parameter lane slice, left alone here for the same reason the last slice left it: #2123 is still open and the doc reads like it gets its update at the end of the arc.