### PR TITLE
Give an imported clip the colour it was showing (#1786)

### DIFF
--- a/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
+++ b/magda/daw/project/serialization/DawProjectXmlAdapter.cpp
@@ -11,6 +11,7 @@
 #include <optional>
 #include <set>
 
+#include "../../core/Config.hpp"
 #include "../../core/ParameterUtils.hpp"
 #include "../../core/TempoUtils.hpp"
 #include "version.hpp"
@@ -804,13 +805,30 @@ SourceId adoptImportedSource(const juce::String& path, double declaredDuration) 
     return sourceId;
 }
 
+/**
+ * @brief One clip of an imported arrangement or scene.
+ *
+ * @p trackColour is what the clip takes when the file gives it none, which is
+ * not an edge case but the common one: a clip in Bitwig has no colour of its
+ * own until somebody picks one, and until then it shows its track's. DAWproject
+ * writes that as an absent `color` attribute, so a colour read straight off the
+ * element would be MAGDA's transparent "unset", and every clip in an imported
+ * project would draw as flat black once the swatch forced it opaque (#1786).
+ *
+ * Inheriting instead is what MAGDA does for its own clips: a new one takes the
+ * colour of the track it lands on (ClipManager, clip colour mode 0). So the two
+ * halves of "this clip has no colour of its own" now agree, whichever side of
+ * the importer they came from.
+ */
 ClipInfo clipFromXml(const juce::XmlElement& clipElement, TrackId trackId, ClipId clipId,
-                     double projectTempo) {
+                     double projectTempo, juce::Colour trackColour) {
     ClipInfo clip;
     clip.id = clipId;
     clip.trackId = trackId;
     clip.name = clipElement.getStringAttribute("name");
     clip.colour = colourFromDawProject(clipElement.getStringAttribute("color"));
+    if (clip.colour.isTransparent())
+        clip.colour = trackColour;
     clip.view = ClipView::Arrangement;
     clip.setPlacementBeats(clipElement.getDoubleAttribute("time", 0.0),
                            clipElement.getDoubleAttribute("duration", 0.0));
@@ -1323,6 +1341,22 @@ bool DawProjectXmlAdapter::fromProjectXml(const juce::String& xml, ProjectDocume
                 : "track:" + juce::String(destinationTrack.id);
     }
 
+    // What a clip with no colour of its own inherits. Resolved here rather than
+    // inside clipFromXml because the tracks are the importer's own by this
+    // point: the clip lanes name a track and this is where that name has
+    // already become a TrackId.
+    //
+    // A track the file left colourless falls through to the first palette
+    // colour, which is where ClipManager lands for a clip on a track it cannot
+    // find. Black is never the answer, because black is what "unset" looks like
+    // once a swatch has forced it opaque, and that is the bug (#1786).
+    const auto importedTrackColour = [&document](TrackId trackId) {
+        for (const auto& track : document.tracks)
+            if (track.id == trackId && !track.colour.isTransparent())
+                return track.colour;
+        return juce::Colour(Config::getDefaultColour(0));
+    };
+
     ClipId nextClipId = 1;
     if (auto* arrangement = root->getChildByName("Arrangement")) {
         if (auto* rootLanes = arrangement->getChildByName("Lanes")) {
@@ -1335,7 +1369,8 @@ bool DawProjectXmlAdapter::fromProjectXml(const juce::String& xml, ProjectDocume
                 if (auto* clips = trackLanes->getChildByName("Clips")) {
                     for (auto* clipElement : clips->getChildWithTagNameIterator("Clip"))
                         document.clips.push_back(clipFromXml(*clipElement, trackIt->second,
-                                                             nextClipId++, document.info.tempo));
+                                                             nextClipId++, document.info.tempo,
+                                                             importedTrackColour(trackIt->second)));
                 }
 
                 for (auto* pointsElement : trackLanes->getChildWithTagNameIterator("Points")) {
@@ -1400,7 +1435,8 @@ bool DawProjectXmlAdapter::fromProjectXml(const juce::String& xml, ProjectDocume
 
                         if (auto* clipElement = timeline->getChildByName("Clip")) {
                             auto clip = clipFromXml(*clipElement, trackIt->second, nextClipId++,
-                                                    document.info.tempo);
+                                                    document.info.tempo,
+                                                    importedTrackColour(trackIt->second));
                             clip.view = ClipView::Session;
                             clip.sceneIndex = sceneIndex;
                             clip.setPlacementBeats(0.0, clip.placement.lengthBeats);

--- a/tests/test_project_document_adapters.cpp
+++ b/tests/test_project_document_adapters.cpp
@@ -8,6 +8,7 @@
 #include "AudioClipTestHelpers.hpp"
 #include "magda/daw/core/AutomationManager.hpp"
 #include "magda/daw/core/ClipManager.hpp"
+#include "magda/daw/core/Config.hpp"
 #include "magda/daw/core/TrackManager.hpp"
 #include "magda/daw/project/ProjectInfo.hpp"
 #include "magda/daw/project/serialization/DawProjectArchive.hpp"
@@ -878,6 +879,105 @@ TEST_CASE("DawProjectXmlAdapter imports Bitwig group and master channel destinat
     REQUIRE(staged.masterTrack != nullptr);
     REQUIRE(staged.masterTrack->name == "Master");
     REQUIRE(staged.tracks.size() == 3);
+}
+
+TEST_CASE("DawProjectXmlAdapter gives a colourless imported clip its track's colour",
+          "[project][serialization][dawproject][colour]") {
+    // A clip in Bitwig has no colour of its own until somebody picks one, and
+    // until then it shows its track's. DAWproject writes that as an absent
+    // `color` attribute, and reading it straight off the element gives MAGDA's
+    // transparent "unset", which the swatch then forces opaque: every clip in
+    // an imported project drew as flat black (#1786).
+    //
+    // The second clip has a colour of its own, so the case also says that
+    // inheriting does not overwrite one the file did set.
+    const juce::String xml = R"(<?xml version="1.0" encoding="UTF-8"?>
+<Project version="1.0">
+  <Structure>
+    <Track contentType="notes" loaded="true" id="tDrums" name="Drums" color="#3c8f4e">
+      <Channel audioChannels="2" destination="cMaster" role="regular" id="cDrums"/>
+    </Track>
+    <Track contentType="audio notes" loaded="true" id="tMaster" name="Master">
+      <Channel audioChannels="2" role="master" id="cMaster"/>
+    </Track>
+  </Structure>
+  <Arrangement id="arrangement">
+    <Lanes timeUnit="beats" id="laneRoot">
+      <Lanes track="tDrums" id="laneDrums">
+        <Clips id="clipsDrums">
+          <Clip time="0.0" duration="4.0" name="Inherited"/>
+          <Clip time="4.0" duration="4.0" name="Explicit" color="#c04070"/>
+        </Clips>
+      </Lanes>
+    </Lanes>
+  </Arrangement>
+</Project>)";
+
+    ProjectDocument doc;
+    juce::String error;
+    REQUIRE(DawProjectXmlAdapter::fromProjectXml(xml, doc, error));
+    REQUIRE(doc.clips.size() == 2);
+
+    const ClipInfo* inherited = nullptr;
+    const ClipInfo* explicitly = nullptr;
+    for (const auto& clip : doc.clips) {
+        if (clip.name == "Inherited")
+            inherited = &clip;
+        else if (clip.name == "Explicit")
+            explicitly = &clip;
+    }
+    REQUIRE(inherited != nullptr);
+    REQUIRE(explicitly != nullptr);
+
+    const TrackInfo* drums = nullptr;
+    for (const auto& track : doc.tracks)
+        if (track.name == "Drums")
+            drums = &track;
+    REQUIRE(drums != nullptr);
+    REQUIRE(drums->colour == juce::Colour(0xff3c8f4e));
+
+    CHECK(inherited->colour == drums->colour);
+    CHECK(explicitly->colour == juce::Colour(0xffc04070));
+
+    // Whatever it inherited, it is a colour: unset is what draws black, and the
+    // report is about black clips rather than about any particular hue.
+    CHECK_FALSE(inherited->colour.isTransparent());
+}
+
+TEST_CASE("DawProjectXmlAdapter gives a colourless clip on a colourless track a real colour",
+          "[project][serialization][dawproject][colour]") {
+    // The end of the fallback chain. A file that colours nothing still must not
+    // produce black clips, because black is what MAGDA's "unset" looks like once
+    // a swatch has forced it opaque, and a user cannot tell that apart from a
+    // colour somebody chose.
+    const juce::String xml = R"(<?xml version="1.0" encoding="UTF-8"?>
+<Project version="1.0">
+  <Structure>
+    <Track contentType="notes" loaded="true" id="tPlain" name="Plain">
+      <Channel audioChannels="2" destination="cMaster" role="regular" id="cPlain"/>
+    </Track>
+    <Track contentType="audio notes" loaded="true" id="tMaster" name="Master">
+      <Channel audioChannels="2" role="master" id="cMaster"/>
+    </Track>
+  </Structure>
+  <Arrangement id="arrangement">
+    <Lanes timeUnit="beats" id="laneRoot">
+      <Lanes track="tPlain" id="lanePlain">
+        <Clips id="clipsPlain">
+          <Clip time="0.0" duration="4.0" name="Colourless"/>
+        </Clips>
+      </Lanes>
+    </Lanes>
+  </Arrangement>
+</Project>)";
+
+    ProjectDocument doc;
+    juce::String error;
+    REQUIRE(DawProjectXmlAdapter::fromProjectXml(xml, doc, error));
+    REQUIRE(doc.clips.size() == 1);
+
+    CHECK_FALSE(doc.clips[0].colour.isTransparent());
+    CHECK(doc.clips[0].colour == juce::Colour(Config::getDefaultColour(0)));
 }
 
 TEST_CASE("DawProjectXmlAdapter imports effect tracks as aux returns with send routing",


### PR DESCRIPTION
Closes #1786.

A clip in Bitwig has no colour of its own until somebody picks one, and until then it shows its track's. DAWproject writes that as an absent `color` attribute, and the importer read it straight off the element: what came back was MAGDA's transparent "unset", which `deriveTrackSwatch` then passes through with alpha forced to one, because near-zero saturation is how the theme recognises a colour nobody chose. Opaque black. Every clip in an imported project, unless the user had coloured it by hand in Bitwig, in which case that one came through correctly, which is what the report says.

So an absent attribute now means what the file means by it: the clip takes its track's colour, which is what MAGDA already does for a clip of its own (ClipManager, clip colour mode 0). A track the file left colourless falls through to the first palette colour rather than to black, since black is the thing that is indistinguishable from a colour somebody chose.

Both places clips are read: the arrangement lanes and the scene slots.

Not touched: the reporter also saw Studio One colours arriving wrong rather than absent, which is a different fault and stays open.

## Tests

Two cases in `tests/test_project_document_adapters.cpp`: a colourless clip next to an explicitly coloured one on a coloured track, and the end of the fallback chain where neither clip nor track has a colour. Full suite green locally: 2833 cases, 589551 assertions.