### PR TITLE
Restore the self-hosted Windows runner pick

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -747,12 +747,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          # TEMPORARY: forced to windows-latest while the magda-luca machine is
-          # not reachable. Delete this block to restore the pick below.
-          echo 'labels=["windows-latest"]' >> "$GITHUB_OUTPUT"
-          echo "Pinned to windows-latest: self-hosted selection is temporarily disabled"
-          exit 0
-
           if [ -z "${GH_TOKEN:-}" ]; then
             echo 'labels=["windows-latest"]' >> "$GITHUB_OUTPUT"
             echo "No RUNNER_STATUS_PAT available in this context (e.g. Dependabot PRs do not see repo secrets); falling back to windows-latest"


### PR DESCRIPTION
`pick-windows-runner` was deliberately pinned to `windows-latest` in #2083 —
parked while I was away from the machine, not because anything broke. I'm back,
so the pin comes out.

The runner reports:

```
name: DESKTOP-3D4P87O   status: online   busy: false
labels: self-hosted, Windows, X64, magda-luca
```

Removing the early-return block restores the original selection: prefer the
self-hosted runner when the API reports it online, not busy, and no other CI
run is in flight; otherwise fall back to `windows-latest`.

Nothing else needed changing. Every runner-dependent step downstream keys off
`runner.environment` rather than the label — the persistent vcpkg clone and
binary cache, the Faust/Mutable prebuilt dirs, the `main`-only Release build
gate — so they take their self-hosted branch again on their own. The
`RUNNER_STATUS_PAT` secret the step queries with is still present on the repo.

## Verification

This PR's own CI run exercised the restored pick, which reported:

```
Falling back to windows-latest (magda-luca status: 'online', busy: 'false', inflight runs: '1')
```

That is the pick working: it reached the API, found magda-luca online and idle,
and fell back only on the anti-collision guard, because another branch's build
was still in flight. `ci.yml` parses, and the code below the removed block is
untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)